### PR TITLE
fix(checker): every well-formed computed member name is nameable in a diagnostic

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
@@ -1510,11 +1510,24 @@ impl<'a> CheckerState<'a> {
         // key-shaped helper whose numeric arm both drops the brackets and
         // canonicalizes the digits, which is right for a dedup key and wrong for
         // a message.
+        //
+        // The inner expression decides only *whether* the name is renderable —
+        // a computed name with no expression (`get [](); `) is a parse-error
+        // shape that tsc leaves to the syntax error alone. Once it is
+        // renderable, the whole `[...]` node's own source text is what
+        // `getTextOfNode` returns, interior trivia included: tsc names
+        // `get [/* c */ "a"]()` as `[/* c */ "a"]`, which reassembling from the
+        // expression's trivia-skipped span cannot reproduce.
         if name_node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME
             && let Some(computed) = self.ctx.arena.get_computed_property(name_node)
             && let Some(inner) = self.computed_name_expression_display_text(computed.expression)
         {
-            return Some(format!("[{inner}]"));
+            return Some(
+                self.node_text(name_idx)
+                    .map(|text| text.trim().to_string())
+                    .filter(|text| !text.is_empty())
+                    .unwrap_or_else(|| format!("[{inner}]")),
+            );
         }
 
         // Fall back to get_member_name_text for computed properties, etc.
@@ -1522,12 +1535,47 @@ impl<'a> CheckerState<'a> {
     }
 
     /// The inner spelling of a computed member name, for
-    /// `get_member_name_display_text`. Returns `None` when the expression is
-    /// absent or too complex to render, which keeps a malformed computed name
-    /// (`get [](); `, a parse-error shape) unnamed rather than rendering it as
-    /// an empty `[]` — tsc reports only the syntax error there.
+    /// `get_member_name_display_text`. Returns `None` only when the expression
+    /// is absent or occupies no source text, which keeps a malformed computed
+    /// name (`get [](); `, a parse-error shape) unnamed rather than rendering
+    /// it as an empty `[]` — tsc reports only the syntax error there.
+    ///
+    /// Everything else renders as its own verbatim source text, because that is
+    /// what tsc does: `declarationNameToString`'s last arm is `getTextOfNode`
+    /// and it is **unconditional**, so every well-formed computed name is
+    /// nameable whatever the expression is. This helper used to pick from a
+    /// whitelist of expression kinds instead (literals here, then identifier /
+    /// dotted access / zero-argument call / parenthesized in
+    /// `simple_computed_name_expr_text_in_arena`) and return `None` for the
+    /// rest — a call with arguments, a binary expression, a conditional, an
+    /// assertion, a tagged template. `None` makes `member_name_for_diagnostic`
+    /// fail, and every site that gates on it then drops the member's whole
+    /// `noImplicitAny` family (TS7008/TS7010/TS7032/TS7033) silently, with
+    /// TS7010 additionally degrading to TS7011 in class containers. Three
+    /// separate fixes (#16190/#16225, #16201, #16229) each closed one more node
+    /// kind before the whitelist itself was recognized as the defect (#16250).
+    ///
+    /// The verbatim text is also the only rendering that survives a
+    /// syntax-preserving wrapper: `simple_computed_name_expr_text_in_arena`
+    /// recurses *through* a parenthesized expression, so it renders `[(a)]` as
+    /// `[a]`, where `getTextOfNode` keeps the parentheses. That helper is not
+    /// widened to fix this — it is shared with the *key* helpers
+    /// (`get_member_name_text`, `should_check_late_bound_class_property_name`)
+    /// where unwrapping is the correct behaviour for member identity. It stays
+    /// as the fallback for the one case verbatim text cannot serve: a node with
+    /// no owning source file (a synthesized or lib-merged declaration), where
+    /// `node_text` has nothing to slice.
     fn computed_name_expression_display_text(&self, expr_idx: NodeIndex) -> Option<String> {
         let expr_node = self.ctx.arena.get(expr_idx)?;
+
+        if !self.computed_name_expression_is_parse_recovered(expr_idx)
+            && let Some(verbatim) = self
+                .node_text(expr_idx)
+                .map(|text| text.trim().to_string())
+                .filter(|text| !text.is_empty())
+        {
+            return Some(verbatim);
+        }
 
         if expr_node.kind == tsz_scanner::SyntaxKind::StringLiteral as u16
             && let Some(lit) = self.ctx.arena.get_literal(expr_node)
@@ -1543,24 +1591,16 @@ impl<'a> CheckerState<'a> {
 
         // Template literal computed name, with substitutions (`` `a${x}` ``) or
         // without (`` `abc` ``). `tsc` names both in messages using their own
-        // source spelling — `declarationNameToString` falls through to
-        // `getTextOfNode` for anything past the literal/identifier cases, and a
-        // `NoSubstitutionTemplateLiteral` is not one of the string/numeric
-        // kinds it special-cases, so the backticks survive into the message
-        // exactly as written.
+        // source spelling, and `node_text` above already produces exactly that
+        // whenever the node has an owning source file — this arm only carries
+        // the source-less case, where there is no text to slice and nothing
+        // better to return.
         //
         // Resolving the *key* is a different question from naming the *member*:
         // `get_property_name` does resolve `` [`abc`] `` to the key `abc` one
         // step earlier, but this display path is reached by node kind, not by
         // first-success, so the key resolver never covers for a missing arm
-        // here. Without one, `member_name_for_diagnostic` returns `None` and
-        // every site that gates on it silently drops the member's
-        // `noImplicitAny` diagnostic (TS7008/TS7010/TS7032/TS7033).
-        //
-        // Verbatim source text is safe for both kinds specifically because the
-        // node is a well-formed template literal, not a parse-error recovery
-        // node — unlike a raw-source fallback keyed on node kind in general,
-        // this can't misrender a malformed computed name.
+        // here.
         if expr_node.kind == syntax_kind_ext::TEMPLATE_EXPRESSION
             || expr_node.kind == tsz_scanner::SyntaxKind::NoSubstitutionTemplateLiteral as u16
         {
@@ -1568,6 +1608,57 @@ impl<'a> CheckerState<'a> {
         }
 
         self.get_simple_computed_name_expr_text(expr_idx)
+    }
+
+    /// Whether a computed-name expression contains a node the parser
+    /// synthesized while recovering from a syntax error, which makes the name
+    /// unrenderable: `get [1+]();` parses as a binary expression whose right
+    /// operand is `create_missing_expression`'s placeholder, and tsc reports
+    /// only the syntax error (`TS1109`) for it, never the member's
+    /// implicit-any diagnostic.
+    ///
+    /// The placeholder is structurally identifiable — it occupies no source
+    /// text at all (`create_missing_expression` builds it at `(pos, pos)`) — so
+    /// this is a deny-list over parser recovery, not a whitelist over
+    /// expression kinds. That polarity is the
+    /// point: an expression form this probe does not know how to descend into
+    /// is treated as **well-formed** and gets named, matching tsc's
+    /// unconditional `getTextOfNode`. The old whitelist had the opposite
+    /// default, which is why each new node kind cost its own bug and fix.
+    fn computed_name_expression_is_parse_recovered(&self, expr_idx: NodeIndex) -> bool {
+        let Some(node) = self.ctx.arena.get(expr_idx) else {
+            return false;
+        };
+
+        if self
+            .get_node_span(expr_idx)
+            .is_none_or(|(start, end)| start >= end)
+        {
+            return true;
+        }
+
+        // Operand-bearing wrappers: a placeholder is only ever produced *inside*
+        // one of these, so descending through them is enough to see it. Any
+        // other kind falls through to `false` (nameable) by design.
+        if let Some(paren) = self.ctx.arena.get_parenthesized(node) {
+            return self.computed_name_expression_is_parse_recovered(paren.expression);
+        }
+        if let Some(binary) = self.ctx.arena.get_binary_expr(node) {
+            return self.computed_name_expression_is_parse_recovered(binary.left)
+                || self.computed_name_expression_is_parse_recovered(binary.right);
+        }
+        if let Some(unary) = self.ctx.arena.get_unary_expr(node) {
+            return self.computed_name_expression_is_parse_recovered(unary.operand);
+        }
+        if let Some(access) = self.ctx.arena.get_access_expr(node) {
+            return self.computed_name_expression_is_parse_recovered(access.expression)
+                || self.computed_name_expression_is_parse_recovered(access.name_or_argument);
+        }
+        if let Some(call) = self.ctx.arena.get_call_expr(node) {
+            return self.computed_name_expression_is_parse_recovered(call.expression);
+        }
+
+        false
     }
 
     /// The name tsc puts in a member diagnostic, via `declarationNameToString`.

--- a/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
@@ -1568,13 +1568,23 @@ impl<'a> CheckerState<'a> {
     fn computed_name_expression_display_text(&self, expr_idx: NodeIndex) -> Option<String> {
         let expr_node = self.ctx.arena.get(expr_idx)?;
 
-        if !self.computed_name_expression_is_parse_recovered(expr_idx)
-            && let Some(verbatim) = self
-                .node_text(expr_idx)
-                .map(|text| text.trim().to_string())
-                .filter(|text| !text.is_empty())
+        // Source text answers the whole question when there is source text to
+        // read: render it verbatim, or decline outright if the parser recovered
+        // this name from a syntax error. Declining must *not* fall through to
+        // the structured arms below — they descend into a recovered node's
+        // well-formed half and rebuild a name from it (`[a.]` renders as `a.`
+        // through the property-access arm), which is the same silent divergence
+        // in the other direction.
+        if let Some(verbatim) = self
+            .node_text(expr_idx)
+            .map(|text| text.trim().to_string())
+            .filter(|text| !text.is_empty())
         {
-            return Some(verbatim);
+            return if self.computed_name_expression_is_parse_recovered(expr_idx) {
+                None
+            } else {
+                Some(verbatim)
+            };
         }
 
         if expr_node.kind == tsz_scanner::SyntaxKind::StringLiteral as u16
@@ -1626,8 +1636,16 @@ impl<'a> CheckerState<'a> {
     /// unconditional `getTextOfNode`. The old whitelist had the opposite
     /// default, which is why each new node kind cost its own bug and fix.
     fn computed_name_expression_is_parse_recovered(&self, expr_idx: NodeIndex) -> bool {
+        // A *required* child that is absent is the other half of the same
+        // recovery signal: `[a.]` parses as a property access whose member name
+        // never materialized at all, rather than as a zero-width placeholder.
+        // Every position this probe descends into is required by its parent's
+        // grammar, so an absent one always means the parser gave up there.
+        if expr_idx.is_none() {
+            return true;
+        }
         let Some(node) = self.ctx.arena.get(expr_idx) else {
-            return false;
+            return true;
         };
 
         if self

--- a/crates/tsz-checker/src/tests/computed_member_name_diagnostic_display_tests.rs
+++ b/crates/tsz-checker/src/tests/computed_member_name_diagnostic_display_tests.rs
@@ -689,3 +689,37 @@ fn parse_recovered_computed_name_inside_parentheses_is_still_declined() {
         "a parse-recovered computed name must not draw TS7033; got {codes:?}"
     );
 }
+
+#[test]
+fn parse_recovered_property_access_computed_name_is_declined() {
+    // `[aq70.]` recovers as a property access whose member name is the
+    // zero-width placeholder. The old whitelist *accepted* property accesses,
+    // so the recovery probe has to descend into the member position too, not
+    // only into operands. tsc reports only TS1003 here.
+    let codes: Vec<u32> = check_source_strict_messages(
+        "declare const aq70: { bq70: string }; declare class Cq55 { get [aq70.](); }",
+    )
+    .into_iter()
+    .map(|(code, _)| code)
+    .collect();
+    assert!(
+        !codes.contains(&7033),
+        "a parse-recovered computed name must not draw TS7033; got {codes:?}"
+    );
+}
+
+#[test]
+fn parse_recovered_element_access_computed_name_is_declined() {
+    // `[aq71[]` recovers as an element access with no argument. tsc reports
+    // only TS1011/TS1005.
+    let codes: Vec<u32> = check_source_strict_messages(
+        "declare const aq71: { bq71: string }; declare class Cq56 { get [aq71[](); }",
+    )
+    .into_iter()
+    .map(|(code, _)| code)
+    .collect();
+    assert!(
+        !codes.contains(&7033),
+        "a parse-recovered computed name must not draw TS7033; got {codes:?}"
+    );
+}

--- a/crates/tsz-checker/src/tests/computed_member_name_diagnostic_display_tests.rs
+++ b/crates/tsz-checker/src/tests/computed_member_name_diagnostic_display_tests.rs
@@ -385,3 +385,307 @@ fn malformed_computed_name_reports_no_implicit_any_member_diagnostic() {
         "a malformed computed name must not draw TS7033; got {codes:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #16250 — the display whitelist itself, not one more node kind
+//
+// `computed_name_expression_display_text` rendered a computed name only if the
+// expression matched a whitelist (string / numeric / template literal here,
+// then identifier / dotted access / zero-argument call / parenthesized in
+// `simple_computed_name_expr_text_in_arena`). Every other expression returned
+// `None`, `member_name_for_diagnostic` failed, and every gated site dropped the
+// member's whole `noImplicitAny` family silently. tsc has no whitelist:
+// `declarationNameToString`'s last arm is an unconditional `getTextOfNode`.
+//
+// Every row below is recorded from `typescript@7.0.2` under
+// `--noEmit --strict --lib es2022 --target es2022`. Binder names are distinct
+// per row so nothing can key on an identifier string, and the expressions are
+// deliberately chosen so the *key* is not statically resolvable — a renderer
+// that still went through the key resolver would produce nothing for them.
+// ---------------------------------------------------------------------------
+
+/// Shared preamble: the binders every expression form below reads. Kept in one
+/// place so each row is only its own name shape.
+const Q30_PRELUDE: &str = "declare const aq30: string; \
+                           declare function fq30(n: number): string; \
+                           declare const oq30: { kq30: string }; \
+                           declare function tagq30(s: TemplateStringsArray): string; \
+                           declare const bq30: boolean; ";
+
+fn assert_computed_name_rendered(member: &str, code: u32, expected: &str) {
+    assert_names(&format!("{Q30_PRELUDE}{member}"), code, expected);
+}
+
+#[test]
+fn ts7033_call_with_arguments_computed_name_is_named() {
+    // `simple_computed_name_expr_text_in_arena` accepted a *zero-argument* call
+    // and declined this one, so the whole family vanished for `[f(1)]`.
+    assert_computed_name_rendered(
+        "declare class Cq31 { get [fq30(1)](); }",
+        7033,
+        "Property '[fq30(1)]'",
+    );
+}
+
+#[test]
+fn ts7033_binary_expression_computed_name_is_named() {
+    assert_computed_name_rendered(
+        "declare class Cq32 { get [aq30 + \"b\"](); }",
+        7033,
+        "Property '[aq30 + \"b\"]'",
+    );
+}
+
+#[test]
+fn ts7033_conditional_expression_computed_name_is_named() {
+    assert_computed_name_rendered(
+        "declare class Cq33 { get [bq30 ? \"x\" : \"y\"](); }",
+        7033,
+        "Property '[bq30 ? \"x\" : \"y\"]'",
+    );
+}
+
+#[test]
+fn ts7033_as_assertion_computed_name_is_named() {
+    assert_computed_name_rendered(
+        "declare class Cq34 { get [aq30 as string](); }",
+        7033,
+        "Property '[aq30 as string]'",
+    );
+}
+
+#[test]
+fn ts7033_tagged_template_computed_name_is_named() {
+    assert_computed_name_rendered(
+        "declare class Cq35 { get [tagq30`sq35`](); }",
+        7033,
+        "Property '[tagq30`sq35`]'",
+    );
+}
+
+#[test]
+fn ts7033_element_access_computed_name_is_named() {
+    assert_computed_name_rendered(
+        "declare class Cq36 { get [oq30[\"kq30\"]](); }",
+        7033,
+        "Property '[oq30[\"kq30\"]]'",
+    );
+}
+
+#[test]
+fn ts7033_non_null_assertion_computed_name_is_named() {
+    assert_computed_name_rendered(
+        "declare class Cq37 { get [aq30!](); }",
+        7033,
+        "Property '[aq30!]'",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Parenthesized forms — the second defect in the same helper. The whitelist
+// *accepted* these by recursing through the parentheses, so the name rendered
+// with the wrapper stripped: `[(aq30)]` came out as `[aq30]`. `getTextOfNode`
+// keeps the source syntax. `simple_computed_name_expr_text_in_arena` is not
+// widened to fix this — it is shared with the key helpers, where unwrapping is
+// correct for member identity.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ts7033_parenthesized_identifier_computed_name_keeps_its_parentheses() {
+    assert_computed_name_rendered(
+        "declare class Cq38 { get [(aq30)](); }",
+        7033,
+        "Property '[(aq30)]'",
+    );
+}
+
+#[test]
+fn ts7033_doubly_parenthesized_identifier_computed_name_keeps_both() {
+    assert_computed_name_rendered(
+        "declare class Cq39 { get [((aq30))](); }",
+        7033,
+        "Property '[((aq30))]'",
+    );
+}
+
+#[test]
+fn ts7033_parenthesized_string_literal_computed_name_is_named() {
+    // The literal arms rendered the *unwrapped* literal only when it was the
+    // expression itself; wrapped in parentheses the whitelist declined outright
+    // and the diagnostic disappeared.
+    assert_computed_name_rendered(
+        "declare class Cq40 { get [(\"sq40\")](); }",
+        7033,
+        "Property '[(\"sq40\")]'",
+    );
+}
+
+#[test]
+fn ts7033_parenthesized_template_literal_computed_name_is_named() {
+    assert_computed_name_rendered(
+        "declare class Cq41 { get [(`sq41`)](); }",
+        7033,
+        "Property '[(`sq41`)]'",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The same expression form across every container and member kind, so the fix
+// is pinned at the shared renderer rather than at one caller.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ts7033_interface_call_computed_name_is_named() {
+    assert_computed_name_rendered(
+        "interface Iq42 { get [fq30(2)](); }",
+        7033,
+        "Property '[fq30(2)]'",
+    );
+}
+
+#[test]
+fn ts7033_type_literal_call_computed_name_is_named() {
+    assert_computed_name_rendered(
+        "type Tq43 = { get [fq30(3)](); };",
+        7033,
+        "Property '[fq30(3)]'",
+    );
+}
+
+#[test]
+fn ts7033_abstract_class_call_computed_name_is_named() {
+    assert_computed_name_rendered(
+        "declare abstract class Aq44 { get [fq30(4)](); }",
+        7033,
+        "Property '[fq30(4)]'",
+    );
+}
+
+#[test]
+fn ts7033_static_call_computed_name_is_named() {
+    assert_computed_name_rendered(
+        "declare class Cq45 { static get [fq30(5)](); }",
+        7033,
+        "Property '[fq30(5)]'",
+    );
+}
+
+#[test]
+fn ts7008_bare_property_call_computed_name_is_named() {
+    assert_computed_name_rendered(
+        "declare class Cq46 { [fq30(6)]; }",
+        7008,
+        "Member '[fq30(6)]'",
+    );
+}
+
+#[test]
+fn ts7008_interface_bare_property_call_computed_name_is_named() {
+    assert_computed_name_rendered("interface Iq47 { [fq30(7)]; }", 7008, "Member '[fq30(7)]'");
+}
+
+#[test]
+fn ts7010_bodyless_method_call_computed_name_is_not_downgraded_to_ts7011() {
+    // An unnamable member falls through to TS7011. This is the row where the
+    // whitelist cost a diagnostic *code*, not only a message.
+    let source = format!("{Q30_PRELUDE}declare class Cq48 {{ [fq30(8)](); }}");
+    let codes: Vec<u32> = check_source_strict_messages(&source)
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect();
+    assert!(
+        !codes.contains(&7011),
+        "a nameable computed member must not fall through to TS7011; got {codes:?}"
+    );
+    assert_names(
+        &source,
+        7010,
+        "'[fq30(8)]', which lacks return-type annotation",
+    );
+}
+
+#[test]
+fn ts7010_interface_bodyless_method_call_computed_name_is_named() {
+    assert_computed_name_rendered(
+        "interface Iq49 { [fq30(9)](); }",
+        7010,
+        "'[fq30(9)]', which lacks return-type annotation",
+    );
+}
+
+#[test]
+fn non_constant_computed_key_accessor_pair_blames_both_halves() {
+    // A constant key pairs the accessors and blames only the setter (TS7032,
+    // see `ts7032_...` above). A call expression is not a constant key, so tsc
+    // treats the two halves as separate members and reports both codes.
+    let source =
+        format!("{Q30_PRELUDE}declare class Cq50 {{ get [fq30(10)](); set [fq30(10)](v); }}");
+    let codes: Vec<u32> = check_source_strict_messages(&source)
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect();
+    assert!(
+        codes.contains(&7033) && codes.contains(&7032),
+        "a non-constant computed key does not pair the accessors; got {codes:?}"
+    );
+    assert_names(&source, 7032, "Property '[fq30(10)]'");
+}
+
+// ---------------------------------------------------------------------------
+// Verbatim means verbatim — the two shapes that prove the renderer reads source
+// text rather than reassembling the name from its parts.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn single_quoted_string_computed_name_keeps_its_own_quote_character() {
+    // The old literal arm rebuilt the name as `"{text}"`, forcing double
+    // quotes. `getTextOfNode` returns the source spelling.
+    assert_names(
+        "declare class Cq51 { get ['sq51'](); }",
+        7033,
+        "Property '['sq51']'",
+    );
+}
+
+#[test]
+fn computed_name_keeps_a_comment_written_inside_the_brackets() {
+    // Reassembling `[{inner}]` from the expression's own span drops interior
+    // trivia, because the expression starts after the comment. tsc renders the
+    // whole name node.
+    assert_names(
+        "declare class Cq52 { get [/* cq52 */ \"sq52\"](); }",
+        7033,
+        "Property '[/* cq52 */ \"sq52\"]'",
+    );
+}
+
+#[test]
+fn parse_recovered_computed_name_still_reports_no_implicit_any_member_diagnostic() {
+    // `get [1+]();` parses as a binary expression whose right operand is the
+    // parser's zero-width recovery placeholder. Verbatim source text would
+    // render it `[1+]` and start reporting a diagnostic tsc never emits —
+    // `typescript@7.0.2` reports only TS1109 here. The recovery placeholder,
+    // not the expression's kind, is what makes a name unrenderable.
+    let codes: Vec<u32> = check_source_strict_messages("declare class Cq53 { get [1+](); }")
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect();
+    assert!(
+        !codes.contains(&7033),
+        "a parse-recovered computed name must not draw TS7033; got {codes:?}"
+    );
+}
+
+#[test]
+fn parse_recovered_computed_name_inside_parentheses_is_still_declined() {
+    // The placeholder is one level deeper here, so a probe that only looked at
+    // the expression node itself would name `[(2+)]` and report.
+    let codes: Vec<u32> = check_source_strict_messages("declare class Cq54 { get [(2+)](); }")
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect();
+    assert!(
+        !codes.contains(&7033),
+        "a parse-recovered computed name must not draw TS7033; got {codes:?}"
+    );
+}


### PR DESCRIPTION
Closes #16250.

**Structural rule.** When a computed member name is well formed, `tsc` names it in a diagnostic with the name node's verbatim source text — `declarationNameToString`'s last arm is `getTextOfNode` and it is **unconditional**, so the expression's kind is irrelevant. tsz now does the same through the checker's diagnostic-display helper, `computed_name_expression_display_text` (`crates/tsz-checker/src/state/state_checking_members/interface_checks.rs`).

The wrong semantic operation was **diagnostic display**, not key resolution or property lookup. The helper rendered a name only if the expression matched a whitelist of node kinds — string / numeric / template literal here, then identifier, dotted access, **zero-argument** call and parenthesized in `simple_computed_name_expr_text_in_arena`. Everything else returned `None`, `member_name_for_diagnostic` failed, and every site that gates on it dropped the member's whole `noImplicitAny` family (TS7008 / TS7010 / TS7032 / TS7033) **silently**, with TS7010 additionally degrading to TS7011 in class containers. Three prior fixes (#16190/#16225, #16201, #16229) each closed one more node kind; the whitelist itself was the defect.

### What changed

1. **Verbatim rendering replaces the whitelist.** The `[...]` node's own source text is returned. The old literal/template arms stay as the fallback for a node with no owning source file (synthesized or lib-merged declarations), where there is nothing to slice.
2. **A deny-list over parser recovery replaces the whitelist's polarity.** `get [1+]();` parses as a binary expression whose right operand is the zero-width placeholder `create_missing_expression` builds; tsc reports only `TS1109` there and never the member diagnostic. `computed_name_expression_is_parse_recovered` finds that placeholder structurally — it occupies no source text — and treats an *absent* required child (`[a.]`, where the member position never materialized) as the same signal. An expression form the probe cannot descend into defaults to **well formed and named**, the opposite of the old default, which is what made each new node kind its own bug.
3. **The whole name node is read, not reassembled from `[{inner}]`.** That is what preserves the syntax `getTextOfNode` preserves: parentheses, the author's own quote character, and a comment written inside the brackets.

`simple_computed_name_expr_text_in_arena` is deliberately **not** widened: it is shared with the *key* helpers (`get_member_name_text`, `should_check_late_bound_class_property_name`), where unwrapping parentheses is correct for member identity. #16212 established that separation and it holds here.

No identifier, alias, property or file-name string drives any decision; no predicate reads rendered type or printer output. The only new predicate is "the parser gave up inside this name".

### Adjacent-case matrix

Every row recorded from the pinned `typescript@7.0.2` (`--noEmit --strict --lib es2022 --target es2022`), not derived from the rule. Binder names are distinct per row so nothing can key on an identifier string, and the expressions are chosen so the *key* is not statically resolvable — a renderer still going through the key resolver produces nothing for them.

| computed name | tsc 7.0.2 | tsz before | tsz after |
| --- | --- | --- | --- |
| `[fq30(1)]` (call **with** arguments) | `Property '[fq30(1)]'` | *nothing* | matches |
| `[aq30 + "b"]` (binary) | `Property '[aq30 + "b"]'` | *nothing* | matches |
| `[bq30 ? "x" : "y"]` (conditional) | `Property '[bq30 ? "x" : "y"]'` | *nothing* | matches |
| `[aq30 as string]` (assertion) | `Property '[aq30 as string]'` | *nothing* | matches |
| ``[tagq30`sq35`]`` (tagged template) | ``Property '[tagq30`sq35`]'`` | *nothing* | matches |
| `[oq30["kq30"]]` (element access) | `Property '[oq30["kq30"]]'` | *nothing* | matches |
| `[aq30!]` (non-null) | `Property '[aq30!]'` | *nothing* | matches |
| `[(aq30)]` | `Property '[(aq30)]'` | `[aq30]` — **parens dropped** | matches |
| `[((aq30))]` | `Property '[((aq30))]'` | `[aq30]` | matches |
| `[("sq40")]` | `Property '[("sq40")]'` | *nothing* | matches |
| ``[(`sq41`)]`` | ``Property '[(`sq41`)]'`` | *nothing* | matches |
| `['sq51']` (single-quoted) | `Property '['sq51']'` | `["sq51"]` — quote rewritten | matches |
| `[/* cq52 */ "sq52"]` | `Property '[/* cq52 */ "sq52"]'` | *nothing* | matches |

Containers and member kinds, all on the same non-resolvable `[fq30(n)]` name, so the fix is pinned at the shared renderer rather than at one caller: `declare class` / `abstract class` / `interface` / type literal / `static` (TS7033), bare property in a class and in an interface (TS7008), bodyless method in a class and in an interface (TS7010, asserted **not** to fall through to TS7011). A non-constant computed key does **not** pair the accessors — tsc reports TS7033 *and* TS7032 for `get [fq30(10)]() / set [fq30(10)](v)`, unlike the constant-key case that blames only the setter; both are pinned.

Negative / fallback rows, all reporting **no** member diagnostic, matching tsc's syntax-error-only output: `get [](); ` (empty name), `get [1+](); ` and `get [(2+)](); ` (zero-width placeholder one and two levels deep), `get [aq70.](); ` (TS1003) and `get [aq71[](); ` (TS1011/TS1005) — the last two an absent required child rather than a placeholder.

## Goal
Goal: hold

## Verification

All at final head `2608f90` unless noted.

- `cargo fmt --all` — clean.
- `cargo clippy --profile ci-lint --workspace --exclude tsz-conformance --all-targets -- -D warnings` — clean (CI's exact invocation). CI at exact head `2608f90`: `clippy`, `arch-size`, `CI Summary` all **success**.
- `cargo test -p tsz-checker --lib --profile ci-unit computed_member_name_diagnostic_display` — **54 passed, 0 failed** (23 new rows). Load-bearing check at the first head: with only the source change reverted and the tests kept, **19 of the new rows fail** (31 passed / 19 failed).
- `cargo test -p tsz-checker --profile ci-unit --test noimplicitany_ambient_member_surface_tests` — **45 passed, 0 failed**. This suite caught the parse-recovery regression the first draft introduced (the `[1+]` row); the recovery probe exists because of it.
- `scripts/conformance/compare-to-parent.sh` — the two-sided gate, run twice, once per head. Both clean:

  | head | base | base failing | branch failing | newly passing | newly failing | fingerprint changed |
  | --- | --- | --- | --- | --- | --- | --- |
  | `ee79baf` | `4ff7c23` | 568 | 568 | 0 | 0 | 0 |
  | `2608f90` | `4ff7c23` | 568 | 568 | 0 | 0 | 0 |

  Both snapshots: 12585 candidates, 12043 runnable, 11475 passed, 507 unsupported, 35 skipped (95.3%). Read this as the gate it was asked for — an additive diagnostic introduced no regression, and no row's message text moved either — not as evidence of corpus reach. The corpus does not appear to exercise a non-whitelisted computed member name in a `noImplicitAny` position.
- Emit: not run in this container (`scripts/` has no `node_modules`; the board flagged that first install as a 40+ min hang risk). This change alters only diagnostic message text and whether a `noImplicitAny` diagnostic is emitted — the emitter consumes neither — but stating that rather than implying the gate ran.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Obsidian