### PR TITLE
[WIP] fix(checker): a position-invalid import/export resolves no module specifier

### DIFF
--- a/crates/tsz-checker/src/declarations/import/declaration_check_body.rs
+++ b/crates/tsz-checker/src/declarations/import/declaration_check_body.rs
@@ -159,10 +159,18 @@ impl<'a> CheckerState<'a> {
             .is_some_and(|clause| clause.is_type_only);
 
         // Suppress semantic diagnostics (TS2307, TS2823, TS2322) when the import
-        // statement has parse errors. A wrong module-element context is a grammar
-        // diagnostic, not a reason to skip module/member validation: tsc still
-        // reports missing modules and missing named exports for imports in a bare
-        // block after TS1232.
+        // statement has parse errors.
+        //
+        // A wrong module-element context no longer reaches here on a parse-error-free
+        // file: the dispatcher short-circuits the whole declaration when
+        // `check_grammar_module_element_context` reports TS1232, because tsc's
+        // `checkImportDeclaration` returns at that point and resolves no specifier.
+        // (The earlier note here claimed tsc still reports missing modules and missing
+        // named exports for an import in a bare block — measured against tsc 7.0.2, it
+        // does not; a bare block behaves exactly like a function body.) The
+        // context-sensitive terms below therefore only still govern the
+        // `has_syntax_parse_errors` path, where the grammar check declines to report
+        // and the declaration is checked anyway.
         let in_wrong_context = self.is_in_non_module_element_context(stmt_idx);
         let wrong_context_allows_module_semantics = in_wrong_context
             && !self.is_inside_function_body(stmt_idx)

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -519,6 +519,9 @@ mod jsdoc_enum_circular_tests;
 #[cfg(test)]
 #[path = "../tests/jsdoc_function_return_type_anchor_tests.rs"]
 mod jsdoc_function_return_type_anchor_tests;
+#[cfg(test)]
+#[path = "../tests/position_invalid_module_element_resolution_tests.rs"]
+mod position_invalid_module_element_resolution_tests;
 
 #[cfg(test)]
 #[path = "../tests/jsdoc_readonly_tests.rs"]

--- a/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
@@ -205,6 +205,16 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
                         crate::diagnostics::diagnostic_messages::EXPORT_DECLARATIONS_ARE_NOT_PERMITTED_IN_A_NAMESPACE,
                         crate::diagnostics::diagnostic_codes::EXPORT_DECLARATIONS_ARE_NOT_PERMITTED_IN_A_NAMESPACE,
                     );
+                    if has_from {
+                        // tsc reports this from `checkExternalImportOrExportDeclaration`,
+                        // which then returns false — the caller gates module resolution on
+                        // that result, so the specifier is never resolved and no TS2307
+                        // follows. Only the `from` form reaches the resolution path, and
+                        // only a non-ambient namespace reaches here at all: inside
+                        // `declare module "m"` the parent IS a module block, so resolution
+                        // still runs and TS2307 is still correct there.
+                        return;
+                    }
                 }
             }
 
@@ -1284,12 +1294,16 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
         }
     }
 
-    fn check_grammar_module_element_context(&mut self, stmt_idx: NodeIndex) -> bool {
+    fn check_grammar_module_element_context(
+        &mut self,
+        stmt_idx: NodeIndex,
+    ) -> crate::statements::ModuleElementContext {
         use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+        use crate::statements::ModuleElementContext;
 
         // Suppress grammar errors when file has parse errors (matches tsc behavior)
         if self.ctx.has_syntax_parse_errors {
-            return false;
+            return ModuleElementContext::Valid;
         }
 
         // Check if the parent is a valid module-element context (SourceFile or ModuleBlock).
@@ -1318,12 +1332,12 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
         };
 
         if is_valid_context {
-            return false;
+            return ModuleElementContext::Valid;
         }
 
         // Determine which error to emit based on the statement kind
         let Some(node) = self.ctx.arena.get(stmt_idx) else {
-            return false;
+            return ModuleElementContext::Valid;
         };
 
         let (message, code) = match node.kind {
@@ -1370,7 +1384,7 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
                     if is_namespace_or_module {
                         // Namespace/module gets its own error (TS1235/TS1234) from
                         // check_module_declaration. Don't also emit TS1233 for the export.
-                        return false;
+                        return ModuleElementContext::Valid;
                     } else if is_class_or_function_or_variable {
                         // TS1184: Modifiers cannot appear here.
                         (
@@ -1414,11 +1428,18 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
                     diagnostic_codes::AN_EXPORT_ASSIGNMENT_MUST_BE_AT_THE_TOP_LEVEL_OF_A_FILE_OR_MODULE_DECLARATION,
                 )
             }
-            _ => return false,
+            _ => return ModuleElementContext::Valid,
         };
 
         self.error_at_node(stmt_idx, message, code);
-        true
+        // TS1184 rejects the `export` MODIFIER on a wrapped declaration; tsc still
+        // checks that declaration. Every other code here rejects the statement's
+        // PLACEMENT, which ends tsc's check of it.
+        if code == diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE {
+            ModuleElementContext::ModifierError
+        } else {
+            ModuleElementContext::PlacementError
+        }
     }
 
     /// TS1184: Check if a declaration with `declare` modifier is inside a block context

--- a/crates/tsz-checker/src/statements.rs
+++ b/crates/tsz-checker/src/statements.rs
@@ -9,6 +9,34 @@ use tsz_parser::parser::node::NodeArena;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::TypeId;
 
+/// Outcome of the module-element placement grammar check.
+///
+/// tsc's `checkImportDeclaration`, `checkExportDeclaration` and
+/// `checkExportAssignment` each report their placement diagnostic and then
+/// `return`, so *nothing else in that declaration's check runs* — the module
+/// specifier is never resolved (no TS2307), re-exported and imported members are
+/// never validated (no TS2305), and the sibling grammar checks on the same
+/// declaration never fire either.
+///
+/// A modifier diagnostic is not a placement diagnostic. When the `export` prefixes
+/// a class/function/variable declaration inside a block, tsc reports TS1184 for the
+/// modifier and still checks the wrapped declaration, so its own diagnostics must
+/// continue to be reported.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ModuleElementContext {
+    /// The declaration is in a `SourceFile` or `ModuleBlock`, or the check declined
+    /// to report (the file has parse errors, or the form owns its placement
+    /// diagnostic elsewhere — `export namespace N {}` gets TS1235 from
+    /// `check_module_declaration`). The declaration's own checks run normally.
+    Valid,
+    /// A placement diagnostic was reported: TS1231/TS1232/TS1233/TS1258, or the
+    /// JS-file variants TS1473/TS1474. tsc stops checking the declaration here.
+    PlacementError,
+    /// TS1184 was reported for the `export` modifier on a wrapped declaration.
+    /// tsc keeps checking the wrapped declaration.
+    ModifierError,
+}
+
 /// Trait for statement checking callbacks.
 ///
 /// This trait defines the interface that `CheckerState` must implement
@@ -427,11 +455,16 @@ pub trait StatementCheckCallbacks {
 
     /// Check if a module element (import/export/namespace/ambient module) is in
     /// a valid context (`SourceFile` or `ModuleBlock`). If not, emit the appropriate
-    /// grammar error (TS1231-1235, TS1258). Returns true if the context is invalid
-    /// (error was emitted), false if the context is valid.
-    fn check_grammar_module_element_context(&mut self, stmt_idx: NodeIndex) -> bool {
+    /// grammar error (TS1231-1235, TS1258, TS1184).
+    ///
+    /// The returned [`ModuleElementContext`] tells the caller whether tsc would keep
+    /// checking the declaration — see that type's documentation.
+    fn check_grammar_module_element_context(
+        &mut self,
+        stmt_idx: NodeIndex,
+    ) -> ModuleElementContext {
         let _ = stmt_idx;
-        false
+        ModuleElementContext::Valid
     }
 
     /// TS1184: Check if a `declare` modifier on a variable/class/enum declaration
@@ -1061,8 +1094,13 @@ impl StatementChecker {
                 state.check_interface_declaration(stmt_idx);
             }
             syntax_kind_ext::EXPORT_DECLARATION => {
-                state.check_grammar_module_element_context(stmt_idx);
-                state.check_export_declaration(stmt_idx);
+                // A placement error ends tsc's `checkExportDeclaration` before it
+                // resolves the module specifier; TS1184 does not.
+                if state.check_grammar_module_element_context(stmt_idx)
+                    != ModuleElementContext::PlacementError
+                {
+                    state.check_export_declaration(stmt_idx);
+                }
             }
             syntax_kind_ext::TYPE_ALIAS_DECLARATION => {
                 state.check_type_alias_declaration(stmt_idx);
@@ -1117,10 +1155,19 @@ impl StatementChecker {
                 state.check_continue_statement(stmt_idx);
             }
             syntax_kind_ext::IMPORT_DECLARATION => {
-                state.check_grammar_module_element_context(stmt_idx);
-                state.check_import_declaration(stmt_idx);
+                // Same short-circuit as the export side: TS1232 ends
+                // `checkImportDeclaration` before any module resolution.
+                if state.check_grammar_module_element_context(stmt_idx)
+                    != ModuleElementContext::PlacementError
+                {
+                    state.check_import_declaration(stmt_idx);
+                }
             }
             syntax_kind_ext::IMPORT_EQUALS_DECLARATION => {
+                // Not short-circuited: tsc still reports TS2307 for a
+                // position-invalid `import x = require("m")` whose alias is
+                // referenced, so the referenced-alias rule in
+                // `check_import_equals_declaration` stays in charge.
                 state.check_grammar_module_element_context(stmt_idx);
                 state.check_import_equals_declaration(stmt_idx);
             }
@@ -1170,10 +1217,15 @@ impl StatementChecker {
                 }
             }
             syntax_kind_ext::EXPORT_ASSIGNMENT => {
-                state.check_grammar_module_element_context(stmt_idx);
-                // Export assignments are mainly checked in check_export_assignment
-                // at the source file level
-                state.get_type_of_node_with_request(stmt_idx, request);
+                // TS1231 ends tsc's `checkExportAssignment`, so the exported
+                // expression is never resolved (no TS2304 for an unknown name).
+                if state.check_grammar_module_element_context(stmt_idx)
+                    != ModuleElementContext::PlacementError
+                {
+                    // Export assignments are mainly checked in check_export_assignment
+                    // at the source file level
+                    state.get_type_of_node_with_request(stmt_idx, request);
+                }
             }
             _ => {
                 // Catch-all for other statement types, including a concise

--- a/crates/tsz-checker/tests/position_invalid_module_element_resolution_tests.rs
+++ b/crates/tsz-checker/tests/position_invalid_module_element_resolution_tests.rs
@@ -1,0 +1,354 @@
+//! A module-element declaration in a non-module-element context is checked no
+//! further — in particular its module specifier is never resolved.
+//!
+//! tsc's `checkImportDeclaration` / `checkExportDeclaration` / `checkExportAssignment`
+//! report the placement diagnostic and then `return`. Nothing downstream of that
+//! point runs, and `resolveExternalModuleName` — the only TS2307 site — is
+//! downstream of it. So `function f() { export * from "nope"; }` is TS1233 alone,
+//! not TS1233 + TS2307.
+//!
+//! Two shapes are deliberately *not* short-circuited, both pinned below:
+//!
+//! * TS1184. When the `export` prefixes a class/function/variable declaration in a
+//!   block, tsc rejects the modifier and still checks the wrapped declaration.
+//! * A `ModuleBlock` parent that is an ambient module. `declare module "amb" { ... }`
+//!   is a valid module-element context, so resolution runs and TS2307 is correct.
+//!
+//! All expectations were taken from `typescript@7.0.2` with
+//! `--strict --lib es2022 --target es2022 --module esnext --moduleResolution bundler`.
+
+use crate::context::CheckerOptions;
+use crate::state::CheckerState;
+use tsz_binder::BinderState;
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_parser::parser::ParserState;
+use tsz_solver::construction::TypeInterner;
+
+/// Check a single source with unresolved-import reporting on, so that a module
+/// specifier naming a nonexistent module would report TS2307 if it were resolved.
+fn check(source: &str) -> Vec<u32> {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        CheckerOptions {
+            module: ModuleKind::ESNext,
+            target: ScriptTarget::ESNext,
+            ..CheckerOptions::default()
+        },
+    );
+    checker.ctx.report_unresolved_imports = true;
+    checker.check_source_file(root);
+    let mut codes: Vec<u32> = checker.ctx.diagnostics.iter().map(|d| d.code).collect();
+    codes.sort_unstable();
+    codes
+}
+
+fn assert_codes(source: &str, expected: &[u32], what: &str) {
+    let actual = check(source);
+    assert_eq!(actual, expected, "{what}\nsource:\n{source}");
+}
+
+// ---------------------------------------------------------------------------
+// Export declarations: TS1233 alone, across every non-module-element container.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn export_star_in_function_body_reports_ts1233_without_ts2307() {
+    assert_codes(
+        r#"function f() {
+  export * from "nonexistent-module";
+}"#,
+        &[1233],
+        "a function body is not a module element context",
+    );
+}
+
+#[test]
+fn export_star_in_bare_block_reports_ts1233_without_ts2307() {
+    assert_codes(
+        r#"{
+  export * from "nonexistent-module";
+}"#,
+        &[1233],
+        "a bare block behaves exactly like a function body here",
+    );
+}
+
+#[test]
+fn export_star_in_if_block_reports_ts1233_without_ts2307() {
+    assert_codes(
+        r#"if (true) {
+  export * from "nonexistent-module";
+}"#,
+        &[1233],
+        "an if-statement block is not a module element context",
+    );
+}
+
+#[test]
+fn export_star_in_method_body_reports_ts1233_without_ts2307() {
+    assert_codes(
+        r#"class C {
+  m() {
+    export * from "nonexistent-module";
+  }
+}"#,
+        &[1233],
+        "a method body is not a module element context",
+    );
+}
+
+#[test]
+fn named_reexport_in_function_body_reports_ts1233_without_ts2307() {
+    assert_codes(
+        r#"function f() {
+  export { a } from "nonexistent-module";
+}
+const a = 1;"#,
+        &[1233],
+        "the named-reexport form short-circuits like the star form",
+    );
+}
+
+#[test]
+fn namespace_reexport_in_function_body_reports_ts1233_without_ts2307() {
+    assert_codes(
+        r#"function f() {
+  export * as ns from "nonexistent-module";
+}"#,
+        &[1233],
+        "the `export * as ns` form short-circuits like the star form",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Import declarations: the same rule, as the adjacent binder axis.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn import_in_bare_block_reports_ts1232_without_ts2307() {
+    assert_codes(
+        r#"{
+  import { a } from "nonexistent-module";
+}"#,
+        &[1232],
+        "an import in a bare block resolves nothing, same as in a function body",
+    );
+}
+
+#[test]
+fn import_in_function_body_reports_ts1232_without_ts2307() {
+    assert_codes(
+        r#"function f() {
+  import { a } from "nonexistent-module";
+}"#,
+        &[1232],
+        "an import in a function body resolves nothing",
+    );
+}
+
+#[test]
+fn namespace_import_in_loop_body_reports_ts1232_without_ts2307() {
+    assert_codes(
+        r#"for (;;) {
+  import * as x from "nonexistent-module";
+}"#,
+        &[1232],
+        "a loop body is not a module element context",
+    );
+}
+
+#[test]
+fn type_only_import_grammar_is_also_short_circuited_in_a_block() {
+    // tsc reports TS1232 alone here: TS1363 ("a type-only import can specify a
+    // default import or named bindings, but not both") lives downstream of the
+    // placement `return`, so it never fires.
+    assert_codes(
+        r#"{
+  import type A, { B } from "nonexistent-module";
+}"#,
+        &[1232],
+        "sibling grammar checks on the declaration are short-circuited too",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Export assignment / default export: the remaining placement codes.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn export_assignment_in_function_body_reports_ts1231_alone() {
+    assert_codes(
+        r#"function f() {
+  export = undefinedName;
+}"#,
+        &[1231],
+        "TS1231 ends the check, so the exported name is never resolved (no TS2304)",
+    );
+}
+
+/// The `export default` half of the same rule. Still failing: the placement
+/// short-circuit lands (TS1258 fires and `check_export_declaration` is skipped),
+/// but a *second* walker types the default-exported expression and reports
+/// TS2552 for the unknown name, so tsz emits `[1258, 2552]` where tsc emits
+/// `[1258]` alone. That walker is not the module-specifier resolution path this
+/// file is about, and it is reached for a top-level `export default` too — so
+/// gating it belongs with whoever owns the default-export expression pass, not
+/// here. Pinned to tsc's answer so closing it is deleting this attribute.
+#[test]
+#[ignore = "residual: a second walker types the default-exported expression; see doc comment"]
+fn export_default_in_bare_block_reports_ts1258_alone() {
+    assert_codes(
+        r#"{
+  export default undefinedName;
+}"#,
+        &[1258],
+        "TS1258 ends the check, so the exported expression is never resolved",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A namespace body is a ModuleBlock, so it takes the TS1194 arm instead — and
+// tsc's `checkExternalImportOrExportDeclaration` returns false there too.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn export_star_in_namespace_reports_ts1194_without_ts2307() {
+    assert_codes(
+        r#"namespace N {
+  export * from "nonexistent-module";
+}"#,
+        &[1194],
+        "TS1194 gates module resolution the same way TS1233 does",
+    );
+}
+
+#[test]
+fn named_reexport_in_namespace_reports_ts1194_without_ts2307() {
+    assert_codes(
+        r#"namespace N {
+  export { a } from "nonexistent-module";
+}
+const a = 1;"#,
+        &[1194],
+        "the named-reexport form takes the same TS1194 gate",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls. These must keep resolving.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn export_star_at_top_level_still_reports_ts2307() {
+    assert_codes(
+        r#"export * from "nonexistent-module";"#,
+        &[2307],
+        "the control: a well-placed re-export must still resolve its specifier",
+    );
+}
+
+#[test]
+fn export_star_inside_ambient_module_still_reports_ts2307() {
+    // The falsifying control for an ordering-based fix. `declare module "amb"` is a
+    // valid module-element context, so nothing is suppressed here — a fix keyed on
+    // "a placement diagnostic was already emitted for this file" would wrongly
+    // silence this row.
+    assert_codes(
+        r#"declare module "amb" {
+  export * from "nonexistent-module";
+}"#,
+        &[2307],
+        "an ambient module body is a valid context; resolution still runs",
+    );
+}
+
+#[test]
+fn import_at_top_level_still_reports_ts2307() {
+    assert_codes(
+        r#"import { a } from "nonexistent-module";"#,
+        &[2307],
+        "the control on the import side",
+    );
+}
+
+#[test]
+fn exported_class_in_a_block_still_checks_the_wrapped_declaration() {
+    // TS1184 rejects the MODIFIER, not the statement's placement. tsc keeps checking
+    // the class, so the unresolved return-type annotation must still report TS2304.
+    let codes = check(
+        r#"{
+  export class C { m(): NotAType { return 1; } }
+}"#,
+    );
+    assert!(
+        codes.contains(&1184),
+        "expected TS1184 for the export modifier, got {codes:?}"
+    );
+    assert!(
+        codes.contains(&2304),
+        "TS1184 must not short-circuit the wrapped declaration, got {codes:?}"
+    );
+}
+
+#[test]
+fn exported_variable_in_a_block_still_checks_the_wrapped_declaration() {
+    let codes = check(
+        r#"{
+  export const v: NotAType = 1;
+}"#,
+    );
+    assert!(
+        codes.contains(&1184),
+        "expected TS1184 for the export modifier, got {codes:?}"
+    );
+    assert!(
+        codes.contains(&2304),
+        "TS1184 must not short-circuit the wrapped declaration, got {codes:?}"
+    );
+}
+
+#[test]
+fn exported_function_in_a_block_still_checks_the_wrapped_declaration() {
+    let codes = check(
+        r#"{
+  export function f(): NotAType { return 1; }
+}"#,
+    );
+    assert!(
+        codes.contains(&1184),
+        "expected TS1184 for the export modifier, got {codes:?}"
+    );
+    assert!(
+        codes.contains(&2304),
+        "TS1184 must not short-circuit the wrapped declaration, got {codes:?}"
+    );
+}
+
+#[test]
+fn exported_namespace_in_a_block_still_checks_its_body() {
+    // `export namespace M {}` gets TS1235 from `check_module_declaration`, so the
+    // placement check declines to report and must not short-circuit: the inner
+    // re-export still reports its own TS1194.
+    let codes = check(
+        r#"{
+  export namespace M { export * from "nonexistent-module"; }
+}"#,
+    );
+    assert!(
+        codes.contains(&1235),
+        "expected TS1235 for the misplaced namespace, got {codes:?}"
+    );
+    assert!(
+        codes.contains(&1194),
+        "the namespace body must still be checked, got {codes:?}"
+    );
+}


### PR DESCRIPTION
`function f() { export * from "nope"; }` reported **TS1233 and TS2307**. tsc reports TS1233 alone.

**Structural rule.** When an import/export declaration sits in a non-module-element context, tsc reports the placement diagnostic and stops checking that declaration entirely — so it never resolves the module specifier; tsz now does the same through the **checker's statement dispatcher**, which consumes the placement check's own result instead of discarding it.

tsc's `checkImportDeclaration` / `checkExportDeclaration` / `checkExportAssignment` each report their placement diagnostic and then `return`. `resolveExternalModuleName` — the only TS2307 site — is downstream of that `return`, and so is everything else: no TS2305 for a missing member, and no sibling grammar checks on the same declaration (TS1363 and the import-attribute family are equally suppressed, both verified against the oracle).

**The predicate already existed and was being thrown away.** `check_grammar_module_element_context` returns a bool meaning "I reported", and all four call sites in `statements.rs` discarded it. Three downstream sites instead carried a hand-rolled proxy — `is_in_non_module_element_context && !is_inside_function_body && !is_inside_namespace_declaration` — whose comment asserted that *"tsc still reports missing modules and missing named exports for imports in a bare block after TS1232."* Measured against `typescript@7.0.2`, it does not: a bare block, an `if` block, a loop body and a method body all behave exactly like a function body. The proxy only ever made the function-body rows look right, which is why every other container leaked a TS2307.

**Why the return type became an enum.** Two codes that check emits are *not* placement errors, and both are pinned as controls:

- **TS1184** rejects the `export` **modifier** on a wrapped class/function/variable. tsc keeps checking the wrapped declaration, so `{ export class C { m(): NotAType {} } }` must still report TS2304.
- **`export namespace N {}`** owns its placement diagnostic elsewhere (TS1235, from `check_module_declaration`), so the check declines to report and the namespace body is still walked.

**`IMPORT_EQUALS_DECLARATION` is not short-circuited**, because tsc's answer there depends on something else: it reports TS2307 for a position-invalid `import x = require("m")` **only when the alias is referenced**. tsz's `namespace_import_alias_is_referenced` rule already models that and stays in charge. It is currently gated on `inside_namespace`, so it does not fire in a block — see residual 2 below.

**The namespace arm is the same rule one layer over.** A `ModuleBlock` parent *is* a valid context, so it takes tsc's other gate: `checkExternalImportOrExportDeclaration` reports TS1194 and returns `false`, which the caller uses to skip resolution. Emitting TS1194 for the `from` form now returns for the same reason.

**This is a short-circuit in the declaration's own check, not a suppression keyed on an already-emitted code** — and the falsifying control proves the difference: `declare module "amb" { export * from "nope"; }` **keeps** its TS2307, because an ambient module body is a valid module-element context. Any ordering-based "silence TS2307 after a placement error" fix passes the twelve suppressed rows and silently breaks that one.

## Goal
Goal: hold

## Verification

**Oracle matrix, `typescript@7.0.2`** (`--strict --lib es2022 --target es2022 --module esnext --moduleResolution bundler`), three-way tsc / main / branch, scored from a built branch binary — **main 7/24, branch 21/24, 0 rows moved away from tsc**:

| container | statement | tsc | main | branch |
| --- | --- | --- | --- | --- |
| function body | `export * from "m"` | TS1233 | TS1233 **+TS2307** | TS1233 ✅ |
| bare block | `export * from "m"` | TS1233 | TS1233 **+TS2307** | TS1233 ✅ |
| `if` block | `export * from "m"` | TS1233 | TS1233 **+TS2307** | TS1233 ✅ |
| method body | `export * from "m"` | TS1233 | TS1233 **+TS2307** | TS1233 ✅ |
| function body | `export { a } from "m"` | TS1233 | TS1233 **+TS2307** | TS1233 ✅ |
| function body | `export * as ns from "m"` | TS1233 | TS1233 **+TS2307** | TS1233 ✅ |
| bare block | `export { a } from "m"` | TS1233 | TS1233 **+TS2307** | TS1233 ✅ |
| bare block | `export { missing } from "./dep"` | TS1233 | TS1233 **+TS2307** | TS1233 ✅ |
| bare block | `import { a } from "m"` | TS1232 | TS1232 **+TS2307** | TS1232 ✅ |
| `if` block | `import { a } from "m"` | TS1232 | TS1232 **+TS2307** | TS1232 ✅ |
| loop body | `import * as x from "m"` | TS1232 | TS1232 **+TS2307** | TS1232 ✅ |
| bare block | `import type A, { B } from "m"` | TS1232 | TS1232 **+TS2307** | TS1232 ✅ |
| bare block | `import { missing } from "./dep"` | TS1232 | TS1232 **+TS2307** | TS1232 ✅ |
| namespace body | `export * from "m"` | TS1194 | TS1194 **+TS2307** | TS1194 ✅ |
| namespace body | `export { a } from "m"` | TS1194 | TS1194 **+TS2307** | TS1194 ✅ |
| function body | `import { a } from "m"` | TS1232 | TS1232 | TS1232 |
| function body | `import { missing } from "./dep"` | TS1232 | TS1232 | TS1232 |
| function body | `export = 1` | TS1231 | TS1231 | TS1231 |
| function body | `export default 1` | TS1258 | TS1258 | TS1258 |
| **top level (control)** | `export * from "m"` | TS2307 | TS2307 | TS2307 |
| **top level (control)** | `import { missing } from "./dep"` | TS2305 | TS2305 | TS2305 |
| **`declare module "amb"` (control)** | `export * from "m"` | TS2307 | TS2307 | TS2307 |
| namespace body | `import { a } from "m"` | TS1147 | TS2307 | TS2307 ❌ residual 1 |
| bare block | `import x = require("m")`, unreferenced | TS1232 | TS1232 +TS2307 | TS1232 +TS2307 ❌ residual 2 |

**15 rows fixed, 0 broken.** Three controls hold.

**Adjacent-case matrix (21 new unit rows, `position_invalid_module_element_resolution_tests.rs`)** — containers (function body / bare block / `if` block / loop body / method body / namespace body), forms (`export *`, `export * as ns`, `export {}`, `import {}`, `import * as`, `import type`, `export =`, `export default`), and the negative side: three controls that must keep resolving (top-level export, top-level import, ambient module body) plus four that must keep checking their wrapped declaration (`export class` / `export const` / `export function` → TS1184 + TS2304; `export namespace` → TS1235 + inner TS1194).

- `cargo test -p tsz-checker --lib position_invalid_module_element` — **20 passed, 0 failed, 1 ignored**
- `cargo test -p tsz-checker --lib` (full) — **9587 run, 1 failure: `ts2303_tests::recursive_export_assignment_self_import_reports_ts2303`**, pre-existing red on `main` and unrelated (filed as #16406; flagged on the coordination board at 22:27Z as *"treat a lone failure with that name as known, not as your diff"*)
- `cargo fmt --all` clean; `cargo clippy -p tsz-checker` and the architecture guard both green via the pre-commit hook

### Known residuals — all pre-existing, none fixed here, none regressions

1. **`import ... from "m"` inside a namespace should report TS1147**, which tsz never emits at all (2 rows). Untouched by this PR.
2. **`import x = require("m")` in a block with an *unreferenced* alias** should report TS1232 alone. tsc's rule here is the referenced-alias rule, which tsz already models — it is just gated on `inside_namespace` and so never applies in a block. A one-predicate extension on a different arm; deliberately not bundled in.
3. **`{ export default undefinedName; }`** gives `[TS1258, TS2552]` vs tsc's `[TS1258]`. The placement short-circuit lands correctly (TS1258 fires, `check_export_declaration` is skipped) — a *second* walker types the default-exported expression, and it is reached for a top-level `export default` too, so gating it belongs with the default-export expression pass. Pinned as an `#[ignore]`d test asserting tsc's answer, so closing it is deleting the attribute.

I originally wrote "22/24, two residuals" in this body from a predicted matrix; the measured run says 21/24 and three. Corrected here, with the reasoning error recorded in the first PR comment.

**`compare-to-parent.sh origin/main` is OWED** at head `daad84e` — corpus fetched in this container, launched at PR-open time. Please do not queue this before that number lands. Expected direction: the corpus is thin on files pairing a misplaced import/export with an unresolvable specifier, so 0 newly-failing / 0 newly-passing is the likely signature (the board's standing gotcha for this family), with the oracle matrix as the primary evidence.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Azurite