### PR TITLE
fix(parser): TS1511 for \q outside a character class under the v flag

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1533,6 +1533,7 @@ pub(super) const fn is_non_suppressing_parse_error(code: u32) -> bool {
             | 1507 // There is nothing available for repetition (`/{1}/u`)
             | 1508 // Unexpected '{0}'. Did you mean to escape it with backslash? (`/[a[b]]/u`)
             | 1510 // '\k' must be followed by a capturing group name enclosed in angle brackets
+            | 1511 // '\q' is only available inside character class (`/\q{a}/v`, regex grammar, AST is valid)
             | 1512 // '\c' must be followed by an ASCII letter (`/\c1/u`)
             | 1516 // A character class range must not be bounded by another character class (`/[a-\d]/u`)
             | 1517 // Range out of order in character class (`/[b-a]/`)

--- a/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
@@ -668,6 +668,26 @@ impl ParserState {
                             );
                         }
                     }
+                    // `\q` is a character-class-only atom (`scan_character_class_escape`
+                    // owns its in-class form). Outside a class under the `v` flag it is
+                    // still a reserved escape, but tsc names the specific reason
+                    // (TS1511) rather than falling through to the generic
+                    // THIS_CHARACTER_CANNOT_BE_ESCAPED_IN_A_REGULAR_EXPRESSION this arm's
+                    // `_` fallback would otherwise report. Not gated on `atom_escape`:
+                    // this function is never reached for `q` from inside a class while
+                    // `unicode_sets_mode` is true, because
+                    // `scan_character_class_escape`'s own `b'q' if unicode_sets_mode`
+                    // arm always claims it first.
+                    b'q' if scan_ctx.unicode_sets_mode => {
+                        emit(
+                            parser,
+                            escape_start,
+                            2,
+                            diagnostic_messages::Q_IS_ONLY_AVAILABLE_INSIDE_CHARACTER_CLASS,
+                            diagnostic_codes::Q_IS_ONLY_AVAILABLE_INSIDE_CHARACTER_CLASS,
+                        );
+                        *pos += 1;
+                    }
                     b'o' if atom_escape => {
                         if strict_mode {
                             emit(

--- a/crates/tsz-parser/tests/parser_improvement_regex_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_regex_recovery_tests.rs
@@ -131,6 +131,64 @@ const missing = /[a&&]/v;
 }
 
 #[test]
+fn test_regex_q_escape_outside_character_class_reports_ts1511_under_v_flag() {
+    // tsc: `\q` is a `v`-mode-only character-class atom (ECMA-262
+    // `ClassSetCharacter :: \q{...}`). Used at atom position outside a class
+    // under the `v` flag it is still reserved, but tsc names the specific
+    // reason (TS1511) rather than the generic TS1535 fallback.
+    let source = r"const outside = /\q{abc}/v;";
+    let (parser, _root) = parse_source(source);
+
+    let diagnostics = parser.get_diagnostics();
+    let codes: Vec<_> = diagnostics.iter().map(|d| d.code).collect();
+
+    assert!(
+        codes.contains(&diagnostic_codes::Q_IS_ONLY_AVAILABLE_INSIDE_CHARACTER_CLASS),
+        "Expected TS1511 for \\q outside a character class under /v, got {diagnostics:?}"
+    );
+    assert!(
+        !codes
+            .contains(&diagnostic_codes::THIS_CHARACTER_CANNOT_BE_ESCAPED_IN_A_REGULAR_EXPRESSION),
+        "TS1511 should replace the generic TS1535 fallback for this shape, got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_regex_q_escape_stays_ts1535_without_v_flag_or_inside_class() {
+    // Negative/adjacent matrix for the TS1511 fix above: only "atom
+    // position + `v` flag" gets the specific code. Every other combination
+    // must keep reporting the pre-existing generic TS1535 (or, inside a
+    // `v`-mode class, no diagnostic at all — `\q{...}` is valid there).
+    let source = r"
+const uOnlyOutsideClass = /\q{abc}/u;
+const noFlagOutsideClass = /\q/;
+const uOnlyInsideClass = /[\q{abc}]/u;
+const vModeInsideClass = /[\q{abc}]/v;
+";
+    let (parser, _root) = parse_source(source);
+
+    let diagnostics = parser.get_diagnostics();
+    let codes: Vec<_> = diagnostics.iter().map(|d| d.code).collect();
+
+    assert!(
+        !codes.contains(&diagnostic_codes::Q_IS_ONLY_AVAILABLE_INSIDE_CHARACTER_CLASS),
+        "TS1511 must not fire without /v at atom position or inside a class, got {diagnostics:?}"
+    );
+    let ts1535_count = diagnostics
+        .iter()
+        .filter(|d| {
+            d.code == diagnostic_codes::THIS_CHARACTER_CANNOT_BE_ESCAPED_IN_A_REGULAR_EXPRESSION
+        })
+        .count();
+    assert_eq!(
+        ts1535_count, 2,
+        "Expected TS1535 for the `u`-only outside-class use and the `u`-only \
+         in-class use (no-flag outside-class and `v`-mode in-class are both \
+         valid \\q shapes), got {diagnostics:?}"
+    );
+}
+
+#[test]
 fn test_regex_hyphen_after_range_is_literal() {
     let source = "const idSuffixPattern = /^([a-z][a-z0-9-]*)(:[a-z0-9-.]*)?$/i;";
     let (parser, _root) = parse_source(source);


### PR DESCRIPTION
Closes the TS1511 gap in #16291's regex-grammar family: this was a wrong-code bug, not a missing diagnostic.

## Structural rule

When `\q{...}` is written at atom position (outside a character class) under the `v` flag, `tsc` still rejects it but names the specific reason — TS1511 (`'\q' is only available inside character class.`) — rather than the generic escape-rejection fallback. tsz's `scan_character_escape` (parser, `state_expressions_literals_regex.rs`) had no arm for `q`, so it fell through to the `_` wildcard and reported TS1535 (`This character cannot be escaped in a regular expression.`) instead — the right diagnostic *family*, wrong *member*. Owner layer: parser (regex-literal grammar), matching all of TS1511's siblings in the same file.

`\q{...}` is otherwise a `v`-mode-only character-class atom; its in-class form is handled separately by `scan_character_class_escape` and was already correct — this PR does not touch that path.

## Adjacent-case matrix (oracle: `typescript@7.0.2`)

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `/\q{abc}/v` (atom position) | TS1511 | TS1535 (wrong code) | TS1511 |
| `/[\q{abc}]/v` (in class) | valid, no error | valid, no error | unchanged |
| `/\q{abc}/u` (atom position, no `v`) | TS1535 | TS1535 | unchanged |
| `/[\q{abc}]/u` (in class, no `v`) | TS1535 | TS1535 | unchanged |
| `/\q/` (atom position, no flags) | valid, no error | valid, no error | unchanged |
| `/\Q{abc}/v` (uppercase, case-sensitive negative) | TS1535 | TS1535 | unchanged |

Also added `1511` to `is_non_suppressing_parse_error` in `crates/tsz-cli/src/driver/check_utils.rs` alongside its regex-grammar siblings (1508/1519/1522/1533/1534/1537/...), so an unrelated syntax error elsewhere in the same file does not drop it.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-parser --lib -- test_regex_q_escape`: 2 new tests pass (positive TS1511 case + full negative/adjacent matrix above), full `--lib` suite 1693/1693 passed, 0 failed.
- `cargo fmt --check`: clean.
- `cargo clippy -p tsz-parser -p tsz-cli --all-targets -- -D warnings`: clean.
- `python3 scripts/arch/arch_guard.py`: `Architecture guardrails passed.`
- `scripts/conformance/compare-to-parent.sh origin/main`: running in the background at push time (this touches a shared parser-grammar predicate table, so the two-sided corpus gate applies); will post the before/after result as a follow-up comment once it reports.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_0185FnVxqTK43KhgjNbEjkAX)_