### PR TITLE
fix(checker): reset loop/switch counters at every class member body boundary

### DIFF
--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -18,7 +18,10 @@ use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeArena;
 use tsz_solver::TypeId;
 
-use super::{CheckerContext, LibContext, ResolutionError, TypeCache};
+use super::{
+    CheckerContext, ClassMemberBodyScope, FunctionLikeControlFlow, LibContext, ResolutionError,
+    TypeCache,
+};
 
 /// Build the union of every name declared in any lib context's `file_locals`.
 ///
@@ -1319,17 +1322,65 @@ impl<'a> CheckerContext<'a> {
     ///
     /// Returns the previous member-body baseline, which the caller must hand
     /// back to [`Self::exit_class_member_body`].
-    pub const fn enter_class_member_body(&mut self) -> u32 {
+    pub const fn enter_class_member_body(&mut self) -> ClassMemberBodyScope {
         self.function_depth += 1;
-        let saved = self.class_member_body_depth;
+        let member_body_depth = self.class_member_body_depth;
         self.class_member_body_depth = self.function_depth;
-        saved
+        ClassMemberBodyScope {
+            member_body_depth,
+            control_flow: self.enter_function_like_control_flow(),
+        }
     }
 
     /// Leave a class member body entered by [`Self::enter_class_member_body`].
-    pub const fn exit_class_member_body(&mut self, saved: u32) {
+    pub fn exit_class_member_body(&mut self, saved: ClassMemberBodyScope) {
+        self.exit_function_like_control_flow(saved.control_flow);
         self.function_depth -= 1;
-        self.class_member_body_depth = saved;
+        self.class_member_body_depth = saved.member_body_depth;
+    }
+
+    /// Enter the control-flow scope of a function-like boundary.
+    ///
+    /// `tsc`'s `checkGrammarBreakOrContinueStatement` is a single upward walk
+    /// from the jump node that stops at the first function-like ancestor, so an
+    /// unlabeled `break`/`continue` can only see iteration and `switch`
+    /// statements declared *inside its own innermost function-like*. tsz models
+    /// that walk as the ambient [`Self::iteration_depth`] and
+    /// [`Self::switch_depth`] counters, which therefore have to be zeroed
+    /// whenever checking descends across such a boundary — otherwise a jump in a
+    /// nested body still sees the enclosing loop and reports nothing.
+    ///
+    /// Labels are deliberately *not* hidden for the duration of the body: only
+    /// the stack length is saved, so labels declared outside stay resolvable and
+    /// the labeled paths keep deciding TS1107 by comparing
+    /// [`LabelInfo::function_depth`] against [`Self::function_depth`]. The
+    /// truncation on exit just drops labels the body itself pushed.
+    ///
+    /// Callers that also raise `function_depth` (free function bodies, class
+    /// member bodies) do so around this call; this guard owns the loop/switch
+    /// and label state only. Returns the saved scope, which the caller must hand
+    /// back to [`Self::exit_function_like_control_flow`].
+    pub(crate) const fn enter_function_like_control_flow(&mut self) -> FunctionLikeControlFlow {
+        let saved = FunctionLikeControlFlow {
+            iteration_depth: self.iteration_depth,
+            switch_depth: self.switch_depth,
+            label_stack_len: self.label_stack.len(),
+            had_outer_loop: self.had_outer_loop,
+        };
+        if self.iteration_depth > 0 || self.switch_depth > 0 || self.had_outer_loop {
+            self.had_outer_loop = true;
+        }
+        self.iteration_depth = 0;
+        self.switch_depth = 0;
+        saved
+    }
+
+    /// Leave a scope entered by [`Self::enter_function_like_control_flow`].
+    pub(crate) fn exit_function_like_control_flow(&mut self, saved: FunctionLikeControlFlow) {
+        self.iteration_depth = saved.iteration_depth;
+        self.switch_depth = saved.switch_depth;
+        self.label_stack.truncate(saved.label_stack_len);
+        self.had_outer_loop = saved.had_outer_loop;
     }
 
     /// True when checking is running directly in the enclosing class member's

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -210,6 +210,33 @@ pub struct LabelInfo {
     pub(crate) label_node: tsz_parser::parser::NodeIndex,
 }
 
+/// The loop/`switch`/label state of the function-like a nested body is being
+/// checked inside of, saved by
+/// [`CheckerContext::enter_function_like_control_flow`].
+///
+/// Opaque on purpose: the fields are only ever produced and consumed by that
+/// enter/exit pair, so no caller can restore a partial scope.
+#[derive(Clone, Copy, Debug)]
+pub struct FunctionLikeControlFlow {
+    iteration_depth: u32,
+    switch_depth: u32,
+    label_stack_len: usize,
+    had_outer_loop: bool,
+}
+
+/// The scope of a class member body, saved by
+/// [`CheckerContext::enter_class_member_body`].
+///
+/// Bundles the member-body baseline with the [`FunctionLikeControlFlow`] scope
+/// so that every member kind — method, accessor, constructor, static block —
+/// crosses the boundary through one call and cannot acquire the function-depth
+/// half without the control-flow half.
+#[derive(Clone, Copy, Debug)]
+pub struct ClassMemberBodyScope {
+    member_body_depth: u32,
+    control_flow: FunctionLikeControlFlow,
+}
+
 /// Classification for deferred implicit-any diagnostics that are surfaced later
 /// at use sites.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -96,15 +96,11 @@ pub mod diagnostics {
 pub mod test_utils;
 
 // Tests that don't depend on root crate's test_fixtures
-#[cfg(test)]
-#[path = "tests/alias_application_display_retention_tests.rs"]
-mod alias_application_display_retention_tests;
-#[cfg(test)]
-#[path = "tests/any_parameter_never_opposite_tests.rs"]
-mod any_parameter_never_opposite_tests;
-#[cfg(test)]
-#[path = "tests/application_unknown_args_assignability_tests.rs"]
-mod application_unknown_args_assignability_tests;
+// The 432 `src/tests/**` registrations live in their own file: the block ran
+// ~1300 lines and kept `lib.rs` within a few lines of the 2000-line
+// architecture cap, so every checker PR adding a test module raced the
+// ceiling. The `../tests/**` registrations below stay here: those modules
+// use `use super::*`, which must keep resolving to the crate root.
 #[cfg(test)]
 #[path = "../tests/assertion_overlap_keyof_primitive_tests.rs"]
 mod assertion_overlap_keyof_primitive_tests;
@@ -115,89 +111,11 @@ mod assertion_overlap_object_primitive_tests;
 #[path = "../tests/assertion_overlap_template_literal_tests.rs"]
 mod assertion_overlap_template_literal_tests;
 #[cfg(test)]
-#[path = "tests/assignability_diagnostics_relation_routing_arch_tests.rs"]
-mod assignability_diagnostics_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/assignability_display_relation_routing_arch_tests.rs"]
-mod assignability_display_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/assignability_eval_memo_tests.rs"]
-mod assignability_eval_memo_tests;
-#[cfg(test)]
-#[path = "tests/assignability_failure_memo_tests.rs"]
-mod assignability_failure_memo_tests;
-#[cfg(test)]
-#[path = "tests/assignability_index_access_normalization_boundary_arch_tests.rs"]
-mod assignability_index_access_normalization_boundary_arch_tests;
-#[cfg(test)]
-#[path = "tests/assignability_reporter_relation_routing_arch_tests.rs"]
-mod assignability_reporter_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/assignability_type_comparability_relation_routing_arch_tests.rs"]
-mod assignability_type_comparability_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/assignment_ops_relation_routing_arch_tests.rs"]
-mod assignment_ops_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/async_generator_yieldstar_contribution_tests.rs"]
-mod async_generator_yieldstar_contribution_tests;
-#[cfg(test)]
-#[path = "tests/async_generator_yieldstar_union_delegate_tests.rs"]
-mod async_generator_yieldstar_union_delegate_tests;
-#[cfg(test)]
 #[path = "../tests/async_imported_promise_tests.rs"]
 mod async_imported_promise_tests;
 #[cfg(test)]
-#[path = "tests/await_alias_union_distribution_tests.rs"]
-mod await_alias_union_distribution_tests;
-#[cfg(test)]
-#[path = "tests/await_concise_arrow_body_grammar_tests.rs"]
-mod await_concise_arrow_body_grammar_tests;
-#[cfg(test)]
-#[path = "tests/await_grammar_computed_property_name_tests.rs"]
-mod await_grammar_computed_property_name_tests;
-#[cfg(test)]
-#[path = "tests/await_grammar_expression_position_tests.rs"]
-mod await_grammar_expression_position_tests;
-#[cfg(test)]
-#[path = "tests/await_grammar_statement_position_tests.rs"]
-mod await_grammar_statement_position_tests;
-#[cfg(test)]
-#[path = "tests/await_static_block_grammar_tests.rs"]
-mod await_static_block_grammar_tests;
-#[cfg(test)]
-#[path = "tests/await_structural_thenable_tests.rs"]
-mod await_structural_thenable_tests;
-#[cfg(test)]
-#[path = "tests/boxed_global_env_authority_tests.rs"]
-mod boxed_global_env_authority_tests;
-#[cfg(test)]
 #[path = "../tests/circular_accessor_annotation_tests.rs"]
 mod circular_accessor_annotation_tests;
-#[cfg(test)]
-#[path = "tests/circular_export_star_const_value_tests.rs"]
-mod circular_export_star_const_value_tests;
-#[cfg(test)]
-#[path = "tests/class_boundary_fallback_relation_routing_arch_tests.rs"]
-mod class_boundary_fallback_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/class_extends_generic_override_variance_tests.rs"]
-mod class_extends_generic_override_variance_tests;
-#[cfg(test)]
-#[path = "tests/class_extends_index_relation_routing_arch_tests.rs"]
-mod class_extends_index_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/class_implements_abstract_member_compat_tests.rs"]
-mod class_implements_abstract_member_compat_tests;
-#[cfg(test)]
-#[path = "tests/class_implements_generic_override_variance_tests.rs"]
-mod class_implements_generic_override_variance_tests;
-#[cfg(test)]
-#[path = "tests/class_implements_index_relation_routing_arch_tests.rs"]
-mod class_implements_index_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/class_member_circular_return_tests.rs"]
-mod class_member_circular_return_tests;
 #[cfg(test)]
 #[path = "../tests/class_member_closure_tests.rs"]
 mod class_member_closure_tests;
@@ -205,29 +123,11 @@ mod class_member_closure_tests;
 #[path = "../tests/class_member_self_type_circularity_tests.rs"]
 mod class_member_self_type_circularity_tests;
 #[cfg(test)]
-#[path = "tests/class_namespace_static_relation_routing_arch_tests.rs"]
-mod class_namespace_static_relation_routing_arch_tests;
-#[cfg(test)]
 #[path = "../tests/class_property_constructor_flow_inference_tests.rs"]
 mod class_property_constructor_flow_inference_tests;
 #[cfg(test)]
 #[path = "../tests/class_property_typed_const_initializer_tests.rs"]
 mod class_property_typed_const_initializer_tests;
-#[cfg(test)]
-#[path = "tests/comlink_row_regression_tests.rs"]
-mod comlink_row_regression_tests;
-#[cfg(test)]
-#[path = "tests/commonjs_export_assignment_chain_tests.rs"]
-mod commonjs_export_assignment_chain_tests;
-#[cfg(test)]
-#[path = "tests/commonjs_export_declaration_level_type_tests.rs"]
-mod commonjs_export_declaration_level_type_tests;
-#[cfg(test)]
-#[path = "tests/commonjs_reentrant_surface_tests.rs"]
-mod commonjs_reentrant_surface_tests;
-#[cfg(test)]
-#[path = "tests/commonjs_require_binding_type_meaning_tests.rs"]
-mod commonjs_require_binding_type_meaning_tests;
 #[cfg(test)]
 #[path = "../tests/comparability_indexed_access_reduce_tests.rs"]
 mod comparability_indexed_access_reduce_tests;
@@ -235,38 +135,17 @@ mod comparability_indexed_access_reduce_tests;
 #[path = "../tests/constructor_overload_excess_property_tests.rs"]
 mod constructor_overload_excess_property_tests;
 #[cfg(test)]
-#[path = "tests/contextual_new_relation_routing_arch_tests.rs"]
-mod contextual_new_relation_routing_arch_tests;
-#[cfg(test)]
 #[path = "../tests/control_flow_tests.rs"]
 mod control_flow_tests;
 #[cfg(test)]
 #[path = "../tests/control_flow_type_guard_tests.rs"]
 mod control_flow_type_guard_tests;
 #[cfg(test)]
-#[path = "tests/cross_module_class_self_member_tests.rs"]
-mod cross_module_class_self_member_tests;
-#[cfg(test)]
-#[path = "tests/declared_signature_return_literal_display_tests.rs"]
-mod declared_signature_return_literal_display_tests;
-#[cfg(test)]
-#[path = "tests/decorator_return_relation_routing_arch_tests.rs"]
-mod decorator_return_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/defaulted_param_deferred_undefined_strip_tests.rs"]
-mod defaulted_param_deferred_undefined_strip_tests;
-#[cfg(test)]
-#[path = "tests/definite_assignment_logical_compound_tests.rs"]
-mod definite_assignment_logical_compound_tests;
-#[cfg(test)]
 #[path = "../tests/definite_assignment_tests.rs"]
 mod definite_assignment_tests;
 #[cfg(test)]
 #[path = "../tests/dynamic_import_defer_tests.rs"]
 mod dynamic_import_defer_tests;
-#[cfg(test)]
-#[path = "tests/enum_computed_relation_routing_arch_tests.rs"]
-mod enum_computed_relation_routing_arch_tests;
 #[cfg(test)]
 #[path = "../tests/enum_member_cache_tests.rs"]
 mod enum_member_cache_tests;
@@ -280,125 +159,17 @@ mod enum_recursion_tests;
 #[path = "../tests/environment_capabilities_tests.rs"]
 mod environment_capabilities_tests;
 #[cfg(test)]
-#[path = "tests/expando_annotated_receiver_tests.rs"]
-mod expando_annotated_receiver_tests;
-#[cfg(test)]
-#[path = "tests/flow_assignment_relation_routing_arch_tests.rs"]
-mod flow_assignment_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/flow_for_of_destructure_closure_assignment_tests.rs"]
-mod flow_for_of_destructure_closure_assignment_tests;
-#[cfg(test)]
-#[path = "tests/flow_guard_boundary_tests.rs"]
-mod flow_guard_boundary_tests;
-#[cfg(test)]
-#[path = "tests/flow_inferred_predicate_boundary_tests.rs"]
-mod flow_inferred_predicate_boundary_tests;
-#[cfg(test)]
-#[path = "tests/flow_promise_identity_tests.rs"]
-mod flow_promise_identity_tests;
-#[cfg(test)]
-#[path = "tests/flow_truthy_proves_assignment_tests.rs"]
-mod flow_truthy_proves_assignment_tests;
-#[cfg(test)]
-#[path = "tests/flow_usage_relation_routing_arch_tests.rs"]
-mod flow_usage_relation_routing_arch_tests;
-#[cfg(test)]
 #[path = "../tests/fresh_literal_boundary_tests.rs"]
 mod fresh_literal_boundary_tests;
-#[cfg(test)]
-#[path = "tests/function_callee_spread_ts2556_tests.rs"]
-mod function_callee_spread_ts2556_tests;
-#[cfg(test)]
-#[path = "tests/function_type_relation_routing_arch_tests.rs"]
-mod function_type_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/function_type_return_node_tests.rs"]
-mod function_type_return_node_tests;
-#[cfg(test)]
-#[path = "tests/generator_declaration_yield_star_inference_tests.rs"]
-mod generator_declaration_yield_star_inference_tests;
-#[cfg(test)]
-#[path = "tests/generator_default_type_argument_relation_tests.rs"]
-mod generator_default_type_argument_relation_tests;
-#[cfg(test)]
-#[path = "tests/generator_inferred_yield_star_array_generic_call_tests.rs"]
-mod generator_inferred_yield_star_array_generic_call_tests;
 #[cfg(test)]
 #[path = "../tests/generator_union_return_type_tests.rs"]
 mod generator_union_return_type_tests;
 #[cfg(test)]
-#[path = "tests/generator_yield_identity_tests.rs"]
-mod generator_yield_identity_tests;
-#[cfg(test)]
-#[path = "tests/generator_yield_literal_widening_tests.rs"]
-mod generator_yield_literal_widening_tests;
-#[cfg(test)]
-#[path = "tests/generator_yield_self_similar_nesting_tests.rs"]
-mod generator_yield_self_similar_nesting_tests;
-#[cfg(test)]
-#[path = "tests/generator_yieldstar_symbol_iterator_contribution_tests.rs"]
-mod generator_yieldstar_symbol_iterator_contribution_tests;
-#[cfg(test)]
-#[path = "tests/generic_call_non_fresh_object_widening_tests.rs"]
-mod generic_call_non_fresh_object_widening_tests;
-#[cfg(test)]
-#[path = "tests/generic_callable_outer_type_param_mismatch_tests.rs"]
-mod generic_callable_outer_type_param_mismatch_tests;
-#[cfg(test)]
-#[path = "tests/generic_default_application_arg_preservation_tests.rs"]
-mod generic_default_application_arg_preservation_tests;
-#[cfg(test)]
-#[path = "tests/generic_method_member_variance_assignability_tests.rs"]
-mod generic_method_member_variance_assignability_tests;
-#[cfg(test)]
-#[path = "tests/generic_method_override_variance_tests.rs"]
-mod generic_method_override_variance_tests;
-#[cfg(test)]
-#[path = "tests/generic_mixed_inheritance_chain_tests.rs"]
-mod generic_mixed_inheritance_chain_tests;
-#[cfg(test)]
-#[path = "tests/generic_rest_tuple_contextual_return_tests.rs"]
-mod generic_rest_tuple_contextual_return_tests;
-#[cfg(test)]
-#[path = "tests/generic_signature_context_instantiation_tests.rs"]
-mod generic_signature_context_instantiation_tests;
-#[cfg(test)]
-#[path = "tests/global_augmentation_computed_key_tests.rs"]
-mod global_augmentation_computed_key_tests;
-#[cfg(test)]
-#[path = "tests/global_augmentation_structural_lookup_arch_tests.rs"]
-mod global_augmentation_structural_lookup_arch_tests;
-#[cfg(test)]
-#[path = "tests/global_this_typeof_surface_tests.rs"]
-mod global_this_typeof_surface_tests;
-#[cfg(test)]
-#[path = "tests/heritage_constraint_structural_name_lookup_arch_tests.rs"]
-mod heritage_constraint_structural_name_lookup_arch_tests;
-#[cfg(test)]
-#[path = "tests/heritage_flow_narrowed_base_tests.rs"]
-mod heritage_flow_narrowed_base_tests;
-#[cfg(test)]
 #[path = "../tests/heritage_type_only_tests.rs"]
 mod heritage_type_only_tests;
 #[cfg(test)]
-#[path = "tests/higher_order_regeneralization_tests.rs"]
-mod higher_order_regeneralization_tests;
-#[cfg(test)]
-#[path = "tests/homomorphic_mapped_member_override_tests.rs"]
-mod homomorphic_mapped_member_override_tests;
-#[cfg(test)]
 #[path = "../tests/imported_generator_iterable_tests.rs"]
 mod imported_generator_iterable_tests;
-#[cfg(test)]
-#[path = "tests/index_sig_param_intersection_validity_tests.rs"]
-mod index_sig_param_intersection_validity_tests;
-#[cfg(test)]
-#[path = "tests/index_sig_param_resolved_key_type_tests.rs"]
-mod index_sig_param_resolved_key_type_tests;
-#[cfg(test)]
-#[path = "tests/index_signature_symbol_keyspace_tests.rs"]
-mod index_signature_symbol_keyspace_tests;
 #[cfg(test)]
 #[path = "../tests/indexed_access_alias_application_relation_tests.rs"]
 mod indexed_access_alias_application_relation_tests;
@@ -406,56 +177,11 @@ mod indexed_access_alias_application_relation_tests;
 #[path = "../tests/inferred_return_error_and_self_call_tests.rs"]
 mod inferred_return_error_and_self_call_tests;
 #[cfg(test)]
-#[path = "tests/inferred_return_object_array_widening_tests.rs"]
-mod inferred_return_object_array_widening_tests;
-#[cfg(test)]
-#[path = "tests/instanceof_indexed_access_lhs_tests.rs"]
-mod instanceof_indexed_access_lhs_tests;
-#[cfg(test)]
-#[path = "tests/instantiation_expression_inline_utility_modifier_tests.rs"]
-mod instantiation_expression_inline_utility_modifier_tests;
-#[cfg(test)]
-#[path = "tests/instantiation_expression_lib_display_tests.rs"]
-mod instantiation_expression_lib_display_tests;
-#[cfg(test)]
-#[path = "tests/interface_extends_generic_override_variance_tests.rs"]
-mod interface_extends_generic_override_variance_tests;
-#[cfg(test)]
-#[path = "tests/interface_heritage_index_relation_routing_arch_tests.rs"]
-mod interface_heritage_index_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/interface_heritage_property_index_relation_routing_arch_tests.rs"]
-mod interface_heritage_property_index_relation_routing_arch_tests;
-#[cfg(test)]
 #[path = "../tests/isolated_declarations_unannotated_param_tests.rs"]
 mod isolated_declarations_unannotated_param_tests;
 #[cfg(test)]
-#[path = "tests/js_expando_order_sensitivity_tests.rs"]
-mod js_expando_order_sensitivity_tests;
-#[cfg(test)]
-#[path = "tests/js_open_object_property_access_tests.rs"]
-mod js_open_object_property_access_tests;
-#[cfg(test)]
 #[path = "../tests/js_property_write_self_declaration_tests.rs"]
 mod js_property_write_self_declaration_tests;
-#[cfg(test)]
-#[path = "tests/jsdoc_bare_import_type_tests.rs"]
-mod jsdoc_bare_import_type_tests;
-#[cfg(test)]
-#[path = "tests/jsdoc_closure_function_type_tests.rs"]
-mod jsdoc_closure_function_type_tests;
-#[cfg(test)]
-#[path = "tests/jsdoc_commonjs_globals_as_type_tests.rs"]
-mod jsdoc_commonjs_globals_as_type_tests;
-#[cfg(test)]
-#[path = "tests/jsdoc_import_type_constraints_relation_routing_arch_tests.rs"]
-mod jsdoc_import_type_constraints_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/jsdoc_lookup_constraints_relation_routing_arch_tests.rs"]
-mod jsdoc_lookup_constraints_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/jsdoc_nested_type_tag_validation_tests.rs"]
-mod jsdoc_nested_type_tag_validation_tests;
 #[cfg(test)]
 #[path = "../tests/jsdoc_postfix_nullable_type_tests.rs"]
 mod jsdoc_postfix_nullable_type_tests;
@@ -466,59 +192,17 @@ mod jsdoc_prototype_assignment_literal_display;
 #[path = "../tests/jsdoc_prototype_assignment_target_display.rs"]
 mod jsdoc_prototype_assignment_target_display;
 #[cfg(test)]
-#[path = "tests/jsdoc_retired_tag_diagnostics_tests.rs"]
-mod jsdoc_retired_tag_diagnostics_tests;
-#[cfg(test)]
-#[path = "tests/jsdoc_template_reference_scope_tests.rs"]
-mod jsdoc_template_reference_scope_tests;
-#[cfg(test)]
 #[path = "../tests/jsdoc_this_arrow_tests.rs"]
 mod jsdoc_this_arrow_tests;
-#[cfg(test)]
-#[path = "tests/jsdoc_typedef_bare_import_tests.rs"]
-mod jsdoc_typedef_bare_import_tests;
 #[cfg(test)]
 #[path = "../tests/jsx_component_attribute_tests.rs"]
 mod jsx_component_attribute_tests;
 #[cfg(test)]
-#[path = "tests/jump_statement_class_member_boundary_tests.rs"]
-mod jump_statement_class_member_boundary_tests;
-#[cfg(test)]
-#[path = "tests/keyof_type_parameter_deferred_heritage_tests.rs"]
-mod keyof_type_parameter_deferred_heritage_tests;
-#[cfg(test)]
-#[path = "tests/lazy_lib_fuel_determinism_tests.rs"]
-mod lazy_lib_fuel_determinism_tests;
-#[cfg(test)]
-#[path = "tests/lazy_lib_heritage_guard_tests.rs"]
-mod lazy_lib_heritage_guard_tests;
-#[cfg(test)]
-#[path = "tests/lazy_lib_member_access_tests.rs"]
-mod lazy_lib_member_access_tests;
-#[cfg(test)]
-#[path = "tests/lib_abstract_member_ts2515_tests.rs"]
-mod lib_abstract_member_ts2515_tests;
-#[cfg(test)]
 #[path = "../tests/literal_application_alias_display_tests.rs"]
 mod literal_application_alias_display_tests;
 #[cfg(test)]
-#[path = "tests/local_type_alias_shadowing_tests.rs"]
-mod local_type_alias_shadowing_tests;
-#[cfg(test)]
-#[path = "tests/logical_assignment_member_narrowing_tests.rs"]
-mod logical_assignment_member_narrowing_tests;
-#[cfg(test)]
-#[path = "tests/loop_self_referential_property_read_tests.rs"]
-mod loop_self_referential_property_read_tests;
-#[cfg(test)]
-#[path = "tests/member_assignment_narrowing_join_tests.rs"]
-mod member_assignment_narrowing_join_tests;
-#[cfg(test)]
 #[path = "../tests/merged_symbol_tests.rs"]
 mod merged_symbol_tests;
-#[cfg(test)]
-#[path = "tests/method_return_type_elaboration_tests.rs"]
-mod method_return_type_elaboration_tests;
 #[cfg(test)]
 #[path = "../tests/missing_name_pass_constrained_type_param_tests.rs"]
 mod missing_name_pass_constrained_type_param_tests;
@@ -529,26 +213,8 @@ mod name_resolution_boundary_tests;
 #[path = "../tests/no_filename_based_behavior_tests.rs"]
 mod no_filename_based_behavior_tests;
 #[cfg(test)]
-#[path = "tests/no_implicit_override_ambient_context_tests.rs"]
-mod no_implicit_override_ambient_context_tests;
-#[cfg(test)]
-#[path = "tests/no_index_element_implicit_any_tests.rs"]
-mod no_index_element_implicit_any_tests;
-#[cfg(test)]
 #[path = "../tests/noinfer_comparability_overlap_tests.rs"]
 mod noinfer_comparability_overlap_tests;
-#[cfg(test)]
-#[path = "tests/noUIA_any_index_emits_ts2322_tests.rs"]
-mod nuia_any_index_emits_ts2322_tests;
-#[cfg(test)]
-#[path = "tests/noUIA_write_index_signature_emits_ts2322_tests.rs"]
-mod nuia_write_index_signature_emits_ts2322_tests;
-#[cfg(test)]
-#[path = "tests/nullish_union_indexed_access_missing_property_tests.rs"]
-mod nullish_union_indexed_access_missing_property_tests;
-#[cfg(test)]
-#[path = "tests/object_literal_method_body_check_tests.rs"]
-mod object_literal_method_body_check_tests;
 #[cfg(test)]
 #[path = "../tests/optional_param_display_tests.rs"]
 mod optional_param_display_tests;
@@ -562,20 +228,11 @@ mod optional_property_target_undefined_display_tests;
 #[path = "../tests/overload_modifier_tests.rs"]
 mod overload_modifier_tests;
 #[cfg(test)]
-#[path = "tests/override_incompatibility_elaboration_tests.rs"]
-mod override_incompatibility_elaboration_tests;
-#[cfg(test)]
 #[path = "../tests/override_intersection_display_tests.rs"]
 mod override_intersection_display_tests;
 #[cfg(test)]
-#[path = "tests/private_field_no_spelling_suggestion_tests.rs"]
-mod private_field_no_spelling_suggestion_tests;
-#[cfg(test)]
 #[path = "../tests/quick_type_nullish_callee_companion_tests.rs"]
 mod quick_type_nullish_callee_companion_tests;
-#[cfg(test)]
-#[path = "tests/readonly_assignment_no_flow_narrow_tests.rs"]
-mod readonly_assignment_no_flow_narrow_tests;
 #[cfg(test)]
 #[path = "../tests/relation_boundary_tests.rs"]
 mod relation_boundary_tests;
@@ -586,23 +243,11 @@ mod rest_parameter_tests;
 #[path = "../tests/rest_tuple_contextual_typing_tests.rs"]
 mod rest_tuple_contextual_typing_tests;
 #[cfg(test)]
-#[path = "tests/return_alias_unknown_eval_assignability_tests.rs"]
-mod return_alias_unknown_eval_assignability_tests;
-#[cfg(test)]
-#[path = "tests/return_relation_routing_arch_tests.rs"]
-mod return_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/spread_array_rest_param_inference_tests.rs"]
-mod spread_array_rest_param_inference_tests;
-#[cfg(test)]
 #[path = "../tests/spread_rest_diagnostics_tests.rs"]
 mod spread_rest_diagnostics_tests;
 #[cfg(test)]
 #[path = "../tests/spread_rest_tests.rs"]
 mod spread_rest_tests;
-#[cfg(test)]
-#[path = "tests/spurious_suggestion_suppression_tests.rs"]
-mod spurious_suggestion_suppression_tests;
 #[cfg(test)]
 #[path = "../tests/stability_validation_tests.rs"]
 mod stability_validation_tests;
@@ -610,14 +255,10 @@ mod stability_validation_tests;
 #[path = "../tests/string_literal_arithmetic_tests.rs"]
 mod string_literal_arithmetic_tests;
 #[cfg(test)]
-#[path = "tests/suggestion_scan_discarded_tests.rs"]
-mod suggestion_scan_discarded_tests;
-#[cfg(test)]
 #[path = "../tests/symbol_resolver_stability_tests.rs"]
 mod symbol_resolver_stability_tests;
 #[cfg(test)]
-#[path = "tests/this_prop_nullish_operand_code_tests.rs"]
-mod this_prop_nullish_operand_code_tests;
+mod test_module_registry;
 #[cfg(test)]
 #[path = "../tests/this_type_tests.rs"]
 mod this_type_tests;
@@ -715,18 +356,6 @@ mod ts2469_symbol_operator_tests;
 #[path = "../tests/ts2498_tests.rs"]
 mod ts2498_tests;
 #[cfg(test)]
-#[path = "tests/ts2515_ambient_class_abstract_member_tests.rs"]
-mod ts2515_ambient_class_abstract_member_tests;
-#[cfg(test)]
-#[path = "tests/ts2536_deferred_conditional_indexed_access_tests.rs"]
-mod ts2536_deferred_conditional_indexed_access_tests;
-#[cfg(test)]
-#[path = "tests/ts2536_error_type_contagion_tests.rs"]
-mod ts2536_error_type_contagion_tests;
-#[cfg(test)]
-#[path = "tests/ts2536_nested_generic_indexed_access_constraint_tests.rs"]
-mod ts2536_nested_generic_indexed_access_constraint_tests;
-#[cfg(test)]
 #[path = "../tests/ts2540_readonly_tests.rs"]
 mod ts2540_readonly_tests;
 #[cfg(test)]
@@ -735,9 +364,6 @@ mod ts2542_readonly_index_coemission_tests;
 #[cfg(test)]
 #[path = "../tests/ts2558_new_type_args_tests.rs"]
 mod ts2558_new_type_args_tests;
-#[cfg(test)]
-#[path = "tests/ts2574_rest_tuple_element_type_tests.rs"]
-mod ts2574_rest_tuple_element_type_tests;
 #[cfg(test)]
 #[path = "../tests/ts2589_tests.rs"]
 mod ts2589_tests;
@@ -775,23 +401,11 @@ mod ts7036_tests;
 #[path = "../tests/ts7041_tests.rs"]
 mod ts7041_tests;
 #[cfg(test)]
-#[path = "tests/ts7053_apparent_receiver_display_tests.rs"]
-mod ts7053_apparent_receiver_display_tests;
-#[cfg(test)]
-#[path = "tests/ts7053_index_reason_chain_tests.rs"]
-mod ts7053_index_reason_chain_tests;
-#[cfg(test)]
 #[path = "../tests/ts7057_yield_implicit_any.rs"]
 mod ts7057_yield_implicit_any;
 #[cfg(test)]
-#[path = "tests/ts8030_jsdoc_type_tag_message_tests.rs"]
-mod ts8030_jsdoc_type_tag_message_tests;
-#[cfg(test)]
 #[path = "../tests/tuple_index_access_tests.rs"]
 mod tuple_index_access_tests;
-#[cfg(test)]
-#[path = "tests/type_parameter_default_identity_tests.rs"]
-mod type_parameter_default_identity_tests;
 #[cfg(test)]
 #[path = "../tests/typeof_operator_result_union_tests.rs"]
 mod typeof_operator_result_union_tests;
@@ -799,63 +413,21 @@ mod typeof_operator_result_union_tests;
 #[path = "../tests/typeof_unique_symbol_source_display_tests.rs"]
 mod typeof_unique_symbol_source_display_tests;
 #[cfg(test)]
-#[path = "tests/typeof_unknown_logical_narrowing_tests.rs"]
-mod typeof_unknown_logical_narrowing_tests;
-#[cfg(test)]
 #[path = "../tests/using_binding_pattern_diagnostics_tests.rs"]
 mod using_binding_pattern_diagnostics_tests;
 #[cfg(test)]
 #[path = "../tests/value_usage_tests.rs"]
 mod value_usage_tests;
 #[cfg(test)]
-#[path = "tests/window_self_globalthis_resolution_tests.rs"]
-mod window_self_globalthis_resolution_tests;
-#[cfg(test)]
 #[path = "../tests/yield_star_return_type_tests.rs"]
 mod yield_star_return_type_tests;
 // Tests kept in root test harness where shared fixtures live.
 #[cfg(test)]
-#[path = "tests/application_arg_concrete_index_access_display_tests.rs"]
-mod application_arg_concrete_index_access_display_tests;
-#[cfg(test)]
-#[path = "tests/application_target_any_arg_assignability_tests.rs"]
-mod application_target_any_arg_assignability_tests;
-#[cfg(test)]
 #[path = "../tests/architecture_contract_tests.rs"]
 mod architecture_contract_tests;
 #[cfg(test)]
-#[path = "tests/architecture_contract_tests.rs"]
-mod architecture_contract_tests_src;
-#[cfg(test)]
-#[path = "tests/array_elaboration_relation_routing_arch_tests.rs"]
-mod array_elaboration_relation_routing_arch_tests;
-#[cfg(test)]
 #[path = "../tests/array_isarray_mutual_subtype_narrowing_tests.rs"]
 mod array_isarray_mutual_subtype_narrowing_tests;
-#[cfg(test)]
-#[path = "tests/array_like_constraint_relation_routing_arch_tests.rs"]
-mod array_like_constraint_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/array_literal_relation_routing_arch_tests.rs"]
-mod array_literal_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/array_literal_spread_inference_widening_tests.rs"]
-mod array_literal_spread_inference_widening_tests;
-#[cfg(test)]
-#[path = "tests/as_const_nested_literal_display_tests.rs"]
-mod as_const_nested_literal_display_tests;
-#[cfg(test)]
-#[path = "tests/assertion_thenable_comparability_tests.rs"]
-mod assertion_thenable_comparability_tests;
-#[cfg(test)]
-#[path = "tests/assertion_type_predicate_diagnostics_tests.rs"]
-mod assertion_type_predicate_diagnostics_tests;
-#[cfg(test)]
-#[path = "tests/assign_to_import_shadowing_local_tests.rs"]
-mod assign_to_import_shadowing_local_tests;
-#[cfg(test)]
-#[path = "tests/base_type_param_default_inheritance_tests.rs"]
-mod base_type_param_default_inheritance_tests;
 #[cfg(test)]
 #[path = "../tests/bigint_exponentiation_target_tests.rs"]
 mod bigint_exponentiation_target_tests;
@@ -863,215 +435,32 @@ mod bigint_exponentiation_target_tests;
 #[path = "../tests/bigint_target_ts2737_tests.rs"]
 mod bigint_target_ts2737_tests;
 #[cfg(test)]
-#[path = "tests/bind_overloaded_receiver_preserves_signatures_tests.rs"]
-mod bind_overloaded_receiver_preserves_signatures_tests;
-#[cfg(test)]
-#[path = "tests/boolean_literal_union_narrowing_tests.rs"]
-mod boolean_literal_union_narrowing_tests;
-#[cfg(test)]
-#[path = "tests/builtin_iterator_implements_tests.rs"]
-mod builtin_iterator_implements_tests;
-#[cfg(test)]
-#[path = "tests/call_architecture_tests.rs"]
-mod call_architecture_tests;
-#[cfg(test)]
-#[path = "tests/call_checker_diagnostic_relation_routing_arch_tests.rs"]
-mod call_checker_diagnostic_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/call_context_relation_routing_arch_tests.rs"]
-mod call_context_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/call_display_format_relation_routing_arch_tests.rs"]
-mod call_display_format_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/call_elaboration_mutual_relation_routing_arch_tests.rs"]
-mod call_elaboration_mutual_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/call_error_anchor_relation_routing_arch_tests.rs"]
-mod call_error_anchor_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/call_error_elaboration_relation_routing_arch_tests.rs"]
-mod call_error_elaboration_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/call_result_constraint_violation_gateway_arch_tests.rs"]
-mod call_result_constraint_violation_gateway_arch_tests;
-#[cfg(test)]
-#[path = "tests/call_result_relation_routing_arch_tests.rs"]
-mod call_result_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/call_spread_constructor_parameters_tests.rs"]
-mod call_spread_constructor_parameters_tests;
-#[cfg(test)]
-#[path = "tests/callable_constraint_function_identity_tests.rs"]
-mod callable_constraint_function_identity_tests;
-#[cfg(test)]
-#[path = "tests/callable_interface_assignment_tests.rs"]
-mod callable_interface_assignment_tests;
-#[cfg(test)]
-#[path = "tests/callable_union_relation_routing_arch_tests.rs"]
-mod callable_union_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/circular_initializer_deferred_generic_tests.rs"]
-mod circular_initializer_deferred_generic_tests;
-#[cfg(test)]
-#[path = "tests/class_constructor_private_static_recovery_tests.rs"]
-mod class_constructor_private_static_recovery_tests;
-#[cfg(test)]
-#[path = "tests/class_duplicate_extends_skip_resolution_tests.rs"]
-mod class_duplicate_extends_skip_resolution_tests;
-#[cfg(test)]
-#[path = "tests/class_feature_target_gates_tests.rs"]
-mod class_feature_target_gates_tests;
-#[cfg(test)]
-#[path = "tests/class_implements_jsdoc_heritage_relation_routing_arch_tests.rs"]
-mod class_implements_jsdoc_heritage_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/class_implements_whole_type_relation_routing_arch_tests.rs"]
-mod class_implements_whole_type_relation_routing_arch_tests;
-#[cfg(test)]
 #[path = "../tests/class_index_signature_compat_tests.rs"]
 mod class_index_signature_compat_tests;
-#[cfg(test)]
-#[path = "tests/class_static_init_self_new_tests.rs"]
-mod class_static_init_self_new_tests;
-#[cfg(test)]
-#[path = "tests/class_static_side_relation_routing_arch_tests.rs"]
-mod class_static_side_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/closure_destructuring_top_level_diagnostics_tests.rs"]
-mod closure_destructuring_top_level_diagnostics_tests;
-#[cfg(test)]
-#[path = "tests/computed_alias_source_display_tests.rs"]
-mod computed_alias_source_display_tests;
-#[cfg(test)]
-#[path = "tests/computed_symbol_name_unification_tests.rs"]
-mod computed_symbol_name_unification_tests;
-#[cfg(test)]
-#[path = "tests/concise_body_return_excess_property_tests.rs"]
-mod concise_body_return_excess_property_tests;
 #[cfg(test)]
 #[path = "../tests/conditional_alias_unreduced_keeps_alias_display_tests.rs"]
 mod conditional_alias_unreduced_keeps_alias_display_tests;
 #[cfg(test)]
-#[path = "tests/conditional_break_narrowing_tests.rs"]
-mod conditional_break_narrowing_tests;
-#[cfg(test)]
-#[path = "tests/conditional_constraint_relation_routing_arch_tests.rs"]
-mod conditional_constraint_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/conditional_flow_substitution_ts2344_tests.rs"]
-mod conditional_flow_substitution_ts2344_tests;
-#[cfg(test)]
 #[path = "../tests/conditional_keyof_test.rs"]
 mod conditional_keyof_test;
-#[cfg(test)]
-#[path = "tests/conditional_narrowed_index_through_generic_alias_tests.rs"]
-mod conditional_narrowed_index_through_generic_alias_tests;
-#[cfg(test)]
-#[path = "tests/conditional_never_param_inference_tests.rs"]
-mod conditional_never_param_inference_tests;
 #[cfg(test)]
 #[path = "../tests/conditional_rest_arity_erasure_tests.rs"]
 mod conditional_rest_arity_erasure_tests;
 #[cfg(test)]
-#[path = "tests/const_asserted_return_type_tests.rs"]
-mod const_asserted_return_type_tests;
-#[cfg(test)]
-#[path = "tests/constraint_position_nullable_access_tests.rs"]
-mod constraint_position_nullable_access_tests;
-#[cfg(test)]
-#[path = "tests/constraint_validation_relation_routing_arch_tests.rs"]
-mod constraint_validation_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/contextual_callback_shadowed_type_param_tests.rs"]
-mod contextual_callback_shadowed_type_param_tests;
-#[cfg(test)]
-#[path = "tests/contextual_return_wrapper_tests.rs"]
-mod contextual_return_wrapper_tests;
-#[cfg(test)]
 #[path = "../tests/contextual_typing_tests.rs"]
 mod contextual_typing_tests;
-#[cfg(test)]
-#[path = "tests/cross_file_class_instance_publication_tests.rs"]
-mod cross_file_class_instance_publication_tests;
 #[cfg(test)]
 #[path = "../tests/cross_file_class_merge_tests.rs"]
 mod cross_file_class_merge_tests;
 #[cfg(test)]
-#[path = "tests/cross_file_generic_alias_union_implements_tests.rs"]
-mod cross_file_generic_alias_union_implements_tests;
-#[cfg(test)]
-#[path = "tests/cross_file_in_operator_indexed_element_narrowing_tests.rs"]
-mod cross_file_in_operator_indexed_element_narrowing_tests;
-#[cfg(test)]
 #[path = "../tests/cross_file_interface_merge_ts2717_tests.rs"]
 mod cross_file_interface_merge_ts2717_tests;
-#[cfg(test)]
-#[path = "tests/cross_file_interface_property_access_tests.rs"]
-mod cross_file_interface_property_access_tests;
-#[cfg(test)]
-#[path = "tests/cross_file_merged_symbol_value_computed_key_tests.rs"]
-mod cross_file_merged_symbol_value_computed_key_tests;
-#[cfg(test)]
-#[path = "tests/cross_file_type_param_decl_identity_tests.rs"]
-mod cross_file_type_param_decl_identity_tests;
 #[cfg(test)]
 #[path = "../tests/cross_file_type_params_cache_tests.rs"]
 mod cross_file_type_params_cache_tests;
 #[cfg(test)]
-#[path = "tests/cross_file_unresolved_alias_union_simplification_tests.rs"]
-mod cross_file_unresolved_alias_union_simplification_tests;
-#[cfg(test)]
-#[path = "tests/cross_module_generic_interface_heritage_tests.rs"]
-mod cross_module_generic_interface_heritage_tests;
-#[cfg(test)]
-#[path = "tests/declaration_extract_key_path_tests.rs"]
-mod declaration_extract_key_path_tests;
-#[cfg(test)]
-#[path = "tests/destructured_binding_narrowed_property_tests.rs"]
-mod destructured_binding_narrowed_property_tests;
-#[cfg(test)]
-#[path = "tests/destructured_discriminant_source_narrowing_tests.rs"]
-mod destructured_discriminant_source_narrowing_tests;
-#[cfg(test)]
-#[path = "tests/destructuring_relation_routing_arch_tests.rs"]
-mod destructuring_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/diagnostic_sink_message_surgery_arch_tests.rs"]
-mod diagnostic_sink_message_surgery_arch_tests;
-#[cfg(test)]
-#[path = "tests/diagnostic_source_relation_routing_arch_tests.rs"]
-mod diagnostic_source_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/direct_generic_return_tests.rs"]
-mod direct_generic_return_tests;
-#[cfg(test)]
-#[path = "tests/dispatch_tests.rs"]
-mod dispatch_tests;
-#[cfg(test)]
-#[path = "tests/display_keyof_alias_budget_tests.rs"]
-mod display_keyof_alias_budget_tests;
-#[cfg(test)]
-#[path = "tests/display_normalization_budget_tests.rs"]
-mod display_normalization_budget_tests;
-#[cfg(test)]
-#[path = "tests/do_while_exit_narrowing_tests.rs"]
-mod do_while_exit_narrowing_tests;
-#[cfg(test)]
-#[path = "tests/dom_fuel_exhaustion_ts2322_tests.rs"]
-mod dom_fuel_exhaustion_ts2322_tests;
-#[cfg(test)]
-#[path = "tests/duplicate_identifier_relation_routing_arch_tests.rs"]
-mod duplicate_identifier_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/dynamic_import_relation_routing_arch_tests.rs"]
-mod dynamic_import_relation_routing_arch_tests;
-#[cfg(test)]
 #[path = "../tests/dynamic_import_ts2307_per_callsite_tests.rs"]
 mod dynamic_import_ts2307_per_callsite_tests;
-#[cfg(test)]
-#[path = "tests/enclosing_type_param_default_scope_tests.rs"]
-mod enclosing_type_param_default_scope_tests;
 #[cfg(test)]
 #[path = "../tests/enum_indexed_access_tests.rs"]
 mod enum_indexed_access_tests;
@@ -1079,38 +468,14 @@ mod enum_indexed_access_tests;
 #[path = "../tests/enum_nominality_tests.rs"]
 mod enum_nominality_tests;
 #[cfg(test)]
-#[path = "tests/enum_residual_narrowing_tests.rs"]
-mod enum_residual_narrowing_tests;
-#[cfg(test)]
-#[path = "tests/error_reporter_assignability_display_boundary_arch_tests.rs"]
-mod error_reporter_assignability_display_boundary_arch_tests;
-#[cfg(test)]
-#[path = "tests/excess_prop_object_union_display_tests.rs"]
-mod excess_prop_object_union_display_tests;
-#[cfg(test)]
-#[path = "tests/explicit_alias_constraint_relation_routing_arch_tests.rs"]
-mod explicit_alias_constraint_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/explicit_type_arg_overload_pruning_tests.rs"]
-mod explicit_type_arg_overload_pruning_tests;
-#[cfg(test)]
 #[path = "../tests/file_session_switch_to_file_tests.rs"]
 mod file_session_switch_to_file_tests;
 #[cfg(test)]
 #[path = "../tests/flow_boundary_contract_tests.rs"]
 mod flow_boundary_contract_tests;
 #[cfg(test)]
-#[path = "tests/flow_cache_policy_arch_tests.rs"]
-mod flow_cache_policy_arch_tests;
-#[cfg(test)]
-#[path = "tests/for_await_non_async_function_body_tests.rs"]
-mod for_await_non_async_function_body_tests;
-#[cfg(test)]
 #[path = "../tests/for_in_intersection_operand_tests.rs"]
 mod for_in_intersection_operand_tests;
-#[cfg(test)]
-#[path = "tests/for_in_lhs_relation_routing_arch_tests.rs"]
-mod for_in_lhs_relation_routing_arch_tests;
 #[cfg(test)]
 #[path = "../tests/for_in_narrowing_tests.rs"]
 mod for_in_narrowing_tests;
@@ -1118,152 +483,23 @@ mod for_in_narrowing_tests;
 #[path = "../tests/for_in_self_reference_and_nullable_operand_tests.rs"]
 mod for_in_self_reference_and_nullable_operand_tests;
 #[cfg(test)]
-#[path = "tests/fresh_const_array_mutable_assignment_tests.rs"]
-mod fresh_const_array_mutable_assignment_tests;
-#[cfg(test)]
-#[path = "tests/fresh_object_literal_array_like_union_drill_gate_tests.rs"]
-mod fresh_object_literal_array_like_union_drill_gate_tests;
-#[cfg(test)]
 #[path = "../tests/fresh_object_literal_union_array_member_drill_in_tests.rs"]
 mod fresh_object_literal_union_array_member_drill_in_tests;
-#[cfg(test)]
-#[path = "tests/fresh_object_literal_union_literal_kind_display_tests.rs"]
-mod fresh_object_literal_union_literal_kind_display_tests;
-#[cfg(test)]
-#[path = "tests/function_parameter_mismatch_elaboration_tests.rs"]
-mod function_parameter_mismatch_elaboration_tests;
-#[cfg(test)]
-#[path = "tests/generic_alias_application_display_tests.rs"]
-mod generic_alias_application_display_tests;
-#[cfg(test)]
-#[path = "tests/generic_argument_suppression_relation_routing_arch_tests.rs"]
-mod generic_argument_suppression_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/generic_call_enclosing_type_param_return_tests.rs"]
-mod generic_call_enclosing_type_param_return_tests;
-#[cfg(test)]
-#[path = "tests/generic_callback_outer_context_tests.rs"]
-mod generic_callback_outer_context_tests;
-#[cfg(test)]
-#[path = "tests/generic_callback_return_outer_annotation_leak_tests.rs"]
-mod generic_callback_return_outer_annotation_leak_tests;
-#[cfg(test)]
-#[path = "tests/generic_callback_sibling_arg_inference_tests.rs"]
-mod generic_callback_sibling_arg_inference_tests;
-#[cfg(test)]
-#[path = "tests/generic_checker_mod_relation_routing_arch_tests.rs"]
-mod generic_checker_mod_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/generic_class_constructor_literal_preservation_tests.rs"]
-mod generic_class_constructor_literal_preservation_tests;
-#[cfg(test)]
-#[path = "tests/generic_class_self_ref_method_param_tests.rs"]
-mod generic_class_self_ref_method_param_tests;
-#[cfg(test)]
-#[path = "tests/generic_function_param_name_collision_assignability_tests.rs"]
-mod generic_function_param_name_collision_assignability_tests;
 #[cfg(test)]
 #[path = "../tests/generic_inference_manual.rs"]
 mod generic_inference_manual;
 #[cfg(test)]
-#[path = "tests/generic_instantiation_boundary_cache_tests.rs"]
-mod generic_instantiation_boundary_cache_tests;
-#[cfg(test)]
-#[path = "tests/generic_rest_satisfies_anchor_tests.rs"]
-mod generic_rest_satisfies_anchor_tests;
-#[cfg(test)]
-#[path = "tests/generic_spread_iterability_tests.rs"]
-mod generic_spread_iterability_tests;
-#[cfg(test)]
 #[path = "../tests/generic_tests.rs"]
 mod generic_tests;
-#[cfg(test)]
-#[path = "tests/generic_unknown_type_arg_tests.rs"]
-mod generic_unknown_type_arg_tests;
-#[cfg(test)]
-#[path = "tests/generics_relation_routing_arch_tests.rs"]
-mod generics_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/identifier_relation_routing_arch_tests.rs"]
-mod identifier_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/import_attributes_relation_routing_arch_tests.rs"]
-mod import_attributes_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/import_shadows_global_ctor_tests.rs"]
-mod import_shadows_global_ctor_tests;
-#[cfg(test)]
-#[path = "tests/imported_predicate_false_branch_tests.rs"]
-mod imported_predicate_false_branch_tests;
-#[cfg(test)]
-#[path = "tests/in_narrow_aliased_union_tests.rs"]
-mod in_narrow_aliased_union_tests;
-#[cfg(test)]
-#[path = "tests/in_narrow_apparent_member_tests.rs"]
-mod in_narrow_apparent_member_tests;
-#[cfg(test)]
-#[path = "tests/in_narrow_bare_type_param_chained_tests.rs"]
-mod in_narrow_bare_type_param_chained_tests;
-#[cfg(test)]
-#[path = "tests/in_operator_relation_routing_arch_tests.rs"]
-mod in_operator_relation_routing_arch_tests;
 #[cfg(test)]
 #[path = "../tests/increment_assignment_target_suppression_tests.rs"]
 mod increment_assignment_target_suppression_tests;
 #[cfg(test)]
-#[path = "tests/index_signature_check_relation_routing_arch_tests.rs"]
-mod index_signature_check_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/index_signature_nested_object_literal_elaboration_tests.rs"]
-mod index_signature_nested_object_literal_elaboration_tests;
-#[cfg(test)]
-#[path = "tests/index_signature_property_relation_routing_arch_tests.rs"]
-mod index_signature_property_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/index_signature_value_relation_routing_arch_tests.rs"]
-mod index_signature_value_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/indexed_access_callable_member_constraint_ts2344_tests.rs"]
-mod indexed_access_callable_member_constraint_ts2344_tests;
-#[cfg(test)]
-#[path = "tests/indexed_access_constraint_relation_routing_arch_tests.rs"]
-mod indexed_access_constraint_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/infer_conditional_relation_routing_arch_tests.rs"]
-mod infer_conditional_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/initializer_relation_routing_arch_tests.rs"]
-mod initializer_relation_routing_arch_tests;
-#[cfg(test)]
 #[path = "../tests/interface_extends_array_json_tests.rs"]
 mod interface_extends_array_json_tests;
 #[cfg(test)]
-#[path = "tests/interface_heritage_alias_arg_substitution_tests.rs"]
-mod interface_heritage_alias_arg_substitution_tests;
-#[cfg(test)]
-#[path = "tests/interface_index_conflict_relation_routing_arch_tests.rs"]
-mod interface_index_conflict_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/intersection_callable_constraint_ts2344_tests.rs"]
-mod intersection_callable_constraint_ts2344_tests;
-#[cfg(test)]
 #[path = "../tests/intersection_signatures.rs"]
 mod intersection_signatures;
-#[cfg(test)]
-#[path = "tests/intersection_source_literal_member_display_tests.rs"]
-mod intersection_source_literal_member_display_tests;
-#[cfg(test)]
-#[path = "tests/intersection_target_elaboration_tests.rs"]
-mod intersection_target_elaboration_tests;
-#[cfg(test)]
-#[path = "tests/invocation_signature_detail_tests.rs"]
-mod invocation_signature_detail_tests;
-#[cfg(test)]
-#[path = "tests/issue_9762_literal_init_callback_inference.rs"]
-mod issue_9762_literal_init_callback_inference;
-#[cfg(test)]
-#[path = "tests/iterable_next_relation_routing_arch_tests.rs"]
-mod iterable_next_relation_routing_arch_tests;
 #[cfg(test)]
 #[path = "../tests/js_constructor_property_tests.rs"]
 mod js_constructor_property_tests;
@@ -1274,27 +510,14 @@ mod jsdoc_accessibility_tests;
 #[path = "../tests/jsdoc_callback_rest_tests.rs"]
 mod jsdoc_callback_rest_tests;
 #[cfg(test)]
-#[path = "tests/jsdoc_cast_and_define_property_widening_tests.rs"]
-mod jsdoc_cast_and_define_property_widening_tests;
-#[cfg(test)]
 #[path = "../tests/jsdoc_cross_file_typedef_tests.rs"]
 mod jsdoc_cross_file_typedef_tests;
-#[cfg(test)]
-#[path = "tests/jsdoc_empty_augments_class_chain_tests.rs"]
-mod jsdoc_empty_augments_class_chain_tests;
 #[cfg(test)]
 #[path = "../tests/jsdoc_enum_circular_tests.rs"]
 mod jsdoc_enum_circular_tests;
 #[cfg(test)]
 #[path = "../tests/jsdoc_function_return_type_anchor_tests.rs"]
 mod jsdoc_function_return_type_anchor_tests;
-#[cfg(test)]
-#[path = "tests/jsdoc_overload_call_resolution_tests.rs"]
-mod jsdoc_overload_call_resolution_tests;
-
-#[cfg(test)]
-#[path = "tests/class_member_modifier_grammar_first_error_wins_tests.rs"]
-mod class_member_modifier_grammar_first_error_wins_tests;
 
 #[cfg(test)]
 #[path = "../tests/jsdoc_readonly_tests.rs"]
@@ -1309,9 +532,6 @@ mod jsdoc_reference_kernel_tests;
 #[path = "../tests/jsdoc_satisfies_tests.rs"]
 mod jsdoc_satisfies_tests;
 #[cfg(test)]
-#[path = "tests/jsdoc_shadowed_type_param_identity_tests.rs"]
-mod jsdoc_shadowed_type_param_identity_tests;
-#[cfg(test)]
 #[path = "../tests/jsdoc_template_class_tests.rs"]
 mod jsdoc_template_class_tests;
 #[cfg(test)]
@@ -1321,65 +541,11 @@ mod jsdoc_type_expression_tests;
 #[path = "../tests/jsdoc_type_tag_tests.rs"]
 mod jsdoc_type_tag_tests;
 #[cfg(test)]
-#[path = "tests/jsdoc_typedef_distinct_alias_names_tests.rs"]
-mod jsdoc_typedef_distinct_alias_names_tests;
-#[cfg(test)]
 #[path = "../tests/jsdoc_typedef_module_export_tests.rs"]
 mod jsdoc_typedef_module_export_tests;
 #[cfg(test)]
-#[path = "tests/jsx_children_relation_routing_arch_tests.rs"]
-mod jsx_children_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/jsx_component_props_relation_routing_arch_tests.rs"]
-mod jsx_component_props_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/jsx_element_type_constraint_tests.rs"]
-mod jsx_element_type_constraint_tests;
-#[cfg(test)]
-#[path = "tests/jsx_excess_attr_with_spread_display_tests.rs"]
-mod jsx_excess_attr_with_spread_display_tests;
-#[cfg(test)]
-#[path = "tests/jsx_generic_spread_relation_routing_arch_tests.rs"]
-mod jsx_generic_spread_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/jsx_overload_relation_routing_arch_tests.rs"]
-mod jsx_overload_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/jsx_props_resolution_relation_routing_arch_tests.rs"]
-mod jsx_props_resolution_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/jsx_props_validation_relation_routing_arch_tests.rs"]
-mod jsx_props_validation_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/jsx_react_alias_relation_routing_arch_tests.rs"]
-mod jsx_react_alias_relation_routing_arch_tests;
-#[cfg(test)]
 #[path = "../tests/jsx_react_hoc_spread_props_tests.rs"]
 mod jsx_react_hoc_spread_props_tests;
-#[cfg(test)]
-#[path = "tests/jsx_render_fallback_relation_routing_arch_tests.rs"]
-mod jsx_render_fallback_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/jsx_return_relation_routing_arch_tests.rs"]
-mod jsx_return_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/jsx_single_child_precise_relation_routing_arch_tests.rs"]
-mod jsx_single_child_precise_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/jsx_spread_assignability_relation_routing_arch_tests.rs"]
-mod jsx_spread_assignability_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/jsx_text_child_relation_routing_arch_tests.rs"]
-mod jsx_text_child_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/jsx_type_arg_arity_suppresses_ts2604_tests.rs"]
-mod jsx_type_arg_arity_suppresses_ts2604_tests;
-#[cfg(test)]
-#[path = "tests/jsx_union_props_relation_routing_arch_tests.rs"]
-mod jsx_union_props_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/keyof_alias_composite_display_tests.rs"]
-mod keyof_alias_composite_display_tests;
 #[cfg(test)]
 #[path = "../tests/keyof_function_type_is_never_tests.rs"]
 mod keyof_function_type_is_never_tests;
@@ -1390,12 +556,6 @@ mod keyof_mapped_as_clause_tests;
 #[path = "../tests/keyof_mapped_constraint_key_space_tests.rs"]
 mod keyof_mapped_constraint_key_space_tests;
 #[cfg(test)]
-#[path = "tests/keyof_suppression_relation_routing_arch_tests.rs"]
-mod keyof_suppression_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/libtype_structural_name_lookup_arch_tests.rs"]
-mod libtype_structural_name_lookup_arch_tests;
-#[cfg(test)]
 #[path = "../tests/logical_assignment_narrowing_tests.rs"]
 mod logical_assignment_narrowing_tests;
 #[cfg(test)]
@@ -1405,68 +565,20 @@ mod logical_operator_literal_preservation_tests;
 #[path = "../tests/mapped_indexed_access_diagnostic_tests.rs"]
 mod mapped_indexed_access_diagnostic_tests;
 #[cfg(test)]
-#[path = "tests/mapped_infer_with_substitution_tests.rs"]
-mod mapped_infer_with_substitution_tests;
-#[cfg(test)]
-#[path = "tests/mapped_intersection_excess_property_tests.rs"]
-mod mapped_intersection_excess_property_tests;
-#[cfg(test)]
 #[path = "../tests/mapped_intersection_indexed_access_tests.rs"]
 mod mapped_intersection_indexed_access_tests;
-#[cfg(test)]
-#[path = "tests/mapped_keyof_remap_excess_property_tests.rs"]
-mod mapped_keyof_remap_excess_property_tests;
-#[cfg(test)]
-#[path = "tests/mapped_optional_target_excess_property_tests.rs"]
-mod mapped_optional_target_excess_property_tests;
-#[cfg(test)]
-#[path = "tests/mapped_true_base_constraint_relation_routing_arch_tests.rs"]
-mod mapped_true_base_constraint_relation_routing_arch_tests;
 #[cfg(test)]
 #[path = "../tests/member_access_architecture_boundary_tests.rs"]
 mod member_access_architecture_boundary_tests;
 #[cfg(test)]
-#[path = "tests/merged_interface_constraint_relation_routing_arch_tests.rs"]
-mod merged_interface_constraint_relation_routing_arch_tests;
-#[cfg(test)]
 #[path = "../tests/module_resolution_guard_tests.rs"]
 mod module_resolution_guard_tests;
-#[cfg(test)]
-#[path = "tests/multi_overload_infer_capture_tests.rs"]
-mod multi_overload_infer_capture_tests;
-#[cfg(test)]
-#[path = "tests/mutable_binding_widening_from_const_literal_tests.rs"]
-mod mutable_binding_widening_from_const_literal_tests;
-#[cfg(test)]
-#[path = "tests/namespace_property_mismatch_boundary_arch_tests.rs"]
-mod namespace_property_mismatch_boundary_arch_tests;
-#[cfg(test)]
-#[path = "tests/narrowed_union_source_display_tests.rs"]
-mod narrowed_union_source_display_tests;
-#[cfg(test)]
-#[path = "tests/narrowing_union_source_display_tests.rs"]
-mod narrowing_union_source_display_tests;
-#[cfg(test)]
-#[path = "tests/nested_function_async_context_scope_tests.rs"]
-mod nested_function_async_context_scope_tests;
-#[cfg(test)]
-#[path = "tests/nested_tuple_literal_source_display_tests.rs"]
-mod nested_tuple_literal_source_display_tests;
-#[cfg(test)]
-#[path = "tests/nested_type_parameter_target_elaboration_tests.rs"]
-mod nested_type_parameter_target_elaboration_tests;
 #[cfg(test)]
 #[path = "../tests/never_absorption_call_spread_tests.rs"]
 mod never_absorption_call_spread_tests;
 #[cfg(test)]
-#[path = "tests/never_indexed_access_reduction_tests.rs"]
-mod never_indexed_access_reduction_tests;
-#[cfg(test)]
 #[path = "../tests/never_initializer_falls_through_tests.rs"]
 mod never_initializer_falls_through_tests;
-#[cfg(test)]
-#[path = "tests/never_return_import_alias_tests.rs"]
-mod never_return_import_alias_tests;
 #[cfg(test)]
 #[path = "../tests/never_returning_narrowing_tests.rs"]
 mod never_returning_narrowing_tests;
@@ -1477,21 +589,6 @@ mod new_expression_source_display_tests;
 #[path = "../tests/new_typeof_property_tests.rs"]
 mod new_typeof_property_tests;
 #[cfg(test)]
-#[path = "tests/nolib_user_global_array_member_tests.rs"]
-mod nolib_user_global_array_member_tests;
-#[cfg(test)]
-#[path = "tests/non_generic_spread_tuple_alias_display_tests.rs"]
-mod non_generic_spread_tuple_alias_display_tests;
-#[cfg(test)]
-#[path = "tests/non_strict_non_null_check_narrows_tests.rs"]
-mod non_strict_non_null_check_narrows_tests;
-#[cfg(test)]
-#[path = "tests/nonunique_symbol_property_access_tests.rs"]
-mod nonunique_symbol_property_access_tests;
-#[cfg(test)]
-#[path = "tests/nullable_union_callback_variance_tests.rs"]
-mod nullable_union_callback_variance_tests;
-#[cfg(test)]
 #[path = "../tests/nullish_coalescing_discriminated_union_tests.rs"]
 mod nullish_coalescing_discriminated_union_tests;
 #[cfg(test)]
@@ -1501,406 +598,28 @@ mod nullish_coalescing_unknown_result_tests;
 #[path = "../tests/nullish_operand_checknonnull_parity_tests.rs"]
 mod nullish_operand_checknonnull_parity_tests;
 #[cfg(test)]
-#[path = "tests/nullish_target_relation_routing_arch_tests.rs"]
-mod nullish_target_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/object_define_property_identity_tests.rs"]
-mod object_define_property_identity_tests;
-#[cfg(test)]
-#[path = "tests/object_global_identity_helper_tests.rs"]
-mod object_global_identity_helper_tests;
-#[cfg(test)]
-#[path = "tests/object_literal_computed_symbol_member_tests.rs"]
-mod object_literal_computed_symbol_member_tests;
-#[cfg(test)]
-#[path = "tests/object_literal_method_this_parameter_contextual_tests.rs"]
-mod object_literal_method_this_parameter_contextual_tests;
-#[cfg(test)]
-#[path = "tests/object_literal_relation_architecture_tests.rs"]
-mod object_literal_relation_architecture_tests;
-#[cfg(test)]
-#[path = "tests/object_literal_this_member_order_tests.rs"]
-mod object_literal_this_member_order_tests;
-#[cfg(test)]
-#[path = "tests/object_property_arrow_param_annotation_elaboration_tests.rs"]
-mod object_property_arrow_param_annotation_elaboration_tests;
-#[cfg(test)]
-#[path = "tests/object_shorthand_literal_preservation_tests.rs"]
-mod object_shorthand_literal_preservation_tests;
-#[cfg(test)]
-#[path = "tests/object_spread_discriminant_narrowing_tests.rs"]
-mod object_spread_discriminant_narrowing_tests;
-#[cfg(test)]
-#[path = "tests/object_spread_optional_merge_tests.rs"]
-mod object_spread_optional_merge_tests;
-#[cfg(test)]
-#[path = "tests/operator_chain_overload_resolution_tests.rs"]
-mod operator_chain_overload_resolution_tests;
-#[cfg(test)]
-#[path = "tests/optional_chain_inherent_nullish_tests.rs"]
-mod optional_chain_inherent_nullish_tests;
-#[cfg(test)]
-#[path = "tests/optional_chain_root_nullish_strict_only_tests.rs"]
-mod optional_chain_root_nullish_strict_only_tests;
-#[cfg(test)]
-#[path = "tests/optional_key_extraction_tests.rs"]
-mod optional_key_extraction_tests;
-#[cfg(test)]
-#[path = "tests/optional_private_field_undefined_tests.rs"]
-mod optional_private_field_undefined_tests;
-#[cfg(test)]
-#[path = "tests/optional_property_union_source_elaboration_tests.rs"]
-mod optional_property_union_source_elaboration_tests;
-#[cfg(test)]
-#[path = "tests/overlap_relation_helper_routing_arch_tests.rs"]
-mod overlap_relation_helper_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/overload_anchor_at_argument_tests.rs"]
-mod overload_anchor_at_argument_tests;
-#[cfg(test)]
-#[path = "tests/overload_argument_reason_chain_tests.rs"]
-mod overload_argument_reason_chain_tests;
-#[cfg(test)]
-#[path = "tests/overload_elaboration_tests.rs"]
-mod overload_elaboration_tests;
-#[cfg(test)]
-#[path = "tests/overload_generic_wrapper_compat_tests.rs"]
-mod overload_generic_wrapper_compat_tests;
-#[cfg(test)]
-#[path = "tests/overload_literal_source_generalization_tests.rs"]
-mod overload_literal_source_generalization_tests;
-#[cfg(test)]
-#[path = "tests/overload_param_relation_routing_arch_tests.rs"]
-mod overload_param_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/overload_two_pass_any_source_tests.rs"]
-mod overload_two_pass_any_source_tests;
-#[cfg(test)]
-#[path = "tests/overload_union_context_callback_tests.rs"]
-mod overload_union_context_callback_tests;
-#[cfg(test)]
-#[path = "tests/overloaded_contextual_rest_tuple_tests.rs"]
-mod overloaded_contextual_rest_tuple_tests;
-#[cfg(test)]
-#[path = "tests/partial_pick_indexed_access_write_tests.rs"]
-mod partial_pick_indexed_access_write_tests;
-#[cfg(test)]
-#[path = "tests/polymorphic_this_relation_routing_arch_tests.rs"]
-mod polymorphic_this_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/predicate_narrowed_lib_union_access_tests.rs"]
-mod predicate_narrowed_lib_union_access_tests;
-#[cfg(test)]
-#[path = "tests/predicate_narrowed_top_type_source_display_tests.rs"]
-mod predicate_narrowed_top_type_source_display_tests;
-#[cfg(test)]
-#[path = "tests/predicate_narrowed_unknown_any_source_display_tests.rs"]
-mod predicate_narrowed_unknown_any_source_display_tests;
-#[cfg(test)]
 #[path = "../tests/private_brands.rs"]
 mod private_brands;
-#[cfg(test)]
-#[path = "tests/private_member_relation_routing_arch_tests.rs"]
-mod private_member_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/private_name_modifier_grammar_order_tests.rs"]
-mod private_name_modifier_grammar_order_tests;
-#[cfg(test)]
-#[path = "tests/private_optional_field_undefined_tests.rs"]
-mod private_optional_field_undefined_tests;
-#[cfg(test)]
-#[path = "tests/promise_like_infer_tests.rs"]
-mod promise_like_infer_tests;
-#[cfg(test)]
-#[path = "tests/promise_this_relation_routing_arch_tests.rs"]
-mod promise_this_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/property_alias_display_tests.rs"]
-mod property_alias_display_tests;
-#[cfg(test)]
-#[path = "tests/property_index_key_relation_routing_arch_tests.rs"]
-mod property_index_key_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/property_receiver_display_recursion_overflow_tests.rs"]
-mod property_receiver_display_recursion_overflow_tests;
-#[cfg(test)]
-#[path = "tests/property_receiver_relation_routing_arch_tests.rs"]
-mod property_receiver_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/readonly_property_assignment_narrowing_tests.rs"]
-mod readonly_property_assignment_narrowing_tests;
-#[cfg(test)]
-#[path = "tests/recursive_accumulator_depth_tests.rs"]
-mod recursive_accumulator_depth_tests;
 #[cfg(test)]
 #[path = "../tests/recursive_alias_application_target_display_tests.rs"]
 mod recursive_alias_application_target_display_tests;
 #[cfg(test)]
-#[path = "tests/recursive_callable_infer_cycle_tests.rs"]
-mod recursive_callable_infer_cycle_tests;
-#[cfg(test)]
-#[path = "tests/recursive_conditional_infer_termination_tests.rs"]
-mod recursive_conditional_infer_termination_tests;
-#[cfg(test)]
-#[path = "tests/recursive_generic_arrow_tests.rs"]
-mod recursive_generic_arrow_tests;
-#[cfg(test)]
-#[path = "tests/recursive_mapped_intersection_nested_excess_property_tests.rs"]
-mod recursive_mapped_intersection_nested_excess_property_tests;
-#[cfg(test)]
-#[path = "tests/recursive_path_default_type_param_tests.rs"]
-mod recursive_path_default_type_param_tests;
-#[cfg(test)]
-#[path = "tests/recursive_tuple_alias_diagnostic_display_tests.rs"]
-mod recursive_tuple_alias_diagnostic_display_tests;
-#[cfg(test)]
-#[path = "tests/recursive_tuple_rest_cycle_tests.rs"]
-mod recursive_tuple_rest_cycle_tests;
-#[cfg(test)]
-#[path = "tests/reexport_resolution_cache_tests.rs"]
-mod reexport_resolution_cache_tests;
-#[cfg(test)]
-#[path = "tests/reexported_generic_interface_property_tests.rs"]
-mod reexported_generic_interface_property_tests;
-#[cfg(test)]
-#[path = "tests/ref_type_params_cache_tests.rs"]
-mod ref_type_params_cache_tests;
-#[cfg(test)]
-#[path = "tests/relation_flags_boundary_contract_tests.rs"]
-mod relation_flags_boundary_contract_tests;
-#[cfg(test)]
-#[path = "tests/remapped_missing_property_relation_routing_arch_tests.rs"]
-mod remapped_missing_property_relation_routing_arch_tests;
-#[cfg(test)]
 #[path = "../tests/repro_parserreal.rs"]
 mod repro_parserreal;
 #[cfg(test)]
-#[path = "tests/rest_parameter_relation_routing_arch_tests.rs"]
-mod rest_parameter_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/return_context_promise_identity_tests.rs"]
-mod return_context_promise_identity_tests;
-#[cfg(test)]
-#[path = "tests/return_context_type_param_shadowing_tests.rs"]
-mod return_context_type_param_shadowing_tests;
-#[cfg(test)]
 #[path = "../tests/reverse_mapped_inference_tests.rs"]
 mod reverse_mapped_inference_tests;
-#[cfg(test)]
-#[path = "tests/satisfies_callback_return_widening_tests.rs"]
-mod satisfies_callback_return_widening_tests;
-#[cfg(test)]
-#[path = "tests/satisfies_relation_routing_arch_tests.rs"]
-mod satisfies_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/self_referential_arrow_property_soundness_tests.rs"]
-mod self_referential_arrow_property_soundness_tests;
-#[cfg(test)]
-#[path = "tests/self_referential_conditional_infer_soundness_tests.rs"]
-mod self_referential_conditional_infer_soundness_tests;
-#[cfg(test)]
-#[path = "tests/semantic_def_body_read_arch_tests.rs"]
-mod semantic_def_body_read_arch_tests;
-#[cfg(test)]
-#[path = "tests/shadowed_type_param_identity_tests.rs"]
-mod shadowed_type_param_identity_tests;
-#[cfg(test)]
-#[path = "tests/split_accessor_variance_tests.rs"]
-mod split_accessor_variance_tests;
-#[cfg(test)]
-#[path = "tests/state_type_environment_relation_routing_arch_tests.rs"]
-mod state_type_environment_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/strict_callback_param_method_tests.rs"]
-mod strict_callback_param_method_tests;
-#[cfg(test)]
-#[path = "tests/strict_mode_class_context_name_tests.rs"]
-mod strict_mode_class_context_name_tests;
 
-#[cfg(test)]
-#[path = "tests/parameter_checker_tests.rs"]
-mod parameter_checker_tests;
 #[cfg(test)]
 #[path = "../tests/strict_null_manual.rs"]
 mod strict_null_manual;
 #[cfg(test)]
-#[path = "tests/string_literal_union_display_order_tests.rs"]
-mod string_literal_union_display_order_tests;
-#[cfg(test)]
-#[path = "tests/super_call_ts2376_ts17009_priority_tests.rs"]
-mod super_call_ts2376_ts17009_priority_tests;
-#[cfg(test)]
-#[path = "tests/switch_distinct_literal_memo_narrowing_tests.rs"]
-mod switch_distinct_literal_memo_narrowing_tests;
-#[cfg(test)]
-#[path = "tests/symbol_env_registration_arch_tests.rs"]
-mod symbol_env_registration_arch_tests;
-#[cfg(test)]
-#[path = "tests/symbol_for_identity_helper_tests.rs"]
-mod symbol_for_identity_helper_tests;
-#[cfg(test)]
 #[path = "../tests/symbol_index_signature_tests.rs"]
 mod symbol_index_signature_tests;
-#[cfg(test)]
-#[path = "tests/syntax_constraint_relation_routing_arch_tests.rs"]
-mod syntax_constraint_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/synthetic_unique_atom_union_display_tests.rs"]
-mod synthetic_unique_atom_union_display_tests;
-#[cfg(test)]
-#[path = "tests/this_context_self_type_tests.rs"]
-mod this_context_self_type_tests;
-#[cfg(test)]
-#[path = "tests/this_source_inference_tests.rs"]
-mod this_source_inference_tests;
-#[cfg(test)]
-#[path = "tests/this_void_method_call_tests.rs"]
-mod this_void_method_call_tests;
-#[cfg(test)]
-#[path = "tests/top_level_await_boundary_tests.rs"]
-mod top_level_await_boundary_tests;
-#[cfg(test)]
-#[path = "tests/truthiness_promise_coercion_tests.rs"]
-mod truthiness_promise_coercion_tests;
-#[cfg(test)]
-#[path = "tests/ts1101_with_in_strict_mode_tests.rs"]
-mod ts1101_with_in_strict_mode_tests;
-#[cfg(test)]
-#[path = "tests/ts1170_computed_property_syntactic_form_tests.rs"]
-mod ts1170_computed_property_syntactic_form_tests;
-#[cfg(test)]
-#[path = "tests/ts1361_ambient_computed_property_name_tests.rs"]
-mod ts1361_ambient_computed_property_name_tests;
 
-#[cfg(test)]
-#[path = "tests/ts18010_jsdoc_tag_anchor_tests.rs"]
-mod ts18010_jsdoc_tag_anchor_tests;
 #[cfg(test)]
 #[path = "../tests/ts18048_unary_arithmetic_nullish_tests.rs"]
 mod ts18048_unary_arithmetic_nullish_tests;
-#[cfg(test)]
-#[path = "tests/ts18050_nullish_keyword_without_strict_null_checks_tests.rs"]
-mod ts18050_nullish_keyword_without_strict_null_checks_tests;
-#[cfg(test)]
-#[path = "tests/ts2322_private_field_narrowing_write_tests.rs"]
-mod ts2322_private_field_narrowing_write_tests;
-#[cfg(test)]
-#[path = "tests/ts2322_readonly_array_element_elaboration_tests.rs"]
-mod ts2322_readonly_array_element_elaboration_tests;
-#[cfg(test)]
-#[path = "tests/ts2322_same_generic_type_argument_elaboration_tests.rs"]
-mod ts2322_same_generic_type_argument_elaboration_tests;
-#[cfg(test)]
-#[path = "tests/ts2323_block_scoped_conflict_message_tests.rs"]
-mod ts2323_block_scoped_conflict_message_tests;
-#[cfg(test)]
-#[path = "tests/ts2323_export_var_namespace_merge_tests.rs"]
-mod ts2323_export_var_namespace_merge_tests;
-#[cfg(test)]
-#[path = "tests/ts2323_mixed_exportedness_two_table_tests.rs"]
-mod ts2323_mixed_exportedness_two_table_tests;
-#[cfg(test)]
-#[path = "tests/ts2323_variable_redeclaration_two_pass_tests.rs"]
-mod ts2323_variable_redeclaration_two_pass_tests;
-#[cfg(test)]
-#[path = "tests/ts2339_js_this_function_name_display_tests.rs"]
-mod ts2339_js_this_function_name_display_tests;
-#[cfg(test)]
-#[path = "tests/ts2341_private_access_via_type_param_constraint_tests.rs"]
-mod ts2341_private_access_via_type_param_constraint_tests;
-#[cfg(test)]
-#[path = "tests/ts2353_generic_constraint_tests.rs"]
-mod ts2353_generic_constraint_tests;
-#[cfg(test)]
-#[path = "tests/ts2445_protected_access_via_subclass_this_tests.rs"]
-mod ts2445_protected_access_via_subclass_this_tests;
-#[cfg(test)]
-#[path = "tests/ts2564_constructor_throw_guard_tests.rs"]
-mod ts2564_constructor_throw_guard_tests;
-#[cfg(test)]
-#[path = "tests/ts2565_jsdoc_prototype_type_decl_tests.rs"]
-mod ts2565_jsdoc_prototype_type_decl_tests;
-#[cfg(test)]
-#[path = "tests/ts2565_object_literal_nullish_spread_tests.rs"]
-mod ts2565_object_literal_nullish_spread_tests;
-#[cfg(test)]
-#[path = "tests/ts2590_array_literal_identity_skip_tests.rs"]
-mod ts2590_array_literal_identity_skip_tests;
-#[cfg(test)]
-#[path = "tests/ts2591_node_global_type_position_tests.rs"]
-mod ts2591_node_global_type_position_tests;
-#[cfg(test)]
-#[path = "tests/ts2739_alias_unfold_display_tests.rs"]
-mod ts2739_alias_unfold_display_tests;
-#[cfg(test)]
-#[path = "tests/tuple_spread_flattening_tests.rs"]
-mod tuple_spread_flattening_tests;
-#[cfg(test)]
-#[path = "tests/type_alias_computed_display_tests.rs"]
-mod type_alias_computed_display_tests;
-#[cfg(test)]
-#[path = "tests/type_alias_primitive_display_tests.rs"]
-mod type_alias_primitive_display_tests;
-#[cfg(test)]
-#[path = "tests/type_analysis_env_merge_arch_tests.rs"]
-mod type_analysis_env_merge_arch_tests;
-#[cfg(test)]
-#[path = "tests/type_param_default_relation_routing_arch_tests.rs"]
-mod type_param_default_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/type_position_resolution_cache_tests.rs"]
-mod type_position_resolution_cache_tests;
-#[cfg(test)]
-#[path = "tests/type_predicate_alias_relation_tests.rs"]
-mod type_predicate_alias_relation_tests;
-#[cfg(test)]
-#[path = "tests/type_predicate_relation_routing_arch_tests.rs"]
-mod type_predicate_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/typeof_class_name_structural_lookup_arch_tests.rs"]
-mod typeof_class_name_structural_lookup_arch_tests;
-#[cfg(test)]
-#[path = "tests/typeof_const_spread_index_access_tests.rs"]
-mod typeof_const_spread_index_access_tests;
-#[cfg(test)]
-#[path = "tests/under_applied_generic_constructor_fill_tests.rs"]
-mod under_applied_generic_constructor_fill_tests;
-#[cfg(test)]
-#[path = "tests/union_call_resolution_tests.rs"]
-mod union_call_resolution_tests;
-#[cfg(test)]
-#[path = "tests/union_constraint_relation_routing_arch_tests.rs"]
-mod union_constraint_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/union_excess_property_relation_routing_arch_tests.rs"]
-mod union_excess_property_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/union_index_signature_relation_routing_arch_tests.rs"]
-mod union_index_signature_relation_routing_arch_tests;
-#[cfg(test)]
-#[path = "tests/union_multi_overload_unified_sig_tests.rs"]
-mod union_multi_overload_unified_sig_tests;
-#[cfg(test)]
-#[path = "tests/union_source_literal_target_display_tests.rs"]
-mod union_source_literal_target_display_tests;
-#[cfg(test)]
-#[path = "tests/union_to_tuple_never_base_depth_tests.rs"]
-mod union_to_tuple_never_base_depth_tests;
-#[cfg(test)]
-#[path = "tests/unique_symbol_assignment_ts2322_tests.rs"]
-mod unique_symbol_assignment_ts2322_tests;
-#[cfg(test)]
-#[path = "tests/unique_symbol_member_lookup_family_tests.rs"]
-mod unique_symbol_member_lookup_family_tests;
-#[cfg(test)]
-#[path = "tests/unresolved_def_eval_cache_backstop_tests.rs"]
-mod unresolved_def_eval_cache_backstop_tests;
-#[cfg(test)]
-#[path = "tests/variadic_tuple_alias_display_tests.rs"]
-mod variadic_tuple_alias_display_tests;
-#[cfg(test)]
-#[path = "tests/variadic_tuple_constraint_literal_preservation_tests.rs"]
-mod variadic_tuple_constraint_literal_preservation_tests;
 #[cfg(test)]
 #[path = "../tests/variadic_tuple_elaboration_tests.rs"]
 mod variadic_tuple_elaboration_tests;
@@ -1908,20 +627,11 @@ mod variadic_tuple_elaboration_tests;
 #[path = "../tests/variadic_tuple_readonly_relation_tests.rs"]
 mod variadic_tuple_readonly_relation_tests;
 #[cfg(test)]
-#[path = "tests/variadic_tuple_spread_element_inference_tests.rs"]
-mod variadic_tuple_spread_element_inference_tests;
-#[cfg(test)]
 #[path = "../tests/variadic_tuple_tail_arity_inference_tests.rs"]
 mod variadic_tuple_tail_arity_inference_tests;
 #[cfg(test)]
 #[path = "../tests/void_param_optionality_tests.rs"]
 mod void_param_optionality_tests;
-#[cfg(test)]
-#[path = "tests/void_undefined_discriminant_narrowing_tests.rs"]
-mod void_undefined_discriminant_narrowing_tests;
-#[cfg(test)]
-#[path = "tests/zod_type_query_regression_tests.rs"]
-mod zod_type_query_regression_tests;
 
 // Re-export key types
 pub use context::{CheckerContext, CheckerOptions, EnclosingClassInfo, TypeCache};

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -481,6 +481,9 @@ mod jsdoc_typedef_bare_import_tests;
 #[path = "../tests/jsx_component_attribute_tests.rs"]
 mod jsx_component_attribute_tests;
 #[cfg(test)]
+#[path = "tests/jump_statement_class_member_boundary_tests.rs"]
+mod jump_statement_class_member_boundary_tests;
+#[cfg(test)]
 #[path = "tests/keyof_type_parameter_deferred_heritage_tests.rs"]
 mod keyof_type_parameter_deferred_heritage_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
@@ -676,22 +676,12 @@ impl<'a> CheckerState<'a> {
         };
         self.ctx.push_generator_next_type(contextual_next_type);
 
-        // Save and reset control flow context (function body creates new context)
-        let saved_cf_context = (
-            self.ctx.iteration_depth,
-            self.ctx.switch_depth,
-            self.ctx.label_stack.len(),
-            self.ctx.had_outer_loop,
-        );
-        // If we were in a loop/switch, or already had an outer loop, mark it
-        if self.ctx.iteration_depth > 0 || self.ctx.switch_depth > 0 || self.ctx.had_outer_loop {
-            self.ctx.had_outer_loop = true;
-        }
-        self.ctx.iteration_depth = 0;
-        self.ctx.switch_depth = 0;
+        // Save and reset control flow context (function body creates new context).
+        // Labels stay visible for the body's duration — only the stack length is
+        // saved — so a labeled jump still decides TS1107 by comparing the
+        // label's `function_depth` against the raised one.
+        let saved_cf_context = self.ctx.enter_function_like_control_flow();
         self.ctx.function_depth += 1;
-        // Note: we don't truncate label_stack here - labels remain visible
-        // but function_depth is used to detect crosses over function boundary
 
         // Save outer generator's yield collection state (for nested generators)
         let saved_yield_collection = std::mem::take(&mut self.ctx.generator_yield_operand_types);
@@ -756,11 +746,8 @@ impl<'a> CheckerState<'a> {
         self.ctx.generator_had_ts7057 = saved_had_ts7057;
 
         // Restore control flow context
-        self.ctx.iteration_depth = saved_cf_context.0;
-        self.ctx.switch_depth = saved_cf_context.1;
         self.ctx.function_depth -= 1;
-        self.ctx.label_stack.truncate(saved_cf_context.2);
-        self.ctx.had_outer_loop = saved_cf_context.3;
+        self.ctx.exit_function_like_control_flow(saved_cf_context);
 
         // Check return path analysis (TS2355/TS2366/TS2534/TS7030)
         self.check_function_return_paths(

--- a/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
@@ -1347,20 +1347,9 @@ impl<'a> CheckerState<'a> {
                 if let Some(block) = self.ctx.arena.get_block(node) {
                     let prev_unreachable = self.ctx.is_unreachable;
                     let prev_reported = self.ctx.has_reported_unreachable;
-                    let saved_cf_context = (
-                        self.ctx.iteration_depth,
-                        self.ctx.switch_depth,
-                        self.ctx.label_stack.len(),
-                        self.ctx.had_outer_loop,
-                    );
-                    if self.ctx.iteration_depth > 0
-                        || self.ctx.switch_depth > 0
-                        || self.ctx.had_outer_loop
-                    {
-                        self.ctx.had_outer_loop = true;
-                    }
-                    self.ctx.iteration_depth = 0;
-                    self.ctx.switch_depth = 0;
+                    // The loop/switch/label reset that used to be hand-copied
+                    // here now rides along with the member-body boundary, so
+                    // every member kind gets it — see `enter_class_member_body`.
                     let saved_member_body_depth = self.ctx.enter_class_member_body();
                     // Check each statement in the block
                     for &stmt_idx in &block.statements.nodes {
@@ -1370,11 +1359,7 @@ impl<'a> CheckerState<'a> {
                             self.ctx.is_unreachable = true;
                         }
                     }
-                    self.ctx.iteration_depth = saved_cf_context.0;
-                    self.ctx.switch_depth = saved_cf_context.1;
                     self.ctx.exit_class_member_body(saved_member_body_depth);
-                    self.ctx.label_stack.truncate(saved_cf_context.2);
-                    self.ctx.had_outer_loop = saved_cf_context.3;
                     self.ctx.is_unreachable = prev_unreachable;
                     self.ctx.has_reported_unreachable = prev_reported;
                 }

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -1,0 +1,883 @@
+//! Registration of the crate's in-`src` test modules.
+//!
+//! `#[cfg(test)] #[path = "..."] mod ...;` triples are three lines each, and at
+//! 432 of them they dominated `lib.rs` — which sits against the 2000-line
+//! architecture cap, so unrelated checker PRs collided here and each new test
+//! module pushed the file closer to failing `arch-size`. Keeping them in their
+//! own file makes the cost of adding a test module one line in a file that has
+//! room for it.
+//!
+//! Paths stay exactly as they were in `lib.rs`: `#[path]` on a non-inline
+//! module resolves against the directory holding the file that declares it, and
+//! this file sits in `src/` alongside `lib.rs`, so `tests/x.rs` still means
+//! `src/tests/x.rs`. The whole module is already `#[cfg(test)]` at its
+//! declaration in `lib.rs`, so the per-entry `#[cfg(test)]` is not repeated.
+//!
+//! Modules under `crates/tsz-checker/tests/` are deliberately NOT registered
+//! here — several of them use `use super::*` and must stay children of the
+//! crate root for that to resolve.
+
+#[path = "tests/alias_application_display_retention_tests.rs"]
+mod alias_application_display_retention_tests;
+#[path = "tests/any_parameter_never_opposite_tests.rs"]
+mod any_parameter_never_opposite_tests;
+#[path = "tests/application_arg_concrete_index_access_display_tests.rs"]
+mod application_arg_concrete_index_access_display_tests;
+#[path = "tests/application_target_any_arg_assignability_tests.rs"]
+mod application_target_any_arg_assignability_tests;
+#[path = "tests/application_unknown_args_assignability_tests.rs"]
+mod application_unknown_args_assignability_tests;
+#[path = "tests/architecture_contract_tests.rs"]
+mod architecture_contract_tests_src;
+#[path = "tests/array_elaboration_relation_routing_arch_tests.rs"]
+mod array_elaboration_relation_routing_arch_tests;
+#[path = "tests/array_like_constraint_relation_routing_arch_tests.rs"]
+mod array_like_constraint_relation_routing_arch_tests;
+#[path = "tests/array_literal_relation_routing_arch_tests.rs"]
+mod array_literal_relation_routing_arch_tests;
+#[path = "tests/array_literal_spread_inference_widening_tests.rs"]
+mod array_literal_spread_inference_widening_tests;
+#[path = "tests/as_const_nested_literal_display_tests.rs"]
+mod as_const_nested_literal_display_tests;
+#[path = "tests/assertion_thenable_comparability_tests.rs"]
+mod assertion_thenable_comparability_tests;
+#[path = "tests/assertion_type_predicate_diagnostics_tests.rs"]
+mod assertion_type_predicate_diagnostics_tests;
+#[path = "tests/assign_to_import_shadowing_local_tests.rs"]
+mod assign_to_import_shadowing_local_tests;
+#[path = "tests/assignability_diagnostics_relation_routing_arch_tests.rs"]
+mod assignability_diagnostics_relation_routing_arch_tests;
+#[path = "tests/assignability_display_relation_routing_arch_tests.rs"]
+mod assignability_display_relation_routing_arch_tests;
+#[path = "tests/assignability_eval_memo_tests.rs"]
+mod assignability_eval_memo_tests;
+#[path = "tests/assignability_failure_memo_tests.rs"]
+mod assignability_failure_memo_tests;
+#[path = "tests/assignability_index_access_normalization_boundary_arch_tests.rs"]
+mod assignability_index_access_normalization_boundary_arch_tests;
+#[path = "tests/assignability_reporter_relation_routing_arch_tests.rs"]
+mod assignability_reporter_relation_routing_arch_tests;
+#[path = "tests/assignability_type_comparability_relation_routing_arch_tests.rs"]
+mod assignability_type_comparability_relation_routing_arch_tests;
+#[path = "tests/assignment_ops_relation_routing_arch_tests.rs"]
+mod assignment_ops_relation_routing_arch_tests;
+#[path = "tests/async_generator_yieldstar_contribution_tests.rs"]
+mod async_generator_yieldstar_contribution_tests;
+#[path = "tests/async_generator_yieldstar_union_delegate_tests.rs"]
+mod async_generator_yieldstar_union_delegate_tests;
+#[path = "tests/await_alias_union_distribution_tests.rs"]
+mod await_alias_union_distribution_tests;
+#[path = "tests/await_concise_arrow_body_grammar_tests.rs"]
+mod await_concise_arrow_body_grammar_tests;
+#[path = "tests/await_grammar_computed_property_name_tests.rs"]
+mod await_grammar_computed_property_name_tests;
+#[path = "tests/await_grammar_expression_position_tests.rs"]
+mod await_grammar_expression_position_tests;
+#[path = "tests/await_grammar_statement_position_tests.rs"]
+mod await_grammar_statement_position_tests;
+#[path = "tests/await_static_block_grammar_tests.rs"]
+mod await_static_block_grammar_tests;
+#[path = "tests/await_structural_thenable_tests.rs"]
+mod await_structural_thenable_tests;
+#[path = "tests/base_type_param_default_inheritance_tests.rs"]
+mod base_type_param_default_inheritance_tests;
+#[path = "tests/bind_overloaded_receiver_preserves_signatures_tests.rs"]
+mod bind_overloaded_receiver_preserves_signatures_tests;
+#[path = "tests/boolean_literal_union_narrowing_tests.rs"]
+mod boolean_literal_union_narrowing_tests;
+#[path = "tests/boxed_global_env_authority_tests.rs"]
+mod boxed_global_env_authority_tests;
+#[path = "tests/builtin_iterator_implements_tests.rs"]
+mod builtin_iterator_implements_tests;
+#[path = "tests/call_architecture_tests.rs"]
+mod call_architecture_tests;
+#[path = "tests/call_checker_diagnostic_relation_routing_arch_tests.rs"]
+mod call_checker_diagnostic_relation_routing_arch_tests;
+#[path = "tests/call_context_relation_routing_arch_tests.rs"]
+mod call_context_relation_routing_arch_tests;
+#[path = "tests/call_display_format_relation_routing_arch_tests.rs"]
+mod call_display_format_relation_routing_arch_tests;
+#[path = "tests/call_elaboration_mutual_relation_routing_arch_tests.rs"]
+mod call_elaboration_mutual_relation_routing_arch_tests;
+#[path = "tests/call_error_anchor_relation_routing_arch_tests.rs"]
+mod call_error_anchor_relation_routing_arch_tests;
+#[path = "tests/call_error_elaboration_relation_routing_arch_tests.rs"]
+mod call_error_elaboration_relation_routing_arch_tests;
+#[path = "tests/call_result_constraint_violation_gateway_arch_tests.rs"]
+mod call_result_constraint_violation_gateway_arch_tests;
+#[path = "tests/call_result_relation_routing_arch_tests.rs"]
+mod call_result_relation_routing_arch_tests;
+#[path = "tests/call_spread_constructor_parameters_tests.rs"]
+mod call_spread_constructor_parameters_tests;
+#[path = "tests/callable_constraint_function_identity_tests.rs"]
+mod callable_constraint_function_identity_tests;
+#[path = "tests/callable_interface_assignment_tests.rs"]
+mod callable_interface_assignment_tests;
+#[path = "tests/callable_union_relation_routing_arch_tests.rs"]
+mod callable_union_relation_routing_arch_tests;
+#[path = "tests/circular_export_star_const_value_tests.rs"]
+mod circular_export_star_const_value_tests;
+#[path = "tests/circular_initializer_deferred_generic_tests.rs"]
+mod circular_initializer_deferred_generic_tests;
+#[path = "tests/class_boundary_fallback_relation_routing_arch_tests.rs"]
+mod class_boundary_fallback_relation_routing_arch_tests;
+#[path = "tests/class_constructor_private_static_recovery_tests.rs"]
+mod class_constructor_private_static_recovery_tests;
+#[path = "tests/class_duplicate_extends_skip_resolution_tests.rs"]
+mod class_duplicate_extends_skip_resolution_tests;
+#[path = "tests/class_extends_generic_override_variance_tests.rs"]
+mod class_extends_generic_override_variance_tests;
+#[path = "tests/class_extends_index_relation_routing_arch_tests.rs"]
+mod class_extends_index_relation_routing_arch_tests;
+#[path = "tests/class_feature_target_gates_tests.rs"]
+mod class_feature_target_gates_tests;
+#[path = "tests/class_implements_abstract_member_compat_tests.rs"]
+mod class_implements_abstract_member_compat_tests;
+#[path = "tests/class_implements_generic_override_variance_tests.rs"]
+mod class_implements_generic_override_variance_tests;
+#[path = "tests/class_implements_index_relation_routing_arch_tests.rs"]
+mod class_implements_index_relation_routing_arch_tests;
+#[path = "tests/class_implements_jsdoc_heritage_relation_routing_arch_tests.rs"]
+mod class_implements_jsdoc_heritage_relation_routing_arch_tests;
+#[path = "tests/class_implements_whole_type_relation_routing_arch_tests.rs"]
+mod class_implements_whole_type_relation_routing_arch_tests;
+#[path = "tests/class_member_circular_return_tests.rs"]
+mod class_member_circular_return_tests;
+#[path = "tests/class_member_modifier_grammar_first_error_wins_tests.rs"]
+mod class_member_modifier_grammar_first_error_wins_tests;
+#[path = "tests/class_namespace_static_relation_routing_arch_tests.rs"]
+mod class_namespace_static_relation_routing_arch_tests;
+#[path = "tests/class_static_init_self_new_tests.rs"]
+mod class_static_init_self_new_tests;
+#[path = "tests/class_static_side_relation_routing_arch_tests.rs"]
+mod class_static_side_relation_routing_arch_tests;
+#[path = "tests/closure_destructuring_top_level_diagnostics_tests.rs"]
+mod closure_destructuring_top_level_diagnostics_tests;
+#[path = "tests/comlink_row_regression_tests.rs"]
+mod comlink_row_regression_tests;
+#[path = "tests/commonjs_export_assignment_chain_tests.rs"]
+mod commonjs_export_assignment_chain_tests;
+#[path = "tests/commonjs_export_declaration_level_type_tests.rs"]
+mod commonjs_export_declaration_level_type_tests;
+#[path = "tests/commonjs_reentrant_surface_tests.rs"]
+mod commonjs_reentrant_surface_tests;
+#[path = "tests/commonjs_require_binding_type_meaning_tests.rs"]
+mod commonjs_require_binding_type_meaning_tests;
+#[path = "tests/computed_alias_source_display_tests.rs"]
+mod computed_alias_source_display_tests;
+#[path = "tests/computed_symbol_name_unification_tests.rs"]
+mod computed_symbol_name_unification_tests;
+#[path = "tests/concise_body_return_excess_property_tests.rs"]
+mod concise_body_return_excess_property_tests;
+#[path = "tests/conditional_break_narrowing_tests.rs"]
+mod conditional_break_narrowing_tests;
+#[path = "tests/conditional_constraint_relation_routing_arch_tests.rs"]
+mod conditional_constraint_relation_routing_arch_tests;
+#[path = "tests/conditional_flow_substitution_ts2344_tests.rs"]
+mod conditional_flow_substitution_ts2344_tests;
+#[path = "tests/conditional_narrowed_index_through_generic_alias_tests.rs"]
+mod conditional_narrowed_index_through_generic_alias_tests;
+#[path = "tests/conditional_never_param_inference_tests.rs"]
+mod conditional_never_param_inference_tests;
+#[path = "tests/const_asserted_return_type_tests.rs"]
+mod const_asserted_return_type_tests;
+#[path = "tests/constraint_position_nullable_access_tests.rs"]
+mod constraint_position_nullable_access_tests;
+#[path = "tests/constraint_validation_relation_routing_arch_tests.rs"]
+mod constraint_validation_relation_routing_arch_tests;
+#[path = "tests/contextual_callback_shadowed_type_param_tests.rs"]
+mod contextual_callback_shadowed_type_param_tests;
+#[path = "tests/contextual_new_relation_routing_arch_tests.rs"]
+mod contextual_new_relation_routing_arch_tests;
+#[path = "tests/contextual_return_wrapper_tests.rs"]
+mod contextual_return_wrapper_tests;
+#[path = "tests/cross_file_class_instance_publication_tests.rs"]
+mod cross_file_class_instance_publication_tests;
+#[path = "tests/cross_file_generic_alias_union_implements_tests.rs"]
+mod cross_file_generic_alias_union_implements_tests;
+#[path = "tests/cross_file_in_operator_indexed_element_narrowing_tests.rs"]
+mod cross_file_in_operator_indexed_element_narrowing_tests;
+#[path = "tests/cross_file_interface_property_access_tests.rs"]
+mod cross_file_interface_property_access_tests;
+#[path = "tests/cross_file_merged_symbol_value_computed_key_tests.rs"]
+mod cross_file_merged_symbol_value_computed_key_tests;
+#[path = "tests/cross_file_type_param_decl_identity_tests.rs"]
+mod cross_file_type_param_decl_identity_tests;
+#[path = "tests/cross_file_unresolved_alias_union_simplification_tests.rs"]
+mod cross_file_unresolved_alias_union_simplification_tests;
+#[path = "tests/cross_module_class_self_member_tests.rs"]
+mod cross_module_class_self_member_tests;
+#[path = "tests/cross_module_generic_interface_heritage_tests.rs"]
+mod cross_module_generic_interface_heritage_tests;
+#[path = "tests/declaration_extract_key_path_tests.rs"]
+mod declaration_extract_key_path_tests;
+#[path = "tests/declared_signature_return_literal_display_tests.rs"]
+mod declared_signature_return_literal_display_tests;
+#[path = "tests/decorator_return_relation_routing_arch_tests.rs"]
+mod decorator_return_relation_routing_arch_tests;
+#[path = "tests/defaulted_param_deferred_undefined_strip_tests.rs"]
+mod defaulted_param_deferred_undefined_strip_tests;
+#[path = "tests/definite_assignment_logical_compound_tests.rs"]
+mod definite_assignment_logical_compound_tests;
+#[path = "tests/destructured_binding_narrowed_property_tests.rs"]
+mod destructured_binding_narrowed_property_tests;
+#[path = "tests/destructured_discriminant_source_narrowing_tests.rs"]
+mod destructured_discriminant_source_narrowing_tests;
+#[path = "tests/destructuring_relation_routing_arch_tests.rs"]
+mod destructuring_relation_routing_arch_tests;
+#[path = "tests/diagnostic_sink_message_surgery_arch_tests.rs"]
+mod diagnostic_sink_message_surgery_arch_tests;
+#[path = "tests/diagnostic_source_relation_routing_arch_tests.rs"]
+mod diagnostic_source_relation_routing_arch_tests;
+#[path = "tests/direct_generic_return_tests.rs"]
+mod direct_generic_return_tests;
+#[path = "tests/dispatch_tests.rs"]
+mod dispatch_tests;
+#[path = "tests/display_keyof_alias_budget_tests.rs"]
+mod display_keyof_alias_budget_tests;
+#[path = "tests/display_normalization_budget_tests.rs"]
+mod display_normalization_budget_tests;
+#[path = "tests/do_while_exit_narrowing_tests.rs"]
+mod do_while_exit_narrowing_tests;
+#[path = "tests/dom_fuel_exhaustion_ts2322_tests.rs"]
+mod dom_fuel_exhaustion_ts2322_tests;
+#[path = "tests/duplicate_identifier_relation_routing_arch_tests.rs"]
+mod duplicate_identifier_relation_routing_arch_tests;
+#[path = "tests/dynamic_import_relation_routing_arch_tests.rs"]
+mod dynamic_import_relation_routing_arch_tests;
+#[path = "tests/enclosing_type_param_default_scope_tests.rs"]
+mod enclosing_type_param_default_scope_tests;
+#[path = "tests/enum_computed_relation_routing_arch_tests.rs"]
+mod enum_computed_relation_routing_arch_tests;
+#[path = "tests/enum_residual_narrowing_tests.rs"]
+mod enum_residual_narrowing_tests;
+#[path = "tests/error_reporter_assignability_display_boundary_arch_tests.rs"]
+mod error_reporter_assignability_display_boundary_arch_tests;
+#[path = "tests/excess_prop_object_union_display_tests.rs"]
+mod excess_prop_object_union_display_tests;
+#[path = "tests/expando_annotated_receiver_tests.rs"]
+mod expando_annotated_receiver_tests;
+#[path = "tests/explicit_alias_constraint_relation_routing_arch_tests.rs"]
+mod explicit_alias_constraint_relation_routing_arch_tests;
+#[path = "tests/explicit_type_arg_overload_pruning_tests.rs"]
+mod explicit_type_arg_overload_pruning_tests;
+#[path = "tests/flow_assignment_relation_routing_arch_tests.rs"]
+mod flow_assignment_relation_routing_arch_tests;
+#[path = "tests/flow_cache_policy_arch_tests.rs"]
+mod flow_cache_policy_arch_tests;
+#[path = "tests/flow_for_of_destructure_closure_assignment_tests.rs"]
+mod flow_for_of_destructure_closure_assignment_tests;
+#[path = "tests/flow_guard_boundary_tests.rs"]
+mod flow_guard_boundary_tests;
+#[path = "tests/flow_inferred_predicate_boundary_tests.rs"]
+mod flow_inferred_predicate_boundary_tests;
+#[path = "tests/flow_promise_identity_tests.rs"]
+mod flow_promise_identity_tests;
+#[path = "tests/flow_truthy_proves_assignment_tests.rs"]
+mod flow_truthy_proves_assignment_tests;
+#[path = "tests/flow_usage_relation_routing_arch_tests.rs"]
+mod flow_usage_relation_routing_arch_tests;
+#[path = "tests/for_await_non_async_function_body_tests.rs"]
+mod for_await_non_async_function_body_tests;
+#[path = "tests/for_in_lhs_relation_routing_arch_tests.rs"]
+mod for_in_lhs_relation_routing_arch_tests;
+#[path = "tests/fresh_const_array_mutable_assignment_tests.rs"]
+mod fresh_const_array_mutable_assignment_tests;
+#[path = "tests/fresh_object_literal_array_like_union_drill_gate_tests.rs"]
+mod fresh_object_literal_array_like_union_drill_gate_tests;
+#[path = "tests/fresh_object_literal_union_literal_kind_display_tests.rs"]
+mod fresh_object_literal_union_literal_kind_display_tests;
+#[path = "tests/function_callee_spread_ts2556_tests.rs"]
+mod function_callee_spread_ts2556_tests;
+#[path = "tests/function_parameter_mismatch_elaboration_tests.rs"]
+mod function_parameter_mismatch_elaboration_tests;
+#[path = "tests/function_type_relation_routing_arch_tests.rs"]
+mod function_type_relation_routing_arch_tests;
+#[path = "tests/function_type_return_node_tests.rs"]
+mod function_type_return_node_tests;
+#[path = "tests/generator_declaration_yield_star_inference_tests.rs"]
+mod generator_declaration_yield_star_inference_tests;
+#[path = "tests/generator_default_type_argument_relation_tests.rs"]
+mod generator_default_type_argument_relation_tests;
+#[path = "tests/generator_inferred_yield_star_array_generic_call_tests.rs"]
+mod generator_inferred_yield_star_array_generic_call_tests;
+#[path = "tests/generator_yield_identity_tests.rs"]
+mod generator_yield_identity_tests;
+#[path = "tests/generator_yield_literal_widening_tests.rs"]
+mod generator_yield_literal_widening_tests;
+#[path = "tests/generator_yield_self_similar_nesting_tests.rs"]
+mod generator_yield_self_similar_nesting_tests;
+#[path = "tests/generator_yieldstar_symbol_iterator_contribution_tests.rs"]
+mod generator_yieldstar_symbol_iterator_contribution_tests;
+#[path = "tests/generic_alias_application_display_tests.rs"]
+mod generic_alias_application_display_tests;
+#[path = "tests/generic_argument_suppression_relation_routing_arch_tests.rs"]
+mod generic_argument_suppression_relation_routing_arch_tests;
+#[path = "tests/generic_call_enclosing_type_param_return_tests.rs"]
+mod generic_call_enclosing_type_param_return_tests;
+#[path = "tests/generic_call_non_fresh_object_widening_tests.rs"]
+mod generic_call_non_fresh_object_widening_tests;
+#[path = "tests/generic_callable_outer_type_param_mismatch_tests.rs"]
+mod generic_callable_outer_type_param_mismatch_tests;
+#[path = "tests/generic_callback_outer_context_tests.rs"]
+mod generic_callback_outer_context_tests;
+#[path = "tests/generic_callback_return_outer_annotation_leak_tests.rs"]
+mod generic_callback_return_outer_annotation_leak_tests;
+#[path = "tests/generic_callback_sibling_arg_inference_tests.rs"]
+mod generic_callback_sibling_arg_inference_tests;
+#[path = "tests/generic_checker_mod_relation_routing_arch_tests.rs"]
+mod generic_checker_mod_relation_routing_arch_tests;
+#[path = "tests/generic_class_constructor_literal_preservation_tests.rs"]
+mod generic_class_constructor_literal_preservation_tests;
+#[path = "tests/generic_class_self_ref_method_param_tests.rs"]
+mod generic_class_self_ref_method_param_tests;
+#[path = "tests/generic_default_application_arg_preservation_tests.rs"]
+mod generic_default_application_arg_preservation_tests;
+#[path = "tests/generic_function_param_name_collision_assignability_tests.rs"]
+mod generic_function_param_name_collision_assignability_tests;
+#[path = "tests/generic_instantiation_boundary_cache_tests.rs"]
+mod generic_instantiation_boundary_cache_tests;
+#[path = "tests/generic_method_member_variance_assignability_tests.rs"]
+mod generic_method_member_variance_assignability_tests;
+#[path = "tests/generic_method_override_variance_tests.rs"]
+mod generic_method_override_variance_tests;
+#[path = "tests/generic_mixed_inheritance_chain_tests.rs"]
+mod generic_mixed_inheritance_chain_tests;
+#[path = "tests/generic_rest_satisfies_anchor_tests.rs"]
+mod generic_rest_satisfies_anchor_tests;
+#[path = "tests/generic_rest_tuple_contextual_return_tests.rs"]
+mod generic_rest_tuple_contextual_return_tests;
+#[path = "tests/generic_signature_context_instantiation_tests.rs"]
+mod generic_signature_context_instantiation_tests;
+#[path = "tests/generic_spread_iterability_tests.rs"]
+mod generic_spread_iterability_tests;
+#[path = "tests/generic_unknown_type_arg_tests.rs"]
+mod generic_unknown_type_arg_tests;
+#[path = "tests/generics_relation_routing_arch_tests.rs"]
+mod generics_relation_routing_arch_tests;
+#[path = "tests/global_augmentation_computed_key_tests.rs"]
+mod global_augmentation_computed_key_tests;
+#[path = "tests/global_augmentation_structural_lookup_arch_tests.rs"]
+mod global_augmentation_structural_lookup_arch_tests;
+#[path = "tests/global_this_typeof_surface_tests.rs"]
+mod global_this_typeof_surface_tests;
+#[path = "tests/heritage_constraint_structural_name_lookup_arch_tests.rs"]
+mod heritage_constraint_structural_name_lookup_arch_tests;
+#[path = "tests/heritage_flow_narrowed_base_tests.rs"]
+mod heritage_flow_narrowed_base_tests;
+#[path = "tests/higher_order_regeneralization_tests.rs"]
+mod higher_order_regeneralization_tests;
+#[path = "tests/homomorphic_mapped_member_override_tests.rs"]
+mod homomorphic_mapped_member_override_tests;
+#[path = "tests/identifier_relation_routing_arch_tests.rs"]
+mod identifier_relation_routing_arch_tests;
+#[path = "tests/import_attributes_relation_routing_arch_tests.rs"]
+mod import_attributes_relation_routing_arch_tests;
+#[path = "tests/import_shadows_global_ctor_tests.rs"]
+mod import_shadows_global_ctor_tests;
+#[path = "tests/imported_predicate_false_branch_tests.rs"]
+mod imported_predicate_false_branch_tests;
+#[path = "tests/in_narrow_aliased_union_tests.rs"]
+mod in_narrow_aliased_union_tests;
+#[path = "tests/in_narrow_apparent_member_tests.rs"]
+mod in_narrow_apparent_member_tests;
+#[path = "tests/in_narrow_bare_type_param_chained_tests.rs"]
+mod in_narrow_bare_type_param_chained_tests;
+#[path = "tests/in_operator_relation_routing_arch_tests.rs"]
+mod in_operator_relation_routing_arch_tests;
+#[path = "tests/index_sig_param_intersection_validity_tests.rs"]
+mod index_sig_param_intersection_validity_tests;
+#[path = "tests/index_sig_param_resolved_key_type_tests.rs"]
+mod index_sig_param_resolved_key_type_tests;
+#[path = "tests/index_signature_check_relation_routing_arch_tests.rs"]
+mod index_signature_check_relation_routing_arch_tests;
+#[path = "tests/index_signature_nested_object_literal_elaboration_tests.rs"]
+mod index_signature_nested_object_literal_elaboration_tests;
+#[path = "tests/index_signature_property_relation_routing_arch_tests.rs"]
+mod index_signature_property_relation_routing_arch_tests;
+#[path = "tests/index_signature_symbol_keyspace_tests.rs"]
+mod index_signature_symbol_keyspace_tests;
+#[path = "tests/index_signature_value_relation_routing_arch_tests.rs"]
+mod index_signature_value_relation_routing_arch_tests;
+#[path = "tests/indexed_access_callable_member_constraint_ts2344_tests.rs"]
+mod indexed_access_callable_member_constraint_ts2344_tests;
+#[path = "tests/indexed_access_constraint_relation_routing_arch_tests.rs"]
+mod indexed_access_constraint_relation_routing_arch_tests;
+#[path = "tests/infer_conditional_relation_routing_arch_tests.rs"]
+mod infer_conditional_relation_routing_arch_tests;
+#[path = "tests/inferred_return_object_array_widening_tests.rs"]
+mod inferred_return_object_array_widening_tests;
+#[path = "tests/initializer_relation_routing_arch_tests.rs"]
+mod initializer_relation_routing_arch_tests;
+#[path = "tests/instanceof_indexed_access_lhs_tests.rs"]
+mod instanceof_indexed_access_lhs_tests;
+#[path = "tests/instantiation_expression_inline_utility_modifier_tests.rs"]
+mod instantiation_expression_inline_utility_modifier_tests;
+#[path = "tests/instantiation_expression_lib_display_tests.rs"]
+mod instantiation_expression_lib_display_tests;
+#[path = "tests/interface_extends_generic_override_variance_tests.rs"]
+mod interface_extends_generic_override_variance_tests;
+#[path = "tests/interface_heritage_alias_arg_substitution_tests.rs"]
+mod interface_heritage_alias_arg_substitution_tests;
+#[path = "tests/interface_heritage_index_relation_routing_arch_tests.rs"]
+mod interface_heritage_index_relation_routing_arch_tests;
+#[path = "tests/interface_heritage_property_index_relation_routing_arch_tests.rs"]
+mod interface_heritage_property_index_relation_routing_arch_tests;
+#[path = "tests/interface_index_conflict_relation_routing_arch_tests.rs"]
+mod interface_index_conflict_relation_routing_arch_tests;
+#[path = "tests/intersection_callable_constraint_ts2344_tests.rs"]
+mod intersection_callable_constraint_ts2344_tests;
+#[path = "tests/intersection_source_literal_member_display_tests.rs"]
+mod intersection_source_literal_member_display_tests;
+#[path = "tests/intersection_target_elaboration_tests.rs"]
+mod intersection_target_elaboration_tests;
+#[path = "tests/invocation_signature_detail_tests.rs"]
+mod invocation_signature_detail_tests;
+#[path = "tests/issue_9762_literal_init_callback_inference.rs"]
+mod issue_9762_literal_init_callback_inference;
+#[path = "tests/iterable_next_relation_routing_arch_tests.rs"]
+mod iterable_next_relation_routing_arch_tests;
+#[path = "tests/js_expando_order_sensitivity_tests.rs"]
+mod js_expando_order_sensitivity_tests;
+#[path = "tests/js_open_object_property_access_tests.rs"]
+mod js_open_object_property_access_tests;
+#[path = "tests/jsdoc_bare_import_type_tests.rs"]
+mod jsdoc_bare_import_type_tests;
+#[path = "tests/jsdoc_cast_and_define_property_widening_tests.rs"]
+mod jsdoc_cast_and_define_property_widening_tests;
+#[path = "tests/jsdoc_closure_function_type_tests.rs"]
+mod jsdoc_closure_function_type_tests;
+#[path = "tests/jsdoc_commonjs_globals_as_type_tests.rs"]
+mod jsdoc_commonjs_globals_as_type_tests;
+#[path = "tests/jsdoc_empty_augments_class_chain_tests.rs"]
+mod jsdoc_empty_augments_class_chain_tests;
+#[path = "tests/jsdoc_import_type_constraints_relation_routing_arch_tests.rs"]
+mod jsdoc_import_type_constraints_relation_routing_arch_tests;
+#[path = "tests/jsdoc_lookup_constraints_relation_routing_arch_tests.rs"]
+mod jsdoc_lookup_constraints_relation_routing_arch_tests;
+#[path = "tests/jsdoc_nested_type_tag_validation_tests.rs"]
+mod jsdoc_nested_type_tag_validation_tests;
+#[path = "tests/jsdoc_overload_call_resolution_tests.rs"]
+mod jsdoc_overload_call_resolution_tests;
+#[path = "tests/jsdoc_retired_tag_diagnostics_tests.rs"]
+mod jsdoc_retired_tag_diagnostics_tests;
+#[path = "tests/jsdoc_shadowed_type_param_identity_tests.rs"]
+mod jsdoc_shadowed_type_param_identity_tests;
+#[path = "tests/jsdoc_template_reference_scope_tests.rs"]
+mod jsdoc_template_reference_scope_tests;
+#[path = "tests/jsdoc_typedef_bare_import_tests.rs"]
+mod jsdoc_typedef_bare_import_tests;
+#[path = "tests/jsdoc_typedef_distinct_alias_names_tests.rs"]
+mod jsdoc_typedef_distinct_alias_names_tests;
+#[path = "tests/jsx_children_relation_routing_arch_tests.rs"]
+mod jsx_children_relation_routing_arch_tests;
+#[path = "tests/jsx_component_props_relation_routing_arch_tests.rs"]
+mod jsx_component_props_relation_routing_arch_tests;
+#[path = "tests/jsx_element_type_constraint_tests.rs"]
+mod jsx_element_type_constraint_tests;
+#[path = "tests/jsx_excess_attr_with_spread_display_tests.rs"]
+mod jsx_excess_attr_with_spread_display_tests;
+#[path = "tests/jsx_generic_spread_relation_routing_arch_tests.rs"]
+mod jsx_generic_spread_relation_routing_arch_tests;
+#[path = "tests/jsx_overload_relation_routing_arch_tests.rs"]
+mod jsx_overload_relation_routing_arch_tests;
+#[path = "tests/jsx_props_resolution_relation_routing_arch_tests.rs"]
+mod jsx_props_resolution_relation_routing_arch_tests;
+#[path = "tests/jsx_props_validation_relation_routing_arch_tests.rs"]
+mod jsx_props_validation_relation_routing_arch_tests;
+#[path = "tests/jsx_react_alias_relation_routing_arch_tests.rs"]
+mod jsx_react_alias_relation_routing_arch_tests;
+#[path = "tests/jsx_render_fallback_relation_routing_arch_tests.rs"]
+mod jsx_render_fallback_relation_routing_arch_tests;
+#[path = "tests/jsx_return_relation_routing_arch_tests.rs"]
+mod jsx_return_relation_routing_arch_tests;
+#[path = "tests/jsx_single_child_precise_relation_routing_arch_tests.rs"]
+mod jsx_single_child_precise_relation_routing_arch_tests;
+#[path = "tests/jsx_spread_assignability_relation_routing_arch_tests.rs"]
+mod jsx_spread_assignability_relation_routing_arch_tests;
+#[path = "tests/jsx_text_child_relation_routing_arch_tests.rs"]
+mod jsx_text_child_relation_routing_arch_tests;
+#[path = "tests/jsx_type_arg_arity_suppresses_ts2604_tests.rs"]
+mod jsx_type_arg_arity_suppresses_ts2604_tests;
+#[path = "tests/jsx_union_props_relation_routing_arch_tests.rs"]
+mod jsx_union_props_relation_routing_arch_tests;
+#[path = "tests/jump_statement_class_member_boundary_tests.rs"]
+mod jump_statement_class_member_boundary_tests;
+#[path = "tests/keyof_alias_composite_display_tests.rs"]
+mod keyof_alias_composite_display_tests;
+#[path = "tests/keyof_suppression_relation_routing_arch_tests.rs"]
+mod keyof_suppression_relation_routing_arch_tests;
+#[path = "tests/keyof_type_parameter_deferred_heritage_tests.rs"]
+mod keyof_type_parameter_deferred_heritage_tests;
+#[path = "tests/lazy_lib_fuel_determinism_tests.rs"]
+mod lazy_lib_fuel_determinism_tests;
+#[path = "tests/lazy_lib_heritage_guard_tests.rs"]
+mod lazy_lib_heritage_guard_tests;
+#[path = "tests/lazy_lib_member_access_tests.rs"]
+mod lazy_lib_member_access_tests;
+#[path = "tests/lib_abstract_member_ts2515_tests.rs"]
+mod lib_abstract_member_ts2515_tests;
+#[path = "tests/libtype_structural_name_lookup_arch_tests.rs"]
+mod libtype_structural_name_lookup_arch_tests;
+#[path = "tests/local_type_alias_shadowing_tests.rs"]
+mod local_type_alias_shadowing_tests;
+#[path = "tests/logical_assignment_member_narrowing_tests.rs"]
+mod logical_assignment_member_narrowing_tests;
+#[path = "tests/loop_self_referential_property_read_tests.rs"]
+mod loop_self_referential_property_read_tests;
+#[path = "tests/mapped_infer_with_substitution_tests.rs"]
+mod mapped_infer_with_substitution_tests;
+#[path = "tests/mapped_intersection_excess_property_tests.rs"]
+mod mapped_intersection_excess_property_tests;
+#[path = "tests/mapped_keyof_remap_excess_property_tests.rs"]
+mod mapped_keyof_remap_excess_property_tests;
+#[path = "tests/mapped_optional_target_excess_property_tests.rs"]
+mod mapped_optional_target_excess_property_tests;
+#[path = "tests/mapped_true_base_constraint_relation_routing_arch_tests.rs"]
+mod mapped_true_base_constraint_relation_routing_arch_tests;
+#[path = "tests/member_assignment_narrowing_join_tests.rs"]
+mod member_assignment_narrowing_join_tests;
+#[path = "tests/merged_interface_constraint_relation_routing_arch_tests.rs"]
+mod merged_interface_constraint_relation_routing_arch_tests;
+#[path = "tests/method_return_type_elaboration_tests.rs"]
+mod method_return_type_elaboration_tests;
+#[path = "tests/multi_overload_infer_capture_tests.rs"]
+mod multi_overload_infer_capture_tests;
+#[path = "tests/mutable_binding_widening_from_const_literal_tests.rs"]
+mod mutable_binding_widening_from_const_literal_tests;
+#[path = "tests/namespace_property_mismatch_boundary_arch_tests.rs"]
+mod namespace_property_mismatch_boundary_arch_tests;
+#[path = "tests/narrowed_union_source_display_tests.rs"]
+mod narrowed_union_source_display_tests;
+#[path = "tests/narrowing_union_source_display_tests.rs"]
+mod narrowing_union_source_display_tests;
+#[path = "tests/nested_function_async_context_scope_tests.rs"]
+mod nested_function_async_context_scope_tests;
+#[path = "tests/nested_tuple_literal_source_display_tests.rs"]
+mod nested_tuple_literal_source_display_tests;
+#[path = "tests/nested_type_parameter_target_elaboration_tests.rs"]
+mod nested_type_parameter_target_elaboration_tests;
+#[path = "tests/never_indexed_access_reduction_tests.rs"]
+mod never_indexed_access_reduction_tests;
+#[path = "tests/never_return_import_alias_tests.rs"]
+mod never_return_import_alias_tests;
+#[path = "tests/no_implicit_override_ambient_context_tests.rs"]
+mod no_implicit_override_ambient_context_tests;
+#[path = "tests/no_index_element_implicit_any_tests.rs"]
+mod no_index_element_implicit_any_tests;
+#[path = "tests/nolib_user_global_array_member_tests.rs"]
+mod nolib_user_global_array_member_tests;
+#[path = "tests/non_generic_spread_tuple_alias_display_tests.rs"]
+mod non_generic_spread_tuple_alias_display_tests;
+#[path = "tests/non_strict_non_null_check_narrows_tests.rs"]
+mod non_strict_non_null_check_narrows_tests;
+#[path = "tests/nonunique_symbol_property_access_tests.rs"]
+mod nonunique_symbol_property_access_tests;
+#[path = "tests/noUIA_any_index_emits_ts2322_tests.rs"]
+mod nuia_any_index_emits_ts2322_tests;
+#[path = "tests/noUIA_write_index_signature_emits_ts2322_tests.rs"]
+mod nuia_write_index_signature_emits_ts2322_tests;
+#[path = "tests/nullable_union_callback_variance_tests.rs"]
+mod nullable_union_callback_variance_tests;
+#[path = "tests/nullish_target_relation_routing_arch_tests.rs"]
+mod nullish_target_relation_routing_arch_tests;
+#[path = "tests/nullish_union_indexed_access_missing_property_tests.rs"]
+mod nullish_union_indexed_access_missing_property_tests;
+#[path = "tests/object_define_property_identity_tests.rs"]
+mod object_define_property_identity_tests;
+#[path = "tests/object_global_identity_helper_tests.rs"]
+mod object_global_identity_helper_tests;
+#[path = "tests/object_literal_computed_symbol_member_tests.rs"]
+mod object_literal_computed_symbol_member_tests;
+#[path = "tests/object_literal_method_body_check_tests.rs"]
+mod object_literal_method_body_check_tests;
+#[path = "tests/object_literal_method_this_parameter_contextual_tests.rs"]
+mod object_literal_method_this_parameter_contextual_tests;
+#[path = "tests/object_literal_relation_architecture_tests.rs"]
+mod object_literal_relation_architecture_tests;
+#[path = "tests/object_literal_this_member_order_tests.rs"]
+mod object_literal_this_member_order_tests;
+#[path = "tests/object_property_arrow_param_annotation_elaboration_tests.rs"]
+mod object_property_arrow_param_annotation_elaboration_tests;
+#[path = "tests/object_shorthand_literal_preservation_tests.rs"]
+mod object_shorthand_literal_preservation_tests;
+#[path = "tests/object_spread_discriminant_narrowing_tests.rs"]
+mod object_spread_discriminant_narrowing_tests;
+#[path = "tests/object_spread_optional_merge_tests.rs"]
+mod object_spread_optional_merge_tests;
+#[path = "tests/operator_chain_overload_resolution_tests.rs"]
+mod operator_chain_overload_resolution_tests;
+#[path = "tests/optional_chain_inherent_nullish_tests.rs"]
+mod optional_chain_inherent_nullish_tests;
+#[path = "tests/optional_chain_root_nullish_strict_only_tests.rs"]
+mod optional_chain_root_nullish_strict_only_tests;
+#[path = "tests/optional_key_extraction_tests.rs"]
+mod optional_key_extraction_tests;
+#[path = "tests/optional_private_field_undefined_tests.rs"]
+mod optional_private_field_undefined_tests;
+#[path = "tests/optional_property_union_source_elaboration_tests.rs"]
+mod optional_property_union_source_elaboration_tests;
+#[path = "tests/overlap_relation_helper_routing_arch_tests.rs"]
+mod overlap_relation_helper_routing_arch_tests;
+#[path = "tests/overload_anchor_at_argument_tests.rs"]
+mod overload_anchor_at_argument_tests;
+#[path = "tests/overload_argument_reason_chain_tests.rs"]
+mod overload_argument_reason_chain_tests;
+#[path = "tests/overload_elaboration_tests.rs"]
+mod overload_elaboration_tests;
+#[path = "tests/overload_generic_wrapper_compat_tests.rs"]
+mod overload_generic_wrapper_compat_tests;
+#[path = "tests/overload_literal_source_generalization_tests.rs"]
+mod overload_literal_source_generalization_tests;
+#[path = "tests/overload_param_relation_routing_arch_tests.rs"]
+mod overload_param_relation_routing_arch_tests;
+#[path = "tests/overload_two_pass_any_source_tests.rs"]
+mod overload_two_pass_any_source_tests;
+#[path = "tests/overload_union_context_callback_tests.rs"]
+mod overload_union_context_callback_tests;
+#[path = "tests/overloaded_contextual_rest_tuple_tests.rs"]
+mod overloaded_contextual_rest_tuple_tests;
+#[path = "tests/override_incompatibility_elaboration_tests.rs"]
+mod override_incompatibility_elaboration_tests;
+#[path = "tests/parameter_checker_tests.rs"]
+mod parameter_checker_tests;
+#[path = "tests/partial_pick_indexed_access_write_tests.rs"]
+mod partial_pick_indexed_access_write_tests;
+#[path = "tests/polymorphic_this_relation_routing_arch_tests.rs"]
+mod polymorphic_this_relation_routing_arch_tests;
+#[path = "tests/predicate_narrowed_lib_union_access_tests.rs"]
+mod predicate_narrowed_lib_union_access_tests;
+#[path = "tests/predicate_narrowed_top_type_source_display_tests.rs"]
+mod predicate_narrowed_top_type_source_display_tests;
+#[path = "tests/predicate_narrowed_unknown_any_source_display_tests.rs"]
+mod predicate_narrowed_unknown_any_source_display_tests;
+#[path = "tests/private_field_no_spelling_suggestion_tests.rs"]
+mod private_field_no_spelling_suggestion_tests;
+#[path = "tests/private_member_relation_routing_arch_tests.rs"]
+mod private_member_relation_routing_arch_tests;
+#[path = "tests/private_name_modifier_grammar_order_tests.rs"]
+mod private_name_modifier_grammar_order_tests;
+#[path = "tests/private_optional_field_undefined_tests.rs"]
+mod private_optional_field_undefined_tests;
+#[path = "tests/promise_like_infer_tests.rs"]
+mod promise_like_infer_tests;
+#[path = "tests/promise_this_relation_routing_arch_tests.rs"]
+mod promise_this_relation_routing_arch_tests;
+#[path = "tests/property_alias_display_tests.rs"]
+mod property_alias_display_tests;
+#[path = "tests/property_index_key_relation_routing_arch_tests.rs"]
+mod property_index_key_relation_routing_arch_tests;
+#[path = "tests/property_receiver_display_recursion_overflow_tests.rs"]
+mod property_receiver_display_recursion_overflow_tests;
+#[path = "tests/property_receiver_relation_routing_arch_tests.rs"]
+mod property_receiver_relation_routing_arch_tests;
+#[path = "tests/readonly_assignment_no_flow_narrow_tests.rs"]
+mod readonly_assignment_no_flow_narrow_tests;
+#[path = "tests/readonly_property_assignment_narrowing_tests.rs"]
+mod readonly_property_assignment_narrowing_tests;
+#[path = "tests/recursive_accumulator_depth_tests.rs"]
+mod recursive_accumulator_depth_tests;
+#[path = "tests/recursive_callable_infer_cycle_tests.rs"]
+mod recursive_callable_infer_cycle_tests;
+#[path = "tests/recursive_conditional_infer_termination_tests.rs"]
+mod recursive_conditional_infer_termination_tests;
+#[path = "tests/recursive_generic_arrow_tests.rs"]
+mod recursive_generic_arrow_tests;
+#[path = "tests/recursive_mapped_intersection_nested_excess_property_tests.rs"]
+mod recursive_mapped_intersection_nested_excess_property_tests;
+#[path = "tests/recursive_path_default_type_param_tests.rs"]
+mod recursive_path_default_type_param_tests;
+#[path = "tests/recursive_tuple_alias_diagnostic_display_tests.rs"]
+mod recursive_tuple_alias_diagnostic_display_tests;
+#[path = "tests/recursive_tuple_rest_cycle_tests.rs"]
+mod recursive_tuple_rest_cycle_tests;
+#[path = "tests/reexport_resolution_cache_tests.rs"]
+mod reexport_resolution_cache_tests;
+#[path = "tests/reexported_generic_interface_property_tests.rs"]
+mod reexported_generic_interface_property_tests;
+#[path = "tests/ref_type_params_cache_tests.rs"]
+mod ref_type_params_cache_tests;
+#[path = "tests/relation_flags_boundary_contract_tests.rs"]
+mod relation_flags_boundary_contract_tests;
+#[path = "tests/remapped_missing_property_relation_routing_arch_tests.rs"]
+mod remapped_missing_property_relation_routing_arch_tests;
+#[path = "tests/rest_parameter_relation_routing_arch_tests.rs"]
+mod rest_parameter_relation_routing_arch_tests;
+#[path = "tests/return_alias_unknown_eval_assignability_tests.rs"]
+mod return_alias_unknown_eval_assignability_tests;
+#[path = "tests/return_context_promise_identity_tests.rs"]
+mod return_context_promise_identity_tests;
+#[path = "tests/return_context_type_param_shadowing_tests.rs"]
+mod return_context_type_param_shadowing_tests;
+#[path = "tests/return_relation_routing_arch_tests.rs"]
+mod return_relation_routing_arch_tests;
+#[path = "tests/satisfies_callback_return_widening_tests.rs"]
+mod satisfies_callback_return_widening_tests;
+#[path = "tests/satisfies_relation_routing_arch_tests.rs"]
+mod satisfies_relation_routing_arch_tests;
+#[path = "tests/self_referential_arrow_property_soundness_tests.rs"]
+mod self_referential_arrow_property_soundness_tests;
+#[path = "tests/self_referential_conditional_infer_soundness_tests.rs"]
+mod self_referential_conditional_infer_soundness_tests;
+#[path = "tests/semantic_def_body_read_arch_tests.rs"]
+mod semantic_def_body_read_arch_tests;
+#[path = "tests/shadowed_type_param_identity_tests.rs"]
+mod shadowed_type_param_identity_tests;
+#[path = "tests/split_accessor_variance_tests.rs"]
+mod split_accessor_variance_tests;
+#[path = "tests/spread_array_rest_param_inference_tests.rs"]
+mod spread_array_rest_param_inference_tests;
+#[path = "tests/spurious_suggestion_suppression_tests.rs"]
+mod spurious_suggestion_suppression_tests;
+#[path = "tests/state_type_environment_relation_routing_arch_tests.rs"]
+mod state_type_environment_relation_routing_arch_tests;
+#[path = "tests/strict_callback_param_method_tests.rs"]
+mod strict_callback_param_method_tests;
+#[path = "tests/strict_mode_class_context_name_tests.rs"]
+mod strict_mode_class_context_name_tests;
+#[path = "tests/string_literal_union_display_order_tests.rs"]
+mod string_literal_union_display_order_tests;
+#[path = "tests/suggestion_scan_discarded_tests.rs"]
+mod suggestion_scan_discarded_tests;
+#[path = "tests/super_call_ts2376_ts17009_priority_tests.rs"]
+mod super_call_ts2376_ts17009_priority_tests;
+#[path = "tests/switch_distinct_literal_memo_narrowing_tests.rs"]
+mod switch_distinct_literal_memo_narrowing_tests;
+#[path = "tests/symbol_env_registration_arch_tests.rs"]
+mod symbol_env_registration_arch_tests;
+#[path = "tests/symbol_for_identity_helper_tests.rs"]
+mod symbol_for_identity_helper_tests;
+#[path = "tests/syntax_constraint_relation_routing_arch_tests.rs"]
+mod syntax_constraint_relation_routing_arch_tests;
+#[path = "tests/synthetic_unique_atom_union_display_tests.rs"]
+mod synthetic_unique_atom_union_display_tests;
+#[path = "tests/this_context_self_type_tests.rs"]
+mod this_context_self_type_tests;
+#[path = "tests/this_prop_nullish_operand_code_tests.rs"]
+mod this_prop_nullish_operand_code_tests;
+#[path = "tests/this_source_inference_tests.rs"]
+mod this_source_inference_tests;
+#[path = "tests/this_void_method_call_tests.rs"]
+mod this_void_method_call_tests;
+#[path = "tests/top_level_await_boundary_tests.rs"]
+mod top_level_await_boundary_tests;
+#[path = "tests/truthiness_promise_coercion_tests.rs"]
+mod truthiness_promise_coercion_tests;
+#[path = "tests/ts1101_with_in_strict_mode_tests.rs"]
+mod ts1101_with_in_strict_mode_tests;
+#[path = "tests/ts1170_computed_property_syntactic_form_tests.rs"]
+mod ts1170_computed_property_syntactic_form_tests;
+#[path = "tests/ts1361_ambient_computed_property_name_tests.rs"]
+mod ts1361_ambient_computed_property_name_tests;
+#[path = "tests/ts18010_jsdoc_tag_anchor_tests.rs"]
+mod ts18010_jsdoc_tag_anchor_tests;
+#[path = "tests/ts18050_nullish_keyword_without_strict_null_checks_tests.rs"]
+mod ts18050_nullish_keyword_without_strict_null_checks_tests;
+#[path = "tests/ts2322_private_field_narrowing_write_tests.rs"]
+mod ts2322_private_field_narrowing_write_tests;
+#[path = "tests/ts2322_readonly_array_element_elaboration_tests.rs"]
+mod ts2322_readonly_array_element_elaboration_tests;
+#[path = "tests/ts2322_same_generic_type_argument_elaboration_tests.rs"]
+mod ts2322_same_generic_type_argument_elaboration_tests;
+#[path = "tests/ts2323_block_scoped_conflict_message_tests.rs"]
+mod ts2323_block_scoped_conflict_message_tests;
+#[path = "tests/ts2323_export_var_namespace_merge_tests.rs"]
+mod ts2323_export_var_namespace_merge_tests;
+#[path = "tests/ts2323_mixed_exportedness_two_table_tests.rs"]
+mod ts2323_mixed_exportedness_two_table_tests;
+#[path = "tests/ts2323_variable_redeclaration_two_pass_tests.rs"]
+mod ts2323_variable_redeclaration_two_pass_tests;
+#[path = "tests/ts2339_js_this_function_name_display_tests.rs"]
+mod ts2339_js_this_function_name_display_tests;
+#[path = "tests/ts2341_private_access_via_type_param_constraint_tests.rs"]
+mod ts2341_private_access_via_type_param_constraint_tests;
+#[path = "tests/ts2353_generic_constraint_tests.rs"]
+mod ts2353_generic_constraint_tests;
+#[path = "tests/ts2445_protected_access_via_subclass_this_tests.rs"]
+mod ts2445_protected_access_via_subclass_this_tests;
+#[path = "tests/ts2515_ambient_class_abstract_member_tests.rs"]
+mod ts2515_ambient_class_abstract_member_tests;
+#[path = "tests/ts2536_deferred_conditional_indexed_access_tests.rs"]
+mod ts2536_deferred_conditional_indexed_access_tests;
+#[path = "tests/ts2536_error_type_contagion_tests.rs"]
+mod ts2536_error_type_contagion_tests;
+#[path = "tests/ts2536_nested_generic_indexed_access_constraint_tests.rs"]
+mod ts2536_nested_generic_indexed_access_constraint_tests;
+#[path = "tests/ts2564_constructor_throw_guard_tests.rs"]
+mod ts2564_constructor_throw_guard_tests;
+#[path = "tests/ts2565_jsdoc_prototype_type_decl_tests.rs"]
+mod ts2565_jsdoc_prototype_type_decl_tests;
+#[path = "tests/ts2565_object_literal_nullish_spread_tests.rs"]
+mod ts2565_object_literal_nullish_spread_tests;
+#[path = "tests/ts2574_rest_tuple_element_type_tests.rs"]
+mod ts2574_rest_tuple_element_type_tests;
+#[path = "tests/ts2590_array_literal_identity_skip_tests.rs"]
+mod ts2590_array_literal_identity_skip_tests;
+#[path = "tests/ts2591_node_global_type_position_tests.rs"]
+mod ts2591_node_global_type_position_tests;
+#[path = "tests/ts2739_alias_unfold_display_tests.rs"]
+mod ts2739_alias_unfold_display_tests;
+#[path = "tests/ts7053_apparent_receiver_display_tests.rs"]
+mod ts7053_apparent_receiver_display_tests;
+#[path = "tests/ts7053_index_reason_chain_tests.rs"]
+mod ts7053_index_reason_chain_tests;
+#[path = "tests/ts8030_jsdoc_type_tag_message_tests.rs"]
+mod ts8030_jsdoc_type_tag_message_tests;
+#[path = "tests/tuple_spread_flattening_tests.rs"]
+mod tuple_spread_flattening_tests;
+#[path = "tests/type_alias_computed_display_tests.rs"]
+mod type_alias_computed_display_tests;
+#[path = "tests/type_alias_primitive_display_tests.rs"]
+mod type_alias_primitive_display_tests;
+#[path = "tests/type_analysis_env_merge_arch_tests.rs"]
+mod type_analysis_env_merge_arch_tests;
+#[path = "tests/type_param_default_relation_routing_arch_tests.rs"]
+mod type_param_default_relation_routing_arch_tests;
+#[path = "tests/type_parameter_default_identity_tests.rs"]
+mod type_parameter_default_identity_tests;
+#[path = "tests/type_position_resolution_cache_tests.rs"]
+mod type_position_resolution_cache_tests;
+#[path = "tests/type_predicate_alias_relation_tests.rs"]
+mod type_predicate_alias_relation_tests;
+#[path = "tests/type_predicate_relation_routing_arch_tests.rs"]
+mod type_predicate_relation_routing_arch_tests;
+#[path = "tests/typeof_class_name_structural_lookup_arch_tests.rs"]
+mod typeof_class_name_structural_lookup_arch_tests;
+#[path = "tests/typeof_const_spread_index_access_tests.rs"]
+mod typeof_const_spread_index_access_tests;
+#[path = "tests/typeof_unknown_logical_narrowing_tests.rs"]
+mod typeof_unknown_logical_narrowing_tests;
+#[path = "tests/under_applied_generic_constructor_fill_tests.rs"]
+mod under_applied_generic_constructor_fill_tests;
+#[path = "tests/union_call_resolution_tests.rs"]
+mod union_call_resolution_tests;
+#[path = "tests/union_constraint_relation_routing_arch_tests.rs"]
+mod union_constraint_relation_routing_arch_tests;
+#[path = "tests/union_excess_property_relation_routing_arch_tests.rs"]
+mod union_excess_property_relation_routing_arch_tests;
+#[path = "tests/union_index_signature_relation_routing_arch_tests.rs"]
+mod union_index_signature_relation_routing_arch_tests;
+#[path = "tests/union_multi_overload_unified_sig_tests.rs"]
+mod union_multi_overload_unified_sig_tests;
+#[path = "tests/union_source_literal_target_display_tests.rs"]
+mod union_source_literal_target_display_tests;
+#[path = "tests/union_to_tuple_never_base_depth_tests.rs"]
+mod union_to_tuple_never_base_depth_tests;
+#[path = "tests/unique_symbol_assignment_ts2322_tests.rs"]
+mod unique_symbol_assignment_ts2322_tests;
+#[path = "tests/unique_symbol_member_lookup_family_tests.rs"]
+mod unique_symbol_member_lookup_family_tests;
+#[path = "tests/unresolved_def_eval_cache_backstop_tests.rs"]
+mod unresolved_def_eval_cache_backstop_tests;
+#[path = "tests/variadic_tuple_alias_display_tests.rs"]
+mod variadic_tuple_alias_display_tests;
+#[path = "tests/variadic_tuple_constraint_literal_preservation_tests.rs"]
+mod variadic_tuple_constraint_literal_preservation_tests;
+#[path = "tests/variadic_tuple_spread_element_inference_tests.rs"]
+mod variadic_tuple_spread_element_inference_tests;
+#[path = "tests/void_undefined_discriminant_narrowing_tests.rs"]
+mod void_undefined_discriminant_narrowing_tests;
+#[path = "tests/window_self_globalthis_resolution_tests.rs"]
+mod window_self_globalthis_resolution_tests;
+#[path = "tests/zod_type_query_regression_tests.rs"]
+mod zod_type_query_regression_tests;

--- a/crates/tsz-checker/src/tests/jump_statement_class_member_boundary_tests.rs
+++ b/crates/tsz-checker/src/tests/jump_statement_class_member_boundary_tests.rs
@@ -1,0 +1,299 @@
+//! Regression coverage for #16199: an unlabeled `break`/`continue` inside a
+//! class **method, accessor or constructor** that is itself nested in a loop or
+//! `switch` reported nothing, where `tsc` reports TS1107.
+//!
+//! `tsc`'s `checkGrammarBreakOrContinueStatement` is a single upward walk from
+//! the jump node that stops at the first `isFunctionLikeOrClassStaticBlockDeclaration`
+//! ancestor, so an unlabeled jump can only see iteration and `switch` statements
+//! declared *inside its own innermost function-like*. tsz models that walk as
+//! the ambient `iteration_depth`/`switch_depth` counters on `CheckerContext`,
+//! which therefore have to be zeroed wherever checking descends across such a
+//! boundary. That reset used to be hand-copied at each boundary, and the class
+//! member-body path had exactly one copy — on the **static block** arm — so
+//! every other member kind kept seeing the enclosing loop and stayed silent.
+//!
+//! The reset now rides along with `CheckerContext::enter_class_member_body`,
+//! which all four member kinds already went through, so the hole cannot reopen
+//! for a member kind one at a time.
+//!
+//! Every witness below was pinned against `typescript@7.0.2`
+//! (`--noEmit --strict --target es2022 --lib es2022`). Binder names are varied
+//! across the matrix on purpose: this family is decided structurally, by the
+//! member-body boundary, never by any name.
+
+use crate::test_utils::check_source_codes;
+
+/// TS1107: jump target cannot cross function boundary.
+const TS1107: u32 = 1107;
+/// TS1105: `break` outside any iteration or switch statement.
+const TS1105: u32 = 1105;
+/// TS1104: `continue` outside any iteration statement.
+const TS1104: u32 = 1104;
+
+// ---------------------------------------------------------------------------
+// The four reported false negatives (#16199's witness table).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn break_in_method_nested_in_while_reports_ts1107() {
+    let codes = check_source_codes("while (true) { class C { m() { break; } } }");
+    assert!(
+        codes.contains(&TS1107),
+        "the method body is a function boundary the enclosing `while` cannot be jumped out of; got {codes:?}"
+    );
+}
+
+#[test]
+fn continue_in_getter_nested_in_while_reports_ts1107() {
+    let codes = check_source_codes("while (true) { class C { get g() { continue; } } }");
+    assert!(codes.contains(&TS1107), "got {codes:?}");
+}
+
+#[test]
+fn break_in_method_nested_in_switch_reports_ts1107() {
+    let codes = check_source_codes("switch (1) { case 1: class C { m() { break; } } }");
+    assert!(
+        codes.contains(&TS1107),
+        "a `switch` is a boundary for unlabeled `break` exactly like an iteration statement; got {codes:?}"
+    );
+}
+
+#[test]
+fn break_in_constructor_nested_in_while_reports_ts1107() {
+    let codes = check_source_codes("while (true) { class C { constructor() { break; } } }");
+    assert!(codes.contains(&TS1107), "got {codes:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Adjacent member kinds: setter, static method, class expression, generator,
+// async method. Renamed binders throughout.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn continue_in_setter_nested_in_while_reports_ts1107() {
+    let codes =
+        check_source_codes("while (true) { class Renamed { set s(v: number) { continue; } } }");
+    assert!(codes.contains(&TS1107), "got {codes:?}");
+}
+
+#[test]
+fn break_in_static_method_nested_in_for_of_reports_ts1107() {
+    let codes = check_source_codes("for (const q of [1]) { class Zed { static sm() { break; } } }");
+    assert!(codes.contains(&TS1107), "got {codes:?}");
+}
+
+#[test]
+fn continue_in_method_nested_in_do_while_reports_ts1107() {
+    let codes = check_source_codes("do { class Q { m() { continue; } } } while (false)");
+    assert!(codes.contains(&TS1107), "got {codes:?}");
+}
+
+#[test]
+fn break_in_class_expression_method_reports_ts1107() {
+    let codes = check_source_codes("while (true) { const O = class { m() { break; } }; }");
+    assert!(
+        codes.contains(&TS1107),
+        "an anonymous class expression's method body is the same boundary as a declaration's; got {codes:?}"
+    );
+}
+
+#[test]
+fn break_in_async_method_nested_in_while_reports_ts1107() {
+    let codes = check_source_codes("while (true) { class C { async m() { break; } } }");
+    assert!(codes.contains(&TS1107), "got {codes:?}");
+}
+
+#[test]
+fn break_in_generator_method_nested_in_while_reports_ts1107() {
+    let codes = check_source_codes("while (true) { class C { *m() { break; } } }");
+    assert!(codes.contains(&TS1107), "got {codes:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Nesting: a class inside a method, a member body inside a free function.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn break_in_method_of_class_nested_in_method_reports_ts1107() {
+    let codes =
+        check_source_codes("while (true) { class C { m() { class D { n() { break; } } } } }");
+    assert!(
+        codes.contains(&TS1107),
+        "two stacked member boundaries must not cancel out; got {codes:?}"
+    );
+}
+
+#[test]
+fn break_in_method_nested_in_loop_inside_function_reports_ts1107() {
+    let codes = check_source_codes("function f() { while (true) { class C { m() { break; } } } }");
+    assert!(codes.contains(&TS1107), "got {codes:?}");
+}
+
+#[test]
+fn break_in_function_declared_in_method_reports_ts1107() {
+    let codes =
+        check_source_codes("while (true) { class C { m() { function inner() { break; } } } }");
+    assert!(codes.contains(&TS1107), "got {codes:?}");
+}
+
+#[test]
+fn break_in_arrow_declared_in_method_reports_ts1107() {
+    let codes =
+        check_source_codes("while (true) { class C { m() { const f = () => { break; }; } } }");
+    assert!(codes.contains(&TS1107), "got {codes:?}");
+}
+
+#[test]
+fn break_in_property_initializer_arrow_reports_ts1107() {
+    let codes = check_source_codes("while (true) { class C { p = () => { break; }; } }");
+    assert!(codes.contains(&TS1107), "got {codes:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Negative / fallback cases. The rule is "reset the counters at the member-body
+// boundary", NOT "always error inside a class member" — a loop the member owns
+// still satisfies the jump, and these must stay silent.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn break_in_members_own_while_stays_clean() {
+    let codes = check_source_codes("while (true) { class C { m() { while (true) { break; } } } }");
+    assert!(
+        !codes.contains(&TS1107) && !codes.contains(&TS1105),
+        "the member's own loop is inside the same function-like, so the jump is legal; got {codes:?}"
+    );
+}
+
+#[test]
+fn break_in_members_own_switch_stays_clean() {
+    let codes =
+        check_source_codes("while (true) { class C { m() { switch (1) { case 1: break; } } } }");
+    assert!(
+        !codes.contains(&TS1107) && !codes.contains(&TS1105),
+        "got {codes:?}"
+    );
+}
+
+#[test]
+fn continue_in_members_own_for_stays_clean() {
+    let codes = check_source_codes("while (true) { class C { m() { for (;;) { continue; } } } }");
+    assert!(
+        !codes.contains(&TS1107) && !codes.contains(&TS1104),
+        "got {codes:?}"
+    );
+}
+
+#[test]
+fn continue_in_members_own_do_while_stays_clean() {
+    let codes =
+        check_source_codes("while (true) { class C { m() { do { continue; } while (0); } } }");
+    assert!(
+        !codes.contains(&TS1107) && !codes.contains(&TS1104),
+        "got {codes:?}"
+    );
+}
+
+#[test]
+fn break_in_constructors_own_while_stays_clean() {
+    let codes =
+        check_source_codes("while (true) { class C { constructor() { while (1) { break; } } } }");
+    assert!(
+        !codes.contains(&TS1107) && !codes.contains(&TS1105),
+        "got {codes:?}"
+    );
+}
+
+#[test]
+fn break_in_static_blocks_own_while_stays_clean() {
+    let codes = check_source_codes("while (true) { class C { static { while (1) { break; } } } }");
+    assert!(
+        !codes.contains(&TS1107) && !codes.contains(&TS1105),
+        "got {codes:?}"
+    );
+}
+
+#[test]
+fn labeled_break_to_members_own_label_stays_clean() {
+    let codes =
+        check_source_codes("while (true) { class C { m() { l: while (1) { break l; } } } }");
+    assert!(
+        !codes.contains(&TS1107),
+        "the label is declared inside the member body, so nothing is crossed; got {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Controls that already passed before the fix, pinned so the member-body reset
+// cannot regress them. The labeled paths decide TS1107 by comparing the label's
+// `function_depth` against the live one, so outer labels must stay resolvable
+// for the whole member body — the boundary saves the label stack's length, it
+// does not hide its contents.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn labeled_break_across_member_boundary_still_reports_ts1107() {
+    let codes = check_source_codes("a: while (true) { class C { m() { break a; } } }");
+    assert!(codes.contains(&TS1107), "got {codes:?}");
+}
+
+#[test]
+fn labeled_continue_across_member_boundary_still_reports_ts1107() {
+    let codes = check_source_codes("outer: while (true) { class C { m() { continue outer; } } }");
+    assert!(codes.contains(&TS1107), "got {codes:?}");
+}
+
+#[test]
+fn break_in_static_block_nested_in_while_still_reports_ts1107() {
+    let codes = check_source_codes("while (true) { class C { static { break; } } }");
+    assert!(
+        codes.contains(&TS1107),
+        "the static block arm was the one member kind that already had the reset; got {codes:?}"
+    );
+}
+
+#[test]
+fn break_in_method_with_no_enclosing_loop_still_reports_ts1107() {
+    let codes = check_source_codes("class C { m() { break; } }");
+    assert!(
+        codes.contains(&TS1107),
+        "TS1107 wins over TS1105 inside a member body because the body raises function_depth; got {codes:?}"
+    );
+}
+
+#[test]
+fn continue_in_method_with_no_enclosing_loop_still_reports_ts1107() {
+    let codes = check_source_codes("class C { m() { continue; } }");
+    assert!(codes.contains(&TS1107), "got {codes:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Top-level fallback: outside any function-like the codes are TS1105/TS1104,
+// not TS1107. The member-body boundary must not leak its raised depth.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn top_level_break_after_a_class_member_still_reports_ts1105() {
+    let codes = check_source_codes("class C { m() { while (1) {} } }\nbreak;");
+    assert!(
+        codes.contains(&TS1105) && !codes.contains(&TS1107),
+        "the member body's raised depth and loop counters must be fully restored on exit; got {codes:?}"
+    );
+}
+
+#[test]
+fn top_level_continue_after_a_class_member_still_reports_ts1104() {
+    let codes = check_source_codes("class C { m() { for (;;) {} } }\ncontinue;");
+    assert!(
+        codes.contains(&TS1104) && !codes.contains(&TS1107),
+        "got {codes:?}"
+    );
+}
+
+#[test]
+fn break_in_loop_after_a_class_member_stays_clean() {
+    let codes = check_source_codes("while (true) { class C { m() { while (1) {} } } break; }");
+    assert!(
+        !codes.contains(&TS1107) && !codes.contains(&TS1105),
+        "the enclosing loop's counters must be restored after the member body, not left at zero; got {codes:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -1778,23 +1778,9 @@ impl<'a> CheckerState<'a> {
             // Skip body checking for function declarations — they are checked via
             // check_function_declaration which maintains the full type param scope chain.
             if !is_function_declaration {
-                // Save and reset control flow context (function body creates new context)
-                let saved_cf_context = (
-                    self.ctx.iteration_depth,
-                    self.ctx.switch_depth,
-                    self.ctx.label_stack.len(),
-                    self.ctx.had_outer_loop,
-                );
-                // If we were in a loop/switch, or already had an outer loop, mark it
-                if self.ctx.iteration_depth > 0
-                    || self.ctx.switch_depth > 0
-                    || self.ctx.had_outer_loop
-                {
-                    self.ctx.had_outer_loop = true;
-                }
-                self.ctx.iteration_depth = 0;
-                self.ctx.switch_depth = 0;
-                // Note: function_depth was already incremented at body entry
+                // Save and reset control flow context (function body creates new context).
+                // Note: function_depth was already incremented at body entry.
+                let saved_cf_context = self.ctx.enter_function_like_control_flow();
                 // Propagate contextual return type for expression-bodied arrows.
                 // Compute the effective body context as a local variable instead of
                 // modifying the ambient ctx.contextual_type.
@@ -1901,10 +1887,7 @@ impl<'a> CheckerState<'a> {
                 self.ctx.generator_yield_operand_types = saved_yield_collection;
                 self.ctx.generator_had_ts7057 = saved_had_ts7057;
 
-                self.ctx.iteration_depth = saved_cf_context.0;
-                self.ctx.switch_depth = saved_cf_context.1;
-                self.ctx.label_stack.truncate(saved_cf_context.2);
-                self.ctx.had_outer_loop = saved_cf_context.3;
+                self.ctx.exit_function_like_control_flow(saved_cf_context);
             }
 
             if is_function_declaration

--- a/crates/tsz-checker/src/types/function_type/generator_declaration_yield.rs
+++ b/crates/tsz-checker/src/types/function_type/generator_declaration_yield.rs
@@ -59,14 +59,7 @@ impl CheckerState<'_> {
         }
 
         let yield_snapshot = self.ctx.snapshot_return_type();
-        let saved_cf_context = (
-            self.ctx.iteration_depth,
-            self.ctx.switch_depth,
-            self.ctx.label_stack.len(),
-            self.ctx.had_outer_loop,
-        );
-        self.ctx.iteration_depth = 0;
-        self.ctx.switch_depth = 0;
+        let saved_cf_context = self.ctx.enter_function_like_control_flow();
         let saved_yield_collection = std::mem::take(&mut self.ctx.generator_yield_operand_types);
         let saved_had_ts7057 = std::mem::replace(&mut self.ctx.generator_had_ts7057, false);
 
@@ -88,10 +81,7 @@ impl CheckerState<'_> {
 
         self.ctx.generator_yield_operand_types = saved_yield_collection;
         self.ctx.generator_had_ts7057 = saved_had_ts7057;
-        self.ctx.iteration_depth = saved_cf_context.0;
-        self.ctx.switch_depth = saved_cf_context.1;
-        self.ctx.label_stack.truncate(saved_cf_context.2);
-        self.ctx.had_outer_loop = saved_cf_context.3;
+        self.ctx.exit_function_like_control_flow(saved_cf_context);
         yield_snapshot.rollback(&mut self.ctx.speculation_state());
         final_yield
     }


### PR DESCRIPTION
Closes #16199.

Two commits: the compiler fix, and a mechanical `lib.rs` split that the fix turned out to require (see **Commit 2** — `lib.rs` was 2 lines from the architecture cap, so *any* checker PR adding a test module broke it on merge).

## Commit 1 — the fix

**Structural rule.** When an unlabeled `break`/`continue` has no enclosing iteration or `switch` statement *inside its own innermost function-like*, `tsc` reports **TS1107** as soon as `checkGrammarBreakOrContinueStatement`'s single upward walk crosses that function-like — and a class method, accessor, constructor and static block are all function-like boundaries. tsz does the same through the **checker**'s member-body boundary (`CheckerContext::enter_class_member_body`), which now owns the loop/switch counter reset instead of leaving it to each caller.

**Wrong semantic operation:** diagnostic-selection state, not inference. tsz models `tsc`'s upward walk as the ambient `iteration_depth` / `switch_depth` counters on `CheckerContext`, so they have to be zeroed wherever checking descends across a function-like. That reset was hand-copied at **five** boundaries. The class member-body path had exactly **one** copy — on the static block arm — so a jump in a method, accessor or constructor nested in a loop still saw the *enclosing* loop, took the "we are inside a loop, this is fine" branch, and reported **nothing at all**.

**Owner layer / DRY.** Rather than adding a sixth copy, the reset gets one owner: `enter_function_like_control_flow` / `exit_function_like_control_flow` on `CheckerContext`, folded into `enter_class_member_body` — which all four member kinds already called. The static block's hand-copy is deleted, and the free-function, arrow/expression and generator-declaration copies now call the same primitive. Five hand-copies → one guard, and the hole cannot reopen for one member kind at a time.

Labels are deliberately **not** hidden for the body's duration — only the stack *length* is saved — so an outer label stays resolvable and the labeled paths keep deciding TS1107 by comparing `LabelInfo::function_depth` against `function_depth`. That is what keeps `a: while (true) { class C { m() { break a; } } }` reporting TS1107 rather than falling to TS1116, and keeps `mark_label_used` firing so no spurious TS7028 appears.

`statement_callback_bridge.rs`'s `save_and_reset_control_flow_context` pair (the fifth site named in the issue) is left alone: it is trait surface with **zero call sites** in the workspace, and it does not handle the label stack, so folding it in would be churn with a behavior-change risk and no caller to benefit.

`had_outer_loop` is preserved bit-for-bit by the guard. It is write-only state — every read in the crate is inside a save/restore block feeding itself; both `check_break_statement` and `check_continue_statement` decide TS1107-vs-TS1105/TS1104 on `function_depth`, despite the field's doc comment claiming otherwise.

## Commit 2 — `lib.rs` registry split (required to merge)

`lib.rs` was **1998** lines on `main` against the **2000**-line architecture cap, with 607 three-line `#[cfg(test)] #[path] mod` registrations making up most of it. This PR measured **1990 in isolation** — which is why `arch-size` passed on the first head — and **2001 once rebased onto `main`**. A file-size cap is a property of the *merge result*, not of the diff, so no CI job could have caught it. Whichever checker PR merged next would have broken it, this one or not.

Moved the **432** registrations pointing at `src/tests/**` into `crates/tsz-checker/src/test_module_registry.rs`. **`lib.rs` 2001 → 712**, new file **882**.

The **175** registrations pointing at `crates/tsz-checker/tests/**` deliberately stay in `lib.rs`: several of those modules use `use super::*`, which must keep resolving to the crate root. `#[path]` resolves against the directory holding the declaring file, and the new file sits in `src/` alongside `lib.rs`, so every path is byte-identical.

## Goal
Goal: hold

## Verification

### Conformance — the gate

```
scripts/conformance/compare-to-parent.sh HEAD~1
  branch  12043 runnable, 11460 passed (95.2%)
  base    12043 runnable, 11460 passed (95.2%)
  base failing=582   branch failing=582
  NEWLY PASSING (0)   NEWLY FAILING (0)   fingerprint changed (0)
```

Independently reproduced by @Quartz on a different machine: `conformance 11459 — 0 newly failing, 0 newly passing`; `emit JS/DTS 11562 / 1375` at floor with row-set 16 → 16; `tsz-solver 7630/7630`. Zero corpus movement is the *expected* signature here — the corpus has no fixture for a jump inside a class member nested in a loop, which is why the hole survived.

### Oracle matrix — 28 rows, `typescript@7.0.2`, `--noEmit --strict --target es2022 --lib es2022`

**13 rows moved to `tsc`, 0 away. 15 controls unchanged.** Binder names varied (`C`/`Renamed`/`Zed`/`Q`/`D`/`O`) so nothing passes on a name.

| row | source | tsc | before | after |
| --- | --- | --- | --- | --- |
| j1 | `while (true) { class C { m() { break; } } }` | 1107 | — | **1107** |
| j2 | `while (true) { class C { get g() { continue; } } }` | 1107, 2378 | — | **1107** |
| j3 | `switch (1) { case 1: class C { m() { break; } } }` | 1107 | — | **1107** |
| j5 | `while (true) { class C { constructor() { break; } } }` | 1107 | — | **1107** |
| a1 | `while (true) { class Renamed { set s(v: number) { continue; } } }` | 1107 | — | **1107** |
| a2 | `for (const q of [1]) { class Zed { static sm() { break; } } }` | 1107 | — | **1107** |
| a3 | `do { class Q { m() { continue; } } } while (false)` | 1107 | — | **1107** |
| a4 | `while (true) { const O = class { m() { break; } }; }` | 1107 | — | **1107** |
| a7 | `while (true) { class C { m() { class D { n() { break; } } } } }` | 1107 | — | **1107** |
| a8 | `switch (1) { case 1: class C { get g() { break; } } }` | 1107, 2378 | — | **1107** |
| b7 | `while (true) { class C { async m() { break; } } }` | 1107 | — | **1107** |
| b8 | `while (true) { class C { *m() { break; } } }` | 1107 | — | **1107** |
| c3 | `function f() { while (true) { class C { m() { break; } } } }` | 1107 | — | **1107** |

Controls held (unchanged before → after): labeled `break a;` / `continue outer;` across the boundary still **1107**; static block still **1107**; `class C { m() { break; } }` with no outer loop still **1107**; and every "member owns its own loop/switch" row still **clean** — `while (true) { class C { m() { while (true) { break; } } } }`, the `switch`, `for(;;)`, `do/while`, constructor and static-block variants, and `l: while (1) { break l; }`.

Three restore-side rows guard the boundary against leaking its raised depth: `class C { m() { while (1) {} } }` + top-level `break;` → **TS1105** (not 1107); the `continue` form → **TS1104**; `while (true) { class C { m() { while (1) {} } } break; }` → **clean**. All oracle-matched.

@Quartz's independent 208-row cross-product (7 outer constructs × 13 member/nesting kinds × 4 jump forms): `main == tsc 99/208`, `PR == tsc 192/208`, **FIXED 93, BROKE 0, moved AWAY 0**, codes ADDED `{1107: 104}`, codes REMOVED `{}` — an empty REMOVED set across 208 rows.

### Unit

- New suite `crates/tsz-checker/src/tests/jump_statement_class_member_boundary_tests.rs`: **8/30 before → 30/30 after**.
- Affected families re-run after the rebase and split: label 13, loop 57, break 38, continue 13, generator 154, jump 30, switch 73, await 190, static_block 20 — **588 passed, 0 failed**. `label` and `generator` are the load-bearing two: they cover the "outer labels stay resolvable" claim and the generator site's move onto the shared primitive.
- `architecture_contract`: **159 passed**. Crate total **9023** tests.

### Split integrity

| check | result |
| --- | --- |
| registrations preserved | 432 + 175 = **607**; `main` has 606 — delta is exactly this PR's one new module |
| `scripts/ci/check-test-file-reachability.py` | **0 known orphans, 0 new** |
| `python3 scripts/arch/arch_guard.py` | passes on the merged-with-main result |

### Lint

`cargo fmt --all` clean; pre-commit gate (workspace clippy under `-D warnings` + architecture guard) passed on both commits.

## Side finding, filed not banked

**#16203** — an illegal `break`/`continue` silently suppresses its enclosing function's return-path analysis (TS2355/TS2378). Present identically before and after this change, so out of scope here. Not accessor- or class-specific: `function f(): number { continue; }` loses TS2355 too, making it a reachability bug fixable without touching class-member paths.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Peridot