### PR TITLE
fix(checker): the non-strict nullish widening gate is closed under nesting (#16396)

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -610,6 +610,8 @@ mod non_strict_nullish_return_widening_tests;
 mod nonstrict_nullish_widening_generic_call_tests;
 #[path = "tests/nonstrict_nullish_widening_mutable_binding_tests.rs"]
 mod nonstrict_nullish_widening_mutable_binding_tests;
+#[path = "tests/nonstrict_nullish_widening_nested_leaf_tests.rs"]
+mod nonstrict_nullish_widening_nested_leaf_tests;
 #[path = "tests/nonunique_symbol_property_access_tests.rs"]
 mod nonunique_symbol_property_access_tests;
 #[path = "tests/noUIA_any_index_emits_ts2322_tests.rs"]

--- a/crates/tsz-checker/src/tests/nonstrict_nullish_widening_nested_leaf_tests.rs
+++ b/crates/tsz-checker/src/tests/nonstrict_nullish_widening_nested_leaf_tests.rs
@@ -1,0 +1,360 @@
+//! Regression tests for #16396: the non-strict nullish widening-provenance
+//! gate's leaf rule must be closed under nesting.
+//!
+//! Structural rule: with `strictNullChecks` off, the `null`/`undefined`-to-`any`
+//! widening is a property of the *expression*. A fresh array/object literal
+//! inherits the flavour from its elements, so the gate walks the literal's
+//! syntax and asks, of every leaf, "is this a widening source?". The leaf rule
+//! previously answered that with `leaf_type != undefined && leaf_type != null`,
+//! which decides only whether a leaf is *exactly* scalar nullish. But
+//! `widen_nullish_to_any_deep` recurses, so a leaf typed `undefined[]` passed
+//! the gate and then had its *interior* rewritten:
+//! `declare function supply(): undefined[]; var v = [supply()];` inferred
+//! `any[][]` where tsc keeps `undefined[][]` — a false negative that silently
+//! accepts later assignments tsc rejects.
+//!
+//! The predicate is now asked of the widener itself —
+//! `widen_nullish_to_any_deep(leaf) == leaf` — which is the same question in
+//! nesting-closed form and the formulation #16383's return-contribution seam
+//! already uses. The rows below therefore cover both seams that share the walk:
+//! the mutable-binding seam (`widen_initializer_type_for_mutable_binding_gated`,
+//! #16384 leg B) and the generic-call candidate seam
+//! (`fresh_literal_argument_nullish_leaves_are_widening`, #16384 leg A).
+//!
+//! Every row is pinned against a real `typescript@7.0.2` oracle,
+//! `--target es2015 --strict false --noImplicitAny false`. Binder names are
+//! varied across rows so no row can be satisfied by a name-shaped predicate.
+
+use crate::test_utils::{check_with_options_code_messages, non_strict_checker_options};
+
+fn nonstrict_messages(source: &str) -> Vec<(u32, String)> {
+    check_with_options_code_messages(source, non_strict_checker_options())
+}
+
+fn assert_inferred(source: &str, expected_type: &str, context: &str) {
+    let messages = nonstrict_messages(source);
+    assert_eq!(
+        messages,
+        vec![(
+            2322,
+            format!("Type '{expected_type}' is not assignable to type 'string'.")
+        )],
+        "{context}: {messages:?}"
+    );
+}
+
+// ── The reported witness and its nesting family (mutable-binding seam) ──
+
+/// The reported repro: a call whose *declared* return type is `undefined[]`
+/// carries no widening flavour, so the array built around it keeps its nullish
+/// interior — tsc: `undefined[][]`.
+#[test]
+fn call_returning_declared_undefined_array_stays_unwidened() {
+    assert_inferred(
+        "\
+declare function supply(): undefined[];
+var nested = [supply()];
+var probe: string = nested;
+",
+        "undefined[][]",
+        "a call returning a declared `undefined[]` is not a widening source",
+    );
+}
+
+/// Same shape reached through an identifier rather than a call: the leaf rule
+/// is about the leaf's *type*, not about which expression form produced it.
+#[test]
+fn identifier_of_declared_undefined_array_stays_unwidened() {
+    assert_inferred(
+        "\
+declare var holder: undefined[];
+var wrapper = [holder];
+var probe: string = wrapper;
+",
+        "undefined[][]",
+        "an identifier typed `undefined[]` is not a widening source",
+    );
+}
+
+/// The object-literal arm of the same walk.
+#[test]
+fn object_member_of_declared_undefined_array_stays_unwidened() {
+    assert_inferred(
+        "\
+declare function produce(): undefined[];
+var boxed = { slot: produce() };
+var probe: string = boxed;
+",
+        "{ slot: undefined[]; }",
+        "an object member typed `undefined[]` is not a widening source",
+    );
+}
+
+/// `null`'s twin of the witness — the leaf rule must not be `undefined`-only.
+#[test]
+fn declared_null_array_leaf_stays_unwidened() {
+    assert_inferred(
+        "\
+declare var blanks: null[];
+var outer = [blanks];
+var probe: string = outer;
+",
+        "null[][]",
+        "an identifier typed `null[]` is not a widening source",
+    );
+}
+
+/// A tuple leaf carrying a nullish slot: the widener would rewrite the slot, so
+/// the leaf is not safe, even though the tuple itself is not nullish.
+#[test]
+fn declared_undefined_tuple_leaf_stays_unwidened() {
+    assert_inferred(
+        "\
+declare var pair: [undefined, string];
+var outer = [pair];
+var probe: string = outer;
+",
+        "[undefined, string][]",
+        "a tuple leaf with a nullish slot is not a widening source",
+    );
+}
+
+/// An object-typed leaf carrying a nullish property — the nesting is through a
+/// property rather than an element.
+#[test]
+fn object_typed_undefined_property_leaf_stays_unwidened() {
+    assert_inferred(
+        "\
+declare var record: { field: undefined };
+var outer = [record];
+var probe: string = outer;
+",
+        "{ field: undefined; }[]",
+        "an object leaf with a nullish property is not a widening source",
+    );
+}
+
+/// Two levels of fresh literal above the declared leaf: the walk recurses, so
+/// the leaf rule must hold at every depth, not only immediately under the
+/// initializer.
+#[test]
+fn deeply_nested_undefined_array_leaf_stays_unwidened() {
+    assert_inferred(
+        "\
+declare function fetchAll(): undefined[];
+var deep = [[fetchAll()]];
+var probe: string = deep;
+",
+        "undefined[][][]",
+        "the leaf rule must hold at every nesting depth",
+    );
+}
+
+// ── Mixed literals: one non-widening leaf decides the whole literal ──
+
+/// A genuine widening source (`undefined` keyword) beside a declared
+/// `undefined[]` leaf: the enclosing `all` means one non-widening element makes
+/// the whole literal non-widening, so the declared leaf keeps `undefined[]`
+/// rather than becoming `any[]` — which is the half this fix owns.
+///
+/// The residual `| undefined` is a *different*, separately tracked defect: with
+/// `strictNullChecks` off tsc reduces `undefined` out of an element union, so it
+/// renders `undefined[][]` where tsz renders `(undefined[] | undefined)[]`. That
+/// is the non-strict union-reduction gap recorded on #16384/#16393, not a
+/// widening-flavour question — a widening "fix" for it would produce `any[][]`,
+/// wrong in the other direction. Twins asserting tsc's full answer are the two
+/// `#[ignore]`d rows below, so they flip green on their own when that gap
+/// closes.
+#[test]
+fn undefined_keyword_sibling_does_not_rescue_an_undefined_array_leaf() {
+    assert_inferred(
+        "\
+declare function collect(): undefined[];
+var mixed = [collect(), undefined];
+var probe: string = mixed;
+",
+        "(undefined[] | undefined)[]",
+        "one non-widening element makes the whole literal non-widening",
+    );
+}
+
+/// The elided-hole carve-out (#16393) is permissive on its own and decisive
+/// nowhere: a hole beside a declared `undefined[]` leaf must not widen it.
+/// Same `| undefined` residual as the row above, same separate owner.
+#[test]
+fn elided_hole_sibling_does_not_rescue_an_undefined_array_leaf() {
+    assert_inferred(
+        "\
+declare function gather(): undefined[];
+var sparse = [, gather()];
+var probe: string = sparse;
+",
+        "(undefined[] | undefined)[]",
+        "an elided hole must not rescue a non-widening sibling leaf",
+    );
+}
+
+/// tsc's full answer for the mixed row above. Blocked only on non-strict union
+/// reduction absorbing `undefined` out of the element union (#16384/#16393);
+/// the widening half is already correct. Flips green when that gap closes.
+#[test]
+#[ignore = "blocked on non-strict union reduction absorbing `undefined` (#16384/#16393)"]
+fn undefined_keyword_sibling_mixed_literal_matches_tsc() {
+    assert_inferred(
+        "\
+declare function collect(): undefined[];
+var mixed = [collect(), undefined];
+var probe: string = mixed;
+",
+        "undefined[][]",
+        "tsc reduces `undefined` out of the element union",
+    );
+}
+
+/// tsc's full answer for the elided-hole row above. Same blocker.
+#[test]
+#[ignore = "blocked on non-strict union reduction absorbing `undefined` (#16384/#16393)"]
+fn elided_hole_sibling_sparse_literal_matches_tsc() {
+    assert_inferred(
+        "\
+declare function gather(): undefined[];
+var sparse = [, gather()];
+var probe: string = sparse;
+",
+        "undefined[][]",
+        "tsc reduces `undefined` out of the element union",
+    );
+}
+
+// ── Generic-call candidate seam (shares the same walk) ──
+
+/// The witness through the inference seam: the argument literal's flavour is
+/// what propagates into the inferred type argument, so the same leaf rule
+/// governs it — tsc: `undefined[][]`.
+#[test]
+fn generic_call_argument_with_undefined_array_leaf_stays_unwidened() {
+    assert_inferred(
+        "\
+declare function echo<T>(value: T): T;
+declare function supplyAll(): undefined[];
+var viaCall = echo([supplyAll()]);
+var probe: string = viaCall;
+",
+        "undefined[][]",
+        "the generic-call seam shares the leaf rule",
+    );
+}
+
+/// Control for the seam above: a scalar declared `undefined` argument leaf was
+/// already correct (#16384 leg A) and must stay correct.
+#[test]
+fn generic_call_argument_with_declared_undefined_stays_unwidened() {
+    assert_inferred(
+        "\
+declare function echo<T>(value: T): T;
+declare var absent: undefined;
+var viaCall = echo([absent]);
+var probe: string = viaCall;
+",
+        "undefined[]",
+        "a declared scalar `undefined` argument leaf must stay unwidened",
+    );
+}
+
+/// Control for the seam above: the bare `undefined` keyword still carries the
+/// flavour through inference — tsc: `any[]`.
+#[test]
+fn generic_call_argument_with_undefined_keyword_still_widens() {
+    assert_inferred(
+        "\
+declare function echo<T>(value: T): T;
+var viaCall = echo([undefined]);
+var probe: string = viaCall;
+",
+        "any[]",
+        "the `undefined` keyword must still widen through inference",
+    );
+}
+
+// ── Controls: the widening the gate must keep ──
+
+/// The bare `undefined` keyword is a widening source and must still widen.
+#[test]
+fn undefined_keyword_element_still_widens_to_any() {
+    assert_inferred(
+        "\
+var direct = [undefined];
+var probe: string = direct;
+",
+        "any[]",
+        "the `undefined` keyword element must still widen to `any[]`",
+    );
+}
+
+/// Nested fresh literals over a genuine widening source still widen at depth.
+#[test]
+fn nested_undefined_keyword_still_widens_to_any() {
+    assert_inferred(
+        "\
+var layered = [[undefined]];
+var probe: string = layered;
+",
+        "any[][]",
+        "a nested `undefined` keyword must still widen",
+    );
+}
+
+/// The object-literal arm's widening control.
+#[test]
+fn object_with_undefined_keyword_still_widens_to_any() {
+    assert_inferred(
+        "\
+var carrier = { entries: [undefined] };
+var probe: string = carrier;
+",
+        "{ entries: any[]; }",
+        "an object member's `undefined` keyword must still widen",
+    );
+}
+
+/// Elided holes alone are still a widening source (#16393's fixture row).
+#[test]
+fn elided_holes_still_widen_to_any() {
+    assert_inferred(
+        "\
+var holes = [,,];
+var probe: string = holes;
+",
+        "any[]",
+        "elided holes must still widen to `any[]`",
+    );
+}
+
+/// A hole beside a declared scalar `undefined` still does not widen — the
+/// carve-out's original control, unchanged by this fix.
+#[test]
+fn elided_hole_with_declared_undefined_sibling_stays_unwidened() {
+    assert_inferred(
+        "\
+var missing: undefined = undefined;
+var sparse = [, missing];
+var probe: string = sparse;
+",
+        "undefined[]",
+        "a declared `undefined` sibling still makes the literal non-widening",
+    );
+}
+
+/// A leaf the widener would never touch is irrelevant to the decision and must
+/// not be turned into a rejection by the new fixed-point form.
+#[test]
+fn non_nullish_leaf_is_unaffected() {
+    assert_inferred(
+        "\
+var words = [\"s\"];
+var probe: string = words;
+",
+        "string[]",
+        "a non-nullish leaf must be unaffected by the gate",
+    );
+}

--- a/crates/tsz-checker/src/types/computation/array_literal.rs
+++ b/crates/tsz-checker/src/types/computation/array_literal.rs
@@ -1433,10 +1433,23 @@ impl<'a> CheckerState<'a> {
             // exhibit this specific pre-widening pairwise-mismatch, and its own
             // (pre-existing, separately owned) resolution already happens where
             // it always has: unaffected by this change either way.
+            //
+            // The eager pre-widen is only legitimate for a literal that actually
+            // CARRIES the widening flavour. It is a shape-driven rewrite with no
+            // provenance of its own, so applying it unconditionally rewrote the
+            // interior of a *declared* nullish element:
+            // `declare function supply(): undefined[]; var v = [supply()];`
+            // became `any[][]` where tsc keeps `undefined[][]` (#16396). The
+            // element is neither `NULL` nor `UNDEFINED`, so the scalar carve-out
+            // below does not exempt it — only the provenance walk can. Gate on
+            // the same `initializer_nullish_leaves_are_widening` walk the
+            // mutable-binding and generic-call seams use, so a literal whose
+            // leaves are genuine widening sources still collapses its siblings
+            // post-widening and one whose leaves are declared values does not.
             let bct_element_types: Vec<TypeId> = if self.ctx.strict_null_checks() {
                 element_types.clone()
             } else {
-                element_types
+                let widened: Vec<TypeId> = element_types
                     .iter()
                     .map(|&t| {
                         if t == TypeId::NULL || t == TypeId::UNDEFINED {
@@ -1448,7 +1461,15 @@ impl<'a> CheckerState<'a> {
                             )
                         }
                     })
-                    .collect()
+                    .collect();
+                // Nothing to decide when the pre-widen is already a no-op — this
+                // keeps the provenance walk off the path of every array literal
+                // that has no nullish interior at all, which is nearly all of them.
+                if widened == element_types || self.initializer_nullish_leaves_are_widening(idx) {
+                    widened
+                } else {
+                    element_types.clone()
+                }
             };
             expr_ops::compute_best_common_type_cached(
                 self.ctx.types,

--- a/crates/tsz-checker/src/types/utilities/mutable_binding_nullish.rs
+++ b/crates/tsz-checker/src/types/utilities/mutable_binding_nullish.rs
@@ -149,20 +149,36 @@ impl<'a> CheckerState<'a> {
         }
 
         // Any other leaf expression (identifier, call, property access, ...):
-        // it only needs to be a widening source when its own checked type is
-        // actually nullish — a non-nullish leaf never reaches the widener.
+        // it only needs to be a widening source when the widener would actually
+        // touch it — a leaf the widener leaves alone never contributes a nullish
+        // leaf to the composite, so it cannot make the widen unsafe.
         //
-        // An *uncached* leaf type is not evidence of a non-nullish leaf, so it
-        // fails closed, per this walk's stated policy. The mutable-binding seam
-        // never observes the difference (it runs after the initializer has been
-        // typed), but the generic-call candidate seam does: the argument's
-        // element types are not necessarily resident when candidates are
-        // normalized, and reading `None` as "safe to widen" there turned
-        // `declare var q: undefined; id([q])` into `any[]` when tsc keeps
+        // The question has to be asked of the widener itself, not of the two
+        // scalar ids: `t != UNDEFINED && t != NULL` is not closed under nesting,
+        // so a leaf typed `undefined[]` passed the gate and the deep widener
+        // then rewrote its *interior* — `declare function supply(): undefined[];
+        // var v = [supply()]` inferred `any[][]` where tsc keeps `undefined[][]`
+        // (#16396). `widen_nullish_to_any_deep(leaf) == leaf` is the same
+        // predicate in nesting-closed form: it agrees on the scalar cases
+        // (`undefined`/`null` widen to `any`, so both still fail here) and
+        // additionally rejects every composite the widener would rewrite.
+        // Reaching this point already means the leaf is not a widening source —
+        // the bare `null`/`undefined` keyword and the global `undefined`
+        // identifier returned `true` above. This is the form #16383's
+        // return-contribution seam uses, which is correct on both repros today.
+        //
+        // An *uncached* leaf type is not evidence of a leaf the widener would
+        // skip, so it fails closed, per this walk's stated policy. The
+        // mutable-binding seam never observes the difference (it runs after the
+        // initializer has been typed), but the generic-call candidate seam does:
+        // the argument's element types are not necessarily resident when
+        // candidates are normalized, and reading `None` as "safe to widen" there
+        // turned `declare var q: undefined; id([q])` into `any[]` when tsc keeps
         // `undefined[]` (#16384 leg A).
-        matches!(
-            self.ctx.node_types.get(&expr.0).copied(),
-            Some(t) if t != TypeId::UNDEFINED && t != TypeId::NULL
-        )
+        let Some(&leaf_type) = self.ctx.node_types.get(&expr.0) else {
+            return false;
+        };
+        crate::query_boundaries::widening::widen_nullish_to_any_deep(self.ctx.types, leaf_type)
+            == leaf_type
     }
 }

--- a/crates/tsz-checker/src/types/utilities/mutable_binding_nullish.rs
+++ b/crates/tsz-checker/src/types/utilities/mutable_binding_nullish.rs
@@ -22,7 +22,6 @@ use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
     /// Whether every `null`/`undefined` leaf that


### PR DESCRIPTION
Closes #16396.

**Structural rule:** when a fresh array/object literal's nullish leaves are *not* all genuine widening sources, `tsc` leaves the literal's nullish interior alone; tsz now does the same through the checker's shared widening-provenance walk (`types/utilities/mutable_binding_nullish.rs`), applied at **every** seam that consumes it.

With `strictNullChecks` off, `tsc`'s `null`/`undefined`-to-`any` widening is a property of the *expression*, not the type: only the bare `null`/`undefined` keyword or an identifier resolving to the global `undefined` carries the flavour (`nullWideningType`/`undefinedWideningType`), and a fresh literal inherits it from its leaves. A value that merely *has* type `undefined` through a declared source does not. tsz carries no per-type widening flag, so it recovers the provenance from syntax before calling the solver's purely shape-driven `widen_nullish_to_any_deep`.

Two sites were deciding that without a nesting-closed rule.

### 1. The leaf rule was not closed under nesting

`initializer_nullish_leaves_are_widening_inner`'s leaf rule asked `leaf != UNDEFINED && leaf != NULL`, which only rejects leaves that are *exactly* scalar nullish. A leaf typed `undefined[]` is neither, so it passed the gate — and `widen_nullish_to_any_deep` then recursed *into* it and rewrote its interior.

Replaced with the widener's own fixed-point question, `widen_nullish_to_any_deep(leaf) == leaf`: the same predicate in nesting-closed form. It agrees on the scalar cases (both widen to `any`, so both still fail here) and additionally rejects every composite the widener would rewrite. This is the formulation #16383's return-contribution seam already uses, and that seam is correct on both repros today. Reaching the leaf rule already means the leaf is not a widening source — the keyword and global-`undefined` arms return `true` above it.

### 2. The dominant site: the array-literal BCT pre-widen was ungated

`get_type_of_array_literal_with_request` pre-widens every *compound* element before best-common-type so siblings compare in their final shape — without it `[[[null]],[undefined]]` produces a spurious `any[] | any[][]` instead of collapsing the way `tsc` does. That rewrite is shape-driven and had no provenance of its own, and it ran unconditionally, so it rewrote declared nullish elements outright. It is what actually produced `any[][]` for the issue's repro; fixing the leaf rule alone moved **0** of the 7 affected rows.

It is now gated on the same provenance walk, behind a no-op short-circuit (`widened == element_types`) so a literal with no nullish interior at all — nearly all of them — never pays for the walk.

### Effect

```ts
declare function supply(): undefined[];
var v = [supply()];
v = [[1]];        // tsc: TS2322 · tsz before: CLEAN (false negative) · tsz after: TS2322
```

The over-widened binding silently accepted later assignments `tsc` rejects.

### Adjacent-case matrix

18 active rows + 2 `#[ignore]`d, every one pinned against a real `typescript@7.0.2` oracle (`--strict false --target es2015 --lib es2015`). Binder names are varied across rows so no row can be satisfied by a name-shaped predicate.

| | row | tsc | before | after |
| --- | --- | --- | --- | --- |
| witness | `[supply()]`, `supply(): undefined[]` | `undefined[][]` | `any[][]` | fixed |
| expression form | identifier `holder: undefined[]` | `undefined[][]` | `any[][]` | fixed |
| object arm | `{ slot: produce() }` | `{ slot: undefined[]; }` | over-widened | fixed |
| `null` twin | `blanks: null[]` | `null[][]` | over-widened | fixed |
| tuple leaf | `pair: [undefined, string]` | `[undefined, string][]` | `[any, string][]` | fixed |
| object leaf | `record: { field: undefined }` | `{ field: undefined; }[]` | over-widened | fixed |
| depth | `[[fetchAll()]]` | `undefined[][][]` | over-widened | fixed |
| generic-call seam | `echo([supplyAll()])` | `undefined[][]` | over-widened | fixed |
| **control** | `[undefined]` | `any[]` | `any[]` | unchanged |
| **control** | `[[undefined]]` | `any[][]` | `any[][]` | unchanged |
| **control** | `{ entries: [undefined] }` | `{ entries: any[]; }` | same | unchanged |
| **control** | `[,,]` (elided holes) | `any[]` | `any[]` | unchanged |
| **control** | `[, missing]`, `missing: undefined` | `undefined[]` | `undefined[]` | unchanged |
| **control** | `echo([undefined])` | `any[]` | `any[]` | unchanged |
| **control** | `echo([absent])`, `absent: undefined` | `undefined[]` | `undefined[]` | unchanged |
| **control** | `["s"]` | `string[]` | `string[]` | unchanged |

Two mixed rows (`[collect(), undefined]`, `[, gather()]`) go `(any[] | undefined)[]` to `(undefined[] | undefined)[]`. The widening half is now correct; the residual `| undefined` is the **separately owned** non-strict union-reduction gap recorded on #16384/#16393 — `tsc` absorbs `undefined` out of the element union, which is not a widening-flavour question and whose "widening fix" would produce `any[][]`, wrong in the other direction. Both are pinned twice: an active row at the achievable answer, and an `#[ignore]`d twin asserting `tsc`'s full answer so it flips green on its own when that gap closes. No accepted-regression entry was added and no floor was lowered.

## Goal
Goal: hold

## Verification

All figures final and measured; nothing outstanding.

- `cargo test -p tsz-checker --lib nonstrict_nullish_widening_nested_leaf` — **18 passed, 0 failed, 2 ignored** (new suite). Measured mid-change with only the leaf-rule half applied: **11 passed, 7 failed** — which is how the array-literal pre-widen was identified as the dominant site. The 2 mixed rows additionally move `(any[] | undefined)[]` to `(undefined[] | undefined)[]`, so 9 of the 18 rows change behaviour.
- `cargo test -p tsz-checker --lib nullish` — **237 passed, 0 failed, 4 ignored** (all three seams' existing suites: mutable-binding #16384 leg B, generic-call leg A, return contribution #16383, the #16393 hole carve-out).
- `cargo clippy --workspace --all-targets -- -D warnings` — **exit 0** at head `38b9244`. `cargo fmt --all` — clean.
- CI at exact head `38b9244` (run `30951278452`): **clippy success, arch-size success, CI Summary success**.

Independently re-measured on m4 against a warm corpus (see review comment):

- Targeted three-way `tsc 7.0.2` / main / PR: **4 fixed / 0 broken**, stated as incompatible-assignment rows so main is *clean* where `tsc` errors — the false negative shown directly. Three scalar controls confirm the genuine-widening path is untouched.
- Conformance `snapshot --workers 12 --force`: **11484 → 11484, 0 regressed / 0 fixed**, diffed against a *fresh* main snapshot rather than the committed `conformance-detail.json` (which currently reads 11482). Zero corpus movement is the expected signature for this family — it joins #16016/#16020/#16039/#16042/#16270; the oracle-pinned matrix is the primary evidence and the corpus is the regression floor.
- `arch_guard.py` rc=0. `test_module_registry.rs` **464 → 465** `#[path]` entries, counted rather than diffed, so the new suite is provably registered.
- `cargo nextest run -p tsz-checker --lib`: 9557 run, 9556 passed. The single failure, `ts2303_tests::recursive_export_assignment_self_import_reports_ts2303`, reproduces at `origin/main` `2ff85e6411` in isolation — pre-existing, not attributable to this PR, filed separately.

Emit and fourslash are not exercised by this change (checker-only, inference of a `var` initializer's type; the emitter reads no part of this path), so they were not run.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Olivine