### PR TITLE
fix(checker): a TypeLiteral member's computed name never inherits async context

### DIFF
--- a/crates/tsz-checker/src/checkers/property_checker.rs
+++ b/crates/tsz-checker/src/checkers/property_checker.rs
@@ -1050,15 +1050,29 @@ impl<'a> CheckerState<'a> {
 
     /// Check a computed property name for type errors (TS2464).
     ///
-    /// Validates that the expression used for a computed property name
-    /// has a type that is string, number, symbol, or any (including literals).
-    /// This check is independent of strictNullChecks. Also roots the
-    /// await-grammar walk (TS1308) — independent of TS1166/1169/1170's
-    /// literal-form check, so every caller runs this in full regardless of
-    /// whether that check already fired (`error_at_node` dedups by
-    /// `(start, code)`, so a position an existing root already reaches is
-    /// never double-reported).
+    /// Validates that the expression used for a computed property name has a
+    /// type that is string, number, symbol, or any (including literals).
+    /// Independent of strictNullChecks. Also roots the await-grammar walk
+    /// (TS1308) — independent of TS1166/1169/1170's literal-form check, so
+    /// every caller runs this in full regardless of whether that check
+    /// already fired (`error_at_node` dedups by `(start, code)`, so a
+    /// position an existing root already reaches is never double-reported).
     pub(crate) fn check_computed_property_name(&mut self, name_idx: NodeIndex) {
+        self.check_computed_property_name_impl(name_idx, /* type_literal_member */ false);
+    }
+
+    /// Same as `check_computed_property_name`, but for a `TypeLiteral`
+    /// member: its `await`-grammar walk does not inherit the enclosing
+    /// function's async-ness. See `check_await_expression_type_literal_member`.
+    pub(crate) fn check_computed_property_name_type_literal_member(&mut self, name_idx: NodeIndex) {
+        self.check_computed_property_name_impl(name_idx, /* type_literal_member */ true);
+    }
+
+    fn check_computed_property_name_impl(
+        &mut self,
+        name_idx: NodeIndex,
+        type_literal_member: bool,
+    ) {
         let Some(name_node) = self.ctx.arena.get(name_idx) else {
             return;
         };
@@ -1072,7 +1086,11 @@ impl<'a> CheckerState<'a> {
         };
 
         // TS1308: independent of TS1166/1169/1170 — see the doc comment above.
-        self.check_await_expression(computed.expression);
+        if type_literal_member {
+            self.check_await_expression_type_literal_member(computed.expression);
+        } else {
+            self.check_await_expression(computed.expression);
+        }
 
         // TS1212/TS1213: Check if the computed expression is a strict mode reserved word.
         // E.g., `{ [public]: 0 }` should emit TS1212 in strict mode.

--- a/crates/tsz-checker/src/tests/await_grammar_computed_property_name_tests.rs
+++ b/crates/tsz-checker/src/tests/await_grammar_computed_property_name_tests.rs
@@ -33,6 +33,23 @@
 //!    unrooted even after (1) and (2). Fixed in `type_alias_checking.rs` by
 //!    always running the full funnel regardless of whether TS1170 fired —
 //!    `tsc` reports both, they are independent grammar/type rules.
+//! 4. **A `TypeLiteral`-specific async-inheritance defect**, found once (1)
+//!    made the walk reachable for type literals too: unlike a class or
+//!    interface member, a `TypeLiteral` member's computed name does NOT
+//!    inherit the enclosing function's async-ness in `tsc` — verified
+//!    against a live `tsc@7.0.2` oracle, `async function w() { type S = {
+//!    [await k]: number } }` still reports TS1308, while the interface
+//!    analog reports only TS1169. It still correctly answers the
+//!    TS1375/TS1378 top-level pair when genuinely at the source file's top
+//!    level, so this is neither the ordinary inheriting case nor an enum
+//!    initializer's fully-own-container case — a third
+//!    `AwaitContainerMode::TypeLiteralMember` in
+//!    `core_statement_checks.rs::check_await_expression_in_container`,
+//!    reached via `check_computed_property_name_type_literal_member`
+//!    (`property_checker.rs`) from all three `type_alias_checking.rs`
+//!    `TypeLiteral`-member call sites (property, method/call signature,
+//!    accessor). Holds regardless of nesting depth — a `TypeLiteral` nested
+//!    inside an `interface` member's type annotation behaves identically.
 //!
 //! Every expectation below is pinned against a live `tsc@7.0.2 --noEmit
 //! --pretty false --target es2017 --module commonjs` run, not recalled, and
@@ -161,14 +178,89 @@ function outer() { type Shape2 = { [await key]: number }; }
 }
 
 #[test]
-fn async_wrapper_type_literal_computed_name_reports_only_ts1170() {
+fn async_wrapper_type_literal_computed_name_reports_ts1170_and_ts1308() {
+    // Unlike the class/interface siblings above, a `TypeLiteral` member's
+    // computed name does NOT inherit the enclosing function's async-ness —
+    // verified against a live `tsc@7.0.2` oracle, which reports both TS1170
+    // and TS1308 here (the interface analog reports only TS1169: no TS1308).
     let codes = without_missing_promise_lib(check_source_codes_with_parse_health(
         r#"
 declare const key: string;
 async function wrapper() { type Shape2 = { [await key]: number }; }
 "#,
     ));
-    assert_eq!(codes, vec![1170], "got {codes:?}");
+    assert_eq!(sorted(codes.clone()), vec![1170, 1308], "got {codes:?}");
+}
+
+#[test]
+fn async_wrapper_type_literal_method_computed_name_reports_ts1170_and_ts1308() {
+    // Adjacent member form: a call/method signature member, not a property.
+    let codes = without_missing_promise_lib(check_source_codes_with_parse_health(
+        r#"
+declare const key: string;
+async function wrapper() { type Shape2 = { [await key](): number }; }
+"#,
+    ));
+    assert_eq!(sorted(codes.clone()), vec![1170, 1308], "got {codes:?}");
+}
+
+#[test]
+fn async_wrapper_type_literal_accessor_computed_name_reports_ts1308() {
+    // Adjacent member form: an accessor. No TS1170 pairing here — a
+    // `get`/`set` computed name isn't gated by the literal-form check the
+    // way property/method members are (mirrors the pre-existing accessor
+    // funnel, which never called `check_computed_property_requires_literal`).
+    let codes = without_missing_promise_lib(check_source_codes_with_parse_health(
+        r#"
+declare const key: string;
+async function wrapper() { type Shape2 = { get [await key](): number }; }
+"#,
+    ));
+    assert_eq!(codes, vec![1308], "got {codes:?}");
+}
+
+#[test]
+fn async_wrapper_type_literal_nested_in_interface_property_reports_ts1170_and_ts1308() {
+    // A `TypeLiteral` nested inside an `interface` member's type annotation
+    // behaves identically to one nested inside a type alias's body — the
+    // rule is keyed to the `TypeLiteral` node, not its enclosing declaration.
+    let codes = without_missing_promise_lib(check_source_codes_with_parse_health(
+        r#"
+declare const key: string;
+async function wrapper() { interface Shape { bar: { [await key]: number } } }
+"#,
+    ));
+    assert_eq!(sorted(codes.clone()), vec![1170, 1308], "got {codes:?}");
+}
+
+#[test]
+fn renamed_binder_async_wrapper_type_literal_computed_name_reports_ts1170_and_ts1308() {
+    // Adjacent case: no identifier-spelling predicate drives the rule.
+    let codes = without_missing_promise_lib(check_source_codes_with_parse_health(
+        r#"
+declare const propertyToken: string;
+async function makeContainer() { type Container = { [await propertyToken]: number }; }
+"#,
+    ));
+    assert_eq!(sorted(codes.clone()), vec![1170, 1308], "got {codes:?}");
+}
+
+#[test]
+fn top_level_type_literal_computed_name_await_unaffected() {
+    // Regression control: a `TypeLiteral` that really is at the source
+    // file's top level still gets the TS1375/TS1378 top-level pair, not
+    // TS1308 — only the async-inheritance half changed, not the top-level
+    // walk. (No `--module`/`--target` flags in this harness, so only TS1375
+    // fires; TS1378 is a separate module/target gate covered elsewhere.)
+    let codes = check_source_codes_with_parse_health(
+        r#"
+declare const key: string;
+type Shape2 = { [await key]: number };
+"#,
+    );
+    assert!(codes.contains(&1170), "got {codes:?}");
+    assert!(codes.contains(&1375), "got {codes:?}");
+    assert!(!codes.contains(&1308), "got {codes:?}");
 }
 
 #[test]

--- a/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
+++ b/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
@@ -11,6 +11,24 @@ use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::TypeId;
 
+/// Which position an `await` expression's grammar walk is rooted from, for
+/// the purposes of async-context inheritance and top-level-`await`
+/// eligibility. See `CheckerState::check_await_expression_in_container`.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AwaitContainerMode {
+    /// The ordinary case: inherits the enclosing function's async-ness and,
+    /// absent one, is eligible for the source file's top-level allowance.
+    Inherits,
+    /// Neither inherits the enclosing async-ness nor is eligible for the
+    /// top-level allowance — always TS1308. Used for enum member
+    /// initializers.
+    OwnContainer,
+    /// Does not inherit the enclosing async-ness, but is still eligible for
+    /// the top-level allowance. Used for a `TypeLiteral` member's computed
+    /// name — see `check_await_expression_type_literal_member`.
+    TypeLiteralMember,
+}
+
 impl<'a> CheckerState<'a> {
     pub(crate) fn check_return_statement(&mut self, stmt_idx: NodeIndex) {
         let Some(node) = self.ctx.arena.get(stmt_idx) else {
@@ -574,7 +592,7 @@ impl<'a> CheckerState<'a> {
     /// - Emits TS1308 if await is used outside async function
     /// - Iteratively checks child expressions for await expressions (no recursion)
     pub(crate) fn check_await_expression(&mut self, expr_idx: NodeIndex) {
-        self.check_await_expression_in_container(expr_idx, /* own_container */ false);
+        self.check_await_expression_in_container(expr_idx, AwaitContainerMode::Inherits);
     }
 
     /// Root the `await`-grammar walk on an expression that sits inside a
@@ -592,10 +610,35 @@ impl<'a> CheckerState<'a> {
     /// never leaks into a nested function body inside the initializer
     /// (`enum E { A = (() => 1)() }`).
     pub(crate) fn check_await_expression_in_own_container(&mut self, expr_idx: NodeIndex) {
-        self.check_await_expression_in_container(expr_idx, /* own_container */ true);
+        self.check_await_expression_in_container(expr_idx, AwaitContainerMode::OwnContainer);
     }
 
-    fn check_await_expression_in_container(&mut self, expr_idx: NodeIndex, own_container: bool) {
+    /// Root the `await`-grammar walk on a `TypeLiteral` member's computed
+    /// name — a third, distinct position that neither inherits the enclosing
+    /// function's async-ness nor is fully its own container.
+    ///
+    /// Verified against a live `tsc@7.0.2` oracle: unlike a class or
+    /// interface member's computed name (which answer clean inside an
+    /// `async` wrapper — the name is evaluated in the enclosing scope), a
+    /// `TypeLiteral` member's computed name still answers TS1308 there,
+    /// regardless of how many enclosing functions are `async`. But unlike an
+    /// enum member initializer's own-container position, it still correctly
+    /// answers the TS1375/TS1378 top-level pair when the `TypeLiteral`
+    /// really does sit at the source file's top level — so only the
+    /// async-inheritance half is suppressed, not the top-level walk. This
+    /// holds for every member form (property, method/call signature,
+    /// accessor) and regardless of nesting depth (a `TypeLiteral` nested
+    /// inside an `interface` member's type annotation behaves identically).
+    pub(crate) fn check_await_expression_type_literal_member(&mut self, expr_idx: NodeIndex) {
+        self.check_await_expression_in_container(expr_idx, AwaitContainerMode::TypeLiteralMember);
+    }
+
+    fn check_await_expression_in_container(
+        &mut self,
+        expr_idx: NodeIndex,
+        mode: AwaitContainerMode,
+    ) {
+        let own_container = matches!(mode, AwaitContainerMode::OwnContainer);
         // Use iterative approach with explicit stack to handle deeply nested expressions.
         // This prevents stack overflow for expressions like `0 + 0 + 0 + ... + 0` (50K+ deep).
         let mut stack = vec![expr_idx];
@@ -616,8 +659,13 @@ impl<'a> CheckerState<'a> {
                     // (e.g., `@dec await 1` — the decorator error suppresses TS1378).
                     // An own-container position never inherits the enclosing
                     // function's async-ness (see
-                    // `check_await_expression_in_own_container`).
-                    let in_async_context = !own_container && self.ctx.in_async_context();
+                    // `check_await_expression_in_own_container`), and neither
+                    // does a `TypeLiteral` member's computed name (see
+                    // `check_await_expression_type_literal_member`) — but the
+                    // latter still answers the top-level walk below, unlike
+                    // the former.
+                    let in_async_context =
+                        matches!(mode, AwaitContainerMode::Inherits) && self.ctx.in_async_context();
                     if !in_async_context && !self.ctx.has_syntax_parse_errors {
                         use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
 

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -1494,7 +1494,7 @@ impl<'a> CheckerState<'a> {
                                     diagnostic_messages::A_COMPUTED_PROPERTY_NAME_IN_A_TYPE_LITERAL_MUST_REFER_TO_AN_EXPRESSION_WHOSE_TYP,
                                     diagnostic_codes::A_COMPUTED_PROPERTY_NAME_IN_A_TYPE_LITERAL_MUST_REFER_TO_AN_EXPRESSION_WHOSE_TYP,
                                 );
-                                self.check_computed_property_name(sig.name);
+                                self.check_computed_property_name_type_literal_member(sig.name);
                             }
                             let (_type_params, type_param_updates) =
                                 self.push_type_parameters(&sig.type_parameters);
@@ -1528,7 +1528,7 @@ impl<'a> CheckerState<'a> {
                             continue;
                         }
                         if let Some(accessor) = self.ctx.arena.get_accessor(member_node) {
-                            self.check_computed_property_name(accessor.name);
+                            self.check_computed_property_name_type_literal_member(accessor.name);
                             if accessor.type_annotation != NodeIndex::NONE {
                                 check_child_type_node!(self, accessor.type_annotation);
                             }
@@ -1561,7 +1561,7 @@ impl<'a> CheckerState<'a> {
                                     diagnostic_messages::A_COMPUTED_PROPERTY_NAME_IN_A_TYPE_LITERAL_MUST_REFER_TO_AN_EXPRESSION_WHOSE_TYP,
                                     diagnostic_codes::A_COMPUTED_PROPERTY_NAME_IN_A_TYPE_LITERAL_MUST_REFER_TO_AN_EXPRESSION_WHOSE_TYP,
                                 );
-                                self.check_computed_property_name(prop.name);
+                                self.check_computed_property_name_type_literal_member(prop.name);
                             }
                             if prop.type_annotation != NodeIndex::NONE {
                                 check_child_type_node!(self, prop.type_annotation);


### PR DESCRIPTION
A follow-up to #16094/#16099/#16101/#16102 (the `await`-in-computed-member-name family): once (1) rooted the walk for type-literal members too, it exposed a fourth, distinct defect — this PR's fix.

## Structural rule

**When a computed member name belongs to a `TypeLiteral` node (property, method/call signature, or accessor — regardless of nesting depth or its enclosing declaration), `tsc` does not carry the enclosing function's async-ness into it, but it still correctly answers the source-file-top-level question. tsz now does the same through a third `AwaitContainerMode::TypeLiteralMember` variant in `check_await_expression_in_container` (checker, `types/type_checking/core_statement_checks.rs`), reached from `check_computed_property_name_type_literal_member` (`checkers/property_checker.rs`).**

Verified against a live `tsc@7.0.2 --noEmit --strict --pretty false` oracle:

```ts
declare const key: string;
async function wrapper() { type Shape2 = { [await key]: number }; }
```
reports **both** TS1170 and TS1308. The interface analog (`interface Shape { [await key]: number }` in the same async wrapper) reports only TS1169 — no TS1308, because an interface member's computed name *does* inherit the enclosing scope's async-ness (already correct via #16099's `EnclosingClassInfo`-style handling for class members and the unmodified default path for interfaces). tsz was silently missing TS1308 for the type-literal case — a false negative, not a false positive.

This is a genuine third position, distinct from both existing `AwaitContainerMode` variants:
- `Inherits` (interface/class member, ordinary expression): inherits async-ness **and** the top-level allowance.
- `OwnContainer` (enum member initializer, pre-existing): inherits **neither** — always TS1308.
- `TypeLiteralMember` (new): does **not** inherit async-ness, but **does** still answer the TS1375/TS1378 top-level pair when the `TypeLiteral` really is at the source file's top level (`type Shape2 = { [await key]: number };` at module scope reports TS1375, not TS1308) — confirmed against the oracle and pinned as a regression control test.

The rule is keyed to the `TypeLiteral` AST node itself, not its parent declaration: a `TypeLiteral` nested inside an `interface` member's type annotation (`interface Shape { bar: { [await key]: number } }`) behaves identically to one that's a type alias's own body.

## Adjacent-case matrix (all oracle-verified against `tsc@7.0.2`)

| case | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| type-literal property, async wrapper | TS1170+TS1308 | TS1170 only | TS1170+TS1308 |
| type-literal method/call signature, async wrapper | TS1170+TS1308 | TS1170 only | TS1170+TS1308 |
| type-literal accessor, async wrapper | TS1308 | clean | TS1308 |
| type-literal nested inside interface property type, async wrapper | TS1170+TS1308 | TS1170 only | TS1170+TS1308 |
| renamed binder (`propertyToken`), async wrapper | TS1170+TS1308 | TS1170 only | TS1170+TS1308 |
| type-literal at true top level (module) | TS1170+TS1375 | unchanged | unchanged (regression control) |
| interface member, async wrapper | TS1169 only | unchanged | unchanged (regression control) |
| class member, async wrapper | clean | unchanged | unchanged (regression control) |

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib await_grammar_computed_property_name_tests`: 19 passed, 0 failed (12 pre-existing + 7 new/updated).
- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings`: clean.
- `scripts/conformance/compare-to-parent.sh` (HEAD vs `HEAD~1` = `2ab55f3`, current `main` tip): 12043 runnable both sides, 599 failing both sides, **0 newly passing, 0 newly failing**. Expected zero-movement signature for a narrow shape with no existing corpus fixture (async function + local type alias + await computed member name) — the oracle-pinned matrix above is the primary evidence here, per the board's own standing note on this failure class.
- Local pre-commit hook (fmt + clippy + arch-size guard): passed.
- **Not run**: full `cargo test -p tsz-checker --lib` (8600+ tests; this container's run stalled well past the point other targeted/clippy runs completed, so it was killed rather than block the session — the targeted suite plus clippy plus arch-guard already exercise this exact code path). Emit/fourslash also not run — this container's emit harness needs a non-`--skip-build` first run (40+ min per board precedent) and this change touches no emit code paths.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01XixipsmNrZAgpTorZqqomx)_