### PR TITLE
fix(checker): TS18057 for string-literal module export names under es2015/es2020

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1965,6 +1965,9 @@ path = "tests/global_module_export_grammar_tests.rs"
 name = "using_declaration_placement_grammar_tests"
 path = "tests/using_declaration_placement_grammar_tests.rs"
 [[test]]
+name = "string_literal_module_export_name_grammar_tests"
+path = "tests/string_literal_module_export_name_grammar_tests.rs"
+[[test]]
 name = "jsdoc_tag_boundary_tests"
 path = "tests/jsdoc_tag_boundary_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/declarations/import/declaration_check_body.rs
+++ b/crates/tsz-checker/src/declarations/import/declaration_check_body.rs
@@ -210,6 +210,11 @@ impl<'a> CheckerState<'a> {
         // Import declarations make the file a module, so it's always strict mode → TS1214.
         self.check_import_binding_reserved_words(import.import_clause);
 
+        // TS18057: string-literal import names need a module target newer than
+        // `es2015`/`es2020`. Like tsc's `checkImportDeclaration`, this only runs
+        // when the module specifier resolves.
+        self.check_import_declaration_module_export_names(stmt_idx);
+
         if import.import_clause.is_some() {
             self.check_import_declaration_conflicts(stmt_idx, import.import_clause);
         }

--- a/crates/tsz-checker/src/declarations/mod.rs
+++ b/crates/tsz-checker/src/declarations/mod.rs
@@ -5,4 +5,5 @@ pub(crate) mod declarations_module_helpers;
 pub(crate) mod dynamic_import_checker;
 pub mod import;
 pub mod module_checker;
+pub(crate) mod module_export_names;
 pub mod namespace_checker;

--- a/crates/tsz-checker/src/declarations/module_export_names.rs
+++ b/crates/tsz-checker/src/declarations/module_export_names.rs
@@ -1,0 +1,187 @@
+//! TS18057: string-literal module export names under `--module es2015`/`es2020`.
+//!
+//! ECMAScript arbitrary module namespace names (`export { x as "str name" }`)
+//! postdate the `es2015` and `es2020` module output formats, so `tsc` rejects
+//! them when `module` is set to exactly one of those two targets. Every other
+//! module target — `es2022`, `esnext`, `commonjs`, `preserve` and the `node*`
+//! family — accepts them.
+//!
+//! `tsc` centralises this in `checkModuleExportName`, which runs over every
+//! *module export name* position: the property name of an import specifier,
+//! both halves of an export specifier, and the name of a namespace export
+//! (`export * as "ns" from "m"`). It reports through `grammarErrorOnNode`, so
+//! the whole check is suppressed once the file has parse diagnostics.
+//!
+//! One asymmetry is load-bearing and oracle-confirmed. `checkImportDeclaration`
+//! only walks its specifiers when the module specifier *resolves*, while the
+//! export paths do not, so an unresolved module suppresses TS18057 on the
+//! import side but not on the export side:
+//!
+//! ```text
+//! import { "x" as y } from "./nope";   // TS2307 only
+//! export { x as "a" }  from "./nope";  // TS18057 + TS2307
+//! ```
+
+use crate::state::CheckerState;
+use tsz_common::common::ModuleKind;
+use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
+use tsz_scanner::SyntaxKind;
+
+impl<'a> CheckerState<'a> {
+    /// Shared gate: the check is module-target-specific and, like every other
+    /// check-time grammar diagnostic, is suppressed once the file has a real
+    /// parse error (`tsc`'s `grammarErrorOnNode` does the same).
+    const fn should_check_module_export_names(&self) -> bool {
+        !self.ctx.has_parse_errors
+            && matches!(
+                self.ctx.compiler_options.module,
+                ModuleKind::ES2015 | ModuleKind::ES2020
+            )
+    }
+
+    /// Report TS18057 on `name_idx` when it is written as a string literal.
+    ///
+    /// Mirrors `tsc`'s `checkModuleExportName` for the `allowStringLiteral`
+    /// case. The `!allowStringLiteral` case — a local binding that cannot be
+    /// named by a string, as in `import { "a" as "b" }` or
+    /// `export { "a" as b }` with no module specifier — is answered by the
+    /// parser as TS1003 and is mutually exclusive with this code, so it is
+    /// reached only through the `has_parse_errors` gate above.
+    fn check_module_export_name(&mut self, name_idx: NodeIndex) {
+        if name_idx.is_none() {
+            return;
+        }
+        let is_string_literal = self
+            .ctx
+            .arena
+            .get(name_idx)
+            .is_some_and(|n| n.kind == SyntaxKind::StringLiteral as u16);
+        if !is_string_literal {
+            return;
+        }
+        self.error_at_node(
+            name_idx,
+            crate::diagnostics::diagnostic_messages::STRING_LITERAL_IMPORT_AND_EXPORT_NAMES_ARE_NOT_SUPPORTED_WHEN_THE_MODULE_FLAG_IS,
+            crate::diagnostics::diagnostic_codes::STRING_LITERAL_IMPORT_AND_EXPORT_NAMES_ARE_NOT_SUPPORTED_WHEN_THE_MODULE_FLAG_IS,
+        );
+    }
+
+    /// Whether `tsc` would consider this module specifier resolved, which is
+    /// what gates `checkImportDeclaration`'s walk over its specifiers. A file
+    /// on disk and an ambient `declare module "..."` both count.
+    fn module_specifier_resolves(&self, module_specifier: NodeIndex) -> bool {
+        let Some(specifier_node) = self.ctx.arena.get(module_specifier) else {
+            return false;
+        };
+        let Some(literal) = self.ctx.arena.get_literal(specifier_node) else {
+            return false;
+        };
+        let module_name = literal.text.clone();
+        self.ctx.resolve_import_target(&module_name).is_some()
+            || self
+                .ctx
+                .declared_modules_contains(self.ctx.binder, &module_name)
+    }
+
+    /// TS18057 for the module export names introduced by an import declaration.
+    ///
+    /// Only the *property name* of an import specifier is a module export
+    /// name; the specifier's own name binds a local and must already be an
+    /// identifier.
+    pub(crate) fn check_import_declaration_module_export_names(&mut self, import_idx: NodeIndex) {
+        if !self.should_check_module_export_names() {
+            return;
+        }
+        let Some(import_node) = self.ctx.arena.get(import_idx) else {
+            return;
+        };
+        let Some(import_decl) = self.ctx.arena.get_import_decl(import_node) else {
+            return;
+        };
+        if !self.module_specifier_resolves(import_decl.module_specifier) {
+            return;
+        }
+        let Some(clause_node) = self.ctx.arena.get(import_decl.import_clause) else {
+            return;
+        };
+        let Some(clause) = self.ctx.arena.get_import_clause(clause_node) else {
+            return;
+        };
+        let Some(bindings_node) = self.ctx.arena.get(clause.named_bindings) else {
+            return;
+        };
+        if bindings_node.kind != syntax_kind_ext::NAMED_IMPORTS {
+            return;
+        }
+        let Some(named_imports) = self.ctx.arena.get_named_imports(bindings_node) else {
+            return;
+        };
+        let property_names: Vec<NodeIndex> = named_imports
+            .elements
+            .nodes
+            .iter()
+            .filter_map(|element_idx| {
+                let element_node = self.ctx.arena.get(*element_idx)?;
+                let specifier = self.ctx.arena.get_specifier(element_node)?;
+                Some(specifier.property_name)
+            })
+            .collect();
+        for property_name in property_names {
+            self.check_module_export_name(property_name);
+        }
+    }
+
+    /// TS18057 for the module export names introduced by an export declaration.
+    ///
+    /// Both halves of an export specifier are module export names — the
+    /// property name is the re-exported source name and the name is the
+    /// exported name — and either may be a string literal, so
+    /// `export { "a" as "b" } from "m"` draws two diagnostics in source order.
+    ///
+    /// tsz does not build a distinct `NAMESPACE_EXPORT` node: `parse_export_star`
+    /// stores the `export * as <name>` name directly in `export_clause`. So any
+    /// export clause that is not `NAMED_EXPORTS` is itself the namespace name.
+    pub(crate) fn check_export_declaration_module_export_names(&mut self, export_idx: NodeIndex) {
+        if !self.should_check_module_export_names() {
+            return;
+        }
+        let Some(export_node) = self.ctx.arena.get(export_idx) else {
+            return;
+        };
+        let Some(export_decl) = self.ctx.arena.get_export_decl(export_node) else {
+            return;
+        };
+        let Some(clause_node) = self.ctx.arena.get(export_decl.export_clause) else {
+            return;
+        };
+        if clause_node.kind != syntax_kind_ext::NAMED_EXPORTS {
+            // `export * as "ns" from "m"` — the clause *is* the namespace name.
+            self.check_module_export_name(export_decl.export_clause);
+            return;
+        }
+        let Some(named_exports) = self.ctx.arena.get_named_imports(clause_node) else {
+            return;
+        };
+        // `allowStringLiteral` in tsc's `checkExportSpecifier` is `!!moduleSpecifier`
+        // for the property name: without a `from` clause the property name is a
+        // *local* binding, which no string can name, so tsc answers TS1003 there
+        // and never TS18057.
+        let property_names_are_module_export_names = export_decl.module_specifier.is_some();
+        let mut names = Vec::with_capacity(named_exports.elements.nodes.len() * 2);
+        for element_idx in &named_exports.elements.nodes {
+            let Some(element_node) = self.ctx.arena.get(*element_idx) else {
+                continue;
+            };
+            let Some(specifier) = self.ctx.arena.get_specifier(element_node) else {
+                continue;
+            };
+            if property_names_are_module_export_names {
+                names.push(specifier.property_name);
+            }
+            names.push(specifier.name);
+        }
+        for name_idx in names {
+            self.check_module_export_name(name_idx);
+        }
+    }
+}

--- a/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
@@ -208,6 +208,11 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
                 }
             }
 
+            // TS18057: string-literal export names need a module target newer
+            // than `es2015`/`es2020`. Unlike the import side, tsc does not gate
+            // this on the module specifier resolving.
+            self.check_export_declaration_module_export_names(export_idx);
+
             // TS2322: Check export attribute values against global ImportAttributes interface
             self.check_import_attributes_assignability(export_decl.attributes);
 

--- a/crates/tsz-checker/tests/string_literal_module_export_name_grammar_tests.rs
+++ b/crates/tsz-checker/tests/string_literal_module_export_name_grammar_tests.rs
@@ -1,0 +1,323 @@
+//! String-literal module export names — TS18057.
+//!
+//! ECMAScript arbitrary module namespace names (`export { x as "str name" }`)
+//! postdate the `es2015` and `es2020` module output formats, so tsc rejects
+//! them when `module` is exactly one of those two and accepts them on every
+//! other module target.
+//!
+//! tsc centralises this in `checkModuleExportName`, which runs over every
+//! *module export name* position: an import specifier's property name, both
+//! halves of an export specifier, and the `export * as <name>` namespace name.
+//! It reports via `grammarErrorOnNode`, so a file with parse diagnostics
+//! suppresses it entirely.
+//!
+//! Every expectation here is pinned against the oracle (`typescript@7.0.2`,
+//! `--noEmit --strict --target es2022`), including the negatives.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+use tsz_common::common::{ModuleKind, ScriptTarget};
+
+/// TS18057.
+const STRING_LITERAL_MODULE_EXPORT_NAME: u32 = 18057;
+
+fn options_for(module: ModuleKind) -> CheckerOptions {
+    CheckerOptions {
+        module,
+        target: ScriptTarget::ES2022,
+        ..CheckerOptions::default()
+    }
+}
+
+fn check_codes_with(module: ModuleKind, source: &str) -> Vec<u32> {
+    check_source(source, "test.ts", options_for(module))
+        .into_iter()
+        .map(|diagnostic| diagnostic.code)
+        .collect()
+}
+
+fn count_18057(module: ModuleKind, source: &str) -> usize {
+    check_codes_with(module, source)
+        .into_iter()
+        .filter(|code| *code == STRING_LITERAL_MODULE_EXPORT_NAME)
+        .count()
+}
+
+/// A resolvable target for the import-side rows. tsc only walks an import
+/// declaration's specifiers when its module specifier resolves, so these tests
+/// need a module that actually exists.
+const AMBIENT_TARGET: &str = r#"
+declare module "target" {
+    export const x: number;
+}
+"#;
+
+fn with_target(source: &str) -> String {
+    format!("{AMBIENT_TARGET}{source}")
+}
+
+// ---------------------------------------------------------------------------
+// The module-target matrix — the whole point of the code
+// ---------------------------------------------------------------------------
+
+#[test]
+fn es2015_rejects_a_string_literal_export_name() {
+    let codes = check_codes_with(
+        ModuleKind::ES2015,
+        r#"export { x as "str name" } from "target";"#,
+    );
+    assert!(
+        codes.contains(&STRING_LITERAL_MODULE_EXPORT_NAME),
+        "expected TS18057 under --module es2015, got {codes:?}"
+    );
+}
+
+#[test]
+fn es2020_rejects_a_string_literal_export_name() {
+    let codes = check_codes_with(
+        ModuleKind::ES2020,
+        r#"export { x as "str name" } from "target";"#,
+    );
+    assert!(
+        codes.contains(&STRING_LITERAL_MODULE_EXPORT_NAME),
+        "expected TS18057 under --module es2020, got {codes:?}"
+    );
+}
+
+#[test]
+fn newer_and_older_module_targets_accept_a_string_literal_export_name() {
+    // es2022 and everything after it postdate the restriction; commonjs,
+    // preserve and the node family were never subject to it.
+    for module in [
+        ModuleKind::ES2022,
+        ModuleKind::ESNext,
+        ModuleKind::CommonJS,
+        ModuleKind::Preserve,
+        ModuleKind::Node16,
+        ModuleKind::Node18,
+        ModuleKind::NodeNext,
+        ModuleKind::AMD,
+        ModuleKind::UMD,
+        ModuleKind::System,
+    ] {
+        let codes = check_codes_with(module, r#"export { x as "str name" } from "target";"#);
+        assert!(
+            !codes.contains(&STRING_LITERAL_MODULE_EXPORT_NAME),
+            "TS18057 must not fire under {module:?}, got {codes:?}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Every module export name position
+// ---------------------------------------------------------------------------
+
+#[test]
+fn export_specifier_property_name_is_a_module_export_name() {
+    let codes = check_codes_with(ModuleKind::ES2015, r#"export { "x" as y } from "target";"#);
+    assert!(
+        codes.contains(&STRING_LITERAL_MODULE_EXPORT_NAME),
+        "expected TS18057 on the re-exported source name, got {codes:?}"
+    );
+}
+
+#[test]
+fn export_specifier_without_a_rename_is_a_module_export_name() {
+    assert_eq!(
+        count_18057(ModuleKind::ES2015, r#"export { "x" } from "target";"#),
+        1,
+        "`export {{ \"x\" }}` names one position, so it draws exactly one TS18057"
+    );
+}
+
+#[test]
+fn both_halves_of_an_export_specifier_are_checked() {
+    assert_eq!(
+        count_18057(
+            ModuleKind::ES2015,
+            r#"export { "x" as "y" } from "target";"#
+        ),
+        2,
+        "property name and name are both module export names"
+    );
+}
+
+#[test]
+fn a_local_export_without_a_module_specifier_still_checks_the_exported_name() {
+    // The exported side may be a string literal even with no `from` clause;
+    // only the local side must be an identifier.
+    let codes = check_codes_with(
+        ModuleKind::ES2015,
+        r#"const q = 1; export { q as "str name" };"#,
+    );
+    assert!(
+        codes.contains(&STRING_LITERAL_MODULE_EXPORT_NAME),
+        "expected TS18057 on a local export's string-literal name, got {codes:?}"
+    );
+}
+
+#[test]
+fn namespace_export_name_is_a_module_export_name() {
+    let codes = check_codes_with(ModuleKind::ES2015, r#"export * as "ns" from "target";"#);
+    assert!(
+        codes.contains(&STRING_LITERAL_MODULE_EXPORT_NAME),
+        "expected TS18057 on an `export * as \"ns\"` name, got {codes:?}"
+    );
+}
+
+#[test]
+fn an_import_from_an_unresolvable_augmentation_target_is_suppressed() {
+    // A single file that both declares `module "target"` and imports from it
+    // makes the declaration an *augmentation* of a module that does not exist,
+    // so the specifier never resolves and the import-side walk is skipped.
+    // Oracle (`--module es2015`) answers TS2664 + the module-not-found code and
+    // no TS18057; this pins that tsz agrees rather than over-reporting.
+    let codes = check_codes_with(
+        ModuleKind::ES2015,
+        &with_target(r#"import { "x" as y } from "target"; y;"#),
+    );
+    assert!(
+        !codes.contains(&STRING_LITERAL_MODULE_EXPORT_NAME),
+        "an augmentation of a missing module does not resolve, so TS18057 must not fire, got {codes:?}"
+    );
+}
+
+#[test]
+fn a_type_only_specifier_is_still_a_module_export_name() {
+    assert_eq!(
+        count_18057(
+            ModuleKind::ES2015,
+            r#"export { x as "a", type T as "b" } from "target";"#
+        ),
+        2,
+        "the `type` modifier does not exempt a specifier from the check"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negatives — identifier names are always fine
+// ---------------------------------------------------------------------------
+
+#[test]
+fn identifier_names_never_draw_the_diagnostic() {
+    for source in [
+        r#"export { x as y } from "target";"#,
+        r#"export { x } from "target";"#,
+        r#"export * as ns from "target";"#,
+        r#"export * from "target";"#,
+        r#"const q = 1; export { q as r };"#,
+    ] {
+        let codes = check_codes_with(ModuleKind::ES2015, source);
+        assert!(
+            !codes.contains(&STRING_LITERAL_MODULE_EXPORT_NAME),
+            "TS18057 must not fire for {source:?}, got {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn a_local_export_property_name_is_not_a_module_export_name() {
+    // Without a `from` clause the property name names a *local* binding, which
+    // no string can name. tsc's `allowStringLiteral` is false there, so it
+    // answers TS1003 and never TS18057.
+    let codes = check_codes_with(ModuleKind::ES2015, r#"const q = 1; export { "q" as y };"#);
+    assert!(
+        !codes.contains(&STRING_LITERAL_MODULE_EXPORT_NAME),
+        "a local export's property name is not a module export name, got {codes:?}"
+    );
+}
+
+#[test]
+fn a_module_declaration_name_is_not_a_module_export_name() {
+    let codes = check_codes_with(ModuleKind::ES2015, r#"declare module "m2" { }"#);
+    assert!(
+        !codes.contains(&STRING_LITERAL_MODULE_EXPORT_NAME),
+        "a module declaration's own name is not a module export name, got {codes:?}"
+    );
+}
+
+#[test]
+fn a_module_specifier_is_not_a_module_export_name() {
+    // The `from "target"` string is a module specifier, not an export name.
+    let codes = check_codes_with(ModuleKind::ES2015, r#"export { x as y } from "target";"#);
+    assert!(
+        !codes.contains(&STRING_LITERAL_MODULE_EXPORT_NAME),
+        "the module specifier must not be treated as an export name, got {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The import/export asymmetry on an unresolved module — oracle-confirmed
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_unresolved_module_suppresses_the_import_side() {
+    // tsc's `checkImportDeclaration` only walks its specifiers when the module
+    // specifier resolves, so this answers the module-not-found code alone.
+    let codes = check_codes_with(
+        ModuleKind::ES2015,
+        r#"import { "x" as y } from "./nope"; y;"#,
+    );
+    assert!(
+        !codes.contains(&STRING_LITERAL_MODULE_EXPORT_NAME),
+        "TS18057 must not fire on an import from an unresolved module, got {codes:?}"
+    );
+}
+
+#[test]
+fn an_unresolved_module_does_not_suppress_the_export_side() {
+    // The export paths have no such gate.
+    let codes = check_codes_with(ModuleKind::ES2015, r#"export { x as "a" } from "./nope";"#);
+    assert!(
+        codes.contains(&STRING_LITERAL_MODULE_EXPORT_NAME),
+        "TS18057 must still fire on an export from an unresolved module, got {codes:?}"
+    );
+}
+
+#[test]
+fn an_unresolved_module_does_not_suppress_a_namespace_export() {
+    let codes = check_codes_with(ModuleKind::ES2015, r#"export * as "ns" from "./nope";"#);
+    assert!(
+        codes.contains(&STRING_LITERAL_MODULE_EXPORT_NAME),
+        "TS18057 must still fire on `export * as \"ns\"` from an unresolved module, got {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Grammar-diagnostic suppression — tsc's `grammarErrorOnNode` gate
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_parse_error_suppresses_the_diagnostic() {
+    // `import { "x" as "y" }` names a local binding with a string literal,
+    // which is a parse error (TS1003). tsc reports that alone.
+    let codes = check_codes_with(
+        ModuleKind::ES2015,
+        &with_target(r#"import { "x" as "y" } from "target";"#),
+    );
+    assert!(
+        !codes.contains(&STRING_LITERAL_MODULE_EXPORT_NAME),
+        "a file with parse diagnostics suppresses this grammar check, got {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Binder-name independence — the rule is structural, not name-driven
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_check_does_not_depend_on_the_names_involved() {
+    for (local, exported) in [
+        ("x", "str name"),
+        ("someOtherBinder", "a-b-c"),
+        ("Zzz", "default"),
+        ("q", ""),
+    ] {
+        let source = format!(r#"export {{ {local} as "{exported}" }} from "target";"#);
+        let codes = check_codes_with(ModuleKind::ES2015, &source);
+        assert!(
+            codes.contains(&STRING_LITERAL_MODULE_EXPORT_NAME),
+            "TS18057 must fire regardless of the names in {source:?}, got {codes:?}"
+        );
+    }
+}


### PR DESCRIPTION
Arbitrary module namespace names (`export { x as "str name" }`) postdate the `es2015` and `es2020` module output formats, so `tsc` rejects them on exactly those two module targets. **tsz had zero emit sites for TS18057** — every such name type-checked completely clean.

**Structural rule.** When a *module export name* is written as a string literal and `module` is exactly `es2015` or `es2020`, tsc reports TS18057 at that literal; tsz does so through the checker (`declarations/module_export_names.rs`), the layer that already owns import/export declaration grammar.

The wrong semantic operation was **diagnostic display / grammar checking on module element declarations** — not resolution. All four module-export-name positions tsc's `checkModuleExportName` covers are now wired:

| position | witness |
| --- | --- |
| import specifier property name | `import { "x" as y } from "./m"` |
| export specifier property name | `export { "x" as y } from "./m"` |
| export specifier name | `export { x as "a" } from "./m"` |
| namespace export name | `export * as "ns" from "./m"` |

### Two asymmetries that are load-bearing, and both oracle-pinned

1. **Unresolved module suppresses the import side only.** tsc's `checkImportDeclaration` walks its specifiers only when the module specifier resolves; the export paths have no such gate.
   ```ts
   import { "x" as y } from "./nope";   // TS2307 only
   export { x as "a" }  from "./nope";  // TS18057 + TS2307
   ```
2. **`allowStringLiteral` is `!!moduleSpecifier` for an export specifier's property name.** Without a `from` clause the property name binds a *local*, which no string can name, so tsc answers TS1003 there and never TS18057. My first cut got this wrong and the oracle matrix caught it — `const q = 1; export { "q" as y }` was the single failing row out of 27.

Like every check-time grammar diagnostic, the whole check sits behind the `has_parse_errors` gate, matching tsc's `grammarErrorOnNode` (so `import { "x" as "y" }` answers TS1003 alone). It is checker-emitted, so it is deliberately **not** added to `is_parser_grammar_code`.

No identifier, alias, property or file-name string drives any decision here; the only inputs are node kind, module target, and resolution state. A dedicated test varies the binder names and the exported strings to pin that.

## Goal
Goal: hold

## Verification

**Oracle matrix — 30/30 byte-identical to `typescript@7.0.2`, positions included.** Direct `tsz` vs `tsc` diff on the same two-file program, comparing the exact `case.ts(line,col): error TS18057` set:

- Module targets on `export { x as "str name" } from "./m"` — fires on `es2015`, `es2020`; silent on `es2022`, `esnext`, `commonjs`, `preserve`, `node18`, `amd`, `umd`, `system`. (10/10)
- Shapes under `es2015` (20/20), including counts: `export { "x" as "y" }` → 2, `export { x as "a", type T as "b" }` → 2, `export { "x" }` → 1, `export * as ns` → 0, and both unresolved-module asymmetry rows above. Type-only forms (`export type { x as "a" }`, `import type { "x" as y }`) fire like their value siblings.

**Before/after on the primary witness** (`--module es2015`):
```
before:  (clean — no diagnostic at all)
after:   use.ts(1,10): error TS18057: String literal import and export names are not
         supported when the '--module' flag is set to 'es2015' or 'es2020'.
```

**Suites run locally:**
- `cargo test -p tsz-checker --test string_literal_module_export_name_grammar_tests` — **19 passed / 0 failed** (new suite).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt` — clean.

**Owed, and disclosed rather than skipped:** `scripts/conformance/compare-to-parent.sh` has not completed. This container was restarted mid-session and a cold `.target/dist-fast` double build does not fit the remaining window. The risk is bounded: the new code is additive, cannot fire unless `module` is exactly `ES2015`/`ES2020` **and** a name node is a `StringLiteral`, and the default corpus module target is neither. The conformance baseline carries a matching row that should flip to passing:
```
FAIL .../arbitraryModuleNamespaceIdentifiers/arbitraryModuleNamespaceIdentifiers_module.ts
     expected:[TS2307,TS18057] actual:[TS2307]
```

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Cinnabar

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZ9nvLbjHCTnv1HEuweDCN)_