### PR TITLE
fix(checker): keep TS2323 off exported variable conflicts that include a block-scoped binding

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1767,6 +1767,9 @@ mod ts2322_readonly_array_element_elaboration_tests;
 #[path = "tests/ts2322_same_generic_type_argument_elaboration_tests.rs"]
 mod ts2322_same_generic_type_argument_elaboration_tests;
 #[cfg(test)]
+#[path = "tests/ts2323_block_scoped_conflict_message_tests.rs"]
+mod ts2323_block_scoped_conflict_message_tests;
+#[cfg(test)]
 #[path = "tests/ts2323_export_var_namespace_merge_tests.rs"]
 mod ts2323_export_var_namespace_merge_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/ts2323_block_scoped_conflict_message_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2323_block_scoped_conflict_message_tests.rs
@@ -1,0 +1,279 @@
+//! TS2323 ("Cannot redeclare exported variable") only applies when *every*
+//! declaration taking part in the conflict is a function-scoped `var`.
+//!
+//! A `let`/`const` binding carries the `VARIABLE` symbol flag alongside
+//! `BLOCK_SCOPED_VARIABLE`, so "every conflicting declaration is a variable"
+//! does not imply "every conflicting declaration is a `var`". Once a
+//! block-scoped binding participates, tsc falls back to its binder-level
+//! redeclaration message and chooses between TS2451 and TS2300 by the
+//! block-scopedness of the *first* conflicting declaration in source order.
+//!
+//! Every expectation below is pinned against `tsc` 7.0.2 run with
+//! `--noEmit --strict --pretty false --lib es2015 --target es2015`.
+
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::check_source_diagnostics;
+
+fn codes(diags: &[Diagnostic]) -> Vec<u32> {
+    let mut out: Vec<u32> = diags.iter().map(|d| d.code).collect();
+    out.sort_unstable();
+    out.dedup();
+    out
+}
+
+/// `export var` then `export let`: the first conflicting declaration is
+/// function-scoped, so tsc reports TS2300 on both declarations.
+#[test]
+fn exported_var_then_let_is_ts2300() {
+    let diags = check_source_diagnostics(
+        r#"
+export var alpha = 1;
+export let alpha = 2;
+"#,
+    );
+    assert_eq!(
+        codes(&diags),
+        vec![2300],
+        "`export var` + `export let` must report TS2300, not TS2323; got: {diags:?}"
+    );
+}
+
+/// `export let` then `export var`: the first conflicting declaration is
+/// block-scoped, so the same pair flips to TS2451. The order dependence is the
+/// whole point — a predicate that only asks "is any declaration block-scoped"
+/// cannot tell these two rows apart.
+#[test]
+fn exported_let_then_var_is_ts2451() {
+    let diags = check_source_diagnostics(
+        r#"
+export let alpha = 1;
+export var alpha = 2;
+"#,
+    );
+    assert_eq!(
+        codes(&diags),
+        vec![2451],
+        "`export let` + `export var` must report TS2451, not TS2323; got: {diags:?}"
+    );
+}
+
+/// `const` behaves exactly like `let` here: block-scoped first means TS2451.
+#[test]
+fn exported_const_then_var_is_ts2451() {
+    let diags = check_source_diagnostics(
+        r#"
+export const alpha = 1;
+export var alpha = 2;
+"#,
+    );
+    assert_eq!(
+        codes(&diags),
+        vec![2451],
+        "`export const` + `export var` must report TS2451, not TS2323; got: {diags:?}"
+    );
+}
+
+/// ...and `var` first means TS2300, whichever block-scoped keyword follows.
+#[test]
+fn exported_var_then_const_is_ts2300() {
+    let diags = check_source_diagnostics(
+        r#"
+export var alpha = 1;
+export const alpha = 2;
+"#,
+    );
+    assert_eq!(
+        codes(&diags),
+        vec![2300],
+        "`export var` + `export const` must report TS2300, not TS2323; got: {diags:?}"
+    );
+}
+
+/// The positive control: an all-`var` exported conflict is the one shape TS2323
+/// is actually for, and it must keep reporting TS2323.
+#[test]
+fn exported_var_then_var_stays_ts2323() {
+    let diags = check_source_diagnostics(
+        r#"
+export var alpha = 1;
+export var alpha = 2;
+"#,
+    );
+    assert_eq!(
+        codes(&diags),
+        vec![2323],
+        "all-`var` exported redeclaration must stay TS2323; got: {diags:?}"
+    );
+}
+
+/// The other side of the same control: an all-block-scoped exported conflict
+/// never reached the TS2323 arm and must stay TS2451.
+#[test]
+fn exported_let_then_let_stays_ts2451() {
+    let diags = check_source_diagnostics(
+        r#"
+export let alpha = 1;
+export let alpha = 2;
+"#,
+    );
+    assert_eq!(
+        codes(&diags),
+        vec![2451],
+        "all-`let` exported redeclaration must stay TS2451; got: {diags:?}"
+    );
+}
+
+/// Three declarations, block-scoped first: still TS2451 across the whole group.
+#[test]
+fn exported_let_var_let_is_ts2451() {
+    let diags = check_source_diagnostics(
+        r#"
+export let alpha = 1;
+export var alpha = 2;
+export let alpha = 3;
+"#,
+    );
+    assert_eq!(
+        codes(&diags),
+        vec![2451],
+        "`let`/`var`/`let` exported conflict must report TS2451; got: {diags:?}"
+    );
+}
+
+/// Renamed binder: the decision is a symbol-flag test, not a name test.
+#[test]
+fn renamed_binder_exported_var_then_let_is_ts2300() {
+    let diags = check_source_diagnostics(
+        r#"
+export var zetaBinding = 1;
+export let zetaBinding = 2;
+"#,
+    );
+    assert_eq!(
+        codes(&diags),
+        vec![2300],
+        "renamed binder must behave identically; got: {diags:?}"
+    );
+}
+
+/// Explicit type annotations do not change the message selection.
+#[test]
+fn annotated_exported_var_then_const_is_ts2300() {
+    let diags = check_source_diagnostics(
+        r#"
+export var alpha: number = 1;
+export const alpha: string = "x";
+"#,
+    );
+    assert_eq!(
+        codes(&diags),
+        vec![2300],
+        "annotated declarations must behave identically; got: {diags:?}"
+    );
+}
+
+/// Inside a namespace body, `export var` + `export let` is a genuine conflict
+/// and reports TS2300 — the namespace `export var` merge exemption covers
+/// var/var merges only, and must not extend to a block-scoped sibling.
+#[test]
+fn namespace_exported_var_then_let_is_ts2300() {
+    let diags = check_source_diagnostics(
+        r#"
+export namespace Holder {
+  export var alpha = 1;
+  export let alpha = 2;
+}
+"#,
+    );
+    assert_eq!(
+        codes(&diags),
+        vec![2300],
+        "namespace-internal `export var` + `export let` must report TS2300; got: {diags:?}"
+    );
+}
+
+/// Negative control: a plain, unexported `var`/`var` pair is legal and must
+/// stay clean. TS2323 is gated on export-ness, and that gate is untouched.
+#[test]
+fn unexported_var_then_var_is_clean() {
+    let diags = check_source_diagnostics(
+        r#"
+var alpha = 1;
+var alpha = 2;
+export {};
+"#,
+    );
+    assert_eq!(
+        codes(&diags),
+        Vec::<u32>::new(),
+        "unexported `var` redeclaration is legal; got: {diags:?}"
+    );
+}
+
+/// Negative control: an unexported `var`/`let` pair already took the fallback
+/// arm before this change and must keep reporting TS2300.
+#[test]
+fn unexported_var_then_let_stays_ts2300() {
+    let diags = check_source_diagnostics(
+        r#"
+var alpha = 1;
+let alpha = 2;
+export {};
+"#,
+    );
+    assert_eq!(
+        codes(&diags),
+        vec![2300],
+        "unexported `var` + `let` must stay TS2300; got: {diags:?}"
+    );
+}
+
+/// Negative control: a non-variable participant (`function`) already forced the
+/// fallback arm through `has_non_variable_conflict`, and still reports TS2300.
+#[test]
+fn exported_var_then_function_stays_ts2300() {
+    let diags = check_source_diagnostics(
+        r#"
+export var alpha = 1;
+export function alpha() {}
+"#,
+    );
+    assert_eq!(
+        codes(&diags),
+        vec![2300],
+        "`export var` + `export function` must stay TS2300; got: {diags:?}"
+    );
+}
+
+/// Negative control: a `class` participant likewise stays TS2300.
+#[test]
+fn exported_var_then_class_stays_ts2300() {
+    let diags = check_source_diagnostics(
+        r#"
+export var alpha = 1;
+export class alpha {}
+"#,
+    );
+    assert_eq!(
+        codes(&diags),
+        vec![2300],
+        "`export var` + `export class` must stay TS2300; got: {diags:?}"
+    );
+}
+
+/// Negative control: mixed export-ness reports TS2395 and never reaches the
+/// redeclaration-message selection at all.
+#[test]
+fn mixed_exportedness_var_pair_is_ts2395() {
+    let diags = check_source_diagnostics(
+        r#"
+export var alpha = 1;
+var alpha = 2;
+"#,
+    );
+    assert_eq!(
+        codes(&diags),
+        vec![2395],
+        "mixed exported/local merged declarations report TS2395; got: {diags:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -1631,8 +1631,35 @@ impl<'a> CheckerState<'a> {
                     && (flags & (symbol_flags::GET_ACCESSOR | symbol_flags::SET_ACCESSOR)) != 0
             });
 
-            // TS2323: Check exported variable conflict using symbol.is_exported
-            let has_exported_variable_conflict = symbol.is_exported && has_variable_conflict;
+            // Whether any declaration taking part in this conflict is block-scoped
+            // (`let`/`const`). `conflicts` only tracks local declarations, so a
+            // remote (cross-file) block-scoped declaration has to be looked up
+            // separately. Both the TS2323 arm and the TS2451-vs-TS2300 fallback
+            // below turn on this, so it is computed once here.
+            let has_block_scoped_conflict =
+                declarations.iter().any(|(decl_idx, flags, _, _, _)| {
+                    conflicts.contains(decl_idx)
+                        && (flags & symbol_flags::BLOCK_SCOPED_VARIABLE) != 0
+                });
+            // See duplicateIdentifierRelatedSpans1.ts: a local `class Bar`
+            // conflicts with a remote `const Bar` from another file — tsc emits
+            // TS2451.
+            let has_remote_block_scoped_conflict =
+                declarations.iter().any(|(_, flags, is_local, _, _)| {
+                    !*is_local && (flags & symbol_flags::BLOCK_SCOPED_VARIABLE) != 0
+                });
+
+            // TS2323: Check exported variable conflict using symbol.is_exported.
+            // A `let`/`const` carries `VARIABLE` alongside `BLOCK_SCOPED_VARIABLE`,
+            // so "every conflicting declaration is a variable" does not by itself
+            // mean "every conflicting declaration is a `var`". tsc only reaches
+            // `Cannot_redeclare_exported_variable_0` when no block-scoped binding
+            // takes part; the moment one does, the binder's own redeclaration
+            // message wins and the choice is TS2451-vs-TS2300 by source order.
+            let has_exported_variable_conflict = symbol.is_exported
+                && has_variable_conflict
+                && !has_block_scoped_conflict
+                && !has_remote_block_scoped_conflict;
 
             let (message, code) = if !has_non_block_scoped && !force2300
                 || has_umd_global_value_conflict
@@ -1680,21 +1707,6 @@ impl<'a> CheckerState<'a> {
                 // (e.g., var hoisted from a child block to conflict with a
                 // function at the parent level), we fall back to scope-based
                 // analysis to choose TS2451 vs TS2300.
-                let has_block_scoped_conflict =
-                    declarations.iter().any(|(decl_idx, flags, _, _, _)| {
-                        conflicts.contains(decl_idx)
-                            && (flags & symbol_flags::BLOCK_SCOPED_VARIABLE) != 0
-                    });
-                // For cross-file scenarios, the remote block-scoped declaration is
-                // not stored in `conflicts` (which only tracks local declarations),
-                // so check `declarations` directly for any remote block-scoped
-                // variable that could be triggering the redeclaration error. See
-                // duplicateIdentifierRelatedSpans1.ts: a local `class Bar` conflicts
-                // with a remote `const Bar` from another file — tsc emits TS2451.
-                let has_remote_block_scoped_conflict =
-                    declarations.iter().any(|(_, flags, is_local, _, _)| {
-                        !*is_local && (flags & symbol_flags::BLOCK_SCOPED_VARIABLE) != 0
-                    });
                 let has_function_conflict =
                     declarations.iter().any(|(decl_idx, flags, _, _, _)| {
                         conflicts.contains(decl_idx) && (flags & symbol_flags::FUNCTION) != 0


### PR DESCRIPTION
Picks up the residual ClaudeDE left unclaimed on the board at 02:43Z ("cheap, well-witnessed, unclaimed pickup for the next TS2300/TS2323 session"), filed as a single witness. Measuring it against a real oracle turned one row into **eight**, and the correct answer is order-dependent — which is why the arm could not be right by construction.

## Structural rule

**When an exported variable conflict includes at least one block-scoped (`let`/`const`) binding, `tsc` does not use TS2323 — it falls back to its binder-level redeclaration message and picks TS2451 vs TS2300 by whether the FIRST conflicting declaration in source order is block-scoped. tsz now does the same, through the checker's duplicate-identifier message selection.**

`Cannot_redeclare_exported_variable_0` is only reachable when every participant is a function-scoped `var`. A `let`/`const` carries the `VARIABLE` symbol flag *alongside* `BLOCK_SCOPED_VARIABLE`, so the TS2323 arm's existing guard —

```
} else if has_exported_variable_conflict
    && has_variable_conflict
    && !has_non_variable_conflict   // only excludes non-variables entirely
    && !has_accessor_conflict
    && !force2300
```

— is satisfied by a `var`/`let` pair and swallows it. `has_non_variable_conflict` screens out `function`/`class`/accessor participants, which is why those rows were already correct; nothing screened out a *block-scoped* participant.

The fix is one added conjunct, not a new rule: the fallback arm immediately below **already** implements first-declaration-wins (`duplicate_identifiers.rs`, the `has_block_scoped_conflict` branch, comment: *"tsc uses TS2451 if the first conflicting declaration by source position is block-scoped, and TS2300 if the first is non-block-scoped"*). It was simply unreachable for exported variables. Gating TS2323 on "no block-scoped participant" routes those conflicts back into it. The two block-scoped predicates (local via `conflicts`, and remote for cross-file) are hoisted above the `if`-chain and shared by both arms rather than duplicated.

### Why the order dependence matters

The two orders of the *same pair of keywords* get different codes, so any predicate of the form "is any declaration block-scoped" is provably insufficient — it cannot separate rows c01 and c05 below. This mirrors `tsc`'s binder, which selects on the flags of the **already-declared** symbol at the moment of collision, not on the union of all participants.

### Owner layer

`crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs` — diagnostic message selection for a duplicate-identifier symbol group. No type semantics move; the predicate is a symbol-flag test. No identifier, alias, property or file-name string drives any decision, and the matrix below varies binders (`alpha`, `zetaBinding`) and annotations.

## Oracle matrix

`tsc` 7.0.2, `--noEmit --strict --pretty false --lib es2015 --target es2015`, run in this container against the same sources as the built `tsz`. Comparison is on the emitted code set.

| # | source | tsc | tsz before | tsz after |
| --- | --- | --- | --- | --- |
| c01 | `export var a=1; export let a=2` | TS2300 | **TS2323** | TS2300 |
| c05 | `export let a=1; export var a=2` | TS2451 | **TS2323** | TS2451 |
| c04 | `export var a=1; export const a=2` | TS2300 | **TS2323** | TS2300 |
| c09 | `export const a=1; export var a=2` | TS2451 | **TS2323** | TS2451 |
| d07 | `export let a=1; export var a=2; export let a=3` | TS2451 | **TS2323** | TS2451 |
| d04 | `namespace H { export var a=1; export let a=2 }` | TS2300 | **TS2323** | TS2300 |
| d05 | c01 with binder renamed to `zetaBinding` | TS2300 | **TS2323** | TS2300 |
| d06 | c04 with both declarations annotated | TS2300 | **TS2323** | TS2300 |

c01 and c05 are the pair that pins the rule: same two keywords, opposite answers, decided by source order alone.

Controls that must not move, and do not:

| # | source | tsc | tsz before | tsz after |
| --- | --- | --- | --- | --- |
| c02 | `export var a=1; export var a=2` | TS2323 | TS2323 | TS2323 |
| c03 | `export let a=1; export let a=2` | TS2451 | TS2451 | TS2451 |
| c08 | `export var a=1; export function a(){}` | TS2300 | TS2300 | TS2300 |
| d08 | `export var a=1; export class a {}` | TS2300 | TS2300 | TS2300 |
| c06 | unexported `var a=1; let a=2` in a module | TS2300 | TS2300 | TS2300 |
| c07 | same, script file | TS2300 | TS2300 | TS2300 |
| d03 | unexported `var a=1; var a=2` | *(clean)* | *(clean)* | *(clean)* |
| d01/d02 | mixed exported/local `var` pair | TS2395 | TS2395 | TS2395 |

c02 is the positive control that keeps TS2323 alive; d03 confirms the export-ness gate itself is untouched.

**Matrix result: 10/18 exact before, 17/18 after.**

### Known residual, not introduced here

`export var a=1; export let a=2; export var a=3` — `tsc` emits a **mix**, `{TS2300, TS2323}` (TS2300 on decls 1-2, TS2323 on decls 1 and 3), because its binder *resets* the symbol after reporting a collision, so the third declaration starts a fresh group. tsz reports one message per symbol group and cannot express a mix. It moves `{TS2323}` → `{TS2300}`: matching one of the two codes instead of the other, so no better and no worse on a code-set comparison. Recorded rather than papered over — matching it needs the binder's post-collision symbol reset, which is a separate change in a different layer.

## Goal
Goal: hold

## Verification
- `cargo fmt --all` — clean.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings` — **clean** (3m05s), plus the pre-commit hook's own clippy + architecture guard, both **passed**.
- New file `crates/tsz-checker/src/tests/ts2323_block_scoped_conflict_message_tests.rs`, 15 tests, every expectation pinned against the `tsc` runs above (the 8 fixed rows plus 7 controls, including the renamed-binder and annotated variants).
- `cargo test -p tsz-checker --lib ts2323` — **29 passed, 0 failed** (15 new + all 14 pre-existing TS2323 tests, including #16161's namespace-merge suite, unchanged).
- Targeted regression filters over the touched surface, all **0 failed**: `duplicate_ident` 10, `redeclar` 18, `ts2300` **79**, `ts2451` 9, `ts2395` 4, `ts2393` 4, `namespace_merge` 17.
- `cargo test -p tsz-checker --lib` (full ~8.8k suite) — started as a background job; result posted as a comment when it lands. Board-recorded cold-seat cost for this suite is 40+ min.
- **Conformance corpus: not run in this container.** There is no `TypeScript/` checkout at all, so neither `compare-to-parent.sh` nor `./scripts/emit/run.sh` can clear here. Scope bound from the committed `conformance-detail.json`, scanning for codes this change can *add* as well as remove (per Basalt's 03:28Z board NOTE): 19 failing rows carry TS2300/TS2451/TS2323 in an `m`/`x` set; **zero** carry TS2323 as an *extra*, so no failing row is failing because of the over-wide arm, and the two rows *missing* TS2323 cannot be affected because this change never adds TS2323. The five rows already carrying extra TS2300 and two carrying extra TS2451 compare on code sets, so an additional occurrence of a code already present cannot move them. Expected delta **0 newly failing**; a warm-seat corpus + emit sweep before merge is the check that matters.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Diorite

---
_Generated by [Claude Code](https://claude.ai/code/session_019DNsvZDWXooDGhe8fNXGtN)_