### PR TITLE
fix(checker): module-scoped var shadowing a lib global must not draw TS2300

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -541,6 +541,8 @@ mod member_assignment_narrowing_join_tests;
 mod merged_interface_constraint_relation_routing_arch_tests;
 #[path = "tests/method_return_type_elaboration_tests.rs"]
 mod method_return_type_elaboration_tests;
+#[path = "tests/module_scoped_var_shadows_lib_global_ts2300_tests.rs"]
+mod module_scoped_var_shadows_lib_global_ts2300_tests;
 #[path = "tests/multi_overload_infer_capture_tests.rs"]
 mod multi_overload_infer_capture_tests;
 #[path = "tests/mutable_binding_widening_from_const_literal_tests.rs"]

--- a/crates/tsz-checker/src/tests/module_scoped_var_shadows_lib_global_ts2300_tests.rs
+++ b/crates/tsz-checker/src/tests/module_scoped_var_shadows_lib_global_ts2300_tests.rs
@@ -1,0 +1,88 @@
+//! TS2300 coverage for module-scoped declarations that share a name with a
+//! lib global (issue #16208).
+//!
+//! Structural rule: a module-scoped declaration lives in a different scope
+//! than the lib's global scope, so `tsc` never forms a duplicate-identifier
+//! conflict between them. tsz's binder intentionally leaves function-scoped
+//! `var` shadowing disabled for modules (some inference paths rely on the
+//! merged-symbol behavior), so a module-scoped `var eval` merges its
+//! declaration directly into the lib's `eval` symbol. The checker's
+//! duplicate-identifier pass re-derives each declaration's arena through
+//! `arena_for_declaration_or`, which falls back to the symbol's stale
+//! per-symbol `symbol_arenas` entry (the lib arena) whenever no precise
+//! per-declaration entry exists — as is the case for a declaration that
+//! merged in without registering one. That stale fallback made the merged
+//! local declaration and the lib declaration look like they shared one file,
+//! corrupting `same_source_file` and bypassing the module-scope skip that
+//! already exists for genuinely cross-file conflicts.
+//!
+//! Owner layer: `crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs`'s
+//! pairwise conflict scan, which now trusts the declaration's already-derived
+//! `is_local` flag instead of re-resolving the arena through the legacy
+//! per-symbol fallback.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_source_with_libs_code_messages, load_lib_files};
+
+fn module_codes(source: &str) -> Vec<u32> {
+    let libs = load_lib_files(&["es5.d.ts"]);
+    check_source_with_libs_code_messages(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|(code, _)| code)
+    .collect()
+}
+
+/// `export {}; var eval;` — `eval` is module-scoped, so it cannot collide
+/// with the global `eval` in `lib.es5.d.ts`. Only TS1215 (the unrelated
+/// strict-mode name restriction) should fire.
+#[test]
+fn module_scoped_var_eval_reports_only_strict_mode_diagnostic() {
+    let codes = module_codes("export {};\nvar eval;\n");
+    assert_eq!(
+        codes,
+        vec![1215],
+        "module-scoped `var eval` must not draw TS2300 against the lib global"
+    );
+}
+
+/// Same shape, a non-reserved lib global name (`Array`) that draws no
+/// strict-mode restriction at all — the file should be entirely clean.
+#[test]
+fn module_scoped_var_array_reports_nothing() {
+    let codes = module_codes("export {};\nvar Array;\n");
+    assert!(
+        codes.is_empty(),
+        "module-scoped `var Array` must not collide with the lib global Array, got {codes:?}"
+    );
+}
+
+/// `declare global { var eval; }` is the true augmentation case this skip
+/// must NOT suppress: the declaration explicitly requests global scope, so
+/// it still conflicts with the lib global exactly like `tsc`.
+#[test]
+fn declare_global_var_eval_still_reports_ts2300() {
+    let codes = module_codes("export {};\ndeclare global {\n  var eval;\n}\n");
+    assert!(
+        codes.contains(&2300),
+        "`declare global {{ var eval }}` must still conflict with the lib global, got {codes:?}"
+    );
+}
+
+/// A plain script (no `export`/`import`) keeps the pre-existing script-scope
+/// behavior: `var eval` at global scope still conflicts with the lib global.
+#[test]
+fn script_scoped_var_eval_still_reports_ts2300() {
+    let codes = module_codes("var eval;\n");
+    assert!(
+        codes.contains(&2300),
+        "script-scoped `var eval` must still conflict with the lib global, got {codes:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -829,14 +829,35 @@ impl<'a> CheckerState<'a> {
                         declarations[i];
                     let (other_idx, other_flags, other_is_local, other_is_exported, other_origin) =
                         declarations[j];
-                    let decl_arena =
+                    // `arena_for_declaration_or` falls back to the per-symbol
+                    // `symbol_arenas` map (the last arena the binder touched
+                    // for this symbol) when no precise per-declaration entry
+                    // exists. That legacy map goes stale the moment a local
+                    // declaration merges into a lib-derived symbol without
+                    // registering its own `declaration_arenas` entry (e.g. a
+                    // module-scoped `var` shadowing-disabled merge into a lib
+                    // global): the lookup then silently resolves the local
+                    // declaration to the lib's arena instead of the current
+                    // file, corrupting `same_source_file` and the flag
+                    // normalization below. `decl_is_local`/`other_is_local`
+                    // are already derived from the authoritative
+                    // `declaration_arenas` walk (or the "no entry means
+                    // local" default) that built `declarations`, so trust
+                    // them directly instead of re-deriving the arena.
+                    let decl_arena = if decl_is_local {
+                        self.ctx.arena
+                    } else {
                         self.ctx
                             .binder
-                            .arena_for_declaration_or(sym_id, decl_idx, self.ctx.arena);
-                    let other_arena =
+                            .arena_for_declaration_or(sym_id, decl_idx, self.ctx.arena)
+                    };
+                    let other_arena = if other_is_local {
+                        self.ctx.arena
+                    } else {
                         self.ctx
                             .binder
-                            .arena_for_declaration_or(sym_id, other_idx, self.ctx.arena);
+                            .arena_for_declaration_or(sym_id, other_idx, self.ctx.arena)
+                    };
                     let decl_conflict_flags =
                         self.normalize_duplicate_conflict_flags(decl_arena, decl_idx, decl_flags);
                     let other_conflict_flags = self.normalize_duplicate_conflict_flags(


### PR DESCRIPTION
When a module-scoped declaration shares a name with a lib global (`export {}; var eval;`), `tsc` never forms a duplicate-identifier conflict — the module-scoped declaration lives in a different scope than the lib's global scope. tsz reported a spurious `TS2300` pair (one at the lib declaration, one at the user declaration).

Structural rule: `tsc`'s binder never merges a module-scoped declaration's identity with the lib's global scope; tsz does form that merge (function-scoped `var` shadowing is intentionally disabled for modules — some inference paths rely on the merged-symbol behavior), and the duplicate-identifier pass owns keeping that merge from becoming a false conflict.

Root cause: the merge into the lib-derived symbol never registers a `declaration_arenas` entry for the new local declaration. `check_duplicate_identifiers`'s pairwise conflict scan (`crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs`) re-resolves each declaration's arena via `arena_for_declaration_or`, which falls back to the symbol's legacy per-symbol `symbol_arenas` entry (still pointing at the lib arena) whenever no precise per-declaration entry exists. That made the local and remote declarations look like they shared one file, corrupting `same_source_file` and silently bypassing the module-scope skip that already exists for genuinely cross-file conflicts.

Fix: the pairwise loop already carries an authoritative `is_local` flag per declaration (derived from the `declaration_arenas` walk that built the declaration list, or the "no entry means local" default). Trust that instead of re-deriving the arena — local declarations always resolve to the current file's arena; only remote declarations still consult the binder lookup.

## Goal
Goal: hold

## Verification
Adjacent-case matrix, verified against an in-container `tsc` 6.0.2 oracle (`/opt/node22/lib/node_modules/typescript/lib/tsc.js`):

| Case | main | this PR | tsc |
| --- | --- | --- | --- |
| `export {}; var eval;` (issue witness) | `TS1215, TS2300, TS2300` | `TS1215` | `TS1215` |
| `export {}; var Array;` (non-reserved lib global) | `TS1215, TS2300, TS2300`* | clean | clean |
| `export {}; declare global { var eval; }` (real augmentation) | `TS2300, TS2300` | `TS2300, TS2300` (unchanged) | `TS2300, TS2300` |
| `var eval;` (script, no module syntax) | `TS1100, TS2300, TS2300` | unchanged | `TS1100, TS2300, TS2300` |
| two module files each with `var eval;` | each `TS1215` only after fix | each `TS1215` only | each `TS1215` only |

\* `Array` isn't a reserved name so it never drew TS1215, but it hit the same false `TS2300` pair pre-fix.

- New unit suite `crates/tsz-checker/src/tests/module_scoped_var_shadows_lib_global_ts2300_tests.rs` (4 tests) pins these cases against a real `es5.d.ts` lib via `check_source_with_libs_code_messages`. All 4 pass.
- `cargo nextest run -p tsz-checker --lib`: 9016 tests, 9015 passed / 1 failed (`ts2303_tests::recursive_export_assignment_self_import_reports_ts2303`) — confirmed pre-existing on `main` at the parent commit (fails identically with the diff stashed out), unrelated to this change.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings`: clean.
- `cargo fmt -p tsz-checker -- --check`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.
- Conformance/emit full-corpus runs not executed this session (narrow diagnostic-scoping fix touching one pairwise-conflict branch; no corpus fixture is expected to exercise "module-scoped var shadowing a same-named lib global," matching the precedent set by sibling TS2300/TS7033 fixes in this same family — see #16186/#16201).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium

Closes #16208.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QfJnCfzSuE77vpBFtds8vC)_