### PR TITLE
fix(checker): a nameless JSDoc @typedef declares the type its host names

### DIFF
--- a/crates/tsz-checker/src/jsdoc/diagnostics_typedef_name.rs
+++ b/crates/tsz-checker/src/jsdoc/diagnostics_typedef_name.rs
@@ -3,19 +3,16 @@
 use crate::state::CheckerState;
 
 impl<'a> CheckerState<'a> {
-    /// TS1003: `@typedef {Type}` with no name after the type expression.
-    /// TypeScript's JSDoc parser requires a typedef name to follow the braced
-    /// type; when the tag ends (comment end or the next `@tag`) with no name it
-    /// reports "Identifier expected." at the closing brace of the type
-    /// expression. Runs once per JS source file over every JSDoc comment.
+    /// Offsets, relative to the start of `comment_text`, of the closing `}` of
+    /// every `@typedef {Type}` tag in that JSDoc comment that carries **no name**
+    /// after its braced type expression.
     ///
-    /// Only the nameless form is handled here. Malformed *names* (deprecated
-    /// `.<T>` generics, `~` inner namepaths, `module:` import types) are a
-    /// distinct type-expression parse concern and are left to their owners.
-    pub(crate) fn check_jsdoc_typedef_missing_name(&mut self) {
-        use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-        use tsz_common::comments::is_jsdoc_comment;
-
+    /// The nameless form is one tsc fact with two consequences, so it has one
+    /// scanner: the tag is a grammar error (TS1003, `check_jsdoc_typedef_missing_name`)
+    /// *and* it still declares a type alias named after the declaration the
+    /// comment annotates (`jsdoc_nameless_typedef_host_name`). Keeping the
+    /// detection in one place is what stops those two consumers from drifting.
+    pub(crate) fn jsdoc_nameless_typedef_close_offsets(comment_text: &str) -> Vec<usize> {
         fn balanced_close(s: &str) -> Option<usize> {
             let mut depth: i32 = 1;
             for (i, ch) in s.char_indices() {
@@ -47,6 +44,41 @@ impl<'a> CheckerState<'a> {
             false
         }
 
+        let mut offsets = Vec::new();
+        for tag_off in Self::jsdoc_tag_offsets(comment_text, "typedef") {
+            let after_tag = tag_off + "@typedef".len();
+            let rest = &comment_text[after_tag..];
+            let trimmed = rest.trim_start();
+            if !trimmed.starts_with('{') {
+                continue;
+            }
+            let leading = rest.len() - trimmed.len();
+            let brace_off = after_tag + leading;
+            let Some(close_rel) = balanced_close(&comment_text[brace_off + 1..]) else {
+                continue;
+            };
+            let close_off = brace_off + 1 + close_rel;
+            if name_follows(&comment_text[close_off + 1..]) {
+                continue;
+            }
+            offsets.push(close_off);
+        }
+        offsets
+    }
+
+    /// TS1003: `@typedef {Type}` with no name after the type expression.
+    /// TypeScript's JSDoc parser requires a typedef name to follow the braced
+    /// type; when the tag ends (comment end or the next `@tag`) with no name it
+    /// reports "Identifier expected." at the closing brace of the type
+    /// expression. Runs once per JS source file over every JSDoc comment.
+    ///
+    /// Only the nameless form is handled here. Malformed *names* (deprecated
+    /// `.<T>` generics, `~` inner namepaths, `module:` import types) are a
+    /// distinct type-expression parse concern and are left to their owners.
+    pub(crate) fn check_jsdoc_typedef_missing_name(&mut self) {
+        use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+        use tsz_common::comments::is_jsdoc_comment;
+
         if !self.is_js_file() {
             return;
         }
@@ -62,22 +94,7 @@ impl<'a> CheckerState<'a> {
             }
             let text = comment.get_text(source_text);
             let base = comment.pos;
-            for tag_off in Self::jsdoc_tag_offsets(text, "typedef") {
-                let after_tag = tag_off + "@typedef".len();
-                let rest = &text[after_tag..];
-                let trimmed = rest.trim_start();
-                if !trimmed.starts_with('{') {
-                    continue;
-                }
-                let leading = rest.len() - trimmed.len();
-                let brace_off = after_tag + leading;
-                let Some(close_rel) = balanced_close(&text[brace_off + 1..]) else {
-                    continue;
-                };
-                let close_off = brace_off + 1 + close_rel;
-                if name_follows(&text[close_off + 1..]) {
-                    continue;
-                }
+            for close_off in Self::jsdoc_nameless_typedef_close_offsets(text) {
                 anchors.push(base + close_off as u32);
             }
         }

--- a/crates/tsz-checker/src/jsdoc/lookup.rs
+++ b/crates/tsz-checker/src/jsdoc/lookup.rs
@@ -228,6 +228,99 @@ impl<'a> CheckerState<'a> {
         result
     }
 
+    /// The qualified name a *nameless* JSDoc `@typedef {T}` tag declares, read
+    /// from the declaration the comment annotates.
+    ///
+    /// A `@typedef` tag with no name after its braced type is a grammar error
+    /// (TS1003) but still declares a type alias: tsc names it after the host
+    /// declaration, so `/** @typedef {string} */ a.b.C;` declares the type
+    /// `a.b.C` and thereby makes `a` a legitimate type-space namespace root.
+    /// Returns the dotted identifier chain written immediately after the
+    /// comment, or `None` when the comment is not followed by one.
+    fn jsdoc_nameless_typedef_host_name(source_text: &str, comment_end: u32) -> Option<String> {
+        let after = source_text.get(comment_end as usize..)?;
+        let after = after.trim_start_matches([' ', '\t', '\r', '\n']);
+        let mut end = 0usize;
+        let mut expect_segment_start = true;
+        for (offset, ch) in after.char_indices() {
+            if expect_segment_start {
+                if ch == '_' || ch == '$' || ch.is_ascii_alphabetic() {
+                    expect_segment_start = false;
+                    end = offset + ch.len_utf8();
+                    continue;
+                }
+                break;
+            }
+            if ch == '_' || ch == '$' || ch.is_ascii_alphanumeric() {
+                end = offset + ch.len_utf8();
+                continue;
+            }
+            if ch == '.' {
+                expect_segment_start = true;
+                continue;
+            }
+            break;
+        }
+        // A bare (undotted) host name declares a plain type alias, not a
+        // namespace; only qualified hosts are of interest to callers asking
+        // about namespace roots, but returning both keeps the query honest and
+        // lets each caller apply its own shape rule.
+        (end > 0).then(|| after[..end].to_string())
+    }
+
+    /// Whether `source_file` declares the qualified type `name` through a
+    /// nameless JSDoc `@typedef` attached to a matching host declaration.
+    ///
+    /// The named form (`@typedef {string} a.b.C`) is already covered by
+    /// `source_file_has_jsdoc_typedef_named`; this is its nameless sibling.
+    pub(crate) fn source_file_has_jsdoc_nameless_typedef_named(
+        source_file: &SourceFileData,
+        name: &str,
+    ) -> bool {
+        use tsz_common::comments::{get_jsdoc_content, is_jsdoc_comment};
+
+        if name.is_empty() || source_file.comments.is_empty() {
+            return false;
+        }
+        let text = &source_file.text;
+        if !text.contains("@typedef") || !text.contains(name) {
+            return false;
+        }
+
+        source_file.comments.iter().any(|comment| {
+            if !is_jsdoc_comment(comment, text) {
+                return false;
+            }
+            let content = get_jsdoc_content(comment, text);
+            if Self::jsdoc_nameless_typedef_close_offsets(&content).is_empty() {
+                return false;
+            }
+            Self::jsdoc_nameless_typedef_host_name(text, comment.end)
+                .is_some_and(|host| host == name)
+        })
+    }
+
+    /// Whether a nameless JSDoc `@typedef` declaring the qualified type `name`
+    /// is visible from the current file's resolution context. Mirrors
+    /// `jsdoc_typedef_named_visible`'s file sweep so the nameless and named
+    /// forms are reachable from the same places.
+    pub(crate) fn jsdoc_nameless_typedef_named_visible(&self, name: &str) -> bool {
+        if let Some(arenas) = self.ctx.all_arenas.as_ref() {
+            for arena in arenas.iter() {
+                for sf in arena.source_files.iter() {
+                    if Self::source_file_has_jsdoc_nameless_typedef_named(sf, name) {
+                        return true;
+                    }
+                }
+            }
+        }
+        self.ctx
+            .arena
+            .source_files
+            .iter()
+            .any(|sf| Self::source_file_has_jsdoc_nameless_typedef_named(sf, name))
+    }
+
     pub(crate) fn source_file_has_jsdoc_typedef_namespace_root(
         source_file: &SourceFileData,
         name: &str,
@@ -909,6 +1002,13 @@ impl<'a> CheckerState<'a> {
         // plain value; tsc resolves it with no error. Only a value-space expando
         // member (`A.B = class {}`) is the "used as a namespace" case.
         if self.resolve_global_jsdoc_typedef_info(trimmed).is_some() {
+            return false;
+        }
+        // Same fact, nameless spelling. `/** @typedef {string} */ A.B.C;` (or
+        // `A.B.C = {...}`) declares the type `A.B.C` named after its host
+        // declaration; the tag's missing name is a separate grammar error
+        // (TS1003), not a reason to deny `A` its type-space namespace meaning.
+        if self.jsdoc_nameless_typedef_named_visible(trimmed) {
             return false;
         }
 

--- a/crates/tsz-cli/Cargo.toml
+++ b/crates/tsz-cli/Cargo.toml
@@ -220,6 +220,10 @@ name = "qualified_type_namespace_shadow_tests"
 path = "tests/qualified_type_namespace_shadow_tests.rs"
 
 [[test]]
+name = "jsdoc_nameless_typedef_namespace_root_tests"
+path = "tests/jsdoc_nameless_typedef_namespace_root_tests.rs"
+
+[[test]]
 name = "imported_infer_readonly_alias_cli_tests"
 path = "tests/imported_infer_readonly_alias_cli_tests.rs"
 

--- a/crates/tsz-cli/tests/jsdoc_nameless_typedef_namespace_root_tests.rs
+++ b/crates/tsz-cli/tests/jsdoc_nameless_typedef_namespace_root_tests.rs
@@ -1,0 +1,254 @@
+//! A nameless JSDoc `@typedef` still declares a type named after its host.
+//!
+//! `/** @typedef {string} */ A.B.C;` (or `A.B.C = { ... }`) carries no name in
+//! the tag itself. That is a grammar error — tsc reports `TS1003` at the type
+//! expression's closing brace, and tsz matches it. But tsc *also* declares the
+//! type alias, naming it after the declaration the comment annotates, so `A.B.C`
+//! is a real type-space name and `A` is a legitimate namespace qualifier.
+//!
+//! tsz recognised only the *named* dotted form (`@typedef {string} A.B.C`) and
+//! so reported a spurious `TS2503` ("Cannot find namespace 'A'") for the
+//! nameless spelling, on top of the correct `TS1003`.
+//!
+//! The negative controls matter as much as the positives here: the exemption is
+//! for a host declaration that actually matches the referenced qualified name.
+//! A plain value expando with no typedef anywhere must still report `TS2503`.
+//!
+//! Binder and file names are varied across cases so the behaviour follows
+//! structure, not identifier text.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn find_tsz_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_tsz") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    let current_exe = std::env::current_exe().ok()?;
+    let debug_dir = current_exe.parent()?.parent()?;
+    let candidate = debug_dir.join("tsz");
+    candidate.exists().then_some(candidate)
+}
+
+/// Run `tsz -p tsconfig.json` over `files`, returning combined stdout+stderr.
+/// `allowJs`/`checkJs` are on because every case here is a `.js` JSDoc shape.
+fn run_tsz(files: &[(&str, &str)]) -> String {
+    let Some(tsz_bin) = find_tsz_binary() else {
+        return String::from("__SKIP__");
+    };
+    let dir = tempfile::tempdir().expect("temp dir");
+    for (name, contents) in files {
+        let path = dir.path().join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent dir");
+        }
+        std::fs::write(path, contents).expect("write file");
+    }
+    std::fs::write(
+        dir.path().join("tsconfig.json"),
+        r#"{ "compilerOptions": { "noEmit": true, "allowJs": true, "checkJs": true, "target": "es2015", "skipLibCheck": true } }"#,
+    )
+    .expect("write tsconfig.json");
+
+    let output = Command::new(tsz_bin)
+        .args(["-p", "tsconfig.json", "--pretty", "false"])
+        .current_dir(dir.path())
+        .output()
+        .expect("run tsz");
+
+    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    combined
+}
+
+/// The nameless tag itself is still a grammar error in tsc, so every positive
+/// case here asserts `TS1003` is *kept* while `TS2503` disappears. Asserting
+/// only the absence of `TS2503` would pass just as well if the whole JSDoc
+/// comment stopped being scanned.
+fn assert_ts1003_without_ts2503(out: &str, case: &str) {
+    if out == "__SKIP__" {
+        return;
+    }
+    assert!(
+        !out.contains("TS2503"),
+        "{case}: a nameless @typedef names its host declaration, so its root \
+         keeps namespace meaning (no TS2503), got:\n{out}"
+    );
+    assert!(
+        out.contains("TS1003"),
+        "{case}: the nameless tag is still a grammar error and TS1003 must \
+         survive the fix, got:\n{out}"
+    );
+}
+
+#[test]
+fn nameless_typedef_on_qualified_expression_statement_host_declares_its_name() {
+    let out = run_tsz(&[(
+        "alpha.js",
+        r#"
+var Zeta = {};
+Zeta.Inner = {};
+/**
+ * @typedef {string}
+ */
+Zeta.Inner.Alpha;
+/** @type {Zeta.Inner.Alpha} */
+var probe = "s";
+"#,
+    )]);
+    assert_ts1003_without_ts2503(&out, "expression-statement host");
+}
+
+#[test]
+fn nameless_typedef_on_qualified_assignment_host_declares_its_name() {
+    let out = run_tsz(&[(
+        "beta.js",
+        r#"
+var Qq = {};
+/**
+ * @typedef {number}
+ */
+Qq.Beta = { z: 1 };
+/** @type {Qq.Beta} */
+var probe = 1;
+"#,
+    )]);
+    assert_ts1003_without_ts2503(&out, "assignment host");
+}
+
+#[test]
+fn nameless_typedef_host_is_visible_across_files() {
+    // The declaring file and the referencing file are different, which is the
+    // shape the `jsEnumCrossFileExport` corpus row exercises.
+    let out = run_tsz(&[
+        (
+            "decl.js",
+            r#"
+var Vendor = {};
+Vendor.Metrics = {};
+/**
+ * @typedef {string}
+ */
+Vendor.Metrics.Label = { x: 12 };
+"#,
+        ),
+        (
+            "use.js",
+            r#"
+/**
+ * @type {Vendor.Metrics.Label}
+ */
+var probe = "ok";
+"#,
+        ),
+    ]);
+    assert_ts1003_without_ts2503(&out, "cross-file host");
+}
+
+#[test]
+fn named_dotted_typedef_still_exempts_its_root() {
+    // Pre-existing exemption for the *named* spelling; the nameless sibling
+    // must not have displaced it. No TS1003 here — this tag has a name.
+    let out = run_tsz(&[(
+        "gamma.js",
+        r#"
+var Wide = {};
+/**
+ * @typedef {string} Wide.Named
+ */
+/** @type {Wide.Named} */
+var probe = "s";
+"#,
+    )]);
+    if out == "__SKIP__" {
+        return;
+    }
+    assert!(
+        !out.contains("TS2503") && !out.contains("TS1003"),
+        "a named dotted @typedef declares its own name and is well-formed, \
+         got:\n{out}"
+    );
+}
+
+#[test]
+fn plain_value_expando_without_any_typedef_still_reports_ts2503() {
+    // The load-bearing negative control. `Root` grows a value-space expando
+    // member and nothing declares a type, so tsc reports TS2503 and tsz must
+    // keep doing so. If this ever goes quiet the exemption has become a blanket
+    // suppression.
+    let out = run_tsz(&[(
+        "delta.js",
+        r#"
+var Root = {};
+Root.Member = class {};
+/** @type {Root.Member} */
+var probe = null;
+"#,
+    )]);
+    if out == "__SKIP__" {
+        return;
+    }
+    assert!(
+        out.contains("TS2503"),
+        "a value-only expando root is not a namespace and must still report \
+         TS2503, got:\n{out}"
+    );
+}
+
+#[test]
+fn nameless_typedef_declaring_a_different_name_does_not_exempt_an_unrelated_member() {
+    // The exemption is keyed to the qualified name actually declared, not to
+    // the mere presence of a nameless typedef somewhere in the file.
+    let out = run_tsz(&[(
+        "epsilon.js",
+        r#"
+var Root = {};
+Root.Other = {};
+/**
+ * @typedef {string}
+ */
+Root.Other.Declared;
+Root.Undeclared = class {};
+/** @type {Root.Undeclared} */
+var probe = null;
+"#,
+    )]);
+    if out == "__SKIP__" {
+        return;
+    }
+    assert!(
+        out.contains("TS2503"),
+        "a nameless typedef declaring `Root.Other.Declared` says nothing about \
+         `Root.Undeclared`, got:\n{out}"
+    );
+}
+
+#[test]
+fn nameless_typedef_with_a_bare_host_does_not_manufacture_a_namespace() {
+    // An undotted host (`Solo;`) declares a plain type alias, not a namespace
+    // member, so it must not exempt an unrelated qualified reference.
+    let out = run_tsz(&[(
+        "zeta.js",
+        r#"
+var Root = {};
+/**
+ * @typedef {string}
+ */
+Solo;
+Root.Member = class {};
+/** @type {Root.Member} */
+var probe = null;
+"#,
+    )]);
+    if out == "__SKIP__" {
+        return;
+    }
+    assert!(
+        out.contains("TS2503"),
+        "a bare nameless-typedef host is not a namespace root, got:\n{out}"
+    );
+}


### PR DESCRIPTION
## Goal

Goal: hold

Closes the **TS2503 pure-extra pair** on the `m`/`x` false-positive queue — the two corpus rows whose only delta from `tsc` is one extra tsz diagnostic:

```
TypeScript/tests/cases/compiler/jsEnumCrossFileExport.ts                    {"m":[],"x":["TS2503"]}
TypeScript/tests/cases/conformance/jsdoc/checkJsdocTypedefOnlySourceFile.ts {"m":[],"x":["TS2503"]}
```

### Structural rule

**When a JSDoc `@typedef {T}` tag carries no name, `tsc` names the declared type alias after the declaration the comment annotates; the host's dotted name is therefore a real type-space name and its root keeps namespace meaning. tsz does the same through the JSDoc typedef-name query in the checker's JSDoc subsystem (`jsdoc/lookup.rs`), the same layer that already owns the named spelling's exemption.**

The nameless tag is *also* a grammar error — `tsc` reports `TS1003` at the type expression's closing brace, and tsz already matched that. Those are two consequences of one fact, and tsz had only implemented one of them: `report_jsdoc_value_root_used_as_namespace` exempted the **named** dotted form (`@typedef {string} A.B.C`, via `resolve_global_jsdoc_typedef_info`) but not its nameless sibling, so the nameless spelling drew a spurious `TS2503 Cannot find namespace 'A'` *on top of* the correct `TS1003`.

### Owner layer

`crates/tsz-checker/src/jsdoc/` only. No solver, emitter, or relation change; nothing reads printer output; no fixture, identifier, or file-name string drives any decision. The exemption is keyed to the qualified name the host declaration actually spells.

The nameless-tag scan previously lived inline inside the `TS1003` diagnostic. It is now a single shared helper (`jsdoc_nameless_typedef_close_offsets`) consumed by both the grammar diagnostic and the new host-name query — this is the same "two implementations of one tsc fact, one incomplete" shape the board has flagged three times recently (#16188, #16238, #16239), so the second consumer was added by sharing the first's scanner rather than writing a parallel one.

## Verification

All numbers below were measured in this container against the pinned `tsc@7.0.2` oracle (`scripts/node_modules/typescript/lib/tsc.js`), release build at `9b9e6a2`→`0895c09`.

**The two corpus rows, tsz vs. oracle:**

| fixture | tsc 7.0.2 | tsz before | tsz after |
| --- | --- | --- | --- |
| `jsEnumCrossFileExport` | `TS1003` | `TS1003`, **`TS2503`** | `TS1003` — **byte-identical to the oracle** |
| `checkJsdocTypedefOnlySourceFile` | `TS1003` | `TS1003`, **`TS2503`**, `TS2339` | `TS1003`, `TS2339` |

`checkJsdocTypedefOnlySourceFile` keeps a separate `TS2339` delta in my repro configuration (`Property 'SomeName' does not exist on type 'typeof exports'` on the host statement itself). It is a different false positive — the value-space expando-member lookup, not namespace resolution — it is present before and after this change, and it is out of scope here. Flagging it rather than folding it in.

Note the checked-in `checkJsdocTypedefOnlySourceFile.errors.txt` baseline expects `TS2694`; that baseline predates TypeScript 7. The pinned 7.0.2 oracle emits only `TS1003`, which is what the conformance harness compares against and what the `m`/`x` table reflects.

**Adjacent-case matrix** (`--allowJs --checkJs --target es2015`, renamed binders throughout, oracle on the left):

| case | shape | tsc | tsz after |
| --- | --- | --- | --- |
| P1 | nameless typedef, expression-statement host (`Zeta.Inner.Alpha;`) | `TS1003` | `TS1003` ✅ |
| P2 | nameless typedef, assignment host (`Qq.Beta = { z: 1 }`) | `TS1003` | `TS1003` ✅ |
| P3 | cross-file: declared in `decl.js`, referenced in `use.js` | `TS1003` | `TS1003` ✅ |
| P4 | **named** dotted typedef (pre-existing exemption) | *clean* | *clean* ✅ |
| **N1** | **value expando, no typedef anywhere** | `TS2503` | **`TS2503`** ✅ |
| N2 | nameless typedef declares a *different* dotted name | `TS1003` | `TS1003`, `TS2503` |
| N3 | nameless typedef with a **bare** (undotted) host | `TS1003` | `TS1003`, `TS2503` |

**N1 is the load-bearing control**: a plain value expando root is still not a namespace and still reports `TS2503`. This is not a blanket suppression.

N2/N3 are *pre-existing* divergences, unchanged by this diff in either direction — they suggest `tsc`'s real rule is broader (once a root has any type-space member, an unknown member stops being `TS2503`). I deliberately kept the exemption keyed to the exact qualified name declared, because that is what the two corpus rows evidence and widening to root-prefix matching has real regression exposure on rows that pass today. Both are pinned as negative tests so the wider behaviour cannot arrive by accident, and both are written up on the coordination board as measured, scoped, unclaimed follow-ups.

**Suites run:**

- `cargo test --release -p tsz-cli --test jsdoc_nameless_typedef_namespace_root_tests` — **7 passed / 0 failed** (new suite: 4 positive, 3 negative controls). Each positive asserts `TS1003` is *kept* as well as `TS2503` gone, so the tests cannot pass by the JSDoc comment simply stopping being scanned.
- `cargo fmt` + `cargo clippy` (`-p tsz-checker -p tsz-cli`, warnings denied) via the pre-commit hook — **Clippy passed. Architecture guard passed.**
- `scripts/conformance/compare-to-parent.sh` — two-sided against this PR's own parent, **started in-container at push time**; I will post its counts as a PR comment when it finishes. Not claiming a result I do not have.
- Emit / fourslash — **not run**. This change adds no output and touches no lowering or emit path; that is scope, not measurement, and it is stated here rather than left implied.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Tremolite

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWJmFZiuyTv16hC7TJzQJ8)_