### PR TITLE
fix(checker): the `this`-parameter placement family was never wired up (TS2680/TS2681/TS2784/TS2730)

### DIFF
--- a/crates/tsz-checker/src/checkers/parameter_checker.rs
+++ b/crates/tsz-checker/src/checkers/parameter_checker.rs
@@ -680,6 +680,8 @@ impl<'a> CheckerState<'a> {
 
         let mut seen_optional = false;
 
+        self.check_this_parameter_placement(parameters, func_idx);
+
         for &param_idx in &parameters.nodes {
             let Some(param_node) = self.ctx.arena.get(param_idx) else {
                 continue;
@@ -737,6 +739,36 @@ impl<'a> CheckerState<'a> {
                 }
             }
         }
+    }
+
+    /// Report the `this`-parameter placement and container errors for one
+    /// signature's parameter list.
+    ///
+    /// A `this` parameter is legal only as the *first* parameter of a
+    /// signature whose container can have one at all. `tsc` decides this in
+    /// `checkParameter` from two structural facts and nothing else — the
+    /// parameter's index in its own list, and the `SyntaxKind` of the
+    /// container — and reports every arm that applies rather than stopping at
+    /// the first:
+    ///
+    /// - not at index 0 -> `TS2680`
+    /// - container constructs (`Constructor` / `ConstructSignature` /
+    ///   `ConstructorType`) -> `TS2681`
+    /// - container is an accessor (`GetAccessor` / `SetAccessor`) -> `TS2784`
+    /// - container is an `ArrowFunction` -> `TS2730`, whose `this` is lexical
+    ///
+    /// The arms are independent: `class C { constructor(x: number, this: C) {} }`
+    /// draws `TS2680` *and* `TS2681`, so this cannot be a match over the
+    /// container kind.
+    pub(crate) fn check_this_parameter_placement(
+        &mut self,
+        parameters: &tsz_parser::parser::NodeList,
+        func_idx: Option<tsz_parser::parser::NodeIndex>,
+    ) {
+        let container_kind = func_idx
+            .and_then(|idx| self.ctx.arena.get(idx))
+            .map(|node| node.kind);
+        check_this_parameter_placement_in_ctx(&mut self.ctx, parameters, container_kind);
     }
 
     /// Check if a JSDoc `@param` tag marks a parameter as optional.
@@ -1544,6 +1576,115 @@ impl<'a> CheckerState<'a> {
                     }
                 }
             }
+        }
+    }
+}
+
+/// Report the `this`-parameter placement and container errors for one
+/// signature's parameter list, given only the checker context and the
+/// container's `SyntaxKind`.
+///
+/// A `this` parameter is legal only as the *first* parameter of a signature
+/// whose container can have one at all. `tsc` decides this in `checkParameter`
+/// from two structural facts and nothing else — the parameter's index in its
+/// own list, and the `SyntaxKind` of the container — and reports every arm
+/// that applies rather than stopping at the first:
+///
+/// - not at index 0 -> `TS2680`
+/// - container constructs (`Constructor` / `ConstructSignature` /
+///   `ConstructorType`) -> `TS2681`
+/// - container is an accessor (`GetAccessor` / `SetAccessor`) -> `TS2784`
+/// - container is an `ArrowFunction` -> `TS2730`, whose `this` is lexical
+///
+/// The arms are independent: `class C { constructor(x: number, this: C) {} }`
+/// draws `TS2680` *and* `TS2681`, so this cannot be a match over the container
+/// kind. `container_kind` is `None` only when the caller has no owning node, in
+/// which case the position arm still applies and the container arms cannot.
+///
+/// Lives at context level rather than on `CheckerState` because the
+/// `FunctionType` / `ConstructorType` callers run inside `TypeNodeChecker`,
+/// which has the context but not the checker state.
+pub(crate) fn check_this_parameter_placement_in_ctx(
+    ctx: &mut crate::CheckerContext,
+    parameters: &tsz_parser::parser::NodeList,
+    container_kind: Option<u16>,
+) {
+    use crate::diagnostics::{diagnostic_codes, format_message};
+    use tsz_common::diagnostics::get_message_template;
+    use tsz_parser::parser::syntax_kind_ext;
+    use tsz_scanner::SyntaxKind;
+
+    let report = |ctx: &mut crate::CheckerContext, param_idx: NodeIndex, code: u32| {
+        let Some(node) = ctx.arena.get(param_idx) else {
+            return;
+        };
+        let (pos, len) = (node.pos, node.end.saturating_sub(node.pos));
+        let template = get_message_template(code).unwrap_or_default();
+        // `{0}` on TS2680 is the parameter name, always `this` here; tsc
+        // renders it from the name rather than hard-coding the word.
+        let message = format_message(template, &["this"]);
+        ctx.error(pos, len, message, code);
+    };
+
+    for (index, &param_idx) in parameters.nodes.iter().enumerate() {
+        let is_this_param = ctx
+            .arena
+            .get(param_idx)
+            .and_then(|param_node| ctx.arena.get_parameter(param_node))
+            .and_then(|param| ctx.arena.get(param.name))
+            .is_some_and(|name_node| {
+                name_node.kind == SyntaxKind::ThisKeyword as u16
+                    || ctx
+                        .arena
+                        .get_identifier(name_node)
+                        .is_some_and(|ident| ident.escaped_text == "this")
+            });
+        if !is_this_param {
+            continue;
+        }
+
+        if index != 0 {
+            report(
+                ctx,
+                param_idx,
+                diagnostic_codes::A_PARAMETER_MUST_BE_THE_FIRST_PARAMETER,
+            );
+        }
+
+        let Some(kind) = container_kind else {
+            continue;
+        };
+
+        // All three of these container kinds construct, so none of them has a
+        // meaningful `this` to annotate.
+        if kind == syntax_kind_ext::CONSTRUCTOR
+            || kind == syntax_kind_ext::CONSTRUCT_SIGNATURE
+            || kind == syntax_kind_ext::CONSTRUCTOR_TYPE
+        {
+            report(
+                ctx,
+                param_idx,
+                diagnostic_codes::A_CONSTRUCTOR_CANNOT_HAVE_A_THIS_PARAMETER,
+            );
+        }
+
+        if kind == syntax_kind_ext::GET_ACCESSOR || kind == syntax_kind_ext::SET_ACCESSOR {
+            report(
+                ctx,
+                param_idx,
+                diagnostic_codes::GET_AND_SET_ACCESSORS_CANNOT_DECLARE_THIS_PARAMETERS,
+            );
+        }
+
+        // The JS/JSDoc `@this`-tag arm for arrow functions lives in
+        // `function_type.rs` and triggers on a tag with no parameter node, so
+        // the two cannot both fire for one arrow function.
+        if kind == syntax_kind_ext::ARROW_FUNCTION {
+            report(
+                ctx,
+                param_idx,
+                diagnostic_codes::AN_ARROW_FUNCTION_CANNOT_HAVE_A_THIS_PARAMETER,
+            );
         }
     }
 }

--- a/crates/tsz-checker/src/state/state_checking/class.rs
+++ b/crates/tsz-checker/src/state/state_checking/class.rs
@@ -795,6 +795,10 @@ impl<'a> CheckerState<'a> {
         // Check for duplicate-member modifier disagreements (TS2687)
         self.check_class_member_modifier_disagreements(&class.members.nodes);
 
+        // TS2784/TS2680 on accessor `this` parameters. Runs for ambient classes
+        // too, unlike the implementation walk below.
+        self.check_class_accessor_this_parameters(&class.members.nodes);
+
         // Check for missing method/constructor implementations (2389, 2390, 2391)
         // Skip for declared classes (ambient declarations don't need implementations)
         if !is_declared {
@@ -1203,6 +1207,9 @@ impl<'a> CheckerState<'a> {
 
         // Check for duplicate-member modifier disagreements (TS2687)
         self.check_class_member_modifier_disagreements(&class.members.nodes);
+
+        // TS2784/TS2680 on accessor `this` parameters.
+        self.check_class_accessor_this_parameters(&class.members.nodes);
 
         // Check for missing method/constructor implementations (2389, 2390, 2391)
         self.check_class_member_implementations(&class.members.nodes);

--- a/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
@@ -1035,6 +1035,31 @@ impl<'a> CheckerState<'a> {
 
     /// Check that all method/constructor overload signatures have implementations.
     /// Reports errors 2389, 2390, 2391, 1042.
+    /// TS2784/TS2680 for class accessors.
+    ///
+    /// Accessors do not route through `check_parameter_ordering` — the walks
+    /// that do are keyed on methods, constructors and signatures — so the
+    /// shared `this`-parameter placement check runs from its own member walk.
+    /// This one deliberately runs for ambient classes too: a `declare class`
+    /// getter can declare a `this` parameter just as illegally as a concrete
+    /// one, and `check_class_member_implementations` is skipped when the class
+    /// is ambient.
+    pub(crate) fn check_class_accessor_this_parameters(&mut self, members: &[NodeIndex]) {
+        for &member_idx in members {
+            let Some(node) = self.ctx.arena.get(member_idx) else {
+                continue;
+            };
+            if node.kind != syntax_kind_ext::GET_ACCESSOR
+                && node.kind != syntax_kind_ext::SET_ACCESSOR
+            {
+                continue;
+            }
+            if let Some(accessor) = self.ctx.arena.get_accessor(node) {
+                self.check_this_parameter_placement(&accessor.parameters, Some(member_idx));
+            }
+        }
+    }
+
     pub(crate) fn check_class_member_implementations(&mut self, members: &[NodeIndex]) {
         use crate::diagnostics::diagnostic_codes;
 

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -767,6 +767,8 @@ mod syntax_constraint_relation_routing_arch_tests;
 mod synthetic_unique_atom_union_display_tests;
 #[path = "tests/this_context_self_type_tests.rs"]
 mod this_context_self_type_tests;
+#[path = "tests/this_parameter_placement_tests.rs"]
+mod this_parameter_placement_tests;
 #[path = "tests/this_prop_nullish_operand_code_tests.rs"]
 mod this_prop_nullish_operand_code_tests;
 #[path = "tests/this_source_inference_tests.rs"]

--- a/crates/tsz-checker/src/tests/this_parameter_placement_tests.rs
+++ b/crates/tsz-checker/src/tests/this_parameter_placement_tests.rs
@@ -1,0 +1,293 @@
+//! Regression tests for the `this`-parameter placement family: TS2680, TS2681,
+//! TS2784 and the TypeScript-syntax half of TS2730.
+//!
+//! `tsc` decides all four in `checkParameter` from two structural facts and
+//! nothing else — the parameter's index in its own list, and the `SyntaxKind`
+//! of the container. Three of the four codes existed in tsz's generated message
+//! table with zero call sites anywhere, so a `this` parameter in an illegal
+//! position or an illegal container was silently accepted; TS2730 was wired for
+//! JS files only, through the JSDoc `@this` tag, and never for a real `this`
+//! parameter node in a TypeScript arrow function.
+//!
+//! The arms are independent rather than a match over the container kind:
+//! a `this` parameter that is both misplaced *and* in a constructing container
+//! draws TS2680 *and* TS2681, and the `both_arms_*` rows below pin that.
+//!
+//! Every binder name is distinct per row so nothing can key on an identifier
+//! string, and each positive shape is paired with the same shape holding a
+//! *legal* leading `this` parameter, so a check that fired on the mere presence
+//! of a `this` parameter would fail the negatives.
+
+use crate::test_utils::check_source_strict_messages;
+
+fn codes(source: &str) -> Vec<u32> {
+    let mut found: Vec<u32> = check_source_strict_messages(source)
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect();
+    found.sort_unstable();
+    found
+}
+
+#[track_caller]
+fn assert_reports(source: &str, expected: &[u32]) {
+    let found = codes(source);
+    let mut want = expected.to_vec();
+    want.sort_unstable();
+    let relevant: Vec<u32> = found
+        .iter()
+        .copied()
+        .filter(|c| matches!(c, 2680 | 2681 | 2730 | 2784))
+        .collect();
+    assert_eq!(
+        relevant, want,
+        "this-parameter diagnostics for source:\n{source}\nall codes: {found:?}"
+    );
+}
+
+#[track_caller]
+fn assert_clean(source: &str) {
+    assert_reports(source, &[]);
+}
+
+// ---------------------------------------------------------------------------
+// TS2680 — a `this` parameter that is not the first parameter
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ts2680_function_declaration_this_parameter_after_another() {
+    assert_reports("function fa20(xa20: number, this: string) {}", &[2680]);
+}
+
+#[test]
+fn ts2680_class_method_this_parameter_after_another() {
+    assert_reports("class Ca20 { ma20(ya20: number, this: Ca20) {} }", &[2680]);
+}
+
+#[test]
+fn ts2680_interface_method_signature_this_parameter_after_another() {
+    assert_reports(
+        "interface Ia20 { mb20(za20: number, this: Ia20): void; }",
+        &[2680],
+    );
+}
+
+#[test]
+fn ts2680_function_type_node_this_parameter_after_another() {
+    assert_reports("type Ta20 = (wa20: number, this: string) => void;", &[2680]);
+}
+
+#[test]
+fn ts2680_function_expression_this_parameter_after_another() {
+    assert_reports(
+        "const ka20 = function (va20: number, this: string) {};",
+        &[2680],
+    );
+}
+
+#[test]
+fn ts2680_third_position_still_reports_once() {
+    assert_reports(
+        "function fb20(ua20: number, ta20: string, this: symbol) {}",
+        &[2680],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TS2681 — constructing containers: Constructor, ConstructSignature,
+// ConstructorType. All three construct, so none has a `this` to annotate.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ts2681_class_constructor() {
+    assert_reports("class Cb20 { constructor(this: Cb20) {} }", &[2681]);
+}
+
+#[test]
+fn ts2681_interface_construct_signature() {
+    assert_reports("interface Ib20 { new (this: Ib20): Ib20; }", &[2681]);
+}
+
+#[test]
+fn ts2681_constructor_type_node() {
+    assert_reports("type Tb20 = new (this: string) => string;", &[2681]);
+}
+
+#[test]
+fn ts2681_ambient_class_constructor() {
+    assert_reports("declare class Cc20 { constructor(this: Cc20); }", &[2681]);
+}
+
+#[test]
+fn ts2681_type_literal_construct_signature() {
+    assert_reports("type Tc20 = { new (this: string): string };", &[2681]);
+}
+
+// ---------------------------------------------------------------------------
+// TS2784 — get/set accessors
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ts2784_class_getter() {
+    assert_reports("class Cd20 { get pa20(this: Cd20) { return 1; } }", &[2784]);
+}
+
+#[test]
+fn ts2784_class_setter() {
+    assert_reports(
+        "class Ce20 { set pb20(this: Ce20, ra20: number) {} }",
+        &[2784],
+    );
+}
+
+#[test]
+fn ts2784_static_class_getter() {
+    assert_reports(
+        "class Cf20 { static get pc20(this: typeof Cf20) { return 1; } }",
+        &[2784],
+    );
+}
+
+#[test]
+fn ts2784_ambient_class_getter() {
+    assert_reports(
+        "declare class Cg20 { get pd20(this: Cg20): number; }",
+        &[2784],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TS2730 — an arrow function's `this` is lexical, so it cannot declare one.
+// The pre-existing JS/JSDoc `@this`-tag arm triggers on a tag with no parameter
+// node, so these rows exercise a path that arm never reached.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ts2730_arrow_function_this_parameter() {
+    assert_reports("const aa20 = (this: string, qa20: number) => {};", &[2730]);
+}
+
+#[test]
+fn ts2730_class_property_arrow_this_parameter() {
+    assert_reports("class Ch20 { pf20 = (this: Ch20) => {}; }", &[2730]);
+}
+
+// ---------------------------------------------------------------------------
+// Independent arms — a misplaced `this` in an illegal container draws both.
+// A `match` over the container kind, or an early return after the position
+// arm, fails exactly these rows.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn both_arms_constructor_with_misplaced_this() {
+    assert_reports(
+        "class Ci20 { constructor(pa21: number, this: Ci20) {} }",
+        &[2680, 2681],
+    );
+}
+
+#[test]
+fn both_arms_setter_with_misplaced_this() {
+    assert_reports(
+        "class Cj20 { set pg20(oa20: number, this: Cj20) {} }",
+        &[2680, 2784],
+    );
+}
+
+#[test]
+fn both_arms_arrow_with_misplaced_this() {
+    assert_reports(
+        "const ba20 = (na20: number, this: string) => {};",
+        &[2680, 2730],
+    );
+}
+
+#[test]
+fn both_arms_constructor_type_with_misplaced_this() {
+    assert_reports(
+        "type Td20 = new (ma20: number, this: string) => string;",
+        &[2680, 2681],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negatives — a legal leading `this` parameter in every container that allows
+// one. These are the same shapes as the positives above; a check that fired on
+// the presence of a `this` parameter rather than on its position and container
+// fails all of them.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn legal_leading_this_in_function_declaration() {
+    assert_clean("function fc20(this: string, la20: number) {}");
+}
+
+#[test]
+fn legal_leading_this_in_class_method() {
+    assert_clean("class Ck20 { mc20(this: Ck20, ka21: number) {} }");
+}
+
+#[test]
+fn legal_leading_this_in_static_class_method() {
+    assert_clean("class Cl20 { static md20(this: typeof Cl20) {} }");
+}
+
+#[test]
+fn legal_leading_this_in_ambient_function() {
+    assert_clean("declare function fd20(this: void): void;");
+}
+
+#[test]
+fn legal_leading_this_in_function_type_node() {
+    assert_clean("type Te20 = (this: string, ja20: number) => void;");
+}
+
+#[test]
+fn legal_leading_this_in_interface_method_signature() {
+    assert_clean("interface Ic20 { me20(this: Ic20): void; }");
+}
+
+#[test]
+fn legal_leading_this_in_interface_call_signature() {
+    assert_clean("interface Id20 { (this: Id20, ia20: number): void; }");
+}
+
+#[test]
+fn legal_leading_this_in_function_expression() {
+    assert_clean("const ca20 = function (this: string) {};");
+}
+
+#[test]
+fn legal_leading_this_in_namespace_function() {
+    assert_clean("namespace Na20 { export function fe20(this: string) {} }");
+}
+
+#[test]
+fn legal_leading_this_in_object_literal_method() {
+    assert_clean("const da20 = { mf20(this: { mf20(): void }) {} };");
+}
+
+// ---------------------------------------------------------------------------
+// Negatives — no `this` parameter at all, in the same containers. Guards
+// against the walk mistaking an ordinary parameter for a `this` parameter.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ordinary_parameters_in_constructor_are_clean() {
+    assert_clean("class Cm20 { constructor(ha20: number, ga20: string) {} }");
+}
+
+#[test]
+fn ordinary_parameters_in_accessor_are_clean() {
+    assert_clean("class Cn20 { set ph20(fa20: number) {} }");
+}
+
+#[test]
+fn ordinary_parameters_in_arrow_are_clean() {
+    assert_clean("const ea20 = (ea21: number, da21: string) => {};");
+}
+
+#[test]
+fn a_parameter_named_like_a_property_is_not_a_this_parameter() {
+    assert_clean("function ff20(ca21: number, ba21: string) {}");
+}

--- a/crates/tsz-checker/src/types/type_node.rs
+++ b/crates/tsz-checker/src/types/type_node.rs
@@ -703,6 +703,16 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         // This ensures errors like "Cannot find name 'C'" are emitted for: (x: T) => C
         check_duplicate_parameters_in_type(self.ctx, &func_data.parameters);
         check_parameter_initializers_in_type(self.ctx, &func_data.parameters);
+        // TS2680/TS2681: a `this` parameter is as illegal in `new (this: T) => T`
+        // as in a `constructor`, and as position-bound in `(a, this: T) => void`
+        // as in any other signature. These type nodes do not route through
+        // `check_parameter_ordering`, so the shared placement check runs here.
+        let container_kind = self.ctx.arena.get(idx).map(|node| node.kind);
+        crate::checkers_domain::parameter_checker::check_this_parameter_placement_in_ctx(
+            self.ctx,
+            &func_data.parameters,
+            container_kind,
+        );
 
         use tsz_parser::parser::syntax_kind_ext;
 

--- a/crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs
@@ -546,21 +546,37 @@ impl ParserState {
             Self::make_node_list(vec![])
         } else {
             use tsz_common::diagnostics::diagnostic_codes;
-            // Report error at the accessor name, matching tsc behavior
-            if let Some(name_node) = self.arena.get(name) {
-                self.parse_error_at(
-                    name_node.pos,
-                    name_node.end - name_node.pos,
-                    "A 'get' accessor cannot have parameters.",
-                    diagnostic_codes::A_GET_ACCESSOR_CANNOT_HAVE_PARAMETERS,
-                );
-            } else {
-                self.parse_error_at_current_token(
-                    "A 'get' accessor cannot have parameters.",
-                    diagnostic_codes::A_GET_ACCESSOR_CANNOT_HAVE_PARAMETERS,
-                );
+            let parsed = self.parse_parameter_list();
+            // A `this` parameter is not a value parameter — see the identical
+            // exclusion on the class-member getter arm. tsc rejects a getter's
+            // `this` parameter in the checker with TS2784, not here.
+            let only_this_parameter = parsed.nodes.len() == 1
+                && parsed.nodes.first().is_some_and(|&param_idx| {
+                    let name_idx = match self.arena.get_parameter_at(param_idx) {
+                        Some(param) => param.name,
+                        None => return false,
+                    };
+                    self.arena
+                        .get(name_idx)
+                        .is_some_and(|name_node| name_node.kind == SyntaxKind::ThisKeyword as u16)
+                });
+            if !only_this_parameter {
+                // Report error at the accessor name, matching tsc behavior
+                if let Some(name_node) = self.arena.get(name) {
+                    self.parse_error_at(
+                        name_node.pos,
+                        name_node.end - name_node.pos,
+                        "A 'get' accessor cannot have parameters.",
+                        diagnostic_codes::A_GET_ACCESSOR_CANNOT_HAVE_PARAMETERS,
+                    );
+                } else {
+                    self.parse_error_at_current_token(
+                        "A 'get' accessor cannot have parameters.",
+                        diagnostic_codes::A_GET_ACCESSOR_CANNOT_HAVE_PARAMETERS,
+                    );
+                }
             }
-            self.parse_parameter_list()
+            parsed
         };
         // Save end of ) for error reporting - get it BEFORE consuming the token
         let close_paren_end = self.token_end();

--- a/crates/tsz-parser/src/parser/state_statements_class_members.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class_members.rs
@@ -816,21 +816,39 @@ impl ParserState {
             Self::make_node_list(vec![])
         } else {
             use tsz_common::diagnostics::diagnostic_codes;
-            // Report error at the accessor name, matching tsc behavior
-            if let Some(name_node) = self.arena.get(name) {
-                self.parse_error_at(
-                    name_node.pos,
-                    name_node.end - name_node.pos,
-                    "A 'get' accessor cannot have parameters.",
-                    diagnostic_codes::A_GET_ACCESSOR_CANNOT_HAVE_PARAMETERS,
-                );
-            } else {
-                self.parse_error_at_current_token(
-                    "A 'get' accessor cannot have parameters.",
-                    diagnostic_codes::A_GET_ACCESSOR_CANNOT_HAVE_PARAMETERS,
-                );
+            let parsed = self.parse_parameter_list();
+            // A `this` parameter is not a value parameter, so a getter whose
+            // only parameter is `this` has zero parameters as far as this
+            // arity grammar is concerned — tsc rejects it in the checker with
+            // TS2784, not here with TS1054. `report_set_accessor_parameter_count`
+            // already makes the same exclusion for the setter arm.
+            let only_this_parameter = parsed.nodes.len() == 1
+                && parsed.nodes.first().is_some_and(|&param_idx| {
+                    let name_idx = match self.arena.get_parameter_at(param_idx) {
+                        Some(param) => param.name,
+                        None => return false,
+                    };
+                    self.arena
+                        .get(name_idx)
+                        .is_some_and(|name_node| name_node.kind == SyntaxKind::ThisKeyword as u16)
+                });
+            if !only_this_parameter {
+                // Report error at the accessor name, matching tsc behavior
+                if let Some(name_node) = self.arena.get(name) {
+                    self.parse_error_at(
+                        name_node.pos,
+                        name_node.end - name_node.pos,
+                        "A 'get' accessor cannot have parameters.",
+                        diagnostic_codes::A_GET_ACCESSOR_CANNOT_HAVE_PARAMETERS,
+                    );
+                } else {
+                    self.parse_error_at_current_token(
+                        "A 'get' accessor cannot have parameters.",
+                        diagnostic_codes::A_GET_ACCESSOR_CANNOT_HAVE_PARAMETERS,
+                    );
+                }
             }
-            self.parse_parameter_list()
+            parsed
         };
         self.parse_expected(SyntaxKind::CloseParenToken);
 


### PR DESCRIPTION
**Structural rule.** When a `this` parameter is not the first parameter of its signature, or its container cannot have one at all, `tsc` reports it from `checkParameter` using two structural facts and nothing else — the parameter's index in its own list, and the `SyntaxKind` of the container. tsz now does the same through the checker's parameter-grammar layer, `check_this_parameter_placement_in_ctx` (`crates/tsz-checker/src/checkers/parameter_checker.rs`).

| condition | code |
| --- | --- |
| not at index 0 | **TS2680** `A 'this' parameter must be the first parameter.` |
| container is `Constructor` / `ConstructSignature` / `ConstructorType` | **TS2681** `A constructor cannot have a 'this' parameter.` |
| container is `GetAccessor` / `SetAccessor` | **TS2784** `'get' and 'set' accessors cannot declare 'this' parameters.` |
| container is `ArrowFunction` | **TS2730** `An arrow function cannot have a 'this' parameter.` |

The wrong semantic operation was **parameter grammar**, not inference, lookup or display.

**TS2680, TS2681 and TS2784 had zero call sites anywhere in the workspace.** They existed only as rows in the generated message table, so every one of these shapes was silently accepted. TS2730 was wired for JS files only, through the JSDoc `@this` tag (`types/function_type.rs`), and never fired for a real `this` parameter node in a TypeScript arrow function. That JSDoc arm triggers on a tag with no parameter node, so it and the new arm cannot both fire for one arrow function.

**The four arms are independent, not a match over the container kind.** A `this` parameter that is both misplaced *and* in a constructing container draws TS2680 **and** TS2681. Four `both_arms_*` rows pin exactly that; a `match` on the container kind, or an early return after the position arm, fails them and nothing else.

### The false positive this uncovered

A getter whose only parameter is `this` drew **TS1054** `A 'get' accessor cannot have parameters.` — where tsc reports TS2784 and no TS1054. A `this` parameter is not a value parameter, so tsc's getter arity grammar does not count it. `report_set_accessor_parameter_count` already made that exclusion for the **setter** arm (`count == 1 || (count == 2 && first_is_this)`); the two **getter** arms — class member and object literal — errored as soon as the token after `(` was not `)`, before the list was even parsed. Both now parse first and exclude a lone `this` parameter, mirroring the setter arm's existing rule. This is a user-visible false positive on code tsc accepts as grammar, and it is why the fix touches the parser as well as the checker.

### Routing

`check_parameter_ordering` is the per-signature parameter-grammar walk and already receives the owning node, so it hosts the shared call and covers function declarations/expressions, methods, constructors, arrow functions, and interface/type-literal method, call and construct signatures. Two containers do not route through it and needed their own call site:

- **`FunctionType` / `ConstructorType` nodes** — `types/type_node.rs`. These run inside `TypeNodeChecker`, which holds the context but not `CheckerState`; that is why the shared logic is a context-level function that `CheckerState::check_this_parameter_placement` delegates to, rather than a method.
- **Class accessors** — a new `check_class_accessor_this_parameters` walk called from both class paths in `state_checking/class.rs`. Deliberately **outside** the `if !is_declared` guard: `check_class_member_implementations` is skipped for ambient classes, but a `declare class` getter can declare a `this` parameter just as illegally as a concrete one (`ts2784_ambient_class_getter` is the row that caught this — it failed against the first version of the routing).

No identifier, alias, property or file-name string drives any decision, and no predicate reads rendered type or printer output. The only inputs are a parameter's index and a container's `SyntaxKind`.

### Adjacent-case matrix

Every row below was recorded from the pinned `typescript@7.0.2` (`--noEmit --strict`), not derived from the rule. Binder names are distinct per row so nothing can key on an identifier string.

**Positives** — TS2680: function declaration, class method, interface method signature, function-type node, function expression, third-position parameter. TS2681: class constructor, interface construct signature, constructor-type node, ambient class constructor, type-literal construct signature. TS2784: class getter, class setter, `static` getter, ambient class getter. TS2730: arrow function, class-property arrow.

**Both arms at once** — misplaced `this` in a constructor, in a setter, in an arrow, in a constructor-type node.

**Negatives, legal leading `this`** — function declaration, class method, `static` class method, ambient function, function-type node, interface method signature, interface call signature, function expression, namespace function, object-literal method. These are the same shapes as the positives, so a check that fired on the *presence* of a `this` parameter rather than on its position and container fails all ten.

**Negatives, no `this` parameter** — ordinary parameters in a constructor, an accessor, an arrow, and a plain function.

## Goal
Goal: hold

## Verification

- `cargo test -p tsz-checker --lib -- this_parameter_placement accessor ts1054 ts2784 get_accessor set_accessor` — **91 passed, 0 failed**, including all **35 new rows**.
- `cargo test -p tsz-parser --lib` — **1524 passed, 0 failed**. This is the suite that covers the TS1054/TS1049 accessor arity grammar the parser half of this change touches.
- **Three probe files diffed verbatim against `node typescript@7.0.2/lib/tsc.js` on the identical input — byte-identical output on all three**, positives, negatives and column positions included. Before this change the same 33-row file was missing 13 diagnostics tsc emits and carried 2 TS1054 false positives tsc does not.
- `cargo fmt --all` clean; the `pre-commit` hook's `Verifying: -p tsz-checker -p tsz-parser` clippy leg and architecture guard both passed on this tree.

**Not run here, stated rather than implied:** the two-sided `scripts/conformance/compare-to-parent.sh`. This container has no TypeScript corpus, and `scripts/setup/reset-ts-submodule.sh --sparse` declined (`Preserving dirty or unavailable TypeScript corpus checkout … Re-run with --force-reset`) within the session's budget. **This change makes previously-silent diagnostics start firing, which is exactly the blast radius a targeted matrix cannot see** — the corpus has fixtures using `this` parameters, and any that pair one with a getter or a constructor will move. Per the board's standing rule, do not land this on the targeted evidence alone: the two-sided run is the gate, and I will post it as a comment here or hand it to a seat with a warm corpus. Emit is not exercised (diagnostics only; the emitter consumes neither), but that is an argument, not a measurement.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Peridot

---
_Generated by [Claude Code](https://claude.ai/code/session_014md1spSpkouL2z4XgHorKD)_