### PR TITLE
fix(checker): a JS whole-module module.exports = X is nameable from consumers

### DIFF
--- a/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs
+++ b/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs
@@ -764,6 +764,17 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
+        // A JS module's whole-module `module.exports = X` / `exports = X` gives
+        // `X` a type meaning the same way TS `export = X` does, but — unlike
+        // `export =` — it never seeds a binder `export=` symbol (that
+        // resolution is a checker-level, type-computed fact, not a binder
+        // fact), so the `is_exported_from_target` / `export=` namespace checks
+        // above never see it. `X` is still fully nameable from a consumer
+        // (`import X = require("./mod")`), so it must not trigger TS9006.
+        if self.is_commonjs_direct_export_target(file_idx, resolved_sym_id, target_sym_id) {
+            return None;
+        }
+
         let locally_nameable = self
             .ctx
             .binder
@@ -801,6 +812,40 @@ impl<'a> CheckerState<'a> {
 
         let module_specifier = self.module_specifier_for_file(file_idx)?;
         Some((referenced_name, module_specifier))
+    }
+
+    /// Whether `resolved_sym_id`/`target_sym_id` is the symbol behind the
+    /// target file's synthesized whole-module CommonJS export
+    /// (`JsExportSurface::direct_export_type`, from `module.exports = X` or
+    /// bare `exports = X`).
+    fn is_commonjs_direct_export_target(
+        &mut self,
+        file_idx: u32,
+        resolved_sym_id: SymbolId,
+        target_sym_id: SymbolId,
+    ) -> bool {
+        let Some(direct_export_type) = self
+            .resolve_js_export_surface(file_idx as usize)
+            .direct_export_type
+        else {
+            return false;
+        };
+        collect_referenced_types(self.ctx.types, direct_export_type)
+            .into_iter()
+            .filter_map(|type_id| {
+                lazy_def_id(self.ctx.types, type_id)
+                    .and_then(|def_id| self.ctx.def_to_symbol_id_with_fallback(def_id))
+                    .or_else(|| query::object_shape(self.ctx.types, type_id).and_then(|s| s.symbol))
+                    .or_else(|| {
+                        query::callable_shape(self.ctx.types, type_id).and_then(|s| s.symbol)
+                    })
+            })
+            .any(|candidate_sym_id| {
+                candidate_sym_id == resolved_sym_id
+                    || candidate_sym_id == target_sym_id
+                    || self.resolve_alias_symbol(candidate_sym_id, &mut AliasCycleTracker::new())
+                        == Some(resolved_sym_id)
+            })
     }
 
     /// Returns true if the current file contains a JSDoc `@type {typeof

--- a/crates/tsz-cli/tests/driver_tests_parts/part_14.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_14.rs
@@ -357,3 +357,114 @@ accept('kind', 'wrong')
         result.diagnostics
     );
 }
+
+/// A JS module's whole-module `module.exports = class X {}` gives `X` a type
+/// meaning the same way TS `export = X` does. Unlike `export =`, this never
+/// seeds a binder `export=` symbol — that resolution is a checker-level,
+/// type-computed fact (`JsExportSurface::direct_export_type`), not a binder
+/// fact — so a naive "is this symbol in the target's exports table" check
+/// misses it and TS9006 fires even though `X` is fully nameable from a
+/// consumer via `import X = require("./mod")`.
+fn ts9006_commonjs_direct_export_target_config() -> &'static str {
+    r#"{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "target": "es2015",
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "module": "commonjs"
+  },
+  "files": ["obj.js", "index.js"]
+}"#
+}
+
+#[test]
+fn commonjs_whole_module_class_export_is_nameable_from_a_requiring_consumer() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = temp.path.as_path();
+
+    write_file(&base.join("tsconfig.json"), ts9006_commonjs_direct_export_target_config());
+    write_file(
+        &base.join("obj.js"),
+        r#"module.exports = class Obj {
+    constructor() {
+        this.x = 12;
+    }
+}
+"#,
+    );
+    write_file(
+        &base.join("index.js"),
+        r#"const Obj = require("./obj");
+
+class Container {
+    constructor() {
+        this.usage = new Obj();
+    }
+}
+
+module.exports = Container;
+"#,
+    );
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+    let ts9006: Vec<_> = result.diagnostics.iter().filter(|d| d.code == 9006).collect();
+    assert!(
+        ts9006.is_empty(),
+        "module.exports = class Obj {{}} makes Obj nameable via `import Obj = require(...)`; \
+         no cross-file private-name diagnostic should fire, got: {:#?}",
+        result.diagnostics
+    );
+}
+
+/// Same shape with every binder renamed, to rule out a name-string match.
+#[test]
+fn commonjs_whole_module_class_export_is_nameable_renamed_binders() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = temp.path.as_path();
+
+    write_file(&base.join("tsconfig.json"), ts9006_commonjs_direct_export_target_config());
+    write_file(
+        &base.join("obj.js"),
+        r#"module.exports = class Widget {
+    constructor() {
+        this.label = "hi";
+    }
+}
+"#,
+    );
+    write_file(
+        &base.join("index.js"),
+        r#"const Widget = require("./obj");
+
+class Host {
+    constructor() {
+        this.child = new Widget();
+    }
+}
+
+module.exports = Host;
+"#,
+    );
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+    let ts9006: Vec<_> = result.diagnostics.iter().filter(|d| d.code == 9006).collect();
+    assert!(
+        ts9006.is_empty(),
+        "renamed-binder variant must also suppress TS9006, got: {:#?}",
+        result.diagnostics
+    );
+}
+
+// Negative control: `declaration_emit_raw_typeof_import_text_still_reports_ts9006`
+// (above) already covers the case this fix must not suppress — a private
+// symbol reached through a *call result* (`require("./some-mod")()`), not
+// through the target file's whole-module export identity itself. That test
+// continues to assert 2 live TS9006s, so it doubles as the regression guard
+// for this change: `is_commonjs_direct_export_target` only matches when the
+// referenced symbol IS (or aliases to) the target's own
+// `JsExportSurface::direct_export_type`, which a function call's return
+// value is not.


### PR DESCRIPTION
Found while investigating #16216 (which turned out to already be fixed by #16224+#16237 before I started — closed with evidence). Looking for a new item, I picked up the `TS9006` family from the `one_extra_zero_missing` conformance queue (2 self-contained rows, `conformance/jsdoc/declarations/`).

## Structural rule

When a JS file's whole-module `module.exports = X` (or bare `exports = X`) gives `X` a type meaning, tsc treats it exactly like TS `export = X` for declaration-emit nameability — `X` is reachable from any consumer via `import X = require("./mod")`, even though `X` itself is never explicitly exported by name. tsz's `private_external_module_nameability_info` (`crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs`) already special-cases the real TS `export=` binder symbol and its namespace surface, but the JS CommonJS equivalent has **no binder counterpart** — unlike `export=`, it is resolved lazily as a checker-level, type-computed fact (`JsExportSurface::direct_export_type`, populated by `resolve_js_export_surface`), so neither `is_exported_from_target` nor the `export=`-namespace check ever sees it, and `TS9006` fires on a symbol that is in fact fully nameable.

## Owner layer

`crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs` only — a new `is_commonjs_direct_export_target` alongside the existing `export=`/named-export checks in `private_external_module_nameability_info`. It walks the target file's `direct_export_type` (via the existing `collect_referenced_types` + `lazy_def_id`/`object_shape`/`callable_shape` pattern already used a few lines above for the *caller's* own type walk) and compares the resulting symbol(s) against the referenced private symbol, with the same alias-resolution fallback the neighboring `export=` check uses. No binder change, no solver change — this reuses an existing checker-owned type fact rather than teaching the binder a new JS-specific export shape.

## Evidence

Corpus fixture `TypeScript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsExportAssignedVisibility.ts` (obj.js: `module.exports = class Obj {}`; index.js: `const Obj = require("./obj"); ... module.exports = Container;` where `Container.usage: Obj`):

| | tsc 7.0.2 (pinned oracle, fetched fresh via `npm install typescript@7.0.2`) | tsz before | tsz after |
| --- | --- | --- | --- |
| diagnostics | 0 | `TS9006` on index.js | 0 |

The mainline `microsoft/TypeScript@main` checked-in `.errors.txt`/canary fetch is **not** authoritative for this repo (confirmed again on this PR, see the coordination-board NOTE from closing #16216) — verified against a freshly-installed pinned `typescript@7.0.2` binary directly, not the container's global `tsc` (6.0.2) and not the vendored submodule baseline.

A second fixture in the same family, `jsDeclarationsExportForms.ts`, has a **different**, larger remaining gap (`cjs.js`/`cjs2.js`: `module.exports = ns` where `ns = require(...)` — a require-aliased re-export, not a direct class/function target) that this fix does not cover; left as a follow-up, not folded in here to keep one structural rule per PR.

## Adjacent-case matrix (new tests, `crates/tsz-cli/tests/driver_tests_parts/part_14.rs`)

- `commonjs_whole_module_class_export_is_nameable_from_a_requiring_consumer` — the corpus shape directly.
- `commonjs_whole_module_class_export_is_nameable_renamed_binders` — same shape, every identifier renamed.
- Negative control: the pre-existing `declaration_emit_raw_typeof_import_text_still_reports_ts9006` test (unmodified) continues to assert 2 live `TS9006`s — that shape reaches a private symbol through a *function call's return type* (`require("./some-mod")()`), not through the target's own whole-module export identity, so `is_commonjs_direct_export_target` correctly does not match it. I looked for a second, fresh negative control but every shape I hand-built and checked against the oracle (a same-file private helper referenced by the export; a value obtained via a wrapping function call) turned out to be diagnostic-clean in real tsc too (structural widening, not `TS9006`) — so I'm relying on the existing test rather than asserting something I couldn't verify.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-cli --lib -- driver_tests::commonjs_whole_module_class_export driver_tests::declaration_emit_raw_typeof_import_text_still_reports_ts9006` — 3/3 pass.
- `cargo test -p tsz-cli --lib` (full suite) — 1618 passed / 18 failed, **identical pass/fail set and count** to unmodified `main` (verified directly: stashed this diff and reran the same 18 failing tests against `main`, all 18 fail identically — 14 are `tsc_parity_*` tests that shell out to a real `tsc` binary absent from this container, the other 4 are pre-existing and unrelated). Zero regressions.
- `cargo fmt -p tsz-checker -p tsz-cli -- --check` — clean.
- `cargo clippy -p tsz-checker -p tsz-cli --all-targets -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py` — `Architecture guardrails passed.`
- `scripts/conformance/compare-to-parent.sh origin/main` (branch `a7a6934` vs `47ba5e7`): branch 11475/12043 passing vs base 11474/12043 (95.3% both) — **1 newly passing** (`jsDeclarationsExportAssignedVisibility.ts`), **0 newly failing**. One additional row (`jsDeclarationsFunctionClassesCjsExportAssignment.ts`) shows a changed diagnostic fingerprint but is still failing overall — it has its own separate extra `TS2322` (unrelated) plus additional `TS9006` instances from the require-aliased-namespace gap described above, so it is not claimed as fixed here.
- Not run: emit / fourslash — this change touches only a diagnostic-suppression decision in a non-emitter checker path; not exercised.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPw8JjEyytJPnYe6kMVAHr)_