### PR TITLE
fix(checker): TS1038 fires for a redundant declare on a nested plain export declaration

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/statement_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_checks.rs
@@ -37,12 +37,47 @@ impl<'a> CheckerState<'a> {
             // `declare` modifier lives on the inner clause. Unwrap so both the
             // modifier check and the nested-namespace recursion see the real
             // declaration (mirrors `check_initializers_in_ambient_body`).
+            //
+            // A plain export declaration (`declare export { x }` / `declare export *
+            // from "m"` / `declare export type { x }`) wraps no declaration — its
+            // `export_clause` is either NONE (a bare `export * from "m"`) or points to
+            // a NamedExports/namespace-alias clause, never to one of the declaration
+            // kinds below — and carries its own `declare`+`export` modifiers directly
+            // on the EXPORT_DECLARATION node itself. `wraps_declaration` tells the two
+            // shapes apart so decl_idx unwraps only the genuine wrapping case; the
+            // plain-form modifiers are read straight off `stmt_node` via the
+            // EXPORT_DECLARATION arm of the modifiers match below.
             let decl_idx = if stmt_node.kind == syntax_kind_ext::EXPORT_DECLARATION {
-                match self.ctx.arena.get_export_decl(stmt_node) {
-                    Some(export_decl) if export_decl.export_clause.is_some() => {
-                        export_decl.export_clause
+                let wraps_declaration =
+                    self.ctx
+                        .arena
+                        .get_export_decl(stmt_node)
+                        .is_some_and(|export_decl| {
+                            export_decl.export_clause.is_some()
+                                && self.ctx.arena.get(export_decl.export_clause).is_some_and(
+                                    |clause| {
+                                        matches!(
+                                            clause.kind,
+                                            syntax_kind_ext::FUNCTION_DECLARATION
+                                                | syntax_kind_ext::VARIABLE_STATEMENT
+                                                | syntax_kind_ext::CLASS_DECLARATION
+                                                | syntax_kind_ext::INTERFACE_DECLARATION
+                                                | syntax_kind_ext::TYPE_ALIAS_DECLARATION
+                                                | syntax_kind_ext::ENUM_DECLARATION
+                                                | syntax_kind_ext::MODULE_DECLARATION
+                                                | syntax_kind_ext::IMPORT_EQUALS_DECLARATION
+                                                | syntax_kind_ext::IMPORT_DECLARATION
+                                        )
+                                    },
+                                )
+                        });
+                if wraps_declaration {
+                    match self.ctx.arena.get_export_decl(stmt_node) {
+                        Some(export_decl) => export_decl.export_clause,
+                        None => continue,
                     }
-                    _ => continue,
+                } else {
+                    stmt_idx
                 }
             } else {
                 stmt_idx
@@ -90,6 +125,13 @@ impl<'a> CheckerState<'a> {
                         .arena
                         .get_import_decl(decl_node)
                         .map(|i| &i.modifiers),
+                    // Plain export declaration (`declare export { x }` etc.) — see the
+                    // decl_idx unwrap above, decl_node is the EXPORT_DECLARATION itself here.
+                    syntax_kind_ext::EXPORT_DECLARATION => self
+                        .ctx
+                        .arena
+                        .get_export_decl(decl_node)
+                        .map(|e| &e.modifiers),
                     _ => None,
                 };
                 let declare_mod = modifiers.and_then(|mods| self.get_declare_modifier(mods));

--- a/crates/tsz-checker/tests/ts1038_ambient_declare_modifier_tests.rs
+++ b/crates/tsz-checker/tests/ts1038_ambient_declare_modifier_tests.rs
@@ -33,6 +33,10 @@ fn count_ts1038(diags: &[tsz_checker::diagnostics::Diagnostic]) -> usize {
     diags.iter().filter(|d| d.code == 1038).count()
 }
 
+fn count_ts1193(diags: &[tsz_checker::diagnostics::Diagnostic]) -> usize {
+    diags.iter().filter(|d| d.code == 1193).count()
+}
+
 #[test]
 fn export_declare_direct_children_of_declare_namespace_report_ts1038() {
     // Each `export declare X` is EXPORT_DECLARATION-wrapped; the `declare` is
@@ -121,5 +125,98 @@ export declare function nu(): void;\n";
         count_ts1038(&diags),
         0,
         "top-level `export declare` must not report TS1038, got {diags:?}"
+    );
+}
+
+// A plain export declaration (`export { }` / `export *` / `export type { }`)
+// wraps no inner declaration — EXPORT_DECLARATION's own `export_clause` is
+// NONE and the `declare`+`export` modifiers live on the node itself. tsc
+// reports TS1193 ("An export declaration cannot have modifiers.") for this
+// shape at top level but TS1038 when it is already inside an ambient body
+// (oracle-confirmed, `typescript@6.0.2`/`7.0.2`, both agree) — the same
+// declare-precedes-export precedence `check_declare_modifiers_in_ambient_body`
+// already applies to every other declaration kind.
+
+#[test]
+fn declare_export_named_nested_in_declare_namespace_reports_ts1038_not_ts1193() {
+    let source = "\
+declare namespace Xi {\n\
+    declare export { omicron };\n\
+}\n";
+    let diags = check(source);
+    assert_eq!(
+        count_ts1038(&diags),
+        1,
+        "nested `declare export {{ }}` must report TS1038, got {diags:?}"
+    );
+    assert_eq!(
+        count_ts1193(&diags),
+        0,
+        "TS1193 must not accompany TS1038 for the same modifier, got {diags:?}"
+    );
+    // Note: tsc also reports TS2304 for the unresolved `omicron` specifier here
+    // (oracle-confirmed); tsz does not, but that is a pre-existing limitation of
+    // ambient-body checking depth unrelated to this fix — confirmed by the
+    // same-shape statement with no redundant `declare` also producing zero
+    // diagnostics (`export { omicron };` alone inside `declare namespace Xi`).
+}
+
+#[test]
+fn declare_export_star_nested_in_declare_namespace_reports_ts1038_not_ts1193() {
+    let source = "\
+declare namespace Pi {\n\
+    declare export * from \"m\";\n\
+}\n";
+    let diags = check(source);
+    assert_eq!(
+        count_ts1038(&diags),
+        1,
+        "nested `declare export *` must report TS1038, got {diags:?}"
+    );
+    assert_eq!(
+        count_ts1193(&diags),
+        0,
+        "TS1193 must not accompany TS1038 for the same modifier, got {diags:?}"
+    );
+}
+
+#[test]
+fn declare_export_type_named_nested_in_declare_namespace_reports_ts1038_not_ts1193() {
+    let source = "\
+declare namespace Rho {\n\
+    declare export type { sigma };\n\
+}\n";
+    let diags = check(source);
+    assert_eq!(
+        count_ts1038(&diags),
+        1,
+        "nested `declare export type {{ }}` must report TS1038, got {diags:?}"
+    );
+    assert_eq!(
+        count_ts1193(&diags),
+        0,
+        "TS1193 must not accompany TS1038 for the same modifier, got {diags:?}"
+    );
+}
+
+#[test]
+fn top_level_declare_export_named_reports_no_ts1038() {
+    // Control: outside any ambient context, threading modifiers through
+    // `parse_export_named` must not spuriously introduce TS1038. TS1193 itself
+    // is a *parser* diagnostic (`state_declarations.rs`) invisible to this
+    // checker-only harness; its own coverage — including that it is unaffected
+    // by this change — lives in
+    // `tsz-parser/tests/export_declaration_modifier_grammar_tests.rs`.
+    let source = "declare export { tau };\n";
+    let diags = check(source);
+    assert_eq!(
+        count_ts1038(&diags),
+        0,
+        "top-level `declare export {{ }}` has no enclosing ambient context, got {diags:?}"
+    );
+    assert_eq!(
+        count_ts1193(&diags),
+        0,
+        "TS1193 is a parser diagnostic and is never surfaced by this checker-only harness, got {diags:?}"
     );
 }

--- a/crates/tsz-parser/src/parser/state_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_declarations.rs
@@ -1817,9 +1817,10 @@ impl ParserState {
                         // Skipped when already in an ambient context (`declare namespace N
                         // { declare export { x }; }`): tsc reports TS1038 there instead of
                         // TS1193 (the same precedence the TS1029 check above already
-                        // follows), but `ExportDeclData` has no modifiers field for the
-                        // checker's TS1038 pass to read, so this nested shape stays a
-                        // known gap rather than a newly-wrong code — see #16291 follow-up.
+                        // follows). The `declare`+`export` modifiers are still attached to
+                        // the resulting `ExportDeclData` below so the checker's
+                        // `check_declare_modifiers_in_ambient_body` pass can see them and
+                        // report TS1038 in the nested case.
                         if (saved_flags & crate::parser::state::CONTEXT_FLAG_AMBIENT) == 0 {
                             use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages};
                             let error_start = all_modifiers
@@ -1834,9 +1835,9 @@ impl ParserState {
                             );
                         }
                         if self.is_token(SyntaxKind::AsteriskToken) {
-                            self.parse_export_star(start_pos, false)
+                            self.parse_export_star(start_pos, false, Some(modifiers))
                         } else {
-                            self.parse_export_named(start_pos, false)
+                            self.parse_export_named(start_pos, false, Some(modifiers))
                         }
                     }
                     SyntaxKind::TypeKeyword if is_type_only_export => {
@@ -1858,9 +1859,9 @@ impl ParserState {
                         }
                         self.parse_expected(SyntaxKind::TypeKeyword);
                         if self.is_token(SyntaxKind::AsteriskToken) {
-                            self.parse_export_star(start_pos, true)
+                            self.parse_export_star(start_pos, true, Some(modifiers))
                         } else {
-                            self.parse_export_named(start_pos, true)
+                            self.parse_export_named(start_pos, true, Some(modifiers))
                         }
                     }
                     SyntaxKind::TypeKeyword => {

--- a/crates/tsz-parser/src/parser/state_declarations_exports.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_exports.rs
@@ -88,12 +88,12 @@ impl ParserState {
 
         // export * from "mod"
         if self.is_token(SyntaxKind::AsteriskToken) {
-            return self.parse_export_star(start_pos, is_type_only);
+            return self.parse_export_star(start_pos, is_type_only, None);
         }
 
         // export { ... }
         if self.is_token(SyntaxKind::OpenBraceToken) {
-            return self.parse_export_named(start_pos, is_type_only);
+            return self.parse_export_named(start_pos, is_type_only, None);
         }
 
         // export = expression (CommonJS-style export)
@@ -475,7 +475,12 @@ impl ParserState {
     }
 
     // Parse export * from "mod"
-    pub(crate) fn parse_export_star(&mut self, start_pos: u32, is_type_only: bool) -> NodeIndex {
+    pub(crate) fn parse_export_star(
+        &mut self,
+        start_pos: u32,
+        is_type_only: bool,
+        modifiers: Option<crate::parser::NodeList>,
+    ) -> NodeIndex {
         self.parse_expected(SyntaxKind::AsteriskToken);
 
         // Optional "as namespace" for re-export (keywords and string literals allowed)
@@ -520,7 +525,7 @@ impl ParserState {
             start_pos,
             end_pos,
             ExportDeclData {
-                modifiers: None,
+                modifiers,
                 is_type_only,
                 is_default_export: false,
                 default_keyword_pos: None,
@@ -532,7 +537,12 @@ impl ParserState {
     }
 
     // Parse export { x, y } or export { x } from "mod"
-    pub(crate) fn parse_export_named(&mut self, start_pos: u32, is_type_only: bool) -> NodeIndex {
+    pub(crate) fn parse_export_named(
+        &mut self,
+        start_pos: u32,
+        is_type_only: bool,
+        modifiers: Option<crate::parser::NodeList>,
+    ) -> NodeIndex {
         let export_clause = self.parse_named_exports();
 
         let module_specifier = if self.parse_optional(SyntaxKind::FromKeyword) {
@@ -556,7 +566,7 @@ impl ParserState {
             start_pos,
             end_pos,
             ExportDeclData {
-                modifiers: None,
+                modifiers,
                 is_type_only,
                 is_default_export: false,
                 default_keyword_pos: None,

--- a/crates/tsz-parser/src/parser/state_exports_recovery.rs
+++ b/crates/tsz-parser/src/parser/state_exports_recovery.rs
@@ -146,7 +146,7 @@ impl ParserState {
                         diagnostic_codes::MODIFIER_ALREADY_SEEN,
                     );
                     if self.is_token(SyntaxKind::OpenBraceToken) {
-                        self.parse_export_named(start_pos, false)
+                        self.parse_export_named(start_pos, false, None)
                     } else if self.is_token(SyntaxKind::ClassKeyword) {
                         let export_modifier = self.arena.add_token(
                             SyntaxKind::ExportKeyword as u16,

--- a/crates/tsz-parser/tests/export_declaration_modifier_grammar_tests.rs
+++ b/crates/tsz-parser/tests/export_declaration_modifier_grammar_tests.rs
@@ -164,13 +164,15 @@ fn export_declare_export_named_emits_ts1193_at_first_export() {
 
 #[test]
 fn nested_declare_export_in_ambient_namespace_does_not_emit_ts1193() {
-    // Known adjacent gap, not a regression: inside an already-ambient body
-    // (`declare namespace N { ... }`), tsc reports TS1038 ("declare modifier
-    // cannot be used in an already ambient context") for a redundant nested
-    // `declare`, never TS1193 — the same precedence the pre-existing TS1029
-    // check already follows for this position. `ExportDeclData` carries no
-    // modifiers field for the checker's TS1038 pass to read, so this shape
-    // stays silently-clean rather than regressing to a wrong TS1193.
+    // Inside an already-ambient body (`declare namespace N { ... }`), tsc
+    // reports TS1038 ("declare modifier cannot be used in an already ambient
+    // context") for a redundant nested `declare`, never TS1193 — the same
+    // precedence the pre-existing TS1029 check already follows for this
+    // position. This parser-level test only confirms TS1193 stays silent
+    // here; the `declare`+`export` modifiers are threaded onto `ExportDeclData`
+    // so the checker's `check_declare_modifiers_in_ambient_body` pass can
+    // report the TS1038 side — see
+    // `tsz-checker/tests/ts1038_ambient_declare_modifier_tests.rs`.
     let source = "declare namespace N {\n  declare export { x };\n}\n";
     let cs = codes(source);
     assert!(


### PR DESCRIPTION
Closes the TS1193 follow-up gap #16291 called out: a plain export declaration (`export { x }` / `export * from "m"` / `export type { x }`) preceded by `declare` inside an already-ambient body (`declare namespace N { declare export { x }; }`) previously produced **no diagnostic at all**.

**Structural rule.** When a `declare` modifier appears on any declaration already inside an ambient body, tsc reports TS1038 ("A 'declare' modifier cannot be used in an already ambient context.") instead of the declaration's own would-be modifier-grammar error — the same precedence `check_declare_modifiers_in_ambient_body` already applies to `function`/`var`/`class`/`interface`/`type`/`enum`/`namespace`/`import`. A plain export declaration is the one shape that fell through: tsz's parser skips TS1193 correctly in the nested-ambient case (pre-existing, oracle-confirmed), but `ExportDeclData` never carried the `declare`+`export` modifiers for the checker's TS1038 pass to read, since `parse_export_star`/`parse_export_named` always hardcoded `modifiers: None`.

## What changed

- **Parser**: `parse_export_star`/`parse_export_named` now take a `modifiers: Option<NodeList>` parameter, stored on `ExportDeclData` instead of the hardcoded `None`. The two `declare export` call sites in `state_declarations.rs` (the `AsteriskToken | OpenBraceToken` arm and the type-only `TypeKeyword` arm) pass the already-built `declare`+`export` modifier list; the other four call sites (all plain top-level `export ...`, no `declare` prefix) pass `None`.
- **Checker**: `check_declare_modifiers_in_ambient_body`'s EXPORT_DECLARATION unwrap previously conflated two different node shapes under `export_clause.is_some()`:
  - a real wrapped declaration (`export declare function f()`, produced by `parse_export_declaration_or_statement`), where `export_clause` points at the inner FUNCTION_DECLARATION/etc. and the wrapper's own modifiers are always `None`;
  - a plain-form export (`export { x }`), where `export_clause` is **also** `Some` (it points at the NamedExports clause, never `None`) — so the old guard misrouted it into the same branch as the wrapped-declaration case, and `decl_kind` then matched nothing in the modifiers lookup.

  Now discriminates by checking whether `export_clause`'s own node kind is one of the recognized declaration kinds; when it isn't (NamedExports / star-alias clause / `NONE`), `decl_idx` stays on the EXPORT_DECLARATION node itself, and a new match arm reads `export_decl.modifiers` directly.

## Adjacent-case matrix

Oracle-confirmed (`typescript@6.0.2`/`7.0.2`, both agree — `/opt/node22`, no npm install needed):

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `declare namespace N { declare export { x }; }` | TS1038 (+TS2304 for `x`) | nothing | TS1038 |
| `declare namespace N { declare export * from "m"; }` | TS1038 (+TS1194) | nothing | TS1038 |
| `declare namespace N { declare export type { y }; }` | TS1038 (+TS2304 for `y`) | nothing | TS1038 |
| `declare export { x };` (top level, no enclosing ambient) | TS1193 | TS1193 | TS1193 (unaffected) |
| `declare namespace N { export declare var x; }` (wrapped-decl case) | TS1038 | TS1038 | TS1038 (unaffected — pre-existing coverage) |

tsz still does not resolve the export specifier itself inside an ambient body (no TS2304/TS1194 companion) — confirmed pre-existing and unrelated to this fix: the same-shape statement with **no** redundant `declare` (`declare namespace N { export { x }; }`) already produces zero diagnostics on `main`. That is a separate, out-of-scope limitation of ambient-body checking depth.

No identifier, alias, or file-name literal drives any decision here — the discriminator is the AST node kind of `export_clause`, structurally the same test tsc's own checker performs.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts1038_ambient_declare_modifier_tests` — **9/9** (4 new: named/star/type-only nested-ambient positive cases + a top-level negative control).
- `cargo test -p tsz-parser --lib` — **1730/1730** (unaffected; includes #16339's regex-group-name suite merged in since).
- `cargo test -p tsz-parser --lib export_declaration_modifier_grammar` — **13/13**, confirms the pre-existing TS1193 wiring is unaffected by threading `modifiers` through.
- `cargo clippy -p tsz-parser -p tsz-checker --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean. `python3 scripts/arch/arch_guard.py` — passed.
- `scripts/conformance/compare-to-parent.sh origin/main` — running in the background at push time; **narrow, additive, ambient-only shape** (a declaration-checking pass whose call site is gated on `is_own_declare && module.body.is_some()`, unaffected outside `declare namespace` bodies) — no rows are expected to move. Will post the number as a PR comment before queuing.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGs3m4E7Ry2RyYb93BuWHe)_