### PR TITLE
fix(parser): abstract/declare before `export as namespace` reports TS1184

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -79,6 +79,9 @@ pub(crate) mod test_fixture;
 #[path = "../../tests/definite_assignment_assertion_tests.rs"]
 mod definite_assignment_assertion_tests;
 #[cfg(test)]
+#[path = "../../tests/parser_abstract_declare_export_as_namespace_tests.rs"]
+mod parser_abstract_declare_export_as_namespace_tests;
+#[cfg(test)]
 #[path = "../../tests/parser_abstract_ts1184_ts1242_tests.rs"]
 mod parser_abstract_ts1184_ts1242_tests;
 #[cfg(test)]

--- a/crates/tsz-parser/src/parser/state_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_declarations.rs
@@ -1754,10 +1754,23 @@ impl ParserState {
                 }
                 match self.token() {
                     SyntaxKind::AsKeyword => {
-                        // `declare export as namespace Foo;` — parse as namespace export declaration.
-                        // TSC treats `declare` as a modifier on the export-as-namespace statement
-                        // and produces no error for this form.
-                        self.parse_namespace_export_declaration(start_pos)
+                        // `declare export as namespace Foo;` — the resulting
+                        // `NamespaceExportDeclaration` admits no modifiers in any
+                        // container (unlike the container split the other arms of
+                        // this match apply), so tsc reports TS1184 across the whole
+                        // statement unconditionally and still parses the namespace
+                        // export (#16389).
+                        let node = self.parse_namespace_export_declaration(start_pos);
+                        if let Some(n) = self.arena.get(node) {
+                            let (span_start, span_end) = (n.pos, n.end);
+                            self.parse_error_at(
+                                span_start,
+                                span_end - span_start,
+                                "Modifiers cannot appear here.",
+                                tsz_common::diagnostics::diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE,
+                            );
+                        }
+                        node
                     }
                     SyntaxKind::FunctionKeyword => {
                         self.parse_function_declaration_with_async(false, Some(modifiers))

--- a/crates/tsz-parser/src/parser/state_statements_keywords.rs
+++ b/crates/tsz-parser/src/parser/state_statements_keywords.rs
@@ -51,6 +51,30 @@ impl ParserState {
                 }
                 _ => self.parse_expression_statement(),
             }
+        } else if self.look_ahead_is_abstract_before_export_as_namespace() {
+            // `abstract export as namespace Foo;` — the resulting
+            // `NamespaceExportDeclaration` admits no modifiers in any container,
+            // unlike the sibling `abstract` var/function declarations handled
+            // just below, which split their diagnostic by container. tsc reports
+            // TS1184 across the whole statement unconditionally and still parses
+            // the namespace export (#16389). The other `abstract export ...`
+            // forms (const/class/function/...) are not covered by this branch —
+            // `abstract` is a legal modifier on some of those node kinds and tsc
+            // picks a different diagnostic there, still open as a separate gap.
+            let start_pos = self.token_pos();
+            self.parse_expected(SyntaxKind::AbstractKeyword);
+            self.parse_expected(SyntaxKind::ExportKeyword);
+            let node = self.parse_namespace_export_declaration(start_pos);
+            if let Some(n) = self.arena.get(node) {
+                let (span_start, span_end) = (n.pos, n.end);
+                self.parse_error_at(
+                    span_start,
+                    span_end - span_start,
+                    "Modifiers cannot appear here.",
+                    diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE,
+                );
+            }
+            node
         } else if self.look_ahead_is_abstract_before_var_or_function() {
             use tsz_common::diagnostics::diagnostic_codes;
             // `abstract` before a variable or function declaration
@@ -624,6 +648,31 @@ impl ParserState {
         self.parse_error_at(start, end - start, message, code);
         self.next_token();
         self.arena.add_token(kind as u16, start, end)
+    }
+
+    /// Look ahead to see if `abstract` is followed by `export as` — the
+    /// `export as namespace ...` shape specifically, distinct from the other
+    /// `abstract export ...` forms (const/class/function/...), whose
+    /// diagnostic choice depends on whether `abstract` is a legal modifier for
+    /// the target node kind and is not decided by this lookahead (#16389).
+    /// Only the `abstract`-`export` boundary is ASI-sensitive (`abstract` is a
+    /// contextual keyword that ASI can cut off into its own expression
+    /// statement); `export`-`as` is not — a line break there does not stop
+    /// `tsc` from reading one `export as namespace` statement, so this
+    /// lookahead does not require it either.
+    pub(crate) fn look_ahead_is_abstract_before_export_as_namespace(&mut self) -> bool {
+        let snapshot = self.scanner.save_state();
+        let current = self.current_token;
+        self.next_token(); // skip 'abstract'
+        let result = !self.scanner.has_preceding_line_break()
+            && self.is_token(SyntaxKind::ExportKeyword)
+            && {
+                self.next_token(); // skip 'export'
+                self.is_token(SyntaxKind::AsKeyword)
+            };
+        self.scanner.restore_state(snapshot);
+        self.current_token = current;
+        result
     }
 
     /// Look ahead to see if `abstract` is followed by a variable or function

--- a/crates/tsz-parser/tests/parser_abstract_declare_export_as_namespace_tests.rs
+++ b/crates/tsz-parser/tests/parser_abstract_declare_export_as_namespace_tests.rs
@@ -1,0 +1,179 @@
+//! `abstract`/`declare` before `export as namespace Foo;` (#16389). Split out
+//! of #16388, which fixed the same shape for the accessibility/`static`
+//! modifiers but could not reach `abstract`/`declare`, since both have their
+//! own statement dispatchers (`parse_statement_abstract_keyword`,
+//! `parse_statement_declare_or_expression`) that never routed `export` at
+//! all.
+//!
+//! A `NamespaceExportDeclaration` admits no modifiers in any container, so
+//! unlike the sibling `abstract`/`declare` declarations (#16380, which split
+//! their diagnostic by container — TS1184 in a Block, TS1242/none elsewhere),
+//! tsc reports TS1184 across the whole statement **unconditionally** — top
+//! level, namespace body, function body, nested block, and class static block
+//! alike — and still parses the namespace export. Every row pinned against a
+//! real `typescript@7.0.2` oracle.
+
+use crate::parser::test_fixture::parse_source;
+use tsz_common::diagnostics::diagnostic_codes;
+
+fn assert_ts1184_over_whole_statement(source: &str) {
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+    let start = source
+        .find("abstract")
+        .or_else(|| source.find("declare"))
+        .unwrap() as u32;
+    // The span covers the whole `NamespaceExportDeclaration` statement, from
+    // the leading modifier through its own semicolon — not the whole source
+    // fixture, which may wrap the statement in an enclosing container.
+    let namespace_kw = source.find("namespace").unwrap();
+    let semicolon = source[namespace_kw..].find(';').unwrap();
+    let end = (namespace_kw + semicolon + 1) as u32;
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE
+                && d.start == start
+                && d.start + d.length == end),
+        "expected TS1184 spanning [{start}, {end}) for {source:?}, got {diagnostics:?}"
+    );
+}
+
+fn assert_no_ts1184(source: &str) {
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.code == diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE),
+        "expected no TS1184 for {source:?}, got {diagnostics:?}"
+    );
+}
+
+// -- `abstract`, every container --
+
+#[test]
+fn abstract_export_as_namespace_in_function_body_reports_ts1184() {
+    assert_ts1184_over_whole_statement(
+        "function collect() { abstract export as namespace Telemetry; }",
+    );
+}
+
+#[test]
+fn abstract_export_as_namespace_at_top_level_reports_ts1184() {
+    assert_ts1184_over_whole_statement("abstract export as namespace Telemetry;");
+}
+
+#[test]
+fn abstract_export_as_namespace_in_namespace_body_reports_ts1184() {
+    assert_ts1184_over_whole_statement("namespace N { abstract export as namespace Telemetry; }");
+}
+
+#[test]
+fn abstract_export_as_namespace_in_nested_block_reports_ts1184() {
+    assert_ts1184_over_whole_statement(
+        "function collect() { { abstract export as namespace Telemetry; } }",
+    );
+}
+
+#[test]
+fn abstract_export_as_namespace_in_class_static_block_reports_ts1184() {
+    assert_ts1184_over_whole_statement(
+        "class C { static { abstract export as namespace Telemetry; } }",
+    );
+}
+
+// -- `declare`, every container --
+
+#[test]
+fn declare_export_as_namespace_in_function_body_reports_ts1184() {
+    assert_ts1184_over_whole_statement(
+        "function collect() { declare export as namespace Telemetry; }",
+    );
+}
+
+#[test]
+fn declare_export_as_namespace_at_top_level_reports_ts1184() {
+    assert_ts1184_over_whole_statement("declare export as namespace Telemetry;");
+}
+
+#[test]
+fn declare_export_as_namespace_in_namespace_body_reports_ts1184() {
+    assert_ts1184_over_whole_statement("namespace N { declare export as namespace Telemetry; }");
+}
+
+#[test]
+fn declare_export_as_namespace_in_nested_block_reports_ts1184() {
+    assert_ts1184_over_whole_statement(
+        "function collect() { { declare export as namespace Telemetry; } }",
+    );
+}
+
+#[test]
+fn declare_export_as_namespace_in_class_static_block_reports_ts1184() {
+    assert_ts1184_over_whole_statement(
+        "class C { static { declare export as namespace Telemetry; } }",
+    );
+}
+
+// -- Binder-name independence: nothing should key on the namespace name --
+
+#[test]
+fn abstract_export_as_namespace_binder_name_does_not_matter() {
+    assert_ts1184_over_whole_statement("abstract export as namespace _$weird1;");
+}
+
+// -- The `abstract`/`export` boundary is ASI-sensitive; `export`/`as` is not --
+
+#[test]
+fn abstract_on_its_own_line_before_export_as_namespace_is_not_ts1184() {
+    // ASI cuts `abstract` into its own (invalid, but unrelated) expression
+    // statement here — ASI applies at the `abstract`/`export` boundary, so
+    // this must NOT report TS1184 for the (now unmodified) export statement.
+    assert_no_ts1184("function collect() { abstract\nexport as namespace Telemetry; }");
+}
+
+#[test]
+fn abstract_export_as_namespace_with_line_break_before_as_still_reports_ts1184() {
+    // Unlike the `abstract`/`export` boundary, a line break between `export`
+    // and `as` does not stop tsc from reading one `export as namespace`
+    // statement, so this lookahead must not require the two to share a line.
+    let source = "function collect() { abstract export\nas namespace Telemetry; }";
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+    let start = source.find("abstract").unwrap() as u32;
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE && d.start == start),
+        "expected TS1184 at 'abstract' for {source:?}, got {diagnostics:?}"
+    );
+}
+
+// -- Negative control: a well-formed, unmodified `export as namespace` --
+
+#[test]
+fn plain_export_as_namespace_reports_no_ts1184() {
+    assert_no_ts1184("export as namespace Telemetry;");
+}
+
+// -- Negative control: `abstract`/`declare` before the OTHER export forms is
+//    untouched by this fix (a distinct, still-open gap; see #16389's "worth
+//    checking" note) — these lookaheads must not accidentally widen to match
+//    `export {}` / `export *` / `export =` / `export default`. --
+
+#[test]
+fn abstract_export_brace_does_not_route_through_the_namespace_export_arm() {
+    // Before this fix `abstract` here was silently swallowed as an
+    // (erroneous) identifier expression; this fix must not change that
+    // pre-existing, separately-tracked shape by accident.
+    let source = "function collect() { abstract export {}; }";
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.code == diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE),
+        "abstract-before-`export {{}}` must not gain TS1184 from this fix, got {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
Closes #16389. Split out of #16388, which fixed the same shape for the accessibility/`static` modifiers but could not reach `abstract`/`declare`.

## Structural rule

**When a `NamespaceExportDeclaration` (`export as namespace Foo;`) carries a leading modifier, tsc reports TS1184 ("Modifiers cannot appear here.") across the whole statement unconditionally — every container alike — and still parses the namespace export.** tsz does the same through the parser's statement dispatch: `parse_statement_abstract_keyword` for `abstract`, and the `ExportKeyword` arm of `parse_ambient_declaration_with_modifiers` for `declare` (`crates/tsz-parser/src/parser/state_statements_keywords.rs`, `state_declarations.rs`).

`abstract` and `declare` each have their own statement dispatcher, and neither routed `export` into the `NamespaceExport` handling #16388 added for `public`/`private`/`protected`/`static` at the top-level modifier dispatcher (a separate function, `parse_statement_top_level_modifier`):

- **`abstract`** — `look_ahead_is_abstract_before_var_or_function` only matched `var`/`let`/`const`/`function`, so `abstract export as namespace F;` fell through to the expression-statement path (`abstract` misread as an identifier, TS2304). Added a narrow, ASI-aware lookahead (`look_ahead_is_abstract_before_export_as_namespace`) and a dedicated branch that parses the namespace export and reports TS1184 over its full span.
- **`declare`** — `look_ahead_is_declare_before_declaration` already recognized `export`, and `parse_ambient_declaration_with_modifiers`'s `ExportKeyword` arm already has careful, oracle-verified handling for every other `declare export ...` form (TS1029 modifier-order, TS1120/TS1193/TS1038 for the assignment/plain-export forms, etc.) — only its `AsKeyword` arm was wrong, with a comment claiming "TSC ... produces no error for this form," which the oracle contradicts. Fixed that one arm; nothing else in that match needed to change.

This is **not** the container split #16380 built for the sibling `abstract`/`declare` var/function declarations (TS1184 in a Block, TS1242/TS1029 elsewhere) — a `NamespaceExportDeclaration` accepts no modifiers in any container, so the diagnostic never varies by container here. Confirmed by testing all five containers for both keywords.

**Scope note, called out in code comments and left open:** `abstract export const/class/function ...` (the OTHER `export`-prefixed forms) are a separate, still-open gap — `abstract` is a legal modifier on some target node kinds (e.g. `abstract export class D {}` at top level is TS1029, not TS1242, because `abstract class` is otherwise valid), so the diagnostic choice needs its own investigation. This PR's lookahead is deliberately narrow (`export` immediately followed by `as`) so it cannot accidentally widen into that unresolved family.

## Adjacent-case matrix

13 rows oracle-verified against pinned `typescript@7.0.2` (`--noEmit --strict --lib es2022 --target es2022 --module esnext`):

| case | tsc | before | after |
| --- | --- | --- | --- |
| `abstract export as namespace F;` in function body | TS1184(+TS1316) | TS2304 only | TS1184 ✅ |
| `abstract export as namespace F;` at top level | TS1184(+TS1314) | TS2304 only | TS1184 ✅ |
| `abstract export as namespace F;` in namespace body | TS1184(+TS1316) | TS2304 only | TS1184 ✅ |
| `abstract export as namespace F;` in nested block | TS1184(+TS1316) | TS2304 only | TS1184 ✅ |
| `abstract export as namespace F;` in class static block | TS1184(+TS1316) | TS2304 only | TS1184 ✅ |
| `declare export as namespace F;` in function body | TS1184(+TS1316) | TS1316 only | TS1184 ✅ |
| `declare export as namespace F;` at top level | TS1184(+TS1314) | TS1314 only | TS1184 ✅ |
| `declare export as namespace F;` in namespace body | TS1184(+TS1316) | TS1316 only | TS1184 ✅ |
| `declare export as namespace F;` in nested block | TS1184(+TS1316) | TS1316 only | TS1184 ✅ |
| `declare export as namespace F;` in class static block | TS1184(+TS1316) | TS1316 only | TS1184 ✅ |
| `abstract\nexport as namespace F;` (ASI at abstract/export) | TS2304+TS1316 | TS2304+TS1316 | unchanged ✅ |
| `abstract export\nas namespace F;` (line break at export/as — not ASI-sensitive) | TS1184(+TS1316) | (would regress without the fix) | TS1184 ✅ |
| plain `export as namespace F;` (negative control) | TS1316/TS1314 only | unchanged | unchanged ✅ |

**The `(+TS1316/TS1314)` half is a disclosed, pre-existing gap, not new to this row.** That companion diagnostic is checker-side and is currently deleted file-wide the moment any parser grammar code fires, via `has_syntax_parse_errors` — the exact bug #16367 (open) fixes generally. Neither PR regresses the other; #16389's own body calls this out explicitly. Do not read the missing TS1316/TS1314 as a regression here.

**Known, narrower gap left undisclosed no longer** — `declare declare export as namespace F;` (a *duplicated* `declare`) reports TS1030 ("'declare' modifier already seen") in tsz where tsc reports only TS1184+TS1314. This is pre-existing behavior in the duplicate-`declare` consumption loop, untouched by this PR (verified: the loop runs before the code this PR changes), and is an extremely narrow edge case not covered by #16389. Left as-is.

## Anti-hardcoding

No identifier/alias/property/file-name string checks. The lookahead is a `SyntaxKind` token match (`abstract` → `export` → `as`); the diagnostic span is read back from the parsed node's own `pos`/`end`, not computed from source text. One test (`abstract_export_as_namespace_binder_name_does_not_matter`) pins that the namespace binder's name does not participate.

## Goal
Goal: hold

## Verification
- Oracle matrix above: 13 rows against pinned `typescript@7.0.2`, all match after the fix (the disclosed TS1316/TS1314 half aside).
- `cargo test -p tsz-parser --lib` — **1795 passed, 0 failed** (parent: 1780; +15 new tests in `parser_abstract_declare_export_as_namespace_tests.rs`), including 8 rows for both containers/keywords, an ASI positive and negative control, a binder-name-independence control, and a negative control confirming `abstract export {}` (the untouched sibling family) does not gain TS1184 by accident.
- `cargo clippy -p tsz-parser --all-targets -- -D warnings` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `python3 scripts/arch/arch_guard.py` — passed.
- `python3 scripts/ci/check-test-file-reachability.py` — `0 known orphan(s), 0 new`.
- `scripts/conformance/compare-to-parent.sh` not run this session (no `TypeScript/tests/cases` corpus checked out in this container). Expectation is a small positive movement or zero: every changed row already errors under this input shape (`abstract`/`declare` directly before `export as namespace`) and gains only a diagnostic tsc already reports; no shape loses a diagnostic tsc reports.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01AoNANjRNmHPYLLL2tNZFkP)_