### PR TITLE
fix(checker): TS18017/TS18018 related-info for shadowed private identifiers

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs
@@ -1818,13 +1818,23 @@ impl<'a> CheckerState<'a> {
         );
     }
 
+    /// `tsc`'s `checkPrivateIdentifierPropertyAccess` attaches two related-info
+    /// pointers to this diagnostic: TS18017 at the shadowing declaration (the
+    /// closest `#name` in lexical scope) and TS18018 at the declaration the
+    /// access probably intended (the outer `#name` actually present on the
+    /// object's type). Either pointer is skipped, not guessed, when its
+    /// declaration node cannot be resolved.
     pub(crate) fn report_private_identifier_shadowed(
         &mut self,
         name_idx: NodeIndex,
         property_name: &str,
         object_type: TypeId,
+        shadowing_sym_id: SymbolId,
+        intended_sym_id: SymbolId,
     ) {
-        use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+        use crate::diagnostics::{
+            Diagnostic, diagnostic_codes, diagnostic_messages, format_message,
+        };
         let type_string = self
             .get_class_display_name_from_type(object_type)
             .unwrap_or_else(|| self.format_type_diagnostic(object_type));
@@ -1832,11 +1842,79 @@ impl<'a> CheckerState<'a> {
             diagnostic_messages::THE_PROPERTY_CANNOT_BE_ACCESSED_ON_TYPE_WITHIN_THIS_CLASS_BECAUSE_IT_IS_SHADOWED,
             &[property_name, &type_string],
         );
-        self.error_at_node(
+        let mut related = Vec::new();
+        if let Some(name_node) = self.private_identifier_declaration_name(shadowing_sym_id)
+            && let Some((start, length)) = self.private_identifier_span(name_node)
+        {
+            related.push(Diagnostic::related_pointer(
+                diagnostic_codes::THE_SHADOWING_DECLARATION_OF_IS_DEFINED_HERE,
+                self.ctx.file_name.clone(),
+                start,
+                length,
+                format_message(
+                    diagnostic_messages::THE_SHADOWING_DECLARATION_OF_IS_DEFINED_HERE,
+                    &[property_name],
+                ),
+            ));
+        }
+        if let Some(name_node) = self.private_identifier_declaration_name(intended_sym_id)
+            && let Some((start, length)) = self.private_identifier_span(name_node)
+        {
+            related.push(Diagnostic::related_pointer(
+                diagnostic_codes::THE_DECLARATION_OF_THAT_YOU_PROBABLY_INTENDED_TO_USE_IS_DEFINED_HERE,
+                self.ctx.file_name.clone(),
+                start,
+                length,
+                format_message(
+                    diagnostic_messages::THE_DECLARATION_OF_THAT_YOU_PROBABLY_INTENDED_TO_USE_IS_DEFINED_HERE,
+                    &[property_name],
+                ),
+            ));
+        }
+        self.error_at_node_with_related(
             name_idx,
             &message,
             diagnostic_codes::THE_PROPERTY_CANNOT_BE_ACCESSED_ON_TYPE_WITHIN_THIS_CLASS_BECAUSE_IT_IS_SHADOWED,
+            related,
         );
+    }
+
+    /// The name node (a `PrivateIdentifier`) of `sym_id`'s own declaration —
+    /// the first of its `PROPERTY_DECLARATION`/`METHOD_DECLARATION`/accessor
+    /// declarations that carries one.
+    fn private_identifier_declaration_name(&self, sym_id: SymbolId) -> Option<NodeIndex> {
+        let symbol = self.ctx.binder.get_symbol(sym_id)?;
+        for &decl_idx in &symbol.declarations {
+            let Some(node) = self.ctx.arena.get(decl_idx) else {
+                continue;
+            };
+            let name = if node.kind == syntax_kind_ext::PROPERTY_DECLARATION {
+                self.ctx.arena.get_property_decl(node).map(|d| d.name)
+            } else if node.kind == syntax_kind_ext::METHOD_DECLARATION {
+                self.ctx.arena.get_method_decl(node).map(|d| d.name)
+            } else if node.kind == syntax_kind_ext::GET_ACCESSOR
+                || node.kind == syntax_kind_ext::SET_ACCESSOR
+            {
+                self.ctx.arena.get_accessor(node).map(|d| d.name)
+            } else {
+                None
+            };
+            if let Some(name_idx) = name
+                && name_idx.is_some()
+            {
+                return Some(name_idx);
+            }
+        }
+        None
+    }
+
+    /// `(start, length)` of a `PrivateIdentifier` name node, narrowed to its
+    /// own written text (`#name`) rather than the raw node span, which runs to
+    /// the start of the next token.
+    fn private_identifier_span(&self, name_idx: NodeIndex) -> Option<(u32, u32)> {
+        let node = self.ctx.arena.get(name_idx)?;
+        let identifier = self.ctx.arena.get_identifier(node)?;
+        Some((node.pos, identifier.escaped_text.len() as u32))
     }
 
     /// Returns true if `sym_id` is a merged interface+value symbol.

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_private.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_private.rs
@@ -744,7 +744,7 @@ impl<'a> CheckerState<'a> {
         };
 
         if !types_compatible {
-            let shadowed = symbols.iter().skip(1).any(|sym_id| {
+            let intended = symbols.iter().skip(1).find(|sym_id| {
                 // The first symbol (symbols[0]) is the *closest* private identifier
                 // in scope — the one that shadows the outer access. Each outer
                 // symbol must be evaluated with its own static-ness, not the
@@ -753,12 +753,12 @@ impl<'a> CheckerState<'a> {
                 // static members fail the subsequent access-compat check and
                 // the shadowing diagnostic is dropped, producing a confusing
                 // "does not exist" (TS2339) instead of TS18014.
-                let outer_is_static = self.ctx.binder.get_symbol(*sym_id).is_some_and(|sym| {
+                let outer_is_static = self.ctx.binder.get_symbol(**sym_id).is_some_and(|sym| {
                     sym.declarations
                         .iter()
                         .any(|&decl_idx| self.class_member_is_static(decl_idx))
                 });
-                self.private_member_declaring_type(*sym_id)
+                self.private_member_declaring_type(**sym_id)
                     .is_some_and(|ty| {
                         if outer_is_static {
                             self.static_private_member_access_compatible(
@@ -774,11 +774,13 @@ impl<'a> CheckerState<'a> {
                         }
                     })
             });
-            if shadowed {
+            if let Some(&intended_sym_id) = intended {
                 self.report_private_identifier_shadowed(
                     name_idx,
                     &property_name,
                     original_object_type,
+                    symbols[0],
+                    intended_sym_id,
                 );
                 return TypeId::ERROR;
             }

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -809,6 +809,8 @@ mod ts1361_ambient_computed_property_name_tests;
 mod ts1539_bigint_literal_property_name_tests;
 #[path = "tests/ts18010_jsdoc_tag_anchor_tests.rs"]
 mod ts18010_jsdoc_tag_anchor_tests;
+#[path = "tests/ts18017_ts18018_private_identifier_shadow_related_info_tests.rs"]
+mod ts18017_ts18018_private_identifier_shadow_related_info_tests;
 #[path = "tests/ts18050_nullish_keyword_without_strict_null_checks_tests.rs"]
 mod ts18050_nullish_keyword_without_strict_null_checks_tests;
 #[path = "tests/ts2322_private_field_narrowing_write_tests.rs"]

--- a/crates/tsz-checker/src/tests/ts18017_ts18018_private_identifier_shadow_related_info_tests.rs
+++ b/crates/tsz-checker/src/tests/ts18017_ts18018_private_identifier_shadow_related_info_tests.rs
@@ -1,0 +1,192 @@
+//! Regression tests for the `TS18017`/`TS18018` related-info pointers `tsc`
+//! attaches to `TS18014` ("The property '#x' cannot be accessed on type 'Y'
+//! within this class because it is shadowed by another private identifier
+//! with the same spelling.").
+//!
+//! Structural rule (pinned against `typescript@7.0.2`): `tsc`'s
+//! `checkPrivateIdentifierPropertyAccess` unconditionally attaches two
+//! `relatedInformation` entries once it reports `TS18014` — `TS18017` at the
+//! *closest lexically-scoped* `#name` declaration (the one that shadows the
+//! access), and `TS18018` at the outer `#name` declaration actually present
+//! on the accessed object's type (the one "probably intended"). Both anchor
+//! on the private-identifier name token alone (`#x`, not the whole member),
+//! and both are `RelatedInformationKind::LocationPointer`, so `--pretty
+//! false` output is unchanged — this class of fix is corpus-neutral by
+//! construction (see #16338).
+//!
+//! tsz owns this in `report_private_identifier_shadowed`
+//! (`state/type_analysis/computed_helpers_binding.rs`), reached from the
+//! shadow-detection branch in `computed_helpers_private.rs`.
+
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::check_source_diagnostics;
+use tsz_common::diagnostics::diagnostic_codes;
+
+const TS18014: u32 = diagnostic_codes::THE_PROPERTY_CANNOT_BE_ACCESSED_ON_TYPE_WITHIN_THIS_CLASS_BECAUSE_IT_IS_SHADOWED;
+const TS18017: u32 = diagnostic_codes::THE_SHADOWING_DECLARATION_OF_IS_DEFINED_HERE;
+const TS18018: u32 =
+    diagnostic_codes::THE_DECLARATION_OF_THAT_YOU_PROBABLY_INTENDED_TO_USE_IS_DEFINED_HERE;
+
+fn only(diags: &[Diagnostic], code: u32) -> Diagnostic {
+    let matching: Vec<_> = diags.iter().filter(|d| d.code == code).collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected exactly one TS{code}; got {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+    matching[0].clone()
+}
+
+fn related_pointer(
+    diagnostic: &Diagnostic,
+    code: u32,
+) -> tsz_common::diagnostics::DiagnosticRelatedInformation {
+    let matching: Vec<_> = diagnostic
+        .related_information
+        .iter()
+        .filter(|info| info.code == code)
+        .collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected exactly one TS{code} related pointer; got {:?}",
+        diagnostic
+            .related_information
+            .iter()
+            .map(|info| (info.code, info.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+    matching[0].clone()
+}
+
+/// Method-declared private identifiers: nested `Derived` shadows outer `Base`.
+#[test]
+fn method_shadow_carries_both_pointers() {
+    let source = r#"
+class Base {
+    #x() { };
+    constructor() {
+        class Derived {
+            #x() { };
+            testBase(x: Base) {
+                x.#x;
+            }
+        }
+    }
+}
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    let ts18014 = only(&diagnostics, TS18014);
+    assert_eq!(
+        ts18014.message_text,
+        "The property '#x' cannot be accessed on type 'Base' within this class because it is shadowed by another private identifier with the same spelling."
+    );
+
+    let shadowing = related_pointer(&ts18014, TS18017);
+    assert_eq!(
+        shadowing.message_text,
+        "The shadowing declaration of '#x' is defined here"
+    );
+    assert_eq!(
+        shadowing.length, 2,
+        "anchor must be '#x' alone, not the whole member"
+    );
+    let derived_decl_start = source.find("#x() { };\n            testBase").unwrap() as u32;
+    assert_eq!(shadowing.start, derived_decl_start);
+
+    let intended = related_pointer(&ts18014, TS18018);
+    assert_eq!(
+        intended.message_text,
+        "The declaration of '#x' that you probably intended to use is defined here"
+    );
+    assert_eq!(intended.length, 2);
+    let base_decl_start = source.find("#x() { };\n    constructor").unwrap() as u32;
+    assert_eq!(intended.start, base_decl_start);
+}
+
+/// Field-declared (not method) private identifiers take the same two
+/// pointers, anchored on the field's own name.
+#[test]
+fn property_field_shadow_carries_both_pointers() {
+    let source = r#"
+class Base {
+    #x = 1;
+    constructor() {
+        class Derived {
+            #x = 2;
+            testBase(x: Base) {
+                x.#x;
+            }
+        }
+    }
+}
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    let ts18014 = only(&diagnostics, TS18014);
+    let shadowing = related_pointer(&ts18014, TS18017);
+    assert_eq!(shadowing.length, 2);
+    let intended = related_pointer(&ts18014, TS18018);
+    assert_eq!(intended.length, 2);
+}
+
+/// An outer *static* member shadowed by an inner *instance* member of the
+/// same spelling: `private_member_declaring_type`'s static/instance split
+/// must not stop the intended-declaration lookup from finding the outer
+/// static field's own name node.
+#[test]
+fn static_outer_shadowed_by_instance_inner_carries_both_pointers() {
+    let source = r#"
+class Base {
+    static #x() { };
+    constructor() {
+        class Derived {
+            #x() { };
+            testBase(x: typeof Base) {
+                x.#x;
+            }
+        }
+    }
+}
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    let ts18014 = only(&diagnostics, TS18014);
+    assert_eq!(
+        ts18014.message_text,
+        "The property '#x' cannot be accessed on type 'typeof Base' within this class because it is shadowed by another private identifier with the same spelling."
+    );
+    let shadowing = related_pointer(&ts18014, TS18017);
+    assert_eq!(shadowing.length, 2);
+    let intended = related_pointer(&ts18014, TS18018);
+    assert_eq!(intended.length, 2);
+    let base_decl_start = source.find("#x() { };\n    constructor").unwrap() as u32;
+    assert_eq!(intended.start, base_decl_start);
+}
+
+/// A plain, unshadowed private-identifier access reports neither TS18014 nor
+/// either pointer — the negative control.
+#[test]
+fn unshadowed_private_access_carries_no_pointers() {
+    let source = r#"
+class Base {
+    #x() { };
+    test() {
+        this.#x();
+    }
+}
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        diagnostics
+            .iter()
+            .all(|d| d.code != TS18014 && d.code != TS18017 && d.code != TS18018),
+        "expected no TS18014/TS18017/TS18018 for an unshadowed access; got {:?}",
+        diagnostics
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
tsc's `checkPrivateIdentifierPropertyAccess` unconditionally attaches two `relatedInformation` pointers once it decides a private-identifier access is shadowed and reports TS18014 ("The property '#x' cannot be accessed on type 'Y' within this class because it is shadowed by another private identifier with the same spelling."): **TS18017** at the closest lexically-scoped `#name` declaration (the one that shadows the access) and **TS18018** at the outer `#name` declaration actually present on the accessed object's type (the one "probably intended"). tsz's `report_private_identifier_shadowed` (`crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs`) already emitted the TS18014 main diagnostic but attached no related info at all.

Structural rule (pinned against `typescript@7.0.2`): both pointers anchor on the private-identifier name token alone (`#x`), not the whole member declaration, and both are `RelatedInformationKind::LocationPointer`, so `--pretty false` output is byte-for-byte unchanged (verified directly against the pinned oracle and against tsz's own dist-fast binary — see below). This class of fix is corpus-neutral by construction (the same mechanism #16338 and #16364 established: a `LocationPointer` entry is skipped by the plain-mode renderer).

## Fix

The shadow-detection branch in `computed_helpers_private.rs` previously used `.any()` over the outer private-identifier symbols to test compatibility with the access, discarding *which* outer symbol matched. It now uses `.find()` to capture that symbol, so `report_private_identifier_shadowed` can anchor TS18018 at its own declaration (`private_identifier_declaration_name`/`private_identifier_span`, new helpers in `computed_helpers_binding.rs`) while TS18017 anchors at `symbols[0]`'s declaration (the closest/shadowing one, already resolved by the caller). Both pointers are built via the existing `error_at_node_with_related`/`Diagnostic::related_pointer` machinery (`error_reporter/emitters.rs`); either is skipped, not guessed, when its declaration node cannot be resolved.

## Adjacent-case matrix

All rows oracle-verified against pinned `tsc@7.0.2`, and cross-checked byte-for-byte against tsz's own `dist-fast` CLI binary in both `--pretty` and `--pretty false` modes:

| Shape | tsc / tsz (pretty) | tsc / tsz (plain) |
| --- | --- | --- |
| Method-declared shadow (`Derived#x` shadows `Base#x`) | TS18014 + TS18017@(5,13) + TS18018@(2,5) | TS18014 only |
| Property-field-declared shadow | TS18014 + TS18017@(5,13) + TS18018@(2,5) | TS18014 only |
| Outer `static #x` shadowed by inner instance `#x` | TS18014 (`typeof Base`) + TS18017@(5,13) + TS18018@(2,12) | TS18014 only |
| Unshadowed private access (`this.#x()`) | clean | clean |

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib ts18017_ts18018`: 4/4 passed (new adjacent-case matrix: method shadow, property-field shadow, static-outer/instance-inner shadow, unshadowed negative control).
- `cargo test -p tsz-checker --test private_brands --test conformance_issues_errors --test conformance_issues_modules`: all pre-existing private-identifier suites green (33 + 8 + 30 relevant tests), including the two pre-existing shadow tests (`test_private_name_nested_class_shadowing`, `ts18014_shadowed_private_access_uses_constructor_type_name`).
- `cargo clippy -p tsz-checker --lib --all-targets -- -D warnings`: clean.
- `cargo fmt -p tsz-checker -- --check`: clean.
- `python3 scripts/arch/arch_guard.py`: passes.
- Manual oracle comparison (pinned `typescript@7.0.2`) across all 4 adjacent-case rows above, `--pretty` and `--pretty false`: tsz's `dist-fast` binary matches byte-for-byte.
- No `compare-to-parent.sh` run: both new related-info entries are `RelatedInformationKind::LocationPointer`, which the plain-mode renderer skips entirely (verified directly above), so `--pretty false` — the mode the corpus/conformance harness checks — is provably unchanged by this diff.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_01JyA7MdZLYJTrvzgWe7qrUF)_