### PR TITLE
fix(checker): TS1230 (type predicate cannot reference binding pattern element) was never wired

### DIFF
--- a/crates/tsz-checker/src/checkers/signature_builder.rs
+++ b/crates/tsz-checker/src/checkers/signature_builder.rs
@@ -35,7 +35,7 @@ impl<'a> CheckerState<'a> {
         self.clear_excluded_params_for_type_param_constraints();
         let (params, this_type) = self.extract_params_from_parameter_list(&func.parameters);
         let (return_type, type_predicate) =
-            self.return_type_and_predicate(func.type_annotation, &params);
+            self.return_type_and_predicate(func.type_annotation, &params, &func.parameters.nodes);
         self.pop_type_parameters(type_param_updates);
         self.pop_type_parameters(enclosing_updates);
 
@@ -240,7 +240,11 @@ impl<'a> CheckerState<'a> {
             }
             (inferred, None)
         } else {
-            self.return_type_and_predicate(method.type_annotation, &params)
+            self.return_type_and_predicate(
+                method.type_annotation,
+                &params,
+                &method.parameters.nodes,
+            )
         };
 
         // Check JSDoc @returns for type predicates on class methods.
@@ -583,12 +587,18 @@ impl<'a> CheckerState<'a> {
     // =========================================================================
 
     /// Extract return type and type predicate from a type annotation (declaration context).
+    ///
+    /// `raw_params` are the parameter declaration nodes backing `params`, used
+    /// only to resolve a type predicate's subject identifier against
+    /// destructuring binding patterns (see
+    /// [`Self::type_predicate_name_matches_binding_element`]).
     pub(crate) fn return_type_and_predicate(
         &mut self,
         type_annotation: NodeIndex,
         params: &[tsz_solver::ParamInfo],
+        raw_params: &[NodeIndex],
     ) -> (TypeId, Option<tsz_solver::TypePredicate>) {
-        self.return_type_and_predicate_impl(type_annotation, params, false)
+        self.return_type_and_predicate_impl(type_annotation, params, raw_params, false)
     }
 
     /// Extract return type and type predicate from a type literal annotation.
@@ -596,8 +606,9 @@ impl<'a> CheckerState<'a> {
         &mut self,
         type_annotation: NodeIndex,
         params: &[tsz_solver::ParamInfo],
+        raw_params: &[NodeIndex],
     ) -> (TypeId, Option<tsz_solver::TypePredicate>) {
-        self.return_type_and_predicate_impl(type_annotation, params, true)
+        self.return_type_and_predicate_impl(type_annotation, params, raw_params, true)
     }
 
     /// Shared implementation for return type + type predicate extraction.
@@ -607,6 +618,7 @@ impl<'a> CheckerState<'a> {
         &mut self,
         type_annotation: NodeIndex,
         params: &[tsz_solver::ParamInfo],
+        raw_params: &[NodeIndex],
         in_type_literal: bool,
     ) -> (TypeId, Option<tsz_solver::TypePredicate>) {
         use tsz_solver::TypePredicateTarget;
@@ -668,6 +680,22 @@ impl<'a> CheckerState<'a> {
                 // plain `X is T` predicate it coincides with `node.pos`, so this is a
                 // no-op there). Mirrors the rest-parameter branch below.
                 let error_node = self.ctx.arena.get(data.parameter_name).unwrap_or(node);
+                // `name` never matched a top-level parameter above. tsc still
+                // resolves it against the whole parameter list, including
+                // destructuring binding patterns, and reports TS1230 when it
+                // names an element the pattern introduces — a predicate's
+                // subject must be a plain parameter, never a destructured
+                // binding (renamed, nested, array, or rest).
+                if self.type_predicate_name_matches_binding_element(raw_params, &name_text) {
+                    self.ctx.error(
+                        error_node.pos,
+                        error_node.end.saturating_sub(error_node.pos),
+                        diagnostic_messages::A_TYPE_PREDICATE_CANNOT_REFERENCE_ELEMENT_IN_A_BINDING_PATTERN
+                            .replace("{0}", &name_text),
+                        diagnostic_codes::A_TYPE_PREDICATE_CANNOT_REFERENCE_ELEMENT_IN_A_BINDING_PATTERN,
+                    );
+                    return (return_type, None);
+                }
                 self.ctx.error(
                     error_node.pos,
                     error_node.end.saturating_sub(error_node.pos),
@@ -726,4 +754,65 @@ impl<'a> CheckerState<'a> {
             _ => None,
         }
     }
+
+    /// True when `name_text` is bound by an element of one of `raw_params`'
+    /// destructuring binding patterns (any nesting depth, object or array,
+    /// including renamed and rest elements) — checked only after `name_text`
+    /// has already failed to match a top-level parameter name.
+    fn type_predicate_name_matches_binding_element(
+        &self,
+        raw_params: &[NodeIndex],
+        name_text: &str,
+    ) -> bool {
+        raw_params.iter().any(|&param_idx| {
+            self.ctx
+                .arena
+                .get(param_idx)
+                .and_then(|param_node| self.ctx.arena.get_parameter(param_node))
+                .is_some_and(|param| self.binding_pattern_contains_name(param.name, name_text))
+        })
+    }
+
+    /// Recursively search a binding pattern for an identifier bound to
+    /// `name_text`. `node_idx` may be a plain identifier (no match, not a
+    /// pattern), an object/array binding pattern, or `NONE`.
+    fn binding_pattern_contains_name(&self, node_idx: NodeIndex, name_text: &str) -> bool {
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return false;
+        };
+        if !node.is_binding_pattern() {
+            return false;
+        }
+        let Some(pattern) = self.ctx.arena.get_binding_pattern(node) else {
+            return false;
+        };
+        pattern.elements.nodes.iter().any(|&el_idx| {
+            let Some(el_name) = self
+                .ctx
+                .arena
+                .get(el_idx)
+                .and_then(|el_node| self.ctx.arena.get_binding_element(el_node))
+                .map(|el| el.name)
+            else {
+                return false;
+            };
+            let is_direct_match = self
+                .ctx
+                .arena
+                .get(el_name)
+                .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
+                .is_some_and(|ident| ident.escaped_text.as_str() == name_text);
+            is_direct_match || self.binding_pattern_contains_name(el_name, name_text)
+        })
+    }
+}
+
+/// Parameter-declaration node indices backing a `SignatureData`'s optional
+/// parameter list, or `&[]` when absent. Lets call sites that only have a
+/// `sig.parameters: Option<NodeList>` pass raw nodes to
+/// [`CheckerState::return_type_and_predicate`] /
+/// [`CheckerState::return_type_and_predicate_in_type_literal`] without
+/// repeating the `Option` unwrap at every site.
+pub(crate) fn signature_param_nodes(list: &Option<tsz_parser::parser::NodeList>) -> &[NodeIndex] {
+    list.as_ref().map_or(&[], |l| l.nodes.as_slice())
 }

--- a/crates/tsz-checker/src/tests/assertion_type_predicate_diagnostics_tests.rs
+++ b/crates/tsz-checker/src/tests/assertion_type_predicate_diagnostics_tests.rs
@@ -270,6 +270,157 @@ function assertAllStrings(...values: unknown[]): asserts values is string[] {}
 }
 
 #[test]
+fn type_predicate_cannot_reference_object_binding_pattern_element() {
+    let codes = check_source_codes(
+        r#"
+function f({a}: {a: unknown}): a is string {
+    return typeof a === "string";
+}
+"#,
+    );
+    assert!(
+        codes.contains(&1230),
+        "expected TS1230 for predicate referencing a shorthand destructured element, got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&1225),
+        "the binding-pattern case must not fall through to TS1225, got {codes:?}"
+    );
+}
+
+#[test]
+fn type_predicate_cannot_reference_renamed_binding_pattern_element() {
+    // The predicate subject must be the LOCAL (renamed) binding name, not the
+    // source property name, mirroring how `{a: r}` introduces `r` into scope.
+    let codes = check_source_codes(
+        r#"
+function f({a: r}: {a: unknown}): r is string {
+    return typeof r === "string";
+}
+"#,
+    );
+    assert!(
+        codes.contains(&1230),
+        "expected TS1230 for predicate referencing a renamed destructured element, got {codes:?}"
+    );
+}
+
+#[test]
+fn type_predicate_cannot_reference_nested_binding_pattern_element() {
+    let codes = check_source_codes(
+        r#"
+function f({a: {b}}: {a: {b: unknown}}): b is string {
+    return typeof b === "string";
+}
+"#,
+    );
+    assert!(
+        codes.contains(&1230),
+        "expected TS1230 for predicate referencing a nested destructured element, got {codes:?}"
+    );
+}
+
+#[test]
+fn type_predicate_cannot_reference_array_binding_pattern_element() {
+    let codes = check_source_codes(
+        r#"
+function f([a]: [unknown]): a is string {
+    return typeof a === "string";
+}
+"#,
+    );
+    assert!(
+        codes.contains(&1230),
+        "expected TS1230 for predicate referencing an array-destructured element, got {codes:?}"
+    );
+}
+
+#[test]
+fn type_predicate_cannot_reference_rest_element_in_binding_pattern() {
+    // Distinct from `type_predicate_cannot_reference_rest_parameter` (TS1229,
+    // a rest PARAMETER): this is a `...rest` element nested inside an object
+    // pattern, which tsc reports as a binding-pattern reference, not TS1229.
+    let codes = check_source_codes(
+        r#"
+function f({...rest}: {x?: unknown}): rest is {x: string} {
+    return true;
+}
+"#,
+    );
+    assert!(
+        codes.contains(&1230),
+        "expected TS1230 for predicate referencing a rest element inside a binding pattern, got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&1229),
+        "a binding-pattern rest element is not a rest PARAMETER, must not emit TS1229, got {codes:?}"
+    );
+}
+
+#[test]
+fn type_predicate_cannot_reference_binding_pattern_element_on_class_method() {
+    let codes = check_source_codes(
+        r#"
+class C {
+    m({a}: {a: unknown}): a is string {
+        return typeof a === "string";
+    }
+}
+"#,
+    );
+    assert!(
+        codes.contains(&1230),
+        "expected TS1230 for a class method predicate referencing a destructured element, got {codes:?}"
+    );
+}
+
+#[test]
+fn type_predicate_cannot_reference_binding_pattern_element_asserts_form() {
+    let codes = check_source_codes(
+        r#"
+function f({a}: {a: unknown}): asserts a is string {
+    if (typeof a !== "string") throw new Error();
+}
+"#,
+    );
+    assert!(
+        codes.contains(&1230),
+        "expected TS1230 for an `asserts` predicate referencing a destructured element, got {codes:?}"
+    );
+}
+
+#[test]
+fn type_predicate_on_plain_parameter_does_not_emit_ts1230() {
+    // Negative control: a plain (non-destructured) parameter must never
+    // trigger the binding-pattern check, even when a sibling parameter in
+    // the same list IS destructured.
+    let codes = check_source_codes(
+        r#"
+function f(a: unknown, {b}: {b: unknown}): a is string {
+    return typeof a === "string";
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&1230),
+        "a plain parameter predicate must not emit TS1230 even with a destructured sibling, got {codes:?}"
+    );
+}
+
+#[test]
+fn type_predicate_binding_pattern_element_in_type_literal_call_signature() {
+    let codes = check_source_codes(
+        r#"
+type Lit = { ({a}: {a: unknown}): a is string };
+"#,
+    );
+    assert!(
+        codes.contains(&1230),
+        "expected TS1230 for a type-literal call-signature predicate referencing a destructured element, got {codes:?}"
+    );
+}
+
+#[test]
 fn assertion_element_access_emits_ts2776() {
     let codes = check_source_codes(
         r#"

--- a/crates/tsz-checker/src/types/class_type/constructor_parts/inferred_predicates.rs
+++ b/crates/tsz-checker/src/types/class_type/constructor_parts/inferred_predicates.rs
@@ -10,15 +10,16 @@ impl<'a> CheckerState<'a> {
         method: &MethodDeclData,
         params: &[ParamInfo],
     ) -> (TypeId, Option<TypePredicate>) {
-        let (return_type, mut type_predicate) =
-            if method.type_annotation.is_none() && method.body != NodeIndex::NONE {
-                (
-                    self.infer_return_type_from_body(method_idx, method.body, None),
-                    None,
-                )
-            } else {
-                self.return_type_and_predicate(method.type_annotation, params)
-            };
+        let (return_type, mut type_predicate) = if method.type_annotation.is_none()
+            && method.body != NodeIndex::NONE
+        {
+            (
+                self.infer_return_type_from_body(method_idx, method.body, None),
+                None,
+            )
+        } else {
+            self.return_type_and_predicate(method.type_annotation, params, &method.parameters.nodes)
+        };
         if type_predicate.is_none()
             && method.type_annotation.is_none()
             && matches!(return_type, TypeId::BOOLEAN | TypeId::UNKNOWN)

--- a/crates/tsz-checker/src/types/computation/interface_member_type.rs
+++ b/crates/tsz-checker/src/types/computation/interface_member_type.rs
@@ -29,8 +29,11 @@ impl<'a> CheckerState<'a> {
 
             let (type_params, type_param_updates) = self.push_type_parameters(&sig.type_parameters);
             let (params, this_type) = self.extract_params_from_signature_in_type_literal(sig);
-            let (return_type, type_predicate) =
-                self.return_type_and_predicate_in_type_literal(sig.type_annotation, &params);
+            let (return_type, type_predicate) = self.return_type_and_predicate_in_type_literal(
+                sig.type_annotation,
+                &params,
+                crate::signature_builder::signature_param_nodes(&sig.parameters),
+            );
 
             let shape = FunctionShape {
                 type_params,
@@ -127,8 +130,11 @@ impl<'a> CheckerState<'a> {
                 let (type_params, type_param_updates) =
                     self.push_type_parameters(&sig.type_parameters);
                 let (params, this_type) = self.extract_params_from_signature(sig);
-                let (return_type, type_predicate) =
-                    self.return_type_and_predicate(sig.type_annotation, &params);
+                let (return_type, type_predicate) = self.return_type_and_predicate(
+                    sig.type_annotation,
+                    &params,
+                    crate::signature_builder::signature_param_nodes(&sig.parameters),
+                );
 
                 let shape = FunctionShape {
                     type_params,

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -1255,7 +1255,8 @@ impl<'a> CheckerState<'a> {
             self.check_type_for_parameter_properties(type_annotation);
             // Check for undefined type names in return type
             self.check_type_for_missing_names(type_annotation);
-            let (ret, pred) = self.return_type_and_predicate(type_annotation, &params);
+            let (ret, pred) =
+                self.return_type_and_predicate(type_annotation, &params, &parameters.nodes);
             (ret, pred)
         } else {
             // Use UNKNOWN as default to enforce strict checking

--- a/crates/tsz-checker/src/types/interface_type.rs
+++ b/crates/tsz-checker/src/types/interface_type.rs
@@ -312,6 +312,7 @@ impl<'a> CheckerState<'a> {
                             self.return_type_and_predicate_in_type_literal(
                                 sig.type_annotation,
                                 &params,
+                                crate::signature_builder::signature_param_nodes(&sig.parameters),
                             )
                         } else {
                             (
@@ -354,6 +355,7 @@ impl<'a> CheckerState<'a> {
                             self.return_type_and_predicate_in_type_literal(
                                 sig.type_annotation,
                                 &params,
+                                crate::signature_builder::signature_param_nodes(&sig.parameters),
                             )
                         } else {
                             (
@@ -449,6 +451,9 @@ impl<'a> CheckerState<'a> {
                                 self.return_type_and_predicate_in_type_literal(
                                     sig.type_annotation,
                                     &params,
+                                    crate::signature_builder::signature_param_nodes(
+                                        &sig.parameters,
+                                    ),
                                 )
                             } else {
                                 (

--- a/crates/tsz-checker/src/types/type_literal_checker.rs
+++ b/crates/tsz-checker/src/types/type_literal_checker.rs
@@ -1224,6 +1224,7 @@ impl<'a> CheckerState<'a> {
                             .return_type_and_predicate_in_type_literal(
                                 sig.type_annotation,
                                 &params,
+                                crate::signature_builder::signature_param_nodes(&sig.parameters),
                             );
                         call_signatures.push(signature_building_boundary::call_signature(
                             type_params,
@@ -1250,6 +1251,7 @@ impl<'a> CheckerState<'a> {
                             .return_type_and_predicate_in_type_literal(
                                 sig.type_annotation,
                                 &params,
+                                crate::signature_builder::signature_param_nodes(&sig.parameters),
                             );
                         construct_signatures.push(signature_building_boundary::call_signature(
                             type_params,
@@ -1288,6 +1290,9 @@ impl<'a> CheckerState<'a> {
                                 .return_type_and_predicate_in_type_literal(
                                     sig.type_annotation,
                                     &params,
+                                    crate::signature_builder::signature_param_nodes(
+                                        &sig.parameters,
+                                    ),
                                 );
                             let call_sig = signature_building_boundary::call_signature(
                                 type_params,


### PR DESCRIPTION
`An type predicate cannot reference element '{0}' in a binding pattern.` (TS1230) had a table entry but no emit site anywhere under `crates/`, confirmed via #16291's unwired-diagnostic enumeration ("type predicates" family: TS1224/TS1226/TS1230 — TS1224/TS1226 are left unclaimed, see below).

**Structural rule.** tsc's checker resolves a type predicate's subject identifier against the whole parameter list, including destructuring binding patterns at any nesting depth. When the identifier does not match a top-level parameter but matches an element the pattern introduces (object, array, nested, renamed, or a `...rest` element inside a pattern), tsc reports TS1230 there instead of falling through to TS1225 ("Cannot find parameter"). tsz's target-resolution code in `return_type_and_predicate_impl` (`crates/tsz-checker/src/checkers/signature_builder.rs`, the exact spot the sibling TS1229 rest-parameter check already lives) only matched top-level `ParamInfo` names, so every destructured shape fell through to TS1225.

**Fix.** Threaded a new `raw_params: &[NodeIndex]` argument (the parameter declaration nodes backing `ParamInfo`) through `return_type_and_predicate` / `return_type_and_predicate_in_type_literal` and all twelve call sites — function declarations/expressions, class/object methods, interface method/call/construct signatures, and type-literal call/construct/method signatures — plus two new recursive helpers, `type_predicate_name_matches_binding_element` and `binding_pattern_contains_name`, that walk a parameter's binding pattern for a matching bound identifier.

**No suppression-list changes needed.** The new branch sits behind the same `self.ctx.has_parse_errors` program-wide guard the sibling TS1225/TS1229 branches already use. Verified directly against the oracle in both directions (isolated, and with an unrelated sibling file carrying a real syntax error) — the existing guard alone reproduces tsc's cross-file suppression exactly, so unlike the recent parser-emitted grammar PRs in this vein, this checker-emitted code needed no `is_checker_routed_ts1xxx_grammar` entry.

**Known adjacent gap, explicitly out of scope.** `interface` declarations check their members eagerly via a separate pass (`check_interface_declaration`'s member loop calling `get_type_from_type_node` directly on `sig.type_annotation`) that never resolves a type-predicate target against parameters at all — so an *unused* `interface I { m({a}: {a:T}): a is string }` still reports nothing. This is pre-existing and shared with the sibling TS1225/TS1229 codes (verified neither fires for an interface method predicate on current main either) — not something this PR introduces or narrows scope around. The type-literal eager-check path (`type_literal_checker.rs`) already worked correctly once `raw_params` was threaded through it.

**TS1224/TS1226 left unclaimed.** Unlike TS1230, these are not standalone top-level diagnostics — oracle-confirmed, they only appear as related-message chain entries nested inside TS2430/TS2322 (e.g. `Type '(x: unknown) => boolean' is not assignable to type '(x: unknown) => x is string'.\n  Signature '(x: unknown): boolean' must be a type predicate.`). That routes through the shared assignability gateway (relation → reason → diagnostic) rather than a simple grammar-check site, a bigger slice better done as its own PR.

## Adjacent-case matrix (10 new unit tests, `assertion_type_predicate_diagnostics_tests.rs`)

All pinned against the `typescript@7.0.2` oracle before coding.

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `{a}: ... a is string` (shorthand) | TS1230 | TS1225 | TS1230 |
| `{a: r}: ... r is string` (renamed) | TS1230 on `r` | TS1225 | TS1230 on `r` |
| `{a: {b}}: ... b is string` (nested) | TS1230 | TS1225 | TS1230 |
| `[a]: ... a is string` (array pattern) | TS1230 | TS1225 | TS1230 |
| `{...rest}: ... rest is T` (rest element in pattern) | TS1230, not TS1229 | TS1225 | TS1230, not TS1229 |
| class method, same shapes | TS1230 | TS1225 | TS1230 |
| `asserts a is string` (asserts form) | TS1230 | TS1225 | TS1230 |
| `(a: unknown, {b}): a is string` (plain param, destructured sibling) | clean | clean | clean |
| type-literal call signature `{ ({a}): a is string }` | TS1230 | TS1225 | TS1230 |

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib assertion_type_predicate` — 35/35 (10 new).
- `cargo test -p tsz-checker --lib type_predicate` — 106/106.
- `cargo test -p tsz-checker --lib interface_` — 376/376; `--lib type_literal` — 64/64; `--lib call_signature` — 9/9; `--lib function_declaration` — 29/29 (regression net for the 12 threaded call sites).
- Oracle-pinned via the built CLI (`typescript@7.0.2`, `--noEmit --strict --target es2022`): every row in the matrix above matches code+line+column exactly, including cross-file real-syntax-error suppression in both directions.
- `cargo fmt --all -- --check` clean; `cargo clippy -p tsz-checker --lib --tests -- -D warnings` clean; `python3 scripts/arch/arch_guard.py` → "Architecture guardrails passed."
- Two-sided `scripts/conformance/compare-to-parent.sh origin/main`: running in the background at this head; expected zero-movement signature per the board's standing note (this is a pure missing-diagnostic family with no committed-corpus fixture observed carrying TS1230 in its failure set) — result to follow as a comment.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_017gAnBnhjBhGwWjZXxSoms4)_