### PR TITLE
fix(checker): the `set`-accessor parameter grammar ran for class members only (TS1052/TS1053)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1567,6 +1567,9 @@ path = "tests/self_referencing_alias_member_inheritance_tests.rs"
 name = "self_referential_class_ctor_window_tests"
 path = "tests/self_referential_class_ctor_window_tests.rs"
 [[test]]
+name = "setter_parameter_grammar_container_coverage_tests"
+path = "tests/setter_parameter_grammar_container_coverage_tests.rs"
+[[test]]
 name = "contextual_typing_tests"
 path = "tests/contextual_typing_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/checkers/accessor_checker.rs
+++ b/crates/tsz-checker/src/checkers/accessor_checker.rs
@@ -451,6 +451,148 @@ impl<'a> CheckerState<'a> {
     // Setter Parameter Validation
     // =========================================================================
 
+    /// The `set`-accessor *parameter grammar* arms tsz owns, for every
+    /// container a `set` accessor can be written in.
+    ///
+    /// `tsc` runs these from `checkGrammarAccessor`, which is reached for a
+    /// `set` accessor wherever one can be written — class member, object
+    /// literal, interface member, type-literal member — because the rule reads
+    /// the accessor's own signature and never the container.
+    ///
+    /// `checkGrammarAccessor` reports **at most one** diagnostic per accessor:
+    /// it is a chain of early returns, in this order.
+    ///
+    /// | # | condition | code | emitted by |
+    /// | --- | --- | --- | --- |
+    /// | 1 | accessor has type parameters | `TS1094` | parser |
+    /// | 2 | value-parameter count is not exactly 1 | `TS1049` | parser |
+    /// | 3 | setter has a return type annotation | `TS1095` | parser |
+    /// | 4 | parameter is a rest parameter | **`TS1053`** | **here** |
+    /// | 5 | parameter is optional | `TS1051` | parser |
+    /// | 6 | parameter has an initializer | **`TS1052`** | **here** |
+    ///
+    /// tsz splits that chain across two layers — rows 1/2/3/5 are emitted by
+    /// the parser, rows 4 and 6 by this checker — so the ordering cannot be a
+    /// local early return inside either one. This function therefore re-tests
+    /// the *earlier* links' conditions before emitting, from the same
+    /// structural facts the parser uses. Without that, `set p(...v: T[]): void`
+    /// draws `TS1095` **and** `TS1053` where `tsc` reports `TS1095` alone.
+    ///
+    /// The value-parameter count in row 2 excludes a leading `this` parameter
+    /// (`tsc`'s `getSetAccessorValueParameter`): `set p(this: C, ...v: T[])` is
+    /// a one-value-parameter setter and still reaches row 4. A `this`
+    /// parameter on an accessor is separately illegal (`TS2784`), which does
+    /// not suppress this family.
+    ///
+    /// Split out of `check_setter_parameter` so the non-class containers reach
+    /// the same rule rather than re-deriving it. `check_setter_parameter` stays
+    /// the class-declaration entry point and additionally owns the
+    /// `noImplicitAny` family (`TS7006`/`TS7032`), whose suppression *does*
+    /// depend on the container and on a paired getter — which is why only the
+    /// grammar half is shared.
+    pub(crate) fn check_setter_parameter_grammar(&mut self, accessor_idx: NodeIndex) {
+        let Some(accessor_node) = self.ctx.arena.get(accessor_idx) else {
+            return;
+        };
+        let Some(accessor) = self.ctx.arena.get_accessor(accessor_node) else {
+            return;
+        };
+        let accessor_name = accessor.name;
+        let has_type_parameters = accessor
+            .type_parameters
+            .as_ref()
+            .is_some_and(|list| !list.nodes.is_empty());
+        let has_return_type = accessor.type_annotation.is_some();
+
+        // Row 1: `TS1094` claims an accessor with type parameters.
+        if has_type_parameters {
+            return;
+        }
+
+        // Row 2: the value parameters are the declared ones minus a leading
+        // `this` parameter, which is not a value parameter.
+        let value_params: Vec<NodeIndex> = accessor
+            .parameters
+            .nodes
+            .iter()
+            .copied()
+            .filter(|&param_idx| {
+                self.ctx
+                    .arena
+                    .get(param_idx)
+                    .and_then(|node| self.ctx.arena.get_parameter(node))
+                    .is_none_or(|param| !self.is_this_parameter_name(param.name))
+            })
+            .collect();
+        let [param_idx] = value_params[..] else {
+            // `TS1049` claims any other count.
+            return;
+        };
+
+        // Row 3: `TS1095` claims a setter with a return type annotation.
+        if has_return_type {
+            return;
+        }
+
+        let Some(param) = self
+            .ctx
+            .arena
+            .get(param_idx)
+            .and_then(|node| self.ctx.arena.get_parameter(node))
+        else {
+            return;
+        };
+        let (is_rest, is_optional, has_initializer, param_name) = (
+            param.dot_dot_dot_token,
+            param.question_token,
+            param.initializer.is_some(),
+            param.name,
+        );
+
+        // Row 4: rest parameter. tsc anchors TS1053 at the `...` token (the
+        // parameter's start), not at the parameter name.
+        if is_rest {
+            // Raw parameter start: the span normalizer would re-anchor a
+            // parameter at its name, which is exactly the divergence.
+            if let Some(start) = self.ctx.arena.get(param_idx).map(|node| node.pos) {
+                self.error_at_position(
+                    start,
+                    3,
+                    "A 'set' accessor cannot have rest parameter.",
+                    diagnostic_codes::A_SET_ACCESSOR_CANNOT_HAVE_REST_PARAMETER,
+                );
+            } else {
+                self.error_at_node(
+                    param_idx,
+                    "A 'set' accessor cannot have rest parameter.",
+                    diagnostic_codes::A_SET_ACCESSOR_CANNOT_HAVE_REST_PARAMETER,
+                );
+            }
+            return;
+        }
+
+        // Row 5: `TS1051` claims an optional parameter.
+        if is_optional {
+            return;
+        }
+
+        // Row 6: initializer. tsc points at the accessor name (e.g. `X` in
+        // `set X(v = 0)`), falling back to the parameter when the accessor has
+        // no usable name node.
+        if has_initializer {
+            let error_node = if accessor_name.is_some() {
+                accessor_name
+            } else {
+                param_name
+            };
+            self.error_at_node(
+                error_node,
+                "A 'set' accessor parameter cannot have an initializer.",
+                diagnostic_codes::A_SET_ACCESSOR_PARAMETER_CANNOT_HAVE_AN_INITIALIZER,
+            );
+        }
+    }
+
     /// Check setter parameter constraints (TS1052, TS1053, TS7006).
     ///
     /// This function validates that setter parameters comply with TypeScript rules:
@@ -484,40 +626,6 @@ impl<'a> CheckerState<'a> {
             let Some(param) = self.ctx.arena.get_parameter(param_node) else {
                 continue;
             };
-
-            // Check for initializer (error 1052)
-            // tsc points at the accessor name (e.g., `X` in `set X(v = 0)`)
-            if param.initializer.is_some() {
-                let error_node = accessor_name.unwrap_or(param.name);
-                self.error_at_node(
-                    error_node,
-                    "A 'set' accessor parameter cannot have an initializer.",
-                    diagnostic_codes::A_SET_ACCESSOR_PARAMETER_CANNOT_HAVE_AN_INITIALIZER,
-                );
-            }
-
-            // Check for rest parameter (error 1053).
-            // tsc anchors TS1053 at the `...` token (the parameter's start),
-            // not at the parameter name.
-            if param.dot_dot_dot_token {
-                // Raw parameter start: the span normalizer would re-anchor a
-                // parameter at its name, which is exactly the divergence.
-                let rest_token_anchor = self.ctx.arena.get(param_idx).map(|node| node.pos);
-                if let Some(start) = rest_token_anchor {
-                    self.error_at_position(
-                        start,
-                        3,
-                        "A 'set' accessor cannot have rest parameter.",
-                        diagnostic_codes::A_SET_ACCESSOR_CANNOT_HAVE_REST_PARAMETER,
-                    );
-                } else {
-                    self.error_at_node(
-                        param_idx,
-                        "A 'set' accessor cannot have rest parameter.",
-                        diagnostic_codes::A_SET_ACCESSOR_CANNOT_HAVE_REST_PARAMETER,
-                    );
-                }
-            }
 
             // Check for implicit any (error 7006)
             // When a setter has a paired getter, the parameter type is inferred from

--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -1525,6 +1525,7 @@ impl<'a> CheckerState<'a> {
             };
             let paired_getter_supplies_type =
                 self.paired_getter_supplies_property_type(accessor) || skip_implicit_any_accessor;
+            self.check_setter_parameter_grammar(member_idx);
             self.check_setter_parameter(
                 &accessor.parameters.nodes,
                 has_paired_getter || skip_implicit_any_accessor,

--- a/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
@@ -902,6 +902,15 @@ impl<'a> CheckerState<'a> {
             self.check_parameter_ordering(params, Some(member_idx));
         }
 
+        // TS1052/TS1053 likewise run for a `set` accessor member of an
+        // interface or type literal: tsc's `checkGrammarAccessor` reads the
+        // parameter node alone, so the container never gates the rule. Both
+        // callers of this walk (interface members and type-literal members)
+        // therefore get it here.
+        if node.kind == syntax_kind_ext::SET_ACCESSOR {
+            self.check_setter_parameter_grammar(member_idx);
+        }
+
         // Check call signatures and construct signatures for parameter properties
         if node.kind == syntax_kind_ext::CALL_SIGNATURE
             || node.kind == syntax_kind_ext::CONSTRUCT_SIGNATURE

--- a/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
@@ -90,6 +90,13 @@ impl<'a> CheckerState<'a> {
         // When a paired getter exists, the setter parameter type is inferred
         // from the getter return type (contextually typed, suppress TS7006/7032).
         if elem_node.kind == syntax_kind_ext::SET_ACCESSOR {
+            // TS1052/TS1053: the `set`-accessor parameter grammar. tsc reaches
+            // it from `checkGrammarAccessor` for an object-literal accessor
+            // exactly as it does for a class member — the rule reads the
+            // parameter node, not the container. Shared with the class and
+            // type-member containers rather than re-derived here.
+            self.check_setter_parameter_grammar(elem_idx);
+
             let name_opt = self.get_property_name(accessor.name).or_else(|| {
                 let prop_name_type = self.get_type_of_node(accessor.name);
                 crate::query_boundaries::type_computation::access::literal_property_name(

--- a/crates/tsz-checker/tests/setter_parameter_grammar_container_coverage_tests.rs
+++ b/crates/tsz-checker/tests/setter_parameter_grammar_container_coverage_tests.rs
@@ -1,0 +1,337 @@
+//! The `set`-accessor *parameter grammar* family (`TS1052`/`TS1053`) for every
+//! container a `set` accessor can be written in.
+//!
+//! Structural rule, one sentence: a `set` accessor's parameter may not carry an
+//! initializer (`TS1052`) and may not be a rest parameter (`TS1053`), and `tsc`
+//! decides both from the parameter node alone — so the rule holds identically
+//! in a class body, an object literal, an interface and a type literal. tsz
+//! reports both through the accessor checker's parameter-grammar layer,
+//! `check_setter_parameter_grammar` (`checkers/accessor_checker.rs`).
+//!
+//! Before this suite the rule was reported for **class members only**. Its one
+//! call site was `check_setter_parameter`, reached from
+//! `check_accessor_declaration_with_request`, which is itself reached only from
+//! the class member walk (`member_declaration_checks.rs`). Object literals
+//! route accessors through `types/computation/object_literal/accessor_element.rs`
+//! and interface / type-literal members through the type-member walk; neither
+//! path saw the rule, so all three containers silently accepted both shapes.
+//!
+//! Two properties of the family are load-bearing and each is pinned below:
+//!
+//! 1. The two arms are **independent**, not a match. `TS1052` and `TS1053` can
+//!    both be live in one member list, and they anchor differently — `TS1052`
+//!    on the accessor's *name*, `TS1053` on the `...` token. A shared anchor,
+//!    or an early return after the first arm, fails the `obj_both` row and
+//!    nothing else.
+//! 2. It is the parameter's *shape*, not the container and not the parameter's
+//!    name or type. Every legal-setter negative below is the same container and
+//!    the same binder shape as its positive, so a check that fired on the
+//!    presence of a `set` accessor rather than on the parameter fails all five.
+//!
+//! Every expectation here was recorded from `typescript@7.0.2` under
+//! `--noEmit --strict --lib es2022 --target es2022`, not derived from the rule.
+//! Anchors are pinned as 0-based offsets (`tsc`'s 1-based column minus one)
+//! because the blame *site* is half of this family. Binder names are distinct
+//! in every row so nothing can key on an identifier string.
+
+use tsz_checker::test_utils::check_source_strict;
+
+/// Every diagnostic as `TS<code>@<0-based start>`, sorted — the exact shape the
+/// oracle rows were recorded in.
+fn sites(source: &str) -> Vec<String> {
+    let mut out: Vec<String> = check_source_strict(source)
+        .iter()
+        .map(|d| format!("TS{}@{}", d.code, d.start))
+        .collect();
+    out.sort();
+    out
+}
+
+#[track_caller]
+fn assert_sites(source: &str, expected: &[&str]) {
+    let actual = sites(source);
+    let expected: Vec<String> = expected.iter().map(|s| (*s).to_string()).collect();
+    assert_eq!(actual, expected, "source: {source}");
+}
+
+// ---------------------------------------------------------------------------
+// Object-literal container. Previously silent on both arms.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn object_literal_setter_rest_parameter_reports_ts1053() {
+    assert_sites(
+        "const holder = {\n    set alpha(...spread: string[]) {},\n};\n",
+        &["TS1053@31"],
+    );
+}
+
+#[test]
+fn object_literal_setter_parameter_initializer_reports_ts1052() {
+    assert_sites(
+        "const carrier = {\n    set beta(weight: string = \"x\") {},\n};\n",
+        &["TS1052@26"],
+    );
+}
+
+/// Both arms live in one object literal, on different members. `TS1053` anchors
+/// at the `...` token, `TS1052` at the accessor name — the row that proves the
+/// arms are independent and do not share an anchor.
+#[test]
+fn object_literal_reports_both_arms_at_their_own_anchors() {
+    assert_sites(
+        "const dual = {\n    set gamma(...pile: string[]) {},\n    set delta(mass: number = 2) {},\n};\n",
+        &["TS1052@60", "TS1053@29"],
+    );
+}
+
+/// A nested object literal is a distinct traversal from the outermost one.
+#[test]
+fn nested_object_literal_setter_rest_parameter_reports_ts1053() {
+    assert_sites(
+        "const outerBag = {\n    innerBag: {\n        set epsilon(...heap: boolean[]) {},\n    },\n};\n",
+        &["TS1053@55"],
+    );
+}
+
+/// An object literal in a class method's return position: the enclosing class
+/// walk runs, but the literal is not a class member. Pins that the fix routes
+/// through the object-literal path and is not being masked by the class one.
+#[test]
+fn object_literal_returned_from_class_method_reports_ts1053() {
+    assert_sites(
+        "class Vessel {\n    build() {\n        return { set zeta(...batch: number[]) {} };\n    }\n}\n",
+        &["TS1053@55"],
+    );
+}
+
+#[test]
+fn object_literal_legal_setter_stays_clean() {
+    assert_sites("const clean = {\n    set eta(value: string) {},\n};\n", &[]);
+}
+
+// ---------------------------------------------------------------------------
+// Interface container. Previously silent.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn interface_setter_rest_parameter_reports_ts1053() {
+    assert_sites(
+        "interface Portal {\n    set theta(...stack: string[]);\n}\n",
+        &["TS1053@33"],
+    );
+}
+
+#[test]
+fn interface_legal_setter_stays_clean() {
+    assert_sites("interface Gate {\n    set iota(value: string);\n}\n", &[]);
+}
+
+// ---------------------------------------------------------------------------
+// Type-literal container. Previously silent. Shares the type-member walk with
+// interfaces, so both are pinned rather than one standing in for the other.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn type_literal_setter_rest_parameter_reports_ts1053() {
+    assert_sites(
+        "type Panel = {\n    set kappa(...queue: number[]);\n};\n",
+        &["TS1053@29"],
+    );
+}
+
+#[test]
+fn type_literal_legal_setter_stays_clean() {
+    assert_sites(
+        "type Frame = {\n    set lambdaProp(value: number);\n};\n",
+        &[],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Generic containers: the rule reads the parameter node, so a type-parameter
+// element type changes nothing. Both the class and the type-member arm.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn generic_class_setter_rest_parameter_reports_ts1053() {
+    assert_sites(
+        "class Crate<T> {\n    set rho(...units: T[]) {}\n}\n",
+        &["TS1053@29"],
+    );
+}
+
+#[test]
+fn generic_type_literal_setter_rest_parameter_reports_ts1053() {
+    assert_sites(
+        "type Sack<T> = {\n    set sigma(...units: T[]);\n};\n",
+        &["TS1053@31"],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Class container: already covered before this change. These are the
+// regression rows — the extraction must leave the class arm byte-identical.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn class_setter_rest_parameter_still_reports_ts1053() {
+    assert_sites(
+        "class Anchor {\n    set mu(...chunks: string[]) {}\n}\n",
+        &["TS1053@26"],
+    );
+}
+
+#[test]
+fn class_setter_parameter_initializer_still_reports_ts1052() {
+    assert_sites(
+        "class Beacon {\n    set nu(level: number = 3) {}\n}\n",
+        &["TS1052@23"],
+    );
+}
+
+#[test]
+fn static_class_setter_rest_parameter_still_reports_ts1053() {
+    assert_sites(
+        "class Compass {\n    static set xi(...marks: boolean[]) {}\n}\n",
+        &["TS1053@34"],
+    );
+}
+
+#[test]
+fn ambient_class_setter_rest_parameter_still_reports_ts1053() {
+    assert_sites(
+        "declare class Derrick {\n    set omicron(...rods: string[]);\n}\n",
+        &["TS1053@40"],
+    );
+}
+
+#[test]
+fn class_legal_setter_stays_clean() {
+    assert_sites("class Ledger {\n    set pi(value: string) {}\n}\n", &[]);
+}
+
+// ---------------------------------------------------------------------------
+// The early-return chain, and why the two arms must stand down.
+//
+// `tsc`'s `checkGrammarAccessor` reports AT MOST ONE diagnostic per accessor —
+// it is a chain of early returns, in this order:
+//
+//     TS1094 (accessor has type parameters)
+//       -> TS1049 (value-parameter count is not exactly 1)
+//         -> TS1095 (setter has a return type annotation)
+//           -> TS1053 (rest parameter)
+//             -> TS1051 (optional parameter)
+//               -> TS1052 (parameter initializer)
+//
+// tsz splits that chain across two layers: TS1094/TS1049/TS1095/TS1051 are
+// emitted by the PARSER, TS1053/TS1052 by this checker. So the ordering cannot
+// be a local early return inside either one — the checker has to re-test the
+// earlier links' conditions before emitting, which is what
+// `check_setter_parameter_grammar` does.
+//
+// `check_source_strict` surfaces CHECKER diagnostics only; the parser's codes
+// are not in its output at all (see `check_source_with_parse_health`'s doc
+// comment). That makes it the exact instrument for this property and no other:
+// an empty result here means the checker's two arms correctly stood down and
+// left the parser's single diagnostic as the whole answer. A non-empty result
+// is tsz about to emit a second, duplicate grammar error that `tsc` never
+// reports. The `tsc` column below is the full oracle output for the same
+// source, recorded from `typescript@7.0.2`, and every row is a case where the
+// suppressed code is one of this file's own two.
+// ---------------------------------------------------------------------------
+
+/// `tsc`: `TS1095` alone. Without the row-3 guard tsz adds `TS1053` beside it.
+#[test]
+fn return_type_annotation_stands_down_the_rest_arm() {
+    assert_sites(
+        "class Kappa {\n    set aa(...v: string[]): void {}\n}\n",
+        &[],
+    );
+    assert_sites(
+        "interface IfaceA {\n    set cc(...v: string[]): void;\n}\n",
+        &[],
+    );
+}
+
+/// `tsc`: `TS1095` alone. Without the row-3 guard tsz adds `TS1052` beside it.
+#[test]
+fn return_type_annotation_stands_down_the_initializer_arm() {
+    assert_sites(
+        "class Mu {\n    set gg(v: string = \"z\"): void {}\n}\n",
+        &[],
+    );
+}
+
+/// KNOWN DIVERGENCE, pinned deliberately — the object-literal container cannot
+/// reach the row-3 guard, and the cause is upstream of this file.
+///
+/// `parse_object_set_accessor`
+/// (`tsz-parser/src/parser/state_expressions_literals/object_members.rs`) parses
+/// the return type and **throws it away** — `let _ = self.parse_return_type();`
+/// — then builds the node with `type_annotation: NodeIndex::NONE` hard-coded.
+/// So an object-literal setter's return annotation is invisible to every
+/// checker-side consumer, this guard included. That is the same hard-coded-empty
+/// defect #16276 fixed for interface and type-literal accessors, in the one
+/// container it did not cover.
+///
+/// The oracle reports `TS1095` alone for both rows. tsz reports `TS1095` from
+/// the parser plus the code below from the checker. The shape needs a setter
+/// that is *already* ill-formed (an explicit return type) to reach, so it is
+/// strictly narrower than the family this file fixes — but it is a real
+/// divergence and is pinned rather than left silent. Restoring the annotation
+/// in the parser makes both rows go to `&[]` with no change to this file's
+/// logic; when that lands, this test fails and should be folded into the two
+/// above.
+#[test]
+fn object_literal_return_type_annotation_is_invisible_to_the_guard() {
+    assert_sites(
+        "const objA = {\n    set bb(...v: string[]): void {},\n};\n",
+        &["TS1053@26"],
+    );
+    assert_sites(
+        "const objC = {\n    set hh(v: string = \"z\"): void {},\n};\n",
+        &["TS1052@23"],
+    );
+}
+
+/// `tsc`: `TS1049` alone. Without the row-2 guard tsz adds `TS1053` beside it.
+#[test]
+fn wrong_value_parameter_count_stands_down_the_rest_arm_in_every_container() {
+    assert_sites(
+        "class Lambda {\n    set dd(first: string, ...rest: string[]) {}\n}\n",
+        &[],
+    );
+    assert_sites(
+        "const objB = {\n    set ee(first: string, ...rest: string[]) {},\n};\n",
+        &[],
+    );
+    assert_sites(
+        "interface IfaceB {\n    set ff(first: string, ...rest: string[]);\n}\n",
+        &[],
+    );
+}
+
+/// `tsc`: `TS1094` alone.
+#[test]
+fn accessor_type_parameters_stand_down_the_rest_arm() {
+    assert_sites("class Rho {\n    set nn<T>(...v: string[]) {}\n}\n", &[]);
+}
+
+/// The row-2 count excludes a leading `this` parameter, so this is a
+/// ONE-value-parameter setter and the rest arm still fires. `tsc`:
+/// `TS1053` at the `...`, plus a `TS2784` this-parameter error that this
+/// harness does not carry. The counter-test to the three rows above: a guard
+/// that counted declared parameters rather than value parameters would return
+/// early here and report nothing.
+#[test]
+fn leading_this_parameter_does_not_count_toward_the_value_parameter_count() {
+    assert_sites(
+        "class Sigma {\n    set oo(this: Sigma, ...v: string[]) {}\n}\n",
+        &["TS1053@38"],
+    );
+    assert_sites(
+        "class Ups {\n    set qq(this: Ups, v: string = \"k\") {}\n}\n",
+        &["TS1052@20"],
+    );
+}


### PR DESCRIPTION
**Structural rule.** When a `set` accessor's parameter carries an initializer or is a rest parameter, `tsc` reports **TS1052** / **TS1053** from `checkGrammarAccessor` — and it reaches that check for a setter written *anywhere*, because the rule reads the accessor's own signature and never the container. tsz now does the same through the checker's accessor parameter-grammar layer, `check_setter_parameter_grammar` (`crates/tsz-checker/src/checkers/accessor_checker.rs`).

The wrong semantic operation was **parameter grammar**, not inference, lookup or display.

### The gap

`check_setter_parameter` had exactly one call site — `check_accessor_declaration_with_request` — which is itself reached only from the **class member** walk (`member_declaration_checks.rs`). The other three containers never touch that path:

| container | routes through | reported before |
| --- | --- | --- |
| class member | `check_accessor_declaration_with_request` | yes |
| object literal | `types/computation/object_literal/accessor_element.rs` | **no** |
| interface member | the type-member walk | **no** |
| type-literal member | the type-member walk | **no** |

So `const o = { set p(...v: string[]) {} }` was silently accepted, as were the interface and type-literal forms. The grammar half is now split out of `check_setter_parameter` and called from all three walks rather than re-derived per container. The `noImplicitAny` half (TS7006/TS7032) stays where it was — its suppression genuinely *does* depend on the container and on a paired getter, which is exactly why only the grammar half is shared.

### `checkGrammarAccessor` is a chain of early returns, and tsz splits it across two layers

`tsc` reports **at most one** diagnostic per accessor:

| # | condition | code | emitted by, in tsz |
| --- | --- | --- | --- |
| 1 | accessor has type parameters | TS1094 | parser |
| 2 | value-parameter count is not exactly 1 | TS1049 | parser |
| 3 | setter has a return type annotation | TS1095 | parser |
| 4 | parameter is a rest parameter | **TS1053** | **checker** |
| 5 | parameter is optional | TS1051 | parser |
| 6 | parameter has an initializer | **TS1052** | **checker** |

Because rows 1/2/3/5 are parser-emitted and rows 4/6 checker-emitted, the ordering **cannot** be a local early return inside either one. `check_setter_parameter_grammar` therefore re-tests the earlier links' conditions from the same structural facts the parser uses before it emits. Without that guard the fix would have shipped a new false positive: `set p(...v: T[]): void` draws TS1095 **and** TS1053 where `tsc` reports TS1095 alone. The guard also fixes that shape for the **class** container, where the divergence already existed.

Row 2 counts *value* parameters, which excludes a leading `this` parameter (`tsc`'s `getSetAccessorValueParameter`): `set p(this: C, ...v: T[])` is a one-value-parameter setter and still reaches row 4. `leading_this_parameter_does_not_count_toward_the_value_parameter_count` is the counter-test — a guard that counted *declared* parameters returns early there and reports nothing.

No identifier, alias, property or file-name string drives any decision, and no predicate reads rendered type or printer output. The only inputs are a parameter's `dot_dot_dot_token` / `question_token` / `initializer`, the accessor's `type_parameters` / `type_annotation`, and the value-parameter count.

### Known divergence, pinned rather than left silent

`object_literal_return_type_annotation_is_invisible_to_the_guard` pins a row where tsz still diverges. `parse_object_set_accessor` (`state_expressions_literals/object_members.rs`) parses the return type and **throws it away** — `let _ = self.parse_return_type();` — then builds the node with `type_annotation: NodeIndex::NONE` hard-coded. An object-literal setter's return annotation is therefore invisible to every checker-side consumer, this guard included, so that one container cannot reach row 3.

This is the same hard-coded-empty defect #16276 fixed for interface and type-literal accessors, in the container it did not cover. Filed separately rather than fixed here: restoring the annotation changes the AST shape for downstream consumers, which is precisely the blast radius #16276 needed the full corpus gate to clear. Reaching the shape needs a setter that is *already* ill-formed, so it is strictly narrower than the family this PR fixes. When the parser fix lands, that test fails and folds into the two rows above it with no change to this PR's logic.

### Adjacent-case matrix

Every row was recorded from the pinned `typescript@7.0.2` (`--noEmit --strict --lib es2022 --target es2022`), not derived from the rule. Anchors are pinned as 0-based offsets because the blame *site* is half of this family — TS1052 lands on the accessor's **name**, TS1053 on the **`...` token**. Binder names are distinct in every row so nothing can key on an identifier string.

**Newly reporting** — object literal (rest, initializer, both arms at once, nested literal, literal returned from a class method), interface (rest), type literal (rest), generic type literal (rest).

**Regression rows, class container** — rest, initializer, `static` setter, ambient `declare class` setter, generic class. These must stay byte-identical through the extraction.

**Negatives, legal single required parameter** — one per container (object literal, interface, type literal, class). Same container and same binder shape as their positives, so a check that fired on the *presence* of a `set` accessor rather than on the parameter fails all four.

**Early-return chain** — return type vs. the rest arm and vs. the initializer arm; wrong value-parameter count vs. the rest arm, in all three containers that can reach it; accessor type parameters vs. the rest arm; and the two leading-`this` counter-tests.

## Goal
Goal: hold

## Verification

- `cargo test -p tsz-checker --test setter_parameter_grammar_container_coverage_tests` — **23 passed, 0 failed**, all 23 new.
- **Non-vacuity, measured not asserted.** With the tests in and only the two new routing call sites ablated (the extraction and the guard left intact), exactly **8 failed / 9 passed**: the 8 newly-reporting rows fail, and all 4 class regression rows plus all 5 negatives pass. It fails for the real reason.
- **Adjacent suites, before/after both green:** all 12 accessor-bearing integration targets in `tsz-checker` (`accessor_assignment_read_surface`, `accessor_getter_contextual_return_from_setter`, `accessor_pair_override_ts2416`, `noimplicitany_type_member_accessor`, `object_literal_accessor_pair_parameter_type`, `object_literal_set_only_accessor_type`, `override_accessor_property_kind_mismatch_ts2416`, `ts1119_object_literal_property_accessor`, `ts1207_decorated_accessor`, `ts1240_accessor_decorator`, `ts2340_super_accessor`, `ts2344_accessor_constraint`) — **130 passed, 0 failed**. `cargo test -p tsz-checker --lib -- accessor setter` — **84 passed, 0 failed**.
- `cargo fmt --all` clean; `cargo clippy -p tsz-checker --lib --tests --all-features -- -D warnings` clean; `scripts/arch/arch_guard.py` passed. The `pre-commit` hook's own clippy + architecture legs passed on this tree.

**Two-sided corpus gate: OWED, not run to completion here — do not land on the targeted evidence alone.** `scripts/conformance/compare-to-parent.sh origin/main` was started in this container at 09:04Z with the corpus already fetched, but the seat is cold (no `.target`) and that script does two full `dist-fast` builds; per the board's standing note a cold cloud seat has not finished it inside a session. **This change makes previously-silent diagnostics start firing in three containers, which is exactly the blast radius a targeted matrix cannot see** — the corpus has fixtures with object-literal and interface setters, and any that pair one with a rest parameter or an initializer will move. Note also that the new guard makes tsz emit *strictly fewer* diagnostics in the row-1/2/3/5 shapes, including for classes, so movement can go in both directions.

Concrete handoff for whoever drains this:

```
git fetch origin claude/magical-brown-q96hz7 && git checkout c481473 \
  && scripts/conformance/compare-to-parent.sh origin/main
```

Post the two-sided number here; if newly-failing is 0, queue with `--match-head-commit c481473`. If it is non-zero, the suspects are corpus rows pairing a non-class setter with a rest parameter or an initializer (newly failing), and rows where an accessor grammar error was previously double-reported (newly passing).

Emit is not exercised — this is diagnostics only and the emitter consumes neither code — but that is an argument, not a measurement.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Basanite

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tx3xxvYQHkRUpShqmzaErF)_