### PR TITLE
fix(checker): a `typeof Symbol.x` alias keys the canonical well-known member

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1098,6 +1098,9 @@ path = "tests/ts2353_cross_module_symbol_computed_key_tests.rs"
 name = "wide_symbol_computed_member_index_signature_tests"
 path = "tests/wide_symbol_computed_member_index_signature_tests.rs"
 [[test]]
+name = "well_known_symbol_type_query_alias_key_tests"
+path = "tests/well_known_symbol_type_query_alias_key_tests.rs"
+[[test]]
 name = "relational_operator_type_display_tests"
 path = "tests/relational_operator_type_display_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/type_resolution/computed_property_names.rs
+++ b/crates/tsz-checker/src/state/type_resolution/computed_property_names.rs
@@ -397,6 +397,20 @@ impl<'a> CheckerState<'a> {
         if let Some(name) = self.local_well_known_symbol_property_name(computed.expression) {
             return Some(ResolvedComputedName::string(name));
         }
+        // `[it]` where `it` is declared `typeof Symbol.<member>` for a genuine
+        // well-known member: tsc types that binding as the well-known symbol
+        // itself, so the key is the canonical `[Symbol.<member>]` — the same
+        // member `[Symbol.<member>]` written inline declares. Checked before
+        // the binding-identity legs below, which would otherwise key the alias
+        // under `__unique_<id>` and split one member into two.
+        if let Some(sym_id) = self.resolve_computed_name_expression_symbol(computed.expression)
+            && let Some(name) =
+                crate::types_domain::computed_names::type_query_well_known_symbol_key(
+                    &self.ctx, sym_id,
+                )
+        {
+            return Some(ResolvedComputedName::string(name));
+        }
         // `Symbol.<member>` where `<member>` is a plain (non-unique)
         // `symbol`-typed global augmentation (xstate's `SymbolConstructor.
         // observable: symbol`) is not a well-known key at all: it does not

--- a/crates/tsz-checker/src/types/computation/object_literal/symbol_key_routing.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/symbol_key_routing.rs
@@ -134,6 +134,24 @@ impl<'a> CheckerState<'a> {
         {
             return false;
         }
+        // A binding declared `typeof Symbol.<member>` for a genuine well-known
+        // member IS that well-known symbol under tsc (the type query reports
+        // `unique symbol`), so it names the canonical `[Symbol.<member>]`
+        // member rather than routing into a symbol index signature — the same
+        // answer `[Symbol.<member>]` written inline gets. The value-position
+        // evaluation below only sees the wide `symbol` intrinsic for such a
+        // binding, so the declaration has to be consulted directly.
+        if self
+            .resolve_computed_name_expression_symbol(computed.expression)
+            .and_then(|sym_id| {
+                crate::types_domain::computed_names::type_query_well_known_symbol_key(
+                    &self.ctx, sym_id,
+                )
+            })
+            .is_some()
+        {
+            return false;
+        }
         self.get_type_of_node(computed.expression) == TypeId::SYMBOL
     }
 

--- a/crates/tsz-checker/src/types/computed_names.rs
+++ b/crates/tsz-checker/src/types/computed_names.rs
@@ -524,30 +524,84 @@ fn declaration_has_wide_type_query_annotation(
     arena: &NodeArena,
     decl_idx: NodeIndex,
 ) -> bool {
-    let Some(node) = arena.get(decl_idx) else {
-        return false;
-    };
-    let type_annotation = if node.kind == syntax_kind_ext::VARIABLE_DECLARATION {
-        let Some(var_decl) = arena.get_variable_declaration(node) else {
+    declaration_type_query_symbol_constructor_member(ctx, owner_binder, arena, decl_idx)
+        .is_some_and(|member| symbol_constructor_member_is_wide(ctx, &member))
+}
+
+/// The `SymbolConstructor` member a declaration's own annotation names through
+/// a `typeof Symbol.<member>` type query, with `Symbol` resolved to the
+/// unshadowed global. `None` for any other annotation shape, and for a
+/// shadowed `Symbol`. Says nothing about whether the member is `unique symbol`
+/// or plain `symbol`; callers decide on that.
+fn declaration_type_query_symbol_constructor_member(
+    ctx: &CheckerContext<'_>,
+    owner_binder: &BinderState,
+    arena: &NodeArena,
+    decl_idx: NodeIndex,
+) -> Option<String> {
+    let node = arena.get(decl_idx)?;
+    if node.kind != syntax_kind_ext::VARIABLE_DECLARATION {
+        return None;
+    }
+    let type_annotation = arena.get_variable_declaration(node)?.type_annotation;
+    if !type_annotation.is_some() {
+        return None;
+    }
+    let ann_node = arena.get(type_annotation)?;
+    if ann_node.kind != syntax_kind_ext::TYPE_QUERY {
+        return None;
+    }
+    let type_query = arena.get_type_query(ann_node)?;
+    let shape = well_known_symbol_access_shape(arena, type_query.expr_name)?;
+    let member = shape
+        .name
+        .as_deref()
+        .and_then(|name| name.strip_prefix("[Symbol."))
+        .and_then(|name| name.strip_suffix(']'))?
+        .to_string();
+    identifier_resolves_to_unshadowed_global_in_context(
+        ctx,
+        arena,
+        owner_binder,
+        shape.base,
+        "Symbol",
+    )
+    .then_some(member)
+}
+
+/// The canonical `[Symbol.<member>]` key a binding writes when it is declared
+/// `typeof Symbol.<member>` for a genuine well-known (`unique symbol`) member
+/// — `declare const it: typeof Symbol.iterator; interface T { [it]: ... }`.
+///
+/// `tsc` types such a binding as the well-known symbol itself (`typeof
+/// Symbol.iterator` is a `unique symbol`), so the member it keys is the very
+/// same one `interface U { [Symbol.iterator]: ... }` declares inline. Without
+/// this leg the alias falls through to binding-identity naming
+/// (`__unique_<id>`), the two declarations describe different member sets, and
+/// `T` reports a missing `[Symbol.iterator]` against `U` where `tsc` is clean.
+///
+/// `None` for a plain (non-`unique`) `SymbolConstructor` member: that binding
+/// carries the wide `symbol` type and routes into the containing type's symbol
+/// index signature instead (#16307), which is a different member shape.
+pub(crate) fn type_query_well_known_symbol_key(
+    ctx: &CheckerContext<'_>,
+    sym_id: SymbolId,
+) -> Option<String> {
+    let sym_id = follow_import_aliases(ctx, sym_id);
+    let found = std::cell::RefCell::new(None);
+    any_declaration_matches(ctx, sym_id, |owner_binder, arena, decl_idx| {
+        let Some(member) =
+            declaration_type_query_symbol_constructor_member(ctx, owner_binder, arena, decl_idx)
+        else {
             return false;
         };
-        var_decl.type_annotation
-    } else {
-        return false;
-    };
-    if !type_annotation.is_some() {
-        return false;
-    }
-    let Some(ann_node) = arena.get(type_annotation) else {
-        return false;
-    };
-    if ann_node.kind != syntax_kind_ext::TYPE_QUERY {
-        return false;
-    }
-    let Some(type_query) = arena.get_type_query(ann_node) else {
-        return false;
-    };
-    wide_well_known_symbol_member_key(ctx, arena, owner_binder, type_query.expr_name).is_some()
+        if symbol_constructor_member_is_wide(ctx, &member) {
+            return false;
+        }
+        *found.borrow_mut() = Some(format!("[Symbol.{member}]"));
+        true
+    });
+    found.into_inner()
 }
 
 fn declaration_is_unique_symbol_binding(

--- a/crates/tsz-checker/src/types/queries/core_names.rs
+++ b/crates/tsz-checker/src/types/queries/core_names.rs
@@ -168,6 +168,22 @@ impl<'a> CheckerState<'a> {
 
         if name_node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME {
             let computed = self.ctx.arena.get_computed_property(name_node)?;
+            // `[it]` where `it` is declared `typeof Symbol.<member>` for a
+            // genuine well-known member names the canonical
+            // `[Symbol.<member>]` member, the same one the inline access
+            // declares — tsc types the alias as that `unique symbol` itself.
+            // Ahead of binding-identity naming, which would otherwise mint a
+            // per-binding `__unique_<id>` key and split one member in two.
+            if let Some(name) = self
+                .resolve_computed_name_expression_symbol(computed.expression)
+                .and_then(|sym_id| {
+                    crate::types_domain::computed_names::type_query_well_known_symbol_key(
+                        &self.ctx, sym_id,
+                    )
+                })
+            {
+                return Some(name);
+            }
             if let Some(sym_ref) =
                 self.computed_identifier_unique_symbol_property_ref(computed.expression)
             {
@@ -425,7 +441,7 @@ impl<'a> CheckerState<'a> {
     /// or qualified entity name), without following import aliases; the
     /// canonical key helpers in `types_domain::computed_names` own alias
     /// hops and the symbol-valued key policy.
-    fn resolve_computed_name_expression_symbol(
+    pub(crate) fn resolve_computed_name_expression_symbol(
         &self,
         expr_idx: NodeIndex,
     ) -> Option<tsz_binder::SymbolId> {

--- a/crates/tsz-checker/tests/well_known_symbol_type_query_alias_key_tests.rs
+++ b/crates/tsz-checker/tests/well_known_symbol_type_query_alias_key_tests.rs
@@ -1,0 +1,203 @@
+//! A computed key written through a `typeof Symbol.<member>` alias keys the
+//! same member as `[Symbol.<member>]` written inline.
+//!
+//! Structural rule, verified against the pinned `tsc` oracle: `typeof
+//! Symbol.iterator` IS the well-known symbol's own type (`tsc` reports it as
+//! `unique symbol`), so `declare const it: typeof Symbol.iterator; interface T
+//! { [it]: V }` declares the canonical `[Symbol.iterator]` member — exactly
+//! what `interface U { [Symbol.iterator]: V }` declares. Before this leg the
+//! alias fell through to binding-identity naming (`__unique_<id>`), so `T` and
+//! `U` described different member sets and `T` reported a missing
+//! `[Symbol.iterator]` against `U` where `tsc` is clean.
+//!
+//! Two boundaries the rule must not cross, both oracle-checked:
+//! - An UNANNOTATED `const it = Symbol.iterator` widens to `symbol`, so it
+//!   keys a symbol index signature, not the well-known member. `tsc` reports
+//!   the mismatch against an inline `[Symbol.iterator]` member; so must tsz.
+//! - A `typeof Symbol.<member>` alias for a PLAIN (non-`unique`) augmented
+//!   member keeps #16307's wide-`symbol` index-signature routing.
+//!
+//! Binder names vary across cases on purpose: the rule reads the declaration's
+//! annotation, never the identifier the user chose.
+
+use std::sync::Arc;
+use tsz_binder::lib_loader::LibFile;
+use tsz_checker::context::{CheckerOptions, ScriptTarget};
+use tsz_checker::test_utils::check_source_with_libs;
+
+fn load_symbol_lib_files_for_test() -> Vec<Arc<LibFile>> {
+    tsz_checker::test_utils::load_compiled_lib_files(&[
+        "lib.es5.d.ts",
+        "lib.es2015.symbol.d.ts",
+        "lib.es2015.symbol.wellknown.d.ts",
+    ])
+}
+
+fn codes(source: &str) -> Vec<u32> {
+    let lib_files = load_symbol_lib_files_for_test();
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            target: ScriptTarget::ES2022,
+            ..CheckerOptions::default()
+        },
+        &lib_files,
+    )
+    .into_iter()
+    .map(|diagnostic| diagnostic.code)
+    .collect()
+}
+
+fn assert_no_missing_property(source: &str) {
+    let result = codes(source);
+    assert!(
+        !result.contains(&2741) && !result.contains(&2345) && !result.contains(&2322),
+        "expected the aliased well-known key to name the same member, got: {result:?}"
+    );
+}
+
+// 1. Reported repro: an interface keyed through the alias satisfies one keyed
+//    inline.
+#[test]
+fn type_query_alias_keys_the_same_member_as_the_inline_well_known() {
+    assert_no_missing_property(
+        r#"
+declare const it: typeof Symbol.iterator;
+interface Aliased { [it]: () => number }
+interface Inline { [Symbol.iterator]: () => number }
+declare const aliased: Aliased;
+declare function want(value: Inline): void;
+want(aliased);
+"#,
+    );
+}
+
+// 2. The other direction: inline-keyed source against an alias-keyed target.
+#[test]
+fn inline_well_known_key_satisfies_a_type_query_alias_target() {
+    assert_no_missing_property(
+        r#"
+declare const marker: typeof Symbol.iterator;
+interface Aliased { [marker]: () => number }
+interface Inline { [Symbol.iterator]: () => number }
+declare const inline: Inline;
+declare function want(value: Aliased): void;
+want(inline);
+"#,
+    );
+}
+
+// 3. Renamed binders and a different well-known member — the rule is
+//    structural, not a match on any particular spelling.
+#[test]
+fn renamed_alias_of_another_well_known_member_is_structural() {
+    assert_no_missing_property(
+        r#"
+declare const asyncKey: typeof Symbol.asyncIterator;
+interface ThroughAlias { [asyncKey]: () => number }
+interface WrittenOut { [Symbol.asyncIterator]: () => number }
+declare const source: ThroughAlias;
+declare function want(value: WrittenOut): void;
+want(source);
+"#,
+    );
+}
+
+// 4. A class member keyed through the alias satisfies an interface that keys
+//    the member inline — the alias must reach every declaration form, not just
+//    interface lowering.
+#[test]
+fn class_member_keyed_through_the_alias_matches_an_inline_interface_member() {
+    assert_no_missing_property(
+        r#"
+declare const slot: typeof Symbol.iterator;
+class Holder { [slot](): number { return 1; } }
+interface Shape { [Symbol.iterator]: () => number }
+declare const holder: Holder;
+declare function want(value: Shape): void;
+want(holder);
+"#,
+    );
+}
+
+// 5. Two aliases of the SAME well-known member agree with each other, even
+//    though they are distinct bindings — binding identity must not survive.
+#[test]
+fn two_distinct_aliases_of_one_well_known_member_agree() {
+    assert_no_missing_property(
+        r#"
+declare const first: typeof Symbol.iterator;
+declare const second: typeof Symbol.iterator;
+interface Producer { [first]: () => number }
+interface Consumer { [second]: () => number }
+declare const producer: Producer;
+declare function want(value: Consumer): void;
+want(producer);
+"#,
+    );
+}
+
+// 6. Negative: aliases of DIFFERENT well-known members still describe
+//    different members, so the mismatch is still reported.
+#[test]
+fn aliases_of_different_well_known_members_still_mismatch() {
+    let result = codes(
+        r#"
+declare const iterKey: typeof Symbol.iterator;
+declare const asyncIterKey: typeof Symbol.asyncIterator;
+interface HasIterator { [iterKey]: () => number }
+interface WantsAsync { [asyncIterKey]: () => number }
+declare const value: HasIterator;
+declare function want(target: WantsAsync): void;
+want(value);
+"#,
+    );
+    assert!(
+        result.contains(&2345) || result.contains(&2741),
+        "two different well-known members must not collapse into one key, got: {result:?}"
+    );
+}
+
+// 7. Boundary: an UNANNOTATED `const` initialized from `Symbol.iterator`
+//    widens to `symbol`, so it keys an index signature rather than the
+//    well-known member. tsc reports the mismatch; the alias leg must not
+//    swallow it.
+#[test]
+fn unannotated_const_initialized_from_symbol_iterator_stays_wide() {
+    let result = codes(
+        r#"
+const inferred = Symbol.iterator;
+interface Widened { [inferred]: () => number }
+interface Inline { [Symbol.iterator]: () => number }
+declare const widened: Widened;
+declare function want(value: Inline): void;
+want(widened);
+"#,
+    );
+    assert!(
+        result.contains(&2345) || result.contains(&2741),
+        "an unannotated Symbol.iterator const widens to `symbol` and keys an index signature, got: {result:?}"
+    );
+}
+
+// 8. Boundary: a `typeof Symbol.<member>` alias for a PLAIN (non-`unique`)
+//    augmented member keeps #16307's wide-`symbol` index-signature routing —
+//    a class keyed through it stays assignable to an interface keyed off an
+//    unrelated wide `symbol` binding.
+#[test]
+fn type_query_alias_of_a_wide_augmented_member_keeps_index_signature_routing() {
+    assert_no_missing_property(
+        r#"
+interface SymbolConstructor { readonly observable: symbol }
+declare const observableKey: typeof Symbol.observable;
+declare const unrelatedKey: symbol;
+class Emitter { [observableKey](): number { return 1; } }
+interface Sink { [unrelatedKey]: () => number }
+declare const emitter: Emitter;
+declare function want(value: Sink): void;
+want(emitter);
+"#,
+    );
+}


### PR DESCRIPTION
**Structural rule.** When a computed key is a binding declared `typeof Symbol.<member>` and `<member>` is a genuine well-known (`unique symbol`) member of the merged `SymbolConstructor`, `tsc` types that binding as the well-known symbol itself, so the member it keys is the canonical `[Symbol.<member>]` one — the very member `[Symbol.<member>]` written inline declares. tsz now does the same through the checker's computed-name resolution (`types_domain::computed_names` + the two member-name paths that consume it), instead of falling through to binding-identity naming.

Oracle, `tsc` 6.0.2 (`typeof Symbol.iterator` reports as `unique symbol`, which is what makes the two spellings one member):

```ts
declare const it: typeof Symbol.iterator;
interface T { [it]: () => number }
interface U { [Symbol.iterator]: () => number }
declare const t: T;
declare function wantU(u: U): void;
wantU(t);
```

| | before | after | `tsc` |
|---|---|---|---|
| `wantU(t)` | `TS2741 Property '[Symbol.iterator]' is missing in type 'T'` | clean | clean |
| `keyof` of the alias binding | `symbol` | `symbol` | `unique symbol` (display gap, not fixed here) |

The false positive is a member-identity split, not a relation bug: `[it]` minted `__unique_<symbolId>` (per-binding), `[Symbol.iterator]` minted `[Symbol.iterator]` (canonical), so the two declarations described disjoint member sets. Two distinct aliases of the same well-known member had the same problem with each other.

**Owner layer.** Checker. `computed_names::type_query_well_known_symbol_key` reads the binding's own declaration (a `TYPE_QUERY` annotation over the unshadowed global `Symbol`, verified through the binder — no identifier-text policy beyond the existing global-`Symbol` shape match that `well_known_symbol_access_shape` already owns) and returns the canonical key. It is consulted from the three places that decide a computed member's identity:

- `state::type_resolution::computed_property_names::resolve_local_computed_property_name` — the interface / type-literal lowering path,
- `types::queries::core_names::get_property_name_resolved` — the `CheckerState` member-name path (classes, object literals),
- `computed_member_key_is_wide_symbol` — so the key is not also routed into a `[k: symbol]: V` index signature.

`declaration_has_wide_type_query_annotation` is refactored onto the same shape extractor rather than duplicating it; the wide (non-`unique`) answer it gave before is unchanged.

**Adjacent matrix** (`crates/tsz-checker/tests/well_known_symbol_type_query_alias_key_tests.rs`, 8 cases, all oracle-checked; binder names vary across cases so nothing keys off a spelling):

| case | expectation |
|---|---|
| alias-keyed interface → inline-keyed target | clean |
| inline-keyed source → alias-keyed target | clean (both directions) |
| renamed binder, `Symbol.asyncIterator` instead | clean (structural, not a spelling match) |
| class member keyed through the alias → inline interface | clean (reaches every declaration form) |
| two distinct aliases of one well-known member | clean (binding identity does not survive) |
| aliases of two *different* well-known members | still mismatches |
| unannotated `const it = Symbol.iterator` | still widens to `symbol` → index signature, mismatch still reported (matches `tsc`) |
| alias of a plain `symbol` `SymbolConstructor` augmentation | keeps #16307's symbol-index routing |

**Not in scope.** The wide-`Symbol.<member>` leg of #16307 (item 2 of the 01:19Z measurement) is untouched and still diverges — `interface I { [Symbol.observable]: number }` with a plain-`symbol` augmentation gets a symbol index in tsz where `tsc` keys a named member, so `i[otherSymbol]` misses `TS7053`. Evidence and the reason it is a bigger change than it looks is on #16307.

## Goal
Goal: hold

## Verification

Run locally at `e3a2951` (debug build; container has no TypeScript corpus and no release build).

- `cargo test -p tsz-checker --test well_known_symbol_type_query_alias_key_tests` — **8 passed, 0 failed** (new suite; 7 of the 8 fail on the parent).
- `cargo test -p tsz-checker --lib` — **9341 passed**, 1 failed: `ts2303_tests::recursive_export_assignment_self_import_reports_ts2303`, confirmed **pre-existing** (fails identically at the parent commit with the diff stashed). Three heavy tests (`ts2589_tests::recursive_conditional_alias_omitted_default_transform_emits_definition_ts2589`, `class_static_init_self_new_tests::three_class_hierarchy_with_instance_field_aliases_and_static_create`, `contextual_return_wrapper_tests::wrapped_this_return_annotations_contextualize_generic_factories`) starve under full-parallel debug on this container; run directly they are **3 passed in 21s**, and the ts2589 one is 2.56s with the diff vs 2.65s at the parent — no slowdown.
- `cargo test -p tsz-checker` for the neighbouring symbol-key suites: `wide_symbol_computed_member_index_signature_tests` 7, `symbol_index_signature_tests` 93, `keyof_well_known_symbol_key_tests` 8, `ts7053_unique_symbol_constrained_type_param_index_tests` 8, `ts2300_tests` 71, new suite 11 collected — **all green**.
- `cargo clippy --workspace --exclude tsz-conformance --all-targets -- -D warnings` — clean (CI's exact invocation). `cargo fmt --all` applied; pre-commit clippy + architecture guard passed.
- CLI-vs-`tsc` 6.0.2 diff on 8 hand fixtures (the repro, both directions, the two boundary shapes, and the #16307 wide shapes): the only tsz/`tsc` deltas left are the out-of-scope #16307 ones listed above.

**Owed, not run here:** `scripts/conformance/compare-to-parent.sh`, `./scripts/emit/run.sh`, and fourslash — this container has no TypeScript submodule and no release build, and cloning plus two release builds does not fit the session. The diff is member-key identity for a `typeof Symbol.x`-annotated binding, so emit is the gate most worth running before merge.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Peridot

---
_Generated by [Claude Code](https://claude.ai/code/session_012ahUorqSDBX9k9MY72R6S5)_