### PR TITLE
test(checker): TS1170-alone negative controls for type-literal computed names

### DIFF
--- a/crates/tsz-checker/src/tests/ts1170_computed_property_syntactic_form_tests.rs
+++ b/crates/tsz-checker/src/tests/ts1170_computed_property_syntactic_form_tests.rs
@@ -161,6 +161,71 @@ type U = { [b as unknown as boolean](): number };
     );
 }
 
+/// Anti-hardcoding cover: same TS1170+TS2464 co-occurrence with a renamed
+/// binder and a type alias name — the fix must not depend on identifier
+/// spelling.
+#[test]
+fn ts2464_fires_alongside_ts1170_renamed_binder() {
+    let codes = diag_codes(
+        r#"
+declare const flag: boolean;
+type Renamed = { [flag as unknown as boolean]: number };
+"#,
+    );
+    assert!(
+        codes.contains(&1170) && codes.contains(&2464),
+        "Renamed binders must not change the TS1170+TS2464 co-occurrence rule. Got: {codes:?}"
+    );
+}
+
+/// Negative control: TS1170 can fire alone when the syntactic form is
+/// invalid (parenthesized entity-name access breaks the entity-name chain)
+/// but the computed type is still a genuinely valid property key (`string`).
+/// TS2464 must NOT fire spuriously just because TS1170 did — these are two
+/// independently-gated checks, not a package deal in either direction.
+/// Covers both the property and method member shapes.
+#[test]
+fn ts1170_alone_when_type_is_valid_property() {
+    let codes = diag_codes(
+        r#"
+declare const ns: { sym: string };
+type X = {
+    [(ns).sym]: number,
+};
+"#,
+    );
+    assert!(
+        codes.contains(&1170),
+        "Expected TS1170 for parenthesized property access. Got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2464),
+        "TS2464 must not fire when the computed name's type is a valid property key (string). \
+         Got: {codes:?}"
+    );
+}
+
+#[test]
+fn ts1170_alone_when_type_is_valid_method() {
+    let codes = diag_codes(
+        r#"
+declare const ns: { sym: string };
+type X = {
+    [(ns).sym](): number,
+};
+"#,
+    );
+    assert!(
+        codes.contains(&1170),
+        "Expected TS1170 for parenthesized method access. Got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2464),
+        "TS2464 must not fire when the computed name's type is a valid property key (string). \
+         Got: {codes:?}"
+    );
+}
+
 /// Anti-regression: a genuinely valid (literal-or-entity-name, valid-key-type)
 /// computed name in a type literal must still emit neither code.
 #[test]


### PR DESCRIPTION
Test-only follow-up to #16102 (merged `ce32746`), which fixed TS1170/TS2464 independence for type-literal computed names but only covered the "both fire" direction.

Adds the missing negative-control direction: TS1170 can fire alone when the syntactic form is invalid (parenthesized entity-name access, e.g. `[(ns).sym]`) while the computed name's type is still genuinely valid (`string`) — TS2464 must not fire spuriously just because TS1170 did. Without this control, an over-broad implementation ("always emit both") would pass every existing test in that file.

Added, both oracle-pinned against `tsc@7.0.2`:
- `ts1170_alone_when_type_is_valid_property` / `ts1170_alone_when_type_is_valid_method` — the negative control, for both member shapes.
- `ts2464_fires_alongside_ts1170_renamed_binder` — anti-hardcoding cover for the existing positive case.

No production code changes. Rebased onto current `main` (`edf7601`); `property_checker.rs` and `type_alias_checking.rs` diffs against `main` are empty.

Filed #16103 separately for an unrelated defect found while verifying the original TS1170/TS2464 gap (type-literal computed-name `await`-context handling looks wrong inside an async wrapper) — out of scope here.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib ts1170_computed_property_syntactic_form_tests`: 12/12 passed (3 new, 9 pre-existing).
- `cargo fmt -p tsz-checker` / pre-commit hook (fmt + clippy + arch-guard): passed.
- Test-only change against already-merged, already-conformance-verified behavior (#16102: 0 newly-passing/0 newly-failing) — no further conformance run needed for this diff.
- Oracle: both new expectations pinned against a live `tsc@7.0.2 --noEmit --pretty false --target es2017 --module commonjs` run.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT