### PR TITLE
fix(checker): TS1168 was never wired up for concrete class method computed names

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -716,6 +716,42 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        // TS1168: a computed method name in a *concrete* (non-ambient) class
+        // must be a literal or `unique symbol`-typed expression when the
+        // method has no body — either a genuine overload signature ahead of
+        // its implementation, or a standalone `abstract` method, both of
+        // which are bodyless. tsc reports this per bodyless declaration, not
+        // once per overload group: an implementation with a body (even one
+        // sharing the same bad computed name) never takes it, only the
+        // signature(s) that precede it. TS1165 is this same grammar rule's
+        // ambient-context sibling (`declare class`/`.d.ts`); the two are
+        // mutually exclusive on the same `is_ambient` computation used above
+        // for TS1221/TS1222, so this arm only ever fires where TS1165 does
+        // not. Accessors are a different function (`check_accessor_...`) and
+        // are not affected: an `abstract get`/`set` with a bad computed name
+        // stays clean under tsc's own grammar, unlike an `abstract` method.
+        if method.body.is_none() {
+            let in_declared_class = self
+                .ctx
+                .enclosing_class
+                .as_ref()
+                .is_some_and(|c| c.is_declared);
+            let method_has_declare = self.has_declare_modifier(&method.modifiers);
+            let is_ambient = in_declared_class
+                || method_has_declare
+                || self.ctx.is_declaration_file()
+                || self.is_ambient_declaration(member_idx);
+
+            if !is_ambient {
+                use crate::diagnostics::diagnostic_messages;
+                self.check_computed_property_requires_literal(
+                    method.name,
+                    diagnostic_messages::A_COMPUTED_PROPERTY_NAME_IN_A_METHOD_OVERLOAD_MUST_REFER_TO_AN_EXPRESSION_WHOSE,
+                    diagnostic_codes::A_COMPUTED_PROPERTY_NAME_IN_A_METHOD_OVERLOAD_MUST_REFER_TO_AN_EXPRESSION_WHOSE,
+                );
+            }
+        }
+
         // Keep syntax and declaration-stamped JSDoc binders in scope while checking.
         let (type_params, type_param_updates) = self.push_type_parameters(&method.type_parameters);
         let method_jsdoc = self.get_jsdoc_for_function(member_idx);

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -779,6 +779,8 @@ mod top_level_await_boundary_tests;
 mod truthiness_promise_coercion_tests;
 #[path = "tests/ts1101_with_in_strict_mode_tests.rs"]
 mod ts1101_with_in_strict_mode_tests;
+#[path = "tests/ts1168_method_overload_computed_name_tests.rs"]
+mod ts1168_method_overload_computed_name_tests;
 #[path = "tests/ts1170_computed_property_syntactic_form_tests.rs"]
 mod ts1170_computed_property_syntactic_form_tests;
 #[path = "tests/ts1361_ambient_computed_property_name_tests.rs"]

--- a/crates/tsz-checker/src/tests/ts1168_method_overload_computed_name_tests.rs
+++ b/crates/tsz-checker/src/tests/ts1168_method_overload_computed_name_tests.rs
@@ -1,0 +1,248 @@
+//! Regression tests for TS1168 — a computed method name in a *concrete*
+//! (non-ambient) class must be a literal or `unique symbol`-typed expression
+//! when the method has no body.
+//!
+//! `check_computed_property_requires_literal` already implements the shared
+//! literal/entity-name/unique-symbol gate for TS1166 (class properties),
+//! TS1169 (interfaces) and TS1170 (type literals); TS1168 is the same rule's
+//! arm for a bodyless class *method* declaration outside an ambient context
+//! (`declare class`/`.d.ts`, which is TS1165 instead). Oracle-verified
+//! against pinned `typescript@7.0.2`.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn diag_codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+// --- Positive: bodyless method, non-ambient, non-literal computed name ---
+
+#[test]
+fn ts1168_overload_signature_before_implementation() {
+    let codes = diag_codes(
+        r#"
+declare const x: string;
+class C {
+    [`a${x}`](): void;
+    [`a${x}`](y: number): void;
+    [`a${x}`](y?: number): void { }
+}
+"#,
+    );
+    assert_eq!(
+        codes.iter().filter(|&&c| c == 1168).count(),
+        2,
+        "Expected TS1168 on both bodyless overload signatures, not the implementation. Got: {codes:?}"
+    );
+}
+
+#[test]
+fn ts1168_standalone_abstract_method() {
+    let codes = diag_codes(
+        r#"
+declare const x: string;
+abstract class C {
+    abstract [`a${x}`](): void;
+}
+"#,
+    );
+    assert!(
+        codes.contains(&1168),
+        "Expected TS1168 for a standalone bodyless abstract method. Got: {codes:?}"
+    );
+}
+
+#[test]
+fn ts1168_static_overload_signatures() {
+    let codes = diag_codes(
+        r#"
+declare const x: string;
+class C {
+    static [`a${x}`](): void;
+    static [`a${x}`](y: number): void;
+    static [`a${x}`](y?: number): void { }
+}
+"#,
+    );
+    assert_eq!(
+        codes.iter().filter(|&&c| c == 1168).count(),
+        2,
+        "Expected TS1168 on both static bodyless overload signatures. Got: {codes:?}"
+    );
+}
+
+#[test]
+fn ts1168_lone_overload_signature_with_no_implementation() {
+    // A single bodyless method with nothing following it also carries TS1168
+    // — the gate is "no body", not "part of a multi-signature overload set".
+    let codes = diag_codes(
+        r#"
+declare const x: string;
+class C {
+    [`a${x}`](): void;
+}
+"#,
+    );
+    assert!(
+        codes.contains(&1168),
+        "Expected TS1168 for a lone bodyless method with a bad computed name. Got: {codes:?}"
+    );
+}
+
+#[test]
+fn ts1168_renamed_binder() {
+    // Renamed-binder control: the diagnostic is keyed on shape, not on any
+    // hardcoded identifier text.
+    let codes = diag_codes(
+        r#"
+declare const zzTemplateOperand: string;
+class Widget {
+    [`prefix${zzTemplateOperand}`](): void;
+    [`prefix${zzTemplateOperand}`](y: number): void;
+    [`prefix${zzTemplateOperand}`](y?: number): void { }
+}
+"#,
+    );
+    assert_eq!(
+        codes.iter().filter(|&&c| c == 1168).count(),
+        2,
+        "Expected TS1168 on both renamed-binder overload signatures. Got: {codes:?}"
+    );
+}
+
+// --- Negative: implementation with a body never takes it ---
+
+#[test]
+fn ts1168_implementation_with_body_is_clean() {
+    let codes = diag_codes(
+        r#"
+declare const x: string;
+class C {
+    [`a${x}`](): void { }
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&1168),
+        "A method with a body must never take TS1168, even with a bad computed name. Got: {codes:?}"
+    );
+}
+
+// --- Negative: entity-name / literal / unique-symbol computed names ---
+
+#[test]
+fn ts1168_string_literal_name_is_clean() {
+    let codes = diag_codes(
+        r#"
+class C {
+    ["abc"](): void;
+    ["abc"](y: number): void;
+    ["abc"](y?: number): void { }
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&1168),
+        "A string-literal computed name must never take TS1168. Got: {codes:?}"
+    );
+}
+
+#[test]
+fn ts1168_unique_symbol_name_is_clean() {
+    let codes = diag_codes(
+        r#"
+declare const sym: unique symbol;
+class C {
+    [sym](): void;
+    [sym](y: number): void;
+    [sym](y?: number): void { }
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&1168),
+        "A unique-symbol-typed computed name must never take TS1168. Got: {codes:?}"
+    );
+}
+
+#[test]
+fn ts1168_entity_name_expression_is_clean() {
+    let codes = diag_codes(
+        r#"
+declare const a: { b: string };
+class C {
+    [a.b](): void;
+    [a.b](y: number): void;
+    [a.b](y?: number): void { }
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&1168),
+        "An entity-name-expression computed name must never take TS1168. Got: {codes:?}"
+    );
+}
+
+// --- Negative: ambient context takes TS1165, not TS1168 ---
+
+#[test]
+fn ts1168_does_not_fire_in_declare_class() {
+    // `declare class` is the ambient sibling rule (TS1165, not yet wired up
+    // as of this test's authoring — tracked separately). This arm must not
+    // fire here regardless.
+    let codes = diag_codes(
+        r#"
+declare const x: string;
+declare class C {
+    [`a${x}`](): void;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&1168),
+        "TS1168 must not fire inside a `declare class` — that is the ambient sibling rule. Got: {codes:?}"
+    );
+}
+
+// --- Negative: accessors are a different grammar arm (TS7032/TS7033), not TS1168 ---
+
+#[test]
+fn ts1168_does_not_fire_on_abstract_accessor() {
+    let codes = diag_codes(
+        r#"
+declare const x: string;
+abstract class C {
+    abstract get [`a${x}`](): number;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&1168),
+        "An abstract accessor with a bad computed name must not take TS1168 — accessors are TS7033's domain. Got: {codes:?}"
+    );
+}
+
+// --- Negative: interface/type-literal members are a different (already-correct) arm ---
+
+#[test]
+fn ts1168_does_not_fire_on_interface_method() {
+    let codes = diag_codes(
+        r#"
+declare const x: string;
+interface I {
+    [`a${x}`](): void;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&1168),
+        "An interface method signature takes TS1169, never TS1168. Got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1169),
+        "Expected the interface's own TS1169 to still fire. Got: {codes:?}"
+    );
+}


### PR DESCRIPTION
Structural rule: when a bodyless class method declaration outside an ambient context — a genuine overload signature preceding its implementation, or a standalone `abstract` method — has a computed name that is not a literal or `unique symbol`-typed expression, `tsc` reports TS1168 unconditionally; tsz never called this diagnostic through any checker path.

TS1168's message/code already existed in the generated diagnostics table (`crates/tsz-common/src/diagnostics/data/parts/part_000.rs:130`) but had **zero call sites anywhere in the checker** (confirmed by grep before starting). TS1165 is this same grammar rule's ambient-context sibling (`declare class`/`.d.ts`, tracked separately in #16253/#16261); the two are mutually exclusive on the same `is_ambient` computation already used in this function for TS1221/TS1222, so this arm only fires where TS1165 does not — and is unaffected by whether TS1165 itself is wired up yet.

## Owner layer

Checker only, one gated call to the existing shared `check_computed_property_requires_literal` helper (already backing TS1166/TS1169/TS1170) in `check_method_declaration_with_request` (`crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs`). No new mechanism, no solver/binder/parser/emitter change, no identifier/file-name string check — the gate is the existing `is_ambient` formula plus `method.body.is_none()`.

## Oracle matrix — pinned `typescript@7.0.2`, `--noEmit --strict --pretty false`

| shape | tsc | before | after |
| --- | --- | --- | --- |
| overload signature before implementation (2 sigs + 1 impl) | TS1168 ×2 | clean | TS1168 ×2 |
| standalone `abstract` method | TS1168 | clean | TS1168 |
| static overload signatures | TS1168 ×2 | clean | TS1168 ×2 |
| lone bodyless method, no following implementation | TS1168 | clean | TS1168 |
| implementation with a body (same bad name) | clean | clean | clean |
| string-literal computed name | clean | clean | clean |
| `unique symbol` computed name | clean | clean | clean |
| entity-name-expression computed name (`a.b`) | clean | clean | clean |
| `declare class` (TS1165's domain) | TS1165 | clean | clean (unaffected — TS1165 not yet wired up) |
| abstract accessor (`abstract get [...]`) | clean | clean | clean |
| interface method signature | TS1169 | TS1169 | TS1169 (unaffected) |

## Adjacent-case matrix (`crates/tsz-checker/src/tests/ts1168_method_overload_computed_name_tests.rs`, wired into `test_module_registry.rs`)

12 new tests: overload signature before implementation, standalone abstract method, static overload signatures, lone bodyless signature, renamed-binder control, implementation-with-body negative, literal/unique-symbol/entity-name negatives, `declare class` negative, abstract-accessor negative, interface-signature negative (confirms TS1169 still fires independently).

Verified load-bearing the same way as #16269: reverting only the one checker hunk left the two positive-count assertions failing while every negative control stayed green (spot-checked by temporarily reverting the added block).

## Verification

- `cargo test -p tsz-checker --lib ts1168` — 12/12 pass.
- `cargo test -p tsz-checker --lib -- computed_property ts1170 ts1169 ts1166 ts1361 generator overload_compatibility ts2394` — 267/267 pass, no regressions in the sibling computed-property-name/generator/overload families that share the same member-loop code.
- `cargo fmt -p tsz-checker -- --check` — clean.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py` — passed.
- Local `pre-commit` hook (fmt + clippy + arch-guard) — passed.
- **Not run**: `scripts/conformance/compare-to-parent.sh` — started (corpus fetched via `reset-ts-submodule.sh --sparse`, then a cold `dist-fast` build), but the cold optimized build for `tsz-checker`/`tsz-emitter` did not finish inside this session's time budget (single-crate cold `dist-fast` runs several minutes past the incremental figures on the board). Risk read as low, same reasoning as #16269/#16261: this is a pure additive false-negative fix on a shape (a non-literal computed name on a bodyless overload signature/abstract method) vanishingly unlikely to appear in the corpus, so zero conformance movement is the expected signature, not evidence the fix is inert.
- Not run: emit/fourslash — no emit or LSP-surface code touched.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_01A3GTW1iNQ2gpKisCL2eygT)_