### PR TITLE
fix(binder): stop renamed export specifiers shadowing container locals

### DIFF
--- a/crates/tsz-binder/src/modules/import_export.rs
+++ b/crates/tsz-binder/src/modules/import_export.rs
@@ -632,18 +632,13 @@ impl BinderState {
                                         };
 
                                         if let Some(target_id) = exported_target {
-                                            if orig == exp
-                                                || exp == "default"
-                                                || current_namespace_sym_id.is_some()
-                                            {
+                                            if orig == exp || exp == "default" {
                                                 // Non-renamed exports bind a real in-module local.
                                                 // The synthetic `default` slot is also kept in
                                                 // `file_locals` because default import
-                                                // classification still consults that path, and
-                                                // namespace member exports resolve through the
-                                                // namespace's own export table.
+                                                // classification still consults that path.
                                                 self.set_scope_and_file_local(exp, target_id);
-                                            } else {
+                                            } else if current_namespace_sym_id.is_none() {
                                                 // Renamed top-level export (`export { Orig as
                                                 // Exp }`): tsc records `Exp` only on the module's
                                                 // public export surface, never as an in-module
@@ -652,6 +647,16 @@ impl BinderState {
                                                 // same-named local declaration.
                                                 self.seed_module_export(exp, target_id);
                                             }
+                                            // A renamed *member* export of a namespace/module
+                                            // container (`declare module "m" { export { Orig as
+                                            // Exp } }`) falls through deliberately: the
+                                            // container's own export table already received `Exp`
+                                            // above, which is the only place tsc records it.
+                                            // Seeding a lexical slot would clobber a same-named
+                                            // local declaration — the exact hazard
+                                            // `seed_module_export` documents — and seeding the
+                                            // file's export surface would publish a name that
+                                            // belongs to the container, not the file.
                                         }
                                         if self.in_global_augmentation {
                                             self.record_global_value_augmentation(

--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -807,6 +807,9 @@ path = "tests/module_augmentation_isolation_tests.rs"
 name = "ambient_module_renamed_export_ts2460_tests"
 path = "tests/ambient_module_renamed_export_ts2460_tests.rs"
 [[test]]
+name = "ambient_module_renamed_export_local_shadow_tests"
+path = "tests/ambient_module_renamed_export_local_shadow_tests.rs"
+[[test]]
 name = "ambient_module_import_alias_defid_collision_tests"
 path = "tests/ambient_module_import_alias_defid_collision_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/ambient_module_renamed_export_local_shadow_tests.rs
+++ b/crates/tsz-checker/tests/ambient_module_renamed_export_local_shadow_tests.rs
@@ -1,0 +1,254 @@
+//! Renamed export specifiers inside a namespace/module container must not
+//! create an in-module lexical binding.
+//!
+//! Structural rule (one sentence):
+//!
+//! > When a container body — `declare module "M" { ... }` or a `namespace N
+//! > { ... }` — contains `export { Orig as Exp }`, tsc records `Exp` on that
+//! > container's export table only and never as an in-module lexical/type
+//! > binding, so a same-named local declaration of `Exp` keeps resolving
+//! > locally; tsz does the same through the binder's export-specifier path
+//! > (`crates/tsz-binder/src/modules/import_export.rs`).
+//!
+//! Before this fix the binder seeded `Exp` into the current scope and
+//! `file_locals` whenever the specifier appeared inside a container, which
+//! clobbered a same-named local. In the witness below the clobbered local is
+//! `namespace X`, so `X.I` stopped resolving as a namespace and produced a
+//! spurious TS2503 ("Cannot find namespace 'X'") in an ambient module and a
+//! spurious TS2702 ("'X' only refers to a type, but is being used as a
+//! namespace here") in a plain namespace. tsc reports neither.
+//!
+//! The same-name (`export { X }`) and top-level-module forms were already
+//! correct — `seed_module_export`'s own doc comment describes exactly this
+//! clobbering hazard for the top-level case; the container case simply
+//! bypassed it.
+//!
+//! Reported witness:
+//! `TypeScript/tests/cases/compiler/exportSpecifierAndExportedMemberDeclaration.ts`,
+//! whose only conformance delta was the extra TS2503.
+//!
+//! Every test varies at least one user-chosen name (module specifier,
+//! namespace name, alias name, member name) so the fix is structural rather
+//! than shape-fingerprinted. All expectations below were pinned against
+//! `tsc` 7.0.2 before the fix was written.
+
+use tsz_checker::test_utils::check_source_codes;
+
+const TS2503: u32 = 2503;
+const TS2702: u32 = 2702;
+
+// ─────────────────── 1. reported repro and its renamings ───────────────────
+
+/// The conformance witness itself: a renamed export whose exported name
+/// collides with a local `namespace` must leave the namespace resolvable,
+/// both in the declaring block and in a merged sibling block.
+#[test]
+fn ambient_module_renamed_export_keeps_local_namespace_resolvable() {
+    let codes = check_source_codes(
+        r#"
+declare module "m2" {
+    export namespace X {
+        interface I { }
+    }
+    function Y(): void;
+    export { Y as X };
+    function Z(): X.I;
+}
+
+declare module "m2" {
+    function Z2(): X.I;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&TS2503),
+        "renamed export must not shadow the local namespace: {codes:?}"
+    );
+}
+
+/// Same shape with every binder renamed — the rule is structural, not keyed
+/// to the witness's identifiers.
+#[test]
+fn renamed_binders_keep_local_namespace_resolvable() {
+    let codes = check_source_codes(
+        r#"
+declare module "mod-alpha" {
+    export namespace Qq {
+        interface Inner { }
+    }
+    function Helper(): void;
+    export { Helper as Qq };
+    function Use(): Qq.Inner;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&TS2503),
+        "renamed binders must behave identically: {codes:?}"
+    );
+}
+
+/// Declaration order must not matter.
+///
+/// Worth knowing: this shape is clean on the **CLI** even without the fix
+/// (the namespace, bound after the specifier, overwrites the clobbered scope
+/// slot back) but still fails in this **harness** without it. The two
+/// surfaces disagree on binding order for the same source, so a CLI-only
+/// check would have called this case healthy. Pinning it here keeps the
+/// order-independence real rather than order-accidental.
+#[test]
+fn specifier_before_namespace_keeps_local_namespace_resolvable() {
+    let codes = check_source_codes(
+        r#"
+declare module "m3" {
+    function Y(): void;
+    export { Y as X };
+    export namespace X {
+        interface I { }
+    }
+    function Z(): X.I;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&TS2503),
+        "specifier-before-namespace must resolve: {codes:?}"
+    );
+}
+
+/// A deeper container: the local shadowed by the specifier is a nested
+/// namespace reached through a qualified name.
+#[test]
+fn renamed_export_keeps_nested_qualified_namespace_resolvable() {
+    let codes = check_source_codes(
+        r#"
+declare module "deep-mod" {
+    export namespace Outer {
+        namespace Middle {
+            interface Leaf { }
+        }
+    }
+    function fallback(): void;
+    export { fallback as Outer };
+    function consume(): Outer.Middle.Leaf;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&TS2503),
+        "nested qualified namespace must stay resolvable: {codes:?}"
+    );
+}
+
+// ──────────────── 2. the plain-namespace surface (TS2702) ─────────────────
+
+/// The same binder path drives a plain `namespace` body, where the symptom
+/// of the clobber is TS2702 rather than TS2503. The body is still a grammar
+/// error (TS1194, "Export declarations are not permitted in a namespace"),
+/// which tsz already reports and tsc agrees on — but tsc reports *only*
+/// that, so the extra TS2702 was a second false positive from one cause.
+#[test]
+fn namespace_body_renamed_export_does_not_add_ts2702() {
+    let codes = check_source_codes(
+        r#"
+namespace Outer {
+    export namespace X {
+        export interface I { }
+    }
+    function Y() {}
+    export { Y as X };
+    export function Z(): X.I { return null as any; }
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&TS2702),
+        "namespace body must not report a spurious TS2702: {codes:?}"
+    );
+}
+
+// ───────────────────────── 3. negative controls ───────────────────────────
+
+/// A genuinely undeclared namespace must still report TS2503. Without this,
+/// the fix could have been "stop reporting TS2503 here" rather than "resolve
+/// the local correctly".
+#[test]
+fn genuinely_missing_namespace_still_reports_ts2503() {
+    let codes = check_source_codes(
+        r#"
+declare module "m5" {
+    function Z(): Missing.I;
+}
+"#,
+    );
+    assert!(
+        codes.contains(&TS2503),
+        "an undeclared namespace must still report TS2503: {codes:?}"
+    );
+}
+
+/// A missing namespace reached through a renamed export's *exported* name
+/// from inside the same container is still missing: the alias lives on the
+/// container's export table, not in the body's lexical scope, so referring
+/// to it locally as a namespace must not start resolving.
+#[test]
+fn renamed_export_name_is_not_itself_a_local_namespace() {
+    let codes = check_source_codes(
+        r#"
+declare module "m10" {
+    namespace Src {
+        interface I { }
+    }
+    export { Src as Pub };
+    function Z(): Pub.I;
+}
+"#,
+    );
+    assert!(
+        codes.contains(&TS2503),
+        "the exported alias name must not become a local namespace: {codes:?}"
+    );
+}
+
+/// Non-renamed `export { Y }` inside a container is untouched by the fix and
+/// must stay clean.
+#[test]
+fn same_name_export_specifier_stays_clean() {
+    let codes = check_source_codes(
+        r#"
+declare module "m7" {
+    namespace X {
+        interface I { }
+    }
+    function Y(): void;
+    export { Y };
+    function Z(): X.I;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&TS2503),
+        "same-name export specifier must stay clean: {codes:?}"
+    );
+}
+
+/// The top-level module form already routed through `seed_module_export`;
+/// pinned here so a future change to that branch cannot silently regress the
+/// surface this fix aligns the container case with.
+#[test]
+fn top_level_renamed_export_keeps_local_namespace_resolvable() {
+    let codes = check_source_codes(
+        r#"
+export namespace X {
+    export interface I { }
+}
+function Y() {}
+export { Y as X };
+export function Z(): X.I { return null as any; }
+"#,
+    );
+    assert!(
+        !codes.contains(&TS2503),
+        "top-level renamed export must stay clean: {codes:?}"
+    );
+}


### PR DESCRIPTION
**Structural rule:** when a container body — `declare module "M" { ... }` or `namespace N { ... }` — contains `export { Orig as Exp }`, `tsc` records `Exp` on that container's export table **only**, never as an in-module lexical/type binding, so a same-named local declaration of `Exp` keeps resolving locally; tsz now does the same through the **binder's** export-specifier path (`crates/tsz-binder/src/modules/import_export.rs`).

Found by clustering the committed `scripts/conformance/conformance-detail.json` (per the board's work-queue note) for rows whose *only* delta is an extra diagnostic.

## The defect

The binder seeded `Exp` into the current scope **and** `file_locals` whenever the specifier appeared inside a container, clobbering a same-named local. In the witness the clobbered local is a `namespace`, so it stopped resolving as one:

```ts
declare module "m2" {
    export namespace X { interface I { } }
    function Y(): void;
    export { Y as X };        // exported alias — must NOT become a local `X`
    function Z(): X.I;        // tsz: TS2503 "Cannot find namespace 'X'"
}
declare module "m2" {
    function Z2(): X.I;       // tsz: TS2503 again, across the merge
}
```

`tsc` 7.0.2 reports nothing here. The same one cause produces a **second** code on the plain-namespace surface: a spurious `TS2702` ("'X' only refers to a type, but is being used as a namespace here").

The top-level module form was already correct — it routes through `seed_module_export`, whose own doc comment describes precisely this clobbering hazard ("writing the alias target into the scope slot would clobber a colliding local declaration named `exp`"). The container case simply bypassed that protection via an `|| current_namespace_sym_id.is_some()` disjunct. Since the container's export table is populated earlier in the same loop, the fix is for the container case to seed **neither** a lexical slot nor the *file's* export surface (the latter would publish a name belonging to the container).

Owner layer is the binder: this is symbol-table construction, not a type or display decision. No checker/solver change, no diagnostic suppression — the diagnostics disappear because the name now resolves.

## Adjacent-case matrix

Every row pinned against `tsc` 7.0.2 **before** the fix was written, then re-run against the built `tsz` binary. `MATCH` = byte-identical diagnostics.

| case | shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- | --- |
| witness | renamed export vs local namespace, ambient module + merged block | clean | 2× TS2503 | MATCH |
| renamed binders | same shape, every identifier renamed (`Qq`/`Helper`/`mod-alpha`) | clean | TS2503 | MATCH |
| order | specifier *before* the namespace | clean | clean (CLI) / TS2503 (harness) | MATCH |
| nested | qualified `Outer.Middle.Leaf` through the shadowed namespace | clean | clean | MATCH |
| plain namespace | same shape in `namespace N { }` | TS1194 only | TS1194 + **TS2702** | MATCH |
| negative | genuinely undeclared namespace | TS2503 | TS2503 | MATCH |
| negative | alias's *exported* name used locally as a namespace | TS2503 | TS2503 | MATCH |
| negative | non-renamed `export { Y }` in a container | clean | clean | MATCH |
| negative | renamed export at top level of a real module | clean | clean | MATCH |
| cross-file | `import { Renamed } from "m9"` through a renamed ambient export, with a deliberate type mismatch | TS2322 | — | MATCH |

That last row is the load-bearing control for the change: dropping the lexical binding must not break cross-file consumption of the renamed name. It resolves and carries the right type.

**Negative control on the tests themselves:** reverting only the binder hunk fails **5 of 9** new tests; all 4 negative controls still pass. They fail for the real reason.

Two findings worth recording:
- The **order** row is clean on the CLI without the fix but fails in the checker harness — the two surfaces disagree on binding order for identical source, so a CLI-only check would have called that case healthy. Noted in the test's doc comment.
- `export { X }` / `export { W as X }` colliding with an exported `namespace X` should be **TS2484** ("Export declaration conflicts with exported declaration of 'X'"). tsz reports nothing. Verified **pre-existing and unchanged** by this diff (missing before and after) — a separate false negative, not touched here.

## Goal
Goal: hold

## Verification

- `cargo test -p tsz-checker --test ambient_module_renamed_export_local_shadow_tests`: **9/9 passed** (new suite). Reverting only the binder hunk: **4 passed / 5 failed**.
- `cargo test -p tsz-binder --lib`: **425/425 passed**.
- `cargo fmt --all`: clean.
- Oracle: all matrix rows above pinned against a locally installed `tsc` **7.0.2** (`npm i typescript@7.0.2`; the container's global `typescript` is 6.0.2 and was not used).
- Expected conformance movement: `compiler/exportSpecifierAndExportedMemberDeclaration.ts` flips (its detail entry is `{"a": ["TS2503"], "x": ["TS2503"]}` — the extra TS2503 was its only delta).

**Disclosed gaps** — flagging explicitly per the repo rule that a suite not run locally did not run:
- `cargo nextest` is **not installed in this container**; the runs above used `cargo test`. Same tests, different runner.
- `cargo test -p tsz-checker --lib` was still compiling when this session's hour closed — **not** a reported result. Someone should confirm the full checker lib lane before landing.
- `scripts/conformance/compare-to-parent.sh` was **not run**: this container has no TypeScript submodule. The committed artifact bounds *visible* risk only — of the 5 failing rows carrying an extra TS2503, one is this witness, three are a different mechanism (namespace-qualified JSDoc `@typedef`, and a global-augmentation/`export =` row), and 0 rows carry an extra TS2702 while 4 have it missing. That bounds nothing about currently-**passing** rows, which is exactly what the two-sided diff is for. A warm-corpus seat should run it before merge.
- `clippy` was not run locally (cargo-lock contention with the in-flight suite at session close); the commit used `TSZ_SKIP_VERIFY=1`. The per-merge CI lane runs it at head.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Obsidian

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hntn3zBFitDARcfPaceyha)_