### PR TITLE
fix(solver): render a function merged with a namespace as `typeof f`

### DIFF
--- a/crates/tsz-checker/src/declarations/namespace_checker.rs
+++ b/crates/tsz-checker/src/declarations/namespace_checker.rs
@@ -549,10 +549,16 @@ impl<'a> CheckerState<'a> {
         self.merge_exports_into_props(sym_id, &mut props, false);
 
         let properties = props.into_values().collect();
+        // Keep the merged symbol, exactly as the constructor path above does.
+        // `function f` merged with `namespace f` carries `ValueModule` on its
+        // symbol, so tsc prints `typeof f`; without the symbol the printer has
+        // nothing to distinguish the merge from a plain expando function and
+        // falls back to the structural surface.
         let merged_type = declaration_exports::namespace_merged_function_callable_type(
             self.ctx.types,
             &shape,
             properties,
+            sym_id,
         );
 
         (merged_type, Vec::new())

--- a/crates/tsz-checker/src/declarations/namespace_checker.rs
+++ b/crates/tsz-checker/src/declarations/namespace_checker.rs
@@ -548,17 +548,31 @@ impl<'a> CheckerState<'a> {
 
         self.merge_exports_into_props(sym_id, &mut props, false);
 
+        // Keep the merged symbol, as the constructor path above does, but only
+        // when the namespace actually contributed a member.
+        //
+        // tsc takes the `typeof f` rendering for an *instantiated* module
+        // (`SymbolFlags.ValueModule`); an empty namespace, or one exporting only
+        // types, is uninstantiated and keeps printing `() => void`. tsz's binder
+        // does not yet model that distinction — `modules/binding.rs` sets
+        // `VALUE_MODULE | NAMESPACE_MODULE` on every namespace — so the flag
+        // cannot separate the two here. Contributing a member is the part of the
+        // rule that is observable at this site, and it covers every merge that
+        // reaches the printer with appended properties.
+        //
+        // The residual gap is a namespace whose only value is *unexported*
+        // (`namespace f { var hidden = 1; }`): tsc prints `typeof f`, and this
+        // still renders structurally. That case is unchanged from before this
+        // fix rather than regressed, and closing it needs the binder to model
+        // instantiation. Withholding the symbol keeps every non-contributing
+        // merge byte-identical to the previous structural rendering.
+        let namespace_contributed_member = props.len() > shape.properties.len();
         let properties = props.into_values().collect();
-        // Keep the merged symbol, exactly as the constructor path above does.
-        // `function f` merged with `namespace f` carries `ValueModule` on its
-        // symbol, so tsc prints `typeof f`; without the symbol the printer has
-        // nothing to distinguish the merge from a plain expando function and
-        // falls back to the structural surface.
         let merged_type = declaration_exports::namespace_merged_function_callable_type(
             self.ctx.types,
             &shape,
             properties,
-            sym_id,
+            namespace_contributed_member.then_some(sym_id),
         );
 
         (merged_type, Vec::new())

--- a/crates/tsz-checker/src/error_reporter/render_request_tests.rs
+++ b/crates/tsz-checker/src/error_reporter/render_request_tests.rs
@@ -1135,3 +1135,84 @@ const t: number = clsMerged;
         d.message_text
     );
 }
+
+/// Regression control for the `esModuleInteropPrettyErrorRelatedInformation.ts`
+/// conformance row: only an *instantiated* module merge takes the name.
+///
+/// `ValueModule` (a namespace containing at least one value) is the operative
+/// flag, not `NamespaceModule`. An empty namespace, or one exporting only
+/// types, adds nothing to the value's observable surface and tsc keeps printing
+/// the call signature. Verified against tsc 7.0.2.
+#[test]
+fn ts2322_empty_or_type_only_namespace_merge_stays_structural() {
+    let empty = r#"
+declare function fa(): void;
+declare namespace fa {}
+const t: number = fa;
+"#;
+    let diagnostics = check_source_diagnostics(empty);
+    let d = diagnostics
+        .iter()
+        .find(|d| d.code == 2322)
+        .unwrap_or_else(|| {
+            panic!("expected TS2322 for empty namespace merge, got: {diagnostics:?}")
+        });
+    assert!(
+        d.message_text.contains("() => void"),
+        "an empty namespace merge is not instantiated and must stay structural, got: {}",
+        d.message_text
+    );
+    assert!(
+        !d.message_text.contains("typeof fa"),
+        "an empty namespace merge must not render as typeof, got: {}",
+        d.message_text
+    );
+
+    let type_only = r#"
+declare function fc(): void;
+declare namespace fc { interface Options {} }
+const t: number = fc;
+"#;
+    let diagnostics = check_source_diagnostics(type_only);
+    let d = diagnostics
+        .iter()
+        .find(|d| d.code == 2322)
+        .unwrap_or_else(|| {
+            panic!("expected TS2322 for type-only namespace merge, got: {diagnostics:?}")
+        });
+    assert!(
+        d.message_text.contains("() => void"),
+        "a type-only namespace merge is not instantiated and must stay structural, got: {}",
+        d.message_text
+    );
+}
+
+/// Known gap, pinned deliberately: tsc's real test is the module flag, *not*
+/// "does the merge append a visible property". A namespace whose only value is
+/// **not exported** contributes no member yet still instantiates the module,
+/// and tsc prints `typeof fg`.
+///
+/// tsz cannot express that here yet: `crates/tsz-binder/src/modules/binding.rs`
+/// sets `VALUE_MODULE | NAMESPACE_MODULE` on *every* namespace, so the flag
+/// cannot distinguish an instantiated module from an empty or type-only one.
+/// This case renders structurally — unchanged from before the merged-namespace
+/// fix, not regressed by it. Un-ignore once the binder models instantiation.
+#[ignore = "needs binder to model instantiated vs uninstantiated modules; see PR #16133"]
+#[test]
+fn ts2322_namespace_with_only_unexported_value_still_renders_typeof() {
+    let source = r#"
+function fg() {}
+namespace fg { var hidden = 1; }
+const t: number = fg;
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    let d = diagnostics
+        .iter()
+        .find(|d| d.code == 2322)
+        .unwrap_or_else(|| panic!("expected TS2322, got: {diagnostics:?}"));
+    assert!(
+        d.message_text.contains("'typeof fg'"),
+        "an unexported value still instantiates the module, got: {}",
+        d.message_text
+    );
+}

--- a/crates/tsz-checker/src/error_reporter/render_request_tests.rs
+++ b/crates/tsz-checker/src/error_reporter/render_request_tests.rs
@@ -942,3 +942,196 @@ const consumer: { mu: number; xi: boolean; omicron: number } = parcel;
         missing.message_text
     );
 }
+
+/// A `function` merged with a same-named `namespace` carries `ValueModule` on
+/// its symbol, so tsc renders it as `typeof f` rather than expanding the
+/// structural surface. A plain function with *expando* assignments carries no
+/// module flag, and there tsc really does print `{ (): void; declared: number; }`
+/// — that distinction is the whole rule.
+///
+/// Every expectation below is pinned to `tsc` 7.0.2 run on the same source
+/// (`--noEmit --target es2015 --strict false --pretty false`).
+#[test]
+fn ts2322_merged_function_namespace_renders_typeof_name() {
+    let source = r#"
+function fnMerged() {}
+namespace fnMerged { export var bar = 1; }
+const t: number = fnMerged;
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    let d = diagnostics
+        .iter()
+        .find(|d| d.code == 2322)
+        .unwrap_or_else(|| panic!("expected TS2322, got: {diagnostics:?}"));
+    assert!(
+        d.message_text.contains("'typeof fnMerged'"),
+        "function+namespace merge should render as `typeof fnMerged`, got: {}",
+        d.message_text
+    );
+    assert!(
+        !d.message_text.contains("(): void"),
+        "merged function must not expand to its structural surface, got: {}",
+        d.message_text
+    );
+}
+
+/// Anti-hardcoding control: the rule is keyed on the symbol's module flag, not
+/// on any particular identifier, so a renamed binder behaves identically.
+#[test]
+fn ts2322_merged_function_namespace_typeof_survives_renamed_binders() {
+    let source = r#"
+function zzQuux() {}
+namespace zzQuux { export var whatever = 1; }
+const t: number = zzQuux;
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    let d = diagnostics
+        .iter()
+        .find(|d| d.code == 2322)
+        .unwrap_or_else(|| panic!("expected TS2322, got: {diagnostics:?}"));
+    assert!(
+        d.message_text.contains("'typeof zzQuux'"),
+        "renamed binder should render as `typeof zzQuux`, got: {}",
+        d.message_text
+    );
+}
+
+/// Negative control, and the reason the module-flag gate cannot simply be
+/// "callable with appended properties": an expando function with **no**
+/// namespace merge keeps tsc's structural rendering.
+#[test]
+fn ts2322_expando_function_without_namespace_stays_structural() {
+    let source = r#"
+function expandoFn() {}
+expandoFn.declared = 1;
+const t: number = expandoFn;
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    let d = diagnostics
+        .iter()
+        .find(|d| d.code == 2322)
+        .unwrap_or_else(|| panic!("expected TS2322, got: {diagnostics:?}"));
+    assert!(
+        d.message_text.contains("{ (): void; declared: number; }"),
+        "expando function without a namespace merge must stay structural, got: {}",
+        d.message_text
+    );
+    assert!(
+        !d.message_text.contains("typeof expandoFn"),
+        "expando function without a namespace merge must not render as typeof, got: {}",
+        d.message_text
+    );
+}
+
+/// Ordering control: when a function carries *both* expando assignments and a
+/// namespace merge, the module flag wins and tsc prints `typeof bothFn`. This
+/// pins the module-flag check ahead of the expando check in the printer.
+#[test]
+fn ts2322_expando_function_merged_with_namespace_prefers_typeof() {
+    let source = r#"
+function bothFn() {}
+bothFn.expandoProp = 1;
+namespace bothFn { export var nsProp = 2; }
+const t: number = bothFn;
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    let d = diagnostics
+        .iter()
+        .find(|d| d.code == 2322)
+        .unwrap_or_else(|| panic!("expected TS2322, got: {diagnostics:?}"));
+    assert!(
+        d.message_text.contains("'typeof bothFn'"),
+        "namespace merge outranks expando assignments, got: {}",
+        d.message_text
+    );
+}
+
+/// Generic and overloaded functions reach the printer through the same merged
+/// callable shape; both render under the merged name.
+#[test]
+fn ts2322_merged_generic_and_overloaded_functions_render_typeof_name() {
+    let generic = r#"
+function genFn<T>(x: T): T { return x; }
+namespace genFn { export var g = 1; }
+const t: number = genFn;
+"#;
+    let diagnostics = check_source_diagnostics(generic);
+    let d = diagnostics
+        .iter()
+        .find(|d| d.code == 2322)
+        .unwrap_or_else(|| panic!("expected TS2322 for generic merge, got: {diagnostics:?}"));
+    assert!(
+        d.message_text.contains("'typeof genFn'"),
+        "generic function+namespace merge should render as `typeof genFn`, got: {}",
+        d.message_text
+    );
+
+    let overloaded = r#"
+function ovl(x: number): number;
+function ovl(x: string): string;
+function ovl(x: any): any { return x; }
+namespace ovl { export var o = 1; }
+const t: number = ovl;
+"#;
+    let diagnostics = check_source_diagnostics(overloaded);
+    let d = diagnostics
+        .iter()
+        .find(|d| d.code == 2322)
+        .unwrap_or_else(|| panic!("expected TS2322 for overloaded merge, got: {diagnostics:?}"));
+    assert!(
+        d.message_text.contains("'typeof ovl'"),
+        "overloaded function+namespace merge should render as `typeof ovl`, got: {}",
+        d.message_text
+    );
+}
+
+/// Fallback controls: a plain function keeps its call-signature rendering, and
+/// the already-correct pure-namespace and class+namespace forms are unchanged.
+#[test]
+fn ts2322_plain_function_and_existing_typeof_forms_are_unchanged() {
+    let plain = r#"
+function plainFn() {}
+const t: number = plainFn;
+"#;
+    let diagnostics = check_source_diagnostics(plain);
+    let d = diagnostics
+        .iter()
+        .find(|d| d.code == 2322)
+        .unwrap_or_else(|| panic!("expected TS2322 for plain function, got: {diagnostics:?}"));
+    assert!(
+        d.message_text.contains("() => void"),
+        "a plain function should still render as `() => void`, got: {}",
+        d.message_text
+    );
+
+    let pure_namespace = r#"
+namespace nsOnly { export var z = 1; }
+const t: number = nsOnly;
+"#;
+    let diagnostics = check_source_diagnostics(pure_namespace);
+    let d = diagnostics
+        .iter()
+        .find(|d| d.code == 2322)
+        .unwrap_or_else(|| panic!("expected TS2322 for pure namespace, got: {diagnostics:?}"));
+    assert!(
+        d.message_text.contains("'typeof nsOnly'"),
+        "pure namespace rendering should be unchanged, got: {}",
+        d.message_text
+    );
+
+    let class_merge = r#"
+class clsMerged {}
+namespace clsMerged { export var baz = 1; }
+const t: number = clsMerged;
+"#;
+    let diagnostics = check_source_diagnostics(class_merge);
+    let d = diagnostics
+        .iter()
+        .find(|d| d.code == 2322)
+        .unwrap_or_else(|| panic!("expected TS2322 for class merge, got: {diagnostics:?}"));
+    assert!(
+        d.message_text.contains("'typeof clsMerged'"),
+        "class+namespace rendering should be unchanged, got: {}",
+        d.message_text
+    );
+}

--- a/crates/tsz-checker/src/query_boundaries/declaration_exports.rs
+++ b/crates/tsz-checker/src/query_boundaries/declaration_exports.rs
@@ -97,6 +97,7 @@ pub(crate) fn namespace_merged_function_callable_type(
     db: &dyn TypeDatabase,
     shape: &CallableShape,
     properties: Vec<PropertyInfo>,
+    symbol: SymbolId,
 ) -> TypeId {
     db.callable(CallableShape {
         call_signatures: shape.call_signatures.clone(),
@@ -104,7 +105,7 @@ pub(crate) fn namespace_merged_function_callable_type(
         properties,
         string_index: shape.string_index,
         number_index: shape.number_index,
-        symbol: None,
+        symbol: Some(symbol),
         is_abstract: false,
     })
 }

--- a/crates/tsz-checker/src/query_boundaries/declaration_exports.rs
+++ b/crates/tsz-checker/src/query_boundaries/declaration_exports.rs
@@ -93,11 +93,14 @@ pub(crate) fn namespace_merged_constructor_callable_type(
     })
 }
 
+/// `symbol` is `Some` only for an *instantiated* module merge (`ValueModule`),
+/// which is what `tsc` renders as `typeof f`; an empty or type-only namespace
+/// passes `None` and keeps the structural rendering.
 pub(crate) fn namespace_merged_function_callable_type(
     db: &dyn TypeDatabase,
     shape: &CallableShape,
     properties: Vec<PropertyInfo>,
-    symbol: SymbolId,
+    symbol: Option<SymbolId>,
 ) -> TypeId {
     db.callable(CallableShape {
         call_signatures: shape.call_signatures.clone(),
@@ -105,7 +108,7 @@ pub(crate) fn namespace_merged_function_callable_type(
         properties,
         string_index: shape.string_index,
         number_index: shape.number_index,
-        symbol: Some(symbol),
+        symbol,
         is_abstract: false,
     })
 }

--- a/crates/tsz-solver/src/diagnostics/format/compound/def_symbol_names.rs
+++ b/crates/tsz-solver/src/diagnostics/format/compound/def_symbol_names.rs
@@ -66,6 +66,38 @@ impl<'a> TypeFormatter<'a> {
     // names in diagnostics (e.g., enum "Foo" displaying as "timeout").
     // DefId and SymbolId are independent ID spaces and must not be conflated.
 
+    /// Whether a value symbol takes `tsc`'s `typeof Name` rendering instead of
+    /// expanding to its structural surface.
+    ///
+    /// `tsc`'s `createAnonymousTypeNode` routes an anonymous object type through
+    /// `symbolToTypeNode` when the type's symbol carries `SymbolFlags.Class`,
+    /// `Enum`, or `ValueModule`, which is what prints `typeof Name`. A value
+    /// symbol that owns a namespace/module or enum declaration therefore keeps
+    /// its name; a plain function with expando assignments carries no module
+    /// flag and really does print its structural surface.
+    ///
+    /// Class and interface declarations win the name in a declaration merge —
+    /// `interface B {}` + `namespace B {}` displays as `B`, not `typeof B` —
+    /// so they are excluded here and render under their own rules.
+    pub(in crate::diagnostics::format) fn symbol_renders_as_typeof_name(
+        &self,
+        sym_id: tsz_binder::SymbolId,
+    ) -> bool {
+        use tsz_binder::symbol_flags;
+        let Some(arena) = self.symbol_arena else {
+            return false;
+        };
+        let Some(sym) = arena.get(sym_id) else {
+            return false;
+        };
+        let is_namespace =
+            sym.has_any_flags(symbol_flags::VALUE_MODULE | symbol_flags::NAMESPACE_MODULE);
+        let is_enum = sym.has_any_flags(symbol_flags::ENUM);
+        let is_class = sym.has_flags(symbol_flags::CLASS);
+        let is_interface = sym.has_any_flags(symbol_flags::INTERFACE);
+        (is_namespace || is_enum) && !is_class && !is_interface
+    }
+
     /// Try to resolve a human-readable name for an object shape via symbol or def store lookup.
     pub(super) fn resolve_object_shape_name(&mut self, shape: &ObjectShape) -> Option<String> {
         // The empty object `{}` is a universally-shared shape. `find_def_by_shape`
@@ -85,21 +117,8 @@ impl<'a> TypeFormatter<'a> {
             && let Some(name) = self.format_symbol_name(sym_id)
         {
             // Namespace/module/enum value types are displayed as `typeof Name` by tsc.
-            if let Some(arena) = self.symbol_arena
-                && let Some(sym) = arena.get(sym_id)
-            {
-                use tsz_binder::symbol_flags;
-                let is_namespace =
-                    sym.has_any_flags(symbol_flags::VALUE_MODULE | symbol_flags::NAMESPACE_MODULE);
-                let is_enum = sym.has_any_flags(symbol_flags::ENUM);
-                let is_class = sym.has_flags(symbol_flags::CLASS);
-                let is_interface = sym.has_any_flags(symbol_flags::INTERFACE);
-                // When a symbol is both an interface and a namespace (declaration
-                // merging), the type-space name wins — tsc displays `B`, not
-                // `typeof B`.  Similarly, classes take priority over namespaces.
-                if (is_namespace || is_enum) && !is_class && !is_interface {
-                    return Some(format!("typeof {name}"));
-                }
+            if self.symbol_renders_as_typeof_name(sym_id) {
+                return Some(format!("typeof {name}"));
             }
             return Some(name);
         }

--- a/crates/tsz-solver/src/diagnostics/format/compound/def_symbol_names.rs
+++ b/crates/tsz-solver/src/diagnostics/format/compound/def_symbol_names.rs
@@ -71,10 +71,24 @@ impl<'a> TypeFormatter<'a> {
     ///
     /// `tsc`'s `createAnonymousTypeNode` routes an anonymous object type through
     /// `symbolToTypeNode` when the type's symbol carries `SymbolFlags.Class`,
-    /// `Enum`, or `ValueModule`, which is what prints `typeof Name`. A value
-    /// symbol that owns a namespace/module or enum declaration therefore keeps
-    /// its name; a plain function with expando assignments carries no module
-    /// flag and really does print its structural surface.
+    /// `Enum`, or `ValueModule`, which is what prints `typeof Name`.
+    ///
+    /// `ValueModule` is `tsc`'s operative flag: only an *instantiated* namespace
+    /// (one containing at least one value, exported or not) carries it, and an
+    /// empty or type-only namespace prints structurally instead:
+    ///
+    /// ```text
+    /// declare function f(): void; declare namespace f {}                 -> () => void
+    /// declare function f(): void; declare namespace f { interface O {} } -> () => void
+    /// function f() {} namespace f { export var v = 1; }                  -> typeof f
+    /// ```
+    ///
+    /// Note that tsz's binder does not model that distinction — every namespace
+    /// gets `VALUE_MODULE | NAMESPACE_MODULE` — so this predicate cannot be the
+    /// thing that separates those rows. Callers that need the distinction gate
+    /// it at their construction site instead (see
+    /// `merge_namespace_exports_into_function`); this helper answers only "does
+    /// this symbol take a name-based rendering at all".
     ///
     /// Class and interface declarations win the name in a declaration merge —
     /// `interface B {}` + `namespace B {}` displays as `B`, not `typeof B` —
@@ -90,12 +104,11 @@ impl<'a> TypeFormatter<'a> {
         let Some(sym) = arena.get(sym_id) else {
             return false;
         };
-        let is_namespace =
-            sym.has_any_flags(symbol_flags::VALUE_MODULE | symbol_flags::NAMESPACE_MODULE);
+        let is_value_module = sym.has_any_flags(symbol_flags::VALUE_MODULE);
         let is_enum = sym.has_any_flags(symbol_flags::ENUM);
         let is_class = sym.has_flags(symbol_flags::CLASS);
         let is_interface = sym.has_any_flags(symbol_flags::INTERFACE);
-        (is_namespace || is_enum) && !is_class && !is_interface
+        (is_value_module || is_enum) && !is_class && !is_interface
     }
 
     /// Try to resolve a human-readable name for an object shape via symbol or def store lookup.

--- a/crates/tsz-solver/src/diagnostics/format/key.rs
+++ b/crates/tsz-solver/src/diagnostics/format/key.rs
@@ -161,6 +161,15 @@ impl<'a> TypeFormatter<'a> {
                     {
                         return format!("typeof {name}").into();
                     }
+                    // A function merged with a same-named namespace carries
+                    // `ValueModule` on its symbol, which tsc renders as
+                    // `typeof f` rather than the structural surface. This must
+                    // precede the expando check below: the merged namespace's
+                    // exports arrive as ordinary appended properties and are
+                    // otherwise indistinguishable from expando assignments.
+                    if self.symbol_renders_as_typeof_name(sym_id) {
+                        return format!("typeof {name}").into();
+                    }
                     // A function symbol whose callable carries appended value
                     // properties (expando assignments) renders structurally in
                     // tsc (`{ (): void; declared: number; }`), never as the


### PR DESCRIPTION
Closes #16132.

## Structural rule

**When a `function f` is merged with a same-named `namespace f` that contributes a member, `tsc` prints `typeof f` rather than the structural surface; tsz now does the same through the solver's type printer, fed by the checker's namespace-merge construction site.**

`tsc`'s `createAnonymousTypeNode` routes an anonymous object type through `symbolToTypeNode` when the type's symbol carries `SymbolFlags.Class`, `Enum`, or `ValueModule`. A plain function with **expando** assignments (`f.declared = 1`) gets no module flag, and there `tsc` really does print `{ (): void; declared: number; }`. tsz collapsed both onto the structural branch.

## Why the printer-only fix was a no-op

#16132 records a refuted attempt: gating the printer's `Callable` arm on the namespace predicate changed nothing. The defect has **two** halves, either alone inert:

1. **The symbol was discarded upstream.** `namespace_merged_function_callable_type` (`crates/tsz-checker/src/query_boundaries/declaration_exports.rs`) rebuilt the merged callable with `symbol: None`, so `shape.symbol` was `None` and the printer's entire named-symbol branch was unreachable. Its constructor sibling already kept the symbol *with a comment saying it does so precisely to render `typeof C`* — the function path was the lone omission of the three.
2. **The expando guard ran first.** A namespace merge appends its exports as ordinary properties, making it structurally indistinguishable from an expando assignment. The name check has to precede it.

The `(is_namespace || is_enum) && !is_class && !is_interface` predicate that `resolve_object_shape_name` already used is extracted as `symbol_renders_as_typeof_name` and shared, rather than duplicated.

## Second head: the empty-namespace refinement

Review (Quartz, m4) caught **one conformance regression** on the first head — `compiler/esModuleInteropPrettyErrorRelatedInformation.ts`, where an *empty* namespace merge must keep printing structurally. Oracled the boundary against tsc 7.0.2:

| namespace body | tsc 7.0.2 |
| --- | --- |
| `declare namespace f {}` (empty) | `() => void` |
| `declare namespace f { interface O {} }` (type-only) | `() => void` |
| `namespace f { var hidden = 1; }` (**unexported** value) | **`typeof f`** |
| `namespace f { export var v = 1; }` | `typeof f` |

Row 3 is the discriminator, and it rules out "does the merge contribute members" as tsc's actual rule: an unexported value contributes no visible member and still prints `typeof f`. tsc's real test is `SymbolFlags.ValueModule` — *instantiated vs uninstantiated*.

**That rule is currently unimplementable in tsz, and I verified it rather than assuming it.** Narrowing the predicate to `VALUE_MODULE` was a measured no-op: `crates/tsz-binder/src/modules/binding.rs:253` sets `VALUE_MODULE | NAMESPACE_MODULE` on *every* namespace unconditionally, so the flag carries no information here — despite `symbols.rs:28-29` annotating the constants as "Instantiated module" / "Uninstantiated module".

So the landed gate is **"the namespace contributed a member"**, computed at the merge site (`props.len() > shape.properties.len()`). It covers every merge that reaches the printer with appended properties, and withholds the symbol otherwise — leaving non-contributing merges byte-identical to the previous rendering.

**Residual gap, pinned as an `#[ignore]`d test:** an unexported-value-only namespace still prints structurally. That case is **unchanged from main, not regressed** — main withheld the symbol from *every* merge — so this PR strictly reduces divergence. Closing it needs the binder to model instantiation; the test names that blocker so it flips loudly when fixed.

## Adjacent-case matrix

All rows oracled against **tsc 7.0.2** (`--noEmit --target es2015 --strict false --pretty false`) and re-run at head `ae70739`.

| # | Case | tsc 7.0.2 | main | this PR |
| --- | --- | --- | --- | --- |
| 1 | pure namespace | `typeof nsOnly` | ✅ | ✅ |
| 2 | **function + namespace** | `typeof fnMerged` | ❌ structural | ✅ **flip** |
| 3 | **renamed binders** (`zzQuux`) | `typeof zzQuux` | ❌ structural | ✅ **flip** |
| 4 | class + namespace | `typeof clsMerged` | ✅ | ✅ |
| 5 | **expando, no namespace** (negative control) | `{ (): void; declared: number; }` | ✅ | ✅ unchanged |
| 6 | plain function (fallback) | `() => void` | ✅ | ✅ unchanged |
| 7 | namespace with several exports | `typeof multiEx` | ❌ structural | ✅ **flip** |
| 8 | **generic** function + namespace | `typeof genFn` | ❌ structural | ✅ **flip** |
| 9 | **overloaded** function + namespace | `typeof ovl` | ❌ structural | ✅ **flip** |
| 10 | enum + namespace | `typeof enMerged` | ✅ | ✅ |
| 11 | namespace declared first | TS2434 + `typeof preNs` | ❌ structural | ✅ **flip** |
| 12 | **expando AND namespace on one function** | `typeof bothFn` | ❌ structural | ✅ **flip** |
| 13 | **empty namespace merge** (the regression) | `() => void` | ✅ | ✅ unchanged |
| 14 | **type-only namespace merge** | `() => void` | ✅ | ✅ unchanged |
| 15 | unexported-value-only namespace | `typeof fg` | ❌ structural | ❌ structural — *documented gap, unchanged* |

Rows 5/12/13 are the set that pins the design: expando alone stays structural, expando *plus* a contributing namespace does not, and a non-contributing namespace stays structural.

## Verification at `ae70739`

- **Quartz's exact regression repro now matches tsc byte-for-byte:** `Argument of type '{ default: () => void; }' …` (first head produced `{ default: typeof foo; }`).
- `cargo fmt`, workspace `cargo clippy` (warnings denied), architecture guard — **all pass** via the `pre-commit` gate.
- `cargo test -p tsz-checker --lib render_request_tests` — **40 passed / 0 failed / 1 ignored**. The pre-existing `ts2339_merged_class_namespace_*` display tests live in this module and still pass, which is the regression check that matters most for a printer change.
- Full `cargo test -p tsz-checker --lib` — the only failure is `ts2303_tests::recursive_export_assignment_self_import_reports_ts2303`, **pre-existing on main** (`scripts/ci/known-failures.txt:127`).
- **Not run in this container: the two-sided conformance sweep, emit, and DTS.** Stated plainly rather than implied — the first head's regression is exactly what that gate exists to catch, and it was found by review, not by me. Quartz has offered a re-run on this head including emit/DTS. No conformance number is claimed here.

Expected movement from **this PR alone: zero newly-passing rows.** #16132's three `typeof f` rows each also carry the sibling #16131 misses, so neither issue flips a row on its own. Newly-failing is the gate.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Andesite