### PR TITLE
refactor(checker): extend Round 1 evidence trust to nested type-param positions (#16018)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2576,3 +2576,6 @@ path = "tests/class_member_body_function_boundary_tests.rs"
 [[test]]
 name = "conditional_extends_redundant_intersection_identity_tests"
 path = "tests/conditional_extends_redundant_intersection_identity_tests.rs"
+[[test]]
+name = "issue_16018_nested_position_evidence_tests"
+path = "tests/issue_16018_nested_position_evidence_tests.rs"

--- a/crates/tsz-checker/src/query_boundaries/generic_instantiation.rs
+++ b/crates/tsz-checker/src/query_boundaries/generic_instantiation.rs
@@ -52,6 +52,22 @@ pub(crate) fn type_contains_type_parameter_binder(
     tsz_solver::visitor::contains_type_parameter_binder(db, type_id, type_param)
 }
 
+/// Infer concrete bindings for a set of type parameters by structurally
+/// matching each `(declared type, concrete type)` pair, reusing the solver's
+/// call-resolution inference engine.
+///
+/// This is the boundary used to recover a type parameter's binding when it
+/// sits nested inside a compound declared type (a generic alias or wrapper
+/// such as `Array<T>`), where a direct parameter/type-parameter identity
+/// check cannot recover it.
+pub(crate) fn infer_type_arguments_from_param_args(
+    db: &dyn QueryDatabase,
+    type_params: &[TypeParamInfo],
+    param_arg_pairs: &[(TypeId, TypeId)],
+) -> Vec<(tsz_common::Atom, TypeId)> {
+    tsz_solver::computation::infer_type_arguments_from_param_args(db, type_params, param_arg_pairs)
+}
+
 // ── FunctionShape transformation helpers ──
 
 /// Apply a `TypeSubstitution` to every type component in a `FunctionShape`.

--- a/crates/tsz-checker/src/types/computation/call_inference/unknown_callback.rs
+++ b/crates/tsz-checker/src/types/computation/call_inference/unknown_callback.rs
@@ -303,11 +303,13 @@ impl<'a> CheckerState<'a> {
     /// That answer can be more informed than the raw per-argument
     /// `arg_types` the heuristic reads — e.g. a sibling argument that itself
     /// failed to check cleanly still leaves the OTHER, correctly computed
-    /// parameter substitution behind. Only bare positions are handled: a
-    /// type parameter nested inside a compound parameter type (`Array<T>`)
-    /// cannot be recovered from the substituted slot without structural
-    /// unification, so those sibling positions still fall through to the
-    /// heuristic below.
+    /// parameter substitution behind. A parameter slot declared as a
+    /// compound type mentioning `type_param` (`Array<T>`, a generic alias or
+    /// wrapper) is handled the same way, structurally: `type_param` cannot
+    /// be read off the slot by identity, so it is recovered by matching the
+    /// declared type against the finalized concrete type through the same
+    /// structural-unification primitive `predicate_resolution.rs` already
+    /// uses to instantiate a nested type-predicate target.
     fn bare_type_param_position_resolved_by_round1(
         &self,
         shape: &FunctionShape,
@@ -324,10 +326,6 @@ impl<'a> CheckerState<'a> {
                 if position == current_index {
                     return None;
                 }
-                let bare_type_param = common::type_param_info(self.ctx.types, param.type_id)?;
-                if !bare_type_param.is_same_binder(type_param) {
-                    return None;
-                }
                 let resolved = finalized.get(position).copied().flatten()?;
                 if resolved == TypeId::UNKNOWN
                     || resolved == TypeId::ERROR
@@ -336,8 +334,55 @@ impl<'a> CheckerState<'a> {
                 {
                     return None;
                 }
-                Some(resolved)
+                if let Some(bare_type_param) =
+                    common::type_param_info(self.ctx.types, param.type_id)
+                {
+                    return bare_type_param
+                        .is_same_binder(type_param)
+                        .then_some(resolved);
+                }
+                self.nested_type_param_resolved_by_structural_match(
+                    param.type_id,
+                    resolved,
+                    type_param,
+                )
             })
+    }
+
+    /// Recover `type_param`'s binding from a compound declared parameter
+    /// type (e.g. `Array<T>`) by structurally matching it against the
+    /// corresponding finalized concrete type (e.g. `Array<string>`) Round 1
+    /// already computed. Returns `None` when `declared` does not mention
+    /// `type_param` at all, or when the structural match yields nothing
+    /// usable (still a type parameter, `unknown`, `error`, or unresolved
+    /// `infer`).
+    fn nested_type_param_resolved_by_structural_match(
+        &self,
+        declared: TypeId,
+        resolved: TypeId,
+        type_param: tsz_solver::TypeParamInfo,
+    ) -> Option<TypeId> {
+        if !crate::query_boundaries::generic_instantiation::type_contains_type_parameter_binder(
+            self.ctx.types,
+            declared,
+            type_param,
+        ) {
+            return None;
+        }
+        let bindings =
+            crate::query_boundaries::generic_instantiation::infer_type_arguments_from_param_args(
+                self.ctx.types,
+                std::slice::from_ref(&type_param),
+                &[(declared, resolved)],
+            );
+        bindings.into_iter().find_map(|(name, inferred)| {
+            (name == type_param.name
+                && inferred != TypeId::UNKNOWN
+                && inferred != TypeId::ERROR
+                && !common::contains_infer_types(self.ctx.types, inferred)
+                && !common::contains_type_parameters(self.ctx.types, inferred))
+            .then_some(inferred)
+        })
     }
 
     /// Positions of a callback argument's own parameters that carry an

--- a/crates/tsz-checker/tests/issue_16018_nested_position_evidence_tests.rs
+++ b/crates/tsz-checker/tests/issue_16018_nested_position_evidence_tests.rs
@@ -1,0 +1,123 @@
+//! Regression tests for [issue #16018]: `bare_type_param_position_resolved_by_round1`
+//! (`crates/tsz-checker/src/types/computation/call_inference/unknown_callback.rs`,
+//! introduced in #16084) only consulted Round 1's own finalized substitution
+//! when a sibling parameter position was declared as a *bare* type-parameter
+//! reference (`x: T`, no nesting) — its own doc comment named a type
+//! parameter nested inside a compound parameter type (`Array<T>`, a generic
+//! alias or wrapper) as unhandled, falling through to the narrower
+//! `argument_provides_type_param_evidence` argument-shape heuristic instead.
+//!
+//! Structural rule: when a sibling parameter position is declared as a
+//! compound type mentioning `T` and the call's own `finalized_contextual_param_types`
+//! already resolved that position to a fully concrete type, `tsc`'s behavior
+//! follows that resolved value regardless of whether the slot's declared
+//! shape is bare or nested; tsz's recheck should trust it the same way,
+//! recovering `T`'s binding via the same structural-unification primitive
+//! (`infer_type_arguments_from_param_args`) `predicate_resolution.rs` already
+//! uses to instantiate a type-predicate target nested inside a wrapper type.
+//!
+//! This is a generalization of #16084's bare-position fix, not a
+//! newly-observed diagnostic flip: the non-callback and callback-return/
+//! -annotated-parameter branches of `argument_provides_type_param_evidence`
+//! already perform a full structural `type_contains_type_parameter_binder`
+//! containment check (nested-safe) rather than a bare-identity check, so most
+//! nested-position evidence was already recognized through that path. The
+//! tests below pin the new code path's behavior — including the case it was
+//! written for (a sibling position whose declared type is nested) — and its
+//! negative controls, so the removed `bare`-only restriction cannot silently
+//! regress a genuinely-uninferred case into a suppressed diagnostic.
+//!
+//! [issue #16018]: https://github.com/tsz-org/tsz/issues/16018
+
+fn compile_and_get_diagnostics(source: &str) -> Vec<(u32, String)> {
+    tsz_checker::test_utils::check_source_code_messages(source)
+}
+
+fn assert_no_ts18046(diagnostics: &[(u32, String)], context: &str) {
+    assert!(
+        diagnostics.iter().all(|(code, _)| *code != 18046),
+        "Did not expect TS18046 in {context}. Got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn nested_array_sibling_seeds_type_param_for_callback() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare function ap<I>(seed: I[], use: (v: I) => void): void;
+declare const seed: { field: number }[];
+ap(seed, item => { item.field; });
+"#,
+    );
+    assert_no_ts18046(&diagnostics, "nested Array<I> sibling seeds I");
+}
+
+#[test]
+fn nested_array_sibling_seeds_type_param_with_renamed_binder() {
+    // Same shape with `J`/`use`/`v` renamed — proves the rule is structural,
+    // not keyed on a specific identifier (per CLAUDE.md's anti-hardcoding
+    // gate).
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare function apply<J>(xs: J[], run: (w: J) => void): void;
+declare const xs: { member: string }[];
+apply(xs, w => { w.member; });
+"#,
+    );
+    assert_no_ts18046(&diagnostics, "renamed nested type parameter J");
+}
+
+#[test]
+fn nested_wrapper_object_sibling_seeds_type_param() {
+    // The sibling's declared type is a wrapper object (`{ value: T }`), not
+    // an array — exercises the general structural match, not just `Array<T>`.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare function withDefault<T>(box: { value: T }, use: (v: T) => void): void;
+declare const box: { value: { field: number } };
+withDefault(box, item => { item.field; });
+"#,
+    );
+    assert_no_ts18046(&diagnostics, "wrapper object sibling seeds T");
+}
+
+#[test]
+fn nested_sibling_position_still_emits_when_type_param_truly_uninferred() {
+    // Negative control: the only other parameter mentioning `I` is itself an
+    // unannotated callback whose body never calls back to any argument that
+    // would supply `I` — Round 1 leaves `I` genuinely unresolved, so
+    // `finalized_contextual_param_types` at that position still contains a
+    // type parameter and the new structural-match path must not manufacture
+    // evidence from it.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare function ap<I>(seed: (mk: () => I[]) => void, use: (v: I) => void): void;
+ap(mk => { mk(); }, item => { item.field; });
+"#,
+    );
+    assert!(
+        diagnostics.iter().any(|(code, _)| *code == 18046),
+        "Expected TS18046 for genuinely uninferred I. Got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn empty_array_literal_sibling_still_reports_real_property_error() {
+    // Negative control: an empty array literal infers as `never[]`, which is
+    // a fully concrete (not type-parameter-containing) resolved type — the
+    // structural match must not treat this as "no evidence" and fall back to
+    // TS18046; `tsc` reports the real `never`-typed property access instead.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare function ap<I>(seed: I[], use: (v: I) => void): void;
+ap([], item => { item.field; });
+"#,
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|(code, msg)| *code == 2339 && msg.contains("never")),
+        "Expected TS2339 on 'never'. Got: {diagnostics:?}"
+    );
+    assert_no_ts18046(&diagnostics, "empty array literal sibling");
+}


### PR DESCRIPTION
Refs #16018 (the post-generic uninferred-callback recheck re-derives inference facts independently of Round 1).

## Structural rule

`bare_type_param_position_resolved_by_round1` (`crates/tsz-checker/src/types/computation/call_inference/unknown_callback.rs`, introduced in #16084) decides whether a shared type parameter `T`, consumed by a context-sensitive callback argument, was genuinely left uninferred by Round 1, by consulting the call's own `finalized_contextual_param_types` (the callee's parameter types after substituting the real solver-inferred type arguments). It only did this when a sibling parameter position was declared as a *bare* `T` reference — its own doc comment named a type parameter nested inside a compound parameter type (`Array<T>`, a generic alias or wrapper) as unhandled, falling through to the narrower `argument_provides_type_param_evidence` argument-shape heuristic.

When a sibling parameter position is declared as a compound type mentioning `T` and Round 1 already resolved that position to a fully concrete type, `tsc`'s behavior follows that resolved value regardless of whether the slot's shape is bare or nested; tsz's recheck should trust it the same way. This PR recovers `T`'s binding from a nested slot by structurally matching the declared type against the finalized concrete type, reusing `tsz_solver::computation::infer_type_arguments_from_param_args` — the same structural-unification primitive `predicate_resolution.rs` already uses to instantiate a type-predicate target nested inside a wrapper type — via a new thin checker query-boundary wrapper in `generic_instantiation.rs` (owner layer: checker's post-generic call-inference query boundary; the actual unification stays in the solver).

## Why this is `hold`, not `green`

Same framing Quartz/ClaudeDE settled on for #16084's bare-position fix, and for the same reason: the non-callback and callback-return/-annotated-parameter branches of `argument_provides_type_param_evidence` already perform a full structural `type_contains_type_parameter_binder` containment check (nested-safe), so most nested-position evidence was already recognized through that path — I could not construct an end-to-end diagnostic-flipping repro this session (tried nested arrays, wrapper objects, and error/unknown-typed siblings; all matched baseline exactly, see test file's doc comment for the reasoning). This closes the documented architectural gap and is verified safe, but it is a refactor, not an observed false-positive fix — filing it as `green` would book a no-op as row progress.

## Adjacent-case matrix (new test file: `issue_16018_nested_position_evidence_tests.rs`)

- `Array<T>`-typed sibling seeds `T` (positive)
- Same with renamed binder (`J`/`run`/`w`) — structural, not identifier-keyed
- Wrapper-object (`{ value: T }`) sibling seeds `T` — not just arrays
- Negative control: sibling is itself an unannotated callback whose body never surfaces `T` — Round 1 leaves `T` genuinely unresolved, and the new structural match must not manufacture evidence — still reports `TS18046`
- Negative control: empty array literal (`never[]`, fully concrete but not what a user would expect) — reports the real `TS2339` on `never`, not a spurious `TS18046`

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test issue_16018_nested_position_evidence_tests --test issue_16018_round1_bare_position_trust_tests --test issue_16018_annotated_sibling_callback_evidence_tests --test issue_16012_any_argument_type_param_evidence_tests --test issue_7653_parameterless_lambda_inference_tests`: 35/35 pass (5 new tests added).
- `cargo test -p tsz-checker --test context_sensitive_callback_inference_tests --test generic_call_assignment_flow_tests --test new_generic_callback_contextual_infer_tests --test generic_callback_local_literal_widening_tests --test generic_call_inference_tests --test issue_3768_generic_callback_outer_inference_tests --test issue_9780_typeof_generic_call_callback_param --test getter_contextual_generic_call_typeparam_tests --test failed_generic_call_default_type_args_tests`: all pass except the same 2 pre-existing failures #16084 hit (`colliding_generic_terminals_keep_flow_diagnostics_clean_across_file_orders`, `imported_generic_result_narrows_inside_reduce_arrow`) — both already in `scripts/ci/known-failures.txt`, unrelated to this change.
- `cargo fmt -p tsz-checker -- --check`: clean.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings`: clean (also re-run by the repo's pre-commit hook, which passed, including the arch-size guard).
- `cargo-nextest` not used (not installed this session); used `cargo test` for the targeted verification above, same as #16084.
- Conformance / emit / fourslash **not run**: no observed behavior change found on any input tried (see "Why this is `hold`" above), matching #16084's own precedent for the same reason.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: Feldspar


---
_Generated by [Claude Code](https://claude.ai/code/session_013HzjPvtdqkCWdMa66MyNxX)_