### PR TITLE
fix(parser): sibling parse_expected(CloseBraceToken)/token_end() sites over-extend node spans

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -230,6 +230,10 @@ mod declaration_node_end_tests;
 mod computed_property_name_end_position_tests;
 
 #[cfg(test)]
+#[path = "../../tests/close_brace_node_end_position_tests.rs"]
+mod close_brace_node_end_position_tests;
+
+#[cfg(test)]
 #[path = "../../tests/decorator_tests.rs"]
 mod decorator_tests;
 

--- a/crates/tsz-parser/src/parser/state_declarations_exports.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_exports.rs
@@ -1827,9 +1827,14 @@ impl ParserState {
 
         let clauses = self.parse_switch_case_clauses();
 
+        // Capture the `}` token's own end before `parse_expected` advances past it —
+        // `token_end()` after the call would report the end of the *next* token instead.
+        // The `SwitchStatement`'s own end is the same position: nothing follows the case
+        // block's `}` inside the switch statement, so reuse `case_block_end` rather than
+        // re-reading the (now advanced) scanner a second time.
         let case_block_end = self.token_end();
         self.parse_expected(SyntaxKind::CloseBraceToken);
-        let end_pos = self.token_end();
+        let end_pos = case_block_end;
 
         let case_block = self.arena.add_block(
             syntax_kind_ext::CASE_BLOCK,

--- a/crates/tsz-parser/src/parser/state_declarations_modules.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_modules.rs
@@ -704,8 +704,10 @@ impl ParserState {
             }
         }
 
-        self.parse_expected(SyntaxKind::CloseBraceToken);
+        // Capture the `}` token's own end before `parse_expected` advances past it —
+        // `token_end()` after the call would report the end of the *next* token instead.
         let end_pos = self.token_end();
+        self.parse_expected(SyntaxKind::CloseBraceToken);
 
         let node_list = Self::make_node_list(elements);
         self.arena.add_import_attributes(

--- a/crates/tsz-parser/src/parser/state_statements_class.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class.rs
@@ -325,9 +325,10 @@ impl ParserState {
         self.context_flags |= CONTEXT_FLAG_IN_CLASS;
         let members = self.parse_class_members();
         self.context_flags = class_saved_flags;
-        self.parse_expected(SyntaxKind::CloseBraceToken);
-
+        // Capture the `}` token's own end before `parse_expected` advances past it —
+        // `token_end()` after the call would report the end of the *next* token instead.
         let end_pos = self.token_end();
+        self.parse_expected(SyntaxKind::CloseBraceToken);
 
         self.arena.add_class(
             syntax_kind_ext::CLASS_EXPRESSION,

--- a/crates/tsz-parser/src/parser/state_statements_class_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class_declarations.rs
@@ -62,32 +62,40 @@ impl ParserState {
             NodeIndex::NONE
         };
 
-        let (type_parameters, heritage_clauses, members) =
+        let (type_parameters, heritage_clauses, members, end_pos) =
             if recover_reserved_class_name_as_statement {
-                (None, None, Self::make_node_list(Vec::new()))
+                (
+                    None,
+                    None,
+                    Self::make_node_list(Vec::new()),
+                    self.token_end(),
+                )
             } else {
                 let type_parameters = self
                     .is_token(SyntaxKind::LessThanToken)
                     .then(|| self.parse_type_parameters());
                 let heritage_clauses = self.parse_heritage_clauses();
                 let has_open_brace = self.parse_expected(SyntaxKind::OpenBraceToken);
-                let members = if !has_open_brace && self.is_token(SyntaxKind::DotToken) {
+                let (members, end_pos) = if !has_open_brace && self.is_token(SyntaxKind::DotToken) {
                     self.next_token();
                     self.non_block_close_brace_statement_errors_remaining =
                         CLASS_DOT_RECOVERY_STRAY_CLOSE_BRACE_COUNT;
-                    Self::make_node_list(Vec::new())
+                    (Self::make_node_list(Vec::new()), self.token_end())
                 } else {
                     let class_saved_flags = self.context_flags;
                     self.context_flags |= CONTEXT_FLAG_IN_CLASS;
                     let members = self.parse_class_members();
                     self.context_flags = class_saved_flags;
+                    // Capture the `}` token's own end before `parse_expected` advances past
+                    // it — `token_end()` after the call would report the end of the *next*
+                    // token instead.
+                    let end_pos = self.token_end();
                     self.parse_expected(SyntaxKind::CloseBraceToken);
-                    members
+                    (members, end_pos)
                 };
-                (type_parameters, heritage_clauses, members)
+                (type_parameters, heritage_clauses, members, end_pos)
             };
 
-        let end_pos = self.token_end();
         self.arena.add_class(
             syntax_kind_ext::CLASS_DECLARATION,
             start_pos,
@@ -213,9 +221,10 @@ impl ParserState {
         self.context_flags |= CONTEXT_FLAG_IN_CLASS;
         let members = self.parse_class_members();
         self.context_flags = class_saved_flags;
-        self.parse_expected(SyntaxKind::CloseBraceToken);
-
+        // Capture the `}` token's own end before `parse_expected` advances past it —
+        // `token_end()` after the call would report the end of the *next* token instead.
         let end_pos = self.token_end();
+        self.parse_expected(SyntaxKind::CloseBraceToken);
         self.arena.add_class(
             syntax_kind_ext::CLASS_DECLARATION,
             start_pos,
@@ -731,9 +740,10 @@ impl ParserState {
         self.context_flags |= CONTEXT_FLAG_IN_CLASS;
         let members = self.parse_class_members();
         self.context_flags = class_saved_flags;
-        self.parse_expected(SyntaxKind::CloseBraceToken);
-
+        // Capture the `}` token's own end before `parse_expected` advances past it —
+        // `token_end()` after the call would report the end of the *next* token instead.
         let end_pos = self.token_end();
+        self.parse_expected(SyntaxKind::CloseBraceToken);
 
         // Create a modifiers list from decorators
         // In TypeScript, decorators are part of the modifiers
@@ -791,9 +801,10 @@ impl ParserState {
         self.context_flags |= CONTEXT_FLAG_IN_CLASS;
         let members = self.parse_class_members();
         self.context_flags = class_saved_flags;
-        self.parse_expected(SyntaxKind::CloseBraceToken);
-
+        // Capture the `}` token's own end before `parse_expected` advances past it —
+        // `token_end()` after the call would report the end of the *next* token instead.
         let end_pos = self.token_end();
+        self.parse_expected(SyntaxKind::CloseBraceToken);
 
         // Combine decorators with abstract modifier
         let modifiers = if let Some(dec_list) = decorators {

--- a/crates/tsz-parser/src/parser/state_statements_class_member_properties.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class_member_properties.rs
@@ -552,9 +552,10 @@ impl ParserState {
         self.context_flags |= CONTEXT_FLAG_STATIC_BLOCK;
         let statements = self.parse_statements();
         self.context_flags = saved_flags;
-        self.parse_expected(SyntaxKind::CloseBraceToken);
-
+        // Capture the `}` token's own end before `parse_expected` advances past it —
+        // `token_end()` after the call would report the end of the *next* token instead.
         let end_pos = self.token_end();
+        self.parse_expected(SyntaxKind::CloseBraceToken);
 
         self.arena.add_block(
             syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION,

--- a/crates/tsz-parser/src/parser/state_types_jsx_elements.rs
+++ b/crates/tsz-parser/src/parser/state_types_jsx_elements.rs
@@ -1152,9 +1152,10 @@ impl ParserState {
         let expression = self.parse_expression();
         self.in_jsx_attribute_initializer_element = was_in_initializer;
         self.context_flags = saved_flags;
-        self.parse_expected(SyntaxKind::CloseBraceToken);
-
+        // Capture the `}` token's own end before `parse_expected` advances past it —
+        // `token_end()` after the call would report the end of the *next* token instead.
         let end_pos = self.token_end();
+        self.parse_expected(SyntaxKind::CloseBraceToken);
         self.arena.add_jsx_spread_attribute(
             syntax_kind_ext::JSX_SPREAD_ATTRIBUTE,
             start_pos,
@@ -1208,9 +1209,10 @@ impl ParserState {
             expr
         };
 
-        self.parse_expected(SyntaxKind::CloseBraceToken);
-
+        // Capture the `}` token's own end before `parse_expected` advances past it —
+        // `token_end()` after the call would report the end of the *next* token instead.
         let end_pos = self.token_end();
+        self.parse_expected(SyntaxKind::CloseBraceToken);
         self.arena.add_jsx_expression(
             syntax_kind_ext::JSX_EXPRESSION,
             start_pos,

--- a/crates/tsz-parser/tests/close_brace_node_end_position_tests.rs
+++ b/crates/tsz-parser/tests/close_brace_node_end_position_tests.rs
@@ -1,0 +1,133 @@
+//! Regression tests for #16259, the sibling family to #16251/#16262: several call sites
+//! captured a node's `end` via `token_end()` *after* calling `parse_expected(CloseBraceToken)`.
+//! `parse_expected` advances the scanner past the matched token on success, so `token_end()`
+//! afterward returns the end of the *next* token, not of the just-consumed `}`. Each site here
+//! is fixed the same way #16251 fixed `ComputedPropertyName`: capture `token_end()` while the
+//! scanner is still positioned on `}`, before `parse_expected` consumes it.
+
+use crate::parser::syntax_kind_ext;
+use crate::parser::test_fixture::{assert_span, assert_span_on, parse_source, parse_source_named};
+
+#[test]
+fn jsx_spread_attribute_ends_before_the_following_attribute() {
+    // Before the fix, the span extended through the following ` b` text. JSX requires a
+    // `.tsx` file name to parse at all.
+    let source = "const x = <div {...a} b />;";
+    let (parser, _) = parse_source_named("test.tsx", source);
+    assert_span_on(
+        &parser,
+        source,
+        syntax_kind_ext::JSX_SPREAD_ATTRIBUTE,
+        "{...a}",
+    );
+}
+
+#[test]
+fn jsx_expression_attribute_initializer_ends_before_the_following_attribute() {
+    let source = "const x = <div a={1} b />;";
+    let (parser, _) = parse_source_named("test.tsx", source);
+    assert_span_on(&parser, source, syntax_kind_ext::JSX_EXPRESSION, "{1}");
+}
+
+#[test]
+fn class_expression_ends_before_the_trailing_semicolon_and_call() {
+    // Before the fix, the span extended through `()` in the IIFE call.
+    let source = "const C = (class { m() {} })();";
+    assert_span(
+        source,
+        syntax_kind_ext::CLASS_EXPRESSION,
+        "class { m() {} }",
+    );
+}
+
+#[test]
+fn class_declaration_ends_before_the_following_statement() {
+    let source = "class Foo { m() {} } const x = 1;";
+    assert_span(
+        source,
+        syntax_kind_ext::CLASS_DECLARATION,
+        "class Foo { m() {} }",
+    );
+}
+
+#[test]
+fn abstract_class_declaration_ends_before_the_following_statement() {
+    let source = "abstract class Foo { m(): void; } const x = 1;";
+    assert_span(
+        source,
+        syntax_kind_ext::CLASS_DECLARATION,
+        "abstract class Foo { m(): void; }",
+    );
+}
+
+#[test]
+fn decorated_abstract_class_declaration_ends_before_the_following_statement() {
+    let source = "@dec abstract class Foo { m(): void; } const x = 1;";
+    assert_span(
+        source,
+        syntax_kind_ext::CLASS_DECLARATION,
+        "@dec abstract class Foo { m(): void; }",
+    );
+}
+
+#[test]
+fn class_static_block_ends_before_the_following_member() {
+    let source = "class Foo { static { a; } m() {} }";
+    assert_span(
+        source,
+        syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION,
+        "static { a; }",
+    );
+}
+
+#[test]
+fn import_attributes_end_before_the_trailing_semicolon() {
+    // The `ImportAttributes` node's own span starts at `with`, not `{`.
+    let source = r#"import x from "x" with { type: "json" };"#;
+    assert_span(
+        source,
+        syntax_kind_ext::IMPORT_ATTRIBUTES,
+        r#"with { type: "json" }"#,
+    );
+}
+
+#[test]
+fn switch_statement_ends_before_the_following_statement() {
+    // Before the fix, the switch statement's own `end` overshot into the following
+    // statement even though the nested `CaseBlock`'s own `end` (a sibling capture in
+    // the same function) was already correct.
+    let source = "switch (a) { case 1: break; } const x = 1;";
+    assert_span(
+        source,
+        syntax_kind_ext::SWITCH_STATEMENT,
+        "switch (a) { case 1: break; }",
+    );
+}
+
+#[test]
+fn two_class_static_blocks_in_the_same_class_each_end_correctly() {
+    // Guards against a fix that only works for the first occurrence.
+    let source = "class Foo { static { a; } static { b; } }";
+    let (parser, _) = parse_source(source);
+    for expected in ["static { a; }", "static { b; }"] {
+        assert_span_on(
+            &parser,
+            source,
+            syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION,
+            expected,
+        );
+    }
+}
+
+#[test]
+fn missing_close_brace_recovery_does_not_regress() {
+    // Error-recovery path (no `}`): `parse_expected` does not advance the scanner when
+    // the expected token is absent, so this shape was never affected by the bug, but it
+    // is worth pinning so a future change to the fix doesn't silently regress it.
+    let source = "class Foo { m() {}";
+    let (parser, _) = parse_source(source);
+    assert!(
+        !parser.get_diagnostics().is_empty(),
+        "missing '}}' should still be reported"
+    );
+}


### PR DESCRIPTION
Closes #16259.

## Structural rule

When the parser finishes a syntactic construct via `self.parse_expected(kind)` followed by `self.token_end()`, tsc's equivalent (`finishNode` reading `scanner.getStartPos()`) captures the end of the just-consumed token; tsz's `token_end()` called *after* the advance instead reads the *following* token's end, because `parse_expected` advances the scanner past the matched token on success. This is the exact mechanism #16251/#16262 fixed for `ComputedPropertyName`; this PR fixes the sibling sites #16259 catalogued for `CloseBraceToken`.

## Owner layer

Parser only (`crates/tsz-parser`). No checker, solver, or emitter change.

## Sites fixed

The 8 sites #16259 named, plus a 9th the issue's own grep missed:

| node | file | shape |
| --- | --- | --- |
| `JsxSpreadAttribute` | `state_types_jsx_elements.rs` | capture moved before `parse_expected` |
| `JsxExpression` | `state_types_jsx_elements.rs` | capture moved before `parse_expected` |
| `ClassExpression` | `state_statements_class.rs` | capture moved before `parse_expected` |
| `ClassDeclaration` (with-modifiers path) | `state_statements_class_declarations.rs` | capture moved before `parse_expected` |
| `ClassDeclaration` (abstract path) | `state_statements_class_declarations.rs` | capture moved before `parse_expected` |
| `ClassDeclaration` (decorator path) | `state_statements_class_declarations.rs` | capture moved before `parse_expected` |
| `ClassStaticBlockDeclaration` | `state_statements_class_member_properties.rs` | capture moved before `parse_expected` |
| `ImportAttributes` | `state_declarations_modules.rs` | capture moved before `parse_expected` |
| `SwitchStatement` (own `end`, not the nested `CaseBlock`'s) | `state_declarations_exports.rs` | the sibling `case_block_end` local already captured the correct position one line earlier (before the `}` advance) — `end_pos` now reuses it instead of re-reading the scanner a second time, since the two are provably the same source position |
| **`ClassDeclaration` (plain, no-modifiers path)** — **not in #16259's list** | `state_statements_class_declarations.rs`, `parse_class_declaration` | found by writing a regression test for the plain `class Foo {}` shape and watching it fail after fixing every site #16259 named; #16259's own grep missed this one. Restructured the `(type_parameters, heritage_clauses, members)` tuple to also carry `end_pos` per branch, since only the "has a class body" branch needs the reordered capture — the other branches (`recover_reserved_class_name_as_statement`, dot-recovery) never call `parse_expected(CloseBraceToken)` and were already correct. |

## Adjacent-case matrix (`crates/tsz-parser/tests/close_brace_node_end_position_tests.rs`, wired into `crates/tsz-parser/src/parser/mod.rs`)

11 new tests, one per site above plus:
- `two_class_static_blocks_in_the_same_class_each_end_correctly` — guards against a fix that only works for the first occurrence in a container.
- `missing_close_brace_recovery_does_not_regress` — negative control: `parse_expected` does not advance the scanner when the expected token is absent, so this shape was never affected; pinned so a future change to the fix can't silently regress it.

Verified the fix is load-bearing by reverting only the `crates/tsz-parser/src/parser/*.rs` source changes (keeping the new tests) and re-running: **10/11 failed** (only the negative control passed), confirming every positive case actually exercises the bug.

## Verification

- `cargo test -p tsz-parser --lib close_brace_node_end_position` — 11/11 pass.
- `cargo test -p tsz-parser --lib` (full suite) — **1517 passed, 0 failed** (includes the 11 new tests + the previously-landed 7 from #16262, both now confirmed wired and running).
- `cargo fmt -p tsz-parser -- --check` — clean.
- `cargo clippy -p tsz-parser --all-targets -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py` — passed.
- Local `pre-commit` hook (fmt + clippy + arch-guard) — passed.
- **Not run**: `scripts/conformance/compare-to-parent.sh` / fourslash — this container has no `TypeScript/` corpus checked out (`git submodule status` prints nothing, and it is a standalone sparse checkout, not an actual submodule, per `scripts/setup/setup-ts-submodule.sh`), and per `.claude/CLAUDE.md` I'm avoiding the full checkout unless the task needs it. Risk read as low: this is the same bug *class* as #16251/#16262 (pure span-widening on `node.end`, no diagnostic decision changes), and that PR's own two-sided `compare-to-parent.sh` run measured **0 newly passing / 0 newly failing** — no corpus fixture reads these particular over-extended spans as text the way `node_text`'s computed-name fallback did. Flagging explicitly rather than silently skipping, per the standing gotcha on unrun suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_012AUV1d3L9rBdYpyPuoMBpM)_