### PR TITLE
fix(checker): regex named-group backreferences allow forward references, compare decoded escape names

### DIFF
--- a/crates/tsz-checker/src/dispatch/helpers.rs
+++ b/crates/tsz-checker/src/dispatch/helpers.rs
@@ -87,6 +87,14 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
         }
     }
 
+    /// tsc collects every named group specifier across the *whole* pattern
+    /// before validating any `\k<name>` backreference against that set
+    /// (`checkGroupingElement` walks the full node tree first; the
+    /// `\k<name>` resolution reads the already-complete
+    /// `groupSpecifiers` map). A forward reference like `/\k<a>(?<a>x)/` is
+    /// therefore legal. This runs the declaration scan to completion first,
+    /// then validates references in a second pass, instead of checking each
+    /// reference against only the names seen so far in one combined walk.
     fn check_regular_expression_named_groups(
         &mut self,
         node_pos: u32,
@@ -94,37 +102,31 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
         bytes: &[u8],
         body_end: usize,
     ) {
-        let mut group_names = BTreeSet::new();
-        let mut i = 1usize;
         let target_supports_named_groups =
             self.checker.ctx.compiler_options.target.supports_es2018();
+        let group_names = self.collect_regex_group_names(
+            node_pos,
+            raw_text,
+            bytes,
+            body_end,
+            target_supports_named_groups,
+        );
+        self.check_regex_named_backreferences(node_pos, raw_text, bytes, body_end, &group_names);
+    }
+
+    fn collect_regex_group_names(
+        &mut self,
+        node_pos: u32,
+        raw_text: &str,
+        bytes: &[u8],
+        body_end: usize,
+        target_supports_named_groups: bool,
+    ) -> BTreeSet<String> {
+        let mut group_names = BTreeSet::new();
+        let mut i = 1usize;
 
         while i < body_end {
             if bytes[i] == b'\\' {
-                if i + 2 < body_end && bytes[i + 1] == b'k' && bytes[i + 2] == b'<' {
-                    let name_start = i + 3;
-                    let mut name_end = name_start;
-                    while name_end < body_end && bytes[name_end] != b'>' {
-                        name_end += 1;
-                    }
-                    if name_end < body_end {
-                        let name = &raw_text[name_start..name_end];
-                        if !group_names.contains(name) {
-                            let message = format_message(
-                                diagnostic_messages::THERE_IS_NO_CAPTURING_GROUP_NAMED_IN_THIS_REGULAR_EXPRESSION,
-                                &[name],
-                            );
-                            self.checker.error_at_position(
-                                node_pos + name_start as u32,
-                                1,
-                                &message,
-                                diagnostic_codes::THERE_IS_NO_CAPTURING_GROUP_NAMED_IN_THIS_REGULAR_EXPRESSION,
-                            );
-                        }
-                        i = name_end + 1;
-                        continue;
-                    }
-                }
                 i += 2;
                 continue;
             }
@@ -150,10 +152,56 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                     name_end += 1;
                 }
                 if name_end < body_end {
-                    group_names.insert(raw_text[name_start..name_end].to_string());
+                    group_names.insert(decode_regex_group_name(&raw_text[name_start..name_end]));
                     i = name_end + 1;
                     continue;
                 }
+            }
+
+            i += 1;
+        }
+
+        group_names
+    }
+
+    fn check_regex_named_backreferences(
+        &mut self,
+        node_pos: u32,
+        raw_text: &str,
+        bytes: &[u8],
+        body_end: usize,
+        group_names: &BTreeSet<String>,
+    ) {
+        let mut i = 1usize;
+
+        while i < body_end {
+            if bytes[i] == b'\\' {
+                if i + 2 < body_end && bytes[i + 1] == b'k' && bytes[i + 2] == b'<' {
+                    let name_start = i + 3;
+                    let mut name_end = name_start;
+                    while name_end < body_end && bytes[name_end] != b'>' {
+                        name_end += 1;
+                    }
+                    if name_end < body_end {
+                        let raw_name = &raw_text[name_start..name_end];
+                        if !group_names.contains(&decode_regex_group_name(raw_name)) {
+                            let message = format_message(
+                                diagnostic_messages::THERE_IS_NO_CAPTURING_GROUP_NAMED_IN_THIS_REGULAR_EXPRESSION,
+                                &[raw_name],
+                            );
+                            self.checker.error_at_position(
+                                node_pos + name_start as u32,
+                                1,
+                                &message,
+                                diagnostic_codes::THERE_IS_NO_CAPTURING_GROUP_NAMED_IN_THIS_REGULAR_EXPRESSION,
+                            );
+                        }
+                        i = name_end + 1;
+                        continue;
+                    }
+                }
+                i += 2;
+                continue;
             }
 
             i += 1;
@@ -306,6 +354,49 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
             _ => false,
         }
     }
+}
+
+/// A named regex group identifier is an ECMAScript `IdentifierName` and may
+/// spell any of its characters as a `\uHHHH` or `\u{H+}` escape, so a
+/// declaration and a reference can name the same group differently
+/// (`(?<a\u{62}>x)` declares `ab`; `\k<ab>` refers to it). tsc compares
+/// group names by their decoded code points, not their source spelling, so
+/// group-name equality here must too.
+fn decode_regex_group_name(name: &str) -> String {
+    if !name.as_bytes().contains(&b'\\') {
+        return name.to_string();
+    }
+
+    let bytes = name.as_bytes();
+    let mut out = String::with_capacity(name.len());
+    let mut i = 0usize;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' && bytes.get(i + 1) == Some(&b'u') {
+            if bytes.get(i + 2) == Some(&b'{')
+                && let Some(close) = name[i + 3..].find('}')
+                && let Ok(code_point) = u32::from_str_radix(&name[i + 3..i + 3 + close], 16)
+                && let Some(decoded) = char::from_u32(code_point)
+            {
+                out.push(decoded);
+                i = i + 3 + close + 1;
+                continue;
+            }
+            if let Some(hex) = name.get(i + 2..i + 6)
+                && hex.bytes().all(|b| b.is_ascii_hexdigit())
+                && let Ok(code_point) = u32::from_str_radix(hex, 16)
+                && let Some(decoded) = char::from_u32(code_point)
+            {
+                out.push(decoded);
+                i += 6;
+                continue;
+            }
+        }
+
+        let ch = name[i..].chars().next().expect("i is at a char boundary");
+        out.push(ch);
+        i += ch.len_utf8();
+    }
+    out
 }
 
 /// Maps a syntax kind to its keyword type name and `TypeId` for TS2693 checking.

--- a/crates/tsz-checker/src/tests/dispatch_tests/part_01.rs
+++ b/crates/tsz-checker/src/tests/dispatch_tests/part_01.rs
@@ -935,6 +935,73 @@ const regex = /(?<foo>)\k<Foo>/;
 }
 
 #[test]
+fn regex_named_group_backreference_allows_forward_reference() {
+    // tsc collects every named-group specifier across the whole pattern
+    // before validating any `\k<name>` reference, so a reference preceding
+    // its declaration is legal. Oracle-confirmed (typescript@6.0.2): clean.
+    let diags = check_source_diagnostics(
+        r#"
+const regex = /\k<a>(?<a>x)/u;
+"#,
+    );
+    let codes = diagnostic_codes(&diags);
+    assert!(
+        !codes.contains(&1532),
+        "Expected no TS1532 for a forward reference to a later-declared group, got {codes:?}"
+    );
+}
+
+#[test]
+fn regex_named_group_backreference_still_flags_undeclared_name() {
+    // Companion negative case: the name genuinely never appears as a
+    // declaration anywhere in the pattern, forward or backward.
+    let diags = check_source_diagnostics(
+        r#"
+const regex = /\k<b>(?<a>x)/u;
+"#,
+    );
+    let codes = diagnostic_codes(&diags);
+    assert!(
+        codes.contains(&1532),
+        "Expected TS1532 for a name with no matching declaration anywhere in the pattern, got {codes:?}"
+    );
+}
+
+#[test]
+fn regex_named_group_backreference_matches_decoded_unicode_escape_name() {
+    // A named-group identifier may spell any character as a `\uHHHH` /
+    // `\u{H+}` escape; tsc compares the *decoded* name, so `a\u{62}` and
+    // `ab` name the same group. Oracle-confirmed (typescript@6.0.2): clean.
+    let diags = check_source_diagnostics(
+        r#"
+const regex = /\k<a\u{62}>(?<ab>x)/u;
+"#,
+    );
+    let codes = diagnostic_codes(&diags);
+    assert!(
+        !codes.contains(&1532),
+        "Expected no TS1532 when the reference's escaped spelling decodes to a declared name, got {codes:?}"
+    );
+}
+
+#[test]
+fn regex_named_group_backreference_rejects_mismatched_decoded_unicode_escape_name() {
+    // Same shape as above but the escape decodes to a name that was never
+    // declared (`ac`, not `ab`) -- decoding must not make an unrelated name
+    // match by accident.
+    let diags = check_source_diagnostics(
+        r#"
+const regex = /\k<a\u{63}>(?<ab>x)/u;
+"#,
+    );
+    let codes = diagnostic_codes(&diags);
+    assert!(
+        codes.contains(&1532),
+        "Expected TS1532 when the decoded reference name has no matching declaration, got {codes:?}"
+    );
+}
+
+#[test]
 fn ts2416_interface_class_merge_method_override_incompatible() {
     // When a class and interface share the same name (declaration merging),
     // the derived class override check must see interface members from the base.


### PR DESCRIPTION
Closes the coordination board's own live claim (`regex-named-group-backreference-forward-ref-ts1532`, posted 03:33Z this rotation, picked up from Gabbro's NOTE on #16339): `check_regular_expression_named_groups` validated each `\k<name>` backreference against only the group names seen *so far* in a single left-to-right pass, so a name declared later in the same pattern false-positived TS1532.

**Structural rule.** When a regex `\k<name>` backreference is checked, tsc collects every named-group specifier across the *whole* pattern first (`checkGroupingElement` walks the full node tree, `\k<name>` resolves against the already-complete `groupSpecifiers` map), and only then validates each reference — so a forward reference (`/\k<a>(?<a>x)/`) is legal. tsz does this through `crates/tsz-checker/src/dispatch/helpers.rs`'s `check_regular_expression_named_groups`, which now runs a `collect_regex_group_names` pass to completion before `check_regex_named_backreferences` validates any reference, instead of checking a reference against a still-partial set collected in the same walk.

**Second half, same owner file.** A named-group identifier is an ECMAScript `IdentifierName` and may spell any character as a `\uHHHH` / `\u{H+}` escape, so a declaration and a reference can name the same group differently (`(?<a\u{62}>x)` declares `ab`; `\k<ab>` refers to it) — tsc compares *decoded* names, not source spelling. Added `decode_regex_group_name`, used on both the declared-name set and each reference before comparison. This is an independent implementation from the parser-side TS1514/1515 escape handling in #16339 (checker-side TS1532, a different file/diagnostic, per that PR's own scoping note).

No identifier/alias/file-name string drives any decision here; every predicate is over decoded regex-source structure.

### Adjacent-case matrix

Oracle-verified against `typescript@6.0.2` (`/opt/node22/lib/node_modules/typescript`, `--noEmit --strict --target esnext`), and byte-for-byte matched against a local `tsz` debug build before/after this change:

| pattern | tsc | before | after |
| --- | --- | --- | --- |
| `/\k<a>(?<a>x)/u` (forward reference) | clean | **TS1532** | clean |
| `/(?<a>x)\k<a>/u` (backward reference) | clean | clean | clean |
| `/\k<b>(?<a>x)/u` (genuinely undeclared) | TS1532 | TS1532 | TS1532 (unchanged) |
| `/\k<a\u{62}>(?<ab>x)/u` (escaped ref decodes to a declared name) | clean | **TS1532** | clean |
| `/\k<a\u{63}>(?<ab>x)/u` (escaped ref decodes to an *undeclared* name) | TS1532 | TS1532 | TS1532 (unchanged) |
| `/(?<foo>)\k<Foo>/` (pre-existing test, case-sensitive mismatch) | TS1532 | TS1532 | TS1532 (unchanged) |

### Known remaining gap (disclosed, not fixed here)

Not touched: TS1514/TS1515 (unwired group-name grammar checks) are #16339's parser-side scope, currently blocked on #16343 landing first per that thread — unrelated file, unrelated diagnostic, not this PR's concern.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib regex_named_group` — **5/5** (4 new tests: forward reference, undeclared-name negative control, escaped-name match, escaped-name mismatch negative control).
- `cargo test -p tsz-checker --lib regex` — **6/6**, including the pre-existing `regex_named_groups_emit_target_and_missing_backreference_diagnostics` test (unchanged).
- `cargo test -p tsz-checker --lib` (full suite) — running at push time; will report before queuing if not finished.
- `cargo fmt --check -p tsz-checker` — clean.
- `cargo clippy -p tsz-checker --lib --tests --all-features -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py --size-only` — passed.
- Manual oracle diff: built `.target/debug/tsz`, ran the 5-row matrix above against both this change and a `git stash`-reverted "before" build, diffed byte-for-byte against `typescript@6.0.2` — exact match after, 2 of 5 rows wrong before.
- `scripts/conformance/compare-to-parent.sh origin/main` — kicked off in the background at push time (cold two-sided run, ~20-25 min); **numbers to follow as a PR comment before queuing.** Risk is low: this only narrows an existing checker-level diagnostic (TS1532), not a parser-level one, so it cannot participate in the `has_syntax_parse_errors` whole-file suppression hazard the sibling regex-grammar PRs this rotation (#16339/#16342/#16343) are working around.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_01HfTLkS4gXWSRQmXGQ1kcFu)_