### PR TITLE
fix(parser): TS1521 for a `\q` class-set operand without string alternatives

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -277,6 +277,10 @@ mod regex_class_set_nesting_tests;
 mod regex_class_set_reserved_double_punctuator_tests;
 
 #[cfg(test)]
+#[path = "../../tests/regex_class_set_string_disjunction_operand_tests.rs"]
+mod regex_class_set_string_disjunction_operand_tests;
+
+#[cfg(test)]
 #[path = "../../tests/regex_negated_class_may_contain_strings_tests.rs"]
 mod regex_negated_class_may_contain_strings_tests;
 

--- a/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
@@ -252,6 +252,27 @@ impl ParserState {
                         );
                         continue;
                     }
+                    // `\q{ ... }` is a class-string-disjunction operand, not a
+                    // code point: it spans through its closing brace and, like
+                    // a nested class, can never bound a range. Letting the
+                    // generic atom walk see it splits it into `q`, `{`, the
+                    // alternatives and `}`, and the brace then compares as a
+                    // range bound.
+                    if unicode_sets_mode
+                        && bytes[*i] == b'\\'
+                        && bytes.get(*i + 1).copied() == Some(b'q')
+                        && bytes.get(*i + 2).copied() == Some(b'{')
+                    {
+                        tokens.push(ClassToken::OpaqueAtom);
+                        *i += 3;
+                        while *i < body_end && bytes[*i] != b'}' {
+                            *i += 1;
+                        }
+                        if *i < body_end {
+                            *i += 1;
+                        }
+                        continue;
+                    }
                     let Some((atoms, next_i)) =
                         parse_class_atom(raw_text, *i, body_end, unicode_mode)
                     else {
@@ -1206,7 +1227,20 @@ impl ParserState {
                             }
                             Some(ClassAtomKind::Class)
                         } else {
-                            Some(ClassAtomKind::Unknown)
+                            // `ClassSetOperand` only admits `\q` as the head of
+                            // `\q{ ... }`. Without the brace there is no string
+                            // disjunction, so the operand degrades to the single
+                            // character `q` — reported, but still a character,
+                            // which is what keeps a following `-` from also
+                            // drawing the class-bounded-range diagnostic.
+                            emit(
+                                parser,
+                                start - 1,
+                                2,
+                                "'\\q' must be followed by string alternatives enclosed in braces.",
+                                diagnostic_codes::Q_MUST_BE_FOLLOWED_BY_STRING_ALTERNATIVES_ENCLOSED_IN_BRACES,
+                            );
+                            Some(ClassAtomKind::Character)
                         }
                     }
                     b'p' | b'P' => {

--- a/crates/tsz-parser/tests/regex_class_set_string_disjunction_operand_tests.rs
+++ b/crates/tsz-parser/tests/regex_class_set_string_disjunction_operand_tests.rs
@@ -1,0 +1,179 @@
+//! `\q` as a class-set operand under the Unicode Sets (`v`) flag.
+//!
+//! `ClassSetOperand ::= '\q{' ClassStringDisjunctionContents '}'` — a `\q`
+//! that is not followed by `{` is not a string disjunction at all. `tsc`
+//! reports TS1521 at the backslash and then treats the operand as the single
+//! character `q`, so no class-bounded-range diagnostic follows it.
+//!
+//! Every expectation below is pinned against `typescript@7.0.2`
+//! (`tsc --noEmit --strict --target esnext`), the version
+//! `scripts/conformance/typescript-versions.json` pairs with the current
+//! corpus.
+
+use crate::parser::test_fixture::parse_source;
+use tsz_common::diagnostics::diagnostic_codes;
+use tsz_common::position::LineMap;
+
+/// Collects every parser diagnostic as `(line, column, code)`, 1-based, in
+/// source order — the same fingerprint shape `tsc`'s CLI prints.
+fn diagnostic_fingerprints(source: &str) -> Vec<(u32, u32, u32)> {
+    let (parser, _root) = parse_source(source);
+    let line_map = LineMap::build(source);
+
+    let mut fingerprints: Vec<(u32, u32, u32)> = parser
+        .get_diagnostics()
+        .iter()
+        .map(|d| {
+            let pos = line_map.offset_to_position(d.start, source);
+            (pos.line + 1, pos.character + 1, d.code)
+        })
+        .collect();
+    fingerprints.sort_unstable();
+    fingerprints
+}
+
+#[test]
+fn test_class_set_q_operand_without_braces_reports_ts1521() {
+    // Column 5 on each line is the backslash of `\q`: two spaces of indent,
+    // `/` at 3, `[` at 4, `\` at 5.
+    let source = r"
+const regexes: RegExp[] = [
+  /[\q]/v,
+  /[\qa]/v,
+];
+";
+    let expected: Vec<(u32, u32, u32)> = vec![
+        (
+            3,
+            5,
+            diagnostic_codes::Q_MUST_BE_FOLLOWED_BY_STRING_ALTERNATIVES_ENCLOSED_IN_BRACES,
+        ),
+        (
+            4,
+            5,
+            diagnostic_codes::Q_MUST_BE_FOLLOWED_BY_STRING_ALTERNATIVES_ENCLOSED_IN_BRACES,
+        ),
+    ];
+
+    assert_eq!(
+        diagnostic_fingerprints(source),
+        expected,
+        "a `\\q` not followed by `{{` is TS1521 at the backslash"
+    );
+}
+
+#[test]
+fn test_class_set_q_operand_with_braces_is_clean() {
+    // A well-formed string disjunction — including the single-character form,
+    // which cannot match a string and so is legal inside a negated class.
+    let source = r"
+const regexes: RegExp[] = [
+  /[\q{ab}]/v,
+  /[\q{a}]/v,
+  /[\q{}]/v,
+  /[\q{ab|c}]/v,
+  /[\q{ab}--\q{a}]/v,
+  /[^\q{a}]/v,
+];
+";
+    assert_eq!(
+        diagnostic_fingerprints(source),
+        Vec::new(),
+        "`\\q{{...}}` is a well-formed class-set operand"
+    );
+}
+
+#[test]
+fn test_class_set_q_operand_without_braces_in_every_operand_position() {
+    let source = r"
+const regexes: RegExp[] = [
+  /[a\q]/v,
+  /[^\q]/v,
+  /[[\q]]/v,
+  /[\q&&a]/v,
+  /[\q\q]/v,
+];
+";
+    const TS1521: u32 =
+        diagnostic_codes::Q_MUST_BE_FOLLOWED_BY_STRING_ALTERNATIVES_ENCLOSED_IN_BRACES;
+    let expected: Vec<(u32, u32, u32)> = vec![
+        (3, 6, TS1521), // after a leading character
+        (4, 6, TS1521), // inside a negated class
+        (5, 6, TS1521), // inside a nested class
+        (6, 5, TS1521), // left operand of an intersection
+        (7, 5, TS1521), // both operands report independently
+        (7, 7, TS1521),
+    ];
+
+    assert_eq!(
+        diagnostic_fingerprints(source),
+        expected,
+        "TS1521 fires once per malformed `\\q`, wherever the operand appears"
+    );
+}
+
+#[test]
+fn test_class_set_q_operand_without_braces_is_a_single_character_operand() {
+    // `tsc` returns the character `q` after reporting, so `\q` bounding a
+    // range does NOT additionally draw TS1516 (a class-bounded range) — the
+    // only diagnostic is TS1521. The `\q{...}` form is a genuine class and
+    // does draw TS1516, which is what keeps the two apart.
+    let source = r"
+const regexes: RegExp[] = [
+  /[\q-z]/v,
+  /[\q{a}-z]/v,
+];
+";
+    let expected: Vec<(u32, u32, u32)> = vec![
+        (
+            3,
+            5,
+            diagnostic_codes::Q_MUST_BE_FOLLOWED_BY_STRING_ALTERNATIVES_ENCLOSED_IN_BRACES,
+        ),
+        (
+            4,
+            5,
+            diagnostic_codes::A_CHARACTER_CLASS_RANGE_MUST_NOT_BE_BOUNDED_BY_ANOTHER_CHARACTER_CLASS,
+        ),
+    ];
+
+    assert_eq!(
+        diagnostic_fingerprints(source),
+        expected,
+        "a reported `\\q` degrades to the single character `q`, not to a class"
+    );
+}
+
+#[test]
+fn test_class_set_q_operand_negative_cases_are_unchanged() {
+    // `\q` is a class-set concept: it exists only under `v`, and only inside a
+    // character class. Neither neighbouring shape may start reporting TS1521.
+    let source = r"
+const regexes: RegExp[] = [
+  /[\q]/u,
+  /[\q]/,
+  /\q/v,
+  /[^\q{ab}]/v,
+];
+";
+    let expected: Vec<(u32, u32, u32)> = vec![
+        (
+            3,
+            5,
+            diagnostic_codes::THIS_CHARACTER_CANNOT_BE_ESCAPED_IN_A_REGULAR_EXPRESSION,
+        ),
+        // `/[\q]/` (no flag) is Annex B — `\q` is an identity escape, clean.
+        (5, 4, diagnostic_codes::Q_IS_ONLY_AVAILABLE_INSIDE_CHARACTER_CLASS),
+        (
+            6,
+            6,
+            diagnostic_codes::ANYTHING_THAT_WOULD_POSSIBLY_MATCH_MORE_THAN_A_SINGLE_CHARACTER_IS_INVALID_INSID,
+        ),
+    ];
+
+    assert_eq!(
+        diagnostic_fingerprints(source),
+        expected,
+        "TS1521 is scoped to a class-set operand under the `v` flag"
+    );
+}


### PR DESCRIPTION
Wires TS1521 (`'\q' must be followed by string alternatives enclosed in braces.`) and removes two false positives that shared its root cause. TS1521 was one of only **two** codes left unwired in #16291's regex-grammar cluster (the other is TS1513 — see the note at the bottom).

## Structural rule

`ClassSetOperand ::= '[' ClassSetExpression ']' | '\' CharacterClassEscape | '\q{' ClassStringDisjunctionContents '}' | ClassSetCharacter`

**When a `\q` inside a character class under the Unicode Sets (`v`) flag is not followed by `{`, tsc reports TS1521 at the backslash and then treats the operand as the single character `q`; tsz now does the same through the parser's regex-grammar walk** (`crates/tsz-parser/src/parser/state_expressions_literals_regex.rs`), the layer that already owns every other code in the TS1499–TS1538 band.

Wrong semantic operation: **parser recovery / grammar validation** inside the regex literal walk — specifically the class-set operand scanner and the TS1517 range-order walk. No checker or solver involvement; regex grammar has one owner.

Two defects, one root cause:

1. **Missing diagnostic.** `scan_character_class_escape`'s `b'q' if unicode_sets_mode` arm returned `ClassAtomKind::Unknown` with no diagnostic when the brace was absent. `typescript-go`'s `scanClassSetOperand` (`internal/scanner/regexp.go`) errors and `return "q"` — a single character, not a class.
2. **Two false positives.** Because the operand was `Unknown`, a following `-` drew TS1516 (`A character class range must not be bounded by another character class.`) on `/[\q-z]/v`, where tsc reports only TS1521. Separately, the TS1517 range-order walk (`parse_class_atom`) did not know that `\q{ ... }` spans through its closing brace, so it split `\q{a}` into `q`, `{`, `a`, `}` and then compared `}` (0x7D) against `z` (0x7A) as a range — a spurious TS1517 on `/[\q{a}-z]/v`. `\q{ ... }` is now opaque to that walk, exactly like the nested-class case immediately above it.

## Goal
Goal: hold

## Adjacent-case matrix

All 19 rows pinned against `typescript@7.0.2` (the pin in `scripts/conformance/typescript-versions.json`), `tsc --noEmit --strict --target esnext`. tsz CLI output is **code- and column-identical to tsc on every row**, verified by running both binaries over the same files.

| pattern | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `/[\q]/v` | TS1521 @13 | *(silent)* | TS1521 @13 |
| `/[\qa]/v` | TS1521 @13 | *(silent)* | TS1521 @13 |
| `/[a\q]/v` | TS1521 @14 | *(silent)* | TS1521 @14 |
| `/[^\q]/v` | TS1521 @14 | *(silent)* | TS1521 @14 |
| `/[[\q]]/v` | TS1521 @14 | *(silent)* | TS1521 @14 |
| `/[\q&&a]/v` | TS1521 @13 | *(silent)* | TS1521 @13 |
| `/[\q\q]/v` | TS1521 @13, @15 | *(silent)* | TS1521 @13, @15 |
| `/[\q-z]/v` | TS1521 @13 | **TS1516 @13** | TS1521 @13 |
| `/[\q{a}-z]/v` | TS1516 @13 | TS1516 @13 + **TS1517 @17** | TS1516 @13 |
| `/[\q{ab}]/v` | clean | clean | clean |
| `/[\q{a}]/v` | clean | clean | clean |
| `/[\q{}]/v` | clean | clean | clean |
| `/[\q{ab\|c}]/v` | clean | clean | clean |
| `/[\q{ab}--\q{a}]/v` | clean | clean | clean |
| `/[^\q{a}]/v` | clean | clean | clean |
| `/[^\q{ab}]/v` | TS1518 @14 | TS1518 @14 | TS1518 @14 |
| `/[\q]/u` | TS1535 @13 | TS1535 @13 | TS1535 @13 |
| `/[\q]/` (Annex B) | clean | clean | clean |
| `/\q/v` (outside class) | TS1511 @12 | TS1511 @12 | TS1511 @12 |

Negative/fallback coverage is the bottom third: the `u` flag, no flag, and outside-a-class shapes must not start reporting TS1521, and the well-formed `\q{ ... }` forms — including the empty and multi-alternative disjunctions and the negated-class TS1518 interaction — must stay exactly where they were.

## Suppression-hazard check (#16279)

TS1521 sits inside the `TS1499..=TS1538` band that `is_parser_grammar_code` (`crates/tsz-cli/src/driver/check_utils.rs`) already excludes wholesale, so a newly emitted TS1521 cannot set `has_syntax_parse_errors` and silently delete unrelated diagnostics from the rest of the file. No change needed there; the band comment already names 1521 explicitly as one of the codes it was widened to cover. Confirmed end-to-end through the CLI binary, not just the parser unit harness.

## Verification

- `cargo test -p tsz-parser --lib` — **1759 passed, 0 failed** (1754 before this change + the 5 new tests). Before the fix, 3 of the 5 new tests failed with exactly the "before" column above.
- `cargo clippy -p tsz-parser --all-targets -- -D warnings` — clean. Also clean through the `pre-commit` hook's own clippy gate.
- `python3 scripts/arch/arch_guard.py` — `Architecture guardrails passed.`
- `python3 scripts/ci/check-test-file-reachability.py` — `0 known orphan(s), 0 new` (the new test file is registered in `src/parser/mod.rs`).
- Oracle: `typescript@7.0.2`, 19 rows, tsz CLI vs tsc, identical codes and columns.
- `scripts/conformance/compare-to-parent.sh origin/main` — running at PR-open time; result posted as a comment when it lands.

## Note for the next session on #16291

Re-ran the both-halves wiring scan over the whole regex cluster on `e855470`. Of the ~20 codes #16291 lists, **only TS1513 (`Undetermined character escape.`) remains unwired after this PR**. In `typescript-go` it is emitted from `scanCharacterEscape` only when the character after `\` is EOF (`case -1`), i.e. the pattern body ends on a bare backslash — which in a terminated literal cannot happen, since `\/` escapes the terminator. The obvious witness `const d = /\` yields only TS1161 (`Unterminated regular expression literal.`) from tsc 7.0.2, with no TS1513. Treat TS1513 as probably-unreachable-by-construction and demand an oracle witness before wiring it.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Cordierite

---
_Generated by [Claude Code](https://claude.ai/code/session_012JCb8cj7hbuWe6czPyduno)_