### PR TITLE
fix(parser): a stray modifier before `export` splits three ways, not one

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -172,6 +172,9 @@ mod parser_improvement_unicode_escape_recovery_tests;
 #[path = "../../tests/parser_improvement_yield_generator_recovery_tests.rs"]
 mod parser_improvement_yield_generator_recovery_tests;
 #[cfg(test)]
+#[path = "../../tests/parser_modified_export_statement_tests.rs"]
+mod parser_modified_export_statement_tests;
+#[cfg(test)]
 #[path = "../../tests/parser_speculative_context_restore_tests.rs"]
 mod parser_speculative_context_restore_tests;
 #[cfg(test)]

--- a/crates/tsz-parser/src/parser/state_statements_keywords.rs
+++ b/crates/tsz-parser/src/parser/state_statements_keywords.rs
@@ -6,6 +6,27 @@ use tsz_common::diagnostics::diagnostic_codes;
 use tsz_common::interner::AstAtom;
 use tsz_scanner::{SyntaxKind, keyword_text_len};
 
+/// What the `export` that follows a stray modifier keyword actually starts.
+///
+/// tsc attaches the modifier to whichever node the `export` begins, and
+/// `checkGrammarModifiers` then answers by that node's own kind — not by the
+/// modifier, and not by the container alone. The three arms below get three
+/// genuinely different answers, so the classification has to happen before the
+/// container gate runs.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ModifiedExportForm {
+    /// `export as namespace Foo;` — a `NamespaceExportDeclaration`, which
+    /// admits no modifiers in any container.
+    NamespaceExport,
+    /// `export {}`, `export * from`, `export =`, `export default` — an export
+    /// declaration or assignment, which draws its own placement diagnostic and
+    /// no modifier diagnostic.
+    ExportDeclarationOrAssignment,
+    /// `export const`, `export class`, `export function`, ... — an ordinary
+    /// modified declaration, which takes the container split.
+    ModifiedDeclaration,
+}
+
 impl ParserState {
     pub(crate) fn parse_statement_async_declaration_or_expression(&mut self) -> NodeIndex {
         if self.look_ahead_is_async_function() {
@@ -228,10 +249,28 @@ impl ParserState {
         if self.next_token_is_on_new_line() {
             self.parse_expression_statement()
         } else if self.look_ahead_is_modifier_before_declaration() {
-            if self.look_ahead_next_token_is_export_keyword() {
-                // Modifier keyword followed by `export as namespace ...`:
-                // TSC silently accepts the modifier and parses the export statement.
-                // e.g., `static export as namespace Foo;` → no error.
+            let export_form = self.modified_export_form();
+            if matches!(
+                export_form,
+                Some(ModifiedExportForm::ExportDeclarationOrAssignment)
+            ) {
+                // `export {}` / `export * from` / `export =` / `export default`
+                // after a stray modifier: tsc reports the form's own placement
+                // diagnostic (TS1233 / TS1231 / TS1258) and no modifier
+                // diagnostic at all, so the modifier is dropped silently here.
+                self.next_token();
+                self.parse_statement()
+            } else if matches!(export_form, Some(ModifiedExportForm::NamespaceExport)) {
+                // `export as namespace Foo;` after a stray modifier. Unlike every
+                // other shape in this branch the answer is not container-derived:
+                // a `NamespaceExportDeclaration` admits no modifiers at all, so
+                // tsc's grammar check reports TS1184 in a Block, in a namespace
+                // body, and at the source file's own top level alike — where a
+                // modified *declaration* would keep TS1044 in the latter two.
+                self.parse_error_at_current_token(
+                    "Modifiers cannot appear here.",
+                    diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE,
+                );
                 self.next_token();
                 self.parse_statement()
             } else {
@@ -571,18 +610,35 @@ impl ParserState {
         has_line_break
     }
 
-    /// Look ahead to see if the next token is `export` on the same line.
-    /// Used to distinguish `static export as namespace ...` (modifier as expression + export statement)
-    /// from `static class ...` (modifier before declaration).
-    pub(crate) fn look_ahead_next_token_is_export_keyword(&mut self) -> bool {
+    /// Look ahead past a stray modifier keyword to classify the `export` statement
+    /// it prefixes, if the next token is `export` on the same line.
+    ///
+    /// Returns `None` when the modifier is not followed by `export`, which leaves
+    /// the caller on its ordinary container-based path.
+    pub(crate) fn modified_export_form(&mut self) -> Option<ModifiedExportForm> {
         let snapshot = self.scanner.save_state();
         let current = self.current_token;
-        self.next_token();
-        let result =
-            !self.scanner.has_preceding_line_break() && self.token() == SyntaxKind::ExportKeyword;
+
+        self.next_token(); // skip the modifier keyword
+        let form = if self.scanner.has_preceding_line_break()
+            || self.token() != SyntaxKind::ExportKeyword
+        {
+            None
+        } else {
+            self.next_token(); // skip `export`
+            Some(match self.token() {
+                SyntaxKind::AsKeyword => ModifiedExportForm::NamespaceExport,
+                SyntaxKind::OpenBraceToken
+                | SyntaxKind::DefaultKeyword
+                | SyntaxKind::AsteriskToken
+                | SyntaxKind::EqualsToken => ModifiedExportForm::ExportDeclarationOrAssignment,
+                _ => ModifiedExportForm::ModifiedDeclaration,
+            })
+        };
+
         self.scanner.restore_state(snapshot);
         self.current_token = current;
-        result
+        form
     }
 
     /// Look ahead to see if we have "async function"

--- a/crates/tsz-parser/tests/parser_modified_export_statement_tests.rs
+++ b/crates/tsz-parser/tests/parser_modified_export_statement_tests.rs
@@ -1,0 +1,273 @@
+//! A stray modifier keyword immediately before an `export` statement.
+//!
+//! `parse_statement_top_level_modifier` used to drop the modifier silently for
+//! *every* `modifier export ...` shape. tsc instead attaches the modifier to
+//! whichever node the `export` begins and lets `checkGrammarModifiers` answer
+//! by that node's own kind, which splits three ways:
+//!
+//! - `export as namespace Foo;` is a `NamespaceExportDeclaration`, which admits
+//!   no modifiers in any container — TS1184 in a Block, in a namespace body,
+//!   and at the source file's own top level alike.
+//! - `export const` / `export class` / `export function` / ... is an ordinary
+//!   modified declaration, so it takes the container split #16368/#16375 built
+//!   for the sibling modifiers: TS1184 in a Block, TS1044 elsewhere.
+//! - `export {}` / `export * from` / `export =` / `export default` draw their
+//!   own placement diagnostic (TS1233 / TS1231 / TS1258) and no modifier
+//!   diagnostic at all, so the silent drop was right for those three.
+//!
+//! Every row below is pinned against `typescript@7.0.2`
+//! (`--noEmit --strict --lib es2022 --target es2022`).
+//!
+//! Note on the `as namespace` rows: tsc reports TS1184 *and* the placement
+//! diagnostic (TS1316 / TS1314) that the checker raises for the export itself.
+//! The second half is a checker diagnostic and so is out of this file's reach;
+//! at the CLI it is currently suppressed for the whole file by
+//! `has_syntax_parse_errors`, which #16367 removes for exactly this class of
+//! code. Verified locally: with #16367's containment applied, these sources
+//! report the full tsc pair.
+
+use crate::parser::test_fixture::parse_source;
+use tsz_common::diagnostics::diagnostic_codes;
+
+fn diagnostic_codes_at(source: &str, needle: &str) -> Vec<u32> {
+    let pos = source.find(needle).unwrap() as u32;
+    let (parser, _root) = parse_source(source);
+    parser
+        .get_diagnostics()
+        .iter()
+        .filter(|d| d.start == pos)
+        .map(|d| d.code)
+        .collect()
+}
+
+fn assert_only_diagnostic(source: &str, needle: &str, expected_code: u32) {
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+    assert_eq!(
+        diagnostic_codes_at(source, needle),
+        vec![expected_code],
+        "expected exactly TS{expected_code} anchored on {needle:?} for {source:?}, \
+         got {diagnostics:?}"
+    );
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "expected exactly one parser diagnostic for {source:?}, got {diagnostics:?}"
+    );
+}
+
+fn assert_no_parser_diagnostics(source: &str) {
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+    assert!(
+        diagnostics.is_empty(),
+        "expected no parser diagnostic for {source:?} — tsc reports only the \
+         export form's own placement diagnostic, which is a checker check; \
+         got {diagnostics:?}"
+    );
+}
+
+// --------------------------------------------------------------------------
+// `export as namespace` — TS1184 in every container.
+// --------------------------------------------------------------------------
+
+#[test]
+fn modifier_before_export_as_namespace_in_function_body_reports_ts1184() {
+    assert_only_diagnostic(
+        "function collect() {\n  public export as namespace Telemetry;\n}",
+        "public",
+        diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE,
+    );
+}
+
+/// The container that distinguishes this rule from the sibling-modifier one:
+/// a modified *declaration* here would be TS1044, not TS1184.
+#[test]
+fn modifier_before_export_as_namespace_at_top_level_reports_ts1184_not_ts1044() {
+    assert_only_diagnostic(
+        "public export as namespace Telemetry;",
+        "public",
+        diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE,
+    );
+}
+
+/// The other non-Block container, for the same reason.
+#[test]
+fn modifier_before_export_as_namespace_in_namespace_body_reports_ts1184_not_ts1044() {
+    assert_only_diagnostic(
+        "namespace Outer {\n  public export as namespace Telemetry;\n}",
+        "public",
+        diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE,
+    );
+}
+
+#[test]
+fn modifier_before_export_as_namespace_in_nested_block_reports_ts1184() {
+    assert_only_diagnostic(
+        "function collect() {\n  { public export as namespace Telemetry; }\n}",
+        "public",
+        diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE,
+    );
+}
+
+#[test]
+fn modifier_before_export_as_namespace_in_class_static_block_reports_ts1184() {
+    assert_only_diagnostic(
+        "class Registry { static { public export as namespace Telemetry; } }",
+        "public",
+        diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE,
+    );
+}
+
+/// The answer is keyed on the node the `export` begins, never on which modifier
+/// was written, so the whole modifier set lands on TS1184 here — including the
+/// ones whose own misplacement message (TS1044 for `public`) would differ in the
+/// sibling-declaration case.
+///
+/// `abstract` is deliberately absent: it never reaches this dispatch at all.
+/// `look_ahead_is_abstract_before_var_or_function` matches only
+/// `var`/`let`/`const`/`function`, so `abstract export as namespace Foo;` falls
+/// through to the expression-statement path and reports nothing, where tsc
+/// reports the same TS1184 as its siblings. That is the `abstract`-has-its-own
+/// dispatcher family (#16380) rather than this one, and it is filed separately.
+/// `declare` is absent for the same reason, via `parse_statement_declare_keyword`.
+///
+/// `public` and `static` are the two rows pinned directly against
+/// `typescript@7.0.2`; `private`/`protected` share their dispatch exactly.
+#[test]
+fn every_modifier_before_export_as_namespace_reports_ts1184() {
+    for modifier in ["public", "private", "protected", "static"] {
+        let source =
+            format!("function collect() {{\n  {modifier} export as namespace Telemetry;\n}}");
+        assert_eq!(
+            diagnostic_codes_at(&source, modifier),
+            vec![diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE],
+            "modifier {modifier:?} must not change the answer — it is the \
+             NamespaceExportDeclaration node kind that admits no modifiers"
+        );
+    }
+}
+
+/// Renamed binder, to pin that nothing keys on the namespace's name.
+#[test]
+fn export_as_namespace_diagnostic_does_not_depend_on_the_namespace_name() {
+    assert_only_diagnostic(
+        "function gather() {\n  static export as namespace QuiteDifferentName;\n}",
+        "static",
+        diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE,
+    );
+}
+
+// --------------------------------------------------------------------------
+// `export <declaration>` — the ordinary container split.
+// --------------------------------------------------------------------------
+
+#[test]
+fn modifier_before_export_const_at_top_level_reports_ts1044() {
+    assert_only_diagnostic(
+        "public export const seeded = 1;",
+        "public",
+        diagnostic_codes::MODIFIER_CANNOT_APPEAR_ON_A_MODULE_OR_NAMESPACE_ELEMENT,
+    );
+}
+
+#[test]
+fn modifier_before_export_const_in_namespace_body_reports_ts1044() {
+    assert_only_diagnostic(
+        "namespace Outer {\n  public export const seeded = 1;\n}",
+        "public",
+        diagnostic_codes::MODIFIER_CANNOT_APPEAR_ON_A_MODULE_OR_NAMESPACE_ELEMENT,
+    );
+}
+
+#[test]
+fn modifier_before_export_class_at_top_level_reports_ts1044() {
+    assert_only_diagnostic(
+        "public export class Widget {}",
+        "public",
+        diagnostic_codes::MODIFIER_CANNOT_APPEAR_ON_A_MODULE_OR_NAMESPACE_ELEMENT,
+    );
+}
+
+/// The message interpolates the modifier that was actually written, so the
+/// non-`public` members of the set have to be exercised too.
+#[test]
+fn modifier_before_export_function_at_top_level_reports_ts1044_naming_that_modifier() {
+    let source = "static export function build() {}";
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+    assert_eq!(diagnostics.len(), 1, "got {diagnostics:?}");
+    assert_eq!(
+        diagnostics[0].code,
+        diagnostic_codes::MODIFIER_CANNOT_APPEAR_ON_A_MODULE_OR_NAMESPACE_ELEMENT
+    );
+    assert!(
+        diagnostics[0].message.contains("'static'"),
+        "the TS1044 message names the modifier that was written; got {:?}",
+        diagnostics[0].message
+    );
+}
+
+/// In a Block the same shape is TS1184 — this half already worked and is the
+/// regression guard on the arm that now falls through to the container gate.
+#[test]
+fn modifier_before_export_const_in_function_body_still_reports_ts1184() {
+    assert_only_diagnostic(
+        "function collect() {\n  public export const seeded = 1;\n}",
+        "public",
+        diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE,
+    );
+}
+
+// --------------------------------------------------------------------------
+// `export {}` / `export *` / `export =` / `export default` — no modifier
+// diagnostic. These are the rows a container-gate-everything fix would break.
+// --------------------------------------------------------------------------
+
+#[test]
+fn modifier_before_export_list_reports_no_parser_diagnostic() {
+    assert_no_parser_diagnostics("function collect() {\n  public export {};\n}");
+}
+
+#[test]
+fn modifier_before_export_star_reports_no_parser_diagnostic() {
+    assert_no_parser_diagnostics("function collect() {\n  public export * from \"./source\";\n}");
+}
+
+#[test]
+fn modifier_before_export_assignment_reports_no_parser_diagnostic() {
+    assert_no_parser_diagnostics("function collect() {\n  public export = 1;\n}");
+}
+
+#[test]
+fn modifier_before_export_default_reports_no_parser_diagnostic() {
+    assert_no_parser_diagnostics("function collect() {\n  public export default 1;\n}");
+}
+
+// --------------------------------------------------------------------------
+// Negative controls.
+// --------------------------------------------------------------------------
+
+/// A line break between the modifier and `export` is an expression statement
+/// followed by an export statement, not a modified export — ASI, unchanged.
+#[test]
+fn modifier_on_its_own_line_before_export_is_not_a_modified_export() {
+    let source = "public\nexport as namespace Telemetry;";
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.code == diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE),
+        "a line break makes `public` its own expression statement, so no \
+         modifier diagnostic belongs here; got {diagnostics:?}"
+    );
+}
+
+/// A well-formed `export as namespace` with no modifier keeps parsing clean —
+/// the placement question is the checker's, not the parser's.
+#[test]
+fn plain_export_as_namespace_reports_no_parser_diagnostic() {
+    assert_no_parser_diagnostics("export as namespace Telemetry;");
+    assert_no_parser_diagnostics("function collect() {\n  export as namespace Telemetry;\n}");
+}


### PR DESCRIPTION
Fixes the gap ClaudeDE noted-but-did-not-file in #16381's body (`state_statements_keywords.rs`, the `look_ahead_next_token_is_export_keyword` branch). The gap turned out to be wider than the note: it is not only `export as namespace`, and the fix is not the container gate.

## Structural rule

`parse_statement_top_level_modifier` dropped the modifier **silently for every** `modifier export ...` shape, on the comment's premise that "TSC silently accepts the modifier". tsc does no such thing in general — it attaches the modifier to whichever node the `export` begins and lets `checkGrammarModifiers` answer by **that node's own kind**, which splits three ways:

| The `export` begins | tsc | owner |
|---|---|---|
| `export as namespace Foo;` — a `NamespaceExportDeclaration`, admits no modifiers at all | **TS1184 in every container** | new `ModifiedExportForm::NamespaceExport` arm |
| `export const` / `export class` / `export function` / ... — an ordinary modified declaration | the container split: **TS1184** in a Block, **TS1044** in a namespace body or at the source file's top level | falls through to the existing container gate (#16368/#16375) |
| `export {}` / `export * from` / `export =` / `export default` | only the form's own placement diagnostic (TS1233 / TS1231 / TS1258), **no** modifier diagnostic | unchanged silent drop |

The first row is the one that matters most, because it is the **opposite** of the container split the sibling modifiers just got: `public export as namespace Foo;` is TS1184 at the top level, where `public export const z = 1;` is TS1044. Anyone fixing this by routing the whole branch into the container gate would regress the third row's four shapes to get the first row's.

Owner layer is the parser: this is grammar-diagnostic selection at the modifier dispatch, and the classification is a token-kind lookahead, not a type question. New `ModifiedExportForm` enum + `modified_export_form()` replaces the single-use `look_ahead_next_token_is_export_keyword`.

## Adjacent-case matrix

17 rows, all pinned against `typescript@7.0.2` (`--noEmit --strict --lib es2022 --target es2022`); `tsz` columns measured on the compiled CLI at parent `59ec721` and at this head.

| # | Source | tsc | tsz before | tsz after |
|---|---|---|---|---|
| a | `public export as namespace F;` in a function body | TS1184 + TS1316 | TS1316 | **TS1184** |
| c | `public export as namespace F;` at top level | TS1184 + TS1314 | TS1314 | **TS1184** |
| e | `public export as namespace F;` in a namespace body | TS1184 + TS1316 | TS1316 | **TS1184** |
| j | `static export as namespace F;` in a function body | TS1184 + TS1316 | TS1316 | **TS1184** |
| p | same, in a class static block | TS1184 + TS1316 | TS1316 | **TS1184** |
| q | same, in a nested block | TS1184 + TS1316 | TS1316 | **TS1184** |
| d | `public export const z = 1;` at top level | TS1044 | *(nothing)* | **TS1044** ✅ exact |
| f | `public export const z = 1;` in a namespace body | TS1044 | *(nothing)* | **TS1044** ✅ exact |
| m | `public export class D {}` at top level | TS1044 | *(nothing)* | **TS1044** ✅ exact |
| b | `public export const z = 1;` in a function body | TS1184 | TS1184 | TS1184 (unchanged) |
| l | `public export class D {}` in a function body | TS1184 | TS1184 | TS1184 (unchanged) |
| o | `public export function g() {}` in a function body | TS1184 | TS1184 | TS1184 (unchanged) |
| g | `public export default 1;` in a function body | TS1258 | TS1258 | TS1258 (unchanged) |
| h | `public export {};` in a function body | TS1233 | TS1233 | TS1233 (unchanged) |
| i | `public export = 1;` in a function body | TS1231 | TS1231 | TS1231 (unchanged) |
| n | `public export * from "./x";` in a function body | TS1233 | TS1233 | TS1233 (unchanged) |
| k | `declare export as namespace F;` at top level | TS1184 + TS1314 | TS1314 | TS1314 (unchanged — see gaps) |

**3 rows go from nothing to exactly tsc. 6 rows gain the TS1184 they were missing. 0 rows move away from tsc. 8 negative/control rows are byte-identical.**

### The 6 `as namespace` rows and their second diagnostic

Those rows read as a swap (TS1316 → TS1184) rather than a gain, and that is worth being precise about: the missing half is **not** this PR's. TS1316/TS1314 is a *checker* diagnostic, and it is being deleted file-wide by `has_syntax_parse_errors` the moment any parser grammar code fires. That is exactly the bug #16279 describes and **#16367 (open) fixes**, by making every `is_parser_grammar_code` — which already includes 1184 — non-suppressing.

Verified rather than assumed. I applied #16367's one-line containment locally as a throwaway probe (reverted; not in this diff) and re-ran the six rows:

```
a  TS1184 TS1316     c  TS1184 TS1314     e  TS1184 TS1316
j  TS1184 TS1316     p  TS1184 TS1316     q  TS1184 TS1316
```

All six become **exactly tsc**. This PR is the missing half of that pair and #16367 is the other; neither regresses the other, and the two together close the family.

### Disclosed gaps, not fixed here

- `abstract export as namespace F;` and `declare export as namespace F;` (row k) still report no TS1184. Neither reaches this dispatch: `look_ahead_is_abstract_before_var_or_function` matches only `var`/`let`/`const`/`function`, and `declare` has `parse_statement_declare_keyword`. That is the same "`abstract`/`declare` have their own dispatcher and never got the sibling-modifier treatment" family as #16380, not this one. Called out in the test module's docs so it is not mistaken for coverage.

## Verification

- `cargo test -p tsz-parser --lib` — **1798 passed, 0 failed** (parent: 1780; +18 from the new file).
- `cargo fmt --all` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean (3m40s, full workspace); pre-commit hook (clippy + architecture guard) passed.
- New test file `crates/tsz-parser/tests/parser_modified_export_statement_tests.rs` (18 tests, wired into `crates/tsz-parser/src/parser/mod.rs`): all five containers for the `as namespace` arm, the modifier set for it, the container split for the declaration arm including the TS1044 message naming the written modifier, all four no-diagnostic export forms, plus two negative controls (ASI line break between modifier and `export`; a well-formed unmodified `export as namespace`).
- Anti-hardcoding: the classification is a `SyntaxKind` match on the token after `export`. No identifier, alias, namespace-name or file-name string participates — one test renames the namespace binder specifically to pin that, and the modifier-set test pins that the answer does not key on which modifier was written.
- **`scripts/conformance/compare-to-parent.sh` is OWED and not run.** Disclosed rather than skipped quietly: this container started cold with no `.target` and no `TypeScript/tests/cases`, and the two-sided run needs a corpus fetch plus two `dist-fast` builds (~20-25 min on a warm seat, more here). Expectation is a small positive movement or zero: three shapes gain a diagnostic they were missing entirely and six gain TS1184, all on sources that are already errors; no shape loses a diagnostic tsc reports. Per the board's standing gotcha, if a row appears under `still failing, fingerprint changed`, diff that fixture against the oracle rather than reading a 0/0 as clean.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Serpentine

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5xjqzkdq2KE52XeWGDWoQ)_