### PR TITLE
fix(checker): type an object-literal setter parameter from its paired getter

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -942,6 +942,9 @@ path = "tests/accessor_pair_override_ts2416_tests.rs"
 name = "object_literal_set_only_accessor_type_tests"
 path = "tests/object_literal_set_only_accessor_type_tests.rs"
 [[test]]
+name = "object_literal_accessor_pair_parameter_type_tests"
+path = "tests/object_literal_accessor_pair_parameter_type_tests.rs"
+[[test]]
 name = "conditional_optional_infer_default_tests"
 path = "tests/conditional_optional_infer_default_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/checkers/accessor_checker.rs
+++ b/crates/tsz-checker/src/checkers/accessor_checker.rs
@@ -16,9 +16,23 @@ impl<'a> CheckerState<'a> {
         setter_accessor: &tsz_parser::parser::node::AccessorData,
     ) -> Option<NodeIndex> {
         let class_info = self.ctx.enclosing_class.as_ref()?;
+        self.paired_getter_in_members(&class_info.member_nodes, setter_accessor)
+    }
 
+    /// Find the `get` accessor paired with `setter_accessor` among `members`.
+    ///
+    /// The class path passes the enclosing class's member nodes; the
+    /// object-literal path passes the literal's elements. Pairing is by
+    /// property name (so `get 'a'()` pairs with `set a()`, and `get 0x20()`
+    /// with `set 3.2e1()`, exactly as `tsc` pairs them), falling back to
+    /// computed-name symbol identity when the name is not a literal.
+    pub(crate) fn paired_getter_in_members(
+        &self,
+        members: &[NodeIndex],
+        setter_accessor: &tsz_parser::parser::node::AccessorData,
+    ) -> Option<NodeIndex> {
         if let Some(setter_name) = self.get_property_name(setter_accessor.name) {
-            for &member_idx in &class_info.member_nodes {
+            for &member_idx in members {
                 let Some(member_node) = self.ctx.arena.get(member_idx) else {
                     continue;
                 };
@@ -36,7 +50,7 @@ impl<'a> CheckerState<'a> {
         let setter_sym = self.resolve_computed_name_symbol(setter_accessor.name);
         setter_sym?;
 
-        for &member_idx in &class_info.member_nodes {
+        for &member_idx in members {
             let Some(member_node) = self.ctx.arena.get(member_idx) else {
                 continue;
             };
@@ -55,13 +69,31 @@ impl<'a> CheckerState<'a> {
         &mut self,
         setter_accessor: &tsz_parser::parser::node::AccessorData,
     ) -> Option<Vec<Option<tsz_solver::TypeId>>> {
+        let class_info = self.ctx.enclosing_class.as_ref()?;
+        let members = class_info.member_nodes.clone();
+        self.contextual_setter_parameter_types_in_members(&members, setter_accessor)
+    }
+
+    /// The contextual types of `setter_accessor`'s parameters, given the
+    /// accessor's sibling `members`.
+    ///
+    /// An unannotated `set` accessor parameter takes the paired `get`
+    /// accessor's type — its return annotation when it has one, otherwise the
+    /// type inferred from its body. Returns `None` when the parameter is
+    /// annotated (the annotation wins) or when there is no paired getter (the
+    /// parameter stays implicitly `any` and keeps its `TS7006`/`TS7032`).
+    pub(crate) fn contextual_setter_parameter_types_in_members(
+        &mut self,
+        members: &[NodeIndex],
+        setter_accessor: &tsz_parser::parser::node::AccessorData,
+    ) -> Option<Vec<Option<tsz_solver::TypeId>>> {
         let &first_param_idx = setter_accessor.parameters.nodes.first()?;
         let param = self.ctx.arena.get_parameter_at(first_param_idx)?;
         if param.type_annotation.is_some() && !self.ctx.is_js_file() {
             return None;
         }
 
-        let getter_member_idx = self.paired_getter_member_for_setter(setter_accessor)?;
+        let getter_member_idx = self.paired_getter_in_members(members, setter_accessor)?;
         let getter_node = self.ctx.arena.get(getter_member_idx)?;
         let getter = self.ctx.arena.get_accessor(getter_node)?;
 

--- a/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
@@ -220,7 +220,35 @@ impl<'a> CheckerState<'a> {
             } else {
                 // Setter: type-check the function body to track variable usage
                 // (especially for noUnusedParameters/noUnusedLocals checking),
-                // but use the parameter type annotation for the property type
+                // but use the parameter type annotation for the property type.
+                //
+                // Cache the paired getter's type onto an unannotated parameter
+                // first, so the body sees the pair's shared declared type rather
+                // than implicit `any`. `get_type_of_function_impl` prefers an
+                // already-cached parameter type, which is the same lever the
+                // class-member path uses via `cache_parameter_types`.
+                if let Some(contextual_param_types) =
+                    self.contextual_setter_parameter_types_in_members(obj_elements, accessor)
+                {
+                    self.cache_parameter_types(
+                        &accessor.parameters.nodes,
+                        Some(&contextual_param_types),
+                    );
+                    for (&param_idx, contextual) in accessor
+                        .parameters
+                        .nodes
+                        .iter()
+                        .zip(contextual_param_types.iter().copied())
+                    {
+                        let Some(contextual) = contextual else {
+                            continue;
+                        };
+                        self.ctx.node_types.insert(param_idx.0, contextual);
+                        if let Some(param) = self.ctx.arena.get_parameter_at(param_idx) {
+                            self.ctx.node_types.insert(param.name.0, contextual);
+                        }
+                    }
+                }
                 self.get_type_of_function(elem_idx);
 
                 // Extract setter write type from first parameter.

--- a/crates/tsz-checker/tests/object_literal_accessor_pair_parameter_type_tests.rs
+++ b/crates/tsz-checker/tests/object_literal_accessor_pair_parameter_type_tests.rs
@@ -1,0 +1,139 @@
+//! An object literal's `get`/`set` accessor pair shares one declared type.
+//!
+//! `tsc` types an unannotated `set` accessor parameter from the paired `get`
+//! accessor (`getAnnotatedAccessorType`, falling back to the getter's inferred
+//! return type). The class-member path already did this via
+//! `contextual_setter_parameter_types_for_class_accessor`; the object-literal
+//! path did not, so the setter's parameter was implicitly `any` inside the
+//! body while the *property* type was correctly the getter's type.
+//!
+//! The witnesses use `var y = <param>; var y: T;` because `TS2403` compares
+//! the two declarations with type identity, which makes the parameter's type
+//! observable in a diagnostic without depending on any rendered type text.
+//!
+//! Negative controls pin the two ways the pair must NOT be joined: an
+//! annotated setter parameter keeps its annotation, and a setter with no
+//! paired getter stays implicitly `any`.
+
+use tsz_checker::test_utils::check_source_non_strict_codes;
+
+/// `CheckerOptions::default()` is a strict run, and these shapes are all
+/// `@strict: false` corpus rows, so every case goes through the non-strict
+/// entry point.
+fn assert_clean(src: &str) {
+    let codes = check_source_non_strict_codes(src);
+    assert!(codes.is_empty(), "expected no diagnostics, got {codes:?}");
+}
+
+fn assert_codes(src: &str, expected: &[u32]) {
+    let codes = check_source_non_strict_codes(src);
+    assert_eq!(codes, expected, "unexpected diagnostics");
+}
+
+// ── setter parameter takes the paired getter's type ─────────────────────────
+
+#[test]
+fn object_literal_setter_param_takes_inferred_getter_return_type() {
+    assert_clean("var o = { get n() { return ''; }, set n(v) { var y = v; var y: string; } };");
+}
+
+#[test]
+fn object_literal_setter_param_takes_annotated_getter_return_type() {
+    assert_clean(
+        "var o = { get n(): string { return undefined; }, \
+         set n(v) { var y = v; var y: string; } };",
+    );
+}
+
+/// Declaration order must not matter: the getter is found by scanning the
+/// literal's elements, not by what has been recorded so far.
+#[test]
+fn object_literal_setter_before_getter_still_pairs() {
+    assert_clean("var o = { set n(v) { var y = v; var y: string; }, get n() { return ''; } };");
+}
+
+/// Binder-name independence: the pairing is by property name, and the same
+/// property name spelled differently (quoted vs. bare, and two numeric
+/// spellings of 32) must still pair, exactly as `tsc` pairs them.
+#[test]
+fn object_literal_accessor_pairing_is_independent_of_name_spelling() {
+    assert_clean("var o = { get 'zz'() { return ''; }, set zz(q) { var w = q; var w: string; } };");
+    assert_clean(
+        "var o = { get 0x20() { return ''; }, set 3.2e1(q) { var w = q; var w: string; } };",
+    );
+}
+
+/// The paired type is not restricted to primitives — an object getter type
+/// reaches the setter body the same way.
+#[test]
+fn object_literal_setter_param_takes_object_getter_type() {
+    assert_clean(
+        "interface Pt { x: number; }\n\
+         declare var pt: Pt;\n\
+         var o = { get n() { return pt; }, set n(v) { var y = v; var y: Pt; } };",
+    );
+}
+
+/// A renamed binder must behave identically — the rule is structural, not
+/// keyed on any particular parameter or property identifier.
+#[test]
+fn object_literal_accessor_pair_survives_renamed_binders() {
+    assert_clean(
+        "var renamedOuter = { get renamedProp() { return ''; }, \
+         set renamedProp(renamedParam) { var renamedLocal = renamedParam; \
+         var renamedLocal: string; } };",
+    );
+}
+
+/// Nesting: an inner object literal's pair must resolve against its own
+/// elements, not the outer literal's.
+#[test]
+fn nested_object_literal_accessor_pairs_resolve_per_literal() {
+    assert_clean(
+        "var outer = { get n() { return 0; }, set n(v) { var y = v; var y: number; }, \
+         inner: { get n() { return ''; }, set n(v) { var y = v; var y: string; } } };",
+    );
+}
+
+// ── class parity (already correct — pinned so it cannot regress) ────────────
+
+#[test]
+fn class_setter_param_takes_paired_getter_type() {
+    assert_clean("class C { get n() { return ''; } set n(v) { var y = v; var y: string; } }");
+}
+
+// ── negative controls ──────────────────────────────────────────────────────
+
+/// No paired getter: the parameter stays implicitly `any`, so the redeclaration
+/// really does conflict and `TS2403` is correct. `tsc` reports it here too.
+#[test]
+fn object_literal_setter_without_paired_getter_stays_any() {
+    assert_codes(
+        "var o = { set n(v) { var y = v; var y: string; } };",
+        &[2403],
+    );
+}
+
+/// An annotated setter parameter wins over the getter's type — the pair is
+/// allowed to be split (TS 4.3+), and the write type must stay the annotation.
+///
+/// Both `TS2322`s are correct and oracle-pinned against `tsc` 7.0.2: one for
+/// the getter's `string` body against the pair's `number` write type, one for
+/// the `number` parameter read into a `string` local.
+#[test]
+fn annotated_setter_param_is_not_overridden_by_getter_type() {
+    assert_codes(
+        "var o = { get n() { return ''; }, set n(v: number) { var y: string = v; } };",
+        &[2322, 2322],
+    );
+}
+
+/// A getter with neither an annotation nor a body yields nothing to pair with,
+/// so the setter parameter must not be silently typed from it.
+#[test]
+fn getter_only_accessor_does_not_type_an_unrelated_setter() {
+    assert_codes(
+        "var o = { get m() { return ''; }, set n(v) { var y = v; var y: string; } };",
+        &[2403],
+    );
+}


### PR DESCRIPTION
**Structural rule.** When a `get`/`set` accessor pair share a property name and the setter's parameter has no type annotation, `tsc` types that parameter from the paired getter (its return annotation, else its inferred return type) — an accessor pair has one declared type. tsz does this through the checker's object-literal accessor path, reusing the same pairing helper the class-member path already used.

The class path was already correct (`contextual_setter_parameter_types_for_class_accessor` → `cache_parameter_types`). The **object-literal path never cached a parameter type at all**, so inside the setter body the parameter was implicitly `any` — while the *property's* own type was correctly the getter's type (`accessor_element.rs` already had that `or_else` fallback). The asymmetry was invisible from the outside and only observable from within the setter body.

```ts
// @strict: false
var o = { get n() { return ''; }, set n(v) { var y = v; var y: string; } };
//                                                      ^ tsz: TS2403 "must be of type 'any'"
//                                                        tsc: (clean)

class C { get n() { return ''; } set n(v) { var y = v; var y: string; } }
//                                                     ^ already clean in tsz — same shape, different path
```

`var y = v; var y: T` is the witness because `TS2403` compares subsequent variable declarations with type *identity*, which makes the parameter's type observable in a diagnostic without any predicate over rendered type text.

## Owner layer

- `crates/tsz-checker/src/checkers/accessor_checker.rs` — `paired_getter_member_for_setter` and `contextual_setter_parameter_types_for_class_accessor` were hard-wired to `ctx.enclosing_class`. Both are now thin wrappers over member-list-parameterized versions (`paired_getter_in_members`, `contextual_setter_parameter_types_in_members`), so class members and object-literal elements share one pairing implementation rather than growing a second one.
- `crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs` — the setter branch caches the paired getter's type onto an unannotated first parameter before walking the body. `get_type_of_function_impl` already prefers an already-cached parameter type (`cached_param_type`), which is the same lever the class path pulls.

No new name/file-string predicates, no printer-output predicates, no single-test suppression. Pairing is by property name with a computed-name-symbol fallback — the pre-existing rule, now reachable from one more caller.

## Adjacent-case matrix

Every row oracle-pinned against vendored `tsc` 7.0.2 (`--strict false`) **before** any code was written.

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| obj: set param ← getter *inferred* return | clean | **TS2403** | clean |
| obj: set param ← getter *annotated* return | clean | **TS2403** | clean |
| obj: setter declared *before* getter | clean | **TS2403** | clean |
| obj: `get 'zz'()` / `set zz(q)` (quoted vs bare) | clean | **TS2403** | clean |
| obj: `get 0x20()` / `set 3.2e1(q)` (numeric spellings of 32) | clean | **TS2403** | clean |
| obj: object-typed getter (`interface Pt`) | clean | **TS2403** | clean |
| obj: renamed binders throughout | clean | **TS2403** | clean |
| obj: nested literal, inner pair resolves per literal | clean | **TS2403** | clean |
| class: set param ← paired getter | clean | clean | clean (pinned) |
| **neg:** setter with *no* paired getter stays `any` | TS2403 | TS2403 | TS2403 |
| **neg:** setter with a *different* name does not pair | TS2403 | TS2403 | TS2403 |
| **neg:** *annotated* setter param wins (split accessor) | TS2322 ×2 | TS2322 ×2 | TS2322 ×2 |

The three negatives are the load-bearing half: the fix must not join a pair that `tsc` leaves split, and must not silence a `TS2403`/`TS7006` that is genuinely correct.

## Conformance row

`conformance/expressions/objectLiterals/objectLiteralGettersAndSetters.ts` — expects zero diagnostics, tsz emitted **11** `TS2403`s. After this change it emits **2**.

The residual 2 (`setParamType1`/`setParamType2`, lines 47/54) are a **different, still-open direction** of the same premise and are deliberately not in this PR — see below. So this PR does not by itself flip that row.

## What I found and did NOT ship

The mirror direction — an unannotated **getter's** contextual return type coming from the paired **setter's** annotated parameter (`tsc`'s `getContextualReturnType`) — is missing too, and unlike this PR's gap it is broken for **classes as well as object literals**:

```ts
var o = { set n(v: (t: string) => void) { }, get n() { return (t) => { var p: string; var p = t; } } };
class K { set n(v: (t: string) => void) { } get n() { return (t) => { var p: string; var p = t; } } }
// tsc: clean, both.  tsz: TS2403 on both — `t` is `any`, not `string`.
```

I built the object-literal half of it (threading the paired setter's annotation into `infer_return_type_from_body`'s `return_context`) and **measured it as a no-op** — the return context does not reach the returned arrow's parameter contextual typing — so I reverted it rather than ship unverified complexity on a hot path. Filed separately with the full matrix; it wants its own session and a different owner (contextual return typing, not parameter caching).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test object_literal_accessor_pair_parameter_type_tests` — **11/11 pass** (new suite: 8 positive shapes, 1 class-parity pin, 3 negative controls). Before this change: 3/11.
- `cargo clippy` + architecture guard via the repo pre-commit hook (`-p tsz-checker`): **Clippy passed. Architecture guard passed.** (One `needless_borrow` was caught and fixed by that gate before commit.)
- `cargo fmt --all`.
- CLI end-to-end against vendored `tsc` 7.0.2 on the real corpus fixture: `objectLiteralGettersAndSetters.ts` **11 → 2** diagnostics; `tsc` reports 0.
- `scripts/conformance/compare-to-parent.sh origin/main` — two-sided against this branch's own parent. **Result posted as a follow-up comment**; started before this PR was opened and not yet finished at open time. Newly-failing is the gate.
- `cargo-nextest` is not installed in this container and `get.nexte.st` is blocked by the agent proxy, so targeted suites ran via `cargo test --test <name>`.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Syenite

---
_Generated by [Claude Code](https://claude.ai/code/session_01SiCA525raZLKJ2imMMkWth)_