### PR TITLE
docs(skill): name the pinned 7.0.2 oracle in tsz-conformance

### DIFF
--- a/.agents/skills/tsz-conformance/SKILL.md
+++ b/.agents/skills/tsz-conformance/SKILL.md
@@ -28,6 +28,28 @@ python3 scripts/conformance/query-conformance.py --code TS2322 --paths-only
 Artifacts: `conformance-detail.json`, `conformance-snapshot.json`,
 `conformance-accepted-regressions.txt`, `conformance-shard-weights.json`.
 
+## Oracle
+
+Semantics come from the **pinned** compiler, not from any other copy on the box:
+
+```bash
+node scripts/node_modules/typescript/lib/tsc.js --version   # Version 7.0.2
+```
+
+- `TypeScript/` (submodule) and any container-global
+  `/opt/**/node_modules/typescript` are the **6.0** line. They are corpus and
+  test *cases* only — never the source of a semantic rule.
+- Reading a rule out of 6.0 source and pinning it with tests lands the wrong
+  behaviour: #16215 encoded `ignoreDeprecations !== "6.0"` from a 6.0.2
+  `typescript.js`, but 7.0 removed that grace window entirely (#16217).
+- 7.0 traps when hand-oracling: **`--target es5` was removed** — it answers
+  `error TS5108` and emits nothing else, and that line carries no `file.ts(l,c):`
+  prefix, so a row filter drops it and every row reads clean. `strict` also
+  defaults to true.
+
+Check raw output once before trusting a filtered sweep: an invalid invocation and
+a clean compile are indistinguishable after filtering.
+
 ## Focused Run
 
 ```bash


### PR DESCRIPTION
Adds an `## Oracle` section to the `tsz-conformance` skill naming the pinned compiler.

## Why

**Two PRs in one day were verified against the wrong TypeScript.** Both used a container-global `tsc` **6.0.2** rather than the repo's pinned **7.0.2** at `scripts/node_modules/typescript/lib/tsc.js`.

- #16211 reached the same answers anyway — luck, not method.
- #16215 did not. Its rule came from `compilerOptions.ignoreDeprecations !== "6.0"`, read verbatim (with line numbers) out of a 6.0.2 `typescript.js`. 7.0 removed that grace window entirely, so `ignoreDeprecations: "6.0"` no longer silences TS2880. It merged, and `main` now pins the 6.0 behaviour with tests — filed as #16217.

The rule under test there *was itself a version threshold*, which is exactly where the two lines are most likely to disagree.

Nothing agent-facing named the pinned binary: `grep -rn "scripts/node_modules/typescript" --include="*.md" .agents/ docs/ AGENTS.md .claude/` returns one incidental hit in `docs/specs/TSC_LIB_LOADING.md`, and the conformance skill — the document an agent reads before doing parity work — did not mention an oracle at all.

## What it says

- The pinned binary, with the `--version` command to confirm it.
- `TypeScript/` and container-global installs are the 6.0 line: corpus and test *cases* only, never a semantic source.
- The two 7.0 hand-oracling traps: `--target es5` was **removed** (it answers `TS5108`, emits nothing else, and that line has no `file.ts(l,c):` prefix — so a row filter drops it and every row reads *clean*), and `strict` defaults to true.

That last one is worth the space: I hit it re-deriving #16211's matrix and briefly had eight rows of false "clean". An invalid invocation and a clean compile are indistinguishable once filtered.

## Goal
Goal: hold

## Verification
- `python3 scripts/agents/llm-context-audit.py` — exits 1 both **before and after** this change, with the same 2 findings, both in `.claude/skills/rust-debugger/SKILL.md` (line and word budgets). Pre-existing and untouched here; verified by stashing this diff and re-running.
- The edited file is **73 lines / 345 words** against the audit's 120-line / 900-word skill budget, and the audit does not flag it.
- Documentation only — no source, script, or workflow changes; no suite can move.

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high
AgentName: Quartz
