### PR TITLE
fix(solver): register verified interface heritage for the nominal fast path (#16142)

### DIFF
--- a/crates/tsz-checker/src/context/def_mapping/env_registration.rs
+++ b/crates/tsz-checker/src/context/def_mapping/env_registration.rs
@@ -153,6 +153,16 @@ impl CheckerContext<'_> {
         });
     }
 
+    /// Register a checker-verified (no TS2430) interface `extends` relationship
+    /// in **both** type environments. See `TypeEnvironment::verified_interface_extends`
+    /// for why this is gated on verification rather than raw name resolution.
+    pub fn register_interface_extends_in_envs(&self, def_id: DefId, parent_def_id: DefId) {
+        self.register_in_envs(DeferredFlowEnvWrite::RegisterInterfaceExtends {
+            def_id,
+            parent_def_id,
+        });
+    }
+
     /// Register a `DefId` ↔ `SymbolId` bridge in **both** type environments.
     ///
     /// This keeps evaluator and flow-analyzer resolution paths aligned for

--- a/crates/tsz-checker/src/context/deferred_flow_env_write.rs
+++ b/crates/tsz-checker/src/context/deferred_flow_env_write.rs
@@ -55,6 +55,9 @@ pub enum DeferredFlowEnvWrite {
     /// `register_class_extends` when absent — merge a child env snapshot
     /// without overwriting a parent edge.
     RegisterClassExtendsIfMissing { def_id: DefId, parent_def_id: DefId },
+    /// `register_interface_extends` — register a checker-verified (no TS2430)
+    /// interface `extends` parent.
+    RegisterInterfaceExtends { def_id: DefId, parent_def_id: DefId },
     /// `register_def_symbol_mapping` — register the `DefId` <-> `SymbolId` bridge.
     RegisterDefSymbolMapping { def_id: DefId, sym_id: SymbolId },
     /// `register_augmented_def` — re-apply an augmentation merge.
@@ -197,6 +200,10 @@ impl DeferredFlowEnvWrite {
                     env.register_class_extends(*def_id, *parent_def_id);
                 }
             }
+            Self::RegisterInterfaceExtends {
+                def_id,
+                parent_def_id,
+            } => env.register_interface_extends(*def_id, *parent_def_id),
             Self::RegisterDefSymbolMapping { def_id, sym_id } => {
                 env.register_def_symbol_mapping(*def_id, *sym_id);
             }

--- a/crates/tsz-checker/src/context/resolver.rs
+++ b/crates/tsz-checker/src/context/resolver.rs
@@ -1532,7 +1532,16 @@ impl<'a> TypeResolver for CheckerContext<'a> {
     }
 
     fn get_interface_extends(&self, def_id: DefId) -> Option<DefId> {
-        self.definition_store.get_extends(def_id)
+        self.type_env
+            .try_borrow()
+            .ok()
+            .and_then(|env| env.get_interface_extends_def(def_id))
+            .or_else(|| {
+                self.type_environment
+                    .try_borrow()
+                    .ok()
+                    .and_then(|env| env.get_interface_extends_def(def_id))
+            })
     }
 
     fn class_def_for_instance_type(&self, type_id: TypeId) -> Option<DefId> {

--- a/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
@@ -9,8 +9,10 @@ use crate::symbols_domain::name_text::{
 };
 use tsz_binder::{SymbolId, symbol_flags};
 use tsz_parser::parser::NodeIndex;
-use tsz_parser::parser::node::NodeAccess;
+use tsz_parser::parser::node::{InterfaceData, NodeAccess};
 use tsz_parser::parser::{NodeList, syntax_kind_ext};
+use tsz_scanner::SyntaxKind;
+use tsz_solver::def::DefId;
 use tsz_solver::{TypeId, TypeParamInfo};
 
 type TypeParameterScopeUpdates = Vec<(String, Option<TypeId>, bool)>;
@@ -522,12 +524,75 @@ impl<'a> CheckerState<'a> {
         }
 
         // Check that interface correctly extends base interfaces (error 2430)
+        let ts2430_diag_start = self.ctx.diagnostics.len();
         self.check_interface_extension_compatibility(stmt_idx, iface);
+        self.register_verified_interface_extends_if_clean(stmt_idx, iface, ts2430_diag_start);
 
         // Check variance annotations match actual usage (TS2636)
         self.check_variance_annotations(stmt_idx, &iface.type_parameters);
 
         self.pop_type_parameters(type_param_updates);
+    }
+
+    /// Register the interface's first `extends` heritage edge as
+    /// checker-verified, but only when `check_interface_extension_compatibility`
+    /// did not fire TS2430 ("incorrectly extends") for this declaration.
+    ///
+    /// The solver's nominal fast path (`class_instance_extends_target_def`)
+    /// trusts this edge to skip the structural member walk against a lib
+    /// target. Trusting the raw name-resolved heritage edge
+    /// (`DefinitionStore::get_extends`, populated unconditionally at
+    /// semantic-construction time) instead is unsound: it also holds for a
+    /// declared-but-rejected `extends`, e.g. `HTMLTrackElement extends
+    /// HTMLElement` in `lib.dom.d.ts`, whose property override tsc itself
+    /// rejects with TS2430 (#16142).
+    fn register_verified_interface_extends_if_clean(
+        &mut self,
+        stmt_idx: NodeIndex,
+        iface: &InterfaceData,
+        ts2430_diag_start: usize,
+    ) {
+        let fired = self.ctx.diagnostics[ts2430_diag_start..].iter().any(|d| {
+            d.code == crate::diagnostics::diagnostic_codes::INTERFACE_INCORRECTLY_EXTENDS_INTERFACE
+        });
+        if fired {
+            return;
+        }
+        let Some(iface_sym_id) = self.ctx.binder.get_node_symbol(stmt_idx) else {
+            return;
+        };
+        let Some(parent_def_id) = self.first_interface_extends_def_id(iface) else {
+            return;
+        };
+        let child_def_id = self.ctx.get_or_create_def_id(iface_sym_id);
+        if child_def_id != parent_def_id {
+            self.ctx
+                .register_interface_extends_in_envs(child_def_id, parent_def_id);
+        }
+    }
+
+    /// Resolve the `DefId` of the first type in the interface's (single)
+    /// `extends` heritage clause, mirroring the "only the first extends name"
+    /// semantics of the unconditional name-resolved edge in
+    /// `DefinitionStore::get_extends`.
+    fn first_interface_extends_def_id(&mut self, iface: &InterfaceData) -> Option<DefId> {
+        let heritage_clauses = iface.heritage_clauses.as_ref()?;
+        let &clause_idx = heritage_clauses.nodes.first()?;
+        let clause_node = self.ctx.arena.get(clause_idx)?;
+        let heritage = self.ctx.arena.get_heritage_clause(clause_node)?;
+        if heritage.token != SyntaxKind::ExtendsKeyword as u16 {
+            return None;
+        }
+        let &type_idx = heritage.types.nodes.first()?;
+        let type_node = self.ctx.arena.get(type_idx)?;
+        let expr_idx = self
+            .ctx
+            .arena
+            .get_expr_type_args(type_node)
+            .map(|expr_type_args| expr_type_args.expression)
+            .unwrap_or(type_idx);
+        let base_sym_id = self.resolve_heritage_symbol(expr_idx)?;
+        Some(self.ctx.get_or_create_def_id(base_sym_id))
     }
 
     fn interface_member_is_mapped_type(&self, member_idx: NodeIndex) -> bool {

--- a/crates/tsz-solver/src/def/resolver.rs
+++ b/crates/tsz-solver/src/def/resolver.rs
@@ -736,6 +736,17 @@ pub struct TypeEnvironment {
     boxed_def_ids: FxHashMap<IntrinsicKind, Vec<DefId>>,
     /// Maps class `DefIds` to their parent class `DefId` (for class hierarchy checks).
     class_extends: FxHashMap<u32, DefId>,
+    /// Maps interface `DefIds` to their parent interface `DefId`, registered by
+    /// the checker only after `check_interface_extension_compatibility` confirms
+    /// the heritage edge did not fire TS2430 ("incorrectly extends"). Unlike
+    /// `class_extends`, this is deliberately NOT the raw name-resolved heritage
+    /// edge from `DefinitionStore::get_extends` (populated unconditionally at
+    /// semantic-construction time) — that edge reports the declared `extends`
+    /// even when tsc's own override check rejected it (e.g. a lib interface
+    /// like `HTMLTrackElement extends HTMLElement` where a property override is
+    /// incompatible), which made the nominal fast path in
+    /// `class_instance_extends_target_def` unsound (#16142).
+    verified_interface_extends: FxHashMap<u32, DefId>,
     /// Reverse map: instance `TypeId` → class `DefId` (for nominal instanceof narrowing).
     instance_type_to_class: FxHashMap<u32, DefId>,
     /// Shared `DefinitionStore` for fallback lookups (e.g., `DefKind` when `def_kinds`
@@ -796,6 +807,7 @@ impl TypeEnvironment {
             class_instance_types: FxHashMap::default(),
             boxed_def_ids: FxHashMap::default(),
             class_extends: FxHashMap::default(),
+            verified_interface_extends: FxHashMap::default(),
             instance_type_to_class: FxHashMap::default(),
             definition_store: None,
             this_type: None,
@@ -1561,9 +1573,25 @@ impl TypeEnvironment {
         self.bump_generation();
     }
 
+    /// Register an interface's parent interface `DefId` once the checker has
+    /// verified the heritage edge did not fire TS2430. See
+    /// `verified_interface_extends` for why this differs from the raw
+    /// name-resolved edge.
+    pub fn register_interface_extends(&mut self, child_def_id: DefId, parent_def_id: DefId) {
+        self.verified_interface_extends
+            .insert(child_def_id.0, parent_def_id);
+        self.bump_generation();
+    }
+
     /// Get the parent class `DefId` for a class.
     pub fn get_class_extends_def(&self, def_id: DefId) -> Option<DefId> {
         self.class_extends.get(&def_id.0).copied()
+    }
+
+    /// Get the checker-verified parent interface `DefId` for an interface. See
+    /// `verified_interface_extends`.
+    pub fn get_interface_extends_def(&self, def_id: DefId) -> Option<DefId> {
+        self.verified_interface_extends.get(&def_id.0).copied()
     }
 
     /// Reverse-lookup: get the class `DefId` for a resolved instance `TypeId`.
@@ -1801,9 +1829,7 @@ impl TypeResolver for TypeEnvironment {
     }
 
     fn get_interface_extends(&self, def_id: DefId) -> Option<DefId> {
-        self.definition_store
-            .as_ref()
-            .and_then(|store| store.get_extends(def_id))
+        self.get_interface_extends_def(def_id)
     }
 
     fn class_def_for_instance_type(&self, type_id: TypeId) -> Option<DefId> {

--- a/crates/tsz-solver/src/relations/subtype/rules/objects.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/objects.rs
@@ -769,19 +769,17 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         else {
             return false;
         };
-        // Classes only. The interface widening (#16137) was reverted here:
-        // its premise — that tsc's declaration-time override check guarantees
-        // the interface is a structural subtype of its heritage parent — holds
-        // only when that check PASSED. `class_extends` is a map the checker
-        // *registers*, so a class whose `extends` was rejected is simply absent
-        // from it; `interface_extends` has no registration site and resolves by
-        // name, reporting the edge as written regardless of TS2430. `lib.dom.d.ts`
-        // contains such an edge (`HTMLTrackElement extends HTMLElement`, TS2430),
-        // so the shortcut wrongly accepted it and TS2344 was lost on 3 conformance
-        // rows. See #16142 for the durable fix (register verified interface
-        // heritage the way `register_class_extends` does).
+        // #16137 widened this to interfaces; #16142 found the widening unsound
+        // (an interface's heritage edge was trusted even when TS2430 rejected
+        // it) and #16148 reverted to classes-only as a stopgap. This restores
+        // the widening on the durable fix: `verified_interface_extends` below
+        // is populated only when the checker's own TS2430 check passed, so an
+        // interface source is now exactly as trustworthy as a class source.
         let source_kind = self.resolver.get_def_kind(source_def);
-        if !matches!(source_kind, Some(crate::def::DefKind::Class)) {
+        if !matches!(
+            source_kind,
+            Some(crate::def::DefKind::Class | crate::def::DefKind::Interface)
+        ) {
             return false;
         }
         let Some(target_def) = target_def else {
@@ -801,13 +799,15 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         let mut current = source_def;
         for _ in 0..50 {
             // Classes use the checker-verified, generics-aware `class_extends`
-            // map. Interfaces never populate it, so they fall back to the
-            // name-resolved, single-parent heritage edge — sound because tsc
-            // requires a heritage clause to already be a structurally
-            // compatible override at declaration time, but incomplete for a
-            // multi-parent `interface B extends A, C {}` (a miss there just
-            // returns `false` here, which re-runs the always-correct
-            // structural walk in the caller).
+            // map. Interfaces use `verified_interface_extends`, a single-parent
+            // edge the checker registers only when
+            // `check_interface_extension_compatibility` found no TS2430
+            // ("incorrectly extends") for this declaration — trusting the raw
+            // name-resolved heritage edge instead is unsound, since tsc's own
+            // override check can reject a declared `extends` (#16142). Both
+            // maps miss on a multi-parent `interface B extends A, C {}` (only
+            // the first parent is tracked); a miss just returns `false` here,
+            // which re-runs the always-correct structural walk in the caller.
             let parent = match self.resolver.get_def_kind(current) {
                 Some(crate::def::DefKind::Class) => self.resolver.get_class_extends(current),
                 Some(crate::def::DefKind::Interface) => {

--- a/crates/tsz-solver/tests/objects_interface_nominal_fastpath_tests.rs
+++ b/crates/tsz-solver/tests/objects_interface_nominal_fastpath_tests.rs
@@ -107,8 +107,6 @@ fn shape_with_symbol(symbol: SymbolId) -> ObjectShape {
 /// `W2 extends Window {}` against a lib-def `Window` target: the new
 /// `DefKind::Interface` arm must consult `get_interface_extends` (the
 /// class-only map is empty) and return `true` in one hop.
-#[ignore = "#16142: the interface fast path is disabled until verified heritage is registered; \
-            its premise fails when the `extends` was itself rejected (TS2430)"]
 #[test]
 fn interface_source_uses_interface_extends_map() {
     let interner = TypeInterner::new();
@@ -224,8 +222,6 @@ fn interface_source_ignores_class_extends_map() {
 /// Multi-hop chain: `C extends B {}`, `B extends A {}`, target `A`. Proves the
 /// walk re-checks `get_def_kind` at every hop rather than only the source's
 /// own kind, and follows more than one edge.
-#[ignore = "#16142: the interface fast path is disabled until verified heritage is registered; \
-            its premise fails when the `extends` was itself rejected (TS2430)"]
 #[test]
 fn interface_multi_hop_chain_walks_to_target() {
     let interner = TypeInterner::new();


### PR DESCRIPTION
Closes #16142 — implements the "durable fix" #16148 (stopgap: classes-only revert) left open.

## Structural rule

When an object relation's source is a nominal interface, `tsc`'s declaration-time override-compatibility check must have **passed** for the interface's heritage edge to be trusted as a structural-subtype shortcut. `tsz`'s solver-side fast path (`class_instance_extends_target_def`, `crates/tsz-solver/src/relations/subtype/rules/objects.rs`) now enforces this through a checker-owned query boundary: `verified_interface_extends`, populated only by `check_interface_extension_compatibility` (`crates/tsz-checker/src/state/state_checking_members/interface_checks.rs`) when it found no TS2430 for that declaration.

## Why the previous state was unsound

- `class_extends` is a map the checker *registers* (`register_class_extends`) — a class whose `extends` was rejected is simply absent from it.
- The old `interface_extends` had **no registration site**: it resolved `DefinitionStore::get_extends` by name at query time, reporting the heritage edge *as written*, independent of whether `TS2430` fired.
- `lib.dom.d.ts` contains such a rejected-but-declared edge (`HTMLTrackElement extends HTMLElement`, real `tsc` also reports `TS2430` here). #16137's widening trusted it anyway, `HTMLElementTagNameMap[K]` then satisfied `Element`, and `TS2344` was lost on 3 conformance rows (`coAndContraVariantInferences{2,3,4}.ts`). #16148 landed a classes-only stopgap and left both interface-fast-path unit tests `#[ignore]`d for this fix.

## The fix

- New `TypeEnvironment::verified_interface_extends` map (`crates/tsz-solver/src/def/resolver.rs`), written only through `register_interface_extends`/`register_interface_extends_in_envs` (mirroring the class path's `register_class_extends`/`_in_envs`), threaded through the existing `DeferredFlowEnvWrite` dual-env-write mechanism.
- `check_interface_declaration` now snapshots the diagnostics length around `check_interface_extension_compatibility`; if no `TS2430` fired for the declaration, it resolves the first `extends` heritage type's `DefId` and registers the edge as verified.
- Both `TypeEnvironment::get_interface_extends` (solver-side) **and** `CheckerContext::get_interface_extends` (`crates/tsz-checker/src/context/resolver.rs`, the resolver actually used during live checking) now read this verified map — the earlier attempt at this fix missed that `CheckerContext` has its own `TypeResolver` impl that bypassed `TypeEnvironment` entirely, which is why the first version of this change had no effect until both were patched.
- `class_instance_extends_target_def`'s `source_kind` gate is widened back to `Class | Interface` now that the interface edge is exactly as trustworthy as the class one.
- Un-ignored `interface_source_uses_interface_extends_map` and `interface_multi_hop_chain_walks_to_target` in `crates/tsz-solver/tests/objects_interface_nominal_fastpath_tests.rs` (the two #16148 marked pending this fix).

Both maps still only track a single (first) `extends` parent, so a multi-parent `interface B extends A, C {}` still misses on `C` and falls back to the always-correct structural walk — unchanged from #16137/#16148, not a regression.

## Adjacent-case matrix

- `interface Bad extends Error { message: number }` (TS2430 fires) → fast path now declines, falls back to structural walk, both `TS2430` and `TS2345` reported (matches `tsc`; previously `TS2345` was silently dropped even on the pre-#16137 code path due to the same underlying gap).
- `HTMLTrackElement extends HTMLElement` in `lib.dom.d.ts` (the real regression trigger) → verified below against the pinned oracle.
- Valid interface heritage (no TS2430) → fast path still fires, one-hop shortcut preserved.
- Multi-hop valid chain (`C extends B extends A`) → still walks hop-by-hop and re-checks `DefKind` at each hop (existing unit test, unchanged).
- Class source → untouched, still uses `class_extends`/`register_class_extends`, both maps proven strictly kind-partitioned (existing unit tests).

## Goal
Goal: hold

## Verification
- `cargo fmt --check`, `cargo clippy -p tsz-solver -p tsz-checker --all-targets -- -D warnings`: clean.
- `cargo nextest run -p tsz-solver --lib objects_interface_nominal_fastpath --run-ignored all`: 8/8 passed (including the 2 un-ignored).
- `cargo nextest run -p tsz-checker --lib`: 8820/8821 passed; the 1 failure (`ts2303_tests::recursive_export_assignment_self_import_reports_ts2303`) is pre-existing and reproduces identically on `main` without this change (confirmed via `git stash`).
- `cargo nextest run -p tsz-checker --test ts2430_tests`: 53/53 passed.
- `cargo nextest run -p tsz-checker --lib interface_extends_generic_override_variance`: 14/14 passed.
- Targeted before/after against the pinned oracle (`npm i typescript@7.0.2`) on the 3 regressed rows, fetched directly from `microsoft/TypeScript`:
  ```
  tsc oracle:            coAndContraVariantInferences{2,3,4}.ts → [TS2344, TS2430]
  main (post-#16148):    [TS2430] only (TS2344 still missing — #16148 was a stopgap revert, not a fix)
  this PR:               [TS2344, TS2430] — matches tsc on all 3 rows
  ```
- Not run from this container: full `conformance.sh snapshot` / `compare-to-parent.sh` (no warmed TypeScript-submodule seat in this session's disk budget — see repeated `ENOSPC` recoveries in this session's board notes). The change is scoped to a query-boundary read used only by one relation shortcut whose answer is required to match the always-correct structural walk by construction, and the 3 named rows are hand-verified against the real `tsc` oracle above.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnB8YnnHGpzJUiXp3c1Vsf)_