### PR TITLE
fix(checker): TS7016 leaks for a side-effect import of an untyped module

### DIFF
--- a/crates/tsz-checker/src/declarations/import/declaration_check_body.rs
+++ b/crates/tsz-checker/src/declarations/import/declaration_check_body.rs
@@ -481,13 +481,25 @@ impl<'a> CheckerState<'a> {
                 self.ctx.import_resolution_stack.pop();
                 return;
             }
-            // Side-effect imports: suppress ALL resolution errors when
-            // noUncheckedSideEffectImports is disabled (the default).
-            // The check inside the CANNOT_FIND_MODULE block above handles
-            // TS2307/TS2792, but other error codes (e.g., TS2882 from the
-            // conformance runner) can bypass that path. This catch-all
-            // ensures no resolution error leaks for bare `import "module"`.
-            if is_side_effect_import && !self.ctx.compiler_options.no_unchecked_side_effect_imports
+            // Side-effect imports: suppress ALL resolution *failure* errors
+            // when noUncheckedSideEffectImports is disabled. The check inside
+            // the CANNOT_FIND_MODULE block above handles TS2307/TS2792, but
+            // other error codes (e.g., TS2882 from the conformance runner)
+            // can bypass that path. This catch-all ensures no resolution
+            // error leaks for bare `import "module"`.
+            //
+            // TS7016 is different: it fires when the specifier *resolved*
+            // successfully to an untyped JS file, not when resolution
+            // failed. `noUncheckedSideEffectImports` only controls whether an
+            // unresolvable side-effect import gets a diagnostic (TS2882) — it
+            // says nothing about a module that resolved fine but lacks
+            // declarations. tsc stays silent on TS7016 for a side-effect
+            // import regardless of the flag's value (verified against the
+            // pinned 7.0.2 oracle), so it is suppressed unconditionally here.
+            if is_side_effect_import
+                && (!self.ctx.compiler_options.no_unchecked_side_effect_imports
+                    || error_code
+                        == crate::diagnostics::diagnostic_codes::COULD_NOT_FIND_A_DECLARATION_FILE_FOR_MODULE_IMPLICITLY_HAS_AN_ANY_TYPE)
             {
                 self.ctx.import_resolution_stack.pop();
                 return;

--- a/crates/tsz-cli/tests/untyped_module_resolution_tests.rs
+++ b/crates/tsz-cli/tests/untyped_module_resolution_tests.rs
@@ -208,6 +208,151 @@ fn untyped_node_modules_package_reports_ts7016_under_no_implicit_any() {
     );
 }
 
+/// A bare side-effect import (`import "pkg";`) of an untyped `node_modules`
+/// package must stay silent under `noImplicitAny`, unlike every other import
+/// form. `noUncheckedSideEffectImports` (on by default as of the pinned
+/// 7.0.2 oracle) only controls whether a genuinely *unresolvable*
+/// side-effect import gets a diagnostic (TS2882); it says nothing about a
+/// specifier that resolved fine but lacks declarations, so TS7016 stays
+/// suppressed here regardless of the flag's value.
+#[test]
+fn untyped_node_modules_package_side_effect_import_stays_silent_under_no_implicit_any() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let base = temp.path();
+
+    write_untyped_package(base, "silent-pkg");
+
+    write_file(
+        &base.join("side_effect.ts"),
+        "import \"silent-pkg\";\nexport const marker = 1;\n",
+    );
+
+    write_tsconfig(
+        base,
+        ",\n                \"noImplicitAny\": true",
+        &["side_effect.ts"],
+    );
+
+    let args = parse_args(&["tsz", "--noEmit"]);
+    let result = compile(&args, base).expect("compile should succeed");
+
+    let unresolved = diagnostics_with_code(&result.diagnostics, CANNOT_FIND_MODULE);
+    assert!(
+        unresolved.is_empty(),
+        "a side-effect import never reports TS2307 for an untyped package, got: {unresolved:#?}"
+    );
+
+    let missing_declaration =
+        diagnostics_with_code(&result.diagnostics, COULD_NOT_FIND_DECLARATION_FILE);
+    assert!(
+        missing_declaration.is_empty(),
+        "a resolved untyped package is not a side-effect-import resolution failure, so TS7016 stays suppressed, got: {missing_declaration:#?}"
+    );
+}
+
+/// Explicitly enabling `noUncheckedSideEffectImports` (redundant with the
+/// real default, but pins the behavior independent of it) must not change
+/// the previous case: TS7016 still stays suppressed for a resolved-but-
+/// untyped side-effect import target.
+#[test]
+fn untyped_node_modules_package_side_effect_import_stays_silent_with_unchecked_side_effect_imports_on()
+ {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let base = temp.path();
+
+    write_untyped_package(base, "checked-pkg");
+
+    write_file(
+        &base.join("side_effect.ts"),
+        "import \"checked-pkg\";\nexport const marker = 1;\n",
+    );
+
+    write_tsconfig(
+        base,
+        ",\n                \"noImplicitAny\": true,\n                \"noUncheckedSideEffectImports\": true",
+        &["side_effect.ts"],
+    );
+
+    let args = parse_args(&["tsz", "--noEmit"]);
+    let result = compile(&args, base).expect("compile should succeed");
+
+    let missing_declaration =
+        diagnostics_with_code(&result.diagnostics, COULD_NOT_FIND_DECLARATION_FILE);
+    assert!(
+        missing_declaration.is_empty(),
+        "a resolved untyped package is not a side-effect-import resolution failure, so TS7016 stays suppressed even with noUncheckedSideEffectImports on, got: {missing_declaration:#?}"
+    );
+}
+
+/// Negative direction for the TS7016-suppression fix above: a side-effect
+/// import of a specifier that does NOT resolve at all is a genuine
+/// resolution failure, which `noUncheckedSideEffectImports` (on by default)
+/// DOES gate — tsc reports TS2882, not silence and not TS7016. The fix must
+/// not conflate "resolved but untyped" with "did not resolve".
+#[test]
+fn missing_module_side_effect_import_reports_ts2882_by_default() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let base = temp.path();
+
+    write_file(
+        &base.join("side_effect.ts"),
+        "import \"totally-missing-pkg\";\nexport const marker = 1;\n",
+    );
+
+    write_tsconfig(base, "", &["side_effect.ts"]);
+
+    let args = parse_args(&["tsz", "--noEmit"]);
+    let result = compile(&args, base).expect("compile should succeed");
+
+    const CANNOT_FIND_MODULE_OR_TYPE_DECLARATIONS_FOR_SIDE_EFFECT_IMPORT_OF: u32 = 2882;
+    let side_effect_not_found = diagnostics_with_code(
+        &result.diagnostics,
+        CANNOT_FIND_MODULE_OR_TYPE_DECLARATIONS_FOR_SIDE_EFFECT_IMPORT_OF,
+    );
+    assert_eq!(
+        side_effect_not_found.len(),
+        1,
+        "noUncheckedSideEffectImports defaults to on, so a genuinely missing side-effect import reports TS2882, got: {:#?}",
+        result.diagnostics
+    );
+
+    let missing_declaration =
+        diagnostics_with_code(&result.diagnostics, COULD_NOT_FIND_DECLARATION_FILE);
+    assert!(
+        missing_declaration.is_empty(),
+        "a genuinely missing module reports TS2882, never TS7016, got: {missing_declaration:#?}"
+    );
+}
+
+/// Explicitly disabling `noUncheckedSideEffectImports` flips the previous
+/// case back to silence: a side-effect import of a specifier that does not
+/// resolve at all reports nothing when the flag is off.
+#[test]
+fn missing_module_side_effect_import_stays_silent_with_unchecked_side_effect_imports_off() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let base = temp.path();
+
+    write_file(
+        &base.join("side_effect.ts"),
+        "import \"totally-missing-pkg\";\nexport const marker = 1;\n",
+    );
+
+    write_tsconfig(
+        base,
+        ",\n                \"noUncheckedSideEffectImports\": false",
+        &["side_effect.ts"],
+    );
+
+    let args = parse_args(&["tsz", "--noEmit"]);
+    let result = compile(&args, base).expect("compile should succeed");
+
+    assert!(
+        result.diagnostics.is_empty(),
+        "noUncheckedSideEffectImports: false silences a genuinely missing side-effect import entirely, got: {:#?}",
+        result.diagnostics
+    );
+}
+
 /// Fallback direction: a specifier with nothing behind it at all still reports
 /// TS2307 at both request-scoped sites. Nothing about the fix may make a
 /// genuinely missing module look resolved.


### PR DESCRIPTION
When a module specifier resolves successfully (to an untyped JS file) rather than failing to resolve at all, tsc never reports TS7016 for a bare side-effect import (`import "pkg";`) — regardless of `noUncheckedSideEffectImports` — verified against the pinned `typescript@7.0.2` oracle in both the default-on and explicit-off configurations.

`check_import_declaration`'s side-effect-import catch-all (`crates/tsz-checker/src/declarations/import/declaration_check_body.rs`) conflated "resolution failed" with "resolved but untyped": it only suppressed a resolution-error diagnostic for a side-effect import when `noUncheckedSideEffectImports` was *off*. Since that flag actually defaults to *on* in the pinned 7.0.2 oracle (confirmed empirically — a genuinely missing module reaches TS2882 with no explicit setting), the guard never fired in the default configuration, and a resolved-but-untyped module's TS7016 fell through to normal emission.

Structural rule: when a side-effect import's specifier *resolves* (even to a file with no declarations), tsc never reports TS7016 for it, independent of `noUncheckedSideEffectImports` — that flag only gates whether a specifier that does **not** resolve at all gets TS2882. tsz now suppresses TS7016 unconditionally for side-effect imports through the same catch-all, leaving the TS2307→TS2882 conversion path (which already respected the flag) untouched.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-cli --lib untyped_module_resolution_tests` — 9/9 passed (5 pre-existing + 4 new), 0 regressions.
- New adjacent-case matrix in `crates/tsz-cli/tests/untyped_module_resolution_tests.rs`:
  - resolved-but-untyped package + side-effect import + `noImplicitAny`, default `noUncheckedSideEffectImports` → TS7016 suppressed (was leaking; now fixed)
  - same, with `noUncheckedSideEffectImports` explicitly `true` → TS7016 suppressed (was leaking; now fixed)
  - genuinely missing module + side-effect import, default `noUncheckedSideEffectImports` (on) → TS2882 reported, not TS7016 (unchanged, still correct)
  - same, with `noUncheckedSideEffectImports` explicitly `false` → fully silent (unchanged, still correct)
- `cargo clippy -p tsz-checker -p tsz-cli --all-targets -- -D warnings` — clean.
- `cargo fmt -- --check` on touched files — clean.
- Root-caused via a temporary `TSZ_DEBUG_PANIC_ON_7016`-gated panic in the diagnostic sinks (`error_at_position`/`ctx.error`) to backtrace the actual emission call site, per the repo's diagnostic-debugging convention — removed before this commit.
- `scripts/conformance/compare-to-parent.sh` is running in the background against this exact head; this narrow change touches only side-effect-import handling (no existing corpus fixture exercises this exact shape per the diagnostic-table entries), so 0/0 newly-failing/newly-passing is expected. Will post the result as a PR comment once it completes, or fix if it surfaces something.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: Feldspar


---
_Generated by [Claude Code](https://claude.ai/code/session_013d5xCp4JSbW4zHXwcynrTc)_