### PR TITLE
fix(binder): decide module-ness from the resolved moduleDetection setting

### DIFF
--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -18,19 +18,35 @@ use tsz_parser::{NodeIndex, NodeList};
 use tsz_scanner::SyntaxKind;
 
 use super::{BinderOptions, FileFeatures};
+use tsz_common::options::module_detection::ModuleDetectionKind;
 
-/// Returns true if the file extension implies module semantics (.mts, .cts, .mjs, .cjs).
-/// In TypeScript, these extensions always indicate module files regardless of content
-/// or moduleDetection settings. This matches tsc behavior where .mts files are ES modules
-/// and .cts files are CommonJS modules.
+/// Returns true if the file extension forces module semantics (.mts, .cts,
+/// .mjs, .cjs) under `moduleDetection: auto`.
+///
+/// Mirrors `tsc`'s `isFileForcedToBeModuleByFormat`, which is explicitly
+/// declaration-file-aware: `.d.mts` and `.d.cts` are *not* forced, because a
+/// declaration file with no module syntax still declares globals. Callers that
+/// want the format-blind rule want `file_has_module_syntax_indicator` instead.
 fn is_module_file_extension(file_name: &str) -> bool {
+    if is_declaration_file_name(file_name) {
+        return false;
+    }
     // Check for .mts, .cts (TypeScript module extensions)
     // and .mjs, .cjs (JavaScript module extensions)
-    // Also handle declaration variants: .d.mts, .d.cts
     file_name.ends_with(".mts")
         || file_name.ends_with(".cts")
         || file_name.ends_with(".mjs")
         || file_name.ends_with(".cjs")
+}
+
+/// Returns true for a declaration file name (`.d.ts`, `.d.mts`, `.d.cts`).
+///
+/// Mirrors `tsc`'s `SourceFile.isDeclarationFile`, which both
+/// `isFileForcedToBeModuleByFormat` and the `moduleDetection: force` rule
+/// consult: a declaration file is never made a module by its extension or by
+/// `force`, only by carrying module syntax of its own.
+fn is_declaration_file_name(file_name: &str) -> bool {
+    file_name.ends_with(".d.ts") || file_name.ends_with(".d.mts") || file_name.ends_with(".d.cts")
 }
 
 pub(super) fn is_js_like_file_name(file_name: &str) -> bool {
@@ -642,25 +658,42 @@ impl BinderState {
         }
     }
 
-    pub(crate) fn source_file_is_external_module(arena: &NodeArena, root: NodeIndex) -> bool {
-        // Note: .mts/.cts/.mjs/.cjs file extension check is handled by the caller
-        // via `is_module_file_extension()`, since this static method doesn't have
-        // access to the file name string.
+    /// Decide whether `root`'s source file is an external module under the
+    /// binder's resolved `moduleDetection` setting.
+    ///
+    /// Mirrors `tsc`'s `getSetExternalModuleIndicator`, which dispatches on
+    /// `getEmitModuleDetectionKind(options)` and installs one of three
+    /// predicates. Only the `Auto` arm consults file format; `Legacy` is module
+    /// syntax alone, and `Force` makes every non-declaration file a module.
+    pub(crate) fn detect_external_module(&self, arena: &NodeArena, root: NodeIndex) -> bool {
+        match self.options.module_detection {
+            ModuleDetectionKind::Auto => Self::source_file_is_external_module(arena, root),
+            ModuleDetectionKind::Legacy => Self::file_has_module_syntax_indicator(arena, root),
+            ModuleDetectionKind::Force => {
+                let Some(source) = arena.get_source_file_at(root) else {
+                    return false;
+                };
+                !is_declaration_file_name(&source.file_name)
+                    || Self::file_has_module_syntax_indicator(arena, root)
+            }
+        }
+    }
+
+    /// Whether module-ness may be forced by file format (`moduleDetection: auto`).
+    pub(crate) const fn auto_module_detection(&self) -> bool {
+        matches!(self.options.module_detection, ModuleDetectionKind::Auto)
+    }
+
+    /// `tsc`'s `isFileProbablyExternalModule`: does the file carry module
+    /// syntax of its own?
+    ///
+    /// An import/export declaration, an `import ... = require(...)`, an
+    /// `export =`, any exported declaration, or `import.meta`. Deliberately
+    /// format-blind — file extensions are the `Auto` arm's business.
+    fn file_has_module_syntax_indicator(arena: &NodeArena, root: NodeIndex) -> bool {
         let Some(source) = arena.get_source_file_at(root) else {
             return false;
         };
-
-        // .mts and .mjs files are always ES modules; .cts and .cjs files are
-        // always CommonJS modules.  Both are module-scoped per the TypeScript
-        // spec, regardless of their content.
-        let fname = &source.file_name;
-        if fname.ends_with(".mts")
-            || fname.ends_with(".mjs")
-            || fname.ends_with(".cts")
-            || fname.ends_with(".cjs")
-        {
-            return true;
-        }
 
         for &stmt_idx in &source.statements.nodes {
             if stmt_idx.is_none() {
@@ -684,24 +717,31 @@ impl BinderState {
             }
         }
 
-        if Self::source_file_contains_import_meta(arena, root) {
+        Self::source_file_contains_import_meta(arena, root)
+    }
+
+    /// The `moduleDetection: auto` predicate — module syntax, plus the formats
+    /// and declaration-file accommodations that force module-ness on their own.
+    pub(crate) fn source_file_is_external_module(arena: &NodeArena, root: NodeIndex) -> bool {
+        // Note: .mts/.cts/.mjs/.cjs file extension check is handled by the caller
+        // via `is_module_file_extension()`, since this static method doesn't have
+        // access to the file name string.
+        let Some(source) = arena.get_source_file_at(root) else {
+            return false;
+        };
+
+        if Self::file_has_module_syntax_indicator(arena, root) {
             return true;
         }
 
-        // .mts/.cts/.mjs/.cjs files are always modules regardless of content.
-        // In tsc's moduleDetection "auto" mode, these extensions force module
-        // scope even without import/export statements.
-        {
-            let lower = source.file_name.to_lowercase();
-            if lower.ends_with(".mts")
-                || lower.ends_with(".cts")
-                || lower.ends_with(".mjs")
-                || lower.ends_with(".cjs")
-                || lower.ends_with(".d.mts")
-                || lower.ends_with(".d.cts")
-            {
-                return true;
-            }
+        // Files with extensions that unambiguously imply a module format (Node16+
+        // CJS/ESM extensions) are modules regardless of statement content.
+        // Matches tsc's `isFileForcedToBeModuleByFormat` under `moduleDetection: auto`,
+        // including its exclusion of declaration files (`.d.mts`, `.d.cts`), which
+        // still require an explicit module indicator — otherwise their ambient
+        // declarations stop seeding the global scope.
+        if is_module_file_extension(&source.file_name) {
+            return true;
         }
 
         // Declaration files that only contain `declare global { ... }` still need
@@ -710,23 +750,6 @@ impl BinderState {
         // opting into global augmentation semantics.
         if source.file_name.ends_with(".d.ts")
             && Self::source_file_has_top_level_global_augmentation(arena, &source.statements.nodes)
-        {
-            return true;
-        }
-
-        // Files with extensions that unambiguously imply a module format (Node16+
-        // CJS/ESM extensions) are always modules, regardless of statement content.
-        // Matches tsc's `isFileForcedToBeModuleByFormat` under `moduleDetection: auto`.
-        // Excludes declaration files (`.d.cts`, `.d.mts`), which still require an
-        // explicit module indicator.
-        let fname = source.file_name.as_str();
-        let is_declaration_file =
-            fname.ends_with(".d.ts") || fname.ends_with(".d.cts") || fname.ends_with(".d.mts");
-        if !is_declaration_file
-            && (fname.ends_with(".cts")
-                || fname.ends_with(".mts")
-                || fname.ends_with(".cjs")
-                || fname.ends_with(".mjs"))
         {
             return true;
         }
@@ -1067,7 +1090,7 @@ impl BinderState {
         // Create START flow node for the file
         let start_flow = Arc::make_mut(&mut self.flow_nodes).alloc(flow_flags::START);
         self.current_flow = start_flow;
-        self.is_external_module = Self::source_file_is_external_module(arena, root);
+        self.is_external_module = self.detect_external_module(arena, root);
 
         if let Some(node) = arena.get(root)
             && let Some(sf) = arena.get_source_file(node)
@@ -1075,7 +1098,12 @@ impl BinderState {
             // .mts/.cts/.mjs/.cjs files are always modules regardless of content.
             // This must happen after source_file_is_external_module which only checks
             // for import/export statements, not file extensions.
-            if !self.is_external_module && is_module_file_extension(&sf.file_name) {
+            // Only under `moduleDetection: auto`: `legacy` never forces module-ness
+            // by format, and `force` has already decided by declaration-file-ness.
+            if self.auto_module_detection()
+                && !self.is_external_module
+                && is_module_file_extension(&sf.file_name)
+            {
                 self.is_external_module = true;
             }
             // Detect strict mode: "use strict" prologue or --alwaysStrict option
@@ -1774,13 +1802,16 @@ impl BinderState {
             return false;
         }
 
-        self.is_external_module = Self::source_file_is_external_module(arena, root);
+        self.is_external_module = self.detect_external_module(arena, root);
 
         // Detect strict mode for incremental rebinding
         if let Some(node) = arena.get(root)
             && let Some(sf) = arena.get_source_file(node)
         {
-            if !self.is_external_module && is_module_file_extension(&sf.file_name) {
+            if self.auto_module_detection()
+                && !self.is_external_module
+                && is_module_file_extension(&sf.file_name)
+            {
                 self.is_external_module = true;
             }
             self.is_strict_scope = self.options.always_strict

--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -19,6 +19,7 @@ use std::mem::size_of;
 use std::sync::Arc;
 use std::sync::RwLock;
 use tsz_common::common::ScriptTarget;
+use tsz_common::options::module_detection::ModuleDetectionKind;
 use tsz_parser::NodeIndex;
 use tsz_parser::parser::node::NodeArena;
 
@@ -178,6 +179,11 @@ pub struct BinderOptions {
     /// When true, parse in strict mode and emit "use strict" for each source file.
     /// This mirrors the `--alwaysStrict` compiler option.
     pub always_strict: bool,
+    /// Resolved `moduleDetection`, i.e. `tsc`'s `getEmitModuleDetectionKind`.
+    ///
+    /// Selects which rule `detect_external_module` applies when deciding
+    /// whether a source file is an external module.
+    pub module_detection: ModuleDetectionKind,
 }
 
 /// Lib file context for global type resolution.

--- a/crates/tsz-binder/src/state/tests.rs
+++ b/crates/tsz-binder/src/state/tests.rs
@@ -11,6 +11,7 @@ mod exports_jsdoc;
 mod hoisting_scopes_flow;
 mod loop_flow;
 mod module_augments;
+mod module_detection;
 mod semantic_defs_core;
 mod semantic_defs_cross_file;
 mod semantic_defs_extended;

--- a/crates/tsz-binder/src/state/tests/hoisting_scopes_flow.rs
+++ b/crates/tsz-binder/src/state/tests/hoisting_scopes_flow.rs
@@ -168,6 +168,7 @@ fn function_body_declarations_hoist_even_in_strict_es2015() {
     let options = BinderOptions {
         target: ScriptTarget::ES2015,
         always_strict: true,
+        ..BinderOptions::default()
     };
     let (binder, _parser) = parse_and_bind_with_options(
         r#"
@@ -201,6 +202,7 @@ fn function_in_block_not_hoisted_in_strict_mode() {
     let options = BinderOptions {
         target: ScriptTarget::ES2015,
         always_strict: true,
+        ..BinderOptions::default()
     };
     let (binder, _parser) = parse_and_bind_with_options(
         r#"
@@ -229,6 +231,7 @@ fn function_in_block_hoisted_in_non_strict_es5() {
     let options = BinderOptions {
         target: ScriptTarget::ES5,
         always_strict: false,
+        ..BinderOptions::default()
     };
     let (binder, _parser) = parse_and_bind_with_options(
         r"

--- a/crates/tsz-binder/src/state/tests/module_detection.rs
+++ b/crates/tsz-binder/src/state/tests/module_detection.rs
@@ -1,0 +1,294 @@
+//! `moduleDetection` and the file-level module-ness predicate.
+//!
+//! `tsc`'s `getSetExternalModuleIndicator` dispatches on
+//! `getEmitModuleDetectionKind(options)` and installs one of three predicates:
+//!
+//! | kind | rule |
+//! | --- | --- |
+//! | `Force` | `isFileProbablyExternalModule(file) \|\| !file.isDeclarationFile` |
+//! | `Legacy` | `isFileProbablyExternalModule(file)` |
+//! | `Auto` | the above, plus `isFileForcedToBeModuleByFormat` |
+//!
+//! The binder owns that predicate here, because `is_external_module` is a
+//! bind-time property of a source file that the checker consumes read-only.
+//!
+//! Every binder name below is arbitrary and none repeats across rows: nothing
+//! in this family may key on an identifier string. Expectations are pinned
+//! against a real `tsc` run, not against tsz's prior behavior.
+
+use super::super::{BinderOptions, BinderState};
+use tsz_common::options::module_detection::ModuleDetectionKind;
+use tsz_parser::ParserState;
+
+/// Bind `source` as `file_name` under a resolved `moduleDetection` kind.
+fn is_external_module(source: &str, file_name: &str, kind: ModuleDetectionKind) -> bool {
+    let mut parser = ParserState::new(file_name.to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::with_options(BinderOptions {
+        module_detection: kind,
+        ..BinderOptions::default()
+    });
+    binder.bind_source_file(parser.get_arena(), root);
+    binder.is_external_module
+}
+
+// ---------------------------------------------------------------------------
+// force: every non-declaration file is a module
+// ---------------------------------------------------------------------------
+
+#[test]
+fn force_makes_a_plain_script_file_a_module() {
+    assert!(
+        is_external_module("var wombat;\n", "a.ts", ModuleDetectionKind::Force),
+        "under force, a file with no module syntax is still a module"
+    );
+}
+
+#[test]
+fn force_keeps_a_file_with_module_syntax_a_module() {
+    assert!(
+        is_external_module("export {};\n", "b.ts", ModuleDetectionKind::Force),
+        "module syntax is a module under every detection kind"
+    );
+}
+
+#[test]
+fn force_leaves_a_declaration_file_without_module_syntax_a_script() {
+    // `!file.isDeclarationFile` is the whole force rule: a `.d.ts` with no
+    // module syntax keeps declaring globals.
+    assert!(
+        !is_external_module(
+            "declare var badger: number;\n",
+            "globals.d.ts",
+            ModuleDetectionKind::Force
+        ),
+        "force must not make a declaration file a module"
+    );
+}
+
+#[test]
+fn force_makes_a_declaration_file_with_module_syntax_a_module() {
+    assert!(
+        is_external_module(
+            "declare var otter: number;\nexport {};\n",
+            "typed.d.ts",
+            ModuleDetectionKind::Force
+        ),
+        "a declaration file is a module when it carries module syntax of its own"
+    );
+}
+
+#[test]
+fn force_leaves_a_declaration_file_with_a_module_extension_a_script() {
+    assert!(
+        !is_external_module(
+            "declare var marmot: number;\n",
+            "globals.d.mts",
+            ModuleDetectionKind::Force
+        ),
+        "`.d.mts` is a declaration file first; force must not reach it"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// legacy: module syntax only, never format
+// ---------------------------------------------------------------------------
+
+#[test]
+fn legacy_leaves_a_plain_script_file_a_script() {
+    assert!(
+        !is_external_module("var lynx;\n", "c.ts", ModuleDetectionKind::Legacy),
+        "no module syntax, no module"
+    );
+}
+
+#[test]
+fn legacy_does_not_force_a_module_extension() {
+    // The divergence Kyanite measured from the other side: under legacy, tsc's
+    // predicate is `isFileProbablyExternalModule` alone, so `.mts` is a script.
+    assert!(
+        !is_external_module("var ibex;\n", "d.mts", ModuleDetectionKind::Legacy),
+        "legacy never forces module-ness by file format"
+    );
+}
+
+#[test]
+fn legacy_does_not_force_a_commonjs_extension() {
+    assert!(
+        !is_external_module("var tapir;\n", "e.cts", ModuleDetectionKind::Legacy),
+        "legacy never forces module-ness by file format"
+    );
+}
+
+#[test]
+fn legacy_still_honours_module_syntax() {
+    assert!(
+        is_external_module(
+            "import { quokka } from \"./q\";\nquokka;\n",
+            "f.ts",
+            ModuleDetectionKind::Legacy
+        ),
+        "an import declaration is module syntax under every detection kind"
+    );
+}
+
+#[test]
+fn legacy_still_honours_an_exported_declaration() {
+    assert!(
+        is_external_module(
+            "export const dingo = 1;\n",
+            "g.ts",
+            ModuleDetectionKind::Legacy
+        ),
+        "an exported declaration is module syntax under every detection kind"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// auto: syntax plus format, declaration files excluded from format forcing
+// ---------------------------------------------------------------------------
+
+#[test]
+fn auto_leaves_a_plain_script_file_a_script() {
+    assert!(
+        !is_external_module("var caracal;\n", "h.ts", ModuleDetectionKind::Auto),
+        "no module syntax and no forcing format"
+    );
+}
+
+#[test]
+fn auto_forces_a_module_extension() {
+    assert!(
+        is_external_module("var serval;\n", "i.mts", ModuleDetectionKind::Auto),
+        "`.mts` forces module-ness by format under auto"
+    );
+}
+
+#[test]
+fn auto_forces_a_commonjs_extension() {
+    assert!(
+        is_external_module("var jerboa;\n", "j.cjs", ModuleDetectionKind::Auto),
+        "`.cjs` forces module-ness by format under auto"
+    );
+}
+
+#[test]
+fn auto_leaves_a_declaration_file_with_a_module_extension_a_script() {
+    // `isFileForcedToBeModuleByFormat` ends in `&& !file.isDeclarationFile`.
+    // Getting this wrong hides every ambient global a `.d.mts` declares.
+    assert!(
+        !is_external_module(
+            "declare var pangolin: number;\n",
+            "ambient.d.mts",
+            ModuleDetectionKind::Auto
+        ),
+        "`.d.mts` is not forced to be a module by its format"
+    );
+}
+
+#[test]
+fn auto_leaves_a_declaration_file_with_a_commonjs_extension_a_script() {
+    assert!(
+        !is_external_module(
+            "declare var okapi: number;\n",
+            "ambient.d.cts",
+            ModuleDetectionKind::Auto
+        ),
+        "`.d.cts` is not forced to be a module by its format"
+    );
+}
+
+#[test]
+fn auto_makes_a_declaration_file_with_a_module_extension_a_module_when_it_has_syntax() {
+    assert!(
+        is_external_module(
+            "declare var gerenuk: number;\nexport {};\n",
+            "typed.d.mts",
+            ModuleDetectionKind::Auto
+        ),
+        "module syntax still wins in a `.d.mts`"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The kind is the only thing that varies: same source, same name, three answers
+// ---------------------------------------------------------------------------
+
+#[test]
+fn detection_kind_is_the_only_variable_for_a_bare_script() {
+    let source = "var kinkajou;\n";
+    assert!(
+        !is_external_module(source, "k.ts", ModuleDetectionKind::Auto),
+        "auto: script"
+    );
+    assert!(
+        !is_external_module(source, "k.ts", ModuleDetectionKind::Legacy),
+        "legacy: script"
+    );
+    assert!(
+        is_external_module(source, "k.ts", ModuleDetectionKind::Force),
+        "force: module"
+    );
+}
+
+#[test]
+fn detection_kind_is_the_only_variable_for_a_module_extension() {
+    let source = "var numbat;\n";
+    assert!(
+        is_external_module(source, "l.mts", ModuleDetectionKind::Auto),
+        "auto: forced by format"
+    );
+    assert!(
+        !is_external_module(source, "l.mts", ModuleDetectionKind::Legacy),
+        "legacy: format is ignored"
+    );
+    assert!(
+        is_external_module(source, "l.mts", ModuleDetectionKind::Force),
+        "force: non-declaration file"
+    );
+}
+
+#[test]
+fn detection_kind_never_changes_the_answer_for_module_syntax() {
+    let source = "export const agouti = 1;\n";
+    for kind in [
+        ModuleDetectionKind::Auto,
+        ModuleDetectionKind::Legacy,
+        ModuleDetectionKind::Force,
+    ] {
+        assert!(
+            is_external_module(source, "m.ts", kind),
+            "module syntax is a module under {kind:?}"
+        );
+    }
+}
+
+#[test]
+fn detection_kind_never_makes_a_bare_declaration_file_a_module() {
+    let source = "declare var saiga: number;\n";
+    for kind in [
+        ModuleDetectionKind::Auto,
+        ModuleDetectionKind::Legacy,
+        ModuleDetectionKind::Force,
+    ] {
+        assert!(
+            !is_external_module(source, "n.d.ts", kind),
+            "a bare declaration file stays a script under {kind:?}"
+        );
+    }
+}
+
+#[test]
+fn default_detection_kind_is_auto() {
+    // `BinderOptions::default()` must keep the pre-existing behavior: every
+    // construction site that has not been taught about the setting yet gets
+    // tsc's own default.
+    assert_eq!(
+        BinderOptions::default().module_detection,
+        ModuleDetectionKind::Auto
+    );
+    assert!(
+        is_external_module("var zebu;\n", "o.mts", ModuleDetectionKind::default()),
+        "the default kind behaves as auto"
+    );
+}

--- a/crates/tsz-binder/src/state/tests/symbols_and_flags.rs
+++ b/crates/tsz-binder/src/state/tests/symbols_and_flags.rs
@@ -479,6 +479,7 @@ fn always_strict_option_enables_strict_mode() {
     let options = BinderOptions {
         target: ScriptTarget::ES5,
         always_strict: true,
+        ..BinderOptions::default()
     };
     let (binder, _parser) = parse_and_bind_with_options(
         r"

--- a/crates/tsz-cli/src/driver/core.rs
+++ b/crates/tsz-cli/src/driver/core.rs
@@ -29,6 +29,7 @@ use tsz_common::common::ScriptTarget;
 use tsz_common::file_extensions::{
     JS_FAMILY_EXTENSIONS, JSON_EXTENSION, TS_FAMILY_EXTENSIONS, is_default_lib_file, is_json_file,
 };
+use tsz_common::options::module_detection::ModuleDetectionKind;
 // Re-export functions that other modules (e.g. watch) access via `driver::`.
 use super::emit::{
     EmitOutputsContext, OutputFile, emit_outputs, normalize_root_dirs, normalize_type_roots,
@@ -1278,6 +1279,7 @@ fn build_program_with_cache(
     cache: &mut CompilationCache,
     lib_files: &[Arc<LibFile>],
     language_version: ScriptTarget,
+    module_detection: ModuleDetectionKind,
 ) -> BuildProgramResult {
     let mut meta = Vec::with_capacity(sources.len());
     let mut to_parse = Vec::new();
@@ -1322,10 +1324,11 @@ fn build_program_with_cache(
         // This ensures global symbols like console, Array, Promise are available
         // during binding, which prevents "Any poisoning" where unresolved symbols
         // default to Any type instead of emitting TS2304 errors.
-        parallel::parse_and_bind_parallel_with_libs_and_target(
+        parallel::parse_and_bind_parallel_with_libs_and_options(
             to_parse,
             lib_files,
             language_version,
+            module_detection,
         )
     };
 

--- a/crates/tsz-cli/src/driver/core_diagnostics.rs
+++ b/crates/tsz-cli/src/driver/core_diagnostics.rs
@@ -1016,7 +1016,13 @@ fn compile_inner_impl(
 
     let build_program_start = Instant::now();
     let (program, dirty_paths) = if let Some(ref mut c) = effective_cache {
-        let result = build_program_with_cache(sources, c, &lib_files, resolved.checker.target);
+        let result = build_program_with_cache(
+            sources,
+            c,
+            &lib_files,
+            resolved.checker.target,
+            resolved.checker.module_detection,
+        );
         (result.program, Some(result.dirty_paths))
     } else {
         let compile_inputs: Vec<(String, String)> = sources
@@ -1030,10 +1036,11 @@ fn compile_inner_impl(
                 (source.path.to_string_lossy().into_owned(), text)
             })
             .collect();
-        let bind_results = parallel::parse_and_bind_parallel_with_libs_and_target(
+        let bind_results = parallel::parse_and_bind_parallel_with_libs_and_options(
             compile_inputs,
             &lib_files,
             resolved.checker.target,
+            resolved.checker.module_detection,
         );
         (Arc::new(parallel::merge_bind_results(bind_results)), None)
     };

--- a/crates/tsz-cli/src/driver/core_merge_cache_tests.rs
+++ b/crates/tsz-cli/src/driver/core_merge_cache_tests.rs
@@ -1,5 +1,6 @@
 use super::sources::SourceEntry;
 use super::*;
+use tsz_common::options::module_detection::ModuleDetectionKind;
 
 fn make_source(path: &str, text: &str) -> SourceEntry {
     SourceEntry {
@@ -27,7 +28,13 @@ fn merge_skipped_on_unchanged_inputs_and_reruns_on_change() {
         make_source("/a.ts", "export const a = 1;"),
         make_source("/b.ts", "export const b = 2;"),
     ];
-    let r1 = build_program_with_cache(sources, &mut cache, &libs, ScriptTarget::ES2020);
+    let r1 = build_program_with_cache(
+        sources,
+        &mut cache,
+        &libs,
+        ScriptTarget::ES2020,
+        ModuleDetectionKind::default(),
+    );
     let ptr1 = Arc::as_ptr(&r1.program);
     assert!(
         !r1.dirty_paths.is_empty(),
@@ -39,7 +46,13 @@ fn merge_skipped_on_unchanged_inputs_and_reruns_on_change() {
         make_source("/a.ts", "export const a = 1;"),
         make_source("/b.ts", "export const b = 2;"),
     ];
-    let r2 = build_program_with_cache(sources, &mut cache, &libs, ScriptTarget::ES2020);
+    let r2 = build_program_with_cache(
+        sources,
+        &mut cache,
+        &libs,
+        ScriptTarget::ES2020,
+        ModuleDetectionKind::default(),
+    );
     let ptr2 = Arc::as_ptr(&r2.program);
     assert!(
         r2.dirty_paths.is_empty(),
@@ -55,7 +68,13 @@ fn merge_skipped_on_unchanged_inputs_and_reruns_on_change() {
         make_source("/a.ts", "export const a = 99;"), // changed
         make_source("/b.ts", "export const b = 2;"),
     ];
-    let r3 = build_program_with_cache(sources, &mut cache, &libs, ScriptTarget::ES2020);
+    let r3 = build_program_with_cache(
+        sources,
+        &mut cache,
+        &libs,
+        ScriptTarget::ES2020,
+        ModuleDetectionKind::default(),
+    );
     let ptr3 = Arc::as_ptr(&r3.program);
     assert!(
         !r3.dirty_paths.is_empty(),
@@ -71,7 +90,13 @@ fn merge_skipped_on_unchanged_inputs_and_reruns_on_change() {
         make_source("/a.ts", "export const a = 99;"),
         make_source("/b.ts", "export const b = 2;"),
     ];
-    let r4 = build_program_with_cache(sources, &mut cache, &libs, ScriptTarget::ES2020);
+    let r4 = build_program_with_cache(
+        sources,
+        &mut cache,
+        &libs,
+        ScriptTarget::ES2020,
+        ModuleDetectionKind::default(),
+    );
     assert!(
         r4.dirty_paths.is_empty(),
         "fourth build (re-stable) should have no dirty paths"
@@ -92,19 +117,37 @@ fn merge_invalidated_on_file_removal() {
         make_source("/a.ts", "export const a = 1;"),
         make_source("/b.ts", "export const b = 2;"),
     ];
-    let r1 = build_program_with_cache(sources, &mut cache, &libs, ScriptTarget::ES2020);
+    let r1 = build_program_with_cache(
+        sources,
+        &mut cache,
+        &libs,
+        ScriptTarget::ES2020,
+        ModuleDetectionKind::default(),
+    );
 
     // Warm the cache with a no-op second pass.
     let sources = vec![
         make_source("/a.ts", "export const a = 1;"),
         make_source("/b.ts", "export const b = 2;"),
     ];
-    let r2 = build_program_with_cache(sources, &mut cache, &libs, ScriptTarget::ES2020);
+    let r2 = build_program_with_cache(
+        sources,
+        &mut cache,
+        &libs,
+        ScriptTarget::ES2020,
+        ModuleDetectionKind::default(),
+    );
     assert_eq!(Arc::as_ptr(&r1.program), Arc::as_ptr(&r2.program));
 
     // Now remove one file.
     let sources = vec![make_source("/a.ts", "export const a = 1;")];
-    let r3 = build_program_with_cache(sources, &mut cache, &libs, ScriptTarget::ES2020);
+    let r3 = build_program_with_cache(
+        sources,
+        &mut cache,
+        &libs,
+        ScriptTarget::ES2020,
+        ModuleDetectionKind::default(),
+    );
     assert_ne!(
         Arc::as_ptr(&r2.program),
         Arc::as_ptr(&r3.program),
@@ -118,11 +161,23 @@ fn merge_invalidated_on_file_addition() {
     let (mut cache, libs) = fresh_cache();
 
     let sources = vec![make_source("/a.ts", "export const a = 1;")];
-    let r1 = build_program_with_cache(sources, &mut cache, &libs, ScriptTarget::ES2020);
+    let r1 = build_program_with_cache(
+        sources,
+        &mut cache,
+        &libs,
+        ScriptTarget::ES2020,
+        ModuleDetectionKind::default(),
+    );
 
     // Warm the cache.
     let sources = vec![make_source("/a.ts", "export const a = 1;")];
-    let r2 = build_program_with_cache(sources, &mut cache, &libs, ScriptTarget::ES2020);
+    let r2 = build_program_with_cache(
+        sources,
+        &mut cache,
+        &libs,
+        ScriptTarget::ES2020,
+        ModuleDetectionKind::default(),
+    );
     assert_eq!(Arc::as_ptr(&r1.program), Arc::as_ptr(&r2.program));
 
     // Add a new file.
@@ -130,7 +185,13 @@ fn merge_invalidated_on_file_addition() {
         make_source("/a.ts", "export const a = 1;"),
         make_source("/c.ts", "export const c = 3;"),
     ];
-    let r3 = build_program_with_cache(sources, &mut cache, &libs, ScriptTarget::ES2020);
+    let r3 = build_program_with_cache(
+        sources,
+        &mut cache,
+        &libs,
+        ScriptTarget::ES2020,
+        ModuleDetectionKind::default(),
+    );
     assert_ne!(
         Arc::as_ptr(&r2.program),
         Arc::as_ptr(&r3.program),
@@ -144,18 +205,36 @@ fn clear_invalidates_merge_cache() {
     let (mut cache, libs) = fresh_cache();
 
     let sources = vec![make_source("/a.ts", "export const a = 1;")];
-    build_program_with_cache(sources, &mut cache, &libs, ScriptTarget::ES2020);
+    build_program_with_cache(
+        sources,
+        &mut cache,
+        &libs,
+        ScriptTarget::ES2020,
+        ModuleDetectionKind::default(),
+    );
 
     // Warm the merge cache.
     let sources = vec![make_source("/a.ts", "export const a = 1;")];
-    let r2 = build_program_with_cache(sources, &mut cache, &libs, ScriptTarget::ES2020);
+    let r2 = build_program_with_cache(
+        sources,
+        &mut cache,
+        &libs,
+        ScriptTarget::ES2020,
+        ModuleDetectionKind::default(),
+    );
     assert!(r2.dirty_paths.is_empty());
 
     cache.clear();
 
     // After clear, next build must re-merge.
     let sources = vec![make_source("/a.ts", "export const a = 1;")];
-    let r3 = build_program_with_cache(sources, &mut cache, &libs, ScriptTarget::ES2020);
+    let r3 = build_program_with_cache(
+        sources,
+        &mut cache,
+        &libs,
+        ScriptTarget::ES2020,
+        ModuleDetectionKind::default(),
+    );
     assert!(
         !r3.dirty_paths.is_empty(),
         "first build after clear must re-parse and re-merge"
@@ -181,10 +260,22 @@ fn merge_call_count_is_zero_on_unchanged_inputs() {
         make_source("/b.ts", "export const b = 2;"),
     ];
 
-    let r1 = build_program_with_cache(sources.clone(), &mut cache, &libs, ScriptTarget::ES2020);
+    let r1 = build_program_with_cache(
+        sources.clone(),
+        &mut cache,
+        &libs,
+        ScriptTarget::ES2020,
+        ModuleDetectionKind::default(),
+    );
     assert_eq!(r1.merge_calls, 1, "cold build must call merge exactly once");
 
-    let r2 = build_program_with_cache(sources, &mut cache, &libs, ScriptTarget::ES2020);
+    let r2 = build_program_with_cache(
+        sources,
+        &mut cache,
+        &libs,
+        ScriptTarget::ES2020,
+        ModuleDetectionKind::default(),
+    );
     assert_eq!(
         r2.merge_calls, 0,
         "unchanged build must skip merge (fast path: merge_calls == 0)"
@@ -195,14 +286,26 @@ fn merge_call_count_is_zero_on_unchanged_inputs() {
         make_source("/a.ts", "export const a = 99;"),
         make_source("/b.ts", "export const b = 2;"),
     ];
-    let r3 = build_program_with_cache(changed.clone(), &mut cache, &libs, ScriptTarget::ES2020);
+    let r3 = build_program_with_cache(
+        changed.clone(),
+        &mut cache,
+        &libs,
+        ScriptTarget::ES2020,
+        ModuleDetectionKind::default(),
+    );
     assert_eq!(
         r3.merge_calls, 1,
         "changed-file build must call merge exactly once"
     );
 
     // Back to unchanged → fast path fires again.
-    let r4 = build_program_with_cache(changed, &mut cache, &libs, ScriptTarget::ES2020);
+    let r4 = build_program_with_cache(
+        changed,
+        &mut cache,
+        &libs,
+        ScriptTarget::ES2020,
+        ModuleDetectionKind::default(),
+    );
     assert_eq!(
         r4.merge_calls, 0,
         "re-stable (unchanged after change) build must skip merge"

--- a/crates/tsz-cli/src/driver/plan.rs
+++ b/crates/tsz-cli/src/driver/plan.rs
@@ -11,11 +11,12 @@ use std::path::{Path, PathBuf};
 use crate::args::{CliArgs, Module, ModuleDetection, ModuleResolution, NewLine, Target};
 use crate::config::{
     CompilerOptions, ModuleResolutionKind, ResolvedCompilerOptions, TsConfig,
-    checker_target_from_emitter, derive_default_module_kind, parse_tsconfig_with_diagnostics,
-    resolve_default_lib_files, resolve_lib_files, strict_family,
+    apply_module_detection, checker_target_from_emitter, derive_default_module_kind,
+    parse_tsconfig_with_diagnostics, resolve_default_lib_files, resolve_lib_files, strict_family,
 };
 use tsz::checker::diagnostics::{Diagnostic, diagnostic_codes};
 use tsz_common::common::NewLineKind;
+use tsz_common::options::module_detection::ModuleDetectionKind;
 
 use super::{canonicalize_or_owned, is_declaration_file};
 
@@ -393,17 +394,14 @@ pub(super) fn apply_cli_overrides_with_config_options(
     // - Not set -> preserve config-level default
     match args.module_detection {
         Some(ModuleDetection::Force) => {
-            options.printer.module_detection_force = true;
-            options.printer.module_detection_legacy = false;
+            apply_module_detection(options, ModuleDetectionKind::Force);
         }
         Some(ModuleDetection::Legacy) => {
-            options.printer.module_detection_force = false;
-            options.printer.module_detection_legacy = true;
+            apply_module_detection(options, ModuleDetectionKind::Legacy);
         }
         Some(ModuleDetection::Auto) => {
             // Explicitly opting out of force mode
-            options.printer.module_detection_force = false;
-            options.printer.module_detection_legacy = false;
+            apply_module_detection(options, ModuleDetectionKind::Auto);
         }
         None => {
             // When module detection is not set via CLI, check if the CLI also overrides
@@ -414,7 +412,7 @@ pub(super) fn apply_cli_overrides_with_config_options(
                     Module::Node16 | Module::Node18 | Module::Node20 | Module::NodeNext
                 )
             {
-                options.printer.module_detection_force = true;
+                apply_module_detection(options, ModuleDetectionKind::Force);
             }
         }
     }

--- a/crates/tsz-common/src/options/checker.rs
+++ b/crates/tsz-common/src/options/checker.rs
@@ -4,6 +4,7 @@
 //! can reference `CheckerOptions` without creating a circular dependency.
 
 use crate::common::{ModuleKind, ScriptTarget};
+use crate::options::module_detection::ModuleDetectionKind;
 
 /// Compiler options for type checking.
 #[derive(Debug, Clone)]
@@ -47,6 +48,13 @@ pub struct CheckerOptions {
     /// Module kind (None, `CommonJS`, ES2015, ES2020, ES2022, `ESNext`, etc.)
     /// Controls which module system is being targeted (affects import/export syntax validity)
     pub module: ModuleKind,
+    /// Resolved `moduleDetection`, i.e. `tsc`'s `getEmitModuleDetectionKind`.
+    ///
+    /// Decides which files are external modules, which in turn drives strict
+    /// mode, global-vs-module symbol contribution and module resolution. The
+    /// binder owns the predicate itself; this is the resolved setting handed to
+    /// it (`BinderOptions::module_detection`).
+    pub module_detection: ModuleDetectionKind,
     /// `useDefineForClassFields`: `None` means the target-derived default
     /// (`true` for ES2022+). `getEmitStandardClassFields` semantics:
     /// standard emit iff this is not `Some(false)` and target >= ES2022.
@@ -248,6 +256,7 @@ impl Default for CheckerOptions {
             types_has_wildcard: false,
             target: ScriptTarget::default(),
             module: ModuleKind::default(),
+            module_detection: ModuleDetectionKind::default(),
             use_define_for_class_fields: None,
             es_module_interop: false,
             allow_synthetic_default_imports: false,

--- a/crates/tsz-common/src/options/mod.rs
+++ b/crates/tsz-common/src/options/mod.rs
@@ -1,3 +1,4 @@
 pub mod checker;
 pub mod checker_fanout;
+pub mod module_detection;
 pub mod strict_family;

--- a/crates/tsz-common/src/options/module_detection.rs
+++ b/crates/tsz-common/src/options/module_detection.rs
@@ -34,7 +34,7 @@ impl ModuleDetectionKind {
     /// Returns `None` for an unrecognized value so the caller can keep its own
     /// default (`tsc` reports an option diagnostic and falls back separately).
     #[must_use]
-    pub fn from_option_str(value: &str) -> Option<Self> {
+    pub const fn from_option_str(value: &str) -> Option<Self> {
         if value.eq_ignore_ascii_case("force") {
             Some(Self::Force)
         } else if value.eq_ignore_ascii_case("legacy") {

--- a/crates/tsz-common/src/options/module_detection.rs
+++ b/crates/tsz-common/src/options/module_detection.rs
@@ -1,0 +1,48 @@
+//! The resolved `moduleDetection` compiler setting.
+//!
+//! This lives in `tsz-common` because module-ness is decided by the binder
+//! (`BinderState::is_external_module`) but resolved from `compilerOptions` by
+//! the config layer, and consumed by the checker and the emitter. Keeping the
+//! kind in one crate lets every consumer name the same value instead of
+//! re-deriving it from a pair of booleans.
+
+/// How a source file's module-ness is decided.
+///
+/// Mirrors `tsc`'s `ModuleDetectionKind` and the `getSetExternalModuleIndicator`
+/// dispatch it drives.
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+)]
+pub enum ModuleDetectionKind {
+    /// A file is a module when it carries module syntax, when a `react-jsx`
+    /// file uses a JSX tag, or when its extension forces a module format
+    /// (`.mts`/`.cts`/`.mjs`/`.cjs`, non-declaration files only).
+    #[default]
+    Auto,
+    /// A file is a module only when it carries module syntax — an
+    /// import/export declaration, an exported declaration, `export =`, or
+    /// `import.meta`. Extensions never force module-ness.
+    Legacy,
+    /// Every non-declaration file is a module. Declaration files still require
+    /// module syntax.
+    Force,
+}
+
+impl ModuleDetectionKind {
+    /// Parse the `compilerOptions.moduleDetection` string, case-insensitively.
+    ///
+    /// Returns `None` for an unrecognized value so the caller can keep its own
+    /// default (`tsc` reports an option diagnostic and falls back separately).
+    #[must_use]
+    pub fn from_option_str(value: &str) -> Option<Self> {
+        if value.eq_ignore_ascii_case("force") {
+            Some(Self::Force)
+        } else if value.eq_ignore_ascii_case("legacy") {
+            Some(Self::Legacy)
+        } else if value.eq_ignore_ascii_case("auto") {
+            Some(Self::Auto)
+        } else {
+            None
+        }
+    }
+}

--- a/crates/tsz-core/src/config/mod.rs
+++ b/crates/tsz-core/src/config/mod.rs
@@ -43,7 +43,7 @@ pub use parse::{
     parse_tsconfig_with_diagnostics_deferred,
 };
 pub use resolved_options::{
-    JsxEmit, ModuleResolutionKind, PathMapping, ResolvedCompilerOptions,
+    JsxEmit, ModuleResolutionKind, PathMapping, ResolvedCompilerOptions, apply_module_detection,
     default_module_detection_for_module, default_module_kind_for_target,
     default_module_resolution_for_module, derive_default_module_kind, resolve_compiler_options,
 };

--- a/crates/tsz-core/src/config/resolved_options.rs
+++ b/crates/tsz-core/src/config/resolved_options.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use crate::checker::context::CheckerOptions;
 use crate::emitter::{ModuleKind, PrinterOptions, ScriptTarget};
 use crate::module_resolver_helpers::match_prefix_suffix;
+use tsz_common::options::module_detection::ModuleDetectionKind;
 use tsz_common::options::strict_family::{StrictFamilyOverrides, apply_strict_family};
 
 use super::{
@@ -241,6 +242,20 @@ pub const fn default_module_resolution_for_module(module: ModuleKind) -> ModuleR
         | ModuleKind::ESNext
         | ModuleKind::Preserve => ModuleResolutionKind::Bundler,
     }
+}
+
+/// Record a resolved `moduleDetection` in every consumer's view of it.
+///
+/// `tsc` resolves the setting once (`getEmitModuleDetectionKind`) and hands the
+/// same kind to the file-level module-ness predicate and to emit. tsz has two
+/// representations — `checker.module_detection`, which the binder reads to
+/// decide `is_external_module`, and the emitter's `module_detection_force` /
+/// `module_detection_legacy` pair — so both are written here and can never
+/// disagree.
+pub fn apply_module_detection(resolved: &mut ResolvedCompilerOptions, kind: ModuleDetectionKind) {
+    resolved.checker.module_detection = kind;
+    resolved.printer.module_detection_force = kind == ModuleDetectionKind::Force;
+    resolved.printer.module_detection_legacy = kind == ModuleDetectionKind::Legacy;
 }
 
 /// Default `moduleDetection` shown by tsc-style config output for a module kind.
@@ -940,15 +955,12 @@ pub fn resolve_compiler_options(
     // - If moduleDetection is NOT set and module is Node16-NodeNext, default to "force".
     // - If moduleDetection is NOT set and module is anything else, default to "auto".
     if let Some(ref module_detection) = options.module_detection {
-        if module_detection.eq_ignore_ascii_case("force") {
-            resolved.printer.module_detection_force = true;
-        } else if module_detection.eq_ignore_ascii_case("legacy") {
-            resolved.printer.module_detection_legacy = true;
-        }
-        // "auto" leaves both detection flags as false
+        // An unrecognized value keeps tsc's own fallback of `auto`.
+        let kind = ModuleDetectionKind::from_option_str(module_detection).unwrap_or_default();
+        apply_module_detection(&mut resolved, kind);
     } else if resolved.printer.module.is_node_module() {
         // tsc defaults to Force for Node16/Node18/Node20/NodeNext
-        resolved.printer.module_detection_force = true;
+        apply_module_detection(&mut resolved, ModuleDetectionKind::Force);
     }
 
     Ok(resolved)

--- a/crates/tsz-core/src/parallel/core.rs
+++ b/crates/tsz-core/src/parallel/core.rs
@@ -55,6 +55,7 @@ use std::sync::Arc;
 #[cfg(not(target_arch = "wasm32"))]
 use std::sync::Once;
 use tsz_common::interner::{AstAtom, Interner};
+use tsz_common::options::module_detection::ModuleDetectionKind;
 use tsz_scanner::SyntaxKind;
 
 include!("core/parse_and_libs.rs");

--- a/crates/tsz-core/src/parallel/core/parse_and_libs.rs
+++ b/crates/tsz-core/src/parallel/core/parse_and_libs.rs
@@ -1605,10 +1605,33 @@ pub fn parse_and_bind_parallel_with_libs(
 }
 
 /// Parse and bind multiple files in parallel with lib contexts and a compiler target.
+///
+/// Uses the default `moduleDetection` (`auto`); see
+/// [`parse_and_bind_parallel_with_libs_and_options`] to pass a resolved one.
 pub fn parse_and_bind_parallel_with_libs_and_target(
     files: Vec<(String, String)>,
     lib_files: &[Arc<lib_loader::LibFile>],
     language_version: ScriptTarget,
+) -> Vec<BindResult> {
+    parse_and_bind_parallel_with_libs_and_options(
+        files,
+        lib_files,
+        language_version,
+        ModuleDetectionKind::default(),
+    )
+}
+
+/// Parse and bind multiple files in parallel with lib contexts, a compiler
+/// target and a resolved `moduleDetection` setting.
+///
+/// `module_detection` decides which files the binder marks as external modules
+/// (`tsc`'s `getSetExternalModuleIndicator`), which in turn drives strict mode,
+/// global-vs-module symbol contribution and module resolution.
+pub fn parse_and_bind_parallel_with_libs_and_options(
+    files: Vec<(String, String)>,
+    lib_files: &[Arc<lib_loader::LibFile>],
+    language_version: ScriptTarget,
+    module_detection: ModuleDetectionKind,
 ) -> Vec<BindResult> {
     let premerged_lib_binder = if files.len() > 1 && !lib_files.is_empty() {
         let mut binder = BinderState::new();
@@ -1627,6 +1650,7 @@ pub fn parse_and_bind_parallel_with_libs_and_target(
                     source_text,
                     lib_files,
                     language_version,
+                    module_detection,
                     premerged_lib_binder.as_deref(),
                 )
             })
@@ -1643,6 +1667,7 @@ pub fn parse_and_bind_parallel_with_libs_and_target(
                 source_text,
                 lib_files,
                 language_version,
+                module_detection,
                 premerged_lib_binder.as_deref(),
             )
         })
@@ -1654,6 +1679,7 @@ fn bind_file_with_libs_with_language_version(
     source_text: String,
     lib_files: &[Arc<lib_loader::LibFile>],
     language_version: ScriptTarget,
+    module_detection: ModuleDetectionKind,
     premerged_lib_binder: Option<&BinderState>,
 ) -> BindResult {
     // Skip parsing .json files - they should not be parsed as TypeScript.
@@ -1674,6 +1700,7 @@ fn bind_file_with_libs_with_language_version(
     let mut binder = premerged_lib_binder
         .cloned()
         .unwrap_or_else(BinderState::new);
+    binder.options.module_detection = module_detection;
     binder.set_debug_file(&file_name);
     if premerged_lib_binder.is_some() {
         binder.symbols.share_current_symbols_for_append();

--- a/crates/tsz-core/src/parallel/lib_snapshot.rs
+++ b/crates/tsz-core/src/parallel/lib_snapshot.rs
@@ -57,7 +57,7 @@ use tsz_parser::parser::node::NodeArena;
 
 /// Magic header. Trailing byte is the format version. Bump on layout
 /// changes that break round-trip.
-const SNAPSHOT_MAGIC: &[u8; 8] = b"TSZSNAP\x08";
+const SNAPSHOT_MAGIC: &[u8; 8] = b"TSZSNAP\x09";
 
 /// Environment variable that controls the lib snapshot cache.
 const ENV_VAR: &str = "TSZ_LIB_CACHE";

--- a/crates/tsz-core/tests/checker_state_tests_parts/part_16.rs
+++ b/crates/tsz-core/tests/checker_state_tests_parts/part_16.rs
@@ -405,6 +405,7 @@ fn test_tier_2_type_checker_accuracy_fixes() {
             preserve_const_enums: false,
             strict_builtin_iterator_return: true,
             erasable_syntax_only: false,
+            module_detection: Default::default(),
         },
     );
     assert!(


### PR DESCRIPTION
Closes Kyanite's measured-but-unfiled family #2 from their jump/loop grammar sweep (#16197's DONE comment, 11:35Z): *"`--moduleDetection force` never reaches the module-ness predicate. The flag parses and is accepted; it just does not feed `is_external_module_file()`."*

**Structural rule.** When `compilerOptions.moduleDetection` resolves to `force`, `tsc` makes every non-declaration file an external module; when it resolves to `legacy`, only module syntax does; `auto` adds format forcing on top of syntax. tsz now does the same through the **binder**, which owns `is_external_module` as a bind-time property of a source file that the checker consumes read-only.

`moduleDetection` parsed (`config/resolved_options.rs`), resolved a per-`ModuleKind` default (force for Node16/18/20/NodeNext), and fed **only** `PrinterOptions.module_detection_force` / `module_detection_legacy` — the emitter. The predicate the checker actually reads, `BinderState::source_file_is_external_module`, took no options at all and hardcoded the `auto` rule, so `force` and `legacy` were silently inert everywhere module-ness matters: strict mode (`context/strict_mode.rs:92`), global-vs-module symbol contribution (`binder/symbols.rs:496`), lib-global queries, UMD/ambient-module resolution and TS2664.

The fix models `tsc`'s `getSetExternalModuleIndicator`, which dispatches on `getEmitModuleDetectionKind(options)` and installs one of three predicates. `isFileProbablyExternalModule` is split out as `file_has_module_syntax_indicator` and the three arms are named explicitly:

| kind | rule |
| --- | --- |
| `Force` | module syntax, or any non-declaration file |
| `Legacy` | module syntax alone; format never forces |
| `Auto` | module syntax, plus `isFileForcedToBeModuleByFormat` |

Two further defects fell out of stating the rule once instead of three times.

**The CLI-argument path was a second copy of `getEmitModuleDetectionKind`.** `driver/plan.rs` re-derived the kind for `--moduleDetection` flags and set only the printer booleans, so even after threading the config path the flag stayed inert on the command line — the first fix measured as a complete no-op until this was found. Both paths now go through one `apply_module_detection`, so the binder's kind and the emitter's booleans cannot disagree.

**`is_module_file_extension` contradicted the same function two blocks below it.** It counted `.d.mts`/`.d.cts` as format-forced modules; `isFileForcedToBeModuleByFormat` ends in `&& !file.isDeclarationFile`, and the *third* of three overlapping extension blocks in `source_file_is_external_module` already implemented that correctly. The earliest and wrongest block won by returning first, so a `.d.mts`'s ambient declarations stopped seeding the global scope. Collapsed onto the one correct helper. This is a separate, user-visible false positive:

```
lib1.d.mts   declare var wombatGlobal: number;
use.ts       wombatGlobal;

tsc  (no diagnostics)
tsz  use.ts(1,1): error TS2304: Cannot find name 'wombatGlobal'.   <- before
tsz  (no diagnostics)                                              <- after
```

**`SNAPSHOT_MAGIC` bump.** The lib snapshot cache round-trips `BinderState`, and adding a `BinderOptions` field is exactly the layout change its own doc comment says to bump the version byte for. Without it a stale `~/.cache/tsz/lib-cache` decodes to garbage and the binary aborts on a 2^48 allocation with no usable backtrace — see the NOTE on the coordination board.

## Goal
Goal: hold

## Verification

**Oracle matrix, 24 rows, three-way against the in-container `tsc` (`--noEmit --strict --pretty false`).** Rows are 7 file shapes × 3 explicit `--moduleDetection` values, plus 3 rows covering the per-`ModuleKind` default. `XX` marks a row where tsz differs from tsc.

```
                                            main                     this PR
a.ts    var eval          auto          ==                       ==
b.mts   var eval          auto        XX 1215 vs 1215,2300,2300 XX (unchanged, TS2300 family)
c.cts   var eval          auto        XX                        XX (unchanged, TS2300 family)
d.d.ts  declare-glob      auto          ==                       ==
e.d.mts declare-glob      auto          ==                       ==
f.ts    var arguments     auto          ==                       ==
g.ts    export+var eval   auto        XX                        XX (unchanged, TS2300 family)
a.ts    var eval          force       XX 1215 vs 1100,2300,2300 XX (1100 -> 1215)
b.mts   var eval          force       XX                        XX (unchanged, TS2300 family)
c.cts   var eval          force       XX                        XX (unchanged, TS2300 family)
d.d.ts  declare-glob      force         ==                       ==
e.d.mts declare-glob      force         ==                       ==
f.ts    var arguments     force       XX 1215 vs 1100              ==   FIXED
g.ts    export+var eval   force       XX                        XX (unchanged, TS2300 family)
a.ts    var eval          legacy        ==                       ==
b.mts   var eval          legacy      XX 1100,2300,2300 vs 1215    ==   FIXED
c.cts   var eval          legacy      XX 1100,2300,2300 vs 1215    ==   FIXED
d.d.ts  declare-glob      legacy        ==                       ==
e.d.mts declare-glob      legacy        ==                       ==
f.ts    var arguments     legacy        ==                       ==
g.ts    export+var eval   legacy      XX                        XX (unchanged, TS2300 family)
a.ts  --module node16     (def force) XX 1215 vs 1100,2300,2300 XX (1100 -> 1215)
a.ts  --module nodenext   (def force) XX 1215 vs 1100,2300,2300 XX (1100 -> 1215)
a.ts  --module esnext     (def auto)    ==                       ==
```

`main == tsc` **11/24**, `PR == tsc` **14/24**. **0 rows moved away from tsc.** Three rows go fully green; three more move `TS1100 -> TS1215` (the correct code) but keep a spurious `TS2300` pair.

That residual `TS2300` is a **separate, pre-existing bug that this PR neither causes nor fixes** — Kyanite's family #3 from the same sweep. It needs no flag at all to reproduce (`g.ts`: `export {}; var eval;` under plain `auto` is `XX` identically before and after), so it is a module-scoped-declaration-vs-lib-global merge bug, not a detection bug. Filed separately rather than folded in here; the `--moduleDetection`-free `g.ts auto` row is the witness. The isolated rows that observe detection alone (`f.ts`, which binds `arguments` — not a lib global — and the `.d.mts` global-visibility probe above) are clean.

**Suites run locally**, since the per-merge lane is only `clippy` + `arch-size`:

- `cargo test -p tsz-binder --lib` — **446 passed / 0 failed** (was 425; +21 new). New suite `state::tests::module_detection` is **21/21**, and its `is_external_module` helper varies file name and binder name per row so nothing can key on an identifier string.
- `cargo fmt --all` — clean.
- `cargo build -p tsz-cli --bin tsz` — clean.
- `scripts/conformance/compare-to-parent.sh` — two-sided against this branch's own parent `75a53cd`, running in-container at PR-open time; result posted as a PR comment. **Newly-failing is the gate; do not land until that number is 0.**
- Emit not run this session: `scripts/emit/run.sh`'s `npm install` step is the known cloud-container hang (standing gotcha on the board). Disclosed rather than skipped silently. The change touches no emitter code — `PrinterOptions` keeps the exact booleans it had, now written from one place instead of two — but the `.d.mts` module-ness narrowing is the hunk an emit reviewer should look at.

**Anti-hardcoding.** No identifier, alias, property or file-*name* string drives a decision: the only string tests are file *extension* suffixes, which is what `tsc`'s own `fileExtensionIsOneOf` / `isDeclarationFileName` do at the same point in the pipeline, and the net change is to *remove* two of the three redundant copies of that test. No predicate reads rendered type or printer output. No test-scoped suppression.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Olivine

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdDspxP8pCy91CZf8HTQ9C)_