### PR TITLE
fix(release): stop the npm publish lane reporting green while publishing nothing (#16126)

### DIFF
--- a/.github/workflows/daily-release.yml
+++ b/.github/workflows/daily-release.yml
@@ -336,8 +336,20 @@ jobs:
           # Belt-and-braces: even when the PAT is configured, explicit dispatch
           # makes the trigger source legible and avoids the GITHUB_TOKEN
           # cascade-suppression edge case. Both workflows accept a `tag` input.
-          gh workflow run release.yml --ref "${TAG}" -f tag="${TAG}" || true
-          gh workflow run npm-publish.yml --ref "${TAG}" -f tag="${TAG}" || true
+          #
+          # A failed dispatch stays non-fatal on purpose -- pushing the tag above
+          # already triggers both workflows via their `on: push: tags:` filter,
+          # so this is redundancy, not the only path. It must not be *silent*
+          # though (#16126): record the outcome so a release that dispatched
+          # nothing is legible from the run summary instead of reporting green.
+          for wf in release.yml npm-publish.yml; do
+            if gh workflow run "$wf" --ref "${TAG}" -f tag="${TAG}"; then
+              echo "- dispatched \`${wf}\`" >> "${GITHUB_STEP_SUMMARY}"
+            else
+              echo "- :warning: dispatch of \`${wf}\` FAILED (tag-push trigger is the fallback)" \
+                >> "${GITHUB_STEP_SUMMARY}"
+            fi
+          done
 
       - name: Summary
         if: always()

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -40,6 +40,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y shellcheck
       - name: shellcheck install.sh
         run: shellcheck -S warning scripts/install.sh
+      - name: shellcheck release publish helpers
+        run: shellcheck -S warning -x scripts/build/npm-publish-lib.sh scripts/build/test-npm-publish-lib.sh
+      - name: npm publish helper unit tests
+        run: bash scripts/build/test-npm-publish-lib.sh
       - name: powershell parse install.ps1
         shell: pwsh
         run: |

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -187,6 +187,9 @@ jobs:
       - name: Assemble package manifests
         run: scripts/build/build-npm-packages.sh --all --native-only --skip-build
 
+      # A dry run never performs the PUT that actually fails, so this step can
+      # confirm the tarballs are well-formed but cannot confirm we may publish
+      # them. The preflight below covers the half it structurally cannot.
       - name: Pack-check packages
         shell: bash
         run: |
@@ -195,24 +198,38 @@ jobs:
             (cd "$pkg" && npm publish --dry-run --access public)
           done
 
-      - name: Publish packages
+      - name: Preflight npm auth
         shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
-          publish_if_needed() {
-            local pkg_dir="$1"
-            local name version
-            name="$(node -p "require('./${pkg_dir}/package.json').name")"
-            version="$(node -p "require('./${pkg_dir}/package.json').version")"
-            if npm view "${name}@${version}" version >/dev/null 2>&1; then
-              echo "${name}@${version} already exists; skipping"
-              return 0
-            fi
-            echo "Publishing ${name}@${version}"
-            (cd "$pkg_dir" && npm publish --access public --provenance)
-          }
+          source scripts/build/npm-publish-lib.sh
+          npm_clear_placeholder_auth
+          npm_auth_preflight
+
+      - name: Publish packages
+        shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          source scripts/build/npm-publish-lib.sh
+          npm_clear_placeholder_auth
 
           for pkg in npm/@mohsen-azimi/try-tsz-*; do
-            publish_if_needed "$pkg"
+            npm_publish_if_needed "$pkg"
           done
-          publish_if_needed npm/try-tsz
+          npm_publish_if_needed npm/try-tsz
+
+      # The guard that would have caught #16126 on its first occurrence rather
+      # than 43 versions later: assert every package is readable at its own
+      # version before this job is allowed to report success.
+      - name: Verify published versions
+        shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          source scripts/build/npm-publish-lib.sh
+          npm_verify_published npm/@mohsen-azimi/try-tsz-* npm/try-tsz

--- a/scripts/build/npm-publish-lib.sh
+++ b/scripts/build/npm-publish-lib.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# Publish helpers for .github/workflows/npm-publish.yml.
+#
+# This file only defines functions; sourcing it has no side effects, so the
+# behaviour below can be exercised directly by test-npm-publish-lib.sh with a
+# stub `npm` on PATH instead of only ever running inside a release.
+#
+# Background (#16126): npm-publish.yml reported success for two months while
+# publishing nothing. Three separate mechanisms hid it, and each has a
+# counterpart here:
+#
+#   1. `npm publish --dry-run` never performs the PUT that fails, so the
+#      pack-check step structurally could not catch an auth problem.
+#      -> npm_auth_preflight asserts a usable credential up front.
+#   2. `publish_if_needed` treated *any* failing `npm view` as "not published
+#      yet", so the lookup failure that signalled the problem also disarmed the
+#      guard that would have reported it.
+#      -> npm_registry_version_state separates "absent" from "unknown", and
+#         only "absent" is allowed to proceed to a publish.
+#   3. Nothing ever asserted that the versions actually landed.
+#      -> npm_verify_published re-reads every package from the registry.
+
+# Registry the release lane publishes to. Overridable for tests.
+NPM_REGISTRY="${NPM_REGISTRY:-https://registry.npmjs.org}"
+
+# Read a field out of a package directory's package.json without needing node's
+# module resolution to agree with the caller's cwd.
+npm_pkg_field() {
+  local pkg_dir="$1" field="$2"
+  node -p "JSON.parse(require('fs').readFileSync('${pkg_dir}/package.json','utf8')).${field}"
+}
+
+# `actions/setup-node` with `registry-url:` writes an .npmrc containing
+#     //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
+# and npm expands that variable when it reads the file. When NODE_AUTH_TOKEN is
+# unset the line still counts as a configured credential for the registry, so
+# npm sends an empty bearer token and never attempts the OIDC exchange that
+# trusted publishing needs -- and an unauthenticated PUT to a package that
+# already exists is answered 404, not 403.
+#
+# Strip only the literal, unexpanded placeholder, and only when the variable is
+# genuinely unset. A real token is never touched.
+npm_clear_placeholder_auth() {
+  local npmrc="${1:-${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}}"
+  if [ -n "${NODE_AUTH_TOKEN:-}" ]; then
+    return 0
+  fi
+  if [ ! -f "$npmrc" ]; then
+    return 0
+  fi
+  if ! grep -q ':_authToken=\${NODE_AUTH_TOKEN}' "$npmrc"; then
+    return 0
+  fi
+  echo "npmrc: dropping unexpanded _authToken placeholder so OIDC can run ($npmrc)"
+  local tmp
+  tmp="$(mktemp)"
+  grep -v ':_authToken=\${NODE_AUTH_TOKEN}' "$npmrc" >"$tmp" || true
+  mv "$tmp" "$npmrc"
+}
+
+# Fail loudly, before any package is touched, when the job has no way to
+# authenticate. Without this the first symptom is an E404 on a PUT, which reads
+# like a missing package rather than a missing credential.
+npm_auth_preflight() {
+  if [ -n "${NODE_AUTH_TOKEN:-}" ]; then
+    echo "npm auth: using NODE_AUTH_TOKEN"
+    return 0
+  fi
+  if [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
+    echo "npm auth: no NODE_AUTH_TOKEN; relying on OIDC trusted publishing"
+    return 0
+  fi
+  cat >&2 <<'EOF'
+npm auth: no usable credential.
+
+  NODE_AUTH_TOKEN is empty and no OIDC id-token is available
+  (ACTIONS_ID_TOKEN_REQUEST_URL is unset).
+
+  npm would answer the publish PUT with a 404 that looks like a missing
+  package rather than a missing credential -- see #16126.
+
+Fix one of:
+  * grant the job `id-token: write` and register the trusted publisher
+    (scripts/build/setup-npm-trusted-publishers.sh), or
+  * set NODE_AUTH_TOKEN from a repository secret on the publish step.
+EOF
+  return 1
+}
+
+# Echo one of: published | absent | unknown
+#
+# The distinction is the point. `npm view` failing because the registry is
+# unreachable, or because the caller is unauthenticated, is NOT evidence that a
+# version needs publishing.
+npm_registry_version_state() {
+  local name="$1" version="$2"
+  local out status
+  set +e
+  out="$(npm view "${name}@${version}" version --registry "$NPM_REGISTRY" 2>&1)"
+  status=$?
+  set -e
+
+  if [ "$status" -eq 0 ]; then
+    # An existing package with a missing version exits 0 and prints nothing.
+    if [ -n "$(printf '%s' "$out" | tr -d '[:space:]')" ]; then
+      echo published
+    else
+      echo absent
+    fi
+    return 0
+  fi
+
+  # E404 is the registry positively reporting "no such package or version".
+  if printf '%s' "$out" | grep -qE 'E404|404 Not Found'; then
+    echo absent
+    return 0
+  fi
+
+  echo "npm view ${name}@${version} failed (exit ${status}):" >&2
+  printf '%s\n' "$out" >&2
+  echo unknown
+}
+
+npm_publish_if_needed() {
+  local pkg_dir="$1"
+  local name version state
+  name="$(npm_pkg_field "$pkg_dir" name)"
+  version="$(npm_pkg_field "$pkg_dir" version)"
+
+  state="$(npm_registry_version_state "$name" "$version")"
+  case "$state" in
+    published)
+      echo "${name}@${version} already exists; skipping"
+      return 0
+      ;;
+    absent)
+      echo "Publishing ${name}@${version}"
+      (cd "$pkg_dir" && npm publish --access public --provenance)
+      ;;
+    *)
+      echo "Refusing to publish ${name}@${version}: registry lookup was inconclusive." >&2
+      echo "Treating an unreadable registry as 'needs publishing' is what hid #16126." >&2
+      return 1
+      ;;
+  esac
+}
+
+# The guard that would have caught #16126 on its first occurrence: after the
+# publish loop, every package must actually be readable at its own version.
+npm_verify_published() {
+  local failed=0 pkg_dir name version state
+  for pkg_dir in "$@"; do
+    name="$(npm_pkg_field "$pkg_dir" name)"
+    version="$(npm_pkg_field "$pkg_dir" version)"
+    state="$(npm_registry_version_state "$name" "$version")"
+    if [ "$state" = "published" ]; then
+      echo "verified ${name}@${version}"
+    else
+      echo "NOT PUBLISHED: ${name}@${version} (registry says: ${state})" >&2
+      failed=1
+    fi
+  done
+  if [ "$failed" -ne 0 ]; then
+    echo "Release did not publish every package; failing the job." >&2
+    return 1
+  fi
+  echo "all packages verified on ${NPM_REGISTRY}"
+}

--- a/scripts/build/test-npm-publish-lib.sh
+++ b/scripts/build/test-npm-publish-lib.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# Exercise scripts/build/npm-publish-lib.sh against a stub `npm`.
+#
+# The release lane's publish step has no local suite -- that is precisely why
+# #16126 went unnoticed for 43 versions. Every behaviour asserted here is one
+# that a release would otherwise only exercise in production.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/build/npm-publish-lib.sh
+source "$SCRIPT_DIR/npm-publish-lib.sh"
+
+tmp_root="$(mktemp -d)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+stub_bin="$tmp_root/bin"
+mkdir -p "$stub_bin"
+PATH="$stub_bin:$PATH"
+export PATH
+
+pass=0
+fail=0
+
+check() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    pass=$((pass + 1))
+    echo "  ok   $label"
+  else
+    fail=$((fail + 1))
+    echo "  FAIL $label: expected '$expected', got '$actual'"
+  fi
+}
+
+# Install a stub `npm` whose `view` behaviour is driven by NPM_STUB_MODE and
+# whose `publish` invocations are appended to $tmp_root/published.
+install_npm_stub() {
+  cat >"$stub_bin/npm" <<'STUB'
+#!/bin/bash
+case "$1" in
+  view)
+    case "${NPM_STUB_MODE:-published}" in
+      published)     echo "1.2.3"; exit 0 ;;
+      missing-ver)   exit 0 ;;                                   # package exists, version does not
+      e404)          echo "npm error code E404" >&2; exit 1 ;;
+      unauthorized)  echo "npm error code E401 Unauthorized" >&2; exit 1 ;;
+      network)       echo "npm error network ETIMEDOUT" >&2; exit 1 ;;
+    esac
+    ;;
+  publish)
+    echo "$PWD" >>"$NPM_STUB_PUBLISH_LOG"
+    exit "${NPM_STUB_PUBLISH_STATUS:-0}"
+    ;;
+esac
+exit 0
+STUB
+  chmod +x "$stub_bin/npm"
+}
+install_npm_stub
+
+export NPM_STUB_PUBLISH_LOG="$tmp_root/published"
+: >"$NPM_STUB_PUBLISH_LOG"
+
+make_pkg() {
+  local dir="$tmp_root/$1" name="$2" version="$3"
+  mkdir -p "$dir"
+  printf '{"name":"%s","version":"%s"}\n' "$name" "$version" >"$dir/package.json"
+  echo "$dir"
+}
+
+echo "npm_registry_version_state"
+for mode_expect in "published:published" "missing-ver:absent" "e404:absent" \
+                   "unauthorized:unknown" "network:unknown"; do
+  mode="${mode_expect%%:*}"
+  expect="${mode_expect##*:}"
+  actual="$(NPM_STUB_MODE="$mode" npm_registry_version_state pkg 1.0.0 2>/dev/null)"
+  check "$mode -> $expect" "$expect" "$actual"
+done
+
+echo
+echo "npm_publish_if_needed"
+pkg="$(make_pkg pkgA @scope/thing 0.1.59)"
+
+: >"$NPM_STUB_PUBLISH_LOG"
+NPM_STUB_MODE=published npm_publish_if_needed "$pkg" >/dev/null 2>&1
+check "already published -> no publish" "0" "$(wc -l <"$NPM_STUB_PUBLISH_LOG" | tr -d ' ')"
+
+: >"$NPM_STUB_PUBLISH_LOG"
+NPM_STUB_MODE=e404 npm_publish_if_needed "$pkg" >/dev/null 2>&1
+check "absent -> publishes once" "1" "$(wc -l <"$NPM_STUB_PUBLISH_LOG" | tr -d ' ')"
+
+# The #16126 regression guard: an unreadable registry must NOT be read as
+# "needs publishing". Before this fix the loop blundered into a doomed PUT.
+: >"$NPM_STUB_PUBLISH_LOG"
+NPM_STUB_MODE=unauthorized npm_publish_if_needed "$pkg" >/dev/null 2>&1
+check "unauthorized -> refuses to publish" "0" "$(wc -l <"$NPM_STUB_PUBLISH_LOG" | tr -d ' ')"
+NPM_STUB_MODE=unauthorized npm_publish_if_needed "$pkg" >/dev/null 2>&1
+check "unauthorized -> non-zero exit" "1" "$?"
+
+echo
+echo "npm_verify_published"
+pkg2="$(make_pkg pkgB @scope/other 0.1.59)"
+NPM_STUB_MODE=published npm_verify_published "$pkg" "$pkg2" >/dev/null 2>&1
+check "all present -> exit 0" "0" "$?"
+NPM_STUB_MODE=e404 npm_verify_published "$pkg" "$pkg2" >/dev/null 2>&1
+check "any absent -> exit 1" "1" "$?"
+NPM_STUB_MODE=network npm_verify_published "$pkg" >/dev/null 2>&1
+check "unreadable -> exit 1" "1" "$?"
+
+echo
+echo "npm_auth_preflight"
+( NODE_AUTH_TOKEN=tok; unset ACTIONS_ID_TOKEN_REQUEST_URL; npm_auth_preflight >/dev/null 2>&1 )
+check "token present -> ok" "0" "$?"
+( unset NODE_AUTH_TOKEN; ACTIONS_ID_TOKEN_REQUEST_URL=https://example.invalid; npm_auth_preflight >/dev/null 2>&1 )
+check "oidc available -> ok" "0" "$?"
+( unset NODE_AUTH_TOKEN; unset ACTIONS_ID_TOKEN_REQUEST_URL; npm_auth_preflight >/dev/null 2>&1 )
+check "neither -> fails" "1" "$?"
+
+echo
+echo "npm_clear_placeholder_auth"
+npmrc="$tmp_root/.npmrc"
+
+printf '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}\nregistry=https://registry.npmjs.org/\n' >"$npmrc"
+( unset NODE_AUTH_TOKEN; npm_clear_placeholder_auth "$npmrc" >/dev/null 2>&1 )
+check "unset token -> placeholder stripped" "0" "$(grep -c '_authToken' "$npmrc")"
+check "unset token -> registry line kept" "1" "$(grep -c '^registry=' "$npmrc")"
+
+printf '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}\n' >"$npmrc"
+( NODE_AUTH_TOKEN=real npm_clear_placeholder_auth "$npmrc" >/dev/null 2>&1 )
+check "token set -> file untouched" "1" "$(grep -c '_authToken' "$npmrc")"
+
+printf '//registry.npmjs.org/:_authToken=npm_realtokenvalue\n' >"$npmrc"
+( unset NODE_AUTH_TOKEN; npm_clear_placeholder_auth "$npmrc" >/dev/null 2>&1 )
+check "literal token -> never stripped" "1" "$(grep -c '_authToken' "$npmrc")"
+
+echo
+echo "passed: $pass, failed: $fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
`npm-publish.yml` has failed on every run since **2026-06-04** and the release lane reported success throughout. This does not fix the credential itself — that is an account action, see *Not fixed here* — it makes the lane incapable of reporting success while publishing nothing.

## Two corrections to #16126, both measured against the live registry

**1. The outage is 43 versions, not 4.**

```
npm view try-tsz versions   ["0.1.9","0.1.11","0.1.12","0.1.13","0.1.14","0.1.15","0.1.16"]
npm view try-tsz time       0.1.16 -> 2026-06-04T10:48:38Z
```

Last successful publish was 2026-06-04. `0.1.17`–`0.1.59` are all tagged and unpublished.

**2. The 404 is not a scope-create permission problem.**

```
npm view @mohsen-azimi/try-tsz-darwin-arm64 versions
  ["0.1.9","0.1.11","0.1.12","0.1.13","0.1.14","0.1.15","0.1.16"]   # identical set
```

The issue reasons that `404 on PUT` is npm refusing to *create* a scoped package, and asks whether the platform packages were meant to be unscoped. The scoped platform package **already exists with seven published versions**, put there by this same workflow — so the scoped/unscoped split is deliberate and is not the bug. A `PUT` 404 against an *existing* package means the caller is unauthenticated or unauthorised; npm answers 404 rather than 403 in both cases.

(Corollary: `@mohsen-azimi/tsz-*` returns a genuine `404 GET` — it has never published anything, so its registry state is not a second data point about token permissions.)

## Structural rule

When a release job cannot read or write the registry, the release must fail loudly **at the credential**, not silently at the last package; and a job that published nothing must never exit 0. Owner layer is the release lane itself (`.github/workflows` + `scripts/build`) — no compiler code is touched.

## What actually changed

Three mechanisms hid this. Each is addressed where it lives:

| # | Mechanism | Fix |
|---|---|---|
| 1 | `npm publish --dry-run` never performs the PUT that fails, so `Pack-check` structurally could not catch an auth problem | `npm_auth_preflight` asserts a usable credential before any package is touched, and names both remedies in the failure text |
| 2 | `publish_if_needed` treated *any* failing `npm view` as "not published yet" — the lookup failure that signalled the problem also disarmed the guard that would report it | `npm_registry_version_state` separates `absent` (registry says E404) from `unknown` (auth/network). Only `absent` may proceed to a publish |
| 3 | Nothing asserted the versions actually landed | `npm_verify_published` re-reads every package at its own version and fails the job if any is missing |

**Plus the most likely root cause, fixed.** `actions/setup-node` with `registry-url:` writes an `.npmrc` containing an `_authToken` line referencing the `NODE_AUTH_TOKEN` variable. Nothing in this repo has ever set that variable (`grep -rn 'NODE_AUTH_TOKEN|NPM_TOKEN' .github/ scripts/` → no matches), and `scripts/build/setup-npm-trusted-publishers.sh` shows OIDC trusted publishing is the intended mechanism. With the variable unset the line still counts as a *configured credential* for the registry, so npm sends an empty bearer token and never attempts the OIDC exchange — producing exactly the observed failure. `npm_clear_placeholder_auth` drops only the literal unexpanded placeholder, and only when the variable is genuinely unset; a real token is never touched (pinned by two tests). `NODE_AUTH_TOKEN` is also now wired from `secrets.NPM_TOKEN`, so a token path works if one is configured and is a no-op if not.

I cannot confirm this hypothesis without a release run — the registry's server-side trusted-publisher state is not visible from here. It is stated as the leading candidate, not as proven. Items 1–3 are correct regardless of which credential path is intended.

`daily-release.yml`'s dispatch stays **non-fatal on purpose** — pushing the tag already triggers both workflows via their `on: push: tags:` filter, so `gh workflow run` is redundancy, not the only path. Making it fatal would be wrong. It no longer stays *silent*: the outcome is recorded in the step summary.

The publish logic moves out of inline YAML into a sourceable library, so it has a local signal at all.

## Goal
Goal: hold

## Verification

- `bash scripts/build/test-npm-publish-lib.sh` → **19 passed, 0 failed** (new suite; stubs `npm` on `PATH`, no network, no registry writes)
- `shellcheck -S warning -x scripts/build/npm-publish-lib.sh scripts/build/test-npm-publish-lib.sh` → clean (caught one real `SC2034` during development, fixed)
- `yaml.safe_load` on all three edited workflows → parse clean
- Both new checks wired into `install-test.yml`'s existing `shellcheck + powershell parse` job, so they run in CI rather than only here

**Two-sided against the pre-fix code.** The old `publish_if_needed`, lifted verbatim from `npm-publish.yml:207` and run against a stub registry returning `E401`:

```
OLD logic, unauthorized registry -> publish attempts: 1   exit 0
NEW logic, unauthorized registry -> publish attempts: 0   exit 1
```

So the `unauthorized` rows (refuses to publish; non-zero exit) are genuinely red without this change, not merely green with it.

**Not verified, and stated plainly:** no compiler suites were run because no compiler code is touched (diff is 3 workflow files + 2 new shell scripts). The end-to-end publish path cannot be exercised without an actual release — the first real release after this lands is the test, and it will now fail loudly if the credential is still wrong instead of reporting green.

## Not fixed here

The credential itself. Whether the fix is registering the trusted publisher (`scripts/build/setup-npm-trusted-publishers.sh`) or adding an `NPM_TOKEN` secret, that is an action on the npm account and cannot be done from a PR. After this lands, the next release either publishes or fails loudly — with `npm auth: no usable credential` from the preflight, or a `NOT PUBLISHED` line naming the package and version from the verify step. Either way it stops being invisible.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Schist