### PR TITLE
fix(binder): keep a namespace body's non-exported declarations out of another body's exports

### DIFF
--- a/crates/tsz-binder/src/nodes/binding.rs
+++ b/crates/tsz-binder/src/nodes/binding.rs
@@ -1337,37 +1337,17 @@ impl BinderState {
                 self.declare_in_persistent_scope_with_atom(owned_name, name_atom_key, sym_id);
                 return sym_id;
             }
-            // In merged namespace blocks, a non-exported variable must not merge with an
-            // exported variable of the same name from a prior block. In tsc, these are
-            // distinct symbols: `export var Origin: Point` in block 1 and `var Origin: string`
-            // in block 2 are separate — the non-exported one is a local variable that shadows
-            // the exported member within that block's scope, without affecting the namespace's
-            // exported type.
-            let is_in_module_scope = self
-                .current_persistent_scope()
-                .is_some_and(|scope| scope.kind == ContainerKind::Module);
-            let existing_is_exported = self.symbols.get(existing_id).is_some_and(|s| s.is_exported);
-            if is_in_module_scope
-                && existing_is_exported
-                && !is_exported
-                && (flags & symbol_flags::FUNCTION_SCOPED_VARIABLE) != 0
-            {
-                let owned_name = name.to_string();
-                let sym_id = self.symbols.alloc(flags, owned_name.clone());
-                let container_sym = self.current_container_symbol();
-                if let Some(sym) = self.symbols.get_mut(sym_id) {
-                    let span = Self::declaration_span(arena, declaration);
-                    sym.add_declaration(declaration, span);
-                    if (flags & symbol_flags::VALUE) != 0 {
-                        sym.set_value_declaration(declaration, span);
-                    }
-                    sym.is_exported = false;
-                    if let Some(parent_id) = container_sym {
-                        sym.parent = parent_id;
-                    }
-                }
-                Arc::make_mut(&mut self.node_symbols).insert(declaration.0, sym_id);
-                self.declare_in_persistent_scope_with_atom(owned_name, name_atom_key, sym_id);
+            // A non-exported declaration in one body of a merged namespace is a
+            // local of that body, not a contribution to the namespace's exports.
+            if let Some(sym_id) = self.try_declare_namespace_body_local(
+                arena,
+                name,
+                flags,
+                declaration,
+                is_exported,
+                existing_id,
+                name_atom_key,
+            ) {
                 return sym_id;
             }
 

--- a/crates/tsz-binder/src/nodes/mod.rs
+++ b/crates/tsz-binder/src/nodes/mod.rs
@@ -10,3 +10,4 @@ mod flow_statements;
 mod hoisting;
 mod merge_flags;
 mod names;
+mod namespace_body_merge;

--- a/crates/tsz-binder/src/nodes/namespace_body_merge.rs
+++ b/crates/tsz-binder/src/nodes/namespace_body_merge.rs
@@ -1,0 +1,220 @@
+//! Declaration merging across the bodies of a merged namespace.
+//!
+//! `tsc` gives every namespace body its own `locals` table while the merged
+//! namespace symbol owns one shared `exports` table. A declaration written
+//! without `export` therefore becomes a local of the body that wrote it and never
+//! joins an exported declaration of the same name contributed by a *different*
+//! body — `A.Point` resolves through `exports` and sees only what was exported.
+//!
+//! Within a single body the two declarations *do* land on one symbol; that is what
+//! `tsc` reports TS2395 against, so the split here is deliberately scoped to the
+//! cross-body case.
+
+use std::sync::Arc;
+
+use crate::state::BinderState;
+use crate::{ContainerKind, SymbolId, symbol_flags};
+use tsz_common::interner::AstAtom;
+use tsz_parser::NodeIndex;
+use tsz_parser::parser::node::NodeArena;
+use tsz_parser::parser::syntax_kind_ext;
+
+/// Declaration kinds that, when written without `export` in one body of a merged
+/// namespace, become locals of that body instead of joining an exported member of
+/// the same name contributed by another body.
+///
+/// `FUNCTION_SCOPED_VARIABLE` is covered by the older same-body-inclusive branch
+/// in [`BinderState::try_declare_namespace_body_local`] and is deliberately absent
+/// here so that branch keeps its existing behaviour.
+const NAMESPACE_BODY_LOCAL_SHADOW_FLAGS: u32 = symbol_flags::INTERFACE
+    | symbol_flags::CLASS
+    | symbol_flags::FUNCTION
+    | symbol_flags::TYPE_ALIAS
+    | symbol_flags::ENUM
+    | symbol_flags::MODULE
+    | symbol_flags::BLOCK_SCOPED_VARIABLE;
+
+/// Bound on the parent walk in [`node_is_within`]; deep enough for any real
+/// nesting depth, and it stops a malformed chain from spinning.
+const MAX_PARENT_WALK: usize = 512;
+
+impl BinderState {
+    /// Allocate a body-local symbol instead of merging into an exported member
+    /// contributed by another body of the same namespace, returning the new
+    /// `SymbolId` when the split applies.
+    ///
+    /// Returns `None` when the declaration should merge as before.
+    pub(crate) fn try_declare_namespace_body_local(
+        &mut self,
+        arena: &NodeArena,
+        name: &str,
+        flags: u32,
+        declaration: NodeIndex,
+        is_exported: bool,
+        existing_id: SymbolId,
+        name_atom_key: Option<(usize, AstAtom)>,
+    ) -> Option<SymbolId> {
+        let scope = self.current_persistent_scope()?;
+        if scope.kind != ContainerKind::Module {
+            return None;
+        }
+        let container_node = scope.container_node;
+        if !self.symbols.get(existing_id).is_some_and(|s| s.is_exported) || is_exported {
+            return None;
+        }
+
+        // The `var` rule predates this module and applies within a single body too.
+        let is_variable = (flags & symbol_flags::FUNCTION_SCOPED_VARIABLE) != 0;
+        if !is_variable
+            && !self.declaration_shadows_other_body_export(
+                arena,
+                declaration,
+                flags,
+                container_node,
+                existing_id,
+            )
+        {
+            return None;
+        }
+
+        let owned_name = name.to_string();
+        let sym_id = self.symbols.alloc(flags, owned_name.clone());
+        let container_sym = self.current_container_symbol();
+        if let Some(sym) = self.symbols.get_mut(sym_id) {
+            let span = Self::declaration_span(arena, declaration);
+            sym.add_declaration(declaration, span);
+            if (flags & symbol_flags::VALUE) != 0 {
+                sym.set_value_declaration(declaration, span);
+            }
+            sym.is_exported = false;
+            if let Some(parent_id) = container_sym {
+                sym.parent = parent_id;
+            }
+        }
+        Arc::make_mut(&mut self.node_symbols).insert(declaration.0, sym_id);
+        self.declare_in_persistent_scope_with_atom(owned_name, name_atom_key, sym_id);
+        Some(sym_id)
+    }
+
+    /// The cross-body test for every declaration kind other than `var`.
+    fn declaration_shadows_other_body_export(
+        &self,
+        arena: &NodeArena,
+        declaration: NodeIndex,
+        flags: u32,
+        container_node: NodeIndex,
+        existing_id: SymbolId,
+    ) -> bool {
+        (flags & NAMESPACE_BODY_LOCAL_SHADOW_FLAGS) != 0
+            && !declaration_is_exported_in_module_body(arena, declaration)
+            && !self.module_body_is_export_context(arena, container_node)
+            && self.existing_declarations_are_in_another_module_body(
+                arena,
+                existing_id,
+                container_node,
+            )
+    }
+
+    /// True when every declaration already recorded on `existing_id` sits outside
+    /// the namespace body currently being bound.
+    ///
+    /// Declarations from another file (cross-file namespace merging) walk to the
+    /// root of their own arena without meeting this body's container node, which
+    /// is the answer we want: they are another body's contribution just as much as
+    /// a second `namespace A { ... }` in the same file is.
+    fn existing_declarations_are_in_another_module_body(
+        &self,
+        arena: &NodeArena,
+        existing_id: SymbolId,
+        container_node: NodeIndex,
+    ) -> bool {
+        if container_node.is_none() {
+            return false;
+        }
+        let Some(existing) = self.symbols.get(existing_id) else {
+            return false;
+        };
+        if existing.declarations.is_empty() {
+            return false;
+        }
+        !existing
+            .declarations
+            .iter()
+            .any(|&declaration| node_is_within(arena, declaration, container_node))
+    }
+
+    /// Whether the namespace body being bound is an *export context*, in which
+    /// unmarked declarations are implicitly exported and so must still merge.
+    ///
+    /// `tsc`'s `setExportContextFlag` marks an ambient container as an export
+    /// context, which is why `declare namespace JSX { interface IntrinsicElements
+    /// {} }` in one file merges with the same shape inside `declare global` in
+    /// another even though neither interface says `export`.
+    fn module_body_is_export_context(&self, arena: &NodeArena, container_node: NodeIndex) -> bool {
+        if self.in_global_augmentation {
+            return true;
+        }
+        let mut current = container_node;
+        for _ in 0..MAX_PARENT_WALK {
+            if current.is_none() {
+                return false;
+            }
+            if let Some(node) = arena.get(current) {
+                if node.kind == syntax_kind_ext::SOURCE_FILE {
+                    return false;
+                }
+                if node.kind == syntax_kind_ext::MODULE_DECLARATION
+                    && arena.get_module(node).is_some_and(|module| {
+                        Self::has_declare_modifier(arena, module.modifiers.as_ref())
+                    })
+                {
+                    return true;
+                }
+            }
+            let Some(extended) = arena.get_extended(current) else {
+                return false;
+            };
+            if extended.parent == current {
+                return false;
+            }
+            current = extended.parent;
+        }
+        false
+    }
+}
+
+/// Whether `declaration` carries `export` where it sits in a namespace body.
+///
+/// Inside a module block, `export interface I {}` parses as an export declaration
+/// *wrapping* the inner declaration, and the inner node's own modifier list stays
+/// empty — so the `is_exported` flag threaded into `declare_symbol` reads `false`
+/// for exactly the declarations that *are* exported. `populate_module_exports` and
+/// the checker's `is_declaration_exported` both consult the wrapper; this does the
+/// same, so the binder agrees with them.
+fn declaration_is_exported_in_module_body(arena: &NodeArena, declaration: NodeIndex) -> bool {
+    arena
+        .get_extended(declaration)
+        .and_then(|ext| arena.get(ext.parent))
+        .is_some_and(|parent| parent.kind == syntax_kind_ext::EXPORT_DECLARATION)
+}
+
+/// Walk `node`'s parent chain looking for `ancestor`.
+fn node_is_within(arena: &NodeArena, node: NodeIndex, ancestor: NodeIndex) -> bool {
+    let mut current = node;
+    for _ in 0..MAX_PARENT_WALK {
+        if current.is_none() {
+            return false;
+        }
+        if current == ancestor {
+            return true;
+        }
+        let Some(extended) = arena.get_extended(current) else {
+            return false;
+        };
+        if extended.parent == current {
+            return false;
+        }
+        current = extended.parent;
+    }
+    false
+}

--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2591,3 +2591,6 @@ path = "tests/conditional_extends_redundant_intersection_identity_tests.rs"
 [[test]]
 name = "issue_16018_nested_position_evidence_tests"
 path = "tests/issue_16018_nested_position_evidence_tests.rs"
+[[test]]
+name = "namespace_body_local_declaration_merge_tests"
+path = "tests/namespace_body_local_declaration_merge_tests.rs"

--- a/crates/tsz-checker/tests/namespace_body_local_declaration_merge_tests.rs
+++ b/crates/tsz-checker/tests/namespace_body_local_declaration_merge_tests.rs
@@ -1,0 +1,371 @@
+//! Regression tests for declaration merging across the bodies of a merged
+//! namespace.
+//!
+//! `tsc` gives every namespace body its own `locals` table while the merged
+//! namespace symbol owns a single shared `exports` table. A declaration written
+//! without `export` therefore becomes a local of the body that wrote it and never
+//! joins an exported declaration of the same name contributed by a *different*
+//! body — `A.Point` sees only what was exported.
+//!
+//! tsz applied that rule to `var` only, so an interface / class / function /
+//! enum / namespace / `let` / `const` written without `export` in a second body
+//! merged into the first body's exported member and widened the namespace's
+//! public type. The witness is
+//! `conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedAndNonExportedInterfacesOfTheSameName.ts`,
+//! where the merge added `fromCarth` to `A.Point` and produced a spurious TS2403.
+//!
+//! Within a *single* body the two declarations do land on one symbol — that is
+//! what `tsc` reports TS2395 against — so the split stays scoped to the
+//! cross-body case and those tests pin that it still does.
+//!
+//! Every expectation here was taken from `tsc` 7.0.2 run over the same source
+//! with `--strict false --target es2015`.
+
+use tsz_checker::test_utils::check_source_codes;
+
+/// `var x: <expected>; var x: <actual>;` reads an inferred type back out as a
+/// diagnostic: TS2403 fires exactly when the two are not identical. No TS2403
+/// means the namespace member has the type the first declaration spells.
+fn codes(source: &str) -> Vec<u32> {
+    check_source_codes(source)
+}
+
+#[test]
+fn non_exported_interface_does_not_join_another_bodys_exported_interface() {
+    let source = r"
+namespace A {
+    export interface Point {
+        x: number;
+        y: number;
+        toCarth(): Point;
+    }
+}
+
+namespace A {
+    interface Point {
+        fromCarth(): Point;
+    }
+}
+
+var p: { x: number; y: number; toCarth(): A.Point; };
+var p: A.Point;
+";
+    assert!(
+        codes(source).is_empty(),
+        "A.Point must stay the exported declaration only: {:?}",
+        codes(source)
+    );
+}
+
+/// Same rule, different binder names, to prove nothing keys on the identifiers
+/// used by the conformance fixture.
+#[test]
+fn non_exported_interface_split_is_not_keyed_on_declaration_names() {
+    let source = r"
+namespace Widgets {
+    export interface Descriptor { width: number; }
+}
+
+namespace Widgets {
+    interface Descriptor { height: number; }
+}
+
+var d: { width: number };
+var d: Widgets.Descriptor;
+";
+    assert!(
+        codes(source).is_empty(),
+        "renamed binders must behave identically: {:?}",
+        codes(source)
+    );
+}
+
+#[test]
+fn exported_interfaces_in_separate_bodies_still_merge() {
+    let source = r"
+namespace A {
+    export interface Shape { a: number; }
+}
+
+namespace A {
+    export interface Shape { b: number; }
+}
+
+var c: { a: number; b: number };
+var c: A.Shape;
+";
+    assert!(
+        codes(source).is_empty(),
+        "two exported declarations must still merge into one interface: {:?}",
+        codes(source)
+    );
+}
+
+#[test]
+fn non_exported_declaration_first_then_exported_stays_separate() {
+    let source = r"
+namespace A {
+    interface Shape { b: number; }
+}
+
+namespace A {
+    export interface Shape { a: number; }
+}
+
+var c: { a: number };
+var c: A.Shape;
+";
+    assert!(
+        codes(source).is_empty(),
+        "the exported declaration must not absorb an earlier body's local: {:?}",
+        codes(source)
+    );
+}
+
+#[test]
+fn same_body_export_mismatch_still_merges_and_reports_ts2395() {
+    let source = r"
+namespace A {
+    export interface Shape { a: number; }
+    interface Shape { b: number; }
+}
+";
+    let codes = codes(source);
+    assert_eq!(
+        codes,
+        vec![2395, 2395],
+        "within one body the declarations share a symbol, which is what TS2395 reports"
+    );
+}
+
+#[test]
+fn non_exported_nested_namespace_does_not_join_another_bodys_export() {
+    let source = r"
+namespace Outer {
+    export namespace Inner { export interface Q { a: number; } }
+}
+
+namespace Outer {
+    namespace Inner { export interface Q { b: number; } }
+}
+
+var q: { a: number };
+var q: Outer.Inner.Q;
+";
+    assert!(
+        codes(source).is_empty(),
+        "a non-exported nested namespace is a local of its own body: {:?}",
+        codes(source)
+    );
+}
+
+#[test]
+fn non_exported_function_does_not_join_another_bodys_exported_function() {
+    let source = r"
+namespace A {
+    export function f(a: number) { return a; }
+}
+
+namespace A {
+    function f(b: string) { return b; }
+}
+
+var g: (a: number) => number;
+var g: typeof A.f;
+";
+    assert!(
+        codes(source).is_empty(),
+        "the two functions are separate symbols, so no duplicate-implementation error: {:?}",
+        codes(source)
+    );
+}
+
+#[test]
+fn non_exported_class_does_not_join_another_bodys_exported_class() {
+    let source = r"
+namespace A {
+    export class K { m(): number { return 1; } }
+}
+
+namespace A {
+    class K { n(): string { return 'x'; } }
+}
+
+var k: { m(): number };
+var k: A.K;
+";
+    assert!(
+        codes(source).is_empty(),
+        "A.K must stay the exported class: {:?}",
+        codes(source)
+    );
+}
+
+/// Enum object types are never identical to an object literal type, so the
+/// `var x; var x` witness does not apply here (`tsc` reports TS2403 for it too).
+/// Member access reads the split out directly instead: the second body's member
+/// must not become visible on the exported enum.
+#[test]
+fn non_exported_enum_does_not_join_another_bodys_exported_enum() {
+    let source = r"
+namespace A {
+    export enum E { First }
+}
+
+namespace A {
+    enum E { Second }
+}
+
+var ok = A.E.First;
+var bad = A.E.Second;
+";
+    assert_eq!(
+        codes(source),
+        vec![2339],
+        "only the local body's member is missing from the exported enum"
+    );
+}
+
+#[test]
+fn non_exported_const_does_not_join_another_bodys_exported_const() {
+    let source = r"
+namespace A {
+    export const v: number = 1;
+}
+
+namespace A {
+    const v: string = 'x';
+}
+
+var w: number;
+var w: typeof A.v;
+";
+    assert!(
+        codes(source).is_empty(),
+        "A.v must keep the exported const's type: {:?}",
+        codes(source)
+    );
+}
+
+/// The local declaration is what the *writing* body sees. Inside the second body
+/// `Shape` is its own local interface, so `local` is typed by it, not by the
+/// namespace's exported member.
+#[test]
+fn the_local_declaration_shadows_the_export_inside_its_own_body() {
+    let source = r"
+namespace A {
+    export interface Shape { a: number; }
+}
+
+namespace A {
+    interface Shape { b: number; }
+    export var local: Shape;
+}
+
+var c: { b: number };
+var c: typeof A.local;
+";
+    assert!(
+        codes(source).is_empty(),
+        "references inside the declaring body resolve to that body's local: {:?}",
+        codes(source)
+    );
+}
+
+/// The dotted / nested spelling of the same fixture shape, which reaches the
+/// rule through a differently built namespace chain.
+#[test]
+fn dotted_namespace_bodies_split_a_non_exported_member_the_same_way() {
+    let source = r"
+namespace X.Y.Z {
+    export interface Line { start: number; }
+}
+
+namespace X {
+    export namespace Y.Z {
+        interface Line { end: number; }
+    }
+}
+
+var l: { start: number };
+var l: X.Y.Z.Line;
+";
+    assert!(
+        codes(source).is_empty(),
+        "dotted namespace bodies follow the same locals/exports split: {:?}",
+        codes(source)
+    );
+}
+
+/// Negative control for the shadow itself: a non-exported declaration must not
+/// start shadowing when there is no exported member of that name to shadow. The
+/// two locals here belong to different bodies and are simply unrelated.
+#[test]
+fn two_non_exported_declarations_in_separate_bodies_do_not_merge() {
+    let source = r"
+namespace A {
+    interface Shape { a: number; }
+    export var first: Shape;
+}
+
+namespace A {
+    interface Shape { b: number; }
+    export var second: Shape;
+}
+
+var one: { a: number };
+var one: typeof A.first;
+var two: { b: number };
+var two: typeof A.second;
+";
+    assert!(
+        codes(source).is_empty(),
+        "each body's local interface is its own type: {:?}",
+        codes(source)
+    );
+}
+
+/// An **ambient** namespace body is an export context: `tsc`'s
+/// `setExportContextFlag` marks it so, and every declaration inside is implicitly
+/// exported even without the keyword. The split must not fire there, or
+/// `declare namespace JSX { interface IntrinsicElements {} }` stops merging with
+/// the same shape declared in another ambient body — which is how JSX intrinsic
+/// tags are contributed.
+#[test]
+fn ambient_namespace_bodies_are_export_contexts_and_still_merge() {
+    let source = r"
+declare namespace Amb {
+    interface Registry { a: number; }
+}
+
+declare namespace Amb {
+    interface Registry { b: number; }
+}
+
+var r: { a: number; b: number };
+var r: Amb.Registry;
+";
+    assert!(
+        codes(source).is_empty(),
+        "unmarked declarations in an ambient body are implicitly exported: {:?}",
+        codes(source)
+    );
+}
+
+/// Same-body merging of a namespace onto an exported function is a legitimate
+/// merge that this change must leave alone: both declarations are written in the
+/// body that owns the symbol.
+#[test]
+fn same_body_namespace_still_merges_onto_an_exported_function() {
+    let source = r"
+namespace A {
+    export function f() { }
+    namespace f { export var tag: number; }
+}
+";
+    assert!(
+        !codes(source).contains(&2403),
+        "same-body function/namespace merging must be untouched: {:?}",
+        codes(source)
+    );
+}


### PR DESCRIPTION
**Structural rule.** When a namespace body declares a member **without** `export` and an exported member of the same name was contributed by a **different body** of the same namespace, `tsc` keeps them separate — every namespace body owns its own `locals` table while the merged namespace symbol owns one shared `exports` table, so the non-exported declaration is a local of the body that wrote it and `A.Point` sees only what was exported. tsz now does the same through the **binder** (`try_declare_namespace_body_local`, new `crates/tsz-binder/src/nodes/namespace_body_merge.rs`, reached from `declare_symbol`).

**What was wrong.** The rule was already implemented — for `FUNCTION_SCOPED_VARIABLE` and nothing else. Interfaces, classes, functions, enums, namespaces and `let`/`const` all fell through and merged into the symbol seeded from the prior body's exports, widening the namespace's public type. This is the third [sibling-arm gap](https://github.com/tsz-org/tsz/issues/15994#issuecomment-5154137150) found this way in two days: the arm existed, the flag mask was one flag wide.

Witness — `conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedAndNonExportedInterfacesOfTheSameName.ts`, the fixture whose entire point is that these do *not* merge. `A.Point` gained the second body's `fromCarth`, so `var p: { x: number; y: number; toCarth(): A.Point }; var p: A.Point;` reported a spurious TS2403. Row expects zero diagnostics; it was one of the three extra-only TS2403 rows [Syenite split into three unrelated causes](https://github.com/tsz-org/tsz/issues/15994#issuecomment-5154092428) (cause **b**, left unclaimed).

**A trap worth naming, because the obvious patch is wrong.** Inside a module block, `export interface I {}` parses as an `EXPORT_DECLARATION` **wrapping** the inner declaration, and the inner node's own `modifiers` list is `None`. So `has_export_modifier` returns `false` for an exported interface and the `is_exported` flag threaded into `declare_symbol` reads `false` for exactly the declarations that *are* exported — the symbol only gets `is_exported = true` later, when `populate_module_exports` walks the statement list at body exit. A first patch that keyed on `!is_exported` regressed the both-exported case (two `export interface S` in separate bodies stopped merging) while the target case looked fixed. The landed version consults the wrapper the same way `populate_module_exports` and the checker's `is_declaration_exported` already do, so the binder now agrees with them.

**A second guard, added after the checker suite caught it.** An *ambient* namespace body is an **export context** — `tsc`'s `setExportContextFlag` marks an ambient container so, and every declaration inside is implicitly exported without the keyword. The first version of this patch split those too, which broke `jsx_intrinsic_elements_merges_global_augmentation_with_existing_namespace`: `declare namespace JSX { interface IntrinsicElements {} }` stopped merging with the same shape inside `declare global`, so custom intrinsic tags went missing. The split now skips ambient bodies, with a test pinning it. This is exactly the failure mode the standing "targeted verification is not sufficient" gotcha describes — the targeted matrix was green and the regression was one suite over.

Scope is otherwise deliberately the **cross-body**, non-ambient case only, gated on the existing symbol's declarations all sitting outside the namespace body being bound. Within a single body the declarations genuinely do share a symbol — that is what `tsc` reports TS2395 against, and TS2395 is decided per-symbol off a symbol carrying mixed-exportedness declarations. Same-body merging is untouched, with tests pinning that.

**Adjacent-case matrix** — 15 tests in `crates/tsz-checker/tests/namespace_body_local_declaration_merge_tests.rs`, every expectation taken from a real `tsc` 7.0.2 run over the same source (`--strict false --target es2015`):

| case | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| cross-body exported + non-exported interface (fixture shape) | clean | TS2403 | clean |
| same shape, renamed binders | clean | TS2403 | clean |
| cross-body **both exported** (must still merge) | clean | clean | clean |
| reverse order: non-exported body first, then exported | clean | clean | clean |
| **same-body** export mismatch | TS2395 x2 | TS2395 x2 | TS2395 x2 |
| cross-body non-exported nested namespace | clean | TS2403 | clean |
| cross-body non-exported function | clean | TS2393 x2 | clean |
| cross-body non-exported class | clean | clean | clean |
| cross-body non-exported enum (member access witness) | TS2339 | TS2339 | TS2339 |
| cross-body non-exported `const` | clean | — | clean |
| local shadows the export **inside its own body** | clean | TS2403 | clean |
| dotted `namespace X.Y.Z` spelling of the fixture | clean | TS2403 | clean |
| two non-exported declarations in separate bodies | clean | — | clean |
| same-body namespace merging onto an exported function (must stay merged) | clean | clean | clean |
| **ambient** bodies (`declare namespace` x2, no `export` keyword) — export context, must still merge | clean | clean | clean |

The renamed-binder row and the two "must still merge" rows are the anti-hardcoding controls: nothing keys on an identifier, a file name, or rendered type text — the discriminator is the declaration's position relative to the namespace body being bound.

Two of my own first expectations were wrong, not the compiler, and were corrected against the oracle rather than worked around: enum object types are never identical to an object literal type (so `var x; var x` is TS2403 under `tsc` too — the test now uses member access), and the class case's `[TS2564, TS2564]` was the no-lib unit harness's strict property initialization, not a merge.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test namespace_body_local_declaration_merge_tests` — **15 / 15 pass**; the ones asserting the new behaviour all fail on parent.
- `cargo test -p tsz-binder` (owner layer, full crate) — **559 / 559 pass**, zero delta vs parent (425 + 7 + 40 + 15 + 20 + 52). Re-run after the module extraction below: still 559 / 559.
- `cargo test -p tsz-checker --lib` — full suite (8828 tests) run against this exact diff: **8818 reported at time of writing, 1 failure — `ts2303_tests::recursive_export_assignment_self_import_reports_ts2303`, which is line 127 of `scripts/ci/known-failures.txt`, pre-existing and unrelated. Zero delta vs parent.** The first version of the patch additionally failed `jsx_intrinsic_elements_merges_global_augmentation_with_existing_namespace`; that is the regression the ambient export-context guard fixes, and it passes now (re-run individually, green). The last 10 rows are long-running tests still finishing on this 4-core seat and were at the identical point on the pre-fix run.
- Oracle-pinned differential on the conformance row itself: reconstructed `TwoInternalModulesThatMergeEachWithExportedAndNonExportedInterfacesOfTheSameName.ts` from `raw.githubusercontent.com` and ran it through both compilers. `tsc` 7.0.2 exit 0 / no diagnostics; tsz **before**: 2 x TS2403 (lines 19 and 38 — both the interface half and the dotted `X.Y.Z` half); tsz **after**: clean, matching `tsc` exactly. The matrix above was pinned the same way.
- `cargo fmt` + the repo `pre-commit` hook (workspace clippy, warnings denied, plus arch-size) — **clippy passed, architecture guard passed, local verification passed.**
- **arch-size handled by splitting, not by raising a ceiling.** The first commit attempt failed the `nodes/binding.rs` size ratchet (1693 vs limit 1587). Rather than bump the number in `scripts/arch/arch_guard_shared.py`, the whole arm moved into the new `namespace_body_merge.rs`, taking the pre-existing `var` branch with it. `binding.rs` ends at **1567 lines — 20 under the ratchet**, so this ratchets the boundary *down* rather than consuming headroom.
- **Not run on this seat, stated explicitly per the standing gotcha:** `compare-to-parent.sh` (two `dist-fast` builds plus two full corpus snapshots; this is a cold 4-core seat with no mold and a `dist-fast` incremental measured at 6.5 min elsewhere) and the emit/fourslash suites. This change is binder-only and cannot reach emit output, but the two-sided corpus diff is the gate that sees rows my matrix cannot, so **a warm seat should run it before this merges.** Expected signature is 1 newly-passing row (the fixture) and 0 newly-failing; note that several recent fixes in this family moved the corpus by exactly 0, so 0-newly-passing would not by itself indicate the fix is inert.

**Known residual, deliberately out of scope.** The same-body shape `namespace A { export interface S { a } interface S { b } }` still reports a spurious TS2403 next to its two correct TS2395s: `tsc` gives the exported declaration both a shell in the body's `locals` and the real symbol in `exports`, so `A.S` is `{a}` while TS2395 still fires off the merged local. tsz has one symbol, so it gets TS2395 right and the exported type wrong. Splitting it here would drop TS2395; fixing it properly needs the two-symbol local/export shell, which is a larger change. Recorded on the coordination board.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Gneiss

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBodvRgzJCGwA3Qyn2KUEY)_