### PR TITLE
fix(checker,parser): class-member modifier grammar is first-error-wins

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1290,6 +1290,9 @@ mod jsdoc_function_return_type_anchor_tests;
 mod jsdoc_overload_call_resolution_tests;
 
 #[cfg(test)]
+#[path = "tests/class_member_modifier_grammar_first_error_wins_tests.rs"]
+mod class_member_modifier_grammar_first_error_wins_tests;
+#[cfg(test)]
 #[path = "../tests/jsdoc_readonly_tests.rs"]
 mod jsdoc_readonly_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking/class_private_name_modifiers.rs
+++ b/crates/tsz-checker/src/state/state_checking/class_private_name_modifiers.rs
@@ -75,6 +75,28 @@ impl CheckerState<'_> {
         }
     }
 
+    /// Whether the private-identifier modifier walk above (`TS18010`/`TS18019`)
+    /// already reports a diagnostic for this member — i.e. whether tsc's
+    /// ordered walk reaches the private-identifier check before it would
+    /// reach some other, order-blind modifier-pair rule (such as the
+    /// `abstract` + `static`/`private`/`async` incompatibility in
+    /// `check_modifier_combinations`), which must yield to it instead of
+    /// co-emitting.
+    pub(crate) fn private_name_modifier_walk_claims(
+        &self,
+        member_kind: u16,
+        modifiers: &Option<NodeList>,
+        is_abstract_class: bool,
+    ) -> bool {
+        matches!(
+            self.walk_private_name_modifiers(member_kind, modifiers, is_abstract_class),
+            Some(
+                PrivateNameModifierError::Accessibility(_)
+                    | PrivateNameModifierError::Incompatible(_, _)
+            )
+        )
+    }
+
     /// The walk itself: returns the first modifier outcome, or `None` when no
     /// modifier in the list interacts with the private identifier.
     fn walk_private_name_modifiers(

--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -100,7 +100,7 @@ impl<'a> CheckerState<'a> {
                 );
             }
         }
-        self.check_modifier_combinations(&prop.modifiers);
+        self.check_modifier_combinations(&prop.modifiers, prop.name, node.kind);
 
         // TS8009/TS8010: Check for TypeScript-only features in JavaScript files
         let is_js_file = self.is_js_file();
@@ -728,7 +728,7 @@ impl<'a> CheckerState<'a> {
             Vec::new()
         };
 
-        self.check_modifier_combinations(&method.modifiers);
+        self.check_modifier_combinations(&method.modifiers, method.name, node.kind);
 
         // Check for unused type parameters (TS6133)
         self.check_unused_type_params(&method.type_parameters, member_idx);
@@ -1288,7 +1288,7 @@ impl<'a> CheckerState<'a> {
             return;
         };
 
-        self.check_modifier_combinations(&accessor.modifiers);
+        self.check_modifier_combinations(&accessor.modifiers, accessor.name, node.kind);
 
         // Error 1183: An implementation cannot be declared in ambient contexts
         // Check if we're in a declared class and the accessor has a body.

--- a/crates/tsz-checker/src/state/state_checking_members/overload_compatibility.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/overload_compatibility.rs
@@ -1140,6 +1140,8 @@ impl<'a> CheckerState<'a> {
     pub(crate) fn check_modifier_combinations(
         &mut self,
         modifiers: &Option<tsz_parser::parser::NodeList>,
+        name_idx: NodeIndex,
+        member_kind: u16,
     ) {
         let Some(mods) = modifiers else {
             return;
@@ -1162,6 +1164,31 @@ impl<'a> CheckerState<'a> {
                     conflicting_nodes.push((m_idx, "async"));
                 }
             }
+        }
+
+        if abstract_node.is_none() {
+            return;
+        }
+
+        // tsc's ordered, first-error-wins modifier walk (see
+        // `class_private_name_modifiers`) reaches container-abstractness
+        // (TS1244/TS1253) before it would reach this pairwise
+        // incompatibility check — `abstract` outside an abstract class
+        // reports only the container error, reported elsewhere in `class.rs`.
+        if !self.enclosing_class_is_abstract() {
+            return;
+        }
+
+        // Likewise, for a private-named member, tsc's walk reaches the
+        // accessibility/private-identifier check (TS18010/TS18019) before
+        // this one — but only when that walk actually claims the member;
+        // when it yields instead (e.g. `static` precedes `abstract`, so the
+        // walk's own `abstract` arm is preempted), this check is still the
+        // true owner of the single diagnostic tsc reports.
+        if self.is_private_identifier_name(name_idx)
+            && self.private_name_modifier_walk_claims(member_kind, modifiers, true)
+        {
+            return;
         }
 
         if let Some(abs_node) = abstract_node {

--- a/crates/tsz-checker/src/tests/class_member_modifier_grammar_first_error_wins_tests.rs
+++ b/crates/tsz-checker/src/tests/class_member_modifier_grammar_first_error_wins_tests.rs
@@ -1,0 +1,156 @@
+//! `TS1029`/`TS1243` co-emitted alongside a checker/checker-owned modifier
+//! diagnostic where `tsc` reports only one, single-sourced code per member.
+//!
+//! `tsc`'s `checkGrammarModifiers` walks a member's modifier list in source
+//! order and returns at the first error, so a member reports **at most one**
+//! modifier-grammar diagnostic. tsz splits this walk across three owners
+//! (parser: `TS1029`/`TS1243` ordering and pairing; checker:
+//! `check_modifier_combinations`'s `abstract` + `static`/`private`/`async`
+//! pairing; checker: `class_private_name_modifiers`'s `TS18010`/`TS18019`
+//! walk), and none of them originally knew about the other two. Every
+//! expectation here is pinned against `typescript@7.0.2`
+//! (`--noEmit --strict --lib es2022 --target es2022`).
+
+use crate::test_utils::check_source_codes_with_parse_health;
+
+/// `TS1029`/`TS1243` and friends can be parser- or checker-owned depending on
+/// the shape (see `check_source_codes_with_parse_health`'s doc comment on its
+/// sibling `check_source_with_parse_health`); combine both sources so a test
+/// doesn't need to know which layer emits which code.
+fn codes(source: &str) -> Vec<u32> {
+    check_source_codes_with_parse_health(source)
+}
+
+const TS1029: u32 = 1029;
+const TS1243: u32 = 1243;
+const TS1244: u32 = 1244;
+const TS1253: u32 = 1253;
+const TS18010: u32 = 18010;
+const TS18019: u32 = 18019;
+
+// --- container-abstractness (TS1244/TS1253) preempts the checker's
+// --- order-blind abstract+static/private/async pairing check --------------
+
+#[test]
+fn abstract_static_method_in_non_abstract_class_reports_only_ts1244() {
+    let source = "class C { abstract static m(): void; }\n";
+    assert_eq!(codes(source), vec![TS1244], "codes: {:?}", codes(source));
+}
+
+#[test]
+fn abstract_private_method_in_non_abstract_class_reports_only_ts1244() {
+    let source = "class C { abstract private m(): void; }\n";
+    assert_eq!(codes(source), vec![TS1244], "codes: {:?}", codes(source));
+}
+
+#[test]
+fn abstract_static_property_in_non_abstract_class_reports_only_ts1253() {
+    let source = "class C { abstract static x: number; }\n";
+    assert_eq!(codes(source), vec![TS1253], "codes: {:?}", codes(source));
+}
+
+// --- abstract+static still fires TS1243 (order-independent) when the
+// --- container genuinely is abstract, regardless of which side is first ---
+
+#[test]
+fn static_then_abstract_in_abstract_class_reports_ts1243() {
+    let source = "abstract class C { static abstract m(): void; }\n";
+    assert_eq!(codes(source), vec![TS1243], "codes: {:?}", codes(source));
+}
+
+#[test]
+fn abstract_then_static_in_abstract_class_reports_ts1243() {
+    let source = "abstract class C { abstract static m(): void; }\n";
+    assert_eq!(codes(source), vec![TS1243], "codes: {:?}", codes(source));
+}
+
+// --- a private-named member's abstract conflict is claimed by the
+// --- TS18010/TS18019 walk, not the checker's pairwise check ---------------
+
+#[test]
+fn abstract_static_private_named_method_reports_only_ts18019() {
+    let source = "abstract class C { abstract static #m(): void; }\n";
+    assert_eq!(codes(source), vec![TS18019], "codes: {:?}", codes(source));
+}
+
+#[test]
+fn abstract_async_private_named_method_reports_only_ts18019() {
+    let source = "abstract class C { abstract async #m(); }\n";
+    assert_eq!(codes(source), vec![TS18019], "codes: {:?}", codes(source));
+}
+
+#[test]
+fn private_keyword_before_abstract_private_named_property_reports_only_ts18010() {
+    let source = "abstract class C { private abstract #x: number; }\n";
+    assert_eq!(codes(source), vec![TS18010], "codes: {:?}", codes(source));
+}
+
+// --- but when the walk itself yields (static precedes abstract), the
+// --- checker's pairwise check is still the true single-diagnostic owner ---
+
+#[test]
+fn static_then_abstract_private_named_method_still_reports_ts1243() {
+    let source = "abstract class C { static abstract #m(): void; }\n";
+    assert_eq!(codes(source), vec![TS1243], "codes: {:?}", codes(source));
+}
+
+// --- accessibility + abstract is a "cannot be used with" pair (TS1243), not
+// --- an ordering rule (TS1029), regardless of which comes first -----------
+
+#[test]
+fn private_before_abstract_reports_only_ts1243() {
+    let source = "abstract class C { private abstract m(): void; }\n";
+    assert_eq!(codes(source), vec![TS1243], "codes: {:?}", codes(source));
+}
+
+#[test]
+fn abstract_before_private_reports_only_ts1243_not_ts1029() {
+    let source = "abstract class C { abstract private m(): void; }\n";
+    assert_eq!(codes(source), vec![TS1243], "codes: {:?}", codes(source));
+}
+
+// --- accessibility ordering (TS1029) is unaffected for the modifiers that
+// --- genuinely have to precede an accessibility keyword --------------------
+
+#[test]
+fn accessibility_after_static_still_reports_ts1029() {
+    let source = "class C { static public x = 1; }\n";
+    assert_eq!(codes(source), vec![TS1029], "codes: {:?}", codes(source));
+}
+
+// --- declare/accessor pairing (TS1243) yields to the private-identifier
+// --- walk (TS18019) for a private name, in both source orders -------------
+
+#[test]
+fn declare_accessor_private_named_property_reports_only_ts18019() {
+    let source = "class C { declare accessor #x: number; }\n";
+    assert_eq!(codes(source), vec![TS18019], "codes: {:?}", codes(source));
+}
+
+#[test]
+fn accessor_declare_private_named_property_reports_only_ts18019() {
+    let source = "class C { accessor declare #x: number; }\n";
+    assert_eq!(codes(source), vec![TS18019], "codes: {:?}", codes(source));
+}
+
+// --- but the ordinary (non-private) declare/accessor pairing keeps
+// --- reporting TS1243 exactly as before -------------------------------------
+
+#[test]
+fn declare_accessor_ordinary_named_property_still_reports_ts1243() {
+    let source = "class C { declare accessor x: number; }\n";
+    assert_eq!(codes(source), vec![TS1243], "codes: {:?}", codes(source));
+}
+
+// --- readonly+accessor is a distinct rule tsc does NOT suppress for a
+// --- private name — regression control for over-broad suppression ---------
+
+#[test]
+fn readonly_accessor_private_named_property_still_reports_ts1243() {
+    let source = "class C { readonly accessor #x: number = 1; }\n";
+    assert!(
+        codes(source).contains(&TS1243),
+        "codes: {:?}",
+        codes(source)
+    );
+}

--- a/crates/tsz-checker/src/types/queries/core.rs
+++ b/crates/tsz-checker/src/types/queries/core.rs
@@ -247,6 +247,21 @@ impl<'a> CheckerState<'a> {
         self.has_modifier_kind(modifiers, SyntaxKind::AbstractKeyword)
     }
 
+    /// Whether the class currently being checked (`self.ctx.enclosing_class`)
+    /// itself carries the `abstract` modifier.
+    pub(crate) fn enclosing_class_is_abstract(&self) -> bool {
+        let Some(class_idx) = self.ctx.enclosing_class.as_ref().map(|c| c.class_idx) else {
+            return false;
+        };
+        let Some(node) = self.ctx.arena.get(class_idx) else {
+            return false;
+        };
+        let Some(class_data) = self.ctx.arena.get_class(node) else {
+            return false;
+        };
+        self.has_abstract_modifier(&class_data.modifiers)
+    }
+
     /// Check if modifiers include the 'static' keyword.
     pub(crate) fn has_static_modifier(
         &self,

--- a/crates/tsz-parser/src/parser/state_statements_class_members.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class_members.rs
@@ -87,14 +87,14 @@ impl ParserState {
                     );
                     reported_accessibility_duplicate = true;
                 }
-                // TS1029: accessibility must come after certain modifiers
-                if seen_static
-                    || seen_abstract
-                    || seen_readonly
-                    || seen_override
-                    || seen_accessor
-                    || seen_async
-                {
+                // TS1029: accessibility must come after certain modifiers.
+                // `abstract` is deliberately excluded: an accessibility
+                // modifier and `abstract` are never in a valid order (tsc
+                // reports the pairwise TS1243 "cannot be used with" instead
+                // of an ordering error, regardless of which one is written
+                // first), unlike static/readonly/override/accessor/async
+                // where accessibility genuinely has to come first.
+                if seen_static || seen_readonly || seen_override || seen_accessor || seen_async {
                     use tsz_common::diagnostics::diagnostic_codes;
                     let current_mod = match current_kind {
                         SyntaxKind::PublicKeyword => "public",
@@ -104,8 +104,6 @@ impl ParserState {
                     };
                     let conflicting_mod = if seen_static {
                         "static"
-                    } else if seen_abstract {
-                        "abstract"
                     } else if seen_readonly {
                         "readonly"
                     } else if seen_override {
@@ -260,7 +258,13 @@ impl ParserState {
                         diagnostic_codes::MODIFIER_CANNOT_BE_USED_WITH_MODIFIER,
                     );
                 }
-                if seen_declare {
+                // A private-named member's `declare`/`accessor` pairing is
+                // reported as TS18019 ("modifier cannot be used with a
+                // private identifier") by the checker's source-ordered
+                // private-identifier modifier walk instead — tsc's single
+                // ordered walk reaches that check before it would reach this
+                // pairwise incompatibility. See `upcoming_member_name_is_private`.
+                if seen_declare && !self.upcoming_member_name_is_private() {
                     use tsz_common::diagnostics::diagnostic_codes;
                     self.parse_error_at_current_token(
                         "'accessor' modifier cannot be used with 'declare' modifier.",
@@ -348,8 +352,11 @@ impl ParserState {
                     }
                     // Auto-accessor properties cannot be `declare`d. When
                     // `accessor` precedes `declare`, tsc emits TS1243 on the
-                    // declare keyword.
-                    if seen_accessor {
+                    // declare keyword — unless the member name is private, in
+                    // which case the checker's private-identifier modifier
+                    // walk reports TS18019 instead (see the accessor arm's
+                    // mirror check above).
+                    if seen_accessor && !self.upcoming_member_name_is_private() {
                         use tsz_common::diagnostics::diagnostic_codes;
                         self.parse_error_at_current_token(
                             "'declare' modifier cannot be used with 'accessor' modifier.",
@@ -531,6 +538,45 @@ impl ParserState {
         } else {
             Some(Self::make_node_list(modifiers))
         }
+    }
+
+    /// Peeks past any remaining modifier keywords, without consuming them,
+    /// to see whether the class member's name (parsed after all modifiers)
+    /// will be a private identifier (`#name`).
+    ///
+    /// The modifier list is parsed before the name, so a check that needs to
+    /// know whether the member is private-named — because tsc's own ordered
+    /// modifier walk would reach the private-identifier check
+    /// (TS18010/TS18019) before a later pairwise modifier check — has to look
+    /// ahead for it.
+    fn upcoming_member_name_is_private(&mut self) -> bool {
+        let snapshot = self.scanner.save_state();
+        let saved_token = self.current_token;
+        let mut is_private = false;
+        loop {
+            match self.current_token {
+                SyntaxKind::StaticKeyword
+                | SyntaxKind::PublicKeyword
+                | SyntaxKind::PrivateKeyword
+                | SyntaxKind::ProtectedKeyword
+                | SyntaxKind::ReadonlyKeyword
+                | SyntaxKind::AbstractKeyword
+                | SyntaxKind::OverrideKeyword
+                | SyntaxKind::AsyncKeyword
+                | SyntaxKind::DeclareKeyword
+                | SyntaxKind::AccessorKeyword => {
+                    self.next_token();
+                }
+                SyntaxKind::PrivateIdentifier => {
+                    is_private = true;
+                    break;
+                }
+                _ => break,
+            }
+        }
+        self.scanner.restore_state(snapshot);
+        self.current_token = saved_token;
+        is_private
     }
 
     pub(crate) fn should_stop_class_member_modifier(&mut self) -> bool {


### PR DESCRIPTION
Closes #16173.

`tsc`'s `checkGrammarModifiers` walks a class member's modifier list **in source order** and **returns at the first error**, so a member reports at most one modifier-grammar diagnostic. tsz split that single walk across three owners that don't know about each other's outcome: the parser (`TS1029` ordering, `TS1243` pairing for readonly/override/accessor/declare), the checker's `check_modifier_combinations` (`TS1243` for `abstract` + `static`/`private`/`async`, order-blind), and the checker's `class_private_name_modifiers` walk (`TS18010`/`TS18019` for a private-named member, added in #16175). Six oracle-pinned shapes (`typescript@7.0.2`) co-emitted two codes where `tsc` emits one.

Three structural fixes, one per owner:

- **Parser**: `abstract` no longer participates in the accessibility-modifier ordering check (`seen_static || seen_abstract || ...`). Accessibility + `abstract` is a "cannot be used with" pair (`TS1243`), never an ordering violation (`TS1029`), regardless of which comes first.
- **Parser**: the `declare`/`accessor` pairwise check (both directions) now peeks ahead past the remaining modifiers to the member name and yields when it's a private identifier, since the checker's private-name walk reports `TS18019` there instead. `readonly`+`accessor` is deliberately left alone — the oracle still reports `TS1243` for that pair even on a private name, so it isn't part of the private-identifier arm of `tsc`'s walk.
- **Checker**: `check_modifier_combinations` now returns early when the enclosing class isn't abstract (`TS1244`/`TS1253` already claims the member) or when the private-name walk's own result already claims a diagnostic for it (new `private_name_modifier_walk_claims` on `class_private_name_modifiers`) — but only then, since `static` before `abstract` makes the private-name walk yield, and this check is still the true source of that member's single `TS1243`.

Owner layers: parser (`crates/tsz-parser/src/parser/state_statements_class_members.rs`) and checker (`crates/tsz-checker/src/state/state_checking_members/overload_compatibility.rs`, `class_private_name_modifiers.rs`, `types/queries/core.rs`). No solver or emitter involvement.

## Adjacent-case matrix

32 rows, all pinned against `typescript@7.0.2` via a one-off CLI diff (`npm i typescript@7.0.2`, `--noEmit --strict --lib es2022 --target es2022`): the six diverging rows from #16173, plus every "already correct" control from the issue (`abstract`+`static`/`private`/`async` in both orders and both container-abstractness states, accessibility-after-static/readonly/override/accessor/async ordering, duplicate-accessibility, `readonly`+`accessor` with and without a private name, `declare`+`accessor` with and without a private name in both orders). All 32 now match `tsc` exactly, with zero regressions on the previously-correct rows.

## Goal
Goal: hold

## Verification
- New suite `class_member_modifier_grammar_first_error_wins_tests` (16 tests): 16/16 pass.
- `cargo nextest run -p tsz-checker --lib` filtered to `class_*|accessor|declare|abstract|private_name|modifier`: 907/907 pass, including the pre-existing `private_name_modifier_grammar_order_tests` (#16175) and `override_modifier_private_identifier_tests`/`ts1038_ambient_declare_modifier_tests` integration suites (21/21).
- `cargo nextest run -p tsz-parser` filtered to `class`/`modifier`: 231/231 pass, 0 regressions.
- `cargo fmt -p tsz-checker -p tsz-parser -- --check`: clean.
- `cargo clippy -p tsz-checker -p tsz-parser --lib --tests -- -D warnings`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.
- Conformance: not run locally (no `TypeScript/` submodule checkout in this container). This family (TS1029/TS1243/TS1244/TS1253/TS18010/TS18019 co-emission) has no corpus fixture — same "zero expected movement" signature already established for the sibling PRs #16172/#16175/#16181 in this cluster.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_019YhS5BxHHuaw2o6LC6Yqrr)_