### PR TITLE
fix(parser): TS1508 bare hyphen in v-mode character class was never wired

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -274,6 +274,10 @@ mod regex_class_set_reserved_double_punctuator_tests;
 mod regex_class_set_operator_mixing_tests;
 
 #[cfg(test)]
+#[path = "../../tests/regex_class_set_bare_hyphen_tests.rs"]
+mod regex_class_set_bare_hyphen_tests;
+
+#[cfg(test)]
 #[path = "../../tests/modifier_ordering_tests.rs"]
 mod modifier_ordering_tests;
 

--- a/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
@@ -1331,6 +1331,36 @@ impl ParserState {
                         continue;
                     }
 
+                    // A bare `-` is only a legal `ClassSetCharacter` when it
+                    // is consumed as a range separator immediately after the
+                    // atom it follows, in the same iteration (the `-` check
+                    // below, right after `scan_class_atom`). Any `-` that
+                    // instead reaches the *top* of this loop as a fresh atom
+                    // to scan — because it opens the class, or because the
+                    // previous iteration ended without chaining into it as a
+                    // range — is not a legal `ClassSetCharacter` in `v` mode
+                    // and reports TS1508: `/[-a]/v`, `/[-]/v`, and
+                    // `/[a-b-]/v`'s second `-` (which follows a *completed*
+                    // range, not a fresh atom) all take this path, while
+                    // `/[a-]/v` and `/[ab-]/v` never reach it because their
+                    // trailing `-` is consumed by the range-separator check
+                    // instead. Reported once per occurrence, not once per
+                    // class — `/[-a-b-c]/v` draws two, on the leading `-`
+                    // and the one after the completed `a-b` range.
+                    if ctx.unicode_sets_mode && ctx.body[*pos] == b'-' {
+                        let message = format_message(
+                            diagnostic_messages::UNEXPECTED_DID_YOU_MEAN_TO_ESCAPE_IT_WITH_BACKSLASH,
+                            &["-"],
+                        );
+                        (ctx.emit)(
+                            parser,
+                            *pos,
+                            1,
+                            &message,
+                            diagnostic_codes::UNEXPECTED_DID_YOU_MEAN_TO_ESCAPE_IT_WITH_BACKSLASH,
+                        );
+                    }
+
                     let mut atoms = Vec::new();
                     let min_start = *pos;
                     scan_class_atom(parser, ctx, pos, &mut atoms);

--- a/crates/tsz-parser/tests/regex_class_set_bare_hyphen_tests.rs
+++ b/crates/tsz-parser/tests/regex_class_set_bare_hyphen_tests.rs
@@ -1,0 +1,190 @@
+//! A bare, unescaped `-` in a `v`-mode character class (TS1508).
+//!
+//! A `-` is only a legal `ClassSetCharacter` when it is consumed as a range
+//! separator immediately after the atom it follows, in the same scan step.
+//! Any `-` that instead reaches the scan as a *fresh* atom — because it opens
+//! the class, stands alone, or follows a range that already completed —
+//! is not legal in `v` mode and reports TS1508 ("Unexpected '-'. Did you mean
+//! to escape it with backslash?"), once per occurrence rather than once per
+//! class.
+//!
+//! Every row is pinned against `typescript@7.0.2`
+//! (`--noEmit --strict --pretty false --target esnext`), on code *and*
+//! column. `tsc` renders 1-based columns; this harness reports zero-based
+//! offsets, so each expectation below is the oracle's column minus one.
+use crate::parser::test_fixture::parse_source;
+
+fn regex_codes(source: &str) -> Vec<u32> {
+    let (parser, _root) = parse_source(source);
+    parser.get_diagnostics().iter().map(|d| d.code).collect()
+}
+
+fn regex_codes_at(source: &str) -> Vec<(u32, u32)> {
+    let (parser, _root) = parse_source(source);
+    parser
+        .get_diagnostics()
+        .iter()
+        .map(|d| (d.code, d.start))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// A bare `-` that is never a range separator
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_lone_hyphen_reports() {
+    // `/[-]/v` — offset 12 is the `-`, the class's only content.
+    assert_eq!(regex_codes_at("const a = /[-]/v;"), vec![(1508, 12)]);
+}
+
+#[test]
+fn a_leading_hyphen_before_an_atom_reports() {
+    // `/[-a]/v` — the leading `-` cannot pair with anything to its left, so
+    // it is not a range separator despite `a` following it.
+    assert_eq!(regex_codes_at("const a = /[-a]/v;"), vec![(1508, 12)]);
+}
+
+#[test]
+fn a_hyphen_after_a_completed_range_reports() {
+    // `/[a-b-c]/v` — offset 15 is the second `-`. `a-b` is a legal range;
+    // the `-` right after it is a fresh atom scan, not a second range.
+    assert_eq!(regex_codes_at("const a = /[a-b-c]/v;"), vec![(1508, 15)]);
+}
+
+/// Reported once per offending `-`, not once per class — a fix that gates on
+/// "already reported for this class" underreports this row.
+#[test]
+fn a_hyphen_after_a_completed_range_reports_once_even_with_a_further_range() {
+    // `/[a-b-c-d]/v` — the second `-` (offset 15) is the only bad one: the
+    // third `-` legally separates the `c-d` range that follows it.
+    assert_eq!(regex_codes_at("const a = /[a-b-c-d]/v;"), vec![(1508, 15)]);
+}
+
+#[test]
+fn a_trailing_hyphen_after_a_completed_range_reports() {
+    // `/[a-b-]/v` — offset 15 is the trailing `-`. Unlike `/[a-]/v` (below),
+    // a range already completed before this `-` is reached, so it is not the
+    // one-off literal-trailing-hyphen shape.
+    assert_eq!(regex_codes_at("const a = /[a-b-]/v;"), vec![(1508, 15)]);
+}
+
+#[test]
+fn two_bad_hyphens_in_one_class_both_report() {
+    // `/[-a-b-c]/v` — the leading `-` (offset 12) and the `-` after the
+    // completed `a-b` range (offset 16) are two independent occurrences.
+    assert_eq!(
+        regex_codes_at("const a = /[-a-b-c]/v;"),
+        vec![(1508, 12), (1508, 16)]
+    );
+}
+
+/// The leading `^` shifts every offset by one; an off-by-one in the report
+/// position is otherwise invisible.
+#[test]
+fn negated_class_reports_at_the_shifted_offset() {
+    // `/[^-a]/v` and `/[^a-b-]/v`.
+    assert_eq!(regex_codes_at("const a = /[^-a]/v;"), vec![(1508, 13)]);
+    assert_eq!(regex_codes_at("const a = /[^a-b-]/v;"), vec![(1508, 16)]);
+}
+
+/// A nested class is its own scope, same as for TS1519.
+#[test]
+fn a_nested_class_reports_at_its_own_offset() {
+    // `/[[a-b-c]]/v` — offset 16 is the `-` inside the nested class.
+    assert_eq!(regex_codes_at("const a = /[[a-b-c]]/v;"), vec![(1508, 16)]);
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls: a `-` consumed as a range separator is legal, however
+// many atoms precede it or however many ranges the class already has
+// ---------------------------------------------------------------------------
+
+/// A trailing `-` immediately before `]` is a literal, not a range attempt —
+/// as long as no range has completed yet in this class.
+#[test]
+fn a_trailing_hyphen_before_any_range_completes_is_clean() {
+    assert_eq!(regex_codes("const a = /[a-]/v;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[ab-]/v;"), Vec::<u32>::new());
+}
+
+/// A single completed range, with nothing after it, is ordinary content.
+#[test]
+fn a_single_range_is_clean() {
+    assert_eq!(regex_codes("const a = /[a-b]/v;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[a-bc-d]/v;"), Vec::<u32>::new());
+}
+
+/// A leading `-` that never reattempts a second range, once past its
+/// (illegal) leading position, is otherwise ordinary — only the leading `-`
+/// itself reports.
+#[test]
+fn a_leading_hyphen_followed_by_one_clean_range_reports_only_the_leading_one() {
+    assert_eq!(regex_codes_at("const a = /[-a-b]/v;"), vec![(1508, 12)]);
+    assert_eq!(regex_codes_at("const a = /[-a-]/v;"), vec![(1508, 12)]);
+}
+
+/// Two ranges, then one bad trailing `-` after the second range completes:
+/// only that final `-` reports, not the legal separators before it.
+#[test]
+fn a_bad_hyphen_after_two_completed_ranges_reports_once() {
+    assert_eq!(regex_codes_at("const a = /[a-bc-d-]/v;"), vec![(1508, 18)]);
+}
+
+/// An escaped hyphen is a `ClassEscape`, not a bare `ClassSetCharacter`, and
+/// is unaffected regardless of what precedes it.
+#[test]
+fn an_escaped_hyphen_is_clean() {
+    assert_eq!(regex_codes("const a = /[a-b\\-c]/v;"), Vec::<u32>::new());
+}
+
+/// Sibling top-level classes do not share state: the second class's trailing
+/// `-` has not seen any range complete in *its own* scope.
+#[test]
+fn sibling_classes_do_not_share_state() {
+    assert_eq!(regex_codes("const a = /[a-b][c-]/v;"), Vec::<u32>::new());
+}
+
+/// A `-` immediately after a range-bounded-by-class-escape report (TS1516)
+/// is that check's own concern, not this one — TS1508 must not also fire.
+/// (tsz additionally emits TS1517 here where the oracle does not — a
+/// pre-existing gap in the unrelated range-order check, orthogonal to this
+/// fix; both assertions only need to show 1508 is absent.)
+#[test]
+fn a_range_bounded_by_a_class_escape_is_not_also_ts1508() {
+    assert_eq!(regex_codes("const a = /[\\d-a]/v;"), vec![1516]);
+    assert_eq!(regex_codes("const a = /[\\p{L}-a]/v;"), vec![1516, 1517]);
+}
+
+/// A mixed-operator report (TS1519) on a bare `-` inside a
+/// subtraction/intersection-committed class is that check's own concern; it
+/// is reached through the range-separator step, not the fresh-atom step this
+/// fix guards, so TS1508 must not also fire.
+#[test]
+fn a_mixed_operator_hyphen_is_not_also_ts1508() {
+    assert_eq!(regex_codes("const a = /[a--b-c]/v;"), vec![1519]);
+}
+
+/// `--` (subtraction with no operand) is TS1520's concern; a doubled hyphen
+/// is an operator, not this check's fresh-atom `-`. (The oracle reports
+/// TS1520 twice for `/[--]/v` — once for each side of the bare operator —
+/// where tsz reports it once; a pre-existing gap in that unrelated operand
+/// check, orthogonal to this fix. Both assertions only need to show 1508 is
+/// absent.)
+#[test]
+fn a_doubled_hyphen_is_not_also_ts1508() {
+    assert_eq!(regex_codes("const a = /[a--]/v;"), vec![1520]);
+    assert_eq!(regex_codes("const a = /[--]/v;"), vec![1520]);
+}
+
+/// TS1508 is a `v`-only diagnostic: under `u` and under Annex B the same
+/// hyphen positions are ordinary class content.
+#[test]
+fn bare_hyphen_position_is_v_only() {
+    assert_eq!(regex_codes("const a = /[-a]/u;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[-a]/;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[a-]/u;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[a-]/;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[a-b-c]/u;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[a-b-c]/;"), Vec::<u32>::new());
+}


### PR DESCRIPTION
## Goal
Goal: hold

Closes the TS1508 half of #16304 (the TS1519 half already merged as #16305).

### Structural rule

**A `-` is only a legal `ClassSetCharacter` in a `v`-mode character class when it is consumed as a range separator immediately after the atom it follows, in the same scan step. Any `-` that instead reaches `scan_class_ranges`'s loop top as a *fresh* atom to scan — because it opens the class, stands alone, or follows a range that already completed — is not a legal `ClassSetCharacter`, and `tsc` reports TS1508 ("Unexpected '-'. Did you mean to escape it with backslash?"). tsz's regex-literal scanner never checked for this and silently consumed the hyphen as an ordinary literal character.**

#16304's own framing ("a second `-` after a completed range is TS1508") is incomplete — I oracled the edge cases it explicitly flagged as unverified before wiring anything (`[-a]`, `[a-]`, `[a-b-]`, `u`/no-flag controls), plus several more, against a real `typescript@7.0.2` subprocess. The real rule is broader:

- A **leading** bare hyphen also reports — `/[-a]/v` and `/[-]/v` (hyphen alone) both error, not just a trailing one after a prior range.
- A hyphen right before `]` is legal only when nothing has forced it through the generic atom-scan path yet (`/[a-]/v`, `/[ab-]/v` clean); once any hyphen has gone through that path once in the class, a later top-of-loop hyphen repeats the same illegal shape (`/[a-b-]/v`, `/[a-bc-d-]/v` both error).
- It is reported **once per occurrence, not once per class** — `/[-a-b-c]/v` draws two (the leading `-` and the one after the completed `a-b` range), where a "report once and gate" implementation would only catch the first.

### Owner layer

`crates/tsz-parser/src/parser/state_expressions_literals_regex.rs`, in `scan_class_ranges` — the same function #16305 generalized for TS1519. The fix adds one check at the top of the loop, before the existing per-atom scan: if `unicode_sets_mode` and the current byte is a single (non-doubled) `-`, emit TS1508 at that position. No checker, solver, or emitter surface touched.

`TS1508` is already registered in `is_non_suppressing_parse_error` (`crates/tsz-cli/src/driver/check_utils.rs`) from an earlier, unrelated TS1508 call site (`/[a[b]]/u`) — same code, so no change needed there; verified via the existing `regex_grammar_suppression_tests.rs` fixture for that code.

**Disclosed file-size note**, same standing issue #16313 and #16305 both flagged: `state_expressions_literals_regex.rs` is now at 2190 physical lines, further over CLAUDE.md's 2000-line cap, with no `arch_guard.py` entry covering it. A split is increasingly owed; not attempted here given the file's ongoing contention from the regex-grammar cluster this session (see coordination board NOTE on #15994).

### Adjacent-case matrix

Every row pinned against `typescript@7.0.2` (`--noEmit --strict --pretty false --target esnext`), on code and column (harness offsets are zero-based; `tsc` columns are one greater).

| shape | tsc | tsz (parent) | tsz (branch) |
| --- | --- | --- | --- |
| `/[-]/v` (lone hyphen) | TS1508 @13 | *(silent)* | TS1508 @12 |
| `/[-a]/v` (leading) | TS1508 @13 | *(silent)* | TS1508 @12 |
| `/[a-b-c]/v` (after completed range) | TS1508 @16 | *(silent)* | TS1508 @15 |
| `/[a-b-c-d]/v` (once, despite a further legal range) | TS1508 @16 only | *(silent)* | TS1508 @15 only |
| `/[a-b-]/v` (trailing, after completed range) | TS1508 @16 | *(silent)* | TS1508 @15 |
| `/[a-bc-d-]/v` (after two completed ranges) | TS1508 @19 | *(silent)* | TS1508 @18 |
| `/[-a-b-c]/v` (two occurrences) | TS1508 @13, @17 | *(silent)* | TS1508 @12, @16 |
| `/[^-a]/v`, `/[^a-b-]/v` (negated, offset shifted by the leading `^`) | TS1508 | *(silent)* | TS1508 |
| `/[[a-b-c]]/v` (nested, own scope) | TS1508 @17 | *(silent)* | TS1508 @16 |
| `/[a-]/v`, `/[ab-]/v` (trailing, no range completed yet) | clean | clean | clean |
| `/[a-b]/v`, `/[a-bc-d]/v` (legal range(s), nothing after) | clean | clean | clean |
| `/[-a-b]/v`, `/[-a-]/v` (leading bad, then one legal range/close) | TS1508 once (leading only) | *(silent)* | TS1508 once |
| `/[a-b\-c]/v` (escaped hyphen) | clean | clean | clean |
| `/[a-b][c-]/v` (sibling classes don't share state) | clean | clean | clean |
| `/[a--b-c]/v` (mixed-operator TS1519, not also TS1508) | TS1519 only | TS1519 only | TS1519 only |
| `/[a--]/v`, `/[--]/v` (doubled-operator TS1520, not also TS1508) | TS1520(×1/×2) | TS1520(×1/×1)* | unchanged, no TS1508 added |
| `/[\d-a]/v`, `/[\p{L}-a]/v` (range bounded by class escape, TS1516, not also TS1508) | TS1516(/+1517) | unchanged* | unchanged, no TS1508 added |
| `/[-a]/u`, `/[-a]/`, `/[a-]/u`, `/[a-]/`, `/[a-b-c]/u`, `/[a-b-c]/` (non-`v`) | clean | clean | clean |

\* Two negative-control rows above (`/[--]/v` and the `\d`/`\p{L}`-bounded-range rows) surface **pre-existing, unrelated** tsz/`tsc` deltas (an operand-count gap in TS1520 and an extra TS1517 alongside TS1516) that this PR does not touch or fix — included only to confirm TS1508 doesn't *also* fire there. Not filed separately this session; out of scope for this diff.

### Verification

- `cargo fmt -p tsz-parser` clean (no changes).
- `cargo clippy -p tsz-parser --all-targets -- -D warnings` clean. `python3 scripts/arch/arch_guard.py` passes.
- `cargo test -p tsz-parser --lib` — **1691 passed, 0 failed** (was 1673 before the 18 new tests; #16305's regex suites and every other parser test unaffected).
- **Non-vacuity**: `git stash` of the source file only (tests left in place) — 10 of the 18 new tests fail without the fix, all for the expected reason (missing TS1508); the other 8 are negative controls that correctly pass either way.
- Oracle: every positive row and every negative control in the matrix above run against a real `typescript@7.0.2` subprocess.
- `scripts/conformance/compare-to-parent.sh origin/main` running now in background at post time; will follow up with the result as a PR comment before this queues, per the routine's land-and-continue policy. Expected signature: 0 newly-failing (a pure missing-diagnostic addition; no committed-corpus fixture currently expects a silent pass on any row in the matrix above).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzAmHsMqCKq9n7rsxP6vmQ)_