### PR TITLE
fix(parser): 9 sibling node kinds' end stops at '}', not the token after it

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -230,6 +230,10 @@ mod declaration_node_end_tests;
 mod computed_property_name_end_position_tests;
 
 #[cfg(test)]
+#[path = "../../tests/sibling_close_brace_end_position_tests.rs"]
+mod sibling_close_brace_end_position_tests;
+
+#[cfg(test)]
 #[path = "../../tests/decorator_tests.rs"]
 mod decorator_tests;
 

--- a/crates/tsz-parser/src/parser/state_declarations_exports.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_exports.rs
@@ -1827,9 +1827,12 @@ impl ParserState {
 
         let clauses = self.parse_switch_case_clauses();
 
+        // The CaseBlock's own end is the '}' token's end, captured here before
+        // `parse_expected` advances past it — `token_end()` after the call would
+        // report the end of the *next* token instead. The SwitchStatement itself
+        // ends at the same position: nothing in the grammar follows the CaseBlock.
         let case_block_end = self.token_end();
         self.parse_expected(SyntaxKind::CloseBraceToken);
-        let end_pos = self.token_end();
 
         let case_block = self.arena.add_block(
             syntax_kind_ext::CASE_BLOCK,
@@ -1844,7 +1847,7 @@ impl ParserState {
         self.arena.add_switch(
             syntax_kind_ext::SWITCH_STATEMENT,
             start_pos,
-            end_pos,
+            case_block_end,
             SwitchData {
                 expression,
                 case_block,

--- a/crates/tsz-parser/src/parser/state_declarations_modules.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_modules.rs
@@ -704,8 +704,10 @@ impl ParserState {
             }
         }
 
-        self.parse_expected(SyntaxKind::CloseBraceToken);
+        // Capture the '}' token's own end before `parse_expected` advances past it —
+        // `token_end()` after the call would report the end of the *next* token instead.
         let end_pos = self.token_end();
+        self.parse_expected(SyntaxKind::CloseBraceToken);
 
         let node_list = Self::make_node_list(elements);
         self.arena.add_import_attributes(

--- a/crates/tsz-parser/src/parser/state_statements_class.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class.rs
@@ -325,9 +325,10 @@ impl ParserState {
         self.context_flags |= CONTEXT_FLAG_IN_CLASS;
         let members = self.parse_class_members();
         self.context_flags = class_saved_flags;
-        self.parse_expected(SyntaxKind::CloseBraceToken);
-
+        // Capture the '}' token's own end before `parse_expected` advances past it —
+        // `token_end()` after the call would report the end of the *next* token instead.
         let end_pos = self.token_end();
+        self.parse_expected(SyntaxKind::CloseBraceToken);
 
         self.arena.add_class(
             syntax_kind_ext::CLASS_EXPRESSION,

--- a/crates/tsz-parser/src/parser/state_statements_class_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class_declarations.rs
@@ -213,9 +213,10 @@ impl ParserState {
         self.context_flags |= CONTEXT_FLAG_IN_CLASS;
         let members = self.parse_class_members();
         self.context_flags = class_saved_flags;
-        self.parse_expected(SyntaxKind::CloseBraceToken);
-
+        // Capture the '}' token's own end before `parse_expected` advances past it —
+        // `token_end()` after the call would report the end of the *next* token instead.
         let end_pos = self.token_end();
+        self.parse_expected(SyntaxKind::CloseBraceToken);
         self.arena.add_class(
             syntax_kind_ext::CLASS_DECLARATION,
             start_pos,
@@ -731,9 +732,10 @@ impl ParserState {
         self.context_flags |= CONTEXT_FLAG_IN_CLASS;
         let members = self.parse_class_members();
         self.context_flags = class_saved_flags;
-        self.parse_expected(SyntaxKind::CloseBraceToken);
-
+        // Capture the '}' token's own end before `parse_expected` advances past it —
+        // `token_end()` after the call would report the end of the *next* token instead.
         let end_pos = self.token_end();
+        self.parse_expected(SyntaxKind::CloseBraceToken);
 
         // Create a modifiers list from decorators
         // In TypeScript, decorators are part of the modifiers
@@ -791,9 +793,10 @@ impl ParserState {
         self.context_flags |= CONTEXT_FLAG_IN_CLASS;
         let members = self.parse_class_members();
         self.context_flags = class_saved_flags;
-        self.parse_expected(SyntaxKind::CloseBraceToken);
-
+        // Capture the '}' token's own end before `parse_expected` advances past it —
+        // `token_end()` after the call would report the end of the *next* token instead.
         let end_pos = self.token_end();
+        self.parse_expected(SyntaxKind::CloseBraceToken);
 
         // Combine decorators with abstract modifier
         let modifiers = if let Some(dec_list) = decorators {

--- a/crates/tsz-parser/src/parser/state_statements_class_member_properties.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class_member_properties.rs
@@ -552,9 +552,10 @@ impl ParserState {
         self.context_flags |= CONTEXT_FLAG_STATIC_BLOCK;
         let statements = self.parse_statements();
         self.context_flags = saved_flags;
-        self.parse_expected(SyntaxKind::CloseBraceToken);
-
+        // Capture the '}' token's own end before `parse_expected` advances past it —
+        // `token_end()` after the call would report the end of the *next* token instead.
         let end_pos = self.token_end();
+        self.parse_expected(SyntaxKind::CloseBraceToken);
 
         self.arena.add_block(
             syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION,

--- a/crates/tsz-parser/src/parser/state_types_jsx_elements.rs
+++ b/crates/tsz-parser/src/parser/state_types_jsx_elements.rs
@@ -1152,9 +1152,10 @@ impl ParserState {
         let expression = self.parse_expression();
         self.in_jsx_attribute_initializer_element = was_in_initializer;
         self.context_flags = saved_flags;
-        self.parse_expected(SyntaxKind::CloseBraceToken);
-
+        // Capture the '}' token's own end before `parse_expected` advances past it —
+        // `token_end()` after the call would report the end of the *next* token instead.
         let end_pos = self.token_end();
+        self.parse_expected(SyntaxKind::CloseBraceToken);
         self.arena.add_jsx_spread_attribute(
             syntax_kind_ext::JSX_SPREAD_ATTRIBUTE,
             start_pos,
@@ -1208,9 +1209,10 @@ impl ParserState {
             expr
         };
 
-        self.parse_expected(SyntaxKind::CloseBraceToken);
-
+        // Capture the '}' token's own end before `parse_expected` advances past it —
+        // `token_end()` after the call would report the end of the *next* token instead.
         let end_pos = self.token_end();
+        self.parse_expected(SyntaxKind::CloseBraceToken);
         self.arena.add_jsx_expression(
             syntax_kind_ext::JSX_EXPRESSION,
             start_pos,

--- a/crates/tsz-parser/tests/sibling_close_brace_end_position_tests.rs
+++ b/crates/tsz-parser/tests/sibling_close_brace_end_position_tests.rs
@@ -1,0 +1,153 @@
+//! Regression tests for #16259: 9 sibling sites shared #16251/#16262's bug shape —
+//! `self.parse_expected(SyntaxKind::CloseBraceToken)` advances the scanner past `}`
+//! on success, so a `self.token_end()` call *after* it reports the end of the
+//! *next* token instead of `}`'s own end. Every node here over-extended its span
+//! into whatever token followed its closing brace.
+//!
+//! Each case is a single-parse-path site (no branching around the `parse_expected`
+//! call), so the fix is the same mechanical move as #16262: capture `token_end()`
+//! while the current token is still `}`, before `parse_expected` consumes it. The
+//! four branching `ClassDeclaration` paths found during this sweep (base
+//! `parse_class_declaration`, `parse_class_declaration_with_modifiers`,
+//! `parse_declare_class`, `parse_declare_abstract_class`) are NOT covered here —
+//! they need per-branch restructuring and are tracked separately.
+
+use crate::parser::syntax_kind_ext;
+use crate::parser::test_fixture::{assert_span, assert_span_on, parse_source_named};
+
+#[test]
+fn jsx_spread_attribute_ends_before_the_next_attribute() {
+    // Before the fix, the span extended through the following identifier.
+    // JSX requires a `.tsx`/`.jsx` file name to parse `<...>` as JSX.
+    let source = "const x = <F {...a} b=\"1\" />;";
+    let (parser, _) = parse_source_named("test.tsx", source);
+    assert_span_on(
+        &parser,
+        source,
+        syntax_kind_ext::JSX_SPREAD_ATTRIBUTE,
+        "{...a}",
+    );
+}
+
+#[test]
+fn jsx_expression_attribute_initializer_ends_before_the_next_attribute() {
+    let source = "const x = <F a={x} b=\"1\" />;";
+    let (parser, _) = parse_source_named("test.tsx", source);
+    assert_span_on(&parser, source, syntax_kind_ext::JSX_EXPRESSION, "{x}");
+}
+
+#[test]
+fn class_expression_ends_before_the_trailing_variable_declarator() {
+    let source = "const C = class { m() {} }, y = 1;";
+    assert_span(
+        source,
+        syntax_kind_ext::CLASS_EXPRESSION,
+        "class { m() {} }",
+    );
+}
+
+#[test]
+fn abstract_class_declaration_ends_before_the_next_statement() {
+    let source = "abstract class C { m(): void; } let y = 1;";
+    assert_span(
+        source,
+        syntax_kind_ext::CLASS_DECLARATION,
+        "abstract class C { m(): void; }",
+    );
+}
+
+#[test]
+fn decorated_class_declaration_ends_before_the_next_statement() {
+    let source = "@dec class C { m() {} } let y = 1;";
+    assert_span(
+        source,
+        syntax_kind_ext::CLASS_DECLARATION,
+        "@dec class C { m() {} }",
+    );
+}
+
+#[test]
+fn decorated_abstract_class_declaration_ends_before_the_next_statement() {
+    let source = "@dec abstract class C { m(): void; } let y = 1;";
+    assert_span(
+        source,
+        syntax_kind_ext::CLASS_DECLARATION,
+        "@dec abstract class C { m(): void; }",
+    );
+}
+
+#[test]
+fn class_static_block_ends_before_the_next_member() {
+    let source = "class C { static { x; } m() {} }";
+    assert_span(
+        source,
+        syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION,
+        "static { x; }",
+    );
+}
+
+#[test]
+fn import_attributes_end_before_the_semicolon() {
+    let source = "import x from \"a\" with { type: \"json\" };";
+    assert_span(
+        source,
+        syntax_kind_ext::IMPORT_ATTRIBUTES,
+        "with { type: \"json\" }",
+    );
+}
+
+#[test]
+fn switch_statement_ends_before_the_next_statement() {
+    // Distinct from its CaseBlock child, which already had the correct end
+    // (captured one line earlier in the source); only the outer SwitchStatement
+    // node over-extended.
+    let source = "switch (a) { case 1: break; } let y = 1;";
+    assert_span(
+        source,
+        syntax_kind_ext::SWITCH_STATEMENT,
+        "switch (a) { case 1: break; }",
+    );
+}
+
+#[test]
+fn jsx_spread_attribute_self_closing_tag_ends_before_the_slash() {
+    // A second, independently-verified shape: the trailing token here is `/`
+    // (self-closing), not an identifier. Before the fix this also overshot,
+    // into "{...a} /" — pinning it guards against a fix narrow enough to only
+    // handle an identifier as the next token.
+    let source = "const x = <F {...a} />;";
+    let (parser, _) = parse_source_named("test.tsx", source);
+    assert_span_on(
+        &parser,
+        source,
+        syntax_kind_ext::JSX_SPREAD_ATTRIBUTE,
+        "{...a}",
+    );
+}
+
+#[test]
+fn two_class_static_blocks_each_end_correctly() {
+    // Guards against a fix that only works for the first occurrence.
+    let source = "class C { static { a; } static { b; } }";
+    let (parser, _) = parse_source_named("test.ts", source);
+    for expected in ["static { a; }", "static { b; }"] {
+        let arena = parser.get_arena();
+        let expected_start = source.find(expected).unwrap();
+        let expected_end = expected_start + expected.len();
+        let found = arena.nodes.iter().any(|n| {
+            n.kind == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION
+                && n.pos as usize == expected_start
+                && n.end as usize == expected_end
+        });
+        assert!(
+            found,
+            "no correctly-spanned ClassStaticBlockDeclaration at {expected_start} for {expected:?} in {source:?}: nodes = {:?}",
+            arena
+                .nodes
+                .iter()
+                .filter(|n| n.kind == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION)
+                .map(|n| (n.pos, n.end))
+                .collect::<Vec<_>>()
+        );
+    }
+}


### PR DESCRIPTION
Follow-up to #16251/#16262. Closes #16259 (partially — see #16265 for what's left).

## Structural rule

When a node's `end` is captured via `self.token_end()` **after** a call to
`self.parse_expected(SyntaxKind::CloseBraceToken)` that already advanced the
scanner past `}`, tsz reads the end of the *next* token instead of `}`'s own
end. tsc's equivalent (`finishNode` reading the scanner's position) always
captures a node's end at the point the closing token was consumed, not after
advancing past it. #16251/#16262 fixed this for `ComputedPropertyName`; #16259
found 8 more grep hits sharing the identical shape (a 9th, ambiguous in the
issue, is confirmed below as `SwitchStatement`'s own end).

## What's fixed here — 9 single-parse-path sites, 6 files

Each fix is the same mechanical reorder as #16262: capture `token_end()`
*while the current token is still `}`*, before `parse_expected` consumes it.

| Node | File |
| --- | --- |
| `JsxSpreadAttribute` | `state_types_jsx_elements.rs` |
| `JsxExpression` (attribute initializer) | `state_types_jsx_elements.rs` |
| `ClassExpression` | `state_statements_class.rs` |
| `ClassDeclaration` (abstract, non-decorated: `abstract class C {}`) | `state_statements_class_declarations.rs` |
| `ClassDeclaration` (decorated: `@dec class C {}`) | `state_statements_class_declarations.rs` |
| `ClassDeclaration` (decorated abstract: `@dec abstract class C {}`) | `state_statements_class_declarations.rs` |
| `ClassStaticBlockDeclaration` | `state_statements_class_member_properties.rs` |
| `ImportAttributes` (`import x from "a" with {...}`) | `state_declarations_modules.rs` |
| `SwitchStatement`'s own end (distinct from its `CaseBlock` child, which already captured its end correctly one line earlier) | `state_declarations_exports.rs` |

## Owner layer

Parser only (`crates/tsz-parser`). No checker, solver, or emitter change.

## What's NOT fixed here (filed as #16265)

A broader grep than #16259 used turned up more sites than the issue estimated:

- **4 branching `ClassDeclaration` paths** in the same file
  (`parse_class_declaration`, `parse_class_declaration_with_modifiers`,
  `parse_declare_class`, `parse_declare_abstract_class`) — these include this
  is the **base `class Foo {}` shape**, the most common way a class is written.
  Each has error-recovery branches that don't consume `}` via `parse_expected`
  at all, sharing one post-branch `end_pos` capture with the branch that does —
  fixing these means threading `end_pos` out of each branch individually, not
  a 3-line reorder, so I did not rush it into this PR.
- **4 more grep hits not yet verified as real bugs**
  (`state_declarations_exports.rs:631`, `state_declarations_modules.rs:417`,
  `state_declarations_modules.rs:1099`, `state_types.rs:23`).

## Adjacent-case matrix / regression tests

New file `crates/tsz-parser/tests/sibling_close_brace_end_position_tests.rs`,
11 tests, one per node kind above plus two negative/robustness controls
(two static blocks in the same class each end correctly; a self-closing JSX
tag where the trailing token is `/` rather than an identifier). Verified
load-bearing: reverted the 6 source fixes (`git stash`) and reran — all 11
failed with the exact overshoot span predicted (e.g.
`got [13..21] = "{...a} /", expected [13..19] = "{...a}"`); restored the fixes
and reran — all 11 pass.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-parser --lib` (full suite): **1517 passed, 0 failed** (includes the 11 new tests + the 6 pre-existing #16262 tests, all still green).
- `cargo fmt -p tsz-parser -- --check`: clean.
- `cargo clippy -p tsz-parser --all-targets -- -D warnings`: clean.
- Pre-commit hook (fmt + clippy + arch-guard): passed.
- `scripts/conformance/compare-to-parent.sh HEAD~1`: **launched, running in the background at PR-open time** (two `dist-fast` builds + two corpus snapshots, ~15-20 min). Will post newly-passing/newly-failing counts as a follow-up comment before this should be considered ready to land — per the standing board note, this is a parser AST-shape change and the additive/subtractive corpus effect (if any, likely limited to `node_text` and emit consumers of these specific node spans) needs the two-sided gate, not just the targeted unit suite.
- Not run: emit/fourslash. These node kinds' end positions do feed the emitter's node bounds and LSP document-symbol ranges, but this fix only *narrows* spans that were previously over-extended into a following token — for well-formed programs (no parse errors), the over-extension only ever ate into trivia/whitespace-adjacent token boundaries at best in some emit-observable cases, so it's a plausible but unconfirmed emit-visible change. Will run `./scripts/emit/run.sh --skip-build` before landing given the emit gate's documented zero headroom.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_013b3Yea2rhUyMwD1sRPvi94)_