### PR TITLE
fix(checker): distribute async iterator thenable-check over union yield* delegates

### DIFF
--- a/crates/tsz-checker/src/checkers/iterable_checker.rs
+++ b/crates/tsz-checker/src/checkers/iterable_checker.rs
@@ -357,6 +357,20 @@ impl<'a> CheckerState<'a> {
         use crate::query_boundaries::common::PropertyAccessResult;
 
         let type_id = self.resolve_lazy_type(type_id);
+
+        // Distribute over union delegates: `tsc` accepts a union `yield*`
+        // delegate as long as every member's async iterator has a valid
+        // `next()` result, so the union as a whole is invalid only if some
+        // member is. Resolving `[Symbol.asyncIterator]`/`next()` on the union
+        // `type_id` as a single receiver (the pre-fix behavior) reads an
+        // inconsistent cross-member result and reports a spurious TS1320 even
+        // when each member alone is clean.
+        if let Some(members) = union_members_for_type(self.ctx.types, type_id) {
+            return members
+                .iter()
+                .any(|&member| self.async_iterator_has_invalid_thenable_next_result(member));
+        }
+
         let iterator_fn = self.resolve_property_access_with_env(type_id, "[Symbol.asyncIterator]");
         let iterator_fn_type = match iterator_fn {
             PropertyAccessResult::Success { type_id, .. } => type_id,

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -136,6 +136,9 @@ mod assignability_type_comparability_relation_routing_arch_tests;
 #[path = "tests/assignment_ops_relation_routing_arch_tests.rs"]
 mod assignment_ops_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/async_generator_yieldstar_union_delegate_tests.rs"]
+mod async_generator_yieldstar_union_delegate_tests;
+#[cfg(test)]
 #[path = "../tests/async_imported_promise_tests.rs"]
 mod async_imported_promise_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/async_generator_yieldstar_union_delegate_tests.rs
+++ b/crates/tsz-checker/src/tests/async_generator_yieldstar_union_delegate_tests.rs
@@ -1,0 +1,185 @@
+//! Regression tests for #16116 item 1: a union `yield*` delegate inside an
+//! `async function*` spuriously reported TS1320 even though `tsc` accepts it.
+//!
+//! Structural rule: `async_iterator_has_invalid_thenable_next_result`
+//! (`checkers/iterable_checker.rs`) resolved `[Symbol.asyncIterator]`/`next()`
+//! on the delegate's `TypeId` as a single receiver. For a union delegate that
+//! reads an inconsistent cross-member result instead of distributing over the
+//! constituents the way every other iterable predicate in this file already
+//! does (see `is_array_or_tuple_type`/`has_string_constituent` a few hundred
+//! lines below, which recurse via `union_members_for_type` and combine with
+//! `all()`/`any()`). `tsc` accepts a union delegate as long as *every* member
+//! has a valid async-iterator `next()` result, so the union is invalid only
+//! when *some* member is -- the fix distributes with `any()`.
+//!
+//! Each "invalid" member below returns an anonymous `{ then(): void }` from
+//! `next()` -- a callable `then` with no resolve-callback parameter, which
+//! `extract_awaited_type_from_thenable` cannot extract a payload type from.
+//! A `then` that *does* take an `(value) => void` callback (even on a bare
+//! object type) is a well-formed thenable and must NOT trigger TS1320 -- see
+//! `mere_thenable_shape_with_resolve_callback_is_not_invalid` below.
+
+use crate::test_utils::{check_source_with_libs, load_default_lib_files};
+
+fn strict_codes(source: &str) -> Vec<u32> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(
+        source,
+        "test.ts",
+        crate::context::CheckerOptions {
+            strict: true,
+            ..crate::context::CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|diagnostic| diagnostic.code)
+    .collect()
+}
+
+/// Core repro: two differently-instantiated `AsyncGenerator`s unioned as a
+/// `yield*` delegate must not report TS1320 -- each member's `next()` result
+/// is a well-formed promise.
+#[test]
+fn union_of_valid_async_generators_does_not_report_invalid_thenable() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const zzSource: AsyncGenerator<string> | AsyncGenerator<number>;
+const d = async function* () {
+    yield* zzSource;
+};
+"#,
+    );
+    assert!(
+        !codes.contains(&1320),
+        "a union of two valid AsyncGenerators must not report TS1320: {codes:?}"
+    );
+}
+
+/// Renamed/wrapper control: the same union through user-declared interfaces
+/// (not the lib `AsyncGenerator` alias), each returning a real `Promise`
+/// from `next()`, proving the fix is about union distribution in general,
+/// not something specific to the lib type's shape.
+#[test]
+fn union_of_valid_user_declared_async_iterators_does_not_report_invalid_thenable() {
+    let codes = strict_codes(
+        r#"
+export {};
+interface GoodAsyncIteratorA {
+    [Symbol.asyncIterator](): GoodAsyncIteratorA;
+    next(): Promise<{ value: string; done: boolean }>;
+}
+interface GoodAsyncIteratorB {
+    [Symbol.asyncIterator](): GoodAsyncIteratorB;
+    next(): Promise<{ value: number; done: boolean }>;
+}
+declare const src: GoodAsyncIteratorA | GoodAsyncIteratorB;
+const d = async function* () {
+    yield* src;
+};
+"#,
+    );
+    assert!(
+        !codes.contains(&1320),
+        "a union of two valid user-declared async iterators must not report TS1320: {codes:?}"
+    );
+}
+
+/// Negative/fallback control: a union where one member's `next()` returns a
+/// bare, argument-less thenable must still report TS1320 -- proves the fix
+/// distributes with `any()` rather than vacuously returning `false` for
+/// every union.
+#[test]
+fn union_with_one_invalid_thenable_member_still_reports_invalid_thenable() {
+    let codes = strict_codes(
+        r#"
+export {};
+interface GoodAsyncIterator {
+    [Symbol.asyncIterator](): GoodAsyncIterator;
+    next(): Promise<{ value: string; done: boolean }>;
+}
+interface BadAsyncIterator {
+    [Symbol.asyncIterator](): BadAsyncIterator;
+    next(): { then(): void };
+}
+declare const src: GoodAsyncIterator | BadAsyncIterator;
+const d = async function* () {
+    yield* src;
+};
+"#,
+    );
+    assert!(
+        codes.contains(&1320),
+        "a union with one invalid-thenable member must still report TS1320: {codes:?}"
+    );
+}
+
+/// Baseline control: a single (non-union) valid `AsyncGenerator` delegate
+/// stays clean, matching the issue's "each member alone is clean" witness.
+#[test]
+fn single_valid_async_generator_delegate_stays_clean() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const zzSource: AsyncGenerator<string>;
+const d = async function* () {
+    yield* zzSource;
+};
+"#,
+    );
+    assert!(
+        !codes.contains(&1320),
+        "a single valid AsyncGenerator delegate must not report TS1320: {codes:?}"
+    );
+}
+
+/// Baseline control: a single (non-union) invalid-thenable delegate still
+/// reports TS1320 on its own, independent of any union handling.
+#[test]
+fn single_invalid_thenable_delegate_still_reports_invalid_thenable() {
+    let codes = strict_codes(
+        r#"
+export {};
+interface BadAsyncIterator {
+    [Symbol.asyncIterator](): BadAsyncIterator;
+    next(): { then(): void };
+}
+declare const src: BadAsyncIterator;
+const d = async function* () {
+    yield* src;
+};
+"#,
+    );
+    assert!(
+        codes.contains(&1320),
+        "a single invalid-thenable delegate must report TS1320: {codes:?}"
+    );
+}
+
+/// Fallback/false-negative guard: a bare object `then` that DOES take a
+/// resolve callback is a well-formed thenable per `tsc`'s own rules (it can
+/// extract an awaited payload type from the callback parameter), so it must
+/// not be misclassified as invalid merely for lacking a named `Promise`
+/// base. Distinguishes "no resolve callback" (invalid) from "any non-lib
+/// thenable" (not automatically invalid).
+#[test]
+fn mere_thenable_shape_with_resolve_callback_is_not_invalid() {
+    let codes = strict_codes(
+        r#"
+export {};
+interface OkAsyncIterator {
+    [Symbol.asyncIterator](): OkAsyncIterator;
+    next(): { then(onfulfilled: (value: { value: string; done: boolean }) => void): void };
+}
+declare const src: OkAsyncIterator;
+const d = async function* () {
+    yield* src;
+};
+"#,
+    );
+    assert!(
+        !codes.contains(&1320),
+        "a thenable with a resolve callback must not report TS1320: {codes:?}"
+    );
+}


### PR DESCRIPTION
Closes #16116 item 1 (the union-delegate false positive; item 2, the nested-generator yield-type loss, is a separate defect the issue itself deprioritizes).

<!-- Describe what and why. For semantic fixes, state the structural rule:
     when <structural condition>, tsc does X; tsz does X through <owner layer>.
     Name the benchmark row or failure family when relevant. -->

**Structural rule.** When a `yield*` delegate inside an `async function*` has a union type, `tsc` accepts it as long as *every* member's async iterator has a well-formed `next()` result — the union is invalid only when *some* member is. `async_iterator_has_invalid_thenable_next_result` (`crates/tsz-checker/src/checkers/iterable_checker.rs`) resolved `[Symbol.asyncIterator]`/`next()` on the union's `TypeId` as a single receiver instead of distributing over the constituents the way every other iterable predicate in this file already does (`is_array_or_tuple_type`/`has_string_constituent`, a few hundred lines below, both recurse via `union_members_for_type`). Reading an inconsistent cross-member result off the union directly produced a spurious TS1320 ("Type of 'await' operand must either be a valid promise or must not contain a callable 'then' member") even when each union member alone was clean.

The fix distributes with `.any()`: a union delegate is invalid if any member is, matching the "all members must be individually valid" acceptance rule.

```ts
declare const zzSource: AsyncGenerator<string> | AsyncGenerator<number>;
const d = async function* () {
    yield* zzSource; // tsc: clean. tsz (pre-fix): spurious TS1320.
};
```

## Goal
Goal: hold

## Verification

New suite `crates/tsz-checker/src/tests/async_generator_yieldstar_union_delegate_tests.rs`, 6 cases, covering the adjacent-case matrix:

| case | shape | expectation |
| --- | --- | --- |
| `union_of_valid_async_generators_does_not_report_invalid_thenable` | lib `AsyncGenerator<string> \| AsyncGenerator<number>` | clean (core repro) |
| `union_of_valid_user_declared_async_iterators_does_not_report_invalid_thenable` | user-declared interfaces, not the lib alias | clean (renamed/wrapper control) |
| `union_with_one_invalid_thenable_member_still_reports_invalid_thenable` | one valid + one genuinely-invalid member | TS1320 (negative/fallback control — proves `.any()`, not a vacuous `false`) |
| `single_valid_async_generator_delegate_stays_clean` | non-union baseline | clean |
| `single_invalid_thenable_delegate_still_reports_invalid_thenable` | non-union baseline | TS1320 |
| `mere_thenable_shape_with_resolve_callback_is_not_invalid` | a bare object `then` that *does* take a resolve callback | clean (guards against over-broadening "invalid" to any non-`Promise` thenable) |

- `cargo test -p tsz-checker --lib async_generator_yieldstar_union_delegate` / `generator_yieldstar` / `iterable`: all pass (6, 16, 21 respectively).
- Verified the fix is load-bearing by reverting only the union-distribution block and re-running the suite: exactly the two positive-fix cases fail (`[1320]` where none expected), all 4 controls stay green — confirms the tests aren't vacuous.
- `cargo fmt --all`: clean, no changes.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings` (dev profile) and the pre-commit hook's `dist-fast` clippy + architecture guard: both clean.
- Conformance/emit/fourslash not run — this is a narrow, newly-added-coverage async-generator corner case (no existing corpus fixture exercises `async_iterator_has_invalid_thenable_next_result` via `yield*` at all, confirmed by grep before writing tests), and the change only narrows a previously-overbroad rejection to match `tsc`, so it cannot regress any currently-passing row.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SX5UEi5wahG4fmrBufYPsA)_