### PR TITLE
test(checker): pin bare-vs-explicitly-defaulted Generator relation (#16119)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -319,6 +319,9 @@ mod function_type_return_node_tests;
 #[path = "tests/generator_declaration_yield_star_inference_tests.rs"]
 mod generator_declaration_yield_star_inference_tests;
 #[cfg(test)]
+#[path = "tests/generator_default_type_argument_relation_tests.rs"]
+mod generator_default_type_argument_relation_tests;
+#[cfg(test)]
 #[path = "../tests/generator_union_return_type_tests.rs"]
 mod generator_union_return_type_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/generator_default_type_argument_relation_tests.rs
+++ b/crates/tsz-checker/src/tests/generator_default_type_argument_relation_tests.rs
@@ -1,0 +1,291 @@
+//! Regression pins for #16119: an **unparameterised** `Generator` /
+//! `AsyncGenerator` annotation related against its own explicitly-written
+//! default form.
+//!
+//! `Generator` and `AsyncGenerator` both declare
+//! `[T = unknown, TReturn = any, TNext = any]`
+//! (`crates/tsz-core/src/lib-assets/es2015.generator.d.ts`,
+//! `es2018.asyncgenerator.d.ts`), so a bare `Generator` and a written-out
+//! `Generator[ unknown, any, any ]` denote the same type and must relate in
+//! both directions. #16119 reported a false `TS2345` on exactly that pair,
+//! measured on #16115's merged head; it does **not** reproduce on this tree.
+//! These rows pin the family so the defect cannot return silently — the
+//! shapes have no conformance-corpus fixture, so an oracled unit matrix is
+//! the only detector.
+//!
+//! Every row was oracled first-hand against `tsc@7.0.2`
+//! (`--noEmit --strict --pretty false --target es2018 --lib es2018,dom`).
+//!
+//! The load-bearing part of this suite is [`bare_source_to_narrower_target_still_errors`]
+//! and its async twin. "tsc reports nothing" is reachable by any change that
+//! makes the relation *more permissive*, including one that stops comparing
+//! type arguments altogether — which is the most likely shape of a wrong fix
+//! for #16119, since the suspected mechanism was a positional type-argument
+//! comparison firing ahead of the structural member comparison. Those two rows
+//! keep a genuinely narrower target (`T = number` against a source `T =
+//! unknown`) rejecting, so a permissive regression fails the suite instead of
+//! passing it.
+//!
+//! Arity is varied independently of the defect (`Generator[ number ]` against
+//! `Generator[ number, any, any ]` in both directions) because the relation
+//! reaches the same comparison through a distinct arity-normalisation path
+//! (`fill_application_defaults`, `relations/subtype/rules/generics.rs`), and
+//! `Iterator` / `AsyncIterator` rows cover the same defaulting rule on the
+//! non-generator declarations that sit above them in the heritage chain.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_source_with_libs, load_default_lib_files};
+
+fn strict_codes(source: &str) -> Vec<u32> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|diagnostic| diagnostic.code)
+    .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls. These must keep reporting TS2345, or every clean row
+// below is satisfied vacuously by a relation that stopped checking arguments.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bare_source_to_narrower_target_still_errors() {
+    // Bare `Generator` is `Generator[ unknown, any, any ]`; `unknown` is not
+    // assignable to `number`, and tsc reports TS2345 here.
+    assert_eq!(
+        strict_codes(
+            r"
+declare const bare: Generator;
+declare function wants(g: Generator<number, any, any>): void;
+wants(bare);
+",
+        ),
+        vec![2345],
+    );
+}
+
+#[test]
+fn async_bare_source_to_narrower_target_still_errors() {
+    assert_eq!(
+        strict_codes(
+            r"
+declare const bare: AsyncGenerator;
+declare function wants(g: AsyncGenerator<number, any, any>): void;
+wants(bare);
+",
+        ),
+        vec![2345],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #16119's reported shape: bare against its own explicitly-defaulted form.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bare_generator_to_explicit_default_form_is_clean() {
+    assert!(
+        strict_codes(
+            r"
+declare const bare: Generator;
+declare function wants(g: Generator<unknown, any, any>): void;
+wants(bare);
+",
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn explicit_default_form_to_bare_generator_is_clean() {
+    // The reverse direction: writing the defaults out must not make the
+    // source stop relating to the bare parameter either.
+    assert!(
+        strict_codes(
+            r"
+declare const written: Generator<unknown, any, any>;
+declare function wants(g: Generator): void;
+wants(written);
+",
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn bare_async_generator_to_explicit_default_form_is_clean() {
+    assert!(
+        strict_codes(
+            r"
+declare const bare: AsyncGenerator;
+declare function wants(g: AsyncGenerator<unknown, any, any>): void;
+wants(bare);
+",
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn explicit_default_form_to_bare_async_generator_is_clean() {
+    assert!(
+        strict_codes(
+            r"
+declare const written: AsyncGenerator<unknown, any, any>;
+declare function wants(g: AsyncGenerator): void;
+wants(written);
+",
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn bare_to_bare_generator_is_clean() {
+    assert!(
+        strict_codes(
+            r"
+declare const bare: Generator;
+declare function wants(g: Generator): void;
+wants(bare);
+",
+        )
+        .is_empty()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Partial arity: the same relation reached through default-filling rather
+// than through an already-equal argument list.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn partially_applied_generator_to_full_arity_is_clean() {
+    assert!(
+        strict_codes(
+            r"
+declare const partial: Generator<number>;
+declare function wants(g: Generator<number, any, any>): void;
+wants(partial);
+",
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn full_arity_generator_to_partially_applied_is_clean() {
+    assert!(
+        strict_codes(
+            r"
+declare const full: Generator<number, any, any>;
+declare function wants(g: Generator<number>): void;
+wants(full);
+",
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn partially_applied_async_generator_to_full_arity_is_clean() {
+    assert!(
+        strict_codes(
+            r"
+declare const partial: AsyncGenerator<number>;
+declare function wants(g: AsyncGenerator<number, any, any>): void;
+wants(partial);
+",
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn full_arity_async_generator_to_partially_applied_is_clean() {
+    assert!(
+        strict_codes(
+            r"
+declare const full: AsyncGenerator<number, any, any>;
+declare function wants(g: AsyncGenerator<number>): void;
+wants(full);
+",
+        )
+        .is_empty()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The same defaulting rule one level up the heritage chain.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn partially_applied_iterator_to_full_arity_is_clean() {
+    assert!(
+        strict_codes(
+            r"
+declare const partial: Iterator<number>;
+declare function wants(g: Iterator<number, any, any>): void;
+wants(partial);
+",
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn partially_applied_async_iterator_to_full_arity_is_clean() {
+    assert!(
+        strict_codes(
+            r"
+declare const partial: AsyncIterator<number>;
+declare function wants(g: AsyncIterator<number, any, any>): void;
+wants(partial);
+",
+        )
+        .is_empty()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// An *inferred* generator reaching the same parameter. This is the shape the
+// original #16119 witness was reported through (`yield*` over an array), and
+// the reporter's own probe table used it to show `yield*` was a red herring.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn inferred_generator_to_partially_applied_target_is_clean() {
+    assert!(
+        strict_codes(
+            r"
+function* gen() { yield* [1, 2, 3]; }
+declare function wants(g: Generator<number>): void;
+wants(gen());
+",
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn inferred_async_generator_to_full_arity_target_is_clean() {
+    assert!(
+        strict_codes(
+            r"
+async function* gen() { yield* [1, 2, 3]; }
+declare function wants(g: AsyncGenerator<number, any, any>): void;
+wants(gen());
+",
+        )
+        .is_empty()
+    );
+}


### PR DESCRIPTION
Refs #16119. **Does not close it** — see "What this is not" below.

## Structural rule

**When a generic reference omits trailing type arguments that have declared defaults, it denotes the same type as the form that writes those defaults out, and `tsc` relates the two in both directions; tsz does the same through the solver's arity normalisation (`fill_application_defaults`, `relations/subtype/rules/generics.rs`).**

`Generator` and `AsyncGenerator` both declare `[ T = unknown, TReturn = any, TNext = any ]` (`crates/tsz-core/src/lib-assets/es2015.generator.d.ts:19`, `es2018.asyncgenerator.d.ts:19`), so bare `Generator` **is** `Generator[ unknown, any, any ]`.

## #16119 does not reproduce on this tree

The issue was measured on #16115's merged head. I could not reproduce it on `main` (`5b9aeeb`) under any spelling I tried:

| dimension | coverage | result |
| --- | --- | --- |
| relation rows | 20, each oracled first-hand against `tsc@7.0.2` | all match |
| flag combinations | `--strict`, no flags, `--target es2015`, `--target esnext --lib esnext`, `--strictFunctionTypes false` | all match |
| cross-file | bare `Generator`/`AsyncGenerator` imported from a second file, plus an imported alias of the defaulted form | matches |

The reporter's `Generator[ number, any, any ]` spelling in the issue **title** is a genuine `TS2345` in `tsc` too (`unknown` is not assignable to `number`) — it is the negative control, not the defect. The defect shape is bare against `Generator[ unknown, any, any ]`, which is clean in both compilers here.

## What this is not

This PR does **not** close #16119. Per the repo's own rule, "does not reproduce" is not one of the sanctioned reasons to close an issue, and I did not bisect to a fixing commit — the issue's stated head (`4e2c139`) is not present in this shallow clone. #16119 gets a comment with this evidence and stays open for the reporter to confirm against their original witness. The next concrete probe is a build at `65cd555` (#16115's squash) to confirm it reproduced there and bisect forward.

## What this does

Pins the family so it cannot return silently. These shapes have **no conformance-corpus fixture** — per the board's standing note, an oracled unit matrix is the only detector for this class, and the corpus sweep is a regression floor rather than a detector.

### The controls are the load-bearing part

`bare_source_to_narrower_target_still_errors` and its async twin assert exactly `vec[2345]`. "tsc reports nothing" is reachable by any change that makes the relation *more permissive*, including one that stops comparing type arguments altogether — which is the most likely shape of a wrong fix for #16119, since the suspected mechanism named in the issue was a positional type-argument comparison firing ahead of the structural member comparison. Those two rows keep a genuinely narrower target rejecting, so a permissive regression fails this suite instead of passing it.

Both controls were verified to actually fire in the unit harness rather than being swallowed — relevant because #16125 records `check_source_with_libs` silently losing `TS2345` on a neighbouring generator shape. They return exactly `[2345]`, so the suite is not vacuous.

### Adjacent-case matrix

| axis | rows |
| --- | --- |
| both directions | bare→written, written→bare, for `Generator` and `AsyncGenerator` |
| arity varied independently | `Generator[ number ]` ↔ `Generator[ number, any, any ]` both ways (reaches the comparison through default-filling rather than an already-equal list) |
| one level up the heritage chain | `Iterator`, `AsyncIterator` partial→full |
| inferred, not annotated | `yield*`-over-array generator and async generator reaching the same parameter — the shape the original witness was reported through |
| negative / fallback | the two `T = number` controls above |

## Goal
Goal: hold

## Verification

- `cargo fmt` — clean.
- `cargo clippy` (workspace, warnings denied) and the architecture guard — **passed**, via the `pre-commit` gate (`Clippy passed. / Architecture guard passed. / Local verification passed.`).
- `cargo test -p tsz-checker --lib generator_default_type_argument_relation_tests` — **15 passed / 0 failed** (8753 filtered out).
- Oracle: `tsc@7.0.2`, `--noEmit --strict --pretty false --target es2018 --lib es2018,dom`, run first-hand on every row.

**Conformance/emit/fourslash were not run and are not claimed.** This is a test-only change: no `crates/**` non-test source is touched, the sole non-test edit is the three-line `#[cfg(test)] mod` registration in `lib.rs`, so no compiled compiler behaviour changes and the emit/DTS floors cannot move. Saying so explicitly rather than implying a sweep passed.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Rhyolite

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTR1ZMWthfMYv5VSgtSC1Q)_