### PR TITLE
fix(checker): a substituted template-literal computed name silently drops the noImplicitAny member family

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
@@ -1541,6 +1541,20 @@ impl<'a> CheckerState<'a> {
             return Some(lit.text.clone());
         }
 
+        // Template expression with substitutions (`` `a${x}` ``) — a
+        // no-substitution template literal is already a literal key handled by
+        // `get_property_name` upstream and never reaches this fallback. A
+        // substituted one has no static key, but `tsc` still names it in
+        // messages using its own source spelling (`declarationNameToString`
+        // falls through to `getTextOfNode` for anything past the literal/
+        // identifier cases). Verbatim source text is safe here specifically
+        // because the node is a well-formed `TemplateExpression`, not a
+        // parse-error recovery node — unlike a raw-source fallback keyed on
+        // node kind in general, this can't misrender a malformed computed name.
+        if expr_node.kind == syntax_kind_ext::TEMPLATE_EXPRESSION {
+            return self.node_text(expr_idx);
+        }
+
         self.get_simple_computed_name_expr_text(expr_idx)
     }
 

--- a/crates/tsz-checker/tests/noimplicitany_ambient_member_surface_tests.rs
+++ b/crates/tsz-checker/tests/noimplicitany_ambient_member_surface_tests.rs
@@ -22,7 +22,7 @@
 //! Every expectation here was recorded from `typescript@7.0.2` under
 //! `--noEmit --strict --lib es2022 --target es2022`.
 
-use tsz_checker::test_utils::check_source_strict_codes;
+use tsz_checker::test_utils::{check_source_codes_named, check_source_strict_codes};
 
 const TS7008: u32 = 7008; // Member implicitly has an 'any' type.
 const TS7010: u32 = 7010; // Lacks return-type annotation, implicitly 'any' return.
@@ -300,6 +300,92 @@ fn malformed_computed_getter_name_does_not_report_ts7033() {
     assert!(!has(&codes, TS7033), "parse-error name: {codes:?}");
     let codes = check_source_strict_codes("declare class C { get [1+](); }");
     assert!(!has(&codes, TS7033), "parse-error name: {codes:?}");
+}
+
+// ---------------------------------------------------------------------------
+// (1c) Adjacent-case matrix for issue #16190 (the residual #16201 left
+// unverified): `static`, a real `.d.ts` container, and a substituted template
+// literal computed name all reached the same `check_accessor_declaration_with_request`
+// bodyless-getter arm — none of them gate on the name's *kind*, so the first
+// two already passed before this change (pinned here as controls). The
+// template-literal case did not: a `TemplateExpression` computed name is not
+// a literal `get_property_name` can resolve, and — unlike `[k]` or
+// `[Symbol.iterator]` — `computed_name_expression_display_text` had no arm
+// for it either, so the whole `member_name_for_diagnostic` call failed and
+// silently suppressed TS7033. Fixed by rendering the template expression's
+// verbatim source text, matching tsc's `declarationNameToString` fallback.
+// Verified against the pinned `typescript@7.0.2` oracle.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn static_computed_unique_symbol_getter_reports_ts7033() {
+    let codes = check_source_strict_codes(
+        "declare const k: unique symbol; declare class C { static get [k](); }",
+    );
+    assert!(has(&codes, TS7033), "expected TS7033: {codes:?}");
+}
+
+#[test]
+fn dts_container_computed_unique_symbol_getter_reports_ts7033() {
+    // A real `.d.ts` file is implicitly ambient — no `declare` keyword needed
+    // on the class — exercising the `is_declaration_file()` half of the
+    // ambient-context check rather than `enclosing_class.is_declared`.
+    let codes = check_source_codes_named(
+        "declare const k: unique symbol; class C { get [k](); }",
+        "test.d.ts",
+    );
+    assert!(has(&codes, TS7033), "expected TS7033: {codes:?}");
+}
+
+#[test]
+fn computed_template_expression_getter_reports_ts7033() {
+    let codes =
+        check_source_strict_codes("declare const x: string; declare class C { get [`a${x}`](); }");
+    assert!(has(&codes, TS7033), "expected TS7033: {codes:?}");
+}
+
+#[test]
+fn computed_template_expression_getter_and_setter_both_report_independently() {
+    // Unlike `[k]` (a `unique symbol` reference, paired by resolved symbol
+    // identity) or a string literal (paired by resolved key), tsc's binder
+    // does not pair two computed accessors whose name is a *non-constant*
+    // template expression — each is bound as its own unrelated member, so
+    // both the getter's TS7033 and the setter's TS7032/TS7006 fire together,
+    // confirmed against the `typescript@7.0.2` oracle. This is the inverse
+    // control of `computed_unique_symbol_pair_still_blames_the_setter`: the
+    // pairing helpers (`paired_setter_in_members`/`paired_getter_in_members`)
+    // correctly fail to match here since neither `get_property_name` nor
+    // `resolve_computed_name_symbol` can key a template expression, and that
+    // failure is the *correct* answer, not a gap this fix needs to close.
+    let codes = check_source_strict_codes(
+        "declare const x: string; declare class C { get [`a${x}`](); set [`a${x}`](v); }",
+    );
+    assert!(
+        has(&codes, TS7033),
+        "expected TS7033 on the getter: {codes:?}"
+    );
+    assert!(
+        has(&codes, TS7032),
+        "expected TS7032 on the setter: {codes:?}"
+    );
+    assert!(
+        has(&codes, TS7006),
+        "expected TS7006 on the parameter: {codes:?}"
+    );
+}
+
+#[test]
+fn computed_template_expression_property_reports_ts7008() {
+    // Bonus reach of the same shared display-name fix: `check_class_property`'s
+    // TS7008 site (line ~550 in ambient_signature_checks.rs) uses the same
+    // `get_member_name_display_text` helper for the identical reason — a
+    // template-expression computed name is not a `get_property_name` literal.
+    // Confirmed against the `typescript@7.0.2` oracle: tsc reports both TS1166
+    // (computed class-property name needs a literal/`unique symbol` type) and
+    // TS7008 here; this test pins only the noImplicitAny half this fix owns.
+    let codes =
+        check_source_strict_codes("declare const x: string; declare class C { [`a${x}`]; }");
+    assert!(has(&codes, TS7008), "expected TS7008: {codes:?}");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #16190.

**Structural rule.** When a class member's computed property name is a template expression with substitutions (`` [`a${x}`] ``), `tsc` still names the member in a `noImplicitAny`-family diagnostic (TS7033 lone getter, TS7032 setter, TS7008 property) using the expression's own source spelling — `declarationNameToString` falls through to raw source text for anything past the literal/identifier cases. tsz does this through the shared `get_member_name_display_text` / `computed_name_expression_display_text` in `crates/tsz-checker/src/state/state_checking_members/interface_checks.rs`, which had arms for identifier, property-access, call, and parenthesized expressions but none for `TemplateExpression` — so it returned `None`, `member_name_for_diagnostic` failed, and every diagnostic site gating on it (TS7033/TS7032/TS7008) silently dropped the case.

**Wrong semantic operation:** diagnostic display-name resolution for a computed class-member name (not a solver/type-semantics change — the shared helper renders member names for several independent diagnostic families).

### What was wrong

`computed_name_expression_display_text` handled `StringLiteral` and `NumericLiteral` computed-name expressions, then fell back to `get_simple_computed_name_expr_text` (identifier / property-access / zero-arg-call / parenthesized). A `TemplateExpression` (`` `a${x}` ``) matched none of these, so the whole computed-name display resolution failed for it. Fixed by rendering the template expression's verbatim source text via the existing `node_text` helper — safe specifically because the node is a well-formed `TemplateExpression`, not a parse-error recovery shape, so it can't misrender a malformed computed name (`get [](); `, `get [1+]();`) the way a raw-source fallback keyed on node *kind* in general would risk.

**Correction (per review):** a no-substitution template literal (`` [`abc`] ``) is untouched by this diff — `get_property_name` already resolves it to a literal key one step earlier, so display-name resolution was never the blocker for it. That is a different question from whether the diagnostic actually fires, though: measured against the `typescript@7.0.2` oracle, `declare class C { get [\`abc\`](); }` gets TS7033 from tsc and **nothing from tsz, on both sides of this change**. That is a live, pre-existing, unfixed gap — not "already correct" — caught by Quartz's review; not fixed in this PR and tracked as a #16190 follow-up.

### Adjacent-case matrix

Issue #16190 asked for the class-arm `TS7033` gap for `unique symbol` computed getters (`declare class C { get [k](); }`) plus a suggested matrix: `static`, a real `.d.ts` container, cross-file resolution, and a template-literal computed name. Investigation found the core scenario was **already fixed** by #16201 (merged, same file) — that fix's `.or_else(get_member_name_display_text)` already covers `[k]` and `[Symbol.iterator]`. This PR:

- Pins regression tests confirming `static get [k]()` and a real `.d.ts` container (no explicit `declare`) both already report TS7033 correctly — no code change needed for either.
- Fixes the one real remaining gap this diff owns: the *substituted* template-literal computed name, verified against the pinned `typescript@7.0.2` oracle:

| shape | tsc 7.0.2 | tsz before | tsz after |
| --- | --- | --- | --- |
| `` declare class C { get [`a${x}`](); } `` | TS7033 | — | TS7033 |
| `` declare class C { [`a${x}`]; } `` | TS7008 (+TS1166, out of scope) | — | TS7008 |
| `` declare class C { get [`a${x}`](); set [`a${x}`](v); } `` | **both** TS7033 *and* TS7032/TS7006 (no pairing) | TS7033 only (setter unnoticed) | both, matching tsc |

The pairing row was the interesting negative result: unlike a `unique symbol` or string-literal name, tsc's binder does **not** pair a get/set accessor whose name is a non-constant template expression — each is bound as an unrelated member. tsz's pairing helpers (`paired_setter_in_members`/`paired_getter_in_members`) already produce that same "no pairing" answer (neither `get_property_name` nor `resolve_computed_name_symbol` can key a template expression), so no pairing-logic change was needed — only the display-name fix, which is what let the setter's own diagnostics through. Verified this is what tsc does before writing the test, not assumed.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test noimplicitany_ambient_member_surface_tests`: 41/41 passed (5 new tests added: static getter, `.d.ts` container, template-expression getter, template-expression property, template-expression get/set-both-report).
- `cargo clippy -p tsz-checker --all-targets -- -D warnings`: clean.
- Pre-commit hook (`cargo fmt` + clippy + architecture guard on `-p tsz-checker`): passed locally.
- All new-test expectations cross-checked against `typescript@7.0.2` (`npm i typescript@7.0.2`, `node node_modules/typescript/lib/tsc.js --noEmit --strict --lib es2022 --target es2022`) before being written, including the get/set non-pairing case.
- Merge review (Quartz, m4): conformance 11460, level with main, 0 newly failing/passing; `tsz-checker --lib` 9056 run, 1 known-baselined failure; full 41/41 suite; arch_guard pass.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT