### PR TITLE
fix(checker): report TS18050 for nullish keyword operands without strictNullChecks

### DIFF
--- a/crates/tsz-checker/src/error_reporter/operator_errors.rs
+++ b/crates/tsz-checker/src/error_reporter/operator_errors.rs
@@ -338,8 +338,8 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    /// Under `strictNullChecks`, emit the "possibly null/undefined" operand
-    /// diagnostic when the operand of a unary `+`/`-`/`~` is nullable.
+    /// Emit the "possibly null/undefined" operand diagnostic when the operand of
+    /// a unary `+`/`-`/`~` is nullable.
     ///
     /// tsc's `checkPrefixUnaryExpression` runs `checkNonNullType(operandType, operand)`
     /// **unconditionally** for `+`/`-`/`~` — there is no arithmetic-operand check for
@@ -349,17 +349,24 @@ impl<'a> CheckerState<'a> {
     /// alone, `string | undefined`, `object | null`, `symbol | null` (alongside the
     /// separate TS2469), and type parameters whose constraint is nullable all report.
     ///
+    /// `checkNonNullType` is not gated on `strictNullChecks` either: the strictness
+    /// policy lives in tsc's `reportObjectPossiblyNullOrUndefinedError`, which reports
+    /// the literal `null`/`undefined` KEYWORD as TS18050 under both settings and the
+    /// type-driven family only under `strictNullChecks`. `emit_nullish_operand_error`
+    /// already implements that routing, so only the keyword needs to reach it without
+    /// `strictNullChecks`.
+    ///
     /// `void` is not in tsc's `Nullable` flag set, so a `void` operand never triggers
     /// this (it is handled by the operator-specific paths instead).
     pub(crate) fn check_nullish_unary_operand(&mut self, operand: NodeIndex, operand_type: TypeId) {
-        if !self.ctx.strict_null_checks() {
-            return;
-        }
         if operand_type == TypeId::VOID {
             return;
         }
         let (_non_nullish, nullish_cause) = self.split_nullish_type(operand_type);
         let Some(cause) = nullish_cause else { return };
+        if !self.ctx.strict_null_checks() && !self.is_literal_null_or_undefined_node(operand) {
+            return;
+        }
         self.emit_nullish_operand_error(operand, cause);
     }
 

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1755,6 +1755,9 @@ mod ts18010_jsdoc_tag_anchor_tests;
 #[path = "../tests/ts18048_unary_arithmetic_nullish_tests.rs"]
 mod ts18048_unary_arithmetic_nullish_tests;
 #[cfg(test)]
+#[path = "tests/ts18050_nullish_keyword_without_strict_null_checks_tests.rs"]
+mod ts18050_nullish_keyword_without_strict_null_checks_tests;
+#[cfg(test)]
 #[path = "tests/ts2322_private_field_narrowing_write_tests.rs"]
 mod ts2322_private_field_narrowing_write_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/ts18050_nullish_keyword_without_strict_null_checks_tests.rs
+++ b/crates/tsz-checker/src/tests/ts18050_nullish_keyword_without_strict_null_checks_tests.rs
@@ -1,0 +1,317 @@
+//! A literal `null`/`undefined` KEYWORD used where a non-nullable value is
+//! required is reported as TS18050 "The value '<x>' cannot be used here." under
+//! **both** `strictNullChecks` settings.
+//!
+//! Structural rule: when such an operand's type carries a nullish part, tsc runs
+//! `checkNonNullType` regardless of `strictNullChecks`; the strictness policy
+//! lives one level down, in `reportObjectPossiblyNullOrUndefinedError`, which
+//! reports the syntactic keyword as TS18050 in both modes and the type-driven
+//! TS18047/18048/2531 family only under `strictNullChecks`. tsz gated the whole
+//! `checkNonNullType` mirror on `strictNullChecks`, so the strict arm was correct
+//! and the non-strict arm reported nothing at all.
+//!
+//! Two sibling call sites had the same over-wide gate:
+//! - `types/computation/binary_support.rs` `check_in_operand_non_null` — both
+//!   `in` operands.
+//! - `error_reporter/operator_errors.rs` `check_nullish_unary_operand` — the
+//!   unary `+`/`-`/`~` operand. Unary `+`/`-` masked the gate with their own
+//!   keyword pre-check, so only `~` was observably wrong.
+//!
+//! The gate is the keyword, not a nullable type: a *named* operand of type `null`
+//! keeps the type-driven routing (TS18047 under strict, nothing without it), and a
+//! parenthesized `(null)` is an unnamed expression, so it reports TS2531 under
+//! strict and, like every other type-driven case, nothing without it. Pinned both
+//! ways below so a future widening of this path cannot silently turn either into
+//! TS18050.
+
+use crate::test_utils::{check_source_non_strict_codes as non_strict, check_source_strict_codes};
+
+const TS18050: u32 = 18050; // The value '<x>' cannot be used here.
+const TS18047: u32 = 18047; // '<x>' is possibly 'null'.
+const TS2531: u32 = 2531; // Object is possibly 'null'.
+const TS2358: u32 = 2358; // The left-hand side of an 'instanceof' expression must be …
+
+fn count(codes: &[u32], code: u32) -> usize {
+    codes.iter().filter(|&&c| c == code).count()
+}
+
+// -------------------------------------------------------------------------
+// The keyword operand: TS18050 in both modes, both positions, both spellings.
+// -------------------------------------------------------------------------
+
+#[test]
+fn null_keyword_as_in_lhs_is_ts18050_without_strict_null_checks() {
+    let codes = non_strict("null in {};");
+    assert_eq!(
+        count(&codes, TS18050),
+        1,
+        "expected one TS18050 for a `null` keyword LHS, got: {codes:?}"
+    );
+}
+
+#[test]
+fn null_keyword_as_in_rhs_is_ts18050_without_strict_null_checks() {
+    let codes = non_strict("\"\" in null;");
+    assert_eq!(
+        count(&codes, TS18050),
+        1,
+        "expected one TS18050 for a `null` keyword RHS, got: {codes:?}"
+    );
+}
+
+#[test]
+fn undefined_keyword_as_in_lhs_is_ts18050_without_strict_null_checks() {
+    let codes = non_strict("undefined in {};");
+    assert_eq!(
+        count(&codes, TS18050),
+        1,
+        "expected one TS18050 for an `undefined` LHS, got: {codes:?}"
+    );
+}
+
+#[test]
+fn undefined_keyword_as_in_rhs_is_ts18050_without_strict_null_checks() {
+    let codes = non_strict("\"\" in undefined;");
+    assert_eq!(
+        count(&codes, TS18050),
+        1,
+        "expected one TS18050 for an `undefined` RHS, got: {codes:?}"
+    );
+}
+
+#[test]
+fn keyword_in_operands_stay_ts18050_under_strict_null_checks() {
+    for source in [
+        "null in {};",
+        "\"\" in null;",
+        "undefined in {};",
+        "\"\" in undefined;",
+    ] {
+        let codes = check_source_strict_codes(source);
+        assert_eq!(
+            count(&codes, TS18050),
+            1,
+            "strict mode regressed for {source:?}, got: {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn a_wholly_nullish_keyword_operand_reports_only_ts18050() {
+    // tsc's `checkNonNullType` returns the error type for a wholly nullish
+    // operand, so the structural key/object check does not also fire. Both
+    // positions report exactly one diagnostic.
+    for source in ["null in {};", "\"\" in null;"] {
+        let codes = non_strict(source);
+        assert_eq!(
+            codes,
+            vec![TS18050],
+            "expected TS18050 alone for {source:?}, got: {codes:?}"
+        );
+    }
+}
+
+// -------------------------------------------------------------------------
+// Controls: a nullish TYPE is not a nullish keyword.
+// -------------------------------------------------------------------------
+
+#[test]
+fn named_null_typed_operand_is_never_ts18050() {
+    // Renamed binders: the routing is keyed on the node kind, not on any
+    // particular identifier text.
+    for binder in ["probe", "nullish", "value"] {
+        let source = format!("declare const {binder}: null;\n\"\" in {binder};");
+
+        let lax = non_strict(&source);
+        assert_eq!(
+            count(&lax, TS18050),
+            0,
+            "a named `null`-typed operand must not become TS18050 (binder {binder}), got: {lax:?}"
+        );
+
+        let strict = check_source_strict_codes(&source);
+        assert_eq!(
+            count(&strict, TS18050),
+            0,
+            "a named `null`-typed operand must not become TS18050 under strict (binder {binder}), got: {strict:?}"
+        );
+        assert_eq!(
+            count(&strict, TS18047),
+            1,
+            "a named `null`-typed operand keeps TS18047 under strict (binder {binder}), got: {strict:?}"
+        );
+    }
+}
+
+#[test]
+fn parenthesized_null_operand_is_not_ts18050() {
+    // `(null)` is a parenthesized expression, not a `NullKeyword` node: tsc
+    // reports it through the unnamed-expression arm (TS2531), never TS18050.
+    for source in ["(null) in {};", "\"\" in (null);"] {
+        let lax = non_strict(source);
+        assert_eq!(
+            count(&lax, TS18050),
+            0,
+            "parenthesized null must not become TS18050 for {source:?}, got: {lax:?}"
+        );
+
+        let strict = check_source_strict_codes(source);
+        assert_eq!(
+            count(&strict, TS18050),
+            0,
+            "parenthesized null must not become TS18050 under strict for {source:?}, got: {strict:?}"
+        );
+        assert_eq!(
+            count(&strict, TS2531),
+            1,
+            "parenthesized null keeps TS2531 under strict for {source:?}, got: {strict:?}"
+        );
+    }
+}
+
+#[test]
+fn instanceof_lhs_keeps_ts2358_and_never_becomes_ts18050() {
+    // The `instanceof` LHS goes through its own rule; widening the `in`
+    // non-null check must not reach it.
+    let source = "null instanceof (() => { });";
+
+    let lax = non_strict(source);
+    assert_eq!(
+        count(&lax, TS2358),
+        1,
+        "expected TS2358 for an `instanceof` null LHS, got: {lax:?}"
+    );
+    assert_eq!(
+        count(&lax, TS18050),
+        0,
+        "an `instanceof` null LHS must not become TS18050, got: {lax:?}"
+    );
+
+    let strict = check_source_strict_codes(source);
+    assert_eq!(
+        count(&strict, TS2358),
+        1,
+        "expected TS2358 for an `instanceof` null LHS under strict, got: {strict:?}"
+    );
+    assert_eq!(
+        count(&strict, TS18050),
+        0,
+        "an `instanceof` null LHS must not become TS18050 under strict, got: {strict:?}"
+    );
+}
+
+#[test]
+fn non_nullish_in_operands_stay_clean_without_strict_null_checks() {
+    // The fallback direction: widening the non-null check must not start
+    // reporting on operands that carry no nullish part at all.
+    let codes = non_strict("declare const o: { a: number };\n\"a\" in o;");
+    assert!(
+        codes.is_empty(),
+        "a well-formed `in` must stay clean without strictNullChecks, got: {codes:?}"
+    );
+}
+
+// -------------------------------------------------------------------------
+// The unary `+`/`-`/`~` sibling arm.
+// -------------------------------------------------------------------------
+
+#[test]
+fn unary_operators_report_ts18050_on_a_keyword_operand_without_strict_null_checks() {
+    // `+` and `-` already had their own keyword pre-check, so `~` was the only
+    // observably wrong arm; all three are pinned so the three stay in step.
+    for source in [
+        "~null;",
+        "~undefined;",
+        "-null;",
+        "-undefined;",
+        "+null;",
+        "+undefined;",
+    ] {
+        let codes = non_strict(source);
+        assert_eq!(
+            count(&codes, TS18050),
+            1,
+            "expected one TS18050 for {source:?} without strictNullChecks, got: {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn unary_keyword_operands_stay_ts18050_under_strict_null_checks() {
+    for source in [
+        "~null;",
+        "~undefined;",
+        "-null;",
+        "-undefined;",
+        "+null;",
+        "+undefined;",
+    ] {
+        let codes = check_source_strict_codes(source);
+        assert_eq!(
+            count(&codes, TS18050),
+            1,
+            "strict mode regressed for {source:?}, got: {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn unary_named_null_typed_operand_is_never_ts18050() {
+    for binder in ["probe", "nullish", "value"] {
+        let source = format!("declare const {binder}: null;\n~{binder};");
+
+        let lax = non_strict(&source);
+        assert_eq!(
+            count(&lax, TS18050),
+            0,
+            "a named `null`-typed unary operand must not become TS18050 (binder {binder}), got: {lax:?}"
+        );
+
+        let strict = check_source_strict_codes(&source);
+        assert_eq!(
+            count(&strict, TS18050),
+            0,
+            "a named `null`-typed unary operand must not become TS18050 under strict (binder {binder}), got: {strict:?}"
+        );
+        assert_eq!(
+            count(&strict, TS18047),
+            1,
+            "a named `null`-typed unary operand keeps TS18047 under strict (binder {binder}), got: {strict:?}"
+        );
+    }
+}
+
+#[test]
+fn unary_parenthesized_null_operand_is_not_ts18050() {
+    let source = "~(null);";
+
+    let lax = non_strict(source);
+    assert_eq!(
+        count(&lax, TS18050),
+        0,
+        "parenthesized null must not become TS18050 for a unary operand, got: {lax:?}"
+    );
+
+    let strict = check_source_strict_codes(source);
+    assert_eq!(
+        count(&strict, TS18050),
+        0,
+        "parenthesized null must not become TS18050 under strict, got: {strict:?}"
+    );
+    assert_eq!(
+        count(&strict, TS2531),
+        1,
+        "parenthesized null keeps TS2531 under strict, got: {strict:?}"
+    );
+}
+
+#[test]
+fn unary_void_and_non_nullish_operands_stay_clean_without_strict_null_checks() {
+    // `void` is not in tsc's `Nullable` flag set, and a non-nullish operand has
+    // nothing to report — neither may be pulled in by the widened gate.
+    let codes = non_strict("declare const v: void;\ndeclare const n: number;\n~v;\n~n;");
+    assert!(
+        codes.is_empty(),
+        "void/number unary operands must stay clean without strictNullChecks, got: {codes:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/computation/binary_support.rs
+++ b/crates/tsz-checker/src/types/computation/binary_support.rs
@@ -1083,26 +1083,36 @@ impl CheckerState<'_> {
 
     /// Mirror tsc's `checkNonNullType` for an `in`-operator operand.
     ///
-    /// Under `strictNullChecks`, a nullable operand is reported as
-    /// TS18047/18048/18049 for a named entity (identifier, property access,
-    /// `this`), TS2531/2532/2533 for an unnamed expression (call result,
-    /// parenthesized expression, …), or TS18050 for the literal
-    /// `null`/`undefined` keyword — exactly the routing `report_nullish_object`
-    /// already implements. The non-nullish remainder is returned so the caller's
-    /// structural check (key type for the LHS, object shape for the RHS) runs on
-    /// the stripped type; `None` means the operand was purely nullish, so no
-    /// structural check applies. `any`/`error`/`unknown` carry no nullish part
-    /// and pass through unchanged.
+    /// A nullable operand is reported as TS18047/18048/18049 for a named entity
+    /// (identifier, property access, `this`), TS2531/2532/2533 for an unnamed
+    /// expression (call result, parenthesized expression, …), or TS18050 for the
+    /// literal `null`/`undefined` keyword — exactly the routing
+    /// `report_nullish_object` already implements. The non-nullish remainder is
+    /// returned so the caller's structural check (key type for the LHS, object
+    /// shape for the RHS) runs on the stripped type; `None` means the operand was
+    /// purely nullish, so no structural check applies. `any`/`error`/`unknown`
+    /// carry no nullish part and pass through unchanged.
+    ///
+    /// `checkNonNullType` itself is not gated on `strictNullChecks`: the
+    /// strictness policy lives one level down, in tsc's
+    /// `reportObjectPossiblyNullOrUndefinedError`, which reports the literal
+    /// `null`/`undefined` KEYWORD as TS18050 under both settings and the
+    /// type-driven family only under `strictNullChecks`. Without
+    /// `strictNullChecks` a non-keyword operand therefore keeps its unstripped
+    /// type, so the structural key/object check below is unchanged for it.
     fn check_in_operand_non_null(&mut self, idx: NodeIndex, ty: TypeId) -> Option<TypeId> {
-        if !self.ctx.compiler_options.strict_null_checks
-            || matches!(ty, TypeId::ANY | TypeId::ERROR | TypeId::UNKNOWN)
-        {
+        if matches!(ty, TypeId::ANY | TypeId::ERROR | TypeId::UNKNOWN) {
             return Some(ty);
         }
         let (non_nullish, nullish_cause) = self.split_nullish_type(ty);
         let Some(cause) = nullish_cause else {
             return Some(ty);
         };
+        if !self.ctx.compiler_options.strict_null_checks
+            && !self.is_literal_null_or_undefined_node(idx)
+        {
+            return Some(ty);
+        }
         self.report_nullish_object(idx, cause, non_nullish.is_none());
         non_nullish
     }


### PR DESCRIPTION
Closes #16139.

**Structural rule.** When an expression that requires a non-nullable value has a
nullish operand, `tsc` runs `checkNonNullType` **regardless of
`strictNullChecks`**. The strictness policy lives one level down, in
`reportObjectPossiblyNullOrUndefinedError`, which reports the *syntactic*
`null`/`undefined` KEYWORD as TS18050 under both settings and the type-driven
TS18047/18048/2531 family only under `strictNullChecks`. tsz gated the whole
`checkNonNullType` mirror on `strictNullChecks`, so the strict arm was already
byte-correct and the non-strict arm reported nothing at all.

Stated as the repo's rule form: **when an `in` operand or a unary `+`/`-`/`~`
operand is the literal `null`/`undefined` keyword, `tsc` reports TS18050 whether
or not `strictNullChecks` is set; tsz now does the same through the checker's two
non-null operand gateways**, which delegate the strict-vs-non-strict decision to
the nullish reporter instead of pre-empting it.

**Owner layer:** checker. Two sibling call sites carried the identical over-wide
gate:

| site | shape | before (non-strict) |
| --- | --- | --- |
| `types/computation/binary_support.rs` `check_in_operand_non_null` | both `in` operands | nothing |
| `error_reporter/operator_errors.rs` `check_nullish_unary_operand` | unary `+`/`-`/`~` operand | nothing |

Unary `+`/`-` masked their gate with a dedicated keyword pre-check further up
`get_type_of_prefix_unary_with_request`, so `~` was the only *observably* wrong
unary arm — a sibling-arm defect of exactly the shape Syenite catalogued on the
coordination board. The fix in both places is the same: stop gating
`checkNonNullType` itself, and let the already-correct reporter decide. A
non-keyword operand still short-circuits without `strictNullChecks`, so its type
is left unstripped and every downstream structural check (the `in` key/object
checks, the unary operator checks) is untouched.

The gate is the keyword, not a nullable type — pinned in both directions:

- `declare const x: null; "" in x;` → TS18047 under strict, **not** TS18050, and
  nothing without `strictNullChecks` (unchanged).
- `(null) in {}` → a parenthesized expression is not a `NullKeyword` node, so it
  stays on the unnamed-expression arm (TS2531 under strict), **never** TS18050.
- `null instanceof f` → keeps TS2358; the `instanceof` LHS has its own rule and
  must not be reached.

## Goal
Goal: hold

## Verification

Every number below was measured in this container.

### Conformance rows

`scripts/conformance/conformance-detail.json` (committed, refreshed to main in
#16149) contains exactly **three** rows whose only missing code is `TS18050`,
and **zero** rows carrying an extra `TS18050`:

```
rows with EXTRA TS18050: 0
rows MISSING TS18050:    3
  compiler/widenedTypes.ts
  conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts
  conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithAnyOtherType.ts
```

All three were run through the built `tsz` binary and diffed against the pinned
`tsc` 7.0.2 oracle (`npm i typescript@7.0.2`), at each fixture's own directives:

| row | `e` (tsc) | `a` before | `a` after |
| --- | --- | --- | --- |
| `compiler/widenedTypes.ts` | TS2322 TS2358 TS2695 TS18050 | TS2322 TS2358 TS2695 | **TS2322 TS2358 TS2695 TS18050** |
| `inOperator/inOperatorWithInvalidOperands.ts` | TS2322 TS18050 | TS2322 | **TS2322 TS18050** |
| `bitwiseNotOperator/bitwiseNotOperatorWithAnyOtherType.ts` | TS2365 TS18050 | TS2365 | **TS2365 TS18050** |

Expected corpus movement: **11454 → 11457**, 3 newly passing, 0 newly failing.

`bitwiseNotOperatorWithAnyOtherType.ts` is now **byte-identical** to the oracle
at the fixture's own directives (`--strict false --allowUnreachableCode`). The
other two match on the code set the harness compares, with residual
*per-location* deltas that pre-date this change and are untouched by it —
`widenedTypes.ts` misses TS2322 at 14,1 / 21,1 and has an extra one at 23,37;
`inOperatorWithInvalidOperands.ts` misses TS2322 for a `void` LHS at 18,11 and
omits an elaboration line. Recording them so nobody re-derives them.

### Oracle matrix (tsz vs tsc 7.0.2, both `strictNullChecks` settings)

`null in {}` / `"" in null` / `undefined in {}` / `"" in undefined` / `~null` /
`~undefined` now match `tsc` without `strictNullChecks`; the controls
(`declare const x: null`, `(null)`, `null instanceof f`, `void`, non-nullish)
are unchanged in both directions. **Strict-mode output on the whole matrix is
byte-identical before and after** — the change can only relax the non-strict
path.

### Suites

- New suite `crates/tsz-checker/src/tests/ts18050_nullish_keyword_without_strict_null_checks_tests.rs`
  — **15/15 pass**: both `in` positions, both spellings, both `strictNullChecks`
  settings, the unary `+`/`-`/`~` arm, and the five negative controls above.
  Binder names are varied (`probe` / `nullish` / `value`) on the type-driven
  controls so nothing can be keyed on identifier text.
- Adjacent existing suites at this head: `ts18048_unary_arithmetic_nullish` 18/18,
  `this_prop_nullish_operand_code` 3/3, `in_operator_relation_routing_arch` 7/7,
  `in_narrow*` 27/27, every `nullish*` suite 165/165.
- `cargo fmt --all` clean. `cargo clippy` and the architecture guard ran as the
  `pre-commit` hook gate and both passed.
- Full `cargo test -p tsz-checker --lib` was still running when this PR was
  opened; the count is posted as a follow-up comment.

### Not run in this container — please re-verify from a warm seat

`./scripts/conformance/conformance.sh snapshot` and
`./scripts/conformance/compare-to-parent.sh` need the TypeScript corpus
materialized plus two `dist-fast` builds; this is a cold 4-core cloud seat with
no corpus checkout, so neither would clear inside the session.
`./scripts/emit/run.sh` likewise needs an `npm install` under `scripts/emit/`
that the board records as hanging in cloud containers. The change adds
diagnostics only and touches no emit path, but the emit floor (JS 11562,
DTS 1375) has zero headroom, so a warm-seat sweep before landing is worth the
minute.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Rhyolite

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1ZtAQw6Ts4U9u45W9B4oV)_