### PR TITLE
test(cli): pin five adjacent .d.ts-hosted TS2665 rows against the 7.0.2 oracle

### DIFF
--- a/crates/tsz-cli/tests/tsc_compat_tests_parts/part_02.rs
+++ b/crates/tsz-cli/tests/tsc_compat_tests_parts/part_02.rs
@@ -1726,3 +1726,214 @@ fn augmenting_untyped_package_from_declaration_file_host_under_skip_lib_check_re
         "skipLibCheck must suppress the augmentation diagnostic, got:\n{output}"
     );
 }
+
+#[test]
+fn augmenting_untyped_subpath_from_declaration_file_host_reports_ts2665() {
+    // The `.d.ts`-hosted positive again, but the target is a nested subpath
+    // rather than the package entry point. #16260's side-channel collector
+    // resolves the augmentation name through the module resolver rather than
+    // through the shared `cached_module_specifiers` pipeline, so a subpath —
+    // which reaches the resolver by a different branch than a bare package
+    // name — needs its own row. The message must carry the subpath's own
+    // resolved file, not the package's `main`.
+    //
+    // Renamed binder relative to the sibling `.d.ts` rows: the rule keys on the
+    // resolution extension and `maxNodeModuleJsDepth`, never on the name.
+    let temp = TempDir::new("augment_untyped_dts_host_subpath").expect("temp dir");
+    write_file(
+        &temp.path.join("node_modules/anvil/lib/deep.js"),
+        "module.exports = {};\n",
+    );
+    write_file(
+        &temp.path.join("node_modules/anvil/package.json"),
+        "{ \"name\": \"anvil\", \"version\": \"1.0.0\", \"main\": \"index.js\" }\n",
+    );
+    write_file(
+        &temp.path.join("a.d.ts"),
+        "declare module \"anvil/lib/deep\" { export const d: string; }\nexport {};\n",
+    );
+    write_file(
+        &temp.path.join("tsconfig.json"),
+        "{ \"compilerOptions\": { \"module\": \"commonjs\", \"strict\": false, \"types\": [] }, \"files\": [\"a.d.ts\"] }\n",
+    );
+
+    let Some((code, output)) = run_tsz_with_exit_code(
+        &temp.path,
+        &["-p", ".", "--noEmit", "--pretty", "false"],
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert_ne!(
+        code, 0,
+        "augmenting an untyped subpath from a .d.ts host should fail:\n{output}"
+    );
+    assert!(
+        output.contains("error TS2665: Invalid module name in augmentation. Module 'anvil/lib/deep' resolves to an untyped module at "),
+        "expected TS2665 naming the subpath specifier, got:\n{output}"
+    );
+    assert!(
+        output.contains("node_modules/anvil/lib/deep.js', which cannot be augmented."),
+        "TS2665 must name the resolved subpath file, not the package entry, got:\n{output}"
+    );
+}
+
+#[test]
+fn augmenting_typed_package_from_declaration_file_host_reports_nothing() {
+    // Negative control: augmenting a *typed* package from a `.d.ts` host is the
+    // ordinary, legal shape — it is what every `@types` override in the wild
+    // looks like. The side-channel collector resolves this specifier too, so
+    // this row is what proves resolving it does not by itself make the site
+    // noisy; only an untyped JS resolution target may.
+    let temp = TempDir::new("augment_typed_dts_host_clean").expect("temp dir");
+    write_file(
+        &temp.path.join("node_modules/gadget/index.js"),
+        "module.exports = {};\n",
+    );
+    write_file(
+        &temp.path.join("node_modules/gadget/index.d.ts"),
+        "export declare const g: string;\n",
+    );
+    write_file(
+        &temp.path.join("node_modules/gadget/package.json"),
+        "{ \"name\": \"gadget\", \"version\": \"1.0.0\", \"main\": \"index.js\", \"types\": \"index.d.ts\" }\n",
+    );
+    write_file(
+        &temp.path.join("a.d.ts"),
+        "declare module \"gadget\" { export const q: number; }\nexport {};\n",
+    );
+    write_file(
+        &temp.path.join("tsconfig.json"),
+        "{ \"compilerOptions\": { \"module\": \"commonjs\", \"strict\": false, \"types\": [] }, \"files\": [\"a.d.ts\"] }\n",
+    );
+
+    let Some((code, output)) = run_tsz_with_exit_code(
+        &temp.path,
+        &["-p", ".", "--noEmit", "--pretty", "false"],
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert_eq!(code, 0, "augmenting a typed module is legal, got:\n{output}");
+    assert!(
+        output.trim().is_empty(),
+        "a typed .d.ts-hosted augmentation is clean, got:\n{output}"
+    );
+}
+
+#[test]
+fn augmenting_missing_module_from_declaration_file_host_reports_nothing() {
+    // Negative control for the arm the new resolution feeds *past*: a target
+    // that resolves to nothing at all stays silent in a `.d.ts` host, because
+    // TS2664 keeps its own `!is_declaration_file()` guard. This is the row that
+    // would catch the side channel leaking into general-purpose resolution and
+    // reviving TS2664 where tsc has none.
+    let temp = TempDir::new("augment_missing_dts_host_clean").expect("temp dir");
+    write_file(
+        &temp.path.join("a.d.ts"),
+        "declare module \"nowhere\" { export const n: number; }\nexport {};\n",
+    );
+    write_file(
+        &temp.path.join("tsconfig.json"),
+        "{ \"compilerOptions\": { \"module\": \"commonjs\", \"strict\": false, \"types\": [] }, \"files\": [\"a.d.ts\"] }\n",
+    );
+
+    let Some((code, output)) = run_tsz_with_exit_code(
+        &temp.path,
+        &["-p", ".", "--noEmit", "--pretty", "false"],
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert_eq!(
+        code, 0,
+        "an unresolvable augmentation target is silent in a .d.ts host, got:\n{output}"
+    );
+    assert!(
+        output.trim().is_empty(),
+        "neither TS2664 nor TS2665 applies here, got:\n{output}"
+    );
+}
+
+#[test]
+fn pattern_and_bare_ambient_names_in_declaration_file_host_report_nothing() {
+    // Negative control for the two unresolvable shapes a real `.d.ts` is most
+    // likely to contain — a pattern ambient (`*.scss`) and a bare virtual
+    // specifier — both of which the new collector now hands to the resolver on
+    // every declaration file in the program. Both are legal and must stay
+    // silent, in tsz as in tsc.
+    let temp = TempDir::new("ambient_patterns_dts_host_clean").expect("temp dir");
+    write_file(
+        &temp.path.join("a.d.ts"),
+        "declare module \"*.scss\" {}\ndeclare module \"virtual:thing\" {}\nexport {};\n",
+    );
+    write_file(
+        &temp.path.join("tsconfig.json"),
+        "{ \"compilerOptions\": { \"module\": \"commonjs\", \"strict\": false, \"types\": [] }, \"files\": [\"a.d.ts\"] }\n",
+    );
+
+    let Some((code, output)) = run_tsz_with_exit_code(
+        &temp.path,
+        &["-p", ".", "--noEmit", "--pretty", "false"],
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert_eq!(
+        code, 0,
+        "pattern and virtual ambient names are legal in a .d.ts, got:\n{output}"
+    );
+    assert!(
+        output.trim().is_empty(),
+        "no augmentation diagnostic applies to these, got:\n{output}"
+    );
+}
+
+#[test]
+fn script_declaration_file_declaring_an_untyped_package_reports_nothing() {
+    // The half of the gate that must NOT move: a *script* `.d.ts` (no top-level
+    // import or export) declares a genuine ambient external module rather than
+    // augmenting one, so tsc stays silent even though the same name resolves to
+    // an untyped `node_modules` JS file. Distinguishing this row from the
+    // positive one above is exactly the external-module test — if the
+    // declaration-file collector ever drops it, this row turns into a false
+    // positive on the single most common shape in `@types` packages.
+    let temp = TempDir::new("ambient_script_dts_clean").expect("temp dir");
+    write_file(
+        &temp.path.join("node_modules/lathe/index.js"),
+        "module.exports = {};\n",
+    );
+    write_file(
+        &temp.path.join("node_modules/lathe/package.json"),
+        "{ \"name\": \"lathe\", \"version\": \"1.0.0\", \"main\": \"index.js\" }\n",
+    );
+    write_file(
+        &temp.path.join("a.d.ts"),
+        "declare module \"lathe\" { export const l: number; }\n",
+    );
+    write_file(
+        &temp.path.join("tsconfig.json"),
+        "{ \"compilerOptions\": { \"module\": \"commonjs\", \"strict\": false, \"types\": [] }, \"files\": [\"a.d.ts\"] }\n",
+    );
+
+    let Some((code, output)) = run_tsz_with_exit_code(
+        &temp.path,
+        &["-p", ".", "--noEmit", "--pretty", "false"],
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert_eq!(
+        code, 0,
+        "a script .d.ts declares an ambient module, not an augmentation, got:\n{output}"
+    );
+    assert!(
+        !output.contains("TS2665"),
+        "an ambient declaration is not an augmentation, got:\n{output}"
+    );
+}


### PR DESCRIPTION
**Rescoped.** This PR opened as an implementation fix for the same gap #16260 fixed, from a session that started before #16260 landed. #16260's approach is the better one and this branch has been reset onto it; what remains here is **tests only, no behaviour change**.

### Why the original implementation was dropped, in its own words

Both PRs found the same root cause — a `.d.ts`-hosted augmentation's bare target never reaches the driver's resolution pass, so `untyped_module_paths` stays empty and the checker's TS2665 arm (correctly not gated on `is_declaration_file`) has nothing to consult. The fix shapes differ:

- **This branch, dropped:** delete `&& !source.is_declaration_file` from `AmbientModuleDeclarationSpecifierPolicy::Check`, so the name joins the shared `cached_module_specifiers` pipeline.
- **#16260, landed:** a dedicated `collect_declaration_file_augmentation_targets_for_untyped_check` side channel that resolves the same specifier but only ever populates `untyped_module_paths`.

#16260's own comment records that it tried the shared-pipeline route first and backed off because joining that pipeline feeds `resolved_module_specifiers`/`resolved_module_paths`, which drive cross-file symbol merging — and doing so surfaced real, unrelated resolution bugs (self-name `exports` condition selection, cross-file overload-merge duplicate identifiers). That is a measurement this session did not have; the 10-row matrix here was clean, so the shared-pipeline route looked safe from the outside. It is not. Superseding was the right call and no part of that diff is retained.

### What is left, and why it is worth landing

#16260 pinned two rows: the package entry point, and its `skipLibCheck` control. Five more shapes in the family were unpinned. All five are verified **byte-identical to the pinned `typescript@7.0.2` oracle running on #16260's own implementation** at `951a3ed` — measured after the reset, not carried over from the earlier build.

| row | shape | tsc | tsz @ `951a3ed` |
| --- | --- | --- | --- |
| new | `.d.ts` host, **nested subpath** target | TS2665 naming `anvil/lib/deep.js` | identical |
| new | `.d.ts` host augmenting a **typed** package | clean | clean |
| new | `.d.ts` host, target resolves to **nothing** | clean | clean |
| new | `.d.ts` host, **pattern** ambient `*.scss` + bare `virtual:thing` | clean | clean |
| new | **script** `.d.ts` naming an untyped package | clean | clean |
| (#16260) | `.d.ts` host, package entry | TS2665 | identical |
| (#16260) | same, under `skipLibCheck` | clean | clean |
| (existing) | `.ts` package entry / subpath / `allowJs` / local relative `.js` / `*.css` pattern | — | all identical |

The subpath row is a genuine second positive, not a restatement: a subpath reaches the resolver by a different branch than a bare package name, and the message has to carry its own resolved file rather than the package's `main`. The four negatives are the ones that guard #16260's boundary — in particular the **script `.d.ts`** row, which is the single most common shape in `@types` packages and turns into a user-visible false positive the moment the external-module half of the gate slips, and the **unresolvable-target** row, which would catch the side channel leaking into general-purpose resolution and reviving TS2664 where tsc has none.

## Goal
Goal: hold

## Verification

- `cargo test -p tsz-cli --test tsc_compat_tests -- augment ambient script_declaration pattern_and_bare` — **15/15 pass**, the whole augmentation family, 5 new here and 10 pre-existing (including both of #16260's).
- Each of the 5 new rows additionally diffed verbatim against `node .../typescript@7.0.2/lib/tsc.js` on the identical project — byte-identical on all 5, and on the 7 pre-existing rows re-run alongside them.
- `cargo fmt` clean; the `pre-commit` hook's `Verifying: -p tsz-cli` clippy leg passed on this tree.
- No source change, so no conformance/emit exposure: `git diff --stat` against `main` touches exactly one file, `crates/tsz-cli/tests/tsc_compat_tests_parts/part_02.rs` (+204). That file is 1939 lines, under the 2000-line shard cap.

Container caveats worth stating rather than hiding, both recorded on the board: `cargo-nextest` is not installed on a fresh cloud seat, so the suites above ran under `cargo test`; and `scripts/node_modules` is absent, so the repo's `tsc_parity_*` tests compare against PATH `tsc` (TypeScript **6.0.2**, vs the pinned **7.0.2**) and fail for that reason on a clean tree — none of them are in this family and none are touched here. The oracle used for every number above is an explicitly installed `typescript@7.0.2`, not PATH `tsc`.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Sodalite