### PR TITLE
fix(cli): parser grammar codes must not set has_syntax_parse_errors (#16360)

### DIFF
--- a/crates/tsz-checker/src/tests/await_static_block_grammar_tests.rs
+++ b/crates/tsz-checker/src/tests/await_static_block_grammar_tests.rs
@@ -6,19 +6,35 @@
 //! already emits TS18037 for any `await` parsed while `in_static_block_context()`
 //! is set, regardless of how deeply the `await` sits inside intervening
 //! statements (`while`, `for`, `switch`, ...) — the context flag survives
-//! statement nesting and is only cleared at a function/class boundary. That
-//! parser diagnostic sets `has_syntax_parse_errors`, which suppresses
-//! `check_await_expression`'s own TS1308 grammar walk
-//! (`core_statement_checks.rs`) for the same file. So on current `main` this
-//! family already matches tsc: exactly TS18037, never an accompanying TS1308.
+//! statement nesting and is only cleared at a function/class boundary. So this
+//! family matches tsc: exactly TS18037, never an accompanying TS1308.
+//!
+//! **The reason it matches changed in #16367, and the old reason was a bug.**
+//! It used to be that the parser's TS18037 set `has_syntax_parse_errors`, which
+//! suppressed `check_await_expression`'s TS1308 walk — for the *whole file*,
+//! not just for the static block. tsc emits TS18037 from the checker, so its
+//! `hasParseDiagnostics(sourceFile)` stays false and every other `await` in the
+//! file still reports: `class C { static { await 4 } }` next to an ordinary
+//! non-async `await` gives tsc two diagnostics and gave tsz one.
+//!
+//! The suppression is gone (TS18037 is now non-suppressing, like every other
+//! parser-emitted checker-grammar code), and the exclusivity is stated where
+//! tsc states it instead: `checkAwaitExpression` opens with an `if` on the
+//! containing function-or-class-static-block being a class static block, and
+//! the entire TS1308/TS1375/TS1378/TS1309 family lives in its `else if`.
+//! `await_container_is_class_static_block` in `core_statement_checks.rs` is
+//! that test. The assertions below are unchanged; what they prove is not.
 //!
 //! #16068 reported the opposite (TS1308 instead of TS18037) — that read came
 //! from `test_utils::check_source_codes`, which never wires real parser
 //! diagnostics or `has_syntax_parse_errors` into the `CheckerState` it builds
 //! (see `test_utils::check_source_with_parse_health`'s doc comment), so it
 //! can neither see the parser's TS18037 nor let it suppress the checker's
-//! TS1308. These tests use the parse-health-aware helper instead, so they
-//! reflect what the compiled CLI actually reports.
+//! TS1308. The tests written for #16068 therefore use the parse-health-aware
+//! helper, so they reflect what the compiled CLI actually reports. The three
+//! added by #16367 at the end of this file deliberately use the blind helper
+//! for the opposite reason — with the suppression removed, the blind helper is
+//! what shows the checker walk deciding on its own.
 
 use crate::test_utils::check_source_codes_with_parse_health;
 
@@ -272,5 +288,78 @@ class Gate { static { using x = 1; } }
     assert!(
         !codes.contains(&18054),
         "a plain `using` (not `await using`) is unaffected by the static-block await restriction; got {codes:?}"
+    );
+}
+
+/// The exclusivity, isolated from parse-health suppression entirely (#16367).
+///
+/// `check_source_codes` is the parse-health-*blind* helper: it never wires the
+/// parser's diagnostics or `has_syntax_parse_errors` into the `CheckerState`
+/// (see `test_utils::check_source_with_parse_health`'s doc comment). That makes
+/// it exactly the right instrument here — it shows what the checker's
+/// await-grammar walk decides on its own, with nothing suppressing it.
+///
+/// Before #16367 this reported TS1308 (or the TS1375/TS1378 top-level pair,
+/// depending on module settings) and only the CLI's file-wide suppression hid
+/// it. Now `await_container_is_class_static_block` declines at the source, so
+/// the walk is silent for a static block's own `await` whether or not anything
+/// is suppressing.
+#[test]
+fn static_block_await_is_silent_in_the_checker_walk_without_suppression() {
+    let codes = crate::test_utils::check_source_codes(
+        r#"
+class Gate { static { await 1; } }
+"#,
+    );
+    assert!(
+        !codes.contains(&1308) && !codes.contains(&1375) && !codes.contains(&1378),
+        "tsc's checkAwaitExpression puts the whole TS1308/TS1375/TS1378 family in \
+         the `else if` of its class-static-block test, so the walk must decline \
+         here on its own rather than relying on a file-wide suppression; got {codes:?}"
+    );
+}
+
+/// The same walk must still speak for an `await` that is *not* in a static
+/// block, in a file that also has one.
+///
+/// This is the shape the old suppression got wrong: it keyed on the file, so
+/// one static block silenced every other `await` in it. Renamed binders
+/// throughout, and the sibling `await` sits in a nested function expression so
+/// it cannot be confused with the static block's container.
+#[test]
+fn sibling_await_outside_a_static_block_still_reports_in_the_checker_walk() {
+    let codes = crate::test_utils::check_source_codes(
+        r#"
+class Latch { static { const seeded = await 4; } }
+function makeReader() { const read = function () { return await 1; }; return read; }
+"#,
+    );
+    assert!(
+        codes.contains(&1308),
+        "the non-async `await` in `makeReader`'s inner function expression is \
+         unaffected by the sibling static block; tsc reports TS1308 for it \
+         alongside the static block's TS18037; got {codes:?}"
+    );
+}
+
+/// Container-walk boundary: an `await` inside a function *nested* in a static
+/// block answers from its own function, not from the static block.
+///
+/// `await_container_is_class_static_block` stops at the first
+/// function-like-or-static-block ancestor rather than searching upward for a
+/// static block anywhere, which is what `getContainingFunctionOrClassStaticBlock`
+/// does. Without that stop, this `await` would be silently swallowed.
+#[test]
+fn await_in_a_non_async_function_nested_in_a_static_block_still_reports() {
+    let codes = crate::test_utils::check_source_codes(
+        r#"
+class Harness { static { const build = function () { return await 2; }; void build; } }
+"#,
+    );
+    assert!(
+        codes.contains(&1308),
+        "the nested function expression is its own container, so its non-async \
+         `await` answers TS1308 rather than deferring to the enclosing static \
+         block; got {codes:?}"
     );
 }

--- a/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
+++ b/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
@@ -852,7 +852,19 @@ impl<'a> CheckerState<'a> {
                     // `check_await_expression_in_own_container`).
                     let in_async_context =
                         container.inherits_async_context() && self.ctx.in_async_context();
-                    if !in_async_context && !self.ctx.has_syntax_parse_errors {
+                    // tsc's `checkAwaitExpression` opens with an `if` on the
+                    // containing function-or-class-static-block being a class
+                    // static block, and the whole TS1308/TS1375/TS1378/TS1309
+                    // family lives in its `else if`. So a class static block
+                    // answers *only* `TS18037` — which tsz's parser emits at
+                    // `state_expressions_unary.rs` — never a second diagnostic
+                    // from this walk.
+                    let in_class_static_block =
+                        self.await_container_is_class_static_block(current_idx);
+                    if !in_async_context
+                        && !in_class_static_block
+                        && !self.ctx.has_syntax_parse_errors
+                    {
                         use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
 
                         // Check if we're directly at the top level of the
@@ -987,6 +999,50 @@ impl<'a> CheckerState<'a> {
     /// top-level twin of the async-context swap `check_class_member_name`
     /// performs with `EnclosingClassInfo::enclosing_async_depth`: the two axes
     /// of `await` legality are independent and each has to be answered here.
+    /// Whether the nearest function-like-or-class-static-block ancestor of
+    /// `idx` is a class static block — tsc's `getContainingFunctionOrClassStaticBlock`
+    /// followed by `isClassStaticBlockDeclaration`.
+    ///
+    /// `checkAwaitExpression` branches on exactly this, and the branch is
+    /// exclusive: a class static block answers `TS18037` and nothing else, so
+    /// neither `TS1308` nor the `TS1375`/`TS1378`/`TS1309` top-level trio may
+    /// also fire. Verified against `typescript@7.0.2`: a file pairing
+    /// `class C { static { const c = await 4; } }` with an ordinary non-async
+    /// `await` reports one `TS18037` and one `TS1308`, never a third row on the
+    /// static block's own `await`.
+    ///
+    /// The walk stops at the first container rather than searching for a static
+    /// block anywhere above, so an `await` inside a function nested in a static
+    /// block (`class C { static { void (async () => await 1); } }`) keeps
+    /// answering from its own function.
+    fn await_container_is_class_static_block(&self, idx: NodeIndex) -> bool {
+        let mut current = idx;
+        let mut iterations = 0;
+        loop {
+            iterations += 1;
+            if iterations > crate::state::MAX_TREE_WALK_ITERATIONS {
+                return false;
+            }
+            let Some(ext) = self.ctx.arena.get_extended(current) else {
+                return false;
+            };
+            let parent_idx = ext.parent;
+            if parent_idx.is_none() {
+                return false;
+            }
+            let Some(parent_node) = self.ctx.arena.get(parent_idx) else {
+                return false;
+            };
+            if parent_node.kind == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION {
+                return true;
+            }
+            if parent_node.is_function_like() || parent_node.kind == syntax_kind_ext::SOURCE_FILE {
+                return false;
+            }
+            current = parent_idx;
+        }
+    }
+
     pub(crate) fn is_directly_at_source_file_top_level(&self, idx: NodeIndex) -> bool {
         let mut current = idx;
         let mut iterations = 0;

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1603,6 +1603,26 @@ pub(super) const fn is_structural_parse_error(code: u32) -> bool {
 /// Codes the regex validator shares with non-regex contexts (TS1005, TS1125,
 /// TS1161, TS1198) are deliberately NOT here: this predicate is keyed on the
 /// code, not the emitting site, and those are real parse failures elsewhere.
+///
+/// # Containment with `is_parser_grammar_code`
+///
+/// The regex band above is one instance of a general rule, and the general rule
+/// is now stated directly: **every code `is_parser_grammar_code` accepts is
+/// non-suppressing.** That predicate means "tsc emits this from the checker via
+/// `grammarErrorOnNode`; tsz emits it from the parser instead". A checker-raised
+/// diagnostic is never in tsc's `sourceFile.parseDiagnostics`, so
+/// `hasParseDiagnostics(sourceFile)` stays `false` and every other checker
+/// grammar check in the file still runs.
+///
+/// Before that containment was stated, the two lists overlapped on only five
+/// codes (`1014`, `1047`, `1048`, `1096`, `1191`) out of ~70, so ~65
+/// parser-emitted grammar codes set `has_syntax_parse_errors` and deleted the
+/// rest of their file's checker diagnostics. Pinned against `typescript@7.0.2`
+/// with each grammar witness paired against a TS1308 (`await` outside an async
+/// function) companion, tsc reported the companion in **every** probed case —
+/// including the structurally suspicious "list is empty" members (`1097`,
+/// `1098`, `1099`, `1123`, `1182`) where a malformed AST might plausibly have
+/// justified suppression. See `parser_grammar_non_suppressing_tests`.
 pub(super) const fn is_non_suppressing_parse_error(code: u32) -> bool {
     // The regular-expression grammar band, matched as a range rather than an
     // enumeration. Every code from 1499 (`Unknown regular expression flag.`)
@@ -1612,6 +1632,19 @@ pub(super) const fn is_non_suppressing_parse_error(code: u32) -> bool {
     // the band keeps a newly wired regex diagnostic from silently suppressing
     // the rest of the file before anyone remembers to add a line here.
     if matches!(code, 1499..=1538) {
+        return true;
+    }
+
+    // Everything `is_parser_grammar_code` covers, by construction. That
+    // predicate's contract is "tsc emits this from the checker via
+    // `grammarErrorOnNode`, tsz emits it from the parser instead" — and a code
+    // tsc raises from the checker is never in `sourceFile.parseDiagnostics`, so
+    // `hasParseDiagnostics(sourceFile)` stays false and tsc's other checker
+    // grammar checks in the same file still run. Anything in that list must
+    // therefore be non-suppressing here too; the two predicates were disagreeing
+    // on ~65 codes, each of which silently deleted the rest of its file's
+    // checker grammar diagnostics.
+    if is_parser_grammar_code(code) {
         return true;
     }
 
@@ -1677,3 +1710,7 @@ mod for_in_of_single_declaration_grammar_tests;
 #[cfg(test)]
 #[path = "check_utils/audit_round_3_grammar_tests.rs"]
 mod audit_round_3_grammar_tests;
+
+#[cfg(test)]
+#[path = "check_utils/parser_grammar_non_suppressing_tests.rs"]
+mod parser_grammar_non_suppressing_tests;

--- a/crates/tsz-cli/src/driver/check_utils/parser_grammar_non_suppressing_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/parser_grammar_non_suppressing_tests.rs
@@ -1,0 +1,150 @@
+//! Unit tests for the containment
+//! `is_parser_grammar_code` ⊆ `is_non_suppressing_parse_error`.
+//!
+//! The two predicates answer different questions about the same set of codes,
+//! and before this containment was stated they disagreed on ~65 of ~70 members.
+//!
+//! - `is_parser_grammar_code` means "tsc emits this from the checker via
+//!   `grammarErrorOnNode`; tsz emits it from the parser instead". It decides
+//!   whether the code is itself suppressed when a sibling parse error exists.
+//! - `is_non_suppressing_parse_error` decides whether the code sets
+//!   `ctx.has_syntax_parse_errors`, tsz's stand-in for tsc's
+//!   `hasParseDiagnostics(sourceFile)`.
+//!
+//! A diagnostic tsc raises from the checker never lands in
+//! `sourceFile.parseDiagnostics`, so `hasParseDiagnostics` stays `false` and
+//! every other checker grammar check in the file still runs. The first
+//! predicate's contract therefore *implies* the second's answer, and the two
+//! cannot legally disagree on any code.
+//!
+//! # Oracle evidence
+//!
+//! Pinned against `typescript@7.0.2`
+//! (`--noEmit --strict --target es2022 --module esnext --pretty false`). Each
+//! witness below was compiled in a file that also contains
+//!
+//! ```text
+//! function outer() { const g = function () { return await 1; }; return g; }
+//! ```
+//!
+//! whose TS1308 (`'await' expressions are only allowed within async functions
+//! and at the top levels of modules.`) is the companion being counted. tsc
+//! reported TS1308 alongside the grammar code in **every** case below. Before
+//! the containment, tsz reported the grammar code alone in every case below.
+//!
+//! The probe is discriminating rather than vacuous for the same reason the
+//! regex-band probe is: a genuine structural error in the same slot
+//! (`const broken = ;`, TS1109) *does* drop the companion, in both compilers.
+
+use super::*;
+
+/// Grammar codes paired with the source line that provokes them, alongside the
+/// TS1308 companion described in the module docs.
+///
+/// Deliberately spans the whole shape range of `is_parser_grammar_code`, not
+/// just the convenient members: modifier-order and modifier-duplication checks,
+/// statement-level checks, the strict-mode pair, decorator placement, and — the
+/// cases most likely to have justified suppression — the "list cannot be empty"
+/// and "declaration must have an initializer" family, where the parser really
+/// does recover a malformed node. tsc keeps the companion for all of them.
+const GRAMMAR_WITNESSES: &[(u32, &str)] = &[
+    (1029, "class D { static public x = 1; }"),
+    (1028, "class E { public public y = 1; }"),
+    (1040, "declare class I { async m(): void; }"),
+    (1097, "class G implements { }"),
+    (1098, "function tp<>() { return 1; }"),
+    (1099, "type TA = Array<>;"),
+    (
+        1113,
+        "function s(v: number) { switch (v) { default: break; default: break; } }",
+    ),
+    (1114, "function l() { a: b: a: while (true) { break a; } }"),
+    (1123, "var ;"),
+    (1163, "function ng() { const q = yield 1; return q; }"),
+    (1182, "function dd() { let { p }; return p; }"),
+    (1200, "const ar = ()\n=> 1;"),
+    (1206, "@dec function bad() {}\ndeclare const dec: any;"),
+    (18037, "class C { static { const c = await 4; } }"),
+];
+
+/// Every code the parser-grammar predicate claims must also be non-suppressing.
+///
+/// This is the invariant itself, checked over the whole `u32` diagnostic range
+/// rather than over a hand-kept list, so a code added to `is_parser_grammar_code`
+/// in a later audit cannot reopen the gap by omission. `#16279`'s audit added
+/// three codes to that list in one PR; without this test each would have
+/// silently started deleting its own file's checker diagnostics.
+#[test]
+fn every_parser_grammar_code_is_non_suppressing() {
+    let mut offenders = Vec::new();
+    for code in 0..20_000_u32 {
+        if is_parser_grammar_code(code) && !is_non_suppressing_parse_error(code) {
+            offenders.push(code);
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "these codes are classified as checker-side grammar checks by \
+         is_parser_grammar_code, yet still set has_syntax_parse_errors: {offenders:?}. \
+         A code tsc raises from the checker is never in sourceFile.parseDiagnostics, \
+         so it cannot participate in hasParseDiagnostics() suppression."
+    );
+}
+
+/// The oracle-pinned witnesses, asserted individually so a failure names the
+/// code and the source that produced it rather than only a set difference.
+#[test]
+fn oracle_pinned_grammar_witnesses_are_non_suppressing() {
+    for &(code, witness) in GRAMMAR_WITNESSES {
+        assert!(
+            is_non_suppressing_parse_error(code),
+            "TS{code} must not set has_syntax_parse_errors: typescript@7.0.2 \
+             reports TS1308 alongside it for `{witness}`, so tsc's \
+             hasParseDiagnostics() is false for this file"
+        );
+    }
+}
+
+/// Guards the direction that makes the probe meaningful.
+///
+/// A real structural parse failure must keep suppressing, otherwise the
+/// containment above would be indistinguishable from deleting
+/// `has_syntax_parse_errors` altogether. TS1109 (`Expression expected.`),
+/// TS1005 (`'{0}' expected.`) and TS1128 (`Declaration or statement expected.`)
+/// are the structural codes the oracle probe used as its negative control.
+#[test]
+fn structural_parse_failures_still_suppress() {
+    for code in [1005_u32, 1109, 1128] {
+        assert!(
+            !is_non_suppressing_parse_error(code),
+            "TS{code} is a structural parse failure and must keep setting \
+             has_syntax_parse_errors; tsc drops the file's other checker \
+             diagnostics for it"
+        );
+        assert!(
+            !is_parser_grammar_code(code),
+            "TS{code} is a structural parse failure, not a checker-side grammar \
+             check; listing it in is_parser_grammar_code would also stop it from \
+             counting as the trigger in filtered_parse_diagnostics"
+        );
+    }
+}
+
+/// The five codes that already overlapped before the containment was stated.
+///
+/// They stay enumerated in `is_non_suppressing_parse_error` for documentation
+/// value; this pins that the containment now answers for them either way, so a
+/// later cleanup of the redundant enumeration cannot change behaviour.
+#[test]
+fn previously_overlapping_codes_still_answer_both_ways() {
+    for code in [1014_u32, 1047, 1048, 1096, 1191] {
+        assert!(
+            is_parser_grammar_code(code),
+            "TS{code} left the grammar list"
+        );
+        assert!(
+            is_non_suppressing_parse_error(code),
+            "TS{code} must remain non-suppressing"
+        );
+    }
+}


### PR DESCRIPTION
Closes the higher-value half of #16360, and it turned out to be a family roughly 20x larger than the issue described.

## Structural rule

**When a parser-emitted diagnostic is one tsc raises from the *checker* (`grammarErrorOnNode`), it is never in tsc's `sourceFile.parseDiagnostics`, so `hasParseDiagnostics(sourceFile)` stays false and every other checker grammar check in the file still runs; tsz does the same through `is_non_suppressing_parse_error` in the CLI driver's parse-health classification.**

Two predicates in `crates/tsz-cli/src/driver/check_utils.rs` classify the same set of codes for two different purposes, and they disagreed:

| predicate | question it answers | members |
| --- | --- | --- |
| `is_parser_grammar_code` (`:494`) | is this code itself suppressed when a sibling parse error exists? | ~70 |
| `is_non_suppressing_parse_error` (`:1606`) | does this code set `ctx.has_syntax_parse_errors`, tsz's stand-in for `hasParseDiagnostics()`? | ~15 + the `1499..=1538` regex band |

The first predicate's contract *implies* the second's answer — a checker-raised diagnostic cannot participate in `hasParseDiagnostics` suppression — so the containment `is_parser_grammar_code` ⊆ `is_non_suppressing_parse_error` must hold. It did not: the lists overlapped on **5 codes out of ~70** (1014, 1047, 1048, 1096, 1191). The other ~65 each set `has_syntax_parse_errors`, which is read at 30+ sites in `tsz-checker` — `check_await_expression`'s TS1308, `name_resolution.rs`'s TS2304 and its suggestions, `properties.rs`'s TS2339, `assignability_suppression.rs`, the `noImplicitAny` circularity checkers. A single misplaced modifier keyword silently deleted the rest of its file's checker diagnostics.

This is the same defect the regex band was fixed for, one layer up: the fix states the general rule instead of enumerating a second family under it.

Second change, in the checker: tsc's `checkAwaitExpression` opens with `if (container && isClassStaticBlockDeclaration(container))` and puts the whole TS1308 / TS1375 / TS1378 / TS1309 family in its `else if`. That branch is **exclusive** — a class static block answers TS18037 and nothing else. tsz's parser emits TS18037 and the checker's await-grammar walk emitted its own diagnostic independently; the suppression was hiding it. Unsuppressing without this produced two rows on one `await`. Owner layer: `types/type_checking/core_statement_checks.rs`, mirroring `getContainingFunctionOrClassStaticBlock` with a first-container walk (so an `await` inside a function *nested* in a static block still answers from its own function).

## Adjacent-case matrix

21 rows, every one pinned against the repo's pinned oracle `typescript@7.0.2` (`--noEmit --strict --target es2022 --module esnext --pretty false`). Each grammar witness shares its file with a TS1308 companion; the companion is what the suppression was eating.

**Before: 3 of 21 matched tsc. After: 20 of 21.**

| witness | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| baseline (no grammar code) | TS1308 | TS1308 | TS1308 |
| `class D { static public x = 1 }` | TS1029 + TS1308 | TS1029 | TS1029 + TS1308 |
| `class E { public public y = 1 }` | TS1028 + TS1308 | TS1028 | TS1028 + TS1308 |
| `declare class I { async m(): void }` | TS1040 + TS1064 + TS1308 | TS1040 + TS1064 | match |
| `class G implements { }` | TS1097 + TS1308 | TS1097 | match |
| `function tp[ ]() { }` (empty type-param list) | TS1098 + TS1308 | TS1098 | match |
| `type TA = Array[ ];` (empty type-arg list) | TS1099 + TS1308 + TS2314 | TS1099 + TS2314 | match |
| duplicate `default:` clause | TS1113 + TS1308 | TS1113 | match |
| duplicate label | TS1114 + TS1308 | TS1114 | match |
| `var ;` | TS1123 + TS1308 | TS1123 | match |
| `yield` outside a generator | TS1163 + TS1308 | TS1163 | match |
| `let { p };` (destructuring, no initializer) | TS1182 + TS1308 + TS7031 | TS1182 + TS7031 | match |
| line terminator before `=>` | TS1200 + TS1308 | TS1200 | match |
| `@dec function bad() {}` | TS1206 + TS1308 | TS1206 | match |
| `with` in a class method | TS1101 + TS1308 + TS2410 | TS1101 + TS2410 | match |
| `let yield` in strict mode | TS1213 + TS1308 | TS1213 + TS1308 | match (already correct) |
| `class J { abstract k = 1 }` | TS1253 + TS1267 + TS1308 | already correct | match |
| **`class C { static { const c = await 4 } }`** | **TS1308 + TS18037** | **TS18037 only** | **match** |
| `class K { static { void (async () =[gt] await 1) } }` + `return` in static block | TS1308 + TS18041 | — | match |
| `class M { static { for await (…) } }` | TS18038 | — | match |
| `function mm() { public const z = 1 }` | TS1184 + TS1308 | TS1044 only | TS1044 + **TS1308** — see below |

Deliberately spans the whole shape range, not the convenient members: modifier order and duplication, statement-level checks, the strict-mode pair, decorator placement, and — the cases most likely to have *justified* suppression — the "list cannot be empty" / "declaration must have an initializer" family (TS1097/1098/1099/1123/1182), where the parser really does recover a malformed node. tsc keeps the companion for every one of them.

**Negative control** (what makes the probe discriminating rather than vacuous): a genuine structural failure in the same slot (`const broken = ;`, TS1109) still drops the companion, in both compilers. `structural_parse_failures_still_suppress` pins TS1005/TS1109/TS1128 on both sides of the containment.

**The one remaining row is a pre-existing, unrelated wrong-code divergence**, not a regression: for `public const z = 1` inside a function body tsz reports TS1044 (`'{0}' modifier cannot appear on a module or namespace element`) where tsc reports TS1184 (`Modifiers cannot appear here`). This PR fixes the missing TS1308 on that row and leaves the code choice alone; filed separately rather than folded in.

## Anti-hardcoding

No identifier, alias, property or file-name strings; no predicate over rendered output. The containment is a set relation between two existing code predicates, and the static-block branch is a syntax-kind container walk (`CLASS_STATIC_BLOCK_DECLARATION`), which is what tsc keys on.

## Goal
Goal: hold

## Verification
- **Oracle matrix**: 21 rows against pinned `typescript@7.0.2`, table above. **3/21 → 20/21 matching**; the single remainder is the pre-existing TS1044-vs-TS1184 code choice.
- `cargo nextest run -p tsz-cli` — pending, will post counts.
- `cargo clippy --workspace --all-targets` (warnings denied) — pending, will post.
- `scripts/conformance/compare-to-parent.sh origin/main` — two-sided, running at PR-open time. **This is the gate that matters for this change** (unlike the recent `LocationPointer` related-info PRs, this one is plain-mode visible by construction), and the number goes here before the PR is queued.
- New unit tests: `parser_grammar_non_suppressing_tests` — four tests, including `every_parser_grammar_code_is_non_suppressing`, which checks the invariant over the whole diagnostic range rather than a hand-kept list, so a future audit adding a code to `is_parser_grammar_code` (as #16279 did for three codes) cannot silently reopen the gap.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Ilmenite

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVwy8hxWGjnDZJhMYzat5B)_