### PR TITLE
fix(checker): TS2741 carries tsc's `'x' is declared here.` pointer

### DIFF
--- a/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
+++ b/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
@@ -1,0 +1,271 @@
+use crate::diagnostics::{
+    Diagnostic, DiagnosticRelatedInformation, diagnostic_codes, diagnostic_messages, format_message,
+};
+use crate::state::CheckerState;
+use tsz_parser::parser::{NodeArena, NodeIndex};
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    /// Build tsc's `'{0}' is declared here.` (TS2728) pointer for the single
+    /// unmatched property of a `TS2741` failure.
+    ///
+    /// tsc's `reportUnmatchedProperty` attaches this related entry only on the
+    /// one-missing-property form: the multi-property forms (`TS2739`/`TS2740`)
+    /// carry no pointer at all. The anchor is the *name node* of the property's
+    /// own declaration, in whichever file declares it — so a property declared
+    /// in an imported module points across files.
+    ///
+    /// `owner_candidates` are the target types the caller already has in hand
+    /// (the relation target and the evaluated member target); the first one
+    /// that resolves to a declaring symbol owning a member with this name wins.
+    /// When no candidate resolves — an anonymous object type with no symbol,
+    /// for instance — no pointer is produced, which leaves output exactly as it
+    /// was rather than guessing at a declaration.
+    pub(super) fn missing_property_declared_here_related(
+        &mut self,
+        owner_candidates: &[TypeId],
+        property_name: tsz_common::interner::Atom,
+        property_display: &str,
+    ) -> Option<DiagnosticRelatedInformation> {
+        let property = self.ctx.types.resolve_atom(property_name);
+        owner_candidates.iter().find_map(|&owner| {
+            self.declared_here_related_for_owner(owner, &property, property_display)
+        })
+    }
+
+    /// Resolve `owner` to its declaring symbol, find the member declaration
+    /// with this name inside that symbol's own declaration, and anchor there.
+    fn declared_here_related_for_owner(
+        &mut self,
+        owner: TypeId,
+        property: &str,
+        property_display: &str,
+    ) -> Option<DiagnosticRelatedInformation> {
+        let owner_symbol = self.ctx.resolve_type_to_symbol_id(owner).or_else(|| {
+            crate::query_boundaries::common::type_shape_symbol(self.ctx.types, owner)
+        })?;
+        let symbol = self.ctx.binder.get_symbol(owner_symbol)?;
+        let locations: Vec<tsz_binder::StableLocation> =
+            std::iter::once(symbol.stable_value_declaration)
+                .chain(symbol.stable_declarations.iter().copied())
+                .filter(tsz_binder::StableLocation::is_known)
+                .collect();
+        let member_locations: Vec<tsz_binder::StableLocation> = symbol
+            .members
+            .as_ref()
+            .and_then(|members| members.get(property))
+            .and_then(|member_id| self.ctx.binder.get_symbol(member_id))
+            .map(|member| {
+                std::iter::once(member.stable_value_declaration)
+                    .chain(member.stable_declarations.iter().copied())
+                    .filter(tsz_binder::StableLocation::is_known)
+                    .collect()
+            })
+            .unwrap_or_default();
+        for location in locations {
+            let Some((start, length, file)) = self.declared_here_anchor(location, property) else {
+                continue;
+            };
+            return Some(Diagnostic::related_message(
+                diagnostic_codes::IS_DECLARED_HERE,
+                file.unwrap_or_else(|| self.ctx.file_name.clone()),
+                start,
+                length,
+                format_message(diagnostic_messages::IS_DECLARED_HERE, &[property_display]),
+            ));
+        }
+        for location in member_locations {
+            let Some((start, length, file)) = self.declared_here_member_anchor(location, property)
+            else {
+                continue;
+            };
+            return Some(Diagnostic::related_message(
+                diagnostic_codes::IS_DECLARED_HERE,
+                file.unwrap_or_else(|| self.ctx.file_name.clone()),
+                start,
+                length,
+                format_message(diagnostic_messages::IS_DECLARED_HERE, &[property_display]),
+            ));
+        }
+        None
+    }
+
+    /// `(start, length, file)` for a member symbol's own declaration, used when
+    /// the owner's declaration does not carry a member list the walk above can
+    /// read (a class records its members on the symbol instead).
+    ///
+    /// A `StableLocation` resolves by `(pos, end)` against whichever arena the
+    /// stamped file index names, and falls back to the current arena when the
+    /// location carries no file index — so the node it lands on is only trusted
+    /// here when it really is a member declaration whose written name is the
+    /// property being reported. Anything else declines rather than anchoring a
+    /// pointer at an unrelated span.
+    fn declared_here_member_anchor(
+        &self,
+        location: tsz_binder::StableLocation,
+        property: &str,
+    ) -> Option<(u32, u32, Option<String>)> {
+        let (decl_idx, arena) = self.ctx.node_at_stable_location(location)?;
+        let name_idx = Self::member_name_node(arena, decl_idx)?;
+        if crate::types_domain::queries::core::get_literal_property_name(arena, name_idx)
+            .is_none_or(|name| name != property)
+        {
+            return None;
+        }
+        let anchor_idx = Self::member_anchor_for_kind(arena, decl_idx, name_idx);
+        let (start, length) = Self::anchor_span(arena, anchor_idx)?;
+        Some((start, length, Self::arena_file_name(arena, anchor_idx)))
+    }
+
+    /// `(start, length, file)` of the pointer anchor for `property` inside the
+    /// declaration at `location`, in that declaration's own arena.
+    fn declared_here_anchor(
+        &self,
+        location: tsz_binder::StableLocation,
+        property: &str,
+    ) -> Option<(u32, u32, Option<String>)> {
+        let (decl_idx, arena) = self.ctx.node_at_stable_location(location)?;
+        let members = Self::declaration_member_list(arena, decl_idx)?;
+        let anchor_idx = Self::member_anchor_node(arena, &members, property)?;
+        let (start, length) = Self::anchor_span(arena, anchor_idx)?;
+        Some((start, length, Self::arena_file_name(arena, anchor_idx)))
+    }
+
+    /// The member list a type's declaration owns: interfaces and classes carry
+    /// theirs directly, a type alias carries its body's when that body is a
+    /// type literal.
+    fn declaration_member_list(
+        arena: &NodeArena,
+        decl_idx: NodeIndex,
+    ) -> Option<tsz_parser::parser::NodeList> {
+        use tsz_parser::parser::syntax_kind_ext;
+
+        let node = arena.get(decl_idx)?;
+        if node.kind == syntax_kind_ext::INTERFACE_DECLARATION {
+            return Some(arena.get_interface(node)?.members.clone());
+        }
+        if node.kind == syntax_kind_ext::CLASS_DECLARATION
+            || node.kind == syntax_kind_ext::CLASS_EXPRESSION
+        {
+            return Some(arena.get_class(node)?.members.clone());
+        }
+        if node.kind == syntax_kind_ext::TYPE_LITERAL {
+            return Some(arena.get_type_literal(node)?.members.clone());
+        }
+        if node.kind == syntax_kind_ext::TYPE_ALIAS_DECLARATION {
+            let body_idx = arena.get_type_alias(node)?.type_node;
+            if body_idx.is_some() && body_idx != decl_idx {
+                return Self::declaration_member_list(arena, body_idx);
+            }
+        }
+        None
+    }
+
+    /// The member in `members` named `property`, resolved to the node tsc
+    /// underlines for it.
+    fn member_anchor_node(
+        arena: &NodeArena,
+        members: &tsz_parser::parser::NodeList,
+        property: &str,
+    ) -> Option<NodeIndex> {
+        for &member_idx in &members.nodes {
+            let Some(name_idx) = Self::member_name_node(arena, member_idx) else {
+                continue;
+            };
+            let Some(name) =
+                crate::types_domain::queries::core::get_literal_property_name(arena, name_idx)
+            else {
+                continue;
+            };
+            if name != property {
+                continue;
+            }
+            return Some(Self::member_anchor_for_kind(arena, member_idx, name_idx));
+        }
+        None
+    }
+
+    /// The name node of a property-like member declaration.
+    fn member_name_node(arena: &NodeArena, member_idx: NodeIndex) -> Option<NodeIndex> {
+        use tsz_parser::parser::syntax_kind_ext;
+
+        let node = arena.get(member_idx)?;
+        if node.kind != syntax_kind_ext::PROPERTY_SIGNATURE
+            && node.kind != syntax_kind_ext::PROPERTY_DECLARATION
+            && node.kind != syntax_kind_ext::METHOD_SIGNATURE
+            && node.kind != syntax_kind_ext::METHOD_DECLARATION
+        {
+            return None;
+        }
+        let name = arena.get_signature(node)?.name;
+        name.is_some().then_some(name)
+    }
+
+    /// Span of an anchor node, narrowed to the token as written.
+    ///
+    /// A node's `end` runs to the start of the next token, so an identifier
+    /// name node measured as `end - pos` swallows the `:` that follows it. The
+    /// same narrowing `normalized_anchor_span` performs for the current arena
+    /// is done here against the declaration's own arena: an identifier is its
+    /// escaped text, a string-literal name is its text plus the two quotes it
+    /// was written with, and anything else keeps the node span.
+    fn anchor_span(arena: &NodeArena, anchor_idx: NodeIndex) -> Option<(u32, u32)> {
+        use tsz_scanner::SyntaxKind;
+
+        let node = arena.get(anchor_idx)?;
+        let start = node.pos;
+        if (node.kind == SyntaxKind::Identifier as u16
+            || node.kind == SyntaxKind::PrivateIdentifier as u16)
+            && let Some(identifier) = arena.get_identifier(node)
+        {
+            return Some((start, identifier.escaped_text.len() as u32));
+        }
+        if node.kind == SyntaxKind::StringLiteral as u16
+            && let Some(name) =
+                crate::types_domain::queries::core::get_literal_property_name(arena, anchor_idx)
+        {
+            return Some((start, name.len() as u32 + 2));
+        }
+        Some((start, node.end.saturating_sub(start)))
+    }
+
+    /// The node tsc underlines for a member: a property member points at its
+    /// *name* (`y` in `y: number;`), a method member at the whole member
+    /// (`run(): void;`).
+    fn member_anchor_for_kind(
+        arena: &NodeArena,
+        member_idx: NodeIndex,
+        name_idx: NodeIndex,
+    ) -> NodeIndex {
+        use tsz_parser::parser::syntax_kind_ext;
+
+        match arena.get(member_idx).map(|node| node.kind) {
+            Some(kind)
+                if kind == syntax_kind_ext::METHOD_SIGNATURE
+                    || kind == syntax_kind_ext::METHOD_DECLARATION =>
+            {
+                member_idx
+            }
+            _ => name_idx,
+        }
+    }
+
+    /// File name owning `idx` in `arena`, walked from the node itself so a
+    /// cross-file declaration reports its own file rather than the file the
+    /// primary diagnostic lives in.
+    fn arena_file_name(arena: &NodeArena, idx: NodeIndex) -> Option<String> {
+        let mut current = idx;
+        while current.is_some() {
+            let node = arena.get(current)?;
+            if let Some(source_file) = arena.get_source_file(node) {
+                return Some(source_file.file_name.clone());
+            }
+            let ext = arena.get_extended(current)?;
+            if ext.parent.is_none() {
+                break;
+            }
+            current = ext.parent;
+        }
+        None
+    }
+}

--- a/crates/tsz-checker/src/error_reporter/mod.rs
+++ b/crates/tsz-checker/src/error_reporter/mod.rs
@@ -39,6 +39,7 @@ mod generic_display_helpers;
 mod generics;
 mod literal_alias_display;
 mod literal_alias_rewrites;
+mod missing_property_declared_here;
 mod name_resolution;
 mod noinfer_diagnostic_display;
 mod operator_errors;

--- a/crates/tsz-checker/src/error_reporter/render_failure_missing_property.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure_missing_property.rs
@@ -612,13 +612,27 @@ impl<'a> CheckerState<'a> {
             diagnostic_messages::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
             &[&prop_name_display, &src_str, &tgt_str_qualified],
         );
-        Diagnostic::error(
+        let mut diagnostic = Diagnostic::error(
             file_name,
             start,
             length,
             message,
             diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
-        )
+        );
+        // tsc's `reportUnmatchedProperty` pairs the one-missing-property form
+        // with a TS2728 pointer at that property's own declaration. The
+        // multi-property forms (TS2739/TS2740) above return before this point
+        // and carry no pointer, matching tsc.
+        if depth == 0
+            && let Some(related) = self.missing_property_declared_here_related(
+                &[target, target_type],
+                property_name,
+                &prop_name_display,
+            )
+        {
+            diagnostic.related_information.push(related);
+        }
+        diagnostic
     }
 
     /// Target display for the primitive-source TS2322 downgrade of a

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -555,6 +555,8 @@ mod member_name_source_quote_fidelity_tests;
 mod merged_interface_constraint_relation_routing_arch_tests;
 #[path = "tests/method_return_type_elaboration_tests.rs"]
 mod method_return_type_elaboration_tests;
+#[path = "tests/missing_property_declared_here_tests.rs"]
+mod missing_property_declared_here_tests;
 #[path = "tests/module_scoped_var_shadows_lib_global_ts2300_tests.rs"]
 mod module_scoped_var_shadows_lib_global_ts2300_tests;
 #[path = "tests/multi_overload_infer_capture_tests.rs"]

--- a/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
+++ b/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
@@ -1,0 +1,184 @@
+//! Regression tests for the `TS2728` `'x' is declared here.` pointer that tsc
+//! pairs with the single-missing-property form of `TS2741`.
+//!
+//! Structural rule (pinned against `typescript@7.0.2`, the conformance pin):
+//! when exactly one required property of the target is unmatched, tsc's
+//! `reportUnmatchedProperty` associates a related-information entry at the
+//! *name node* of that property's own declaration, in the file that declares
+//! it. When more than one property is unmatched the diagnostic is TS2739 /
+//! TS2740 and tsc attaches no pointer at all.
+//!
+//! Two shapes are deliberately *not* covered yet and produce no pointer at all
+//! (unchanged output, never a wrong anchor): a class-typed target, whose
+//! members the owner declaration walk below does not reach, and a target whose
+//! declaration lives in another file, whose `StableLocation` does not resolve
+//! to the declaring arena from here. Both are written up as the next slice.
+//!
+//! tsz builds the pointer in the assignability renderer
+//! (`error_reporter/missing_property_declared_here.rs`), reached from the one
+//! TS2741 construction in `render_missing_property`.
+
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::check_source_diagnostics;
+use tsz_common::diagnostics::diagnostic_codes;
+
+const TS2741: u32 = diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE;
+const TS2739: u32 = diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE;
+const TS2728: u32 = diagnostic_codes::IS_DECLARED_HERE;
+
+fn only(diags: &[Diagnostic], code: u32) -> Diagnostic {
+    let matching: Vec<_> = diags.iter().filter(|d| d.code == code).collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected exactly one TS{code}; got {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+    matching[0].clone()
+}
+
+/// The pointer's `(file, start, length)` plus its message, so each case can
+/// assert the anchor lands on the declared name and nothing wider.
+fn declared_here(diagnostic: &Diagnostic) -> (String, u32, u32, String) {
+    let pointers: Vec<_> = diagnostic
+        .related_information
+        .iter()
+        .filter(|info| info.code == TS2728)
+        .collect();
+    assert_eq!(
+        pointers.len(),
+        1,
+        "expected exactly one TS2728 pointer; got {:?}",
+        diagnostic
+            .related_information
+            .iter()
+            .map(|info| (info.code, info.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+    (
+        pointers[0].file.clone(),
+        pointers[0].start,
+        pointers[0].length,
+        pointers[0].message_text.clone(),
+    )
+}
+
+fn span_text(source: &str, start: u32, length: u32) -> &str {
+    &source[start as usize..(start + length) as usize]
+}
+
+#[test]
+fn single_missing_interface_property_points_at_its_declaration() {
+    let source = "interface Point { x: number; y: number; }\nconst p: Point = { x: 1 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (file, start, length, message) = declared_here(&diagnostic);
+    assert_eq!(message, "'y' is declared here.");
+    assert_eq!(span_text(source, start, length), "y");
+    assert_eq!(file, "test.ts");
+}
+
+/// Binder names must not matter: the same shape under different identifiers
+/// resolves through the target's own member table, not a name match.
+#[test]
+fn renamed_binders_point_at_the_renamed_declaration() {
+    let source =
+        "interface Coord { alpha: number; omega: number; }\nconst c: Coord = { alpha: 1 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, message) = declared_here(&diagnostic);
+    assert_eq!(message, "'omega' is declared here.");
+    assert_eq!(span_text(source, start, length), "omega");
+}
+
+/// A quoted property name anchors on the name node as written, quotes included
+/// — the anchor is the declaration's name node, not a re-rendered identifier.
+#[test]
+fn quoted_property_name_anchors_on_the_written_name_node() {
+    let source = "interface Q { one: number; \"two-part\": number; }\nconst q: Q = { one: 1 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, message) = declared_here(&diagnostic);
+    // tsc renders a string-literal property name with its quotes in BOTH the
+    // primary and the pointer (`'"two-part"' is declared here.`); tsz renders
+    // it bare in the primary today, and the pointer reuses that same display so
+    // the two can never disagree with each other. The quoted-name display gap
+    // is a separate, pre-existing divergence.
+    assert_eq!(message, "'two-part' is declared here.");
+    assert!(
+        diagnostic
+            .message_text
+            .contains("Property 'two-part' is missing"),
+        "pointer must reuse the primary's property display: {}",
+        diagnostic.message_text
+    );
+    assert_eq!(span_text(source, start, length), "\"two-part\"");
+}
+
+#[test]
+fn missing_method_member_points_at_the_method_name() {
+    let source =
+        "interface HasRun { keep: number; run(): void; }\nconst h: HasRun = { keep: 1 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, message) = declared_here(&diagnostic);
+    assert_eq!(message, "'run' is declared here.");
+    assert_eq!(span_text(source, start, length), "run(): void;");
+}
+
+/// Negative half of the rule: two or more unmatched properties is TS2739, and
+/// tsc attaches no pointer there.
+#[test]
+fn multiple_missing_properties_carry_no_pointer() {
+    let source = "interface P3 { x: number; y: number; z: number; }\nconst q: P3 = { x: 1 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2739);
+    assert!(
+        diagnostic
+            .related_information
+            .iter()
+            .all(|info| info.code != TS2728),
+        "TS2739 must not carry a declared-here pointer: {:?}",
+        diagnostic
+            .related_information
+            .iter()
+            .map(|info| (info.code, info.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Optional members are not required, so no diagnostic and no pointer.
+#[test]
+fn optional_missing_property_produces_no_diagnostic() {
+    let source = "interface Opt { x: number; y?: number; }\nconst o: Opt = { x: 1 };\n";
+    let diags = check_source_diagnostics(source);
+    assert!(
+        diags.iter().all(|d| d.code != TS2741),
+        "optional property must not report TS2741: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// An alias in front of the interface does not change the owner the pointer
+/// resolves through.
+#[test]
+fn aliased_target_still_points_at_the_underlying_declaration() {
+    let source = "interface Base { keep: number; gone: number; }\ntype Alias = Base;\nconst a: Alias = { keep: 1 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, message) = declared_here(&diagnostic);
+    assert_eq!(message, "'gone' is declared here.");
+    assert_eq!(span_text(source, start, length), "gone");
+}
+
+/// A generic interface instantiated at a concrete argument points at the
+/// declaration in the generic's own body.
+#[test]
+fn generic_target_points_at_the_declaration_in_the_generic_body() {
+    let source =
+        "interface Box<T> { held: T; label: string; }\nconst b: Box<number> = { held: 1 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, message) = declared_here(&diagnostic);
+    assert_eq!(message, "'label' is declared here.");
+    assert_eq!(span_text(source, start, length), "label");
+}


### PR DESCRIPTION
**Structural rule.** When exactly one required property of the target is unmatched, `tsc`'s `reportUnmatchedProperty` associates a `TS2728` related entry at the *name node* of that property's own declaration; when two or more are unmatched the diagnostic is `TS2739`/`TS2740` and `tsc` attaches no pointer at all. tsz does this through the checker's assignability renderer (`error_reporter/missing_property_declared_here.rs`), reached from the single `TS2741` construction in `render_missing_property`.

`IS_DECLARED_HERE` (TS2728) previously had exactly one construction site in the whole checker — `checkers/jsx/props/validation.rs:1412`, the JSX props path — so every non-JSX `TS2741` lost the pointer entirely. This is the checker-layer half of #16316 that Aventurine's NOTE carved out ("TS2741 does not build its pointer at all — do not read that as a drop"); it is missing data, not the CLI render-shape defect #16318 fixes.

### Anchors, pinned against the oracle

`typescript@7.0.2` (the pin in `scripts/conformance/typescript-versions.json`), `--noEmit --strict --pretty --target es2022 --lib es2022`:

| target shape | primary | pointer message | pointer underlines |
| --- | --- | --- | --- |
| `interface Point { x: number; y: number }` | TS2741 | `'y' is declared here.` | `y` |
| `type T = { m: string; n: string }` | TS2741 | `'n' is declared here.` | `n` |
| `interface HasRun { keep: number; run(): void }` | TS2741 | `'run' is declared here.` | `run(): void;` |
| `interface P3 { x; y; z }` (two missing) | TS2739 | — | — |

So a property member anchors on its **name**, a method member on the **whole member** — that asymmetry is `tsc`'s, and both shapes are asserted by span text in the tests rather than by offset.

The span is narrowed the way `normalized_anchor_span` already narrows for the current arena (a node's `end` runs to the next token, so a bare `end - pos` on a name node swallows the following `:`), except performed against the declaration's own arena so the pointer can name another file.

### What decides the anchor

The target type resolves to its declaring symbol, the symbol's declaration is walked for the member list it owns (interface, class body, type-literal alias body — recursing through the alias), and the member whose **written name** matches the reported property supplies the anchor. No identifier, alias, or file-name literal drives any branch; the property name is compared against the declaration's own name node, which is the same discriminator `tsc` uses. A second route reads the member symbol's own declaration for owners that record members on the symbol, and it declines unless the node it lands on really is a member declaration whose written name is the property being reported — a `StableLocation` resolves by `(pos, end)` and falls back to the current arena when unstamped, so an unvalidated anchor lands on an unrelated span (observed, and the reason for the guard).

### Deliberately not covered yet

Two shapes produce **no** entry — unchanged output, never a wrong anchor:

- **class-typed target** (`class C { a = 0; b = 0 }`, `const c: C = { a: 1 }`) — the owner walk does not reach a class's members from the resolved symbol here;
- **cross-file declaration** — the declaring `StableLocation` does not resolve to the declaring arena from this call site (the unvalidated version anchored 3 bytes into the wrong file, which is what the guard now rejects).

Both are the natural next slice and are written up on #16316 with this evidence rather than half-landed here.

Also noted, separate and pre-existing: `tsc` renders a string-literal property name **with its quotes** in both the primary and the pointer (`Property '"two-part"' is missing…` / `'"two-part"' is declared here.`); tsz renders it bare in the primary. The pointer reuses the primary's own display string, so the two can never disagree with each other — a test pins that coupling.

## Goal
Goal: hold

## Verification
- Oracle: `typescript@7.0.2`, `--noEmit --strict --pretty --target es2022 --lib es2022`, on eight witnesses (interface, renamed binders, class, type-literal alias, generic instantiation, method member, quoted name, two-missing, cross-file). Every expected string and span in the new tests is transcribed from those runs.
- `cargo test -p tsz-checker --lib missing_property_declared_here` — **8 passed, 0 failed** (new file, adjacent-case matrix: interface / renamed binders / alias / generic / method / quoted name, plus the two negatives — TS2739 carries no pointer, an optional member reports nothing).
- `cargo test -p tsz-checker --lib` (full lib) — **9275 passed, 1 failed** at the time of writing, with the 5 known long-tail tests still running and no summary line yet (`class_static_init_self_new_tests::three_class_hierarchy_with_instance_field_aliases_and_static_create`, `contextual_return_wrapper_tests::wrapped_this_return_annotations_contextualize_generic_factories`, the two `global_augmentation_computed_key_tests` rows, `ts2589_tests::recursive_conditional_alias_omitted_default_transform_emits_definition_ts2589` — the same five the board records as the long tail, none on this path). The one failure is `ts2303_tests::recursive_export_assignment_self_import_reports_ts2303`, baselined at `scripts/ci/known-failures.txt:127` and unrelated. No other test moved.
- `cargo clippy -p tsz-checker --lib --all-targets` clean; `cargo fmt --all` applied; pre-commit arch guard passed.
- Not run: conformance / emit / fourslash. This change only *adds* `related_information` to an existing `TS2741`; the conformance fingerprint compares primary codes and the emit gate compares JS/DTS bytes, neither of which observes related entries. No primary code, message, or span changes — the TS2739/TS2740 branches return before this point and are untouched.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Citrine