### PR TITLE
fix(checker): declare on a private-identifier class member no longer reports noImplicitAny

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -483,14 +483,18 @@ impl<'a> CheckerState<'a> {
         // TS7008: Member implicitly has an 'any' type
         // Report this error when noImplicitAny is enabled and the property has no type annotation
         // AND no initializer (if there's an initializer, TypeScript can infer the type)
-        // TSC suppresses this for private members in ambient (declare) classes
-        let is_private_in_ambient = self
+        // TSC suppresses this for private members in ambient (declare) classes,
+        // and independently for a private/private-identifier member that
+        // carries its own (grammatically illegal here) `declare` modifier —
+        // see `member_own_declare_hides_from_ambient_surface`.
+        let is_private_in_ambient = (self
             .ctx
             .enclosing_class
             .as_ref()
             .is_some_and(|c| c.is_declared)
             && (self.has_private_modifier(&prop.modifiers)
-                || self.is_private_identifier_name(prop.name));
+                || self.is_private_identifier_name(prop.name)))
+            || self.member_own_declare_hides_from_ambient_surface(&prop.modifiers, prop.name);
         let is_static = self.has_static_modifier(&prop.modifiers);
         // tsc suppresses TS7008 for `static prototype` since TS2699 already fires
         let is_static_prototype = is_static
@@ -926,9 +930,15 @@ impl<'a> CheckerState<'a> {
 
         // Check parameter type annotations for parameter properties in function types
         // TSC suppresses the noImplicitAny member family for members that are not
-        // part of an ambient declaration's observable surface.
-        let skip_implicit_any =
-            self.member_hidden_from_ambient_declaration_surface(&method.modifiers, method.name);
+        // part of an ambient declaration's observable surface, and independently
+        // for a private/private-identifier method that carries its own
+        // (grammatically illegal here) `declare` modifier — see
+        // `member_own_declare_hides_from_ambient_surface`. Accessors do not get
+        // this second suppression (oracle-confirmed); only this method call site
+        // ORs it in.
+        let skip_implicit_any = self
+            .member_hidden_from_ambient_declaration_surface(&method.modifiers, method.name)
+            || self.member_own_declare_hides_from_ambient_surface(&method.modifiers, method.name);
         // Pre-extract ordered @param names for positional matching with binding patterns
         let jsdoc_param_names: Vec<String> = method_jsdoc
             .as_ref()

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -219,6 +219,8 @@ mod cross_module_class_self_member_tests;
 mod cross_module_generic_interface_heritage_tests;
 #[path = "tests/declaration_extract_key_path_tests.rs"]
 mod declaration_extract_key_path_tests;
+#[path = "tests/declare_private_member_implicit_any_tests.rs"]
+mod declare_private_member_implicit_any_tests;
 #[path = "tests/declared_signature_return_literal_display_tests.rs"]
 mod declared_signature_return_literal_display_tests;
 #[path = "tests/decorator_return_relation_routing_arch_tests.rs"]

--- a/crates/tsz-checker/src/tests/declare_private_member_implicit_any_tests.rs
+++ b/crates/tsz-checker/src/tests/declare_private_member_implicit_any_tests.rs
@@ -1,0 +1,181 @@
+//! Regression tests for #16371: `declare` on a private/private-identifier
+//! class *member* (as opposed to the enclosing class or file being ambient)
+//! suppresses the `noImplicitAny` member family (TS7006/TS7008/TS7010) for
+//! methods and properties, but not for accessors.
+//!
+//! `declare` is not a legal modifier on a *method* inside a non-ambient
+//! class — `tsc` reports TS1031 for it, which tsz does not yet implement
+//! (a separate, pre-existing gap; these tests assert only the
+//! `noImplicitAny` family, not TS1031) — but is legal on a *property* (an
+//! ambient property declaration). Either way, `tsc` treats the member as
+//! hidden from the ambient declaration surface for the `noImplicitAny`
+//! family when it is also `private` or named with a private identifier.
+//! Neither condition suppresses alone: `declare m()` (no private-ness) keeps
+//! TS7010, and `private m()` without `declare` keeps TS7010 too. A
+//! private-*identifier* property (`#x`) additionally routes through the
+//! dedicated TS18019 grammar check rather than TS7008.
+//!
+//! Oracle-verified against pinned `typescript@7.0.2`
+//! (`--noEmit --strict --target es2022 --module esnext --pretty false`).
+
+use crate::context::CheckerOptions;
+use crate::test_utils::check_source;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            no_implicit_any: true,
+            ..CheckerOptions::default()
+        },
+    )
+    .iter()
+    .map(|d| d.code)
+    .collect()
+}
+
+// -- Methods (TS7010) -------------------------------------------------------
+
+#[test]
+fn declare_private_identifier_method_suppresses_ts7010() {
+    assert_eq!(codes("class A { declare #m(); }"), Vec::<u32>::new());
+}
+
+#[test]
+fn declare_private_modifier_method_suppresses_ts7010() {
+    assert_eq!(codes("class A { declare private m(); }"), Vec::<u32>::new());
+}
+
+#[test]
+fn declare_static_private_identifier_method_suppresses_ts7010() {
+    assert_eq!(codes("class A { declare static #m(); }"), Vec::<u32>::new());
+}
+
+#[test]
+fn declare_ordinary_name_method_keeps_ts7010() {
+    assert_eq!(codes("class A { declare m(); }"), vec![7010]);
+}
+
+#[test]
+fn declare_protected_method_keeps_ts7010() {
+    assert_eq!(codes("class A { declare protected m(); }"), vec![7010]);
+}
+
+#[test]
+fn private_identifier_method_without_declare_stays_clean() {
+    // Negative control: no `declare` at all keeps behaving as before this fix
+    // (a private-identifier method body infers its return type, so no TS7010
+    // fires anyway; this pins that this fix does not touch that path).
+    assert_eq!(codes("class A { #m() { return 1; } }"), Vec::<u32>::new());
+}
+
+// -- Method parameters (TS7006) ---------------------------------------------
+//
+// The same suppression must reach parameter checking, which — for methods —
+// is computed twice: once in `check_method_declaration_with_request`
+// (`ambient_signature_checks.rs`) and independently in `get_type_of_function`
+// (`function_type.rs`), which has its own `is_ambient_private` predicate.
+// Both needed the private-identifier case added; only the `private` modifier
+// was previously wired in `function_type.rs`.
+
+#[test]
+fn declare_private_identifier_method_suppresses_ts7006_param() {
+    assert_eq!(codes("class A { declare #m(x); }"), Vec::<u32>::new());
+}
+
+#[test]
+fn declare_private_modifier_method_suppresses_ts7006_param() {
+    assert_eq!(
+        codes("class A { declare private m(x); }"),
+        Vec::<u32>::new()
+    );
+}
+
+#[test]
+fn declare_class_private_identifier_method_param_stays_clean() {
+    // Adjacent case caught by the same `function_type.rs` gap: a *whole*
+    // ambient class with a private-identifier method parameter was also
+    // wrongly reporting TS7006 before this fix (the `is_ambient_private`
+    // predicate never matched a private-identifier name, only `private`).
+    assert_eq!(codes("declare class A { #m(x); }"), Vec::<u32>::new());
+}
+
+// -- Properties (TS7008) -----------------------------------------------------
+
+#[test]
+fn declare_private_identifier_property_suppresses_ts7008() {
+    // `tsc` reports TS18019 ('declare' cannot be used with a private
+    // identifier) for the name itself — a property, unlike a method, is a
+    // legal position for `declare`. TS7008 must not join it.
+    assert_eq!(codes("class A { declare #x; }"), vec![18019]);
+}
+
+#[test]
+fn declare_private_modifier_property_suppresses_ts7008() {
+    assert_eq!(codes("class A { declare private x; }"), Vec::<u32>::new());
+}
+
+#[test]
+fn declare_static_private_identifier_property_suppresses_ts7008() {
+    assert_eq!(codes("class A { declare static #x; }"), vec![18019]);
+}
+
+#[test]
+fn declare_ordinary_name_property_keeps_ts7008() {
+    assert_eq!(codes("class A { declare x; }"), vec![7008]);
+}
+
+// -- Accessors: this suppression must NOT apply (TS7032/TS7033) -------------
+//
+// A member's own `declare` does not hide an accessor from the ambient
+// surface the way it does a method or property — only the enclosing class
+// or file being genuinely ambient does. `function_type.rs`'s
+// `is_ambient_private` deliberately keeps its narrower `private`-modifier-only
+// check for accessors so these stay unsuppressed.
+
+#[test]
+fn declare_private_identifier_getter_keeps_ts7033() {
+    assert_eq!(codes("class A { declare get #m(); }"), vec![7033]);
+}
+
+#[test]
+fn declare_private_modifier_getter_keeps_ts7033() {
+    assert_eq!(codes("class A { declare private get m(); }"), vec![7033]);
+}
+
+#[test]
+fn declare_private_identifier_setter_keeps_ts7032_and_ts7006() {
+    assert_eq!(codes("class A { declare set #m(v); }"), vec![7006, 7032]);
+}
+
+#[test]
+fn declare_private_modifier_setter_keeps_ts7032_and_ts7006() {
+    assert_eq!(
+        codes("class A { declare private set m(v); }"),
+        vec![7006, 7032]
+    );
+}
+
+// -- Whole class already-ambient: unaffected by this change -----------------
+
+#[test]
+fn declare_class_private_identifier_method_stays_clean() {
+    assert_eq!(codes("declare class A { #m(); }"), Vec::<u32>::new());
+}
+
+#[test]
+fn declare_class_private_identifier_property_stays_clean() {
+    assert_eq!(codes("declare class A { #x; }"), Vec::<u32>::new());
+}
+
+#[test]
+fn declare_class_private_identifier_setter_stays_clean() {
+    // Whole-class ambient accessors DO suppress (unlike the member-own-declare
+    // case above): a genuinely ambient class hides every private member,
+    // accessors included. Routed through
+    // `member_hidden_from_ambient_declaration_surface` in
+    // `accessor_checker.rs`, not the `function_type.rs` predicate this PR
+    // touches.
+    assert_eq!(codes("declare class A { set #m(v); }"), Vec::<u32>::new());
+}

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -1017,25 +1017,37 @@ impl<'a> CheckerState<'a> {
                 // and ambient declarations (declare class/module private members).
                 let is_setter = node.kind == syntax_kind_ext::SET_ACCESSOR
                     || self.is_object_define_property_setter(idx);
-                // In ambient contexts (declare class, .d.ts), tsc suppresses
-                // TS7006/TS7031 for private members since they're excluded from
-                // .d.ts output. check_method_declaration in ambient_signature_checks.rs
-                // handles this for the method-checking path, but get_type_of_function
-                // also processes these methods and must skip as well.
+                // In ambient contexts (declare class, .d.ts, or a method carrying
+                // its own — here grammatically illegal — `declare` modifier), tsc
+                // suppresses TS7006/TS7031 for private members since they're
+                // excluded from .d.ts output. check_method_declaration in
+                // ambient_signature_checks.rs handles this for the method-checking
+                // path, but get_type_of_function also processes these methods and
+                // must skip as well.
                 // Check the node's own modifiers directly rather than relying on
                 // enclosing_class (which may not be set when get_type_of_function
                 // is called outside the class member checking pass).
+                //
+                // A method may be hidden by a private-identifier (`#m`) name as well
+                // as the `private` modifier (oracle-verified: `declare #m(x)` and
+                // `declare class A { #m(x) }` both suppress TS7006, matching the
+                // `private`-modifier sibling). Accessors deliberately keep the
+                // narrower `private`-modifier-only check: a private-identifier
+                // accessor's own `declare` does NOT suppress its parameter/return
+                // implicit-any (`class A { declare set #m(v) }` still reports
+                // TS7032/TS7006, oracle-verified) — only a *class*-level ambient
+                // context does, and that path is handled by
+                // `member_hidden_from_ambient_declaration_surface` in
+                // `accessor_checker.rs`, not here.
                 let is_ambient_private = self.ctx.is_ambient_declaration(idx)
-                    && (self
+                    && (self.ctx.arena.get_method_decl(node).is_some_and(|m| {
+                        self.has_private_modifier(&m.modifiers)
+                            || self.is_private_identifier_name(m.name)
+                    }) || self
                         .ctx
                         .arena
-                        .get_method_decl(node)
-                        .is_some_and(|m| self.has_private_modifier(&m.modifiers))
-                        || self
-                            .ctx
-                            .arena
-                            .get_accessor(node)
-                            .is_some_and(|a| self.has_private_modifier(&a.modifiers))
+                        .get_accessor(node)
+                        .is_some_and(|a| self.has_private_modifier(&a.modifiers))
                         || self
                             .ctx
                             .arena

--- a/crates/tsz-checker/src/types/queries/core.rs
+++ b/crates/tsz-checker/src/types/queries/core.rs
@@ -375,6 +375,32 @@ impl<'a> CheckerState<'a> {
             && (self.has_private_modifier(modifiers) || self.is_private_identifier_name(name_idx))
     }
 
+    /// Whether a class member's own `declare` modifier — independent of
+    /// whether the enclosing class or file is ambient — hides it from the
+    /// observable surface, suppressing `noImplicitAny` (TS7006/TS7008/TS7010)
+    /// for it.
+    ///
+    /// `declare` is not a legal modifier on a method or property inside a
+    /// non-ambient class (`tsc` reports TS1031 for it), but `tsc` still
+    /// treats the member as if it were ambient for this one purpose when it
+    /// is also `private` or named with a private identifier — the same
+    /// discriminator as [`Self::member_hidden_from_ambient_declaration_surface`].
+    /// Oracle-verified against `typescript@7.0.2`: `declare #m()` and
+    /// `declare private m()` report only TS1031, `declare m()` (no
+    /// private-ness) still reports TS7010 alongside TS1031.
+    ///
+    /// This does **not** apply to accessors — `declare get #m()` and
+    /// `declare private set m(v)` still report TS7033/TS7032/TS7006, oracle-
+    /// confirmed. Callers checking an accessor must not use this helper.
+    pub(crate) fn member_own_declare_hides_from_ambient_surface(
+        &self,
+        modifiers: &Option<tsz_parser::parser::NodeList>,
+        name_idx: NodeIndex,
+    ) -> bool {
+        self.has_declare_modifier(modifiers)
+            && (self.has_private_modifier(modifiers) || self.is_private_identifier_name(name_idx))
+    }
+
     /// Check if a node is a private identifier.
     pub(crate) fn is_private_identifier_name(&self, name_idx: NodeIndex) -> bool {
         let Some(node) = self.ctx.arena.get(name_idx) else {


### PR DESCRIPTION
Closes #16371, which blocks #16367 (`is_parser_grammar_code` ⊆ `is_non_suppressing_parse_error` containment fix) — its `compare-to-parent.sh` run found exactly this bug as its one newly-failing row (`privateNamesIncompatibleModifiers.ts`).

## Structural rule

**When a class member carries its own `declare` modifier — grammatically illegal on a *method* (`tsc` reports TS1031) but legal on a *property* (an ambient property declaration) — and is also `private` or named with a private identifier (`#x`), `tsc` treats the member as hidden from the ambient declaration surface and suppresses the `noImplicitAny` family (TS7006/TS7008/TS7010) for it, exactly as a whole ambient class already does. Neither condition suppresses alone.**

This is the same discriminator `member_hidden_from_ambient_declaration_surface` (`crates/tsz-checker/src/types/queries/core.rs`) already uses for class-level/file-level ambient context; this PR adds the sibling case where the *member itself* is the one carrying `declare`.

**Accessors are the one exception**, oracle-verified: `declare get #m()` / `declare private set m(v)` still report TS7033/TS7032/TS7006 — only a genuinely ambient *class* suppresses an accessor's implicit-any, not the member's own (here illegal) `declare`. The new helper `member_own_declare_hides_from_ambient_surface` is therefore only OR'd in at the method and property call sites, never the accessor one.

## Two independent owner sites

1. `crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs`: the property's `is_private_in_ambient` (TS7008) and the method's `skip_implicit_any` (TS7006/TS7010) computations.
2. `crates/tsz-checker/src/types/function_type.rs`: a **second, independent** `is_ambient_private` predicate inside `get_type_of_function`, which already special-cased a member's own `declare` (via `is_in_ambient_context` walking the node's own modifiers) but only checked the `private` *modifier*, never a private-*identifier* name — a pre-existing gap this PR's own adjacent-case testing surfaced independently of the `declare`-suppression work: `declare class A { #m(x); }` (a **whole ambient class**, no member-level `declare` involved at all) was already wrongly reporting TS7006 on `main` before this PR.

## Adjacent-case matrix (oracle-verified against `typescript@7.0.2`, `--noEmit --strict --target es2022 --module esnext --pretty false`)

| source | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `class A { declare #m(); }` | TS1031 | TS1031 + TS7010 | TS1031 only |
| `class A { declare private m(); }` | TS1031 | TS1031 + TS7010 | TS1031 only |
| `class A { declare static #m(); }` | TS1031 | TS1031 + TS7010 | TS1031 only |
| `class A { declare m(); }` (no private-ness) | TS1031 + TS7010 | same | unchanged |
| `class A { declare protected m(); }` | TS1031 + TS7010 | same | unchanged |
| `class A { declare #m(x); }` | TS1031 | TS1031 + TS7006 | TS1031 only |
| `declare class A { #m(x); }` (whole-class ambient, pre-existing gap) | clean | TS7006 | clean |
| `class A { declare #x; }` | TS18019 | TS18019 + TS7008 | TS18019 only |
| `class A { declare private x; }` | clean | TS7008 | clean |
| `class A { declare x; }` (no private-ness) | TS7008 | same | unchanged |
| `class A { declare get #m(); }` | TS1031 + TS7033 | same | unchanged (accessor exempt) |
| `class A { declare set #m(v); }` | TS1031 + TS7032 + TS7006 | same | unchanged (accessor exempt) |
| `declare class A { set #m(v); }` (whole-class ambient accessor) | clean | clean | unchanged |

Note: `tsz` doesn't yet implement TS1031 for methods (a separate, pre-existing gap — this PR's unit tests assert only the `noImplicitAny` family, not TS1031).

**The conformance repro from #16371** (`TypeScript/tests/cases/conformance/classes/members/privateNames/privateNamesIncompatibleModifiers.ts`) now matches `tsc` exactly: `.target/debug/tsz --noEmit --strict --target es6 --pretty false` on that file produces `[3×TS1024, 3×TS1031, 2×TS1042, 1×TS1267, 12×TS18010, 2×TS18019]` — byte-identical to the file's own expected-diagnostics comments, zero TS7008/TS7010/TS7032/TS7033 leaking in.

## Anti-hardcoding

No identifier/file-name string checks; the new predicate is a structural combination of two existing modifier/name-shape queries (`has_declare_modifier`, `has_private_modifier`, `is_private_identifier_name`), gated per member-kind exactly as the existing sibling predicate already is.

## Goal
Goal: hold

## Verification
- New suite `crates/tsz-checker/src/tests/declare_private_member_implicit_any_tests.rs`: 20/20 passing (`cargo test -p tsz-checker --lib declare_private_member_implicit_any`).
- Broader regression sweep: `cargo test -p tsz-checker --lib -- implicit_any private_name private_identifier ambient_signature accessor` — **210 passed, 0 failed**.
- Direct repro check: `.target/debug/tsz` on `privateNamesIncompatibleModifiers.ts` matches `tsc`'s expected-diagnostics comments exactly (counts above).
- `cargo clippy -p tsz-checker --lib --all-targets -- -D warnings` — clean.
- `cargo fmt -p tsz-checker -- --check` — clean.
- `python3 scripts/arch/arch_guard.py` — `Architecture guardrails passed.`
- `scripts/conformance/compare-to-parent.sh origin/main` — running (two-sided, this is a plain-mode-visible behavior change); will post the newly-passing/newly-failing counts in a follow-up comment before this is queued.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ph2bNeyG4MNv88jaxYHB7j)_