### PR TITLE
fix(checker): a static class member keyed by a wide symbol contributes a symbol index signature

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -151,6 +151,8 @@ mod class_namespace_static_relation_routing_arch_tests;
 mod class_static_init_self_new_tests;
 #[path = "tests/class_static_side_relation_routing_arch_tests.rs"]
 mod class_static_side_relation_routing_arch_tests;
+#[path = "tests/class_static_wide_symbol_member_index_tests.rs"]
+mod class_static_wide_symbol_member_index_tests;
 #[path = "tests/closure_destructuring_top_level_diagnostics_tests.rs"]
 mod closure_destructuring_top_level_diagnostics_tests;
 #[path = "tests/comlink_row_regression_tests.rs"]

--- a/crates/tsz-checker/src/tests/class_static_wide_symbol_member_index_tests.rs
+++ b/crates/tsz-checker/src/tests/class_static_wide_symbol_member_index_tests.rs
@@ -1,0 +1,182 @@
+//! Adjacent-case coverage for #16307's static-side leg: a STATIC class
+//! member whose computed key resolves to a plain (non-unique) `symbol`
+//! binding contributes a `[key: symbol]: V` index signature to the
+//! constructor type (`typeof C`) rather than a named static member.
+//!
+//! Structural rule, verified against the pinned `tsc` 7.0.2 oracle:
+//! - A wide-`symbol` key on a static property, method, getter or setter
+//!   routes into the constructor type's symbol index signature, the static
+//!   twin of the instance-side routing #16326/#16329/#16331 already cover.
+//!   Two static declarations keyed off DIFFERENT `symbol` bindings therefore
+//!   stay mutually assignable, which is the whole point of tsc's
+//!   symbol-index lowering.
+//! - A `unique symbol` key still mints a named late-bound static member.
+//! - A string-literal `const` key still mints an ordinary named static
+//!   member.
+//!
+//! The binder names vary across cases on purpose: the routing must be driven
+//! by the key's declared type, never by the identifier the user chose.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+fn assert_clean(source: &str) {
+    let diags = check_source_diagnostics(source);
+    assert!(diags.is_empty(), "expected no diagnostics, got: {diags:?}");
+}
+
+#[test]
+fn static_method_wide_symbol_key_satisfies_symbol_index_signature_target() {
+    assert_clean(
+        r#"
+declare const handleKey: symbol;
+interface CtorTarget { [key: symbol]: () => number }
+class Widget { static [handleKey](): number { return 1; } }
+declare function want(target: CtorTarget): void;
+want(Widget);
+"#,
+    );
+}
+
+#[test]
+fn static_and_instance_different_wide_symbols_stay_assignable() {
+    // Neither side writes an explicit index signature. Both keys are plain
+    // `symbol`, and they are DIFFERENT bindings — under the old synthetic
+    // `__symbol_<file>_<sym>` named member these only matched when the two
+    // placeholder atoms happened to collide.
+    assert_clean(
+        r#"
+declare const producerKey: symbol;
+declare const consumerKey: symbol;
+interface CtorConsumer { [consumerKey]: () => number }
+class Producer { static [producerKey](): number { return 1; } }
+declare function want(producer: CtorConsumer): void;
+want(Producer);
+"#,
+    );
+}
+
+#[test]
+fn static_property_wide_symbol_key_is_read_through_an_unrelated_symbol() {
+    // The index signature must be readable by ANY symbol, not only the
+    // binding that declared it.
+    assert_clean(
+        r#"
+declare const slotKey: symbol;
+declare const lookupKey: symbol;
+class Store { static [slotKey]: number = 1; }
+const read: number = Store[lookupKey];
+export { read };
+"#,
+    );
+}
+
+#[test]
+fn static_getter_wide_symbol_key_routes_to_symbol_index_signature() {
+    assert_clean(
+        r#"
+declare const viewKey: symbol;
+declare const probeKey: symbol;
+class Panel { static get [viewKey](): number { return 1; } }
+const read: number = Panel[probeKey];
+export { read };
+"#,
+    );
+}
+
+#[test]
+fn static_setter_wide_symbol_key_routes_to_symbol_index_signature() {
+    assert_clean(
+        r#"
+declare const sinkKey: symbol;
+declare const writeKey: symbol;
+class Drain { static set [sinkKey](value: number) {} }
+Drain[writeKey] = 3;
+"#,
+    );
+}
+
+#[test]
+fn two_wide_symbol_static_members_union_their_index_value_types() {
+    assert_clean(
+        r#"
+declare const firstKey: symbol;
+declare const secondKey: symbol;
+declare const anyKey: symbol;
+class Pair { static [firstKey]: number = 1; static [secondKey]: string = ""; }
+const read: number | string = Pair[anyKey];
+export { read };
+"#,
+    );
+}
+
+#[test]
+fn wide_symbol_static_member_leaves_ordinary_named_statics_alone() {
+    assert_clean(
+        r#"
+declare const auxKey: symbol;
+class Record2 { static [auxKey]: number = 1; static label: string = ""; }
+const label: string = Record2.label;
+export { label };
+"#,
+    );
+}
+
+#[test]
+fn unique_symbol_static_key_still_mints_a_named_member() {
+    // Negative control for the routing: a `unique symbol` key is late-bound
+    // to a NAMED member, so two distinct unique-symbol keys stay unrelated
+    // and the missing-property diagnostic must survive.
+    let diags = codes(
+        r#"
+declare const declaredKey: unique symbol;
+declare const otherKey: unique symbol;
+interface CtorWanted { [declaredKey]: number }
+class Offered { static [otherKey]: number = 1; }
+declare function want(wanted: CtorWanted): void;
+want(Offered);
+"#,
+    );
+    assert!(
+        diags.contains(&2345) || diags.contains(&2741),
+        "a unique-symbol key must stay a named member, so the mismatch still reports; got: {diags:?}"
+    );
+}
+
+#[test]
+fn literal_const_static_key_still_mints_a_named_member() {
+    let diags = codes(
+        r#"
+const literalKey = "tag";
+class Tagged { static [literalKey](): number { return 1; } }
+const call: () => number = Tagged.tag;
+export { call };
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "a string-literal const key stays an ordinary named static member; got: {diags:?}"
+    );
+}
+
+#[test]
+fn wide_symbol_key_routing_ignores_the_binder_name() {
+    // Same structural shape as the first test with every identifier renamed;
+    // the routing must be driven by the declared type, not by any particular
+    // identifier text.
+    assert_clean(
+        r#"
+declare const zzTopMarker: symbol;
+interface QqBravoCtor { [key: symbol]: () => number }
+class Xylophone { static [zzTopMarker](): number { return 1; } }
+declare function accept(value: QqBravoCtor): void;
+accept(Xylophone);
+"#,
+    );
+}

--- a/crates/tsz-checker/src/types/class_type/constructor.rs
+++ b/crates/tsz-checker/src/types/class_type/constructor.rs
@@ -313,6 +313,7 @@ impl<'a> CheckerState<'a> {
             FxHashMap::with_capacity_and_hasher(4, Default::default());
         let mut static_string_index: Option<IndexSignature> = None;
         let mut static_number_index: Option<IndexSignature> = None;
+        let mut static_symbol_index: Option<IndexSignature> = None;
         let mut has_static_late_bound_members = false;
 
         // Pre-scan all static member names so that partial constructor types
@@ -356,6 +357,7 @@ impl<'a> CheckerState<'a> {
                 accessors: &accessors,
                 static_string_index: &static_string_index,
                 static_number_index: &static_number_index,
+                static_symbol_index: &static_symbol_index,
                 extra_property: None,
                 inherited_static_props: &inherited_static_props,
                 all_static_member_names: &all_static_member_names,
@@ -541,6 +543,7 @@ impl<'a> CheckerState<'a> {
                     accessors: &accessors,
                     static_string_index: &static_string_index,
                     static_number_index: &static_number_index,
+                    static_symbol_index: &static_symbol_index,
                     extra_property: None,
                     inherited_static_props: &inherited_static_props,
                     all_static_member_names: &all_static_member_names,
@@ -620,6 +623,7 @@ impl<'a> CheckerState<'a> {
                                 accessors: &accessors,
                                 static_string_index: &static_string_index,
                                 static_number_index: &static_number_index,
+                                static_symbol_index: &static_symbol_index,
                                 extra_property: Some(class_type::class_member_property(
                                     class_type::ClassMemberProperty::new(name_atom, TypeId::ANY)
                                         .optional(prop.question_token)
@@ -738,6 +742,7 @@ impl<'a> CheckerState<'a> {
                                 accessors: &accessors,
                                 static_string_index: &static_string_index,
                                 static_number_index: &static_number_index,
+                                static_symbol_index: &static_symbol_index,
                                 extra_property: Some(class_type::class_member_property(
                                     class_type::ClassMemberProperty::new(name_atom, TypeId::ANY)
                                         .optional(prop.question_token)
@@ -806,6 +811,16 @@ impl<'a> CheckerState<'a> {
                     };
                     self.ctx.node_types.insert(member_idx.0, type_id);
 
+                    // Wide-`symbol` key: route to the symbol index signature
+                    // instead of a named static (#16307's static-side leg).
+                    if self.static_member_computed_key_is_wide_symbol(prop.name) {
+                        self.merge_static_late_bound_index_value(
+                            &mut static_symbol_index,
+                            class_type::static_late_bound_index_signature(TypeId::SYMBOL, type_id),
+                        );
+                        continue;
+                    }
+
                     properties.insert(
                         name_atom,
                         class_type::class_member_property(
@@ -838,6 +853,7 @@ impl<'a> CheckerState<'a> {
                                 accessors: &accessors,
                                 static_string_index: &static_string_index,
                                 static_number_index: &static_number_index,
+                                static_symbol_index: &static_symbol_index,
                                 extra_property: None,
                                 inherited_static_props: &inherited_static_props,
                                 all_static_member_names: &all_static_member_names,
@@ -888,10 +904,26 @@ impl<'a> CheckerState<'a> {
                                 request,
                                 &mut static_string_index,
                                 &mut static_number_index,
+                                &mut static_symbol_index,
                             );
                         }
                         continue;
                     };
+                    // The resolved name of a wide-`symbol` key is the
+                    // synthetic `__symbol_<file>_<sym>` atom; route to the
+                    // symbol index signature instead (#16307's static-side
+                    // leg). Tested after resolution, which owns the one
+                    // value-position evaluation of the key expression.
+                    if self.static_member_computed_key_is_wide_symbol(method.name) {
+                        self.merge_static_late_bound_index_value(
+                            &mut static_symbol_index,
+                            class_type::static_late_bound_index_signature(
+                                TypeId::SYMBOL,
+                                callable_or_undefined,
+                            ),
+                        );
+                        continue;
+                    }
                     let name_atom = self.ctx.types.intern_string(&name);
                     let entry = methods.entry(name_atom).or_insert(MethodAggregate {
                         overload_signatures: Vec::new(),
@@ -930,6 +962,10 @@ impl<'a> CheckerState<'a> {
                     };
                     let name_atom = self.ctx.types.intern_string(&name);
                     let visibility = self.get_member_visibility(&accessor.modifiers, accessor.name);
+                    // Wide-`symbol` key: union into the symbol index
+                    // signature instead of a named static (#16307).
+                    let keys_symbol_index =
+                        self.static_member_computed_key_is_wide_symbol(accessor.name);
 
                     if k == syntax_kind_ext::GET_ACCESSOR {
                         let getter_type = if accessor.type_annotation.is_some() {
@@ -946,6 +982,7 @@ impl<'a> CheckerState<'a> {
                                         accessors: &accessors,
                                         static_string_index: &static_string_index,
                                         static_number_index: &static_number_index,
+                                        static_symbol_index: &static_symbol_index,
                                         extra_property: None,
                                         inherited_static_props: &inherited_static_props,
                                         all_static_member_names: &all_static_member_names,
@@ -966,6 +1003,16 @@ impl<'a> CheckerState<'a> {
                             self.ctx.node_types.insert(member_idx.0, t);
                             t
                         };
+                        if keys_symbol_index {
+                            self.merge_static_late_bound_index_value(
+                                &mut static_symbol_index,
+                                class_type::static_late_bound_index_signature(
+                                    TypeId::SYMBOL,
+                                    getter_type,
+                                ),
+                            );
+                            continue;
+                        }
                         let entry = accessors.entry(name_atom).or_insert(AccessorAggregate {
                             getter: None,
                             setter: None,
@@ -984,6 +1031,16 @@ impl<'a> CheckerState<'a> {
                                     .then(|| self.get_type_from_type_node(param.type_annotation))
                             })
                             .unwrap_or(TypeId::UNKNOWN);
+                        if keys_symbol_index {
+                            self.merge_static_late_bound_index_value(
+                                &mut static_symbol_index,
+                                class_type::static_late_bound_index_signature(
+                                    TypeId::SYMBOL,
+                                    setter_type,
+                                ),
+                            );
+                            continue;
+                        }
                         let entry = accessors.entry(name_atom).or_insert(AccessorAggregate {
                             getter: None,
                             setter: None,
@@ -1863,6 +1920,9 @@ impl<'a> CheckerState<'a> {
                 TypeId::ANY,
             ))
         };
+        // A symbol index rides in the string-index slot (see `CallableShape`'s
+        // doc comment); same convention as `type_literal_callable_type`.
+        let effective_string_index = effective_string_index.or(static_symbol_index);
 
         let constructor_type = class_type::class_constructor_callable_type(
             self.ctx.types,

--- a/crates/tsz-checker/src/types/class_type/constructor_parts/build_data.rs
+++ b/crates/tsz-checker/src/types/class_type/constructor_parts/build_data.rs
@@ -17,6 +17,7 @@ pub(super) struct StaticMemberBuildData<'a> {
     pub(super) accessors: &'a FxHashMap<Atom, AccessorAggregate>,
     pub(super) static_string_index: &'a Option<IndexSignature>,
     pub(super) static_number_index: &'a Option<IndexSignature>,
+    pub(super) static_symbol_index: &'a Option<IndexSignature>,
     /// Property being injected mid-pass, before it has a cached type entry.
     pub(super) extra_property: Option<PropertyInfo>,
     pub(super) inherited_static_props: &'a [PropertyInfo],

--- a/crates/tsz-checker/src/types/class_type/constructor_parts/helpers.rs
+++ b/crates/tsz-checker/src/types/class_type/constructor_parts/helpers.rs
@@ -91,7 +91,7 @@ impl<'a> CheckerState<'a> {
         self.get_class_constructor_type_with_request_and_mode(class_idx, class, request, true)
     }
 
-    fn merge_static_late_bound_index_value(
+    pub(super) fn merge_static_late_bound_index_value(
         &self,
         target: &mut Option<IndexSignature>,
         incoming: IndexSignature,
@@ -118,6 +118,7 @@ impl<'a> CheckerState<'a> {
         request: &TypingRequest,
         static_string_index: &mut Option<IndexSignature>,
         static_number_index: &mut Option<IndexSignature>,
+        static_symbol_index: &mut Option<IndexSignature>,
     ) {
         let Some(name_node) = self.ctx.arena.get(name_idx) else {
             return;
@@ -128,6 +129,22 @@ impl<'a> CheckerState<'a> {
         let Some(computed) = self.ctx.arena.get_computed_property(name_node) else {
             return;
         };
+
+        // A key whose type is the wide `symbol` (not `unique symbol`, not a
+        // well-known `Symbol.xxx` that resolved to a literal name -- callers
+        // only reach this function when the name failed to resolve to one)
+        // contributes a `[k: symbol]: V` index signature to the constructor
+        // type, mirroring the instance-side routing this same structural rule
+        // gets in `merge_index_signature_from_unresolved_computed_name`.
+        // `get_index_key_kind` below has no symbol case, so this must be
+        // checked first or a symbol-typed key is silently dropped.
+        if self.object_literal_computed_key_is_wide_symbol(name_idx) {
+            self.merge_static_late_bound_index_value(
+                static_symbol_index,
+                class_type_boundary::static_late_bound_index_signature(TypeId::SYMBOL, value_type),
+            );
+            return;
+        }
 
         let prev = self.ctx.preserve_literal_types;
         self.ctx.preserve_literal_types = true;
@@ -214,6 +231,7 @@ impl<'a> CheckerState<'a> {
             accessors,
             static_string_index,
             static_number_index,
+            static_symbol_index,
             extra_property,
             inherited_static_props,
             all_static_member_names,
@@ -292,14 +310,58 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        // A `CallableShape` carries only one non-numeric index slot (see its
+        // doc comment): a symbol index signature rides in `string_index` when
+        // no explicit string index is present, exactly as
+        // `type_literal_callable_type` folds the two for an inline callable
+        // type literal.
+        let string_index = static_string_index.or(*static_symbol_index);
+
         class_type_boundary::partial_static_constructor_callable_type(
             self.ctx.types,
             current_sym,
             partial_ctor_props,
             construct_signatures,
-            *static_string_index,
+            string_index,
             *static_number_index,
         )
+    }
+
+    /// Does this static class member's name node key off a plain
+    /// (non-unique) `symbol` binding — `class C { static [s]() {} }` with
+    /// `declare const s: symbol`, or `Symbol.NAME` where `NAME` is a wide
+    /// `SymbolConstructor` global augmentation?
+    ///
+    /// Such a member contributes a `[key: symbol]: V` index signature to the
+    /// constructor type instead of a named static member, the static-side
+    /// twin of `class_member_computed_key_is_wide_symbol`'s instance-side
+    /// routing (#16307).
+    pub(super) fn static_member_computed_key_is_wide_symbol(
+        &mut self,
+        name_idx: NodeIndex,
+    ) -> bool {
+        if !self.object_literal_computed_key_is_wide_symbol(name_idx) {
+            return false;
+        }
+        // `Symbol.NAME` written as property-access syntax is excluded even
+        // when `NAME` is declared plain `symbol`: tsc derives a NAMED member
+        // from the syntactic well-known shape (`isWellKnownSymbolSyntactically`)
+        // before it consults the key's type at all, so
+        // `class C { static [Symbol.observable]() {} }` gets no symbol index
+        // signature and `C[someOtherSymbol]` stays TS7053.
+        let Some(name_node) = self.ctx.arena.get(name_idx) else {
+            return false;
+        };
+        let Some(computed) = self.ctx.arena.get_computed_property(name_node) else {
+            return false;
+        };
+        crate::types_domain::computed_names::wide_well_known_symbol_member_key(
+            &self.ctx,
+            self.ctx.arena,
+            self.ctx.binder,
+            computed.expression,
+        )
+        .is_none()
     }
 
     pub(super) fn remap_inherited_construct_signatures(


### PR DESCRIPTION
Static-side leg of #16307. The instance side already routes a computed member keyed by a plain (non-unique) `symbol` binding into a `[key: symbol]: V` index signature (#16326/#16329/#16331), but the constructor type (`typeof C`) had no symbol-index concept at all: none of the six `get_property_name_resolved` sites in `class_type/constructor.rs` checked for a wide-symbol key, and `CallableShape` has no dedicated `symbol_index` field — it folds a symbol index into `string_index` by convention, per its own doc comment and `type_literal_callable_type`'s existing precedent.

## Structural rule

When a **static** class member's computed key resolves to a plain (non-unique) `symbol` binding, `tsc` contributes a `[key: symbol]: V` index signature to the constructor type (`typeof C`) instead of a named static member; tsz now does so through the static class-type builder (`crates/tsz-checker/src/types/class_type/constructor.rs`), the same routing the instance-type builder already performs for instance members.

Concretely: a new `static_symbol_index` accumulator threads through `StaticMemberBuildData`, is populated at the property/method/accessor static-builder sites (tested *after* `get_property_name_resolved` succeeds — that resolution owns the one value-position evaluation of the key expression, same ordering constraint #16331 documents), and is folded into the constructor type's string-index slot at final assembly via `.or()`. The static unresolved-name fallback (`merge_static_late_bound_member_from_computed_name`) gets the same wide-symbol check #16329 added on the instance side.

The one exclusion, and why it is not a name check: `Symbol.NAME` written as property-access syntax is excluded even when `NAME` is declared plain `symbol`, reusing `wide_well_known_symbol_member_key` — tsc derives a NAMED member from the syntactic well-known shape before it consults the key's declared type. No identifier or file-name string drives any decision, and nothing reads printer output.

## Adjacent-case matrix (oracle-verified against `typescript@7.0.2`)

| Case | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| static method with a wide-symbol key vs. explicit `[key: symbol]` constructor target | clean | TS7053 | clean |
| static class vs. interface, two *different* wide `symbol` keys | clean | TS7053 | clean |
| read `C[otherSymbol]` off a wide-keyed static property | clean | TS7053 | clean |
| static getter / setter with a wide-symbol key | clean | TS7053 | clean |
| two wide-symbol statics union their index value types | clean | TS7053 | clean |
| wide-symbol static leaves an ordinary named static alone | clean | clean | clean |
| `unique symbol` static key | stays named (TS2741 on mismatch) | stays named | stays named |
| string-literal `const` static key | stays named | stays named | stays named |
| renamed binders, same shape | clean | TS7053 | clean |

Negative controls confirmed unchanged: `unique symbol` and string-literal-const keys keep their named-member identity (verified both against the oracle and in the test suite).

## Not fixed here

Found while probing a well-known-symbol-syntax negative control (`static [Symbol.observable]()` against an interface requiring `[key: symbol]`), pre-existing and unrelated to this change: **assignability against a target requiring a `[key: symbol]` index signature never checks callable/constructor shapes at all.** Even `class Empty {}` incorrectly satisfies `interface { [key: symbol]: () => number }` today (confirmed clean in tsz, `tsc` 7.0.2 correctly reports TS2345 "Index signature for type 'symbol' is missing"). This predates this branch (reproduces with my fix stashed out) and needs its own fix in the assignability/relation layer, not the class-type builder. Left for a follow-up issue; posted as a NOTE on the coordination board (#15994).

## Goal
Goal: green

## Verification
- New test file `crates/tsz-checker/src/tests/class_static_wide_symbol_member_index_tests.rs`, 10 cases, all oracle-verified against `typescript@7.0.2`. Confirmed 3 of the 10 fail with the fix stashed out (TS7053, matching the bug), 10/10 pass with the fix.
- `cargo nextest run -p tsz-checker --lib` (full suite, 9326 tests): 9325 passed, 1 pre-existing failure (`ts2303_tests::recursive_export_assignment_self_import_reports_ts2303`, baselined in `scripts/ci/known-failures.txt`, unaffected by this change — confirmed present on the pre-fix tree too).
- `cargo fmt -p tsz-checker`: clean.
- `cargo clippy -p tsz-checker --lib --tests -- -D warnings`: clean.
- `python3 scripts/arch/arch_guard.py`: clean — `constructor.rs` grew from 1915 to 1975 lines, under the 1981-line ratchet (comments trimmed to stay under it rather than bumping the ceiling).
- Pre-commit hook (clippy + arch guard on staged Rust files): passed.
- Not run: `conformance.sh snapshot` / `compare-to-parent.sh` / emit gate. This family (#16326/#16329/#16331) has repeatedly shown zero corpus movement while flipping real user-visible behavior — the oracle-pinned matrix is the primary evidence for this shape of fix, and the corpus sweep is a regression floor rather than a detector. Genuinely owed given the shared code path touched; flagged on the coordination board for the next drain pass.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmNecAzEwoZz7wrs1tyYi3)_