### PR TITLE
fix(solver): restrict the nominal heritage fast path back to classes (#16142)

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/rules/objects.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/objects.rs
@@ -769,11 +769,19 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         else {
             return false;
         };
+        // Classes only. The interface widening (#16137) was reverted here:
+        // its premise — that tsc's declaration-time override check guarantees
+        // the interface is a structural subtype of its heritage parent — holds
+        // only when that check PASSED. `class_extends` is a map the checker
+        // *registers*, so a class whose `extends` was rejected is simply absent
+        // from it; `interface_extends` has no registration site and resolves by
+        // name, reporting the edge as written regardless of TS2430. `lib.dom.d.ts`
+        // contains such an edge (`HTMLTrackElement extends HTMLElement`, TS2430),
+        // so the shortcut wrongly accepted it and TS2344 was lost on 3 conformance
+        // rows. See #16142 for the durable fix (register verified interface
+        // heritage the way `register_class_extends` does).
         let source_kind = self.resolver.get_def_kind(source_def);
-        if !matches!(
-            source_kind,
-            Some(crate::def::DefKind::Class | crate::def::DefKind::Interface)
-        ) {
+        if !matches!(source_kind, Some(crate::def::DefKind::Class)) {
             return false;
         }
         let Some(target_def) = target_def else {

--- a/crates/tsz-solver/tests/objects_interface_nominal_fastpath_tests.rs
+++ b/crates/tsz-solver/tests/objects_interface_nominal_fastpath_tests.rs
@@ -107,6 +107,8 @@ fn shape_with_symbol(symbol: SymbolId) -> ObjectShape {
 /// `W2 extends Window {}` against a lib-def `Window` target: the new
 /// `DefKind::Interface` arm must consult `get_interface_extends` (the
 /// class-only map is empty) and return `true` in one hop.
+#[ignore = "#16142: the interface fast path is disabled until verified heritage is registered; \
+            its premise fails when the `extends` was itself rejected (TS2430)"]
 #[test]
 fn interface_source_uses_interface_extends_map() {
     let interner = TypeInterner::new();
@@ -222,6 +224,8 @@ fn interface_source_ignores_class_extends_map() {
 /// Multi-hop chain: `C extends B {}`, `B extends A {}`, target `A`. Proves the
 /// walk re-checks `get_def_kind` at every hop rather than only the source's
 /// own kind, and follows more than one edge.
+#[ignore = "#16142: the interface fast path is disabled until verified heritage is registered; \
+            its premise fails when the `extends` was itself rejected (TS2430)"]
 #[test]
 fn interface_multi_hop_chain_walks_to_target() {
     let interner = TypeInterner::new();


### PR DESCRIPTION
Restores the 3 conformance rows #16137 regressed (#16142). **Stopgap, not the durable fix** — see "What this is not".

## Structural rule

When an object relation's source is a nominal **interface**, its heritage edge cannot be trusted as a subtyping shortcut, because tsz has no record of whether that `extends` was *accepted*. Restricting `class_instance_extends_target_def` back to `DefKind::Class` restores the invariant the class path actually relies on.

## Why the premise failed

#16137's rule was *"tsc's declaration-time override-compatibility check already guarantees the interface's instance is structurally a subtype of its heritage parent."* True — **conditional on that check having passed**, which the shortcut never tested.

The two paths differ in a way the code comment described but did not act on:

- `class_extends` is a map the **checker registers** (`register_class_extends`, `def/resolver.rs:1558`, driven from `deferred_flow_env_write.rs:191`). It is populated as a *result* of checking, so a class whose `extends` was rejected is simply absent from it.
- `interface_extends` has **no registration site** — `grep 'interface_extends.insert'` in the resolver returns nothing. It resolves by name at query time and therefore reports the edge *as written*, regardless of TS2430.

So "checker-verified" was doing real work on the class side with no counterpart on the interface side. `lib.dom.d.ts` contains a violating edge, reported by both compilers:

```
lib.dom.d.ts(21602,11): TS2430: Interface 'HTMLTrackElement' incorrectly extends interface 'HTMLElement'.
  Types of property 'kind' are incompatible.
```

The shortcut took it anyway, `HTMLElementTagNameMap[K]` then satisfied `Element`, and TS2344 was lost. Three lines, no DOM:

```ts
interface Bad extends Error { message: number; }   // TS2430
declare const b: Bad;
declare function want(e: Error): void;
want(b);

tsc:            TS2345 + TS2430
main (#16137):  TS2430 only
this PR:        TS2345 + TS2430
```

## What this is not

This does **not** implement the durable fix, which is to register verified interface heritage the way `register_class_extends` does — recording the edge only when TS2430 did not fire. That spans checker + solver and is a design call about where interface heritage gets recorded; #16142 stays open for it, and #16137's two interface-shortcut unit tests are `#[ignore]`d with that reason rather than deleted, so they go live the moment it lands.

The class-only path has the same latent hole (`class Bad extends Error { message: number }` is TS2416) — it never surfaced because no *lib class* violates it, only a lib interface does. Worth gating both when the real fix arrives.

## Goal
Goal: hold

## Verification

Measured against a fresh `main` snapshot, not the committed artifact (which is stale by 9 rows and cannot be refreshed while these 3 are red — that would baseline them):

```
TRUE main (measured)   11451
this PR                11454      +3 restored, 0 newly failing

coAndContraVariantInferences2.ts   tsc [TS2344, TS2430]   this PR matches
coAndContraVariantInferences3.ts   tsc [TS2344, TS2430]   this PR matches
coAndContraVariantInferences4.ts   tsc [TS2344, TS2430]   this PR matches

accounting        failed 589 == 589 entries · runnable 12043 == 12043 baseline lines
emit JS / DTS     11562 / 1375   both floors hold
tsz-solver --lib  7628 run, 7628 passed, 2 skipped (the 2 newly #[ignore]d)
tsz-checker --lib 8819 run, 1 failed — baselined ts2303, zero delta
```

`--run-ignored all` on the fast-path suite confirms the 2 ignored rows are the interface-shortcut ones and nothing else changed behaviour.

Happy for this to be closed in favour of the durable fix if someone has it in flight — the point is that `main` should not stay red, and every review meanwhile pays for a full `main` snapshot to tell borrowed regressions from real ones.

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high
AgentName: Quartz
