### PR TITLE
fix(parser): TS1184 for a misplaced modifier statement inside a block

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -169,6 +169,9 @@ mod parser_improvement_yield_generator_recovery_tests;
 #[path = "../../tests/parser_speculative_context_restore_tests.rs"]
 mod parser_speculative_context_restore_tests;
 #[cfg(test)]
+#[path = "../../tests/parser_top_level_modifier_ts1044_ts1184_tests.rs"]
+mod parser_top_level_modifier_ts1044_ts1184_tests;
+#[cfg(test)]
 #[path = "../../tests/tests.rs"]
 mod tests;
 

--- a/crates/tsz-parser/src/parser/state_statements_keywords.rs
+++ b/crates/tsz-parser/src/parser/state_statements_keywords.rs
@@ -218,15 +218,37 @@ impl ParserState {
                 self.next_token();
                 self.parse_statement()
             } else {
-                // TS1044: '{0}' modifier cannot appear on a module or namespace element.
+                // tsc's grammar check picks the message from the statement's
+                // container, not the modifier itself: a Block body (function
+                // body, a nested block, or a class static block) gets the
+                // generic TS1184; a module/namespace body or the source
+                // file's own top level, neither of which is a Block, keeps
+                // the module/namespace-specific TS1044 (#16368).
+                //
+                // `in_static_block_context()` covers the static-block case
+                // directly rather than through `in_block_context()`
+                // (`parse_static_block` does not set CONTEXT_FLAG_IN_BLOCK,
+                // deliberately: doing so also makes the class-body nested-
+                // block recovery heuristic a few lines up in
+                // `parse_statements` fire inside static blocks, which is a
+                // separate, pre-existing bug — confirmed it already
+                // misparses a plain method body the same way, unrelated to
+                // this fix — and out of scope here).
                 let modifier_start = self.token_pos();
                 let modifier_text = self.scanner.get_token_text();
-                self.parse_error_at_current_token(
-                    &format!(
-                        "'{modifier_text}' modifier cannot appear on a module or namespace element."
-                    ),
-                    diagnostic_codes::MODIFIER_CANNOT_APPEAR_ON_A_MODULE_OR_NAMESPACE_ELEMENT,
-                );
+                if self.in_block_context() || self.in_static_block_context() {
+                    self.parse_error_at_current_token(
+                        "Modifiers cannot appear here.",
+                        diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE,
+                    );
+                } else {
+                    self.parse_error_at_current_token(
+                        &format!(
+                            "'{modifier_text}' modifier cannot appear on a module or namespace element."
+                        ),
+                        diagnostic_codes::MODIFIER_CANNOT_APPEAR_ON_A_MODULE_OR_NAMESPACE_ELEMENT,
+                    );
+                }
                 let modifier_kind = self.token();
                 self.next_token();
                 let modifier = self.arena.add_token(

--- a/crates/tsz-parser/tests/parser_top_level_modifier_ts1044_ts1184_tests.rs
+++ b/crates/tsz-parser/tests/parser_top_level_modifier_ts1044_ts1184_tests.rs
@@ -1,0 +1,94 @@
+//! A misplaced class-modifier keyword (`public`, `private`, `protected`,
+//! `static`, `override`, `readonly`) at the start of a statement is a grammar
+//! error in every container, but tsc picks its diagnostic from the
+//! *container*, not the modifier: a `Block` body (function body, a nested
+//! block, or a class static block) reports the generic TS1184 ("Modifiers
+//! cannot appear here"); a module/namespace body or the source file's own
+//! top level — neither of which is a `Block` — keeps the module/namespace-
+//! specific TS1044 ("'{0}' modifier cannot appear on a module or namespace
+//! element."). #16368.
+
+use crate::parser::test_fixture::parse_source;
+use tsz_common::diagnostics::diagnostic_codes;
+
+fn assert_single_diagnostic(source: &str, expected_code: u32, expected_pos: u32) {
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == expected_code && d.start == expected_pos),
+        "expected TS{expected_code} at position {expected_pos} for {source:?}, got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn modifier_in_function_body_reports_ts1184() {
+    let source = "function mm() { public const z = 1; return z; }";
+    let pos = source.find("public").unwrap() as u32;
+    assert_single_diagnostic(source, diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE, pos);
+}
+
+#[test]
+fn modifier_in_nested_block_inside_function_body_reports_ts1184() {
+    let source = "function mm() { { public const z = 1; } }";
+    let pos = source.find("public").unwrap() as u32;
+    assert_single_diagnostic(source, diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE, pos);
+}
+
+#[test]
+fn modifier_in_class_static_block_reports_ts1184() {
+    let source = "class C { static { public const z = 1; } }";
+    let pos = source.find("public").unwrap() as u32;
+    assert_single_diagnostic(source, diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE, pos);
+}
+
+#[test]
+fn modifier_at_namespace_top_level_reports_ts1044() {
+    let source = "namespace N { public const z = 1; }";
+    let pos = source.find("public").unwrap() as u32;
+    assert_single_diagnostic(
+        source,
+        diagnostic_codes::MODIFIER_CANNOT_APPEAR_ON_A_MODULE_OR_NAMESPACE_ELEMENT,
+        pos,
+    );
+}
+
+#[test]
+fn modifier_at_source_file_top_level_reports_ts1044() {
+    let source = "public const z = 1;";
+    assert_single_diagnostic(
+        source,
+        diagnostic_codes::MODIFIER_CANNOT_APPEAR_ON_A_MODULE_OR_NAMESPACE_ELEMENT,
+        0,
+    );
+}
+
+#[test]
+fn modifier_before_namespace_nested_in_function_body_still_reports_ts1044() {
+    // The modifier's own container is the namespace body, not the enclosing
+    // function block, even though the namespace itself sits inside one.
+    let source = "function mm() { namespace N { public const z = 1; } }";
+    let pos = source.rfind("public").unwrap() as u32;
+    assert_single_diagnostic(
+        source,
+        diagnostic_codes::MODIFIER_CANNOT_APPEAR_ON_A_MODULE_OR_NAMESPACE_ELEMENT,
+        pos,
+    );
+}
+
+#[test]
+fn every_top_level_modifier_keyword_reports_ts1184_in_a_block() {
+    for keyword in [
+        "public",
+        "private",
+        "protected",
+        "static",
+        "override",
+        "readonly",
+    ] {
+        let source = format!("function mm() {{ {keyword} const z = 1; }}");
+        let pos = source.find(keyword).unwrap() as u32;
+        assert_single_diagnostic(&source, diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE, pos);
+    }
+}


### PR DESCRIPTION
Closes #16368.

`function mm() { public const z = 1; return z; }` reported TS1044 ("'public' modifier cannot appear on a module or namespace element.") where tsc reports TS1184 ("Modifiers cannot appear here.").

## Structural rule

When a class-modifier keyword (`public`/`private`/`protected`/`static`/`override`/`readonly`) starts an illegal statement, tsc's `checkGrammarModifiers` picks the diagnostic from the statement's **container**, not the modifier itself: a `Block` body (function body, a nested block, or a class static block — `ClassStaticBlockDeclaration.body` is a `Block` in tsc's own AST) gets the generic TS1184; a module/namespace body or the source file's own top level, neither of which is a `Block`, keeps the module/namespace-specific TS1044. `parse_statement_top_level_modifier` (`crates/tsz-parser/src/parser/state_statements_keywords.rs`) emitted TS1044 unconditionally, ignoring the container.

Fixed by gating the diagnostic choice on `in_block_context() || in_static_block_context()`. Static blocks go through the dedicated static-block flag rather than through `CONTEXT_FLAG_IN_BLOCK` itself: making `parse_static_block` set that flag (the structurally "correct" route, since a static block's body really is a `Block`) also activates an unrelated, pre-existing class-body nested-block recovery heuristic a few lines up in `parse_statements` (`state_statements.rs:625`) — confirmed with a repro that it *already* misparses a plain, well-formed method-body statement the same way on unmodified `main` (`class C { method() { public const z = 1; return z; } }` → four unrelated diagnostics instead of tsc's single TS1184). That's a separate, pre-existing bug; fixing it is out of scope here, so the narrower `in_static_block_context()` gate avoids resurfacing it.

## Adjacent-case matrix (oracle-pinned, `typescript@7.0.2`)

| Shape | tsc | tsz before | tsz after |
|---|---|---|---|
| modifier in a function body | TS1184 | TS1044 | TS1184 |
| modifier in a nested block inside a function body | TS1184 | TS1044 | TS1184 |
| modifier in a class static block | TS1184 | TS1044 | TS1184 |
| modifier at a namespace body's top level | TS1044 | TS1044 | TS1044 |
| modifier at the source file's top level | TS1044 | TS1044 | TS1044 |
| modifier before a namespace nested in a function body | TS1044 | TS1044 | TS1044 |

**Known, disclosed gap, not in the issue's matrix:** a namespace/module nested directly inside a class static block (`class C { static { namespace N { public const z = 1; } } }`) reports TS1184 instead of tsc's TS1044, because entering the namespace body clears `CONTEXT_FLAG_IN_BLOCK` but not the static-block flag. Fixing that needs touching `CONTEXT_FLAG_STATIC_BLOCK`'s much wider `await`-reserved-word call-site list (15+ sites across arrow/unary/variable-declaration parsing) for a combination that borders on unwritable real-world TypeScript — left as a follow-up rather than risking that blast radius here.

## Verification

- New test file `crates/tsz-parser/tests/parser_top_level_modifier_ts1044_ts1184_tests.rs` (wired into `crates/tsz-parser/src/parser/mod.rs`), 7 tests covering the matrix above plus all six modifier keywords — all passing.
- `cargo test -p tsz-parser --lib` — **1761 passed, 0 failed** (no regressions).
- `cargo fmt --all` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `scripts/conformance/compare-to-parent.sh origin/main` (two-sided, base `9808b0e`): base failing=561, branch failing=561, **0 newly failing / 0 newly passing** — this is a wrong-*code* fix on an already-erroring statement, so zero corpus movement is the expected signature, not a null result.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdhUJuqPLVpv14yXHtsLx7)_