### PR TITLE
test(core): correct the stale var/let/var TS2300 count to 2

### DIFF
--- a/crates/tsz-core/tests/checker_state_tests_parts/part_00.rs
+++ b/crates/tsz-core/tests/checker_state_tests_parts/part_00.rs
@@ -1528,12 +1528,27 @@ fn test_duplicate_identifier_const_var_2451() {
 
 #[test]
 fn test_duplicate_identifier_three_way_var_let_var_2300() {
-    // The first conflicting declaration is `var`, so tsc reports TS2300 on
-    // each declaration in this same-file mixed set.
+    // Two, not three. `tsc`'s binder collision walk reports on the surviving
+    // symbol's declarations plus the colliding one, then attaches the collider
+    // to a throwaway symbol; the trailing `var` never collides with the
+    // function-scoped survivor, so it rejoins it and draws nothing. Modelled in
+    // `duplicate_identifiers_variable_family` by #16169.
+    //
+    // Contrast `test_duplicate_identifier_let_var_function_stays_2300` below,
+    // where a `function` joins the conflict and all three declarations do
+    // report — that row is 3 and stays 3.
+    //
+    // Pinned `typescript@7.0.2`, `--noEmit --strict --lib es2015 --target es2015`:
+    //   vlv.ts(1,5): error TS2300: Duplicate identifier 'q'.
+    //   vlv.ts(2,5): error TS2300: Duplicate identifier 'q'.
     let (ts2451, ts2300) =
         count_redeclaration_diagnostics("var q = 1;\nlet q = 2;\nvar q = 3;\n");
     assert_eq!(ts2451, 0, "Expected no TS2451 for var/let/var redeclaration");
-    assert_eq!(ts2300, 3, "Expected 3 TS2300 for var/let/var redeclaration");
+    assert_eq!(
+        ts2300, 2,
+        "Expected 2 TS2300 for var/let/var redeclaration: the trailing `var` \
+         rejoins the function-scoped survivor instead of colliding"
+    );
 }
 
 #[test]


### PR DESCRIPTION
`cargo nextest run -p tsz-core --lib` has been **red on `main`** with one failure:

```
FAIL  tsz-core checker_state_tests::test_duplicate_identifier_three_way_var_let_var_2300
      assertion `left == right` failed: Expected 3 TS2300 for var/let/var redeclaration
        left: 2   right: 3
```

**The compiler is right and the test is wrong.** Pinned `typescript@7.0.2`, `--noEmit --strict --lib es2015 --target es2015`:

```
var q = 1;
let q = 2;
var q = 3;

tsc   vlv.ts(1,5): TS2300      vlv.ts(2,5): TS2300      -> 2
tsz   identical                                          -> 2
test  asserts 3
```

## Why 2 is correct

`tsc`'s binder collision walk reports on the surviving symbol's declarations *so far* plus the colliding declaration, then attaches the collider to a throwaway symbol that never re-enters the symbol table. The trailing `var` does **not** collide with the function-scoped survivor — it rejoins it — so it draws nothing. That is the model #16169 landed in `duplicate_identifiers_variable_family`, and it is what made tsz start answering 2.

The assertion predates that work, so the fix exposed it rather than caused it.

**The adjacent row is the control, and it stays at 3:**

```
let e0 = 1; var e0 = 2; function e0() {}

tsc  3x TS2300      tsz  3x TS2300      test asserts 3   unchanged
```

Once a `function` joins the conflict every declaration reports. Those two rows sitting side by side are the whole rule, so I put the contrast in the comment — a bare `2` invites someone to "fix" it back.

## Why it went unnoticed

- It is **not** in `scripts/ci/known-failures.txt`, so nothing baselines it.
- `tsz-core` is outside the crate set most local verification covers (`tsz-checker`, `tsz-solver`, `tsz-parser`, `tsz-emitter`), which is how I had missed it too — I found it only because #16230 touched `tsz-core/src/config/` and I ran the crate.

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-core --lib`: **3257 passed, 0 failed** (was 3256 passed / 1 failed).
- `-E 'test(duplicate_identifier)'`: 9/9, including the `let/var/function` control still asserting 3.
- `python3 scripts/arch/arch_guard.py`: passed.
- Test-only: no source change, so no suite can move. Conformance and emit unaffected by construction.

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high
AgentName: Quartz
