### PR TITLE
fix(cli): match the regex grammar suppression band as a range, not an enumeration

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1482,7 +1482,7 @@ pub(super) const fn is_structural_parse_error(code: u32) -> bool {
 ///
 /// # The regular-expression grammar family
 ///
-/// The whole `TS1487..=TS1538` regex band belongs here, for one structural
+/// The whole `TS1499..=TS1538` regex band belongs here, for one structural
 /// reason: tsc never puts a regex grammar diagnostic in `parseDiagnostics` at
 /// all. Its regex validation runs from the checker, which re-scans the literal
 /// through `scanner.scanRange`, so a malformed pattern cannot participate in
@@ -1490,6 +1490,33 @@ pub(super) const fn is_structural_parse_error(code: u32) -> bool {
 /// `state_expressions_literals_regex.rs` during parsing, which places the same
 /// diagnostics in `parse_diagnostics` — so every code that walk can emit has to
 /// be excluded here or it silently suppresses the rest of the file.
+///
+/// That band is matched as a **range, not an enumeration**, and the distinction
+/// is load-bearing. Enumerating it one code at a time made the predicate drift
+/// out of step with this very doc comment three separate times, each time
+/// landing a live whole-file suppression bug on `main`: `TS1511` (`\q` outside a
+/// character class), then `TS1501`/`TS1504`/`TS1509` (subpattern modifier
+/// groups), then `TS1514`/`TS1515` (capturing group names). The codes an
+/// enumeration was missing were exactly `1503`, `1513`, `1514`, `1515`, `1518`,
+/// `1521` and `1532` — every code the family had tripped on plus every one still
+/// queued to be wired.
+///
+/// The range is safe to state as a range because it is upstream's own
+/// allocation, not a shape tsz imposes: the diagnostics table in
+/// `tsz_common::diagnostics` is generated verbatim from TypeScript's
+/// `diagnosticMessages.json`, and every row from `1499` (`Unknown regular
+/// expression flag.`) through `1538` (`Unicode escape sequences are only
+/// available when the Unicode (u) flag …`) is a regular-expression grammar
+/// message, with `1498` (`Invalid syntax in decorator.`) and `1539` (`A 'bigint'
+/// literal cannot be used as a property name.`) as non-regex neighbours on
+/// either side. `regex_grammar_suppression_tests` pins both the band and those
+/// two boundary codes, so a future upstream sync that allocates a non-regex
+/// message inside the band fails a test rather than silently widening this
+/// predicate.
+///
+/// `TS1487` (`Octal escape sequences are not allowed…`) sits outside the band
+/// and stays enumerated below: it is shared with string-literal escapes and is
+/// not part of upstream's contiguous regex allocation.
 ///
 /// That suppression is not limited to the check-time `TS1xxx` grammar family named
 /// above. `has_syntax_parse_errors` is read at 30+ sites in `tsz-checker`,
@@ -1510,6 +1537,17 @@ pub(super) const fn is_structural_parse_error(code: u32) -> bool {
 /// TS1161, TS1198) are deliberately NOT here: this predicate is keyed on the
 /// code, not the emitting site, and those are real parse failures elsewhere.
 pub(super) const fn is_non_suppressing_parse_error(code: u32) -> bool {
+    // The regular-expression grammar band, matched as a range rather than an
+    // enumeration. Every code from 1499 (`Unknown regular expression flag.`)
+    // through 1538 (`Unicode escape sequences are only available when the
+    // Unicode (u) flag …`) is a regex grammar message in upstream's own
+    // diagnostics table, and tsc reports all of them from the checker. Matching
+    // the band keeps a newly wired regex diagnostic from silently suppressing
+    // the rest of the file before anyone remembers to add a line here.
+    if matches!(code, 1499..=1538) {
+        return true;
+    }
+
     matches!(
         code,
         1009  // Trailing comma not allowed
@@ -1523,44 +1561,9 @@ pub(super) const fn is_non_suppressing_parse_error(code: u32) -> bool {
             | 1262 // 'await' at top level
             | 1359 // 'await' in async context
             | 1492 // 'using' declarations may not have binding patterns (grammar constraint, AST is valid)
-            // --- regular-expression grammar band; see the doc comment above ---
-            | 1487 // Octal escape sequences are not allowed (regex `\0`-prefixed decimal escape, AST is valid)
-            | 1499 // Unknown regular expression flag (grammar check in tsc's checker, not a parse failure)
-            | 1500 // Duplicate regular expression flag (grammar check, AST is valid)
-            | 1501 // This regular expression flag is only available when targeting '{0}' or later.
-                   // Reachable from the parser only for `s` inside a subpattern
-                   // (`/(?s:x)/` below ES2018); the trailing-flag pass emits the
-                   // same code from the checker, where suppression never applied.
-            | 1502 // The Unicode 'u' and 'v' flags cannot be set simultaneously (grammar check, AST is valid)
-            | 1504 // Subpattern flags must be present when there is a minus sign (`/(?-:x)/`)
-            | 1505 // Incomplete quantifier. Digit expected
-            | 1506 // Numbers out of order in quantifier (`/a{2,1}/`)
-            | 1507 // There is nothing available for repetition (`/{1}/u`)
-            | 1508 // Unexpected '{0}'. Did you mean to escape it with backslash? (`/[a[b]]/u`)
-            | 1509 // This regular expression flag cannot be toggled within a subpattern (`/(?g:x)/`)
-            | 1510 // '\k' must be followed by a capturing group name enclosed in angle brackets
-            | 1511 // '\q' is only available inside character class (`/\q{a}/v`, regex grammar, AST is valid)
-            | 1512 // '\c' must be followed by an ASCII letter (`/\c1/u`)
-            | 1516 // A character class range must not be bounded by another character class (`/[a-\d]/u`)
-            | 1517 // Range out of order in character class (`/[b-a]/`)
-            | 1519 // Operators must not be mixed within a character class (regex grammar, AST is valid)
-            | 1520 // Expected a class set operand (`/[a--]/v`)
-            | 1523 // Expected a Unicode property name (`/\p{=x}/u`)
-            | 1524 // Unknown Unicode property name (`/\p{Foo=Bar}/u`)
-            | 1525 // Expected a Unicode property value (`/\p{Script=}/u`)
-            | 1526 // Unknown Unicode property value (`/\p{Script=NotAScript}/u`)
-            | 1527 // Expected a Unicode property name or value (`/\p{}/u`)
-            | 1529 // Unknown Unicode property name or value (`/\p{NotAThing}/u`)
-            | 1528 // Any Unicode property that would match more than a single character is only available with the 'v' flag
-            | 1530 // Unicode property value expressions are only available with the 'u'/'v' flag (`/\p{L}/`)
-            | 1531 // '\p' must be followed by a Unicode property value expression in braces (`/\p/u`)
-            | 1533 // Backreference to a group beyond the capturing-group count (regex grammar, AST is valid)
-            | 1534 // Backreference with no capturing group in the pattern (regex grammar, AST is valid)
-            | 1535 // This character cannot be escaped in a regular expression (`/\y/u`)
-            | 1536 // Octal escape sequences and backreferences are not allowed in a character class (regex grammar, AST is valid)
-            | 1537 // Decimal escape sequences and backreferences are not allowed in a character class (regex grammar, AST is valid)
-            | 1522 // A character class must not contain a reserved double punctuator (regex grammar, AST is valid)
-            | 1538 // Unicode escape sequences are only available with the 'u'/'v' flag (`/\u{61}/`)
+            | 1487 // Octal escape sequences are not allowed (regex `\0`-prefixed decimal escape,
+                   // AST is valid). Outside the contiguous regex band handled above — shared
+                   // with string-literal escapes — so it stays enumerated here.
             | 17019 // '?' at end of type is not valid TS syntax (parser recovers valid AST)
             | 17020 // '?' at start of type is not valid TS syntax (parser recovers valid AST)
     )

--- a/crates/tsz-cli/src/driver/check_utils/regex_grammar_suppression_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/regex_grammar_suppression_tests.rs
@@ -61,6 +61,79 @@ const REGEX_GRAMMAR_CODES: &[(u32, &str)] = &[
     (1538, r"/\u{61}/"),
 ];
 
+/// The contiguous regular-expression grammar band in upstream's diagnostics
+/// table, from `Unknown regular expression flag.` to `Unicode escape sequences
+/// are only available when the Unicode (u) flag …`.
+///
+/// `is_non_suppressing_parse_error` matches this as a range. The witness table
+/// above is the subset someone has already wired and oracle-pinned; the band is
+/// what actually has to hold, including for codes not yet emitted anywhere
+/// (`1503`, `1513`, `1518`, `1521`).
+const REGEX_GRAMMAR_BAND: std::ops::RangeInclusive<u32> = 1499..=1538;
+
+/// The message upstream assigns to `code`, or `None` for an unallocated code.
+///
+/// Reads the generated table rather than a copy of it, so these tests observe
+/// exactly what `sync-typescript-diagnostics` produced.
+fn diagnostic_message_for_code(code: u32) -> Option<String> {
+    tsz_common::diagnostics::data::iter_diagnostic_messages()
+        .find(|message| message.code == code)
+        .map(|message| message.message.to_owned())
+}
+
+/// Every `NAME -> code` row in the generated diagnostics table.
+///
+/// The audit below scrapes `diagnostic_codes::NAME` references out of the
+/// parser's regex modules as text, so it needs a way to turn those names back
+/// into codes before it can ask the predicate about them. Parsing the generated
+/// table's own single-declaration rows (`(NAME, code, Category, "message")`) is
+/// that way — it is the same source the `codes` and `templates` modules expand
+/// from, so it cannot drift from them.
+fn diagnostic_codes_by_name() -> std::collections::HashMap<String, u32> {
+    const TABLE_PARTS: &[&str] = &[
+        include_str!("../../../../tsz-common/src/diagnostics/data/parts/part_000.rs"),
+        include_str!("../../../../tsz-common/src/diagnostics/data/parts/part_001.rs"),
+        include_str!("../../../../tsz-common/src/diagnostics/data/parts/part_002.rs"),
+        include_str!("../../../../tsz-common/src/diagnostics/data/parts/part_003.rs"),
+    ];
+
+    let mut by_name = std::collections::HashMap::new();
+    for part in TABLE_PARTS {
+        for line in part.lines() {
+            let row = line.trim_start();
+            let Some(row) = row.strip_prefix('(') else {
+                continue;
+            };
+            let Some((name, rest)) = row.split_once(',') else {
+                continue;
+            };
+            let name = name.trim();
+            if name.is_empty()
+                || !name
+                    .bytes()
+                    .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit() || byte == b'_')
+            {
+                continue;
+            }
+            let code = rest.trim_start();
+            let end = code
+                .find(|c: char| !c.is_ascii_digit())
+                .unwrap_or(code.len());
+            if let Ok(code) = code[..end].parse::<u32>() {
+                by_name.insert(name.to_owned(), code);
+            }
+        }
+    }
+
+    assert!(
+        by_name.len() > 1000,
+        "parsed only {} rows out of the generated diagnostics table; the row \
+         format changed and this extraction is broken",
+        by_name.len()
+    );
+    by_name
+}
+
 #[test]
 fn every_regex_grammar_code_is_non_suppressing() {
     for &(code, witness) in REGEX_GRAMMAR_CODES {
@@ -75,14 +148,121 @@ fn every_regex_grammar_code_is_non_suppressing() {
     }
 }
 
-/// Tripwire. The regex validator's diagnostic surface must not grow without
-/// someone deciding whether the new code suppresses.
+/// The predicate must cover the regex band as a *range*, including the codes no
+/// witness above exercises yet.
 ///
-/// This asserts on the set of `diagnostic_codes::` constants the validator
-/// references, not on compiler behaviour, so it is a review gate rather than a
-/// predicate: when it fails, oracle-probe the new code against
-/// `typescript@7.0.2` and either add it to `is_non_suppressing_parse_error` and
-/// to `REGEX_GRAMMAR_CODES` above, or record here why it suppresses.
+/// The witness table is necessarily a list of what someone has already wired.
+/// Every whole-file suppression bug in this family so far landed on a code that
+/// was not in such a list at the time — TS1511, then TS1501/1504/1509, then
+/// TS1514/1515 — so a test that only walks the witnesses cannot catch the next
+/// one. This walks the band instead.
+#[test]
+fn the_whole_regex_grammar_band_is_non_suppressing() {
+    for code in REGEX_GRAMMAR_BAND {
+        assert!(
+            is_non_suppressing_parse_error(code),
+            "TS{code} is inside the TS{}..=TS{} regular-expression grammar band, \
+             where tsc reports every code from the checker rather than the parser, \
+             so it must never set has_syntax_parse_errors. Match the band as a \
+             range; do not re-enumerate it.",
+            REGEX_GRAMMAR_BAND.start(),
+            REGEX_GRAMMAR_BAND.end(),
+        );
+    }
+}
+
+/// The band's edges, so widening it is a deliberate act rather than a drift.
+///
+/// These two codes are the non-regex neighbours in upstream's own allocation.
+/// If a future `sync-typescript-diagnostics` run moves the boundary, this fails
+/// instead of the predicate silently swallowing a real parse failure.
+#[test]
+fn the_codes_bounding_the_regex_band_are_not_regex_grammar() {
+    for (code, message) in [
+        (1498u32, "Invalid syntax in decorator."),
+        (
+            1539u32,
+            "A 'bigint' literal cannot be used as a property name.",
+        ),
+    ] {
+        assert_eq!(
+            diagnostic_message_for_code(code).as_deref(),
+            Some(message),
+            "TS{code} bounds the regular-expression grammar band and is expected \
+             to carry a non-regex message. Upstream reallocated it, so re-derive \
+             the band in is_non_suppressing_parse_error before trusting the range."
+        );
+    }
+
+    assert!(
+        !is_non_suppressing_parse_error(1498),
+        "TS1498 sits just below the regex band and is a real parse failure; \
+         widening the range to include it would suppress real diagnostics."
+    );
+    assert!(
+        !is_non_suppressing_parse_error(1539),
+        "TS1539 sits just above the regex band and is a real parse failure; \
+         widening the range to include it would suppress real diagnostics."
+    );
+}
+
+/// Every message inside the band really is a regular-expression grammar message.
+///
+/// This is what licenses matching the band as a range at all. The diagnostics
+/// table is generated verbatim from TypeScript's `diagnosticMessages.json`, so
+/// the band is upstream's allocation, not a shape tsz imposes — but an upstream
+/// sync could in principle drop a non-regex message into a gap. Each row is
+/// identified by its own message text, so a reallocation fails here.
+#[test]
+fn every_message_in_the_regex_band_is_regex_grammar() {
+    // Wording that only a regular-expression grammar message uses. Kept as
+    // whole phrases rather than loose substrings so an unrelated message cannot
+    // pass by accident.
+    const REGEX_MARKERS: &[&str] = &[
+        "regular expression",
+        "character class",
+        "capturing group",
+        "Unicode property",
+        "quantifier",
+        "backreference",
+        "class set operand",
+        "Unicode (u) flag",
+        "repetition",
+        "character escape",
+        "string alternatives",
+        "negated",
+        // Regex messages whose wording names no regex noun at all. Each is
+        // distinctive enough that no non-regex diagnostic shares it.
+        "Subpattern flags",         // TS1504
+        "escape it with backslash", // TS1508
+        "ASCII letter",             // TS1512
+    ];
+
+    for code in REGEX_GRAMMAR_BAND {
+        let Some(message) = diagnostic_message_for_code(code) else {
+            continue; // A gap in upstream's allocation is fine; nothing emits it.
+        };
+        assert!(
+            REGEX_MARKERS.iter().any(|marker| message.contains(marker)),
+            "TS{code} is inside the regular-expression grammar band that \
+             is_non_suppressing_parse_error matches as a range, but its message \
+             does not read like a regex grammar message:\n  {message}\nEither \
+             upstream reallocated this code — in which case narrow the band and \
+             re-pin it — or add the new wording to REGEX_MARKERS."
+        );
+    }
+}
+
+/// Tripwire. Every diagnostic the regex validator can emit must be
+/// non-suppressing, whoever wired it and whenever.
+///
+/// This scrapes the `diagnostic_codes::` constants the validator references,
+/// resolves each one to its actual code through the generated diagnostics
+/// table, and asks `is_non_suppressing_parse_error` about it — so it is keyed
+/// on the same thing the predicate is keyed on. With the TS1499..=TS1538 band
+/// matched as a range, a newly wired regex diagnostic passes here by
+/// construction; what remains is a real check for anything emitted from the
+/// regex walk that falls *outside* the band.
 #[test]
 fn regex_validator_diagnostic_surface_is_audited() {
     // Every parser module that emits into the regex-literal walk has to be
@@ -111,52 +291,6 @@ fn regex_validator_diagnostic_surface_is_audited() {
         "AN_EXTENDED_UNICODE_ESCAPE_VALUE_MUST_BE_BETWEEN_0X0_AND_0X10FFFF_INCLUSIVE",
     ];
 
-    /// Regex-only constants, each already audited against the oracle and
-    /// carried by `is_non_suppressing_parse_error`.
-    const AUDITED_REGEX_ONLY: &[&str] = &[
-        "OCTAL_ESCAPE_SEQUENCES_ARE_NOT_ALLOWED_USE_THE_SYNTAX",
-        "UNKNOWN_REGULAR_EXPRESSION_FLAG",
-        "INCOMPLETE_QUANTIFIER_DIGIT_EXPECTED",
-        "NUMBERS_OUT_OF_ORDER_IN_QUANTIFIER",
-        "THERE_IS_NOTHING_AVAILABLE_FOR_REPETITION",
-        "UNEXPECTED_DID_YOU_MEAN_TO_ESCAPE_IT_WITH_BACKSLASH",
-        "K_MUST_BE_FOLLOWED_BY_A_CAPTURING_GROUP_NAME_ENCLOSED_IN_ANGLE_BRACKETS",
-        "C_MUST_BE_FOLLOWED_BY_AN_ASCII_LETTER",
-        "A_CHARACTER_CLASS_RANGE_MUST_NOT_BE_BOUNDED_BY_ANOTHER_CHARACTER_CLASS",
-        "A_CHARACTER_CLASS_MUST_NOT_CONTAIN_A_RESERVED_DOUBLE_PUNCTUATOR_DID_YOU_MEAN_TO",
-        "OPERATORS_MUST_NOT_BE_MIXED_WITHIN_A_CHARACTER_CLASS_WRAP_IT_IN_A_NESTED_CLASS_I",
-        "RANGE_OUT_OF_ORDER_IN_CHARACTER_CLASS",
-        "EXPECTED_A_CLASS_SET_OPERAND",
-        "EXPECTED_A_UNICODE_PROPERTY_NAME",
-        "UNKNOWN_UNICODE_PROPERTY_NAME",
-        "EXPECTED_A_UNICODE_PROPERTY_VALUE",
-        "UNKNOWN_UNICODE_PROPERTY_VALUE",
-        "EXPECTED_A_UNICODE_PROPERTY_NAME_OR_VALUE",
-        "UNKNOWN_UNICODE_PROPERTY_NAME_OR_VALUE",
-        "ANY_UNICODE_PROPERTY_THAT_WOULD_POSSIBLY_MATCH_MORE_THAN_A_SINGLE_CHARACTER_IS_O",
-        "UNICODE_PROPERTY_VALUE_EXPRESSIONS_ARE_ONLY_AVAILABLE_WHEN_THE_UNICODE_U_FLAG_OR",
-        "MUST_BE_FOLLOWED_BY_A_UNICODE_PROPERTY_VALUE_EXPRESSION_ENCLOSED_IN_BRACES",
-        "THIS_BACKREFERENCE_REFERS_TO_A_GROUP_THAT_DOES_NOT_EXIST_THERE_ARE_ONLY_CAPTURIN",
-        "THIS_BACKREFERENCE_REFERS_TO_A_GROUP_THAT_DOES_NOT_EXIST_THERE_ARE_NO_CAPTURING",
-        "THIS_CHARACTER_CANNOT_BE_ESCAPED_IN_A_REGULAR_EXPRESSION",
-        "OCTAL_ESCAPE_SEQUENCES_AND_BACKREFERENCES_ARE_NOT_ALLOWED_IN_A_CHARACTER_CLASS_I",
-        "DECIMAL_ESCAPE_SEQUENCES_AND_BACKREFERENCES_ARE_NOT_ALLOWED_IN_A_CHARACTER_CLASS",
-        "UNICODE_ESCAPE_SEQUENCES_ARE_ONLY_AVAILABLE_WHEN_THE_UNICODE_U_FLAG_OR_THE_UNICO",
-        // `\q` outside a character class under the `v` flag. Already carried by
-        // `is_non_suppressing_parse_error`; it was the emit site that landed
-        // without a matching entry here.
-        "Q_IS_ONLY_AVAILABLE_INSIDE_CHARACTER_CLASS",
-        // Subpattern modifier groups, `(?ims-ims: … )`.
-        "SUBPATTERN_FLAGS_MUST_BE_PRESENT_WHEN_THERE_IS_A_MINUS_SIGN",
-        "THIS_REGULAR_EXPRESSION_FLAG_CANNOT_BE_TOGGLED_WITHIN_A_SUBPATTERN",
-        "DUPLICATE_REGULAR_EXPRESSION_FLAG",
-        // Emitted from the parser only for `s` in a subpattern below ES2018.
-        // The trailing-flag pass emits the same code from the checker, where
-        // parse-diagnostic suppression never applied — which is exactly why
-        // this one was easy to miss.
-        "THIS_REGULAR_EXPRESSION_FLAG_IS_ONLY_AVAILABLE_WHEN_TARGETING_OR_LATER",
-    ];
-
     let mut referenced: Vec<(&str, &str)> = VALIDATOR_SOURCES
         .iter()
         .flat_map(|&(module, source)| {
@@ -174,29 +308,56 @@ fn regex_validator_diagnostic_surface_is_audited() {
     referenced.sort_unstable();
     referenced.dedup();
 
-    let unaudited: Vec<(&str, &str)> = referenced
+    let codes_by_name = diagnostic_codes_by_name();
+
+    // Resolve each referenced constant to its actual code and ask the predicate
+    // about it. This is the whole point of the rewrite: the previous version
+    // compared constant NAMES against a hand-maintained allowlist, which could
+    // only tell you whether a human had typed the name into a list — never
+    // whether the code actually suppresses. It went red twice on main for pure
+    // bookkeeping drift while the one real defect it existed to catch (TS1501,
+    // whose name WAS present) sailed past it.
+    let unaudited: Vec<String> = referenced
         .iter()
-        .copied()
-        .filter(|(_, name)| {
-            !AUDITED_REGEX_ONLY.contains(name) && !SHARED_WITH_REAL_PARSE_FAILURES.contains(name)
+        .filter(|(_, name)| !SHARED_WITH_REAL_PARSE_FAILURES.contains(name))
+        .filter_map(|&(module, name)| {
+            let code = codes_by_name.get(name).copied()?;
+            (!is_non_suppressing_parse_error(code)).then(|| format!("{module}: {name} (TS{code})"))
         })
         .collect();
 
     assert!(
         unaudited.is_empty(),
-        "the regex validator emits diagnostic code constant(s) \
-         {unaudited:?} that no one has classified. tsz emits these at PARSE time \
-         but tsc emits the whole regex grammar family at CHECK time, so an \
-         unclassified code silently suppresses every other diagnostic in any file \
-         containing the offending literal. Probe it against typescript@7.0.2 with \
-         a companion fixture (TS1039 + TS2304 + TS2322 + TS2339), then add it to \
-         AUDITED_REGEX_ONLY and is_non_suppressing_parse_error, or to \
-         SHARED_WITH_REAL_PARSE_FAILURES with the reason."
+        "the regex validator emits diagnostic code(s) {unaudited:?} that still \
+         suppress. tsz emits these at PARSE time but tsc emits the whole regex \
+         grammar family at CHECK time, so a suppressing code silently deletes \
+         every other diagnostic in any file containing the offending literal. \
+         If the code is inside the TS1499..=TS1538 band it is covered \
+         automatically and this failure means the band regressed; otherwise \
+         probe it against typescript@7.0.2 with a companion fixture (TS1039 + \
+         TS2304 + TS2322 + TS2339), then add it to is_non_suppressing_parse_error, \
+         or to SHARED_WITH_REAL_PARSE_FAILURES with the reason."
+    );
+
+    // Every name the scan pulled out must exist in the diagnostics table. A
+    // typo'd or renamed constant would otherwise resolve to nothing and be
+    // silently skipped by the filter above.
+    let unresolved: Vec<(&str, &str)> = referenced
+        .iter()
+        .copied()
+        .filter(|(_, name)| !codes_by_name.contains_key(*name))
+        .collect();
+    assert!(
+        unresolved.is_empty(),
+        "constant(s) {unresolved:?} are referenced by the regex validator but do \
+         not appear in the generated diagnostics table, so this audit cannot \
+         classify them. Either the extraction above is broken or the constants \
+         come from an aliased re-export that needs handling here."
     );
 
     // Non-vacuity: the scan must actually find the band, not silently match zero.
     assert!(
-        referenced.len() >= AUDITED_REGEX_ONLY.len(),
+        referenced.len() >= REGEX_GRAMMAR_CODES.len(),
         "scan found only {} constants; the extraction is broken",
         referenced.len()
     );


### PR DESCRIPTION
Third fix for the same defect family in three hours. #16325 → TS1511, #16332 → TS1501/TS1504/TS1509 (cleaned up by #16337 an hour ago), and #16339 is open right now carrying TS1514/TS1515. This closes the mechanism instead of the instance.

**Structural rule.** `When a diagnostic code falls in the TS1499..=TS1538 regular-expression grammar band, tsc reports it from the checker — checkRegularExpressionLiteral re-scans the literal through scanner.scanRange, so it never enters parseDiagnostics and can never participate in hasParseDiagnostics() suppression — and tsz does the same through the is_non_suppressing_parse_error gateway in tsz-cli's check_utils, keyed on the band rather than on a hand-maintained enumeration.`

tsz validates regex literals during *parsing*, so a regex grammar code without an entry in that predicate sets `has_syntax_parse_errors` and deletes unrelated diagnostics from the whole file. `has_syntax_parse_errors` is read at 30+ sites in `tsz-checker`, so a single bad regex literal takes TS2304, TS2322, TS2339 and more with it.

## The drift

The predicate's own doc comment already described the rule as a band. The body enumerated it one code at a time, so the doc and the code disagreed and the code is what ran. The codes the enumeration was missing were exactly:

```
1503  Named capturing groups are only available when targeting 'ES2018' or later.
1513  Undetermined character escape.
1514  Expected a capturing group name.                        <- #16339, open now
1515  Named capturing groups with the same name must be ...   <- #16339, open now
1518  Anything that would possibly match more than a single character is invalid ...
1521  '\q' must be followed by string alternatives enclosed in braces.
1532  There is no capturing group named '{0}' in this regular expression.
```

Every code the family has tripped on, plus every one still queued to be wired. `1513`, `1518` and `1521` are on the genuinely-unwired list being worked through this week, and `1532` is the subject of an open claim right now — so without this change the next three sessions each land the same bug again.

**Why a range is safe to state as a range.** It is upstream's own allocation, not a shape tsz imposes. The diagnostics table in `tsz_common::diagnostics` is generated verbatim from TypeScript's `diagnosticMessages.json`, and every row from `1499` (`Unknown regular expression flag.`) through `1538` (`Unicode escape sequences are only available when the Unicode (u) flag …`) is a regular-expression grammar message, with `1498` (`Invalid syntax in decorator.`) and `1539` (`A 'bigint' literal cannot be used as a property name.`) as non-regex neighbours on either side. `TS1487` stays enumerated: it sits outside the band and is shared with string-literal escapes.

## The audit tripwire was the wrong shape

`regex_validator_diagnostic_surface_is_audited` compared constant **names** scraped from `include_str!`'d parser modules against a hand-maintained list of ~32 names. A name-keyed audit over a code-keyed predicate cannot be made correct by adding entries, and the record shows it:

- it went **red on main twice** for pure bookkeeping drift (TS1511 after #16325; `Q_IS_ONLY_AVAILABLE_INSIDE_CHARACTER_CLASS`), costing two sessions a diagnosis each;
- the one real defect it existed to catch — #16332's TS1501 — had its name **already present** in the list and sailed straight through.

It now resolves each scraped `diagnostic_codes::NAME` to its actual code through the generated table and asks `is_non_suppressing_parse_error` about it, so it is keyed on the same thing the predicate is. The hand list is gone. A second assertion fails if a scraped name does not resolve at all, so a renamed constant cannot be silently skipped.

## Adjacent-case matrix

Verified end-to-end by layering #16339's parser change onto this branch locally and diffing against a real `tsc` (`/opt/node22/…/tsc.js`). Both files pair the regex literal with three unrelated companions.

| fixture | before (main + #16339) | after (this PR) | tsc |
|---|---|---|---|
| `/(?<>x)/` + TS2322/TS2304/TS2339 | TS1514, TS2304 — **TS2322 and TS2339 deleted** | all 4 | all 4 |
| `/(?<a>x)(?<a>y)/` + same | TS1515, TS2304 — **TS2322 and TS2339 deleted** | all 4 | all 4 |

After the fix, tsz's output is byte-identical to tsc's on both, including columns.

New unit coverage, all in `regex_grammar_suppression_tests`:

- `the_whole_regex_grammar_band_is_non_suppressing` — walks the band, not the witness list. The witness list is by construction a list of what someone already wired, which is why every bug in this family landed on a code absent from it.
- `the_codes_bounding_the_regex_band_are_not_regex_grammar` — pins 1498 and 1539 by message text *and* asserts both still suppress, so widening the range is deliberate rather than drift.
- `every_message_in_the_regex_band_is_regex_grammar` — checks every message inside the band reads as regex grammar, so an upstream `sync-typescript-diagnostics` run that reallocates a code fails here instead of silently widening the predicate. This one earned its keep immediately: it caught three real band members whose wording names no regex noun (TS1504, TS1508, TS1512).

## Conformance risk is nil, and provably so

This change only *widens* a non-suppression set, and only for the seven codes above. On current `main` **none of them is emitted into `parse_diagnostics` at all** — `rg` finds zero emit sites in `crates/tsz-parser/` for all seven, and the two that are emitted anywhere (TS1503, TS1532) are checker-side only, where `is_non_suppressing_parse_error` is never consulted (it is applied exclusively to `file.parse_diagnostics`). So this is a behavioural no-op at this head that becomes load-bearing the moment #16339 or the TS1513/1518/1521 wiring lands.

## Goal
Goal: hold

## Verification
- **End-to-end oracle diff**, the table above: #16339's parser change layered on locally, both fixtures byte-identical to `tsc` after the fix and missing 2 of 4 diagnostics before it. Reverted before commit; this PR is `tsz-cli` only, 2 files.
- `cargo test -p tsz-cli --lib check_utils` — **121/121 pass**, including all 6 `regex_grammar_suppression_tests` (3 of them new). `regex_validator_diagnostic_surface_is_audited` passes in its rewritten form.
- `cargo clippy -p tsz-cli --all-targets -- -D warnings` — clean.
- `cargo fmt --all --check` — clean. `python3 scripts/arch/arch_guard.py` — `Architecture guardrails passed.`
- `scripts/conformance/compare-to-parent.sh` — **not run, and disclosed as owed.** A cold corpus fetch plus two `dist-fast` builds does not fit this session. The no-op argument above is the primary evidence and is checkable by `rg` in under a minute; the corpus sweep would be a regression floor here rather than a detector. No emit path is touched.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Malachite

---
_Generated by [Claude Code](https://claude.ai/code/session_015r1fsnTzxKZEfba1E6SNVT)_