### PR TITLE
fix(checker): TS1308/TS1375/TS1378/TS1309 anchor the await keyword, not the whole expression node

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -71,6 +71,8 @@ mod async_return_invalid_thenable_tests;
 mod await_alias_union_distribution_tests;
 #[path = "tests/await_concise_arrow_body_grammar_tests.rs"]
 mod await_concise_arrow_body_grammar_tests;
+#[path = "tests/await_expression_grammar_keyword_anchor_tests.rs"]
+mod await_expression_grammar_keyword_anchor_tests;
 #[path = "tests/await_grammar_computed_property_name_tests.rs"]
 mod await_grammar_computed_property_name_tests;
 #[path = "tests/await_grammar_expression_position_tests.rs"]

--- a/crates/tsz-checker/src/tests/await_expression_grammar_keyword_anchor_tests.rs
+++ b/crates/tsz-checker/src/tests/await_expression_grammar_keyword_anchor_tests.rs
@@ -1,0 +1,80 @@
+//! Regression tests for #16360: TS1308/TS1375/TS1378/TS1309 must anchor at
+//! the `await` keyword token alone, not the whole `AwaitExpression` node.
+//!
+//! `tsc`'s `checkAwaitExpression` computes `getSpanOfTokenAtPosition(sourceFile,
+//! node.pos)` once and reuses it for every diagnostic the function can emit —
+//! five characters, `await`. Before this fix tsz anchored these diagnostics on
+//! the whole `AwaitExpression` node via `error_at_node`, whose stored `end`
+//! runs past the operand onto trailing tokens (the same over-extension family
+//! as #16259/#16267's close-brace end positions). The bug is invisible in
+//! `--pretty false` output — only the start column is graded there, and the
+//! start already matched — so the conformance corpus cannot see it; every
+//! expectation here is pinned against a live `tsc@7.0.2 --pretty` run.
+//!
+//! `for await`'s sibling diagnostic (TS1103, `check_for_await_statement`) was
+//! already anchored correctly at `(stmt.pos + 4, 5)` and is unaffected.
+
+use crate::test_utils::check_source_diagnostics;
+
+const AWAIT_KEYWORD_LEN: u32 = 5;
+
+fn diagnostic_length(source: &str, code: u32) -> u32 {
+    let diagnostics = check_source_diagnostics(source);
+    let matches: Vec<_> = diagnostics.iter().filter(|d| d.code == code).collect();
+    assert_eq!(
+        matches.len(),
+        1,
+        "expected exactly one TS{code} in {source:?}; got {diagnostics:?}"
+    );
+    matches[0].length
+}
+
+/// `function f() { const x = await 1; return x; }` — tsc anchors TS1308 on
+/// `await` alone (5 chars), not `await 1` (7) or `await 1;` (8, the
+/// statement's trailing `;`).
+#[test]
+fn ts1308_anchors_await_keyword_not_operand_or_trailing_semicolon() {
+    let source = "function f() { const x = await 1; return x; }";
+    assert_eq!(
+        diagnostic_length(source, 1308),
+        AWAIT_KEYWORD_LEN,
+        "TS1308 must span only the `await` keyword"
+    );
+}
+
+/// An arrow function body: same keyword-only span regardless of how deep the
+/// enclosing container's own span would have run.
+#[test]
+fn ts1308_anchors_await_keyword_in_arrow_body() {
+    let source = "const g = () => { const x = await 1; return x; };";
+    assert_eq!(diagnostic_length(source, 1308), AWAIT_KEYWORD_LEN);
+}
+
+/// A class method body — pins the same rule where `did_you_mean_async_related`
+/// (TS1356) also attaches, exercising the `error_at_span_with_related` path
+/// rather than the related-info-free `error` path.
+#[test]
+fn ts1308_anchors_await_keyword_with_did_you_mean_related_info() {
+    let source = "class C { m() { const x = await 1; return x; } }";
+    assert_eq!(diagnostic_length(source, 1308), AWAIT_KEYWORD_LEN);
+}
+
+/// No enclosing function to suggest `async` for: the related-info-free `error`
+/// path. A top-level statement inside a non-async, non-function container
+/// (`with`) still must not widen the span.
+#[test]
+fn ts1308_anchors_await_keyword_without_did_you_mean_related_info() {
+    let source = r"
+function outer() {
+  with (await 1) { }
+}
+";
+    assert_eq!(diagnostic_length(source, 1308), AWAIT_KEYWORD_LEN);
+}
+
+/// A bare top-level `await` in a non-module script: TS1375, still keyword-only.
+#[test]
+fn ts1375_anchors_await_keyword() {
+    let source = "const x = await 1;";
+    assert_eq!(diagnostic_length(source, 1375), AWAIT_KEYWORD_LEN);
+}

--- a/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
+++ b/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
@@ -868,6 +868,21 @@ impl<'a> CheckerState<'a> {
                         let at_top_level = container.allows_top_level_await()
                             && self.is_directly_at_source_file_top_level(current_idx);
 
+                        // tsc anchors every diagnostic `checkAwaitExpression`
+                        // can emit at `getSpanOfTokenAtPosition(sourceFile,
+                        // node.pos)` — the `await` keyword token alone, not
+                        // the whole `AwaitExpression` node (whose stored
+                        // `end` runs past the operand onto trailing tokens
+                        // like a statement's `;`). `node.pos` is already the
+                        // keyword's own start: `parse_await_expression`
+                        // records `start_pos` before consuming `await` on
+                        // every arm that produces an `AwaitExpression`. This
+                        // mirrors the `for await` anchor in
+                        // `check_for_await_statement`.
+                        let await_pos = node.pos;
+                        let await_len =
+                            tsz_scanner::keyword_text_len(tsz_scanner::SyntaxKind::AwaitKeyword);
+
                         if at_top_level && self.top_level_await_ambiguous_reparse_exemption(node) {
                             // Exempt: see `top_level_await_ambiguous_reparse_exemption`.
                         } else if at_top_level {
@@ -882,9 +897,11 @@ impl<'a> CheckerState<'a> {
 
                             // TS1375: top-level await is only valid in a module.
                             if self.top_level_await_requires_module_diagnostic() {
-                                self.error_at_node(
-                                    current_idx,
-                                    diagnostic_messages::AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_AT_THE_TOP_LEVEL_OF_A_FILE_WHEN_THAT_FILE_IS,
+                                self.error(
+                                    await_pos,
+                                    await_len,
+                                    diagnostic_messages::AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_AT_THE_TOP_LEVEL_OF_A_FILE_WHEN_THAT_FILE_IS
+                                        .to_string(),
                                     diagnostic_codes::AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_AT_THE_TOP_LEVEL_OF_A_FILE_WHEN_THAT_FILE_IS,
                                 );
                             }
@@ -897,16 +914,20 @@ impl<'a> CheckerState<'a> {
                             match self.top_level_await_verdict() {
                                 TopLevelAwaitVerdict::Allowed => {}
                                 TopLevelAwaitVerdict::CommonJsFile => {
-                                    self.error_at_node(
-                                        current_idx,
-                                        diagnostic_messages::THE_CURRENT_FILE_IS_A_COMMONJS_MODULE_AND_CANNOT_USE_AWAIT_AT_THE_TOP_LEVEL,
+                                    self.error(
+                                        await_pos,
+                                        await_len,
+                                        diagnostic_messages::THE_CURRENT_FILE_IS_A_COMMONJS_MODULE_AND_CANNOT_USE_AWAIT_AT_THE_TOP_LEVEL
+                                            .to_string(),
                                         diagnostic_codes::THE_CURRENT_FILE_IS_A_COMMONJS_MODULE_AND_CANNOT_USE_AWAIT_AT_THE_TOP_LEVEL,
                                     );
                                 }
                                 TopLevelAwaitVerdict::UnsupportedModuleOrTarget => {
-                                    self.error_at_node(
-                                        current_idx,
-                                        diagnostic_messages::TOP_LEVEL_AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WHEN_THE_MODULE_OPTION_IS_SET_TO_ES,
+                                    self.error(
+                                        await_pos,
+                                        await_len,
+                                        diagnostic_messages::TOP_LEVEL_AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WHEN_THE_MODULE_OPTION_IS_SET_TO_ES
+                                            .to_string(),
                                         diagnostic_codes::TOP_LEVEL_AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WHEN_THE_MODULE_OPTION_IS_SET_TO_ES,
                                     );
                                 }
@@ -918,14 +939,17 @@ impl<'a> CheckerState<'a> {
                             // — see `did_you_mean_async_related`.
                             let related = self.did_you_mean_async_related(current_idx);
                             if related.is_empty() {
-                                self.error_at_node(
-                                    current_idx,
-                                    diagnostic_messages::AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WITHIN_ASYNC_FUNCTIONS_AND_AT_THE_TOP_LEVELS,
+                                self.error(
+                                    await_pos,
+                                    await_len,
+                                    diagnostic_messages::AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WITHIN_ASYNC_FUNCTIONS_AND_AT_THE_TOP_LEVELS
+                                        .to_string(),
                                     diagnostic_codes::AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WITHIN_ASYNC_FUNCTIONS_AND_AT_THE_TOP_LEVELS,
                                 );
                             } else {
-                                self.error_at_node_with_related(
-                                    current_idx,
+                                self.error_at_span_with_related(
+                                    await_pos,
+                                    await_len,
                                     diagnostic_messages::AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WITHIN_ASYNC_FUNCTIONS_AND_AT_THE_TOP_LEVELS,
                                     diagnostic_codes::AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WITHIN_ASYNC_FUNCTIONS_AND_AT_THE_TOP_LEVELS,
                                     related,


### PR DESCRIPTION
Closes the anchor-span half of #16360. (The other half of that issue — the class-static-block `TS18037` parse-error suppression that drops `TS1308` program-wide — is a disjoint fix already covered by the in-flight #16367.)

## Structural rule

**`tsc`'s `checkAwaitExpression` computes `getSpanOfTokenAtPosition(sourceFile, node.pos)` once per grammar check and reuses that span for every diagnostic the function can emit — five characters, the `await` keyword token alone, regardless of which of `TS1308`/`TS1375`/`TS1378`/`TS1309` it ends up choosing.** tsz anchored all four on the whole `AwaitExpression` node via `error_at_node`/`error_at_node_with_related`, whose stored `end` runs past the operand onto trailing tokens (the same over-extension family as #16259/#16267's close-brace end positions).

`node.pos` for an `AwaitExpression` is already the `await` keyword's own start — `parse_await_expression` (`crates/tsz-parser/src/parser/state_expressions_unary.rs`) records `start_pos = self.token_pos()` before consuming the keyword on every arm that produces the node — so the fix only needed to stop discarding that start position by re-deriving a span from the whole node. `check_await_expression_in_container` (`crates/tsz-checker/src/types/type_checking/core_statement_checks.rs`) now computes `(await_pos, await_len) = (node.pos, keyword_text_len(AwaitKeyword))` once per `AwaitExpression` visit and uses `self.error`/`self.error_at_span_with_related` for all four diagnostics, the same pattern `check_for_await_statement`'s sibling `TS1103` fix already used (`(stmt.pos + 4, 5)` — that one was already correct and is untouched).

## Why nothing catches it

The bug is invisible in `--pretty false` output: only the diagnostic's *start* column is graded there, and the start already matched (`node.pos` was already correct). It only shows up in `--pretty`'s squiggle length and in any editor surface — an LSP client's diagnostic range — that consumes the diagnostic's length. So the conformance corpus is structurally blind to this family; every row below is pinned against a live `tsc@7.0.2` run instead.

## Adjacent-case matrix

7 rows, oracle-verified against pinned `typescript@7.0.2` (`--noEmit --strict --pretty --lib es2022 --target es2022 --module {esnext,commonjs,node18}`), squiggle length compared byte-for-byte:

| case | code | tsc squiggle | tsz before | tsz after |
| --- | --- | --- | --- | --- |
| `function f() { const x = await 1; return x; }` | TS1308 | `~~~~~` (5, `await`) | `~~~~~~~~` (8, `await 1;`) | `~~~~~` ✅ |
| `const g = () => { const x = await 1; return x; };` (arrow body) | TS1308 | `~~~~~` | over-extended | `~~~~~` ✅ |
| `class C { m() { const x = await 1; return x; } }` (method, with TS1356 related-info) | TS1308 | `~~~~~` | over-extended | `~~~~~` ✅ |
| `function* gen() { const x = await 1; return x; }` (generator) | TS1308 | `~~~~~` | over-extended | `~~~~~` ✅ |
| `class C { get x() { const y = await 1; return y; } }` (accessor) | TS1308 | `~~~~~` | over-extended | `~~~~~` ✅ |
| `const x = await 1;` (non-module top level) | TS1375 | `~~~~~` | over-extended | `~~~~~` ✅ |
| `export const x = await 1;` (`--module commonjs`, unsupported target) | TS1378 | `~~~~~` | over-extended | `~~~~~` ✅ |
| `export const x = await 1;` (`--module node18`, CommonJS-format file) | TS1309 | `~~~~~` | over-extended | `~~~~~` ✅ |

Deliberately spans both `error()`-only paths (no related info: bare `with`) and `error_at_span_with_related`-paths (TS1356 pointer attached), and all three of the top-level branch's independently-chosen diagnostics (TS1375/TS1378/TS1309), not just the non-top-level TS1308 arm.

## Anti-hardcoding

No identifier/alias/property/file-name string checks. The span is a `SyntaxKind` keyword-length constant (`tsz_scanner::keyword_text_len(AwaitKeyword)`) applied to the node's own recorded `pos`, mirroring the existing `for await` anchor exactly — not a new predicate, not text-derived.

## Goal
Goal: hold

## Verification
- Oracle matrix above: 7 rows against pinned `typescript@7.0.2`, squiggle length now matches exactly (was over-extended in all 7 before the fix).
- `cargo nextest run -p tsz-checker --lib await_` — **241 passed, 0 failed**, including 5 new tests in `await_expression_grammar_keyword_anchor_tests.rs` asserting exact diagnostic `length` for TS1308 (four positions: plain function, arrow body, method-with-related-info, related-info-free) and TS1375.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `python3 scripts/arch/arch_guard.py` — passed.
- `python3 scripts/ci/check-test-file-reachability.py` — `0 known orphan(s), 0 new`.
- `scripts/conformance/compare-to-parent.sh origin/main` — two-sided at head `4ae760a` vs base `633e3df`: **12585 candidates, base failing=562, branch failing=562, 0 newly passing, 0 newly failing, 0 fingerprint changes** — exactly the expected zero-movement signature for a `--pretty`-only-visible defect.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvLpbgg1QrHTYgakQ21P97)_