### PR TITLE
fix(solver): stop `any` silencing a `never` parameter under strictFunctionTypes

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -100,6 +100,9 @@ pub mod test_utils;
 #[path = "tests/alias_application_display_retention_tests.rs"]
 mod alias_application_display_retention_tests;
 #[cfg(test)]
+#[path = "tests/any_parameter_never_opposite_tests.rs"]
+mod any_parameter_never_opposite_tests;
+#[cfg(test)]
 #[path = "tests/application_unknown_args_assignability_tests.rs"]
 mod application_unknown_args_assignability_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/any_parameter_never_opposite_tests.rs
+++ b/crates/tsz-checker/src/tests/any_parameter_never_opposite_tests.rs
@@ -1,0 +1,133 @@
+//! `never` opposite an `any` parameter under `strictFunctionTypes`.
+//!
+//! Structural rule: when one signature's parameter is exactly `any` and the
+//! other's is exactly `never`, tsc does not let `any` silence the pair. Its
+//! `isSimpleTypeRelatedTo` rejects `any -> never` before any `any` allowance
+//! applies, so the contravariant parameter check (`target <: source`) rejects
+//! `(u: never) => R` against `(u: any) => R2`, while the mirrored pair stays
+//! compatible through `never <: any`. tsz decides this in the solver, in
+//! `are_parameters_compatible_impl`
+//! (`relations/subtype/rules/functions/mod.rs`): the permissive `any`
+//! shortcut now skips the `never`-opposite pair and lets the ordinary
+//! variance-directed check answer — the same check that already gets
+//! `ReadonlyArray<any>` vs `ReadonlyArray<never>` right.
+//!
+//! Method parameters stay bivariant, so a `never`-parameter method still
+//! satisfies an `any`-parameter method through the reverse direction.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::check_source;
+
+fn strict_opts() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        strict_function_types: true,
+        ..CheckerOptions::default()
+    }
+}
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source(source, "main.ts", strict_opts())
+        .iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+#[test]
+fn never_parameter_source_is_rejected_against_any_parameter_target() {
+    let source = "declare function accept(fn: (u: any) => any): void;\n\
+                  declare const produce: (u: never) => number;\n\
+                  accept(produce);\n";
+    assert_eq!(
+        codes(source),
+        vec![2345],
+        "`(u: never) => number` must not be assignable to `(u: any) => any`: \
+         the contravariant parameter check is `any <: never`, which tsc rejects"
+    );
+}
+
+#[test]
+fn any_parameter_source_is_accepted_against_never_parameter_target() {
+    let source = "declare function accept(fn: (u: never) => any): void;\n\
+                  declare const produce: (u: any) => number;\n\
+                  accept(produce);\n";
+    assert!(
+        codes(source).is_empty(),
+        "the mirrored pair is compatible through `never <: any`; \
+         only the `any`-in-target-position direction rejects"
+    );
+}
+
+#[test]
+fn renamed_binders_do_not_change_the_verdict() {
+    let source = "declare function consume(handler: (payload: any) => void): void;\n\
+                  declare const emitter: (bottom: never) => void;\n\
+                  consume(emitter);\n";
+    assert_eq!(
+        codes(source),
+        vec![2345],
+        "the rule is structural: renaming the parameter binders must not change it"
+    );
+}
+
+#[test]
+fn alias_wrapped_signature_is_rejected_the_same_way() {
+    let source = "type Handler<A, U> = (u: U) => A;\n\
+                  declare function accept(fn: Handler<any, any>): void;\n\
+                  declare const produce: Handler<number, never>;\n\
+                  accept(produce);\n";
+    assert_eq!(
+        codes(source),
+        vec![2345],
+        "wrapping both signatures in the same generic alias must not hide the pair"
+    );
+}
+
+#[test]
+fn callback_position_parameter_pair_stays_bivariant() {
+    let source = "declare function accept(fn: (inner: (u: any) => any) => void): void;\n\
+                  declare const produce: (inner: (u: never) => number) => void;\n\
+                  accept(produce);\n";
+    assert!(
+        codes(source).is_empty(),
+        "`strictFunctionTypes` does not reach a parameter that is itself a callback \
+         parameter, so tsc relates this pair bivariantly and accepts it"
+    );
+}
+
+#[test]
+fn method_parameters_stay_bivariant() {
+    let source = "declare function accept(o: { run(u: any): any }): void;\n\
+                  declare const produce: { run(u: never): number };\n\
+                  accept(produce);\n";
+    assert!(
+        codes(source).is_empty(),
+        "method parameters are bivariant even under strictFunctionTypes, so the \
+         reverse direction (`never <: any`) accepts this pair"
+    );
+}
+
+#[test]
+fn any_opposite_a_non_never_parameter_is_still_silenced() {
+    let source = "declare function accept(fn: (u: any) => any): void;\n\
+                  declare const produce: (u: string) => number;\n\
+                  accept(produce);\n";
+    assert!(
+        codes(source).is_empty(),
+        "the narrowing applies to `never` only: `any` must keep silencing every \
+         other parameter mismatch it silenced before"
+    );
+}
+
+#[test]
+fn never_in_a_covariant_type_argument_is_unchanged() {
+    let source = "interface Box<T> { readonly value: T }\n\
+                  declare function accept(b: Box<never>): void;\n\
+                  declare const b: Box<any>;\n\
+                  accept(b);\n";
+    assert_eq!(
+        codes(source),
+        vec![2345],
+        "the pre-existing covariant `any` -> `never` rejection must not regress"
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs
@@ -403,11 +403,25 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             return true;
         }
 
+        // `never` opposite an `any` parameter is the one pair the permissive
+        // shortcut below must not answer. `tsc`'s `isSimpleTypeRelatedTo`
+        // rejects `any -> never` outright (`if (t & TypeFlags.Never) return
+        // false`) before any `any` allowance applies, so under
+        // `strictFunctionTypes` the contravariant parameter check
+        // `target <: source` rejects `(u: never) => R` against
+        // `(u: any) => R2`, while the reverse pair stays compatible through
+        // `never <: any`. Both answers already fall out of the ordinary
+        // variance-directed check below (the same one that gets
+        // `ReadonlyArray<any>` vs `ReadonlyArray<never>` right), so skip the
+        // shortcut and let the direction decide instead of encoding it here.
+        let never_opposite_any = (source_type.is_any() && target_type == TypeId::NEVER)
+            || (target_type.is_any() && source_type == TypeId::NEVER);
+
         // Fast path: `any` in either parameter position is always compatible
         // in permissive mode. In strict mode (TopLevelOnly), we require structural
         // compatibility unless both are ANY.
         // NOTE: North Star mandate #3.3 - any should not silence structural mismatches.
-        if source_type.is_any() || target_type.is_any() {
+        if !never_opposite_any && (source_type.is_any() || target_type.is_any()) {
             use crate::relations::subtype::AnyPropagationMode;
             if matches!(self.any_propagation, AnyPropagationMode::All) {
                 return true;


### PR DESCRIPTION
Structural rule: **when one signature's parameter is exactly `any` and the other's is exactly `never`, tsc does not let `any` silence the pair — `isSimpleTypeRelatedTo` rejects `any -> never` (`if (t & TypeFlags.Never) return false`) before any `any` allowance applies, so under `strictFunctionTypes` the contravariant parameter check `target <: source` rejects `(u: never) => R` against `(u: any) => R2`, while the mirrored pair stays compatible through `never <: any`; tsz does this through the solver, in `are_parameters_compatible_impl`.**

Wrong semantic operation: **relation** (signature parameter compatibility), owner layer **solver** (`crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs`).

`are_parameters_compatible_impl` answered every parameter pair containing an `any` with an unconditional `true` in permissive any-propagation mode. That is correct for every opposite type except `never`. The fix skips the shortcut for that one pair and lets the ordinary variance-directed check answer — the same check that already gets `Box<any>` versus `Box<never>` right in a covariant type-argument position, and that keeps method parameters and callback-position parameters bivariant. No new decision logic is added; the existing direction-aware path decides.

### Witness (missing diagnostic, false negative)

```ts
declare function accept(fn: (u: any) => any): void;
declare const produce: (u: never) => number;
accept(produce);
```

`tsc@7.0.2` (`--strict`, `strictFunctionTypes`):

```
error TS2345: Argument of type '(u: never) => number' is not assignable to parameter of type '(u: any) => any'.
  Types of parameters 'u' and 'u' are incompatible.
    Type 'any' is not assignable to type 'never'.
```

tsz before: clean. tsz after: byte-identical to tsc, message and elaboration chain included.

### Adjacent-case matrix

All eight rows oracle-checked against `tsc@7.0.2` on the identical config before being written as assertions; tsz matches tsc on every row after the fix.

| Row | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `(u: never) => number` -> `(u: any) => any` | TS2345 | clean | TS2345 |
| mirrored: `(u: any) => number` -> `(u: never) => any` | clean | clean | clean |
| renamed binders (`payload`/`bottom`) | TS2345 | clean | TS2345 |
| both sides wrapped in one generic alias `Handler[ A, U ]` | TS2345 | clean | TS2345 |
| pair nested in a callback-position parameter | clean | clean | clean |
| method parameters (bivariant) | clean | clean | clean |
| `any` opposite a non-`never` parameter (`string`) | clean | clean | clean |
| covariant type argument `Box[ any ]` -> `Box[ never ]` | TS2345 | TS2345 | TS2345 |

Negative/fallback rows are the point of the last three: the narrowing is to `never` only, `any` keeps silencing every other parameter mismatch it silenced before, and the pre-existing covariant `any -> never` rejection is untouched.

## Goal
Goal: hold

## Verification

Cold cloud container, 4 cores / 15 GB. The TypeScript submodule is absent in a fresh container, so conformance and `compare-to-parent.sh` were **not runnable from this seat** — stated plainly rather than implied. What did run:

- `cargo fmt` — clean.
- `cargo clippy` (workspace, via the repo pre-commit hook: `Clippy passed. / Architecture guard passed. / Local verification passed.`).
- `cargo test -p tsz-checker --lib --profile ci-unit any_parameter_never_opposite` — **8 passed, 0 failed** (`cargo nextest` is not installed in this container; `cargo test` with the `ci-unit` profile was used instead).
- `cargo test -p tsz-solver --lib --profile ci-unit` — full solver lib suite, result recorded in a follow-up comment on this PR.
- Real **kysely** row (`b4566a1f7a3277997b0a15f27d3113e8e095fa87` / `v0.28.16`, `tsconfig.tsz-guard.json` from `scripts/bench/project-fixtures.sh`), `dist-fast` build with this change: **39 diagnostics, exit 1** — exactly the count #16074 records for `main`. The change adds no diagnostics to a required row.
- Oracle for every row above: `tsc@7.0.2` from npm, same tsconfig, `--pretty false`.

Not claimed: conformance, emit, and fourslash did not run from this container. A reviewer on a seat with the TypeScript submodule should run `scripts/conformance/compare-to-parent.sh` and `./scripts/emit/run.sh` before landing — this change adds diagnostics, so it is exactly the shape that a two-sided conformance diff exists to catch.

### Found while working #16074

The kysely Family-1 witnesses (`InsertExpression[ DB, TB, never ]` rejected against `InsertExpression[ any, any, any ]`) are **not** this bug and are not fixed here — the row is unchanged at 39. Two measurements from the same session, recorded so the next session does not re-derive them:

- tsc itself **rejects** `Alias[ T, never ]` -> `Alias[ any, any ]` when the defaulted parameter is reliably contravariant (a plain `type Fn[ A, UT = never ] = (u: UT) =[ gt ] A` reproduces TS2345 on tsc). So the any/never variance rule in `classify_application_args_any_never_variance` is tsc-faithful in the simple shape, and the kysely divergence must come from the variance being unmeasurable in the real alias, not from the rule itself.
- tsz's diagnostic **display** loses the alias on the target side: for the alias-wrapped row tsc prints `Handler[ any, any ]` where tsz prints the expanded `(u: any) =[ gt ] any`. Separate display gap, not touched here.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Rhyolite

---
_Generated by [Claude Code](https://claude.ai/code/session_015GycfZ5xzcDNY1oKbjbaa8)_