### PR TITLE
fix(cli): plain-mode output suppresses cross-location related information

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/props/validation.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/validation.rs
@@ -3,8 +3,8 @@
 
 use crate::context::TypingRequest;
 use crate::diagnostics::{
-    DiagnosticCategory, DiagnosticRelatedInformation, diagnostic_codes, diagnostic_messages,
-    format_message,
+    DiagnosticCategory, DiagnosticRelatedInformation, RelatedInformationKind, diagnostic_codes,
+    diagnostic_messages, format_message,
 };
 use crate::error_reporter::{
     DiagnosticAnchorKind, DiagnosticRenderRequest, RelatedInformationPolicy,
@@ -1418,6 +1418,7 @@ impl<'a> CheckerState<'a> {
                         &[&prop_name],
                     ),
                     depth: 0,
+                    kind: RelatedInformationKind::LocationPointer,
                 });
             }
             self.emit_render_request_at_anchor(

--- a/crates/tsz-checker/src/checkers/use_strict_parameter_list.rs
+++ b/crates/tsz-checker/src/checkers/use_strict_parameter_list.rs
@@ -141,6 +141,7 @@ impl<'a> CheckerState<'a> {
             length,
             message_text: message.to_string(),
             depth: 0,
+            kind: crate::diagnostics::RelatedInformationKind::LocationPointer,
         }
     }
 

--- a/crates/tsz-checker/src/classes/class_implements_checker/core.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/core.rs
@@ -571,6 +571,7 @@ impl<'a> CheckerState<'a> {
                     category: crate::diagnostics::DiagnosticCategory::Message,
                     code,
                     depth,
+                    kind: crate::diagnostics::RelatedInformationKind::ChainLink,
                 });
         }
         true

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -1,8 +1,8 @@
 //! Type assignability error reporting (TS2322 and related).
 
 use crate::diagnostics::{
-    Diagnostic, DiagnosticCategory, DiagnosticRelatedInformation, diagnostic_codes,
-    diagnostic_messages, format_message,
+    Diagnostic, DiagnosticCategory, DiagnosticRelatedInformation, RelatedInformationKind,
+    diagnostic_codes, diagnostic_messages, format_message,
 };
 use crate::error_reporter::assignability_literal_display::display_has_boolean_member_literal_assignability;
 use crate::error_reporter::fingerprint_policy::{
@@ -834,6 +834,7 @@ impl<'a> CheckerState<'a> {
                 length: anchor.length,
                 message_text: detail,
                 depth: 0,
+                kind: RelatedInformationKind::ChainLink,
             }];
 
             self.emit_render_request_at_anchor(

--- a/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
@@ -466,6 +466,7 @@ impl<'a> CheckerState<'a> {
             length: anchor.length,
             message_text: detail,
             depth: 0,
+            kind: crate::diagnostics::RelatedInformationKind::ChainLink,
         }];
 
         self.emit_render_request_at_anchor(

--- a/crates/tsz-checker/src/error_reporter/assignability_type_parameter_target.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_type_parameter_target.rs
@@ -5,8 +5,8 @@
 //! failure is annotated with one of two notes (`TS5082`/`TS5075`).
 
 use crate::diagnostics::{
-    DiagnosticCategory, DiagnosticRelatedInformation, diagnostic_codes, diagnostic_messages,
-    format_message,
+    DiagnosticCategory, DiagnosticRelatedInformation, RelatedInformationKind, diagnostic_codes,
+    diagnostic_messages, format_message,
 };
 use crate::state::CheckerState;
 use tsz_solver::TypeId;
@@ -57,6 +57,7 @@ impl<'a> CheckerState<'a> {
             length,
             message_text,
             depth: note_depth,
+            kind: RelatedInformationKind::ChainLink,
         };
         let constraint =
             crate::query_boundaries::diagnostics::type_parameter_constraint(self.ctx.types, target)

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -1,8 +1,8 @@
 //! Call error emission functions (TS2345, TS2554, TS2769, etc.).
 
 use crate::diagnostics::{
-    DiagnosticCategory, DiagnosticRelatedInformation, diagnostic_codes, diagnostic_messages,
-    format_message,
+    DiagnosticCategory, DiagnosticRelatedInformation, RelatedInformationKind, diagnostic_codes,
+    diagnostic_messages, format_message,
 };
 use crate::error_reporter::fingerprint_policy::{
     DiagnosticAnchorKind, DiagnosticRenderRequest, RelatedInformationPolicy,
@@ -1250,6 +1250,7 @@ impl<'a> CheckerState<'a> {
                     category: DiagnosticCategory::Message,
                     code,
                     depth,
+                    kind: RelatedInformationKind::ChainLink,
                 }
             };
 

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -7,8 +7,8 @@
 //! - related-information normalization
 
 use crate::diagnostics::{
-    Diagnostic, DiagnosticCategory, DiagnosticRelatedInformation, diagnostic_codes,
-    diagnostic_messages, format_message,
+    Diagnostic, DiagnosticCategory, DiagnosticRelatedInformation, RelatedInformationKind,
+    diagnostic_codes, diagnostic_messages, format_message,
 };
 use crate::error_reporter::assignability::is_object_prototype_method;
 use crate::error_reporter::type_display_policy::DiagnosticTypeDisplayRole;
@@ -400,6 +400,7 @@ impl<'a> CheckerState<'a> {
                         &[&prop_name, &src_str, &tgt_str],
                     ),
                     depth: 0,
+                    kind: RelatedInformationKind::ChainLink,
                 }]
             }
             SubtypeFailureReason::MissingProperties {
@@ -461,6 +462,7 @@ impl<'a> CheckerState<'a> {
                             &[&src_str, &tgt_str, &names.join(", ")],
                         ),
                         depth: 0,
+                        kind: RelatedInformationKind::ChainLink,
                     }]
                 } else {
                     let shown: Vec<&str> = names.iter().take(4).map(|s| s.as_str()).collect();
@@ -476,6 +478,7 @@ impl<'a> CheckerState<'a> {
                             &[&src_str, &tgt_str, &shown.join(", "), &more.to_string()],
                         ),
                                             depth: 0,
+                    kind: RelatedInformationKind::ChainLink,
                     }]
                 }
             }
@@ -534,6 +537,7 @@ impl<'a> CheckerState<'a> {
                             &[&self.ctx.types.resolve_atom_ref(*property_name)],
                         ),
                         depth: 0,
+                        kind: RelatedInformationKind::ChainLink,
                     },
                     DiagnosticRelatedInformation {
                         category: DiagnosticCategory::Message,
@@ -550,6 +554,7 @@ impl<'a> CheckerState<'a> {
                         // `normalize_related_information` for why the chain
                         // order depends on this.
                         depth: 1,
+                        kind: RelatedInformationKind::ChainLink,
                     },
                 ];
                 // When the property type fails because a union member is not
@@ -594,6 +599,7 @@ impl<'a> CheckerState<'a> {
                         ],
                     ),
                     depth: 0,
+                    kind: RelatedInformationKind::ChainLink,
                 }]
             }
             SubtypeFailureReason::ReturnTypeMismatch {
@@ -628,6 +634,7 @@ impl<'a> CheckerState<'a> {
                         &[&source_str, &target_str],
                     ),
                     depth: 0,
+                    kind: RelatedInformationKind::ChainLink,
                 }];
                 // Drill into nested reason to produce elaboration diagnostics
                 // (e.g. TS2741 "Property 'x' is missing..." when the return type
@@ -675,6 +682,7 @@ impl<'a> CheckerState<'a> {
                             "{index_kind} index signature is incompatible: '{source_str}' is not assignable to '{target_str}'."
                         ),
                         depth: 0,
+                        kind: RelatedInformationKind::ChainLink,
                     },
                     DiagnosticRelatedInformation {
                         category: DiagnosticCategory::Message,
@@ -687,6 +695,7 @@ impl<'a> CheckerState<'a> {
                             &[&source_str, &target_str],
                         ),
                         depth: 1,
+                        kind: RelatedInformationKind::ChainLink,
                     },
                 ]
             }
@@ -732,6 +741,7 @@ impl<'a> CheckerState<'a> {
                         ],
                     ),
                     depth: 0,
+                    kind: RelatedInformationKind::ChainLink,
                 }]
             }
             SubtypeFailureReason::AbstractConstructorAssignment => {
@@ -744,6 +754,7 @@ impl<'a> CheckerState<'a> {
                     message_text: diagnostic_messages::CANNOT_ASSIGN_AN_ABSTRACT_CONSTRUCTOR_TYPE_TO_A_NON_ABSTRACT_CONSTRUCTOR_TYPE
                         .to_string(),
                                     depth: 0,
+                kind: RelatedInformationKind::ChainLink,
                 }]
             }
             SubtypeFailureReason::UnionSourceMismatch { .. }
@@ -937,6 +948,7 @@ impl<'a> CheckerState<'a> {
                 &[&member_str, &target_str],
             ),
             depth,
+            kind: RelatedInformationKind::ChainLink,
         })
     }
 
@@ -956,6 +968,7 @@ impl<'a> CheckerState<'a> {
                 length: diag.length,
                 message_text: diag.message_text.clone(),
                 depth: 0,
+                kind: RelatedInformationKind::ChainLink,
             });
         }
 

--- a/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
+++ b/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
@@ -66,7 +66,7 @@ impl<'a> CheckerState<'a> {
             let Some((start, length, file)) = self.declared_here_anchor(location, property) else {
                 continue;
             };
-            return Some(Diagnostic::related_message(
+            return Some(Diagnostic::related_pointer(
                 diagnostic_codes::IS_DECLARED_HERE,
                 file.unwrap_or_else(|| self.ctx.file_name.clone()),
                 start,
@@ -79,7 +79,7 @@ impl<'a> CheckerState<'a> {
             else {
                 continue;
             };
-            return Some(Diagnostic::related_message(
+            return Some(Diagnostic::related_pointer(
                 diagnostic_codes::IS_DECLARED_HERE,
                 file.unwrap_or_else(|| self.ctx.file_name.clone()),
                 start,

--- a/crates/tsz-checker/src/error_reporter/operator_errors.rs
+++ b/crates/tsz-checker/src/error_reporter/operator_errors.rs
@@ -4,8 +4,8 @@ use super::fingerprint_policy::{
     DiagnosticAnchorKind, DiagnosticRenderRequest, RelatedInformationPolicy,
 };
 use crate::diagnostics::{
-    DiagnosticCategory, DiagnosticRelatedInformation, diagnostic_codes, diagnostic_messages,
-    format_message,
+    DiagnosticCategory, DiagnosticRelatedInformation, RelatedInformationKind, diagnostic_codes,
+    diagnostic_messages, format_message,
 };
 use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::CheckerState;
@@ -131,6 +131,7 @@ impl<'a> CheckerState<'a> {
             length,
             message_text: format_message(template, &[&type_str]),
             depth: 0,
+            kind: RelatedInformationKind::ChainLink,
         })
     }
 

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -87,8 +87,8 @@ pub use types_domain::{
 pub mod diagnostics {
     pub use crate::jsdoc::diagnostics_typedef_name::jsdoc_typedef_missing_name_anchors;
     pub use tsz_common::diagnostics::{
-        Diagnostic, DiagnosticCategory, DiagnosticRelatedInformation, diagnostic_codes,
-        diagnostic_messages, format_message, internal_elaboration_messages,
+        Diagnostic, DiagnosticCategory, DiagnosticRelatedInformation, RelatedInformationKind,
+        diagnostic_codes, diagnostic_messages, format_message, internal_elaboration_messages,
         is_js_grammar_diagnostic, is_parser_grammar_diagnostic,
     };
 }

--- a/crates/tsz-checker/src/state/state_checking/core.rs
+++ b/crates/tsz-checker/src/state/state_checking/core.rs
@@ -246,6 +246,7 @@ impl<'a> CheckerState<'a> {
                             &[&var_name],
                         ),
                         depth: 0,
+                        kind: crate::diagnostics::RelatedInformationKind::ChainLink,
                     }]
                 })
                 .unwrap_or_default();

--- a/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
+++ b/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
@@ -70,6 +70,36 @@ fn span_text(source: &str, start: u32, length: u32) -> &str {
     &source[start as usize..(start + length) as usize]
 }
 
+/// The pointer models tsc's `relatedInformation`, not a `messageText` chain
+/// link, so it must carry that tag through to the reporter. Oracled on
+/// `typescript@7.0.2`: `tsc --noEmit --strict --pretty false` on this source
+/// prints the TS2741 line alone, with no `'y' is declared here.` beneath it,
+/// while the `--pretty` run does print it with its own location and snippet.
+/// Only the tag distinguishes the two — a chain link carries a real file and a
+/// real span exactly as this entry does.
+#[test]
+fn declared_here_pointer_is_tagged_as_a_cross_location_pointer() {
+    let source = "interface Point { x: number; y: number; }\nconst p: Point = { x: 1 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let pointer = diagnostic
+        .related_information
+        .iter()
+        .find(|info| info.code == TS2728)
+        .expect("TS2728 pointer");
+    assert!(
+        pointer.is_location_pointer(),
+        "TS2728 must be a cross-location pointer: {pointer:?}"
+    );
+    assert!(
+        diagnostic
+            .related_information
+            .iter()
+            .filter(|info| info.code != TS2728)
+            .all(|info| !info.is_location_pointer()),
+        "elaboration links on the same diagnostic stay chain links: {diagnostic:?}"
+    );
+}
+
 #[test]
 fn single_missing_interface_property_points_at_its_declaration() {
     let source = "interface Point { x: number; y: number; }\nconst p: Point = { x: 1 };\n";

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -4,6 +4,7 @@ use super::check_module_graph::*;
 use super::check_utils::*;
 use super::*;
 use tsz::checker::context::RequestCacheCounters;
+use tsz::checker::diagnostics::RelatedInformationKind;
 use tsz_common::checker_options::JsxMode;
 
 const fn checker_resolution_mode_override(
@@ -274,6 +275,7 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
                         length: 0,
                         message_text: "The file is in the program because:".to_string(),
                         depth: 0,
+                        kind: RelatedInformationKind::ChainLink,
                     });
                 ts6504
                     .related_information
@@ -287,6 +289,7 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
                         // Second link of tsc's file-inclusion-reason chain, so
                         // it indents one level deeper than the header above it.
                         depth: 1,
+                        kind: RelatedInformationKind::ChainLink,
                     });
                 diagnostics.push(ts6504);
             }

--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part5.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part5.rs
@@ -300,4 +300,16 @@ const elem = <div className={class1, class2}/>;
             vec![(1348, 11, 6)],
             "TS1347 must keep its parameter pointer: {ts1347:?}"
         );
+
+        // Both are `tsc` `relatedInformation` (cross-location pointers), not
+        // `messageText` chain links, so they must survive the driver tagged as
+        // such — that tag is what keeps them out of plain-mode output.
+        assert!(
+            ts1346.related_information.iter().all(|r| r.is_location_pointer()),
+            "TS1346's pointer must survive tagged as a pointer: {ts1346:?}"
+        );
+        assert!(
+            ts1347.related_information.iter().all(|r| r.is_location_pointer()),
+            "TS1347's pointer must survive tagged as a pointer: {ts1347:?}"
+        );
     }

--- a/crates/tsz-cli/src/driver/core.rs
+++ b/crates/tsz-cli/src/driver/core.rs
@@ -18,7 +18,8 @@ use tsz::binder::{SymbolId, SymbolTable};
 use tsz::checker::TypeCache;
 use tsz::checker::context::LibContext;
 use tsz::checker::diagnostics::{
-    Diagnostic, DiagnosticCategory, DiagnosticRelatedInformation, diagnostic_codes,
+    Diagnostic, DiagnosticCategory, DiagnosticRelatedInformation, RelatedInformationKind,
+    diagnostic_codes,
 };
 use tsz::checker::state::CheckerState;
 use tsz::lib_loader::LibFile;
@@ -585,6 +586,8 @@ fn compilation_cache_to_build_info(
                                 message_text: r.message_text.clone(),
                                 category: r.category as u8,
                                 code: r.code,
+                                depth: r.depth,
+                                location_pointer: r.is_location_pointer(),
                             }
                         })
                         .collect(),
@@ -695,7 +698,12 @@ fn build_info_to_compilation_cache(build_info: &BuildInfo, base_dir: &Path) -> C
                         message_text: r.message_text.clone(),
                         category: DiagnosticCategory::from_cache_index(r.category),
                         code: r.code,
-                        depth: 0,
+                        depth: r.depth,
+                        kind: if r.location_pointer {
+                            RelatedInformationKind::LocationPointer
+                        } else {
+                            RelatedInformationKind::ChainLink
+                        },
                     })
                     .collect(),
             })

--- a/crates/tsz-cli/src/project/incremental.rs
+++ b/crates/tsz-cli/src/project/incremental.rs
@@ -130,6 +130,19 @@ pub struct CachedRelatedInformation {
     pub message_text: String,
     pub category: u8,
     pub code: u32,
+    /// Elaboration nesting depth, mirroring
+    /// `DiagnosticRelatedInformation::depth`. Defaults to the first
+    /// elaboration level so build-info files written before this field
+    /// existed still deserialize.
+    #[serde(default)]
+    pub depth: u8,
+    /// `true` when the entry is a cross-location pointer (`tsc`:
+    /// `relatedInformation`) rather than an elaboration chain link. Drives
+    /// plain-mode suppression, so it has to survive the cache round trip or a
+    /// cached diagnostic renders differently from a freshly checked one.
+    /// Defaults to `false` (chain link) for older build-info files.
+    #[serde(default)]
+    pub location_pointer: bool,
 }
 
 impl Default for BuildInfo {

--- a/crates/tsz-cli/src/reporting/reporter.rs
+++ b/crates/tsz-cli/src/reporting/reporter.rs
@@ -129,8 +129,15 @@ impl Reporter {
         let message = self.translate_message(diagnostic.code, &diagnostic.message_text);
         out.push_str(&message);
 
-        // Non-pretty: related info is shown inline
+        // Non-pretty: elaboration chain links are shown inline, cross-location
+        // pointers are not. `tsc`'s non-pretty formatter renders only
+        // `flattenDiagnosticMessageText(messageText)` — `relatedInformation` is
+        // rendered exclusively by the pretty formatter, so a `'y' is declared
+        // here.` pointer has no plain-mode line at all.
         for related in &diagnostic.related_information {
+            if related.is_location_pointer() {
+                continue;
+            }
             out.push('\n');
             self.format_related_plain(out, related);
         }
@@ -706,6 +713,128 @@ mod tests {
         reporter
     }
 
+    use tsz::checker::diagnostics::RelatedInformationKind;
+
+    /// A cross-location pointer (`tsc`: `relatedInformation`) at `file`.
+    fn pointer_at(
+        file: &str,
+        start: u32,
+        length: u32,
+        message: &str,
+    ) -> DiagnosticRelatedInformation {
+        related_at(file, start, length, message).into_location_pointer()
+    }
+
+    /// #16316: `tsc`'s non-pretty formatter renders only the flattened
+    /// `messageText`; `relatedInformation` is rendered exclusively by the
+    /// pretty formatter. Oracled on `typescript@7.0.2`:
+    ///
+    /// ```text
+    /// $ tsc --noEmit --strict --pretty false rel.ts
+    /// rel.ts(2,7): error TS2741: Property 'y' is missing in type '{ x: number; }' but required in type 'Point'.
+    /// ```
+    ///
+    /// — one line, no `'y' is declared here.` beneath it, even though the
+    /// pretty run prints that pointer with its own location and snippet.
+    #[test]
+    fn plain_output_suppresses_cross_location_pointers() {
+        let source = "interface Point { x: number; y: number; }\nconst p: Point = { x: 1 };\n";
+        let mut reporter = reporter_with_source("rel.ts", source);
+        reporter.set_pretty(false);
+
+        let mut diagnostic = Diagnostic::error(
+            "rel.ts",
+            48,
+            1,
+            "Property 'y' is missing in type '{ x: number; }' but required in type 'Point'.",
+            2741,
+        );
+        diagnostic
+            .related_information
+            .push(pointer_at("rel.ts", 29, 1, "'y' is declared here."));
+
+        let mut out = String::new();
+        reporter.format_diagnostic_plain(&mut out, &diagnostic);
+
+        assert_eq!(
+            out,
+            "rel.ts(2,7): error TS2741: Property 'y' is missing in type '{ x: number; }' but \
+             required in type 'Point'."
+        );
+    }
+
+    /// The suppression is keyed on the entry's kind, not on whether it names a
+    /// file: an elaboration chain link carries a real file and the primary's
+    /// own anchor, and `tsc` flattens it into `messageText`, so plain output
+    /// must keep printing it.
+    #[test]
+    fn plain_output_keeps_elaboration_chain_links() {
+        let source = "declare const a: string;\nconst b: number = a;\n";
+        let mut reporter = reporter_with_source("chain.ts", source);
+        reporter.set_pretty(false);
+
+        let mut diagnostic = Diagnostic::error(
+            "chain.ts",
+            31,
+            1,
+            "Type 'string' is not assignable to type 'number'.",
+            2322,
+        );
+        diagnostic
+            .related_information
+            .push(related_at("chain.ts", 31, 1, "First elaboration."));
+        diagnostic.related_information.push({
+            let mut deeper = related_at("chain.ts", 31, 1, "Nested elaboration.");
+            deeper.depth = 1;
+            deeper
+        });
+
+        let mut out = String::new();
+        reporter.format_diagnostic_plain(&mut out, &diagnostic);
+
+        assert_eq!(
+            out,
+            "chain.ts(2,7): error TS2322: Type 'string' is not assignable to type 'number'.\n  \
+             First elaboration.\n    Nested elaboration."
+        );
+    }
+
+    /// A diagnostic carrying both kinds keeps only the chain link in plain
+    /// output and renders both in pretty output — the two modes must not agree.
+    #[test]
+    fn pretty_output_still_renders_pointers_that_plain_output_drops() {
+        let source = "interface Point { x: number; y: number; }\nconst p: Point = { x: 1 };\n";
+        let mut diagnostic = Diagnostic::error(
+            "rel.ts",
+            48,
+            1,
+            "Property 'y' is missing in type '{ x: number; }' but required in type 'Point'.",
+            2741,
+        );
+        diagnostic
+            .related_information
+            .push(related_at("rel.ts", 48, 1, "Chain link."));
+        diagnostic
+            .related_information
+            .push(pointer_at("rel.ts", 29, 1, "'y' is declared here."));
+
+        let mut plain = reporter_with_source("rel.ts", source);
+        plain.set_pretty(false);
+        let mut plain_out = String::new();
+        plain.format_diagnostic_plain(&mut plain_out, &diagnostic);
+        assert!(plain_out.contains("Chain link."), "{plain_out}");
+        assert!(!plain_out.contains("declared here"), "{plain_out}");
+
+        let mut pretty = reporter_with_source("rel.ts", source);
+        let mut pretty_out = String::new();
+        pretty.format_diagnostic_pretty(&mut pretty_out, &diagnostic);
+        assert!(pretty_out.contains("Chain link."), "{pretty_out}");
+        assert!(
+            pretty_out.contains("rel.ts:1:30 - 'y' is declared here."),
+            "{pretty_out}"
+        );
+    }
+
     fn related_at(
         file: &str,
         start: u32,
@@ -720,6 +849,7 @@ mod tests {
             length,
             message_text: message.to_string(),
             depth: 0,
+            kind: RelatedInformationKind::ChainLink,
         }
     }
 

--- a/crates/tsz-common/src/diagnostics/mod.rs
+++ b/crates/tsz-common/src/diagnostics/mod.rs
@@ -70,6 +70,34 @@ pub mod internal_elaboration_messages {
         "Types have separate declarations of a protected property '{0}'.";
 }
 
+/// Which of `tsc`'s two distinct diagnostic concepts a related entry models.
+///
+/// `tsc` keeps these in *separate* fields and renders them in different modes;
+/// `tsz` carries both in one `related_information` vector, so the distinction
+/// has to travel with the entry:
+///
+/// - a message-chain link lives in `tsc`'s `messageText`
+///   (`DiagnosticMessageChain`) and is flattened into the message body, so it
+///   prints in **both** pretty and plain output;
+/// - a cross-location pointer lives in `tsc`'s `relatedInformation` and is
+///   rendered only by `formatDiagnosticsWithColorAndContext`, so it prints in
+///   **pretty output only**.
+///
+/// Without this field the two are indistinguishable — an elaboration link
+/// carries a real file and the primary's own anchor, exactly like a pointer
+/// would — and the plain-mode renderer has to print both or neither.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RelatedInformationKind {
+    /// A link in the primary diagnostic's elaboration message chain. Rendered
+    /// as `2 * (depth + 1)`-indented text in pretty and plain output alike.
+    #[default]
+    ChainLink,
+    /// A genuine cross-location pointer such as `'y' is declared here.`.
+    /// Rendered with its own file/line/col header and source snippet in pretty
+    /// output, and suppressed entirely in plain output.
+    LocationPointer,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiagnosticRelatedInformation {
     pub category: DiagnosticCategory,
@@ -84,9 +112,26 @@ pub struct DiagnosticRelatedInformation {
     /// deeper level adds 2 more spaces. Genuine cross-location related
     /// information (not part of an elaboration chain) stays at `0`.
     pub depth: u8,
+    /// Whether this entry is an elaboration chain link or a cross-location
+    /// pointer. See [`RelatedInformationKind`]; drives plain-mode suppression.
+    pub kind: RelatedInformationKind,
 }
 
 impl DiagnosticRelatedInformation {
+    /// Whether this entry models `tsc`'s `relatedInformation` (a cross-location
+    /// pointer) rather than a `messageText` chain link.
+    #[must_use]
+    pub const fn is_location_pointer(&self) -> bool {
+        matches!(self.kind, RelatedInformationKind::LocationPointer)
+    }
+
+    /// Re-tag this entry as a cross-location pointer.
+    #[must_use]
+    pub const fn into_location_pointer(mut self) -> Self {
+        self.kind = RelatedInformationKind::LocationPointer;
+        self
+    }
+
     /// Return this related entry with its elaboration `depth` shifted by `delta`
     /// and clamped into the `u8` rendering range (saturating at both ends).
     ///
@@ -185,7 +230,24 @@ impl Diagnostic {
             length,
             message_text: message_text.into(),
             depth: 0,
+            kind: RelatedInformationKind::ChainLink,
         }
+    }
+
+    /// Build a cross-location "declared here"-style pointer (`tsc`:
+    /// `relatedInformation`) at `file`/`start`/`length`.
+    ///
+    /// Same shape as [`Diagnostic::related_message`] but tagged
+    /// [`RelatedInformationKind::LocationPointer`], so plain output suppresses
+    /// it the way `tsc`'s non-pretty formatter does.
+    pub fn related_pointer(
+        code: u32,
+        file: impl Into<String>,
+        start: u32,
+        length: u32,
+        message_text: impl Into<String>,
+    ) -> DiagnosticRelatedInformation {
+        Self::related_message(code, file, start, length, message_text).into_location_pointer()
     }
 
     #[must_use]

--- a/crates/tsz-lsp/tests/diagnostics_tests.rs
+++ b/crates/tsz-lsp/tests/diagnostics_tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use tsz_checker::diagnostics::{
-    Diagnostic, DiagnosticCategory, DiagnosticRelatedInformation, diagnostic_codes,
+    Diagnostic, DiagnosticCategory, DiagnosticRelatedInformation, RelatedInformationKind,
+    diagnostic_codes,
 };
 use tsz_common::position::LineMap;
 
@@ -35,6 +36,7 @@ fn test_convert_diagnostic_with_related_info() {
         category: DiagnosticCategory::Message,
         code: 0,
         depth: 0,
+        kind: RelatedInformationKind::ChainLink,
     };
     let related_other = DiagnosticRelatedInformation {
         file: "other.ts".to_string(),
@@ -44,6 +46,7 @@ fn test_convert_diagnostic_with_related_info() {
         category: DiagnosticCategory::Message,
         code: 0,
         depth: 0,
+        kind: RelatedInformationKind::ChainLink,
     };
     let diag = Diagnostic {
         file: "test.ts".to_string(),
@@ -279,6 +282,7 @@ fn test_ts_diagnostic_with_related_information() {
         category: DiagnosticCategory::Message,
         code: 0,
         depth: 0,
+        kind: RelatedInformationKind::ChainLink,
     });
     let ts_diag = convert_to_ts_diagnostic(&diag, &line_map, source);
     assert_eq!(ts_diag.code, 2322);
@@ -437,6 +441,7 @@ fn test_convert_diagnostic_all_related_info_from_other_files_filtered_out() {
         category: DiagnosticCategory::Message,
         code: 0,
         depth: 0,
+        kind: RelatedInformationKind::ChainLink,
     });
     let lsp_diag = convert_diagnostic(&diag, &line_map, source);
     assert!(
@@ -703,6 +708,7 @@ fn test_convert_to_ts_diagnostic_related_info_filtered_by_file() {
         category: DiagnosticCategory::Message,
         code: 0,
         depth: 0,
+        kind: RelatedInformationKind::ChainLink,
     });
     let ts_diag = convert_to_ts_diagnostic(&diag, &line_map, source);
     assert!(
@@ -1233,6 +1239,7 @@ fn test_diagnostic_with_related_info_same_file() {
         category: DiagnosticCategory::Message,
         code: 0,
         depth: 0,
+        kind: RelatedInformationKind::ChainLink,
     });
     let lsp_diag = convert_diagnostic(&diag, &line_map, source);
     let _ = lsp_diag;
@@ -1344,6 +1351,7 @@ fn test_diagnostic_multiple_related_info() {
             category: DiagnosticCategory::Message,
             code: 0,
             depth: 0,
+            kind: RelatedInformationKind::ChainLink,
         });
     }
     let lsp_diag = convert_diagnostic(&diag, &line_map, source);

--- a/crates/tsz-solver/src/diagnostics/builders.rs
+++ b/crates/tsz-solver/src/diagnostics/builders.rs
@@ -671,7 +671,7 @@ impl TypeDiagnostic {
     /// Uses the provided `file_name` if no span is present.
     pub fn to_checker_diagnostic(&self, default_file: &str) -> tsz_common::diagnostics::Diagnostic {
         use tsz_common::diagnostics::{
-            Diagnostic, DiagnosticCategory, DiagnosticRelatedInformation,
+            Diagnostic, DiagnosticCategory, DiagnosticRelatedInformation, RelatedInformationKind,
         };
 
         let (file, start, length) = if let Some(ref span) = self.span {
@@ -698,6 +698,7 @@ impl TypeDiagnostic {
                 category: DiagnosticCategory::Message,
                 code: 0,
                 depth: rel.depth,
+                kind: RelatedInformationKind::ChainLink,
             })
             .collect();
 


### PR DESCRIPTION
Closes the CLI-side half of #16316 — the one Aventurine wrote up at 19:08Z and both #16318 and #16322/#16330 explicitly left open.

**Structural rule.** When a related entry models `tsc`'s `relatedInformation` (a cross-location pointer such as `'y' is declared here.`) rather than a `messageText` chain link, `tsc` renders it in pretty output only — its non-pretty formatter emits `flattenDiagnosticMessageText(messageText)` and nothing else. `tsz` now does the same through the **CLI reporting layer**, driven by a discriminator the checker sets at construction time.

`tsz` carries both of `tsc`'s concepts in one `related_information` vector, and until now nothing told them apart: an elaboration chain link carries a real file and a real span *exactly* as a pointer does (the chain links `error_reporter/assignability.rs` builds sit at the primary's own anchor with `file: self.ctx.file_name`). So the plain renderer had to print both or neither, and printed both.

Oracle (`typescript@7.0.2`, `--noEmit --strict --pretty false`, transcripts from #16316's investigation comment):

```
$ tsc --pretty false rel.ts
rel.ts(2,7): error TS2741: Property 'y' is missing in type '{ x: number; }' but required in type 'Point'.

$ tsc --pretty false us.ts
us.ts(1,12): error TS1346: This parameter is not allowed with 'use strict' directive.
us.ts(1,21): error TS1347: 'use strict' directive cannot be used with non-simple parameter list.
```

No related lines in either. The same sources under `--pretty` do print `'y' is declared here.` and `'use strict' directive used here.` with their own location headers and snippets. `tsz` printed them in **both** modes.

## What changed

- `RelatedInformationKind { ChainLink (default), LocationPointer }` on `DiagnosticRelatedInformation` (`tsz-common`), plus `Diagnostic::related_pointer` beside the existing `related_message`, and `is_location_pointer()` / `into_location_pointer()`.
- `format_diagnostic_plain` skips pointers. **`format_diagnostic_pretty` is untouched** — the located/unlocated branch #16318 landed still owns pretty rendering.
- Tagged the two pointer families the oracle covers: `TS2728 'x' is declared here.` at both construction sites (`error_reporter/missing_property_declared_here.rs`, `checkers/jsx/props/validation.rs`) and the `TS1348`/`TS1349` use-strict pair (`checkers/use_strict_parameter_list.rs`, whose own doc comment already called these "genuine 'declared here' pointers, not links in an elaboration chain").
- Every other construction site is `ChainLink`, i.e. **current behavior preserved**. Only oracle-confirmed families flip; nothing is reclassified on a guess.
- The incremental build-info cache round-trips the tag — and `depth` with it. `depth` was being reset to `0` on every cache read, so a cached diagnostic's elaboration chain rendered flat where a freshly checked one nested. Both new `CachedRelatedInformation` fields are `#[serde(default)]`, so build-info files written before this change still deserialize.

## Anti-hardcoding

No identifier, alias, property, or file-name string drives any decision here, and no predicate reads rendered output. The discriminator is set structurally at the constructor by the checker module that knows which `tsc` concept it is building, and the reporter branches on that field alone.

## Goal
Goal: hold

## Verification

Run locally at head `886b5fb`:

- `cargo fmt` — clean.
- `cargo clippy --workspace --exclude tsz-conformance --all-targets -- -D warnings` — clean (two `missing_const_for_fn` hits on the new helpers were fixed, not allowlisted).
- `python3 scripts/arch/arch_guard.py` — `Architecture guardrails passed.`
- `cargo test -p tsz-cli --lib reporting::` — **23/23**. Three new tests: plain output drops a pointer, plain output keeps chain links (including a nested `depth: 1` link), and one diagnostic carrying both kinds renders differently in the two modes.
- `cargo test -p tsz-checker --lib missing_property_declared_here` — **11/11**, including a new test pinning that the `TS2728` entry is tagged a pointer while elaboration links on the same diagnostic stay chain links.
- `cargo test -p tsz-cli --lib -- cross_location_related_information_survives_collect_diagnostics` — **passes**. This is #16316's own driver-level regression test, extended here to assert the tag survives `collect_diagnostics`, not just the entry.

### Failures in the surrounding suite — all three accounted for, none mine

The full `cargo test -p tsz-cli` run does not complete in this container, so I ran the failing rows individually and attributed each:

| test | verdict |
| --- | --- |
| `check_tests::cross_file_class_namespace_merge_value_keeps_call_signature_in_import_cycle` | **pre-existing** — `scripts/ci/known-failures.txt:128` |
| `check_tests::default_lib_validation_normalizes_cross_arena_method_members_after_global_merge` | **pre-existing** — `scripts/ci/known-failures.txt:129` |
| `check_utils::regex_grammar_suppression_tests::regex_validator_diagnostic_surface_is_audited` | **cannot be mine** — it is a static `include_str!` audit over `crates/tsz-parser/src/parser/state_expressions_literals_regex.rs`; it never runs the compiler, and `git diff main..HEAD --name-only` touches **zero** files under `crates/tsz-parser/`. It is the regex-surface tripwire from the recent #16325/#16328/#16332 cluster, not this PR |
| `tsc_compat_tests::tsc_parity_version` / `_help` / `_no_input` / … | **environmental** — no `typescript`/`node` oracle installed here (`scripts/node_modules/typescript` is absent) |

Two things I did **not** run, stated plainly rather than implied: `cargo nextest` is not installed in this container (the runs above used `cargo test`), and neither the conformance snapshot nor the emit suite was run here. Neither is expected to move — the conformance fingerprint compares primary codes, and this change touches no emit path — but that is an expectation, not a measurement, and a reviewer with a warm corpus should confirm before landing.

## Follow-ups deliberately left out

- **Chain links that carry a real file still render in pretty mode as located blocks with a snippet**, where `tsc` would render them as indented message-chain text. Same root cause, opposite mode; it moves output for many diagnostics and wants its own oracle matrix.
- `TS6504`'s file-inclusion reasons ("The file is in the program because:") are `relatedInformation` in `tsc` and are left as `ChainLink` here — I had no oracle in this container to confirm the plain-mode shape, and would not flip it on inference.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Tourmaline