### PR TITLE
fix(cli): pretty-mode chain links render before the snippet, not after it as a spurious located block

### DIFF
--- a/crates/tsz-cli/src/reporting/reporter.rs
+++ b/crates/tsz-cli/src/reporting/reporter.rs
@@ -197,6 +197,21 @@ impl Reporter {
         let message = self.translate_message(diagnostic.code, &diagnostic.message_text);
         out.push_str(&message);
 
+        // Chain links are part of `tsc`'s flattened `messageText`, not its
+        // `relatedInformation`, so they render immediately after the message
+        // — before the primary's own snippet — in both pretty and non-pretty
+        // mode. Oracled on a nested property-type-mismatch (`typescript@7.0.2`,
+        // `--pretty --strict`): the "Types of ... are incompatible" / "Type
+        // 'string' is not assignable ..." lines print directly under the
+        // header, then a blank line, then the primary's snippet.
+        for related in &diagnostic.related_information {
+            if related.is_location_pointer() {
+                continue;
+            }
+            out.push('\n');
+            self.format_related_plain(out, related);
+        }
+
         // Source snippet
         if let Some(snippet) =
             self.format_snippet_pretty(&diagnostic.file, diagnostic.start, diagnostic.length, 0)
@@ -205,11 +220,13 @@ impl Reporter {
             out.push_str(&snippet);
         }
 
-        // Related information. Each entry supplies its own leading newline(s):
-        // a located entry is separated from what precedes it by a blank line,
-        // an unlocated chain link is not.
+        // Cross-location pointers (`tsc`'s `relatedInformation`) render after
+        // the primary's own snippet, each with its own blank line, location
+        // header, and snippet.
         for related in &diagnostic.related_information {
-            self.format_related_pretty(out, related);
+            if related.is_location_pointer() {
+                self.format_related_pretty(out, related);
+            }
         }
     }
 
@@ -330,29 +347,28 @@ impl Reporter {
         out.push_str(&message);
     }
 
-    /// Format related information in pretty mode.
+    /// Format a cross-location [`RelatedInformationKind::LocationPointer`] in
+    /// pretty mode — a genuine `tsc` `relatedInformation` entry such as a
+    /// "declared here" pointer. Callers only reach this for pointers;
+    /// [`RelatedInformationKind::ChainLink`] entries are folded into the
+    /// primary's flattened message in [`Reporter::format_diagnostic_pretty`]
+    /// instead, before the primary's own snippet.
     ///
-    /// A *located* entry — one that names a file, i.e. a genuine cross-location
-    /// "declared here" pointer — is preceded by a blank line and puts its
-    /// message on the location line, with the source snippet underneath:
+    /// A pointer is preceded by a blank line and puts its message on the
+    /// location line, with the source snippet underneath:
     /// ```text
     ///
     ///   file:line:col - message
     ///     {line_num} {source_line}
     ///     {spaces}{tildes}
     /// ```
-    /// An *unlocated* entry is a message-chain link (tsc keeps these in
-    /// `messageText` rather than `relatedInformation`), and renders as plain
-    /// indented text with no blank line and no location, exactly as in
-    /// non-pretty mode.
     fn format_related_pretty(&mut self, out: &mut String, related: &DiagnosticRelatedInformation) {
+        debug_assert!(
+            related.is_location_pointer(),
+            "format_related_pretty is only called for LocationPointer entries; \
+             ChainLink entries are rendered by format_diagnostic_pretty before the snippet"
+        );
         let message = self.translate_message(related.code, &related.message_text);
-
-        if related.file.is_empty() {
-            out.push('\n');
-            self.format_related_plain(out, related);
-            return;
-        }
 
         // Blank line, then the location line (2-space indent).
         out.push_str("\n\n  ");
@@ -882,7 +898,7 @@ mod tests {
             "This parameter is not allowed with 'use strict' directive.",
             1346,
         );
-        diagnostic.related_information.push(related_at(
+        diagnostic.related_information.push(pointer_at(
             "us.ts",
             20,
             13,
@@ -922,7 +938,7 @@ mod tests {
             "'use strict' directive cannot be used with non-simple parameter list.",
             1347,
         );
-        diagnostic.related_information.push(related_at(
+        diagnostic.related_information.push(pointer_at(
             "multi.ts",
             11,
             5,
@@ -930,7 +946,7 @@ mod tests {
         ));
         diagnostic
             .related_information
-            .push(related_at("multi.ts", 18, 9, "and here."));
+            .push(pointer_at("multi.ts", 18, 9, "and here."));
 
         let mut out = String::new();
         reporter.format_diagnostic_pretty(&mut out, &diagnostic);
@@ -998,6 +1014,72 @@ mod tests {
             "error TS6504: File 'root.js' is a JavaScript file. Did you mean to enable the 'allowJs' option?\n\
              \x20 The file is in the program because:\n\
              \x20   Root file specified for compilation",
+            "rendered:\n{out}"
+        );
+    }
+
+    /// A chain link commonly carries the *same* file/span as its own parent
+    /// diagnostic — `push_elaboration` anchors nested property-mismatch
+    /// elaboration at the primary's own span, not a distinct location — so
+    /// dispatch must key off `kind`, never off whether `file` is empty, or a
+    /// same-file chain link gets misrendered as a second, spurious located
+    /// block. tsc 7.0.2, `--pretty --strict`, on
+    /// `interface A { x: { a: string } } interface B { x: { a: number } }
+    /// const b: B = {} as A;`:
+    ///
+    /// ```text
+    /// rel2.ts:3:7 - error TS2322: Type 'A' is not assignable to type 'B'.
+    ///   The types of 'x.a' are incompatible between these types.
+    ///     Type 'string' is not assignable to type 'number'.
+    ///
+    /// 3 const b: B = {} as A;
+    ///         ~
+    /// ```
+    /// The chain lines sit directly under the header with no blank line
+    /// before them, and the primary's own snippet comes *after* the whole
+    /// chain — the reverse of a pointer, whose snippet always follows a
+    /// blank line and its own location header.
+    #[test]
+    fn pretty_chain_link_with_real_file_renders_before_the_primary_snippet() {
+        let source = "const b: B = {} as A;\n";
+        let mut reporter = reporter_with_source("rel2.ts", source);
+
+        let mut diagnostic = Diagnostic::error(
+            "rel2.ts".to_string(),
+            6,
+            1,
+            "Type 'A' is not assignable to type 'B'.",
+            2322,
+        );
+        diagnostic.related_information.push(related_at(
+            "rel2.ts",
+            6,
+            1,
+            "The types of 'x.a' are incompatible between these types.",
+        ));
+        diagnostic
+            .related_information
+            .push(DiagnosticRelatedInformation {
+                depth: 1,
+                ..related_at(
+                    "rel2.ts",
+                    6,
+                    1,
+                    "Type 'string' is not assignable to type 'number'.",
+                )
+            });
+
+        let mut out = String::new();
+        reporter.format_diagnostic_pretty(&mut out, &diagnostic);
+
+        assert_eq!(
+            out,
+            "rel2.ts:1:7 - error TS2322: Type 'A' is not assignable to type 'B'.\n\
+             \x20 The types of 'x.a' are incompatible between these types.\n\
+             \x20   Type 'string' is not assignable to type 'number'.\n\
+             \n\
+             1 const b: B = {} as A;\n\
+             \x20       ~",
             "rendered:\n{out}"
         );
     }

--- a/crates/tsz-cli/tests/reporter_tests.rs
+++ b/crates/tsz-cli/tests/reporter_tests.rs
@@ -405,19 +405,27 @@ fn pretty_mode_renders_related_location_snippet_and_message() {
     write_file(&decl_path, "declare function foo(): void;\n");
 
     let related_start = "declare function ".len() as u32;
-    let diagnostic = Diagnostic::error(
+    let mut diagnostic = Diagnostic::error(
         main_path.to_string_lossy().into_owned(),
         0,
         3,
         "Cannot find name 'foo'.".to_string(),
         2304,
-    )
-    .with_related(
-        decl_path.to_string_lossy().into_owned(),
-        related_start,
-        3,
-        "The symbol is declared here.",
     );
+    // A cross-file "declared here" reference is a genuine `relatedInformation`
+    // pointer, not a `messageText` chain link — tag it explicitly rather than
+    // via `with_related` (which defaults to `ChainLink`, the common case for
+    // same-span elaboration), or pretty mode renders it as plain indented
+    // text before the primary's snippet instead of a located block after it.
+    diagnostic
+        .related_information
+        .push(Diagnostic::related_pointer(
+            0,
+            decl_path.to_string_lossy().into_owned(),
+            related_start,
+            3,
+            "The symbol is declared here.",
+        ));
 
     let mut reporter = Reporter::new(false);
     reporter.set_pretty(true);


### PR DESCRIPTION
## Goal
Goal: hold

Fixes the remaining pretty-mode half of #16316, left open by #16338's "Follow-ups deliberately left out": *"Chain links that carry a real file still render in pretty mode as located blocks with a snippet, where tsc would render them as indented message-chain text."*

**Structural rule.** `tsc` composes a diagnostic's flattened `messageText` (the primary message plus every `DiagnosticMessageChain` link) into one block that prints immediately under the header — before the primary's own source snippet — in both `--pretty` and non-pretty mode. Only entries in `relatedInformation` (genuine cross-location "declared here" pointers) get their own blank line, location header, and snippet, and only in `--pretty`. `tsz` models both `tsc` concepts in one `DiagnosticRelatedInformation` vec, discriminated since #16338 by `RelatedInformationKind::{ChainLink, LocationPointer}` — but `format_related_pretty` still dispatched on `!related.file.is_empty()` instead of `related.kind`. A chain link commonly carries a real file (`push_elaboration` anchors nested elaboration at the primary's own file/span — e.g. a "Types of property 'x' are incompatible" chain), so it took the located-block branch: rendered after the primary's snippet, with its own spurious blank line, location header, and duplicate snippet, instead of as plain indented text before the snippet.

Oracle (`typescript@7.0.2`, `--noEmit --strict --pretty --target es2022 --lib es2022`), on
```ts
interface A { x: { a: string } }
interface B { x: { a: number } }
const b: B = {} as A;
```
```
rel2.ts:3:7 - error TS2322: Type 'A' is not assignable to type 'B'.
  The types of 'x.a' are incompatible between these types.
    Type 'string' is not assignable to type 'number'.

3 const b: B = {} as A;
        ~
```
Chain lines sit directly under the header with no blank line, then the primary's snippet — the reverse of the current (pre-fix) tsz order.

### What changed
- `format_diagnostic_pretty` now renders `ChainLink` related entries (via the existing `format_related_plain`) immediately after the message and *before* the primary's snippet, then renders only `LocationPointer` entries after the snippet — matching `tsc`'s messageText-vs-relatedInformation split instead of branching on whether `file` happens to be empty.
- `format_related_pretty` is simplified to assume (via `debug_assert!`) it is only ever called for pointers, since its sole caller now filters by `kind`.
- Two existing tests (`pretty_located_related_puts_message_on_the_location_line`, `pretty_blank_line_precedes_every_located_related_entry`) modeled genuine TS1348/TS1349 "declared here" pointers with the `related_at` (`ChainLink`-defaulting) helper rather than `pointer_at` — cosmetically fine under the old file-based dispatch, but silently relying on the bug being present. Switched to `pointer_at` so they pin production behavior (`checkers/use_strict_parameter_list.rs` already tags these `LocationPointer`), not an artifact of the dispatch bug.
- `crates/tsz-cli/tests/reporter_tests.rs::pretty_mode_renders_related_location_snippet_and_message` built its cross-file "declared here" fixture through `Diagnostic::with_related`, a generic helper that always tags `ChainLink` (correct for same-span elaboration, its dominant real use in `tsz-checker`/`tsz-solver`). Switched to `Diagnostic::related_pointer` so the fixture matches what it is actually modeling.
- New unit test `pretty_chain_link_with_real_file_renders_before_the_primary_snippet` pins the oracle shape above.

### Adjacent cases covered
- Pointer with own location + own snippet, after the primary's snippet (unchanged, re-pinned with the correct `kind` tag).
- Multiple pointers, each with its own blank line (unchanged, re-pinned).
- Unlocated chain link (`file` empty, e.g. TS6504's "file is in the program because") — unchanged, still renders as plain indented text.
- **New:** same-file chain link (the common case for nested property/argument mismatch elaboration) — now renders before the snippet as plain indented text, not as a second located block.
- Mixed chain-link + pointer on one diagnostic — still exercised by `pretty_output_still_renders_pointers_that_plain_output_drops`.

Diagnostic decisions here read only the structural `kind` tag set by the checker at construction time; nothing branches on rendered text, file names, or diagnostic codes.

## Verification
- `cargo test -p tsz-cli --lib reporter` (unit `reporting::reporter::tests::*` + integration `reporter_tests::*`) — **27/27** pass at head `7729eed`, including the new regression test, the two re-pinned pointer tests, and the corrected cross-file fixture.
- `cargo clippy -p tsz-cli --all-targets -- -D warnings` — clean.
- `cargo fmt -p tsz-cli -- --check` — clean.
- `python3 scripts/arch/arch_guard.py` — `Architecture guardrails passed.`
- Full `cargo test -p tsz-cli --lib` (with a debug `tsz` binary built so `tsc_compat_tests` can run against it): **1696 passed, 19 failed** at this head. All 19 failures reproduce **identically** on unmodified `main` (verified via `git stash`): 13 are `tsc_compat_tests` cases that depend on the environment's `tsc` (PATH fallback resolves to a different version/help text than the pinned oracle, not present as `scripts/node_modules`), 2 are the known-baseline `check_tests` failures in `scripts/ci/known-failures.txt:128-129`, and 3 are `driver_tests` cases sensitive to running as root in this container (e.g. the tsbuildinfo-not-writable simulation). None are new; the diff here touches only `crates/tsz-cli/src/reporting/reporter.rs` and its own tests.
- Not run: conformance, emit, fourslash. The change is confined to the CLI's pretty-mode presentation layer (no checker/solver/emit path touched), so no drift is expected — but that is a scoping argument, not a measurement.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1wbaXJ9vVZDPRoLb4hCdy)_