### PR TITLE
fix(checker): a position-invalid `import =` in a declaration scope resolves its specifier when the alias is referenced

### DIFF
--- a/crates/tsz-checker/src/declarations/import/equals.rs
+++ b/crates/tsz-checker/src/declarations/import/equals.rs
@@ -821,9 +821,24 @@ impl<'a> CheckerState<'a> {
             return;
         };
 
-        // When the import-equals is inside a function body (not just a block),
-        // skip module resolution errors. tsc doesn't resolve require() inside functions.
-        if in_wrong_context && self.is_inside_function_body(stmt_idx) {
+        // A position-invalid `import =` inside a declaration scope resolves its
+        // specifier only when the alias is referenced. What reaches
+        // `resolveExternalModuleName` in tsc is `markAliasReferenced`, so the
+        // discriminator is the use, not the position — the same rule the namespace
+        // arm above already applies via `namespace_import_alias_is_referenced`.
+        //
+        // The scope test is what keeps this narrow. A bare block, an `if` body and a
+        // loop body are not declaration scopes, and tsc resolves in all three however
+        // the alias is used; only a function body, a method body, a static block and a
+        // namespace body suppress. #16489 draws the same line for `export ... from`.
+        //
+        // This condition used to be unqualified, under the comment "tsc doesn't
+        // resolve require() inside functions". It does — when the alias is
+        // referenced — so the unqualified form swallowed a TS2307 that tsc reports.
+        if in_wrong_context
+            && self.is_inside_function_body(stmt_idx)
+            && !self.import_alias_is_referenced(stmt_idx)
+        {
             return;
         }
 
@@ -1872,12 +1887,57 @@ impl<'a> CheckerState<'a> {
             return true;
         }
 
-        let mut stack: Vec<NodeIndex> = self
-            .ctx
-            .arena
-            .get_children(module_decl.body)
-            .into_iter()
-            .collect();
+        self.alias_is_referenced_under(module_decl.body, import_decl_node, import_alias_sym_id)
+    }
+
+    /// Is the alias declared by a position-invalid `import =` at `import_decl_node`
+    /// referenced anywhere in its source file?
+    ///
+    /// The declaration-scope counterpart of `namespace_import_alias_is_referenced`.
+    /// It scans from the `SourceFile` rather than from the enclosing function body
+    /// because the test is symbol identity, not position: only an identifier that
+    /// resolves to *this* alias counts, so widening the walk cannot produce a false
+    /// positive, and it does catch a use from a nested closure.
+    ///
+    /// Defaults to `true` (resolve the specifier) whenever the alias has no symbol
+    /// or no enclosing file, matching the pre-existing behaviour of both callers.
+    fn import_alias_is_referenced(&self, import_decl_node: NodeIndex) -> bool {
+        let Some(import_alias_sym_id) = self.ctx.binder.get_node_symbol(import_decl_node) else {
+            return true;
+        };
+
+        let mut scan_root = import_decl_node;
+        loop {
+            if self
+                .ctx
+                .arena
+                .get(scan_root)
+                .is_some_and(|node| node.kind == syntax_kind_ext::SOURCE_FILE)
+            {
+                break;
+            }
+            let Some(ext) = self.ctx.arena.get_extended(scan_root) else {
+                return true;
+            };
+            if ext.parent.is_none() {
+                return true;
+            }
+            scan_root = ext.parent;
+        }
+
+        self.alias_is_referenced_under(scan_root, import_decl_node, import_alias_sym_id)
+    }
+
+    /// Does any identifier under `scan_root`, other than the declaration itself,
+    /// resolve to `import_alias_sym_id`?
+    fn alias_is_referenced_under(
+        &self,
+        scan_root: NodeIndex,
+        import_decl_node: NodeIndex,
+        import_alias_sym_id: tsz_binder::SymbolId,
+    ) -> bool {
+        let mut stack: Vec<NodeIndex> =
+            self.ctx.arena.get_children(scan_root).into_iter().collect();
         while let Some(current_idx) = stack.pop() {
             if current_idx == import_decl_node {
                 continue;

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -169,6 +169,9 @@ mod generator_union_return_type_tests;
 #[path = "../tests/heritage_type_only_tests.rs"]
 mod heritage_type_only_tests;
 #[cfg(test)]
+#[path = "../tests/import_equals_referenced_alias_resolution_tests.rs"]
+mod import_equals_referenced_alias_resolution_tests;
+#[cfg(test)]
 #[path = "../tests/imported_generator_iterable_tests.rs"]
 mod imported_generator_iterable_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/tests/import_equals_referenced_alias_resolution_tests.rs
+++ b/crates/tsz-checker/tests/import_equals_referenced_alias_resolution_tests.rs
@@ -1,0 +1,307 @@
+//! A position-invalid `import x = require("m")` inside a **declaration scope**
+//! resolves its module specifier only when the alias is referenced.
+//!
+//! What reaches `resolveExternalModuleName` in tsc is `markAliasReferenced`, so the
+//! discriminator is the *use*, not the position:
+//!
+//! ```text
+//! function f() { import x = require("nope"); }      tsc: TS1232 alone
+//! function f() { import x = require("nope"); x; }   tsc: TS1232 + TS2307
+//! ```
+//!
+//! tsz already modelled this for a namespace body
+//! (`namespace_import_alias_is_referenced`). A function body, a method body and a
+//! class static block took a different path — an unqualified early return under the
+//! comment *"tsc doesn't resolve require() inside functions"*. It does, when the
+//! alias is referenced, so that arm **swallowed** a TS2307 tsc reports.
+//!
+//! The scope test is what keeps the rule narrow, and it is the half that is easy to
+//! get backwards. A bare block, an `if` body and a loop body are **not** declaration
+//! scopes: tsc resolves the specifier in all three *however the alias is used*, so
+//! they must keep reporting TS2307 even when nothing references the alias. #16489
+//! draws the same line for `export ... from`. Every one of those rows is pinned
+//! below as a negative control, because a "suppress when unreferenced" rule applied
+//! uniformly across containers passes the declaration-scope rows and silently breaks
+//! these.
+//!
+//! Expectations were taken from `scripts/conformance/oracle.sh` — the pinned
+//! `typescript@7.0.2` run with the same `--singleThreaded --stableTypeOrdering`
+//! flags the conformance cache generator uses. Per #16413 that matters here: a bare
+//! block's diagnostics differ between schedulers, so a plain `tsc file.ts` disagrees
+//! with what the gate actually scores for exactly this family.
+
+use crate::context::CheckerOptions;
+use crate::state::CheckerState;
+use tsz_binder::BinderState;
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_parser::parser::ParserState;
+use tsz_solver::construction::TypeInterner;
+
+/// TS1232: An import declaration can only be used at the top level of a namespace or module.
+const TS1232: u32 = 1232;
+/// TS1147: Import declarations in a namespace cannot reference a module.
+const TS1147: u32 = 1147;
+/// TS1202: Import assignment cannot be used when targeting ECMAScript modules.
+const TS1202: u32 = 1202;
+/// TS2307: Cannot find module '...' or its corresponding type declarations.
+const TS2307: u32 = 2307;
+
+/// Check a single source with unresolved-import reporting on, so that a module
+/// specifier naming a nonexistent module reports TS2307 if it is resolved at all.
+fn check(source: &str) -> Vec<u32> {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        CheckerOptions {
+            module: ModuleKind::ESNext,
+            target: ScriptTarget::ESNext,
+            ..CheckerOptions::default()
+        },
+    );
+    checker.ctx.report_unresolved_imports = true;
+    checker.check_source_file(root);
+    let mut codes: Vec<u32> = checker.ctx.diagnostics.iter().map(|d| d.code).collect();
+    codes.sort_unstable();
+    codes
+}
+
+fn assert_codes(source: &str, expected: &[u32], what: &str) {
+    let actual = check(source);
+    assert_eq!(actual, expected, "{what}\nsource:\n{source}");
+}
+
+const DECL: &str = r#"import x = require("nonexistent-module");"#;
+
+fn unreferenced(container: &str) -> String {
+    container.replace("BODY", DECL)
+}
+
+fn referenced(container: &str) -> String {
+    container.replace("BODY", &format!("{DECL}\nx;"))
+}
+
+// Declaration scopes: the referenced-alias rule applies.
+const FUNCTION_BODY: &str = "function f() {\nBODY\n}";
+const METHOD_BODY: &str = "class C { m() {\nBODY\n} }";
+const STATIC_BLOCK: &str = "class C { static {\nBODY\n} }";
+const NAMESPACE_BODY: &str = "namespace N {\nBODY\n}";
+
+// Not declaration scopes: resolution runs regardless of use.
+const BARE_BLOCK: &str = "{\nBODY\n}";
+const IF_BLOCK: &str = "if (true) {\nBODY\n}";
+const LOOP_BODY: &str = "for (;;) {\nBODY\n}";
+
+// ---------------------------------------------------------------------------
+// Declaration scope, alias unreferenced: the placement diagnostic alone.
+// These already held before the fix; they are here to keep it that way.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unreferenced_alias_in_function_body_does_not_resolve_the_specifier() {
+    assert_codes(
+        &unreferenced(FUNCTION_BODY),
+        &[TS1232],
+        "function body, alias never used",
+    );
+}
+
+#[test]
+fn unreferenced_alias_in_method_body_does_not_resolve_the_specifier() {
+    assert_codes(
+        &unreferenced(METHOD_BODY),
+        &[TS1232],
+        "method body, alias never used",
+    );
+}
+
+#[test]
+fn unreferenced_alias_in_static_block_does_not_resolve_the_specifier() {
+    assert_codes(
+        &unreferenced(STATIC_BLOCK),
+        &[TS1232],
+        "class static block, alias never used",
+    );
+}
+
+#[test]
+fn unreferenced_alias_in_namespace_body_does_not_resolve_the_specifier() {
+    assert_codes(
+        &unreferenced(NAMESPACE_BODY),
+        &[TS1147],
+        "namespace body, alias never used",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Declaration scope, alias referenced: resolution runs. This is the half the
+// unqualified early return was swallowing.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn referenced_alias_in_function_body_resolves_the_specifier() {
+    assert_codes(
+        &referenced(FUNCTION_BODY),
+        &[TS1232, TS2307],
+        "function body, alias used",
+    );
+}
+
+#[test]
+fn referenced_alias_in_method_body_resolves_the_specifier() {
+    assert_codes(
+        &referenced(METHOD_BODY),
+        &[TS1232, TS2307],
+        "method body, alias used",
+    );
+}
+
+#[test]
+fn referenced_alias_in_static_block_resolves_the_specifier() {
+    assert_codes(
+        &referenced(STATIC_BLOCK),
+        &[TS1232, TS2307],
+        "class static block, alias used",
+    );
+}
+
+#[test]
+fn referenced_alias_in_namespace_body_resolves_the_specifier() {
+    assert_codes(
+        &referenced(NAMESPACE_BODY),
+        &[TS1147, TS2307],
+        "namespace body, alias used",
+    );
+}
+
+#[test]
+fn alias_referenced_only_from_a_nested_closure_resolves_the_specifier() {
+    assert_codes(
+        "function f() {\nimport x = require(\"nonexistent-module\");\nconst g = () => x;\n}",
+        &[TS1232, TS2307],
+        "function body, alias used only inside a nested arrow",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// NEGATIVE CONTROLS — a block-like container is not a declaration scope, so it
+// resolves the specifier whether or not the alias is used. A "suppress when
+// unreferenced" rule applied uniformly across containers passes every test above
+// and breaks all five of these.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_bare_block_resolves_the_specifier_even_when_unreferenced() {
+    assert_codes(
+        &unreferenced(BARE_BLOCK),
+        &[TS1232, TS2307],
+        "bare block is not a declaration scope",
+    );
+}
+
+#[test]
+fn an_if_block_resolves_the_specifier_even_when_unreferenced() {
+    assert_codes(
+        &unreferenced(IF_BLOCK),
+        &[TS1232, TS2307],
+        "`if` body is not a declaration scope",
+    );
+}
+
+#[test]
+fn a_loop_body_resolves_the_specifier_even_when_unreferenced() {
+    assert_codes(
+        &unreferenced(LOOP_BODY),
+        &[TS1232, TS2307],
+        "loop body is not a declaration scope",
+    );
+}
+
+#[test]
+fn a_bare_block_resolves_the_specifier_when_referenced_too() {
+    assert_codes(
+        &referenced(BARE_BLOCK),
+        &[TS1232, TS2307],
+        "bare block, alias used",
+    );
+}
+
+#[test]
+fn a_shadowed_alias_in_a_bare_block_still_resolves_the_specifier() {
+    // The use resolves to the inner `let x`, so the alias is unreferenced — and it
+    // still resolves, because the container is a block. Same verdict as the plain
+    // unreferenced block row, reached by a different route.
+    assert_codes(
+        "{\nimport x = require(\"nonexistent-module\");\n{ let x = 1; x; }\n}",
+        &[TS1232, TS2307],
+        "bare block, alias shadowed at the use site",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Symbol identity, not spelling: the anti-hardcoding axis.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_shadowing_local_is_not_a_reference_to_the_alias() {
+    // Inside a declaration scope, where the referenced-alias rule is live, the
+    // shadowing local must not count as a use.
+    assert_codes(
+        "function f() {\nimport x = require(\"nonexistent-module\");\n{ let x = 1; x; }\n}",
+        &[TS1232],
+        "function body, the only `x` at the use site is a shadowing local",
+    );
+}
+
+#[test]
+fn the_rule_does_not_depend_on_the_binder_name() {
+    assert_codes(
+        "function f() {\nimport someLongAliasName = require(\"nonexistent-module\");\n}",
+        &[TS1232],
+        "renamed binder, alias never used",
+    );
+    assert_codes(
+        "function f() {\nimport someLongAliasName = require(\"nonexistent-module\");\nsomeLongAliasName;\n}",
+        &[TS1232, TS2307],
+        "renamed binder, alias used",
+    );
+}
+
+#[test]
+fn each_alias_in_a_declaration_scope_is_judged_on_its_own_use() {
+    // Only `a` is used, so only `a`'s specifier resolves — one TS2307, not two.
+    assert_codes(
+        "function f() {\nimport a = require(\"nonexistent-a\");\nimport b = require(\"nonexistent-b\");\na;\n}",
+        &[TS1232, TS1232, TS2307],
+        "function body, two aliases, one of them used",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Controls: a valid position resolves regardless of use.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn top_level_import_equals_resolves_when_unreferenced() {
+    assert_codes(
+        "import x = require(\"nonexistent-module\");",
+        &[TS1202, TS2307],
+        "control: valid position, alias never used",
+    );
+}
+
+#[test]
+fn top_level_import_equals_resolves_when_referenced() {
+    assert_codes(
+        "import x = require(\"nonexistent-module\");\nx;",
+        &[TS1202, TS2307],
+        "control: valid position, alias used",
+    );
+}

--- a/crates/tsz-checker/tests/import_equals_referenced_alias_resolution_tests.rs
+++ b/crates/tsz-checker/tests/import_equals_referenced_alias_resolution_tests.rs
@@ -12,7 +12,7 @@
 //! tsz already modelled this for a namespace body
 //! (`namespace_import_alias_is_referenced`). A function body, a method body and a
 //! class static block took a different path — an unqualified early return under the
-//! comment *"tsc doesn't resolve require() inside functions"*. It does, when the
+//! comment *"tsc doesn't resolve `require()` inside functions"*. It does, when the
 //! alias is referenced, so that arm **swallowed** a TS2307 tsc reports.
 //!
 //! The scope test is what keeps the rule narrow, and it is the half that is easy to


### PR DESCRIPTION
`function f() { import x = require("nope"); x; }` reports **TS1232 alone**. tsc reports TS1232 **+ TS2307**. Same for a method body and a class static block. The unreferenced twin is TS1232 alone in both and was already correct.

This is an **under**-report, which is why it survived #16489, #16453 and #16437 — each of those closed an over-reporting row in this family, and a probe that only checks whether a spurious diagnostic went away cannot see a missing one.

> **This PR was re-scoped after review.** Its first version applied a "suppress when unreferenced" rule uniformly across containers, which measured against `oracle.sh` would have **regressed five rows that are green on main**. That version was wrong and is gone; the branch is reset onto `d3c5bb0`. See the discussion below for the measurements that turned it around.

**Structural rule.** When an `import =` declaration sits in a non-module-element position **inside a declaration scope**, tsc reports the placement diagnostic and resolves the module specifier only if the alias is referenced; tsz now does the same through the checker's `import =` declaration check, by qualifying an early return with the referenced-alias predicate the namespace arm already used.

What reaches `resolveExternalModuleName` in tsc is `markAliasReferenced`, so the discriminator is the **use**, not the position.

## The bug was one unqualified condition

```rust
// When the import-equals is inside a function body (not just a block),
// skip module resolution errors. tsc doesn't resolve require() inside functions.
if in_wrong_context && self.is_inside_function_body(stmt_idx) {
    return;
}
```

The comment's premise is false — tsc does resolve there, when the alias is referenced — so this swallowed a TS2307 tsc reports. The namespace arm four hundred lines above already implemented the correct rule (`namespace_import_alias_is_referenced`), which is exactly why the namespace rows pass today and the function/method/static-block rows do not. The fix qualifies the return and adds the file-scoped sibling of that walk:

```rust
if in_wrong_context
    && self.is_inside_function_body(stmt_idx)
    && !self.import_alias_is_referenced(stmt_idx)
{
    return;
}
```

## The scope test is what keeps it narrow, and it is the half that inverts

A **bare block, an `if` body and a loop body are not declaration scopes**. tsc resolves the specifier in all three *however the alias is used*, so they must keep reporting TS2307 even when nothing references the alias. #16489 draws the same line for `export ... from`. Those containers never reach the branch above, so this diff cannot move them — and five negative controls pin that.

**Symbol identity, not spelling.** The walk compares `resolve_identifier_symbol(...)` against the alias's `SymbolId`: a shadowing inner `let x` is not a use, a use from a nested closure is, and two aliases in one scope are judged independently. No name, file-name or rendered-text predicate.

## Goal
Goal: hold

## Verification

**Three-way CLI matrix — 18 rows, `oracle.sh` vs a `dist-fast` binary from each side.** Expectations come from `scripts/conformance/oracle.sh`, *not* a bare `tsc` invocation: per #16413 a bare block's diagnostics are scheduler-sensitive for exactly this family, and that is what mis-scoped the first version of this PR.

| row | tsc (`oracle.sh`) | main `d3c5bb0` | branch `b246f70` |
| --- | --- | --- | --- |
| function body, unreferenced | TS1232 | TS1232 | TS1232 |
| **function body, referenced** | **TS1232, TS2307** | **TS1232** ❌ | **TS1232, TS2307** ✅ |
| method body, unreferenced | TS1232 | TS1232 | TS1232 |
| **method body, referenced** | **TS1232, TS2307** | **TS1232** ❌ | **TS1232, TS2307** ✅ |
| static block, unreferenced | TS1232 | TS1232 | TS1232 |
| **static block, referenced** | **TS1232, TS2307** | **TS1232** ❌ | **TS1232, TS2307** ✅ |
| namespace body, unreferenced | TS1147 | TS1147 | TS1147 |
| namespace body, referenced | TS1147, TS2307 | TS1147, TS2307 | TS1147, TS2307 |
| bare block, unreferenced | TS1232, TS2307 | TS1232, TS2307 | TS1232, TS2307 |
| bare block, referenced | TS1232, TS2307 | TS1232, TS2307 | TS1232, TS2307 |
| `if` block, unreferenced / referenced | TS1232, TS2307 | TS1232, TS2307 | TS1232, TS2307 |
| loop body, unreferenced / referenced | TS1232, TS2307 | TS1232, TS2307 | TS1232, TS2307 |
| bare block, alias shadowed at use site | TS1232, TS2307 | TS1232, TS2307 | TS1232, TS2307 |
| bare block, two aliases one used | TS1232, TS2307 | TS1232, TS2307 | TS1232, TS2307 |
| top level, unreferenced / referenced | TS1202, TS2307 | TS1202, TS2307 | TS1202, TS2307 |

**Rows differing from tsc — main 3/18, branch 0/18. 3 rows fixed, 0 moved away.**

**Adjacent-case matrix** — `crates/tsz-checker/tests/import_equals_referenced_alias_resolution_tests.rs`, 19 rows: four declaration-scope containers × referenced/unreferenced, the nested-closure use, **five negative controls** asserting block-like containers keep TS2307 either way, the shadowing negative, the renamed-binder pair, per-alias independence, and both top-level controls.

- `cargo test -p tsz-checker --lib import_equals_referenced_alias` — **19 passed, 0 failed, 0 ignored**
- `scripts/conformance/compare-to-parent.sh origin/main` — **0 newly failing / 0 newly passing / 0 fingerprint-changed**; `base failing=548  branch failing=548`, both sides 11494 passed. Expected signature: the corpus has no fixture pairing a *referenced* `import =` alias with an unresolvable specifier inside a declaration scope, so the oracle matrix is the primary evidence and this is the regression floor. (The first version of this PR was `NEWLY FAILING (1)` on `moduleElementsInWrongContext.ts`, so the gate does bite on this diff shape.)
- `cargo clippy --profile ci-lint --workspace --all-targets -- -D warnings` clean; `cargo fmt --all` clean; architecture guard passed
- CI green at exact head `b246f70` — clippy / arch-size / CI Summary, run `31050434957`, `head_sha` verified

Note the five negative controls are the point of the test file, not padding: a uniform "suppress when unreferenced" rule passes every other row in it and breaks all five. That is the mistake this PR made in its first version, now pinned so it cannot recur.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Azurite