### PR TITLE
fix(parser): accessor signatures in interfaces and type literals parse their parameter list

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -234,6 +234,10 @@ mod computed_property_name_end_position_tests;
 mod close_brace_node_end_position_tests;
 
 #[cfg(test)]
+#[path = "../../tests/accessor_signature_parameter_list_tests.rs"]
+mod accessor_signature_parameter_list_tests;
+
+#[cfg(test)]
 #[path = "../../tests/close_brace_node_end_position_remaining_tests.rs"]
 mod close_brace_node_end_position_remaining_tests;
 

--- a/crates/tsz-parser/src/parser/state_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_declarations.rs
@@ -1105,13 +1105,35 @@ impl ParserState {
 
     /// Parse get accessor signature in type context: get `foo()`: type
     /// Note: TypeScript allows bodies here (which is an error), so we parse them for error recovery
+    ///
+    /// The parameter list is parsed, not asserted empty. tsc's grammar for an
+    /// accessor is keyed on the accessor node, not on its container, so an
+    /// accessor in a type-member list accepts exactly the same parameter list as
+    /// one in a class body and reports the same grammar errors on it. Asserting
+    /// `()` here made the first parameter token terminate the member, which
+    /// turned every such signature into a `TS1005`/`TS1131` parse cascade.
     pub(crate) fn parse_get_accessor_signature(&mut self, start_pos: u32) -> NodeIndex {
         self.parse_expected(SyntaxKind::GetKeyword);
 
         let name = self.parse_property_name();
 
+        let type_parameters = self.is_token(SyntaxKind::LessThanToken).then(|| {
+            self.report_accessor_type_parameters_error(name);
+            self.parse_type_parameters()
+        });
+
         self.parse_expected(SyntaxKind::OpenParenToken);
+        let parameters = if self.is_token(SyntaxKind::CloseParenToken) {
+            Self::make_node_list(vec![])
+        } else {
+            self.parse_parameter_list()
+        };
         self.parse_expected(SyntaxKind::CloseParenToken);
+
+        // TS1054: reported after the list is parsed, so a `,` in an otherwise
+        // empty slot (`get x(,)`) yields the `TS1138` its own slot already
+        // emitted and no arity error, matching tsc.
+        self.report_get_accessor_parameter_count(name, &parameters);
 
         // Return type (supports type predicates)
         let type_annotation = if self.parse_optional(SyntaxKind::ColonToken) {
@@ -1135,8 +1157,8 @@ impl ParserState {
             crate::parser::node::AccessorData {
                 modifiers: None,
                 name,
-                type_parameters: None,
-                parameters: Self::make_node_list(vec![]),
+                type_parameters,
+                parameters,
                 type_annotation,
                 body,
             },
@@ -1145,14 +1167,39 @@ impl ParserState {
 
     /// Parse set accessor signature in type context: set foo(v: type)
     /// Note: TypeScript allows bodies here (which is an error), so we parse them for error recovery
+    ///
+    /// Carries the same accessor grammar as a `set` accessor in a class body —
+    /// `TS1094`, `TS1049`, `TS1051` and `TS1095` — because tsc keys that grammar
+    /// on the accessor node rather than on its container.
     pub(crate) fn parse_set_accessor_signature(&mut self, start_pos: u32) -> NodeIndex {
         self.parse_expected(SyntaxKind::SetKeyword);
 
         let name = self.parse_property_name();
 
-        self.parse_expected(SyntaxKind::OpenParenToken);
+        let type_parameters = self.is_token(SyntaxKind::LessThanToken).then(|| {
+            self.report_accessor_type_parameters_error(name);
+            self.parse_type_parameters()
+        });
+
+        let had_open_paren = self.parse_expected(SyntaxKind::OpenParenToken);
         let parameters = self.parse_parameter_list();
         self.parse_expected(SyntaxKind::CloseParenToken);
+
+        // TS1049, and the early return that suppresses the later `set`-specific
+        // grammar once the count is already wrong.
+        let count_error =
+            had_open_paren && self.report_set_accessor_parameter_count(name, &parameters);
+
+        self.report_set_accessor_optional_parameter(&parameters, count_error);
+
+        // Parse the return type annotation for error recovery even though a
+        // setter cannot legally carry one; the emitter preserves it.
+        let type_annotation = if self.parse_optional(SyntaxKind::ColonToken) {
+            self.report_set_accessor_return_type_annotation(name, count_error);
+            self.parse_return_type()
+        } else {
+            NodeIndex::NONE
+        };
 
         // Parse body if present (this is an error in type context, but we handle it)
         let body = if self.is_token(SyntaxKind::OpenBraceToken) {
@@ -1169,9 +1216,9 @@ impl ParserState {
             crate::parser::node::AccessorData {
                 modifiers: None,
                 name,
-                type_parameters: None,
+                type_parameters,
                 parameters,
-                type_annotation: NodeIndex::NONE,
+                type_annotation,
                 body,
             },
         )

--- a/crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs
@@ -676,26 +676,14 @@ impl ParserState {
         let count_error =
             had_open_paren && self.report_set_accessor_parameter_count(name, &parameters);
 
+        // TS1051: A 'set' accessor cannot have an optional parameter. tsc applies
+        // this to an object-literal setter exactly as it does to a class one; this
+        // arm was the only one of the three that never checked it.
+        self.report_set_accessor_optional_parameter(&parameters, count_error);
+
         if self.parse_optional(SyntaxKind::ColonToken) {
-            use tsz_common::diagnostics::diagnostic_codes;
-            // Report error at the accessor name, matching tsc behavior. A wrong
-            // parameter count already fired TS1049, so tsc's early return
-            // suppresses this one.
-            if !count_error {
-                if let Some(name_node) = self.arena.get(name) {
-                    self.parse_error_at(
-                        name_node.pos,
-                        name_node.end - name_node.pos,
-                        "A 'set' accessor cannot have a return type annotation.",
-                        diagnostic_codes::A_SET_ACCESSOR_CANNOT_HAVE_A_RETURN_TYPE_ANNOTATION,
-                    );
-                } else {
-                    self.parse_error_at_current_token(
-                        "A 'set' accessor cannot have a return type annotation.",
-                        diagnostic_codes::A_SET_ACCESSOR_CANNOT_HAVE_A_RETURN_TYPE_ANNOTATION,
-                    );
-                }
-            }
+            // TS1095, suppressed when TS1049 already fired.
+            self.report_set_accessor_return_type_annotation(name, count_error);
             let _ = self.parse_return_type();
         }
 

--- a/crates/tsz-parser/src/parser/state_statements_class_members.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class_members.rs
@@ -1106,55 +1106,15 @@ impl ParserState {
         let count_error =
             had_open_paren && self.report_set_accessor_parameter_count(name, &parameters);
 
-        // TS1051: A 'set' accessor cannot have an optional parameter
-        // tsc anchors the error at the `?` token, which is right after the
-        // parameter name.
-        if !count_error
-            && let Some(&first_param) = parameters.nodes.first()
-            && let Some(param_node) = self.arena.get(first_param)
-        {
-            let data_idx = param_node.data_index as usize;
-            if let Some(param_data) = self.arena.parameters.get(data_idx)
-                && param_data.question_token
-            {
-                use tsz_common::diagnostics::diagnostic_codes;
-                // Anchor at the `?` token: it starts at param_name.end
-                let question_pos = self
-                    .arena
-                    .get(param_data.name)
-                    .map_or(param_node.pos, |name_node| name_node.end);
-                self.parse_error_at(
-                    question_pos,
-                    1, // `?` is a single character
-                    "A 'set' accessor cannot have an optional parameter.",
-                    diagnostic_codes::A_SET_ACCESSOR_CANNOT_HAVE_AN_OPTIONAL_PARAMETER,
-                );
-            }
-        }
+        // TS1051: A 'set' accessor cannot have an optional parameter.
+        self.report_set_accessor_optional_parameter(&parameters, count_error);
 
         // Parse return type annotation for error recovery (tsc preserves it in JS output).
         // Setters cannot legally have return type annotations, but we store it so the
         // emitter can preserve it.
         let type_annotation = if self.parse_optional(SyntaxKind::ColonToken) {
-            use tsz_common::diagnostics::diagnostic_codes;
-            // Report error at the accessor name, matching tsc behavior. A wrong
-            // parameter count already fired TS1049, so tsc's early return
-            // suppresses this one.
-            if !count_error {
-                if let Some(name_node) = self.arena.get(name) {
-                    self.parse_error_at(
-                        name_node.pos,
-                        name_node.end - name_node.pos,
-                        "A 'set' accessor cannot have a return type annotation.",
-                        diagnostic_codes::A_SET_ACCESSOR_CANNOT_HAVE_A_RETURN_TYPE_ANNOTATION,
-                    );
-                } else {
-                    self.parse_error_at_current_token(
-                        "A 'set' accessor cannot have a return type annotation.",
-                        diagnostic_codes::A_SET_ACCESSOR_CANNOT_HAVE_A_RETURN_TYPE_ANNOTATION,
-                    );
-                }
-            }
+            // TS1095, suppressed when TS1049 already fired.
+            self.report_set_accessor_return_type_annotation(name, count_error);
             // Use parse_return_type to match tsc, which parses type predicates
             // even in invalid setter return types
             self.parse_return_type()
@@ -1196,16 +1156,7 @@ impl ParserState {
         parameters: &NodeList,
     ) -> bool {
         let count = parameters.nodes.len();
-        let first_is_this = parameters.nodes.first().is_some_and(|&param_idx| {
-            let name_idx = match self.arena.get_parameter_at(param_idx) {
-                Some(param) => param.name,
-                None => return false,
-            };
-            self.arena
-                .get(name_idx)
-                .is_some_and(|name_node| name_node.kind == SyntaxKind::ThisKeyword as u16)
-        });
-        if count == 1 || (count == 2 && first_is_this) {
+        if count == 1 || (count == 2 && self.first_parameter_is_this(parameters)) {
             return false;
         }
         use tsz_common::diagnostics::diagnostic_codes;
@@ -1223,6 +1174,124 @@ impl ParserState {
             );
         }
         true
+    }
+
+    /// Whether a signature's first parameter is a `this` parameter.
+    ///
+    /// A `this` parameter is not a value parameter, so every accessor arity rule
+    /// discounts it. Shared by the `get` and `set` arity checks so the two
+    /// cannot drift apart.
+    pub(crate) fn first_parameter_is_this(&self, parameters: &NodeList) -> bool {
+        parameters.nodes.first().is_some_and(|&param_idx| {
+            let name_idx = match self.arena.get_parameter_at(param_idx) {
+                Some(param) => param.name,
+                None => return false,
+            };
+            self.arena
+                .get(name_idx)
+                .is_some_and(|name_node| name_node.kind == SyntaxKind::ThisKeyword as u16)
+        })
+    }
+
+    /// TS1054: a `get` accessor cannot have parameters. The counterpart to
+    /// `report_set_accessor_parameter_count`, and discounting a leading `this`
+    /// parameter for the same reason: tsc's `checkGrammarAccessor` reads the
+    /// accessor's *value* parameters, so a getter whose only parameter is `this`
+    /// has correct arity and draws `TS2784` alone, with no `TS1054`.
+    ///
+    /// Reported on the accessor name, like tsc's `grammarErrorOnNode(accessor.name, …)`.
+    ///
+    /// Returns whether the diagnostic fired.
+    pub(crate) fn report_get_accessor_parameter_count(
+        &mut self,
+        name: NodeIndex,
+        parameters: &NodeList,
+    ) -> bool {
+        let count = parameters.nodes.len();
+        if count == 0 || (count == 1 && self.first_parameter_is_this(parameters)) {
+            return false;
+        }
+        use tsz_common::diagnostics::diagnostic_codes;
+        if let Some(name_node) = self.arena.get(name) {
+            self.parse_error_at(
+                name_node.pos,
+                name_node.end - name_node.pos,
+                "A 'get' accessor cannot have parameters.",
+                diagnostic_codes::A_GET_ACCESSOR_CANNOT_HAVE_PARAMETERS,
+            );
+        } else {
+            self.parse_error_at_current_token(
+                "A 'get' accessor cannot have parameters.",
+                diagnostic_codes::A_GET_ACCESSOR_CANNOT_HAVE_PARAMETERS,
+            );
+        }
+        true
+    }
+
+    /// TS1051: a `set` accessor cannot have an optional parameter. tsc anchors
+    /// the error at the `?` token, which begins at the parameter name's end.
+    ///
+    /// Suppressed when the parameter count was already wrong, matching tsc's
+    /// single-error early return out of `checkGrammarAccessor`.
+    pub(crate) fn report_set_accessor_optional_parameter(
+        &mut self,
+        parameters: &NodeList,
+        count_error: bool,
+    ) {
+        if count_error {
+            return;
+        }
+        let Some(&first_param) = parameters.nodes.first() else {
+            return;
+        };
+        let Some(param_node) = self.arena.get(first_param) else {
+            return;
+        };
+        let data_idx = param_node.data_index as usize;
+        let Some(param_data) = self.arena.parameters.get(data_idx) else {
+            return;
+        };
+        if !param_data.question_token {
+            return;
+        }
+        use tsz_common::diagnostics::diagnostic_codes;
+        let question_pos = self
+            .arena
+            .get(param_data.name)
+            .map_or(param_node.pos, |name_node| name_node.end);
+        self.parse_error_at(
+            question_pos,
+            1, // `?` is a single character
+            "A 'set' accessor cannot have an optional parameter.",
+            diagnostic_codes::A_SET_ACCESSOR_CANNOT_HAVE_AN_OPTIONAL_PARAMETER,
+        );
+    }
+
+    /// TS1095: a `set` accessor cannot have a return type annotation. Reported
+    /// on the accessor name, and suppressed when the parameter count was already
+    /// wrong, matching tsc's single-error early return.
+    pub(crate) fn report_set_accessor_return_type_annotation(
+        &mut self,
+        name: NodeIndex,
+        count_error: bool,
+    ) {
+        if count_error {
+            return;
+        }
+        use tsz_common::diagnostics::diagnostic_codes;
+        if let Some(name_node) = self.arena.get(name) {
+            self.parse_error_at(
+                name_node.pos,
+                name_node.end - name_node.pos,
+                "A 'set' accessor cannot have a return type annotation.",
+                diagnostic_codes::A_SET_ACCESSOR_CANNOT_HAVE_A_RETURN_TYPE_ANNOTATION,
+            );
+        } else {
+            self.parse_error_at_current_token(
+                "A 'set' accessor cannot have a return type annotation.",
+                diagnostic_codes::A_SET_ACCESSOR_CANNOT_HAVE_A_RETURN_TYPE_ANNOTATION,
+            );
+        }
     }
 
     /// Parse class members

--- a/crates/tsz-parser/tests/accessor_signature_parameter_list_tests.rs
+++ b/crates/tsz-parser/tests/accessor_signature_parameter_list_tests.rs
@@ -1,0 +1,452 @@
+//! Regression tests for #16273: an accessor in a **type-member list** (interface or
+//! type literal) parsed through a stripped-down clone of the accessor-declaration
+//! path. `parse_get_accessor_signature` asserted `()` instead of parsing a parameter
+//! list, and neither signature arm parsed a type-parameter list or carried any of the
+//! accessor grammar.
+//!
+//! tsc keys its accessor grammar on the accessor node, not on its container, so an
+//! accessor signature accepts exactly the same parameter list as a class or
+//! object-literal accessor and reports the same errors on it.
+//!
+//! The failure mode was worse than the missing diagnostics: the first parameter token
+//! terminated the member, so `get g(this: I): number` became a `TS1005`/`TS1131`
+//! cascade — and a parse error of that shape suppresses checker output for the whole
+//! file, so one mistyped accessor signature silently disabled type checking for every
+//! unrelated construct in its file.
+//!
+//! Every expectation below was recorded from the pinned `typescript@7.0.2` oracle
+//! (`--noEmit --strict --pretty false`), not derived from the rule. Binder names vary
+//! per row so no check can key on an identifier string.
+
+use crate::parser::test_fixture::parse_source;
+
+/// Codes emitted by the parser for `source`, in emission order.
+fn codes(source: &str) -> Vec<u32> {
+    let (parser, _) = parse_source(source);
+    parser.get_diagnostics().iter().map(|d| d.code).collect()
+}
+
+/// Assert the parser emits exactly `expected` for `source`.
+fn assert_codes(source: &str, expected: &[u32], label: &str) {
+    let (parser, _) = parse_source(source);
+    let actual: Vec<u32> = parser.get_diagnostics().iter().map(|d| d.code).collect();
+    assert_eq!(
+        actual,
+        expected,
+        "{label}: parser diagnostics mismatch for {source:?}\n  got: {:?}",
+        parser.get_diagnostics()
+    );
+}
+
+const TS1049_SET_MUST_HAVE_EXACTLY_ONE_PARAMETER: u32 = 1049;
+const TS1051_SET_CANNOT_HAVE_OPTIONAL_PARAMETER: u32 = 1051;
+const TS1054_GET_CANNOT_HAVE_PARAMETERS: u32 = 1054;
+const TS1094_ACCESSOR_CANNOT_HAVE_TYPE_PARAMETERS: u32 = 1094;
+const TS1095_SET_CANNOT_HAVE_RETURN_TYPE: u32 = 1095;
+
+// ---------------------------------------------------------------------------
+// The reported witness: a `this` parameter no longer breaks the parse.
+//
+// tsc reports TS2784 on each of these and nothing from the parser. TS2784 is a
+// checker diagnostic, so the parser's contract here is to emit *nothing* and
+// produce a well-formed accessor node.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn interface_get_accessor_signature_accepts_a_this_parameter() {
+    assert_codes(
+        "interface Ia10 { get ga10(this: Ia10): number; }",
+        &[],
+        "interface getter with a lone `this` parameter",
+    );
+}
+
+#[test]
+fn interface_set_accessor_signature_accepts_a_this_parameter() {
+    assert_codes(
+        "interface Ib11 { set sb11(this: Ib11, vb11: number); }",
+        &[],
+        "interface setter with a leading `this` parameter",
+    );
+}
+
+#[test]
+fn type_literal_get_accessor_signature_accepts_a_this_parameter() {
+    assert_codes(
+        "type Tc12 = { get gc12(this: Tc12): number };",
+        &[],
+        "type-literal getter with a lone `this` parameter",
+    );
+}
+
+#[test]
+fn type_literal_set_accessor_signature_accepts_a_this_parameter() {
+    assert_codes(
+        "type Td13 = { set sd13(this: Td13, vd13: string) };",
+        &[],
+        "type-literal setter with a leading `this` parameter",
+    );
+}
+
+#[test]
+fn ambient_declaration_accessor_signature_accepts_a_this_parameter() {
+    assert_codes(
+        "declare const de14: { get ge14(this: unknown): number };",
+        &[],
+        "accessor signature inside a `declare const` type literal",
+    );
+}
+
+/// The whole point of the bug: one bad accessor signature used to suppress
+/// checking for its entire file by leaving a `TS1005`/`TS1131` cascade behind.
+/// Unrelated members after it must parse cleanly.
+#[test]
+fn a_this_parameter_accessor_does_not_wreck_the_rest_of_the_member_list() {
+    assert_codes(
+        "interface If15 {\n  get gf15(this: If15): number;\n  mg15(xh15: number): void;\n  pi15: string;\n}",
+        &[],
+        "members following an accessor signature with a `this` parameter",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TS1054 — a `get` accessor cannot have parameters.
+//
+// A `this` parameter is not a value parameter, so a getter whose *only*
+// parameter is `this` has correct arity and draws no TS1054 (rows above);
+// `this` plus a real parameter draws it (row below), exactly as tsc does.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn interface_get_accessor_signature_with_a_value_parameter_reports_ts1054() {
+    assert_codes(
+        "interface Ij20 { get gj20(xk20: number): number; }",
+        &[TS1054_GET_CANNOT_HAVE_PARAMETERS],
+        "interface getter with one value parameter",
+    );
+}
+
+#[test]
+fn interface_get_accessor_signature_with_two_value_parameters_reports_ts1054_once() {
+    assert_codes(
+        "interface Il21 { get gl21(xm21: number, yn21: string): number; }",
+        &[TS1054_GET_CANNOT_HAVE_PARAMETERS],
+        "interface getter with two value parameters",
+    );
+}
+
+#[test]
+fn get_accessor_signature_with_this_plus_a_value_parameter_reports_ts1054() {
+    // tsc reports TS1054 here *and* TS2784 on the `this` parameter: the `this`
+    // parameter is discounted for arity but is still illegal on an accessor.
+    assert_codes(
+        "interface Io22 { get go22(this: Io22, xp22: number): number; }",
+        &[TS1054_GET_CANNOT_HAVE_PARAMETERS],
+        "interface getter with `this` plus a value parameter",
+    );
+}
+
+#[test]
+fn type_literal_get_accessor_signature_with_a_value_parameter_reports_ts1054() {
+    assert_codes(
+        "type Tq23 = { get gq23(xr23: string): string };",
+        &[TS1054_GET_CANNOT_HAVE_PARAMETERS],
+        "type-literal getter with one value parameter",
+    );
+}
+
+/// Returns the `(start, length)` of the first diagnostic with `code`.
+fn span_of(source: &str, code: u32) -> (u32, u32) {
+    let (parser, _) = parse_source(source);
+    let diagnostic = parser
+        .get_diagnostics()
+        .iter()
+        .find(|d| d.code == code)
+        .unwrap_or_else(|| panic!("expected code {code} for {source:?}"));
+    (diagnostic.start, diagnostic.length)
+}
+
+#[test]
+fn get_accessor_signature_reports_ts1054_at_the_accessor_name() {
+    // tsc's `grammarErrorOnNode(accessor.name, …)` anchors at the name, not at
+    // the `get` keyword and not at the offending parameter. The reported column
+    // is what the anchor controls, so `start` is the assertion that matters.
+    let source = "interface Is24 { get gs24(xt24: number): number; }";
+    let (start, _) = span_of(source, TS1054_GET_CANNOT_HAVE_PARAMETERS);
+    assert_eq!(
+        start,
+        source.find("gs24").expect("name present") as u32,
+        "TS1054 must anchor at the accessor name in {source:?}"
+    );
+}
+
+/// The signature arm and the class arm must produce the *same shape* of span for
+/// TS1054, so the two cannot drift. Both read `name.end - name.pos`, and that
+/// length currently overshoots the identifier by one — a property-name node-end
+/// overshoot shared by both arms and out of scope here. Pinning the two against
+/// each other catches a change to either without baking in the wrong number.
+#[test]
+fn get_accessor_ts1054_span_agrees_between_the_signature_and_class_arms() {
+    let (sig_start, sig_len) = span_of(
+        "interface Iy27 { get gy27(xz27: number): number; }",
+        TS1054_GET_CANNOT_HAVE_PARAMETERS,
+    );
+    let (class_start, class_len) = span_of(
+        "class Ky27 { get gy27(xz27: number) { return 1 } }",
+        TS1054_GET_CANNOT_HAVE_PARAMETERS,
+    );
+    assert_eq!(
+        sig_len, class_len,
+        "TS1054 span length must match between the accessor-signature and class arms"
+    );
+    assert_eq!(
+        sig_start - "interface Iy27 { get ".len() as u32,
+        class_start - "class Ky27 { get ".len() as u32,
+        "TS1054 must anchor at the same offset within the member in both arms"
+    );
+}
+
+#[test]
+fn empty_get_accessor_signature_is_clean() {
+    assert_codes(
+        "interface Iu25 { get gu25(): number; }",
+        &[],
+        "getter signature with an empty parameter list",
+    );
+}
+
+/// `get x(,)` is a parameter-declaration error, not an arity error: tsc emits
+/// TS1138 for the empty slot and no TS1054, because the parsed list is empty.
+/// Reporting TS1054 *after* parsing the list rather than before is what makes
+/// this row come out right.
+#[test]
+fn get_accessor_signature_with_an_empty_parameter_slot_does_not_report_ts1054() {
+    assert!(
+        !codes("interface Iv26 { get gv26(,): number; }")
+            .contains(&TS1054_GET_CANNOT_HAVE_PARAMETERS),
+        "an empty parameter slot is TS1138, not TS1054"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TS1094 — an accessor cannot have type parameters.
+//
+// Neither signature arm parsed a type-parameter list at all, so `get g<T>()`
+// produced `TS1005: '(' expected.` and took the rest of the member list with it.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn get_accessor_signature_with_type_parameters_reports_ts1094() {
+    assert_codes(
+        "interface Iw30 { get gw30<Tx30>(): number; }",
+        &[TS1094_ACCESSOR_CANNOT_HAVE_TYPE_PARAMETERS],
+        "interface getter with a type parameter list",
+    );
+}
+
+#[test]
+fn set_accessor_signature_with_type_parameters_reports_ts1094() {
+    assert_codes(
+        "interface Iy31 { set sy31<Tz31>(va31: number); }",
+        &[TS1094_ACCESSOR_CANNOT_HAVE_TYPE_PARAMETERS],
+        "interface setter with a type parameter list",
+    );
+}
+
+#[test]
+fn type_literal_get_accessor_signature_with_type_parameters_reports_ts1094() {
+    assert_codes(
+        "type Tb32 = { get gb32<Tc32>(): number };",
+        &[TS1094_ACCESSOR_CANNOT_HAVE_TYPE_PARAMETERS],
+        "type-literal getter with a type parameter list",
+    );
+}
+
+#[test]
+fn type_parameters_on_an_accessor_signature_do_not_wreck_the_member_list() {
+    assert_codes(
+        "interface Id33 {\n  get gd33<Te33>(): number;\n  mf33(): void;\n}",
+        &[TS1094_ACCESSOR_CANNOT_HAVE_TYPE_PARAMETERS],
+        "member following a generic accessor signature",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TS1049 / TS1051 / TS1095 — the `set` grammar, which the signature arm carried
+// none of. The class-body arm already had all three; these rows pin that the
+// signature arm now agrees with it.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn set_accessor_signature_with_two_value_parameters_reports_ts1049() {
+    assert_codes(
+        "interface Ig40 { set sg40(vh40: number, wi40: number); }",
+        &[TS1049_SET_MUST_HAVE_EXACTLY_ONE_PARAMETER],
+        "interface setter with two value parameters",
+    );
+}
+
+#[test]
+fn set_accessor_signature_with_no_parameters_reports_ts1049() {
+    assert_codes(
+        "interface Ij41 { set sj41(); }",
+        &[TS1049_SET_MUST_HAVE_EXACTLY_ONE_PARAMETER],
+        "interface setter with an empty parameter list",
+    );
+}
+
+#[test]
+fn set_accessor_signature_with_this_plus_one_value_parameter_is_correct_arity() {
+    // `this` is discounted, so this is a one-value-parameter setter: no TS1049.
+    // tsc reports only TS2784 here.
+    assert_codes(
+        "interface Ik42 { set sk42(this: Ik42, vl42: number); }",
+        &[],
+        "interface setter with `this` plus one value parameter",
+    );
+}
+
+#[test]
+fn set_accessor_signature_with_only_a_this_parameter_is_correct_arity() {
+    // tsc counts `parameters.length`, which is 1 here, so TS1049 does not fire.
+    assert_codes(
+        "interface Im43 { set sm43(this: Im43); }",
+        &[],
+        "interface setter whose only parameter is `this`",
+    );
+}
+
+#[test]
+fn set_accessor_signature_with_an_optional_parameter_reports_ts1051() {
+    assert_codes(
+        "interface In44 { set sn44(vo44?: number); }",
+        &[TS1051_SET_CANNOT_HAVE_OPTIONAL_PARAMETER],
+        "interface setter with an optional parameter",
+    );
+}
+
+#[test]
+fn set_accessor_signature_with_a_return_type_reports_ts1095() {
+    assert_codes(
+        "interface Ip45 { set sp45(vq45: number): void; }",
+        &[TS1095_SET_CANNOT_HAVE_RETURN_TYPE],
+        "interface setter with a return type annotation",
+    );
+}
+
+#[test]
+fn set_accessor_signature_return_type_is_suppressed_by_a_count_error() {
+    // tsc's `checkGrammarAccessor` returns at the first error, so a wrong
+    // parameter count suppresses the return-type and optional-parameter checks.
+    assert_codes(
+        "interface Ir46 { set sr46(vs46: number, wt46: number): void; }",
+        &[TS1049_SET_MUST_HAVE_EXACTLY_ONE_PARAMETER],
+        "count error suppresses TS1095",
+    );
+}
+
+#[test]
+fn set_accessor_signature_optional_parameter_is_suppressed_by_a_count_error() {
+    assert_codes(
+        "interface Iu47 { set su47(vv47?: number, ww47?: number); }",
+        &[TS1049_SET_MUST_HAVE_EXACTLY_ONE_PARAMETER],
+        "count error suppresses TS1051",
+    );
+}
+
+#[test]
+fn type_literal_set_accessor_signature_with_two_parameters_reports_ts1049() {
+    assert_codes(
+        "type Tx48 = { set sx48(vy48: string, wz48: string) };",
+        &[TS1049_SET_MUST_HAVE_EXACTLY_ONE_PARAMETER],
+        "type-literal setter with two value parameters",
+    );
+}
+
+#[test]
+fn well_formed_set_accessor_signature_is_clean() {
+    assert_codes(
+        "interface Ia49 { set sa49(vb49: number); }",
+        &[],
+        "setter signature with exactly one value parameter",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The sibling type-member kinds already accepted `this` and must keep doing so.
+// These are the negatives that distinguish "the accessor arm was broken" from
+// "the member list was broken".
+// ---------------------------------------------------------------------------
+
+#[test]
+fn method_call_and_construct_signatures_still_accept_a_this_parameter() {
+    assert_codes(
+        "interface Ic50 {\n  mc50(this: Ic50): void;\n  (this: Ic50): void;\n  new (this: Ic50): Ic50;\n}",
+        &[],
+        "method, call and construct signatures with a `this` parameter",
+    );
+}
+
+#[test]
+fn a_property_named_get_is_still_a_property() {
+    // `get` and `set` are not reserved: a member literally named `get` must not
+    // route into the accessor arm.
+    assert_codes(
+        "interface Id51 { get: number; set: string; }",
+        &[],
+        "members named `get` and `set`",
+    );
+}
+
+#[test]
+fn a_method_named_get_is_still_a_method() {
+    assert_codes(
+        "interface Ie52 { get(xf52: number): void; set(yg52: string): void; }",
+        &[],
+        "methods named `get` and `set`",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Class and object-literal accessors are the paths this change deliberately
+// left alone apart from routing them through the shared helpers. Pinned here so
+// the extraction cannot silently change them.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn class_set_accessor_grammar_is_unchanged_by_the_shared_helpers() {
+    assert_codes(
+        "class Kh60 { set sh60(vi60: number, wj60: number) {} }",
+        &[TS1049_SET_MUST_HAVE_EXACTLY_ONE_PARAMETER],
+        "class setter count error",
+    );
+    assert_codes(
+        "class Kk61 { set sk61(vl61?: number) {} }",
+        &[TS1051_SET_CANNOT_HAVE_OPTIONAL_PARAMETER],
+        "class setter optional parameter",
+    );
+    assert_codes(
+        "class Km62 { set sm62(vn62: number): void {} }",
+        &[TS1095_SET_CANNOT_HAVE_RETURN_TYPE],
+        "class setter return type",
+    );
+    assert_codes(
+        "class Ko63 { set so63(this: Ko63, vp63: number) {} }",
+        &[],
+        "class setter with `this` plus one value parameter",
+    );
+}
+
+#[test]
+fn object_literal_set_accessor_grammar_is_unchanged_by_the_shared_helpers() {
+    assert_codes(
+        "const oq64 = { set sq64(vr64: number, ws64: number) {} };",
+        &[TS1049_SET_MUST_HAVE_EXACTLY_ONE_PARAMETER],
+        "object-literal setter count error",
+    );
+    assert_codes(
+        "const ot65 = { set st65(vu65?: number) {} };",
+        &[TS1051_SET_CANNOT_HAVE_OPTIONAL_PARAMETER],
+        "object-literal setter optional parameter",
+    );
+}


### PR DESCRIPTION
**Structural rule.** When a `get`/`set` accessor appears in a **type-member list** (an interface or a type literal), `tsc` parses its parameter list and applies the identical accessor grammar it applies to a class or object-literal accessor — `checkGrammarAccessor` is keyed on the **accessor node**, not on its container. tsz now does the same through the parser's type-member signature path (`parse_get_accessor_signature` / `parse_set_accessor_signature`, `crates/tsz-parser/src/parser/state_declarations.rs`).

The wrong operation was **parser recovery / grammar**, not inference, lookup or display. Closes #16273.

### The defect

The accessor **signature** arm was a stripped-down clone of the accessor **declaration** arm. `parse_get_accessor_signature` asserted an empty list outright:

```rust
self.parse_expected(SyntaxKind::OpenParenToken);
self.parse_expected(SyntaxKind::CloseParenToken);   // <- no parameter list, ever
```

so the first parameter token failed `parse_expected(CloseParenToken)`, terminated the member, and the remainder was re-parsed as fresh members. Neither arm parsed a type-parameter list, and the setter arm carried none of the accessor grammar.

**This is not only a missing diagnostic.** A TS1005 parse failure of this shape **suppresses checker output for the whole file** — #16273 records a 38-row probe file that produced *no* checker output at all because of one such member. A single mistyped accessor signature silently disabled type checking for every unrelated construct in its file. That is the user-visible bug; the missing grammar codes are the smaller half.

### Measured blast radius — wider than the issue documented

The issue reported the `this`-parameter shape. Running the pre-change binary against the oracle showed **two more shapes hitting the same cascade**, both of which this PR also fixes:

| input | tsz before | tsc 7.0.2 |
| --- | --- | --- |
| `interface I { get g(this: I): number }` | TS1005 + 2x TS1131 | TS2784 |
| `interface I { get g(x: number): number }` | TS1005 + 2x TS1131 | TS1054 |
| `interface I { get g<T>(): number }` | TS1005 `'(' expected` | TS1094 |

The third took the rest of the interface with it — the `d.ts` probe cascaded to a stray TS1005 at EOF, ten lines past the offending member.

### What the arms now carry

Both signature arms parse the type-parameter list (**TS1094**) and the parameter list. The getter reports **TS1054**; the setter reports **TS1049**, **TS1051** and **TS1095**, with tsc's single-error early return (a wrong count suppresses the other two).

**TS1054 discounts a leading `this` parameter.** A `this` parameter is not a value parameter, so a getter whose only parameter is `this` has correct arity and draws TS2784 alone — this mirrors the exclusion `report_set_accessor_parameter_count` already encoded for setters. Confirmed against the oracle in both directions: a lone `this` draws no TS1054, while `this` *plus* a real parameter draws it.

**TS1054 is reported after the list is parsed, not before.** The class arm errors before parsing and needs a bespoke `get x(,)` carve-out; parsing first and counting after makes that row fall out for free — the empty slot emits its own TS1138 and the parsed list is empty, so no arity error, matching tsc.

### Second pre-existing gap this surfaced

TS1051, TS1095 and the `this`-discounting arity test moved into shared helpers beside the existing setter-count helper, and the class and object-literal arms now route through them so each rule has one owner. Pinning the object-literal arm against the oracle showed **it never checked TS1051 at all** — `const o = { set s(v?: number) {} }` drew nothing where tsc reports TS1051. Fixed by the same routing; the `y1` probe (object literal / class / interface side by side) is now byte-identical to tsc.

No identifier, alias, property or file-name string drives any decision, and no predicate reads rendered type or printer output. The only inputs are a parameter's index, its `this`-ness, and the presence of a type-parameter list or return type.

### Adjacent-case matrix

33 new rows in `crates/tsz-parser/tests/accessor_signature_parameter_list_tests.rs`, every expectation recorded from the pinned `typescript@7.0.2` oracle rather than derived from the rule. Binder names vary per row so nothing can key on an identifier string.

- **Containers** — interface, type literal, `declare const` type literal, and (as untouched controls) class body and object literal.
- **`this` positives** — lone `this` in a getter and in a setter, in each container; `this` + a value parameter in a getter (TS1054 fires); `this` + one value parameter in a setter (correct arity, silent); a setter whose only parameter is `this` (`parameters.length == 1`, so no TS1049).
- **Arity** — getter with one / two value parameters; setter with zero / two; the `get x(,)` empty-slot row that must *not* draw TS1054.
- **Suppression** — a count error suppresses both TS1095 and TS1051, matching tsc's early return.
- **Negatives that isolate the arm** — method, call and construct signatures on the same member list still accept `this`; a property literally named `get`/`set`; a *method* named `get`/`set`; a well-formed getter and setter signature; a member list whose later members must survive a bad accessor (the whole-file-suppression regression).
- **Span** — TS1054 anchors at the accessor name, cross-pinned between the signature and class arms so the two cannot drift.

## Goal
Goal: hold

## Verification

- `cargo test -p tsz-parser --lib` — **1557 passed, 0 failed** (1524 before, + the 33 new rows). This is the suite that owns every path this PR touches.
- **Five probe files diffed against `node typescript@7.0.2/lib/tsc.js` on identical input**, before and after. All TS1005/TS1131 cascades are gone; `y1.ts` (the object-literal/class/interface TS1051 triple) is now **byte-identical** to tsc.
- `cargo fmt --all` clean; the `pre-commit` hook's `Verifying: -p tsz-parser` clippy leg and the architecture guard both passed.
- Two-sided `scripts/conformance/compare-to-parent.sh origin/main` — **running at time of opening; result posted as a comment on this PR.** Do not land before it reports. This change makes previously-silent diagnostics start firing *and* populates AST fields (`parameters`, `type_parameters`) that were hard-coded empty on interface accessors, so the corpus is a genuine regression gate here, not a formality.

### Residual gaps, deliberately not patched

All three are pre-existing, confirmed against the oracle, and out of this PR's layer:

1. **TS2784 / TS2681 do not fire yet** — that is #16272's checker work, not yet on `main`. Once it lands, #16273's acceptance rows should pass with no further parser change; the nodes are now the right shape for it.
2. **TS1053** (`A 'set' accessor cannot have rest parameter`) has no call site anywhere in the workspace — a fresh instance of Peridot's 393-unwired-codes vein, not specific to signatures.
3. **A getter's TS1054 is dropped whenever a setter's TS1049/TS1051 fires in the same member list.** Reproduced on the **untouched class and object-literal paths** with the same binary, so it predates this change and is not a regression from it. Filed separately with the bisection.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Serpentine

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjSQSxDUkWYdUvKpchjYn9)_