### PR TITLE
fix(checker): yield* of an async iterable with an invalid-thenable element reports TS1322

### DIFF
--- a/crates/tsz-checker/src/checkers/promise_checker.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker.rs
@@ -568,6 +568,21 @@ impl<'a> CheckerState<'a> {
         self.invalid_thenable_info(type_id, 0).is_some()
     }
 
+    /// Whether a `yield*` delegate's iterated *element* type (TS1322) is an
+    /// invalid thenable. Same leaf rule as
+    /// [`Self::await_operand_is_invalid_thenable`] per member, but a union
+    /// combines members with ALL- rather than ANY-invalid semantics: oracle
+    /// (`typescript@7.0.2`) shows `AsyncIterable<Good | Bad>` clean and only
+    /// `AsyncIterable<Bad1 | Bad2>` reporting.
+    pub(crate) fn async_iterated_element_is_invalid_thenable(&mut self, type_id: TypeId) -> bool {
+        match query::promise_union_members(self.ctx.types, type_id) {
+            Some(members) => members
+                .into_iter()
+                .all(|member| self.await_operand_is_invalid_thenable(member)),
+            None => self.await_operand_is_invalid_thenable(type_id),
+        }
+    }
+
     fn invalid_thenable_info(&mut self, type_id: TypeId, depth: u8) -> Option<ThenableAwaitInfo> {
         if depth > MAX_THENABLE_THIS_VALIDATION_DEPTH {
             return None;

--- a/crates/tsz-checker/src/dispatch/yield_.rs
+++ b/crates/tsz-checker/src/dispatch/yield_.rs
@@ -452,6 +452,41 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                         },
                         |i| i.yield_type,
                     );
+                    // TS1322 checks the delegated iterable's *element* type —
+                    // distinct from TS1320 above, which checks the iterator's
+                    // `next()` result. tsc reaches both through
+                    // `getAwaitedTypeNoAliasEx`/`isThenableType` on different
+                    // operands, so a delegate can fail either independently
+                    // (a well-formed `IteratorResult` wrapping an invalid
+                    // thenable element, or vice versa).
+                    //
+                    // Deliberately re-resolved through the checker's env-aware
+                    // `for_of_element_type` rather than reusing `element`
+                    // above: `element`'s solver-only fallback hits the same
+                    // `TypeData::Lazy(DefId)` blind spot documented on
+                    // `async_info` (every non-array/tuple lib iterable,
+                    // including plain `AsyncIterable<T>`/`AsyncGenerator<T>`,
+                    // resolves to `ANY` structurally), which silently
+                    // swallowed this check on the exact lib shapes the issue
+                    // is about. That blind spot is `element`'s consumer's
+                    // problem (the annotated-container TS2322 contextual
+                    // check a few lines below, which has its own generic-delegate
+                    // reason to stay solver-only) — TS1322 has no such
+                    // constraint, so it can use the more accurate chain.
+                    let invalid_thenable_element = async_info.as_ref().map_or_else(
+                        || self.checker.for_of_element_type(expression_type, true),
+                        |i| i.yield_type,
+                    );
+                    if self
+                        .checker
+                        .async_iterated_element_is_invalid_thenable(invalid_thenable_element)
+                    {
+                        self.checker.error_at_node(
+                            yield_expr.expression,
+                            diagnostic_messages::TYPE_OF_ITERATED_ELEMENTS_OF_A_YIELD_OPERAND_MUST_EITHER_BE_A_VALID_PROMISE_OR_M,
+                            diagnostic_codes::TYPE_OF_ITERATED_ELEMENTS_OF_A_YIELD_OPERAND_MUST_EITHER_BE_A_VALID_PROMISE_OR_M,
+                        );
+                    }
                     // Capture the delegated iterator's return type for yield* expression result.
                     // Try get_iterator_info first (structural), then fall back to
                     // get_generator_return_type_argument (direct Application arg extraction)

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -932,5 +932,7 @@ mod variadic_tuple_spread_element_inference_tests;
 mod void_undefined_discriminant_narrowing_tests;
 #[path = "tests/window_self_globalthis_resolution_tests.rs"]
 mod window_self_globalthis_resolution_tests;
+#[path = "tests/yieldstar_async_iterable_invalid_thenable_element_tests.rs"]
+mod yieldstar_async_iterable_invalid_thenable_element_tests;
 #[path = "tests/zod_type_query_regression_tests.rs"]
 mod zod_type_query_regression_tests;

--- a/crates/tsz-checker/src/tests/yieldstar_async_iterable_invalid_thenable_element_tests.rs
+++ b/crates/tsz-checker/src/tests/yieldstar_async_iterable_invalid_thenable_element_tests.rs
@@ -1,0 +1,298 @@
+//! Regression tests for #16378: `yield*` of an async iterable whose *element*
+//! type is an invalid thenable never reported TS1322.
+//!
+//! Structural rule: when an `async function*` delegates with `yield*` to an
+//! async iterable, `tsc` validates each iterated *element* the same way it
+//! validates an `await` operand — thenable (`isThenableType`) but no
+//! promised type recoverable (`getPromisedTypeOfPromiseEx`) — reporting its
+//! own code, TS1322, distinct from TS1320 (the delegate's `next()` result)
+//! and TS1321/TS1058 (plain `yield`/annotated return, #16374). tsz reuses
+//! `CheckerState::await_operand_is_invalid_thenable`'s leaf rule through the
+//! new `async_iterated_element_is_invalid_thenable` in
+//! `checkers/promise_checker.rs`, wired into the `yield_expr.asterisk_token`
+//! async-generator arm of `dispatch/yield_::check_yield_expression`.
+//!
+//! Two things the sibling codes' predicate could not be reused for verbatim,
+//! both oracle-verified against `typescript@7.0.2`:
+//!
+//! 1. **Element resolution must go through the checker's env-aware
+//!    `for_of_element_type`, not the solver-only fallback.** `get_iterator_info`
+//!    cannot evaluate through the `TypeData::Lazy(DefId)` alias body every
+//!    non-array/tuple lib iterable (`AsyncIterable<T>`, `AsyncGenerator<T>`)
+//!    exposes its iterator member behind, so the solver-only fallback
+//!    silently resolved the element to `ANY` and the check never fired on
+//!    any lib-typed delegate — including the issue's own witness.
+//! 2. **A union's constituents combine with opposite semantics from `await`.**
+//!    `await_operand_is_invalid_thenable` reports as soon as *any* union
+//!    member is an invalid thenable (correct for `await`, oracle-confirmed by
+//!    #16374). At this position `tsc` instead reports only when *every*
+//!    member is invalid — `AsyncIterable<Good | Bad>` is clean,
+//!    `AsyncIterable<Bad1 | Bad2>` reports. Naively reusing the `await`
+//!    predicate here is a false positive on the one-bad-branch shape.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_source_with_libs, load_default_lib_files};
+
+fn strict_codes(source: &str) -> Vec<u32> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|diagnostic| diagnostic.code)
+    .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Positives: an invalid-thenable element reachable through the iterated
+// element type.
+// ---------------------------------------------------------------------------
+
+/// The issue's own witness: a callable but non-callback `then` on a lib
+/// `AsyncIterable<T>` element.
+#[test]
+fn yieldstar_lib_async_iterable_invalid_thenable_element_reports_ts1322() {
+    let codes = strict_codes(
+        r#"
+export {};
+interface BadT { then(cb: string): void }
+declare const src: AsyncIterable<BadT>;
+async function* ag1() { yield* src; }
+"#,
+    );
+    assert!(
+        codes.contains(&1322),
+        "a lib AsyncIterable element with a non-callback `then` must report TS1322: {codes:?}"
+    );
+}
+
+#[test]
+fn yieldstar_optional_then_element_reports_ts1322() {
+    let codes = strict_codes(
+        r#"
+export {};
+interface BadT { then?: (cb: (v: number) => void) => void }
+declare const src: AsyncIterable<BadT>;
+async function* ag() { yield* src; }
+"#,
+    );
+    assert!(
+        codes.contains(&1322),
+        "an optional `then` is thenable but has no raw call signature: {codes:?}"
+    );
+}
+
+#[test]
+fn yieldstar_then_with_no_parameters_element_reports_ts1322() {
+    let codes = strict_codes(
+        r#"
+export {};
+interface BadT { then(): void }
+declare const src: AsyncIterable<BadT>;
+async function* ag() { yield* src; }
+"#,
+    );
+    assert!(codes.contains(&1322), "{codes:?}");
+}
+
+#[test]
+fn yieldstar_then_with_non_callable_parameter_element_reports_ts1322() {
+    let codes = strict_codes(
+        r#"
+export {};
+interface BadT { then(cb: any): void }
+declare const src: AsyncIterable<BadT>;
+async function* ag() { yield* src; }
+"#,
+    );
+    assert!(codes.contains(&1322), "{codes:?}");
+}
+
+/// The `this`-rejected sub-case: TS1322 here, not TS1320 — same predicate as
+/// #16374, different code because of the operand position.
+#[test]
+fn yieldstar_this_rejected_element_reports_ts1322() {
+    let codes = strict_codes(
+        r#"
+export {};
+interface BadThenable<T> {
+    then(this: { required: string }, onfulfilled?: ((value: T) => void) | null): void;
+}
+declare const src: AsyncIterable<BadThenable<string>>;
+async function* ag() { yield* src; }
+"#,
+    );
+    assert!(codes.contains(&1322), "{codes:?}");
+}
+
+/// User-defined async iterable (`[Symbol.asyncIterator]`/`next()`), not the
+/// lib `AsyncIterable<T>` alias — exercises the `async_info.is_some()`
+/// (structural) branch of element resolution rather than the
+/// `for_of_element_type` fallback.
+#[test]
+fn yieldstar_user_defined_async_iterator_invalid_thenable_element_reports_ts1322() {
+    let codes = strict_codes(
+        r#"
+export {};
+interface BadT { then(cb: string): void }
+interface UserAsyncIterator {
+    [Symbol.asyncIterator](): UserAsyncIterator;
+    next(): Promise<{ value: BadT; done: boolean }>;
+}
+declare const src: UserAsyncIterator;
+async function* ag() { yield* src; }
+"#,
+    );
+    assert!(codes.contains(&1322), "{codes:?}");
+}
+
+/// A delegated `async function*` (not a bare iterable binding) reaches the
+/// same element-resolution path.
+#[test]
+fn yieldstar_delegated_async_generator_invalid_thenable_element_reports_ts1322() {
+    let codes = strict_codes(
+        r#"
+export {};
+interface BadT { then(cb: string): void }
+declare function inner(): AsyncGenerator<BadT>;
+async function* outer() { yield* inner(); }
+"#,
+    );
+    assert!(codes.contains(&1322), "{codes:?}");
+}
+
+/// Every union member invalid: the whole union stays invalid.
+#[test]
+fn yieldstar_union_element_all_branches_invalid_reports_ts1322() {
+    let codes = strict_codes(
+        r#"
+export {};
+interface BadA { then(cb: string): void }
+interface BadB { then(cb: number): void }
+declare const src: AsyncIterable<BadA | BadB>;
+async function* ag() { yield* src; }
+"#,
+    );
+    assert!(
+        codes.contains(&1322),
+        "a union whose every member is an invalid thenable must still report: {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negatives: shapes `tsc` accepts, which the check must not claim.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn yieldstar_valid_thenable_element_reports_nothing() {
+    let codes = strict_codes(
+        r#"
+export {};
+interface GoodT { then(cb: (v: number) => void): void }
+declare const src: AsyncIterable<GoodT>;
+async function* ag() { yield* src; }
+"#,
+    );
+    assert!(!codes.contains(&1322), "{codes:?}");
+}
+
+/// Load-bearing negative: a union with *one* valid branch is clean even
+/// though the sibling branch alone would report — the opposite of `await`'s
+/// union semantics (`await_union_with_one_invalid_thenable_branch_reports_ts1320`
+/// in `invalid_thenable_no_fulfillment_payload_tests.rs`). Proves the fix
+/// does not simply reuse the `await` predicate's union combination.
+#[test]
+fn yieldstar_union_element_one_invalid_branch_reports_nothing() {
+    let codes = strict_codes(
+        r#"
+export {};
+interface GoodT { then(cb: (v: number) => void): void }
+interface BadT { then(cb: string): void }
+declare const src: AsyncIterable<GoodT | BadT>;
+async function* ag() { yield* src; }
+"#,
+    );
+    assert!(
+        !codes.contains(&1322),
+        "one valid union member absorbs an invalid sibling at this position: {codes:?}"
+    );
+}
+
+#[test]
+fn yieldstar_promise_element_reports_nothing() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const src: AsyncIterable<Promise<number>>;
+async function* ag() { yield* src; }
+"#,
+    );
+    assert!(!codes.contains(&1322), "{codes:?}");
+}
+
+#[test]
+fn yieldstar_plain_non_thenable_element_reports_nothing() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const src: AsyncIterable<number>;
+async function* ag() { yield* src; }
+"#,
+    );
+    assert!(!codes.contains(&1322), "{codes:?}");
+}
+
+/// A primitive never adopts a `then` member, however the intersection's
+/// property lookup resolves it.
+#[test]
+fn yieldstar_primitive_intersection_element_reports_nothing() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const src: AsyncIterable<string & { then(cb: string): void }>;
+async function* ag() { yield* src; }
+"#,
+    );
+    assert!(!codes.contains(&1322), "{codes:?}");
+}
+
+/// A *synchronous* `yield*` never awaits its elements, so no invalid-thenable
+/// check applies at all — control that keeps the fix scoped to
+/// `is_async_generator`.
+#[test]
+fn sync_yieldstar_invalid_thenable_element_reports_nothing() {
+    let codes = strict_codes(
+        r#"
+export {};
+interface BadT { then(cb: string): void }
+declare const src: Iterable<BadT>;
+function* g() { yield* src; }
+"#,
+    );
+    assert!(
+        !codes.contains(&1322),
+        "a synchronous generator never awaits its yield* elements: {codes:?}"
+    );
+}
+
+/// Renamed-binder control: the same shape behind differently-named
+/// interfaces and generator still reports, proving the rule is structural.
+#[test]
+fn yieldstar_invalid_thenable_element_through_renamed_interfaces_reports_ts1322() {
+    let codes = strict_codes(
+        r#"
+export {};
+interface WidgetElement { then(callbackParam: string): void }
+type WidgetAlias = WidgetElement;
+declare const widgetSource: AsyncIterable<WidgetAlias>;
+async function* produceWidgets() { yield* widgetSource; }
+"#,
+    );
+    assert!(codes.contains(&1322), "{codes:?}");
+}


### PR DESCRIPTION
When an `async function*` delegates with `yield*` to an async iterable, `tsc` validates each iterated **element** the same way it validates an `await` operand — thenable (`isThenableType`) but no promised type recoverable (`getPromisedTypeOfPromiseEx`) — and reports TS1322. tsz reported nothing. Closes #16378.

Structural rule: when a `yield*` delegate's resolved iterated-element type is thenable but not a valid promise, `tsc` reports TS1322 through `checkAsyncIteratedTypeOrElementType`; tsz now does this through `CheckerState::async_iterated_element_is_invalid_thenable` (new, `checkers/promise_checker.rs`), wired into the async-generator `yield*` arm of `dispatch/yield_::check_yield_expression`.

Two divergences from the sibling TS1320/1321/1058 predicate (#16374), both oracle-verified against `typescript@7.0.2`:

- **Element resolution** must go through the checker's env-aware `for_of_element_type`, not the solver-only `get_iterator_info` fallback. `get_iterator_info` cannot evaluate through the `TypeData::Lazy(DefId)` alias body every non-array/tuple lib iterable (`AsyncIterable<T>`, `AsyncGenerator<T>`) exposes its iterator member behind, so the solver-only path resolved to `ANY` and silently swallowed the check on exactly the lib shapes the issue's own witness uses.
- **A union's constituents combine with ALL-invalid semantics here, not `await`'s ANY-invalid.** `AsyncIterable<Good | Bad>` is clean; only `AsyncIterable<Bad1 | Bad2>` (every constituent invalid) reports. Implemented by composing the existing per-member `await_operand_is_invalid_thenable` rather than threading a new parameter through its shared recursion (keeps `promise_checker.rs` under the 2000-line arch guard).

Adjacent-case matrix (15 tests, `yieldstar_async_iterable_invalid_thenable_element_tests.rs`), every row oracle-verified individually against `typescript@7.0.2`:
- positives: lib `AsyncIterable<T>` element, optional `then?:`, parameterless `then`, non-callable `onfulfilled`, `this`-rejected `then`, user-defined `[Symbol.asyncIterator]` iterator (structural path, not the lib-alias fallback), delegated `async function*`, union with every member invalid, renamed binders
- negatives: valid thenable, union with one valid member (the load-bearing case that disproves naive predicate reuse), `Promise<T>` element, plain non-thenable element, primitive+intersection, and a **synchronous** `yield*` (no `await` semantics, so no diagnostic at all)

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-checker --lib -E 'test(invalid_thenable) or test(generator_yield_invalid_thenable) or test(async_return_invalid_thenable) or test(yieldstar) or test(async_generator_yieldstar)'` — 91/91 pass
- `cargo clippy -p tsz-checker --lib -- -D warnings` — clean
- `scripts/architecture-check.sh` — 0 LOC violations (`promise_checker.rs` at 1987/2000)
- `cargo fmt --check -p tsz-checker` — clean
- `scripts/conformance/compare-to-parent.sh origin/main` (head `85b082a`, base `3ad8955`) — both sides 12043 runnable / 11481 passed / 561 failing, **0 newly passing, 0 newly failing, 0 fingerprint-changed**. Zero-movement is the expected signature: TS1322 was previously entirely unwired and the corpus has no witness for this exact shape.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE