### PR TITLE
fix(checker): a type literal is parsed outside await context

### DIFF
--- a/crates/tsz-checker/src/checkers/property_checker.rs
+++ b/crates/tsz-checker/src/checkers/property_checker.rs
@@ -1072,7 +1072,7 @@ impl<'a> CheckerState<'a> {
         };
 
         // TS1308: independent of TS1166/1169/1170 — see the doc comment above.
-        self.check_await_expression(computed.expression);
+        self.check_computed_property_name_await(name_idx, computed.expression);
 
         // TS1212/TS1213: Check if the computed expression is a strict mode reserved word.
         // E.g., `{ [public]: 0 }` should emit TS1212 in strict mode.

--- a/crates/tsz-checker/src/tests/await_grammar_computed_property_name_tests.rs
+++ b/crates/tsz-checker/src/tests/await_grammar_computed_property_name_tests.rs
@@ -34,6 +34,20 @@
 //!    always running the full funnel regardless of whether TS1170 fired —
 //!    `tsc` reports both, they are independent grammar/type rules.
 //!
+//! 4. **A wrong async-context rule for type literals** (#16103, fixed after
+//!    the above). (1) gave *every* computed-name position the "evaluated in
+//!    the enclosing scope, so an enclosing `async` makes `await` legal" rule.
+//!    That is right for class and interface members but wrong for a type
+//!    literal: `tsc` gates TS1308 on the parser's `NodeFlags.AwaitContext`,
+//!    and `parseType` runs under `doOutsideOfContext(TypeExcludesFlags)`,
+//!    which clears that flag for the whole type. `parseInterfaceDeclaration`
+//!    reaches its members through `parseObjectTypeMembers` instead, so an
+//!    interface keeps the flag — which is why the two disagree. Fixed via
+//!    `AwaitContainerKind::OutsideAwaitContext`, keyed structurally on the
+//!    owning member's parent being a `TypeLiteral` so it holds for every way
+//!    of reaching one (type-alias body, variable or parameter annotation,
+//!    nested inside an `interface` member's type).
+//!
 //! Every expectation below is pinned against a live `tsc@7.0.2 --noEmit
 //! --pretty false --target es2017 --module commonjs` run, not recalled, and
 //! cross-checked against the compiled `tsz` CLI (not just this unit
@@ -161,14 +175,23 @@ function outer() { type Shape2 = { [await key]: number }; }
 }
 
 #[test]
-fn async_wrapper_type_literal_computed_name_reports_only_ts1170() {
+fn async_wrapper_type_literal_computed_name_reports_ts1170_and_ts1308() {
+    // #16103. This assertion previously read `[1170]` — added in #16099 by
+    // analogy with the class and interface siblings above, never checked
+    // against a live oracle, and wrong. `tsc@7.0.2` reports **both** codes:
+    // a type literal's members are parsed under `parseType`, which runs
+    // inside `doOutsideOfContext(TypeExcludesFlags)` and clears
+    // `NodeFlags.AwaitContext`, so the enclosing `async` never reaches the
+    // computed name. The class and interface siblings really do inherit it —
+    // that asymmetry is the whole rule, and it is pinned by the two control
+    // tests directly above and below this one.
     let codes = without_missing_promise_lib(check_source_codes_with_parse_health(
         r#"
 declare const key: string;
 async function wrapper() { type Shape2 = { [await key]: number }; }
 "#,
     ));
-    assert_eq!(codes, vec![1170], "got {codes:?}");
+    assert_eq!(sorted(codes.clone()), vec![1170, 1308], "got {codes:?}");
 }
 
 #[test]
@@ -440,5 +463,116 @@ class Holder { [(() => await key)()]() {} }
     assert!(
         codes.contains(&1308),
         "an arrow body is its own container; got {codes:?}"
+    );
+}
+
+// --- #16103: a type literal is parsed outside await context, wherever it
+// --- appears. Every expectation below is pinned against a live
+// --- `tsc@7.0.2 --noEmit --pretty false --target es2017 --module commonjs`
+// --- run made for this change, not recalled.
+
+/// The rule is keyed on the *type literal*, not on the type alias that
+/// happens to be the most common way to spell one. A literal reached through
+/// an `interface` member's type annotation answers the same way — even
+/// though the enclosing `interface` member's own computed name would not
+/// (see `async_wrapper_interface_computed_name_reports_only_ts1169`).
+#[test]
+fn async_wrapper_type_literal_inside_interface_member_reports_ts1170_and_ts1308() {
+    let codes = without_missing_promise_lib(check_source_codes_with_parse_health(
+        r#"
+declare const key: string;
+async function wrapper() { interface Outer { inner: { [await key]: number } } }
+"#,
+    ));
+    assert_eq!(sorted(codes.clone()), vec![1170, 1308], "got {codes:?}");
+}
+
+/// A type literal in a variable's type annotation — no type alias involved.
+#[test]
+fn async_wrapper_type_literal_in_variable_annotation_reports_ts1170_and_ts1308() {
+    let codes = without_missing_promise_lib(check_source_codes_with_parse_health(
+        r#"
+declare const key: string;
+async function wrapper() { let slot: { [await key]: number }; }
+"#,
+    ));
+    assert_eq!(sorted(codes.clone()), vec![1170, 1308], "got {codes:?}");
+}
+
+/// A type literal nested one level deeper inside a type alias body.
+#[test]
+fn async_wrapper_nested_type_literal_reports_ts1170_and_ts1308() {
+    let codes = without_missing_promise_lib(check_source_codes_with_parse_health(
+        r#"
+declare const key: string;
+async function wrapper() { type Outer = { inner: { [await key]: number } }; }
+"#,
+    ));
+    assert_eq!(sorted(codes.clone()), vec![1170, 1308], "got {codes:?}");
+}
+
+/// A method signature is a separate arm of the type-literal member walk from
+/// the property signature every other case here exercises.
+#[test]
+fn async_wrapper_type_literal_method_signature_reports_ts1170_and_ts1308() {
+    let codes = without_missing_promise_lib(check_source_codes_with_parse_health(
+        r#"
+declare const key: string;
+async function wrapper() { type Shape3 = { [await key](): number }; }
+"#,
+    ));
+    assert_eq!(sorted(codes.clone()), vec![1170, 1308], "got {codes:?}");
+}
+
+/// Renamed-binder control: nothing here may depend on the spelling of the
+/// key, the alias, or the wrapper.
+#[test]
+fn async_wrapper_type_literal_computed_name_is_binder_name_independent() {
+    let codes = without_missing_promise_lib(check_source_codes_with_parse_health(
+        r#"
+declare const zzTag: string;
+async function qqOuter() { type MmShape = { [await zzTag]: number }; }
+"#,
+    ));
+    assert_eq!(sorted(codes.clone()), vec![1170, 1308], "got {codes:?}");
+}
+
+/// **The row that proves this is a routing fix and not a suppression.**
+/// Clearing await context does not change `isInTopLevelContext`, so a type
+/// literal at the source file's own top level must still answer the
+/// TS1375/TS1378 top-level pair — never TS1308. Only a fix that actually
+/// routes to the top-level branch can produce this; a fix that force-reports
+/// TS1308 for type literals would fail exactly here.
+#[test]
+fn script_top_level_type_literal_computed_name_reports_top_level_await_pair() {
+    let codes = check_source_codes_with_parse_health(
+        r#"
+declare const key: string;
+type Shape4 = { [await key]: number };
+"#,
+    );
+    assert_eq!(
+        sorted(codes.clone()),
+        vec![1170, 1375, 1378],
+        "got {codes:?}"
+    );
+}
+
+/// Negative control on the other side: an **object literal**'s computed name
+/// is an ordinary value position and must keep inheriting the enclosing
+/// `async`. tsc reports nothing here. This is the case a fix keyed on
+/// "computed name in a braced member list" rather than on the type literal
+/// would break.
+#[test]
+fn async_wrapper_object_literal_computed_name_stays_clean() {
+    let codes = without_missing_promise_lib(check_source_codes_with_parse_health(
+        r#"
+declare const key: string;
+async function wrapper() { const bag = { [await key]: 1 }; }
+"#,
+    ));
+    assert!(
+        codes.is_empty(),
+        "an object literal is a value position and keeps the enclosing async context; got {codes:?}"
     );
 }

--- a/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
+++ b/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
@@ -11,6 +11,41 @@ use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::TypeId;
 
+/// How an `await`-grammar walk's root position relates to `tsc`'s two
+/// independent `checkAwaitExpression` axes.
+///
+/// `tsc` asks two separate questions about an `await`: whether the parser left
+/// it in await context (`NodeFlags.AwaitContext`, which an enclosing `async`
+/// function sets), and whether it sits in a top-level context
+/// (`isInTopLevelContext`, which selects the TS1375/TS1378 pair over TS1308).
+/// A root position can suppress either axis independently, so they are modelled
+/// as two orthogonal properties rather than one "is this special" flag.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AwaitContainerKind {
+    /// Ordinary position: both axes answered from the surrounding code.
+    Inherited,
+    /// Parsed outside await context, but still eligible for top-level `await`
+    /// (a type literal's computed member name).
+    OutsideAwaitContext,
+    /// Its own container for both axes: never async, never top level (an enum
+    /// member initializer).
+    OwnContainer,
+}
+
+impl AwaitContainerKind {
+    /// Whether an enclosing `async` function's await context reaches this
+    /// position.
+    const fn inherits_async_context(self) -> bool {
+        matches!(self, Self::Inherited)
+    }
+
+    /// Whether this position can be the source file's own top level, and so
+    /// answer the TS1375/TS1378 pair instead of TS1308.
+    const fn allows_top_level_await(self) -> bool {
+        matches!(self, Self::Inherited | Self::OutsideAwaitContext)
+    }
+}
+
 impl<'a> CheckerState<'a> {
     pub(crate) fn check_return_statement(&mut self, stmt_idx: NodeIndex) {
         let Some(node) = self.ctx.arena.get(stmt_idx) else {
@@ -574,7 +609,65 @@ impl<'a> CheckerState<'a> {
     /// - Emits TS1308 if await is used outside async function
     /// - Iteratively checks child expressions for await expressions (no recursion)
     pub(crate) fn check_await_expression(&mut self, expr_idx: NodeIndex) {
-        self.check_await_expression_in_container(expr_idx, /* own_container */ false);
+        self.check_await_expression_in_container(expr_idx, AwaitContainerKind::Inherited);
+    }
+
+    /// Root the `await`-grammar walk on an expression that `tsc` parses
+    /// **outside await context**, while leaving its top-level-`await`
+    /// eligibility intact.
+    ///
+    /// A type literal's computed member name is the case this exists for.
+    /// `tsc`'s `checkAwaitExpression` gates TS1308 on the parser's
+    /// `NodeFlags.AwaitContext`, and `parseType` runs under
+    /// `doOutsideOfContext(TypeExcludesFlags)` — which clears `AwaitContext`
+    /// for the whole type. So an `await` inside a type literal never inherits
+    /// the enclosing function's `async`-ness, no matter how the literal is
+    /// reached (type-alias body, a variable/parameter annotation, or nested
+    /// inside an `interface` member's type).
+    ///
+    /// This is a strictly weaker forcing than
+    /// `check_await_expression_in_own_container`: clearing `AwaitContext` does
+    /// not change `isInTopLevelContext`, so a type literal at the source
+    /// file's own top level still answers the TS1375/TS1378 pair rather than
+    /// TS1308 — verified against `tsc@7.0.2`.
+    ///
+    /// An `interface` member's computed name is deliberately *not* routed
+    /// here: `parseInterfaceDeclaration` reaches its members through
+    /// `parseObjectTypeMembers` directly rather than through `parseType`, so
+    /// it keeps the enclosing await context.
+    fn check_await_expression_outside_await_context(&mut self, expr_idx: NodeIndex) {
+        self.check_await_expression_in_container(expr_idx, AwaitContainerKind::OutsideAwaitContext);
+    }
+
+    /// Root the `await`-grammar walk on a computed property name's expression,
+    /// picking the await context its owning member implies.
+    ///
+    /// A **type literal** member's name is parsed outside await context (see
+    /// `check_await_expression_outside_await_context`); a class member, an
+    /// interface member and an object-literal property all inherit the
+    /// enclosing one. The member declaration sits between the name and its
+    /// owner (`ComputedPropertyName` -> `PropertySignature`/`MethodSignature`/
+    /// accessor -> `TypeLiteral`), so this reads exactly two levels up —
+    /// keyed on the owner rather than on the caller, so every way of reaching
+    /// a type literal answers the same way.
+    pub(crate) fn check_computed_property_name_await(
+        &mut self,
+        name_idx: NodeIndex,
+        expr_idx: NodeIndex,
+    ) {
+        let owner_is_type_literal = self
+            .ctx
+            .arena
+            .get_extended(name_idx)
+            .and_then(|name_ext| self.ctx.arena.get_extended(name_ext.parent))
+            .and_then(|member_ext| self.ctx.arena.get(member_ext.parent))
+            .is_some_and(|node| node.kind == syntax_kind_ext::TYPE_LITERAL);
+
+        if owner_is_type_literal {
+            self.check_await_expression_outside_await_context(expr_idx);
+        } else {
+            self.check_await_expression(expr_idx);
+        }
     }
 
     /// Root the `await`-grammar walk on an expression that sits inside a
@@ -592,10 +685,14 @@ impl<'a> CheckerState<'a> {
     /// never leaks into a nested function body inside the initializer
     /// (`enum E { A = (() => 1)() }`).
     pub(crate) fn check_await_expression_in_own_container(&mut self, expr_idx: NodeIndex) {
-        self.check_await_expression_in_container(expr_idx, /* own_container */ true);
+        self.check_await_expression_in_container(expr_idx, AwaitContainerKind::OwnContainer);
     }
 
-    fn check_await_expression_in_container(&mut self, expr_idx: NodeIndex, own_container: bool) {
+    fn check_await_expression_in_container(
+        &mut self,
+        expr_idx: NodeIndex,
+        container: AwaitContainerKind,
+    ) {
         // Use iterative approach with explicit stack to handle deeply nested expressions.
         // This prevents stack overflow for expressions like `0 + 0 + 0 + ... + 0` (50K+ deep).
         let mut stack = vec![expr_idx];
@@ -617,7 +714,8 @@ impl<'a> CheckerState<'a> {
                     // An own-container position never inherits the enclosing
                     // function's async-ness (see
                     // `check_await_expression_in_own_container`).
-                    let in_async_context = !own_container && self.ctx.in_async_context();
+                    let in_async_context =
+                        container.inherits_async_context() && self.ctx.in_async_context();
                     if !in_async_context && !self.ctx.has_syntax_parse_errors {
                         use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
 
@@ -631,7 +729,7 @@ impl<'a> CheckerState<'a> {
                         // An own-container position is likewise never the source
                         // file's own top level, so it answers TS1308 rather than
                         // the TS1375/TS1378 top-level pair.
-                        let at_top_level = !own_container
+                        let at_top_level = container.allows_top_level_await()
                             && self.is_directly_at_source_file_top_level(current_idx);
 
                         if at_top_level {


### PR DESCRIPTION
Closes #16103.

**Structural rule.** When an `await` sits in the computed member name of a **type literal**, `tsc` treats it as outside await context, so an enclosing `async` function does not make it legal; tsz now does the same through the checker's await-grammar container funnel.

`tsc` gates TS1308 on the parser flag `NodeFlags.AwaitContext`, and `parseType` runs under `doOutsideOfContext(TypeExcludesFlags)` — which clears that flag for the whole type. `parseInterfaceDeclaration` reaches its members through `parseObjectTypeMembers` rather than `parseType`, so an interface member's computed name *keeps* the flag. That asymmetry is the entire rule, and it is why the sibling positions disagree:

```ts
declare const key: string;
async function w() { class Bag { [await key]() { } } }         // tsc: clean            (inherits async)
async function w() { interface Shape { [await key]: number } } // tsc: TS1169 only      (inherits async)
async function w() { type S = { [await key]: number }; }       // tsc: TS1170 + TS1308  (does NOT inherit)
```

#16099 gave every computed-name position the inherited-async rule — correct for class members (its own witness) and for interface members, wrong for type literals. The result was a **missing** diagnostic: tsz was silently more permissive than tsc, the loss direction no gate we run can see.

**Owner layer.** `check_await_expression_in_container` already modelled one special position (the enum-member initializer, #16098) with an `own_container: bool`. That flag conflated tsc's two independent axes — await context (`NodeFlags.AwaitContext`) and top-level context (`isInTopLevelContext`) — because the enum case happens to suppress both. A type literal suppresses only the first: clearing await context does not change top-level eligibility, so a type literal at the source file's own top level must still answer the TS1375/TS1378 pair. Replaced the boolean with `AwaitContainerKind` (`Inherited` / `OutsideAwaitContext` / `OwnContainer`), which asks the two axes separately. This is Schist's two-axis standing check from #16106 applied as a type rather than restated as a comment.

Routing is keyed **structurally on the owning member's parent being a `TypeLiteral`**, not on the calling arm — so every way of reaching a type literal answers identically. That is what makes rows 2–4 below pass without separate handling.

## Before / after

Measured on the same test binary, oracle column from a live `tsc@7.0.2 --noEmit --pretty false --target es2017 --module commonjs` run made for this change:

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| type alias literal, in `async` fn | `[1170, 1308]` | `[1170]` ❌ | `[1170, 1308]` ✅ |
| literal in an `interface` member's type, in `async` fn | `[1170, 1308]` | `[1170]` ❌ | `[1170, 1308]` ✅ |
| literal in a variable annotation, in `async` fn | `[1170, 1308]` | `[1170]` ❌ | `[1170, 1308]` ✅ |
| nested literal in a type alias, in `async` fn | `[1170, 1308]` | `[1170]` ❌ | `[1170, 1308]` ✅ |
| literal method signature, in `async` fn | `[1170, 1308]` | `[1170]` ❌ | `[1170, 1308]` ✅ |
| literal in a parameter annotation, in `async` fn | `[1170, 1308]` | `[1170, 1308]` ✅ | unmoved |
| **type literal at script top level** | `[1170, 1375, 1378]` | `[1170, 1375, 1378]` ✅ | **unmoved** |
| `interface` member, in `async` fn | `[1169]` | `[1169]` ✅ | unmoved |
| class member, in `async` fn | `[]` | `[]` ✅ | unmoved |
| **object literal, in `async` fn** | `[]` | `[]` ✅ | **unmoved** |
| class member at script top level | `[1375, 1378]` | `[1375, 1378]` ✅ | unmoved |

The two bolded rows are the ones that fail a plausible-but-wrong fix. The script-top-level row (Schist's standing control from #16106) is only reachable if the fix actually routes to the top-level branch — a fix that force-reported TS1308 for type literals would match every positive row and break exactly this one. The object-literal row breaks any fix keyed on "computed name in a braced member list" instead of on the type literal.

Also corrects `async_wrapper_type_literal_computed_name_reports_only_ts1170`, added in #16099 by analogy with its class/interface siblings and never oracle-checked — it asserted `[1170]`, i.e. it pinned the defect. #16103 named this test specifically.

## Goal
Goal: hold

## Verification
- `cargo fmt --all`, `cargo clippy -p tsz-checker --all-targets -- -D warnings`: clean.
- Pre-commit hook (fmt + clippy + arch-guard): passed. The helper landed in `core_statement_checks.rs` next to the await machinery rather than in `property_checker.rs`, which the arch guard flagged at 2016 lines against its 2000 limit — both files are now under it (1981 / 1386), no allowlist added.
- `cargo test -p tsz-checker --lib await_grammar_computed_property_name_tests`: **33 passed, 0 failed** (7 new cases + 1 corrected assertion).
- Adjacent suites, one run: `await_ computed_property type_literal ts1170 ts1169 ts1166 ts2464 interface_ enum_ top_level` → **910 passed, 0 failed, 1 ignored**.
- `scripts/conformance/compare-to-parent.sh` (two-sided vs this branch's own parent): result appended as a comment below — it was still running at PR-open time and I did not idle-wait on it.
- Oracle: every expectation pinned against a live `tsc@7.0.2` run, including the `--target esnext --module esnext` module-top-level row (`[1170]`, no TS1308) which confirms the top-level branch is still reachable but is not expressible in the script-only unit harness.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Dolerite

---
_Generated by [Claude Code](https://claude.ai/code/session_01JfJNudfeNGq1ULh9mB7kyW)_