### PR TITLE
fix(checker): only a namespace-export clause is a module export name (#16393)

### DIFF
--- a/crates/tsz-checker/src/declarations/module_export_names.rs
+++ b/crates/tsz-checker/src/declarations/module_export_names.rs
@@ -50,6 +50,7 @@
 
 use crate::state::CheckerState;
 use tsz_common::common::ModuleKind;
+use tsz_parser::parser::node::ExportDeclData;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
 
@@ -103,6 +104,27 @@ impl<'a> CheckerState<'a> {
                 crate::diagnostics::diagnostic_codes::STRING_LITERAL_IMPORT_AND_EXPORT_NAMES_ARE_NOT_SUPPORTED_WHEN_THE_MODULE_FLAG_IS,
             );
         }
+    }
+
+    /// Whether an export declaration's `export_clause` holds a *namespace
+    /// export name* — the `<name>` of `export * as <name> from "m"` — rather
+    /// than some other node that merely shares the field.
+    ///
+    /// tsz has no distinct `NamespaceExport` node, so `ExportDeclData::export_clause`
+    /// is reused by five unrelated productions: the namespace name, the
+    /// `NAMED_EXPORTS` clause, a **default-export expression**, an
+    /// `export import X = Y` declaration, and the declaration of an
+    /// `export <declaration>`. Only the first is a module export name in `tsc`'s
+    /// sense, so only the first may reach `checkModuleExportName`; treating the
+    /// others as names is how `export default "./foo"` came to draw TS18057
+    /// while `tsc` is silent.
+    ///
+    /// `parse_export_star` is the sole producer of a namespace name and always
+    /// parses a `from` clause, so a non-default export declaration carrying a
+    /// module specifier selects exactly that production. The other four
+    /// productions all leave `module_specifier` empty or set `is_default_export`.
+    const fn export_clause_is_namespace_export_name(export_decl: &ExportDeclData) -> bool {
+        !export_decl.is_default_export && export_decl.module_specifier.is_some()
     }
 
     /// Whether `tsc` would consider this module specifier resolved, which is
@@ -204,6 +226,9 @@ impl<'a> CheckerState<'a> {
             return;
         };
         if clause_node.kind != syntax_kind_ext::NAMED_EXPORTS {
+            if !Self::export_clause_is_namespace_export_name(export_decl) {
+                return;
+            }
             // `export * as "ns" from "m"` — the clause *is* the namespace name.
             // `checkExportDeclaration` passes no second argument, so this
             // position always allows a string literal.

--- a/crates/tsz-checker/tests/string_literal_module_export_name_grammar_tests.rs
+++ b/crates/tsz-checker/tests/string_literal_module_export_name_grammar_tests.rs
@@ -556,3 +556,184 @@ fn plain_identifier_specifiers_never_draw_ts1003() {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// The `export_clause` field is shared by five productions; only one of them is
+// a module export name
+// ---------------------------------------------------------------------------
+//
+// tsz has no distinct `NamespaceExport` node, so `ExportDeclData::export_clause`
+// carries the `export * as <name>` namespace name, a `NAMED_EXPORTS` clause, a
+// **default-export expression**, an `export import X = Y`, and the declaration
+// of an `export <declaration>`. `checkModuleExportName` may only ever see the
+// first. Reading the field as a name regardless is what made
+// `export default "./foo"` draw TS18057 while tsc is silent — four conformance
+// rows, all `conformance/dynamicImport/importCallExpressionNested*`.
+//
+// Oracle: `typescript@7.0.2 --noEmit --module <m> --target es2020`.
+
+/// Every module target a default export can be written under. The two that
+/// reject string-literal export *names* lead, because they are the only ones
+/// where a misread clause could reach a diagnostic at all.
+const ALL_MODULE_TARGETS: [ModuleKind; 8] = [
+    ModuleKind::ES2015,
+    ModuleKind::ES2020,
+    ModuleKind::ES2022,
+    ModuleKind::ESNext,
+    ModuleKind::CommonJS,
+    ModuleKind::Preserve,
+    ModuleKind::Node16,
+    ModuleKind::NodeNext,
+];
+
+#[test]
+fn a_string_literal_default_export_is_not_a_module_export_name() {
+    // The reported witness. `export default "./foo"` has no *name* node at all,
+    // so no module target may report on it — tsc is clean on every one.
+    for module in ALL_MODULE_TARGETS {
+        let codes = check_codes_with(module, r#"export default "./foo";"#);
+        assert!(
+            !codes.contains(&STRING_LITERAL_MODULE_EXPORT_NAME),
+            "TS18057 must not fire for a string-literal default export under {module:?}, got {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn the_default_export_row_holds_for_every_string_valued_expression_shape() {
+    // The witness generalises past a bare literal: anything whose *value* is a
+    // string is still valueless as a name. The renamed binders are deliberate —
+    // nothing here may key on a particular identifier or path text.
+    for source in [
+        r#"export default "./foo";"#,
+        r#"export default "";"#,
+        r#"export default "a name with spaces";"#,
+        r#"const someBinding = "s"; export default someBinding;"#,
+        r#"const otherBinding = "s"; export default otherBinding;"#,
+        r#"export default "a" + "b";"#,
+        r#"export default ["./foo"];"#,
+        r#"export default { path: "./foo" };"#,
+    ] {
+        for module in [ModuleKind::ES2015, ModuleKind::ES2020] {
+            assert_eq!(
+                count_18057(module, source),
+                0,
+                "TS18057 must not fire for {source:?} under {module:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn non_string_default_exports_stay_clean_as_the_negative_control() {
+    // These were already clean before the fix — but only because a
+    // `NumericLiteral` fails the string-literal test one frame later, not
+    // because the clause was recognised as a non-name. They are the control
+    // that shows the fix did not simply widen the silence.
+    for source in [
+        "export default 42;",
+        "export default class Renamed {}",
+        "export default function renamed() {}",
+        "export default class {}",
+        "const n = 1; export default n;",
+    ] {
+        for module in ALL_MODULE_TARGETS {
+            assert_eq!(
+                count_18057(module, source),
+                0,
+                "TS18057 must not fire for {source:?} under {module:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn the_other_clause_sharing_productions_are_not_module_export_names() {
+    // `export import X = Y` and `export <declaration>` also park a non-name in
+    // `export_clause`. Neither can hold a string literal today, so neither had
+    // a witness — they are pinned so a future parser change that puts one there
+    // cannot resurrect the family silently.
+    for source in [
+        r#"export const someValue = "a string";"#,
+        r#"export let otherValue = "a string";"#,
+        r#"export type Alias = "a string";"#,
+        r#"namespace Inner { export const z = 1; } export import Renamed = Inner;"#,
+        r#"export function renamed(): "lit" { return "lit"; }"#,
+    ] {
+        for module in [ModuleKind::ES2015, ModuleKind::ES2020] {
+            assert_eq!(
+                count_18057(module, source),
+                0,
+                "TS18057 must not fire for {source:?} under {module:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn the_namespace_export_name_still_reports_on_the_two_restricted_targets() {
+    // The one production whose clause *is* a module export name. This is what
+    // the gate must keep reaching; it is the positive half of the same rule.
+    for module in [ModuleKind::ES2015, ModuleKind::ES2020] {
+        assert_eq!(
+            count_18057(module, r#"export * as "ns name" from "target";"#),
+            1,
+            "the namespace export name must still draw TS18057 under {module:?}"
+        );
+    }
+    for module in [ModuleKind::ES2022, ModuleKind::CommonJS] {
+        assert_eq!(
+            count_18057(module, r#"export * as "ns name" from "target";"#),
+            0,
+            "the namespace export name is accepted under {module:?}"
+        );
+    }
+}
+
+#[test]
+fn an_identifier_namespace_export_name_never_reports() {
+    // The negative twin of the row above: same production, name is not a
+    // string, so the gate reaching it must still change nothing.
+    for module in ALL_MODULE_TARGETS {
+        assert_eq!(
+            count_18057(module, r#"export * as renamedNs from "target";"#),
+            0,
+            "an identifier namespace export name must stay clean under {module:?}"
+        );
+    }
+}
+
+#[test]
+fn a_default_export_beside_a_real_string_export_name_reports_exactly_once() {
+    // The discriminating row: both productions in one file. Only the specifier
+    // is a name, so the count pins "one", which neither a blanket report nor a
+    // blanket suppression can satisfy.
+    let source = r#"const q = 1;
+export default "./foo";
+export { q as "real name" };"#;
+    for module in [ModuleKind::ES2015, ModuleKind::ES2020] {
+        assert_eq!(
+            count_18057(module, source),
+            1,
+            "exactly the export specifier's name reports under {module:?}"
+        );
+    }
+}
+
+#[test]
+fn the_conformance_row_shape_is_clean_end_to_end() {
+    // `conformance/dynamicImport/importCallExpressionNested*.ts` in one line:
+    // a module whose default export is a path string, consumed by a nested
+    // dynamic import. Four rows regressed on exactly this.
+    let source = with_target(
+        r#"export default "./foo";
+export const later = () => import("target");"#,
+    );
+    for module in [ModuleKind::ES2015, ModuleKind::ES2020] {
+        assert_eq!(
+            count_18057(module, &source),
+            0,
+            "the conformance row shape must be clean under {module:?}"
+        );
+    }
+}


### PR DESCRIPTION
Fixes the TS18057 false positive filed in #16393 — `export default "./foo"` reports `TS18057` under `--module es2015`/`es2020` where `tsc` is silent, costing 4 conformance rows.

**Structural rule.** When an export declaration's `export_clause` holds anything other than the `<name>` of `export * as <name> from "m"`, `tsc` never routes it through `checkModuleExportName`; tsz now does the same, through the checker's `declarations/module_export_names` gate.

### The mechanism is a node-shape collision, not the predicate

#16393 proposes gating "on the export **name** node being a `StringLiteral`, not on the exported expression" — but `check_module_export_name` already tests only the node handed to it, and both `allowStringLiteral` branches are already faithful. Reading the predicate alone, it looks correct.

The defect is one frame up. tsz builds no distinct `NamespaceExport` node, so `ExportDeclData::export_clause` is reused by **five** unrelated productions:

| production | what `export_clause` holds | a module export name? |
| --- | --- | --- |
| `export * as <name> from "m"` | the namespace name | **yes** |
| `export { … }` | the `NAMED_EXPORTS` clause | handled by its own arm |
| `export default <expr>` | the **default-exported expression** | no |
| `export import X = Y` | the `import X = Y` declaration | no |
| `export <declaration>` | the declaration | no |

`check_export_declaration_module_export_names` reasoned *"the clause is not `NAMED_EXPORTS`, therefore the clause is the namespace name"*, so all four non-name productions were handed to `checkModuleExportName`. A default-export expression is the only one of the four that can currently be a `StringLiteral`, which is why it is the only one with a witness — the other three are misread today and silent only by luck.

That also reframes the issue's control: `export default 42` staying clean does **not** isolate the predicate: it is a `NumericLiteral` failing the string-literal test one frame later, having already been misidentified as a name.

`parse_export_star` is the sole producer of a namespace name and always parses a `from` clause, so `!is_default_export && module_specifier.is_some()` selects exactly that production. No new plumbing, no name/text inspection.

```rust
const fn export_clause_is_namespace_export_name(export_decl: &ExportDeclData) -> bool {
    !export_decl.is_default_export && export_decl.module_specifier.is_some()
}
```

## Goal
Goal: hold

## Verification

**Oracle matrix — 18 export shapes × 4 module targets (`es2015`, `es2020`, `es2022`, `commonjs`), sorted diagnostic-code sets against `typescript@7.0.2 --noEmit --target es2020`:**

| | before | after |
| --- | --- | --- |
| rows matching `tsc` | 70 / 72 | **72 / 72** |
| rows diverging | 2 | **0** |

Exactly two rows moved, both in the fixing direction; no row moved away from `tsc`:

```
r01_default_string  es2015   tsc: -            tsz: TS18057  ->  tsz: -   ok
r01_default_string  es2020   tsc: -            tsz: TS18057  ->  tsz: -   ok
```

True positives held byte-identical across the same run, including the ones the gate must still reach:

```
r04_star_as_string      es2015/es2020   TS18057          unchanged
r08_named_prop_string   es2015/es2020   TS1003,TS18057   unchanged
r09_named_from_string   es2015/es2020   TS18057          unchanged
r12_import_prop_string  es2015/es2020   TS18057          unchanged
```

**Unit — `cargo test -p tsz-checker --test string_literal_module_export_name_grammar_tests`: 39 passed, 0 failed** (was 31; 8 new). Adjacent-case matrix, all oracle-pinned:

- the witness across all 8 module targets, and across 8 string-valued default-export expression shapes (bare literal, empty string, spaces, two differently-named bindings, concatenation, array, object) — **renamed binders throughout, nothing keys on an identifier or path text**;
- non-string default exports (`42`, named/anonymous `class`, `function`, identifier) as the negative control across all 8 targets;
- the other three clause-sharing productions (`export const`/`let`/`type`, `export import X = Y`, `export function`), pinned so a future parser change that lets one hold a string literal cannot resurrect the family silently;
- the positive half: `export * as "ns name" from "target"` still draws exactly one TS18057 under `es2015`/`es2020` and none under `es2022`/`commonjs`; its identifier twin stays clean everywhere;
- the discriminating row — a default export *and* a real string export name in one file report **exactly one** TS18057, which neither a blanket report nor a blanket suppression satisfies;
- the conformance row shape end to end (default-exported path string + nested dynamic import).

**`cargo fmt --all` and `cargo clippy --workspace --all-targets -- -D warnings`: clean.**

**`scripts/conformance/compare-to-parent.sh origin/main`: launched at PR-open time, result posted as a comment when it lands.** The 4 rows this is expected to move are named in #16393 — `conformance/dynamicImport/importCallExpressionNested{ES2015,ES20152,ES2020,ES20202}.ts`, all carrying `export default "./foo";` at line 6.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Sylvite

---
_Generated by [Claude Code](https://claude.ai/code/session_016biuceQpdDWahnhnqmguqX)_