### PR TITLE
fix(checker): duplicate-name diagnostics render/compare against the first eagerly-bound declaration

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
@@ -988,9 +988,10 @@ impl<'a> CheckerState<'a> {
         use crate::diagnostics::diagnostic_codes;
         use rustc_hash::FxHashMap;
 
-        // Track canonical property names → (member_idx, type_annotation_node) pairs.
-        // Methods are allowed to have overloads so they are excluded.
-        let mut seen_properties: FxHashMap<String, Vec<(NodeIndex, NodeIndex)>> =
+        // Track canonical property names → (member_idx, type_annotation_node,
+        // is_eagerly_bound) triples. Methods are allowed to have overloads so
+        // they are excluded.
+        let mut seen_properties: FxHashMap<String, Vec<(NodeIndex, NodeIndex, bool)>> =
             FxHashMap::default();
 
         for &member_idx in members {
@@ -1036,10 +1037,12 @@ impl<'a> CheckerState<'a> {
                 continue;
             };
 
-            seen_properties
-                .entry(canonical_name)
-                .or_default()
-                .push((member_idx, sig.type_annotation));
+            let is_eager = self.is_eagerly_bound_member_name(sig.name);
+            seen_properties.entry(canonical_name).or_default().push((
+                member_idx,
+                sig.type_annotation,
+                is_eager,
+            ));
         }
 
         // Report errors for duplicates — tsc reports TS2300 on ALL occurrences
@@ -1047,33 +1050,53 @@ impl<'a> CheckerState<'a> {
         for (name, entries) in &seen_properties {
             if entries.len() > 1 {
                 // tsc renders the duplicate name via `declarationNameToString` of
-                // the FIRST declaration's name node (verbatim source spelling) and
-                // reuses it for every occurrence: `{ "artist"; artist }` reports
-                // `'"artist"'` at both, and `{ "1"; 1 }` reports `'"1"'` (source,
-                // not the canonicalized `1`). Computed spellings are kept whole,
-                // so `{ ["abc"]; abc }` reports `'["abc"]'` at both. TS2717, by
-                // contrast, names the member by the *subsequent* declaration's
-                // spelling — the asymmetry is deliberate on both sides.
+                // the group's first *eagerly bound* declaration's name node
+                // (verbatim source spelling), falling back to the first
+                // declaration only when every member of the group is
+                // late-bound: `{ "artist"; artist }` reports `'"artist"'` at
+                // both, `{ "1"; 1 }` reports `'"1"'` (source, not the
+                // canonicalized `1`), and `{ [c0]: number; 1: number }` (where
+                // `const c0 = "1"`) reports `'1'` even though `[c0]` is
+                // written first, because a computed name over an entity
+                // reference is late-bound and the plain numeric-literal `1`
+                // is not (#16258 residual 1). Computed spellings are kept
+                // whole, so `{ ["abc"]; abc }` reports `'["abc"]'` at both.
+                // TS2717, by contrast, names the member by the *subsequent*
+                // declaration's spelling — the asymmetry is deliberate on
+                // both sides.
+                let render_entry = *entries.iter().find(|entry| entry.2).unwrap_or(&entries[0]);
+                let render_idx = render_entry.0;
                 let first_name_node = self
-                    .get_interface_member_name_node(entries[0].0)
-                    .unwrap_or(entries[0].0);
+                    .get_interface_member_name_node(render_idx)
+                    .unwrap_or(render_idx);
                 let display_name = self
                     .declaration_name_to_string(first_name_node)
                     .unwrap_or_else(|| name.clone());
 
                 // TS2687: duplicate property declarations must agree on
                 // `readonly` / optional modifiers. Independent of TS2300/TS2717.
+                // The comparison reference is the same eagerly-bound
+                // declaration TS2300 renders, not source-order-first (#16258
+                // residual 1: oracle-verified on `readonly [c0]: number;
+                // [c1]: string; 1: boolean;` — only the declaration that
+                // disagrees with `1`'s modifiers is flagged, not `[c1]`'s,
+                // even though `[c0]` is written first).
                 let member_nodes: Vec<NodeIndex> = entries.iter().map(|entry| entry.0).collect();
-                self.report_property_modifier_disagreements(&display_name, &member_nodes);
+                self.report_property_modifier_disagreements(render_idx, &member_nodes);
 
-                // Resolve the first property's type for TS2717 comparison
-                let first_type = if entries[0].1.is_some() {
-                    self.get_type_from_type_node(entries[0].1)
+                // The reference type for TS2717 is the eagerly-bound
+                // declaration's own type, not source-order-first's — same
+                // reference `render_idx` as TS2300/TS2687. Oracle-verified:
+                // `[c0]: number; [c1]: string; 1: boolean;` reports TS2717 on
+                // `[c0]` and `[c1]` naming `'boolean'` (the eager `1`'s type)
+                // as the expected type, never on `1` itself.
+                let reference_type = if render_entry.1.is_some() {
+                    self.get_type_from_type_node(render_entry.1)
                 } else {
                     TypeId::ANY
                 };
 
-                for (i, &(idx, type_ann)) in entries.iter().enumerate() {
+                for &(idx, type_ann, _) in entries.iter() {
                     let error_node = self.get_interface_member_name_node(idx).unwrap_or(idx);
 
                     // TS2300 on every declaration in the group. How each name was
@@ -1086,30 +1109,31 @@ impl<'a> CheckerState<'a> {
                         &[&display_name],
                     );
 
-                    // TS2717 on subsequent declarations when types differ
-                    if i > 0 {
+                    // TS2717 on every declaration OTHER than the reference,
+                    // when its type differs from the reference's.
+                    if idx != render_idx {
                         let this_type = if type_ann.is_some() {
                             self.get_type_from_type_node(type_ann)
                         } else {
                             TypeId::ANY
                         };
-                        if !self.type_contains_error(first_type)
+                        if !self.type_contains_error(reference_type)
                             && !self.type_contains_error(this_type)
                         {
                             // TS2717 uses type identity, not assignability.
                             // With interned types, TypeId equality is structural identity.
-                            if first_type != this_type {
+                            if reference_type != this_type {
                                 // Use display text for the property name in diagnostics.
                                 // For computed properties, this preserves the `[expr]` syntax.
                                 let display_name = self
                                     .get_member_name_display_text(error_node)
                                     .unwrap_or_else(|| name.clone());
-                                let first_type_str = self.format_type(first_type);
+                                let reference_type_str = self.format_type(reference_type);
                                 let this_type_str = self.format_type(this_type);
                                 self.error_at_node_msg(
                                     error_node,
                                     diagnostic_codes::SUBSEQUENT_PROPERTY_DECLARATIONS_MUST_HAVE_THE_SAME_TYPE_PROPERTY_MUST_BE_OF_TYP,
-                                    &[&display_name, &first_type_str, &this_type_str],
+                                    &[&display_name, &reference_type_str, &this_type_str],
                                 );
                             }
                         }

--- a/crates/tsz-checker/src/tests/duplicate_member_computed_name_ts2300_tests.rs
+++ b/crates/tsz-checker/src/tests/duplicate_member_computed_name_ts2300_tests.rs
@@ -262,18 +262,27 @@ fn subsequent_property_uses_the_redeclarations_spelling() {
 }
 
 #[test]
-fn identical_modifiers_uses_the_first_declarations_spelling() {
+fn identical_modifiers_names_each_flagged_declaration_by_its_own_spelling() {
+    // Oracle-corrected (`typescript@7.0.2`): unlike TS2300, which uses ONE
+    // shared name for every occurrence, TS2687 names each flagged declaration
+    // by its OWN spelling: `readonly ["rho"]: number; rho: number;` reports
+    // `'["rho"]'` at the first declaration and `'rho'` — not `'["rho"]'` — at
+    // the second.
     let messages = messages_for(
         "export {};\ninterface Nu { readonly [\"rho\"]: number; rho: number; }\n",
         IDENTICAL_MODIFIERS,
     );
     assert_eq!(messages.len(), 2, "got {messages:?}");
-    for message in &messages {
-        assert!(
-            message.contains("'[\"rho\"]'"),
-            "TS2687 should name the member by the first declaration's spelling; got {message:?}"
-        );
-    }
+    assert!(
+        messages.iter().any(|m| m.contains("'[\"rho\"]'")),
+        "TS2687 should name the reference declaration '[\"rho\"]'; got {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("'rho'") && !m.contains("'[\"rho\"]'")),
+        "TS2687 should name the disagreeing declaration by its own spelling 'rho', not the reference's; got {messages:?}"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -293,6 +302,145 @@ fn three_declarations_each_get_exactly_one_duplicate_identifier() {
         count_of(source, SUBSEQUENT_PROPERTY),
         2,
         "TS2717 is reported on the two redeclarations only"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Renderer selection: "first eagerly-bound declaration", not "first
+// declaration" (#16258 residual 1). A name is eagerly bound when the binder
+// keys it without checking types: an identifier, a string/numeric-literal
+// name, or a computed name over a string/numeric literal. A computed name
+// over an entity reference (`[c0]`) is late-bound and loses the rendering
+// slot to any eagerly-bound sibling, wherever in the group it sits; the first
+// declaration wins only when every member of the group is late-bound (already
+// covered by `interface_const_references_with_different_spellings_but_one_key_are_duplicates`
+// above).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn interface_late_bound_first_eager_second_renders_the_eager_spelling() {
+    // The exact `dynamicNamesErrors.ts` shape from #16258 residual 1: `[c0]`
+    // is written first but is late-bound; the plain numeric-literal `1` is
+    // written second but is eagerly bound. tsc renders `'1'`, not `'[c0]'`.
+    assert_duplicate_on_both(
+        "export {};\ndeclare const c0: \"1\";\ninterface T0 { [c0]: number; 1: number; }\n",
+        "'1'",
+    );
+}
+
+#[test]
+fn type_literal_late_bound_first_eager_second_renders_the_eager_spelling() {
+    assert_duplicate_on_both(
+        "export {};\ndeclare const c0: \"1\";\ntype T0 = { [c0]: number; 1: number };\n",
+        "'1'",
+    );
+}
+
+#[test]
+fn interface_eager_first_late_bound_second_still_renders_the_eager_spelling() {
+    // Same pair, opposite source order: the eager declaration is first, so
+    // this also matches the old "first declaration" rule — kept as a
+    // completeness control, not a regression discriminator.
+    assert_duplicate_on_both(
+        "export {};\ndeclare const c0: \"1\";\ninterface T1 { 1: number; [c0]: string; }\n",
+        "'1'",
+    );
+}
+
+#[test]
+fn interface_two_late_bound_then_eager_renders_the_eager_spelling_from_third_position() {
+    // Two late-bound computed names precede the eagerly-bound one; the
+    // eagerly-bound declaration still wins the rendering slot regardless of
+    // its position in the group.
+    let source = "export {};\ndeclare const c0: \"1\";\ndeclare const c1: \"1\";\ninterface T2 { [c0]: number; [c1]: string; 1: boolean; }\n";
+    let messages = messages_for(source, DUPLICATE_IDENTIFIER);
+    assert_eq!(messages.len(), 3, "got {messages:?}");
+    for message in &messages {
+        assert!(
+            message.contains("'1'"),
+            "TS2300 should name the member '1' (the eagerly-bound spelling); got {message:?}"
+        );
+    }
+}
+
+#[test]
+fn interface_modifier_disagreement_compares_against_the_eagerly_bound_declaration() {
+    // Oracle-pinned on `readonly [c0]: number; 1: string;` (`const c0 = "1"`):
+    // the comparison REFERENCE is `1` (eagerly bound), even though `[c0]` is
+    // written first — and unlike TS2300, each flagged declaration is named by
+    // its OWN spelling, not the reference's: `tsc` reports `'[c0]'` at `[c0]`
+    // and `'1'` at `1`, never `'1'` at both.
+    let messages = messages_for(
+        "export {};\ndeclare const c0: \"1\";\ninterface T3 { readonly [c0]: number; 1: string; }\n",
+        IDENTICAL_MODIFIERS,
+    );
+    assert_eq!(messages.len(), 2, "got {messages:?}");
+    assert!(
+        messages.iter().any(|m| m.contains("'[c0]'")),
+        "TS2687 should name [c0] by its own spelling; got {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("'1'") && !m.contains("'[c0]'")),
+        "TS2687 should name the reference declaration '1'; got {messages:?}"
+    );
+}
+
+#[test]
+fn interface_ts2717_reference_type_is_the_eagerly_bound_declarations_type() {
+    // Oracle-pinned on `[c0]: number; [c1]: string; 1: boolean;` (both `c0`
+    // and `c1` const `"1"`): TS2717's expected-type operand is `1`'s own type
+    // (`boolean`, the eagerly-bound reference), not `[c0]`'s (source-order-
+    // first, `number`). Both non-reference declarations are flagged against
+    // it; the reference itself (`1`) never gets TS2717.
+    let source = "export {};\ndeclare const c0: \"1\";\ndeclare const c1: \"1\";\ninterface T2 { [c0]: number; [c1]: string; 1: boolean; }\n";
+    let messages = messages_for(source, SUBSEQUENT_PROPERTY);
+    assert_eq!(messages.len(), 2, "got {messages:?}");
+    for message in &messages {
+        assert!(
+            message.contains("be of type 'boolean'"),
+            "TS2717 should compare against the eagerly-bound reference's type 'boolean'; got {message:?}"
+        );
+    }
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("'[c0]'") && m.contains("type 'number'")),
+        "expected a TS2717 naming [c0] with its own type 'number'; got {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("'[c1]'") && m.contains("type 'string'")),
+        "expected a TS2717 naming [c1] with its own type 'string'; got {messages:?}"
+    );
+}
+
+#[test]
+fn interface_modifier_reference_selection_skips_a_late_bound_declaration_that_agrees() {
+    // Oracle-pinned on `readonly [c0]: number; [c1]: string; 1: boolean;`
+    // (`c0`, `c1` both const `"1"`): the reference is `1` (non-readonly).
+    // `[c0]` (readonly) disagrees and is flagged; `[c1]` (also non-readonly)
+    // agrees with the reference and is NOT flagged, even though it disagrees
+    // with `[c0]`'s modifiers — modifier agreement is judged against the
+    // reference only, never pairwise.
+    let source = "export {};\ndeclare const c0: \"1\";\ndeclare const c1: \"1\";\ninterface T5 { readonly [c0]: number; [c1]: string; 1: boolean; }\n";
+    let messages = messages_for(source, IDENTICAL_MODIFIERS);
+    assert_eq!(messages.len(), 2, "got {messages:?}");
+    assert!(
+        messages.iter().any(|m| m.contains("'[c0]'")),
+        "expected [c0] flagged; got {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("'1'") && !m.contains("'[c0]'")),
+        "expected the reference '1' flagged; got {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("'[c1]'")),
+        "[c1] agrees with the reference's modifiers and must not be flagged; got {messages:?}"
     );
 }
 

--- a/crates/tsz-checker/src/types/queries/core_names.rs
+++ b/crates/tsz-checker/src/types/queries/core_names.rs
@@ -13,6 +13,47 @@ impl<'a> CheckerState<'a> {
     // Section 30: Name Extraction Utilities
     // =========================================================================
 
+    /// Whether `name_idx` is a member name the *binder* keys immediately,
+    /// without consulting the expression's type: an identifier, a private
+    /// name, a string/numeric-literal name, or a computed name whose
+    /// expression is itself a string/numeric/no-substitution-template literal
+    /// (`["abc"]`, `[123]`, `` [`abc`] ``).
+    ///
+    /// Purely syntactic — unlike `is_late_bound_member_name`, this never
+    /// evaluates the expression's type. `[c0]` where `const c0 = "1"` is
+    /// late-bound by *this* test even though `is_late_bound_member_name`
+    /// classifies it as not-late-bound once `c0`'s type resolves to a string
+    /// literal: tsc's binder defers a computed name over an entity-name
+    /// expression to a later binding pass regardless of what its type turns
+    /// out to be, and it is that deferral — not the eventual resolved type —
+    /// that decides which declaration's spelling a duplicate-name group's
+    /// `TS2300`/`TS2687`/`TS2717` diagnostics render: the group's first
+    /// *eagerly* bound declaration, falling back to the first declaration
+    /// only when every member of the group is late-bound (`#16258` residual
+    /// 1, `dynamicNamesErrors.ts`: `[c0]: number; 1: number` with
+    /// `const c0 = "1"` renders `'1'`, not `'[c0]'`).
+    pub(crate) fn is_eagerly_bound_member_name(&self, name_idx: NodeIndex) -> bool {
+        if name_idx.is_none() {
+            return false;
+        }
+        let Some(name_node) = self.ctx.arena.get(name_idx) else {
+            return false;
+        };
+        if name_node.kind != syntax_kind_ext::COMPUTED_PROPERTY_NAME {
+            return true;
+        }
+        let Some(computed) = self.ctx.arena.get_computed_property(name_node) else {
+            return true;
+        };
+        let Some(expr_node) = self.ctx.arena.get(computed.expression) else {
+            return false;
+        };
+        let kind = expr_node.kind;
+        kind == SyntaxKind::StringLiteral as u16
+            || kind == SyntaxKind::NumericLiteral as u16
+            || kind == SyntaxKind::NoSubstitutionTemplateLiteral as u16
+    }
+
     /// Check if a computed property name resolves to a string literal type
     /// (e.g. `[hundredStr]` where `const hundredStr = "100"`).
     pub(crate) fn is_computed_string_property_name(&mut self, name_idx: NodeIndex) -> bool {

--- a/crates/tsz-checker/src/types/type_checking/duplicate_property_modifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_property_modifiers.rs
@@ -34,15 +34,10 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        // Track (member_idx, type_annotation) of the first declaration of each
-        // member name, for the TS2300 / TS2717 comparisons below.
-        let mut seen: rustc_hash::FxHashMap<String, (NodeIndex, NodeIndex)> =
-            rustc_hash::FxHashMap::default();
-        // Canonical name -> property-signature member nodes (source order) for
-        // names that occur more than once. Only populated on a duplicate hit, so
-        // the common (no-duplicate) type literal allocates nothing extra. Feeds
-        // the TS2687 modifier-agreement check after the duplicate scan.
-        let mut duplicate_groups: rustc_hash::FxHashMap<String, Vec<NodeIndex>> =
+        // Canonical name -> (member_idx, type_annotation, is_eagerly_bound)
+        // triples, in source order. Mirrors `check_duplicate_interface_members`
+        // (`interface_checks.rs`) — the two containers apply one rule.
+        let mut seen_properties: rustc_hash::FxHashMap<String, Vec<(NodeIndex, NodeIndex, bool)>> =
             rustc_hash::FxHashMap::default();
 
         for &member_idx in members {
@@ -80,96 +75,100 @@ impl<'a> CheckerState<'a> {
             } else {
                 continue;
             };
-            let type_ann = sig.type_annotation;
 
-            if let Some(&(prev_idx, prev_type_ann)) = seen.get(&name) {
-                let name_idx = sig.name;
+            let is_eager = self.is_eagerly_bound_member_name(sig.name);
+            seen_properties.entry(name).or_default().push((
+                member_idx,
+                sig.type_annotation,
+                is_eager,
+            ));
+        }
 
-                // Record the full duplicate group (first declaration once, then
-                // each subsequent one) for the TS2687 modifier check below.
-                duplicate_groups
-                    .entry(name.clone())
-                    .or_insert_with(|| vec![prev_idx])
-                    .push(member_idx);
+        // Report errors for duplicates — tsc reports TS2300 on ALL occurrences
+        // (both first and subsequent), not just the second+.
+        for (name, entries) in &seen_properties {
+            if entries.len() <= 1 {
+                continue;
+            }
+
+            // tsc renders the duplicate name via `declarationNameToString` of
+            // the group's first *eagerly bound* declaration's name node
+            // (verbatim source spelling), falling back to the first
+            // declaration only when every member of the group is late-bound:
+            // `{ "artist"; artist }` reports `'"artist"'` at both, `{ 0.0;
+            // '0' }` reports `'0.0'` (raw source, not the canonicalized `0`),
+            // and `{ [c0]: number; 1: number }` (where `const c0 = "1"`)
+            // reports `'1'` even though `[c0]` is written first, because a
+            // computed name over an entity reference is late-bound and the
+            // plain numeric-literal `1` is not (#16258 residual 1).
+            let render_entry = *entries.iter().find(|entry| entry.2).unwrap_or(&entries[0]);
+            let render_idx = render_entry.0;
+            let render_name_idx = self
+                .property_signature_name_node(render_idx)
+                .unwrap_or(render_idx);
+            let display_name = self
+                .declaration_name_to_string(render_name_idx)
+                .unwrap_or_else(|| name.clone());
+
+            // TS2687: duplicate property declarations must agree on
+            // `readonly` / optional modifiers. Independent of TS2300/TS2717.
+            // The comparison reference is the same eagerly-bound declaration
+            // TS2300 renders, not source-order-first — see the doc comment on
+            // `report_property_modifier_disagreements`.
+            let member_nodes: Vec<NodeIndex> = entries.iter().map(|entry| entry.0).collect();
+            self.report_property_modifier_disagreements(render_idx, &member_nodes);
+
+            // The reference type for TS2717 is the eagerly-bound
+            // declaration's own type, not source-order-first's — same
+            // reference `render_idx` as TS2300/TS2687.
+            let reference_type = if render_entry.1.is_some() {
+                self.get_type_from_type_node(render_entry.1)
+            } else {
+                TypeId::ANY
+            };
+
+            for &(idx, type_ann, _) in entries.iter() {
+                let Some(error_node) = self.property_signature_name_node(idx) else {
+                    continue;
+                };
 
                 // TS2300 on every declaration in the group. How each name was
                 // spelled does not matter — a computed name that reached this
                 // point resolved to a real member key, so it names the same
                 // member as its group siblings.
-                //
-                // tsc renders the duplicate name via `declarationNameToString`
-                // of the FIRST declaration's name node (verbatim source
-                // spelling), and reuses that spelling for every occurrence:
-                // `{ "artist"; artist }` reports `'"artist"'` at both, and
-                // `{ 0.0; '0' }` reports `'0.0'` (raw source, not the
-                // canonicalized `0`).
-                let prev_name_idx = self
-                    .ctx
-                    .arena
-                    .get(prev_idx)
-                    .and_then(|prev_node| self.ctx.arena.get_signature(prev_node))
-                    .map(|prev_sig| prev_sig.name)
-                    .unwrap_or(prev_idx);
-                let display_name = self
-                    .declaration_name_to_string(prev_name_idx)
-                    .unwrap_or_else(|| name.clone());
                 self.error_at_node(
-                    name_idx,
+                    error_node,
                     &format!("Duplicate identifier '{display_name}'."),
                     diagnostic_codes::DUPLICATE_IDENTIFIER,
                 );
-                // Also mark the first occurrence.
-                if self.ctx.arena.get(prev_idx).is_some() {
-                    self.error_at_node(
-                        prev_name_idx,
-                        &format!("Duplicate identifier '{display_name}'."),
-                        diagnostic_codes::DUPLICATE_IDENTIFIER,
-                    );
-                }
 
-                // TS2717 on the subsequent declaration when types differ.
-                // Use display text for the property name to match TSC's
+                // TS2717 on every declaration OTHER than the reference, when
+                // its type differs from the reference's. Use display text
+                // for the property name to match TSC's
                 // declarationNameToString (e.g., "1.0" not "1").
-                let first_type = if prev_type_ann.is_some() {
-                    self.get_type_from_type_node(prev_type_ann)
-                } else {
-                    TypeId::ANY
-                };
-                let this_type = if type_ann.is_some() {
-                    self.get_type_from_type_node(type_ann)
-                } else {
-                    TypeId::ANY
-                };
-                if !self.type_contains_error(first_type)
-                    && !self.type_contains_error(this_type)
-                    && first_type != this_type
-                {
-                    let display_name = self
-                        .get_member_name_display_text(name_idx)
-                        .unwrap_or_else(|| name.clone());
-                    let first_type_str = self.format_type(first_type);
-                    let this_type_str = self.format_type(this_type);
-                    self.error_at_node_msg(
-                        name_idx,
-                        diagnostic_codes::SUBSEQUENT_PROPERTY_DECLARATIONS_MUST_HAVE_THE_SAME_TYPE_PROPERTY_MUST_BE_OF_TYP,
-                        &[&display_name, &first_type_str, &this_type_str],
-                    );
+                if idx != render_idx {
+                    let this_type = if type_ann.is_some() {
+                        self.get_type_from_type_node(type_ann)
+                    } else {
+                        TypeId::ANY
+                    };
+                    if !self.type_contains_error(reference_type)
+                        && !self.type_contains_error(this_type)
+                        && reference_type != this_type
+                    {
+                        let display_name = self
+                            .get_member_name_display_text(error_node)
+                            .unwrap_or_else(|| name.clone());
+                        let reference_type_str = self.format_type(reference_type);
+                        let this_type_str = self.format_type(this_type);
+                        self.error_at_node_msg(
+                            error_node,
+                            diagnostic_codes::SUBSEQUENT_PROPERTY_DECLARATIONS_MUST_HAVE_THE_SAME_TYPE_PROPERTY_MUST_BE_OF_TYP,
+                            &[&display_name, &reference_type_str, &this_type_str],
+                        );
+                    }
                 }
-            } else {
-                seen.insert(name, (member_idx, type_ann));
             }
-        }
-
-        for (name, member_nodes) in &duplicate_groups {
-            // TS2687 names the member the same way TS2300 does — by the first
-            // declaration's verbatim spelling, not the canonical member key.
-            let first_name_node = self
-                .property_signature_name_node(member_nodes[0])
-                .unwrap_or(member_nodes[0]);
-            let display_name = self
-                .declaration_name_to_string(first_name_node)
-                .unwrap_or_else(|| name.clone());
-            self.report_property_modifier_disagreements(&display_name, member_nodes);
         }
     }
 
@@ -179,22 +178,27 @@ impl<'a> CheckerState<'a> {
     /// the same member name but disagree on the `readonly` or optional (`?`)
     /// modifier. It is independent of the same-type (TS2717) diagnostic: it
     /// fires even when the declared types are identical (so TS2717 is absent).
-    /// It accompanies TS2300 on the same group of declarations, and `name` is
-    /// the same first-declaration spelling TS2300 renders.
     ///
-    /// Targeting mirrors `tsc`: the first declaration is the reference; every
-    /// later declaration whose flags differ from it is flagged, and the
-    /// reference itself is flagged once if any later declaration differs. So
-    /// `readonly a; a; readonly a` flags the first two (the third matches the
-    /// reference) while `a; readonly a; readonly a` flags all three.
+    /// Targeting and naming both key off `reference_idx` — the group's first
+    /// *eagerly bound* declaration (`is_eagerly_bound_member_name`), the same
+    /// declaration TS2300 renders and TS2717 compares types against — not
+    /// source-order-first. Every other declaration whose flags differ from
+    /// the reference's is flagged, and the reference itself is flagged once
+    /// if anything differs. Unlike TS2300 (one shared name for the whole
+    /// group), each flagged declaration is named by **its own** spelling, not
+    /// the reference's: oracle-pinned on `readonly [c0]: number; 1: string;`
+    /// (`const c0 = "1"`, so `1` is the reference) — `tsc` reports `"All
+    /// declarations of '[c0]' must have identical modifiers."` at `[c0]` and
+    /// `"...of '1'..."` at `1`, not the same name at both (#16258 residual 1).
     ///
     /// `member_nodes` is the property-signature member nodes that share the
-    /// canonical `name`, in source order. Callers pass the same group of
-    /// declarations they already detected as duplicates, so computed names that
-    /// resolve to the same value share a group.
+    /// canonical member name, in source order; `reference_idx` must be one of
+    /// them. Callers pass the same group of declarations they already
+    /// detected as duplicates, so computed names that resolve to the same
+    /// value share a group.
     pub(crate) fn report_property_modifier_disagreements(
         &mut self,
-        name: &str,
+        reference_idx: NodeIndex,
         member_nodes: &[NodeIndex],
     ) {
         use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
@@ -203,38 +207,42 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        let Some(reference) = self.property_signature_modifier_flags(member_nodes[0]) else {
+        let Some(reference) = self.property_signature_modifier_flags(reference_idx) else {
             return;
         };
 
         // Collect the declarations that disagree with the reference before
         // emitting, so the flag reads (`&self`) don't interleave with the error
-        // emission (`&mut self`). The reference is flagged once if any later
+        // emission (`&mut self`). The reference is flagged once if any other
         // declaration differs.
         let mut nodes_to_flag: Vec<NodeIndex> = Vec::new();
-        for &member_idx in &member_nodes[1..] {
+        for &member_idx in member_nodes {
+            if member_idx == reference_idx {
+                continue;
+            }
             let Some(flags) = self.property_signature_modifier_flags(member_idx) else {
                 continue;
             };
             if flags != reference {
-                if nodes_to_flag.is_empty() {
-                    nodes_to_flag.push(member_nodes[0]);
-                }
                 nodes_to_flag.push(member_idx);
             }
         }
         if nodes_to_flag.is_empty() {
             return;
         }
+        nodes_to_flag.insert(0, reference_idx);
 
-        let message = crate::diagnostics::format_message(
-            diagnostic_messages::ALL_DECLARATIONS_OF_MUST_HAVE_IDENTICAL_MODIFIERS,
-            &[name],
-        );
         for member_idx in nodes_to_flag {
             let name_node = self
                 .property_signature_name_node(member_idx)
                 .unwrap_or(member_idx);
+            let display_name = self
+                .get_member_name_display_text(name_node)
+                .unwrap_or_default();
+            let message = crate::diagnostics::format_message(
+                diagnostic_messages::ALL_DECLARATIONS_OF_MUST_HAVE_IDENTICAL_MODIFIERS,
+                &[&display_name],
+            );
             self.error_at_node(
                 name_node,
                 &message,


### PR DESCRIPTION
Closes #16258 residual 1.

## Structural rule

When a duplicate-name group in an interface or type literal mixes eagerly-bound and late-bound spellings, `tsc`'s TS2300/TS2687 naming and TS2717/TS2687 comparison reference is the group's first *eagerly bound* declaration (identifier / string / numeric literal name, or a computed name over a string/numeric literal) — not the first declaration in source order. A computed name over an entity reference (`[c0]`, `[E.A]`, `[s]`) is late-bound and loses the reference slot to any eagerly-bound sibling, wherever it sits in the group; the source-order-first declaration wins only when every member of the group is late-bound. tsz now does this through a shared `is_eagerly_bound_member_name` query-boundary helper (`crates/tsz-checker/src/types/queries/core_names.rs`), consumed identically by both container scans (`interface_checks.rs`/`duplicate_property_modifiers.rs`), which #16258 had already unified onto one algorithm for everything except this selection rule.

This also corrects two behaviors that residual 1 did not call out, found by re-deriving the rule against the pinned `typescript@7.0.2` oracle rather than trusting the existing (merged, passing) TS2687 test's assumption:

- TS2717's expected-type operand and TS2687's modifier-comparison reference are the SAME eagerly-bound declaration TS2300 renders, not source-order-first. The reference itself is exempt from both diagnostics; every other declaration is compared/flagged against it.
- Unlike TS2300 (one shared name for the whole group), TS2687 names EACH flagged declaration by its OWN spelling, not the reference's — the merged `identical_modifiers_uses_the_first_declarations_spelling` test asserted uniform naming for both messages, which the real oracle contradicts (`readonly ["rho"]: number; rho: number;` reports `'["rho"]'` at the first and `'rho'`, not `'["rho"]'`, at the second). Corrected in this PR along with `report_property_modifier_disagreements`.

## Goal
Goal: hold

## Verification
- 7 new/corrected adjacent-case tests in `duplicate_member_computed_name_ts2300_tests.rs` (renderer selection, TS2717 reference type, TS2687 reference selection and per-node naming), plus 1 corrected pre-existing test. Load-bearing verified: reverting only the 3 source files (keeping tests) fails exactly the 7 new/corrected tests, 24 others pass unaffected.
- Every shape oracle-pinned against `typescript@7.0.2` (`--noEmit --strict --pretty false --lib es2022 --target es2022`) before implementing, including the reference-selection probes for TS2717 and TS2687 that this PR's rule derivation depends on.
- `cargo test -p tsz-checker --lib -- duplicate_member_computed_name`: 31/31 pass.
- `cargo test -p tsz-checker --lib -- duplicate interface_checks type_literal ts2717 ts2687 ts2300 computed_property`: 287/287 pass, no regressions.
- `cargo fmt -p tsz-checker -- --check`: clean.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.
- `scripts/conformance/compare-to-parent.sh origin/main` (base `fcb3166`): **11476 → 11477 passed, 0 newly failing, +1 newly passing** (`dynamicNamesErrors.ts` — the exact fixture #16258 residual 1 named).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqgqnnRxsJNbj4hy13fXXC)_