### PR TITLE
fix(cli): the extends/implements heritage-clause grammar family is all-in or all-out of the parse-diagnostic filter

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -444,7 +444,10 @@ const fn is_parser_grammar_code(code: u32) -> bool {
         | 1163 // A 'yield' expression is only allowed in a generator body
         | 1171 // A comma expression is not allowed in a computed property name
         | 1172 // extends clause already seen
+        | 1173 // extends clause must precede implements clause
         | 1174 // Classes can only extend a single class
+        | 1175 // implements clause already seen
+        | 1176 // Interface declaration cannot have an implements clause
         | 1182 // A destructuring declaration must have an initializer
         | 1184 // Modifiers cannot appear here
         | 1191 // An import declaration cannot have modifiers
@@ -1467,3 +1470,7 @@ pub(super) const fn is_plain_js_allowed_code(code: u32) -> bool {
 #[cfg(test)]
 #[path = "check_utils/tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "check_utils/heritage_clause_tests.rs"]
+mod heritage_clause_tests;

--- a/crates/tsz-cli/src/driver/check_utils/heritage_clause_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/heritage_clause_tests.rs
@@ -1,0 +1,237 @@
+//! Unit tests for the class/interface heritage-clause slice of
+//! `is_parser_grammar_code` (#16279's general shape). Split into its own file
+//! rather than growing `tests.rs` past the 2000-line limit (§19).
+//!
+//! tsc's `checkGrammarClassDeclarationHeritageClauses` /
+//! `checkGrammarInterfaceDeclaration` report TS1172/1173/1174/1175/1176, all
+//! parser-emitted in tsz (`parse_heritage_clause_extends` /
+//! `parse_heritage_clause_implements` in
+//! `state_statements_class_declarations.rs`, and the interface path in
+//! `state_declarations.rs`). Before this fix, `is_parser_grammar_code` listed
+//! only TS1172/1174 — TS1173 ('extends' must precede 'implements'), TS1175
+//! ('implements' already seen) and TS1176 (interface cannot have
+//! 'implements') were unlisted, so each counted as a "real" parse error and
+//! silently deleted the listed siblings (TS1172/1174) from the same file,
+//! while itself never being suppressed alongside an unrelated real syntax
+//! error the way tsc suppresses it.
+
+use super::*;
+
+#[test]
+fn filtered_parse_diagnostics_suppresses_ts1173_when_real_parse_error_present() {
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 20,
+            length: 6,
+            message: "'extends' clause must precede 'implements' clause.".to_string(),
+            code: 1173,
+        },
+        ParseDiagnostic {
+            start: 60,
+            length: 1,
+            message: "Type expected.".to_string(),
+            code: 1110,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&1173),
+        "TS1173 should be suppressed when a real parse error (TS1110) is present, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1110),
+        "TS1110 (real parse error) should survive, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_suppresses_ts1175_when_real_parse_error_present() {
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 20,
+            length: 6,
+            message: "'implements' clause already seen.".to_string(),
+            code: 1175,
+        },
+        ParseDiagnostic {
+            start: 60,
+            length: 1,
+            message: "Type expected.".to_string(),
+            code: 1110,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&1175),
+        "TS1175 should be suppressed when a real parse error (TS1110) is present, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1110),
+        "TS1110 (real parse error) should survive, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_suppresses_ts1176_when_real_parse_error_present() {
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 20,
+            length: 6,
+            message: "Interface declaration cannot have an 'implements' clause.".to_string(),
+            code: 1176,
+        },
+        ParseDiagnostic {
+            start: 60,
+            length: 1,
+            message: "Type expected.".to_string(),
+            code: 1110,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&1176),
+        "TS1176 should be suppressed when a real parse error (TS1110) is present, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1110),
+        "TS1110 (real parse error) should survive, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_keeps_ts1173_ts1175_ts1176_when_alone() {
+    use tsz::parser::ParseDiagnostic;
+
+    for (code, message) in [
+        (1173, "'extends' clause must precede 'implements' clause."),
+        (1175, "'implements' clause already seen."),
+        (
+            1176,
+            "Interface declaration cannot have an 'implements' clause.",
+        ),
+    ] {
+        let diagnostics = vec![ParseDiagnostic {
+            start: 20,
+            length: 1,
+            message: message.to_string(),
+            code,
+        }];
+
+        let filtered = filtered_parse_diagnostics(&diagnostics, false);
+        let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+        assert!(
+            codes.contains(&code),
+            "TS{code} should be kept when it is the only diagnostic, got: {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn filtered_parse_diagnostics_ts1173_does_not_self_suppress_listed_sibling() {
+    use tsz::parser::ParseDiagnostic;
+
+    // Before the fix, TS1173 was unlisted in `is_parser_grammar_code`, so it
+    // counted as a "real" non-grammar parse error under
+    // `has_non_grammar_parse_error` and silently deleted every *listed*
+    // sibling in the same file — here, the already-listed TS1172 (duplicate
+    // `extends` clause).
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 20,
+            length: 8,
+            message: "'extends' clause already seen.".to_string(),
+            code: 1172,
+        },
+        ParseDiagnostic {
+            start: 80,
+            length: 6,
+            message: "'extends' clause must precede 'implements' clause.".to_string(),
+            code: 1173,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&1172),
+        "TS1172 must not be self-suppressed by unlisted TS1173, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1173),
+        "TS1173 should survive when it is the only non-grammar-looking diagnostic, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_ts1175_does_not_self_suppress_listed_sibling() {
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 20,
+            length: 8,
+            message: "'extends' clause already seen.".to_string(),
+            code: 1172,
+        },
+        ParseDiagnostic {
+            start: 80,
+            length: 6,
+            message: "'implements' clause already seen.".to_string(),
+            code: 1175,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&1172),
+        "TS1172 must not be self-suppressed by unlisted TS1175, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1175),
+        "TS1175 should survive when it is the only non-grammar-looking diagnostic, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_ts1176_does_not_self_suppress_listed_sibling() {
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 20,
+            length: 8,
+            message: "'extends' clause already seen.".to_string(),
+            code: 1172,
+        },
+        ParseDiagnostic {
+            start: 80,
+            length: 6,
+            message: "Interface declaration cannot have an 'implements' clause.".to_string(),
+            code: 1176,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&1172),
+        "TS1172 must not be self-suppressed by unlisted TS1176, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1176),
+        "TS1176 should survive when it is the only non-grammar-looking diagnostic, got: {codes:?}"
+    );
+}


### PR DESCRIPTION
Part of #16279 (third confirmed slice of the audit; issue stays open for the rest of the ~45-entry list).

**Structural rule.** When a file's parse diagnostics contain a member of tsc's `checkGrammarClassDeclarationHeritageClauses` / `checkGrammarInterfaceDeclaration` family, tsc reports every member of that family unless `hasParseDiagnostics(sourceFile)` holds, in which case it reports none of them; tsz does the same through `is_parser_grammar_code` in the CLI's parse-diagnostic filter (`crates/tsz-cli/src/driver/check_utils.rs`).

**What was wrong.** `is_parser_grammar_code` listed TS1172/1174 but not TS1173/1175/1176 — all five are siblings emitted from the same parser functions, `parse_heritage_clause_extends` / `parse_heritage_clause_implements` (`crates/tsz-parser/src/parser/state_statements_class_declarations.rs`) and the interface path in `state_declarations.rs`, the tsz counterparts of tsc's checker-side heritage-clause grammar checks. `has_non_grammar_parse_error` is computed as the *complement* of the list, so membership is load-bearing in both directions:

- a **listed** code is suppressed when a real parse error exists (intended), and
- an **unlisted** parser-emitted grammar code counts as a real parse error and suppresses every listed sibling **file-wide** (not intended) — and is itself never suppressed when it should be.

This is the third confirmed instance of #16279's general shape, after #16278 (accessor family) and #16281 (index-signature family).

## Goal
Goal: hold

## Verification

**Oracle matrix — pinned `typescript@7.0.2`, `--noEmit --strict --pretty false --lib es2022 --target es2022`, compared end-to-end against the built `tsz` binary.** Both directions:

| fixture | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| TS1173/1174/1175/1176 alone (controls) | each fires alone | unchanged ✅ | unchanged ✅ |
| TS1173 + unrelated real syntax error (`let x: = 1;`, TS1110) | `TS1110` only | `TS1173 TS1110` ❌ (over-reports) | `TS1110` only ✅ |
| TS1172 (listed) + TS1173 (unlisted), no real syntax error | `TS1172 TS1173` | `TS1173` only — **TS1172 silently dropped** ❌ | `TS1172 TS1173` ✅ |
| TS1172 (listed) + TS1175 (unlisted), no real syntax error | `TS1172 TS1175` | `TS1175` only — **TS1172 silently dropped** ❌ | `TS1172 TS1175` ✅ |
| TS1172 (listed) + TS1176 (unlisted), no real syntax error | `TS1172 TS1176` | `TS1176` only — **TS1172 silently dropped** ❌ | `TS1172 TS1176` ✅ |

The self-suppression direction (rows 3-5) is the same bug shape as #16278/#16281: an unlisted parser-emitted grammar code counted as a "real" non-grammar parse error and silently deleted the already-listed TS1172 from the same file. The over-reporting direction (row 2) is new to this family: TS1173/1175/1176 being unlisted also meant they were *never* suppressed alongside an unrelated real syntax error, where tsc does suppress them.

**Adjacent-case unit matrix** — 7 new tests in a new file, `crates/tsz-cli/src/driver/check_utils/heritage_clause_tests.rs` (kept separate from `tests.rs`, which is already at the 2000-line ceiling on `main` after #16281 — pre-existing, not touched here): suppression of each of TS1173/1175/1176 alongside a real parse error, all three kept when alone, and the file-wide self-suppression-of-TS1172 case in both directions for each of the three codes.

**Non-vacuity proven.** With the tests in place and only the three new list entries reverted: `cargo test -p tsz-cli --lib filtered_parse_diagnostics` → **19 passed, 6 failed** — exactly the 3 new suppression tests plus the 3 new self-suppression tests; every other test (including the "kept when alone" controls and the #16278/#16281 accessor/index-signature suites) still passes. With the fix: **25 passed, 0 failed**.

**Commands run:** `cargo fmt --all` clean · `cargo clippy -p tsz-cli --lib --tests -- -D warnings` clean · `python3 scripts/arch/arch_guard.py` → "Architecture guardrails passed."

**Corpus gate:** `compare-to-parent.sh origin/main` run to completion — see follow-up comment for the number before this is queued.

**Remaining audit scope, for whoever continues #16279.** Accessor (#16278), index-signature (#16281), modifier cluster (confirmed fully listed, per #16281), and heritage-clause (this PR) are done. The rest of the ~45-entry list is still unaudited.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ev72JCNnUXHN5MPtsfDbRh)_