### PR TITLE
fix(checker): report TS2407 for unknown for-in operands

### DIFF
--- a/crates/tsz-checker/src/state/variable_checking/for_loop.rs
+++ b/crates/tsz-checker/src/state/variable_checking/for_loop.rs
@@ -462,15 +462,21 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Leaf (non-union, non-intersection) validity test for a for-in operand:
-    /// `any`, `unknown`, the `object` intrinsic, a type parameter, or any object-like
+    /// `any`, the `object` intrinsic, a type parameter, or any object-like
     /// type — including deferred index-access / generic-application forms.
+    ///
+    /// `unknown` is deliberately NOT accepted here: `tsc`'s
+    /// `checkForInStatement` only special-cases `any` via `isTypeAny` before
+    /// falling through to `allTypesAssignableToKind(rightType, NonPrimitive |
+    /// InstantiableNonPrimitive)`, which `unknown` fails just like any other
+    /// non-object type — `declare const u: unknown; for (const k in u) {}`
+    /// reports TS2407 (oracle-verified, `tsc` 7.0.2, both strictness modes).
     ///
     /// `is_deferred_object_like_for_in` already returns `true` for both
     /// `is_type_parameter_like` and `is_object_like_type`, so this is the single
     /// predicate shared by the scalar and intersection-member checks.
     fn for_in_leaf_type_is_valid(&mut self, ty: TypeId) -> bool {
         ty == TypeId::ANY
-            || ty == TypeId::UNKNOWN
             || ty == TypeId::OBJECT
             || self.for_in_operand_is_absorbed_nullable(ty)
             || self.is_deferred_object_like_for_in(ty)
@@ -495,7 +501,6 @@ impl<'a> CheckerState<'a> {
         if let Some(members) = query::union_members(self.ctx.types, expr_type) {
             for &member in &members {
                 if member == TypeId::ANY
-                    || member == TypeId::UNKNOWN
                     || query::is_type_parameter_like(self.ctx.types, member)
                     || query::is_object_like_type(self.ctx.types, member)
                     || self.is_deferred_object_like_for_in(member)

--- a/crates/tsz-checker/tests/for_in_self_reference_and_nullable_operand_tests.rs
+++ b/crates/tsz-checker/tests/for_in_self_reference_and_nullable_operand_tests.rs
@@ -196,3 +196,45 @@ for (var textKey in text) { }
 ";
     assert_has_2407(&non_strict(source), "non-object outer binding");
 }
+
+// ---------------------------------------------------------------------------
+// Mechanism 3 — `unknown` is not `any`: `tsc`'s `checkForInStatement` only
+// special-cases `any` via `isTypeAny` before falling through to
+// `allTypesAssignableToKind(rightType, NonPrimitive | InstantiableNonPrimitive)`,
+// which `unknown` fails like any other non-object type. Oracle-verified,
+// `tsc` 7.0.2, `--strict` both ways: `unknown` reports TS2407 identically in
+// both modes (it is not a `strictNullChecks`-gated fact the way `null`/
+// `undefined` are).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn declared_unknown_for_in_operand_is_ts2407_in_both_modes() {
+    let source = "declare const u: unknown;\nfor (const k in u) { }\n";
+    assert_has_2407(&non_strict(source), "unknown operand");
+    assert_has_2407(&strict(source), "unknown operand, strict");
+}
+
+#[test]
+fn union_collapsing_to_unknown_for_in_operand_is_still_ts2407() {
+    // `string | unknown` collapses to `unknown` itself; the union path must
+    // reject it the same way the bare leaf type does.
+    let source = "declare const su: string | unknown;\nfor (const k in su) { }\n";
+    assert_has_2407(&non_strict(source), "string | unknown operand");
+}
+
+#[test]
+fn any_for_in_operand_is_still_not_ts2407() {
+    // Negative control: `any` keeps its own, separate exemption — the
+    // `unknown` fix must not have widened the gate the other direction.
+    let source = "declare const a: any;\nfor (const k in a) { }\n";
+    assert_no_2407(&non_strict(source), "any operand");
+    assert_no_2407(&strict(source), "any operand, strict");
+}
+
+#[test]
+fn type_parameter_for_in_operand_is_still_not_ts2407() {
+    // Negative control: a bare type parameter is object-like via
+    // `is_type_parameter_like`, unaffected by the `unknown` leaf change.
+    let source = "function f<T>(x: T) {\n  for (const k in x) { }\n}\n";
+    assert_no_2407(&non_strict(source), "type parameter operand");
+}


### PR DESCRIPTION
Closes #16141 (slice 2).

**Structural rule.** When a for-in operand's type is `unknown`, `tsc`'s `checkForInStatement` reports TS2407 in both strictness modes — it exempts only `any` via a separate `isTypeAny` check before falling through to `allTypesAssignableToKind(rightType, TypeFlags.NonPrimitive | TypeFlags.InstantiableNonPrimitive)`, and `unknown` is not assignable to that kind any more than `string`/`number`/etc are. `tsz`'s `for_in_leaf_type_is_valid` (`crates/tsz-checker/src/state/variable_checking/for_loop.rs`) accepted `TypeId::UNKNOWN` outright, apparently by analogy with `TypeId::ANY` rather than from the actual `tsc` rule, so `declare const u: unknown; for (const k in u) {}` was silently accepted instead of reporting.

## The fix

Removed the `TypeId::UNKNOWN` arm from `for_in_leaf_type_is_valid` (the leaf validity predicate shared by the scalar and intersection-member checks) and from the parallel `member == TypeId::UNKNOWN` arm in `for_in_expr_type_is_valid_union` — a union that includes `unknown` collapses to `unknown` itself in real TypeScript, so the two checks must agree with the same rule rather than only one of them being fixed.

This branch also merges in `origin/main`'s #16144 (the adjacent TS7022-for-self-reference slice of the same #16141 issue), which landed mid-session and touched the same test file; the merge conflict there was two additive, non-overlapping test sections and both survived intact.

## Adjacent-case matrix

Every row oracle-pinned against `tsc` 7.0.2 (`--noEmit --pretty false`, `--strict` both ways) before writing code:

| Case | tsc | tsz after |
| --- | --- | --- |
| `declare const u: unknown; for (const k in u) {}` | `TS2407` (both modes) | `TS2407` (both modes) — the fix |
| `declare const su: string [ | ] unknown; for (const k in su) {}` — collapses to `unknown` | `TS2407` | `TS2407` |
| `declare const a: any; for (const k in a) {}` | clean | clean *(negative control — `any`'s own exemption is untouched)* |
| `function f[T](x: T) { for (const k in x) {} }` — bare type parameter | clean | clean *(negative control, unaffected)* |
| `declare const n: never; for (const k in n) {}` | `TS2407` | `TS2407` *(unchanged, pre-existing test)* |

(Square brackets stand in for angle brackets above — this board/PR-body pipeline strips real `<T>` on write.)

## Goal
Goal: hold

## Verification
- New tests in `crates/tsz-checker/tests/for_in_self_reference_and_nullable_operand_tests.rs` (wired into the `tsz-checker` lib target): 4 new rows, all pass.
- `cargo nextest run -p tsz-checker --lib for_in_self_reference_and_nullable_operand`: 20/20 passed (pre-merge), re-verified after merging #16144's additions.
- Targeted regression filters, post-merge: `for_in` 81/81, `2407` 17/17, `7022` 8/8.
- Full `cargo nextest run -p tsz-checker --lib`, post-merge: 8817/8818 passed — the single failure (`ts2303_tests::recursive_export_assignment_self_import_reports_ts2303`) is pre-existing on a clean `main` checkout in this same container, unrelated to this change (confirmed independently by other sessions today on #16143).
- `cargo fmt` + `cargo clippy -p tsz-checker --all-targets -- -D warnings` (via the pre-commit hook, post-merge): clean.
- `python3 scripts/arch/arch_guard.py`: passed, no size-ratchet changes.
- `scripts/conformance/compare-to-parent.sh origin/main` (two-sided, `dist-fast` build), pre-merge: base 11445 passed / branch 11445 passed, **0 newly failing, 0 newly passing**. Zero movement is the expected signature here — this is an additive diagnostic on a narrow shape (`unknown` for-in operand) with no corpus fixture, not a null result; it bounds the change's blast radius rather than proving it inert. Re-running this same diff against the post-merge head now that main advanced past #16144; will report the result as a PR comment.

### Not run from this container
`./scripts/emit/run.sh` — the first-run `npm install` step hung indefinitely in this cloud container (a known issue other sessions hit today) and was killed after a 4-minute timeout rather than risk the rest of the session. The conformance two-sided diff already exercises the same 12,585-candidate corpus with zero movement, which substantially bounds the risk to the emit floor, but a seat with a warm emit install should confirm the JS/DTS floors (11562/1375) before merging.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4FkxeESoxiz618Yc6Cz6D)_