### PR TITLE
fix(checker): TS1064's `Promise` suggestion renders the annotation's awaited type

### DIFF
--- a/crates/tsz-checker/src/checkers/promise_checker.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker.rs
@@ -523,6 +523,36 @@ impl<'a> CheckerState<'a> {
             .awaited_type
     }
 
+    /// tsc's `getAwaitedTypeNoAlias(t)`.
+    ///
+    /// A type that is not thenable is its own awaited type; a thenable is
+    /// awaited recursively, since a `then` callback whose payload is itself
+    /// thenable keeps unwrapping. `None` marks tsc's `undefined` result — a
+    /// `then` that is callable but yields no fulfillment payload — which the
+    /// diagnostic callers render as `void`, matching tsc's `|| voidType`.
+    pub(crate) fn awaited_type_no_alias(&mut self, type_id: TypeId) -> Option<TypeId> {
+        self.awaited_type_no_alias_with_depth(type_id, 0)
+    }
+
+    fn awaited_type_no_alias_with_depth(&mut self, type_id: TypeId, depth: u8) -> Option<TypeId> {
+        if depth > MAX_THENABLE_THIS_VALIDATION_DEPTH {
+            return Some(type_id);
+        }
+        // Unwrap the `Promise`/`PromiseLike` applications and distribute over
+        // unions and intersections first, so only a user-written thenable
+        // reaches the payload extraction below.
+        let unwrapped = self.compute_awaited_type(type_id, 0);
+        let info = self.extract_awaited_type_from_valid_thenable(unwrapped, false);
+        match info.awaited_type {
+            Some(payload) if payload != unwrapped => {
+                self.awaited_type_no_alias_with_depth(payload, depth + 1)
+            }
+            Some(_) => Some(unwrapped),
+            None if info.has_callable_then => None,
+            None => Some(unwrapped),
+        }
+    }
+
     pub(crate) fn await_operand_invalid_thenable_this_type(
         &mut self,
         type_id: TypeId,

--- a/crates/tsz-checker/src/checkers/promise_checker.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker.rs
@@ -38,6 +38,8 @@ impl ThenableAwaitInfo {
     }
 }
 
+mod awaited_type;
+
 const MAX_THENABLE_THIS_VALIDATION_DEPTH: u8 = 10;
 
 // =============================================================================
@@ -541,40 +543,6 @@ impl<'a> CheckerState<'a> {
     pub(super) fn extract_awaited_type_from_thenable(&mut self, type_id: TypeId) -> Option<TypeId> {
         self.extract_awaited_type_from_valid_thenable(type_id, false)
             .awaited_type
-    }
-
-    /// tsc's `getAwaitedTypeNoAlias(t)`.
-    ///
-    /// A type that is not thenable is its own awaited type; a thenable is
-    /// awaited recursively, since a `then` callback whose payload is itself
-    /// thenable keeps unwrapping. `None` marks tsc's `undefined` result — a
-    /// thenable whose `getPromisedTypeOfPromiseEx` still yields nothing —
-    /// which the diagnostic callers render as `void`, matching tsc's
-    /// `|| voidType`.
-    pub(crate) fn awaited_type_no_alias(&mut self, type_id: TypeId) -> Option<TypeId> {
-        self.awaited_type_no_alias_with_depth(type_id, 0)
-    }
-
-    fn awaited_type_no_alias_with_depth(&mut self, type_id: TypeId, depth: u8) -> Option<TypeId> {
-        if depth > MAX_THENABLE_THIS_VALIDATION_DEPTH {
-            return Some(type_id);
-        }
-        // Unwrap the `Promise`/`PromiseLike` applications and distribute over
-        // unions and intersections first, so only a user-written thenable
-        // reaches the payload extraction below.
-        let unwrapped = self.compute_awaited_type(type_id, 0);
-        let info = self.extract_awaited_type_from_valid_thenable(unwrapped, true);
-        match info.awaited_type {
-            Some(payload) if payload != unwrapped => {
-                self.awaited_type_no_alias_with_depth(payload, depth + 1)
-            }
-            // Thenable, yet no fulfillment payload survives: tsc's `undefined`
-            // result. Everything else — a thenable that already awaits to
-            // itself, and a type that is not thenable at all — is its own
-            // awaited type.
-            None if info.is_thenable => None,
-            _ => Some(unwrapped),
-        }
     }
 
     /// The `this` type that rejected every `then` signature of an invalid

--- a/crates/tsz-checker/src/checkers/promise_checker.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker.rs
@@ -547,9 +547,12 @@ impl<'a> CheckerState<'a> {
             Some(payload) if payload != unwrapped => {
                 self.awaited_type_no_alias_with_depth(payload, depth + 1)
             }
-            Some(_) => Some(unwrapped),
+            // A callable `then` that yields no fulfillment payload is tsc's
+            // `undefined` result. Everything else — a thenable that already
+            // awaits to itself, and a type that is not thenable at all — is
+            // its own awaited type.
             None if info.has_callable_then => None,
-            None => Some(unwrapped),
+            _ => Some(unwrapped),
         }
     }
 

--- a/crates/tsz-checker/src/checkers/promise_checker/awaited_type.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker/awaited_type.rs
@@ -1,0 +1,47 @@
+//! tsc's `getAwaitedTypeNoAlias`, the awaited-type walk TS1064's
+//! `Did you mean to write 'Promise[T]'?` suggestion is formatted from.
+//!
+//! A child module rather than a sibling: it reads `ThenableAwaitInfo` and
+//! `extract_awaited_type_from_valid_thenable`, which are private to the parent
+//! and stay that way. It lives here rather than in `promise_checker.rs`
+//! because that file sits against the 2000-line architecture cap.
+
+use super::MAX_THENABLE_THIS_VALIDATION_DEPTH;
+use crate::state::CheckerState;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    /// tsc's `getAwaitedTypeNoAlias(t)`.
+    ///
+    /// A type that is not thenable is its own awaited type; a thenable is
+    /// awaited recursively, since a `then` callback whose payload is itself
+    /// thenable keeps unwrapping. `None` marks tsc's `undefined` result — a
+    /// thenable whose `getPromisedTypeOfPromiseEx` still yields nothing —
+    /// which the diagnostic callers render as `void`, matching tsc's
+    /// `|| voidType`.
+    pub(crate) fn awaited_type_no_alias(&mut self, type_id: TypeId) -> Option<TypeId> {
+        self.awaited_type_no_alias_with_depth(type_id, 0)
+    }
+
+    fn awaited_type_no_alias_with_depth(&mut self, type_id: TypeId, depth: u8) -> Option<TypeId> {
+        if depth > MAX_THENABLE_THIS_VALIDATION_DEPTH {
+            return Some(type_id);
+        }
+        // Unwrap the `Promise`/`PromiseLike` applications and distribute over
+        // unions and intersections first, so only a user-written thenable
+        // reaches the payload extraction below.
+        let unwrapped = self.compute_awaited_type(type_id, 0);
+        let info = self.extract_awaited_type_from_valid_thenable(unwrapped, true);
+        match info.awaited_type {
+            Some(payload) if payload != unwrapped => {
+                self.awaited_type_no_alias_with_depth(payload, depth + 1)
+            }
+            // Thenable, yet no fulfillment payload survives: tsc's `undefined`
+            // result. Everything else — a thenable that already awaits to
+            // itself, and a type that is not thenable at all — is its own
+            // awaited type.
+            None if info.is_thenable => None,
+            _ => Some(unwrapped),
+        }
+    }
+}

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -795,6 +795,8 @@ mod this_void_method_call_tests;
 mod top_level_await_boundary_tests;
 #[path = "tests/truthiness_promise_coercion_tests.rs"]
 mod truthiness_promise_coercion_tests;
+#[path = "tests/ts1064_awaited_suggestion_tests.rs"]
+mod ts1064_awaited_suggestion_tests;
 #[path = "tests/ts1101_with_in_strict_mode_tests.rs"]
 mod ts1101_with_in_strict_mode_tests;
 #[path = "tests/ts1165_ambient_class_method_computed_name_tests.rs"]

--- a/crates/tsz-checker/src/tests/ts1064_awaited_suggestion_tests.rs
+++ b/crates/tsz-checker/src/tests/ts1064_awaited_suggestion_tests.rs
@@ -1,0 +1,235 @@
+//! TS1064's `Did you mean to write 'Promise[T]'?` suggestion renders the
+//! annotation's **awaited** type, not the annotation itself.
+//!
+//! tsc's `checkAsyncFunctionReturnType` formats the message argument as
+//! `typeToString(getAwaitedTypeNoAlias(returnType) || voidType)`. A type that
+//! is not thenable is its own awaited type, so every non-thenable annotation
+//! renders unchanged — which is exactly why rendering the annotation itself
+//! went unnoticed. Only an annotation that *is* a thenable other than the
+//! global `Promise` distinguishes the two, and a thenable whose `then` yields
+//! no fulfillment payload awaits to nothing and falls back to `void`.
+//!
+//! Every row below is pinned against `typescript@7.0.2`
+//! (`--noEmit --strict --target es2022 --lib es2022`); the binder names are
+//! varied across rows so no assertion can be satisfied by a name check.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_source_with_libs, load_default_lib_files};
+
+/// The `Promise[...]` argument tsz renders inside TS1064's suggestion, for the
+/// single TS1064 the source is expected to produce.
+fn ts1064_suggestion(source: &str) -> String {
+    let libs = load_default_lib_files();
+    let messages: Vec<String> = check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .filter(|diagnostic| diagnostic.code == 1064)
+    .map(|diagnostic| diagnostic.message_text)
+    .collect();
+    assert_eq!(
+        messages.len(),
+        1,
+        "expected exactly one TS1064; got {messages:?}"
+    );
+    let message = &messages[0];
+    let start = message
+        .find("Did you mean to write '")
+        .map(|at| at + "Did you mean to write '".len())
+        .unwrap_or_else(|| panic!("TS1064 carries no suggestion clause: {message}"));
+    let rest = &message[start..];
+    let end = rest
+        .rfind('\'')
+        .unwrap_or_else(|| panic!("TS1064 suggestion is unterminated: {message}"));
+    rest[..end].to_string()
+}
+
+/// A valid thenable annotation suggests its fulfillment payload, not itself.
+#[test]
+fn valid_thenable_annotation_suggests_its_payload() {
+    assert_eq!(
+        ts1064_suggestion(
+            r#"
+export {};
+interface QqSettled { then(onDone: (value: number) => void): void }
+declare const qqValue: QqSettled;
+async function qqRun(): QqSettled { return qqValue; }
+"#
+        ),
+        "Promise<number>"
+    );
+}
+
+/// The payload is rendered structurally, exactly as tsc prints it.
+#[test]
+fn thenable_payload_object_type_is_rendered_structurally() {
+    assert_eq!(
+        ts1064_suggestion(
+            r#"
+export {};
+interface WwBoxed { then(onDone: (value: { id: string }) => void): void }
+declare const wwValue: WwBoxed;
+async function wwRun(): WwBoxed { return wwValue; }
+"#
+        ),
+        "Promise<{ id: string; }>"
+    );
+}
+
+/// Control: a non-thenable annotation is its own awaited type, so the rendered
+/// suggestion is unchanged by this rule. This is the row that shows the fix is
+/// the awaited-vs-annotation choice and not a general printer change.
+#[test]
+fn non_thenable_class_annotation_suggests_itself() {
+    assert_eq!(
+        ts1064_suggestion(
+            r#"
+export {};
+class EeThing { x = 1 }
+declare const eeValue: EeThing;
+async function eeRun(): EeThing { return eeValue; }
+"#
+        ),
+        "Promise<EeThing>"
+    );
+}
+
+/// Control: a primitive annotation is likewise its own awaited type.
+#[test]
+fn primitive_annotation_suggests_itself() {
+    assert_eq!(
+        ts1064_suggestion(
+            r#"
+export {};
+declare const rrValue: string;
+async function rrRun(): string { return rrValue; }
+"#
+        ),
+        "Promise<string>"
+    );
+}
+
+/// An *invalid* thenable — a callable `then` that yields no fulfillment
+/// payload — awaits to nothing, and tsc's `|| voidType` fallback applies.
+#[test]
+fn invalid_thenable_annotation_suggests_void() {
+    assert_eq!(
+        ts1064_suggestion(
+            r#"
+export {};
+interface TtBadParam { then(onDone: string): void }
+declare const ttValue: TtBadParam;
+async function ttRun(): TtBadParam { return ttValue; }
+"#
+        ),
+        "Promise<void>"
+    );
+}
+
+/// `getAwaitedTypeNoAlias` recurses, so a `then` whose payload is itself
+/// thenable unwraps all the way to the settled value.
+#[test]
+fn nested_thenable_annotation_suggests_the_fully_awaited_type() {
+    assert_eq!(
+        ts1064_suggestion(
+            r#"
+export {};
+interface YyInner { then(onDone: (value: number) => void): void }
+interface YyOuter { then(onDone: (value: YyInner) => void): void }
+declare const yyValue: YyOuter;
+async function yyRun(): YyOuter { return yyValue; }
+"#
+        ),
+        "Promise<number>"
+    );
+}
+
+/// A generic `then` callback still yields its parameter's payload.
+#[test]
+fn generic_then_callback_annotation_suggests_its_payload() {
+    assert_eq!(
+        ts1064_suggestion(
+            r#"
+export {};
+interface UuGeneric { then<R>(onDone: (value: string) => R): void }
+declare const uuValue: UuGeneric;
+async function uuRun(): UuGeneric { return uuValue; }
+"#
+        ),
+        "Promise<string>"
+    );
+}
+
+/// A `PromiseLike[T]` annotation already suggested `Promise[T]` before this
+/// rule; pinning it guards the Promise-application unwrap that the awaited
+/// walk now runs first.
+#[test]
+fn promise_like_annotation_still_suggests_its_type_argument() {
+    assert_eq!(
+        ts1064_suggestion(
+            r#"
+export {};
+declare const iiValue: PromiseLike<boolean>;
+async function iiRun(): PromiseLike<boolean> { return iiValue; }
+"#
+        ),
+        "Promise<boolean>"
+    );
+}
+
+/// The rule is a property of the annotation, not of the function form: an
+/// async arrow reports the same suggestion as a declaration.
+#[test]
+fn async_arrow_annotation_suggests_its_payload() {
+    assert_eq!(
+        ts1064_suggestion(
+            r#"
+export {};
+interface OoSettled { then(onDone: (value: number) => void): void }
+declare const ooValue: OoSettled;
+const ooRun = async (): OoSettled => ooValue;
+"#
+        ),
+        "Promise<number>"
+    );
+}
+
+/// ...and so does an async class method.
+#[test]
+fn async_method_annotation_suggests_its_payload() {
+    assert_eq!(
+        ts1064_suggestion(
+            r#"
+export {};
+interface PpSettled { then(onDone: (value: number) => void): void }
+declare const ppValue: PpSettled;
+class PpHolder { async ppRun(): PpSettled { return ppValue; } }
+"#
+        ),
+        "Promise<number>"
+    );
+}
+
+/// An alias in front of a thenable does not change the awaited type, and the
+/// suggestion follows the type rather than the alias spelling.
+#[test]
+fn alias_of_a_thenable_annotation_suggests_the_payload() {
+    assert_eq!(
+        ts1064_suggestion(
+            r#"
+export {};
+interface AaSettled { then(onDone: (value: number) => void): void }
+type AaAlias = AaSettled;
+declare const aaValue: AaAlias;
+async function aaRun(): AaAlias { return aaValue; }
+"#
+        ),
+        "Promise<number>"
+    );
+}

--- a/crates/tsz-checker/src/types/function_type_helpers_async_promise.rs
+++ b/crates/tsz-checker/src/types/function_type_helpers_async_promise.rs
@@ -215,13 +215,17 @@ impl<'a> CheckerState<'a> {
                 diagnostic_codes::TYPE_IS_NOT_A_VALID_ASYNC_FUNCTION_RETURN_TYPE_IN_ES5_BECAUSE_IT_DOES_NOT_REFER,
             );
         } else {
-            // TS1064: For ES6+ targets, the return type must be Promise<T>
-            let type_name = self
-                .promise_like_return_type_argument(return_type)
-                .map_or_else(
-                    || self.format_type(return_type),
-                    |inner| self.format_type(inner),
-                );
+            // TS1064: For ES6+ targets, the return type must be Promise<T>.
+            //
+            // tsc's `checkAsyncFunctionReturnType` renders the suggestion from
+            // `typeToString(getAwaitedTypeNoAlias(returnType) || voidType)` —
+            // the annotation's *awaited* type, not the annotation itself. The
+            // two coincide for every non-thenable annotation, which is why
+            // rendering the annotation went unnoticed: only an annotation that
+            // is a thenable other than the global `Promise` distinguishes them.
+            // An invalid thenable awaits to nothing and reports `Promise<void>`.
+            let suggested = self.awaited_type_no_alias(return_type);
+            let type_name = self.format_type(suggested.unwrap_or(TypeId::VOID));
             self.error_at_node(
                 type_annotation,
                 &format_message(


### PR DESCRIPTION
Closes #16376.

> **Note on notation:** this body writes type arguments with **square** brackets — `Promise[ number ]` — because GitHub strips real angle brackets from PR bodies on this repo, including inside code fences. Every such spelling means the ordinary angle-bracket form. The in-repo test file carries the real source; source files are never mangled.

**Structural rule.** When an async function's return-type annotation is not the global `Promise`, `tsc` formats TS1064's suggestion from the annotation's **awaited** type — `checkAsyncFunctionReturnType` passes `typeToString(getAwaitedTypeNoAlias(returnType) || voidType)` — falling back to `void` when the annotation awaits to nothing. tsz rendered the annotation itself. tsz now does the same as tsc through the **checker**'s promise-checker layer (`checkers/promise_checker.rs`), consumed at the single TS1064 emission site in `types/function_type_helpers_async_promise.rs`.

The two spellings coincide for every annotation that is not thenable, which is why this survived: only an annotation that *is* a thenable other than the global `Promise` distinguishes them. Diagnostic display only — the code, the count and the span were already correct, and no relation, inference or narrowing behaviour changes.

### What changed

`awaited_type_no_alias` mirrors tsc's `getAwaitedTypeNoAlias`:

- `Promise`/`PromiseLike` applications, unions and intersections unwrap first through the existing `compute_awaited_type`, so only a user-written thenable reaches payload extraction;
- a user-written thenable unwraps **recursively** — a `then` whose payload is itself thenable keeps unwrapping, matching tsc;
- a thenable whose `getPromisedTypeOfPromiseEx` still yields nothing returns `None`, which the caller renders as `void` (tsc's `|| voidType`);
- a type that is not thenable at all is its own awaited type, so every non-thenable annotation renders exactly as before.

The thenable test is `ThenableAwaitInfo::is_thenable` — tsc's own `isThenableType` — landed by #16374, and the walk runs the same `this` filter `getPromisedTypeOfPromiseEx` applies. No identifier, alias, property or file-name string drives any decision, and the depth bound reuses the family's existing constant.

## Goal
Goal: hold

## Verification

**Oracle matrix vs `typescript@7.0.2`** (pinned via `scripts/conformance/typescript-versions.json`), `--noEmit --strict --pretty false --target es2022 --lib es2022`, comparing the rendered suggestion character-for-character. Binder names are varied across rows so nothing can pass on a name check.

| annotation | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| valid thenable, `number` payload | `Promise[ number ]` | `Promise[ ValidThenable ]` ❌ | ✅ |
| valid thenable, object payload | `Promise[ { id: string; } ]` | `Promise[ Boxed ]` ❌ | ✅ |
| non-thenable class (**control**) | `Promise[ MyThing ]` | `Promise[ MyThing ]` ✅ | ✅ |
| **in**valid thenable (`then(cb: string)`) | `Promise[ void ]` | `Promise[ BadParam ]` ❌ | ✅ |
| generic `then[ R ]` callback | `Promise[ string ]` | `Promise[ PL ]` ❌ | ✅ |
| `PromiseLike[ boolean ]` | `Promise[ boolean ]` | `Promise[ boolean ]` ✅ | ✅ |
| nested thenable (payload is thenable) | `Promise[ number ]` | `Promise[ Nested ]` ❌ | ✅ |
| plain `string` (**control**) | `Promise[ string ]` | `Promise[ string ]` ✅ | ✅ |
| async arrow, valid thenable | `Promise[ number ]` | `Promise[ ValidThenable ]` ❌ | ✅ |

**3/9 → 9/9, zero rows moved away from tsc.** The three rows that already agreed are the controls, and they are unchanged.

Adjacent-case matrix, same oracle, **6/6 before and after** — these are the guard on the Promise-application unwrap that now runs first. A fix that reached for the thenable payload before that unwrap is exactly what these rows would have caught:

| annotation | tsc | tsz after |
| --- | --- | --- |
| alias in front of a thenable | `Promise[ number ]` | ✅ |
| union `Inner \| string` | `Promise[ string \| number ]` | ✅ (distribution **and** member order match) |
| generic thenable `Gen[ string[] ]` | `Promise[ string[] ]` | ✅ |
| **class**-declared thenable `MyPromise[ number ]` | `Promise[ number ]` | ✅ |
| `never` | `Promise[ never ]` | ✅ |
| `any` | `Promise[ any ]` | ✅ |

Both matrices re-run at the post-merge head and are **byte-identical to the oracle** (`diff` of the two diagnostic streams, empty).

**Unit.** New `crates/tsz-checker/src/tests/ts1064_awaited_suggestion_tests.rs` pins 11 rows, including both controls, the `void` fallback, the recursive nested case, and the method/arrow forms:

```
cargo test -p tsz-checker --lib -- ts1064_awaited_suggestion
  → 11 passed; 0 failed
```

**Regression sweep** over the whole async/promise/thenable/await/yield family, at the post-merge head:

```
cargo test -p tsz-checker --lib -- ts1064 async_return promise thenable await_ yield
  → 527 passed; 0 failed; 9 ignored
```

**Lint.** `cargo fmt` clean. `cargo clippy --profile ci-lint --workspace --exclude tsz-conformance --all-targets -- -D warnings` → **exit 0** (verified locally; re-running at the post-merge head, result to be posted as a comment).

**Merged `origin/main`.** #16374 landed mid-session and refactored this exact file — `has_callable_then` is gone, replaced by `is_thenable` + `invalid_thenable_info`. Conflict resolved onto the new API rather than around it; the resolution is a small improvement, since `is_thenable` is tsc's own `isThenableType` and the walk now applies the same `this` filter `getPromisedTypeOfPromiseEx` uses. Every number above was re-measured after the merge, not carried over.

**`compare-to-parent.sh` is OWED and disclosed.** No TypeScript corpus in this container, and fetching it plus the two `dist-fast` builds does not fit this session. Stated rather than assumed: this changes a message *argument* only — never a code, count or span — and the conformance fingerprint compares primary codes, so the honest expectation is 0 newly failing / 0 newly passing. That same property makes the run cheap insurance rather than a formality. Whoever drains this next, run it at the current head, and per @Tourmaline's finding on #16374 earlier today, if any row lands under `still failing, fingerprint changed`, diff that fixture against the oracle rather than reading the 0/0 as clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Topaz