### PR TITLE
fix(config): TS5052/TS18035 for jsxFragmentFactory without jsxFactory

### DIFF
--- a/crates/tsz-core/src/config/parse.rs
+++ b/crates/tsz-core/src/config/parse.rs
@@ -856,6 +856,23 @@ pub fn parse_tsconfig_with_diagnostics_deferred(
             );
         }
 
+        // TS5052: jsxFragmentFactory requires jsxFactory. Presence-based like
+        // checkJs/allowJs above, not a boolean flag, so a non-empty string
+        // value (any value at all, since option_is_truthy treats a present
+        // string as truthy) is enough to trigger the dependency regardless of
+        // whether that value later fails the TS18035 identifier check below.
+        if option_is_truthy(compiler_opts.get("jsxFragmentFactory"))
+            && !option_is_truthy(compiler_opts.get("jsxFactory"))
+        {
+            push_option_dependency_diagnostic(
+                &mut diagnostics,
+                file_path,
+                &stripped,
+                "jsxFragmentFactory",
+                "jsxFactory",
+            );
+        }
+
         // TS5053: Option '{0}' cannot be specified with option '{1}'.
         // tsc emits for each conflicting key, pointing at the key's position.
         // The message always names the pair (A, B) regardless of which key is pointed at.
@@ -927,6 +944,28 @@ pub fn parse_tsconfig_with_diagnostics_deferred(
                 jsx_factory_val.len() as u32 + 2, // include surrounding quotes
                 msg,
                 diagnostic_codes::INVALID_VALUE_FOR_JSXFACTORY_IS_NOT_A_VALID_IDENTIFIER_OR_QUALIFIED_NAME,
+            ));
+        }
+
+        // TS18035: Invalid value for 'jsxFragmentFactory' — same identifier-or-
+        // qualified-name rule as jsxFactory (TS5067) above, independent
+        // diagnostic. tsc reports this regardless of whether jsxFactory is
+        // present, so it does not gate on the TS5052 dependency check above.
+        if let Some(serde_json::Value::String(jsx_fragment_factory_val)) =
+            compiler_opts.get("jsxFragmentFactory")
+            && !is_valid_identifier_or_qualified_name(jsx_fragment_factory_val)
+        {
+            let start = find_value_offset_in_source(&stripped, "jsxFragmentFactory");
+            let msg = format_message(
+                diagnostic_messages::INVALID_VALUE_FOR_JSXFRAGMENTFACTORY_IS_NOT_A_VALID_IDENTIFIER_OR_QUALIFIED_NAME,
+                &[jsx_fragment_factory_val.as_str()],
+            );
+            diagnostics.push(Diagnostic::error(
+                file_path,
+                start,
+                jsx_fragment_factory_val.len() as u32 + 2, // include surrounding quotes
+                msg,
+                diagnostic_codes::INVALID_VALUE_FOR_JSXFRAGMENTFACTORY_IS_NOT_A_VALID_IDENTIFIER_OR_QUALIFIED_NAME,
             ));
         }
 

--- a/crates/tsz-core/src/config/tests/module_resolution.rs
+++ b/crates/tsz-core/src/config/tests/module_resolution.rs
@@ -1475,6 +1475,90 @@ fn test_ts5052_not_emitted_when_check_js_and_allow_js_true() {
 }
 
 #[test]
+fn test_ts5052_jsx_fragment_factory_requires_jsx_factory() {
+    // Oracle-confirmed (typescript@7.0.2): `jsxFragmentFactory` alone, even
+    // with a syntactically valid value, still requires `jsxFactory`.
+    let source = r#"{"compilerOptions":{"jsxFragmentFactory":"Fragment"}}"#;
+    let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
+    let hits: Vec<&Diagnostic> = parsed
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 5052)
+        .collect();
+    assert_eq!(
+        hits.len(),
+        1,
+        "Expected exactly one TS5052 diagnostic, got: {:?}",
+        parsed.diagnostics
+    );
+    assert!(
+        hits[0].message_text.contains(
+            "'jsxFragmentFactory' cannot be specified without specifying option 'jsxFactory'"
+        ),
+        "Unexpected TS5052 message: {}",
+        hits[0].message_text
+    );
+}
+
+#[test]
+fn test_ts5052_jsx_fragment_factory_silent_when_jsx_factory_present() {
+    let source = r#"{"compilerOptions":{"jsxFactory":"h","jsxFragmentFactory":"Fragment.Nested"}}"#;
+    let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
+    let has_5052 = parsed.diagnostics.iter().any(|d| d.code == 5052);
+    assert!(
+        !has_5052,
+        "jsxFactory is present, so no TS5052 is due, got: {:?}",
+        parsed.diagnostics
+    );
+}
+
+#[test]
+fn test_ts18035_invalid_jsx_fragment_factory_value() {
+    // Oracle-confirmed (typescript@7.0.2): fires independently of the TS5052
+    // dependency check -- an invalid value is still invalid even paired with
+    // jsxFactory.
+    let source = r#"{"compilerOptions":{"jsxFactory":"h","jsxFragmentFactory":"not a name!"}}"#;
+    let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
+    let ts18035 = parsed
+        .diagnostics
+        .iter()
+        .find(|d| d.code == diagnostic_codes::INVALID_VALUE_FOR_JSXFRAGMENTFACTORY_IS_NOT_A_VALID_IDENTIFIER_OR_QUALIFIED_NAME)
+        .unwrap_or_else(|| panic!("Expected TS18035, got: {:?}", parsed.diagnostics));
+    assert!(
+        ts18035
+            .message_text
+            .contains("'not a name!' is not a valid identifier or qualified-name"),
+        "Unexpected TS18035 message: {}",
+        ts18035.message_text
+    );
+    assert_eq!(
+        ts18035.start,
+        source.find("\"not a name!\"").expect("value position") as u32,
+    );
+    let has_5052 = parsed.diagnostics.iter().any(|d| d.code == 5052);
+    assert!(
+        !has_5052,
+        "jsxFactory is present, so no TS5052 is due even though the value is invalid, got: {:?}",
+        parsed.diagnostics
+    );
+}
+
+#[test]
+fn test_ts18035_not_emitted_for_valid_jsx_fragment_factory_value() {
+    let source = r#"{"compilerOptions":{"jsxFactory":"h","jsxFragmentFactory":"Fragment.Nested"}}"#;
+    let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
+    let has_18035 = parsed.diagnostics.iter().any(|d| {
+        d.code
+            == diagnostic_codes::INVALID_VALUE_FOR_JSXFRAGMENTFACTORY_IS_NOT_A_VALID_IDENTIFIER_OR_QUALIFIED_NAME
+    });
+    assert!(
+        !has_18035,
+        "'Fragment.Nested' is a valid qualified name, got: {:?}",
+        parsed.diagnostics
+    );
+}
+
+#[test]
 fn test_resolve_compiler_options_propagates_check_js_to_checker_options() {
     let source = r#"{"compilerOptions":{"allowJs":true,"checkJs":true}}"#;
     let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();


### PR DESCRIPTION
Part of #16291's unwired-code enumeration. TS18035 was flagged there as "confirmed reachable, unclaimed," with a warning that it "fires alongside TS5052, so whoever takes it must check the pairing, not just the presence" — this PR wires both.

**Structural rule.** tsc's `verifyCompilerOptions` reports TS5052 (`Option 'jsxFragmentFactory' cannot be specified without specifying option 'jsxFactory'`) whenever `jsxFragmentFactory` is present in the raw config, regardless of whether its value is valid, and *independently* validates `jsxFragmentFactory`'s own value as an identifier-or-qualified-name (TS18035) regardless of whether `jsxFactory` is present. The two checks are orthogonal, not a fallback chain. tsz implements both in `crates/tsz-core/src/config/parse.rs`: TS5052 via the existing `push_option_dependency_diagnostic` helper already used for `checkJs`/`allowJs` and `emitDecoratorMetadata`/`experimentalDecorators`; TS18035 by mirroring the adjacent `jsxFactory`/TS5067 validation block, reusing `is_valid_identifier_or_qualified_name` and `find_value_offset_in_source`.

**Adjacent-case matrix** (oracle: `typescript@7.0.2`, pinned native binary, `tsc -p . --pretty false`):

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `{"jsxFragmentFactory":"not a name!"}` | TS5052 + TS18035 | (nothing) | TS5052 + TS18035 |
| `{"jsxFragmentFactory":"Fragment"}` (valid value, no `jsxFactory`) | TS5052 only | (nothing) | TS5052 only |
| `{"jsxFactory":"h","jsxFragmentFactory":"not a name!"}` | TS18035 only (no TS5052) | (nothing) | TS18035 only |
| `{"jsxFactory":"h","jsxFragmentFactory":"Fragment.Nested"}` | clean | clean | clean |

The third row is the pairing hazard the source issue called out: `jsxFactory` present is enough to silence TS5052 even though the paired value is still invalid, so the two checks had to stay independent rather than one gating the other.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-core --lib "jsx_fragment"` — 4/4 new tests (both TS5052 rows, both TS18035 rows).
- `cargo test -p tsz-core --lib config::` — 250/250, no regressions.
- `cargo test -p tsz-core --lib` (full) — 3258 passed, 2 failed; both failures (`test_sourcemap_parity_computed_property_names_es6`, `isolated_test_runner::tests::test_isolated_runner_timeout`) are pre-existing on `main`, unrelated to config loading (previously confirmed via `git stash` in #16355's session).
- `cargo build -p tsz-cli --lib` — clean, no downstream breakage.
- `cargo clippy -p tsz-core --all-targets -- -D warnings` — clean.
- `cargo fmt -p tsz-core -- --check` — clean.
- `python3 scripts/arch/arch_guard.py` — `Architecture guardrails passed.`
- Oracle: `typescript@7.0.2` installed fresh (`npm i typescript@7.0.2`), all 4 matrix rows run directly against the real binary via a real `tsconfig.json` + `-p .` invocation (not `--noEmit` on a loose file, since this is project-config validation).
- Not run: `compare-to-parent.sh` / emit / fourslash. Narrow, additive config-diagnostic change gated on a specific tsconfig key combination (`jsxFragmentFactory` present); grepped the corpus/benchmark fixtures for that key and found no existing usage, so the corpus/emit/fourslash surfaces are not exercised by it.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNbn3BM4CBvRNpbiXBsKYC)_