### PR TITLE
fix(checker): TS1501 never gated the `s`/`d` regex flags on their target

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2622,3 +2622,6 @@ path = "tests/noimplicitany_type_member_accessor_tests.rs"
 [[test]]
 name = "signature_binding_pattern_typeof_scope_tests"
 path = "tests/signature_binding_pattern_typeof_scope_tests.rs"
+[[test]]
+name = "ts1501_tests"
+path = "tests/ts1501_tests.rs"

--- a/crates/tsz-checker/src/dispatch/helpers.rs
+++ b/crates/tsz-checker/src/dispatch/helpers.rs
@@ -40,7 +40,7 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                 }
             }
 
-            self.check_regular_expression_v_flag(node.pos, bytes, body_end);
+            self.check_regular_expression_target_gated_flags(node.pos, bytes, body_end);
             self.check_regular_expression_named_groups(node.pos, raw_text, bytes, body_end);
         }
 
@@ -49,29 +49,42 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
             .unwrap_or(TypeId::ANY)
     }
 
-    fn check_regular_expression_v_flag(&mut self, node_pos: u32, bytes: &[u8], body_end: usize) {
-        if self.checker.ctx.compiler_options.target.supports_es2024() {
-            return;
-        }
-
+    /// tsc gates the `s` (dotAll), `d` (hasIndices), and `v` (unicodeSets)
+    /// regex flags on the target that introduced them; `u` and `y` require
+    /// only ES2015, which every reachable target already satisfies. Each
+    /// offending flag is reported at its own position, in source order,
+    /// mirroring tsc's per-flag scan.
+    fn check_regular_expression_target_gated_flags(
+        &mut self,
+        node_pos: u32,
+        bytes: &[u8],
+        body_end: usize,
+    ) {
+        let target = self.checker.ctx.compiler_options.target;
         let flag_start = body_end.saturating_add(1);
-        let Some(v_offset) = bytes
-            .get(flag_start..)
-            .and_then(|flags| flags.iter().position(|&flag| flag == b'v'))
-        else {
+        let Some(flags) = bytes.get(flag_start..) else {
             return;
         };
 
-        let message = format_message(
-            diagnostic_messages::THIS_REGULAR_EXPRESSION_FLAG_IS_ONLY_AVAILABLE_WHEN_TARGETING_OR_LATER,
-            &["es2024"],
-        );
-        self.checker.error_at_position(
-            node_pos + (flag_start + v_offset) as u32,
-            1,
-            &message,
-            diagnostic_codes::THIS_REGULAR_EXPRESSION_FLAG_IS_ONLY_AVAILABLE_WHEN_TARGETING_OR_LATER,
-        );
+        for (offset, &flag) in flags.iter().enumerate() {
+            let min_target = match flag {
+                b's' if !target.supports_es2018() => "es2018",
+                b'd' if !target.supports_es2022() => "es2022",
+                b'v' if !target.supports_es2024() => "es2024",
+                _ => continue,
+            };
+
+            let message = format_message(
+                diagnostic_messages::THIS_REGULAR_EXPRESSION_FLAG_IS_ONLY_AVAILABLE_WHEN_TARGETING_OR_LATER,
+                &[min_target],
+            );
+            self.checker.error_at_position(
+                node_pos + (flag_start + offset) as u32,
+                1,
+                &message,
+                diagnostic_codes::THIS_REGULAR_EXPRESSION_FLAG_IS_ONLY_AVAILABLE_WHEN_TARGETING_OR_LATER,
+            );
+        }
     }
 
     fn check_regular_expression_named_groups(

--- a/crates/tsz-checker/tests/ts1501_tests.rs
+++ b/crates/tsz-checker/tests/ts1501_tests.rs
@@ -1,7 +1,9 @@
 //! Tests for TS1501: Regular expression flag target validation.
 //!
-//! TypeScript 6.0 still emits TS1501 for the `v` regular-expression flag
-//! when targeting below ES2024.
+//! tsc gates `s` (dotAll) on ES2018, `d` (hasIndices) on ES2022, and `v`
+//! (unicodeSets) on ES2024; `u` and `y` require only ES2015 and never fire
+//! on a reachable target. Every row below is pinned against the
+//! `typescript@7.0.2` oracle.
 
 use tsz_checker::context::CheckerOptions;
 use tsz_common::common::ScriptTarget;
@@ -27,6 +29,16 @@ fn ts1501_diagnostic(source: &str, target: ScriptTarget) -> tsz_common::diagnost
         .into_iter()
         .find(|d| d.code == 1501)
         .expect("expected TS1501 diagnostic")
+}
+
+fn ts1501_diagnostics(
+    source: &str,
+    target: ScriptTarget,
+) -> Vec<tsz_common::diagnostics::Diagnostic> {
+    diagnostics_for(source, target)
+        .into_iter()
+        .filter(|d| d.code == 1501)
+        .collect()
 }
 
 #[test]
@@ -57,11 +69,71 @@ fn v_flag_is_allowed_for_es2024_or_later() {
 }
 
 #[test]
-fn ts1501_not_emitted_for_other_regex_flags() {
-    assert!(!has_ts1501("var x = /foo/u;", ScriptTarget::ES5));
-    assert!(!has_ts1501("var x = /foo/y;", ScriptTarget::ES5));
-    assert!(!has_ts1501("var x = /foo/s;", ScriptTarget::ES2015));
-    assert!(!has_ts1501("var x = /foo/d;", ScriptTarget::ES2018));
-    assert!(!has_ts1501("var x = /foo/gim;", ScriptTarget::ES3));
-    assert!(!has_ts1501("var x = /foo/us;", ScriptTarget::ES5));
+fn ts1501_not_emitted_for_flags_requiring_only_es2015() {
+    assert!(!has_ts1501("var x = /foo/u;", ScriptTarget::ES2015));
+    assert!(!has_ts1501("var x = /foo/y;", ScriptTarget::ES2015));
+    assert!(!has_ts1501("var x = /foo/gim;", ScriptTarget::ES2015));
+    assert!(!has_ts1501("var x = /foo/uy;", ScriptTarget::ES2015));
+}
+
+#[test]
+fn s_flag_requires_es2018_or_later() {
+    assert!(has_ts1501("var x = /foo/s;", ScriptTarget::ES2015));
+    assert!(has_ts1501("var x = /foo/s;", ScriptTarget::ES2017));
+    assert!(!has_ts1501("var x = /foo/s;", ScriptTarget::ES2018));
+    assert!(!has_ts1501("var x = /foo/s;", ScriptTarget::ES2022));
+}
+
+#[test]
+fn s_flag_ts1501_points_to_flag() {
+    let diagnostic = ts1501_diagnostic("var a = /foo/s;", ScriptTarget::ES2015);
+
+    assert_eq!(diagnostic.start, 13);
+    assert_eq!(diagnostic.length, 1);
+    assert_eq!(
+        diagnostic.message_text,
+        "This regular expression flag is only available when targeting 'es2018' or later."
+    );
+}
+
+#[test]
+fn d_flag_requires_es2022_or_later() {
+    assert!(has_ts1501("var x = /foo/d;", ScriptTarget::ES2018));
+    assert!(has_ts1501("var x = /foo/d;", ScriptTarget::ES2021));
+    assert!(!has_ts1501("var x = /foo/d;", ScriptTarget::ES2022));
+    assert!(!has_ts1501("var x = /foo/d;", ScriptTarget::ESNext));
+}
+
+#[test]
+fn d_flag_ts1501_points_to_flag() {
+    let diagnostic = ts1501_diagnostic("var a = /foo/d;", ScriptTarget::ES2018);
+
+    assert_eq!(diagnostic.start, 13);
+    assert_eq!(diagnostic.length, 1);
+    assert_eq!(
+        diagnostic.message_text,
+        "This regular expression flag is only available when targeting 'es2022' or later."
+    );
+}
+
+#[test]
+fn multiple_offending_flags_each_report_at_their_own_position_in_source_order() {
+    let diagnostics = ts1501_diagnostics("var a = /foo/dsv;", ScriptTarget::ES2015);
+
+    assert_eq!(diagnostics.len(), 3);
+    assert_eq!(diagnostics[0].start, 13);
+    assert_eq!(
+        diagnostics[0].message_text,
+        "This regular expression flag is only available when targeting 'es2022' or later."
+    );
+    assert_eq!(diagnostics[1].start, 14);
+    assert_eq!(
+        diagnostics[1].message_text,
+        "This regular expression flag is only available when targeting 'es2018' or later."
+    );
+    assert_eq!(diagnostics[2].start, 15);
+    assert_eq!(
+        diagnostics[2].message_text,
+        "This regular expression flag is only available when targeting 'es2024' or later."
+    );
 }


### PR DESCRIPTION
A slice of #16291's unwired-diagnostic enumeration, sized by Obsidian's 14:09Z board measurement of `regularExpressionScanning.ts`.

### Structural rule

When a regular-expression literal's flag was introduced by a version of the spec later than the compilation target supports, tsc reports TS1501 at that flag's own position; it does this per-flag, in source order, not just for `v`. tsz's `check_regular_expression_v_flag` (`crates/tsz-checker/src/dispatch/helpers.rs`) only ever checked the `v` (`unicodeSets`, ES2024) flag — `s` (`dotAll`, ES2018) and `d` (`hasIndices`, ES2022) were never checked at all, so e.g. `/foo/s` under `--target es2015` stayed clean where tsc reports TS1501. Generalized the single-flag check into a per-flag scan over `s`/`d`/`v`, each reporting independently at its own column. `u`/`y` require only ES2015, which every reachable target satisfies (ES3/ES5 are removed in tsc 7 — `--target es5` itself dies with TS5108), so they are correctly left unchecked.

### Owner layer

`crates/tsz-checker/src/dispatch/helpers.rs`, the same site that already owned the `v`-flag check — a checker-level target-gate, no parser/solver/emit surface touched.

### Adjacent-case matrix

Pinned against `typescript@7.0.2` (`--noEmit --strict --target TARGET`), by code + column:

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `/foo/s` @ es2015/es2017 | TS1501 'es2018' @14 | clean | TS1501 'es2018' @14 |
| `/foo/s` @ es2018+ | clean | clean | clean |
| `/foo/d` @ es2018/es2021 | TS1501 'es2022' @14 | clean | TS1501 'es2022' @14 |
| `/foo/d` @ es2022+ | clean | clean | clean |
| `/foo/v` @ below es2024 | TS1501 'es2024' | TS1501 'es2024' (unchanged) | TS1501 'es2024' (unchanged) |
| `/foo/u`, `/foo/y`, `/foo/gim` @ es2015 | clean | clean | clean |
| `/foo/su` @ es2015 (offending + non-offending) | TS1501 'es2018' @14 only | clean | TS1501 'es2018' @14 only |
| `/foo/dsv` @ es2015 (three offending) | 3x TS1501 @13,@14,@15 ('es2022','es2018','es2024' in that order) | 1x TS1501 (v only) | 3x TS1501, same order/columns |

Also registers `crates/tsz-checker/tests/ts1501_tests.rs` in `Cargo.toml`'s `[[test]]` list. `tsz-checker` sets `autotests = false`, and this file had **no entry at all** — it has never actually run in CI, including the pre-existing `v`-flag tests and the (now-corrected) assertion that `s`/`d` never fire.

### Non-vacuity

`git stash` of the source change only, tests left in place: 5 of the 9 tests in `ts1501_tests.rs` fail without the fix, for the expected reason (`Option::expect` on a missing TS1501 diagnostic).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts1501_tests` — 9/9 (5 new/rewritten, all previously-unregistered).
- `cargo clippy -p tsz-checker --lib --tests -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py` — "Architecture guardrails passed."
- `cargo fmt --all` — clean.
- `scripts/conformance/compare-to-parent.sh origin/main` — running at post time; result to follow as a PR comment per the board's standing convention for this vein.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PYLJ6BirHq5uAkqHQHsZTs)_