### PR TITLE
fix(cli): source discovery feeds the untyped-module map so TS2665 fires under allowJs

### DIFF
--- a/crates/tsz-cli/src/driver/source_resolution_setup.rs
+++ b/crates/tsz-cli/src/driver/source_resolution_setup.rs
@@ -263,6 +263,40 @@ pub(super) fn prepare_source_resolution_setup(
                         _ => false,
                     };
 
+                // Record the untyped-JS resolution target for the checker's
+                // augmentation-site TS2665 check on the *source-discovery*
+                // producer, mirroring the `module_resolver.lookup` producer
+                // below. Every branch under `discovered` ends in `continue`, so
+                // without this the map stays empty for any specifier discovery
+                // already mapped and the augmentation site reports nothing.
+                //
+                // tsc's `resolveExternalModule` returns the resolved file's own
+                // symbol when that file is part of the program, and only falls
+                // through to the untyped-module arm when it is not. The program
+                // membership that matters here is the one tsc computes, not the
+                // one tsz's discovery pass happens to produce: tsz records a
+                // program index for a `node_modules` JS file that tsc leaves out
+                // at the default `maxNodeModuleJsDepth` of 0. So the gate is the
+                // driver's existing model of that same tsc rule rather than the
+                // presence of a discovered target — which keeps a *local* JS
+                // file (a genuine program input, and a non-module entity that
+                // tsc diagnoses as TS2671) out of this arm.
+                if let Some(discovered) = discovered
+                    && super::super::sources::should_skip_js_in_node_modules(
+                        &discovered.canonical_path,
+                        options.max_node_module_js_depth,
+                    )
+                {
+                    untyped_module_paths.insert(
+                        (file_idx, specifier.clone()),
+                        tsz_common::module_resolution::path_identity::normalize_segments(
+                            &discovered.canonical_path,
+                        )
+                        .to_string_lossy()
+                        .into_owned(),
+                    );
+                }
+
                 if exact_name_ambient_match && !discovered_target_declares_ambient {
                     resolved_module_specifiers.insert((file_idx, specifier.clone()));
                     continue;

--- a/crates/tsz-cli/src/driver/sources.rs
+++ b/crates/tsz-cli/src/driver/sources.rs
@@ -28,7 +28,7 @@ fn has_source_file_extension(path: &Path) -> bool {
 /// Check if a JS file should be skipped due to `maxNodeModuleJsDepth`.
 /// Returns true if the file is a `.js` file inside `node_modules` and its
 /// nesting depth exceeds the allowed maximum.
-fn should_skip_js_in_node_modules(path: &Path, max_depth: u32) -> bool {
+pub(super) fn should_skip_js_in_node_modules(path: &Path, max_depth: u32) -> bool {
     if !is_js_file(path) {
         return false;
     }

--- a/crates/tsz-cli/tests/tsc_compat_tests_parts/part_02.rs
+++ b/crates/tsz-cli/tests/tsc_compat_tests_parts/part_02.rs
@@ -1482,3 +1482,150 @@ fn ambient_module_declaration_in_script_file_is_not_an_augmentation() {
         "script-file ambient declaration is not an augmentation, got:\n{output}"
     );
 }
+
+/// Same project shape as `write_untyped_package_project`, but with `allowJs`
+/// on. `allowJs` is what makes source discovery map the specifier to the
+/// package's JS file before `module_resolver.lookup` ever runs, which is the
+/// producer this family exercises.
+fn write_untyped_package_project_allow_js(root: &std::path::Path, pkg: &str, source: &str) {
+    write_file(
+        &root.join(format!("node_modules/{pkg}/index.js")),
+        "module.exports = {};\n",
+    );
+    write_file(
+        &root.join(format!("node_modules/{pkg}/package.json")),
+        &format!("{{ \"name\": \"{pkg}\", \"version\": \"1.0.0\", \"main\": \"index.js\" }}\n"),
+    );
+    write_file(&root.join("a.ts"), source);
+    write_file(
+        &root.join("tsconfig.json"),
+        "{ \"compilerOptions\": { \"module\": \"commonjs\", \"strict\": false, \"allowJs\": true, \"types\": [] }, \"files\": [\"a.ts\"] }\n",
+    );
+}
+
+#[test]
+fn augmenting_untyped_package_under_allow_js_reports_ts2665() {
+    // `allowJs` plus a real import of the same specifier: source discovery
+    // resolves the package to its JS entry point and records a program index
+    // for it, so the driver's discovery branch `continue`s before
+    // `module_resolver.lookup` runs. Before the discovery producer populated
+    // `untyped_module_paths`, this reported nothing at all.
+    //
+    // Renamed binder relative to the sibling cases above — the rule keys on the
+    // resolution extension and `maxNodeModuleJsDepth`, never on the name.
+    let temp = TempDir::new("augment_untyped_allow_js_ts2665").expect("temp dir");
+    write_untyped_package_project_allow_js(
+        &temp.path,
+        "cogwheel",
+        "declare module \"cogwheel\" { export const c: number; }\nimport { c } from \"cogwheel\";\nc;\n",
+    );
+
+    let Some((code, output)) = run_tsz_with_exit_code(
+        &temp.path,
+        &["-p", ".", "--noEmit", "--pretty", "false"],
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert_ne!(
+        code, 0,
+        "augmenting an untyped module under allowJs should fail:\n{output}"
+    );
+    assert!(
+        output.contains("error TS2665: Invalid module name in augmentation. Module 'cogwheel' resolves to an untyped module at "),
+        "expected TS2665 on the allowJs discovery path, got:\n{output}"
+    );
+    assert!(
+        output.contains("node_modules/cogwheel/index.js', which cannot be augmented."),
+        "TS2665 must name the discovered JS file, got:\n{output}"
+    );
+    // `allowJs` means the import site is legal JS interop, so no TS7016 — the
+    // augmentation diagnostic is independent of it.
+    assert!(
+        !output.contains("error TS7016"),
+        "allowJs suppresses the import-site TS7016, got:\n{output}"
+    );
+}
+
+#[test]
+fn augmenting_untyped_subpath_under_allow_js_reports_ts2665() {
+    // Discovery path again, but the discovered file is a nested subpath rather
+    // than the package entry point, under a third binder name. The message must
+    // carry the subpath's own resolved file.
+    let temp = TempDir::new("augment_untyped_subpath_allow_js").expect("temp dir");
+    write_file(
+        &temp.path.join("node_modules/toolkit/lib/inner.js"),
+        "module.exports = {};\n",
+    );
+    write_file(
+        &temp.path.join("node_modules/toolkit/package.json"),
+        "{ \"name\": \"toolkit\", \"version\": \"1.0.0\", \"main\": \"index.js\" }\n",
+    );
+    write_file(
+        &temp.path.join("a.ts"),
+        "declare module \"toolkit/lib/inner\" { export const y: string; }\nimport { y } from \"toolkit/lib/inner\";\ny;\n",
+    );
+    write_file(
+        &temp.path.join("tsconfig.json"),
+        "{ \"compilerOptions\": { \"module\": \"commonjs\", \"strict\": false, \"allowJs\": true, \"types\": [] }, \"files\": [\"a.ts\"] }\n",
+    );
+
+    let Some((code, output)) = run_tsz_with_exit_code(
+        &temp.path,
+        &["-p", ".", "--noEmit", "--pretty", "false"],
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert_ne!(
+        code, 0,
+        "augmenting an untyped subpath under allowJs should fail:\n{output}"
+    );
+    assert!(
+        output.contains("error TS2665: Invalid module name in augmentation. Module 'toolkit/lib/inner' resolves to an untyped module at "),
+        "expected TS2665 naming the subpath specifier, got:\n{output}"
+    );
+    assert!(
+        output.contains("node_modules/toolkit/lib/inner.js', which cannot be augmented."),
+        "TS2665 must name the discovered subpath file, got:\n{output}"
+    );
+}
+
+#[test]
+fn augmenting_local_relative_js_file_does_not_report_ts2665() {
+    // Negative control that separates "resolved to a JS file" from "resolved to
+    // an *untyped module*". A local `.js` listed in `files` is a genuine
+    // program input: tsc's `resolveExternalModule` returns that file's own
+    // symbol and never reaches the untyped-module arm, so the augmentation is
+    // diagnosed as TS2671 (non-module entity), not TS2665.
+    //
+    // Only `node_modules` JS beyond `maxNodeModuleJsDepth` (default 0) is
+    // outside the program for this purpose, which is exactly what the gate
+    // tests — a JS-extension check alone would turn this row into a false
+    // positive.
+    let temp = TempDir::new("augment_local_relative_js_no_ts2665").expect("temp dir");
+    write_file(&temp.path.join("local.js"), "module.exports = {};\n");
+    write_file(
+        &temp.path.join("a.ts"),
+        "declare module \"./local\" { export const r: number; }\nexport {};\n",
+    );
+    write_file(
+        &temp.path.join("tsconfig.json"),
+        "{ \"compilerOptions\": { \"module\": \"commonjs\", \"strict\": false, \"allowJs\": true, \"types\": [] }, \"files\": [\"a.ts\", \"local.js\"] }\n",
+    );
+
+    let Some((_code, output)) = run_tsz_with_exit_code(
+        &temp.path,
+        &["-p", ".", "--noEmit", "--pretty", "false"],
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        !output.contains("TS2665"),
+        "a local JS program input is not an untyped module, got:\n{output}"
+    );
+}


### PR DESCRIPTION
Closes the `allowJs` half of #16221's remaining slice, explicitly left open by #16227's author.

#16227 landed the `module_resolver.lookup` producer: `untyped_module_path` on `ModuleLookupResult`/`ModuleLookupOutcome`, the `untyped_module_paths` map in `source_resolution_setup.rs`, and the checker's TS2665 arm in `declarations_module.rs`. The consumer is complete and needs no change here. What was missing is the **second producer**.

## Structural rule

When source discovery has already mapped an augmentation target's specifier to a file, `tsc`'s `resolveExternalModule` still reports TS2665 if that file is an untyped JS module; tsz records the same resolution through the driver's **source-discovery** producer, so both producers feed the one `untyped_module_paths` consumer.

Every branch under `discovered` in `prepare_source_resolution_setup` ends in `continue` **before** `module_resolver.lookup` is reached, so for any specifier discovery had already resolved, no `ModuleLookupResult` ever existed to carry the path and the map stayed empty. `allowJs` is exactly what makes discovery pick up a `node_modules` JS entry point, which is why the gap presents as "`allowJs` on → silent".

### Why the gate is `maxNodeModuleJsDepth` and not "is it a `.js` file"

tsc's `resolveExternalModule` returns the resolved file's **own symbol** when that file is part of the program, and only falls through to the untyped-module arm when it is not. The program membership that matters is the one *tsc* computes: at the default `maxNodeModuleJsDepth` of 0, tsc leaves `node_modules` JS out of the program, while tsz's discovery pass does record a program index for it. Gating on the discovered target's presence would therefore never fire; gating on the JS extension alone would fire too often.

So the gate is the driver's existing model of that same tsc rule — `should_skip_js_in_node_modules` (`driver/sources.rs`), already used to implement `maxNodeModuleJsDepth` during discovery, promoted from `fn` to `pub(super) fn`. That keeps a **local** `.js` program input out of the arm, where tsc reports TS2671 (non-module entity) and not TS2665. A JS-extension check alone would have turned that row into a false positive; it is pinned as a negative test.

No new predicate was written for "is this an untyped module" — the resolver producer keys on `ModuleExtension::is_javascript()` and this producer keys on the driver's existing depth model, so the one tsc fact keeps one implementation per layer rather than gaining a third spelling.

## Goal
Goal: hold

## Verification

Full 11-row matrix, each project hand-built (`node_modules/[pkg]/index.js`, no declaration file), run against the pinned `typescript@7.0.2` oracle (`npm i typescript@7.0.2`, installed in-container) and against a `dev` build of this branch. Oracle first, tsz second:

| case | shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- | --- |
| A | strict, import, no `allowJs` | TS2665 + TS7016 | same | unchanged |
| B | `allowJs`, **no** import | TS2665 | TS2665 | unchanged |
| **B2** | **`allowJs` + import** | **TS2665** | **silent** | **TS2665, byte-identical** |
| C | augmentation in a `.d.ts` | TS2665 | silent | still silent — see below |
| C3 | same as C but in a `.ts` | TS2665 | TS2665 | unchanged |
| D | typed package (`index.d.ts`) | TS2664 | silent | unchanged |
| E | genuinely missing module | TS2664 | TS2664 | unchanged |
| F | relative local `.js` | TS2671 | silent | **still silent — negative control** |
| G | `.d.ts` + `allowJs` | TS2665 | silent | still silent — see below |
| H | script file (no import/export) | clean | clean | unchanged |

The only row that moves is B2, and it moves to parity. Every negative control — including F, the row a naive JS-extension gate would have broken — is untouched.

- `cargo test -p tsz-cli --test tsc_compat_tests -- augment` — **8/8 pass**, 3 new: `augmenting_untyped_package_under_allow_js_reports_ts2665` (renamed binder), `augmenting_untyped_subpath_under_allow_js_reports_ts2665` (third binder, nested subpath rather than package entry), `augmenting_local_relative_js_file_does_not_report_ts2665` (the F negative control).
- `cargo test -p tsz-cli --test tsc_compat_tests` (whole target) — **138 passed / 13 failed**, against a **measured** baseline of 135 passed / 13 failed with the diff stashed. Same 13 failures before and after: they are `tsc_parity_*` rows that shell out to a real `tsc`, which is not installed in this container. Environmental, pre-existing, unrelated.
- `cargo fmt -p tsz-cli`, workspace `clippy` and the architecture guard — all clean via the pre-commit hook.

**Not run, stated plainly:** conformance / `compare-to-parent.sh`, emit, and fourslash. Cold cloud seat with no `TypeScript/` submodule; a `dist-fast` build plus corpus checkout did not fit the session. Blast radius is narrow by construction — the map's only consumer is the TS2665 arm, itself gated on a `declare module` with a string-literal name in an external-module file — but the two corpus rows (`untypedModuleImport_withAugmentation{,2}.ts`) are **not** claimed as flipped by this diff and should be graded from a real corpus run.

## Known residual (measured, not fixed here, different mechanism)

Rows C and G — an augmentation written inside a **`.d.ts`** — are still silent, and they are *not* the discovery path. Traced with a temporary probe (reverted before commit): for a `.d.ts` host the specifier never enters `cached_module_specifiers` at all, so `prepare_source_resolution_setup`'s loop never sees it and no branch in this function is reached. That is a specifier-**collection** gap upstream of this producer, with a much wider blast radius (every ambient `declare module` name in every `.d.ts`, including all of `@types`, would start resolving), so it is deliberately out of scope rather than folded in. #16221 stays open for it.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Perlite