### PR TITLE
fix(parser): abstract-before-declaration reports TS1184 in Block containers

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -79,6 +79,9 @@ pub(crate) mod test_fixture;
 #[path = "../../tests/definite_assignment_assertion_tests.rs"]
 mod definite_assignment_assertion_tests;
 #[cfg(test)]
+#[path = "../../tests/parser_abstract_ts1184_ts1242_tests.rs"]
+mod parser_abstract_ts1184_ts1242_tests;
+#[cfg(test)]
 #[path = "../../tests/parser_async_arrow_context_tests.rs"]
 mod parser_async_arrow_context_tests;
 #[cfg(test)]

--- a/crates/tsz-parser/src/parser/state_statements_keywords.rs
+++ b/crates/tsz-parser/src/parser/state_statements_keywords.rs
@@ -55,17 +55,34 @@ impl ParserState {
             use tsz_common::diagnostics::diagnostic_codes;
             // `abstract` before a variable or function declaration
             // (`abstract const x = 1;`, `abstract function f() {}`): tsc parses
-            // `abstract` as a modifier and reports TS1242 at the keyword, then
-            // parses the trailing declaration with the (invalid) modifier — it
-            // does NOT degrade to an identifier expression (which would give a
-            // spurious TS2304). Route through the shared modifier-prefixed
-            // statement parser so the declaration is still produced.
+            // `abstract` as a modifier and reports a diagnostic at the keyword,
+            // then parses the trailing declaration with the (invalid) modifier
+            // — it does NOT degrade to an identifier expression (which would
+            // give a spurious TS2304). Route through the shared
+            // modifier-prefixed statement parser so the declaration is still
+            // produced.
+            //
+            // tsc's grammar check picks the message from the statement's
+            // container, the same split `parse_statement_top_level_modifier`
+            // uses for the sibling modifiers (#16368/#16375): a Block body
+            // (function body, a nested block, or a class static block) gets
+            // the generic TS1184; a module/namespace body or the source
+            // file's own top level, neither of which is a Block, keeps the
+            // specific TS1242.
             let abstract_start = self.token_pos();
-            let abstract_modifier = self.consume_modifier_with_error(
-                SyntaxKind::AbstractKeyword,
-                "'abstract' modifier can only appear on a class, method, or property declaration.",
-                diagnostic_codes::ABSTRACT_MODIFIER_CAN_ONLY_APPEAR_ON_A_CLASS_METHOD_OR_PROPERTY_DECLARATION,
-            );
+            let abstract_modifier = if self.in_block_context() || self.in_static_block_context() {
+                self.consume_modifier_with_error(
+                    SyntaxKind::AbstractKeyword,
+                    "Modifiers cannot appear here.",
+                    diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE,
+                )
+            } else {
+                self.consume_modifier_with_error(
+                    SyntaxKind::AbstractKeyword,
+                    "'abstract' modifier can only appear on a class, method, or property declaration.",
+                    diagnostic_codes::ABSTRACT_MODIFIER_CAN_ONLY_APPEAR_ON_A_CLASS_METHOD_OR_PROPERTY_DECLARATION,
+                )
+            };
             self.parse_accessor_modified_statement(abstract_start, vec![abstract_modifier])
         } else {
             // When 'abstract' at statement level is followed by '@' on the same line,

--- a/crates/tsz-parser/tests/parser_abstract_ts1184_ts1242_tests.rs
+++ b/crates/tsz-parser/tests/parser_abstract_ts1184_ts1242_tests.rs
@@ -1,0 +1,102 @@
+//! `abstract` before a variable or function declaration (`abstract const x =
+//! 1;`, `abstract function f() {}`) is a grammar error in every container,
+//! but tsc picks its diagnostic from the *container*, the same split
+//! `parse_statement_top_level_modifier` uses for the sibling class modifiers
+//! (`public`/`private`/`protected`/`static`/`override`/`readonly`, #16368):
+//! a `Block` body (function body, a nested block, or a class static block)
+//! reports the generic TS1184 ("Modifiers cannot appear here"); a
+//! module/namespace body or the source file's own top level — neither of
+//! which is a `Block` — keeps the specific TS1242 ("'abstract' modifier can
+//! only appear on a class, method, or property declaration."). #16380.
+
+use crate::parser::test_fixture::parse_source;
+use tsz_common::diagnostics::diagnostic_codes;
+
+fn assert_single_diagnostic(source: &str, expected_code: u32, expected_pos: u32) {
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == expected_code && d.start == expected_pos),
+        "expected TS{expected_code} at position {expected_pos} for {source:?}, got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn abstract_const_in_function_body_reports_ts1184() {
+    let source = "function mm() { abstract const z = 1; return z; }";
+    let pos = source.find("abstract").unwrap() as u32;
+    assert_single_diagnostic(source, diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE, pos);
+}
+
+#[test]
+fn abstract_function_in_function_body_reports_ts1184() {
+    // Deliberately a plain function body, not a class method body: a class
+    // body's nested-block recovery heuristic (`state_statements.rs:625`) is a
+    // separate, pre-existing bug (#16377) that unconditionally terminates the
+    // inner block on any class-modifier-like keyword followed by an
+    // identifier, `abstract` included, regardless of container. That bug has
+    // its own owner and claim; this file only covers the diagnostic-choice
+    // fix in `parse_statement_abstract_keyword`.
+    let source = "function mm() { abstract function f() {} }";
+    let pos = source.find("abstract").unwrap() as u32;
+    assert_single_diagnostic(source, diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE, pos);
+}
+
+#[test]
+fn abstract_var_and_let_in_function_body_report_ts1184() {
+    for keyword in ["var", "let"] {
+        let source = format!("function mm() {{ abstract {keyword} z = 1; }}");
+        let pos = source.find("abstract").unwrap() as u32;
+        assert_single_diagnostic(&source, diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE, pos);
+    }
+}
+
+#[test]
+fn abstract_const_in_nested_block_inside_function_body_reports_ts1184() {
+    let source = "function mm() { { abstract const z = 1; } }";
+    let pos = source.find("abstract").unwrap() as u32;
+    assert_single_diagnostic(source, diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE, pos);
+}
+
+#[test]
+fn abstract_const_in_class_static_block_reports_ts1184() {
+    let source = "class C { static { abstract const z = 1; } }";
+    let pos = source.find("abstract").unwrap() as u32;
+    assert_single_diagnostic(source, diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE, pos);
+}
+
+#[test]
+fn abstract_const_at_namespace_top_level_reports_ts1242() {
+    let source = "namespace N { abstract const z = 1; }";
+    let pos = source.find("abstract").unwrap() as u32;
+    assert_single_diagnostic(
+        source,
+        diagnostic_codes::ABSTRACT_MODIFIER_CAN_ONLY_APPEAR_ON_A_CLASS_METHOD_OR_PROPERTY_DECLARATION,
+        pos,
+    );
+}
+
+#[test]
+fn abstract_const_at_source_file_top_level_reports_ts1242() {
+    let source = "abstract const z = 1;";
+    assert_single_diagnostic(
+        source,
+        diagnostic_codes::ABSTRACT_MODIFIER_CAN_ONLY_APPEAR_ON_A_CLASS_METHOD_OR_PROPERTY_DECLARATION,
+        0,
+    );
+}
+
+#[test]
+fn abstract_before_namespace_nested_in_function_body_still_reports_ts1242() {
+    // The modifier's own container is the namespace body, not the enclosing
+    // function block, even though the namespace itself sits inside one.
+    let source = "function mm() { namespace N { abstract const z = 1; } }";
+    let pos = source.rfind("abstract").unwrap() as u32;
+    assert_single_diagnostic(
+        source,
+        diagnostic_codes::ABSTRACT_MODIFIER_CAN_ONLY_APPEAR_ON_A_CLASS_METHOD_OR_PROPERTY_DECLARATION,
+        pos,
+    );
+}


### PR DESCRIPTION
Closes #16380.

## Structural rule

**When a class-modifier-shaped keyword starts an illegal statement, tsc's grammar check picks the diagnostic from the statement's *container*, not the modifier itself: a `Block` body (function body, a nested block, or a class static block) reports the generic TS1184 ("Modifiers cannot appear here"); a module/namespace body or the source file's own top level — neither of which is a `Block` — keeps the modifier-specific message.**

#16368/#16375 already implemented this container split for `parse_statement_top_level_modifier` (`public`/`private`/`protected`/`static`/`override`/`readonly`). `abstract` before a variable/function declaration (`parse_statement_abstract_keyword`'s `look_ahead_is_abstract_before_var_or_function` branch, `crates/tsz-parser/src/parser/state_statements_keywords.rs`) never got the same split and unconditionally reported TS1242 ("'abstract' modifier can only appear on a class, method, or property declaration"), even inside a Block where tsc reports TS1184.

Fix mirrors the existing `in_block_context() || in_static_block_context()` gate at the `abstract`-before-var/function call site, choosing `MODIFIERS_CANNOT_APPEAR_HERE` (TS1184) vs `ABSTRACT_MODIFIER_CAN_ONLY_APPEAR_ON_A_CLASS_METHOD_OR_PROPERTY_DECLARATION` (TS1242) instead of always the latter. Owner layer: parser (`crates/tsz-parser/src/parser/state_statements_keywords.rs`), same file/function as the reported issue.

## Adjacent-case matrix

8 new tests in `crates/tsz-parser/tests/parser_abstract_ts1184_ts1242_tests.rs`, oracle-verified against pinned `typescript@7.0.2` for the load-bearing rows:

| case | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `class C { method() { abstract const z = 1; } }` (issue repro) | TS1184 | TS1242 | **TS1184** |
| `function mm() { abstract function f() {} }` (Block, function keyword) | TS1184 | TS1242 | **TS1184** |
| `function mm() { abstract var/let z = 1; }` | TS1184 | TS1242 | **TS1184** |
| `function mm() { { abstract const z = 1; } }` (nested block) | TS1184 | TS1242 | **TS1184** |
| `class C { static { abstract const z = 1; } }` (class static block) | TS1184 | TS1242 | **TS1184** |
| `namespace N { abstract const z = 1; }` | TS1242 | TS1242 | TS1242 (unchanged) |
| `abstract const z = 1;` (source-file top level) | TS1242 | TS1242 | TS1242 (unchanged) |
| `function mm() { namespace N { abstract const z = 1; } }` (namespace nested in a block — container is the namespace body, not the enclosing block) | TS1242 | TS1242 | TS1242 (unchanged) |

The first repro row (`class C { method() { ... } }`) exercises the class-body nested-block recovery heuristic at `state_statements.rs:625` — a separate, pre-existing, already-claimed bug (#16377, fixed by #16381) that also unconditionally consumes `abstract` there. This PR does not touch that heuristic; the unit-test matrix deliberately uses a plain function body (not a class method body) for the `abstract function` row to isolate the diagnostic-choice fix from that other owner code. The oracle probe above confirms the diagnostic-choice fix is correct independent of that other bug.

## Anti-hardcoding

No identifier/alias/property/file-name string checks; the branch selects on `in_block_context()`/`in_static_block_context()`, the same structural predicate `parse_statement_top_level_modifier` already uses for the sibling modifiers.

## Goal
Goal: hold

## Verification
- Oracle matrix: 4 rows against pinned `typescript@7.0.2` (repro, block-function, namespace, top-level) — all match after the fix; verified directly against `node .../tsc --noEmit --strict --target es2022`.
- `cargo test -p tsz-parser --lib` — 1769/1769 passed (8 new).
- `cargo clippy -p tsz-parser --all-targets` — clean.
- `cargo fmt --check` — clean.
- `scripts/conformance/compare-to-parent.sh origin/main` — running in background (cold-cache dist-fast build), not yet complete at PR-open time; this is a pure diagnostic-code swap on an already-erroring statement (like #16368/#16375), so the expected result is 0 newly-failing / 0 newly-passing. Will post the two-sided count before queuing.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_01MCAGCKpVoKmaaCBpdjWwxF)_