### PR TITLE
fix(checker): an imported type reference resolves by imported name, not raw SymbolId ordinal

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file_import_alias_pin.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_import_alias_pin.rs
@@ -25,4 +25,34 @@ impl<'a> CheckerState<'a> {
         (local.has_any_flags(symbol_flags::ALIAS) && local.import_module().is_some())
             .then_some(local)
     }
+
+    /// `true` when a symbol read out of the *declaring* file's binder at the
+    /// raw id `sym_id` is genuinely the entity a local import alias at that
+    /// same id refers to.
+    ///
+    /// `get_symbol_from_registered_file_target` answers the right *file* — the
+    /// overlay records where the alias's target lives — but then indexes that
+    /// file's binder with the **consuming** file's raw `SymbolId`. Raw ids are
+    /// minted per binder from zero with no `base_offset`, so the read lands on
+    /// whichever declaration of the declaring file happens to sit at that
+    /// ordinal. It is right only by coincidence, when the imported entity is
+    /// also that file's Nth declaration.
+    ///
+    /// The imported name is what ties the two ends together, so require it to
+    /// match: `import { Shape }` may only accept a declaring-file symbol named
+    /// `Shape`, and `import { Shape as S }` likewise (the alias's
+    /// `import_name` is the module-side name, `escaped_name` the local one).
+    /// When `sym_id` is not a local import alias there is no alias for the
+    /// read to disagree with and it stands unchanged.
+    pub(crate) fn registered_file_target_matches_import_alias(
+        &self,
+        sym_id: SymbolId,
+        candidate: &tsz_binder::Symbol,
+    ) -> bool {
+        let Some(alias) = self.local_import_alias(sym_id) else {
+            return true;
+        };
+        let imported_name = alias.import_name().unwrap_or(alias.escaped_name.as_str());
+        candidate.escaped_name == imported_name
+    }
 }

--- a/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
+++ b/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
@@ -36,9 +36,17 @@ impl<'a> CheckerState<'a> {
             .binder
             .get_symbol(sym_id)
             .filter(|symbol| !self.reference_symbol_is_import_alias(symbol));
+        // The registered file target answers the right file but is indexed by
+        // the *consuming* file's raw `SymbolId`, which per-file binders mint
+        // from zero: `import { Shape }` in one file and an unrelated `Unused`
+        // in the imported one routinely share an id. Reading the declaring
+        // binder at that ordinal is right only by coincidence, so it may drive
+        // this reference's declaration metadata only when the imported name
+        // agrees.
         let registered_non_import_symbol = self
             .get_symbol_from_registered_file_target(sym_id)
-            .filter(|symbol| !self.reference_symbol_is_import_alias(symbol));
+            .filter(|symbol| !self.reference_symbol_is_import_alias(symbol))
+            .filter(|symbol| self.registered_file_target_matches_import_alias(sym_id, symbol));
         let symbol_meta = local_alias_symbol
             .or(registered_non_import_symbol)
             .or(current_non_import_symbol)

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -396,6 +396,8 @@ mod import_attributes_relation_routing_arch_tests;
 mod import_shadows_global_ctor_tests;
 #[path = "tests/imported_predicate_false_branch_tests.rs"]
 mod imported_predicate_false_branch_tests;
+#[path = "tests/imported_type_reference_raw_symbol_collision_tests.rs"]
+mod imported_type_reference_raw_symbol_collision_tests;
 #[path = "tests/in_narrow_aliased_union_tests.rs"]
 mod in_narrow_aliased_union_tests;
 #[path = "tests/in_narrow_apparent_member_tests.rs"]

--- a/crates/tsz-checker/src/tests/imported_type_reference_raw_symbol_collision_tests.rs
+++ b/crates/tsz-checker/src/tests/imported_type_reference_raw_symbol_collision_tests.rs
@@ -1,0 +1,238 @@
+//! Regression tests for cross-file type references whose raw `SymbolId`
+//! collides with an unrelated declaration in the imported file.
+//!
+//! Structural rule (pinned against `typescript@7.0.2`, the conformance pin):
+//! a type reference to an imported name denotes the entity that name is
+//! *imported as*, whatever ordinal position its declaration occupies in the
+//! declaring file. tsz resolves that through `type_reference_symbol_type`,
+//! whose declaration metadata may only come from the declaring file's binder
+//! when the raw `SymbolId` genuinely names the imported entity there.
+//!
+//! Per-file binders mint raw `SymbolId`s from zero with no `base_offset`, so
+//! `import { Shape } from "./dep"` in one file and an unrelated `Unused` in
+//! `./dep` routinely share an id. `get_symbol_from_registered_file_target`
+//! answers the right *file* but indexes it with the consuming file's raw id,
+//! which lands on whichever declaration sits at that ordinal — right only by
+//! coincidence, when the imported entity happens to be the declaring file's
+//! first declaration. When the collision landed on an `INTERFACE` or `CLASS`
+//! symbol it drove a committing branch of `type_reference_symbol_type` and
+//! produced a diagnostic naming the *wrong target type* and a *wrong missing
+//! property* (the class's static side, so `prototype`); when it landed on a
+//! type alias, variable, function, or enum the fallback path re-resolved the
+//! alias and the answer came out right. Every row below therefore varies the
+//! declaration that precedes the imported one.
+//!
+//! The oracle for each row is recorded inline as the tsc output it was pinned
+//! against.
+
+use crate::context::CheckerOptions;
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::check_multi_file_with_libs_stamped;
+use tsz_common::diagnostics::diagnostic_codes;
+
+const TS2741: u32 = diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE;
+
+const SHAPE_CLASS: &str = "export class Shape { held: number = 0; away: number = 0; }\n";
+const IMPORT_SHAPE_ANNOTATION: &str =
+    "import { Shape } from \"./dep\";\nconst s: Shape = { held: 1 };\n";
+
+fn diagnostics(dep: &str, main: &str) -> Vec<Diagnostic> {
+    check_multi_file_with_libs_stamped(
+        &[("dep.ts", dep), ("main.ts", main)],
+        "main.ts",
+        CheckerOptions::default(),
+        &[],
+    )
+}
+
+/// The single diagnostic of `code`, as `(message, count of all diagnostics)`.
+fn only_message(dep: &str, main: &str, code: u32) -> String {
+    let diags = diagnostics(dep, main);
+    let matching: Vec<_> = diags.iter().filter(|d| d.code == code).collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected exactly one TS{code}; got {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+    matching[0].message_text.clone()
+}
+
+fn assert_clean(dep: &str, main: &str) {
+    let diags = diagnostics(dep, main);
+    assert!(
+        diags.is_empty(),
+        "expected no diagnostics; got {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// The witness. `Shape` is the declaring file's *second* declaration, so its
+/// raw `SymbolId` in `dep.ts` is not the one `main.ts` minted for the import
+/// alias. tsc:
+///
+/// ```text
+/// main.ts(2,7): error TS2741: Property 'away' is missing in type
+/// '{ held: number; }' but required in type 'Shape'.
+/// ```
+#[test]
+fn imported_class_after_an_interface_resolves_to_the_class_instance() {
+    let dep = format!("export interface Unused {{ keep: number; }}\n{SHAPE_CLASS}");
+    assert_eq!(
+        only_message(&dep, IMPORT_SHAPE_ANNOTATION, TS2741),
+        "Property 'away' is missing in type '{ held: number; }' but required in type 'Shape'."
+    );
+}
+
+/// The coincidence case that already worked: the imported class is the
+/// declaring file's first declaration, so the colliding raw id happened to
+/// name it. Same tsc output as the row above — it must stay unchanged.
+#[test]
+fn imported_class_as_the_first_declaration_is_unchanged() {
+    assert_eq!(
+        only_message(SHAPE_CLASS, IMPORT_SHAPE_ANNOTATION, TS2741),
+        "Property 'away' is missing in type '{ held: number; }' but required in type 'Shape'."
+    );
+}
+
+/// A preceding *class* is the other shape that drove a committing branch. tsc
+/// reports the same TS2741 as every other row.
+#[test]
+fn imported_class_after_another_class_resolves_to_the_imported_class() {
+    let dep = format!("export class Unused {{ keep: number = 0; }}\n{SHAPE_CLASS}");
+    assert_eq!(
+        only_message(&dep, IMPORT_SHAPE_ANNOTATION, TS2741),
+        "Property 'away' is missing in type '{ held: number; }' but required in type 'Shape'."
+    );
+}
+
+/// Two preceding declarations, so the collision lands on neither the imported
+/// class nor the declaration immediately before it — the defect was an ordinal
+/// mismatch, not an off-by-one.
+#[test]
+fn imported_class_after_two_interfaces_resolves_to_the_imported_class() {
+    let dep = format!(
+        "export interface A {{ a: number; }}\nexport interface B {{ b: number; }}\n{SHAPE_CLASS}"
+    );
+    assert_eq!(
+        only_message(&dep, IMPORT_SHAPE_ANNOTATION, TS2741),
+        "Property 'away' is missing in type '{ held: number; }' but required in type 'Shape'."
+    );
+}
+
+/// Binder names must not matter: the same shape under different identifiers
+/// resolves through the imported name, not a name the fix could have keyed on.
+/// tsc:
+///
+/// ```text
+/// main.ts(2,7): error TS2741: Property 'omega' is missing in type
+/// '{ alpha: number; }' but required in type 'Widget'.
+/// ```
+#[test]
+fn renamed_binders_resolve_the_imported_class_the_same_way() {
+    let dep = "export interface Zed { keep: number; }\nexport class Widget { alpha: number = 0; omega: number = 0; }\n";
+    let main = "import { Widget } from \"./dep\";\nconst w: Widget = { alpha: 1 };\n";
+    assert_eq!(
+        only_message(dep, main, TS2741),
+        "Property 'omega' is missing in type '{ alpha: number; }' but required in type 'Widget'."
+    );
+}
+
+/// A renamed import: the alias's local name is `S`, its module-side name is
+/// `Shape`, and tsc reports the *module-side* name as the target type.
+///
+/// ```text
+/// main.ts(2,7): error TS2741: Property 'away' is missing in type
+/// '{ held: number; }' but required in type 'Shape'.
+/// ```
+#[test]
+fn renamed_import_resolves_through_the_module_side_name() {
+    let dep = format!("export interface Unused {{ keep: number; }}\n{SHAPE_CLASS}");
+    let main = "import { Shape as S } from \"./dep\";\nconst s: S = { held: 1 };\n";
+    assert_eq!(
+        only_message(&dep, main, TS2741),
+        "Property 'away' is missing in type '{ held: number; }' but required in type 'Shape'."
+    );
+}
+
+/// A generic imported class after an interface. tsc:
+///
+/// ```text
+/// main.ts(2,7): error TS2741: Property 'away' is missing in type
+/// '{ held: number; }' but required in type 'Box[number]'.
+/// ```
+/// (rendered here with square brackets only in this comment).
+#[test]
+fn imported_generic_class_after_an_interface_keeps_its_type_arguments() {
+    let dep = "export interface Unused { keep: number; }\nexport class Box<T> { held: T; away: T; constructor(v: T) { this.held = v; this.away = v; } }\n";
+    let main = "import { Box } from \"./dep\";\nconst b: Box<number> = { held: 1 };\n";
+    assert_eq!(
+        only_message(dep, main, TS2741),
+        "Property 'away' is missing in type '{ held: number; }' but required in type 'Box<number>'."
+    );
+}
+
+/// A namespace import reaches the same declaration through a qualified name.
+/// tsc reports the same TS2741, so the two spellings must agree.
+#[test]
+fn namespace_import_member_resolves_to_the_same_class() {
+    let dep = format!("export interface Unused {{ keep: number; }}\n{SHAPE_CLASS}");
+    let main = "import * as dep from \"./dep\";\nconst s: dep.Shape = { held: 1 };\n";
+    assert_eq!(
+        only_message(&dep, main, TS2741),
+        "Property 'away' is missing in type '{ held: number; }' but required in type 'Shape'."
+    );
+}
+
+/// An imported *interface* after another interface — the sibling of the class
+/// witness, and the shape that already worked. It must keep working.
+#[test]
+fn imported_interface_after_an_interface_is_unchanged() {
+    let dep = "export interface Unused { keep: number; }\nexport interface Shape { held: number; away: number; }\n";
+    assert_eq!(
+        only_message(dep, IMPORT_SHAPE_ANNOTATION, TS2741),
+        "Property 'away' is missing in type '{ held: number; }' but required in type 'Shape'."
+    );
+}
+
+/// Negative case: a complete object literal satisfies the imported class's
+/// *instance* side. The defect compared its static side, where every such
+/// literal is missing `prototype`, so a clean row is the load-bearing half of
+/// the fix. tsc reports nothing here.
+#[test]
+fn a_complete_literal_satisfies_the_imported_class_instance_side() {
+    let dep = format!("export interface Unused {{ keep: number; }}\n{SHAPE_CLASS}");
+    assert_clean(
+        &dep,
+        "import { Shape } from \"./dep\";\nconst s: Shape = { held: 1, away: 2 };\n",
+    );
+}
+
+/// Property access through an imported-class annotation. tsc reports nothing;
+/// the members must come from the instance side.
+#[test]
+fn member_access_through_an_imported_class_annotation_is_clean() {
+    let dep = format!("export interface Unused {{ keep: number; }}\n{SHAPE_CLASS}");
+    assert_clean(
+        &dep,
+        "import { Shape } from \"./dep\";\nexport function f(s: Shape): number { return s.held; }\n",
+    );
+}
+
+/// Heritage through an imported class after an interface: the subclass's
+/// instance must still be assignable to the base annotation. tsc reports
+/// nothing.
+#[test]
+fn heritage_through_an_imported_class_after_an_interface_is_clean() {
+    let dep = format!("export interface Unused {{ keep: number; }}\n{SHAPE_CLASS}");
+    assert_clean(
+        &dep,
+        "import { Shape } from \"./dep\";\nexport class Sub extends Shape { extra: number = 0; }\nconst x: Shape = new Sub();\n",
+    );
+}


### PR DESCRIPTION
Fixes #16415 row 1 — filed this morning by Halite and handed off as *"the highest-value item I found this hour and I did not take it."* It is a **wrong primary message**, not a missing pointer.

## Structural rule

**When a type reference names a local import alias, it denotes the entity that name is imported as — whatever ordinal position that declaration occupies in the declaring file. tsc resolves the alias to its target symbol; tsz does the same through the checker's cross-file symbol layer (`type_reference_symbol_type` + `cross_file_import_alias_pin`), which may only let a raw-`SymbolId` read of the declaring file's binder drive the reference when the imported name agrees.**

### What was wrong

`type_reference_symbol_type` takes the reference's declaration metadata (name, flags, declarations, value declaration) from `get_symbol_from_registered_file_target`. That helper answers the right *file* — the overlay records where the alias's target lives — but then indexes that file's binder with the **consuming** file's raw `SymbolId`:

```rust
let file_idx = self.ctx.resolve_symbol_file_index(sym_id)?;
self.ctx.get_binder_for_file(file_idx)?.get_symbol(sym_id)
```

Per-file binders mint raw ids from `0` with no `base_offset`, so `import { Shape } from "./dep"` in one file and an unrelated `Unused` in `./dep` routinely share an id. The read lands on whichever declaration of the declaring file sits at that ordinal. It was right only by **coincidence** — when the imported entity happened to be that file's first declaration.

Instrumented on the witness (probe since removed):

```
tref sym=SymbolId(0) cur_file=1
  meta=("Unused", INTERFACE)      <- what drove the reference
  reg_nonimport=("Unused", INTERFACE)
  crossfile=("Shape", ALIAS)      <- the collision-safe reader had it right
```

`INTERFACE` and `CLASS` flags drive *committing* branches of `type_reference_symbol_type`, so the wrong symbol is finalised. Everything downstream follows: the def registry publishes the class's **constructor** shape under the interface's `DefId`, and the annotation lowers to `Lazy(DefId(3))` whose `body` is a `Callable`:

```
def DefId(2) kind=Class     name="Shape"  file=0 sym=1 body=Callable(3)
def DefId(3) kind=Interface name="Unused" file=0 sym=0 body=Callable(3)   <- poisoned
```

When the collision instead lands on a type alias, variable, function, or enum, none of those branches commits, the fallback path re-resolves the alias, and the answer comes out right — which is why this family is only visible behind a **preceding interface or class** declaration. That is also why it survived: the obvious two-file repro (`export class Shape` alone in `dep.ts`) does not reproduce it.

### The fix

`registered_file_target_matches_import_alias` requires the imported name to match before the raw-id read may drive the reference. `import { Shape }` accepts only a declaring-file symbol named `Shape`; `import { Shape as S }` likewise, since the alias's `import_name` is the module-side name and `escaped_name` the local one. When `sym_id` is not a local import alias there is no alias for the read to disagree with and it stands unchanged — the guard can only ever *reject* a read that was already arbitrary.

Rejecting it lets the existing alias-following path resolve the reference, exactly as it already does for the type-alias/variable/function/enum neighbours. The trace after the fix shows the alias correctly followed to the declaring file's real id:

```
tref sym=SymbolId(0) meta=("Shape", ALIAS)   reg_nonimport=None     <- collision rejected
tref sym=SymbolId(2) meta=("Shape", CLASS)   reg_nonimport=("Shape", CLASS)
```

This is the #15983 raw-`SymbolId`-ambiguity family reached from the reference-resolution side. It is *not* the general fix for that campaign — it closes the one reader that lets an ambiguous id decide a type reference's identity.

### Anti-hardcoding

No identifier, alias, property, or file-name literal drives the decision; the predicate is `alias.import_name() == candidate.escaped_name`, both binder-supplied. No predicate reads rendered type or printer output. Binder names are varied in the suite (`Shape`/`Unused`/`Widget`/`Zed`/`Box`/`A`/`B`) and the renamed-import row proves the local name is not what is matched.

## Goal
Goal: hold

## Verification

**Corpus gate — `./scripts/conformance/compare-to-parent.sh origin/main`, two-sided, branch `bfde5b8` vs base `77c3fd4`:**

```
base failing=553  branch failing=552

NEWLY PASSING (1):
   + typeArgumentInferenceConstructSignatures.ts
NEWLY FAILING (0):
   (none)
still failing, fingerprint changed (0):
```

Both sides `12043` runnable; branch `11490` passed vs base `11489`. Graded on newly-failing, which is **0**. The +1 is real corpus movement, not a total-count artifact.

**New suite `imported_type_reference_raw_symbol_collision_tests.rs` — 12 rows, every one pinned against `typescript@7.0.2` (the conformance pin) run directly.**

| row | tsc `7.0.2` | tsz before | tsz after |
| --- | --- | --- | --- |
| class after interface | `TS2741 'away' … in type 'Shape'` | `TS2741 'prototype' … in type 'Unused'` | matches |
| class after another class | `TS2741 'away' … 'Shape'` | `TS2353 'held' does not exist in type 'Unused'` | matches |
| class after **two** interfaces | `TS2741 'away' … 'Shape'` | `TS2741 'prototype' … 'A'` | matches |
| renamed binders (`Widget`/`Zed`) | `TS2741 'omega' … 'Widget'` | `TS2741 'prototype' … 'Zed'` | matches |
| renamed import (`Shape as S`) | `TS2741 'away' … 'Shape'` | `TS2741 'prototype' … 'Unused'` | matches |
| complete literal (negative) | clean | `TS2741 'prototype'` | matches |
| heritage `extends Shape` | clean | `TS2741 'prototype'` | matches |
| class as **first** declaration | `TS2741 'away' … 'Shape'` | matches | unchanged |
| imported **interface** after interface | `TS2741 'away' … 'Shape'` | matches | unchanged |
| generic class `Box[T]` after interface | `TS2741 'away' … 'Box[number]'` | matches | unchanged |
| namespace import `dep.Shape` | `TS2741 'away' … 'Shape'` | matches | unchanged |
| member access `s.held` | clean | matches | unchanged |

- **Known-bad probe run first** (per the board's standing gotcha — a fix on this path cannot fail loudly): at parent `77c3fd4` the suite is **7 failed / 5 passed**. The 5 passing rows are exactly the coincidence + already-correct rows, so they guard against over-application rather than decorating the diff. With the fix: **12 passed / 0 failed**.
- `cargo test -p tsz-checker --lib imported_type_reference_raw_symbol_collision` → 12/12.
- `cargo fmt`; pre-commit hook (`clippy -p tsz-checker`, warnings denied, + architecture guard) → clean.
- CI at exact head `bfde5b8`: `clippy` ✅, `arch-size` ✅, `CI Summary` ✅.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Zircon