### PR TITLE
fix(checker): TS1539 was never wired up for bigint literal property names

### DIFF
--- a/crates/tsz-checker/src/checkers/property_checker.rs
+++ b/crates/tsz-checker/src/checkers/property_checker.rs
@@ -1,5 +1,6 @@
 //! Property access checking (accessibility, computed names, const modifiers).
 
+mod literal_name_grammar;
 mod private_error;
 mod super_static_access;
 mod union_restricted_property;

--- a/crates/tsz-checker/src/checkers/property_checker/literal_name_grammar.rs
+++ b/crates/tsz-checker/src/checkers/property_checker/literal_name_grammar.rs
@@ -1,0 +1,32 @@
+//! TS1539: a literal (non-computed) `bigint` property name.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_scanner::SyntaxKind;
+
+impl<'a> CheckerState<'a> {
+    /// TS1539: a literal (non-computed) `bigint` name cannot be used as a
+    /// property name.
+    ///
+    /// Fires unconditionally for property-shaped members — interface/type-literal
+    /// property signatures, class property declarations, and object-literal
+    /// property assignments — regardless of `readonly`, `static`, `declare`,
+    /// optionality, or decorators. Never fires on the method-shaped equivalent
+    /// (methods, `get`/`set` accessors) in any of those containers, so callers
+    /// must gate on the member being a property, not a method or accessor.
+    pub(crate) fn check_bigint_literal_property_name(&mut self, name_idx: NodeIndex) -> bool {
+        let Some(name_node) = self.ctx.arena.get(name_idx) else {
+            return false;
+        };
+        if name_node.kind != SyntaxKind::BigIntLiteral as u16 {
+            return false;
+        }
+        use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+        self.error_at_node(
+            name_idx,
+            diagnostic_messages::A_BIGINT_LITERAL_CANNOT_BE_USED_AS_A_PROPERTY_NAME,
+            diagnostic_codes::A_BIGINT_LITERAL_CANNOT_BE_USED_AS_A_PROPERTY_NAME,
+        );
+        true
+    }
+}

--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -100,6 +100,8 @@ impl<'a> CheckerState<'a> {
                 );
             }
         }
+        // TS1539: a bigint literal class property name (`123n = 1`).
+        self.check_bigint_literal_property_name(prop.name);
         self.check_modifier_combinations(&prop.modifiers, prop.name, node.kind);
 
         // TS8009/TS8010: Check for TypeScript-only features in JavaScript files

--- a/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
@@ -307,6 +307,12 @@ impl<'a> CheckerState<'a> {
                             diagnostic_codes::A_COMPUTED_PROPERTY_NAME_IN_AN_INTERFACE_MUST_REFER_TO_AN_EXPRESSION_WHOSE_TYPE,
                         );
                     }
+                    // TS1539: a bigint literal interface property name (`123n: string`).
+                    // Method signatures share this same `sig` shape but never take
+                    // this diagnostic — gate on the member being a property.
+                    if member_node.kind == syntax_kind_ext::PROPERTY_SIGNATURE {
+                        self.check_bigint_literal_property_name(sig.name);
+                    }
                     let (_type_params, type_param_updates) =
                         self.push_type_parameters(&sig.type_parameters);
                     // Resolve parameters first so the param scope is built

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -781,6 +781,8 @@ mod ts1101_with_in_strict_mode_tests;
 mod ts1170_computed_property_syntactic_form_tests;
 #[path = "tests/ts1361_ambient_computed_property_name_tests.rs"]
 mod ts1361_ambient_computed_property_name_tests;
+#[path = "tests/ts1539_bigint_literal_property_name_tests.rs"]
+mod ts1539_bigint_literal_property_name_tests;
 #[path = "tests/ts18010_jsdoc_tag_anchor_tests.rs"]
 mod ts18010_jsdoc_tag_anchor_tests;
 #[path = "tests/ts18050_nullish_keyword_without_strict_null_checks_tests.rs"]

--- a/crates/tsz-checker/src/tests/ts1539_bigint_literal_property_name_tests.rs
+++ b/crates/tsz-checker/src/tests/ts1539_bigint_literal_property_name_tests.rs
@@ -1,0 +1,133 @@
+//! Regression tests for TS1539 — a literal (non-computed) `bigint` name
+//! cannot be used as a property name.
+//!
+//! Verified against the pinned `typescript@7.0.2` oracle: this fires
+//! unconditionally on property-shaped members (interface/type-literal
+//! property signatures, class property declarations, object-literal
+//! property assignments) regardless of `readonly`, `static`, `declare`, or
+//! optionality, and never fires on the method-shaped equivalent (methods,
+//! `get`/`set` accessors) in any of those four containers.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn diag_codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+#[test]
+fn ts1539_interface_property_signature() {
+    let codes = diag_codes("interface I { 123n: string; }");
+    assert!(codes.contains(&1539), "Got: {codes:?}");
+}
+
+#[test]
+fn ts1539_interface_optional_property_signature() {
+    let codes = diag_codes("interface I { 123n?: string; }");
+    assert!(codes.contains(&1539), "Got: {codes:?}");
+}
+
+#[test]
+fn ts1539_interface_readonly_property_signature() {
+    let codes = diag_codes("interface I { readonly 123n: string; }");
+    assert!(codes.contains(&1539), "Got: {codes:?}");
+}
+
+#[test]
+fn ts1539_interface_method_signature_is_not_affected() {
+    let codes = diag_codes("interface I { 123n(): void; }");
+    assert!(!codes.contains(&1539), "Got: {codes:?}");
+}
+
+#[test]
+fn ts1539_type_literal_property_signature() {
+    let codes = diag_codes("type T = { 123n: string };");
+    assert!(codes.contains(&1539), "Got: {codes:?}");
+}
+
+#[test]
+fn ts1539_type_literal_method_signature_is_not_affected() {
+    let codes = diag_codes("type T = { 123n(): void };");
+    assert!(!codes.contains(&1539), "Got: {codes:?}");
+}
+
+#[test]
+fn ts1539_class_instance_property() {
+    let codes = diag_codes("class C { 123n = 1; }");
+    assert!(codes.contains(&1539), "Got: {codes:?}");
+}
+
+#[test]
+fn ts1539_class_static_property() {
+    let codes = diag_codes("class C { static 123n = 1; }");
+    assert!(codes.contains(&1539), "Got: {codes:?}");
+}
+
+#[test]
+fn ts1539_class_readonly_property() {
+    let codes = diag_codes("class C { readonly 123n = 1; }");
+    assert!(codes.contains(&1539), "Got: {codes:?}");
+}
+
+#[test]
+fn ts1539_ambient_class_property() {
+    let codes = diag_codes("declare class C { 123n: number; static 123n: number; }");
+    let count = codes.iter().filter(|&&c| c == 1539).count();
+    assert_eq!(count, 2, "Got: {codes:?}");
+}
+
+#[test]
+fn ts1539_class_method_is_not_affected() {
+    let codes = diag_codes("class C { 123n() {} }");
+    assert!(!codes.contains(&1539), "Got: {codes:?}");
+}
+
+#[test]
+fn ts1539_class_accessor_is_not_affected() {
+    let codes = diag_codes("class C { get 123n() { return 1; } set 123n(v: number) {} }");
+    assert!(!codes.contains(&1539), "Got: {codes:?}");
+}
+
+#[test]
+fn ts1539_ambient_class_method_is_not_affected() {
+    let codes = diag_codes("declare class C { 123n(): void; }");
+    assert!(!codes.contains(&1539), "Got: {codes:?}");
+}
+
+#[test]
+fn ts1539_object_literal_property_assignment() {
+    let codes = diag_codes("const o = { 123n: 1 };");
+    assert!(codes.contains(&1539), "Got: {codes:?}");
+}
+
+#[test]
+fn ts1539_object_literal_method_is_not_affected() {
+    let codes = diag_codes("const o = { 123n() {} };");
+    assert!(!codes.contains(&1539), "Got: {codes:?}");
+}
+
+#[test]
+fn ts1539_string_and_numeric_property_names_are_not_affected() {
+    let codes = diag_codes(
+        r#"
+interface I { 123: string; "abc": string; }
+class C { 123 = 1; "abc" = 2; }
+const o = { 123: 1, "abc": 2 };
+"#,
+    );
+    assert!(!codes.contains(&1539), "Got: {codes:?}");
+}
+
+#[test]
+fn ts1539_renamed_binders_do_not_change_the_result() {
+    let codes = diag_codes(
+        r#"
+interface AnotherName { 999n: boolean; }
+class YetAnotherName { 999n = true; }
+"#,
+    );
+    let count = codes.iter().filter(|&&c| c == 1539).count();
+    assert_eq!(count, 2, "Got: {codes:?}");
+}

--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -124,6 +124,11 @@ impl<'a> CheckerState<'a> {
                     // the name can be resolved to a literal atom.
                     self.check_computed_property_name(prop.name);
                 }
+                // TS1539: a bigint literal object-literal property name (`{ 123n: 1 }`).
+                // Object-literal methods (`{ 123n() {} }`) share PropertyAssignment's
+                // sibling ShorthandPropertyAssignment/MethodDeclaration node kinds and
+                // never reach this branch, so no extra gate is needed here.
+                self.check_bigint_literal_property_name(prop.name);
 
                 // When the computed key expression has error type (e.g., [Symbol.nonsense]),
                 // treat the property as unnamed to avoid cascading errors. tsc drops

--- a/crates/tsz-checker/src/types/type_checking/core.rs
+++ b/crates/tsz-checker/src/types/type_checking/core.rs
@@ -953,6 +953,12 @@ impl<'a> CheckerState<'a> {
                                     diagnostic_codes::A_COMPUTED_PROPERTY_NAME_IN_A_TYPE_LITERAL_MUST_REFER_TO_AN_EXPRESSION_WHOSE_TYP,
                                 );
                             }
+                            // TS1539: a bigint literal type-literal property name
+                            // (`123n: string`). Method signatures share this same
+                            // `sig` shape but never take this diagnostic.
+                            if member_node.kind == syntax_kind_ext::PROPERTY_SIGNATURE {
+                                self.check_bigint_literal_property_name(sig.name);
+                            }
                         } else if let Some(accessor) = self.ctx.arena.get_accessor(member_node) {
                             // For get/set accessors in type literals, use TS2464
                             // (general computed property check) matching tsc behavior


### PR DESCRIPTION
## Goal
Goal: hold

## Structural rule

**When a property-shaped member — an interface or type-literal property signature, a class property declaration, or an object-literal property assignment — is named with a literal (non-computed) `bigint` (`123n`), `tsc` reports `TS1539` unconditionally; tsz never called this diagnostic through any checker path.**

And its converse, which the oracle also pins: **a method-shaped member (a method, or a `get`/`set` accessor) sharing the exact same literal name never takes `TS1539`, in any of the four containers above, ambient or not.** The new check is gated on the member being property-shaped so it does not leak onto methods/accessors.

## What was wrong

`TS1539`'s message ("A 'bigint' literal cannot be used as a property name.") is defined in the generated diagnostics table (`crates/tsz-common/src/diagnostics/data/parts/part_000.rs:460`) but had **zero call sites anywhere in the checker** (confirmed by grep before starting). `interface I { 123n: string; }`, `type T = { 123n: string }`, `class C { 123n = 1; }`, and `const o = { 123n: 1 };` all silently passed.

## Owner layer

Checker only (`crates/tsz-checker`), four call sites, one new shared helper:
- `crates/tsz-checker/src/checkers/property_checker/literal_name_grammar.rs` (new file) — `check_bigint_literal_property_name`, the shared TS1539 check.
- `crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs` — class property declarations.
- `crates/tsz-checker/src/state/state_checking_members/interface_checks.rs` — interface property signatures (gated on `PROPERTY_SIGNATURE`, not `METHOD_SIGNATURE`, which shares the same `sig` shape).
- `crates/tsz-checker/src/types/type_checking/core.rs` — type-literal property signatures (same gate).
- `crates/tsz-checker/src/types/computation/object_literal/computation.rs` — object-literal property assignments.

The new helper lives in its own small file rather than growing `property_checker.rs` past the 2000-line arch-size cap (`crates/tsz-checker/src/checkers/property_checker.rs` was already at 1981 lines).

No solver, binder, parser, or emitter change. No identifier/file-name string check — the gate is purely the `BigIntLiteral` node kind vs. the enclosing member's node kind (property vs. method/accessor signature kind), never rendered text or a name.

## Oracle matrix — pinned `typescript@7.0.2`, `--noEmit --strict --pretty false`

| shape | tsc | before | after |
| --- | --- | --- | --- |
| interface property (`123n: string`) | TS1539 | clean | TS1539 |
| interface optional property (`123n?: string`) | TS1539 | clean | TS1539 |
| interface readonly property | TS1539 | clean | TS1539 |
| interface method (`123n(): void`) | clean | clean | clean |
| type-literal property | TS1539 | clean | TS1539 |
| type-literal method | clean | clean | clean |
| class instance property | TS1539 | clean | TS1539 |
| class static property | TS1539 | clean | TS1539 |
| class readonly property | TS1539 | clean | TS1539 |
| class decorated property (`experimentalDecorators`) | TS1539 | clean | TS1539 |
| class method | clean | clean | clean |
| class get/set accessor | clean | clean | clean |
| `declare class` property (instance + static) | TS1539 ×2 | clean | TS1539 ×2 |
| `declare class` method | clean | clean | clean |
| object-literal property assignment | TS1539 | clean | TS1539 |
| object-literal method (`{ 123n() {} }`) | clean | clean | clean |
| numeric/string literal names (negative control) | clean | clean | clean |

## Adjacent-case matrix (`crates/tsz-checker/src/tests/ts1539_bigint_literal_property_name_tests.rs`, wired into `test_module_registry.rs`)

17 new tests covering all four containers × property/method, plus `readonly`/`static`/`declare`/optional modifiers, a renamed-binder control, and a negative control for ordinary numeric/string property names (must stay unaffected).

Verified load-bearing by reverting only the four `crates/tsz-checker/src/**/*.rs` source edits (keeping the new tests): **10/17 failed** — exactly the 10 positive cases; the 7 negative-control tests (methods/accessors/plain names) correctly kept passing throughout, confirming every positive case actually exercises the new code path.

## Verification

- `cargo test -p tsz-checker --lib ts1539` — 17/17 pass.
- `cargo test -p tsz-checker --lib -- ts1166 ts1169 ts1170 computed_property duplicate_member_computed_name` — 77/77 pass, no regressions in the sibling computed-property-name families that share the same `sig`/member-loop code.
- `cargo fmt -p tsz-checker -- --check` — clean.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py` — passed (the new helper lives in its own file specifically to keep `property_checker.rs` under the 2000-line cap after this change).
- Local `pre-commit` hook (fmt + clippy + arch-guard) — passed.
- `cargo test -p tsz-checker --lib` (full suite): every test alphabetically before `ts2589_tests` passed with **zero failures** before the run hit a pre-existing, unrelated hang in `ts2589_tests::recursive_conditional_alias_omitted_default_transform_emits_definition_ts2589` (recursive conditional-alias default-transform display, nothing to do with property names) — this matches the board's previously-documented checker hangs (issue #15338). Killed the run there; the targeted + adjacent suites above are the primary evidence.
- **Not run**: `scripts/conformance/compare-to-parent.sh` / full `conformance.sh` — this container has no `TypeScript/tests/cases` corpus checked out. Risk read as low: this is a pure additive false-negative fix (a new diagnostic on a shape no fixture is likely to exercise — a literal `bigint` used as an object/interface/class member name is vanishingly rare real-world syntax), so zero conformance movement is the expected signature, not evidence the fix is inert.
- Not run: emit/fourslash — no emit or LSP-surface code touched.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_01SNSJaYXm7v2dp7tS59zy8v)_