### PR TITLE
fix(checker): TS1539 must be suppressed program-wide by a real syntax error

### DIFF
--- a/crates/tsz-checker/src/checkers/property_checker/literal_name_grammar.rs
+++ b/crates/tsz-checker/src/checkers/property_checker/literal_name_grammar.rs
@@ -8,17 +8,30 @@ impl<'a> CheckerState<'a> {
     /// TS1539: a literal (non-computed) `bigint` name cannot be used as a
     /// property name.
     ///
-    /// Fires unconditionally for property-shaped members — interface/type-literal
-    /// property signatures, class property declarations, and object-literal
-    /// property assignments — regardless of `readonly`, `static`, `declare`,
-    /// optionality, or decorators. Never fires on the method-shaped equivalent
-    /// (methods, `get`/`set` accessors) in any of those containers, so callers
-    /// must gate on the member being a property, not a method or accessor.
+    /// Fires for property-shaped members — interface/type-literal property
+    /// signatures, class property declarations, and object-literal property
+    /// assignments — regardless of `readonly`, `static`, `declare`, or
+    /// optionality. Never fires on the method-shaped equivalent (methods,
+    /// `get`/`set` accessors) in any of those containers, so callers must
+    /// gate on the member being a property, not a method or accessor.
+    ///
+    /// Suppressed program-wide when any file has a real syntax error, like its
+    /// sibling property-name-shape checks (TS2464's computed-property-name
+    /// validation in `property_checker.rs`, TS1170 in `type_checking/core.rs`):
+    /// `tsc` never runs semantic checks past a parse failure anywhere in the
+    /// compilation, so a `bigintPropertyName`-shaped member sitting in a file
+    /// unrelated to an unrelated file's own syntax error must not report this
+    /// either. Without this gate a single genuine parse error anywhere in the
+    /// program left this the only property-name diagnostic in this family
+    /// that still fired.
     pub(crate) fn check_bigint_literal_property_name(&mut self, name_idx: NodeIndex) -> bool {
         let Some(name_node) = self.ctx.arena.get(name_idx) else {
             return false;
         };
         if name_node.kind != SyntaxKind::BigIntLiteral as u16 {
+            return false;
+        }
+        if self.has_parse_errors() {
             return false;
         }
         use crate::diagnostics::{diagnostic_codes, diagnostic_messages};

--- a/crates/tsz-checker/src/tests/ts1539_bigint_literal_property_name_tests.rs
+++ b/crates/tsz-checker/src/tests/ts1539_bigint_literal_property_name_tests.rs
@@ -1,14 +1,18 @@
 //! Regression tests for TS1539 — a literal (non-computed) `bigint` name
 //! cannot be used as a property name.
 //!
-//! Verified against the pinned `typescript@7.0.2` oracle: this fires
-//! unconditionally on property-shaped members (interface/type-literal
-//! property signatures, class property declarations, object-literal
-//! property assignments) regardless of `readonly`, `static`, `declare`, or
-//! optionality, and never fires on the method-shaped equivalent (methods,
-//! `get`/`set` accessors) in any of those four containers.
+//! Verified against the pinned `typescript@7.0.2` oracle: this fires on
+//! property-shaped members (interface/type-literal property signatures,
+//! class property declarations, object-literal property assignments)
+//! regardless of `readonly`, `static`, `declare`, or optionality, and never
+//! fires on the method-shaped equivalent (methods, `get`/`set` accessors) in
+//! any of those four containers. It is suppressed program-wide whenever any
+//! file in the compilation has a real syntax error, matching `tsc` (verified
+//! directly against the oracle: a genuine parse error in one file suppresses
+//! semantic diagnostics in a completely unrelated file of the same
+//! compilation, not just its own file).
 
-use crate::test_utils::check_source_diagnostics;
+use crate::test_utils::{check_source_codes_with_parse_health, check_source_diagnostics};
 
 fn diag_codes(source: &str) -> Vec<u32> {
     check_source_diagnostics(source)
@@ -130,4 +134,56 @@ class YetAnotherName { 999n = true; }
     );
     let count = codes.iter().filter(|&&c| c == 1539).count();
     assert_eq!(count, 2, "Got: {codes:?}");
+}
+
+// TS1539 must be suppressed program-wide whenever the file has a real syntax
+// error, matching every sibling property-name-shape check in this checker
+// (TS2464's computed-property-name validation, TS1170's type-literal
+// computed-property check). Verified directly against the pinned oracle: a
+// genuine parse error in one file suppresses semantic diagnostics in an
+// entirely unrelated file of the same compilation. These use
+// `check_source_codes_with_parse_health` (real parser-diagnostic wiring)
+// rather than `check_source_diagnostics`, which never sets `has_parse_errors`
+// and so could never observe this suppression either way.
+
+#[test]
+fn ts1539_suppressed_by_a_real_syntax_error_in_the_same_file_interface() {
+    let codes = check_source_codes_with_parse_health(
+        r#"
+interface I { 123n: string; }
+const broken = ;
+"#,
+    );
+    assert!(!codes.contains(&1539), "Got: {codes:?}");
+}
+
+#[test]
+fn ts1539_suppressed_by_a_real_syntax_error_in_the_same_file_class() {
+    let codes = check_source_codes_with_parse_health(
+        r#"
+class C { 123n = 1; }
+const broken = ;
+"#,
+    );
+    assert!(!codes.contains(&1539), "Got: {codes:?}");
+}
+
+#[test]
+fn ts1539_suppressed_by_a_real_syntax_error_in_the_same_file_object_literal() {
+    let codes = check_source_codes_with_parse_health(
+        r#"
+const o = { 123n: 1 };
+const broken = ;
+"#,
+    );
+    assert!(!codes.contains(&1539), "Got: {codes:?}");
+}
+
+#[test]
+fn ts1539_still_fires_via_the_parse_health_harness_without_a_syntax_error() {
+    // Negative control for the three tests above: confirms the harness
+    // itself does not suppress TS1539 unconditionally — only a real parse
+    // error does.
+    let codes = check_source_codes_with_parse_health("interface I { 123n: string; }");
+    assert!(codes.contains(&1539), "Got: {codes:?}");
 }


### PR DESCRIPTION
**Structural rule.** When any file in the compilation has a real syntax error, `tsc` suppresses semantic diagnostics program-wide — verified directly against the pinned `typescript@7.0.2` oracle: a genuine parse error in one file suppresses semantic diagnostics in a *completely unrelated file* of the same `tsc` invocation, not just its own file. tsz mirrors this with the CLI driver's program-wide `program_has_real_syntax_errors` flag (`crates/tsz-cli/src/driver/check_file.rs`), surfaced to the checker as `ctx.has_parse_errors`/`self.has_parse_errors()`. Every sibling property-name-shape check in the checker already respects it — TS2464's computed-property-name validation (`property_checker.rs:1132`), TS1170's type-literal computed-property check (`type_checking/core.rs:300,312`) — but `check_bigint_literal_property_name` (TS1539, added by #16269) was the one holdout: it fired unconditionally, with no gate at all.

**What broke.** The automated conformance-refresh bot (#16282) flagged `TypeScript/tests/cases/compiler/bigintPropertyName.ts` as newly failing. That fixture is a multi-`@filename` test (`a.ts`/`g.ts`/`q.ts`) whose last statement (`g.2n;`) is a genuine syntax error. Oracle-verified: compiling the three files together, real `tsc` reports *only* the two syntax diagnostics (TS1434/TS1353) — every other diagnostic in the fixture, including the ones from `a.ts` and `q.ts` which have no syntax error of their own, is suppressed program-wide. tsz's own program-wide gate already suppressed everything else in that family; TS1539 was the only diagnostic still leaking through, matching the bot's exact finding (`x: ["TS1539"]`).

**Fix, at the shared owner.** All four call sites (`interface_checks.rs`, `ambient_signature_checks.rs`, `object_literal/computation.rs`, `type_checking/core.rs`) route through one function, `check_bigint_literal_property_name` in `crates/tsz-checker/src/checkers/property_checker/literal_name_grammar.rs`. Added a single `if self.has_parse_errors() { return false; }` gate there, matching the sibling checks' pattern — no call site needed touching.

**Adjacent-case matrix.** 4 new tests added to `ts1539_bigint_literal_property_name_tests.rs`, using `check_source_codes_with_parse_health` (real parser-diagnostic wiring — the plain `check_source_diagnostics` helper never sets `has_parse_errors`, so it can't observe this suppression either way):
- interface property + same-file real syntax error → suppressed
- class property + same-file real syntax error → suppressed
- object-literal property + same-file real syntax error → suppressed
- negative control: same interface case *without* a syntax error, through the parse-health harness → still fires (proves the harness itself isn't unconditionally suppressive)

All 17 pre-existing TS1539 tests (interface/type-literal/class/object-literal × readonly/static/declare/optional, method/accessor negative controls, renamed-binder check) are unaffected — none of them have a parse error, so `has_parse_errors()` is `false` and the new gate is a no-op for them.

## Goal
Goal: hold

## Verification
- Oracle (`typescript@7.0.2`, matching `scripts/conformance/typescript-versions.json`'s pin): reproduced the exact 3-file fixture two ways — as separate files and as one concatenated file — both give exactly `[TS1434, TS1353]`, zero `TS1539`/`TS2464`/`TS2538`/`TS2741`/`TS2322`. Also isolated with a minimal 2-file repro (`bad.ts` with a syntax error + unrelated `clean.ts` with a semantic error): the semantic error in `clean.ts` disappears when compiled together with `bad.ts`, confirming the program-wide (not just same-file) scope of the suppression.
- `cargo test -p tsz-checker --lib ts1539` — **21 passed, 0 failed** (17 pre-existing + 4 new).
- `cargo fmt` — clean. `cargo clippy -p tsz-checker --lib --tests -- -D warnings` — clean. Pre-commit hook's `-p tsz-checker` clippy + architecture guard — both passed.
- **Corpus gate owed and running.** This touches a shared checker helper reachable from 4 call sites, so `scripts/conformance/compare-to-parent.sh` is the real gate; it is queued behind this session's other in-flight two-sided sweep (draining #16313 on the same 4-core cloud seat) and will be posted as a follow-up comment. Expected signature: 0 newly-failing given the fix only *removes* a diagnostic under a condition where nothing in the committed corpus currently expects it to fire (the one fixture that does, `bigintPropertyName.ts`, is exactly what this fixes) — but unverified as of this post per the routine's land-and-continue policy. Do not queue until it reports.
- Emit/fourslash not run: this only gates an existing checker diagnostic behind a pre-existing program-wide flag; no emitter or LSP surface touched.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtnsMs8XPPkmpvMQtmpATP)_