### PR TITLE
fix(cli): audit is_parser_grammar_code, add 11 missing checker-suppressible codes

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -414,6 +414,21 @@ fn is_hard_keyword_interface_name_2427_parse_diagnostic(diagnostic: &ParseDiagno
 /// TS1014 elsewhere in the same file. TS1015/1016 belong to the same tsc
 /// function but are checker-emitted in tsz (`parameter_checker.rs`), so they
 /// never reach this filter either.
+///
+/// #16279 audit round: 11 more parser-emitted codes confirmed
+/// checker-suppressible against a real `typescript@7.0.2` oracle (a genuine
+/// unrelated syntax error in the same file drops each of these, matching the
+/// families already above) and added here: TS1079/1120 (modifier-on-a-
+/// declaration-that-cannot-have-modifiers, siblings of TS1191/1193 above),
+/// TS1092/1094 (type parameters where none are allowed, siblings of
+/// TS1093/1054 above), TS1098/1099 (list-cannot-be-empty, sibling of TS1097
+/// above), TS1242 (modifier-can-only-appear-on-X, sibling of TS1275 below),
+/// TS1246/1247 (property initializer not allowed in a type position), and
+/// TS1491/1495 (modifier-on-a-using-declaration). Two adjacent candidates
+/// with the same "modifier/decorator in the wrong place" shape, TS1433 and
+/// TS1436, were oracle-tested and rejected: tsc keeps both alongside an
+/// unrelated syntax error in the same file, so they are real parser
+/// diagnostics in tsc too and must NOT be added here.
 const fn is_parser_grammar_code(code: u32) -> bool {
     matches!(
         code,
@@ -445,14 +460,20 @@ const fn is_parser_grammar_code(code: u32) -> bool {
         | 1054 // A 'get' accessor cannot have parameters
         | 1070 // '{0}' modifier cannot appear on a type member
         | 1071 // An accessor must have a body (interface/ambient)
+        | 1079 // A '{0}' modifier cannot be used with an import declaration
         | 1089 // '{0}' modifier cannot appear on a constructor declaration
         | 1090 // '{0}' modifier cannot appear on a parameter
+        | 1092 // Type parameters cannot appear on a constructor declaration
         | 1093 // Type annotation cannot appear on a constructor declaration
+        | 1094 // An accessor cannot have type parameters
         | 1095 // A 'set' accessor cannot have a return type annotation
         | 1096 // An index signature must have exactly one parameter
         | 1097 // '{0}' list cannot be empty
+        | 1098 // Type parameter list cannot be empty
+        | 1099 // Type argument list cannot be empty
         | 1113 // A 'default' clause cannot appear more than once in a 'switch' statement
         | 1114 // Duplicate label
+        | 1120 // An export assignment cannot have modifiers
         | 1123 // Variable declaration list cannot be empty
         | 1162 // An object member cannot be declared optional
         | 1163 // A 'yield' expression is only allowed in a generator body
@@ -472,7 +493,12 @@ const fn is_parser_grammar_code(code: u32) -> bool {
         | 1210 // Code contained in a class is evaluated in strict mode
         | 1212 // Identifier expected. '{0}' is a reserved word in strict mode
         | 1213 // Identifier expected. '{0}' is a reserved word in strict mode. Class definitions are automatically in strict mode.
+        | 1242 // 'abstract' modifier can only appear on a class, method, or property declaration
         | 1243 // '{0}' modifier cannot be used with '{1}' modifier
+        | 1246 // An interface property cannot have an initializer
+        | 1247 // A type literal property cannot have an initializer
+        | 1491 // '{0}' modifier cannot appear on a 'using' declaration
+        | 1495 // '{0}' modifier cannot appear on an 'await using' declaration
         | 1275 // 'accessor' modifier can only appear on a property declaration
         | 1276 // An 'accessor' property cannot be declared optional
         | 8038 // Decorators may not appear after 'export' or 'export default' if they also appear before 'export'

--- a/crates/tsz-cli/src/driver/check_utils/tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/tests.rs
@@ -1714,6 +1714,103 @@ fn filtered_parse_diagnostics_ts1018_does_not_self_suppress_listed_sibling() {
 }
 
 #[test]
+fn filtered_parse_diagnostics_suppresses_16279_audit_codes_when_real_parse_error_present() {
+    use tsz::parser::ParseDiagnostic;
+
+    // #16279 audit round: TS1079/1092/1094/1098/1099/1120/1242/1246/1247/1491/1495
+    // were confirmed checker-suppressible against a real `typescript@7.0.2`
+    // oracle (a genuine unrelated syntax error in the same file drops each of
+    // these, matching the already-listed families they belong to). Before this
+    // fix, each was unlisted and so both went unsuppressed on its own AND
+    // silently deleted every listed sibling in the same file.
+    for code in [
+        1079, 1092, 1094, 1098, 1099, 1120, 1242, 1246, 1247, 1491, 1495,
+    ] {
+        let diagnostics = vec![
+            ParseDiagnostic {
+                start: 0,
+                length: 1,
+                message: "candidate".to_string(),
+                code,
+            },
+            ParseDiagnostic {
+                start: 10,
+                length: 1,
+                message: "Expression expected.".to_string(),
+                code: 1109,
+            },
+        ];
+        let filtered = filtered_parse_diagnostics(&diagnostics, false);
+        let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+        assert!(
+            !codes.contains(&code),
+            "TS{code} should be suppressed when a real parse error (TS1109) is present, got: {codes:?}"
+        );
+        assert!(
+            codes.contains(&1109),
+            "TS1109 (real parse error) should survive for the TS{code} case, got: {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn filtered_parse_diagnostics_keeps_16279_audit_codes_when_alone() {
+    use tsz::parser::ParseDiagnostic;
+
+    for code in [
+        1079, 1092, 1094, 1098, 1099, 1120, 1242, 1246, 1247, 1491, 1495,
+    ] {
+        let diagnostics = vec![ParseDiagnostic {
+            start: 0,
+            length: 1,
+            message: "candidate".to_string(),
+            code,
+        }];
+        let filtered = filtered_parse_diagnostics(&diagnostics, false);
+        let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+        assert!(
+            codes.contains(&code),
+            "TS{code} should be kept when it is the only diagnostic, got: {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn filtered_parse_diagnostics_keeps_ts1433_and_ts1436_alongside_real_parse_error() {
+    use tsz::parser::ParseDiagnostic;
+
+    // Oracle-tested and rejected for `is_parser_grammar_code`: unlike their
+    // modifier/decorator-shaped neighbors above, tsc keeps TS1433 ("Neither
+    // decorators nor modifiers may be applied to 'this' parameters.") and
+    // TS1436 ("Decorators must precede the name...") even when a real
+    // structural syntax error (TS1109) exists elsewhere in the file. They are
+    // real tsc parser diagnostics, not checker-side grammar checks, so they
+    // must never be added to the suppression list.
+    for code in [1433, 1436] {
+        let diagnostics = vec![
+            ParseDiagnostic {
+                start: 0,
+                length: 1,
+                message: "candidate".to_string(),
+                code,
+            },
+            ParseDiagnostic {
+                start: 10,
+                length: 1,
+                message: "Expression expected.".to_string(),
+                code: 1109,
+            },
+        ];
+        let filtered = filtered_parse_diagnostics(&diagnostics, false);
+        let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+        assert!(
+            codes.contains(&code),
+            "TS{code} must survive alongside a real parse error (confirmed real tsc parser diagnostic), got: {codes:?}"
+        );
+    }
+}
+
+#[test]
 fn js_parse_allowlist_keeps_plain_js_binder_strict_codes() {
     for code in [1214, 18012] {
         assert!(


### PR DESCRIPTION
Closes the modifier/type-parameter/list-empty slice of #16279's audit.

### Structural rule

`is_parser_grammar_code` (`crates/tsz-cli/src/driver/check_utils.rs`) lists parser-emitted codes that tsc instead emits via `grammarErrorOnNode` in the checker, so they must be suppressed whenever a real parse error exists elsewhere in the file (`hasParseDiagnostics`). Membership is load-bearing in **both** directions: `has_non_grammar_parse_error` is computed as this list's *complement*, so an unlisted parser-emitted grammar code is treated as a real parse error and silently deletes every *listed* sibling in the same file — the exact bug #16278 fixed for the accessor family (TS1049/1051 missing, deleting TS1054's siblings).

#16279 asked for a systematic audit rather than another one-off fix. I extracted every `diagnostic_codes::*` name referenced from `crates/tsz-parser/src` (190 distinct codes), resolved each to its numeric code, and diffed against the current list. Real syntax-error codes ("X expected", "unterminated Y") and the regex-grammar family (already audited separately in #16312) are correctly absent. The remaining candidates were verified individually against a real `typescript@7.0.2` oracle using the issue's own Direction B test: the candidate diagnostic plus an unrelated genuine syntax error (`const a = ;` → TS1109) in the same file — if tsc drops the candidate under that condition, it belongs in the list.

**11 codes confirmed and added**, each is the shape-sibling of an already-listed member of the same tsc grammar family:

| new code | message | sibling already listed |
| --- | --- | --- |
| TS1079 | A '{0}' modifier cannot be used with an import declaration | TS1191 (import decl. cannot have modifiers) |
| TS1120 | An export assignment cannot have modifiers | TS1193 (export decl. cannot have modifiers) |
| TS1092 | Type parameters cannot appear on a constructor declaration | TS1093 (type annotation on constructor) |
| TS1094 | An accessor cannot have type parameters | TS1054 (get accessor cannot have parameters) |
| TS1098 | Type parameter list cannot be empty | TS1097 ('{0}' list cannot be empty) |
| TS1099 | Type argument list cannot be empty | TS1097 |
| TS1242 | 'abstract' modifier can only appear on a class, method, or property declaration | TS1275 ('accessor' modifier can only appear on a property declaration) |
| TS1246 | An interface property cannot have an initializer | (new small family) |
| TS1247 | A type literal property cannot have an initializer | (new small family) |
| TS1491 | '{0}' modifier cannot appear on a 'using' declaration | TS1040/1044/1070/1090 (modifier cannot appear on X) |
| TS1495 | '{0}' modifier cannot appear on an 'await using' declaration | same family |

**Two adjacent candidates rejected** after the same test: TS1433 ("Neither decorators nor modifiers may be applied to 'this' parameters") and TS1436 ("Decorators must precede the name...") both *survive* alongside a real syntax error in tsc's own output — they are genuine tsc parser diagnostics, not checker-side grammar checks, and adding them would be a new bug in the other direction. Recorded as negative controls in the doc comment and as a dedicated test so nobody re-adds them.

Owner layer: `crates/tsz-cli/src/driver/check_utils.rs`, the CLI diagnostic-filtering boundary — no checker, solver, or emitter surface touched. Purely a suppression-membership change on already-existing parser diagnostics; no new diagnostic is introduced.

### Not yet done

The audit is not exhaustive — I worked module/list/accessor/using-declaration families in `crates/tsz-parser/src/parser/state_declarations.rs`, `state_variable_declarations.rs`, `state_statements_keywords.rs`, `state_statements_class_members.rs`, `state_type_parameters.rs`, and `state_types_advanced.rs`. Left unaudited for a future slice: TS1246/1247's own family may have further siblings, and the class-member/decorator cluster around TS1436 (rejected here) may still hide a real checker-suppressible sibling I didn't test. Full candidate list (190 parser-emitted codes vs. the pre-PR list) is reproducible with the grep-and-diff recipe in the commit; happy to hand it to the next session.

## Goal
Goal: hold

## Verification
- `cargo fmt -p tsz-cli` clean (pre-commit hook ran it).
- `cargo clippy -p tsz-cli --lib --all-targets -- -D warnings` clean.
- `cargo test -p tsz-cli --lib -- check_utils::tests::` — **102 passed, 0 failed** (was 99 before this PR's 3 new test functions, one of which loops over all 11 new codes for both directions, plus the TS1433/1436 negative-control test).
- Oracle: all 11 additions and both rejections verified individually against a real `typescript@7.0.2` subprocess (Direction B: candidate + unrelated real syntax error in the same file).
- `scripts/conformance/compare-to-parent.sh origin/main` running now in background at post time (this changes existing suppression behavior, not purely additive, so the corpus gate matters here); will follow up with the result as a PR comment before this queues, per the routine's land-and-continue policy.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uj9AfAH3qZM5nLJBHu2cnW)_