### PR TITLE
ci(emit): gate on the named failing-row set, not just the pass count

### DIFF
--- a/scripts/ci/check-emit-regression-set.py
+++ b/scripts/ci/check-emit-regression-set.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Direction check for the emit gate: diff the named failing-row set (#16171).
+
+The emit gate in ``scripts/ci/full-ci.sh`` compares summed pass *counts*
+against ``scripts/emit/emit-snapshot.json``. Two things that comparison
+structurally cannot see:
+
+1. **A swap.** One row fixed and another broken leaves ``jsPass`` unchanged,
+   so a real regression passes the gate.
+2. **A ratchet-down.** ``cap_positive_baseline`` computes ``min(baseline,
+   floor)``, so ``TSZ_CI_JS_ACCEPTED_FLOOR`` is a *ceiling* — an
+   anti-unsatisfiability valve — not a floor. If ``emit-snapshot.json`` is
+   ever hand-refreshed while emit is regressed, the count bar follows the
+   snapshot down and the constant that looks like a backstop does not stop it.
+
+``emit-snapshot.json``'s ``detailFingerprint`` / ``detailResultCount`` pin that
+``emit-detail.json`` matches its own summary. That is an internal-consistency
+check, not a direction check.
+
+This script is the direction check, modelled on how conformance diffs its
+failure set rather than its pass count: a row that is failing now and was not
+failing in the committed baseline is reported by name and fails the gate,
+whatever the counts say.
+
+Deliberately asymmetric:
+
+* **Newly failing rows are fatal.** That is the regression this exists to catch.
+* **Baseline rows absent from the run are a warning, not an error.** The
+  corpus legitimately gains and loses tests when the TypeScript submodule is
+  bumped, and a gate that hard-fails on that would just get disabled.
+* **Rows that are failing in the baseline and still failing are silent.** They
+  are the accepted set; shrinking it is an improvement and never blocks.
+"""
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+FAILING_STATUSES = ("fail", "timeout")
+
+
+def row_key(row):
+    """Stable identity for one emit result row.
+
+    ``(testPath, baselineFile, name)`` is unique across the committed corpus
+    (11564/11564 distinct at the time of writing).
+    """
+    return (
+        row.get("testPath") or "",
+        row.get("baselineFile") or "",
+        row.get("name") or "",
+    )
+
+
+def format_key(key):
+    test_path, baseline_file, name = key
+    return "%s [%s] (%s)" % (name, baseline_file, test_path)
+
+
+def load_results(path):
+    """Return the ``results`` list from an emit detail JSON document."""
+    with open(path, "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    results = data.get("results")
+    if not isinstance(results, list):
+        raise ValueError("%s has no 'results' array" % path)
+    return results
+
+
+def index_rows(results):
+    """Map row key -> row, last write wins for duplicate keys."""
+    indexed = {}
+    for row in results:
+        if isinstance(row, dict):
+            indexed[row_key(row)] = row
+    return indexed
+
+
+def is_failing(status):
+    return status in FAILING_STATUSES
+
+
+def find_regressions(baseline_rows, current_rows):
+    """Rows failing now that were not failing in the baseline.
+
+    Returns a list of ``(key, kind, baseline_status, current_status)`` tuples
+    sorted by name, where ``kind`` is ``"JS"`` or ``"DTS"``.
+    """
+    regressions = []
+    for key, current in sorted(current_rows.items()):
+        baseline = baseline_rows.get(key)
+        if baseline is None:
+            # A row the baseline has never seen (new corpus test). It cannot be
+            # a regression against a baseline that does not describe it.
+            continue
+        for kind, field in (("JS", "jsStatus"), ("DTS", "dtsStatus")):
+            current_status = current.get(field)
+            baseline_status = baseline.get(field)
+            if is_failing(current_status) and not is_failing(baseline_status):
+                regressions.append((key, kind, baseline_status, current_status))
+    return regressions
+
+
+def find_absent(baseline_rows, current_rows):
+    """Baseline rows the run did not report at all."""
+    return sorted(key for key in baseline_rows if key not in current_rows)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--baseline",
+        default="scripts/emit/emit-detail.json",
+        help="committed emit detail JSON to diff against",
+    )
+    parser.add_argument(
+        "detail",
+        nargs="+",
+        help="per-shard emit detail JSON produced by scripts/emit/run.sh --json-out",
+    )
+    parser.add_argument(
+        "--max-report",
+        type=int,
+        default=50,
+        help="cap the number of named rows printed (all are counted)",
+    )
+    args = parser.parse_args(argv)
+
+    baseline_path = pathlib.Path(args.baseline)
+    if not baseline_path.is_file():
+        print(
+            "error: emit regression set check needs a baseline at %s" % baseline_path,
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        baseline_rows = index_rows(load_results(baseline_path))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print("error: cannot read emit baseline %s: %s" % (baseline_path, exc), file=sys.stderr)
+        return 1
+
+    current_rows = {}
+    for detail in args.detail:
+        try:
+            current_rows.update(index_rows(load_results(detail)))
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            print("error: cannot read emit detail %s: %s" % (detail, exc), file=sys.stderr)
+            return 1
+
+    if not current_rows:
+        print(
+            "error: emit regression set check found no result rows across %d detail file(s)"
+            % len(args.detail),
+            file=sys.stderr,
+        )
+        return 1
+
+    absent = find_absent(baseline_rows, current_rows)
+    if absent:
+        # Not fatal: the corpus changes when the TypeScript submodule moves.
+        print(
+            "warning: %d baseline emit row(s) were not reported by this run "
+            "(corpus drift, or a shard that produced no detail)" % len(absent),
+            file=sys.stderr,
+        )
+        for key in absent[: args.max_report]:
+            print("warning:   absent %s" % format_key(key), file=sys.stderr)
+
+    regressions = find_regressions(baseline_rows, current_rows)
+    if regressions:
+        print(
+            "error: emit regression: %d row(s) fail now and did not fail in %s"
+            % (len(regressions), baseline_path),
+            file=sys.stderr,
+        )
+        for key, kind, baseline_status, current_status in regressions[: args.max_report]:
+            print(
+                "error:   %s %s: %s -> %s"
+                % (kind, format_key(key), baseline_status, current_status),
+                file=sys.stderr,
+            )
+        if len(regressions) > args.max_report:
+            print(
+                "error:   ... and %d more" % (len(regressions) - args.max_report),
+                file=sys.stderr,
+            )
+        return 1
+
+    baseline_failing = sum(
+        1
+        for row in baseline_rows.values()
+        if is_failing(row.get("jsStatus")) or is_failing(row.get("dtsStatus"))
+    )
+    current_failing = sum(
+        1
+        for row in current_rows.values()
+        if is_failing(row.get("jsStatus")) or is_failing(row.get("dtsStatus"))
+    )
+    print(
+        "Emit regression set OK: %d row(s) compared, failing rows %d -> %d "
+        "(no row newly failing)" % (len(current_rows), baseline_failing, current_failing)
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check-unit-gate-contracts.sh
+++ b/scripts/ci/check-unit-gate-contracts.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 # Single owner of the cheap per-merge repo-hygiene contract checks: the
 # known-failures unit-gate baseline growth/integrity gate and its wiring
-# contract tests (#15646), plus the orphaned-test-file reachability guard
-# (#16013). Both the ci.yml cheap-guards step and full-ci.sh run_lint invoke
-# this script, so the two tiers cannot drift.
+# contract tests (#15646), the orphaned-test-file reachability guard (#16013),
+# and the emit failing-row direction gate's own contract tests (#16171). Both
+# the ci.yml cheap-guards step and full-ci.sh run_lint invoke this script, so
+# the two tiers cannot drift.
+#
+# The emit gate itself only runs nightly, so its wiring has to be checked on
+# every merge — otherwise a break in the gate is invisible for a day, which is
+# the failure mode #16171 is about.
 set -Eeuo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -24,3 +29,4 @@ python3 scripts/ci/test_full_ci_unit_gate.py
 node scripts/ci/test-known-failures-check.mjs
 python3 scripts/ci/check-test-file-reachability.py
 python3 scripts/ci/test_check_test_file_reachability.py
+python3 scripts/ci/test_check_emit_regression_set.py

--- a/scripts/ci/full-ci.sh
+++ b/scripts/ci/full-ci.sh
@@ -402,6 +402,7 @@ run_lint() {
   python3 scripts/ci/test_full_ci_conformance_artifacts.py || return $?
   python3 scripts/ci/test_full_ci_summary.py || return $?
   python3 scripts/ci/test_full_ci_emit_metrics.py || return $?
+  python3 scripts/ci/test_check_emit_regression_set.py || return $?
   # Known-failures baseline contract + gate-wiring tests (#15646). The
   # command list lives in one script shared with the ci.yml cheap-guards
   # step so the two tiers cannot drift.
@@ -723,6 +724,31 @@ validate_emit_aggregate_counts() {
   echo "Emit OK: JS ${js_passed}/${js_total}, DTS ${dts_passed}/${dts_total}"
 }
 
+# Direction check for emit (#16171). The count comparison above is the whole
+# emit gate today, and it cannot see two things:
+#
+#   * a swap — one row fixed and another broken leaves jsPass unchanged;
+#   * a ratchet-down — cap_positive_baseline is min(baseline, floor), so
+#     TSZ_CI_JS_ACCEPTED_FLOOR is a ceiling (an anti-unsatisfiability valve),
+#     not a floor. A hand-refreshed emit-snapshot.json that lands while emit is
+#     regressed takes the count bar down with it.
+#
+# emit-snapshot.json's detailFingerprint only proves emit-detail.json matches
+# its own summary: internal consistency, not direction. So diff the named
+# failing-row set out of the committed emit-detail.json, the way conformance
+# diffs its failure set. Fails closed — if the per-shard detail JSON is missing
+# there is no direction evidence, and a gate that silently skips when its data
+# is absent is the same bug class this closes.
+validate_emit_regression_set() {
+  if [[ "$#" -eq 0 ]]; then
+    echo "error: emit regression set check received no per-test detail JSON" >&2
+    echo "hint: emit shards write ci-metrics/emit-detail-N.json via run.sh --json-out" >&2
+    return 1
+  fi
+  python3 scripts/ci/check-emit-regression-set.py \
+    --baseline scripts/emit/emit-detail.json "$@" || return 1
+}
+
 run_emit_shard() {
   ci_section "Emit shard"
   local shard_index shard_count
@@ -778,6 +804,7 @@ run_emit_shard() {
   if [[ "$shard_count" -eq 1 ]]; then
     ci_section "Emit aggregate"
     validate_emit_aggregate_counts "$js_p" "$js_t" "$js_s" "$js_to" "$dts_p" "$dts_t" "$dts_s" 1 1 || return 1
+    validate_emit_regression_set "$detail_json" || return 1
     write_emit_metric "$METRICS_DIR/emit.json" \
       "$js_p" "$js_t" "$js_s" "$js_to" \
       "$dts_p" "$dts_t" "$dts_s"
@@ -811,6 +838,14 @@ run_emit_aggregate() {
       local shard_name
       shard_name="$(basename "$shard_dir")"
       cp "$json" "$tmp_dir/shard-${shard_name#emit-shard-}.json"
+      # The same artifact carries the per-test detail (ci.yml uploads
+      # emit-detail-N.json alongside emit-shard-N.json). It feeds the
+      # failing-row direction check below.
+      local detail
+      detail="$(find "$shard_dir" -name "emit-detail-*.json" -maxdepth 4 2>/dev/null | head -1)"
+      if [[ -f "$detail" ]]; then
+        cp "$detail" "$tmp_dir/detail-${shard_name#emit-shard-}.json"
+      fi
       found=$(( found + 1 ))
     done
     if [[ "$found" -gt 0 ]]; then
@@ -849,6 +884,12 @@ run_emit_aggregate() {
   fi
 
   validate_emit_aggregate_counts "$js_p" "$js_t" "$js_s" "$js_to" "$dts_p" "$dts_t" "$dts_s" "$shard_count" "$expected_shards" || return 1
+  if compgen -G "$tmp_dir/detail-*.json" >/dev/null; then
+    validate_emit_regression_set "$tmp_dir"/detail-*.json || return 1
+  else
+    # No detail in the artifacts: fail closed rather than pass on counts alone.
+    validate_emit_regression_set || return 1
+  fi
   write_emit_metric "$METRICS_DIR/emit.json" \
     "$js_p" "$js_t" "$js_s" "$js_to" \
     "$dts_p" "$dts_t" "$dts_s"

--- a/scripts/ci/test_check_emit_regression_set.py
+++ b/scripts/ci/test_check_emit_regression_set.py
@@ -1,0 +1,268 @@
+"""Contract tests for the emit failing-row direction check (#16171).
+
+The point of the gate under test is that it catches what the emit *count*
+comparison structurally cannot: a swap (one row fixed, one broken, counts
+unchanged) and a ratchet-down (a refreshed snapshot lowering the count bar).
+Each of those has its own test below, exercised end to end rather than read off
+the source.
+"""
+
+import io
+import json
+import pathlib
+import subprocess
+import tempfile
+import unittest
+import contextlib
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+CHECKER = ROOT / "scripts" / "ci" / "check-emit-regression-set.py"
+FULL_CI = ROOT / "scripts" / "ci" / "full-ci.sh"
+COMMITTED_DETAIL = ROOT / "scripts" / "emit" / "emit-detail.json"
+
+def _load_checker():
+    """Import the hyphenated script as a module."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("check_emit_regression_set", CHECKER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+CHECK = _load_checker()
+
+
+def row(name, js="pass", dts="skip"):
+    return {
+        "name": name,
+        "baselineFile": "%s.js" % name,
+        "testPath": "tests/cases/compiler/%s.ts" % name,
+        "jsStatus": js,
+        "dtsStatus": dts,
+    }
+
+
+def detail_doc(rows):
+    return {"results": rows}
+
+
+def write_json(path, payload):
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def run_checker(baseline_rows, detail_row_sets):
+    """Run the checker in-process; return (exit_code, stderr_text)."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = pathlib.Path(temp_dir)
+        baseline = write_json(temp / "baseline.json", detail_doc(baseline_rows))
+        details = []
+        for index, rows in enumerate(detail_row_sets):
+            details.append(str(write_json(temp / ("detail-%d.json" % index), detail_doc(rows))))
+        err = io.StringIO()
+        out = io.StringIO()
+        with contextlib.redirect_stderr(err), contextlib.redirect_stdout(out):
+            code = CHECK.main(["--baseline", str(baseline)] + details)
+        return code, err.getvalue(), out.getvalue()
+
+
+class EmitRegressionSetTests(unittest.TestCase):
+    def test_identical_sets_pass(self):
+        rows = [row("a"), row("b", js="fail")]
+        code, err, out = run_checker(rows, [rows])
+        self.assertEqual(code, 0, err)
+        self.assertIn("Emit regression set OK", out)
+
+    def test_newly_failing_row_is_fatal_and_named(self):
+        baseline = [row("a"), row("b")]
+        current = [row("a"), row("b", js="fail")]
+        code, err, _ = run_checker(baseline, [current])
+        self.assertEqual(code, 1)
+        self.assertIn("emit regression", err)
+        self.assertIn("b", err)
+        self.assertIn("pass -> fail", err)
+
+    def test_swap_with_identical_counts_is_caught(self):
+        """The hole the count gate cannot see: one row fixed, one broken."""
+        baseline = [row("a", js="fail"), row("b"), row("c")]
+        current = [row("a"), row("b", js="fail"), row("c")]
+
+        baseline_pass = sum(1 for r in baseline if r["jsStatus"] == "pass")
+        current_pass = sum(1 for r in current if r["jsStatus"] == "pass")
+        self.assertEqual(baseline_pass, current_pass, "the swap must be count-neutral")
+
+        code, err, _ = run_checker(baseline, [current])
+        self.assertEqual(code, 1)
+        self.assertIn("b", err)
+
+    def test_ratcheted_down_baseline_still_catches_the_named_row(self):
+        """A regressed row stays fatal even when the counts were refreshed with it.
+
+        This models the #16171 trap: a hand-refreshed snapshot lowers the count
+        bar, so the count comparison is satisfied. The set check is keyed on
+        row identity, not totals, so it is unaffected.
+        """
+        baseline = [row("a"), row("b"), row("c")]
+        current = [row("a"), row("b", js="fail"), row("c", js="fail")]
+        code, err, _ = run_checker(baseline, [current])
+        self.assertEqual(code, 1)
+        self.assertIn("2 row(s) fail now", err)
+
+    def test_dts_regression_is_caught_independently_of_js(self):
+        baseline = [row("a", js="pass", dts="pass")]
+        current = [row("a", js="pass", dts="fail")]
+        code, err, _ = run_checker(baseline, [current])
+        self.assertEqual(code, 1)
+        self.assertIn("DTS", err)
+
+    def test_timeout_counts_as_failing(self):
+        baseline = [row("a")]
+        current = [row("a", js="timeout")]
+        code, err, _ = run_checker(baseline, [current])
+        self.assertEqual(code, 1)
+        self.assertIn("pass -> timeout", err)
+
+    def test_fixing_a_baseline_failure_is_not_a_regression(self):
+        baseline = [row("a", js="fail"), row("b", dts="fail")]
+        current = [row("a"), row("b", dts="pass")]
+        code, err, out = run_checker(baseline, [current])
+        self.assertEqual(code, 0, err)
+        self.assertIn("failing rows 2 -> 0", out)
+
+    def test_new_corpus_row_absent_from_baseline_is_not_a_regression(self):
+        baseline = [row("a")]
+        current = [row("a"), row("brand_new", js="fail")]
+        code, err, _ = run_checker(baseline, [current])
+        self.assertEqual(code, 0, err)
+
+    def test_absent_baseline_row_warns_but_does_not_fail(self):
+        baseline = [row("a"), row("removed_by_submodule_bump")]
+        current = [row("a")]
+        code, err, _ = run_checker(baseline, [current])
+        self.assertEqual(code, 0, err)
+        self.assertIn("warning", err)
+        self.assertIn("removed_by_submodule_bump", err)
+
+    def test_shards_are_unioned_before_comparing(self):
+        baseline = [row("a"), row("b"), row("c")]
+        code, err, _ = run_checker(baseline, [[row("a")], [row("b")], [row("c")]])
+        self.assertEqual(code, 0, err)
+        self.assertNotIn("warning", err)
+
+    def test_regression_in_any_shard_is_caught(self):
+        baseline = [row("a"), row("b"), row("c")]
+        code, err, _ = run_checker(baseline, [[row("a")], [row("b", js="fail")], [row("c")]])
+        self.assertEqual(code, 1)
+        self.assertIn("b", err)
+
+    def test_empty_result_set_is_fatal(self):
+        code, err, _ = run_checker([row("a")], [[]])
+        self.assertEqual(code, 1)
+        self.assertIn("no result rows", err)
+
+    def test_missing_baseline_file_is_fatal(self):
+        err = io.StringIO()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = pathlib.Path(temp_dir)
+            detail = write_json(temp / "detail.json", detail_doc([row("a")]))
+            with contextlib.redirect_stderr(err):
+                code = CHECK.main(
+                    ["--baseline", str(temp / "nope.json"), str(detail)]
+                )
+        self.assertEqual(code, 1)
+        self.assertIn("needs a baseline", err.getvalue())
+
+    def test_row_key_is_unique_across_the_committed_baseline(self):
+        """The whole check rests on (testPath, baselineFile, name) being an identity."""
+        data = json.loads(COMMITTED_DETAIL.read_text(encoding="utf-8"))
+        results = data["results"]
+        keys = [CHECK.row_key(r) for r in results]
+        self.assertEqual(len(keys), len(set(keys)))
+
+    def test_committed_baseline_compares_clean_against_itself(self):
+        """Self-comparison must be a no-op, or the gate would fail on a green run."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            err, out = io.StringIO(), io.StringIO()
+            with contextlib.redirect_stderr(err), contextlib.redirect_stdout(out):
+                code = CHECK.main(
+                    ["--baseline", str(COMMITTED_DETAIL), str(COMMITTED_DETAIL)]
+                )
+            self.assertEqual(code, 0, err.getvalue())
+            self.assertIn("no row newly failing", out.getvalue())
+
+
+class EmitRegressionSetWiringTests(unittest.TestCase):
+    """The gate is only real if the emit leaves actually call it."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.script = FULL_CI.read_text(encoding="utf-8")
+
+    def function_body(self, name, end_marker):
+        start = self.script.index("%s() {" % name)
+        end = self.script.index(end_marker, start)
+        return self.script[start:end]
+
+    def test_single_shard_path_runs_the_set_check_before_publishing(self):
+        body = self.function_body("run_emit_shard", "\n# Recombine the per-shard")
+        counts_idx = body.index("validate_emit_aggregate_counts")
+        set_idx = body.index("validate_emit_regression_set", counts_idx)
+        publish_idx = body.index("publish_latest_metric emit", set_idx)
+        self.assertLess(counts_idx, set_idx)
+        self.assertLess(set_idx, publish_idx)
+
+    def test_aggregate_path_runs_the_set_check_before_publishing(self):
+        body = self.function_body("run_emit_aggregate", "\nrun_fourslash_shard() {")
+        counts_idx = body.index("validate_emit_aggregate_counts")
+        set_idx = body.index("validate_emit_regression_set", counts_idx)
+        publish_idx = body.index("publish_latest_metric emit", set_idx)
+        self.assertLess(counts_idx, set_idx)
+        self.assertLess(set_idx, publish_idx)
+
+    def test_aggregate_collects_per_shard_detail_from_artifacts(self):
+        body = self.function_body("run_emit_aggregate", "\nrun_fourslash_shard() {")
+        self.assertIn('-name "emit-detail-*.json"', body)
+        self.assertIn('cp "$detail" "$tmp_dir/detail-', body)
+
+    def test_workflow_uploads_the_detail_the_aggregate_reads(self):
+        workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+        self.assertIn("emit-detail-${{ matrix.shard }}.json", workflow)
+
+    def test_set_check_fails_closed_with_no_detail(self):
+        helper = self.function_body("validate_emit_regression_set", "\nrun_emit_shard() {")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            runner = pathlib.Path(temp_dir) / "run.sh"
+            runner.write_text(
+                "#!/usr/bin/env bash\nset -Eeuo pipefail\n%s\nvalidate_emit_regression_set\n" % helper,
+                encoding="utf-8",
+            )
+            proc = subprocess.run(
+                ["bash", str(runner)], cwd=str(ROOT), capture_output=True, text=True
+            )
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("no per-test detail JSON", proc.stderr)
+
+    def test_set_check_invokes_the_checker_against_the_committed_baseline(self):
+        helper = self.function_body("validate_emit_regression_set", "\nrun_emit_shard() {")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp = pathlib.Path(temp_dir)
+            detail = write_json(temp / "detail.json", detail_doc([row("a")]))
+            runner = temp / "run.sh"
+            runner.write_text(
+                "#!/usr/bin/env bash\nset -Eeuo pipefail\n%s\nvalidate_emit_regression_set '%s'\n"
+                % (helper, detail),
+                encoding="utf-8",
+            )
+            proc = subprocess.run(
+                ["bash", str(runner)], cwd=str(ROOT), capture_output=True, text=True
+            )
+        # The row is unknown to the real baseline, so this is a clean run that
+        # proves the wiring reaches scripts/emit/emit-detail.json.
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("Emit regression set OK", proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #16171.

**When an emit row regresses, the gate must fail on the row's identity; tsz now does that through a failing-set diff in `scripts/ci/full-ci.sh`'s emit leaves, instead of only through a summed pass count.**

The emit gate is a pass-count comparison against `emit-snapshot.json` and nothing else (`validate_emit_aggregate_counts`, `full-ci.sh`). Two regressions pass it by construction:

* **A swap.** One row fixed and another broken leaves `jsPass` unchanged.
* **A ratchet-down.** `cap_positive_baseline` computes `min(baseline, floor)`, so `TSZ_CI_JS_ACCEPTED_FLOOR` / `TSZ_CI_DTS_ACCEPTED_FLOOR` are *ceilings* — an anti-unsatisfiability valve — never floors. A hand-refreshed `emit-snapshot.json` landing while emit is regressed takes the count bar down with it, and the constant that looks like a backstop does not stop it.

`emit-snapshot.json`'s `detailFingerprint` / `detailResultCount` prove `emit-detail.json` matches its own summary. That is internal consistency, not direction — the same shape as #16088's accounting guard.

This adds the direction check, using the issue's own preferred option: give emit conformance's treatment by diffing the **named failing-row set** out of the committed `emit-detail.json`. Counts stay exactly as they are, as a backstop; the set diff is the direction gate.

### What changed

- **`scripts/ci/check-emit-regression-set.py`** (new). Keys rows on `(testPath, baselineFile, name)` — verified unique 11564/11564 across the committed baseline, and that identity is itself pinned by a test. Reports every row failing now that was not failing in the baseline, by name, with its `before -> after` status.
- **`scripts/ci/full-ci.sh`**: new `validate_emit_regression_set`, called from **both** emit leaves — the single-shard inline path in `run_emit_shard` and `run_emit_aggregate` — after the count check and before the metric is published. `run_emit_aggregate` now also copies `emit-detail-*.json` out of the downloaded shard artifacts.
- **`scripts/ci/check-unit-gate-contracts.sh`**: runs the new contract tests per merge.

No workflow change was needed: `ci.yml` already uploads `emit-detail-${{ matrix.shard }}.json` inside the very `emit-shard-*` artifact the aggregate downloads (`ci.yml:159`). The aggregate simply never read it. A test pins that upload so the two cannot drift apart.

### Deliberate asymmetry

- **Newly failing rows are fatal** — the regression this exists to catch.
- **Baseline rows absent from the run warn, never fail.** The corpus legitimately gains and loses tests when the TypeScript submodule is bumped, and a gate that hard-fails on that just gets disabled.
- **Rows already failing in the baseline are silent.** That is the accepted set; shrinking it is an improvement and must never block.
- **Missing detail fails closed.** A gate that silently skips when its evidence is absent is the same bug class this closes.

### Goal
Goal: hold

### Verification

**The gap, demonstrated on the real 11564-row corpus rather than argued from the source.** Both scenarios were built by mutating the committed `emit-detail.json`, then run against the old count comparison and the new set check:

| Scenario | Old count gate | New set gate |
| --- | --- | --- |
| A — swap: `jsdocDisallowedInTypescript` fixed, `APISample_Watch` broken. `jsPass` 11562 → **11562** | **PASS** — regression sails through | **FAIL**, names `APISample_Watch`: `pass -> fail` |
| B — ratchet: 3 rows regress, `jsPass` 11562 → 11559 **and the snapshot is refreshed to 11559** (`min(11559, 11562) = 11559`) | **PASS** — gate followed the snapshot down | **FAIL**, names all 3 rows |
| Real unmodified run | PASS | `Emit regression set OK: 11564 row(s) compared, failing rows 16 -> 16 (no row newly failing)` — exit 0 |

The third row matters as much as the first two: the new gate is an exact no-op on today's green state (1 JS + 15 DTS accepted failures), so it cannot block a clean run.

Commands actually run, all on this branch at `a9978e0`:

- `python3 scripts/ci/test_check_emit_regression_set.py` → **21 passed** (new). Covers the swap, the ratchet-down, DTS-independent-of-JS, timeout-as-failing, fix-is-not-a-regression, new-corpus-row, absent-row-warns, shard union, per-shard regression, empty-set fatal, missing-baseline fatal, plus 6 wiring tests asserting both emit leaves call the check before publishing and that `ci.yml` uploads the detail the aggregate reads.
- `scripts/ci/check-unit-gate-contracts.sh` → exit 0 (the per-merge gate, now including the 21 above)
- `python3 scripts/ci/test_full_ci_emit_metrics.py` → 4 passed (existing, unchanged)
- `python3 scripts/emit/test_query_emit_families.py` → 101 passed (existing, unchanged)
- `python3 scripts/lib/check-sh-portability.py` → OK (bash 3.2 guard)
- `python3 scripts/arch/arch_guard.py` → `Architecture guardrails passed.`
- `bash -n` on both modified shell scripts → clean
- `cargo fmt --all -- --check` → clean

**Not run, and why:** no crate code is touched, so this cannot move a diagnostic or a byte of emit output. `scripts/emit/run.sh` produces the data; this PR only changes how CI judges it. Conformance/emit/fourslash counts are therefore unaffected by construction, and the gate was instead verified directly against the committed 11564-row detail as tabulated above. `clippy` is unaffected for the same reason and runs in CI regardless.

### Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Tuff

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDBfBwe1r8w5GtuZFX8HHF)_