### PR TITLE
fix(checker): a class member keyed by a plain `symbol` contributes a symbol index signature

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -151,6 +151,8 @@ mod class_namespace_static_relation_routing_arch_tests;
 mod class_static_init_self_new_tests;
 #[path = "tests/class_static_side_relation_routing_arch_tests.rs"]
 mod class_static_side_relation_routing_arch_tests;
+#[path = "tests/class_wide_symbol_member_index_tests.rs"]
+mod class_wide_symbol_member_index_tests;
 #[path = "tests/closure_destructuring_top_level_diagnostics_tests.rs"]
 mod closure_destructuring_top_level_diagnostics_tests;
 #[path = "tests/comlink_row_regression_tests.rs"]

--- a/crates/tsz-checker/src/tests/class_wide_symbol_member_index_tests.rs
+++ b/crates/tsz-checker/src/tests/class_wide_symbol_member_index_tests.rs
@@ -199,6 +199,29 @@ export { call };
 }
 
 #[test]
+fn classifying_the_key_does_not_re_report_its_value_position_diagnostics() {
+    // Regression guard for the routing's one hazard: classifying the key
+    // evaluates its expression in VALUE position, and several value-position
+    // diagnostics are suppressed only inside a computed-property-name context
+    // (`is_in_ambient_computed_property_context`). An `abstract` member is
+    // emit-free, so tsc reports nothing for its key; classifying without
+    // publishing that context re-fired the diagnostic here.
+    //
+    // The cross-file `import type` form this mirrors is
+    // `conformance/externalModules/typeOnly/computedPropertyName.ts`; the
+    // single-file harness cannot resolve a module specifier, so the ambient
+    // spelling stands in — both reach the same suppression.
+    assert_clean(
+        r#"
+declare const hookKey: symbol;
+declare class Ambient { [hookKey]: number; }
+abstract class Partial2 { abstract [hookKey](): void; }
+export { Partial2 };
+"#,
+    );
+}
+
+#[test]
 fn wide_symbol_key_routing_ignores_the_binder_name() {
     // Same structural shape as the first test with every identifier renamed;
     // the routing must be driven by the declared type, not by any particular

--- a/crates/tsz-checker/src/tests/class_wide_symbol_member_index_tests.rs
+++ b/crates/tsz-checker/src/tests/class_wide_symbol_member_index_tests.rs
@@ -1,0 +1,216 @@
+//! Adjacent-case coverage for #16307's class leg: a class member whose
+//! computed key resolves to a plain (non-unique) `symbol` binding contributes
+//! a `[key: symbol]: V` index signature to the class instance shape rather
+//! than a named member.
+//!
+//! Structural rule, verified against the pinned `tsc` 7.0.2 oracle:
+//! - A wide-`symbol` key on a class property, method, getter or setter routes
+//!   into the shape's symbol index signature, exactly as the object-literal
+//!   and interface lowering paths already do. Two declarations keyed off
+//!   DIFFERENT `symbol` bindings therefore stay mutually assignable, which is
+//!   the whole point of tsc's symbol-index lowering.
+//! - A `unique symbol` key still mints a named late-bound member, so a
+//!   mismatch between two distinct `unique symbol` keys still reports.
+//! - A string/number literal `const` key still mints an ordinary named member.
+//!
+//! The binder names vary across cases on purpose: the routing must be driven
+//! by the key's declared type, never by the identifier the user chose.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+fn assert_clean(source: &str) {
+    let diags = check_source_diagnostics(source);
+    assert!(diags.is_empty(), "expected no diagnostics, got: {diags:?}");
+}
+
+#[test]
+fn class_method_wide_symbol_key_satisfies_symbol_index_signature_target() {
+    // The witness shape behind xstate's `class Actor implements
+    // InteropObservable`: the target declares an explicit symbol index
+    // signature, the class keys its member off an unrelated `symbol` binding.
+    assert_clean(
+        r#"
+declare const handleKey: symbol;
+interface Target { [key: symbol]: () => number }
+class Widget { [handleKey](): number { return 1; } }
+declare function want(target: Target): void;
+declare const widget: Widget;
+want(widget);
+"#,
+    );
+}
+
+#[test]
+fn class_and_interface_keyed_off_different_wide_symbols_stay_assignable() {
+    // Neither side writes an explicit index signature. Both keys are plain
+    // `symbol`, and they are DIFFERENT bindings — under the old synthetic
+    // `__symbol_<file>_<sym>` named member these only matched when the two
+    // placeholder atoms happened to collide.
+    assert_clean(
+        r#"
+declare const producerKey: symbol;
+declare const consumerKey: symbol;
+interface Producer { [consumerKey]: () => number }
+class Consumer { [producerKey](): number { return 1; } }
+declare function want(producer: Producer): void;
+declare const consumer: Consumer;
+want(consumer);
+"#,
+    );
+}
+
+#[test]
+fn class_property_wide_symbol_key_is_read_through_an_unrelated_symbol() {
+    // The index signature must be readable by ANY symbol, not only the
+    // binding that declared it — that is what distinguishes a real index
+    // signature from a late-bound named member.
+    assert_clean(
+        r#"
+declare const slotKey: symbol;
+declare const lookupKey: symbol;
+class Store { [slotKey]: number = 1; }
+declare const store: Store;
+const read: number = store[lookupKey];
+export { read };
+"#,
+    );
+}
+
+#[test]
+fn class_getter_wide_symbol_key_routes_to_symbol_index_signature() {
+    assert_clean(
+        r#"
+declare const viewKey: symbol;
+declare const probeKey: symbol;
+class Panel { get [viewKey](): number { return 1; } }
+declare const panel: Panel;
+const read: number = panel[probeKey];
+export { read };
+"#,
+    );
+}
+
+#[test]
+fn class_setter_wide_symbol_key_routes_to_symbol_index_signature() {
+    assert_clean(
+        r#"
+declare const sinkKey: symbol;
+declare const writeKey: symbol;
+class Drain { set [sinkKey](value: number) {} }
+declare const drain: Drain;
+drain[writeKey] = 3;
+"#,
+    );
+}
+
+#[test]
+fn two_wide_symbol_class_members_union_their_index_value_types() {
+    // Several contributors widen the one index signature rather than each
+    // minting a member of its own.
+    assert_clean(
+        r#"
+declare const firstKey: symbol;
+declare const secondKey: symbol;
+declare const anyKey: symbol;
+class Pair { [firstKey]: number = 1; [secondKey]: string = ""; }
+declare const pair: Pair;
+const read: number | string = pair[anyKey];
+export { read };
+"#,
+    );
+}
+
+#[test]
+fn wide_symbol_class_member_leaves_ordinary_named_members_alone() {
+    // The symbol index must not swallow string-named members, and `keyof`
+    // must still surface them.
+    assert_clean(
+        r#"
+declare const auxKey: symbol;
+class Record2 { [auxKey]: number = 1; label: string = ""; }
+declare const rec: Record2;
+const label: string = rec.label;
+type Keys = keyof Record2;
+const key: Keys = "label";
+export { label, key };
+"#,
+    );
+}
+
+#[test]
+fn wide_symbol_index_signature_is_inherited_by_a_subclass() {
+    assert_clean(
+        r#"
+declare const baseKey: symbol;
+declare const probeKey: symbol;
+class Origin { [baseKey](): number { return 1; } }
+class Extended extends Origin { extra: number = 1; }
+declare const extended: Extended;
+const call: () => number = extended[probeKey];
+export { call };
+"#,
+    );
+}
+
+#[test]
+fn unique_symbol_class_key_still_mints_a_named_member() {
+    // Negative control for the routing: a `unique symbol` key is late-bound to
+    // a NAMED member, so two distinct unique-symbol keys stay unrelated and
+    // the missing-property diagnostic must survive. If the wide-symbol routing
+    // over-applied to unique symbols this would silently go clean.
+    let diags = codes(
+        r#"
+declare const declaredKey: unique symbol;
+declare const otherKey: unique symbol;
+interface Wanted { [declaredKey]: number }
+class Offered { [otherKey]: number = 1; }
+declare function want(wanted: Wanted): void;
+declare const offered: Offered;
+want(offered);
+"#,
+    );
+    assert!(
+        diags.contains(&2345) || diags.contains(&2741),
+        "a unique-symbol key must stay a named member, so the mismatch still reports; got: {diags:?}"
+    );
+}
+
+#[test]
+fn literal_const_class_key_still_mints_a_named_member() {
+    // Negative control for the key-type test: a string-literal `const` key is
+    // an ordinary named member, reachable by its literal name and NOT by an
+    // arbitrary symbol.
+    assert_clean(
+        r#"
+const literalKey = "tag";
+class Tagged { [literalKey](): number { return 1; } }
+declare const tagged: Tagged;
+const call: () => number = tagged.tag;
+export { call };
+"#,
+    );
+}
+
+#[test]
+fn wide_symbol_key_routing_ignores_the_binder_name() {
+    // Same structural shape as the first test with every identifier renamed;
+    // the routing must be driven by the declared type, not by any particular
+    // identifier text.
+    assert_clean(
+        r#"
+declare const zzTopMarker: symbol;
+interface QqBravo { [key: symbol]: () => number }
+class Xylophone { [zzTopMarker](): number { return 1; } }
+declare function accept(value: QqBravo): void;
+declare const instance: Xylophone;
+accept(instance);
+"#,
+    );
+}

--- a/crates/tsz-checker/src/types/class_type/helpers.rs
+++ b/crates/tsz-checker/src/types/class_type/helpers.rs
@@ -546,10 +546,10 @@ impl<'a> CheckerState<'a> {
         // only reach this function when the name failed to resolve to one)
         // contributes a `[k: symbol]: V` index signature, mirroring the
         // object-literal routing in
-        // `object_literal_computed_key_is_wide_symbol`. `get_index_key_kind`
+        // `computed_member_key_is_wide_symbol`. `get_index_key_kind`
         // below has no symbol case, so this must be checked first: a
         // symbol-typed key is otherwise silently dropped from every bucket.
-        if self.object_literal_computed_key_is_wide_symbol(name_idx) {
+        if self.computed_member_key_is_wide_symbol(name_idx) {
             self.merge_union_index_signature(
                 symbol_index,
                 class_type::static_late_bound_index_signature(TypeId::SYMBOL, value_type),

--- a/crates/tsz-checker/src/types/class_type/helpers.rs
+++ b/crates/tsz-checker/src/types/class_type/helpers.rs
@@ -455,6 +455,64 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Does this class member's name node key off a plain (non-unique)
+    /// `symbol` binding — `class C { [s]() {} }` with `declare const s: symbol`,
+    /// or `Symbol.NAME` where `NAME` is a wide `SymbolConstructor` global
+    /// augmentation?
+    ///
+    /// Such a member contributes a `[key: symbol]: V` index signature to the
+    /// class instance shape instead of a named member, matching what the
+    /// object-literal and interface lowering paths already do. Without this the
+    /// member is stashed under a synthetic `__symbol_<file>_<sym>` atom that
+    /// only ever matches another declaration whose key resolves to the SAME
+    /// binding, so a class and the interface it implements — keyed off two
+    /// different `symbol` bindings, as tsc allows — stop being mutually
+    /// assignable.
+    pub(super) fn class_member_computed_key_is_wide_symbol(&mut self, name_idx: NodeIndex) -> bool {
+        if !self.computed_member_key_is_wide_symbol(name_idx) {
+            return false;
+        }
+        // `Symbol.NAME` written as property-access syntax is excluded even when
+        // `NAME` is declared plain `symbol`: tsc derives a NAMED member from the
+        // syntactic well-known shape (`isWellKnownSymbolSyntactically`) before it
+        // consults the key's type at all, so `class C { [Symbol.observable]() {} }`
+        // gets no symbol index signature and `c[someOtherSymbol]` stays TS7053.
+        // Every other wide-`symbol` key — a bare identifier, or a property access
+        // whose base is not the unshadowed global `Symbol` — does route to the
+        // index signature. A genuine well-known (`Symbol.iterator`, `unique
+        // symbol`-typed) never reaches here, having failed the wide-key test above.
+        let Some(name_node) = self.ctx.arena.get(name_idx) else {
+            return false;
+        };
+        let Some(computed) = self.ctx.arena.get_computed_property(name_node) else {
+            return false;
+        };
+        crate::types_domain::computed_names::wide_well_known_symbol_member_key(
+            &self.ctx,
+            self.ctx.arena,
+            self.ctx.binder,
+            computed.expression,
+        )
+        .is_none()
+    }
+
+    /// Fold a wide-`symbol`-keyed class member's value type into the class
+    /// instance shape's symbol index signature.
+    ///
+    /// Several such members union their value types, exactly as tsc widens a
+    /// late-bound index signature over every contributing declaration; the
+    /// signature stays `readonly` only while every contributor is.
+    pub(super) fn merge_class_wide_symbol_member_index(
+        &mut self,
+        symbol_index: &mut Option<IndexSignature>,
+        value_type: TypeId,
+        readonly: bool,
+    ) {
+        let mut index = class_type::static_late_bound_index_signature(TypeId::SYMBOL, value_type);
+        index.readonly = readonly;
+        self.merge_union_index_signature(symbol_index, index);
+    }
+
     pub(super) fn merge_index_signature_from_unresolved_computed_name(
         &mut self,
         name_idx: NodeIndex,

--- a/crates/tsz-checker/src/types/class_type/helpers.rs
+++ b/crates/tsz-checker/src/types/class_type/helpers.rs
@@ -469,7 +469,22 @@ impl<'a> CheckerState<'a> {
     /// different `symbol` bindings, as tsc allows — stop being mutually
     /// assignable.
     pub(super) fn class_member_computed_key_is_wide_symbol(&mut self, name_idx: NodeIndex) -> bool {
-        if !self.computed_member_key_is_wide_symbol(name_idx) {
+        // Classifying the key evaluates its expression in VALUE position, and a
+        // value-position evaluation reports its own diagnostics. Several of those
+        // are suppressed only inside a computed-property-name context —
+        // `is_in_ambient_computed_property_context` reads
+        // `ctx.checking_computed_property_name` and returns early for an
+        // interface/type-literal member, an ambient class, and an `abstract` or
+        // `declare` member. Publishing that context here is what keeps a
+        // type-only-imported key from re-reporting TS1361 on
+        // `abstract class F { abstract [onInit](): void }`, which is emit-free and
+        // clean under tsc. Restored unconditionally so a nested classification
+        // cannot leak this frame's node.
+        let prev_checking = self.ctx.checking_computed_property_name;
+        self.ctx.checking_computed_property_name = Some(name_idx);
+        let is_wide = self.computed_member_key_is_wide_symbol(name_idx);
+        self.ctx.checking_computed_property_name = prev_checking;
+        if !is_wide {
             return false;
         }
         // `Symbol.NAME` written as property-access syntax is excluded even when

--- a/crates/tsz-checker/src/types/class_type/instance.rs
+++ b/crates/tsz-checker/src/types/class_type/instance.rs
@@ -43,6 +43,10 @@ pub(super) struct DeferredAccessor<'b> {
     pub(super) is_getter: bool,
     pub(super) name_atom: Atom,
     pub(super) is_symbol_named: bool,
+    /// The key is a plain (non-unique) `symbol` binding, so the accessor's
+    /// resolved type folds into the shape's symbol index signature instead of
+    /// becoming a named accessor member.
+    pub(super) keys_symbol_index: bool,
     pub(super) visibility: Visibility,
     pub(super) declaration_order: u32,
 }
@@ -537,6 +541,8 @@ impl<'a> CheckerState<'a> {
                         continue;
                     };
                     let is_symbol_named = self.class_member_name_is_symbol_named(prop.name);
+                    let keys_symbol_index =
+                        self.class_member_computed_key_is_wide_symbol(prop.name);
                     let name_atom = self.ctx.types.intern_string(&name);
                     let is_readonly = self.has_readonly_modifier(&prop.modifiers)
                         || self.jsdoc_has_readonly_tag(member_idx);
@@ -679,6 +685,21 @@ impl<'a> CheckerState<'a> {
                     };
                     self.ctx.node_types.insert(member_idx.0, type_id);
 
+                    // A wide-`symbol` key contributes to the shape's symbol
+                    // index signature rather than a named member; the synthetic
+                    // `__symbol_<file>_<sym>` atom must not reach `properties`,
+                    // or the member would only match a declaration keyed off the
+                    // very same binding.
+                    if keys_symbol_index {
+                        b.set_has_late_bound_members();
+                        self.merge_class_wide_symbol_member_index(
+                            &mut b.symbol_index,
+                            type_id,
+                            is_readonly,
+                        );
+                        continue;
+                    }
+
                     b.properties.insert(
                         name_atom,
                         class_type::class_member_property(
@@ -745,6 +766,8 @@ impl<'a> CheckerState<'a> {
                         continue;
                     };
                     let is_symbol_named = self.class_member_name_is_symbol_named(accessor.name);
+                    let keys_symbol_index =
+                        self.class_member_computed_key_is_wide_symbol(accessor.name);
                     let name_atom = self.ctx.types.intern_string(&name);
                     let visibility = self.get_member_visibility(&accessor.modifiers, accessor.name);
                     b.deferred_accessors.push(DeferredAccessor {
@@ -753,6 +776,7 @@ impl<'a> CheckerState<'a> {
                         is_getter: k == syntax_kind_ext::GET_ACCESSOR,
                         name_atom,
                         is_symbol_named,
+                        keys_symbol_index,
                         visibility,
                         declaration_order,
                     });
@@ -1045,6 +1069,11 @@ impl<'a> CheckerState<'a> {
                 FxHashSet::with_capacity_and_hasher(partial_props.len(), Default::default());
             partial_prop_names.extend(partial_props.iter().map(|prop| prop.name));
             for (_, method, declaration_order) in &b.deferred_methods {
+                // Wide-`symbol`-keyed methods have no named member to placehold;
+                // they reach `this` through the symbol index signature.
+                if self.class_member_computed_key_is_wide_symbol(method.name) {
+                    continue;
+                }
                 if let Some(name) = self.get_property_name_resolved(method.name) {
                     let is_symbol_named = self.class_member_name_is_symbol_named(method.name);
                     let name_atom = self.ctx.types.intern_string(&name);
@@ -1190,6 +1219,20 @@ impl<'a> CheckerState<'a> {
                     callable_type,
                     method.question_token,
                 );
+                // A wide-`symbol`-keyed method contributes to the shape's symbol
+                // index signature rather than a named member, so that a class
+                // and the interface it implements stay mutually assignable when
+                // each keys off a DIFFERENT `symbol` binding — which is the
+                // whole point of tsc's symbol-index lowering.
+                if self.class_member_computed_key_is_wide_symbol(method.name) {
+                    b.set_has_late_bound_members();
+                    self.merge_class_wide_symbol_member_index(
+                        &mut b.symbol_index,
+                        callable_or_undefined,
+                        false,
+                    );
+                    continue;
+                }
                 let Some(name) = self.get_property_name_resolved(method.name) else {
                     if self
                         .ctx
@@ -1286,6 +1329,12 @@ impl<'a> CheckerState<'a> {
             let mut placeholder_seen: FxHashSet<Atom> =
                 base_props.iter().map(|prop| prop.name).collect();
             for ad in &deferred_accessors {
+                // A wide-`symbol`-keyed accessor has no named member to
+                // placehold; it reaches `this` through the symbol index
+                // signature that `b.symbol_index` already carries.
+                if ad.keys_symbol_index {
+                    continue;
+                }
                 if placeholder_seen.insert(ad.name_atom) {
                     placeholder_accessors.push(ad);
                 }
@@ -1380,6 +1429,15 @@ impl<'a> CheckerState<'a> {
                             t
                         }
                     };
+                    if deferred.keys_symbol_index {
+                        b.set_has_late_bound_members();
+                        self.merge_class_wide_symbol_member_index(
+                            &mut b.symbol_index,
+                            getter_type,
+                            false,
+                        );
+                        continue;
+                    }
                     let entry =
                         b.accessors
                             .entry(deferred.name_atom)
@@ -1419,6 +1477,15 @@ impl<'a> CheckerState<'a> {
                             None
                         })
                         .unwrap_or(TypeId::UNKNOWN);
+                    if deferred.keys_symbol_index {
+                        b.set_has_late_bound_members();
+                        self.merge_class_wide_symbol_member_index(
+                            &mut b.symbol_index,
+                            setter_type,
+                            false,
+                        );
+                        continue;
+                    }
                     let entry =
                         b.accessors
                             .entry(deferred.name_atom)

--- a/crates/tsz-checker/src/types/class_type/instance.rs
+++ b/crates/tsz-checker/src/types/class_type/instance.rs
@@ -1069,12 +1069,17 @@ impl<'a> CheckerState<'a> {
                 FxHashSet::with_capacity_and_hasher(partial_props.len(), Default::default());
             partial_prop_names.extend(partial_props.iter().map(|prop| prop.name));
             for (_, method, declaration_order) in &b.deferred_methods {
-                // Wide-`symbol`-keyed methods have no named member to placehold;
-                // they reach `this` through the symbol index signature.
-                if self.class_member_computed_key_is_wide_symbol(method.name) {
-                    continue;
-                }
                 if let Some(name) = self.get_property_name_resolved(method.name) {
+                    // Wide-`symbol`-keyed methods have no named member to
+                    // placehold; they reach `this` through the symbol index
+                    // signature. Tested only AFTER the name resolution above,
+                    // which owns the one value-position evaluation of the key
+                    // expression — an evaluation performed outside that context
+                    // re-reports its diagnostics (a type-only-imported key in an
+                    // ambient class re-fires TS1361).
+                    if self.class_member_computed_key_is_wide_symbol(method.name) {
+                        continue;
+                    }
                     let is_symbol_named = self.class_member_name_is_symbol_named(method.name);
                     let name_atom = self.ctx.types.intern_string(&name);
                     if partial_prop_names.insert(name_atom) {
@@ -1219,20 +1224,6 @@ impl<'a> CheckerState<'a> {
                     callable_type,
                     method.question_token,
                 );
-                // A wide-`symbol`-keyed method contributes to the shape's symbol
-                // index signature rather than a named member, so that a class
-                // and the interface it implements stay mutually assignable when
-                // each keys off a DIFFERENT `symbol` binding — which is the
-                // whole point of tsc's symbol-index lowering.
-                if self.class_member_computed_key_is_wide_symbol(method.name) {
-                    b.set_has_late_bound_members();
-                    self.merge_class_wide_symbol_member_index(
-                        &mut b.symbol_index,
-                        callable_or_undefined,
-                        false,
-                    );
-                    continue;
-                }
                 let Some(name) = self.get_property_name_resolved(method.name) else {
                     if self
                         .ctx
@@ -1255,6 +1246,28 @@ impl<'a> CheckerState<'a> {
                     }
                     continue;
                 };
+                // The key resolved to a name, but a wide-`symbol` key's name is
+                // the synthetic `__symbol_<file>_<sym>` atom, which only ever
+                // matches a declaration keyed off the SAME binding. Route the
+                // member into the shape's symbol index signature instead, so a
+                // class and the interface it implements stay mutually assignable
+                // when each keys off a DIFFERENT `symbol` binding — the whole
+                // point of tsc's symbol-index lowering. Tested after the
+                // resolution above, which owns the one value-position evaluation
+                // of the key expression; re-evaluating outside that context
+                // re-reports its diagnostics (TS1361 for a type-only-imported
+                // key in an ambient class). The unresolved-name sibling case is
+                // handled by `merge_index_signature_from_unresolved_computed_name`
+                // in the `else` arm above.
+                if self.class_member_computed_key_is_wide_symbol(method.name) {
+                    b.set_has_late_bound_members();
+                    self.merge_class_wide_symbol_member_index(
+                        &mut b.symbol_index,
+                        callable_or_undefined,
+                        false,
+                    );
+                    continue;
+                }
                 let is_symbol_named = self.class_member_name_is_symbol_named(method.name);
                 let name_atom = self.ctx.types.intern_string(&name);
                 let visibility = self.get_member_visibility(&method.modifiers, method.name);

--- a/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
@@ -146,7 +146,7 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        let name_opt = if self.object_literal_computed_key_is_wide_symbol(accessor.name) {
+        let name_opt = if self.computed_member_key_is_wide_symbol(accessor.name) {
             None
         } else {
             self.get_property_name_resolved(accessor.name)

--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -144,7 +144,7 @@ impl<'a> CheckerState<'a> {
                         self.get_type_of_node(computed.expression) == TypeId::ERROR
                     });
                 let name_opt = if computed_key_is_error
-                    || self.object_literal_computed_key_is_wide_symbol(prop.name)
+                    || self.computed_member_key_is_wide_symbol(prop.name)
                 {
                     None
                 } else {
@@ -1265,7 +1265,7 @@ impl<'a> CheckerState<'a> {
                 {
                     self.get_type_of_node(computed.expression);
                 }
-                let name_opt = if self.object_literal_computed_key_is_wide_symbol(method.name) {
+                let name_opt = if self.computed_member_key_is_wide_symbol(method.name) {
                     None
                 } else {
                     self.get_property_name_resolved(method.name)

--- a/crates/tsz-checker/src/types/computation/object_literal/symbol_key_routing.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/symbol_key_routing.rs
@@ -100,10 +100,13 @@ impl<'a> CheckerState<'a> {
         (is_string_named, is_symbol_named, single_quoted_name)
     }
 
-    pub(crate) fn object_literal_computed_key_is_wide_symbol(
-        &mut self,
-        name_idx: NodeIndex,
-    ) -> bool {
+    /// True when `name_idx` is a computed-property name whose key expression
+    /// has the wide `symbol` type. Shared by every member-bearing declaration
+    /// form — object literals, and class bodies via
+    /// `class_member_computed_key_is_wide_symbol` — because `tsc` routes such a
+    /// member into the containing type's `[key: symbol]: V` index signature
+    /// regardless of which declaration form wrote it.
+    pub(crate) fn computed_member_key_is_wide_symbol(&mut self, name_idx: NodeIndex) -> bool {
         let Some(name_node) = self.ctx.arena.get(name_idx) else {
             return false;
         };

--- a/crates/tsz-checker/src/types/computation/object_literal_circularity.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_circularity.rs
@@ -166,7 +166,7 @@ impl<'a> CheckerState<'a> {
             || elem_node.kind == syntax_kind_ext::SET_ACCESSOR
         {
             let accessor_name = self.ctx.arena.get_accessor(elem_node)?.name;
-            if self.object_literal_computed_key_is_wide_symbol(accessor_name) {
+            if self.computed_member_key_is_wide_symbol(accessor_name) {
                 return None;
             }
             let name = self.get_property_name_resolved(accessor_name)?;
@@ -206,7 +206,7 @@ impl<'a> CheckerState<'a> {
         }) {
             return None;
         }
-        if self.object_literal_computed_key_is_wide_symbol(prop.name) {
+        if self.computed_member_key_is_wide_symbol(prop.name) {
             return None;
         }
         let name = self.get_property_name_resolved(prop.name)?;


### PR DESCRIPTION
Closes the **resolved-name class leg** of #16307.

Three PRs have now worked this family in one night. They cover disjoint slices — this one does not overlap either predecessor:

| PR | Slice |
|---|---|
| #16326 (merged) | interface / type-literal / object-literal, plus the identifier-alias form |
| #16329 (merged, mid-review of this PR) | class methods on the **unresolved-name** path — `[Symbol.member]` written directly, where `get_property_name_resolved` returns `None` |
| **this PR** | class members on the **resolved-name** path — a `symbol`-typed binding, whose name resolves to the synthetic `__symbol_[file]_[sym]` atom — across **all four** member forms |

Verified after merging #16329 in: it fixes none of the 10 rows below, and this PR breaks none of its tests.

## Structural rule

**When a class member's computed key resolves to a plain (non-unique) `symbol` binding, `tsc` contributes a `[key: symbol]: V` index signature to the class instance shape instead of a named member; tsz now does so through the class instance-type builder (`crates/tsz-checker/src/types/class_type`), the same routing the object-literal and interface lowering paths already perform.**

The synthetic `__symbol_[file]_[sym]` atom only ever matches a declaration whose key resolves to the **same** binding, so:

- a class and the interface it implements, keyed off two *different* `symbol` bindings as tsc allows, stopped being mutually assignable (`TS2345` / `TS2420`);
- `instance[someOtherSymbol]` was `TS7053`, because no symbol index signature ever existed.

Routed at all four instance member forms — property declarations, methods, getters and setters. Several contributors union their value types into one signature; the signature stays `readonly` only while every contributor is.

Each site tests the key **after** `get_property_name_resolved`, never before. That resolution owns the one value-position evaluation of the key expression, and evaluating it again outside that context re-reports its diagnostics — placing the method-site test first re-fired `TS1361` for a type-only-imported key in an ambient class. Second commit on this branch, with the suite that caught it.

### The one exclusion, and why it is not a name check

`Symbol.NAME` written as property-access syntax is excluded even when `NAME` is declared plain `symbol`. Oracle-confirmed: `tsc` derives a NAMED member from the syntactic well-known shape (`isWellKnownSymbolSyntactically`) *before* it consults the key's declared type. The gate reuses the existing `wide_well_known_symbol_member_key`, which resolves `Symbol` through the binder as an unshadowed global — a shadowed `Symbol` is an ordinary property access and does route to the index (covered, `q5`). No identifier or file-name string drives any decision, and nothing reads printer output.

### Shared predicate rename

`object_literal_computed_key_is_wide_symbol` -> `computed_member_key_is_wide_symbol`. Never object-literal-specific, and it now has callers in both domains; 7 call sites including the one #16329 added. No behaviour change.

## Verification

### Oracle-pinned matrix — 26 cases against `typescript@7.0.2` (the pin in `scripts/conformance/typescript-versions.json`)

Measured **three-way**: oracle, this branch, and a baseline binary built from `origin/main` at `250b2e5` (i.e. *including* #16329) — the parent is measured, not read off `known-failures.txt`.

| | rows diverging from tsc |
|---|---|
| main `250b2e5` | **14** |
| this branch | **4** |

**10 rows fixed, 0 newly broken.**

| Case | main `250b2e5` | branch |
|---|---|---|
| class method wide key vs. explicit `[key: symbol]` target | `TS2345` | clean |
| class vs. interface, two *different* wide `symbol` keys | `TS2345` | clean |
| read `c[otherSymbol]` off a wide-keyed class method | `TS7053` | clean |
| renamed binders, same shape | `TS2345` | clean |
| `get [s]()` | `TS2345` | clean |
| `set [s](v)` | `TS7053` | clean |
| `readonly [s]` property | `TS7053` | clean |
| two wide members union their value types | `TS7053` | clean |
| wide index inherited by a subclass | `TS7053` | clean |
| `class C implements I` with distinct wide keys | `TS2420` | clean |

Negative controls that must and do keep reporting: a `unique symbol` key still mints a named member (`TS2741` survives); a string-literal `const` key still mints an ordinary named member; `[Symbol.iterator]` unchanged; a wide key on a non-`Symbol` property-access base still routes to the index.

### xstate distilled repro — the corpus witness (#16307's own 4-file form)

```
main 250b2e5:  actor.ts(12,6): error TS2345: Argument of type 'Actor' is not assignable
                               to parameter of type 'InteropObservable[number]'.
                                 Index signature for type 'symbol' is missing in type 'Actor'.
               exit 1
this branch:   exit 0        (tsc 7.0.2 on the same fixture: exit 0)
```

### Suites

- `cargo nextest run -p tsz-checker --lib` — **9319 run, 9318 passed, 1 failed**. The one failure is `ts2303_tests::recursive_export_assignment_self_import_reports_ts2303`, a baselined entry (`scripts/ci/known-failures.txt:127`) independently reported as pre-existing on main earlier tonight.
- New file `class_wide_symbol_member_index_tests.rs` — **11/11**, incl. both negative controls and a renamed-binder twin. #16329's own `wide_symbol_computed_member_index_signature_tests` and the `ts1361_ambient_computed_property_name_tests` regression suite: **19/19 together**.
- `cargo fmt --all` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean (full workspace, no excludes).
- `python3 scripts/arch/arch_guard.py` — `Architecture guardrails passed.`
- `scripts/conformance/compare-to-parent.sh` — two-sided against this branch's own parent; number posted as a follow-up comment before this PR is queued.

## Not fixed here (all pre-existing on `250b2e5`, all measured)

Disclosed rather than folded in; each needs its own adjacent-case matrix.

1. **Static side.** `class C { static [s]() {} }` gets no symbol index on `typeof C` (`TS7053` on `C[other]`; tsc clean). Lives in `class_type/constructor.rs`, six separate name-resolution sites.
2. **`Symbol.NAME` on interfaces and object literals is *more* permissive than tsc.** Oracle: `interface I { [Symbol.observable]: number }` with a wide `SymbolConstructor` augmentation keeps `[Symbol.observable]` a NAMED member, so `i[other]` is `TS7053`; same for `{ [Symbol.observable]: 1 }`. tsz is clean on both. This is the other side of the exclusion above and predates this branch. Worth a look from whoever owns #16326/#16329, since #16329's positive test asserts the class-side version of exactly this shape — flagged, not touched, because reverting it needs the xstate row re-verified end to end.
3. `TS2669` cascade: tsz drops the follow-on `TS2339`s after a misplaced `declare global`. Unrelated.

## Goal
Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Serpentine