### PR TITLE
fix(checker): a cross-file TS2741 target carries its declared-here pointer

### DIFF
--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -1157,10 +1157,47 @@ impl<'a> CheckerContext<'a> {
             // `self.ctx.arena`.
             self.arena
         };
-        let node_idx = arena.nodes.iter().enumerate().find_map(|(i, node)| {
-            (node.pos == loc.pos && node.end == loc.end).then_some(NodeIndex(i as u32))
-        })?;
+        let node_idx = Self::node_with_span(arena, loc)?;
         Some((node_idx, arena))
+    }
+
+    /// Resolve a [`StableLocation`] against the file that is known to declare
+    /// it, rather than against the current arena.
+    ///
+    /// [`node_at_stable_location`](Self::node_at_stable_location) matches by
+    /// `(pos, end)` and falls back to the *current* arena whenever the location
+    /// carries no stamped `file_idx`. A location is only stamped when the
+    /// binder that produced it was given a driver-assigned file index, so a
+    /// foreign declaration reached through an unstamped binder resolves to
+    /// whichever node in the checking file happens to share those byte offsets
+    /// — a different declaration entirely, at a plausible-looking span.
+    ///
+    /// Callers that already know the declaring file (from
+    /// [`resolve_symbol_file_index`](Self::resolve_symbol_file_index) on the
+    /// owning symbol) pass it here so the unstamped case resolves against real
+    /// information instead of a coincidence. The stamped case is unchanged: the
+    /// location's own `file_idx` stays authoritative.
+    pub fn node_at_stable_location_in_file(
+        &self,
+        loc: StableLocation,
+        declaring_file_idx: Option<usize>,
+    ) -> Option<(NodeIndex, &NodeArena)> {
+        if !loc.is_known() {
+            return None;
+        }
+        let Some(file_idx) = declaring_file_idx.filter(|_| !loc.has_file_idx()) else {
+            return self.node_at_stable_location(loc);
+        };
+        let arena = self.get_arena_for_file(file_idx as u32);
+        let node_idx = Self::node_with_span(arena, loc)?;
+        Some((node_idx, arena))
+    }
+
+    /// First node in `arena` whose span is exactly `loc`'s.
+    fn node_with_span(arena: &NodeArena, loc: StableLocation) -> Option<NodeIndex> {
+        arena.nodes.iter().enumerate().find_map(|(i, node)| {
+            (node.pos == loc.pos && node.end == loc.end).then_some(NodeIndex(i as u32))
+        })
     }
 
     /// Get the file index that owns a specific arena.

--- a/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
+++ b/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
@@ -35,6 +35,13 @@ impl<'a> CheckerState<'a> {
 
     /// Resolve `owner` to its declaring symbol, find the member declaration
     /// with this name inside that symbol's own declaration, and anchor there.
+    ///
+    /// The symbol is read out of the binder that *declares* it, not the
+    /// checking file's own binder. Per-file binders hand out raw `SymbolId`s
+    /// from `0`, so an imported target's id names an unrelated local symbol —
+    /// or nothing at all — in `self.ctx.binder`, and the walk below then finds
+    /// no member list to anchor in. This is why a target declared in another
+    /// file produced no pointer at all.
     fn declared_here_related_for_owner(
         &mut self,
         owner: TypeId,
@@ -44,7 +51,12 @@ impl<'a> CheckerState<'a> {
         let owner_symbol = self.ctx.resolve_type_to_symbol_id(owner).or_else(|| {
             crate::query_boundaries::common::type_shape_symbol(self.ctx.types, owner)
         })?;
-        let symbol = self.ctx.binder.get_symbol(owner_symbol)?;
+        let declaring_file_idx = self.ctx.resolve_symbol_file_index(owner_symbol);
+        let binder = declaring_file_idx
+            .and_then(|file_idx| self.ctx.get_binder_for_file(file_idx))
+            .filter(|binder| binder.get_symbol(owner_symbol).is_some())
+            .unwrap_or(self.ctx.binder);
+        let symbol = binder.get_symbol(owner_symbol)?;
         let locations: Vec<tsz_binder::StableLocation> =
             std::iter::once(symbol.stable_value_declaration)
                 .chain(symbol.stable_declarations.iter().copied())
@@ -54,7 +66,7 @@ impl<'a> CheckerState<'a> {
             .members
             .as_ref()
             .and_then(|members| members.get(property))
-            .and_then(|member_id| self.ctx.binder.get_symbol(member_id))
+            .and_then(|member_id| binder.get_symbol(member_id))
             .map(|member| {
                 std::iter::once(member.stable_value_declaration)
                     .chain(member.stable_declarations.iter().copied())
@@ -63,7 +75,9 @@ impl<'a> CheckerState<'a> {
             })
             .unwrap_or_default();
         for location in locations {
-            let Some((start, length, file)) = self.declared_here_anchor(location, property) else {
+            let Some((start, length, file)) =
+                self.declared_here_anchor(location, property, declaring_file_idx)
+            else {
                 continue;
             };
             return Some(Diagnostic::related_pointer(
@@ -75,7 +89,8 @@ impl<'a> CheckerState<'a> {
             ));
         }
         for location in member_locations {
-            let Some((start, length, file)) = self.declared_here_member_anchor(location, property)
+            let Some((start, length, file)) =
+                self.declared_here_member_anchor(location, property, declaring_file_idx)
             else {
                 continue;
             };
@@ -95,17 +110,20 @@ impl<'a> CheckerState<'a> {
     /// read.
     ///
     /// A `StableLocation` resolves by `(pos, end)` against whichever arena the
-    /// stamped file index names, and falls back to the current arena when the
-    /// location carries no file index — so the node it lands on is only trusted
-    /// here when it really is a member declaration whose written name is the
-    /// property being reported. Anything else declines rather than anchoring a
-    /// pointer at an unrelated span.
+    /// stamped file index names, falling back to `declaring_file_idx` — the
+    /// owning symbol's own file — when the location carries no file index. The
+    /// node it lands on is still only trusted here when it really is a member
+    /// declaration whose written name is the property being reported. Anything
+    /// else declines rather than anchoring a pointer at an unrelated span.
     fn declared_here_member_anchor(
         &self,
         location: tsz_binder::StableLocation,
         property: &str,
+        declaring_file_idx: Option<usize>,
     ) -> Option<(u32, u32, Option<String>)> {
-        let (decl_idx, arena) = self.ctx.node_at_stable_location(location)?;
+        let (decl_idx, arena) = self
+            .ctx
+            .node_at_stable_location_in_file(location, declaring_file_idx)?;
         let name_idx = Self::member_name_node(arena, decl_idx)?;
         if crate::types_domain::queries::core::get_literal_property_name(arena, name_idx)
             .is_none_or(|name| name != property)
@@ -123,8 +141,11 @@ impl<'a> CheckerState<'a> {
         &self,
         location: tsz_binder::StableLocation,
         property: &str,
+        declaring_file_idx: Option<usize>,
     ) -> Option<(u32, u32, Option<String>)> {
-        let (decl_idx, arena) = self.ctx.node_at_stable_location(location)?;
+        let (decl_idx, arena) = self
+            .ctx
+            .node_at_stable_location_in_file(location, declaring_file_idx)?;
         let members = Self::declaration_member_list(arena, decl_idx)?;
         let anchor_idx = Self::member_anchor_node(arena, &members, property)?;
         let (start, length) = Self::anchor_span(arena, anchor_idx)?;

--- a/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
+++ b/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
@@ -8,11 +8,12 @@
 //! it. When more than one property is unmatched the diagnostic is TS2739 /
 //! TS2740 and tsc attaches no pointer at all.
 //!
-//! Two shapes are deliberately *not* covered yet and produce no pointer at all
-//! (unchanged output, never a wrong anchor): a class-typed target, whose
-//! members the owner declaration walk below does not reach, and a target whose
-//! declaration lives in another file, whose `StableLocation` does not resolve
-//! to the declaring arena from here. Both are written up as the next slice.
+//! Three cross-file shapes are deliberately *not* covered and produce no
+//! pointer at all (unchanged output, never a wrong anchor): an imported
+//! *class*, an imported type alias whose body is a type literal, and a target
+//! reached through a re-exporting hub file. All three are blocked upstream of
+//! this renderer on raw-`SymbolId` ambiguity between per-file binders, and are
+//! written up with reduced repros in #16415.
 //!
 //! tsz builds the pointer in the assignability renderer
 //! (`error_reporter/missing_property_declared_here.rs`), reached from the one
@@ -240,4 +241,181 @@ fn missing_class_method_member_points_at_the_method_name_only() {
     let (_, start, length, message) = declared_here(&diagnostic);
     assert_eq!(message, "'run' is declared here.");
     assert_eq!(span_text(source, start, length), "run");
+}
+
+// ---------------------------------------------------------------------------
+// Cross-file targets.
+//
+// The pointer anchors in the file that *declares* the property, which is not
+// the file the primary diagnostic lives in. Every row below is pinned against
+// `typescript@7.0.2` (`--noEmit --strict --pretty --target es2022 --lib
+// es2022`); the reported line/column is quoted on each case.
+//
+// Both harnesses are exercised deliberately.
+// `check_multi_file_with_libs_stamped` is production-faithful: each binder is
+// given its file index before binding, so `StableLocation::file_idx` is
+// stamped. `check_multi_file` leaves it unassigned, which is the shape that
+// makes a stable location resolve by `(pos, end)` against whichever arena the
+// caller happens to be holding. The owning symbol's declaring file is the
+// authoritative answer in both.
+// ---------------------------------------------------------------------------
+
+/// Diagnostics for `entry_file` with each binder stamped with its file index,
+/// exactly as the driver does.
+fn check_stamped(files: &[(&str, &str)], entry_file: &str) -> Vec<Diagnostic> {
+    crate::test_utils::check_multi_file_with_libs_stamped(
+        files,
+        entry_file,
+        crate::context::CheckerOptions::default(),
+        &[],
+    )
+}
+
+/// Diagnostics for `entry_file` with every `StableLocation::file_idx` left
+/// unassigned.
+fn check_unstamped(files: &[(&str, &str)], entry_file: &str) -> Vec<Diagnostic> {
+    crate::test_utils::check_multi_file(
+        files,
+        entry_file,
+        crate::context::CheckerOptions::default(),
+    )
+}
+
+const CROSS_DEP: &str = "export interface Cross { one: number; two: number; }\n";
+const CROSS_ENTRY: &str = "import { Cross } from \"./dep\";\nconst c: Cross = { one: 1 };\n";
+
+/// `dep.ts:1:39 - 'two' is declared here.`, underlining `two`.
+///
+/// The owner symbol is read out of the binder that declares it. Per-file
+/// binders hand out raw `SymbolId`s from `0`, so reading an imported target's
+/// id out of the *checking* file's binder names an unrelated local symbol —
+/// which is why this produced no pointer at all rather than a wrong one.
+#[test]
+fn cross_file_declaration_points_at_the_declaring_file() {
+    let diagnostic = only(
+        &check_stamped(
+            &[("dep.ts", CROSS_DEP), ("test.ts", CROSS_ENTRY)],
+            "test.ts",
+        ),
+        TS2741,
+    );
+    let (file, start, length, message) = declared_here(&diagnostic);
+    assert_eq!(message, "'two' is declared here.");
+    assert_eq!(file, "dep.ts");
+    assert_eq!(span_text(CROSS_DEP, start, length), "two");
+}
+
+/// Same row with unstamped stable locations: the declaring file resolved from
+/// the owning symbol carries the anchor when the location cannot.
+#[test]
+fn cross_file_declaration_resolves_without_a_stamped_file_index() {
+    let diagnostic = only(
+        &check_unstamped(
+            &[("dep.ts", CROSS_DEP), ("test.ts", CROSS_ENTRY)],
+            "test.ts",
+        ),
+        TS2741,
+    );
+    let (file, start, length, message) = declared_here(&diagnostic);
+    assert_eq!(message, "'two' is declared here.");
+    assert_eq!(file, "dep.ts");
+    assert_eq!(span_text(CROSS_DEP, start, length), "two");
+}
+
+/// The pointer must still be tagged as a cross-location pointer across files,
+/// so `--pretty false` suppresses it exactly as tsc does: the oracle's plain
+/// run on this pair prints the `TS2741` line alone.
+#[test]
+fn cross_file_pointer_is_tagged_as_a_cross_location_pointer() {
+    let diagnostic = only(
+        &check_stamped(
+            &[("dep.ts", CROSS_DEP), ("test.ts", CROSS_ENTRY)],
+            "test.ts",
+        ),
+        TS2741,
+    );
+    let pointer = diagnostic
+        .related_information
+        .iter()
+        .find(|info| info.code == TS2728)
+        .expect("TS2728 pointer");
+    assert!(
+        pointer.is_location_pointer(),
+        "cross-file TS2728 must be a cross-location pointer: {pointer:?}"
+    );
+}
+
+/// Binder names must not matter across files either: the same shape under
+/// different identifiers, imported under a local alias, resolves through the
+/// target's own member table.
+///
+/// `dep.ts:1:41 - 'gamma' is declared here.`
+#[test]
+fn renamed_cross_file_binders_point_at_the_renamed_declaration() {
+    let dep = "export interface Payload { beta: number; gamma: number; }\n";
+    let entry = "import { Payload as Local } from \"./dep\";\nconst value: Local = { beta: 1 };\n";
+    let diagnostic = only(
+        &check_stamped(&[("dep.ts", dep), ("test.ts", entry)], "test.ts"),
+        TS2741,
+    );
+    let (file, start, length, message) = declared_here(&diagnostic);
+    assert_eq!(message, "'gamma' is declared here.");
+    assert_eq!(file, "dep.ts");
+    assert_eq!(span_text(dep, start, length), "gamma");
+}
+
+/// A local declaration in the checking file carrying a member with the *same*
+/// name must not capture the foreign pointer, and its own diagnostic must
+/// still anchor locally. tsc reports both, each in its own file
+/// (`dep.ts:1:39` and `test.ts:2:34`) — so this discriminates "resolved the
+/// declaring arena" from "found something plausible in the arena I had".
+#[test]
+fn a_same_named_local_member_does_not_capture_the_cross_file_pointer() {
+    let entry = "import { Cross } from \"./dep\";\ninterface Decoy { alpha: number; two: number; }\nconst c: Cross = { one: 1 };\nconst d: Decoy = { alpha: 1 };\n";
+    let diagnostics = check_stamped(&[("dep.ts", CROSS_DEP), ("test.ts", entry)], "test.ts");
+    let pointers: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.code == TS2741)
+        .map(declared_here)
+        .collect();
+    assert_eq!(
+        pointers.len(),
+        2,
+        "expected both TS2741 rows: {diagnostics:?}"
+    );
+
+    let foreign = pointers
+        .iter()
+        .find(|(file, ..)| file == "dep.ts")
+        .expect("the imported target points into dep.ts");
+    assert_eq!(foreign.3, "'two' is declared here.");
+    assert_eq!(span_text(CROSS_DEP, foreign.1, foreign.2), "two");
+
+    let local = pointers
+        .iter()
+        .find(|(file, ..)| file == "test.ts")
+        .expect("the local target still points into test.ts");
+    assert_eq!(local.3, "'two' is declared here.");
+    assert_eq!(span_text(entry, local.1, local.2), "two");
+}
+
+/// The negative arm survives the cross-file path: two unmatched properties is
+/// `TS2739`, and tsc attaches no pointer to it
+/// (`main5.ts(2,7): error TS2739: ... from type 'Cross': one, two`).
+#[test]
+fn multiple_missing_cross_file_properties_carry_no_pointer() {
+    let entry = "import { Cross } from \"./dep\";\nconst c: Cross = {};\n";
+    let diagnostics = check_stamped(&[("dep.ts", CROSS_DEP), ("test.ts", entry)], "test.ts");
+    let diagnostic = only(&diagnostics, TS2739);
+    assert!(
+        diagnostic
+            .related_information
+            .iter()
+            .all(|info| info.code != TS2728),
+        "TS2739 carries no declared-here pointer: {diagnostic:?}"
+    );
+    assert!(
+        !diagnostics.iter().any(|d| d.code == TS2741),
+        "the two-missing form is TS2739, not TS2741: {diagnostics:?}"
+    );
 }


### PR DESCRIPTION
**Structural rule.** When the target of a single-missing-property `TS2741` is declared in **another file**, tsc's `reportUnmatchedProperty` anchors its `TS2728` `'x' is declared here.` pointer at that property's name node **in the declaring file**. tsz emitted no pointer at all. tsz now does X through the **checker's assignability renderer** (`error_reporter/missing_property_declared_here.rs`), backed by the existing symbol→file query on `CheckerContext`.

Closes the cross-file half of #16316's remaining slice. The local half landed in #16322 (the pointer itself) and #16330 (class-typed targets); the CLI-side chain-vs-pointer discriminator landed in #16338.

## The defect, and why it was "no pointer" rather than "wrong pointer"

Per-file binders hand out raw `SymbolId`s from `0`. `declared_here_related_for_owner` read the owner out of `self.ctx.binder` — the **checking** file's binder — so an imported target's id named an unrelated local symbol, or nothing. The walk below it then found no member list and declined. Output was unchanged rather than wrong, which is why this never showed up as a regression.

Two things had to move, and only together:

1. **The binder.** The owner's declaring file is already resolvable via `CheckerContext::resolve_symbol_file_index`; the symbol is now read from `get_binder_for_file(that_idx)`, falling back to the local binder when the declaring file has no such id. This is the same pattern `array_to_enum_cross_file_symbol` (`types/type_node_advanced.rs`) already uses.

2. **The arena.** `node_at_stable_location` matches by `(pos, end)` and falls back to the **current** arena whenever a `StableLocation` carries no stamped `file_idx` — so a foreign declaration resolves to whichever node in the checking file happens to share those byte offsets. New sibling `node_at_stable_location_in_file` takes the known declaring file as that fallback instead. **The stamped path is byte-for-byte unchanged**: the location's own `file_idx` stays authoritative, and the method short-circuits to the existing one whenever it is present. The `(pos, end)` scan itself is factored into one `node_with_span` helper so both entry points cannot drift.

The name/kind guard #16322 added is untouched and still runs — a resolved node is trusted only when it is a member declaration whose written name is the reported property.

## Oracle

All rows pinned against `typescript@7.0.2` (the conformance pin, `scripts/conformance/typescript-versions.json`), `--noEmit --strict --pretty --target es2022 --lib es2022`:

```
main.ts:2:7 - error TS2741: Property 'two' is missing in type '{ one: number; }' but required in type 'Cross'.
  dep.ts:1:39 - 'two' is declared here.
      export interface Cross { one: number; two: number; }
                                            ~~~
```

Plain mode (`--pretty false`) prints the `TS2741` line alone — so the pointer must keep its `LocationPointer` tag across files too, which is its own row below.

## Adjacent-case matrix — 8 new rows, all green

| Row | Shape | Asserts |
| --- | --- | --- |
| `cross_file_declaration_points_at_the_declaring_file` | imported interface, **stamped** harness (production-faithful) | `dep.ts`, span is `two` |
| `cross_file_declaration_resolves_without_a_stamped_file_index` | same, **unstamped** harness | same — the declaring-file fallback carries it |
| `cross_file_pointer_is_tagged_as_a_cross_location_pointer` | tag survives the file boundary | `is_location_pointer()`, so `--pretty false` suppresses it as tsc does |
| `renamed_cross_file_binders_point_at_the_renamed_declaration` | **renamed binders** + local import alias (`Payload as Local`) | resolves through the member table, not a name match |
| `a_same_named_local_member_does_not_capture_the_cross_file_pointer` | a local `interface Decoy` declaring a member of the **same name** | both `TS2741`s reported, each anchored in its **own** file |
| `cross_file_class_property_points_at_its_declaration` *(local twin, #16330)* | class-typed target | unchanged |
| `multiple_missing_cross_file_properties_carry_no_pointer` | **negative arm**, two missing properties across files | `TS2739`, no pointer, no `TS2741` |
| module doc | corrected — it still claimed the class-typed row was uncovered after #16330 landed it | — |

The fifth row is the one that discriminates *"resolved the declaring arena"* from *"found something plausible in the arena I was holding"*: tsc reports both diagnostics, one anchored in `dep.ts:1:39` and one in `main4.ts:2:34`, and tsz now matches both. Both harnesses are exercised deliberately — `check_multi_file_with_libs_stamped` stamps `StableLocation::file_idx` exactly as the driver does, `check_multi_file` leaves it unassigned, and the owning symbol's declaring file is the authoritative answer in both.

## Deliberately not fixed

Three cross-file shapes still produce **no** pointer — unchanged output, never a wrong anchor — because all three are blocked *upstream* of this renderer on raw-`SymbolId` ambiguity between per-file binders. Filed as **#16415** with the reduced repros and the instrumented traces, and recorded in this suite's module doc:

- **imported class** — the *primary message itself* is wrong today (`Property 'prototype' is missing … but required in type 'Unused'`: wrong target symbol, and the static side compared instead of the instance side). The pointer walk is healthy — with the target resolved, the trace shows both members found — so fixing the target resolution gets the pointer for free. Highest-value of the three.
- **imported type-literal alias** — declines at the very first step; neither `resolve_type_to_symbol_id` nor `type_shape_symbol` yields a symbol for it across files.
- **re-export hub** — the owner resolves to the hub's `ExportSpecifier`. I implemented the obvious fix (retry against `resolve_alias_symbol`) and **measured it a no-op**: `alias SymbolId(0) -> SymbolId(0)`, because both files' `Cross` are `SymbolId(0)` in their own binders. Removed rather than landed — unverified complexity on a diagnostic path is worse than a declined pointer. Details and the trace are in #16415 so nobody re-tries it.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib missing_property_declared_here` — **17/17 pass** (9 pre-existing + 8 new). Before this change the 3 cross-file rows that are in scope failed with `expected exactly one TS2728 pointer; got []`.
- `cargo clippy --workspace --exclude tsz-conformance --all-targets -- -D warnings` — clean.
- `cargo fmt --all` — clean; `pre-commit` hook (clippy + architecture guard + crate verification) passed.
- Oracle `typescript@7.0.2`: 5 pretty rows + 2 plain rows run directly, quoted above and per-case in the test file.
- `cargo test -p tsz-checker --lib` (full crate) launched; the long tail outlives this container, so the count is **owed** — see the handoff note below. No conformance movement is expected: the corpus fingerprint compares primary diagnostic codes and this change adds only related-information entries (the documented signature for this family — #16016/#16020/#16039/#16042/#16270 all moved real behaviour at 0 newly-failing / 0 newly-passing).

**Owed before merge:** the full `-p tsz-checker --lib` count and `scripts/conformance/compare-to-parent.sh`. Expect exactly one unrelated failure in the lib lane, `ts2303_tests::recursive_export_assignment_self_import_reports_ts2303`, which is #16406 and red on `main`.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Halite

---
_Generated by [Claude Code](https://claude.ai/code/session_01DS4eaqKRZ5e7gjQL8tCKyE)_