### PR TITLE
fix(checker): report the noImplicitAny accessor family for interface and type-literal members

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2606,3 +2606,6 @@ path = "tests/issue_16018_nested_position_evidence_tests.rs"
 [[test]]
 name = "namespace_body_local_declaration_merge_tests"
 path = "tests/namespace_body_local_declaration_merge_tests.rs"
+[[test]]
+name = "noimplicitany_type_member_accessor_tests"
+path = "tests/noimplicitany_type_member_accessor_tests.rs"

--- a/crates/tsz-checker/src/checkers/accessor_checker.rs
+++ b/crates/tsz-checker/src/checkers/accessor_checker.rs
@@ -196,6 +196,115 @@ impl<'a> CheckerState<'a> {
         None
     }
 
+    /// The `noImplicitAny` accessor family (`TS7033`/`TS7032`/`TS7006`) for
+    /// *type members* — the members of an `interface` or of a type literal.
+    ///
+    /// Structural rule, identical to the class arm in
+    /// `state_checking_members/ambient_signature_checks.rs`: a `get`/`set` pair
+    /// shares **one** property type. It comes from the getter's return type —
+    /// annotated, or inferred from a body — if there is one, else from the
+    /// setter's parameter annotation. When nothing supplies it, `tsc` reports
+    /// `TS7032` on the **setter**; the getter is the blame site (`TS7033`) only
+    /// when it has no paired setter at all. tsz does this through the accessor
+    /// checker, which already owns the same rule for class members and for
+    /// object-literal accessor elements.
+    ///
+    /// Class members reach that rule as *declarations*
+    /// (`check_accessor_declaration_with_request`, which also reasons about
+    /// bodies, modifiers and enclosing-class ambientness). Interface and
+    /// type-literal members are never declaration-checked, so they need this
+    /// separate entry point — but they must not re-derive the rule, only the
+    /// container-specific parts of it.
+    ///
+    /// Three properties of the rule that a matrix built one axis at a time
+    /// misses, all of them load-bearing here:
+    ///
+    /// 1. The getter supplies the property type when it has an annotation
+    ///    **or a body**. A type member can never have a body (`TS1183` claims
+    ///    it), but the condition is written out rather than assumed away so the
+    ///    two arms stay the same rule.
+    /// 2. `TS7006` and `TS7032` need **separate** suppression flags. Any paired
+    ///    getter contextually types the setter's *parameter* (suppressing
+    ///    `TS7006`), but only an annotated-or-bodied one supplies the
+    ///    *property's* type (gating `TS7032`). `interface I { get g(); set g(v); }`
+    ///    is exactly the shape that separates them: `TS7032` alone, no `TS7006`.
+    /// 3. It is the annotation's **presence**, not its type — `set g(v: any)`
+    ///    is clean.
+    pub(crate) fn check_type_member_accessor_implicit_any(
+        &mut self,
+        member_idx: NodeIndex,
+        siblings: &[NodeIndex],
+    ) {
+        if !self.ctx.no_implicit_any() || self.is_js_file() {
+            return;
+        }
+        let Some(member_node) = self.ctx.arena.get(member_idx) else {
+            return;
+        };
+        let kind = member_node.kind;
+        if kind != syntax_kind_ext::GET_ACCESSOR && kind != syntax_kind_ext::SET_ACCESSOR {
+            return;
+        }
+        let Some(accessor) = self.ctx.arena.get_accessor(member_node) else {
+            return;
+        };
+
+        if kind == syntax_kind_ext::GET_ACCESSOR {
+            // TS7033: an unannotated, bodyless getter resolves to `any`. Any
+            // paired setter moves the blame to the setter (see above), whether
+            // or not that setter is itself annotated.
+            if accessor.type_annotation.is_none()
+                && accessor.body.is_none()
+                && self.paired_setter_in_members(siblings, accessor).is_none()
+                && let Some(accessor_name) = self.property_name_for_error(accessor.name)
+            {
+                self.error_at_node_msg(
+                    accessor.name,
+                    diagnostic_codes::PROPERTY_IMPLICITLY_HAS_TYPE_ANY_BECAUSE_ITS_GET_ACCESSOR_LACKS_A_RETURN_TYPE_AN,
+                    &[&accessor_name],
+                );
+            }
+            return;
+        }
+
+        let paired_getter = self.paired_getter_in_members(siblings, accessor);
+        // Property (2): the *property* type comes from the getter only when the
+        // getter names one. Reusing `paired_getter.is_some()` here would silence
+        // TS7032 on every pair, which is the shape the issue reported.
+        let paired_getter_supplies_type = paired_getter
+            .and_then(|getter_idx| self.ctx.arena.get(getter_idx))
+            .and_then(|getter_node| self.ctx.arena.get_accessor(getter_node))
+            .is_some_and(|getter| getter.type_annotation.is_some() || getter.body.is_some());
+        let accessor_name = accessor.name;
+
+        for (param_index, &param_idx) in accessor.parameters.nodes.iter().enumerate() {
+            let Some(param_node) = self.ctx.arena.get(param_idx) else {
+                continue;
+            };
+            let Some(param) = self.ctx.arena.get_parameter(param_node) else {
+                continue;
+            };
+
+            // TS7006 on the parameter: a paired getter contextually types it.
+            self.maybe_report_implicit_any_parameter(param, paired_getter.is_some(), param_index);
+
+            // TS7032 on the setter name: nothing gave the property a type.
+            if param.type_annotation.is_none()
+                && !paired_getter_supplies_type
+                && let Some(prop_name) = self.property_name_for_error(accessor_name)
+            {
+                let message = format!(
+                    "Property '{prop_name}' implicitly has type 'any', because its set accessor lacks a parameter type annotation."
+                );
+                self.error_at_node(
+                    accessor_name,
+                    &message,
+                    diagnostic_codes::PROPERTY_IMPLICITLY_HAS_TYPE_ANY_BECAUSE_ITS_SET_ACCESSOR_LACKS_A_PARAMETER_TYPE,
+                );
+            }
+        }
+    }
+
     pub(crate) fn contextual_getter_return_type_for_class_accessor(
         &mut self,
         getter_accessor: &tsz_parser::parser::node::AccessorData,

--- a/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
@@ -290,6 +290,10 @@ impl<'a> CheckerState<'a> {
             self.check_styled_component_inner_component_constraint(member_idx);
             self.check_type_member_for_missing_names(member_idx);
             self.check_type_member_for_parameter_properties(member_idx);
+            // The noImplicitAny accessor family (TS7033/TS7032/TS7006). Needs
+            // the sibling members to resolve the get/set pair, so it cannot ride
+            // the per-member walk above.
+            self.check_type_member_accessor_implicit_any(member_idx, &iface.members.nodes);
             // TS1268: Check index signature parameter types
             self.check_index_signature_parameter_type(member_idx);
             // TS1169: Computed property in interface must have literal/unique symbol type

--- a/crates/tsz-checker/src/types/type_checking/core.rs
+++ b/crates/tsz-checker/src/types/type_checking/core.rs
@@ -936,6 +936,12 @@ impl<'a> CheckerState<'a> {
                 self.check_type_literal_overload_optionality(&type_lit.members.nodes);
                 for &member_idx in &type_lit.members.nodes {
                     self.check_type_member_for_parameter_properties(member_idx);
+                    // The noImplicitAny accessor family (TS7033/TS7032/TS7006).
+                    // Needs the sibling members to resolve the get/set pair.
+                    self.check_type_member_accessor_implicit_any(
+                        member_idx,
+                        &type_lit.members.nodes,
+                    );
                     // TS1170: Computed property in type literal must have literal/unique symbol type
                     if let Some(member_node) = self.ctx.arena.get(member_idx) {
                         if let Some(sig) = self.ctx.arena.get_signature(member_node) {

--- a/crates/tsz-checker/tests/noimplicitany_type_member_accessor_tests.rs
+++ b/crates/tsz-checker/tests/noimplicitany_type_member_accessor_tests.rs
@@ -1,0 +1,321 @@
+//! The `noImplicitAny` accessor family (`TS7033`/`TS7032`/`TS7006`) for *type
+//! members* — the members of an `interface` or of a type literal. Issue #16186.
+//!
+//! Structural rule, one sentence: a `get`/`set` pair shares **one** property
+//! type, taken from the getter's return type (annotated, or inferred from a
+//! body) if there is one and otherwise from the setter's parameter annotation,
+//! and when nothing supplies it `tsc` blames the **setter** with `TS7032` — the
+//! getter is the blame site (`TS7033`) only when it has no paired setter at
+//! all. tsz does this through `checkers/accessor_checker.rs`
+//! (`check_type_member_accessor_implicit_any`), the same owner that already
+//! holds the rule for class members and object-literal accessor elements.
+//!
+//! This is the type-member arm of the rule #16185 established for classes.
+//! Class members are checked as *declarations*
+//! (`check_accessor_declaration_with_request`); interface and type-literal
+//! members are never declaration-checked, which is why the family was reported
+//! for classes and silent here.
+//!
+//! Three properties of the rule are load-bearing and each is pinned in both
+//! directions below, because a matrix built one axis at a time skips exactly
+//! the cell where the rule lives:
+//!
+//! 1. The getter supplies the property type when it has an annotation **or a
+//!    body** — not annotation alone.
+//! 2. `TS7006` and `TS7032` need **separate** suppression flags. Any paired
+//!    getter contextually types the setter's *parameter*; only an
+//!    annotated-or-bodied one supplies the *property's* type. The both-missing
+//!    pair (`get g(); set g(v);`) reports `TS7032` and **no** `TS7006`, which is
+//!    the one row that separates the two flags.
+//! 3. It is the annotation's **presence**, not its type — `set g(v: any)` is
+//!    clean.
+//!
+//! Every expectation here was recorded from `typescript@7.0.2` under
+//! `--noEmit --strict --lib es2022 --target es2022`. Anchors are pinned as
+//! 0-based offsets (`tsc`'s 1-based column minus one) because the blame *site*
+//! is half of this rule: `TS7032` lands on the setter's name, never on its
+//! parameter.
+
+use tsz_checker::test_utils::{check_source_non_strict_codes, check_source_strict};
+
+/// Every diagnostic as `TS<code>@<0-based start>`, sorted — the exact shape the
+/// oracle rows were recorded in.
+fn sites(source: &str) -> Vec<String> {
+    let mut out: Vec<String> = check_source_strict(source)
+        .iter()
+        .map(|d| format!("TS{}@{}", d.code, d.start))
+        .collect();
+    out.sort();
+    out
+}
+
+fn assert_sites(source: &str, expected: &[&str]) {
+    let actual = sites(source);
+    let expected: Vec<String> = expected.iter().map(|s| (*s).to_string()).collect();
+    assert_eq!(actual, expected, "source: {source}");
+}
+
+// ---------------------------------------------------------------------------
+// Interface members: the getter axis.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn interface_lone_unannotated_getter_reports_ts7033_on_the_getter_name() {
+    // interface I { get g(); }
+    //                   ^18
+    assert_sites("interface I { get g(); }", &["TS7033@18"]);
+}
+
+#[test]
+fn interface_lone_annotated_getter_is_clean() {
+    assert_sites("interface I { get g(): number; }", &[]);
+}
+
+#[test]
+fn interface_getter_with_any_paired_setter_is_never_the_blame_site() {
+    // The pair moves the blame to the setter even though the setter is itself
+    // unannotated: property (2) above. Only TS7032, and it is on `g` at 27 —
+    // the *setter's* name, not the getter's and not the parameter.
+    assert_sites("interface I { get g(); set g(v); }", &["TS7032@27"]);
+}
+
+#[test]
+fn interface_pair_with_annotated_getter_is_clean() {
+    assert_sites("interface I { get g(): number; set g(v); }", &[]);
+}
+
+#[test]
+fn interface_pair_with_annotated_setter_is_clean() {
+    assert_sites("interface I { get g(); set g(v: number); }", &[]);
+}
+
+#[test]
+fn interface_pair_with_both_annotated_is_clean() {
+    assert_sites("interface I { get g(): number; set g(v: number); }", &[]);
+}
+
+// ---------------------------------------------------------------------------
+// Interface members: the setter axis, and the TS7006/TS7032 flag split.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn interface_lone_unannotated_setter_reports_both_ts7006_and_ts7032() {
+    // No paired getter: the parameter is not contextually typed (TS7006 on the
+    // parameter at 20) *and* the property has no type (TS7032 on the name at
+    // 18). This is the direction that proves the two flags are separate.
+    assert_sites("interface I { set g(v); }", &["TS7006@20", "TS7032@18"]);
+}
+
+#[test]
+fn interface_paired_setter_suppresses_ts7006_but_not_ts7032() {
+    // The opposite direction of the same split: the paired getter contextually
+    // types the parameter (no TS7006) but supplies no property type (TS7032).
+    // Collapsing the two flags into one passes exactly one of these two tests.
+    assert_sites("interface I { get g(); set g(v); }", &["TS7032@27"]);
+}
+
+#[test]
+fn interface_lone_annotated_setter_is_clean() {
+    assert_sites("interface I { set g(v: number); }", &[]);
+}
+
+#[test]
+fn interface_setter_annotated_any_is_clean() {
+    // Property (3): presence of the annotation, not its type.
+    assert_sites("interface I { set g(v: any); }", &[]);
+    assert_sites("interface I { get g(); set g(v: any); }", &[]);
+}
+
+#[test]
+fn interface_pair_order_does_not_move_the_blame_site() {
+    // Setter first. The blame is still the setter's name (18), because pairing
+    // is by name, not by source order.
+    assert_sites("interface I { set g(v); get g(); }", &["TS7032@18"]);
+}
+
+// ---------------------------------------------------------------------------
+// Per-member, not per-container. A single interface holding several accessors
+// must reach a different verdict for each — no "does this interface have a
+// setter" rule gets this right by accident.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn interface_mixes_blame_sites_within_one_container() {
+    // `g` is a pair (TS7032 on its setter at 27); `h` is a lone getter
+    // (TS7033 at 37). Two different verdicts inside one member list.
+    assert_sites(
+        "interface I { get g(); set g(v); get h(); }",
+        &["TS7032@27", "TS7033@37"],
+    );
+}
+
+#[test]
+fn interface_three_accessors_each_resolve_independently() {
+    // a: both missing  -> TS7032 on a's setter (27)
+    // b: setter annotated -> clean
+    // c: getter annotated -> clean
+    assert_sites(
+        "interface I { get a(); set a(v); get b(); set b(w: string); get c(): boolean; set c(y); }",
+        &["TS7032@27"],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Binder-name independence. The rule is structural; renaming everything the
+// user chose must not move a single anchor's *relationship* to its member.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn interface_renamed_binders_report_identically() {
+    assert_sites("interface Zqx { get wobble(); }", &["TS7033@20"]);
+    assert_sites(
+        "interface Zqx { get wobble(); set wobble(qq); }",
+        &["TS7032@34"],
+    );
+}
+
+#[test]
+fn interface_string_literal_and_numeric_names_pair_by_property_name() {
+    // `get 'g'()` pairs with `set g(v)` exactly as tsc pairs them, so the
+    // getter is not the blame site and the setter is.
+    assert_sites("interface I { get 'g'(); set g(v); }", &["TS7032@29"]);
+    assert_sites("interface I { get 0(); set 0(v); }", &["TS7032@27"]);
+    assert_sites("interface I { get 'a b'(); }", &["TS7033@18"]);
+    assert_sites("interface I { get 0(); }", &["TS7033@18"]);
+}
+
+#[test]
+fn interface_computed_unique_symbol_names_pair_by_symbol_identity() {
+    // Pairing falls back to computed-name symbol identity, and the message
+    // renders the name as `[k]` — so the blame site is the setter at 61.
+    assert_sites(
+        "declare const k: unique symbol; interface I { get [k](); set [k](v); }",
+        &["TS7032@61"],
+    );
+    assert_sites(
+        "declare const k: unique symbol; interface I { get [k](); }",
+        &["TS7033@50"],
+    );
+}
+
+#[test]
+fn interface_computed_name_message_renders_the_bracketed_name() {
+    let messages: Vec<String> = check_source_strict(
+        "declare const k: unique symbol; interface I { get [k](); set [k](v); }",
+    )
+    .iter()
+    .map(|d| d.message_text.clone())
+    .collect();
+    assert!(
+        messages
+            .iter()
+            .any(|m: &String| m.contains("Property '[k]'")),
+        "expected the bracketed computed name: {messages:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Type literals. The other half of the type-member walk — a distinct call site
+// from the interface one, so every container shape it is reached through is
+// pinned rather than assumed.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn type_alias_literal_reports_the_family() {
+    assert_sites("type T = { get g(); };", &["TS7033@15"]);
+    assert_sites("type T = { get g(); set g(v); };", &["TS7032@24"]);
+    assert_sites("type T = { get g(): number; set g(v); };", &[]);
+    assert_sites("type T = { get g(); set g(v: number); };", &[]);
+    assert_sites("type T = { set g(v); };", &["TS7006@17", "TS7032@15"]);
+}
+
+#[test]
+fn type_literal_in_a_variable_annotation_reports_the_family() {
+    assert_sites("declare const x: { get g(); };", &["TS7033@23"]);
+    assert_sites("declare const x: { get g(); set g(v); };", &["TS7032@32"]);
+}
+
+#[test]
+fn type_literal_nested_inside_an_interface_property_reports_the_family() {
+    assert_sites("interface I { p: { get g(); }; }", &["TS7033@23"]);
+    assert_sites("interface I { p: { get g(); set g(v); }; }", &["TS7032@32"]);
+}
+
+#[test]
+fn type_literal_in_signature_positions_reports_the_family() {
+    assert_sites("declare function f(a: { get g(); }): void;", &["TS7033@28"]);
+    assert_sites(
+        "declare function f(): { get g(); set g(v); };",
+        &["TS7032@37"],
+    );
+}
+
+#[test]
+fn type_literal_inside_composite_types_reports_the_family() {
+    assert_sites("type T = { get g(); } & { a: number };", &["TS7033@15"]);
+    assert_sites("type T = { get g(); } | { a: number };", &["TS7033@15"]);
+}
+
+#[test]
+fn interface_with_heritage_and_type_parameters_reports_the_family() {
+    assert_sites(
+        "interface B { x: number } interface I extends B { get g(); set g(v); }",
+        &["TS7032@63"],
+    );
+    assert_sites("interface I<T> { get g(); set g(v); }", &["TS7032@30"]);
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls: shapes that must stay exactly as they were.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_family_is_governed_by_no_implicit_any() {
+    // Nothing in this family fires with noImplicitAny off.
+    assert!(
+        check_source_non_strict_codes("interface I { get g(); }").is_empty(),
+        "TS7033 must be governed by noImplicitAny"
+    );
+    assert!(
+        check_source_non_strict_codes("interface I { get g(); set g(v); }").is_empty(),
+        "TS7032 must be governed by noImplicitAny"
+    );
+    assert!(
+        check_source_non_strict_codes("interface I { set g(v); }").is_empty(),
+        "TS7006/TS7032 must be governed by noImplicitAny"
+    );
+}
+
+#[test]
+fn neighbouring_type_member_kinds_are_untouched() {
+    // The property-signature (TS7008) and method-signature (TS7010/TS7006)
+    // arms of the same walk keep their existing verdicts and anchors.
+    assert_sites("interface I { p; }", &["TS7008@14"]);
+    assert_sites("interface I { m(); }", &["TS7010@14"]);
+    assert_sites("interface I { m(a); }", &["TS7006@16", "TS7010@14"]);
+    assert_sites("type T = { m(a); };", &["TS7006@13", "TS7010@11"]);
+    assert_sites("interface I { m(a: number); }", &["TS7010@14"]);
+    assert_sites("interface I { (a): void; }", &["TS7006@15"]);
+    assert_sites("interface I { [k: string]: number; }", &[]);
+}
+
+#[test]
+fn accessor_shaped_parse_recovery_still_lands_on_the_method_arm() {
+    // `get ()` is not an accessor — it parses as a method signature *named*
+    // `get`, so it keeps TS7010 from the method arm and must not acquire a
+    // TS7033 from the accessor arm.
+    assert_sites("interface I { get (); }", &["TS7010@14"]);
+    assert_sites("type T = { get (); };", &["TS7010@11"]);
+    assert_sites("interface I { get; }", &["TS7008@14"]);
+    assert_sites("interface I { set (v); }", &["TS7006@19", "TS7010@14"]);
+}
+
+#[test]
+fn class_and_object_literal_arms_are_unchanged() {
+    // The class arm (#16179/#16183) and the object-literal arm own the same
+    // rule through different entry points; this change is additive to them.
+    assert_sites("declare class C { get g(); set g(v); }", &["TS7032@31"]);
+    assert_sites("declare class C { get g(); }", &["TS7033@22"]);
+    assert_sites("declare class C { set g(v); }", &["TS7006@24", "TS7032@22"]);
+    assert_sites("const o = { get g() { return 1; } };", &[]);
+}


### PR DESCRIPTION
Closes #16186.

**When a type member is a `get`/`set` accessor whose property type nothing supplies, `tsc` reports the `noImplicitAny` accessor family on it; tsz now does too, through the checker's accessor checker.**

#16185 established the blame rule for **class** members:

> A get/set pair shares **one** property type. It comes from the getter's return type — annotated, **or inferred from a body** — if there is one, else from the setter's parameter annotation. When nothing supplies it, `tsc` reports **TS7032 on the setter**. The getter is the blame site (**TS7033**) only when it has **no paired setter at all**.

Class members reach that rule as *declarations* (`check_accessor_declaration_with_request`, which also reasons about bodies, modifiers and enclosing-class ambientness). Interface and type-literal members are never declaration-checked — they are walked as *type members* — so the entire family was silent for them: `interface I { get g(); }` and `interface I { get g(); set g(v); }` both produced **nothing**.

This ports the rule rather than re-deriving it. The new entry point `check_type_member_accessor_implicit_any` lives in `crates/tsz-checker/src/checkers/accessor_checker.rs`, the owner that already holds this rule for class members and for object-literal accessor elements, and it reuses that file's existing `paired_getter_in_members` / `paired_setter_in_members` pairing primitives (which were already sibling-slice parameterized). It is called from the two type-member walks — `state_checking_members/interface_checks.rs` for interface members and `types/type_checking/core.rs` for type-literal members — because the pair can only be resolved against the sibling member list, which the per-member walk does not carry.

Owner layer: checker only. No solver, parser or emitter involvement. +122 lines of source across 3 files, all additive.

### The three traps #16186 called out, and where each is pinned

1. **`annotation.is_some() || body.is_some()`, not the annotation alone.** Written out rather than collapsed, so the class and type-member arms stay literally the same rule even though a type member can never carry a body (`TS1183` claims it).
2. **`TS7006` and `TS7032` need separate suppression flags.** Any paired getter contextually types the setter's *parameter*; only an annotated-or-bodied one supplies the *property's* type. Both directions are pinned, and each fails a different way if the flags are merged: `interface I { set g(v); }` reports **both** `TS7006@20` and `TS7032@18`, while `interface I { get g(); set g(v); }` reports **`TS7032@27` and no `TS7006`**. One flag passes exactly one of those two tests.
3. **Presence of the annotation, not its type** — `set g(v: any)` is clean, pinned lone and paired.

### Anchors are part of the rule

The blame *site* is half of this fix, so the suite asserts `TS<code>@<0-based offset>`, not just codes. `TS7032` lands on the **setter's name**, never on its parameter and never on the getter — `interface I { set g(v); get g(); }` still anchors at 18, because pairing is by name and not by source order.

### Adjacent-case matrix

49 rows pinned against `typescript@7.0.2` (`npm i typescript@7.0.2`, `--noEmit --strict --lib es2022 --target es2022 --pretty false`, one file per row). **Before this change 24 of them diverged; after it, all 49 match `tsc` exactly on both code and anchor, with zero movement on the 25 that were already correct.**

- **Getter axis**: lone unannotated (TS7033), lone annotated (clean), pair with unannotated setter (blame moves to setter), pair with annotated getter / annotated setter / both (clean).
- **Setter axis**: lone unannotated (TS7006 **and** TS7032), lone annotated, `any`-annotated, paired-unannotated, setter-before-getter.
- **Per-member, not per-container**: `interface I { get g(); set g(v); get h(); }` → `TS7032` on `g`'s setter *and* `TS7033` on lone `h`; and a three-accessor interface where `a` is both-missing, `b`'s setter is annotated and `c`'s getter is annotated → only `a` reports. No "does this container have a setter" rule reaches those by accident.
- **Renamed binders**: every row re-run with `interface Zqx { get wobble(); set wobble(qq); }` — no user-chosen string participates in any decision.
- **Name forms**: string-literal (`get 'g'()` pairs with `set g(v)`), numeric (`get 0()`), and computed `unique symbol` names, which pair by symbol identity and render as `Property '[k]'`.
- **Container shapes for the type-literal arm** (a distinct call site, so each is pinned rather than assumed reached): `type T = {…}`, variable annotation, nested inside an interface property, function parameter, function return, intersection member, union member; plus interface heritage and type parameters.
- **Negative / fallback**: whole family off under `noImplicitAny: false`; neighbouring member kinds unchanged (`TS7008` property signatures, `TS7010`/`TS7006` method signatures, call signatures, index signatures); and parse-recovery shapes — `get ()` parses as a method signature *named* `get`, so it keeps `TS7010` from the method arm and must not acquire a `TS7033`.
- **Class and object-literal controls**: `declare class C { get g(); set g(v); }`, `{ get g(); }`, `{ set g(v); }` and `const o = { get g() { return 1; } }` all unchanged — this change is additive to the arms #16179/#16183 fixed.

### Known residual, filed not patched

Computed-name getters lose `TS7033` in the **class** arm (`declare class C { get [k](); }` → `tsc` reports, tsz does not). That is a pre-existing gap in a different owner (`ambient_signature_checks.rs` uses `get_property_name`, which returns `None` for computed names, where the `TS7032` path uses the computed-aware helper). The new type-member arm uses the computed-aware helper and so does not have it. I did not widen this diff to the class declaration path because that helper carries a raw-source-text fallback whose parse-recovery behaviour deserves its own conformance run. Recorded on #16186.

## Goal
Goal: hold

## Verification
- New suite `noimplicitany_type_member_accessor_tests` (27 tests): **27/27 pass**. Every expectation oracle-recorded from `typescript@7.0.2`; before the change 24 of the 49 matrix rows diverged.
- **Regression floor named by #16186** — `noimplicitany_ambient_member_surface_tests` (the 28 class rows from #16179/#16183): **28/28 pass, unchanged**.
- `cargo test -p tsz-checker --lib` plus the 78 registered integration targets matching `accessor|interface|implicit|type_literal|noimplicit|member`, run in batches: results in the comment below (this container OOMs at 12GB linking the full 842-target suite in one invocation, so it was sharded with `-j 2`).
- `cargo fmt -p tsz-checker`: clean.
- Conformance/emit/fourslash: **not run** — this container has no `TypeScript/` corpus checkout (`git submodule status` empty), the same constraint recorded on the board by Tuff, Dacite and Cinder this hour. The change is a pure false-negative fix (it only adds diagnostics on shapes that previously produced none, and every added row is oracle-matched to `tsc`), but a warm-seat conformance/emit pass before merge is the right check and I am asking for one rather than asserting parity I did not measure.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Siltstone

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyYg6dCptAxVuqkV8LDPR1)_