### PR TITLE
fix(parser): a ComputedPropertyName node's end stops at ']', not the token after it

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -226,6 +226,10 @@ mod state_declaration_tests;
 mod declaration_node_end_tests;
 
 #[cfg(test)]
+#[path = "../../tests/computed_property_name_end_position_tests.rs"]
+mod computed_property_name_end_position_tests;
+
+#[cfg(test)]
 #[path = "../../tests/decorator_tests.rs"]
 mod decorator_tests;
 

--- a/crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs
@@ -1116,8 +1116,10 @@ impl ParserState {
                 if bare_static_block_await_name && self.is_token(SyntaxKind::CloseBracketToken) {
                     self.error_expression_expected();
                 }
-                self.parse_expected(SyntaxKind::CloseBracketToken);
+                // Capture the `]` token's own end before `parse_expected` advances past it —
+                // `token_end()` after the call would report the end of the *next* token instead.
                 let end_pos = self.token_end();
+                self.parse_expected(SyntaxKind::CloseBracketToken);
 
                 self.arena.add_computed_property(
                     syntax_kind_ext::COMPUTED_PROPERTY_NAME,

--- a/crates/tsz-parser/tests/computed_property_name_end_position_tests.rs
+++ b/crates/tsz-parser/tests/computed_property_name_end_position_tests.rs
@@ -1,0 +1,80 @@
+//! Regression tests for #16251: `ComputedPropertyName`'s `end` used to be read via
+//! `token_end()` *after* `parse_expected(CloseBracketToken)` had already advanced the
+//! scanner past `]`, so the node's span over-extended into whatever token followed the
+//! `]` instead of stopping at it. `parse_property_name` is shared by class members,
+//! object literal members, and interface/type-literal members, so one fix covers all
+//! of them — these cases exercise that shared path from each container, plus a
+//! non-trivial (call) expression form, not just an identifier chain.
+
+use crate::parser::syntax_kind_ext;
+use crate::parser::test_fixture::{assert_span, assert_span_on, parse_source};
+
+#[test]
+fn class_method_computed_name_ends_before_the_parameter_list() {
+    // Before the fix, the node's span extended through the following `(`.
+    let source = "class Foo { [Symbol.iterator]() {} }";
+    assert_span(
+        source,
+        syntax_kind_ext::COMPUTED_PROPERTY_NAME,
+        "[Symbol.iterator]",
+    );
+}
+
+#[test]
+fn class_bodyless_method_no_substitution_template_name_ends_before_the_parameter_list() {
+    // The exact shape from #16251's own repro: `declare class C { get [`abc`](); }`.
+    let source = "declare class C { get [`abc`](); }";
+    assert_span(source, syntax_kind_ext::COMPUTED_PROPERTY_NAME, "[`abc`]");
+}
+
+#[test]
+fn object_literal_computed_name_ends_before_the_colon() {
+    let source = "const o = { [`abc`]: 1 };";
+    assert_span(source, syntax_kind_ext::COMPUTED_PROPERTY_NAME, "[`abc`]");
+}
+
+#[test]
+fn interface_computed_name_with_call_expression_ends_before_the_colon() {
+    // A non-trivial expression form (call), not just an identifier/template.
+    let source = "interface I { [foo()]: string; }";
+    assert_span(source, syntax_kind_ext::COMPUTED_PROPERTY_NAME, "[foo()]");
+}
+
+#[test]
+fn type_literal_computed_name_ends_before_the_semicolon() {
+    let source = "type T = { [Symbol.iterator]: string };";
+    assert_span(
+        source,
+        syntax_kind_ext::COMPUTED_PROPERTY_NAME,
+        "[Symbol.iterator]",
+    );
+}
+
+#[test]
+fn two_computed_names_in_the_same_container_each_end_correctly() {
+    // Guards against a fix that only works for the first occurrence, or that
+    // leaks state between sibling members.
+    let source = "class Foo { [a](): void {} [b](): void {} }";
+    let (parser, _) = parse_source(source);
+    for expected in ["[a]", "[b]"] {
+        assert_span_on(
+            &parser,
+            source,
+            syntax_kind_ext::COMPUTED_PROPERTY_NAME,
+            expected,
+        );
+    }
+}
+
+#[test]
+fn missing_close_bracket_recovery_does_not_regress() {
+    // Error-recovery path (no `]`): `parse_expected` does not advance the scanner when
+    // the expected token is absent, so this shape was never affected by the bug, but it
+    // is worth pinning so a future change to the fix doesn't silently regress it.
+    let source = "const o = { [a: 1 };";
+    let (parser, _) = parse_source(source);
+    assert!(
+        !parser.get_diagnostics().is_empty(),
+        "missing ']' should still be reported"
+    );
+}


### PR DESCRIPTION
Closes #16251.

`parse_property_name`'s `OpenBracketToken` arm (`crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs:1119-1120`, shared by class members, object-literal members, and interface/type-literal members) captured `end_pos` via `self.token_end()` **after** calling `self.parse_expected(SyntaxKind::CloseBracketToken)`. `parse_expected` advances the scanner past the matched token on success, so `token_end()` afterward returns the end of the *next* token, not of `]` itself. Every `ComputedPropertyName` node's span therefore over-extended into whatever token followed the `]` — e.g. for `` get [`abc`](); ``, the node's text sliced out by `node_text` came back as `` [`abc`]( `` (trailing `(` included).

## Structural rule

When the parser finishes a syntactic construct via `parse_expected(kind)` followed by `self.token_end()`, tsc's equivalent (`finishNode` reading `scanner.getStartPos()`) captures the end of the just-consumed token; tsz's `token_end()` called after the advance instead reads the *following* token's end. The fix captures `token_end()` while the scanner is still positioned on `]`, before `parse_expected` consumes it.

## Owner layer

Parser only (`crates/tsz-parser`). No checker, solver, or emitter change. The only currently-known consumer of the wrong span is `node_text`, reached via the JSDoc/computed-name display whitelist-miss fallback (#16250, still open) — this fix corrects the underlying span regardless of which consumer eventually reads it.

## Adjacent-case matrix (new `crates/tsz-parser/tests/computed_property_name_end_position_tests.rs`, wired into `crates/tsz-parser/src/parser/mod.rs`)

| shape | container | before | after |
| --- | --- | --- | --- |
| `[Symbol.iterator]()` | class method | span included `(` | span is exactly `[Symbol.iterator]` |
| `` get [`abc`](); `` | ambient class bodyless method (the issue's own repro) | span included `(` | span is exactly `` [`abc`] `` |
| `` [`abc`]: 1 `` | object literal | span included `:` | span is exactly `` [`abc`] `` |
| `[foo()]: string` | interface (non-trivial call expression) | span included `:` | span is exactly `[foo()]` |
| `[Symbol.iterator]: string` | type literal | span included `}` | span is exactly `[Symbol.iterator]` |
| two computed names in one container (`[a]`, `[b]`) | class | both wrong | both correct, independently |
| missing `]` (error recovery) | object literal | unaffected (parse_expected doesn't advance on mismatch) | unaffected (negative control) |

Verified the fix is actually load-bearing by reverting it locally and re-running the new suite: 6/7 failed (the 7th is the error-recovery negative control, which was never affected).

## Follow-up filed, not fixed here

Grep found 8 more `parse_expected(CloseBraceToken); token_end()` sites with the identical shape across `ClassDeclaration`/`ClassExpression`/`JsxExpression`/`JsxSpreadAttribute`/`ClassStaticBlockDeclaration`/`ImportAttributes`. Each needs its own regression test and verification pass (much broader consumers — LSP document-symbol ranges, source maps, emit node bounds) rather than a drive-by batch edit here. Filed as #16259 with exact file:line locations.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-parser --lib` — 1513 passed, 0 failed (full lib suite, includes the 7 new tests).
- `cargo fmt -p tsz-parser -- --check` — clean.
- `cargo clippy -p tsz-parser --all-targets -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py` — passed.
- `scripts/conformance/compare-to-parent.sh` (base `4712e01`, branch head): base failing=583, branch failing=583, **0 newly passing, 0 newly failing, 0 fingerprint changes**.
- Local pre-commit hook (fmt + clippy + arch guard) — passed.
- Not run locally: fourslash (`scripts/fourslash/run-fourslash.sh`) — this container's `TypeScript` submodule checkout has diverged/local changes and the script refuses to force-reset it (per CLAUDE.md's "prefer not to checkout the full TypeScript submodule unless the task needs it," did not force it). The nightly lane covers this; flagged here because #16251 itself called out LSP ranges as the likeliest place a dependent has silently calibrated against the wrong (old) span. cargo-nextest is not installed in this container; used `cargo test` instead.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_013Tp7XNYWxSRqpjTUZ9jRt7)_