### PR TITLE
fix(checker): anchor TS2880 at the assert property name for import type expressions

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/import_type.rs
+++ b/crates/tsz-checker/src/state/type_resolution/import_type.rs
@@ -1155,14 +1155,14 @@ impl<'a> CheckerState<'a> {
             };
             if name == "assert" {
                 use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-                // For import type expressions, tsc positions TS2880 at the attributes
-                // value object (the inner `{ ... }`) to match the ImportAttributes
-                // node position in tsc's AST.
-                let Some(val_node) = self.ctx.arena.get(prop.initializer) else {
+                // tsc anchors TS2880 at the `assert` property name token itself
+                // (`grammarErrorOnFirstToken` on the attributes container), not
+                // the attribute's value object.
+                let Some(name_node) = self.ctx.arena.get(prop.name) else {
                     continue;
                 };
                 self.error_at_position(
-                    val_node.pos,
+                    name_node.pos,
                     6, // length of "assert"
                     diagnostic_messages::IMPORT_ASSERTIONS_HAVE_BEEN_REPLACED_BY_IMPORT_ATTRIBUTES_USE_WITH_INSTEAD_OF_AS,
                     diagnostic_codes::IMPORT_ASSERTIONS_HAVE_BEEN_REPLACED_BY_IMPORT_ATTRIBUTES_USE_WITH_INSTEAD_OF_AS,

--- a/crates/tsz-checker/tests/import_attributes_resolution_mode_tests.rs
+++ b/crates/tsz-checker/tests/import_attributes_resolution_mode_tests.rs
@@ -761,3 +761,66 @@ fn import_attribute_grammar_matrix_matches_tsc() {
         );
     }
 }
+
+/// TS2880 for an *import type expression* (`import("mod", { assert: ... })`,
+/// as opposed to an import/export declaration's attributes clause) must
+/// anchor on the `assert` property name token, matching tsc's
+/// `grammarErrorOnFirstToken` on the attributes node — not on the property's
+/// value object, which sits several tokens later.
+#[test]
+fn import_type_expression_deprecated_assert_anchors_at_property_name() {
+    let source = r#"type T = import("./config.json", { assert: { type: "json" } });"#;
+    let diagnostics = check_json_module_import("main.ts", source, ModuleKind::Node18, Some(true));
+
+    let ts2880 = diagnostics
+        .iter()
+        .find(|d| d.code == 2880)
+        .unwrap_or_else(|| panic!("Expected TS2880, got: {diagnostics:?}"));
+
+    let expected_start = source.find("assert").unwrap() as u32;
+    assert_eq!(
+        ts2880.start, expected_start,
+        "Expected TS2880 anchored at the `assert` property name (not its value object), \
+         got start={} in {source:?}",
+        ts2880.start
+    );
+    assert_eq!(
+        ts2880.length, 6,
+        "Expected TS2880 to span exactly the `assert` keyword"
+    );
+}
+
+/// Adjacent case: renaming the type alias binder and reordering unrelated
+/// object-literal properties around `assert` must not move the anchor.
+#[test]
+fn import_type_expression_deprecated_assert_anchors_at_property_name_with_sibling_props() {
+    let source =
+        r#"type ImportedShape = import("./config.json", { with: {}, assert: { type: "json" } });"#;
+    let diagnostics = check_json_module_import("main.ts", source, ModuleKind::Node18, Some(true));
+
+    let ts2880 = diagnostics
+        .iter()
+        .find(|d| d.code == 2880)
+        .unwrap_or_else(|| panic!("Expected TS2880, got: {diagnostics:?}"));
+
+    let expected_start = source.rfind("assert").unwrap() as u32;
+    assert_eq!(
+        ts2880.start, expected_start,
+        "Expected TS2880 anchored at the `assert` property name even with sibling properties, \
+         got start={} in {source:?}",
+        ts2880.start
+    );
+}
+
+/// Negative control: a bare import type expression that only uses `with`
+/// (never `assert`) must not report TS2880 at all.
+#[test]
+fn import_type_expression_with_keyword_does_not_report_deprecated_assert() {
+    let source = r#"type T = import("./config.json", { with: { type: "json" } });"#;
+    let diagnostics = check_json_module_import("main.ts", source, ModuleKind::Node18, Some(true));
+
+    assert!(
+        diagnostics.iter().all(|d| d.code != 2880),
+        "Did not expect TS2880 for an import type expression using `with`, got: {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
Fixes the position half of #16216. `importTypeAssertionDeprecation.ts` has TS2880 on both sides of the diff (code set already matches, per #16215) and still fails conformance — the residual is count-or-position, not a gate question.

## Goal
Goal: hold

## Structural rule

When an *import type expression* (`import("mod", { assert: {...} })`, e.g. inside `type T = import(...)`) carries a deprecated `assert` attribute, tsc anchors TS2880 at the `assert` property name token itself — `grammarErrorOnFirstToken` on the attributes container — not at the attribute's value object. `check_import_type_deprecated_assert` (`crates/tsz-checker/src/state/type_resolution/import_type.rs`) read `prop.initializer` (the value, several tokens later) instead of `prop.name`, while still hardcoding the correct length (6, "assert") — so the anchor and the length never lined up with tsc's actual position. Owner layer: checker diagnostic display / call-site position selection, same layer as the sibling `declaration_attributes.rs` TS2880 site, which already anchors correctly.

Verified against the pinned 7.0.2 oracle (`scripts/node_modules/typescript/lib/tsc.js` — confirmed via `--version`):

```
type A = import("./types", { assert: { "resolution-mode": "import" } }).MyType;
tsc  main.ts(1,30): TS2880   <- 'a' of "assert"
tsz (before) main.ts(1,48ish): TS2880  <- inner value object, wrong anchor
tsz (after)  main.ts(1,30): TS2880   <- matches
```

## What this PR does NOT fix

The same corpus fixture mixes type-position `import(...)` usages with value-position dynamic `import(...)` calls on the same module. Empirically (5 isolated probes against the pinned oracle, all reproduced), tsc suppresses TS2880 for **every** dynamic-position occurrence in a file whenever the file also contains a qualifying type-position occurrence — order-independent, specifier-independent. That's a distinct, structurally different bug (needs new per-file state threaded between `import_type.rs` and `dynamic_import_checker.rs`) and is out of scope for this position-anchor fix. Filed as #16220 with the full empirical matrix; the row named in #16216 will not fully flip to green until both land.

## Verification
- New unit coverage: 3 tests in `crates/tsz-checker/tests/import_attributes_resolution_mode_tests.rs` — position assertion (computed via `source.find("assert")`, not hand-counted), a sibling-properties adjacent case (renamed binder + reordered object-literal keys), and a negative control (`with` instead of `assert` must not report TS2880 at all).
- `cargo nextest run -p tsz-checker --test import_attributes_resolution_mode_tests`: 26/26 pass (was 23/23 before the 3 new tests).
- `cargo clippy -p tsz-checker --lib --tests --all-features`: clean.
- `cargo clippy --workspace --all-targets`: clean (this is a call-site position fix, not a shared-struct change, so no cross-crate literal risk — ran the workspace form anyway per board precedent).
- Oracle: 3-row targeted matrix against pinned `tsc@7.0.2`, 3/3 position-match after the fix (bare assert, sibling-`with`-then-assert, `with`-only negative control).
- `scripts/conformance/compare-to-parent.sh` (branch `9029897` vs parent `f6da48f`): both sides 11460/12043 passing (95.2%), failing set 583 → 583, **0 newly failing / 0 newly passing** — the fixed anchor doesn't flip `importTypeAssertionDeprecation.ts` itself (that needs #16220 too) but touches nothing else in the corpus.
- Not run: emit / fourslash — unaffected by this diagnostic-position-only change in a non-emitter, non-declaration-check path; not exercised.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8cbxpfuXUv9cDGhCZwKsE)_