### PR TITLE
fix(checker): stop reporting TS2323 on namespace-internal `export var` merges

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1764,6 +1764,9 @@ mod ts2322_readonly_array_element_elaboration_tests;
 #[path = "tests/ts2322_same_generic_type_argument_elaboration_tests.rs"]
 mod ts2322_same_generic_type_argument_elaboration_tests;
 #[cfg(test)]
+#[path = "tests/ts2323_export_var_namespace_merge_tests.rs"]
+mod ts2323_export_var_namespace_merge_tests;
+#[cfg(test)]
 #[path = "tests/ts2339_js_this_function_name_display_tests.rs"]
 mod ts2339_js_this_function_name_display_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/ts2323_export_var_namespace_merge_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2323_export_var_namespace_merge_tests.rs
@@ -1,0 +1,180 @@
+//! `var` merges across `export var` redeclarations of the same name inside a
+//! namespace: tsc treats `namespace A { export var x = 1; export var x = 2; }`
+//! as one variable, whether the two declarations sit in one body or several.
+//! TS2323 ("Cannot redeclare exported variable") only applies to a module's
+//! own top-level exports, not to namespace-internal `export var` merges.
+
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::check_source_diagnostics;
+
+fn ts2323_count(diags: &[Diagnostic]) -> usize {
+    diags.iter().filter(|d| d.code == 2323).count()
+}
+
+#[test]
+fn namespace_single_body_export_var_merge_is_clean() {
+    let diags = check_source_diagnostics(
+        r#"
+namespace A { export var x = 1; export var x = 2; }
+export {};
+"#,
+    );
+    assert_eq!(
+        ts2323_count(&diags),
+        0,
+        "namespace-internal `export var` merge must not report TS2323; got: {diags:?}"
+    );
+}
+
+#[test]
+fn namespace_two_bodies_export_var_merge_is_clean() {
+    let diags = check_source_diagnostics(
+        r#"
+namespace A { export var x = 1; }
+namespace A { export var x = 2; }
+export {};
+"#,
+    );
+    assert_eq!(
+        ts2323_count(&diags),
+        0,
+        "cross-body namespace `export var` merge must not report TS2323; got: {diags:?}"
+    );
+}
+
+#[test]
+fn namespace_three_bodies_export_var_merge_is_clean() {
+    let diags = check_source_diagnostics(
+        r#"
+namespace A { export var x = 1; }
+namespace A { export var x = 2; }
+namespace A { export var x = 3; }
+export {};
+"#,
+    );
+    assert_eq!(
+        ts2323_count(&diags),
+        0,
+        "three-body namespace `export var` merge must not report TS2323; got: {diags:?}"
+    );
+}
+
+#[test]
+fn namespace_export_var_merge_is_clean_in_a_script_file_too() {
+    let diags = check_source_diagnostics(
+        r#"
+namespace A { export var x = 1; export var x = 2; }
+"#,
+    );
+    assert_eq!(
+        ts2323_count(&diags),
+        0,
+        "namespace `export var` merge must be clean in a script file; got: {diags:?}"
+    );
+}
+
+#[test]
+fn module_top_level_export_var_redeclaration_still_reports_ts2323() {
+    let diags = check_source_diagnostics(
+        r#"
+export var x = 1;
+export var x = 2;
+"#,
+    );
+    assert_eq!(
+        ts2323_count(&diags),
+        2,
+        "top-level `export var` redeclaration in a module must still report TS2323 on both \
+         declarations; got: {diags:?}"
+    );
+}
+
+#[test]
+fn module_top_level_export_var_redeclaration_with_sibling_namespace_still_reports_ts2323() {
+    let diags = check_source_diagnostics(
+        r#"
+namespace A { export var x = 1; }
+export var x2 = 1;
+export var x2 = 2;
+export {};
+"#,
+    );
+    assert_eq!(
+        ts2323_count(&diags),
+        2,
+        "a namespace-scoped sibling must not suppress a genuine module-level `export var` \
+         redeclaration; got: {diags:?}"
+    );
+}
+
+#[test]
+fn namespace_export_let_redeclaration_still_reports_ts2451() {
+    let diags = check_source_diagnostics(
+        r#"
+namespace A { export let x = 1; export let x = 2; }
+export {};
+"#,
+    );
+    let ts2451 = diags.iter().filter(|d| d.code == 2451).count();
+    assert_eq!(
+        ts2451, 2,
+        "`let` must still refuse to merge inside a namespace (sibling arm, unaffected by the \
+         `var` fix); got: {diags:?}"
+    );
+    assert_eq!(
+        ts2323_count(&diags),
+        0,
+        "must not report TS2323; got: {diags:?}"
+    );
+}
+
+#[test]
+fn namespace_export_function_redeclaration_still_reports_ts2393() {
+    let diags = check_source_diagnostics(
+        r#"
+namespace A { export function f() {} export function f() {} }
+export {};
+"#,
+    );
+    let ts2393 = diags.iter().filter(|d| d.code == 2393).count();
+    assert_eq!(
+        ts2393, 2,
+        "duplicate function implementations must still be rejected inside a namespace \
+         (sibling arm, unaffected by the `var` fix); got: {diags:?}"
+    );
+    assert_eq!(
+        ts2323_count(&diags),
+        0,
+        "must not report TS2323; got: {diags:?}"
+    );
+}
+
+#[test]
+fn namespace_export_var_merge_is_clean_with_renamed_binder() {
+    let diags = check_source_diagnostics(
+        r#"
+namespace Zeta { export var probe = 1; export var probe = 2; }
+export {};
+"#,
+    );
+    assert_eq!(
+        ts2323_count(&diags),
+        0,
+        "the fix must not key on the identifier name; got: {diags:?}"
+    );
+}
+
+#[test]
+fn namespace_export_var_merge_is_clean_with_type_annotation() {
+    let diags = check_source_diagnostics(
+        r#"
+namespace A { export var x: number; export var x: number = 2; }
+export {};
+"#,
+    );
+    assert_eq!(
+        ts2323_count(&diags),
+        0,
+        "annotated namespace `export var` merge must not report TS2323; got: {diags:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -915,7 +915,20 @@ impl<'a> CheckerState<'a> {
                     let decl_is_var = (decl_flags & symbol_flags::FUNCTION_SCOPED_VARIABLE) != 0;
                     let other_is_var = (other_flags & symbol_flags::FUNCTION_SCOPED_VARIABLE) != 0;
                     if decl_is_var && other_is_var {
-                        if is_external_module && decl_is_exported && other_is_exported {
+                        // A remote (non-local) declaration's index belongs to another
+                        // file's arena, so `get_enclosing_namespace` (which always reads
+                        // `self.ctx.arena`) cannot be asked about it; fall back to
+                        // module-scope (the pre-existing behavior) in that case.
+                        let decl_at_module_scope =
+                            !decl_is_local || self.get_enclosing_namespace(decl_idx).is_none();
+                        let other_at_module_scope =
+                            !other_is_local || self.get_enclosing_namespace(other_idx).is_none();
+                        if is_external_module
+                            && decl_is_exported
+                            && other_is_exported
+                            && decl_at_module_scope
+                            && other_at_module_scope
+                        {
                             if decl_is_local {
                                 conflicts.insert(decl_idx);
                             }


### PR DESCRIPTION
Closes #16158.

**Structural rule.** `export var x` redeclared inside a namespace is a legal merge — `var` is function-scoped and redeclarable — and `tsc` accepts it whether the two declarations sit in one namespace body or several. TS2323 ("Cannot redeclare exported variable") only applies to a module's own top-level exports; tsz now enforces that distinction through the checker's exported-variable-conflict check instead of the file-is-an-external-module test alone.

**Owner layer.** Checker, `crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs`. The var/var conflict branch already carried a comment stating the namespace-exemption rule ("Namespace-internal `export var` redeclarations are allowed...") but the code never implemented it — it flagged any pair of exported `var` declarations in an external module regardless of whether either sat inside a namespace. The fix adds a real namespace-scope check (via the existing `get_enclosing_namespace` helper) for local declarations before treating the pair as a TS2323 conflict; a remote (cross-file) declaration keeps the pre-existing module-scope assumption, since `get_enclosing_namespace` only walks the current file's arena.

## Oracle matrix (tsz vs tsc 7.0.2, `--strict false --target es2015`)

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `namespace A { export var x=1; export var x=2; }` + `export {}` | clean | 2x TS2323 | **clean** |
| same, two separate `namespace A { ... }` bodies | clean | 2x TS2323 | **clean** |
| same, three bodies | clean | 2x TS2323 | **clean** |
| same namespace shape in a **script** file (no `export {}`) | clean | clean | clean (unchanged) |
| `export var x=1; export var x=2;` at **module top level** | 2x TS2323 | 2x TS2323 | **2x TS2323 (unchanged)** |
| module-top-level redeclare with an unrelated namespace-scoped sibling present | 2x TS2323 | 2x TS2323 | **2x TS2323 (unchanged)** |
| sibling arm: `export let x` x2 in a namespace | 2x TS2451 | 2x TS2451 | 2x TS2451 (unchanged, was already correct) |
| sibling arm: `export function f(){}` x2 in a namespace | 2x TS2393 | 2x TS2393 | 2x TS2393 (unchanged, was already correct) |
| renamed binder (`Zeta`/`probe`) | clean | 2x TS2323 | **clean** |
| annotated `export var x: number` x2 in a namespace | clean | 2x TS2323 | **clean** |

One pre-existing, unrelated gap found while building this matrix, left unfixed: `export var x=1; export let x=2;` (same name, genuine conflict, module top level) reports tsc's `TS2300` but tsz reports `TS2323`. That's a distinct diagnostic-selection defect in the later message-choosing logic (unreached by the var/var branch this PR touches, confirmed by the fact this shape isn't in `decl_is_var && other_is_var`) — filing separately rather than scope-creeping this fix.

## Verification

- New suite `crates/tsz-checker/src/tests/ts2323_export_var_namespace_merge_tests.rs` — **10/10 pass**: single-body, two-body, three-body, script-file, module-top-level (still-firing control), sibling-with-namespace control, both sibling arms (`let`→TS2451, `function`→TS2393) with renamed identifiers, renamed binder, and an annotated-declaration variant.
- `cargo fmt --all -- --check` clean.
- `cargo commit` pre-commit hook (clippy + `arch-size` guard) passed on this diff.
- Targeted `cargo test -p tsz-checker --lib ts2323_export_var_namespace_merge_tests`: 10 passed, 0 failed.

### Not completed in this container

`cargo test -p tsz-checker --lib` (the full ~8823-test suite) did not finish inside this cold cloud seat's time budget (hit a 590s internal timeout mid-run, no partial failures observed before then). The change is narrowly scoped to one `if decl_is_var && other_is_var` branch and its net effect can only relax a false-positive path (fewer TS2323s, never more), but a warm seat re-running the full `--lib` suite before landing is worth the few minutes.

`scripts/conformance/conformance-detail.json`'s aggregate `one_missing_zero_extra`/`one_extra_zero_missing` tables carry **zero** `TS2323` entries today, so this shape has no reducible corpus fixture — 0/0 conformance movement is the expected signature here, not a null result (same pattern as several recent PRs in this campaign, e.g. #16016/#16020/#16039/#16042). `./scripts/conformance/conformance.sh` and `./scripts/emit/run.sh` were not run; this diff touches no emit path and the corpus has no fixture for this shape per the check above.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nwc4BipNtDC5Uw1nGvgSfz)_