### PR TITLE
fix(checker): report TS7033 for computed class getter names via display text

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -1602,10 +1602,22 @@ impl<'a> CheckerState<'a> {
             // (tsc's `isGetAccessorWithAnnotatedSetAccessor`); an unannotated one
             // becomes the blame site itself and is reported there by
             // `check_setter_parameter`. Either way the getter stays clean.
+            // `get_property_name` alone cannot name a computed key whose
+            // expression is a plain identifier reference (`get [k]()` for a
+            // `unique symbol` const, `get [Symbol.iterator]()`) — it
+            // deliberately skips those to avoid returning the identifier's
+            // own text. Fall back to the structured computed-name display
+            // (`declarationNameToString`-equivalent) for that case, but stop
+            // there: `property_name_for_error`'s further fallback to a raw
+            // source-text slice would also fire on a genuinely malformed
+            // computed name (`get [](); `, a parse error), where tsc reports
+            // only the syntax error and stays silent on `TS7033`.
             if self.ctx.no_implicit_any()
                 && !self.is_js_file()
                 && self.paired_setter_member_for_getter(accessor).is_none()
-                && let Some(accessor_name) = self.get_property_name(accessor.name)
+                && let Some(accessor_name) = self
+                    .get_property_name(accessor.name)
+                    .or_else(|| self.get_member_name_display_text(accessor.name))
             {
                 use crate::diagnostics::diagnostic_codes;
                 self.error_at_node_msg(

--- a/crates/tsz-checker/tests/noimplicitany_ambient_member_surface_tests.rs
+++ b/crates/tsz-checker/tests/noimplicitany_ambient_member_surface_tests.rs
@@ -218,6 +218,91 @@ fn ts7033_is_reported_once_per_getter() {
 }
 
 // ---------------------------------------------------------------------------
+// (1b) Computed names — the class arm did not resolve a display name for a
+// computed getter/setter whose expression is not a literal, so the TS7033
+// site's `get_property_name` returned `None` and silently suppressed the
+// diagnostic. Issue #16186 (the residual left by #16188, which fixed the
+// interface/type-literal arm the same way). tsc still reports, using the
+// raw `[expr]` source text as the display name (`declarationNameToString`).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn computed_unique_symbol_getter_reports_ts7033() {
+    let codes =
+        check_source_strict_codes("declare const k: unique symbol; declare class C { get [k](); }");
+    assert!(has(&codes, TS7033), "expected TS7033: {codes:?}");
+}
+
+#[test]
+fn computed_unique_symbol_pair_still_blames_the_setter() {
+    // Control: the TS7032 sibling site already used the computed-aware
+    // helper, so this direction must be unaffected by the TS7033 fix.
+    let codes = check_source_strict_codes(
+        "declare const k: unique symbol; declare class C { get [k](); set [k](v); }",
+    );
+    assert!(has(&codes, TS7032), "expected TS7032: {codes:?}");
+    assert!(!has(&codes, TS7033), "setter is the blame site: {codes:?}");
+}
+
+#[test]
+fn computed_non_literal_typed_getter_reports_ts7033() {
+    // `k`'s type is plain `string`, not a literal or unique symbol — tsc
+    // cannot resolve a concrete property key either, and still reports
+    // using the raw source text as the display name.
+    let codes =
+        check_source_strict_codes("declare const k: string; declare class C { get [k](); }");
+    assert!(has(&codes, TS7033), "expected TS7033: {codes:?}");
+}
+
+#[test]
+fn computed_well_known_symbol_getter_reports_ts7033() {
+    let codes = check_source_strict_codes("declare class C { get [Symbol.iterator](); }");
+    assert!(has(&codes, TS7033), "expected TS7033: {codes:?}");
+}
+
+#[test]
+fn computed_getter_in_abstract_class_reports_ts7033() {
+    let codes = check_source_strict_codes(
+        "declare const k: unique symbol; abstract class C { abstract get [k](); }",
+    );
+    assert!(has(&codes, TS7033), "expected TS7033: {codes:?}");
+}
+
+#[test]
+fn computed_string_literal_getter_still_reports_ts7033() {
+    // Control: a computed name whose expression IS a string literal already
+    // resolved through `get_property_name`'s literal fast path before this
+    // fix — must keep working unchanged.
+    let codes = check_source_strict_codes("declare class C { get [\"foo\"](); }");
+    assert!(has(&codes, TS7033), "expected TS7033: {codes:?}");
+}
+
+#[test]
+fn computed_private_hidden_getter_stays_clean() {
+    // The surface rule (private/`.d.ts`-hidden) must still win over the
+    // computed-name display fix — a hidden member reports nothing at all,
+    // so the computed-name display fallback must never be reached for it.
+    let codes = check_source_strict_codes(
+        "declare const k: unique symbol; declare class C { private get [k](); }",
+    );
+    assert!(!has(&codes, TS7033), "hidden from the surface: {codes:?}");
+}
+
+#[test]
+fn malformed_computed_getter_name_does_not_report_ts7033() {
+    // `[]` and `[1+]` are parse errors (empty / incomplete computed-name
+    // expression) — tsc reports only the syntax error and stays silent on
+    // `TS7033`. The fix must resolve computed names through the *structured*
+    // display helper (identifier / property-access / literal), not through a
+    // raw source-text slice — a slice would render `[]`/`[1+]` as a "name"
+    // and start reporting a semantic diagnostic tsc never emits here.
+    let codes = check_source_strict_codes("declare class C { get [](); }");
+    assert!(!has(&codes, TS7033), "parse-error name: {codes:?}");
+    let codes = check_source_strict_codes("declare class C { get [1+](); }");
+    assert!(!has(&codes, TS7033), "parse-error name: {codes:?}");
+}
+
+// ---------------------------------------------------------------------------
 // (2) The surface rule. Issue #16178 — TS7010 fired where tsc is silent.
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #16186 (the residual left open by #16188, which fixed the interface/type-literal arm of the same rule the same way).

**When a bodyless `get` accessor's computed name can't be rendered by `get_property_name`, `tsc` still reports `TS7033` using the structured display text; tsz now does that too, through `get_member_name_display_text` at the class arm's `TS7033` site.**

`state_checking_members/ambient_signature_checks.rs`'s `TS7033` site (`check_accessor_declaration_with_request`) gated the diagnostic on `self.get_property_name(accessor.name)`. `get_property_name` *deliberately* returns `None` for a computed name whose expression is a plain identifier reference (`get [k]()` where `k` is a `unique symbol` const, `get [Symbol.iterator]()`) — it skips those to avoid returning the identifier's own text instead of the resolved property key. The sibling `TS7032` site (`check_setter_parameter`) already used the computed-aware `parameter_name_for_error`, so `declare class C { get [k](); set [k](v); }` correctly reported `TS7032`, but the lone-getter shape `declare class C { get [k](); }` silently reported nothing.

```ts
declare const k: unique symbol;
declare class C { get [k](); }
```
```
tsc   TS7033 @55: Property '[k]' implicitly has type 'any', because its get accessor lacks a return type annotation.
tsz   —  (before this PR)
```

### The fix, and why it's narrower than the obvious one

The obvious fix is to swap in `property_name_for_error` — the same helper #16188 used for the interface arm. I started there, but it regresses on malformed input: `property_name_for_error`'s final fallback slices raw source text when the structured renderers all fail, and that fallback also fires on a genuinely broken computed name (`declare class C { get [](); }`, `get [1+]();` — parse errors), where `tsc` reports only the syntax error and stays silent on `TS7033`. Verified this directly: with `property_name_for_error`, `get [](); ` started reporting `TS7033` where `tsc` does not.

The actual fix keeps the raw-slice fallback out of the picture entirely:

```rust
let Some(accessor_name) = self
    .get_property_name(accessor.name)
    .or_else(|| self.get_member_name_display_text(accessor.name))
```

`get_member_name_display_text` renders identifiers, string/numeric literals, and the computed-name cases (plain identifier expression, `Symbol.x` property access, nested chains) structurally — the same helper the `TS7032` message path already builds on — and returns `None` rather than a raw slice when the computed expression itself doesn't parse into something nameable. That keeps parse-error recovery silent, matching `tsc`.

### Adjacent matrix (oracle: `typescript@7.0.2`, `--noEmit --strict --lib es2022 --target es2022`)

| Shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `get [k]()` (`k: unique symbol`) | `TS7033` | — | `TS7033` |
| `get [k](); set [k](v);` | `TS7032` (setter blamed), no `TS7033` | `TS7032`, no `TS7033` | unchanged |
| `get [k]()` (`k: string`, non-literal) | `TS7033`, name `[k]` | — | `TS7033` |
| `get [Symbol.iterator]()` | `TS7033`, name `[Symbol.iterator]` | — | `TS7033` |
| `abstract get [k]()` in `abstract class` | `TS7033` | — | `TS7033` |
| `get ["foo"]()` (literal computed name — pre-existing path) | `TS7033` | `TS7033` | unchanged |
| `private get [k]()` in `declare class` (surface rule) | clean | clean | unchanged |
| `get [](); ` / `get [1+]();` (parse-error computed name) | syntax error only, no `TS7033` | (none) | **still none** — the risk case, explicitly tested |

8 new tests in `noimplicitany_ambient_member_surface_tests.rs`, including the parse-recovery negative control.

### Goal
Goal: hold

### Verification
- `cargo nextest run -p tsz-checker --test noimplicitany_ambient_member_surface_tests --test noimplicitany_type_member_accessor_tests` → 63 passed (55 existing + 8 new), 0 failed
- `cargo clippy -p tsz-checker --all-targets` (workspace warnings denied) → clean
- `cargo fmt --all -- --check` → clean
- `python3 scripts/arch/arch_guard.py` → `Architecture guardrails passed.`
- `scripts/safe-run.sh scripts/conformance/compare-to-parent.sh` → both sides `11460/12043` passed (582 failing), **0 newly passing / 0 newly failing** — expected for this shape: no corpus fixture exercises a computed `unique symbol` class-accessor name, so this is a targeted-oracle-pinned fix, not a corpus mover, consistent with several other PRs in this same accessor-family campaign (#16185, #16188)
- `./scripts/emit/run.sh` (full build, no crate touches emit code) → JS `11562/11563`, DTS `1375/1390` — exact ROADMAP floor, unchanged

### Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAE7dkqU1RwvEczpW6YtPj)_