### PR TITLE
fix(checker): model tsc's ordered, first-error-wins private-name modifier walk (TS18010/TS18019)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1596,6 +1596,9 @@ mod private_brands;
 #[path = "tests/private_member_relation_routing_arch_tests.rs"]
 mod private_member_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/private_name_modifier_grammar_order_tests.rs"]
+mod private_name_modifier_grammar_order_tests;
+#[cfg(test)]
 #[path = "tests/private_optional_field_undefined_tests.rs"]
 mod private_optional_field_undefined_tests;
 #[cfg(test)]
@@ -1754,6 +1757,7 @@ mod ts1170_computed_property_syntactic_form_tests;
 #[cfg(test)]
 #[path = "tests/ts1361_ambient_computed_property_name_tests.rs"]
 mod ts1361_ambient_computed_property_name_tests;
+
 #[cfg(test)]
 #[path = "tests/ts18010_jsdoc_tag_anchor_tests.rs"]
 mod ts18010_jsdoc_tag_anchor_tests;

--- a/crates/tsz-checker/src/state/state_checking/class.rs
+++ b/crates/tsz-checker/src/state/state_checking/class.rs
@@ -470,7 +470,11 @@ impl<'a> CheckerState<'a> {
                         );
                     }
 
-                    // Get member modifiers for TS18010/TS18019 checks
+                    // Get member modifiers for the TS18010/TS18019 walk. Every
+                    // class element that can be named by a private identifier
+                    // and can carry modifiers belongs here — a private-named
+                    // method or accessor is as capable of carrying `abstract`
+                    // as a property is.
                     let member_modifiers: Option<&Option<tsz_parser::parser::NodeList>> =
                         match member_node.kind {
                             syntax_kind_ext::PROPERTY_DECLARATION => self
@@ -492,84 +496,15 @@ impl<'a> CheckerState<'a> {
                         };
 
                     if let Some(modifiers) = member_modifiers {
-                        // TS18010: An accessibility modifier cannot be used with a private identifier.
-                        // tsc points the error at the modifier node, not the member.
-                        let accessibility_modifier = self
-                            .ctx
-                            .arena
-                            .find_modifier(modifiers, tsz_scanner::SyntaxKind::PublicKeyword)
-                            .or_else(|| {
-                                self.ctx.arena.find_modifier(
-                                    modifiers,
-                                    tsz_scanner::SyntaxKind::PrivateKeyword,
-                                )
-                            })
-                            .or_else(|| {
-                                self.ctx.arena.find_modifier(
-                                    modifiers,
-                                    tsz_scanner::SyntaxKind::ProtectedKeyword,
-                                )
-                            });
-                        // In JS files, accessibility modifiers come from JSDoc tags
-                        // (@public, @private, @protected) rather than AST modifiers.
-                        let has_jsdoc_accessibility = accessibility_modifier.is_none()
-                            && self.is_js_file()
-                            && self.has_jsdoc_accessibility_modifier(member_idx);
-                        if let Some(mod_idx) = accessibility_modifier {
-                            self.error_at_node(
-                                mod_idx,
-                                diagnostic_messages::AN_ACCESSIBILITY_MODIFIER_CANNOT_BE_USED_WITH_A_PRIVATE_IDENTIFIER,
-                                diagnostic_codes::AN_ACCESSIBILITY_MODIFIER_CANNOT_BE_USED_WITH_A_PRIVATE_IDENTIFIER,
-                            );
-                        } else if has_jsdoc_accessibility {
-                            // tsc anchors TS18010 at the `@public`/`@private`/
-                            // `@protected` tag inside the JSDoc comment for JS
-                            // files. Recover that span if present; fall back
-                            // to the member node otherwise.
-                            if let Some((start, len)) =
-                                self.jsdoc_accessibility_tag_span(member_idx)
-                            {
-                                self.error_at_position(
-                                    start,
-                                    len,
-                                    diagnostic_messages::AN_ACCESSIBILITY_MODIFIER_CANNOT_BE_USED_WITH_A_PRIVATE_IDENTIFIER,
-                                    diagnostic_codes::AN_ACCESSIBILITY_MODIFIER_CANNOT_BE_USED_WITH_A_PRIVATE_IDENTIFIER,
-                                );
-                            } else {
-                                self.error_at_node(
-                                    member_idx,
-                                    diagnostic_messages::AN_ACCESSIBILITY_MODIFIER_CANNOT_BE_USED_WITH_A_PRIVATE_IDENTIFIER,
-                                    diagnostic_codes::AN_ACCESSIBILITY_MODIFIER_CANNOT_BE_USED_WITH_A_PRIVATE_IDENTIFIER,
-                                );
-                            }
-                        }
-
-                        // TS18019: 'declare'/'abstract' modifier cannot be used with a private identifier.
-                        // Only applies to property declarations. tsc points at the modifier node.
-                        if member_node.kind == syntax_kind_ext::PROPERTY_DECLARATION {
-                            if let Some(mod_idx) = self
-                                .ctx
-                                .arena
-                                .find_modifier(modifiers, tsz_scanner::SyntaxKind::DeclareKeyword)
-                            {
-                                self.error_at_node_msg(
-                                    mod_idx,
-                                    diagnostic_codes::MODIFIER_CANNOT_BE_USED_WITH_A_PRIVATE_IDENTIFIER,
-                                    &["declare"],
-                                );
-                            }
-                            if let Some(mod_idx) = self
-                                .ctx
-                                .arena
-                                .find_modifier(modifiers, tsz_scanner::SyntaxKind::AbstractKeyword)
-                            {
-                                self.error_at_node_msg(
-                                    mod_idx,
-                                    diagnostic_codes::MODIFIER_CANNOT_BE_USED_WITH_A_PRIVATE_IDENTIFIER,
-                                    &["abstract"],
-                                );
-                            }
-                        }
+                        // TS18010/TS18019 follow tsc's source-ordered,
+                        // first-error-wins modifier walk; see
+                        // `class_private_name_modifiers`.
+                        self.check_private_name_modifier_grammar(
+                            member_idx,
+                            member_node.kind,
+                            modifiers,
+                            is_abstract_class,
+                        );
                     }
                 }
 

--- a/crates/tsz-checker/src/state/state_checking/class_private_name_modifiers.rs
+++ b/crates/tsz-checker/src/state/state_checking/class_private_name_modifiers.rs
@@ -1,0 +1,156 @@
+//! Modifier grammar for class members named by a private identifier
+//! (`#name`): `TS18010` and `TS18019`.
+//!
+//! `tsc` reports these two codes from `checkGrammarModifiers`, which walks a
+//! member's modifier list **in source order** and **returns at the first
+//! error**. A member therefore reports at most one modifier-grammar
+//! diagnostic, and *which* one it reports depends on the order the modifiers
+//! were written in:
+//!
+//! ```text
+//! abstract class C { abstract static #x: number; }   // TS18019 at `abstract`
+//! abstract class C { static abstract #x: number; }   // TS1243  at `abstract`
+//! ```
+//!
+//! Both spellings declare the same member; only the walk order differs. The
+//! same rule explains why an `abstract` member of a *non*-abstract class never
+//! reports `TS18019` (the `TS1244`/`TS1253` container check fires first and
+//! returns), and why `declare abstract #x` reports one `TS18019` rather than
+//! two.
+//!
+//! This module owns the private-identifier arm of that walk. Modifier errors
+//! that preempt it are reported elsewhere — container-abstractness in
+//! `class.rs`, modifier ordering (`TS1029`) and modifier pairs (`TS1243`) in
+//! the parser — so this walk stops without reporting when it reaches a
+//! modifier whose own error `tsc` would have emitted first.
+
+use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+use crate::state::CheckerState;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_parser::parser::{NodeIndex, NodeList};
+use tsz_scanner::SyntaxKind;
+
+/// Which private-identifier diagnostic a modifier walk settled on, if any.
+enum PrivateNameModifierError {
+    /// `TS18010`, anchored at an accessibility modifier.
+    Accessibility(NodeIndex),
+    /// `TS18019`, anchored at `abstract`/`declare` (carried for the message).
+    Incompatible(NodeIndex, &'static str),
+    /// A different modifier error preempts the private-identifier check and is
+    /// reported by another owner; report nothing here.
+    PreemptedElsewhere,
+}
+
+impl CheckerState<'_> {
+    /// Report `TS18010`/`TS18019` for a private-named class member, following
+    /// `tsc`'s source-ordered, first-error-wins modifier walk.
+    ///
+    /// `member_kind` is the member's `SyntaxKind`; `is_abstract_class` is the
+    /// containing class's own abstractness, which decides whether an
+    /// `abstract` modifier reaches the private-identifier check at all.
+    pub(super) fn check_private_name_modifier_grammar(
+        &mut self,
+        member_idx: NodeIndex,
+        member_kind: u16,
+        modifiers: &Option<NodeList>,
+        is_abstract_class: bool,
+    ) {
+        match self.walk_private_name_modifiers(member_kind, modifiers, is_abstract_class) {
+            Some(PrivateNameModifierError::Accessibility(mod_idx)) => {
+                self.error_at_node(
+                    mod_idx,
+                    diagnostic_messages::AN_ACCESSIBILITY_MODIFIER_CANNOT_BE_USED_WITH_A_PRIVATE_IDENTIFIER,
+                    diagnostic_codes::AN_ACCESSIBILITY_MODIFIER_CANNOT_BE_USED_WITH_A_PRIVATE_IDENTIFIER,
+                );
+            }
+            Some(PrivateNameModifierError::Incompatible(mod_idx, keyword)) => {
+                self.error_at_node_msg(
+                    mod_idx,
+                    diagnostic_codes::MODIFIER_CANNOT_BE_USED_WITH_A_PRIVATE_IDENTIFIER,
+                    &[keyword],
+                );
+            }
+            Some(PrivateNameModifierError::PreemptedElsewhere) => {}
+            None => self.report_jsdoc_accessibility_on_private_name(member_idx),
+        }
+    }
+
+    /// The walk itself: returns the first modifier outcome, or `None` when no
+    /// modifier in the list interacts with the private identifier.
+    fn walk_private_name_modifiers(
+        &self,
+        member_kind: u16,
+        modifiers: &Option<NodeList>,
+        is_abstract_class: bool,
+    ) -> Option<PrivateNameModifierError> {
+        let Some(mods) = modifiers else {
+            return None;
+        };
+        // `declare` is only a valid class-element modifier on a property; on a
+        // method or accessor it is TS1031 ("cannot appear on class elements of
+        // this kind"), which tsc reports instead of TS18019.
+        let declare_is_valid_here = member_kind == syntax_kind_ext::PROPERTY_DECLARATION;
+        let mut seen_static = false;
+
+        for &mod_idx in &mods.nodes {
+            let Some(mod_node) = self.ctx.arena.get(mod_idx) else {
+                continue;
+            };
+            let kind = mod_node.kind;
+            if kind == SyntaxKind::PublicKeyword as u16
+                || kind == SyntaxKind::PrivateKeyword as u16
+                || kind == SyntaxKind::ProtectedKeyword as u16
+            {
+                // An accessibility modifier must precede `static`; written
+                // after it, tsc reports the ordering error (TS1029, owned by
+                // the parser) and returns before reaching TS18010.
+                return Some(if seen_static {
+                    PrivateNameModifierError::PreemptedElsewhere
+                } else {
+                    PrivateNameModifierError::Accessibility(mod_idx)
+                });
+            } else if kind == SyntaxKind::StaticKeyword as u16 {
+                seen_static = true;
+            } else if kind == SyntaxKind::AbstractKeyword as u16 {
+                // `abstract` on a member of a non-abstract class is
+                // TS1244/TS1253, and `static` before `abstract` is TS1243.
+                // Either way tsc returns before the private-identifier check.
+                return Some(if !is_abstract_class || seen_static {
+                    PrivateNameModifierError::PreemptedElsewhere
+                } else {
+                    PrivateNameModifierError::Incompatible(mod_idx, "abstract")
+                });
+            } else if kind == SyntaxKind::DeclareKeyword as u16 {
+                return Some(if declare_is_valid_here {
+                    PrivateNameModifierError::Incompatible(mod_idx, "declare")
+                } else {
+                    PrivateNameModifierError::PreemptedElsewhere
+                });
+            }
+        }
+        None
+    }
+
+    /// JS files carry accessibility through JSDoc tags (`@public`/`@private`/
+    /// `@protected`) rather than AST modifiers. tsc anchors TS18010 at the tag
+    /// itself; fall back to the member when the span cannot be recovered.
+    fn report_jsdoc_accessibility_on_private_name(&mut self, member_idx: NodeIndex) {
+        if !self.is_js_file() || !self.has_jsdoc_accessibility_modifier(member_idx) {
+            return;
+        }
+        if let Some((start, len)) = self.jsdoc_accessibility_tag_span(member_idx) {
+            self.error_at_position(
+                start,
+                len,
+                diagnostic_messages::AN_ACCESSIBILITY_MODIFIER_CANNOT_BE_USED_WITH_A_PRIVATE_IDENTIFIER,
+                diagnostic_codes::AN_ACCESSIBILITY_MODIFIER_CANNOT_BE_USED_WITH_A_PRIVATE_IDENTIFIER,
+            );
+        } else {
+            self.error_at_node(
+                member_idx,
+                diagnostic_messages::AN_ACCESSIBILITY_MODIFIER_CANNOT_BE_USED_WITH_A_PRIVATE_IDENTIFIER,
+                diagnostic_codes::AN_ACCESSIBILITY_MODIFIER_CANNOT_BE_USED_WITH_A_PRIVATE_IDENTIFIER,
+            );
+        }
+    }
+}

--- a/crates/tsz-checker/src/state/state_checking/mod.rs
+++ b/crates/tsz-checker/src/state/state_checking/mod.rs
@@ -3,6 +3,7 @@
 pub(crate) mod class;
 mod class_decorators;
 mod class_heritage_diagnostics;
+mod class_private_name_modifiers;
 #[cfg(test)]
 mod class_tests;
 mod core;

--- a/crates/tsz-checker/src/tests/private_name_modifier_grammar_order_tests.rs
+++ b/crates/tsz-checker/src/tests/private_name_modifier_grammar_order_tests.rs
@@ -1,0 +1,234 @@
+//! `TS18010`/`TS18019` on class members named by a private identifier.
+//!
+//! `tsc` reports both codes from `checkGrammarModifiers`, which walks a
+//! member's modifier list in source order and returns at the first error. Two
+//! consequences drive every expectation below, and each was pinned against
+//! `typescript@7.0.2`:
+//!
+//! 1. **At most one** private-identifier diagnostic per member, anchored at the
+//!    first modifier that conflicts — `declare abstract #x` reports one
+//!    `TS18019`, not two.
+//! 2. A modifier error that `tsc` reaches **earlier in the walk** preempts the
+//!    private-identifier check entirely: container-abstractness
+//!    (`TS1244`/`TS1253`), modifier ordering (`TS1029`) and modifier pairs
+//!    (`TS1243`) all win when they come first.
+//!
+//! Member kind is not part of the rule. A private-named method or accessor
+//! carrying `abstract` reports `TS18019` exactly as a property does.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+fn count(source: &str, code: u32) -> usize {
+    codes(source).iter().filter(|&&c| c == code).count()
+}
+
+/// Underlined source text of the single diagnostic with `code`.
+fn anchor(source: &str, code: u32) -> String {
+    let diags = check_source_diagnostics(source);
+    let matching: Vec<_> = diags.iter().filter(|d| d.code == code).collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected exactly one TS{code}, got: {diags:#?}"
+    );
+    let d = matching[0];
+    source[d.start as usize..(d.start + d.length) as usize].to_string()
+}
+
+const TS18010: u32 = 18010;
+const TS18019: u32 = 18019;
+const TS1244: u32 = 1244;
+const TS1253: u32 = 1253;
+
+// --- member kind is not part of the rule -----------------------------------
+
+#[test]
+fn abstract_on_private_named_method_reports_ts18019() {
+    let source = "abstract class C { abstract #m(): void; }\n";
+    assert_eq!(count(source, TS18019), 1, "codes: {:?}", codes(source));
+    assert_eq!(anchor(source, TS18019), "abstract");
+}
+
+#[test]
+fn abstract_on_private_named_get_accessor_reports_ts18019() {
+    let source = "abstract class C { abstract get #x(): number; }\n";
+    assert_eq!(count(source, TS18019), 1, "codes: {:?}", codes(source));
+}
+
+#[test]
+fn abstract_on_private_named_set_accessor_reports_ts18019() {
+    let source = "abstract class C { abstract set #x(v: number); }\n";
+    assert_eq!(count(source, TS18019), 1, "codes: {:?}", codes(source));
+}
+
+#[test]
+fn abstract_on_private_named_auto_accessor_reports_ts18019() {
+    let source = "abstract class C { abstract accessor #x: number; }\n";
+    assert_eq!(count(source, TS18019), 1, "codes: {:?}", codes(source));
+}
+
+#[test]
+fn each_abstract_private_named_member_reports_its_own_ts18019() {
+    let source = "abstract class C {\n    abstract #m(): void;\n    abstract get #g(): number;\n    abstract set #s(v: number);\n    abstract #p: number;\n}\n";
+    assert_eq!(count(source, TS18019), 4, "codes: {:?}", codes(source));
+}
+
+/// Anti-hardcoding cover: the rule is structural, so renaming every binder
+/// (class and members alike) must not change the count.
+#[test]
+fn renamed_binders_report_the_same_ts18019_count() {
+    let source = "abstract class Renamed {\n    abstract #alpha(): void;\n    abstract get #bravo(): number;\n}\n";
+    assert_eq!(count(source, TS18019), 2, "codes: {:?}", codes(source));
+}
+
+// --- an earlier error in the walk preempts the private-identifier check -----
+
+#[test]
+fn abstract_private_named_property_in_non_abstract_class_reports_only_ts1253() {
+    let source = "class C { abstract #x: number; }\n";
+    assert_eq!(count(source, TS1253), 1, "codes: {:?}", codes(source));
+    assert_eq!(
+        count(source, TS18019),
+        0,
+        "TS1253 preempts TS18019; codes: {:?}",
+        codes(source)
+    );
+}
+
+#[test]
+fn abstract_private_named_method_in_non_abstract_class_reports_only_ts1244() {
+    let source = "class C { abstract #m(): void; }\n";
+    assert_eq!(count(source, TS1244), 1, "codes: {:?}", codes(source));
+    assert_eq!(count(source, TS18019), 0, "codes: {:?}", codes(source));
+}
+
+#[test]
+fn abstract_private_named_auto_accessor_in_non_abstract_class_reports_only_ts1253() {
+    let source = "class C { abstract accessor #x: number; }\n";
+    assert_eq!(count(source, TS1253), 1, "codes: {:?}", codes(source));
+    assert_eq!(count(source, TS18019), 0, "codes: {:?}", codes(source));
+}
+
+#[test]
+fn static_written_before_abstract_preempts_ts18019() {
+    // `static abstract` is TS1243, reported at `abstract`, and tsc returns
+    // there. The mirror spelling below still reports TS18019.
+    let source = "abstract class C { static abstract #x: number; }\n";
+    assert_eq!(count(source, TS18019), 0, "codes: {:?}", codes(source));
+}
+
+#[test]
+fn abstract_written_before_static_still_reports_ts18019() {
+    let source = "abstract class C { abstract static #x: number; }\n";
+    assert_eq!(count(source, TS18019), 1, "codes: {:?}", codes(source));
+    assert_eq!(anchor(source, TS18019), "abstract");
+}
+
+#[test]
+fn accessibility_written_before_abstract_reports_only_ts18010() {
+    let source = "abstract class C { private abstract #x: number; }\n";
+    assert_eq!(count(source, TS18010), 1, "codes: {:?}", codes(source));
+    assert_eq!(
+        count(source, TS18019),
+        0,
+        "TS18010 fires first and returns; codes: {:?}",
+        codes(source)
+    );
+}
+
+#[test]
+fn accessibility_written_after_static_is_preempted_by_the_ordering_error() {
+    // `static public #x` is TS1029 ("'public' modifier must precede 'static'"),
+    // which tsc reports instead of TS18010.
+    let source = "class C { static public #x = 1; }\n";
+    assert_eq!(count(source, TS18010), 0, "codes: {:?}", codes(source));
+}
+
+#[test]
+fn declare_on_a_private_named_method_is_preempted_by_ts1031() {
+    // `declare` is not a valid modifier on a method at all, so tsc reports
+    // TS1031 rather than TS18019.
+    let source = "class C { declare #m(): void; }\n";
+    assert_eq!(count(source, TS18019), 0, "codes: {:?}", codes(source));
+}
+
+// --- only the first conflicting modifier reports ---------------------------
+
+#[test]
+fn declare_before_abstract_reports_one_ts18019_anchored_at_declare() {
+    let source = "abstract class C { declare abstract #x: number; }\n";
+    assert_eq!(count(source, TS18019), 1, "codes: {:?}", codes(source));
+    assert_eq!(anchor(source, TS18019), "declare");
+}
+
+#[test]
+fn abstract_before_declare_reports_one_ts18019_anchored_at_abstract() {
+    let source = "abstract class C { abstract declare #x: number; }\n";
+    assert_eq!(count(source, TS18019), 1, "codes: {:?}", codes(source));
+    assert_eq!(anchor(source, TS18019), "abstract");
+}
+
+// --- rows that already matched tsc, held unchanged -------------------------
+
+#[test]
+fn declare_on_a_private_named_property_still_reports_ts18019() {
+    let source = "class C { declare #x: number; }\n";
+    assert_eq!(count(source, TS18019), 1, "codes: {:?}", codes(source));
+    assert_eq!(anchor(source, TS18019), "declare");
+}
+
+#[test]
+fn accessibility_on_private_named_members_still_reports_ts18010() {
+    for source in [
+        "class C { public #x = 1; }\n",
+        "class C { private #x = 1; }\n",
+        "class C { protected #x = 1; }\n",
+        "class C { private #m() {} }\n",
+        "class C { public get #x() { return 1; } }\n",
+        "class C { protected accessor #x = 1; }\n",
+    ] {
+        assert_eq!(
+            count(source, TS18010),
+            1,
+            "expected one TS18010 for {source:?}, codes: {:?}",
+            codes(source)
+        );
+    }
+}
+
+// --- negative controls ------------------------------------------------------
+
+#[test]
+fn abstract_members_with_ordinary_names_report_nothing_from_this_family() {
+    let source = "abstract class C {\n    abstract m(): void;\n    abstract get g(): number;\n    abstract p: number;\n}\n";
+    assert_eq!(count(source, TS18019), 0, "codes: {:?}", codes(source));
+    assert_eq!(count(source, TS18010), 0, "codes: {:?}", codes(source));
+}
+
+#[test]
+fn private_named_members_without_conflicting_modifiers_stay_clean() {
+    let source = "class C {\n    #x = 1;\n    static #y = 2;\n    readonly #z = 3;\n    accessor #a = 4;\n    #m() {}\n    get #g() { return 1; }\n}\n";
+    assert_eq!(count(source, TS18019), 0, "codes: {:?}", codes(source));
+    assert_eq!(count(source, TS18010), 0, "codes: {:?}", codes(source));
+}
+
+#[test]
+fn private_names_in_an_ambient_class_without_declare_modifiers_stay_clean() {
+    // The members carry no `declare` modifier of their own; the containing
+    // class being ambient must not synthesize one.
+    let source = "declare class C {\n    #x: number;\n    #m(): void;\n    get #g(): boolean;\n}\n";
+    assert_eq!(count(source, TS18019), 0, "codes: {:?}", codes(source));
+}
+
+#[test]
+fn explicit_declare_on_a_private_name_inside_an_ambient_class_reports_ts18019() {
+    let source = "declare class C { declare #x: number; }\n";
+    assert_eq!(count(source, TS18019), 1, "codes: {:?}", codes(source));
+}


### PR DESCRIPTION
## Structural rule

**When a class member is named by a private identifier, `tsc` decides `TS18010`/`TS18019` inside `checkGrammarModifiers`, which walks the member's modifier list in source order and returns at the first error — so the member reports at most one modifier diagnostic, chosen by modifier order and not by member kind; tsz now does the same through the checker's new `state_checking/class_private_name_modifiers` walk.**

Wrong semantic operation: **diagnostic selection**. Not relation, not inference. tsz asked two order-independent questions (`find_modifier(Public|Private|Protected)`, then `find_modifier(Declare)` and `find_modifier(Abstract)`), each reporting on its own, and gated the second pair on `PROPERTY_DECLARATION`. No refinement of those predicates can express "first one wins" or "yield to whoever `tsc` reached earlier" — the shape of the check had to change.

The cleanest witness is a pair of spellings that declare the **identical** member:

```
abstract class C { abstract static #x: number; }   tsc: TS18019, at `abstract`
abstract class C { static abstract #x: number; }   tsc: TS1243,  at `abstract`
```

Both are correct `tsc` output; they differ only in walk order. An order-blind check must get one of them wrong.

### Two independent consequences, both wrong before

1. **Member kind is not part of the rule.** `TS18019` was gated on `PROPERTY_DECLARATION`, so a private-named **method or accessor** carrying `abstract` reported nothing at all.
2. **An earlier error preempts the check.** Container abstractness (`TS1244`/`TS1253`), modifier ordering (`TS1029`) and modifier pairs (`TS1243`) all win when `tsc` reaches them first — tsz emitted its private-identifier code on top of them.

## Oracle

Pinned `typescript@7.0.2` (`node node_modules/typescript/lib/tsc.js --noEmit --strict --pretty false --lib es2022 --target es2022`), **positions recorded, not code sets** — a code-set comparison shows row 4 below as "one extra code" and hides that the two spellings of one member disagree, which is the whole rule. 64 one-line rows swept across the class-member modifier family; ~50 already matched and are held as the floor.

| source (one class member) | tsc 7.0.2 | tsz before | tsz after |
| --- | --- | --- | --- |
| `abstract class C { abstract #m(): void; }` | TS18019 | *nothing* | ✅ |
| `abstract class C { abstract get #x(): number; }` | TS18019 | *nothing* | ✅ |
| `abstract class C { abstract set #x(v: number); }` | TS18019 | *nothing* | ✅ |
| `abstract class C { abstract accessor #x: number; }` | TS18019 | TS18019 | unchanged |
| `class C { abstract #x: number; }` | TS1253 | TS1253 + **TS18019** | ✅ |
| `class C { abstract accessor #x: number; }` | TS1253 | TS1253 + **TS18019** | ✅ |
| `class C { abstract #m(): void; }` | TS1244 | TS1244 | unchanged |
| `abstract class C { static abstract #x: number; }` | TS1243 | TS1243 + **TS18019** | ✅ |
| `abstract class C { abstract static #x: number; }` | TS18019 | TS18019 (+TS1243, see #16173) | ✅ |
| `abstract class C { private abstract #x: number; }` | TS18010 | TS18010 + **TS18019** (+TS1243) | ✅ |
| `abstract class C { declare abstract #x: number; }` | 1× TS18019 at `declare` | **2×** TS18019 | ✅ |
| `abstract class C { abstract declare #x: number; }` | 1× TS18019 at `abstract` | **2×** TS18019 | ✅ |
| `class C { static public #x = 1; }` | TS1029 | TS1029 + **TS18010** | ✅ |
| `class C { declare #m(): void; }` | TS1031 | TS1031 | unchanged |
| `class C { declare #x: number; }` | TS18019 | TS18019 | unchanged |
| `declare class C { #x; #m(); get #g(); }` | *clean* | *clean* | unchanged |

**After this change every `TS18010`/`TS18019` row in the sweep matches `tsc` exactly**, position included.

## Scope and fallback

The walk reports at most one diagnostic and returns `PreemptedElsewhere` — reporting nothing — the moment it reaches a modifier whose error another owner emits first:

- an accessibility modifier written **after** `static` (the ordering error, `TS1029`, is the parser's);
- `abstract` on a member of a **non**-abstract class (`TS1244`/`TS1253`, still reported by `class.rs`);
- `abstract` written **after** `static` (`TS1243`, the parser's);
- `declare` on anything but a property (`TS1031`, since `declare` is not a valid modifier there at all).

Members with ordinary names never enter the walk — the whole block sits under the existing `is_private_identifier` guard. The JS-file path (accessibility carried by a JSDoc `@public`/`@private`/`@protected` tag rather than an AST modifier, anchored at the tag) is preserved unchanged and now runs only when the AST walk found nothing, which is exactly its old condition.

**Deliberately not fixed here, filed instead:**
- **#16173** — the parser-owned half of the same rule: `TS1029`/`TS1243` are co-emitted where `tsc` returns after one code, on 6 rows including two with ordinary names. It needs one owner to hold both modifier order and container abstractness, so it is a genuinely different change; the issue carries the mirror-spelling rows that must keep reporting `TS1243`.
- **#16174** — unrelated find from the same sweep: `class B {}` + `class C extends B { override #x = 1; }` gets `TS4113` from `tsc` and nothing from tsz.

## Anti-hardcoding

No identifier, alias, property or file-name string drives any decision. The walk branches only on `SyntaxKind` modifier constants and the member's own `SyntaxKind`; the message argument (`"abstract"` / `"declare"`) is the diagnostic's format parameter, not a predicate. One test repeats the headline shape under a renamed class and renamed members to pin that — though note the ordering pair above is the control that actually matters here, and a renamed-binder test cannot catch it.

## Goal
Goal: hold

## Verification
- New suite `private_name_modifier_grammar_order_tests`: **22/22 pass**, every expectation pinned per-position against `tsc` 7.0.2. Includes 6 preemption controls, 2 order-pair controls (`declare abstract` vs `abstract declare`), 4 "already correct, held unchanged" rows, and 3 negative controls (ordinary names, private names with no conflicting modifier, ambient class whose members carry no `declare` of their own).
- Full 64-row oracle sweep re-run against the built binary after the change: **every remaining diff is #16173's parser rows or #16174**, listed above. No `TS18010`/`TS18019` divergence remains.
- `cargo clippy` + `architecture-check.sh` via the pre-commit gate (`-p tsz-checker`): **both passed**.
- `cargo fmt --all`: clean.
- `cargo test -p tsz-checker --lib -- --test-threads=3` (nextest is not installed in this cold container; `--test-threads=3` per the board's standing note that 3 tests do not complete under full parallelism on a 4-core seat): **launched before this PR was opened, still running at post time — I will post the count as a comment and drive any regression myself.** The targeted 22/22 above ran green on the same binary.
- Conformance / emit / fourslash: **not run.** This container has no `TypeScript/tests/cases` checkout and no emit harness. Static argument for low risk, not a substitute for the sweep: the change adds no semantic computation and only selects among diagnostics on class members named `#...`, and the committed `conformance-detail.json` has **zero** failing rows mentioning TS18010 or TS18019. A warm-corpus seat should confirm before merge; the fallback is built so that any member outside the modelled family reports exactly as it did on main.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Chert

---
_Generated by [Claude Code](https://claude.ai/code/session_0194sdBf4AaMFFF5Yh49FRnb)_