### PR TITLE
fix(parser): 4 remaining CloseBraceToken/token_end() over-extension sites

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -230,6 +230,10 @@ mod declaration_node_end_tests;
 mod computed_property_name_end_position_tests;
 
 #[cfg(test)]
+#[path = "../../tests/close_brace_node_end_position_remaining_tests.rs"]
+mod close_brace_node_end_position_remaining_tests;
+
+#[cfg(test)]
 #[path = "../../tests/decorator_tests.rs"]
 mod decorator_tests;
 

--- a/crates/tsz-parser/src/parser/state_declarations_exports.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_exports.rs
@@ -627,10 +627,15 @@ impl ParserState {
 
         // Skip '}' expected if we already emitted ',' expected at the same position.
         // tsc's parseDelimitedList emits only the comma error, not a closing brace error.
-        if !emitted_comma_error && !leave_closing_brace_for_statement_recovery {
+        let end_pos = if !emitted_comma_error && !leave_closing_brace_for_statement_recovery {
+            // Capture the `}` token's own end before `parse_expected` advances past it —
+            // `token_end()` after the call would report the end of the *next* token instead.
+            let end_pos = self.token_end();
             self.parse_expected(SyntaxKind::CloseBraceToken);
-        }
-        let end_pos = self.token_end();
+            end_pos
+        } else {
+            self.token_end()
+        };
 
         self.arena.add_named_imports(
             syntax_kind_ext::NAMED_EXPORTS,

--- a/crates/tsz-parser/src/parser/state_declarations_modules.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_modules.rs
@@ -414,8 +414,11 @@ impl ParserState {
             self.deferred_module_close_braces -= 1;
             self.token_pos()
         } else {
+            // Capture the `}` token's own end before `parse_expected` advances past it —
+            // `token_end()` after the call would report the end of the *next* token instead.
+            let end_pos = self.token_end();
             self.parse_expected(SyntaxKind::CloseBraceToken);
-            self.token_end()
+            end_pos
         };
 
         self.arena.add_module_block(
@@ -957,6 +960,10 @@ impl ParserState {
         let mut elements = Vec::new();
         let mut leave_closing_brace_for_statement_recovery = false;
         let mut consumed_closing_brace = false;
+        // Captured at each point `parse_expected(CloseBraceToken)` is actually about to
+        // consume `}` — `token_end()` called after that consumption reads the end of the
+        // *next* token instead, so the `}` end must be read before advancing past it.
+        let mut close_brace_end_pos: Option<u32> = None;
         while !self.is_token(SyntaxKind::CloseBraceToken)
             && !self.is_token(SyntaxKind::EndOfFileToken)
         {
@@ -977,6 +984,7 @@ impl ParserState {
                         "Expression expected.",
                         tsz_common::diagnostics::diagnostic_codes::EXPRESSION_EXPECTED,
                     );
+                    close_brace_end_pos = Some(self.token_end());
                     let _ = self.parse_expected(SyntaxKind::CloseBraceToken);
                     consumed_closing_brace = true;
                     leave_closing_brace_for_statement_recovery = false;
@@ -1096,9 +1104,10 @@ impl ParserState {
             } else if consumed_closing_brace {
                 true
             } else {
+                close_brace_end_pos = Some(self.token_end());
                 self.parse_expected(SyntaxKind::CloseBraceToken)
             };
-        let end_pos = self.token_end();
+        let end_pos = close_brace_end_pos.unwrap_or_else(|| self.token_end());
 
         self.arena.add_named_imports(
             syntax_kind_ext::NAMED_IMPORTS,

--- a/crates/tsz-parser/src/parser/state_types.rs
+++ b/crates/tsz-parser/src/parser/state_types.rs
@@ -20,8 +20,11 @@ impl ParserState {
             self.deferred_type_member_close_braces -= 1;
             self.token_pos()
         } else {
+            // Capture the `}` token's own end before `parse_expected` advances past it —
+            // `token_end()` after the call would report the end of the *next* token instead.
+            let end_pos = self.token_end();
             self.parse_expected(SyntaxKind::CloseBraceToken);
-            self.token_end()
+            end_pos
         }
     }
 

--- a/crates/tsz-parser/tests/close_brace_node_end_position_remaining_tests.rs
+++ b/crates/tsz-parser/tests/close_brace_node_end_position_remaining_tests.rs
@@ -1,0 +1,66 @@
+//! Regression tests for the 4 "not yet verified" candidate sites #16265 named as siblings
+//! of #16251/#16259/#16262: a node's `end` captured via `token_end()` *after* calling
+//! `parse_expected(CloseBraceToken)` reads the end of the *next* token instead of the
+//! just-consumed `}`, because `parse_expected` advances the scanner past the matched token
+//! on success. Each site here is fixed the same way: capture `token_end()` while the scanner
+//! is still positioned on `}`, before `parse_expected` consumes it.
+
+use crate::parser::syntax_kind_ext;
+use crate::parser::test_fixture::assert_span;
+
+#[test]
+fn named_exports_end_before_the_following_from_clause() {
+    // `NamedExports`'s own span is just the brace list; the `from "m"` clause belongs to
+    // the outer `ExportDeclaration`. Before the fix, the span extended through `from`.
+    let source = r#"export { a, b } from "m";"#;
+    assert_span(source, syntax_kind_ext::NAMED_EXPORTS, "{ a, b }");
+}
+
+#[test]
+fn named_imports_end_before_the_following_statement() {
+    let source = r#"import { a, b } from "m"; const x = 1;"#;
+    assert_span(source, syntax_kind_ext::NAMED_IMPORTS, "{ a, b }");
+}
+
+#[test]
+fn named_imports_with_asterisk_recovery_ends_at_the_consumed_close_brace() {
+    // `{ * }` is malformed (asterisk isn't a valid specifier); the parser's recovery path
+    // consumes the closing `}` itself mid-loop rather than falling through to the shared
+    // end-of-function `parse_expected(CloseBraceToken)` call. This exercises that separate
+    // capture point, not just the common-case one the other tests above cover.
+    let source = r#"import { * } from "m"; const x = 1;"#;
+    assert_span(source, syntax_kind_ext::NAMED_IMPORTS, "{ * }");
+}
+
+#[test]
+fn module_block_ends_before_the_following_statement() {
+    let source = "namespace N { const x = 1; } const y = 2;";
+    assert_span(source, syntax_kind_ext::MODULE_BLOCK, "{ const x = 1; }");
+}
+
+#[test]
+fn interface_declaration_ends_before_the_following_statement() {
+    let source = "interface Foo { m(): void; } const x = 1;";
+    assert_span(
+        source,
+        syntax_kind_ext::INTERFACE_DECLARATION,
+        "interface Foo { m(): void; }",
+    );
+}
+
+#[test]
+fn type_literal_ends_before_the_following_union_member() {
+    // Before the fix, the span extended through ` | string`.
+    let source = "type T = { a: number } | string;";
+    assert_span(source, syntax_kind_ext::TYPE_LITERAL, "{ a: number }");
+}
+
+#[test]
+fn mapped_type_ends_before_the_following_union_member() {
+    let source = "type T = { [K in Keys]: number } | string;";
+    assert_span(
+        source,
+        syntax_kind_ext::MAPPED_TYPE,
+        "{ [K in Keys]: number }",
+    );
+}


### PR DESCRIPTION
Closes #16265 (the second, "not yet verified" half — the first half, the 4 branching `ClassDeclaration` paths, was already fully covered by #16266/#16267).

## Structural rule

When `self.parse_expected(SyntaxKind::CloseBraceToken)` succeeds, it advances the scanner past `}`. Capturing a node's `end` via `self.token_end()` *after* that call therefore reads the end of the *next* token, not `}`'s own end. tsc's equivalent (`finishNode` reading `scanner.getStartPos()` before the following token is scanned) never has this problem because the end is read at the position the parser was at when the construct finished. This is the same mechanism #16251/#16262 fixed for `ComputedPropertyName` and #16259/#16266/#16267 fixed for 9 sibling sites; this PR fixes the 4 sites #16265 flagged as needing individual verification rather than a mechanical grep-and-move.

## Owner layer

Parser only (`crates/tsz-parser`). No checker, solver, or emitter change.

## Sites fixed

| node(s) | file | shape |
| --- | --- | --- |
| `NamedExports` (`export { a, b } from "m"`) | `state_declarations_exports.rs` | capture moved into the branch that actually calls `parse_expected` |
| `ModuleBlock` (`namespace N { }`, `declare module "m" { }`) | `state_declarations_modules.rs` | capture moved into the `else` branch (deferred-close-brace branch already read the position correctly) |
| `NamedImports` (`import { a, b } from "m"`) | `state_declarations_modules.rs` | two separate consumption points feed the same `end_pos`: the normal end-of-function `parse_expected` call, and a mid-loop `{ * }`-recovery consumption. Both now capture before advancing, tracked through an `Option<u32>` so the unaffected `leave_closing_brace_for_statement_recovery` path (where `}` is never consumed here) is untouched. |
| `InterfaceDeclaration`, `MappedType` (×2 call sites), `TypeLiteral` | `state_types.rs` (`finish_type_member_container_close_brace`, shared helper) | capture moved before `parse_expected` |

The `NamedImports` site needed more care than the others — #16265 called it out as one of the "not close enough to eyeball confidently" sites, and it turned out to have two distinct places where `}` gets consumed feeding one shared `end_pos`, not one.

## Adjacent-case matrix (new tests, `crates/tsz-parser/tests/close_brace_node_end_position_remaining_tests.rs`)

- `named_exports_end_before_the_following_from_clause`
- `named_imports_end_before_the_following_statement`
- `named_imports_with_asterisk_recovery_ends_at_the_consumed_close_brace` — exercises the second, mid-loop consumption point specifically, not just the common-case one
- `module_block_ends_before_the_following_statement`
- `interface_declaration_ends_before_the_following_statement`
- `type_literal_ends_before_the_following_union_member`
- `mapped_type_ends_before_the_following_union_member`

All 7 failed before the fix (verified by writing them against the pre-fix source and confirming every one panics with the over-extended span) and pass after.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-parser --lib` — 1513 passed / 0 failed (was 1506 before the 7 new tests).
- `cargo fmt -p tsz-parser -- --check` — clean.
- `cargo clippy -p tsz-parser --all-targets -- -D warnings` — clean.
- `cargo clippy -p tsz-cli --all-targets -- -D warnings` — clean (downstream consumer of parser spans).
- `python3 scripts/arch/arch_guard.py` — `Architecture guardrails passed.`
- `cargo test -p tsz-checker --lib` — attempted but did not finish locally: this container's run stalled 35+ minutes in on `ts2589_tests::recursive_conditional_alias_omitted_default_transform_emits_definition_ts2589`, which matches the repo's documented pre-existing checker-hang class (#15338, "3 checker hangs"), unrelated to this parser-only change. Before killing it, one real failure surfaced: `ts2303_tests::recursive_export_assignment_self_import_reports_ts2303`. Verified pre-existing and unaffected by this diff — reproduces identically (same assertion, same `left: 2 / right: 1`) on the unpatched parent commit (`e6848c3`) with only `crates/tsz-parser/` reverted, everything else held constant.
- Not run: `compare-to-parent.sh` / `conformance.sh` (no `TypeScript/tests/cases` corpus in this container) and emit/fourslash. Risk assessed as low by analogy with #16251/#16262/#16266/#16267, which all measured 0/0 corpus movement on the identical bug class — these are pure span-of-an-already-correctly-shaped-node fixes with no diagnostic-producing side effects, and the affected node kinds (declarations/imports/exports/interfaces/type literals) are extremely common, so any real corpus impact would already have been visible on the earlier PRs in this family.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_019KcAZg3fweocCw36sEVAu7)_