### PR TITLE
fix(checker): TS1348/TS1349 related information on the use-strict grammar pair

### DIFF
--- a/crates/tsz-checker/src/checkers/use_strict_parameter_list.rs
+++ b/crates/tsz-checker/src/checkers/use_strict_parameter_list.rs
@@ -5,6 +5,11 @@
 //! parameter with a default initializer, a rest element, or a binding pattern)
 //! may not carry a `"use strict"` directive in its body prologue. TS1346 is
 //! anchored on each offending parameter, TS1347 on the directive itself.
+//!
+//! Both halves carry cross-location related information, which is the whole
+//! point of reporting the pair: TS1346 points forward at the directive with
+//! TS1349, and TS1347 points back at every offending parameter with TS1348 for
+//! the first and TS6204 (`and here.`) for each subsequent one.
 
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
@@ -41,27 +46,102 @@ impl<'a> CheckerState<'a> {
         if non_simple.is_empty() {
             return;
         }
-        use crate::diagnostics::diagnostic_codes;
-        for &param_idx in &non_simple {
-            // tsc anchors on the whole parameter node (`error(parameter, …)`),
-            // which for a rest parameter starts at the `...` token. Emit at the
-            // raw parameter span rather than through `error_at_node`, whose
-            // parameter normalization narrows the anchor to the name and would
-            // drop the leading `...`.
-            if let Some((start, end)) = self.get_node_span(param_idx) {
-                self.error(
-                    start,
-                    end.saturating_sub(start),
-                    "This parameter is not allowed with 'use strict' directive.".to_string(),
-                    diagnostic_codes::THIS_PARAMETER_IS_NOT_ALLOWED_WITH_USE_STRICT_DIRECTIVE,
-                );
-            }
+        use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+
+        // The directive anchor is shared: TS1347 is reported at it, and every
+        // TS1346 points at it through a TS1349 related entry. Compute it once,
+        // exactly as `error_at_node` would, so the primary diagnostic and the
+        // related entries cannot drift onto different spans.
+        let directive_span = self.get_node_span(directive_idx).map(|(start, end)| {
+            self.normalized_anchor_span(directive_idx, start, end.saturating_sub(start))
+        });
+
+        // tsc anchors on the whole parameter node (`error(parameter, …)`),
+        // which for a rest parameter starts at the `...` token. Emit at the
+        // raw parameter span rather than through `error_at_node`, whose
+        // parameter normalization narrows the anchor to the name and would
+        // drop the leading `...`.
+        let param_spans: Vec<(NodeIndex, u32, u32)> = non_simple
+            .iter()
+            .filter_map(|&param_idx| {
+                self.get_node_span(param_idx)
+                    .map(|(start, end)| (param_idx, start, end.saturating_sub(start)))
+            })
+            .collect();
+
+        for &(_, start, length) in &param_spans {
+            let related = directive_span
+                .map(|(directive_start, directive_length)| {
+                    vec![self.related_entry(
+                        directive_start,
+                        directive_length,
+                        diagnostic_codes::USE_STRICT_DIRECTIVE_USED_HERE,
+                        diagnostic_messages::USE_STRICT_DIRECTIVE_USED_HERE,
+                    )]
+                })
+                .unwrap_or_default();
+            self.error_at_span_with_related(
+                start,
+                length,
+                diagnostic_messages::THIS_PARAMETER_IS_NOT_ALLOWED_WITH_USE_STRICT_DIRECTIVE,
+                diagnostic_codes::THIS_PARAMETER_IS_NOT_ALLOWED_WITH_USE_STRICT_DIRECTIVE,
+                related,
+            );
         }
-        self.error_at_node(
+
+        // tsc names the first offending parameter and elides the rest as
+        // `and here.`, in source order — the same shape as its other
+        // multi-site grammar reports.
+        let related: Vec<_> = param_spans
+            .iter()
+            .enumerate()
+            .map(|(index, &(_, start, length))| {
+                if index == 0 {
+                    self.related_entry(
+                        start,
+                        length,
+                        diagnostic_codes::NON_SIMPLE_PARAMETER_DECLARED_HERE,
+                        diagnostic_messages::NON_SIMPLE_PARAMETER_DECLARED_HERE,
+                    )
+                } else {
+                    self.related_entry(
+                        start,
+                        length,
+                        diagnostic_codes::AND_HERE,
+                        diagnostic_messages::AND_HERE,
+                    )
+                }
+            })
+            .collect();
+        self.error_at_node_with_related(
             directive_idx,
-            "'use strict' directive cannot be used with non-simple parameter list.",
+            diagnostic_messages::USE_STRICT_DIRECTIVE_CANNOT_BE_USED_WITH_NON_SIMPLE_PARAMETER_LIST,
             diagnostic_codes::USE_STRICT_DIRECTIVE_CANNOT_BE_USED_WITH_NON_SIMPLE_PARAMETER_LIST,
+            related,
         );
+    }
+
+    /// A cross-location related-information entry in the file under check.
+    ///
+    /// `depth` stays `0`: these are genuine "declared here" pointers, not links
+    /// in an elaboration chain, so they must not pick up the progressive
+    /// indentation the renderer applies to nested elaborations.
+    fn related_entry(
+        &self,
+        start: u32,
+        length: u32,
+        code: u32,
+        message: &str,
+    ) -> crate::diagnostics::DiagnosticRelatedInformation {
+        crate::diagnostics::DiagnosticRelatedInformation {
+            category: tsz_common::diagnostics::DiagnosticCategory::Message,
+            code,
+            file: self.ctx.file_name.clone(),
+            start,
+            length,
+            message_text: message.to_string(),
+            depth: 0,
+        }
     }
 
     /// The brace block body of a function-like declaration, if it has one. Only
@@ -137,7 +217,10 @@ mod tests {
     use tsz_binder::BinderState;
     use tsz_parser::parser::ParserState;
 
-    fn checker_codes_at_target(source: &str, target: tsz_common::common::ScriptTarget) -> Vec<u32> {
+    fn checker_diagnostics_at_target(
+        source: &str,
+        target: tsz_common::common::ScriptTarget,
+    ) -> Vec<crate::diagnostics::Diagnostic> {
         let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
         let root = parser.parse_source_file();
         let parse_diagnostics = parser.get_diagnostics().to_vec();
@@ -165,12 +248,52 @@ mod tests {
             parse_diagnostics.iter().map(|diag| diag.start).collect();
 
         checker.check_source_file(root);
-        checker
-            .ctx
-            .diagnostics
+        checker.ctx.diagnostics.clone()
+    }
+
+    fn checker_codes_at_target(source: &str, target: tsz_common::common::ScriptTarget) -> Vec<u32> {
+        checker_diagnostics_at_target(source, target)
             .iter()
             .map(|diag| diag.code)
             .collect()
+    }
+
+    /// The `(code, message_text)` pairs of the related information attached to
+    /// the first diagnostic with `code`, or `None` when no such diagnostic was
+    /// reported at all — so a test cannot pass vacuously on a missing primary.
+    fn related_of(
+        source: &str,
+        code: u32,
+        target: tsz_common::common::ScriptTarget,
+    ) -> Option<Vec<(u32, String)>> {
+        checker_diagnostics_at_target(source, target)
+            .into_iter()
+            .find(|diag| diag.code == code)
+            .map(|diag| {
+                diag.related_information
+                    .iter()
+                    .map(|rel| (rel.code, rel.message_text.clone()))
+                    .collect()
+            })
+    }
+
+    /// The source offset a related entry of `related_code` points at, on the
+    /// first diagnostic with `code`.
+    fn related_start(
+        source: &str,
+        code: u32,
+        related_code: u32,
+        target: tsz_common::common::ScriptTarget,
+    ) -> Option<u32> {
+        checker_diagnostics_at_target(source, target)
+            .into_iter()
+            .find(|diag| diag.code == code)
+            .and_then(|diag| {
+                diag.related_information
+                    .iter()
+                    .find(|rel| rel.code == related_code)
+                    .map(|rel| rel.start)
+            })
     }
 
     #[test]
@@ -190,6 +313,119 @@ mod tests {
                 codes.contains(&1346) && codes.contains(&1347),
                 "expected TS1346+TS1347 for `{source}`: {codes:?}"
             );
+        }
+    }
+
+    /// TS1346 points forward at the directive with a single TS1349 entry, for
+    /// every non-simple parameter shape and every function-like carrier.
+    #[test]
+    fn ts1346_carries_one_ts1349_pointing_at_the_directive() {
+        for source in [
+            "function widget(size = 1) { \"use strict\"; }",
+            "function collect(...items) { \"use strict\"; }",
+            "function unpack({ label }) { \"use strict\"; }",
+            "const handler = (opt = 2) => { \"use strict\"; };",
+            "class Store { method(seed = 3) { \"use strict\"; } }",
+            "class Widget { set label({ text }) { \"use strict\"; } }",
+        ] {
+            let related = related_of(source, 1346, tsz_common::common::ScriptTarget::ES2016)
+                .unwrap_or_else(|| panic!("no TS1346 reported for `{source}`"));
+            assert_eq!(
+                related,
+                vec![(1349, "'use strict' directive used here.".to_string())],
+                "TS1346 related information for `{source}`"
+            );
+            // The related entry must land on the directive, not on the
+            // parameter TS1346 is already anchored at.
+            assert_eq!(
+                related_start(source, 1346, 1349, tsz_common::common::ScriptTarget::ES2016),
+                Some(
+                    source
+                        .find("\"use strict\"")
+                        .expect("witness contains a \"use strict\" directive")
+                        as u32
+                ),
+                "TS1349 anchor for `{source}`"
+            );
+        }
+    }
+
+    /// TS1347 points back at every offending parameter: TS1348 names the first,
+    /// TS6204 (`and here.`) elides each subsequent one, in source order.
+    #[test]
+    fn ts1347_carries_ts1348_then_and_here_per_extra_parameter() {
+        let single = "function widget(size = 1) { \"use strict\"; }";
+        assert_eq!(
+            related_of(single, 1347, tsz_common::common::ScriptTarget::ES2016),
+            Some(vec![(
+                1348,
+                "Non-simple parameter declared here.".to_string()
+            )]),
+            "one non-simple parameter must produce exactly one TS1348 and no `and here.`"
+        );
+
+        // Three parameters, two of them non-simple, with a simple parameter
+        // interleaved — the related list must skip the simple one and stay in
+        // source order.
+        let multi = "function render(size = 1, plain, ...rest) { \"use strict\"; }";
+        assert_eq!(
+            related_of(multi, 1347, tsz_common::common::ScriptTarget::ES2016),
+            Some(vec![
+                (1348, "Non-simple parameter declared here.".to_string()),
+                (6204, "and here.".to_string()),
+            ]),
+            "TS1347 related information for `{multi}`"
+        );
+        assert_eq!(
+            related_start(multi, 1347, 1348, tsz_common::common::ScriptTarget::ES2016),
+            Some(
+                multi
+                    .find("size = 1")
+                    .expect("witness contains the first non-simple parameter")
+                    as u32
+            ),
+            "TS1348 must anchor on the first non-simple parameter"
+        );
+        assert_eq!(
+            related_start(multi, 1347, 6204, tsz_common::common::ScriptTarget::ES2016),
+            Some(
+                multi
+                    .find("...rest")
+                    .expect("witness contains the rest parameter") as u32
+            ),
+            "`and here.` must anchor on the rest parameter including its `...`"
+        );
+    }
+
+    /// The negative side: when the grammar check does not fire, neither related
+    /// code may appear anywhere in the file's diagnostics.
+    #[test]
+    fn related_codes_do_not_leak_when_the_check_does_not_fire() {
+        for (source, target) in [
+            (
+                "function plain(first, second) { \"use strict\"; }",
+                tsz_common::common::ScriptTarget::ES2016,
+            ),
+            (
+                "function widget(size = 1) { \"use strict\"; }",
+                tsz_common::common::ScriptTarget::ES2015,
+            ),
+            (
+                "function widget(size = 1) { const c = 1; \"use strict\"; }",
+                tsz_common::common::ScriptTarget::ES2016,
+            ),
+        ] {
+            let diagnostics = checker_diagnostics_at_target(source, target);
+            for diag in &diagnostics {
+                for rel in &diag.related_information {
+                    assert!(
+                        !matches!(rel.code, 1348 | 1349),
+                        "TS{} leaked as related information on TS{} for `{source}`",
+                        rel.code,
+                        diag.code
+                    );
+                }
+            }
         }
     }
 

--- a/crates/tsz-checker/src/error_reporter/emitters.rs
+++ b/crates/tsz-checker/src/error_reporter/emitters.rs
@@ -69,6 +69,29 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Report an error at a raw span with its `related_information` already
+    /// attached, built as one complete `Diagnostic` value before it is pushed.
+    ///
+    /// The raw-span counterpart to [`Self::error_at_node_with_related`], for the
+    /// callers that deliberately bypass `normalized_anchor_span` because tsc
+    /// anchors on the whole node rather than its normalized sub-span (a
+    /// parameter's leading `...`, for instance). Routing through
+    /// [`CheckerContext::push_diagnostic`] keeps the same deduplication and
+    /// related-information collision reconciliation as every other emitter, so
+    /// this is not a way to smuggle a duplicate diagnostic past the buffer.
+    pub(crate) fn error_at_span_with_related(
+        &mut self,
+        start: u32,
+        length: u32,
+        message: &str,
+        code: u32,
+        related: Vec<crate::diagnostics::DiagnosticRelatedInformation>,
+    ) {
+        let mut diag = Diagnostic::error(self.ctx.file_name.clone(), start, length, message, code);
+        diag.related_information = related;
+        self.ctx.push_diagnostic(diag);
+    }
+
     /// Report an error using a shared diagnostic anchor policy.
     pub(crate) fn error_at_anchor(
         &mut self,


### PR DESCRIPTION
When a function's parameter list is non-simple and its body prologue carries a `"use strict"` directive, tsc reports TS1346 on each offending parameter **and** TS1347 on the directive, with each half carrying a cross-location pointer at the other; tsz reports the two primaries at the correct spans with **empty** related information. Owner: checker diagnostic display (`crates/tsz-checker/src/checkers/use_strict_parameter_list.rs`).

TS1348 (`Non-simple parameter declared here.`) and TS1349 (`'use strict' directive used here.`) were dead entries in the message table — two of the 88 codes enumerated in #16291.

## Goal
Goal: hold

## What tsc does

`checkGrammarForUseStrictSimpleParameterList` reports the pair as mutually referencing:

- each **TS1346** gets one **TS1349** entry anchored on the directive;
- **TS1347** gets one entry per offending parameter, in source order — **TS1348** naming the first and **TS6204** (`and here.`) eliding each subsequent one.

Oracle, `typescript@7.0.2`, `--noEmit --strict --pretty --target es2022 --lib es2022`, on `function h(a = 1, b, ...rest) { "use strict"; return a; }`:

```
h.ts:1:12 - error TS1346: This parameter is not allowed with 'use strict' directive.
  h.ts:1:33 - 'use strict' directive used here.
h.ts:1:22 - error TS1346: This parameter is not allowed with 'use strict' directive.
  h.ts:1:33 - 'use strict' directive used here.
h.ts:1:33 - error TS1347: 'use strict' directive cannot be used with non-simple parameter list.
  h.ts:1:12 - Non-simple parameter declared here.
  h.ts:1:22 - and here.
```

Before this change tsz emits the same three primaries at the same three spans and nothing underneath any of them. The simple parameter `b` is correctly absent from the related list on both sides.

## Anchor invariants

Both related lists are built from the spans the primaries already use, not recomputed:

- The **directive anchor is computed once** through `normalized_anchor_span` and shared between the TS1347 primary and every TS1349 entry, so the two cannot drift onto different spans.
- The **parameter entries reuse the raw parameter spans** TS1346 is anchored at. Those deliberately bypass parameter normalization (which narrows to the name), so a rest parameter keeps its leading `...` — asserted directly: the `and here.` entry starts at `...rest`, not at `rest`.
- `depth` stays `0` on every entry. These are genuine cross-location pointers, not links in an elaboration chain, so they must not pick up the renderer's progressive indentation.

## New emitter

Adds `error_at_span_with_related`, the raw-span counterpart to the existing `error_at_node_with_related`, for the callers that intentionally skip anchor normalization. It routes through `CheckerContext::push_diagnostic` exactly like every other emitter, so deduplication and related-information collision reconciliation are unchanged — it is not a path around the buffer.

## Verification

- `cargo test -p tsz-checker --lib use_strict` — **10 passed, 0 failed** (7 pre-existing, 3 new). The three new tests assert on a field that was unconditionally empty on the parent, so none of them can pass against it.
- Adjacent-case matrix in the three new tests, with binder names varied throughout:
  - **carriers**: function declaration, `const`-bound arrow, class method, set accessor — TS1346 carries exactly one TS1349 in each, anchored at the directive offset rather than at the parameter it is already reported on.
  - **parameter shapes**: default initializer, rest element, object binding pattern.
  - **arity**: one non-simple parameter produces exactly one TS1348 and **no** `and here.`; `(size = 1, plain, ...rest)` produces `[TS1348, TS6204]` in source order with the simple parameter `plain` skipped.
  - **negative / fallback**: a simple parameter list, an ES2015 target (below the ES2016 gate), and a `"use strict"` that follows a non-directive statement (so it is not a prologue directive) — asserted that neither TS1348 nor TS1349 appears as related information on *any* diagnostic in the file, not merely that the primaries are absent.
- `cargo fmt --all`; `cargo clippy --workspace --all-targets` — clean. Pre-commit gate (clippy + architecture guard for `tsz-checker`) passed.
- Corpus: not run. This change adds only related information to two diagnostics that already fire at unchanged codes, spans, and messages; no primary diagnostic is added, removed, moved, or reworded, and no shared predicate is touched. The conformance fingerprint is over primary codes, so the expected signature is exactly zero movement. No accepted-regressions entry was added and no floor was lowered.

## Disclosure: this is not observable through the CLI today, and that is a pre-existing bug

I built the branch as a `dist-fast` binary and diffed it against the oracle end to end. The three primaries match tsc exactly; **the related blocks do not appear in tsz's output**. That is not this diff — `tsz` prints no cross-location related information for *any* diagnostic. Same binary, `interface Point { x: number; y: number; } const p: Point = { x: 1 };`: tsc renders TS2741 with `'y' is declared here.` underneath it, tsz renders the identical primary at the identical span and nothing underneath, even though `assignability.rs` builds that entry.

The reporter is not the gap — `reporting/reporter.rs` has `format_related_plain` and `format_related_pretty` and iterates the list. The list is empty by the time it gets there. Filed as **#16316** with the witness, both candidate mechanisms, and a probe; not fixed here because it is a different layer (`driver/`) and a different bug from the one this PR is about.

So the evidence for this change is the checker-level matrix above plus the LSP path (`bin/tsz_lsp.rs:518`), which does consume `related_information` — an editor client sees these pointers today. Once #16316 is fixed, this data starts rendering in the CLI with no further change here.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Serpentine