### PR TITLE
fix(checker): TS1252 for a module-hosted strict-mode function-in-block

### DIFF
--- a/crates/tsz-checker/src/declarations/declarations.rs
+++ b/crates/tsz-checker/src/declarations/declarations.rs
@@ -351,6 +351,7 @@ impl<'a, 'ctx> DeclarationChecker<'a, 'ctx> {
 
     /// TS1250: "Function declarations are not allowed inside blocks in strict mode when targeting 'ES3' or 'ES5'."
     /// TS1251: Same, with "Class definitions are automatically in strict mode."
+    /// TS1252: Same, with "Modules are automatically in strict mode."
     fn check_strict_mode_function_in_block(&mut self, func_idx: NodeIndex) {
         // Only applies when targeting ES5 or lower
         if !self.ctx.compiler_options.target.is_es5() {
@@ -400,9 +401,13 @@ impl<'a, 'ctx> DeclarationChecker<'a, 'ctx> {
             _ => {}
         }
 
-        // The function is inside a block (if/while/for/etc.) — check strict mode
+        // The function is inside a block (if/while/for/etc.) — check strict mode.
+        // A module file is automatically strict, same as a class body; oracle-confirmed
+        // precedence when more than one reason applies: class > module > explicit strict.
         let in_class = self.is_inside_class(func_idx);
+        let in_module = !in_class && self.ctx.is_external_module_file();
         let in_strict = in_class
+            || in_module
             || self.ctx.compiler_options.always_strict
             || self.has_use_strict_directive(func_idx);
 
@@ -432,6 +437,14 @@ impl<'a, 'ctx> DeclarationChecker<'a, 'ctx> {
                 diagnostic_messages::FUNCTION_DECLARATIONS_ARE_NOT_ALLOWED_INSIDE_BLOCKS_IN_STRICT_MODE_WHEN_TARGETIN_2
                     .to_string(),
                 diagnostic_codes::FUNCTION_DECLARATIONS_ARE_NOT_ALLOWED_INSIDE_BLOCKS_IN_STRICT_MODE_WHEN_TARGETIN_2,
+            );
+        } else if in_module {
+            self.ctx.error(
+                pos,
+                len,
+                diagnostic_messages::FUNCTION_DECLARATIONS_ARE_NOT_ALLOWED_INSIDE_BLOCKS_IN_STRICT_MODE_WHEN_TARGETIN_3
+                    .to_string(),
+                diagnostic_codes::FUNCTION_DECLARATIONS_ARE_NOT_ALLOWED_INSIDE_BLOCKS_IN_STRICT_MODE_WHEN_TARGETIN_3,
             );
         } else {
             self.ctx.error(

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -789,6 +789,8 @@ mod ts1165_ambient_class_method_computed_name_tests;
 mod ts1168_method_overload_computed_name_tests;
 #[path = "tests/ts1170_computed_property_syntactic_form_tests.rs"]
 mod ts1170_computed_property_syntactic_form_tests;
+#[path = "tests/ts1250_ts1251_ts1252_strict_function_in_block_tests.rs"]
+mod ts1250_ts1251_ts1252_strict_function_in_block_tests;
 #[path = "tests/ts1318_abstract_accessor_implementation_tests.rs"]
 mod ts1318_abstract_accessor_implementation_tests;
 #[path = "tests/ts1361_ambient_computed_property_name_tests.rs"]

--- a/crates/tsz-checker/src/tests/ts1250_ts1251_ts1252_strict_function_in_block_tests.rs
+++ b/crates/tsz-checker/src/tests/ts1250_ts1251_ts1252_strict_function_in_block_tests.rs
@@ -1,0 +1,252 @@
+//! Regression tests for the TS1250/TS1251/TS1252 family — a function
+//! declaration nested inside a block (if/while/for/etc.) when targeting
+//! ES3/ES5 in strict mode.
+//!
+//! `tsc` picks one of three messages depending on *why* the enclosing code is
+//! strict, oracle-confirmed (`typescript@5.6.2`, since the pinned
+//! `typescript@7.0.2` native compiler has removed `--target es5` entirely and
+//! can no longer be invoked to observe this legacy family directly):
+//!
+//! - inside a class body -> TS1251 ("Class definitions are automatically in
+//!   strict mode.")
+//! - else inside an external module (has top-level `import`/`export`) ->
+//!   TS1252 ("Modules are automatically in strict mode.")
+//! - else (an explicit `"use strict"` directive, or `alwaysStrict`) -> TS1250
+//!
+//! Class beats module beats explicit directive when more than one reason
+//! applies (`export class C { m() { if (true) function f() {} } }` still
+//! reports TS1251, and a module file with its own `"use strict"` prologue
+//! still reports TS1252, not TS1250).
+//!
+//! `crates/tsz-checker/src/declarations/declarations.rs`'s
+//! `check_strict_mode_function_in_block` used to only distinguish class vs.
+//! not-class, so a module-hosted, non-class occurrence fell through to the
+//! generic TS1250 message instead of TS1252 — and, since module-ness was not
+//! itself treated as a strict-mode reason there, some module-hosted cases
+//! reported no diagnostic at all.
+
+use tsz_common::common::ScriptTarget;
+use tsz_common::options::checker::CheckerOptions;
+
+/// This whole family is target-gated: `tsc` only reports it when targeting
+/// ES3 or ES5 (downlevel `function` hoisting semantics differ from ES2015+
+/// block-scoped `function` declarations). Tests below target ES5 unless
+/// checking that gate itself.
+fn diag_codes(source: &str) -> Vec<u32> {
+    diag_codes_with_target(source, ScriptTarget::ES5)
+}
+
+fn diag_codes_with_target(source: &str, target: ScriptTarget) -> Vec<u32> {
+    crate::test_utils::check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            target,
+            ..CheckerOptions::default()
+        },
+    )
+    .into_iter()
+    .map(|d| d.code)
+    .collect()
+}
+
+/// `CheckerOptions::default()` sets `always_strict: true` (tsc's own default
+/// when not explicitly configured), which alone is a strict-mode reason. The
+/// sloppy-mode negative controls below need it off to isolate "no reason at
+/// all to be strict".
+fn diag_codes_not_always_strict(source: &str) -> Vec<u32> {
+    crate::test_utils::check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            target: ScriptTarget::ES5,
+            always_strict: false,
+            ..CheckerOptions::default()
+        },
+    )
+    .into_iter()
+    .map(|d| d.code)
+    .collect()
+}
+
+/// Plain script, explicit `"use strict"` prologue, no class, no module -> TS1250.
+#[test]
+fn ts1250_plain_script_with_use_strict_directive() {
+    let codes = diag_codes(
+        r#"
+"use strict";
+if (true) {
+    function f1() {}
+}
+"#,
+    );
+    assert!(codes.contains(&1250), "Expected TS1250. Got: {codes:?}");
+    assert!(
+        !codes.contains(&1251) && !codes.contains(&1252),
+        "Got: {codes:?}"
+    );
+}
+
+/// Function declaration in a block inside a class method -> TS1251 (class wins).
+#[test]
+fn ts1251_inside_class_method() {
+    let codes = diag_codes(
+        r#"
+class C {
+    m() {
+        if (true) {
+            function f2() {}
+        }
+    }
+}
+"#,
+    );
+    assert!(codes.contains(&1251), "Expected TS1251. Got: {codes:?}");
+    assert!(
+        !codes.contains(&1250) && !codes.contains(&1252),
+        "Got: {codes:?}"
+    );
+}
+
+/// Anti-hardcoding cover: renamed class/method/function names.
+#[test]
+fn ts1251_inside_class_method_renamed() {
+    let codes = diag_codes(
+        r#"
+class WrappedThing {
+    invoke() {
+        if (true) {
+            function innerHelper() {}
+        }
+    }
+}
+"#,
+    );
+    assert!(
+        codes.contains(&1251),
+        "Renamed variant: expected TS1251. Got: {codes:?}"
+    );
+}
+
+/// Module top-level (file has `export`), no class, no explicit directive -> TS1252.
+#[test]
+fn ts1252_inside_external_module_no_directive() {
+    let codes = diag_codes(
+        r#"
+export {};
+if (true) {
+    function f3() {}
+}
+"#,
+    );
+    assert!(codes.contains(&1252), "Expected TS1252. Got: {codes:?}");
+    assert!(
+        !codes.contains(&1250) && !codes.contains(&1251),
+        "Got: {codes:?}"
+    );
+}
+
+/// A module made external via `import` rather than `export` still gets TS1252.
+#[test]
+fn ts1252_inside_external_module_via_import() {
+    let codes = diag_codes(
+        r#"
+import "some-module";
+if (true) {
+    function f4() {}
+}
+"#,
+    );
+    assert!(codes.contains(&1252), "Expected TS1252. Got: {codes:?}");
+}
+
+/// Module *and* an explicit `"use strict"` prologue -> still TS1252, not TS1250:
+/// module-ness outranks the explicit directive as the stated reason.
+#[test]
+fn ts1252_module_outranks_explicit_use_strict_directive() {
+    let codes = diag_codes(
+        r#"
+export {};
+"use strict";
+if (true) {
+    function f5() {}
+}
+"#,
+    );
+    assert!(codes.contains(&1252), "Expected TS1252. Got: {codes:?}");
+    assert!(!codes.contains(&1250), "Got: {codes:?}");
+}
+
+/// Class *and* module (an exported class) -> TS1251: class outranks module.
+#[test]
+fn ts1251_class_outranks_module() {
+    let codes = diag_codes(
+        r#"
+export class C {
+    m() {
+        if (true) {
+            function f6() {}
+        }
+    }
+}
+"#,
+    );
+    assert!(codes.contains(&1251), "Expected TS1251. Got: {codes:?}");
+    assert!(!codes.contains(&1252), "Got: {codes:?}");
+}
+
+/// Negative control: a plain script (no class, no module, no directive, no
+/// `alwaysStrict`) is sloppy mode — a function declaration in a block is
+/// legal ES3/ES5 sloppy-mode behavior, no TS1250/1251/1252.
+#[test]
+fn no_diagnostic_in_sloppy_mode_script() {
+    let codes = diag_codes_not_always_strict(
+        r#"
+if (true) {
+    function f7() {}
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&1250) && !codes.contains(&1251) && !codes.contains(&1252),
+        "Sloppy-mode script should not report the strict-mode family. Got: {codes:?}"
+    );
+}
+
+/// Negative control: the whole family is gated on ES3/ES5; an otherwise
+/// identical strict-mode shape at ES2015+ reports nothing from this family.
+#[test]
+fn no_diagnostic_at_es2015_target() {
+    let codes = diag_codes_with_target(
+        r#"
+"use strict";
+if (true) {
+    function f9() {}
+}
+"#,
+        ScriptTarget::ES2015,
+    );
+    assert!(
+        !codes.contains(&1250) && !codes.contains(&1251) && !codes.contains(&1252),
+        "ES2015+ target should not report the strict-mode family. Got: {codes:?}"
+    );
+}
+
+/// Negative control: a namespace body is not itself strict and has no
+/// `import`/`export`, so a nested function-in-block stays legal.
+#[test]
+fn no_diagnostic_inside_plain_namespace() {
+    let codes = diag_codes_not_always_strict(
+        r#"
+namespace M {
+    if (true) {
+        function f8() {}
+    }
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&1250) && !codes.contains(&1251) && !codes.contains(&1252),
+        "Namespace alone should not induce strict mode. Got: {codes:?}"
+    );
+}


### PR DESCRIPTION
Picks up the `misc/strict-mode` slice of #16291's unwired-diagnostics enumeration.

## Structural rule

When a `function` declaration is nested inside a block (`if`/`while`/`for`/etc.) under an ES3/ES5 target, `tsc` reports one of three messages depending on *why* the surrounding code is strict, and picks between them with a fixed precedence when more than one reason applies: **class beats module beats an explicit `"use strict"` directive**.

- inside a class body → **TS1251** ("Class definitions are automatically in strict mode.")
- else inside an external module (top-level `import`/`export`) → **TS1252** ("Modules are automatically in strict mode.")
- else (an explicit `"use strict"` prologue, or `alwaysStrict`) → **TS1250**

tsz's `check_strict_mode_function_in_block` (`crates/tsz-checker/src/declarations/declarations.rs`) only distinguished class vs. not-class. A module-hosted, non-class occurrence therefore either fell through to the generic TS1250 message, or — since module-ness was not itself treated as a strict-mode reason at this site — reported **nothing at all** when there was no explicit directive and `alwaysStrict` was off. Fixed by adding an `in_module` check (reusing the existing `CheckerContext::is_external_module_file()`, the same predicate `is_strict_mode_for_node`/TS1101 already use) with the oracle-confirmed precedence: `in_class` first, then `in_module`, else the plain-strict fallback.

This whole family (TS1250/1251/1252) had **zero existing test coverage** before this PR — the diagnostics table entries existed, TS1250/1251 were wired, but nothing pinned the branching rule.

## Why the oracle is `typescript@5.6.2`, not the pinned `7.0.2`

The native `typescript@7.0.2` compiler (the repo's pinned oracle) has **removed `--target es5` entirely** (`error TS5108: Option 'target=ES5' has been removed`), so it can't observe this legacy family directly. This is stable, long-settled ES5 semantics unrelated to any 7.0.2 behavior change, so `typescript@5.6.2` (still `--target es5`-capable) was used to confirm the precedence rule. All 10 rows below were run against it.

## Adjacent-case matrix (oracle: `typescript@5.6.2`, `--target es5 --module commonjs`)

| shape | tsc | tsz (parent) | tsz (branch) |
| --- | --- | --- | --- |
| plain script, `"use strict"` | TS1250 | TS1250 | TS1250 |
| inside class method (no directive) | TS1251 | TS1251 | TS1251 |
| inside class method, renamed binders | TS1251 | TS1251 | TS1251 |
| module (`export {}`), no directive | TS1252 | *(silent)* | TS1252 |
| module via bare `import "x"`, no directive | TS1252 | *(silent)* | TS1252 |
| module + explicit `"use strict"` (module outranks directive) | TS1252 | TS1250 (wrong code) | TS1252 |
| exported class (class outranks module) | TS1251 | TS1251 | TS1251 |
| plain script, no directive, no `alwaysStrict` (sloppy mode) | clean | clean | clean |
| bare `namespace` body, no directive (not itself strict) | clean | clean | clean |
| same shapes at ES2015+ target (family is target-gated) | clean | clean | clean |

## Verification

- New file `crates/tsz-checker/src/tests/ts1250_ts1251_ts1252_strict_function_in_block_tests.rs`, registered in `test_module_registry.rs`. `cargo test -p tsz-checker --lib ts1250` — **10 passed, 0 failed**.
- **Non-vacuity**: reverted only `declarations.rs` (tests left in place) — 3 of the 3 new TS1252 rows fail without the fix, all for the expected reason (missing/wrong code); the other 7 pass either way (pre-existing behavior, negative controls, and the target gate).
- `cargo clippy -p tsz-checker --lib --all-targets -- -D warnings` clean. `python3 scripts/arch/arch_guard.py` passes. `cargo fmt` applied (no-op).
- `cargo test -p tsz-checker --lib` (full suite, all ~9200 tests) was started but did not finish within this session's window — the pre-commit hook's own gate (clippy + arch-guard, the same fast subset CI's `merge_group` lane runs) passed. Will post the full-suite result as a follow-up comment once it completes.
- Not run: conformance / emit / fourslash. This change touches one function-in-block grammar check gated on a target (ES3/ES5) that the committed corpus's default project rows do not use; no solver/emitter surface touched.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_012mjy7jZgGN9NdwEssEuCPt)_