### PR TITLE
fix(checker): stop TS1170's literal-form gate from swallowing type-literal computed-name checks

### DIFF
--- a/crates/tsz-checker/src/checkers/property_checker.rs
+++ b/crates/tsz-checker/src/checkers/property_checker.rs
@@ -1048,34 +1048,16 @@ impl<'a> CheckerState<'a> {
         true
     }
 
-    /// Root the await-grammar walk (TS1308) on a computed member name's
-    /// expression only — for a caller that already ran the literal-type
-    /// check (TS1166/1169/1170, mutually exclusive with TS2464 in tsc) and
-    /// wants the independent await diagnostic without re-running
-    /// [`Self::check_computed_property_name`]'s TS2464 branch too.
-    /// `error_at_node` dedups by `(start, code)`, so calling this from a
-    /// position an existing root already reaches is safe.
-    pub(crate) fn check_computed_property_name_await_only(&mut self, name_idx: NodeIndex) {
-        let Some(name_node) = self.ctx.arena.get(name_idx) else {
-            return;
-        };
-        if name_node.kind != tsz_parser::parser::syntax_kind_ext::COMPUTED_PROPERTY_NAME {
-            return;
-        }
-        let Some(computed) = self.ctx.arena.get_computed_property(name_node) else {
-            return;
-        };
-        self.check_await_expression(computed.expression);
-    }
-
     /// Check a computed property name for type errors (TS2464).
     ///
     /// Validates that the expression used for a computed property name
     /// has a type that is string, number, symbol, or any (including literals).
     /// This check is independent of strictNullChecks. Also roots the
-    /// await-grammar walk (TS1308) — see
-    /// [`Self::check_computed_property_name_await_only`] for callers that
-    /// need only that part.
+    /// await-grammar walk (TS1308) — independent of TS1166/1169/1170's
+    /// literal-form check, so every caller runs this in full regardless of
+    /// whether that check already fired (`error_at_node` dedups by
+    /// `(start, code)`, so a position an existing root already reaches is
+    /// never double-reported).
     pub(crate) fn check_computed_property_name(&mut self, name_idx: NodeIndex) {
         let Some(name_node) = self.ctx.arena.get(name_idx) else {
             return;
@@ -1089,7 +1071,7 @@ impl<'a> CheckerState<'a> {
             return;
         };
 
-        // TS1308: see `check_computed_property_name_await_only`'s doc comment.
+        // TS1308: independent of TS1166/1169/1170 — see the doc comment above.
         self.check_await_expression(computed.expression);
 
         // TS1212/TS1213: Check if the computed expression is a strict mode reserved word.

--- a/crates/tsz-checker/src/tests/await_grammar_computed_property_name_tests.rs
+++ b/crates/tsz-checker/src/tests/await_grammar_computed_property_name_tests.rs
@@ -27,10 +27,12 @@
 //! 3. **A TS1170 routing gap** (Blocker B, already named in #16094): a
 //!    type-literal member whose computed name failed the literal-type check
 //!    (TS1170) never got the shared `check_computed_property_name` funnel at
-//!    all, so `await` inside it was silently unrooted even after (1) and (2).
-//!    Fixed by always running the await-only half of that funnel
-//!    (`check_computed_property_name_await_only`) regardless of whether
-//!    TS1170 fired — `tsc` reports both, they are independent grammar rules.
+//!    all, so `await` inside it (and separately, TS2464's property-key-type
+//!    check — verified against `tsc@7.0.2`: `type U = { [b as unknown as
+//!    boolean]: number }` reports both TS1170 and TS2464) was silently
+//!    unrooted even after (1) and (2). Fixed in `type_alias_checking.rs` by
+//!    always running the full funnel regardless of whether TS1170 fired —
+//!    `tsc` reports both, they are independent grammar/type rules.
 //!
 //! Every expectation below is pinned against a live `tsc@7.0.2 --noEmit
 //! --pretty false --target es2017 --module commonjs` run, not recalled, and

--- a/crates/tsz-checker/src/tests/ts1170_computed_property_syntactic_form_tests.rs
+++ b/crates/tsz-checker/src/tests/ts1170_computed_property_syntactic_form_tests.rs
@@ -113,3 +113,66 @@ type X = {
         "TS1170 must fire for parenthesized access regardless of identifier names. Got: {codes:?}"
     );
 }
+
+/// tsc's `checkComputedPropertyName` (TS1170, "must be a literal or unique
+/// symbol type") and its type-of-property-key check (TS2464, "must be of
+/// type string/number/symbol/any") are independent: both fire together when
+/// a type-literal property's computed name is neither a literal/entity-name
+/// expression NOR of a valid property-key type. Verified against
+/// `tsc@7.0.2`: `type U = { [b as unknown as boolean]: number }` (`b:
+/// boolean`) reports both TS1170 and TS2464 at the same position.
+#[test]
+fn ts2464_fires_alongside_ts1170_type_literal_property() {
+    let codes = diag_codes(
+        r#"
+declare const b: boolean;
+type U = { [b as unknown as boolean]: number };
+"#,
+    );
+    assert!(
+        codes.contains(&1170),
+        "Expected TS1170 for non-literal computed name in type literal. Got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&2464),
+        "Expected TS2464 alongside TS1170 — the type-literal literal-form gate must not \
+         suppress the independent property-key-type check. Got: {codes:?}"
+    );
+}
+
+/// Same independence, for a type literal's computed *method* name (the
+/// signature-member arm, a separate code path from the property-member arm
+/// above).
+#[test]
+fn ts2464_fires_alongside_ts1170_type_literal_method() {
+    let codes = diag_codes(
+        r#"
+declare const b: boolean;
+type U = { [b as unknown as boolean](): number };
+"#,
+    );
+    assert!(
+        codes.contains(&1170),
+        "Expected TS1170 for non-literal computed method name in type literal. Got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&2464),
+        "Expected TS2464 alongside TS1170 for a type-literal method's computed name. Got: {codes:?}"
+    );
+}
+
+/// Anti-regression: a genuinely valid (literal-or-entity-name, valid-key-type)
+/// computed name in a type literal must still emit neither code.
+#[test]
+fn ts1170_and_ts2464_absent_for_valid_type_literal_computed_name() {
+    let codes = diag_codes(
+        r#"
+declare const k: unique symbol;
+type X = { [k]: number };
+"#,
+    );
+    assert!(
+        !codes.contains(&1170) && !codes.contains(&2464),
+        "Valid unique-symbol computed name must not trigger TS1170/TS2464. Got: {codes:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -1481,24 +1481,20 @@ impl<'a> CheckerState<'a> {
                         if let Some(sig) = self.ctx.arena.get_signature(member_node) {
                             {
                                 use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-                                let emitted_literal_diagnostic =
-                                    self.check_computed_property_requires_literal(
-                                        sig.name,
-                                        diagnostic_messages::A_COMPUTED_PROPERTY_NAME_IN_A_TYPE_LITERAL_MUST_REFER_TO_AN_EXPRESSION_WHOSE_TYP,
-                                        diagnostic_codes::A_COMPUTED_PROPERTY_NAME_IN_A_TYPE_LITERAL_MUST_REFER_TO_AN_EXPRESSION_WHOSE_TYP,
-                                    );
-                                if emitted_literal_diagnostic {
-                                    // TS1170 and TS1308 are independent
-                                    // grammar rules tsc reports together; the
-                                    // broader TS2464 type-validation branch
-                                    // in check_computed_property_name is
-                                    // mutually exclusive with TS1170 in tsc,
-                                    // so only the await-grammar root runs
-                                    // here, not the full function.
-                                    self.check_computed_property_name_await_only(sig.name);
-                                } else {
-                                    self.check_computed_property_name(sig.name);
-                                }
+                                // TS1170 (syntactic form) and check_computed_property_name's
+                                // diagnostics (TS2464 property-key-type, TS1212/1213 reserved
+                                // words, await-grammar) are independent checks in tsc — it
+                                // emits both when both conditions hold. Verified against
+                                // tsc@7.0.2: `type U = { [b as unknown as boolean]: number }`
+                                // (`b: boolean`) reports both TS1170 and TS2464 at the same
+                                // position, so the literal-form check must never gate the
+                                // shared funnel down to the await-only half.
+                                let _ = self.check_computed_property_requires_literal(
+                                    sig.name,
+                                    diagnostic_messages::A_COMPUTED_PROPERTY_NAME_IN_A_TYPE_LITERAL_MUST_REFER_TO_AN_EXPRESSION_WHOSE_TYP,
+                                    diagnostic_codes::A_COMPUTED_PROPERTY_NAME_IN_A_TYPE_LITERAL_MUST_REFER_TO_AN_EXPRESSION_WHOSE_TYP,
+                                );
+                                self.check_computed_property_name(sig.name);
                             }
                             let (_type_params, type_param_updates) =
                                 self.push_type_parameters(&sig.type_parameters);
@@ -1556,22 +1552,16 @@ impl<'a> CheckerState<'a> {
                         if let Some(prop) = self.ctx.arena.get_property_decl(member_node) {
                             {
                                 use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-                                let emitted_literal_diagnostic = self
-                                    .check_computed_property_requires_literal(
-                                        prop.name,
-                                        diagnostic_messages::A_COMPUTED_PROPERTY_NAME_IN_A_TYPE_LITERAL_MUST_REFER_TO_AN_EXPRESSION_WHOSE_TYP,
-                                        diagnostic_codes::A_COMPUTED_PROPERTY_NAME_IN_A_TYPE_LITERAL_MUST_REFER_TO_AN_EXPRESSION_WHOSE_TYP,
-                                    );
-                                if emitted_literal_diagnostic {
-                                    // See the METHOD_SIGNATURE arm above:
-                                    // TS1170 and TS1308 are independent and
-                                    // tsc reports both, but its TS2464
-                                    // branch is mutually exclusive with
-                                    // TS1170, so only the await root runs.
-                                    self.check_computed_property_name_await_only(prop.name);
-                                } else {
-                                    self.check_computed_property_name(prop.name);
-                                }
+                                // See the signature-member arm above: TS1170 and
+                                // check_computed_property_name's diagnostics are
+                                // independent checks, so the literal-form check must
+                                // never gate the shared funnel down to the await-only half.
+                                let _ = self.check_computed_property_requires_literal(
+                                    prop.name,
+                                    diagnostic_messages::A_COMPUTED_PROPERTY_NAME_IN_A_TYPE_LITERAL_MUST_REFER_TO_AN_EXPRESSION_WHOSE_TYP,
+                                    diagnostic_codes::A_COMPUTED_PROPERTY_NAME_IN_A_TYPE_LITERAL_MUST_REFER_TO_AN_EXPRESSION_WHOSE_TYP,
+                                );
+                                self.check_computed_property_name(prop.name);
                             }
                             if prop.type_annotation != NodeIndex::NONE {
                                 check_child_type_node!(self, prop.type_annotation);


### PR DESCRIPTION
Split off from #16094 (Blocker B). The full await-grammar root for computed member names (Blocker A) is NOT included here — landed separately as #16099 while this PR was in flight (see below for the rebase). The top-level-module axis of Blocker A (a separate, still-open false positive) is tracked at #16100.

Rebased onto `main` (now includes #16099/#16101). #16099 touched the same two `type_alias_checking.rs` arms this PR touches, with a comment claiming TS1170 and `check_computed_property_name`'s TS2464 branch are "mutually exclusive in tsc" — verified against a live `tsc@7.0.2` oracle that this is false (see below); resolved by always routing through the full `check_computed_property_name`, which after the merge already carries #16099's await root too. Removed the stale "mutually exclusive" comment and deleted `check_computed_property_name_await_only`, which had no remaining callers once both arms call the full function.

When a type-literal member's computed name is both syntactically invalid for TS1170 ("must refer to an expression whose type is a literal type or a 'unique symbol' type") AND its expression type is not a valid property-key type, `tsc` emits **both** TS1170 and TS2464 — they are independent checks. tsz's type-literal arm (both the signature/method sub-case and the property-declaration sub-case) called `check_computed_property_name` — which owns TS2464, TS1212/1213, and (after #16099) the await-grammar root — only when `check_computed_property_requires_literal`'s TS1170 did **not** fire, so the TS2464 half silently dropped whenever both conditions held.

Verified against a live `tsc@7.0.2` oracle:
```ts
declare const b: boolean;
type U = { [b as unknown as boolean]: number };
```
reports both TS1170 and TS2464. Confirmed the gap on tsz before this fix by adding a probe test (`codes: [1170]`, TS2464 missing).

Structural rule: **when a type-literal member's computed name fails both TS1170's syntactic-form check and TS2464's property-key-type check, tsc reports both codes independently; tsz now does the same by always routing the name through `check_computed_property_name` regardless of whether TS1170 fired.**

Adjacent-case matrix added in `ts1170_computed_property_syntactic_form_tests.rs`:
- TS2464 alongside TS1170 for a type-literal **property** member (new).
- TS2464 alongside TS1170 for a type-literal **method/signature** member — a separate code path (new).
- Anti-regression: a genuinely valid (entity-name/literal, valid-key-type) computed name still emits neither code (new).
- Existing TS1166/TS1169/TS1170 paren-property-access and conditional tests (class/interface, unaffected by this change), and #16099's full `await_grammar_computed_property_name_tests.rs` matrix (async/non-async, class/interface/type-literal), all still pass unchanged.

Not touched: the interface arm (`core.rs`) already had no such gate. The top-level-module axis of the await-grammar root (#16100) is a separate, already-filed issue — not attempted here.

## Goal
Goal: hold

## Verification
- `cargo fmt --check -p tsz-checker`: clean.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings`: clean.
- `cargo nextest run -p tsz-checker --lib`: 8680 tests, 8679 passed, 1 pre-existing/baselined failure unrelated to this change (`ts2303_tests::recursive_export_assignment_self_import_reports_ts2303`, a known `--lib` baseline failure independently confirmed by another session on the same head).
- `scripts/conformance/compare-to-parent.sh` (two-sided, HEAD vs HEAD~1 = `37dd090`, current `main` tip): 12043 runnable / 11443 passed both sides, 599 failing both sides, **0 newly passing, 0 newly failing**.
- Local pre-commit hook (fmt + clippy + arch-size guard): passed.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE