### PR TITLE
fix(checker): report TS7022 for self-referential for-in loop variables

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
@@ -829,6 +829,14 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
         CheckerState::check_for_of_self_reference_circularity(self, decl_list_idx, expression_idx);
     }
 
+    fn check_for_in_self_reference_circularity(
+        &mut self,
+        decl_list_idx: NodeIndex,
+        expression_idx: NodeIndex,
+    ) {
+        CheckerState::check_for_in_self_reference_circularity(self, decl_list_idx, expression_idx);
+    }
+
     fn check_statement(&mut self, stmt_idx: NodeIndex) {
         // This calls back to the main check_statement which will delegate to StatementChecker
         CheckerState::check_statement(self, stmt_idx);

--- a/crates/tsz-checker/src/state/variable_checking/for_loop.rs
+++ b/crates/tsz-checker/src/state/variable_checking/for_loop.rs
@@ -416,24 +416,55 @@ impl<'a> CheckerState<'a> {
     /// never on the identifier's spelling — a differently-named loop variable
     /// over an unrelated binding of any type is untouched by this.
     fn for_in_operand_resolution_is_circular(&mut self, expression: NodeIndex) -> bool {
+        let Some(decl_list_idx) = self.for_in_statement_declaration_list(expression) else {
+            return false;
+        };
+        !self
+            .for_in_circular_loop_head_declarations(decl_list_idx, expression)
+            .is_empty()
+    }
+
+    /// The `VariableDeclarationList` of the for-in statement whose operand is
+    /// `expression`, when the loop head declares its variables inline.
+    fn for_in_statement_declaration_list(&self, expression: NodeIndex) -> Option<NodeIndex> {
         let arena = self.ctx.arena;
-        let Some(ext) = arena.get_extended(expression) else {
-            return false;
-        };
-        let statement_idx = ext.parent;
-        let Some(statement) = arena.get(statement_idx) else {
-            return false;
-        };
+        let statement_idx = arena.get_extended(expression)?.parent;
+        let statement = arena.get(statement_idx)?;
         if statement.kind != syntax_kind_ext::FOR_IN_STATEMENT {
-            return false;
+            return None;
         }
-        let Some(initializer) = arena.get_for_in_of(statement).map(|f| f.initializer) else {
-            return false;
-        };
-        let Some(list) = arena.get(initializer).and_then(|n| arena.get_variable(n)) else {
-            return false;
+        let initializer = arena.get_for_in_of(statement).map(|f| f.initializer)?;
+        arena.get(initializer)?;
+        Some(initializer)
+    }
+
+    /// Name nodes of the loop-head declarations that the for-in operand itself
+    /// references — the declarations whose type resolution is circular.
+    ///
+    /// tsc derives a for-in loop variable's type from the loop's own operand
+    /// (`getIndexType(checkExpression(node.expression))` in
+    /// `getTypeForVariableLikeDeclaration`), so an operand naming a variable
+    /// this same loop head declares cannot be resolved: `pushTypeResolution`
+    /// fails, `reportCircularityError` hands back `any`, and reports TS7022
+    /// under `noImplicitAny`.
+    ///
+    /// Returning the declarations rather than a bare flag keeps the TS2407
+    /// suppression and the TS7022 report driven by one predicate, so a circular
+    /// operand can never be both silently accepted by the object-type gate and
+    /// left unreported.
+    ///
+    /// Keyed on binder symbol identity, never on the identifier's spelling.
+    fn for_in_circular_loop_head_declarations(
+        &mut self,
+        decl_list_idx: NodeIndex,
+        expression: NodeIndex,
+    ) -> Vec<NodeIndex> {
+        let arena = self.ctx.arena;
+        let Some(list) = arena.get(decl_list_idx).and_then(|n| arena.get_variable(n)) else {
+            return Vec::new();
         };
 
+        let mut circular = Vec::new();
         for &decl_idx in &list.declarations.nodes {
             let Some(var_decl) = arena
                 .get(decl_idx)
@@ -455,10 +486,42 @@ impl<'a> CheckerState<'a> {
             if let Some(sym_id) = sym_id
                 && self.expression_references_symbol(expression, sym_id)
             {
-                return true;
+                circular.push(var_decl.name);
             }
         }
-        false
+        circular
+    }
+
+    /// TS7022: report a for-in loop variable whose own operand references it.
+    ///
+    /// The for-of twin (`check_for_of_self_reference_circularity`) additionally
+    /// walks iterator-protocol return sites and falls back to an identifier-name
+    /// match; neither applies here. for-in has no iterator protocol, and the
+    /// name fallback would misfire on a member name that merely spells the loop
+    /// variable — `for (const v in o.v) {}` is clean in tsc — so this path is
+    /// symbol-identity only.
+    pub(crate) fn check_for_in_self_reference_circularity(
+        &mut self,
+        decl_list_idx: NodeIndex,
+        expression_idx: NodeIndex,
+    ) {
+        // TS7022 is an implicit-any diagnostic: tsc's `reportCircularityError`
+        // reports it only `if (noImplicitAny && ...)`. With the flag off the
+        // circular loop variable is silently `any`.
+        if !self.ctx.no_implicit_any() {
+            return;
+        }
+        for name_idx in self.for_in_circular_loop_head_declarations(decl_list_idx, expression_idx) {
+            let Some(name) = self.get_identifier_text_from_idx(name_idx) else {
+                continue;
+            };
+            use crate::diagnostics::diagnostic_codes;
+            self.error_at_node_msg(
+                name_idx,
+                diagnostic_codes::IMPLICITLY_HAS_TYPE_ANY_BECAUSE_IT_DOES_NOT_HAVE_A_TYPE_ANNOTATION_AND_IS_REFERE,
+                &[&name],
+            );
+        }
     }
 
     /// Leaf (non-union, non-intersection) validity test for a for-in operand:
@@ -1519,6 +1582,18 @@ impl<'a> CheckerState<'a> {
                 | syntax_kind_ext::CLASS_EXPRESSION
         ) {
             return false;
+        }
+
+        // The member name of a property access is not a reference to any value
+        // binding, so `o.v` must not count as a reference to a variable named
+        // `v` that happens to be in scope (`for (const v in o.v) {}` is clean in
+        // tsc). Walk only the object side. An *element* access is different —
+        // `o[v]` really does read `v` — so only `PropertyAccessExpression` is
+        // narrowed here, and its `name_or_argument` is the sole skipped child.
+        if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+            && let Some(access) = self.ctx.arena.get_access_expr(node)
+        {
+            return self.expression_references_symbol(access.expression, target_sym);
         }
 
         // Recurse into children

--- a/crates/tsz-checker/src/statements.rs
+++ b/crates/tsz-checker/src/statements.rs
@@ -229,6 +229,15 @@ pub trait StatementCheckCallbacks {
         // Default: no check
     }
 
+    /// TS7022: Detect self-referencing for-in loop variables under noImplicitAny.
+    fn check_for_in_self_reference_circularity(
+        &mut self,
+        _decl_list_idx: NodeIndex,
+        _expression_idx: NodeIndex,
+    ) {
+        // Default: no check
+    }
+
     /// Recursively check a nested statement (callback to `check_statement`).
     fn check_statement(&mut self, stmt_idx: NodeIndex);
 
@@ -832,11 +841,15 @@ impl StatementChecker {
                         if !is_for_of {
                             state.check_for_in_destructuring_pattern(initializer);
                         }
-                        // TS7022/TS7023: Detect self-referencing for-of variables.
-                        // This covers both direct `for (var v of v)` cycles and
-                        // iterator-protocol methods whose return expressions read `v`.
+                        // TS7022/TS7023: Detect self-referencing loop variables.
+                        // for-of covers both direct `for (var v of v)` cycles and
+                        // iterator-protocol methods whose return expressions read
+                        // `v`; for-in has no iterator protocol, so only the direct
+                        // `for (var v in v)` cycle applies there.
                         if is_for_of {
                             state.check_for_of_self_reference_circularity(initializer, expression);
+                        } else {
+                            state.check_for_in_self_reference_circularity(initializer, expression);
                         }
                         state.assign_for_in_of_initializer_types(
                             initializer,

--- a/crates/tsz-checker/tests/for_in_self_reference_and_nullable_operand_tests.rs
+++ b/crates/tsz-checker/tests/for_in_self_reference_and_nullable_operand_tests.rs
@@ -196,3 +196,159 @@ for (var textKey in text) { }
 ";
     assert_has_2407(&non_strict(source), "non-object outer binding");
 }
+
+// ---------------------------------------------------------------------------
+// Mechanism 1, reporting half — the same circular loop head that clears the
+// TS2407 gate is what `tsc` reports TS7022 on.
+//
+// #16138 removed the wrong TS2407 for this shape; `tsz` then said nothing at
+// all, where `tsc` reports TS7022 (plus a TDZ TS2448 for `let`/`const`, which
+// is a separate owner and deliberately not asserted here). Every expectation
+// below is oracle-pinned against `tsc` 7.0.2, `--noEmit --pretty false`, run
+// under `--strict`, `--strict false`, and `--strict --noImplicitAny false`.
+// ---------------------------------------------------------------------------
+
+const TS7022: u32 = 7022;
+
+fn assert_has_7022(codes: &[u32], label: &str) {
+    assert!(
+        codes.contains(&TS7022),
+        "{label}: expected TS7022 (tsc reports the circular loop variable), got codes: {codes:?}"
+    );
+}
+
+fn assert_no_7022(codes: &[u32], label: &str) {
+    assert!(
+        !codes.contains(&TS7022),
+        "{label}: expected no TS7022, got codes: {codes:?}"
+    );
+}
+
+#[test]
+fn for_in_operand_naming_its_own_var_loop_variable_reports_ts7022() {
+    // Oracle: `for (var v in v) {}` under --strict is exactly `TS7022` — no
+    // TS2448, because `var` is hoisted and has no TDZ.
+    let source = "for (var scratch in scratch) { }\n";
+    assert_has_7022(&strict(source), "var self-reference");
+    // And the TS2407 half stays suppressed: one predicate drives both.
+    assert_no_2407(&strict(source), "var self-reference keeps no TS2407");
+}
+
+#[test]
+fn for_in_operand_naming_its_own_const_loop_variable_reports_ts7022() {
+    // Oracle for `for (const k in k) {}` is `TS2448 + TS7022`. tsz does not yet
+    // report the TDZ half (tracked separately in #16141); the implicit-any half
+    // is what this path owns.
+    let source = "for (const entry in entry) { }\n";
+    assert_has_7022(&strict(source), "const self-reference");
+}
+
+#[test]
+fn for_in_operand_naming_its_own_let_loop_variable_reports_ts7022() {
+    let source = "for (let cursor in cursor) { }\n";
+    assert_has_7022(&strict(source), "let self-reference");
+}
+
+#[test]
+fn for_in_operand_reaching_its_own_loop_variable_through_a_property_reports_ts7022() {
+    // Oracle: `for (var w in w.k) {}` is `TS7022`. The cycle is indirect — the
+    // operand is a property access whose *object* is the loop variable.
+    let source = "for (var holder in holder.inner) { }\n";
+    assert_has_7022(&strict(source), "indirect self-reference through property");
+}
+
+#[test]
+fn for_in_operand_reaching_its_own_loop_variable_through_a_call_reports_ts7022() {
+    // Oracle: `for (const k in id(k)) {}` is `TS2448 + TS7022`.
+    let source = "\
+declare function passthrough(value: any): any;
+for (const item in passthrough(item)) { }
+";
+    assert_has_7022(&strict(source), "indirect self-reference through call");
+}
+
+#[test]
+fn a_loop_variable_shadowing_an_outer_object_binding_still_reports_ts7022() {
+    // Oracle: an outer `k: object` does NOT rescue the inner loop head —
+    // `declare const k: object; function f() { for (const k in k) {} }` is
+    // still `TS2448 + TS7022`. The inner declaration shadows, so the operand
+    // resolves to the loop variable and the cycle stands.
+    let source = "\
+declare const shadowed: object;
+function walk() {
+    for (const shadowed in shadowed) { }
+}
+";
+    assert_has_7022(&strict(source), "loop variable shadowing an outer object");
+}
+
+#[test]
+fn a_member_name_that_merely_spells_the_loop_variable_is_not_a_self_reference() {
+    // Oracle: `declare const o: { v: object }; for (const v in o.v) {}` is
+    // CLEAN. `v` occurs in the operand only as a *member name*, which is not a
+    // reference to the loop variable — this is exactly the case an
+    // identifier-spelling match would get wrong, and why this path resolves
+    // binder symbols instead.
+    let source = "\
+declare const bag: { field: object };
+for (const field in bag.field) { }
+";
+    assert_no_7022(&strict(source), "member name spelling the loop variable");
+    assert_no_2407(&strict(source), "member name spelling the loop variable");
+}
+
+#[test]
+fn an_unrelated_loop_variable_over_an_object_operand_reports_nothing() {
+    // Negative control: no cycle, no diagnostic on either half.
+    let source = "\
+declare const source: object;
+for (const key in source) { }
+";
+    assert_no_7022(&strict(source), "unrelated loop variable");
+    assert_no_2407(&strict(source), "unrelated loop variable");
+}
+
+#[test]
+fn an_annotated_circular_loop_variable_does_not_report_ts7022() {
+    // Oracle: `for (const v: string in o) {}` reports only `TS2404` (a for-in
+    // variable may not have a type annotation). An annotation means tsc reads
+    // it instead of the operand, so there is no circular resolution to report.
+    let source = "for (var labeled: string in labeled) { }\n";
+    assert_no_7022(&strict(source), "annotated loop variable");
+}
+
+#[test]
+fn for_in_self_reference_is_silent_without_no_implicit_any() {
+    // Oracle: with `--noImplicitAny false`, `tsc`'s `reportCircularityError`
+    // stays silent and the variable is quietly `any` — the same gating the
+    // for-of twin already implements. Both `--strict false` and
+    // `--strict --noImplicitAny false` drop TS7022 in the oracle; the
+    // non-strict projection is the one the corpus rows carry.
+    let source = "for (var scratch in scratch) { }\n";
+    assert_no_7022(&non_strict(source), "var self-reference, noImplicitAny off");
+    assert_no_2407(&non_strict(source), "var self-reference, noImplicitAny off");
+}
+
+#[test]
+fn the_for_of_twin_is_unchanged_by_the_for_in_path() {
+    // for-of already reported TS7022 for its own self-reference; the for-in
+    // arm must not disturb it.
+    let source = "for (var stream of stream) { }\n";
+    assert_has_7022(&strict(source), "for-of self-reference still reports");
+}
+
+#[test]
+fn an_element_access_indexed_by_the_loop_variable_is_a_self_reference() {
+    // The mirror of the member-name case, and the reason the narrowing above is
+    // property-access-only. Oracle: `declare const o: { [k: string]: object };
+    // for (const v in o[v]) {}` is `TS2448 + TS7022` — an element access really
+    // does read the loop variable.
+    let source = "\
+declare const table: { [k: string]: object };
+for (const slot in table[slot]) { }
+";
+    assert_has_7022(
+        &strict(source),
+        "element access indexed by the loop variable",
+    );
+}


### PR DESCRIPTION
Closes #16141 (slice 1). Slice 2 (`unknown` operand missing TS2407) is deliberately **not** in this PR — see "Not in scope" below.

**Structural rule.** When a for-in loop head declares an unannotated variable and the loop's own operand references that same variable, `tsc` cannot resolve the loop variable's type — `getTypeForVariableLikeDeclaration` derives it from `getIndexType(checkExpression(node.expression))`, so `pushTypeResolution` fails, `reportCircularityError` hands back `any`, and TS7022 is reported under `noImplicitAny`. `tsz` reported nothing. `tsz` now does the same through the checker's for-loop variable checking (`crates/tsz-checker/src/state/variable_checking/for_loop.rs`), alongside the for-of twin that already implemented this.

## Why this shape was silent

#16138 correctly removed the *wrong* `TS2407` here (the `any` clears the object-type gate), but `tsz` never had the `TS7022` half for for-in. By code-set that row improved; by user experience `for (var v in v) {}` went from one misleading error to **silence**. The detection predicate already existed on both sides — only the report was missing.

## The fix

`for_in_operand_resolution_is_circular` is refactored into `for_in_circular_loop_head_declarations`, which returns the offending declarations instead of a bare flag. The TS2407 suppression and the new TS7022 report are now driven by **that one predicate**, so a circular operand can never be both silently accepted by the object-type gate *and* left unreported. That coupling is the point of the refactor, not incidental cleanup.

The for-of twin additionally walks iterator-protocol return sites and falls back to an identifier-**name** match. Neither is correct for for-in: there is no iterator protocol, and the name fallback misfires on a member name that merely spells the loop variable. So this path is symbol-identity only, and `expression_references_symbol` is narrowed to skip the member name of a property access — that walk is symbol-keyed everywhere else, and a member name is not a reference to a value binding.

That narrowing is asymmetric on purpose, and both directions are oracle-pinned:

| operand | tsc | why |
| --- | --- | --- |
| `for (const v in o.v)` | clean | `v` occurs only as a member name |
| `for (const v in o[v])` | `TS7022` | an element access really does read `v` |

Only `PropertyAccessExpression`'s `name_or_argument` is skipped; element access is untouched. Without this, the new report false-positives on the first row (confirmed — the first run of the matrix failed exactly there).

## Adjacent-case matrix

Every row pinned against `tsc` 7.0.2 (`--noEmit --pretty false`) under `--strict`, `--strict false`, and `--strict --noImplicitAny false` **before** any code was written. Binder names are varied throughout; no test reuses a name from another.

| Case | tsc | tsz after |
| --- | --- | --- |
| `for (var v in v)` | `TS7022` (no TDZ — `var` is hoisted) | `TS7022`, still no `TS2407` |
| `for (const k in k)` | `TS2448` + `TS7022` | `TS7022` (TDZ half is separate, below) |
| `for (let v in v)` | `TS2448` + `TS7022` | `TS7022` |
| `for (var w in w.inner)` — indirect via property *object* | `TS7022` | `TS7022` |
| `for (const i in passthrough(i))` — indirect via call | `TS2448` + `TS7022` | `TS7022` |
| loop variable shadowing an outer `object` binding of the same name | `TS2448` + `TS7022` | `TS7022` |
| `for (const field in bag.field)` — member name only | clean | clean *(negative control)* |
| `for (const slot in table[slot])` — element access | `TS2448` + `TS7022` | `TS7022` *(positive control)* |
| `for (const key in source)` — unrelated binding | clean | clean *(negative control)* |
| `for (var labeled: string in labeled)` — annotated | `TS2404` only | no `TS7022` *(annotation wins)* |
| same self-reference with `noImplicitAny` off | clean | clean *(gating control)* |
| `for (var stream of stream)` — for-of twin | `TS7022` | `TS7022` *(unchanged)* |

The `noImplicitAny`-off row is what keeps the three conformance rows #16138 just fixed (`parserForOfStatement19`, `parserES5ForOfStatement19`, `recursiveLetConst`) unaffected: all three carry `// @strict: false`, and the oracle drops `TS7022` in that mode.

## Not in scope

- **`TS2448`** (the TDZ half of #16141's first shape) is a use-before-declaration question with a different owner; `tsc` reports it in *both* strictness modes while `TS7022` is `noImplicitAny`-gated, so the two halves need different gating. Left open on #16141.
- **#16141 slice 2** (`declare const u: unknown; for (const k in u)` missing `TS2407`) is a *new* diagnostic on a common operand type and needs a two-sided corpus diff that this container cannot run. Folding it in here would hold this fix hostage to that measurement. Left open on #16141.

## Goal
Goal: hold

## Verification
- New/extended suite `crates/tsz-checker/tests/for_in_self_reference_and_nullable_operand_tests.rs` (wired into the lib target): **before 16/28 passed, after 28/28**. The 12 new rows are the matrix above.
- Targeted regression filters on the built lib binary: `for_of` **43/43**, `7022` **8/8**, `circular` **78/78**, `for_in` **76/77** — the single failure is `for_in_lhs_relation_routing_arch_tests::for_in_lhs_relation_outcome_uses_for_in_request`, which reads a source file by relative path and fails only when the test binary is invoked directly rather than through cargo (the documented harness artifact); it passes under `cargo test`.
- `cargo test -p tsz-checker --lib for_in_self_reference` — 28/28.
- `cargo fmt` + `cargo clippy` + architecture guard, via the `pre-commit` hook: **all passed** ("Clippy passed. Architecture guard passed.").
- Oracle: `tsc` 7.0.2 installed locally; the full 20-case matrix run across three flag configurations, transcribed into the table above.
- Conformance artifact triage (no submodule in this container, so this is not a run): of the 601 committed failing rows, **1** expects a missing `TS7022` (`conformance/salsa/defaultPropertyAssignedClassWithPrototype.ts`, a JS-prototype shape unrelated to for-in) and **0** report an extra one.

### Not run from this container
`scripts/conformance/compare-to-parent.sh`, the full `conformance.sh snapshot`, emit, and fourslash — this is a cold cloud seat with no TypeScript submodule and no warm emit install. **This PR adds a diagnostic**, so the two-sided corpus diff is the gate that matters and it has not run. Its blast radius is bounded by the predicate: a for-in loop head that declares an unannotated variable whose own operand references that same binder symbol, under `noImplicitAny` — a shape `tsc` always reports on. A seat with a warm corpus should run the two-sided diff before this lands; expected movement is 0 newly failing.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Schist

---
_Generated by [Claude Code](https://claude.ai/code/session_015qqwguTgNYxpqCBFWo5TYR)_