### PR TITLE
fix(checker): TS1309 for top-level await in a CommonJS-format file

### DIFF
--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -55,6 +55,7 @@ mod file_format_lookup;
 pub(crate) use file_format_lookup::{lookup_file_is_esm_in_map, lookup_is_external_module_in_map};
 mod import_alias_resolution;
 mod import_conflicts;
+mod module_format;
 mod parse_health;
 pub use parse_health::ParseHealth;
 mod import_assert_file_scan;

--- a/crates/tsz-checker/src/context/module_format.rs
+++ b/crates/tsz-checker/src/context/module_format.rs
@@ -1,0 +1,36 @@
+//! Per-file CommonJS/ESM output format for the current file.
+//!
+//! Under the Node module kinds (`node16`, `node18`, `node20`, `nodenext`)
+//! `tsc` decides several grammar questions per *file* rather than per
+//! program: the file's implied format — from its extension, or from the
+//! nearest `package.json`'s `"type"` field when the extension is ambiguous —
+//! selects the diagnostic. `import.meta` (TS1470) and top-level `await`
+//! (TS1309) both ask this same question, so the predicate lives here rather
+//! than being restated at each site.
+
+use super::CheckerContext;
+
+impl CheckerContext<'_> {
+    /// Whether the current file builds into `CommonJS` output.
+    ///
+    /// `.cts`/`.cjs` force `CommonJS` and `.mts`/`.mjs` force ESM regardless of
+    /// any `package.json`; an ambiguous `.ts`/`.js` extension defers to the
+    /// driver-resolved format (`file_is_esm`), which mirrors `tsc`'s
+    /// `impliedNodeFormat`. An unresolved format (`file_is_esm == None`, the
+    /// single-file case with no project context) is not treated as `CommonJS`:
+    /// `tsc` only reaches the `CommonJS` arm when the program actually
+    /// resolved the file to that format.
+    ///
+    /// Callers are responsible for checking that the module kind is a Node
+    /// one — this answers the format question alone.
+    pub(crate) fn current_file_builds_to_commonjs(&self) -> bool {
+        let file_name = &self.file_name;
+        if file_name.ends_with(".cts") || file_name.ends_with(".cjs") {
+            return true;
+        }
+        if file_name.ends_with(".mts") || file_name.ends_with(".mjs") {
+            return false;
+        }
+        self.file_is_esm == Some(false)
+    }
+}

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -793,6 +793,8 @@ mod ts1168_method_overload_computed_name_tests;
 mod ts1170_computed_property_syntactic_form_tests;
 #[path = "tests/ts1250_ts1251_ts1252_strict_function_in_block_tests.rs"]
 mod ts1250_ts1251_ts1252_strict_function_in_block_tests;
+#[path = "tests/ts1309_top_level_await_commonjs_file_tests.rs"]
+mod ts1309_top_level_await_commonjs_file_tests;
 #[path = "tests/ts1318_abstract_accessor_implementation_tests.rs"]
 mod ts1318_abstract_accessor_implementation_tests;
 #[path = "tests/ts1361_ambient_computed_property_name_tests.rs"]

--- a/crates/tsz-checker/src/tests/ts1309_top_level_await_commonjs_file_tests.rs
+++ b/crates/tsz-checker/src/tests/ts1309_top_level_await_commonjs_file_tests.rs
@@ -1,0 +1,410 @@
+//! TS1309 (`The current file is a CommonJS module and cannot use 'await' at
+//! the top level.`) — the per-file arm of `tsc`'s
+//! `checkGrammarAwaitOrAwaitUsing` module switch.
+//!
+//! Under a Node module kind (`node16`/`node18`/`node20`/`nodenext`) `tsc`
+//! decides the top-level-`await` question per *file*, from the file's implied
+//! format, not per program:
+//!
+//! * `CommonJS`-format file (a `.cts`/`.cjs` extension, or an ambiguous
+//!   `.ts`/`.js` whose nearest `package.json` has no `"type": "module"`) —
+//!   TS1309, at every target, and the module/target family (TS1378 for
+//!   `await`, TS1432 for `for await`, TS2854 for `await using`) does not also
+//!   fire.
+//! * ESM-format file — no TS1309; the ordinary module + target requirement
+//!   applies, so a target below ES2017 still answers TS1378.
+//!
+//! The "…but this file has no imports or exports" family (TS1375/TS1431/
+//! TS2853) is unreachable under a Node module kind in either direction: an
+//! ESM-format file is a module even with no imports or exports, and a
+//! `CommonJS`-format one answers TS1309 instead.
+//!
+//! Every expectation below is pinned against a live `typescript@7.0.2` run
+//! (`--noEmit --strict --lib esnext`, `--module node16 --moduleResolution
+//! node16` unless the row says otherwise), not recalled. The fixtures used a
+//! two-package layout — one `package.json` with no `"type"` field, one with
+//! `"type": "module"` — to drive the ambiguous-extension rows.
+
+use crate::test_utils::check_source_with_file_is_esm;
+use tsz_common::checker_options::CheckerOptions;
+use tsz_common::common::{ModuleKind, ScriptTarget};
+
+/// Check `source` as `file_name` under `module`/`target`, with the driver's
+/// per-file format classification set to `file_is_esm`, and return the
+/// diagnostic codes.
+fn codes(
+    source: &str,
+    file_name: &str,
+    module: ModuleKind,
+    target: ScriptTarget,
+    file_is_esm: Option<bool>,
+) -> Vec<u32> {
+    let options = CheckerOptions {
+        module,
+        target,
+        ..CheckerOptions::default()
+    };
+    check_source_with_file_is_esm(source, file_name, options, file_is_esm)
+        .iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+/// The common case: a Node module kind and a `CommonJS`-format file.
+fn node16_cjs_codes(source: &str, file_name: &str) -> Vec<u32> {
+    codes(
+        source,
+        file_name,
+        ModuleKind::Node16,
+        ScriptTarget::ES2022,
+        Some(false),
+    )
+}
+
+// --- `await` expression ---
+
+/// oracle: `m/cjs/a.ts(2,1): error TS1309` under `--module node16`. An
+/// ambiguous `.ts` extension in a package without `"type": "module"`.
+#[test]
+fn top_level_await_in_commonjs_ts_file_reports_ts1309() {
+    let source = "export {};\nawait 1;";
+    let diags = node16_cjs_codes(source, "a.ts");
+    assert!(
+        diags.contains(&1309),
+        "a CommonJS-format file under node16 must report TS1309; got {diags:?}"
+    );
+    assert!(
+        !diags.contains(&1378),
+        "TS1309 replaces the module/target family, it does not accompany it; got {diags:?}"
+    );
+}
+
+/// The unambiguous extension: `.cts` is `CommonJS` whatever the surrounding
+/// `package.json` says, so the format lookup must not be consulted.
+/// oracle: `nomod.cts(1,1): error TS1309`.
+#[test]
+fn top_level_await_in_cts_file_reports_ts1309_without_format_lookup() {
+    let source = "await 1;";
+    let diags = codes(
+        source,
+        "nomod.cts",
+        ModuleKind::Node16,
+        ScriptTarget::ES2022,
+        None,
+    );
+    assert!(
+        diags.contains(&1309),
+        "a `.cts` file under node16 must report TS1309; got {diags:?}"
+    );
+}
+
+/// The same `.cts` file has no imports or exports, and `tsc` still does not
+/// add TS1375 — under a Node module kind the "no imports or exports" family
+/// is unreachable. oracle: TS1309 alone.
+#[test]
+fn top_level_await_in_cts_file_does_not_also_report_ts1375() {
+    let source = "await 1;";
+    let diags = codes(
+        source,
+        "nomod.cts",
+        ModuleKind::Node16,
+        ScriptTarget::ES2022,
+        None,
+    );
+    assert!(
+        !diags.contains(&1375),
+        "TS1375 must not accompany TS1309; got {diags:?}"
+    );
+}
+
+/// The ambiguous-extension, no-imports-or-exports row: `plain.ts` in a
+/// CommonJS package. oracle: TS1309 alone — again no TS1375.
+#[test]
+fn top_level_await_in_commonjs_script_reports_only_ts1309() {
+    let source = "await 1;";
+    let diags = node16_cjs_codes(source, "plain.ts");
+    assert!(diags.contains(&1309), "expected TS1309; got {diags:?}");
+    assert!(
+        !diags.contains(&1375) && !diags.contains(&1378),
+        "TS1309 is the whole answer for this row; got {diags:?}"
+    );
+}
+
+/// Anti-hardcoding control: nothing about the decision may depend on the
+/// awaited expression or on the binder names around it.
+#[test]
+fn top_level_await_ts1309_is_independent_of_awaited_expression_and_names() {
+    let source = "export const someBinding = 1;\ndeclare const producer: { readonly job: number };\nawait producer.job;";
+    let diags = node16_cjs_codes(source, "renamed-module.cts");
+    assert!(
+        diags.contains(&1309),
+        "the TS1309 decision is per file format, not per expression; got {diags:?}"
+    );
+}
+
+// --- the ESM side of the same switch ---
+
+/// oracle: `esm.mts` under node16 is clean — an ESM-format file may host
+/// top-level `await`.
+#[test]
+fn top_level_await_in_mts_file_is_clean() {
+    let source = "export {};\nawait 1;";
+    let diags = codes(
+        source,
+        "esm.mts",
+        ModuleKind::Node16,
+        ScriptTarget::ES2022,
+        None,
+    );
+    assert!(
+        !diags.contains(&1309) && !diags.contains(&1378) && !diags.contains(&1375),
+        "an ESM-format file under node16 must be clean; got {diags:?}"
+    );
+}
+
+/// The ambiguous extension resolved the other way: a `.ts` file in a package
+/// with `"type": "module"`. oracle: `m/esmpkg/a.ts` is clean.
+#[test]
+fn top_level_await_in_esm_resolved_ts_file_is_clean() {
+    let source = "export {};\nawait 1;";
+    let diags = codes(
+        source,
+        "a.ts",
+        ModuleKind::Node16,
+        ScriptTarget::ES2022,
+        Some(true),
+    );
+    assert!(
+        !diags.contains(&1309),
+        "an ESM-resolved file must not report TS1309; got {diags:?}"
+    );
+}
+
+/// An ESM-format file with no imports or exports is still a module under a
+/// Node module kind — `tsc` does not report TS1375 for it.
+/// oracle: `plainesm.mts` under node16 is clean.
+#[test]
+fn top_level_await_in_esm_script_under_node16_is_clean() {
+    let source = "await 1;";
+    let diags = codes(
+        source,
+        "plainesm.mts",
+        ModuleKind::Node16,
+        ScriptTarget::ES2022,
+        None,
+    );
+    assert!(
+        !diags.contains(&1375) && !diags.contains(&1309),
+        "an ESM-format file needs no import or export to be a module; got {diags:?}"
+    );
+}
+
+/// The unresolved single-file case (`file_is_esm == None`, ambiguous
+/// extension): no project resolved the format, so the `CommonJS` arm must not
+/// be taken on a guess.
+#[test]
+fn top_level_await_with_unresolved_file_format_does_not_report_ts1309() {
+    let source = "export {};\nawait 1;";
+    let diags = codes(
+        source,
+        "a.ts",
+        ModuleKind::Node16,
+        ScriptTarget::ES2022,
+        None,
+    );
+    assert!(
+        !diags.contains(&1309),
+        "an unresolved implied format must not answer TS1309; got {diags:?}"
+    );
+}
+
+// --- the other Node module kinds ---
+
+/// oracle: node18, node20 and nodenext all report TS1309 on the same file.
+#[test]
+fn top_level_await_reports_ts1309_under_every_node_module_kind() {
+    for module in [ModuleKind::Node18, ModuleKind::Node20, ModuleKind::NodeNext] {
+        let diags = codes(
+            "export {};\nawait 1;",
+            "a.ts",
+            module,
+            ScriptTarget::ES2022,
+            Some(false),
+        );
+        assert!(
+            diags.contains(&1309),
+            "{module:?} must report TS1309; got {diags:?}"
+        );
+    }
+}
+
+/// The `CommonJS` arm short-circuits the target check: TS1309 fires at a
+/// target below ES2017 too, and TS1378 still does not accompany it.
+/// oracle: `--target es2016 --module node16` on the CommonJS file → TS1309.
+#[test]
+fn top_level_await_in_commonjs_file_reports_ts1309_below_es2017() {
+    let diags = codes(
+        "export {};\nawait 1;",
+        "a.ts",
+        ModuleKind::Node16,
+        ScriptTarget::ES2016,
+        Some(false),
+    );
+    assert!(
+        diags.contains(&1309) && !diags.contains(&1378),
+        "the CommonJS arm precedes the target check; got {diags:?}"
+    );
+}
+
+/// The ESM-format sibling at the same low target keeps the ordinary
+/// module/target answer. oracle: `esm.mts --target es2015 --module node16` →
+/// TS1378.
+#[test]
+fn top_level_await_in_esm_file_below_es2017_reports_ts1378() {
+    let diags = codes(
+        "export {};\nawait 1;",
+        "esm.mts",
+        ModuleKind::Node16,
+        ScriptTarget::ES2015,
+        None,
+    );
+    assert!(
+        diags.contains(&1378) && !diags.contains(&1309),
+        "an ESM-format file below ES2017 still answers TS1378; got {diags:?}"
+    );
+}
+
+// --- non-Node module kinds are untouched ---
+
+/// oracle: `--module commonjs` on a module file → TS1378, never TS1309. The
+/// per-file arm belongs to the Node module kinds alone.
+#[test]
+fn top_level_await_under_module_commonjs_still_reports_ts1378() {
+    let diags = codes(
+        "export {};\nawait 1;",
+        "a.ts",
+        ModuleKind::CommonJS,
+        ScriptTarget::ES2022,
+        Some(false),
+    );
+    assert!(
+        diags.contains(&1378) && !diags.contains(&1309),
+        "module=commonjs answers TS1378; got {diags:?}"
+    );
+}
+
+/// oracle: `--module commonjs` on a script → the TS1375 + TS1378 pair, which
+/// this change must leave intact.
+#[test]
+fn top_level_await_under_module_commonjs_script_still_reports_the_pair() {
+    let diags = codes(
+        "await 1;",
+        "plain.ts",
+        ModuleKind::CommonJS,
+        ScriptTarget::ES2022,
+        None,
+    );
+    assert!(
+        diags.contains(&1375) && diags.contains(&1378),
+        "the non-Node pair must survive; got {diags:?}"
+    );
+}
+
+/// oracle: `--module esnext` on a `.cts` file is clean — outside the Node
+/// module kinds the extension does not decide anything.
+#[test]
+fn cts_extension_under_module_esnext_is_clean() {
+    let diags = codes(
+        "await 1;",
+        "nomod.cts",
+        ModuleKind::ESNext,
+        ScriptTarget::ES2022,
+        None,
+    );
+    assert!(
+        !diags.contains(&1309),
+        "a `.cts` file under module=esnext must not report TS1309; got {diags:?}"
+    );
+}
+
+// --- the two sibling constructs ---
+
+/// `for await` asks the same question and gets the same answer.
+/// oracle: `forawait.cts(3,5): error TS1309` — and no TS1432.
+#[test]
+fn top_level_for_await_in_commonjs_file_reports_ts1309() {
+    let source =
+        "export {};\ndeclare const it: AsyncIterable<number>;\nfor await (const value of it) { }";
+    let diags = node16_cjs_codes(source, "forawait.cts");
+    assert!(
+        diags.contains(&1309),
+        "top-level `for await` in a CommonJS file must report TS1309; got {diags:?}"
+    );
+    assert!(
+        !diags.contains(&1432) && !diags.contains(&1431),
+        "TS1309 replaces the `for await` module/target family; got {diags:?}"
+    );
+}
+
+/// `await using` likewise. oracle: `awaitusing.cts(3,1): error TS1309` — and
+/// no TS2853/TS2854.
+#[test]
+fn top_level_await_using_in_commonjs_file_reports_ts1309() {
+    let source =
+        "export {};\ndeclare const resource: AsyncDisposable;\nawait using held = resource;";
+    let diags = node16_cjs_codes(source, "awaitusing.cts");
+    assert!(
+        diags.contains(&1309),
+        "top-level `await using` in a CommonJS file must report TS1309; got {diags:?}"
+    );
+    assert!(
+        !diags.contains(&2853) && !diags.contains(&2854),
+        "TS1309 replaces the `await using` module/target family; got {diags:?}"
+    );
+}
+
+/// The ESM sibling of both constructs stays clean.
+/// oracle: `fa-nomod.mts` and `au-nomod.mts` under node16 are clean.
+#[test]
+fn sibling_constructs_in_esm_file_are_clean() {
+    let for_await = "declare const it: AsyncIterable<number>;\nfor await (const value of it) { }";
+    let diags = codes(
+        for_await,
+        "fa-nomod.mts",
+        ModuleKind::Node16,
+        ScriptTarget::ES2022,
+        None,
+    );
+    assert!(
+        !diags.contains(&1309) && !diags.contains(&1431) && !diags.contains(&1432),
+        "`for await` in an ESM-format file is clean; got {diags:?}"
+    );
+
+    let await_using = "declare const resource: AsyncDisposable;\nawait using held = resource;";
+    let diags = codes(
+        await_using,
+        "au-nomod.mts",
+        ModuleKind::Node16,
+        ScriptTarget::ES2022,
+        None,
+    );
+    assert!(
+        !diags.contains(&1309) && !diags.contains(&2853) && !diags.contains(&2854),
+        "`await using` in an ESM-format file is clean; got {diags:?}"
+    );
+}
+
+// --- negative control ---
+
+/// The construct still has to be at the top level: an `await` inside an
+/// `async` function in the very same CommonJS file is legal.
+/// oracle: `inasync.cts` under node16 is clean.
+#[test]
+fn await_inside_async_function_in_commonjs_file_is_clean() {
+    let source = "export {};\nasync function run() { await 1; }";
+    let diags = node16_cjs_codes(source, "inasync.cts");
+    assert!(
+        !diags.contains(&1309),
+        "a nested `await` is not a top-level `await`; got {diags:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
@@ -1497,15 +1497,10 @@ impl<'a> CheckerState<'a> {
         if module_kind.is_node_module() {
             // Node16/Node18/Node20/NodeNext: per-file CJS/ESM determination.
             // Only files that build into CommonJS output are rejected (TS1470).
-            let current_file = &self.ctx.file_name;
-            let is_commonjs_file = current_file.ends_with(".cts") || current_file.ends_with(".cjs");
-            let is_esm_file = current_file.ends_with(".mts") || current_file.ends_with(".mjs");
-            // `.cts`/`.cjs` force CJS, `.mts`/`.mjs` force ESM; otherwise an
-            // extensionless `.ts`/`.js` builds to CJS only when the resolved
-            // format is explicitly CommonJS (`file_is_esm == Some(false)`).
-            let builds_to_cjs =
-                is_commonjs_file || (!is_esm_file && self.ctx.file_is_esm == Some(false));
-            if builds_to_cjs {
+            // `CheckerContext::current_file_builds_to_commonjs` owns the
+            // extension/`package.json` precedence; the top-level-`await`
+            // TS1309 family asks it the same question.
+            if self.ctx.current_file_builds_to_commonjs() {
                 self.error_at_node(
                     node_idx,
                     diagnostic_messages::THE_IMPORT_META_META_PROPERTY_IS_NOT_ALLOWED_IN_FILES_WHICH_WILL_BUILD_INTO_COMM,

--- a/crates/tsz-checker/src/types/type_checking/core.rs
+++ b/crates/tsz-checker/src/types/type_checking/core.rs
@@ -5,6 +5,7 @@
 //! Type alias declaration checking and type node validation are in
 //! `type_alias_checking.rs`.
 
+use super::core_statement_checks::TopLevelAwaitVerdict;
 use crate::context::TypingRequest;
 use crate::state::CheckerState;
 use rustc_hash::FxHashSet;
@@ -1629,7 +1630,7 @@ impl<'a> CheckerState<'a> {
             // `function_depth == 0`.
             if self.is_directly_at_source_file_top_level(list_idx) {
                 // TS2853: Top-level 'await using' is only valid in modules.
-                if !self.ctx.is_external_module_file() {
+                if self.top_level_await_requires_module_diagnostic() {
                     self.error_at_node(
                         list_idx,
                         diagnostic_messages::AWAIT_USING_STATEMENTS_ARE_ONLY_ALLOWED_AT_THE_TOP_LEVEL_OF_A_FILE_WHEN_THAT_FIL,
@@ -1637,21 +1638,28 @@ impl<'a> CheckerState<'a> {
                     );
                 }
 
-                // TS2854: Top-level 'await using' requires specific module + target options.
-                // Routes through the environment capability boundary to determine whether
-                // a diagnostic should be emitted.
-                use crate::query_boundaries::capabilities::FeatureGate;
-                if self
-                    .ctx
-                    .capabilities
-                    .check_feature_gate(FeatureGate::TopLevelAwaitUsing)
-                    .is_some()
-                {
-                    self.error_at_node(
-                        list_idx,
-                        diagnostic_messages::TOP_LEVEL_AWAIT_USING_STATEMENTS_ARE_ONLY_ALLOWED_WHEN_THE_MODULE_OPTION_IS_SET,
-                        diagnostic_codes::TOP_LEVEL_AWAIT_USING_STATEMENTS_ARE_ONLY_ALLOWED_WHEN_THE_MODULE_OPTION_IS_SET,
-                    );
+                // TS1309 when a Node module kind pairs with a CommonJS-format
+                // file; otherwise TS2854, which requires specific module +
+                // target options. Both answers come from the shared
+                // `checkGrammarAwaitOrAwaitUsing` switch, which routes the
+                // module/target half through the environment capability
+                // boundary.
+                match self.top_level_await_verdict() {
+                    TopLevelAwaitVerdict::Allowed => {}
+                    TopLevelAwaitVerdict::CommonJsFile => {
+                        self.error_at_node(
+                            list_idx,
+                            diagnostic_messages::THE_CURRENT_FILE_IS_A_COMMONJS_MODULE_AND_CANNOT_USE_AWAIT_AT_THE_TOP_LEVEL,
+                            diagnostic_codes::THE_CURRENT_FILE_IS_A_COMMONJS_MODULE_AND_CANNOT_USE_AWAIT_AT_THE_TOP_LEVEL,
+                        );
+                    }
+                    TopLevelAwaitVerdict::UnsupportedModuleOrTarget => {
+                        self.error_at_node(
+                            list_idx,
+                            diagnostic_messages::TOP_LEVEL_AWAIT_USING_STATEMENTS_ARE_ONLY_ALLOWED_WHEN_THE_MODULE_OPTION_IS_SET,
+                            diagnostic_codes::TOP_LEVEL_AWAIT_USING_STATEMENTS_ARE_ONLY_ALLOWED_WHEN_THE_MODULE_OPTION_IS_SET,
+                        );
+                    }
                 }
             } else if !self.enclosing_function_allows_await_using(list_idx) {
                 // TS2852: Nested 'await using' is only valid inside async functions.

--- a/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
+++ b/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
@@ -20,6 +20,23 @@ use tsz_solver::TypeId;
 /// (`isInTopLevelContext`, which selects the TS1375/TS1378 pair over TS1308).
 /// A root position can suppress either axis independently, so they are modelled
 /// as two orthogonal properties rather than one "is this special" flag.
+/// What `tsc`'s module switch decides about a top-level `await` in the
+/// current file, independent of which of the three constructs asked.
+///
+/// The two error arms map to a different code per construct — `await`
+/// answers TS1378, `for await` TS1432, `await using` TS2854 — except for
+/// [`Self::CommonJsFile`], where all three answer the single shared TS1309.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TopLevelAwaitVerdict {
+    /// The module kind, target, and file format all permit top-level `await`.
+    Allowed,
+    /// A Node module kind with a `CommonJS`-format file: TS1309, at every
+    /// target.
+    CommonJsFile,
+    /// The module/target pair does not support top-level `await` at all.
+    UnsupportedModuleOrTarget,
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum AwaitContainerKind {
     /// Ordinary position: both axes answered from the surrounding code.
@@ -597,6 +614,41 @@ impl<'a> CheckerState<'a> {
         self.ctx.capabilities.top_level_await_using_supported
     }
 
+    /// `tsc`'s module switch in `checkGrammarAwaitOrAwaitUsing`, shared by all
+    /// three top-level `await` constructs (`await`, `for await`,
+    /// `await using`).
+    ///
+    /// Under a Node module kind the verdict is per *file*: a file whose
+    /// implied format is `CommonJS` cannot host top-level `await` at any
+    /// target, and answers TS1309 instead of the module/target family. A file
+    /// whose implied format is ESM falls through to the ordinary
+    /// module + target requirement.
+    pub(crate) fn top_level_await_verdict(&self) -> TopLevelAwaitVerdict {
+        if self.ctx.compiler_options.module.is_node_module()
+            && self.ctx.current_file_builds_to_commonjs()
+        {
+            return TopLevelAwaitVerdict::CommonJsFile;
+        }
+        if self.supports_top_level_await() {
+            TopLevelAwaitVerdict::Allowed
+        } else {
+            TopLevelAwaitVerdict::UnsupportedModuleOrTarget
+        }
+    }
+
+    /// Whether the "…but this file has no imports or exports" family
+    /// (TS1375 / TS1431 / TS2853) can fire for the current file.
+    ///
+    /// Under a Node module kind a file's module-ness is settled by its implied
+    /// format rather than by the presence of an `import`/`export`: an
+    /// ESM-format file is a module even with none (`await` in a bare `.mts` is
+    /// clean), and a `CommonJS`-format file answers TS1309 instead. So the
+    /// family is unreachable there, and only the non-Node module kinds ask the
+    /// binder's external-module question.
+    pub(crate) fn top_level_await_requires_module_diagnostic(&self) -> bool {
+        !self.ctx.compiler_options.module.is_node_module() && !self.ctx.is_external_module_file()
+    }
+
     /// Check an await expression for async context.
     ///
     /// Validates that await expressions are only used within async functions,
@@ -743,7 +795,7 @@ impl<'a> CheckerState<'a> {
                             // way (`check_using_declaration_list` in `core.rs`).
 
                             // TS1375: top-level await is only valid in a module.
-                            if !self.ctx.is_external_module_file() {
+                            if self.top_level_await_requires_module_diagnostic() {
                                 self.error_at_node(
                                     current_idx,
                                     diagnostic_messages::AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_AT_THE_TOP_LEVEL_OF_A_FILE_WHEN_THAT_FILE_IS,
@@ -751,15 +803,27 @@ impl<'a> CheckerState<'a> {
                                 );
                             }
 
+                            // TS1309: a CommonJS-format file under a Node
+                            // module kind, at any target.
                             // TS1378: top-level await requires a module in
                             // {ES2022, ESNext, System, Node16/18/20, NodeNext,
                             // Preserve} and target >= ES2017.
-                            if !self.supports_top_level_await() {
-                                self.error_at_node(
-                                    current_idx,
-                                    diagnostic_messages::TOP_LEVEL_AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WHEN_THE_MODULE_OPTION_IS_SET_TO_ES,
-                                    diagnostic_codes::TOP_LEVEL_AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WHEN_THE_MODULE_OPTION_IS_SET_TO_ES,
-                                );
+                            match self.top_level_await_verdict() {
+                                TopLevelAwaitVerdict::Allowed => {}
+                                TopLevelAwaitVerdict::CommonJsFile => {
+                                    self.error_at_node(
+                                        current_idx,
+                                        diagnostic_messages::THE_CURRENT_FILE_IS_A_COMMONJS_MODULE_AND_CANNOT_USE_AWAIT_AT_THE_TOP_LEVEL,
+                                        diagnostic_codes::THE_CURRENT_FILE_IS_A_COMMONJS_MODULE_AND_CANNOT_USE_AWAIT_AT_THE_TOP_LEVEL,
+                                    );
+                                }
+                                TopLevelAwaitVerdict::UnsupportedModuleOrTarget => {
+                                    self.error_at_node(
+                                        current_idx,
+                                        diagnostic_messages::TOP_LEVEL_AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WHEN_THE_MODULE_OPTION_IS_SET_TO_ES,
+                                        diagnostic_codes::TOP_LEVEL_AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WHEN_THE_MODULE_OPTION_IS_SET_TO_ES,
+                                    );
+                                }
                             }
                         } else {
                             // TS1308: 'await' expressions are only allowed within async functions
@@ -981,7 +1045,7 @@ impl<'a> CheckerState<'a> {
         };
 
         // TS1431: top-level `for await` is only valid in a module.
-        if !self.ctx.is_external_module_file() {
+        if self.top_level_await_requires_module_diagnostic() {
             self.error(
                 await_pos,
                 await_len,
@@ -991,15 +1055,29 @@ impl<'a> CheckerState<'a> {
             );
         }
 
-        // TS1432: top-level `for await` requires a supporting module/target.
-        if !self.supports_top_level_await() {
-            self.error(
-                await_pos,
-                await_len,
-                diagnostic_messages::TOP_LEVEL_FOR_AWAIT_LOOPS_ARE_ONLY_ALLOWED_WHEN_THE_MODULE_OPTION_IS_SET_TO_ES20
-                    .to_string(),
-                diagnostic_codes::TOP_LEVEL_FOR_AWAIT_LOOPS_ARE_ONLY_ALLOWED_WHEN_THE_MODULE_OPTION_IS_SET_TO_ES20,
-            );
+        // TS1309 for a CommonJS-format file under a Node module kind;
+        // otherwise TS1432 when the module/target pair does not support
+        // top-level `for await`.
+        match self.top_level_await_verdict() {
+            TopLevelAwaitVerdict::Allowed => {}
+            TopLevelAwaitVerdict::CommonJsFile => {
+                self.error(
+                    await_pos,
+                    await_len,
+                    diagnostic_messages::THE_CURRENT_FILE_IS_A_COMMONJS_MODULE_AND_CANNOT_USE_AWAIT_AT_THE_TOP_LEVEL
+                        .to_string(),
+                    diagnostic_codes::THE_CURRENT_FILE_IS_A_COMMONJS_MODULE_AND_CANNOT_USE_AWAIT_AT_THE_TOP_LEVEL,
+                );
+            }
+            TopLevelAwaitVerdict::UnsupportedModuleOrTarget => {
+                self.error(
+                    await_pos,
+                    await_len,
+                    diagnostic_messages::TOP_LEVEL_FOR_AWAIT_LOOPS_ARE_ONLY_ALLOWED_WHEN_THE_MODULE_OPTION_IS_SET_TO_ES20
+                        .to_string(),
+                    diagnostic_codes::TOP_LEVEL_FOR_AWAIT_LOOPS_ARE_ONLY_ALLOWED_WHEN_THE_MODULE_OPTION_IS_SET_TO_ES20,
+                );
+            }
         }
     }
 

--- a/crates/tsz-checker/src/types/type_checking/mod.rs
+++ b/crates/tsz-checker/src/types/type_checking/mod.rs
@@ -13,7 +13,7 @@
 mod alias_defid_visited_pool;
 mod commonjs_object_exports;
 mod core;
-mod core_statement_checks;
+pub(crate) mod core_statement_checks;
 mod cross_file_conflicts;
 mod declarations;
 mod declarations_utils;


### PR DESCRIPTION
Picks up the TS1309 third of #16291's `module-element context` row — ClaudeT's 15:22Z board claim on that row expired at 17:20Z with no `DONE`/`DROP`, and all three of its codes are still unwired on `main`.

## Structural rule

When the module kind is a Node one (`node16`/`node18`/`node20`/`nodenext`), `tsc` decides the top-level-`await` question **per file**, from the file's implied format, rather than per program (`checkGrammarAwaitOrAwaitUsing`'s module switch):

- **`CommonJS`-format file** — `TS1309 The current file is a CommonJS module and cannot use 'await' at the top level.`, at **every** target, and the module/target family does *not* also fire.
- **ESM-format file** — no TS1309; the ordinary module + target requirement applies, so a target below ES2017 still answers TS1378.
- The `…but this file has no imports or exports` family (TS1375 / TS1431 / TS2853) is **unreachable** under a Node module kind in both directions: an ESM-format file is a module with no imports or exports at all, and a `CommonJS`-format one answers TS1309 instead.

tsz answered **nothing** for any of it. `supports_top_level_await()` returns `true` for every Node module kind and the sites had no per-file arm, so a top-level `await` in a `.cts` file — or in an ordinary `.ts` file under a `package.json` without `"type": "module"` — was silently accepted.

tsz now does X through the **checker**, with the format question owned by one predicate at the context boundary:

- `CheckerContext::current_file_builds_to_commonjs` (new `context/module_format.rs`) — extension first (`.cts`/`.cjs` force `CommonJS`, `.mts`/`.mjs` force ESM), then the driver-resolved `file_is_esm` for the ambiguous extensions. An **unresolved** format (`file_is_esm == None`) is not guessed as `CommonJS`. This is the predicate the `import.meta` TS1470 site already had inline; it is hoisted, not duplicated, and that site now calls it.
- `TopLevelAwaitVerdict` + `top_level_await_verdict()` — one shared switch. All three constructs share TS1309 and differ only in the module/target arm (TS1378 / TS1432 / TS2854).
- `top_level_await_requires_module_diagnostic()` — the TS1375/TS1431/TS2853 gate, which now asks the module kind before asking the binder.

No identifier, alias, or file-*name* string drives anything: the only string inspection is the file **extension**, which is what `impliedNodeFormat` itself is defined on.

## Adjacent-case matrix

Oracle is `typescript@7.0.2` (the pin in `scripts/conformance/typescript-versions.json`), `--noEmit --strict --lib esnext`, `--module node16 --moduleResolution node16` unless the row says otherwise. Two package fixtures drove the ambiguous-extension rows: one `package.json` with no `"type"`, one with `"type": "module"`.

| # | shape | tsc 7.0.2 | tsz before | tsz after |
| --- | --- | --- | --- | --- |
| 1 | `.ts` + module, CJS package | TS1309 | *(silent)* | TS1309 |
| 2 | `.cts` + module | TS1309 | *(silent)* | TS1309 |
| 3 | `.cts`, **no** import/export | TS1309 alone | *(silent)* | TS1309 alone |
| 4 | `.ts`, no import/export, CJS package | TS1309 alone (no TS1375) | *(silent)* | TS1309 alone |
| 5 | renamed binders, `await obj.prop` instead of a literal | TS1309 | *(silent)* | TS1309 |
| 6 | `.mts` + module | clean | clean | clean |
| 7 | `.ts` + module, `"type": "module"` package | clean | clean | clean |
| 8 | `.mts`, **no** import/export | clean (no TS1375) | clean | clean |
| 9 | `.ts`, unresolved format (single file, no project) | n/a | clean | clean |
| 10 | node18 / node20 / nodenext, CJS file | TS1309 | *(silent)* | TS1309 |
| 11 | node16 + `--target es2016`, CJS file | TS1309, no TS1378 | *(silent)* | TS1309, no TS1378 |
| 12 | node16 + `--target es2015`, `.mts` | TS1378 | TS1378 | TS1378 |
| 13 | `--module commonjs`, module file | TS1378 | TS1378 | TS1378 |
| 14 | `--module commonjs`, script file | TS1375 + TS1378 | TS1375 + TS1378 | TS1375 + TS1378 |
| 15 | `--module esnext`, `.cts` file | clean | clean | clean |
| 16 | top-level `for await`, CJS file | TS1309 (no TS1432/TS1431) | *(silent)* | TS1309 |
| 17 | top-level `await using`, CJS file | TS1309 (no TS2854/TS2853) | *(silent)* | TS1309 |
| 18 | `for await` / `await using` in an `.mts`, no import/export | clean | clean | clean |
| 19 | `await` inside an `async` function in the same CJS file | clean | clean | clean |

Rows 13–15 and 19 are the negative controls: outside the Node module kinds the file extension decides nothing, and the construct still has to be at the top level.

## Verification

- `cargo test -p tsz-checker --lib ts1309` — **19 passed, 0 failed** (new `crates/tsz-checker/src/tests/ts1309_top_level_await_commonjs_file_tests.rs`, one test per row above).
- **Non-vacuity**: ablated `current_file_builds_to_commonjs` to return `false` unconditionally, tests untouched — **8 of 19 fail**, exactly the TS1309-asserting rows; the other 11 are negative controls and pre-existing behavior that must hold either way. Reverted before commit.
- `cargo test -p tsz-checker --lib -- await import_meta` — **212 passed, 0 failed** (covers `top_level_await_boundary_tests`, the three `await_grammar_*` suites, `await_concise_arrow_body_grammar_tests`, and `value_usage_tests::test_for_await_top_level_non_module_emits_ts1431_ts1432`, i.e. the TS1375/TS1378/TS1431/TS1432/TS2853/TS2854 rows this change routes around).
- `cargo test -p tsz-checker --lib -- 1470 meta_module esm` — 5 passed, 0 failed (the `import.meta` site whose inline predicate was hoisted).
- `cargo clippy --workspace --exclude tsz-conformance --all-targets -- -D warnings` — clean. `cargo fmt` applied. `python3 scripts/arch/arch_guard.py` — passed. Pre-commit hook's own gate passed.
- Before/after was also measured end-to-end through the release CLI on the oracle fixtures: the pre-change binary is silent on rows 1–4, 10, 11, 16 and 17.
- Not run: conformance / emit / fourslash. This is an additive grammar diagnostic behind `module.is_node_module()`; the committed corpus's project rows do not compile under a Node module kind with a `CommonJS`-format file, so the expected corpus signature is 0 newly-failing / 0 newly-passing. The oracle-pinned matrix above is the primary evidence for this class, per the board's standing note.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Selenite

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9FHjeLMReBwzi7Wqb5eTU)_