### PR TITLE
fix(checker): report TS17001 for repeated JSX attribute names

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/duplicate_attribute_grammar_tests.rs
+++ b/crates/tsz-checker/src/checkers/jsx/duplicate_attribute_grammar_tests.rs
@@ -1,0 +1,293 @@
+//! TS17001 — `JSX elements cannot have multiple attributes with the same name.`
+//!
+//! Structural rule: when a JSX opening element repeats an attribute name, tsc
+//! reports TS17001 on the *second* occurrence's name node and stops checking
+//! that element's grammar; tsz does this in `check_grammar_jsx_element`, the
+//! same per-element grammar pass that already owned TS17000.
+//!
+//! Every expectation below is pinned against `typescript@7.0.2`
+//! (`--noEmit --strict --jsx preserve --target es2022 --lib es2022`), the
+//! version `scripts/conformance/typescript-versions.json` pins as `default`.
+//!
+//! The matrix deliberately varies the binder names (`a`/`b`, `alpha`/`beta`,
+//! `data-x`, `ns:local`) so no expectation can be satisfied by matching a
+//! particular identifier.
+
+use crate::diagnostics::diagnostic_codes;
+use crate::test_utils::check_source;
+
+fn check_jsx(source: &str) -> Vec<crate::diagnostics::Diagnostic> {
+    use crate::context::CheckerOptions;
+    use tsz_common::checker_options::JsxMode;
+
+    let opts = CheckerOptions {
+        jsx_mode: JsxMode::Preserve,
+        ..CheckerOptions::default()
+    };
+    check_source(source, "test.tsx", opts)
+}
+
+fn check_jsx_codes(source: &str) -> Vec<u32> {
+    check_jsx(source).iter().map(|d| d.code).collect()
+}
+
+/// Preamble giving the unit harness (which runs with no lib) a JSX namespace.
+/// `any`-typed intrinsics keep the element's *type* checking silent so each
+/// assertion below observes the grammar pass alone.
+const JSX_PREAMBLE: &str = r#"
+        declare namespace JSX {
+          interface Element { kind: string }
+          interface IntrinsicElements {
+            div: any;
+            span: any;
+          }
+        }
+"#;
+
+fn check_jsx_with_preamble(body: &str) -> Vec<crate::diagnostics::Diagnostic> {
+    check_jsx(&format!("{JSX_PREAMBLE}{body}"))
+}
+
+fn codes_with_preamble(body: &str) -> Vec<u32> {
+    check_jsx_codes(&format!("{JSX_PREAMBLE}{body}"))
+}
+
+const TS17001: u32 =
+    diagnostic_codes::JSX_ELEMENTS_CANNOT_HAVE_MULTIPLE_ATTRIBUTES_WITH_THE_SAME_NAME;
+const TS17000: u32 = diagnostic_codes::JSX_ATTRIBUTES_MUST_ONLY_BE_ASSIGNED_A_NON_EMPTY_EXPRESSION;
+
+// ---------------------------------------------------------------------------
+// Positive: the name repeats.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repeated_attribute_name_on_a_self_closing_intrinsic_reports_ts17001() {
+    let codes = codes_with_preamble(r#"const e = <div alpha="1" alpha="2" />;"#);
+    assert_eq!(
+        codes,
+        vec![TS17001],
+        "a repeated attribute name is TS17001 and nothing else"
+    );
+}
+
+#[test]
+fn repeated_attribute_name_on_a_paired_intrinsic_reports_ts17001() {
+    let codes = codes_with_preamble(r#"const e = <span beta="1" beta="2">text</span>;"#);
+    assert_eq!(
+        codes,
+        vec![TS17001],
+        "the paired open/close form is checked the same as the self-closing form"
+    );
+}
+
+/// tsc anchors on the *second* occurrence's name node
+/// (`grammarErrorOnNode(name, ...)`), not on the first and not on the whole
+/// attribute. The span must therefore cover exactly the repeated name.
+#[test]
+fn ts17001_anchors_on_the_second_occurrence_name_node() {
+    let source = format!("{JSX_PREAMBLE}const e = <div gamma=\"1\" gamma=\"2\" />;");
+    let diagnostics = check_jsx(&source);
+    let diagnostic = diagnostics
+        .iter()
+        .find(|d| d.code == TS17001)
+        .expect("expected TS17001");
+
+    let start = diagnostic.start as usize;
+    let reported = &source[start..start + diagnostic.length as usize];
+    assert_eq!(reported, "gamma", "TS17001 spans the repeated name only");
+
+    let first = source.find("gamma").expect("first occurrence");
+    assert!(
+        start > first,
+        "TS17001 must anchor on the SECOND occurrence (at {start}), not the first (at {first})"
+    );
+}
+
+/// A component tag reaches a different resolution path than an intrinsic tag,
+/// but tsc runs `checkGrammarJsxElement` for both.
+#[test]
+fn repeated_attribute_name_on_a_component_reports_ts17001() {
+    let codes = codes_with_preamble(
+        r#"
+        function Widget(props: { delta?: string }): JSX.Element {
+          return null as any;
+        }
+        const e = <Widget delta="1" delta="2" />;
+        "#,
+    );
+    assert!(
+        codes.contains(&TS17001),
+        "a component tag gets the same grammar check as an intrinsic one, got: {codes:?}"
+    );
+}
+
+/// tsc reports TS17001 from the grammar pass, which runs even when the tag
+/// name itself fails to resolve — so the unresolved-tag TS2304 and TS17001
+/// coexist rather than one suppressing the other.
+#[test]
+fn repeated_attribute_name_still_reports_when_the_tag_is_unresolved() {
+    let codes = codes_with_preamble(r#"const e = <Missing epsilon="1" epsilon="2" />;"#);
+    assert!(
+        codes.contains(&TS17001),
+        "the grammar pass does not depend on the tag resolving, got: {codes:?}"
+    );
+}
+
+/// Shorthand (initializer-less) attributes are still named attributes.
+#[test]
+fn repeated_shorthand_attribute_name_reports_ts17001() {
+    let codes = codes_with_preamble(r#"const e = <div zeta zeta />;"#);
+    assert_eq!(
+        codes,
+        vec![TS17001],
+        "an absent initializer must not skip the name comparison"
+    );
+}
+
+/// Hyphenated names are ordinary JSX identifiers, not a special form.
+#[test]
+fn repeated_hyphenated_attribute_name_reports_ts17001() {
+    let codes = codes_with_preamble(r#"const e = <div data-token="1" data-token="2" />;"#);
+    assert_eq!(codes, vec![TS17001]);
+}
+
+/// A namespaced name collides only with the identical namespace *and* local
+/// name. Keying on the local half alone (or on a null key, which is the shape
+/// of tsc's own legacy `name.escapedText` read) would make every namespaced
+/// pair collide — see the negative case below.
+#[test]
+fn repeated_namespaced_attribute_name_reports_ts17001() {
+    let codes = codes_with_preamble(r#"const e = <div xlink:href="1" xlink:href="2" />;"#);
+    assert_eq!(codes, vec![TS17001]);
+}
+
+/// A spread between two occurrences does NOT clear the seen-name set: tsc
+/// `continue`s past a `JsxSpreadAttribute` without touching the map.
+#[test]
+fn a_spread_between_two_occurrences_does_not_reset_the_seen_set() {
+    let codes = codes_with_preamble(
+        r#"
+        declare const rest: { theta?: string };
+        const e = <div theta="1" {...rest} theta="2" />;
+        "#,
+    );
+    assert!(
+        codes.contains(&TS17001),
+        "an intervening spread must not clear the seen names, got: {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative / fallback: the name does not repeat.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn distinct_attribute_names_report_nothing() {
+    let diagnostics = check_jsx_with_preamble(r#"const e = <div alpha="1" beta="2" gamma="3" />;"#);
+    assert!(
+        diagnostics.is_empty(),
+        "distinct names are clean, got: {diagnostics:?}"
+    );
+}
+
+/// Comparison is case-sensitive — JSX attribute names are not folded.
+#[test]
+fn attribute_names_differing_only_in_case_report_nothing() {
+    let diagnostics = check_jsx_with_preamble(r#"const e = <div Alpha="1" alpha="2" />;"#);
+    assert!(
+        diagnostics.is_empty(),
+        "`Alpha` and `alpha` are distinct names, got: {diagnostics:?}"
+    );
+}
+
+/// Two namespaced names sharing a local half are distinct.
+#[test]
+fn namespaced_names_with_different_namespaces_report_nothing() {
+    let diagnostics =
+        check_jsx_with_preamble(r#"const e = <div one:shared="1" two:shared="2" />;"#);
+    assert!(
+        diagnostics.is_empty(),
+        "`one:shared` and `two:shared` are distinct names, got: {diagnostics:?}"
+    );
+}
+
+/// Repeated *spread* attributes are never duplicates — tsc skips them before
+/// the name comparison, and they have no name to compare.
+#[test]
+fn repeated_spread_attributes_report_no_ts17001() {
+    let codes = codes_with_preamble(
+        r#"
+        declare const rest: { iota?: string };
+        const e = <div {...rest} {...rest} />;
+        "#,
+    );
+    assert!(
+        !codes.contains(&TS17001),
+        "spreads carry no name and can never duplicate, got: {codes:?}"
+    );
+}
+
+/// Each element gets its own seen-name set.
+#[test]
+fn the_same_name_on_sibling_elements_reports_nothing() {
+    let diagnostics = check_jsx_with_preamble(
+        r#"const e = <div kappa="1"><span kappa="2" /><span kappa="3" /></div>;"#,
+    );
+    assert!(
+        diagnostics.is_empty(),
+        "the seen-name set is per opening element, got: {diagnostics:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Ordering: TS17001 vs TS17000, and the one-report-per-element rule.
+// ---------------------------------------------------------------------------
+
+/// tsc reports at most one grammar error per opening element and returns, so
+/// only the FIRST repeat is reported even when several names repeat.
+#[test]
+fn only_the_first_repeated_name_is_reported_per_element() {
+    let codes = codes_with_preamble(r#"const e = <div mu="1" nu="2" mu="3" xi="4" nu="5" />;"#);
+    assert_eq!(
+        codes,
+        vec![TS17001],
+        "one grammar report per element, anchored at the first repeat"
+    );
+}
+
+#[test]
+fn a_name_repeated_three_times_reports_ts17001_once() {
+    let codes = codes_with_preamble(r#"const e = <div omicron="1" omicron="2" omicron="3" />;"#);
+    assert_eq!(codes, vec![TS17001]);
+}
+
+/// Within one attribute tsc tests the name BEFORE the initializer, so a repeat
+/// outranks that same attribute's empty `{}`.
+#[test]
+fn a_repeated_name_outranks_its_own_empty_initializer() {
+    let codes = codes_with_preamble(r#"const e = <div pi="1" pi={} />;"#);
+    assert_eq!(
+        codes,
+        vec![TS17001],
+        "the duplicate-name test runs before the empty-expression test"
+    );
+}
+
+/// Conversely, an earlier attribute's empty `{}` returns before a later pair
+/// is ever compared — so TS17000 wins on ordering, not on precedence.
+#[test]
+fn an_earlier_empty_initializer_preempts_a_later_repeated_name() {
+    let codes = codes_with_preamble(r#"const e = <div rho={} sigma="1" sigma="2" />;"#);
+    assert_eq!(
+        codes,
+        vec![TS17000],
+        "the first attribute's empty initializer returns before `sigma` repeats"
+    );
+}
+
+/// The pre-existing TS17000 behaviour is unchanged when no name repeats.
+#[test]
+fn empty_initializer_alone_still_reports_ts17000() {
+    let codes = codes_with_preamble(r#"const e = <div tau={} />;"#);
+    assert_eq!(codes, vec![TS17000]);
+}

--- a/crates/tsz-checker/src/checkers/jsx/mod.rs
+++ b/crates/tsz-checker/src/checkers/jsx/mod.rs
@@ -25,6 +25,8 @@ pub(crate) mod spread;
 #[cfg(test)]
 mod contextual_children_tests;
 #[cfg(test)]
+mod duplicate_attribute_grammar_tests;
+#[cfg(test)]
 mod optional_prop_display_tests;
 #[cfg(test)]
 mod ref_callback_tests;

--- a/crates/tsz-checker/src/checkers/jsx/props/validation.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/validation.rs
@@ -13,6 +13,7 @@ use crate::error_reporter::{
 use crate::query_boundaries::checkers::jsx as jsx_queries;
 use crate::query_boundaries::common::TypeSubstitution;
 use crate::state::CheckerState;
+use std::collections::HashSet;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
 use tsz_solver::{ObjectShape, TypeId};
@@ -1763,9 +1764,28 @@ impl<'a> CheckerState<'a> {
             }
         }
     }
-    /// Grammar check: TS17000 for empty expressions in JSX attributes.
-    /// Matches tsc's `checkGrammarJsxElement`: reports only the first empty
-    /// expression per JSX opening element, then returns.
+    /// Grammar check: TS17001 for repeated attribute names and TS17000 for
+    /// empty expressions in JSX attributes.
+    ///
+    /// Mirrors tsc's `checkGrammarJsxElement` exactly, including its control
+    /// flow, which is observable:
+    ///
+    /// - A `JsxSpreadAttribute` is skipped **without** clearing the seen-name
+    ///   set, so `[div a="1" {...s} a="2" /]` still reports TS17001 on the
+    ///   second `a` even though the spread may have rewritten it in between.
+    /// - Within one attribute the duplicate-name test runs **before** the
+    ///   empty-expression test, and each reports at most once for the whole
+    ///   element and then returns. So `[div a="1" a={} /]` is TS17001 (the
+    ///   name repeats before the empty initializer is reached), while
+    ///   `[div a={} b="1" b="2" /]` is TS17000 (the first attribute's empty
+    ///   initializer returns before the `b` pair is ever compared).
+    /// - The name key is the attribute's full text, so a namespaced name
+    ///   collides only with the same namespace *and* local name: `ns:a` and
+    ///   `other:a` are distinct, `ns:a` twice is TS17001. Comparison is
+    ///   case-sensitive.
+    ///
+    /// The report anchors on the attribute's name node, not the whole
+    /// attribute, matching tsc's `grammarErrorOnNode(name, ...)`.
     pub(in crate::checkers_domain::jsx) fn check_grammar_jsx_element(
         &mut self,
         attributes_idx: NodeIndex,
@@ -1777,6 +1797,8 @@ impl<'a> CheckerState<'a> {
             return;
         };
 
+        let mut seen_names: HashSet<String> = HashSet::new();
+
         for &attr_idx in &attrs.properties.nodes {
             let Some(attr_node) = self.ctx.arena.get(attr_idx) else {
                 continue;
@@ -1787,6 +1809,22 @@ impl<'a> CheckerState<'a> {
             let Some(attr_data) = self.ctx.arena.get_jsx_attribute(attr_node) else {
                 continue;
             };
+
+            // TS17001 first: tsc compares the name before it ever looks at the
+            // initializer, so a repeated name outranks a later empty `{}`.
+            if let Some(name_node) = self.ctx.arena.get(attr_data.name)
+                && let Some(attr_name) = self.get_jsx_attribute_name(name_node)
+                && !seen_names.insert(attr_name)
+            {
+                self.error_at_node(
+                    attr_data.name,
+                    diagnostic_messages::JSX_ELEMENTS_CANNOT_HAVE_MULTIPLE_ATTRIBUTES_WITH_THE_SAME_NAME,
+                    diagnostic_codes::JSX_ELEMENTS_CANNOT_HAVE_MULTIPLE_ATTRIBUTES_WITH_THE_SAME_NAME,
+                );
+                // tsc returns after the first grammar error per element
+                return;
+            }
+
             if attr_data.initializer.is_none() {
                 continue;
             }
@@ -1801,10 +1839,9 @@ impl<'a> CheckerState<'a> {
             };
             // Empty expression {} without spread
             if expr_data.expression.is_none() && !expr_data.dot_dot_dot_token {
-                use crate::diagnostics::diagnostic_codes;
                 self.error_at_node(
                     attr_data.initializer,
-                    "JSX attributes must only be assigned a non-empty 'expression'.",
+                    diagnostic_messages::JSX_ATTRIBUTES_MUST_ONLY_BE_ASSIGNED_A_NON_EMPTY_EXPRESSION,
                     diagnostic_codes::JSX_ATTRIBUTES_MUST_ONLY_BE_ASSIGNED_A_NON_EMPTY_EXPRESSION,
                 );
                 // tsc returns after the first grammar error per element


### PR DESCRIPTION
`check_grammar_jsx_element` mirrored tsc's `checkGrammarJsxElement` but implemented only its *second* half — TS17000, the empty `{}` initializer. The first half, the seen-name map that yields TS17001, was absent, so `[div a="1" a="2" /]` type-checked completely clean while tsc rejects it. TS17001 was one of the codes on #16291's unwired list.

**Structural rule.** `When a JSX opening element repeats an attribute name, tsc reports TS17001 on the SECOND occurrence's name node and stops checking that element's grammar; tsz does this in check_grammar_jsx_element, the same per-element grammar pass in the checker that already owned TS17000.`

## What makes this more than an added `if`

tsc's control flow here is **observable**, so it is reproduced rather than approximated. Four separate facts, each pinned against the oracle:

1. A `JsxSpreadAttribute` is `continue`d past **without clearing the seen set**, so an intervening spread does not hide a later repeat.
2. Within one attribute the name test runs **before** the initializer test. So a repeat outranks that same attribute's empty `{}` — but an *earlier* attribute's empty `{}` returns before a later pair is ever compared. The two codes do not have a fixed precedence; they interleave by source order, and both directions are tested.
3. At most one grammar report per element, so a name repeated three times, or two different names each repeated, still yields exactly one diagnostic.
4. The key is the attribute's **full** text. A namespaced name collides only with the same namespace *and* local name — `ns:a` twice is TS17001, `one:shared` vs `two:shared` is clean. Comparison is case-sensitive.

Point 4 is worth calling out: tsc's own legacy implementation keys on `name.escapedText`, which is `undefined` for a `JsxNamespacedName` and would make *every* namespaced pair collide. 7.0.2 does not behave that way, so this follows the observed behaviour, not the historical source. The name text comes from the existing `get_jsx_attribute_name`, which already renders both identifiers and namespaced names — no new name handling is introduced, and nothing reads rendered diagnostic output.

Also replaces the hand-copied TS17000 message string literal with its catalog constant, so the wording can no longer drift from the generated table.

**Owner layer.** Checker, in the existing per-element JSX grammar pass. This is not a parser diagnostic, so it cannot participate in `hasParseDiagnostics()` whole-file suppression and needs no `is_non_suppressing_parse_error` entry — unrelated to the regex-grammar suppression family that has been active on this board.

## Goal
Goal: hold

## Verification

Oracle is `typescript@7.0.2`, the version `scripts/conformance/typescript-versions.json` pins as `default`, run as `--noEmit --strict --pretty false --jsx preserve --target es2022 --lib es2022`.

**Before/after on the witness family** (tsz `main` @ `5f353b8` vs this branch):

| source | tsc 7.0.2 | tsz before | tsz after |
|---|---|---|---|
| `[div alpha="1" alpha="2" /]` | TS17001 | *(clean)* | TS17001 |
| `[span beta="1" beta="2"]text[/span]` | TS17001 | *(clean)* | TS17001 |
| `[Widget delta="1" delta="2" /]` (component) | TS17001 | *(clean)* | TS17001 |
| `[Missing eps="1" eps="2" /]` (unresolved tag) | TS2304 + TS17001 | TS2304 | TS2304 + TS17001 |
| `[div zeta zeta /]` (shorthand) | TS17001 | *(clean)* | TS17001 |
| `[div data-token="1" data-token="2" /]` | TS17001 | *(clean)* | TS17001 |
| `[div xlink:href="1" xlink:href="2" /]` | TS17001 | *(clean)* | TS17001 |
| `[div theta="1" {...rest} theta="2" /]` | TS17001 | *(clean)* | TS17001 |
| `[div mu="1" nu="2" mu="3" xi="4" nu="5" /]` | TS17001 **once** | *(clean)* | TS17001 once |
| `[div pi="1" pi={} /]` | TS17001 | TS17000 | TS17001 |
| `[div rho={} sigma="1" sigma="2" /]` | TS17000 | TS17000 | TS17000 |
| `[div Alpha="1" alpha="2" /]` | *(clean)* | *(clean)* | *(clean)* |
| `[div one:shared="1" two:shared="2" /]` | *(clean)* | *(clean)* | *(clean)* |
| `[div {...rest} {...rest} /]` | *(clean)* | *(clean)* | *(clean)* |
| `[div kappa="1"][span kappa="2" /][span kappa="3" /][/div]` | *(clean)* | *(clean)* | *(clean)* |

Note row 10 (`pi="1" pi={}`) is a **changed** diagnostic, not just an added one: tsz previously reported TS17000 there because it never compared the name. That is the ordering fact in point 2 above.

**Commands actually run:**

- `cargo fmt -p tsz-checker` — clean.
- `cargo clippy --profile ci-lint --workspace --exclude tsz-conformance --all-targets -- -D warnings` — clean (CI's exact invocation), 4m22s.
- `cargo test -p tsz-checker --lib duplicate_attribute_grammar` — **19 passed, 0 failed** (the new matrix; every row above plus the anchor-position assertion).
- `cargo test -p tsz-checker --lib jsx` — **443 passed, 0 failed**, no movement against the pre-change run.

The new matrix varies binder names throughout (`alpha`/`beta`/`gamma`, `data-token`, `xlink:href`, `one:shared`) so no assertion can be satisfied by matching a particular identifier, and asserts the report anchors on the *second* occurrence by slicing the source at the reported span.

**Gates owed, disclosed:** `compare-to-parent.sh` was not run — this container is cold (`.target` empty at session start, ~6 min per debug build) and the two-sided `dist-fast` run does not fit the remaining window. The risk is low and bounded: TS17001 had **zero** emit sites before this change, and the only behaviour that can change for existing code is an element that both repeats a name and has an empty `{}` initializer, where the reported code flips TS17000 → TS17001. `cargo nextest` is not installed in this image; the runs above used `cargo test` with a filter. I will post `compare-to-parent.sh` numbers on the next run.

Closes part of #16291 (the TS17001 row).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Azurite

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bu4wrnnUuxbf7LieUV6Mms)_