### PR TITLE
fix(parser): `v`-mode character classes nest, so a nested class is not a stray bracket (TS1508/TS1516/TS1517)

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -258,6 +258,10 @@ mod decorator_tests;
 mod regex_backreference_tests;
 
 #[cfg(test)]
+#[path = "../../tests/regex_class_set_nesting_tests.rs"]
+mod regex_class_set_nesting_tests;
+
+#[cfg(test)]
 #[path = "../../tests/modifier_ordering_tests.rs"]
 mod modifier_ordering_tests;
 

--- a/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
@@ -191,8 +191,103 @@ impl ParserState {
                 }
             }
 
+            /// Analyse one character class, starting just past its `[`, and
+            /// push range-order (TS1517) errors for the ranges it contains.
+            /// Under the `v` flag a class may contain further classes, and a
+            /// class that has committed to a `--`/`&&` class-set operator
+            /// contains no ranges at all — but its nested classes still do, so
+            /// the walk recurses instead of skipping.
+            fn analyze_class_ranges(
+                raw_text: &str,
+                i: &mut usize,
+                body_end: usize,
+                unicode_mode: bool,
+                unicode_sets_mode: bool,
+                errors: &mut Vec<(u32, u32)>,
+            ) {
+                let bytes = raw_text.as_bytes();
+                let mut tokens: Vec<ClassToken> = Vec::new();
+                let mut in_class_set_expression = false;
+
+                while *i < body_end {
+                    if bytes[*i] == b']' {
+                        *i += 1;
+                        break;
+                    }
+                    // `--` and `&&` commit the class to a `ClassSetExpression`,
+                    // which admits no ranges.
+                    if unicode_sets_mode
+                        && *i + 1 < body_end
+                        && ((bytes[*i] == b'-' && bytes[*i + 1] == b'-')
+                            || (bytes[*i] == b'&' && bytes[*i + 1] == b'&'))
+                    {
+                        in_class_set_expression = true;
+                        *i += 2;
+                        continue;
+                    }
+                    if bytes[*i] == b'-' {
+                        tokens.push(ClassToken::Hyphen);
+                        *i += 1;
+                        continue;
+                    }
+                    // A nested class is never a range bound, so it contributes
+                    // no code point to compare — but it is a class in its own
+                    // right and carries its own ranges.
+                    if unicode_sets_mode && bytes[*i] == b'[' {
+                        tokens.push(ClassToken::OpaqueAtom);
+                        *i += 1;
+                        analyze_class_ranges(
+                            raw_text,
+                            i,
+                            body_end,
+                            unicode_mode,
+                            unicode_sets_mode,
+                            errors,
+                        );
+                        continue;
+                    }
+                    let Some((atoms, next_i)) =
+                        parse_class_atom(raw_text, *i, body_end, unicode_mode)
+                    else {
+                        break;
+                    };
+                    if atoms.is_empty() {
+                        tokens.push(ClassToken::OpaqueAtom);
+                    } else {
+                        tokens.extend(
+                            atoms
+                                .into_iter()
+                                .map(|(value, start)| ClassToken::Atom { value, start }),
+                        );
+                    }
+                    *i = next_i;
+                }
+
+                if in_class_set_expression {
+                    return;
+                }
+
+                let mut token_index = 0usize;
+                while token_index + 2 < tokens.len() {
+                    match &tokens[token_index..token_index + 3] {
+                        [
+                            ClassToken::Atom { value: left, start },
+                            ClassToken::Hyphen,
+                            ClassToken::Atom { value: right, .. },
+                        ] => {
+                            if left > right {
+                                errors.push((*start, 1));
+                            }
+                            token_index += 3;
+                        }
+                        _ => token_index += 1,
+                    }
+                }
+            }
+
             let flags = &raw_text[body_end + 1..];
             let unicode_mode = flags.contains('u') || flags.contains('v');
+            let unicode_sets_mode = flags.contains('v');
             let bytes = raw_text.as_bytes();
             let mut errors = Vec::new();
             let mut i = 1usize;
@@ -207,50 +302,14 @@ impl ParserState {
                     }
                     b'[' => {
                         i += 1;
-                        let mut tokens = Vec::new();
-                        while i < body_end {
-                            if bytes[i] == b']' {
-                                i += 1;
-                                break;
-                            }
-                            if bytes[i] == b'-' {
-                                tokens.push(ClassToken::Hyphen);
-                                i += 1;
-                                continue;
-                            }
-                            let Some((atoms, next_i)) =
-                                parse_class_atom(raw_text, i, body_end, unicode_mode)
-                            else {
-                                break;
-                            };
-                            if atoms.is_empty() {
-                                tokens.push(ClassToken::OpaqueAtom);
-                            } else {
-                                tokens.extend(
-                                    atoms
-                                        .into_iter()
-                                        .map(|(value, start)| ClassToken::Atom { value, start }),
-                                );
-                            }
-                            i = next_i;
-                        }
-
-                        let mut token_index = 0usize;
-                        while token_index + 2 < tokens.len() {
-                            match &tokens[token_index..token_index + 3] {
-                                [
-                                    ClassToken::Atom { value: left, start },
-                                    ClassToken::Hyphen,
-                                    ClassToken::Atom { value: right, .. },
-                                ] => {
-                                    if left > right {
-                                        errors.push((*start, 1));
-                                    }
-                                    token_index += 3;
-                                }
-                                _ => token_index += 1,
-                            }
-                        }
+                        analyze_class_ranges(
+                            raw_text,
+                            &mut i,
+                            body_end,
+                            unicode_mode,
+                            unicode_sets_mode,
+                            &mut errors,
+                        );
                     }
                     _ => {
                         if let Some(ch) = raw_text.get(i..body_end).and_then(|s| s.chars().next()) {
@@ -867,6 +926,16 @@ impl ParserState {
                     return;
                 }
                 let ch = ctx.body[*pos];
+                // `ClassSetExpression` (the `v` flag) nests: a `[` inside a
+                // character class opens another class instead of contributing
+                // a literal `[`. Without the `v` flag the nested form is not
+                // grammar, so this must stay gated.
+                if ctx.unicode_sets_mode && ch == b'[' {
+                    *pos += 1;
+                    scan_class_ranges(parser, ctx, pos);
+                    range.push(ClassAtomKind::Class);
+                    return;
+                }
                 if ch == b'\\' {
                     *pos += 1;
                     if *pos >= ctx.body_end {
@@ -957,6 +1026,11 @@ impl ParserState {
                     *pos += 1;
                 }
 
+                // A `ClassSetExpression` that has committed to `--`/`&&` no
+                // longer admits ranges, so a later `-` is not a range operator
+                // and its operands are not range bounds.
+                let mut in_class_set_expression = false;
+
                 while *pos < ctx.body_end {
                     if ctx.body[*pos] == b']' {
                         *pos += 1;
@@ -965,6 +1039,7 @@ impl ParserState {
                     if ctx.unicode_sets_mode
                         && is_class_set_operator_at(ctx.body, *pos, ctx.body_end)
                     {
+                        in_class_set_expression = true;
                         scan_class_set_operator(parser, ctx.emit, ctx.body, ctx.body_end, pos);
                         continue;
                     }
@@ -975,10 +1050,15 @@ impl ParserState {
                     if ctx.unicode_sets_mode
                         && is_class_set_operator_at(ctx.body, *pos, ctx.body_end)
                     {
+                        in_class_set_expression = true;
                         scan_class_set_operator(parser, ctx.emit, ctx.body, ctx.body_end, pos);
                         continue;
                     }
                     if *pos >= ctx.body_end || ctx.body[*pos] != b'-' {
+                        continue;
+                    }
+                    if in_class_set_expression {
+                        *pos += 1;
                         continue;
                     }
 

--- a/crates/tsz-parser/tests/regex_class_set_nesting_tests.rs
+++ b/crates/tsz-parser/tests/regex_class_set_nesting_tests.rs
@@ -1,0 +1,160 @@
+//! Nested character classes inside a `ClassSetExpression` (the `v` flag).
+//!
+//! Under `v` (Unicode Sets) a `[` inside a character class opens a *nested*
+//! class rather than contributing a literal `[`, and a class that has committed
+//! to a `--`/`&&` class-set operator no longer admits ranges. Without `v` the
+//! nested form is not grammar at all, so both rules must stay flag-gated.
+//!
+//! Every row below is pinned against `typescript@7.0.2`
+//! (`--noEmit --strict --target esnext`), including the reported column.
+use crate::parser::test_fixture::parse_source;
+
+fn regex_codes(source: &str) -> Vec<u32> {
+    let (parser, _root) = parse_source(source);
+    parser.get_diagnostics().iter().map(|d| d.code).collect()
+}
+
+/// `(code, zero-based offset)` pairs — the offset is what the CLI renders as a
+/// column, and a nested-class fix that lands the code on the wrong operand is
+/// only visible here.
+fn regex_codes_at(source: &str) -> Vec<(u32, u32)> {
+    let (parser, _root) = parse_source(source);
+    parser
+        .get_diagnostics()
+        .iter()
+        .map(|d| (d.code, d.start))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// A nested class is grammar under `v` and only under `v`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nested_class_under_v_flag_is_clean() {
+    assert_eq!(regex_codes("const a = /[a[b]]/v;"), Vec::<u32>::new());
+}
+
+/// The same pattern under `u` keeps tsc's TS1508: outside `v` the inner `[` is
+/// an unescaped literal and the trailing `]` has no class to close.
+#[test]
+fn nested_class_under_u_flag_still_reports_ts1508() {
+    assert_eq!(regex_codes("const a = /[a[b]]/u;"), vec![1508]);
+}
+
+/// Annex B (no `u`/`v`) accepts the shape outright, so nothing may fire.
+#[test]
+fn nested_class_without_unicode_flags_is_clean() {
+    assert_eq!(regex_codes("const a = /[a[b]]/;"), Vec::<u32>::new());
+}
+
+#[test]
+fn adjacent_and_repeated_nested_classes_are_clean() {
+    assert_eq!(regex_codes("const a = /[[a][b]]/v;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[[[a]]]/v;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[a[b]c]/v;"), Vec::<u32>::new());
+}
+
+#[test]
+fn empty_and_negated_nested_classes_are_clean() {
+    assert_eq!(regex_codes("const a = /[[]]/v;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[a[]]/v;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[[^a]]/v;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[^[a][b]]/v;"), Vec::<u32>::new());
+}
+
+#[test]
+fn nested_class_operands_of_class_set_operators_are_clean() {
+    assert_eq!(regex_codes("const a = /[a--[b]]/v;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[a&&[b]]/v;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[[a]&&[b]]/v;"), Vec::<u32>::new());
+}
+
+#[test]
+fn class_escapes_beside_a_nested_class_are_clean() {
+    assert_eq!(regex_codes("const a = /[\\d[a]]/v;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[[a]\\d]/v;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[[a-z]]/v;"), Vec::<u32>::new());
+}
+
+/// A `]` that closes nothing is still TS1508 — the fix must consume exactly the
+/// nested class, not swallow the rest of the pattern.
+#[test]
+fn stray_bracket_after_a_nested_class_still_reports_ts1508() {
+    // `/[[a]]]/v` — offset 16 is the third `]`, the one with no open class.
+    assert_eq!(regex_codes_at("const a = /[[a]]]/v;"), vec![(1508, 16)]);
+}
+
+// ---------------------------------------------------------------------------
+// A nested class cannot bound a range (TS1516), and the report lands on the
+// offending bound
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nested_class_as_range_maximum_reports_ts1516_on_the_maximum() {
+    // `/[a-[b]]/v` — offset 14 is the `[` that opens the nested class.
+    assert_eq!(regex_codes_at("const a = /[a-[b]]/v;"), vec![(1516, 14)]);
+}
+
+#[test]
+fn nested_class_as_range_minimum_reports_ts1516_on_the_minimum() {
+    // `/[[a]-b]/v` — offset 12 is the `[` that opens the nested class.
+    assert_eq!(regex_codes_at("const a = /[[a]-b]/v;"), vec![(1516, 12)]);
+}
+
+#[test]
+fn nested_classes_on_both_range_bounds_report_ts1516_twice() {
+    assert_eq!(
+        regex_codes_at("const a = /[[a]-[b]]/v;"),
+        vec![(1516, 12), (1516, 16)]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A committed `ClassSetExpression` admits no ranges, so neither the range-bound
+// check (TS1516) nor the range-order check (TS1517) may fire inside one
+// ---------------------------------------------------------------------------
+
+#[test]
+fn hyphen_after_a_class_set_operator_is_not_a_range() {
+    assert_eq!(regex_codes("const a = /[a--b-c]/v;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[a&&b-c]/v;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[[a]--b-c]/v;"), Vec::<u32>::new());
+}
+
+/// The witness that first exposed this: a descending pair inside a subtraction
+/// is not a range, so TS1517 must not fire on it.
+#[test]
+fn descending_pair_inside_a_subtraction_does_not_report_ts1517() {
+    assert_eq!(
+        regex_codes("const a = /[[a]--\\P{L}-_]/v;"),
+        Vec::<u32>::new()
+    );
+}
+
+/// Suppression is scoped to the class that carries the operator: a plain class
+/// elsewhere in the same pattern keeps its range diagnostics.
+#[test]
+fn class_set_suppression_does_not_leak_to_a_sibling_class() {
+    assert_eq!(regex_codes("const a = /[a--b][z-a]/v;"), vec![1517]);
+}
+
+/// And it does not leak into a nested class either.
+#[test]
+fn class_set_suppression_does_not_leak_into_a_nested_class() {
+    assert_eq!(regex_codes("const a = /[a--[z-a]]/v;"), vec![1517]);
+}
+
+/// Ranges keep working in a `v`-mode class that never uses an operator.
+#[test]
+fn plain_range_under_v_flag_is_unaffected() {
+    assert_eq!(regex_codes("const a = /[a-b]/v;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[z-a]/v;"), vec![1517]);
+}
+
+/// `--`/`&&` are `v`-only spellings; under `u` a `-` keeps its range meaning and
+/// the descending pair must still report.
+#[test]
+fn class_set_suppression_is_v_only() {
+    assert_eq!(regex_codes("const a = /[z-a]/u;"), vec![1517]);
+}


### PR DESCRIPTION
## Goal

Goal: hold

A false-positive family in the regex grammar validator, found by clustering `regularExpressionScanning.ts` against its `tsc` baseline rather than from an issue. The parent emits **54** `TS1508` on that one fixture where `tsc` emits **17**; this PR takes it to **10**, with zero new diagnostics of any code.

### Structural rule

**When a character class is scanned under the `v` (Unicode Sets) flag, a `[` inside it opens a nested `ClassSetExpression` instead of contributing a literal `[`; `tsc` parses it as a nested class, and `tsz` now does the same through the parser's regex walker.**

Two consequences fall out of the same rule and are implemented with it:

- A nested class can never bound a range, so `tsc` reports **TS1516** on the offending bound (`/[a-[b]]/v` → TS1516 on the `[`). Routing the nested class through `ClassAtomKind::Class` reaches the walker's existing range-bound check, so this needed no new report site.
- A class that has committed to a `--`/`&&` class-set operator admits **no ranges at all**, so a later `-` is not a range operator. Both the walker's range-bound check and the separate `regex_range_order_errors` pass (TS1517) stop treating it as one.

All three are gated on the `v` flag. Under `u` (`/[a[b]]/u` → TS1508) and under Annex B (`/[a[b]]/` → clean) behaviour is byte-identical to before.

### Owner layer

`crates/tsz-parser/src/parser/state_expressions_literals_regex.rs` — the parser's regex validation, which already owns TS1508/TS1516/TS1517/TS1520 and the `unicode_sets_mode` flag. No checker, solver or emitter surface is touched, and no diagnostic string is used as a predicate.

`regex_range_order_errors` had an inline, non-recursive class loop; it is now a recursive `analyze_class_ranges` helper. That was not cosmetic — skipping a nested class wholesale silently dropped a real TS1517 inside it (`/[a--[z-a]]/v`), which the adjacent-case matrix caught before this was pushed.

### Adjacent-case matrix

Every row pinned against `typescript@7.0.2` (`--noEmit --strict --target esnext`), compared on **code and column**:

| shape | tsc | tsz (parent) | tsz (branch) |
| --- | --- | --- | --- |
| `/[a[b]]/v` | clean | TS1508 | clean |
| `/[a[b]]/u` | TS1508 | TS1508 | TS1508 |
| `/[a[b]]/` | clean | clean | clean |
| `/[[a][b]]/v`, `/[[[a]]]/v`, `/[a[b]c]/v` | clean | TS1508 ×1–2 | clean |
| `/[[]]/v`, `/[a[]]/v`, `/[[^a]]/v`, `/[^[a][b]]/v` | clean | TS1508 | clean |
| `/[a--[b]]/v`, `/[a&&[b]]/v`, `/[[a]&&[b]]/v` | clean | TS1508 | clean |
| `/[\d[a]]/v`, `/[[a]\d]/v`, `/[[a-z]]/v` | clean | TS1508 | clean |
| `/[[a]]]/v` | TS1508 @15 | TS1508 @14, @15 | TS1508 @15 |
| `/[a-[b]]/v` | TS1516 @13 | TS1517 @11 + TS1508 @16 | TS1516 @13 |
| `/[[a]-b]/v` | TS1516 @11 | TS1508 @16 | TS1516 @11 |
| `/[[a]-[b]]/v` | TS1516 @11, @15 | TS1508 @18 | TS1516 @11, @15 |
| `/[a--b-c]/v`, `/[a&&b-c]/v`, `/[[a]--b-c]/v` | TS1519 (unwired) | clean | clean |
| `/[[a]--\P{L}-_]/v` | TS1519 (unwired) | TS1516 @16 + TS1517 @20 | clean |
| `/[a--b][z-a]/v` | TS1517 @19 | TS1517 @19 | TS1517 @19 |
| `/[a--[z-a]]/v` | TS1517 @17 | TS1517 @17 | TS1517 @17 |
| `/[z-a]/v`, `/[z-a]/u` | TS1517 @13 | TS1517 @13 | TS1517 @13 |
| `/[a-b]/v` | clean | clean | clean |

Negative/fallback rows (`u`, no-flag, sibling class, nested class, plain range) are in the table and in the test file, not just the positive ones.

**Deliberately out of scope, all pre-existing and unchanged by this PR** — none is a false positive, each is a missing or wrong code recorded for the next slice: `TS1519` (operators must not be mixed — needs the full mixing model), `TS1518` (`/[^\q{ab}]/v`, negated class containing a multi-character string), `TS1005` on an unterminated nested class (`/[a[b]/v`), and `\q` outside a class rendering as TS1535 where tsc says TS1511 (already recorded on the board by `Cinnabar`).

## Verification

- `cargo fmt`, `cargo clippy -p tsz-parser --all-targets` — clean (workspace clippy + arch-size also run by the pre-commit hook, both passed).
- `cargo test -p tsz-parser --lib` — **1617 passed, 0 failed** (`cargo-nextest` is absent on this cloud seat, per several board notes).
- **Non-vacuity**, by `git stash` of the source file only, leaving the tests in place: **12 of the 17 new tests fail without the fix**, so the suite fails for the real reason.
- **Fixture measurement**, `TypeScript/tests/cases/compiler/regularExpressionScanning.ts` at `--target es2015` against `regularExpressionScanning(target=es2015).errors.txt`, compared by column per `Jasper`'s baseline-direction note:

  | | parent | branch | tsc baseline |
  | --- | --- | --- | --- |
  | TS1508 | 54 | **10** | 17 |
  | TS1535 | 22 | **15** | 18 |
  | TS1517 | 3 | 3 | 9 |
  | total diagnostics | 139 | **88** | 219 |

  −51 diagnostics, all of them over-reports; every other code's count is unchanged. Rows that do not appear in the baseline drop from the parent's set to 6, and those 6 are a subset of the parent's — **no new non-baseline row is introduced by this change**. The row does not flip green and is not expected to: per `Jasper`, `regularExpressionScanning.ts` needs essentially the whole regex cluster, so this slice is graded on codes matched, not on the row.

- **`scripts/conformance/compare-to-parent.sh origin/main` — clean**, run at head `b16c63d` against base `5989773`:

  ```
  base failing=563  branch failing=563
  NEWLY PASSING (0):  (none)
  NEWLY FAILING (0):  (none)
  still failing, fingerprint changed (0):
  ```

  **Correcting a prediction I made in the first version of this body**: I expected `regularExpressionScanning.ts` to land in the "fingerprint changed" bucket and it did not, because the comparator adjudicates on the **set** of codes a test emits, not on how many times each fires. TS1508 and TS1535 are still in that test's actual-code set (10 and 15 occurrences), so removing 44 and 7 duplicate occurrences is invisible to the fingerprint. The fixture *is* in the corpus — `conformance-baseline.txt:212` — so it ran and did not regress; the gate simply cannot see a pure over-report reduction on a test that stays failing. The occurrence-level evidence above is the measurement that shows the actual gain, and the oracle matrix is what shows it is a gain rather than a loss.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Obsidian