### PR TITLE
fix(checker): TS1309 exempts an ambiguous-operand top-level await in a CJS file

### DIFF
--- a/crates/tsz-checker/src/tests/ts1309_top_level_await_commonjs_file_tests.rs
+++ b/crates/tsz-checker/src/tests/ts1309_top_level_await_commonjs_file_tests.rs
@@ -408,3 +408,149 @@ fn await_inside_async_function_in_commonjs_file_is_clean() {
         "a nested `await` is not a top-level `await`; got {diags:?}"
     );
 }
+
+// --- the ambiguous-operand reparse exemption (#16341) ---
+//
+// `tsc`'s parser cannot tell a top-level `await` apart from `await` used as a
+// plain identifier until it sees the next token
+// (`nextTokenIsIdentifierOrKeywordOrLiteralOnSameLine`). When that token is
+// not an identifier/keyword/numeric-or-bigint/string literal on the same
+// line — most commonly `await (`, `await [`, `await {`, or a line break
+// right after `await` — `tsc` initially parses `await` as an identifier and
+// only fixes it up in a whole-file reparse (`reparseTopLevelAwait`) that
+// forces `NodeFlags.AwaitContext` onto the resulting `AwaitExpression`.
+// `checkGrammarAwaitOrAwaitUsing` gates its *entire* top-level check on that
+// flag being clear, so an ambiguous top-level `await` in an external-module
+// file answers none of TS1375, TS1309, or TS1378 — independent of module
+// kind or target. Every row below is pinned against a live `tsc` run
+// (`--module node16 --moduleResolution node16 --target esnext --strict`,
+// package.json `{}` so `.ts` resolves CommonJS).
+
+/// The reported repro shape: `await` applied directly to a parenthesized
+/// IIFE call. oracle: clean, for all three callee spellings.
+#[test]
+fn top_level_await_of_parenthesized_iife_call_is_exempt() {
+    for (label, source) in [
+        (
+            "async arrow",
+            "export const mod = await (async () => { return 1; })();",
+        ),
+        (
+            "plain arrow returning a promise",
+            "export const mod = await (() => Promise.resolve(1))();",
+        ),
+        (
+            "function expression",
+            "export const mod = await (function () { return 1; })();",
+        ),
+    ] {
+        let diags = node16_cjs_codes(source, "a.ts");
+        // Not a plain `is_empty()`: the no-lib unit harness has no global
+        // `Promise`, so an `async` callee's implicit `Promise<number>`
+        // return type produces unrelated TS2468/TS2705 noise. This checks
+        // exactly the family the exemption governs.
+        assert!(
+            !diags.contains(&1309) && !diags.contains(&1375) && !diags.contains(&1378),
+            "{label}: an ambiguous-operand top-level `await` must be exempt; got {diags:?}"
+        );
+    }
+}
+
+/// The negative control the issue's repro contrasted against: a named-call
+/// callee is unambiguous (`await` immediately followed by an identifier), so
+/// no exemption applies and TS1309 fires normally. oracle: TS1309.
+#[test]
+fn top_level_await_of_named_function_call_is_not_exempt() {
+    let source = "declare const fn: () => Promise<number>;\nexport const mod = await fn();";
+    let diags = node16_cjs_codes(source, "a.ts");
+    assert!(
+        diags.contains(&1309),
+        "an identifier-led operand is unambiguous and must still report TS1309; got {diags:?}"
+    );
+}
+
+/// A bare literal operand is equally unambiguous. oracle: TS1309 for both a
+/// string and a bigint literal.
+#[test]
+fn top_level_await_of_a_literal_is_not_exempt() {
+    for source in [
+        "export const mod = await \"hello\";",
+        "export const mod = await 123n;",
+    ] {
+        let diags = node16_cjs_codes(source, "a.ts");
+        assert!(
+            diags.contains(&1309),
+            "a literal operand is unambiguous; got {diags:?} for {source:?}"
+        );
+    }
+}
+
+/// A keyword-led operand (`typeof`) is also unambiguous — keywords satisfy
+/// `tokenIsIdentifierOrKeyword` — so the exemption does not apply. oracle:
+/// TS1309.
+#[test]
+fn top_level_await_of_a_keyword_led_operand_is_not_exempt() {
+    let source = "export const mod = await typeof 1;";
+    let diags = node16_cjs_codes(source, "a.ts");
+    assert!(
+        diags.contains(&1309),
+        "`typeof` is a keyword, not an ambiguous punctuation lead; got {diags:?}"
+    );
+}
+
+/// Array and object literal operands share the same punctuation-led shape as
+/// the parenthesized-IIFE case and get the same exemption. oracle: clean for
+/// both.
+#[test]
+fn top_level_await_of_array_or_object_literal_is_exempt() {
+    for source in [
+        "export const mod = await [1, 2, 3];",
+        "export const mod = await { then(r: (v: number) => void) { r(1); } };",
+    ] {
+        let diags = node16_cjs_codes(source, "a.ts");
+        assert!(
+            diags.is_empty(),
+            "a punctuation-led operand must be exempt; got {diags:?} for {source:?}"
+        );
+    }
+}
+
+/// A prefix-unary operand (`-x`) is punctuation-led too, and gets the same
+/// exemption. oracle: clean.
+#[test]
+fn top_level_await_of_a_prefix_unary_operand_is_exempt() {
+    let source = "declare const x: number;\nexport const mod = await -x;";
+    let diags = node16_cjs_codes(source, "a.ts");
+    assert!(
+        !diags.contains(&1309) && !diags.contains(&1375) && !diags.contains(&1378),
+        "a prefix-unary operand is punctuation-led and must be exempt; got {diags:?}"
+    );
+}
+
+/// A line break right after `await`, even before an otherwise-unambiguous
+/// identifier, defeats `tsc`'s same-line lookahead and triggers the same
+/// exemption. oracle: clean.
+#[test]
+fn top_level_await_followed_by_a_line_break_is_exempt() {
+    let source = "declare const fn: () => number;\nexport const mod = await\n  fn();";
+    let diags = node16_cjs_codes(source, "a.ts");
+    assert!(
+        !diags.contains(&1309) && !diags.contains(&1375) && !diags.contains(&1378),
+        "a line break before the operand must trigger the exemption too; got {diags:?}"
+    );
+}
+
+/// The exemption is scoped to top-level `await`: the same ambiguous-operand
+/// shape inside an `async` function is ordinary code, not a grammar
+/// question, and stays clean for a wholly different reason (it is not a
+/// top-level `await` at all). Guards against the exemption accidentally
+/// widening `in_async_context` handling.
+#[test]
+fn ambiguous_operand_await_inside_async_function_is_unaffected() {
+    let source = "export {};\nasync function run() { await (async () => 1)(); }";
+    let diags = node16_cjs_codes(source, "inasync.cts");
+    assert!(
+        !diags.contains(&1309),
+        "a nested `await` was already clean before this exemption; got {diags:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
+++ b/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
@@ -649,6 +649,40 @@ impl<'a> CheckerState<'a> {
         !self.ctx.compiler_options.module.is_node_module() && !self.ctx.is_external_module_file()
     }
 
+    /// Whether `tsc`'s ambiguous-top-level-`await` parse quirk exempts this
+    /// `AwaitExpression` from the *entire* top-level-`await` grammar family
+    /// (TS1375, TS1309, and TS1378 alike) — not narrowed to any one of them.
+    ///
+    /// `tsc`'s parser cannot tell a Script-shaped top-level `await` apart
+    /// from `await` used as a plain identifier until it sees the next token
+    /// (`nextTokenIsIdentifierOrKeywordOrLiteralOnSameLine`). When that
+    /// heuristic fails — `await (`, `await [`, `await {`, or a line break
+    /// right after `await` — `tsc` initially parses `await` as an identifier
+    /// and only fixes it up in a whole-statement reparse
+    /// (`reparseTopLevelAwait`) that runs once the file is known to be an
+    /// external module. That reparse forces `NodeFlags.AwaitContext` onto the
+    /// resulting `AwaitExpression`, and `checkGrammarAwaitOrAwaitUsing` gates
+    /// its entire top-level check on that flag being clear — so an ambiguous
+    /// top-level `await` in an external-module file answers none of TS1375,
+    /// TS1309, or TS1378, independent of module kind or target.
+    ///
+    /// `tsz`'s parser has no equivalent ambiguous-identifier fallback: it
+    /// always parses `await <expr>` as a real `AwaitExpression`. This
+    /// reconstructs `tsc`'s verdict from the same token-adjacency fact the
+    /// parser already recorded
+    /// (`UnaryExprDataEx::next_token_identifier_keyword_or_literal_same_line`)
+    /// rather than replicating the two-pass reparse.
+    fn top_level_await_ambiguous_reparse_exemption(
+        &self,
+        await_node: &tsz_parser::parser::node::Node,
+    ) -> bool {
+        self.ctx
+            .arena
+            .get_unary_expr_ex(await_node)
+            .is_some_and(|unary| !unary.next_token_identifier_keyword_or_literal_same_line)
+            && self.ctx.is_external_module_file()
+    }
+
     /// Check an await expression for async context.
     ///
     /// Validates that await expressions are only used within async functions,
@@ -784,7 +818,9 @@ impl<'a> CheckerState<'a> {
                         let at_top_level = container.allows_top_level_await()
                             && self.is_directly_at_source_file_top_level(current_idx);
 
-                        if at_top_level {
+                        if at_top_level && self.top_level_await_ambiguous_reparse_exemption(node) {
+                            // Exempt: see `top_level_await_ambiguous_reparse_exemption`.
+                        } else if at_top_level {
                             // tsc's `checkAwaitExpression` emits these two
                             // grammar diagnostics *independently*: a non-module
                             // file gets TS1375, and an unsupported module/target

--- a/crates/tsz-parser/src/parser/node.rs
+++ b/crates/tsz-parser/src/parser/node.rs
@@ -387,6 +387,23 @@ pub struct ParenthesizedData {
 pub struct UnaryExprDataEx {
     pub expression: NodeIndex,
     pub asterisk_token: bool, // For yield*
+    /// `AWAIT_EXPRESSION` only: whether the token immediately following the
+    /// `await` keyword, on the same line, is an identifier, a keyword, or a
+    /// numeric/bigint/string literal — `tsc`'s own
+    /// `nextTokenIsIdentifierOrKeywordOrLiteralOnSameLine` heuristic.
+    ///
+    /// When this is `false` (e.g. `await (x)`, `await [x]`, `await` before a
+    /// line break), `tsc`'s parser cannot tell an `AwaitExpression` apart
+    /// from `await` used as a plain identifier and defers the decision to a
+    /// whole-statement reparse pass (`reparseTopLevelAwait`) that forces
+    /// `NodeFlags.AwaitContext` on the reparsed `AwaitExpression`. That flag
+    /// being set makes `checkGrammarAwaitOrAwaitUsing` skip its entire
+    /// top-level-`await` validity family (TS1309/TS1375/TS1378) for the
+    /// node, in an external-module file — see `top_level_await_verdict`'s
+    /// caller in `core_statement_checks.rs`. Meaningless for the other three
+    /// node kinds this struct backs (`YIELD_EXPRESSION`, `NON_NULL_EXPRESSION`,
+    /// `SPREAD_ELEMENT`); always `true` there.
+    pub next_token_identifier_keyword_or_literal_same_line: bool,
 }
 
 /// Data for as/satisfies/type assertion expressions

--- a/crates/tsz-parser/src/parser/state_expressions_call_member.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_call_member.rs
@@ -407,6 +407,7 @@ impl ParserState {
                         crate::parser::node::UnaryExprDataEx {
                             expression: expr,
                             asterisk_token: false,
+                            next_token_identifier_keyword_or_literal_same_line: true,
                         },
                     );
                 }

--- a/crates/tsz-parser/src/parser/state_expressions_unary.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_unary.rs
@@ -163,6 +163,20 @@ impl ParserState {
         let current_token = self.current_token;
         self.next_token(); // consume 'await'
         let next_token = self.token();
+        // tsc's `nextTokenIsIdentifierOrKeywordOrLiteralOnSameLine`, the same
+        // ambiguity heuristic the yield-expression parser below already
+        // replicates. Recorded on the resulting node for the checker's
+        // top-level-`await` grammar check; see
+        // `UnaryExprDataEx::next_token_identifier_keyword_or_literal_same_line`.
+        let next_token_identifier_keyword_or_literal_same_line =
+            !self.scanner.has_preceding_line_break()
+                && (crate::parser::parse_rules::is_identifier_or_keyword(next_token)
+                    || matches!(
+                        next_token,
+                        SyntaxKind::NumericLiteral
+                            | SyntaxKind::BigIntLiteral
+                            | SyntaxKind::StringLiteral
+                    ));
         self.scanner.restore_state(snapshot);
         self.current_token = current_token;
 
@@ -274,6 +288,7 @@ impl ParserState {
                     UnaryExprDataEx {
                         expression: NodeIndex::NONE,
                         asterisk_token: false,
+                        next_token_identifier_keyword_or_literal_same_line: true,
                     },
                 );
             }
@@ -331,6 +346,7 @@ impl ParserState {
                 UnaryExprDataEx {
                     expression: NodeIndex::NONE,
                     asterisk_token: false,
+                    next_token_identifier_keyword_or_literal_same_line: true,
                 },
             );
         }
@@ -353,6 +369,7 @@ impl ParserState {
             UnaryExprDataEx {
                 expression,
                 asterisk_token: false,
+                next_token_identifier_keyword_or_literal_same_line,
             },
         )
     }
@@ -468,6 +485,7 @@ impl ParserState {
             UnaryExprDataEx {
                 expression,
                 asterisk_token,
+                next_token_identifier_keyword_or_literal_same_line: true,
             },
         )
     }


### PR DESCRIPTION
Closes #16341, filed by an earlier session in this same rotation: `tsz` reported a false-positive TS1309 ("The current file is a CommonJS module and cannot use 'await' at the top level.") for `await (async () => {...})()` at the top level of a CommonJS-format file, where real `tsc` is clean.

**Structural rule.** `tsc`'s parser cannot tell a top-level `await` apart from `await` used as a plain identifier until it sees the next token (`nextTokenIsIdentifierOrKeywordOrLiteralOnSameLine` in `microsoft/typescript-go`'s `parser.go`). When that heuristic fails — the token right after `await` is not an identifier/keyword/numeric-or-bigint/string literal on the same line, most commonly `await (`, `await [`, `await {`, a prefix-unary lead, or a line break right after `await` — `tsc` initially parses `await` as a plain identifier and only fixes it up in a whole-file reparse (`reparseTopLevelAwait`) that runs once the file is known to be an external module. That reparse forces `NodeFlags.AwaitContext` onto the resulting `AwaitExpression`, and `checkGrammarAwaitOrAwaitUsing` (`grammarchecks.go`) gates its *entire* top-level-`await` check on that flag being clear — not just the CommonJS arm. So an ambiguous-operand top-level `await` in an external-module file answers none of TS1375, TS1309, or TS1378, independent of module kind or target.

`tsz`'s parser has no equivalent ambiguous-identifier fallback: it always parses `await` followed by its operand as a real `AwaitExpression` (deliberately — the parser stays permissive and pushes grammar diagnostics to the checker, per the existing comment at `parse_await_expression`'s call site). This change reconstructs `tsc`'s verdict from the same token-adjacency fact `tsc`'s own parser used, computed once in `tsz-parser`'s existing `await` lookahead (already there for `has_following_expression`) and recorded on the node as `UnaryExprDataEx::next_token_identifier_keyword_or_literal_same_line`. The checker's `check_await_expression_in_container` (owner: `crates/tsz-checker/src/types/type_checking/core_statement_checks.rs`) reads that flag through a new `top_level_await_ambiguous_reparse_exemption` helper, gated additionally on the file being an external module (`is_external_module_file()`, the same syntactic proxy `tsc`'s `ExternalModuleIndicator` is) — a plain script with no import/export keeps its prior (unrelated, pre-existing) behavior.

No identifier/alias/property/file-name string drives this decision; the predicate is a scanner-level token-kind check identical to the one `tsc`'s own parser performs, reusing `tsz-parser`'s existing `is_identifier_or_keyword` (already used by the sibling `yield`-expression ambiguity heuristic a few lines below).

### Adjacent-case matrix (oracle-verified against a live `typescript` 6.0.2, which agrees with the pinned 7.0.2 on every row here — `--module node16 --moduleResolution node16 --target esnext --strict`, `package.json: {}`)

| Case | `tsc` | before | after |
| --- | --- | --- | --- |
| `await (async () => {...})()` | clean | TS1309 | clean |
| `await (() => Promise.resolve(1))()` | clean | TS1309 | clean |
| `await (function () {...})()` | clean | TS1309 | clean |
| `await [1, 2, 3]` | clean | TS1309 | clean |
| `await { then(...) {...} }` | clean | TS1309 | clean |
| `await -x` (prefix unary) | clean | TS1309 | clean |
| `await typeof 1` (keyword-led) | TS1309 | TS1309 | TS1309 (unchanged — keywords are unambiguous) |
| `await fn()` (identifier-led) | TS1309 | TS1309 | TS1309 (unchanged) |
| `await "hello"` / `await 123n` (literal) | TS1309 | TS1309 | TS1309 (unchanged) |
| `await` then a line break then `fn();` (line break before an otherwise-unambiguous identifier) | clean | TS1309 | clean |
| same ambiguous shape nested inside an `async function` | clean | clean | clean (unaffected — this only reaches the top-level branch) |

### Known gap disclosed, not fixed here

A plain (non-module) `.ts` script with **no** import/export and an ambiguous-operand top-level `await` diverges from `tsc` in a different way: `tsc` never runs the reparse at all (no `ExternalModuleIndicator`), so `await(...)` there stays a literal identifier call and answers TS2311 ("Cannot find name 'await'"); `tsz` still answers TS1375+TS1378 today, since `tsz`'s parser has no ambiguous-identifier-as-fallback path in the first place. This is orthogonal to this fix (the exemption here already correctly does not fire for that case, so nothing regresses) and would need `tsz`'s parser itself to grow the fallback, not just the checker's grammar check — left for a follow-up since it's a deeper parser-architecture change.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib ts1309_top_level_await` — **27/27** (7 new tests + all pre-existing rows unchanged).
- `cargo test -p tsz-checker --lib await` — **218/218** (broader await-typing/grammar suite, no regressions).
- `cargo test -p tsz-parser --lib` — **1701/1701**.
- `cargo fmt --check -p tsz-parser -p tsz-checker` — clean.
- `cargo clippy -p tsz-parser -p tsz-checker --lib --tests --all-features -- -D warnings` — clean.
- Pre-commit hook (clippy + arch guard on staged files) — passed.
- Manual oracle diff: built `.target/debug/tsz` and ran it against 13 hand-written fixtures spanning every row in the matrix above, diffed byte-for-byte against a real `tsc` 6.0.2 run — exact match on every row, including both line-break edge cases.
- `scripts/conformance/compare-to-parent.sh` — two-sided against `origin/main`, running at push time; **numbers to follow as a PR comment.**

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE