### PR TITLE
fix(parser): TS1180 (object-binding property destructuring) was never wired

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1332,6 +1332,7 @@ pub(super) const fn is_real_syntax_error(code: u32) -> bool {
         | 1155 // 'const' declarations must be initialized
         | 1160 // Unterminated template literal
         | 1161 // Unterminated regular expression literal
+        | 1180 // Property destructuring pattern expected
         | 1002 // Unterminated string literal
         | 1003 // Identifier expected
         | 1006 // A file cannot have a reference to itself
@@ -1417,6 +1418,7 @@ pub(super) const fn is_structural_parse_error(code: u32) -> bool {
         | 1155 // 'const' declarations must be initialized
         | 1160 // Unterminated template literal
         | 1161 // Unterminated regular expression literal
+        | 1180 // Property destructuring pattern expected
         | 1185 // Merge conflict marker encountered
         | 1313 // 'else' is not allowed after rest element
         | 1351 // An identifier or keyword cannot immediately follow a numeric literal

--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -305,6 +305,10 @@ mod computed_property_binding_recovery_tests;
 #[path = "../../tests/reserved_parameter_recovery_tests.rs"]
 mod reserved_parameter_recovery_tests;
 
+#[cfg(test)]
+#[path = "../../tests/ts1180_property_destructuring_pattern_expected_tests.rs"]
+mod ts1180_property_destructuring_pattern_expected_tests;
+
 // Re-export flags
 pub use flags::{modifier_flags, node_flags, transform_flags};
 

--- a/crates/tsz-parser/src/parser/state_expressions_literals.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals.rs
@@ -90,7 +90,7 @@ impl ParserState {
                 let first_token_is_reserved = self.is_reserved_word();
                 let first_name_start = self.token_pos();
                 let first_name_end = self.token_end();
-                let first_name = self.parse_property_name();
+                let first_name = self.parse_property_name_for_binding();
 
                 let (property_name, name) = if self.parse_optional(SyntaxKind::ColonToken) {
                     // propertyName: name

--- a/crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs
@@ -1065,6 +1065,19 @@ impl ParserState {
 
     /// Parse property name (identifier, string literal, numeric literal, bigint literal, computed)
     pub(crate) fn parse_property_name(&mut self) -> NodeIndex {
+        self.parse_property_name_impl(false)
+    }
+
+    /// Parse a binding-element property name: `{ propertyName: name } = ...`.
+    /// Same grammar as `parse_property_name`, but an invalid token reports
+    /// TS1180 ("Property destructuring pattern expected.") instead of
+    /// TS1136 ("Property assignment expected."), matching tsc's
+    /// `ParsingContext.ObjectBindingElements` recovery message.
+    pub(crate) fn parse_property_name_for_binding(&mut self) -> NodeIndex {
+        self.parse_property_name_impl(true)
+    }
+
+    fn parse_property_name_impl(&mut self, in_binding_pattern: bool) -> NodeIndex {
         match self.token() {
             SyntaxKind::StringLiteral => {
                 // String literal can be property name: { "key": value }
@@ -1162,10 +1175,17 @@ impl ParserState {
 
                 if !is_identifier_or_keyword {
                     use tsz_common::diagnostics::diagnostic_codes;
-                    self.parse_error_at_current_token(
-                        "Property assignment expected.",
-                        diagnostic_codes::PROPERTY_ASSIGNMENT_EXPECTED,
-                    );
+                    if in_binding_pattern {
+                        self.parse_error_at_current_token(
+                            "Property destructuring pattern expected.",
+                            diagnostic_codes::PROPERTY_DESTRUCTURING_PATTERN_EXPECTED,
+                        );
+                    } else {
+                        self.parse_error_at_current_token(
+                            "Property assignment expected.",
+                            diagnostic_codes::PROPERTY_ASSIGNMENT_EXPECTED,
+                        );
+                    }
                     // For object-literal terminators/separators (`,`, `}`, `;`, EOF), do NOT
                     // consume the token. Consuming a `,` here causes us to synthesize a
                     // SHORTHAND_PROPERTY_ASSIGNMENT with an empty name, which then prints

--- a/crates/tsz-parser/tests/ts1180_property_destructuring_pattern_expected_tests.rs
+++ b/crates/tsz-parser/tests/ts1180_property_destructuring_pattern_expected_tests.rs
@@ -1,0 +1,123 @@
+//! TS1180 (`Property destructuring pattern expected.`) was previously
+//! unwired: an invalid property-name token inside an object *binding*
+//! pattern (`const { <bad> } = x`) fell through to the object-*literal*
+//! message TS1136 (`Property assignment expected.`) instead, because both
+//! contexts shared one property-name parser with a single hardcoded
+//! diagnostic. tsc's `parsingContextErrors` picks the message from the
+//! enclosing `ParsingContext` (`ObjectBindingElements` vs
+//! `ObjectLiteralMembers`); this generalizes the shared parser the same way.
+//!
+//! Oracle: typescript@7.0.2, `--noEmit --strict --target es2022`.
+
+use crate::parser::test_fixture::parse_source;
+use tsz_common::diagnostics::diagnostic_codes;
+
+fn parse_codes(source: &str) -> Vec<u32> {
+    let (parser, _root) = parse_source(source);
+    parser.parse_diagnostics.iter().map(|d| d.code).collect()
+}
+
+fn assert_ts1180_at_bad_token(source: &str, bad_token: &str) {
+    let (parser, _root) = parse_source(source);
+    let expected_start = source.find(bad_token).expect("bad token in source") as u32;
+    let first = parser
+        .parse_diagnostics
+        .first()
+        .unwrap_or_else(|| panic!("expected at least one diagnostic for {source:?}"));
+    assert_eq!(
+        first.code,
+        diagnostic_codes::PROPERTY_DESTRUCTURING_PATTERN_EXPECTED,
+        "expected TS1180 for {source:?}, got {:?}",
+        parser
+            .parse_diagnostics
+            .iter()
+            .map(|d| d.code)
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        first.start, expected_start,
+        "expected TS1180 at the bad token's position for {source:?}"
+    );
+}
+
+#[test]
+fn const_decl_with_invalid_property_token_emits_ts1180() {
+    assert_ts1180_at_bad_token("const {!} = x;", "!");
+}
+
+#[test]
+fn function_parameter_object_binding_with_invalid_token_emits_ts1180() {
+    assert_ts1180_at_bad_token("function f({!}: any) {}", "!");
+}
+
+#[test]
+fn catch_clause_object_binding_with_invalid_token_emits_ts1180() {
+    assert_ts1180_at_bad_token("try {} catch ({!}) {}", "!");
+}
+
+#[test]
+fn for_of_head_object_binding_with_invalid_token_emits_ts1180() {
+    assert_ts1180_at_bad_token("for (const {!} of []) {}", "!");
+}
+
+#[test]
+fn nested_array_binding_with_invalid_token_emits_ts1180() {
+    assert_ts1180_at_bad_token("const [{!}] = [];", "!");
+}
+
+#[test]
+fn different_invalid_token_still_emits_ts1180() {
+    // Proves the diagnostic is not keyed to the specific offending character.
+    assert_ts1180_at_bad_token("const {@} = x;", "@");
+}
+
+#[test]
+fn object_literal_with_invalid_property_token_still_emits_ts1136_not_ts1180() {
+    let codes = parse_codes("const o = {!};");
+    assert!(
+        codes.contains(&diagnostic_codes::PROPERTY_ASSIGNMENT_EXPECTED),
+        "expected TS1136 for an object-literal expression, got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&diagnostic_codes::PROPERTY_DESTRUCTURING_PATTERN_EXPECTED),
+        "must not emit TS1180 for an object-literal expression, got {codes:?}"
+    );
+}
+
+#[test]
+fn destructuring_assignment_pattern_with_invalid_token_still_emits_ts1136_not_ts1180() {
+    // `({...} = x)` is parsed as an object-literal expression and later
+    // reinterpreted as an assignment pattern, so it stays on tsc's
+    // `ObjectLiteralMembers` message — not the binding-declaration one.
+    let codes = parse_codes("declare let x: any; ({!} = x);");
+    assert!(
+        codes.contains(&diagnostic_codes::PROPERTY_ASSIGNMENT_EXPECTED),
+        "expected TS1136 for a destructuring-assignment pattern, got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&diagnostic_codes::PROPERTY_DESTRUCTURING_PATTERN_EXPECTED),
+        "must not emit TS1180 for a destructuring-assignment pattern, got {codes:?}"
+    );
+}
+
+#[test]
+fn well_formed_object_binding_pattern_emits_no_diagnostics() {
+    let source = "declare const obj: {a: number, b: number}; const {a, b: c, ...rest} = obj;";
+    let codes = parse_codes(source);
+    assert!(
+        codes.is_empty(),
+        "expected zero parser diagnostics for well-formed binding pattern, got {codes:?}"
+    );
+}
+
+#[test]
+fn numeric_property_name_in_binding_pattern_still_parses_cleanly() {
+    // Numeric/string property names are handled by an earlier match arm in
+    // the shared parser and must stay unaffected by the TS1180/TS1136 split.
+    let source = "declare const obj: {123: number}; const {123: x} = obj;";
+    let codes = parse_codes(source);
+    assert!(
+        codes.is_empty(),
+        "expected zero parser diagnostics for numeric property binding, got {codes:?}"
+    );
+}


### PR DESCRIPTION
## Goal

Goal: hold

Closes the TS1180 slice of [#16291](https://github.com/tsz-org/tsz/issues/16291)'s "parser recovery" family (TS1140, TS1179, TS1180, TS1439).

### Structural rule

**When an object *binding* pattern (`const {...} = x`, a parameter list, a catch clause, a for-of head, or a nested array/object pattern) hits a token that cannot start a property name, `tsc` reports TS1180 ("Property destructuring pattern expected."); when the same failure happens inside an object-*literal* expression, `tsc` reports TS1136 ("Property assignment expected."). tsz's parser shared one `parse_property_name` helper for both contexts with the TS1136 message hardcoded, so every binding-pattern site silently emitted the wrong code.**

tsc's `parsingContextErrors` (parser.ts) dispatches the recovery message from the enclosing `ParsingContext` — `ObjectBindingElements` → TS1180, `ObjectLiteralMembers` → TS1136. tsz had no such split: `crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs`'s `parse_property_name` always reported TS1136 for an unrecognized token, regardless of whether it was called from `parse_object_binding_pattern` (binding context) or object-literal member parsing.

### Owner layer

Parser only — `crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs` (the shared property-name parser) and its one binding-pattern call site in `state_expressions_literals.rs`. No checker/solver/emitter surface touched. `crates/tsz-cli/src/driver/check_utils.rs` gets TS1180 added to `is_real_syntax_error`/`is_structural_parse_error` alongside its TS1136 sibling, since it's the same class of structural (AST-malforming) parse failure and needs the same cascading-suppression treatment.

The fix splits `parse_property_name` into:
- `parse_property_name` (unchanged) — TS1136, used by every existing call site (object literals, class members, import attributes, etc.)
- `parse_property_name_for_binding` (new) — TS1180, wired only at `parse_object_binding_pattern`'s regular-element call site

### Adjacent-case matrix

Oracle-pinned against `typescript@7.0.2` (`--noEmit --strict --target es2022`), primary code and column exact:

| shape | tsc (primary) | tsz (parent) | tsz (branch) |
| --- | --- | --- | --- |
| `const {!} = x;` | TS1180 @ col 8 | TS1136 @ col 8 | TS1180 @ col 8 |
| `function f({!}: any) {}` (parameter) | TS1180 @ col 13 | TS1136 | TS1180 @ col 13 |
| `try {} catch ({!}) {}` | TS1180 @ col 16 | TS1136 | TS1180 @ col 16 |
| `for (const {!} of []) {}` | TS1180 @ col 13 | TS1136 | TS1180 @ col 13 |
| `const [{!}] = [];` (nested array) | TS1180 @ col 9 | TS1136 | TS1180 @ col 9 |
| `const {@} = x;` (different bad token) | TS1180 | TS1136 | TS1180 |
| `const o = {!};` (object literal, negative control) | TS1136 | TS1136 | TS1136 (unchanged) |
| `({!} = x);` (destructuring *assignment*, negative control) | TS1136 | TS1136 | TS1136 (unchanged) |
| `const {a, b: c, ...rest} = obj;` (well-formed) | clean | clean | clean |
| `const {123: x} = obj;` (numeric property name) | clean | clean | clean |

The negative controls are load-bearing: destructuring-*assignment* patterns (`({...} = x)`) are parsed as object-literal expressions in both tsc and tsz and only later reinterpreted as assignment targets, so they correctly stay on TS1136 — this is why the fix is scoped to `parse_object_binding_pattern`'s call site only, not a blanket "binding vs not" flag threaded through every caller.

Secondary cascade diagnostics after the primary code differ from tsc's (tsz emits `TS1005 ':' expected`, tsc emits `TS1109`/`TS1138`/etc. depending on context) — this divergence in the downstream recovery cascade predates this change (tsz emitted `TS1136` + the same `TS1005` before the fix) and is out of scope here; only the primary unwired code is addressed.

## Verification

- `cargo fmt` clean; `cargo clippy -p tsz-parser -p tsz-cli --all-targets` clean (pre-commit hook's full clippy + arch-size guard passed).
- `cargo test -p tsz-parser --lib` — **1649 passed, 0 failed** (was 1639 before the 10 new tests).
- `cargo test -p tsz-cli --lib check_utils` — **112 passed, 0 failed**.
- **Non-vacuity**: `git stash` of the two parser source files (tests left in place) — 6 of the 10 new tests fail without the fix, for the expected reason (wrong diagnostic code).
- Oracle: every row in the matrix above run against a real `typescript@7.0.2` subprocess.
- **Corpus gate — now run and clean.** `scripts/conformance/compare-to-parent.sh` (branch `36a7faa` vs base `d7f173d`, the exact PR base sha): both sides `11482/12043` passed, `561` failing on both sides, **0 newly failing, 0 newly passing, 0 fingerprint-changed**. This closes the gate that was owed and disclosed at open time (the change touches the shared `is_real_syntax_error`/`is_structural_parse_error` predicates).
- CI Summary green at exact head `36a7faa` (clippy + arch-size, the per-merge lane).

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_011suERNATNToCSD9BMxnrur)_