### PR TITLE
fix(checker): blame the setter, not the getter, when an accessor pair supplies no property type

### DIFF
--- a/crates/tsz-checker/src/checkers/accessor_checker.rs
+++ b/crates/tsz-checker/src/checkers/accessor_checker.rs
@@ -115,6 +115,48 @@ impl<'a> CheckerState<'a> {
     /// The mirror of `paired_getter_in_members`: given a getter, find its
     /// setter by property name, falling back to computed-name symbol
     /// identity when the name is not a literal.
+    /// The `set` accessor paired with `getter_accessor` in the enclosing class.
+    ///
+    /// Distinct from `contextual_getter_return_type_for_class_accessor`, which
+    /// answers only for an *annotated* setter because it is looking for a type.
+    /// This answers whether the pair exists at all, which is what decides where
+    /// `tsc` anchors a missing property type: a getter with any paired setter is
+    /// never the blame site.
+    pub(crate) fn paired_setter_member_for_getter(
+        &self,
+        getter_accessor: &tsz_parser::parser::node::AccessorData,
+    ) -> Option<NodeIndex> {
+        let class_info = self.ctx.enclosing_class.as_ref()?;
+        let members = class_info.member_nodes.clone();
+        self.paired_setter_in_members(&members, getter_accessor)
+    }
+
+    /// Whether the `get` accessor paired with `setter_accessor` supplies the
+    /// property's type — by a return-type annotation, or by a body to infer one
+    /// from.
+    ///
+    /// This is deliberately *not* the same question as "does a paired getter
+    /// exist". A paired getter always contextually types the setter's parameter
+    /// (so it always suppresses TS7006), but it only supplies the *property's*
+    /// type when it has an annotation or a body. A bodyless, unannotated getter
+    /// — the ordinary shape in a `declare class` — supplies nothing, and `tsc`
+    /// then reports TS7032 on the setter.
+    pub(crate) fn paired_getter_supplies_property_type(
+        &self,
+        setter_accessor: &tsz_parser::parser::node::AccessorData,
+    ) -> bool {
+        let Some(getter_idx) = self.paired_getter_member_for_setter(setter_accessor) else {
+            return false;
+        };
+        let Some(getter_node) = self.ctx.arena.get(getter_idx) else {
+            return false;
+        };
+        let Some(getter) = self.ctx.arena.get_accessor(getter_node) else {
+            return false;
+        };
+        getter.type_annotation.is_some() || getter.body.is_some()
+    }
+
     pub(crate) fn paired_setter_in_members(
         &self,
         members: &[NodeIndex],
@@ -313,10 +355,16 @@ impl<'a> CheckerState<'a> {
     /// ## Error Messages:
     /// - TS1052: "A 'set' accessor parameter cannot have an initializer."
     /// - TS1053: "A 'set' accessor cannot have rest parameter."
+    ///
+    /// `paired_getter_supplies_type` is the TS7032 half of `has_paired_getter`:
+    /// a paired getter always contextually types the parameter (TS7006), but
+    /// only one with an annotation or a body gives the *property* a type
+    /// (TS7032). See `paired_getter_supplies_property_type`.
     pub(crate) fn check_setter_parameter(
         &mut self,
         parameters: &[NodeIndex],
         has_paired_getter: bool,
+        paired_getter_supplies_type: bool,
         accessor_jsdoc: Option<&str>,
         accessor_name: Option<NodeIndex>,
     ) {
@@ -367,18 +415,29 @@ impl<'a> CheckerState<'a> {
             // the getter return type, so it's contextually typed (suppress TS7006).
             // Also check for inline JSDoc @param/@type annotations and accessor-level
             // JSDoc @param annotations (e.g., `/** @param {string} value */ set p(value)`).
-            let has_jsdoc = has_paired_getter
-                || self.param_has_inline_jsdoc_type(param_idx)
+            let jsdoc_declares_type = self.param_has_inline_jsdoc_type(param_idx)
                 || accessor_jsdoc.is_some_and(|jsdoc| {
                     let pname = self.parameter_name_for_error(param.name);
                     Self::jsdoc_has_param_type(jsdoc, &pname)
                         || Self::jsdoc_type_tag_declares_callable(jsdoc)
                 });
+            let has_jsdoc = has_paired_getter || jsdoc_declares_type;
             self.maybe_report_implicit_any_parameter(param, has_jsdoc, 0);
 
             // Also report TS7032 on the setter name if the parameter implicitly has type any.
+            //
+            // A paired getter suppresses this only when it actually supplies the
+            // property's type. `declare class A { get g(); set g(v); }` has a
+            // paired getter and still reports TS7032 on the setter, because
+            // neither accessor names a type — the pair shares one property type
+            // and nothing provides it. The TS7006 flag above cannot be reused
+            // here: it folds in `has_paired_getter` unconditionally, which is
+            // right for contextually typing the parameter and wrong for deciding
+            // whether the property has a type at all.
+            let property_type_supplied =
+                jsdoc_declares_type || (has_paired_getter && paired_getter_supplies_type);
             if param.type_annotation.is_none()
-                && !has_jsdoc
+                && !property_type_supplied
                 && self.ctx.no_implicit_any()
                 && let Some(name_idx) = accessor_name
             {

--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -1448,9 +1448,12 @@ impl<'a> CheckerState<'a> {
             } else {
                 None
             };
+            let paired_getter_supplies_type =
+                self.paired_getter_supplies_property_type(accessor) || skip_implicit_any_accessor;
             self.check_setter_parameter(
                 &accessor.parameters.nodes,
                 has_paired_getter || skip_implicit_any_accessor,
+                paired_getter_supplies_type,
                 accessor_jsdoc.as_deref(),
                 accessor_name,
             );
@@ -1591,16 +1594,17 @@ impl<'a> CheckerState<'a> {
             // plain class too, where tsc emits it alongside the syntax error.
             //
             // This is the accessor analogue of the bodyless-method TS7010 arm above,
-            // and it carries one exemption that arm does not need: a getter paired
-            // with an annotated setter takes its type from the setter
-            // (tsc's `isGetAccessorWithAnnotatedSetAccessor`), so it is not implicitly
-            // `any` and must stay clean. `get g(); set g(v: number);` is ordinary in
-            // real declaration files.
+            // and it carries one exemption that arm does not need: a get/set pair
+            // shares a single property type, and when it is missing tsc blames the
+            // *setter* (TS7032 on the setter name), never the getter. So ANY paired
+            // setter takes the getter out of TS7033 — not just an annotated one.
+            // An annotated setter supplies the type outright
+            // (tsc's `isGetAccessorWithAnnotatedSetAccessor`); an unannotated one
+            // becomes the blame site itself and is reported there by
+            // `check_setter_parameter`. Either way the getter stays clean.
             if self.ctx.no_implicit_any()
                 && !self.is_js_file()
-                && self
-                    .contextual_getter_return_type_for_class_accessor(accessor)
-                    .is_none()
+                && self.paired_setter_member_for_getter(accessor).is_none()
                 && let Some(accessor_name) = self.get_property_name(accessor.name)
             {
                 use crate::diagnostics::diagnostic_codes;

--- a/crates/tsz-checker/tests/noimplicitany_ambient_member_surface_tests.rs
+++ b/crates/tsz-checker/tests/noimplicitany_ambient_member_surface_tests.rs
@@ -27,6 +27,8 @@ use tsz_checker::test_utils::check_source_strict_codes;
 const TS7008: u32 = 7008; // Member implicitly has an 'any' type.
 const TS7010: u32 = 7010; // Lacks return-type annotation, implicitly 'any' return.
 const TS7033: u32 = 7033; // Property implicitly 'any', get accessor lacks return type.
+const TS7006: u32 = 7006; // Parameter implicitly has an 'any' type.
+const TS7032: u32 = 7032; // Property implicitly 'any', set accessor lacks a param type.
 
 fn has(codes: &[u32], code: u32) -> bool {
     codes.contains(&code)
@@ -90,6 +92,106 @@ fn getter_paired_with_annotated_setter_is_clean() {
         !has(&codes, TS7033),
         "paired annotated setter supplies the getter's type: {codes:?}"
     );
+}
+
+// --- the pairing rule: who gets blamed when neither side names a type -------
+//
+// A get/set pair shares ONE property type. It comes from the getter's return
+// type (annotation, or inferred from a body) if there is one, else from the
+// setter's parameter annotation. When nothing supplies it, `tsc` blames the
+// *setter* with TS7032 — the getter is only the blame site when it has no
+// paired setter at all. Issue #16183.
+
+#[test]
+fn unannotated_pair_blames_the_setter_not_the_getter() {
+    // tsc: TS7032 on the setter name, and no TS7033.
+    let codes = check_source_strict_codes("declare class A { get g(); set g(v); }");
+    assert!(
+        has(&codes, TS7032),
+        "expected TS7032 on the setter: {codes:?}"
+    );
+    assert!(
+        !has(&codes, TS7033),
+        "a getter with any paired setter is never the blame site: {codes:?}"
+    );
+}
+
+#[test]
+fn unannotated_pair_blames_the_setter_in_declaration_order_too() {
+    // Same pair, setter declared first — pairing is by name, not by order.
+    let codes = check_source_strict_codes("declare class A { set g(v); get g(); }");
+    assert!(has(&codes, TS7032), "expected TS7032: {codes:?}");
+    assert!(
+        !has(&codes, TS7033),
+        "no TS7033 on the paired getter: {codes:?}"
+    );
+}
+
+#[test]
+fn unannotated_static_pair_blames_the_setter() {
+    let codes = check_source_strict_codes("declare class A { static get g(); static set g(v); }");
+    assert!(has(&codes, TS7032), "expected TS7032: {codes:?}");
+    assert!(!has(&codes, TS7033), "no TS7033: {codes:?}");
+}
+
+#[test]
+fn unannotated_pair_does_not_report_ts7006_on_the_parameter() {
+    // The paired getter still contextually types the parameter, so TS7006 stays
+    // suppressed even though TS7032 fires. These two suppressions are different
+    // questions and a single flag cannot answer both.
+    let codes = check_source_strict_codes("declare class A { get g(); set g(v); }");
+    assert!(
+        !has(&codes, TS7006),
+        "paired getter contextually types the param: {codes:?}"
+    );
+}
+
+#[test]
+fn annotated_getter_supplies_the_pair_type() {
+    let codes = check_source_strict_codes("declare class A { get g(): number; set g(v); }");
+    assert!(
+        !has(&codes, TS7032),
+        "getter annotation supplies it: {codes:?}"
+    );
+    assert!(
+        !has(&codes, TS7033),
+        "getter annotation supplies it: {codes:?}"
+    );
+}
+
+#[test]
+fn getter_with_a_body_supplies_the_pair_type() {
+    // The common non-ambient shape. The getter's body infers `number`, so the
+    // pair has a type and neither side reports — this is the row a naive
+    // "any paired getter without an annotation means TS7032" rule would break.
+    let codes = check_source_strict_codes("class B { get g() { return 1; } set g(v) {} }");
+    assert!(!has(&codes, TS7032), "inferred from the body: {codes:?}");
+    assert!(!has(&codes, TS7033), "inferred from the body: {codes:?}");
+}
+
+#[test]
+fn lone_unannotated_setter_reports_both_ts7032_and_ts7006() {
+    // No getter to contextually type the parameter, so both fire.
+    let codes = check_source_strict_codes("declare class A { set s(v); }");
+    assert!(has(&codes, TS7032), "expected TS7032: {codes:?}");
+    assert!(has(&codes, TS7006), "expected TS7006: {codes:?}");
+}
+
+#[test]
+fn any_annotation_on_the_setter_supplies_the_pair_type() {
+    // It is the annotation's *presence* that matters, not its type — `any`
+    // written explicitly is not an implicit any.
+    let codes = check_source_strict_codes("declare class A { get g(); set g(v: any); }");
+    assert!(!has(&codes, TS7032), "explicit annotation: {codes:?}");
+    assert!(!has(&codes, TS7033), "explicit annotation: {codes:?}");
+}
+
+#[test]
+fn hidden_ambient_pair_stays_clean_through_the_pairing_rule() {
+    // The surface rule from #16178 still wins over the pairing rule.
+    let codes = check_source_strict_codes("declare class A { get #g(); set #g(v); }");
+    assert!(!has(&codes, TS7032), "hidden from the surface: {codes:?}");
+    assert!(!has(&codes, TS7033), "hidden from the surface: {codes:?}");
 }
 
 #[test]


### PR DESCRIPTION
Closes #16183 — the residual Quartz found reviewing #16181. That was my PR, so this is my follow-up rather than a handoff.

## Structural rule

**A get/set accessor pair shares one property type.** It comes from the getter's return type — annotated, or inferred from a body — if there is one, else from the setter's parameter annotation. When *nothing* supplies it, `tsc` reports **TS7032 on the setter's name**. The getter is the blame site only when it has no paired setter at all (TS7033). tsz now does this through the checker's accessor walk (`checkers/accessor_checker.rs` + `state_checking_members/ambient_signature_checks.rs`).

Two gates were wrong, in opposite directions, and they had to be fixed together:

**1 — TS7033 exempted too little.** #16181's new arm keyed its exemption on an *annotated* paired setter (`isGetAccessorWithAnnotatedSetAccessor`). But an unannotated paired setter takes the getter out of TS7033 just as completely — it does not supply the type, it becomes the blame site instead. The exemption is now "any paired setter", via a new `paired_setter_member_for_getter`.

**2 — TS7032 exempted too much, and this half predates #16181.** `check_setter_parameter` computed one `has_jsdoc` flag folding in `has_paired_getter`, then used it to gate *both* TS7006 and TS7032. Those are different questions. A paired getter always contextually types the *parameter* (so it always suppresses TS7006 — correct), but it only gives the *property* a type when it has an annotation or a body. Reusing one flag meant any paired getter silenced TS7032, so `declare class A { get g(); set g(v); }` was clean on main before #16181 too — a false negative that #16181 then converted into a wrong-code/wrong-position TS7033.

Splitting them is the whole fix. New `paired_getter_supplies_property_type` answers the second question; `jsdoc_declares_type` is now separated from `has_paired_getter` so a JSDoc-typed parameter still suppresses TS7032 on its own.

## Oracle

14 rows re-derived against pinned `typescript@7.0.2` (`--noEmit --strict --lib es2022 --target es2022`). The rows that decide the rule:

| source | tsc | main (post-#16181) |
| --- | --- | --- |
| `declare class A { get g(); set g(v); }` | TS7032 @32 | **TS7033 @23** ❌ |
| `declare class A { set g(v); get g(); }` | TS7032 @23 | **TS7033** ❌ |
| `declare class A { static get g(); static set g(v); }` | TS7032 @46 | **TS7033** ❌ |
| `declare class A { get g(): number; set g(v); }` | clean | clean ✅ |
| `class B { get g() { return 1; } set g(v) {} }` | clean | clean ✅ |
| `declare class A { get g(); set g(v: any); }` | clean | clean ✅ |
| `declare class A { set s(v); }` | TS7032 + TS7006 | same ✅ |
| `declare class A { get g(); }` | TS7033 @23 | same ✅ |
| `declare class A { get #g(); set #g(v); }` | clean | clean ✅ |

Three things this pins that a narrower rule would get wrong:

- **The bodied getter row is the trap.** `class B { get g() { return 1; } set g(v) {} }` is clean because the getter's *body* supplies the type. A rule of "paired getter without an annotation ⇒ TS7032" would report on the single most common real-world accessor shape. Hence `annotation.is_some() || body.is_some()`, not just the annotation.
- **TS7006 must stay suppressed on the same row TS7032 fires.** `get g(); set g(v);` gets TS7032 and *no* TS7006 — the parameter really is contextually typed by the getter; it is the property that has no type. Pinned as its own test.
- **It is the annotation's presence, not its type.** `set g(v: any)` is clean in both — an explicit `any` is not an implicit one.

## Adjacent-case matrix

9 tests added to `noimplicitany_ambient_member_surface_tests.rs` (now 28): unannotated pair in both declaration orders, `static` pair, annotated-getter pair, bodied-getter pair, `any`-annotated setter, lone unannotated setter, the TS7006-stays-suppressed row, and the `#`-named ambient pair confirming #16178's surface rule still wins over the pairing rule.

## Goal

Goal: hold

## Verification

- **Flip measured against main**, not assumed: stashed only the two source hunks and re-ran the same binary → **25 passed / 3 failed**, the 3 being exactly the unannotated-pair rows (`[7033]` → `[7032]`). The other 6 new pairing tests pass on main, so they are controls, not evidence. With the fix: **28/28**.
- `cargo test -p tsz-checker --lib -- accessor implicit_any ambient setter getter`: 210/210.
- 61 integration suites matching `accessor|implicit_any|ambient|getter|setter|private|declare|noimplicit|jsdoc`: no new failures. The one red, `import_type_ambient_module_member_tests::cross_file_import_type_member_still_works`, fails byte-identically on main with the hunks stashed — the #15983 `TS2456` family, unrelated (also reported on #16181 and noted on the board).
- `cargo fmt`, `cargo clippy -p tsz-checker --all-targets -- -D warnings`, `python3 scripts/arch/arch_guard.py` — all clean, all re-run by the pre-commit gate.
- **Conformance / emit / fourslash not run** — no `TypeScript/` corpus in this container. Unlike #16181 this PR adds no new emit site: it moves one existing diagnostic's blame from the getter to the setter and re-enables an existing TS7032 arm on a shape where both main and the pre-#16181 tree were silent. Direction of risk is a *newly reported* TS7032 on unannotated ambient accessor pairs, so a `compare-to-parent.sh` against `e9ec4b6` is still the check I would want before merge.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Dacite

---
_Generated by [Claude Code](https://claude.ai/code/session_011J1uAW6bhfGK9k84twoU4W)_