### PR TITLE
fix(checker): TS1356 "Did you mean to mark this function as 'async'?" pointer on TS1308/TS1103

### DIFF
--- a/crates/tsz-checker/src/error_reporter/async_suggestion.rs
+++ b/crates/tsz-checker/src/error_reporter/async_suggestion.rs
@@ -1,0 +1,283 @@
+//! The TS1356 `Did you mean to mark this function as 'async'?` pointer that
+//! `tsc` attaches to an `await`-outside-`async` grammar error.
+//!
+//! `tsc`'s `checkAwaitExpression` (TS1308) and `checkGrammarForInOrOfStatement`
+//! (TS1103) both build their diagnostic, then look up
+//! `getContainingFunction(node)` and — when that container exists, is not a
+//! constructor, and does not carry `async` — attach
+//! `Did_you_mean_to_mark_this_function_as_async` as `relatedInformation`
+//! anchored on `getErrorSpanForNode(container)`.
+//!
+//! It is a cross-location pointer, not a message-chain link: `tsc --pretty`
+//! prints it with its own location and snippet while `tsc --pretty false`
+//! prints nothing for it. So it is tagged
+//! [`RelatedInformationKind::LocationPointer`](tsz_common::diagnostics::RelatedInformationKind::LocationPointer)
+//! and plain-mode output is unchanged by it.
+
+use crate::diagnostics::{Diagnostic, DiagnosticRelatedInformation, diagnostic_codes};
+use crate::state::CheckerState;
+use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
+use tsz_scanner::SyntaxKind;
+
+/// How far up the parent chain the containing-function search walks before
+/// giving up. `getContainingFunction` is unbounded in `tsc`; the walk here is
+/// capped so a malformed parent chain cannot spin, and the cap is far above
+/// the nesting any real expression puts between an `await` and its function
+/// (parenthesis/binary/call/argument levels).
+const CONTAINING_FUNCTION_WALK_LIMIT: usize = 256;
+
+impl CheckerState<'_> {
+    /// The TS1356 related-information entry for an `await` grammar error at
+    /// `node_idx`, or an empty vector when `tsc` attaches none.
+    ///
+    /// Empty for a top-level `await` (no containing function), for a
+    /// constructor body (`tsc` excludes `SyntaxKind.Constructor` explicitly),
+    /// and for an `async` container — the last one is reachable through a
+    /// position that does not inherit the container's await context, such as a
+    /// parameter initializer.
+    pub(crate) fn did_you_mean_async_related(
+        &self,
+        node_idx: NodeIndex,
+    ) -> Vec<DiagnosticRelatedInformation> {
+        let Some(func_idx) = self.containing_function_like(node_idx) else {
+            return Vec::new();
+        };
+        let Some(func_node) = self.ctx.arena.get(func_idx) else {
+            return Vec::new();
+        };
+        if func_node.kind == syntax_kind_ext::CONSTRUCTOR || self.function_like_is_async(func_idx) {
+            return Vec::new();
+        }
+        let Some((start, length)) = self.function_like_error_span(func_idx) else {
+            return Vec::new();
+        };
+        vec![Diagnostic::related_pointer(
+            diagnostic_codes::DID_YOU_MEAN_TO_MARK_THIS_FUNCTION_AS_ASYNC,
+            self.ctx.file_name.clone(),
+            start,
+            length,
+            crate::diagnostics::diagnostic_messages::DID_YOU_MEAN_TO_MARK_THIS_FUNCTION_AS_ASYNC,
+        )]
+    }
+
+    /// `tsc`'s `getContainingFunction`: the nearest function-like ancestor,
+    /// arrows and accessors included, constructors included (the caller
+    /// filters those out the way `tsc` does).
+    fn containing_function_like(&self, node_idx: NodeIndex) -> Option<NodeIndex> {
+        let mut current = node_idx;
+        for _ in 0..CONTAINING_FUNCTION_WALK_LIMIT {
+            let parent = self.ctx.arena.get_extended(current)?.parent;
+            if parent.is_none() {
+                return None;
+            }
+            let parent_node = self.ctx.arena.get(parent)?;
+            if matches!(
+                parent_node.kind,
+                syntax_kind_ext::FUNCTION_DECLARATION
+                    | syntax_kind_ext::FUNCTION_EXPRESSION
+                    | syntax_kind_ext::ARROW_FUNCTION
+                    | syntax_kind_ext::METHOD_DECLARATION
+                    | syntax_kind_ext::CONSTRUCTOR
+                    | syntax_kind_ext::GET_ACCESSOR
+                    | syntax_kind_ext::SET_ACCESSOR
+            ) {
+                return Some(parent);
+            }
+            current = parent;
+        }
+        None
+    }
+
+    /// Whether a function-like node carries `async`.
+    fn function_like_is_async(&self, func_idx: NodeIndex) -> bool {
+        let Some(func_node) = self.ctx.arena.get(func_idx) else {
+            return false;
+        };
+        if let Some(func) = self.ctx.arena.get_function(func_node) {
+            return func.is_async;
+        }
+        if let Some(method) = self.ctx.arena.get_method_decl(func_node) {
+            return self
+                .ctx
+                .arena
+                .has_modifier(&method.modifiers, SyntaxKind::AsyncKeyword);
+        }
+        self.ctx
+            .arena
+            .get_accessor(func_node)
+            .is_some_and(|accessor| {
+                self.ctx
+                    .arena
+                    .has_modifier(&accessor.modifiers, SyntaxKind::AsyncKeyword)
+            })
+    }
+
+    /// `tsc`'s `getErrorSpanForNode` for a function-like node.
+    ///
+    /// A named declaration answers with its name (a computed member name
+    /// included, as the whole `[expr]` node). An arrow answers through
+    /// [`Self::arrow_error_span`]. An anonymous function expression answers
+    /// with the name it is assigned to, when it has one, and otherwise with
+    /// its first token — the `function` keyword.
+    fn function_like_error_span(&self, func_idx: NodeIndex) -> Option<(u32, u32)> {
+        let func_node = self.ctx.arena.get(func_idx)?;
+        if func_node.kind == syntax_kind_ext::ARROW_FUNCTION {
+            return self.arrow_error_span(func_idx);
+        }
+
+        let name_idx = self.function_like_name(func_idx);
+        if name_idx.is_some()
+            && let Some(span) = self.name_node_span(name_idx)
+        {
+            return Some(span);
+        }
+
+        if let Some(assigned) = self.assigned_name_span(func_idx) {
+            return Some(assigned);
+        }
+
+        let (start, end) = self.get_node_span(func_idx)?;
+        let keyword_len = tsz_scanner::keyword_text_len(SyntaxKind::FunctionKeyword);
+        Some((start, keyword_len.min(end.saturating_sub(start))))
+    }
+
+    /// The declared name node of a function-like, for the kinds that have one.
+    fn function_like_name(&self, func_idx: NodeIndex) -> NodeIndex {
+        let Some(func_node) = self.ctx.arena.get(func_idx) else {
+            return NodeIndex::NONE;
+        };
+        if let Some(func) = self.ctx.arena.get_function(func_node) {
+            return func.name;
+        }
+        if let Some(method) = self.ctx.arena.get_method_decl(func_node) {
+            return method.name;
+        }
+        self.ctx
+            .arena
+            .get_accessor(func_node)
+            .map_or(NodeIndex::NONE, |accessor| accessor.name)
+    }
+
+    /// `tsc`'s `getAssignedName`: the name an anonymous function expression is
+    /// bound to by its immediate parent.
+    ///
+    /// Covers the four parent shapes `tsc` covers — a variable declaration, a
+    /// binding element, an object-literal property assignment, and the right
+    /// operand of an assignment. A class property initializer is deliberately
+    /// **not** one of them (`class C { p = function () {} }` answers with the
+    /// `function` keyword, oracle-confirmed), so this reads the parent kind
+    /// rather than looking for any enclosing named declaration.
+    fn assigned_name_span(&self, func_idx: NodeIndex) -> Option<(u32, u32)> {
+        let parent_idx = self.ctx.arena.get_extended(func_idx)?.parent;
+        let parent_node = self.ctx.arena.get(parent_idx)?;
+
+        let name_idx = match parent_node.kind {
+            syntax_kind_ext::VARIABLE_DECLARATION => {
+                let decl = self.ctx.arena.get_variable_declaration(parent_node)?;
+                (decl.initializer == func_idx).then_some(decl.name)?
+            }
+            syntax_kind_ext::BINDING_ELEMENT => {
+                let element = self.ctx.arena.get_binding_element(parent_node)?;
+                (element.initializer == func_idx).then_some(element.name)?
+            }
+            syntax_kind_ext::PROPERTY_ASSIGNMENT => {
+                let assignment = self.ctx.arena.get_property_assignment(parent_node)?;
+                (assignment.initializer == func_idx).then_some(assignment.name)?
+            }
+            syntax_kind_ext::BINARY_EXPRESSION => {
+                let binary = self.ctx.arena.get_binary_expr(parent_node)?;
+                if binary.right != func_idx
+                    || binary.operator_token != SyntaxKind::EqualsToken as u16
+                    || !self.is_assignment_target_name(binary.left)
+                {
+                    return None;
+                }
+                binary.left
+            }
+            _ => return None,
+        };
+
+        self.name_node_span(name_idx)
+    }
+
+    /// The span of a declaration name node, through the shared anchor policy
+    /// so an identifier is trimmed to the identifier itself rather than to the
+    /// token that follows it, and a computed name keeps its whole `[expr]`.
+    fn name_node_span(&self, name_idx: NodeIndex) -> Option<(u32, u32)> {
+        let (start, end) = self.get_node_span(name_idx)?;
+        Some(self.normalized_anchor_span(name_idx, start, end.saturating_sub(start)))
+    }
+
+    /// Whether an assignment's left operand is a name `tsc`'s `getAssignedName`
+    /// would answer with: a bare identifier or an access expression.
+    fn is_assignment_target_name(&self, left_idx: NodeIndex) -> bool {
+        self.ctx.arena.get(left_idx).is_some_and(|left| {
+            left.kind == SyntaxKind::Identifier as u16
+                || left.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+                || left.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+        })
+    }
+
+    /// `tsc`'s `getErrorSpanForArrowFunction`: the whole arrow, except that an
+    /// arrow whose block body spans more than one line is trimmed to its
+    /// header — everything up to and including the body's opening brace — so
+    /// the pointer stays on one line.
+    fn arrow_error_span(&self, arrow_idx: NodeIndex) -> Option<(u32, u32)> {
+        let (start, end) = self.get_node_span(arrow_idx)?;
+        let arrow_node = self.ctx.arena.get(arrow_idx)?;
+        let body_idx = self
+            .ctx
+            .arena
+            .get_function(arrow_node)
+            .map_or(NodeIndex::NONE, |func| func.body);
+        let body_span = self
+            .ctx
+            .arena
+            .get(body_idx)
+            .and_then(|body_node| Some((body_node.kind, self.get_node_span(body_idx)?)));
+
+        if let Some((body_kind, (body_start, body_end))) = body_span
+            && body_kind == syntax_kind_ext::BLOCK
+            && self.span_spans_multiple_lines(body_start, body_end)
+            && body_start >= start
+        {
+            return Some((start, body_start.saturating_sub(start) + 1));
+        }
+
+        Some((
+            start,
+            self.trimmed_span_end(start, end).saturating_sub(start),
+        ))
+    }
+
+    /// An arrow's stored `end` runs to the end of the token that closes the
+    /// construct it sits in, so a statement's `;` lands inside the node's span
+    /// (the same over-extension family as the close-brace positions fixed in
+    /// tsz#16259, recorded for this position in tsz#16360). `tsc` anchors on the arrow's own last token, so the span is
+    /// trimmed back over trailing separators and whitespace before it is used
+    /// as a pointer.
+    fn trimmed_span_end(&self, start: u32, end: u32) -> u32 {
+        let Some(text) = self
+            .ctx
+            .arena
+            .source_files
+            .first()
+            .and_then(|file| file.text.get(start as usize..end as usize))
+        else {
+            return end;
+        };
+        let trimmed = text.trim_end_matches([';', ',', ' ', '\t', '\r', '\n']);
+        start + trimmed.len() as u32
+    }
+
+    /// Whether the source between two offsets contains a line break — the
+    /// offset-level form of `tsc`'s `startLine < endLine` comparison.
+    fn span_spans_multiple_lines(&self, start: u32, end: u32) -> bool {
+        self.ctx
+            .arena
+            .source_files
+            .first()
+            .and_then(|file| file.text.get(start as usize..end as usize))
+            .is_some_and(|text| text.contains('\n'))
+    }
+}

--- a/crates/tsz-checker/src/error_reporter/mod.rs
+++ b/crates/tsz-checker/src/error_reporter/mod.rs
@@ -26,6 +26,7 @@ mod assignability_numeric_display;
 mod assignability_satisfies;
 mod assignability_type_helpers;
 mod assignability_type_parameter_target;
+mod async_suggestion;
 mod call_errors;
 mod call_errors_anchors;
 mod conditional_alias_display;

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -235,6 +235,8 @@ mod destructuring_relation_routing_arch_tests;
 mod diagnostic_sink_message_surgery_arch_tests;
 #[path = "tests/diagnostic_source_relation_routing_arch_tests.rs"]
 mod diagnostic_source_relation_routing_arch_tests;
+#[path = "tests/did_you_mean_async_related_tests.rs"]
+mod did_you_mean_async_related_tests;
 #[path = "tests/direct_generic_return_tests.rs"]
 mod direct_generic_return_tests;
 #[path = "tests/dispatch_tests.rs"]

--- a/crates/tsz-checker/src/tests/did_you_mean_async_related_tests.rs
+++ b/crates/tsz-checker/src/tests/did_you_mean_async_related_tests.rs
@@ -1,0 +1,263 @@
+//! Regression tests for the `TS1356` `Did you mean to mark this function as
+//! 'async'?` pointer that tsc pairs with `TS1308` (`await` outside `async`)
+//! and `TS1103` (`for await` outside `async`).
+//!
+//! Structural rule (pinned against `typescript@7.0.2`, the conformance pin):
+//! after building either diagnostic, tsc looks up `getContainingFunction` and
+//! attaches the TS1356 related-information entry when that container exists,
+//! is not a constructor, and does not carry `async`. The anchor is
+//! `getErrorSpanForNode(container)` — the declared name where there is one,
+//! the assigned name for an anonymous function expression, and the arrow
+//! itself (trimmed to its header when its block body is multi-line) for an
+//! arrow.
+//!
+//! The entry is a cross-location pointer, not a message-chain link: tsc
+//! `--pretty` prints it with its own location and snippet while tsc
+//! `--pretty false` prints nothing for it. `location_pointer_keeps_plain_mode_
+//! output_unchanged` pins that tag, which is what keeps plain-mode (and so
+//! conformance) output byte-identical.
+//!
+//! tsz builds the pointer in `error_reporter/async_suggestion.rs`, reached
+//! from the two await-grammar sites in
+//! `types/type_checking/core_statement_checks.rs`.
+
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::check_source_diagnostics;
+use tsz_common::diagnostics::diagnostic_codes;
+
+const TS1103: u32 = diagnostic_codes::FOR_AWAIT_LOOPS_ARE_ONLY_ALLOWED_WITHIN_ASYNC_FUNCTIONS_AND_AT_THE_TOP_LEVELS_OF;
+const TS1308: u32 =
+    diagnostic_codes::AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WITHIN_ASYNC_FUNCTIONS_AND_AT_THE_TOP_LEVELS;
+const TS1356: u32 = diagnostic_codes::DID_YOU_MEAN_TO_MARK_THIS_FUNCTION_AS_ASYNC;
+
+fn only(diags: &[Diagnostic], code: u32) -> Diagnostic {
+    let matching: Vec<_> = diags.iter().filter(|d| d.code == code).collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected exactly one TS{code}; got {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+    matching[0].clone()
+}
+
+/// The text the TS1356 pointer covers, so each case asserts the anchor lands
+/// exactly where tsc's does rather than merely existing.
+fn pointer_text(source: &str, diagnostic: &Diagnostic) -> String {
+    let pointers: Vec<_> = diagnostic
+        .related_information
+        .iter()
+        .filter(|info| info.code == TS1356)
+        .collect();
+    assert_eq!(
+        pointers.len(),
+        1,
+        "expected exactly one TS1356 pointer; got {:?}",
+        diagnostic
+            .related_information
+            .iter()
+            .map(|info| (info.code, info.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+    let pointer = pointers[0];
+    assert_eq!(
+        pointer.message_text,
+        "Did you mean to mark this function as 'async'?"
+    );
+    source[pointer.start as usize..(pointer.start + pointer.length) as usize].to_string()
+}
+
+fn ts1308_pointer_text(source: &str) -> String {
+    let diagnostic = only(&check_source_diagnostics(source), TS1308);
+    pointer_text(source, &diagnostic)
+}
+
+fn ts1308_related_codes(source: &str) -> Vec<u32> {
+    only(&check_source_diagnostics(source), TS1308)
+        .related_information
+        .iter()
+        .map(|info| info.code)
+        .collect()
+}
+
+#[test]
+fn function_declaration_points_at_its_name() {
+    let source = "function fetchIt() { const x = await 1; return x; }\n";
+    assert_eq!(ts1308_pointer_text(source), "fetchIt");
+}
+
+/// Binder-name variation: the anchor is derived from the declaration, never
+/// from any particular identifier text.
+#[test]
+fn renamed_function_declaration_points_at_its_own_name() {
+    let source = "function zzz_other_name() { const x = await 1; return x; }\n";
+    assert_eq!(ts1308_pointer_text(source), "zzz_other_name");
+}
+
+#[test]
+fn generator_declaration_points_at_its_name() {
+    let source = "function* gen() { const d = await 5; return d; }\n";
+    assert_eq!(ts1308_pointer_text(source), "gen");
+}
+
+#[test]
+fn named_function_expression_points_at_its_own_name() {
+    let source = "const inner = function nested() { return await 1; };\n";
+    assert_eq!(ts1308_pointer_text(source), "nested");
+}
+
+#[test]
+fn anonymous_function_expression_points_at_the_variable_it_is_assigned_to() {
+    let source = "const g = function () { return await 1; };\n";
+    assert_eq!(ts1308_pointer_text(source), "g");
+}
+
+#[test]
+fn anonymous_function_expression_points_at_the_property_it_is_assigned_to() {
+    let source = "const po = { p: function () { return await 3; } };\n";
+    assert_eq!(ts1308_pointer_text(source), "p");
+}
+
+#[test]
+fn anonymous_function_expression_points_at_the_assignment_target() {
+    let source = "let assigned;\nassigned = function () { return await 4; };\n";
+    assert_eq!(ts1308_pointer_text(source), "assigned");
+}
+
+/// A class property initializer is **not** one of `getAssignedName`'s parent
+/// shapes, so the anchor falls back to the `function` keyword rather than the
+/// property name — oracle-confirmed, and the reason the assigned-name lookup
+/// reads the parent kind instead of the nearest named declaration.
+#[test]
+fn unassigned_function_expression_points_at_the_function_keyword() {
+    let source = "const r = (function () { return await 1; })();\n";
+    assert_eq!(ts1308_pointer_text(source), "function");
+}
+
+#[test]
+fn class_property_function_expression_points_at_the_function_keyword() {
+    let source = "class D { p = function () { return await 2; }; }\n";
+    assert_eq!(ts1308_pointer_text(source), "function");
+}
+
+#[test]
+fn single_line_arrow_points_at_the_whole_arrow() {
+    let source = "const one = () => { return await 2; };\n";
+    assert_eq!(ts1308_pointer_text(source), "() => { return await 2; }");
+}
+
+#[test]
+fn concise_body_arrow_points_at_the_whole_arrow() {
+    let source = "const h = () => await 2;\n";
+    assert_eq!(ts1308_pointer_text(source), "() => await 2");
+}
+
+/// tsc trims a multi-line arrow to its header so the pointer stays on one
+/// line: everything up to and including the body's opening brace.
+#[test]
+fn multi_line_arrow_points_at_its_header_only() {
+    let source = "const multi = () => {\n  return await 1;\n};\n";
+    assert_eq!(ts1308_pointer_text(source), "() => {");
+}
+
+#[test]
+fn method_declaration_points_at_its_name() {
+    let source = "class C { m() { const b = await 2; return b; } }\n";
+    assert_eq!(ts1308_pointer_text(source), "m");
+}
+
+#[test]
+fn object_literal_method_points_at_its_name() {
+    let source = "const o = { m() { return await 1; } };\n";
+    assert_eq!(ts1308_pointer_text(source), "m");
+}
+
+#[test]
+fn getter_points_at_its_name() {
+    let source = "const obj = { get g() { return await 4; } };\n";
+    assert_eq!(ts1308_pointer_text(source), "g");
+}
+
+#[test]
+fn computed_method_name_points_at_the_whole_computed_name() {
+    let source = "declare const k: string;\nconst cm = { [k]() { return await 5; } };\n";
+    assert_eq!(ts1308_pointer_text(source), "[k]");
+}
+
+/// tsc excludes `SyntaxKind.Constructor` from the suggestion outright — a
+/// constructor cannot be made `async`.
+#[test]
+fn constructor_gets_no_suggestion() {
+    let source = "class C { constructor() { const a = await 1; } }\n";
+    assert!(
+        ts1308_related_codes(source).is_empty(),
+        "a constructor must carry no TS1356 pointer"
+    );
+}
+
+/// The nearest container wins, exactly as `getContainingFunction` does: a
+/// non-async function nested inside an `async` one still gets the suggestion,
+/// pointing at the inner function.
+#[test]
+fn nested_non_async_function_inside_async_points_at_the_inner_function() {
+    let source = "async function outer() { const inner = function nested() { return await 1; }; return inner; }\n";
+    assert_eq!(ts1308_pointer_text(source), "nested");
+}
+
+/// Top-level `await` in a script has no containing function, so there is
+/// nothing to suggest marking.
+#[test]
+fn top_level_await_in_a_non_module_gets_no_suggestion() {
+    let diagnostics = check_source_diagnostics("const x = await 1;\n");
+    assert!(
+        diagnostics
+            .iter()
+            .flat_map(|diagnostic| diagnostic.related_information.iter())
+            .all(|info| info.code != TS1356),
+        "top-level await must carry no TS1356 pointer: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn for_await_in_a_plain_function_points_at_its_name() {
+    let source =
+        "declare const arr: number[];\nfunction f1() { for await (const x of arr) { x; } }\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS1103);
+    assert_eq!(pointer_text(source, &diagnostic), "f1");
+}
+
+#[test]
+fn for_await_in_a_constructor_gets_no_suggestion() {
+    let source = "declare const arr: number[];\nclass C { constructor() { for await (const x of arr) { x; } } }\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS1103);
+    assert!(
+        diagnostic
+            .related_information
+            .iter()
+            .all(|info| info.code != TS1356),
+        "a constructor must carry no TS1356 pointer: {diagnostic:?}"
+    );
+}
+
+/// The pointer models tsc's `relatedInformation`, not a `messageText` chain
+/// link, so it must carry that tag through to the reporter. Oracled on
+/// `typescript@7.0.2`: `tsc --noEmit --strict --pretty false` prints the
+/// TS1308 line alone, while `--pretty` prints the suggestion beneath it with
+/// its own location and snippet. Only the tag distinguishes the two.
+#[test]
+fn location_pointer_keeps_plain_mode_output_unchanged() {
+    let source = "function fetchIt() { const x = await 1; return x; }\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS1308);
+    let pointer = diagnostic
+        .related_information
+        .iter()
+        .find(|info| info.code == TS1356)
+        .expect("TS1356 pointer");
+    assert!(
+        pointer.is_location_pointer(),
+        "TS1356 must be a cross-location pointer: {pointer:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
+++ b/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
@@ -862,12 +862,25 @@ impl<'a> CheckerState<'a> {
                                 }
                             }
                         } else {
-                            // TS1308: 'await' expressions are only allowed within async functions
-                            self.error_at_node(
-                                current_idx,
-                                diagnostic_messages::AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WITHIN_ASYNC_FUNCTIONS_AND_AT_THE_TOP_LEVELS,
-                                diagnostic_codes::AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WITHIN_ASYNC_FUNCTIONS_AND_AT_THE_TOP_LEVELS,
-                            );
+                            // TS1308: 'await' expressions are only allowed within async functions.
+                            // tsc points the reader at the function that would
+                            // have to become `async` (TS1356), when there is one
+                            // — see `did_you_mean_async_related`.
+                            let related = self.did_you_mean_async_related(current_idx);
+                            if related.is_empty() {
+                                self.error_at_node(
+                                    current_idx,
+                                    diagnostic_messages::AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WITHIN_ASYNC_FUNCTIONS_AND_AT_THE_TOP_LEVELS,
+                                    diagnostic_codes::AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WITHIN_ASYNC_FUNCTIONS_AND_AT_THE_TOP_LEVELS,
+                                );
+                            } else {
+                                self.error_at_node_with_related(
+                                    current_idx,
+                                    diagnostic_messages::AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WITHIN_ASYNC_FUNCTIONS_AND_AT_THE_TOP_LEVELS,
+                                    diagnostic_codes::AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WITHIN_ASYNC_FUNCTIONS_AND_AT_THE_TOP_LEVELS,
+                                    related,
+                                );
+                            }
                         }
                     }
                 }
@@ -1054,20 +1067,23 @@ impl<'a> CheckerState<'a> {
                 // TS1103: 'for await' loops are only allowed within async
                 // functions and at the top levels of modules. This is to
                 // `for await` exactly what TS1308 is to a bare `await`
-                // expression's non-top-level arm.
+                // expression's non-top-level arm — including tsc's TS1356
+                // pointer at the function that would have to become `async`.
+                let related = self.did_you_mean_async_related(stmt_idx);
                 if let Some((await_pos, await_len)) = await_anchor {
-                    self.error(
+                    self.error_at_span_with_related(
                         await_pos,
                         await_len,
-                        diagnostic_messages::FOR_AWAIT_LOOPS_ARE_ONLY_ALLOWED_WITHIN_ASYNC_FUNCTIONS_AND_AT_THE_TOP_LEVELS_OF
-                            .to_string(),
+                        diagnostic_messages::FOR_AWAIT_LOOPS_ARE_ONLY_ALLOWED_WITHIN_ASYNC_FUNCTIONS_AND_AT_THE_TOP_LEVELS_OF,
                         diagnostic_codes::FOR_AWAIT_LOOPS_ARE_ONLY_ALLOWED_WITHIN_ASYNC_FUNCTIONS_AND_AT_THE_TOP_LEVELS_OF,
+                        related,
                     );
                 } else {
-                    self.error_at_node(
+                    self.error_at_node_with_related(
                         stmt_idx,
                         diagnostic_messages::FOR_AWAIT_LOOPS_ARE_ONLY_ALLOWED_WITHIN_ASYNC_FUNCTIONS_AND_AT_THE_TOP_LEVELS_OF,
                         diagnostic_codes::FOR_AWAIT_LOOPS_ARE_ONLY_ALLOWED_WITHIN_ASYNC_FUNCTIONS_AND_AT_THE_TOP_LEVELS_OF,
+                        related,
                     );
                 }
             }


### PR DESCRIPTION
**Structural rule.** When an `await` expression (TS1308) or a `for await` loop (TS1103) is reported outside an `async` context and it sits inside a function-like container that is **not a constructor** and does **not** already carry `async`, tsc attaches `Did_you_mean_to_mark_this_function_as_async` (TS1356) as `relatedInformation`, anchored on `getErrorSpanForNode(container)`. tsz now does the same through the checker's diagnostic-construction layer (`crates/tsz-checker/src/error_reporter/async_suggestion.rs`), reached from the two await-grammar sites in `types/type_checking/core_statement_checks.rs`.

Before this PR, TS1356 had **zero emit sites** in the workspace — it was one of the unwired codes enumerated in #16291 — and tsz emitted TS1308/TS1103 with no related information at all.

### Why this is invisible to the corpus but not to users

The entry is a cross-location **pointer**, not a message-chain link, in the sense #16338 introduced: `tsc --pretty` prints it with its own location and snippet, `tsc --pretty false` prints nothing for it. It is tagged `RelatedInformationKind::LocationPointer`, so plain-mode output — what conformance grades — is byte-identical before and after, while `--pretty` (tsc's default) and every LSP client gain the suggestion. `location_pointer_keeps_plain_mode_output_unchanged` pins the tag so a future refactor cannot silently promote it into plain output.

### The anchor rule (all oracle-derived, not inferred)

`getErrorSpanForNode` for a function-like is not one rule but four, and the empirical matrix disagreed with a naive reading of it twice:

| container shape | anchor | example |
| --- | --- | --- |
| function / generator declaration, method, accessor | its declared name | `function fetchIt()` → `fetchIt` |
| computed member name | the whole `[expr]` | `{ [k]() {} }` → `[k]` |
| named function expression | its own name | `function nested()` → `nested` |
| anonymous function expression **bound by** a variable declaration, binding element, property assignment, or assignment | the name it is bound to | `const g = function () {}` → `g` |
| anonymous function expression otherwise — **including a class property initializer** | the `function` keyword | `class D { p = function () {} }` → `function`, *not* `p` |
| arrow | the whole arrow | `() => await 2` |
| arrow with a **multi-line** block body | its header, through the `{` | `() => {` |
| constructor | none — tsc excludes `SyntaxKind.Constructor` outright | |

The class-property row is why the assigned-name lookup reads the **parent kind** rather than searching for an enclosing named declaration; `getAssignedName` covers exactly four parent shapes and a property declaration is not one of them.

## Goal
Goal: hold

## Verification

All oracle rows measured against the pinned `typescript@7.0.2` (`scripts/conformance/typescript-versions.json`), `--noEmit --strict --target es2022 --module esnext`.

- `cargo test -p tsz-checker --lib did_you_mean_async` — **22/22 pass** (new file `tests/did_you_mean_async_related_tests.rs`), one row per shape in the table above plus a renamed-binder variant, the nested-non-async-inside-async case, both no-suggestion cases (constructor, top-level await), the TS1103 pair, and the pointer-tag assertion.
- **End-to-end `--pretty` diff against the real oracle**, 5 fixtures covering every row: **every `Did you mean to mark this function as 'async'?` line — location, column and snippet underline — is byte-identical to tsc's.** The only remaining diffs in those files are the pre-existing TS1308 primary-squiggle width, filed separately as #16360.
- **Plain-mode (`--pretty false`) output is byte-identical to tsc on every fixture**, which is the property that makes this corpus-neutral.
- `cargo clippy --workspace --all-targets --exclude tsz-conformance -- -D warnings` — clean (exit 0).
- `cargo fmt --all`, `python3 scripts/arch/arch_guard.py` — clean; pre-commit hook (clippy + `tsz-checker` verification) passed on the commit.
- `scripts/conformance/compare-to-parent.sh` not run: this container has no corpus checkout and the two-sided run does not fit the session. The exposure argument is that plain-mode output is provably unchanged — the conformance harness compares plain output, and the only new data is `related_information` entries tagged `LocationPointer`, which the plain renderer skips by construction (#16338). No diagnostic code, position, or message changed.

## Notes for reviewers

Two findings from this session that are recorded on #16360 rather than patched here, because each is a different defect with its own risk profile:

1. tsz anchors TS1308 on the whole `AwaitExpression` (whose stored `end` also runs onto the statement's `;`); tsc anchors the `await` keyword alone. Same start column, so `--pretty false` — and the corpus — cannot see it.
2. `class C { static { await 1 } }` makes tsz's **parser** emit TS18037, which sets `has_syntax_parse_errors` and suppresses every checker-side await grammar check program-wide. tsc emits TS18037 from the checker, so its other TS1308 rows in the same file still fire — a real plain-mode-visible false-negative family.

The arrow span here compensates for (1)'s second half by trimming trailing separators; that is documented at the call site and pointed at #16360.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Serpentine

---
_Generated by [Claude Code](https://claude.ai/code/session_01BpUVGsuVeRB71E88AAo9nB)_