### PR TITLE
fix(parser): a regex subpattern modifier group is validated instead of backtracked

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -27,6 +27,7 @@ mod node_modifiers;
 mod node_pools;
 mod node_view;
 pub mod parse_rules;
+mod regex_modifier_groups;
 mod regex_unicode_properties;
 mod speculation;
 pub mod spelling;

--- a/crates/tsz-parser/src/parser/regex_modifier_groups.rs
+++ b/crates/tsz-parser/src/parser/regex_modifier_groups.rs
@@ -1,0 +1,183 @@
+//! Subpattern modifier groups inside regular expression literals: `(?ims-ims: … )`.
+//!
+//! A group that opens `(?` and is not followed by `=`, `!` or `<` is a
+//! *modifier group* in tsc's grammar (`scanRegularExpressionWorker`'s `default`
+//! arm in `scanner.ts`). Its prelude is an optional run of flags, an optional
+//! `-` plus a second run, and then a mandatory `:` — so `(?:` is the degenerate
+//! modifier group with two empty runs rather than a separate syntactic form.
+//!
+//! The rules the runs carry are the same ones tsc's `scanPatternModifiers`
+//! applies, in this order per character: an identifier character that is not a
+//! regular expression flag is TS1499, a flag already present in the accumulated
+//! set is TS1500, a flag outside the toggleable set (`i`, `m`, `s`) is TS1509,
+//! and anything else joins the set. The second run starts from the first run's
+//! flags, which is why `(?i-i:x)` is a duplicate rather than a toggle.
+//!
+//! Kept out of `state_expressions_literals_regex.rs` deliberately: that file is
+//! already past the 2000-line shard limit, so regex sub-grammars with a
+//! self-contained owner live beside it instead of inside it.
+
+use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+
+use super::state::ParserState;
+
+/// Flag bits, mirroring tsc's `RegularExpressionFlags` so the toggleable mask
+/// below can be read against `scanner.ts` directly.
+const FLAG_HAS_INDICES: u32 = 1 << 0;
+const FLAG_GLOBAL: u32 = 1 << 1;
+const FLAG_IGNORE_CASE: u32 = 1 << 2;
+const FLAG_MULTILINE: u32 = 1 << 3;
+const FLAG_DOT_ALL: u32 = 1 << 4;
+const FLAG_UNICODE: u32 = 1 << 5;
+const FLAG_UNICODE_SETS: u32 = 1 << 6;
+const FLAG_STICKY: u32 = 1 << 7;
+
+/// The only flags a subpattern may toggle (tsc's `RegularExpressionFlags.Modifiers`).
+const TOGGLEABLE_IN_SUBPATTERN: u32 = FLAG_IGNORE_CASE | FLAG_MULTILINE | FLAG_DOT_ALL;
+
+/// Map a regular expression flag character to its bit, or `None` when the
+/// character is not a flag at all (tsc's `characterCodeToRegularExpressionFlag`).
+const fn regular_expression_flag(ch: char) -> Option<u32> {
+    match ch {
+        'd' => Some(FLAG_HAS_INDICES),
+        'g' => Some(FLAG_GLOBAL),
+        'i' => Some(FLAG_IGNORE_CASE),
+        'm' => Some(FLAG_MULTILINE),
+        's' => Some(FLAG_DOT_ALL),
+        'u' => Some(FLAG_UNICODE),
+        'v' => Some(FLAG_UNICODE_SETS),
+        'y' => Some(FLAG_STICKY),
+        _ => None,
+    }
+}
+
+/// Decode the character at `pos`, bounded by `end`.
+pub(crate) fn next_utf8_char(bytes: &[u8], end: usize, pos: usize) -> Option<(char, usize)> {
+    bytes
+        .get(pos..end)
+        .and_then(|slice| std::str::from_utf8(slice).ok())
+        .and_then(|slice| slice.chars().next())
+        .map(|ch| (ch, ch.len_utf8()))
+}
+
+/// Scan one run of subpattern modifier flags, seeded with `current_flags`, and
+/// return the accumulated set. Mirrors tsc's `scanPatternModifiers`: the run
+/// ends at the first character that is not an identifier part, so a bad flag is
+/// reported and consumed rather than terminating the run.
+pub(crate) fn scan_pattern_modifiers(
+    parser: &mut ParserState,
+    emit: &impl Fn(&mut ParserState, usize, u32, &str, u32),
+    body: &[u8],
+    end: usize,
+    pos: &mut usize,
+    current_flags: u32,
+) -> u32 {
+    let mut flags = current_flags;
+
+    while *pos < end {
+        let Some((ch, char_len)) = next_utf8_char(body, end, *pos) else {
+            break;
+        };
+
+        // tsc terminates flag scanning with `isIdentifierPart`; route through
+        // the scanner predicate so termination matches identifier scanning.
+        if !tsz_scanner::is_ecmascript_identifier_part(ch) {
+            break;
+        }
+
+        let char_size = u32::try_from(char_len).unwrap_or(1);
+        match regular_expression_flag(ch) {
+            None => emit(
+                parser,
+                *pos,
+                char_size,
+                diagnostic_messages::UNKNOWN_REGULAR_EXPRESSION_FLAG,
+                diagnostic_codes::UNKNOWN_REGULAR_EXPRESSION_FLAG,
+            ),
+            Some(flag) if flags & flag != 0 => emit(
+                parser,
+                *pos,
+                char_size,
+                diagnostic_messages::DUPLICATE_REGULAR_EXPRESSION_FLAG,
+                diagnostic_codes::DUPLICATE_REGULAR_EXPRESSION_FLAG,
+            ),
+            Some(flag) if flag & TOGGLEABLE_IN_SUBPATTERN == 0 => emit(
+                parser,
+                *pos,
+                char_size,
+                diagnostic_messages::THIS_REGULAR_EXPRESSION_FLAG_CANNOT_BE_TOGGLED_WITHIN_A_SUBPATTERN,
+                diagnostic_codes::THIS_REGULAR_EXPRESSION_FLAG_CANNOT_BE_TOGGLED_WITHIN_A_SUBPATTERN,
+            ),
+            Some(flag) => {
+                // tsc calls `checkRegularExpressionFlagAvailability` only on
+                // the accepted branch, i.e. after TS1509 has already rejected
+                // every flag outside `i`/`m`/`s`. Of those three only `s` is
+                // version-gated, so the subpattern path can reach exactly one
+                // availability answer — the wider flag/version table stays
+                // owned by the checker's trailing-flag pass.
+                if flag == FLAG_DOT_ALL && !parser.language_version.supports_es2018() {
+                    let message = format_message(
+                        diagnostic_messages::THIS_REGULAR_EXPRESSION_FLAG_IS_ONLY_AVAILABLE_WHEN_TARGETING_OR_LATER,
+                        &["es2018"],
+                    );
+                    emit(
+                        parser,
+                        *pos,
+                        char_size,
+                        &message,
+                        diagnostic_codes::THIS_REGULAR_EXPRESSION_FLAG_IS_ONLY_AVAILABLE_WHEN_TARGETING_OR_LATER,
+                    );
+                }
+                flags |= flag;
+            }
+        }
+
+        *pos += char_len;
+    }
+
+    flags
+}
+
+/// Scan the prelude of a modifier group — the flag runs, the optional `-`, and
+/// the mandatory `:` — leaving `pos` just past the `:` when one is present.
+///
+/// `(?-:x)` is the shape TS1504 exists for: tsc detects it by position, not by
+/// flag set, reporting when the whole prelude consumed exactly the minus sign.
+/// A prelude with flags on either side of the minus (`(?i-:x)`, `(?-i:x)`) is
+/// legal, so a flag-set test would report where tsc does not.
+pub(crate) fn scan_modifier_group_prelude(
+    parser: &mut ParserState,
+    emit: &impl Fn(&mut ParserState, usize, u32, &str, u32),
+    body: &[u8],
+    end: usize,
+    pos: &mut usize,
+) {
+    let prelude_start = *pos;
+    let set_flags = scan_pattern_modifiers(parser, emit, body, end, pos, 0);
+
+    if *pos < end && body[*pos] == b'-' {
+        *pos += 1;
+        scan_pattern_modifiers(parser, emit, body, end, pos, set_flags);
+
+        if *pos == prelude_start + 1 {
+            emit(
+                parser,
+                prelude_start,
+                u32::try_from(*pos - prelude_start).unwrap_or(1),
+                diagnostic_messages::SUBPATTERN_FLAGS_MUST_BE_PRESENT_WHEN_THERE_IS_A_MINUS_SIGN,
+                diagnostic_codes::SUBPATTERN_FLAGS_MUST_BE_PRESENT_WHEN_THERE_IS_A_MINUS_SIGN,
+            );
+        }
+    }
+
+    // tsc's `scanExpectedChar(colon)`: consume the `:` or report a zero-width
+    // TS1005 where it should have been, and keep scanning the disjunction
+    // either way. There is deliberately no backtracking here — a group that
+    // opened `(?` is a modifier group even when it is malformed, so it must
+    // not be re-scanned as pattern characters.
+    if *pos < end && body[*pos] == b':' {
+        *pos += 1;
+    } else {
+        emit(parser, *pos, 0, "':' expected.", diagnostic_codes::EXPECTED);
+    }
+}

--- a/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
@@ -466,12 +466,7 @@ impl ParserState {
                 }
             }
 
-            fn next_utf8_char(bytes: &[u8], end: usize, pos: usize) -> Option<(char, usize)> {
-                std::str::from_utf8(&bytes[pos..end])
-                    .ok()
-                    .and_then(|slice| slice.chars().next())
-                    .map(|ch| (ch, ch.len_utf8()))
-            }
+            use crate::parser::regex_modifier_groups::next_utf8_char;
 
             const fn is_word_char(ch: u8) -> bool {
                 ch == b'_' || ch.is_ascii_alphanumeric() || ch >= 0x80
@@ -559,55 +554,7 @@ impl ParserState {
                 }
             }
 
-            fn is_identifier_part_for_regex_flags(ch: char) -> bool {
-                // tsc terminates regex-flag scanning with `isIdentifierPart`
-                // (`scanner.ts`); route through the scanner predicate so flag
-                // termination matches identifier scanning exactly.
-                tsz_scanner::is_ecmascript_identifier_part(ch)
-            }
-
-            const fn is_regex_flag(ch: char) -> bool {
-                matches!(ch, 'g' | 'i' | 'm' | 's' | 'u' | 'v' | 'y' | 'd')
-            }
-
-            fn scan_regex_modifier_segment(
-                parser: &mut ParserState,
-                emit: &impl Fn(&mut ParserState, usize, u32, &str, u32),
-                body: &[u8],
-                end: usize,
-                pos: &mut usize,
-            ) -> bool {
-                let mut consumed_any = false;
-
-                while *pos < end {
-                    let Some((ch, char_len)) = next_utf8_char(body, end, *pos) else {
-                        break;
-                    };
-
-                    if is_regex_flag(ch) {
-                        *pos += char_len;
-                        consumed_any = true;
-                        continue;
-                    }
-
-                    if is_identifier_part_for_regex_flags(ch) {
-                        emit(
-                            parser,
-                            *pos,
-                            1,
-                            diagnostic_messages::UNKNOWN_REGULAR_EXPRESSION_FLAG,
-                            diagnostic_codes::UNKNOWN_REGULAR_EXPRESSION_FLAG,
-                        );
-                        *pos += char_len;
-                        consumed_any = true;
-                        continue;
-                    }
-
-                    break;
-                }
-
-                consumed_any
-            }
+            use crate::parser::regex_modifier_groups::scan_modifier_group_prelude;
 
             fn scan_character_escape(
                 parser: &mut ParserState,
@@ -1573,10 +1520,12 @@ impl ParserState {
 
                             if ctx.body[*pos] == b'?' {
                                 *pos += 1;
-                                if *pos >= ctx.body_end {
-                                    break;
-                                }
-                                match ctx.body[*pos] {
+                                // tsc reads the character after `?` through
+                                // `charCodeChecked`, so end-of-body is not a
+                                // termination condition here: `/(?/` still
+                                // enters the modifier-group arm and reports the
+                                // missing `:` where the body ran out.
+                                match ctx.body.get(*pos).copied().unwrap_or(b'\0') {
                                     b'=' | b'!' => {
                                         *pos += 1;
                                         is_previous_term_quantifiable = !ctx.strict_mode;
@@ -1598,53 +1547,19 @@ impl ParserState {
                                         }
                                         scan_disjunction(parser, ctx, pos, true);
                                     }
+                                    // Modifier group, including the degenerate
+                                    // `(?:` form: tsc reaches both through this
+                                    // same `default` arm and never backtracks
+                                    // out of it.
                                     _ => {
-                                        let saved_pos = *pos;
-                                        let has_first = scan_regex_modifier_segment(
+                                        scan_modifier_group_prelude(
                                             parser,
                                             ctx.emit,
                                             ctx.body,
                                             ctx.body_end,
                                             pos,
                                         );
-
-                                        if has_first
-                                            && *pos < ctx.body_end
-                                            && ctx.body[*pos] == b'-'
-                                        {
-                                            *pos += 1;
-                                            if *pos < ctx.body_end {
-                                                let has_second = scan_regex_modifier_segment(
-                                                    parser,
-                                                    ctx.emit,
-                                                    ctx.body,
-                                                    ctx.body_end,
-                                                    pos,
-                                                );
-
-                                                if !has_second {
-                                                    *pos = saved_pos;
-                                                }
-                                            } else {
-                                                *pos = saved_pos;
-                                            }
-                                        }
-
-                                        let is_modifier_group = has_first
-                                            && *pos < ctx.body_end
-                                            && ctx.body[*pos] == b':';
-
-                                        if !is_modifier_group {
-                                            *pos = saved_pos;
-                                        } else {
-                                            *pos += 1;
-                                            is_previous_term_quantifiable = true;
-                                        }
-
-                                        if !is_modifier_group {
-                                            is_previous_term_quantifiable = true;
-                                        }
-
+                                        is_previous_term_quantifiable = true;
                                         scan_disjunction(parser, ctx, pos, true);
                                     }
                                 }

--- a/crates/tsz-parser/tests/parser_improvement_regex_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_regex_recovery_tests.rs
@@ -893,3 +893,176 @@ const underV: RegExp[] = [
         "Properties of strings are legal under the v flag, got: {diagnostics:?}"
     );
 }
+
+/// Codes per witness, in emission order, so the modifier-group tests below can
+/// assert an exact sequence rather than "contains".
+fn regex_codes(source: &str, target: tsz_common::ScriptTarget) -> Vec<u32> {
+    let (parser, _root) =
+        crate::parser::test_fixture::parse_source_with_language_version(source, target);
+    parser.get_diagnostics().iter().map(|d| d.code).collect()
+}
+
+#[test]
+fn test_subpattern_modifier_group_rejects_non_toggleable_flags_with_ts1509() {
+    // Only `i`, `m` and `s` may be toggled within a subpattern; `d`, `g`, `u`,
+    // `v` and `y` are whole-pattern flags. Checked on both sides of the minus
+    // so the second run is not silently exempt.
+    for witness in [
+        "const r = /(?d:x)/;",
+        "const r = /(?g:x)/;",
+        "const r = /(?u:x)/;",
+        "const r = /(?v:x)/;",
+        "const r = /(?y:x)/;",
+        "const r = /(?-d:x)/;",
+        "const r = /(?-g:x)/;",
+        "const r = /(?-y:x)/;",
+    ] {
+        assert_eq!(
+            regex_codes(witness, tsz_common::ScriptTarget::ES2022),
+            vec![
+                diagnostic_codes::THIS_REGULAR_EXPRESSION_FLAG_CANNOT_BE_TOGGLED_WITHIN_A_SUBPATTERN
+            ],
+            "{witness} should report exactly one TS1509"
+        );
+    }
+}
+
+#[test]
+fn test_subpattern_modifier_group_minus_without_any_flag_reports_ts1504() {
+    // TS1504 is positional in tsc: it fires only when the whole prelude
+    // consumed nothing but the minus sign, so a flag on either side clears it.
+    assert_eq!(
+        regex_codes("const r = /(?-:x)/;", tsz_common::ScriptTarget::ES2022),
+        vec![diagnostic_codes::SUBPATTERN_FLAGS_MUST_BE_PRESENT_WHEN_THERE_IS_A_MINUS_SIGN],
+    );
+    assert_eq!(
+        regex_codes("const r = /(?i-:x)/;", tsz_common::ScriptTarget::ES2022),
+        Vec::<u32>::new(),
+        "flags before the minus satisfy the rule"
+    );
+    assert_eq!(
+        regex_codes("const r = /(?-i:x)/;", tsz_common::ScriptTarget::ES2022),
+        Vec::<u32>::new(),
+        "flags after the minus satisfy the rule"
+    );
+    assert_eq!(
+        regex_codes("const r = /(?i-m:x)/;", tsz_common::ScriptTarget::ES2022),
+        Vec::<u32>::new(),
+        "flags on both sides are the ordinary legal form"
+    );
+}
+
+#[test]
+fn test_subpattern_modifier_group_duplicate_flags_report_ts1500() {
+    // The second run is seeded with the first run's flags, so `(?i-i:` is a
+    // duplicate rather than a set-then-clear toggle.
+    assert_eq!(
+        regex_codes("const r = /(?ii:x)/;", tsz_common::ScriptTarget::ES2022),
+        vec![diagnostic_codes::DUPLICATE_REGULAR_EXPRESSION_FLAG],
+    );
+    assert_eq!(
+        regex_codes("const r = /(?i-i:x)/;", tsz_common::ScriptTarget::ES2022),
+        vec![diagnostic_codes::DUPLICATE_REGULAR_EXPRESSION_FLAG],
+    );
+    assert_eq!(
+        regex_codes(
+            "const r = /(?ims-ims:x)/;",
+            tsz_common::ScriptTarget::ES2022
+        ),
+        vec![
+            diagnostic_codes::DUPLICATE_REGULAR_EXPRESSION_FLAG,
+            diagnostic_codes::DUPLICATE_REGULAR_EXPRESSION_FLAG,
+            diagnostic_codes::DUPLICATE_REGULAR_EXPRESSION_FLAG,
+        ],
+    );
+}
+
+#[test]
+fn test_subpattern_modifier_group_without_colon_reports_ts1005() {
+    // A group that opened `(?` stays a modifier group even when malformed, so
+    // the missing `:` is reported instead of the prelude being re-scanned as
+    // pattern characters.
+    assert_eq!(
+        regex_codes("const r = /(?i)/;", tsz_common::ScriptTarget::ES2022),
+        vec![diagnostic_codes::EXPECTED],
+    );
+    assert_eq!(
+        regex_codes("const r = /(?P<n>x)/;", tsz_common::ScriptTarget::ES2022),
+        vec![
+            diagnostic_codes::UNKNOWN_REGULAR_EXPRESSION_FLAG,
+            diagnostic_codes::EXPECTED,
+        ],
+        "`P` is an unknown flag, then the `<` is where the `:` should have been"
+    );
+    assert_eq!(
+        regex_codes("const r = /(?-)/;", tsz_common::ScriptTarget::ES2022),
+        vec![
+            diagnostic_codes::SUBPATTERN_FLAGS_MUST_BE_PRESENT_WHEN_THERE_IS_A_MINUS_SIGN,
+            diagnostic_codes::EXPECTED,
+        ],
+    );
+    assert_eq!(
+        regex_codes("const r = /(?/;", tsz_common::ScriptTarget::ES2022),
+        vec![diagnostic_codes::EXPECTED],
+        "end of body is not a group terminator — tsc still wants the `:`"
+    );
+}
+
+#[test]
+fn test_subpattern_modifier_group_is_not_a_capturing_group() {
+    // `\1` has nothing to refer to when the only group is a modifier group.
+    assert_eq!(
+        regex_codes("const r = /(?i:x)\\1/;", tsz_common::ScriptTarget::ES2022),
+        vec![
+            diagnostic_codes::THIS_BACKREFERENCE_REFERS_TO_A_GROUP_THAT_DOES_NOT_EXIST_THERE_ARE_NO_CAPTURING
+        ],
+    );
+    assert_eq!(
+        regex_codes("const r = /(?i:(x))\\1/;", tsz_common::ScriptTarget::ES2022),
+        Vec::<u32>::new(),
+        "a real group nested inside a modifier group still counts"
+    );
+}
+
+#[test]
+fn test_subpattern_modifier_group_dot_all_flag_follows_target_availability() {
+    // Of the three toggleable flags only `s` is version-gated, and TS1509
+    // rejects every other flag before availability is ever consulted.
+    assert_eq!(
+        regex_codes("const r = /(?s:x)/;", tsz_common::ScriptTarget::ES2015),
+        vec![diagnostic_codes::THIS_REGULAR_EXPRESSION_FLAG_IS_ONLY_AVAILABLE_WHEN_TARGETING_OR_LATER],
+    );
+    assert_eq!(
+        regex_codes("const r = /(?s:x)/;", tsz_common::ScriptTarget::ES2018),
+        Vec::<u32>::new(),
+    );
+    assert_eq!(
+        regex_codes("const r = /(?im:x)/;", tsz_common::ScriptTarget::ES2015),
+        Vec::<u32>::new(),
+        "`i` and `m` are not version-gated"
+    );
+}
+
+#[test]
+fn test_non_modifier_group_forms_are_unaffected() {
+    // The `(?` arm now runs unconditionally, so every neighbouring group form
+    // has to stay silent — including the degenerate `(?:` modifier group.
+    for witness in [
+        "const r = /(?:x)/;",
+        "const r = /(?=x)/;",
+        "const r = /(?!x)/;",
+        "const r = /(?<=x)/;",
+        "const r = /(?<!x)/;",
+        "const r = /(?<n>x)\\k<n>/;",
+        "const r = /(x)(?:y)\\1/;",
+        "const r = /(?i:x)*/;",
+        "const r = /a(?i:b)c/u;",
+        "const r = /(?i:(?m:x))/;",
+    ] {
+        assert_eq!(
+            regex_codes(witness, tsz_common::ScriptTarget::ES2022),
+            Vec::<u32>::new(),
+            "{witness} is legal and must stay clean"
+        );
+    }
+}


### PR DESCRIPTION
**Structural rule.** When a group opens `(?` and the next character is not `=`, `!` or `<`, tsc treats it as a *subpattern modifier group* unconditionally (`scanRegularExpressionWorker`'s `default` arm plus `scanPatternModifiers`, `scanner.ts`): it scans a flag run, an optional `-` followed by a second run **seeded with the first run's flags**, and then requires `:`. tsz scanned the two flag runs but tracked no flag set at all and *backtracked out of the arm* whenever the `:` was missing — so four codes could never fire and a malformed group reported the wrong one. tsz now does X through the **parser**, the layer that already owns regex-body grammar (`crates/tsz-parser/src/parser/regex_modifier_groups.rs`, called from `state_expressions_literals_regex.rs`).

Concretely, on `#16291`'s regex-grammar cluster:

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `/(?g:x)/`, `/(?-y:x)/`, `/(?d:x)/`, `/(?u:x)/`, `/(?v:x)/` | TS1509 | *(silent)* | TS1509 |
| `/(?-:x)/`, `/(?-)/` | TS1504 | *(silent)* | TS1504 |
| `/(?ii:x)/`, `/(?i-i:x)/`, `/(?ims-ims:x)/` | TS1500 ×1/×1/×3 | *(silent)* | same |
| `/(?s:x)/` below ES2018 | TS1501 | *(silent)* | TS1501 |
| `/(?i)/`, `/(?P<n>x)/`, `/(?i/` | TS1005 `':' expected.` | backtracked; `/(?/` gave `')' expected.` | TS1005 `':' expected.` |
| `/(?i-:x)/`, `/(?-i:x)/`, `/(?:x)/`, `/(?<n>x)\k<n>/` | clean | clean | clean |

Three details that are easy to get wrong and are pinned by tests:

- **TS1504 is positional, not set-based.** tsc reports it only when the whole prelude consumed exactly the minus sign, so `(?i-:x)` and `(?-i:x)` are legal. A "both runs empty" flag-set test would over-report on those.
- **The second run is seeded with the first run's flags**, which is why `(?i-i:x)` is a *duplicate* (TS1500) rather than a set-then-clear toggle.
- **TS1509 runs before availability.** tsc consults `checkRegularExpressionFlagAvailability` only on the accepted branch, after every non-toggleable flag is already rejected — so `s` below ES2018 is the *only* TS1501 reachable inside a subpattern. The wider flag/version table stays owned by the checker's trailing-flag pass; this does not duplicate it.

`(?:` is not special-cased: it is the degenerate modifier group with two empty runs, exactly as tsc reaches it. Removing the backtrack also required letting `(?` at end-of-body fall into the arm (tsc reads that character through `charCodeChecked`, so EOF is not a group terminator).

The new prelude scan lives in its own `regex_modifier_groups` module rather than in `state_expressions_literals_regex.rs`, which is already past the 2000-line shard limit; `next_utf8_char` moves there with it, and the file shrinks by 99 lines net.

## Goal
Goal: hold

## Verification

Oracle: `typescript` 6.0.2 (`tsc.js`) — this repo's pinned 7.0.2 needs a `scripts/` `npm install` that hangs in this container (documented on the coordination board); the regex scanner is unchanged between the two, and every expectation below was taken from a real oracle run, not from reading `scanner.ts`.

- **25-witness adjacent matrix × 5 targets, tsz vs tsc diffed byte-for-byte — 0 differences.** Witnesses cover all five non-toggleable flags on both sides of the minus, both legal minus forms, duplicate-within-run and duplicate-across-minus, `(?:`/`(?=`/`(?!`/`(?<=`/`(?<!`/named-group/`\k<n>` negatives, nesting (`(?i:(?m:x))`), quantified (`(?i:x)*`), under `/u` and `/v`, capturing-count interaction (`(?i:x)\1` → TS1534, `(?i:(x))\1` → clean), unterminated `(?-`, `(?i`, `(?`, non-flag prelude characters (`P`, `$`, `_`, `9`, `ü`, `I`).
  - before: `es2015 DIFF, es2017 DIFF, es2018 DIFF, es2022 DIFF, esnext DIFF` — 13 of 22 expected diagnostics missing at ES2015, 12 of 19 at ES2022, plus one wrong code.
  - after: `es2015: MATCH (22 diags)`, `es2017: MATCH (22)`, `es2018: MATCH (19)`, `es2022: MATCH (19)`, `esnext: MATCH (18)`.
  - `target=ES5` is excluded: tsz removes it (TS5108) as tsc 7 does, so that row is a deliberate pre-existing difference against the 6.0.2 oracle, not a regression from this change.
- `cargo test -p tsz-parser` — **1701 passed, 0 failed** (1694 before; 7 new tests, all asserting exact diagnostic sequences in emission order, not "contains").
- `cargo clippy -p tsz-parser -p tsz-cli --all-targets -- -D warnings` — clean.
- `cargo fmt --all` — clean; `python3 scripts/arch/arch_guard.py` — passed.
- `cargo test -p tsz-cli` (includes `regex_grammar_suppression_tests`) — running at push time; will report on the PR.
- **Not run locally: `conformance.sh snapshot` / `compare-to-parent.sh`.** This touches a shared regex-scanning path, so that gate is genuinely owed — see the disclosure comment I am posting on this PR.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Obsidian

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dx5XJM4WKLmHS7dhQcPUVa)_