### PR TITLE
fix(solver): widen the class-only nominal fast path to interfaces

### DIFF
--- a/crates/tsz-checker/src/context/resolver.rs
+++ b/crates/tsz-checker/src/context/resolver.rs
@@ -1531,6 +1531,10 @@ impl<'a> TypeResolver for CheckerContext<'a> {
             })
     }
 
+    fn get_interface_extends(&self, def_id: DefId) -> Option<DefId> {
+        self.definition_store.get_extends(def_id)
+    }
+
     fn class_def_for_instance_type(&self, type_id: TypeId) -> Option<DefId> {
         self.type_env
             .try_borrow()

--- a/crates/tsz-solver/src/caches/query_cache_evaluation.rs
+++ b/crates/tsz-solver/src/caches/query_cache_evaluation.rs
@@ -324,6 +324,10 @@ impl TypeResolver for DelegatingHktResolver<'_> {
         self.inner.get_class_extends(def_id)
     }
 
+    fn get_interface_extends(&self, def_id: DefId) -> Option<DefId> {
+        self.inner.get_interface_extends(def_id)
+    }
+
     fn resolve_this_type(&self, interner: &dyn TypeDatabase) -> Option<TypeId> {
         self.inner.resolve_this_type(interner)
     }

--- a/crates/tsz-solver/src/def/resolver.rs
+++ b/crates/tsz-solver/src/def/resolver.rs
@@ -371,6 +371,20 @@ pub trait TypeResolver {
         None
     }
 
+    /// Get the name-resolved parent `DefId` for an interface heritage clause.
+    ///
+    /// Unlike `get_class_extends`, this is kind-agnostic binder/solver
+    /// heritage data (`DefinitionInfo::extends`, populated for both `Class`
+    /// and `Interface` defs at semantic-construction time) rather than the
+    /// checker-verified, generics-aware `class_extends` map. It records only
+    /// the first `extends` clause, so it is a correct but incomplete parent
+    /// for a multi-parent `interface B extends A, C {}` — callers must treat
+    /// a miss as "unknown", not as "no relationship", and fall back to a
+    /// structural check.
+    fn get_interface_extends(&self, _def_id: DefId) -> Option<DefId> {
+        None
+    }
+
     /// Resolve the concrete class/interface instance type for the current polymorphic `this`.
     ///
     /// When the caller is inside a class or interface member, this lets the solver
@@ -636,6 +650,10 @@ impl<T: TypeResolver + ?Sized> TypeResolver for &T {
 
     fn get_class_extends(&self, def_id: DefId) -> Option<DefId> {
         (**self).get_class_extends(def_id)
+    }
+
+    fn get_interface_extends(&self, def_id: DefId) -> Option<DefId> {
+        (**self).get_interface_extends(def_id)
     }
 
     fn class_def_for_instance_type(&self, type_id: TypeId) -> Option<DefId> {
@@ -1780,6 +1798,12 @@ impl TypeResolver for TypeEnvironment {
 
     fn get_class_extends(&self, def_id: DefId) -> Option<DefId> {
         self.get_class_extends_def(def_id)
+    }
+
+    fn get_interface_extends(&self, def_id: DefId) -> Option<DefId> {
+        self.definition_store
+            .as_ref()
+            .and_then(|store| store.get_extends(def_id))
     }
 
     fn class_def_for_instance_type(&self, type_id: TypeId) -> Option<DefId> {

--- a/crates/tsz-solver/src/relations/subtype/rules/objects.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/objects.rs
@@ -769,9 +769,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         else {
             return false;
         };
+        let source_kind = self.resolver.get_def_kind(source_def);
         if !matches!(
-            self.resolver.get_def_kind(source_def),
-            Some(crate::def::DefKind::Class)
+            source_kind,
+            Some(crate::def::DefKind::Class | crate::def::DefKind::Interface)
         ) {
             return false;
         }
@@ -791,7 +792,22 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
 
         let mut current = source_def;
         for _ in 0..50 {
-            let Some(parent) = self.resolver.get_class_extends(current) else {
+            // Classes use the checker-verified, generics-aware `class_extends`
+            // map. Interfaces never populate it, so they fall back to the
+            // name-resolved, single-parent heritage edge — sound because tsc
+            // requires a heritage clause to already be a structurally
+            // compatible override at declaration time, but incomplete for a
+            // multi-parent `interface B extends A, C {}` (a miss there just
+            // returns `false` here, which re-runs the always-correct
+            // structural walk in the caller).
+            let parent = match self.resolver.get_def_kind(current) {
+                Some(crate::def::DefKind::Class) => self.resolver.get_class_extends(current),
+                Some(crate::def::DefKind::Interface) => {
+                    self.resolver.get_interface_extends(current)
+                }
+                _ => None,
+            };
+            let Some(parent) = parent else {
                 return false;
             };
             if self.resolver.defs_are_equivalent(parent, target_def) {
@@ -1965,3 +1981,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         SubtypeResult::True
     }
 }
+
+#[cfg(test)]
+#[path = "../../../../tests/objects_interface_nominal_fastpath_tests.rs"]
+mod objects_interface_nominal_fastpath_tests;

--- a/crates/tsz-solver/tests/objects_interface_nominal_fastpath_tests.rs
+++ b/crates/tsz-solver/tests/objects_interface_nominal_fastpath_tests.rs
@@ -1,0 +1,293 @@
+//! Regression tests for issue #16089 — the O(1) nominal fast path in
+//! `check_object_subtype` (`class_instance_extends_target_def`) was hard-gated
+//! to `DefKind::Class`, so every `interface B extends A {}` relation against
+//! `A` fell through to the full structural member walk even though tsc's own
+//! override-compatibility rule at declaration time already guarantees `B`'s
+//! instance is `<: A` — the same premise the class fast path relies on. The
+//! walk over a DOM-lib interface's ~58-receiver closure (`Window`, `Document`,
+//! …) is what made `interface W2 extends Window {}` time out; see the issue
+//! for the full measurement trail.
+//!
+//! These are white-box tests of `class_instance_extends_target_def` itself,
+//! constructed with a fake `TypeResolver`, not run through the diagnostics
+//! harness: the fast path and the structural walk it short-circuits are
+//! required to reach the same verdict by construction, so a checker-level
+//! before/after diagnostics diff cannot distinguish "took the fast path" from
+//! "the slow path happened to agree" (see the coordination board's standing
+//! note on `#16018`-style widenings that moved zero tests either way). Only a
+//! direct call proves the new `DefKind::Interface` branch consults
+//! `get_interface_extends`, walks multiple hops, and never leaks onto/from
+//! the class-only `class_extends` map.
+//!
+//! The real DOM-lib performance win is a separate, non-unit-testable claim:
+//! the fast path only fires when `is_actual_or_cloned_lib_def(target_def)` is
+//! true, which no synthetic user-program def in this harness (or in the
+//! checker's lib-free unit harness) ever satisfies. That half is verified by
+//! timing the real `tsz` binary against the issue's own witness.
+
+use crate::construction::TypeDatabase;
+use crate::construction::TypeInterner;
+use crate::def::DefId;
+use crate::def::DefKind;
+use crate::relations::subtype::SubtypeChecker;
+use crate::relations::subtype::TypeResolver;
+use crate::types::{ObjectShape, SymbolRef, TypeId};
+use std::collections::HashMap;
+use tsz_binder::SymbolId;
+
+#[derive(Default)]
+struct FakeHeritageResolver {
+    kinds: HashMap<u32, DefKind>,
+    class_extends: HashMap<u32, DefId>,
+    interface_extends: HashMap<u32, DefId>,
+    lib_defs: HashMap<u32, ()>,
+    symbol_defs: HashMap<u32, DefId>,
+}
+
+impl FakeHeritageResolver {
+    fn with_kind(mut self, def_id: DefId, kind: DefKind) -> Self {
+        self.kinds.insert(def_id.0, kind);
+        self
+    }
+
+    fn with_class_extends(mut self, child: DefId, parent: DefId) -> Self {
+        self.class_extends.insert(child.0, parent);
+        self
+    }
+
+    fn with_interface_extends(mut self, child: DefId, parent: DefId) -> Self {
+        self.interface_extends.insert(child.0, parent);
+        self
+    }
+
+    fn with_lib_def(mut self, def_id: DefId) -> Self {
+        self.lib_defs.insert(def_id.0, ());
+        self
+    }
+
+    fn with_symbol(mut self, symbol: SymbolId, def_id: DefId) -> Self {
+        self.symbol_defs.insert(symbol.0, def_id);
+        self
+    }
+}
+
+impl TypeResolver for FakeHeritageResolver {
+    fn resolve_ref(&self, _symbol: SymbolRef, _interner: &dyn TypeDatabase) -> Option<TypeId> {
+        None
+    }
+
+    fn get_def_kind(&self, def_id: DefId) -> Option<DefKind> {
+        self.kinds.get(&def_id.0).copied()
+    }
+
+    fn get_class_extends(&self, def_id: DefId) -> Option<DefId> {
+        self.class_extends.get(&def_id.0).copied()
+    }
+
+    fn get_interface_extends(&self, def_id: DefId) -> Option<DefId> {
+        self.interface_extends.get(&def_id.0).copied()
+    }
+
+    fn is_actual_or_cloned_lib_def(&self, def_id: DefId) -> bool {
+        self.lib_defs.contains_key(&def_id.0)
+    }
+
+    fn symbol_to_def_id(&self, symbol: SymbolRef) -> Option<DefId> {
+        self.symbol_defs.get(&symbol.0).copied()
+    }
+}
+
+fn shape_with_symbol(symbol: SymbolId) -> ObjectShape {
+    ObjectShape {
+        symbol: Some(symbol),
+        ..Default::default()
+    }
+}
+
+/// `W2 extends Window {}` against a lib-def `Window` target: the new
+/// `DefKind::Interface` arm must consult `get_interface_extends` (the
+/// class-only map is empty) and return `true` in one hop.
+#[test]
+fn interface_source_uses_interface_extends_map() {
+    let interner = TypeInterner::new();
+    let source = DefId(1);
+    let target = DefId(2);
+    let symbol = SymbolId(100);
+    let resolver = FakeHeritageResolver::default()
+        .with_kind(source, DefKind::Interface)
+        .with_kind(target, DefKind::Interface)
+        .with_interface_extends(source, target)
+        .with_lib_def(target)
+        .with_symbol(symbol, source);
+    let checker = SubtypeChecker::with_resolver(&interner, &resolver);
+
+    assert!(checker.class_instance_extends_target_def(
+        &shape_with_symbol(symbol),
+        None,
+        Some(target),
+    ));
+}
+
+/// Negative control: an interface with no recorded heritage edge must not be
+/// treated as related — the caller's structural walk is the one that gets to
+/// decide, not a stale/absent fast-path answer.
+#[test]
+fn interface_source_without_heritage_edge_declines() {
+    let interner = TypeInterner::new();
+    let source = DefId(1);
+    let target = DefId(2);
+    let symbol = SymbolId(100);
+    let resolver = FakeHeritageResolver::default()
+        .with_kind(source, DefKind::Interface)
+        .with_lib_def(target)
+        .with_symbol(symbol, source);
+    let checker = SubtypeChecker::with_resolver(&interner, &resolver);
+
+    assert!(!checker.class_instance_extends_target_def(
+        &shape_with_symbol(symbol),
+        None,
+        Some(target),
+    ));
+}
+
+/// Regression control: the pre-existing class path is untouched — a class
+/// source still resolves its parent through `get_class_extends`.
+#[test]
+fn class_source_still_uses_class_extends_map() {
+    let interner = TypeInterner::new();
+    let source = DefId(1);
+    let target = DefId(2);
+    let symbol = SymbolId(100);
+    let resolver = FakeHeritageResolver::default()
+        .with_kind(source, DefKind::Class)
+        .with_kind(target, DefKind::Class)
+        .with_class_extends(source, target)
+        .with_lib_def(target)
+        .with_symbol(symbol, source);
+    let checker = SubtypeChecker::with_resolver(&interner, &resolver);
+
+    assert!(checker.class_instance_extends_target_def(
+        &shape_with_symbol(symbol),
+        None,
+        Some(target),
+    ));
+}
+
+/// A class source must never fall back to the interface map, even if it
+/// happens to be populated — the two maps are strictly kind-partitioned.
+#[test]
+fn class_source_ignores_interface_extends_map() {
+    let interner = TypeInterner::new();
+    let source = DefId(1);
+    let target = DefId(2);
+    let symbol = SymbolId(100);
+    let resolver = FakeHeritageResolver::default()
+        .with_kind(source, DefKind::Class)
+        .with_kind(target, DefKind::Class)
+        .with_interface_extends(source, target) // wrong map, deliberately
+        .with_lib_def(target)
+        .with_symbol(symbol, source);
+    let checker = SubtypeChecker::with_resolver(&interner, &resolver);
+
+    assert!(!checker.class_instance_extends_target_def(
+        &shape_with_symbol(symbol),
+        None,
+        Some(target),
+    ));
+}
+
+/// Symmetric control: an interface source must never fall back to the
+/// class-only map.
+#[test]
+fn interface_source_ignores_class_extends_map() {
+    let interner = TypeInterner::new();
+    let source = DefId(1);
+    let target = DefId(2);
+    let symbol = SymbolId(100);
+    let resolver = FakeHeritageResolver::default()
+        .with_kind(source, DefKind::Interface)
+        .with_kind(target, DefKind::Interface)
+        .with_class_extends(source, target) // wrong map, deliberately
+        .with_lib_def(target)
+        .with_symbol(symbol, source);
+    let checker = SubtypeChecker::with_resolver(&interner, &resolver);
+
+    assert!(!checker.class_instance_extends_target_def(
+        &shape_with_symbol(symbol),
+        None,
+        Some(target),
+    ));
+}
+
+/// Multi-hop chain: `C extends B {}`, `B extends A {}`, target `A`. Proves the
+/// walk re-checks `get_def_kind` at every hop rather than only the source's
+/// own kind, and follows more than one edge.
+#[test]
+fn interface_multi_hop_chain_walks_to_target() {
+    let interner = TypeInterner::new();
+    let source = DefId(1); // C
+    let mid = DefId(2); // B
+    let target = DefId(3); // A
+    let symbol = SymbolId(100);
+    let resolver = FakeHeritageResolver::default()
+        .with_kind(source, DefKind::Interface)
+        .with_kind(mid, DefKind::Interface)
+        .with_kind(target, DefKind::Interface)
+        .with_interface_extends(source, mid)
+        .with_interface_extends(mid, target)
+        .with_lib_def(target)
+        .with_symbol(symbol, source);
+    let checker = SubtypeChecker::with_resolver(&interner, &resolver);
+
+    assert!(checker.class_instance_extends_target_def(
+        &shape_with_symbol(symbol),
+        None,
+        Some(target),
+    ));
+}
+
+/// A def kind the fast path does not recognize (e.g. a type alias standing in
+/// for any non-class/interface kind) must decline immediately, unchanged from
+/// before this fix.
+#[test]
+fn unrecognized_def_kind_declines() {
+    let interner = TypeInterner::new();
+    let source = DefId(1);
+    let target = DefId(2);
+    let symbol = SymbolId(100);
+    let resolver = FakeHeritageResolver::default()
+        .with_kind(source, DefKind::TypeAlias)
+        .with_interface_extends(source, target)
+        .with_lib_def(target)
+        .with_symbol(symbol, source);
+    let checker = SubtypeChecker::with_resolver(&interner, &resolver);
+
+    assert!(!checker.class_instance_extends_target_def(
+        &shape_with_symbol(symbol),
+        None,
+        Some(target),
+    ));
+}
+
+/// The fast path must still require the target to be an actual/cloned lib
+/// def — an interface heritage edge to a plain user-program interface must
+/// not short-circuit (matches the pre-existing class behavior).
+#[test]
+fn interface_source_requires_lib_target() {
+    let interner = TypeInterner::new();
+    let source = DefId(1);
+    let target = DefId(2);
+    let symbol = SymbolId(100);
+    let resolver = FakeHeritageResolver::default()
+        .with_kind(source, DefKind::Interface)
+        .with_kind(target, DefKind::Interface)
+        .with_interface_extends(source, target)
+        .with_symbol(symbol, source); // no with_lib_def(target)
+    let checker = SubtypeChecker::with_resolver(&interner, &resolver);
+
+    assert!(!checker.class_instance_extends_target_def(
+        &shape_with_symbol(symbol),
+        None,
+        Some(target),
+    ));
+}


### PR DESCRIPTION
Closes (partially) #16089. Fixes the specific `interface extends` fast-path gap found by Dolomite's investigation on that issue.

Structural rule: when an object relation's source is a nominal interface declared with `extends`, and the target is a lib-originated def with no type parameters, `tsc`'s declaration-time override-compatibility check already guarantees the interface's instance is structurally a subtype of its heritage parent — `tsz` should take the same O(1) heritage-chain shortcut it already takes for classes, through the solver's relation layer (`class_instance_extends_target_def`, `crates/tsz-solver/src/relations/subtype/rules/objects.rs`), instead of paying the full structural member walk every time.

## Why this was slow

`check_object_subtype`'s nominal fast path was hard-gated to `DefKind::Class` (`objects.rs:772-777` before this change). `interface W2 extends Window {}` therefore fell through to the full structural walk on every relation against `Window`, which per #16089's measurement trail costs ~118 `run_instantiator` invocations walking `Window`'s ~58-receiver DOM closure for polymorphic-`this` substitution — the mechanism behind `typeArgumentInferenceConstructSignatures.ts` timing out in conformance.

## The fix

- Widened the gate to `DefKind::Class | DefKind::Interface`.
- Classes keep using the existing checker-verified, generics-aware `class_extends` map via `get_class_extends` — unchanged.
- Interfaces never populate that map, so they use a new `TypeResolver::get_interface_extends` query-boundary method, backed by the already-populated, kind-agnostic `DefinitionStore::get_extends` (binder/solver heritage data, populated for both `Class` and `Interface` at semantic-construction time, but only for the *first* `extends` clause).
- The walk re-checks `get_def_kind` at every hop (not just the source's own kind), and each `DefKind` strictly reads its own map — verified by tests that deliberately cross-populate the wrong map and assert the fast path still declines.
- A multi-parent `interface B extends A, C {}` only has `A` tracked; the miss on `C` correctly returns `false` from the fast path and falls back to the always-correct structural walk — no behavior change for that shape, just no speedup for it.
- Added `get_interface_extends` to the two other places that forward `get_class_extends` today (the `&T` blanket resolver impl, `DelegatingHktResolver`) so the fast path doesn't silently go inert behind those wrappers.

Owner layers: this is entirely within the solver relation layer and its `TypeResolver` query-boundary surface (`crates/tsz-solver/src/def/resolver.rs`, `crates/tsz-solver/src/relations/subtype/rules/objects.rs`, `crates/tsz-solver/src/caches/query_cache_evaluation.rs`); the one checker-side change is a one-line `TypeResolver` impl method on `CheckerContext` (`crates/tsz-checker/src/context/resolver.rs`) delegating to the existing `DefinitionStore`, mirroring how `get_class_extends` is already wired there.

## Adjacent-case matrix (8 white-box unit tests)

The fast path and the structural walk it short-circuits are required to reach the *same diagnostic verdict* by construction (that's the whole soundness argument), so a checker-level diagnostics diff cannot distinguish "took the fast path" from "the slow path agreed anyway" — this exact trap is called out on the coordination board for prior `#16018`-style widenings. Instead, `crates/tsz-solver/tests/objects_interface_nominal_fastpath_tests.rs` calls `class_instance_extends_target_def` directly against a fake `TypeResolver`:

| Case | Assertion |
| --- | --- |
| Interface source, direct interface-extends hit | fast path returns `true` |
| Interface source, no heritage edge recorded | fast path declines (`false`) |
| Class source (regression control) | still resolves via `get_class_extends` |
| Class source with only the *interface* map populated | still declines — maps are strictly kind-partitioned |
| Interface source with only the *class* map populated | still declines (symmetric control) |
| Multi-hop interface chain (`C extends B extends A`) | walk re-checks kind per hop, follows 2 edges |
| Unrecognized `DefKind` (e.g. `TypeAlias`) | declines, unchanged from before |
| Interface heritage edge to a non-lib target | declines — `is_actual_or_cloned_lib_def` gate still applies |

The real DOM-lib performance win is a separate, non-unit-testable claim (the fast path only fires when the target is `is_actual_or_cloned_lib_def`, which no synthetic def in either unit harness ever satisfies) — verified below by timing the real binary against the issue's own witness.

## Goal
Goal: fast

## Verification
- `cargo test -p tsz-solver --lib`: **7630 passed / 0 failed** (7622 baseline + 8 new), including the new `objects_interface_nominal_fastpath_tests` module.
- `cargo fmt` / `cargo clippy` (workspace, warnings denied) via the `pre-commit` hook — passed.
- Real-binary timing on `dev` profile, the exact `e2` witness from #16089 (`interface W2 extends Window {} declare var w: W2; var r: Window = w;`), `--target es2017 --lib es5,dom`:
  - **Before** (parent `5b9aeeb`, binary built from the pre-fix source): still running past **150s** CPU time when killed (consistent with Gneiss's/Andesite's earlier >200-400s measurements on this exact witness).
  - **After** (this branch): **5.2s** wall clock.
- Not run from this container: `scripts/conformance/compare-to-parent.sh` and the full `conformance.sh snapshot` — no TypeScript-submodule-bearing, warmed seat was available in the session budget after the build+measurement above. This PR only *adds* a fast-path shortcut whose answer is required to match the existing structural walk by construction (see the unit-test rationale above), so the expected conformance delta is zero either way; a seat that can run the two-sided diff should still do so before this lands, per the repo's own hot-relation-path gate.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT