### PR TITLE
test(checker): correct the await-grammar suite's stale header and pin what it excluded

### DIFF
--- a/crates/tsz-checker/src/tests/await_grammar_statement_position_tests.rs
+++ b/crates/tsz-checker/src/tests/await_grammar_statement_position_tests.rs
@@ -264,17 +264,19 @@ function h() { const holder = { emit() { throw await 1; } }; }
 /// And in a function expression, the third enclosing-function form. tsc:
 /// `(1,35): error TS1308`.
 ///
-/// Two enclosing forms are deliberately *not* asserted here, both
-/// pre-existing wrong-diagnostic defects independent of these roots:
-/// - a class method, constructor, or accessor body, where tsz answers
-///   `[TS1375, TS1378]` (the top-level-await pair) because
-///   `ctx.function_depth` is still 0 inside them — it reproduces on the plain
-///   `class K { m() { await 1; } }` expression-statement witness, rooted long
-///   before this suite;
-/// - a class static block, where tsc reports TS18037 (`'await' expression
-///   cannot be used inside a class static block`) and tsz reports TS1308.
+/// A class method, constructor, or accessor body was once wrong here and is
+/// now correct and pinned below (`class_member_body_await_reports_ts1308`):
+/// #16070 made a class member body a `ctx.function_depth` boundary.
 ///
-/// Both are tracked on their own issue rather than pinned red here.
+/// A class static block is deliberately *not* asserted, and the reason is
+/// narrower than it looks. `class K { static { await 1; } }` is correct
+/// through the CLI on any target — tsc and tsz both answer TS18037 — but
+/// through this suite's `check_source_codes` (which uses
+/// `CheckerOptions::default()`) tsz answers `[TS1375, TS1378]`, the
+/// top-level-await pair, i.e. it treats the static block as the top level of
+/// the file. That is a real defect, visible only under the unit harness's
+/// default options, and it is tracked on its own issue rather than pinned
+/// red here.
 #[test]
 fn while_condition_await_in_function_expression_reports_ts1308() {
     let source = r"
@@ -365,4 +367,42 @@ async function outer(p: Promise<number>) {
         "a non-async function nested in an async one still reports TS1308 for its own `await`; got {:?}",
         check_source_codes(source)
     );
+}
+
+// --- enclosing forms the header once listed as unasserted defects ---
+
+/// A class method, constructor, or accessor body is a `ctx.function_depth`
+/// boundary (#16070), so a non-async one answers TS1308 rather than the
+/// top-level-await pair. tsc on each of the three, `--target es2017`:
+/// `TS1308`, once.
+#[test]
+fn class_member_body_await_reports_ts1308() {
+    for source in [
+        "class K { m() { await 1; } }",
+        "class K { constructor() { await 1; } }",
+        "class K { get g() { await 1; return 1; } }",
+    ] {
+        assert_eq!(
+            count_ts1308(source),
+            1,
+            "a non-async class member body must report exactly one TS1308: {source}"
+        );
+        assert!(
+            !check_source_codes(source).contains(&1375),
+            "a class member body is not the top level of the file: {source}"
+        );
+    }
+}
+
+/// Renamed binders for the same three forms — the boundary is structural, not
+/// keyed on any member or class name.
+#[test]
+fn class_member_body_await_is_name_agnostic() {
+    for source in [
+        "class Widget { render() { await 1; } }",
+        "class Widget { constructor() { await 1; } }",
+        "class Widget { get label() { await 1; return 1; } }",
+    ] {
+        assert_eq!(count_ts1308(source), 1, "renamed binders: {source}");
+    }
 }


### PR DESCRIPTION
Fixes the stale doc header at `crates/tsz-checker/src/tests/await_grammar_statement_position_tests.rs` reported in #16073, and pins the coverage it was excluding. **The issue's own conclusion turned out to be half wrong — details below.**

The header claimed two enclosing forms were "deliberately not asserted, both pre-existing wrong-diagnostic defects":

1. a class method/constructor/accessor body answering `[TS1375, TS1378]` instead of TS1308
2. a class static block answering TS1308 where tsc reports TS18037

## (1) is fixed — now pinned instead of described

#16070 made a class member body a `ctx.function_depth` boundary. Verified against `tsc@7.0.2`:

```
class K { m() { await 1; } }                    tsc TS1308   tsz TS1308
class K { constructor() { await 1; } }          tsc TS1308   tsz TS1308
class K { get g() { await 1; return 1; } }      tsc TS1308   tsz TS1308
```

Added `class_member_body_await_reports_ts1308` (all three forms, and an explicit assertion that TS1375 is *not* present, since that was the reported wrong answer) and `class_member_body_await_is_name_agnostic` (renamed binders — the boundary is structural).

## (2) is NOT fixed, and #16073 was wrong to say so

I filed #16073 and verified it through the CLI, where tsz answers TS18037 correctly on every target. Writing the test exposed that the **unit harness disagrees with the CLI on the same source**:

```
class K { static { await 1; } }

CLI, default options       tsc TS18037    tsz TS18037     correct
CLI, --target es2017       tsc TS18037    tsz TS18037     correct
check_source_codes(...)    (n/a)          tsz [TS1375, TS1378]
```

`check_source_codes` uses `CheckerOptions::default()`, and under those options tsz treats the static block as **the top level of the file** and emits the top-level-await pair. So the defect is real; the header simply named the wrong codes for it (TS1308 rather than `[TS1375, TS1378]`), and my CLI-only verification could not see it at all.

The header now says that precisely, including that it reproduces only under the harness's default options, so the next person does not repeat my mistake of "the CLI is clean, therefore it is fixed." I have corrected #16073 with the same finding and it stays open for this half.

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-checker --lib -E 'test(await_grammar_statement_position)'` — **21/21 pass** (19 existing + 2 new).
- Every new expectation taken from a live `tsc@7.0.2` run (`--noEmit --pretty false --target es2017`), not from tsz's output.
- Test-only: no source, script, or workflow changes, so conformance/emit/fourslash do not apply.

**This flips no test** — the two new ones pass on `main` as-is. It is not a correctness change; the value is deleting a false claim about compiler behaviour and converting a "deliberately unasserted" note into either real coverage or an accurate description. A wrong comment about `tsc` semantics is worse than none, because the next reader reasonably trusts it — that is precisely how #16099 and #16102 came to assert opposite rules about TS1170/TS2464 in the same function.

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high
AgentName: Quartz
