### PR TITLE
test(checker): pin the array half of #16095's conditional extends-clause identity

### DIFF
--- a/crates/tsz-checker/tests/conditional_extends_redundant_intersection_identity_tests.rs
+++ b/crates/tsz-checker/tests/conditional_extends_redundant_intersection_identity_tests.rs
@@ -170,6 +170,157 @@ fn distinct_object_intersections_are_not_identical() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// Array shape (#16095). Array members of an intersection are never merged at
+// intern time, so unlike the object rows above the intersection itself survives
+// interning here (pinned by `redundant_array_intersection_survives_interning`
+// in the solver's `intern/normalize_tests.rs`). What goes wrong is
+// downstream of interning: something subtype-reduces `string[] & (string |
+// number)[]` to plain `string[]` — the element relation is a simple covariant
+// check, which is exactly why the tuple witness at the top of this file is
+// unaffected — and once both sides of the `IfEquals` trick hold the same
+// TypeId, `check_subtype`'s identity fast path answers before the extends
+// clause identity guard in `relations::subtype::rules::conditionals` runs.
+// tsc does not subtype-reduce intersections at all, and compares extends
+// clauses with `isTypeIdenticalTo`, so the two stay distinct there.
+//
+// The two rows below are `#[ignore]`d rather than deleted so they go live the
+// moment the reduction is fixed. Everything else in this section passes today
+// and is a live control: the identity guard is doing its job wherever the
+// operands still reach it, which is what makes the two ignored rows a
+// statement about *where* the operands are lost rather than about the guard.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "#16095: tsz answers EQ, tsc TS2344. The extends clause is subtype-reduced \
+     to plain `string[]` before the identity guard can see it, so both sides of the \
+     IfEquals trick become the same TypeId. See the module comment above."]
+fn redundant_array_intersection_is_not_identical_to_its_subsumed_member() {
+    let source = format!(
+        "{IF_EQUALS_PRELUDE}\n\
+        type R = IfEquals<string[] & (string | number)[], string[], \"EQ\", \"DIFF\">;\n\
+        const r: R = \"DIFF\";\n"
+    );
+    let diags = check(&source);
+    assert!(
+        error_codes(&diags).is_empty(),
+        "A redundant array intersection and its subsumed member are different types to tsc's isTypeIdenticalTo; got: {diags:#?}"
+    );
+}
+
+#[test]
+#[ignore = "#16095: same defect as the row above, renamed binders. Pinned so the \
+     renamed-binder control goes live with the fix rather than after it."]
+fn redundant_array_intersection_under_alpha_renamed_type_parameters() {
+    let source = r#"
+type Equal<L, R, T = "EQ", F = "DIFF"> =
+  (<U>() => U extends L ? 1 : 2) extends
+  (<U>() => U extends R ? 1 : 2) ? T : F;
+type R = Equal<number[] & (number | boolean)[], number[]>;
+const r: R = "DIFF";
+"#;
+    let diags = check(source);
+    assert!(
+        error_codes(&diags).is_empty(),
+        "Renamed binders must not change the array-intersection identity answer; got: {diags:#?}"
+    );
+}
+
+#[test]
+fn redundant_array_intersection_is_not_identical_to_the_wider_member_either() {
+    let source = format!(
+        "{IF_EQUALS_PRELUDE}\n\
+        type R = IfEquals<string[] & (string | number)[], (string | number)[], \"EQ\", \"DIFF\">;\n\
+        const r: R = \"DIFF\";\n"
+    );
+    let diags = check(&source);
+    assert!(
+        error_codes(&diags).is_empty(),
+        "The reduction dropped the wider member, so pin that side too; got: {diags:#?}"
+    );
+}
+
+#[test]
+fn identical_array_intersections_stay_identical() {
+    let source = format!(
+        "{IF_EQUALS_PRELUDE}\n\
+        type R = IfEquals<\n\
+          string[] & (string | number)[],\n\
+          string[] & (string | number)[],\n\
+          \"EQ\",\n\
+          \"DIFF\"\n\
+        >;\n\
+        const r: R = \"EQ\";\n"
+    );
+    let diags = check(&source);
+    assert!(
+        error_codes(&diags).is_empty(),
+        "Two array intersections written from the same members must stay EQ; got: {diags:#?}"
+    );
+}
+
+#[test]
+fn aliased_array_intersection_is_identical_to_its_spelled_out_form() {
+    let source = format!(
+        "{IF_EQUALS_PRELUDE}\n\
+        type Both = string[] & (string | number)[];\n\
+        type R = IfEquals<string[] & (string | number)[], Both, \"EQ\", \"DIFF\">;\n\
+        const r: R = \"EQ\";\n"
+    );
+    let diags = check(&source);
+    assert!(
+        error_codes(&diags).is_empty(),
+        "An alias for an intersection must stay identical to the intersection it names; got: {diags:#?}"
+    );
+}
+
+#[test]
+fn array_intersection_member_order_does_not_affect_identity() {
+    let source = format!(
+        "{IF_EQUALS_PRELUDE}\n\
+        type R = IfEquals<\n\
+          string[] & (string | number)[],\n\
+          (string | number)[] & string[],\n\
+          \"EQ\",\n\
+          \"DIFF\"\n\
+        >;\n\
+        const r: R = \"EQ\";\n"
+    );
+    let diags = check(&source);
+    assert!(
+        error_codes(&diags).is_empty(),
+        "Reordered array-intersection members must stay EQ; got: {diags:#?}"
+    );
+}
+
+#[test]
+fn plain_arrays_are_unaffected() {
+    let source = format!(
+        "{IF_EQUALS_PRELUDE}\n\
+        type R = IfEquals<string[], string[], \"EQ\", \"DIFF\">;\n\
+        const r: R = \"EQ\";\n"
+    );
+    let diags = check(&source);
+    assert!(
+        error_codes(&diags).is_empty(),
+        "Two plain arrays carry no intersection member set and must stay EQ; got: {diags:#?}"
+    );
+}
+
+#[test]
+fn distinct_arrays_are_not_identical() {
+    let source = format!(
+        "{IF_EQUALS_PRELUDE}\n\
+        type R = IfEquals<string[], number[], \"EQ\", \"DIFF\">;\n\
+        const r: R = \"DIFF\";\n"
+    );
+    let diags = check(&source);
+    assert!(
+        error_codes(&diags).is_empty(),
+        "Arrays over different elements must stay DIFF; got: {diags:#?}"
+    );
+}
+
 #[test]
 fn plain_objects_are_unaffected_by_the_merge_origin_lookup() {
     let source = format!(


### PR DESCRIPTION
## Goal

Goal: hold

`#16095`'s array shape had **no test anywhere in the tree** — neither the defect
nor the surrounding behaviour that is already correct. Three sessions have now
written about this family in issue comments (#16092, #16101, and #16095's own
thread); none of it is executable. This makes it executable.

### Structural rule

When two conditional types' extends clauses are a redundant intersection and the
member it subsumes, `tsc` reports them as different types — `isTypeIdenticalTo`,
and `tsc` never subtype-reduces an intersection in the first place. tsz answers
`EQ`. The owner is the solver: something between interning and
`relations::subtype::rules::conditionals` reduces `string[] & (string |
number)[]` to plain `string[]`, and once both sides of the higher-order
`IfEquals` trick hold the same `TypeId`, `check_subtype`'s identity fast path
answers before the extends-clause identity guard added by #16092/#16101 is
consulted.

### What this changes

Test-only. Eight rows added to the existing
`conditional_extends_redundant_intersection_identity_tests` suite:

| row | today |
| --- | --- |
| redundant array intersection vs its subsumed member | `#[ignore]` — the defect, `EQ` where tsc says TS2344 |
| same, alpha-renamed binders | `#[ignore]` — renamed-binder control for the defect |
| redundant array intersection vs the **wider** member | passes |
| two identical array intersections stay `EQ` | passes |
| an alias for an intersection stays identical to it | passes |
| member order does not affect identity | passes |
| two plain arrays stay `EQ` | passes |
| two distinct arrays stay `DIFF` | passes |

The two known-failing rows are `#[ignore]`d with the reason recorded inline
rather than deleted, so they go live the moment the reduction is fixed. The six
live rows matter as much: they show the identity guard is doing its job wherever
the operands still reach it, which is what makes the ignored pair a statement
about *where* the operands are lost rather than about the guard.

The module comment also records why the tuple witness directly above this
section passes while the array one does not — an array element relation is a
plain covariant check so the intersection is reduced away, whereas the
rest-tuple subsumption cannot be decided in the same place and the intersection
survives to reach the guard. That asymmetry looks arbitrary until it is written
down next to both cases.

### Anti-hardcoding

No compiler code touched. Binders are varied (a full alpha-renamed twin of the
defect row) and element types differ between the two defect spellings
(`string`/`number` vs `number`/`boolean`), so neither row can pass on a
name-shaped coincidence.

## Verification

- `cargo test -p tsz-checker --test conditional_extends_redundant_intersection_identity_tests`
  — **14 passed / 0 failed / 2 ignored** (was 8 passed / 0 failed / 0 ignored
  before this change; the 6 new live rows all pass, the 2 new ignored rows are
  the documented defect).
- Negative control on the ignored rows: run without `#[ignore]` they fail
  `14 passed / 2 failed`, with `TS2322 "DIFF" is not assignable to "EQ"` — i.e.
  they fail for the real reason and are not vacuous.
- `cargo clippy -p tsz-checker --tests` — clean. `cargo fmt` — clean.
- Architecture guard — clean (via the `pre-commit` hook, which runs both).
- **Conformance / emit / fourslash NOT run.** Cold 4-core cloud seat, no
  `.target` and an empty corpus at session start. Stated rather than implied.
  This is a test-only diff that adds no `#[should_panic]`, no baseline entry and
  no accepted-regression line, so the corpus exposure is a new integration test
  binary compiling — but a warm seat should still confirm before merge if the
  reviewer wants the usual gate.

### Explicitly not in scope

An attempted fix, which I am recording as a refuted direction rather than
shipping: preserving the written intersection at all eight conditional-deferral
sites (`evaluate_rules/conditional.rs`, `conditional/phases.rs`) plus hardening
`conditional_extends_types_equivalent`'s evaluated-operand re-check to read each
side's member set from its pre-evaluation form **does not flip either row**.
That is #16095's leading hypothesis (deferred conditionals carry the evaluated
extends type) and it is not sufficient on its own — the operands are already
reduced by the time any of those sites see them. Reverted rather than pushed: a
measured no-op on a hot identity path is unverified complexity, not a fix. Full
detail on the board and on #16095.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Tuff

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcMQzg228YX3FZScygEMUd)_