### PR TITLE
fix(checker): TS1147 for a plain import-from declaration in a namespace (#16410 item 1)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2637,3 +2637,6 @@ path = "tests/ts1501_tests.rs"
 [[test]]
 name = "ts18036_class_decorator_static_private_identifier_tests"
 path = "tests/ts18036_class_decorator_static_private_identifier_tests.rs"
+[[test]]
+name = "import_namespace_ts1147_tests"
+path = "tests/import_namespace_ts1147_tests.rs"

--- a/crates/tsz-checker/src/declarations/import/declaration_check_body.rs
+++ b/crates/tsz-checker/src/declarations/import/declaration_check_body.rs
@@ -173,6 +173,34 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
+        // TS1147: Import declarations in a namespace cannot reference a module.
+        // Mirrors tsc's `checkExternalImportOrExportDeclaration`: when the
+        // enclosing module element is a non-ambient namespace, tsc reports this
+        // at the module specifier and returns immediately — nothing downstream
+        // runs, including module resolution (no TS2307/TS2305) and binder-level
+        // checks like the reserved-word TS1214 gate (oracle-confirmed:
+        // `namespace N { import { eval } from "m"; }` is TS1147 alone).
+        // `is_inside_namespace_declaration` already excludes string-literal
+        // ambient modules (`declare module "m"`), which stay a valid
+        // module-element context and keep resolving normally; `declare global`
+        // augmentations are excluded here too since they report TS2667 via
+        // `is_inside_global_augmentation` instead. `!in_wrong_context` defers to
+        // the TS1232 placement diagnostic when the import is further nested in
+        // a block within the namespace (oracle-confirmed: TS1232 alone there).
+        if !self.ctx.has_parse_errors
+            && !in_wrong_context
+            && self.is_inside_namespace_declaration(stmt_idx)
+            && !self.is_inside_global_augmentation(stmt_idx)
+        {
+            use crate::diagnostics::diagnostic_messages;
+            self.error_at_node(
+                import.module_specifier,
+                diagnostic_messages::IMPORT_DECLARATIONS_IN_A_NAMESPACE_CANNOT_REFERENCE_A_MODULE,
+                diagnostic_codes::IMPORT_DECLARATIONS_IN_A_NAMESPACE_CANNOT_REFERENCE_A_MODULE,
+            );
+            return;
+        }
+
         // TS18058/TS18059: Validate deferred import binding restrictions.
         // Deferred imports only allow namespace imports: `import defer * as ns from "..."`
         self.check_deferred_import_restrictions(import.import_clause);

--- a/crates/tsz-checker/tests/import_namespace_ts1147_tests.rs
+++ b/crates/tsz-checker/tests/import_namespace_ts1147_tests.rs
@@ -1,0 +1,283 @@
+//! A plain `import ... from "m"` declaration directly inside a non-ambient
+//! namespace reports TS1147 alone — never TS2307/TS2305, and never a
+//! co-occurring binder-level diagnostic like TS1214.
+//!
+//! tsc's `checkExternalImportOrExportDeclaration` reports this at the module
+//! specifier and returns `false` immediately when the enclosing module
+//! element is a namespace (a `ModuleBlock` whose declaration name is not a
+//! string literal). The caller gates everything downstream — module
+//! resolution, named-export validation, and even the reserved-word binding
+//! check — on that `false`, so TS1147 is the *only* diagnostic. This mirrors
+//! the same-shaped TS1194 gate already implemented for `export ... from` in a
+//! namespace (`check_export_declaration`).
+//!
+//! `declare module "m" { ... }` is a distinct, valid module-element context
+//! (string-literal ambient module) and is excluded by
+//! `is_inside_namespace_declaration` itself; `declare global { ... }` is a
+//! separate augmentation form that reports TS2667 instead of TS1147.
+//!
+//! All expectations were measured against `typescript@7.0.2` with
+//! `--strict --lib es2022 --target es2022 --module esnext --moduleResolution
+//! bundler`.
+
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::sync::Arc;
+use tsz_binder::BinderState;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::state::CheckerState;
+use tsz_parser::parser::ParserState;
+use tsz_solver::construction::TypeInterner;
+
+/// Check a single source with unresolved-import reporting on, so a module
+/// specifier naming a nonexistent module would report TS2307/TS2305 if it
+/// were resolved.
+fn check(source: &str) -> Vec<u32> {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        CheckerOptions {
+            module: tsz_common::common::ModuleKind::ESNext,
+            target: tsz_common::common::ScriptTarget::ESNext,
+            ..CheckerOptions::default()
+        },
+    );
+    checker.ctx.report_unresolved_imports = true;
+    checker.check_source_file(root);
+    let mut codes: Vec<u32> = checker.ctx.diagnostics.iter().map(|d| d.code).collect();
+    codes.sort_unstable();
+    codes
+}
+
+fn assert_codes(source: &str, expected: &[u32], what: &str) {
+    let actual = check(source);
+    assert_eq!(actual, expected, "{what}\nsource:\n{source}");
+}
+
+// ---------------------------------------------------------------------------
+// TS1147 alone, across the shapes that would otherwise reach resolution or a
+// binder-level check.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn named_import_in_namespace_reports_ts1147_without_ts2307() {
+    assert_codes(
+        r#"namespace N {
+  import { a } from "nonexistent-module";
+}"#,
+        &[1147],
+        "the primary repro from #16410 item 1",
+    );
+}
+
+#[test]
+fn default_import_in_namespace_reports_ts1147_without_ts2307() {
+    assert_codes(
+        r#"namespace N {
+  import Default from "nonexistent-module";
+}"#,
+        &[1147],
+        "a default import binding takes the same gate",
+    );
+}
+
+#[test]
+fn namespace_star_import_in_namespace_reports_ts1147_without_ts2307() {
+    assert_codes(
+        r#"namespace N {
+  import * as ns from "nonexistent-module";
+}"#,
+        &[1147],
+        "a namespace-form binding takes the same gate",
+    );
+}
+
+#[test]
+fn side_effect_import_in_namespace_reports_ts1147_without_ts2307() {
+    assert_codes(
+        r#"namespace N {
+  import "nonexistent-module";
+}"#,
+        &[1147],
+        "a bare side-effect import still has a module specifier to anchor on",
+    );
+}
+
+#[test]
+fn reserved_word_binding_in_namespace_reports_ts1147_alone() {
+    // Oracle-confirmed: `namespace N { import { eval } from "m"; }` under
+    // `--strict` is TS1147 alone, not TS1147 + TS1214. The reserved-word
+    // check never runs because tsc's checkImportDeclaration returns before
+    // reaching it.
+    assert_codes(
+        r#"namespace N {
+  import { eval } from "nonexistent-module";
+}"#,
+        &[1147],
+        "TS1147 suppresses the downstream reserved-word (TS1214) check too",
+    );
+}
+
+#[test]
+fn nested_namespace_import_reports_ts1147() {
+    assert_codes(
+        r#"namespace Outer {
+  namespace Inner {
+    import { a } from "nonexistent-module";
+  }
+}"#,
+        &[1147],
+        "a doubly-nested namespace is still a namespace context",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls. These must keep resolving / reporting normally.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn import_at_top_level_still_reports_ts2307() {
+    assert_codes(
+        r#"import { a } from "nonexistent-module";"#,
+        &[2307],
+        "the control: a well-placed import must still resolve its specifier",
+    );
+}
+
+#[test]
+fn import_inside_ambient_module_still_reports_ts2307() {
+    // `declare module "amb"` is a string-literal ambient module, a distinct
+    // and valid module-element context — `is_inside_namespace_declaration`
+    // excludes it, so resolution still runs.
+    assert_codes(
+        r#"declare module "amb" {
+  import { a } from "nonexistent-module";
+}"#,
+        &[2307],
+        "an ambient module body is a valid context; resolution still runs",
+    );
+}
+
+#[test]
+fn import_nested_in_block_within_namespace_reports_ts1232_not_ts1147() {
+    // Oracle-confirmed: further nested in a block inside the namespace, tsc
+    // reports TS1232 alone — the namespace-specific TS1147 gate correctly
+    // defers to it via `!in_wrong_context` (no TS1147 below). The residual
+    // TS2307 is a distinct, pre-existing gap (tsz does not yet short-circuit
+    // module resolution after a TS1232 placement error — that suppression is
+    // #16409's territory, out of scope here) and is pinned rather than hidden.
+    assert_codes(
+        r#"namespace N {
+  if (true) {
+    import { a } from "nonexistent-module";
+  }
+}"#,
+        &[1232, 2307],
+        "a block nested inside the namespace is not a direct module-element context; TS1147 must not also fire",
+    );
+}
+
+#[test]
+fn import_inside_declare_global_reports_ts2307_not_ts1147() {
+    // `declare global {}` is a distinct augmentation form (not a namespace);
+    // tsc reports TS2667 (imports not permitted in module augmentations) AND
+    // still resolves the specifier (TS2307), oracle-confirmed. tsz's
+    // `is_inside_global_augmentation` guard keeps the namespace-specific
+    // TS1147 gate from also firing here (the assertion this test protects),
+    // but TS2667 itself is only wired for the `import x = require(...)` form
+    // today (`declarations/import/equals.rs`), not this plain `import ...
+    // from` form — a distinct, pre-existing gap, pinned rather than hidden.
+    assert_codes(
+        r#"declare global {
+  import { a } from "nonexistent-module";
+}
+export {};"#,
+        &[2307],
+        "declare global is not a namespace context for TS1147 purposes",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Two-file case: the module resolves, but the imported member does not
+// exist. tsc still reports TS1147 alone (not TS1147 + TS2305) because
+// resolution never runs at all.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn named_import_of_missing_member_in_namespace_reports_ts1147_without_ts2305() {
+    let dep_source = "export const present = 1;\n";
+    let entry_source = r#"namespace N {
+  import { missing } from "./dep";
+}"#;
+
+    let dep_name = "dep.ts";
+    let entry_name = "entry.ts";
+    let module_specifier = "./dep";
+
+    let mut parser_dep = ParserState::new(dep_name.to_string(), dep_source.to_string());
+    let root_dep = parser_dep.parse_source_file();
+    let mut binder_dep = BinderState::new();
+    binder_dep.bind_source_file(parser_dep.get_arena(), root_dep);
+
+    let mut parser_entry = ParserState::new(entry_name.to_string(), entry_source.to_string());
+    let root_entry = parser_entry.parse_source_file();
+    let mut binder_entry = BinderState::new();
+    binder_entry.bind_source_file(parser_entry.get_arena(), root_entry);
+
+    if let Some(exports) = binder_dep.module_exports.get(dep_name).cloned() {
+        Arc::make_mut(&mut binder_entry.module_exports)
+            .insert(module_specifier.to_string(), exports);
+    }
+
+    let arena_entry = Arc::new(parser_entry.get_arena().clone());
+    let all_arenas = Arc::new(vec![
+        Arc::new(parser_dep.get_arena().clone()),
+        Arc::clone(&arena_entry),
+    ]);
+    let binder_entry = Arc::new(binder_entry);
+    let all_binders = Arc::new(vec![Arc::new(binder_dep), Arc::clone(&binder_entry)]);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        arena_entry.as_ref(),
+        binder_entry.as_ref(),
+        &types,
+        entry_name.to_string(),
+        CheckerOptions {
+            module: tsz_common::common::ModuleKind::ESNext,
+            target: tsz_common::common::ScriptTarget::ESNext,
+            ..CheckerOptions::default()
+        },
+    );
+    checker.ctx.set_all_arenas(Arc::clone(&all_arenas));
+    checker.ctx.set_all_binders(Arc::clone(&all_binders));
+    checker.ctx.set_current_file_idx(1);
+    checker.ctx.report_unresolved_imports = true;
+
+    let mut resolved_module_paths: FxHashMap<(usize, String), usize> = FxHashMap::default();
+    resolved_module_paths.insert((1, module_specifier.to_string()), 0);
+    checker
+        .ctx
+        .set_resolved_module_paths(Arc::new(resolved_module_paths));
+
+    let mut resolved_modules: FxHashSet<String> = FxHashSet::default();
+    resolved_modules.insert(module_specifier.to_string());
+    checker.ctx.set_resolved_modules(resolved_modules);
+
+    checker.check_source_file(root_entry);
+
+    let mut codes: Vec<u32> = checker.ctx.diagnostics.iter().map(|d| d.code).collect();
+    codes.sort_unstable();
+    assert_eq!(
+        codes,
+        vec![1147],
+        "a resolvable module with a missing member is still TS1147 alone, not TS1147 + TS2305"
+    );
+}


### PR DESCRIPTION
`import { a } from "m"` directly inside a non-ambient namespace resolved its module specifier and reported TS2307/TS2305 on branch; tsc reports TS1147 ("Import declarations in a namespace cannot reference a module.") alone, anchored on the module specifier, and never resolves it.

**Structural rule:** tsc's `checkExternalImportOrExportDeclaration` reports this diagnostic and returns `false` immediately when the enclosing module element is a namespace, and the caller gates everything downstream on that result — module resolution, named-export validation, and even the binder-level reserved-word check (oracle-confirmed: `namespace N { import { eval } from "m"; } ` is TS1147 alone, not TS1147 + TS1214). tsz already has exactly this TS1147 emit site for `import x = require(...)` (`crates/tsz-checker/src/declarations/import/equals.rs`); the plain `import ... from` form never reached it. Owner is `check_import_declaration` (`crates/tsz-checker/src/declarations/import/declaration_check_body.rs`), mirroring the existing TS1194 gate for `export ... from` in a namespace (`check_export_declaration`).

`is_inside_namespace_declaration` already excludes string-literal ambient modules (`declare module "m"`, oracle-confirmed still TS2307) and this change additionally excludes `declare global` augmentations (oracle-confirmed TS2667 + TS2307, a distinct diagnostic family via `is_inside_global_augmentation`). `!in_wrong_context` defers to the existing TS1232 placement diagnostic when the import is further nested in a block within the namespace (oracle-confirmed TS1232 alone there).

### Adjacent cases covered

New unit suite `tests/import_namespace_ts1147_tests.rs`: named/default/namespace-star/side-effect import forms, a reserved-word binding, nested namespaces, and a two-file case where the module resolves but the member does not (still TS1147 alone, not TS1147 + TS2305) — plus negative controls for top-level, ambient-module, nested-block, and declare-global placements.

### Two residuals, pinned rather than hidden — both pre-existing, both out of scope here

- A block nested inside a namespace still leaks TS2307 alongside its correct TS1232 (tsz does not yet short-circuit resolution after a wrong-context placement error — that suppression belongs to #16409, currently open).
- `declare global` does not yet emit TS2667 for this plain `import ... from` form (only wired for `import x = require(...)` today, in `equals.rs`).

All expectations measured against `typescript@7.0.2` with `--strict --lib es2022 --target es2022 --module esnext --moduleResolution bundler`.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test import_namespace_ts1147_tests`: **11/11**.
- `cargo clippy -p tsz-checker --all-targets`: clean.
- Pre-commit hook (clippy + arch guard + local verification): passed.
- `compare-to-parent.sh origin/main` (base `a0040dd`): base failing=552, branch failing=550. **0 newly failing / 2 newly passing** (`es5ModuleInternalNamedImports.ts`, `promisePermutations.ts`), 0 fingerprint-changed. CI (clippy/arch-size/CI Summary) green at exact head `9f82f53`.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q76d8BABv7QsHriqTkg2AB)_
