### PR TITLE
fix(checker): gate namespace-body TS1063/TS1319 on has_parse_errors

### DIFF
--- a/crates/tsz-checker/src/declarations/import/core/module_exports.rs
+++ b/crates/tsz-checker/src/declarations/import/core/module_exports.rs
@@ -55,11 +55,13 @@ impl<'a> CheckerState<'a> {
                         .get(stmt_idx)
                         .is_some_and(|n| n.kind == syntax_kind_ext::EXPORT_ASSIGNMENT);
                     if is_export_assign && !is_ambient_external_module {
-                        self.error_at_node(
-                            stmt_idx,
-                            diagnostic_messages::AN_EXPORT_ASSIGNMENT_CANNOT_BE_USED_IN_A_NAMESPACE,
-                            diagnostic_codes::AN_EXPORT_ASSIGNMENT_CANNOT_BE_USED_IN_A_NAMESPACE,
-                        );
+                        if !self.ctx.has_parse_errors {
+                            self.error_at_node(
+                                stmt_idx,
+                                diagnostic_messages::AN_EXPORT_ASSIGNMENT_CANNOT_BE_USED_IN_A_NAMESPACE,
+                                diagnostic_codes::AN_EXPORT_ASSIGNMENT_CANNOT_BE_USED_IN_A_NAMESPACE,
+                            );
+                        }
                         continue;
                     }
                     if is_ambient_body

--- a/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
@@ -127,7 +127,8 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
             // diagnostics like TS1194 or TS1319.
             let in_non_module_context = self.is_in_non_module_element_context(export_idx);
 
-            if !in_non_module_context
+            if !self.ctx.has_parse_errors
+                && !in_non_module_context
                 && export_decl.is_default_export
                 && self.is_inside_namespace_declaration(export_idx)
             {

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -275,6 +275,8 @@ mod expando_annotated_receiver_tests;
 mod explicit_alias_constraint_relation_routing_arch_tests;
 #[path = "tests/explicit_type_arg_overload_pruning_tests.rs"]
 mod explicit_type_arg_overload_pruning_tests;
+#[path = "tests/export_assignment_default_namespace_parse_error_gate_tests.rs"]
+mod export_assignment_default_namespace_parse_error_gate_tests;
 #[path = "tests/export_declaration_module_element_context_tests.rs"]
 mod export_declaration_module_element_context_tests;
 #[path = "tests/flow_assignment_relation_routing_arch_tests.rs"]

--- a/crates/tsz-checker/src/tests/export_assignment_default_namespace_parse_error_gate_tests.rs
+++ b/crates/tsz-checker/src/tests/export_assignment_default_namespace_parse_error_gate_tests.rs
@@ -1,0 +1,109 @@
+//! #16416: a namespace-body `export =` / `export default` reports TS1063 /
+//! TS1319 unconditionally, even when the same statement already carries a
+//! genuine parser error. tsc's `hasParseDiagnostics(sourceFile)` gate is
+//! whole-file (not statement-scoped) and suppresses these grammar checks the
+//! moment any real syntax error exists anywhere in the file — the sibling
+//! `TS1194` branch three lines below the TS1319 site in
+//! `check_export_declaration` (`state/state_checking_members/statement_callback_bridge.rs`)
+//! already guards on `!self.ctx.has_parse_errors`; the TS1319 branch above it
+//! did not, and `module_exports.rs`'s TS1063 site
+//! (`declarations/import/core/module_exports.rs`) had no such guard at all.
+//!
+//! `override` is the reproducer because it is the one statement modifier
+//! whose own TS1434 ("Unexpected keyword or identifier.") is never itself
+//! suppressed by the parser's own container-split recovery, so it is the
+//! first case where a genuine parse error and this namespace-body check
+//! collide in the same statement (see #16416, split from #16412).
+//!
+//! All expectations measured directly against `typescript@7.0.2` (the
+//! conformance pin, `scripts/conformance/typescript-versions.json`),
+//! `--noEmit --strict --pretty false --lib es2022 --target es2022 --module es2022`.
+//!
+//! Uses [`check_source_codes_with_parse_health`], not the blind
+//! `check_source`/`check_source_codes` helpers: those never wire real parser
+//! diagnostics into `has_parse_errors`, so they cannot observe this
+//! suppression at all (see that helper's own doc comment).
+
+use crate::test_utils::check_source_codes_with_parse_health;
+
+const UNEXPECTED_KEYWORD_OR_IDENTIFIER: u32 = 1434;
+const EXPORT_ASSIGNMENT_CANNOT_BE_USED_IN_A_NAMESPACE: u32 = 1063;
+const DEFAULT_EXPORT_ONLY_IN_ECMASCRIPT_MODULE: u32 = 1319;
+
+/// `override` before `export =` in a namespace: tsc reports TS1434 alone —
+/// the parser fails on `override` before anything downstream runs, so
+/// `module_exports.rs`'s namespace-body check must not also fire TS1063.
+#[test]
+fn override_export_assignment_in_namespace_reports_only_ts1434() {
+    let codes = check_source_codes_with_parse_health("namespace N { override export = 1; }");
+    assert!(
+        codes.contains(&UNEXPECTED_KEYWORD_OR_IDENTIFIER),
+        "expected TS1434 for the misplaced `override`; got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&EXPORT_ASSIGNMENT_CANNOT_BE_USED_IN_A_NAMESPACE),
+        "tsc suppresses TS1063 once a genuine parse error exists in the file; got {codes:?}"
+    );
+}
+
+/// Same shape for `export default <expr>`: tsc reports TS1434 alone, and
+/// `check_export_declaration`'s TS1319 branch must defer to it.
+#[test]
+fn override_export_default_expression_in_namespace_reports_only_ts1434() {
+    let codes = check_source_codes_with_parse_health("namespace N { override export default 1; }");
+    assert!(codes.contains(&UNEXPECTED_KEYWORD_OR_IDENTIFIER));
+    assert!(
+        !codes.contains(&DEFAULT_EXPORT_ONLY_IN_ECMASCRIPT_MODULE),
+        "tsc suppresses TS1319 once a genuine parse error exists in the file; got {codes:?}"
+    );
+}
+
+/// `export default class C {}` in a namespace exercises the other branch of
+/// `check_export_declaration`'s TS1319 code (the `clause_is_declaration` arm
+/// that anchors on the `default` keyword instead of the export node).
+#[test]
+fn override_export_default_class_in_namespace_reports_only_ts1434() {
+    let codes =
+        check_source_codes_with_parse_health("namespace N { override export default class C {} }");
+    assert!(codes.contains(&UNEXPECTED_KEYWORD_OR_IDENTIFIER));
+    assert!(!codes.contains(&DEFAULT_EXPORT_ONLY_IN_ECMASCRIPT_MODULE));
+}
+
+/// Same declaration-clause branch, a function this time.
+#[test]
+fn override_export_default_function_in_namespace_reports_only_ts1434() {
+    let codes = check_source_codes_with_parse_health(
+        "namespace N { override export default function f() {} }",
+    );
+    assert!(codes.contains(&UNEXPECTED_KEYWORD_OR_IDENTIFIER));
+    assert!(!codes.contains(&DEFAULT_EXPORT_ONLY_IN_ECMASCRIPT_MODULE));
+}
+
+/// A nested namespace, and a renamed outer binder — the suppression is a
+/// whole-file parse-health signal, not tied to nesting depth or a specific
+/// namespace name.
+#[test]
+fn override_export_assignment_in_nested_namespace_reports_only_ts1434() {
+    let codes = check_source_codes_with_parse_health(
+        "namespace Outer { namespace Inner { override export = 1; } }",
+    );
+    assert!(codes.contains(&UNEXPECTED_KEYWORD_OR_IDENTIFIER));
+    assert!(!codes.contains(&EXPORT_ASSIGNMENT_CANNOT_BE_USED_IN_A_NAMESPACE));
+}
+
+/// Negative control: with no parse error present, TS1063 still fires exactly
+/// as before — the gate must not over-suppress the ordinary case.
+#[test]
+fn export_assignment_in_namespace_without_parse_error_still_reports_ts1063() {
+    let codes = check_source_codes_with_parse_health("namespace N { export = 1; }");
+    assert!(!codes.contains(&UNEXPECTED_KEYWORD_OR_IDENTIFIER));
+    assert!(codes.contains(&EXPORT_ASSIGNMENT_CANNOT_BE_USED_IN_A_NAMESPACE));
+}
+
+/// Negative control for TS1319: with no parse error, it still fires.
+#[test]
+fn export_default_in_namespace_without_parse_error_still_reports_ts1319() {
+    let codes = check_source_codes_with_parse_health("namespace N { export default 1; }");
+    assert!(!codes.contains(&UNEXPECTED_KEYWORD_OR_IDENTIFIER));
+    assert!(codes.contains(&DEFAULT_EXPORT_ONLY_IN_ECMASCRIPT_MODULE));
+}


### PR DESCRIPTION
`namespace N { override export = 1; }`: tsc reports **TS1434** ("Unexpected keyword or identifier.") alone — `override` is never a valid statement modifier outside a class member, so the parser fails on it before anything downstream runs. tsz (main) reported **TS1434 + TS1063**, because `module_exports.rs`'s namespace-body export-assignment check fires unconditionally. Same shape for `export default`: tsc reports TS1434 alone, tsz reported TS1434 + TS1319.

**Structural rule:** tsc's `hasParseDiagnostics(sourceFile)` gate is whole-file, and `checkExportAssignment`/namespace-body export-default checks defer to it exactly like every other checker-grammar diagnostic. tsz already implements this gate — `check_grammar_module_element_context`'s TS1231/TS1258 family (`state/state_checking_members/statement_callback_bridge.rs`) and `check_export_declaration`'s own **TS1194** branch three lines below the TS1319 site both already guard on `!self.ctx.has_parse_errors`. The TS1319 branch above it never got the same guard, and `module_exports.rs`'s TS1063 site (`declarations/import/core/module_exports.rs`) had no guard at all. `override` is the first statement modifier whose own TS1434 is never itself silenced by the parser's container-split recovery, so it's the first case where a genuine parse error and this namespace-body check collide in the same statement.

Owner: checker (`check_export_declaration` and `check_module_body`'s suppression gating), mirroring the pattern #16367 established for `check_grammar_module_element_context`.

## Adjacent cases covered

New unit suite `tests/export_assignment_default_namespace_parse_error_gate_tests.rs`, all rows measured directly against `typescript@7.0.2` (`--noEmit --strict --pretty false --lib es2022 --target es2022 --module es2022`) before being written:

| Row | Shape | tsc | 
| --- | --- | --- |
| `override_export_assignment_in_namespace_reports_only_ts1434` | `override export = 1` | TS1434 alone |
| `override_export_default_expression_in_namespace_reports_only_ts1434` | `override export default 1` | TS1434 alone |
| `override_export_default_class_in_namespace_reports_only_ts1434` | `override export default class C {}` — the `clause_is_declaration` branch anchored on `default` | TS1434 alone |
| `override_export_default_function_in_namespace_reports_only_ts1434` | same branch, function | TS1434 alone |
| `override_export_assignment_in_nested_namespace_reports_only_ts1434` | nested namespace + renamed outer binder | TS1434 alone |
| `export_assignment_in_namespace_without_parse_error_still_reports_ts1063` | negative control, no parse error | TS1063 alone |
| `export_default_in_namespace_without_parse_error_still_reports_ts1319` | negative control, no parse error | TS1319 alone |

Closes #16416.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib export_assignment_default_namespace_parse_error_gate_tests`: 7/7 new.
- `cargo nextest run -p tsz-checker --lib export_declaration_module_element_context_tests module_exports no_implicit_override_ambient_context`: 42/42, no regressions in the closest sibling suites.
- Full `cargo nextest run -p tsz-checker --lib` (9589 tests): 9586 passed, 1 failed, 2 timed out. The 1 failure is `ts2303_tests::recursive_export_assignment_self_import_reports_ts2303` — pre-existing on main, tracked as #16406 and independently documented as red-on-main in #16417's verification. The 2 timeouts (`global_augmentation_computed_key_tests`) were a CPU-contention artifact from a concurrent `compare-to-parent` run in a sibling worktree on a 4-core seat; both pass in ~90s total (`cargo test -p tsz-checker --lib global_augmentation_computed_key_tests -- --test-threads=1`) when run without contention.
- `cargo clippy -p tsz-checker --all-targets`: clean.
- `cargo fmt --check` on all touched/added files: clean.
- Pre-commit hook (clippy + architecture guard + crate verification): passed.
- Oracle `typescript@7.0.2`: all 7 rows run directly, quoted in the test file's module doc.
- `compare-to-parent.sh`: not run in this container (busy draining #16418's own compare-to-parent). No corpus movement expected — the corpus does not pair a namespace-scoped `export =`/`export default` with a colliding genuine parse error on the same statement today (this is a net-new combination, not a regression on an existing fixture), consistent with the documented zero-movement signature for this diagnostic family (#16016/#16020/#16039/#16042/#16270/#16418).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_01PJCX1j6o3Pwtk2LcnXi6Qt)_