### PR TITLE
fix(checker): a require-aliased whole-module re-export is nameable

### DIFF
--- a/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs
+++ b/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs
@@ -775,6 +775,32 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
+        // A JS module can also re-export ANOTHER module's namespace wholesale
+        // (`const ns = require("./cls"); module.exports = ns;`), rather than
+        // exporting a class/function it declares itself. tsc's declaration
+        // emit prints this as a single alias, `import ns = require("./cls");
+        // export = ns;`, so a member reached only by drilling into that
+        // namespace (e.g. `Foo`) needs no name of its own — the whole
+        // namespace is nameable via the require path. `direct_export_type`
+        // is registered in `namespace_module_names` exactly when it denotes
+        // such a wholesale `typeof import(...)` re-export; a structural
+        // object literal (`module.exports = { foo: X }`) is never
+        // registered there, so this stays scoped to the re-export shape and
+        // does not suppress TS9006 for a literal that must name each member.
+        if self.ctx.current_file_idx as u32 != file_idx
+            && self
+                .resolve_js_export_surface(self.ctx.current_file_idx)
+                .direct_export_type
+                .is_some_and(|ty| self.ctx.namespace_module_names.contains_key(&ty))
+            && self.is_commonjs_direct_export_target(
+                self.ctx.current_file_idx as u32,
+                resolved_sym_id,
+                target_sym_id,
+            )
+        {
+            return None;
+        }
+
         let locally_nameable = self
             .ctx
             .binder

--- a/crates/tsz-cli/tests/driver_tests_parts/part_14.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_14.rs
@@ -468,3 +468,125 @@ module.exports = Host;
 // referenced symbol IS (or aliases to) the target's own
 // `JsExportSurface::direct_export_type`, which a function call's return
 // value is not.
+
+fn ts9006_require_aliased_reexport_config() -> &'static str {
+    r#"{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "target": "es2015",
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "module": "commonjs"
+  },
+  "files": ["cls.js", "cjs2.js", "includeAll.js"]
+}"#
+}
+
+/// `module.exports = ns;` where `ns = require(...)` re-exports another
+/// module's namespace WHOLESALE, distinct from #16254's direct
+/// class/function export target: the private member (`Foo`) is reached only
+/// by drilling into `ns`'s namespace type, not by `ns` itself matching
+/// `Foo`'s symbol. tsc still prints this as a single alias
+/// (`import ns = require("./cls"); export = ns;`) and never needs to name
+/// `Foo` on its own, so no TS9006 should fire on any member reachable
+/// through the re-exported namespace.
+#[test]
+fn commonjs_require_aliased_whole_module_reexport_is_nameable() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = temp.path.as_path();
+
+    write_file(&base.join("tsconfig.json"), ts9006_require_aliased_reexport_config());
+    write_file(&base.join("cls.js"), "export class Foo {}\n");
+    write_file(
+        &base.join("cjs2.js"),
+        r#"const ns = require("./cls");
+module.exports = ns;
+"#,
+    );
+    write_file(&base.join("includeAll.js"), "import \"./cjs2\";\n");
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+    let ts9006: Vec<_> = result.diagnostics.iter().filter(|d| d.code == 9006).collect();
+    assert!(
+        ts9006.is_empty(),
+        "module.exports = ns (require-aliased whole-module re-export) makes every member of \
+         ns's namespace nameable via `import ns = require(...)`; no TS9006 should fire, got: {:#?}",
+        result.diagnostics
+    );
+}
+
+/// Same shape with every binder renamed, to rule out a name-string match.
+#[test]
+fn commonjs_require_aliased_whole_module_reexport_is_nameable_renamed_binders() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = temp.path.as_path();
+
+    write_file(&base.join("tsconfig.json"), ts9006_require_aliased_reexport_config());
+    write_file(&base.join("cls.js"), "export class Gadget {}\n");
+    write_file(
+        &base.join("cjs2.js"),
+        r#"const alias = require("./cls");
+module.exports = alias;
+"#,
+    );
+    write_file(&base.join("includeAll.js"), "import \"./cjs2\";\n");
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+    let ts9006: Vec<_> = result.diagnostics.iter().filter(|d| d.code == 9006).collect();
+    assert!(
+        ts9006.is_empty(),
+        "renamed-binder variant must also suppress TS9006, got: {:#?}",
+        result.diagnostics
+    );
+}
+
+/// Negative control: a *structural* re-export (`module.exports = { ns };`,
+/// the object literal wraps the require-aliased namespace rather than
+/// assigning it wholesale) is a DIFFERENT, still-open mechanism (tsc prints
+/// it as `declare const _exports: { ns: typeof ns }; export = _exports;
+/// import ns = require("./cls");` — a distinct alias-hoisting shape this fix
+/// does not implement). This pins the current, pre-existing behavior so a
+/// future widening of the `namespace_module_names` gate cannot silently
+/// start masking real TS9006s on structural (non-wholesale) exports without
+/// this test forcing a conscious update.
+#[test]
+fn commonjs_object_literal_wrapped_namespace_reexport_still_reports_ts9006() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = temp.path.as_path();
+
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "target": "es2015",
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "module": "commonjs"
+  },
+  "files": ["cls.js", "cjs.js", "includeAll.js"]
+}"#,
+    );
+    write_file(&base.join("cls.js"), "export class Foo {}\n");
+    write_file(
+        &base.join("cjs.js"),
+        r#"const ns = require("./cls");
+module.exports = { ns };
+"#,
+    );
+    write_file(&base.join("includeAll.js"), "import \"./cjs\";\n");
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+    let ts9006: Vec<_> = result.diagnostics.iter().filter(|d| d.code == 9006).collect();
+    assert!(
+        !ts9006.is_empty(),
+        "structural (object-literal-wrapped) re-export is a distinct, still-open mechanism; \
+         expected TS9006 to still fire, got: {:#?}",
+        result.diagnostics
+    );
+}


### PR DESCRIPTION
Follow-up to #16254, which fixed `module.exports = class Obj {}` (a direct class/function export target declared in the SAME file as the `module.exports` assignment). This PR covers the sibling shape #16254 itself flagged as a distinct, still-open gap: `const ns = require("./cls"); module.exports = ns;` — a whole-module re-export of ANOTHER file's namespace, where the private member (`Foo`, declared in `cls.js`) is reached only by drilling into `ns`'s namespace type, not by `ns` itself matching `Foo`'s symbol.

## Structural rule

When a JS file re-exports another required module's namespace wholesale (`const ns = require("./mod"); module.exports = ns;`), tsc's declaration emit prints this as a single alias — `import ns = require("./mod"); export = ns;` — and never needs to name any individual member of that namespace (e.g. a class declared in `./mod`) on its own. tsz's `is_commonjs_direct_export_target` (`crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs`) only checked the referenced symbol's OWNER file (`cls.js`, which has no `module.exports = X` of its own — it uses plain ES `export class Foo {}`), never the file actually performing the require-aliased re-export (`cjs2.js`). Falling through past that check, tsz reported TS9006 on `Foo` as though it were unreachable, even though the whole namespace containing it is nameable via the require path.

## Owner layer

`crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs` only. `private_external_module_nameability_info` now also tries `is_commonjs_direct_export_target` against `self.ctx.current_file_idx`'s own `direct_export_type` (the file doing the `module.exports = ns` re-export), **gated** on that type being registered in `ctx.namespace_module_names` — the existing map that tags a `TypeId` as denoting a wholesale `typeof import(...)` re-export. A structural object literal (`module.exports = { foo: PrivateClass }`) is never registered there, so the gate keeps this scoped to the genuine whole-namespace re-export shape and does not touch cases that must still name each member individually.

## Evidence

Reduced from the corpus fixture `TypeScript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsExportForms.ts` (`cls.js: export class Foo {}`; `cjs2.js: const ns = require("./cls"); module.exports = ns;`), verified against a freshly-installed pinned `typescript@7.0.2` oracle:

| | tsc 7.0.2 | tsz before | tsz after |
| --- | --- | --- | --- |
| diagnostics | 0 | `TS9006` on `cjs2.js` | 0 |

The same fixture's `cjs.js` shape (`module.exports = { ns };` — the require-alias wrapped in an object literal rather than assigned wholesale) is a **distinct, still-open mechanism** this PR does not fix: tsc still avoids naming `Foo` there too (`declare const _exports: { ns: typeof ns }; export = _exports; import ns = require("./cls");`), but via a different alias-hoisting rule tsz does not yet implement. Verified this is pre-existing and unaffected by this change (fails identically before and after, on `origin/main` and on this branch) and pinned it as a negative control (`commonjs_object_literal_wrapped_namespace_reexport_still_reports_ts9006`) so a future widening of the `namespace_module_names` gate can't silently start masking it.

## Adjacent-case matrix (new tests, `crates/tsz-cli/tests/driver_tests_parts/part_14.rs`)

- `commonjs_require_aliased_whole_module_reexport_is_nameable` — the corpus shape directly.
- `commonjs_require_aliased_whole_module_reexport_is_nameable_renamed_binders` — same shape, every identifier renamed.
- `commonjs_object_literal_wrapped_namespace_reexport_still_reports_ts9006` — negative control pinning the distinct, still-open `cjs.js` gap (must NOT be silently fixed by future changes to this gate).
- Pre-existing `commonjs_whole_module_class_export_is_nameable_*` (#16254) and `declaration_emit_raw_typeof_import_text_still_reports_ts9006` (call-result private symbol, not a whole-module re-export) both still pass, confirming no interaction with the direct-export-target path.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-cli --lib -- driver_tests::commonjs_require_aliased_whole_module_reexport_is_nameable driver_tests::commonjs_require_aliased_whole_module_reexport_is_nameable_renamed_binders driver_tests::commonjs_object_literal_wrapped_namespace_reexport_still_reports_ts9006 driver_tests::commonjs_whole_module_class_export_is_nameable_from_a_requiring_consumer driver_tests::commonjs_whole_module_class_export_is_nameable_renamed_binders driver_tests::declaration_emit_raw_typeof_import_text_still_reports_ts9006` — 6/6 pass.
- `cargo test -p tsz-cli --lib` (full suite) — 1629 passed / 18 failed. Verified the same 5 driver-level failures (`cross_file_class_namespace_merge_value_keeps_call_signature_in_import_cycle`, `default_lib_validation_normalizes_cross_arena_method_members_after_global_merge`, `compile_incremental_reports_ts5033_when_tsbuildinfo_is_not_writable`, `cross_file_dependent_operand_aliases_accept_scalars_and_literal_arrays`, `declaration_emit_reports_ts7056_for_private_import_type_alias`) reproduce identically on `origin/main` with this diff stashed out — pre-existing/environmental, not caused by this change. The remaining 13 are `tsc_parity_*`/`tsc_compat_*` tests that shell out to a real `tsc` binary absent from this container.
- `cargo fmt -p tsz-checker -p tsz-cli -- --check` — clean.
- `cargo clippy -p tsz-checker -p tsz-cli --all-targets -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py` — `Architecture guardrails passed.`
- `scripts/conformance/compare-to-parent.sh origin/main` (branch `61a16e0` vs base `1c0e732`): both sides 11475/12043 passing (95.3%) — **0 newly passing, 0 newly failing, 0 fingerprint changes**. Expected: `jsDeclarationsExportForms.ts` still fails overall because of the distinct `cjs.js` gap documented above, so the row's fingerprint doesn't move even though the specific `cjs2.js` false positive this PR fixes is gone.
- Not run: emit / fourslash — this change touches only a diagnostic-suppression decision in a non-emitter checker path; not exercised.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_012mPTNY63H8zc2JDfpimE3Y)_