### PR TITLE
arch: gate `#[path = "tests/…"] mod x;` on an adjacent #[cfg(test)] guard

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -802,6 +802,7 @@ mod window_self_globalthis_resolution_tests;
 #[path = "../tests/yield_star_return_type_tests.rs"]
 mod yield_star_return_type_tests;
 // Tests kept in root test harness where shared fixtures live.
+#[cfg(test)]
 #[path = "tests/application_arg_concrete_index_access_display_tests.rs"]
 mod application_arg_concrete_index_access_display_tests;
 #[cfg(test)]
@@ -1104,6 +1105,7 @@ mod for_in_narrowing_tests;
 #[cfg(test)]
 #[path = "tests/fresh_const_array_mutable_assignment_tests.rs"]
 mod fresh_const_array_mutable_assignment_tests;
+#[cfg(test)]
 #[path = "tests/fresh_object_literal_array_like_union_drill_gate_tests.rs"]
 mod fresh_object_literal_array_like_union_drill_gate_tests;
 #[cfg(test)]
@@ -1530,6 +1532,7 @@ mod overlap_relation_helper_routing_arch_tests;
 #[cfg(test)]
 #[path = "tests/overload_anchor_at_argument_tests.rs"]
 mod overload_anchor_at_argument_tests;
+#[cfg(test)]
 #[path = "tests/overload_argument_reason_chain_tests.rs"]
 mod overload_argument_reason_chain_tests;
 #[cfg(test)]

--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -374,6 +374,12 @@ def main() -> int:
         if hits:
             failures.append((name, hits))
 
+    for name, lib_rs_paths in CFG_TEST_GATED_PATH_MOD_CHECKS:
+        hits = scan_cfg_test_gated_path_mod(lib_rs_paths)
+        total_hits += len(hits)
+        if hits:
+            failures.append((name, hits))
+
     for name, file_path in PROJECT_DASHBOARD_ROW_CHECKS:
         hits = scan_project_dashboard_rows(file_path)
         total_hits += len(hits)

--- a/scripts/arch/arch_guard_rust.py
+++ b/scripts/arch/arch_guard_rust.py
@@ -75,6 +75,43 @@ def relative_path(path: pathlib.Path) -> str:
         return path.as_posix()
 
 
+_CFG_TEST_PATH_ATTR = re.compile(r'^\s*#\[path\s*=\s*"(?:\.\./)*tests/[^"]+\.rs"\]\s*$')
+_CFG_TEST_MOD_DECL = re.compile(r"^\s*mod\s+[A-Za-z_][A-Za-z0-9_]*\s*;\s*$")
+_CFG_TEST_ATTR = re.compile(r"^\s*#\[cfg\(test\)\]\s*$")
+
+
+def scan_cfg_test_gated_path_mod(paths) -> list[str]:
+    """Flag a `#[path = "…tests/…"] mod x;` pair not gated by #[cfg(test)].
+
+    The three lines (`#[cfg(test)]`, `#[path = "…"]`, `mod x;`) are written as
+    one declaration, but a git merge that inserts two such declarations at the
+    same point can align the shared `#[cfg(test)]` line as common context and
+    conflict only the `#[path]`/`mod` pair — the naive "keep both" resolution
+    then leaves one declaration's module compiling outside `#[cfg(test)]`
+    without the diff looking wrong (#16121). This scans for that end state:
+    a test-fixture `#[path]` immediately followed by `mod x;` with no
+    `#[cfg(test)]` immediately above it.
+    """
+    hits = []
+    for path in paths:
+        if not path.exists():
+            continue
+        lines = path.read_text(encoding="utf-8", errors="ignore").splitlines()
+        for i, line in enumerate(lines):
+            if not _CFG_TEST_PATH_ATTR.match(line):
+                continue
+            if i + 1 >= len(lines) or not _CFG_TEST_MOD_DECL.match(lines[i + 1]):
+                continue
+            prev = lines[i - 1] if i > 0 else ""
+            if not _CFG_TEST_ATTR.match(prev):
+                rel = relative_path(path)
+                hits.append(
+                    f"{rel}:{i + 1}: {lines[i + 1].strip()} — "
+                    "#[path] into tests/ not immediately gated by #[cfg(test)]"
+                )
+    return hits
+
+
 def find_struct_body(path: pathlib.Path, struct_name: str):
     text = path.read_text(encoding="utf-8", errors="ignore")
     stripped = strip_rust_comments(text)

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -1523,6 +1523,16 @@ DEBUG_PRINT_MACRO_CHECKS = [
     ),
 ]
 
+CFG_TEST_GATED_PATH_MOD_CHECKS = [
+    (
+        "Test-module gate: every `#[path = \"…tests/…\"] mod x;` declaration "
+        "must be immediately preceded by #[cfg(test)] (#16121 — a same-point "
+        "merge conflict can silently drop the gate and compile a test-only "
+        "module into non-test builds)",
+        tuple(sorted((ROOT / "crates").glob("*/src/lib.rs"))),
+    ),
+]
+
 # Pin Track 10's diagnostic-debt ratchets in the shared architecture guard.
 # These are count metrics, not new semantic bans: the current baselines still
 # contain legacy fingerprint rewrites, source-text snippets, and rendered-type

--- a/scripts/arch/test_arch_guard_misc.py
+++ b/scripts/arch/test_arch_guard_misc.py
@@ -112,6 +112,75 @@ class ArchGuardDebugPrintMacroTests(unittest.TestCase):
         )
 
 
+class ArchGuardCfgTestGatedPathModTests(unittest.TestCase):
+    """Cover #16121's cfg(test) gate for `#[path = "…tests/…"] mod x;`."""
+
+    def setUp(self):
+        self.arch_guard = load_arch_guard_module()
+
+    def test_flags_ungated_test_path_mod(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            lib_rs = root / "lib.rs"
+            lib_rs.write_text(
+                "\n".join(
+                    [
+                        "#[cfg(test)]",
+                        '#[path = "tests/gated_tests.rs"]',
+                        "mod gated_tests;",
+                        '#[path = "tests/ungated_tests.rs"]',
+                        "mod ungated_tests;",
+                        "#[cfg(test)]",
+                        '#[path = "../tests/other_gated_tests.rs"]',
+                        "mod other_gated_tests;",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            hits = self.arch_guard.scan_cfg_test_gated_path_mod([lib_rs])
+
+        self.assertEqual(len(hits), 1)
+        self.assertIn("ungated_tests", hits[0])
+        self.assertIn("lib.rs:4", hits[0])
+
+    def test_accepts_a_fully_gated_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            lib_rs = root / "lib.rs"
+            lib_rs.write_text(
+                "\n".join(
+                    [
+                        "#[cfg(test)]",
+                        '#[path = "tests/a_tests.rs"]',
+                        "mod a_tests;",
+                        "#[cfg(test)]",
+                        '#[path = "../tests/b_tests.rs"]',
+                        "mod b_tests;",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            hits = self.arch_guard.scan_cfg_test_gated_path_mod([lib_rs])
+
+        self.assertEqual(hits, [])
+
+    def test_real_crate_lib_rs_files_are_fully_gated(self):
+        for name, paths in self.arch_guard.CFG_TEST_GATED_PATH_MOD_CHECKS:
+            hits = self.arch_guard.scan_cfg_test_gated_path_mod(paths)
+            self.assertEqual(hits, [], f"{name}: {hits[:5]}")
+
+    def test_check_is_registered(self):
+        names = [entry[0] for entry in self.arch_guard.CFG_TEST_GATED_PATH_MOD_CHECKS]
+        self.assertTrue(
+            any("cfg(test)" in name for name in names),
+            "cfg(test) gate check missing from CFG_TEST_GATED_PATH_MOD_CHECKS",
+        )
+
+
 class ArchGuardVisitedCloneTests(unittest.TestCase):
     """Cover Track 10 branch-local `visited.clone()` traversal guardrails."""
 


### PR DESCRIPTION
This crate's 416-entry `#[cfg(test)] #[path = "tests/…"] mod x;` block in
`crates/tsz-checker/src/lib.rs` has a same-point-merge-conflict failure mode:
when two PRs insert a declaration at the same alphabetical position, git can
align the identical `#[cfg(test)]` line as shared context and conflict only
the `#[path]`/`mod` pair. The natural "keep both" resolution then leaves one
declaration's module compiling into every build, not just test builds, with
nothing in the diff looking wrong. Filed and evidenced in #16121 (three
same-shape incidents in one day).

Structural rule: when a `#[path = "…tests/…"]` attribute is not immediately
preceded by `#[cfg(test)]`, that module compiles unconditionally, through
the crate's normal `mod` resolution — there is no owning semantic layer
here, this is a build-hygiene/CI-guard gap, closed at the architecture-guard
layer (`scripts/arch/`), the same layer that already owns Track 10's
debug-print-macro ban and the CheckerContext lifetime manifest.

## What changed

- New check `scan_cfg_test_gated_path_mod` (`scripts/arch/arch_guard_rust.py`),
  wired into `scripts/arch/arch_guard.py` via `CFG_TEST_GATED_PATH_MOD_CHECKS`
  (`scripts/arch/arch_guard_shared.py`). Scans every `crates/*/src/lib.rs` and
  flags any `#[path = "…tests/…"]` + `mod x;` pair not immediately preceded
  by `#[cfg(test)]`. Runs in the `arch-size` CI job, which despite its name
  runs the *full* guard on every PR — this is option (3) from #16121, the
  "cheapest, catches all cited incidents at the point of error" one.
- The guard found **three real, already-merged violations on current
  `main`** while I was validating it — not synthetic test fixtures:
  `application_arg_concrete_index_access_display_tests` (lib.rs:805, sitting
  out of alphabetical order at the literal tail of the file — a live
  instance of exactly this bug, predating #16121's three cited incidents),
  `fresh_object_literal_array_like_union_drill_gate_tests` (lib.rs:1107),
  and `overload_argument_reason_chain_tests` (lib.rs:1533). All three are
  genuine `#[test]`-bearing modules (2/12/5 `#[test]` fns respectively) that
  were compiling into every build — release included — instead of only test
  builds. Restored the missing `#[cfg(test)]` on each; no other change to
  those files.
- Added unit coverage for the new check (`ArchGuardCfgTestGatedPathModTests`
  in `scripts/arch/test_arch_guard_misc.py`): a synthetic ungated/gated
  fixture, plus an assertion that every real crate `lib.rs` is fully gated
  (this is what caught the three live violations, and will catch the next
  one at CI time going forward).

Not attempted: #16121's option (1)/(2) (single-line attribute collapse or a
generated block). Collapsing the three lines onto one is defeated by
`cargo fmt`, which force-splits multi-attribute-per-line back onto separate
lines (verified empirically — see PR discussion if asked). A generated block
would remove the conflict class entirely but is a much larger, riskier
change to a 1947-line crate root; left as future work in #16121 if the CI
guard alone proves insufficient.

## Goal
Goal: hold

## Verification
- `python3 scripts/arch/arch_guard.py` — clean (was 3 failures before the
  fix; passes after).
- `cd scripts/arch && python3 -m unittest discover -p "test_arch_guard*.py"`
  — 472/473 tests pass; the 1 failure (`test_no_unguarded_oversized_production_files`,
  unrelated file-size ratchet debt on `part_00.rs`/`parse_and_libs.rs`) is
  pre-existing, confirmed via `git stash` against unmodified `main`.
- `cargo fmt --check -p tsz-checker` — clean.
- `cargo check -p tsz-checker --lib --tests` — clean build.
- `cargo test -p tsz-checker --lib -- application_arg_concrete_index_access_display_tests fresh_object_literal_array_like_union_drill_gate_tests overload_argument_reason_chain_tests`
  — 19/19 pass (the three newly re-gated modules run correctly as tests).
- `cargo clippy -p tsz-checker --lib --tests --profile ci-lint -- -D warnings`
  — clean.
- Pre-commit hook (fmt + clippy `-p tsz-checker` + architecture guard) — passed.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT