### PR TITLE
fix(checker): only ignoreDeprecations "6.0" silences the deprecated-assert TS2880

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/capabilities.rs
+++ b/crates/tsz-checker/src/query_boundaries/capabilities.rs
@@ -100,6 +100,9 @@ pub struct EnvironmentCapabilities {
     pub resolve_json_module: bool,
     pub experimental_decorators: bool,
     pub ignore_deprecations: bool,
+    /// `ignoreDeprecations` was set to exactly `"6.0"` — the only value that
+    /// silences TS2880. See `CheckerOptions::ignore_deprecations_6_0`.
+    pub ignore_deprecations_6_0: bool,
     pub verbatim_module_syntax: bool,
     pub types_explicitly_set: bool,
 
@@ -160,6 +163,7 @@ impl EnvironmentCapabilities {
             resolve_json_module: options.resolve_json_module,
             experimental_decorators: options.experimental_decorators,
             ignore_deprecations: options.ignore_deprecations,
+            ignore_deprecations_6_0: options.ignore_deprecations_6_0,
             verbatim_module_syntax: options.verbatim_module_syntax,
             types_explicitly_set: options.types_explicitly_set,
             has_deprecation_diagnostics: false, // set by driver after config parsing

--- a/crates/tsz-checker/src/query_boundaries/environment.rs
+++ b/crates/tsz-checker/src/query_boundaries/environment.rs
@@ -236,10 +236,18 @@ impl EnvironmentCapabilities {
     /// Check whether the deprecated `assert` keyword for import attributes
     /// should produce a diagnostic (TS2880).
     ///
-    /// Returns `Some(ImportAssertDeprecated)` when `ignore_deprecations` is false
-    /// (meaning the deprecation is not suppressed by the user's config).
+    /// Returns `Some(ImportAssertDeprecated)` unless `ignoreDeprecations` is
+    /// exactly `"6.0"`.
+    ///
+    /// The gate is the *value*, not the presence of the option. `tsc` spells
+    /// this as `compilerOptions.ignoreDeprecations !== "6.0"` at all three of
+    /// its emission sites (`checkImportCallExpression`,
+    /// `checkImportDeclaration`, `checkImportType`), which this boundary is the
+    /// single counterpart to. `ignoreDeprecations: "5.0"` is accepted by the
+    /// option validator and still reports TS2880: it names an older grace
+    /// window than the release that removed the `assert` keyword.
     pub(crate) const fn check_import_assert_deprecated(&self) -> Option<CapabilityDiagnostic> {
-        if !self.ignore_deprecations {
+        if !self.ignore_deprecations_6_0 {
             Some(CapabilityDiagnostic::ImportAssertDeprecated)
         } else {
             None

--- a/crates/tsz-checker/src/symbols/symbol_resolver_utils.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver_utils.rs
@@ -1226,6 +1226,23 @@ impl<'a> CheckerState<'a> {
         })
     }
 
+    /// The value of a key/value directive, with any surrounding quotes
+    /// stripped so `@opt: 6.0` and `@opt: "6.0"` read alike.
+    ///
+    /// Directives whose value is a version string rather than a boolean
+    /// (`@ignoreDeprecations`) need the text, which `bool_pragma` discards.
+    fn value_pragma<'d>(
+        directives: &[tsz_common::test_directives::DirectiveLine<'d>],
+        key: &str,
+    ) -> Option<&'d str> {
+        let name = key.strip_prefix('@').unwrap_or(key);
+        directives.iter().find_map(|directive| {
+            directive
+                .key_is(name)
+                .then(|| directive.value.trim_matches(['"', '\'']))
+        })
+    }
+
     /// The leading comment block of a source file: non-empty lines from the
     /// top of the file up to the first non-comment line, capped at 32 lines.
     /// Test pragmas are only honored in this region so a directive-shaped
@@ -1344,11 +1361,16 @@ impl<'a> CheckerState<'a> {
             .unwrap_or(defaults.allow_unused_labels);
 
         // @ignoreDeprecations: "5.0"/"6.0" carries a version string, and the
-        // flag form also counts as present, so it is a presence check over
-        // the leading comment block rather than a `pragmas` lookup (the
+        // flag form also counts as present, so presence is a scan over the
+        // leading comment block rather than a `pragmas` lookup (the
         // pre-parsed slice only holds key/value directives).
         if Self::source_has_pragma(text, "@ignoredeprecations") {
             opts.ignore_deprecations = true;
+            // The *value* is a separate question from presence: only "6.0"
+            // silences TS2880. The flag form carries no version, so it cannot
+            // reach the "6.0" threshold.
+            opts.ignore_deprecations_6_0 =
+                Self::value_pragma(&pragmas, "@ignoredeprecations") == Some("6.0");
         }
     }
 

--- a/crates/tsz-checker/tests/environment_capabilities_tests.rs
+++ b/crates/tsz-checker/tests/environment_capabilities_tests.rs
@@ -1039,18 +1039,42 @@ fn test_import_assert_deprecated_fires_by_default() {
 }
 
 #[test]
-fn test_import_assert_deprecated_suppressed_by_ignore_deprecations() {
+fn test_import_assert_deprecated_suppressed_only_by_ignore_deprecations_6_0() {
     use tsz_checker::query_boundaries::capabilities::EnvironmentCapabilities;
 
     let opts = CheckerOptions {
         ignore_deprecations: true,
+        ignore_deprecations_6_0: true,
         ..CheckerOptions::default()
     };
     let caps = EnvironmentCapabilities::from_options(&opts, true);
     assert_eq!(
         caps.check_import_assert_deprecated(),
         None,
-        "TS2880 should NOT fire when ignore_deprecations is true"
+        "TS2880 should NOT fire when ignoreDeprecations is \"6.0\""
+    );
+}
+
+#[test]
+fn test_import_assert_deprecated_not_suppressed_by_ignore_deprecations_5_0() {
+    use tsz_checker::query_boundaries::capabilities::EnvironmentCapabilities;
+    use tsz_checker::query_boundaries::environment::CapabilityDiagnostic;
+
+    // `ignoreDeprecations: "5.0"` is a legal value and sets the presence flag,
+    // but it names an older grace window than the release that removed the
+    // `assert` keyword, so tsc still reports TS2880. Verified against tsc at
+    // all four emission sites (import/export declaration, import type,
+    // dynamic import).
+    let opts = CheckerOptions {
+        ignore_deprecations: true,
+        ignore_deprecations_6_0: false,
+        ..CheckerOptions::default()
+    };
+    let caps = EnvironmentCapabilities::from_options(&opts, true);
+    assert_eq!(
+        caps.check_import_assert_deprecated(),
+        Some(CapabilityDiagnostic::ImportAssertDeprecated),
+        "TS2880 should still fire when ignoreDeprecations is \"5.0\""
     );
 }
 
@@ -1077,18 +1101,63 @@ fn test_import_assert_deprecated_checker_integration_ts2880() {
 #[test]
 fn test_import_assert_deprecated_suppressed_checker_integration() {
     let diags = check_with_options(
-        r#"import data from './data.json' assert { type: "json" };"#,
+        r#"import payload from './payload.json' assert { type: "json" };"#,
         CheckerOptions {
             module: ModuleKind::ESNext,
             ignore_deprecations: true,
+            ignore_deprecations_6_0: true,
             ..CheckerOptions::default()
         },
     );
     let ts2880: Vec<_> = diags.iter().filter(|d| d.code == 2880).collect();
     assert!(
         ts2880.is_empty(),
-        "Expected NO TS2880 with ignore_deprecations=true, got: {ts2880:?}"
+        "Expected NO TS2880 with ignoreDeprecations=\"6.0\", got: {ts2880:?}"
     );
+}
+
+#[test]
+fn test_import_assert_deprecated_not_suppressed_by_5_0_checker_integration() {
+    let diags = check_with_options(
+        r#"import records from './records.json' assert { type: "json" };"#,
+        CheckerOptions {
+            module: ModuleKind::ESNext,
+            ignore_deprecations: true,
+            ignore_deprecations_6_0: false,
+            ..CheckerOptions::default()
+        },
+    );
+    let ts2880: Vec<_> = diags.iter().filter(|d| d.code == 2880).collect();
+    assert!(
+        !ts2880.is_empty(),
+        "Expected TS2880 with ignoreDeprecations=\"5.0\", got: {diags:?}"
+    );
+}
+
+/// The `with` keyword is the replacement spelling and must stay silent under
+/// every `ignoreDeprecations` value — the negative control for the gate above.
+#[test]
+fn test_import_with_attributes_never_reports_ts2880() {
+    for (ignore_deprecations, ignore_deprecations_6_0) in
+        [(false, false), (true, false), (true, true)]
+    {
+        let diags = check_with_options(
+            r#"import entries from './entries.json' with { type: "json" };"#,
+            CheckerOptions {
+                module: ModuleKind::ESNext,
+                ignore_deprecations,
+                ignore_deprecations_6_0,
+                ..CheckerOptions::default()
+            },
+        );
+        let ts2880: Vec<_> = diags.iter().filter(|d| d.code == 2880).collect();
+        assert!(
+            ts2880.is_empty(),
+            "`with` must never report TS2880 \
+             (ignore_deprecations={ignore_deprecations}, 6_0={ignore_deprecations_6_0}), \
+             got: {ts2880:?}"
+        );
+    }
 }
 
 // =============================================================================

--- a/crates/tsz-cli/src/driver/plan.rs
+++ b/crates/tsz-cli/src/driver/plan.rs
@@ -234,6 +234,9 @@ pub(super) fn apply_cli_overrides_with_config_options(
         && (id == "5.0" || id == "6.0")
     {
         options.checker.ignore_deprecations = true;
+        // Only "6.0" silences the deprecated-`assert` diagnostic (TS2880);
+        // "5.0" is a legal value that leaves it reporting.
+        options.checker.ignore_deprecations_6_0 = id == "6.0";
     }
     if let Some(val) = args.allow_unreachable_code {
         options.checker.allow_unreachable_code = Some(val);

--- a/crates/tsz-common/src/options/checker.rs
+++ b/crates/tsz-common/src/options/checker.rs
@@ -193,9 +193,30 @@ pub struct CheckerOptions {
     /// verbatim-only cases at the import statement. Recover the raw flag as
     /// `isolated_modules && !isolated_modules_from_verbatim`.
     pub isolated_modules_from_verbatim: bool,
-    /// When true, suppress deprecation warnings (e.g., TS2880 for `assert` import assertions).
+    /// When true, a valid `ignoreDeprecations` version was supplied.
     /// Set when `ignoreDeprecations` is "5.0" or "6.0".
+    ///
+    /// This records *presence*, not what the value silences. `ignoreDeprecations`
+    /// is a version string naming the release whose deprecations the user is
+    /// opting out of, so each deprecation has its own threshold and a single
+    /// bool cannot answer for all of them. Consumers that need a specific
+    /// threshold must ask for it: the deprecated `assert` import-attribute
+    /// keyword (TS2880) is silenced by `"6.0"` *only*, which is
+    /// `ignore_deprecations_6_0` below.
     pub ignore_deprecations: bool,
+    /// When true, `ignoreDeprecations` was set to exactly `"6.0"`.
+    ///
+    /// `tsc` gates the deprecated-`assert` diagnostic (TS2880) on the literal
+    /// value rather than on presence — `checkImportCallExpression`,
+    /// `checkImportDeclaration` and `checkImportType` each test
+    /// `compilerOptions.ignoreDeprecations !== "6.0"`. `"5.0"` is a legal value
+    /// that does *not* silence it, because it names a strictly older grace
+    /// window than the release that removed `assert`.
+    ///
+    /// Same shape as `isolated_modules_from_verbatim` above: the coarse flag
+    /// stays for the consumers that want presence, and this one recovers the
+    /// distinction the coarse flag erases.
+    pub ignore_deprecations_6_0: bool,
     /// When true, allow accessing UMD globals from modules without importing them.
     /// Suppresses TS2686 ("refers to a UMD global, but the current file is a module").
     pub allow_umd_global_access: bool,
@@ -300,6 +321,7 @@ impl Default for CheckerOptions {
             verbatim_module_syntax: false,
             isolated_modules_from_verbatim: false,
             ignore_deprecations: false,
+            ignore_deprecations_6_0: false,
             allow_umd_global_access: false,
             preserve_const_enums: false,
             strict_builtin_iterator_return: true,

--- a/crates/tsz-core/src/config/resolved_options.rs
+++ b/crates/tsz-core/src/config/resolved_options.rs
@@ -829,6 +829,10 @@ pub fn resolve_compiler_options(
         && (id == "5.0" || id == "6.0")
     {
         resolved.checker.ignore_deprecations = true;
+        // Only "6.0" silences the deprecated-`assert` diagnostic (TS2880);
+        // "5.0" is a legal value that leaves it reporting. Mirrors the CLI
+        // override path in `tsz-cli`'s `driver::plan`.
+        resolved.checker.ignore_deprecations_6_0 = id == "6.0";
     }
 
     if let Some(allow_umd) = options.allow_umd_global_access {

--- a/crates/tsz-core/tests/checker_state_tests_parts/part_16.rs
+++ b/crates/tsz-core/tests/checker_state_tests_parts/part_16.rs
@@ -401,6 +401,7 @@ fn test_tier_2_type_checker_accuracy_fixes() {
             verbatim_module_syntax: false,
             isolated_modules_from_verbatim: false,
             ignore_deprecations: false,
+            ignore_deprecations_6_0: false,
             allow_umd_global_access: false,
             preserve_const_enums: false,
             strict_builtin_iterator_return: true,


### PR DESCRIPTION
**Structural rule.** When `ignoreDeprecations` is set to any accepted value other than the literal `"6.0"`, `tsc` still reports **TS2880** for the deprecated `assert` import-attribute keyword; only `"6.0"` silences it. tsz now does the same through the **checker's environment query boundary**, `EnvironmentCapabilities::check_import_assert_deprecated`. No type semantics move.

`ignoreDeprecations` is a **version string** naming the release whose deprecations the user is opting out of, so each deprecation has its own threshold and one bool cannot answer for all of them. `"5.0"` is a legal value (the option validator accepts exactly `"5.0"` and `"6.0"`) that does **not** silence TS2880 — it names a strictly older grace window than the release that removed `assert`.

This is read out of real `tsc` rather than inferred. `/opt/node22/lib/node_modules/typescript/lib/typescript.js` is non-minified compiled source, and the rule appears verbatim at all three emission sites:

```
82373   if (compilerOptions.ignoreDeprecations !== "6.0" && isObjectLiteralExpression(node.arguments[1]))   checkImportCallExpression
86623   if (node.attributes.token !== WithKeyword && compilerOptions.ignoreDeprecations !== "6.0")          checkImportDeclaration
90832   if (!isImportAttributes2 && compilerOptions.ignoreDeprecations !== "6.0")                           checkImportType
```

### What was wrong

`CheckerOptions::ignore_deprecations` is a **bool**, and every entry point collapsed the version into it, so any accepted value suppressed the diagnostic and the version never reached the checker at all — the gate could not express tsc's rule even in principle. Three independent entry points had the same defect:

| entry point | before |
|---|---|
| `tsz-cli/src/driver/plan.rs:233` (CLI overrides) | `Some("5.0") \| Some("6.0")` → `ignore_deprecations = true` |
| `tsz-core/src/config/resolved_options.rs:828` (tsconfig) | same collapse |
| `tsz-checker/src/symbols/symbol_resolver_utils.rs:1351` (source pragma) | **presence check** — `source_has_pragma("@ignoredeprecations")`, version discarded outright |

The pragma path is the one the conformance corpus runs through, and its own comment acknowledged the version string exists before dropping it.

### What changed

`CheckerOptions` gains `ignore_deprecations_6_0` beside the existing presence flag — the same shape as the neighbouring `isolated_modules_from_verbatim`: the coarse flag stays for consumers that want presence, and the new one recovers the distinction the coarse flag erases. All three entry points set it (the pragma path via a new `value_pragma` helper, since `bool_pragma` discards the text), and the single TS2880 query boundary gates on it.

**The coarse flag keeps its other consumer** — `declarations/import/core/helpers.rs:39`, classic-`moduleResolution` module-not-found suppression. Its correct version semantics are a separate question I did not verify, so it is deliberately unchanged.

**The `"6.0"`-only rule was already encoded twice elsewhere in this repo**, so this was an inconsistency between tsz layers as much as a gap against tsc: `plan.rs:1162 cli_ignore_deprecations_silences_6_0` and `tsz-core/config/mod.rs:1363 config_ignore_deprecations_silences_6_0`, both for the TS5108 path. The CLI knew the value was a version; the checker got a bool.

## Goal
Goal: hold

## Verification

**Oracle matrix, 24 rows, two-way against `tsc` 6.0.2** (`--noEmit --strict --module esnext --target esnext --moduleResolution bundler --pretty false`). 4 emission sites x {`assert`, `with`} x `ignoreDeprecations` {absent, `5.0`, `6.0`}. **Every row uses a distinct binder name** (`b0`..`b23`) and its own module, so nothing can key on an identifier or file name.

```
                                        rows == tsc     FIXED   BROKE
parent (e7fd877^)                          20 / 24
this PR                                    24 / 24        4       0
```

The 4 moved rows are exactly the `assert` + `ignoreDeprecations: "5.0"` cell at each of the four sites — tsc reports TS2880, tsz reported nothing. Every other cell was already correct and stays correct, including all 12 `with` rows (the negative control: the replacement spelling must never report TS2880 under any value) and the 4 `assert` + `"6.0"` rows (the suppression that is genuinely correct and must survive).

**Corpus rows this targets.** From the committed `scripts/conformance/conformance-detail.json`, three rows are `{"e": ["TS2880"], "m": ["TS2880"]}` — tsc reports it, tsz reports nothing: `importAssertionsDeprecatedIgnored.ts`, `importTypeAssertionDeprecationIgnored.ts`, `nodeModulesImportTypeModeDeclarationEmitErrors1.ts`. A fourth, `importTypeAssertionDeprecation.ts`, carries TS2880 on **both** sides and still fails, so it is a count/position residual in the same family and this PR does not claim it.

**Blast radius is bounded and was checked, not assumed.** The change makes TS2880 fire in *strictly more* cases, and only in the `ignoreDeprecations != "6.0"` cell. Every pre-existing `ignoreDeprecations` usage in the repo passes `"6.0"` (`tsz-cli/tests/driver_tests_parts/part_04.rs:1022,1039`, `tsz-cli/src/driver/emit_tests.rs:244,281`, `tsz-checker/tests/repro_parserreal.rs:13`), so it is a no-op for all of them. The only two `"5.0"` fixtures in the tree (`tsz-core/src/config/tests/module_resolution.rs:363,948`) assert TS5023 and TS5103 — config validation, not TS2880.

**Suites run locally**, since the per-merge lane is only `clippy` + `arch-size`:

- `cargo clippy --workspace --all-targets` — **clean**. Run at workspace scope deliberately: this widens a shared options struct, and a per-crate run is not sufficient for that (Olivine's 13:51Z board note). It caught exactly what that note predicts — a full `CheckerOptions` struct literal in `tsz-core/tests/checker_state_tests_parts/part_16.rs:403` that a per-crate `-p tsz-checker` run never compiles.
- `cargo fmt --all` — clean. Pre-commit hook (clippy over the 4 touched crates + architecture guard) passed.
- `cargo test -p tsz-checker --lib environment_capabilities` — results posted as a PR comment.
- **Emit not run**: `scripts/emit/run.sh`'s `npm install` step is the known cloud-container hang (standing board gotcha). Disclosed rather than skipped silently. The change touches no emitter code and constructs, widens or drops no type — it decides whether one grammar diagnostic is emitted.
- **Conformance not run in-container**: no TypeScript submodule on this seat. The corpus evidence above is from the committed artifact (a real run on main), and the oracle matrix is the primary evidence.

**Tests added.** The existing `test_import_assert_deprecated_suppressed_by_ignore_deprecations` **pinned the defect** — it asserted TS2880 must not fire whenever the presence bool is set. It is rewritten to the actual rule and joined by the cell it was missing:

- `..._suppressed_only_by_ignore_deprecations_6_0` — `"6.0"` still suppresses (the correct half, protected).
- `..._not_suppressed_by_ignore_deprecations_5_0` — `"5.0"` still reports, at the query boundary.
- `..._not_suppressed_by_5_0_checker_integration` — same, end-to-end through the checker.
- `test_import_with_attributes_never_reports_ts2880` — `with` stays silent across all three option states.

**Anti-hardcoding.** No user identifier, alias, property or file name drives any decision; the gate reads one option value. No predicate reads rendered type or printer output. No test-scoped suppression, and no accepted-regression entry. Every oracle row varies its binder name and module name.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Gabbro

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4m4X161yQpCc5QEtqwbfe)_