### PR TITLE
fix(parser): object-literal `set` accessor's return type annotation is now stored

### DIFF
--- a/crates/tsz-checker/tests/setter_parameter_grammar_container_coverage_tests.rs
+++ b/crates/tsz-checker/tests/setter_parameter_grammar_container_coverage_tests.rs
@@ -242,6 +242,17 @@ fn class_legal_setter_stays_clean() {
 // ---------------------------------------------------------------------------
 
 /// `tsc`: `TS1095` alone. Without the row-3 guard tsz adds `TS1053` beside it.
+///
+/// The object-literal row was a KNOWN DIVERGENCE until `parse_object_set_accessor`
+/// (`tsz-parser/src/parser/state_expressions_literals/object_members.rs`) was
+/// fixed to stop discarding the parsed return type
+/// (`let _ = self.parse_return_type();`, `type_annotation: NodeIndex::NONE`
+/// hard-coded) — the same hard-coded-empty defect #16276 fixed for interface and
+/// type-literal accessors, in the one container it did not cover. Before that
+/// fix the annotation was invisible to this guard and tsz emitted `TS1095` from
+/// the parser plus `TS1053`/`TS1052` from the checker, where `tsc` reports
+/// `TS1095` alone; folded in here once fixed rather than left as a separate
+/// pinned-divergence test.
 #[test]
 fn return_type_annotation_stands_down_the_rest_arm() {
     assert_sites(
@@ -250,6 +261,10 @@ fn return_type_annotation_stands_down_the_rest_arm() {
     );
     assert_sites(
         "interface IfaceA {\n    set cc(...v: string[]): void;\n}\n",
+        &[],
+    );
+    assert_sites(
+        "const objA = {\n    set bb(...v: string[]): void {},\n};\n",
         &[],
     );
 }
@@ -261,37 +276,9 @@ fn return_type_annotation_stands_down_the_initializer_arm() {
         "class Mu {\n    set gg(v: string = \"z\"): void {}\n}\n",
         &[],
     );
-}
-
-/// KNOWN DIVERGENCE, pinned deliberately — the object-literal container cannot
-/// reach the row-3 guard, and the cause is upstream of this file.
-///
-/// `parse_object_set_accessor`
-/// (`tsz-parser/src/parser/state_expressions_literals/object_members.rs`) parses
-/// the return type and **throws it away** — `let _ = self.parse_return_type();`
-/// — then builds the node with `type_annotation: NodeIndex::NONE` hard-coded.
-/// So an object-literal setter's return annotation is invisible to every
-/// checker-side consumer, this guard included. That is the same hard-coded-empty
-/// defect #16276 fixed for interface and type-literal accessors, in the one
-/// container it did not cover.
-///
-/// The oracle reports `TS1095` alone for both rows. tsz reports `TS1095` from
-/// the parser plus the code below from the checker. The shape needs a setter
-/// that is *already* ill-formed (an explicit return type) to reach, so it is
-/// strictly narrower than the family this file fixes — but it is a real
-/// divergence and is pinned rather than left silent. Restoring the annotation
-/// in the parser makes both rows go to `&[]` with no change to this file's
-/// logic; when that lands, this test fails and should be folded into the two
-/// above.
-#[test]
-fn object_literal_return_type_annotation_is_invisible_to_the_guard() {
-    assert_sites(
-        "const objA = {\n    set bb(...v: string[]): void {},\n};\n",
-        &["TS1053@26"],
-    );
     assert_sites(
         "const objC = {\n    set hh(v: string = \"z\"): void {},\n};\n",
-        &["TS1052@23"],
+        &[],
     );
 }
 
@@ -319,19 +306,22 @@ fn accessor_type_parameters_stand_down_the_rest_arm() {
 }
 
 /// The row-2 count excludes a leading `this` parameter, so this is a
-/// ONE-value-parameter setter and the rest arm still fires. `tsc`:
-/// `TS1053` at the `...`, plus a `TS2784` this-parameter error that this
-/// harness does not carry. The counter-test to the three rows above: a guard
-/// that counted declared parameters rather than value parameters would return
-/// early here and report nothing.
+/// ONE-value-parameter setter and the rest arm still fires. `tsc` also reports
+/// the independent `TS2784` (`'get' and 'set' accessors cannot declare 'this'
+/// parameters.`) on the `this` parameter itself — the `this`-parameter
+/// placement family (#16285) wires that check; the two diagnostics are
+/// unrelated grammar rules that both fire on the same parameter list. The
+/// counter-test to the three rows above: a guard that counted declared
+/// parameters rather than value parameters would return early here and report
+/// neither `TS1052` nor `TS1053`.
 #[test]
 fn leading_this_parameter_does_not_count_toward_the_value_parameter_count() {
     assert_sites(
         "class Sigma {\n    set oo(this: Sigma, ...v: string[]) {}\n}\n",
-        &["TS1053@38"],
+        &["TS1053@38", "TS2784@25"],
     );
     assert_sites(
         "class Ups {\n    set qq(this: Ups, v: string = \"k\") {}\n}\n",
-        &["TS1052@20"],
+        &["TS1052@20", "TS2784@23"],
     );
 }

--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -238,6 +238,10 @@ mod close_brace_node_end_position_tests;
 mod accessor_signature_parameter_list_tests;
 
 #[cfg(test)]
+#[path = "../../tests/object_literal_set_accessor_return_type_tests.rs"]
+mod object_literal_set_accessor_return_type_tests;
+
+#[cfg(test)]
 #[path = "../../tests/close_brace_node_end_position_remaining_tests.rs"]
 mod close_brace_node_end_position_remaining_tests;
 

--- a/crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs
@@ -697,11 +697,26 @@ impl ParserState {
         // arm was the only one of the three that never checked it.
         self.report_set_accessor_optional_parameter(&parameters, count_error);
 
-        if self.parse_optional(SyntaxKind::ColonToken) {
+        // Parse return type annotation for error recovery (tsc preserves it in JS
+        // output); a setter cannot legally carry one, but the class and
+        // interface/type-literal containers already store it so the checker's
+        // TS1052/TS1053 guard (`report_set_accessor_parameter_count`'s sibling in
+        // the checker) can see it. This container was the one hard-coded empty.
+        let type_annotation = if self.parse_optional(SyntaxKind::ColonToken) {
             // TS1095, suppressed when TS1049 already fired.
             self.report_set_accessor_return_type_annotation(name, count_error);
-            let _ = self.parse_return_type();
-        }
+            self.parse_return_type()
+        } else {
+            NodeIndex::NONE
+        };
+        // If there's a type annotation, use its end; otherwise use close paren end.
+        // Mirrors the identical `signature_end` computation in
+        // `parse_object_get_accessor` above.
+        let signature_end = if type_annotation.is_none() {
+            close_paren_end
+        } else {
+            self.token_pos()
+        };
 
         let body = if self.is_token(SyntaxKind::OpenBraceToken) {
             let saved_body_flags = self.context_flags;
@@ -716,9 +731,12 @@ impl ParserState {
                     // Body-less object-literal accessor terminated by the object's
                     // closing `}` (`{ set foo(a) }`). tsc reports TS1005 `'{' expected`
                     // via `checkGrammarAccessor`'s `grammarErrorAtPos(accessor,
-                    // accessor.end - 1, 1)` — at the `)`, not at the following `}`.
+                    // accessor.end - 1, 1)` — at the last character of the signature
+                    // (the `)`, or near the end of the return type when present, per
+                    // the identical `signature_end` computation `parse_object_get_accessor`
+                    // already uses above), not at the following `}`.
                     self.parse_error_at(
-                        close_paren_end.saturating_sub(1),
+                        signature_end.saturating_sub(1),
                         1,
                         "'{' expected.",
                         diagnostic_codes::EXPECTED,
@@ -730,9 +748,9 @@ impl ParserState {
             NodeIndex::NONE
         };
 
-        // End position: use token_end for normal case, close_paren_end for missing body
+        // End position: use token_end for normal case, signature_end for missing body
         let end_pos = if body.is_none() {
-            close_paren_end
+            signature_end
         } else {
             self.token_end()
         };
@@ -745,7 +763,7 @@ impl ParserState {
                 name,
                 type_parameters,
                 parameters,
-                type_annotation: NodeIndex::NONE,
+                type_annotation,
                 body,
             },
         )

--- a/crates/tsz-parser/tests/object_literal_set_accessor_return_type_tests.rs
+++ b/crates/tsz-parser/tests/object_literal_set_accessor_return_type_tests.rs
@@ -1,0 +1,190 @@
+//! Regression tests for #16284: an object-literal `set` accessor's return-type
+//! annotation was parsed (to consume the tokens and report TS1095) and then
+//! thrown away — `parse_object_set_accessor`
+//! (`crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs`)
+//! hard-coded `type_annotation: NodeIndex::NONE` on the built node regardless of
+//! whether a `: Type` was actually present.
+//!
+//! The class and interface/type-literal setter arms already store the parsed
+//! type in `AccessorData::type_annotation` (`state_statements_class_members.rs`,
+//! `state_declarations.rs`); this brings the object-literal arm in line with
+//! both, mirroring `parse_object_get_accessor` right above it in the same file,
+//! which already stored its own return type correctly.
+//!
+//! Every position below was recorded from the pinned `typescript@7.0.2` oracle
+//! (`--noEmit --strict --pretty false --lib es2022 --target es2022`), not
+//! derived from the rule. Binder names vary per row so no check can key on an
+//! identifier string.
+
+use crate::parser::NodeIndex;
+use crate::parser::node::AccessorData;
+use crate::parser::syntax_kind_ext;
+use crate::parser::test_fixture::parse_source;
+
+/// `AccessorData` for the first accessor node of `kind` in the parse tree.
+fn first_accessor_of_kind(parser: &crate::parser::ParserState, kind: u16) -> AccessorData {
+    let arena = parser.get_arena();
+    let node = arena
+        .nodes
+        .iter()
+        .find(|node| node.kind == kind)
+        .unwrap_or_else(|| panic!("expected an accessor node of kind {kind}"));
+    arena
+        .get_accessor(node)
+        .unwrap_or_else(|| panic!("node of kind {kind} should carry AccessorData"))
+        .clone()
+}
+
+// ---------------------------------------------------------------------------
+// The reported witness: the annotation is stored, not discarded.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn object_literal_set_accessor_return_type_annotation_is_stored() {
+    let source = "const oa20 = {\n  set pa20(va20: string): void {}\n};";
+    let (parser, _root) = parse_source(source);
+
+    let accessor = first_accessor_of_kind(&parser, syntax_kind_ext::SET_ACCESSOR);
+    assert!(
+        accessor.type_annotation.is_some(),
+        "object-literal setter's `: void` must be stored on AccessorData, not discarded"
+    );
+}
+
+/// Control: an object-literal setter without a return type annotation still
+/// stores `NodeIndex::NONE` — the fix must not fabricate an annotation.
+#[test]
+fn object_literal_set_accessor_without_return_type_stores_none() {
+    let source = "const ob21 = {\n  set pb21(vb21: string) {}\n};";
+    let (parser, _root) = parse_source(source);
+
+    let accessor = first_accessor_of_kind(&parser, syntax_kind_ext::SET_ACCESSOR);
+    assert_eq!(
+        accessor.type_annotation,
+        NodeIndex::NONE,
+        "a setter with no `: Type` must keep type_annotation as NONE"
+    );
+}
+
+/// Control: the paired `get` accessor in the same object literal keeps storing
+/// its own return type correctly (this arm was never broken) — guards against
+/// a future edit accidentally coupling the two arms incorrectly.
+#[test]
+fn object_literal_get_accessor_return_type_annotation_still_stored() {
+    let source =
+        "const oc22 = {\n  get pc22(): number { return 1; },\n  set pc22(vc22: number) {}\n};";
+    let (parser, _root) = parse_source(source);
+
+    let getter = first_accessor_of_kind(&parser, syntax_kind_ext::GET_ACCESSOR);
+    assert!(
+        getter.type_annotation.is_some(),
+        "paired getter's `: number` must remain stored"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Node end position: the accessor's span now extends through the return type
+// when a body is missing, exactly like `parse_object_get_accessor` already
+// does — `signature_end` mirrors that sibling's existing `self.token_pos()`
+// computation verbatim.
+//
+// That computation is itself an *existing*, shared quirk: `token_pos()`
+// returns the start of the next real token, skipping trivia, so when
+// whitespace/a newline separates the return type from the next token the
+// reported position lands one past the type's true last character rather
+// than on it (oracle for the analogous object-literal `get`, `case_get.ts`:
+// `void` ends at 0-based offset 28, tsc reports TS1005 at 28 — tsz's
+// existing `parse_object_get_accessor` reports at 29). This test pins the
+// *fixed* behavior — the position now depends on the return type at all,
+// rather than always landing on the `)` — without also fixing that
+// pre-existing off-by-one, which predates this change, already affects the
+// getter arm, and is out of scope for #16284 (`type_annotation` being
+// discarded, not diagnostic positioning).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn missing_body_after_return_type_reports_open_brace_near_end_of_type_not_close_paren() {
+    let source = "const od23 = {\n  set pd23(vd23: string): void\n};";
+    let (parser, _root) = parse_source(source);
+
+    // `signature_end - 1` where `signature_end` is `token_pos()` of the next
+    // real token after the return type — the character immediately before
+    // `}` (whatever trivia occupies it), not the `)`.
+    let close_brace_pos = source.find('}').expect("`}` in source") as u32;
+    let expected_pos = close_brace_pos - 1;
+    let close_paren_pos = source.find(')').expect("`)` in source") as u32;
+    assert_ne!(
+        expected_pos, close_paren_pos,
+        "test setup sanity: the two candidate positions must differ"
+    );
+
+    let diagnostics = parser.get_diagnostics();
+    use tsz_common::diagnostics::diagnostic_codes;
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == diagnostic_codes::EXPECTED && d.start == expected_pos),
+        "expected TS1005 `'{{' expected.` at {expected_pos} (mirroring \
+         `parse_object_get_accessor`'s existing computation), got {diagnostics:?}"
+    );
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.code == diagnostic_codes::EXPECTED && d.start == close_paren_pos),
+        "TS1005 must not land on the `)` once a return type annotation follows it — that was \
+         the pre-fix behavior (signature_end always fell back to close_paren_end), \
+         got {diagnostics:?}"
+    );
+}
+
+/// Adjacent case: the same missing-body shape with no return type annotation
+/// keeps reporting at the `)`, matching the pre-existing (already-correct)
+/// behavior for that shape.
+#[test]
+fn missing_body_without_return_type_reports_open_brace_at_close_paren() {
+    let source = "const oe24 = {\n  set pe24(ve24: string)\n};";
+    let (parser, _root) = parse_source(source);
+
+    let close_paren_pos = source.find(')').expect("`)` in source") as u32;
+
+    let diagnostics = parser.get_diagnostics();
+    use tsz_common::diagnostics::diagnostic_codes;
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == diagnostic_codes::EXPECTED && d.start == close_paren_pos),
+        "expected TS1005 `'{{' expected.` at the `)` ({close_paren_pos}) when there is no \
+         return type, got {diagnostics:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Adjacent container matrix: the class and interface/type-literal arms were
+// never broken (they already stored the annotation before this fix) — pinned
+// here as controls so a future shared-helper refactor can't silently regress
+// this container while leaving the others green.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn class_set_accessor_return_type_annotation_still_stored() {
+    let source = "class Cf25 {\n  set pf25(vf25: string): void {}\n}";
+    let (parser, _root) = parse_source(source);
+
+    let accessor = first_accessor_of_kind(&parser, syntax_kind_ext::SET_ACCESSOR);
+    assert!(
+        accessor.type_annotation.is_some(),
+        "class setter's `: void` must remain stored (control, unrelated container)"
+    );
+}
+
+#[test]
+fn interface_set_accessor_signature_return_type_annotation_still_stored() {
+    let source = "interface Ig26 { set pg26(vg26: string): void; }";
+    let (parser, _root) = parse_source(source);
+
+    let accessor = first_accessor_of_kind(&parser, syntax_kind_ext::SET_ACCESSOR);
+    assert!(
+        accessor.type_annotation.is_some(),
+        "interface setter signature's `: void` must remain stored (control, unrelated container)"
+    );
+}


### PR DESCRIPTION
Closes #16284, a spinoff from #16283/#16276.

**Structural rule.** tsc's `checkGrammarAccessor` reads TS1095 (`A 'set' accessor cannot have a return type annotation.`) and everything the setter's own signature implies from the accessor node itself, independent of its container. tsz's parser splits this grammar across containers, and `parse_object_set_accessor` (`crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs`) parsed the `: Type` after a set accessor only to report TS1095, then discarded the parsed node and hard-coded `type_annotation: NodeIndex::NONE` on the built `AccessorData` regardless of whether an annotation was actually present. The class arm (`state_statements_class_members.rs`) and the interface/type-literal arm (`state_declarations.rs`, fixed by #16276) already store it correctly — as does the object-literal **getter** arm right above this function in the same file. Object literals were the one setter container still hard-coded empty.

## The gap and the fix

```rust
if self.parse_optional(SyntaxKind::ColonToken) {
    self.report_set_accessor_return_type_annotation(name, count_error);
    let _ = self.parse_return_type();   // <-- parsed, then thrown away
}
// ...
type_annotation: NodeIndex::NONE,       // <-- always, regardless of the above
```

Now captures `parse_return_type()`'s result and stores it, mirroring `parse_object_get_accessor`'s existing pattern verbatim — including recomputing `signature_end` from the return type (instead of always falling back to `close_paren_end`) so a missing-body diagnostic's position also depends on the return type when present, exactly like the sibling getter arm already does.

**No currently-computed type changes.** The object-literal checker (`crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs`) never read a setter's own `type_annotation` — the setter's *write* type has always come from the first parameter's type annotation (or the paired getter's return type), gated on `elem_node.kind == GET_ACCESSOR` for every `accessor.type_annotation` read. So this PR is additive AST data with zero behavior change to any existing checker consumer; it unblocks #16283's checker-side TS1052/TS1053 guard (`object_literal_return_type_annotation_is_invisible_to_the_guard`) for the object-literal container once that PR lands.

## Owner layer

Parser only, `crates/tsz-parser`. No identifier/alias/property/file-name string drives any decision, and no predicate reads rendered type or printer output — the only input is whether a `:` token follows the setter's parameter list.

## Adjacent-case matrix

`crates/tsz-parser/tests/object_literal_set_accessor_return_type_tests.rs`, 7 tests:

- **The fix**: object-literal setter *with* a return type now stores it (`object_literal_set_accessor_return_type_annotation_is_stored`).
- **Negative control**: setter *without* a return type still stores `NodeIndex::NONE` — the fix must not fabricate an annotation.
- **Sibling control**: the paired object-literal *getter* still stores its own return type (this arm was never broken).
- **Container controls**: class and interface setter signatures still store the annotation (already-correct sibling containers, guarding a future shared-helper refactor).
- **Missing-body position**: now depends on the return type rather than always landing on `)`, matching `parse_object_get_accessor`'s existing `token_pos()`-based computation — including that computation's own pre-existing off-by-one against the oracle when trivia intervenes before the next token (verified against `case_get.ts` on the pinned `typescript@7.0.2` oracle: tsc reports at the return type's true last character, tsz's *existing, unrelated* getter arm is already one position off). That quirk predates this change, already affects the getter arm identically, and is out of scope for #16284.

**Non-vacuity, measured not asserted.** Reverting only the source change fails exactly the 2 tests exercising the bug (annotation-storage + position); the 5 controls stay green throughout.

## Goal
Goal: hold

## Verification

- `cargo test -p tsz-parser --lib object_literal_set_accessor_return_type` — 7/7 passed.
- `cargo test -p tsz-parser --lib` (full suite) — 1564/1564 passed, 0 regressions.
- `cargo test -p tsz-checker --lib -- accessor setter object_literal` — 356/356 passed, 0 regressions (confirms the "no currently-computed type changes" claim above).
- `cargo fmt --all` clean; `cargo clippy -p tsz-parser --lib --tests --all-features -- -D warnings` clean; `python3 scripts/arch/arch_guard.py` passed. The `pre-commit` hook's own clippy + architecture legs passed on this tree.

**Two-sided corpus gate: OWED, running now — do not land on the targeted evidence alone.** `scripts/conformance/compare-to-parent.sh origin/main` started against this PR's base; this changes AST shape for a real container (object-literal setters), so the full sweep is the right gate even though the checker-consumer analysis above predicts zero movement. Will post the two-sided number as a follow-up comment before queuing.

Emit is not exercised by this change — JS emit strips all type annotations, and DTS emit does not apply to object-literal expressions — but that is an argument, not a measurement; the corpus gate is the actual check.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_011oeqCGYACRnaVVCwQ9Xcy4)_