### PR TITLE
fix(solver): reject conditional extends-type equivalence for redundant intersections

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/rules/conditionals.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/conditionals.rs
@@ -7,6 +7,8 @@
 
 use std::sync::Arc;
 
+use rustc_hash::FxHashSet;
+
 use crate::type_queries::type_includes_undefined;
 use crate::types::{ConditionalType, IntrinsicKind, TypeData, TypeId};
 use crate::visitor::{
@@ -56,15 +58,18 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             return false;
         }
 
-        if self.with_extends_clause_identity_mode(|sub| {
-            sub.check_subtype(left, right).is_true() && sub.check_subtype(right, left).is_true()
-        }) {
+        if self.intersection_identity_compatible(left, right)
+            && self.with_extends_clause_identity_mode(|sub| {
+                sub.check_subtype(left, right).is_true() && sub.check_subtype(right, left).is_true()
+            })
+        {
             return true;
         }
 
         let left_eval = self.evaluate_type(left);
         let right_eval = self.evaluate_type(right);
         if (left_eval != left || right_eval != right)
+            && self.intersection_identity_compatible(left_eval, right_eval)
             && self.with_extends_clause_identity_mode(|sub| {
                 sub.check_subtype(left_eval, right_eval).is_true()
                     && sub.check_subtype(right_eval, left_eval).is_true()
@@ -74,6 +79,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         }
 
         if !self.identity_fallback_property_modifiers_match(left_eval, right_eval) {
+            return false;
+        }
+
+        if !self.intersection_identity_compatible(left_eval, right_eval) {
             return false;
         }
 
@@ -90,6 +99,39 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         );
         self.absorb_relation_limit_events_from(&fallback, fallback_limits_at_entry);
         equivalent
+    }
+
+    /// Bidirectional subtyping approximates tsc's `isTypeIdenticalTo` for most
+    /// extends-type shapes, but it is unsound whenever one side is an
+    /// `Intersection` containing a member that already subsumes the whole
+    /// comparison: `A & M` is mutually assignable with `A` alone whenever
+    /// `A <: M` (the intersection contributes no extra constraint), even
+    /// though `A & M` and `A` are different type nodes and tsc's real
+    /// `isTypeIdenticalTo` does not conflate a redundant intersection with
+    /// one of its own members. Gate every bidirectional-subtype acceptance in
+    /// `conditional_extends_types_equivalent` on this: when either side is an
+    /// `Intersection`, require an exact (order-independent) member-set match
+    /// — matching tsc, which does not sort intersection members but does
+    /// treat differently-ordered intersections of the same members as
+    /// identical — rather than falling back to mutual assignability.
+    fn intersection_identity_compatible(&self, left: TypeId, right: TypeId) -> bool {
+        match (
+            self.intersection_member_set(left),
+            self.intersection_member_set(right),
+        ) {
+            (None, None) => true,
+            (Some(left_members), Some(right_members)) => left_members == right_members,
+            _ => false,
+        }
+    }
+
+    fn intersection_member_set(&self, id: TypeId) -> Option<FxHashSet<TypeId>> {
+        match self.interner.lookup(id) {
+            Some(TypeData::Intersection(list_id)) => {
+                Some(self.interner.type_list(list_id).iter().copied().collect())
+            }
+            _ => None,
+        }
     }
 
     fn identity_fallback_property_modifiers_match(&self, left: TypeId, right: TypeId) -> bool {


### PR DESCRIPTION
When a conditional type's extends-clause on one side is an Intersection containing a member already subsumed by the other side (`A & M` where `A` is a subtype of `M`), `tsc` does NOT treat the two extends-types as identical; `tsz` did, through `conditional_extends_types_equivalent`'s (`crates/tsz-solver/src/relations/subtype/rules/conditionals.rs`) bidirectional-subtype approximation of `isTypeIdenticalTo`.

## Structural rule

`conditional_extends_types_equivalent` approximates tsc's `isTypeIdenticalTo` for a conditional type's extends-clause using mutual assignability (both-directions `check_subtype`). That approximation is unsound whenever one extends-type is `A & M` and `A` is a subtype of `M`: the intersection is mutually assignable with `A` alone (it contributes no extra constraint beyond `A`), so the shortcut declared them "equivalent" — even though `A & M` and `A` are different type nodes and tsc's real identity check does not conflate a redundant intersection with one of its own members.

This is exactly the mechanism behind the higher-order "Equal" / "IfEquals" trick — a distributive-conditional identity test built from two generic function types whose return types are `T extends X ? 1 : 2` and `T extends Y ? 1 : 2` — which the codebase already special-cases carefully for property-modifier identity (readonly/optional). The redundant-intersection case was an uncovered gap in the same mechanism.

Confirmed via `TSZ_LOG=tsz_solver::relations::subtype::rules::conditionals=debug` on a `dev` build that the intersection is never collapsed at intern time (the trace showed the left operand as a genuine `Intersection`) — this is a relation-identity bug, not an interning/normalization bug. Both previously-suspected mechanisms (`resolve_intersection_new`, `reduce_intersection_subtypes`) are unrelated: `is_subtype_shallow`'s structural match arm only recognizes Object-vs-Object and Function-vs-Function pairs, so it never inspects Tuple/Array members at all.

## Fix

Gate every bidirectional-subtype acceptance point in `conditional_extends_types_equivalent` on a new `intersection_identity_compatible` check: whenever either side is an Intersection, require an exact (order-independent) member-set match instead of falling back to mutual assignability.

## Adjacent-case matrix

- Tuple repro (readonly 1-tuple `& ` a redundant rest-tuple supertype vs the 1-tuple alone): the Equal-trick result was `true`, now `false` (tsc-exact).
- Readonly/optional property-modifier identity (IfEquals, ReadonlyKeys, MutableKeys patterns) — unaffected, still passes existing targeted suite.
- Generic-signature variance through conditional check-types — unaffected (targeted suite passes).
- Object and array sub-cases of the same Equal-trick shape (`{a: 1} & {a: 1 | number}` vs `{a: 1}`, `string[] & (string | number)[]` vs `string[]`) are **not** fixed by this change — traced separately and confirmed to go through a different mechanism entirely (`conditional_extends_types_equivalent` is never invoked with the real operand types for those two shapes). Left as a follow-up; findings posted to the `agent-coordination` board (issue #15994) for the next session to pick up.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test conditional_extends_readonly_identity_tests` — 8/8 pass
- `cargo test -p tsz-checker --test conditional_extends_readonly_variance_tests` — 14/14 pass
- `cargo test -p tsz-checker --test deferred_conditional_identity_extends_tests` — 7/7 pass
- `cargo test -p tsz-checker --test distributive_conditional_default_tests` — 17/17 pass
- `cargo test -p tsz-checker --test generic_conditional_default_assignability_tests` — 7/7 pass
- `cargo test -p tsz-checker --test conditional_infer_tests` — 120/120 pass
- `cargo test -p tsz-solver --lib` — 7617/7617 pass
- `cargo clippy -p tsz-solver --lib` (and the pre-commit hook's `--profile dist-fast -p tsz-solver --lib -D warnings`) — clean
- `./scripts/conformance/compare-to-parent.sh 91406c1` — base failing=599, branch failing=599; 0 newly passing, 0 newly failing (zero corpus movement is the expected signature for this narrow a shape, per prior sessions' findings on sibling fixes in this same family — an oracle-pinned repro is the primary evidence, not the corpus sweep)
- Manual oracle repro against tsc@7.0.2: tuple-shape Equal-trick result now matches tsc (false); previously reported true

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT