### PR TITLE
fix(checker): a signature-scoped rename shadowing a primitive keyword still resolves in its own typeof query

### DIFF
--- a/crates/tsz-checker/src/error_reporter/name_resolution.rs
+++ b/crates/tsz-checker/src/error_reporter/name_resolution.rs
@@ -712,6 +712,18 @@ impl<'a> CheckerState<'a> {
             });
 
         if is_primitive_type_keyword && !is_import_equals_module_specifier {
+            // A destructured parameter rename that shadows a primitive-keyword
+            // name (`({ a: string }) => typeof string`) is in scope for the
+            // signature's own `typeof` queries, same as any other renamed
+            // binding — see the general guard below. This early-return branch
+            // sits before that guard textually, so it needs its own check;
+            // tsc resolves the binding and reports nothing here rather than
+            // TS2693 on the shadowed primitive.
+            if crate::types_domain::signature_binding_scope::signature_parameter_declares_binding(
+                &self.ctx, idx, name,
+            ) {
+                return;
+            }
             self.error_type_only_value_at(name, idx);
             return;
         }

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -825,6 +825,8 @@ mod ts2574_rest_tuple_element_type_tests;
 mod ts2590_array_literal_identity_skip_tests;
 #[path = "tests/ts2591_node_global_type_position_tests.rs"]
 mod ts2591_node_global_type_position_tests;
+#[path = "tests/ts2693_signature_binding_shadowed_primitive_tests.rs"]
+mod ts2693_signature_binding_shadowed_primitive_tests;
 #[path = "tests/ts2739_alias_unfold_display_tests.rs"]
 mod ts2739_alias_unfold_display_tests;
 #[path = "tests/ts7053_apparent_receiver_display_tests.rs"]

--- a/crates/tsz-checker/src/tests/ts2693_signature_binding_shadowed_primitive_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2693_signature_binding_shadowed_primitive_tests.rs
@@ -1,0 +1,163 @@
+//! TS2693 for a destructured parameter rename that shadows a primitive-keyword
+//! name (`string`, `number`, ...) referenced by `typeof` inside the same
+//! signature.
+//!
+//! Structural rule: a parameter binding pattern declares a real value binding
+//! that stays in scope for every `typeof` type query of its own signature,
+//! same as any other name (#16241/#16249). `error_cannot_find_name_at`
+//! (`error_reporter/name_resolution.rs`) special-cases primitive-keyword names
+//! with an early `TS2693` return *before* the general
+//! `signature_parameter_declares_binding` guard runs later in the same
+//! function, so a rename that happens to reuse a primitive keyword
+//! (`({ a: string }) => typeof string`) fell through to that early branch and
+//! reported `TS2693` even though `tsc` resolves the binding and reports
+//! nothing.
+//!
+//! A second, adjacent gap: `signature_parameter_declares_binding` only checked
+//! the *nearest* enclosing signature. A `typeof` query nested inside a
+//! bodyless `FunctionType` that is itself part of an outer signature's return
+//! type (`(a: T) => (b: U) => typeof a`) still names the outer binding under
+//! `tsc`, since the inner `FunctionType` has no body and so no scope of its
+//! own — fixed by climbing through pure-type signatures to the next enclosing
+//! one.
+//!
+//! Every expectation here was checked against the pinned `typescript@7.0.2`
+//! oracle (`--noEmit --strict false --target es2015 --pretty false`), not
+//! against tsz's own prior output.
+
+use crate::test_utils::{check_source, non_strict_checker_options};
+
+/// All fixtures in this file mirror the pinned `typescript@7.0.2` oracle run
+/// under `// @strict: false`, matching how the issue's own repro was checked
+/// (`--strict false --target es2015`).
+fn codes(source: &str) -> Vec<u32> {
+    check_source(source, "test.ts", non_strict_checker_options())
+        .iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+fn assert_clean(source: &str, label: &str) {
+    let got = codes(source);
+    assert!(
+        got.is_empty(),
+        "{label}: expected no diagnostics, got codes {got:?}"
+    );
+}
+
+fn assert_codes(source: &str, expected: &[u32], label: &str) {
+    let got = codes(source);
+    assert_eq!(got, expected, "{label}: expected {expected:?}, got {got:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Positive: the rename resolves and the primitive-keyword TS2693 must not fire.
+// ---------------------------------------------------------------------------
+
+/// The issue's own witness: a single renamed property, referenced via `typeof`
+/// in the signature's return type.
+#[test]
+fn renamed_to_string_referenced_by_typeof_stays_clean() {
+    assert_clean(
+        "type F = ({ a: string }) => typeof string;",
+        "single rename to `string`, referenced",
+    );
+}
+
+/// Two renames in the same parameter pattern: the unused one (`string`) still
+/// reports `TS2842`, the referenced one (`number`) reports nothing — `tsc`
+/// never emits `TS2693` on either.
+#[test]
+fn two_renames_one_used_one_unused_reports_only_ts2842() {
+    assert_codes(
+        "type F = ({ a: string, b: number }) => typeof number;",
+        &[2842],
+        "two renames, one referenced by typeof",
+    );
+}
+
+/// Same rule on an interface method signature, not just a `FunctionType`
+/// alias body.
+#[test]
+fn interface_method_signature_renamed_to_string_stays_clean() {
+    assert_clean(
+        "interface I { m({ a: string }): typeof string; }",
+        "interface method signature rename",
+    );
+}
+
+/// `number` is not special-cased by name; the same shadowing must hold for
+/// every primitive keyword the early-return branch covers.
+#[test]
+fn renamed_to_number_referenced_by_typeof_stays_clean() {
+    assert_clean(
+        "type F = ({ a: number }) => typeof number;",
+        "single rename to `number`, referenced",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Positive: nested pure-type signatures climb to the outer binding.
+// ---------------------------------------------------------------------------
+
+/// A `typeof` reference inside a nested, bodyless `FunctionType` (the return
+/// type's own return type) still names the outer signature's renamed
+/// binding — the inner `FunctionType` has no parameters and no body, so it is
+/// not a separate scope.
+#[test]
+fn typeof_in_nested_function_type_return_resolves_outer_binding() {
+    assert_clean(
+        "type F = ({ a: string }) => (x: number) => typeof string;",
+        "typeof nested inside the outer signature's return type",
+    );
+}
+
+/// Two levels of nesting: the climb must not stop after a single hop.
+#[test]
+fn typeof_in_doubly_nested_function_type_return_resolves_outer_binding() {
+    assert_clean(
+        "type F = ({ a: string }) => (x: number) => (y: boolean) => typeof string;",
+        "typeof nested two FunctionTypes deep",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls: what must stay exactly as before.
+// ---------------------------------------------------------------------------
+
+/// No renaming at all: `typeof string` names the global primitive and `tsc`
+/// reports `TS2693`. This is the control that fails if the fix over-widens to
+/// "never report TS2693 near a signature".
+#[test]
+fn plain_parameter_no_rename_typeof_primitive_still_reports_ts2693() {
+    assert_codes(
+        "type F = (x: string) => typeof string;",
+        &[2693],
+        "no destructuring, bare typeof on a primitive keyword",
+    );
+}
+
+/// The rename exists but is never referenced by a `typeof` query anywhere:
+/// `TS2842` (unused renaming) fires alone, same as before this fix — the
+/// guard must not suppress the unused-rename diagnostic.
+#[test]
+fn renamed_to_string_never_referenced_reports_only_ts2842() {
+    assert_codes(
+        "type F = ({ a: string }) => number;",
+        &[2842],
+        "rename with no typeof reference anywhere",
+    );
+}
+
+/// The rename shadows one primitive keyword but the `typeof` query names a
+/// *different* one: the queried name is not declared by any parameter, so the
+/// global primitive is what actually gets referenced and `TS2693` still
+/// fires — alongside `TS2842`, since the `number` rename itself is unused.
+#[test]
+fn typeof_names_a_different_primitive_than_the_rename_still_reports_ts2693() {
+    assert_codes(
+        "type F = ({ a: number }) => typeof string;",
+        &[2842, 2693],
+        "rename to `number`, typeof queries `string`",
+    );
+}

--- a/crates/tsz-checker/src/types/signature_binding_scope.rs
+++ b/crates/tsz-checker/src/types/signature_binding_scope.rs
@@ -137,26 +137,31 @@ fn binding_pattern_declares(ctx: &CheckerContext, name_idx: NodeIndex, name: &st
     })
 }
 
-/// True when a parameter of the signature owning `within` declares a value
-/// binding called `name`.
-///
-/// This is the resolution half of the scope: a `typeof name` query inside the
-/// signature names that binding, so it must not fall through to global name
-/// resolution. It answers structurally from the AST rather than from seeded
-/// scope state, so it holds on every traversal of the signature, not only the
-/// one that lowers its return type.
-pub(crate) fn signature_parameter_declares_binding(
+/// Signature-like kinds that are pure type syntax with no body of their own:
+/// a `FunctionType`/`MethodSignature`/etc. nested inside an outer signature's
+/// return type is still part of that outer signature's type positions, not a
+/// separate scope. The remaining `is_signature_like` kinds (function/method/
+/// accessor/constructor declarations and expressions) can own a body and
+/// resolve their own parameters as ordinary local symbols, so they end the
+/// climb to an outer signature.
+const fn is_pure_type_signature(kind: u16) -> bool {
+    matches!(
+        kind,
+        syntax_kind_ext::FUNCTION_TYPE
+            | syntax_kind_ext::CONSTRUCTOR_TYPE
+            | syntax_kind_ext::CALL_SIGNATURE
+            | syntax_kind_ext::CONSTRUCT_SIGNATURE
+            | syntax_kind_ext::METHOD_SIGNATURE
+    )
+}
+
+/// True when a parameter declared directly on `signature` (not on a nested
+/// signature inside it) binds `name`.
+fn signature_own_parameters_declare(
     ctx: &CheckerContext,
-    within: NodeIndex,
+    signature: NodeIndex,
     name: &str,
 ) -> bool {
-    let Some((signature, saw_type_query)) = enclosing_signature_through_type_query(ctx, within)
-    else {
-        return false;
-    };
-    if !saw_type_query {
-        return false;
-    }
     // Walk the signature's own subtree for its parameters without descending
     // into a nested signature: an inner signature's parameters are scoped to
     // that inner signature and must not answer for the outer one.
@@ -185,6 +190,59 @@ pub(crate) fn signature_parameter_declares_binding(
         stack.extend(ctx.arena.get_children(node_idx));
     }
     false
+}
+
+/// True when a parameter of the signature owning `within` declares a value
+/// binding called `name`.
+///
+/// This is the resolution half of the scope: a `typeof name` query inside the
+/// signature names that binding, so it must not fall through to global name
+/// resolution. It answers structurally from the AST rather than from seeded
+/// scope state, so it holds on every traversal of the signature, not only the
+/// one that lowers its return type.
+///
+/// A `typeof` query nested inside a pure-type signature that is itself part
+/// of an outer signature's return type (`(a: T) => (b: U) => typeof a`) climbs
+/// to that outer signature when the inner one doesn't declare the name — the
+/// inner `FunctionType` has no body and so no scope of its own.
+pub(crate) fn signature_parameter_declares_binding(
+    ctx: &CheckerContext,
+    within: NodeIndex,
+    name: &str,
+) -> bool {
+    let Some((mut signature, saw_type_query)) = enclosing_signature_through_type_query(ctx, within)
+    else {
+        return false;
+    };
+    if !saw_type_query {
+        return false;
+    }
+    let mut guard = 0usize;
+    loop {
+        guard += 1;
+        if guard > 256 {
+            return false;
+        }
+        if signature_own_parameters_declare(ctx, signature, name) {
+            return true;
+        }
+        let Some(node) = ctx.arena.get(signature) else {
+            return false;
+        };
+        if !is_pure_type_signature(node.kind) {
+            return false;
+        }
+        let Some(ext) = ctx.arena.get_extended(signature) else {
+            return false;
+        };
+        if ext.parent.is_none() {
+            return false;
+        }
+        let Some(next) = enclosing_signature(ctx, ext.parent) else {
+            return false;
+        };
+        signature = next;
+    }
 }
 
 /// True when the binding named `name`, declared by a parameter of the signature


### PR DESCRIPTION
Closes #16242.

`error_cannot_find_name_at` (`crates/tsz-checker/src/error_reporter/name_resolution.rs`) special-cases primitive-keyword names (`string`, `number`, `boolean`, ...) with an early `TS2693` return — added so a `typeof` query on a primitive keyword reports the right diagnostic instead of falling into spelling-suggestion logic. That early return sits *before* the general `signature_parameter_declares_binding` guard later in the same function (added by #16241/#16249 for the sibling `TS2842`/`TS2304` halves of this same mechanism), so a destructured parameter rename that happens to reuse a primitive keyword — `({ a: string }) => typeof string` — took the primitive branch and reported a spurious `TS2693`, even though the rename is in scope for the signature's own `typeof` queries and `tsc` reports nothing.

## Structural rule

When a `typeof` type query inside a signature names a value binding declared by that same signature's own parameter destructuring pattern, `tsc` resolves the binding and reports nothing — whether or not the renamed name happens to also be a primitive keyword. tsz's checker already modeled this (`crates/tsz-checker/src/types/signature_binding_scope.rs`, `signature_parameter_declares_binding`) but only wired the guard into the "symbol truly not found" fallback path; the primitive-keyword branch resolves to a real (built-in, type-only) symbol and takes a different, earlier-returning path that never reached it.

## Adjacent gap found while building the matrix

`signature_parameter_declares_binding` also only checked the *nearest* enclosing signature. A `typeof` query nested inside a bodyless `FunctionType` that is itself part of an outer signature's return type — e.g. an outer function type whose return type is itself another function type ending in `typeof` on the outer binding — still names the outer binding under `tsc`, since the inner `FunctionType` has no body and so no scope of its own. Fixed by climbing through pure-type signature kinds (`FunctionType`, `ConstructorType`, `CallSignature`, `ConstructSignature`, `MethodSignature`) to the next enclosing signature when the immediate one doesn't declare the name; signature kinds that can own a body (function/method/accessor/constructor declarations and expressions) end the climb, since their own parameters resolve as ordinary local symbols through the binder.

## Owner layer

`crates/tsz-checker/src/error_reporter/name_resolution.rs` (the `TS2693` emission site) and `crates/tsz-checker/src/types/signature_binding_scope.rs` (the shared scope query both this and #16241/#16249 depend on). No solver or emitter change.

## Adjacent-case matrix (`crates/tsz-checker/src/tests/ts2693_signature_binding_shadowed_primitive_tests.rs`)

All rows checked against the pinned `typescript@7.0.2` oracle (`--noEmit --strict false --target es2015 --pretty false`), including via a hand-built matrix run directly through both binaries (byte-identical output). Shapes below use square brackets in place of angle brackets so they survive posting to GitHub:

| shape | tsc 7.0.2 | tsz before | tsz after |
| --- | --- | --- | --- |
| `({ a: string }) =[ typeof string` (single rename, referenced) | clean | `TS2693` | clean |
| `({ a: string, b: number }) =[ typeof number` (one used, one unused) | `TS2842` only | `TS2842`, `TS2693` | `TS2842` only |
| `interface I { m({ a: string }): typeof string; }` | clean | `TS2693` | clean |
| `({ a: number }) =[ typeof number` (`number`, not `string`) | clean | `TS2693` | clean |
| `({ a: string }) =[ (x: number) =[ typeof string` (nested `FunctionType`) | clean | `TS2693` | clean |
| `({ a: string }) =[ (x) =[ (y) =[ typeof string` (two levels of nesting) | clean | `TS2693` | clean |
| `(x: string) =[ typeof string` (no rename — negative control) | `TS2693` | `TS2693` | `TS2693` (unaffected) |
| `({ a: string }) =[ number` (rename never referenced — negative control) | `TS2842` only | `TS2842` only | `TS2842` only (unaffected) |
| `({ a: number }) =[ typeof string` (rename shadows a *different* primitive) | `TS2842`, `TS2693` | `TS2842`, `TS2693` | `TS2842`, `TS2693` (unaffected) |

(Read `=[` as the arrow `=>` — see the actual test file for the real source.)

## Conformance impact

`renamingDestructuredPropertyInFunctionType{,2}.ts` (named in #16242 as blocked on this) both change fingerprint under `compare-to-parent.sh` but **do not** reach full parity from this PR alone — they were already failing for an unrelated, pre-existing reason: tsz emits no `TS2842` at all for a destructured rename on a *quoted or computed* property key (a string-literal key, a numeric key, or a computed key). That gap is orthogonal to this fix (it's about `TS2842`'s own property-key handling, not `typeof` resolution) and is left as a follow-up rather than folded into this diff. Confirmed directly: running `.target/debug/tsz` against the real fixture now reports 13 of 21 expected diagnostics, all correct, with the missing 8 being exactly those quoted/computed-key rows (`F10`-`F13`/`G10`-`G13` in the fixture).

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-checker --lib -- ts2693_signature_binding_shadowed_primitive` — 9/9 passed (new).
- `cargo nextest run -p tsz-checker --lib` (full suite) — 9082/9083 passed; the 1 failure (`ts2303_tests::recursive_export_assignment_self_import_reports_ts2303`) reproduces identically on `origin/main` with this branch's changes stashed — pre-existing, unrelated.
- `scripts/conformance/compare-to-parent.sh` (base `61af36f`, branch head): base failing=569, branch failing=569, **newly passing: 0, newly failing: 0**. Two rows change fingerprint (`renamingDestructuredPropertyInFunctionType{,2}.ts`) but stay failing for the separate reason above.
- `cargo fmt -p tsz-checker -- --check` — clean.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py` — passed.
- Direct oracle comparison: `.target/debug/tsz` vs pinned `typescript@7.0.2` on a hand-built 9-case matrix (table above) — byte-identical.
- Local pre-commit hook (fmt + clippy + arch guard) — passed.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE