### PR TITLE
test(cli): fix wrong precondition in branch_filter cache-agreement test

### DIFF
--- a/crates/tsz-cli/tests/evaluator_cache_agreement_tests.rs
+++ b/crates/tsz-cli/tests/evaluator_cache_agreement_tests.rs
@@ -138,17 +138,44 @@ fn assert_cache_modes_agree(
     tsconfig: &str,
     disabled_switches: &[&str],
 ) {
+    assert_cache_modes_agree_impl(name, files, tsconfig, disabled_switches, true);
+}
+
+/// Like `assert_cache_modes_agree`, but does not require the baseline run to
+/// compile cleanly first. Agreement between cache modes is the only thing
+/// under test here; a fixture that legitimately reports diagnostics under
+/// every cache configuration still proves the caches agree.
+fn assert_cache_modes_agree_regardless_of_diagnostics(
+    name: &str,
+    files: &[(&str, &str)],
+    tsconfig: &str,
+    disabled_switches: &[&str],
+) {
+    assert_cache_modes_agree_impl(name, files, tsconfig, disabled_switches, false);
+}
+
+fn assert_cache_modes_agree_impl(
+    name: &str,
+    files: &[(&str, &str)],
+    tsconfig: &str,
+    disabled_switches: &[&str],
+    require_clean: bool,
+) {
     let Some(tsz_bin) = find_tsz_binary() else {
         println!("skipping evaluator cache agreement test: tsz binary not found");
         return;
     };
     let temp = stage_project(name, files, tsconfig);
     let baseline = run_tsz(&tsz_bin, &temp.path, None);
-    assert_clean_success(name, &baseline);
+    if require_clean {
+        assert_clean_success(name, &baseline);
+    }
 
     for switch in disabled_switches {
         let disabled = run_tsz(&tsz_bin, &temp.path, Some(switch));
-        assert_clean_success(name, &disabled);
+        if require_clean {
+            assert_clean_success(name, &disabled);
+        }
         assert_eq!(disabled, baseline, "{name} output changed when {switch}=1");
     }
 }
@@ -172,7 +199,12 @@ fn branch_filter_agrees_with_conditional_branch_cache_disabled() {
     // Structural rule: a repeated conditional branch verdict for the same
     // structural `(check, extends)` pair may be reused, but disabling that reuse
     // must still select the same true/false branches.
-    assert_cache_modes_agree(
+    //
+    // The fixture's two `Assert<Equal<...>>` checks genuinely evaluate to
+    // `false` under a live `tsc@7.0.2` oracle (confirmed #15983), so the
+    // baseline run was never clean; requiring exit 0 here tested a
+    // precondition that could never hold, not cache agreement.
+    assert_cache_modes_agree_regardless_of_diagnostics(
         "branch_filters",
         BRANCH_FILTERS_FILES,
         BRANCH_FILTERS_TSCONFIG,

--- a/scripts/ci/known-failures.txt
+++ b/scripts/ci/known-failures.txt
@@ -130,5 +130,4 @@ tsz-cli::driver::core::check::check_tests::cross_file_class_namespace_merge_valu
 tsz-cli::driver::core::check::check_tests::default_lib_validation_normalizes_cross_arena_method_members_after_global_merge
 tsz-cli::driver_tests::cross_file_dependent_operand_aliases_accept_scalars_and_literal_arrays
 tsz-cli::driver_tests::declaration_emit_reports_ts7056_for_private_import_type_alias
-tsz-cli::evaluator_cache_agreement_tests::branch_filter_agrees_with_conditional_branch_cache_disabled
 tsz-emitter::declaration_emitter::tests::simple_declarations::test_overloaded_call_initializer_does_not_use_first_signature_return_type


### PR DESCRIPTION
Closes one row of #15983's nine-test batch.

**Structural rule.** `evaluator_cache_agreement_tests` exists to prove that cache-enabled and cache-disabled `tsz` runs agree — "the caches may reduce repeated work, not change the result" (file header, #14351). It does not exist to prove a fixture compiles cleanly. `branch_filter_agrees_with_conditional_branch_cache_disabled`'s fixture has two `Assert[Equal[...]]`-shaped type-level checks (the `_paths` and `_values` type aliases) that genuinely evaluate to `false` under a live `tsc@7.0.2` oracle (`--noEmit --strict --pretty false`, matching the fixture's own `tsconfig.json`):

```
src/index.ts(55,22): error TS2344: Type 'false' does not satisfy the constraint 'true'.
src/index.ts(59,23): error TS2344: Type 'false' does not satisfy the constraint 'true'.
```

So the baseline run's exit code was never `0`, independent of any cache setting — `assert_clean_success` tested a precondition that could never hold. The thing actually under test already passes: `tsz` and `TSZ_DISABLE_CONDITIONAL_BRANCH_CACHE=1 tsz` produce byte-identical stdout/stderr/exit-code on this fixture. This diagnosis and fix direction were fully characterized on #15983 by a prior session (comment at 2026-08-01T04:48:52Z) before I picked up the row.

**Owner layer.** Test-only; no product code touched. `assert_cache_modes_agree_impl` now takes a `require_clean: bool` so the two genuinely-clean fixtures (`validator_keys`, `recursive_iteration`) keep their existing clean-compile assertion, and `branch_filters` compares the two cache-mode runs to each other without requiring a clean exit first.

Two real parity gaps sit underneath the fixture's failing assertions (a missing `TS2344` at line 55, and an unevaluated `Equal[...]` type rendered in the line-59 diagnostic instead of tsc's evaluated `false`) — both already documented on #15983 as part of the broader "materialize-or-defer" family (#15396) shared with 3 other rows in the same batch; out of scope for this test-infrastructure fix.

## Goal
Goal: hold

## Verification
- `cargo fmt --all`: clean.
- `cargo clippy -p tsz-cli --all-targets -- -D warnings`: clean (also ran via the pre-commit hook).
- `CARGO_PROFILE_DEV_DEBUG=0 CARGO_BIN_EXE_tsz=$(pwd)/.target/debug/tsz cargo nextest run -p tsz-cli --test evaluator_cache_agreement_tests`: before → 2 passed, 1 failed (`branch_filter_agrees_with_conditional_branch_cache_disabled`); after → **3 passed, 0 failed**.
- Removed the now-passing row from `scripts/ci/known-failures.txt` (131 → 130 baselined rows).
- Pre-commit hook (fmt + clippy + arch-guard): passed.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: Peridotite
