### PR TITLE
fix(parser): TS1193 (export declaration modifiers) was never wired

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -454,6 +454,7 @@ const fn is_parser_grammar_code(code: u32) -> bool {
         | 1182 // A destructuring declaration must have an initializer
         | 1184 // Modifiers cannot appear here
         | 1191 // An import declaration cannot have modifiers
+        | 1193 // An export declaration cannot have modifiers
         | 1197 // Catch clause variable cannot have an initializer
         | 1200 // Line terminator not permitted before arrow
         | 1206 // Decorators are not valid here

--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -222,6 +222,10 @@ mod state_type_tests;
 mod state_declaration_tests;
 
 #[cfg(test)]
+#[path = "../../tests/export_declaration_modifier_grammar_tests.rs"]
+mod export_declaration_modifier_grammar_tests;
+
+#[cfg(test)]
 #[path = "../../tests/declaration_node_end_tests.rs"]
 mod declaration_node_end_tests;
 

--- a/crates/tsz-parser/src/parser/state_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_declarations.rs
@@ -1706,6 +1706,20 @@ impl ParserState {
                     export_end,
                 );
                 let modifiers = Self::make_node_list(vec![declare_modifier, export_modifier]);
+                // `declare export type { x }` / `declare export type * from "m"` is a
+                // type-only export declaration, not the type-alias form `declare export
+                // type X = Y` — same lookahead as the non-ambient path in
+                // `parse_export_declaration`.
+                let is_type_only_export = self.is_token(SyntaxKind::TypeKeyword) && {
+                    let snapshot = self.scanner.save_state();
+                    let current = self.current_token;
+                    self.next_token();
+                    let is_type_only = self.is_token(SyntaxKind::OpenBraceToken)
+                        || self.is_token(SyntaxKind::AsteriskToken);
+                    self.scanner.restore_state(snapshot);
+                    self.current_token = current;
+                    is_type_only
+                };
                 // TS1029: 'export' modifier must precede 'declare' modifier.
                 // Skip for `declare export as namespace` (valid UMD pattern) and
                 // `declare export = expr` (export assignment — TS1120 handles it).
@@ -1716,11 +1730,17 @@ impl ParserState {
                 // TS1184 (Modifiers cannot appear here) is already emitted.
                 // Also skip for `declare export module/namespace` — tsc 6.0 accepts this
                 // form without TS1029 for ambient module/namespace declarations.
+                // Also skip for a plain export declaration (`{ }` / `*` / type-only
+                // `type { }` / `type *`) — tsc emits TS1193 alone there, never TS1029
+                // alongside it (oracle-confirmed).
                 if !self.in_block_context()
                     && !self.is_token(SyntaxKind::AsKeyword)
                     && !self.is_token(SyntaxKind::EqualsToken)
                     && !self.is_token(SyntaxKind::ModuleKeyword)
                     && !self.is_token(SyntaxKind::NamespaceKeyword)
+                    && !self.is_token(SyntaxKind::OpenBraceToken)
+                    && !self.is_token(SyntaxKind::AsteriskToken)
+                    && !is_type_only_export
                     && (saved_flags & crate::parser::state::CONTEXT_FLAG_AMBIENT) == 0
                 {
                     self.parse_error_at(
@@ -1786,6 +1806,62 @@ impl ParserState {
                     SyntaxKind::InterfaceKeyword => {
                         // `declare export interface X { ... }`
                         self.parse_interface_declaration_with_modifiers(start_pos, Some(modifiers))
+                    }
+                    SyntaxKind::AsteriskToken | SyntaxKind::OpenBraceToken => {
+                        // `declare export * from "m"` / `declare export { x }` (from "m")? —
+                        // a plain export declaration cannot carry a `declare` modifier.
+                        // tsc reports TS1193 at the first modifier and still parses the
+                        // export declaration itself (the checker then resolves `x`/`"m"`
+                        // as usual, e.g. TS2304/TS2307 alongside TS1193).
+                        //
+                        // Skipped when already in an ambient context (`declare namespace N
+                        // { declare export { x }; }`): tsc reports TS1038 there instead of
+                        // TS1193 (the same precedence the TS1029 check above already
+                        // follows), but `ExportDeclData` has no modifiers field for the
+                        // checker's TS1038 pass to read, so this nested shape stays a
+                        // known gap rather than a newly-wrong code — see #16291 follow-up.
+                        if (saved_flags & crate::parser::state::CONTEXT_FLAG_AMBIENT) == 0 {
+                            use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages};
+                            let error_start = all_modifiers
+                                .first()
+                                .and_then(|idx| self.arena.get(*idx))
+                                .map_or(start_pos, |node| node.pos);
+                            self.parse_error_at(
+                                error_start,
+                                self.token_pos() - error_start,
+                                diagnostic_messages::AN_EXPORT_DECLARATION_CANNOT_HAVE_MODIFIERS,
+                                diagnostic_codes::AN_EXPORT_DECLARATION_CANNOT_HAVE_MODIFIERS,
+                            );
+                        }
+                        if self.is_token(SyntaxKind::AsteriskToken) {
+                            self.parse_export_star(start_pos, false)
+                        } else {
+                            self.parse_export_named(start_pos, false)
+                        }
+                    }
+                    SyntaxKind::TypeKeyword if is_type_only_export => {
+                        // `declare export type { x }` / `declare export type * from "m"`
+                        // See the `AsteriskToken | OpenBraceToken` arm above for the
+                        // already-ambient exception.
+                        if (saved_flags & crate::parser::state::CONTEXT_FLAG_AMBIENT) == 0 {
+                            use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages};
+                            let error_start = all_modifiers
+                                .first()
+                                .and_then(|idx| self.arena.get(*idx))
+                                .map_or(start_pos, |node| node.pos);
+                            self.parse_error_at(
+                                error_start,
+                                self.token_pos() - error_start,
+                                diagnostic_messages::AN_EXPORT_DECLARATION_CANNOT_HAVE_MODIFIERS,
+                                diagnostic_codes::AN_EXPORT_DECLARATION_CANNOT_HAVE_MODIFIERS,
+                            );
+                        }
+                        self.parse_expected(SyntaxKind::TypeKeyword);
+                        if self.is_token(SyntaxKind::AsteriskToken) {
+                            self.parse_export_star(start_pos, true)
+                        } else {
+                            self.parse_export_named(start_pos, true)
+                        }
                     }
                     SyntaxKind::TypeKeyword => {
                         // `declare export type X = ...`

--- a/crates/tsz-parser/tests/export_declaration_modifier_grammar_tests.rs
+++ b/crates/tsz-parser/tests/export_declaration_modifier_grammar_tests.rs
@@ -1,0 +1,188 @@
+//! TS1193 (`An export declaration cannot have modifiers.`) — a plain export
+//! declaration (`export { }`, `export * from`, type-only `export type { }` /
+//! `export type *`) preceded by a `declare` modifier.
+//!
+//! Every expectation below is pinned against the vendored `typescript@7.0.2`
+//! oracle (`--noEmit --strict --target es2022 --module esnext --lib es2022`).
+//! TS1193 was previously unwired: `state_declarations.rs`'s `declare export`
+//! arm had no match for `OpenBraceToken` / `AsteriskToken` / a type-only
+//! `TypeKeyword`, so all four shapes fell through to a generic
+//! `error_declaration_expected` (TS1146) instead.
+
+use crate::parser::test_fixture::parse_source;
+
+fn codes(source: &str) -> Vec<u32> {
+    let (parser, _root) = parse_source(source);
+    parser.get_diagnostics().iter().map(|d| d.code).collect()
+}
+
+fn first_diag_start(source: &str, code: u32) -> u32 {
+    let (parser, _root) = parse_source(source);
+    parser
+        .get_diagnostics()
+        .iter()
+        .find(|d| d.code == code)
+        .unwrap_or_else(|| panic!("expected TS{code} for {source:?}"))
+        .start
+}
+
+#[test]
+fn declare_export_named_emits_ts1193_at_declare() {
+    // oracle: TS1193 at (1,1), TS2304 for `x` — no TS1029.
+    let source = "declare export { x };";
+    let cs = codes(source);
+    assert!(
+        cs.contains(&1193),
+        "expected TS1193 for {source:?}, got {cs:?}"
+    );
+    assert!(
+        !cs.contains(&1029),
+        "TS1029 must not accompany TS1193 for a plain export declaration, got {cs:?}"
+    );
+    assert_eq!(first_diag_start(source, 1193), 0);
+}
+
+#[test]
+fn declare_export_named_renamed_binder() {
+    // Same shape, different exported name — the rule is positional, not
+    // keyed to the binder's spelling.
+    let source = "declare export { qux$_0 };";
+    let cs = codes(source);
+    assert!(
+        cs.contains(&1193),
+        "expected TS1193 for {source:?}, got {cs:?}"
+    );
+}
+
+#[test]
+fn declare_export_star_emits_ts1193() {
+    let source = r#"declare export * from "mod";"#;
+    let cs = codes(source);
+    assert!(
+        cs.contains(&1193),
+        "expected TS1193 for {source:?}, got {cs:?}"
+    );
+    assert!(!cs.contains(&1029), "got {cs:?}");
+    assert_eq!(first_diag_start(source, 1193), 0);
+}
+
+#[test]
+fn declare_export_named_with_module_specifier_emits_ts1193() {
+    let source = r#"declare export { x } from "mod";"#;
+    let cs = codes(source);
+    assert!(
+        cs.contains(&1193),
+        "expected TS1193 for {source:?}, got {cs:?}"
+    );
+    assert!(!cs.contains(&1029), "got {cs:?}");
+}
+
+#[test]
+fn declare_export_type_only_named_emits_ts1193() {
+    // `declare export type { x }` is a type-only *export declaration*, not
+    // the type-alias form `declare export type X = Y` — the parser must
+    // disambiguate via lookahead the same way the non-ambient path does.
+    let source = "declare export type { x };";
+    let cs = codes(source);
+    assert!(
+        cs.contains(&1193),
+        "expected TS1193 for {source:?}, got {cs:?}"
+    );
+    assert!(!cs.contains(&1029), "got {cs:?}");
+}
+
+#[test]
+fn declare_export_type_only_star_emits_ts1193() {
+    let source = r#"declare export type * as ns from "mod";"#;
+    let cs = codes(source);
+    assert!(
+        cs.contains(&1193),
+        "expected TS1193 for {source:?}, got {cs:?}"
+    );
+    assert!(!cs.contains(&1029), "got {cs:?}");
+}
+
+#[test]
+fn declare_export_type_alias_does_not_emit_ts1193() {
+    // Negative / adjacent: `declare export type X = ...` is a genuine type
+    // alias declaration (tsc: TS1029 only, `declare` after `export`), not a
+    // plain export declaration — must not draw TS1193.
+    let source = "declare export type X = number;";
+    let cs = codes(source);
+    assert!(
+        !cs.contains(&1193),
+        "must not emit TS1193 for {source:?}, got {cs:?}"
+    );
+    assert!(
+        cs.contains(&1029),
+        "expected TS1029 for {source:?}, got {cs:?}"
+    );
+}
+
+#[test]
+fn plain_export_named_stays_clean() {
+    // Negative: no `declare` modifier at all.
+    assert_eq!(codes("export { x };"), Vec::<u32>::new());
+}
+
+#[test]
+fn plain_export_empty_stays_clean() {
+    assert_eq!(codes("export {};"), Vec::<u32>::new());
+}
+
+#[test]
+fn declare_export_class_still_reports_ts1029_not_ts1193() {
+    // Adjacent/negative: a `declare export`-prefixed declaration that is NOT
+    // a plain export declaration (class here) keeps its pre-existing TS1029
+    // behavior and must not regress to TS1193.
+    let source = "declare export class C {}";
+    let cs = codes(source);
+    assert!(
+        cs.contains(&1029),
+        "expected TS1029 for {source:?}, got {cs:?}"
+    );
+    assert!(
+        !cs.contains(&1193),
+        "must not emit TS1193 for {source:?}, got {cs:?}"
+    );
+}
+
+#[test]
+fn export_declare_export_named_emits_ts1193_at_first_export() {
+    // `export declare export { x };` — TS1029 already fired for the
+    // out-of-order `export`/`declare` pair (existing behavior, unrelated to
+    // this fix); TS1193 still fires for the inner plain export declaration,
+    // anchored at the *first* modifier (the outer `export`).
+    let source = "export declare export { x };";
+    let cs = codes(source);
+    assert!(
+        cs.contains(&1193),
+        "expected TS1193 for {source:?}, got {cs:?}"
+    );
+    assert_eq!(first_diag_start(source, 1193), 0);
+}
+
+#[test]
+fn nested_declare_export_in_ambient_namespace_does_not_emit_ts1193() {
+    // Known adjacent gap, not a regression: inside an already-ambient body
+    // (`declare namespace N { ... }`), tsc reports TS1038 ("declare modifier
+    // cannot be used in an already ambient context") for a redundant nested
+    // `declare`, never TS1193 — the same precedence the pre-existing TS1029
+    // check already follows for this position. `ExportDeclData` carries no
+    // modifiers field for the checker's TS1038 pass to read, so this shape
+    // stays silently-clean rather than regressing to a wrong TS1193.
+    let source = "declare namespace N {\n  declare export { x };\n}\n";
+    let cs = codes(source);
+    assert!(
+        !cs.contains(&1193),
+        "must not emit TS1193 inside an already-ambient body, got {cs:?}"
+    );
+}
+
+#[test]
+fn export_in_ambient_namespace_without_declare_stays_clean() {
+    // Adjacent negative: an export declaration inside `declare namespace`
+    // that does NOT itself carry a `declare` modifier is unaffected.
+    let source = "declare namespace N {\n  export { x };\n}\n";
+    assert_eq!(codes(source), Vec::<u32>::new());
+}


### PR DESCRIPTION
`An export declaration cannot have modifiers.` (TS1193) had no emit site anywhere under `crates/`, confirmed via #16291's fresh 88-code unwired-diagnostic enumeration (its own "highest-yield remaining" pick). The `declare export ...` arm in `parse_ambient_declaration_with_modifiers` (`crates/tsz-parser/src/parser/state_declarations.rs`) matched `AsKeyword`/`FunctionKeyword`/`ClassKeyword`/var-like/`EqualsToken`/`ImportKeyword`/`Module`/`Namespace`/`InterfaceKeyword`/`TypeKeyword`/`EnumKeyword`, but had no arm for a **plain export declaration** (`OpenBraceToken`, `AsteriskToken`, or the type-only `type { }` / `type *` forms) — so `declare export { x }`, `declare export * from "m"`, and `declare export type { x }` all fell through to a generic `error_declaration_expected` (TS1146) instead of tsc's TS1193.

**Structural rule.** When a plain export declaration (`export { }` / `export * from` / type-only `export type { }` / `export type *`) is preceded by any modifier, tsc's checker-side grammar check reports TS1193 alone at the first modifier's position and still parses the declaration itself — the checker's own semantic diagnostics for the export clause/specifier survive alongside it (TS2304/TS2307). tsz now does the same through the parser's `declare export` arm, the exact sibling of the already-wired TS1191 (`An import declaration cannot have modifiers.`).

Because TS1193 is parser-emitted in tsz (like TS1191), it needed the same `is_parser_grammar_code` list entry in `crates/tsz-cli/src/driver/check_utils.rs`, oracle-verified in both directions per #16279's protocol: Direction A (isolated, TS1193 survives with no other parse error) and Direction B (`declare export { x };\nfoo(;` — a real structural parse error elsewhere in the file suppresses TS1193, matching tsc exactly).

**A second bug fell out of wiring the first.** The pre-existing TS1029 (`'export' modifier must precede 'declare' modifier`) check already carried exemptions for `as`/`=`/`module`/`namespace`, but not for the three new branches — so `declare export { x }` was emitting **both** TS1193 and a spurious TS1029 the oracle never shows. Extended the same exemption.

## Adjacent-case matrix

13 tests, `crates/tsz-parser/tests/export_declaration_modifier_grammar_tests.rs`, registered via `#[path=...]` in `parser/mod.rs` (this crate has `autotests = false`). Every expectation pinned against the vendored `typescript@7.0.2` oracle.

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `declare export { x };` | TS1193 + TS2304 | TS1146 | TS1193 + TS2304 |
| renamed binder, same shape | TS1193 | TS1146 | TS1193 |
| `declare export * from "mod";` | TS1193 + TS2307 | TS1146 + TS1005 | TS1193 + TS2307 |
| `declare export { x } from "mod";` | TS1193 + TS2307 | TS1146 + TS1005 | TS1193 + TS2307 |
| `declare export type { x };` | TS1193 + TS2304 | TS1003 | TS1193 + TS2304 |
| `declare export type * as ns from "mod";` | TS1193 + TS2307 | — | TS1193 + TS2307 |
| `export declare export { x };` | TS1193 + TS2304 (at first `export`) | — | TS1193 + TS2304 |
| `declare export type X = number;` (type alias, not export) | TS1029 only | TS1029 | TS1029 only (no TS1193) |
| `declare export class C {}` (non-export form) | TS1029 only | TS1029 | TS1029 only (no TS1193) |
| `export { x };` (no declare) | clean | clean | clean |
| `export {};` | clean | clean | clean |
| `declare namespace N { export { x }; }` (no inner declare) | clean | clean | clean |

The negatives carry the weight: a type-alias `declare export type X = Y` and a non-export form (`class`) must keep their pre-existing TS1029-only behavior, never regressing to TS1193; a plain export with no `declare` at all stays clean.

## Known adjacent gap, explicitly out of scope

`declare namespace N { declare export { x }; }` — inside an already-ambient body, tsc reports **TS1038** (`A 'declare' modifier cannot be used in an already ambient context.`) for the redundant nested `declare`, never TS1193, the same precedence the pre-existing TS1029 exemption already follows for this position (oracle-confirmed). Fixing that fully needs `ExportDeclData` to carry a modifiers field (it hard-codes `None` today) plus a new `EXPORT_DECLARATION` arm in the checker's `check_declare_modifiers_in_ambient_body` match (`crates/tsz-checker/src/state/state_checking_members/statement_checks.rs`) — confirmed via oracle that the equivalent mechanism already works correctly for `declare namespace N { declare class C {} }` today, so this is a scoped, well-understood follow-up, not a design gap. This PR gates the new TS1193 emission on not-already-ambient so the nested shape stays silently-clean rather than regressing to a *new* wrong code (test: `nested_declare_export_in_ambient_namespace_does_not_emit_ts1193`).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-parser --lib export_declaration_modifier_grammar_tests` — **13/13**, new file.
- `cargo test -p tsz-parser --lib` — **1577/1577**, full crate suite, no regressions.
- `cargo test -p tsz-cli --lib check_utils` — **106/106**, owns the `is_parser_grammar_code` list this PR extends.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p tsz-parser -p tsz-cli --lib --tests -- -D warnings` — clean.
- Measured through the real CLI (`.target/debug/tsz --noEmit --strict --target es2022 --module esnext --lib esnext`) against the vendored `typescript@7.0.2` oracle on 12 fixture files covering the full matrix above — parent binary diverged on all TS1193-bearing rows (wrong code or missing), branch binary diagnostic-for-diagnostic identical to the oracle on every row except the documented nested-ambient gap.
- This container started cold with no `TypeScript/tests/cases` corpus and no `.target` cache; the two-sided `scripts/conformance/compare-to-parent.sh origin/main` corpus gate was not run this session given the time budget. The change is narrowly scoped to a previously-dead diagnostic code plus one list-membership addition verified in both directions against the oracle — flagging here per the repo's own standing note that a targeted matrix cannot see every corpus interaction, in case a later session wants to run the broader gate before this lands.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01TspZ7XnC9UXPvCWGZbcKkR)_