### PR TITLE
fix(checker): validate `override` on private-identifier class members (TS4112/TS4113)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1639,6 +1639,9 @@ path = "tests/jsdoc_cross_file_typedef_tests.rs"
 name = "override_intersection_display_tests"
 path = "tests/override_intersection_display_tests.rs"
 [[test]]
+name = "override_modifier_private_identifier_tests"
+path = "tests/override_modifier_private_identifier_tests.rs"
+[[test]]
 name = "ts2451_cross_file_augmentation_tests"
 path = "tests/ts2451_cross_file_augmentation_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/classes/class_checker.rs
+++ b/crates/tsz-checker/src/classes/class_checker.rs
@@ -826,12 +826,14 @@ impl<'a> CheckerState<'a> {
                 info.has_computed_non_literal_name,
             );
 
-            // Skip override checking for private identifiers (#foo)
-            // Private fields are scoped to the class that declares them and
-            // do NOT participate in the inheritance hierarchy
-            if member_name.starts_with('#') {
-                continue;
-            }
+            // Private identifiers (#foo) are lexically scoped to their own
+            // class body, so a derived `#foo` never structurally relates to a
+            // same-spelled base `#foo`. `override`'s legality check
+            // (TS4112/TS4113 below) still applies — tsc always rejects
+            // `override` on a private name — but base-compat and
+            // implicit-override checks do not. `base_info` is forced `None`
+            // so validity always takes the "not declared" path.
+            let is_private_name = member_name.starts_with('#');
 
             // Detect overload signatures (method declarations without body) so we
             // can skip the type compatibility check for them later.  We do NOT
@@ -845,9 +847,13 @@ impl<'a> CheckerState<'a> {
                     .is_some_and(|m| m.body.is_none())
             };
 
-            let base_info = base_chain_summary
-                .lookup(&member_name, is_static, true)
-                .cloned();
+            let base_info = if is_private_name {
+                None
+            } else {
+                base_chain_summary
+                    .lookup(&member_name, is_static, true)
+                    .cloned()
+            };
 
             if has_override {
                 // Cannot use `override` when name is computed dynamically.
@@ -984,6 +990,12 @@ impl<'a> CheckerState<'a> {
                         },
                     );
                 }
+                continue;
+            }
+
+            // See `is_private_name` above: no branding/compat check below
+            // applies to a name a base class can never visibly declare.
+            if is_private_name {
                 continue;
             }
 

--- a/crates/tsz-checker/src/classes/class_member_info.rs
+++ b/crates/tsz-checker/src/classes/class_member_info.rs
@@ -266,10 +266,17 @@ impl<'a> CheckerState<'a> {
             .collect();
 
         for info in all_members {
-            if info.name.starts_with('#') {
-                continue;
-            }
-            let base_type_for_member = if info.is_static {
+            // Private identifiers (#foo) are lexically scoped to the class body
+            // that declares them and never structurally relate to a base
+            // member, even a same-spelled one — `override`'s own legality
+            // check (TS4112/TS4113 below) still applies, but base-type
+            // resolution is skipped and `member_exists_in_base` is forced
+            // `false` so the implicit-override requirement and the
+            // TS2416/accessor-kind compat checks below never fire for it.
+            let is_private_name = info.name.starts_with('#');
+            let base_type_for_member = if is_private_name {
+                None
+            } else if info.is_static {
                 base_static_type
             } else {
                 base_instance_type
@@ -291,11 +298,12 @@ impl<'a> CheckerState<'a> {
                         if type_id != TypeId::NEVER
                 )
             });
-            let member_exists_in_base = if info.is_static {
-                base_static_member_names.contains(&info.name)
-            } else {
-                base_instance_member_names.contains(&info.name)
-            } || member_exists_via_type;
+            let member_exists_in_base = !is_private_name
+                && ((if info.is_static {
+                    base_static_member_names.contains(&info.name)
+                } else {
+                    base_instance_member_names.contains(&info.name)
+                }) || member_exists_via_type);
 
             if info.has_dynamic_name {
                 if info.has_override {
@@ -361,6 +369,13 @@ impl<'a> CheckerState<'a> {
                         diagnostic_codes::THIS_MEMBER_MUST_HAVE_AN_OVERRIDE_MODIFIER_BECAUSE_IT_OVERRIDES_A_MEMBER_IN_THE
                     },
                 );
+            }
+
+            // See the `is_private_name` comment above: a private name never
+            // structurally relates to a base member, so none of the
+            // accessor-kind or type-compatibility checks below apply to it.
+            if is_private_name {
+                continue;
             }
 
             if !info.is_static

--- a/crates/tsz-checker/tests/override_modifier_private_identifier_tests.rs
+++ b/crates/tsz-checker/tests/override_modifier_private_identifier_tests.rs
@@ -1,0 +1,286 @@
+//! Regression tests: `override` on a private-identifier (`#foo`) class member
+//! must still be validated (TS4112/TS4113) even though private names never
+//! structurally participate in inheritance.
+//!
+//! `tsc`'s model: a `#foo` name is lexically scoped to the class body that
+//! declares it, so a derived class's `#foo` is never the same binding as a
+//! same-spelled `#foo` in a base class — there is no legal spelling under
+//! which `override` on a private name can be correct. tsz previously skipped
+//! override checking entirely for any member whose name starts with `#`
+//! (`crates/tsz-checker/src/classes/class_checker.rs`, and the mirror path in
+//! `crates/tsz-checker/src/classes/class_member_info.rs` for bases resolved
+//! only at the type level, e.g. cross-file generic bases) — silently dropping
+//! TS4113 (base exists) and, for the type-level path, TS4112 (no base) too.
+//!
+//! Every expectation below was verified against the pinned `typescript@7.0.2`
+//! oracle with `--noEmit --strict --lib es2022 --target es2022`.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::check_multi_file;
+use tsz_checker::test_utils::check_with_options;
+use tsz_common::common::ModuleKind;
+
+const TS4112: u32 = 4112;
+const TS4113: u32 = 4113;
+const TS4117: u32 = 4117;
+const TS2416: u32 = 2416;
+
+fn opts() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    }
+}
+
+fn codes(source: &str) -> Vec<u32> {
+    check_with_options(source, opts())
+        .iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+fn has_code(diags: &[Diagnostic], code: u32) -> bool {
+    diags.iter().any(|d| d.code == code)
+}
+
+// ---------------------------------------------------------------------------
+// TS4113: base class exists but does not (and structurally cannot) declare
+// the private name.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn override_private_property_with_base_reports_ts4113() {
+    let source = r#"
+class B {}
+class C extends B { override #x = 1; }
+"#;
+    assert_eq!(codes(source), vec![TS4113]);
+}
+
+#[test]
+fn override_private_method_with_base_reports_ts4113() {
+    let source = r#"
+class B {}
+class C extends B { override #m(): void {} }
+"#;
+    assert_eq!(codes(source), vec![TS4113]);
+}
+
+#[test]
+fn override_private_getter_with_base_reports_ts4113() {
+    let source = r#"
+class B {}
+class C extends B { override get #x(): number { return 1; } }
+"#;
+    assert_eq!(codes(source), vec![TS4113]);
+}
+
+#[test]
+fn override_static_private_property_with_base_reports_ts4113() {
+    let source = r#"
+class B {}
+class C extends B { static override #x = 1; }
+"#;
+    assert_eq!(codes(source), vec![TS4113]);
+}
+
+/// A private getter+setter pair independently reports TS4113 for each
+/// accessor — unlike the TS2416 compat check, the accessor-pair
+/// canonicalization does not apply to override-validity, matching `tsc`.
+#[test]
+fn override_private_accessor_pair_reports_ts4113_twice() {
+    let source = r#"
+class B {}
+class C extends B {
+  override get #x(): number { return 1; }
+  override set #x(v: number) {}
+}
+"#;
+    assert_eq!(codes(source), vec![TS4113, TS4113]);
+}
+
+/// Renamed-binder control: the class and member names carry no significance,
+/// only the private-identifier shape does.
+#[test]
+fn override_private_property_with_base_reports_ts4113_renamed() {
+    let source = r#"
+class Animal {}
+class Dog extends Animal { override #secretName = "Rex"; }
+"#;
+    assert_eq!(codes(source), vec![TS4113]);
+}
+
+/// Even when the base class declares an identically-spelled private member,
+/// `tsc` still reports TS4113 — the two `#x` names are unrelated bindings,
+/// lexically scoped to their own class bodies. This is the control that
+/// falsifies "match by spelling"-style fixes.
+#[test]
+fn override_private_property_matching_base_private_name_still_reports_ts4113() {
+    let source = r#"
+class B { #x = 1; }
+class C extends B { override #x = 2; }
+"#;
+    assert_eq!(codes(source), vec![TS4113]);
+}
+
+/// A generic base resolved via the AST (same file) hits the same code path.
+#[test]
+fn override_private_method_generic_base_reports_ts4113() {
+    let source = r#"
+class Base<T> { m(x: T): T { return x; } }
+class Derived<T> extends Base<T> { override #priv(x: T): T { return x; } }
+"#;
+    assert_eq!(codes(source), vec![TS4113]);
+}
+
+/// `tsc`'s "did you mean" suggestion (TS4117) is a plain edit-distance match
+/// against the base's own member names and is not privacy-aware: `#xxxx` is
+/// one edit from base's public `xxxx`, so `tsc` (and tsz) suggest it despite
+/// the member being private. This is not privacy-specific behavior to
+/// preserve on purpose — it's a side effect of reusing the same suggestion
+/// pool tsc uses — but it is the pinned oracle's actual output.
+#[test]
+fn override_private_property_suggests_close_base_name() {
+    let diags = check_with_options(
+        r#"
+class B { xxxx = 1; }
+class C extends B { override #xxxx = 1; }
+"#,
+        opts(),
+    );
+    assert_eq!(
+        diags.iter().map(|d| d.code).collect::<Vec<_>>(),
+        vec![TS4117]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TS4112: no base class at all. This path (`report_overrides_without_base`)
+// was already correct before this fix — held here as a regression control.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn override_private_property_without_base_reports_ts4112() {
+    let source = "class C { override #x = 1; }";
+    assert_eq!(codes(source), vec![TS4112]);
+}
+
+#[test]
+fn override_static_private_method_without_base_reports_ts4112() {
+    let source = "class C { static override #m(): void {} }";
+    assert_eq!(codes(source), vec![TS4112]);
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls: no `override` keyword and no `noImplicitOverride` — a
+// private member is never required to declare `override`, even when a base
+// class declares a same-spelled private member, since there is nothing to
+// structurally implicitly override.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn private_property_shadowing_base_private_no_override_is_clean() {
+    let source = r#"
+class B { #x = 1; }
+class C extends B { #x = 2; }
+"#;
+    assert_eq!(codes(source), Vec::<u32>::new());
+}
+
+#[test]
+fn private_property_shadowing_base_private_no_implicit_override_required() {
+    let diags = check_with_options(
+        r#"
+class B { #x = 1; }
+class C extends B { #x = 2; }
+"#,
+        CheckerOptions {
+            strict: true,
+            no_implicit_override: true,
+            ..CheckerOptions::default()
+        },
+    );
+    assert_eq!(
+        diags.iter().map(|d| d.code).collect::<Vec<_>>(),
+        Vec::<u32>::new()
+    );
+}
+
+/// A private member is never type-compatibility checked against the base
+/// (TS2416), even when the derived and base private members carry
+/// incompatible types — they are unrelated bindings.
+#[test]
+fn private_property_type_mismatch_vs_base_private_no_ts2416() {
+    let diags = check_with_options(
+        r#"
+class B { #x: string = "a"; }
+class C extends B { #x: number = 1; }
+"#,
+        opts(),
+    );
+    assert!(
+        !has_code(&diags, TS2416),
+        "private members must never be TS2416-compared against a base's same-spelled private member, got: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Positive control: an ordinary (non-private) member keeps reporting exactly
+// as before — this fix must not touch the public/protected override path.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn override_public_property_without_matching_base_member_still_reports_ts4113() {
+    let source = r#"
+class B {}
+class C extends B { override x = 1; }
+"#;
+    assert_eq!(codes(source), vec![TS4113]);
+}
+
+// ---------------------------------------------------------------------------
+// Cross-file / type-level base resolution path
+// (`check_override_members_against_type`, `class_member_info.rs`): a base
+// imported from another module whose full instance type is resolved
+// structurally rather than via a local AST class node hits a separate code
+// path from the single-file cases above and needs its own coverage.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn override_private_method_cross_file_generic_base_reports_ts4113() {
+    let diags = check_multi_file(
+        &[
+            (
+                "./base.ts",
+                r#"
+export class Base<T> {
+  m(x: T): T { return x; }
+}
+"#,
+            ),
+            (
+                "./derived.ts",
+                r#"
+import { Base } from "./base";
+export class Derived<T> extends Base<T> {
+  override #priv(x: T): T { return x; }
+}
+"#,
+            ),
+        ],
+        "./derived.ts",
+        CheckerOptions {
+            module: ModuleKind::ESNext,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+    );
+    assert_eq!(
+        diags.iter().map(|d| d.code).collect::<Vec<_>>(),
+        vec![TS4113],
+        "cross-file generic base must still validate a private override, got: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
Closes #16174.

`override`'s own legality check (TS4112 when the class has no base, TS4113 when it has one but doesn't declare the member) applies to every class member, including one named by a private identifier (`#foo`) — tsc always rejects `override` on a private name, since `#foo` is lexically scoped to the class body that declares it and can never be the same binding as a same-spelled `#foo` in a base class. tsz did the override legality check through two per-member loops (`class_checker.rs`'s AST-resolved-base path and `class_member_info.rs`'s type-level/cross-file path); both skipped ALL diagnostics for `#`-named members outright, silently dropping TS4112/TS4113 along with the (correctly skipped) base-type compatibility checks that don't apply to private names.

Fix: keep the override-validity check running for private names by forcing the base-lookup result to "not found" (`base_info = None` / `member_exists_in_base = false`) instead of skipping the member entirely, then skip only the base-compatibility checks (TS2415/TS2416/TS2610/TS2611, implicit-override) that don't apply once override-validity has run. Owner layer: checker (`crates/tsz-checker/src/classes/class_checker.rs` and `class_member_info.rs`); no solver or emitter involvement.

## Adjacent-case matrix

Every expectation verified against the pinned `typescript@7.0.2` oracle (`--noEmit --strict --lib es2022 --target es2022`): property/method/accessor/static member, with/without a base class, generic and cross-file bases, an accessor get/set pair (reports independently per accessor, matching tsc — not deduplicated like the TS2416 compat check), a renamed-binder control, and the sharpest control — a base class that itself declares an identically-spelled private member, which tsc still rejects (private names never cross a class boundary, even when the spelling repeats). Negative controls confirm no TS4114 (implicit-override) or TS2416 (type mismatch) fires for a private member merely sharing a name with a base's private member. TS4112 (no base at all) was already correct on main and is held here as a regression control, not new behavior.

## Goal
Goal: hold

## Verification
- New suite `override_modifier_private_identifier_tests`: 16/16 pass, every expectation pinned against the `typescript@7.0.2` oracle.
- `cargo test -p tsz-checker --lib override|class_private|private|ts4112|ts4113|ts4114` and the existing `ts4112_cross_file_override_heritage_tests`, `override_intersection_display_tests`, `no_implicit_override_ambient_context_tests`, `class_member_closure_tests` suites: 165+ tests across these filters, 0 failures, 0 regressions.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings`: clean.
- `cargo fmt -p tsz-checker -- --check`: clean.
- `python3 scripts/arch/arch_guard.py`: passed (`class_checker.rs` trimmed back to exactly the 2000-line boundary after the fix).
- Conformance: the committed `conformance-detail.json` has zero rows mentioning TS4112 or TS4113 — this family has no corpus fixture, so the oracle-pinned matrix above is the primary evidence (same "zero expected movement" signature as several other landed diagnostic-selection fixes today). Not run locally: this cloud container has no `TypeScript/` submodule checkout at all.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_014KQqzx6WQ5WuiZqMYBWc1A)_