### PR TITLE
fix(checker): class-typed TS2741 targets carry the declared-here pointer

### DIFF
--- a/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
+++ b/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
@@ -92,7 +92,7 @@ impl<'a> CheckerState<'a> {
 
     /// `(start, length, file)` for a member symbol's own declaration, used when
     /// the owner's declaration does not carry a member list the walk above can
-    /// read (a class records its members on the symbol instead).
+    /// read.
     ///
     /// A `StableLocation` resolves by `(pos, end)` against whichever arena the
     /// stamped file index names, and falls back to the current arena when the
@@ -186,18 +186,27 @@ impl<'a> CheckerState<'a> {
     }
 
     /// The name node of a property-like member declaration.
+    ///
+    /// An interface/type-literal member (`PROPERTY_SIGNATURE`/
+    /// `METHOD_SIGNATURE`) stores its name on `SignatureData`; a class member
+    /// (`PROPERTY_DECLARATION`/`METHOD_DECLARATION`) stores it on the
+    /// distinct `PropertyDeclData`/`MethodDeclData` instead, so each kind
+    /// needs its own accessor rather than one shared `get_signature` call.
     fn member_name_node(arena: &NodeArena, member_idx: NodeIndex) -> Option<NodeIndex> {
         use tsz_parser::parser::syntax_kind_ext;
 
         let node = arena.get(member_idx)?;
-        if node.kind != syntax_kind_ext::PROPERTY_SIGNATURE
-            && node.kind != syntax_kind_ext::PROPERTY_DECLARATION
-            && node.kind != syntax_kind_ext::METHOD_SIGNATURE
-            && node.kind != syntax_kind_ext::METHOD_DECLARATION
+        let name = if node.kind == syntax_kind_ext::PROPERTY_SIGNATURE
+            || node.kind == syntax_kind_ext::METHOD_SIGNATURE
         {
+            arena.get_signature(node)?.name
+        } else if node.kind == syntax_kind_ext::PROPERTY_DECLARATION {
+            arena.get_property_decl(node)?.name
+        } else if node.kind == syntax_kind_ext::METHOD_DECLARATION {
+            arena.get_method_decl(node)?.name
+        } else {
             return None;
-        }
-        let name = arena.get_signature(node)?.name;
+        };
         name.is_some().then_some(name)
     }
 
@@ -229,9 +238,11 @@ impl<'a> CheckerState<'a> {
         Some((start, node.end.saturating_sub(start)))
     }
 
-    /// The node tsc underlines for a member: a property member points at its
-    /// *name* (`y` in `y: number;`), a method member at the whole member
-    /// (`run(): void;`).
+    /// The node tsc underlines for a member: a property points at its *name*
+    /// (`y` in `y: number;`), an interface/type-literal method signature at
+    /// the whole member (`run(): void;`) — but a *class* method declaration
+    /// points at its name only (`run` in `run(): void {}`), pinned against
+    /// `typescript@7.0.2`.
     fn member_anchor_for_kind(
         arena: &NodeArena,
         member_idx: NodeIndex,
@@ -240,12 +251,7 @@ impl<'a> CheckerState<'a> {
         use tsz_parser::parser::syntax_kind_ext;
 
         match arena.get(member_idx).map(|node| node.kind) {
-            Some(kind)
-                if kind == syntax_kind_ext::METHOD_SIGNATURE
-                    || kind == syntax_kind_ext::METHOD_DECLARATION =>
-            {
-                member_idx
-            }
+            Some(kind) if kind == syntax_kind_ext::METHOD_SIGNATURE => member_idx,
             _ => name_idx,
         }
     }

--- a/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
+++ b/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
@@ -182,3 +182,32 @@ fn generic_target_points_at_the_declaration_in_the_generic_body() {
     assert_eq!(message, "'label' is declared here.");
     assert_eq!(span_text(source, start, length), "label");
 }
+
+/// A class-typed target points at its own field declaration. The owner walk
+/// already resolved the class's own symbol correctly; the gap was
+/// `member_name_node` reading a class member's name through `get_signature`
+/// (the accessor for an interface/type-literal `PROPERTY_SIGNATURE`), which
+/// returns `None` for a class's `PROPERTY_DECLARATION` — its name lives on
+/// the distinct `PropertyDeclData` instead.
+#[test]
+fn single_missing_class_property_points_at_its_declaration() {
+    let source = "class C { a: number = 0; b: number = 0; }\nconst c: C = { a: 1 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, message) = declared_here(&diagnostic);
+    assert_eq!(message, "'b' is declared here.");
+    assert_eq!(span_text(source, start, length), "b");
+}
+
+/// Unlike an interface/type-literal method signature (underlined whole,
+/// `run(): void;`), tsc underlines only a *class* method's name — pinned
+/// against `typescript@7.0.2`: `class HasRun { keep = 0; run(): void {} }`
+/// underlines exactly `run` (3 chars), not the method body.
+#[test]
+fn missing_class_method_member_points_at_the_method_name_only() {
+    let source =
+        "class HasRun { keep: number = 0; run(): void {} }\nconst h: HasRun = { keep: 1 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, message) = declared_here(&diagnostic);
+    assert_eq!(message, "'run' is declared here.");
+    assert_eq!(span_text(source, start, length), "run");
+}


### PR DESCRIPTION
Closes the class-typed-target gap #16322 (`missing_property_declared_here.rs`) wrote up on #16316: a class-typed `TS2741` target ("`Property 'b' is missing in type '{ a: number; }' but required in type 'C'.`") produced no `TS2728` `'b' is declared here.` pointer at all.

## Structural rule

When exactly one required property of a class-typed target is unmatched, `tsc`'s `reportUnmatchedProperty` attaches a `TS2728` related entry at the *name node* of that property's own declaration — same rule as the interface/type-literal case #16322 already implemented, just not reaching class declarations.

#16322's own write-up diagnosed the gap as "the owner walk does not reach a class's members from the resolved symbol here." That diagnosis pointed at the wrong layer: `resolve_type_to_symbol_id` already resolves a class-typed target to the class's own symbol correctly, and `declaration_member_list` already has a working `CLASS_DECLARATION` arm that returns the class's member list. The real bug is one level deeper, in `member_name_node`: it read every member's name through `arena.get_signature(node)`, which only returns `Some` for `PROPERTY_SIGNATURE`/`METHOD_SIGNATURE` (interface/type-literal members, backed by `SignatureData`). A class's `PROPERTY_DECLARATION`/`METHOD_DECLARATION` store their name on the distinct `PropertyDeclData`/`MethodDeclData` structs instead, so `get_signature` silently returned `None` for every class member and the member-list walk found nothing to anchor on — even though the member list itself was right there.

Owner layer: checker's assignability renderer (`error_reporter/missing_property_declared_here.rs`), same file #16322 built.

## What changed

- `member_name_node` now dispatches per node kind: `get_signature` for `PROPERTY_SIGNATURE`/`METHOD_SIGNATURE`, `get_property_decl` for `PROPERTY_DECLARATION`, `get_method_decl` for `METHOD_DECLARATION`.
- `member_anchor_for_kind`: while investigating, the oracle showed a second asymmetry — an interface method *signature* underlines the whole member (`run(): void;`), but a class method *declaration* underlines only its name (`run`). Narrowed the whole-member-underline branch to `METHOD_SIGNATURE` only.
- Removed a first-pass fallback I added and then found unnecessary once probing showed `resolve_type_to_symbol_id` already succeeds for class-typed targets without it — no dead code left behind.

## Oracle evidence (`typescript@7.0.2`)

```
class C { a: number = 0; b: number = 0; }
const c: C = { a: 1 };
```
→ `TS2741` + `'b' is declared here.` pointing at `b` (1 char).

```
class HasRun { keep: number = 0; run(): void {} }
const h: HasRun = { keep: 1 };
```
→ `TS2741` + `'run' is declared here.` pointing at `run` (3 chars) — **not** the whole `run(): void {}` member, unlike the interface-method-signature case #16322 already covers.

## Deliberately not covered

Cross-file declaration (the other gap #16322 wrote up: a `StableLocation` not resolving to its declaring arena from this call site) is untouched — separate mechanism, not exercised by this fix.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib missing_property_declared_here`: 10/10 passed (8 pre-existing + 2 new: class field, class method-name-only).
- `cargo clippy -p tsz-checker --lib --all-targets -- -D warnings`: clean (also re-run via the pre-commit hook's own `-p tsz-checker` gate).
- `python3 scripts/arch/arch_guard.py`: `Architecture guardrails passed.`
- `cargo fmt --all`: applied, clean.
- `cargo test -p tsz-checker --lib` (full suite, 9320 tests): 9319 passed, 1 failed — `ts2303_tests::recursive_export_assignment_self_import_reports_ts2303`, which is `scripts/ci/known-failures.txt:127`, a pre-existing baselined failure unrelated to this change (also called out as pre-existing in #16322's own verification). No other test moved. The change touches only private helpers used exclusively by this file's two call sites, so the blast radius is contained to `missing_property_declared_here_tests`.
- Not run: conformance / emit / fourslash. This only adds/corrects `related_information` on an existing `TS2741`; the conformance fingerprint compares primary codes and the emit gate compares JS/DTS bytes, neither of which observes related entries — same rationale #16322 gave for the same reason.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_013AUGj8XbJxK1pYJetJS7tS)_