### PR TITLE
fix(parser): the `\p{…}` Unicode property expression was never validated (TS1523/TS1525/TS1527/TS1528/TS1530)

### DIFF
--- a/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
@@ -308,6 +308,7 @@ impl ParserState {
             struct CharEscapeScanCtx<'a> {
                 body: &'a [u8],
                 strict_mode: bool,
+                unicode_sets_mode: bool,
                 end: usize,
             }
 
@@ -509,13 +510,16 @@ impl ParserState {
                         let escape_char = ch;
                         *pos += 1;
                         if *pos < end && body[*pos] == b'{' {
-                            *pos += 1;
-                            while *pos < end && body[*pos] != b'}' {
-                                *pos += 1;
-                            }
-                            if *pos < end {
-                                *pos += 1;
-                            }
+                            scan_unicode_property_value_expression(
+                                parser,
+                                emit,
+                                body,
+                                strict_mode,
+                                scan_ctx.unicode_sets_mode,
+                                end,
+                                pos,
+                                escape_start,
+                            );
                         } else if strict_mode {
                             let message = if escape_char == b'P' {
                                 "'\\P' must be followed by a Unicode property value expression enclosed in braces."
@@ -610,13 +614,119 @@ impl ParserState {
                 }
             }
 
+            /// Scans the `{…}` body of a `\p` / `\P` Unicode property value
+            /// expression, with `pos` positioned at the opening brace.
+            ///
+            /// Mirrors `tsc`'s regular-expression scanner: the property name
+            /// and value are scanned as ASCII word characters only, the two
+            /// halves are validated independently so `\p{=}` reports both
+            /// TS1523 and TS1525, and the closing brace is consumed only when
+            /// it is already at `pos`. Anything else is deliberately left for
+            /// the surrounding walker to report as ordinary regex text, which
+            /// is how `\p{ Script=Latin }` gets TS1527 followed by a TS1508 on
+            /// the trailing brace.
+            fn scan_unicode_property_value_expression(
+                parser: &mut ParserState,
+                emit: &impl Fn(&mut ParserState, usize, u32, &str, u32),
+                body: &[u8],
+                unicode_mode: bool,
+                unicode_sets_mode: bool,
+                end: usize,
+                pos: &mut usize,
+                escape_start: usize,
+            ) {
+                /// The binary Unicode properties of strings (ECMA-262
+                /// "Binary Unicode property of strings" table). Each matches a
+                /// sequence rather than a single character, so `\p{…}` accepts
+                /// them only under the Unicode Sets (`v`) flag.
+                const PROPERTIES_OF_STRINGS: [&[u8]; 7] = [
+                    b"Basic_Emoji",
+                    b"Emoji_Keycap_Sequence",
+                    b"RGI_Emoji",
+                    b"RGI_Emoji_Flag_Sequence",
+                    b"RGI_Emoji_Modifier_Sequence",
+                    b"RGI_Emoji_Tag_Sequence",
+                    b"RGI_Emoji_ZWJ_Sequence",
+                ];
+
+                fn scan_word(body: &[u8], end: usize, pos: &mut usize) -> usize {
+                    let start = *pos;
+                    while *pos < end && (body[*pos] == b'_' || body[*pos].is_ascii_alphanumeric()) {
+                        *pos += 1;
+                    }
+                    *pos - start
+                }
+
+                if !unicode_mode {
+                    emit(
+                        parser,
+                        escape_start,
+                        2,
+                        diagnostic_messages::UNICODE_PROPERTY_VALUE_EXPRESSIONS_ARE_ONLY_AVAILABLE_WHEN_THE_UNICODE_U_FLAG_OR,
+                        diagnostic_codes::UNICODE_PROPERTY_VALUE_EXPRESSIONS_ARE_ONLY_AVAILABLE_WHEN_THE_UNICODE_U_FLAG_OR,
+                    );
+                }
+
+                *pos += 1;
+                let name_start = *pos;
+                let name_len = scan_word(body, end, pos);
+
+                if *pos < end && body[*pos] == b'=' {
+                    *pos += 1;
+                    let value_start = *pos;
+                    let value_len = scan_word(body, end, pos);
+                    if name_len == 0 {
+                        emit(
+                            parser,
+                            name_start,
+                            0,
+                            diagnostic_messages::EXPECTED_A_UNICODE_PROPERTY_NAME,
+                            diagnostic_codes::EXPECTED_A_UNICODE_PROPERTY_NAME,
+                        );
+                    }
+                    if value_len == 0 {
+                        emit(
+                            parser,
+                            value_start,
+                            0,
+                            diagnostic_messages::EXPECTED_A_UNICODE_PROPERTY_VALUE,
+                            diagnostic_codes::EXPECTED_A_UNICODE_PROPERTY_VALUE,
+                        );
+                    }
+                } else {
+                    if name_len == 0 {
+                        emit(
+                            parser,
+                            name_start,
+                            0,
+                            diagnostic_messages::EXPECTED_A_UNICODE_PROPERTY_NAME_OR_VALUE,
+                            diagnostic_codes::EXPECTED_A_UNICODE_PROPERTY_NAME_OR_VALUE,
+                        );
+                    } else if !unicode_sets_mode
+                        && PROPERTIES_OF_STRINGS.contains(&&body[name_start..name_start + name_len])
+                    {
+                        emit(
+                            parser,
+                            name_start,
+                            name_len as u32,
+                            diagnostic_messages::ANY_UNICODE_PROPERTY_THAT_WOULD_POSSIBLY_MATCH_MORE_THAN_A_SINGLE_CHARACTER_IS_O,
+                            diagnostic_codes::ANY_UNICODE_PROPERTY_THAT_WOULD_POSSIBLY_MATCH_MORE_THAN_A_SINGLE_CHARACTER_IS_O,
+                        );
+                    }
+                }
+
+                if *pos < end && body[*pos] == b'}' {
+                    *pos += 1;
+                }
+            }
+
             fn scan_character_class_escape(
                 parser: &mut ParserState,
                 emit: &impl Fn(&mut ParserState, usize, u32, &str, u32),
                 body: &[u8],
                 strict_mode: bool,
                 unicode_sets_mode: bool,
-                _end: usize,
+                end: usize,
                 pos: &mut usize,
                 _start_pos: u32,
             ) -> Option<ClassAtomKind> {
@@ -712,58 +822,41 @@ impl ParserState {
                             Some(ClassAtomKind::Unknown)
                         }
                     }
-                    b'P' => {
+                    b'p' | b'P' => {
+                        let negated = body[*pos] == b'P';
                         *pos += 1;
                         if *pos < body.len() && body[*pos] == b'{' {
-                            *pos += 1;
-                            while *pos < body.len() && body[*pos] != b'}' {
-                                *pos += 1;
-                            }
-                            if *pos < body.len() {
-                                *pos += 1;
-                            }
+                            scan_unicode_property_value_expression(
+                                parser,
+                                emit,
+                                body,
+                                strict_mode,
+                                unicode_sets_mode,
+                                end,
+                                pos,
+                                start - 1,
+                            );
                             Some(ClassAtomKind::Class)
                         } else if strict_mode {
                             emit(
                                 parser,
                                 start - 1,
                                 2,
-                                "'\\P' must be followed by a Unicode property value expression enclosed in braces.",
+                                if negated {
+                                    "'\\P' must be followed by a Unicode property value expression enclosed in braces."
+                                } else {
+                                    "'\\p' must be followed by a Unicode property value expression enclosed in braces."
+                                },
                                 diagnostic_codes::MUST_BE_FOLLOWED_BY_A_UNICODE_PROPERTY_VALUE_EXPRESSION_ENCLOSED_IN_BRACES,
                             );
                             Some(ClassAtomKind::Class)
                         } else {
-                            // Annex B: `\P` without braces is treated as the
-                            // literal character `P`. Position is already past
-                            // `P`, so emit a Character atom directly rather
-                            // than returning None and letting the caller
-                            // re-scan (which would consume the next escape).
-                            Some(ClassAtomKind::Character)
-                        }
-                    }
-                    b'p' => {
-                        *pos += 1;
-                        if *pos < body.len() && body[*pos] == b'{' {
-                            *pos += 1;
-                            while *pos < body.len() && body[*pos] != b'}' {
-                                *pos += 1;
-                            }
-                            if *pos < body.len() {
-                                *pos += 1;
-                            }
-                            Some(ClassAtomKind::Class)
-                        } else if strict_mode {
-                            emit(
-                                parser,
-                                start - 1,
-                                2,
-                                "'\\p' must be followed by a Unicode property value expression enclosed in braces.",
-                                diagnostic_codes::MUST_BE_FOLLOWED_BY_A_UNICODE_PROPERTY_VALUE_EXPRESSION_ENCLOSED_IN_BRACES,
-                            );
-                            Some(ClassAtomKind::Class)
-                        } else {
-                            // Annex B: `\p` without braces is treated as the
-                            // literal character `p`. See `\P` above.
+                            // Annex B: `\p` / `\P` without braces is treated as
+                            // the literal character `p` / `P`. Position is
+                            // already past it, so emit a Character atom
+                            // directly rather than returning None and letting
+                            // the caller re-scan (which would consume the next
+                            // escape).
                             Some(ClassAtomKind::Character)
                         }
                     }
@@ -808,6 +901,7 @@ impl ParserState {
                                 &CharEscapeScanCtx {
                                     body: ctx.body,
                                     strict_mode: ctx.strict_mode,
+                                    unicode_sets_mode: ctx.unicode_sets_mode,
                                     end: ctx.body_end,
                                 },
                                 pos,
@@ -994,6 +1088,7 @@ impl ParserState {
                                     &CharEscapeScanCtx {
                                         body: ctx.body,
                                         strict_mode: ctx.strict_mode,
+                                        unicode_sets_mode: ctx.unicode_sets_mode,
                                         end: ctx.body_end,
                                     },
                                     pos,

--- a/crates/tsz-parser/tests/parser_improvement_regex_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_regex_recovery_tests.rs
@@ -674,3 +674,101 @@ fn test_regex_trailing_non_identifier_codepoint_ends_flag_scan() {
         "non-ID_Continue code point after flags must not emit TS1499, got {diagnostics:?}"
     );
 }
+
+/// `\p{…}` / `\P{…}` Unicode property value expressions, pinned against
+/// `typescript@7.0.2` (`--noEmit --strict --target esnext --module esnext
+/// --lib esnext`). Every fingerprint below — including the two TS1508
+/// follow-ons on the malformed tails, and the clean rows that must stay
+/// silent — was taken from an oracle run over this exact source.
+#[test]
+fn test_regex_unicode_property_escape_diagnostics_match_tsc() {
+    let source = r#"
+const unicodePropertyEscapes: RegExp[] = [
+  /\p{L}/u,
+  /\p{Script=Latin}/u,
+  /\p{General_Category=Letter}/u,
+  /\p{}/u,
+  /\P{}/u,
+  /\p{=Letter}/u,
+  /\p{Script=}/u,
+  /\p{=}/u,
+  /\p{RGI_Emoji}/u,
+  /\p{Basic_Emoji}/u,
+  /[\p{RGI_Emoji}]/u,
+  /\p{L}/,
+  /\P{L}/,
+  /\p{}/,
+  /\p{RGI_Emoji}/,
+  /a\p{L}b/,
+  /\p{Ω}/u,
+  /\p{ Script=Latin }/u,
+];
+"#;
+    let (parser, _root) = parse_source(source);
+
+    let diagnostics = parser.get_diagnostics();
+    let line_map = LineMap::build(source);
+
+    let mut actual: Vec<(u32, u32, u32)> = diagnostics
+        .iter()
+        .map(|d| {
+            let pos = line_map.offset_to_position(d.start, source);
+            (pos.line + 1, pos.character + 1, d.code)
+        })
+        .collect();
+    actual.sort_unstable();
+
+    let expected: Vec<(u32, u32, u32)> = vec![
+        (6, 7, diagnostic_codes::EXPECTED_A_UNICODE_PROPERTY_NAME_OR_VALUE),
+        (7, 7, diagnostic_codes::EXPECTED_A_UNICODE_PROPERTY_NAME_OR_VALUE),
+        (8, 7, diagnostic_codes::EXPECTED_A_UNICODE_PROPERTY_NAME),
+        (9, 14, diagnostic_codes::EXPECTED_A_UNICODE_PROPERTY_VALUE),
+        (10, 7, diagnostic_codes::EXPECTED_A_UNICODE_PROPERTY_NAME),
+        (10, 8, diagnostic_codes::EXPECTED_A_UNICODE_PROPERTY_VALUE),
+        (11, 7, diagnostic_codes::ANY_UNICODE_PROPERTY_THAT_WOULD_POSSIBLY_MATCH_MORE_THAN_A_SINGLE_CHARACTER_IS_O),
+        (12, 7, diagnostic_codes::ANY_UNICODE_PROPERTY_THAT_WOULD_POSSIBLY_MATCH_MORE_THAN_A_SINGLE_CHARACTER_IS_O),
+        (13, 8, diagnostic_codes::ANY_UNICODE_PROPERTY_THAT_WOULD_POSSIBLY_MATCH_MORE_THAN_A_SINGLE_CHARACTER_IS_O),
+        (14, 4, diagnostic_codes::UNICODE_PROPERTY_VALUE_EXPRESSIONS_ARE_ONLY_AVAILABLE_WHEN_THE_UNICODE_U_FLAG_OR),
+        (15, 4, diagnostic_codes::UNICODE_PROPERTY_VALUE_EXPRESSIONS_ARE_ONLY_AVAILABLE_WHEN_THE_UNICODE_U_FLAG_OR),
+        (16, 4, diagnostic_codes::UNICODE_PROPERTY_VALUE_EXPRESSIONS_ARE_ONLY_AVAILABLE_WHEN_THE_UNICODE_U_FLAG_OR),
+        (16, 7, diagnostic_codes::EXPECTED_A_UNICODE_PROPERTY_NAME_OR_VALUE),
+        (17, 4, diagnostic_codes::UNICODE_PROPERTY_VALUE_EXPRESSIONS_ARE_ONLY_AVAILABLE_WHEN_THE_UNICODE_U_FLAG_OR),
+        (17, 7, diagnostic_codes::ANY_UNICODE_PROPERTY_THAT_WOULD_POSSIBLY_MATCH_MORE_THAN_A_SINGLE_CHARACTER_IS_O),
+        (18, 5, diagnostic_codes::UNICODE_PROPERTY_VALUE_EXPRESSIONS_ARE_ONLY_AVAILABLE_WHEN_THE_UNICODE_U_FLAG_OR),
+        (19, 7, diagnostic_codes::EXPECTED_A_UNICODE_PROPERTY_NAME_OR_VALUE),
+        (19, 8, diagnostic_codes::UNEXPECTED_DID_YOU_MEAN_TO_ESCAPE_IT_WITH_BACKSLASH),
+        (20, 7, diagnostic_codes::EXPECTED_A_UNICODE_PROPERTY_NAME_OR_VALUE),
+        (20, 21, diagnostic_codes::UNEXPECTED_DID_YOU_MEAN_TO_ESCAPE_IT_WITH_BACKSLASH),
+    ];
+
+    assert_eq!(
+        actual, expected,
+        "Unicode property escape diagnostics should match tsc exactly, got: {diagnostics:?}"
+    );
+}
+
+/// The Unicode Sets (`v`) flag makes the properties-of-strings legal, so the
+/// same sources that draw TS1528 under `u` must stay silent under `v`.
+#[test]
+fn test_regex_properties_of_strings_are_accepted_under_the_v_flag() {
+    let source = r#"
+const underV: RegExp[] = [
+  /\p{RGI_Emoji}/v,
+  /\p{Basic_Emoji}/v,
+  /\p{Emoji_Keycap_Sequence}/v,
+  /\p{RGI_Emoji_Modifier_Sequence}/v,
+  /\p{RGI_Emoji_Flag_Sequence}/v,
+  /\p{RGI_Emoji_Tag_Sequence}/v,
+  /\p{RGI_Emoji_ZWJ_Sequence}/v,
+  /[\p{RGI_Emoji}]/v,
+];
+"#;
+    let (parser, _root) = parse_source(source);
+
+    let diagnostics = parser.get_diagnostics();
+
+    assert!(
+        diagnostics.is_empty(),
+        "Properties of strings are legal under the v flag, got: {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
Wires five of the ~20 regex codes enumerated in #16291, at the parser's regex walker.

**Structural rule.** When a regular expression contains a `\p{…}` / `\P{…}` Unicode property value expression, tsc validates the braced body — reporting TS1527 for an empty name-or-value, TS1523/TS1525 for the empty halves of a `name=value` form, TS1528 for a property of strings without the Unicode Sets (`v`) flag, and TS1530 when neither `u` nor `v` is set — and tsz now does the same through the parser's regex-literal validator (`state_expressions_literals_regex.rs`), which is where the rest of the regex grammar family already lives.

The wrong semantic operation was **parser recovery / grammar validation**, not a missing report: both escape paths consumed the body with `while body[pos] != b'}' { pos += 1 }`, so the whole family was *unreachable*, not merely unwired. Only TS1531 (`\p` with no brace) fired.

`scan_unicode_property_value_expression` is now shared by the class-atom path (`scan_character_class_escape`) and the atom-escape path (`scan_character_escape`) — previously two independent copies of the same skip loop, which is why `[\p{RGI_Emoji}]` and `\p{RGI_Emoji}` had to be verified separately. It mirrors tsc's scanner on four points that each showed up as an oracle diff before they were matched:

1. **ASCII-only word scan.** The file's existing `is_word_char` accepts any byte ≥ 0x80; tsc's `isWordCharacter` does not. `\p{Ω}` must report TS1527 (empty name), then TS1508 on the brace.
2. **Both halves validated, no early return.** `\p{=}` reports TS1523 *and* TS1525.
3. **TS1530 is emitted ahead of, not instead of, the structural checks.** `/\p{}/` with no flag reports TS1530 **and** TS1527; `/\p{RGI_Emoji}/` reports TS1530 **and** TS1528. My first attempt gated the inner checks on unicode mode and lost the second diagnostic on both.
4. **The closing brace is consumed only when it is already at `pos`.** That is what leaves `\p{ Script=Latin }` with a TS1508 on its trailing brace instead of silently swallowing the tail.

**Anti-hardcoding.** The one table added is the 7-entry ECMA-262 "binary Unicode property of strings" set (`Basic_Emoji`, `Emoji_Keycap_Sequence`, `RGI_Emoji`, and the four RGI sequence properties). These are spec-defined grammar tokens, not user-chosen identifiers — the same category as a keyword table. All 7 are oracle-pinned. No predicate reads rendered output, and no check is scoped to a file or test.

**Deliberately out of scope.** TS1524 / TS1526 / TS1529 (unknown property name / value / name-or-value) need the full `General_Category` + `Script` + binary-property tables. A *missing* entry there yields a **false positive** on valid code, and the tsc 7.0.2 npm package ships a native binary with no extractable JS tables, so the lists cannot be lifted mechanically. That slice is written up in a comment on #16291 rather than guessed at here.

## Goal
Goal: hold

## Verification
- **Oracle parity matrix, `typescript@7.0.2` vs this build, diagnostic code + line + column compared exactly:**
  - 43/43 exact at `--target es2022` — the 5 new codes across both the atom and character-class paths, plus negative controls that must stay silent (`\p{L}`, `\p{Script=Latin}`, `\p{General_Category=Letter}`, `\p{gc=L}`, `\p{Script_Extensions=Greek}`, `\p{Alphabetic}`, `\pL`), adjacent shapes (`\P` negation, inside `[...]`, quantified `{2,3}`, in a range `[a-\p{L}]`, alongside a backreference, mid-pattern `a\p{L}b`, trailing text `\p{RGI_Emoji}x`, repeated `\p{L}\p{}`), and malformed tails (`\p{Ω}`, `\p{ Script=Latin }`).
  - 8/10 exact at `--target esnext` with the `v` flag. Both residuals are pre-existing and unrelated to this diff — see the note below.
  - Before this change the same matrix was 4/22 on the `\p` rows: everything except `[\p{RGI_Emoji}]`, `\pL` and the clean controls was a missed diagnostic.
- `cargo test -p tsz-parser --lib` — **1566 passed, 0 failed** (was 1564 before; +2 are the new tests).
- Two new regression tests in `parser_improvement_regex_recovery_tests.rs`: a 20-fingerprint `(line, column, code)` table generated from an oracle run over that exact source — including the two TS1508 follow-ons and the rows that must stay clean — and a v-flag test asserting all 7 properties of strings are silent under `v`.
- `cargo clippy -p tsz-parser --all-targets -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py` — passed. Touched file is 1776/2000 lines.
- `scripts/conformance/compare-to-parent.sh` — started against this head; result posted as a follow-up comment. Parser-only grammar change with no shared predicate weakened, so the expected result is 0 newly failing.

**Two pre-existing divergences found while measuring, neither introduced here and neither in this family:**
- `/\q{ab}/v` → tsc TS1511 (`'\q' is only available inside character class`), tsz TS1535. TS1511 is on #16291's unwired list; this is a *wrong-code*, not a missing one, so that slice is smaller than the issue implies.
- `/\p{RGI_Emoji}/uv` → tsc reports TS1528 alongside TS1502, tsz reports only TS1502, and at column 28 rather than 27. tsc evidently does not treat `v` as active once the `u`+`v` conflict is reported. Matching that means redefining the shared `unicode_sets_mode` flag, which would also move `\q` and the class-set operators — too wide for this slice, on an input that is already a hard error.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Cinnabar


---
_Generated by [Claude Code](https://claude.ai/code/session_01DTDLHRSC8Er6v2mFcmXMUd)_