### PR TITLE
fix(checker): add the missing TS7033 get-accessor arm and scope the noImplicitAny member suppression to hidden ambient members

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1029,6 +1029,9 @@ path = "tests/jsdoc_type_tag_tests.rs"
 name = "ts1203_node_esm_tests"
 path = "tests/ts1203_node_esm_tests.rs"
 [[test]]
+name = "noimplicitany_ambient_member_surface_tests"
+path = "tests/noimplicitany_ambient_member_surface_tests.rs"
+[[test]]
 name = "node_esm_default_import_export_equals_callable_tests"
 path = "tests/node_esm_default_import_export_equals_callable_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -857,14 +857,10 @@ impl<'a> CheckerState<'a> {
         self.check_parameter_properties(&method.parameters.nodes);
 
         // Check parameter type annotations for parameter properties in function types
-        // TSC suppresses TS7006 for private members in ambient (declare) classes
-        // since private members are excluded from .d.ts output.
-        let skip_implicit_any = self
-            .ctx
-            .enclosing_class
-            .as_ref()
-            .is_some_and(|c| c.is_declared)
-            && self.has_private_modifier(&method.modifiers);
+        // TSC suppresses the noImplicitAny member family for members that are not
+        // part of an ambient declaration's observable surface.
+        let skip_implicit_any =
+            self.member_hidden_from_ambient_declaration_surface(&method.modifiers, method.name);
         // Pre-extract ordered @param names for positional matching with binding patterns
         let jsdoc_param_names: Vec<String> = method_jsdoc
             .as_ref()
@@ -1417,13 +1413,10 @@ impl<'a> CheckerState<'a> {
         // Parameter properties are only allowed in constructors, not in accessors
         self.check_parameter_properties(&accessor.parameters.nodes);
 
-        // TSC suppresses TS7006/TS7010 for private accessors in ambient (declare) classes
-        let skip_implicit_any_accessor = self
-            .ctx
-            .enclosing_class
-            .as_ref()
-            .is_some_and(|c| c.is_declared)
-            && self.has_private_modifier(&accessor.modifiers);
+        // TSC suppresses the noImplicitAny member family (TS7006/TS7010/TS7033) for
+        // accessors that are not part of an ambient declaration's observable surface.
+        let skip_implicit_any_accessor =
+            self.member_hidden_from_ambient_declaration_surface(&accessor.modifiers, accessor.name);
 
         // Check getter parameters for TS7006 here.
         // Setter parameters are checked in check_setter_parameter() below, which also
@@ -1590,6 +1583,33 @@ impl<'a> CheckerState<'a> {
             }
 
             self.pop_return_type();
+        } else if is_getter && !has_type_annotation && !skip_implicit_any_accessor {
+            // TS7033. A bodyless get accessor has no body to infer a return type from,
+            // so an unannotated one resolves to `any` and tsc reports it — in every
+            // container a bodyless getter can legally appear (`declare class`, an
+            // `abstract` getter, a `.d.ts` class) and in parse-error recovery for a
+            // plain class too, where tsc emits it alongside the syntax error.
+            //
+            // This is the accessor analogue of the bodyless-method TS7010 arm above,
+            // and it carries one exemption that arm does not need: a getter paired
+            // with an annotated setter takes its type from the setter
+            // (tsc's `isGetAccessorWithAnnotatedSetAccessor`), so it is not implicitly
+            // `any` and must stay clean. `get g(); set g(v: number);` is ordinary in
+            // real declaration files.
+            if self.ctx.no_implicit_any()
+                && !self.is_js_file()
+                && self
+                    .contextual_getter_return_type_for_class_accessor(accessor)
+                    .is_none()
+                && let Some(accessor_name) = self.get_property_name(accessor.name)
+            {
+                use crate::diagnostics::diagnostic_codes;
+                self.error_at_node_msg(
+                    accessor.name,
+                    diagnostic_codes::PROPERTY_IMPLICITLY_HAS_TYPE_ANY_BECAUSE_ITS_GET_ACCESSOR_LACKS_A_RETURN_TYPE_AN,
+                    &[&accessor_name],
+                );
+            }
         }
 
         if self.has_static_modifier(&accessor.modifiers) {

--- a/crates/tsz-checker/src/types/queries/core.rs
+++ b/crates/tsz-checker/src/types/queries/core.rs
@@ -333,6 +333,33 @@ impl<'a> CheckerState<'a> {
                 .has_modifier(modifiers, SyntaxKind::OverrideKeyword)
     }
 
+    /// Whether a class member is hidden from the observable surface of an ambient
+    /// declaration, which suppresses the whole `noImplicitAny` member family
+    /// (TS7006/TS7008/TS7010/TS7033) for it.
+    ///
+    /// `tsc` reports those diagnostics on ambient members because an ambient
+    /// declaration *is* the public API — an implicit `any` there is consumed by
+    /// everyone importing it. That reasoning does not apply to a member no consumer
+    /// can observe, and `tsc` reports nothing for one. Two independent things hide a
+    /// member: the `private` modifier, and a private-identifier (`#x`) name. Neither
+    /// condition suppresses anything on its own — a `#x` member of a *non-ambient*
+    /// class still reports normally, because its implicit `any` still affects the
+    /// inferred type of the enclosing class body.
+    pub(crate) fn member_hidden_from_ambient_declaration_surface(
+        &self,
+        modifiers: &Option<tsz_parser::parser::NodeList>,
+        name_idx: NodeIndex,
+    ) -> bool {
+        let in_ambient_context = self
+            .ctx
+            .enclosing_class
+            .as_ref()
+            .is_some_and(|c| c.is_declared)
+            || self.ctx.is_declaration_file();
+        in_ambient_context
+            && (self.has_private_modifier(modifiers) || self.is_private_identifier_name(name_idx))
+    }
+
     /// Check if a node is a private identifier.
     pub(crate) fn is_private_identifier_name(&self, name_idx: NodeIndex) -> bool {
         let Some(node) = self.ctx.arena.get(name_idx) else {

--- a/crates/tsz-checker/tests/noimplicitany_ambient_member_surface_tests.rs
+++ b/crates/tsz-checker/tests/noimplicitany_ambient_member_surface_tests.rs
@@ -1,0 +1,203 @@
+//! The `noImplicitAny` class-member family: the missing get-accessor arm
+//! (`TS7033`) and the surface rule that decides when the family is suppressed.
+//!
+//! Structural rule, one sentence per half:
+//!
+//! 1. When a `get` accessor has no body and no return-type annotation, `tsc`
+//!    reports `TS7033` — the accessor analogue of the bodyless-method `TS7010`
+//!    arm — unless a paired `set` accessor's annotated parameter supplies the
+//!    type (`isGetAccessorWithAnnotatedSetAccessor`). tsz does this through
+//!    `state_checking_members/ambient_signature_checks.rs`
+//!    (`check_accessor_declaration_with_request`).
+//! 2. When a class member is hidden from the observable surface of an ambient
+//!    declaration — `private`, or named by a private identifier, *and* inside a
+//!    `declare class` or a `.d.ts` — `tsc` reports none of the family for it.
+//!    tsz does this through `member_hidden_from_ambient_declaration_surface`.
+//!
+//! Neither condition of the conjunction in (2) suppresses on its own: an
+//! ordinary-named ambient member still reports, and a private-identifier member
+//! of a *non-ambient* class still reports. Both directions are pinned below,
+//! because a guard keyed on either condition alone passes half of this file.
+//!
+//! Every expectation here was recorded from `typescript@7.0.2` under
+//! `--noEmit --strict --lib es2022 --target es2022`.
+
+use tsz_checker::test_utils::check_source_strict_codes;
+
+const TS7008: u32 = 7008; // Member implicitly has an 'any' type.
+const TS7010: u32 = 7010; // Lacks return-type annotation, implicitly 'any' return.
+const TS7033: u32 = 7033; // Property implicitly 'any', get accessor lacks return type.
+
+fn has(codes: &[u32], code: u32) -> bool {
+    codes.contains(&code)
+}
+
+fn count(codes: &[u32], code: u32) -> usize {
+    codes.iter().filter(|&&c| c == code).count()
+}
+
+// ---------------------------------------------------------------------------
+// (1) TS7033 — the arm that did not exist. Issue #16179.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ambient_class_bodyless_getter_reports_ts7033() {
+    let codes = check_source_strict_codes("declare class J { get g(); }");
+    assert!(has(&codes, TS7033), "expected TS7033: {codes:?}");
+}
+
+#[test]
+fn ambient_class_annotated_getter_is_clean() {
+    let codes = check_source_strict_codes("declare class J { get g(): number; }");
+    assert!(
+        !has(&codes, TS7033),
+        "annotation supplies the type: {codes:?}"
+    );
+}
+
+#[test]
+fn abstract_getter_without_annotation_reports_ts7033() {
+    // A bodyless getter is legal outside an ambient context too.
+    let codes = check_source_strict_codes("abstract class A { abstract get g(); }");
+    assert!(has(&codes, TS7033), "expected TS7033: {codes:?}");
+}
+
+#[test]
+fn abstract_annotated_getter_is_clean() {
+    let codes = check_source_strict_codes("abstract class A { abstract get g(): number; }");
+    assert!(
+        !has(&codes, TS7033),
+        "annotation supplies the type: {codes:?}"
+    );
+}
+
+#[test]
+fn ambient_static_bodyless_getter_reports_ts7033() {
+    let codes = check_source_strict_codes("declare class J { static get g(); }");
+    assert!(
+        has(&codes, TS7033),
+        "static is not part of the rule: {codes:?}"
+    );
+}
+
+#[test]
+fn getter_paired_with_annotated_setter_is_clean() {
+    // The exemption the bodyless-method TS7010 arm does not need, and the one
+    // that matters most in practice: `get g(); set g(v: T);` is ordinary in real
+    // declaration files, and tsc reports nothing for it.
+    let codes = check_source_strict_codes("declare class J { get g(); set g(v: number); }");
+    assert!(
+        !has(&codes, TS7033),
+        "paired annotated setter supplies the getter's type: {codes:?}"
+    );
+}
+
+#[test]
+fn setter_without_paired_getter_never_reports_ts7033() {
+    // TS7033 is a *get* accessor diagnostic; a lone setter is not in scope.
+    let codes = check_source_strict_codes("declare class J { set s(v: number); }");
+    assert!(!has(&codes, TS7033), "setter-only: {codes:?}");
+}
+
+#[test]
+fn ambient_class_reports_all_three_family_codes_together() {
+    // tsc: TS7008 (x), TS7010 (m), TS7033 (g) — the three arms are independent
+    // and co-emit on one class.
+    let codes = check_source_strict_codes("declare class D { x; m(); get g(); }");
+    assert!(has(&codes, TS7008), "expected TS7008: {codes:?}");
+    assert!(has(&codes, TS7010), "expected TS7010: {codes:?}");
+    assert!(has(&codes, TS7033), "expected TS7033: {codes:?}");
+}
+
+#[test]
+fn ts7033_is_reported_once_per_getter() {
+    let codes = check_source_strict_codes("declare class D { get g(); }");
+    assert_eq!(count(&codes, TS7033), 1, "exactly one TS7033: {codes:?}");
+}
+
+// ---------------------------------------------------------------------------
+// (2) The surface rule. Issue #16178 — TS7010 fired where tsc is silent.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ambient_private_named_method_is_clean() {
+    // The #16178 witness.
+    let codes = check_source_strict_codes("declare class C { #m(); }");
+    assert!(!has(&codes, TS7010), "hidden from the surface: {codes:?}");
+}
+
+#[test]
+fn ambient_private_named_property_is_clean() {
+    let codes = check_source_strict_codes("declare class C { #x; }");
+    assert!(!has(&codes, TS7008), "hidden from the surface: {codes:?}");
+}
+
+#[test]
+fn ambient_private_named_getter_is_clean() {
+    // The new TS7033 arm must respect the same surface rule it was added under,
+    // or fixing #16179 would have re-opened #16178 through a different code.
+    let codes = check_source_strict_codes("declare class C { get #g(); }");
+    assert!(!has(&codes, TS7033), "hidden from the surface: {codes:?}");
+}
+
+#[test]
+fn ambient_static_private_named_method_is_clean() {
+    let codes = check_source_strict_codes("declare class C { static #m(); }");
+    assert!(!has(&codes, TS7010), "hidden from the surface: {codes:?}");
+}
+
+#[test]
+fn ambient_private_modifier_members_stay_clean() {
+    // Pre-existing behavior, kept as a control: the `private` keyword is the
+    // other way a member leaves the surface, and it must keep working.
+    let codes = check_source_strict_codes("declare class F { private m(); private get g(); }");
+    assert!(!has(&codes, TS7010), "private keyword: {codes:?}");
+    assert!(!has(&codes, TS7033), "private keyword: {codes:?}");
+}
+
+#[test]
+fn ambient_whole_private_named_class_is_clean() {
+    // Renamed binders throughout — no identifier string drives the rule.
+    let codes = check_source_strict_codes("declare class Zebra { #alpha; #beta(); get #gamma(); }");
+    assert!(!has(&codes, TS7008), "renamed binders: {codes:?}");
+    assert!(!has(&codes, TS7010), "renamed binders: {codes:?}");
+    assert!(!has(&codes, TS7033), "renamed binders: {codes:?}");
+}
+
+// --- negative controls: neither half of the conjunction suppresses alone -----
+
+#[test]
+fn non_ambient_private_named_method_still_reports_ts7010() {
+    // A `#m()` outside an ambient context is NOT hidden — its implicit `any`
+    // still affects the enclosing class body's inferred type. A guard keyed on
+    // the private-identifier name alone would wrongly silence this.
+    let codes = check_source_strict_codes("class E { #m(); }");
+    assert!(has(&codes, TS7010), "non-ambient private name: {codes:?}");
+}
+
+#[test]
+fn non_ambient_abstract_private_named_method_still_reports_ts7010() {
+    let codes = check_source_strict_codes("abstract class G { abstract #m(); }");
+    assert!(has(&codes, TS7010), "non-ambient private name: {codes:?}");
+}
+
+#[test]
+fn ambient_ordinary_named_members_still_report() {
+    // An ambient declaration *is* the public API for ordinary names. A guard
+    // keyed on the ambient context alone would wrongly silence all of these.
+    let codes = check_source_strict_codes("declare class D { m(); }");
+    assert!(has(&codes, TS7010), "ordinary ambient name: {codes:?}");
+    let codes = check_source_strict_codes("declare class D { x; }");
+    assert!(has(&codes, TS7008), "ordinary ambient name: {codes:?}");
+    let codes = check_source_strict_codes("declare class D { get g(); }");
+    assert!(has(&codes, TS7033), "ordinary ambient name: {codes:?}");
+}
+
+#[test]
+fn ambient_private_named_annotated_members_are_clean_either_way() {
+    // Annotated hidden members are clean for two independent reasons; pinned so
+    // a later change to either reason does not silently start reporting.
+    let codes = check_source_strict_codes("declare class C { get #g(): number; #m(): void; }");
+    assert!(!has(&codes, TS7033), "annotated + hidden: {codes:?}");
+    assert!(!has(&codes, TS7010), "annotated + hidden: {codes:?}");
+}


### PR DESCRIPTION
Closes #16179. Closes #16178.

Both issues were filed 06:28Z out of Chert's modifier-grammar sweep, and both are the same walk in `state_checking_members/ambient_signature_checks.rs`. They are not independent: #16179 asks for a get-accessor arm that does not exist, #16178 says the sibling method arm over-fires on exactly one conjunction, and the new arm has to respect that conjunction or fixing #16179 re-opens #16178 through a different diagnostic code. One PR, one matrix.

## Structural rule

Two halves, both owned by the checker's class-member walk. No solver, emitter, or parser involvement.

**1 — the missing arm (#16179).** When a `get` accessor has no body and no return-type annotation, `tsc` reports **TS7033**: the accessor analogue of the bodyless-method TS7010 arm. tsz's accessor walk only reported implicit-any inside `if accessor.body.is_some()`, so a bodyless getter — the only kind that can be unannotated-and-uninferable — fell through the walk entirely with no `else`. TS7033 was defined in `tsz-common/.../part_002.rs:410` and already offered as an LSP quick-fix, but `rg 7033` over `crates/tsz-checker` returned nothing. tsz now emits it through a new `else` arm on `check_accessor_declaration_with_request`.

That arm carries one exemption the TS7010 arm does not need: a getter paired with an **annotated setter** takes its type from the setter (`tsc`'s `isGetAccessorWithAnnotatedSetAccessor`), so it is not implicitly `any`. `get g(); set g(v: T);` is ordinary in real declaration files, and emitting there would have been a far worse false positive than the one being fixed. The pairing is read through the already-existing `contextual_getter_return_type_for_class_accessor`.

**2 — the suppression scope (#16178).** When a class member is hidden from the observable surface of an ambient declaration, `tsc` reports none of the `noImplicitAny` member family for it — an implicit `any` no consumer can observe has no consequence to report. Two independent things hide a member: the `private` modifier, and a private-identifier (`#x`) name. tsz's `skip_implicit_any` / `skip_implicit_any_accessor` predicates checked `has_private_modifier` only, so `declare class C { #m(); }` drew a TS7010 that `tsc` does not emit. Both sites now route through one shared `member_hidden_from_ambient_declaration_surface` helper in `types/queries/core.rs`, built on the existing structural `is_private_identifier_name` node-kind query — no name-string matching.

**The conjunction is the whole rule, and neither half suppresses alone.** Oracle-measured in both directions:

| container | member | tsc | tsz before |
| --- | --- | --- | --- |
| `declare class` | `#m()` | clean | **TS7010** ❌ |
| `declare class` | `m()` | TS7010 | TS7010 ✅ |
| `class` | `#m()` | TS2391 + TS7010 | TS2391 + TS7010 ✅ |
| `abstract class` | `abstract #m()` | TS18019 + TS7010 | same ✅ |

A guard keyed on the private-identifier name alone would silence rows 3 and 4; a guard keyed on "ambient" alone would silence row 2. Both negative controls are in the suite.

The helper also treats a `.d.ts` class as an ambient context, which the old inline predicate did not. That widening is oracle-confirmed on both legs rather than assumed — in a `.d.ts`, `class B { #m(); #x; get #g(); }` and `class C { private m(); private x; private get g(); }` are both clean, while `class D { m(); x; get g(); }` still reports all three of TS7010/TS7008/TS7033. So the rule really is the hidden-member conjunction and not "everything in a `.d.ts` is exempt".

## Adjacent-case matrix

New suite `crates/tsz-checker/tests/noimplicitany_ambient_member_surface_tests.rs`, 19 tests, every expectation recorded from a pinned `typescript@7.0.2` run (`--noEmit --strict --lib es2022 --target es2022`) rather than from reading tsz: getter with and without annotation; `abstract` getter (bodyless outside an ambient context) with and without annotation; `static` getter; getter paired with an annotated setter; setter with no getter; all three family codes co-emitting on one class; TS7033 emitted exactly once per getter; private-identifier method, property, getter, and `static` method in a `declare class`; the `private`-keyword control; renamed binders throughout (`Zebra`/`#alpha`/`#beta`/`#gamma`); and the two negative controls above.

## Goal

Goal: hold

## Verification

- **The flip is measured, not assumed.** Stashed only the two source hunks and re-ran the same test binary against the parent: **9 failed / 10 passed**. The 10 that pass on the parent are genuine controls, not evidence. With the fix: **19/19**. The 9 that move are the 6 TS7033 rows (arm did not exist) and the 3 private-identifier rows (the false positive).
- `cargo test -p tsz-checker --test noimplicitany_ambient_member_surface_tests`: 19/19.
- `cargo test -p tsz-checker --lib -- accessor implicit_any ambient`: 166/166, 0 failures.
- All 34 `tsz-checker` integration suites whose names match `accessor|implicit_any|ambient|getter|setter|private|declare|noimplicit`: all green except one, `import_type_ambient_module_member_tests::cross_file_import_type_member_still_works`, which **fails byte-identically on the parent with the two source hunks stashed** (`TS2456 Type alias 'Member' circularly references itself`). That is the #15983 family, unrelated to this change — see the NOTE on the coordination board.
- `cargo fmt` clean; `cargo clippy -p tsz-checker --all-targets -- -D warnings` clean; `python3 scripts/arch/arch_guard.py` → `Architecture guardrails passed.` (all three also re-run by the pre-commit gate).
- **Conformance / emit / fourslash NOT run.** This container has no `TypeScript/` corpus checkout at all — absent, not stale — so `compare-to-parent.sh` and that whole tier are unavailable here. Stating the gap plainly rather than implying coverage.

  **This one deserves a warm-seat sweep more than the usual narrow-fix PR does, and I want to be explicit about why:** half of it *adds* a diagnostic code the checker has never emitted. The board's standing "zero conformance movement is the expected signature" gotcha covers false-positive removals; it does not cover a new emit site, which can only move the corpus in the *newly-failing* direction. The trigger is narrow (bodyless get accessor, no annotation, no annotated paired setter, `noImplicitAny` on, not hidden), and the one shape I could not rule out by construction is a bodyless getter reached through parser error recovery in a plain class — `class K { get g(); }`, where the pinned oracle does report TS7033 alongside the TS1005, so tsz matching there is parity rather than noise. A `compare-to-parent.sh` run against `1af17fc` is the check I would want before merge.

## Follow-up left open, not folded in

`interface I { get g(); }` also reports TS7033 in `tsc` and still does not in tsz. That is the interface/type-literal member walk, a different code path from the class-accessor walk this PR touches, so it is deliberately out of scope rather than forgotten. Recorded as a board NOTE with the oracle row.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Dacite

---
_Generated by [Claude Code](https://claude.ai/code/session_011J1uAW6bhfGK9k84twoU4W)_