### PR TITLE
fix(checker): a bare JSDoc @type tag on a non-prototype property statement stops manufacturing a declaration

### DIFF
--- a/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
@@ -308,17 +308,21 @@ impl<'a> CheckerState<'a> {
             if self.expression_text(expr_stmt.expression).as_deref() != Some(name) {
                 continue;
             }
-            // A bare JSDoc-commented `C.prototype.member` read is a
-            // declaration site only for a function-as-constructor's expando
-            // prototype. An ES class's prototype is closed: skip so the
-            // ordinary property-access path decides (TS2339 for an absent
-            // member), matching `tsc`.
-            let is_class_prototype_member = self
+            // A bare JSDoc-commented member read is a declaration site only
+            // for a function-as-constructor's expando prototype
+            // (`C.prototype.member`) — tsc still reports TS2339 for a bare
+            // `@type`-commented read of any other property (a plain
+            // namespace/object member, a function's own static property, an
+            // ES class's closed prototype), so the ordinary property-access
+            // path must decide those, not this one.
+            let is_function_constructor_prototype_member = self
                 .ctx
                 .arena
                 .get_access_expr_at(expr_stmt.expression)
-                .is_some_and(|access| self.expando_receiver_is_class(access.expression));
-            if is_class_prototype_member {
+                .is_some_and(|access| {
+                    self.expando_receiver_is_function_constructor(access.expression)
+                });
+            if !is_function_constructor_prototype_member {
                 continue;
             }
             if let Some(jsdoc_type) = self.js_statement_declared_type(idx) {

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -447,6 +447,8 @@ mod js_file_function_parameters_as_optional_tests;
 mod js_open_object_property_access_tests;
 #[path = "tests/jsdoc_bare_import_type_tests.rs"]
 mod jsdoc_bare_import_type_tests;
+#[path = "tests/jsdoc_bare_type_tag_non_prototype_expando_tests.rs"]
+mod jsdoc_bare_type_tag_non_prototype_expando_tests;
 #[path = "tests/jsdoc_cast_and_define_property_widening_tests.rs"]
 mod jsdoc_cast_and_define_property_widening_tests;
 #[path = "tests/jsdoc_closure_function_type_tests.rs"]

--- a/crates/tsz-checker/src/tests/jsdoc_bare_type_tag_non_prototype_expando_tests.rs
+++ b/crates/tsz-checker/src/tests/jsdoc_bare_type_tag_non_prototype_expando_tests.rs
@@ -1,0 +1,143 @@
+//! A bare JSDoc `@type`-commented property-access *statement* declares a
+//! member only for a function-as-constructor's expando prototype
+//! (`function C(){} /** @type {T} */ C.prototype.x;` — see
+//! `ts2565_jsdoc_prototype_type_decl_tests.rs`). For every other receiver —
+//! a plain namespace/value object, a function's own static property, or an
+//! ES class's closed prototype — tsc still reports `TS2339` for the read.
+//!
+//! `resolve_jsdoc_assigned_value_type_in_arena`'s bare-statement scan used to
+//! gate only on excluding an ES class prototype (`expando_receiver_is_class`
+//! applied one level too shallow, on the statement's own receiver rather than
+//! on a `.prototype` link), so it never actually required the access be a
+//! `.prototype` chain at all. Any `/** @type {T} */ ns.prop;` was treated as
+//! a declaration, suppressing `TS2339` on the following real read too.
+//! Verified against the pinned `typescript@7.0.2` oracle for every row below.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::check_source;
+
+fn diag_codes_js(source: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        allow_js: true,
+        check_js: true,
+        ..CheckerOptions::default()
+    };
+    check_source(source, "test.js", options)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+/// The original repro: a bare `@type` tag before a plain object's property
+/// read must not suppress `TS2339`. Oracle: `tsc` 7.0.2 reports `TS2339` on
+/// both the declaring statement and the later read.
+#[test]
+fn bare_type_tag_on_plain_namespace_property_still_reports_ts2339() {
+    let codes = diag_codes_js(
+        r#"
+var exports = {};
+/** @type {string} */
+exports.SomeName;
+"#,
+    );
+    assert!(
+        codes.contains(&2339),
+        "a bare @type tag on a plain object's property must not manufacture a \
+         declaration; tsc still reports TS2339 here. Got: {codes:?}"
+    );
+}
+
+/// Same shape, renamed binders, to keep the rule structural rather than
+/// keyed on the `exports`/`SomeName` identifiers from the original repro.
+#[test]
+fn bare_type_tag_on_plain_namespace_property_works_with_renamed_binders() {
+    let codes = diag_codes_js(
+        r#"
+var Registry = {};
+/** @type {number} */
+Registry.Count;
+"#,
+    );
+    assert!(
+        codes.contains(&2339),
+        "the rule must hold under renamed binders, not just the original repro's \
+         names. Got: {codes:?}"
+    );
+}
+
+/// A function's own *static* property (no `.prototype` in the chain) is not
+/// a constructor's expando prototype either — tsc reports TS2339.
+#[test]
+fn bare_type_tag_on_function_static_property_still_reports_ts2339() {
+    let codes = diag_codes_js(
+        r#"
+function F() {}
+/** @type {number} */
+F.x;
+"#,
+    );
+    assert!(
+        codes.contains(&2339),
+        "a bare @type tag on a function's own static property (not \
+         `.prototype`) must not manufacture a declaration. Got: {codes:?}"
+    );
+}
+
+/// Negative control keeping the real feature alive: a function-as-constructor
+/// `.prototype` member declared via a bare `@type` statement must still be
+/// silent, matching `ts2565_jsdoc_prototype_type_decl_tests`.
+#[test]
+fn bare_type_tag_on_function_constructor_prototype_stays_silent() {
+    let codes = diag_codes_js(
+        r#"
+function C() {}
+/** @type {number} */
+C.prototype.x;
+var y = C.prototype.x;
+"#,
+    );
+    assert!(
+        !codes.contains(&2339),
+        "the real function-as-constructor prototype declaration must still be \
+         recognized. Got: {codes:?}"
+    );
+}
+
+/// Negative control: the same plain-namespace shape with no JSDoc comment at
+/// all must already report TS2339 — this pins the baseline behavior the bug
+/// only broke once a `@type` tag was added.
+#[test]
+fn plain_namespace_property_without_jsdoc_reports_ts2339() {
+    let codes = diag_codes_js(
+        r#"
+var exports = {};
+exports.SomeName;
+"#,
+    );
+    assert!(
+        codes.contains(&2339),
+        "the un-annotated read is the baseline the bug regressed against; it \
+         must stay TS2339. Got: {codes:?}"
+    );
+}
+
+/// An unrelated member on the same root, immediately after the bare
+/// `@type`-tagged statement, must independently keep reporting TS2339 — the
+/// declaration mechanism must not leak namespace-wide.
+#[test]
+fn unrelated_member_after_bare_type_tag_still_reports_ts2339() {
+    let codes = diag_codes_js(
+        r#"
+var exports = {};
+/** @type {string} */
+exports.SomeName;
+exports.Other;
+"#,
+    );
+    let ts2339_count = codes.iter().filter(|&&c| c == 2339).count();
+    assert_eq!(
+        ts2339_count, 2,
+        "both `exports.SomeName` and `exports.Other` must independently report \
+         TS2339. Got: {codes:?}"
+    );
+}


### PR DESCRIPTION
tsc recognizes a bare `/** @type {T} */ expr.prop;` expression statement as a declaration site only for one specific shape: a function-as-constructor's expando prototype (`function C(){} /** @type {T} */ C.prototype.x;`). Every other receiver — a plain namespace/value object, a function's own static property, or an ES class's closed prototype — still gets an ordinary `TS2339` on the read.

## Structural rule

When a bare JSDoc `@type`-commented property-access statement's receiver is **not** a `.prototype` chain rooted at a function-as-constructor, tsc's checker still reports `TS2339` for the property read; tsz's `resolve_jsdoc_assigned_value_type_in_arena` (`crates/tsz-checker/src/jsdoc/resolution/type_construction.rs`) treated *any* such statement as a declaration.

Root cause: the loop's only exclusion was `expando_receiver_is_class`, applied to `expr_stmt.expression`'s own receiver (e.g. for `exports.SomeName;`, that's the bare identifier `exports`) instead of to a `.prototype` link one level up. `expando_receiver_is_class` immediately returns `false` for a non-`PROPERTY_ACCESS_EXPRESSION` argument, so for any plain `ns.prop;` shape the exclusion never fired — the loop proceeded to treat the statement as declaring `prop`, matched it against the following read, and suppressed `TS2339` on both.

## Owner layer

`crates/tsz-checker/src/jsdoc/resolution/type_construction.rs` — one predicate swap. Replaced the flawed exclusion with `expando_receiver_is_function_constructor` (`crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs`), already used elsewhere (`property_access_type/resolve.rs:756`) for the identical "is this a real constructor's expando prototype" gate. It requires the access be a `.prototype` chain whose root resolves to a function and *not* a class — the rule the removed code's own comment already described but never actually enforced. No solver, emitter, or binder change.

Found via the adjacent finding left in #16249's PR body (`/** @type {string} */ exports.SomeName;` failing to report `TS2339`).

## Adjacent-case matrix (oracle: pinned `typescript@7.0.2`, `--allowJs --checkJs`)

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| plain namespace object, bare `@type` (`var exports = {}; /** @type {string} */ exports.SomeName;`) | `TS2339` | silent | `TS2339` |
| same, renamed binders (`Registry.Count`) | `TS2339` | silent | `TS2339` |
| function's own static property, no `.prototype` (`function F(){} /** @type {number} */ F.x;`) | `TS2339` | silent | `TS2339` |
| function-as-constructor `.prototype` (`function C(){} /** @type {number} */ C.prototype.x;`) — the real feature | silent | silent | silent (unaffected) |
| plain namespace property, **no** `@type` at all (baseline control) | `TS2339` | `TS2339` | `TS2339` (unaffected) |
| unrelated member immediately after the tagged statement (`exports.Other;`) | `TS2339` | `TS2339` | `TS2339` (unaffected) |

All six rows verified directly against a debug binary built from this branch and the npm-installed `typescript@7.0.2` oracle, byte-identical after the fix. The four negative controls (function-constructor prototype, no-`@type` baseline, unrelated member, and the existing `ts2565_jsdoc_prototype_type_decl_tests` class-prototype family) confirm the fix doesn't regress the real declaration mechanism or the class-prototype exclusion it was layered next to.

## Goal
Goal: hold

## Verification
- New `crates/tsz-checker/src/tests/jsdoc_bare_type_tag_non_prototype_expando_tests.rs` (registered in `test_module_registry.rs`) — 6/6 passed: the bug repro, a renamed-binder variant, the function-static-property variant, the function-constructor-prototype negative control, the no-`@type` baseline control, and the unrelated-member independence check.
- `cargo test -p tsz-checker --lib -- jsdoc prototype expando` — 586/586 passed, 0 regressions (covers the full `ts2565_jsdoc_prototype_type_decl_tests` family this predicate is shared with).
- `cargo fmt -p tsz-checker -- --check` — clean.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py` — passed.
- `scripts/conformance/compare-to-parent.sh HEAD~1` — two-sided, 12043 runnable both sides: **0 newly passing, 0 newly failing, 0 fingerprint changes** (569/569 failing both sides). Expected for an oracle-matrix fix with no corpus fixture for this exact shape, not a null result — see the standing board gotcha on this pattern.
- End-to-end manual verification: built `.target/debug/tsz` from this branch and ran all six oracle-matrix rows above directly through it, matching the pinned `typescript@7.0.2` oracle byte-for-byte.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_015xn2EnbmJwKY91eMHtQ9GL)_