### PR TITLE
fix(cli): the rest-parameter grammar family is all-in or all-out of the parse-diagnostic filter

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -405,6 +405,15 @@ fn is_hard_keyword_interface_name_2427_parse_diagnostic(diagnostic: &ParseDiagno
 /// in or all out: TS1049, TS1051, TS1054, TS1095. TS1052/TS1053 belong to the
 /// same tsc function but are checker-emitted in tsz, so they never reach this
 /// parse-diagnostic filter.
+///
+/// Same shape for tsc's `checkGrammarParameterList`, which reports TS1014 (a
+/// rest parameter must be last), TS1047 (a rest parameter cannot be
+/// optional), and TS1048 (a rest parameter cannot have an initializer) from
+/// one function. TS1014 was listed, TS1047/1048 were not: a file whose rest
+/// parameter tripped 1047 or 1048 silently deleted an unrelated function's
+/// TS1014 elsewhere in the same file. TS1015/1016 belong to the same tsc
+/// function but are checker-emitted in tsz (`parameter_checker.rs`), so they
+/// never reach this filter either.
 const fn is_parser_grammar_code(code: u32) -> bool {
     matches!(
         code,
@@ -429,6 +438,8 @@ const fn is_parser_grammar_code(code: u32) -> bool {
         | 1040 // '{0}' modifier cannot be used in an ambient context
         | 1042 // 'async' modifier cannot be used here
         | 1044 // '{0}' modifier cannot appear on a module or namespace element
+        | 1047 // A rest parameter cannot be optional
+        | 1048 // A rest parameter cannot have an initializer
         | 1049 // A 'set' accessor must have exactly one parameter
         | 1051 // A 'set' accessor cannot have an optional parameter
         | 1054 // A 'get' accessor cannot have parameters
@@ -1477,3 +1488,7 @@ mod tests;
 #[cfg(test)]
 #[path = "check_utils/heritage_clause_tests.rs"]
 mod heritage_clause_tests;
+
+#[cfg(test)]
+#[path = "check_utils/rest_parameter_grammar_tests.rs"]
+mod rest_parameter_grammar_tests;

--- a/crates/tsz-cli/src/driver/check_utils/rest_parameter_grammar_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/rest_parameter_grammar_tests.rs
@@ -1,0 +1,184 @@
+//! Unit tests for the rest-parameter slice of `is_parser_grammar_code`
+//! (#16279's general shape). Split into its own file rather than growing
+//! `tests.rs` past the 2000-line limit (already over before this change).
+//!
+//! tsc's `checkGrammarParameterList` reports TS1014 (a rest parameter must be
+//! last in a parameter list), TS1047 (a rest parameter cannot be optional)
+//! and TS1048 (a rest parameter cannot have an initializer) from one
+//! function, all parser-emitted in tsz
+//! (`crates/tsz-parser/src/parser/state_statements_class.rs`). Before this
+//! fix, `is_parser_grammar_code` listed only TS1014 — TS1047/1048 were
+//! unlisted, so either counted as a "real" parse error and silently deleted
+//! an unrelated function's listed TS1014 from the same file, while itself
+//! never being suppressed alongside an unrelated real syntax error the way
+//! tsc suppresses it. TS1015 ('{0}' cannot have question mark and
+//! initializer) and TS1016 (a required parameter cannot follow an optional
+//! parameter) belong to the same tsc function but are checker-emitted in tsz
+//! (`crates/tsz-checker/src/checkers/parameter_checker.rs`), so they must not
+//! get an entry here.
+
+use super::*;
+
+#[test]
+fn filtered_parse_diagnostics_suppresses_ts1047_when_real_parse_error_present() {
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 20,
+            length: 6,
+            message: "A rest parameter cannot be optional.".to_string(),
+            code: 1047,
+        },
+        ParseDiagnostic {
+            start: 60,
+            length: 1,
+            message: "Type expected.".to_string(),
+            code: 1110,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&1047),
+        "TS1047 should be suppressed when a real parse error (TS1110) is present, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1110),
+        "TS1110 (real parse error) should survive, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_suppresses_ts1048_when_real_parse_error_present() {
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 20,
+            length: 6,
+            message: "A rest parameter cannot have an initializer.".to_string(),
+            code: 1048,
+        },
+        ParseDiagnostic {
+            start: 60,
+            length: 1,
+            message: "Type expected.".to_string(),
+            code: 1110,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&1048),
+        "TS1048 should be suppressed when a real parse error (TS1110) is present, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1110),
+        "TS1110 (real parse error) should survive, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_keeps_ts1047_ts1048_when_alone() {
+    use tsz::parser::ParseDiagnostic;
+
+    for (code, message) in [
+        (1047, "A rest parameter cannot be optional."),
+        (1048, "A rest parameter cannot have an initializer."),
+    ] {
+        let diagnostics = vec![ParseDiagnostic {
+            start: 20,
+            length: 1,
+            message: message.to_string(),
+            code,
+        }];
+
+        let filtered = filtered_parse_diagnostics(&diagnostics, false);
+        let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+        assert!(
+            codes.contains(&code),
+            "TS{code} should be kept when it is the only diagnostic, got: {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn filtered_parse_diagnostics_ts1047_does_not_self_suppress_listed_sibling() {
+    use tsz::parser::ParseDiagnostic;
+
+    // Before the fix, TS1047 was unlisted in `is_parser_grammar_code`, so it
+    // counted as a "real" non-grammar parse error under
+    // `has_non_grammar_parse_error` and silently deleted every *listed*
+    // sibling in the same file — here, the already-listed TS1014 from an
+    // unrelated function's rest parameter.
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 12,
+            length: 6,
+            message: "A rest parameter must be last in a parameter list.".to_string(),
+            code: 1014,
+        },
+        ParseDiagnostic {
+            start: 80,
+            length: 6,
+            message: "A rest parameter cannot be optional.".to_string(),
+            code: 1047,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&1014),
+        "TS1014 must not be self-suppressed by unlisted TS1047, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1047),
+        "TS1047 should survive when it is the only non-grammar-looking diagnostic, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_ts1048_does_not_self_suppress_listed_sibling() {
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 12,
+            length: 6,
+            message: "A rest parameter must be last in a parameter list.".to_string(),
+            code: 1014,
+        },
+        ParseDiagnostic {
+            start: 80,
+            length: 6,
+            message: "A rest parameter cannot have an initializer.".to_string(),
+            code: 1048,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&1014),
+        "TS1014 must not be self-suppressed by unlisted TS1048, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1048),
+        "TS1048 should survive when it is the only non-grammar-looking diagnostic, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_ts1015_ts1016_are_not_listed() {
+    // TS1015 and TS1016 belong to the same tsc `checkGrammarParameterList`
+    // function as TS1014/1047/1048, but tsz emits them from the checker
+    // (`parameter_checker.rs`), not the parser, so they must never reach
+    // this parse-diagnostic filter's suppression list. Guard this so a
+    // future edit does not fold them in by analogy with their siblings.
+    assert!(!is_parser_grammar_code(1015));
+    assert!(!is_parser_grammar_code(1016));
+}


### PR DESCRIPTION
Part of #16279 (fourth confirmed slice of the audit; accessor #16278, index-signature #16281, heritage-clause #16286 are the prior three).

**Structural rule.** tsc's `checkGrammarParameterList` reports TS1014 (a rest parameter must be last in a parameter list), TS1047 (a rest parameter cannot be optional), and TS1048 (a rest parameter cannot have an initializer) from one function, suppressed file-wide when `hasParseDiagnostics(sourceFile)` holds. All three are parser-emitted in tsz (`crates/tsz-parser/src/parser/state_statements_class.rs`), the tsz counterpart of that tsc function. `is_parser_grammar_code` (`crates/tsz-cli/src/driver/check_utils.rs`) listed only TS1014.

**What was wrong.** `has_non_grammar_parse_error` is computed as the complement of `is_parser_grammar_code`, so membership is load-bearing in both directions:

- a listed code (TS1014) is suppressed when a real parse error exists (intended), and
- an unlisted parser-emitted grammar code (TS1047/1048) counts as a real parse error and suppresses every listed sibling **file-wide** — and is itself never suppressed when it should be.

Same shape as #16278 (accessor), #16281 (index-signature), #16286 (heritage-clause).

**What was correctly left out.** TS1015 (`'{0}' cannot have question mark and initializer`) and TS1016 (a required parameter cannot follow an optional parameter) belong to the same tsc function but are checker-emitted in tsz (`crates/tsz-checker/src/checkers/parameter_checker.rs`), so they must not get an entry here — adding them would be wrong, same as TS1052/1053 for the accessor family. Guarded by a dedicated test (`filtered_parse_diagnostics_ts1015_ts1016_are_not_listed`).

## Goal
Goal: hold

## Verification

**Oracle matrix — pinned `typescript@7.0.2`, `--noEmit --strict --pretty false --lib es2022 --target es2022`, compared against the built `tsz` binary:**

| fixture | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| TS1047 alone (control) | fires (+ unrelated TS2370) | unchanged ✅ | unchanged ✅ |
| TS1048 alone (control) | fires alone | unchanged ✅ | unchanged ✅ |
| TS1014 (listed, different function) + TS1047 (unlisted), no real syntax error | both fire | TS1047 only — **TS1014 silently dropped** ❌ | both fire ✅ |
| TS1014 (listed, different function) + TS1048 (unlisted), no real syntax error | both fire | TS1048 only — **TS1014 silently dropped** ❌ | both fire ✅ |
| TS1047 + unrelated real syntax error (`let x: = 1;`, TS1110) | `TS1110` only | `TS1110 TS1047` ❌ (over-reports) | `TS1110` only ✅ |
| TS1048 + unrelated real syntax error | `TS1110` only | `TS1110 TS1048` ❌ (over-reports) | `TS1110` only ✅ |
| TS1014 alone (control) | fires | unchanged ✅ | unchanged ✅ |

**Adjacent-case unit matrix** — 6 new tests in a new file, `crates/tsz-cli/src/driver/check_utils/rest_parameter_grammar_tests.rs` (kept separate from `tests.rs`, which is already over the repo's 2000-line ceiling on `main`): suppression of TS1047/1048 alongside a real parse error, both kept when alone, file-wide self-suppression-of-TS1014 in both directions, and a guard that TS1015/1016 stay unlisted.

**Non-vacuity proven.** With the tests in place and only the two new list entries reverted: `cargo test -p tsz-cli --lib rest_parameter_grammar` → 2 passed, 4 failed — exactly the 4 fix-dependent tests; the 2 controls (`keeps_when_alone`, `ts1015_ts1016_are_not_listed`) stayed green. With the fix: 6 passed, 0 failed.

**Full suite:** `cargo test -p tsz-cli --lib` — 1667 passed, 18 failed, 2 ignored. All 18 failures are pre-existing and unrelated to this change (verified individually): `tsc_compat_tests::*` compares against this container's globally-installed `tsc` (reports `6.0.2`) rather than the pinned `7.0.2` oracle, and `driver_tests::compile_incremental_reports_ts5033_when_tsbuildinfo_is_not_writable` relies on filesystem permission bits that root bypasses in this container. Neither touches `check_utils.rs` or parser grammar codes.

**Two-sided `compare-to-parent.sh origin/main`, run to completion** at head `b327895` (base `fe56fb6`):

```
base failing=567  branch failing=567
NEWLY PASSING (0) / NEWLY FAILING (0) / fingerprint changed (0)
```

0/0/0 — the expected zero-movement signature for this bug class (per the board's standing note: #16016, #16020, #16039, #16042, #16270, #16278, #16281, #16286 all showed the same signature). The oracle-pinned targeted matrix above is the primary evidence; this sweep is the regression floor.

**Commands run:** `cargo fmt --all` clean · `cargo clippy -p tsz-cli --lib --tests --all-targets -- -D warnings` clean · `python3 scripts/arch/arch_guard.py` → "Architecture guardrails passed." The pre-commit hook's own clippy + test + arch-guard legs passed at commit time.

**Remaining audit scope, for whoever continues #16279.** Accessor (#16278), index-signature (#16281), modifier cluster (confirmed fully listed), heritage-clause (#16286), and rest-parameter (this PR) are done. The rest of the ~45-entry list is still unaudited.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01WD3b7FnbQqqcwsgC3QDqpB)_