### PR TITLE
fix(checker): TS2880 is unconditional on the pinned 7.0.2 oracle; ignoreDeprecations accepts "7.0"

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/environment.rs
+++ b/crates/tsz-checker/src/query_boundaries/environment.rs
@@ -236,22 +236,18 @@ impl EnvironmentCapabilities {
     /// Check whether the deprecated `assert` keyword for import attributes
     /// should produce a diagnostic (TS2880).
     ///
-    /// Returns `Some(ImportAssertDeprecated)` unless `ignoreDeprecations` is
-    /// exactly `"6.0"`.
-    ///
-    /// The gate is the *value*, not the presence of the option. `tsc` spells
-    /// this as `compilerOptions.ignoreDeprecations !== "6.0"` at all three of
-    /// its emission sites (`checkImportCallExpression`,
-    /// `checkImportDeclaration`, `checkImportType`), which this boundary is the
-    /// single counterpart to. `ignoreDeprecations: "5.0"` is accepted by the
-    /// option validator and still reports TS2880: it names an older grace
-    /// window than the release that removed the `assert` keyword.
+    /// Always returns `Some(ImportAssertDeprecated)`: on the pinned 7.0.2
+    /// oracle TS2880 is unconditional, and no `ignoreDeprecations` value
+    /// silences it. The `"6.0"` grace window a 6.x `tsc` build granted at its
+    /// three emission sites (`checkImportCallExpression`,
+    /// `checkImportDeclaration`, `checkImportType`) closed in 7.0 — verified
+    /// against `scripts/node_modules/typescript/lib/tsc.js`, where
+    /// `ignoreDeprecations: "6.0"` produces neither a config error nor a
+    /// suppression, only an unconditional TS2880 (#16217). `ignore_deprecations_6_0`
+    /// (`CheckerOptions::ignore_deprecations_6_0`) is not read here; it stays
+    /// threaded for any deprecation whose grace window has not closed.
     pub(crate) const fn check_import_assert_deprecated(&self) -> Option<CapabilityDiagnostic> {
-        if !self.ignore_deprecations_6_0 {
-            Some(CapabilityDiagnostic::ImportAssertDeprecated)
-        } else {
-            None
-        }
+        Some(CapabilityDiagnostic::ImportAssertDeprecated)
     }
 
     /// Whether the deprecated `assert` import-attribute keyword is a *hard*

--- a/crates/tsz-checker/src/symbols/symbol_resolver_utils.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver_utils.rs
@@ -1360,15 +1360,14 @@ impl<'a> CheckerState<'a> {
             .map(Some)
             .unwrap_or(defaults.allow_unused_labels);
 
-        // @ignoreDeprecations: "5.0"/"6.0" carries a version string, and the
-        // flag form also counts as present, so presence is a scan over the
-        // leading comment block rather than a `pragmas` lookup (the
+        // @ignoreDeprecations: "5.0"/"6.0"/"7.0" carries a version string, and
+        // the flag form also counts as present, so presence is a scan over
+        // the leading comment block rather than a `pragmas` lookup (the
         // pre-parsed slice only holds key/value directives).
         if Self::source_has_pragma(text, "@ignoredeprecations") {
             opts.ignore_deprecations = true;
-            // The *value* is a separate question from presence: only "6.0"
-            // silences TS2880. The flag form carries no version, so it cannot
-            // reach the "6.0" threshold.
+            // `ignore_deprecations_6_0` no longer gates TS2880 (#16217); kept
+            // for any deprecation still gated on the "6.0" value specifically.
             opts.ignore_deprecations_6_0 =
                 Self::value_pragma(&pragmas, "@ignoredeprecations") == Some("6.0");
         }

--- a/crates/tsz-checker/tests/environment_capabilities_tests.rs
+++ b/crates/tsz-checker/tests/environment_capabilities_tests.rs
@@ -1039,9 +1039,13 @@ fn test_import_assert_deprecated_fires_by_default() {
 }
 
 #[test]
-fn test_import_assert_deprecated_suppressed_only_by_ignore_deprecations_6_0() {
+fn test_import_assert_deprecated_not_suppressed_by_ignore_deprecations_6_0() {
     use tsz_checker::query_boundaries::capabilities::EnvironmentCapabilities;
+    use tsz_checker::query_boundaries::environment::CapabilityDiagnostic;
 
+    // On the pinned 7.0.2 oracle the "6.0" grace window a 6.x tsc build
+    // granted has closed: TS2880 is unconditional and no ignoreDeprecations
+    // value silences it (#16217).
     let opts = CheckerOptions {
         ignore_deprecations: true,
         ignore_deprecations_6_0: true,
@@ -1050,8 +1054,8 @@ fn test_import_assert_deprecated_suppressed_only_by_ignore_deprecations_6_0() {
     let caps = EnvironmentCapabilities::from_options(&opts, true);
     assert_eq!(
         caps.check_import_assert_deprecated(),
-        None,
-        "TS2880 should NOT fire when ignoreDeprecations is \"6.0\""
+        Some(CapabilityDiagnostic::ImportAssertDeprecated),
+        "TS2880 should still fire even when ignoreDeprecations is \"6.0\""
     );
 }
 
@@ -1099,7 +1103,7 @@ fn test_import_assert_deprecated_checker_integration_ts2880() {
 }
 
 #[test]
-fn test_import_assert_deprecated_suppressed_checker_integration() {
+fn test_import_assert_deprecated_not_suppressed_by_6_0_checker_integration() {
     let diags = check_with_options(
         r#"import payload from './payload.json' assert { type: "json" };"#,
         CheckerOptions {
@@ -1111,8 +1115,8 @@ fn test_import_assert_deprecated_suppressed_checker_integration() {
     );
     let ts2880: Vec<_> = diags.iter().filter(|d| d.code == 2880).collect();
     assert!(
-        ts2880.is_empty(),
-        "Expected NO TS2880 with ignoreDeprecations=\"6.0\", got: {ts2880:?}"
+        !ts2880.is_empty(),
+        "Expected TS2880 even with ignoreDeprecations=\"6.0\" (#16217), got: {diags:?}"
     );
 }
 

--- a/crates/tsz-cli/src/driver/plan.rs
+++ b/crates/tsz-cli/src/driver/plan.rs
@@ -231,11 +231,12 @@ pub(super) fn apply_cli_overrides_with_config_options(
         options.printer.always_strict = val;
     }
     if let Some(ref id) = args.ignore_deprecations
-        && (id == "5.0" || id == "6.0")
+        && (id == "5.0" || id == "6.0" || id == "7.0")
     {
         options.checker.ignore_deprecations = true;
-        // Only "6.0" silences the deprecated-`assert` diagnostic (TS2880);
-        // "5.0" is a legal value that leaves it reporting.
+        // No accepted value silences the deprecated-`assert` diagnostic
+        // (TS2880) on the pinned 7.0.2 oracle (#16217); `ignore_deprecations_6_0`
+        // stays threaded for any deprecation whose grace window has not closed.
         options.checker.ignore_deprecations_6_0 = id == "6.0";
     }
     if let Some(val) = args.allow_unreachable_code {
@@ -1159,7 +1160,7 @@ fn effective_ignore_deprecations_for_cli_validation<'a>(
     config
         .and_then(|cfg| cfg.compiler_options.as_ref())
         .and_then(|compiler_options| compiler_options.ignore_deprecations.as_deref())
-        .filter(|value| *value == "5.0" || *value == "6.0")
+        .filter(|value| *value == "5.0" || *value == "6.0" || *value == "7.0")
 }
 
 pub(super) fn cli_ignore_deprecations_silences_6_0(args: &CliArgs) -> bool {
@@ -1467,6 +1468,12 @@ mod tests {
     #[test]
     fn cli_ignore_deprecations_5_0_not_6_0() {
         let args = CliArgs::try_parse_from(["tsz", "--ignoreDeprecations", "5.0"]).unwrap();
+        assert!(!cli_ignore_deprecations_silences_6_0(&args));
+    }
+
+    #[test]
+    fn cli_ignore_deprecations_7_0_not_6_0() {
+        let args = CliArgs::try_parse_from(["tsz", "--ignoreDeprecations", "7.0"]).unwrap();
         assert!(!cli_ignore_deprecations_silences_6_0(&args));
     }
 

--- a/crates/tsz-cli/tests/driver_tests_parts/part_10.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_10.rs
@@ -1543,7 +1543,7 @@ fn cli_invalid_ignore_deprecations_emits_ts5103() {
         "--pretty",
         "false",
         "--ignoreDeprecations",
-        "7.0",
+        "8.0",
         "--typeRoots",
         "./empty-types",
         "main.ts",
@@ -1555,6 +1555,35 @@ fn cli_invalid_ignore_deprecations_emits_ts5103() {
     assert!(
         codes.contains(&5103),
         "Expected TS5103 for direct invalid --ignoreDeprecations, got: {:#?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn cli_valid_ignore_deprecations_7_0_does_not_emit_ts5103() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+    write_file(&base.join("main.ts"), "const ok = 1;\n");
+    std::fs::create_dir_all(base.join("empty-types")).expect("empty typeRoots");
+
+    let args = CliArgs::try_parse_from([
+        "tsz",
+        "--noEmit",
+        "--pretty",
+        "false",
+        "--ignoreDeprecations",
+        "7.0",
+        "--typeRoots",
+        "./empty-types",
+        "main.ts",
+    ])
+    .expect("CLI args should parse");
+    let result = compile(&args, base).expect("compile should succeed");
+    let codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+
+    assert!(
+        !codes.contains(&5103),
+        "tsc 7.0.2 accepts --ignoreDeprecations 7.0 (#16217), got: {:#?}",
         result.diagnostics
     );
 }

--- a/crates/tsz-common/src/options/checker.rs
+++ b/crates/tsz-common/src/options/checker.rs
@@ -194,24 +194,23 @@ pub struct CheckerOptions {
     /// `isolated_modules && !isolated_modules_from_verbatim`.
     pub isolated_modules_from_verbatim: bool,
     /// When true, a valid `ignoreDeprecations` version was supplied.
-    /// Set when `ignoreDeprecations` is "5.0" or "6.0".
+    /// Set when `ignoreDeprecations` is "5.0", "6.0", or "7.0".
     ///
     /// This records *presence*, not what the value silences. `ignoreDeprecations`
     /// is a version string naming the release whose deprecations the user is
     /// opting out of, so each deprecation has its own threshold and a single
     /// bool cannot answer for all of them. Consumers that need a specific
-    /// threshold must ask for it: the deprecated `assert` import-attribute
-    /// keyword (TS2880) is silenced by `"6.0"` *only*, which is
-    /// `ignore_deprecations_6_0` below.
+    /// threshold must ask for it — see `ignore_deprecations_6_0` below.
     pub ignore_deprecations: bool,
     /// When true, `ignoreDeprecations` was set to exactly `"6.0"`.
     ///
-    /// `tsc` gates the deprecated-`assert` diagnostic (TS2880) on the literal
-    /// value rather than on presence — `checkImportCallExpression`,
-    /// `checkImportDeclaration` and `checkImportType` each test
-    /// `compilerOptions.ignoreDeprecations !== "6.0"`. `"5.0"` is a legal value
-    /// that does *not* silence it, because it names a strictly older grace
-    /// window than the release that removed `assert`.
+    /// On the pinned 7.0.2 oracle no `ignoreDeprecations` value silences the
+    /// deprecated `assert` import-attribute keyword (TS2880) — the `"6.0"`
+    /// grace window a 6.x `tsc` build granted at its three emission sites
+    /// (`checkImportCallExpression`, `checkImportDeclaration`,
+    /// `checkImportType`) has closed (#16217), so this flag has no current
+    /// TS2880 consumer. It stays threaded for any deprecation whose grace
+    /// window has not closed.
     ///
     /// Same shape as `isolated_modules_from_verbatim` above: the coarse flag
     /// stays for the consumers that want presence, and this one recovers the

--- a/crates/tsz-core/src/config/mod.rs
+++ b/crates/tsz-core/src/config/mod.rs
@@ -418,7 +418,7 @@ pub struct CompilerOptions {
     /// Control what method is used to detect module-format JS files.
     #[serde(default)]
     pub module_detection: Option<String>,
-    /// Suppress deprecation warnings. Valid values: "5.0", "6.0".
+    /// Suppress deprecation warnings. Valid values: "5.0", "6.0", "7.0".
     #[serde(default)]
     pub ignore_deprecations: Option<String>,
     /// Allow accessing UMD globals from modules.

--- a/crates/tsz-core/src/config/parse.rs
+++ b/crates/tsz-core/src/config/parse.rs
@@ -286,10 +286,12 @@ pub fn parse_tsconfig_with_diagnostics_deferred(
 
         // Check ignoreDeprecations value (TS5103)
         // TypeScript 7 still accepts the historical "5.0" and "6.0"
-        // literals, but neither suppresses TS7 removal diagnostics.
+        // literals plus its own "7.0", but none of the three suppresses TS7
+        // removal diagnostics (#16217).
         if let Some(serde_json::Value::String(id_value)) = compiler_opts.get("ignoreDeprecations")
             && id_value != "5.0"
             && id_value != "6.0"
+            && id_value != "7.0"
         {
             let start = find_value_offset_in_source(&stripped, "ignoreDeprecations");
             let value_len = id_value.len() as u32 + 2; // include quotes

--- a/crates/tsz-core/src/config/resolved_options.rs
+++ b/crates/tsz-core/src/config/resolved_options.rs
@@ -826,12 +826,13 @@ pub fn resolve_compiler_options(
     }
 
     if let Some(ref id) = options.ignore_deprecations
-        && (id == "5.0" || id == "6.0")
+        && (id == "5.0" || id == "6.0" || id == "7.0")
     {
         resolved.checker.ignore_deprecations = true;
-        // Only "6.0" silences the deprecated-`assert` diagnostic (TS2880);
-        // "5.0" is a legal value that leaves it reporting. Mirrors the CLI
-        // override path in `tsz-cli`'s `driver::plan`.
+        // No accepted value silences the deprecated-`assert` diagnostic
+        // (TS2880) on the pinned 7.0.2 oracle (#16217); `ignore_deprecations_6_0`
+        // stays threaded for any deprecation whose grace window has not
+        // closed. Mirrors the CLI override path in `tsz-cli`'s `driver::plan`.
         resolved.checker.ignore_deprecations_6_0 = id == "6.0";
     }
 

--- a/crates/tsz-core/src/config/tests/module_resolution.rs
+++ b/crates/tsz-core/src/config/tests/module_resolution.rs
@@ -372,7 +372,7 @@ fn test_ts5023_not_suppressed_with_ignore_deprecations() {
 #[test]
 fn test_ts5023_not_suppressed_with_invalid_ignore_deprecations() {
     // Invalid ignoreDeprecations reports TS5103 alongside the dropped-name TS5023.
-    let source = r#"{"compilerOptions":{"ignoreDeprecations":"7.0","noImplicitUseStrict":true}}"#;
+    let source = r#"{"compilerOptions":{"ignoreDeprecations":"8.0","noImplicitUseStrict":true}}"#;
     let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
     let codes: Vec<u32> = parsed.diagnostics.iter().map(|d| d.code).collect();
     assert!(
@@ -893,12 +893,26 @@ fn test_ts5103_emitted_for_invalid_ignore_deprecations() {
     // tsc only emits TS5103 when deprecated features are also present, but since tsz cannot
     // detect all deprecated features (e.g. deprecated source syntax like import assertions),
     // it conservatively emits TS5103 for any invalid ignoreDeprecations value.
-    let source = r#"{"compilerOptions":{"ignoreDeprecations":"7.0"}}"#;
+    let source = r#"{"compilerOptions":{"ignoreDeprecations":"8.0"}}"#;
     let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
     let codes: Vec<u32> = parsed.diagnostics.iter().map(|d| d.code).collect();
     assert!(
         codes.contains(&5103),
-        "Expected TS5103 for invalid ignoreDeprecations='7.0', got: {codes:?}"
+        "Expected TS5103 for invalid ignoreDeprecations='8.0', got: {codes:?}"
+    );
+}
+
+#[test]
+fn test_ts5103_not_emitted_for_valid_7_0() {
+    // tsc 7.0.2 accepts its own version literal alongside the two historical
+    // ones (#16217); it does not suppress TS2880 (or anything else), but it
+    // is not an *invalid* value either.
+    let source = r#"{"compilerOptions":{"ignoreDeprecations":"7.0"}}"#;
+    let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
+    let codes: Vec<u32> = parsed.diagnostics.iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&5103),
+        "Should NOT emit TS5103 for valid ignoreDeprecations='7.0', got: {codes:?}"
     );
 }
 
@@ -920,12 +934,12 @@ fn test_ts5103_emitted_for_invalid_ignore_deprecations_with_deprecated_target_al
     // tsc emits TS5103 when an invalid ignoreDeprecations value is used alongside
     // a deprecated target alias like "es6" (deprecated in favor of "es2015").
     // This matches the arrowFunction conformance test pattern.
-    let source = r#"{"compilerOptions":{"ignoreDeprecations":"7.0","target":"es6"}}"#;
+    let source = r#"{"compilerOptions":{"ignoreDeprecations":"8.0","target":"es6"}}"#;
     let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
     let codes: Vec<u32> = parsed.diagnostics.iter().map(|d| d.code).collect();
     assert!(
         codes.contains(&5103),
-        "Expected TS5103 for ignoreDeprecations='7.0' with deprecated target='es6', got: {codes:?}"
+        "Expected TS5103 for ignoreDeprecations='8.0' with deprecated target='es6', got: {codes:?}"
     );
 }
 
@@ -934,12 +948,12 @@ fn test_ts5103_emitted_for_invalid_ignore_deprecations_with_any_target() {
     // tsz emits TS5103 conservatively for any invalid ignoreDeprecations value,
     // regardless of target. Even non-deprecated targets like "es2018" will trigger
     // TS5103 in tsz (conservative approach since we can't detect all deprecated syntax).
-    let source = r#"{"compilerOptions":{"ignoreDeprecations":"7.0","target":"es2018"}}"#;
+    let source = r#"{"compilerOptions":{"ignoreDeprecations":"8.0","target":"es2018"}}"#;
     let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
     let codes: Vec<u32> = parsed.diagnostics.iter().map(|d| d.code).collect();
     assert!(
         codes.contains(&5103),
-        "Expected TS5103 (conservative) for ignoreDeprecations='7.0' with target='es2018', got: {codes:?}"
+        "Expected TS5103 (conservative) for ignoreDeprecations='8.0' with target='es2018', got: {codes:?}"
     );
 }
 


### PR DESCRIPTION
Fixes #16217.

**Structural rule.** When `compilerOptions.ignoreDeprecations` is set to any value, tsc 7.0.2 still reports TS2880 for the deprecated `assert` import-attribute keyword unconditionally — the `"6.0"` grace window a 6.x `tsc` build granted at its three emission sites (`checkImportCallExpression`, `checkImportDeclaration`, `checkImportType`) closed in 7.0. tsz now does the same through `EnvironmentCapabilities::check_import_assert_deprecated` (`crates/tsz-checker/src/query_boundaries/environment.rs`), the single query boundary for this diagnostic.

Separately, `"7.0"` is itself a legal `ignoreDeprecations` value on the pinned oracle (it just doesn't silence anything) — tsz was rejecting it as TS5103. Fixed at the three entry points that gate on the accepted-value set: `crates/tsz-core/src/config/parse.rs` (TS5103 validation), `crates/tsz-core/src/config/resolved_options.rs` (tsconfig resolution), and `crates/tsz-cli/src/driver/plan.rs` (CLI override, two call sites).

### Wrong semantic operation

Config/capability-gate evaluation — specifically the checker's environment-capabilities query boundary for "should TS2880 fire" and the config-value validators for "is this `ignoreDeprecations` value legal."

### Why this happened

#16215 modeled the gate from a container-global `tsc` **6.0.2** build (`compilerOptions.ignoreDeprecations !== "6.0"`) instead of this repo's pinned **7.0.2** oracle (`scripts/node_modules/typescript/lib/tsc.js`). 6.0.2 and 7.0.2 disagree on exactly this threshold. Filed as #16217 by Quartz with the full oracle matrix; this PR is the fix.

### What changed

- `check_import_assert_deprecated` always returns `Some(ImportAssertDeprecated)`. `CheckerOptions::ignore_deprecations_6_0` and its threading through the CLI override / tsconfig-resolution / source-pragma paths (`#16215`'s plumbing) are kept — the modeling (a version string, not a bool, since different deprecations can have different grace windows) is still correct in general, it just has no current TS2880 consumer.
- `"7.0"` joins `"5.0"`/`"6.0"` as an accepted `ignoreDeprecations` value at all three entry points, so it no longer produces TS5103.
- Doc comments on `CheckerOptions::ignore_deprecations`/`ignore_deprecations_6_0`, `TsConfigCompilerOptions::ignore_deprecations`, and the source-pragma parser updated to match (they asserted the now-wrong "TS2880 silenced by `\"6.0\"`" rule).

### Adjacent-case matrix

| `ignoreDeprecations` | tsc 7.0.2 (`assert` import present) | tsz before | tsz after |
| --- | --- | --- | --- |
| absent | TS2880 | TS2880 | TS2880 |
| `"5.0"` | TS2880 | TS2880 | TS2880 |
| `"6.0"` | TS2880 | *(suppressed)* | TS2880 |
| `"7.0"` | TS2880, no TS5103 | TS5103 (invalid value) | TS2880, no TS5103 |
| `"8.0"` | TS2880, no TS5103 (see #16228) | TS5103 | TS5103 *(unchanged — out of scope, see below)* |
| any value, `with` keyword (not `assert`) | clean | clean | clean *(negative control, unaffected)* |

Verified directly against `scripts/node_modules/typescript/lib/tsc.js --version` → `Version 7.0.2`, both via a `tsconfig.json` and a direct `--ignoreDeprecations` CLI flag, and cross-checked against the container-global `/opt/node22/bin/tsc` (6.0.2) to confirm the divergence is a real version difference and not an invocation mistake.

Tests updated/added:
- `crates/tsz-checker/tests/environment_capabilities_tests.rs`: inverted the two tests that asserted `"6.0"` suppresses TS2880 (they now assert it still fires). Note: this integration-test file is **not currently wired into `Cargo.toml`** — it needs `tsz_checker::query_boundaries` to be reachable from an external test crate, which it currently is not (`pub(crate)`-shaped visibility), so registering it surfaces 65 unrelated compile errors. Pre-existing gap, out of scope here; left as-is rather than papered over.
- `crates/tsz-core/src/config/tests/module_resolution.rs`: added `test_ts5103_not_emitted_for_valid_7_0`; the five tests that previously used `"7.0"` as their *invalid*-value witness now use `"8.0"` instead (still genuinely invalid — see #16228 caveat below).
- `crates/tsz-cli/tests/driver_tests_parts/part_10.rs`: `cli_invalid_ignore_deprecations_emits_ts5103` now uses `"8.0"`; added `cli_valid_ignore_deprecations_7_0_does_not_emit_ts5103`.
- `crates/tsz-cli/src/driver/plan.rs`: added `cli_ignore_deprecations_7_0_not_6_0`.

### Not in scope — filed as #16228

Verifying this fix surfaced a third, separate, larger-blast-radius defect in the same family: **TS5103 itself appears to never fire on tsc 7.0.2, for any `ignoreDeprecations` value, valid or invalid** (probed with `"8.0"`, `"banana"`, with/without an accompanying removed option, deprecated target alias, or live deprecated feature — always clean/no-TS5103 on 7.0.2, and TS5103 confirmed firing on the container-global 6.0.2 for the same probe). That's a bigger change (does the whole diagnostic code still exist, not which values its gate accepts) and needs its own probing before landing, so it's filed with full evidence rather than folded in here.

## Goal
Goal: hold

## Verification
- `cargo fmt --all` / `cargo clippy -p tsz-checker -p tsz-core -p tsz-cli --all-targets -- -D warnings` — clean (also via the `pre-commit` hook's `Local verification passed` / `Architecture guard passed`).
- `python3 scripts/arch/arch_guard.py` — `Architecture guardrails passed.`
- `cargo nextest run -p tsz-core -p tsz-cli ignore_deprecations` → **19/19 passed** (includes the new/inverted tests above).
- `cargo nextest run -p tsz-checker --test import_attributes_resolution_mode_tests` → **23/23 passed** (unaffected TS2880 grammar-matrix regression check).
- `cargo nextest run -p tsz-common -p tsz-core -p tsz-checker -p tsz-cli --lib` → **14498 passed, 7 failed** (all 7 pre-existing: 5 are listed in `scripts/ci/known-failures.txt`; the other 2 — `compile_incremental_reports_ts5033_when_tsbuildinfo_is_not_writable` (root-user chmod quirk) and `test_duplicate_identifier_three_way_var_let_var_2300` — reproduced identically on `main` via `git stash`, confirmed unrelated to this change).
- Not run in this container: full `conformance.sh snapshot` and `./scripts/emit/run.sh` (no TypeScript submodule checked out here). This change only affects the TS2880/TS5103 config-gate family and touches no emit path; a seat with a warm build should run the two-sided corpus diff before landing per the standing note on targeted-verification sufficiency.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_01F5UR5wNKCriNwhF7Lx2NMA)_