### PR TITLE
fix(checker): suppress TS1361/TS1362 for computed property names in any ambient class spelling

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1716,6 +1716,9 @@ mod ts1101_with_in_strict_mode_tests;
 #[path = "tests/ts1170_computed_property_syntactic_form_tests.rs"]
 mod ts1170_computed_property_syntactic_form_tests;
 #[cfg(test)]
+#[path = "tests/ts1361_ambient_computed_property_name_tests.rs"]
+mod ts1361_ambient_computed_property_name_tests;
+#[cfg(test)]
 #[path = "tests/ts18010_jsdoc_tag_anchor_tests.rs"]
 mod ts18010_jsdoc_tag_anchor_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/symbols/scope_finder_contexts.rs
+++ b/crates/tsz-checker/src/symbols/scope_finder_contexts.rs
@@ -1661,17 +1661,14 @@ impl<'a> CheckerState<'a> {
                 k if k == syntax_kind_ext::INTERFACE_DECLARATION => return true,
                 k if k == syntax_kind_ext::TYPE_LITERAL => return true,
 
-                // Ambient class: `declare class C { [x]: any; }`
-                k if k == syntax_kind_ext::CLASS_DECLARATION
-                    || k == syntax_kind_ext::CLASS_EXPRESSION =>
-                {
-                    if let Some(class) = self.ctx.arena.get_class(parent_node)
-                        && self.has_declare_modifier(&class.modifiers)
-                    {
-                        return true;
-                    }
-                    return false;
+                // Ambient class: `declare class C { [x]: any; }`, a class inside
+                // `declare namespace`/`declare module`, or any class in a `.d.ts`.
+                // Class expressions are never ambient (`declare` only attaches to
+                // class declarations).
+                k if k == syntax_kind_ext::CLASS_DECLARATION => {
+                    return self.is_ambient_class_declaration(parent_idx);
                 }
+                k if k == syntax_kind_ext::CLASS_EXPRESSION => return false,
 
                 // Property/method declarations may have abstract or declare modifiers
                 k if k == syntax_kind_ext::PROPERTY_DECLARATION => {

--- a/crates/tsz-checker/src/tests/ts1361_ambient_computed_property_name_tests.rs
+++ b/crates/tsz-checker/src/tests/ts1361_ambient_computed_property_name_tests.rs
@@ -1,0 +1,151 @@
+//! TS1361/TS1362 suppression for computed property names in ambient classes.
+//!
+//! Structural rule: a computed property name (`[expr]: T;`) inside any ambient
+//! class never emits runtime code, so `tsc` never reports TS1361/TS1362 there
+//! regardless of which of the four ambient spellings introduced the class:
+//! `declare class`, a class inside `declare namespace`, a class inside
+//! `declare module`, or any class in a `.d.ts` file. `tsz` implements this
+//! through `is_in_ambient_computed_property_context`
+//! (`crates/tsz-checker/src/symbols/scope_finder_contexts.rs`).
+//!
+//! Before the fix, the class-declaration arm tested
+//! `has_declare_modifier(&class.modifiers)` — a syntactic test for the literal
+//! `declare` keyword on the class node itself. That covers the explicit
+//! `declare class` spelling, but a class inside `declare namespace`/`declare
+//! module` carries no `declare` modifier of its own, so it fell through to
+//! the `false` branch and produced a spurious TS1361 on any type-only-imported
+//! identifier used as a computed property key. The fix delegates to
+//! `is_ambient_class_declaration`, the same helper the caller of
+//! `check_class_member_implementations` already uses to gate ambient classes
+//! correctly across every spelling.
+//!
+//! A cross-file `import type { Sym } from './sym'` needs `check_multi_file`
+//! (the single-file harness cannot resolve a real module specifier); see
+//! `global_augmentation_computed_key_tests.rs` for the established pattern.
+//!
+//! Every expectation here was taken from the vendored `tsc` 7.0.2 oracle
+//! (`--noEmit --strict --pretty false`), not from tsz's own output.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::check_multi_file;
+
+const TS1361: u32 = 1361;
+
+fn strict() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    }
+}
+
+const SYM_MODULE: &str = "export const Sym = \"sym\";\n";
+
+fn codes(main: &str) -> Vec<u32> {
+    check_multi_file(
+        &[("main.ts", main), ("sym.ts", SYM_MODULE)],
+        "main.ts",
+        strict(),
+    )
+    .iter()
+    .map(|d| d.code)
+    .collect()
+}
+
+fn assert_clean(main: &str, label: &str) {
+    let got = codes(main);
+    assert!(
+        !got.contains(&TS1361),
+        "{label}: expected no TS1361, got codes {got:?}"
+    );
+}
+
+fn assert_reports_ts1361(main: &str, label: &str) {
+    let got = codes(main);
+    assert!(
+        got.contains(&TS1361),
+        "{label}: expected TS1361, got codes {got:?}"
+    );
+}
+
+const IMPORT: &str = "import type { Sym } from './sym';\n";
+
+// ---------------------------------------------------------------------------
+// Positive cases: every ambient spelling must suppress TS1361.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn declare_class_computed_property_name_stays_clean() {
+    let main = format!("{IMPORT}\ndeclare class C {{\n    [Sym]: string;\n}}\n");
+    assert_clean(&main, "declare class");
+}
+
+#[test]
+fn class_in_declare_namespace_computed_property_name_stays_clean() {
+    let main = format!(
+        "{IMPORT}\ndeclare namespace N {{\n    class C {{\n        [Sym]: string;\n    }}\n}}\n"
+    );
+    assert_clean(&main, "class inside declare namespace");
+}
+
+#[test]
+fn class_in_declare_module_computed_property_name_stays_clean() {
+    let main = format!(
+        "{IMPORT}\ndeclare module './other' {{\n    class C {{\n        [Sym]: string;\n    }}\n}}\n"
+    );
+    let got = check_multi_file(
+        &[
+            ("main.ts", &main),
+            ("sym.ts", SYM_MODULE),
+            ("other.ts", "export const dummy = 1;\n"),
+        ],
+        "main.ts",
+        strict(),
+    )
+    .iter()
+    .map(|d| d.code)
+    .collect::<Vec<u32>>();
+    assert!(
+        !got.contains(&TS1361),
+        "class inside declare module: expected no TS1361, got codes {got:?}"
+    );
+}
+
+#[test]
+fn class_in_nested_declare_namespace_computed_property_name_stays_clean() {
+    let main = format!(
+        "{IMPORT}\ndeclare namespace Outer {{\n    namespace Inner {{\n        class C {{\n            [Sym]: string;\n        }}\n    }}\n}}\n"
+    );
+    assert_clean(&main, "class inside nested declare namespace");
+}
+
+// ---------------------------------------------------------------------------
+// Boundary control: the already-correct forms must not move.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn interface_computed_property_name_stays_clean() {
+    let main = format!("{IMPORT}\ninterface I {{\n    [Sym]: string;\n}}\n");
+    assert_clean(&main, "interface member");
+}
+
+#[test]
+fn declare_class_method_computed_property_name_stays_clean() {
+    let main = format!("{IMPORT}\ndeclare class C {{\n    [Sym](): void;\n}}\n");
+    assert_clean(&main, "declare class method");
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls: the non-ambient forms must keep reporting TS1361.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn plain_class_computed_property_name_still_reports_ts1361() {
+    let main = format!("{IMPORT}\nclass C {{\n    [Sym]: string;\n}}\n");
+    assert_reports_ts1361(&main, "plain class");
+}
+
+#[test]
+fn class_expression_computed_property_name_still_reports_ts1361() {
+    let main = format!("{IMPORT}\nconst C = class {{\n    [Sym]: string;\n}};\n");
+    assert_reports_ts1361(&main, "class expression");
+}


### PR DESCRIPTION
Structural rule: a computed property name (`[expr]: T;`) inside any ambient class never emits runtime code, so `tsc` never reports TS1361/TS1362 there regardless of which of the four ambient spellings introduced the class — `declare class`, a class inside `declare namespace`, a class inside `declare module`, or any class in a `.d.ts`. `tsz` implements this through `is_in_ambient_computed_property_context` (`crates/tsz-checker/src/symbols/scope_finder_contexts.rs`).

The class-declaration arm tested `has_declare_modifier(&class.modifiers)` — a syntactic test for the literal `declare` keyword on the class node itself. That covers the explicit `declare class` spelling, but a class inside `declare namespace`/`declare module` carries no `declare` modifier of its own, so it fell through to `false` and produced a spurious TS1361 on any type-only-imported identifier used as a computed property key. The fix delegates to `is_ambient_class_declaration`, the same helper the caller of `check_class_member_implementations` already uses to gate ambient classes correctly across every spelling (landed for a sibling `has_declare_modifier` misuse in #16085/#16087). Class expressions are never ambient (`declare` only attaches to class declarations) and now return `false` directly instead of re-checking modifiers.

This continues the `has_declare_modifier`-is-not-ambient-ness audit tracked on the agent-coordination board (#15994): Chert's #16087 handoff listed `symbols/scope_finder_contexts.rs:1669` as one of the remaining unexamined call sites, and this is that fix.

## Goal
Goal: hold

## Verification
- Live `tsc@7.0.2` oracle, run through the actual `tsz` CLI binary on real multi-file fixtures (not just unit tests), across `declare class` / `declare namespace` / `declare module` (augmenting a real second file) / `.d.ts`: all four clean before AND after for `declare class`/`.d.ts` (already correct), `declare namespace`/`declare module` regressed from a spurious TS1361 to clean after the fix; negative control (plain class) still correctly reports TS1361.
- New suite `ts1361_ambient_computed_property_name_tests.rs` (uses `check_multi_file` for real cross-file `import type` resolution, following `global_augmentation_computed_key_tests.rs`'s established pattern): 8/8 passing (4 positive ambient spellings, interface + method boundary controls, 2 negative controls).
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`: 0 warnings.
- `cargo test -p tsz-checker --lib`: ran through every module alphabetically with zero failures/regressions before hitting a pre-existing, unrelated hang in `tests/ts2589_tests.rs::recursive_conditional_alias_omitted_default_transform_emits_definition_ts2589` (deep recursion in `tsz_solver::evaluation::eval_materialization_probe`, confirmed via `gdb` backtrace — nothing to do with this change's code path). Full conformance/emit sweep not run in this container; the change is a single-predicate substitution in an existing helper with no printer/type-shape implications, and the new suite plus the CLI oracle sweep are the primary evidence per the board's established convention for this exact bug family (#16085/#16087 precedent).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_01TwtVVaZP2nbCc2qvQkh3sU)_