### PR TITLE
fix(parser): legacy octal/decimal escapes are validated inside a regex character class (TS1487/TS1536/TS1537)

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1444,9 +1444,12 @@ pub(super) const fn is_non_suppressing_parse_error(code: u32) -> bool {
         | 1262 // 'await' at top level
         | 1359 // 'await' in async context
         | 1492 // 'using' declarations may not have binding patterns (grammar constraint, AST is valid)
+        | 1487 // Octal escape sequences are not allowed (regex `\0`-prefixed decimal escape, AST is valid)
         | 1499 // Unknown regular expression flag (grammar check in tsc's checker, not a parse failure)
         | 1500 // Duplicate regular expression flag (grammar check, AST is valid)
         | 1502 // The Unicode 'u' and 'v' flags cannot be set simultaneously (grammar check, AST is valid)
+        | 1536 // Octal escape sequences and backreferences are not allowed in a character class (regex grammar, AST is valid)
+        | 1537 // Decimal escape sequences and backreferences are not allowed in a character class (regex grammar, AST is valid)
         | 17019 // '?' at end of type is not valid TS syntax (parser recovers valid AST)
         | 17020 // '?' at start of type is not valid TS syntax (parser recovers valid AST)
     )

--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -250,6 +250,10 @@ mod close_brace_node_end_position_remaining_tests;
 mod decorator_tests;
 
 #[cfg(test)]
+#[path = "../../tests/regex_octal_decimal_class_escape_tests.rs"]
+mod regex_octal_decimal_class_escape_tests;
+
+#[cfg(test)]
 #[path = "../../tests/modifier_ordering_tests.rs"]
 mod modifier_ordering_tests;
 

--- a/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
@@ -5,7 +5,7 @@
 
 use super::state::ParserState;
 use crate::parser::{NodeIndex, node::LiteralData};
-use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages};
+use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
 use tsz_scanner::SyntaxKind;
 use tsz_scanner::scanner_impl::TokenFlags;
 
@@ -319,6 +319,36 @@ impl ParserState {
                 *pos - start
             }
 
+            /// Consume a legacy (Annex-B) octal digit run starting at `pos`
+            /// (which points at the leading digit, already known to be
+            /// `0`..=`7`) and return the exclusive end. Mirrors tsc's
+            /// per-leading-digit maximum: a leading `0`-`3` may pull up to 3
+            /// octal digits (`\377` fits in a byte), a leading `4`-`7` only 2
+            /// (`\477` parses as `\47` followed by a literal `7`).
+            fn scan_legacy_octal_digits(body: &[u8], end: usize, pos: usize) -> usize {
+                let max_digits = if body[pos] <= b'3' { 3 } else { 2 };
+                let mut octal_end = pos + 1;
+                let mut count = 1usize;
+                while count < max_digits
+                    && octal_end < end
+                    && (b'0'..=b'7').contains(&body[octal_end])
+                {
+                    octal_end += 1;
+                    count += 1;
+                }
+                octal_end
+            }
+
+            /// Interpret `body[start..octal_end]` (a run produced by
+            /// `scan_legacy_octal_digits`) as a base-8 integer.
+            fn legacy_octal_value(body: &[u8], start: usize, octal_end: usize) -> u32 {
+                let mut value = 0u32;
+                for &byte in &body[start..octal_end] {
+                    value = value * 8 + u32::from(byte - b'0');
+                }
+                value
+            }
+
             const fn hex_byte_value(byte: u8) -> Option<u32> {
                 match byte {
                     b'0'..=b'9' => Some((byte - b'0') as u32),
@@ -574,7 +604,75 @@ impl ParserState {
                             *pos += 1;
                         }
                     }
-                    b'0'..=b'9' => {
+                    // `\0` is judged the same way in every context — atom
+                    // position or character class — so this arm is not
+                    // gated on `atom_escape`. Mirrors tsc's per-leading-digit
+                    // octal maximum (leading 0-3 allows up to 3 octal digits,
+                    // leading 4-7 only 2) via the same computation as
+                    // `report_invalid_template_octal_escape`.
+                    b'0' => {
+                        // `\0` not followed by another digit is the NUL
+                        // escape, legal everywhere.
+                        if *pos + 1 < end && body[*pos + 1].is_ascii_digit() {
+                            let octal_end = scan_legacy_octal_digits(body, end, *pos);
+                            let value = legacy_octal_value(body, *pos, octal_end);
+                            let message = format_message(
+                                diagnostic_messages::OCTAL_ESCAPE_SEQUENCES_ARE_NOT_ALLOWED_USE_THE_SYNTAX,
+                                &[&format!("\\x{value:02x}")],
+                            );
+                            emit(
+                                parser,
+                                escape_start,
+                                (octal_end - escape_start) as u32,
+                                &message,
+                                diagnostic_codes::OCTAL_ESCAPE_SEQUENCES_ARE_NOT_ALLOWED_USE_THE_SYNTAX,
+                            );
+                            *pos = octal_end;
+                        } else {
+                            *pos += 1;
+                        }
+                    }
+                    // `\1`..`\9` outside a character class are backreferences
+                    // (a distinct, not-yet-validated family — #16291/#16296);
+                    // this arm only judges them inside a class, where a
+                    // decimal escape is never a backreference and always a
+                    // legacy octal (`\1`-`\7`) or bare decimal (`\8`/`\9`)
+                    // escape instead.
+                    b'1'..=b'7' if !atom_escape => {
+                        let octal_end = scan_legacy_octal_digits(body, end, *pos);
+                        let value = legacy_octal_value(body, *pos, octal_end);
+                        let message = format_message(
+                            diagnostic_messages::OCTAL_ESCAPE_SEQUENCES_AND_BACKREFERENCES_ARE_NOT_ALLOWED_IN_A_CHARACTER_CLASS_I,
+                            &[&format!("\\x{value:02x}")],
+                        );
+                        emit(
+                            parser,
+                            escape_start,
+                            (octal_end - escape_start) as u32,
+                            &message,
+                            diagnostic_codes::OCTAL_ESCAPE_SEQUENCES_AND_BACKREFERENCES_ARE_NOT_ALLOWED_IN_A_CHARACTER_CLASS_I,
+                        );
+                        *pos = octal_end;
+                    }
+                    b'8' | b'9' if !atom_escape => {
+                        emit(
+                            parser,
+                            escape_start,
+                            (*pos + 1 - escape_start) as u32,
+                            diagnostic_messages::DECIMAL_ESCAPE_SEQUENCES_AND_BACKREFERENCES_ARE_NOT_ALLOWED_IN_A_CHARACTER_CLASS,
+                            diagnostic_codes::DECIMAL_ESCAPE_SEQUENCES_AND_BACKREFERENCES_ARE_NOT_ALLOWED_IN_A_CHARACTER_CLASS,
+                        );
+                        *pos += 1;
+                    }
+                    // `\1`..`\9` at atom position (`atom_escape == true`):
+                    // a decimal escape here is a backreference, a distinct
+                    // family this arm does not validate (#16291/#16296).
+                    // Consume the whole digit run without judgement, same as
+                    // every digit did before this arm split — falling
+                    // through to the generic "cannot be escaped" arm below
+                    // would wrongly diagnose a plain backreference and only
+                    // advance by one byte, desynchronising the scan.
+                    b'1'..=b'9' => {
                         while *pos < end && body[*pos].is_ascii_digit() {
                             *pos += 1;
                         }

--- a/crates/tsz-parser/tests/regex_octal_decimal_class_escape_tests.rs
+++ b/crates/tsz-parser/tests/regex_octal_decimal_class_escape_tests.rs
@@ -1,0 +1,224 @@
+//! Legacy octal (TS1487/TS1536) and decimal (TS1537) escape validation for
+//! digit escapes reached by a regular-expression literal's character-class
+//! walker (`crates/tsz-parser/src/parser/state_expressions_literals_regex.rs`,
+//! `scan_character_escape`'s `\0`..`\9` arms).
+//!
+//! `\1`..`\9` at atom position (outside a class) are backreferences, a
+//! distinct family (#16291/#16296) this suite does not touch — see
+//! `atom_position_backreference_digits_are_not_judged_by_this_family` below,
+//! which pins that this family must not reach them.
+//!
+//! Every row is pinned against `typescript@7.0.2`.
+use crate::parser::test_fixture::parse_source;
+
+fn codes(source: &str) -> Vec<u32> {
+    let (parser, _root) = parse_source(source);
+    parser.get_diagnostics().iter().map(|d| d.code).collect()
+}
+
+fn message(source: &str) -> String {
+    let (parser, _root) = parse_source(source);
+    parser
+        .get_diagnostics()
+        .first()
+        .map_or_else(String::new, |d| d.message.clone())
+}
+
+// ---------------------------------------------------------------------------
+// `\0` — legal everywhere unless followed by another digit
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bare_null_escape_in_a_character_class_is_legal() {
+    assert!(codes(r"const a = /[\0]/;").is_empty());
+}
+
+/// `\0` followed by a non-digit is still the NUL escape, not the start of an
+/// octal run.
+#[test]
+fn null_escape_followed_by_a_non_digit_is_legal() {
+    assert!(codes(r"const a = /[\0a]/;").is_empty());
+}
+
+#[test]
+fn null_escape_followed_by_a_digit_reports_ts1487_in_a_character_class() {
+    assert_eq!(codes(r"const a = /[\01]/;"), vec![1487]);
+}
+
+/// The suggested replacement renders the actual octal digits consumed
+/// (`\x00`), not the trailing non-octal `8`.
+#[test]
+fn null_escape_followed_by_a_non_octal_digit_still_reports_ts1487() {
+    assert_eq!(codes(r"const a = /[\08]/;"), vec![1487]);
+    assert!(
+        message(r"const a = /[\08]/;").contains("\\x00"),
+        "must suggest \\x00: {}",
+        message(r"const a = /[\08]/;")
+    );
+}
+
+/// `\0` followed by a digit is TS1487 at atom position too — this half of
+/// the rule is not specific to character classes.
+#[test]
+fn null_escape_followed_by_a_digit_reports_ts1487_outside_a_character_class() {
+    assert_eq!(codes(r"const a = /\01/;"), vec![1487]);
+}
+
+#[test]
+fn bare_null_escape_outside_a_character_class_is_legal() {
+    assert!(codes(r"const a = /\0/;").is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// TS1536 — a leading `1`-`7` digit in a character class is a legacy octal
+// escape
+// ---------------------------------------------------------------------------
+
+#[test]
+fn single_octal_digit_in_a_character_class_reports_ts1536() {
+    assert_eq!(codes(r"const a = /[\1]/;"), vec![1536]);
+    assert_eq!(codes(r"const a = /[\7]/;"), vec![1536]);
+}
+
+/// Leading `0`-`3` may pull up to 3 octal digits: `\123` is one escape with
+/// value 0o123 = 0x53.
+#[test]
+fn leading_zero_to_three_consumes_up_to_three_octal_digits() {
+    assert_eq!(codes(r"const a = /[\123]/;"), vec![1536]);
+    assert!(
+        message(r"const a = /[\123]/;").contains("\\x53"),
+        "must render the full 3-digit octal value: {}",
+        message(r"const a = /[\123]/;")
+    );
+}
+
+/// Leading `4`-`7` may only pull 2 octal digits: `\400` is `\40` (value
+/// 0o40 = 0x20) followed by a literal `0`, not a 3-digit escape.
+#[test]
+fn leading_four_to_seven_consumes_only_two_octal_digits() {
+    assert_eq!(codes(r"const a = /[\400]/;"), vec![1536]);
+    assert!(
+        message(r"const a = /[\400]/;").contains("\\x20"),
+        "must truncate to the 2-digit octal value: {}",
+        message(r"const a = /[\400]/;")
+    );
+    assert_eq!(codes(r"const a = /[\777]/;"), vec![1536]);
+    assert!(
+        message(r"const a = /[\777]/;").contains("\\x3f"),
+        "must truncate to the 2-digit octal value: {}",
+        message(r"const a = /[\777]/;")
+    );
+}
+
+/// A 2-digit run entirely within the leading-0-3 budget still stops at the
+/// digits actually present.
+#[test]
+fn short_octal_run_uses_only_the_digits_present() {
+    assert_eq!(codes(r"const a = /[\12]/;"), vec![1536]);
+    assert!(
+        message(r"const a = /[\12]/;").contains("\\x0a"),
+        "0o12 == 0x0a: {}",
+        message(r"const a = /[\12]/;")
+    );
+}
+
+/// Not gated on the `u` flag — tsc validates this with and without Unicode
+/// mode.
+#[test]
+fn octal_class_escape_reports_ts1536_under_the_unicode_flag() {
+    assert_eq!(codes(r"const a = /[\1]/u;"), vec![1536]);
+}
+
+/// A class-escape octal digit at the start of a range is still judged before
+/// the `-` is parsed.
+#[test]
+fn octal_class_escape_at_the_start_of_a_range_reports_ts1536() {
+    assert_eq!(codes(r"const a = /[\1-3]/;"), vec![1536]);
+}
+
+/// Two independent octal escapes in the same class each report.
+#[test]
+fn two_octal_class_escapes_each_report() {
+    assert_eq!(codes(r"const a = /[\1\2]/;"), vec![1536, 1536]);
+}
+
+// ---------------------------------------------------------------------------
+// TS1537 — a leading `8`/`9` digit in a character class is a decimal escape
+// ---------------------------------------------------------------------------
+
+#[test]
+fn leading_eight_or_nine_in_a_character_class_reports_ts1537() {
+    assert_eq!(codes(r"const a = /[\8]/;"), vec![1537]);
+    assert_eq!(codes(r"const a = /[\9]/;"), vec![1537]);
+}
+
+/// The span covers only the first digit — `\89` is `\8` (TS1537) followed by
+/// a literal `9`, not a two-digit escape.
+#[test]
+fn decimal_class_escape_span_is_one_digit_only() {
+    assert_eq!(codes(r"const a = /[\89]/;"), vec![1537]);
+}
+
+#[test]
+fn decimal_class_escape_reports_ts1537_under_the_unicode_flag() {
+    assert_eq!(codes(r"const a = /[\8]/u;"), vec![1537]);
+}
+
+// ---------------------------------------------------------------------------
+// Not gated on strict mode
+// ---------------------------------------------------------------------------
+
+#[test]
+fn octal_and_decimal_class_escapes_report_without_strict_mode() {
+    let (parser, _root) = parse_source(r"const a = /[\1]/;");
+    assert!(parser.get_diagnostics().iter().any(|d| d.code == 1536));
+    let (parser, _root) = parse_source(r"const a = /[\8]/;");
+    assert!(parser.get_diagnostics().iter().any(|d| d.code == 1537));
+}
+
+// ---------------------------------------------------------------------------
+// Negative / boundary controls
+// ---------------------------------------------------------------------------
+
+/// `\1`..`\9` outside a character class are backreferences, a distinct
+/// family (#16291/#16296) that this family must not reach — neither TS1536
+/// nor TS1537 fires there, whatever backreference validation eventually
+/// decides.
+#[test]
+fn atom_position_backreference_digits_are_not_judged_by_this_family() {
+    for source in [
+        r"const a = /\1/;",
+        r"const a = /\8/;",
+        r"const a = /(a)\1/;",
+    ] {
+        let cs = codes(source);
+        assert!(
+            !cs.contains(&1536) && !cs.contains(&1537),
+            "atom-position digit escapes must stay outside the character-class family, got {cs:?} for {source}"
+        );
+    }
+}
+
+/// Non-digit character-class escapes are unaffected.
+#[test]
+fn non_digit_character_class_escapes_stay_clean() {
+    assert!(codes(r"const a = /[\d\s\w]/;").is_empty());
+    assert!(codes(r"const a = /[\x41]/;").is_empty());
+}
+
+/// A realistic pattern with a digit-shaped literal (not an escape) inside a
+/// class stays clean — this family only judges `\`-prefixed digits.
+#[test]
+fn realistic_patterns_report_nothing() {
+    for source in [
+        r"const a = /[0-9]/;",
+        r"const a = /[a-zA-Z0-9_]/;",
+        r"const a = /^[\d]{3}-[\d]{4}$/;",
+    ] {
+        assert!(
+            codes(source).is_empty(),
+            "expected no diagnostics for {source}, got {:?}",
+            codes(source)
+        );
+    }
+}


### PR DESCRIPTION
Part of #16291's regex-grammar family (the ~19-code cluster Jasper's 12:12Z comment on that issue scoped but did not fully implement — #16296, open, covers the sibling backreference codes TS1533/TS1534).

**Structural rule.** `tsc`'s regex scanner judges every decimal-digit escape by leading digit and context. `\0` alone is the NUL escape everywhere. `\0` followed by another digit is a legacy Annex-B octal escape (TS1487) in both an atom position and a character class. Inside a character class specifically, `\1`-`\7` is a second, class-scoped legacy octal escape (TS1536) and `\8`/`\9` is a bare decimal escape (TS1537) — neither can be a backreference there, since a character class has no backreference syntax at all. tsz's parser walker (`scan_character_escape` in `crates/tsz-parser/src/parser/state_expressions_literals_regex.rs`, the structural port of tsc's `scanRegularExpressionWorker`) consumed every digit run unconditionally with no judgement, owner layer: parser.

**Scope boundary.** `\1`-`\9` at atom position (outside a class) are backreferences — a separate, not-yet-validated family (#16291/#16296, TS1533/TS1534). This fix explicitly gates its `\1`-`\9` arms on `!atom_escape` so it cannot reach them, and keeps a fallback arm that preserves the pre-existing "consume the digit run, no diagnostic" behavior at atom position, so #16296 (or any future backreference fix) can still land as an independent change without a merge conflict in behavior.

## Goal
Goal: hold

## Verification

**Oracle-pinned against `typescript@7.0.2`** (`--noEmit --strict --pretty false --lib es2022 --target es2022`), a 24-fixture combined file compared byte-for-byte between the pinned oracle and the built `tsz` CLI: every row but the two atom-position backreference rows (explicitly out of scope, see above) matches column-for-column and message-for-message, including the Annex-B per-leading-digit octal-digit-count truncation (leading `0`-`3` allows up to 3 octal digits — `\123` → `\x53`; leading `4`-`7` only 2 — `\400` → `\x20`, `\777` → `\x3f`).

**20 new adjacent-case unit tests** in `crates/tsz-parser/tests/regex_octal_decimal_class_escape_tests.rs`: `\0` alone/followed-by-digit/followed-by-non-digit in both contexts, `\1`-`\7` short and truncated octal runs, `\8`/`\9` decimal (span is one digit only — `\89` is `\8` + literal `9`), not gated on strict mode or the `u` flag, a range-start position (`[\1-3]`), and a negative control proving atom-position backreference digits (`\1`, `\8`, `(a)\1`) are never reached by this family.

**Non-vacuity proven**: reverted the parser fix via `git stash`, re-ran the new suite — 14 of 20 tests fail (exactly the fix-dependent rows), the 6 controls (negative cases + `\0`-alone cases) stay green.

**Full suites, all green:** `cargo test -p tsz-parser --lib` 1584/1584. `cargo test -p tsz-cli --lib check_utils` 106/106. `cargo fmt --all` clean. `cargo clippy -p tsz-parser -p tsz-cli --lib --tests --all-targets -- -D warnings` clean. `python3 scripts/arch/arch_guard.py` → "Architecture guardrails passed."

**Suppression-set membership:** added 1487/1536/1537 to `is_non_suppressing_parse_error` (`crates/tsz-cli/src/driver/check_utils.rs`), the same set #16296 adds 1533/1534 to — per that PR's own finding, an unlisted newly-wired parser-emitted grammar code sets `has_syntax_parse_errors` and silently suppresses unrelated check-time diagnostics (e.g. TS2322/TS2304) elsewhere in the same file.

**Two-sided `compare-to-parent.sh origin/main`:** running in the background at commit `b558437`; will post the number and queue once it reports 0 newly-failing (expected zero-movement signature per the board's standing note — this is a pure missing-diagnostic family with no other-direction divergence measured).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01698XfRXeijg4f2edWxBxyK)_