### PR TITLE
fix(solver): a computed member keyed by a wide symbol becomes a symbol index signature

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1095,6 +1095,9 @@ path = "tests/ts2353_generic_constraint_excess_property_tests.rs"
 name = "ts2353_cross_module_symbol_computed_key_tests"
 path = "tests/ts2353_cross_module_symbol_computed_key_tests.rs"
 [[test]]
+name = "wide_symbol_computed_member_index_signature_tests"
+path = "tests/wide_symbol_computed_member_index_signature_tests.rs"
+[[test]]
 name = "relational_operator_type_display_tests"
 path = "tests/relational_operator_type_display_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
@@ -1755,17 +1755,22 @@ impl<'a> CheckerState<'a> {
                 );
 
                 // Pre-compute computed property names that the lowering can't resolve from AST alone.
-                let (computed_names, computed_symbol_names) = if needs_computed_name_map {
-                    (
-                        self.precompute_computed_property_names(local_declarations),
-                        self.precompute_symbol_named_computed_property_names(local_declarations),
-                    )
-                } else {
-                    (
-                        rustc_hash::FxHashMap::default(),
-                        rustc_hash::FxHashSet::default(),
-                    )
-                };
+                let (computed_names, computed_symbol_names, computed_wide_symbol_names) =
+                    if needs_computed_name_map {
+                        (
+                            self.precompute_computed_property_names(local_declarations),
+                            self.precompute_symbol_named_computed_property_names(
+                                local_declarations,
+                            ),
+                            self.precompute_wide_symbol_computed_property_names(local_declarations),
+                        )
+                    } else {
+                        (
+                            rustc_hash::FxHashMap::default(),
+                            rustc_hash::FxHashSet::default(),
+                            rustc_hash::FxHashSet::default(),
+                        )
+                    };
                 let prewarmed_type_params = if needs_prewarm {
                     self.prewarm_member_type_reference_params(local_declarations)
                 } else {
@@ -1795,6 +1800,9 @@ impl<'a> CheckerState<'a> {
                 };
                 let computed_symbol_name_resolver =
                     |expr_idx: NodeIndex| computed_symbol_names.contains(&(expr_idx, arena_ptr));
+                let computed_wide_symbol_name_resolver = |expr_idx: NodeIndex| {
+                    computed_wide_symbol_names.contains(&(expr_idx, arena_ptr))
+                };
                 let lazy_type_params_resolver = |def_id: tsz_solver::def::DefId| {
                     prewarmed_type_params
                         .get(&def_id)
@@ -1848,6 +1856,7 @@ impl<'a> CheckerState<'a> {
                 .with_type_param_bindings(type_param_bindings)
                 .with_computed_name_resolver(&computed_name_resolver)
                 .with_computed_symbol_name_resolver(&computed_symbol_name_resolver)
+                .with_computed_wide_symbol_name_resolver(&computed_wide_symbol_name_resolver)
                 .with_lazy_type_params_resolver(&lazy_type_params_resolver)
                 .with_name_def_id_resolver(&name_resolver)
                 .with_type_query_override(&type_query_override);

--- a/crates/tsz-checker/src/state/type_resolution/computed_property_names.rs
+++ b/crates/tsz-checker/src/state/type_resolution/computed_property_names.rs
@@ -245,6 +245,66 @@ impl<'a> CheckerState<'a> {
         set
     }
 
+    pub(crate) fn precompute_wide_symbol_computed_property_names(
+        &mut self,
+        declarations: &[NodeIndex],
+    ) -> rustc_hash::FxHashSet<(NodeIndex, usize)> {
+        let decls = self.with_current_arena(declarations);
+        self.precompute_wide_symbol_computed_property_names_in_arenas(&decls)
+    }
+
+    /// Members whose computed key resolves to a plain (non-unique)
+    /// `symbol`-typed binding — the `__symbol_<file>_<id>` leg of
+    /// `resolve_computed_property_name_in_arena`, distinct from a genuine
+    /// `unique symbol` binding's `__unique_<id>` key. These do not mint a
+    /// named member; the interface/type-literal lowering pipeline routes
+    /// them into the containing type's symbol index signature instead.
+    pub(crate) fn precompute_wide_symbol_computed_property_names_in_arenas(
+        &mut self,
+        declarations: &[(NodeIndex, &NodeArena)],
+    ) -> rustc_hash::FxHashSet<(NodeIndex, usize)> {
+        let mut set = rustc_hash::FxHashSet::default();
+        for &(decl_idx, decl_arena) in declarations {
+            let arena_key = decl_arena as *const NodeArena as usize;
+            let Some(node) = decl_arena.get(decl_idx) else {
+                continue;
+            };
+            let Some(interface) = decl_arena.get_interface(node) else {
+                continue;
+            };
+            for &member_idx in &interface.members.nodes {
+                let Some(member) = decl_arena.get(member_idx) else {
+                    continue;
+                };
+                let name_idx = if let Some(sig) = decl_arena.get_signature(member) {
+                    sig.name
+                } else if let Some(acc) = decl_arena.get_accessor(member) {
+                    acc.name
+                } else {
+                    continue;
+                };
+                let Some(name_node) = decl_arena.get(name_idx) else {
+                    continue;
+                };
+                if name_node.kind != syntax_kind_ext::COMPUTED_PROPERTY_NAME {
+                    continue;
+                }
+                let Some(computed) = decl_arena.get_computed_property(name_node) else {
+                    continue;
+                };
+                if self
+                    .resolve_computed_property_name_in_arena(decl_arena, name_idx)
+                    .is_some_and(|resolved| {
+                        resolved.is_symbol && resolved.name.starts_with("__symbol_")
+                    })
+                {
+                    set.insert((computed.expression, arena_key));
+                }
+            }
+        }
+        set
+    }
+
     fn resolve_type_reference_symbol_in_arena(
         &self,
         arena: &NodeArena,

--- a/crates/tsz-checker/src/state/type_resolution/core.rs
+++ b/crates/tsz-checker/src/state/type_resolution/core.rs
@@ -444,6 +444,9 @@ impl CheckerState<'_> {
                 let computed_symbol_name_resolver = |expr_idx: NodeIndex| {
                     self.computed_property_expression_is_symbol_named(expr_idx)
                 };
+                let computed_wide_symbol_name_resolver = |expr_idx: NodeIndex| {
+                    self.computed_property_expression_is_wide_symbol_named(expr_idx)
+                };
                 let lowering = tsz_lowering::TypeLowering::with_hybrid_resolver(
                     self.ctx.arena,
                     self.ctx.types,
@@ -455,7 +458,8 @@ impl CheckerState<'_> {
                 .with_name_def_id_resolver(&name_resolver)
                 .with_type_query_override(&type_query_override)
                 .with_computed_name_resolver(&computed_name_resolver)
-                .with_computed_symbol_name_resolver(&computed_symbol_name_resolver);
+                .with_computed_symbol_name_resolver(&computed_symbol_name_resolver)
+                .with_computed_wide_symbol_name_resolver(&computed_wide_symbol_name_resolver);
                 let mut type_id = lowering.lower_type(idx);
                 if let Some(args) = &type_ref.type_arguments {
                     type_id = self.rebuild_application_with_checker_type_args(type_id, args, None);
@@ -1407,6 +1411,9 @@ impl CheckerState<'_> {
                 let computed_symbol_name_resolver = |expr_idx: NodeIndex| {
                     self.computed_property_expression_is_symbol_named(expr_idx)
                 };
+                let computed_wide_symbol_name_resolver = |expr_idx: NodeIndex| {
+                    self.computed_property_expression_is_wide_symbol_named(expr_idx)
+                };
                 let lowering = tsz_lowering::TypeLowering::with_hybrid_resolver(
                     self.ctx.arena,
                     self.ctx.types,
@@ -1419,7 +1426,8 @@ impl CheckerState<'_> {
                 .with_name_def_id_resolver(&name_resolver)
                 .with_type_query_override(&type_query_override)
                 .with_computed_name_resolver(&computed_name_resolver)
-                .with_computed_symbol_name_resolver(&computed_symbol_name_resolver);
+                .with_computed_symbol_name_resolver(&computed_symbol_name_resolver)
+                .with_computed_wide_symbol_name_resolver(&computed_wide_symbol_name_resolver);
                 let mut result = lowering.lower_type(idx);
                 if let Some(args) = &type_ref.type_arguments {
                     result = self.rebuild_application_with_checker_type_args(
@@ -1893,105 +1901,6 @@ impl CheckerState<'_> {
         }
 
         // Unknown type name node kind - propagate error
-        TypeId::ERROR
-    }
-
-    pub(crate) fn handle_missing_global_type_with_args(
-        &mut self,
-        name: &str,
-        type_ref: &tsz_parser::parser::node::TypeRefData,
-        type_name_idx: NodeIndex,
-    ) -> TypeId {
-        if self.is_mapped_type_utility(name) {
-            if self.ctx.compiler_options.no_lib {
-                self.report_missing_lib_type_name(name, type_name_idx);
-                return TypeId::ANY;
-            }
-
-            if let Some(args) = &type_ref.type_arguments {
-                let type_args: Vec<TypeId> = args
-                    .nodes
-                    .iter()
-                    .map(|&arg_idx| self.get_type_from_type_node(arg_idx))
-                    .collect();
-
-                if name == "Pick" && type_args.len() == 2 {
-                    let factory = self.ctx.types.factory();
-                    let key_param = tsz_solver::TypeParamInfo {
-                        name: self.ctx.types.intern_string("__pick_key"),
-                        constraint: None,
-                        default: None,
-                        is_const: false,
-                        origin: tsz_solver::TypeParamOrigin::User,
-                    };
-                    let key_type = self.ctx.types.type_param(key_param);
-                    return factory.mapped(tsz_solver::MappedType {
-                        type_param: key_param,
-                        constraint: type_args[1],
-                        name_type: None,
-                        template: factory.index_access(type_args[0], key_type),
-                        readonly_modifier: None,
-                        optional_modifier: None,
-                    });
-                }
-
-                let (base_type, _) = self.resolve_lib_type_with_params(name);
-                if let Some(base_type) = base_type {
-                    return self.ctx.types.factory().application(base_type, type_args);
-                }
-            }
-            return TypeId::ANY;
-        }
-
-        self.report_missing_lib_type_name(name, type_name_idx);
-
-        if !self.ctx.compiler_options.no_lib
-            && matches!(name, "Promise" | "PromiseLike")
-            && let Some(args) = &type_ref.type_arguments
-        {
-            let type_args: Vec<TypeId> = args
-                .nodes
-                .iter()
-                .map(|&arg_idx| self.get_type_from_type_node(arg_idx))
-                .collect();
-            if !type_args.is_empty() {
-                let promise_base = {
-                    let lib_binders = self.get_lib_binders();
-                    crate::types_domain::queries::lib_resolution::resolve_name_to_lib_symbol(
-                        name,
-                        self.ctx.binder,
-                        self.ctx.global_file_locals_index.as_deref(),
-                        self.ctx
-                            .all_binders
-                            .as_ref()
-                            .map(|binders| binders.as_ref().as_slice()),
-                        &self.ctx.lib_contexts,
-                    )
-                    .or_else(|| {
-                        lib_binders
-                            .iter()
-                            .find_map(|binder| binder.file_locals.get(name))
-                    })
-                    .map(|sym_id| {
-                        let _ = self.resolve_lib_type_by_name(name);
-                        let def_id = self.ctx.get_canonical_lib_def_id(name, sym_id);
-                        self.ctx.types.factory().lazy(def_id)
-                    })
-                    .unwrap_or(TypeId::PROMISE_BASE)
-                };
-                return self
-                    .ctx
-                    .types
-                    .factory()
-                    .application(promise_base, type_args);
-            }
-        }
-
-        if let Some(args) = &type_ref.type_arguments {
-            for &arg_idx in &args.nodes {
-                let _ = self.get_type_from_type_node(arg_idx);
-            }
-        }
         TypeId::ERROR
     }
 }

--- a/crates/tsz-checker/src/state/type_resolution/missing_global_type.rs
+++ b/crates/tsz-checker/src/state/type_resolution/missing_global_type.rs
@@ -1,0 +1,108 @@
+//! Fallback construction for a type-reference name that resolves to no
+//! declaration (missing lib type), split out of `core.rs` to keep that file
+//! under the architecture guard's line cap.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_solver::TypeId;
+
+impl CheckerState<'_> {
+    pub(crate) fn handle_missing_global_type_with_args(
+        &mut self,
+        name: &str,
+        type_ref: &tsz_parser::parser::node::TypeRefData,
+        type_name_idx: NodeIndex,
+    ) -> TypeId {
+        if self.is_mapped_type_utility(name) {
+            if self.ctx.compiler_options.no_lib {
+                self.report_missing_lib_type_name(name, type_name_idx);
+                return TypeId::ANY;
+            }
+
+            if let Some(args) = &type_ref.type_arguments {
+                let type_args: Vec<TypeId> = args
+                    .nodes
+                    .iter()
+                    .map(|&arg_idx| self.get_type_from_type_node(arg_idx))
+                    .collect();
+
+                if name == "Pick" && type_args.len() == 2 {
+                    let factory = self.ctx.types.factory();
+                    let key_param = tsz_solver::TypeParamInfo {
+                        name: self.ctx.types.intern_string("__pick_key"),
+                        constraint: None,
+                        default: None,
+                        is_const: false,
+                        origin: tsz_solver::TypeParamOrigin::User,
+                    };
+                    let key_type = self.ctx.types.type_param(key_param);
+                    return factory.mapped(tsz_solver::MappedType {
+                        type_param: key_param,
+                        constraint: type_args[1],
+                        name_type: None,
+                        template: factory.index_access(type_args[0], key_type),
+                        readonly_modifier: None,
+                        optional_modifier: None,
+                    });
+                }
+
+                let (base_type, _) = self.resolve_lib_type_with_params(name);
+                if let Some(base_type) = base_type {
+                    return self.ctx.types.factory().application(base_type, type_args);
+                }
+            }
+            return TypeId::ANY;
+        }
+
+        self.report_missing_lib_type_name(name, type_name_idx);
+
+        if !self.ctx.compiler_options.no_lib
+            && matches!(name, "Promise" | "PromiseLike")
+            && let Some(args) = &type_ref.type_arguments
+        {
+            let type_args: Vec<TypeId> = args
+                .nodes
+                .iter()
+                .map(|&arg_idx| self.get_type_from_type_node(arg_idx))
+                .collect();
+            if !type_args.is_empty() {
+                let promise_base = {
+                    let lib_binders = self.get_lib_binders();
+                    crate::types_domain::queries::lib_resolution::resolve_name_to_lib_symbol(
+                        name,
+                        self.ctx.binder,
+                        self.ctx.global_file_locals_index.as_deref(),
+                        self.ctx
+                            .all_binders
+                            .as_ref()
+                            .map(|binders| binders.as_ref().as_slice()),
+                        &self.ctx.lib_contexts,
+                    )
+                    .or_else(|| {
+                        lib_binders
+                            .iter()
+                            .find_map(|binder| binder.file_locals.get(name))
+                    })
+                    .map(|sym_id| {
+                        let _ = self.resolve_lib_type_by_name(name);
+                        let def_id = self.ctx.get_canonical_lib_def_id(name, sym_id);
+                        self.ctx.types.factory().lazy(def_id)
+                    })
+                    .unwrap_or(TypeId::PROMISE_BASE)
+                };
+                return self
+                    .ctx
+                    .types
+                    .factory()
+                    .application(promise_base, type_args);
+            }
+        }
+
+        if let Some(args) = &type_ref.type_arguments {
+            for &arg_idx in &args.nodes {
+                let _ = self.get_type_from_type_node(arg_idx);
+            }
+        }
+        TypeId::ERROR
+    }
+}

--- a/crates/tsz-checker/src/state/type_resolution/mod.rs
+++ b/crates/tsz-checker/src/state/type_resolution/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod heritage_publication;
 pub(crate) mod import_type;
 pub(crate) mod import_type_meaning;
 pub(crate) mod judge;
+mod missing_global_type;
 pub(crate) mod mixin_constraints;
 pub(crate) mod module;
 mod primitive_keyword;
@@ -22,6 +23,7 @@ mod symbol_shadowing;
 pub(crate) mod symbol_types;
 pub(crate) mod symbol_types_class;
 pub(crate) mod symbol_types_dynamic_alias;
+pub(crate) mod symbol_types_import_alias;
 pub(crate) mod symbol_types_lazy;
 #[cfg(test)]
 mod symbol_types_tests;

--- a/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
+++ b/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
@@ -889,56 +889,6 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Fallback alias resolution for cross-file imports when `resolve_alias_symbol` can't find the target.
-    pub(crate) fn resolve_import_alias_cross_file(&self, sym_id: SymbolId) -> Option<SymbolId> {
-        let lib_binders: Vec<_> = self
-            .ctx
-            .lib_contexts
-            .iter()
-            .map(|lc| std::sync::Arc::clone(&lc.binder))
-            .collect();
-        let symbol = self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders)?;
-        if !symbol.has_any_flags(symbol_flags::ALIAS) {
-            return None;
-        }
-        let module_specifier = symbol.import_module()?;
-        let import_name = symbol.import_name().unwrap_or(symbol.escaped_name.as_str());
-
-        // Local import aliases resolve relative to the current file even if a
-        // same-number cross-file target has already been registered for `sym_id`.
-        // SymbolIds are per binder, so imported aliases can collide numerically
-        // with their target after lib merging.
-        let source_file_idx = if self
-            .ctx
-            .binder
-            .get_symbol(sym_id)
-            .is_some_and(|local| local.has_any_flags(symbol_flags::ALIAS))
-        {
-            self.ctx.current_file_idx
-        } else {
-            self.ctx
-                .resolve_symbol_file_index(sym_id)
-                .unwrap_or(self.ctx.current_file_idx)
-        };
-
-        let target_idx = self
-            .ctx
-            .resolve_import_target_from_file(source_file_idx, module_specifier)?;
-        let target_binder = self.ctx.get_binder_for_file(target_idx)?;
-        let target_arena = self.ctx.get_arena_for_file(target_idx as u32);
-        let file_name = &target_arena.source_files.first()?.file_name;
-
-        // Try module_exports first (keyed by filename), then file_locals.
-        let target_sym_id = target_binder
-            .module_exports
-            .get(file_name)
-            .and_then(|exports| exports.get(import_name))
-            .or_else(|| target_binder.file_locals.get(import_name))?;
-
-        self.ctx
-            .register_symbol_file_target(target_sym_id, target_idx);
-        Some(target_sym_id)
-    }
-
     /// Bypasses `get_type_of_symbol` to get the interface type directly from declarations.
     /// Needed for merged interface+namespace symbols where `get_type_of_symbol` returns the namespace type.
     pub(crate) fn compute_interface_type_from_declarations(&mut self, sym_id: SymbolId) -> TypeId {
@@ -1050,6 +1000,11 @@ impl<'a> CheckerState<'a> {
                 &cross_arena_declarations,
             )
         };
+        let computed_wide_symbol_names = if cross_arena_declarations.is_empty() {
+            self.precompute_wide_symbol_computed_property_names(&declarations)
+        } else {
+            self.precompute_wide_symbol_computed_property_names_in_arenas(&cross_arena_declarations)
+        };
         let prewarmed_type_params = if cross_arena_declarations.is_empty() {
             self.prewarm_member_type_reference_params(&declarations)
         } else {
@@ -1096,6 +1051,9 @@ impl<'a> CheckerState<'a> {
         };
         let computed_symbol_name_resolver =
             |expr_idx: NodeIndex| computed_symbol_names.contains(&(expr_idx, single_arena_ptr));
+        let computed_wide_symbol_name_resolver = |expr_idx: NodeIndex| {
+            computed_wide_symbol_names.contains(&(expr_idx, single_arena_ptr))
+        };
         let lazy_type_params_resolver = |def_id: tsz_solver::def::DefId| {
             prewarmed_type_params
                 .get(&def_id)
@@ -1112,6 +1070,7 @@ impl<'a> CheckerState<'a> {
         .with_type_param_bindings(type_param_bindings)
         .with_computed_name_resolver(&computed_name_resolver)
         .with_computed_symbol_name_resolver(&computed_symbol_name_resolver)
+        .with_computed_wide_symbol_name_resolver(&computed_wide_symbol_name_resolver)
         .with_lazy_type_params_resolver(&lazy_type_params_resolver)
         .with_name_def_id_resolver(&name_resolver);
         let lowering = if (self.ctx.is_declaration_file() && !self.ctx.lib_contexts.is_empty())
@@ -1443,6 +1402,8 @@ impl<'a> CheckerState<'a> {
                     self.precompute_computed_property_names_in_arenas(&decls_with_arenas);
                 let computed_symbol_names = self
                     .precompute_symbol_named_computed_property_names_in_arenas(&decls_with_arenas);
+                let computed_wide_symbol_names = self
+                    .precompute_wide_symbol_computed_property_names_in_arenas(&decls_with_arenas);
 
                 // Push type params, lower interface, pop type params.
                 // push_type_parameters uses self.ctx.arena (user arena) to read
@@ -1632,6 +1593,12 @@ impl<'a> CheckerState<'a> {
                      -> bool {
                         computed_symbol_names.contains(&(expr_idx, arena as usize))
                     };
+                let computed_wide_symbol_name_resolver_with_arena =
+                    |expr_idx: NodeIndex,
+                     arena: *const tsz_parser::parser::node::NodeArena|
+                     -> bool {
+                        computed_wide_symbol_names.contains(&(expr_idx, arena as usize))
+                    };
                 let lazy_type_params_resolver = |def_id: tsz_solver::def::DefId| {
                     prewarmed_lazy_type_params
                         .get(&def_id)
@@ -1651,6 +1618,9 @@ impl<'a> CheckerState<'a> {
                 .with_computed_name_resolver_with_arena(&computed_name_resolver_with_arena)
                 .with_computed_symbol_name_resolver_with_arena(
                     &computed_symbol_name_resolver_with_arena,
+                )
+                .with_computed_wide_symbol_name_resolver_with_arena(
+                    &computed_wide_symbol_name_resolver_with_arena,
                 )
                 .with_preferred_self_reference(
                     symbol.escaped_name.clone(),

--- a/crates/tsz-checker/src/state/type_resolution/symbol_types_import_alias.rs
+++ b/crates/tsz-checker/src/state/type_resolution/symbol_types_import_alias.rs
@@ -1,0 +1,57 @@
+//! Cross-file import-alias resolution split out of `symbol_types.rs` to keep
+//! that file under the architecture guard's line cap.
+
+use crate::state::CheckerState;
+use tsz_binder::{SymbolId, symbol_flags};
+
+impl<'a> CheckerState<'a> {
+    pub(crate) fn resolve_import_alias_cross_file(&self, sym_id: SymbolId) -> Option<SymbolId> {
+        let lib_binders: Vec<_> = self
+            .ctx
+            .lib_contexts
+            .iter()
+            .map(|lc| std::sync::Arc::clone(&lc.binder))
+            .collect();
+        let symbol = self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders)?;
+        if !symbol.has_any_flags(symbol_flags::ALIAS) {
+            return None;
+        }
+        let module_specifier = symbol.import_module()?;
+        let import_name = symbol.import_name().unwrap_or(symbol.escaped_name.as_str());
+
+        // Local import aliases resolve relative to the current file even if a
+        // same-number cross-file target has already been registered for `sym_id`.
+        // SymbolIds are per binder, so imported aliases can collide numerically
+        // with their target after lib merging.
+        let source_file_idx = if self
+            .ctx
+            .binder
+            .get_symbol(sym_id)
+            .is_some_and(|local| local.has_any_flags(symbol_flags::ALIAS))
+        {
+            self.ctx.current_file_idx
+        } else {
+            self.ctx
+                .resolve_symbol_file_index(sym_id)
+                .unwrap_or(self.ctx.current_file_idx)
+        };
+
+        let target_idx = self
+            .ctx
+            .resolve_import_target_from_file(source_file_idx, module_specifier)?;
+        let target_binder = self.ctx.get_binder_for_file(target_idx)?;
+        let target_arena = self.ctx.get_arena_for_file(target_idx as u32);
+        let file_name = &target_arena.source_files.first()?.file_name;
+
+        // Try module_exports first (keyed by filename), then file_locals.
+        let target_sym_id = target_binder
+            .module_exports
+            .get(file_name)
+            .and_then(|exports| exports.get(import_name))
+            .or_else(|| target_binder.file_locals.get(import_name))?;
+
+        self.ctx
+            .register_symbol_file_target(target_sym_id, target_idx);
+        Some(target_sym_id)
+    }
+}

--- a/crates/tsz-checker/src/types/computed_names.rs
+++ b/crates/tsz-checker/src/types/computed_names.rs
@@ -333,6 +333,23 @@ pub(crate) fn symbol_is_unique_symbol_binding(ctx: &CheckerContext<'_>, sym_id: 
     })
 }
 
+/// Does `sym_id` denote a binding with plain (non-unique) `symbol` identity —
+/// a `const`/parameter/property annotated `: symbol` rather than `: unique
+/// symbol`? Unlike [`symbol_is_unique_symbol_binding`], which value-position
+/// consumers (`ws[sym]` element access) use to key a member by binding
+/// identity, this predicate is for STRUCTURAL member collection
+/// (interface/type-literal lowering): tsc does not give such a key its own
+/// named identity there — it contributes to the containing type's symbol
+/// index signature instead. The two predicates are mutually exclusive for
+/// any single declaration.
+pub(crate) fn symbol_is_wide_symbol_binding(ctx: &CheckerContext<'_>, sym_id: SymbolId) -> bool {
+    let sym_id = follow_import_aliases(ctx, sym_id);
+    any_declaration_matches(ctx, sym_id, |owner_binder, arena, decl_idx| {
+        !declaration_is_unique_symbol_binding(ctx, owner_binder, arena, decl_idx)
+            && declaration_has_nonunique_symbol_annotation(arena, decl_idx)
+    })
+}
+
 fn declaration_is_unique_symbol_binding(
     ctx: &CheckerContext<'_>,
     owner_binder: &BinderState,
@@ -788,4 +805,34 @@ pub(crate) fn computed_property_is_symbol_named_in_arena(
     expr_idx: NodeIndex,
 ) -> bool {
     computed_property_name_atom_in_arena(ctx, arena, binder, resolve_symbol, expr_idx).is_some()
+}
+
+/// Is the computed-name expression keyed by a plain (non-unique)
+/// `symbol`-typed binding — the structural-lowering counterpart of
+/// [`symbol_is_wide_symbol_binding`]? `false` for a well-known `[Symbol.x]`
+/// syntactic key or any other qualified member access (`base.member`),
+/// neither of which routes through binding-identity resolution, and for a
+/// genuine `unique symbol` binding.
+pub(crate) fn computed_property_is_wide_symbol_named(
+    ctx: &CheckerContext<'_>,
+    resolve_symbol: impl Fn(NodeIndex) -> Option<SymbolId>,
+    expr_idx: NodeIndex,
+) -> bool {
+    computed_property_is_wide_symbol_named_in_arena(ctx, ctx.arena, resolve_symbol, expr_idx)
+}
+
+/// Arena-aware form of [`computed_property_is_wide_symbol_named`].
+pub(crate) fn computed_property_is_wide_symbol_named_in_arena(
+    ctx: &CheckerContext<'_>,
+    arena: &NodeArena,
+    resolve_symbol: impl Fn(NodeIndex) -> Option<SymbolId>,
+    expr_idx: NodeIndex,
+) -> bool {
+    if member_access_parts(arena, expr_idx).is_some_and(|parts| parts.member.is_some()) {
+        return false;
+    }
+    let Some(sym_id) = resolve_symbol(expr_idx) else {
+        return false;
+    };
+    symbol_is_wide_symbol_binding(ctx, sym_id)
 }

--- a/crates/tsz-checker/src/types/queries/core_names.rs
+++ b/crates/tsz-checker/src/types/queries/core_names.rs
@@ -379,6 +379,32 @@ impl<'a> CheckerState<'a> {
                 .is_some()
     }
 
+    /// Is the computed-name expression keyed by a plain (non-unique)
+    /// `symbol`-typed binding? `false` for a well-known `[Symbol.x]` key, a
+    /// declared unique-symbol member, or a genuine `unique symbol` binding —
+    /// only a plain `: symbol` binding routes into the containing type's
+    /// symbol index signature during structural member collection.
+    pub(crate) fn computed_property_expression_is_wide_symbol_named(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> bool {
+        if self.get_symbol_property_name_from_expr(expr_idx).is_some() {
+            return false;
+        }
+        if self
+            .declared_unique_symbol_member_property_name(expr_idx)
+            .is_some()
+        {
+            return false;
+        }
+        self.resolve_computed_name_expression_symbol(expr_idx)
+            .is_some_and(|sym_id| {
+                crate::types_domain::computed_names::symbol_is_wide_symbol_binding(
+                    &self.ctx, sym_id,
+                )
+            })
+    }
+
     pub(crate) fn computed_property_expression_unique_symbol_type(
         &self,
         expr_idx: NodeIndex,
@@ -451,7 +477,18 @@ impl<'a> CheckerState<'a> {
         self.ctx.preserve_literal_types = prev_preserve;
         self.ctx.checking_computed_property_name = prev_checking;
 
-        crate::query_boundaries::common::unique_symbol_ref(self.ctx.types, expr_type).is_some()
+        if crate::query_boundaries::common::unique_symbol_ref(self.ctx.types, expr_type).is_some() {
+            return true;
+        }
+        // A plain (non-unique) `symbol`-typed binding: the containing
+        // declaration (e.g. a class) still enumerates this as an ordinary
+        // named member — unlike an interface/type-literal, it has no symbol
+        // index signature to route into — but flagging it `is_symbol_named`
+        // lets `check_properties_against_index_signatures` (tsz-solver)
+        // recognize it as structurally satisfying a TARGET's real symbol
+        // index signature, matching tsc's late-bound-member assignability.
+        self.symbol_valued_binding_property_name(computed.expression, expr_type)
+            .is_some()
     }
 
     fn resolve_computed_unique_symbol_property(

--- a/crates/tsz-checker/src/types/type_node_lowering.rs
+++ b/crates/tsz-checker/src/types/type_node_lowering.rs
@@ -375,6 +375,8 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             |expr_idx: NodeIndex| self.computed_property_expression_name_atom(expr_idx);
         let computed_symbol_name_resolver =
             |expr_idx: NodeIndex| self.computed_property_expression_is_symbol_named(expr_idx);
+        let computed_wide_symbol_name_resolver =
+            |expr_idx: NodeIndex| self.computed_property_expression_is_wide_symbol_named(expr_idx);
 
         let mut lowering = TypeLowering::with_hybrid_resolver(
             self.ctx.arena,
@@ -389,6 +391,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         .with_type_query_override(&type_query_override)
         .with_computed_name_resolver(&computed_name_resolver)
         .with_computed_symbol_name_resolver(&computed_symbol_name_resolver)
+        .with_computed_wide_symbol_name_resolver(&computed_wide_symbol_name_resolver)
         .with_local_shadow_def_id_resolver(&local_shadow_def_id_resolver);
         if use_qualified_names && self.type_node_is_in_lib_declaration(idx) {
             lowering = lowering.prefer_name_def_id_resolution();

--- a/crates/tsz-checker/src/types/type_node_property_names.rs
+++ b/crates/tsz-checker/src/types/type_node_property_names.rs
@@ -149,6 +149,17 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         )
     }
 
+    pub(super) fn computed_property_expression_is_wide_symbol_named(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> bool {
+        computed_names::computed_property_is_wide_symbol_named(
+            self.ctx,
+            |idx| self.resolve_computed_property_symbol(idx),
+            expr_idx,
+        )
+    }
+
     /// Resolve the binding a computed-name expression refers to, mirroring the
     /// strong `CheckerState` path's `resolve_computed_name_expression_symbol`:
     /// scope-aware `resolve_identifier` with a `file_locals` fallback (no

--- a/crates/tsz-checker/src/types/type_node_resolution.rs
+++ b/crates/tsz-checker/src/types/type_node_resolution.rs
@@ -1112,6 +1112,26 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                     name.starts_with("[Symbol.") || name.starts_with("__unique_")
                 })
             };
+            // A plain (non-unique) `symbol`-typed binding isn't resolved by
+            // `computed_name_resolver` above (it only recognizes `unique
+            // symbol` identity), so it must be checked independently here
+            // rather than derived from that resolver's answer.
+            let computed_wide_symbol_name_resolver = |expr_idx: NodeIndex| -> bool {
+                let sym_id = value_resolver(expr_idx)
+                    .map(tsz_binder::SymbolId)
+                    .or_else(|| {
+                        Self::resolve_computed_property_symbol_in_arena(
+                            decl_arena,
+                            expr_idx,
+                            &resolve_text_symbol,
+                        )
+                    });
+                sym_id.is_some_and(|sym_id| {
+                    crate::types_domain::computed_names::symbol_is_wide_symbol_binding(
+                        self.ctx, sym_id,
+                    )
+                })
+            };
 
             // Provide flow-narrowed types for `typeof expr` in the type alias body.
             // These were pre-computed by `precompute_type_query_flow_types` during
@@ -1312,6 +1332,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                 .with_type_param_bindings(bindings)
                 .with_computed_name_resolver(&computed_name_resolver)
                 .with_computed_symbol_name_resolver(&computed_symbol_name_resolver)
+                .with_computed_wide_symbol_name_resolver(&computed_wide_symbol_name_resolver)
                 .with_name_def_id_resolver(&name_resolver)
                 .with_type_query_override(&type_query_override)
             };

--- a/crates/tsz-checker/tests/wide_symbol_computed_member_index_signature_tests.rs
+++ b/crates/tsz-checker/tests/wide_symbol_computed_member_index_signature_tests.rs
@@ -1,0 +1,124 @@
+//! Adjacent-case matrix for issue #16307: a computed member keyed by a plain
+//! (non-unique) `symbol` must route into the containing type's symbol index
+//! signature, not mint a synthetic named member.
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn assert_clean(source: &str) {
+    let diags = check_source_diagnostics(source);
+    assert!(diags.is_empty(), "expected exit 0 like tsc, got: {diags:?}");
+}
+
+#[test]
+fn issue_16307_minimal_repro() {
+    assert_clean(
+        r#"
+declare const s: symbol;
+declare const other: symbol;
+
+interface Explicit { [key: symbol]: number }
+declare const e: Explicit;
+export const readExplicit: number = e[other];
+
+interface Implicit { [s]: number }
+declare const i: Implicit;
+export const readImplicit: number = i[other];
+export const implicitToExplicit: Explicit = i;
+export const explicitToImplicit: Implicit = e;
+"#,
+    );
+}
+
+#[test]
+fn wide_symbol_computed_member_renamed_binders() {
+    // Same structural shape as the minimal repro, with every identifier
+    // renamed, proving the fix is not keyed off a specific binder name.
+    assert_clean(
+        r#"
+declare const mySymbolKey: symbol;
+declare const anotherSymbol: symbol;
+
+interface WithExplicitIndex { [k: symbol]: string }
+declare const withExplicit: WithExplicitIndex;
+export const readViaExplicit: string = withExplicit[anotherSymbol];
+
+interface WithComputedKey { [mySymbolKey]: string }
+declare const withComputed: WithComputedKey;
+export const readViaComputed: string = withComputed[anotherSymbol];
+export const computedToExplicit: WithExplicitIndex = withComputed;
+export const explicitToComputed: WithComputedKey = withExplicit;
+"#,
+    );
+}
+
+#[test]
+fn two_independent_wide_symbol_keyed_interfaces_are_mutually_assignable() {
+    // Two interfaces each computed-keyed by a DIFFERENT `symbol`-typed const
+    // still describe the same member set (tsc widens both to the symbol
+    // index signature, discarding per-declaration identity).
+    assert_clean(
+        r#"
+declare const symA: symbol;
+declare const symB: symbol;
+
+interface FromA { [symA]: number }
+interface FromB { [symB]: number }
+
+declare const a: FromA;
+declare const b: FromB;
+export const aToB: FromB = a;
+export const bToA: FromA = b;
+"#,
+    );
+}
+
+#[test]
+fn wide_symbol_index_alongside_named_string_members() {
+    assert_clean(
+        r#"
+declare const s: symbol;
+interface Mixed {
+    name: string;
+    [s]: number;
+}
+declare const m: Mixed;
+declare const other: symbol;
+export const nameRead: string = m.name;
+export const symbolRead: number = m[other];
+"#,
+    );
+}
+
+#[test]
+fn wide_symbol_computed_method_signature_routes_to_symbol_index() {
+    assert_clean(
+        r#"
+declare const s: symbol;
+declare const other: symbol;
+interface HasMethod { [s](): number }
+declare const h: HasMethod;
+export const called: number = h[other]();
+"#,
+    );
+}
+
+#[test]
+fn unique_symbol_computed_member_keeps_distinct_identity_not_index() {
+    // Negative control: a genuine `unique symbol` key must NOT be folded
+    // into a symbol index signature — it keeps its own named identity, so
+    // two interfaces keyed by two DIFFERENT unique symbols are NOT
+    // mutually assignable.
+    let source = r#"
+declare const u1: unique symbol;
+declare const u2: unique symbol;
+interface FromU1 { [u1]: number }
+interface FromU2 { [u2]: number }
+declare const a: FromU1;
+export const bad: FromU2 = a;
+"#;
+    let diags = check_source_diagnostics(source);
+    assert!(
+        diags.iter().any(|d| d.code == 2322 || d.code == 2741),
+        "unique-symbol-keyed interfaces must not unify via a shared symbol \
+         index signature, got: {diags:?}"
+    );
+}

--- a/crates/tsz-lowering/src/lower/core.rs
+++ b/crates/tsz-lowering/src/lower/core.rs
@@ -847,6 +847,27 @@ impl<'a> TypeLowering<'a> {
         self
     }
 
+    /// Set the resolver for computed property names that are keyed by a
+    /// plain (non-unique) `symbol`-typed binding. Such members route into
+    /// the containing type's symbol index signature instead of minting a
+    /// named member — see `LoweringHost::computed_name_is_wide_symbol`.
+    pub fn with_computed_wide_symbol_name_resolver(
+        mut self,
+        resolver: &'a dyn Fn(NodeIndex) -> bool,
+    ) -> Self {
+        self.host.computed_wide_symbol_name_resolver = Some(resolver);
+        self
+    }
+
+    /// Arena-aware variant of `with_computed_wide_symbol_name_resolver`.
+    pub fn with_computed_wide_symbol_name_resolver_with_arena(
+        mut self,
+        resolver: &'a dyn Fn(NodeIndex, *const NodeArena) -> bool,
+    ) -> Self {
+        self.host.computed_wide_symbol_name_resolver_with_arena = Some(resolver);
+        self
+    }
+
     /// Set the lazy type parameter resolver for applying omitted defaulted type arguments
     /// when lowering lazy references from interface members.
     pub fn with_lazy_type_params_resolver(

--- a/crates/tsz-lowering/src/lower/core/signature_members.rs
+++ b/crates/tsz-lowering/src/lower/core/signature_members.rs
@@ -139,7 +139,19 @@ impl<'a> TypeLowering<'a> {
                             .push(self.lower_call_signature(sig));
                     }
                     k if k == syntax_kind_ext::METHOD_SIGNATURE => {
-                        if let Some(name) = self.lower_signature_name(sig.name) {
+                        if self.is_wide_symbol_computed_name(sig.name) {
+                            let readonly = self.arena.has_modifier(
+                                &sig.modifiers,
+                                tsz_scanner::SyntaxKind::ReadonlyKeyword,
+                            );
+                            let value_type = self.lower_method_signature(sig);
+                            parts.merge_index_signature(IndexSignature {
+                                key_type: TypeId::SYMBOL,
+                                value_type,
+                                readonly,
+                                param_name: None,
+                            });
+                        } else if let Some(name) = self.lower_signature_name(sig.name) {
                             let is_symbol_named =
                                 self.lower_signature_name_is_symbol_named(sig.name);
                             let (is_string_named, single_quoted_name) =
@@ -164,7 +176,19 @@ impl<'a> TypeLowering<'a> {
                         }
                     }
                     _ => {
-                        if let Some(prop) = self.lower_type_element(idx) {
+                        if self.is_wide_symbol_computed_name(sig.name) {
+                            let readonly = self.arena.has_modifier(
+                                &sig.modifiers,
+                                tsz_scanner::SyntaxKind::ReadonlyKeyword,
+                            );
+                            let value_type = self.lower_type(sig.type_annotation);
+                            parts.merge_index_signature(IndexSignature {
+                                key_type: TypeId::SYMBOL,
+                                value_type,
+                                readonly,
+                                param_name: None,
+                            });
+                        } else if let Some(prop) = self.lower_type_element(idx) {
                             parts.merge_property(prop);
                         } else if self.is_unresolved_computed_property_name(sig.name) {
                             parts.has_late_bound_members = true;
@@ -183,6 +207,30 @@ impl<'a> TypeLowering<'a> {
 
             // Handle accessor declarations (get/set) in interfaces and type literals
             if member.is_accessor()
+                && let Some(accessor) = self.arena.get_accessor(member)
+                && self.is_wide_symbol_computed_name(accessor.name)
+            {
+                let is_getter = member.kind == syntax_kind_ext::GET_ACCESSOR;
+                let value_type = if is_getter {
+                    self.lower_type(accessor.type_annotation)
+                } else {
+                    accessor
+                        .parameters
+                        .nodes
+                        .first()
+                        .and_then(|&param_idx| self.arena.get(param_idx))
+                        .and_then(|param_node| self.arena.get_parameter(param_node))
+                        .map_or(TypeId::UNKNOWN, |param| {
+                            self.lower_type(param.type_annotation)
+                        })
+                };
+                parts.merge_index_signature(IndexSignature {
+                    key_type: TypeId::SYMBOL,
+                    value_type,
+                    readonly: is_getter,
+                    param_name: None,
+                });
+            } else if member.is_accessor()
                 && let Some(accessor) = self.arena.get_accessor(member)
                 && let Some(name) = self.lower_signature_name(accessor.name)
             {
@@ -681,6 +729,30 @@ impl<'a> TypeLowering<'a> {
         self.arena
             .get(name_idx)
             .is_some_and(|n| n.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME)
+    }
+
+    /// Returns true when `name_idx` is a computed property name keyed by a
+    /// plain (non-unique) `symbol`-typed binding. Such a member does not mint
+    /// a named property: tsc routes it into the containing type's symbol
+    /// index signature, so two independently-keyed `symbol`-typed members
+    /// still describe the same member set. Checked BEFORE
+    /// `lower_signature_name` so the wide-symbol key never reaches the
+    /// named-member path, matching tsc rather than binding-identity naming
+    /// (which is correct only for value-position member access, not for
+    /// structural interface/type-literal member collection).
+    pub(super) fn is_wide_symbol_computed_name(&self, name_idx: NodeIndex) -> bool {
+        let Some(node) = self.arena.get(name_idx) else {
+            return false;
+        };
+        if node.kind != syntax_kind_ext::COMPUTED_PROPERTY_NAME {
+            return false;
+        }
+        let Some(computed) = self.arena.get_computed_property(node) else {
+            return false;
+        };
+        self.host
+            .computed_name_is_wide_symbol(computed.expression, self.arena)
+            .unwrap_or(false)
     }
 
     pub(super) fn lower_signature_name_is_symbol_named(&self, node_idx: NodeIndex) -> bool {

--- a/crates/tsz-lowering/src/lower/host.rs
+++ b/crates/tsz-lowering/src/lower/host.rs
@@ -81,6 +81,21 @@ pub trait LoweringHost {
         None
     }
 
+    /// Whether a computed property expression resolves to a plain
+    /// (non-unique) `symbol`-valued key — a binding annotated `: symbol`
+    /// rather than `: unique symbol`. Such a key does not mint a named
+    /// member: tsc routes it into the containing type's symbol index
+    /// signature instead, so two declarations keyed by independent
+    /// `symbol`-typed bindings still describe the same member set.
+    ///
+    /// Returns `None` when this host wires no such resolver, in which case
+    /// the caller treats the key as an ordinary named member (the previous
+    /// behavior). A host that does wire a resolver returns `Some(answer)`
+    /// and that answer wins outright.
+    fn computed_name_is_wide_symbol(&self, _expr: NodeIndex, _arena: &NodeArena) -> Option<bool> {
+        None
+    }
+
     /// Resolve lazy type-parameter metadata for a `DefId` (used to apply omitted
     /// defaulted type arguments).
     fn resolve_lazy_type_params(&self, _def_id: DefId) -> Option<Vec<TypeParamInfo>> {
@@ -119,6 +134,9 @@ pub struct ClosureLoweringHost<'a> {
         Option<&'a dyn Fn(NodeIndex, *const NodeArena) -> Option<Atom>>,
     pub(super) computed_symbol_name_resolver: Option<&'a dyn Fn(NodeIndex) -> bool>,
     pub(super) computed_symbol_name_resolver_with_arena:
+        Option<&'a dyn Fn(NodeIndex, *const NodeArena) -> bool>,
+    pub(super) computed_wide_symbol_name_resolver: Option<&'a dyn Fn(NodeIndex) -> bool>,
+    pub(super) computed_wide_symbol_name_resolver_with_arena:
         Option<&'a dyn Fn(NodeIndex, *const NodeArena) -> bool>,
     pub(super) lazy_type_params_resolver: Option<&'a LazyTypeParamsResolver<'a>>,
     pub(super) type_query_override: Option<&'a NodeIndexResolver<'a, TypeId>>,
@@ -180,6 +198,17 @@ impl LoweringHost for ClosureLoweringHost<'_> {
             return Some(resolver(expr, arena_ptr));
         }
         if let Some(resolver) = self.computed_symbol_name_resolver {
+            return Some(resolver(expr));
+        }
+        None
+    }
+
+    fn computed_name_is_wide_symbol(&self, expr: NodeIndex, arena: &NodeArena) -> Option<bool> {
+        let arena_ptr: *const NodeArena = arena;
+        if let Some(resolver) = self.computed_wide_symbol_name_resolver_with_arena {
+            return Some(resolver(expr, arena_ptr));
+        }
+        if let Some(resolver) = self.computed_wide_symbol_name_resolver {
             return Some(resolver(expr));
         }
         None


### PR DESCRIPTION
Closes the identifier-keyed half of #16307 (xstate: `Symbol.observable`-shaped false positives, 23/108 row diagnostics).

## Goal
Goal: green

## Structural rule

**When a computed member's key expression resolves to a plain (non-unique) `symbol`-typed binding, `tsc` does not mint a named member — the declaration contributes a symbol index signature (`[key: symbol]: T`) to the containing type. tsz instead minted a synthetic named member (`__symbol_<file>_<id>`) through `tsz-lowering`'s `collect_object_type_members`, the shared interface/type-literal structural member collector.**

This made independently-declared `symbol`-keyed interfaces mutually unassignable (TS2322/TS2741), rejected `obj[someSymbol]` element access (TS7053), and leaked the internal placeholder name into diagnostic text (`Property '__symbol_0_743' is missing...`).

## Owner layer and fix

`tsz-lowering::collect_object_type_members` resolved a computed name via `lower_signature_name` (method/property/accessor arms) *before* checking whether the key denotes a wide symbol. Added:

- `LoweringHost::computed_name_is_wide_symbol` — a new resolver capability, checked first in each member arm; when `true`, the member routes into `ObjectTypeParts::merge_index_signature` with `key_type: TypeId::SYMBOL` instead of the named-member path.
- Wired at all 6 `TypeLowering` construction sites in `tsz-checker` (`symbol_types.rs` ×2, `state/type_analysis/computed/mod.rs`, `type_node_lowering.rs`, `type_node_resolution.rs`, `state/type_resolution/core.rs` ×2), via:
  - a new precompute pass `precompute_wide_symbol_computed_property_names[_in_arenas]` for the two arena-aware interface-lowering sites (mirrors the existing `precompute_symbol_named_computed_property_names`, distinguishing the `__symbol_` prefix from `__unique_`);
  - a new `symbol_is_wide_symbol_binding`/`computed_property_is_wide_symbol_named` predicate pair in `types::computed_names` for the 3 type-node-resolution sites, which otherwise fold wide-symbol and unique-symbol bindings into the same `__unique_<id>` binding-identity key (correct for *their* purpose — value-position `ws[sym]` element access — but wrong for structural member collection).
- Broadened `is_symbol_property_name` (checker) so a **class** member still enumerated by name (classes have no member-collection index-signature routing to fall back on) is flagged `is_symbol_named`, letting `check_properties_against_index_signatures` (tsz-solver) recognize it as structurally satisfying a target interface's real symbol index signature.

## Adjacent-case matrix (all oracle-consistent, `tsz-checker/tests/wide_symbol_computed_member_index_signature_tests.rs`)

| Case | tsc | tsz (before) | tsz (after) |
| --- | --- | --- | --- |
| `interface Explicit { [key: symbol]: T }` | ok | ok | ok (unchanged) |
| `interface Implicit { [s]: T }` (identifier, `s: symbol`) | ok | **named member, TS7053 on read** | ok — real `symbol_index` |
| `Implicit` ↔ `Explicit` mutual assignability | ok | **TS2322/TS2741 both ways** | ok |
| Two interfaces keyed by two *different* `symbol` consts | mutually assignable | **not assignable** | ok |
| Renamed binders (same shape, different identifier names) | ok | fails | ok |
| Mixed: `symbol` index alongside a named string property | ok | fails | ok |
| Computed **method** signature (`[s](): T`) keyed by wide symbol | ok | fails | ok |
| Negative control: two `unique symbol`-keyed interfaces (different consts) | **not** assignable | not assignable | **still not assignable** (unchanged — must not fold into an index signature) |

## Anti-hardcoding

No identifier/file-name checks; the routing decision is a resolver capability keyed off the expression's *resolved binder identity and declared type* (`: symbol` vs `: unique symbol`), computed identically regardless of what the binding or file is named. Binder names are varied across the test matrix.

## Known remaining gap (not attempted here, disclosed)

`[Symbol.x]` written as literal property-access syntax (e.g. a user-augmented `SymbolConstructor.observable: symbol`, xstate's actual shape) is still resolved as a literal string key by a separate, purely-syntactic shortcut (`get_well_known_symbol_name` / `well_known_symbol_access_shape`) that doesn't distinguish a genuine well-known *unique* symbol from a user-augmented *wide* one. That shortcut is why xstate's `Symbol.observable` row isn't fully closed by this PR — only the identifier-keyed half (this PR's own minimal repro, matching #16307's issue text exactly) is. Making that shortcut semantic (check the resolved type rather than the syntax) is a separate, larger, riskier change touching a much more widely-used code path; left as a sized follow-up and noted on the coordination board.

## Side note: architecture guard

`state/type_resolution/core.rs` and `state/type_resolution/symbol_types.rs` were already within a few lines of the 2000-line cap; this PR's additions tipped both over. Per CLAUDE.md ("split instead of adding local allowlists"), split one self-contained function out of each into a new sibling module (`missing_global_type.rs`, `symbol_types_import_alias.rs`) — pure relocation, no logic change.

## Verification

- `cargo test -p tsz-checker --test wide_symbol_computed_member_index_signature_tests` — **6 passed, 0 failed** (all new).
- `cargo nextest run -p tsz-lowering --lib` — **167 passed, 0 failed**.
- `cargo nextest run -p tsz-checker --lib` — **9263 passed, 1 failed** (`ts2303_tests::recursive_export_assignment_self_import_reports_ts2303`), **11 skipped**. Verified the 1 failure is pre-existing on `main` at the same head this branch forked from (reproduces identically with this branch's diff stashed out) — unrelated to this change (TS2303 export-assignment cycles vs. this PR's computed-symbol-member routing).
- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p tsz-lowering -p tsz-checker --all-targets -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py` — passes (both previously-near-cap files back under 2000 lines after the split).
- Pre-commit hook (clippy + tsz-checker/tsz-lowering tests) — passed.
- Conformance `compare-to-parent.sh` / project-corpus xstate row: **not run this session** (time budget). Expected-signature note: this is an ADDITIVE structural-routing change for a case (computed `symbol`-keyed interface members) not exercised by any currently-passing committed-corpus fixture in the way this PR changes it, so the primary evidence is the oracle-consistent adjacent-case matrix above rather than the corpus sweep. Flagging honestly rather than claiming a result I didn't measure — next session or a drain step should run `compare-to-parent.sh` and the xstate project-compile-guard invocation from #16307's own body before merge if that gate matters to the reviewer.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_01KBMKyqf3kDTrUQRnwnb8r1)_