### PR TITLE
fix(checker): TS1165 was never wired up for ambient class method computed names

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -647,16 +647,37 @@ impl<'a> CheckerState<'a> {
             );
         }
 
+        // TS1165: Computed property name in an ambient context must refer to
+        // an expression whose type is a literal type or a 'unique symbol'
+        // type. `is_declared` already folds in every ambient spelling
+        // (`declare class`, `declare abstract class`, a class nested in
+        // `declare namespace`/`declare module`, and an implicitly-ambient
+        // `.d.ts` file), so no separate `is_declaration_file()` check is
+        // needed here. This is the method-signature sibling of TS1166 (class
+        // property declarations, checked unconditionally regardless of
+        // ambient-ness in `check_property_declaration_with_request`), TS1169
+        // (interfaces), and TS1170 (type literals) — verified against the
+        // pinned `typescript@7.0.2` oracle that accessors are exempt from
+        // this arm entirely, so it applies to method declarations only.
+        let in_declared_class = self
+            .ctx
+            .enclosing_class
+            .as_ref()
+            .is_some_and(|c| c.is_declared);
+        if in_declared_class {
+            use crate::diagnostics::diagnostic_messages;
+            self.check_computed_property_requires_literal(
+                method.name,
+                diagnostic_messages::A_COMPUTED_PROPERTY_NAME_IN_AN_AMBIENT_CONTEXT_MUST_REFER_TO_AN_EXPRESSION_WHOSE,
+                diagnostic_codes::A_COMPUTED_PROPERTY_NAME_IN_AN_AMBIENT_CONTEXT_MUST_REFER_TO_AN_EXPRESSION_WHOSE,
+            );
+        }
+
         // Error 1183: An implementation cannot be declared in ambient contexts
         // Check if we're in a declared class and the method has a body,
         // OR if the method itself has a `declare` modifier and a body.
         // TSC anchors the error at the body node (the `{`), not the whole member.
         if method.body.is_some() {
-            let in_declared_class = self
-                .ctx
-                .enclosing_class
-                .as_ref()
-                .is_some_and(|c| c.is_declared);
             let method_has_declare = self.has_declare_modifier(&method.modifiers);
             if in_declared_class || method_has_declare {
                 self.error_at_node(

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -775,6 +775,8 @@ mod top_level_await_boundary_tests;
 mod truthiness_promise_coercion_tests;
 #[path = "tests/ts1101_with_in_strict_mode_tests.rs"]
 mod ts1101_with_in_strict_mode_tests;
+#[path = "tests/ts1165_ambient_class_method_computed_name_tests.rs"]
+mod ts1165_ambient_class_method_computed_name_tests;
 #[path = "tests/ts1170_computed_property_syntactic_form_tests.rs"]
 mod ts1170_computed_property_syntactic_form_tests;
 #[path = "tests/ts1361_ambient_computed_property_name_tests.rs"]

--- a/crates/tsz-checker/src/tests/ts1165_ambient_class_method_computed_name_tests.rs
+++ b/crates/tsz-checker/src/tests/ts1165_ambient_class_method_computed_name_tests.rs
@@ -1,0 +1,181 @@
+//! Regression tests for TS1165 — a computed method name in an ambient class
+//! must refer to an expression whose type is a literal type or a 'unique
+//! symbol' type.
+//!
+//! TS1165 is the method-signature sibling of TS1166 (class property
+//! declarations), TS1169 (interfaces), and TS1170 (type literals): all four
+//! route through the shared `check_computed_property_requires_literal`
+//! helper, but TS1165 previously had no call site anywhere in the checker.
+//! Verified against the pinned `typescript@7.0.2` oracle: unlike TS1166,
+//! this arm only fires inside an ambient context (never for a non-ambient
+//! class method) and only for method declarations (never for accessors).
+
+use crate::test_utils::check_source_diagnostics;
+
+fn diag_codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+#[test]
+fn ts1165_declare_class_method() {
+    let codes = diag_codes(
+        r#"
+declare const x: string;
+declare class C {
+    [`a${x}`](): void;
+}
+"#,
+    );
+    assert!(
+        codes.contains(&1165),
+        "Expected TS1165 for non-literal computed method name in a declare class. Got: {codes:?}"
+    );
+}
+
+#[test]
+fn ts1165_declare_abstract_class_method() {
+    let codes = diag_codes(
+        r#"
+declare const x: string;
+declare abstract class C {
+    [`a${x}`](): void;
+}
+"#,
+    );
+    assert!(
+        codes.contains(&1165),
+        "Expected TS1165 for non-literal computed method name in a declare abstract class. Got: {codes:?}"
+    );
+}
+
+#[test]
+fn ts1165_declare_class_static_method() {
+    let codes = diag_codes(
+        r#"
+declare const x: string;
+declare class C {
+    static [`a${x}`](): void;
+}
+"#,
+    );
+    assert!(
+        codes.contains(&1165),
+        "Expected TS1165 for non-literal computed static method name in a declare class. Got: {codes:?}"
+    );
+}
+
+#[test]
+fn ts1165_class_nested_in_declare_namespace() {
+    let codes = diag_codes(
+        r#"
+declare const x: string;
+declare namespace N {
+    class C {
+        [`a${x}`](): void;
+    }
+}
+"#,
+    );
+    assert!(
+        codes.contains(&1165),
+        "Expected TS1165 for a class method nested inside a declare namespace. Got: {codes:?}"
+    );
+}
+
+/// Anti-hardcoding cover: renamed binder and container names must not change
+/// whether the check fires.
+#[test]
+fn ts1165_renamed_binder_and_container() {
+    let codes = diag_codes(
+        r#"
+declare const suffix: string;
+declare class Widget {
+    [`prefix_${suffix}`](): void;
+}
+"#,
+    );
+    assert!(
+        codes.contains(&1165),
+        "TS1165 must fire regardless of identifier spelling. Got: {codes:?}"
+    );
+}
+
+/// Negative control: the identical shape in a non-ambient (concrete) class
+/// must NOT trigger TS1165 — the check is ambient-only, unlike TS1166.
+#[test]
+fn ts1165_absent_for_non_ambient_class_method() {
+    let codes = diag_codes(
+        r#"
+declare const x: string;
+class C {
+    [`a${x}`](): void {}
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&1165),
+        "TS1165 must not fire for a non-ambient class method. Got: {codes:?}"
+    );
+}
+
+/// Negative control: accessors are exempt from this arm entirely, even
+/// inside an ambient class (verified against the tsc@7.0.2 oracle).
+#[test]
+fn ts1165_absent_for_ambient_class_accessor() {
+    let codes = diag_codes(
+        r#"
+declare const x: string;
+declare class C {
+    get [`a${x}`](): string;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&1165),
+        "TS1165 must not fire for an ambient class accessor. Got: {codes:?}"
+    );
+}
+
+/// Negative control: a `unique symbol`-typed operand is a valid ambient
+/// computed name and must not trigger TS1165.
+#[test]
+fn ts1165_absent_for_unique_symbol_operand() {
+    let codes = diag_codes(
+        r#"
+declare const sym: unique symbol;
+declare class C {
+    [sym](): void;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&1165),
+        "TS1165 must not fire for a unique-symbol-typed computed method name. Got: {codes:?}"
+    );
+}
+
+/// Fallback/adjacent case: the property-member arm in the same ambient class
+/// must keep reporting TS1166, not TS1165 — the two arms are distinct and
+/// this fix must not blur them.
+#[test]
+fn ts1166_still_used_for_ambient_class_property() {
+    let codes = diag_codes(
+        r#"
+declare const x: string;
+declare class C {
+    [`a${x}`]: number;
+}
+"#,
+    );
+    assert!(
+        codes.contains(&1166),
+        "Expected TS1166 for the property arm in a declare class. Got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&1165),
+        "TS1165 must not fire for a property declaration. Got: {codes:?}"
+    );
+}


### PR DESCRIPTION
Structural rule: when a computed method name in an ambient class (`declare class`, `declare abstract class`, a class nested in `declare namespace`/`declare module`, or a class in an implicitly-ambient `.d.ts` file) is not a literal or `unique symbol`-typed expression, `tsc` reports TS1165 through its ambient-context computed-property grammar arm; tsz never did, through the checker's `check_method_declaration_with_request`.

TS1165's diagnostic message/code already existed in the generated table but had **zero call sites anywhere in the checker** (confirmed by grep). The three sibling arms — TS1166 (class property declarations), TS1169 (interfaces), TS1170 (type literals) — all route through the shared `check_computed_property_requires_literal` helper (`crates/tsz-checker/src/checkers/property_checker.rs`); only the ambient-class-method arm was never wired up. Fix is a single gated call to that existing helper in `crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs`, reusing `enclosing_class.is_declared` (already computed by `is_ambient_class_declaration`, which folds in all four ambient spellings) — no new mechanism, no other layer touched.

Verified against the pinned `typescript@7.0.2` oracle (not the vendored/canary baseline) before implementing:
- Fires: bodyless method in `declare class` / `declare abstract class` / a class nested in `declare namespace` / an implicitly-ambient `.d.ts` file, on both instance and `static` methods.
- Does NOT fire: the same shape in a non-ambient class, on accessors (`get`/`set`) even inside an ambient class, or when the computed expression is `unique symbol`-typed.
- TS1166 (property arm) is unaffected and keeps firing on ambient class properties, unconditional on ambient-ness as before.

Closes #16253.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib ts1165_ambient_class_method_computed_name_tests`: 9/9 new tests pass (positive: declare class/abstract class/static/namespace-nested/renamed-binder; negative: non-ambient class, accessor, unique-symbol operand, sibling TS1166 property arm).
- `cargo test -p tsz-checker --lib -- computed_property ambient_signature ts1170 ts1361 ts7010 ts7011`: 88/88 adjacent tests pass, no regressions.
- `cargo fmt -p tsz-checker -- --check`: clean.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings`: clean.
- `scripts/conformance/compare-to-parent.sh origin/main`: 0 newly passing / 0 newly failing (12043 runnable, 11475 passed both sides) — expected, no corpus fixture exercises this narrow ambient-computed-method-name shape; the oracle-pinned targeted matrix above is the primary evidence for this family, per the standing "zero conformance movement is expected" pattern for this class of false-negative fix.
- Pre-commit hook (fmt + clippy + arch-guard): passed locally.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: Zeolite

---
_Generated by [Claude Code](https://claude.ai/code/session_012Lbky1p9fPCVxvaZ99sVEP)_