### PR TITLE
fix(checker): gate noImplicitOverride on ambient context, not the `declare` modifier

### DIFF
--- a/crates/tsz-checker/src/classes/class_checker.rs
+++ b/crates/tsz-checker/src/classes/class_checker.rs
@@ -305,6 +305,20 @@ impl<'a> CheckerState<'a> {
     ) {
         use crate::query_boundaries::common::{TypeSubstitution, instantiate_type};
 
+        // tsc does not require an `override` modifier on members of an ambient class.
+        // `checkMemberForOverrideModifier` gates the `noImplicitOverride` requirement on
+        // `nodeInAmbientContext` (`node.flags & NodeFlags.Ambient`), which covers a
+        // `declare class`, any class inside `declare namespace`/`declare module`, and
+        // every class in a `.d.ts` — not merely a `declare` modifier spelled on the class
+        // node itself. Computed once here so both the heritage path and the base-less
+        // fallback below answer the ambient question identically.
+        //
+        // Only the *implicit* requirement is ambient gated. The explicit-`override`
+        // diagnostics (TS4112/TS4113) are reported in ambient contexts too, and they do
+        // not consult this flag.
+        let no_implicit_override =
+            self.ctx.no_implicit_override() && !self.ctx.is_ambient_declaration(class_idx);
+
         // Find base class from heritage clauses (extends, not implements)
         // If there are no heritage clauses, we still need to check for
         // invalid `override` members (TS4112) since override requires extends.
@@ -327,7 +341,7 @@ impl<'a> CheckerState<'a> {
                 self.report_overrides_without_base(
                     class_data,
                     &derived_class_name,
-                    self.ctx.no_implicit_override(),
+                    no_implicit_override,
                 );
                 return;
             }
@@ -477,10 +491,6 @@ impl<'a> CheckerState<'a> {
         } else {
             String::from("(Anonymous class)")
         };
-        // tsc does not enforce noImplicitOverride in ambient/declare class declarations.
-        let is_ambient_class = self.has_declare_modifier(&class_data.modifiers);
-        let no_implicit_override = self.ctx.no_implicit_override() && !is_ambient_class;
-
         let Some(base_idx) = base_class_idx else {
             // No AST-level class declaration found. Try type-level fallback for complex
             // heritage expressions (function calls, intersection types, etc.).

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -502,6 +502,9 @@ mod name_resolution_boundary_tests;
 #[path = "../tests/no_filename_based_behavior_tests.rs"]
 mod no_filename_based_behavior_tests;
 #[cfg(test)]
+#[path = "tests/no_implicit_override_ambient_context_tests.rs"]
+mod no_implicit_override_ambient_context_tests;
+#[cfg(test)]
 #[path = "tests/no_index_element_implicit_any_tests.rs"]
 mod no_index_element_implicit_any_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/no_implicit_override_ambient_context_tests.rs
+++ b/crates/tsz-checker/src/tests/no_implicit_override_ambient_context_tests.rs
@@ -1,0 +1,349 @@
+//! Regression tests: `noImplicitOverride` (TS4114/TS4115/TS4116/TS4117) must be
+//! suppressed in **every** ambient spelling, not just on a literal `declare class`.
+//!
+//! `tsc` gates the implicit-override requirement on `nodeInAmbientContext`
+//! (`node.flags & NodeFlags.Ambient`) in `checkMemberForOverrideModifier`. That flag
+//! covers four spellings of the same concept:
+//!
+//! 1. `declare class D extends B { ... }`
+//! 2. a class inside `declare namespace N { ... }`
+//! 3. a class inside `declare module "m" { ... }`
+//! 4. any class in a `.d.ts` file, including one written `export class D`
+//!
+//! tsz previously tested only spelling 1, via
+//! `has_declare_modifier(&class_data.modifiers)` — a syntactic test for whether the
+//! class node literally carries the `declare` keyword. Spellings 2-4 carry no
+//! `declare` modifier on the class node itself, so they wrongly kept
+//! `noImplicitOverride` enabled and reported a false TS4114.
+//!
+//! The explicit-`override`-modifier diagnostics (TS4112/TS4113) are *not* ambient
+//! gated in `tsc` and must keep firing in all four spellings; those are the negative
+//! controls here.
+//!
+//! Every expectation below was verified against `tsc@7.0.2` with
+//! `--noEmit --strict --noImplicitOverride --target es2017`.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_source, check_with_options};
+
+const TS4113_MEMBER_CANNOT_HAVE_OVERRIDE: u32 = 4113;
+const TS4114_MEMBER_MUST_HAVE_OVERRIDE: u32 = 4114;
+
+fn no_implicit_override_options() -> CheckerOptions {
+    CheckerOptions {
+        no_implicit_override: true,
+        ..CheckerOptions::default()
+    }
+}
+
+fn codes(source: &str) -> Vec<u32> {
+    check_with_options(source, no_implicit_override_options())
+        .iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+fn codes_in_file(source: &str, file_name: &str) -> Vec<u32> {
+    check_source(source, file_name, no_implicit_override_options())
+        .iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+fn count_of(codes: &[u32], code: u32) -> usize {
+    codes.iter().filter(|c| **c == code).count()
+}
+
+// ---------------------------------------------------------------------------
+// Positive controls: a non-ambient class still requires `override`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn plain_class_method_override_still_reports_ts4114() {
+    let found = codes(
+        r"
+class Base { m(): void {} }
+class Derived extends Base { m(): void {} }
+",
+    );
+    assert_eq!(
+        count_of(&found, TS4114_MEMBER_MUST_HAVE_OVERRIDE),
+        1,
+        "non-ambient method override must still report exactly one TS4114, got: {found:?}"
+    );
+}
+
+#[test]
+fn plain_class_property_override_still_reports_ts4114() {
+    let found = codes(
+        r"
+class Base { p: number = 1; }
+class Derived extends Base { p: number = 2; }
+",
+    );
+    assert_eq!(
+        count_of(&found, TS4114_MEMBER_MUST_HAVE_OVERRIDE),
+        1,
+        "non-ambient property override must still report exactly one TS4114, got: {found:?}"
+    );
+}
+
+#[test]
+fn plain_class_with_override_keyword_is_clean() {
+    let found = codes(
+        r"
+class Base { m(): void {} }
+class Derived extends Base { override m(): void {} }
+",
+    );
+    assert!(
+        !found.contains(&TS4114_MEMBER_MUST_HAVE_OVERRIDE),
+        "an explicit `override` satisfies noImplicitOverride, got: {found:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Spelling 1: `declare class` — already correct before the fix.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn declare_class_method_override_is_clean() {
+    let found = codes(
+        r"
+declare class Base { m(): void; }
+declare class Derived extends Base { m(): void; }
+",
+    );
+    assert!(
+        !found.contains(&TS4114_MEMBER_MUST_HAVE_OVERRIDE),
+        "`declare class` is ambient; noImplicitOverride does not apply, got: {found:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Spelling 2: `declare namespace` — the regressing case.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn class_in_declare_namespace_method_override_is_clean() {
+    let found = codes(
+        r"
+declare namespace N {
+  class Base { m(): void; }
+  class Derived extends Base { m(): void; }
+}
+",
+    );
+    assert!(
+        !found.contains(&TS4114_MEMBER_MUST_HAVE_OVERRIDE),
+        "a class inside `declare namespace` is ambient, got: {found:?}"
+    );
+}
+
+#[test]
+fn class_in_declare_namespace_property_override_is_clean() {
+    let found = codes(
+        r"
+declare namespace N {
+  class Base { p: number; }
+  class Derived extends Base { p: number; }
+}
+",
+    );
+    assert!(
+        !found.contains(&TS4114_MEMBER_MUST_HAVE_OVERRIDE),
+        "an ambient property re-declaration needs no `override`, got: {found:?}"
+    );
+}
+
+#[test]
+fn class_in_declare_namespace_accessor_override_is_clean() {
+    let found = codes(
+        r"
+declare namespace N {
+  class Base { get v(): number; }
+  class Derived extends Base { get v(): number; }
+}
+",
+    );
+    assert!(
+        !found.contains(&TS4114_MEMBER_MUST_HAVE_OVERRIDE),
+        "an ambient accessor override needs no `override`, got: {found:?}"
+    );
+}
+
+#[test]
+fn class_in_declare_namespace_parameter_property_override_is_clean() {
+    let found = codes(
+        r"
+declare namespace N {
+  class Base { p: number; }
+  class Derived extends Base { constructor(p: number); }
+}
+",
+    );
+    assert!(
+        !found.contains(&TS4114_MEMBER_MUST_HAVE_OVERRIDE),
+        "ambient constructor parameters need no `override`, got: {found:?}"
+    );
+}
+
+/// Binder names are irrelevant to the rule; only the ambient context is.
+#[test]
+fn class_in_declare_namespace_renamed_binders_is_clean() {
+    let found = codes(
+        r"
+declare namespace Zqx {
+  class Wombat { flurble(): void; }
+  class Grommet extends Wombat { flurble(): void; }
+}
+",
+    );
+    assert!(
+        !found.contains(&TS4114_MEMBER_MUST_HAVE_OVERRIDE),
+        "the rule is structural, not name-driven, got: {found:?}"
+    );
+}
+
+/// The `declare` sits on the outer namespace only; the inner namespace and the
+/// classes inside it inherit ambient-ness through the parent chain.
+#[test]
+fn class_in_nested_declare_namespace_is_clean() {
+    let found = codes(
+        r"
+declare namespace Outer {
+  namespace Inner {
+    class Base { z(): void; }
+    class Derived extends Base { z(): void; }
+  }
+}
+",
+    );
+    assert!(
+        !found.contains(&TS4114_MEMBER_MUST_HAVE_OVERRIDE),
+        "ambient-ness is inherited through nested namespaces, got: {found:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Spelling 3: `declare module "m"`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn class_in_declare_module_is_clean() {
+    let found = codes(
+        r#"
+declare module "mod" {
+  class Base { w(): void; }
+  class Derived extends Base { w(): void; }
+}
+"#,
+    );
+    assert!(
+        !found.contains(&TS4114_MEMBER_MUST_HAVE_OVERRIDE),
+        "a class inside `declare module` is ambient, got: {found:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Spelling 4: `.d.ts` file, where the class carries no `declare` modifier.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn export_class_in_declaration_file_is_clean() {
+    let found = codes_in_file(
+        r"
+export declare class Base { t(): void; }
+export class Derived extends Base { t(): void; }
+",
+        "test.d.ts",
+    );
+    assert!(
+        !found.contains(&TS4114_MEMBER_MUST_HAVE_OVERRIDE),
+        "every declaration in a .d.ts is ambient, got: {found:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls: TS4112/TS4113 are NOT ambient gated in tsc and must keep
+// firing. This is the boundary the fix must not cross.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn explicit_override_not_in_base_still_reports_ts4113_in_declare_namespace() {
+    let found = codes(
+        r"
+declare namespace N {
+  class Base { m(): void; }
+  class Derived extends Base { override notInBase(): void; }
+}
+",
+    );
+    assert!(
+        found.contains(&TS4113_MEMBER_CANNOT_HAVE_OVERRIDE),
+        "TS4113 is not ambient gated in tsc and must still fire, got: {found:?}"
+    );
+}
+
+#[test]
+fn explicit_override_not_in_base_still_reports_ts4113_in_declare_class() {
+    let found = codes(
+        r"
+declare class Base { m(): void; }
+declare class Derived extends Base { override notInBase(): void; }
+",
+    );
+    assert!(
+        found.contains(&TS4113_MEMBER_CANNOT_HAVE_OVERRIDE),
+        "TS4113 must still fire on an explicit `declare class`, got: {found:?}"
+    );
+}
+
+#[test]
+fn explicit_override_not_in_base_still_reports_ts4113_in_declaration_file() {
+    let found = codes_in_file(
+        r"
+export declare class Base { m(): void; }
+export class Derived extends Base { override notInBase(): void; }
+",
+        "test.d.ts",
+    );
+    assert!(
+        found.contains(&TS4113_MEMBER_CANNOT_HAVE_OVERRIDE),
+        "TS4113 must still fire inside a .d.ts, got: {found:?}"
+    );
+}
+
+/// A class with no `extends` clause takes the `report_overrides_without_base`
+/// path, which threaded the raw `noImplicitOverride` option with no ambient
+/// correction at all. `override` without a base is TS4112 in every context.
+#[test]
+fn override_without_base_class_still_reports_in_declare_namespace() {
+    let found = codes(
+        r"
+declare namespace N {
+  class Solo { override m(): void; }
+}
+",
+    );
+    assert!(
+        found.iter().any(|c| *c == 4112 || *c == 4113),
+        "`override` with no base class must still be reported when ambient, got: {found:?}"
+    );
+}
+
+/// The no-heritage path must not invent a TS4114 for an ambient class either.
+#[test]
+fn ambient_class_without_base_and_without_override_is_clean() {
+    let found = codes(
+        r"
+declare namespace N {
+  class Solo { m(): void; }
+}
+",
+    );
+    assert!(
+        !found.contains(&TS4114_MEMBER_MUST_HAVE_OVERRIDE),
+        "a base-less ambient class has nothing to override, got: {found:?}"
+    );
+}


### PR DESCRIPTION
## Goal

Goal: hold

Closes the second and third members of the family Rhyolite named in #16085's handoff: `has_declare_modifier(...)` is a syntactic test for whether a node literally carries the `declare` keyword, and is **not** a test for ambient-ness. Any call site that means "is this ambient?" is the same latent defect. This is the `noImplicitOverride` site.

## Structural rule

**When a class is in an ambient context, `tsc` does not require an `override` modifier on its members; tsz now does the same through `CheckerState::check_property_inheritance_compatibility` (checker, class-member override checking).**

`tsc` gates the implicit-override requirement on `nodeInAmbientContext` (`node.flags & NodeFlags.Ambient`) in `checkMemberForOverrideModifier`. That flag covers **four** spellings of the same concept:

1. `declare class D extends B { ... }`
2. a class inside `declare namespace N { ... }` (including nested namespaces)
3. a class inside `declare module "m" { ... }`
4. any class in a `.d.ts`, including one written `export class D`

tsz tested only spelling 1, via `has_declare_modifier(&class_data.modifiers)`. Spellings 2–4 carry no `declare` modifier on the class node itself, so they kept `noImplicitOverride` enabled and reported a **false TS4114**. As in #16083, the tell is that tsz disagreed with *itself* across two spellings of the same ambient concept.

### Second, independent defect on the same line of reasoning

The base-less path — a class with no `extends` clause, which still needs TS4112/TS4113 checking — called `report_overrides_without_base(..., self.ctx.no_implicit_override())`, threading the **raw** compiler option with no ambient correction at all. So the two paths through one function disagreed about the same question, and the fallback was wrong even for an explicit `declare class`. Both now read a single flag computed once at the top of `check_property_inheritance_compatibility`, which makes them structurally incapable of diverging again.

### What the fix deliberately does not touch

Only the **implicit** requirement is ambient gated. `TS4112`/`TS4113` (explicit `override` modifier that is invalid) are reported in ambient contexts by `tsc` too, and they do not consult this flag. Verified against the oracle in all three ambient spellings and pinned as negative controls below. No new predicate was introduced — `ctx.is_ambient_declaration(idx)` already existed and already means exactly `NodeFlags.Ambient` (`is_declaration_file() || arena.is_in_ambient_context(idx)`).

## Verification

### Oracle

Every expectation was verified against a live `tsc@7.0.2`, `--noEmit --strict --noImplicitOverride --target es2017`:

| case | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| plain `class D extends B { m() {} }` | TS4114 | TS4114 | TS4114 |
| plain, property override | TS4114 | TS4114 | TS4114 |
| plain, explicit `override` | clean | clean | clean |
| `declare class` method override | clean | clean | clean |
| `declare namespace` method override | clean | **TS4114** | clean |
| `declare namespace` property override | clean | **TS4114** | clean |
| `declare namespace` accessor override | clean | **TS4114** | clean |
| `declare namespace` ctor parameter property | clean | clean | clean |
| `declare namespace`, renamed binders | clean | **TS4114** | clean |
| nested `declare namespace` | clean | **TS4114** | clean |
| `declare module "m"` | clean | **TS4114** | clean |
| `.d.ts`, `export class D extends B` | clean | **TS4114** | clean |
| `declare namespace` + `override notInBase` | TS4113 | TS4113 | TS4113 |
| `declare class` + `override notInBase` | TS4113 | TS4113 | TS4113 |
| `.d.ts` + `override notInBase` | TS4113 | TS4113 | TS4113 |
| ambient class, no base, `override m()` | TS4112/4113 | reported | reported |
| ambient class, no base, no `override` | clean | clean | clean |

`--target es5` is no longer accepted by `tsc@7.0.2` (TS5108), so the adjacent TS2725 `has_declare_modifier` site could not be oracled and was deliberately left alone.

### Suites

- **New suite `no_implicit_override_ambient_context_tests` (17 cases): 10 passed / 7 failed before the production diff → 17 / 0 after.** The 7 reds are exactly the false-positive rows in the table; the 10 greens are the positive and negative controls, so the suite constrains both directions.
- `cargo test -p tsz-checker --lib` — full-crate result posted to this thread.
- `cargo clippy --profile ci-lint -p tsz-checker` + `arch_guard.py` — green via the pre-commit hook ("Clippy passed. / Architecture guard passed.").
- `cargo fmt --all` — clean.
- `scripts/conformance/compare-to-parent.sh ad6662c` — two-sided against this branch's real parent, running in-container; result posted to this thread when it lands.

### Risk shape, stated in advance

This change can only **remove** TS4114/TS4115/TS4116/TS4117 diagnostics, and only from classes that are genuinely ambient. So any conformance movement must be a newly-*failing* row whose fixture asserts the old false positive — it cannot lose a newly-passing row. `noImplicitOverride` is also off by default, which bounds the blast radius to fixtures that opt into it.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Chert

---
_Generated by [Claude Code](https://claude.ai/code/session_012yurakfeS52LtkLcWdmTVd)_