### PR TITLE
fix(checker): warm generator return-type Application cache to fix TS2345 FP

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -322,6 +322,9 @@ mod generator_declaration_yield_star_inference_tests;
 #[path = "tests/generator_default_type_argument_relation_tests.rs"]
 mod generator_default_type_argument_relation_tests;
 #[cfg(test)]
+#[path = "tests/generator_inferred_yield_star_array_generic_call_tests.rs"]
+mod generator_inferred_yield_star_array_generic_call_tests;
+#[cfg(test)]
 #[path = "../tests/generator_union_return_type_tests.rs"]
 mod generator_union_return_type_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/generator_inferred_yield_star_array_generic_call_tests.rs
+++ b/crates/tsz-checker/src/tests/generator_inferred_yield_star_array_generic_call_tests.rs
@@ -2,8 +2,8 @@
 //! contribution is `yield*` over an array reported a spurious `TS2345` when
 //! its inferred return type was passed to a *generic* parameter (`want<T>(x:
 //! AsyncGenerator<T, any, any>): T`) — the source rendered with no type
-//! arguments at all ("Argument of type 'AsyncGenerator' is not assignable to
-//! parameter of type 'AsyncGenerator<number, any, any>'") even though a
+//! arguments at all ("Argument of type '`AsyncGenerator`' is not assignable to
+//! parameter of type '`AsyncGenerator<number, any, any>`'") even though a
 //! concrete, non-generic target (`AsyncGenerator<number, any, any>`) accepted
 //! the identical value.
 //!

--- a/crates/tsz-checker/src/tests/generator_inferred_yield_star_array_generic_call_tests.rs
+++ b/crates/tsz-checker/src/tests/generator_inferred_yield_star_array_generic_call_tests.rs
@@ -1,0 +1,193 @@
+//! Regression tests for #16119: an unannotated generator whose *sole* yield
+//! contribution is `yield*` over an array reported a spurious `TS2345` when
+//! its inferred return type was passed to a *generic* parameter (`want<T>(x:
+//! AsyncGenerator<T, any, any>): T`) — the source rendered with no type
+//! arguments at all ("Argument of type 'AsyncGenerator' is not assignable to
+//! parameter of type 'AsyncGenerator<number, any, any>'") even though a
+//! concrete, non-generic target (`AsyncGenerator<number, any, any>`) accepted
+//! the identical value.
+//!
+//! Structural rule: `unannotated_generator_return_type`
+//! (`types/function_type_helpers.rs`) builds the generator's own return type
+//! as `Application(Lazy(AsyncGenerator/Generator def), [yield_t, return_t,
+//! next_t])` directly through the solver's construction API, bypassing the
+//! ordinary type-node lowering path an explicit `: AsyncGenerator<...>`
+//! annotation goes through. A generic call's constraint/finalize passes can
+//! later re-evaluate that exact `Application` through a resolver context that
+//! cannot re-derive the lib interface's type parameters from a bare
+//! `Lazy(DefId)` base on its own, and falls back to the interface's
+//! unsubstituted structural shape — silently dropping `yield_t`/`return_t`/
+//! `next_t`. The fix warms the solver's application-eval cache for this exact
+//! `(def, args)` pair while the checker's env-aware resolver is still live,
+//! so the later raw-solver re-evaluation hits the cache instead of
+//! re-deriving (and getting it wrong).
+//!
+//! Every expectation below was pinned against `tsc` 7.0.2 (`--strict
+//! --target es2018 --lib es2018,dom`).
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_source_with_libs, load_default_lib_files};
+
+fn strict_codes(source: &str) -> Vec<u32> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|diagnostic| diagnostic.code)
+    .collect()
+}
+
+#[test]
+fn async_generator_sole_array_yield_star_passed_directly_to_generic_call() {
+    assert!(
+        strict_codes(
+            r#"
+async function* outer() { yield* [1, 2, 3]; }
+declare function want<T>(x: AsyncGenerator<T, any, any>): T;
+want(outer());
+"#
+        )
+        .is_empty(),
+        "an unannotated async generator whose sole yield is `yield*` over an \
+         array must satisfy a generic AsyncGenerator<T, ...> parameter"
+    );
+}
+
+#[test]
+fn async_generator_sole_array_yield_star_bound_to_const_first() {
+    // Same shape, argument bound to a variable before the call — must behave
+    // identically to the direct-call-argument form above.
+    assert!(
+        strict_codes(
+            r#"
+async function* outer() { yield* [1, 2, 3]; }
+declare function want<T>(x: AsyncGenerator<T, any, any>): T;
+const g = outer();
+want(g);
+"#
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn sync_generator_sole_array_yield_star_generic_call() {
+    // Sync twin: the same construction path is shared by `Generator`.
+    assert!(
+        strict_codes(
+            r#"
+function* outer() { yield* [1, 2, 3]; }
+declare function want<T>(x: Generator<T, any, any>): T;
+want(outer());
+"#
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn async_generator_result_still_usable_as_the_inferred_type() {
+    // The inferred T must actually be `number`, not `any`/`unknown` — a
+    // downstream mismatch against the resolved T must still be rejected.
+    assert_eq!(
+        strict_codes(
+            r#"
+async function* outer() { yield* [1, 2, 3]; }
+declare function want<T>(x: AsyncGenerator<T, any, any>): T;
+const v = want(outer());
+const bad: string = v;
+"#
+        ),
+        vec![2322],
+        "T must resolve to number so only the trailing string assignment fails"
+    );
+}
+
+#[test]
+fn generic_call_still_rejects_a_real_type_argument_mismatch() {
+    // Negative control: a genuine T mismatch (source yields string, T is
+    // constrained to number) must still report TS2345 — this is not a
+    // blanket bypass of the relation.
+    assert_eq!(
+        strict_codes(
+            r#"
+async function* outer() { yield* ["a", "b"]; }
+declare function want<T extends number>(x: AsyncGenerator<T, any, any>): T;
+want(outer());
+"#
+        ),
+        vec![2345]
+    );
+}
+
+#[test]
+fn concrete_non_generic_target_still_rejects_a_real_mismatch() {
+    // Negative control on the non-generic side: a concrete parameter type
+    // must still catch a genuine element-type mismatch.
+    assert_eq!(
+        strict_codes(
+            r#"
+async function* outer() { yield* [1, 2, 3]; }
+declare function want(x: AsyncGenerator<string, any, any>): void;
+want(outer());
+"#
+        ),
+        vec![2345]
+    );
+}
+
+#[test]
+fn renamed_binders_do_not_change_the_outcome() {
+    // Anti-hardcoding control: identical shape, every binder renamed.
+    assert!(
+        strict_codes(
+            r#"
+async function* qqq() { yield* [7, 8, 9]; }
+declare function zzz<Elem>(g: AsyncGenerator<Elem, any, any>): Elem;
+zzz(qqq());
+"#
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn mixed_yield_and_array_yield_star_generic_call() {
+    // A second, non-array-delegate contribution alongside the array delegate
+    // must not reintroduce the defect (or regress this already-working shape).
+    assert!(
+        strict_codes(
+            r#"
+async function* outer() { yield 1; yield* [2, 3]; }
+declare function want<T>(x: AsyncGenerator<T, any, any>): T;
+want(outer());
+"#
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn annotated_generator_return_type_generic_call_unaffected() {
+    // Regression control: an explicit return-type annotation lowers through
+    // the ordinary type-node path and never touches
+    // `unannotated_generator_return_type` — must keep working exactly as
+    // before this fix.
+    assert!(
+        strict_codes(
+            r#"
+async function* outer(): AsyncGenerator<number, any, any> { yield* [1, 2, 3]; }
+declare function want<T>(x: AsyncGenerator<T, any, any>): T;
+want(outer());
+"#
+        )
+        .is_empty()
+    );
+}

--- a/crates/tsz-checker/src/types/function_type_helpers.rs
+++ b/crates/tsz-checker/src/types/function_type_helpers.rs
@@ -1026,11 +1026,27 @@ impl<'a> CheckerState<'a> {
             .unwrap_or(TypeId::VOID);
         let next_t = ctx.early_gen_next_type.unwrap_or(TypeId::UNKNOWN);
 
-        return_type_construction::function_return_application(
+        let application = return_type_construction::function_return_application(
             self.ctx.types,
             base,
             vec![yield_t, return_t, next_t],
-        )
+        );
+        // Warm the solver's application-eval cache for this exact (def, args)
+        // pair while the checker's env-aware resolver is live. Without this,
+        // a later raw-solver re-evaluation of the same Application — e.g. a
+        // generic call's constraint/finalize passes over an argument that IS
+        // this call's own return type — can run through a resolver context
+        // that cannot re-derive `AsyncGenerator`/`Generator`'s type params
+        // from the bare `Lazy(DefId)` base on its own, and falls back to the
+        // interface's unsubstituted structural shape (dropping our `yield_t`/
+        // `return_t`/`next_t` args): the printer then shows a bare
+        // `AsyncGenerator` and a spurious TS2345 fires even though a
+        // concrete assignment against the identical type args succeeds.
+        // Reachable only via `AsyncGenerator`/`Generator` return-type
+        // inference — an explicit annotation lowers through the ordinary
+        // type-node path and never hits this gap. See #16119.
+        let _ = self.evaluate_type_with_env(application);
+        application
     }
 
     fn unannotated_generator_body_return_type(


### PR DESCRIPTION
Closes #16119.

Structural rule: when an unannotated generator's own return type is built by the checker directly through the solver's `Application` construction API (`unannotated_generator_return_type` in `crates/tsz-checker/src/types/function_type_helpers.rs`, `Application(Lazy(AsyncGenerator/Generator def), [yield_t, return_t, next_t])`) rather than through the ordinary type-node lowering path an explicit `: AsyncGenerator<...>` annotation goes through, `tsc` still treats the resulting generic instantiation as fully decidable everywhere it's used; `tsz` did not, through the solver's raw-solver re-evaluation of that same `Application` during a later generic call's constraint/finalize passes.

## Symptom

```ts
async function* outer() { yield* [1, 2, 3]; }
declare function want<T>(x: AsyncGenerator<T, any, any>): T;
want(outer()); // tsc: clean   tsz: TS2345
```

The false-positive fires whenever the generator's *sole* yield contribution comes from `yield*` over an array (the `for_of_element_type` fallback path — `get_iterator_info` isn't async-iterable-aware for plain arrays) **and** the resulting generator value flows into a *generic* call parameter requiring `T` inference. A concrete, non-generic target (`AsyncGenerator<number, any, any>`) always accepted the identical value — so the generator's own construction was already correct; only its re-evaluation inside generic-call resolution was wrong. The diagnostic rendered the source with no type arguments at all ("Argument of type `'AsyncGenerator'`") even though a plain assignment through the identical construction displayed and checked correctly.

## Root cause

Traced with `TSZ_LOG` across checker + solver: `unannotated_generator_return_type` constructs the `Application` with the correct concrete args (`yield_t=number, return_t=void, next_t=unknown`), and Round-1 constraint collection during generic inference reads that construction correctly (`T` resolves to `number`). But the checker's **raw argument type** collected for the call (`collect_call_argument_types_with_context`) is a *different* `TypeId` than the one just constructed — evaluating to `Object(ObjectShapeId)` with the interface's *unsubstituted* structural shape (`resolver_gen=0, has_type_params=false`) rather than the substituted one (`resolver_gen=326, has_type_params=true`) the checker's own env-aware resolver produced moments earlier. The solver's `Final argument check` in `generic_call::resolve::finalize` then compares this wrong, defaulted shape against the correctly-instantiated parameter and fails.

This is the same family as #15396 (divergent evaluation entries for a deferred `Lazy`/`Application` operand) manifesting at a new site: a generic call's own argument-collection/finalize passes, not the property-access receiver the existing `apparent_type` gateway already covers.

## The fix

`unannotated_generator_return_type` now calls `self.evaluate_type_with_env(application)` (discarding the result) immediately after constructing the generator's own `Application`, while the checker's env-aware resolver context is still live. This warms the solver's application-eval cache for the exact `(def_id, args)` pair, so a later raw-solver re-evaluation of the same `Application` — from a resolver context that cannot re-derive the lib interface's type parameters on its own — hits the cache instead of falling back to the unsubstituted shape.

Reachable only through `AsyncGenerator`/`Generator` return-type *inference*; an explicit return-type annotation lowers through the ordinary type-node path and never hits this construction site at all.

## Adjacent-case matrix (new tests, `generator_inferred_yield_star_array_generic_call_tests.rs`)

| Case | Result |
| --- | --- |
| Direct call argument (`want(outer())`) | clean (was FP) |
| Bound to `const` first, then passed | clean (was FP) |
| Sync `Generator` twin | clean (was FP) |
| Inferred `T` is genuinely usable downstream (`const bad: string = v`) | only the real `TS2322` fires |
| Real `T` mismatch (`T extends number`, source yields `string`) | `TS2345` (negative control) |
| Concrete non-generic target, real mismatch | `TS2345` (negative control) |
| Renamed binders (function/param names) | clean |
| Mixed `yield 1; yield* [...]` through the same generic call | clean (no regression) |
| Explicit return-type annotation, generic call | clean (unaffected control) |

## Goal
Goal: hold

## Verification
- New suite: `cargo test -p tsz-checker --lib generator_inferred_yield_star_array_generic_call_tests` — 9/9 passed.
- `cargo test -p tsz-checker --lib generator` — 141/141 passed (0 regressions across the existing generator suites).
- `cargo test -p tsz-checker --lib yield` — 151/151 passed.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`: clean.
- `pre-commit` hook (clippy + arch-guard): passed.
- Oracle matrix (`tsc@7.0.2` via `scripts/node_modules`-style local install vs `.target/debug/tsz`, `--strict --pretty false --target es2018 --lib es2018,dom`): byte-identical on the repro, its `const`-bound twin, the sync twin, and both negative-mismatch controls.
- **Not run from this container**: `scripts/conformance/compare-to-parent.sh` and the full `conformance.sh snapshot` — no warmed TypeScript-submodule seat was available in the session budget after the trace-driven investigation above. This shape has no corpus fixture (a narrow generic-inference-over-inferred-generator gap), so the targeted oracle matrix above is the primary evidence, consistent with the repo's own precedent for this class of fix; a seat with a warm corpus checkout should still run the two-sided diff before this lands.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_016zy9mfBNG3HanpYQuePXu4)_