### PR TITLE
fix(checker): model tsc's two-pass variable-redeclaration reporting (TS2323 + TS2300 co-emission)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1776,6 +1776,9 @@ mod ts2323_block_scoped_conflict_message_tests;
 #[path = "tests/ts2323_export_var_namespace_merge_tests.rs"]
 mod ts2323_export_var_namespace_merge_tests;
 #[cfg(test)]
+#[path = "tests/ts2323_variable_redeclaration_two_pass_tests.rs"]
+mod ts2323_variable_redeclaration_two_pass_tests;
+#[cfg(test)]
 #[path = "tests/ts2339_js_this_function_name_display_tests.rs"]
 mod ts2339_js_this_function_name_display_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/ts2323_variable_redeclaration_two_pass_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2323_variable_redeclaration_two_pass_tests.rs
@@ -1,0 +1,232 @@
+//! `tsc` reports variable redeclarations through two independent passes, so a
+//! single declaration can carry TS2323 *and* TS2300 at once, and the two codes
+//! can cover different subsets of the declaration list.
+//!
+//! Pass 1 is the binder's collision walk: each declaration is tested against
+//! the *surviving* symbol, and a colliding declaration is reported (TS2451 when
+//! the survivor is block-scoped, TS2300 otherwise) on the survivor's
+//! declarations so far plus itself — then dropped onto a throwaway symbol, so
+//! it never joins the survivor or widens its flags. Pass 2 is the
+//! exported-variable check (TS2323), which reads the survivor alone.
+//!
+//! That is why `export var` / `export let` / `export var` reports TS2300 on
+//! lines 1-2 but TS2323 on lines 1 and 3: the third `var` never collided with
+//! the function-scoped survivor, so it joined it.
+//!
+//! Every expectation below is pinned against `tsc` 7.0.2 run with
+//! `--noEmit --strict --pretty false --lib es2015 --target es2015`. Positions
+//! matter, so these assert per-line code sets rather than whole-file code sets
+//! — a code-set comparison cannot see co-emission at all.
+
+use crate::test_utils::check_source_diagnostics;
+use std::collections::BTreeMap;
+
+/// Diagnostics grouped by 1-based source line, codes sorted and deduplicated.
+fn codes_by_line(source: &str) -> Vec<(u32, Vec<u32>)> {
+    let diags = check_source_diagnostics(source);
+    let mut by_line: BTreeMap<u32, Vec<u32>> = BTreeMap::new();
+    for diag in &diags {
+        let offset = (diag.start as usize).min(source.len());
+        let line = source[..offset].matches('\n').count() as u32 + 1;
+        by_line.entry(line).or_default().push(diag.code);
+    }
+    by_line
+        .into_iter()
+        .map(|(line, mut codes)| {
+            codes.sort_unstable();
+            codes.dedup();
+            (line, codes)
+        })
+        .collect()
+}
+
+/// The headline row of #16165/#16166. The middle `let` collides with the
+/// survivor (`var` on line 1) and earns TS2300 for both; the trailing `var`
+/// does not collide, so it joins the survivor and the exported pass reports
+/// TS2323 on lines 1 and 3. Neither code covers all three declarations.
+#[test]
+fn exported_var_let_var_co_emits_ts2300_and_ts2323_with_different_footprints() {
+    assert_eq!(
+        codes_by_line("export var alpha = 1;\nexport let alpha = 2;\nexport var alpha = 3;\n"),
+        vec![(1, vec![2300, 2323]), (2, vec![2300]), (3, vec![2323])],
+    );
+}
+
+/// Same shape under a different binder name — the rule is structural, not
+/// keyed on any identifier.
+#[test]
+fn exported_var_let_var_is_name_independent() {
+    assert_eq!(
+        codes_by_line("export var zeta = 1;\nexport let zeta = 2;\nexport var zeta = 3;\n"),
+        vec![(1, vec![2300, 2323]), (2, vec![2300]), (3, vec![2323])],
+    );
+}
+
+/// Trailing block-scoped declaration: the survivor already holds both `var`s
+/// when the `let` collides, so TS2300 covers all three and TS2323 covers the
+/// first two.
+#[test]
+fn exported_var_var_let_co_emits_on_the_two_vars() {
+    assert_eq!(
+        codes_by_line("export var alpha = 1;\nexport var alpha = 2;\nexport let alpha = 3;\n"),
+        vec![
+            (1, vec![2300, 2323]),
+            (2, vec![2300, 2323]),
+            (3, vec![2300])
+        ],
+    );
+}
+
+/// `const` behaves exactly like `let` in the collision pass.
+#[test]
+fn exported_var_const_var_co_emits_like_the_let_row() {
+    assert_eq!(
+        codes_by_line("export var alpha = 1;\nexport const alpha = 2;\nexport var alpha = 3;\n"),
+        vec![(1, vec![2300, 2323]), (2, vec![2300]), (3, vec![2323])],
+    );
+}
+
+/// The row that rules out "TS2300 lands on every declaration": the rejoining
+/// `var` on line 4 was never part of a collision, so it carries TS2323 only.
+#[test]
+fn exported_var_let_let_var_leaves_the_rejoining_var_without_ts2300() {
+    assert_eq!(
+        codes_by_line(
+            "export var alpha = 1;\nexport let alpha = 2;\nexport let alpha = 3;\nexport var alpha = 4;\n"
+        ),
+        vec![
+            (1, vec![2300, 2323]),
+            (2, vec![2300]),
+            (3, vec![2300]),
+            (4, vec![2323]),
+        ],
+    );
+}
+
+/// Alternating four-declaration shape: both `var`s join the survivor, both
+/// `let`s collide, and the two codes interleave.
+#[test]
+fn exported_var_let_var_let_interleaves_both_codes() {
+    assert_eq!(
+        codes_by_line(
+            "export var alpha = 1;\nexport let alpha = 2;\nexport var alpha = 3;\nexport let alpha = 4;\n"
+        ),
+        vec![
+            (1, vec![2300, 2323]),
+            (2, vec![2300]),
+            (3, vec![2300, 2323]),
+            (4, vec![2300]),
+        ],
+    );
+}
+
+/// A lone surviving `var` is not a redeclaration of anything, so the exported
+/// pass stays silent even though the file is full of `export var`.
+#[test]
+fn exported_var_let_let_reports_only_ts2300() {
+    assert_eq!(
+        codes_by_line("export var alpha = 1;\nexport let alpha = 2;\nexport let alpha = 3;\n"),
+        vec![(1, vec![2300]), (2, vec![2300]), (3, vec![2300])],
+    );
+}
+
+/// Block-scoped first: every later declaration collides with a block-scoped
+/// survivor, so the whole group is TS2451 and the survivor never grows past
+/// one declaration — no TS2323 anywhere, despite the exported `var`/`var` pair
+/// on lines 2-3.
+#[test]
+fn exported_let_var_var_stays_ts2451_with_no_ts2323() {
+    assert_eq!(
+        codes_by_line("export let alpha = 1;\nexport var alpha = 2;\nexport var alpha = 3;\n"),
+        vec![(1, vec![2451]), (2, vec![2451]), (3, vec![2451])],
+    );
+}
+
+/// #16163's two-declaration rows must not move: one conflicting pair means
+/// per-pass and per-symbol selection agree.
+#[test]
+fn two_declaration_rows_are_unchanged() {
+    assert_eq!(
+        codes_by_line("export var alpha = 1;\nexport var alpha = 2;\n"),
+        vec![(1, vec![2323]), (2, vec![2323])],
+    );
+    assert_eq!(
+        codes_by_line("export var alpha = 1;\nexport let alpha = 2;\n"),
+        vec![(1, vec![2300]), (2, vec![2300])],
+    );
+    assert_eq!(
+        codes_by_line("export let alpha = 1;\nexport var alpha = 2;\n"),
+        vec![(1, vec![2451]), (2, vec![2451])],
+    );
+    assert_eq!(
+        codes_by_line("export const alpha = 1;\nexport var alpha = 2;\n"),
+        vec![(1, vec![2451]), (2, vec![2451])],
+    );
+}
+
+/// Three exported `var`s never collide, so the binder pass is silent and only
+/// the exported pass fires.
+#[test]
+fn three_exported_vars_are_ts2323_only() {
+    assert_eq!(
+        codes_by_line("export var alpha = 1;\nexport var alpha = 2;\nexport var alpha = 3;\n"),
+        vec![(1, vec![2323]), (2, vec![2323]), (3, vec![2323])],
+    );
+}
+
+/// Negative control, module scope: without `export` the exported pass cannot
+/// fire, so the same var/let/var shape reports the binder pass only — and the
+/// trailing `var` is clean.
+#[test]
+fn unexported_var_let_var_reports_the_binder_pass_only() {
+    assert_eq!(
+        codes_by_line("export {};\nvar alpha = 1;\nlet alpha = 2;\nvar alpha = 3;\n"),
+        vec![(2, vec![2300]), (3, vec![2300])],
+    );
+}
+
+/// Negative control: `var` is redeclarable, so a pure unexported `var`/`var`
+/// group is legal and reports nothing at all.
+#[test]
+fn unexported_var_var_is_legal() {
+    assert_eq!(
+        codes_by_line("export {};\nvar alpha = 1;\nvar alpha = 2;\n"),
+        Vec::<(u32, Vec<u32>)>::new(),
+    );
+}
+
+/// Namespace-internal `export var` merges never reach the module's export
+/// table, so the exported pass stays off (see #16158/#16161) while the binder
+/// pass still reports the `let` collision.
+#[test]
+fn namespace_internal_var_let_var_reports_the_binder_pass_only() {
+    assert_eq!(
+        codes_by_line(
+            "export {};\nnamespace Outer {\n  export var alpha = 1;\n  export let alpha = 2;\n  export var alpha = 3;\n}\n"
+        ),
+        vec![(3, vec![2300]), (4, vec![2300])],
+    );
+}
+
+/// Function-scope control: the same collision walk runs inside a function
+/// body, where no declaration can be exported.
+#[test]
+fn function_scope_var_let_var_reports_the_binder_pass_only() {
+    assert_eq!(
+        codes_by_line(
+            "export {};\nfunction outer() {\n  var alpha = 1;\n  let alpha = 2;\n  var alpha = 3;\n}\n"
+        ),
+        vec![(3, vec![2300]), (4, vec![2300])],
+    );
+}
+
+/// Fallback control: once a non-variable declaration joins the group the
+/// family no longer applies and the general selection chain owns the report —
+/// TS2300 across the group, with no TS2323 for the `var`/`var` pair.
+#[test]
+fn merged_function_declaration_leaves_the_variable_family() {
+    assert_eq!(
+        codes_by_line("export var alpha = 1;\nexport var alpha = 2;\nexport function alpha() {}\n"),
+        vec![(1, vec![2300]), (2, vec![2300]), (3, vec![2300])],
+    );
+}

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -1661,6 +1661,22 @@ impl<'a> CheckerState<'a> {
                 && !has_block_scoped_conflict
                 && !has_remote_block_scoped_conflict;
 
+            // A symbol whose declarations are all plain `var`/`let`/`const`
+            // goes through tsc's two independent reporting passes, which can
+            // co-emit TS2323 and TS2300 on one declaration and give the two
+            // codes different footprints over the group. The single-code
+            // selection below cannot express either, so that family is modelled
+            // directly in `duplicate_identifiers_variable_family`.
+            if self.try_emit_variable_redeclaration_family(
+                &declarations,
+                &conflicts,
+                &name,
+                is_external_module,
+                force2300 || has_umd_global_value_conflict || has_merge_visibility_diagnostic,
+            ) {
+                continue;
+            }
+
             let (message, code) = if !has_non_block_scoped && !force2300
                 || has_umd_global_value_conflict
             {

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_variable_family.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_variable_family.rs
@@ -1,0 +1,227 @@
+//! Variable-redeclaration reporting for a symbol whose declarations are *all*
+//! plain variable declarations (`var`/`let`/`const`).
+//!
+//! `tsc` reaches this family through **two independent passes**, so one
+//! declaration can carry two codes at once and the two codes can cover
+//! different subsets of the declaration list:
+//!
+//! 1. The binder's collision pass (`declareSymbol`). Each declaration is
+//!    tested against the *surviving* symbol's accumulated flags. On a
+//!    collision the message (TS2451 when the surviving symbol is already
+//!    block-scoped, otherwise TS2300) is reported on every declaration
+//!    recorded on the surviving symbol so far **and** on the colliding
+//!    declaration — and then the colliding declaration is attached to a fresh
+//!    throwaway symbol that never re-enters the symbol table. The surviving
+//!    symbol therefore keeps its original flags and its declaration list only
+//!    grows with declarations that did *not* collide.
+//! 2. The exported-variable pass (TS2323), which reads the surviving symbol
+//!    and reports on each of its declarations when it is exported and has
+//!    more than one.
+//!
+//! The consequence is that `export var a; export let a; export var a;` reports
+//! TS2300 on lines 1-2 (binder pass, whose surviving symbol at that point was
+//! just line 1) and TS2323 on lines 1 and 3 (exported pass, whose surviving
+//! symbol ends up holding both `var` declarations because the third one never
+//! collided with the function-scoped survivor).
+//!
+//! A single-code-per-symbol `if`-chain cannot express either half: not the
+//! co-emission, and not the differing footprints. This module models the two
+//! passes directly for the sub-family where it is safe and self-contained —
+//! every declaration local, a plain variable, part of the conflict set, and
+//! uniformly exported or uniformly local. Anything else falls back to the
+//! general selection chain in `duplicate_identifiers.rs`.
+//!
+//! Every expectation is pinned against `tsc` 7.0.2 with
+//! `--noEmit --strict --pretty false --lib es2015 --target es2015`.
+
+use super::duplicate_identifiers::DuplicateDeclarationOrigin;
+use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+use crate::state::CheckerState;
+use rustc_hash::FxHashSet;
+use tsz_binder::symbol_flags;
+use tsz_parser::parser::NodeIndex;
+
+/// One entry of the symbol's declaration list, in the shape
+/// `check_duplicate_identifiers` collects it.
+type DuplicateDeclaration = (NodeIndex, u32, bool, bool, DuplicateDeclarationOrigin);
+
+impl CheckerState<'_> {
+    /// Emit the variable-redeclaration diagnostics for `declarations` the way
+    /// `tsc`'s two passes do, returning `true` when this module owns the
+    /// reporting for the symbol and the caller must not run its own selection
+    /// chain.
+    ///
+    /// Returns `false` — leaving the existing behaviour untouched — whenever
+    /// the symbol is outside the modelled sub-family, or when the model
+    /// produces no diagnostics at all (`var a; var a;` is a legal
+    /// redeclaration, and suppressing an unrelated pre-existing diagnostic is
+    /// not this module's job).
+    pub(super) fn try_emit_variable_redeclaration_family(
+        &mut self,
+        declarations: &[DuplicateDeclaration],
+        conflicts: &FxHashSet<NodeIndex>,
+        name: &str,
+        is_external_module: bool,
+        suppressed_by_caller: bool,
+    ) -> bool {
+        if suppressed_by_caller || conflicts.is_empty() || declarations.len() < 2 {
+            return false;
+        }
+
+        let Some(ordered) = self.variable_family_declarations(declarations, conflicts) else {
+            return false;
+        };
+        let all_exported = declarations
+            .iter()
+            .all(|(_, _, _, is_exported, _)| *is_exported);
+        let none_exported = declarations
+            .iter()
+            .all(|(_, _, _, is_exported, _)| !*is_exported);
+        // Mixed exportedness routes through `tsc`'s *separate* export table as
+        // well as the local one, which gives the two passes different inputs
+        // and pulls TS2395 in alongside. That is a different family; leave it.
+        if !all_exported && !none_exported {
+            return false;
+        }
+        // The exported-variable pass reads the *module's* export table, so a
+        // namespace-internal `export var` merge never reaches it — tsc accepts
+        // those (see #16158/#16161). The binder pass below still runs for them.
+        let exported_pass_applies = all_exported
+            && is_external_module
+            && declarations
+                .iter()
+                .all(|(decl_idx, _, _, _, _)| self.get_enclosing_namespace(*decl_idx).is_none());
+
+        let reports = variable_family_reports(&ordered, exported_pass_applies);
+        if reports.is_empty() {
+            return false;
+        }
+
+        for (decl_idx, code) in reports {
+            let message = match code {
+                diagnostic_codes::CANNOT_REDECLARE_EXPORTED_VARIABLE => format_message(
+                    diagnostic_messages::CANNOT_REDECLARE_EXPORTED_VARIABLE,
+                    &[name],
+                ),
+                diagnostic_codes::CANNOT_REDECLARE_BLOCK_SCOPED_VARIABLE => format_message(
+                    diagnostic_messages::CANNOT_REDECLARE_BLOCK_SCOPED_VARIABLE,
+                    &[name],
+                ),
+                _ => format_message(diagnostic_messages::DUPLICATE_IDENTIFIER, &[name]),
+            };
+            let error_node = self.get_declaration_name_node(decl_idx).unwrap_or(decl_idx);
+            self.error_at_node(error_node, &message, code);
+        }
+        true
+    }
+
+    /// Validate that every declaration belongs to the modelled sub-family and
+    /// return them ordered by source position as `(declaration, flags)`.
+    ///
+    /// The family is deliberately narrow: a plain local variable declaration
+    /// carrying no symbol flag other than `FUNCTION_SCOPED_VARIABLE` or
+    /// `BLOCK_SCOPED_VARIABLE`, sourced from the symbol's own declaration list,
+    /// and part of the conflict set. Merged functions, classes, enums, aliases,
+    /// namespaces, accessors and cross-file declarations all leave the family.
+    fn variable_family_declarations(
+        &self,
+        declarations: &[DuplicateDeclaration],
+        conflicts: &FxHashSet<NodeIndex>,
+    ) -> Option<Vec<(NodeIndex, u32)>> {
+        let mut ordered: Vec<(NodeIndex, u32, u32)> = Vec::with_capacity(declarations.len());
+        for (decl_idx, flags, is_local, _, origin) in declarations {
+            if !*is_local
+                || *origin != DuplicateDeclarationOrigin::SymbolDeclaration
+                || !conflicts.contains(decl_idx)
+            {
+                return None;
+            }
+            if (flags & !symbol_flags::VARIABLE) != 0 || (flags & symbol_flags::VARIABLE) == 0 {
+                return None;
+            }
+            // `var` shadowing a block-scoped binding in the same scope is
+            // TS2481's job, reported elsewhere; do not double-report it here.
+            if self.is_var_shadowing_block_scoped_in_same_scope(*decl_idx) {
+                return None;
+            }
+            let pos = self.ctx.arena.get(*decl_idx)?.pos;
+            if ordered.iter().any(|(idx, _, _)| *idx == *decl_idx) {
+                return None;
+            }
+            ordered.push((*decl_idx, *flags, pos));
+        }
+        // Two declarations at the same position mean the list is not a faithful
+        // source-order view of the symbol, and the binder pass depends on order.
+        ordered.sort_by_key(|(_, _, pos)| *pos);
+        if ordered.windows(2).any(|w| w[0].2 == w[1].2) {
+            return None;
+        }
+        Some(
+            ordered
+                .into_iter()
+                .map(|(idx, flags, _)| (idx, flags))
+                .collect(),
+        )
+    }
+}
+
+/// Replay `tsc`'s two passes over `ordered` (source order) and return the
+/// `(declaration, code)` pairs to report, deduplicated, in source order with
+/// ascending code per declaration.
+fn variable_family_reports(
+    ordered: &[(NodeIndex, u32)],
+    exported_pass_applies: bool,
+) -> Vec<(NodeIndex, u32)> {
+    let Some(((first_idx, first_flags), rest)) = ordered.split_first() else {
+        return Vec::new();
+    };
+
+    // Pass 1: the binder's collision walk. `surviving` is the symbol that stays
+    // in the symbol table; colliding declarations are reported and dropped onto
+    // a throwaway symbol, so they neither join the list nor widen the flags.
+    let mut surviving: Vec<NodeIndex> = vec![*first_idx];
+    let mut surviving_flags = *first_flags;
+    let mut reports: Vec<(NodeIndex, u32)> = Vec::new();
+
+    for (decl_idx, flags) in rest {
+        let excludes = if (flags & symbol_flags::BLOCK_SCOPED_VARIABLE) != 0 {
+            symbol_flags::BLOCK_SCOPED_VARIABLE_EXCLUDES
+        } else {
+            symbol_flags::FUNCTION_SCOPED_VARIABLE_EXCLUDES
+        };
+        if (surviving_flags & excludes) == 0 {
+            surviving.push(*decl_idx);
+            surviving_flags |= flags;
+            continue;
+        }
+        let code = if (surviving_flags & symbol_flags::BLOCK_SCOPED_VARIABLE) != 0 {
+            diagnostic_codes::CANNOT_REDECLARE_BLOCK_SCOPED_VARIABLE
+        } else {
+            diagnostic_codes::DUPLICATE_IDENTIFIER
+        };
+        reports.extend(surviving.iter().map(|idx| (*idx, code)));
+        reports.push((*decl_idx, code));
+    }
+
+    // Pass 2: the exported-variable pass, reading the surviving symbol only.
+    if exported_pass_applies && surviving.len() > 1 {
+        reports.extend(
+            surviving
+                .iter()
+                .map(|idx| (*idx, diagnostic_codes::CANNOT_REDECLARE_EXPORTED_VARIABLE)),
+        );
+    }
+
+    let order: Vec<NodeIndex> = ordered.iter().map(|(idx, _)| *idx).collect();
+    reports.sort_by_key(|(idx, code)| {
+        (
+            order
+                .iter()
+                .position(|candidate| candidate == idx)
+                .unwrap_or(usize::MAX),
+            *code,
+        )
+    });
+    reports.dedup();
+    reports
+}

--- a/crates/tsz-checker/src/types/type_checking/mod.rs
+++ b/crates/tsz-checker/src/types/type_checking/mod.rs
@@ -27,6 +27,7 @@ mod duplicate_identifiers_global_augmentation;
 mod duplicate_identifiers_helpers;
 mod duplicate_identifiers_remote_lib;
 mod duplicate_identifiers_symbol_set;
+mod duplicate_identifiers_variable_family;
 mod duplicate_index_signatures;
 mod duplicate_property_modifiers;
 mod global;


### PR DESCRIPTION
Closes #16165. Closes #16166.

## Structural rule

**When a symbol's declarations are all plain `var`/`let`/`const`, `tsc` reports them through two independent passes, so one declaration can carry TS2323 *and* TS2300 at once and the two codes cover different subsets of the group; tsz now does the same through the checker's duplicate-identifier reporter (`crates/tsz-checker/src/types/type_checking/duplicate_identifiers_variable_family.rs`).**

Wrong semantic operation: **diagnostic selection/display**, not relation or inference. tsz picked exactly one code per symbol group from a mutually-exclusive `if`-chain. No predicate refinement inside that chain can produce co-emission, and none can give two codes different footprints — the reporting *shape* had to change.

### The two passes

1. **Binder collision pass** (`declareSymbol`). Each declaration is tested against the **surviving** symbol's accumulated flags. On a collision the message — TS2451 when the survivor is already block-scoped, TS2300 otherwise — is reported on every declaration recorded on the survivor *so far* **plus** the colliding declaration; the colliding declaration is then attached to a fresh throwaway symbol that never re-enters the symbol table. The survivor therefore keeps its original flags, and its declaration list only grows with declarations that did **not** collide.
2. **Exported-variable pass** (TS2323), which reads the survivor alone and reports on each of its declarations when the module exports it and it holds more than one.

That is why `export var a; export let a; export var a;` gives TS2300 on lines 1-2 and TS2323 on lines 1 and 3: the trailing `var` never collided with the function-scoped survivor, so it joined it and the binder pass never saw it.

### This also settles #16166 against #16165

#16166 proposed that TS2323 is awarded **per conflicting pair**. That is refuted by `export let a; export var a; export var a;` → `3× TS2451`, **no** TS2323, even though an exported `var`/`var` pair exists (declarations 2 and 3). Under the two-pass model the `let` is the survivor, every later declaration collides with it, and the survivor never grows past one declaration — so the exported pass has nothing to report. Both issues describe the same family; the model above explains **all 53** oracle rows below, including the ones each issue got wrong.

## Oracle

Pinned `typescript@7.0.2` (`node node_modules/typescript/lib/tsc.js --noEmit --strict --pretty false --lib es2015 --target es2015`), **positions recorded, not code sets** — a code-set comparison cannot see co-emission, which is why this family stayed invisible through #16161 and #16163. Exhaustive over `{var,let,const}` at lengths 2 and 3 and `{var,let}` at length 4 (53 rows), all-`export`ed. Representative rows, before → after:

| source (all `export`ed) | tsc 7.0.2 | tsz before | tsz after |
| --- | --- | --- | --- |
| `var` `let` `var` | `1: 2300+2323` `2: 2300` `3: 2323` | `3× 2300` | ✅ matches |
| `var` `var` `let` | `1: 2300+2323` `2: 2300+2323` `3: 2300` | `3× 2300` | ✅ matches |
| `var` `const` `var` | `1: 2300+2323` `2: 2300` `3: 2323` | `3× 2300` | ✅ matches |
| `var` `let` `let` `var` | `1: 2300+2323` `2: 2300` `3: 2300` `4: 2323` | `4× 2300` | ✅ matches |
| `var` `let` `var` `let` | `1: 2300+2323` `2: 2300` `3: 2300+2323` `4: 2300` | `4× 2300` | ✅ matches |
| `var` `var` `let` `var` | `1: 2300+2323` `2: 2300+2323` `3: 2300` `4: 2323` | `4× 2300` | ✅ matches |
| `let` `var` `var` | `3× 2451` | `3× 2451` | unchanged |
| `var` `let` `let` | `3× 2300` | `3× 2300` | unchanged |
| `var` `var` / `var` `let` / `let` `var` / `const` `var` | #16163's rows | correct | unchanged |

Row 4 is the one that rules out a flat "TS2300 lands on every declaration" rule: line 4 carries **no** TS2300, because it rejoined the survivor instead of colliding.

## Scope and fallback

The family is deliberately narrow, and everything outside it falls through to the existing selection chain **untouched**:

- every declaration local, from the symbol's own declaration list, and in the conflict set;
- every declaration a plain variable carrying no symbol flag other than `FUNCTION_SCOPED_VARIABLE`/`BLOCK_SCOPED_VARIABLE` (merged functions, classes, enums, aliases, namespaces, accessors all leave);
- uniform exportedness. Mixed exportedness routes through tsc's *separate* export table as well as the local one — the two passes get different inputs and TS2395 joins in. Oracled but deliberately **not** implemented here; filed as a follow-up.
- namespace-internal `export var` merges keep #16161's module-export gate: the exported pass stays off (tsc accepts them), while the binder pass still runs. Oracle-confirmed: `namespace N { export var a; export let a; export var a; }` → TS2300 on the first two only.
- `var` shadowing a block-scoped binding in the same scope stays TS2481's job.

No identifier, alias, property or file-name string drives any decision; the collision test is `surviving_flags & symbol_flags::{FUNCTION_SCOPED,BLOCK_SCOPED}_VARIABLE_EXCLUDES`, the binder's own constants. One test repeats the headline row under a renamed binder to pin that.

## Goal
Goal: hold

## Verification
- **`cargo test -p tsz-checker --lib` (nextest is not installed in this container): 8900 tests — 8896 pass, 1 baselined `ts2303_tests::recursive_export_assignment_self_import_reports_ts2303`, 3 need `RUST_MIN_STACK` in this debug Linux container. Zero delta attributable to this diff.** The 3 are `class_static_init_self_new_tests::three_class_hierarchy_with_instance_field_aliases_and_static_create`, `contextual_return_wrapper_tests::wrapped_this_return_annotations_contextualize_generic_factories` and `ts2589_tests::recursive_conditional_alias_omitted_default_transform_emits_definition_ts2589`: the first aborts with `has overflowed its stack` at the default 8 MiB debug frame size, and all three pass in 19.34s under `RUST_MIN_STACK=134217728`. None touches variable redeclaration; this is the same debug/Linux-container depth family as #16089, not a regression here.
- New suite `ts2323_variable_redeclaration_two_pass_tests`: **15/15 pass**, every expectation pinned per-line against `tsc` 7.0.2. Includes 6 negative/fallback controls — unexported var/let/var, legal unexported `var`/`var`, namespace-internal, function-scope, merged `function` leaving the family, and all four of #16163's two-declaration rows held unchanged.
- `cargo clippy -p tsz-checker --lib --all-targets`: clean (warnings denied).
- `cargo fmt --all`: clean.
- Conformance: **not run** — this container has no `TypeScript/tests/cases` checkout, and a two-sided `compare-to-parent.sh` needs two release builds plus two snapshots. Static evidence instead: the committed `conformance-detail.json` has **zero** failing rows mentioning TS2323, and of the 37 failing rows touching TS2300/TS2451 none is a pure-variable redeclaration group. A warm-corpus seat should confirm before merge; the fallback is designed so that any group outside the modelled family reports byte-identically to main.
- Emit unaffected by construction: the change adds no semantic computation and touches only diagnostic emission.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Aster