### PR TITLE
fix(checker): TS1003 for a string-literal export specifier property name

### DIFF
--- a/crates/tsz-checker/src/declarations/module_export_names.rs
+++ b/crates/tsz-checker/src/declarations/module_export_names.rs
@@ -1,21 +1,47 @@
-//! TS18057: string-literal module export names under `--module es2015`/`es2020`.
+//! Module export names written as string literals: TS1003 and TS18057.
 //!
-//! ECMAScript arbitrary module namespace names (`export { x as "str name" }`)
-//! postdate the `es2015` and `es2020` module output formats, so `tsc` rejects
-//! them when `module` is set to exactly one of those two targets. Every other
-//! module target — `es2022`, `esnext`, `commonjs`, `preserve` and the `node*`
-//! family — accepts them.
+//! `tsc` centralises both codes in a single `checkModuleExportName`, which runs
+//! over every *module export name* position: the property name of an import
+//! specifier, both halves of an export specifier, and the name of a namespace
+//! export (`export * as "ns" from "m"`). It reports through `grammarErrorOnNode`,
+//! so the whole check is suppressed once the file has parse diagnostics.
 //!
-//! `tsc` centralises this in `checkModuleExportName`, which runs over every
-//! *module export name* position: the property name of an import specifier,
-//! both halves of an export specifier, and the name of a namespace export
-//! (`export * as "ns" from "m"`). It reports through `grammarErrorOnNode`, so
-//! the whole check is suppressed once the file has parse diagnostics.
+//! ```ts
+//! function checkModuleExportName(name, allowStringLiteral = true) {
+//!     if (name === undefined || name.kind !== SyntaxKind.StringLiteral) return;
+//!     if (!allowStringLiteral) grammarErrorOnNode(name, Identifier_expected);
+//!     else if (moduleKind === ES2015 || moduleKind === ES2020) grammarErrorOnNode(name, ...);
+//! }
+//! ```
 //!
-//! One asymmetry is load-bearing and oracle-confirmed. `checkImportDeclaration`
-//! only walks its specifiers when the module specifier *resolves*, while the
-//! export paths do not, so an unresolved module suppresses TS18057 on the
-//! import side but not on the export side:
+//! The two branches are **mutually exclusive per position and answer to
+//! different conditions**, which is the whole structural point of this module:
+//!
+//! * `!allowStringLiteral` (TS1003) means *this position binds a local*, and no
+//!   string can name a local. It is **module-target independent**.
+//! * `allowStringLiteral` (TS18057) means the position really is a module export
+//!   name, and ECMAScript arbitrary module namespace names postdate the `es2015`
+//!   and `es2020` output formats, so `tsc` rejects them on exactly those two
+//!   targets and accepts them everywhere else (`es2022`, `esnext`, `commonjs`,
+//!   `preserve`, the `node*` family).
+//!
+//! `allowStringLiteral` is `false` at exactly one position: an export
+//! specifier's property name when the export declaration has **no module
+//! specifier**, per `checkExportSpecifier`'s
+//! `checkModuleExportName(node.propertyName, hasModuleSpecifier)`. Because the
+//! branches are chosen per position rather than per declaration, one specifier
+//! can draw one of each — oracle-confirmed under `--module es2015`:
+//!
+//! ```text
+//! const q = 1; export { "q" as "y" };
+//!                       ^^^ TS1003 (property name binds a local)
+//!                              ^^^ TS18057 (exported name, es2015 target)
+//! ```
+//!
+//! A second asymmetry is load-bearing and oracle-confirmed.
+//! `checkImportDeclaration` only walks its specifiers when the module specifier
+//! *resolves*, while the export paths do not, so an unresolved module suppresses
+//! TS18057 on the import side but not on the export side:
 //!
 //! ```text
 //! import { "x" as y } from "./nope";   // TS2307 only
@@ -28,26 +54,31 @@ use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
 
 impl<'a> CheckerState<'a> {
-    /// Shared gate: the check is module-target-specific and, like every other
-    /// check-time grammar diagnostic, is suppressed once the file has a real
-    /// parse error (`tsc`'s `grammarErrorOnNode` does the same).
+    /// Shared gate: like every other check-time grammar diagnostic, both codes
+    /// are suppressed once the file has a real parse error (`tsc`'s
+    /// `grammarErrorOnNode` does the same).
     const fn should_check_module_export_names(&self) -> bool {
         !self.ctx.has_parse_errors
-            && matches!(
-                self.ctx.compiler_options.module,
-                ModuleKind::ES2015 | ModuleKind::ES2020
-            )
     }
 
-    /// Report TS18057 on `name_idx` when it is written as a string literal.
+    /// Whether the current module target is one of the two that reject
+    /// arbitrary module namespace names. This is the condition on
+    /// `checkModuleExportName`'s *second* branch only.
+    const fn module_target_rejects_string_export_names(&self) -> bool {
+        matches!(
+            self.ctx.compiler_options.module,
+            ModuleKind::ES2015 | ModuleKind::ES2020
+        )
+    }
+
+    /// `tsc`'s `checkModuleExportName`, both branches.
     ///
-    /// Mirrors `tsc`'s `checkModuleExportName` for the `allowStringLiteral`
-    /// case. The `!allowStringLiteral` case — a local binding that cannot be
-    /// named by a string, as in `import { "a" as "b" }` or
-    /// `export { "a" as b }` with no module specifier — is answered by the
-    /// parser as TS1003 and is mutually exclusive with this code, so it is
-    /// reached only through the `has_parse_errors` gate above.
-    fn check_module_export_name(&mut self, name_idx: NodeIndex) {
+    /// `allow_string_literal` is `false` only where the position binds a local
+    /// rather than naming a module export — an export specifier's property name
+    /// with no module specifier. There a string literal is not a module export
+    /// name at all but a malformed binding identifier, so the answer is TS1003
+    /// regardless of module target, and TS18057 is never reached.
+    fn check_module_export_name(&mut self, name_idx: NodeIndex, allow_string_literal: bool) {
         if name_idx.is_none() {
             return;
         }
@@ -59,11 +90,19 @@ impl<'a> CheckerState<'a> {
         if !is_string_literal {
             return;
         }
-        self.error_at_node(
-            name_idx,
-            crate::diagnostics::diagnostic_messages::STRING_LITERAL_IMPORT_AND_EXPORT_NAMES_ARE_NOT_SUPPORTED_WHEN_THE_MODULE_FLAG_IS,
-            crate::diagnostics::diagnostic_codes::STRING_LITERAL_IMPORT_AND_EXPORT_NAMES_ARE_NOT_SUPPORTED_WHEN_THE_MODULE_FLAG_IS,
-        );
+        if !allow_string_literal {
+            self.error_at_node(
+                name_idx,
+                crate::diagnostics::diagnostic_messages::IDENTIFIER_EXPECTED,
+                crate::diagnostics::diagnostic_codes::IDENTIFIER_EXPECTED,
+            );
+        } else if self.module_target_rejects_string_export_names() {
+            self.error_at_node(
+                name_idx,
+                crate::diagnostics::diagnostic_messages::STRING_LITERAL_IMPORT_AND_EXPORT_NAMES_ARE_NOT_SUPPORTED_WHEN_THE_MODULE_FLAG_IS,
+                crate::diagnostics::diagnostic_codes::STRING_LITERAL_IMPORT_AND_EXPORT_NAMES_ARE_NOT_SUPPORTED_WHEN_THE_MODULE_FLAG_IS,
+            );
+        }
     }
 
     /// Whether `tsc` would consider this module specifier resolved, which is
@@ -89,7 +128,15 @@ impl<'a> CheckerState<'a> {
     /// name; the specifier's own name binds a local and must already be an
     /// identifier.
     pub(crate) fn check_import_declaration_module_export_names(&mut self, import_idx: NodeIndex) {
-        if !self.should_check_module_export_names() {
+        // Every module export name reachable from an import declaration is
+        // `allowStringLiteral = true`, so TS18057 is the only branch this path
+        // can take. Skipping the whole walk when the module target does not
+        // reject string export names is therefore exactly equivalent to running
+        // it, and avoids resolving a module specifier for every import in the
+        // program on targets where nothing could be reported.
+        if !self.should_check_module_export_names()
+            || !self.module_target_rejects_string_export_names()
+        {
             return;
         }
         let Some(import_node) = self.ctx.arena.get(import_idx) else {
@@ -127,7 +174,9 @@ impl<'a> CheckerState<'a> {
             })
             .collect();
         for property_name in property_names {
-            self.check_module_export_name(property_name);
+            // `checkImportBinding` passes no second argument: an import
+            // specifier's property name is always a module export name.
+            self.check_module_export_name(property_name, true);
         }
     }
 
@@ -156,7 +205,9 @@ impl<'a> CheckerState<'a> {
         };
         if clause_node.kind != syntax_kind_ext::NAMED_EXPORTS {
             // `export * as "ns" from "m"` — the clause *is* the namespace name.
-            self.check_module_export_name(export_decl.export_clause);
+            // `checkExportDeclaration` passes no second argument, so this
+            // position always allows a string literal.
+            self.check_module_export_name(export_decl.export_clause, true);
             return;
         }
         let Some(named_exports) = self.ctx.arena.get_named_imports(clause_node) else {
@@ -165,7 +216,8 @@ impl<'a> CheckerState<'a> {
         // `allowStringLiteral` in tsc's `checkExportSpecifier` is `!!moduleSpecifier`
         // for the property name: without a `from` clause the property name is a
         // *local* binding, which no string can name, so tsc answers TS1003 there
-        // and never TS18057.
+        // and never TS18057. The specifier's own name is always a module export
+        // name and always allows a string literal.
         let property_names_are_module_export_names = export_decl.module_specifier.is_some();
         let mut names = Vec::with_capacity(named_exports.elements.nodes.len() * 2);
         for element_idx in &named_exports.elements.nodes {
@@ -175,13 +227,16 @@ impl<'a> CheckerState<'a> {
             let Some(specifier) = self.ctx.arena.get_specifier(element_node) else {
                 continue;
             };
-            if property_names_are_module_export_names {
-                names.push(specifier.property_name);
-            }
-            names.push(specifier.name);
+            // Source order within a specifier: property name, then name — the
+            // order `checkExportSpecifier` calls them in.
+            names.push((
+                specifier.property_name,
+                property_names_are_module_export_names,
+            ));
+            names.push((specifier.name, true));
         }
-        for name_idx in names {
-            self.check_module_export_name(name_idx);
+        for (name_idx, allow_string_literal) in names {
+            self.check_module_export_name(name_idx, allow_string_literal);
         }
     }
 }

--- a/crates/tsz-checker/tests/string_literal_module_export_name_grammar_tests.rs
+++ b/crates/tsz-checker/tests/string_literal_module_export_name_grammar_tests.rs
@@ -1,25 +1,39 @@
-//! String-literal module export names — TS18057.
+//! String-literal module export names — TS18057 and TS1003.
 //!
-//! ECMAScript arbitrary module namespace names (`export { x as "str name" }`)
-//! postdate the `es2015` and `es2020` module output formats, so tsc rejects
-//! them when `module` is exactly one of those two and accepts them on every
-//! other module target.
-//!
-//! tsc centralises this in `checkModuleExportName`, which runs over every
+//! tsc centralises both codes in `checkModuleExportName`, which runs over every
 //! *module export name* position: an import specifier's property name, both
 //! halves of an export specifier, and the `export * as <name>` namespace name.
 //! It reports via `grammarErrorOnNode`, so a file with parse diagnostics
 //! suppresses it entirely.
 //!
+//! The function has two mutually exclusive branches, chosen **per position**:
+//!
+//! * `!allowStringLiteral` answers **TS1003** and is module-target independent.
+//!   It means the position binds a local, which no string can name. Exactly one
+//!   position takes it: an export specifier's property name when the export
+//!   declaration has no module specifier.
+//! * otherwise ECMAScript arbitrary module namespace names postdate the `es2015`
+//!   and `es2020` output formats, so tsc answers **TS18057** on exactly those
+//!   two targets and accepts them on every other.
+//!
+//! Because the choice is per position, one specifier can draw one of each.
+//!
 //! Every expectation here is pinned against the oracle (`typescript@7.0.2`,
 //! `--noEmit --strict --target es2022`), including the negatives.
 
 use tsz_checker::context::CheckerOptions;
-use tsz_checker::test_utils::check_source;
+use tsz_checker::test_utils::{check_source, check_source_with_parse_health};
 use tsz_common::common::{ModuleKind, ScriptTarget};
 
 /// TS18057.
 const STRING_LITERAL_MODULE_EXPORT_NAME: u32 = 18057;
+
+/// TS1003 — `checkModuleExportName`'s *other* branch, taken when the position
+/// binds a local rather than naming a module export.
+const IDENTIFIER_EXPECTED: u32 = 1003;
+
+/// TS1110, used only as the parse error in the suppression row.
+const TYPE_EXPECTED: u32 = 1110;
 
 fn options_for(module: ModuleKind) -> CheckerOptions {
     CheckerOptions {
@@ -225,6 +239,10 @@ fn a_local_export_property_name_is_not_a_module_export_name() {
         !codes.contains(&STRING_LITERAL_MODULE_EXPORT_NAME),
         "a local export's property name is not a module export name, got {codes:?}"
     );
+    assert!(
+        codes.contains(&IDENTIFIER_EXPECTED),
+        "the same position must answer TS1003 instead, got {codes:?}"
+    );
 }
 
 #[test]
@@ -319,5 +337,222 @@ fn the_check_does_not_depend_on_the_names_involved() {
             codes.contains(&STRING_LITERAL_MODULE_EXPORT_NAME),
             "TS18057 must fire regardless of the names in {source:?}, got {codes:?}"
         );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `checkModuleExportName`'s first branch: `!allowStringLiteral` -> TS1003
+//
+// `allowStringLiteral` is false at exactly one position — an export specifier's
+// property name when the export declaration has no module specifier. There the
+// name binds a local, which no string can name, so the answer is TS1003 on
+// EVERY module target rather than the target-gated TS18057. Every expectation
+// below is pinned against `typescript@7.0.2`.
+// ---------------------------------------------------------------------------
+
+fn count_1003(module: ModuleKind, source: &str) -> usize {
+    check_codes_with(module, source)
+        .into_iter()
+        .filter(|code| *code == IDENTIFIER_EXPECTED)
+        .count()
+}
+
+#[test]
+fn a_local_export_property_name_draws_ts1003_on_every_module_target() {
+    // The branch is chosen by position, not by module target, so this fires
+    // identically on targets that reject string export names and on those that
+    // accept them.
+    for module in [
+        ModuleKind::ES2015,
+        ModuleKind::ES2020,
+        ModuleKind::ES2022,
+        ModuleKind::ESNext,
+        ModuleKind::CommonJS,
+        ModuleKind::Preserve,
+        ModuleKind::Node16,
+        ModuleKind::NodeNext,
+        ModuleKind::AMD,
+        ModuleKind::UMD,
+        ModuleKind::System,
+    ] {
+        assert_eq!(
+            count_1003(module, r#"const q = 1; export { "q" as y };"#),
+            1,
+            "expected exactly one TS1003 under {module:?}"
+        );
+    }
+}
+
+#[test]
+fn one_specifier_can_draw_both_codes_at_different_positions() {
+    // The load-bearing row. Under es2015 `export { "q" as "y" }` with no module
+    // specifier answers TS1003 on the property name (binds a local) and TS18057
+    // on the exported name (a real module export name on a rejecting target).
+    // A per-declaration implementation of either branch fails this.
+    let codes = check_codes_with(ModuleKind::ES2015, r#"const q = 1; export { "q" as "y" };"#);
+    assert!(
+        codes.contains(&IDENTIFIER_EXPECTED) && codes.contains(&STRING_LITERAL_MODULE_EXPORT_NAME),
+        "expected TS1003 and TS18057 together, got {codes:?}"
+    );
+}
+
+#[test]
+fn the_exported_name_half_stays_silent_on_an_accepting_target() {
+    // Same source as above on esnext: only the local-binding half is wrong.
+    let codes = check_codes_with(ModuleKind::ESNext, r#"const q = 1; export { "q" as "y" };"#);
+    assert_eq!(
+        codes.iter().filter(|c| **c == IDENTIFIER_EXPECTED).count(),
+        1,
+        "only the property name binds a local, got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&STRING_LITERAL_MODULE_EXPORT_NAME),
+        "esnext accepts a string-literal exported name, got {codes:?}"
+    );
+}
+
+#[test]
+fn a_module_specifier_restores_the_module_export_name_reading() {
+    // With a `from` clause the property name IS a module export name, so
+    // `allowStringLiteral` is true and TS1003 must not fire on any target.
+    for module in [ModuleKind::ES2015, ModuleKind::ESNext, ModuleKind::CommonJS] {
+        assert_eq!(
+            count_1003(module, r#"export { "x" as y } from "target";"#),
+            0,
+            "a re-export's property name is a module export name under {module:?}"
+        );
+    }
+}
+
+#[test]
+fn a_bare_string_specifier_without_a_module_specifier_is_not_a_property_name() {
+    // `export { "q" }` parses the string as the specifier's NAME, leaving the
+    // property name absent — so the false-`allowStringLiteral` position does
+    // not exist and tsc reports nothing on an accepting target. Distinguishing
+    // this from `export { "q" as y }` is the point.
+    assert_eq!(
+        count_1003(ModuleKind::ESNext, r#"const q = 1; export { "q" };"#),
+        0,
+        "the name half always allows a string literal"
+    );
+    assert_eq!(
+        count_1003(ModuleKind::ES2015, r#"const q = 1; export { "q" };"#),
+        0,
+        "and it answers TS18057, not TS1003, on a rejecting target"
+    );
+    assert!(
+        check_codes_with(ModuleKind::ES2015, r#"const q = 1; export { "q" };"#)
+            .contains(&STRING_LITERAL_MODULE_EXPORT_NAME),
+        "es2015 still rejects the exported name itself"
+    );
+}
+
+#[test]
+fn a_local_exported_name_written_as_a_string_never_draws_ts1003() {
+    // The mirror image: `export { q as "a" }` puts the string on the name half,
+    // which always allows it.
+    assert_eq!(
+        count_1003(ModuleKind::ESNext, r#"const q = 1; export { q as "a" };"#),
+        0,
+        "the exported name may be a string literal with no `from` clause"
+    );
+}
+
+#[test]
+fn the_type_modifier_does_not_exempt_the_property_name() {
+    assert_eq!(
+        count_1003(
+            ModuleKind::ESNext,
+            r#"type Q = 1; export { type "Q" as y };"#
+        ),
+        1,
+        "a type-only specifier's property name binds a local just the same"
+    );
+}
+
+#[test]
+fn every_specifier_in_the_clause_is_checked() {
+    assert_eq!(
+        count_1003(
+            ModuleKind::ESNext,
+            r#"const a = 1, b = 2; export { "a" as x, "b" as y };"#
+        ),
+        2,
+        "the walk covers all specifiers, not just the first"
+    );
+}
+
+#[test]
+fn ts1003_does_not_depend_on_the_names_involved() {
+    // Anti-hardcoding: the rule is structural. Vary both the binder and the
+    // string, including a string that does not name any local at all — tsc
+    // skips its local-resolution check for exactly this shape, so TS1003 is
+    // the only diagnostic and no resolution error joins it.
+    for (local, quoted) in [
+        ("q", "q"),
+        ("someOtherBinder", "someOtherBinder"),
+        ("Zzz", "Zzz"),
+        ("q", "nothingNamedThis"),
+    ] {
+        let source = format!(r#"const {local} = 1; export {{ "{quoted}" as renamed }};"#);
+        assert_eq!(
+            count_1003(ModuleKind::ESNext, &source),
+            1,
+            "expected exactly one TS1003 for {source:?}"
+        );
+    }
+}
+
+#[test]
+fn a_parse_error_suppresses_ts1003_too() {
+    // Both branches report through `grammarErrorOnNode`, so a file with parse
+    // diagnostics suppresses the whole check. Oracle answers TS1110 alone for
+    // this source.
+    //
+    // This needs `check_source_with_parse_health`: the plain helpers leave
+    // `has_parse_errors` at its `false` default, so a test written on them
+    // cannot observe the suppression at all.
+    let (parser_codes, checker_codes) =
+        check_source_with_parse_health(r#"const q = 1; export { "q" as y }; let z: = 1;"#);
+    assert!(
+        parser_codes.contains(&TYPE_EXPECTED),
+        "the source must actually produce the parse error, got {parser_codes:?}"
+    );
+    assert!(
+        !checker_codes.contains(&IDENTIFIER_EXPECTED),
+        "a parse error suppresses this grammar check, got {checker_codes:?}"
+    );
+}
+
+#[test]
+fn without_the_parse_error_the_same_source_reports_ts1003() {
+    // The control for the row above: same file, parse error removed.
+    let (parser_codes, checker_codes) =
+        check_source_with_parse_health(r#"const q = 1; export { "q" as y }; let z = 1;"#);
+    assert!(
+        parser_codes.is_empty(),
+        "control must parse cleanly, got {parser_codes:?}"
+    );
+    assert!(
+        checker_codes.contains(&IDENTIFIER_EXPECTED),
+        "expected TS1003 once nothing suppresses it, got {checker_codes:?}"
+    );
+}
+
+#[test]
+fn plain_identifier_specifiers_never_draw_ts1003() {
+    for source in [
+        r#"const q = 1; export { q };"#,
+        r#"const q = 1; export { q as r };"#,
+        r#"export { x as y } from "target";"#,
+        r#"export * as ns from "target";"#,
+    ] {
+        for module in [ModuleKind::ES2015, ModuleKind::ESNext] {
+            assert_eq!(
+                count_1003(module, source),
+                0,
+                "TS1003 must not fire for {source:?} under {module:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
`tsc` centralises two diagnostics in one `checkModuleExportName`, and the two branches are **mutually exclusive and chosen per name position**:

```ts
function checkModuleExportName(name, allowStringLiteral = true) {
    if (name === undefined || name.kind !== SyntaxKind.StringLiteral) return;
    if (!allowStringLiteral) grammarErrorOnNode(name, Identifier_expected);          // TS1003
    else if (moduleKind === ES2015 || moduleKind === ES2020) grammarErrorOnNode(...); // TS18057
}
```

#16354 landed the second branch. The first was **unreachable**, so tsz had zero emit sites for the TS1003 half and the shape type-checked completely clean.

**Structural rule.** When a module export name is a string literal at a position that binds a *local* rather than naming a module export — an export specifier's property name whose export declaration has no module specifier — tsc reports TS1003 on **every** module target; tsz does so through the checker (`declarations/module_export_names.rs`), the layer that already owns the sibling branch.

`allowStringLiteral` is `false` at exactly one of the four call sites — `checkExportSpecifier`'s `checkModuleExportName(node.propertyName, hasModuleSpecifier)`. The other three (import specifier property name, export specifier name, namespace export name) pass the default `true`.

```ts
const q = 1; export { "q" as y };   // tsc: TS1003    tsz before: clean
```

The wrong semantic operation was **diagnostic display / grammar checking on module element declarations**, not resolution or symbol lookup.

### What made this more than adding a branch

The old code hoisted the module-target test into a single `should_check_module_export_names()` gate covering both walks. That is only correct while TS18057 is the sole branch: **TS1003 is module-target independent**, so keeping the hoisted gate would have made it fire on `es2015`/`es2020` only. The target test now lives inside `check_module_export_name`, next to the branch it actually conditions.

Because the branch is chosen per position, one specifier can draw one of each — the load-bearing row, oracle-confirmed:

```text
--module es2015:   const q = 1; export { "q" as "y" };
                                        ^^^ TS1003  (property name binds a local)
                                               ^^^ TS18057 (exported name, rejecting target)
```

A per-declaration implementation of either branch fails that row. It is pinned by name.

The import-side walk keeps an explicit module-target early return, with a comment stating why it is *equivalent* rather than merely cheaper: every module export name reachable from an import declaration is `allowStringLiteral = true`, so TS18057 is the only branch that path can take. That avoids resolving a module specifier for every import in the program on targets where nothing could be reported.

No identifier, alias, property or file-name string drives any decision; the inputs are node kind, the presence of a module specifier, and the module target. A dedicated test varies the binders and the quoted strings — including a string naming no local at all — to pin that.

## Goal
Goal: hold

## Verification

**Oracle matrix — 26/26 byte-identical to `typescript@7.0.2`, positions included.** Direct `tsz` vs `tsc` diff on the same program, comparing the exact `(line,col) TSxxxx` set:

- `!allowStringLiteral` rows (12): TS1003 at the identical column on `es2015`, `es2020`, `es2022`, `esnext`, `commonjs`; the both-codes row; two specifiers in one clause; renamed binders; a string naming no local (tsc skips its local-resolution check for this shape, so TS1003 is alone — tsz agrees, no spurious resolution error); type-only specifiers on both an accepting and a rejecting target.
- `allowStringLiteral` negatives (11): bare `export { "q" }`, the name half `export { q as "a" }`, every re-export form, `export * as "ns"`, and the import side — all unchanged, still TS18057-or-clean exactly as before.
- Suppression + plain identifiers (3).

**Before/after on the primary witness** (`--module esnext`, and identically on every other target):
```
before:  (clean — no diagnostic at all)
after:   case.ts(1,23): error TS1003: Identifier expected.
```

**Suites run locally:**
- `cargo test -p tsz-checker --test string_literal_module_export_name_grammar_tests` — **31 passed / 0 failed** (was 17 before this PR; 14 new rows).
- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt` — clean.
- `python3 scripts/arch/arch_guard.py` — clean.

**`scripts/conformance/compare-to-parent.sh 926071a`** was started against the PR's actual base sha in a sister worktree and had not finished when this PR was opened; it is the gate that matters here because — unlike #16354's module-gated code — **this diagnostic fires on every module target**, so corpus exposure is real. I will post the two-sided result on this PR and will not queue the merge before it is green.

One harness finding worth recording: the grammar-suppression row cannot be written on `check_source`. Those helpers leave `has_parse_errors` at its `false` default, so a test built on them never observes the suppression and passes vacuously. It uses `check_source_with_parse_health` and asserts the parse error actually fired, with a clean-parse control alongside.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Malachite

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCgJaUb6hYR67PZWTf8i9p)_