### PR TITLE
fix(parser): TS1518 for a negated `v`-mode class that may match a string

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -277,6 +277,10 @@ mod regex_class_set_nesting_tests;
 mod regex_class_set_reserved_double_punctuator_tests;
 
 #[cfg(test)]
+#[path = "../../tests/regex_negated_class_may_contain_strings_tests.rs"]
+mod regex_negated_class_may_contain_strings_tests;
+
+#[cfg(test)]
 #[path = "../../tests/regex_class_set_operator_mixing_tests.rs"]
 mod regex_class_set_operator_mixing_tests;
 

--- a/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
@@ -367,7 +367,6 @@ impl ParserState {
                 body_end: usize,
                 strict_mode: bool,
                 unicode_sets_mode: bool,
-                start_pos: u32,
                 capturing_group_count: u32,
                 /// Per-alternative capturing-group name scopes, shared across
                 /// the whole recursive scan. `RefCell` because the scan hands
@@ -646,15 +645,23 @@ impl ParserState {
                         let escape_char = ch;
                         *pos += 1;
                         if *pos < end && body[*pos] == b'{' {
+                            // At atom position there is no enclosing class to
+                            // judge, so the strings answer is discarded; only
+                            // the `\P` rejection above can fire here.
+                            let mut may_contain_strings = false;
                             scan_unicode_property_value_expression(
                                 parser,
                                 emit,
                                 body,
-                                strict_mode,
-                                scan_ctx.unicode_sets_mode,
+                                PropertyExpressionMode {
+                                    unicode: strict_mode,
+                                    unicode_sets: scan_ctx.unicode_sets_mode,
+                                    negated: escape_char == b'P',
+                                },
                                 end,
                                 pos,
                                 escape_start,
+                                &mut may_contain_strings,
                             );
                         } else if strict_mode {
                             let message = if escape_char == b'P' {
@@ -875,16 +882,35 @@ impl ParserState {
             /// the surrounding walker to report as ordinary regex text, which
             /// is how `\p{ Script=Latin }` gets TS1527 followed by a TS1508 on
             /// the trailing brace.
+            /// The three mode bits `scan_unicode_property_value_expression`
+            /// judges by, bundled so the parameter list stays readable.
+            #[derive(Clone, Copy)]
+            struct PropertyExpressionMode {
+                unicode: bool,
+                unicode_sets: bool,
+                /// `true` for `\P{...}`, whose complement is only defined over
+                /// single characters — see the properties-of-strings arm.
+                negated: bool,
+            }
+
             fn scan_unicode_property_value_expression(
                 parser: &mut ParserState,
                 emit: &impl Fn(&mut ParserState, usize, u32, &str, u32),
                 body: &[u8],
-                unicode_mode: bool,
-                unicode_sets_mode: bool,
+                mode: PropertyExpressionMode,
                 end: usize,
                 pos: &mut usize,
                 escape_start: usize,
+                // Set when this expression names a property of *strings*, so
+                // the enclosing class can judge TS1518 for itself.
+                may_contain_strings: &mut bool,
             ) {
+                let PropertyExpressionMode {
+                    unicode: unicode_mode,
+                    unicode_sets: unicode_sets_mode,
+                    negated: property_negated,
+                } = mode;
+
                 fn scan_word(body: &[u8], end: usize, pos: &mut usize) -> usize {
                     let start = *pos;
                     while *pos < end && (body[*pos] == b'_' || body[*pos].is_ascii_alphanumeric()) {
@@ -969,9 +995,7 @@ impl ParserState {
                     {
                         // Matches a sequence rather than a single character,
                         // so it is only accepted under the Unicode Sets (`v`)
-                        // flag; under `v` it is valid as-is (the negated-class
-                        // restriction tsc applies here is a separate,
-                        // unwired diagnostic).
+                        // flag.
                         if !unicode_sets_mode {
                             emit(
                                 parser,
@@ -980,6 +1004,25 @@ impl ParserState {
                                 diagnostic_messages::ANY_UNICODE_PROPERTY_THAT_WOULD_POSSIBLY_MATCH_MORE_THAN_A_SINGLE_CHARACTER_IS_O,
                                 diagnostic_codes::ANY_UNICODE_PROPERTY_THAT_WOULD_POSSIBLY_MATCH_MORE_THAN_A_SINGLE_CHARACTER_IS_O,
                             );
+                        } else if property_negated {
+                            // `\P{...}` complements the property, and a
+                            // complement is only defined over single
+                            // characters — so a property of strings is
+                            // rejected outright, in or out of a negated
+                            // class, and reported on the property *name*
+                            // rather than on the escape. Because the
+                            // operand is already an error it does not also
+                            // feed the enclosing class's own TS1518 check:
+                            // `/[^\P{RGI_Emoji}]/v` draws exactly one.
+                            emit(
+                                parser,
+                                name_start,
+                                name_len as u32,
+                                diagnostic_messages::ANYTHING_THAT_WOULD_POSSIBLY_MATCH_MORE_THAN_A_SINGLE_CHARACTER_IS_INVALID_INSID,
+                                diagnostic_codes::ANYTHING_THAT_WOULD_POSSIBLY_MATCH_MORE_THAN_A_SINGLE_CHARACTER_IS_INVALID_INSID,
+                            );
+                        } else {
+                            *may_contain_strings = true;
                         }
                     } else if !is_known_unicode_property_name_or_value(
                         &body[name_start..name_start + name_len],
@@ -999,6 +1042,56 @@ impl ParserState {
                 }
             }
 
+            /// Whether a `\q{...}` body — the raw bytes between the braces —
+            /// denotes a set containing anything other than single characters.
+            /// Each `|`-separated alternative is a `ClassString`, and the
+            /// disjunction may contain strings as soon as one alternative is
+            /// not exactly one code point. An escape sequence contributes
+            /// exactly one code point, so `\q{a}` is a single character
+            /// and must not be judged by its six source bytes.
+            fn class_string_disjunction_may_contain_strings(alternatives: &[u8]) -> bool {
+                let mut code_points = 0usize;
+                let mut pos = 0usize;
+
+                while pos < alternatives.len() {
+                    match alternatives[pos] {
+                        b'|' => {
+                            if code_points != 1 {
+                                return true;
+                            }
+                            code_points = 0;
+                            pos += 1;
+                        }
+                        b'\\' => {
+                            code_points += 1;
+                            pos += 1;
+                            // `\u{H+}` spans to its closing brace; every other
+                            // escape is sized by the walker that follows, and
+                            // consuming the single byte after the backslash is
+                            // enough to keep `|` and code-point counting
+                            // aligned for all of them.
+                            if alternatives.get(pos) == Some(&b'u')
+                                && alternatives.get(pos + 1) == Some(&b'{')
+                            {
+                                pos += 2;
+                                while pos < alternatives.len() && alternatives[pos] != b'}' {
+                                    pos += 1;
+                                }
+                            }
+                            pos += 1;
+                        }
+                        _ => {
+                            let advance = next_utf8_char(alternatives, alternatives.len(), pos)
+                                .map_or(1, |(_ch, char_len)| char_len);
+                            code_points += 1;
+                            pos += advance;
+                        }
+                    }
+                }
+
+                code_points != 1
+            }
+
             fn scan_character_class_escape(
                 parser: &mut ParserState,
                 emit: &impl Fn(&mut ParserState, usize, u32, &str, u32),
@@ -1007,7 +1100,10 @@ impl ParserState {
                 unicode_sets_mode: bool,
                 end: usize,
                 pos: &mut usize,
-                _start_pos: u32,
+                // Set when this escape denotes a set that can match something
+                // other than exactly one character, which is what the
+                // enclosing negated class rejects with TS1518.
+                may_contain_strings: &mut bool,
             ) -> Option<ClassAtomKind> {
                 if *pos >= body.len() {
                     return None;
@@ -1090,8 +1186,20 @@ impl ParserState {
                         *pos += 1;
                         if *pos < body.len() && body[*pos] == b'{' {
                             *pos += 1;
+                            let alternatives_start = *pos;
                             while *pos < body.len() && body[*pos] != b'}' {
                                 *pos += 1;
+                            }
+                            // `\q{...}` denotes a set of string literals. It
+                            // can match other than exactly one character as
+                            // soon as any single `|`-separated alternative is
+                            // not exactly one code point long — including the
+                            // empty alternative in `\q{}`, which matches the
+                            // empty string.
+                            if class_string_disjunction_may_contain_strings(
+                                &body[alternatives_start..*pos],
+                            ) {
+                                *may_contain_strings = true;
                             }
                             if *pos < body.len() {
                                 *pos += 1;
@@ -1109,11 +1217,15 @@ impl ParserState {
                                 parser,
                                 emit,
                                 body,
-                                strict_mode,
-                                unicode_sets_mode,
+                                PropertyExpressionMode {
+                                    unicode: strict_mode,
+                                    unicode_sets: unicode_sets_mode,
+                                    negated,
+                                },
                                 end,
                                 pos,
                                 start - 1,
+                                may_contain_strings,
                             );
                             Some(ClassAtomKind::Class)
                         } else if strict_mode {
@@ -1148,6 +1260,7 @@ impl ParserState {
                 ctx: &RegexScanContext<'_, F>,
                 pos: &mut usize,
                 range: &mut Vec<ClassAtomKind>,
+                may_contain_strings: &mut bool,
             ) where
                 F: Fn(&mut ParserState, usize, u32, &str, u32),
             {
@@ -1161,7 +1274,10 @@ impl ParserState {
                 // grammar, so this must stay gated.
                 if ctx.unicode_sets_mode && ch == b'[' {
                     *pos += 1;
-                    scan_class_ranges(parser, ctx, pos);
+                    // A nested class contributes its own strings answer to the
+                    // class that encloses it: `/[^[\q{ab}]]/v` is reported on
+                    // the nested `[`, not on the `\q` inside it.
+                    *may_contain_strings |= scan_class_ranges(parser, ctx, pos);
                     range.push(ClassAtomKind::Class);
                     return;
                 }
@@ -1222,7 +1338,7 @@ impl ParserState {
                         ctx.unicode_sets_mode,
                         ctx.body_end,
                         pos,
-                        ctx.start_pos,
+                        may_contain_strings,
                     ) {
                         Some(atom) => range.push(atom),
                         None => {
@@ -1259,11 +1375,16 @@ impl ParserState {
                 }
             }
 
+            /// Returns whether this class may match something other than
+            /// exactly one character, for the benefit of a class that encloses
+            /// it. See the TS1518 block below for why that answer is the
+            /// *first* operand's rather than the union of every operand's.
             fn scan_class_ranges<F>(
                 parser: &mut ParserState,
                 ctx: &RegexScanContext<'_, F>,
                 pos: &mut usize,
-            ) where
+            ) -> bool
+            where
                 F: Fn(&mut ParserState, usize, u32, &str, u32),
             {
                 fn is_class_set_operator_at(body: &[u8], pos: usize, end: usize) -> bool {
@@ -1348,9 +1469,38 @@ impl ParserState {
                 }
 
                 // Consume optional leading ^
-                if *pos < ctx.body_end && ctx.body[*pos] == b'^' {
+                let negated = *pos < ctx.body_end && ctx.body[*pos] == b'^';
+                if negated {
                     *pos += 1;
                 }
+
+                // A negated class complements its contents, and a complement
+                // is only defined over single characters, so an operand that
+                // may match a string is TS1518.
+                //
+                // In a UNION, tsc consults only the class's FIRST operand:
+                // `/[^\q{xy}b]/v` is reported and `/[^b\q{xy}]/v` is not, and
+                // likewise `/[^\p{RGI_Emoji}a]/v` against
+                // `/[^a\p{RGI_Emoji}]/v`. The ECMAScript grammar makes
+                // `MayContainStrings` of a union true when *any* operand may
+                // contain strings, so the second member of each pair is a tsc
+                // miss rather than intended behaviour — filed upstream, and
+                // matched here deliberately, because parity with tsc is the
+                // contract.
+                //
+                // INTERSECTION is not subject to that miss and is spec-exact
+                // in tsc: `A&&B` may contain strings only when *every* operand
+                // does, so `/[^\q{ab}&&\q{a}]/v` is clean while
+                // `/[^\q{ab}&&\q{cd}]/v` is not. SUBTRACTION takes its first
+                // operand's answer, which the union rule already gives.
+                //
+                // Because an intersection's verdict is not known until its
+                // last operand, the report is deferred to the end of the class
+                // and anchored to the first operand's start — which is where
+                // tsc points for every shape above.
+                let mut class_may_contain_strings = false;
+                let mut first_operand_start = None;
+                let mut operand_index = 0usize;
 
                 // The first operator a class uses fixes its kind, and mixing a
                 // different one in the same class is TS1519. The commitment is
@@ -1415,7 +1565,15 @@ impl ParserState {
 
                     let mut atoms = Vec::new();
                     let min_start = *pos;
-                    scan_class_atom(parser, ctx, pos, &mut atoms);
+                    let mut atom_may_contain_strings = false;
+                    scan_class_atom(parser, ctx, pos, &mut atoms, &mut atom_may_contain_strings);
+                    if operand_index == 0 {
+                        class_may_contain_strings = atom_may_contain_strings;
+                        first_operand_start = Some(min_start);
+                    } else if committed == Some(ClassSetKind::Intersection) {
+                        class_may_contain_strings &= atom_may_contain_strings;
+                    }
+                    operand_index += 1;
                     if ctx.unicode_sets_mode
                         && is_class_set_operator_at(ctx.body, *pos, ctx.body_end)
                     {
@@ -1464,7 +1622,17 @@ impl ParserState {
 
                     let max_start = *pos;
                     let mut max_atoms = Vec::new();
-                    scan_class_atom(parser, ctx, pos, &mut max_atoms);
+                    // The upper bound of a range is not an operand of the
+                    // class, so its strings answer is not the class's; a
+                    // non-single-character bound is already TS1517's business.
+                    let mut max_atom_may_contain_strings = false;
+                    scan_class_atom(
+                        parser,
+                        ctx,
+                        pos,
+                        &mut max_atoms,
+                        &mut max_atom_may_contain_strings,
+                    );
 
                     let min_atom = atoms.first().copied();
                     let max_atom = max_atoms.first().copied();
@@ -1501,6 +1669,22 @@ impl ParserState {
                     // and surrogate pairs consistently. This scanner still
                     // validates class-boundary rules above.
                 }
+
+                if let Some(report_at) = first_operand_start
+                    && ctx.unicode_sets_mode
+                    && negated
+                    && class_may_contain_strings
+                {
+                    (ctx.emit)(
+                        parser,
+                        report_at,
+                        1,
+                        diagnostic_messages::ANYTHING_THAT_WOULD_POSSIBLY_MATCH_MORE_THAN_A_SINGLE_CHARACTER_IS_INVALID_INSID,
+                        diagnostic_codes::ANYTHING_THAT_WOULD_POSSIBLY_MATCH_MORE_THAN_A_SINGLE_CHARACTER_IS_INVALID_INSID,
+                    );
+                }
+
+                class_may_contain_strings
             }
 
             fn scan_alternative<F>(
@@ -1824,7 +2008,10 @@ impl ParserState {
                         }
                         b'[' => {
                             *pos += 1;
-                            scan_class_ranges(parser, ctx, pos);
+                            // A top-level class has no enclosing class to
+                            // answer to; it has already reported TS1518 for
+                            // itself if it needed to.
+                            let _ = scan_class_ranges(parser, ctx, pos);
                             is_previous_term_quantifiable = true;
                         }
                         b')' => {
@@ -1915,7 +2102,6 @@ impl ParserState {
                 body_end,
                 strict_mode,
                 unicode_sets_mode,
-                start_pos,
                 capturing_group_count: count_capturing_groups(bytes, body_end),
                 group_names: &group_names,
             };

--- a/crates/tsz-parser/tests/regex_negated_class_may_contain_strings_tests.rs
+++ b/crates/tsz-parser/tests/regex_negated_class_may_contain_strings_tests.rs
@@ -1,0 +1,286 @@
+//! TS1518 — anything that would possibly match more than a single character
+//! is invalid inside a negated character class (the `v` flag).
+//!
+//! A negated class complements its contents, and a complement is only defined
+//! over single characters, so an operand denoting a *set of strings* is
+//! rejected. Two constructs produce such an operand under `v`:
+//!
+//! - `\q{...}`, when any `|`-separated alternative is not exactly one code
+//!   point — including the empty alternative of `\q{}`;
+//! - `\p{...}` naming one of the seven binary properties *of strings*
+//!   (`RGI_Emoji` and friends), which `BINARY_UNICODE_PROPERTIES_OF_STRINGS`
+//!   already enumerates for TS1528.
+//!
+//! `\P{...}` over such a property is rejected outright — in or out of a
+//! negated class — because complementing a set of strings is not defined.
+//! tsc reports that one on the property *name* rather than on the escape.
+//!
+//! Every row below is pinned against `typescript@7.0.2`
+//! (`--noEmit --strict --target es2024 --lib es2024`), including the reported
+//! column. `scripts/conformance/typescript-versions.json` `current` resolves
+//! to that exact npm version.
+//!
+//! ## One row family here encodes a tsc bug on purpose
+//!
+//! In a UNION, tsc consults only the class's FIRST operand, so
+//! `/[^\q{xy}b]/v` is reported and `/[^b\q{xy}]/v` is not. The ECMAScript
+//! grammar makes `MayContainStrings` of a union true when *any* operand may
+//! contain strings, so the un-reported member of each pair is a tsc miss.
+//! Parity with tsc is the contract, so the miss is matched deliberately and
+//! pinned by the `union_only_consults_the_first_operand_matching_tsc` tests
+//! below — if a future change starts reporting those rows, it has diverged
+//! from tsc even though it has moved toward the spec.
+//!
+//! Intersection is *not* subject to that miss and is spec-exact in tsc:
+//! `A&&B` may contain strings only when every operand does.
+use crate::parser::test_fixture::parse_source;
+use tsz_common::diagnostics::diagnostic_codes;
+
+const TS1518: u32 =
+    diagnostic_codes::ANYTHING_THAT_WOULD_POSSIBLY_MATCH_MORE_THAN_A_SINGLE_CHARACTER_IS_INVALID_INSID;
+
+/// `(code, zero-based offset)` pairs — the offset is what the CLI renders as a
+/// column, and an operand-anchoring mistake is only visible here.
+fn regex_codes_at(source: &str) -> Vec<(u32, u32)> {
+    let (parser, _root) = parse_source(source);
+    parser
+        .get_diagnostics()
+        .iter()
+        .map(|d| (d.code, d.start))
+        .collect()
+}
+
+fn regex_codes(source: &str) -> Vec<u32> {
+    let (parser, _root) = parse_source(source);
+    parser.get_diagnostics().iter().map(|d| d.code).collect()
+}
+
+/// Offset of `needle` in `source`, for anchoring the expected report.
+fn at(source: &str, needle: &str) -> u32 {
+    source.find(needle).expect("needle in source") as u32
+}
+
+// ---------------------------------------------------------------------------
+// `\q{...}` string disjunctions
+
+#[test]
+fn negated_class_rejects_multi_character_string_alternative() {
+    let src = r"const a = /[^\q{ab}]/v;";
+    assert_eq!(regex_codes_at(src), vec![(TS1518, at(src, r"\q{ab}"))]);
+}
+
+#[test]
+fn negated_class_accepts_single_character_string_alternative() {
+    assert_eq!(regex_codes(r"const a = /[^\q{a}]/v;"), Vec::<u32>::new());
+}
+
+#[test]
+fn negated_class_rejects_disjunction_when_any_alternative_is_multi_character() {
+    let src = r"const a = /[^\q{ab|c}]/v;";
+    assert_eq!(regex_codes_at(src), vec![(TS1518, at(src, r"\q{ab|c}"))]);
+}
+
+#[test]
+fn negated_class_accepts_disjunction_of_single_characters() {
+    assert_eq!(regex_codes(r"const a = /[^\q{a|b}]/v;"), Vec::<u32>::new());
+}
+
+#[test]
+fn negated_class_rejects_empty_string_alternative() {
+    // `\q{}` matches the empty string, which is a string of length 0 — not a
+    // single character — so the class is still rejected.
+    let src = r"const a = /[^\q{}]/v;";
+    assert_eq!(regex_codes_at(src), vec![(TS1518, at(src, r"\q{}"))]);
+}
+
+#[test]
+fn negated_class_sizes_an_escaped_alternative_by_code_points_not_source_bytes() {
+    // `\q{\u{1F600}}` is one code point spelled in ten source bytes. Judging
+    // it by its raw text would false-positive.
+    assert_eq!(
+        regex_codes(r"const a = /[^\q{\u{1F600}}]/v;"),
+        Vec::<u32>::new()
+    );
+}
+
+#[test]
+fn non_negated_class_accepts_a_string_alternative() {
+    assert_eq!(regex_codes(r"const a = /[\q{ab}]/v;"), Vec::<u32>::new());
+}
+
+// ---------------------------------------------------------------------------
+// Properties of strings
+
+#[test]
+fn negated_class_rejects_a_property_of_strings() {
+    let src = r"const a = /[^\p{RGI_Emoji}]/v;";
+    assert_eq!(
+        regex_codes_at(src),
+        vec![(TS1518, at(src, r"\p{RGI_Emoji}"))]
+    );
+}
+
+#[test]
+fn negated_class_rejects_a_second_property_of_strings_under_a_different_name() {
+    // The set is a table lookup, not a spelling match on one witness.
+    let src = r"const a = /[^\p{Basic_Emoji}]/v;";
+    assert_eq!(
+        regex_codes_at(src),
+        vec![(TS1518, at(src, r"\p{Basic_Emoji}"))]
+    );
+}
+
+#[test]
+fn negated_class_accepts_an_ordinary_single_character_property() {
+    assert_eq!(
+        regex_codes(r"const a = /[^\p{Letter}]/v;"),
+        Vec::<u32>::new()
+    );
+}
+
+#[test]
+fn complemented_property_of_strings_is_rejected_outside_a_negated_class() {
+    // `\P` over a set of strings is not defined at all, so the class need not
+    // be negated — and tsc anchors this one on the property NAME.
+    let src = r"const a = /[\P{RGI_Emoji}]/v;";
+    assert_eq!(regex_codes_at(src), vec![(TS1518, at(src, "RGI_Emoji"))]);
+}
+
+#[test]
+fn complemented_property_of_strings_inside_a_negated_class_reports_once() {
+    // Both the `\P` rule and the negated-class rule could speak here; tsc
+    // emits exactly one, on the property name.
+    let src = r"const a = /[^\P{RGI_Emoji}]/v;";
+    assert_eq!(regex_codes_at(src), vec![(TS1518, at(src, "RGI_Emoji"))]);
+}
+
+#[test]
+fn complemented_ordinary_property_is_accepted() {
+    assert_eq!(
+        regex_codes(r"const a = /[^\P{Letter}]/v;"),
+        Vec::<u32>::new()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Nesting
+
+#[test]
+fn negated_class_rejects_a_nested_class_that_may_contain_strings() {
+    // Reported on the nested class's `[`, which is the outer class's operand.
+    let src = r"const a = /[^[\q{ab}]]/v;";
+    assert_eq!(regex_codes_at(src), vec![(TS1518, at(src, r"[\q{ab}]]"))]);
+}
+
+#[test]
+fn a_negated_nested_class_reports_for_itself() {
+    let src = r"const a = /[[^\q{ab}]]/v;";
+    assert_eq!(regex_codes_at(src), vec![(TS1518, at(src, r"\q{ab}"))]);
+}
+
+#[test]
+fn negated_class_accepts_a_nested_class_of_single_characters() {
+    assert_eq!(regex_codes(r"const a = /[^[ab]]/v;"), Vec::<u32>::new());
+}
+
+// ---------------------------------------------------------------------------
+// Class-set operators
+
+#[test]
+fn subtraction_takes_its_first_operand_answer() {
+    let src = r"const a = /[^\p{RGI_Emoji}--\q{a}]/v;";
+    assert_eq!(
+        regex_codes_at(src),
+        vec![(TS1518, at(src, r"\p{RGI_Emoji}"))]
+    );
+}
+
+#[test]
+fn intersection_is_rejected_only_when_every_operand_may_contain_strings() {
+    let src = r"const a = /[^\q{ab}&&\q{cd}]/v;";
+    assert_eq!(regex_codes_at(src), vec![(TS1518, at(src, r"\q{ab}"))]);
+}
+
+#[test]
+fn intersection_with_a_single_character_operand_is_accepted() {
+    // `\q{ab} && \q{a}` cannot contain a string, so the complement is defined.
+    // Both orders are clean, which is what distinguishes a real intersection
+    // rule from the union's first-operand-only behaviour.
+    assert_eq!(
+        regex_codes(r"const a = /[^\q{ab}&&\q{a}]/v;"),
+        Vec::<u32>::new()
+    );
+    assert_eq!(
+        regex_codes(r"const a = /[^\q{a}&&\q{ab}]/v;"),
+        Vec::<u32>::new()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Deliberate tsc-bug parity: a union consults only its first operand.
+// See the module header. These rows pin tsc's behaviour, not the spec's.
+
+#[test]
+fn union_only_consults_the_first_operand_matching_tsc_string_disjunction() {
+    let reported = r"const a = /[^\q{xy}b]/v;";
+    assert_eq!(
+        regex_codes_at(reported),
+        vec![(TS1518, at(reported, r"\q{xy}"))]
+    );
+
+    // Same set, operands swapped — tsc misses it, so tsz must too.
+    assert_eq!(regex_codes(r"const a = /[^b\q{xy}]/v;"), Vec::<u32>::new());
+    assert_eq!(
+        regex_codes(r"const a = /[^a-z\q{xy}]/v;"),
+        Vec::<u32>::new()
+    );
+}
+
+#[test]
+fn union_only_consults_the_first_operand_matching_tsc_property_of_strings() {
+    let reported = r"const a = /[^\p{RGI_Emoji}a]/v;";
+    assert_eq!(
+        regex_codes_at(reported),
+        vec![(TS1518, at(reported, r"\p{RGI_Emoji}"))]
+    );
+
+    assert_eq!(
+        regex_codes(r"const a = /[^a\p{RGI_Emoji}]/v;"),
+        Vec::<u32>::new()
+    );
+}
+
+#[test]
+fn a_range_upper_bound_is_not_a_class_operand() {
+    // The first operand is `\q{xy}`, so the class is reported for that and
+    // the trailing range does not add a second report.
+    let src = r"const a = /[^\q{xy}a-z]/v;";
+    assert_eq!(regex_codes_at(src), vec![(TS1518, at(src, r"\q{xy}"))]);
+}
+
+// ---------------------------------------------------------------------------
+// Flag gating: TS1518 is a `v`-mode rule, and the `u`-mode siblings still own
+// their own shapes.
+
+#[test]
+fn under_u_a_property_of_strings_keeps_its_own_diagnostic() {
+    // TS1528, not TS1518: without `v` the property is unavailable at all.
+    let src = r"const a = /[^\p{RGI_Emoji}]/u;";
+    assert_eq!(
+        regex_codes_at(src),
+        vec![(
+            diagnostic_codes::ANY_UNICODE_PROPERTY_THAT_WOULD_POSSIBLY_MATCH_MORE_THAN_A_SINGLE_CHARACTER_IS_O,
+            at(src, "RGI_Emoji")
+        )]
+    );
+}
+
+#[test]
+fn under_u_a_string_disjunction_keeps_its_own_diagnostic() {
+    // TS1535: `\q` is not grammar without `v`, so it is judged as an
+    // ordinary un-escapable character instead.
+    assert_eq!(
+        regex_codes(r"const a = /[^\q{ab}]/u;"),
+        vec![diagnostic_codes::THIS_CHARACTER_CANNOT_BE_ESCAPED_IN_A_REGULAR_EXPRESSION]
+    );
+}


### PR DESCRIPTION
**Structural rule.** When a character class is negated under the Unicode Sets (`v`) flag and one of its operands denotes a set containing anything other than exactly one character, `tsc` reports **TS1518** — a complement is only defined over single characters. `tsz` now does the same through the **parser's** regex-literal scanner (`state_expressions_literals_regex.rs`), which is where the rest of the `v`-mode class-set grammar already lives (TS1517/TS1519/TS1522/TS1528/TS1535).

`tsz` reported **nothing** for this entire family before this change — all 13 error rows below were silently clean.

Two constructs produce a strings-valued operand under `v`:

- `\q{...}` when any `|`-separated alternative is not exactly one code point — including the empty alternative of `\q{}`, which matches the empty string;
- `\p{...}` naming one of the seven binary **properties of strings**, which `BINARY_UNICODE_PROPERTIES_OF_STRINGS` already enumerates for TS1528. No new table.

`\P{...}` over such a property is rejected outright — in or out of a negated class — because complementing a set of strings is undefined. `tsc` anchors that one on the property **name** rather than the escape, and emits exactly one diagnostic even when the enclosing class is *also* negated.

The unwired-code enumeration in #16291 listed TS1518 under "misc"; the previous author of the TS1528 arm had already left a marker comment naming it as "a separate, unwired diagnostic". That comment is now the implementation.

### Owner layer

Parser. The scanner threads a may-contain-strings answer out of `scan_character_class_escape` and returns it from `scan_class_ranges`, so a nested class reports through the operand that encloses it. Nothing is matched on rendered output or on user-chosen spellings: the property decision is the existing table lookup, and the `\q{}` decision counts code points (an escape contributes exactly one, so `\q{\u{1F600}}` is correctly a single character and not ten source bytes).

### This PR deliberately reproduces a `tsc` bug

In a **union**, `tsc` consults only the class's **first** operand:

| pattern | `tsc` | note |
|---|---|---|
| `/[^\q{xy}b]/v` | TS1518 | strings operand first |
| `/[^b\q{xy}]/v` | *clean* | same set, operands swapped |
| `/[^\p{RGI_Emoji}a]/v` | TS1518 | |
| `/[^a\p{RGI_Emoji}]/v` | *clean* | same set, operands swapped |

The ECMAScript grammar makes `MayContainStrings` of a `ClassUnion` true when **any** operand may contain strings, so the clean rows are an upstream miss, not intended behaviour. Per the repo's bug discipline I did **not** patch away from parity: the miss is matched deliberately and pinned by two tests named `union_only_consults_the_first_operand_matching_tsc_*`, so a future change that "fixes" it toward the spec fails loudly instead of silently diverging from `tsc`. Filed with full evidence as **#16351** (`TypeScript bug` label).

**Intersection is not subject to that miss and is spec-exact in `tsc`** — `A&&B` may contain strings only when *every* operand does — so it is implemented correctly (ANDed across operands) rather than by the first-operand shortcut. That distinction is what forced the report to be deferred to the end of the class and anchored back to the first operand's start, which is where `tsc` points for every shape.

### Adjacent-case matrix

30 rows, every one pinned byte-identical to `typescript@7.0.2` — the version `scripts/conformance/typescript-versions.json` `current` (`4d4f005c…`) actually maps to — comparing **code and column**, not just code.

| group | rows | covered |
|---|---|---|
| `\q{...}` | 7 | multi-char alternative, single-char alternative, mixed disjunction `\q{ab\|c}`, all-single disjunction `\q{a\|b}`, empty `\q{}`, escaped single code point `\q{\u{1F600}}`, non-negated class |
| properties of strings | 6 | `RGI_Emoji`, `Basic_Emoji` (second name — table lookup, not a one-witness spelling match), ordinary `\p{Letter}`, `\P` outside a negated class, `\P` inside one (reports once), `\P{Letter}` |
| nesting | 3 | outer negated over nested strings class, inner-negated nested class reporting for itself, nested class of single chars |
| class-set operators | 4 | subtraction, intersection with both operands stringy, intersection with one single-char operand in **both** orders |
| `tsc` union bug | 5 | both members of each swapped pair, plus a range upper bound proving it is not an operand |
| flag gating | 2 | under `u` the same shapes keep TS1528 / TS1535, so TS1518 stays a `v`-mode rule |

### Not in scope

The remaining genuinely-unwired code in the regex cluster is **TS1513** (`Undetermined character escape.`). See the NOTE on #15994 — most of #16291's regex list is already wired and its enumeration is stale.

## Goal
Goal: hold

## Verification

All run locally at `5afaff1` (cold cloud container; debug build).

- **Oracle differential, 30 rows, code + column:** `tsz` vs `node typescript@7.0.2/bin/tsc --noEmit --strict --target es2024 --lib es2024`.
  - **before:** 13 of 30 rows diverge — `tsc` reports TS1518, `tsz` reports nothing.
  - **after:** **30/30 byte-identical, 0 diverging.**
- `cargo test -p tsz-parser --lib` — **1754 passed, 0 failed** (was 1731 before; +23 new tests). No pre-existing failures in this crate to disentangle.
- `cargo clippy --workspace --exclude tsz-conformance --all-targets -- -D warnings` — clean (CI's exact invocation). This required two real cleanups rather than an allow: the two `too_many_arguments` hits were resolved by bundling the three property-scan mode bits into `PropertyExpressionMode` and by deleting a `_start_pos` parameter and the `RegexScanContext::start_pos` field it was the last reader of.
- `cargo fmt --all` applied.

**Owed, not run here:** `scripts/conformance/compare-to-parent.sh`, `./scripts/emit/run.sh`, fourslash. This container has no TypeScript corpus and no release build. The risk is low and bounded: the diff only adds diagnostics inside `v`-flag regex literals and changes no types, no emit path, and no shared predicate — the one behaviour change outside a `[^...]` class under `v` is the `\P{property-of-strings}` rejection. `--lib` was clean and the whole change is additive to a scanner the emitter does not consult.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Travertine