### PR TITLE
fix(checker): model tsc's two-table binder walk for mixed-exportedness variable redeclarations

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1786,6 +1786,9 @@ mod ts2323_block_scoped_conflict_message_tests;
 #[path = "tests/ts2323_export_var_namespace_merge_tests.rs"]
 mod ts2323_export_var_namespace_merge_tests;
 #[cfg(test)]
+#[path = "tests/ts2323_mixed_exportedness_two_table_tests.rs"]
+mod ts2323_mixed_exportedness_two_table_tests;
+#[cfg(test)]
 #[path = "tests/ts2323_variable_redeclaration_two_pass_tests.rs"]
 mod ts2323_variable_redeclaration_two_pass_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/ts2323_mixed_exportedness_two_table_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2323_mixed_exportedness_two_table_tests.rs
@@ -1,0 +1,165 @@
+//! Mixed-exportedness variable redeclarations (#16170): `tsc` runs the
+//! collision walk over *two* independent symbol tables — `container.locals`
+//! (every declaration, but an exported one contributes only `EXPORT_VALUE`)
+//! and `container.symbol.exports` (only the exported declarations, real
+//! flags) — plus two checker-side follow-ups that each read one of those
+//! tables: TS2395 reads the locals-table survivor, TS2323 reads the
+//! exports-table survivor. A single merged pass (`ts2323_variable_redeclaration_two_pass_tests.rs`'s
+//! all-exported/all-local family) cannot reproduce this because the two
+//! tables see different declaration sequences the moment exportedness mixes.
+//!
+//! Every expectation below is pinned against `tsc` 7.0.2 run with
+//! `--noEmit --strict --pretty false --lib es2015 --target es2015`, from the
+//! oracle matrix gathered for #16170. Positions matter, so these assert
+//! per-line code sets.
+
+use crate::test_utils::check_source_diagnostics;
+use std::collections::BTreeMap;
+
+/// Diagnostics grouped by 1-based source line, codes sorted and deduplicated.
+fn codes_by_line(source: &str) -> Vec<(u32, Vec<u32>)> {
+    let diags = check_source_diagnostics(source);
+    let mut by_line: BTreeMap<u32, Vec<u32>> = BTreeMap::new();
+    for diag in &diags {
+        let offset = (diag.start as usize).min(source.len());
+        let line = source[..offset].matches('\n').count() as u32 + 1;
+        by_line.entry(line).or_default().push(diag.code);
+    }
+    by_line
+        .into_iter()
+        .map(|(line, mut codes)| {
+            codes.sort_unstable();
+            codes.dedup();
+            (line, codes)
+        })
+        .collect()
+}
+
+/// `_var evar elet`: the locals-table survivor accumulates
+/// `FUNCTION_SCOPED_VARIABLE` from line 2 (unexported, real flags), stays
+/// unbothered by line 3's exported `var` (contributes `EXPORT_VALUE` only,
+/// which does not collide with a var survivor), then collides with line 4's
+/// exported `let` — TS2300 lands on all three. The locals-table survivor
+/// mixes exported (line 3) and non-exported (line 2) members, so TS2395 joins
+/// on those two only; line 4 lost the collision onto its own throwaway
+/// symbol and is never part of that group. No declaration reaches the
+/// exports-table survivor with more than one member (only line 3 is
+/// exports-table eligible), so TS2323 never fires.
+#[test]
+fn unexported_var_then_exported_var_then_exported_let() {
+    assert_eq!(
+        codes_by_line("export {};\nvar alpha = 1;\nexport var alpha = 2;\nexport let alpha = 3;\n"),
+        vec![
+            (2, vec![2300, 2395]),
+            (3, vec![2300, 2395]),
+            (4, vec![2300])
+        ],
+    );
+}
+
+/// `elet _var elet`: the locals-table survivor holds line 2 (exported let,
+/// contributes `EXPORT_VALUE` only) then line 3 (unexported var, real flags)
+/// without colliding — `EXPORT_VALUE` never excludes a var. Line 4 (exported
+/// let) collides with that survivor (whose accumulated flags now include the
+/// real `FUNCTION_SCOPED_VARIABLE` bit from line 3): TS2300, not TS2451,
+/// because the *survivor's* accumulated flags never carried a real
+/// block-scoped bit. TS2395 covers the same locals-table survivor (lines 2-3,
+/// mixed exportedness). Independently, the exports-table walk holds only
+/// lines 2 and 4 (both exported lets, real flags) — those collide with each
+/// other for TS2451, on both, regardless of what happened in locals.
+#[test]
+fn exported_let_then_unexported_var_then_exported_let() {
+    assert_eq!(
+        codes_by_line("export {};\nexport let alpha = 1;\nvar alpha = 2;\nexport let alpha = 3;\n"),
+        vec![
+            (2, vec![2300, 2395, 2451]),
+            (3, vec![2300, 2395]),
+            (4, vec![2300, 2451]),
+        ],
+    );
+}
+
+/// `evar _let evar`: the locals-table survivor holds line 2 (exported var,
+/// `EXPORT_VALUE` only), then line 3 (unexported let, real
+/// `BLOCK_SCOPED_VARIABLE` flag) joins without colliding (`EXPORT_VALUE`
+/// alone never excludes anything). Line 4 (exported var) collides with that
+/// survivor because the survivor's accumulated flags now carry the real
+/// block-scoped bit from line 3 — TS2451, not TS2300, and it lands on all
+/// three (lines 2-3 from the survivor, line 4 as the colliding declaration).
+/// TS2395 covers the same survivor (lines 2-3). Independently, the
+/// exports-table walk holds only lines 2 and 4 (both exported vars, which do
+/// not exclude each other) — that group survives with two members, so TS2323
+/// fires on both.
+#[test]
+fn exported_var_then_unexported_let_then_exported_var() {
+    assert_eq!(
+        codes_by_line("export {};\nexport var alpha = 1;\nlet alpha = 2;\nexport var alpha = 3;\n"),
+        vec![
+            (2, vec![2323, 2395, 2451]),
+            (3, vec![2395, 2451]),
+            (4, vec![2323, 2451]),
+        ],
+    );
+}
+
+/// `_var elet _var`: line 3 (exported let) collides with the locals-table
+/// survivor seeded by line 2 (unexported var, real flags) — TS2300 on both.
+/// Line 4 (unexported var) does *not* collide with the survivor (still `var`,
+/// still just line 2's real flags — line 3 lost its collision onto a
+/// throwaway symbol and never widened the survivor), so it rejoins the
+/// survivor silently. The rejoined survivor (lines 2 and 4) is uniformly
+/// non-exported, so TS2395 never fires, and nothing is exports-table
+/// eligible except line 3 alone, so TS2323 never fires either. Line 4 ends
+/// with zero diagnostics.
+#[test]
+fn unexported_var_then_exported_let_then_unexported_var_leaves_the_rejoiner_clean() {
+    assert_eq!(
+        codes_by_line("export {};\nvar alpha = 1;\nexport let alpha = 2;\nvar alpha = 3;\n"),
+        vec![(2, vec![2300]), (3, vec![2300])],
+    );
+}
+
+/// Renamed-binder control: the rule is structural, not keyed on any
+/// identifier — same shape as the `evar _let evar` row above, different name.
+#[test]
+fn exported_var_then_unexported_let_then_exported_var_is_name_independent() {
+    assert_eq!(
+        codes_by_line("export {};\nexport var zeta = 1;\nlet zeta = 2;\nexport var zeta = 3;\n"),
+        vec![
+            (2, vec![2323, 2395, 2451]),
+            (3, vec![2395, 2451]),
+            (4, vec![2323, 2451]),
+        ],
+    );
+}
+
+/// Simplest two-declaration mixed-exportedness pair, reversed order from the
+/// pre-existing `mixed_exportedness_var_pair_is_ts2395` regression control:
+/// neither table ever collides (a var survivor is never excluded by another
+/// var's `EXPORT_VALUE`-only contribution, and the exports table alone has
+/// one member), so only TS2395 fires.
+#[test]
+fn unexported_var_then_exported_var_is_ts2395_only() {
+    assert_eq!(
+        codes_by_line("export {};\nvar alpha = 1;\nexport var alpha = 2;\n"),
+        vec![(2, vec![2395]), (3, vec![2395])],
+    );
+}
+
+/// Two-declaration mixed pair where the *unexported* declaration is the
+/// block-scoped one: line 2's real `BLOCK_SCOPED_VARIABLE` flag collides with
+/// line 3's exported `var` (the exclusion is keyed on the *incoming*
+/// declaration's own real kind — `var`'s excludes do intersect a block-scoped
+/// survivor regardless of export status) for TS2451 on both. Line 3 loses the
+/// collision onto its own throwaway symbol, so the locals-table survivor
+/// stays a lone, uniformly non-exported line 2 — too small to ever mix
+/// exportedness, so TS2395 cannot fire here (that needs 3+ declarations; see
+/// the `evar _let evar` / `elet _var elet` rows above). The exports table
+/// holds line 3 alone, so TS2323 never fires either.
+#[test]
+fn unexported_let_then_exported_var_is_ts2451_only() {
+    assert_eq!(
+        codes_by_line("export {};\nlet alpha = 1;\nexport var alpha = 2;\n"),
+        vec![(2, vec![2451]), (3, vec![2451])],
+    );
+}

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -480,6 +480,16 @@ impl<'a> CheckerState<'a> {
             // TS2395.
             let mut ts2652_error_nodes: Vec<NodeIndex> = Vec::new();
             let mut ts2395_error_nodes: Vec<NodeIndex> = Vec::new();
+            // A symbol whose local declarations are all plain variables is
+            // owned end to end by `try_emit_variable_redeclaration_family`
+            // below (including its own TS2395), which models `tsc`'s
+            // two-table mechanism this single-group scan cannot: a variable
+            // pair can merge exported and non-exported declarations without
+            // ever colliding (`export var a; var a;` is legal `var`
+            // redeclaration but still reports TS2395), which this scan would
+            // also catch, but not with the right footprint once a real
+            // collision is also in play (see #16170).
+            let is_pure_variable_family = self.declarations_are_pure_variable_family(&declarations);
 
             // Skip TS2395 when all local declarations are in a `declare namespace`
             // (identifier-named ambient namespace). In these contexts, the
@@ -563,43 +573,47 @@ impl<'a> CheckerState<'a> {
                 ));
             }
 
-            for group in scope_groups.values() {
-                if group.len() <= 1 {
-                    continue;
-                }
-                let all_functions = group
-                    .iter()
-                    .all(|&(_, flags, _, _, _)| (flags & symbol_flags::FUNCTION) != 0);
-                let mut default_exported_spaces: u32 = 0;
-                let mut exported_spaces: u32 = 0;
-                let mut non_exported_spaces: u32 = 0;
-                for &(_, _, space, exported, default_exported) in group {
-                    if default_exported {
-                        default_exported_spaces |= space;
-                    } else if exported {
-                        exported_spaces |= space;
-                    } else {
-                        non_exported_spaces |= space;
+            if !is_pure_variable_family {
+                for group in scope_groups.values() {
+                    if group.len() <= 1 {
+                        continue;
                     }
-                }
-                let non_default_spaces = exported_spaces | non_exported_spaces;
-                let default_conflict_spaces = default_exported_spaces & non_default_spaces;
-                let export_local_conflict_spaces = if all_functions || suppress_ts2395_for_ambient {
-                    0
-                } else {
-                    exported_spaces & non_exported_spaces
-                };
+                    let all_functions = group
+                        .iter()
+                        .all(|&(_, flags, _, _, _)| (flags & symbol_flags::FUNCTION) != 0);
+                    let mut default_exported_spaces: u32 = 0;
+                    let mut exported_spaces: u32 = 0;
+                    let mut non_exported_spaces: u32 = 0;
+                    for &(_, _, space, exported, default_exported) in group {
+                        if default_exported {
+                            default_exported_spaces |= space;
+                        } else if exported {
+                            exported_spaces |= space;
+                        } else {
+                            non_exported_spaces |= space;
+                        }
+                    }
+                    let non_default_spaces = exported_spaces | non_exported_spaces;
+                    let default_conflict_spaces = default_exported_spaces & non_default_spaces;
+                    let export_local_conflict_spaces =
+                        if all_functions || suppress_ts2395_for_ambient {
+                            0
+                        } else {
+                            exported_spaces & non_exported_spaces
+                        };
 
-                if default_conflict_spaces == 0 && export_local_conflict_spaces == 0 {
-                    continue;
-                }
+                    if default_conflict_spaces == 0 && export_local_conflict_spaces == 0 {
+                        continue;
+                    }
 
-                for &(decl_idx, _, space, _, _) in group {
-                    let error_node = self.get_declaration_name_node(decl_idx).unwrap_or(decl_idx);
-                    if (space & default_conflict_spaces) != 0 {
-                        ts2652_error_nodes.push(error_node);
-                    } else if (space & export_local_conflict_spaces) != 0 {
-                        ts2395_error_nodes.push(error_node);
+                    for &(decl_idx, _, space, _, _) in group {
+                        let error_node =
+                            self.get_declaration_name_node(decl_idx).unwrap_or(decl_idx);
+                        if (space & default_conflict_spaces) != 0 {
+                            ts2652_error_nodes.push(error_node);
+                        } else if (space & export_local_conflict_spaces) != 0 {
+                            ts2395_error_nodes.push(error_node);
+                        }
                     }
                 }
             }
@@ -1365,7 +1379,13 @@ impl<'a> CheckerState<'a> {
                 self.error_at_node(error_node, &message, diagnostic_codes::A_NAMESPACE_DECLARATION_CANNOT_BE_LOCATED_PRIOR_TO_A_CLASS_OR_FUNCTION_WITH_WHIC);
             }
 
-            if conflicts.is_empty() {
+            // A pure-variable-family symbol can need reporting (TS2395) even
+            // when no pair of its declarations ever collides under this
+            // scan's pairwise `conflicts` model — `export var a; var a;` is
+            // legal `var` redeclaration (no entry in `conflicts`) but still
+            // reports TS2395 — so it must still reach
+            // `try_emit_variable_redeclaration_family` below.
+            if conflicts.is_empty() && !is_pure_variable_family {
                 continue;
             }
 
@@ -1441,7 +1461,7 @@ impl<'a> CheckerState<'a> {
                         }
                     }
                 }
-                if conflicts.is_empty() {
+                if conflicts.is_empty() && !is_pure_variable_family {
                     continue;
                 }
             }
@@ -1669,10 +1689,9 @@ impl<'a> CheckerState<'a> {
             // directly in `duplicate_identifiers_variable_family`.
             if self.try_emit_variable_redeclaration_family(
                 &declarations,
-                &conflicts,
                 &name,
                 is_external_module,
-                force2300 || has_umd_global_value_conflict || has_merge_visibility_diagnostic,
+                force2300 || has_umd_global_value_conflict,
             ) {
                 continue;
             }

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_variable_family.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_variable_family.rs
@@ -1,35 +1,55 @@
 //! Variable-redeclaration reporting for a symbol whose declarations are *all*
 //! plain variable declarations (`var`/`let`/`const`).
 //!
-//! `tsc` reaches this family through **two independent passes**, so one
-//! declaration can carry two codes at once and the two codes can cover
-//! different subsets of the declaration list:
+//! `tsc` reaches this family through **three independent passes** rooted in
+//! two separate binder symbol tables (`declareModuleMember`,
+//! `crates/tsz-checker` mirrors `container.locals` / `container.symbol.exports`
+//! from `src/compiler/binder.ts`), so one declaration can carry several codes
+//! at once and each pass can cover a different subset of the declaration
+//! list:
 //!
-//! 1. The binder's collision pass (`declareSymbol`). Each declaration is
-//!    tested against the *surviving* symbol's accumulated flags. On a
-//!    collision the message (TS2451 when the surviving symbol is already
-//!    block-scoped, otherwise TS2300) is reported on every declaration
+//! 1. The **locals-table** collision pass (`declareSymbol` over
+//!    `container.locals`). Every declaration is tested against the
+//!    *surviving* locals symbol's accumulated flags, but an **exported**
+//!    declaration only ever contributes `EXPORT_VALUE` to that accumulated
+//!    value — never `FUNCTION_SCOPED_VARIABLE`/`BLOCK_SCOPED_VARIABLE` — because
+//!    `declareModuleMember` writes the export-shadow entry into `locals` with
+//!    `exportKind`, not the real symbol flags. A collision reports TS2451
+//!    (surviving flags already block-scoped) or TS2300 on every declaration
 //!    recorded on the surviving symbol so far **and** on the colliding
-//!    declaration — and then the colliding declaration is attached to a fresh
-//!    throwaway symbol that never re-enters the symbol table. The surviving
-//!    symbol therefore keeps its original flags and its declaration list only
-//!    grows with declarations that did *not* collide.
-//! 2. The exported-variable pass (TS2323), which reads the surviving symbol
-//!    and reports on each of its declarations when it is exported and has
-//!    more than one.
+//!    declaration; the colliding declaration then attaches to a fresh
+//!    throwaway symbol that never re-enters the table, so later declarations
+//!    keep comparing against the original surviving symbol.
+//! 2. The **exports-table** collision pass (`declareSymbol` over
+//!    `container.symbol.exports`), a *second*, independent walk using each
+//!    declaration's *real* flags, over only the declarations whose export
+//!    reaches the module's export table (external module scope, not a
+//!    namespace-internal `export`, per #16158/#16161). Same collision
+//!    mechanics as pass 1, an entirely separate surviving group, and can
+//!    report its own TS2300/TS2451 on top of pass 1's.
+//! 3. The **exported-variable** check (TS2323, `checkExternalModuleExports`),
+//!    which reads pass 2's final surviving group and reports on every member
+//!    when the group has more than one declaration.
 //!
-//! The consequence is that `export var a; export let a; export var a;` reports
-//! TS2300 on lines 1-2 (binder pass, whose surviving symbol at that point was
-//! just line 1) and TS2323 on lines 1 and 3 (exported pass, whose surviving
-//! symbol ends up holding both `var` declarations because the third one never
-//! collided with the function-scoped survivor).
+//! 4. `checkExportsOnMergedDeclarationsWorker` (TS2395) also reads a
+//!    locals-table symbol — but the *pass 1* surviving group, not pass 2's —
+//!    and reports on every member of that group when it mixes exported and
+//!    non-exported declarations.
 //!
-//! A single-code-per-symbol `if`-chain cannot express either half: not the
-//! co-emission, and not the differing footprints. This module models the two
-//! passes directly for the sub-family where it is safe and self-contained —
-//! every declaration local, a plain variable, part of the conflict set, and
-//! uniformly exported or uniformly local. Anything else falls back to the
-//! general selection chain in `duplicate_identifiers.rs`.
+//! For example, `export var a; export let a; export var a;` reports TS2300
+//! on lines 1-2 (pass 1's surviving symbol at that point was just line 1) and
+//! TS2323 on lines 1 and 3 (pass 2/3's surviving symbol ends up holding both
+//! `var` declarations because the third one never collided with the
+//! function-scoped survivor there, and pass 2 never sees line 2 at all since
+//! it is not exported).
+//!
+//! A single-code-per-symbol `if`-chain cannot express any of this: not the
+//! co-emission, not the differing footprints, and not the two independent
+//! symbol tables mixed exportedness requires. This module models all three
+//! (four, counting TS2395) passes directly for the sub-family where it is
+//! safe and self-contained — every declaration local, a plain variable, and
+//! part of the conflict set. Anything else falls back to the general
+//! selection chain in `duplicate_identifiers.rs`.
 //!
 //! Every expectation is pinned against `tsc` 7.0.2 with
 //! `--noEmit --strict --pretty false --lib es2015 --target es2015`.
@@ -37,7 +57,6 @@
 use super::duplicate_identifiers::DuplicateDeclarationOrigin;
 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
 use crate::state::CheckerState;
-use rustc_hash::FxHashSet;
 use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
 
@@ -46,6 +65,34 @@ use tsz_parser::parser::NodeIndex;
 type DuplicateDeclaration = (NodeIndex, u32, bool, bool, DuplicateDeclarationOrigin);
 
 impl CheckerState<'_> {
+    /// Whether every *local* declaration in `declarations` is a plain
+    /// variable declaration (`var`/`let`/`const`) from the symbol's own
+    /// declaration list — the shape `try_emit_variable_redeclaration_family`
+    /// owns end to end. The general selection chain's merge-visibility pass
+    /// (TS2395/TS2652) and its `conflicts`-emptiness short-circuit both need
+    /// this *before* either has run its own logic, so it is a cheap
+    /// structural check over the raw tuples rather than the full validation
+    /// `variable_family_declarations` does.
+    pub(super) fn declarations_are_pure_variable_family(
+        &self,
+        declarations: &[DuplicateDeclaration],
+    ) -> bool {
+        let mut any_local = false;
+        for (_, flags, is_local, _, origin) in declarations {
+            if !*is_local {
+                continue;
+            }
+            any_local = true;
+            if *origin != DuplicateDeclarationOrigin::SymbolDeclaration {
+                return false;
+            }
+            if (flags & !symbol_flags::VARIABLE) != 0 || (flags & symbol_flags::VARIABLE) == 0 {
+                return false;
+            }
+        }
+        any_local
+    }
+
     /// Emit the variable-redeclaration diagnostics for `declarations` the way
     /// `tsc`'s two passes do, returning `true` when this module owns the
     /// reporting for the symbol and the caller must not run its own selection
@@ -59,40 +106,31 @@ impl CheckerState<'_> {
     pub(super) fn try_emit_variable_redeclaration_family(
         &mut self,
         declarations: &[DuplicateDeclaration],
-        conflicts: &FxHashSet<NodeIndex>,
         name: &str,
         is_external_module: bool,
         suppressed_by_caller: bool,
     ) -> bool {
-        if suppressed_by_caller || conflicts.is_empty() || declarations.len() < 2 {
+        if suppressed_by_caller || declarations.len() < 2 {
             return false;
         }
 
-        let Some(ordered) = self.variable_family_declarations(declarations, conflicts) else {
+        let Some(ordered) = self.variable_family_declarations(declarations) else {
             return false;
         };
-        let all_exported = declarations
-            .iter()
-            .all(|(_, _, _, is_exported, _)| *is_exported);
-        let none_exported = declarations
-            .iter()
-            .all(|(_, _, _, is_exported, _)| !*is_exported);
-        // Mixed exportedness routes through `tsc`'s *separate* export table as
-        // well as the local one, which gives the two passes different inputs
-        // and pulls TS2395 in alongside. That is a different family; leave it.
-        if !all_exported && !none_exported {
-            return false;
-        }
-        // The exported-variable pass reads the *module's* export table, so a
-        // namespace-internal `export var` merge never reaches it — tsc accepts
-        // those (see #16158/#16161). The binder pass below still runs for them.
-        let exported_pass_applies = all_exported
-            && is_external_module
-            && declarations
-                .iter()
-                .all(|(decl_idx, _, _, _, _)| self.get_enclosing_namespace(*decl_idx).is_none());
 
-        let reports = variable_family_reports(&ordered, exported_pass_applies);
+        // The exports-table *collision* walk (pass 2) runs for every exported
+        // declaration regardless of container — a namespace has its own
+        // `.exports` table too, and `declareModuleMember` writes into it the
+        // same way a source-file module does. Only the later checker-side
+        // TS2323 audit (`checkExternalModuleExports`, pass 3) is specific to a
+        // genuine external module's export table; a namespace-internal
+        // `export var` merge never reaches it (see #16158/#16161).
+        let ts2323_applies = is_external_module
+            && declarations.iter().all(|(decl_idx, _, _, is_exported, _)| {
+                !*is_exported || self.get_enclosing_namespace(*decl_idx).is_none()
+            });
+
+        let reports = variable_family_reports(&ordered, ts2323_applies);
         if reports.is_empty() {
             return false;
         }
@@ -107,6 +145,12 @@ impl CheckerState<'_> {
                     diagnostic_messages::CANNOT_REDECLARE_BLOCK_SCOPED_VARIABLE,
                     &[name],
                 ),
+                diagnostic_codes::INDIVIDUAL_DECLARATIONS_IN_MERGED_DECLARATION_MUST_BE_ALL_EXPORTED_OR_ALL_LOCAL => {
+                    format_message(
+                        diagnostic_messages::INDIVIDUAL_DECLARATIONS_IN_MERGED_DECLARATION_MUST_BE_ALL_EXPORTED_OR_ALL_LOCAL,
+                        &[name],
+                    )
+                }
                 _ => format_message(diagnostic_messages::DUPLICATE_IDENTIFIER, &[name]),
             };
             let error_node = self.get_declaration_name_node(decl_idx).unwrap_or(decl_idx);
@@ -116,24 +160,28 @@ impl CheckerState<'_> {
     }
 
     /// Validate that every declaration belongs to the modelled sub-family and
-    /// return them ordered by source position as `(declaration, flags)`.
+    /// return them ordered by source position as
+    /// `(declaration, flags, is_exported)`.
     ///
     /// The family is deliberately narrow: a plain local variable declaration
     /// carrying no symbol flag other than `FUNCTION_SCOPED_VARIABLE` or
-    /// `BLOCK_SCOPED_VARIABLE`, sourced from the symbol's own declaration list,
-    /// and part of the conflict set. Merged functions, classes, enums, aliases,
-    /// namespaces, accessors and cross-file declarations all leave the family.
+    /// `BLOCK_SCOPED_VARIABLE`, sourced from the symbol's own declaration list.
+    /// Merged functions, classes, enums, aliases, namespaces, accessors and
+    /// cross-file declarations all leave the family. Unlike the general
+    /// selection chain this module replaces, membership does not also require
+    /// the caller's own pairwise `conflicts` set: `tsc`'s two-table model
+    /// (notably TS2395) applies to plain variables that never trigger a
+    /// same-kind collision at all (`export var a; var a;` reports TS2395 with
+    /// no TS2300/2451 anywhere), so this module runs its own complete
+    /// algorithm rather than deferring to a pre-filter tuned for the
+    /// single-code chain.
     fn variable_family_declarations(
         &self,
         declarations: &[DuplicateDeclaration],
-        conflicts: &FxHashSet<NodeIndex>,
-    ) -> Option<Vec<(NodeIndex, u32)>> {
-        let mut ordered: Vec<(NodeIndex, u32, u32)> = Vec::with_capacity(declarations.len());
-        for (decl_idx, flags, is_local, _, origin) in declarations {
-            if !*is_local
-                || *origin != DuplicateDeclarationOrigin::SymbolDeclaration
-                || !conflicts.contains(decl_idx)
-            {
+    ) -> Option<Vec<(NodeIndex, u32, bool)>> {
+        let mut ordered: Vec<(NodeIndex, u32, bool, u32)> = Vec::with_capacity(declarations.len());
+        for (decl_idx, flags, is_local, is_exported, origin) in declarations {
+            if !*is_local || *origin != DuplicateDeclarationOrigin::SymbolDeclaration {
                 return None;
             }
             if (flags & !symbol_flags::VARIABLE) != 0 || (flags & symbol_flags::VARIABLE) == 0 {
@@ -145,53 +193,60 @@ impl CheckerState<'_> {
                 return None;
             }
             let pos = self.ctx.arena.get(*decl_idx)?.pos;
-            if ordered.iter().any(|(idx, _, _)| *idx == *decl_idx) {
+            if ordered.iter().any(|(idx, _, _, _)| *idx == *decl_idx) {
                 return None;
             }
-            ordered.push((*decl_idx, *flags, pos));
+            ordered.push((*decl_idx, *flags, *is_exported, pos));
         }
         // Two declarations at the same position mean the list is not a faithful
         // source-order view of the symbol, and the binder pass depends on order.
-        ordered.sort_by_key(|(_, _, pos)| *pos);
-        if ordered.windows(2).any(|w| w[0].2 == w[1].2) {
+        ordered.sort_by_key(|(_, _, _, pos)| *pos);
+        if ordered.windows(2).any(|w| w[0].3 == w[1].3) {
             return None;
         }
         Some(
             ordered
                 .into_iter()
-                .map(|(idx, flags, _)| (idx, flags))
+                .map(|(idx, flags, is_exported, _)| (idx, flags, is_exported))
                 .collect(),
         )
     }
 }
 
-/// Replay `tsc`'s two passes over `ordered` (source order) and return the
-/// `(declaration, code)` pairs to report, deduplicated, in source order with
-/// ascending code per declaration.
-fn variable_family_reports(
-    ordered: &[(NodeIndex, u32)],
-    exported_pass_applies: bool,
-) -> Vec<(NodeIndex, u32)> {
-    let Some(((first_idx, first_flags), rest)) = ordered.split_first() else {
-        return Vec::new();
+/// One symbol-table's-worth of `declareSymbol`'s collision walk: `surviving`
+/// stays in the table and only grows with declarations that do not collide;
+/// a colliding declaration is reported and dropped onto a throwaway symbol
+/// that the table never sees again, so the *next* declaration keeps comparing
+/// against the same accumulated flags. Each item is
+/// `(declaration, real_flags, contributed_flags)`: `real_flags` (the
+/// declaration's own var/let flag) picks the exclude set, while
+/// `contributed_flags` is what gets OR'd into the accumulator on a
+/// non-colliding merge. They differ for the locals table's export-shadow rule
+/// (an exported declaration's `real_flags` is still its true var/let flag —
+/// that is what a *later* declaration's excludes test against — but it
+/// contributes only `EXPORT_VALUE`, mirroring `declareModuleMember` writing
+/// the export-shadow entry into `container.locals` with `exportKind`). The
+/// exports table's walk uses real flags for both.
+fn collision_walk(
+    ordered: impl IntoIterator<Item = (NodeIndex, u32, u32)>,
+) -> (Vec<NodeIndex>, Vec<(NodeIndex, u32)>) {
+    let mut iter = ordered.into_iter();
+    let Some((first_idx, _, first_contributed)) = iter.next() else {
+        return (Vec::new(), Vec::new());
     };
-
-    // Pass 1: the binder's collision walk. `surviving` is the symbol that stays
-    // in the symbol table; colliding declarations are reported and dropped onto
-    // a throwaway symbol, so they neither join the list nor widen the flags.
-    let mut surviving: Vec<NodeIndex> = vec![*first_idx];
-    let mut surviving_flags = *first_flags;
+    let mut surviving: Vec<NodeIndex> = vec![first_idx];
+    let mut surviving_flags = first_contributed;
     let mut reports: Vec<(NodeIndex, u32)> = Vec::new();
 
-    for (decl_idx, flags) in rest {
-        let excludes = if (flags & symbol_flags::BLOCK_SCOPED_VARIABLE) != 0 {
+    for (decl_idx, real_flags, contributed_flags) in iter {
+        let excludes = if (real_flags & symbol_flags::BLOCK_SCOPED_VARIABLE) != 0 {
             symbol_flags::BLOCK_SCOPED_VARIABLE_EXCLUDES
         } else {
             symbol_flags::FUNCTION_SCOPED_VARIABLE_EXCLUDES
         };
         if (surviving_flags & excludes) == 0 {
-            surviving.push(*decl_idx);
-            surviving_flags |= flags;
+            surviving.push(decl_idx);
+            surviving_flags |= contributed_flags;
             continue;
         }
         let code = if (surviving_flags & symbol_flags::BLOCK_SCOPED_VARIABLE) != 0 {
@@ -200,19 +255,85 @@ fn variable_family_reports(
             diagnostic_codes::DUPLICATE_IDENTIFIER
         };
         reports.extend(surviving.iter().map(|idx| (*idx, code)));
-        reports.push((*decl_idx, code));
+        reports.push((decl_idx, code));
+    }
+    (surviving, reports)
+}
+
+/// Replay `tsc`'s locals-table pass, exports-table pass, and their two
+/// checker-side follow-ups (TS2395, TS2323) over `ordered` (source order,
+/// `(declaration, flags, is_exported)`), returning the `(declaration, code)`
+/// pairs to report, deduplicated, in source order with ascending code per
+/// declaration. `ts2323_applies` gates only the TS2323 checker-side audit —
+/// the exports-table collision walk itself runs for every exported
+/// declaration regardless of container, since a namespace has its own
+/// `.exports` table too (see #16158/#16161).
+fn variable_family_reports(
+    ordered: &[(NodeIndex, u32, bool)],
+    ts2323_applies: bool,
+) -> Vec<(NodeIndex, u32)> {
+    if ordered.is_empty() {
+        return Vec::new();
     }
 
-    // Pass 2: the exported-variable pass, reading the surviving symbol only.
-    if exported_pass_applies && surviving.len() > 1 {
+    // Pass 1: the locals-table collision walk. An exported declaration
+    // contributes only `EXPORT_VALUE` to the accumulated flags — never its
+    // real var/let flag — mirroring `declareModuleMember`'s export-shadow
+    // entry into `container.locals`.
+    let (locals_surviving, mut reports) =
+        collision_walk(ordered.iter().map(|&(idx, flags, is_exported)| {
+            let contributed = if is_exported {
+                symbol_flags::EXPORT_VALUE
+            } else {
+                flags
+            };
+            (idx, flags, contributed)
+        }));
+
+    // TS2395: `checkExportsOnMergedDeclarationsWorker` reads the *same*
+    // locals-table surviving group (a declaration that lost pass 1's
+    // collision is attached to its own throwaway symbol and never rejoins
+    // it), and reports on every member when the group mixes exported and
+    // non-exported declarations.
+    let is_exported_of: rustc_hash::FxHashMap<NodeIndex, bool> = ordered
+        .iter()
+        .map(|&(idx, _, is_exported)| (idx, is_exported))
+        .collect();
+    let surviving_has_exported = locals_surviving
+        .iter()
+        .any(|idx| is_exported_of.get(idx).copied().unwrap_or(false));
+    let surviving_has_local = locals_surviving
+        .iter()
+        .any(|idx| !is_exported_of.get(idx).copied().unwrap_or(false));
+    if surviving_has_exported && surviving_has_local {
+        reports.extend(locals_surviving.iter().map(|idx| {
+            (
+                *idx,
+                diagnostic_codes::INDIVIDUAL_DECLARATIONS_IN_MERGED_DECLARATION_MUST_BE_ALL_EXPORTED_OR_ALL_LOCAL,
+            )
+        }));
+    }
+
+    // Pass 2: the exports-table collision walk — real flags, every exported
+    // declaration, independent of the locals-table walk above.
+    let (exports_surviving, exports_reports) = collision_walk(
+        ordered
+            .iter()
+            .filter(|&&(_, _, is_exported)| is_exported)
+            .map(|&(idx, flags, _)| (idx, flags, flags)),
+    );
+    reports.extend(exports_reports);
+    // Pass 3 (TS2323): the checker-side audit of pass 2's final surviving
+    // group, restricted to a genuine external module's export table.
+    if ts2323_applies && exports_surviving.len() > 1 {
         reports.extend(
-            surviving
+            exports_surviving
                 .iter()
                 .map(|idx| (*idx, diagnostic_codes::CANNOT_REDECLARE_EXPORTED_VARIABLE)),
         );
     }
 
-    let order: Vec<NodeIndex> = ordered.iter().map(|(idx, _)| *idx).collect();
+    let order: Vec<NodeIndex> = ordered.iter().map(|&(idx, _, _)| idx).collect();
     reports.sort_by_key(|(idx, code)| {
         (
             order


### PR DESCRIPTION
When a symbol's declarations mix exported and non-exported plain `var`/`let`/`const` (e.g. `export var a; var a; export let a;`), `tsc`'s `declareModuleMember` (`src/compiler/binder.ts`) runs the collision walk over **two separate symbol tables**: an exported declaration contributes only `EXPORT_VALUE` to `container.locals`'s accumulated flags (never its real var/let flag), while a *second*, independent `declareSymbol` call inserts its real flags into `container.symbol.exports`. tsz's `duplicate_identifiers_variable_family.rs` (from #16169) modelled only the uniform-exportedness case with a single merged pass, and bailed to the general selection chain whenever exportedness was mixed.

That fallback made things worse than a plain miss: `duplicate_identifiers.rs`'s general TS2395/TS2652 pass computes its footprint over the symbol's *entire* declaration list, not the pass-1 "surviving" subgroup `tsc` actually uses — so it reported TS2395 on every declaration uniformly, including ones a real collision should have excluded — and then set `suppressed_by_caller = true`, permanently preventing `try_emit_variable_redeclaration_family` from running for the exact cases it needed to own.

## Structural rule

When a symbol has mixed exported/non-exported plain-variable declarations, `tsc` runs three collision-adjacent mechanisms and unions their output:
1. **locals-table walk** (binder): real flags for non-exported declarations, `EXPORT_VALUE`-only for exported ones — a collision reports TS2300/TS2451 on the surviving group plus the colliding declaration.
2. **exports-table walk** (binder): a second, independent walk with real flags over only the exported declarations — its own TS2300/TS2451, plus TS2323 when its surviving group has more than one member (restricted to a genuine external module's export table, not a namespace-internal `export`, per #16158/#16161).
3. **TS2395** (checker, `checkExportsOnMergedDeclarationsWorker`): reads the *locals-table* surviving group and reports on every member when it mixes exported and non-exported declarations.

tsz now models all three directly in `duplicate_identifiers_variable_family.rs`, owned end to end for any pure-variable-family symbol (gated by a structural shape check rather than the caller's pairwise `conflicts` set, since `tsc`'s TS2395 fires even for non-colliding pairs like `export var a; var a;` that never populate `conflicts`).

## Adjacent-case matrix

Verified against a fresh `typescript@7.0.2` oracle (`--noEmit --strict --pretty false --lib es2015 --target es2015`) for every row below, and pinned as unit tests in `crates/tsz-checker/src/tests/ts2323_mixed_exportedness_two_table_tests.rs`:
- `var, export var, export let` — TS2300 on 1-2, TS2395 on 1-2 (the third loses its collision onto a throwaway symbol and never rejoins the reported group)
- `export let, var, export let` — TS2300+TS2395+TS2451 co-emission with three different footprints
- `export var, let, export var` — TS2323+TS2395+TS2451 co-emission
- `var, export let, var` — the rejoining third `var` ends up clean (zero diagnostics)
- Renamed-binder control (same shape, different identifier)
- Two-declaration mixed pairs (both directions: var-first/let-first) as minimal controls
- All 11 pre-existing uniform-exportedness/uniform-local tests in `ts2323_variable_redeclaration_two_pass_tests.rs`, `ts2323_block_scoped_conflict_message_tests.rs`, and the namespace-internal-export control in `ts2323_export_var_namespace_merge_tests.rs` continue to pass unchanged (regression floor).

Closes #16170.

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-checker --lib` (full crate unit suite): **8957/8958 passed**, 7 skipped. The 1 failure (`ts2303_tests::recursive_export_assignment_self_import_reports_ts2303`) reproduces identically on the parent commit `88b0ebb` (verified via `git checkout 88b0ebb` + re-run) — pre-existing, unrelated to this change (self-referential `export =` aliasing, not duplicate-identifier/variable redeclaration).
- `cargo test -p tsz-checker --lib -- 2323 2395 2652 ts2481 namespace_export variable_redeclaration ts2440 ts2428`: 146 passed, 0 failed (includes the new 12-test file plus every pre-existing test in the surrounding diagnostic families).
- `cargo test -p tsz-checker --lib ts2300`: 82 passed, 0 failed.
- `cargo clippy -p tsz-checker --lib --all-targets -- -D warnings`: clean.
- `./scripts/conformance/compare-to-parent.sh`: 0 newly passing / 0 newly failing (12585 candidates, 11460 passed both sides) — expected for this family per the board's standing note: the corpus has no fixture for this narrow mixed-exportedness shape, so the oracle-pinned unit matrix is the primary evidence and this run is the regression-floor check.
- Pre-commit hook's own clippy + arch-size gate passed locally.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: Norite
