### PR TITLE
fix(solver): Symbol.&lt;member&gt; keyed by a wide global augmentation routes to the symbol index signature

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/computed_property_names.rs
+++ b/crates/tsz-checker/src/state/type_resolution/computed_property_names.rs
@@ -397,6 +397,22 @@ impl<'a> CheckerState<'a> {
         if let Some(name) = self.local_well_known_symbol_property_name(computed.expression) {
             return Some(ResolvedComputedName::string(name));
         }
+        // `Symbol.<member>` where `<member>` is a plain (non-unique)
+        // `symbol`-typed global augmentation (xstate's `SymbolConstructor.
+        // observable: symbol`) is not a well-known key at all: it does not
+        // mint a named member, so it must be flagged wide (`__symbol_`
+        // prefix) the same way an aliasing identifier's plain-`symbol`
+        // binding is below — `symbol_valued_binding_property_name` only
+        // resolves bare identifiers, so this qualified-access shape needs its
+        // own leg.
+        if let Some(name) = crate::types_domain::computed_names::wide_well_known_symbol_member_key(
+            &self.ctx,
+            self.ctx.arena,
+            self.ctx.binder,
+            computed.expression,
+        ) {
+            return Some(ResolvedComputedName::symbol(name));
+        }
 
         if let Some(name) =
             self.computed_expression_literal_name_in_arena(self.ctx.arena, computed.expression)

--- a/crates/tsz-checker/src/types/computed_names.rs
+++ b/crates/tsz-checker/src/types/computed_names.rs
@@ -150,10 +150,169 @@ pub(crate) fn well_known_symbol_property_name(
     let shape = well_known_symbol_access_shape(arena, expr_idx)?;
     if identifier_resolves_to_unshadowed_global_in_context(ctx, arena, binder, shape.base, "Symbol")
     {
+        // A `Symbol.<member>` access whose member is a plain (non-unique)
+        // `symbol`-typed global augmentation (xstate's `SymbolConstructor.
+        // observable: symbol`) is not a genuine well-known key; it must not
+        // short-circuit here so callers fall through to binding-identity
+        // (wide-symbol) resolution instead.
+        if wide_well_known_symbol_member_key(ctx, arena, binder, expr_idx).is_some() {
+            return None;
+        }
         shape.name.map(WellKnownSymbolName::Global)
     } else {
         Some(WellKnownSymbolName::Shadowed)
     }
+}
+
+/// `Symbol.<member>` (or `Symbol["<member>"]`, parens peeled) where `<member>`
+/// is a plain (non-unique) `symbol`-typed member of the merged
+/// `SymbolConstructor` interface — a user global augmentation (xstate's
+/// `interface SymbolConstructor { readonly observable: symbol }`) rather than
+/// a genuine well-known (`Symbol.iterator` and friends, `unique symbol`-typed).
+/// Such an access does not carry its own literal `[Symbol.<member>]` key: tsc
+/// routes it into the containing type's symbol index signature exactly like
+/// any other plain-`symbol` binding. `None` for a non-`Symbol.X` shape, a
+/// shadowed `Symbol`, or a genuine well-known/unresolvable member — the
+/// historical literal-key behavior stays default for anything this cannot
+/// positively identify as wide.
+pub(crate) fn wide_well_known_symbol_member_key(
+    ctx: &CheckerContext<'_>,
+    arena: &NodeArena,
+    binder: &BinderState,
+    expr_idx: NodeIndex,
+) -> Option<String> {
+    let shape = well_known_symbol_access_shape(arena, expr_idx)?;
+    let name = shape.name?;
+    let member = name.strip_prefix("[Symbol.")?.strip_suffix(']')?;
+    if !identifier_resolves_to_unshadowed_global_in_context(
+        ctx, arena, binder, shape.base, "Symbol",
+    ) {
+        return None;
+    }
+    symbol_constructor_member_is_wide(ctx, member).then(|| format!("__symbol_wellknown_{member}"))
+}
+
+/// Resolve the merged `SymbolConstructor` INTERFACE symbol (the type-space
+/// binding, distinct from the `declare var Symbol: SymbolConstructor` value
+/// symbol). Its `all_declarations()` spans every `interface SymbolConstructor
+/// { ... }` block the binder merged together — the lib declaration plus any
+/// `declare global { interface SymbolConstructor { ... } }` user augmentation
+/// — so walking them finds a member regardless of which file declared it.
+fn symbol_constructor_type_symbol(ctx: &CheckerContext<'_>) -> Option<SymbolId> {
+    crate::types_domain::queries::lib_resolution::resolve_name_to_lib_symbol(
+        "SymbolConstructor",
+        ctx.binder,
+        ctx.global_file_locals_index.as_deref(),
+        ctx.all_binders
+            .as_ref()
+            .map(|binders| binders.as_ref().as_slice()),
+        &ctx.lib_contexts,
+    )
+}
+
+/// Declared symbol-kind of `member_name` on the `interface SymbolConstructor`
+/// declaration at `decl_idx` (an `INTERFACE_DECLARATION` node — interfaces
+/// have no binder-level `members` table; their members only exist as AST
+/// child nodes, so this walks the member list directly): `Some(true)` for
+/// `unique symbol` (a genuine well-known, e.g. `Symbol.iterator`),
+/// `Some(false)` for plain `symbol` (a user global augmentation, e.g.
+/// xstate's `SymbolConstructor.observable: symbol`), `None` when the member
+/// isn't found on this particular declaration or isn't property-shaped (a
+/// method like `for(key: string): symbol`, or a missing annotation).
+fn interface_member_declared_symbol_kind(
+    arena: &NodeArena,
+    decl_idx: NodeIndex,
+    member_name: &str,
+) -> Option<bool> {
+    let node = arena.get(decl_idx)?;
+    let interface = arena.get_interface(node)?;
+    for &member_idx in &interface.members.nodes {
+        let Some(member) = arena.get(member_idx) else {
+            continue;
+        };
+        let Some(sig) = arena.get_signature(member) else {
+            continue;
+        };
+        if arena.get_identifier_text(sig.name) != Some(member_name) {
+            continue;
+        }
+        if !sig.type_annotation.is_some() {
+            return None;
+        }
+        if is_unique_symbol_type_annotation_unwrapped(arena, sig.type_annotation) {
+            return Some(true);
+        }
+        return is_symbol_type_node(arena, sig.type_annotation).then_some(false);
+    }
+    None
+}
+
+/// Declared symbol-kind of `member_name` across every `declare global {
+/// interface SymbolConstructor { ... } }` augmentation the binder recorded.
+/// A `declare global` augmentation is NOT merged into the target symbol's own
+/// `declarations` list (that list holds only the plain lib declarations);
+/// the binder tracks it separately in `global_augmentations`, each entry
+/// carrying the arena it was declared in (`None` means the current file's own
+/// arena) — see `resolve_array_global_augmentation_property` for the same
+/// pattern applied to `Array`.
+fn symbol_constructor_augmentation_kind(
+    ctx: &CheckerContext<'_>,
+    member_name: &str,
+) -> Option<bool> {
+    if let Some(kind) = ctx
+        .binder
+        .global_augmentations
+        .get("SymbolConstructor")
+        .and_then(|augs| {
+            augs.iter().find_map(|aug| {
+                let arena = aug.arena.as_deref().unwrap_or(ctx.arena);
+                interface_member_declared_symbol_kind(arena, aug.node, member_name)
+            })
+        })
+    {
+        return Some(kind);
+    }
+    // Fallback for the rare case where the current file's own binder hasn't
+    // merged another file's augmentation into its `global_augmentations` map.
+    ctx.all_binders.as_ref().and_then(|all_binders| {
+        all_binders.iter().find_map(|binder| {
+            binder
+                .global_augmentations
+                .get("SymbolConstructor")
+                .and_then(|augs| {
+                    augs.iter().find_map(|aug| {
+                        let arena = aug.arena.as_deref().unwrap_or(ctx.arena);
+                        interface_member_declared_symbol_kind(arena, aug.node, member_name)
+                    })
+                })
+        })
+    })
+}
+
+/// Is `member_name` a plain (non-unique) `symbol`-typed member of the merged
+/// `SymbolConstructor` interface — a user global augmentation like xstate's
+/// `interface SymbolConstructor { readonly observable: symbol }` — rather
+/// than a genuine well-known `unique symbol` (`Symbol.iterator` and friends)?
+/// `false` when the member cannot be found at all, preserving the historical
+/// well-known-literal-key behavior for anything this cannot resolve.
+pub(crate) fn symbol_constructor_member_is_wide(
+    ctx: &CheckerContext<'_>,
+    member_name: &str,
+) -> bool {
+    if let Some(kind) = symbol_constructor_augmentation_kind(ctx, member_name) {
+        return !kind;
+    }
+    let Some(sc_sym_id) = symbol_constructor_type_symbol(ctx) else {
+        return false;
+    };
+    if any_declaration_matches(ctx, sc_sym_id, |_owner_binder, arena, decl_idx| {
+        interface_member_declared_symbol_kind(arena, decl_idx, member_name) == Some(true)
+    }) {
+        return false;
+    }
+    any_declaration_matches(ctx, sc_sym_id, |_owner_binder, arena, decl_idx| {
+        interface_member_declared_symbol_kind(arena, decl_idx, member_name) == Some(false)
+    })
 }
 
 /// Look up a symbol preferring the binder of its authoritative declaration
@@ -345,9 +504,50 @@ pub(crate) fn symbol_is_unique_symbol_binding(ctx: &CheckerContext<'_>, sym_id: 
 pub(crate) fn symbol_is_wide_symbol_binding(ctx: &CheckerContext<'_>, sym_id: SymbolId) -> bool {
     let sym_id = follow_import_aliases(ctx, sym_id);
     any_declaration_matches(ctx, sym_id, |owner_binder, arena, decl_idx| {
-        !declaration_is_unique_symbol_binding(ctx, owner_binder, arena, decl_idx)
-            && declaration_has_nonunique_symbol_annotation(arena, decl_idx)
+        (!declaration_is_unique_symbol_binding(ctx, owner_binder, arena, decl_idx)
+            && declaration_has_nonunique_symbol_annotation(arena, decl_idx))
+            || declaration_has_wide_type_query_annotation(ctx, owner_binder, arena, decl_idx)
     })
+}
+
+/// Does `decl_idx`'s own type annotation resolve, syntactically, to `typeof
+/// Symbol.<member>` where `<member>` is a plain (non-unique) `symbol`-typed
+/// member of the merged `SymbolConstructor` interface? xstate's own
+/// interop-convention re-export (`export const symbolObservable: typeof
+/// Symbol.observable = ...`) is exactly this shape: the const's annotation is
+/// a type query, not a literal `symbol` keyword, so
+/// `declaration_has_nonunique_symbol_annotation`'s syntactic match on the
+/// annotation node never fires for it.
+fn declaration_has_wide_type_query_annotation(
+    ctx: &CheckerContext<'_>,
+    owner_binder: &BinderState,
+    arena: &NodeArena,
+    decl_idx: NodeIndex,
+) -> bool {
+    let Some(node) = arena.get(decl_idx) else {
+        return false;
+    };
+    let type_annotation = if node.kind == syntax_kind_ext::VARIABLE_DECLARATION {
+        let Some(var_decl) = arena.get_variable_declaration(node) else {
+            return false;
+        };
+        var_decl.type_annotation
+    } else {
+        return false;
+    };
+    if !type_annotation.is_some() {
+        return false;
+    }
+    let Some(ann_node) = arena.get(type_annotation) else {
+        return false;
+    };
+    if ann_node.kind != syntax_kind_ext::TYPE_QUERY {
+        return false;
+    }
+    let Some(type_query) = arena.get_type_query(ann_node) else {
+        return false;
+    };
+    wide_well_known_symbol_member_key(ctx, arena, owner_binder, type_query.expr_name).is_some()
 }
 
 fn declaration_is_unique_symbol_binding(
@@ -643,6 +843,7 @@ pub(crate) fn symbol_binding_property_atom(
     any_declaration_matches(ctx, sym_id, |owner_binder, arena, decl_idx| {
         declaration_is_unique_symbol_binding(ctx, owner_binder, arena, decl_idx)
             || declaration_has_nonunique_symbol_annotation(arena, decl_idx)
+            || declaration_has_wide_type_query_annotation(ctx, owner_binder, arena, decl_idx)
     })
     .then(|| ctx.types.intern_string(&unique_symbol_binding_name(sym_id)))
 }
@@ -680,6 +881,7 @@ pub(crate) fn computed_property_name_atom_in_arena(
             && identifier_resolves_to_unshadowed_global_in_context(
                 ctx, arena, binder, parts.base, "Symbol",
             )
+            && !symbol_constructor_member_is_wide(ctx, member)
         {
             return Some(ctx.types.intern_string(&format!("[Symbol.{member}]")));
         }

--- a/crates/tsz-checker/tests/wide_symbol_computed_member_index_signature_tests.rs
+++ b/crates/tsz-checker/tests/wide_symbol_computed_member_index_signature_tests.rs
@@ -1,10 +1,19 @@
 //! Adjacent-case matrix for issue #16307: a computed member keyed by a plain
 //! (non-unique) `symbol` must route into the containing type's symbol index
 //! signature, not mint a synthetic named member.
-use tsz_checker::test_utils::check_source_diagnostics;
+use tsz_checker::CheckerOptions;
+use tsz_checker::test_utils::{
+    check_source_diagnostics, check_source_with_libs, load_default_lib_files,
+};
 
 fn assert_clean(source: &str) {
     let diags = check_source_diagnostics(source);
+    assert!(diags.is_empty(), "expected exit 0 like tsc, got: {diags:?}");
+}
+
+fn assert_clean_with_libs(source: &str) {
+    let libs = load_default_lib_files();
+    let diags = check_source_with_libs(source, "test.ts", CheckerOptions::default(), &libs);
     assert!(diags.is_empty(), "expected exit 0 like tsc, got: {diags:?}");
 }
 
@@ -120,5 +129,53 @@ export const bad: FromU2 = a;
         diags.iter().any(|d| d.code == 2322 || d.code == 2741),
         "unique-symbol-keyed interfaces must not unify via a shared symbol \
          index signature, got: {diags:?}"
+    );
+}
+
+#[test]
+fn well_known_symbol_syntax_keyed_by_a_wide_global_augmentation_routes_to_index() {
+    // Adjacent case for #16307's own corpus witness (xstate's `Symbol.
+    // observable` interop convention): the literal `Symbol.<member>` syntax
+    // — not an identifier alias — routes to the symbol index signature when
+    // `<member>` is a user global augmentation typed plain `symbol`, exactly
+    // like the identifier-keyed cases above.
+    assert_clean_with_libs(
+        r#"
+declare global {
+  interface SymbolConstructor {
+    readonly observable: symbol;
+  }
+}
+
+interface Explicit { [key: symbol]: number }
+declare const e: Explicit;
+
+interface Implicit { [Symbol.observable]: number }
+declare const i: Implicit;
+
+export const implicitToExplicit: Explicit = i;
+export const explicitToImplicit: Implicit = e;
+"#,
+    );
+}
+
+#[test]
+fn well_known_symbol_syntax_for_a_real_well_known_keeps_named_identity() {
+    // Negative control: `Symbol.iterator` (and any genuine `unique
+    // symbol`-typed `SymbolConstructor` member) must keep minting its own
+    // literal `[Symbol.iterator]` named key, not fold into the wide-symbol
+    // index-signature path the new global-augmentation leg added.
+    let source = r#"
+interface HasIterator { [Symbol.iterator](): number }
+interface Other { other(): number }
+declare const h: HasIterator;
+export const bad: Other = h;
+"#;
+    let libs = load_default_lib_files();
+    let diags = check_source_with_libs(source, "test.ts", CheckerOptions::default(), &libs);
+    assert!(
+        diags.iter().any(|d| d.code == 2322 || d.code == 2741),
+        "Symbol.iterator must keep its own named identity, not unify with an \
+         unrelated interface via a symbol index signature, got: {diags:?}"
     );
 }


### PR DESCRIPTION
Follow-up to #16319, which routed an identifier-keyed plain-`symbol` computed member into the containing type's symbol index signature but disclosed a remaining gap: `[Symbol.NAME]` written as literal property-access syntax was still always treated as a well-known literal key, even when `NAME` is a user `declare global { interface SymbolConstructor { ... } }` augmentation typed plain `symbol` (xstate's `SymbolConstructor.observable: symbol` interop convention) rather than a genuine `unique symbol` well-known (`Symbol.iterator` and friends).

## Structural rule

When `Symbol.NAME`'s resolved member on the merged `SymbolConstructor` interface is `unique symbol`, tsc mints the literal `[Symbol.NAME]` key; when it is plain `symbol`, tsc routes it into the symbol index signature instead, same as any other wide-`symbol` key.

`crates/tsz-checker/src/types/computed_names.rs` (checker) now resolves `SymbolConstructor`'s merged declarations and checks each member's declared kind before deciding whether the literal-key shortcut applies. One real trap along the way: `declare global` augmentations are **not** merged into the target symbol's own `declarations` list — the binder tracks them separately in `global_augmentations` (see `resolve_array_global_augmentation_property`'s `Array` analogue), so a naive `symbol.all_declarations()` walk silently misses a user's own `SymbolConstructor` augmentation.

Also extends `symbol_is_wide_symbol_binding`/`symbol_binding_property_atom` to recognize a binding annotated with a type query that resolves to a wide `Symbol.NAME` (e.g. `const alias: typeof Symbol.observable = ...`), matching the same structural rule for the aliased-identifier form — this is exactly xstate's own `symbolObservable` re-export convention.

## Adjacent-case matrix

New tests in `wide_symbol_computed_member_index_signature_tests.rs`:
- `[Symbol.observable]` (literal syntax, user global augmentation) versus explicit `[key: symbol]` interface: mutually assignable — was previously TS2741/TS2322.
- Negative control: `[Symbol.iterator]` (real well-known) still keeps its own named identity — must NOT unify with an unrelated interface via the index signature.

## Known remaining gap (disclosed)

A class member written **directly** as `[Symbol.NAME]()` (not via an aliasing identifier) is still not recognized as symbol-named for structural comparison against a target's symbol index signature — `symbol_binding_property_atom`'s predicates don't yet recognize a `SymbolConstructor` member's own `PROPERTY_SIGNATURE` declaration (only `VARIABLE_DECLARATION`/`PROPERTY_DECLARATION`/`PARAMETER`). xstate's own `Actor` class reaches this through the `symbolObservable` alias (now fixed by this PR) rather than the bare form, so the corpus witness is closed, but the bare-form case is a real adjacent case for a future slice.

## Goal
Goal: green

## Verification
- `cargo test -p tsz-checker --test wide_symbol_computed_member_index_signature_tests` — **8/8 passed** (2 new, 6 pre-existing from #16319 unaffected).
- `cargo test -p tsz-checker --lib -- symbol` — **424/424 passed, 0 failed** (targeted symbol-family suite; the full `--lib` run was started but killed after 15+ min per the board's documented hang risk on this suite, unrelated to this diff).
- `cargo clippy -p tsz-checker --lib --all-targets -- -D warnings` — clean.
- `cargo fmt -p tsz-checker -- --check` — clean.
- `python3 scripts/arch/arch_guard.py` — passes.
- Not run: conformance / emit / fourslash. This is an additive structural-routing change for a case (a `Symbol.NAME`-syntax computed name keyed by a `symbol`-typed `SymbolConstructor` global augmentation) not exercised by any currently-passing committed-corpus fixture, following the same disclosed-evidence pattern #16319 itself used.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

Closes the `Symbol.observable` literal-syntax half of #16307 (the identifier-keyed half landed in #16319).