### PR TITLE
test(checker): adjacent-case coverage for the bare @param JS-optional-arity rule

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -441,6 +441,8 @@ mod issue_9762_literal_init_callback_inference;
 mod iterable_next_relation_routing_arch_tests;
 #[path = "tests/js_expando_order_sensitivity_tests.rs"]
 mod js_expando_order_sensitivity_tests;
+#[path = "tests/js_file_function_parameters_as_optional_tests.rs"]
+mod js_file_function_parameters_as_optional_tests;
 #[path = "tests/js_open_object_property_access_tests.rs"]
 mod js_open_object_property_access_tests;
 #[path = "tests/jsdoc_bare_import_type_tests.rs"]

--- a/crates/tsz-checker/src/tests/js_file_function_parameters_as_optional_tests.rs
+++ b/crates/tsz-checker/src/tests/js_file_function_parameters_as_optional_tests.rs
@@ -1,0 +1,117 @@
+//! TS2554 for calls to a JS-declared function documented only with bare
+//! `@param name` tags (no `{type}`, no `[bracket]`).
+//!
+//! A name-only `@param` tag carries no type, so it must not override the
+//! "untyped JS parameter is implicitly optional" leniency: tsc treats it the
+//! same as no tag at all for arity purposes (`jsFileFunctionParametersAsOptional2.ts`,
+//! verified against the pinned `typescript@7.0.2` oracle). Only a tag with an
+//! explicit `{type}` pins the parameter's type and makes it required.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_multi_file_with_libs_stamped, check_source, load_lib_files};
+
+const TOO_FEW_ARGUMENTS: u32 = 2554;
+
+fn js_codes(files: &[(&str, &str)], entry: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        allow_js: true,
+        ..CheckerOptions::default()
+    };
+    check_multi_file_with_libs_stamped(files, entry, options, &load_lib_files(&["es5.d.ts"]))
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+fn same_file_js_codes(source: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        allow_js: true,
+        ..CheckerOptions::default()
+    };
+    check_source(source, "same.js", options)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+// --- Cross-file: JS declares, a .ts file calls with fewer arguments. ---
+// Witnesses `jsFileFunctionParametersAsOptional2.ts`.
+
+const BARE_PARAM_DOC: &str =
+    "/**\n * @param a\n * @param b\n * @param c\n */\nfunction f(a, b, c) { }\n";
+
+#[test]
+fn cross_file_bare_param_tags_allow_fewer_call_arguments() {
+    let codes = js_codes(
+        &[("foo.js", BARE_PARAM_DOC), ("bar.ts", "f();\n")],
+        "bar.ts",
+    );
+    assert!(!codes.contains(&TOO_FEW_ARGUMENTS));
+}
+
+#[test]
+fn cross_file_bare_param_tags_allow_one_call_argument() {
+    let codes = js_codes(
+        &[("foo.js", BARE_PARAM_DOC), ("bar.ts", "f(1);\n")],
+        "bar.ts",
+    );
+    assert!(!codes.contains(&TOO_FEW_ARGUMENTS));
+}
+
+#[test]
+fn cross_file_bare_param_tags_still_allow_full_arity() {
+    let codes = js_codes(
+        &[("foo.js", BARE_PARAM_DOC), ("bar.ts", "f(1, 2, 3);\n")],
+        "bar.ts",
+    );
+    assert!(!codes.contains(&TOO_FEW_ARGUMENTS));
+}
+
+// --- Renamed binder: the fix must not be keyed on `f`/`a`/`b`/`c`. ---
+
+#[test]
+fn cross_file_bare_param_tags_allow_fewer_arguments_renamed() {
+    let doc = "/**\n * @param first\n * @param second\n */\nfunction greet(first, second) { }\n";
+    let codes = js_codes(
+        &[("declare.js", doc), ("call.ts", "greet(\"hi\");\n")],
+        "call.ts",
+    );
+    assert!(!codes.contains(&TOO_FEW_ARGUMENTS));
+}
+
+// --- Same-file: the leniency already worked for untyped params; bare
+// @param tags on the same function in the same file must not regress it.
+
+#[test]
+fn same_file_bare_param_tags_allow_fewer_call_arguments() {
+    let codes = same_file_js_codes(&format!("{BARE_PARAM_DOC}f();\nf(1);\nf(1, 2, 3);\n"));
+    assert!(!codes.contains(&TOO_FEW_ARGUMENTS));
+}
+
+// --- Negative: a genuinely typed `@param {Type} name` tag still pins the
+// parameter as required, in both same-file and cross-file forms.
+
+#[test]
+fn cross_file_typed_param_tag_still_required() {
+    let doc = "/**\n * @param {string} a\n * @param {string} b\n */\nfunction f(a, b) { }\n";
+    let codes = js_codes(&[("foo.js", doc), ("bar.ts", "f(\"x\");\n")], "bar.ts");
+    assert!(codes.contains(&TOO_FEW_ARGUMENTS));
+}
+
+#[test]
+fn same_file_typed_param_tag_still_required() {
+    let doc =
+        "/**\n * @param {string} a\n * @param {string} b\n */\nfunction f(a, b) { }\nf(\"x\");\n";
+    let codes = same_file_js_codes(doc);
+    assert!(codes.contains(&TOO_FEW_ARGUMENTS));
+}
+
+// --- Negative: a bracket-optional typed tag stays optional (unaffected by
+// this fix, guarding against a regression in the adjacent branch). ---
+
+#[test]
+fn cross_file_bracket_optional_typed_param_stays_optional() {
+    let doc = "/**\n * @param {string} a\n * @param {string} [b]\n */\nfunction f(a, b) { }\n";
+    let codes = js_codes(&[("foo.js", doc), ("bar.ts", "f(\"x\");\n")], "bar.ts");
+    assert!(!codes.contains(&TOO_FEW_ARGUMENTS));
+}


### PR DESCRIPTION
#16240 fixed `jsdoc_has_required_param_tag` (a name-only `@param` tag no longer makes a JS parameter required for arity purposes) with unit tests directly on the string predicate. This adds integration-level coverage that exercises the actual `TS2554` diagnostic through the checker/multi-file test harness, which #16240 didn't add:

- cross-file (JS declares, `.ts` calls) with 0/1/3 call arguments — the `jsFileFunctionParametersAsOptional2.ts` conformance-row shape
- a same-file variant — the same bug reproduced with no cross-file/cross-arena involvement at all, worth pinning down explicitly since an earlier hypothesis on the coordination board wrongly suspected cross-arena delegation
- a renamed-binder variant (`greet`/`first`/`second` instead of `f`/`a`/`b`/`c`)
- negative controls: a typed `@param {string}` tag still makes its parameter required (same-file and cross-file), and a bracket-optional typed tag (`@param {string} [b]`) still stays optional

No production code changes — this PR only adds `crates/tsz-checker/src/tests/js_file_function_parameters_as_optional_tests.rs` and its one-line registration in `test_module_registry.rs`. Originally written alongside a fix for this same bug that raced #16240 (landed first with an identical predicate change) and was closed as an exact duplicate; salvaging just the test coverage here since it exercises a layer #16240's unit tests don't.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib -- js_file_function_parameters_as_optional` — 8/8 passed against current `main` (with #16240 already applied).
- `cargo clippy -p tsz-checker --all-targets -- -D warnings` — clean.
- `cargo fmt -p tsz-checker -- --check` — clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01QAcYQdwCZfEMxtNhFoibob)_