### PR TITLE
fix(cli): TS1091/TS1188 for...in/for...of grammar codes suppress correctly

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -429,6 +429,17 @@ fn is_hard_keyword_interface_name_2427_parse_diagnostic(diagnostic: &ParseDiagno
 /// TS1436, were oracle-tested and rejected: tsc keeps both alongside an
 /// unrelated syntax error in the same file, so they are real parser
 /// diagnostics in tsc too and must NOT be added here.
+///
+/// #16279 audit round 2: tsc's `checkGrammarForInOrForOfStatement` reports
+/// TS1091 (`for...in`) and TS1188 (`for...of`) — "only a single variable
+/// declaration is allowed" — for a multi-declarator loop head. Both are
+/// parser-emitted in tsz (`state_declarations_exports.rs`) and were entirely
+/// absent from this list, so neither was ever suppressed alongside a real
+/// syntax error the way tsc suppresses both (oracle-confirmed against
+/// `typescript@7.0.2`: a `let a: = 1;` syntax error elsewhere in the file
+/// drops the TS1091/TS1188 that would otherwise fire), and each counted as a
+/// "real" parse error that could silently delete an unrelated listed
+/// sibling from the same file.
 const fn is_parser_grammar_code(code: u32) -> bool {
     matches!(
         code,
@@ -463,6 +474,7 @@ const fn is_parser_grammar_code(code: u32) -> bool {
         | 1079 // A '{0}' modifier cannot be used with an import declaration
         | 1089 // '{0}' modifier cannot appear on a constructor declaration
         | 1090 // '{0}' modifier cannot appear on a parameter
+        | 1091 // Only a single variable declaration is allowed in a 'for...in' statement
         | 1092 // Type parameters cannot appear on a constructor declaration
         | 1093 // Type annotation cannot appear on a constructor declaration
         | 1094 // An accessor cannot have type parameters
@@ -485,6 +497,7 @@ const fn is_parser_grammar_code(code: u32) -> bool {
         | 1176 // Interface declaration cannot have an implements clause
         | 1182 // A destructuring declaration must have an initializer
         | 1184 // Modifiers cannot appear here
+        | 1188 // Only a single variable declaration is allowed in a 'for...of' statement
         | 1191 // An import declaration cannot have modifiers
         | 1193 // An export declaration cannot have modifiers
         | 1197 // Catch clause variable cannot have an initializer
@@ -1602,3 +1615,7 @@ mod rest_parameter_grammar_tests;
 #[cfg(test)]
 #[path = "check_utils/regex_grammar_suppression_tests.rs"]
 mod regex_grammar_suppression_tests;
+
+#[cfg(test)]
+#[path = "check_utils/for_in_of_single_declaration_grammar_tests.rs"]
+mod for_in_of_single_declaration_grammar_tests;

--- a/crates/tsz-cli/src/driver/check_utils/for_in_of_single_declaration_grammar_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/for_in_of_single_declaration_grammar_tests.rs
@@ -1,0 +1,180 @@
+//! Unit tests for the `for...in`/`for...of` slice of `is_parser_grammar_code`
+//! (#16279's general shape). Split into its own file rather than growing
+//! `tests.rs` past the 2000-line limit (already over before this change).
+//!
+//! tsc's `checkGrammarForInOrForOfStatement` reports TS1091 ("Only a single
+//! variable declaration is allowed in a 'for...in' statement.") and TS1188
+//! (the `for...of` sibling) for a multi-declarator loop head, both
+//! parser-emitted in tsz
+//! (`crates/tsz-parser/src/parser/state_declarations_exports.rs`). Before
+//! this fix, neither code was listed in `is_parser_grammar_code` at all, so
+//! each counted as a "real" non-grammar parse error and could silently
+//! delete an unrelated listed sibling from the same file, while also never
+//! being suppressed itself alongside a genuine syntax error — where tsc
+//! oracle-confirmed (`typescript@7.0.2`) suppresses both TS1091 and TS1188
+//! when the file has an unrelated real syntax error (e.g. `let a: = 1;`).
+
+use super::*;
+
+#[test]
+fn filtered_parse_diagnostics_suppresses_ts1091_when_real_parse_error_present() {
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 16,
+            length: 1,
+            message: "Only a single variable declaration is allowed in a 'for...in' statement."
+                .to_string(),
+            code: 1091,
+        },
+        ParseDiagnostic {
+            start: 60,
+            length: 1,
+            message: "Type expected.".to_string(),
+            code: 1110,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&1091),
+        "TS1091 should be suppressed when a real parse error (TS1110) is present, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1110),
+        "TS1110 (real parse error) should survive, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_suppresses_ts1188_when_real_parse_error_present() {
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 16,
+            length: 1,
+            message: "Only a single variable declaration is allowed in a 'for...of' statement."
+                .to_string(),
+            code: 1188,
+        },
+        ParseDiagnostic {
+            start: 60,
+            length: 1,
+            message: "Type expected.".to_string(),
+            code: 1110,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&1188),
+        "TS1188 should be suppressed when a real parse error (TS1110) is present, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1110),
+        "TS1110 (real parse error) should survive, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_keeps_ts1091_ts1188_when_alone() {
+    use tsz::parser::ParseDiagnostic;
+
+    for (code, message) in [
+        (
+            1091,
+            "Only a single variable declaration is allowed in a 'for...in' statement.",
+        ),
+        (
+            1188,
+            "Only a single variable declaration is allowed in a 'for...of' statement.",
+        ),
+    ] {
+        let diagnostics = vec![ParseDiagnostic {
+            start: 16,
+            length: 1,
+            message: message.to_string(),
+            code,
+        }];
+
+        let filtered = filtered_parse_diagnostics(&diagnostics, false);
+        let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+        assert!(
+            codes.contains(&code),
+            "TS{code} should be kept when it is the only diagnostic, got: {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn filtered_parse_diagnostics_ts1091_does_not_self_suppress_listed_sibling() {
+    use tsz::parser::ParseDiagnostic;
+
+    // Before the fix, TS1091 was unlisted in `is_parser_grammar_code`, so it
+    // counted as a "real" non-grammar parse error under
+    // `has_non_grammar_parse_error` and silently deleted every *listed*
+    // sibling in the same file — here, the already-listed TS1191 from an
+    // unrelated import declaration.
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 0,
+            length: 6,
+            message: "An import declaration cannot have modifiers.".to_string(),
+            code: 1191,
+        },
+        ParseDiagnostic {
+            start: 60,
+            length: 1,
+            message: "Only a single variable declaration is allowed in a 'for...in' statement."
+                .to_string(),
+            code: 1091,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&1191),
+        "TS1191 must not be self-suppressed by unlisted TS1091, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1091),
+        "TS1091 should survive when it is the only non-grammar-looking diagnostic, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_ts1188_does_not_self_suppress_listed_sibling() {
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 0,
+            length: 6,
+            message: "An import declaration cannot have modifiers.".to_string(),
+            code: 1191,
+        },
+        ParseDiagnostic {
+            start: 60,
+            length: 1,
+            message: "Only a single variable declaration is allowed in a 'for...of' statement."
+                .to_string(),
+            code: 1188,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&1191),
+        "TS1191 must not be self-suppressed by unlisted TS1188, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1188),
+        "TS1188 should survive when it is the only non-grammar-looking diagnostic, got: {codes:?}"
+    );
+}


### PR DESCRIPTION
Part of #16279's general audit (the `is_parser_grammar_code` self-suppressing-set shape).

**Structural rule.** tsc's `checkGrammarForInOrForOfStatement` reports TS1091 (`Only a single variable declaration is allowed in a 'for...in' statement.`) and TS1188 (its `for...of` sibling) from the checker via `grammarErrorOnNode`, which tsc suppresses whenever the file has an unrelated real syntax error (`hasParseDiagnostics`). tsz emits both from the parser (`crates/tsz-parser/src/parser/state_declarations_exports.rs`), through `is_parser_grammar_code` (`crates/tsz-cli/src/driver/check_utils.rs`).

Both codes were entirely absent from that list — not merely partially listed. That is a variant of #16279's mechanism: `has_non_grammar_parse_error` is the list's complement, so an unlisted parser-emitted grammar code (1) is never itself suppressed alongside a real syntax error the way tsc suppresses it, and (2) counts as a "real" parse error, which can silently delete an unrelated *listed* sibling from the same file. Added both codes with a doc comment explaining the family.

## Adjacent-case matrix (oracle: `typescript@7.0.2`, `--noEmit --strict --pretty false --lib es2022 --target es2022`)

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `for (let a, b in {}) {}` alone | TS1091 | TS1091 (never suppressed, but never contaminates listed siblings either — no partial-family bug from co-occurrence) | TS1091 (same, now correctly suppressible) |
| `for (let a, b of []) {}` alone | TS1188 | TS1188 | TS1188 |
| `for (let a, b in {}) {}` + unrelated `let x: = 1;` in the same file | TS1091 dropped, only TS1110 survives | TS1091 kept (bug: never suppressed) | TS1091 dropped, matches tsc |
| `for (let a, b of []) {}` + unrelated `let x: = 1;` in the same file | TS1188 dropped, only TS1110 survives | TS1188 kept (bug) | TS1188 dropped, matches tsc |
| unlisted TS1091/TS1188 alongside an already-listed sibling (e.g. TS1191) in the same file | tsc: only TS1191 is suppression-eligible on its own family logic, unrelated to this pair | **TS1191 could be silently deleted** by the unlisted TS1091/TS1188 acting as a "real" parse error | TS1191 survives, TS1091/TS1188 correctly join the suppression set |

No identifier/alias/file-name string drives any decision here — the two codes are added to a `const fn matches!` table keyed purely on diagnostic code, exactly like every other entry in this list.

## Goal
Goal: hold

## Verification
- `cargo build -p tsz-cli --lib --tests` — clean.
- `cargo test -p tsz-cli --lib -- for_in_of_single_declaration` — **5/5** (new file, mirrors the `rest_parameter_grammar_tests.rs` pattern: suppresses-when-real-error x2, keeps-when-alone, does-not-self-suppress-listed-sibling x2).
- `cargo test -p tsz-cli --lib -- filtered_parse_diagnostics rest_parameter_grammar heritage_clause regex_grammar_suppression` — **45/45**, including the `regex_validator_diagnostic_surface_is_audited` tripwire and every sibling grammar-suppression family — no regressions.
- `cargo clippy -p tsz-cli --all-targets -- -D warnings` — clean.
- `cargo fmt -p tsz-cli -- --check` — clean.
- `python3 scripts/arch/arch_guard.py` — `Architecture guardrails passed.`
- Oracle: `typescript@7.0.2` (installed fresh via `npm i typescript@7.0.2`, matching `scripts/conformance/typescript-versions.json`'s pinned mapping), both directions of the adjacent-case matrix above confirmed manually.
- New test file (180 lines) added rather than growing `check_utils/tests.rs`, which is already at 2258 lines, over the repo's 2000-line ceiling (pre-existing debt, not introduced here).
- Not run: `compare-to-parent.sh`/emit/fourslash — this is a CLI-layer parse-diagnostic filter change with zero effect on which diagnostics are *emitted*, only on which are *displayed* when a co-occurring real syntax error exists in the same file. Risk is bounded to files containing both a multi-declarator `for-in`/`for-of` head and an unrelated real syntax error, or a listed grammar sibling — a narrow, additive intersection.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_019wrgZGQTM9UqbUjnMo9kKG)_