### PR TITLE
fix(checker): element access on a nullish optional-chain root is not gated like property access

### DIFF
--- a/crates/tsz-checker/src/tests/optional_chain_root_nullish_strict_only_tests.rs
+++ b/crates/tsz-checker/src/tests/optional_chain_root_nullish_strict_only_tests.rs
@@ -24,6 +24,19 @@
 //! and `computation::call::inner`'s optional-call callee resolution) stripped
 //! unconditionally, so both reported the strict-mode answer in every mode.
 //!
+//! A third chain-root call site, `computation::access`'s element-access path
+//! (`on?.[0]`, `on?.["foo"]`, `on?.[i]`), needs a further split on top of the
+//! strict/non-strict one above: in STRICT mode, `never`'s bracket-notation
+//! lookup (`getIndexedAccessType`, which distributes `never` over any index
+//! type) answers `never` silently for every key shape, while dot-notation
+//! property lookup (`getPropertyOfType`) explicitly reports TS2339 for a
+//! named member `never` doesn't have. So `on?.foo` (dot) keeps TS2339 in
+//! strict mode, but `on?.["foo"]` / `on?.[0]` / `on?.[i]` (bracket, any key)
+//! report NOTHING in strict mode — matching plain `(x: never)["foo"]` /
+//! `(x: never)[0]` reporting nothing outside a chain too. In non-strict
+//! mode, every access kind (dot and bracket alike) reports the ordinary
+//! TS18047/18048 family uniformly, same as the property case above.
+//!
 //! Oracle: `tsc` 7.0.2, `--noEmit --strictNullChecks <bool> --pretty false`.
 //! Every expectation below is pinned against a real run, in both modes.
 
@@ -68,12 +81,14 @@ fn null_receiver_optional_property_access_reports_ts18047_without_strict_null_ch
 #[test]
 fn null_receiver_optional_string_literal_element_access_reports_ts18047_without_strict_null_checks()
 {
-    // Uses a string-literal key (`on?.["foo"]`): the chain-root short
-    // circuit this test targets lives on the `literal_string` arm of
-    // `get_type_of_element_access_with_request`. A *numeric*-literal key
-    // (`on?.[0]`) does not reach that arm at all and reports nothing in
-    // either mode — a separate, pre-existing false-negative, not part of
-    // this gate's scope (see the NOTE this PR leaves on the board).
+    // Uses a string-literal key (`on?.["foo"]`). Element access (bracket
+    // notation) on `never` is NOT the same tsc code path as dot-notation
+    // property access: `getIndexedAccessType` distributes `never` over the
+    // index type and answers `never` silently for ANY key shape, while
+    // `getPropertyOfType` (dot access only) explicitly reports TS2339 for a
+    // named lookup `never` has no member for. Confirmed on the pinned
+    // oracle: `(n: never)["foo"]` and `(n: never).foo` disagree in BOTH
+    // strict and non-strict mode — only the dot form reports TS2339.
     let source = "declare const on: null;\non?.[\"foo\"];";
     let lax = non_strict(source);
     assert_eq!(
@@ -88,10 +103,85 @@ fn null_receiver_optional_string_literal_element_access_reports_ts18047_without_
     );
 
     let strict_codes = strict(source);
+    assert!(
+        strict_codes.is_empty(),
+        "strict mode must NOT report TS2339 for bracket access `on?.[\"foo\"]` — only dot \
+         access hits `never`'s named-property lookup; bracket access resolves silently \
+         through indexed-access distribution over `never`, got: {strict_codes:?}"
+    );
+}
+
+#[test]
+fn null_receiver_optional_numeric_literal_element_access_reports_ts18047_without_strict_null_checks()
+ {
+    // The false-negative this test file's numeric-key TODO pointed at
+    // (`on?.[0]` reported nothing in either mode): fixed alongside the
+    // string-literal-bracket correction above, since both are the same
+    // "element access on a wholly-nullish chain root" gate.
+    for binder in ["on", "probe", "receiver"] {
+        let source = format!("declare const {binder}: null;\n{binder}?.[0];");
+        let lax = non_strict(&source);
+        assert_eq!(
+            count(&lax, TS18047),
+            1,
+            "expected TS18047 for `{binder}?.[0]` without strictNullChecks, got: {lax:?}"
+        );
+
+        let strict_codes = strict(&source);
+        assert!(
+            strict_codes.is_empty(),
+            "strict mode must report nothing for `{binder}?.[0]` (matches `(x: never)[0]`), \
+             got: {strict_codes:?}"
+        );
+    }
+}
+
+#[test]
+fn null_receiver_optional_computed_element_access_reports_ts18047_without_strict_null_checks() {
+    // Non-literal keys (identifier index expressions), both a `number`- and
+    // a `string`-typed index. Neither is `literal_string` nor `literal_index`
+    // in the checker's own terms, so this exercises the general element-
+    // access branch rather than either literal fast path.
+    let numeric_index = "declare const on: null;\ndeclare const i: number;\non?.[i];";
+    let lax = non_strict(numeric_index);
     assert_eq!(
-        count(&strict_codes, TS2339),
+        count(&lax, TS18047),
         1,
-        "strict mode must keep TS2339 for `on?.[\"foo\"]`, got: {strict_codes:?}"
+        "expected TS18047 for `on?.[i]` (number index) without strictNullChecks, got: {lax:?}"
+    );
+    let strict_codes = strict(numeric_index);
+    assert!(
+        strict_codes.is_empty(),
+        "strict mode must report nothing for `on?.[i]`, got: {strict_codes:?}"
+    );
+
+    let string_index = "declare const on: null;\ndeclare const s: string;\non?.[s];";
+    let lax = non_strict(string_index);
+    assert_eq!(
+        count(&lax, TS18047),
+        1,
+        "expected TS18047 for `on?.[s]` (string index) without strictNullChecks, got: {lax:?}"
+    );
+    let strict_codes = strict(string_index);
+    assert!(
+        strict_codes.is_empty(),
+        "strict mode must report nothing for `on?.[s]`, got: {strict_codes:?}"
+    );
+}
+
+#[test]
+fn undefined_receiver_optional_element_access_reports_ts18048_without_strict_null_checks() {
+    let source = "declare const ou: undefined;\nou?.[0];";
+    let lax = non_strict(source);
+    assert_eq!(
+        count(&lax, TS18048),
+        1,
+        "expected TS18048 for `ou?.[0]` without strictNullChecks, got: {lax:?}"
+    );
+    let strict_codes = strict(source);
+    assert!(
+        strict_codes.is_empty(),
+        "strict mode must report nothing for `ou?.[0]`, got: {strict_codes:?}"
     );
 }
 
@@ -211,5 +301,21 @@ fn partial_union_optional_chain_stays_clean_in_both_modes() {
             .iter()
             .all(|c| ![TS18047, TS2339, TS2721, TS2349].contains(c)),
         "`(() => void | null)?.()` must stay clean without strictNullChecks, got: {lax_call:?}"
+    );
+
+    let element_source = "declare const arr: number[] | null;\narr?.[0];";
+    let lax_element = non_strict(element_source);
+    assert!(
+        lax_element
+            .iter()
+            .all(|c| ![TS18047, TS18048, TS2339, TS2721, TS2722, TS2349].contains(c)),
+        "`(number[] | null)?.[0]` must stay clean without strictNullChecks, got: {lax_element:?}"
+    );
+    let strict_element = strict(element_source);
+    assert!(
+        strict_element
+            .iter()
+            .all(|c| ![TS18047, TS18048, TS2339, TS2721, TS2722, TS2349].contains(c)),
+        "`(number[] | null)?.[0]` must stay clean under strictNullChecks, got: {strict_element:?}"
     );
 }

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -228,26 +228,31 @@ impl<'a> CheckerState<'a> {
 
         // The chain root's nullish stripping is tsc's `getNonNullableType`,
         // the identity function without `strictNullChecks` — so a
-        // wholly-nullish receiver only narrows to `never` (and reports
-        // TS2339 here) in strict mode. Without it, the receiver's own
+        // wholly-nullish receiver only narrows to `never` in strict mode.
+        // What that narrowing then does is NOT uniform across access kinds:
+        // `never`'s named-property lookup (`getPropertyOfType`, dot access
+        // like `on?.foo`) reports TS2339, but `never`'s index lookup
+        // (element access with ANY key — string literal, numeric literal,
+        // or computed — like `on?.["foo"]`/`on?.[0]`/`on?.[i]`) resolves
+        // silently, matching plain `(x: never)["foo"]`/`x[0]` reporting
+        // nothing in either mode. Without strict mode, the receiver's own
         // (unstripped) type drives the same `checkNonNullTypeWithReporter`
-        // own-flags trigger as a non-chain access: an operand that IS
-        // `null`/`undefined` still reports TS18047/18048, while a genuine
-        // `null | undefined` union's own flags are `TypeFlags.Union` and do
-        // not trigger, so it falls through unchanged.
-        if access.question_dot_token
-            && let Some(property_name) = literal_string.as_deref()
-            && self.split_nullish_type(object_type).0.is_none()
-        {
+        // own-flags trigger as a non-chain access, for every access kind
+        // alike: an operand that IS `null`/`undefined` still reports
+        // TS18047/18048, while a genuine `null | undefined` union's own
+        // flags are `TypeFlags.Union` and do not trigger, so it falls
+        // through unchanged.
+        if access.question_dot_token && self.split_nullish_type(object_type).0.is_none() {
             if self.ctx.compiler_options.strict_null_checks {
-                self.error_property_not_exist_at(
-                    property_name,
-                    TypeId::NEVER,
-                    access.name_or_argument,
-                );
-                return TypeId::UNDEFINED;
-            }
-            if crate::query_boundaries::type_predicates::has_ts_nullable_flag(object_type) {
+                if !is_value_element_access && let Some(property_name) = literal_string.as_deref() {
+                    self.error_property_not_exist_at(
+                        property_name,
+                        TypeId::NEVER,
+                        access.name_or_argument,
+                    );
+                    return TypeId::UNDEFINED;
+                }
+            } else if crate::query_boundaries::type_predicates::has_ts_nullable_flag(object_type) {
                 if !self.report_literal_nullish_value_error(access.expression, object_type) {
                     self.report_named_possibly_nullish_expression(access.expression, object_type);
                 }

--- a/crates/tsz-checker/tests/optional_chain_literal_nullish_ts2339_tests.rs
+++ b/crates/tsz-checker/tests/optional_chain_literal_nullish_ts2339_tests.rs
@@ -7,7 +7,12 @@
 //! > `undefined`, or `null | undefined` (i.e. no non-nullish slice
 //! > remains after splitting), the chain always short-circuits. tsc
 //! > emits TS2339 ("Property 'X' does not exist on type 'never'.") at
-//! > the property name, because the property access is unreachable.
+//! > the property name, because the property access is unreachable —
+//! > for DOT-NOTATION property access only. Bracket-notation element
+//! > access (`null?.["foo"]`, `null?.[0]`) distributes `never` over the
+//! > index type instead and resolves silently in every mode; see
+//! > `element_access_on_literal_null` below and the fuller matrix in
+//! > `optional_chain_root_nullish_strict_only_tests.rs`.
 //!
 //! The fix lives in `handle_possibly_null_or_undefined_access`
 //! (`crates/tsz-checker/src/types/property_access_type/nullish_access.rs`):
@@ -81,15 +86,20 @@ fn null_or_undefined_union_optional_chain() {
 
 #[test]
 fn element_access_on_literal_null() {
-    // Indexed (element) access form: `null?.["valueOf"]`. The fix uses
-    // `name_or_argument` so this position should also trigger TS2339.
+    // Indexed (element) access form: `null?.["valueOf"]`. Unlike dot-notation
+    // property access, `never`'s bracket-notation lookup
+    // (`getIndexedAccessType`) distributes `never` over any index type and
+    // answers `never` silently, so tsc reports NOTHING here — confirmed on
+    // the pinned oracle (`tsc` 7.0.2, `--strict`). Element (bracket) access
+    // never hits the TS2339-on-`never` rule this file's other cases exercise
+    // for dot access; see `optional_chain_root_nullish_strict_only_tests.rs`
+    // for the fuller matrix (property vs. bracket, literal vs. computed key).
     let source = "const z = null?.[\"valueOf\"];\n";
     let diags = diags_strict(source);
     assert!(
-        diags
-            .iter()
-            .any(|(c, m)| *c == 2339 && m.contains("'never'")),
-        "expected TS2339 / 'never' for `null?.[...]`, got: {diags:?}",
+        diags.is_empty(),
+        "expected no diagnostics for `null?.[\"valueOf\"]` under strictNullChecks \
+         (bracket access on `never` resolves silently, unlike dot access), got: {diags:?}",
     );
 }
 


### PR DESCRIPTION
Follow-up to #16167 (closes the unclaimed pickup ClaudeDE's NOTE left on `agent-coordination: hourly routine board`, #15994).

## Structural rule

`getIndexedAccessType` (bracket/element access, `on?.["foo"]`, `on?.[0]`, `on?.[i]`) distributes `never` over any index type and resolves silently in every mode. `getPropertyOfType` (dot-notation property access only, `on?.foo`) explicitly reports TS2339 for a named lookup `never` has no member for. These are different tsc code paths that disagree on `never`, confirmed on the pinned oracle (`typescript@7.0.2`, `--noEmit --strict <bool>`):

```
(n: never).foo    both modes -> TS2339
(n: never)["foo"] both modes -> nothing
(n: never)[0]     both modes -> nothing
```

tsz's `get_type_of_element_access_with_request` (`crates/tsz-checker/src/types/computation/access.rs`) gated its whole "wholly-nullish optional-chain root" special case on `literal_string.is_some()`, which is `true` for BOTH `on?.foo` (dot) and `on?.["foo"]` (bracket string literal) — so it:
1. wrongly applied the strict-mode TS2339 to bracket string-literal access, and
2. never reported anything for `on?.[0]` / `on?.[i]` (numeric-literal or computed keys) in non-strict mode — the unclaimed false-negative ClaudeDE's board NOTE flagged after #16167 landed.

Fix: gate the strict-mode `error_property_not_exist_at` branch on `!is_value_element_access` (dot access only) instead of `literal_string.is_some()`. The non-strict `TS18047`/`TS18048` branch now fires uniformly for every access kind (dot, bracket-string-literal, bracket-numeric-literal, bracket-computed) once the receiver is wholly nullish — owner layer is the checker's element/property access query (`crates/tsz-checker/src/types/computation/access.rs`), same file, no solver or emitter involvement.

Two existing tests encoded the pre-oracle-verification assumption that bracket access matches dot access on `never`, and are corrected in this PR (both now match the pinned oracle instead of asserting the old, wrong behavior):
- `optional_chain_literal_nullish_ts2339_tests::element_access_on_literal_null` (#5938)
- `optional_chain_root_nullish_strict_only_tests`'s string-literal element-access case (introduced in #16167)

## Adjacent-case matrix

New/updated tests in `optional_chain_root_nullish_strict_only_tests.rs`: dot property, bracket string-literal, bracket numeric-literal, bracket computed (`number`- and `string`-typed index), `null` and `undefined` receivers, renamed binders, nested chains, and the partial-union (`T[] | null`) control staying clean in both modes.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib optional_chain_root_nullish_strict_only`: 10/10 pass (new/updated tests), pinned against `typescript@7.0.2` oracle.
- `cargo test -p tsz-checker --test optional_chain_literal_nullish_ts2339_tests`: 7/7 pass (corrected pre-existing test).
- `cargo test -p tsz-checker --lib` filtered by name, since a full unlimited `--lib` run hangs on a pre-existing, unrelated issue (`#15983`, "3 checker hangs"): `access` 568/568, `nullish` 176/176, `optional_chain` 36/36, `never` 133/133, `element` 291/291 — all pass, 0 failures across every filter.
- `cargo fmt -p tsz-checker -- --check`: clean.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings`: clean.
- `python3 scripts/arch/arch_guard.py`: `Architecture guardrails passed.`
- Conformance / emit / fourslash **not run**: this cloud container has no `TypeScript/` corpus checkout at all (not merely stale — absent), matching several other sessions' reports on the coordination board today. The change is a narrow diagnostic-selection gate on a wholly-nullish optional-chain root reached only through bracket/dot element access; no corpus fixture is expected to exercise it (same class of "zero movement expected" change as #16009/#16016/#16020/#16039/#16042/#16167 per the board's standing gotchas). Flagging for a warm-seat corpus sweep before merge, per repo convention.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_017xqhzbYGrSXEYzhNP8rooL)_