### PR TITLE
fix(checker): an enum member initializer is its own await-grammar container

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
@@ -660,6 +660,10 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
         CheckerState::check_await_expression(self, expr_idx);
     }
 
+    fn check_await_expression_in_own_container(&mut self, expr_idx: NodeIndex) {
+        CheckerState::check_await_expression_in_own_container(self, expr_idx);
+    }
+
     fn check_for_await_statement(&mut self, stmt_idx: NodeIndex) {
         CheckerState::check_for_await_statement(self, stmt_idx);
     }

--- a/crates/tsz-checker/src/statements.rs
+++ b/crates/tsz-checker/src/statements.rs
@@ -123,6 +123,12 @@ pub trait StatementCheckCallbacks {
     /// Check an await expression (TS1359: await outside async).
     fn check_await_expression(&mut self, expr_idx: NodeIndex);
 
+    /// Check an await expression that sits inside a construct which is its own
+    /// container for the grammar check — the enclosing async-ness and the
+    /// source file's top-level allowance do not reach it, so the answer is
+    /// always TS1308. Used for enum member initializers.
+    fn check_await_expression_in_own_container(&mut self, expr_idx: NodeIndex);
+
     /// Check a for-await statement (TS1103/TS1432: for-await outside async or without proper module/target).
     fn check_for_await_statement(&mut self, stmt_idx: NodeIndex);
 
@@ -1078,11 +1084,13 @@ impl StatementChecker {
                     }
                 };
                 for init_idx in initializers {
-                    // An enum member initializer is an expression position in the
-                    // enclosing container, so it carries the `await`-grammar walk
-                    // (TS1308/TS1375/TS1378). `ENUM_DECLARATION` owns this arm, so
-                    // it never reaches the catch-all root below.
-                    state.check_await_expression(init_idx);
+                    // An enum member initializer carries the `await`-grammar walk
+                    // (`ENUM_DECLARATION` owns this arm, so it never reaches the
+                    // catch-all root below), and the enum declaration is its own
+                    // container for that check: tsc answers TS1308 whether or not
+                    // the enclosing function is `async`, and at the top level of a
+                    // module where a bare `await` would be legal.
+                    state.check_await_expression_in_own_container(init_idx);
                     state.get_type_of_node_with_request(init_idx, &non_contextual_request);
                 }
             }

--- a/crates/tsz-checker/src/tests/await_grammar_expression_position_tests.rs
+++ b/crates/tsz-checker/src/tests/await_grammar_expression_position_tests.rs
@@ -13,7 +13,11 @@
 //! - a class heritage expression (`class C extends (await b()) {}`) — the
 //!   dispatcher's walk stops at `CLASS_DECLARATION`/`CLASS_EXPRESSION` before
 //!   reaching it
-//! - an enum member initializer — `ENUM_DECLARATION` owns a dispatcher arm
+//! - an enum member initializer — `ENUM_DECLARATION` owns a dispatcher arm,
+//!   and the enum declaration is additionally its **own container** for the
+//!   check: tsc answers TS1308 there whether or not the enclosing function is
+//!   `async`, and at the top level of a module where a bare `await` would be
+//!   legal (#16097)
 //!
 //! Computed property names are a fourth unrooted position and are **not**
 //! covered here: rooting them surfaces a separate pre-existing defect in the
@@ -207,6 +211,90 @@ function outer() {
         count_ts1308(source),
         0,
         "an enum with no `await` must report no TS1308; got {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// An enum member initializer is its own container for the grammar check, so
+/// an enclosing `async` function does **not** make the `await` legal. tsc:
+/// `(1,35): error TS1308` for `async function f() { enum E { A = await 1 } }`.
+/// This is the half #16093 shipped without — it routed through the ordinary
+/// async-context check, so it only fired for a non-async enclosing function.
+#[test]
+fn enum_member_initializer_await_reports_ts1308_inside_async_function() {
+    let source = r"
+async function wrapper() {
+  enum Flags { First = await 1 }
+}
+";
+    assert_eq!(
+        count_ts1308(source),
+        1,
+        "an enum initializer `await` must report TS1308 even inside an async function; got {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// The same rule stated at its clearest: at the top level of a module a bare
+/// `await` is allowed under a top-level-await-capable module/target, and tsc
+/// *still* answers TS1308 inside an enum member initializer — TS1308, not the
+/// TS1375/TS1378 top-level pair. So the enum is not the source-file top level
+/// either.
+#[test]
+fn enum_member_initializer_await_reports_ts1308_at_module_top_level() {
+    let source = r"
+enum Flags { First = await 1 }
+export { };
+";
+    let codes = check_source_codes(source);
+    assert_eq!(
+        count_ts1308(source),
+        1,
+        "a top-level enum initializer `await` must report TS1308; got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&1375) && !codes.contains(&1378),
+        "an enum initializer is not the source-file top level, so the TS1375/TS1378 top-level pair must not fire; got {codes:?}"
+    );
+}
+
+/// A nested expression inside the initializer is reached by the same walk, and
+/// a `const enum` takes the same path. tsc reports TS1308 for both (plus
+/// TS2474 for the const-enum non-constant initializer, which is a different
+/// check and not asserted here).
+#[test]
+fn enum_member_initializer_await_reports_ts1308_when_nested_and_for_const_enum() {
+    let source = r"
+declare function mk(): number;
+async function wrapper() {
+  enum Flags { First = (await mk()) + 2 }
+  const enum Frozen { Second = await mk() }
+}
+";
+    assert_eq!(
+        count_ts1308(source),
+        2,
+        "a nested and a const-enum initializer `await` must each report one TS1308; got {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// The own-container forcing must stop at a function boundary like every other
+/// part of the walk: an `await` inside an arrow function nested in an enum
+/// initializer belongs to that arrow, not to the enum. Here the arrow is
+/// `async`, so tsc reports nothing.
+#[test]
+fn enum_member_initializer_own_container_does_not_leak_into_a_nested_async_arrow() {
+    let source = r"
+declare function mk(): Promise<number>;
+function outer() {
+  enum Flags { First = (async () => await mk()) as any }
+}
+";
+    assert_eq!(
+        count_ts1308(source),
+        0,
+        "an `await` inside an async arrow nested in an enum initializer must not report TS1308; got {:?}",
         check_source_codes(source)
     );
 }

--- a/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
+++ b/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
@@ -574,6 +574,28 @@ impl<'a> CheckerState<'a> {
     /// - Emits TS1308 if await is used outside async function
     /// - Iteratively checks child expressions for await expressions (no recursion)
     pub(crate) fn check_await_expression(&mut self, expr_idx: NodeIndex) {
+        self.check_await_expression_in_container(expr_idx, /* own_container */ false);
+    }
+
+    /// Root the `await`-grammar walk on an expression that sits inside a
+    /// construct which is **its own container** for tsc's `checkAwaitExpression`
+    /// — the enclosing function's async-ness does not reach it, and neither does
+    /// the source file's top-level-`await` allowance.
+    ///
+    /// The enum member initializer is the case this exists for. tsc answers
+    /// TS1308 for `enum E { A = await 1 }` unconditionally: inside an `async`
+    /// function, and at the top level of a module under `--module esnext` where
+    /// a bare `await` is otherwise legal — and it answers TS1308 there rather
+    /// than the TS1375/TS1378 top-level pair.
+    ///
+    /// The walk still stops at function and class boundaries, so the forcing
+    /// never leaks into a nested function body inside the initializer
+    /// (`enum E { A = (() => 1)() }`).
+    pub(crate) fn check_await_expression_in_own_container(&mut self, expr_idx: NodeIndex) {
+        self.check_await_expression_in_container(expr_idx, /* own_container */ true);
+    }
+
+    fn check_await_expression_in_container(&mut self, expr_idx: NodeIndex, own_container: bool) {
         // Use iterative approach with explicit stack to handle deeply nested expressions.
         // This prevents stack overflow for expressions like `0 + 0 + 0 + ... + 0` (50K+ deep).
         let mut stack = vec![expr_idx];
@@ -592,7 +614,11 @@ impl<'a> CheckerState<'a> {
                     // Validate await expression context.
                     // tsc suppresses these grammar checks when the file has parse errors
                     // (e.g., `@dec await 1` — the decorator error suppresses TS1378).
-                    if !self.ctx.in_async_context() && !self.ctx.has_syntax_parse_errors {
+                    // An own-container position never inherits the enclosing
+                    // function's async-ness (see
+                    // `check_await_expression_in_own_container`).
+                    let in_async_context = !own_container && self.ctx.in_async_context();
+                    if !in_async_context && !self.ctx.has_syntax_parse_errors {
                         use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
 
                         // Check if we're directly at the top level of the
@@ -602,7 +628,11 @@ impl<'a> CheckerState<'a> {
                         // all disqualify top-level-await eligibility without
                         // being function-like (see
                         // `is_directly_at_source_file_top_level`).
-                        let at_top_level = self.is_directly_at_source_file_top_level(current_idx);
+                        // An own-container position is likewise never the source
+                        // file's own top level, so it answers TS1308 rather than
+                        // the TS1375/TS1378 top-level pair.
+                        let at_top_level = !own_container
+                            && self.is_directly_at_source_file_top_level(current_idx);
 
                         if at_top_level {
                             // tsc's `checkAwaitExpression` emits these two


### PR DESCRIPTION
Closes #16097 — the remainder Quartz filed while merging #16093 rather than letting it close over a two-thirds-missing arm.

**Structural rule.** When an `await` sits in an enum member initializer, tsc treats the enum declaration as its own container for `checkAwaitExpression`: the enclosing function's async-ness does not reach it, and neither does the source file's top-level-`await` allowance — so the answer is **always TS1308**. tsz does the same through the checker's `check_await_expression` walk, given a container-forcing entry point.

Independently re-measured against a live `tsc@7.0.2` before touching anything, rather than taken from the report:

| fixture | tsc@7.0.2 | tsz @ `91e259a` |
| --- | --- | --- |
| `function f() { enum E { A = await 1 } }` | TS1308 | TS1308 ✓ |
| `async function f() { enum E { A = await 1 } }` | TS1308 | clean ✗ |
| `enum E { A = await 1 }` at module top level, `--module esnext` | TS1308 | clean ✗ |
| `enum E { A = await 1 }` at module top level, `--module commonjs` | TS1308, **not** TS1375/TS1378 | clean ✗ |
| `async function f() { enum E { A = (await mk()) + 2 } }` | TS1308 | clean ✗ |
| `async function f() { const enum C { B = await mk() } }` | TS1308 (+ TS2474) | clean ✗ |

The `--module esnext` row is the one that states the rule: at the top level of a module a bare `await` is otherwise *legal*, and tsc still answers TS1308 inside an enum initializer. The commonjs row adds that it answers TS1308 rather than the top-level pair — so the enum is not the source-file top level either, not merely not-async.

#16093's enum root routed through the ordinary `in_async_context()` / `is_directly_at_source_file_top_level` pair, so it only fired when the enclosing function happened to be non-async.

### Owner layer, and what this deliberately does not touch

A new `check_await_expression_in_own_container` entry point on the grammar walk, forcing both classifications at the one place that consumes them. The alternatives were both worse:

- **Not** widening `in_async_context()` — ten-plus readers, and moving it for class-member code is exactly the #16068/#16094 hazard.
- **Not** adding `ENUM_DECLARATION` to `is_directly_at_source_file_top_level`'s disqualifying list — that predicate is shared with the `await using` TS2852/TS2853/TS2854 path, and a shared predicate should not move for a case that cannot occur there.

The walk still stops at function and class boundaries, so the forcing cannot leak into a nested function body inside the initializer — pinned by a case where an `async` arrow nested in an enum initializer stays silent.

### Adjacent-case matrix

4 new cases (34 total in the two `await`-grammar suites), each pinned against a live `tsc@7.0.2 --noEmit --pretty false --target es2017` run:

- enum initializer `await` **inside an `async` function** → TS1308;
- enum initializer `await` **at module top level** → TS1308, and asserted that TS1375/TS1378 do **not** fire (the distinction, not just the code);
- **nested expression** (`(await mk()) + 2`) and **`const enum`** → one TS1308 each;
- **negative, boundary**: `async` arrow nested inside an enum initializer → 0 TS1308, so the forcing is proven not to leak past a function boundary.

All counted, not `contains`-asserted — `error_at_node` dedups by `(start, code)`.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib await_grammar` → **34 passed / 0 failed**, re-run after the rebase onto current main (`734eee3`).
- **Two-sided against the parent**: production diff stashed with the new tests kept → **31 passed / 3 failed**; with it → **34 / 0**. The 4th new case is the nested-`async`-arrow negative, correctly green either way.
- `cargo fmt` clean; pre-commit `clippy` (`-p tsz-checker`, warnings denied) and the architecture/size guard both pass.
- Rebased onto `734eee3` rather than stacked on #16093's pre-squash commit, so this is a single-commit diff.
- Not run in this container: conformance / emit / fourslash. Blast radius is narrower than #16093's — that one added TS1308 on three previously-silent positions and measured **0 newly failing / 0 newly passing** across 12,043 rows; this one only widens the enum arm, and the corpus has no `await` in an enum initializer to move. A `compare-to-parent.sh` from a warm seat is still the right confirmation.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Slate

---
_Generated by [Claude Code](https://claude.ai/code/session_018hnT7MD4UXRXu8pDSQcaUR)_