### PR TITLE
ci(conformance): catch a dropped-passing-test as well as a dropped-failure

### DIFF
--- a/.github/workflows/conformance-snapshot-refresh.yml
+++ b/.github/workflows/conformance-snapshot-refresh.yml
@@ -86,6 +86,28 @@ jobs:
               )
               sys.exit(1)
           print(f"Accounting OK: {failed} failed == {recorded} detail entries.")
+
+          # The check above only catches a dropped result that still shows up
+          # as a *failure* miscount. A test that hangs/crashes and is dropped
+          # from BOTH the passing set and the failures dict shifts
+          # summary.runnable down without disturbing failed == recorded at
+          # all, so it needs its own witness: conformance-baseline.txt carries
+          # one PASS/FAIL line per runnable test, independent of how
+          # conformance-detail.json tallies failures.
+          runnable = snapshot["summary"]["runnable"]
+          with open("scripts/conformance/conformance-baseline.txt") as f:
+              baseline_lines = sum(1 for _ in f)
+          if baseline_lines != runnable:
+              print(
+                  f"::error::accounting mismatch: summary.runnable={runnable} "
+                  f"but conformance-baseline.txt has {baseline_lines} lines. "
+                  "A per-test result was likely dropped (hang or crash) "
+                  "during this run rather than a genuine pass/fail change. "
+                  "Refusing to open/update the refresh PR with a snapshot "
+                  "that does not account for every runnable test."
+              )
+              sys.exit(1)
+          print(f"Accounting OK: {runnable} runnable == {baseline_lines} baseline lines.")
           PY
 
       - name: Detect changes


### PR DESCRIPTION
The snapshot-refresh integrity check added for #16086 (`conformance-snapshot-refresh.yml`'s "Verify snapshot accounting integrity" step) verifies `summary.failed == len(conformance-detail.json's failures dict)`. That catches a per-test result dropped from the *failing* side (a hang/crash that still gets tallied into `summary.failed` but never recorded in the `failures` dict).

It misses the symmetric case: a test dropped from **both** the passing and failing tallies. If a hang/crash causes a test to vanish from the run entirely, `summary.runnable` shrinks by one, but `summary.failed` and the `failures` dict count stay mutually consistent with each other — the existing check sees nothing wrong, and a snapshot that silently accounts for one fewer test than it should gets committed as tomorrow's "truth" (the exact failure mode #16086/#16081 were about, just on the passing side instead of the failing side).

`conformance-baseline.txt` carries one `PASS`/`FAIL` line per runnable test, independent of how `conformance-detail.json` tallies failures — 601 `FAIL` + 11442 `PASS` = 12043 lines on the currently committed snapshot, matching `summary.runnable` exactly. Comparing its line count against `summary.runnable` is a second, independent witness that closes this gap the same way the existing check closes the failure-side one.

## Goal
Goal: hold

## Verification
- YAML syntax: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/conformance-snapshot-refresh.yml'))"` — clean.
- Logic sanity-checked against the currently committed snapshot files (`conformance-snapshot.json`, `conformance-detail.json`, `conformance-baseline.txt`) by running the check's Python inline: `failed=601 == recorded=601` and `runnable=12043 == baseline_lines=12043`, both `True` — the new check does not false-positive against today's clean snapshot.
- This is a workflow-only change (no Rust source touched), so `cargo fmt`/`clippy`/`arch-size`/conformance/emit/fourslash suites are not applicable; the pre-commit hook ran and found no staged Rust files.
- Not exercisable end-to-end without triggering the actual scheduled/`workflow_dispatch` job (which does a full corpus run); the new step only runs inside that job.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_01XXmL71hcKE6m3P5Eo6pDAg)_