### PR TITLE
chore(readme): refresh conformance stats to 11,475

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ test suite against it.
 
 <!-- CONFORMANCE_START -->
 ```
-Progress: [███████████████████░] 95.2% (11,460/12,043 runnable tests)
+Progress: [███████████████████░] 95.3% (11,475/12,043 runnable tests)
 Candidates: 12,585 (12,043 runnable, 507 unsupported, 35 skipped)
 ```
 <!-- CONFORMANCE_END -->


### PR DESCRIPTION
Goal: hold

Follows #16289 (which published `11,460`). Re-measured at the resulting
post-merge head `b52c953dae` rather than reusing my earlier number from a
different tree, and refreshed from that snapshot.

Single line changes: `95.2% (11,460/12,043)` -> `95.3% (11,475/12,043)`.

Generated via `scripts/refresh-readme.py --write --skip-performance`; no
hand-edited numbers. The published value was read back out of the commit
(`git show HEAD:README.md`) before the conformance snapshot tree was discarded,
to confirm the committed figure is the measured one.

Emit metrics left untouched -- the script declined to rewrite them
(`preserving README emit metrics because scripts/emit/emit-detail.json is
behind the existing README emit block`). Fourslash metrics already accurate.

Performance chart skipped: #16289 regenerated it minutes ago, and the chart
generator is blocked on the artifact-lifetime defect in #16195.

## Verification

Measured locally at `b52c953dae`:

- conformance: `11475 / 12043` runnable (95.3%), 12585 candidates, 507
  unsupported, 35 skipped

Measured at `1c0e7320ba` (44 commits earlier, same day):

- conformance `11474 / 12043` (95.3%)
- emit JS `11562 / 11563`, emit DTS `1375 / 1390` -- both exactly at the parity
  floor, unchanged across the last 94 commits
- fourslash `6558 / 6562` baseline held, 0 watchdog kills. The 4 failures are
  the known set (`completionListFunctionExpression`,
  `importFixesWithPackageJsonInSideAnotherPackage`,
  `importNameCodeFix_importType`, `autoImportProvider_importsMap1`). Run was
  partial (6548/6562) under concurrent load, with 8 tests reporting "Test
  completed but took Xms" -- those passed, over the 15s wall clock.
- benchmark (load 11.68 -> 4.03): script score `tsz 94 vs tsgo 4`. Real gaps
  comlink `2.70 ± 0.02`, ts-toolbelt `2.49 ± 0.04`, vite-vanilla-ts-app
  `1.77 ± 0.03`, recursive utility aliases `1.13 ± 0.03` -- each within one
  stddev of the prior day, so these gaps are stable rather than drifting.

Rows that do not complete, reported separately from the `fast` gaps above:
`large-ts-repo` (tsz exit 124, killed at the 1500s ceiling; tsgo 34.9s, itself
non-zero), `zod-project` and `kysely-project` (`tsz error; tsc ok`). The harness
prints a "42.99 times faster than tsz" line for large-ts-repo, but that is
`timeout_ceiling / tsgo_time`, not a speed measurement -- hyperfine reports it
as `Time (abs =)` with no stddev because only one killed run was collected.

## Provenance

Machine: m1
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high

AgentName: M1FableArchitect