### PR TITLE
fix(checker): stop reporting TS2407 for circular and nullable for-in operands

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1109,6 +1109,9 @@ mod for_in_lhs_relation_routing_arch_tests;
 #[path = "../tests/for_in_narrowing_tests.rs"]
 mod for_in_narrowing_tests;
 #[cfg(test)]
+#[path = "../tests/for_in_self_reference_and_nullable_operand_tests.rs"]
+mod for_in_self_reference_and_nullable_operand_tests;
+#[cfg(test)]
 #[path = "tests/fresh_const_array_mutable_assignment_tests.rs"]
 mod fresh_const_array_mutable_assignment_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/variable_checking/for_loop.rs
+++ b/crates/tsz-checker/src/state/variable_checking/for_loop.rs
@@ -388,7 +388,17 @@ impl<'a> CheckerState<'a> {
             // member is object-like (the raw operand above was not itself an intersection).
             || self.for_in_expr_type_is_valid_intersection(expr_type);
 
-        if !is_valid {
+        // Checked only on the error path, so an accepted operand never pays for
+        // the walk: tsc derives a for-in loop variable's type from the loop's
+        // own operand (`getIndexType(checkExpression(node.expression))` in
+        // `getTypeForVariableLikeDeclaration`), so an operand naming a variable
+        // this same loop head declares is a circular resolution —
+        // `pushTypeResolution` fails, `reportCircularityError` hands back `any`
+        // (reporting TS7022 only under `noImplicitAny`), and `any` clears this
+        // gate. tsz resolves the loop variable to its `string` key type instead,
+        // which is a primitive and tripped a false TS2407 on `for (var of in of)`
+        // and on `recursiveLetConst.ts`'s `for (let v in v)`.
+        if !is_valid && !self.for_in_operand_resolution_is_circular(expression) {
             let type_str = self.format_type(expr_type);
             let message = format_message(
                 diagnostic_messages::THE_RIGHT_HAND_SIDE_OF_A_FOR_IN_STATEMENT_MUST_BE_OF_TYPE_ANY_AN_OBJECT_TYPE_OR,
@@ -396,6 +406,59 @@ impl<'a> CheckerState<'a> {
             );
             self.error_at_node(expression, &message, diagnostic_codes::THE_RIGHT_HAND_SIDE_OF_A_FOR_IN_STATEMENT_MUST_BE_OF_TYPE_ANY_AN_OBJECT_TYPE_OR);
         }
+    }
+
+    /// Whether the for-in operand at `expression` resolves circularly: it
+    /// references a variable declared by the very loop head it belongs to.
+    ///
+    /// Keyed on binder symbol identity (through the same
+    /// `expression_references_symbol` walk the for-of circularity check uses),
+    /// never on the identifier's spelling — a differently-named loop variable
+    /// over an unrelated binding of any type is untouched by this.
+    fn for_in_operand_resolution_is_circular(&mut self, expression: NodeIndex) -> bool {
+        let arena = self.ctx.arena;
+        let Some(ext) = arena.get_extended(expression) else {
+            return false;
+        };
+        let statement_idx = ext.parent;
+        let Some(statement) = arena.get(statement_idx) else {
+            return false;
+        };
+        if statement.kind != syntax_kind_ext::FOR_IN_STATEMENT {
+            return false;
+        }
+        let Some(initializer) = arena.get_for_in_of(statement).map(|f| f.initializer) else {
+            return false;
+        };
+        let Some(list) = arena.get(initializer).and_then(|n| arena.get_variable(n)) else {
+            return false;
+        };
+
+        for &decl_idx in &list.declarations.nodes {
+            let Some(var_decl) = arena
+                .get(decl_idx)
+                .and_then(|node| arena.get_variable_declaration(node))
+            else {
+                continue;
+            };
+            // An annotated loop variable is not circular: tsc reads the
+            // annotation instead of the operand (and reports TS2404 for it).
+            if var_decl.type_annotation.is_some() {
+                continue;
+            }
+            let sym_id = self
+                .ctx
+                .binder
+                .get_node_symbol(decl_idx)
+                .or_else(|| self.ctx.binder.get_node_symbol(var_decl.name))
+                .or_else(|| self.ctx.binder.resolve_identifier(arena, var_decl.name));
+            if let Some(sym_id) = sym_id
+                && self.expression_references_symbol(expression, sym_id)
+            {
+                return true;
+            }
+        }
+        false
     }
 
     /// Leaf (non-union, non-intersection) validity test for a for-in operand:
@@ -409,7 +472,20 @@ impl<'a> CheckerState<'a> {
         ty == TypeId::ANY
             || ty == TypeId::UNKNOWN
             || ty == TypeId::OBJECT
+            || self.for_in_operand_is_absorbed_nullable(ty)
             || self.is_deferred_object_like_for_in(ty)
+    }
+
+    /// Without `strictNullChecks`, `null` and `undefined` are members of every
+    /// type, so `tsc`'s `allTypesAssignableToKind(rightType, NonPrimitive | ...)`
+    /// gate accepts them and `for (var a in null) {}` is silent. With the flag
+    /// on the operand is stripped to `never` and TS2407 *is* reported — so this
+    /// is a flag-dependent assignability fact, not a claim that bottom types are
+    /// acceptable operands (a declared `never` operand still reports in both
+    /// modes). Verified against `tsc` 7.0.2 both ways.
+    fn for_in_operand_is_absorbed_nullable(&self, ty: TypeId) -> bool {
+        !self.ctx.compiler_options.strict_null_checks
+            && (ty == TypeId::NULL || ty == TypeId::UNDEFINED)
     }
 
     /// Helper for TS2407: Check if a union type contains at least one valid for-in expression type.

--- a/crates/tsz-checker/tests/for_in_self_reference_and_nullable_operand_tests.rs
+++ b/crates/tsz-checker/tests/for_in_self_reference_and_nullable_operand_tests.rs
@@ -1,0 +1,198 @@
+//! Regression tests for TS2407 on `for-in` operands that `tsc` accepts because
+//! the operand never reaches the object-type gate with a real type.
+//!
+//! Two independent mechanisms, both oracle-verified against `tsc` 7.0.2
+//! (`--noEmit --target es2015 --pretty false`, `--strict` both ways):
+//!
+//! 1. **Circular self-reference.** `for (var v in v) {}` asks for the type of
+//!    `v` while computing the type of `v` — `tsc` breaks that cycle by handing
+//!    back `any` (and, under `noImplicitAny` only, reporting TS7022). `any` is
+//!    a valid for-in operand, so TS2407 never fires. tsz resolved the loop
+//!    variable to its for-in key type instead and reported a false TS2407.
+//!    This is the `for (var of in of) {}` witness behind
+//!    `parserForOfStatement19.ts` / `parserES5ForOfStatement19.ts`, and the
+//!    `for (let v in v) {}` line of `recursiveLetConst.ts`.
+//!
+//! 2. **Nullable operands without `strictNullChecks`.** With the flag off,
+//!    `null` and `undefined` are members of every type, so `null` satisfies the
+//!    object-type gate and `tsc` is silent; with the flag on, the operand is
+//!    stripped to `never` and TS2407 *is* reported. tsz reported TS2407 in both
+//!    modes. This is the `for (var a in null) {}` line of `widenedTypes.ts`.
+//!
+//! `never` itself stays an error in both modes (oracle-confirmed), so the
+//! nullable case is genuinely about flag-dependent assignability and not about
+//! bottom types being acceptable operands.
+//!
+//! Binder names are varied across cases so nothing here can be satisfied by a
+//! user-chosen identifier.
+
+use crate::test_utils::{check_source_non_strict_codes, check_source_strict_codes};
+
+const TS2407: u32 = 2407;
+
+/// All four conformance rows behind this suite carry `// @strict: false`, and
+/// `CheckerOptions::default()` is a *strict* run in TypeScript 7 — so the
+/// non-strict projection is the one that reproduces them.
+fn non_strict(source: &str) -> Vec<u32> {
+    check_source_non_strict_codes(source)
+}
+
+fn strict(source: &str) -> Vec<u32> {
+    check_source_strict_codes(source)
+}
+
+fn assert_no_2407(codes: &[u32], label: &str) {
+    assert!(
+        !codes.contains(&TS2407),
+        "{label}: expected no TS2407 (tsc accepts this operand), got codes: {codes:?}"
+    );
+}
+
+fn assert_has_2407(codes: &[u32], label: &str) {
+    assert!(
+        codes.contains(&TS2407),
+        "{label}: expected TS2407 (tsc rejects this operand), got codes: {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Mechanism 1 — circular self-reference resolves to `any`, so no TS2407.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn for_in_operand_naming_its_own_var_loop_variable_is_not_ts2407() {
+    // `parserForOfStatement19.ts` / `parserES5ForOfStatement19.ts`: the loop
+    // variable is literally named `of`, which is a for-in over itself.
+    let source = "for (var of in of) { }\n";
+    assert_no_2407(&non_strict(source), "var self-reference (`of`)");
+    assert_no_2407(&strict(source), "var self-reference (`of`), strict");
+}
+
+#[test]
+fn for_in_operand_naming_its_own_let_loop_variable_is_not_ts2407() {
+    // `recursiveLetConst.ts`: tsc reports TS2448 for the TDZ use and nothing
+    // else — in particular no TS2407.
+    let source = "for (let v in v) { }\n";
+    assert_no_2407(&non_strict(source), "let self-reference");
+    assert_no_2407(&strict(source), "let self-reference, strict");
+}
+
+#[test]
+fn renamed_binder_self_referential_for_in_operand_is_not_ts2407() {
+    let source = "for (var payload in payload) { }\n";
+    assert_no_2407(&non_strict(source), "renamed binder self-reference");
+}
+
+#[test]
+fn indirect_self_referential_for_in_operand_is_not_ts2407() {
+    // The cycle runs through a property access: `w.k` still needs `w`'s type.
+    let source = "for (var w in w.k) { }\n";
+    assert_no_2407(&non_strict(source), "indirect self-reference");
+}
+
+#[test]
+fn const_self_referential_for_in_operand_is_not_ts2407() {
+    let source = "for (const c in c) { }\n";
+    assert_no_2407(&non_strict(source), "const self-reference");
+}
+
+#[test]
+fn self_referential_for_in_operand_inside_a_function_body_is_not_ts2407() {
+    let source = "function outer() { for (var s in s) { } }\n";
+    assert_no_2407(&non_strict(source), "nested self-reference");
+}
+
+// ---------------------------------------------------------------------------
+// Mechanism 2 — nullable operands are flag-dependent.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn null_for_in_operand_without_strict_null_checks_is_not_ts2407() {
+    // `widenedTypes.ts` (`// @strict: false`).
+    let source = "for (var a in null) { }\n";
+    assert_no_2407(&non_strict(source), "null operand, non-strict");
+}
+
+#[test]
+fn undefined_for_in_operand_without_strict_null_checks_is_not_ts2407() {
+    let source = "for (var b in undefined) { }\n";
+    assert_no_2407(&non_strict(source), "undefined operand, non-strict");
+}
+
+#[test]
+fn null_for_in_operand_under_strict_null_checks_is_still_ts2407() {
+    // Same source, opposite verdict: with the flag on tsc strips the operand to
+    // `never` and reports TS2407. The non-strict rows above must not be bought
+    // by making nullable operands universally valid.
+    let source = "for (var a in null) { }\n";
+    assert_has_2407(&strict(source), "null operand, strict");
+}
+
+#[test]
+fn undefined_for_in_operand_under_strict_null_checks_is_still_ts2407() {
+    let source = "for (var b in undefined) { }\n";
+    assert_has_2407(&strict(source), "undefined operand, strict");
+}
+
+// ---------------------------------------------------------------------------
+// Controls — the gate still rejects what tsc rejects.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn string_literal_for_in_operand_is_still_ts2407() {
+    let source = "for (var k in \"abc\") { }\n";
+    assert_has_2407(&non_strict(source), "string literal operand");
+    assert_has_2407(&strict(source), "string literal operand, strict");
+}
+
+#[test]
+fn declared_never_for_in_operand_is_still_ts2407_in_both_modes() {
+    let source = "declare const nothing: never;\nfor (var a in nothing) { }\n";
+    assert_has_2407(&non_strict(source), "never operand");
+    assert_has_2407(&strict(source), "never operand, strict");
+}
+
+#[test]
+fn number_variable_for_in_operand_is_still_ts2407() {
+    let source = "declare const count: number;\nfor (var idx in count) { }\n";
+    assert_has_2407(&non_strict(source), "number operand");
+}
+
+#[test]
+fn ordinary_object_for_in_operands_stay_clean() {
+    let source = "\
+var src = { a: 1 };
+for (var kk in src) { }
+let obj = { b: 2 };
+for (let k2 in obj) { }
+";
+    assert_no_2407(&non_strict(source), "ordinary object operands");
+    assert_no_2407(&strict(source), "ordinary object operands, strict");
+}
+
+#[test]
+fn a_distinct_outer_binding_of_the_same_name_is_not_treated_as_self_reference() {
+    // `holder` here is an ordinary object in scope; the loop variable shadows
+    // it. The operand still resolves to the *outer* binding for tsc (the inner
+    // declaration is not yet initialized), so this must not become an error —
+    // and, just as importantly, the self-reference exemption must not be the
+    // reason it is clean for a non-object outer binding, which the next case
+    // pins.
+    let source = "\
+var holder = { a: 1 };
+for (var holder2 in holder) { }
+";
+    assert_no_2407(&non_strict(source), "shadowing outer object");
+}
+
+#[test]
+fn a_non_object_outer_binding_still_reports_even_when_a_loop_variable_shadows_it() {
+    // The exemption is keyed on the operand's *own* circular resolution, not on
+    // name equality: a differently-named loop variable over a `string` binding
+    // must still report.
+    let source = "\
+var text = \"abc\";
+for (var textKey in text) { }
+";
+    assert_has_2407(&non_strict(source), "non-object outer binding");
+}


### PR DESCRIPTION
TS2407's operand gate fires on two shapes `tsc` accepts. Both rules below were oracle-verified against `tsc` 7.0.2 (`--noEmit --target es2015 --pretty false`, `--strict` both ways) before any code was touched.

**Structural rule 1.** When a `for-in` operand references a variable that the same loop head declares, `tsc` is in a circular resolution — it derives the loop variable's type from the loop's own operand (`getIndexType(checkExpression(node.expression))` in `getTypeForVariableLikeDeclaration`), so `pushTypeResolution` fails and `reportCircularityError` hands back `any`, which clears the operand gate (TS7022 is a separate diagnostic, reported only under `noImplicitAny`). tsz resolves the loop variable to its `string` key type instead, so the operand looked like a primitive and TS2407 fired. tsz now takes the same exemption through the checker's for-loop layer (`crates/tsz-checker/src/state/variable_checking/for_loop.rs`), keyed on **binder symbol identity** via the same `expression_references_symbol` walk the existing for-of circularity check uses — never on the identifier's spelling.

**Structural rule 2.** When `strictNullChecks` is off, `null` and `undefined` are members of every type, so they satisfy `allTypesAssignableToKind(rightType, NonPrimitive | InstantiableNonPrimitive)` and `tsc` is silent; with the flag on the operand is stripped to `never` and TS2407 *is* correct. tsz reported in both modes. The exemption is leaf-only and flag-gated, so a declared `never` operand still reports in both modes and `string | null` (which collapses to `string` without the flag) is untouched.

## Why this is not a suppression

Neither exemption reads a name, a file, or rendered output. Rule 1 is a symbol-identity property of the loop head; rule 2 is a compiler-flag-dependent assignability fact with the opposite verdict pinned under the opposite flag. Rule 1 is evaluated **only on the error path** (after `is_valid` fails), so an accepted operand pays nothing for the walk.

## Conformance rows this targets

Found by clustering the committed `scripts/conformance/conformance-detail.json` on extra-diagnostic codes (`x`), not from an issue:

| row | tsc expects | tsz before | tsz after |
| --- | --- | --- | --- |
| `conformance/parser/ecmascript6/Iterators/parserForOfStatement19.ts` | (clean) | `TS2407` | expected clean |
| `conformance/parser/ecmascript5/Statements/parserES5ForOfStatement19.ts` | (clean) | `TS2407` | expected clean |
| `compiler/recursiveLetConst.ts` | `TS2448` | `TS2407 TS2448` | expected `TS2448` |
| `compiler/widenedTypes.ts` | `TS2322 TS2358 TS2695 TS18050` | `TS2322 TS2358 TS2407 TS2695` | one code closer; still fails on a separate **missing** TS18050 |

The first three have no other delta, so they are expected to flip; `widenedTypes.ts` needs `checkNonNullExpression`'s TS18050 on `in`/`instanceof` operands, which is a different defect and deliberately out of scope here.

## Adjacent-case matrix

New suite `crates/tsz-checker/tests/for_in_self_reference_and_nullable_operand_tests.rs` (16 tests, registered in `lib.rs` — an unregistered test file silently never runs, per a prior session's finding). Every row's expectation is the oracle's output, not tsz's:

| case | expectation |
| --- | --- |
| `for (var of in of)` — the parser fixtures' witness | no TS2407, both modes |
| `for (let v in v)` — TDZ self-reference | no TS2407, both modes |
| `for (var payload in payload)` — renamed binder | no TS2407 |
| `for (var w in w.k)` — indirect, through a property access | no TS2407 |
| `for (const c in c)` | no TS2407 |
| self-reference nested in a function body | no TS2407 |
| `for (var a in null)` / `for (var b in undefined)`, no `strictNullChecks` | no TS2407 |
| the same two sources **with** `strictNullChecks` | TS2407 still reported |
| `for (var k in "abc")` | TS2407 still reported, both modes |
| declared `never` operand | TS2407 still reported, both modes |
| `number` operand | TS2407 still reported |
| ordinary object operands (`var`/`let`) | clean, both modes |
| loop variable shadowing an unrelated object binding | clean |
| differently-named loop variable over a `string` binding | TS2407 still reported |

The last two exist specifically so the exemption cannot be satisfied by name equality.

All four conformance fixtures carry `// @strict: false`, and `CheckerOptions::default()` is a *strict* run in TypeScript 7 — the suite uses `check_source_non_strict_codes` for those rows. Measuring this wrong is why an earlier iteration of the nullable half read as a no-op.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib for_in_self_reference_and_nullable_operand` — **before the fix: 9 passed / 7 failed** (all 7 failures are the defect rows; every control already passed). **After: 16 passed / 0 failed.**
- `cargo test -p tsz-checker --lib for_in` — 65 passed / 0 failed (includes the pre-existing `for_in_intersection_operand_tests` and `for_in_narrowing_tests` suites).
- `cargo fmt`, `cargo clippy` (workspace, warnings denied) and the architecture guard — passed via the `pre-commit` hook.
- Full `cargo test -p tsz-checker --lib` — running at push time on this container; result posted as a PR comment.
- **Not run here:** `scripts/conformance/compare-to-parent.sh` and the full snapshot (no TypeScript submodule on this seat — the row table above is derived from the committed detail artifact, not from a fresh run), and `scripts/emit/run.sh` (cold `npm install` under `scripts/emit/` is the 40+ minute path on a cloud seat). This change only *removes* diagnostics on two narrowly-gated shapes and adds no new ones, but a seat with a warm corpus should still run the two-sided diff before this lands.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Diorite

---
_Generated by [Claude Code](https://claude.ai/code/session_01BxZdSCXxuGQrdytijMBjSn)_