### PR TITLE
fix(checker): gate optional-chain-root nullish stripping on strictNullChecks

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1533,6 +1533,9 @@ mod operator_chain_overload_resolution_tests;
 #[path = "tests/optional_chain_inherent_nullish_tests.rs"]
 mod optional_chain_inherent_nullish_tests;
 #[cfg(test)]
+#[path = "tests/optional_chain_root_nullish_strict_only_tests.rs"]
+mod optional_chain_root_nullish_strict_only_tests;
+#[cfg(test)]
 #[path = "tests/optional_key_extraction_tests.rs"]
 mod optional_key_extraction_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/non_strict_non_null_check_narrows_tests.rs
+++ b/crates/tsz-checker/src/tests/non_strict_non_null_check_narrows_tests.rs
@@ -301,21 +301,25 @@ fn uninitialized_and_any_and_plain_operands_stay_clean_without_strict_null_check
 }
 
 #[test]
-fn optional_chain_on_a_null_receiver_is_unchanged_by_this_gate() {
-    // Not a tsc-parity pin: `on?.foo` / `on?.()` on a `null` receiver is a
-    // separate pre-existing divergence (tsz reports TS2339 on `never`, tsc
-    // reports TS18047/TS2721) that this gate does not reach. Pinned as
-    // "identical in both modes" so a later widening of the gate cannot quietly
-    // start routing optional chains through it.
+fn optional_chain_on_a_null_receiver_now_reports_the_non_strict_family() {
+    // `on?.foo` / `on?.()` on a `null` receiver used to report TS2339 on
+    // `never` in both modes, because tsz's chain-root nullish stripping
+    // (mirroring tsc's `getNonNullableType`) fired unconditionally. That
+    // strip is strict-only in tsc, so without `strictNullChecks` this now
+    // falls through to the same TS18047/TS2721 family as `on.foo` / `on()`.
+    // Full matrix (property/element/call, undefined, nesting, unions) lives
+    // in `optional_chain_root_nullish_strict_only_tests.rs`; this row stays
+    // here as the one this gate's docstring used to call out as unreached.
     let source = "declare const on: null;\non?.foo;\non?.();";
+    let lax = nullish_codes(&non_strict(source));
     assert_eq!(
-        nullish_codes(&non_strict(source)),
-        nullish_codes(&check_source_strict_codes(source)),
-        "the optional-chain rows must not become mode-dependent"
+        lax,
+        vec![TS18047, TS2721],
+        "the optional-chain rows must report the non-strict nullish family, got: {lax:?}"
     );
     assert!(
-        nullish_codes(&non_strict(source)).is_empty(),
-        "the optional-chain rows are not routed through this gate today"
+        nullish_codes(&check_source_strict_codes(source)).is_empty(),
+        "strict mode keeps reporting TS2339/TS2349 (outside this family), not TS18047/TS2721"
     );
 }
 

--- a/crates/tsz-checker/src/tests/optional_chain_root_nullish_strict_only_tests.rs
+++ b/crates/tsz-checker/src/tests/optional_chain_root_nullish_strict_only_tests.rs
@@ -1,0 +1,215 @@
+//! An optional-chain root's nullish stripping is `strictNullChecks`-only,
+//! not unconditional.
+//!
+//! Structural rule: tsc's `getOptionalExpressionType` calls
+//! `getNonNullableType` on the expression at the root of an optional chain
+//! (`on` in `on?.foo`, `on` in `on?.()`), and `getNonNullableType` is
+//!
+//! ```text
+//! function getNonNullableType(type) {
+//!     return strictNullChecks ? getTypeWithFacts(type, TypeFacts.NEUndefinedOrNull) : type;
+//! }
+//! ```
+//!
+//! — the identity function without `strictNullChecks`. So only in strict mode
+//! does `on?.foo` narrow its receiver to `never` (TS2339) and `on?.()` narrow
+//! its callee to `never` (TS2349, "has no call signatures"). Without it, the
+//! receiver's/callee's own (unstripped) type flows into the ordinary
+//! non-chain nullish reporter — the same `checkNonNullTypeWithReporter` this
+//! narrows on `type.flags` — and reports TS18047/18048/2721/2722 exactly as
+//! the non-chain `on.foo` / `on()` would.
+//!
+//! tsz's two chain-root call sites
+//! (`property_access_type::nullish_access::handle_possibly_null_or_undefined_access`
+//! and `computation::call::inner`'s optional-call callee resolution) stripped
+//! unconditionally, so both reported the strict-mode answer in every mode.
+//!
+//! Oracle: `tsc` 7.0.2, `--noEmit --strictNullChecks <bool> --pretty false`.
+//! Every expectation below is pinned against a real run, in both modes.
+
+use crate::test_utils::{
+    check_source_non_strict_codes as non_strict, check_source_strict_codes as strict,
+};
+
+const TS18047: u32 = 18047; // '<x>' is possibly 'null'.
+const TS18048: u32 = 18048; // '<x>' is possibly 'undefined'.
+const TS2339: u32 = 2339; // Property '<x>' does not exist on type '<T>'.
+const TS2349: u32 = 2349; // This expression is not callable.
+const TS2721: u32 = 2721; // Cannot invoke an object which is possibly 'null'.
+const TS2722: u32 = 2722; // Cannot invoke an object which is possibly 'undefined'.
+
+fn count(codes: &[u32], code: u32) -> usize {
+    codes.iter().filter(|&&c| c == code).count()
+}
+
+// -------------------------------------------------------------------------
+// `null`-typed receiver/callee, property/element/call positions, both modes.
+// Binders are varied so nothing keys on identifier text.
+// -------------------------------------------------------------------------
+
+#[test]
+fn null_receiver_optional_property_access_reports_ts18047_without_strict_null_checks() {
+    for binder in ["on", "probe", "receiver"] {
+        let source = format!("declare const {binder}: null;\n{binder}?.foo;");
+        let lax = non_strict(&source);
+        assert_eq!(
+            count(&lax, TS18047),
+            1,
+            "expected TS18047 for `{binder}?.foo` without strictNullChecks, got: {lax:?}"
+        );
+        assert_eq!(
+            count(&lax, TS2339),
+            0,
+            "`{binder}?.foo` must not report TS2339 without strictNullChecks, got: {lax:?}"
+        );
+    }
+}
+
+#[test]
+fn null_receiver_optional_string_literal_element_access_reports_ts18047_without_strict_null_checks()
+{
+    // Uses a string-literal key (`on?.["foo"]`): the chain-root short
+    // circuit this test targets lives on the `literal_string` arm of
+    // `get_type_of_element_access_with_request`. A *numeric*-literal key
+    // (`on?.[0]`) does not reach that arm at all and reports nothing in
+    // either mode — a separate, pre-existing false-negative, not part of
+    // this gate's scope (see the NOTE this PR leaves on the board).
+    let source = "declare const on: null;\non?.[\"foo\"];";
+    let lax = non_strict(source);
+    assert_eq!(
+        count(&lax, TS18047),
+        1,
+        "expected TS18047 for `on?.[\"foo\"]` without strictNullChecks, got: {lax:?}"
+    );
+    assert_eq!(
+        count(&lax, TS2339),
+        0,
+        "`on?.[\"foo\"]` must not report TS2339 without strictNullChecks, got: {lax:?}"
+    );
+
+    let strict_codes = strict(source);
+    assert_eq!(
+        count(&strict_codes, TS2339),
+        1,
+        "strict mode must keep TS2339 for `on?.[\"foo\"]`, got: {strict_codes:?}"
+    );
+}
+
+#[test]
+fn null_callee_optional_call_reports_ts2721_not_ts2349_without_strict_null_checks() {
+    for binder in ["on", "probe", "callee"] {
+        let source = format!("declare const {binder}: null;\n{binder}?.();");
+        let lax = non_strict(&source);
+        assert_eq!(
+            count(&lax, TS2721),
+            1,
+            "expected TS2721 for `{binder}?.()` without strictNullChecks, got: {lax:?}"
+        );
+        assert_eq!(
+            count(&lax, TS2349),
+            0,
+            "`{binder}?.()` must not report TS2349 without strictNullChecks, got: {lax:?}"
+        );
+    }
+}
+
+#[test]
+fn undefined_receiver_and_callee_report_the_undefined_family_without_strict_null_checks() {
+    let access = non_strict("declare const ou: undefined;\nou?.bar;");
+    assert_eq!(
+        count(&access, TS18048),
+        1,
+        "expected TS18048 for `ou?.bar` without strictNullChecks, got: {access:?}"
+    );
+
+    let call = non_strict("declare const ou: undefined;\nou?.();");
+    assert_eq!(
+        count(&call, TS2722),
+        1,
+        "expected TS2722 for `ou?.()` without strictNullChecks, got: {call:?}"
+    );
+    assert_eq!(
+        count(&call, TS2349),
+        0,
+        "`ou?.()` must not report TS2349 without strictNullChecks, got: {call:?}"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Strict mode is unchanged: `never`-on-chain-root stays exactly as before.
+// -------------------------------------------------------------------------
+
+#[test]
+fn strict_mode_keeps_never_on_optional_chain_root() {
+    let source = "declare const on: null;\non?.foo;\non?.();";
+    let codes = strict(source);
+    assert_eq!(
+        count(&codes, TS2339),
+        1,
+        "strict mode must keep TS2339 on the `never`-narrowed receiver, got: {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, TS2349),
+        1,
+        "strict mode must keep TS2349 on the `never`-narrowed callee, got: {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, TS18047) + count(&codes, TS2721),
+        0,
+        "strict mode must not additionally report the nullish family here, got: {codes:?}"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Nested chains: one report at the root, no cascading diagnostic on the
+// continuation once the receiver/callee resolves to the ERROR sink.
+// -------------------------------------------------------------------------
+
+#[test]
+fn nested_optional_chain_reports_once_at_the_root_without_strict_null_checks() {
+    let property = non_strict("declare const nested: null;\nnested?.foo?.bar;");
+    assert_eq!(
+        count(&property, TS18047),
+        1,
+        "expected exactly one TS18047 for `nested?.foo?.bar`, got: {property:?}"
+    );
+
+    let call = non_strict("declare const callroot: undefined;\ncallroot?.()?.x;");
+    assert_eq!(
+        count(&call, TS2722),
+        1,
+        "expected exactly one TS2722 for `callroot?.()?.x`, got: {call:?}"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Controls: a genuinely partial union (`T | null`) is unaffected by this
+// gate in either mode — it never had a wholly-nullish root to begin with.
+// -------------------------------------------------------------------------
+
+#[test]
+fn partial_union_optional_chain_stays_clean_in_both_modes() {
+    let property_source = "declare const h: { a: number } | null;\nh?.a;";
+    let lax = non_strict(property_source);
+    assert!(
+        lax.iter()
+            .all(|c| ![TS18047, TS18048, TS2339, TS2721, TS2722, TS2349].contains(c)),
+        "`(T | null)?.a` must stay clean without strictNullChecks, got: {lax:?}"
+    );
+    let strict_codes = strict(property_source);
+    assert!(
+        strict_codes
+            .iter()
+            .all(|c| ![TS18047, TS18048, TS2339, TS2721, TS2722, TS2349].contains(c)),
+        "`(T | null)?.a` must stay clean under strictNullChecks, got: {strict_codes:?}"
+    );
+
+    let call_source = "declare const f: (() => void) | null;\nf?.();";
+    let lax_call = non_strict(call_source);
+    assert!(
+        lax_call
+            .iter()
+            .all(|c| ![TS18047, TS2339, TS2721, TS2349].contains(c)),
+        "`(() => void | null)?.()` must stay clean without strictNullChecks, got: {lax_call:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -226,12 +226,33 @@ impl<'a> CheckerState<'a> {
             object_type
         };
 
+        // The chain root's nullish stripping is tsc's `getNonNullableType`,
+        // the identity function without `strictNullChecks` — so a
+        // wholly-nullish receiver only narrows to `never` (and reports
+        // TS2339 here) in strict mode. Without it, the receiver's own
+        // (unstripped) type drives the same `checkNonNullTypeWithReporter`
+        // own-flags trigger as a non-chain access: an operand that IS
+        // `null`/`undefined` still reports TS18047/18048, while a genuine
+        // `null | undefined` union's own flags are `TypeFlags.Union` and do
+        // not trigger, so it falls through unchanged.
         if access.question_dot_token
             && let Some(property_name) = literal_string.as_deref()
             && self.split_nullish_type(object_type).0.is_none()
         {
-            self.error_property_not_exist_at(property_name, TypeId::NEVER, access.name_or_argument);
-            return TypeId::UNDEFINED;
+            if self.ctx.compiler_options.strict_null_checks {
+                self.error_property_not_exist_at(
+                    property_name,
+                    TypeId::NEVER,
+                    access.name_or_argument,
+                );
+                return TypeId::UNDEFINED;
+            }
+            if crate::query_boundaries::type_predicates::has_ts_nullable_flag(object_type) {
+                if !self.report_literal_nullish_value_error(access.expression, object_type) {
+                    self.report_named_possibly_nullish_expression(access.expression, object_type);
+                }
+                return TypeId::ERROR;
+            }
         }
 
         let effective_write_result = |type_id: TypeId, write_type: Option<TypeId>| -> TypeId {

--- a/crates/tsz-checker/src/types/computation/call/inner.rs
+++ b/crates/tsz-checker/src/types/computation/call/inner.rs
@@ -478,11 +478,23 @@ impl<'a> CheckerState<'a> {
             let callee_for_split = self.evaluate_type_with_env(callee_type);
             if call.question_dot_token || !callee_expr_is_chain {
                 // The `?.` guards the invoked value itself (`f?.()`,
-                // `o.m?.()`, `o?.f?.()`): strip all of its nullishness,
-                // mirroring tsc's chain-root `getNonNullableType`.
+                // `o.m?.()`, `o?.f?.()`). When the callee has a non-nullish
+                // slice (`(() => void) | null`), tsc's call-signature
+                // resolution always uses that slice regardless of
+                // `strictNullChecks` — this split is unconditional. It is
+                // only the *diagnostic* for a callee with NO non-nullish
+                // slice at all that is strict-only: tsc's chain-root
+                // `getNonNullableType` is the identity function without
+                // `strictNullChecks`, so only strict mode narrows such a
+                // callee to `never`. Without it, the callee's own
+                // (unstripped) type drives the ordinary
+                // `checkNonNullTypeWithReporter`-style own-flags trigger and
+                // reports TS2721/2722/2723 instead of TS2349-on-`never`.
                 let (non_nullish, cause) = self.split_nullish_type(callee_for_split);
-                nullish_cause = cause;
-                let Some(non_nullish) = non_nullish else {
+                if let Some(non_nullish) = non_nullish {
+                    nullish_cause = cause;
+                    callee_type = non_nullish;
+                } else if self.ctx.compiler_options.strict_null_checks {
                     // The callee is entirely nullish (`null`, `undefined`, or
                     // `null | undefined`). The chain short-circuits to `undefined`,
                     // but tsc still computes the non-nullish slice as `never`, which
@@ -494,8 +506,18 @@ impl<'a> CheckerState<'a> {
                         self.error_not_callable_at(TypeId::NEVER, call.expression);
                     }
                     return TypeId::UNDEFINED;
-                };
-                callee_type = non_nullish;
+                } else if crate::query_boundaries::type_predicates::has_ts_nullable_flag(
+                    callee_for_split,
+                ) {
+                    self.error_cannot_invoke_possibly_nullish_at(callee_for_split, call.expression);
+                    return TypeId::ERROR;
+                } else {
+                    // A genuine `null | undefined` union's own flags are
+                    // `TypeFlags.Union`, never `Nullable`, so the non-strict
+                    // trigger does not fire here either; flow the
+                    // un-stripped type through unchanged.
+                    callee_type = callee_for_split;
+                }
             } else {
                 // The call continues a chain without its own `?.` (`o?.f()`):
                 // tsc's `getOptionalExpressionType` removes only the

--- a/crates/tsz-checker/src/types/property_access_type/nullish_access.rs
+++ b/crates/tsz-checker/src/types/property_access_type/nullish_access.rs
@@ -87,19 +87,34 @@ impl<'a> CheckerState<'a> {
             }
             // When the optional-chain receiver has no non-nullish slice
             // (`property_type` is `None`, i.e. the receiver is exactly `null`,
-            // `undefined`, or `null | undefined`), tsc reports TS2339 at the
-            // property name with the receiver type narrowed to `never` — the
-            // chain always short-circuits, so the property access is
-            // unreachable. Match that diagnostic; the result type still flows
+            // `undefined`, or `null | undefined`) AND `strictNullChecks` is on,
+            // tsc reports TS2339 at the property name with the receiver type
+            // narrowed to `never` — the chain always short-circuits, so the
+            // property access is unreachable. The result type still flows
             // through as `unknown | undefined` to keep downstream typing.
-            if property_type.is_none() {
-                self.error_property_not_exist_at(property_name, TypeId::NEVER, name_or_argument);
+            //
+            // This chain-root stripping is tsc's `getNonNullableType`, which is
+            // the identity function without `strictNullChecks` — so only in
+            // strict mode does the receiver actually narrow to `never` here.
+            // Without it, the receiver's own (unstripped) type keeps flowing
+            // into the ordinary nullish reporter below, exactly as it would
+            // for a non-chain `on.foo`, producing TS18047/18048/18049 instead.
+            if property_type.is_none() && !self.ctx.compiler_options.strict_null_checks {
+                // Fall through to the shared reporter below.
+            } else {
+                if property_type.is_none() {
+                    self.error_property_not_exist_at(
+                        property_name,
+                        TypeId::NEVER,
+                        name_or_argument,
+                    );
+                }
+                let base_type = property_type.unwrap_or(TypeId::UNKNOWN);
+                // The added `| undefined` is the chain short-circuit marker; the
+                // helper tracks whether the member itself already carried
+                // `undefined` so chain continuations can strip only the marker.
+                return self.union_optional_chain_undefined(idx, base_type, true).0;
             }
-            let base_type = property_type.unwrap_or(TypeId::UNKNOWN);
-            // The added `| undefined` is the chain short-circuit marker; the
-            // helper tracks whether the member itself already carried
-            // `undefined` so chain continuations can strip only the marker.
-            return self.union_optional_chain_undefined(idx, base_type, true).0;
         }
 
         if cause == TypeId::ERROR || cause == TypeId::ANY || cause == TypeId::UNKNOWN {

--- a/crates/tsz-checker/src/types/property_access_type/optional_fast_path.rs
+++ b/crates/tsz-checker/src/types/property_access_type/optional_fast_path.rs
@@ -84,6 +84,15 @@ impl<'a> CheckerState<'a> {
 
         let (non_nullish_base, base_nullish) = self.split_nullish_type(object_type);
         let Some(non_nullish_base) = non_nullish_base else {
+            // The chain root's nullish stripping is tsc's `getNonNullableType`,
+            // which is the identity function without `strictNullChecks` — so a
+            // wholly-nullish receiver only narrows to `never` (and reports
+            // TS2339 here) in strict mode. Without it, fall back to the full
+            // path so the receiver's own (unstripped) type reaches the
+            // ordinary nullish reporter and produces TS18047/18048 instead.
+            if !self.ctx.compiler_options.strict_null_checks {
+                return None;
+            }
             self.error_property_not_exist_at(property_name, TypeId::NEVER, name_or_argument);
             return Some(TypeId::UNDEFINED);
         };


### PR DESCRIPTION
`on?.foo` / `on?.()` on a wholly-`null`/`undefined` receiver reported TS2339 ("Property does not exist on type 'never'") / TS2349 ("not callable") in tsz under both `strictNullChecks` settings. `tsc` only reports those in strict mode; without it, it reports TS18047/18048/2721/2722 — the same family a non-chain `on.foo` / `on()` would. This is `#16157`'s residual 2 (Basalt's 03:36Z comment on that issue), left unclaimed after `#16162` closed the issue's main body.

## Structural rule

tsc's chain-root nullish removal (`getOptionalExpressionType` -> `getNonNullableType`) is the identity function without `strictNullChecks`:

```ts
function getNonNullableType(type) {
    return strictNullChecks ? getTypeWithFacts(type, TypeFacts.NEUndefinedOrNull) : type;
}
```

So only in strict mode does an optional-chain root with no non-nullish slice at all narrow to `never`. Without it, the receiver's/callee's own (unstripped) type keeps flowing into the ordinary `checkNonNullTypeWithReporter`-style own-flags trigger (the same mechanism `#16162` fixed for non-chain access), and reports TS18047/18048/2721/2722 instead.

tsz had **four** call sites that stripped a wholly-nullish chain root unconditionally (regardless of mode), owned by the checker's property-access / call-resolution layer:
- `types/property_access_type/optional_fast_path.rs` (property-name fast path)
- `types/property_access_type/nullish_access.rs` (property/element-access full path, `PossiblyNullOrUndefined` handling)
- `types/computation/access.rs` (string-literal-keyed element access)
- `types/computation/call/inner.rs` (optional-call callee resolution)

Fix: gate the "no non-nullish slice" special case on `strict_null_checks` at each site, falling through to the existing non-chain nullish reporter when it's off. A callee/receiver with a genuine non-nullish slice (`(() => void) | null`) keeps stripping unconditionally in both modes — that split is tsc's call-signature/property-lookup resolution, not the diagnostic gate, and stayed unconditional deliberately (an earlier draft of this fix regressed exactly this case).

### Adjacent-case matrix (tsc 7.0.2, `--strictNullChecks <bool>`, oracle-pinned)

| Source | strict:false (tsc / tsz before / tsz after) | strict:true |
| --- | --- | --- |
| `on?.foo` (`on: null`) | TS18047 / **TS2339** / TS18047 | TS2339 (unchanged) |
| `on?.()` (`on: null`) | TS2721 / **TS2349** / TS2721 | TS2349 (unchanged) |
| `ou?.bar` (`ou: undefined`) | TS18048 / **TS2339** / TS18048 | TS2339 (unchanged) |
| `on?.["foo"]` (string-literal key) | TS18047 / **TS2339** / TS18047 | TS2339 (unchanged) |
| `nested?.foo?.bar` (`nested: null`) | 1x TS18047, none on `.bar` | 1x TS2339, none on `.bar` (unchanged) |
| `f?.()` (`f: (() => void) \| null`, partial union) | clean, resolves to `void` (unchanged both before/after) | clean (unchanged) |
| `h?.a` (`h: {a:number} \| null`, partial union) | clean (unchanged) | clean (unchanged) |
| `on?.[0]` (numeric-literal key) | **nothing, in either mode** — separate pre-existing false-negative, not reached by any of these 4 sites, out of scope here (noted on the coordination board) | — |

## Goal
Goal: hold

## Verification
- `cargo fmt` — clean (via pre-commit hook).
- `cargo clippy -p tsz-checker --lib -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py` — passed.
- New `crates/tsz-checker/src/tests/optional_chain_root_nullish_strict_only_tests.rs` (9 tests: property/element/call positions, `null`/`undefined`, nested chains, partial-union controls, strict-mode-unchanged control) — all pass.
- Updated the stale `optional_chain_on_a_null_receiver_is_unchanged_by_this_gate` control in `non_strict_non_null_check_narrows_tests.rs` (it documented the bug as "not routed through this gate today"; now asserts the corrected behavior).
- `cargo test -p tsz-checker --lib -- optional_chain_root_nullish_strict_only non_strict_non_null_check_narrows optional_chain_inherent_nullish` — 39 passed, 0 failed.
- Broader collateral sweep: `cargo test -p tsz-checker --lib -- call_errors nullish optional_chain access_ null_ nullable` (842 passed) and `-- possibly_null possibly_undefined invoke chain_ not_callable ts2721 ts2722 ts2349 ts2339 ts18047 ts18048` (430 passed), plus the existing nullish/optional-chain-adjacent suites (`ts18050_nullish_keyword_without_strict_null_checks`, `nullish_union_indexed_access_missing_property`, `this_prop_nullish_operand_code`, `ts2565_object_literal_nullish_spread`, `call_error_anchor_relation_routing_arch`, `call_error_elaboration_relation_routing_arch`, `nullish_target_relation_routing_arch`, 42 passed). 0 failures across all of the above.
- Conformance/emit suites not run: this container has no `TypeScript/` submodule checked out, and the change is a narrow diagnostic-selection gate on a shape (`on?.foo` with `on` typed exactly `null`/`undefined`, under `strictNullChecks: false`) that the committed `conformance-detail.json` shows no failing corpus row currently exercises — consistent with the "0/0 movement expected" precedent from `#16162`/`#16163` this same session. A warm-seat two-sided `compare-to-parent.sh` sweep is a fair ask before landing.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium


---
_Generated by [Claude Code](https://claude.ai/code/session_01NexY5tMe9fofwrbbXS8mNY)_