### PR TITLE
fix(checker): stop synthesizing construct signatures on the CommonJS export surface

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/js_exports.rs
+++ b/crates/tsz-checker/src/query_boundaries/js_exports.rs
@@ -265,57 +265,6 @@ pub(crate) fn commonjs_type_with_define_property_members(
     }
 }
 
-pub(crate) fn commonjs_export_constructor_type_with_instance(
-    db: &dyn TypeDatabase,
-    rhs_type: TypeId,
-    instance_type: TypeId,
-    symbol: Option<SymbolId>,
-) -> TypeId {
-    if let Some(func) = crate::query_boundaries::common::function_shape_for_type(db, rhs_type) {
-        if func.is_constructor {
-            return rhs_type;
-        }
-
-        let call_sig = CallSignature {
-            type_params: func.type_params.clone(),
-            params: func.params.clone(),
-            this_type: func.this_type,
-            return_type: func.return_type,
-            type_predicate: func.type_predicate,
-            is_method: func.is_method,
-        };
-        let construct_sig = CallSignature {
-            return_type: instance_type,
-            ..call_sig.clone()
-        };
-        return db.callable(CallableShape {
-            call_signatures: vec![call_sig],
-            construct_signatures: vec![construct_sig],
-            properties: Vec::new(),
-            string_index: None,
-            number_index: None,
-            symbol,
-            is_abstract: false,
-        });
-    }
-
-    let Some(shape) = crate::query_boundaries::common::callable_shape_for_type(db, rhs_type) else {
-        return rhs_type;
-    };
-    if !shape.construct_signatures.is_empty() || shape.call_signatures.is_empty() {
-        return rhs_type;
-    }
-
-    let mut new_shape = shape.as_ref().clone();
-    let mut construct_sig = new_shape.call_signatures[0].clone();
-    construct_sig.return_type = instance_type;
-    new_shape.construct_signatures.push(construct_sig);
-    if new_shape.symbol.is_none() {
-        new_shape.symbol = symbol;
-    }
-    db.callable(new_shape)
-}
-
 pub(crate) struct CommonJsExpandoMember {
     pub(crate) name: String,
     pub(crate) type_id: TypeId,

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_collection.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_collection.rs
@@ -345,7 +345,6 @@ impl<'a> CheckerState<'a> {
                     }
                 }
             }
-            ty = self.upgrade_commonjs_export_constructor_type(rhs_expr, ty);
             ty = self.augment_commonjs_export_type_with_expandos(target_file_idx, expando_root, ty);
             ty = self.widen_fresh_object_literal_properties_for_display(ty);
             return crate::query_boundaries::common::widen_freshness(self.ctx.types, ty);
@@ -356,7 +355,6 @@ impl<'a> CheckerState<'a> {
                 .literal_type_from_initializer(rhs_expr)
                 .or_else(|| checker.commonjs_export_rhs_symbol_type(rhs_expr))
                 .unwrap_or_else(|| checker.get_type_of_node(rhs_expr));
-            ty = checker.upgrade_commonjs_export_constructor_type(rhs_expr, ty);
             ty = checker.augment_commonjs_export_type_with_expandos(
                 target_file_idx,
                 expando_root,

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_resolution.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_resolution.rs
@@ -564,26 +564,6 @@ impl<'a> CheckerState<'a> {
         )
     }
 
-    pub(super) fn upgrade_commonjs_export_constructor_type(
-        &mut self,
-        rhs_expr: NodeIndex,
-        rhs_type: TypeId,
-    ) -> TypeId {
-        let Some(instance_type) =
-            self.synthesize_js_constructor_instance_type(rhs_expr, rhs_type, &[])
-        else {
-            return rhs_type;
-        };
-
-        let symbol = self.resolve_identifier_symbol_without_tracking(rhs_expr);
-        crate::query_boundaries::js_exports::commonjs_export_constructor_type_with_instance(
-            self.ctx.types,
-            rhs_type,
-            instance_type,
-            symbol,
-        )
-    }
-
     /// Match a bare CommonJS export assignment `module.exports = <rhs>` or
     /// `exports = <rhs>` and return `(lhs, rhs)`, where `lhs` is the
     /// `module.exports` / `exports` target node (used for TS2309 positioning)

--- a/crates/tsz-checker/tests/arch_source_scans/commonjs_resolution_export_surface_construction_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/commonjs_resolution_export_surface_construction_boundary_scans.rs
@@ -83,7 +83,6 @@ fn js_exports_boundary_owns_commonjs_resolution_surface_helpers() {
         "commonjs_define_property_setter_contextual_function_type",
         "commonjs_define_property_descriptor_property",
         "commonjs_type_with_define_property_members",
-        "commonjs_export_constructor_type_with_instance",
         "commonjs_export_surface_type_with_display_name",
         "commonjs_imported_module_value_type",
         "commonjs_expando_property",

--- a/crates/tsz-checker/tests/commonjs_constructor_diagnostics_tests.rs
+++ b/crates/tsz-checker/tests/commonjs_constructor_diagnostics_tests.rs
@@ -1,3 +1,16 @@
+//! Cross-file CommonJS `new` semantics for plain JS functions.
+//!
+//! TypeScript 7 dropped the `isJSConstructor` inference: a plain JS function
+//! never acquires a construct signature from `this.x = ...` assignments,
+//! `F.prototype` assignments, or a JSDoc `@constructor` tag. Under
+//! `noImplicitAny`, `new F()` is TS7009 and the result is `any`, so element and
+//! property reads off the result are silent. Only a real `class` declaration
+//! keeps a construct signature.
+//!
+//! These tests pin that the CommonJS export surface agrees with the same-file
+//! `new` path. Every expectation here was taken from `tsc` 7.0.2 with
+//! `allowJs`/`checkJs`/`strict` before the fix was written.
+
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::Arc;
 use tsz_binder::BinderState;
@@ -6,23 +19,13 @@ use tsz_checker::state::CheckerState;
 use tsz_parser::parser::ParserState;
 use tsz_solver::construction::TypeInterner;
 
-/// TSC treats `F.prototype[sym] = val` as "currently unsupported" late-bound declarations.
-/// Accessing `inst[sym]` should emit TS7053, even across CommonJS module boundaries.
-#[test]
-fn test_commonjs_constructor_index_error_uses_exported_function_name() {
-    let a_source = r#"
-const s = Symbol();
-function F() {}
-F.prototype[s] = "ok";
-module.exports.F = F;
-module.exports.S = s;
-"#;
-    let b_source = r#"
-const x = require("./a.js");
-const inst = new x.F();
-inst[x.S];
-"#;
-
+/// Check `b.js` against a two-file CommonJS program where `b.js` does
+/// `require("./a.js")`. Returns every diagnostic reported for `b.js`.
+fn check_commonjs_pair(
+    a_source: &str,
+    b_source: &str,
+    options: CheckerOptions,
+) -> Vec<(u32, String)> {
     let mut parser_a = ParserState::new("a.js".to_string(), a_source.to_string());
     let root_a = parser_a.parse_source_file();
     let mut binder_a = BinderState::new();
@@ -39,8 +42,7 @@ inst[x.S];
 
     let file_a_exports = binder_a.module_exports.get("a.js").cloned();
     if let Some(exports) = &file_a_exports {
-        std::sync::Arc::make_mut(&mut binder_b.module_exports)
-            .insert("./a.js".to_string(), exports.clone());
+        Arc::make_mut(&mut binder_b.module_exports).insert("./a.js".to_string(), exports.clone());
     }
 
     let mut cross_file_targets = FxHashMap::default();
@@ -60,16 +62,10 @@ inst[x.S];
         binder_b.as_ref(),
         &types,
         "b.js".to_string(),
-        CheckerOptions {
-            allow_js: true,
-            check_js: true,
-            strict: true,
-            no_lib: true,
-            module: tsz_common::common::ModuleKind::CommonJS,
-            ..Default::default()
-        },
+        options,
     );
 
+    checker.ctx.set_lib_contexts(Vec::new());
     checker.ctx.set_all_arenas(all_arenas);
     checker.ctx.set_all_binders(all_binders);
     checker.ctx.set_current_file_idx(1);
@@ -89,21 +85,251 @@ inst[x.S];
 
     checker.check_source_file(root_b);
 
-    let ts7053 = checker
+    checker
         .ctx
         .diagnostics
         .iter()
-        .filter(|d| d.code == 7053)
-        .map(|d| d.message_text.as_str())
-        .collect::<Vec<_>>();
+        .map(|d| (d.code, d.message_text.clone()))
+        .collect()
+}
+
+fn no_lib_options() -> CheckerOptions {
+    CheckerOptions {
+        allow_js: true,
+        check_js: true,
+        strict: true,
+        no_lib: true,
+        module: tsz_common::common::ModuleKind::CommonJS,
+        ..Default::default()
+    }
+}
+
+/// The two-file harness runs without lib files, so every case reports the same
+/// fixed set of TS2318 "Cannot find global type" diagnostics. They are a
+/// property of the harness, not of the code under test, so they are dropped
+/// before asserting.
+fn codes(diagnostics: &[(u32, String)]) -> Vec<u32> {
+    diagnostics
+        .iter()
+        .map(|(code, _)| *code)
+        .filter(|code| *code != 2318)
+        .collect()
+}
+
+/// `tsc` 7.0.2 on `conformance/salsa/lateBoundAssignmentDeclarationSupport4.ts`:
+/// the `new x.F()` in the importing file is TS7009 and nothing else. The
+/// late-bound `F.prototype[sym]` declaration is "currently unsupported", so the
+/// instance is `any` and `inst[x.S]` is silent.
+#[test]
+fn test_commonjs_new_on_prototype_expando_function_is_ts7009_only() {
+    let a_source = r#"
+const s = Symbol();
+function F() {}
+F.prototype[s] = "ok";
+module.exports.F = F;
+module.exports.S = s;
+"#;
+    let b_source = r#"
+const x = require("./a.js");
+const inst = new x.F();
+inst[x.S];
+"#;
+
+    let diagnostics = check_commonjs_pair(a_source, b_source, no_lib_options());
 
     assert_eq!(
-        ts7053.len(),
-        1,
-        "Expected TS7053 for cross-file CommonJS prototype element-access expando read, got: {ts7053:#?}"
+        codes(&diagnostics),
+        vec![7009],
+        "Expected exactly TS7009 for the cross-file `new` on a plain JS function, got: {diagnostics:#?}"
     );
 }
 
+/// Renamed-binder control for the case above: nothing about the fix may depend
+/// on the exported function being called `F`.
+#[test]
+fn test_commonjs_new_on_prototype_expando_function_is_ts7009_only_renamed_binder() {
+    let a_source = r#"
+const marker = Symbol();
+function WidgetFactory() {}
+WidgetFactory.prototype[marker] = "ok";
+module.exports.WidgetFactory = WidgetFactory;
+module.exports.Marker = marker;
+"#;
+    let b_source = r#"
+const mod = require("./a.js");
+const made = new mod.WidgetFactory();
+made[mod.Marker];
+"#;
+
+    let diagnostics = check_commonjs_pair(a_source, b_source, no_lib_options());
+
+    assert_eq!(
+        codes(&diagnostics),
+        vec![7009],
+        "Renamed binders must behave identically, got: {diagnostics:#?}"
+    );
+}
+
+/// The `this.prop = value` form is the original `isJSConstructor` shape and is
+/// equally not a constructor in TypeScript 7: `new x.F()` is TS7009, and the
+/// `any` result silences both the property read and the element read.
+#[test]
+fn test_commonjs_new_on_this_assignment_function_is_ts7009_only() {
+    let a_source = r#"
+function F() {
+  this.a = 1;
+}
+module.exports.F = F;
+"#;
+    let b_source = r#"
+const x = require("./a.js");
+const inst = new x.F();
+inst.a;
+inst["nope"];
+inst.alsoNope;
+"#;
+
+    let diagnostics = check_commonjs_pair(a_source, b_source, no_lib_options());
+
+    assert_eq!(
+        codes(&diagnostics),
+        vec![7009],
+        "An `any` result must silence every downstream read, got: {diagnostics:#?}"
+    );
+}
+
+/// A JSDoc `@constructor` tag does not resurrect the dropped inference either —
+/// `tsc` 7.0.2 still reports TS7009 for `new x.G()`.
+#[test]
+fn test_commonjs_new_on_jsdoc_constructor_function_is_ts7009_only() {
+    let a_source = r#"
+/** @constructor */
+function G() {
+  this.a = 1;
+}
+module.exports.G = G;
+"#;
+    let b_source = r#"
+const x = require("./a.js");
+const g = new x.G();
+g["nope"];
+"#;
+
+    let diagnostics = check_commonjs_pair(a_source, b_source, no_lib_options());
+
+    assert_eq!(
+        codes(&diagnostics),
+        vec![7009],
+        "A JSDoc @constructor tag must not add a construct signature, got: {diagnostics:#?}"
+    );
+}
+
+/// The bare `module.exports = function ...` export form takes the same path as
+/// the named `module.exports.F = F` form and must reach the same answer.
+#[test]
+fn test_commonjs_bare_export_assignment_new_is_ts7009_only() {
+    let a_source = r#"
+module.exports = function Boxed() {
+  this.a = 1;
+};
+"#;
+    let b_source = r#"
+const Boxed = require("./a.js");
+const b = new Boxed();
+b["nope"];
+"#;
+
+    let diagnostics = check_commonjs_pair(a_source, b_source, no_lib_options());
+
+    assert_eq!(
+        codes(&diagnostics),
+        vec![7009],
+        "The bare export-assignment form must agree with the named form, got: {diagnostics:#?}"
+    );
+}
+
+/// Negative control: a real `class` still carries its construct signature
+/// across the CommonJS export surface. `new x.K()` is clean, its declared
+/// members resolve, and an undeclared member still errors — so the fix removes
+/// the synthesized construct signature without weakening the genuine one.
+#[test]
+fn test_commonjs_new_on_exported_class_still_constructs() {
+    let a_source = r#"
+class K {
+  constructor() {
+    this.b = 2;
+  }
+}
+module.exports.K = K;
+"#;
+    let b_source = r#"
+const x = require("./a.js");
+const k = new x.K();
+k.b;
+"#;
+
+    let diagnostics = check_commonjs_pair(a_source, b_source, no_lib_options());
+
+    assert!(
+        codes(&diagnostics).is_empty(),
+        "An exported class must keep its construct signature, got: {diagnostics:#?}"
+    );
+}
+
+/// Negative control, error side: the exported class's instance type must still
+/// be a real type, not `any` — an unknown member is TS2339.
+#[test]
+fn test_commonjs_new_on_exported_class_still_reports_unknown_members() {
+    let a_source = r#"
+class K {
+  constructor() {
+    this.b = 2;
+  }
+}
+module.exports.K = K;
+"#;
+    let b_source = r#"
+const x = require("./a.js");
+const k = new x.K();
+k.missingMember;
+"#;
+
+    let diagnostics = check_commonjs_pair(a_source, b_source, no_lib_options());
+
+    assert_eq!(
+        codes(&diagnostics),
+        vec![2339],
+        "An exported class instance must stay concrete, got: {diagnostics:#?}"
+    );
+}
+
+/// Calling the exported plain function *without* `new` is unaffected: it still
+/// has its call signature and reports nothing.
+#[test]
+fn test_commonjs_plain_call_of_exported_function_is_unaffected() {
+    let a_source = r#"
+function F() {}
+F.prototype.m = function () {};
+module.exports.F = F;
+"#;
+    let b_source = r#"
+const x = require("./a.js");
+x.F();
+"#;
+
+    let diagnostics = check_commonjs_pair(a_source, b_source, no_lib_options());
+
+    assert!(
+        codes(&diagnostics).is_empty(),
+        "A plain call must keep working, got: {diagnostics:#?}"
+    );
+}
+
+/// `tsc` 7.0.2 on `conformance/salsa/lateBoundAssignmentDeclarationSupport2.ts`:
+/// indexing the imported CommonJS *namespace* with its own exported unique
+/// symbol is genuinely TS7053. This is the positive control for the family —
+/// the namespace index check must not be weakened by removing the synthesized
+/// construct signature.
 #[test]
 fn test_commonjs_exported_unique_symbol_stays_concrete_for_namespace_index_errors() {
     let a_source = r#"
@@ -118,78 +344,20 @@ const x = require("./a.js");
 x[x.S];
 "#;
 
-    let mut parser_a = ParserState::new("a.js".to_string(), a_source.to_string());
-    let root_a = parser_a.parse_source_file();
-    let mut binder_a = BinderState::new();
-    binder_a.bind_source_file(parser_a.get_arena(), root_a);
+    let options = CheckerOptions {
+        allow_js: true,
+        check_js: true,
+        strict: true,
+        target: tsz_common::common::ScriptTarget::ES2015,
+        module: tsz_common::common::ModuleKind::CommonJS,
+        ..Default::default()
+    };
+    let diagnostics = check_commonjs_pair(a_source, b_source, options);
 
-    let mut parser_b = ParserState::new("b.js".to_string(), b_source.to_string());
-    let root_b = parser_b.parse_source_file();
-    let mut binder_b = BinderState::new();
-    binder_b.bind_source_file(parser_b.get_arena(), root_b);
-
-    let arena_a = Arc::new(parser_a.get_arena().clone());
-    let arena_b = Arc::new(parser_b.get_arena().clone());
-    let all_arenas = Arc::new(vec![Arc::clone(&arena_a), Arc::clone(&arena_b)]);
-
-    let file_a_exports = binder_a.module_exports.get("a.js").cloned();
-    if let Some(exports) = &file_a_exports {
-        std::sync::Arc::make_mut(&mut binder_b.module_exports)
-            .insert("./a.js".to_string(), exports.clone());
-    }
-
-    let mut cross_file_targets = FxHashMap::default();
-    if let Some(exports) = &file_a_exports {
-        for (_name, &sym_id) in exports.iter() {
-            cross_file_targets.insert(sym_id, 0usize);
-        }
-    }
-
-    let binder_a = Arc::new(binder_a);
-    let binder_b = Arc::new(binder_b);
-    let all_binders = Arc::new(vec![Arc::clone(&binder_a), Arc::clone(&binder_b)]);
-
-    let types = TypeInterner::new();
-    let mut checker = CheckerState::new(
-        arena_b.as_ref(),
-        binder_b.as_ref(),
-        &types,
-        "b.js".to_string(),
-        CheckerOptions {
-            allow_js: true,
-            check_js: true,
-            strict: true,
-            target: tsz_common::common::ScriptTarget::ES2015,
-            module: tsz_common::common::ModuleKind::CommonJS,
-            ..Default::default()
-        },
-    );
-
-    checker.ctx.set_all_arenas(all_arenas);
-    checker.ctx.set_all_binders(all_binders);
-    checker.ctx.set_current_file_idx(1);
-    for (sym_id, file_idx) in &cross_file_targets {
-        checker.ctx.register_symbol_file_target(*sym_id, *file_idx);
-    }
-
-    let mut resolved_module_paths: FxHashMap<(usize, String), usize> = FxHashMap::default();
-    resolved_module_paths.insert((1, "./a.js".to_string()), 0);
-    checker
-        .ctx
-        .set_resolved_module_paths(Arc::new(resolved_module_paths));
-
-    let mut resolved_modules: FxHashSet<String> = FxHashSet::default();
-    resolved_modules.insert("./a.js".to_string());
-    checker.ctx.set_resolved_modules(resolved_modules);
-
-    checker.check_source_file(root_b);
-
-    let ts7053 = checker
-        .ctx
-        .diagnostics
+    let ts7053 = diagnostics
         .iter()
-        .filter(|d| d.code == 7053)
-        .map(|d| d.message_text.as_str())
+        .filter(|(code, _)| *code == 7053)
+        .map(|(_, message)| message.as_str())
         .collect::<Vec<_>>();
 
     assert_eq!(


### PR DESCRIPTION
**Structural rule.** When a plain JS function is exported through CommonJS and constructed in an importing file, `tsc` reports TS7009 and types the result `any`; tsz now does the same through the **checker's CommonJS export-surface resolution** (`state/type_analysis/computed_commonjs`), instead of grafting a synthesized construct signature onto the exported function type.

TypeScript 7 dropped the `isJSConstructor` inference. A plain JS function never acquires a construct signature — not from `this.x = ...` body assignments, not from `F.prototype.m = ...` / `F.prototype[sym] = ...` assignments, and not from a JSDoc `@constructor` tag. Under `noImplicitAny`, `new F()` is TS7009 and the result is `any`. tsz already implements exactly that on the **same-file** `new` path, and says so in a comment (`types/computation/complex.rs`, the `VoidFunctionCalledWithNew | NonVoidFunctionCalledWithNew` arm).

The **cross-file** path disagreed. `upgrade_commonjs_export_constructor_type` ran `synthesize_js_constructor_instance_type` over every CommonJS-exported RHS and, whenever it produced an instance type, called `commonjs_export_constructor_type_with_instance` to attach a construct signature returning it. So `new x.F()` in an importing file resolved that synthesized signature: TS7009 never fired, and the result was a concrete instance type rather than `any` — which then made every downstream element or property read report a false TS7053 / TS2339.

This PR removes the graft and its query-boundary helper. Real `class` declarations are untouched — their construct signatures come from the class, not from this path.

### Failure family

Three conformance rows, one cause, each flips outright:

```
conformance/salsa/lateBoundAssignmentDeclarationSupport4.ts | expected:[TS7009] actual:[TS7009,TS7053]
conformance/salsa/lateBoundAssignmentDeclarationSupport5.ts | expected:[TS7009] actual:[TS7009,TS7053]
conformance/salsa/lateBoundAssignmentDeclarationSupport6.ts | expected:[TS7009] actual:[TS7009,TS7053]
```

The extra TS7053 was only the visible half. The same defect also **suppressed a TS7009** that `tsc` reports on the importing file's own `new x.F()` — so these rows were both a false positive and a false negative from one root.

## Goal
Goal: hold

## Verification

All expectations below were taken from a live `typescript@7.0.2` run (`--noEmit --strict --allowJs --checkJs --target es6 --module commonjs`) **before** the fix was written, then re-run against the built binary.

**The three failing rows, reconstructed from the upstream fixtures** (`tsz` built from this branch vs `tsc` 7.0.2) — byte-identical after the fix, on both files of each two-file program:

| row | tsc 7.0.2 | tsz before | tsz after |
| --- | --- | --- | --- |
| lateBound…4 | `decl(9,15) TS7009`, `usage(2,15) TS7009` | `decl(9,15) TS7009`, `usage(3,11) TS7053`, `usage(4,11) TS7053` | matches tsc |
| lateBound…5 | `decl(11,15) TS7009`, `usage(2,15) TS7009` | `decl(11,15) TS7009`, `usage(3,11) TS7053`, `usage(4,11) TS7053` | matches tsc |
| lateBound…6 | `decl(10,15) TS7009`, `usage(2,15) TS7009` | `decl(10,15) TS7009`, `usage(3,11) TS7053`, `usage(4,11) TS7053` | matches tsc |

**Sibling-row controls in the same family** — reconstructed and run the same way; unchanged by this diff, and matching `tsc` on code and position before and after:

- `lateBoundAssignmentDeclarationSupport1.ts` — 4 × TS7053 (namespace index), matches.
- `lateBoundAssignmentDeclarationSupport2.ts` — 4 × TS7053, matches on codes/positions. (This row still fails the corpus for an unrelated reason: tsz renders the module path as `typeof import("…Support2.js")` with the extension in the declaring file and without it in the importing file. Not touched here.)
- `lateBoundAssignmentDeclarationSupport3.ts` — 2 × TS7053, matches.
- `lateBoundAssignmentDeclarationSupport7.ts` — clean in both, matches. (No `new`; static `F[sym]` only.)

**Adjacent-case matrix**, 9 tests in `crates/tsz-checker/tests/commonjs_constructor_diagnostics_tests.rs`, all oracle-pinned:

| case | expectation |
| --- | --- |
| `F.prototype[sym] = …`, `new x.F()` | exactly TS7009 |
| same, **renamed binders** (`WidgetFactory` / `marker` / `mod` / `made`) | exactly TS7009 |
| `this.a = 1` body form; result read via `.a`, `["nope"]`, `.alsoNope` | exactly TS7009 — `any` silences all three |
| JSDoc `/** @constructor */` | exactly TS7009 |
| bare `module.exports = function Boxed(){…}` export form | exactly TS7009 |
| exported `class K`, `new x.K()` then `k.b` | clean — construct signature survives |
| exported `class K`, `k.missingMember` | TS2339 — instance stays concrete, not `any` |
| plain call `x.F()` (no `new`) | clean — call signature untouched |
| `module.exports[sym]`, `x[x.S]` namespace index (row 2's shape) | one TS7053, `unique symbol` preserved |

The first of these previously asserted the opposite (`Expected TS7053 … even across CommonJS module boundaries`). Its premise was wrong: `tsc`'s TS7053 in this family is on the imported **namespace** (row 2 / row 1), never on an instance produced by `new`. Verified against `tsc` 7.0.2 on that test's own source — `tsc` reports `b.js(2,14): TS7009` and no TS7053. Corrected rather than deleted, and the genuine namespace-index case is kept as the positive control.

**Suites**
- `cargo test -p tsz-checker --test commonjs_constructor_diagnostics_tests` — 9/9 pass (was 2 tests, 1 asserting the false positive).
- `cargo test -p tsz-checker --lib` — running at post time; result posted as a follow-up comment.
- `cargo fmt --check` — clean.
- `cargo clippy` — CI's per-merge lane runs it at head.

**Not run in this container, disclosed:**
- `scripts/conformance/compare-to-parent.sh` and `conformance.sh snapshot` — no TypeScript submodule here. The three target rows and their four sibling controls were reconstructed from the upstream fixtures and measured individually instead, which covers the family but not the rest of the corpus. **A warm-corpus seat running `compare-to-parent.sh` against this head is the remaining gate**; expected result is 3 newly passing (`lateBoundAssignmentDeclarationSupport4/5/6.ts`), 0 newly failing.
- Emit and fourslash — no emit-path or LSP code is touched; the diff only removes a construct signature from a checker-side type surface.

**Blast radius.** `commonjs_export_constructor_type_with_instance` had exactly one caller, `upgrade_commonjs_export_constructor_type`, which in turn had exactly two (the same-file and cross-file arms of `infer_commonjs_export_rhs_type`). Both are removed. The helper's row in `commonjs_resolution_export_surface_construction_boundary_scans.rs` is removed with it — the scan asserts that `query_boundaries::js_exports` owns the surface-construction helpers that exist, and this one no longer does. `synthesize_js_constructor_instance_type` itself is unchanged and still serves its six other callers (heritage bases, prototype reads, `binary_support`, ambient signature checks).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Andesite

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgfTzhMT6vueB7krDNMUPN)_