### PR TITLE
fix(checker): a name-only JSDoc @param tag does not make a JS param required

### DIFF
--- a/crates/tsz-checker/src/jsdoc/params_type_strings.rs
+++ b/crates/tsz-checker/src/jsdoc/params_type_strings.rs
@@ -30,8 +30,11 @@ impl<'a> CheckerState<'a> {
     /// - `@param {Type} [name]` — brackets around name
     /// - `@param {Type} [name=default]` — brackets with default
     ///
+    /// A name-only tag (`@param name`, no `{Type}`) supplies no type information,
+    /// so it does not override the untyped-JS-parameter implicit-optional rule —
+    /// tsc treats it exactly as if there were no `@param` tag at all (returns false).
+    ///
     /// Non-optional `@param` tags (returns true):
-    /// - `@param name` — name-only, no type
     /// - `@param {Type} name` — standard typed param
     pub(crate) fn jsdoc_has_required_param_tag(jsdoc: &str, param_name: &str) -> bool {
         for chunk in jsdoc.split_inclusive('\n') {
@@ -42,6 +45,7 @@ impl<'a> CheckerState<'a> {
             if let Some((_tag, rest)) = Self::strip_jsdoc_param_tag_prefix(effective)
                 && let Some(param) = Self::parse_jsdoc_param_tag(rest)
                 && param.name == param_name
+                && param.type_expr.is_some()
                 && !param.optional
             {
                 return true;

--- a/crates/tsz-checker/src/types/utilities/tests/jsdoc_params_tests.rs
+++ b/crates/tsz-checker/src/types/utilities/tests/jsdoc_params_tests.rs
@@ -302,11 +302,38 @@ fn jsdoc_has_required_param_tag_standard() {
 
 #[test]
 fn jsdoc_has_required_param_tag_name_only() {
-    // @param name (no type) is considered required
+    // @param name (no type) supplies no type info, so it is NOT considered
+    // required — it must behave exactly like having no @param tag at all
+    // (verified against the pinned tsc@7.0.2 oracle: `function f(a,b,c){}`
+    // with only name-only @param tags in an allowJs file leaves all three
+    // params implicitly optional).
     let jsdoc = r#"
  * @param name
         "#;
-    assert!(CheckerState::jsdoc_has_required_param_tag(jsdoc, "name"));
+    assert!(!CheckerState::jsdoc_has_required_param_tag(jsdoc, "name"));
+}
+
+#[test]
+fn jsdoc_has_required_param_tag_name_only_renamed_binder() {
+    // Same shape, different parameter name — the rule is about tag shape,
+    // never spelling.
+    let jsdoc = r#"
+ * @param count
+        "#;
+    assert!(!CheckerState::jsdoc_has_required_param_tag(jsdoc, "count"));
+}
+
+#[test]
+fn jsdoc_has_required_param_tag_name_only_multiple_params() {
+    // Multiple name-only tags on separate lines — none should be required.
+    let jsdoc = r#"
+ * @param a
+ * @param b
+ * @param c
+        "#;
+    assert!(!CheckerState::jsdoc_has_required_param_tag(jsdoc, "a"));
+    assert!(!CheckerState::jsdoc_has_required_param_tag(jsdoc, "b"));
+    assert!(!CheckerState::jsdoc_has_required_param_tag(jsdoc, "c"));
 }
 
 #[test]
@@ -334,6 +361,18 @@ fn jsdoc_has_required_param_tag_optional_type_suffix() {
  * @param {string=} name
         "#;
     assert!(!CheckerState::jsdoc_has_required_param_tag(jsdoc, "name"));
+}
+
+#[test]
+fn jsdoc_has_required_param_tag_mixed_typed_and_name_only() {
+    // A typed tag for one param and a name-only tag for another: each
+    // param's requiredness is judged independently by its own tag shape.
+    let jsdoc = r#"
+ * @param {string} a
+ * @param b
+        "#;
+    assert!(CheckerState::jsdoc_has_required_param_tag(jsdoc, "a"));
+    assert!(!CheckerState::jsdoc_has_required_param_tag(jsdoc, "b"));
 }
 
 #[test]


### PR DESCRIPTION
Fixes the `jsFileFunctionParametersAsOptional2.ts` conformance row (pure-extra `TS2554` x3) and the associated real false positive: a plain-JS function parameter documented only by a name-only JSDoc `@param name` tag (no `{type}`) was incorrectly required, when tsc treats it exactly like an undocumented untyped parameter (implicitly optional).

## Structural rule

> When a JS-file function parameter has no real type annotation, `tsc` treats it as implicitly optional — regardless of whether a JSDoc `@param` tag merely *names* it without a `{type}`. tsz now does the same through `jsdoc_has_required_param_tag` (`crates/tsz-checker/src/jsdoc/params_type_strings.rs`), the single predicate consumed by all three call sites that decide JS-implicit-parameter-optionality (`crates/tsz-checker/src/types/function_type.rs`, `crates/tsz-checker/src/types/utilities/contextual_parameters.rs`, `crates/tsz-checker/src/jsdoc/params.rs`).

`jsdoc_has_required_param_tag` treated *any* `@param` tag matching the parameter's name as making it required, including a name-only tag carrying no type information at all. The fix adds one condition: the tag must supply an actual `type_expr` (a real `{type}`) to count as "required" — a name-only tag now falls through exactly like having no `@param` tag, matching a JSDoc `@param {Type} name` (typed, no optional marker) unchanged as still-required.

## Root cause hunt

Picked up from a prior session's (ClaudeT, board issue #15994) precise root-cause writeup, which had correctly ruled out the cross-arena delegation machinery (`delegate_cross_arena_symbol_resolution` / `compute_type_of_symbol`'s FUNCTION branch) as innocent and left a `dev`-build trace as the next step. Tracing confirmed delegation is not involved: a two-file repro with **no JSDoc at all** already produced the correct zero-diagnostics result, isolating the bug to JSDoc `@param` handling specifically, not cross-file symbol resolution.

## Verification (pinned `tsc@7.0.2` oracle matrix)

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| no `@param` tags at all | 0 diagnostics | 0 (already correct) | 0 |
| `@param a` / `@param b` / `@param c` (name-only, multi-line) | 0 diagnostics | **3x TS2554** | 0 |
| `@param {number} a/b/c` (typed, no optional marker) | 3x TS2554 (all required) | 3x TS2554 (already correct) | 3x TS2554 (unchanged) |
| `@param {number} a`, `@param {number} [b]`, `@param {number} [c]` (typed + bracket-optional) | 1x TS2554 (`1-3` range) | already correct | unchanged |

The typed rows are the negative control — the fix does not touch tags that carry real type information.

- `cargo test -p tsz-checker --lib jsdoc_has_required_param_tag` — **9/9 pass** (5 pre-existing + inverted `..._name_only` + 3 new: renamed binder, multi-param, mixed typed/name-only-in-one-doc). Before the fix, the un-inverted `..._name_only` test asserted the wrong (buggy) behavior explicitly.
- `cargo fmt --all` clean; pre-commit gate (`cargo clippy -p tsz-checker`, warnings denied) **passed**; architecture guard **passed**.
- `scripts/conformance/compare-to-parent.sh` (two-sided, this branch vs. parent `7e7dbd0`): **base failing=577, branch failing=576. NEWLY PASSING (1): `jsFileFunctionParametersAsOptional2.ts`. NEWLY FAILING (0).**

Emit and fourslash were not run — this change touches only JS-file JSDoc parameter-optionality resolution in the checker and produces no output.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib jsdoc_has_required_param_tag` — 9/9 pass, 0 regressions.
- `cargo fmt --all` clean; `cargo clippy -p tsz-checker` (pre-commit gate) clean; architecture guard passed.
- `scripts/conformance/compare-to-parent.sh` vs parent `7e7dbd0`: 1 newly passing (`jsFileFunctionParametersAsOptional2.ts`), 0 newly failing.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xg9zTGkRKwSXwP9QzvY3PL)_