### PR TITLE
fix(cli): the accessor grammar family is all-in or all-out of the parse-diagnostic filter

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -392,6 +392,19 @@ fn is_hard_keyword_interface_name_2427_parse_diagnostic(diagnostic: &ParseDiagno
 /// These should be suppressed when the file has parse errors, matching tsc behavior.
 /// Only includes codes confirmed to be checker-side grammar checks in tsc that
 /// our parser emits instead.
+///
+/// Membership is load-bearing in BOTH directions. A listed code is suppressed
+/// when a real parse error exists, and — because `has_non_grammar_parse_error`
+/// is computed as the complement of this list — an *unlisted* parser-emitted
+/// grammar code counts as a real parse error and suppresses every listed
+/// sibling. So omitting one member of a `grammarError`-family silently deletes
+/// the rest of its family: TS1049/TS1051 were missing here, and any file whose
+/// setter tripped one of them lost the getter's TS1054 entirely.
+///
+/// The accessor family (tsc's single `checkGrammarAccessor`) is therefore all
+/// in or all out: TS1049, TS1051, TS1054, TS1095. TS1052/TS1053 belong to the
+/// same tsc function but are checker-emitted in tsz, so they never reach this
+/// parse-diagnostic filter.
 const fn is_parser_grammar_code(code: u32) -> bool {
     matches!(
         code,
@@ -413,6 +426,8 @@ const fn is_parser_grammar_code(code: u32) -> bool {
         | 1040 // '{0}' modifier cannot be used in an ambient context
         | 1042 // 'async' modifier cannot be used here
         | 1044 // '{0}' modifier cannot appear on a module or namespace element
+        | 1049 // A 'set' accessor must have exactly one parameter
+        | 1051 // A 'set' accessor cannot have an optional parameter
         | 1054 // A 'get' accessor cannot have parameters
         | 1070 // '{0}' modifier cannot appear on a type member
         | 1071 // An accessor must have a body (interface/ambient)

--- a/crates/tsz-cli/src/driver/check_utils/tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/tests.rs
@@ -1374,6 +1374,171 @@ fn filtered_parse_diagnostics_keeps_ts1101_with_non_real_parse_error() {
     );
 }
 
+/// Build the parse-diagnostic pair a bad getter + bad setter in one member list
+/// produces. `setter_code`/`setter_message` vary the setter's grammar failure so
+/// the whole `checkGrammarAccessor` family is covered by one helper rather than
+/// four hand-copied vectors.
+fn accessor_grammar_pair(
+    setter_code: u32,
+    setter_message: &str,
+) -> Vec<tsz::parser::ParseDiagnostic> {
+    use tsz::parser::ParseDiagnostic;
+
+    vec![
+        ParseDiagnostic {
+            start: 18,
+            length: 2,
+            message: "A 'get' accessor cannot have parameters.".to_string(),
+            code: 1054,
+        },
+        ParseDiagnostic {
+            start: 52,
+            length: 2,
+            message: setter_message.to_string(),
+            code: setter_code,
+        },
+    ]
+}
+
+#[test]
+fn filtered_parse_diagnostics_keeps_getter_ts1054_alongside_setter_ts1049() {
+    // #16277. Both codes come from tsc's single `checkGrammarAccessor`, so a
+    // setter's TS1049 must not suppress a getter's TS1054 in the same member
+    // list. Pinned against tsc 7.0.2 (`--noEmit --strict --pretty false`) in all
+    // three accessor containers — class, object literal and type-member list —
+    // each of which reports TS1054 and TS1049 together.
+    let diagnostics =
+        accessor_grammar_pair(1049, "A 'set' accessor must have exactly one parameter.");
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&1054),
+        "TS1054 must survive alongside a sibling TS1049, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1049),
+        "TS1049 must survive alongside a sibling TS1054, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_keeps_getter_ts1054_alongside_setter_ts1051() {
+    // Same family, optional-parameter arm. tsc reports TS1054 + TS1051 together.
+    let diagnostics =
+        accessor_grammar_pair(1051, "A 'set' accessor cannot have an optional parameter.");
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&1054),
+        "TS1054 must survive alongside a sibling TS1051, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1051),
+        "TS1051 must survive alongside a sibling TS1054, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_keeps_getter_ts1054_alongside_setter_ts1095() {
+    // Positive control that already passed before the fix: TS1095 was the one
+    // accessor code already listed as a grammar code, so it never triggered the
+    // sibling-suppression path. It pins the arm that must NOT change.
+    let diagnostics = accessor_grammar_pair(
+        1095,
+        "A 'set' accessor cannot have a return type annotation.",
+    );
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&1054),
+        "TS1054 must survive alongside a sibling TS1095, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1095),
+        "TS1095 must survive alongside a sibling TS1054, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_keeps_repeated_setter_ts1049_without_a_getter() {
+    // Negative control for the fix's own risk: listing TS1049 as a grammar code
+    // must not make it suppress itself or vanish when it is the only kind of
+    // diagnostic in the file. Two bad setters alone keep both TS1049s.
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 18,
+            length: 2,
+            message: "A 'set' accessor must have exactly one parameter.".to_string(),
+            code: 1049,
+        },
+        ParseDiagnostic {
+            start: 52,
+            length: 2,
+            message: "A 'set' accessor must have exactly one parameter.".to_string(),
+            code: 1049,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert_eq!(
+        codes,
+        vec![1049, 1049],
+        "both TS1049s must survive when no other diagnostic kind is present, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_suppresses_accessor_grammar_family_when_real_parse_error_present() {
+    // The direction the fix newly introduces, and it is tsc's, not a side
+    // effect: `checkGrammarAccessor` reports through `grammarErrorOnNode`, which
+    // returns without reporting once `hasParseDiagnostics(sourceFile)` holds.
+    // Verified against tsc 7.0.2 — a class carrying `set sd(vd: number, wd:
+    // number) {}` plus a structural parse error reports ONLY the structural
+    // errors (TS1440/TS1109/TS1128); the TS1049 is gone. Same for TS1051.
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 18,
+            length: 2,
+            message: "A 'get' accessor cannot have parameters.".to_string(),
+            code: 1054,
+        },
+        ParseDiagnostic {
+            start: 52,
+            length: 2,
+            message: "A 'set' accessor must have exactly one parameter.".to_string(),
+            code: 1049,
+        },
+        ParseDiagnostic {
+            start: 70,
+            length: 2,
+            message: "A 'set' accessor cannot have an optional parameter.".to_string(),
+            code: 1051,
+        },
+        ParseDiagnostic {
+            start: 90,
+            length: 1,
+            message: "Expression expected.".to_string(),
+            code: 1109,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert_eq!(
+        codes,
+        vec![1109],
+        "the whole accessor grammar family must be suppressed by a real parse error, got: {codes:?}"
+    );
+}
+
 #[test]
 fn js_parse_allowlist_keeps_plain_js_binder_strict_codes() {
     for code in [1214, 18012] {


### PR DESCRIPTION
Closes #16277.

**Structural rule.** When a file's parse diagnostics contain a member of tsc's `checkGrammarAccessor` family, tsc reports every member of that family unless `hasParseDiagnostics(sourceFile)` holds, in which case it reports none of them; tsz does the same through `is_parser_grammar_code` in the CLI's parse-diagnostic filter (`crates/tsz-cli/src/driver/check_utils.rs`).

**What was wrong.** `is_parser_grammar_code` listed TS1054 and TS1095 but not TS1049 or TS1051. `has_non_grammar_parse_error` is computed as the *complement* of that list, so membership is load-bearing in both directions:

- a **listed** code is suppressed when a real parse error exists (intended), and
- an **unlisted** parser-emitted grammar code counts as a real parse error and suppresses every listed sibling (not intended).

So TS1049/TS1051 — parser-emitted in tsz, but checker-side `grammarErrorOnNode` calls in tsc — silently deleted their own sibling TS1054. Any member list with both a bad getter and a bad setter lost the getter's diagnostic entirely, in every accessor container, independent of order, count and column. TS1095 was already listed, which is exactly why the issue observed that TS1095 does *not* suppress TS1054 while TS1049/TS1051 do.

tsc reports all four codes from one `checkGrammarAccessor` via `grammarErrorOnNode`, so the family stands or falls together. TS1052/TS1053 belong to the same tsc function but are checker-emitted in tsz, so they never reach this parse-diagnostic filter and need no entry.

The fix is two lines in the list. No identifier, alias, property or file-name string drives it, and no rendered diagnostic text is used as a predicate — it corrects the membership of an existing, principled code set.

## Goal
Goal: hold

## Verification

**Oracle matrix — pinned `typescript@7.0.2`, `--noEmit --strict --pretty false --lib es2022 --target es2022`, compared end-to-end against the built `tsz` binary.** Both directions, not just the reported one:

| fixture | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| class: bad getter + bad setter (TS1049) | `TS1054 TS1049` | `TS1049` | `TS1054 TS1049` ✅ |
| object literal: bad getter + bad setter | `TS1054 TS1049` | `TS1049` | `TS1054 TS1049` ✅ |
| class: bad getter + optional setter param (TS1051) | `TS1054 TS1051` | `TS1051` | `TS1054 TS1051` ✅ |
| class: bad getter + setter return annotation (TS1095) | `TS1054 TS1095` | `TS1054 TS1095` | `TS1054 TS1095` ✅ (control, unchanged) |
| class: bad getter + bad setter **+ real syntax error** | `TS1005` only | — | `TS1005` only ✅ |

That last row is the direction this PR newly introduces for TS1049/TS1051, and it is tsc's behaviour, not a side effect: once a structural parse error exists, tsc drops the whole accessor family. Confirmed directly against the oracle before writing the fix.

**Adjacent-case unit matrix** — 5 new tests in `crates/tsz-cli/src/driver/check_utils/tests.rs`, matching the file's existing `filtered_parse_diagnostics_*` idiom:

- TS1054 survives alongside TS1049
- TS1054 survives alongside TS1051
- TS1054 survives alongside TS1095 (positive control — passed before the fix, pins the arm that must not change)
- two TS1049s with no getter both survive (negative control for this PR's own risk: listing TS1049 must not make it suppress itself or vanish when alone)
- the whole family (TS1049 + TS1051 + TS1054) is suppressed by a real TS1109 (the newly-introduced direction)

**Non-vacuity proven.** With the tests in place and only the two-line source change reverted, exactly the 3 behavioural tests fail and both controls still pass:

```
test result: FAILED. 10 passed; 3 failed
  ..._keeps_getter_ts1054_alongside_setter_ts1049
  ..._keeps_getter_ts1054_alongside_setter_ts1051
  ..._suppresses_accessor_grammar_family_when_real_parse_error_present
```

With the fix: `cargo test -p tsz-cli --lib filtered_parse_diagnostics` → **13 passed, 0 failed** (8 pre-existing + 5 new).

**Commands run:** `cargo fmt --all` clean · `cargo clippy -p tsz-cli --lib --tests -- -D warnings` clean · `python3 scripts/arch/arch_guard.py` → "Architecture guardrails passed."

**Corpus gate:** `compare-to-parent.sh` is running against `origin/main` and the two-sided number will be posted as a PR comment before this is queued. Not queuing until it reports 0 newly-failing.

**Known unaffected-by-this-PR delta, for the reviewer's benefit.** The type-member-list container (`interface I { get g(p: number): number; set s(a: number, b: number); }`) still differs from tsc — but for an unrelated upstream reason: on `main` that shape does not parse its accessor parameter list at all (`TS1005`/`TS1131`, #16273), so it never reaches this filter. #16276 fixes that parse. Per #16277's own `ParserState` bisect, the parser returns `[1054, 1049]` for the interface shape once it parses, and this filter is shared across all three containers — so the interface container gets this fix for free the moment #16276 lands. Stated as a prediction with its evidence; I did not verify it on a tree carrying another agent's unlanded PR.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Travertine

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNwsnxT3UEh47tdrmbtBEv)_