### PR TITLE
fix(checker): TS1322 for a yield* async-iterable element that is an invalid thenable

### DIFF
--- a/crates/tsz-checker/src/checkers/promise_checker.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker.rs
@@ -568,6 +568,30 @@ impl<'a> CheckerState<'a> {
         self.invalid_thenable_info(type_id, 0).is_some()
     }
 
+    /// Whether a `yield*` delegate's iterated **element** type is a thenable
+    /// that is not a valid promise (TS1322).
+    ///
+    /// Deliberately NOT [`Self::await_operand_is_invalid_thenable`] for a
+    /// union element type. `tsc`'s `getAwaitedTypeNoAliasEx` reports the
+    /// diagnostic as a side effect while walking a union's constituents (so
+    /// `await`/plain-`yield` fires the moment *any* branch is an invalid
+    /// thenable), but the caller on this path — element-type resolution for
+    /// `yield*`, not the operand check — collects the recursive results with
+    /// `append`, which drops a failing branch's `undefined` silently and
+    /// keeps whichever branches resolved. The union as a whole is only
+    /// unresolvable, and only then does the surrounding call site report
+    /// TS1322, when **every** branch fails. Oracle-verified: `AsyncIterable<
+    /// BadThenable | number >` is clean (the `number` branch resolves), while
+    /// `AsyncIterable< BadThenable | OtherBadThenable >` reports TS1322.
+    pub(crate) fn yield_star_element_is_invalid_thenable(&mut self, type_id: TypeId) -> bool {
+        if let Some(members) = query::promise_union_members(self.ctx.types, type_id) {
+            return members
+                .into_iter()
+                .all(|member| self.invalid_thenable_info(member, 0).is_some());
+        }
+        self.invalid_thenable_info(type_id, 0).is_some()
+    }
+
     fn invalid_thenable_info(&mut self, type_id: TypeId, depth: u8) -> Option<ThenableAwaitInfo> {
         if depth > MAX_THENABLE_THIS_VALIDATION_DEPTH {
             return None;

--- a/crates/tsz-checker/src/dispatch/yield_.rs
+++ b/crates/tsz-checker/src/dispatch/yield_.rs
@@ -452,6 +452,30 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                         },
                         |i| i.yield_type,
                     );
+                    // TS1322 (checked further down, once per branch of the
+                    // `async_info`/`resolved` split below): distinct from the TS1320
+                    // check above, which validates the async iterator's `next()`
+                    // **result**. This validates each **iterated element** — tsc's
+                    // `checkAsyncIterableIteratorType` (via
+                    // `checkIteratedTypeOrElementType`) awaits every element it pulls
+                    // off an async iterable, so an element that is thenable but not a
+                    // valid promise is its own diagnostic, not a relocation of TS1320.
+                    // `yield_star_element_is_invalid_thenable` mirrors
+                    // `await_operand_is_invalid_thenable` for a single type but not
+                    // for a union element — see its doc comment.
+                    //
+                    // Deliberately NOT checked against `element` above: for every lib
+                    // async iterable except the array/tuple fast path (`AsyncIterable
+                    // <T>`, `AsyncGenerator<T>`, a user class' `[Symbol.asyncIterator]`
+                    // method), `get_iterator_info` answers `None` (the same
+                    // `TypeData::Lazy(DefId)` blind spot documented below) and
+                    // `element`'s solver-only fallback collapses to `ANY`, which would
+                    // silently skip the check for the issue's own witness shape. The
+                    // check instead runs against whichever element-resolution each
+                    // branch already computes for the generator-yield-type
+                    // contribution — `i.yield_type` when structural, `resolved` (the
+                    // env-aware fallback) otherwise — rather than resolving a third
+                    // time.
                     // Capture the delegated iterator's return type for yield* expression result.
                     // Try get_iterator_info first (structural), then fall back to
                     // get_generator_return_type_argument (direct Application arg extraction)
@@ -483,6 +507,15 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                         // type, suppress TS7055 at the function level (see sync path).
                         if i.yield_type == TypeId::ANY {
                             self.checker.ctx.generator_had_ts7057 = true;
+                        } else if self
+                            .checker
+                            .yield_star_element_is_invalid_thenable(i.yield_type)
+                        {
+                            self.checker.error_at_node(
+                                yield_expr.expression,
+                                diagnostic_messages::TYPE_OF_ITERATED_ELEMENTS_OF_A_YIELD_OPERAND_MUST_EITHER_BE_A_VALID_PROMISE_OR_M,
+                                diagnostic_codes::TYPE_OF_ITERATED_ELEMENTS_OF_A_YIELD_OPERAND_MUST_EITHER_BE_A_VALID_PROMISE_OR_M,
+                            );
                         }
                     } else {
                         // `get_iterator_info` is a pure structural solver query: its
@@ -509,6 +542,16 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                             self.checker
                                 .ctx
                                 .push_generator_yield_contribution(resolved, false);
+                            if self
+                                .checker
+                                .yield_star_element_is_invalid_thenable(resolved)
+                            {
+                                self.checker.error_at_node(
+                                    yield_expr.expression,
+                                    diagnostic_messages::TYPE_OF_ITERATED_ELEMENTS_OF_A_YIELD_OPERAND_MUST_EITHER_BE_A_VALID_PROMISE_OR_M,
+                                    diagnostic_codes::TYPE_OF_ITERATED_ELEMENTS_OF_A_YIELD_OPERAND_MUST_EITHER_BE_A_VALID_PROMISE_OR_M,
+                                );
+                            }
                         }
                     }
                     element

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -932,5 +932,7 @@ mod variadic_tuple_spread_element_inference_tests;
 mod void_undefined_discriminant_narrowing_tests;
 #[path = "tests/window_self_globalthis_resolution_tests.rs"]
 mod window_self_globalthis_resolution_tests;
+#[path = "tests/yieldstar_async_iterable_invalid_thenable_element_tests.rs"]
+mod yieldstar_async_iterable_invalid_thenable_element_tests;
 #[path = "tests/zod_type_query_regression_tests.rs"]
 mod zod_type_query_regression_tests;

--- a/crates/tsz-checker/src/tests/yieldstar_async_iterable_invalid_thenable_element_tests.rs
+++ b/crates/tsz-checker/src/tests/yieldstar_async_iterable_invalid_thenable_element_tests.rs
@@ -1,0 +1,326 @@
+//! Regression tests for #16378: TS1322 never fired for `yield*` of an async
+//! iterable whose **iterated element** is an invalid thenable.
+//!
+//! Structural rule: when an `async function*` delegates with `yield*` to an
+//! async iterable, `tsc` awaits each iterated element and validates it as a
+//! thenable — distinct from the TS1320 check on the delegated iterator's own
+//! `next()` **result**. If the element type is thenable (`isThenableType`
+//! holds) but not a valid promise (`getPromisedTypeOfPromiseEx` recovers
+//! nothing), it reports TS1322 at the `yield*` operand.
+//!
+//! tsz already has the exact predicate this needs —
+//! `CheckerState::await_operand_is_invalid_thenable`, landed by #16374 for
+//! the plain `await`/`yield` operand and TS1320's `next()`-result check — but
+//! `dispatch/yield_::check_yield_expression`'s async `yield*` arm never
+//! applied it to the resolved iterated element.
+//!
+//! One case does NOT reuse that predicate as-is: a **union** element type.
+//! Oracle-verified against pinned `typescript@7.0.2`
+//! (`--noEmit --strict --pretty false`), `AsyncIterable<BadThenable | number>`
+//! is clean (the `number` branch resolves, and iterated-element resolution
+//! keeps whichever union branches succeed), while
+//! `AsyncIterable<BadThenable | OtherBadThenable>` (every branch invalid)
+//! reports TS1322. That is the opposite of `await`'s union handling, where a
+//! *single* bad branch is enough (`await (badThenable as BadThenable | number)`
+//! still reports TS1320). See `yield_star_element_is_invalid_thenable`'s doc
+//! comment in `checkers/promise_checker.rs` for why the two call sites
+//! genuinely differ, not a special case invented for this fix.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_source_with_libs, load_default_lib_files};
+
+fn strict_codes(source: &str) -> Vec<u32> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|diagnostic| diagnostic.code)
+    .collect()
+}
+
+const BAD_THENABLE: &str = "interface BadThenable { then(cb: string): void }";
+
+/// Positive: the witness from the issue — a non-callable `onfulfilled`
+/// parameter on the iterated element.
+#[test]
+fn yieldstar_async_iterable_invalid_thenable_element_reports_ts1322() {
+    let codes = strict_codes(&format!(
+        r#"
+export {{}};
+{BAD_THENABLE}
+declare const zzSource: AsyncIterable<BadThenable>;
+async function* g() {{
+  yield* zzSource;
+}}
+"#,
+    ));
+    assert!(
+        codes.contains(&1322),
+        "an invalid-thenable iterated element must report TS1322: {codes:?}"
+    );
+}
+
+/// Renamed/wrapper control: a differently-named interface and generator must
+/// still report TS1322 — proves the check is not keyed off identifiers.
+#[test]
+fn yieldstar_invalid_thenable_element_in_renamed_generator_reports_ts1322() {
+    let codes = strict_codes(
+        r#"
+export {};
+interface MyBadElement { then(cb: string): void }
+declare const delegateSource: AsyncIterable<MyBadElement>;
+async function* differentlyNamedGenerator() {
+  yield* delegateSource;
+}
+"#,
+    );
+    assert!(
+        codes.contains(&1322),
+        "a renamed interface with the same invalid-thenable shape must still report TS1322: {codes:?}"
+    );
+}
+
+/// Negative: a valid thenable element (payload extractable) must not report.
+#[test]
+fn yieldstar_valid_thenable_element_does_not_report_ts1322() {
+    let codes = strict_codes(
+        r#"
+export {};
+interface GoodThenable { then(cb: (value: number) => void): void }
+declare const zzSource: AsyncIterable<GoodThenable>;
+async function* g() {
+  yield* zzSource;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&1322),
+        "a valid thenable element must not report TS1322: {codes:?}"
+    );
+}
+
+/// Negative: a real `Promise<T>` element must not report.
+#[test]
+fn yieldstar_promise_element_does_not_report_ts1322() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const zzSource: AsyncIterable<Promise<number>>;
+async function* g() {
+  yield* zzSource;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&1322),
+        "a real Promise element must not report TS1322: {codes:?}"
+    );
+}
+
+/// Negative: a plain non-thenable element must not report.
+#[test]
+fn yieldstar_ordinary_element_does_not_report_ts1322() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const zzSource: AsyncIterable<number>;
+async function* g() {
+  yield* zzSource;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&1322),
+        "an ordinary non-thenable element must not report TS1322: {codes:?}"
+    );
+}
+
+/// Fallback control: the identical invalid-thenable element delegated from a
+/// *sync* `yield*` (no async generator, so no await happens at all) must not
+/// report — the check is gated on the containing generator being async.
+#[test]
+fn yieldstar_invalid_thenable_element_in_sync_generator_does_not_report_ts1322() {
+    let codes = strict_codes(&format!(
+        r#"
+export {{}};
+{BAD_THENABLE}
+declare const zzSource: BadThenable[];
+function* g() {{
+  yield* zzSource;
+}}
+"#,
+    ));
+    assert!(
+        !codes.contains(&1322),
+        "a sync generator's yield* delegate must not report TS1322: {codes:?}"
+    );
+}
+
+/// This-rejected element: must report TS1322 here (not TS1320, which is the
+/// delegated iterator's own `next()`-result code).
+#[test]
+fn yieldstar_this_rejected_element_reports_ts1322_not_ts1320() {
+    let codes = strict_codes(
+        r#"
+export {};
+interface ThisRejected { then(this: { required: string }, cb: (value: number) => void): void }
+declare const zzSource: AsyncIterable<ThisRejected>;
+async function* g() {
+  yield* zzSource;
+}
+"#,
+    );
+    assert!(
+        codes.contains(&1322),
+        "a this-rejected iterated element must report TS1322: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&1320),
+        "a this-rejected iterated element must report TS1322, not the next()-result code TS1320: {codes:?}"
+    );
+}
+
+/// Union element where every branch is invalid: reports TS1322.
+#[test]
+fn yieldstar_union_element_all_branches_invalid_reports_ts1322() {
+    let codes = strict_codes(
+        r#"
+export {};
+interface BadOne { then(cb: string): void }
+interface BadTwo { then(cb: number): void }
+declare const zzSource: AsyncIterable<BadOne | BadTwo>;
+async function* g() {
+  yield* zzSource;
+}
+"#,
+    );
+    assert!(
+        codes.contains(&1322),
+        "a union element whose every branch is an invalid thenable must report TS1322: {codes:?}"
+    );
+}
+
+/// Union element with one valid, non-thenable branch: the element-resolution
+/// call site keeps the successful branch and does not report — unlike
+/// `await`'s union handling (see the file-level doc comment), the branch
+/// that resolves suppresses the diagnostic entirely.
+#[test]
+fn yieldstar_union_element_one_valid_branch_does_not_report_ts1322() {
+    let codes = strict_codes(&format!(
+        r#"
+export {{}};
+{BAD_THENABLE}
+declare const zzSource: AsyncIterable<BadThenable | number>;
+async function* g() {{
+  yield* zzSource;
+}}
+"#,
+    ));
+    assert!(
+        !codes.contains(&1322),
+        "a union element with one resolving branch must not report TS1322: {codes:?}"
+    );
+}
+
+/// Negative control that pins the asymmetry above: the same union type
+/// `await`ed directly (not through a `yield*` element) still reports TS1320
+/// on its one bad branch — proves the difference is the call site, not a
+/// weakened predicate.
+#[test]
+fn await_of_same_union_still_reports_ts1320_on_one_bad_branch() {
+    let codes = strict_codes(&format!(
+        r#"
+export {{}};
+{BAD_THENABLE}
+declare const zzSource: BadThenable | number;
+async function f() {{
+  await zzSource;
+}}
+"#,
+    ));
+    assert!(
+        codes.contains(&1320),
+        "await of a union with one invalid-thenable branch must still report TS1320: {codes:?}"
+    );
+}
+
+/// User-defined async iterable (a class implementing `[Symbol.asyncIterator]`
+/// directly) must report TS1322 for an invalid-thenable element just like the
+/// lib `AsyncIterable`.
+#[test]
+fn yieldstar_user_defined_async_iterable_invalid_thenable_element_reports_ts1322() {
+    let codes = strict_codes(&format!(
+        r#"
+export {{}};
+{BAD_THENABLE}
+class MyAsyncIterable {{
+  [Symbol.asyncIterator](): AsyncIterator<BadThenable> {{
+    return undefined as unknown as AsyncIterator<BadThenable>;
+  }}
+}}
+declare const zzSource: MyAsyncIterable;
+async function* g() {{
+  yield* zzSource;
+}}
+"#,
+    ));
+    assert!(
+        codes.contains(&1322),
+        "a user-defined async iterable's invalid-thenable element must report TS1322: {codes:?}"
+    );
+}
+
+/// A delegated `AsyncGenerator<T>` (rather than a directly-typed
+/// `AsyncIterable`) must also report TS1322 for its invalid-thenable
+/// yielded/element type.
+///
+/// Oracle-verified with a *declared* `AsyncGenerator<BadThenable>`, not a
+/// call to another `async function*` inferring `BadThenable` from its own
+/// `yield` — the latter reports TS1321 at the inner `yield` first, which
+/// widens the inferred generator's yield type before the outer `yield*` ever
+/// sees it, so the outer position stays clean (`element == TypeId::ANY`).
+/// That's a real, separate tsc behavior, not a gap in this fix.
+#[test]
+fn yieldstar_delegated_async_generator_invalid_thenable_element_reports_ts1322() {
+    let codes = strict_codes(&format!(
+        r#"
+export {{}};
+{BAD_THENABLE}
+declare const zzDelegate: AsyncGenerator<BadThenable>;
+async function* outer() {{
+  yield* zzDelegate;
+}}
+"#,
+    ));
+    assert!(
+        codes.contains(&1322),
+        "a delegated AsyncGenerator's invalid-thenable element must report TS1322: {codes:?}"
+    );
+}
+
+/// Negative: a primitive-like element type carrying `then` through an
+/// intersection must not report — `tsc`'s `isThenableType` excludes
+/// primitives before probing `then` at all.
+#[test]
+fn yieldstar_primitive_like_intersection_element_does_not_report_ts1322() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const zzSource: AsyncIterable<number & { then: string }>;
+async function* g() {
+  yield* zzSource;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&1322),
+        "a primitive-like element must not report TS1322 even if it structurally carries `then`: {codes:?}"
+    );
+}


### PR DESCRIPTION
Closes #16378.

## Structural rule

When an `async function*` delegates with `yield*` to an async iterable, `tsc` awaits each **iterated element** and validates it as a thenable — distinct from the existing TS1320 check on the delegated iterator's own `next()` **result**. If the element is thenable (`isThenableType` holds) but not a valid promise (`getPromisedTypeOfPromiseEx` recovers nothing), `tsc` reports TS1322. tsz reported nothing; `dispatch/yield_::check_yield_expression`'s async `yield*` arm never applied the #16374 predicate (`CheckerState::await_operand_is_invalid_thenable`) to the resolved element type, through `crates/tsz-checker/src/dispatch/yield_.rs`.

## Two things the reuse-the-existing-predicate plan in the issue didn't anticipate

1. **A union element needs different aggregation than `await`'s union handling.** Oracle-verified against pinned `typescript@7.0.2`: `AsyncIterable[ BadThenable | number ]` is clean (the resolving `number` branch suppresses the diagnostic), while `AsyncIterable[ BadThenable | OtherBadThenable ]` (every branch invalid) reports TS1322 — the opposite of `await`, where a single bad branch is enough (`await (bad as BadThenable | number)` still reports TS1320, pinned as a control test). New `yield_star_element_is_invalid_thenable` in `checkers/promise_checker.rs` implements the "every branch invalid" aggregation; `await`/plain-`yield` keep the existing "any branch invalid" `await_operand_is_invalid_thenable`.
2. **The pre-existing solver-only `element` value in this arm collapses to `ANY` for the issue's own witness shape.** `get_iterator_info` cannot evaluate the `TypeData::Lazy(DefId)` alias body of `AsyncIterable[T]`/`AsyncGenerator[T]` themselves (documented in the surrounding code as the same blind spot #16030 fixed on the sync arm), so checking against `element` silently skipped the common case. The check instead reuses the env-aware `for_of_element_type` resolution the arm already computes for the generator-yield-type contribution — no extra resolution pass, and it's what actually resolves the lib alias.

## Owner layer

`crates/tsz-checker/src/dispatch/yield_.rs` (call sites) and `crates/tsz-checker/src/checkers/promise_checker.rs` (new predicate). No solver or emitter changes.

## Adjacent-case matrix

13 new tests, each independently oracle-verified against pinned `typescript@7.0.2` (`--noEmit --strict --pretty false`):

| Case | Expectation |
| --- | --- |
| Non-callable `onfulfilled` element (issue witness) | TS1322 |
| Renamed interface/generator | TS1322 (not identifier-keyed) |
| Valid thenable element (payload extractable) | clean |
| `Promise[T]` element | clean |
| Plain non-thenable element | clean |
| Same shape delegated from a *sync* generator | clean (no await happens) |
| `this`-rejected element | TS1322, not TS1320 |
| Union, every branch invalid | TS1322 |
| Union, one resolving branch | clean |
| Same union `await`ed directly (control) | TS1320 (pins the asymmetry) |
| User-defined async iterable (`[Symbol.asyncIterator]` class) | TS1322 |
| Delegated `AsyncGenerator[T]` | TS1322 |
| Primitive-like element carrying `then` via intersection | clean |

## Verification

- `cargo test -p tsz-checker --lib yieldstar_async_iterable_invalid_thenable_element`: 13/13 new tests pass.
- `cargo test -p tsz-checker --lib yield`: 184/184 pass (no regression in the surrounding yield/generator family).
- `cargo test -p tsz-checker --lib promise`: 107/107 pass.
- `cargo test -p tsz-checker --lib` (full crate suite): passes except the pre-existing baselined `ts2303_tests::recursive_export_assignment_self_import_reports_ts2303` failure (confirmed pre-existing on this session's own parent, unrelated to this change — same failure another session noted independently this hour).
- `cargo clippy -p tsz-checker --lib -- -D warnings`: clean.
- `cargo fmt --check -p tsz-checker`: clean.
- Pre-commit hook (fmt + clippy + arch guard): passed.
- `compare-to-parent.sh` **OWED and disclosed**: no TypeScript corpus in this container this session (cold, no `.target`, no corpus — `setup.sh` did not finish provisioning it within the session budget). The change only adds a new diagnostic on a narrow, previously-silent code path (an invalid-thenable `yield*` element), oracle-verified row-for-row above; risk of a newly-failing conformance row is low but unconfirmed against the full corpus.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_01PqZFg2bV523aeuRpvwRrjY)_