### PR TITLE
fix(cli): drop parser-emitted TS1101 when the program has a real parse error

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -320,9 +320,15 @@ pub(super) fn filtered_parse_diagnostics(
     // tsc's suppression behavior. We only suppress grammar codes when there's a
     // non-grammar parse error present (e.g., TS1005, TS1109) to avoid suppressing
     // grammar codes that are the file's only diagnostic.
-    let has_non_grammar_parse_error = parse_diagnostics
-        .iter()
-        .any(|d| !matches!(d.code, 1009 | 1185 | 1214 | 1262) && !is_parser_grammar_code(d.code));
+    //
+    // 1009/1185/1214/1262/1359 are themselves parser-emitted strict-mode/grammar
+    // checks (not structural parse failures), so their presence must not count as
+    // the "real" trigger that suppresses sibling grammar codes in the same file —
+    // e.g. plainJSBinderErrors.ts reports TS1101 and TS1359 together with no
+    // structural parse error at all, per the pinned tsc oracle.
+    let has_non_grammar_parse_error = parse_diagnostics.iter().any(|d| {
+        !matches!(d.code, 1009 | 1185 | 1214 | 1262 | 1359) && !is_parser_grammar_code(d.code)
+    });
 
     // TS1359 for `await` is parser-emitted in tsz. Keep it alongside unrelated
     // parse diagnostics (tsc does this in plain JS binder errors), but suppress

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -317,19 +317,26 @@ pub(super) fn filtered_parse_diagnostics(
     // tsc emits these codes via grammarErrorOnNode in the checker, which checks
     // hasParseDiagnostics(sourceFile) and suppresses when any parse error exists.
     // In tsz, these are emitted by the parser. We post-filter them here to match
-    // tsc's suppression behavior. Only a genuine structural parse failure
-    // (`is_real_syntax_error`, already the authoritative classification used
-    // above for `has_real_syntax_error`) counts as "this file has parse
-    // diagnostics" for hasParseDiagnostics purposes: codes tsz emits from the
-    // parser that are themselves grammar/strict-mode checks (not AST-corrupting,
-    // e.g. TS1214/TS1262/TS1359/TS18012) must not trigger suppression of their
-    // siblings in the same file. plainJSBinderErrors.ts reports TS1101 alongside
-    // several of those together, with no structural parse error at all, per the
-    // pinned tsc oracle — an ad-hoc exemption tuple here previously had to
-    // enumerate each such code individually and kept missing entries; reusing
-    // `has_real_syntax_error` covers the whole family by construction (it is
-    // disjoint from `is_parser_grammar_code` by design — a diagnostic is either
-    // a structural failure or a grammar check, never both).
+    // tsc's suppression behavior. We only suppress grammar codes when there's a
+    // non-grammar parse error present (e.g., TS1005, TS1109) to avoid suppressing
+    // grammar codes that are the file's only diagnostic.
+    //
+    // `is_real_syntax_error` is NOT a substitute for this exemption tuple: TS1260
+    // (keyword containing an escape character, e.g. `default:`) is neither a
+    // structural failure nor a listed grammar code, yet per the pinned tsc oracle
+    // it DOES trigger file-wide suppression of sibling grammar codes
+    // (switchStatementsWithMultipleDefaults.ts reports only TS1260, dropping every
+    // TS1113 duplicate-default diagnostic) — so "not exempted" must stay the
+    // default for anything not proven to need exemption, not "not a real syntax
+    // error". 1009/1185/1214/1262/1359/18012 are themselves parser-emitted
+    // strict-mode/grammar checks (not structural failures) that must NOT count as
+    // the trigger: e.g. plainJSBinderErrors.ts reports TS1101, TS1359, and TS18012
+    // ('#constructor' is a reserved word) all together with no structural parse
+    // error at all, per the same oracle.
+    let has_non_grammar_parse_error = parse_diagnostics.iter().any(|d| {
+        !matches!(d.code, 1009 | 1185 | 1214 | 1262 | 1359 | 18012)
+            && !is_parser_grammar_code(d.code)
+    });
 
     // TS1359 for `await` is parser-emitted in tsz. Keep it alongside unrelated
     // parse diagnostics (tsc does this in plain JS binder errors), but suppress
@@ -351,7 +358,7 @@ pub(super) fn filtered_parse_diagnostics(
             // and program-wide (when any file in the program has real syntax errors).
             // tsc's grammarErrorOnNode calls hasParseDiagnostics(sourceFile) which
             // covers program-level parse errors; we mirror that behavior here.
-            if (has_real_syntax_error || program_has_real_syntax_errors)
+            if (has_non_grammar_parse_error || program_has_real_syntax_errors)
                 && is_parser_grammar_code(diagnostic.code)
             {
                 return false;

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -383,6 +383,13 @@ const fn is_parser_grammar_code(code: u32) -> bool {
         code,
         1014 // A rest parameter must be last in a parameter list
         | 1017 // An index signature cannot have a rest parameter
+        | 1101 // 'with' statements are not allowed in strict mode. tsc's
+                // checkStrictModeWithStatement is a binder check
+                // (file.bindDiagnostics); tsz emits it eagerly from the parser
+                // for the syntactically-auto-strict cases (class body, ES
+                // module top level) since that context is known without the
+                // checker. Route it through the same hasParseDiagnostics-style
+                // suppression as its checker-emitted binder-check siblings.
         | 1019 // An index signature parameter cannot have a question mark
         | 1021 // An index signature must have a type annotation
         | 1028 // Accessibility modifier already seen

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -317,18 +317,19 @@ pub(super) fn filtered_parse_diagnostics(
     // tsc emits these codes via grammarErrorOnNode in the checker, which checks
     // hasParseDiagnostics(sourceFile) and suppresses when any parse error exists.
     // In tsz, these are emitted by the parser. We post-filter them here to match
-    // tsc's suppression behavior. We only suppress grammar codes when there's a
-    // non-grammar parse error present (e.g., TS1005, TS1109) to avoid suppressing
-    // grammar codes that are the file's only diagnostic.
-    //
-    // 1009/1185/1214/1262/1359 are themselves parser-emitted strict-mode/grammar
-    // checks (not structural parse failures), so their presence must not count as
-    // the "real" trigger that suppresses sibling grammar codes in the same file —
-    // e.g. plainJSBinderErrors.ts reports TS1101 and TS1359 together with no
-    // structural parse error at all, per the pinned tsc oracle.
-    let has_non_grammar_parse_error = parse_diagnostics.iter().any(|d| {
-        !matches!(d.code, 1009 | 1185 | 1214 | 1262 | 1359) && !is_parser_grammar_code(d.code)
-    });
+    // tsc's suppression behavior. Only a genuine structural parse failure
+    // (`is_real_syntax_error`, already the authoritative classification used
+    // above for `has_real_syntax_error`) counts as "this file has parse
+    // diagnostics" for hasParseDiagnostics purposes: codes tsz emits from the
+    // parser that are themselves grammar/strict-mode checks (not AST-corrupting,
+    // e.g. TS1214/TS1262/TS1359/TS18012) must not trigger suppression of their
+    // siblings in the same file. plainJSBinderErrors.ts reports TS1101 alongside
+    // several of those together, with no structural parse error at all, per the
+    // pinned tsc oracle — an ad-hoc exemption tuple here previously had to
+    // enumerate each such code individually and kept missing entries; reusing
+    // `has_real_syntax_error` covers the whole family by construction (it is
+    // disjoint from `is_parser_grammar_code` by design — a diagnostic is either
+    // a structural failure or a grammar check, never both).
 
     // TS1359 for `await` is parser-emitted in tsz. Keep it alongside unrelated
     // parse diagnostics (tsc does this in plain JS binder errors), but suppress
@@ -350,7 +351,7 @@ pub(super) fn filtered_parse_diagnostics(
             // and program-wide (when any file in the program has real syntax errors).
             // tsc's grammarErrorOnNode calls hasParseDiagnostics(sourceFile) which
             // covers program-level parse errors; we mirror that behavior here.
-            if (has_non_grammar_parse_error || program_has_real_syntax_errors)
+            if (has_real_syntax_error || program_has_real_syntax_errors)
                 && is_parser_grammar_code(diagnostic.code)
             {
                 return false;

--- a/crates/tsz-cli/src/driver/check_utils/tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/tests.rs
@@ -1287,6 +1287,94 @@ fn filtered_parse_diagnostics_keeps_ts1028_when_alone() {
 }
 
 #[test]
+fn filtered_parse_diagnostics_suppresses_ts1101_when_real_parse_error_present() {
+    use tsz::parser::ParseDiagnostic;
+
+    // `with` inside a class body or module top level is parser-emitted TS1101
+    // in tsz (the parser knows the syntactic auto-strict context without the
+    // checker). tsc's checkStrictModeWithStatement is a binder check
+    // (file.bindDiagnostics), suppressed program-wide by hasParseDiagnostics
+    // whenever a real structural parse error exists — verified against the
+    // pinned tsc oracle: `with (o) { ... }` plus an unrelated `function f( {}`
+    // reports only TS1005, dropping both TS1101 and the checker's TS2410.
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 30,
+            length: 4,
+            message: "'with' statements are not allowed in strict mode.".to_string(),
+            code: 1101,
+        },
+        ParseDiagnostic {
+            start: 80,
+            length: 1,
+            message: "')' expected.".to_string(),
+            code: 1005,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&1101),
+        "TS1101 should be suppressed when a real parse error (TS1005) is present, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1005),
+        "TS1005 (real parse error) should survive, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_keeps_ts1101_when_alone() {
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![ParseDiagnostic {
+        start: 30,
+        length: 4,
+        message: "'with' statements are not allowed in strict mode.".to_string(),
+        code: 1101,
+    }];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&1101),
+        "TS1101 should be kept when it is the only diagnostic, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_keeps_ts1101_with_non_real_parse_error() {
+    use tsz::parser::ParseDiagnostic;
+
+    // TS1014 (rest parameter must be last) does not corrupt the AST and is
+    // intentionally excluded from `is_real_syntax_error` — verified against
+    // the pinned tsc oracle: `with` plus `function f(...a, b) {}` in the same
+    // file still reports both TS1101 and TS1014/TS7019/TS7006 together.
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 30,
+            length: 4,
+            message: "'with' statements are not allowed in strict mode.".to_string(),
+            code: 1101,
+        },
+        ParseDiagnostic {
+            start: 90,
+            length: 1,
+            message: "A rest parameter must be last in a parameter list.".to_string(),
+            code: 1014,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&1101),
+        "TS1101 should survive alongside a non-real parse error (TS1014), got: {codes:?}"
+    );
+}
+
+#[test]
 fn js_parse_allowlist_keeps_plain_js_binder_strict_codes() {
     for code in [1214, 18012] {
         assert!(


### PR DESCRIPTION
When any file in a program has a real structural parse error, tsc's `emitFilesAndReportErrors` never reaches the semantic phase, so every diagnostic tsc's *binder* or *checker* would otherwise report — including `checkStrictModeWithStatement`'s TS1101 (`'with' statements are not allowed in strict mode`) — disappears program-wide. #16238 fixed this suppression for the sibling `checkStrictMode*`/checker-routed `TS1xxx` codes (`1100`, `1104`, `1105`, `1107`, `1215`, `1344`) by threading them through `is_checker_routed_ts1xxx_grammar`, but explicitly left TS1101 out: tsz has a **fourth emission path** for it, direct in the parser (`crates/tsz-parser/src/parser/state_switch_recovery.rs:324`, `parse_with_statement`), used for the syntactically-auto-strict contexts (`with` inside a class body or at ES module top level, where the parser already knows the strict-mode context without the checker). That diagnostic lands in `parse_diagnostics`, which the checker-diagnostics gate never touches.

**Structural rule:** when a program has a real (structural) parse error anywhere, tsc drops TS1101 program-wide; tsz's parser-emitted TS1101 must go through the same `filtered_parse_diagnostics` suppression its siblings (`TS1028`, `TS1014`, …) already use via `is_parser_grammar_code` — the existing list built for exactly this shape (parser-emitted in tsz, checker/binder-emitted in tsc, suppressed by `hasParseDiagnostics`). Fix: add `1101` to `is_parser_grammar_code`.

I considered moving the emission into the checker instead (which already has a partial `is_with_statement_in_strict_mode_context` for the `alwaysStrict` case), but that path risks a position regression: `error_at_node` anchors on the full `WITH_STATEMENT` node span, not the keyword-only span tsc's `grammarErrorOnFirstToken` uses — the span the parser's existing `parse_error_at(start_pos, with_end - start_pos, ...)` already gets right, and that the checked-in `ts1101_with_in_strict_mode_tests.rs` fixture comment cites an exact corpus position for.

### Two follow-up fixes, both found by `compare-to-parent.sh`, not the targeted unit matrix

Adding `1101` to `is_parser_grammar_code` alone regressed `plainJSBinderErrors.ts` (a JS file exercising many binder strict-mode checks at once with **no** structural parse error — tsc reports `TS1101` alongside `TS1102/1107/1210/1214/1215/1262/1344/1359/2528/18012`, all together). `filtered_parse_diagnostics`'s `has_non_grammar_parse_error` heuristic treats any parser-emitted code not in a small exemption tuple as a "real" trigger that suppresses sibling grammar codes in the same file — `TS1359` (parser-emitted, itself a strict-mode grammar check) was missing from that tuple even though siblings `1214`/`1262` were already there.

I first tried replacing the whole ad-hoc tuple with the already-computed `is_real_syntax_error` (cleaner, and provably disjoint from `is_parser_grammar_code`) — but that traded one gap for another: `TS1260` (keyword containing an escape character) is neither a structural failure nor a listed grammar code, yet per the pinned oracle it **does** trigger tsc's file-wide suppression (`switchStatementsWithMultipleDefaults.ts` reports only `TS1260`, dropping every `TS1113` duplicate-default diagnostic). So "not exempted" has to stay the conservative default; `is_real_syntax_error` is not a safe substitute for the hand-curated tuple. Reverted to the tuple and added the two entries actually missing: `1359` and `18012` (`'#constructor' is a reserved word`, the other parser-emitted grammar check `plainJSBinderErrors.ts` needed).

## Goal
Goal: hold

## Verification
Verified against the pinned `tsc` 6.0.2 oracle throughout (not just inferred from #16238's list):
- `with` in a module alone → tsc reports `TS1101` + `TS2410`.
- same + an unrelated **non-real** parse error (`TS1014`) → `TS1101` still reports. Negative control.
- same + a genuine structural parse error (`function f( {}` → `TS1005`) anywhere in the file → tsc drops **everything** but the `TS1005`.
- `plainJSBinderErrors.ts` (11 codes incl. `TS1101`, no structural error) and `switchStatementsWithMultipleDefaults.ts` (`TS1260` only, dropping all `TS1113`) — both now match `dist-fast` byte-for-byte.

- `cargo test -p tsz-cli --lib -- filtered_parse_diagnostics` — 8/8 passed (new: suppression + two keep-alone/keep-with-non-real-error controls for TS1101).
- `cargo test -p tsz-cli --lib -- driver::core::tests::tests_diagnostics` — 27/27 passed, 0 regressions.
- `cargo test -p tsz-checker --lib -- ts1101` — 3/3 passed, 0 regressions (class-body, renamed-binder, module-top-level).
- `cargo fmt -p tsz-cli -- --check` — clean. `cargo clippy -p tsz-cli --all-targets -- -D warnings` — clean. Pre-commit hook (workspace clippy + arch-size) — passed on every commit.
- `scripts/conformance/compare-to-parent.sh 1d30029` (two-sided, against this branch's parent, final head `1d01587`): **base failing=574, branch failing=574, 0 newly passing, 0 newly failing, 0 fingerprint changes.**

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: Dolomite
