### PR TITLE
test(checker): pin the self-similar generator boundary and retract the "harness gap" framing

### DIFF
--- a/crates/tsz-checker/src/tests/generator_yield_self_similar_nesting_tests.rs
+++ b/crates/tsz-checker/src/tests/generator_yield_self_similar_nesting_tests.rs
@@ -1,6 +1,12 @@
-//! #16116 item 2 is **not a compiler defect**. It is an artifact of the unit
-//! harness, and this suite pins the harness gap so it cannot swallow the same
-//! class of diagnostic silently again.
+//! #16116 item 2, tracked as #16125: an unannotated generator's inferred
+//! container is silently accepted against a target that nests the **same**
+//! generator interface inside itself. This suite pins the boundary so the class
+//! cannot be swallowed silently again.
+//!
+//! This file originally headlined the divergence as "not a compiler defect, an
+//! artifact of the unit harness". That framing is retracted throughout — see
+//! the measured boundary further down. It is a real divergence that the harness
+//! is merely the cheapest place to observe.
 //!
 //! The issue reports that an unannotated generator yielding an inner generator
 //! loses the inner's type argument: `tsc` reports TS2345 and tsz reports
@@ -37,11 +43,56 @@
 //! CLI. So the gap is narrow and structural, not a blanket "the harness is
 //! weaker".
 //!
-//! The two `#[ignore]`d rows below assert the CLI's (and `tsc`'s) answer. They
-//! are red **because of the harness divergence**, not because of anything in
-//! the container's inferred yield type — fixing a checker or solver path will
-//! not turn them green. They go live when `check_source_with_libs` resolves
-//! self-similar generator applications the way a real program does.
+//! The `#[ignore]`d rows below assert the CLI's (and `tsc`'s) answer.
+//!
+//! **This suite used to claim they could not be fixed from a checker or solver
+//! path.** That claim is retracted: it was never measured, and the boundary
+//! measured since (#16125) contradicts it. Do not read the ignores as
+//! "unreachable" — read them as "open, mechanism not yet located".
+//!
+//! What has actually been measured, all on `check_source_with_libs`:
+//!
+//! | `d`'s declaration | harness |
+//! | --- | --- |
+//! | `const d = async function* () { ... }` (anonymous expression) | **silent** |
+//! | `const d = async function* named() { ... }` (named expression) | TS2345 |
+//! | `async function* d() { ... }` (declaration) | TS2345 |
+//!
+//! and the loss is not specific to the call-argument position — a plain
+//! `const forced: AsyncGenerator<AsyncGenerator<number>> = d();` loses it too.
+//!
+//! The named rows do **not** report because they are correct. Rendering the
+//! container out of the diagnostic text shows the named forms degrading to the
+//! bare, unsubstituted interface, which fails against every target including
+//! the ones it should pass:
+//!
+//! ```text
+//!                target                     tsz renders the container as
+//! anonymous   AsyncGenerator<{x:number}>    'AsyncGenerator<AsyncGenerator<string, any, any>, void, unknown>'
+//! named       AsyncGenerator<{x:number}>    'AsyncGenerator'
+//! named       AsyncGenerator<AsyncGenerator<number>>   'AsyncGenerator'
+//! anonymous   AsyncGenerator<AsyncGenerator<number>>   (no diagnostic)
+//! ```
+//!
+//! `tsc` renders the full application for both forms, so the **anonymous** form
+//! is the one holding the correct container type — it is not the broken half,
+//! it is the half where only the relation loses. Making anonymous match named
+//! would be chasing a second defect, not fixing this one. That degradation is
+//! its own row below.
+//!
+//! Three directions are measured dead, so they are not worth re-attempting
+//! without new evidence (each was built, measured on this suite, and reverted;
+//! all three left the counts byte-identical):
+//!
+//! 1. Minting the `Application` base in `unannotated_generator_return_type`
+//!    through the name-verified `get_or_create_def_id_for_symbol_name` instead
+//!    of the raw `get_or_create_def_id`. That code is reached identically for
+//!    anonymous and named forms, so it cannot explain an anonymity boundary.
+//! 2. Gating `subtype/cache.rs`'s symbol-level cycle check on `def_pair`, so it
+//!    honours the same-base-application exemption the `DefId`-level check
+//!    already has.
+//! 3. Widening `both_same_base_app` to cover two `DefId`s resolving to one
+//!    `SymbolId` when the applications' type arguments differ.
 //!
 //! Everything else here is a live control, green today, pinning the shapes the
 //! harness *does* see so the boundary of the gap stays measured. Oracle for
@@ -75,8 +126,9 @@ fn strict_codes(source: &str) -> Vec<u32> {
 /// generator expression out of the picture entirely, so a reader cannot
 /// mistake this for an inference problem.
 #[test]
-#[ignore = "unit-harness gap, NOT a checker defect: the CLI reports TS2345 here; \
-            `check_source_with_libs` loses it on self-similar generator nesting"]
+#[ignore = "#16125 open: the CLI and tsc report TS2345 here, the harness does \
+            not. Mechanism not located; see the module doc for the measured \
+            boundary and the three dead directions"]
 fn harness_sees_async_generator_operand_in_async_container() {
     let codes = strict_codes(
         r#"
@@ -99,8 +151,9 @@ wants(d());
 /// rather than anything async-specific: no `await`, no `[Symbol.asyncIterator]`,
 /// same divergence.
 #[test]
-#[ignore = "unit-harness gap, NOT a checker defect: the CLI reports TS2345 here; \
-            `check_source_with_libs` loses it on self-similar generator nesting"]
+#[ignore = "#16125 open: the CLI and tsc report TS2345 here, the harness does \
+            not. Mechanism not located; see the module doc for the measured \
+            boundary and the three dead directions"]
 fn harness_sees_sync_generator_operand_in_sync_container() {
     let codes = strict_codes(
         r#"
@@ -287,5 +340,180 @@ wants(d());
     assert!(
         codes.contains(&2345),
         "an annotated inner generator expression must stay visible: {codes:?}"
+    );
+}
+
+/// The named-expression form of the two ignored rows. Green today, and the
+/// reason the boundary is a property of the container's declaration form rather
+/// than of the target: only the binder-visible name changes between this row
+/// and `harness_sees_async_generator_operand_in_async_container`.
+#[test]
+fn named_generator_function_expression_reports_the_self_similar_mismatch() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const zzSource: AsyncGenerator<string>;
+declare function wants(h: AsyncGenerator<AsyncGenerator<number>>): void;
+const d = async function* named() {
+    yield zzSource;
+};
+wants(d());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "the named-expression form must keep reporting: {codes:?}"
+    );
+}
+
+/// The function-declaration form, third row of the boundary table. Green today.
+#[test]
+fn generator_function_declaration_reports_the_self_similar_mismatch() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const zzSource: AsyncGenerator<string>;
+declare function wants(h: AsyncGenerator<AsyncGenerator<number>>): void;
+async function* d() {
+    yield zzSource;
+}
+wants(d());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "the function-declaration form must keep reporting: {codes:?}"
+    );
+}
+
+/// The matching case stays clean. Without this row a "fix" that reported on
+/// every self-similar comparison would look green on the two ignored rows while
+/// trading the false negative for a false positive. `tsc` is clean here.
+#[test]
+fn self_similar_container_matching_the_target_stays_clean() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const zzSource: AsyncGenerator<string>;
+declare function wants(h: AsyncGenerator<AsyncGenerator<string>>): void;
+const d = async function* () {
+    yield zzSource;
+};
+wants(d());
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "the matching self-similar assignment must stay clean: {codes:?}"
+    );
+}
+
+/// The same loss with every user binder renamed. Red for the same reason as the
+/// two rows above; pinned so a future fix cannot be keyed on anything in the
+/// user's naming without this row staying red.
+#[test]
+#[ignore = "#16125 open: same family as the two rows above, renamed binders"]
+fn renamed_binders_async_generator_operand_in_async_container() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const qqFeed: AsyncGenerator<string>;
+declare function accepts(pipe: AsyncGenerator<AsyncGenerator<number>>): void;
+const emit = async function* () {
+    yield qqFeed;
+};
+accepts(emit());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "renamed binders must not change the answer: {codes:?}"
+    );
+}
+
+/// The loss is not specific to the call-argument path: a plain annotated
+/// variable declaration loses it too, as TS2322. Pins the finding that
+/// argument-position resolution is not the owner.
+#[test]
+#[ignore = "#16125 open: the same loss on a plain variable declaration (TS2322)"]
+fn variable_declaration_target_loses_the_self_similar_mismatch() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const zzSource: AsyncGenerator<string>;
+const d = async function* () {
+    yield zzSource;
+};
+const forceMismatch: AsyncGenerator<AsyncGenerator<number>> = d();
+"#,
+    );
+    assert!(
+        codes.contains(&2322),
+        "the variable-declaration form must report TS2322: {codes:?}"
+    );
+}
+
+/// Depth 3. Pins that a fix has to hold when the interface nests inside itself
+/// more than once, not just at the first level.
+#[test]
+#[ignore = "#16125 open: same family at nesting depth 3"]
+fn depth_three_self_similar_nesting_reports() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const zzSource: AsyncGenerator<AsyncGenerator<string>>;
+declare function wants(h: AsyncGenerator<AsyncGenerator<AsyncGenerator<number>>>): void;
+const d = async function* () {
+    yield zzSource;
+};
+wants(d());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "depth-3 self-similar nesting must report: {codes:?}"
+    );
+}
+
+/// The second, separate defect this suite's investigation surfaced: the **named**
+/// forms report only because their container degraded to the bare, unsubstituted
+/// interface. `tsc` renders
+/// `AsyncGenerator<AsyncGenerator<string, any, any>, void, unknown>` here; tsz
+/// renders a bare `AsyncGenerator`, dropping every type argument.
+///
+/// This is the failure mode `unannotated_generator_return_type`'s own comment
+/// says its `evaluate_type_with_env` cache-warming exists to prevent (#16119),
+/// so the warming is not holding on the named path. Kept red rather than
+/// asserting today's wrong text, so a fix for it cannot land unnoticed.
+#[test]
+#[ignore = "#16125 open, separate defect: the named form's container degrades \
+            to a bare unsubstituted `AsyncGenerator` in the message text"]
+fn named_form_container_keeps_its_type_arguments_in_the_message() {
+    let libs = load_default_lib_files();
+    let messages = crate::test_utils::check_source_with_libs_code_messages(
+        r#"
+export {};
+declare const zzSource: AsyncGenerator<string>;
+declare function wants(h: AsyncGenerator<{ x: number }>): void;
+async function* d() {
+    yield zzSource;
+}
+wants(d());
+"#,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    );
+    let text = messages
+        .iter()
+        .find(|(code, _)| *code == 2345)
+        .map(|(_, message)| message.clone())
+        .unwrap_or_default();
+    assert!(
+        text.contains("AsyncGenerator<AsyncGenerator<string"),
+        "the named form must keep its type arguments the way tsc renders them: {text:?}"
     );
 }


### PR DESCRIPTION
`generator_yield_self_similar_nesting_tests` opened by asserting that #16125 is **"not a compiler defect ... an artifact of the unit harness"**, and both `#[ignore]` reasons said **"fixing a checker or solver path will not turn them green"**.

Neither claim was ever measured. The second is refuted; the first survives in weakened form (see the post-merge correction at the bottom). Until this landed the file was steering sessions away from the only layers that can fix the defect, which is worse than having no note at all — so the retraction, not the new rows, is the point of the PR.

Test-only. No compiler behaviour changes; `crates/` outside `src/tests/` is untouched.

## What the file claimed vs what is measured

| `d`'s declaration | harness |
| --- | --- |
| `const d = async function* () { ... }` (anonymous expression) | **silent** |
| `const d = async function* named() { ... }` (named expression) | TS2345 |
| `async function* d() { ... }` (declaration) | TS2345 |

and the loss is not specific to the call-argument path — a plain `const forced: AsyncGenerator[ AsyncGenerator[ number ] ] = d();` loses it too, as TS2322.

Nothing about harness wiring distinguishes an anonymous function expression from a named one, and the harness runs checker and solver code, so a declaration-form split has to arise in those layers. That is what retracts `"fixing a checker or solver path will not turn them green"`.

## The named rows are not the reference behaviour

Rendering the container out of the diagnostic text (`check_source_with_libs_code_messages`, no instrumentation) against two targets:

```
form        target                                     tsz renders the container as
anonymous   AsyncGenerator[ {x:number} ]               'AsyncGenerator[ AsyncGenerator[ string, any, any ], void, unknown ]'
named       AsyncGenerator[ {x:number} ]               'AsyncGenerator'
named       AsyncGenerator[ AsyncGenerator[ number ] ] 'AsyncGenerator'
anonymous   AsyncGenerator[ AsyncGenerator[ number ] ] (no diagnostic — the #16125 row)
```

The named forms report only because their container degraded to the bare, unsubstituted interface, which fails against **every** target including ones it should pass. `tsc` 7.0.2 renders the full application for both forms. So the **anonymous** form is the one holding the correct container type — it is not the broken half, it is the half where only the relation loses, and "make anonymous match named" would be chasing a second defect. Filed separately as #16191 and pinned here as a documented red.

## Rows added

Three live controls, green today:

- `named_generator_function_expression_reports_the_self_similar_mismatch`
- `generator_function_declaration_reports_the_self_similar_mismatch`
- `self_similar_container_matching_the_target_stays_clean` — without it, a "fix" reporting on every self-similar comparison would look green on the two ignored rows while trading the false negative for a false positive

Four documented `#[ignore]`s, red for the reason each states:

- `renamed_binders_async_generator_operand_in_async_container` — a fix cannot be keyed on user naming with this row present
- `variable_declaration_target_loses_the_self_similar_mismatch` — TS2322, pins that argument-position resolution is not the owner
- `depth_three_self_similar_nesting_reports`
- `named_form_container_keeps_its_type_arguments_in_the_message` — #16191

## Directions recorded dead

Each was built, measured, and reverted **against main's version of the file** (`--include-ignored generator yield`, `206 run: 202 passed / 4 failed`). All three came back byte-identical:

1. Minting the `Application` base in `unannotated_generator_return_type` through the name-verified `get_or_create_def_id_for_symbol_name` instead of the raw `get_or_create_def_id` — ClaudeT's suggested direction on #16125. Beyond the measurement, that code is reached identically for anonymous and named forms, so it cannot explain an anonymity boundary.
2. Gating `subtype/cache.rs`'s symbol-level cycle check on `def_pair`, so it honours the same-base-application exemption the `DefId`-level check already documents.
3. Widening `both_same_base_app` to cover two `DefId`s resolving to one `SymbolId` when the applications' type arguments differ.

No fix earned a push; a measured no-op on a hot relation path is unverified complexity.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib -- generator_yield_self_similar` — **11 passed, 0 failed, 6 ignored** (before: 8 passed, 0 failed, 2 ignored)
- `cargo test -p tsz-checker --lib -- --include-ignored generator_yield_self_similar` — 11 passed, 6 failed; the six failures are exactly the six documented `#[ignore]`s
- `cargo test -p tsz-checker --lib -- --include-ignored generator yield` — main `88b0ebb` `206 run: 202 passed / 4 failed`; this branch `213 run: 205 passed / 8 failed`. The `+7 run / +3 passed / +4 failed` delta is exactly the 3 new green rows and 4 new documented reds — nothing regressed. **(Corrected post-merge — see below. The line originally here claimed `202 / 4` on both sides, which was the main-side figure carried over from the three reverted experiments and wrong as a branch measurement. Caught by Quartz in review.)**
- Full default lane, measured by Quartz: `tsz-checker --lib` 8954 run, 1 failed (`ts2303`, known baselined) — zero delta
- `cargo fmt` + `cargo clippy -p tsz-checker` + architecture guard — via the pre-commit gate, all passed
- tsc oracle for every asserted row: `typescript@7.0.2`, `--noEmit --strict --pretty false --target es2018 --lib es2018,dom`, installed and run in this container
- **Not run, stated explicitly:** conformance, emit, and fourslash. The change touches only `#[cfg(test)]` rows in one file and no compiler path, so none of those suites can move; the corpus was also absent from this container (materialized via `reset-ts-submodule.sh --sparse`, but two `dist-fast` builds plus two snapshots did not fit the session).

## Post-merge corrections from Quartz's review

Two, both worth carrying forward rather than leaving in a review thread:

1. **The branch measurement above was wrong**, corrected in place.
2. **The CLI has no boundary at all.** All three declaration forms report TS2345 through the CLI, all three rendering the full correct application. So both the declaration-form split *and* the bare-`AsyncGenerator` degradation are **harness-only** — the old note's "harness" half survives, and only the "not fixable from checker or solver" half is retracted. The two claims deserved different verdicts. #16191 has been rescoped accordingly; it is a harness-observable defect, not a user-facing rendering bug.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Pyrite