### PR TITLE
perf(solver): memoize contains_free_infer_types per-TypeId

### DIFF
--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -760,6 +760,14 @@ impl TypePredicateCache for TypeInterner {
         );
     }
 
+    fn contains_free_infer_cached(&self, type_id: TypeId) -> Option<bool> {
+        self.predicate_cache_get(type_id, PredicateCacheKind::ContainsFreeInfer)
+    }
+
+    fn set_contains_free_infer_cache(&self, type_id: TypeId, result: bool) {
+        self.predicate_cache_set(type_id, PredicateCacheKind::ContainsFreeInfer, result);
+    }
+
     fn contains_generic_params_root_cached(&self, type_id: TypeId) -> Option<bool> {
         self.predicate_cache_get(type_id, PredicateCacheKind::ContainsGenericParamsRoot)
     }

--- a/crates/tsz-solver/src/caches/db_base_traits.rs
+++ b/crates/tsz-solver/src/caches/db_base_traits.rs
@@ -94,6 +94,17 @@ pub trait TypePredicateCache {
     /// interner cache. Default impl is a no-op.
     fn set_contains_extractable_type_params_cache(&self, _type_id: TypeId, _result: bool) {}
 
+    /// Look up a cached free-`infer` containment result (the `FREE_INFER`
+    /// policy walk backing `contains_free_infer_types`) if available. Default
+    /// impl returns `None` (no caching).
+    fn contains_free_infer_cached(&self, _type_id: TypeId) -> Option<bool> {
+        None
+    }
+
+    /// Record a free-`infer` containment result in the shared interner cache.
+    /// Default impl is a no-op.
+    fn set_contains_free_infer_cache(&self, _type_id: TypeId, _result: bool) {}
+
     /// Look up a cached `contains_type_parameters_db(type_id)` result if
     /// available. Default impl returns `None` (no caching).
     fn contains_type_params_cached(&self, _type_id: TypeId) -> Option<bool> {

--- a/crates/tsz-solver/src/caches/query_cache/predicate_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache/predicate_cache.rs
@@ -70,6 +70,14 @@ impl TypePredicateCache for QueryCache<'_> {
             .set_contains_extractable_type_params_cache(type_id, result);
     }
 
+    fn contains_free_infer_cached(&self, type_id: TypeId) -> Option<bool> {
+        self.interner.contains_free_infer_cached(type_id)
+    }
+
+    fn set_contains_free_infer_cache(&self, type_id: TypeId, result: bool) {
+        self.interner.set_contains_free_infer_cache(type_id, result);
+    }
+
     fn contains_type_params_cached(&self, type_id: TypeId) -> Option<bool> {
         self.interner.contains_type_params_cached(type_id)
     }

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -210,6 +210,22 @@ pub(crate) enum PredicateCacheKind {
     /// [`ChildPolicy::CONTENT_PREDICATE`]:
     ///     crate::visitors::child_policy::ChildPolicy::CONTENT_PREDICATE
     ContainsExtractableTypeParams = 18,
+    /// `type_id` contains a *free* `infer` type anywhere on its
+    /// [`ChildPolicy::FREE_INFER`] surface — an inference placeholder not
+    /// buried inside a `TypeParameter`'s constraint/default, a generic
+    /// signature body, or the operand of a deferred conditional/mapped/
+    /// indexed-access/keyof operation. Freeness under this policy is a purely
+    /// structural, resolver-independent property of the `TypeId` within one
+    /// interner, so the deep walk is memoized per node like the sibling
+    /// `Contains*` predicates. Distinct from [`Self::ContainsFreeTypeParams`],
+    /// which walks the wider `FREE_TYPE_PARAMS` policy and also matches
+    /// `TypeParameter`/`ThisType`/`BoundParameter`. Backs
+    /// `should_suppress_assignability_diagnostic`'s free-`infer` gate
+    /// (#15729).
+    ///
+    /// [`ChildPolicy::FREE_INFER`]:
+    ///     crate::visitors::child_policy::ChildPolicy::FREE_INFER
+    ContainsFreeInfer = 19,
 }
 
 impl PredicateCacheKind {

--- a/crates/tsz-solver/src/type_queries/data/content_predicates.rs
+++ b/crates/tsz-solver/src/type_queries/data/content_predicates.rs
@@ -597,7 +597,7 @@ pub fn is_substitution_dependent_type(db: &dyn TypeDatabase, type_id: TypeId) ->
 /// only written to the persistent cache when its computation did NOT touch an
 /// in-progress (cycle) node — the `cycle_tainted` flag tracks this so a
 /// provisional cycle-break answer is never cached as if it were final.
-fn contains_content_cached<P: ContentPredicate>(
+pub(super) fn contains_content_cached<P: ContentPredicate>(
     db: &dyn TypeDatabase,
     type_id: TypeId,
     predicate: &P,

--- a/crates/tsz-solver/src/type_queries/data/free_infer_cache_tests.rs
+++ b/crates/tsz-solver/src/type_queries/data/free_infer_cache_tests.rs
@@ -1,0 +1,209 @@
+//! Parity tests for the memoized free-`infer` containment query.
+//!
+//! `contains_free_infer_types` was changed (#15729) to memoize its deep
+//! `FREE_INFER`-policy walk per node in the project-wide predicate cache,
+//! mirroring `contains_free_type_parameters_db` (#13250). These tests pin
+//! that the cached answer is byte-identical to a fresh uncached walk over the
+//! same policy, that re-querying the same id is stable (cache hits return the
+//! same value), and that the `FREE_INFER` semantics — generic signature
+//! bodies and the operands of deferred conditional/mapped/indexed-access/
+//! `keyof` operations do not count as free `infer` uses (#14784) — survive
+//! the cache.
+
+use crate::intern::TypeInterner;
+use crate::types::{
+    ConditionalType, FunctionShape, MappedType, PropertyInfo, TupleElement, TypeData, TypeId,
+    TypeParamInfo,
+};
+use crate::visitors::child_policy::ChildPolicy;
+use crate::visitors::visitor_predicates::contains_free_infer_types;
+
+/// Reference oracle: a fresh, fully-uncached `FREE_INFER`-policy containment
+/// walk. This mirrors the pre-memoization `DeepContainsChecker` behaviour
+/// exactly, so any divergence from `contains_free_infer_types` is a cache bug.
+fn reference_contains_free_infer(interner: &TypeInterner, root: TypeId) -> bool {
+    use crate::visitors::child_policy::{for_each_child_with_policy, has_policy_children};
+    use rustc_hash::FxHashSet;
+
+    let mut stack = vec![root];
+    let mut visited = FxHashSet::default();
+    while let Some(current) = stack.pop() {
+        if current.is_intrinsic() || !visited.insert(current) {
+            continue;
+        }
+        let Some(key) = interner.lookup(current) else {
+            continue;
+        };
+        if matches!(key, TypeData::Infer(_)) {
+            return true;
+        }
+        if !has_policy_children(&key, &ChildPolicy::FREE_INFER) {
+            continue;
+        }
+        for_each_child_with_policy(interner, &key, &ChildPolicy::FREE_INFER, |child| {
+            stack.push(child);
+        });
+    }
+    false
+}
+
+fn build_corpus(interner: &TypeInterner) -> Vec<TypeId> {
+    let t = interner.type_param(TypeParamInfo::simple(interner.intern_string("T")));
+    let infer_v = interner.infer(TypeParamInfo::simple(interner.intern_string("V")));
+    let p = interner.intern_string("p");
+
+    let leaves = [TypeId::STRING, TypeId::NUMBER, t, infer_v];
+
+    let mut corpus = Vec::new();
+    for leaf in leaves {
+        corpus.push(leaf);
+        corpus.push(interner.array(leaf));
+        corpus.push(interner.union(vec![TypeId::NUMBER, leaf]));
+        corpus.push(interner.tuple(vec![TupleElement::fixed(leaf)]));
+        corpus.push(interner.object(vec![PropertyInfo::new(p, leaf)]));
+        // Nest two levels deep so the per-node memo has shared subtrees to reuse.
+        let nested = interner.array(interner.union(vec![leaf, interner.array(leaf)]));
+        corpus.push(nested);
+    }
+
+    // A conditional whose `extends` clause structurally contains `infer V` is
+    // the canonical *declaration-site* shape (`X extends Foo<infer V> ? V :
+    // never`): the deferred operand is not descended, so the conditional as a
+    // whole must NOT be reported as containing a free `infer`, even though
+    // `infer_v` itself is reachable as a direct child of `extends_type`.
+    let declared_cond = interner.conditional(ConditionalType {
+        check_type: t,
+        extends_type: infer_v,
+        true_type: TypeId::NUMBER,
+        false_type: TypeId::STRING,
+        is_distributive: false,
+    });
+    corpus.push(declared_cond);
+    corpus.push(interner.array(declared_cond));
+
+    // A conditional whose `true_type` branch leaks a bare `infer` that is NOT
+    // itself declared in this conditional's `extends` clause is a separate
+    // question from the declaration-site case above; the branch bodies are
+    // ordinary structural children (not deferred operands) and must still be
+    // walked, so a free `infer` embedded there is still detected.
+    let leaking_cond = interner.conditional(ConditionalType {
+        check_type: t,
+        extends_type: TypeId::STRING,
+        true_type: infer_v,
+        false_type: TypeId::NUMBER,
+        is_distributive: false,
+    });
+    corpus.push(leaking_cond);
+
+    // `keyof`/indexed-access operands are deferred the same way.
+    corpus.push(interner.keyof(infer_v));
+    corpus.push(interner.index_access(infer_v, TypeId::STRING));
+
+    // A mapped type's `constraint` (a `keyof` operand) hides its `infer` the
+    // same way a conditional's `extends` clause does.
+    let mapped_hidden = interner.mapped(MappedType {
+        type_param: TypeParamInfo::simple(interner.intern_string("K")),
+        constraint: interner.keyof(infer_v),
+        name_type: None,
+        template: TypeId::NUMBER,
+        readonly_modifier: None,
+        optional_modifier: None,
+    });
+    corpus.push(mapped_hidden);
+
+    // A generic function whose only `infer`-shaped use is inside its own
+    // signature body must not count as a free `infer` (skipped wholesale).
+    let generic_fn = interner.function(FunctionShape {
+        type_params: vec![TypeParamInfo::simple(interner.intern_string("W"))],
+        params: vec![],
+        this_type: None,
+        return_type: infer_v,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+    corpus.push(generic_fn);
+    corpus.push(interner.union(vec![TypeId::NUMBER, generic_fn]));
+
+    // But a free outer `infer` alongside a signature body must still be found.
+    let mixed = interner.union(vec![infer_v, generic_fn]);
+    corpus.push(mixed);
+
+    corpus.push(interner.recursive(0));
+    corpus.push(interner.array(interner.recursive(1)));
+    corpus
+}
+
+#[test]
+fn cached_free_infer_query_matches_uncached_reference() {
+    let interner = TypeInterner::new();
+    for root in build_corpus(&interner) {
+        let expected = reference_contains_free_infer(&interner, root);
+        // First query populates the cache; second must hit it with the same answer.
+        let first = contains_free_infer_types(&interner, root);
+        let second = contains_free_infer_types(&interner, root);
+        assert_eq!(
+            first,
+            expected,
+            "cached free-infer query disagreed with reference for {:?}",
+            interner.lookup(root)
+        );
+        assert_eq!(
+            second,
+            first,
+            "cached free-infer query not stable on re-query for {:?}",
+            interner.lookup(root)
+        );
+    }
+}
+
+#[test]
+fn declaration_site_infer_is_not_free() {
+    let interner = TypeInterner::new();
+    let t = interner.type_param(TypeParamInfo::simple(interner.intern_string("T")));
+    let infer_v = interner.infer(TypeParamInfo::simple(interner.intern_string("V")));
+
+    // `T extends Foo<infer V> ? V : never`-shaped: `infer V` is declared in
+    // the (deferred, unwalked) `extends` clause, so the conditional as a
+    // whole contains no free `infer`.
+    let cond = interner.conditional(ConditionalType {
+        check_type: t,
+        extends_type: infer_v,
+        true_type: TypeId::NUMBER,
+        false_type: TypeId::STRING,
+        is_distributive: false,
+    });
+    assert!(
+        !contains_free_infer_types(&interner, cond),
+        "infer declared only in a conditional's extends clause must not count as free"
+    );
+}
+
+#[test]
+fn generic_signature_body_infer_is_not_free() {
+    let interner = TypeInterner::new();
+    let infer_v = interner.infer(TypeParamInfo::simple(interner.intern_string("V")));
+    let generic_fn = interner.function(FunctionShape {
+        type_params: vec![TypeParamInfo::simple(interner.intern_string("W"))],
+        params: vec![],
+        this_type: None,
+        return_type: infer_v,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+
+    assert!(
+        !contains_free_infer_types(&interner, generic_fn),
+        "infer used only inside a signature body must not count as free"
+    );
+
+    // A free outer `infer` reachable outside any signature must still be
+    // detected, even when an inner signature is also present (the cache must
+    // not let the body-skip mask the free outer use).
+    let mixed = interner.union(vec![infer_v, generic_fn]);
+    assert!(
+        contains_free_infer_types(&interner, mixed),
+        "free outer infer alongside a generic signature must be detected"
+    );
+}

--- a/crates/tsz-solver/src/type_queries/data/free_infer_predicate.rs
+++ b/crates/tsz-solver/src/type_queries/data/free_infer_predicate.rs
@@ -1,0 +1,44 @@
+//! `contains_free_infer_types` cache wiring, split out of `content_predicates`
+//! to stay under that file's size ratchet.
+
+use super::content_predicates::{ContentPredicate, contains_content_cached};
+use crate::construction::TypeDatabase;
+use crate::types::{TypeData, TypeId};
+use crate::visitors::child_policy::ChildPolicy;
+
+/// `Infer` containment over the [`ChildPolicy::FREE_INFER`] child set: skips
+/// generic signature bodies and the operands of deferred conditional/mapped/
+/// indexed-access/keyof operations, so only a genuinely free inference
+/// placeholder counts. See [`ChildPolicy::FREE_INFER`]'s doc for the full
+/// rationale (issue #14784). Freeness under this policy is a pure structural
+/// function of the `TypeId` within one interner, so the deep walk is memoized
+/// per node in its own project-wide cache slot, distinct from the plain
+/// `InferPredicate` and from `FreeTypeParamPredicate` (which also matches
+/// `TypeParameter`/`ThisType`/`BoundParameter` over the wider
+/// `FREE_TYPE_PARAMS` policy).
+struct FreeInferPredicate;
+impl ContentPredicate for FreeInferPredicate {
+    fn matches_node(&self, _db: &dyn TypeDatabase, key: &TypeData) -> bool {
+        matches!(key, TypeData::Infer(_))
+    }
+    fn cached(&self, db: &dyn TypeDatabase, type_id: TypeId) -> Option<bool> {
+        db.contains_free_infer_cached(type_id)
+    }
+    fn set_cache(&self, db: &dyn TypeDatabase, type_id: TypeId, result: bool) {
+        db.set_contains_free_infer_cache(type_id, result);
+    }
+    fn child_policy(&self) -> ChildPolicy {
+        ChildPolicy::FREE_INFER
+    }
+}
+
+/// Check if a type contains a *free* `infer` type — see
+/// `visitor_predicates::contains_free_infer_types` for the full semantics
+/// this must agree with (used by `should_suppress_assignability_diagnostic`
+/// to avoid suppressing real errors when the only `infer` types are in type
+/// parameter constraint chains). The deep walk is memoized per node in the
+/// project-wide predicate cache, so repeated checks over shared closed
+/// subtrees stay O(1) (#15729).
+pub fn contains_free_infer_types_db(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    contains_content_cached(db, type_id, &FreeInferPredicate)
+}

--- a/crates/tsz-solver/src/type_queries/data/mod.rs
+++ b/crates/tsz-solver/src/type_queries/data/mod.rs
@@ -13,6 +13,9 @@ mod content_predicate_guards;
 mod content_predicates;
 mod exact_property_keys;
 #[cfg(test)]
+mod free_infer_cache_tests;
+mod free_infer_predicate;
+#[cfg(test)]
 mod free_param_cache_tests;
 mod nominal_and_base;
 mod rest_binder_queries;
@@ -26,6 +29,7 @@ pub use conditional_constraint::*;
 pub use conditional_distribution::*;
 pub use content_predicates::*;
 pub use exact_property_keys::*;
+pub use free_infer_predicate::*;
 pub use nominal_and_base::*;
 pub use rest_binder_queries::*;
 pub use signatures_and_advanced::*;

--- a/crates/tsz-solver/src/visitors/visitor_predicates/content.rs
+++ b/crates/tsz-solver/src/visitors/visitor_predicates/content.rs
@@ -59,11 +59,17 @@ pub fn contains_infer_types(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
 /// This variant is used by `should_suppress_assignability_diagnostic` to avoid
 /// suppressing real errors like TS2322 when the only `infer` types are in
 /// type parameter constraint chains.
+///
+/// The deep walk is memoized per node in the project-wide free-`infer` cache
+/// (the answer is immutable per `TypeId` within one interner), so repeated
+/// checks over shared closed subtrees stay O(1) instead of re-walking on every
+/// call (#15729).
 pub fn contains_free_infer_types(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
-    DeepContainsChecker::new(types, ChildPolicy::FREE_INFER, |key| {
-        matches!(key, TypeData::Infer(_))
-    })
-    .check_from_root(type_id)
+    // Fast path: intrinsic types never contain a free `infer`.
+    if type_id.is_intrinsic() {
+        return false;
+    }
+    crate::type_queries::contains_free_infer_types_db(types, type_id)
 }
 
 /// Check if a type contains the `any` intrinsic anywhere.


### PR DESCRIPTION
Structural rule: a `contains_*` deep-content predicate walk asked repeatedly for the same `TypeId` under a fixed `ChildPolicy` always returns the same answer, since interned type data is immutable — this is a solver-internal memoization question, not an observable `tsc`-parity question. Every sibling tsz predicate (`contains_this_type`, `contains_infer_types`, `contains_type_parameters`, `contains_free_type_parameters`, ...) already shares the `PredicateCacheKind` bit-packed per-`TypeId` project-wide cache on `TypeInterner` to make repeat queries O(1), through the solver's owning cache-boundary layer (`crates/tsz-solver/src/caches`). `contains_free_infer_types` was the one exception left calling the raw uncached `DeepContainsChecker` on every invocation, re-walking its full subtree each time.

This is issue #15729's candidate direction #4: two of the three `DeepContainsChecker` walks named in that issue's original profile (`contains_free_infer_types`, `contains_error_type`) were unmemoized; `contains_this_type` had already picked up memoization since the issue was filed. This PR closes the `contains_free_infer_types` gap. `contains_error_type` is **not** included here: `TypeId::ERROR` sits in the intrinsic id range, so its containment check needs a sentinel-matched-before-the-intrinsic-short-circuit special case that the shared `CachedContentWalker`/`ContentPredicate` machinery doesn't have yet — a real but separate slice, left as a named follow-up (see NOTE on the coordination board, issue #15994).

## What changed

- `PredicateCacheKind::ContainsFreeInfer` (new cache slot; freeness under the `FREE_INFER` policy is a distinct question from the existing `ContainsFreeTypeParams`/`FREE_TYPE_PARAMS` slot, which also matches `TypeParameter`/`ThisType`/`BoundParameter`).
- Wired through `TypePredicateCache` (default no-op trait methods, `TypeInterner` impl backed by the bit-packed cache, `QueryCache` delegate) — the same three-layer wiring every sibling predicate already uses.
- New `FreeInferPredicate` + `contains_free_infer_types_db`, extracted into their own module (`free_infer_predicate.rs`) rather than added to `content_predicates.rs`, which was already at 1974/2000 lines — adding inline would have tipped it over the repo's hard line-count ratchet.
- `visitor_predicates::contains_free_infer_types` now delegates to the cached db function instead of constructing a fresh `DeepContainsChecker` per call. Public signature and semantics are unchanged.

## Correctness

Pure caching change: no diagnostic, inference, or narrowing behavior can move, since the cached and uncached answers are proven identical by a new parity test suite (mirroring the existing `free_param_cache_tests.rs` pattern for the sibling `FREE_TYPE_PARAMS` cache):

- `cached_free_infer_query_matches_uncached_reference` — a corpus of `infer`/type-param leaves nested under array/union/tuple/object/conditional/mapped/keyof/indexed-access/generic-signature shapes, each checked against a fresh from-scratch `FREE_INFER` walk, first-query and re-query.
- `declaration_site_infer_is_not_free` — `infer V` reachable only through a conditional's (deferred, unwalked) `extends` clause must not count as free.
- `generic_signature_body_infer_is_not_free` — `infer` used only inside a *generic* signature's own body must not count as free, but a free outer `infer` alongside that signature must still be detected (cache must not let the body-skip mask it).

## Goal
Goal: fast

## Verification
- `cargo nextest run -p tsz-solver --lib`: 7622/7622 passed (was 7619; +3 new tests), including the pre-existing `free_infer_policy_skips_*` semantic tests in `visitor_predicates::content::tests`, unaffected.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `python3 scripts/arch/arch_guard.py`: passed (content_predicates.rs stays at 1974/2000 lines; new logic lives in its own 44-line module).
- `cargo fmt --check`: clean.
- Pre-commit hook (clippy + arch guard) passed on commit.
- Not run in this container (no `TypeScript` submodule checked out; disclosing rather than implying coverage): `compare-to-parent.sh`, full `conformance.sh`, emit, fourslash. This is a pure per-`TypeId` memoization with proven-identical cached/uncached answers and zero diagnostic-surface change, so these suites are not expected to move; a warm seat should still confirm before merge per repo convention.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: Ignimbrite