### PR TITLE
fix(parser): TS1519 class-set operator mixing was never wired

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1469,6 +1469,7 @@ pub(super) const fn is_non_suppressing_parse_error(code: u32) -> bool {
             | 1499 // Unknown regular expression flag (grammar check in tsc's checker, not a parse failure)
             | 1500 // Duplicate regular expression flag (grammar check, AST is valid)
             | 1502 // The Unicode 'u' and 'v' flags cannot be set simultaneously (grammar check, AST is valid)
+            | 1519 // Operators must not be mixed within a character class (regex grammar, AST is valid)
             | 1533 // Backreference to a group beyond the capturing-group count (regex grammar, AST is valid)
             | 1534 // Backreference with no capturing group in the pattern (regex grammar, AST is valid)
             | 1536 // Octal escape sequences and backreferences are not allowed in a character class (regex grammar, AST is valid)

--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -266,6 +266,10 @@ mod regex_backreference_tests;
 mod regex_class_set_nesting_tests;
 
 #[cfg(test)]
+#[path = "../../tests/regex_class_set_operator_mixing_tests.rs"]
+mod regex_class_set_operator_mixing_tests;
+
+#[cfg(test)]
 #[path = "../../tests/modifier_ordering_tests.rs"]
 mod modifier_ordering_tests;
 

--- a/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
@@ -1177,6 +1177,59 @@ impl ParserState {
                             || (body[pos] == b'-' && body[pos + 1] == b'-'))
                 }
 
+                /// Which `ClassSetExpression` production a class has committed
+                /// to. A plain range or a bare `-` is a union; the two
+                /// class-set operators are their own kinds. Mixing any two of
+                /// these in one class is TS1519.
+                #[derive(Clone, Copy, PartialEq, Eq)]
+                enum ClassSetKind {
+                    Union,
+                    Subtraction,
+                    Intersection,
+                }
+
+                /// Classify the operator at `pos`, which the caller has already
+                /// confirmed with `is_class_set_operator_at`.
+                fn class_set_operator_kind(body: &[u8], pos: usize) -> ClassSetKind {
+                    if body[pos] == b'-' {
+                        ClassSetKind::Subtraction
+                    } else {
+                        ClassSetKind::Intersection
+                    }
+                }
+
+                /// Record `kind` as this class's operator, reporting TS1519 on
+                /// the first operator that disagrees with the one already
+                /// committed. The committed kind is deliberately left unchanged
+                /// on a mismatch so the report stays keyed to the class's
+                /// original production.
+                fn note_class_set_kind<F>(
+                    parser: &mut ParserState,
+                    ctx: &RegexScanContext<'_, F>,
+                    committed: &mut Option<ClassSetKind>,
+                    mixed_reported: &mut bool,
+                    kind: ClassSetKind,
+                    at: usize,
+                    len: u32,
+                ) where
+                    F: Fn(&mut ParserState, usize, u32, &str, u32),
+                {
+                    match *committed {
+                        None => *committed = Some(kind),
+                        Some(existing) if existing != kind && !*mixed_reported => {
+                            *mixed_reported = true;
+                            (ctx.emit)(
+                                parser,
+                                at,
+                                len,
+                                diagnostic_messages::OPERATORS_MUST_NOT_BE_MIXED_WITHIN_A_CHARACTER_CLASS_WRAP_IT_IN_A_NESTED_CLASS_I,
+                                diagnostic_codes::OPERATORS_MUST_NOT_BE_MIXED_WITHIN_A_CHARACTER_CLASS_WRAP_IT_IN_A_NESTED_CLASS_I,
+                            );
+                        }
+                        Some(_) => {}
+                    }
+                }
+
                 fn scan_class_set_operator(
                     parser: &mut ParserState,
                     emit: &impl Fn(&mut ParserState, usize, u32, &str, u32),
@@ -1204,10 +1257,15 @@ impl ParserState {
                     *pos += 1;
                 }
 
-                // A `ClassSetExpression` that has committed to `--`/`&&` no
-                // longer admits ranges, so a later `-` is not a range operator
-                // and its operands are not range bounds.
-                let mut in_class_set_expression = false;
+                // The first operator a class uses fixes its kind, and mixing a
+                // different one in the same class is TS1519. The commitment is
+                // per class, not per pattern: a nested class recurses into its
+                // own `scan_class_ranges` and so gets its own `committed`,
+                // which is why `/[[a--b]&&c]/v` is legal.
+                let mut committed: Option<ClassSetKind> = None;
+                // tsc reports the mixture once, on the first operator that
+                // disagrees — `/[a--b&&c--d]/v` draws a single TS1519.
+                let mut mixed_reported = false;
 
                 while *pos < ctx.body_end {
                     if ctx.body[*pos] == b']' {
@@ -1217,7 +1275,15 @@ impl ParserState {
                     if ctx.unicode_sets_mode
                         && is_class_set_operator_at(ctx.body, *pos, ctx.body_end)
                     {
-                        in_class_set_expression = true;
+                        note_class_set_kind(
+                            parser,
+                            ctx,
+                            &mut committed,
+                            &mut mixed_reported,
+                            class_set_operator_kind(ctx.body, *pos),
+                            *pos,
+                            2,
+                        );
                         scan_class_set_operator(parser, ctx.emit, ctx.body, ctx.body_end, pos);
                         continue;
                     }
@@ -1228,17 +1294,41 @@ impl ParserState {
                     if ctx.unicode_sets_mode
                         && is_class_set_operator_at(ctx.body, *pos, ctx.body_end)
                     {
-                        in_class_set_expression = true;
+                        note_class_set_kind(
+                            parser,
+                            ctx,
+                            &mut committed,
+                            &mut mixed_reported,
+                            class_set_operator_kind(ctx.body, *pos),
+                            *pos,
+                            2,
+                        );
                         scan_class_set_operator(parser, ctx.emit, ctx.body, ctx.body_end, pos);
                         continue;
                     }
                     if *pos >= ctx.body_end || ctx.body[*pos] != b'-' {
                         continue;
                     }
-                    if in_class_set_expression {
+                    // A class already committed to `--`/`&&` admits no ranges,
+                    // so this `-` is a union operator mixed into a set
+                    // expression rather than a range separator.
+                    if matches!(
+                        committed,
+                        Some(ClassSetKind::Subtraction | ClassSetKind::Intersection)
+                    ) {
+                        note_class_set_kind(
+                            parser,
+                            ctx,
+                            &mut committed,
+                            &mut mixed_reported,
+                            ClassSetKind::Union,
+                            *pos,
+                            1,
+                        );
                         *pos += 1;
                         continue;
                     }
+                    committed = Some(ClassSetKind::Union);
 
                     *pos += 1;
 

--- a/crates/tsz-parser/tests/regex_class_set_nesting_tests.rs
+++ b/crates/tsz-parser/tests/regex_class_set_nesting_tests.rs
@@ -115,20 +115,26 @@ fn nested_classes_on_both_range_bounds_report_ts1516_twice() {
 // check (TS1516) nor the range-order check (TS1517) may fire inside one
 // ---------------------------------------------------------------------------
 
+/// A `-` after a class-set operator is not a range separator — but it is not
+/// nothing either. It is a union operator mixed into a set expression, which is
+/// TS1519; these three rows asserted `clean` while that code was unwired, and
+/// the oracle reports on the `-` in every one of them.
 #[test]
-fn hyphen_after_a_class_set_operator_is_not_a_range() {
-    assert_eq!(regex_codes("const a = /[a--b-c]/v;"), Vec::<u32>::new());
-    assert_eq!(regex_codes("const a = /[a&&b-c]/v;"), Vec::<u32>::new());
-    assert_eq!(regex_codes("const a = /[[a]--b-c]/v;"), Vec::<u32>::new());
+fn hyphen_after_a_class_set_operator_is_a_mixed_operator_not_a_range() {
+    assert_eq!(regex_codes_at("const a = /[a--b-c]/v;"), vec![(1519, 16)]);
+    assert_eq!(regex_codes_at("const a = /[a&&b-c]/v;"), vec![(1519, 16)]);
+    assert_eq!(regex_codes_at("const a = /[[a]--b-c]/v;"), vec![(1519, 18)]);
 }
 
 /// The witness that first exposed this: a descending pair inside a subtraction
 /// is not a range, so TS1517 must not fire on it.
 #[test]
 fn descending_pair_inside_a_subtraction_does_not_report_ts1517() {
+    // Still no TS1517 — the point of this row. The `-` is now correctly
+    // reported as a mixed union operator (TS1519) rather than passing silently.
     assert_eq!(
-        regex_codes("const a = /[[a]--\\P{L}-_]/v;"),
-        Vec::<u32>::new()
+        regex_codes_at("const a = /[[a]--\\P{L}-_]/v;"),
+        vec![(1519, 22)]
     );
 }
 

--- a/crates/tsz-parser/tests/regex_class_set_operator_mixing_tests.rs
+++ b/crates/tsz-parser/tests/regex_class_set_operator_mixing_tests.rs
@@ -1,0 +1,153 @@
+//! Mixing class-set operators inside one `v`-mode character class (TS1519).
+//!
+//! Under `v` the first operator a class uses fixes its production — union (a
+//! range or a bare `-`), subtraction (`--`) or intersection (`&&`) — and a
+//! later operator of a different kind is an error. The commitment is scoped to
+//! one class: a nested class recurses and gets its own, which is what makes
+//! `/[[a--b]&&c]/v` legal.
+//!
+//! Every row is pinned against `typescript@7.0.2`
+//! (`--noEmit --strict --pretty false --target esnext`), on code *and* column.
+//! `tsc` renders 1-based columns; this harness reports zero-based offsets, so
+//! each expectation below is the oracle's column minus one.
+use crate::parser::test_fixture::parse_source;
+
+fn regex_codes(source: &str) -> Vec<u32> {
+    let (parser, _root) = parse_source(source);
+    parser.get_diagnostics().iter().map(|d| d.code).collect()
+}
+
+/// `(code, zero-based offset)` — the offset is what the CLI renders as a
+/// column, and an operator-mixing fix that reports on the wrong operand is only
+/// visible here.
+fn regex_codes_at(source: &str) -> Vec<(u32, u32)> {
+    let (parser, _root) = parse_source(source);
+    parser
+        .get_diagnostics()
+        .iter()
+        .map(|d| (d.code, d.start))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Two different class-set operators in one class
+// ---------------------------------------------------------------------------
+
+#[test]
+fn subtraction_then_intersection_reports_on_the_intersection() {
+    // `/[a--b&&c]/v` — offset 16 is the `&&`, the operator that disagrees.
+    // (tsc renders it as column 17; the harness offset is zero-based.)
+    assert_eq!(regex_codes_at("const a = /[a--b&&c]/v;"), vec![(1519, 16)]);
+}
+
+#[test]
+fn intersection_then_subtraction_reports_on_the_subtraction() {
+    assert_eq!(regex_codes_at("const a = /[a&&b--c]/v;"), vec![(1519, 16)]);
+}
+
+/// The leading `^` shifts every offset by one; an off-by-one in the report
+/// position is otherwise invisible.
+#[test]
+fn negated_class_reports_at_the_shifted_offset() {
+    assert_eq!(regex_codes_at("const a = /[^a--b&&c]/v;"), vec![(1519, 17)]);
+}
+
+/// A nested class is an operand, so the operator after it still belongs to the
+/// outer class and still mixes.
+#[test]
+fn operator_after_a_nested_class_operand_still_mixes() {
+    assert_eq!(
+        regex_codes_at("const a = /[[a]--b&&c]/v;"),
+        vec![(1519, 18)]
+    );
+}
+
+/// tsc reports the mixture once, on the first operator that disagrees — not
+/// once per subsequent operator.
+#[test]
+fn a_mixed_class_reports_exactly_once() {
+    assert_eq!(
+        regex_codes_at("const a = /[a--b&&c--d]/v;"),
+        vec![(1519, 16)]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A range commits the class to union, so a class-set operator after one mixes
+// ---------------------------------------------------------------------------
+
+#[test]
+fn range_then_subtraction_reports_on_the_subtraction() {
+    // `/[a-b--c]/v` — offset 15 is the `--`; the range `a-b` came first.
+    assert_eq!(regex_codes_at("const a = /[a-b--c]/v;"), vec![(1519, 15)]);
+}
+
+#[test]
+fn range_then_intersection_reports_on_the_intersection() {
+    assert_eq!(regex_codes_at("const a = /[a-b&&c]/v;"), vec![(1519, 15)]);
+}
+
+// ---------------------------------------------------------------------------
+// A bare `-` inside a committed set expression is a union operator, not a range
+// ---------------------------------------------------------------------------
+
+#[test]
+fn hyphen_after_a_subtraction_reports_on_the_hyphen() {
+    // `/[a--b-c]/v` — offset 16 is the bare `-`, which is a mixed union
+    // operator here rather than a range separator.
+    assert_eq!(regex_codes_at("const a = /[a--b-c]/v;"), vec![(1519, 16)]);
+}
+
+#[test]
+fn hyphen_after_an_intersection_reports_on_the_hyphen() {
+    assert_eq!(regex_codes_at("const a = /[a&&b-c]/v;"), vec![(1519, 16)]);
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls: a repeated operator is legal, and nesting scopes the
+// commitment
+// ---------------------------------------------------------------------------
+
+/// Repeating the *same* operator is not mixing — a fix keyed on "a second
+/// operator appeared" regresses these two.
+#[test]
+fn a_repeated_operator_is_not_mixing() {
+    assert_eq!(regex_codes("const a = /[a--b--c]/v;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[a&&b&&c]/v;"), Vec::<u32>::new());
+}
+
+/// Each class carries its own commitment, so an inner operator and a different
+/// outer one do not mix. A fix that hoists the state out of `scan_class_ranges`
+/// regresses these two.
+#[test]
+fn nesting_scopes_the_commitment() {
+    assert_eq!(regex_codes("const a = /[[a--b]&&c]/v;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[a--[b&&c]]/v;"), Vec::<u32>::new());
+}
+
+/// A class that uses one operator, or none, is unaffected.
+#[test]
+fn a_single_operator_or_none_is_clean() {
+    assert_eq!(regex_codes("const a = /[a--b]/v;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[a&&b]/v;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[a-b]/v;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[abc]/v;"), Vec::<u32>::new());
+}
+
+/// `--`/`&&` are `v`-only spellings: under `u` and under Annex B the same text
+/// is ordinary class content, so TS1519 must never fire outside `v`.
+#[test]
+fn mixing_is_v_only() {
+    assert_eq!(regex_codes("const a = /[a--b&&c]/u;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[a--b&&c]/;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[a&&b--c]/;"), Vec::<u32>::new());
+}
+
+/// The range-order pass (TS1517) is driven by its own walk and must keep
+/// working inside a class that also carries an operator — this is the row
+/// #16301 added, re-asserted here so a TS1519 fix cannot silently take it out.
+#[test]
+fn range_order_diagnostics_survive_alongside_an_operator() {
+    assert_eq!(regex_codes("const a = /[a--b][z-a]/v;"), vec![1517]);
+    assert_eq!(regex_codes("const a = /[a--[z-a]]/v;"), vec![1517]);
+}


### PR DESCRIPTION
## Goal

Goal: hold

Closes the TS1519 half of [#16304](https://github.com/tsz-org/tsz/issues/16304), which I filed this session after scoping it. It is the slice [#16301](https://github.com/tsz-org/tsz/pull/16301) named in its own "deliberately out of scope" list, and one of the ~20 codes in [#16291](https://github.com/tsz-org/tsz/issues/16291)'s regex cluster. **8 shapes that tsc reports are silent in tsz today; this wires 9 of the 11 measured rows.**

### Structural rule

**When a `v`-mode character class uses a second class-set operator of a different kind from the one it already committed to, `tsc` reports TS1519 on the offending operator, and `tsz` now does the same through the parser's regex walker.**

The commitment is one of three productions — union (a range or a bare `-`), subtraction (`--`), intersection (`&&`) — and it is scoped to a single class. `scan_class_ranges` already tracked exactly this as a bool (`in_class_set_expression`, added by #16301); this generalises that bool into the kind it should have been. Because a nested class recurses into its own `scan_class_ranges`, per-class scoping falls out for free — `/[[a--b]&&c]/v` stays legal with no extra work.

**A bare `-` is not simply a third operator kind**, and this is the part that makes the rule non-obvious:

- inside a class already committed to `--`/`&&`, a `-` is a *mixed union operator* and reports TS1519 (`/[a&&b-c]/v`);
- inside a plain union class, the same character is an ordinary range separator and does not (`/[a-b]/v`).

#16301's body described the missing model as *"the class must remember which operator it committed to"*. That framing is not sufficient — implemented literally it gets the two bare-`-` rows wrong — which is why #16304 records the corrected rule.

### Owner layer

`crates/tsz-parser/src/parser/state_expressions_literals_regex.rs`, in `scan_class_ranges` — the parser's regex validation, which already owns TS1508/TS1516/TS1517/TS1520 and the `unicode_sets_mode` flag. No checker, solver or emitter surface is touched, and no diagnostic string is used as a predicate. The one non-parser line is the `is_non_suppressing_parse_error` entry described below.

### Adjacent-case matrix

Every row pinned against `typescript@7.0.2` (`--noEmit --strict --pretty false --target esnext`), on **code and column**. Offsets in the tests are zero-based; `tsc`'s rendered column is one greater.

| shape | tsc | tsz (parent) | tsz (branch) |
| --- | --- | --- | --- |
| `/[a--b&&c]/v` | TS1519 @17 | *(silent)* | TS1519 @17 |
| `/[a&&b--c]/v` | TS1519 @17 | *(silent)* | TS1519 @17 |
| `/[a--b-c]/v` | TS1519 @17 | *(silent)* | TS1519 @17 |
| `/[a&&b-c]/v` | TS1519 @17 | *(silent)* | TS1519 @17 |
| `/[a-b--c]/v` | TS1519 @16 | *(silent)* | TS1519 @16 |
| `/[a-b&&c]/v` | TS1519 @16 | *(silent)* | TS1519 @16 |
| `/[[a]--b&&c]/v` | TS1519 @19 | *(silent)* | TS1519 @19 |
| `/[^a--b&&c]/v` | TS1519 @18 | *(silent)* | TS1519 @18 |
| `/[[a]--b-c]/v` | TS1519 @19 | *(silent)* | TS1519 @19 |
| `/[[a]--\P{L}-_]/v` | TS1519 @23 | *(silent)* | TS1519 @23 |
| `/[a--b&&c--d]/v` | TS1519 @17 **once** | *(silent)* | TS1519 @17 once |
| `/[a--b--c]/v`, `/[a&&b&&c]/v` | clean | clean | clean |
| `/[[a--b]&&c]/v`, `/[a--[b&&c]]/v` | clean | clean | clean |
| `/[a--b]/v`, `/[a&&b]/v`, `/[a-b]/v`, `/[abc]/v` | clean | clean | clean |
| `/[a--b&&c]/u`, `/[a--b&&c]/`, `/[a&&b--c]/` | clean | clean | clean |
| `/[a--b][z-a]/v`, `/[a--[z-a]]/v` | TS1517 | TS1517 | TS1517 |

The negative controls are the load-bearing rows and each kills a specific wrong implementation: **a repeated operator of the same kind is legal** (kills "report on the second operator"), **nesting scopes the commitment** (kills hoisting the state into `RegexScanContext`), **the `^` row** shifts every offset by one (catches an off-by-one that is otherwise invisible), and the **`u`/Annex-B rows** hold the flag gate. The two TS1517 rows are #16301's, re-asserted here so a TS1519 fix cannot silently take the range-order pass out.

### Two of #16301's expectations are corrected, not preserved

`hyphen_after_a_class_set_operator_is_not_a_range` and `descending_pair_inside_a_subtraction_does_not_report_ts1517` asserted `clean` on `/[a--b-c]/v`, `/[a&&b-c]/v`, `/[[a]--b-c]/v` and `/[[a]--\P{L}-_]/v`. Those assertions encoded the *unwired* state — #16301's own matrix marks all four `TS1519 (unwired)` — and the oracle reports TS1519 on every one. They are updated to the oracle here. The second test's actual point (no spurious TS1517 inside a subtraction) is unchanged and still asserted.

### `is_non_suppressing_parse_error`

TS1519 is added to that list (`crates/tsz-cli/src/driver/check_utils.rs`), per @mohsen1's `Jasper` hazard on #16296: a newly-wired parser diagnostic joins the suppressing set by default and silently swallows unrelated check-time diagnostics. Checked in the direction the change introduces, with that finding's standard fixture:

```
const r = /[a--b&&c]/v;   // tsc: TS1519
const n: number = "x";    //      TS2322   <- would be swallowed without the entry
undeclaredFn();           //      TS2304
```

`tsc` reports all three, so TS1519 belongs in the list. It joins 1487/1499/1500/1502/1533/1534/1536/1537, which are there for exactly this reason.

## Verification

- `cargo fmt`; `cargo clippy -p tsz-parser --all-targets` clean. The pre-commit hook's full `dist-fast` workspace clippy + arch-size guard both passed (`Clippy passed. / Architecture guard passed.`).
- `cargo test -p tsz-parser --lib` — **1653 passed, 0 failed** (`cargo-nextest` is absent on this cloud seat, per several board notes). The regex-class-set families specifically: **31 passed, 0 failed**.
- **Non-vacuity**, by `git stash` of the source file only, leaving the tests in place: the new suite fails without the fix, so it fails for the real reason.
- Oracle: all 11 positive rows and every negative control above run against a real `typescript@7.0.2` subprocess, compared on code and column.

**Gate owed — please do not queue this until it is run.** This adds a diagnostic, so `scripts/conformance/compare-to-parent.sh` is the real gate here and I could not run it: this container spent its corpus budget on a two-sided sweep for #16301 before that PR merged with its own gate already clean, and a fresh `dist-fast` build plus two snapshots did not fit in the remaining session. The targeted matrix above is oracle-pinned but it cannot see corpus rows that pair a `v`-mode regex with other diagnostics. A warm-corpus seat can clear this in one pass; per @mohsen1's `Diorite` note, a pushed head with its verification gap named is worth more than a held diff.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Gabbro

---
_Generated by [Claude Code](https://claude.ai/code/session_01TXKUqf7VwCkCW8raHDcDw3)_