### PR TITLE
fix(checker): abstract accessor implementation reports TS1318, not TS1245

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -1338,7 +1338,7 @@ impl<'a> CheckerState<'a> {
             self.error_at_node(
                 member_idx,
                 "An abstract accessor cannot have an implementation.",
-                diagnostic_codes::METHOD_CANNOT_HAVE_AN_IMPLEMENTATION_BECAUSE_IT_IS_MARKED_ABSTRACT,
+                diagnostic_codes::AN_ABSTRACT_ACCESSOR_CANNOT_HAVE_AN_IMPLEMENTATION,
             );
         }
 

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -783,6 +783,8 @@ mod ts1101_with_in_strict_mode_tests;
 mod ts1165_ambient_class_method_computed_name_tests;
 #[path = "tests/ts1170_computed_property_syntactic_form_tests.rs"]
 mod ts1170_computed_property_syntactic_form_tests;
+#[path = "tests/ts1318_abstract_accessor_implementation_tests.rs"]
+mod ts1318_abstract_accessor_implementation_tests;
 #[path = "tests/ts1361_ambient_computed_property_name_tests.rs"]
 mod ts1361_ambient_computed_property_name_tests;
 #[path = "tests/ts1539_bigint_literal_property_name_tests.rs"]

--- a/crates/tsz-checker/src/tests/ts1318_abstract_accessor_implementation_tests.rs
+++ b/crates/tsz-checker/src/tests/ts1318_abstract_accessor_implementation_tests.rs
@@ -1,0 +1,143 @@
+//! TS1318 for an abstract accessor that carries an implementation body.
+//!
+//! Structural rule: when an abstract `get`/`set` accessor declares a body,
+//! `tsc` reports **TS1318** (`An abstract accessor cannot have an
+//! implementation.`), a distinct diagnostic from **TS1245** (`Method '{0}'
+//! cannot have an implementation because it is marked abstract.`) used for the
+//! sibling abstract *method* case. The two messages differ in shape — TS1318
+//! takes no substitution, TS1245 interpolates the member name — so they are
+//! not interchangeable renderings of one rule.
+//!
+//! `check_accessor_declaration_with_request`
+//! (`crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs`)
+//! already detected the shape and had the right message text, but reported it
+//! under the TS1245 diagnostic *code* constant
+//! (`METHOD_CANNOT_HAVE_AN_IMPLEMENTATION_BECAUSE_IT_IS_MARKED_ABSTRACT`)
+//! instead of TS1318's own
+//! (`AN_ABSTRACT_ACCESSOR_CANNOT_HAVE_AN_IMPLEMENTATION`) — so tsz emitted the
+//! right text under the wrong code. Every expectation below was taken from the
+//! vendored `tsc` 7.0.2 oracle (`--noEmit --strict --pretty false`), not from
+//! tsz's own prior output.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Positives: an abstract accessor with a body reports TS1318, never TS1245.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn abstract_get_accessor_with_body_reports_ts1318_not_ts1245() {
+    let got = codes(
+        r#"
+abstract class A {
+  abstract get g(): number {
+    return 1;
+  }
+}
+"#,
+    );
+    assert!(got.contains(&1318), "expected TS1318, got {got:?}");
+    assert!(!got.contains(&1245), "must not report TS1245, got {got:?}");
+}
+
+#[test]
+fn abstract_set_accessor_with_body_reports_ts1318_not_ts1245() {
+    let got = codes(
+        r#"
+abstract class A {
+  abstract set s(v: number) {
+    console.log(v);
+  }
+}
+"#,
+    );
+    assert!(got.contains(&1318), "expected TS1318, got {got:?}");
+    assert!(!got.contains(&1245), "must not report TS1245, got {got:?}");
+}
+
+/// Both accessors of an abstract pair carry their own body: each is an
+/// independent TS1318, not deduplicated to one diagnostic.
+#[test]
+fn abstract_get_and_set_both_with_bodies_each_report_ts1318() {
+    let got = codes(
+        r#"
+abstract class A {
+  abstract get g(): number {
+    return 1;
+  }
+  abstract set s(v: number) {
+    console.log(v);
+  }
+}
+"#,
+    );
+    assert_eq!(
+        got.iter().filter(|&&c| c == 1318).count(),
+        2,
+        "expected two independent TS1318s, got {got:?}"
+    );
+}
+
+/// Renamed-binder control: the rule is structural, so renaming every
+/// identifier must not change the outcome.
+#[test]
+fn abstract_accessor_renamed_binders_reports_ts1318() {
+    let got = codes(
+        r#"
+abstract class Shape {
+  abstract get area(): number {
+    return 1;
+  }
+}
+"#,
+    );
+    assert!(got.contains(&1318), "expected TS1318, got {got:?}");
+    assert!(!got.contains(&1245), "must not report TS1245, got {got:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Sibling control: an abstract *method* with a body still reports TS1245 —
+// this fix must not blur the two codes together.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn abstract_method_with_body_still_reports_ts1245_not_ts1318() {
+    let got = codes(
+        r#"
+abstract class A {
+  abstract m(): number {
+    return 1;
+  }
+}
+"#,
+    );
+    assert!(got.contains(&1245), "expected TS1245, got {got:?}");
+    assert!(!got.contains(&1318), "must not report TS1318, got {got:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Negative: a bodyless abstract accessor pair is clean — no TS1318, no TS1245.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn abstract_accessor_pair_without_bodies_reports_neither_code() {
+    let got = codes(
+        r#"
+abstract class A {
+  abstract get g(): number;
+  abstract set s(v: number);
+}
+"#,
+    );
+    assert!(
+        !got.iter().any(|c| matches!(c, 1318 | 1245)),
+        "bodyless abstract accessors must not report either code, got {got:?}"
+    );
+}


### PR DESCRIPTION
**Structural rule.** When an abstract `get`/`set` accessor declares a body, `tsc` reports **TS1318** (`An abstract accessor cannot have an implementation.`) — a distinct diagnostic from **TS1245** (`Method '{0}' cannot have an implementation because it is marked abstract.`), used for the sibling abstract *method* case. The two messages differ in shape: TS1245 interpolates the member name, TS1318 takes no substitution. tsz's checker owns this grammar check in `check_accessor_declaration_with_request` (`crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs`).

**The bug.** That function already detected the shape and already used TS1318's own literal message text ("An abstract accessor cannot have an implementation.") — but reported it under the `METHOD_CANNOT_HAVE_AN_IMPLEMENTATION_BECAUSE_IT_IS_MARKED_ABSTRACT` (TS1245) diagnostic *code* constant instead of `AN_ABSTRACT_ACCESSOR_CANNOT_HAVE_AN_IMPLEMENTATION` (TS1318). So tsz emitted the right text under the wrong code — every abstract accessor with a body was silently misreported as TS1245 instead of TS1318. Fixed by swapping the constant on that one call site; no other change. The sibling method call site (line 707, TS1245) was already correct and is untouched.

Confirmed against a fresh `typescript@7.0.2` oracle probe (`node node_modules/typescript/lib/tsc.js --noEmit --strict --pretty false`): abstract getter/setter with a body → TS1318 (×2 independently for a get/set pair on the same class); abstract method with a body → TS1245; bodyless abstract accessor pair → clean.

### Adjacent-case matrix (`crates/tsz-checker/src/tests/ts1318_abstract_accessor_implementation_tests.rs`, 6 new tests, wired into `test_module_registry.rs`)

- Positive: abstract `get` accessor with a body → TS1318, not TS1245.
- Positive: abstract `set` accessor with a body → TS1318, not TS1245.
- Positive: an abstract get/set pair each carrying its own body → two independent TS1318s (not deduplicated to one).
- Renamed-binder control: same shape with different identifiers → still TS1318.
- Sibling control: abstract *method* with a body → still TS1245, not TS1318 (proves the fix didn't blur the two codes together).
- Negative: bodyless abstract get/set pair → neither code fires.

No identifier/alias/property/file-name string drives any decision; the only inputs are the accessor's own body-presence and abstract-modifier bits, unchanged from before this fix.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib ts1318` — 6/6 pass (all new).
- `cargo test -p tsz-checker --lib -- ts2515 class_implements_abstract abstract_member ambient_class` — 56/56 pass, no regressions in the sibling abstract-member/ambient-class families that share this code path.
- `cargo fmt -p tsz-checker -- --check` — clean.
- `cargo clippy -p tsz-checker --all-targets --profile ci-lint -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py` — passed.
- Local `pre-commit` hook (fmt + clippy + arch-guard) — passed.
- **Not run**: `scripts/conformance/compare-to-parent.sh`. This changes only which diagnostic *code* is attached to an already-firing diagnostic (message text and position are unchanged), for a narrow shape (an abstract accessor given a body) that is itself invalid TypeScript and vanishingly unlikely to appear as a passing-test fixture in the corpus — zero conformance movement is the expected signature here, not evidence the fix is inert, per the board's standing note on this diagnostic-wiring family.
- Not run: emit/fourslash — no emit or LSP-surface code touched; this is a diagnostics-only fix.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01H93R4EQhuJWirGXb6TChiQ)_