### PR TITLE
fix(checker): a non-entity computed member name contributes no class index signature

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
@@ -1841,7 +1841,14 @@ impl<'a> CheckerState<'a> {
         Some((key_type, value_type, is_static))
     }
 
-    fn computed_name_uses_entity_expression(&self, expr_idx: NodeIndex) -> bool {
+    /// Whether a computed property name's key expression is an entity name --
+    /// a bare identifier or a dotted chain rooted in one.
+    ///
+    /// `tsc` only lets such a name contribute an index signature to the
+    /// containing class type. An arbitrary expression key (`["" + ""]`, `[+s]`,
+    /// `[f()]`) contributes nothing and is only ever *checked* against index
+    /// signatures contributed by other members.
+    pub(crate) fn computed_name_uses_entity_expression(&self, expr_idx: NodeIndex) -> bool {
         let Some(expr_node) = self.ctx.arena.get(expr_idx) else {
             return false;
         };

--- a/crates/tsz-checker/src/types/class_type/helpers.rs
+++ b/crates/tsz-checker/src/types/class_type/helpers.rs
@@ -472,6 +472,16 @@ impl<'a> CheckerState<'a> {
             return;
         };
 
+        // Only an entity-name key (`[s]`, `[o.p]`) contributes an index
+        // signature to the class type. `tsc` gives an arbitrary expression key
+        // (`["" + ""]`, `[+s]`, `[f()]`) no index signature at all -- such a
+        // member is only ever *checked* against index signatures contributed by
+        // others. Without this gate the member manufactures the very signature
+        // it is then measured against, producing a spurious `TS2411`.
+        if !self.computed_name_uses_entity_expression(computed.expression) {
+            return;
+        }
+
         let prev = self.ctx.preserve_literal_types;
         self.ctx.preserve_literal_types = true;
         let key_type = self.get_type_of_node(computed.expression);

--- a/crates/tsz-checker/tests/ts2411_tests.rs
+++ b/crates/tsz-checker/tests/ts2411_tests.rs
@@ -615,3 +615,141 @@ export {};
         "Two structurally-identical unannotated function types must not report TS2411"
     );
 }
+
+// ---------------------------------------------------------------------------
+// A computed member name that is not an entity name contributes no index
+// signature to the class type.
+//
+// `tsc` only lets an entity-name key (`[s]`, `[o.p]`) contribute an index
+// signature. An arbitrary expression key (`["" + ""]`, `[+s]`, `[f()]`)
+// contributes nothing and is only ever *checked* against index signatures
+// contributed by others. tsz used to synthesize a signature from any computed
+// name whose key type was `string`/`number`/`any`, so such a member
+// manufactured the very signature it was then measured against.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn non_entity_computed_method_name_contributes_no_index_signature() {
+    // The conformance shape: computedPropertyNamesDeclarationEmit1_ES5/ES6.
+    let source = r#"
+class C {
+    ["" + ""]() { }
+    get ["" + ""]() { return 0; }
+    set ["" + ""](x) { }
+}
+"#;
+    assert!(
+        !has_error_with_code(source, 2411),
+        "a class whose only members have non-entity computed names has no index \
+         signature at all, so nothing can be checked against one: {:?}",
+        get_diagnostics(source)
+    );
+}
+
+#[test]
+fn non_entity_computed_method_name_contributes_nothing_under_renamed_binders() {
+    // Same structure, different key text and member names -- the rule is about
+    // the shape of the key expression, never the spelling of any binder.
+    let source = r#"
+class Renamed {
+    ["alpha" + "beta"]() { }
+    get ["gamma" + "delta"]() { return 0; }
+}
+"#;
+    assert!(
+        !has_error_with_code(source, 2411),
+        "renaming the class and the key operands must not change the outcome: {:?}",
+        get_diagnostics(source)
+    );
+}
+
+#[test]
+fn non_entity_computed_name_wrapper_forms_contribute_no_index_signature() {
+    // Wrapper/nesting forms of a non-entity key: parenthesized identifier,
+    // unary operator, and a call expression all fail the entity-name test.
+    let source = r#"
+declare var s: string;
+declare function f(): string;
+class C {
+    [(s)]() { }
+    [+s]() { }
+    [f()]() { }
+    get [(s)]() { return 0; }
+}
+"#;
+    assert!(
+        !has_error_with_code(source, 2411),
+        "parenthesized, unary and call-expression keys are not entity names: {:?}",
+        get_diagnostics(source)
+    );
+}
+
+#[test]
+fn non_entity_computed_static_method_name_contributes_no_index_signature() {
+    let source = r#"
+class C {
+    static ["" + ""]() { }
+    static get ["" + ""]() { return 0; }
+}
+"#;
+    assert!(
+        !has_error_with_code(source, 2411),
+        "the static side follows the same rule as the instance side: {:?}",
+        get_diagnostics(source)
+    );
+}
+
+#[test]
+fn declared_index_signature_still_checks_a_non_entity_computed_member() {
+    // Positive control, and the direction the gate must NOT suppress: a member
+    // with a non-entity computed name contributes no signature, but it is still
+    // *checked* against a signature that was really declared.
+    let source = r#"
+class C {
+    [k: string]: number;
+    ["" + ""]() { }
+}
+"#;
+    assert!(
+        has_error_with_code(source, 2411),
+        "a declared string index signature still constrains a non-entity \
+         computed member: {:?}",
+        get_diagnostics(source)
+    );
+}
+
+#[test]
+fn declared_index_signature_still_checks_a_literal_computed_member() {
+    // Adjacent concrete form: a computed name with a literal type resolves to a
+    // real named property and is checked exactly like one.
+    let source = r#"
+class C {
+    [k: string]: number;
+    ["lit"]() { }
+}
+"#;
+    assert!(
+        has_error_with_code(source, 2411),
+        "a literal computed name is a named property and is still checked: {:?}",
+        get_diagnostics(source)
+    );
+}
+
+#[test]
+fn entity_computed_name_still_contributes_an_index_signature() {
+    // The gate must not over-apply: an entity-name key still contributes, and a
+    // sibling non-entity computed member is still measured against it.
+    let source = r#"
+declare var s: string;
+class C {
+    [s]: number;
+    [+s]: typeof s;
+}
+"#;
+    assert!(
+        has_error_with_code(source, 2411),
+        "an entity-name key still contributes a string index signature that \
+         constrains other computed members: {:?}",
+        get_diagnostics(source)
+    );
+}


### PR DESCRIPTION
Fixes the two `computedPropertyNamesDeclarationEmit1_ES5/ES6` conformance rows. Both are **pure-extra** (`m` empty, `x` = `["TS2411"]`): the fixture expects zero diagnostics and tsz produced exactly one TS2411.

## Structural rule

> When a class member's computed property name is **not an entity name** — an arbitrary expression key such as `["" + ""]`, `[+s]`, `[f()]`, `[(s)]` — `tsc` contributes **no** index signature to the containing class type. Such a member is only ever *checked* against index signatures contributed by others. tsz now does the same through the checker's class-type construction (`crates/tsz-checker/src/types/class_type/helpers.rs`).

`merge_index_signature_from_unresolved_computed_name` had no entity-name gate: it synthesized a `string`/`number` index signature from **any** computed name whose key type was `string`, `number`, or `any`. A class whose only members had non-entity computed names therefore manufactured the very index signature it was then measured against — the getter's `number`, the method's `() =&gt; void` and the setter's parameter type were merged into one synthetic string index, and then each member was reported as not assignable to it.

The **sibling** synthesis path — `synthesized_computed_member_index_info` in `state_checking_members/index_signature_checks.rs` — already restricts itself to entity keys, with a comment explaining exactly why. Two implementations of one `tsc` fact, only one of them complete. They now share the `computed_name_uses_entity_expression` predicate (widened from module-private to `pub(crate)`), so the rule lives in one place.

This is the same "find a gate with a hand-maintained rule, grep for its sibling before extending it" shape called out on #15994 after #16238.

Worth recording, because it sent me to the wrong layer first: the intuition that *classes never get index signatures from computed names* is *wrong*. `tsc` does synthesize them — but only from entity-name keys. The decisive probe is to put the candidate contributor and a sibling that fails *iff* a signature was contributed into one class and diff the count: `class C { [s]: number; [+s]: typeof s; }` errors, `class C { [+s]: typeof s; }` alone does not.

## Verification

Oracle is the pinned native `typescript@7.0.2` binary (resolved via `getExePath.js`, not the `tsc.js` shim), `--noEmit --strict false --target es2015`.

**Two-sided corpus diff — `scripts/conformance/compare-to-parent.sh`, run against this PR's own parent `9b9e6a2`, both sides built and snapshotted locally:**

```
base   11463 passed, 579 failing
branch 11465 passed, 577 failing

NEWLY PASSING (2):
   + computedPropertyNamesDeclarationEmit1_ES5.ts
   + computedPropertyNamesDeclarationEmit1_ES6.ts
NEWLY FAILING (0):   (none)
still failing, fingerprint changed (0)
```

**+2 newly passing, 0 newly failing, 0 fingerprint changes** — the two newly-passing rows are exactly the two targeted, and nothing else moved in either direction, including the "still failing but with a different diagnostic set" bucket that catches a fix trading one wrong answer for another.

**The reported rows, before/after** (`--declaration`, targets es2015/es2020/esnext — the fixture is one body under two targets, so target-invariance is a built-in control):

| fixture | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `computedPropertyNamesDeclarationEmit1_ES5.ts` | clean | `TS2411` | clean |
| `computedPropertyNamesDeclarationEmit1_ES6.ts` | clean | `TS2411` | clean |

**Key-shape matrix** — a computed member plus a sibling that fails *iff* an index signature was contributed. Counts are TS2411 occurrences.

| contributor key | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `["" + ""]() { }` (binary, method) | 0 | **1** | 0 |
| the 3-member fixture (method + getter + setter) | 0 | **1** | 0 |
| `[(s)]`, `[+s]`, `[f()]` (paren / unary / call) | 0 | 0 | 0 |
| `[k: string]: number;` + `["" + ""]() { }` (**declared** signature) | 1 | 1 | 1 |
| `[k: string]: number;` + `["lit"]() { }` (literal name = real property) | 1 | 1 | 1 |
| `[s]: number;` + `[+s]: typeof s;` (**entity** key still contributes) | 1 | 1 | 1 |

The last three rows are the direction the gate must not suppress, and none moved. Across the full 21-cell contributor x checked-member matrix (contributors: entity-`string`, entity-`number`, entity-`any`, property-access, binary-property, binary-method, declared; checked: named property, non-entity computed, entity computed) **no cell moved away from `tsc`**; the pre-existing divergences listed under "Not in scope" below are unchanged.

**Adjacent cases** (7 new tests in `crates/tsz-checker/tests/ts2411_tests.rs`): the conformance shape; renamed binders (class and both key operands renamed — the rule is about key *shape*, never spelling); wrapper/nesting forms (parenthesized, unary, call); the static side; and three positive controls (declared signature still constrains a non-entity computed member; a literal computed name is still a real named property; an entity key still contributes).

- `cargo test -p tsz-checker --test ts2411_tests` — **39/39 pass** (32 pre-existing + 7 new).
- Re-run against the **unfixed** source to confirm the tests actually bite: **36 passed / 3 failed** — the 3 negative-direction tests fail, and all 4 positive controls pass in *both* states, so they are real controls rather than tautologies.
- `cargo fmt --all` clean; pre-commit gate (`cargo clippy -p tsz-checker`, warnings denied) **passed**; architecture guard **passed**.

Emit and fourslash were **not** run in this container. The change touches only class-type construction and produces no output, so no emit row can move — but that is scope, not measurement, and is labelled as such.

## Not in scope (pre-existing, unchanged by this PR)

The same matrix surfaced five *other* TS2411 divergences, all in the **sibling** path (`synthesized_computed_member_index_info`) and all untouched here. Recording them so the next session does not re-derive them:

- `[s]: number;` (entity, `string`) or `[a]: number;` (entity, `any`) + an ordinary named property `m: string` → tsc **0**, tsz **1**. tsc never checks an *ordinary named property* against an index signature contributed by a computed member; tsz does. Two false positives.
- `[a]: number;` + a non-entity computed member → tsc 1, tsz 2 (one extra).
- `[o.p]: number;` (property-access key) + a non-entity computed member → tsc 1, tsz **0**, and a declared signature + an entity computed member → tsc 1, tsz **0**. Two *missing* diagnostics, opposite direction.

Fixing these means teaching TS2411 target-selection to carry contributed-vs-declared provenance — a wider change with real regression risk on rows that pass today, and none of it affects the two rows this PR closes.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Sanidine