### PR TITLE
fix(cli): render cross-location related information the way tsc does

### DIFF
--- a/crates/tsz-cli/src/bin/tsz.rs
+++ b/crates/tsz-cli/src/bin/tsz.rs
@@ -859,9 +859,11 @@ fn list_files_only_unsupported_js_root_diagnostics(
                     "Root file specified for compilation",
                 )
             };
-            diagnostic
-                .related_information
-                .push(Diagnostic::related_message(code, String::new(), 0, 0, message));
+            let mut reason = Diagnostic::related_message(code, String::new(), 0, 0, message);
+            // Second link of tsc's file-inclusion-reason chain, so it indents
+            // one level deeper than the header above it.
+            reason.depth = 1;
+            diagnostic.related_information.push(reason);
             diagnostic
         })
         .collect()

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -284,7 +284,9 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
                         start: 0,
                         length: 0,
                         message_text: "Root file specified for compilation".to_string(),
-                        depth: 0,
+                        // Second link of tsc's file-inclusion-reason chain, so
+                        // it indents one level deeper than the header above it.
+                        depth: 1,
                     });
                 diagnostics.push(ts6504);
             }

--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part5.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part5.rs
@@ -258,3 +258,46 @@ const elem = <div className={class1, class2}/>;
             "Did not expect TS2349 for mapper[key](o), got: {diagnostics:?}"
         );
     }
+
+    /// #16316: cross-location related information must survive the real
+    /// driver, not just the checker's own diagnostic buffer.
+    ///
+    /// `tsc --strict` on this source reports TS1346 carrying a TS1349
+    /// `'use strict' directive used here.` pointer at the directive, and
+    /// TS1347 carrying a TS1348 `Non-simple parameter declared here.` pointer
+    /// at the parameter. Both entries point somewhere other than their
+    /// primary's own span, so a pipeline stage that rebuilt the diagnostic
+    /// without the field would show up here as an empty list.
+    #[test]
+    fn cross_location_related_information_survives_collect_diagnostics() {
+        let diagnostics =
+            collect_test_diagnostics(&[("/main.ts", "function f(a = 1) { \"use strict\"; }\n")]);
+
+        let ts1346 = diagnostics
+            .iter()
+            .find(|d| d.code == 1346)
+            .unwrap_or_else(|| panic!("expected TS1346, got: {diagnostics:?}"));
+        assert_eq!(
+            ts1346
+                .related_information
+                .iter()
+                .map(|r| (r.code, r.start, r.length))
+                .collect::<Vec<_>>(),
+            vec![(1349, 20, 13)],
+            "TS1346 must keep its directive pointer: {ts1346:?}"
+        );
+
+        let ts1347 = diagnostics
+            .iter()
+            .find(|d| d.code == 1347)
+            .unwrap_or_else(|| panic!("expected TS1347, got: {diagnostics:?}"));
+        assert_eq!(
+            ts1347
+                .related_information
+                .iter()
+                .map(|r| (r.code, r.start, r.length))
+                .collect::<Vec<_>>(),
+            vec![(1348, 11, 6)],
+            "TS1347 must keep its parameter pointer: {ts1347:?}"
+        );
+    }

--- a/crates/tsz-cli/src/reporting/reporter.rs
+++ b/crates/tsz-cli/src/reporting/reporter.rs
@@ -198,9 +198,10 @@ impl Reporter {
             out.push_str(&snippet);
         }
 
-        // Related information
+        // Related information. Each entry supplies its own leading newline(s):
+        // a located entry is separated from what precedes it by a blank line,
+        // an unlocated chain link is not.
         for related in &diagnostic.related_information {
-            out.push('\n');
             self.format_related_pretty(out, related);
         }
     }
@@ -323,17 +324,32 @@ impl Reporter {
     }
 
     /// Format related information in pretty mode.
+    ///
+    /// A *located* entry — one that names a file, i.e. a genuine cross-location
+    /// "declared here" pointer — is preceded by a blank line and puts its
+    /// message on the location line, with the source snippet underneath:
     /// ```text
-    ///   file:line:col
+    ///
+    ///   file:line:col - message
     ///     {line_num} {source_line}
     ///     {spaces}{tildes}
-    ///     message
     /// ```
+    /// An *unlocated* entry is a message-chain link (tsc keeps these in
+    /// `messageText` rather than `relatedInformation`), and renders as plain
+    /// indented text with no blank line and no location, exactly as in
+    /// non-pretty mode.
     fn format_related_pretty(&mut self, out: &mut String, related: &DiagnosticRelatedInformation) {
-        let file_display = self.relative_path(&related.file);
+        let message = self.translate_message(related.code, &related.message_text);
 
-        // Location line (2-space indent)
-        out.push_str("  ");
+        if related.file.is_empty() {
+            out.push('\n');
+            self.format_related_plain(out, related);
+            return;
+        }
+
+        // Blank line, then the location line (2-space indent).
+        out.push_str("\n\n  ");
+        let file_display = self.relative_path(&related.file);
         if let Some((line, col)) = self.position_for(&related.file, related.start) {
             if self.color {
                 out.push_str(&file_display.bright_cyan().to_string());
@@ -344,26 +360,22 @@ impl Reporter {
             } else {
                 let _ = write!(out, "{file_display}:{line}:{col}");
             }
-        } else if !related.file.is_empty() {
-            if self.color {
-                out.push_str(&file_display.bright_cyan().to_string());
-            } else {
-                out.push_str(&file_display);
-            }
+        } else if self.color {
+            out.push_str(&file_display.bright_cyan().to_string());
+        } else {
+            out.push_str(&file_display);
         }
 
-        // Source snippet (4-space indent)
+        // Message continues the location line, uncolored.
+        out.push_str(" - ");
+        out.push_str(&message);
+
+        // Source snippet (4-space indent), underneath the location line.
         if let Some(snippet) =
             self.format_snippet_pretty_related(&related.file, related.start, related.length)
         {
             out.push_str(&snippet);
         }
-
-        // Message (4-space indent)
-        out.push('\n');
-        out.push_str("    ");
-        let message = self.translate_message(related.code, &related.message_text);
-        out.push_str(&message);
     }
 
     /// Format snippet for related info with 4-space indent and cyan underline.
@@ -680,6 +692,185 @@ fn decode_source_bytes(bytes: &[u8]) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A reporter that renders from in-memory sources, with no cwd-relative
+    /// path rewriting and no colors, so rendered output can be compared byte
+    /// for byte against a `tsc --pretty` transcript.
+    fn reporter_with_source(file: &str, source: &str) -> Reporter {
+        let mut reporter = Reporter::new(false);
+        reporter.set_pretty(true);
+        reporter.cwd = None;
+        reporter
+            .sources
+            .insert(file.to_string(), source.to_string());
+        reporter
+    }
+
+    fn related_at(
+        file: &str,
+        start: u32,
+        length: u32,
+        message: &str,
+    ) -> DiagnosticRelatedInformation {
+        DiagnosticRelatedInformation {
+            category: DiagnosticCategory::Message,
+            code: 0,
+            file: file.to_string(),
+            start,
+            length,
+            message_text: message.to_string(),
+            depth: 0,
+        }
+    }
+
+    /// tsc 7.0.2, `--pretty --strict`, on
+    /// `function f(a = 1) { "use strict"; }`:
+    ///
+    /// ```text
+    /// us.ts:1:12 - error TS1346: This parameter is not allowed with 'use strict' directive.
+    ///
+    /// 1 function f(a = 1) { "use strict"; }
+    ///              ~~~~~
+    ///
+    ///   us.ts:1:21 - 'use strict' directive used here.
+    ///     1 function f(a = 1) { "use strict"; }
+    ///                           ~~~~~~~~~~~~~
+    /// ```
+    ///
+    /// The load-bearing details: a blank line separates the related entry from
+    /// the primary's underline, and the related message sits on the location
+    /// line after ` - `, with its snippet underneath.
+    #[test]
+    fn pretty_located_related_puts_message_on_the_location_line() {
+        let source = "function f(a = 1) { \"use strict\"; }\n";
+        let mut reporter = reporter_with_source("us.ts", source);
+
+        let mut diagnostic = Diagnostic::error(
+            "us.ts".to_string(),
+            11,
+            5,
+            "This parameter is not allowed with 'use strict' directive.",
+            1346,
+        );
+        diagnostic.related_information.push(related_at(
+            "us.ts",
+            20,
+            13,
+            "'use strict' directive used here.",
+        ));
+
+        let mut out = String::new();
+        reporter.format_diagnostic_pretty(&mut out, &diagnostic);
+
+        assert_eq!(
+            out,
+            "us.ts:1:12 - error TS1346: This parameter is not allowed with 'use strict' directive.\n\
+             \n\
+             1 function f(a = 1) { \"use strict\"; }\n\
+             \x20            ~~~~~\n\
+             \n\
+             \x20 us.ts:1:21 - 'use strict' directive used here.\n\
+             \x20   1 function f(a = 1) { \"use strict\"; }\n\
+             \x20                         ~~~~~~~~~~~~~",
+            "rendered:\n{out}"
+        );
+    }
+
+    /// Every located entry gets its own blank line, not just the first — tsc
+    /// on `function g(a = 1, [b] = [2]) {{ \"use strict\"; }}` reports TS1347
+    /// with two pointers (`Non-simple parameter declared here.` / `and here.`)
+    /// separated by a blank line each.
+    #[test]
+    fn pretty_blank_line_precedes_every_located_related_entry() {
+        let source = "function g(a = 1, [b] = [2]) { \"use strict\"; }\n";
+        let mut reporter = reporter_with_source("multi.ts", source);
+
+        let mut diagnostic = Diagnostic::error(
+            "multi.ts".to_string(),
+            31,
+            13,
+            "'use strict' directive cannot be used with non-simple parameter list.",
+            1347,
+        );
+        diagnostic.related_information.push(related_at(
+            "multi.ts",
+            11,
+            5,
+            "Non-simple parameter declared here.",
+        ));
+        diagnostic
+            .related_information
+            .push(related_at("multi.ts", 18, 9, "and here."));
+
+        let mut out = String::new();
+        reporter.format_diagnostic_pretty(&mut out, &diagnostic);
+
+        let related_block = out
+            .split_once("~~~~~~~~~~~~~\n")
+            .expect("primary underline present")
+            .1;
+        assert_eq!(
+            related_block,
+            "\n\
+             \x20 multi.ts:1:12 - Non-simple parameter declared here.\n\
+             \x20   1 function g(a = 1, [b] = [2]) { \"use strict\"; }\n\
+             \x20                ~~~~~\n\
+             \n\
+             \x20 multi.ts:1:19 - and here.\n\
+             \x20   1 function g(a = 1, [b] = [2]) { \"use strict\"; }\n\
+             \x20                       ~~~~~~~~~",
+            "rendered:\n{out}"
+        );
+    }
+
+    /// An entry with no file is a message-chain link, not a cross-location
+    /// pointer. tsc renders those as plain indented text in *both* modes —
+    /// `tsc --pretty` on a JS root without `allowJs` prints
+    ///
+    /// ```text
+    /// error TS6504: File 'root.js' is a JavaScript file. Did you mean to enable the 'allowJs' option?
+    ///   The file is in the program because:
+    ///     Root file specified for compilation
+    /// ```
+    ///
+    /// with no blank line, no location, and 2 spaces per nesting level.
+    #[test]
+    fn pretty_unlocated_related_renders_as_indented_chain_text() {
+        let mut reporter = Reporter::new(false);
+        reporter.set_pretty(true);
+        reporter.cwd = None;
+
+        let mut diagnostic = Diagnostic::error(
+            String::new(),
+            0,
+            0,
+            "File 'root.js' is a JavaScript file. Did you mean to enable the 'allowJs' option?",
+            6504,
+        );
+        diagnostic
+            .related_information
+            .push(DiagnosticRelatedInformation {
+                depth: 0,
+                ..related_at("", 0, 0, "The file is in the program because:")
+            });
+        diagnostic
+            .related_information
+            .push(DiagnosticRelatedInformation {
+                depth: 1,
+                ..related_at("", 0, 0, "Root file specified for compilation")
+            });
+
+        let mut out = String::new();
+        reporter.format_diagnostic_pretty(&mut out, &diagnostic);
+
+        assert_eq!(
+            out,
+            "error TS6504: File 'root.js' is a JavaScript file. Did you mean to enable the 'allowJs' option?\n\
+             \x20 The file is in the program because:\n\
+             \x20   Root file specified for compilation",
+            "rendered:\n{out}"
+        );
+    }
 
     #[test]
     fn decode_utf8() {

--- a/crates/tsz-cli/tests/reporter_tests.rs
+++ b/crates/tsz-cli/tests/reporter_tests.rs
@@ -424,21 +424,15 @@ fn pretty_mode_renders_related_location_snippet_and_message() {
     reporter.set_cwd(&temp.path);
     let output = reporter.render(&[diagnostic]);
 
+    // tsc puts a blank line before a cross-location related entry, then the
+    // message on the location line after ` - `, then the snippet underneath.
     assert!(
-        output.contains("decl.ts:1:18"),
-        "missing related location: {output}"
-    );
-    assert!(
-        output.contains("1 declare function foo(): void;"),
-        "missing related source snippet: {output}"
-    );
-    assert!(
-        output.contains("~~~"),
-        "missing related underline: {output}"
-    );
-    assert!(
-        output.contains("    The symbol is declared here."),
-        "missing related message: {output}"
+        output.contains(
+            "\n\n  decl.ts:1:18 - The symbol is declared here.\n\
+             \x20   1 declare function foo(): void;\n\
+             \x20                      ~~~"
+        ),
+        "related block does not match tsc's pretty shape: {output}"
     );
 }
 


### PR DESCRIPTION
Closes the diagnosable half of #16316 — and corrects that issue's diagnosis, which named the wrong defect.

**Structural rule.** When a diagnostic carries a related-information entry that *names a file*, tsc renders it as a blank line, then `  file:line:col - message`, then the 4-space-indented code span; when the entry names no file it is a message-chain link, which tsc keeps in `messageText` and prints as `2 * (depth + 1)`-indented text in **both** pretty and plain mode. tsz does this through the CLI reporter (`crates/tsz-cli/src/reporting/reporter.rs`), the owner of output shape.

### What #16316 got wrong

The issue reports that related information "is simply empty by the time the reporter sees it" and proposes two candidate mechanisms (a struct rebuild in `driver/`, or `RelatedInformationPolicy` filtering). Both are wrong, and a driver-level probe settles it:

```
PROBE code=1346 start=11 len=6  related=1
PROBE   related code=1349 file=/main.ts start=20 len=13 depth=0 msg='use strict' directive used here.
PROBE code=1347 start=20 len=13 related=1
PROBE   related code=1348 file=/main.ts start=11 len=6  depth=0 msg=Non-simple parameter declared here.
```

Cross-location related information survives the **real** `collect_diagnostics` intact, spans and all. There is also no site where it could have been dropped: `reporting/reporter.rs` consumes `tsz::checker::diagnostics::Diagnostic` directly, and the only diagnostic-rebuilding code in the whole crate is the incremental-cache round trip the issue already exonerates. `post_process_checker_diagnostics` only ever `retain`s.

The issue's `TS2741` witness is also not a witness for a *drop*. `IS_DECLARED_HERE` has exactly one construction site in the checker (`checkers/jsx/props/validation.rs:1412`); nothing on the TS2741 path ever builds a `'y' is declared here.` pointer, so `related.len() == 0` there is missing data, not lost data. That remains open and is now recorded on #16316 with this evidence.

What actually broke output parity is the render shape.

### The two defects fixed

Against `typescript@7.0.2` (the pin in `scripts/conformance/typescript-versions.json`), `function f(a = 1) { "use strict"; }`:

```
us.ts:1:12 - error TS1346: This parameter is not allowed with 'use strict' directive.

1 function f(a = 1) { "use strict"; }
             ~~~~~

  us.ts:1:21 - 'use strict' directive used here.
    1 function f(a = 1) { "use strict"; }
                          ~~~~~~~~~~~~~
```

1. **Located entries.** tsz emitted the location alone, then the snippet, then the message on a separate 4-space-indented line, with no blank line separating the entry from the primary's underline. Now: blank line, `  loc - message`, snippet underneath. The blank line precedes *every* entry, not just the first — confirmed on a two-pointer TS1347 (`Non-simple parameter declared here.` / `and here.`).
2. **Unlocated entries.** These are chain links, not pointers. Pretty mode was giving them the location treatment with an empty location, leaving a stray two-space line above a 4-space-indented message. They now take the same path plain mode already used. Adjacent to that, TS6504's file-inclusion chain builds its second link with `depth: 0` at both construction sites, so it printed beside its header instead of under it; tsc prints 2 then 4 spaces. Fixed to `depth: 1`.

No identifier, file-name, or rendered-output predicate drives any of this — the branch is on whether the entry names a file, which is the same discriminator tsc's own formatter uses.

### Known remaining gap (not this PR)

tsz models message chains and cross-location pointers in one `related_information` vec, and its chain links carry the primary's own file and anchor. So in *plain* mode tsz still prints located pointers, which tsc never does there, and there is no field that distinguishes the two concepts. Fixing that means adding the distinction to `DiagnosticRelatedInformation` (43 construction sites, plus the LSP mapping and the cache format) — a separate slice, written up on #16316 with the oracle matrix rather than half-done here.

## Goal
Goal: hold

## Verification
- Oracle: `typescript@7.0.2` (pin read from `scripts/conformance/typescript-versions.json`), `--noEmit --strict --pretty --target es2022 --lib es2022`, on six witnesses: single pointer (TS1346), two pointers on one primary (TS1347), same-file TS2741, cross-file TS2741, a nested chain, and an unlocated chain (TS6504 via a JS root without `allowJs`). Expected strings in the new tests are transcribed byte-for-byte from those runs.
- `cargo test -p tsz-cli --lib -- reporter_tests reporting::reporter::tests cross_location_related` — **24 passed, 0 failed**. Three new reporter unit tests (located single, located multiple, unlocated chain) and one new driver-level test asserting related information survives `collect_diagnostics`.
- `cargo test -p tsz-cli --lib -- --skip tsc_compat_tests` — before: 1527 passed / 7 failed. After: 1528 passed / 6 failed. The one test that moved is `reporter_tests::pretty_mode_renders_related_location_snippet_and_message`, which pinned the old shape and is updated to the tsc-exact block. Of the 6 remaining, 4 are in `scripts/ci/known-failures.txt`; the other 2 (`regex_validator_diagnostic_surface_is_audited`, `compile_incremental_reports_ts5033_when_tsbuildinfo_is_not_writable`) were re-run on the stashed parent and fail there identically — pre-existing and unbaselined, reported separately on the board.
- `cargo clippy -p tsz-cli --lib --all-targets` clean; `cargo fmt --all` applied.
- `tsc_compat_tests` (126 tests) cannot run in this container at all — they shell out to a `tsz` binary that is not built and a vendored tsc that is not installed; they fail identically before and after.
- Not run: conformance / emit / fourslash. This change touches only CLI output formatting, which the conformance fingerprint (primary codes) and the emit gate (JS/DTS bytes) do not observe; no `crates/tsz-checker`, `-solver`, `-emitter` code is touched.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Aventurine

---
_Generated by [Claude Code](https://claude.ai/code/session_01RPLp1gtmMCNADLqzvxESre)_