### PR TITLE
fix(solver): cache local depth-exceeded instantiation walks project-wide

### DIFF
--- a/crates/tsz-solver/src/caches/instantiation_cache_test.rs
+++ b/crates/tsz-solver/src/caches/instantiation_cache_test.rs
@@ -12,7 +12,13 @@
 //!    cached — they remain allocation-free.
 //! 4. The empty / concrete-identity short-circuit runs BEFORE cache-key
 //!    construction, leaving the cache untouched on no-op substitutions.
-//! 5. Results from a `depth_exceeded` walk are NOT cached.
+//! 5. A `depth_exceeded` walk's result is never cached in the PER-FILE
+//!    `InstantiationCache` (`query_db=Some`'s own gate reads the raw
+//!    termination flag). The PROJECT-WIDE proto cache is more precise: a
+//!    depth-exceeded verdict from the per-walk local depth cap (which always
+//!    starts fresh at 0, so it is a pure function of the request) IS cached
+//!    there; only a bail through the ambient cross-operation solver-frame
+//!    budget is excluded (see `InstantiationResult::is_ambient_limited`).
 //! 6. Semantically equal substitutions hit the same cache slot even if their
 //!    `FxHashMap` insertion order differs.
 //!
@@ -566,11 +572,16 @@ fn mode_bits_isolate_preserving_from_default() {
 }
 
 #[test]
-fn depth_exceeded_result_is_not_cached() {
+fn depth_exceeded_result_is_not_cached_per_file_but_short_circuits_project_wide() {
     // A depth-overflow walk returns a relation-preserving partial type (no
-    // longer the `TypeId::ERROR` sentinel; see #13652), but that recovery
-    // value must not poison the cross-call cache. Repeating the same request
-    // should miss again and recompute instead of hitting a cached result.
+    // longer the `TypeId::ERROR` sentinel; see #13652). The PER-FILE
+    // `InstantiationCache` never stores it (`query_db=Some`'s own gate reads
+    // the raw `depth_exceeded()` termination flag, unconditionally). But the
+    // walk's local depth cap always starts fresh at 0 per instance, so its
+    // depth-exceeded verdict is a pure function of `(type_id, subst,
+    // mode_bits, this_type)` and IS stored in the project-wide proto cache
+    // (#14345) — so the second call short-circuits there, before ever
+    // reaching (and re-missing) the per-file cache the first call probed.
     let interner = TypeInterner::new();
     let db = QueryCache::new(&interner);
 
@@ -591,23 +602,27 @@ fn depth_exceeded_result_is_not_cached() {
     let r1 = instantiate_type_cached(&interner, Some(&db), body, &subst);
     let r2 = instantiate_type_cached(&interner, Some(&db), body, &subst);
 
-    // The bail no longer surfaces the ERROR sentinel.
+    // The bail no longer surfaces the ERROR sentinel, and repeating the
+    // request is deterministic.
     assert_ne!(r1, TypeId::ERROR);
     assert_eq!(r1, r2);
 
     let stats1 = db.statistics();
     assert_eq!(
         stats1.instantiation_cache_entries, stats0.instantiation_cache_entries,
-        "depth-overflow results must not populate the instantiation cache"
+        "depth-overflow results must not populate the PER-FILE instantiation cache"
     );
     assert_eq!(
         stats1.instantiation_cache_hits, stats0.instantiation_cache_hits,
-        "a repeated depth-overflow request must not hit a cached ERROR"
+        "the second request never reaches the per-file cache to hit it — \
+         it short-circuits at the project-wide proto cache first"
     );
     assert_eq!(
         stats1.instantiation_cache_misses,
-        stats0.instantiation_cache_misses + 2,
-        "both depth-overflow requests should probe and miss independently"
+        stats0.instantiation_cache_misses + 1,
+        "only the FIRST depth-overflow request probes and misses the \
+         per-file cache; the second is served by the project-wide proto \
+         cache before the per-file cache is ever consulted"
     );
 }
 
@@ -867,14 +882,22 @@ fn clean_instantiation_is_cached_project_wide() {
     );
 }
 
-/// #14345 limit gate: a depth-exceeded walk produces a bounded result that must
-/// NOT enter the project-wide cache — a later hit would lock the alias to the
-/// truncated value (the construction-layer analog of
-/// `instantiate_generic_cached_depth_overflow_not_cached`'s per-file guard).
-/// This exercises the `result.depth_exceeded()` arm of the store-gate through a
-/// real walk (the recursion-limit analog of `closed_eval`'s `recursion_limit_hit`).
+/// #14345 limit gate (refined): a depth-exceeded walk from the per-instance
+/// LOCAL depth cap DOES enter the project-wide cache. That cap always starts
+/// fresh at 0 for every `TypeInstantiator` (`run_instantiator` builds a new
+/// one per call), so its verdict is a pure, reproducible function of
+/// `(type_id, subst, mode_bits, this_type)` alone — caching it is sound, and
+/// necessary: without it, a self-referential/deeply-nested shape (e.g. DOM
+/// lib interfaces, #16089) that legitimately overflows the walk on every
+/// request recomputes the same bounded-but-expensive walk from scratch every
+/// single time, since a truncated result was never memoized to short-circuit
+/// the repeat. Only a bail through the AMBIENT cross-operation solver-frame
+/// budget stays excluded (`InstantiationResult::is_ambient_limited`), because
+/// that budget is shared state that can make the identical request bail or
+/// succeed depending on unrelated concurrent recursion — see the unit tests
+/// on `InstantiationMemoStability` in `instantiation::result` for that half.
 #[test]
-fn depth_exceeded_instantiation_not_cached_project_wide() {
+fn locally_depth_exceeded_instantiation_is_cached_project_wide() {
     let interner = TypeInterner::new();
     let db = QueryCache::new(&interner);
 
@@ -887,16 +910,19 @@ fn depth_exceeded_instantiation_not_cached_project_wide() {
     }
     let key = proto_key_for(&interner, body, &param, TypeId::STRING);
 
-    let _ = instantiate_generic_cached(
+    let r = instantiate_generic_cached(
         &interner,
         Some(&db),
         body,
         std::slice::from_ref(&param),
         &[TypeId::STRING],
     );
-    assert!(
-        interner.proto_instantiation_memo(&key).is_none(),
-        "a depth-exceeded instantiation must not be stored project-wide"
+    assert_eq!(
+        interner.proto_instantiation_memo(&key),
+        Some(r),
+        "a purely-local depth-exceeded instantiation is a pure function of \
+         the request and must be stored project-wide so a repeat short-\
+         circuits instead of re-walking the same bounded-but-expensive shape"
     );
 }
 
@@ -935,12 +961,15 @@ fn pre_existing_limit_flag_does_not_block_clean_instantiation() {
 }
 
 #[test]
-fn instantiate_generic_cached_depth_overflow_not_cached() {
+fn instantiate_generic_cached_depth_overflow_short_circuits_project_wide_on_repeat() {
     // A depth-overflow walk returns a relation-preserving partial type (no
-    // longer the `TypeId::ERROR` sentinel; see #13652) but must not poison the
-    // cache: re-requesting the same (body, args) must miss again. Otherwise a
-    // single spurious overflow would lock the alias to that value for the
-    // lifetime of the QueryCache.
+    // longer the `TypeId::ERROR` sentinel; see #13652). The PER-FILE
+    // `InstantiationCache` never stores it, matching
+    // `depth_exceeded_result_is_not_cached_per_file_but_short_circuits_project_wide`
+    // above. But the local depth cap's verdict is a pure function of the
+    // request (see `locally_depth_exceeded_instantiation_is_cached_project_wide`),
+    // so the second identical request is served by the project-wide proto
+    // cache and never reaches (or re-misses) the per-file cache at all.
     let interner = TypeInterner::new();
     let db = QueryCache::new(&interner);
 
@@ -964,16 +993,19 @@ fn instantiate_generic_cached_depth_overflow_not_cached() {
     let stats1 = db.statistics();
     assert_eq!(
         stats1.instantiation_cache_entries, stats0.instantiation_cache_entries,
-        "depth-overflow results must not populate the cache"
+        "depth-overflow results must not populate the PER-FILE cache"
     );
     assert_eq!(
         stats1.instantiation_cache_hits, stats0.instantiation_cache_hits,
-        "a repeated depth-overflow request must not hit a cached ERROR"
+        "the second request never reaches the per-file cache to hit it — \
+         it short-circuits at the project-wide proto cache first"
     );
     assert_eq!(
         stats1.instantiation_cache_misses,
-        stats0.instantiation_cache_misses + 2,
-        "both depth-overflow requests should probe and miss independently"
+        stats0.instantiation_cache_misses + 1,
+        "only the FIRST depth-overflow request probes and misses the \
+         per-file cache; the second is served by the project-wide proto \
+         cache before the per-file cache is ever consulted"
     );
 }
 

--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -181,6 +181,20 @@ pub struct TypeInstantiator<'a> {
     /// inference variable (`__infer_*`). The substitution is immutable for the
     /// lifetime of the instantiator, so this is computed once at construction.
     substitution_is_inference_only: bool,
+    /// Set when this walk ever bailed through the SHARED cross-operation
+    /// solver-frame budget (see [`crate::recursion::with_solver_frame`]),
+    /// as opposed to this instance's own local `walk_state` depth cap.
+    ///
+    /// The distinction matters for the project-wide instantiation cache
+    /// (#14345): the local depth cap is a per-instance counter that always
+    /// starts at 0 (`InstantiationWalkState::new`), so a local depth-exceeded
+    /// verdict is a pure, reproducible function of this request's
+    /// `(type_id, this_type, subst, options)` and is safe to memoize. The
+    /// shared frame budget is ambient state shared with every other
+    /// concurrently-nested solver operation, so the SAME request could
+    /// legitimately succeed or bail depending on unrelated call-stack depth
+    /// at the time it runs — memoizing that verdict would be unsound.
+    ambient_frame_exhausted: bool,
 }
 
 impl<'a> TypeInstantiator<'a> {
@@ -209,6 +223,7 @@ impl<'a> TypeInstantiator<'a> {
             shallow_this_only: false,
             walk_state: InstantiationWalkState::new(MAX_INSTANTIATION_DEPTH),
             substitution_is_inference_only,
+            ambient_frame_exhausted: false,
         }
     }
 
@@ -279,6 +294,15 @@ impl<'a> TypeInstantiator<'a> {
 
     pub(crate) const fn has_depth_exceeded(&self) -> bool {
         self.walk_state.has_depth_exceeded()
+    }
+
+    /// Whether this walk ever bailed through the SHARED cross-operation
+    /// solver-frame budget rather than only its own local depth cap. See the
+    /// field doc on [`Self::ambient_frame_exhausted`] for why the project-wide
+    /// instantiation cache must gate on this instead of on
+    /// [`Self::has_depth_exceeded`] alone.
+    pub(crate) const fn ambient_frame_exhausted(&self) -> bool {
+        self.ambient_frame_exhausted
     }
 
     pub(crate) const fn termination(&self) -> InstantiationTermination {
@@ -756,6 +780,7 @@ impl<'a> TypeInstantiator<'a> {
         .unwrap_or_else(|| {
             self.walk_state.leave_frame();
             self.mark_depth_exceeded();
+            self.ambient_frame_exhausted = true;
             self.bail_value(type_id)
         })
     }

--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -997,7 +997,11 @@ fn run_instantiator(
     instantiator.shallow_this_only = options.shallow_this_only();
     instantiator.this_type = request.this_type();
     let result = instantiator.instantiate(request.type_id());
-    InstantiationResult::from_walk(result, instantiator.termination())
+    InstantiationResult::from_walk_with_ambient_limit(
+        result,
+        instantiator.termination(),
+        instantiator.ambient_frame_exhausted(),
+    )
 }
 
 /// Convenience function for instantiating a type with a substitution.

--- a/crates/tsz-solver/src/instantiation/result.rs
+++ b/crates/tsz-solver/src/instantiation/result.rs
@@ -42,6 +42,17 @@ impl InstantiationTermination {
 pub struct InstantiationResult {
     type_id: TypeId,
     termination: InstantiationTermination,
+    /// Set when `termination` is `DepthExceeded` *because* the walk bailed
+    /// through the shared cross-operation solver-frame budget rather than
+    /// only its own local depth cap. See
+    /// `TypeInstantiator::ambient_frame_exhausted` for why the project-wide
+    /// instantiation cache must gate on this narrower signal instead of on
+    /// `depth_exceeded()` alone: the local cap always starts at 0 per walk,
+    /// so a local-only depth-exceeded verdict is a pure, reproducible
+    /// function of the request and safe to memoize, while the shared budget
+    /// is ambient state that can make the same request bail or succeed
+    /// depending on unrelated concurrent recursion.
+    ambient_limited: bool,
 }
 
 /// Instantiation result plus the verdict for project-wide cache publication.
@@ -66,8 +77,15 @@ pub(crate) enum InstantiationMemoStability {
 }
 
 impl InstantiationMemoStability {
+    /// A local depth-exceeded verdict (the per-walk cap, always starting
+    /// fresh at depth 0) is a pure function of the request and stays
+    /// eligible for the project-wide cache; only an ambient-budget bail
+    /// (`InstantiationResult::is_ambient_limited`) or tainted surrounding
+    /// request state makes a result unsafe to memoize. See the field docs on
+    /// `InstantiationResult::ambient_limited` and
+    /// `TypeInstantiator::ambient_frame_exhausted` for the full rationale.
     const fn from_result(result: InstantiationResult, request_state_stable: bool) -> Self {
-        if result.depth_exceeded() || !request_state_stable {
+        if result.is_ambient_limited() || !request_state_stable {
             Self::Unstable
         } else {
             Self::Stable
@@ -85,6 +103,7 @@ impl InstantiationResult {
         Self {
             type_id,
             termination: InstantiationTermination::Complete,
+            ambient_limited: false,
         }
     }
 
@@ -112,6 +131,7 @@ impl InstantiationResult {
         Self {
             type_id,
             termination: InstantiationTermination::DepthExceeded,
+            ambient_limited: false,
         }
     }
 
@@ -124,12 +144,37 @@ impl InstantiationResult {
         }
     }
 
+    /// Construct from a walk's partial type, termination verdict, and whether
+    /// the walk ever bailed through the shared cross-operation solver-frame
+    /// budget (see the `ambient_limited` field doc). Callers that feed the
+    /// project-wide instantiation cache must use this over
+    /// [`Self::from_walk`] so a purely-local depth-exceeded verdict — which
+    /// always starts fresh at depth 0 per walk and is a pure function of the
+    /// request — stays eligible for memoization, while an ambient-budget bail
+    /// does not.
+    pub(crate) const fn from_walk_with_ambient_limit(
+        type_id: TypeId,
+        termination: InstantiationTermination,
+        ambient_frame_exhausted: bool,
+    ) -> Self {
+        let mut result = Self::from_walk(type_id, termination);
+        result.ambient_limited = ambient_frame_exhausted;
+        result
+    }
+
     pub const fn type_id(self) -> TypeId {
         self.type_id
     }
 
     pub const fn depth_exceeded(self) -> bool {
         self.termination.depth_exceeded()
+    }
+
+    /// Whether this result is unsafe to memoize in the project-wide
+    /// instantiation cache: it hit the shared cross-operation solver-frame
+    /// budget rather than only its own local, request-pure depth cap.
+    pub(crate) const fn is_ambient_limited(self) -> bool {
+        self.ambient_limited
     }
 
     pub const fn termination(self) -> InstantiationTermination {
@@ -264,15 +309,39 @@ mod tests {
             TypeId::NUMBER
         );
 
-        let overflowed = InstantiationMemoResult::for_project_cache(
+        // A plain (local-only) depth-exceeded result is a pure function of
+        // the request — the walk-local depth cap always starts fresh at 0
+        // (see `TypeInstantiator::ambient_frame_exhausted`'s doc) — so with
+        // clean surrounding request state it stays eligible for the
+        // project-wide cache instead of being treated as unstable.
+        let locally_overflowed = InstantiationMemoResult::for_project_cache(
             InstantiationResult::overflow_with(TypeId::BOOLEAN),
             true,
         );
         assert_eq!(
-            overflowed.cache_stability,
+            locally_overflowed.cache_stability,
+            InstantiationMemoStability::Stable
+        );
+        assert!(locally_overflowed.is_stable_for_project_cache());
+        assert_eq!(locally_overflowed.into_result().type_id(), TypeId::BOOLEAN);
+
+        // A depth-exceeded result that bailed through the SHARED
+        // cross-operation solver-frame budget is ambient state, not a pure
+        // function of the request, so it must stay unstable even with clean
+        // request state.
+        let ambient_overflowed = InstantiationMemoResult::for_project_cache(
+            InstantiationResult::from_walk_with_ambient_limit(
+                TypeId::BOOLEAN,
+                InstantiationTermination::DepthExceeded,
+                true,
+            ),
+            true,
+        );
+        assert_eq!(
+            ambient_overflowed.cache_stability,
             InstantiationMemoStability::Unstable
         );
-        assert!(!overflowed.is_stable_for_project_cache());
-        assert_eq!(overflowed.into_result().type_id(), TypeId::BOOLEAN);
+        assert!(!ambient_overflowed.is_stable_for_project_cache());
+        assert_eq!(ambient_overflowed.into_result().type_id(), TypeId::BOOLEAN);
     }
 }


### PR DESCRIPTION
When a `this`-substitution walk over a self-referential/very-wide shape (DOM lib interfaces like `Window`) legitimately overflows the instantiator's per-instance depth cap, `tsc` still finishes the equivalent check in ~1s while tsz repeatedly redoes the exact same bounded-but-expensive walk from scratch (#16089). Six prior sessions (see #16089's thread) traced this to `run_instantiator`'s cost without finding a landable fix; this PR closes one concrete slice of it.

## Structural rule

**When a `TypeInstantiator` walk bails because its own per-instance local depth cap (`InstantiationWalkState`, always fresh at depth 0 per `run_instantiator` call — a pure, reproducible function of `(type_id, subst, mode_bits, this_type)`) is exceeded, tsz now caches that result in the project-wide instantiation cache (#14345) through the shared `query_boundaries`-adjacent solver instantiation layer — the same layer that already caches clean results.** Only a bail through the *ambient* cross-operation solver-frame budget (`crate::recursion::with_solver_frame`, #7574 — genuinely shared, mutable state that can make the identical request bail or succeed depending on unrelated concurrent recursion) stays excluded from caching, exactly as before.

The old code conflated both bail causes under one `result.depth_exceeded()` flag and refused to cache either. `TypeInstantiator` now tracks `ambient_frame_exhausted` separately from its (still sticky, unchanged) local depth flag, threaded through a new `InstantiationResult::from_walk_with_ambient_limit` / `is_ambient_limited()` pair. `InstantiationMemoStability::from_result` gates caching on `is_ambient_limited()` instead of the broader `depth_exceeded()`. The per-file `InstantiationCache` (`query_db=Some`'s own gate in `instantiate_with_request_cached_inner`) is untouched and still never stores any depth-exceeded result — only the project-wide proto cache's gate changes.

## Evidence

Traced live with temporary `tracing::debug!` probes (removed before this diff) on #16089's minimal witness (`interface W2 extends Window {} declare var w: W2; var r: Window = w;`), `dev` build:

- ~88% (1244/1414 sampled) of `substitute_this_type_cached` calls hit `depth_exceeded`, **100% via the local cap** — 0 ambient/shared-frame-budget bails across 659k additional samples from a finer probe.
- The same `(type_id, this_type)` key was requested up to 338 times in one run, each time independently missing the project cache and re-running the full walk, despite the walk being fully deterministic (confirmed via a self-check: insert-then-immediate-lookup on the same key always hit — the cache mechanics themselves were never the bug, only the eligibility gate was too broad).
- After the fix: cache hit rate for that previously ~0%-hit population rose to **67%** in a bounded 30s sampling window on the same witness.
- The witness still does not complete in reasonable time even after this fix — there's a second, larger contributor (most likely: once a walk's sticky local-depth flag trips once, it poisons the *rest* of that same walk's sibling subtrees too, fanning out into a much larger population of genuinely-distinct substitution keys than a single deep chain would produce). Left as a NOTE on #16089 for a follow-up session; this PR is one bounded, verified slice, not a full fix for #16089.

### Adjacent cases

- Local depth-exceeded, clean request state → **now cached** (new behavior, this PR).
- Ambient/shared-frame-budget bail → **still not cached** (unchanged; covered by a new unit-test case).
- Clean (non-overflowing) result → unchanged, already cached.
- Sticky pre-existing limit flags (`tuple_too_large`/`union_too_complex`) on an unrelated sibling → unchanged, still doesn't block a clean result (`pre_existing_limit_flag_does_not_block_clean_instantiation`, untouched).
- Per-file `InstantiationCache` (`query_db=Some`) → unchanged, still never caches any depth-exceeded result regardless of cause.

## Goal
Goal: fast

## Verification
- `cargo fmt --all` and `cargo clippy -p tsz-solver --all-targets -- -D warnings`: clean (via the pre-commit hook — `Clippy passed. Architecture guard passed.`).
- `cargo test -p tsz-solver --lib`: **7619 passed, 0 failed** (full crate, includes the 4 updated tests below).
- `cargo test -p tsz-solver --lib instantiation_cache_wiring_tests`: **32 passed, 0 failed** — includes the 3 renamed/rewritten tests (`depth_exceeded_result_is_not_cached_per_file_but_short_circuits_project_wide`, `locally_depth_exceeded_instantiation_is_cached_project_wide`, `instantiate_generic_cached_depth_overflow_short_circuits_project_wide_on_repeat`) that previously encoded the old "depth-exceeded is never cached" invariant without the local/ambient split.
- `instantiation::result::tests::memo_result_requires_clean_instantiation_and_request_state`: updated to cover both a local-only bail (now stable) and an ambient-limited bail (still unstable) instead of asserting all depth-exceeded results are unstable.
- **Conformance/emit/fourslash were NOT run** — this container has no TypeScript submodule checked out (`compare-to-parent.sh` and that whole tier are unavailable here per the board's standing gotcha). This is a solver-internal caching-eligibility change only (it changes *when* a walk's result is memoized, never *what* the walk computes — same inputs always produce the same output whether served from cache or freshly walked), so risk to diagnostic output is low, but a warm seat should confirm with a two-sided `compare-to-parent.sh` before merge.
- `cargo test -p tsz-checker --lib` was started to check downstream consumers but did not finish compiling within this session's window (cold `tsz-checker` test-binary compile, consistent with the board's ~13min-cold-compile gotcha); will report back once it lands, or a later drain step should confirm.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_01YANCxVziazQBVVbfmFKiHA)_