### PR TITLE
fix(checker): TS1058 for an annotated async function's invalid-thenable return

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -65,6 +65,8 @@ mod assignment_ops_relation_routing_arch_tests;
 mod async_generator_yieldstar_contribution_tests;
 #[path = "tests/async_generator_yieldstar_union_delegate_tests.rs"]
 mod async_generator_yieldstar_union_delegate_tests;
+#[path = "tests/async_return_invalid_thenable_tests.rs"]
+mod async_return_invalid_thenable_tests;
 #[path = "tests/await_alias_union_distribution_tests.rs"]
 mod await_alias_union_distribution_tests;
 #[path = "tests/await_concise_arrow_body_grammar_tests.rs"]

--- a/crates/tsz-checker/src/tests/async_return_invalid_thenable_tests.rs
+++ b/crates/tsz-checker/src/tests/async_return_invalid_thenable_tests.rs
@@ -1,0 +1,184 @@
+//! TS1058: a `return` statement inside an *annotated* async function/method
+//! whose expression's type has a callable `then` member that does not resolve
+//! to a valid promise shape.
+//!
+//! tsc's `checkReturnExpression` runs `checkAwaitedType(exprType, false, node,
+//! The_return_type_of_an_async_function_must_either_be_a_valid_promise_or_must_not_contain_a_callable_then_member)`
+//! whenever the enclosing function is async AND
+//! `getReturnTypeFromAnnotation(container) != nil` — an inferred (unannotated)
+//! return type has no independent annotation to validate the return expression
+//! against, so the check does not run there (a distinct, unimplemented gap:
+//! tsc still reports TS1058 for the unannotated case through a different path,
+//! anchored at the function name rather than the return statement).
+//!
+//! The check tests the return *expression's* own type, independent of whether
+//! the declared return type is itself `Promise<T>` — TS1064 (declared return
+//! type is not `Promise<T>`) is a separate, earlier check on the annotation
+//! node, and both can fire together on the same statement.
+//!
+//! Like `generator_yield_invalid_thenable_tests.rs` (TS1321, the `yield`
+//! sibling of this check), every positive witness here uses the `this`-type
+//! mismatch shape: tsz's `await_operand_invalid_thenable_this_type` — the same
+//! predicate this fix reuses — only implements that sub-case of "invalid
+//! thenable", not tsc's full "callable `then` with no extractable payload"
+//! rule. Oracle-verified against `typescript@7.0.2`.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_source_with_libs, load_default_lib_files};
+
+fn strict_codes(source: &str) -> Vec<u32> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|diagnostic| diagnostic.code)
+    .collect()
+}
+
+const BAD_THENABLE: &str = r#"
+interface BadThenable<T> {
+    then(this: { required: string }, onfulfilled?: ((value: T) => void) | null): void;
+}
+"#;
+
+/// Baseline: a `this`-type-mismatched thenable returned from an annotated
+/// async function draws TS1058 at the `return` statement, alongside TS1064 on
+/// the declared return type.
+#[test]
+fn malformed_thenable_return_in_annotated_function_reports_ts1058() {
+    let codes = strict_codes(&format!(
+        r#"
+export {{}};
+{BAD_THENABLE}
+declare const zzSource: BadThenable<string>;
+async function f(): BadThenable<string> {{
+  return zzSource;
+}}
+"#,
+    ));
+    assert!(
+        codes.contains(&1058),
+        "a return statement whose expression has an invalid thenable must report TS1058; got {codes:?}"
+    );
+}
+
+/// Same shape on an async class method (`METHOD_DECLARATION`, not
+/// `FUNCTION_DECLARATION`) — the enclosing-function lookup must resolve
+/// methods, not just plain functions. Renamed binders throughout (a
+/// differently-named interface, container, and method) to prove the check is
+/// not keyed off any of `BadThenable`/`f`'s identifiers.
+#[test]
+fn malformed_thenable_return_in_annotated_method_reports_ts1058() {
+    let codes = strict_codes(
+        r#"
+export {};
+interface WeirdThenable<T> {
+    then(this: { needed: string }, onfulfilled?: ((value: T) => void) | null): void;
+}
+declare const src: WeirdThenable<number>;
+class Container {
+    async m(): WeirdThenable<number> {
+        return src;
+    }
+}
+"#,
+    );
+    assert!(
+        codes.contains(&1058),
+        "an async method's invalid-thenable return must report TS1058; got {codes:?}"
+    );
+}
+
+/// Same shape on an async arrow function with a block body (`ARROW_FUNCTION`).
+#[test]
+fn malformed_thenable_return_in_annotated_arrow_reports_ts1058() {
+    let codes = strict_codes(
+        r#"
+export {};
+interface BogusThenable<T> {
+    then(this: { must: string }, onfulfilled?: ((value: T) => void) | null): void;
+}
+declare const bogusSource: BogusThenable<boolean>;
+const arrowFn = async (): BogusThenable<boolean> => {
+    return bogusSource;
+};
+"#,
+    );
+    assert!(
+        codes.contains(&1058),
+        "an async arrow function's invalid-thenable return must report TS1058; got {codes:?}"
+    );
+}
+
+/// Negative: a real `Promise<T>` return draws neither TS1058 nor TS1064.
+#[test]
+fn valid_promise_return_does_not_report_ts1058() {
+    let codes = strict_codes(
+        r#"
+export {};
+async function ok(): Promise<string> {
+    return "x";
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&1058),
+        "a valid Promise<T> return must not report TS1058; got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&1064),
+        "a valid Promise<T> return must not report TS1064; got {codes:?}"
+    );
+}
+
+/// Negative/fallback: a returned value with no invalid-thenable shape at all
+/// is not this check's concern — an ordinary type mismatch (TS2322) is
+/// reported instead, not TS1058.
+#[test]
+fn non_thenable_mismatch_does_not_report_ts1058() {
+    let codes = strict_codes(
+        r#"
+export {};
+async function g(): Promise<string> {
+    return 5 as unknown as { x: number };
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&1058),
+        "a plain (non-thenable) type mismatch must not report TS1058; got {codes:?}"
+    );
+    assert!(
+        codes.contains(&2322),
+        "the plain type mismatch itself must still report TS2322; got {codes:?}"
+    );
+}
+
+/// Fallback: an *unannotated* async function is out of this fix's scope (tsc
+/// answers TS1058 there too, through inferred-return-type checking anchored at
+/// the function name, not the return statement) — the annotated-only gate must
+/// not accidentally fire here.
+#[test]
+fn unannotated_async_function_does_not_report_ts1058_at_return_statement() {
+    let codes = strict_codes(&format!(
+        r#"
+export {{}};
+{BAD_THENABLE}
+declare const zzSource: BadThenable<string>;
+async function noAnnotation() {{
+  return zzSource;
+}}
+"#,
+    ));
+    assert!(
+        !codes.contains(&1058),
+        "the annotated-only TS1058 gate must not fire for an unannotated async function; got {codes:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
+++ b/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
@@ -264,6 +264,27 @@ impl<'a> CheckerState<'a> {
             }
             self.ctx.preserve_literal_types = prev_preserve_literals;
             if self.ctx.in_async_context() {
+                // TS1058: tsc's `checkReturnExpression` runs this check only when
+                // the enclosing async function has an explicit return type
+                // annotation (`getReturnTypeFromAnnotation(container) != nil`) —
+                // an inferred return type widens from the return expressions
+                // themselves, so there is no independent annotation to validate
+                // against. It reports at the return statement itself, testing the
+                // return *expression's* type directly, independent of whether the
+                // declared return type is even `Promise<T>` (that is TS1064's
+                // separate, earlier check on the annotation node).
+                if self.enclosing_async_function_has_return_type_annotation(stmt_idx)
+                    && self
+                        .await_operand_invalid_thenable_this_type(return_type)
+                        .is_some()
+                {
+                    use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+                    self.error_at_node(
+                        stmt_idx,
+                        diagnostic_messages::THE_RETURN_TYPE_OF_AN_ASYNC_FUNCTION_MUST_EITHER_BE_A_VALID_PROMISE_OR_MUST_NOT,
+                        diagnostic_codes::THE_RETURN_TYPE_OF_AN_ASYNC_FUNCTION_MUST_EITHER_BE_A_VALID_PROMISE_OR_MUST_NOT,
+                    );
+                }
                 // Use unwrap_async_return_type_for_body which handles unions
                 // by unwrapping Promise from each member individually.
                 // This is needed for cases like:
@@ -544,6 +565,37 @@ impl<'a> CheckerState<'a> {
 
     pub(crate) fn type_references_unresolved_import(&self, type_id: TypeId) -> bool {
         self.ctx.type_references_unresolved_import(type_id)
+    }
+
+    /// Whether the innermost function-like container of `idx` is async and
+    /// carries an explicit return type annotation. Mirrors tsc's
+    /// `getReturnTypeFromAnnotation(container) != nil` gate on
+    /// `checkReturnExpression`'s TS1058 branch — an inferred (unannotated)
+    /// async return type widens from the return expressions themselves, so
+    /// there is nothing independent to validate a return expression against.
+    fn enclosing_async_function_has_return_type_annotation(&self, idx: NodeIndex) -> bool {
+        let Some(fn_idx) = self.find_enclosing_function(idx) else {
+            return false;
+        };
+        let Some(fn_node) = self.ctx.arena.get(fn_idx) else {
+            return false;
+        };
+        let type_annotation = match fn_node.kind {
+            syntax_kind_ext::FUNCTION_DECLARATION
+            | syntax_kind_ext::FUNCTION_EXPRESSION
+            | syntax_kind_ext::ARROW_FUNCTION => self
+                .ctx
+                .arena
+                .get_function(fn_node)
+                .map(|f| f.type_annotation),
+            syntax_kind_ext::METHOD_DECLARATION => self
+                .ctx
+                .arena
+                .get_method_decl(fn_node)
+                .map(|m| m.type_annotation),
+            _ => return false,
+        };
+        type_annotation.is_some_and(|t| t.is_some())
     }
 
     fn should_report_primitive_to_generic_indexed_conditional_return(


### PR DESCRIPTION
TS1058 (`The return type of an async function must either be a valid promise or must not contain a callable 'then' member.`) was entirely unwired — part of #16291's "async/promise return types" family (TS1058/1059/1060/1065/1322).

## Structural rule

When an *annotated* async function/method/arrow's `return` expression has a type whose `then` member is callable but does not resolve to a valid promise shape, `tsc`'s `checkReturnExpression` reports TS1058 at the return statement — through `checkAwaitedType(exprType, false, node, msg)` — **independent of** whether the declared return type is itself `Promise< T >` (that's TS1064's separate, earlier check on the annotation node; both can fire together on the same statement, oracle-confirmed).

`tsc` gates this on `getReturnTypeFromAnnotation(container) != nil`. An *unannotated* async function's TS1058 comes from a different, unimplemented inferred-return-type path anchored at the function name rather than the return statement (oracle-confirmed still reachable there) — left out of scope for this PR and called out explicitly with a regression test.

tsz already had the exact predicate this needs — `await_operand_invalid_thenable_this_type` in `crates/tsz-checker/src/checkers/promise_checker.rs`, the same one the `await` operand check (`types/computation/access_await.rs`) and #16291's TS1321 fix for `yield` (`generator_yield_invalid_thenable_tests.rs`) both reuse — but it was never wired to return-statement checking. The fix is ~15 lines in `check_return_statement` (`crates/tsz-checker/src/types/type_checking/core_statement_checks.rs`), gated by a new `enclosing_async_function_has_return_type_annotation` helper that resolves the return-type annotation across `FUNCTION_DECLARATION`/`FUNCTION_EXPRESSION`/`ARROW_FUNCTION`/`METHOD_DECLARATION`.

## Adjacent-case matrix (oracle-verified against `typescript@7.0.2`)

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| annotated `function`, invalid thenable return | TS1058 (+ TS1064) | silent | TS1058 |
| annotated class `method`, invalid thenable return | TS1058 (+ TS1064) | silent | TS1058 |
| annotated arrow (block body), invalid thenable return | TS1058 (+ TS1064) | silent | TS1058 |
| valid `Promise< string >` return | clean | clean | clean |
| non-thenable type mismatch (`Promise< string >` vs `{ x: number }`) | TS2322 only | TS2322 only | TS2322 only |
| **unannotated** async function, invalid thenable return | TS1058 (different path, anchored at fn name) | silent | silent (unchanged — explicitly out of scope, regression-tested) |

Every positive witness uses the `this`-type-mismatch thenable shape (`then(this: { required: string }, onfulfilled?: ...)`), matching `generator_yield_invalid_thenable_tests.rs`'s note that tsz's predicate only implements that sub-case of "invalid thenable" (not tsc's full "callable `then` with no extractable payload" rule — see the NOTE below).

## Not covered — filed as a note, not a regression

TS1059 (`A promise must have a 'then' method.`) and TS1060 (`The first parameter of the 'then' method of a promise must be a callback.`) are `tsc`'s more specific sub-messages for two other `getPromisedTypeOfPromiseEx` failure branches (no `then` method at all; `then`'s `onfulfilled` parameter has zero valid signatures). `extract_awaited_type_from_valid_thenable` doesn't distinguish those from the generic case yet, so tsz will still answer the generic TS1058 there today rather than the more specific code — posted as a NOTE on the coordination board (issue #15994) for whoever picks that up next.

## Goal
Goal: hold

## Verification
- New suite `crates/tsz-checker/src/tests/async_return_invalid_thenable_tests.rs`, 6/6 passing (`cargo test -p tsz-checker --lib async_return_invalid_thenable`).
- Broader regression sweep: `cargo test -p tsz-checker --lib -- return_statement async_ promise_ thenable generator_yield` — **329 passed, 0 failed, 9 ignored** (no regressions in any return/async/promise/generator/thenable test).
- `cargo clippy -p tsz-checker --lib -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py` — `Architecture guardrails passed.`
- `python3 scripts/ci/check-test-file-reachability.py` — `0 known orphan(s), 0 new`.
- `cargo fmt -p tsz-checker` — clean, no diff.
- Not run locally: full `conformance.sh`/`compare-to-parent.sh` (cold container, no TypeScript corpus checked out this session) and emit/fourslash suites. This change only adds a new diagnostic report site behind a narrow, previously-always-false condition (`has_callable_then && awaited_type.is_none()` on an annotated async return statement) — it cannot change output for any program that doesn't already exercise a malformed thenable in that exact position, so no drift is expected. Flagging for the nightly/dispatch suites to confirm, per repo convention for a scoping argument rather than a run.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT