### PR TITLE
fix(parser): numeric backreferences are validated against the capturing-group count (TS1533/TS1534)

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1447,6 +1447,8 @@ pub(super) const fn is_non_suppressing_parse_error(code: u32) -> bool {
         | 1499 // Unknown regular expression flag (grammar check in tsc's checker, not a parse failure)
         | 1500 // Duplicate regular expression flag (grammar check, AST is valid)
         | 1502 // The Unicode 'u' and 'v' flags cannot be set simultaneously (grammar check, AST is valid)
+        | 1533 // Backreference to a group beyond the capturing-group count (regex grammar, AST is valid)
+        | 1534 // Backreference with no capturing group in the pattern (regex grammar, AST is valid)
         | 17019 // '?' at end of type is not valid TS syntax (parser recovers valid AST)
         | 17020 // '?' at start of type is not valid TS syntax (parser recovers valid AST)
     )

--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -250,6 +250,10 @@ mod close_brace_node_end_position_remaining_tests;
 mod decorator_tests;
 
 #[cfg(test)]
+#[path = "../../tests/regex_backreference_tests.rs"]
+mod regex_backreference_tests;
+
+#[cfg(test)]
 #[path = "../../tests/modifier_ordering_tests.rs"]
 mod modifier_ordering_tests;
 

--- a/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
@@ -5,7 +5,7 @@
 
 use super::state::ParserState;
 use crate::parser::{NodeIndex, node::LiteralData};
-use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages};
+use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
 use tsz_scanner::SyntaxKind;
 use tsz_scanner::scanner_impl::TokenFlags;
 
@@ -303,12 +303,56 @@ impl ParserState {
                 strict_mode: bool,
                 unicode_sets_mode: bool,
                 start_pos: u32,
+                capturing_group_count: u32,
             }
 
             struct CharEscapeScanCtx<'a> {
                 body: &'a [u8],
                 strict_mode: bool,
                 end: usize,
+                capturing_group_count: u32,
+            }
+
+            /// Count the capturing groups in the whole pattern, the way tsc's
+            /// `scanRegularExpressionWorker` does on its first pass.
+            ///
+            /// A backreference is legal when it names a group that exists
+            /// *anywhere* in the pattern, including one that appears later or in
+            /// another alternative, so the count has to be known before any
+            /// escape is judged. Capturing forms are `(` and `(?<name>`;
+            /// `(?:`, `(?=`, `(?!`, `(?<=`, `(?<!` and modifier groups are not.
+            fn count_capturing_groups(body: &[u8], body_end: usize) -> u32 {
+                let mut count = 0u32;
+                let mut in_class = false;
+                let mut pos = 1usize;
+
+                while pos < body_end {
+                    match body[pos] {
+                        // Skip the escaped byte so `\(` and `\[` never open
+                        // anything. Continuation bytes of a multi-byte escaped
+                        // character are all >= 0x80, so they match no arm here.
+                        b'\\' => pos += 1,
+                        b'[' if !in_class => in_class = true,
+                        b']' if in_class => in_class = false,
+                        b'(' if !in_class => {
+                            if body.get(pos + 1) == Some(&b'?') {
+                                // `(?<name>` captures; `(?<=` and `(?<!` are
+                                // lookbehind assertions and do not.
+                                if body.get(pos + 2) == Some(&b'<')
+                                    && !matches!(body.get(pos + 3), Some(&b'=' | &b'!'))
+                                {
+                                    count += 1;
+                                }
+                            } else {
+                                count += 1;
+                            }
+                        }
+                        _ => {}
+                    }
+                    pos += 1;
+                }
+
+                count
             }
 
             fn scan_digits(body: &[u8], end: usize, pos: &mut usize) -> usize {
@@ -574,6 +618,46 @@ impl ParserState {
                             *pos += 1;
                         }
                     }
+                    b'1'..=b'9' if atom_escape => {
+                        // A decimal escape outside a character class is a
+                        // backreference, in every mode: tsc validates it with
+                        // and without the Unicode flags, so this arm must not be
+                        // gated on `strict_mode`. The span covers the digits
+                        // only — the backslash is not part of it.
+                        let digits_start = *pos;
+                        while *pos < end && body[*pos].is_ascii_digit() {
+                            *pos += 1;
+                        }
+                        let digits_len = (*pos - digits_start) as u32;
+                        let group_number = std::str::from_utf8(&body[digits_start..*pos])
+                            .ok()
+                            .and_then(|digits| digits.parse::<u32>().ok())
+                            // A digit run too long for `u32` cannot name any
+                            // group in a pattern this scanner could reach.
+                            .unwrap_or(u32::MAX);
+
+                        if scan_ctx.capturing_group_count == 0 {
+                            emit(
+                                parser,
+                                digits_start,
+                                digits_len,
+                                diagnostic_messages::THIS_BACKREFERENCE_REFERS_TO_A_GROUP_THAT_DOES_NOT_EXIST_THERE_ARE_NO_CAPTURING,
+                                diagnostic_codes::THIS_BACKREFERENCE_REFERS_TO_A_GROUP_THAT_DOES_NOT_EXIST_THERE_ARE_NO_CAPTURING,
+                            );
+                        } else if group_number > scan_ctx.capturing_group_count {
+                            let message = format_message(
+                                diagnostic_messages::THIS_BACKREFERENCE_REFERS_TO_A_GROUP_THAT_DOES_NOT_EXIST_THERE_ARE_ONLY_CAPTURIN,
+                                &[&scan_ctx.capturing_group_count.to_string()],
+                            );
+                            emit(
+                                parser,
+                                digits_start,
+                                digits_len,
+                                &message,
+                                diagnostic_codes::THIS_BACKREFERENCE_REFERS_TO_A_GROUP_THAT_DOES_NOT_EXIST_THERE_ARE_ONLY_CAPTURIN,
+                            );
+                        }
+                    }
                     b'0'..=b'9' => {
                         while *pos < end && body[*pos].is_ascii_digit() {
                             *pos += 1;
@@ -809,6 +893,7 @@ impl ParserState {
                                     body: ctx.body,
                                     strict_mode: ctx.strict_mode,
                                     end: ctx.body_end,
+                                    capturing_group_count: ctx.capturing_group_count,
                                 },
                                 pos,
                                 false,
@@ -995,6 +1080,7 @@ impl ParserState {
                                         body: ctx.body,
                                         strict_mode: ctx.strict_mode,
                                         end: ctx.body_end,
+                                        capturing_group_count: ctx.capturing_group_count,
                                     },
                                     pos,
                                     true,
@@ -1384,6 +1470,7 @@ impl ParserState {
                 strict_mode,
                 unicode_sets_mode,
                 start_pos,
+                capturing_group_count: count_capturing_groups(bytes, body_end),
             };
             let mut pos = 1usize;
             scan_disjunction(parser, &ctx, &mut pos, false);

--- a/crates/tsz-parser/tests/regex_backreference_tests.rs
+++ b/crates/tsz-parser/tests/regex_backreference_tests.rs
@@ -1,0 +1,203 @@
+//! Numeric backreference validation inside regular expression literals
+//! (TS1533 / TS1534).
+//!
+//! A decimal escape outside a character class is a backreference. It is legal
+//! only when the pattern actually contains a capturing group with that number,
+//! counted over the *whole* pattern — forward references and references across
+//! alternatives are both legal, so the count cannot be accumulated as the walk
+//! goes. Every row below is pinned against `typescript@7.0.2`.
+use crate::parser::ParserState;
+use crate::parser::test_fixture::parse_source;
+
+fn codes(parser: &ParserState) -> Vec<u32> {
+    parser.get_diagnostics().iter().map(|d| d.code).collect()
+}
+
+fn regex_codes(source: &str) -> Vec<u32> {
+    let (parser, _root) = parse_source(source);
+    codes(&parser)
+}
+
+/// TS1533 carries the capturing-group count as `{0}`; assert on the rendered
+/// number so an off-by-one in the count is visible, not just the code.
+fn regex_message(source: &str) -> String {
+    let (parser, _root) = parse_source(source);
+    parser
+        .get_diagnostics()
+        .first()
+        .map_or_else(String::new, |d| d.message.clone())
+}
+
+// ---------------------------------------------------------------------------
+// TS1534 — no capturing group anywhere in the pattern
+// ---------------------------------------------------------------------------
+
+#[test]
+fn backreference_with_no_capturing_group_reports_ts1534() {
+    assert_eq!(regex_codes("const a = /\\1/u;"), vec![1534]);
+}
+
+/// tsc validates backreferences with and without the Unicode flags, so this
+/// must not be gated on `u`/`v`.
+#[test]
+fn backreference_with_no_capturing_group_reports_ts1534_without_unicode_flag() {
+    assert_eq!(regex_codes("const a = /\\1/;"), vec![1534]);
+}
+
+#[test]
+fn backreference_with_no_capturing_group_reports_ts1534_under_unicode_sets_flag() {
+    assert_eq!(regex_codes("const a = /\\1/v;"), vec![1534]);
+}
+
+/// `\8` and `\9` are decimal escapes too, not literal characters.
+#[test]
+fn high_digit_backreference_with_no_capturing_group_reports_ts1534() {
+    assert_eq!(regex_codes("const a = /\\8/;"), vec![1534]);
+}
+
+#[test]
+fn non_capturing_group_does_not_satisfy_a_backreference() {
+    assert_eq!(regex_codes("const a = /(?:a)\\1/u;"), vec![1534]);
+}
+
+#[test]
+fn lookahead_group_does_not_satisfy_a_backreference() {
+    assert_eq!(regex_codes("const a = /(?!a)\\1/u;"), vec![1534]);
+}
+
+#[test]
+fn lookbehind_group_does_not_satisfy_a_backreference() {
+    assert_eq!(regex_codes("const a = /(?<=a)\\1/u;"), vec![1534]);
+}
+
+/// A `(` inside a character class is a literal character, not a group.
+#[test]
+fn open_paren_inside_character_class_is_not_a_capturing_group() {
+    assert_eq!(regex_codes("const a = /[(]\\1/u;"), vec![1534]);
+}
+
+/// An escaped `(` is a literal character, not a group.
+#[test]
+fn escaped_open_paren_is_not_a_capturing_group() {
+    assert_eq!(regex_codes("const a = /\\(\\1/u;"), vec![1534]);
+}
+
+// ---------------------------------------------------------------------------
+// TS1533 — the group number exceeds the capturing-group count
+// ---------------------------------------------------------------------------
+
+#[test]
+fn backreference_past_the_group_count_reports_ts1533() {
+    assert_eq!(regex_codes("const a = /(a)\\2/u;"), vec![1533]);
+}
+
+#[test]
+fn backreference_past_the_group_count_reports_ts1533_without_unicode_flag() {
+    assert_eq!(regex_codes("const a = /(a)\\2/;"), vec![1533]);
+}
+
+#[test]
+fn backreference_past_the_group_count_reports_the_actual_count() {
+    assert!(
+        regex_message("const a = /(a)(b)\\3/u;").contains("only 2 capturing groups"),
+        "TS1533 must render the real capturing-group count, got: {}",
+        regex_message("const a = /(a)(b)\\3/u;")
+    );
+}
+
+/// A multi-digit escape is one backreference to group 10, not `\1` followed by
+/// a literal `0`.
+#[test]
+fn multi_digit_backreference_is_read_as_one_group_number() {
+    assert_eq!(regex_codes("const a = /(a)\\10/u;"), vec![1533]);
+}
+
+/// The count spans the whole pattern, so a reference in one alternative sees
+/// a group declared in another.
+#[test]
+fn group_count_spans_alternatives() {
+    assert_eq!(regex_codes("const a = /(a)|\\2/u;"), vec![1533]);
+    assert!(regex_codes("const a = /[a-z]|(q)\\1/u;").is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Negative cases — valid backreferences must stay silent
+// ---------------------------------------------------------------------------
+
+#[test]
+fn valid_backreference_is_accepted() {
+    assert!(regex_codes("const a = /(a)\\1/u;").is_empty());
+    assert!(regex_codes("const a = /(a)\\1/;").is_empty());
+}
+
+/// A forward reference is legal: the group is counted before the walk judges
+/// any escape.
+#[test]
+fn forward_backreference_is_accepted() {
+    assert!(regex_codes("const a = /\\1(a)/u;").is_empty());
+}
+
+/// A named group is a capturing group and contributes to the number space.
+#[test]
+fn named_capturing_group_counts_toward_the_group_number() {
+    assert!(regex_codes("const a = /(?<n>a)\\1/u;").is_empty());
+    assert!(regex_codes("const a = /(?<n>a)(?<m>b)\\2/u;").is_empty());
+}
+
+/// Nesting does not collapse the count: `(b(c(d)))` is three groups, so `\3`
+/// resolves and `\4` does not.
+#[test]
+fn nested_groups_are_all_counted() {
+    assert!(regex_codes("const a = /a(b(c(d)))\\3/u;").is_empty());
+    assert_eq!(regex_codes("const a = /a(b(c(d)))\\4/u;"), vec![1533]);
+}
+
+#[test]
+fn group_inside_lookbehind_is_still_a_capturing_group() {
+    assert!(regex_codes("const a = /(?<=(a))\\1/u;").is_empty());
+}
+
+/// A capturing group whose body is a literal `(` still counts once.
+#[test]
+fn group_containing_an_escaped_paren_counts_once() {
+    assert!(regex_codes("const a = /(\\()\\1/u;").is_empty());
+}
+
+/// `\0` is the NUL escape, not a backreference.
+#[test]
+fn null_escape_is_not_a_backreference() {
+    assert!(regex_codes("const a = /\\0/u;").is_empty());
+}
+
+/// Inside a character class a decimal escape is not a backreference, so the
+/// backreference rule must not reach it.
+#[test]
+fn decimal_escape_inside_character_class_is_not_judged_as_a_backreference() {
+    let inside = regex_codes("const a = /(a)[\\1]/u;");
+    assert!(
+        !inside.contains(&1533) && !inside.contains(&1534),
+        "character-class decimal escapes are TS1536/TS1537 territory, got {inside:?}"
+    );
+}
+
+/// Ordinary real-world patterns must stay clean — this is the regression the
+/// whole-pattern count exists to prevent.
+#[test]
+fn realistic_patterns_report_nothing() {
+    for source in [
+        "const a = /^(\\d{3})-(\\d{4})$/;",
+        "const a = /(\\w+)\\s+\\1/;",
+        "const a = /(?<year>\\d{4})-(?<mo>\\d{2})/u;",
+        "const a = /([a-z])(?:x)\\1/;",
+        "const a = /(?:(a)|(b))\\2/u;",
+        "const a = /x{2,3}(y)\\1/u;",
+        "const a = /(a)\\1{2,}/u;",
+        "const a = /(a)[\\d]\\1/u;",
+    ] {
+        assert!(
+            regex_codes(source).is_empty(),
+            "expected no diagnostics for {source}, got {:?}",
+            regex_codes(source)
+        );
+    }
+}


### PR DESCRIPTION
**Structural rule.** When a regular expression literal contains a decimal escape outside a character class, that escape is a backreference, and tsc validates it against the number of capturing groups in the **whole pattern**: TS1534 when the pattern has no capturing group at all, TS1533 (`There are only {0} capturing groups`) when the number exceeds the count. tsz now does the same through the parser's regex-grammar walker.

Two properties of tsc's rule that shape the fix:

1. **The count is whole-pattern, established before the walk judges anything.** A forward reference (`/\1(a)/`) and a reference across an alternative (`/(a)|\2/`) are both resolved against the same total, so an accumulate-as-you-go counter is wrong in both directions.
2. **Neither code is gated on the Unicode flags.** `/(a)\2/` reports TS1533 with no flag at all, so this arm must not sit behind the walker's existing `strict_mode`.

**Why it was missing, and where it belongs.** [#16291](https://github.com/tsz-org/tsz/issues/16291) lists the ~20 regex codes as unwired and estimates the owner as "the scanner's regex validation", implying the validation has to be written from scratch. It does not — `crates/tsz-parser/src/parser/state_expressions_literals_regex.rs` already contains a structural port of tsc's `scanRegularExpressionWorker` (`scan_disjunction` / `scan_alternative` / `scan_class_ranges` / `scan_character_escape` / `scan_character_class_escape`, same decomposition and names). Its decimal-escape arm consumed the digits without judging them. So the owner layer is the parser, the traversal and position arithmetic were already paid for, and the fix is a prepass plus a report at the existing site:

- `count_capturing_groups` — `(` and `(?<name>` capture; `(?:`, `(?=`, `(?!`, `(?<=`, `(?<!` and modifier groups do not; a `(` that is escaped or inside a character class is a literal character.
- the `b'1'..=b'9' if atom_escape` arm reports TS1533/TS1534 against that count, spanning the digits only (not the backslash), matching tsc's column exactly.

**The self-suppressing-set half.** TS1533/TS1534 also join `is_non_suppressing_parse_error` (`crates/tsz-cli/src/driver/check_utils.rs`), where the TS1499/TS1500/TS1502 regex-flag codes already sit. All five are grammar checks over a valid AST. Without the entry the *new* diagnostic set `has_syntax_parse_errors` and swallowed unrelated check-time diagnostics in the same file — measured, not theorised:

```
const a = /\1/u;                 tsc: TS1534 + TS2322 + TS2304
const b: number = "x";           tsz before the gate entry: TS1534 + TS2304   ← TS2322 lost
undeclaredFn();                  tsz after:  TS1534 + TS2322 + TS2304  (exact match)
```

This is [#16279](https://github.com/tsz-org/tsz/issues/16279)'s hazard arriving from the other direction: not a code wrongly *in* the suppressing set, but a newly-wired code that lands in it by default and takes unrelated diagnostics down with it. Worth checking on every future slice of the #16291 vein.

## Goal
Goal: hold

## Verification

**Oracle matrix — 26 rows, `typescript@7.0.2`** (`--noEmit --strict --target esnext --lib esnext`), comparing the real `tsz` CLI against real `tsc` on each fixture:

| | parent `fe56fb6` | this branch |
|---|---|---|
| rows matching the oracle | **9 / 26** | **26 / 26** |
| diverging | 17 | 0 |

Non-vacuity is measured, not asserted: 17 of the 26 rows genuinely diverge on the parent build. Positions were checked separately and match tsc column-for-column (`/(a)\10/u` → `(1,16)` on both; the span covers the digit run, not the backslash).

Rows cover the adjacent-case matrix: `u` / `v` / no-flag for the same pattern; forward reference; reference across an alternative; nested groups (`\3` resolves, `\4` does not); named groups counted, `(?:`/`(?=`/`(?!`/`(?<=` not counted; `(` escaped and `(` inside a character class both treated as literals; multi-digit `\10` read as one group number; `\8`/`\9` as backreferences; `\0` left alone as the NUL escape; character-class decimal escapes untouched (TS1536/TS1537 territory, still unwired).

**Negative sweep — 20 realistic patterns** (date/phone/URL/named-group/quantifier/property-escape shapes): 0 diagnostics on both tsc and tsz, i.e. no new false positives. Eight of them are pinned as a test.

**Suites**

- `cargo test -p tsz-parser --lib` → **1587 passed, 0 failed** (includes 23 new tests in `regex_backreference_tests.rs`)
- `cargo test -p tsz-cli --lib check_utils` → 106 passed, 0 failed
- `cargo test -p tsz-core --lib regex` → 12 passed, 0 failed (the existing TS1499/TS1500/TS1502 flag suite, unchanged)
- `cargo fmt --all` clean
- `cargo clippy --profile ci-lint --workspace --exclude tsz-conformance --all-targets -- -D warnings` → clean (CI's exact invocation)
- pre-commit hook (clippy + architecture guard) passed

**Owed:** the two-sided `scripts/conformance/compare-to-parent.sh origin/main` gate did not run in this session — the container had no `.target` and no corpus at start, and the gate does not fit in the remaining time. **Do not queue this PR until it reports 0 newly-failing.** Movement in the newly-*passing* direction is expected (this adds diagnostics tsc emits and tsz did not); newly-failing is the gate. If a row does newly fail, the first place to look is `count_capturing_groups` — a pattern shape where tsz counts a group tsc does not would produce a spurious TS1533. Emit was not run either; the change adds diagnostics only and touches no emit path, but the emit floor has zero headroom, so `./scripts/emit/run.sh` is cheap insurance before landing.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Jasper

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fj22SM897u8eAyy28YqV8R)_