### PR TITLE
fix(checker): anchor TS1308/TS1103/TS1375/TS1378 on the `await` keyword token

### DIFF
--- a/crates/tsz-checker/src/error_reporter/mod.rs
+++ b/crates/tsz-checker/src/error_reporter/mod.rs
@@ -50,6 +50,7 @@ mod property_receiver_formatting;
 mod recursive_alias_display;
 mod render_failure;
 mod suggestions;
+mod token_anchors;
 mod ts2820_display;
 pub(crate) mod type_display_policy;
 mod type_query_alias_display;

--- a/crates/tsz-checker/src/error_reporter/token_anchors.rs
+++ b/crates/tsz-checker/src/error_reporter/token_anchors.rs
@@ -1,0 +1,136 @@
+//! Token-anchored diagnostic spans.
+//!
+//! A family of `tsc` grammar diagnostics is anchored with
+//! `getSpanOfTokenAtPosition(sourceFile, pos)` rather than with the span of
+//! the node that triggered them:
+//!
+//! ```js
+//! function getSpanOfTokenAtPosition(sourceFile, pos) {
+//!   const scanner = createScanner(..., sourceFile.text, /*onError*/ undefined, pos);
+//!   scanner.scan();
+//!   return createTextSpanFromBounds(scanner.getTokenStart(), scanner.getTokenEnd());
+//! }
+//! ```
+//!
+//! That is: skip trivia from `pos`, scan exactly one token, and report that
+//! token's own bounds. `checkAwaitExpression`'s TS1308/TS1375/TS1309/TS1378
+//! all use it, so `tsc` squiggles the five characters of the `await` keyword
+//! and never the operand or the statement's trailing `;`.
+//!
+//! Anchoring on the node instead produces the same `start` (so `--pretty
+//! false` output, and therefore the conformance corpus, is byte-identical)
+//! but a longer `length` — visible in `--pretty` mode, which is `tsc`'s
+//! default, and in every editor surface that draws the squiggle from the
+//! diagnostic's length.
+//!
+//! These helpers own that rule so call sites do not re-derive it with fixed
+//! offsets. A hand-computed `node.pos + 4` for the `await` of a `for await`
+//! is right only when exactly one space separates the two keywords; the
+//! scanner is right for `for /* c */ await` and for a `pos` that still
+//! carries leading trivia.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_scanner::SyntaxKind;
+use tsz_scanner::scanner_impl::ScannerState;
+
+impl CheckerState<'_> {
+    /// The span of the `skip`-th token (0-based) at or after `pos`, as
+    /// `(start, length)`.
+    ///
+    /// Mirrors `tsc`'s `getSpanOfTokenAtPosition` for `skip == 0`; larger
+    /// `skip` values walk forward token by token, which is how a keyword that
+    /// `tsc` reaches through a dedicated child node (`ForOfStatement`'s
+    /// `awaitModifier`) is located in an arena that does not store one.
+    ///
+    /// Returns `None` when the scan runs out of tokens or lands on an
+    /// unrecognized one, so callers fall back to their node anchor rather
+    /// than reporting a zero-width or nonsense span.
+    ///
+    /// Cost: builds a scanner over the file's text, so this belongs on
+    /// diagnostic paths only — never in a checking hot loop.
+    pub(crate) fn span_of_token_at_position(&self, pos: u32, skip: usize) -> Option<(u32, u32)> {
+        let source_file = self.ctx.arena.source_files.first()?;
+        let text: &str = &source_file.text;
+        if pos as usize > text.len() {
+            return None;
+        }
+
+        let mut scanner = ScannerState::new(text.to_string(), true);
+        scanner.reset_token_state(pos as usize);
+
+        for _ in 0..=skip {
+            match scanner.scan() {
+                SyntaxKind::EndOfFileToken | SyntaxKind::Unknown => return None,
+                _ => {}
+            }
+        }
+
+        let start = scanner.get_token_start();
+        let end = scanner.get_token_end();
+        if end <= start {
+            return None;
+        }
+        u32::try_from(start)
+            .ok()
+            .zip(u32::try_from(end - start).ok())
+    }
+
+    /// The span of `node`'s own first token.
+    ///
+    /// The direct analogue of `getSpanOfTokenAtPosition(sourceFile, node.pos)`
+    /// — the form every `checkAwaitExpression` diagnostic uses.
+    pub(crate) fn span_of_first_token_of_node(&self, idx: NodeIndex) -> Option<(u32, u32)> {
+        let (pos, _) = self.get_node_span(idx)?;
+        self.span_of_token_at_position(pos, 0)
+    }
+
+    /// The span of the token that follows `node`'s first token.
+    ///
+    /// `for await (... of ...)` stores no `awaitModifier` node in this arena,
+    /// so the keyword `tsc` anchors on is located as "the token after `for`".
+    pub(crate) fn span_of_second_token_of_node(&self, idx: NodeIndex) -> Option<(u32, u32)> {
+        let (pos, _) = self.get_node_span(idx)?;
+        self.span_of_token_at_position(pos, 1)
+    }
+
+    /// Emit `code` anchored on `idx`'s own first token, the way `tsc` anchors
+    /// a `getSpanOfTokenAtPosition(sourceFile, node.pos)` diagnostic.
+    ///
+    /// Falls back to the node anchor when the token cannot be scanned, so a
+    /// diagnostic is never lost to a failed anchor lookup. Routes through the
+    /// same deduplicating emitter as [`Self::error_at_node`].
+    pub(crate) fn error_at_first_token_of_node(
+        &mut self,
+        idx: NodeIndex,
+        message: &str,
+        code: u32,
+    ) {
+        if let Some((start, length)) = self.span_of_first_token_of_node(idx) {
+            self.error(start, length, message.to_string(), code);
+        } else {
+            self.error_at_node(idx, message, code);
+        }
+    }
+
+    /// [`Self::error_at_first_token_of_node`] with related information already
+    /// built — `tsc`'s `checkAwaitExpression` attaches its TS1356 "Did you mean
+    /// to mark this function as 'async'?" pointer to exactly this diagnostic.
+    pub(crate) fn error_at_first_token_of_node_with_related(
+        &mut self,
+        idx: NodeIndex,
+        message: &str,
+        code: u32,
+        related: Vec<crate::diagnostics::DiagnosticRelatedInformation>,
+    ) {
+        if let Some((start, length)) = self.span_of_first_token_of_node(idx) {
+            self.error_at_span_with_related(start, length, message, code, related);
+        } else {
+            self.error_at_node_with_related(idx, message, code, related);
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "token_anchors_tests.rs"]
+mod token_anchors_tests;

--- a/crates/tsz-checker/src/error_reporter/token_anchors_tests.rs
+++ b/crates/tsz-checker/src/error_reporter/token_anchors_tests.rs
@@ -1,0 +1,174 @@
+//! Span-level tests for the `getSpanOfTokenAtPosition` anchor family.
+//!
+//! Every expectation here is the `(start, length)` pair `tsc@7.0.2` reports
+//! for the same source, read off `--pretty` output (the squiggle's column and
+//! width). Asserting the code alone cannot see this defect: the `start`
+//! already matched before the fix, which is exactly why the conformance
+//! corpus — graded on `--pretty false`, i.e. `file(line,col)` only — is
+//! structurally blind to it (#16360).
+//!
+//! Binder names are varied across the matrix so no expectation can be
+//! satisfied by a name-shaped rule.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_source_diagnostics, check_source_with_file_is_esm};
+
+/// `(start, length)` of every diagnostic with `code`, in report order.
+fn spans_for(source: &str, code: u32) -> Vec<(u32, u32)> {
+    check_source_diagnostics(source)
+        .iter()
+        .filter(|diag| diag.code == code)
+        .map(|diag| (diag.start, diag.length))
+        .collect()
+}
+
+/// The byte offset of `needle` in `source`, as a span of `needle`'s length.
+/// Expectations are written against the source text itself so a test cannot
+/// silently encode an off-by-one the implementation also has.
+fn span_of(source: &str, needle: &str) -> (u32, u32) {
+    let start = source.find(needle).expect("needle not present in source");
+    (
+        u32::try_from(start).expect("offset fits u32"),
+        u32::try_from(needle.len()).expect("length fits u32"),
+    )
+}
+
+const AWAIT: &str = "await";
+const TS1308: u32 = 1308;
+const TS1103: u32 = 1103;
+
+#[test]
+fn ts1308_anchors_the_await_keyword_not_the_expression() {
+    // tsc: `f.ts:1:26 - error TS1308` with a 5-character squiggle over
+    // `await`. Anchoring the AwaitExpression node covered `await 1;`,
+    // including the statement's trailing semicolon.
+    let source = "function outer() { const value = await 1; return value; }";
+    assert_eq!(spans_for(source, TS1308), vec![span_of(source, AWAIT)]);
+}
+
+#[test]
+fn ts1308_anchor_is_the_keyword_for_a_multi_token_operand() {
+    // The operand's size must not reach the squiggle at all.
+    let source = "function compute() { return await someCall(1, 2, 3).then(handler); }";
+    assert_eq!(spans_for(source, TS1308), vec![span_of(source, AWAIT)]);
+}
+
+#[test]
+fn ts1308_anchor_survives_trivia_between_the_operator_and_its_operand() {
+    // Comment trivia sits inside the AwaitExpression's span but after the
+    // keyword, so a node anchor swallows it and a token anchor does not.
+    let source = "function withNote() { const held = await /* pending */ 1; return held; }";
+    assert_eq!(spans_for(source, TS1308), vec![span_of(source, AWAIT)]);
+}
+
+#[test]
+fn ts1308_anchor_is_per_await_in_a_function_expression() {
+    // Adjacent binder shape: function expression rather than declaration,
+    // and two independent awaits, each anchored on its own keyword.
+    let source =
+        "const runner = function () { const a = await 1; const b = await 2; return a + b; };";
+    let spans = spans_for(source, TS1308);
+    let first = span_of(source, AWAIT);
+    let second_start = source[first.0 as usize + 1..]
+        .find(AWAIT)
+        .expect("second await present") as u32
+        + first.0
+        + 1;
+    assert_eq!(spans, vec![first, (second_start, 5)]);
+}
+
+#[test]
+fn ts1308_anchor_in_an_arrow_body() {
+    let source = "const load = () => await fetchThing();";
+    assert_eq!(spans_for(source, TS1308), vec![span_of(source, AWAIT)]);
+}
+
+#[test]
+fn ts1308_anchor_in_a_method() {
+    let source = "class Holder { grab() { const item = await 1; return item; } }";
+    assert_eq!(spans_for(source, TS1308), vec![span_of(source, AWAIT)]);
+}
+
+#[test]
+fn ts1308_anchor_in_a_getter() {
+    let source = "class Store { get value() { return await 1; } }";
+    assert_eq!(spans_for(source, TS1308), vec![span_of(source, AWAIT)]);
+}
+
+#[test]
+fn ts1308_anchor_in_a_generator() {
+    let source = "function* stream() { const chunk = await 1; yield chunk; }";
+    assert_eq!(spans_for(source, TS1308), vec![span_of(source, AWAIT)]);
+}
+
+#[test]
+fn ts1103_anchors_the_await_keyword_of_a_for_await() {
+    // tsc anchors `ForOfStatement.awaitModifier`, not the statement.
+    let source = "function drain() { for await (const line of lines) { use(line); } }";
+    assert_eq!(spans_for(source, TS1103), vec![span_of(source, AWAIT)]);
+}
+
+#[test]
+fn ts1103_anchor_holds_when_the_keywords_are_not_one_space_apart() {
+    // The regression this replaces a fixed `stmt.pos + 4` offset for: any
+    // spacing other than a single space mis-anchored the squiggle, silently,
+    // since only the length and start-within-the-line move.
+    let source = "function drain() { for /* soon */ await (const row of rows) { use(row); } }";
+    assert_eq!(spans_for(source, TS1103), vec![span_of(source, AWAIT)]);
+}
+
+#[test]
+fn ts1103_anchor_holds_across_a_line_break_after_for() {
+    let source = "function drain() {\n  for\n    await (const item of items) { use(item); }\n}";
+    assert_eq!(spans_for(source, TS1103), vec![span_of(source, AWAIT)]);
+}
+
+#[test]
+fn top_level_await_pair_anchors_the_keyword_in_a_script_file() {
+    // Negative-control axis for the top-level arm: a non-module file gets
+    // TS1375, and it is anchored on the same keyword token as TS1308's arm.
+    // `check_source_diagnostics` checks a script (non-ESM) file.
+    let source = "const started = await 1;";
+    let expected = span_of(source, AWAIT);
+    let spans = spans_for(source, 1375);
+    assert_eq!(spans, vec![expected], "TS1375 anchors the `await` keyword");
+}
+
+#[test]
+fn an_await_inside_an_async_function_is_still_clean() {
+    // The anchor change must not make a legal `await` report anything.
+    let source = "async function ok() { const value = await 1; return value; }";
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|diag| matches!(diag.code, TS1308 | TS1103 | 1375 | 1378)),
+        "legal await reported {:?}",
+        diagnostics.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn ts1378_anchors_the_keyword_in_a_module_file() {
+    // The fourth changed site. In an ESM file the TS1375 "must be a module"
+    // arm falls away, leaving the module/target arm — which `tsc` anchors on
+    // the same keyword token. Covering it here keeps all four
+    // `checkAwaitExpression` diagnostics pinned, not just the two a script
+    // file can reach.
+    let source = "export const started = await 1;";
+    let diagnostics =
+        check_source_with_file_is_esm(source, "m.ts", CheckerOptions::default(), Some(true));
+    let spans: Vec<(u32, u32)> = diagnostics
+        .iter()
+        .filter(|diag| diag.code == 1378)
+        .map(|diag| (diag.start, diag.length))
+        .collect();
+    assert_eq!(spans, vec![span_of(source, AWAIT)]);
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|diag| matches!(diag.code, TS1308 | TS1103 | 1375)),
+        "a module file answers neither TS1308/TS1103 nor TS1375 here; got {:?}",
+        diagnostics.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}

--- a/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
+++ b/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
@@ -832,7 +832,7 @@ impl<'a> CheckerState<'a> {
 
                             // TS1375: top-level await is only valid in a module.
                             if self.top_level_await_requires_module_diagnostic() {
-                                self.error_at_node(
+                                self.error_at_first_token_of_node(
                                     current_idx,
                                     diagnostic_messages::AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_AT_THE_TOP_LEVEL_OF_A_FILE_WHEN_THAT_FILE_IS,
                                     diagnostic_codes::AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_AT_THE_TOP_LEVEL_OF_A_FILE_WHEN_THAT_FILE_IS,
@@ -847,14 +847,14 @@ impl<'a> CheckerState<'a> {
                             match self.top_level_await_verdict() {
                                 TopLevelAwaitVerdict::Allowed => {}
                                 TopLevelAwaitVerdict::CommonJsFile => {
-                                    self.error_at_node(
+                                    self.error_at_first_token_of_node(
                                         current_idx,
                                         diagnostic_messages::THE_CURRENT_FILE_IS_A_COMMONJS_MODULE_AND_CANNOT_USE_AWAIT_AT_THE_TOP_LEVEL,
                                         diagnostic_codes::THE_CURRENT_FILE_IS_A_COMMONJS_MODULE_AND_CANNOT_USE_AWAIT_AT_THE_TOP_LEVEL,
                                     );
                                 }
                                 TopLevelAwaitVerdict::UnsupportedModuleOrTarget => {
-                                    self.error_at_node(
+                                    self.error_at_first_token_of_node(
                                         current_idx,
                                         diagnostic_messages::TOP_LEVEL_AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WHEN_THE_MODULE_OPTION_IS_SET_TO_ES,
                                         diagnostic_codes::TOP_LEVEL_AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WHEN_THE_MODULE_OPTION_IS_SET_TO_ES,
@@ -868,13 +868,13 @@ impl<'a> CheckerState<'a> {
                             // — see `did_you_mean_async_related`.
                             let related = self.did_you_mean_async_related(current_idx);
                             if related.is_empty() {
-                                self.error_at_node(
+                                self.error_at_first_token_of_node(
                                     current_idx,
                                     diagnostic_messages::AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WITHIN_ASYNC_FUNCTIONS_AND_AT_THE_TOP_LEVELS,
                                     diagnostic_codes::AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WITHIN_ASYNC_FUNCTIONS_AND_AT_THE_TOP_LEVELS,
                                 );
                             } else {
-                                self.error_at_node_with_related(
+                                self.error_at_first_token_of_node_with_related(
                                     current_idx,
                                     diagnostic_messages::AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WITHIN_ASYNC_FUNCTIONS_AND_AT_THE_TOP_LEVELS,
                                     diagnostic_codes::AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WITHIN_ASYNC_FUNCTIONS_AND_AT_THE_TOP_LEVELS,
@@ -1038,12 +1038,14 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        // The `await` keyword sits immediately after `for `.
-        let await_anchor = self
-            .ctx
-            .arena
-            .get(stmt_idx)
-            .map(|stmt_node| (stmt_node.pos + 4, 5u32));
+        // tsc anchors this family on `ForOfStatement.awaitModifier` — the
+        // `await` keyword token, never the whole statement. This arena stores
+        // no modifier node, so the keyword is located as the token after
+        // `for`. Scanning for it (rather than assuming `stmt.pos + 4`) keeps
+        // the anchor right when the two keywords are not separated by exactly
+        // one space, e.g. `for /* c */ await (const x of y) {}`, and when
+        // `stmt.pos` still carries leading trivia.
+        let await_anchor = self.span_of_second_token_of_node(stmt_idx);
 
         if self.ctx.function_depth > 0 {
             if self.find_enclosing_static_block(stmt_idx).is_some() {


### PR DESCRIPTION
Closes the **first half** of #16360 (the anchor-span defect). The issue's second half — TS18037's file-wide suppression — is being handled separately in #16367 / #16370 and this PR does not touch `check_utils.rs` or change which codes fire.

## Structural rule

**When `tsc` anchors a grammar diagnostic with `getSpanOfTokenAtPosition(sourceFile, pos)`, the span is the first *token* at that position — trivia-skipped, token-length exact. tsz does the same through a scanner-backed span helper in the checker's `error_reporter`, not through node spans or fixed byte offsets.**

`checkAwaitExpression` uses that helper for all four of TS1308 / TS1375 / TS1309 / TS1378, so `tsc` squiggles the five characters of `await` and never the operand or the statement's trailing `;`. tsz anchored the whole `AwaitExpression`, whose stored `end` additionally runs past its last token.

Owner layer: checker (`error_reporter` owns source locations per `.claude/CLAUDE.md`). No solver, binder or emitter change; no change to which diagnostics fire.

### A second, unreported defect fixed in the same pass

The `for await` family (TS1103 / TS18038 / TS1431 / TS1309) *was* already keyword-anchored — but by assuming the keyword sits at `stmt.pos + 4` ("the `await` keyword sits immediately after `for `"). That holds only when exactly one space separates the two keywords. Measured, before → after:

| witness | before | after | tsc@7.0.2 |
| --- | --- | --- | --- |
| `function outer() { const value = await 1; ... }` (TS1308) | `(33, 8)` — covers `await 1;` | `(33, 5)` | `1:34`, width 5 |
| `for /* soon */ await (const row of rows)` (TS1103) | `(23, 5)` — **11 bytes early, inside the comment** | `(34, 5)` | `1:35`, width 5 |

So the first family was wrong in `length` only; the `for await` family could be wrong in `start` too, which is plain-mode visible.

## Why the corpus never caught this

`--pretty false` prints only `file(line,col)`, and the `start` of the await-expression family was already correct — so the plain output tsz is graded on is byte-identical to tsc's, and the conformance corpus is structurally blind to this class. It is visible in `--pretty` (tsc's *default*) and in any editor surface that draws the squiggle from the diagnostic's length. Per #16360, the oracle-pinned span matrix is the primary evidence here and the corpus sweep is a regression floor.

## Verification

**Oracle matrix — 13/13 rows against pinned `typescript@7.0.2`** (`--noEmit --target es2022 --module esnext --pretty`), each squiggle's column+width extracted and asserted to cover exactly `await`:

```
c01 TS1308 1:34 width=5 covers='await' OK      c08 TS1308 1:36 width=5 covers='await' OK
c02 TS1308 1:29 width=5 covers='await' OK      c09 TS1103 1:24 width=5 covers='await' OK
c03 TS1308 1:36 width=5 covers='await' OK      c10 TS1103 1:35 width=5 covers='await' OK
c04 TS1308 1:40 + 1:59 width=5 covers='await'  c11 TS1103 3:5  width=5 covers='await' OK
c05 TS1308 1:20 width=5 covers='await' OK      c12 TS1375 1:17 width=5 covers='await' OK
c06 TS1308 1:38 width=5 covers='await' OK
c07 TS1308 1:36 width=5 covers='await' OK
```

Rows c10/c11 are the two spacing variants (`for /* soon */ await`, `for` + newline + `await`) that the old fixed-offset anchor could not produce.

**Adjacent-case matrix — 14 new tests, `cargo test -p tsz-checker --lib token_anchors` 14/14.** Varied binders throughout (no expectation is satisfiable by a name-shaped rule); expectations are computed from the source text itself rather than hard-coded offsets. Covers: function declaration, function expression with two independent awaits, arrow body, method, getter, generator, multi-token operand, trivia between operator and operand; `for await` in three spacings; TS1375 (script file) and TS1378 (ESM file) top-level arms; plus two negative controls (a legal `await` in an `async` function stays clean, and a module file answers neither TS1308/TS1103 nor TS1375).

**Negative control — 12 of the 14 fail with only `core_statement_checks.rs` reverted** (`git stash push` on that one file), so they fail for the real reason. The 2 that still pass are the legal-await control and the single-space `for await` row that `pos + 4` happened to get right.

- `cargo clippy -p tsz-checker --lib --all-targets -- -D warnings` — clean.
- `cargo fmt --all`, pre-commit hook (clippy + architecture guard) — passed.
- `scripts/conformance/compare-to-parent.sh origin/main` — **launched, still running at PR-open time**; the number goes in a comment on this PR before it is queued. Expected flat: `start` is unchanged for the await-expression family, and the only `start` that moves is the `for`-then-trivia-then-`await` shape, where the old value pointed into the comment.

Note: `cargo nextest` is not installed on a stock cloud seat (`cargo test -p CRATE --lib` used instead) — consistent with Ilmenite's container note on #16367.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Malachite

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhmdYaXwbYgGe9faCmUFSZ)_