### PR TITLE
fix(checker): widen non-strict nullish leaves of a block-bodied inferred return

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -604,6 +604,8 @@ mod nolib_user_global_array_member_tests;
 mod non_generic_spread_tuple_alias_display_tests;
 #[path = "tests/non_strict_non_null_check_narrows_tests.rs"]
 mod non_strict_non_null_check_narrows_tests;
+#[path = "tests/non_strict_nullish_return_widening_tests.rs"]
+mod non_strict_nullish_return_widening_tests;
 #[path = "tests/nonstrict_nullish_widening_generic_call_tests.rs"]
 mod nonstrict_nullish_widening_generic_call_tests;
 #[path = "tests/nonstrict_nullish_widening_mutable_binding_tests.rs"]

--- a/crates/tsz-checker/src/tests/non_strict_nullish_return_widening_tests.rs
+++ b/crates/tsz-checker/src/tests/non_strict_nullish_return_widening_tests.rs
@@ -220,3 +220,47 @@ fn strict_mode_keeps_undefined_array_return_unwidened() {
     .collect();
     assert_eq!(codes, vec![2322]);
 }
+
+#[test]
+fn elided_array_holes_in_a_return_are_widening_sources() {
+    // `return [,,]` — the user wrote no value, so tsc gives each hole
+    // `undefinedWideningType` and infers `() => any[]`.
+    assert_eq!(
+        non_strict_2322(
+            "function sparse() { return [,,]; }\n\
+             var holes = sparse();\n\
+             holes = [\"\"];",
+        ),
+        Vec::<u32>::new(),
+    );
+}
+
+#[test]
+fn one_declared_undefined_sibling_makes_an_elided_literal_non_widening() {
+    // A hole is permissive on its own and decisive nowhere: the declared
+    // `undefined` element still pins the whole literal to `undefined[]`.
+    assert_eq!(
+        non_strict_2322(
+            "declare var gap: undefined;\n\
+             function mixed() { return [, gap]; }\n\
+             var mixture = mixed();\n\
+             mixture = [\"\"];",
+        ),
+        vec![2322],
+    );
+}
+
+#[test]
+fn a_declared_nullish_array_leaf_is_not_a_widening_source() {
+    // `g()` returns a declared `undefined[]`; the array literal built around it
+    // carries no widening flavour, so tsc keeps `undefined[][]`.
+    assert_eq!(
+        non_strict_2322(
+            "declare function supply(): undefined[];\n\
+             function nest() { return [supply()]; }\n\
+             var nested = nest();\n\
+             nested = [[\"\"]];",
+        ),
+        vec![2322],
+    );
+}

--- a/crates/tsz-checker/src/tests/non_strict_nullish_return_widening_tests.rs
+++ b/crates/tsz-checker/src/tests/non_strict_nullish_return_widening_tests.rs
@@ -1,0 +1,222 @@
+//! Tests for the non-strict (`strictNullChecks: false`) `null`/`undefined` →
+//! `any` widening of a **block-bodied** function's inferred return type.
+//!
+//! tsc gives the `null` keyword and the global `undefined` the widening flavour
+//! (`nullWideningType` / `undefinedWideningType`), propagates it through
+//! array/object-literal construction, and `getWidenedType` maps those leaves to
+//! `any` at every inferred position. So with `strictNullChecks` off:
+//!
+//! ```ts
+//! function f() { return [undefined]; }  // () => any[]
+//! function g() { return { p: null }; }  // () => { p: any }
+//! ```
+//!
+//! tsz applied that widening only at the *expression-bodied* return seam
+//! (`maybe_widen_return_contribution`), so the block-bodied twin kept
+//! `undefined[]` / `{ p: undefined }` and produced a false `TS2322` on any later
+//! assignment into the binding.
+//!
+//! The widening flavour is a property of the *expression*, not of the type: a
+//! leaf that is merely typed `undefined` carries none of it, so
+//! `declare var q: undefined; function f() { return [q]; }` keeps `undefined[]`
+//! in tsc and must keep it here. Every case below is pinned against
+//! `typescript@7.0.2`.
+//!
+//! Binder names are varied across cases per the anti-hardcoding contract.
+
+use crate::test_utils::{check_source_non_strict_codes, check_source_strict_codes};
+
+fn non_strict_2322(src: &str) -> Vec<u32> {
+    check_source_non_strict_codes(src)
+        .into_iter()
+        .filter(|&code| code == 2322)
+        .collect()
+}
+
+#[test]
+fn block_bodied_undefined_array_return_widens_to_any_array() {
+    // `() => any[]`, so a later `string[]` assignment is fine. Unwidened
+    // (`undefined[]`) this is a false TS2322.
+    assert_eq!(
+        non_strict_2322(
+            "function makeRow() { return [undefined]; }\n\
+             var row = makeRow();\n\
+             row = [\"\"];",
+        ),
+        Vec::<u32>::new(),
+    );
+}
+
+#[test]
+fn block_bodied_null_array_return_widens_to_any_array() {
+    assert_eq!(
+        non_strict_2322(
+            "function buildSlots() { return [null]; }\n\
+             var slots = buildSlots();\n\
+             slots = [\"\"];",
+        ),
+        Vec::<u32>::new(),
+    );
+}
+
+#[test]
+fn block_bodied_nested_undefined_array_return_widens_every_level() {
+    assert_eq!(
+        non_strict_2322(
+            "function grid() { return [[undefined]]; }\n\
+             var cells = grid();\n\
+             cells = [[\"\"]];",
+        ),
+        Vec::<u32>::new(),
+    );
+}
+
+#[test]
+fn block_bodied_object_literal_nullish_property_return_widens_to_any() {
+    assert_eq!(
+        non_strict_2322(
+            "function makeBox() { return { payload: undefined }; }\n\
+             var box1 = makeBox();\n\
+             box1 = { payload: \"\" };",
+        ),
+        Vec::<u32>::new(),
+    );
+}
+
+#[test]
+fn block_bodied_undefined_tuple_in_object_property_return_widens() {
+    assert_eq!(
+        non_strict_2322(
+            "function wrap() { return { items: [null, undefined] }; }\n\
+             var wrapped = wrap();\n\
+             wrapped = { items: [\"a\", \"b\"] };",
+        ),
+        Vec::<u32>::new(),
+    );
+}
+
+#[test]
+fn expression_bodied_and_block_bodied_returns_agree() {
+    // The expression-bodied seam already widened; the block-bodied twin now
+    // reaches the same inferred return type rather than diverging by body form.
+    let arrow = non_strict_2322(
+        "var pick = () => [undefined];\n\
+         var picked = pick();\n\
+         picked = [\"\"];",
+    );
+    let block = non_strict_2322(
+        "function choose() { return [undefined]; }\n\
+         var chosen = choose();\n\
+         chosen = [\"\"];",
+    );
+    assert_eq!(arrow, block);
+    assert_eq!(block, Vec::<u32>::new());
+}
+
+#[test]
+fn recursive_function_expression_undefined_return_widens() {
+    // `wideningTuples2.ts`'s shape: a self-referential function expression whose
+    // only return is `[undefined]`. tsc reports nothing here.
+    assert_eq!(
+        non_strict_2322(
+            "var head: () => [any] = function walk() {\n\
+             \x20   let step = walk();\n\
+             \x20   step = [\"\"];\n\
+             \x20   return [undefined];\n\
+             };",
+        ),
+        Vec::<u32>::new(),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative side: a leaf that is only *typed* `undefined` carries no widening
+// flavour, so the contribution must stay unwidened and keep reporting.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn declared_undefined_element_return_keeps_undefined_array() {
+    // `declare var seed: undefined` is not a widening source: tsc infers
+    // `() => undefined[]` and reports TS2322 on the `string[]` assignment.
+    assert_eq!(
+        non_strict_2322(
+            "declare var seed: undefined;\n\
+             function collect() { return [seed]; }\n\
+             var collected = collect();\n\
+             collected = [\"\"];",
+        ),
+        vec![2322],
+    );
+}
+
+#[test]
+fn declared_undefined_property_return_keeps_undefined_property() {
+    assert_eq!(
+        non_strict_2322(
+            "declare var blank: undefined;\n\
+             function shape() { return { slot: blank }; }\n\
+             var shaped = shape();\n\
+             shaped = { slot: \"\" };",
+        ),
+        vec![2322],
+    );
+}
+
+#[test]
+fn annotated_return_type_is_not_widened() {
+    // An explicit `undefined[]` annotation is a contextual return type, so the
+    // contribution is not widenable at all and the target keeps `undefined[]`.
+    assert_eq!(
+        non_strict_2322(
+            "function fixed(): undefined[] { return [undefined]; }\n\
+             var held = fixed();\n\
+             held = [\"\"];",
+        ),
+        vec![2322],
+    );
+}
+
+#[test]
+fn local_shadowing_undefined_is_not_a_widening_source() {
+    // A user binding spelled `undefined` shadows the global sentinel; it is a
+    // plain reference, so nothing widens and the assignment still reports.
+    assert_eq!(
+        non_strict_2322(
+            "function scope(undefined: undefined) {\n\
+             \x20   return [undefined];\n\
+             }\n\
+             var scoped = scope(void 0);\n\
+             scoped = [\"\"];",
+        ),
+        vec![2322],
+    );
+}
+
+#[test]
+fn non_nullish_literal_returns_are_unaffected() {
+    // The nullish pass is a no-op when there is no nullish leaf: the ordinary
+    // literal widening still applies (`() => number[]`), so this is clean.
+    assert_eq!(
+        non_strict_2322(
+            "function counts() { return [1, 2, 3]; }\n\
+             var tally = counts();\n\
+             tally = [4];",
+        ),
+        Vec::<u32>::new(),
+    );
+}
+
+#[test]
+fn strict_mode_keeps_undefined_array_return_unwidened() {
+    // The whole rule is `strictNullChecks: false`-only. Under strict mode the
+    // inferred return stays `undefined[]` and the assignment still reports.
+    let codes: Vec<u32> = check_source_strict_codes(
+        "function makeRow() { return [undefined]; }\n\
+         var row = makeRow();\n\
+         row = [\"\"];",
+    )
+    .into_iter()
+    .filter(|&code| code == 2322)
+    .collect();
+    assert_eq!(codes, vec![2322]);
+}

--- a/crates/tsz-checker/src/types/utilities/mod.rs
+++ b/crates/tsz-checker/src/types/utilities/mod.rs
@@ -16,4 +16,5 @@ pub(crate) mod heritage_walk_state;
 pub(crate) mod mutable_binding_nullish;
 pub(crate) mod overlap_relation_helpers;
 pub(crate) mod return_type;
+pub(crate) mod return_type_nullish;
 pub(crate) mod widening;

--- a/crates/tsz-checker/src/types/utilities/return_type.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type.rs
@@ -718,7 +718,7 @@ impl<'a> CheckerState<'a> {
         )
     }
 
-    fn unwrap_parenthesized_expression(&self, expr_idx: NodeIndex) -> NodeIndex {
+    pub(crate) fn unwrap_parenthesized_expression(&self, expr_idx: NodeIndex) -> NodeIndex {
         let mut current = expr_idx;
         while let Some(node) = self.ctx.arena.get(current) {
             if node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION
@@ -1682,7 +1682,17 @@ impl<'a> CheckerState<'a> {
                                     self.ctx.types,
                                     return_type,
                                 );
-                            (self.widen_enum_member_type(widened), None)
+                            let widened = self.widen_enum_member_type(widened);
+                            // Non-strict nullish widening, the block-body twin of
+                            // the expression-body seam in
+                            // `maybe_widen_return_contribution`: under
+                            // `strictNullChecks: false` tsc maps the widening
+                            // `null`/`undefined` leaves of a fresh return
+                            // contribution to `any`, so `return [undefined]`
+                            // infers `any[]`, not `undefined[]`.
+                            let widened = self
+                                .widen_nullish_return_contribution(return_data.expression, widened);
+                            (widened, None)
                         } else {
                             (return_type, widenable.then_some(return_data.expression))
                         };

--- a/crates/tsz-checker/src/types/utilities/return_type_nullish.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type_nullish.rs
@@ -1,0 +1,129 @@
+//! Non-strict (`strictNullChecks: false`) `null`/`undefined` widening for a
+//! block-bodied function's inferred return type.
+//!
+//! Split out of `return_type.rs`, which sits at the checker's 2000-line
+//! boundary. The expression-bodied seam lives there
+//! (`maybe_widen_return_contribution`); this is the block-bodied twin, called
+//! per return contribution from `collect_return_types_in_statement`.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::SyntaxKind;
+use tsz_solver::TypeId;
+
+impl CheckerState<'_> {
+    /// Apply the non-strict `null`/`undefined` → `any` widening to a fresh
+    /// return contribution, but only when every nullish leaf the widener would
+    /// touch actually originates from a *widening* nullish source.
+    ///
+    /// tsc gives the `null` keyword and the global `undefined` the widening
+    /// flavour (`nullWideningType` / `undefinedWideningType`) and propagates it
+    /// through array/object-literal construction, so `getWidenedType` maps those
+    /// leaves to `any` when `strictNullChecks` is off:
+    /// `function f() { return [undefined]; }` infers `any[]`. A leaf that is
+    /// merely *typed* `undefined` carries no widening flavour — with
+    /// `declare var q: undefined`, `function f() { return [q]; }` keeps
+    /// `undefined[]`. tsz has no per-type widening flag, so the provenance is
+    /// recovered from the return expression's own syntax; anything the walk
+    /// cannot account for keeps the unwidened contribution.
+    pub(crate) fn widen_nullish_return_contribution(
+        &mut self,
+        expr_idx: NodeIndex,
+        type_id: TypeId,
+    ) -> TypeId {
+        if self.ctx.strict_null_checks() {
+            return type_id;
+        }
+        let widened =
+            crate::query_boundaries::widening::widen_nullish_to_any_deep(self.ctx.types, type_id);
+        if widened == type_id {
+            return type_id;
+        }
+        if self.return_contribution_nullish_leaves_are_widening(expr_idx, 0) {
+            widened
+        } else {
+            type_id
+        }
+    }
+
+    /// Whether every nullish leaf reachable through a return expression's fresh
+    /// literal structure comes from a widening nullish source. See
+    /// [`Self::widen_nullish_return_contribution`] for the rule this recovers.
+    fn return_contribution_nullish_leaves_are_widening(
+        &mut self,
+        expr_idx: NodeIndex,
+        depth: u8,
+    ) -> bool {
+        const MAX_NULLISH_PROVENANCE_DEPTH: u8 = 8;
+        if depth > MAX_NULLISH_PROVENANCE_DEPTH {
+            return false;
+        }
+        let expr_idx = self.unwrap_parenthesized_expression(expr_idx);
+        let Some(node) = self.ctx.arena.get(expr_idx) else {
+            return false;
+        };
+        let kind = node.kind;
+
+        // Fresh literal structure: the widening flavour of a leaf propagates to
+        // the array/object literal built around it, so recurse into the members
+        // instead of judging the composite node itself.
+        if kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION {
+            let Some(array) = self.ctx.arena.get_literal_expr(node) else {
+                return false;
+            };
+            let elements: Vec<NodeIndex> = array.elements.nodes.clone();
+            return elements.into_iter().all(|element| {
+                self.return_contribution_nullish_leaves_are_widening(element, depth + 1)
+            });
+        }
+        if kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+            let Some(object) = self.ctx.arena.get_literal_expr(node) else {
+                return false;
+            };
+            let elements: Vec<NodeIndex> = object.elements.nodes.clone();
+            for element_idx in elements {
+                let Some(element) = self.ctx.arena.get(element_idx) else {
+                    return false;
+                };
+                // Only a plain `name: value` member exposes its own value
+                // expression; spreads, shorthands, methods and accessors are
+                // judged by the leaf rule below on the member node itself, which
+                // rejects anything carrying a nullish leaf.
+                let member_value = if element.kind == syntax_kind_ext::PROPERTY_ASSIGNMENT {
+                    self.ctx
+                        .arena
+                        .get_property_assignment(element)
+                        .map(|prop| prop.initializer)
+                        .unwrap_or(element_idx)
+                } else {
+                    element_idx
+                };
+                if !self.return_contribution_nullish_leaves_are_widening(member_value, depth + 1) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        // Leaf rule: a leaf whose checked type has no nullish leaf for the
+        // widener to touch is always fine; one that does must be a widening
+        // source (the `null` keyword or the global `undefined`).
+        let Some(&leaf_type) = self.ctx.node_types.get(&expr_idx.0) else {
+            return false;
+        };
+        let widened =
+            crate::query_boundaries::widening::widen_nullish_to_any_deep(self.ctx.types, leaf_type);
+        if widened == leaf_type {
+            return true;
+        }
+        if kind == SyntaxKind::NullKeyword as u16 || kind == SyntaxKind::UndefinedKeyword as u16 {
+            return true;
+        }
+        crate::flow_domain::control_flow::narrowing_helpers::is_global_undefined_identifier(
+            self.ctx.arena,
+            self.ctx.binder,
+            expr_idx,
+        )
+    }
+}

--- a/crates/tsz-checker/src/types/utilities/return_type_nullish.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type_nullish.rs
@@ -74,6 +74,19 @@ impl CheckerState<'_> {
             };
             let elements: Vec<NodeIndex> = array.elements.nodes.clone();
             return elements.into_iter().all(|element| {
+                // An elided element (`return [,,]`, parsed as `NodeIndex::NONE`)
+                // is a widening source: the user wrote no value, so tsc gives
+                // the hole `undefinedWideningType` exactly as it does the bare
+                // `undefined` keyword, and `() => [,,]` infers `any[]`. Without
+                // this the hole hits the node-lookup guard and fails closed.
+                // The enclosing `all` keeps it honest — a hole is permissive on
+                // its own and decisive nowhere, so one declared-`undefined`
+                // sibling (`return [, q]`) still makes the whole literal
+                // non-widening. Matches the mutable-binding seam's identical
+                // carve-out (`mutable_binding_nullish.rs`, #16393).
+                if element == NodeIndex::NONE {
+                    return true;
+                }
                 self.return_contribution_nullish_leaves_are_widening(element, depth + 1)
             });
         }


### PR DESCRIPTION
**Structural rule.** When `strictNullChecks` is off and a widenable return contribution carries `null`/`undefined` leaves that originate from a *widening* nullish source, tsc widens those leaves to `any` (`nullWideningType`/`undefinedWideningType` reaching `getWidenedType`); tsz now does the same through the checker's block-bodied return-contribution seam.

The defect was a pure **body-form asymmetry**. tsz applied the non-strict nullish widening only at the expression-bodied seam (`maybe_widen_return_contribution`), so:

```ts
// strictNullChecks: false
var pick = () => [undefined];          // tsz: any[]        ✅ matches tsc
function choose() { return [undefined]; }  // tsz: undefined[]  ❌ tsc: any[]
```

The block-bodied twin in `collect_return_types_in_statement` (`types/utilities/return_type.rs`) widened literals (`widen_const_initializer`) and enum members but never the nullish leaves, so every later assignment into such a binding produced a **false `TS2322`**.

**Owner layer.** Checker, at the existing per-contribution return-widening seam — the same place `widen_const_initializer` / `widen_enum_member_type` already run. The widening itself is the solver's `widen_nullish_to_any_deep` via the existing `query_boundaries::widening` gateway; no new type semantics live in the checker.

**Provenance gate (why this is not a blanket widen).** In tsc the widening flavour belongs to the *expression*, not to the type: `declare var q: undefined; function f() { return [q]; }` keeps `undefined[]`, because `q` is not a widening source. tsz has no per-type widening flag, so the new pass recovers the provenance from the return expression's own syntax — it walks the fresh array/object-literal structure and widens only when **every** nullish leaf the widener would touch is a widening source. A widening source is the `null`/`undefined` keyword token or an identifier resolving to the global `undefined` **through the binder's lib symbols** (`is_global_undefined_identifier`, promoted from `pub(super)` to `pub(crate)`) — a user binding that merely spells `undefined` shadows the global and does not qualify. Anything the walk cannot account for (spreads, shorthand members, accessors, an uncached leaf) keeps the unwidened contribution, so the gate fails closed.

New code lives in `types/utilities/return_type_nullish.rs`; `return_type.rs` is at the checker's 2000-line boundary.

## Goal
Goal: hold

## Verification

Every row below pinned against a real `typescript@7.0.2` oracle installed in this container (not the container's global 6.0.2).

**Conformance rows this targets.** From the committed `scripts/conformance/conformance-detail.json`, `conformance/types/tuple/wideningTuples2.ts` is `{"a":["TS2322"],"x":["TS2322"]}` — tsc expects zero diagnostics, tsz reports one extra `TS2322` and nothing else. **That row is now byte-clean against tsc** (`tsz --noEmit --target es2015 --strict false --noImplicitAny true`: exit 1 → exit 0, matching tsc's exit 0). Its sibling `wideningTuples1.ts` is a *different* leg (generic-call inference) and is **not** fixed here — filed separately, see below.

**Adjacent-case matrix, before → after (tsc value in brackets):**

| case | before | after |
|---|---|---|
| `function f() { return [undefined]; }` | `undefined[]` ❌ | `any[]` ✅ |
| `function f() { return [null]; }` | `null[]` ❌ | `any[]` ✅ |
| `function f() { return [[undefined]]; }` | `undefined[][]` ❌ | `any[][]` ✅ |
| `function f() { return { p: undefined }; }` | `{ p: undefined }` ❌ | `{ p: any }` ✅ |
| `var h: () => [any] = function w() { let s = w(); s = [""]; return [undefined]; }` (`wideningTuples2`) | `TS2322` ❌ | clean ✅ |
| `var pick = () => [undefined]` (expression body, control) | `any[]` ✅ | `any[]` ✅ |
| `declare var q: undefined; function f() { return [q]; }` | `undefined[]` ✅ | `undefined[]` ✅ (preserved) |
| `function f(): undefined[] { return [undefined]; }` | `undefined[]` ✅ | `undefined[]` ✅ (preserved) |
| `function f(undefined: undefined) { return [undefined]; }` (shadowing local) | reports ✅ | reports ✅ (preserved) |
| `function f() { return [1, 2, 3]; }` (no nullish leaf) | `number[]` ✅ | `number[]` ✅ |
| strict-mode control (`--strict`) | reports ✅ | reports ✅ (rule is non-strict-only) |

**Commands run locally:**
- `cargo test -p tsz-checker --lib non_strict_nullish_return_widening` — **13/13 pass** (new file, renamed binders across cases).
- `cargo test -p tsz-checker --lib` — full suite, result below.
- `cargo clippy -p tsz-checker --all-targets` — clean, warnings denied.
- `cargo fmt --all` + `scripts/githooks/pre-commit` (clippy + arch-size guard) — passed.

**Gate owed and disclosed:** `scripts/conformance/compare-to-parent.sh` did **not** run — this cold cloud container has no TypeScript corpus checked out (`git submodule status` is empty) and two release builds plus two snapshots do not fit the seat. The change is removal-only for diagnostics (it widens inferred types; it cannot add a diagnostic), and the committed conformance artifact shows the targeted family, but a two-sided run is still the right gate before this is queued. A warm seat re-running it at this head would close it out cheaply.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Zircon

---
_Generated by [Claude Code](https://claude.ai/code/session_01BE1ZgEvTpT9ZxkVKpUSmjj)_