### PR TITLE
fix(checker): request-scoped import sites lose path-less module resolution (spurious TS2307 on untyped packages)

### DIFF
--- a/crates/tsz-checker/src/context/resolver.rs
+++ b/crates/tsz-checker/src/context/resolver.rs
@@ -233,6 +233,44 @@ impl<'a> CheckerContext<'a> {
         self.get_resolution_error(specifier)
     }
 
+    /// Whether this request resolved to a module that has no program file.
+    ///
+    /// Some specifiers resolve successfully without ever producing a file the
+    /// program can index: an ambient `declare module "x"` target, and an
+    /// untyped JavaScript module under `node_modules` picked up by the
+    /// resolver's JS probe (`ModuleLookupResult::untyped_js`). The driver
+    /// records those in the mode-agnostic `resolved_modules` set, because
+    /// `resolved_module_request_paths` is keyed by a program file index it
+    /// does not have for them.
+    ///
+    /// Request-scoped consumers therefore cannot simply ignore
+    /// `resolved_modules` whenever the driver supplied request-keyed paths —
+    /// that makes path-less resolution invisible and reports a spurious
+    /// TS2307. They must instead ask whether *this* request produced a
+    /// resolution error of its own; a request that failed always records one,
+    /// so its absence plus membership in the set means the specifier resolved
+    /// path-lessly here.
+    pub fn module_resolved_without_program_file_for_request(
+        &self,
+        specifier: &str,
+        resolution_mode_override: Option<ResolutionModeOverride>,
+        request_kind: ResolutionRequestKind,
+    ) -> bool {
+        let Some(resolved) = self.resolved_modules.as_ref() else {
+            return false;
+        };
+        if !resolved.contains(specifier) {
+            return false;
+        }
+        if self.resolved_module_request_paths.is_none() {
+            // No request-keyed data at all: the mode-agnostic set is the only
+            // signal the driver produced, so it is authoritative.
+            return true;
+        }
+        self.get_resolution_error_for_request(specifier, resolution_mode_override, request_kind)
+            .is_none()
+    }
+
     /// Get the resolution error for a specifier under the exact driver request.
     pub fn get_resolution_error_for_request(
         &self,

--- a/crates/tsz-checker/src/declarations/dynamic_import_checker.rs
+++ b/crates/tsz-checker/src/declarations/dynamic_import_checker.rs
@@ -464,13 +464,17 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        // Fall back to the legacy resolved set only when the driver did not provide
-        // request-keyed paths. Otherwise a successful require/static lookup for the
-        // same specifier can hide a dynamic-import resolution error.
-        if self.ctx.resolved_module_request_paths.is_none()
-            && let Some(ref resolved) = self.ctx.resolved_modules
-            && resolved.contains(module_name)
-        {
+        // A specifier can resolve without a program file (ambient module, untyped
+        // JS module under `node_modules`); the request-keyed path map cannot
+        // represent that, so consult the mode-agnostic set — but only when this
+        // request recorded no error of its own, so a successful require/static
+        // lookup for the same specifier still cannot hide a dynamic-import
+        // resolution error.
+        if self.ctx.module_resolved_without_program_file_for_request(
+            module_name,
+            request_resolution_mode,
+            request_kind,
+        ) {
             return; // Module exists
         }
 

--- a/crates/tsz-checker/src/declarations/import/equals.rs
+++ b/crates/tsz-checker/src/declarations/import/equals.rs
@@ -947,10 +947,11 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        if self.ctx.resolved_module_request_paths.is_none()
-            && let Some(ref resolved) = self.ctx.resolved_modules
-            && resolved.contains(module_name)
-        {
+        if self.ctx.module_resolved_without_program_file_for_request(
+            module_name,
+            request_resolution_mode,
+            request_kind,
+        ) {
             return;
         }
 

--- a/crates/tsz-cli/src/lib.rs
+++ b/crates/tsz-cli/src/lib.rs
@@ -104,5 +104,8 @@ mod tuple_interface_extends_array_numeric_member_cli_tests;
 #[path = "../tests/unresolved_import_type_application_cli_tests.rs"]
 mod unresolved_import_type_application_cli_tests;
 #[cfg(test)]
+#[path = "../tests/untyped_module_resolution_tests.rs"]
+mod untyped_module_resolution_tests;
+#[cfg(test)]
 #[path = "../tests/watch_tests.rs"]
 mod watch_tests;

--- a/crates/tsz-cli/tests/untyped_module_resolution_tests.rs
+++ b/crates/tsz-cli/tests/untyped_module_resolution_tests.rs
@@ -1,0 +1,312 @@
+//! Regression tests for request-scoped resolution of modules that resolve
+//! without a program file.
+//!
+//! Structural rule:
+//! When a module specifier resolves successfully but yields no file the program
+//! can index — an untyped JavaScript module under `node_modules` picked up by
+//! the resolver's JS probe, or an ambient `declare module` target — the driver
+//! can only record it in the mode-agnostic resolved-specifier set, because the
+//! request-keyed path map is keyed by a program file index that does not exist
+//! for it. `tsc` binds such an import as `any` and reports nothing (or TS7016
+//! under `noImplicitAny`); tsz does the same through
+//! `CheckerContext::module_resolved_without_program_file_for_request`, which
+//! request-scoped consumers consult instead of ignoring the mode-agnostic set
+//! whenever request-keyed paths exist at all.
+//!
+//! Owner layer: `crates/tsz-checker/src/context/resolver.rs` (the query), with
+//! the two request-scoped call sites in
+//! `crates/tsz-checker/src/declarations/import/equals.rs` (`import x =
+//! require(...)`) and
+//! `crates/tsz-checker/src/declarations/dynamic_import_checker.rs`
+//! (`import(...)`).
+//!
+//! The negative direction matters as much as the positive one: a specifier
+//! that resolves for one request mode and genuinely fails for another must
+//! keep its TS2307. That is what the request-scoped guard existed for, and
+//! `require_only_exports_still_reports_ts2307_for_esm_dynamic_import` pins it.
+
+use super::args::CliArgs;
+use super::driver::compile;
+use clap::Parser;
+use std::path::Path;
+use tsz_common::diagnostics::Diagnostic;
+
+fn write_file(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("failed to create parent directory");
+    }
+    std::fs::write(path, contents).expect("failed to write file");
+}
+
+fn parse_args(args: &[&str]) -> CliArgs {
+    CliArgs::try_parse_from(args).expect("test args should parse")
+}
+
+fn write_tsconfig(base: &Path, extra_options: &str, files: &[&str]) {
+    let files_json = files
+        .iter()
+        .map(|f| format!("\"{f}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    write_file(
+        &base.join("tsconfig.json"),
+        &format!(
+            r#"{{
+              "compilerOptions": {{
+                "target": "es2015",
+                "module": "commonjs",
+                "strict": false,
+                "noEmit": true,
+                "types": []{extra_options}
+              }},
+              "files": [{files_json}]
+            }}"#
+        ),
+    );
+}
+
+/// An untyped package: a `node_modules` entry whose only file is JavaScript,
+/// with no `package.json` `types` entry and no sibling declaration file.
+fn write_untyped_package(base: &Path, package_name: &str) {
+    write_file(
+        &base.join(format!("node_modules/{package_name}/index.js")),
+        "module.exports = {};\n",
+    );
+}
+
+fn diagnostics_with_code(diagnostics: &[Diagnostic], code: u32) -> Vec<&Diagnostic> {
+    diagnostics
+        .iter()
+        .filter(|diag| diag.code == code)
+        .collect()
+}
+
+const CANNOT_FIND_MODULE: u32 = 2307;
+const COULD_NOT_FIND_DECLARATION_FILE: u32 = 7016;
+
+/// Every import form that can reach an untyped `node_modules` package binds it
+/// as `any` without TS2307. The binder names vary across the matrix (package
+/// name and local alias both differ per file) so no name-shaped rule can pass
+/// this by accident.
+#[test]
+fn untyped_node_modules_package_resolves_for_every_import_form() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let base = temp.path();
+
+    write_untyped_package(base, "alpha-pkg");
+    write_untyped_package(base, "beta-pkg");
+    write_untyped_package(base, "gamma-pkg");
+    write_untyped_package(base, "delta-pkg");
+
+    write_file(
+        &base.join("equals.ts"),
+        "import viaRequire = require(\"alpha-pkg\");\nexport const a = viaRequire;\n",
+    );
+    write_file(
+        &base.join("dynamic.ts"),
+        "export async function load() {\n    const mod = await import(\"beta-pkg\");\n    return mod;\n}\n",
+    );
+    write_file(
+        &base.join("star.ts"),
+        "import * as everything from \"gamma-pkg\";\nexport const g = everything;\n",
+    );
+    write_file(
+        &base.join("reexport.ts"),
+        "export { whatever } from \"delta-pkg\";\n",
+    );
+
+    write_tsconfig(
+        base,
+        "",
+        &["equals.ts", "dynamic.ts", "star.ts", "reexport.ts"],
+    );
+
+    let args = parse_args(&["tsz", "--noEmit"]);
+    let result = compile(&args, base).expect("compile should succeed");
+
+    let unresolved = diagnostics_with_code(&result.diagnostics, CANNOT_FIND_MODULE);
+    assert!(
+        unresolved.is_empty(),
+        "untyped node_modules packages resolve as `any` for every import form, got: {unresolved:#?}"
+    );
+}
+
+/// A subpath into an untyped package resolves the same way as its entry point.
+/// Nesting the target one directory deep exercises the resolver's directory
+/// probe rather than the package-index fallback.
+#[test]
+fn untyped_node_modules_subpath_resolves_for_import_equals_and_dynamic_import() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let base = temp.path();
+
+    write_file(
+        &base.join("node_modules/nested-pkg/lib/deep/helper.js"),
+        "module.exports = {};\n",
+    );
+
+    write_file(
+        &base.join("sub_equals.ts"),
+        "import deep = require(\"nested-pkg/lib/deep/helper\");\nexport const d = deep;\n",
+    );
+    write_file(
+        &base.join("sub_dynamic.ts"),
+        "export async function load() {\n    return await import(\"nested-pkg/lib/deep/helper\");\n}\n",
+    );
+
+    write_tsconfig(base, "", &["sub_equals.ts", "sub_dynamic.ts"]);
+
+    let args = parse_args(&["tsz", "--noEmit"]);
+    let result = compile(&args, base).expect("compile should succeed");
+
+    let unresolved = diagnostics_with_code(&result.diagnostics, CANNOT_FIND_MODULE);
+    assert!(
+        unresolved.is_empty(),
+        "an untyped subpath resolves as `any` like the package entry, got: {unresolved:#?}"
+    );
+}
+
+/// Under `noImplicitAny` the same two request-scoped sites report TS7016 — the
+/// "no declaration file" diagnostic — and never TS2307. A fix that suppressed
+/// the false positive by suppressing the site entirely would lose this.
+#[test]
+fn untyped_node_modules_package_reports_ts7016_under_no_implicit_any() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let base = temp.path();
+
+    write_untyped_package(base, "implicit-pkg");
+
+    write_file(
+        &base.join("equals.ts"),
+        "import viaRequire = require(\"implicit-pkg\");\nexport const a = viaRequire;\n",
+    );
+    write_file(
+        &base.join("dynamic.ts"),
+        "export async function load() {\n    return await import(\"implicit-pkg\");\n}\n",
+    );
+
+    write_tsconfig(
+        base,
+        ",\n                \"noImplicitAny\": true",
+        &["equals.ts", "dynamic.ts"],
+    );
+
+    let args = parse_args(&["tsz", "--noEmit"]);
+    let result = compile(&args, base).expect("compile should succeed");
+
+    let unresolved = diagnostics_with_code(&result.diagnostics, CANNOT_FIND_MODULE);
+    assert!(
+        unresolved.is_empty(),
+        "`noImplicitAny` reports the missing-declaration diagnostic, not TS2307, got: {unresolved:#?}"
+    );
+
+    let missing_declaration =
+        diagnostics_with_code(&result.diagnostics, COULD_NOT_FIND_DECLARATION_FILE);
+    assert_eq!(
+        missing_declaration.len(),
+        2,
+        "both the import-equals and the dynamic import report TS7016 under `noImplicitAny`, got: {missing_declaration:#?}"
+    );
+}
+
+/// Fallback direction: a specifier with nothing behind it at all still reports
+/// TS2307 at both request-scoped sites. Nothing about the fix may make a
+/// genuinely missing module look resolved.
+#[test]
+fn genuinely_missing_module_still_reports_ts2307_at_both_request_sites() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let base = temp.path();
+
+    write_file(
+        &base.join("equals.ts"),
+        "import absent = require(\"no-such-pkg\");\nexport const a = absent;\n",
+    );
+    write_file(
+        &base.join("dynamic.ts"),
+        "export async function load() {\n    return await import(\"also-absent-pkg\");\n}\n",
+    );
+
+    write_tsconfig(base, "", &["equals.ts", "dynamic.ts"]);
+
+    let args = parse_args(&["tsz", "--noEmit"]);
+    let result = compile(&args, base).expect("compile should succeed");
+
+    let unresolved = diagnostics_with_code(&result.diagnostics, CANNOT_FIND_MODULE);
+    assert_eq!(
+        unresolved.len(),
+        2,
+        "a module with nothing behind it keeps TS2307 at both sites, got: {unresolved:#?}"
+    );
+}
+
+/// The guard this change relaxes existed so that a specifier resolving under
+/// one request mode could not hide a genuine failure under another. Pin it: a
+/// package whose `exports` map only has a `require` condition resolves for the
+/// `.cts` import-equals and genuinely fails for the `.mts` dynamic import, and
+/// `tsc` reports TS2307 for exactly the second one.
+#[test]
+fn require_only_exports_still_reports_ts2307_for_esm_dynamic_import() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let base = temp.path();
+
+    write_file(
+        &base.join("node_modules/require-only-pkg/package.json"),
+        r#"{
+          "name": "require-only-pkg",
+          "version": "1.0.0",
+          "exports": {
+            ".": {
+              "require": {
+                "types": "./index.d.cts",
+                "default": "./index.cjs"
+              }
+            }
+          }
+        }"#,
+    );
+    write_file(
+        &base.join("node_modules/require-only-pkg/index.d.cts"),
+        "export declare const value: number;\n",
+    );
+    write_file(
+        &base.join("node_modules/require-only-pkg/index.cjs"),
+        "module.exports = { value: 1 };\n",
+    );
+
+    write_file(
+        &base.join("esm.mts"),
+        "export async function load() {\n    return await import(\"require-only-pkg\");\n}\n",
+    );
+    write_file(
+        &base.join("cjs.cts"),
+        "import requireOnly = require(\"require-only-pkg\");\nexport const v = requireOnly;\n",
+    );
+
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "compilerOptions": {
+            "target": "es2022",
+            "module": "node16",
+            "moduleResolution": "node16",
+            "strict": false,
+            "noEmit": true,
+            "types": []
+          },
+          "files": ["esm.mts", "cjs.cts"]
+        }"#,
+    );
+
+    let args = parse_args(&["tsz", "--noEmit"]);
+    let result = compile(&args, base).expect("compile should succeed");
+
+    let unresolved = diagnostics_with_code(&result.diagnostics, CANNOT_FIND_MODULE);
+    assert_eq!(
+        unresolved.len(),
+        1,
+        "the ESM-mode dynamic import must keep its own TS2307, got: {unresolved:#?}"
+    );
+    assert!(
+        unresolved[0].message_text.contains("require-only-pkg"),
+        "TS2307 names the require-only package, got: {unresolved:#?}"
+    );
+}


### PR DESCRIPTION
**Structural rule.** When a module specifier resolves successfully but yields no file the program can index — an untyped JavaScript module under `node_modules` picked up by the resolver's JS probe, or an ambient `declare module` target — `tsc` binds the import as `any` and reports nothing (TS7016 under `noImplicitAny`). tsz now does the same through `CheckerContext::module_resolved_without_program_file_for_request` (`crates/tsz-checker/src/context/resolver.rs`), which the two request-scoped import sites consult.

**Wrong semantic operation:** symbol resolution — specifically, the checker's request-scoped query for "did this specifier resolve?".

### What was wrong

The driver can only record a path-less resolution in the mode-agnostic `resolved_modules` set: `resolved_module_request_paths` is keyed by a program file index that does not exist for it (`crates/tsz-cli/src/driver/source_resolution_setup.rs:388` — the `else if outcome.is_resolved` arm inserts the specifier with no path).

Both request-scoped consumers ignored that set outright whenever the driver supplied request-keyed paths at all:

```rust
if self.ctx.resolved_module_request_paths.is_none()
    && let Some(ref resolved) = self.ctx.resolved_modules
    && resolved.contains(module_name)
```

Under the CLI the map is always `Some`, so path-less resolution was invisible to them and they fell through to a spurious TS2307. The two sites are `import x = require(...)` (`declarations/import/equals.rs`) and `import(...)` (`declarations/dynamic_import_checker.rs`); `import * as`, `import d from`, `export ... from`, and side-effect imports never had the guard and were already correct.

The guard existed for a real reason — a specifier resolving under one request mode must not hide a genuine failure under another — so it is replaced, not deleted. The new query consults the set only when *this* request recorded no resolution error of its own. A failed lookup always records one (`ModuleLookupResult::failed` always carries an error), so its absence plus membership in the set means the specifier resolved path-lessly here. `require_only_exports_still_reports_ts2307_for_esm_dynamic_import` pins the property the old guard protected.

### Before / after, against the pinned `typescript@7.0.2` oracle

Fixture: `node_modules/pkg/index.js` only (no declaration file), `strict: false`, `types: []`.

| import form | tsc 7.0.2 | tsz before | tsz after |
| --- | --- | --- | --- |
| `import eq = require("pkg")` | — | **TS2307** | — |
| `await import("pkg")` | — | **TS2307** | — |
| `import * as ns from "pkg"` | — | — | — |
| `export { a } from "pkg"` | — | — | — |
| `import "pkg"` | — | — | — |

Corpus row `conformance/moduleResolution/untypedModuleImport.ts` (`{"e":[],"x":["TS2307"]}` in the committed `conformance-detail.json`) reproduced exactly and is now byte-identical to the oracle — 0 diagnostics on both sides.

### Adjacent-case matrix

New file `crates/tsz-cli/tests/untyped_module_resolution_tests.rs`, 5 tests through the full CLI compile pipeline (real resolver, source discovery, binder, checker):

| case | asserts |
| --- | --- |
| every import form, four distinct package names and four distinct local binder names | no TS2307 |
| untyped **subpath** `nested-pkg/lib/deep/helper` (directory probe, not package-index fallback) | no TS2307 |
| `noImplicitAny` on | TS7016 at both sites, never TS2307 — a fix that muted the sites entirely would lose this |
| genuinely missing module, both sites | TS2307 **preserved**, count exact |
| node16 package with `require`-only `exports`: `.cts` import-equals resolves, `.mts` dynamic import genuinely fails | exactly one TS2307, on the ESM request — the dual-mode property the old guard existed for |

Names vary across the matrix so no name-shaped rule passes by accident. Verified case-by-case against the oracle before writing the assertions.

### Not in scope

- **TS2665** (augmenting an untyped module) is the other half of this family and is unimplemented — filed as **#16221** with the reduction, the owner site, and why it is not a one-liner (the resolver drops the untyped JS path unless `noImplicitAny` is on, so the checker has nothing structural to read).
- `compiler/typeRootsFromNodeModulesInParentDirectory.ts` also carries an extra TS2307 but is a **different** bug — `@types/*` discovery from a parent directory, on a static ESM import, which never had this guard. Not touched here.

## Goal
Goal: hold

## Verification

- `cargo fmt --all` — clean.
- `cargo clippy` — clean via the `pre-commit` hook, which is the clippy gate (`Verifying: -p tsz-checker -p tsz-cli` → `Local verification passed`, `Architecture guard passed`).
- `cargo test -p tsz-cli --lib untyped_module_resolution` → **5 passed, 0 failed** (the new matrix).
- `cargo test -p tsz-cli --lib` (full crate, 1622 tests) → **1604 passed, 18 failed**. All 18 accounted for, none caused by this change:
  - 4 are in `scripts/ci/known-failures.txt`.
  - 14 are environment-dependent on this cloud seat: 13 `tsc_compat_tests::tsc_parity_*` fail because the container's `tsc` on `PATH` is `/opt/node22/bin/tsc` **Version 6.0.2**, not the pinned 7.0.2 the parity assertions expect (e.g. `tsc_parity_version` diffs `"Version 6.0.2"` vs `"Version 7.0.2"`; `tsc_parity_ts5025_did_you_mean` expects a suggestion 6.0.2 does not emit). `compile_incremental_reports_ts5033_when_tsbuildinfo_is_not_writable` expects a permission error, and the session runs as root, for which `chmod` read-only does not deny writes.
  - No failing test's output mentions TS2307 (`awk` over the run log, grouped by test — empty).
- **Not run in this container, stated explicitly** per the standing note on targeted-verification sufficiency: full conformance and `compare-to-parent.sh` need the TypeScript submodule, which this seat does not have checked out; `./scripts/emit/run.sh` needs the emit harness `npm install`, which can hang here. This change only *suppresses* a diagnostic at two import sites and adds no new one, and it touches no emit path, but the two-sided corpus diff is the gate that sees the rest — a seat with a warm build should run it before landing.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Pyrite

---
_Generated by [Claude Code](https://claude.ai/code/session_01LfofBNBNv3LeY3QAK2jYDj)_