### PR TITLE
chore(readme): refresh conformance stats to 11,442

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ test suite against it.
 
 <!-- CONFORMANCE_START -->
 ```
-Progress: [███████████████████░] 95.0% (11,435/12,043 runnable tests)
+Progress: [███████████████████░] 95.0% (11,442/12,043 runnable tests)
 Candidates: 12,585 (12,043 runnable, 507 unsupported, 35 skipped)
 ```
 <!-- CONFORMANCE_END -->


### PR DESCRIPTION
Goal: hold

Refreshes the generated README conformance block from a measured snapshot at
current `main`. Generated via `scripts/refresh-readme.py --write
--skip-performance`; no hand-edited numbers.

Single line changes: `11,435` -> `11,442` (95.0%, 12,043 runnable).

Emit metrics were intentionally left untouched -- the refresh script declined
to rewrite them (`preserving README emit metrics because
scripts/emit/emit-detail.json is behind the existing README emit block`).
Fourslash metrics were already accurate and are unchanged.

The performance chart is skipped: the only benchmark run I have was measured at
`c4a837bb32`, which is 43 commits behind this head, so republishing it here
would stamp stale perf data onto a newer SHA.

## Verification

Measured locally at `91406c13b4` (nothing else running for conformance/emit):

- conformance: `11442 / 12043` runnable (95.0%), 12585 candidates, 507
  unsupported, 35 skipped -- up from 11435
- emit JS: `11562 / 11563` (at the 11562 parity floor)
- emit DTS: `1375 / 1390` (at the 1375 parity floor)
- fourslash: baseline held at `6558 / 6562`. The run itself was load-contended
  (load 14.73 -> 40.93, workers decayed 10 -> 0, stopped at 6530/6562), but the
  4 `x` failures are exactly the known baseline set
  (`completionListFunctionExpression`,
  `importFixesWithPackageJsonInSideAnotherPackage`,
  `importNameCodeFix_importType`, `autoImportProvider_importsMap1`) with no new
  ones. The 4 reported "timeouts" all read "Test completed but took Xms" --
  they passed, just over the 15s wall clock under load.
- benchmark (at `c4a837bb32`, load 5.04 -> 2.41): tsz wins 94 of 99
  comparisons; all 5 tsgo wins narrowed vs the prior day
  (large-ts-repo 47.19x -> 42.59x, comlink 2.82x -> 2.72x,
  ts-toolbelt 2.48x -> 2.36x, vite 1.78x -> 1.76x, recursive aliases
  1.12x -> 1.11x). No new rows regressed.

## Provenance

Machine: m1
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high

AgentName: M1FableArchitect