### PR TITLE
fix(solver): widen nested array-literal siblings before BCT combines them

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -345,6 +345,9 @@ path = "tests/method_inference_bivariance_tests.rs"
 name = "conditional_branch_array_literal_widening_tests"
 path = "tests/conditional_branch_array_literal_widening_tests.rs"
 [[test]]
+name = "nested_array_literal_any_widening_bct_tie_break_tests"
+path = "tests/nested_array_literal_any_widening_bct_tie_break_tests.rs"
+[[test]]
 name = "extract_alias_distributive_mapped_tests"
 path = "tests/extract_alias_distributive_mapped_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/computation/array_literal.rs
+++ b/crates/tsz-checker/src/types/computation/array_literal.rs
@@ -1416,10 +1416,44 @@ impl<'a> CheckerState<'a> {
         {
             array_surfaces::element_union(self.ctx.types, element_types.clone())
         } else {
+            // A nested array/tuple literal element (e.g. `[[null]]` inside
+            // `[[[null]],[undefined]]`) resolves its own `null`/`undefined`
+            // leaves only at the enclosing `var`/`let` binding's widening seam
+            // (`widen_initializer_type_for_mutable_binding`) — this array's own
+            // BCT still sees the sibling's PRE-widening shape. Two siblings that
+            // widen to structurally different-but-`any`-absorbed-compatible
+            // shapes (`any[][]` and `any[]`) can look pairwise unrelated before
+            // widening (`Array<null-sentinel>` vs `Array<undefined>` isn't a
+            // subtype pair the way the post-widening `any[]`/`any[][]` pair is),
+            // producing a spurious `any[] | any[][]` instead of collapsing like
+            // tsc does. Widen each COMPOUND element eagerly before BCT so
+            // siblings compare in their final (post-widening) shape. A bare
+            // scalar `null`/`undefined` element is left untouched here — it is
+            // never itself `Array`/`Tuple`/fresh-`Object` shaped, so it cannot
+            // exhibit this specific pre-widening pairwise-mismatch, and its own
+            // (pre-existing, separately owned) resolution already happens where
+            // it always has: unaffected by this change either way.
+            let bct_element_types: Vec<TypeId> = if self.ctx.strict_null_checks() {
+                element_types.clone()
+            } else {
+                element_types
+                    .iter()
+                    .map(|&t| {
+                        if t == TypeId::NULL || t == TypeId::UNDEFINED {
+                            t
+                        } else {
+                            crate::query_boundaries::widening::widen_nullish_to_any_deep(
+                                self.ctx.types,
+                                t,
+                            )
+                        }
+                    })
+                    .collect()
+            };
             expr_ops::compute_best_common_type_cached(
                 self.ctx.types,
                 Some(self.ctx.types),
-                &element_types,
+                &bct_element_types,
                 Some(&self.ctx), // Pass TypeResolver for class hierarchy BCT
             )
         };

--- a/crates/tsz-checker/tests/nested_array_literal_any_widening_bct_tie_break_tests.rs
+++ b/crates/tsz-checker/tests/nested_array_literal_any_widening_bct_tie_break_tests.rs
@@ -1,0 +1,208 @@
+//! Regression tests for the `arrayLiteralWidened.ts` conformance witness.
+//!
+//! Structural rule: when a nested array/tuple literal element (e.g. `[[null]]`
+//! inside `[[[null]],[undefined]]`) resolves its `null`/`undefined` leaves,
+//! that resolution normally happens only at the enclosing `var`/`let`
+//! binding's widening seam — *after* the outer array literal's own
+//! best-common-type (BCT) has already combined the sibling element types.
+//! Pre-widening, `[[null]]` and `[undefined]` are structurally unrelated
+//! (`Array<null-sentinel>` isn't a subtype of `Array<undefined>` the way the
+//! post-widening `any[][]`/`any[]` pair is), so the BCT tournament never gets
+//! a chance to see that the two siblings collapse once widened.
+//!
+//! tsc widens `[[null]]` to `any[][]` and `[undefined]` to `any[]` before
+//! comparing them, and its `removeSubtypes` keeps the first-declared,
+//! mutually-related candidate (`any[][]`) — never emitting a spurious
+//! `any[] | any[][]` and never disagreeing with a same-shape sibling
+//! redeclaration (`var c = [[[]]]; var c = [[[null]],[undefined]]` compiles
+//! clean, both `any[][][]`).
+//!
+//! tsz's fix has two parts, at their respective owner layers:
+//! - `crates/tsz-checker/src/types/computation/array_literal.rs`: eagerly
+//!   widen each COMPOUND (array/tuple/object) element's nullish leaves before
+//!   handing the element types to the solver's BCT, under `!strictNullChecks`
+//!   (a bare scalar `null`/`undefined` element is left alone — it is already
+//!   a universal subtype for BCT's own tournament under non-strict mode).
+//! - `crates/tsz-solver/src/operations/expression_ops.rs`
+//!   (`compute_best_common_type_cached`'s tournament): only replace the
+//!   current "best" candidate with a new one that *strictly* dominates it
+//!   (is a supertype but not also a subtype). Two candidates can be mutually
+//!   related only through `any`'s absorption; the un-fixed tournament drifted
+//!   to whichever mutually-related candidate came LAST.
+
+use tsz_checker::test_utils::check_source_non_strict_codes;
+use tsz_checker::test_utils::check_with_options_code_messages;
+use tsz_checker::test_utils::non_strict_checker_options;
+
+fn assert_clean(source: &str, why: &str) {
+    let found = check_source_non_strict_codes(source);
+    assert!(
+        found.is_empty(),
+        "{why}: expected no diagnostics under non-strict mode, got {found:?}"
+    );
+}
+
+fn messages_non_strict(source: &str) -> Vec<(u32, String)> {
+    check_with_options_code_messages(source, non_strict_checker_options())
+}
+
+// --- The reported witness (arrayLiteralWidened.ts) -------------------------
+
+#[test]
+fn nested_empty_array_redeclaration_matches_tsc() {
+    // `TypeScript/tests/cases/conformance/types/typeRelationships/widenedTypes/arrayLiteralWidened.ts`
+    assert_clean(
+        r#"
+var c = [[[]]];
+var c = [[[null]],[undefined]];
+"#,
+        "tsc compiles this redeclaration clean (both sides are `any[][][]`)",
+    );
+}
+
+#[test]
+fn nested_empty_array_redeclaration_survives_renamed_binder() {
+    assert_clean(
+        r#"
+var container = [[[]]];
+var container = [[[null]],[undefined]];
+"#,
+        "the rule is structural, not name-keyed",
+    );
+}
+
+#[test]
+fn nested_empty_array_redeclaration_survives_unrelated_preceding_code() {
+    // The tie-break must depend on this literal's own element order, not on
+    // whatever `any[]`/`any[][]` shapes unrelated earlier code interned first.
+    assert_clean(
+        r#"
+var unrelated1 = [];
+var unrelated2 = [[], [null, null]];
+var c = [[[]]];
+var c = [[[null]],[undefined]];
+"#,
+        "an unrelated `any[]`/`any[][]` created earlier in the file must not change the tie-break",
+    );
+}
+
+#[test]
+fn sibling_elements_widen_to_the_same_type_directly() {
+    // A single level of nesting: `[null]` and `[undefined]` both widen to
+    // `any[]` directly (identical, not merely mutually related), so this
+    // never needs the tie-break at all — a cheap adjacent control. The
+    // TS2322 below is the deliberate witness assignment (`string` can never
+    // hold an array), not a defect: it exists only to read the inferred
+    // element type back out of the diagnostic message.
+    let found = messages_non_strict(
+        r#"
+var oneLevel = [[null],[undefined]];
+var check: string = oneLevel;
+"#,
+    );
+    assert!(
+        found
+            .iter()
+            .any(|(code, msg)| *code == 2322 && msg.contains("any[][]")),
+        "expected TS2322 naming `any[][]`, got {found:?}"
+    );
+}
+
+#[test]
+fn deep_nested_mutual_tie_reports_first_declared_shape() {
+    let found = messages_non_strict(
+        r#"
+var deep = [[[[null]]],[[undefined]]];
+var check: string = deep;
+"#,
+    );
+    assert!(
+        found
+            .iter()
+            .any(|(code, msg)| *code == 2322 && msg.contains("any[][][][]")),
+        "first-declared element must survive the mutual tie at any nesting depth, got {found:?}"
+    );
+}
+
+// --- Negative controls: this must not become a blanket "prefer first" rule -
+
+#[test]
+fn genuinely_different_primitive_siblings_still_form_a_real_union() {
+    // `[1]` and `["a"]` are not mutually related through `any` — ordinary BCT
+    // must still produce a real union, not silently collapse to the first.
+    let found = messages_non_strict(
+        r#"
+var mixed = [[1], ["a"]];
+var check: string = mixed;
+"#,
+    );
+    assert!(
+        found.iter().any(|(code, msg)| *code == 2322
+            && msg.contains("number[]")
+            && msg.contains("string[]")),
+        "unrelated sibling shapes must still union, got {found:?}"
+    );
+}
+
+#[test]
+fn strict_supertype_chain_still_prefers_the_supertype_not_the_first() {
+    // A genuine (non-mutual) supertype relationship must still win regardless
+    // of declaration order: `[1, "a" as string | number]` widens to
+    // `(string | number)[]`, not `number[]` (the first element's own type).
+    let found = messages_non_strict(
+        r#"
+declare const sn: string | number;
+var chain = [1, sn];
+var check: string = chain;
+"#,
+    );
+    assert!(
+        found
+            .iter()
+            .any(|(code, msg)| *code == 2322 && msg.contains("(string | number)[]")),
+        "a strict (non-mutual) supertype must still win the tournament, got {found:?}"
+    );
+}
+
+#[test]
+fn unrelated_same_shape_classes_still_form_a_union() {
+    // From the existing BCT tournament comment: unrelated same-shape classes
+    // must not crown one of them winner via structural mutual-subtyping.
+    let found = messages_non_strict(
+        r#"
+class A { x = 0; }
+class B { x = 0; }
+declare const a: A;
+declare const b: B;
+var instances = [a, b];
+var check: string = instances;
+"#,
+    );
+    assert!(
+        found
+            .iter()
+            .any(|(code, msg)| *code == 2322 && msg.contains('|')),
+        "unrelated same-shape classes must keep a union, not crown one winner, got {found:?}"
+    );
+}
+
+#[test]
+fn strict_null_checks_on_is_unaffected() {
+    // Under strictNullChecks, `null`/`undefined` are never implicitly widened
+    // to `any` (empty array literals become `never[]`, not `any[]`, and the
+    // redeclaration reports TS2403 against a `never[][][]`/nullish-tuple
+    // mismatch instead of matching). This pins that the eager pre-BCT
+    // widening in `array_literal.rs` is gated on `!strict_null_checks()` and
+    // does not fire — this fix is a non-strict-mode-only change.
+    use tsz_checker::test_utils::check_source_strict_codes;
+    let found = check_source_strict_codes(
+        r#"
+var c = [[[]]];
+var c = [[[null]],[undefined]];
+"#,
+    );
+    assert!(
+        !found.is_empty(),
+        "strictNullChecks mode must not silently accept a real nullish-in-never error"
+    );
+}

--- a/crates/tsz-solver/src/operations/expression_ops.rs
+++ b/crates/tsz-solver/src/operations/expression_ops.rs
@@ -1074,7 +1074,15 @@ pub fn compute_best_common_type_cached<R: TypeResolver>(
     //
     // OPTIMIZATION: Tournament-style O(N) reduction instead of O(N²) brute-force.
     // Pass 1 (O(N)): Find the "tournament winner" — iterate through candidates,
-    //   replacing `best` whenever we find a candidate that is a supertype of it.
+    //   replacing `best` whenever we find a candidate that STRICTLY dominates
+    //   it (is a supertype but not also a subtype). Two candidates can be
+    //   MUTUALLY related only through `any`'s absorption (e.g. `any[]` and
+    //   `any[][]` are each a subtype of the other, since `any` is compatible
+    //   with any element type); a plain "replace on any relation" tournament
+    //   would then drift to whichever candidate appears LAST, but tsc keeps
+    //   the first: `[[[null]],[undefined]]`'s sibling elements widen to
+    //   `any[][]` and `any[]`, and tsc's `arrayLiteralWidened.ts` witness
+    //   keeps `any[][]` (the first-declared element), not `any[]`.
     // Pass 2 (O(N)): Verify the winner is truly a supertype of ALL types.
     // Total: O(2N) instead of O(N²). For 50 candidates: 100 checks vs 2,500.
     //
@@ -1101,7 +1109,7 @@ pub fn compute_best_common_type_cached<R: TypeResolver>(
         // Pass 1: Tournament to find potential best candidate
         let mut best = widened[0];
         for &candidate in &widened[1..] {
-            if related(&mut checker, best, candidate) {
+            if related(&mut checker, best, candidate) && !related(&mut checker, candidate, best) {
                 best = candidate;
             }
         }
@@ -1116,7 +1124,10 @@ pub fn compute_best_common_type_cached<R: TypeResolver>(
         let mut best = widened[0];
         for &candidate in &widened[1..] {
             checker.guard.reset();
-            if checker.is_subtype_of(best, candidate) {
+            let best_to_candidate = checker.is_subtype_of(best, candidate);
+            checker.guard.reset();
+            let candidate_to_best = checker.is_subtype_of(candidate, best);
+            if best_to_candidate && !candidate_to_best {
                 best = candidate;
             }
         }


### PR DESCRIPTION
When a nested array/tuple literal element (e.g. `[[null]]` inside `[[[null]],[undefined]]`) contains `null`/`undefined` leaves, tsc resolves those leaves to `any` only at the enclosing `var`/`let` binding's widening seam — well after the outer array literal's own best-common-type (BCT) has already combined the sibling element types. Before that seam runs, `[[null]]` and `[undefined]` are structurally unrelated (an array of the null-sentinel isn't a subtype of an array of undefined the way the post-widening `any[][]`/`any[]` pair is), so tsz's BCT tournament never got a chance to see that the two siblings collapse once widened, and instead produced a spurious `any[] | any[][]`.

Even once both siblings are correctly widened, a second bug surfaced: `compute_best_common_type_cached`'s O(N) tournament (`crates/tsz-solver/src/operations/expression_ops.rs`) replaces its running "best" candidate whenever a new candidate is merely *related* to it. Two candidates can be mutually related only through `any`'s absorption (e.g. `any[]` and `any[][]` are each a subtype of the other, since `any` is compatible with any element type). The un-fixed tournament drifted to whichever mutually-related candidate came LAST, but tsc's real `removeSubtypes` keeps the first-declared one — confirmed empirically against `tsc@7.0.2`, independent of any unrelated preceding code in the same file.

**Structural rule.** When two array-literal BCT candidates are mutually related only through `any`'s absorption, `tsc` keeps the first-declared candidate; `tsz` now does the same through `compute_best_common_type_cached`'s tournament tie-break (solver layer). Separately, a nested array/tuple literal element's own nullish leaves must be resolved to `any` *before* the outer array's BCT compares it against a sibling, not deferred to the enclosing binding's widening seam; `tsz` now does this in `array_literal.rs` (checker layer), gated on `!strictNullChecks` and scoped to compound (array/tuple/object) elements only — a bare scalar `null`/`undefined` element is untouched since it can't exhibit this specific pre-widening mismatch.

Fixes the conformance witness `TypeScript/tests/cases/conformance/types/typeRelationships/widenedTypes/arrayLiteralWidened.ts`, which now compiles clean (previously a spurious `TS2403`).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-solver --lib` (full suite): 7628 passed, 0 failed
- `cargo test -p tsz-checker --lib array_literal` / `widen` / `best_common`: 69 + 202 + 2 passed, 0 failed
- `cargo test -p tsz-checker --test nested_array_literal_any_widening_bct_tie_break_tests` (new, 9 cases: the reported witness, renamed binders, unrelated-preceding-code, single/deep nesting, and negative controls for genuinely-different siblings, a real strict-supertype chain, unrelated same-shape classes, and strictNullChecks-on): 9 passed
- `cargo clippy -p tsz-solver -p tsz-checker --lib --tests -- -D warnings`: clean
- `python3 scripts/arch/arch_guard.py`: passed
- `cargo fmt -- --check`: clean
- Manual oracle diff against `tsc@7.0.2` across 10+ hand-built witnesses (the reported fixture, isolated redeclaration, single/deep nesting, mixed-primitive siblings, a real supertype chain, unrelated same-shape classes, strict-mode negative control): all byte-identical to tsz's output after this fix
- **Not run in this container**: `scripts/conformance/compare-to-parent.sh` / a full `conformance.sh snapshot` — no `TypeScript/` corpus checkout available in this cold cloud seat. This is a narrowly-scoped, unit-tested fix (2 files, ~50 lines) with an oracle-pinned adjacent-case matrix; a warm-corpus seat should run the two-sided diff before landing, per repo convention for cold-seat PRs.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT