### PR TITLE
fix(checker): TS1474 (export declaration outside module top level, JS files) was never wired

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
@@ -1378,6 +1378,12 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
                             diagnostic_messages::A_DEFAULT_EXPORT_MUST_BE_AT_THE_TOP_LEVEL_OF_A_FILE_OR_MODULE_DECLARATION,
                             diagnostic_codes::A_DEFAULT_EXPORT_MUST_BE_AT_THE_TOP_LEVEL_OF_A_FILE_OR_MODULE_DECLARATION,
                         )
+                    } else if self.is_js_file() {
+                        // In JS files, use TS1474 "...top level of a module" (no namespaces in JS).
+                        (
+                            diagnostic_messages::AN_EXPORT_DECLARATION_CAN_ONLY_BE_USED_AT_THE_TOP_LEVEL_OF_A_MODULE,
+                            diagnostic_codes::AN_EXPORT_DECLARATION_CAN_ONLY_BE_USED_AT_THE_TOP_LEVEL_OF_A_MODULE,
+                        )
                     } else {
                         // TS1233: An export declaration can only be used at the top level
                         (
@@ -1385,6 +1391,11 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
                             diagnostic_codes::AN_EXPORT_DECLARATION_CAN_ONLY_BE_USED_AT_THE_TOP_LEVEL_OF_A_NAMESPACE_OR_MODULE,
                         )
                     }
+                } else if self.is_js_file() {
+                    (
+                        diagnostic_messages::AN_EXPORT_DECLARATION_CAN_ONLY_BE_USED_AT_THE_TOP_LEVEL_OF_A_MODULE,
+                        diagnostic_codes::AN_EXPORT_DECLARATION_CAN_ONLY_BE_USED_AT_THE_TOP_LEVEL_OF_A_MODULE,
+                    )
                 } else {
                     (
                         diagnostic_messages::AN_EXPORT_DECLARATION_CAN_ONLY_BE_USED_AT_THE_TOP_LEVEL_OF_A_NAMESPACE_OR_MODULE,

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -265,6 +265,8 @@ mod expando_annotated_receiver_tests;
 mod explicit_alias_constraint_relation_routing_arch_tests;
 #[path = "tests/explicit_type_arg_overload_pruning_tests.rs"]
 mod explicit_type_arg_overload_pruning_tests;
+#[path = "tests/export_declaration_module_element_context_tests.rs"]
+mod export_declaration_module_element_context_tests;
 #[path = "tests/flow_assignment_relation_routing_arch_tests.rs"]
 mod flow_assignment_relation_routing_arch_tests;
 #[path = "tests/flow_cache_policy_arch_tests.rs"]

--- a/crates/tsz-checker/src/tests/export_declaration_module_element_context_tests.rs
+++ b/crates/tsz-checker/src/tests/export_declaration_module_element_context_tests.rs
@@ -1,0 +1,141 @@
+//! TS1233 vs TS1474: an export declaration nested outside a module's top
+//! level (function body, block, arrow body) reports different wording in a
+//! `.ts` file (`"...top level of a namespace or module."`) than in a `.js`
+//! file (`"...top level of a module."`, no namespace phrase since JS has no
+//! namespaces). `check_grammar_module_element_context`
+//! (`state/state_checking_members/statement_callback_bridge.rs`) already made
+//! this exact TS-vs-JS distinction for the sibling `IMPORT_DECLARATION` case
+//! (TS1232/TS1473) but always emitted the namespace-flavored TS1233 message
+//! for `EXPORT_DECLARATION`, leaving TS1474 permanently unreachable.
+//!
+//! Verified against the pinned tsc 7.0.2 (`--strict --target es2022
+//! --module esnext`, plus `--allowJs --checkJs` for the `.js` witnesses).
+
+use crate::context::CheckerOptions;
+use crate::test_utils::check_source;
+
+const EXPORT_DECL_TOP_LEVEL_OF_NAMESPACE_OR_MODULE: u32 = 1233;
+const EXPORT_DECL_TOP_LEVEL_OF_MODULE: u32 = 1474;
+const DEFAULT_EXPORT_TOP_LEVEL: u32 = 1258;
+const MODIFIERS_CANNOT_APPEAR_HERE: u32 = 1184;
+
+fn ts_codes(source: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    };
+    check_source(source, "test.ts", options)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+fn js_codes(source: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        allow_js: true,
+        check_js: true,
+        strict: true,
+        ..CheckerOptions::default()
+    };
+    check_source(source, "test.js", options)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+// --- A named-export list nested in a function body. ---
+
+#[test]
+fn named_export_list_in_function_body_reports_ts1233_in_ts_file() {
+    let source = "function f() {\n  export { y };\n}\nvar y = 1;\n";
+    let codes = ts_codes(source);
+    assert!(codes.contains(&EXPORT_DECL_TOP_LEVEL_OF_NAMESPACE_OR_MODULE));
+    assert!(!codes.contains(&EXPORT_DECL_TOP_LEVEL_OF_MODULE));
+}
+
+#[test]
+fn named_export_list_in_function_body_reports_ts1474_in_js_file() {
+    let source = "function f() {\n  export { y };\n}\nvar y = 1;\n";
+    let codes = js_codes(source);
+    assert!(codes.contains(&EXPORT_DECL_TOP_LEVEL_OF_MODULE));
+    assert!(!codes.contains(&EXPORT_DECL_TOP_LEVEL_OF_NAMESPACE_OR_MODULE));
+}
+
+// --- Nesting depth varies: a bare block and an arrow function body. ---
+
+#[test]
+fn named_export_list_in_bare_block_reports_ts1233_in_ts_file() {
+    let source = "{\n  export { y };\n}\nvar y = 1;\n";
+    let codes = ts_codes(source);
+    assert!(codes.contains(&EXPORT_DECL_TOP_LEVEL_OF_NAMESPACE_OR_MODULE));
+    assert!(!codes.contains(&EXPORT_DECL_TOP_LEVEL_OF_MODULE));
+}
+
+#[test]
+fn named_export_list_in_bare_block_reports_ts1474_in_js_file() {
+    let source = "{\n  export { y };\n}\nvar y = 1;\n";
+    let codes = js_codes(source);
+    assert!(codes.contains(&EXPORT_DECL_TOP_LEVEL_OF_MODULE));
+    assert!(!codes.contains(&EXPORT_DECL_TOP_LEVEL_OF_NAMESPACE_OR_MODULE));
+}
+
+#[test]
+fn named_export_list_in_arrow_body_reports_ts1233_in_ts_file() {
+    let source = "const f = () => {\n  export { y };\n};\nvar y = 1;\n";
+    let codes = ts_codes(source);
+    assert!(codes.contains(&EXPORT_DECL_TOP_LEVEL_OF_NAMESPACE_OR_MODULE));
+    assert!(!codes.contains(&EXPORT_DECL_TOP_LEVEL_OF_MODULE));
+}
+
+#[test]
+fn named_export_list_in_arrow_body_reports_ts1474_in_js_file() {
+    let source = "const f = () => {\n  export { y };\n};\nvar y = 1;\n";
+    let codes = js_codes(source);
+    assert!(codes.contains(&EXPORT_DECL_TOP_LEVEL_OF_MODULE));
+    assert!(!codes.contains(&EXPORT_DECL_TOP_LEVEL_OF_NAMESPACE_OR_MODULE));
+}
+
+// --- Positive control: a top-level export list is clean in both file kinds. ---
+
+#[test]
+fn named_export_list_at_top_level_is_clean_in_ts_file() {
+    let source = "var y = 1;\nexport { y };\n";
+    let codes = ts_codes(source);
+    assert!(!codes.contains(&EXPORT_DECL_TOP_LEVEL_OF_NAMESPACE_OR_MODULE));
+    assert!(!codes.contains(&EXPORT_DECL_TOP_LEVEL_OF_MODULE));
+}
+
+#[test]
+fn named_export_list_at_top_level_is_clean_in_js_file() {
+    let source = "var y = 1;\nexport { y };\n";
+    let codes = js_codes(source);
+    assert!(!codes.contains(&EXPORT_DECL_TOP_LEVEL_OF_NAMESPACE_OR_MODULE));
+    assert!(!codes.contains(&EXPORT_DECL_TOP_LEVEL_OF_MODULE));
+}
+
+// --- Fallback controls: sibling grammar codes on the same statement kind do
+// --- NOT gain a JS-file variant, so they must stay byte-identical across
+// --- both file kinds (regression net for the two other arms this match
+// --- expression shares with the fix).
+
+#[test]
+fn default_export_nested_reports_ts1258_regardless_of_file_kind() {
+    let source = "function f() {\n  export default 5;\n}\n";
+    let ts = ts_codes(source);
+    let js = js_codes(source);
+    assert!(ts.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(js.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(!ts.contains(&EXPORT_DECL_TOP_LEVEL_OF_MODULE));
+    assert!(!js.contains(&EXPORT_DECL_TOP_LEVEL_OF_NAMESPACE_OR_MODULE));
+}
+
+#[test]
+fn exported_function_declaration_nested_reports_ts1184_regardless_of_file_kind() {
+    let source = "function f() {\n  export function g() {}\n}\n";
+    let ts = ts_codes(source);
+    let js = js_codes(source);
+    assert!(ts.contains(&MODIFIERS_CANNOT_APPEAR_HERE));
+    assert!(js.contains(&MODIFIERS_CANNOT_APPEAR_HERE));
+    assert!(!ts.contains(&EXPORT_DECL_TOP_LEVEL_OF_NAMESPACE_OR_MODULE));
+    assert!(!js.contains(&EXPORT_DECL_TOP_LEVEL_OF_MODULE));
+}


### PR DESCRIPTION
`check_grammar_module_element_context` (`crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs`) already makes the TS-file-vs-JS-file distinction for a misplaced `IMPORT_DECLARATION` — TS1232 "An import declaration can only be used at the top level of a namespace or module." in a `.ts` file vs TS1473 "...top level of a module." in a `.js` file, since JS has no namespaces — but the sibling `EXPORT_DECLARATION` arm always emitted the namespace-flavored TS1233, leaving its `.js`-file counterpart TS1474 permanently unreachable. Found while scanning #16291's "module-element context" family (TS1195/TS1216/TS1309/TS1474).

### Structural rule

**When an export declaration (a named-export list `export { x };` or `export * from "mod"`) appears outside a module's top level — a function body, bare block, or arrow-function body — in a `.js`/`.jsx` file, `tsc` reports TS1474; in a `.ts`/`.tsx` file it reports TS1233. `tsz`'s `EXPORT_DECLARATION` match arm now checks `self.is_js_file()` before choosing the message, mirroring the `IMPORT_DECLARATION` arm immediately above it in the same function.**

Two emit sites shared the TS1233 wording (the normal path, when `get_export_decl_at` resolves the export's clause, and a defensive fallback when it does not) and both needed the same gate; both are covered by tests.

### Owner layer

`crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs`, the single existing owner of TS1191/TS1232/TS1233/TS1258/TS1473/TS1474 grammar checks — no parser, solver, or emitter surface touched.

### Adjacent-case matrix

Pinned against `typescript@7.0.2` (`--strict --target es2022 --module esnext`, `--allowJs --checkJs` for the `.js` witnesses):

| shape | tsc (.ts) | tsc (.js) | tsz before | tsz after |
| --- | --- | --- | --- | --- |
| `export { y };` nested in a function body | TS1233 | TS1474 | TS1233 (both) | TS1233 / TS1474 |
| `export { y };` nested in a bare block | TS1233 | TS1474 | TS1233 (both) | TS1233 / TS1474 |
| `export { y };` nested in an arrow body | TS1233 | TS1474 | TS1233 (both) | TS1233 / TS1474 |
| `export { y };` at top level | clean | clean | clean | clean (unchanged) |
| `export default 5;` nested (sibling arm) | TS1258 | TS1258 | TS1258 (both) | TS1258 (both, unchanged) |
| `export function g() {}` nested (sibling arm) | TS1184 | TS1184 | TS1184 (both) | TS1184 (both, unchanged) |

The two sibling arms on the same match expression (TS1258 default-export, TS1184 modifiers-cannot-appear-here for an exported class/function/variable) do **not** vary by file kind — verified directly against the oracle and covered as regression-control tests so a future edit to this function can't accidentally couple them to `is_js_file()` too.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib export_declaration_module_element_context` — 10/10 (all new).
- `cargo nextest run -p tsz-checker --lib -E 'test(export) or test(import_declaration) or test(module_element)'` — 258/259 passed; the one failure (`ts2303_tests::recursive_export_assignment_self_import_reports_ts2303`) reproduces identically on `origin/main` in an isolated worktree (pre-existing, unrelated to this change — a global-type-count assertion in the no-lib unit harness).
- `cargo fmt --all` and `cargo clippy -p tsz-checker --lib -- -D warnings` — clean (run by the pre-commit hook).
- `scripts/arch/check-checker-boundaries.sh` — passed (run by the pre-commit hook).
- `scripts/conformance/compare-to-parent.sh origin/main` — running in the background at post time; this is a pure missing-diagnostic addition with no committed-corpus fixture observed emitting TS1474 today, so the expected signature is 0 newly-failing / 0 newly-passing per the board's standing note on this test class. Result to follow as a PR comment.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_01AQBkX8pcVT8ztToH2YZMpx)_