### PR TITLE
fix(checker): render a computed member name by its syntax in the implicit-any diagnostics

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -965,7 +965,7 @@ impl<'a> CheckerState<'a> {
             let is_ambient_file = self.ctx.is_declaration_file();
 
             if (is_ambient_class || is_ambient_file) && !is_async && !skip_implicit_any {
-                let method_name = self.get_property_name(method.name);
+                let method_name = self.member_name_for_diagnostic(method.name);
                 self.maybe_report_implicit_any_return(
                     method_name,
                     Some(method.name),
@@ -1134,7 +1134,7 @@ impl<'a> CheckerState<'a> {
             // Async methods infer Promise<void>, not 'any', so they should NOT trigger TS7010
             // Private members in ambient classes are excluded (not visible in .d.ts)
             if !is_async && !skip_implicit_any {
-                let method_name = self.get_property_name(method.name);
+                let method_name = self.member_name_for_diagnostic(method.name);
                 self.maybe_report_implicit_any_return(
                     method_name,
                     Some(method.name),
@@ -1500,7 +1500,7 @@ impl<'a> CheckerState<'a> {
 
                 if (is_ambient_class || is_ambient_file) && !is_async && !skip_implicit_any_accessor
                 {
-                    let accessor_name = self.get_property_name(accessor.name);
+                    let accessor_name = self.member_name_for_diagnostic(accessor.name);
                     self.maybe_report_implicit_any_return(
                         accessor_name,
                         Some(accessor.name),
@@ -1618,22 +1618,18 @@ impl<'a> CheckerState<'a> {
             // (tsc's `isGetAccessorWithAnnotatedSetAccessor`); an unannotated one
             // becomes the blame site itself and is reported there by
             // `check_setter_parameter`. Either way the getter stays clean.
-            // `get_property_name` alone cannot name a computed key whose
-            // expression is a plain identifier reference (`get [k]()` for a
-            // `unique symbol` const, `get [Symbol.iterator]()`) — it
-            // deliberately skips those to avoid returning the identifier's
-            // own text. Fall back to the structured computed-name display
-            // (`declarationNameToString`-equivalent) for that case, but stop
-            // there: `property_name_for_error`'s further fallback to a raw
-            // source-text slice would also fire on a genuinely malformed
-            // computed name (`get [](); `, a parse error), where tsc reports
-            // only the syntax error and stays silent on `TS7033`.
+            // The member is named through `member_name_for_diagnostic`, which
+            // picks the renderer by the name node's kind so a computed name
+            // keeps its brackets whether or not `get_property_name` can resolve
+            // it to a key. Deliberately not `property_name_for_error`: its
+            // further fallback to a raw source-text slice would also fire on a
+            // genuinely malformed computed name (`get [](); `, a parse error),
+            // where tsc reports only the syntax error and stays silent on
+            // `TS7033`.
             if self.ctx.no_implicit_any()
                 && !self.is_js_file()
                 && self.paired_setter_member_for_getter(accessor).is_none()
-                && let Some(accessor_name) = self
-                    .get_property_name(accessor.name)
-                    .or_else(|| self.get_member_name_display_text(accessor.name))
+                && let Some(accessor_name) = self.member_name_for_diagnostic(accessor.name)
             {
                 use crate::diagnostics::diagnostic_codes;
                 self.error_at_node_msg(

--- a/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
@@ -1500,8 +1500,68 @@ impl<'a> CheckerState<'a> {
             return Some(lit.text.clone());
         }
 
+        // Computed name — `declarationNameToString` renders the *syntax*, so the
+        // brackets survive and the expression keeps its own spelling: `["a"]`,
+        // `[1.0]` and `[0x10]` (never canonicalized to `[1]` / `[16]`), `[k]`,
+        // `[Symbol.iterator]`. `get_member_name_text` cannot serve this: it is a
+        // key-shaped helper whose numeric arm both drops the brackets and
+        // canonicalizes the digits, which is right for a dedup key and wrong for
+        // a message.
+        if name_node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME
+            && let Some(computed) = self.ctx.arena.get_computed_property(name_node)
+            && let Some(inner) = self.computed_name_expression_display_text(computed.expression)
+        {
+            return Some(format!("[{inner}]"));
+        }
+
         // Fall back to get_member_name_text for computed properties, etc.
         self.get_member_name_text(name_idx)
+    }
+
+    /// The inner spelling of a computed member name, for
+    /// `get_member_name_display_text`. Returns `None` when the expression is
+    /// absent or too complex to render, which keeps a malformed computed name
+    /// (`get [](); `, a parse-error shape) unnamed rather than rendering it as
+    /// an empty `[]` — tsc reports only the syntax error there.
+    fn computed_name_expression_display_text(&self, expr_idx: NodeIndex) -> Option<String> {
+        let expr_node = self.ctx.arena.get(expr_idx)?;
+
+        if expr_node.kind == tsz_scanner::SyntaxKind::StringLiteral as u16
+            && let Some(lit) = self.ctx.arena.get_literal(expr_node)
+        {
+            return Some(format!("\"{}\"", lit.text));
+        }
+
+        if expr_node.kind == tsz_scanner::SyntaxKind::NumericLiteral as u16
+            && let Some(lit) = self.ctx.arena.get_literal(expr_node)
+        {
+            return Some(lit.text.clone());
+        }
+
+        self.get_simple_computed_name_expr_text(expr_idx)
+    }
+
+    /// The name tsc puts in a member diagnostic, via `declarationNameToString`.
+    ///
+    /// The renderer is chosen by the name node's **kind**, not by whichever
+    /// helper happens to succeed first. That distinction is the whole point:
+    /// `get_property_name` resolves a computed name whose expression is a
+    /// literal (`["foo"]`, `[0]`) to its property *key* and returns it without
+    /// the syntactic wrapper, so a first-success chain silently renders half
+    /// the computed names as bare keys and the other half — the ones
+    /// `get_property_name` declines, like `[k]` and `[Symbol.iterator]` — with
+    /// their brackets intact.
+    pub(crate) fn member_name_for_diagnostic(&self, name_idx: NodeIndex) -> Option<String> {
+        if self
+            .ctx
+            .arena
+            .get(name_idx)
+            .is_some_and(|node| node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME)
+        {
+            return self.get_member_name_display_text(name_idx);
+        }
+        self.get_property_name(name_idx)
+            .or_else(|| self.get_member_name_display_text(name_idx))
     }
 
     /// Check if an interface property type annotation circularly references

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -165,6 +165,8 @@ mod commonjs_reentrant_surface_tests;
 mod commonjs_require_binding_type_meaning_tests;
 #[path = "tests/computed_alias_source_display_tests.rs"]
 mod computed_alias_source_display_tests;
+#[path = "tests/computed_member_name_diagnostic_display_tests.rs"]
+mod computed_member_name_diagnostic_display_tests;
 #[path = "tests/computed_symbol_name_unification_tests.rs"]
 mod computed_symbol_name_unification_tests;
 #[path = "tests/concise_body_return_excess_property_tests.rs"]

--- a/crates/tsz-checker/src/tests/computed_member_name_diagnostic_display_tests.rs
+++ b/crates/tsz-checker/src/tests/computed_member_name_diagnostic_display_tests.rs
@@ -1,0 +1,208 @@
+//! Regression tests for #16204 — a computed member name keeps its brackets in
+//! the implicit-any diagnostics (TS7008 / TS7010 / TS7032 / TS7033).
+//!
+//! `tsc` names a member through `declarationNameToString`, which renders the
+//! name node's *syntax*: `["a"]`, `[0x10]`, `[k]`, `[Symbol.iterator]`. tsz
+//! used to pick the renderer by whichever helper succeeded first, so a computed
+//! name whose expression is a literal went through the semantic key resolver
+//! (`get_property_name`) and came out as a bare key — `foo`, `0`, `16` — while
+//! the names that resolver *declines* (an identifier or `Symbol.x` expression)
+//! kept their brackets. Two spellings of one message, decided by an accident of
+//! call order.
+//!
+//! Every binder name below is distinct so nothing can key on an identifier
+//! string, and the numeric rows deliberately use forms whose *key* differs from
+//! their *source spelling* (`1.0` -> key `1`, `0x10` -> key `16`): a test that
+//! only used `[0]` would pass against a renderer that still canonicalized.
+
+use crate::test_utils::check_source_strict_messages;
+
+fn message_for(source: &str, code: u32) -> Option<String> {
+    check_source_strict_messages(source)
+        .into_iter()
+        .find(|(c, _)| *c == code)
+        .map(|(_, message)| message)
+}
+
+fn assert_names(source: &str, code: u32, expected: &str) {
+    let message = message_for(source, code)
+        .unwrap_or_else(|| panic!("expected TS{code} for source:\n{source}\n"));
+    assert!(
+        message.contains(expected),
+        "TS{code} should name the member {expected}; got {message:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TS7033 — lone bodyless getter, every container a bodyless getter can appear in
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ts7033_declare_class_computed_string_name_keeps_brackets() {
+    assert_names(
+        "declare class Cq1 { get [\"pq1\"](); }",
+        7033,
+        "Property '[\"pq1\"]'",
+    );
+}
+
+#[test]
+fn ts7033_declare_class_computed_numeric_name_keeps_brackets_and_source_spelling() {
+    // `1.0` canonicalizes to the key `1`. The message must show the source form.
+    assert_names(
+        "declare class Cq2 { get [1.0](); }",
+        7033,
+        "Property '[1.0]'",
+    );
+}
+
+#[test]
+fn ts7033_declare_class_computed_hex_name_is_not_canonicalized() {
+    // `0x10` canonicalizes to the key `16`.
+    assert_names(
+        "declare class Cq3 { get [0x10](); }",
+        7033,
+        "Property '[0x10]'",
+    );
+}
+
+#[test]
+fn ts7033_interface_computed_string_name_keeps_brackets() {
+    assert_names(
+        "interface Iq4 { get [\"pq4\"](); }",
+        7033,
+        "Property '[\"pq4\"]'",
+    );
+}
+
+#[test]
+fn ts7033_type_literal_computed_string_name_keeps_brackets() {
+    assert_names(
+        "type Tq5 = { get [\"pq5\"](); };",
+        7033,
+        "Property '[\"pq5\"]'",
+    );
+}
+
+#[test]
+fn ts7033_static_computed_numeric_name_keeps_brackets() {
+    assert_names(
+        "declare class Cq6 { static get [1.0](); }",
+        7033,
+        "Property '[1.0]'",
+    );
+}
+
+#[test]
+fn ts7033_abstract_computed_numeric_name_keeps_brackets() {
+    assert_names(
+        "abstract class Cq7 { abstract get [0x10](); }",
+        7033,
+        "Property '[0x10]'",
+    );
+}
+
+#[test]
+fn ts7033_identifier_computed_name_still_keeps_brackets() {
+    // The arm that was already correct: `get_property_name` declines an
+    // identifier expression, so this row went through the display renderer
+    // before the fix and must be unchanged by it.
+    assert_names(
+        "declare const kq8: unique symbol; declare class Cq8 { get [kq8](); }",
+        7033,
+        "Property '[kq8]'",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The sibling codes that share the renderer
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ts7032_setter_computed_numeric_name_keeps_brackets() {
+    assert_names(
+        "declare class Cq9 { set [1.0](v); }",
+        7032,
+        "Property '[1.0]'",
+    );
+}
+
+#[test]
+fn ts7032_interface_setter_computed_string_name_keeps_brackets() {
+    assert_names(
+        "interface Iq10 { set [\"pq10\"](v); }",
+        7032,
+        "Property '[\"pq10\"]'",
+    );
+}
+
+#[test]
+fn ts7008_property_computed_numeric_name_keeps_brackets() {
+    assert_names("declare class Cq11 { [0x10]; }", 7008, "Member '[0x10]'");
+}
+
+#[test]
+fn ts7010_bodyless_method_computed_string_name_keeps_brackets() {
+    assert_names(
+        "declare class Cq12 { [\"pq12\"](); }",
+        7010,
+        "'[\"pq12\"]', which lacks return-type annotation",
+    );
+}
+
+#[test]
+fn ts7010_bodyless_method_computed_identifier_name_is_not_downgraded_to_ts7011() {
+    // An unnamable member fell through to TS7011 ("Function expression, which
+    // lacks return-type annotation..."). A computed identifier name is
+    // nameable, so tsc reports TS7010 with the bracketed name — this row is a
+    // diagnostic *code* divergence, not only a message one.
+    let source = "declare const kq13: unique symbol; declare class Cq13 { [kq13](); }";
+    let codes: Vec<u32> = check_source_strict_messages(source)
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect();
+    assert!(
+        !codes.contains(&7011),
+        "a nameable computed member must not fall through to TS7011; got {codes:?}"
+    );
+    assert_names(source, 7010, "'[kq13]', which lacks return-type annotation");
+}
+
+// ---------------------------------------------------------------------------
+// Controls — non-computed names are named by their key, unchanged
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ts7033_plain_identifier_name_has_no_brackets() {
+    let message = message_for("declare class Cq14 { get pq14(); }", 7033)
+        .expect("expected TS7033 for a plain identifier getter");
+    assert!(
+        message.contains("Property 'pq14'") && !message.contains('['),
+        "a non-computed name must not gain brackets; got {message:?}"
+    );
+}
+
+#[test]
+fn ts7008_plain_identifier_name_has_no_brackets() {
+    let message = message_for("declare class Cq15 { pq15; }", 7008)
+        .expect("expected TS7008 for a plain identifier property");
+    assert!(
+        message.contains("Member 'pq15'") && !message.contains('['),
+        "a non-computed name must not gain brackets; got {message:?}"
+    );
+}
+
+#[test]
+fn malformed_computed_name_reports_no_implicit_any_member_diagnostic() {
+    // A computed name with no expression is a parse-error shape. tsc reports
+    // only the syntax error, so the renderer must return `None` rather than an
+    // empty `[]`, and the implicit-any diagnostics must stay off.
+    let codes: Vec<u32> = check_source_strict_messages("declare class Cq16 { get [](); }")
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect();
+    assert!(
+        !codes.contains(&7033),
+        "a malformed computed name must not draw TS7033; got {codes:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/queries/class.rs
+++ b/crates/tsz-checker/src/types/queries/class.rs
@@ -562,16 +562,7 @@ impl<'a> CheckerState<'a> {
 
     /// Get the name of a property for error messages.
     pub(crate) fn property_name_for_error(&self, name_idx: NodeIndex) -> Option<String> {
-        self.get_property_name(name_idx).or_else(|| {
-            if self
-                .ctx
-                .arena
-                .get(name_idx)
-                .is_some_and(|n| n.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME)
-                && let Some(display_name) = self.get_member_name_display_text(name_idx)
-            {
-                return Some(display_name);
-            }
+        self.member_name_for_diagnostic(name_idx).or_else(|| {
             self.node_text(name_idx)
                 .map(|text| text.trim().to_string())
                 .filter(|text| !text.is_empty())


### PR DESCRIPTION
Closes #16204.

**Structural rule.** When a member's name node is a `ComputedPropertyName`, `tsc` names it in a diagnostic through `declarationNameToString`, which renders the name node's **syntax** — the brackets survive and the inner expression keeps its own source spelling. tsz now does the same through the **checker's diagnostic-display layer**; no type semantics move.

tsz chose the renderer by **whichever helper happened to succeed first**, not by what the name node is:

```
get ["foo"]()            get_property_name succeeds  ->  'foo'                 brackets + quotes dropped
get [0x10]()             get_property_name succeeds  ->  '16'                  brackets dropped AND canonicalized
get [k]()                get_property_name declines  ->  '[k]'                 correct
get [Symbol.iterator]()  get_property_name declines  ->  '[Symbol.iterator]'   correct
```

`get_property_name` resolves a computed name whose expression is a literal to its property **key** and returns it without the syntactic wrapper. That is correct for a key and wrong for a message, so a first-success chain rendered half the computed names one way and half the other — and the half it got right was the half the key resolver *refused*.

### What changed

`get_member_name_display_text` now renders a `ComputedPropertyName` itself instead of delegating to `get_member_name_text`. That helper is key-shaped: its computed-numeric arm both drops the brackets and canonicalizes the digits (`[1.0]` -> `1`, `[0x10]` -> `16`), which is right for a dedup key and wrong for a message. Its computed-*string* arm already produced `["a"]`, so the two halves of one function disagreed — the same read-all-N-copies shape as #16207's extension blocks. `get_member_name_text` is left untouched; the display path no longer routes through it for computed names.

A new `member_name_for_diagnostic` picks the renderer by the name node's **kind**, and the TS7008 / TS7010 / TS7032 / TS7033 sites route through it. `property_name_for_error` (the type-member arm's renderer, used by `function_type.rs` too) is rewritten on top of it and keeps its raw-source-text last resort; the ambient-class TS7033 site deliberately does **not** take that last resort, because a source slice would also fire on a malformed computed name (`get [](); `, a parse error) where tsc reports only the syntax error.

Returning `None` for an unrenderable computed expression is load-bearing in both directions — it is what keeps the malformed shape silent, and there is a test for it.

**This is not only a message-text change.** #16204 called the family cosmetic, and one row is not. An unnamable member fell through from TS7010 to **TS7011** ("Function expression, which lacks return-type annotation, implicitly has an 'any' return type") because `maybe_report_implicit_any_return` branches on `name.is_none()`. A computed identifier name is nameable by tsc, so tsz reported a different diagnostic code, not a differently-worded one:

```
declare const k: unique symbol;
declare class C { [k](); }

tsc   TS7010  '[k]', which lacks return-type annotation, implicitly has an 'any' return type.
tsz   TS7011  Function expression, which lacks return-type annotation, ...   [ before ]
tsz   TS7010  '[k]', which lacks return-type annotation, ...                 [ after  ]
```

## Goal
Goal: hold

## Verification

**Oracle matrix, 108 rows, three-way against in-container `tsc@7.0.2`** (`--noEmit --strict --lib es2022 --target es2022 --pretty false`). Rows are 6 declaration sites (`get`, `static get`, `abstract get`, `set`, bare property, bodyless method) x their legal containers (`declare class`, `abstract class`, `interface`, type literal) x 9 name forms (`["foo"]`, `[0]`, `[1.0]`, `[0x10]`, `[k]` with `unique symbol`, `[Symbol.iterator]`, and the non-computed controls `foo`, `"foo"`, `0`). **Every row uses a distinct binder name** (`b0`..`b107`) so nothing can key on an identifier string.

```
                     rows == tsc      FIXED   BROKE   MOVED AWAY
main                    49 / 108
this PR                 96 / 108        47      0         0
```

Diagnostic **count, code and position were already identical on all 108 rows** (135 diagnostics both sides) except the TS7011/TS7010 row above — this family is a renderer defect, so the matrix is the primary evidence and the corpus is a floor, per the board's standing note that zero conformance movement is the expected signature here.

The residual **12 rows are one shape and are not this bug**: a non-computed **string-literal** name (`get "foo"()`), where tsc prints the source spelling `"foo"` and tsz prints the bare key `foo` (and, at TS7008 only, `'foo'` with single quotes). That needs source-quote fidelity — recovering which quote character the author wrote — which is a different mechanism from the bracket decision, and `get_member_name_display_text`'s single-quote convention has 17 callers. Filed separately rather than folded in; the numbers above count those 12 as still-diverging.

**Suites run locally**, since the per-merge lane is only `clippy` + `arch-size`:

- `cargo test -p tsz-checker --lib computed_member_name_diagnostic_display` — **16 passed / 0 failed**. New suite covers all four codes, both computed literal kinds, the four containers, `static`/`abstract`, the already-correct identifier arm as a containment control, two non-computed controls asserting a plain name does *not* gain brackets, and the malformed-`[]` silence row. The numeric rows use `[1.0]` and `[0x10]` deliberately: a test written on `[0]` alone passes against a renderer that still canonicalizes.
- `cargo clippy -p tsz-checker --lib --all-features` — clean.
- `cargo fmt --all` — clean. Pre-commit hook (clippy + architecture guard) passed.
- Full `cargo test -p tsz-checker --lib` and `scripts/conformance/compare-to-parent.sh` were still running when the PR was opened; results are posted as a PR comment. **Newly-failing is the gate — do not land until that number is confirmed 0.**
- Emit not run: `scripts/emit/run.sh`'s `npm install` step is the known cloud-container hang (standing board gotcha). Disclosed rather than skipped silently. The change touches no emitter code and no type is constructed, widened or dropped — only the string a diagnostic is formatted with.

**Anti-hardcoding.** No user identifier, alias, property or file name drives any decision; the renderer dispatches on `SyntaxKind` only. No predicate reads rendered type or printer output — the direction is strictly types-to-printer. No test-scoped suppression. Every oracle row and every unit test varies its binder name.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Zircon

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXTqHN8nWZ5zy2Ecufb93K)_