### PR TITLE
fix(config): TS18002 for an explicit empty `files` list in tsconfig

### DIFF
--- a/crates/tsz-core/src/config/mod.rs
+++ b/crates/tsz-core/src/config/mod.rs
@@ -1456,6 +1456,7 @@ fn load_tsconfig_inner_with_diagnostics(
     }
 
     let extends = parsed.config.extends.take();
+    let has_own_extends = extends.is_some();
     if let Some(extends_value) = extends {
         let extends_paths = match extends_value {
             ExtendsValue::Single(s) => vec![s],
@@ -1584,6 +1585,38 @@ fn load_tsconfig_inner_with_diagnostics(
         }
         // The flush happens in the public load wrappers so the CLI driver's
         // deferred path can retract CLI-overridden notices first.
+
+        // tsc's `getConfigFileSpecs` (`commandLineParser.ts`): an explicit
+        // `"files": []` is only diagnosed on the entry config itself (never
+        // on a base pulled in through `extends` — see below), and only when
+        // there is no other way the entry could name its own inputs: no
+        // `extends` (which could otherwise supply `files` from a base) and
+        // no non-empty `references` (a solution-style root that legitimately
+        // has an empty `files`). This is independent of `include`/`exclude`:
+        // tsc reports it even when `include` would find real sources.
+        if !has_own_extends
+            && parsed
+                .config
+                .references
+                .as_ref()
+                .is_none_or(|r| r.is_empty())
+            && let Some(files) = parsed.config.files.as_ref()
+            && files.is_empty()
+        {
+            let value_start = find_top_level_value_offset_in_source(&source, "files");
+            let value_len = estimate_json_value_len(&serde_json::Value::Array(Vec::new()));
+            let message = format_message(
+                diagnostic_messages::THE_FILES_LIST_IN_CONFIG_FILE_IS_EMPTY,
+                &[&file_display],
+            );
+            parsed.diagnostics.push(Diagnostic::error(
+                &file_display,
+                value_start,
+                value_len,
+                message,
+                diagnostic_codes::THE_FILES_LIST_IN_CONFIG_FILE_IS_EMPTY,
+            ));
+        }
     }
 
     visited.remove(&canonical);

--- a/crates/tsz-core/src/config/tests/files_list_empty.rs
+++ b/crates/tsz-core/src/config/tests/files_list_empty.rs
@@ -1,0 +1,204 @@
+//! TS18002 (`The 'files' list in config file '{0}' is empty.`) — the entry
+//! config's own `"files": []` diagnostic from `commandLineParser.ts`'s
+//! `getConfigFileSpecs`, distinct from the CLI-driver-owned TS18003 ("no
+//! inputs were found") which reacts to file-discovery results instead of the
+//! raw JSON shape.
+//!
+//! Split from `config/mod.rs` to keep each file under the 2000-line limit
+//! (§19; ratchet tracked by #8280).
+
+use super::super::*;
+use tempfile::tempdir;
+
+fn write_tsconfig(dir: &std::path::Path, name: &str, contents: &str) -> std::path::PathBuf {
+    let path = dir.join(name);
+    std::fs::write(&path, contents).expect("write tsconfig");
+    path
+}
+
+#[test]
+fn empty_files_alone_reports_ts18002() {
+    let temp = tempdir().expect("create temp dir");
+    let path = write_tsconfig(temp.path(), "tsconfig.json", r#"{"files": []}"#);
+
+    let parsed = load_tsconfig_with_diagnostics(&path).expect("load config");
+    assert!(
+        parsed.diagnostics.iter().any(|d| d.code == 18002),
+        "expected TS18002 for bare empty files list, got: {:?}",
+        parsed
+            .diagnostics
+            .iter()
+            .map(|d| d.code)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn empty_files_alongside_include_still_reports_ts18002() {
+    // tsc's check is purely on the raw `files` shape; it does not consult
+    // `include`, even though `include` here would find real sources.
+    let temp = tempdir().expect("create temp dir");
+    std::fs::write(temp.path().join("a.ts"), "export const a = 1;").expect("write a.ts");
+    let path = write_tsconfig(
+        temp.path(),
+        "tsconfig.json",
+        r#"{"files": [], "include": ["*.ts"]}"#,
+    );
+
+    let parsed = load_tsconfig_with_diagnostics(&path).expect("load config");
+    assert!(
+        parsed.diagnostics.iter().any(|d| d.code == 18002),
+        "expected TS18002 even with a satisfying include, got: {:?}",
+        parsed
+            .diagnostics
+            .iter()
+            .map(|d| d.code)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn empty_files_with_nonempty_references_does_not_report_ts18002() {
+    let temp = tempdir().expect("create temp dir");
+    std::fs::create_dir(temp.path().join("other")).expect("mkdir other");
+    write_tsconfig(
+        &temp.path().join("other"),
+        "tsconfig.json",
+        r#"{"files": ["b.ts"]}"#,
+    );
+    std::fs::write(
+        temp.path().join("other").join("b.ts"),
+        "export const b = 1;",
+    )
+    .expect("write b.ts");
+    let path = write_tsconfig(
+        temp.path(),
+        "tsconfig.json",
+        r#"{"files": [], "references": [{"path": "./other"}]}"#,
+    );
+
+    let parsed = load_tsconfig_with_diagnostics(&path).expect("load config");
+    assert!(
+        !parsed.diagnostics.iter().any(|d| d.code == 18002),
+        "a solution-style root with non-empty references must not report TS18002, got: {:?}",
+        parsed
+            .diagnostics
+            .iter()
+            .map(|d| d.code)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn empty_files_with_empty_references_still_reports_ts18002() {
+    // `references: []` is the same as omitting it entirely for this check
+    // (tsc: `referencesOfRaw === "no-prop" || referencesOfRaw.length === 0`).
+    let temp = tempdir().expect("create temp dir");
+    let path = write_tsconfig(
+        temp.path(),
+        "tsconfig.json",
+        r#"{"files": [], "references": []}"#,
+    );
+
+    let parsed = load_tsconfig_with_diagnostics(&path).expect("load config");
+    assert!(
+        parsed.diagnostics.iter().any(|d| d.code == 18002),
+        "expected TS18002 when references is an explicit empty array, got: {:?}",
+        parsed
+            .diagnostics
+            .iter()
+            .map(|d| d.code)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn empty_files_with_extends_does_not_report_ts18002() {
+    // The entry has its own `extends`, so tsc treats `files` as potentially
+    // completed by the base and never reports TS18002 here — independent of
+    // whether the base actually supplies any files.
+    let temp = tempdir().expect("create temp dir");
+    write_tsconfig(
+        temp.path(),
+        "base.json",
+        r#"{"compilerOptions": {"strict": true}}"#,
+    );
+    let path = write_tsconfig(
+        temp.path(),
+        "tsconfig.json",
+        r#"{"extends": "./base.json", "files": []}"#,
+    );
+
+    let parsed = load_tsconfig_with_diagnostics(&path).expect("load config");
+    assert!(
+        !parsed.diagnostics.iter().any(|d| d.code == 18002),
+        "an entry with its own extends must not report TS18002, got: {:?}",
+        parsed
+            .diagnostics
+            .iter()
+            .map(|d| d.code)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn nonempty_files_does_not_report_ts18002() {
+    let temp = tempdir().expect("create temp dir");
+    std::fs::write(temp.path().join("a.ts"), "export const a = 1;").expect("write a.ts");
+    let path = write_tsconfig(temp.path(), "tsconfig.json", r#"{"files": ["a.ts"]}"#);
+
+    let parsed = load_tsconfig_with_diagnostics(&path).expect("load config");
+    assert!(
+        !parsed.diagnostics.iter().any(|d| d.code == 18002),
+        "a non-empty files list must not report TS18002, got: {:?}",
+        parsed
+            .diagnostics
+            .iter()
+            .map(|d| d.code)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn absent_files_does_not_report_ts18002() {
+    let temp = tempdir().expect("create temp dir");
+    std::fs::write(temp.path().join("a.ts"), "export const a = 1;").expect("write a.ts");
+    let path = write_tsconfig(temp.path(), "tsconfig.json", r#"{}"#);
+
+    let parsed = load_tsconfig_with_diagnostics(&path).expect("load config");
+    assert!(
+        !parsed.diagnostics.iter().any(|d| d.code == 18002),
+        "an absent files key (undefined filesSpecs) must not report TS18002, got: {:?}",
+        parsed
+            .diagnostics
+            .iter()
+            .map(|d| d.code)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn empty_files_inherited_from_extends_base_when_entry_omits_files_does_not_report_ts18002() {
+    // Entry omits `files` itself (so the check would look at the inherited,
+    // empty value from the base) but the entry's own `extends` presence
+    // alone already suppresses TS18002 — this must not regress into firing
+    // once inheritance is taken into account.
+    let temp = tempdir().expect("create temp dir");
+    write_tsconfig(temp.path(), "base.json", r#"{"files": []}"#);
+    let path = write_tsconfig(
+        temp.path(),
+        "tsconfig.json",
+        r#"{"extends": "./base.json"}"#,
+    );
+
+    let parsed = load_tsconfig_with_diagnostics(&path).expect("load config");
+    assert!(
+        !parsed.diagnostics.iter().any(|d| d.code == 18002),
+        "TS18002 is entry-only per tsc, even when the base's own files is empty, got: {:?}",
+        parsed
+            .diagnostics
+            .iter()
+            .map(|d| d.code)
+            .collect::<Vec<_>>()
+    );
+}

--- a/crates/tsz-core/src/config/tests/mod.rs
+++ b/crates/tsz-core/src/config/tests/mod.rs
@@ -4,6 +4,7 @@
 //! under the 2000-line limit (§19; ratchet tracked by #8280). This module
 //! contains no test logic itself; it only wires up the shards.
 
+mod files_list_empty;
 mod module_resolution;
 mod options_parsing;
 mod strict_lib_extends;


### PR DESCRIPTION
Part of #16291's freshly-recounted unwired-code list (Cinnabar's 07:39Z probe confirmed TS18002 as a clean one-line witness, CLI-config owner).

**Structural rule.** `commandLineParser.ts`'s `getConfigFileSpecs`: an entry tsconfig's own `"files": []` reports TS18002 (`The 'files' list in config file '{0}' is empty.`) whenever the entry has no `extends` (which could otherwise supply `files` from a base) and `references` is absent or empty. tsc checks this purely on the entry's own raw JSON shape — it is independent of `include`/`exclude`, and never anchors on a base config pulled in through `extends`, even when the base's own `files` is empty. tsz implements it in `crates/tsz-core/src/config/mod.rs`'s `load_tsconfig_inner_with_diagnostics` (entry-only branch), sibling to but distinct from the existing TS18003 (`no_input_diagnostics_for_config`, CLI-driver-owned, reacts to file-*discovery* results rather than the raw `files` shape).

## Adjacent-case matrix (oracle: `typescript@7.0.2`, the pinned native oracle — verified by running the actual binary, not by reading source, since typescript-go ships no readable JS source for this compiler version)

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `{"files": []}` alone | TS18002 | *(silent)* | TS18002 |
| `{"files": [], "include": ["*.ts"]}` (include would find real files) | TS18002 | *(silent)* | TS18002 |
| `{"files": [], "references": [{"path": "./other"}]}` | *(silent)* | *(silent)* | *(silent)* |
| `{"files": [], "references": []}` (explicit empty array) | TS18002 | *(silent)* | TS18002 |
| `{"extends": "./base.json", "files": []}` | *(silent)* | *(silent)* | *(silent)* |
| `{"extends": "./base.json"}` where `base.json` has `"files": []` | *(silent)* | *(silent)* | *(silent)* |
| `{"files": ["a.ts"]}` | *(silent)* | *(silent)* | *(silent)* |
| `{}` (files key absent) | *(silent)* | *(silent)* | *(silent)* |

All 6 of the state-changing/boundary rows above were run directly against the real pinned `tsc` binary (not inferred from reading classic-TypeScript source, which is a different implementation from the pinned `typescript-go` native compiler) — outputs and error positions (`tsconfig.json(1,11)`) match tsz's implementation exactly.

No identifier/alias/file-name string drives any decision — the check is purely over the parsed `files`/`references`/`extends` shape, matching every other structural config diagnostic in this file.

## Goal
Goal: hold

## Verification
- `cargo build -p tsz-core --lib` — clean.
- `cargo test -p tsz-core --lib config::tests::files_list_empty` — **8/8** (new file: the 8-row matrix above plus the entry-vs-inherited-extends case).
- `cargo test -p tsz-core --lib config::` — **254/254**, no regressions in the existing extends/strict/lib suite.
- `cargo test -p tsz-core --lib` (full) — 3262/3264, the 2 failures (`test_sourcemap_parity_computed_property_names_es6`, `isolated_test_runner::tests::test_isolated_runner_timeout`) reproduce identically on `main` before this change (confirmed via `git stash`) — pre-existing, unrelated to config loading.
- `cargo test -p tsz-cli --lib` (scoped to config/tsconfig/no-input/show-config tests) — 119 passed, 31 failed; the same 31 fail identically on `main` (confirmed via `git stash`) — all `tsc_compat_tests` that shell out to a real `tsc` binary unavailable in this container, pre-existing and unrelated.
- `cargo clippy -p tsz-core --all-targets -- -D warnings` — clean.
- `cargo fmt -p tsz-core -- --check` — clean.
- `python3 scripts/arch/arch_guard.py` — `Architecture guardrails passed.`
- Oracle: `typescript@7.0.2` installed fresh (`npm i typescript@7.0.2`, matching `scripts/conformance/typescript-versions.json`'s pinned mapping), all 6 boundary rows above run directly against the real binary.
- Not run: `compare-to-parent.sh` / emit / fourslash. This is a narrow, additive config-diagnostic change gated on a specific literal tsconfig shape (`"files": []` with no `extends` and no non-empty `references`); grepped the repo tree, benchmark fixtures, and this session's fixtures for that pattern and found none, so the corpus/emit/fourslash surfaces are not exercised by it. Risk is bounded to a tsconfig that already writes this exact shape.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJrfvHxp4KdpprRdhjUydD)_