### PR TITLE
ci(conformance): fail the refresh on a per-test accounting mismatch

### DIFF
--- a/.github/workflows/conformance-snapshot-refresh.yml
+++ b/.github/workflows/conformance-snapshot-refresh.yml
@@ -53,6 +53,41 @@ jobs:
       - name: Run full conformance snapshot
         run: ./scripts/conformance/conformance.sh snapshot --workers 12 --force
 
+      # A per-test result can go missing from the structured output (observed
+      # on #16086: a specific test hung and its result never made it into
+      # conformance-detail.json's `failures` dict) while still being tallied
+      # in the aggregate `summary.failed` count, so `passed = runnable -
+      # failed` keeps looking internally consistent even though the file it
+      # is derived from is short one entry. `conformance.sh`'s own
+      # completeness retry only checks the runner's self-reported counts,
+      # not this cross-check, so verify it here before anything gets
+      # committed: a hang/drop must block the refresh, not silently become
+      # tomorrow's "truth".
+      - name: Verify snapshot accounting integrity
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import sys
+
+          snapshot = json.load(open("scripts/conformance/conformance-snapshot.json"))
+          detail = json.load(open("scripts/conformance/conformance-detail.json"))
+          failed = snapshot["summary"]["failed"]
+          recorded = len(detail.get("failures", {}))
+          if failed != recorded:
+              print(
+                  f"::error::accounting mismatch: summary.failed={failed} but "
+                  f"conformance-detail.json's failures dict has {recorded} "
+                  "entries. A per-test result was likely dropped (hang or "
+                  "crash) during this run rather than a genuine pass/fail "
+                  "change. Refusing to open/update the refresh PR with a "
+                  "snapshot that does not account for every runnable test."
+              )
+              sys.exit(1)
+          print(f"Accounting OK: {failed} failed == {recorded} detail entries.")
+          PY
+
       - name: Detect changes
         id: diff
         shell: bash


### PR DESCRIPTION
Follow-up to #16086, per its own review thread (comment: https://github.com/tsz-org/tsz/pull/16086#issuecomment-5149510135).

## What I found running the workflow's actual command for real

Quartz's review on #16086 asked whether `ubuntu-latest`'s conformance count matches the macOS-measured `11442` currently committed, since `workflow_dispatch` can't be tested before a workflow lands on `main`. I ran `./scripts/conformance/conformance.sh snapshot --workers 12 --force` directly in this Linux container (cold build, then a warm re-run) to get a real answer before #16086 merged.

Both runs reported **11443**, not 11442 — but not because Linux genuinely passes one more test. Both times, the exact same test — `TypeScript/tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts` — disappeared from `conformance-baseline.txt` and `conformance-detail.json`'s `failures` dict **entirely** (not moved to PASS: `conformance-baseline.txt` goes from 12043 lines to 12042). Yet `summary.failed` still reports 600 while the `failures` dict backing it only has 599 entries — an accounting hole that does not exist in the currently-committed artifact (601 failed / 601 entries, consistent). Isolating that one test directly against the built binary (`--filter ... --workers 1`) hangs with zero output for minutes, well past when the full 12,043-test corpus normally finishes — consistent with a genuine per-test hang whose result never gets serialized, while the runner's own timeout still marks it not-passed in the aggregate tally.

## Why this matters for the auto-refresh workflow specifically

`conformance.sh snapshot`'s own completeness retry (`recorded_results == candidate_tests`) only checks the runner's self-reported counts, not a cross-check against the detail file it writes — so this kind of silent per-test drop is invisible to it. And critically, #16086's own regression banner would **not** have caught this: a dropped test shows up as a *fixed* failure (present in the old committed detail, absent from the new one), not a *new* one, so `new_failures > 0` never fires. Left as merged, the first 05:00 UTC scheduled run would have silently committed a short-by-one snapshot with no visible warning.

## Structural rule

When a freshly generated conformance snapshot's `summary.failed` count disagrees with the actual number of entries in its own `failures` dict, that snapshot is internally inconsistent (a per-test result was dropped, not a genuine pass/fail change) and must never be treated as ground truth. Owner: the new `conformance-snapshot-refresh.yml` workflow (owns this artifact's lifecycle), added as a new step immediately after the snapshot run and before anything gets diffed or committed.

## Scope

One file, `.github/workflows/conformance-snapshot-refresh.yml`: adds a "Verify snapshot accounting integrity" step that reads `conformance-snapshot.json`'s `summary.failed` and `conformance-detail.json`'s `failures` dict length, and fails the job (before the "Detect changes"/"Open or update refresh PR" steps run) if they disagree. No source, script, or unrelated workflow changes.

## Verification
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/conformance-snapshot-refresh.yml'))"`: valid YAML.
- Extracted the new step's embedded Python via `yaml.safe_load` and ran it standalone against two synthetic fixture pairs: a mismatched pair (`failed=600`, 1 detail entry) exits 1 with the `::error::` message; a matched pair (`failed=3`, 3 detail entries) exits 0 with `Accounting OK`.
- Did not re-run the full `conformance.sh snapshot` end-to-end again in this container for this specific PR (already ran it twice investigating #16086; the underlying hang is being filed as its own issue separately, since it's a real bug independent of this workflow guard).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_01CKHiyGuceFzDQdbKmRE1d5)_