### PR TITLE
fix(checker): class static block await no longer suppresses TS1308 program-wide

### DIFF
--- a/crates/tsz-checker/src/tests/await_static_block_grammar_tests.rs
+++ b/crates/tsz-checker/src/tests/await_static_block_grammar_tests.rs
@@ -6,11 +6,7 @@
 //! already emits TS18037 for any `await` parsed while `in_static_block_context()`
 //! is set, regardless of how deeply the `await` sits inside intervening
 //! statements (`while`, `for`, `switch`, ...) — the context flag survives
-//! statement nesting and is only cleared at a function/class boundary. That
-//! parser diagnostic sets `has_syntax_parse_errors`, which suppresses
-//! `check_await_expression`'s own TS1308 grammar walk
-//! (`core_statement_checks.rs`) for the same file. So on current `main` this
-//! family already matches tsc: exactly TS18037, never an accompanying TS1308.
+//! statement nesting and is only cleared at a function/class boundary.
 //!
 //! #16068 reported the opposite (TS1308 instead of TS18037) — that read came
 //! from `test_utils::check_source_codes`, which never wires real parser
@@ -19,8 +15,131 @@
 //! can neither see the parser's TS18037 nor let it suppress the checker's
 //! TS1308. These tests use the parse-health-aware helper instead, so they
 //! reflect what the compiled CLI actually reports.
+//!
+//! `static_block_own_node_no_double_report_when_not_globally_suppressed` and
+//! `static_block_await_does_not_suppress_unrelated_ts1308_program_wide` below
+//! instead build a `CheckerState` directly with `has_syntax_parse_errors`
+//! computed the way `tsz-cli`'s `check_file.rs`/`check_utils.rs::is_non_suppressing_parse_error`
+//! compute it in production (TS18037 excluded), rather than the
+//! `!parse_diagnostics.is_empty()` coarse signal
+//! `check_source_codes_with_parse_health` uses. That coarse signal makes
+//! `has_syntax_parse_errors` true for *any* file containing an `await` inside
+//! a static block, same as before #16360's fix — so it cannot exercise the
+//! cross-file suppression bug #16360 reported (a static block's TS18037
+//! deleting an unrelated function's TS1308 elsewhere in the same file) or its
+//! fix (`is_non_suppressing_parse_error` no longer includes TS18037; the
+//! static block's own node is instead skipped explicitly via
+//! `find_enclosing_static_block` in `check_await_expression_in_container`,
+//! matching tsc's `checkAwaitExpression`, which returns after its own
+//! static-block diagnostic without falling through to the "only allowed
+//! within async functions" check).
 
+use crate::context::CheckerOptions;
+use crate::query_boundaries::common::TypeInterner;
+use crate::state::CheckerState;
 use crate::test_utils::check_source_codes_with_parse_health;
+use tsz_binder::BinderState;
+use tsz_parser::parser::ParserState;
+
+/// Parse, bind, and check `source` with `has_syntax_parse_errors` computed
+/// the way `tsz-cli` computes it in production: TS18037 (check-time grammar
+/// in tsc, parser-emitted in tsz — see `check_utils.rs::is_non_suppressing_parse_error`)
+/// does not count as a "real" syntax error. Returns `(parser codes, checker
+/// codes)` like `test_utils::check_source_with_parse_health`.
+fn check_with_production_suppression(source: &str) -> (Vec<u32>, Vec<u32>) {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let source_file = parser.parse_source_file();
+    let parse_diagnostics = parser.get_diagnostics().to_vec();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), source_file);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        CheckerOptions::default(),
+    );
+    checker.enable_source_file_test_pragmas();
+    checker.ctx.set_lib_contexts(Vec::new());
+    let real_syntax_errors: Vec<u32> = parse_diagnostics
+        .iter()
+        .filter(|d| d.code != 18037)
+        .map(|d| d.start)
+        .collect();
+    checker.ctx.has_parse_errors = !real_syntax_errors.is_empty();
+    checker.ctx.has_syntax_parse_errors = !real_syntax_errors.is_empty();
+    checker.ctx.syntax_parse_error_positions = real_syntax_errors;
+    checker.ctx.all_parse_error_positions =
+        parse_diagnostics.iter().map(|diag| diag.start).collect();
+    checker.check_source_file(source_file);
+
+    let parse_codes = parse_diagnostics.iter().map(|diag| diag.code).collect();
+    let checker_codes = checker
+        .ctx
+        .diagnostics
+        .iter()
+        .map(|diag| diag.code)
+        .collect();
+    (parse_codes, checker_codes)
+}
+
+/// #16360: a class static block's `await` must not delete an unrelated
+/// function's TS1308 elsewhere in the same file. tsc reports all three
+/// diagnostics (TS1308, TS18037, TS1308) for this file; before #16360's fix,
+/// tsz reported only TS18037 — the static block's TS18037 parse diagnostic
+/// set `has_syntax_parse_errors` file-wide, which gates `check_await_expression_in_container`'s
+/// entire TS1308/TS1375/TS1378 walk.
+#[test]
+fn static_block_await_does_not_suppress_unrelated_ts1308_program_wide() {
+    let (parse_codes, checker_codes) = check_with_production_suppression(
+        r#"
+function outer() { const g = function () { return await 1; }; return g; }
+class C { static { const c = await 4; } }
+function* gen() { const d = await 5; return d; }
+"#,
+    );
+    assert!(
+        parse_codes.contains(&18037),
+        "got parse codes {parse_codes:?}"
+    );
+    assert_eq!(
+        checker_codes.iter().filter(|&&c| c == 1308).count(),
+        2,
+        "tsc reports TS1308 for both `outer`'s and `gen`'s awaits — the static block's own TS18037 must not suppress either; got checker codes {checker_codes:?}"
+    );
+}
+
+/// #16360's second defect: `is_directly_at_source_file_top_level` did not
+/// stop its container walk at `CLASS_STATIC_BLOCK_DECLARATION`, so a static
+/// block's `await` walked all the way up to `SourceFile` and was
+/// misclassified as top-level `await` (TS1375/TS1378) instead of TS1308 —
+/// latent and unobservable before #16360's fix because
+/// `has_syntax_parse_errors` already suppressed this whole branch whenever a
+/// static block's `await` was present. This is a pure checker-classification
+/// bug: reproducible even with `has_syntax_parse_errors` correctly cleared.
+#[test]
+fn static_block_own_node_no_double_report_when_not_globally_suppressed() {
+    let (parse_codes, checker_codes) = check_with_production_suppression(
+        r#"
+class C { static { await 1; } }
+"#,
+    );
+    assert!(
+        parse_codes.contains(&18037),
+        "got parse codes {parse_codes:?}"
+    );
+    assert!(
+        !checker_codes.contains(&1375) && !checker_codes.contains(&1378),
+        "a static block's `await` is never at the source file's top level; got checker codes {checker_codes:?}"
+    );
+    assert!(
+        !checker_codes.contains(&1308),
+        "TS18037 (parser) already covers this `await`; a second TS1308 (checker) would be extra output tsc never produces; got checker codes {checker_codes:?}"
+    );
+}
 
 /// #16068's literal repro: `await` in a static block reached through a
 /// `while` condition, not the block's own top-level statement.

--- a/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
+++ b/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
@@ -861,6 +861,16 @@ impl<'a> CheckerState<'a> {
                                     );
                                 }
                             }
+                        } else if self.find_enclosing_static_block(current_idx).is_some() {
+                            // The parser already reported TS18037 for this
+                            // `await` (directly inside a class static block,
+                            // not a nested async function). tsc's
+                            // `checkAwaitExpression` returns after its own
+                            // static-block diagnostic without falling
+                            // through to "await expressions are only
+                            // allowed within async functions" — matching
+                            // that here avoids a TS18037+TS1308 double
+                            // report tsc never produces for the same node.
                         } else {
                             // TS1308: 'await' expressions are only allowed within async functions.
                             // tsc points the reader at the function that would
@@ -969,6 +979,7 @@ impl<'a> CheckerState<'a> {
                 || parent_node.kind == syntax_kind_ext::MODULE_DECLARATION
                 || parent_node.kind == syntax_kind_ext::PROPERTY_DECLARATION
                 || parent_node.kind == syntax_kind_ext::PARAMETER
+                || parent_node.kind == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION
             {
                 return false;
             }

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1535,6 +1535,22 @@ pub(super) const fn is_structural_parse_error(code: u32) -> bool {
 /// - TS1214: Identifier expected (strict mode reserved word)
 /// - TS1262: 'await' at top level
 /// - TS1359: 'await' in async context
+/// - TS18037: 'await' expression inside a class static block
+///
+/// TS18037 belongs here for the same reason as TS1096: tsc reports it from
+/// `checkAwaitExpression` at CHECK time (the `await` parses fine as an
+/// expression), so it never participates in tsc's `hasParseDiagnostics()`
+/// suppression. tsz emits it from `parse_await_expression` during parsing
+/// instead, so without this entry a class static block's `await` sets
+/// `has_syntax_parse_errors` and silently drops every *other* TS1308/TS1375/
+/// TS1378 ('await' outside an async function/module top level) diagnostic in
+/// the same file — those checks gate on the same flag in
+/// `check_await_expression_in_container` (`core_statement_checks.rs`). The
+/// static block's own `await` does not get a redundant TS1308 once this flag
+/// is cleared: `check_await_expression_in_container` skips it separately via
+/// `find_enclosing_static_block`, matching tsc's `checkAwaitExpression`,
+/// which returns after the static-block diagnostic without falling through
+/// to the "only allowed within async functions" check.
 ///
 /// tsc emits TS7006/TS7019 even in the presence of these errors because
 /// the parameter identity (name) is still valid and can be type-checked.
@@ -1627,6 +1643,8 @@ pub(super) const fn is_non_suppressing_parse_error(code: u32) -> bool {
             | 1214 // Identifier expected (strict mode reserved word)
             | 1262 // 'await' at top level
             | 1359 // 'await' in async context
+            | 18037 // 'await' expression cannot be used inside a class static block
+                    // (check-time grammar in tsc; see doc comment above)
             | 1492 // 'using' declarations may not have binding patterns (grammar constraint, AST is valid)
             | 1487 // Octal escape sequences are not allowed (regex `\0`-prefixed decimal escape,
                    // AST is valid). Outside the contiguous regex band handled above — shared
@@ -1677,3 +1695,7 @@ mod for_in_of_single_declaration_grammar_tests;
 #[cfg(test)]
 #[path = "check_utils/audit_round_3_grammar_tests.rs"]
 mod audit_round_3_grammar_tests;
+
+#[cfg(test)]
+#[path = "check_utils/await_static_block_suppression_tests.rs"]
+mod await_static_block_suppression_tests;

--- a/crates/tsz-cli/src/driver/check_utils/await_static_block_suppression_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/await_static_block_suppression_tests.rs
@@ -1,0 +1,22 @@
+//! Unit test for the `is_non_suppressing_parse_error` entry added for
+//! #16360's cross-file suppression bug. Split into its own file rather than
+//! growing `tests.rs` past the 2000-line limit (already over before this
+//! change), mirroring `rest_parameter_grammar_tests.rs`.
+//!
+//! TS18037 ('await' expression cannot be used inside a class static block)
+//! is a check-time grammar error in tsc (`checkAwaitExpression`) on an
+//! otherwise well-formed AST — tsz emits it from the parser instead
+//! (`parse_await_expression`), so before this entry it set
+//! `has_syntax_parse_errors` and deleted every other TS1308/TS1375/TS1378
+//! ('await' outside an async function, or outside a module at the top
+//! level) diagnostic elsewhere in the same file.
+
+use super::*;
+
+#[test]
+fn class_static_block_await_error_does_not_suppress_grammar_diagnostics() {
+    assert!(
+        is_non_suppressing_parse_error(18037),
+        "TS18037 (await inside class static block) should be non-suppressing"
+    );
+}


### PR DESCRIPTION
Closes the false-negative half of #16360 (the higher-value half per the issue's own framing).

## What's wrong

`tsc` emits **TS18037** (`'await' expression cannot be used inside a class static block`) from `checkAwaitExpression` at *check* time, so it never participates in `hasParseDiagnostics()` suppression. tsz emits it from `parse_await_expression` (`crates/tsz-parser/src/parser/state_expressions_unary.rs`) — a *parser* diagnostic — which sets `has_syntax_parse_errors` file-wide and silently deletes every other TS1308/TS1375/TS1378 (`'await'` outside an async function, or outside a module top level) diagnostic elsewhere in the same file.

Witness (`typescript@7.0.2`, `--noEmit --strict --target es2022 --module esnext --pretty false`):

```ts
function outer() { const g = function () { return await 1; }; return g; }
class C { static { const c = await 4; } }
function* gen() { const d = await 5; return d; }
```

- tsc: 3 errors — TS1308 (outer), TS18037 (static block), TS1308 (gen)
- tsz before: 1 error — TS18037 only (both TS1308s deleted)
- tsz after: matches tsc exactly

## Structural rule

When a class static block's `await` is check-time grammar in tsc (not a parse failure), tsz must not let its own parser-emitted equivalent poison `has_syntax_parse_errors` for the rest of the file — the same precedent already established for TS1096 and the `TS1499..=TS1538` regex band in `is_non_suppressing_parse_error` (`crates/tsz-cli/src/driver/check_utils.rs`).

## Fix

1. Add `18037` to `is_non_suppressing_parse_error`.
2. So the static block's *own* `await` doesn't now double-report (TS18037 + TS1308) once the flag clears: `check_await_expression_in_container` (`crates/tsz-checker/src/types/type_checking/core_statement_checks.rs`) now skips the TS1308 branch for a node inside a static block via the existing `find_enclosing_static_block` query, matching tsc's `checkAwaitExpression`, which returns after its own static-block diagnostic without falling through to the "only allowed within async functions" check.

## A second, previously latent bug this surfaced

Un-suppressing revealed that `is_directly_at_source_file_top_level` did not stop its container walk at `CLASS_STATIC_BLOCK_DECLARATION`, so a static block's `await` walked all the way to `SourceFile` and was misclassified as top-level `await` — producing a spurious TS1375 for `class C { static { const c = await 4; } }` once the file-wide suppression no longer masked it. Fixed by adding that node kind to the walk's disqualifying-container list, alongside the existing function/module/property/parameter entries.

## Adjacent-case matrix

All rows oracle-verified against pinned `typescript@7.0.2`, `--pretty false`:

| Shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| Static block await + unrelated non-async fn awaits elsewhere in file | TS1308, TS18037, TS1308 | TS18037 only | matches |
| Static block await, nested **async** fn inside it | clean | clean | clean (unchanged) |
| Static block await, nested **non-async** fn inside it (own container) | TS1308 | TS1308 | TS1308 (unchanged) |
| Static block nested inside another static block | TS18037 | TS18037 | TS18037 (unchanged) |
| Ordinary async function awaits (regression control) | clean | clean | clean (unchanged) |

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib await_static_block_grammar_tests`: 18/18 passed, including 2 new tests exercising the fix directly (`static_block_await_does_not_suppress_unrelated_ts1308_program_wide`, `static_block_own_node_no_double_report_when_not_globally_suppressed`) via a helper that computes `has_syntax_parse_errors` the way `tsz-cli` computes it in production, unlike the existing coarse `check_source_codes_with_parse_health` helper which can't observe this class of bug (see the file's updated module doc).
- `cargo test -p tsz-cli --lib class_static_block_await_error_does_not_suppress_grammar_diagnostics`: 1/1 passed (new `is_non_suppressing_parse_error(18037)` unit test, own file per the 2000-line-shard rule, mirroring `rest_parameter_grammar_tests.rs`'s precedent).
- `cargo test -p tsz-checker --lib await`: 229/229 passed (full await-family regression sweep).
- `cargo test -p tsz-checker --lib`: 9406 passed, 1 failed — `ts2303_tests::recursive_export_assignment_self_import_reports_ts2303`, a pre-existing baselined entry (`scripts/ci/known-failures.txt:127`), unrelated to this change.
- `cargo clippy -p tsz-checker -p tsz-cli --lib --all-targets -- -D warnings`: clean.
- `cargo fmt -p tsz-checker -p tsz-cli -- --check`: clean.
- `python3 scripts/arch/arch_guard.py`: passes.
- Manual oracle comparison (pinned `typescript@7.0.2`) across the full adjacent-case matrix above, via the compiled `dist-fast`-equivalent release `tsz` binary: byte-for-byte match on every row.
- `scripts/conformance/compare-to-parent.sh origin/main`: running now (this is a plain-mode-visible behavior change — new TS1308 diagnostics can appear program-wide — not a `LocationPointer` entry, so it needs the two-sided corpus check). Will post the newly-passing/newly-failing counts in a follow-up comment before landing.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZvz6ZtxMHC89xRwVSHG5L)_