### PR TITLE
fix(parser): class-body-nested-block modifier statement before a declaration no longer misparses into a cascade

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -82,6 +82,9 @@ mod definite_assignment_assertion_tests;
 #[path = "../../tests/parser_async_arrow_context_tests.rs"]
 mod parser_async_arrow_context_tests;
 #[cfg(test)]
+#[path = "../../tests/parser_class_body_modifier_recovery_tests.rs"]
+mod parser_class_body_modifier_recovery_tests;
+#[cfg(test)]
 #[path = "../../tests/parser_export_specifier_from_tests.rs"]
 mod parser_export_specifier_from_tests;
 #[cfg(test)]

--- a/crates/tsz-parser/src/parser/state_statements.rs
+++ b/crates/tsz-parser/src/parser/state_statements.rs
@@ -622,6 +622,17 @@ impl ParserState {
             // matches TSC's "abort parsing list" behavior: tokens that could start a
             // class member in an outer context cause the inner block list to terminate
             // rather than consuming tokens that belong to the class body.
+            //
+            // This must NOT fire when the modifier is itself followed by a real
+            // declaration keyword (`const`/`class`/`function`/... — see
+            // `look_ahead_is_modifier_before_declaration`): tsc parses that shape as
+            // a (misplaced) modified declaration and reports a single grammar
+            // diagnostic from `parse_statement`'s own modifier dispatch (TS1184/
+            // TS1044, #16368), not the "declaration or statement expected" recovery
+            // this branch performs. Oracle-confirmed on `public const z = 1;` inside
+            // a method body: tsc reports one TS1184, not this recovery's TS1128
+            // followed by a cascade of unrelated errors from misinterpreting the
+            // rest of the statement as class-body content (#16377).
             if self.in_block_context()
                 && self.in_class_body()
                 && matches!(
@@ -636,6 +647,7 @@ impl ParserState {
                         | SyntaxKind::AccessorKeyword
                 )
                 && self.look_ahead_next_is_identifier_or_keyword_on_same_line()
+                && !self.look_ahead_is_modifier_before_declaration()
             {
                 use tsz_common::diagnostics::diagnostic_codes;
                 self.parse_error_at_current_token(

--- a/crates/tsz-parser/tests/parser_class_body_modifier_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_class_body_modifier_recovery_tests.rs
@@ -1,0 +1,159 @@
+//! `parse_statements`' unclosed-`{` recovery heuristic (a class-modifier
+//! keyword followed by an identifier/keyword inside a class-body-nested
+//! block terminates the block, on the assumption a class member's `{` was
+//! never closed) must not fire when the modifier is actually followed by a
+//! real declaration keyword (`const`/`class`/`function`/...): tsc parses
+//! that shape as a (misplaced) modified declaration and reports a single
+//! grammar diagnostic from the statement's own modifier dispatch, not this
+//! block-termination recovery. #16377.
+
+use crate::parser::test_fixture::parse_source;
+use tsz_common::diagnostics::diagnostic_codes;
+
+fn assert_single_diagnostic(source: &str, expected_code: u32, expected_pos: u32) {
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+    assert_eq!(
+        diagnostics
+            .iter()
+            .filter(|d| d.code == expected_code && d.start == expected_pos)
+            .count(),
+        1,
+        "expected exactly one TS{expected_code} at position {expected_pos} for {source:?}, got {diagnostics:?}"
+    );
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "expected exactly one diagnostic for {source:?}, got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn modifier_before_declaration_in_method_body_reports_single_ts1184() {
+    let source = "class C { method() { public const z = 1; return z; } }";
+    let pos = source.find("public").unwrap() as u32;
+    assert_single_diagnostic(source, diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE, pos);
+}
+
+#[test]
+fn modifier_before_declaration_in_getter_body_reports_single_ts1184() {
+    let source = "class C { get x() { public const z = 1; return z; } }";
+    let pos = source.find("public").unwrap() as u32;
+    assert_single_diagnostic(source, diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE, pos);
+}
+
+#[test]
+fn modifier_before_declaration_in_setter_body_reports_single_ts1184() {
+    let source = "class C { set x(v: number) { static const z = 1; } }";
+    let pos = source.find("static").unwrap() as u32;
+    assert_single_diagnostic(source, diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE, pos);
+}
+
+#[test]
+fn modifier_before_declaration_in_constructor_body_reports_single_ts1184() {
+    let source = "class C { constructor() { public const z = 1; } }";
+    let pos = source.find("public").unwrap() as u32;
+    assert_single_diagnostic(source, diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE, pos);
+}
+
+#[test]
+fn modifier_before_declaration_in_nested_block_inside_method_reports_single_ts1184() {
+    let source = "class C { method() { { public const z = 1; } } }";
+    let pos = source.find("public").unwrap() as u32;
+    assert_single_diagnostic(source, diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE, pos);
+}
+
+#[test]
+fn every_class_modifier_keyword_before_a_declaration_reports_single_ts1184_in_a_method_body() {
+    // `abstract` is deliberately excluded: `parse_statement_abstract_keyword`
+    // reports TS1242 unconditionally regardless of container, a separate,
+    // pre-existing bug unrelated to this heuristic (#16380).
+    for keyword in [
+        "public",
+        "private",
+        "protected",
+        "static",
+        "override",
+        "readonly",
+    ] {
+        let source = format!("class C {{ method() {{ {keyword} const z = 1; }} }}");
+        let pos = source.find(keyword).unwrap() as u32;
+        assert_single_diagnostic(&source, diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE, pos);
+    }
+}
+
+#[test]
+fn modifier_before_class_keyword_in_method_body_reports_single_ts1184() {
+    let source = "class C { method() { static class D {} } }";
+    let pos = source.find("static").unwrap() as u32;
+    assert_single_diagnostic(source, diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE, pos);
+}
+
+#[test]
+fn modifier_before_function_keyword_in_method_body_reports_single_ts1184() {
+    let source = "class C { method() { static function f() {} } }";
+    let pos = source.find("static").unwrap() as u32;
+    assert_single_diagnostic(source, diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE, pos);
+}
+
+#[test]
+fn abstract_class_declaration_in_method_body_is_legal_and_reports_nothing() {
+    // `abstract class D {}` is a legal local class declaration; the modifier
+    // precedes a real declaration keyword (`class`), so the unclosed-brace
+    // recovery must not intercept it.
+    let source = "class C { method() { abstract class D {} } }";
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+    assert!(
+        diagnostics.is_empty(),
+        "expected no diagnostics for a legal local abstract class, got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn genuinely_unclosed_method_body_before_a_class_member_still_recovers() {
+    // Positive regression for the recovery this heuristic exists for: a
+    // missing `}` on `method()`'s body, followed by what tsc's parser reads
+    // as a new class member declaration (`public` here is NOT followed by a
+    // declaration keyword, so this is not a modified-declaration shape).
+    let source = "class C {\n  method() {\n    doStuff();\n  public method2() {}\n}\n";
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+    let pos = source.find("public").unwrap() as u32;
+    assert_eq!(
+        diagnostics
+            .iter()
+            .filter(|d| d.code == diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED)
+            .count(),
+        1,
+        "expected exactly one recovery diagnostic, got {diagnostics:?}"
+    );
+    assert!(
+        diagnostics.iter().any(
+            |d| d.code == diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED && d.start == pos
+        ),
+        "expected the recovery diagnostic at the modifier token, got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn genuinely_unclosed_method_body_before_a_class_field_still_recovers() {
+    let source = "class C {\n  method() {\n    doStuff();\n  public field = 1;\n}\n";
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+    let pos = source.find("public").unwrap() as u32;
+    assert_eq!(
+        diagnostics
+            .iter()
+            .filter(|d| d.code == diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED)
+            .count(),
+        1,
+        "expected exactly one recovery diagnostic, got {diagnostics:?}"
+    );
+    assert!(
+        diagnostics.iter().any(
+            |d| d.code == diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED && d.start == pos
+        ),
+        "expected the recovery diagnostic at the modifier token, got {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
Closes #16377. Found while building #16375 (TS1044 vs TS1184 container rule).

## Structural rule

`parse_statements`' unclosed-`{` recovery heuristic (`crates/tsz-parser/src/parser/state_statements.rs:625`) bails the current block whenever a class-modifier keyword is followed by an identifier/keyword on the same line, inside a class-body-nested block — on the assumption a class member's `{` was never closed. It fired unconditionally, with no check that a brace was actually missing, so it also intercepted a *syntactically well-formed* block containing an illegal modifier statement (`class C { method() { public const z = 1; return z; } }`), pre-empting `parse_statement`'s own modifier dispatch (`parse_statement_top_level_modifier`, #16368/#16375) before it could run and produce the correct single TS1184 — cascading into 4 unrelated diagnostics (TS1128/TS1248/TS1435/TS1128) instead.

**When the modifier is followed by a real declaration keyword** (`const`/`let`/`var`/`class`/`function`/`interface`/`enum`/`namespace`/`module`/`type`/`export`/`abstract`), tsc parses it as a misplaced modified declaration and reports one grammar diagnostic chosen by the statement's container — tsz does the same through `parse_statement_top_level_modifier`'s existing container gate, once this recovery heuristic gets out of its way. **When it is not** (e.g. a real missing `}` followed by a legitimate `public method2() {}` class member), tsc really does bail the block — oracle-confirmed this heuristic's original behavior is correct there and must survive unchanged.

Fixed with one added condition: `&& !self.look_ahead_is_modifier_before_declaration()` — the same lookahead `parse_statement_top_level_modifier` already uses for its own TS1184/TS1044 split (#16368), so the two code paths now agree on where one ends and the other begins.

## Adjacent-case matrix (oracle-pinned, `typescript@7.0.2`)

| Shape | tsc | tsz before | tsz after |
|---|---|---|---|
| `public const z = 1;` in a method body | TS1184 (1 diag) | TS1128×2 + TS1248 + TS1435 (4 diags) | TS1184 (1 diag) |
| same, in a getter/setter/constructor body | TS1184 | 4-diag cascade | TS1184 |
| same, in a nested block inside a method | TS1184 | 4-diag cascade | TS1184 |
| `static class D {}` / `static function f() {}` in a method body | TS1184 | 4/3-diag cascade | TS1184 |
| `abstract class D {}` in a method body (legal local class) | clean | 4-diag cascade (false positive) | clean |
| every modifier keyword × `const` in a method body | TS1184 | cascade | TS1184 |
| genuinely missing `}` before `public method2() {}` | TS1128 (1 diag, at the modifier) | TS1128 (1 diag) — already correct | **unchanged**, still TS1128 (1 diag) |
| genuinely missing `}` before `public field = 1;` | TS1128 (1 diag) | TS1128 (1 diag) — already correct | **unchanged** |
| plain (no modifier) genuinely missing `}` | `'}' expected` at true EOF | same | **unchanged** |

**Known, disclosed gaps, not fixed here** (both pre-existing, oracle-confirmed, filed separately so they aren't lost):
- `abstract const z = 1;`/`abstract function f() {}` in a block still reports TS1242 instead of TS1184 — `parse_statement_abstract_keyword`'s `look_ahead_is_abstract_before_var_or_function` branch never had the container-based split #16368 added to the sibling modifiers. Filed as #16380.
- A modifier immediately before `export as namespace ...` inside a block (`public export as namespace Foo;`) is missing its TS1184, even outside class bodies (function body, and the source-file top level) — `parse_statement_top_level_modifier`'s "silently accept the modifier" special case for `export as namespace` doesn't actually match tsc, which reports the modifier diagnostic too. Unaffected by this PR (reachable before and after); not filed as its own issue this session for time, noted here for whoever picks it up next — `look_ahead_next_token_is_export_keyword` branch, `state_statements_keywords.rs:213-220`.

## Verification

- New test file `crates/tsz-parser/tests/parser_class_body_modifier_recovery_tests.rs` (wired into `crates/tsz-parser/src/parser/mod.rs`), 11 tests: the cascade fix across method/getter/setter/constructor/nested-block bodies, every sibling modifier keyword, the legal-abstract-class negative case, and two positive regressions for the genuine-missing-brace recovery this heuristic exists for.
- `cargo test -p tsz-parser --lib` — **1772 passed, 0 failed** (no regressions).
- `cargo fmt --all` clean; `cargo clippy -p tsz-parser --all-targets -- -D warnings` clean; pre-commit hook (clippy + arch-guard) passed.
- `scripts/conformance/compare-to-parent.sh origin/main` — **running now**, two-sided against base `82db43b`; will post the newly-failing/newly-passing count in a follow-up comment before this is queued. This is a narrower-cascade fix on already-erroring statements plus one false-positive removal (`abstract class` in a method body), so a small positive movement is plausible and expected, not a red flag.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2pri3FPHKqdSZ3jjR32cd)_