### PR TITLE
fix(checker): Symbol.member keys the well-known symbol regardless of declared kind

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/computed_property_names.rs
+++ b/crates/tsz-checker/src/state/type_resolution/computed_property_names.rs
@@ -411,23 +411,6 @@ impl<'a> CheckerState<'a> {
         {
             return Some(ResolvedComputedName::string(name));
         }
-        // `Symbol.<member>` where `<member>` is a plain (non-unique)
-        // `symbol`-typed global augmentation (xstate's `SymbolConstructor.
-        // observable: symbol`) is not a well-known key at all: it does not
-        // mint a named member, so it must be flagged wide (`__symbol_`
-        // prefix) the same way an aliasing identifier's plain-`symbol`
-        // binding is below — `symbol_valued_binding_property_name` only
-        // resolves bare identifiers, so this qualified-access shape needs its
-        // own leg.
-        if let Some(name) = crate::types_domain::computed_names::wide_well_known_symbol_member_key(
-            &self.ctx,
-            self.ctx.arena,
-            self.ctx.binder,
-            computed.expression,
-        ) {
-            return Some(ResolvedComputedName::symbol(name));
-        }
-
         if let Some(name) =
             self.computed_expression_literal_name_in_arena(self.ctx.arena, computed.expression)
         {

--- a/crates/tsz-checker/src/types/class_type/constructor_parts/helpers.rs
+++ b/crates/tsz-checker/src/types/class_type/constructor_parts/helpers.rs
@@ -329,39 +329,20 @@ impl<'a> CheckerState<'a> {
 
     /// Does this static class member's name node key off a plain
     /// (non-unique) `symbol` binding — `class C { static [s]() {} }` with
-    /// `declare const s: symbol`, or `Symbol.NAME` where `NAME` is a wide
-    /// `SymbolConstructor` global augmentation?
+    /// `declare const s: symbol`?
     ///
     /// Such a member contributes a `[key: symbol]: V` index signature to the
     /// constructor type instead of a named static member, the static-side
     /// twin of `class_member_computed_key_is_wide_symbol`'s instance-side
-    /// routing (#16307).
+    /// routing. `Symbol.NAME` written as property-access syntax is excluded
+    /// by `computed_member_key_is_wide_symbol` itself, even when `NAME` is
+    /// declared plain `symbol`: tsc derives a NAMED member from the syntactic
+    /// well-known shape before it consults the key's type at all (#16307).
     pub(super) fn static_member_computed_key_is_wide_symbol(
         &mut self,
         name_idx: NodeIndex,
     ) -> bool {
-        if !self.computed_member_key_is_wide_symbol(name_idx) {
-            return false;
-        }
-        // `Symbol.NAME` written as property-access syntax is excluded even
-        // when `NAME` is declared plain `symbol`: tsc derives a NAMED member
-        // from the syntactic well-known shape (`isWellKnownSymbolSyntactically`)
-        // before it consults the key's type at all, so
-        // `class C { static [Symbol.observable]() {} }` gets no symbol index
-        // signature and `C[someOtherSymbol]` stays TS7053.
-        let Some(name_node) = self.ctx.arena.get(name_idx) else {
-            return false;
-        };
-        let Some(computed) = self.ctx.arena.get_computed_property(name_node) else {
-            return false;
-        };
-        crate::types_domain::computed_names::wide_well_known_symbol_member_key(
-            &self.ctx,
-            self.ctx.arena,
-            self.ctx.binder,
-            computed.expression,
-        )
-        .is_none()
+        self.computed_member_key_is_wide_symbol(name_idx)
     }
 
     pub(super) fn remap_inherited_construct_signatures(

--- a/crates/tsz-checker/src/types/class_type/helpers.rs
+++ b/crates/tsz-checker/src/types/class_type/helpers.rs
@@ -456,9 +456,7 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Does this class member's name node key off a plain (non-unique)
-    /// `symbol` binding — `class C { [s]() {} }` with `declare const s: symbol`,
-    /// or `Symbol.NAME` where `NAME` is a wide `SymbolConstructor` global
-    /// augmentation?
+    /// `symbol` binding — `class C { [s]() {} }` with `declare const s: symbol`?
     ///
     /// Such a member contributes a `[key: symbol]: V` index signature to the
     /// class instance shape instead of a named member, matching what the
@@ -467,7 +465,10 @@ impl<'a> CheckerState<'a> {
     /// only ever matches another declaration whose key resolves to the SAME
     /// binding, so a class and the interface it implements — keyed off two
     /// different `symbol` bindings, as tsc allows — stop being mutually
-    /// assignable.
+    /// assignable. `Symbol.NAME` written as property-access syntax is excluded
+    /// by `computed_member_key_is_wide_symbol` itself, even when `NAME` is
+    /// declared plain `symbol`: tsc derives a NAMED member from the syntactic
+    /// well-known shape before it consults the key's type at all (#16307).
     pub(super) fn class_member_computed_key_is_wide_symbol(&mut self, name_idx: NodeIndex) -> bool {
         // Classifying the key evaluates its expression in VALUE position, and a
         // value-position evaluation reports its own diagnostics. Several of those
@@ -484,31 +485,7 @@ impl<'a> CheckerState<'a> {
         self.ctx.checking_computed_property_name = Some(name_idx);
         let is_wide = self.computed_member_key_is_wide_symbol(name_idx);
         self.ctx.checking_computed_property_name = prev_checking;
-        if !is_wide {
-            return false;
-        }
-        // `Symbol.NAME` written as property-access syntax is excluded even when
-        // `NAME` is declared plain `symbol`: tsc derives a NAMED member from the
-        // syntactic well-known shape (`isWellKnownSymbolSyntactically`) before it
-        // consults the key's type at all, so `class C { [Symbol.observable]() {} }`
-        // gets no symbol index signature and `c[someOtherSymbol]` stays TS7053.
-        // Every other wide-`symbol` key — a bare identifier, or a property access
-        // whose base is not the unshadowed global `Symbol` — does route to the
-        // index signature. A genuine well-known (`Symbol.iterator`, `unique
-        // symbol`-typed) never reaches here, having failed the wide-key test above.
-        let Some(name_node) = self.ctx.arena.get(name_idx) else {
-            return false;
-        };
-        let Some(computed) = self.ctx.arena.get_computed_property(name_node) else {
-            return false;
-        };
-        crate::types_domain::computed_names::wide_well_known_symbol_member_key(
-            &self.ctx,
-            self.ctx.arena,
-            self.ctx.binder,
-            computed.expression,
-        )
-        .is_none()
+        is_wide
     }
 
     /// Fold a wide-`symbol`-keyed class member's value type into the class

--- a/crates/tsz-checker/src/types/computation/object_literal/symbol_key_routing.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/symbol_key_routing.rs
@@ -134,6 +134,25 @@ impl<'a> CheckerState<'a> {
         {
             return false;
         }
+        // `Symbol.<member>` (or `Symbol["<member>"]`) written directly is
+        // ALWAYS the well-known symbol itself, regardless of `<member>`'s own
+        // declared kind on a (possibly user-augmented) `SymbolConstructor`:
+        // tsc derives a NAMED member from the syntactic well-known shape
+        // (`isWellKnownSymbolSyntactically`) before it ever consults the
+        // key's type, so `{ [Symbol.observable]: 1 }` mints the literal
+        // `[Symbol.observable]` key and does NOT route into a symbol index
+        // signature even when `SymbolConstructor.observable` is a user
+        // global augmentation typed plain `symbol` (#16307). Checked ahead of
+        // the type-based fallback below, which cannot see this syntactic
+        // override on its own.
+        if crate::types_domain::computed_names::is_well_known_symbol_syntax(
+            &self.ctx,
+            self.ctx.arena,
+            self.ctx.binder,
+            computed.expression,
+        ) {
+            return false;
+        }
         // A binding declared `typeof Symbol.<member>` for a genuine well-known
         // member IS that well-known symbol under tsc (the type query reports
         // `unique symbol`), so it names the canonical `[Symbol.<member>]`

--- a/crates/tsz-checker/src/types/computed_names.rs
+++ b/crates/tsz-checker/src/types/computed_names.rs
@@ -141,6 +141,17 @@ pub(crate) enum WellKnownSymbolName {
 }
 
 /// Match and verify a well-known-symbol computed name expression.
+///
+/// `tsc`'s discriminator for whether `Symbol.<member>` denotes the well-known
+/// symbol itself is purely SYNTACTIC — reach to the global `Symbol` value,
+/// written inline or through a `typeof Symbol.<member>` binding (see
+/// [`type_query_well_known_symbol_key`]) — never the declared kind of
+/// `<member>` on the (possibly user-augmented) `SymbolConstructor` interface.
+/// A user augmentation like xstate's `interface SymbolConstructor { readonly
+/// observable: symbol }` does not change what `Symbol.observable` itself
+/// types as; it only affects a SEPARATE binding independently annotated
+/// `: symbol` (`declare const wide: symbol`), which is not this shape at all
+/// (`symbol_is_wide_symbol_binding` owns that case). #16307.
 pub(crate) fn well_known_symbol_property_name(
     ctx: &CheckerContext<'_>,
     arena: &NodeArena,
@@ -150,169 +161,29 @@ pub(crate) fn well_known_symbol_property_name(
     let shape = well_known_symbol_access_shape(arena, expr_idx)?;
     if identifier_resolves_to_unshadowed_global_in_context(ctx, arena, binder, shape.base, "Symbol")
     {
-        // A `Symbol.<member>` access whose member is a plain (non-unique)
-        // `symbol`-typed global augmentation (xstate's `SymbolConstructor.
-        // observable: symbol`) is not a genuine well-known key; it must not
-        // short-circuit here so callers fall through to binding-identity
-        // (wide-symbol) resolution instead.
-        if wide_well_known_symbol_member_key(ctx, arena, binder, expr_idx).is_some() {
-            return None;
-        }
         shape.name.map(WellKnownSymbolName::Global)
     } else {
         Some(WellKnownSymbolName::Shadowed)
     }
 }
 
-/// `Symbol.<member>` (or `Symbol["<member>"]`, parens peeled) where `<member>`
-/// is a plain (non-unique) `symbol`-typed member of the merged
-/// `SymbolConstructor` interface — a user global augmentation (xstate's
-/// `interface SymbolConstructor { readonly observable: symbol }`) rather than
-/// a genuine well-known (`Symbol.iterator` and friends, `unique symbol`-typed).
-/// Such an access does not carry its own literal `[Symbol.<member>]` key: tsc
-/// routes it into the containing type's symbol index signature exactly like
-/// any other plain-`symbol` binding. `None` for a non-`Symbol.X` shape, a
-/// shadowed `Symbol`, or a genuine well-known/unresolvable member — the
-/// historical literal-key behavior stays default for anything this cannot
-/// positively identify as wide.
-pub(crate) fn wide_well_known_symbol_member_key(
+/// Is `expr_idx` a resolved `Symbol.<member>` (or `Symbol["<member>"]`)
+/// syntactic access — the shape that always mints the canonical
+/// `[Symbol.<member>]` named key regardless of `<member>`'s declared kind?
+/// Used by callers (class instance/static member routing) that need to
+/// exclude this shape from a separate wide-`symbol` classification derived
+/// from the expression's evaluated type, which cannot see the syntactic
+/// override on its own. #16307.
+pub(crate) fn is_well_known_symbol_syntax(
     ctx: &CheckerContext<'_>,
     arena: &NodeArena,
     binder: &BinderState,
     expr_idx: NodeIndex,
-) -> Option<String> {
-    let shape = well_known_symbol_access_shape(arena, expr_idx)?;
-    let name = shape.name?;
-    let member = name.strip_prefix("[Symbol.")?.strip_suffix(']')?;
-    if !identifier_resolves_to_unshadowed_global_in_context(
-        ctx, arena, binder, shape.base, "Symbol",
-    ) {
-        return None;
-    }
-    symbol_constructor_member_is_wide(ctx, member).then(|| format!("__symbol_wellknown_{member}"))
-}
-
-/// Resolve the merged `SymbolConstructor` INTERFACE symbol (the type-space
-/// binding, distinct from the `declare var Symbol: SymbolConstructor` value
-/// symbol). Its `all_declarations()` spans every `interface SymbolConstructor
-/// { ... }` block the binder merged together — the lib declaration plus any
-/// `declare global { interface SymbolConstructor { ... } }` user augmentation
-/// — so walking them finds a member regardless of which file declared it.
-fn symbol_constructor_type_symbol(ctx: &CheckerContext<'_>) -> Option<SymbolId> {
-    crate::types_domain::queries::lib_resolution::resolve_name_to_lib_symbol(
-        "SymbolConstructor",
-        ctx.binder,
-        ctx.global_file_locals_index.as_deref(),
-        ctx.all_binders
-            .as_ref()
-            .map(|binders| binders.as_ref().as_slice()),
-        &ctx.lib_contexts,
-    )
-}
-
-/// Declared symbol-kind of `member_name` on the `interface SymbolConstructor`
-/// declaration at `decl_idx` (an `INTERFACE_DECLARATION` node — interfaces
-/// have no binder-level `members` table; their members only exist as AST
-/// child nodes, so this walks the member list directly): `Some(true)` for
-/// `unique symbol` (a genuine well-known, e.g. `Symbol.iterator`),
-/// `Some(false)` for plain `symbol` (a user global augmentation, e.g.
-/// xstate's `SymbolConstructor.observable: symbol`), `None` when the member
-/// isn't found on this particular declaration or isn't property-shaped (a
-/// method like `for(key: string): symbol`, or a missing annotation).
-fn interface_member_declared_symbol_kind(
-    arena: &NodeArena,
-    decl_idx: NodeIndex,
-    member_name: &str,
-) -> Option<bool> {
-    let node = arena.get(decl_idx)?;
-    let interface = arena.get_interface(node)?;
-    for &member_idx in &interface.members.nodes {
-        let Some(member) = arena.get(member_idx) else {
-            continue;
-        };
-        let Some(sig) = arena.get_signature(member) else {
-            continue;
-        };
-        if arena.get_identifier_text(sig.name) != Some(member_name) {
-            continue;
-        }
-        if !sig.type_annotation.is_some() {
-            return None;
-        }
-        if is_unique_symbol_type_annotation_unwrapped(arena, sig.type_annotation) {
-            return Some(true);
-        }
-        return is_symbol_type_node(arena, sig.type_annotation).then_some(false);
-    }
-    None
-}
-
-/// Declared symbol-kind of `member_name` across every `declare global {
-/// interface SymbolConstructor { ... } }` augmentation the binder recorded.
-/// A `declare global` augmentation is NOT merged into the target symbol's own
-/// `declarations` list (that list holds only the plain lib declarations);
-/// the binder tracks it separately in `global_augmentations`, each entry
-/// carrying the arena it was declared in (`None` means the current file's own
-/// arena) — see `resolve_array_global_augmentation_property` for the same
-/// pattern applied to `Array`.
-fn symbol_constructor_augmentation_kind(
-    ctx: &CheckerContext<'_>,
-    member_name: &str,
-) -> Option<bool> {
-    if let Some(kind) = ctx
-        .binder
-        .global_augmentations
-        .get("SymbolConstructor")
-        .and_then(|augs| {
-            augs.iter().find_map(|aug| {
-                let arena = aug.arena.as_deref().unwrap_or(ctx.arena);
-                interface_member_declared_symbol_kind(arena, aug.node, member_name)
-            })
-        })
-    {
-        return Some(kind);
-    }
-    // Fallback for the rare case where the current file's own binder hasn't
-    // merged another file's augmentation into its `global_augmentations` map.
-    ctx.all_binders.as_ref().and_then(|all_binders| {
-        all_binders.iter().find_map(|binder| {
-            binder
-                .global_augmentations
-                .get("SymbolConstructor")
-                .and_then(|augs| {
-                    augs.iter().find_map(|aug| {
-                        let arena = aug.arena.as_deref().unwrap_or(ctx.arena);
-                        interface_member_declared_symbol_kind(arena, aug.node, member_name)
-                    })
-                })
-        })
-    })
-}
-
-/// Is `member_name` a plain (non-unique) `symbol`-typed member of the merged
-/// `SymbolConstructor` interface — a user global augmentation like xstate's
-/// `interface SymbolConstructor { readonly observable: symbol }` — rather
-/// than a genuine well-known `unique symbol` (`Symbol.iterator` and friends)?
-/// `false` when the member cannot be found at all, preserving the historical
-/// well-known-literal-key behavior for anything this cannot resolve.
-pub(crate) fn symbol_constructor_member_is_wide(
-    ctx: &CheckerContext<'_>,
-    member_name: &str,
 ) -> bool {
-    if let Some(kind) = symbol_constructor_augmentation_kind(ctx, member_name) {
-        return !kind;
-    }
-    let Some(sc_sym_id) = symbol_constructor_type_symbol(ctx) else {
-        return false;
-    };
-    if any_declaration_matches(ctx, sc_sym_id, |_owner_binder, arena, decl_idx| {
-        interface_member_declared_symbol_kind(arena, decl_idx, member_name) == Some(true)
-    }) {
-        return false;
-    }
-    any_declaration_matches(ctx, sc_sym_id, |_owner_binder, arena, decl_idx| {
-        interface_member_declared_symbol_kind(arena, decl_idx, member_name) == Some(false)
-    })
+    matches!(
+        well_known_symbol_property_name(ctx, arena, binder, expr_idx),
+        Some(WellKnownSymbolName::Global(_))
+    )
 }
 
 /// Look up a symbol preferring the binder of its authoritative declaration
@@ -504,28 +375,9 @@ pub(crate) fn symbol_is_unique_symbol_binding(ctx: &CheckerContext<'_>, sym_id: 
 pub(crate) fn symbol_is_wide_symbol_binding(ctx: &CheckerContext<'_>, sym_id: SymbolId) -> bool {
     let sym_id = follow_import_aliases(ctx, sym_id);
     any_declaration_matches(ctx, sym_id, |owner_binder, arena, decl_idx| {
-        (!declaration_is_unique_symbol_binding(ctx, owner_binder, arena, decl_idx)
-            && declaration_has_nonunique_symbol_annotation(arena, decl_idx))
-            || declaration_has_wide_type_query_annotation(ctx, owner_binder, arena, decl_idx)
+        !declaration_is_unique_symbol_binding(ctx, owner_binder, arena, decl_idx)
+            && declaration_has_nonunique_symbol_annotation(arena, decl_idx)
     })
-}
-
-/// Does `decl_idx`'s own type annotation resolve, syntactically, to `typeof
-/// Symbol.<member>` where `<member>` is a plain (non-unique) `symbol`-typed
-/// member of the merged `SymbolConstructor` interface? xstate's own
-/// interop-convention re-export (`export const symbolObservable: typeof
-/// Symbol.observable = ...`) is exactly this shape: the const's annotation is
-/// a type query, not a literal `symbol` keyword, so
-/// `declaration_has_nonunique_symbol_annotation`'s syntactic match on the
-/// annotation node never fires for it.
-fn declaration_has_wide_type_query_annotation(
-    ctx: &CheckerContext<'_>,
-    owner_binder: &BinderState,
-    arena: &NodeArena,
-    decl_idx: NodeIndex,
-) -> bool {
-    declaration_type_query_symbol_constructor_member(ctx, owner_binder, arena, decl_idx)
-        .is_some_and(|member| symbol_constructor_member_is_wide(ctx, &member))
 }
 
 /// The `SymbolConstructor` member a declaration's own annotation names through
@@ -573,16 +425,16 @@ fn declaration_type_query_symbol_constructor_member(
 /// `typeof Symbol.<member>` for a genuine well-known (`unique symbol`) member
 /// — `declare const it: typeof Symbol.iterator; interface T { [it]: ... }`.
 ///
-/// `tsc` types such a binding as the well-known symbol itself (`typeof
-/// Symbol.iterator` is a `unique symbol`), so the member it keys is the very
-/// same one `interface U { [Symbol.iterator]: ... }` declares inline. Without
-/// this leg the alias falls through to binding-identity naming
+/// `tsc` types such a binding as the well-known symbol itself regardless of
+/// `<member>`'s own declared kind on the (possibly user-augmented)
+/// `SymbolConstructor` interface — `typeof Symbol.<member>` is `unique
+/// symbol` purely because of its syntactic reach to the global `Symbol`
+/// (#16307), the same discriminator [`well_known_symbol_property_name`] uses
+/// for the inline `Symbol.<member>` spelling. So the member it keys is the
+/// very same one `interface U { [Symbol.iterator]: ... }` declares inline.
+/// Without this leg the alias falls through to binding-identity naming
 /// (`__unique_<id>`), the two declarations describe different member sets, and
 /// `T` reports a missing `[Symbol.iterator]` against `U` where `tsc` is clean.
-///
-/// `None` for a plain (non-`unique`) `SymbolConstructor` member: that binding
-/// carries the wide `symbol` type and routes into the containing type's symbol
-/// index signature instead (#16307), which is a different member shape.
 pub(crate) fn type_query_well_known_symbol_key(
     ctx: &CheckerContext<'_>,
     sym_id: SymbolId,
@@ -595,9 +447,6 @@ pub(crate) fn type_query_well_known_symbol_key(
         else {
             return false;
         };
-        if symbol_constructor_member_is_wide(ctx, &member) {
-            return false;
-        }
         *found.borrow_mut() = Some(format!("[Symbol.{member}]"));
         true
     });
@@ -897,7 +746,6 @@ pub(crate) fn symbol_binding_property_atom(
     any_declaration_matches(ctx, sym_id, |owner_binder, arena, decl_idx| {
         declaration_is_unique_symbol_binding(ctx, owner_binder, arena, decl_idx)
             || declaration_has_nonunique_symbol_annotation(arena, decl_idx)
-            || declaration_has_wide_type_query_annotation(ctx, owner_binder, arena, decl_idx)
     })
     .then(|| ctx.types.intern_string(&unique_symbol_binding_name(sym_id)))
 }
@@ -935,7 +783,6 @@ pub(crate) fn computed_property_name_atom_in_arena(
             && identifier_resolves_to_unshadowed_global_in_context(
                 ctx, arena, binder, parts.base, "Symbol",
             )
-            && !symbol_constructor_member_is_wide(ctx, member)
         {
             return Some(ctx.types.intern_string(&format!("[Symbol.{member}]")));
         }

--- a/crates/tsz-checker/tests/well_known_symbol_type_query_alias_key_tests.rs
+++ b/crates/tsz-checker/tests/well_known_symbol_type_query_alias_key_tests.rs
@@ -10,12 +10,17 @@
 //! `U` described different member sets and `T` reported a missing
 //! `[Symbol.iterator]` against `U` where `tsc` is clean.
 //!
-//! Two boundaries the rule must not cross, both oracle-checked:
-//! - An UNANNOTATED `const it = Symbol.iterator` widens to `symbol`, so it
-//!   keys a symbol index signature, not the well-known member. `tsc` reports
-//!   the mismatch against an inline `[Symbol.iterator]` member; so must tsz.
-//! - A `typeof Symbol.<member>` alias for a PLAIN (non-`unique`) augmented
-//!   member keeps #16307's wide-`symbol` index-signature routing.
+//! One boundary the rule must not cross, oracle-checked: an UNANNOTATED
+//! `const it = Symbol.iterator` widens to `symbol`, so it keys a symbol index
+//! signature, not the well-known member. `tsc` reports the mismatch against
+//! an inline `[Symbol.iterator]` member; so must tsz.
+//!
+//! `typeof Symbol.<member>` is `unique symbol` to `tsc` — and so names the
+//! canonical `[Symbol.<member>]` member — regardless of `<member>`'s own
+//! declared kind on a (possibly user-augmented) `SymbolConstructor`. A PLAIN
+//! (non-`unique`) augmented member is NOT an exception: `tsc`'s discriminator
+//! is the syntactic reach to the global `Symbol`, never the member's declared
+//! type (#16307).
 //!
 //! Binder names vary across cases on purpose: the rule reads the declaration's
 //! annotation, never the identifier the user chose.
@@ -182,13 +187,19 @@ want(widened);
     );
 }
 
-// 8. Boundary: a `typeof Symbol.<member>` alias for a PLAIN (non-`unique`)
-//    augmented member keeps #16307's wide-`symbol` index-signature routing —
-//    a class keyed through it stays assignable to an interface keyed off an
-//    unrelated wide `symbol` binding.
+// 8. Boundary (oracle-verified against pinned `tsc` 7.0.2, corrected from an
+//    earlier premise): a `typeof Symbol.<member>` alias for a PLAIN
+//    (non-`unique`) augmented member is STILL the well-known member, not a
+//    wide-`symbol` binding — `typeof Symbol.observable` types as `unique
+//    symbol` to `tsc` even when `SymbolConstructor.observable` is declared
+//    plain `symbol`. A class keyed through it therefore does NOT structurally
+//    satisfy an interface keyed off an unrelated wide `symbol` binding: `tsc`
+//    reports the missing index signature (`Argument of type 'Emitter' is not
+//    assignable to parameter of type 'Sink'. Index signature for type
+//    'symbol' is missing in type 'Emitter'.`).
 #[test]
-fn type_query_alias_of_a_wide_augmented_member_keeps_index_signature_routing() {
-    assert_no_missing_property(
+fn type_query_alias_of_a_wide_augmented_member_keeps_named_identity() {
+    let result = codes(
         r#"
 interface SymbolConstructor { readonly observable: symbol }
 declare const observableKey: typeof Symbol.observable;
@@ -199,5 +210,11 @@ declare const emitter: Emitter;
 declare function want(value: Sink): void;
 want(emitter);
 "#,
+    );
+    assert!(
+        result.contains(&2345) || result.contains(&2741),
+        "a typeof Symbol.<member> alias for a plain-`symbol`-augmented member \
+         must keep its well-known named identity, not fold into an unrelated \
+         wide-`symbol` index signature, got: {result:?}"
     );
 }

--- a/crates/tsz-checker/tests/wide_symbol_computed_member_index_signature_tests.rs
+++ b/crates/tsz-checker/tests/wide_symbol_computed_member_index_signature_tests.rs
@@ -1,6 +1,11 @@
 //! Adjacent-case matrix for issue #16307: a computed member keyed by a plain
-//! (non-unique) `symbol` must route into the containing type's symbol index
-//! signature, not mint a synthetic named member.
+//! (non-unique) `symbol` BINDING (`declare const s: symbol`) must route into
+//! the containing type's symbol index signature, not mint a synthetic named
+//! member. `Symbol.<member>` written as literal property-access syntax is a
+//! DIFFERENT shape and stays a named `[Symbol.<member>]` member regardless of
+//! `<member>`'s own declared kind on a (possibly user-augmented)
+//! `SymbolConstructor` — `tsc`'s `isWellKnownSymbolSyntactically` decides
+//! purely from the syntax, never the member's type.
 use tsz_checker::CheckerOptions;
 use tsz_checker::test_utils::{
     check_multi_file_with_libs, check_source_diagnostics, check_source_with_libs,
@@ -9,12 +14,6 @@ use tsz_checker::test_utils::{
 
 fn assert_clean(source: &str) {
     let diags = check_source_diagnostics(source);
-    assert!(diags.is_empty(), "expected exit 0 like tsc, got: {diags:?}");
-}
-
-fn assert_clean_with_libs(source: &str) {
-    let libs = load_default_lib_files();
-    let diags = check_source_with_libs(source, "test.ts", CheckerOptions::default(), &libs);
     assert!(diags.is_empty(), "expected exit 0 like tsc, got: {diags:?}");
 }
 
@@ -134,14 +133,21 @@ export const bad: FromU2 = a;
 }
 
 #[test]
-fn well_known_symbol_syntax_keyed_by_a_wide_global_augmentation_routes_to_index() {
-    // Adjacent case for #16307's own corpus witness (xstate's `Symbol.
-    // observable` interop convention): the literal `Symbol.<member>` syntax
-    // — not an identifier alias — routes to the symbol index signature when
-    // `<member>` is a user global augmentation typed plain `symbol`, exactly
-    // like the identifier-keyed cases above.
-    assert_clean_with_libs(
-        r#"
+fn well_known_symbol_syntax_keeps_named_identity_even_with_a_wide_global_augmentation() {
+    // Corrected adjacent case for #16307 (oracle-verified against pinned
+    // `tsc` 7.0.2, both directions): the literal `Symbol.<member>` syntax —
+    // unlike an identifier bound `: symbol` — is ALWAYS the well-known symbol
+    // itself, regardless of what `<member>` is declared as on a (possibly
+    // user-augmented) `SymbolConstructor`. `isWellKnownSymbolSyntactically`
+    // decides this from the syntax alone, before tsc ever looks at the
+    // member's type. So `[Symbol.observable]` mints the literal
+    // `[Symbol.observable]` NAMED member even when the global augmentation
+    // types `observable` as plain `symbol` — it does NOT fold into a symbol
+    // index signature, and an interface built that way stays mutually
+    // UN-assignable with a real `[key: symbol]` index-signature interface in
+    // both directions, exactly like the real well-known (`Symbol.iterator`)
+    // negative control below.
+    let source = r#"
 declare global {
   interface SymbolConstructor {
     readonly observable: symbol;
@@ -156,7 +162,15 @@ declare const i: Implicit;
 
 export const implicitToExplicit: Explicit = i;
 export const explicitToImplicit: Implicit = e;
-"#,
+"#;
+    let libs = load_default_lib_files();
+    let diags = check_source_with_libs(source, "test.ts", CheckerOptions::default(), &libs);
+    let codes: Vec<u32> = diags.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&2322) && codes.contains(&2741),
+        "Symbol.observable must keep its own named identity even under a wide \
+         global augmentation, so BOTH directions must mismatch (missing index \
+         signature one way, missing named member the other); got: {diags:?}"
     );
 }
 
@@ -238,15 +252,14 @@ declare global { interface SymbolConstructor { readonly observable: symbol } }
 }
 
 #[test]
-fn well_known_symbol_syntax_direct_on_class_member_same_file() {
-    // A class member keyed DIRECTLY by `[Symbol.observable]` (not via an
-    // identifier alias) implementing an interface with the same literal key.
-    // Class instance-type construction routed an unresolved computed name's
-    // string/number key kind into `string_index`/`number_index` but had no
-    // symbol leg at all (`merge_index_signature_from_unresolved_computed_name`,
-    // `crates/tsz-checker/src/types/class_type/helpers.rs`), so a wide-symbol
-    // class member silently contributed to no index signature and the class
-    // failed to structurally satisfy an interface with a symbol index.
+fn well_known_symbol_syntax_direct_on_class_member_keeps_named_identity() {
+    // Corrected adjacent case for #16307 (oracle-verified against pinned
+    // `tsc` 7.0.2): a class member keyed DIRECTLY by `[Symbol.observable]`
+    // (not via an identifier alias) mints its own named `[Symbol.observable]`
+    // member — same rule as the interface case above — even though the
+    // global augmentation types `observable` as plain `symbol`. It does NOT
+    // structurally satisfy an unrelated `[key: symbol]` index-signature
+    // interface.
     let source = r#"
 declare global {
   interface SymbolConstructor {
@@ -265,7 +278,13 @@ export const implicitToExplicit: Explicit = i;
 "#;
     let libs = load_default_lib_files();
     let diags = check_source_with_libs(source, "test.ts", CheckerOptions::default(), &libs);
-    assert!(diags.is_empty(), "expected exit 0 like tsc, got: {diags:?}");
+    assert!(
+        diags.iter().any(|d| d.code == 2322 || d.code == 2741),
+        "Symbol.observable on a class member must keep its own named identity \
+         even under a wide global augmentation, so the class must NOT \
+         structurally satisfy an unrelated symbol-index-signature interface; \
+         got: {diags:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Remaining leg of #16307, root-caused by Peridot at https://github.com/tsz-org/tsz/issues/16307#issuecomment-5175385235 and left unclaimed after #16348 landed the `typeof Symbol.X` alias leg.

Structural rule: when a computed name is spelled `Symbol.member` (inline, or through a `typeof Symbol.member`-annotated binding), `tsc` mints the literal `[Symbol.member]` named member unconditionally, purely from the syntactic reach to the global `Symbol` (`isWellKnownSymbolSyntactically`) — it never consults the member's own declared type. tsz owns this decision through `crates/tsz-checker/src/types/computed_names.rs`'s `well_known_symbol_property_name`/`type_query_well_known_symbol_key`, the checker's single declared owner for this policy per the module's own doc comment.

#16326/#16348 keyed this off the member's declared kind on the (possibly user-augmented) `SymbolConstructor` interface instead: a wide `symbol`-typed global augmentation — xstate's own `interface SymbolConstructor { readonly observable: symbol }` interop convention, the corpus witness #16307 was originally filed against — made `Symbol.observable` fold into a `[key: symbol]` index signature instead of minting its own named member. That is backwards from `tsc` and a live false negative (missing `TS7053`/`TS2322`), confirmed against the pinned `typescript@7.0.2` oracle across five independent producers: interface/type-literal lowering, class instance members, class static members, index-signature assignability, and object literals.

## Fix

Deletes `wide_well_known_symbol_member_key` and `symbol_constructor_member_is_wide` (and their now-dead support helpers `symbol_constructor_type_symbol`, `interface_member_declared_symbol_kind`, `symbol_constructor_augmentation_kind`) and simplifies `well_known_symbol_property_name` and `type_query_well_known_symbol_key` to answer the canonical well-known key for every resolved `Symbol.member` access unconditionally. `computed_member_key_is_wide_symbol` (`object_literal/symbol_key_routing.rs`), shared by object literals and class routing per its own doc comment, gets the same syntactic exclusion — which lets both class-routing call sites (`class_member_computed_key_is_wide_symbol`, `static_member_computed_key_is_wide_symbol`) drop their now-redundant duplicate check.

## Adjacent-case matrix

All rows oracle-verified against pinned `tsc@7.0.2` (not just read from source — the pinned native compiler ships no readable JS):

| Shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `interface I { [Symbol.observable]: number }`, read `i[other]` | `TS7053` | clean (bug) | `TS7053` |
| `class C { [Symbol.observable]() {} }`, read `c[other]` | `TS7053` | clean (bug) | `TS7053` |
| `class C { static [Symbol.observable]() {} }`, read `C[other]` | `TS7053` | `TS2538` (wrong code) | `TS7053` |
| `const t: { [k: symbol]: number } = i` (i: `{ [Symbol.observable]: number }`) | `TS2322` | clean (bug) | `TS2322` |
| `{ [Symbol.observable]: 1 }` object literal, read `o[other]` | `TS7053` | clean (bug) | `TS7053` |
| `const alias: typeof Symbol.observable; class Actor { [alias]() {} }` implements interface keyed `[Symbol.observable]` (the xstate interop convention #16307/#16348 fixed) | clean | clean | clean (unchanged) |
| `declare const wide: symbol; class Impl { [wide]() {} }` — bare `: symbol` binding, unrelated to `Symbol.X` syntax | wide index signature | wide index signature | wide index signature (unchanged) |
| `Symbol.iterator` (genuine `unique symbol`, no augmentation) | named member | named member | named member (unchanged) |

Two existing integration tests directly asserted the old, oracle-disproven premise (`well_known_symbol_syntax_keyed_by_a_wide_global_augmentation_routes_to_index`, `well_known_symbol_syntax_direct_on_class_member_same_file`, and `type_query_alias_of_a_wide_augmented_member_keeps_index_signature_routing`) and are corrected in place with fresh oracle evidence recorded in their doc comments and assertions.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib -- symbol`: 446/446 passed (unaffected).
- `cargo test -p tsz-checker --test wide_symbol_computed_member_index_signature_tests`: 11/11 passed (2 corrected in place).
- `cargo test -p tsz-checker --test well_known_symbol_type_query_alias_key_tests`: 8/8 passed (1 corrected in place).
- 13 additional directly-relevant integration test files (`class_implements_index_signature_tests`, `symbol_index_signature_tests`, `ts2300_tests`, `keyof_well_known_symbol_key_tests`, `reexported_symbol_keyed_member_tests`, etc.): all pass except two **pre-existing** failures confirmed unrelated by reproducing them identically on unmodified `main` (`duplicate_property_modifier_ts2687_tests::computed_names_resolving_to_same_value_report_ts2687_without_ts2300`, and `reexported_symbol_keyed_member_tests::direct_import_symbol_keyed_member_is_clean`, the long-open #15983 cross-file symbol-overlay issue).
- `cargo clippy -p tsz-checker --lib --all-targets -- -D warnings`: clean.
- `cargo fmt -p tsz-checker -- --check`: clean.
- `python3 scripts/arch/arch_guard.py`: passes.
- Manual oracle comparison (pinned `typescript@7.0.2` via `npm i typescript@7.0.2`) across all 8 adjacent-case rows above: tsz matches tsc on diagnostic code, position, and direction for every row.
- Emit gate not run: `crates/tsz-emitter` has zero references to any touched function/module (grep-confirmed) — this is a checker-only member-key/type-identity decision that the emitter, which owns output and never validates semantics per the architecture contract, cannot see.
- `scripts/conformance/compare-to-parent.sh` (two-sided, base `110ca66`): running; numbers to follow in a comment once it completes.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT