### PR TITLE
fix(solver): type-predicate assignability failures elaborate as TS1224/TS1226

### DIFF
--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -1044,6 +1044,19 @@ impl<'a> CheckerState<'a> {
                 *target_return,
                 nested_reason.as_deref(),
             ),
+            SubtypeFailureReason::TypePredicateMismatch {
+                source_predicate,
+                target_predicate,
+                source_signature,
+                nested_reason,
+            } => self.render_type_predicate_mismatch(
+                reason,
+                &rctx,
+                source_predicate.as_ref(),
+                target_predicate,
+                *source_signature,
+                nested_reason.as_deref(),
+            ),
             SubtypeFailureReason::TypeArgumentMismatch {
                 source_arg,
                 target_arg,

--- a/crates/tsz-checker/src/error_reporter/render_failure_property_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure_property_helpers.rs
@@ -596,6 +596,142 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Format a `TypePredicate` the way tsc's `typePredicateToString` does
+    /// (`x is T`, `this is T`, `asserts x is T`) — used for the TS1226
+    /// `Type predicate '{0}' is not assignable to '{1}'.` arguments. Mirrors
+    /// the solver's own `format_signature_with_predicate` predicate leg
+    /// (`crates/tsz-solver/src/diagnostics/format/compound.rs`), duplicated
+    /// here because that helper only renders a predicate as part of a whole
+    /// signature, never standalone.
+    fn format_type_predicate_for_diagnostic(&mut self, pred: &tsz_solver::TypePredicate) -> String {
+        let target_name = match pred.target {
+            tsz_solver::TypePredicateTarget::This => "this".to_string(),
+            tsz_solver::TypePredicateTarget::Identifier(atom) => {
+                self.ctx.types.resolve_atom_ref(atom).to_string()
+            }
+        };
+        let type_part = pred
+            .type_id
+            .map(|ty| format!(" is {}", self.format_type_diagnostic(ty)));
+        if pred.asserts {
+            format!("asserts {target_name}{}", type_part.unwrap_or_default())
+        } else {
+            format!("{target_name}{}", type_part.unwrap_or_default())
+        }
+    }
+
+    /// Render a type-predicate assignability failure: TS1224
+    /// (`source_predicate: None` — the target demands a type guard the
+    /// source signature doesn't declare at all) or TS1226 (`Some` — both
+    /// sides declare a predicate but are incompatible), each nested under
+    /// the ordinary `Type 'S' is not assignable to type 'T'.` TS2322 header.
+    pub(super) fn render_type_predicate_mismatch(
+        &mut self,
+        reason: &tsz_solver::SubtypeFailureReason,
+        ctx: &RenderContext,
+        source_predicate: Option<&tsz_solver::TypePredicate>,
+        target_predicate: &tsz_solver::TypePredicate,
+        source_signature: Option<TypeId>,
+        nested_reason: Option<&tsz_solver::SubtypeFailureReason>,
+    ) -> Diagnostic {
+        let source = ctx.source;
+        let target = ctx.target;
+        let idx = ctx.idx;
+        let depth = ctx.depth;
+        let start = ctx.start;
+        let length = ctx.length;
+        let file_name = ctx.file_name.clone();
+
+        let own_message = match source_predicate {
+            None => {
+                let sig_str = source_signature
+                    .and_then(|ty| {
+                        self.ctx
+                            .create_diagnostic_type_formatter()
+                            .format_overload_signature(ty)
+                    })
+                    .unwrap_or_else(|| self.format_type_diagnostic(source));
+                format_message(
+                    diagnostic_messages::SIGNATURE_MUST_BE_A_TYPE_PREDICATE,
+                    &[&sig_str],
+                )
+            }
+            Some(source_pred) => {
+                let source_str = self.format_type_predicate_for_diagnostic(source_pred);
+                let target_str = self.format_type_predicate_for_diagnostic(target_predicate);
+                format_message(
+                    diagnostic_messages::TYPE_PREDICATE_IS_NOT_ASSIGNABLE_TO,
+                    &[&source_str, &target_str],
+                )
+            }
+        };
+
+        // Both predicates narrow to a concrete type: tsc relates those types
+        // directly beneath the TS1226 line (`Type 'S' is not assignable to
+        // type 'T'.`), recursing through the same structured chain a plain
+        // assignability failure would use.
+        let predicate_type_pair = source_predicate
+            .and_then(|p| p.type_id)
+            .zip(target_predicate.type_id);
+
+        if depth == 0 {
+            let (source_str, target_str) =
+                self.format_top_level_assignability_message_types_at(source, target, idx);
+            let base = format_message(
+                diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+                &[&source_str, &target_str],
+            );
+            let mut diag = Diagnostic::error(
+                file_name,
+                start,
+                length,
+                base,
+                diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            );
+            diag.push_elaboration(own_message, reason.diagnostic_code(), 0);
+            if let Some(nested) = nested_reason
+                && let Some((s_ty, t_ty)) = predicate_type_pair
+            {
+                let nested_diag = self.render_failure_reason(nested, s_ty, t_ty, idx, depth + 1);
+                diag.push_elaboration_at(
+                    nested_diag.file,
+                    nested_diag.start,
+                    nested_diag.length,
+                    nested_diag.message_text,
+                    nested_diag.code,
+                    1,
+                );
+                diag.related_information
+                    .extend(nested_diag.related_information);
+            }
+            diag
+        } else {
+            let mut diag = Diagnostic::error(
+                file_name,
+                start,
+                length,
+                own_message,
+                reason.diagnostic_code(),
+            );
+            if let Some(nested) = nested_reason
+                && let Some((s_ty, t_ty)) = predicate_type_pair
+            {
+                let nested_diag = self.render_failure_reason(nested, s_ty, t_ty, idx, depth + 1);
+                diag.push_elaboration_at(
+                    nested_diag.file,
+                    nested_diag.start,
+                    nested_diag.length,
+                    nested_diag.message_text,
+                    nested_diag.code,
+                    0,
+                );
+                diag.related_information
+                    .extend(nested_diag.related_information);
+            }
+            diag
+        }
+    }
+
     /// Locate the span of an excess property name within a source expression.
     ///
     /// Walks any surrounding parenthesized expression, `||`/`??`/`,` combinator,

--- a/crates/tsz-checker/src/query_boundaries/relation_types.rs
+++ b/crates/tsz-checker/src/query_boundaries/relation_types.rs
@@ -371,6 +371,31 @@ impl RelationFailure {
                 source_type: TypeId::ERROR,
                 target_type: TypeId::ERROR,
             },
+            // The checker-facing classification only needs a representative
+            // type pair (used for drift/heuristic inspection); the live
+            // TS1224/TS1226 elaboration is rendered from the solver reason's
+            // structured chain via `render_failure_reason`. When both sides
+            // narrow to a type, that pair is the most useful signal;
+            // otherwise (TS1224: source has no predicate at all) there is no
+            // natural pair, matching the other structural-only reasons above.
+            SubtypeFailureReason::TypePredicateMismatch {
+                source_predicate,
+                target_predicate,
+                ..
+            } => {
+                let (source_type, target_type) = match source_predicate
+                    .as_ref()
+                    .and_then(|p| p.type_id)
+                    .zip(target_predicate.type_id)
+                {
+                    Some((s, t)) => (s, t),
+                    None => (TypeId::ERROR, TypeId::ERROR),
+                };
+                Self::TypeMismatch {
+                    source_type,
+                    target_type,
+                }
+            }
             SubtypeFailureReason::IndexAccessTypeParameterMismatch {
                 source_param,
                 target_param,

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -873,6 +873,8 @@ mod type_parameter_default_identity_tests;
 mod type_position_resolution_cache_tests;
 #[path = "tests/type_predicate_alias_relation_tests.rs"]
 mod type_predicate_alias_relation_tests;
+#[path = "tests/type_predicate_assignability_elaboration_tests.rs"]
+mod type_predicate_assignability_elaboration_tests;
 #[path = "tests/type_predicate_relation_routing_arch_tests.rs"]
 mod type_predicate_relation_routing_arch_tests;
 #[path = "tests/typeof_class_name_structural_lookup_arch_tests.rs"]

--- a/crates/tsz-checker/src/tests/type_predicate_assignability_elaboration_tests.rs
+++ b/crates/tsz-checker/src/tests/type_predicate_assignability_elaboration_tests.rs
@@ -1,0 +1,188 @@
+//! Regression tests for the assignability elaboration of a type-predicate
+//! return mismatch — TS1224 (`Signature '{0}' must be a type predicate.`) and
+//! TS1226 (`Type predicate '{0}' is not assignable to '{1}'.`).
+//!
+//! Structural rule: `are_type_predicates_compatible`
+//! (`crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs`) already
+//! correctly rejects these assignments — `x is T` vs. a plain
+//! boolean-returning function, or two incompatible predicates — so TS2322
+//! already fires. What was missing is the elaboration `tsc` always attaches
+//! under that TS2322 header; tsz owns it through the same
+//! `relation -> reason -> diagnostic` chain as every other structural
+//! assignability failure, via a new `SubtypeFailureReason::TypePredicateMismatch`
+//! explained in `explain_function.rs` and rendered in
+//! `render_type_predicate_mismatch`.
+//!
+//! The rule is structural, so cases vary binder/interface names where a name
+//! reaches the rendered output (CLAUDE.md anti-hardcoding gate).
+
+use crate::test_utils::{check_with_options, strict_checker_options};
+
+/// Full elaboration text (primary message plus every related-information
+/// line, in order) of the single diagnostic with `code` in `source`.
+fn elaboration(source: &str, code: u32) -> String {
+    let diags = check_with_options(source, strict_checker_options());
+    let matching: Vec<_> = diags.iter().filter(|d| d.code == code).collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "Expected exactly one TS{code}. Got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+    let mut lines = vec![matching[0].message_text.clone()];
+    lines.extend(
+        matching[0]
+            .related_information
+            .iter()
+            .map(|info| info.message_text.clone()),
+    );
+    lines.join("\n")
+}
+
+fn diagnostic_codes(source: &str) -> Vec<u32> {
+    check_with_options(source, strict_checker_options())
+        .iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+/// TS1224: the target demands a type guard (`x is string`) and the source is
+/// a plain boolean-returning function with no predicate at all.
+#[test]
+fn plain_boolean_function_to_type_guard_reports_ts1224() {
+    let text = elaboration(
+        r#"
+function isString(x: unknown): boolean {
+    return typeof x === "string";
+}
+let guard: (x: unknown) => x is string;
+guard = isString;
+"#,
+        2322,
+    );
+    assert_eq!(
+        text,
+        "Type '(x: unknown) => boolean' is not assignable to type '(x: unknown) => x is string'.\n\
+         Signature '(x: unknown): boolean' must be a type predicate.",
+    );
+}
+
+/// Same rule, renamed binders/parameter — locks the shape as structural, not
+/// a fixture spelling.
+#[test]
+fn plain_boolean_function_to_type_guard_reports_ts1224_renamed_binders() {
+    let text = elaboration(
+        r#"
+function checkThing(value: unknown): boolean {
+    return typeof value === "number";
+}
+let predicate: (value: unknown) => value is number;
+predicate = checkThing;
+"#,
+        2322,
+    );
+    assert_eq!(
+        text,
+        "Type '(value: unknown) => boolean' is not assignable to type '(value: unknown) => value is number'.\n\
+         Signature '(value: unknown): boolean' must be a type predicate.",
+    );
+}
+
+/// TS1226: both sides declare a type guard but narrow to incompatible types.
+/// tsc nests the inner `Type 'S' is not assignable to type 'T'.` leaf beneath
+/// the predicate-specific line.
+#[test]
+fn incompatible_type_guards_reports_ts1226() {
+    let text = elaboration(
+        r#"
+declare function isNumber(x: unknown): x is number;
+let guard: (x: unknown) => x is string;
+guard = isNumber;
+"#,
+        2322,
+    );
+    assert_eq!(
+        text,
+        "Type '(x: unknown) => x is number' is not assignable to type '(x: unknown) => x is string'.\n\
+         Type predicate 'x is number' is not assignable to 'x is string'.\n\
+         Type 'number' is not assignable to type 'string'.",
+    );
+}
+
+/// Same rule, renamed binders — the predicate subject and interface names
+/// must not leak into the structural decision.
+#[test]
+fn incompatible_type_guards_reports_ts1226_renamed_binders() {
+    let text = elaboration(
+        r#"
+interface Cat { meow(): void; }
+interface Dog { bark(): void; }
+declare function isDog(value: unknown): value is Dog;
+let guard: (value: unknown) => value is Cat;
+guard = isDog;
+"#,
+        2322,
+    );
+    assert_eq!(
+        text,
+        "Type '(value: unknown) => value is Dog' is not assignable to type '(value: unknown) => value is Cat'.\n\
+         Type predicate 'value is Dog' is not assignable to 'value is Cat'.\n\
+         Property 'meow' is missing in type 'Dog' but required in type 'Cat'.",
+    );
+}
+
+/// Negative control: a target with an ASSERTION predicate (`asserts x`, no
+/// narrowed type) accepts a plain function with no predicate at all — the
+/// assertion is a call-site annotation, not a runtime contract the
+/// implementation must satisfy. Must stay clean (no TS2322/TS1224).
+#[test]
+fn plain_function_to_assertion_only_target_is_compatible() {
+    let codes = diagnostic_codes(
+        r#"
+function noop(x: unknown): void {}
+let assertFn: (x: unknown) => asserts x;
+assertFn = noop;
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "assigning a plain void function to an assertion-only target must be clean, got {codes:?}"
+    );
+}
+
+/// Negative control: a source with a type guard is assignable to a plain
+/// boolean-returning target (the predicate only narrows the caller's view;
+/// tsc treats it as strictly more specific). Must stay clean.
+#[test]
+fn type_guard_source_to_plain_boolean_target_is_compatible() {
+    let codes = diagnostic_codes(
+        r#"
+declare function isString(x: unknown): x is string;
+let plain: (x: unknown) => boolean;
+plain = isString;
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "assigning a type-guard source to a plain boolean target must be clean, got {codes:?}"
+    );
+}
+
+/// Negative control: matching type guards on both sides are compatible.
+#[test]
+fn matching_type_guards_are_compatible() {
+    let codes = diagnostic_codes(
+        r#"
+declare function isString(x: unknown): x is string;
+let guard: (x: unknown) => x is string;
+guard = isString;
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "identical type guards must be compatible, got {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/diagnostics/core.rs
+++ b/crates/tsz-solver/src/diagnostics/core.rs
@@ -3,7 +3,7 @@
 //! Contains failure reasons, lazy diagnostics, diagnostic codes,
 //! and core diagnostic data types. Re-exported from the parent `diagnostics` module.
 
-use crate::types::{TypeId, Visibility};
+use crate::types::{TypeId, TypePredicate, Visibility};
 use std::sync::Arc;
 use tsz_binder::SymbolId;
 use tsz_common::interner::Atom;
@@ -146,6 +146,29 @@ pub enum SubtypeFailureReason {
         /// example, distinguishing a callback's inner return-type
         /// failure from an inner parameter failure.
         inner_reason: Option<Box<Self>>,
+    },
+    /// A target function/method's return carries a type predicate (`x is T`,
+    /// `this is T`) that the source signature cannot satisfy.
+    ///
+    /// `source_predicate: None` is tsc's `Signature_0_must_be_a_type_predicate`
+    /// (TS1224) — the target requires a type guard and the source has no
+    /// predicate at all (an assertion-only target, `asserts x`, is compatible
+    /// without one and never reaches this variant). `source_signature` is the
+    /// interned whole-function type of the source, rendered in
+    /// `signatureToString` colon form for that message's `'{0}'` argument.
+    ///
+    /// `source_predicate: Some(_)` is `Type_predicate_0_is_not_assignable_to_1`
+    /// (TS1226) — both sides declare a predicate but they target different
+    /// parameters, mix a type guard with an assertion, or narrow to
+    /// incompatible types. `nested_reason` carries the inner
+    /// `source_predicate.type_id`/`target_predicate.type_id` mismatch when
+    /// both predicates narrow to a type and those types are merely related,
+    /// not the same/subtype.
+    TypePredicateMismatch {
+        source_predicate: Option<TypePredicate>,
+        target_predicate: TypePredicate,
+        source_signature: Option<TypeId>,
+        nested_reason: Option<Box<Self>>,
     },
     /// Too many parameters in source.
     TooManyParameters {
@@ -763,10 +786,12 @@ pub mod codes {
     pub use dc::PROPERTY_IS_OPTIONAL_IN_TYPE_BUT_REQUIRED_IN_TYPE as PROPERTY_OPTIONAL_BUT_REQUIRED;
     pub use dc::PROPERTY_IS_PRIVATE_AND_ONLY_ACCESSIBLE_WITHIN_CLASS as PROPERTY_VISIBILITY_MISMATCH;
     pub use dc::PROPERTY_IS_PROTECTED_AND_ONLY_ACCESSIBLE_THROUGH_AN_INSTANCE_OF_CLASS_THIS_IS_A as PROPERTY_NOMINAL_MISMATCH;
+    pub use dc::SIGNATURE_MUST_BE_A_TYPE_PREDICATE;
     pub use dc::THE_TYPE_IS_READONLY_AND_CANNOT_BE_ASSIGNED_TO_THE_MUTABLE_TYPE as READONLY_TO_MUTABLE;
     pub use dc::TYPE_HAS_NO_PROPERTIES_IN_COMMON_WITH_TYPE as NO_COMMON_PROPERTIES;
     pub use dc::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE as MISSING_PROPERTIES;
     pub use dc::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE as TYPE_NOT_ASSIGNABLE;
+    pub use dc::TYPE_PREDICATE_IS_NOT_ASSIGNABLE_TO as TYPE_PREDICATE_NOT_ASSIGNABLE_TO;
 
     pub use dc::INDEX_SIGNATURE_FOR_TYPE_IS_MISSING_IN_TYPE as MISSING_INDEX_SIGNATURE;
     pub use dc::IS_ASSIGNABLE_TO_THE_CONSTRAINT_OF_TYPE_BUT_COULD_BE_INSTANTIATED_WITH_A_DIFFERE as TYPE_PARAM_INSTANTIATED_WITH_DIFFERENT_SUBTYPE;
@@ -897,6 +922,14 @@ impl SubtypeFailureReason {
             Self::ReadonlyPropertyMismatch { .. } => codes::READONLY_PROPERTY,
             Self::PropertyVisibilityMismatch { .. } => codes::PROPERTY_VISIBILITY_MISMATCH,
             Self::PropertyNominalMismatch { .. } => codes::PROPERTY_NOMINAL_MISMATCH,
+            Self::TypePredicateMismatch {
+                source_predicate: None,
+                ..
+            } => codes::SIGNATURE_MUST_BE_A_TYPE_PREDICATE,
+            Self::TypePredicateMismatch {
+                source_predicate: Some(_),
+                ..
+            } => codes::TYPE_PREDICATE_NOT_ASSIGNABLE_TO,
             Self::ReturnTypeMismatch { .. }
             | Self::ParameterTypeMismatch { .. }
             | Self::TupleElementMismatch { .. }
@@ -1101,6 +1134,22 @@ impl SubtypeFailureReason {
                 codes::TYPE_NOT_ASSIGNABLE,
                 vec![(*source_param).into(), (*target_param).into()],
             )),
+
+            Self::TypePredicateMismatch {
+                source_predicate: _,
+                target_predicate: _,
+                source_signature: _,
+                nested_reason,
+            } => {
+                let mut diag = PendingDiagnostic::error(
+                    codes::TYPE_NOT_ASSIGNABLE,
+                    vec![source.into(), target.into()],
+                );
+                if let Some(nested) = nested_reason {
+                    diag = diag.with_related(nested.to_diagnostic(source, target));
+                }
+                diag
+            }
 
             Self::TooManyParameters {
                 source_count: _,

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -760,12 +760,35 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         }
 
         if let (Some(s_fn_id), Some(t_fn_id)) = (
-            function_shape_id(self.interner, source),
-            function_shape_id(self.interner, target),
+            function_shape_id(self.interner, resolved_source),
+            function_shape_id(self.interner, resolved_target),
         ) {
             let s_fn = self.interner.function_shape(s_fn_id);
             let t_fn = self.interner.function_shape(t_fn_id);
             return self.explain_function_failure(&s_fn, &t_fn);
+        }
+
+        // A `declare function` symbol's own type — or any other single-signature,
+        // property-free Callable — behaves exactly like a bare Function for
+        // every structural purpose, but tsz interns it as a `Callable` shape
+        // rather than `Function`. When it fails against a genuine `Function`
+        // target (e.g. an arrow-type-annotated variable), the Function-vs-Function
+        // check above never matches on the source side, so return-type and
+        // type-predicate elaboration (TS1224/TS1226) silently produced no
+        // structured reason at all. Peel the lone call signature to a
+        // `FunctionShape` and reuse the same explainer.
+        if let Some(t_fn_id) = function_shape_id(self.interner, resolved_target)
+            && let Some(s_callable_id) = callable_shape_id(self.interner, resolved_source)
+        {
+            let s_callable = self.interner.callable_shape(s_callable_id);
+            if let [sig] = s_callable.call_signatures.as_slice()
+                && s_callable.construct_signatures.is_empty()
+                && s_callable.properties.is_empty()
+            {
+                let s_fn = Self::function_shape_from_call_signature(sig, false);
+                let t_fn = self.interner.function_shape(t_fn_id);
+                return self.explain_function_failure(&s_fn, &t_fn);
+            }
         }
 
         if let Some(t_callable_id) = callable_shape_id(self.interner, resolved_target) {

--- a/crates/tsz-solver/src/relations/subtype/explain_function.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain_function.rs
@@ -35,7 +35,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     .is_true()
                     || checker.allow_void_return && target.return_type == TypeId::VOID
                 {
-                    return None;
+                    return checker.explain_type_predicate_failure(source, target);
                 }
                 let nested_reason = checker
                     .explain_failure(source.return_type, target.return_type)
@@ -47,6 +47,52 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 })
             },
         )
+    }
+
+    /// Explain a `check_function_subtype` failure caused solely by
+    /// `are_type_predicates_compatible` (called only once the parameter and
+    /// return-type legs have already passed, mirroring tsc's
+    /// `compareSignaturesRelated`, which checks the predicate only after the
+    /// return type itself relates).
+    fn explain_type_predicate_failure(
+        &mut self,
+        source: &FunctionShape,
+        target: &FunctionShape,
+    ) -> Option<SubtypeFailureReason> {
+        if self.are_type_predicates_compatible(source, target) {
+            return None;
+        }
+        match (&source.type_predicate, &target.type_predicate) {
+            // TS1224: the target demands a type guard (`x is T`/`this is T`)
+            // and the source has no predicate at all. An assertion-only
+            // target (`asserts x`) is compatible without one and never
+            // reaches this branch — see `are_type_predicates_compatible`.
+            (None, Some(target_predicate)) => Some(SubtypeFailureReason::TypePredicateMismatch {
+                source_predicate: None,
+                target_predicate: *target_predicate,
+                source_signature: Some(self.interner.function(source.clone())),
+                nested_reason: None,
+            }),
+            // TS1226: both sides declare a predicate but they are
+            // incompatible (different target, guard-vs-assertion, or
+            // unrelated narrowed types).
+            (Some(source_predicate), Some(target_predicate)) => {
+                let nested_reason = match (source_predicate.type_id, target_predicate.type_id) {
+                    (Some(source_type), Some(target_type)) => {
+                        self.explain_failure(source_type, target_type).map(Box::new)
+                    }
+                    _ => None,
+                };
+                Some(SubtypeFailureReason::TypePredicateMismatch {
+                    source_predicate: Some(*source_predicate),
+                    target_predicate: *target_predicate,
+                    source_signature: None,
+                    nested_reason,
+                })
+            }
+            // (None, None) and (Some(_), None) are always compatible.
+            _ => None,
+        }
     }
 
     fn explain_function_parameter_failure(
@@ -268,7 +314,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         None
     }
 
-    fn function_shape_from_call_signature(
+    pub(super) fn function_shape_from_call_signature(
         signature: &CallSignature,
         is_constructor: bool,
     ) -> FunctionShape {


### PR DESCRIPTION
Part of #16291's "type predicates" family (TS1224/1226/1230). TS1230 was already fully wired and tested; this closes the other two.

Structural rule: when a function/method's target signature declares a type predicate (`x is T`, `this is T`) and the source signature either has no predicate at all or a predicate that targets a different parameter/asserts-flag/type, `tsc` reports `Signature '{0}' must be a type predicate.` (TS1224) or `Type predicate '{0}' is not assignable to '{1}'.` (TS1226, often with a nested `Type 'S' is not assignable to type 'T'.` line) as elaboration under the TS2322 header. `are_type_predicates_compatible` (`crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs`) already correctly makes the boolean decision — the assignment already failed as TS2322 before this change — but nothing in the solver's `relation -> reason -> diagnostic` chain explained why, so tsz produced the bare `Type 'S' is not assignable to type 'T'.` header with zero elaboration.

Root cause was two layers deep:

1. `explain_function_failure` (`crates/tsz-solver/src/relations/subtype/explain_function.rs`) never consulted `are_type_predicates_compatible` at all. Added `explain_type_predicate_failure`, a new `SubtypeFailureReason::TypePredicateMismatch` variant (`crates/tsz-solver/src/diagnostics/core.rs`), and `render_type_predicate_mismatch` in the checker (`crates/tsz-checker/src/error_reporter/render_failure_property_helpers.rs`) to turn it into the TS1224/TS1226 text, following the existing `ReturnTypeMismatch`/`PropertyTypeMismatch` chain-rendering conventions.
2. Even with (1), the TS1226 cases still produced no elaboration when the source was a `declare function` symbol: tsz interns an ambient function declaration's own type as a single-signature `Callable`, not `Function`. The existing Function-vs-Function dispatch in `explain_failure_inner` (`crates/tsz-solver/src/relations/subtype/explain.rs`) only matched when *both* sides were literally `TypeData::Function`, so it silently skipped this shape whenever the target was a bare `Function` (e.g. an arrow-type-annotated variable) and fell through to a generic `TypeMismatch` fallback. Added a symmetric branch that peels a property-free, single-call-signature `Callable` to a `FunctionShape`, mirroring the existing `explain_function_to_callable_failure` handling already present for the reverse direction.

## Adjacent-case matrix

New tests in `type_predicate_assignability_elaboration_tests.rs`:
- TS1224 (plain boolean function to a type-guard target), with renamed binders.
- TS1226 (two incompatible type guards, primitive predicate types), with renamed binders.
- TS1226 where the predicate types are structural interfaces, so the nested reason is a `MissingProperty` chain rather than a plain type mismatch — oracle-confirmed this collapses to 3 lines (no extra generic wrapper), same as `tsc`.
- Negative controls: assertion-only target accepts a plain function; a type-guard source is compatible with a plain-boolean target; matching type guards are compatible.

Both `declare function` (ambient, the shape that exposed the Callable-vs-Function gap) and inline function declarations are covered across the matrix.

## Goal
Goal: green

## Verification
- `cargo test -p tsz-checker --lib type_predicate_assignability_elaboration_tests`: 7/7 passed.
- `cargo test -p tsz-solver --lib`: 7637/7637 passed (full solver suite, no regressions from the `explain.rs` dispatch change).
- `cargo fmt`, `cargo clippy -p tsz-solver -p tsz-checker --lib --all-targets -- -D warnings`: clean.
- Pre-commit hook (`clippy` + `arch_guard.py` over `-p tsz-checker -p tsz-solver`): passed.
- `cargo test -p tsz-checker --lib` (full, ~9300 tests): started before this PR was opened; the fast bulk (>9000 tests) passed with no new failures observed, the known long-tail slow tests were still finishing at push time. Will report back if that surfaces anything; nothing in the affected diff touches those tests' subsystems.
- Not run: conformance/emit/fourslash. This is a pure elaboration-chain addition (new `SubtypeFailureReason` variant plus a dispatch-shape fix) that changes only *which sub-messages* accompany an already-correct TS2322, never whether an assignment is accepted or rejected — no currently-passing corpus fixture exercises the exact rendered text of a predicate-mismatch elaboration chain.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_01CUdrr3kb3d9L3bjvB647UJ)_