### PR TITLE
fix(cli): subpattern regex grammar codes must not suppress the rest of the file

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1527,11 +1527,17 @@ pub(super) const fn is_non_suppressing_parse_error(code: u32) -> bool {
             | 1487 // Octal escape sequences are not allowed (regex `\0`-prefixed decimal escape, AST is valid)
             | 1499 // Unknown regular expression flag (grammar check in tsc's checker, not a parse failure)
             | 1500 // Duplicate regular expression flag (grammar check, AST is valid)
+            | 1501 // This regular expression flag is only available when targeting '{0}' or later.
+                   // Reachable from the parser only for `s` inside a subpattern
+                   // (`/(?s:x)/` below ES2018); the trailing-flag pass emits the
+                   // same code from the checker, where suppression never applied.
             | 1502 // The Unicode 'u' and 'v' flags cannot be set simultaneously (grammar check, AST is valid)
+            | 1504 // Subpattern flags must be present when there is a minus sign (`/(?-:x)/`)
             | 1505 // Incomplete quantifier. Digit expected
             | 1506 // Numbers out of order in quantifier (`/a{2,1}/`)
             | 1507 // There is nothing available for repetition (`/{1}/u`)
             | 1508 // Unexpected '{0}'. Did you mean to escape it with backslash? (`/[a[b]]/u`)
+            | 1509 // This regular expression flag cannot be toggled within a subpattern (`/(?g:x)/`)
             | 1510 // '\k' must be followed by a capturing group name enclosed in angle brackets
             | 1511 // '\q' is only available inside character class (`/\q{a}/v`, regex grammar, AST is valid)
             | 1512 // '\c' must be followed by an ASCII letter (`/\c1/u`)

--- a/crates/tsz-cli/src/driver/check_utils/regex_grammar_suppression_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/regex_grammar_suppression_tests.rs
@@ -28,7 +28,11 @@ const REGEX_GRAMMAR_CODES: &[(u32, &str)] = &[
     (1487, r"/[\0]/u"),
     (1499, "/a/q"),
     (1500, "/a/gg"),
+    (1501, "/(?s:x)/"), // parser-side only for a subpattern flag; see below
     (1502, "/a/uv"),
+    (1504, "/(?-:x)/"),
+    (1509, "/(?g:x)/"),
+    (1511, r"/\q{a}/v"),
     (1505, "/a{1,/u"),
     (1506, "/a{2,1}/"),
     (1507, "/{1}/u"),
@@ -81,8 +85,21 @@ fn every_regex_grammar_code_is_non_suppressing() {
 /// to `REGEX_GRAMMAR_CODES` above, or record here why it suppresses.
 #[test]
 fn regex_validator_diagnostic_surface_is_audited() {
-    const VALIDATOR_SOURCE: &str =
-        include_str!("../../../../tsz-parser/src/parser/state_expressions_literals_regex.rs");
+    // Every parser module that emits into the regex-literal walk has to be
+    // listed here, not just the main one. Splitting a sub-grammar out into its
+    // own module is normal (`state_expressions_literals_regex.rs` is past the
+    // 2000-line shard limit, so it will keep happening) and must not carry the
+    // emit sites out of this tripwire's sight along with them.
+    const VALIDATOR_SOURCES: &[(&str, &str)] = &[
+        (
+            "state_expressions_literals_regex.rs",
+            include_str!("../../../../tsz-parser/src/parser/state_expressions_literals_regex.rs"),
+        ),
+        (
+            "regex_modifier_groups.rs",
+            include_str!("../../../../tsz-parser/src/parser/regex_modifier_groups.rs"),
+        ),
+    ];
 
     /// Constants the validator shares with non-regex parse failures. These stay
     /// out of `is_non_suppressing_parse_error` because the code, not the site,
@@ -125,32 +142,49 @@ fn regex_validator_diagnostic_surface_is_audited() {
         "OCTAL_ESCAPE_SEQUENCES_AND_BACKREFERENCES_ARE_NOT_ALLOWED_IN_A_CHARACTER_CLASS_I",
         "DECIMAL_ESCAPE_SEQUENCES_AND_BACKREFERENCES_ARE_NOT_ALLOWED_IN_A_CHARACTER_CLASS",
         "UNICODE_ESCAPE_SEQUENCES_ARE_ONLY_AVAILABLE_WHEN_THE_UNICODE_U_FLAG_OR_THE_UNICO",
+        // `\q` outside a character class under the `v` flag. Already carried by
+        // `is_non_suppressing_parse_error`; it was the emit site that landed
+        // without a matching entry here.
+        "Q_IS_ONLY_AVAILABLE_INSIDE_CHARACTER_CLASS",
+        // Subpattern modifier groups, `(?ims-ims: … )`.
+        "SUBPATTERN_FLAGS_MUST_BE_PRESENT_WHEN_THERE_IS_A_MINUS_SIGN",
+        "THIS_REGULAR_EXPRESSION_FLAG_CANNOT_BE_TOGGLED_WITHIN_A_SUBPATTERN",
+        "DUPLICATE_REGULAR_EXPRESSION_FLAG",
+        // Emitted from the parser only for `s` in a subpattern below ES2018.
+        // The trailing-flag pass emits the same code from the checker, where
+        // parse-diagnostic suppression never applied — which is exactly why
+        // this one was easy to miss.
+        "THIS_REGULAR_EXPRESSION_FLAG_IS_ONLY_AVAILABLE_WHEN_TARGETING_OR_LATER",
     ];
 
-    let mut referenced: Vec<&str> = VALIDATOR_SOURCE
-        .match_indices("diagnostic_codes::")
-        .map(|(at, marker)| {
-            let rest = &VALIDATOR_SOURCE[at + marker.len()..];
-            let end = rest
-                .find(|c: char| !c.is_ascii_uppercase() && !c.is_ascii_digit() && c != '_')
-                .unwrap_or(rest.len());
-            &rest[..end]
+    let mut referenced: Vec<(&str, &str)> = VALIDATOR_SOURCES
+        .iter()
+        .flat_map(|&(module, source)| {
+            source
+                .match_indices("diagnostic_codes::")
+                .map(move |(at, marker)| {
+                    let rest = &source[at + marker.len()..];
+                    let end = rest
+                        .find(|c: char| !c.is_ascii_uppercase() && !c.is_ascii_digit() && c != '_')
+                        .unwrap_or(rest.len());
+                    (module, &rest[..end])
+                })
         })
         .collect();
     referenced.sort_unstable();
     referenced.dedup();
 
-    let unaudited: Vec<&str> = referenced
+    let unaudited: Vec<(&str, &str)> = referenced
         .iter()
         .copied()
-        .filter(|name| {
+        .filter(|(_, name)| {
             !AUDITED_REGEX_ONLY.contains(name) && !SHARED_WITH_REAL_PARSE_FAILURES.contains(name)
         })
         .collect();
 
     assert!(
         unaudited.is_empty(),
-        "state_expressions_literals_regex.rs emits diagnostic code constant(s) \
+        "the regex validator emits diagnostic code constant(s) \
          {unaudited:?} that no one has classified. tsz emits these at PARSE time \
          but tsc emits the whole regex grammar family at CHECK time, so an \
          unclassified code silently suppresses every other diagnostic in any file \


### PR DESCRIPTION
**Follow-up to #16332, which merged before this was caught. There is a live false-negative on `main` right now.**

**Structural rule.** tsc validates regex literals from the *checker* — it re-scans the literal through `scanner.scanRange` — so a malformed pattern never enters `parseDiagnostics` and can never participate in `hasParseDiagnostics()` suppression. tsz validates during *parsing*, so every regex grammar code needs an entry in `is_non_suppressing_parse_error` (`crates/tsz-cli/src/driver/check_utils.rs`) or it sets `has_syntax_parse_errors` and **deletes unrelated diagnostics from the whole file**.

## The live regression

`#16332` added a parser-side TS1501 for `s` inside a subpattern. TS1501 had only ever been emitted by the checker's trailing-flag pass, where suppression does not apply — so it had no entry, and the new parser emit inherited none. Measured on `main` at `f0dc7cf`:

```ts
const re = /(?s:x)/;      // --target es2015
const bad: string = 1;
missingName;
({}).nope;
```

| | tsc 6.0.2 | tsz before | tsz after |
|---|---|---|---|
| `(1,15)` TS1501 | ✅ | ✅ | ✅ |
| `(2,7)` TS2322 | ✅ | **dropped** | ✅ |
| `(3,1)` TS2304 | ✅ | ✅ | ✅ |
| `(4,6)` TS2339 | ✅ | **dropped** | ✅ |

The control is the same file at `--target es2018`, where TS1501 does not fire: all three companions survive there before and after, so the deletion is caused by the diagnostic, not by the fixture. TS1504 and TS1509 are added for the same reason.

## Two older instances of the same gap, closed here

**TS1511.** `regex_validator_diagnostic_surface_is_audited` has been **failing on `main`** since #16325: the code is already carried by `is_non_suppressing_parse_error`, but its emit site landed without the matching audit entry. Verified pre-existing — `git show origin/main:…/state_expressions_literals_regex.rs | grep -c Q_IS_ONLY_AVAILABLE_INSIDE_CHARACTER_CLASS` → 2 emit sites, and 0 entries in the audit list at the same commit.

**The audit's own blind spot, which is why this class of bug keeps landing.** The tripwire `include_str!`'d exactly one file, `state_expressions_literals_regex.rs`. That file is past the 2000-line shard limit, so splitting sub-grammars out of it is the expected move — and #16332 did exactly that, which carried its emit sites out of the tripwire's sight along with them. The audit now scans a list of parser modules and names the offending module in its failure message, so the next split is covered by construction rather than by whoever remembers.

## Goal
Goal: hold

## Verification
- **The regression probe above**, run against a real `tsc` (`/opt/node22/…/tsc.js`, 6.0.2) with the ES2018 control. Before: 2 of 4 diagnostics deleted. After: exact match with tsc.
- Same probe for TS1509 (`/(?g:x)/` + the same three companions, `--target es2022`) — exact match with tsc.
- `cargo test -p tsz-cli --lib regex_grammar_suppression` — **3/3 pass** (`regex_validator_diagnostic_surface_is_audited` was **red on `main`** before this).
- `cargo test -p tsz-parser` — 1701/1701.
- `cargo clippy -p tsz-parser -p tsz-cli --all-targets -- -D warnings`, `cargo fmt --all`, `python3 scripts/arch/arch_guard.py` — all clean.
- Remaining `cargo test -p tsz-cli --lib` failures are untouched by this and were checked individually: 4 are `scripts/ci/known-failures.txt` baseline entries, and the `tsc_compat_tests` rows are environmental in a cloud container (they diff against the locally-resolvable `tsc`, which is 6.0.2 here, against tsz's 7.0.2 version string).
- **`compare-to-parent.sh` is owed at this head and is running now.** #16332's clean run (0 newly failing) was measured *before* this fix, and un-suppressing diagnostics can move rows in either direction, so that result does not carry over. Posting the new numbers here when it finishes.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Obsidian

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dx5XJM4WKLmHS7dhQcPUVa)_