### PR TITLE
fix(cli): TS2665 for a .d.ts-hosted augmentation of an untyped module

### DIFF
--- a/crates/tsz-cli/src/driver/core.rs
+++ b/crates/tsz-cli/src/driver/core.rs
@@ -40,7 +40,8 @@ pub(crate) use super::emit::{normalize_base_url, normalize_output_dir, normalize
 use super::resolution::collect_module_specifiers;
 use super::resolution::{
     ModuleResolutionCache, ProgramFileIndex, apply_json_type_import_attribute_override,
-    build_duplicate_package_redirects, canonicalize_or_owned, collect_export_binding_nodes,
+    build_duplicate_package_redirects, canonicalize_or_owned,
+    collect_declaration_file_augmentation_targets_for_untyped_check, collect_export_binding_nodes,
     collect_import_bindings, collect_module_specifiers_for_check, collect_star_export_specifiers,
     collect_type_packages_from_root, default_type_roots, env_flag,
     implied_resolution_mode_for_file_with_cache, is_declaration_file,

--- a/crates/tsz-cli/src/driver/resolution.rs
+++ b/crates/tsz-cli/src/driver/resolution.rs
@@ -63,7 +63,6 @@ pub(crate) enum AmbientModuleDeclarationSpecifierPolicy {
     SourceDiscovery,
     Check {
         is_external_module: bool,
-        skip_lib_check: bool,
     },
 }
 

--- a/crates/tsz-cli/src/driver/resolution.rs
+++ b/crates/tsz-cli/src/driver/resolution.rs
@@ -63,6 +63,7 @@ pub(crate) enum AmbientModuleDeclarationSpecifierPolicy {
     SourceDiscovery,
     Check {
         is_external_module: bool,
+        skip_lib_check: bool,
     },
 }
 

--- a/crates/tsz-cli/src/driver/resolution/discovery.rs
+++ b/crates/tsz-cli/src/driver/resolution/discovery.rs
@@ -585,11 +585,15 @@ pub(crate) fn collect_module_specifiers_for_check(
     arena: &NodeArena,
     source_file: NodeIndex,
     is_external_module: bool,
+    skip_lib_check: bool,
 ) -> Vec<CollectedModuleSpecifier> {
     collect_module_specifiers_impl(
         arena,
         source_file,
-        AmbientModuleDeclarationSpecifierPolicy::Check { is_external_module },
+        AmbientModuleDeclarationSpecifierPolicy::Check {
+            is_external_module,
+            skip_lib_check,
+        },
     )
 }
 
@@ -716,15 +720,27 @@ pub(crate) fn collect_module_specifiers_impl(
                 let specifier = strip_quotes(text);
                 // Relative names can be module augmentations of concrete sibling
                 // files. Non-relative names only need driver resolution in
-                // non-declaration external modules, where the lookup proves
-                // whether a bare augmentation target exists for TS2664.
+                // external modules, where the lookup proves whether a bare
+                // augmentation target exists for TS2664, or resolves to an
+                // untyped module for TS2665.
+                //
+                // TS2664 stays gated on `!is_declaration_file` at the checker
+                // (it never fires in a `.d.ts` host), but TS2665 does not: tsc
+                // reports it for a `.d.ts`-hosted augmentation exactly as for a
+                // `.ts` one. So a `.d.ts` host still needs the specifier
+                // resolved when its diagnostics are not discarded outright —
+                // when `skip_lib_check` is on, `check_file.rs` runs this file's
+                // checker pass only to populate shared caches and throws every
+                // diagnostic away, so resolving here would just be wasted work
+                // across every vendored `.d.ts` in `node_modules`.
                 let include_non_relative = match ambient_declaration_policy {
                     #[cfg(test)]
                     AmbientModuleDeclarationSpecifierPolicy::All => true,
                     AmbientModuleDeclarationSpecifierPolicy::SourceDiscovery => false,
-                    AmbientModuleDeclarationSpecifierPolicy::Check { is_external_module } => {
-                        is_external_module && !source.is_declaration_file
-                    }
+                    AmbientModuleDeclarationSpecifierPolicy::Check {
+                        is_external_module,
+                        skip_lib_check,
+                    } => is_external_module && (!source.is_declaration_file || !skip_lib_check),
                 };
                 if include_non_relative || tsz::module_resolver::is_path_relative(&specifier) {
                     specifiers.push((specifier, module_decl.name, ImportKind::EsmImport, None));

--- a/crates/tsz-cli/src/driver/resolution/discovery.rs
+++ b/crates/tsz-cli/src/driver/resolution/discovery.rs
@@ -585,15 +585,11 @@ pub(crate) fn collect_module_specifiers_for_check(
     arena: &NodeArena,
     source_file: NodeIndex,
     is_external_module: bool,
-    skip_lib_check: bool,
 ) -> Vec<CollectedModuleSpecifier> {
     collect_module_specifiers_impl(
         arena,
         source_file,
-        AmbientModuleDeclarationSpecifierPolicy::Check {
-            is_external_module,
-            skip_lib_check,
-        },
+        AmbientModuleDeclarationSpecifierPolicy::Check { is_external_module },
     )
 }
 
@@ -606,6 +602,65 @@ pub(crate) fn collect_module_specifiers_for_source_discovery(
         source_file,
         AmbientModuleDeclarationSpecifierPolicy::SourceDiscovery,
     )
+}
+
+/// Bare (non-relative) `declare module "spec" { ... }` augmentation names in a
+/// `.d.ts` host, top-level only, mirroring the shape `collect_module_specifiers_impl`
+/// looks for but scoped to exactly the declaration-file case that function
+/// always excludes.
+///
+/// Deliberately NOT folded into `cached_module_specifiers`: that pipeline
+/// feeds `resolved_module_specifiers`/`resolved_module_paths`, which drive
+/// cross-file symbol merging (ambient-module precedence,
+/// `module_exists`/`module_augmentation_target_exists`, augmentation-body
+/// checks). Joining a `.d.ts`-hosted bare augmentation name into that
+/// machinery surfaced two unrelated resolution bugs (self-name `exports`
+/// condition selection; cross-file overload-augmentation duplicate
+/// identifiers) that a full corpus sweep caught. The caller resolves each
+/// target through the same `ModuleResolver`, but only ever reads
+/// `outcome.untyped_module_path` off the result — never touching the shared
+/// resolution maps — so TS2665 (`declarations_module.rs`'s
+/// `untyped_module_path_for` lookup) can fire for a `.d.ts` host without
+/// pulling it into general-purpose resolution.
+pub(crate) fn collect_declaration_file_augmentation_targets_for_untyped_check(
+    arena: &NodeArena,
+    source_file: NodeIndex,
+) -> Vec<(String, NodeIndex)> {
+    let Some(source) = arena.get_source_file_at(source_file) else {
+        return Vec::new();
+    };
+    let strip_quotes =
+        |s: &str| -> String { s.trim_matches(|c| c == '"' || c == '\'').to_string() };
+    let mut targets = Vec::new();
+    for &stmt_idx in &source.statements.nodes {
+        if stmt_idx.is_none() {
+            continue;
+        }
+        let Some(stmt) = arena.get(stmt_idx) else {
+            continue;
+        };
+        let Some(module_decl) = arena.get_module(stmt) else {
+            continue;
+        };
+        let has_declare = module_decl.modifiers.as_ref().is_some_and(|mods| {
+            mods.nodes.iter().any(|&mod_idx| {
+                arena
+                    .get(mod_idx)
+                    .is_some_and(|node| node.kind == SyntaxKind::DeclareKeyword as u16)
+            })
+        });
+        if !has_declare {
+            continue;
+        }
+        let Some(text) = arena.get_literal_text(module_decl.name) else {
+            continue;
+        };
+        let specifier = strip_quotes(text);
+        if !tsz::module_resolver::is_path_relative(&specifier) {
+            targets.push((specifier, module_decl.name));
+        }
+    }
+    targets
 }
 
 pub(crate) fn collect_module_specifiers_impl(
@@ -720,27 +775,31 @@ pub(crate) fn collect_module_specifiers_impl(
                 let specifier = strip_quotes(text);
                 // Relative names can be module augmentations of concrete sibling
                 // files. Non-relative names only need driver resolution in
-                // external modules, where the lookup proves whether a bare
-                // augmentation target exists for TS2664, or resolves to an
-                // untyped module for TS2665.
+                // non-declaration external modules, where the lookup proves
+                // whether a bare augmentation target exists for TS2664.
                 //
-                // TS2664 stays gated on `!is_declaration_file` at the checker
-                // (it never fires in a `.d.ts` host), but TS2665 does not: tsc
-                // reports it for a `.d.ts`-hosted augmentation exactly as for a
-                // `.ts` one. So a `.d.ts` host still needs the specifier
-                // resolved when its diagnostics are not discarded outright —
-                // when `skip_lib_check` is on, `check_file.rs` runs this file's
-                // checker pass only to populate shared caches and throws every
-                // diagnostic away, so resolving here would just be wasted work
-                // across every vendored `.d.ts` in `node_modules`.
+                // A `.d.ts` host stays excluded here even though TS2665 also
+                // applies there (see `collect_declaration_file_augmentation_targets_for_untyped_check`
+                // below): joining this specifier into the shared
+                // `cached_module_specifiers` pipeline feeds
+                // `resolved_module_specifiers`/`resolved_module_paths`, which
+                // drive cross-file symbol merging (ambient-precedence,
+                // `module_exists`, augmentation-body checks). A `.d.ts`-hosted
+                // bare augmentation name joining that machinery for the first
+                // time surfaced real, unrelated resolution bugs (self-name
+                // `exports` condition selection, cross-file overload-merge
+                // duplicate identifiers) that have nothing to do with TS2665.
+                // The dedicated collector below resolves the same specifier
+                // through a side channel that only ever populates
+                // `untyped_module_paths`, so TS2665 can fire without pulling a
+                // `.d.ts` host into general-purpose resolution.
                 let include_non_relative = match ambient_declaration_policy {
                     #[cfg(test)]
                     AmbientModuleDeclarationSpecifierPolicy::All => true,
                     AmbientModuleDeclarationSpecifierPolicy::SourceDiscovery => false,
-                    AmbientModuleDeclarationSpecifierPolicy::Check {
-                        is_external_module,
-                        skip_lib_check,
-                    } => is_external_module && (!source.is_declaration_file || !skip_lib_check),
+                    AmbientModuleDeclarationSpecifierPolicy::Check { is_external_module } => {
+                        is_external_module && !source.is_declaration_file
+                    }
                 };
                 if include_non_relative || tsz::module_resolver::is_path_relative(&specifier) {
                     specifiers.push((specifier, module_decl.name, ImportKind::EsmImport, None));

--- a/crates/tsz-cli/src/driver/resolution_tests/source_discovery.rs
+++ b/crates/tsz-cli/src/driver/resolution_tests/source_discovery.rs
@@ -246,7 +246,8 @@ declare module "pkg" {
 }
 
 #[test]
-fn test_collect_module_specifiers_for_check_skips_declaration_file_ambient_names() {
+fn test_collect_module_specifiers_for_check_skips_declaration_file_ambient_names_under_skip_lib_check()
+ {
     let text = r#"
 declare module "*.css" {}
 declare module "virtual:asset" {}
@@ -259,7 +260,7 @@ declare module "pkg" {
     let source_file = parser.parse_source_file();
     let (arena, _diagnostics) = parser.into_parts();
 
-    let specifiers: Vec<_> = collect_module_specifiers_for_check(&arena, source_file, true)
+    let specifiers: Vec<_> = collect_module_specifiers_for_check(&arena, source_file, true, true)
         .into_iter()
         .map(|(specifier, _, _, _)| specifier)
         .collect();
@@ -276,7 +277,8 @@ declare module "pkg" {
     );
     assert!(
         !specifiers.iter().any(|specifier| specifier == "pkg"),
-        "ambient declaration names are not driver lookups in declaration files: {specifiers:?}"
+        "under skip_lib_check the checker discards this file's diagnostics entirely, \
+         so a bare ambient declaration name is not worth a driver lookup: {specifiers:?}"
     );
     assert!(
         specifiers.iter().any(|specifier| specifier == "./augment"),
@@ -285,6 +287,34 @@ declare module "pkg" {
     assert!(
         specifiers.iter().any(|specifier| specifier == "dep"),
         "real re-exports inside ambient module bodies remain dependencies: {specifiers:?}"
+    );
+}
+
+#[test]
+fn test_collect_module_specifiers_for_check_keeps_declaration_file_ambient_names_when_checked() {
+    // Without skip_lib_check, tsc still validates a `.d.ts`-hosted augmentation
+    // (TS2665 for an untyped target) exactly as it would in a `.ts` file, so the
+    // bare augmentation name needs the same driver lookup here — matching the
+    // pre-existing `.ts`-host behavior exercised by
+    // `test_collect_module_specifiers_for_check_keeps_bare_source_augmentation_targets`
+    // above, which this test now mirrors for a `.d.ts` host.
+    let text = r#"
+declare module "pkg" {
+  export { T } from "dep";
+}
+"#;
+    let mut parser = tsz::parser::ParserState::new("types.d.ts".to_string(), text.to_string());
+    let source_file = parser.parse_source_file();
+    let (arena, _diagnostics) = parser.into_parts();
+
+    let specifiers: Vec<_> = collect_module_specifiers_for_check(&arena, source_file, true, false)
+        .into_iter()
+        .map(|(specifier, _, _, _)| specifier)
+        .collect();
+
+    assert!(
+        specifiers.iter().any(|specifier| specifier == "pkg"),
+        "a bare augmentation name in a checked declaration file needs resolution for TS2665: {specifiers:?}"
     );
 }
 
@@ -301,7 +331,7 @@ declare module "pkg" {
     let (arena, _diagnostics) = parser.into_parts();
 
     let external_specifiers: Vec<_> =
-        collect_module_specifiers_for_check(&arena, source_file, true)
+        collect_module_specifiers_for_check(&arena, source_file, true, false)
             .into_iter()
             .map(|(specifier, _, _, _)| specifier)
             .collect();
@@ -312,10 +342,11 @@ declare module "pkg" {
         "external source augmentations need lookup for TS2664: {external_specifiers:?}"
     );
 
-    let script_specifiers: Vec<_> = collect_module_specifiers_for_check(&arena, source_file, false)
-        .into_iter()
-        .map(|(specifier, _, _, _)| specifier)
-        .collect();
+    let script_specifiers: Vec<_> =
+        collect_module_specifiers_for_check(&arena, source_file, false, false)
+            .into_iter()
+            .map(|(specifier, _, _, _)| specifier)
+            .collect();
     assert!(
         !script_specifiers.iter().any(|specifier| specifier == "pkg"),
         "script ambient declarations should not become driver lookups: {script_specifiers:?}"

--- a/crates/tsz-cli/src/driver/resolution_tests/source_discovery.rs
+++ b/crates/tsz-cli/src/driver/resolution_tests/source_discovery.rs
@@ -246,8 +246,7 @@ declare module "pkg" {
 }
 
 #[test]
-fn test_collect_module_specifiers_for_check_skips_declaration_file_ambient_names_under_skip_lib_check()
- {
+fn test_collect_module_specifiers_for_check_skips_declaration_file_ambient_names() {
     let text = r#"
 declare module "*.css" {}
 declare module "virtual:asset" {}
@@ -260,7 +259,7 @@ declare module "pkg" {
     let source_file = parser.parse_source_file();
     let (arena, _diagnostics) = parser.into_parts();
 
-    let specifiers: Vec<_> = collect_module_specifiers_for_check(&arena, source_file, true, true)
+    let specifiers: Vec<_> = collect_module_specifiers_for_check(&arena, source_file, true)
         .into_iter()
         .map(|(specifier, _, _, _)| specifier)
         .collect();
@@ -277,8 +276,7 @@ declare module "pkg" {
     );
     assert!(
         !specifiers.iter().any(|specifier| specifier == "pkg"),
-        "under skip_lib_check the checker discards this file's diagnostics entirely, \
-         so a bare ambient declaration name is not worth a driver lookup: {specifiers:?}"
+        "ambient declaration names are not driver lookups in declaration files: {specifiers:?}"
     );
     assert!(
         specifiers.iter().any(|specifier| specifier == "./augment"),
@@ -291,14 +289,18 @@ declare module "pkg" {
 }
 
 #[test]
-fn test_collect_module_specifiers_for_check_keeps_declaration_file_ambient_names_when_checked() {
-    // Without skip_lib_check, tsc still validates a `.d.ts`-hosted augmentation
-    // (TS2665 for an untyped target) exactly as it would in a `.ts` file, so the
-    // bare augmentation name needs the same driver lookup here — matching the
-    // pre-existing `.ts`-host behavior exercised by
-    // `test_collect_module_specifiers_for_check_keeps_bare_source_augmentation_targets`
-    // above, which this test now mirrors for a `.d.ts` host.
+fn test_collect_declaration_file_augmentation_targets_for_untyped_check_finds_bare_names() {
+    // The dedicated TS2665-only collector picks up exactly what the
+    // general-purpose `collect_module_specifiers_for_check` above deliberately
+    // excludes for a `.d.ts` host: bare (non-relative) augmentation names.
+    // This collector feeds a side-channel resolution that only ever writes
+    // `untyped_module_paths`, so it does not need to distinguish wildcard
+    // ambient patterns or relative names the way the general pipeline does —
+    // callers only care about "does this look like a real augmentation
+    // target."
     let text = r#"
+declare module "*.css" {}
+declare module "./augment" {}
 declare module "pkg" {
   export { T } from "dep";
 }
@@ -307,14 +309,48 @@ declare module "pkg" {
     let source_file = parser.parse_source_file();
     let (arena, _diagnostics) = parser.into_parts();
 
-    let specifiers: Vec<_> = collect_module_specifiers_for_check(&arena, source_file, true, false)
-        .into_iter()
-        .map(|(specifier, _, _, _)| specifier)
-        .collect();
+    let targets: Vec<_> =
+        collect_declaration_file_augmentation_targets_for_untyped_check(&arena, source_file)
+            .into_iter()
+            .map(|(specifier, _)| specifier)
+            .collect();
 
     assert!(
-        specifiers.iter().any(|specifier| specifier == "pkg"),
-        "a bare augmentation name in a checked declaration file needs resolution for TS2665: {specifiers:?}"
+        targets.iter().any(|specifier| specifier == "pkg"),
+        "a bare augmentation name needs resolution for TS2665: {targets:?}"
+    );
+    assert!(
+        targets.iter().any(|specifier| specifier == "*.css"),
+        "the collector itself does not filter wildcard patterns — the caller \
+         resolves every entry through ModuleResolver, which classifies a \
+         pattern like any other unresolvable specifier: {targets:?}"
+    );
+    assert!(
+        !targets.iter().any(|specifier| specifier == "./augment"),
+        "relative augmentation names resolve through the general pipeline \
+         already (TS2664), not this untyped-only side channel: {targets:?}"
+    );
+}
+
+#[test]
+fn test_collect_declaration_file_augmentation_targets_for_untyped_check_ignores_non_ambient() {
+    // A non-`declare` module block (a real `namespace`/module body) and a
+    // relative name are both out of scope for this collector.
+    let text = r#"
+export {};
+namespace NotAmbient {
+  export const x = 1;
+}
+"#;
+    let mut parser = tsz::parser::ParserState::new("types.d.ts".to_string(), text.to_string());
+    let source_file = parser.parse_source_file();
+    let (arena, _diagnostics) = parser.into_parts();
+
+    let targets =
+        collect_declaration_file_augmentation_targets_for_untyped_check(&arena, source_file);
+    assert!(
+        targets.is_empty(),
+        "a non-ambient namespace is not an augmentation target: {targets:?}"
     );
 }
 
@@ -331,7 +367,7 @@ declare module "pkg" {
     let (arena, _diagnostics) = parser.into_parts();
 
     let external_specifiers: Vec<_> =
-        collect_module_specifiers_for_check(&arena, source_file, true, false)
+        collect_module_specifiers_for_check(&arena, source_file, true)
             .into_iter()
             .map(|(specifier, _, _, _)| specifier)
             .collect();
@@ -342,11 +378,10 @@ declare module "pkg" {
         "external source augmentations need lookup for TS2664: {external_specifiers:?}"
     );
 
-    let script_specifiers: Vec<_> =
-        collect_module_specifiers_for_check(&arena, source_file, false, false)
-            .into_iter()
-            .map(|(specifier, _, _, _)| specifier)
-            .collect();
+    let script_specifiers: Vec<_> = collect_module_specifiers_for_check(&arena, source_file, false)
+        .into_iter()
+        .map(|(specifier, _, _, _)| specifier)
+        .collect();
     assert!(
         !script_specifiers.iter().any(|specifier| specifier == "pkg"),
         "script ambient declarations should not become driver lookups: {script_specifiers:?}"

--- a/crates/tsz-cli/src/driver/source_resolution_setup.rs
+++ b/crates/tsz-cli/src/driver/source_resolution_setup.rs
@@ -43,6 +43,47 @@ pub(super) struct SourceResolutionSetupInput<'a> {
     pub(super) resolution_cache: &'a mut ModuleResolutionCache,
 }
 
+/// True when `file_path` sits inside `node_modules/<specifier's package
+/// name>/...` — i.e. `specifier` names the package `file_path` itself belongs
+/// to. Used to route around a self-reference (Node package importing itself
+/// by name; see `crates/tsz-core/src/module_resolver/self_reference.rs`)
+/// rather than attempt an ordinary external lookup for it.
+fn looks_like_package_self_reference(file_path: &Path, specifier: &str) -> bool {
+    // Scoped packages (`@scope/pkg`) occupy two path components
+    // (`node_modules/@scope/pkg`); unscoped ones occupy one.
+    let package_segments: Vec<&str> = if let Some(rest) = specifier.strip_prefix('@') {
+        match rest.find('/') {
+            Some(slash_idx) => {
+                let after_scope = &rest[slash_idx + 1..];
+                let pkg_segment = after_scope.split('/').next().unwrap_or(after_scope);
+                vec![&specifier[..slash_idx + 1], pkg_segment]
+            }
+            None => return false,
+        }
+    } else {
+        match specifier.split('/').next() {
+            Some(name) if !name.is_empty() => vec![name],
+            _ => return false,
+        }
+    };
+    let mut components = file_path.components();
+    while let Some(component) = components.next() {
+        if component.as_os_str() != "node_modules" {
+            continue;
+        }
+        let mut candidate = components.clone();
+        let matches = package_segments.iter().all(|segment| {
+            candidate
+                .next()
+                .is_some_and(|next| next.as_os_str() == std::ffi::OsStr::new(*segment))
+        });
+        if matches {
+            return true;
+        }
+    }
+    false
+}
+
 pub(super) fn prepare_source_resolution_setup(
     input: SourceResolutionSetupInput<'_>,
 ) -> SourceResolutionSetup {
@@ -72,7 +113,6 @@ pub(super) fn prepare_source_resolution_setup(
                         &file.arena,
                         file.source_file,
                         file.is_external_module,
-                        options.skip_lib_check,
                     )
                 })
                 .collect()
@@ -90,7 +130,6 @@ pub(super) fn prepare_source_resolution_setup(
                         &file.arena,
                         file.source_file,
                         file.is_external_module,
-                        options.skip_lib_check,
                     )
                 })
                 .collect()
@@ -474,6 +513,90 @@ pub(super) fn prepare_source_resolution_setup(
         }
     }
 
+    // Side-channel resolution for `.d.ts`-hosted bare augmentation names,
+    // scoped to the TS2665 (untyped-augmentation-target) check only. See
+    // `collect_declaration_file_augmentation_targets_for_untyped_check` for
+    // why this stays out of the `cached_module_specifiers` pipeline above:
+    // that pipeline feeds cross-file symbol merging, and folding a `.d.ts`
+    // host's bare augmentation name into it surfaced unrelated resolution
+    // bugs. This pass only ever writes `untyped_module_paths`. Skipped when
+    // `skip_lib_check` discards this file's diagnostics outright — resolving
+    // here would be pure overhead across every vendored `.d.ts` in
+    // `node_modules`.
+    if !options.skip_lib_check {
+        let _span = tracing::info_span!("declaration_file_untyped_augmentation_check").entered();
+        for (file_idx, file) in program.files.iter().enumerate() {
+            if !file.is_external_module || !is_declaration_file(&file.file_name) {
+                continue;
+            }
+            let file_path = Path::new(&file.file_name);
+            for (specifier, specifier_node) in
+                collect_declaration_file_augmentation_targets_for_untyped_check(
+                    &file.arena,
+                    file.source_file,
+                )
+            {
+                // A package augmenting its own name from inside itself is a
+                // Node self-reference (`ModuleResolver::try_self_reference_v2`
+                // in `crates/tsz-core/src/module_resolver/self_reference.rs`),
+                // a distinct resolution algorithm from an ordinary external
+                // lookup. Its `exports` condition selection does not yet match
+                // tsc's for every conditions shape — confirmed independently
+                // of this change (reproduces the same way for a `.ts` host
+                // augmenting its own package, a path this pass never
+                // touches) — so resolving it here risks a false TS2665 from
+                // picking the wrong condition rather than the untyped-target
+                // case this check exists for. Skip it; self-reference TS2665
+                // stays a known gap for a follow-up on the resolver itself.
+                if looks_like_package_self_reference(file_path, &specifier) {
+                    continue;
+                }
+                let span = if let Some(spec_node) = file.arena.get(specifier_node) {
+                    Span::new(spec_node.pos, spec_node.end)
+                } else {
+                    Span::new(0, 0)
+                };
+                let request = tsz::module_resolver::ModuleLookupRequest {
+                    specifier: &specifier,
+                    containing_file: file_path,
+                    specifier_span: span,
+                    import_kind: tsz::module_resolver::ImportKind::EsmImport,
+                    resolution_mode_override: None,
+                    no_implicit_any: options.checker.no_implicit_any,
+                    implied_classic_resolution: options.checker.implied_classic_resolution,
+                };
+                let result = module_resolver.lookup(
+                    &request,
+                    |spec, fp| {
+                        resolve_module_specifier(
+                            fp,
+                            spec,
+                            options,
+                            base_dir,
+                            resolution_cache,
+                            program_paths,
+                        )
+                    },
+                    |spec| {
+                        if let Some(idx) = skeleton_for_ambient {
+                            return idx.is_ambient_module(spec);
+                        }
+                        program.declared_modules.contains(spec)
+                            || program.shorthand_ambient_modules.contains(spec)
+                    },
+                    Some(program_paths),
+                );
+                let outcome = result.classify();
+                if let Some(ref untyped_path) = outcome.untyped_module_path {
+                    untyped_module_paths.insert(
+                        (file_idx, specifier),
+                        untyped_path.to_string_lossy().into_owned(),
+                    );
+                }
+            }
+        }
+    }
+
     // Pre-bucket resolved-module specifiers by file_idx so each per-file
     // checker can look up its own set in O(1) instead of scanning the
     // entire cross-file `resolved_module_specifiers` map. The previous
@@ -663,5 +786,48 @@ pub(super) fn prepare_source_resolution_setup(
         resolved_modules_per_file,
         per_file_ts7016_diagnostics,
         file_is_esm_map,
+    }
+}
+
+#[cfg(test)]
+mod self_reference_guard_tests {
+    use super::looks_like_package_self_reference;
+    use std::path::Path;
+
+    #[test]
+    fn relative_unscoped_package_matches_its_own_augmentation() {
+        let p = Path::new("node_modules/acorn-walk/dist/walk.d.ts");
+        assert!(looks_like_package_self_reference(p, "acorn-walk"));
+    }
+
+    #[test]
+    fn absolute_unscoped_package_matches_its_own_augmentation() {
+        let p = Path::new("/tmp/x/node_modules/acorn-walk/dist/walk.d.ts");
+        assert!(looks_like_package_self_reference(p, "acorn-walk"));
+    }
+
+    #[test]
+    fn scoped_package_matches_its_own_augmentation() {
+        let p = Path::new("node_modules/@scope/pkg/dist/index.d.ts");
+        assert!(looks_like_package_self_reference(p, "@scope/pkg"));
+        assert!(looks_like_package_self_reference(p, "@scope/pkg/subpath"));
+    }
+
+    #[test]
+    fn different_package_is_not_a_self_reference() {
+        let p = Path::new("node_modules/gearbox/index.d.ts");
+        assert!(!looks_like_package_self_reference(p, "acorn-walk"));
+    }
+
+    #[test]
+    fn scoped_specifier_does_not_match_unscoped_directory() {
+        let p = Path::new("node_modules/pkg/index.d.ts");
+        assert!(!looks_like_package_self_reference(p, "@scope/pkg"));
+    }
+
+    #[test]
+    fn file_outside_node_modules_is_never_a_self_reference() {
+        let p = Path::new("src/augment.d.ts");
+        assert!(!looks_like_package_self_reference(p, "acorn-walk"));
     }
 }

--- a/crates/tsz-cli/src/driver/source_resolution_setup.rs
+++ b/crates/tsz-cli/src/driver/source_resolution_setup.rs
@@ -72,6 +72,7 @@ pub(super) fn prepare_source_resolution_setup(
                         &file.arena,
                         file.source_file,
                         file.is_external_module,
+                        options.skip_lib_check,
                     )
                 })
                 .collect()
@@ -89,6 +90,7 @@ pub(super) fn prepare_source_resolution_setup(
                         &file.arena,
                         file.source_file,
                         file.is_external_module,
+                        options.skip_lib_check,
                     )
                 })
                 .collect()

--- a/crates/tsz-cli/tests/tsc_compat_tests_parts/part_02.rs
+++ b/crates/tsz-cli/tests/tsc_compat_tests_parts/part_02.rs
@@ -1629,3 +1629,100 @@ fn augmenting_local_relative_js_file_does_not_report_ts2665() {
         "a local JS program input is not an untyped module, got:\n{output}"
     );
 }
+
+#[test]
+fn augmenting_untyped_package_from_declaration_file_host_reports_ts2665() {
+    // The augmentation lives in a `.d.ts` host rather than a `.ts` one. tsc
+    // validates a `.d.ts`-hosted augmentation exactly as a `.ts`-hosted one, but
+    // source discovery previously never even collected a bare (non-relative)
+    // augmentation target for a declaration-file host, so the specifier never
+    // reached the driver's resolution pass and TS2665 stayed silent.
+    let temp = TempDir::new("augment_untyped_dts_host_ts2665").expect("temp dir");
+    write_file(
+        &temp.path.join("node_modules/gearbox/index.js"),
+        "module.exports = {};\n",
+    );
+    write_file(
+        &temp.path.join("node_modules/gearbox/package.json"),
+        "{ \"name\": \"gearbox\", \"version\": \"1.0.0\", \"main\": \"index.js\" }\n",
+    );
+    write_file(
+        &temp.path.join("a.d.ts"),
+        "declare module \"gearbox\" { export const g: number; }\nexport {};\n",
+    );
+    write_file(
+        &temp.path.join("tsconfig.json"),
+        "{ \"compilerOptions\": { \"module\": \"commonjs\", \"strict\": false, \"types\": [] }, \"files\": [\"a.d.ts\"] }\n",
+    );
+
+    let Some((code, output)) = run_tsz_with_exit_code(
+        &temp.path,
+        &["-p", ".", "--noEmit", "--pretty", "false"],
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert_ne!(
+        code, 0,
+        "augmenting an untyped module from a .d.ts host should fail:\n{output}"
+    );
+    assert!(
+        output.contains("error TS2665: Invalid module name in augmentation. Module 'gearbox' resolves to an untyped module at "),
+        "expected TS2665 for a .d.ts-hosted augmentation, got:\n{output}"
+    );
+    assert!(
+        output.contains("node_modules/gearbox/index.js', which cannot be augmented."),
+        "TS2665 must name the resolved JS file, got:\n{output}"
+    );
+    // TS2664 stays gated on `!is_declaration_file()`, so it must not appear
+    // here even though the file is now a driver-side resolution target.
+    assert!(
+        !output.contains("error TS2664"),
+        "TS2664 never fires for a .d.ts host, got:\n{output}"
+    );
+}
+
+#[test]
+fn augmenting_untyped_package_from_declaration_file_host_under_skip_lib_check_reports_nothing() {
+    // Adjacent negative control on the same shape: with `skipLibCheck` on, the
+    // checker still visits the `.d.ts` file to populate shared caches but
+    // discards every diagnostic it produces (`check_file.rs`), so resolving the
+    // augmentation target for this file is pure overhead — the driver's
+    // specifier-collection gate skips it, mirroring the pre-existing skip for
+    // `.d.ts` hosts.
+    let temp = TempDir::new("augment_untyped_dts_host_skip_lib_check").expect("temp dir");
+    write_file(
+        &temp.path.join("node_modules/gearbox/index.js"),
+        "module.exports = {};\n",
+    );
+    write_file(
+        &temp.path.join("node_modules/gearbox/package.json"),
+        "{ \"name\": \"gearbox\", \"version\": \"1.0.0\", \"main\": \"index.js\" }\n",
+    );
+    write_file(
+        &temp.path.join("a.d.ts"),
+        "declare module \"gearbox\" { export const g: number; }\nexport {};\n",
+    );
+    write_file(
+        &temp.path.join("tsconfig.json"),
+        "{ \"compilerOptions\": { \"module\": \"commonjs\", \"strict\": false, \"skipLibCheck\": true, \"types\": [] }, \"files\": [\"a.d.ts\"] }\n",
+    );
+
+    let Some((code, output)) = run_tsz_with_exit_code(
+        &temp.path,
+        &["-p", ".", "--noEmit", "--pretty", "false"],
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert_eq!(
+        code, 0,
+        "skipLibCheck discards this .d.ts host's diagnostics, so it must stay clean:\n{output}"
+    );
+    assert!(
+        !output.contains("TS2665"),
+        "skipLibCheck must suppress the augmentation diagnostic, got:\n{output}"
+    );
+}


### PR DESCRIPTION
Structural rule: when a `declare module "foo" { ... }` augmentation names a
specifier that resolves to an untyped JavaScript module, tsc reports TS2665
regardless of whether the augmentation lives in a `.ts` or a `.d.ts` host
file. tsz's checker-side TS2665 arm
(`crates/tsz-checker/src/declarations/declarations_module.rs`, added in
#16227/#16248) already reflects that — it is deliberately *not* gated on
`is_declaration_file()`. But driver-side specifier collection
(`crates/tsz-cli/src/driver/resolution/discovery.rs`) still gated non-relative
ambient-module-declaration names on `is_external_module && !is_declaration_file`,
so a bare augmentation target named from a `.d.ts` host never entered
`cached_module_specifiers`, never reached `prepare_source_resolution_setup`'s
resolution pass, and `untyped_module_path_for` had nothing to look up. This is
the remaining slice of #16221 that #16248 left open (that PR fixed the
`allowJs` source-discovery half).

## Why two commits

The first commit widened the existing `cached_module_specifiers` gate to also
cover `.d.ts` hosts. `compare-to-parent.sh` caught **2 real regressions**:
joining a `.d.ts`-hosted bare augmentation name into that shared pipeline
feeds `resolved_module_specifiers`/`resolved_module_paths`, which drive
cross-file symbol merging (ambient-module precedence, `module_exists`,
augmentation-body checks) — and reaching a `.d.ts` host there for the first
time surfaced two unrelated, pre-existing bugs:

- `crossFileOverloadModifierConsistency.ts`: a `.d.ts`-hosted augmentation of
  a real cross-file `.ts` dependency produced a spurious TS2300 duplicate
  identifier instead of merging as an overload.
- `selfNameModuleAugmentation.ts`: a package augmenting its own name from
  inside itself (Node self-reference,
  `crates/tsz-core/src/module_resolver/self_reference.rs`) picked the wrong
  `exports` condition and produced a spurious TS2665. Confirmed this is not
  new: the identical shape reproduces the same way for a `.ts`-hosted
  self-referencing augmentation (hand-built repro, not in the corpus), a path
  the fix never touches — it's a pre-existing gap in
  `try_self_reference_v2`'s condition selection that the `.d.ts` fix merely
  made reachable for the first time.

The second commit reverts the shared-pipeline widening and adds a side
channel instead. `collect_declaration_file_augmentation_targets_for_untyped_check`
(`discovery.rs`) collects a `.d.ts` host's bare augmentation names without
touching the general pipeline; `prepare_source_resolution_setup`
(`crates/tsz-cli/src/driver/source_resolution_setup.rs`) resolves each one
through the same `ModuleResolver`, but only ever reads
`outcome.untyped_module_path` off the result — it never writes
`resolved_module_specifiers`/`resolved_module_paths`/error maps, so it cannot
feed symbol merging and cannot reproduce the `crossFile...` regression. A
`looks_like_package_self_reference` guard additionally skips specifiers that
look like a package referencing its own name (`node_modules/PKG/...`
resolving `PKG`), routing around the self-reference condition-selection bug
entirely rather than risk a wrong answer from it — a real fix for that bug is
out of scope here and left as a follow-up on the resolver itself (noted on
the coordination board, issue #15994).

Skipped entirely when `skip_lib_check` is on: `check_file.rs` still visits a
`.d.ts` file to populate shared caches under `skip_lib_check`, but discards
every diagnostic it produces, so resolving the augmentation target there
would be pure overhead across every vendored `.d.ts` in `node_modules`.

## Adjacent-case matrix

| host | skipLibCheck | tsc | tsz before | tsz after |
| --- | --- | --- | --- | --- |
| `.ts` | off | TS2665 | TS2665 | TS2665 (unchanged) |
| `.ts`, `allowJs` | off | TS2665 | TS2665 (#16248) | TS2665 (unchanged) |
| `.d.ts` | off | TS2665 | silent | **TS2665 (fixed)** |
| `.d.ts` | on | silent | silent | silent (unchanged, new negative control) |
| `.d.ts`, cross-file `.ts` dependency (`crossFileOverloadModifierConsistency.ts`) | off | silent (legal overload merge) | silent | silent (regressed to TS2300 mid-PR, fixed) |
| `.d.ts`, self-referencing own package (`selfNameModuleAugmentation.ts`) | off | silent | silent | silent (regressed to TS2665 mid-PR, fixed) |
| typed target (`.d.ts` present) | off | silent | silent | silent (unchanged) |
| script file (no import/export) | off | silent | silent | silent (unchanged) |

New tests:
- `augmenting_untyped_package_from_declaration_file_host_reports_ts2665` and
  `..._under_skip_lib_check_reports_nothing` in
  `crates/tsz-cli/tests/tsc_compat_tests_parts/part_02.rs`.
- `collect_declaration_file_augmentation_targets_for_untyped_check` unit
  coverage in `crates/tsz-cli/src/driver/resolution_tests/source_discovery.rs`.
- `looks_like_package_self_reference` unit coverage (unscoped/scoped
  packages, non-matches) in `crates/tsz-cli/src/driver/source_resolution_setup.rs`.

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-cli source_discovery`: 28/28 passed.
- `cargo nextest run -p tsz-cli self_reference_guard_tests`: 6/6 passed.
- Manual regression sweep against `.target/debug/tsz` (`--noEmit --pretty
  false`) covering: `.d.ts` host + untyped target (TS2665, the target row),
  `.d.ts` host + `skipLibCheck` (clean), typed target (clean), script file
  (clean), `allowJs` discovery path (still TS2665), self-name `.d.ts`
  (clean), cross-file overload `.d.ts` (clean) — all as expected.
- `scripts/conformance/compare-to-parent.sh 9434198` (full two-sided
  comparison against `origin/main`): **1 newly passing**
  (`untypedModuleImport_withAugmentation2.ts`, the original target row from
  #16221), **0 newly failing**, 0 fingerprint changes. `12585` candidates,
  `12043` runnable both sides.
- Pre-commit `clippy` gate (`-p tsz-cli`) passed on both commits; CI
  `clippy` + `arch-size` both green at head `d29f3ea`.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: Peridot