### PR TITLE
fix(parser): readonly/override before export take their own diagnostic (#16403 slice 2)

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -557,6 +557,7 @@ const fn is_parser_grammar_code(code: u32) -> bool {
         | 1210 // Code contained in a class is evaluated in strict mode
         | 1212 // Identifier expected. '{0}' is a reserved word in strict mode
         | 1213 // Identifier expected. '{0}' is a reserved word in strict mode. Class definitions are automatically in strict mode.
+        | 1024 // 'readonly' modifier can only appear on a property declaration or index signature
         | 1242 // 'abstract' modifier can only appear on a class, method, or property declaration
         | 1243 // '{0}' modifier cannot be used with '{1}' modifier
         | 1246 // An interface property cannot have an initializer

--- a/crates/tsz-parser/src/parser/state_statements_keywords.rs
+++ b/crates/tsz-parser/src/parser/state_statements_keywords.rs
@@ -367,16 +367,40 @@ impl ParserState {
 
         if self.next_token_is_on_new_line() {
             self.parse_expression_statement()
+        } else if self.token() == SyntaxKind::OverrideKeyword {
+            // `override` is never a valid statement/declaration modifier
+            // outside a class member — tsc's parser does not recognize it as
+            // starting a declaration there at all, so it reports a single,
+            // unconditional "Unexpected keyword or identifier." at the
+            // `override` token and continues parsing the remainder as if
+            // `override` were never there. Unlike the sibling modifiers this
+            // does not depend on the container or on what follows (`export`
+            // or otherwise): oracle-pinned across 3 containers x 11 export
+            // forms plus the non-export control, all 34 rows report TS1434
+            // alone (#16403). Consuming the token and re-dispatching through
+            // `parse_statement()` reproduces that: whatever follows parses as
+            // an ordinary statement with no leftover modifier, so it draws no
+            // diagnostic of its own — matching tsc, which still binds the
+            // trailing declaration (confirmed: a reference to the declared
+            // name after this statement resolves, not TS2304) while
+            // suppressing its grammar diagnostics for the file, the same
+            // file-wide effect #16367 documented for a genuine parse error.
+            self.parse_error_at_current_token(
+                "Unexpected keyword or identifier.",
+                diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER,
+            );
+            self.next_token();
+            self.parse_statement()
         } else if self.look_ahead_is_modifier_before_declaration() {
-            // `static`/`public`/`protected`/`private` share one modifier
-            // diagnostic family (TS1044, "'{0}' modifier cannot appear on a
-            // module or namespace element") and the container split below is
-            // oracle-pinned for exactly those four (#16403 slice 1).
-            // `readonly` needs its own code (TS1024) and `override` its own
-            // unconditional one (TS1434) regardless of container — both stay
-            // on the pre-existing silent-drop behavior for the three forms
-            // below until their own slice lands, rather than adopting this
-            // family's TS1044 by sharing the same dispatch.
+            // `static`/`public`/`protected`/`private`/`readonly` share the
+            // same container split (#16403 slices 1-2): a Block body gets
+            // the generic TS1184; a module/namespace body or the source
+            // file's own top level, neither of which is a Block, keeps a
+            // module/namespace-specific diagnostic — TS1044 for the first
+            // four (formatted with the actual modifier text), TS1024 for
+            // `readonly` (its own fixed message, oracle-pinned identical to
+            // the TS1044 family's silencing shape in every other position).
+            // `override` never reaches here (short-circuited above).
             let is_ts1044_family_modifier = matches!(
                 self.token(),
                 SyntaxKind::StaticKeyword
@@ -384,6 +408,8 @@ impl ParserState {
                     | SyntaxKind::ProtectedKeyword
                     | SyntaxKind::PrivateKeyword
             );
+            let is_readonly_modifier = self.token() == SyntaxKind::ReadonlyKeyword;
+            let takes_container_split = is_ts1044_family_modifier || is_readonly_modifier;
             let export_form = self.modified_export_form();
             // `in_static_block_context()` covers the static-block case
             // directly rather than through `in_block_context()`
@@ -396,7 +422,7 @@ impl ParserState {
             let block_context = self.in_block_context() || self.in_static_block_context();
             match export_form {
                 Some(ModifiedExportForm::ExportDeclaration)
-                    if !is_ts1044_family_modifier || block_context =>
+                    if !takes_container_split || block_context =>
                 {
                     // `export {}` / `export * from` after a stray modifier,
                     // inside a Block: tsc reports the form's own placement
@@ -406,9 +432,7 @@ impl ParserState {
                     self.parse_statement()
                 }
                 Some(ModifiedExportForm::ExportAssignment)
-                    if !is_ts1044_family_modifier
-                        || block_context
-                        || self.in_module_body_context() =>
+                    if !takes_container_split || block_context || self.in_module_body_context() =>
                 {
                     // `export =` / `export default` after a stray modifier,
                     // inside a Block *or* a namespace body: the assignment's
@@ -421,17 +445,15 @@ impl ParserState {
                     self.parse_statement()
                 }
                 Some(ModifiedExportForm::ModuleDeclaration)
-                    if is_ts1044_family_modifier && block_context =>
+                    if takes_container_split && block_context =>
                 {
                     // `export namespace N {}` / `export module M {}` inside
                     // a Block: a nested module declaration is itself illegal
                     // there (TS1235) independent of any modifier, and that
                     // placement diagnostic wins the same way the two forms
-                    // above do. Gated to the TS1044 family (unlike the two
-                    // arms above, `readonly`/`override` classified this form
-                    // as an ordinary `ModifiedDeclaration` before this PR —
-                    // preserve that catchall routing for them rather than
-                    // newly silencing it, since it was never silent).
+                    // above do. Gated to the modifiers that take the
+                    // container split (#16403 slices 1-2) — `override` never
+                    // reaches this match at all (short-circuited above).
                     self.next_token();
                     self.parse_statement()
                 }
@@ -460,14 +482,23 @@ impl ParserState {
                     // ordinary modified declaration: a Block body gets the
                     // generic TS1184; a module/namespace body or the source
                     // file's own top level, neither of which is a Block,
-                    // keeps the module/namespace-specific TS1044 (#16368,
-                    // #16403).
+                    // keeps a module/namespace-specific diagnostic — TS1044
+                    // (formatted with the modifier text) for the
+                    // `static`/`public`/`protected`/`private` family,
+                    // `readonly`'s own fixed-message TS1024 otherwise
+                    // (#16368, #16403).
                     let modifier_start = self.token_pos();
                     let modifier_text = self.scanner.get_token_text();
+                    let modifier_kind = self.token();
                     if block_context {
                         self.parse_error_at_current_token(
                             "Modifiers cannot appear here.",
                             diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE,
+                        );
+                    } else if modifier_kind == SyntaxKind::ReadonlyKeyword {
+                        self.parse_error_at_current_token(
+                            "'readonly' modifier can only appear on a property declaration or index signature.",
+                            diagnostic_codes::READONLY_MODIFIER_CAN_ONLY_APPEAR_ON_A_PROPERTY_DECLARATION_OR_INDEX_SIGNATURE,
                         );
                     } else {
                         self.parse_error_at_current_token(
@@ -477,7 +508,6 @@ impl ParserState {
                             diagnostic_codes::MODIFIER_CANNOT_APPEAR_ON_A_MODULE_OR_NAMESPACE_ELEMENT,
                         );
                     }
-                    let modifier_kind = self.token();
                     self.next_token();
                     let modifier = self.arena.add_token(
                         modifier_kind as u16,

--- a/crates/tsz-parser/tests/parser_class_body_modifier_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_class_body_modifier_recovery_tests.rs
@@ -67,19 +67,27 @@ fn modifier_before_declaration_in_nested_block_inside_method_reports_single_ts11
 fn every_class_modifier_keyword_before_a_declaration_reports_single_ts1184_in_a_method_body() {
     // `abstract` is deliberately excluded: `parse_statement_abstract_keyword`
     // reports TS1242 unconditionally regardless of container, a separate,
-    // pre-existing bug unrelated to this heuristic (#16380).
-    for keyword in [
-        "public",
-        "private",
-        "protected",
-        "static",
-        "override",
-        "readonly",
-    ] {
+    // pre-existing bug unrelated to this heuristic (#16380). `override` is
+    // also excluded: it is never a valid statement/declaration modifier
+    // outside a class member, so a method body (itself a Block) gets the
+    // same unconditional TS1434 as every other container, not TS1184
+    // (oracle-pinned, #16403 slice 2; see the dedicated test below).
+    for keyword in ["public", "private", "protected", "static", "readonly"] {
         let source = format!("class C {{ method() {{ {keyword} const z = 1; }} }}");
         let pos = source.find(keyword).unwrap() as u32;
         assert_single_diagnostic(&source, diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE, pos);
     }
+}
+
+#[test]
+fn override_before_a_declaration_in_a_method_body_reports_ts1434_not_ts1184() {
+    let source = "class C { method() { override const z = 1; } }";
+    let pos = source.find("override").unwrap() as u32;
+    assert_single_diagnostic(
+        source,
+        diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER,
+        pos,
+    );
 }
 
 #[test]

--- a/crates/tsz-parser/tests/parser_modified_export_statement_tests.rs
+++ b/crates/tsz-parser/tests/parser_modified_export_statement_tests.rs
@@ -382,15 +382,25 @@ fn modifier_before_export_namespace_declaration_in_namespace_body_reports_ts1044
 }
 
 // --------------------------------------------------------------------------
-// Containment: `readonly`/`override` are a different diagnostic family
-// (TS1024 always-fixed-text, TS1434 unconditional-of-container) and stay on
-// the pre-existing silent-drop behavior for these four export forms outside
-// a Block until their own slice — this PR must not change their answer.
+// `readonly` — TS1024, oracle-pinned to the exact same container/form
+// silencing shape as the TS1044 family (#16403 slice 2).
 // --------------------------------------------------------------------------
 
 #[test]
-fn readonly_before_export_list_at_top_level_reports_no_parser_diagnostic() {
-    assert_no_parser_diagnostics("readonly export {};");
+fn readonly_before_export_list_at_top_level_reports_ts1024() {
+    assert_only_diagnostic(
+        "readonly export {};",
+        "readonly",
+        diagnostic_codes::READONLY_MODIFIER_CAN_ONLY_APPEAR_ON_A_PROPERTY_DECLARATION_OR_INDEX_SIGNATURE,
+    );
+}
+
+#[test]
+fn readonly_before_export_list_in_function_body_reports_only_ts1233() {
+    // Silenced the same way the TS1044 family is: the export declaration's
+    // own placement diagnostic wins inside a Block and the modifier is
+    // dropped silently.
+    assert_no_parser_diagnostics("function f() {\n  readonly export {};\n}");
 }
 
 #[test]
@@ -399,22 +409,99 @@ fn readonly_before_export_assignment_in_namespace_body_reports_no_parser_diagnos
 }
 
 #[test]
-fn override_before_export_default_at_top_level_reports_no_parser_diagnostic() {
-    assert_no_parser_diagnostics("override export default 1;");
+fn readonly_before_export_class_at_top_level_reports_ts1024() {
+    assert_only_diagnostic(
+        "readonly export class C {}",
+        "readonly",
+        diagnostic_codes::READONLY_MODIFIER_CAN_ONLY_APPEAR_ON_A_PROPERTY_DECLARATION_OR_INDEX_SIGNATURE,
+    );
 }
 
-/// `override` classifies this form as an ordinary `ModifiedDeclaration`
-/// (unlike `static`/`public`/`protected`/`private`, for which #16403 slice 1
-/// adds a Block-only silent path) — this PR must not touch that routing, so
-/// the pre-existing catchall diagnostic still fires here. tsc's real answer
-/// is TS1434 unconditionally, a separate, still-open gap (#16403 slice 2).
 #[test]
-fn override_before_export_namespace_declaration_at_top_level_reports_pre_existing_diagnostic() {
+fn readonly_before_export_class_in_function_body_reports_ts1184() {
+    assert_only_diagnostic(
+        "function f() {\n  readonly export class C {}\n}",
+        "readonly",
+        diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE,
+    );
+}
+
+// --------------------------------------------------------------------------
+// `override` — never a valid statement/declaration modifier outside a class
+// member, so tsc's parser reports a single unconditional TS1434 at the
+// `override` token regardless of container or of what follows, `export` or
+// otherwise (#16403 slice 2). This is a different mechanism from every other
+// modifier in this file: it never reaches `modified_export_form`'s
+// container/form split at all.
+// --------------------------------------------------------------------------
+
+#[test]
+fn override_before_export_default_at_top_level_reports_ts1434() {
+    assert_only_diagnostic(
+        "override export default 1;",
+        "override",
+        diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER,
+    );
+}
+
+#[test]
+fn override_before_export_namespace_declaration_at_top_level_reports_ts1434() {
     assert_only_diagnostic(
         "override export namespace N {}",
         "override",
-        diagnostic_codes::MODIFIER_CANNOT_APPEAR_ON_A_MODULE_OR_NAMESPACE_ELEMENT,
+        diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER,
     );
+}
+
+#[test]
+fn override_before_export_class_in_function_body_reports_ts1434_not_ts1184() {
+    assert_only_diagnostic(
+        "function f() {\n  override export class C {}\n}",
+        "override",
+        diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER,
+    );
+}
+
+#[test]
+fn override_before_export_list_in_namespace_body_reports_ts1434_not_ts1194() {
+    assert_only_diagnostic(
+        "namespace Outer {\n  override export {};\n}",
+        "override",
+        diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER,
+    );
+}
+
+#[test]
+fn override_before_export_as_namespace_reports_ts1434_not_ts1184() {
+    // `export as namespace` is TS1184-unconditional for every other
+    // modifier in this file; `override` still short-circuits to its own
+    // TS1434 before the `NamespaceExport` arm is ever reached.
+    assert_only_diagnostic(
+        "override export as namespace Foo;",
+        "override",
+        diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER,
+    );
+}
+
+#[test]
+fn override_before_non_export_declaration_reports_ts1434() {
+    // Confirms the rule is about `override` itself, not about `export`:
+    // the same unconditional TS1434 fires with no `export` involved at all.
+    assert_only_diagnostic(
+        "override class C {}",
+        "override",
+        diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER,
+    );
+}
+
+#[test]
+fn override_on_its_own_line_is_still_an_identifier_expression() {
+    // A line break before the next token takes the same ASI path every
+    // other modifier in this file takes — `override` is parsed as a
+    // standalone identifier expression, not specially. No parser diagnostic:
+    // `override` resolving as a name is a checker-level TS2304, out of this
+    // file's reach.
+    assert_no_parser_diagnostics("override\nexport class C {}\n");
 }
 
 // --------------------------------------------------------------------------

--- a/crates/tsz-parser/tests/parser_top_level_modifier_ts1044_ts1184_tests.rs
+++ b/crates/tsz-parser/tests/parser_top_level_modifier_ts1044_ts1184_tests.rs
@@ -1,12 +1,16 @@
 //! A misplaced class-modifier keyword (`public`, `private`, `protected`,
-//! `static`, `override`, `readonly`) at the start of a statement is a grammar
-//! error in every container, but tsc picks its diagnostic from the
-//! *container*, not the modifier: a `Block` body (function body, a nested
-//! block, or a class static block) reports the generic TS1184 ("Modifiers
-//! cannot appear here"); a module/namespace body or the source file's own
-//! top level — neither of which is a `Block` — keeps the module/namespace-
-//! specific TS1044 ("'{0}' modifier cannot appear on a module or namespace
-//! element."). #16368.
+//! `static`, `readonly`) at the start of a statement is a grammar error in
+//! every container, but tsc picks its diagnostic from the *container*, not
+//! the modifier: a `Block` body (function body, a nested block, or a class
+//! static block) reports the generic TS1184 ("Modifiers cannot appear
+//! here"); a module/namespace body or the source file's own top level —
+//! neither of which is a `Block` — keeps a module/namespace-specific
+//! diagnostic (TS1044 "'{0}' modifier cannot appear on a module or namespace
+//! element." for the first four, `readonly`'s own fixed-message TS1024).
+//! #16368, #16403.
+//!
+//! `override` is a different rule entirely — see this file's own note above
+//! `every_top_level_modifier_keyword_reports_ts1184_in_a_block`.
 
 use crate::parser::test_fixture::parse_source;
 use tsz_common::diagnostics::diagnostic_codes;
@@ -79,14 +83,12 @@ fn modifier_before_namespace_nested_in_function_body_still_reports_ts1044() {
 
 #[test]
 fn every_top_level_modifier_keyword_reports_ts1184_in_a_block() {
-    for keyword in [
-        "public",
-        "private",
-        "protected",
-        "static",
-        "override",
-        "readonly",
-    ] {
+    // `override` is deliberately excluded: unlike these five, tsc's parser
+    // does not recognize it as a statement/declaration modifier at all
+    // outside a class member, so it never reaches the container split and
+    // instead reports an unconditional TS1434 (see the `override_*` tests
+    // in `parser_modified_export_statement_tests.rs`, #16403).
+    for keyword in ["public", "private", "protected", "static", "readonly"] {
         let source = format!("function mm() {{ {keyword} const z = 1; }}");
         let pos = source.find(keyword).unwrap() as u32;
         assert_single_diagnostic(&source, diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE, pos);


### PR DESCRIPTION
`readonly` and `override` before an `export`-prefixed statement were deliberately left on their pre-existing (silent-drop) behavior by #16408, which scoped the container/form split to the `static`/`public`/`protected`/`private` family only (slice 1 of #16403). This is slice 2.

**Structural rule, `readonly`:** it shares the exact same container/form silencing shape as the `static` family (a `Block` silences the `ExportDeclaration` and `ModuleDeclaration` forms; a `Block` or namespace body silences `ExportAssignment`) but reports its own fixed-message **TS1024** instead of the family's dynamically-formatted TS1044 wherever that family would report anything at all. tsz now routes `readonly` through the same `takes_container_split` path introduced in #16408, branching only on the final diagnostic code/message (`crates/tsz-parser/src/parser/state_statements_keywords.rs`).

**Structural rule, `override`:** it is never a valid statement/declaration modifier outside a class member, so tsc's parser does not recognize it as starting a declaration in that position at all — it reports an unconditional `"Unexpected keyword or identifier."` (**TS1434**) at the `override` token regardless of container or of what follows (`export` or otherwise, even no `export` at all), then continues parsing the remainder as an ordinary statement (confirmed: a name declared after the error still binds — no TS2304 — so tsc keeps the AST, it only suppresses the grammar diagnostics for it). tsz now short-circuits on `SyntaxKind::OverrideKeyword` *before* the export-form dispatch runs, since the answer never depends on it. This also corrects two pre-existing tests that wrongly asserted TS1184 for `override` in a `Block`/method body — verified against the oracle, tsc gives TS1434 there too.

**Also fixes a diagnostic-suppression classification gap this exposed:** `READONLY_MODIFIER_CAN_ONLY_APPEAR_ON_A_PROPERTY_DECLARATION_OR_INDEX_SIGNATURE` (1024) was missing from `is_parser_grammar_code` in `crates/tsz-cli/src/driver/check_utils.rs`. Emitting it therefore set `has_syntax_parse_errors` and silently deleted the rest of the file's checker diagnostics — visible as a missing **TS1203** alongside `readonly export = 1;` at the source file's own top level (tsc reports both `TS1024` and `TS1203`; tsz reported only `TS1024`). `abstract`'s sibling `TS1242` and `accessor`'s sibling `TS1275` were already correctly classified in this list; `TS1024` was a plain oversight, never previously exercised in a position where another checker diagnostic co-occurred in the same file.

### One residual, pinned rather than hidden

Oracle matrix (`typescript@7.0.2`, `--noEmit --strict --lib es2022 --target es2022 --module es2022`): `readonly` + `override`, 3 containers × 11 export forms + a non-export control = **42 rows, 40/42 exact**.

The 2 remaining mismatches are both `override` + an `ExportAssignment` form (`export =` / `export default`) **in a namespace body**: tsc reports `TS1434` alone; tsz additionally leaks `TS1063`/`TS1319` from `crates/tsz-checker/src/declarations/import/core/module_exports.rs` — an independent checker pass that (unlike `check_grammar_module_element_context`) is **not** gated by `has_syntax_parse_errors`. This is a separate, pre-existing architectural gap, only exposed here because `override` is the first modifier in this family whose diagnostic is never silenced by the container/form split (every other modifier's namespace-body `ExportAssignment` row is silent, so no genuine parse error ever co-occurs with these two checks until now). Fixing `module_exports.rs`'s gating is out of scope for a modifier-diagnostic PR; will file as a follow-up issue.

### Adjacent cases covered

- `readonly` × 3 containers × 6 export forms (`export {}`, `export default`, `export =`, `export namespace`, `export const`, `export class`), plus the `export as namespace` control (unconditional TS1184, unchanged) and the non-export control.
- `override` × the same matrix, plus a method-body container and the ASI/newline control (`override\nexport class C {}` still degrades to an identifier expression, unchanged).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-parser --lib`: **1862/1862** (was 1853; +9 covering the new readonly TS1024 rows and override TS1434 rows, plus 2 corrected pre-existing tests).
- `cargo test -p tsz-cli --lib check_utils`: **138/138**, confirming the TS1024 classification fix has no regressions.
- `cargo clippy -p tsz-cli -p tsz-parser` (via pre-commit hook): clean.
- Architecture guard (via pre-commit hook): passed.
- Oracle matrix (`typescript@7.0.2`): 40/42 exact, 2 residual rows pinned above with root cause identified.
- `compare-to-parent.sh origin/main`: not yet run in this container (budget spent on the oracle matrix + the TS1024 classification fix); will post the two-sided number before queuing the merge. Expected signature is 0 newly failing given the narrow, oracle-pinned scope — the corpus is thin on files pairing a bare `readonly`/`override` with an `export` statement in the wrong container, per the board's standing "zero conformance movement is the expected signature" pattern for this PR family (#16408, #16407, #16405 all showed it).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01AVuykZxY4CH6Bzz8zq7s7v)_