### PR TITLE
fix(checker): TS2880 is unconditional on tsc 7.0.2; accept ignoreDeprecations "7.0"

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/capabilities.rs
+++ b/crates/tsz-checker/src/query_boundaries/capabilities.rs
@@ -100,8 +100,9 @@ pub struct EnvironmentCapabilities {
     pub resolve_json_module: bool,
     pub experimental_decorators: bool,
     pub ignore_deprecations: bool,
-    /// `ignoreDeprecations` was set to exactly `"6.0"` — the only value that
-    /// silences TS2880. See `CheckerOptions::ignore_deprecations_6_0`.
+    /// `ignoreDeprecations` was set to exactly `"6.0"`. See
+    /// `CheckerOptions::ignore_deprecations_6_0` — no accepted value silences
+    /// TS2880 today.
     pub ignore_deprecations_6_0: bool,
     pub verbatim_module_syntax: bool,
     pub types_explicitly_set: bool,

--- a/crates/tsz-checker/src/query_boundaries/environment.rs
+++ b/crates/tsz-checker/src/query_boundaries/environment.rs
@@ -236,22 +236,13 @@ impl EnvironmentCapabilities {
     /// Check whether the deprecated `assert` keyword for import attributes
     /// should produce a diagnostic (TS2880).
     ///
-    /// Returns `Some(ImportAssertDeprecated)` unless `ignoreDeprecations` is
-    /// exactly `"6.0"`.
-    ///
-    /// The gate is the *value*, not the presence of the option. `tsc` spells
-    /// this as `compilerOptions.ignoreDeprecations !== "6.0"` at all three of
-    /// its emission sites (`checkImportCallExpression`,
-    /// `checkImportDeclaration`, `checkImportType`), which this boundary is the
-    /// single counterpart to. `ignoreDeprecations: "5.0"` is accepted by the
-    /// option validator and still reports TS2880: it names an older grace
-    /// window than the release that removed the `assert` keyword.
+    /// Always returns `Some(ImportAssertDeprecated)`: on the pinned 7.0.2
+    /// oracle, TS2880 is unconditional — no `ignoreDeprecations` value
+    /// silences it, including `"6.0"`. (An earlier revision of this boundary
+    /// gated on `ignoreDeprecations !== "6.0"`, derived from a 6.0.2 build of
+    /// `tsc`; 7.0 closed that grace window entirely. See #16217.)
     pub(crate) const fn check_import_assert_deprecated(&self) -> Option<CapabilityDiagnostic> {
-        if !self.ignore_deprecations_6_0 {
-            Some(CapabilityDiagnostic::ImportAssertDeprecated)
-        } else {
-            None
-        }
+        Some(CapabilityDiagnostic::ImportAssertDeprecated)
     }
 
     /// Whether the deprecated `assert` import-attribute keyword is a *hard*

--- a/crates/tsz-checker/tests/environment_capabilities_tests.rs
+++ b/crates/tsz-checker/tests/environment_capabilities_tests.rs
@@ -1039,9 +1039,12 @@ fn test_import_assert_deprecated_fires_by_default() {
 }
 
 #[test]
-fn test_import_assert_deprecated_suppressed_only_by_ignore_deprecations_6_0() {
+fn test_import_assert_deprecated_not_suppressed_by_ignore_deprecations_6_0() {
     use tsz_checker::query_boundaries::capabilities::EnvironmentCapabilities;
+    use tsz_checker::query_boundaries::environment::CapabilityDiagnostic;
 
+    // On the pinned 7.0.2 oracle TS2880 is unconditional: `"6.0"` silenced it
+    // in tsc 6.0.2, but 7.0 closed that grace window entirely (#16217).
     let opts = CheckerOptions {
         ignore_deprecations: true,
         ignore_deprecations_6_0: true,
@@ -1050,8 +1053,8 @@ fn test_import_assert_deprecated_suppressed_only_by_ignore_deprecations_6_0() {
     let caps = EnvironmentCapabilities::from_options(&opts, true);
     assert_eq!(
         caps.check_import_assert_deprecated(),
-        None,
-        "TS2880 should NOT fire when ignoreDeprecations is \"6.0\""
+        Some(CapabilityDiagnostic::ImportAssertDeprecated),
+        "TS2880 should still fire when ignoreDeprecations is \"6.0\""
     );
 }
 
@@ -1099,7 +1102,7 @@ fn test_import_assert_deprecated_checker_integration_ts2880() {
 }
 
 #[test]
-fn test_import_assert_deprecated_suppressed_checker_integration() {
+fn test_import_assert_deprecated_not_suppressed_by_6_0_checker_integration() {
     let diags = check_with_options(
         r#"import payload from './payload.json' assert { type: "json" };"#,
         CheckerOptions {
@@ -1111,8 +1114,8 @@ fn test_import_assert_deprecated_suppressed_checker_integration() {
     );
     let ts2880: Vec<_> = diags.iter().filter(|d| d.code == 2880).collect();
     assert!(
-        ts2880.is_empty(),
-        "Expected NO TS2880 with ignoreDeprecations=\"6.0\", got: {ts2880:?}"
+        !ts2880.is_empty(),
+        "Expected TS2880 with ignoreDeprecations=\"6.0\" (unconditional on 7.0.2), got: {diags:?}"
     );
 }
 

--- a/crates/tsz-cli/src/driver/plan.rs
+++ b/crates/tsz-cli/src/driver/plan.rs
@@ -231,11 +231,11 @@ pub(super) fn apply_cli_overrides_with_config_options(
         options.printer.always_strict = val;
     }
     if let Some(ref id) = args.ignore_deprecations
-        && (id == "5.0" || id == "6.0")
+        && (id == "5.0" || id == "6.0" || id == "7.0")
     {
         options.checker.ignore_deprecations = true;
-        // Only "6.0" silences the deprecated-`assert` diagnostic (TS2880);
-        // "5.0" is a legal value that leaves it reporting.
+        // No accepted value silences TS2880 (see #16217); this only carries
+        // the version distinction for future version-gated deprecations.
         options.checker.ignore_deprecations_6_0 = id == "6.0";
     }
     if let Some(val) = args.allow_unreachable_code {
@@ -1159,7 +1159,7 @@ fn effective_ignore_deprecations_for_cli_validation<'a>(
     config
         .and_then(|cfg| cfg.compiler_options.as_ref())
         .and_then(|compiler_options| compiler_options.ignore_deprecations.as_deref())
-        .filter(|value| *value == "5.0" || *value == "6.0")
+        .filter(|value| *value == "5.0" || *value == "6.0" || *value == "7.0")
 }
 
 pub(super) fn cli_ignore_deprecations_silences_6_0(args: &CliArgs) -> bool {

--- a/crates/tsz-cli/tests/driver_tests_parts/part_10.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_10.rs
@@ -1543,7 +1543,7 @@ fn cli_invalid_ignore_deprecations_emits_ts5103() {
         "--pretty",
         "false",
         "--ignoreDeprecations",
-        "7.0",
+        "5.5",
         "--typeRoots",
         "./empty-types",
         "main.ts",
@@ -1555,6 +1555,37 @@ fn cli_invalid_ignore_deprecations_emits_ts5103() {
     assert!(
         codes.contains(&5103),
         "Expected TS5103 for direct invalid --ignoreDeprecations, got: {:#?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn cli_ignore_deprecations_7_0_does_not_emit_ts5103() {
+    // "7.0" is a valid ignoreDeprecations value on the pinned 7.0.2 oracle
+    // (#16217), same as the historical "5.0"/"6.0".
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+    write_file(&base.join("main.ts"), "const ok = 1;\n");
+    std::fs::create_dir_all(base.join("empty-types")).expect("empty typeRoots");
+
+    let args = CliArgs::try_parse_from([
+        "tsz",
+        "--noEmit",
+        "--pretty",
+        "false",
+        "--ignoreDeprecations",
+        "7.0",
+        "--typeRoots",
+        "./empty-types",
+        "main.ts",
+    ])
+    .expect("CLI args should parse");
+    let result = compile(&args, base).expect("compile should succeed");
+    let codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+
+    assert!(
+        !codes.contains(&5103),
+        "Expected NO TS5103 for direct --ignoreDeprecations '7.0', got: {:#?}",
         result.diagnostics
     );
 }

--- a/crates/tsz-common/src/options/checker.rs
+++ b/crates/tsz-common/src/options/checker.rs
@@ -194,28 +194,23 @@ pub struct CheckerOptions {
     /// `isolated_modules && !isolated_modules_from_verbatim`.
     pub isolated_modules_from_verbatim: bool,
     /// When true, a valid `ignoreDeprecations` version was supplied.
-    /// Set when `ignoreDeprecations` is "5.0" or "6.0".
+    /// Set when `ignoreDeprecations` is "5.0", "6.0", or "7.0".
     ///
     /// This records *presence*, not what the value silences. `ignoreDeprecations`
     /// is a version string naming the release whose deprecations the user is
     /// opting out of, so each deprecation has its own threshold and a single
     /// bool cannot answer for all of them. Consumers that need a specific
-    /// threshold must ask for it: the deprecated `assert` import-attribute
-    /// keyword (TS2880) is silenced by `"6.0"` *only*, which is
-    /// `ignore_deprecations_6_0` below.
+    /// threshold must ask for it via `ignore_deprecations_6_0` below.
     pub ignore_deprecations: bool,
     /// When true, `ignoreDeprecations` was set to exactly `"6.0"`.
     ///
-    /// `tsc` gates the deprecated-`assert` diagnostic (TS2880) on the literal
-    /// value rather than on presence — `checkImportCallExpression`,
-    /// `checkImportDeclaration` and `checkImportType` each test
-    /// `compilerOptions.ignoreDeprecations !== "6.0"`. `"5.0"` is a legal value
-    /// that does *not* silence it, because it names a strictly older grace
-    /// window than the release that removed `assert`.
-    ///
-    /// Same shape as `isolated_modules_from_verbatim` above: the coarse flag
-    /// stays for the consumers that want presence, and this one recovers the
-    /// distinction the coarse flag erases.
+    /// No accepted `ignoreDeprecations` value currently silences a diagnostic
+    /// in tsz: the deprecated `assert` import-attribute keyword (TS2880) was
+    /// silenced by `"6.0"` in `tsc` 6.0.2, but 7.0 closed that grace window —
+    /// TS2880 is unconditional on the pinned 7.0.2 oracle (#16217). This field
+    /// still carries the `"6.0"` distinction for a future consumer that needs
+    /// it (same shape as `isolated_modules_from_verbatim` above), but nothing
+    /// reads it today.
     pub ignore_deprecations_6_0: bool,
     /// When true, allow accessing UMD globals from modules without importing them.
     /// Suppresses TS2686 ("refers to a UMD global, but the current file is a module").

--- a/crates/tsz-core/src/config/parse.rs
+++ b/crates/tsz-core/src/config/parse.rs
@@ -285,11 +285,13 @@ pub fn parse_tsconfig_with_diagnostics_deferred(
         }
 
         // Check ignoreDeprecations value (TS5103)
-        // TypeScript 7 still accepts the historical "5.0" and "6.0"
-        // literals, but neither suppresses TS7 removal diagnostics.
+        // TypeScript 7 accepts the historical "5.0" and "6.0" literals plus
+        // its own "7.0", but none of them suppresses TS7 removal diagnostics
+        // or the unconditional TS2880 (see #16217).
         if let Some(serde_json::Value::String(id_value)) = compiler_opts.get("ignoreDeprecations")
             && id_value != "5.0"
             && id_value != "6.0"
+            && id_value != "7.0"
         {
             let start = find_value_offset_in_source(&stripped, "ignoreDeprecations");
             let value_len = id_value.len() as u32 + 2; // include quotes

--- a/crates/tsz-core/src/config/resolved_options.rs
+++ b/crates/tsz-core/src/config/resolved_options.rs
@@ -826,12 +826,12 @@ pub fn resolve_compiler_options(
     }
 
     if let Some(ref id) = options.ignore_deprecations
-        && (id == "5.0" || id == "6.0")
+        && (id == "5.0" || id == "6.0" || id == "7.0")
     {
         resolved.checker.ignore_deprecations = true;
-        // Only "6.0" silences the deprecated-`assert` diagnostic (TS2880);
-        // "5.0" is a legal value that leaves it reporting. Mirrors the CLI
-        // override path in `tsz-cli`'s `driver::plan`.
+        // No accepted value silences TS2880 (see #16217); this only carries
+        // the version distinction for future version-gated deprecations.
+        // Mirrors the CLI override path in `tsz-cli`'s `driver::plan`.
         resolved.checker.ignore_deprecations_6_0 = id == "6.0";
     }
 

--- a/crates/tsz-core/src/config/tests/module_resolution.rs
+++ b/crates/tsz-core/src/config/tests/module_resolution.rs
@@ -372,7 +372,7 @@ fn test_ts5023_not_suppressed_with_ignore_deprecations() {
 #[test]
 fn test_ts5023_not_suppressed_with_invalid_ignore_deprecations() {
     // Invalid ignoreDeprecations reports TS5103 alongside the dropped-name TS5023.
-    let source = r#"{"compilerOptions":{"ignoreDeprecations":"7.0","noImplicitUseStrict":true}}"#;
+    let source = r#"{"compilerOptions":{"ignoreDeprecations":"5.5","noImplicitUseStrict":true}}"#;
     let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
     let codes: Vec<u32> = parsed.diagnostics.iter().map(|d| d.code).collect();
     assert!(
@@ -399,6 +399,24 @@ fn test_ts5023_fires_with_ignore_deprecations_6_0() {
     assert!(
         !codes.contains(&5103),
         "Should NOT emit TS5103 — '6.0' is a valid ignoreDeprecations value, got: {codes:?}"
+    );
+}
+
+#[test]
+fn test_ts5023_fires_with_ignore_deprecations_7_0() {
+    // "7.0" is a valid ignoreDeprecations value on the pinned 7.0.2 oracle
+    // (#16217), but — like "5.0" and "6.0" — it does not suppress a
+    // dropped-name TS5023.
+    let source = r#"{"compilerOptions":{"ignoreDeprecations":"7.0","noImplicitUseStrict":true}}"#;
+    let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
+    let codes: Vec<u32> = parsed.diagnostics.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&5023),
+        "Expected TS5023 even with ignoreDeprecations '7.0', got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&5103),
+        "Should NOT emit TS5103 — '7.0' is a valid ignoreDeprecations value, got: {codes:?}"
     );
 }
 
@@ -893,12 +911,12 @@ fn test_ts5103_emitted_for_invalid_ignore_deprecations() {
     // tsc only emits TS5103 when deprecated features are also present, but since tsz cannot
     // detect all deprecated features (e.g. deprecated source syntax like import assertions),
     // it conservatively emits TS5103 for any invalid ignoreDeprecations value.
-    let source = r#"{"compilerOptions":{"ignoreDeprecations":"7.0"}}"#;
+    let source = r#"{"compilerOptions":{"ignoreDeprecations":"5.5"}}"#;
     let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
     let codes: Vec<u32> = parsed.diagnostics.iter().map(|d| d.code).collect();
     assert!(
         codes.contains(&5103),
-        "Expected TS5103 for invalid ignoreDeprecations='7.0', got: {codes:?}"
+        "Expected TS5103 for invalid ignoreDeprecations='5.5', got: {codes:?}"
     );
 }
 
@@ -920,12 +938,12 @@ fn test_ts5103_emitted_for_invalid_ignore_deprecations_with_deprecated_target_al
     // tsc emits TS5103 when an invalid ignoreDeprecations value is used alongside
     // a deprecated target alias like "es6" (deprecated in favor of "es2015").
     // This matches the arrowFunction conformance test pattern.
-    let source = r#"{"compilerOptions":{"ignoreDeprecations":"7.0","target":"es6"}}"#;
+    let source = r#"{"compilerOptions":{"ignoreDeprecations":"5.5","target":"es6"}}"#;
     let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
     let codes: Vec<u32> = parsed.diagnostics.iter().map(|d| d.code).collect();
     assert!(
         codes.contains(&5103),
-        "Expected TS5103 for ignoreDeprecations='7.0' with deprecated target='es6', got: {codes:?}"
+        "Expected TS5103 for ignoreDeprecations='5.5' with deprecated target='es6', got: {codes:?}"
     );
 }
 
@@ -934,12 +952,12 @@ fn test_ts5103_emitted_for_invalid_ignore_deprecations_with_any_target() {
     // tsz emits TS5103 conservatively for any invalid ignoreDeprecations value,
     // regardless of target. Even non-deprecated targets like "es2018" will trigger
     // TS5103 in tsz (conservative approach since we can't detect all deprecated syntax).
-    let source = r#"{"compilerOptions":{"ignoreDeprecations":"7.0","target":"es2018"}}"#;
+    let source = r#"{"compilerOptions":{"ignoreDeprecations":"5.5","target":"es2018"}}"#;
     let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
     let codes: Vec<u32> = parsed.diagnostics.iter().map(|d| d.code).collect();
     assert!(
         codes.contains(&5103),
-        "Expected TS5103 (conservative) for ignoreDeprecations='7.0' with target='es2018', got: {codes:?}"
+        "Expected TS5103 (conservative) for ignoreDeprecations='5.5' with target='es2018', got: {codes:?}"
     );
 }
 
@@ -963,6 +981,20 @@ fn test_ts5103_not_emitted_for_valid_6_0() {
     assert!(
         !codes.contains(&5103),
         "Should NOT emit TS5103 for valid ignoreDeprecations='6.0', got: {codes:?}"
+    );
+}
+
+#[test]
+fn test_ts5103_not_emitted_for_valid_7_0() {
+    // TypeScript 7.0.2 accepts its own "7.0" value (#16217) alongside the
+    // historical "5.0"/"6.0" — none of the three silence any diagnostic
+    // today, but all three are accepted as legal ignoreDeprecations values.
+    let source = r#"{"compilerOptions":{"ignoreDeprecations":"7.0"}}"#;
+    let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
+    let codes: Vec<u32> = parsed.diagnostics.iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&5103),
+        "Should NOT emit TS5103 for valid ignoreDeprecations='7.0', got: {codes:?}"
     );
 }
 


### PR DESCRIPTION
Fixes #16217.

## Goal
Goal: hold

## Structural rule

When a source file uses the deprecated `assert` import-attribute keyword,
`tsc` 7.0.2 reports TS2880 unconditionally — no `ignoreDeprecations` value
silences it. `tsc` 6.0.2 gated the diagnostic on
`compilerOptions.ignoreDeprecations !== "6.0"`; the 7.0 line closed that
grace window entirely. Owner layer: the checker's single query-boundary
counterpart to `tsc`'s three emission sites, `check_import_assert_deprecated`
in `crates/tsz-checker/src/query_boundaries/environment.rs`, now always
returns `Some(ImportAssertDeprecated)`.

Separately, TS5103 (`Invalid value for '--ignoreDeprecations'`) rejected the
literal `"7.0"` even though it's a legal value on the pinned 7.0.2 oracle.
Widened the accepted-value list at its three entry points: tsconfig parse
(`crates/tsz-core/src/config/parse.rs`), CLI override
(`crates/tsz-cli/src/driver/plan.rs`), and the tsconfig-resolution merge
(`crates/tsz-core/src/config/resolved_options.rs`).

The `ignore_deprecations_6_0` field and its three setters are left in place
per #16217's own guidance: `ignoreDeprecations` is a version string and each
future deprecation may have its own threshold, so the plumbing stays even
though no current consumer reads it.

## Adjacent-case matrix
- `check_import_assert_deprecated` unit tests: default (fires), `"5.0"`
  (fires — was already correct), `"6.0"` (now fires — inverted from #16215),
  `with` keyword negative control across all three ignoreDeprecations
  combinations (never fires, unaffected).
- Checker integration tests (`check_with_options`): same three
  `ignoreDeprecations` values against a real `assert { type: "json" }`
  import, `"6.0"` inverted from suppressed to firing.
- TS5103 tests: `"5.0"`/`"6.0"`/`"7.0"` all valid (no TS5103); a genuinely
  invalid value (`"5.5"`) still reports TS5103, including combined with a
  dropped option (TS5023) and a deprecated target alias — the tests that
  previously used `"7.0"` as their invalid witness now use `"5.5"`.
- CLI-level integration test mirrors the tsconfig-level one: direct
  `--ignoreDeprecations 7.0` no longer reports TS5103.

## Verification
- `cargo build -p tsz-checker -p tsz-core -p tsz-cli --lib`: clean.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- `cargo nextest run -p tsz-checker --lib environment_capabilities_tests`: 53/53 pass.
- `cargo nextest run -p tsz-core config::tests::module_resolution`: 95/95 pass.
- `cargo nextest run -p tsz-cli --lib ignore_deprecations`: 8/8 pass.
- `cargo nextest run -p tsz-core checker_state_tests part_16`: 715/716 pass;
  the one failure (`test_duplicate_identifier_three_way_var_let_var_2300`)
  reproduces identically on unmodified `main` (verified via `git stash`) — a
  pre-existing, unrelated failure in the known #15983 family.
- Not run: `compare-to-parent.sh` / full conformance snapshot, emit,
  fourslash. This container has no populated `TypeScript/` submodule
  (`scripts/setup/setup.sh`'s corpus step refused to `--force-reset` a
  checkout with unexpected local changes) and disk is tight after building
  the ~800-binary `tsz-checker` test matrix once. This change is narrowly
  scoped to the TS2880 gate and the `ignoreDeprecations` accepted-value list;
  no corpus fixture currently exercises the flipped `"6.0"` case (per the
  board's standing note, zero-conformance-movement is the expected signature
  for a narrow oracle-pinned fix like this one, not a null result).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_01Sb9TV7WfaHDpATNrkC1Ykv)_