### PR TITLE
fix(scripts): degrade gracefully when the README benchmark artifact vanishes

### DIFF
--- a/scripts/bench/readme-perf-svg.mjs
+++ b/scripts/bench/readme-perf-svg.mjs
@@ -505,6 +505,10 @@ if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
     process.exit(2);
   }
 
+  if (!fs.existsSync(inputPath)) {
+    console.error(`benchmark artifact not found: ${inputPath} (re-run the benchmark, e.g. scripts/bench/bench-vs-tsgo.sh --json)`);
+    process.exit(2);
+  }
   const data = JSON.parse(fs.readFileSync(inputPath, "utf8"));
   if (outputPath.toLowerCase().endsWith(".png")) {
     fs.writeFileSync(outputPath, await renderReadmePerfPng(data, { theme }));

--- a/scripts/refresh-readme.py
+++ b/scripts/refresh-readme.py
@@ -399,7 +399,13 @@ def load_benchmark_json(args):
         if not path.is_absolute():
             path = ROOT / path
         if not path.exists():
-            raise SystemExit(f"Error: benchmark artifact not found: {path}")
+            print(
+                f"warning: skipping README performance chart because the "
+                f"benchmark artifact was not found: {path} (re-run the "
+                "benchmark, e.g. scripts/bench/bench-vs-tsgo.sh --json)",
+                file=sys.stderr,
+            )
+            return None, None
         return path, None
 
     try:
@@ -434,6 +440,13 @@ def write_performance_png(benchmark_json):
         (PERFORMANCE_PNG_LIGHT, "light"),
         (PERFORMANCE_PNG_DARK, "dark"),
     ]:
+        if not benchmark_json.exists():
+            # The artifact can be deleted concurrently between this check and
+            # load_benchmark_json's own check (e.g. a concurrent clean.sh run).
+            # Only this specific race is safe to downgrade to a warning below;
+            # any other subprocess failure (e.g. a missing `sharp` dependency)
+            # must keep failing loudly.
+            raise FileNotFoundError(benchmark_json)
         subprocess.run(
             [
                 "node",
@@ -515,9 +528,16 @@ def main():
 
         if write:
             if benchmark_json is not None:
-                write_performance_png(benchmark_json)
-                print(f"{PERFORMANCE_PNG_LIGHT.relative_to(ROOT)} updated.")
-                print(f"{PERFORMANCE_PNG_DARK.relative_to(ROOT)} updated.")
+                try:
+                    write_performance_png(benchmark_json)
+                    print(f"{PERFORMANCE_PNG_LIGHT.relative_to(ROOT)} updated.")
+                    print(f"{PERFORMANCE_PNG_DARK.relative_to(ROOT)} updated.")
+                except FileNotFoundError as exc:
+                    print(
+                        "warning: skipping README performance chart because the "
+                        f"benchmark artifact vanished before it could be read: {exc}",
+                        file=sys.stderr,
+                    )
             if text != original:
                 README.write_text(text)
                 print("README.md updated.")


### PR DESCRIPTION
Fixes #16195.

`readme-perf-svg.mjs` did an unguarded read of the input benchmark JSON, so an
artifact deleted between generation and publish (e.g. a concurrent
`clean.sh`, since `artifacts/` is listed in `CLEAN_DIRS`) surfaced as a raw
`ENOENT` stack trace instead of a clear message. `refresh-readme.py` then
aborted the whole refresh on that failure, even though it already has a
"prefer stale README data over an incomplete artifact" precedent for the
conformance/emit blocks (`readme_emit_summary_is_ahead` etc.) — the benchmark
chart had no equivalent.

## Changes

- `readme-perf-svg.mjs`: check the input path exists and exit 2 with a clear
  message naming the missing artifact, instead of throwing on the raw
  `fs.readFileSync`.
- `refresh-readme.py`: treat a missing/vanished benchmark artifact the same
  way it already treats a stale one — warn and skip the performance chart,
  still write the other README blocks (conformance/emit/fourslash), rather
  than aborting the whole refresh. This covers both the up-front-missing case
  (`--benchmark-json` points at a path that never existed) and the
  concurrent-deletion race described in the issue (the file existed when
  first checked, but is gone by the time the PNG-writing subprocess runs).
- The "vanished artifact" catch in `refresh-readme.py` is scoped narrowly
  (`FileNotFoundError` raised from an explicit `exists()` check right before
  each subprocess call) rather than a blanket catch of
  `subprocess.CalledProcessError`, so an unrelated failure — e.g. the
  existing "sharp is required" error when the optional PNG-rendering
  dependency isn't installed — still fails loudly instead of being
  misreported as a vanished artifact. Verified this distinction explicitly
  (see Verification).

## Goal
Goal: hold

## Verification
- `node scripts/bench/test-readme-perf-svg.mjs` — existing suite, still passes.
- `python3 -m py_compile scripts/refresh-readme.py` and
  `python3 scripts/refresh-readme.py --help` — clean.
- `node scripts/bench/readme-perf-svg.mjs --theme light /tmp/does-not-exist.json /tmp/out.png` →
  now exits 2 with `benchmark artifact not found: ...` instead of an ENOENT stack trace.
- `python3 scripts/refresh-readme.py --write --benchmark-json <path that never existed>` →
  now prints `warning: skipping README performance chart because the benchmark
  artifact was not found: ...` and still updates the other blocks, instead of
  aborting with `SystemExit`.
- Unit-level repro of the concurrent-deletion race (write a file, delete it,
  then call `write_performance_png` directly): now raises `FileNotFoundError`
  cleanly instead of the node subprocess's raw `ENOENT` traceback.
- Regression check that the narrowing didn't over-catch: ran the same command
  against a real benchmark JSON with `sharp` uninstalled — still fails loudly
  with the original `Error: sharp is required for normal monospace PNG
  rendering...` traceback and a non-zero exit, confirming that failure mode
  is not swallowed by the new artifact-vanished handling.
- `git diff --stat` — only the two intended files changed.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnfmaX5bwt4ntrtrYdQDqM)_