### PR TITLE
test(checker): pin the unit-harness gap behind #16116 item 2 (not a compiler defect)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -322,6 +322,9 @@ mod generator_yield_identity_tests;
 #[path = "tests/generator_yield_literal_widening_tests.rs"]
 mod generator_yield_literal_widening_tests;
 #[cfg(test)]
+#[path = "tests/generator_yield_self_similar_nesting_tests.rs"]
+mod generator_yield_self_similar_nesting_tests;
+#[cfg(test)]
 #[path = "tests/generator_yieldstar_symbol_iterator_contribution_tests.rs"]
 mod generator_yieldstar_symbol_iterator_contribution_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/generator_yield_self_similar_nesting_tests.rs
+++ b/crates/tsz-checker/src/tests/generator_yield_self_similar_nesting_tests.rs
@@ -1,36 +1,53 @@
-//! Regression matrix for #16116 item 2, **re-scoped**: an unannotated
-//! generator that yields a value whose type is *the same generator kind as the
-//! container* loses that value's type argument.
+//! #16116 item 2 is **not a compiler defect**. It is an artifact of the unit
+//! harness, and this suite pins the harness gap so it cannot swallow the same
+//! class of diagnostic silently again.
 //!
-//! The issue files this as "the inner generator expression's inferred yield
-//! type is lost through one nesting level", which points at the inner
-//! generator's own inference. It is not: the same loss reproduces with **no
-//! inference on the yielded side at all**, from a `declare const` of a fully
-//! written-out `AsyncGenerator` type (`declared_async_generator_operand_*`
-//! below). What actually decides the outcome is whether the operand's
-//! constructor is the *same* alias as the containing generator's:
+//! The issue reports that an unannotated generator yielding an inner generator
+//! loses the inner's type argument: `tsc` reports TS2345 and tsz reports
+//! nothing. That is true of `check_source_with_libs`. It is **false** of the
+//! compiler. Run the issue's own repro through the CLI and tsz reports the
+//! same TS2345 `tsc` does, having inferred the container correctly:
 //!
-//! | operand type                    | container      | result  |
-//! | ---                             | ---            | ---     |
-//! | `AsyncGenerator[ string ]`      | async `function*` | **lost** |
-//! | `Generator[ string ]`           | sync `function*`  | **lost** |
-//! | `Generator[ string ]`           | async `function*` | correct |
-//! | `AsyncIterable`/`AsyncIterator` | async `function*` | correct |
-//! | `Iterator`/`Set`/`Promise`/`T[]`/object | async `function*` | correct |
+//! ```text
+//! $ tsz --noEmit --strict --pretty false item2.ts
+//! item2.ts(9,7): error TS2345: Argument of type '{ next(..._: [] | [unknown]):
+//!   Promise<IteratorResult<{ ... [Symbol.asyncIterator](): AsyncGenerator<string,
+//!   void, unknown>; }, void>>; ... }' is not assignable to parameter of type
+//!   'AsyncGenerator<AsyncGenerator<number, any, any>, any, any>'.
+//! ```
 //!
-//! The relation is not at fault either: spelling the expected container type
-//! out by hand and assigning it (`written_out_*_relation_still_reports`)
-//! reports the mismatch in exactly the shape the inferred container should
-//! have had. So the loss is in the *container's inferred yield type*, and it is
-//! specific to a self-similar (same-alias-nested-in-itself) application.
+//! The `AsyncGenerator<string, void, unknown>` in that rendering is the inner's
+//! type argument, intact. Nothing was degraded to `any`; no yield contribution
+//! was lost.
 //!
-//! Every row is oracled against `tsc@7.0.2`
-//! (`--noEmit --strict --pretty false --target es2018 --lib es2018,dom`).
-//! Each negative row feeds the container to a deliberately **wrong**
-//! instantiation, so a missing `TS2345` means the operand's type argument was
-//! degraded rather than contributed. The controls are what make that
-//! inference sound: they pin the same shape one alias away, where tsz is
-//! already correct, so a "fix" that widens or drops types wholesale fails them.
+//! What *does* diverge is which shapes the unit harness can see the mismatch
+//! on. Same fixture, `strict_codes` vs the release CLI:
+//!
+//! | yielded operand | container | CLI | harness |
+//! | --- | --- | --- | --- |
+//! | `AsyncGenerator<string>` | `async function*` | TS2345 | **silent** |
+//! | `Generator<string>` | `function*` | TS2345 | **silent** |
+//! | `Generator<string>` | `async function*` | TS2345 | TS2345 |
+//! | `AsyncIterable`/`AsyncIterator`/`Iterator`/`Set`/`Iterable` | `async function*` | TS2345 | TS2345 |
+//! | `Promise<string>`, `string[]`, `{ a: string }` | `async function*` | TS2345 | TS2345 |
+//!
+//! The harness loses the diagnostic on exactly the **self-similar** rows — the
+//! ones where the yielded operand's alias is the same alias as the container's.
+//! One alias away (`Generator` inside an *async* container) it agrees with the
+//! CLI. So the gap is narrow and structural, not a blanket "the harness is
+//! weaker".
+//!
+//! The two `#[ignore]`d rows below assert the CLI's (and `tsc`'s) answer. They
+//! are red **because of the harness divergence**, not because of anything in
+//! the container's inferred yield type — fixing a checker or solver path will
+//! not turn them green. They go live when `check_source_with_libs` resolves
+//! self-similar generator applications the way a real program does.
+//!
+//! Everything else here is a live control, green today, pinning the shapes the
+//! harness *does* see so the boundary of the gap stays measured. Oracle for
+//! every row: `tsc@7.0.2`
+//! (`--noEmit --strict --pretty false --target es2018 --lib es2018,dom`),
+//! cross-checked against `tsz --noEmit --strict --pretty false`.
 
 use crate::context::CheckerOptions;
 use crate::test_utils::{check_source_with_libs, load_default_lib_files};
@@ -51,12 +68,16 @@ fn strict_codes(source: &str) -> Vec<u32> {
     .collect()
 }
 
-/// The minimal witness for #16116 item 2, with the issue's inner generator
-/// expression replaced by a `declare const` — no inference on the yielded side
-/// at all, and the defect is unchanged. `tsc` reports TS2345 here.
+/// The minimal form of the harness gap: `tsc` and the tsz CLI both report
+/// TS2345; `check_source_with_libs` returns an empty diagnostic vector.
+///
+/// The `declare const` operand is deliberate — it strips the issue's inner
+/// generator expression out of the picture entirely, so a reader cannot
+/// mistake this for an inference problem.
 #[test]
-#[ignore = "#16116 item 2: a self-similar `AsyncGenerator` operand loses its type argument"]
-fn declared_async_generator_operand_contributes_its_type_argument() {
+#[ignore = "unit-harness gap, NOT a checker defect: the CLI reports TS2345 here; \
+            `check_source_with_libs` loses it on self-similar generator nesting"]
+fn harness_sees_async_generator_operand_in_async_container() {
     let codes = strict_codes(
         r#"
 export {};
@@ -70,16 +91,17 @@ wants(d());
     );
     assert!(
         codes.contains(&2345),
-        "a yielded `AsyncGenerator<string>` must contribute its own type argument: {codes:?}"
+        "the harness must see the mismatch the CLI reports: {codes:?}"
     );
 }
 
-/// The sync twin of the row above. Pins that this is a property of the
-/// self-similar nesting rather than anything async-specific: no `await`, no
-/// `[Symbol.asyncIterator]`, same loss.
+/// The sync twin. Pins that the gap is a property of the self-similar nesting
+/// rather than anything async-specific: no `await`, no `[Symbol.asyncIterator]`,
+/// same divergence.
 #[test]
-#[ignore = "#16116 item 2: a self-similar `Generator` operand loses its type argument"]
-fn declared_sync_generator_operand_contributes_its_type_argument() {
+#[ignore = "unit-harness gap, NOT a checker defect: the CLI reports TS2345 here; \
+            `check_source_with_libs` loses it on self-similar generator nesting"]
+fn harness_sees_sync_generator_operand_in_sync_container() {
     let codes = strict_codes(
         r#"
 export {};
@@ -93,17 +115,16 @@ wants(d());
     );
     assert!(
         codes.contains(&2345),
-        "a yielded `Generator<string>` must contribute its own type argument: {codes:?}"
+        "the harness must see the mismatch the CLI reports: {codes:?}"
     );
 }
 
-/// The load-bearing control: a **sync** `Generator` operand inside an **async**
-/// container is one alias away from the failing row and is already correct on
-/// `main`. This is the row that localises the defect to same-alias nesting; a
-/// diagnosis that blamed "yielding an iterable" or "yielding a generator"
-/// would predict this fails too.
+/// The load-bearing control, and the row that localises the gap: a **sync**
+/// `Generator` operand inside an **async** container is one alias away from the
+/// ignored rows and the harness sees it. A diagnosis blaming "yielding a
+/// generator" or "yielding an iterable" would predict this fails too.
 #[test]
-fn sync_generator_operand_in_async_container_is_already_correct() {
+fn sync_generator_operand_in_async_container_is_visible_to_the_harness() {
     let codes = strict_codes(
         r#"
 export {};
@@ -117,14 +138,14 @@ wants(d());
     );
     assert!(
         codes.contains(&2345),
-        "a `Generator` operand in an async container must keep its argument: {codes:?}"
+        "a `Generator` operand in an async container must stay visible: {codes:?}"
     );
 }
 
-/// `AsyncIterable` is the same structural shape as `AsyncGenerator` minus the
-/// generator members, and is correct today.
+/// `AsyncIterable` is `AsyncGenerator`'s shape minus the generator members, and
+/// the harness sees it — so the gap is not "any async iterable operand".
 #[test]
-fn async_iterable_operand_is_already_correct() {
+fn async_iterable_operand_is_visible_to_the_harness() {
     let codes = strict_codes(
         r#"
 export {};
@@ -138,14 +159,14 @@ wants(d());
     );
     assert!(
         codes.contains(&2345),
-        "an `AsyncIterable` operand must keep its argument: {codes:?}"
+        "an `AsyncIterable` operand must stay visible: {codes:?}"
     );
 }
 
 /// A non-iterable generic operand: rules out "any nested generic argument is
-/// dropped".
+/// invisible to the harness".
 #[test]
-fn promise_operand_is_already_correct() {
+fn promise_operand_is_visible_to_the_harness() {
     let codes = strict_codes(
         r#"
 export {};
@@ -159,14 +180,14 @@ wants(d());
     );
     assert!(
         codes.contains(&2345),
-        "a `Promise` operand must keep its argument: {codes:?}"
+        "a `Promise` operand must stay visible: {codes:?}"
     );
 }
 
-/// The container's *own* yield argument is not degraded — only the operand's
-/// nested one. Feeding the same container to a target whose yield type is not
-/// a generator at all still reports, which is why the failing rows above
-/// cannot be explained by "the whole inferred container collapsed to `any`".
+/// The container's own yield type is not lost in the harness either — only the
+/// self-similar comparison is. Feeding the same container to a target whose
+/// yield type is not a generator still reports, which is why the ignored rows
+/// cannot be read as "the harness inferred `any` for the container".
 #[test]
 fn self_similar_container_still_rejects_a_non_generator_yield_type() {
     let codes = strict_codes(
@@ -186,11 +207,12 @@ wants(d());
     );
 }
 
-/// The relation is exonerated: the type the failing row *should* have inferred,
-/// written out by hand, is rejected against the same target. Whatever is lost
-/// is lost while building the container's yield type, not while comparing it.
+/// The relation itself is fine even inside the harness: the type the ignored
+/// rows should have compared, written out by hand, is rejected against the same
+/// target. So the gap is in how the harness builds or resolves the container,
+/// not in the subtype check.
 #[test]
-fn written_out_self_similar_relation_still_reports() {
+fn written_out_self_similar_relation_reports_in_the_harness() {
     let codes = strict_codes(
         r#"
 export {};
@@ -207,7 +229,7 @@ wants(a);
 
 /// The sync half of the exoneration above.
 #[test]
-fn written_out_sync_self_similar_relation_still_reports() {
+fn written_out_sync_self_similar_relation_reports_in_the_harness() {
     let codes = strict_codes(
         r#"
 export {};
@@ -222,10 +244,10 @@ wants(a);
     );
 }
 
-/// A non-nested container is correct, so the defect needs the nesting — this is
-/// the depth-1 baseline the failing rows are the depth-2 form of.
+/// The depth-1 baseline the ignored rows are the depth-2 form of: without the
+/// nesting the harness agrees with the CLI.
 #[test]
-fn non_nested_container_is_already_correct() {
+fn non_nested_container_is_visible_to_the_harness() {
     let codes = strict_codes(
         r#"
 export {};
@@ -239,18 +261,17 @@ wants(d());
     );
     assert!(
         codes.contains(&2345),
-        "the non-nested delegate row must stay correct: {codes:?}"
+        "the non-nested delegate row must stay visible: {codes:?}"
     );
 }
 
-/// An **annotated** operand-producing generator expression is unaffected, which
-/// is why the issue's original framing (inner-generator inference) looked
-/// plausible: annotating the inner makes the row pass. It passes because the
-/// annotated inner's type reaches the container by a different construction
-/// path, not because inference of the inner was ever the problem — the
-/// `declare const` rows above have no inner inference and still fail.
+/// Annotating the operand's generator expression makes the row visible to the
+/// harness. This is the row that made #16116's inference framing look
+/// plausible: annotating "fixes" it, which reads like an inference problem.
+/// It is not — the `declare const` rows above have no inference on the yielded
+/// side at all and still diverge.
 #[test]
-fn annotated_inner_generator_expression_is_already_correct() {
+fn annotated_inner_generator_expression_is_visible_to_the_harness() {
     let codes = strict_codes(
         r#"
 export {};
@@ -265,6 +286,6 @@ wants(d());
     );
     assert!(
         codes.contains(&2345),
-        "an annotated inner generator expression must stay correct: {codes:?}"
+        "an annotated inner generator expression must stay visible: {codes:?}"
     );
 }

--- a/crates/tsz-checker/src/tests/generator_yield_self_similar_nesting_tests.rs
+++ b/crates/tsz-checker/src/tests/generator_yield_self_similar_nesting_tests.rs
@@ -1,0 +1,270 @@
+//! Regression matrix for #16116 item 2, **re-scoped**: an unannotated
+//! generator that yields a value whose type is *the same generator kind as the
+//! container* loses that value's type argument.
+//!
+//! The issue files this as "the inner generator expression's inferred yield
+//! type is lost through one nesting level", which points at the inner
+//! generator's own inference. It is not: the same loss reproduces with **no
+//! inference on the yielded side at all**, from a `declare const` of a fully
+//! written-out `AsyncGenerator` type (`declared_async_generator_operand_*`
+//! below). What actually decides the outcome is whether the operand's
+//! constructor is the *same* alias as the containing generator's:
+//!
+//! | operand type                    | container      | result  |
+//! | ---                             | ---            | ---     |
+//! | `AsyncGenerator[ string ]`      | async `function*` | **lost** |
+//! | `Generator[ string ]`           | sync `function*`  | **lost** |
+//! | `Generator[ string ]`           | async `function*` | correct |
+//! | `AsyncIterable`/`AsyncIterator` | async `function*` | correct |
+//! | `Iterator`/`Set`/`Promise`/`T[]`/object | async `function*` | correct |
+//!
+//! The relation is not at fault either: spelling the expected container type
+//! out by hand and assigning it (`written_out_*_relation_still_reports`)
+//! reports the mismatch in exactly the shape the inferred container should
+//! have had. So the loss is in the *container's inferred yield type*, and it is
+//! specific to a self-similar (same-alias-nested-in-itself) application.
+//!
+//! Every row is oracled against `tsc@7.0.2`
+//! (`--noEmit --strict --pretty false --target es2018 --lib es2018,dom`).
+//! Each negative row feeds the container to a deliberately **wrong**
+//! instantiation, so a missing `TS2345` means the operand's type argument was
+//! degraded rather than contributed. The controls are what make that
+//! inference sound: they pin the same shape one alias away, where tsz is
+//! already correct, so a "fix" that widens or drops types wholesale fails them.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_source_with_libs, load_default_lib_files};
+
+fn strict_codes(source: &str) -> Vec<u32> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|diagnostic| diagnostic.code)
+    .collect()
+}
+
+/// The minimal witness for #16116 item 2, with the issue's inner generator
+/// expression replaced by a `declare const` — no inference on the yielded side
+/// at all, and the defect is unchanged. `tsc` reports TS2345 here.
+#[test]
+#[ignore = "#16116 item 2: a self-similar `AsyncGenerator` operand loses its type argument"]
+fn declared_async_generator_operand_contributes_its_type_argument() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const zzSource: AsyncGenerator<string>;
+declare function wants(h: AsyncGenerator<AsyncGenerator<number>>): void;
+const d = async function* () {
+    yield zzSource;
+};
+wants(d());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "a yielded `AsyncGenerator<string>` must contribute its own type argument: {codes:?}"
+    );
+}
+
+/// The sync twin of the row above. Pins that this is a property of the
+/// self-similar nesting rather than anything async-specific: no `await`, no
+/// `[Symbol.asyncIterator]`, same loss.
+#[test]
+#[ignore = "#16116 item 2: a self-similar `Generator` operand loses its type argument"]
+fn declared_sync_generator_operand_contributes_its_type_argument() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const zzSource: Generator<string>;
+declare function wants(h: Generator<Generator<number>>): void;
+const d = function* () {
+    yield zzSource;
+};
+wants(d());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "a yielded `Generator<string>` must contribute its own type argument: {codes:?}"
+    );
+}
+
+/// The load-bearing control: a **sync** `Generator` operand inside an **async**
+/// container is one alias away from the failing row and is already correct on
+/// `main`. This is the row that localises the defect to same-alias nesting; a
+/// diagnosis that blamed "yielding an iterable" or "yielding a generator"
+/// would predict this fails too.
+#[test]
+fn sync_generator_operand_in_async_container_is_already_correct() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const zzSource: Generator<string>;
+declare function wants(h: AsyncGenerator<Generator<number>>): void;
+const d = async function* () {
+    yield zzSource;
+};
+wants(d());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "a `Generator` operand in an async container must keep its argument: {codes:?}"
+    );
+}
+
+/// `AsyncIterable` is the same structural shape as `AsyncGenerator` minus the
+/// generator members, and is correct today.
+#[test]
+fn async_iterable_operand_is_already_correct() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const zzSource: AsyncIterable<string>;
+declare function wants(h: AsyncGenerator<AsyncIterable<number>>): void;
+const d = async function* () {
+    yield zzSource;
+};
+wants(d());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "an `AsyncIterable` operand must keep its argument: {codes:?}"
+    );
+}
+
+/// A non-iterable generic operand: rules out "any nested generic argument is
+/// dropped".
+#[test]
+fn promise_operand_is_already_correct() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const zzSource: Promise<string>;
+declare function wants(h: AsyncGenerator<Promise<number>>): void;
+const d = async function* () {
+    yield zzSource;
+};
+wants(d());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "a `Promise` operand must keep its argument: {codes:?}"
+    );
+}
+
+/// The container's *own* yield argument is not degraded — only the operand's
+/// nested one. Feeding the same container to a target whose yield type is not
+/// a generator at all still reports, which is why the failing rows above
+/// cannot be explained by "the whole inferred container collapsed to `any`".
+#[test]
+fn self_similar_container_still_rejects_a_non_generator_yield_type() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const zzSource: AsyncGenerator<string>;
+declare function wants(h: AsyncGenerator<{ x: number }>): void;
+const d = async function* () {
+    yield zzSource;
+};
+wants(d());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "the container's own yield type must still be a generator: {codes:?}"
+    );
+}
+
+/// The relation is exonerated: the type the failing row *should* have inferred,
+/// written out by hand, is rejected against the same target. Whatever is lost
+/// is lost while building the container's yield type, not while comparing it.
+#[test]
+fn written_out_self_similar_relation_still_reports() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const a: AsyncGenerator<AsyncGenerator<string>, void, unknown>;
+declare function wants(h: AsyncGenerator<AsyncGenerator<number>>): void;
+wants(a);
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "the written-out self-similar relation must report: {codes:?}"
+    );
+}
+
+/// The sync half of the exoneration above.
+#[test]
+fn written_out_sync_self_similar_relation_still_reports() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const a: Generator<Generator<string>, void, unknown>;
+declare function wants(h: Generator<Generator<number>>): void;
+wants(a);
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "the written-out sync self-similar relation must report: {codes:?}"
+    );
+}
+
+/// A non-nested container is correct, so the defect needs the nesting — this is
+/// the depth-1 baseline the failing rows are the depth-2 form of.
+#[test]
+fn non_nested_container_is_already_correct() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const zzSource: AsyncGenerator<string>;
+declare function wants(h: AsyncGenerator<number>): void;
+const d = async function* () {
+    yield* zzSource;
+};
+wants(d());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "the non-nested delegate row must stay correct: {codes:?}"
+    );
+}
+
+/// An **annotated** operand-producing generator expression is unaffected, which
+/// is why the issue's original framing (inner-generator inference) looked
+/// plausible: annotating the inner makes the row pass. It passes because the
+/// annotated inner's type reaches the container by a different construction
+/// path, not because inference of the inner was ever the problem — the
+/// `declare const` rows above have no inner inference and still fail.
+#[test]
+fn annotated_inner_generator_expression_is_already_correct() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare function wants(h: AsyncGenerator<AsyncGenerator<number>>): void;
+const d = async function* () {
+    yield (async function* (): AsyncGenerator<string> {
+        yield "a";
+    })();
+};
+wants(d());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "an annotated inner generator expression must stay correct: {codes:?}"
+    );
+}


### PR DESCRIPTION
Refs #16116 (item 2). Test-only. **Rewritten at head `2d204b1` after @mohsen1 / Quartz's review** — the first head asserted a checker defect that does not exist. See the review reply for the full retraction; this body describes what the PR now says.

## What is actually true

**#16116 item 2 is not a compiler defect.** Run the issue's own repro through the release CLI and tsz reports the same `TS2345` `tsc` does:

```
$ tsz --noEmit --strict --pretty false item2.ts
item2.ts(9,7): error TS2345: Argument of type '{ next(..._: [] | [unknown]):
  Promise< IteratorResult< { ... [Symbol.asyncIterator](): AsyncGenerator< string,
  void, unknown >; }, void > >; ... }' is not assignable to parameter of type
  'AsyncGenerator< AsyncGenerator< number, any, any >, any, any >'.
```

The `AsyncGenerator< string, void, unknown >` in that rendering is the inner generator's type argument, intact. Nothing was degraded to `any`; no yield contribution was lost; the container inferred correctly. The same holds for the named-`const` form, the `declare const` form, and the sync twin.

**The divergence is `check_source_with_libs`.** Same fixtures, harness vs release CLI:

| yielded operand | container | CLI | harness |
| --- | --- | --- | --- |
| `AsyncGenerator< string >` | `async function*` | TS2345 | **silent** |
| `Generator< string >` | `function*` | TS2345 | **silent** |
| `Generator< string >` | `async function*` | TS2345 | TS2345 |
| `AsyncIterable` / `AsyncIterator` / `Iterator` / `Set` / `Iterable` | `async function*` | TS2345 | TS2345 |
| `Promise< string >`, `string[]`, `{ a: string }` | `async function*` | TS2345 | TS2345 |

The harness loses the diagnostic on exactly the **self-similar** rows — where the yielded operand's alias is the same alias as the container's. One alias away (`Generator` inside an *async* container) it agrees with the CLI. The gap is narrow and structural, not a blanket weakness.

## Structural rule

When the unit harness checks a program in which a generator's inferred yield type is an application of the same `Generator` / `AsyncGenerator` alias as the container itself, `tsz`'s CLI reports the argument mismatch and `tsc` reports it; `check_source_with_libs` reports nothing. Owner: the test harness (`crates/tsz-checker/src/test_utils.rs`), not the checker and not the solver.

## What this PR contains

- Two `#[ignore]`d rows asserting the CLI's (and `tsc`'s) answer, whose ignore reason states in full that they are red **for a harness reason** and that fixing a checker or solver path will not turn them green. They go live when the harness resolves self-similar generator applications the way a real program does.
- Eight live controls, green today, that measure the boundary of the gap — including the one-alias-away row that localises it and the written-out relation, which reports correctly *inside the harness*, exonerating the subtype check.

This is Quartz's second suggested option. Their first (assert on the rendered message) is not available here: the harness returns an empty diagnostic vector, so there is no message to assert on. That distinction is itself part of what the ignore reason records.

## Goal
Goal: hold

## Verification

- `cargo test -p tsz-checker --lib generator_yield_self_similar`: **8 passed, 2 ignored**.
- Same suite `--ignored`: **0 passed, 2 failed**, and the failures are exactly the two documented rows — nothing else moves.
- Release CLI cross-check on every row (`cargo build --release -p tsz-cli --bin tsz`, then `tsz --noEmit --strict --pretty false`): TS2345 on all eleven negative fixtures including both ignored rows, clean on the correct-instantiation control.
- `cargo fmt --all`: clean. `cargo clippy -p tsz-checker --lib --tests`: clean.
- Conformance / emit / fourslash **not run**: test-only diff, no production code, no baseline or accepted-regression entry touched. It cannot move a corpus row.

Angle brackets are spaced in this body per the board's round-trip stripping gotcha; the source file carries the real spellings.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Andesite