### PR TITLE
test(checker,emitter): pin the two red-on-main unit tests to the tsc oracle (#16406)

### DIFF
--- a/crates/tsz-checker/tests/ts2303_tests.rs
+++ b/crates/tsz-checker/tests/ts2303_tests.rs
@@ -38,7 +38,69 @@ fn get_diagnostics(source: &str, file_name: &str) -> Vec<(u32, String)> {
         .collect()
 }
 
-fn get_project_diagnostics(files: &[(&str, &str)]) -> Vec<(String, u32, String)> {
+/// Asserts the `TS2303` set for an `import self = require(...)` / `export = self`
+/// cycle matches what `tsc` reports.
+///
+/// `tsc` treats the import declaration and the `export =` assignment as two
+/// independent circular-alias sites, so every module participating in the cycle
+/// is reported exactly twice — once at each. Modules outside the cycle are
+/// reported not at all.
+fn assert_self_alias_cycle_sites(
+    files: &[(&str, &str)],
+    diagnostics: &[(String, u32, u32, String)],
+    cycle_members: &[&str],
+) {
+    let ts2303: Vec<_> = diagnostics
+        .iter()
+        .filter(|(_, code, _, _)| *code == 2303)
+        .collect();
+
+    for member in cycle_members {
+        let source = files
+            .iter()
+            .find_map(|(name, source)| (name == member).then_some(*source))
+            .unwrap_or_else(|| panic!("cycle member {member} is not in the fixture"));
+        let import_site = u32::try_from(source.find("import self").expect("import site")).unwrap();
+        let export_site =
+            u32::try_from(source.find("export = self").expect("export site")).unwrap();
+
+        let sites: Vec<u32> = ts2303
+            .iter()
+            .filter(|(file, _, _, message)| file == member && message.contains("'self'"))
+            .map(|(_, _, start, _)| *start)
+            .collect();
+
+        assert!(
+            sites.contains(&import_site),
+            "Expected TS2303 on {member}'s `import self = require(...)` declaration (offset {import_site}). Actual TS2303: {ts2303:#?}"
+        );
+        assert!(
+            sites.contains(&export_site),
+            "Expected TS2303 on {member}'s `export = self;` assignment (offset {export_site}). Actual TS2303: {ts2303:#?}"
+        );
+        assert_eq!(
+            sites.len(),
+            2,
+            "Expected exactly two TS2303 sites in {member}, with no duplicate at either. Actual TS2303: {ts2303:#?}"
+        );
+    }
+
+    assert_eq!(
+        ts2303.len(),
+        cycle_members.len() * 2,
+        "Only the {} cycle members may report TS2303, twice each. Actual diagnostics: {diagnostics:#?}",
+        cycle_members.len()
+    );
+}
+
+/// Checks a multi-file project, returning `(file, code, start, message)` per
+/// diagnostic.
+///
+/// A bare `(file, code, message)` triple cannot tell two reports at the same
+/// site apart from two reports at different sites, which is exactly the
+/// distinction `tsc` draws for a circular import alias: it reports `TS2303`
+/// once on the `import` declaration and once on the `export =` assignment.
+fn get_project_diagnostics_positioned(files: &[(&str, &str)]) -> Vec<(String, u32, u32, String)> {
     let mut arenas = Vec::with_capacity(files.len());
     let mut binders = Vec::with_capacity(files.len());
     let mut roots = Vec::with_capacity(files.len());
@@ -88,7 +150,7 @@ fn get_project_diagnostics(files: &[(&str, &str)]) -> Vec<(String, u32, String)>
                 .ctx
                 .diagnostics
                 .iter()
-                .map(|d| (file_name.clone(), d.code, d.message_text.clone())),
+                .map(|d| (file_name.clone(), d.code, d.start, d.message_text.clone())),
         );
     }
 
@@ -181,7 +243,7 @@ export as namespace N;
 
 #[test]
 fn recursive_export_assignment_self_import_reports_ts2303() {
-    let diagnostics = get_project_diagnostics(&[
+    const FILES: &[(&str, &str)] = &[
         (
             "recursiveExportAssignmentAndFindAliasedType4_moduleC.ts",
             r#"import self = require("./recursiveExportAssignmentAndFindAliasedType4_moduleC");
@@ -198,29 +260,20 @@ export = ClassB;"#,
 import ClassB = require("./recursiveExportAssignmentAndFindAliasedType4_moduleB");
 export var b: ClassB;"#,
         ),
-    ]);
+    ];
 
-    let ts2303: Vec<_> = diagnostics
-        .iter()
-        .filter(|(_, code, _)| *code == 2303)
-        .collect();
-    assert_eq!(
-        ts2303.len(),
-        1,
-        "Expected one TS2303 for recursive export assignment self-import. Actual diagnostics: {diagnostics:#?}"
-    );
-    assert!(
-        ts2303.iter().any(|(file, _, message)| {
-            file == "recursiveExportAssignmentAndFindAliasedType4_moduleC.ts"
-                && message.contains("'self'")
-        }),
-        "Expected TS2303 on moduleC's `self` alias. Actual TS2303 diagnostics: {ts2303:#?}"
+    let diagnostics = get_project_diagnostics_positioned(FILES);
+
+    assert_self_alias_cycle_sites(
+        FILES,
+        &diagnostics,
+        &["recursiveExportAssignmentAndFindAliasedType4_moduleC.ts"],
     );
 }
 
 #[test]
 fn recursive_export_assignment_two_file_cycle_reports_ts2303() {
-    let diagnostics = get_project_diagnostics(&[
+    const FILES: &[(&str, &str)] = &[
         (
             "recursiveExportAssignmentAndFindAliasedType5_moduleC.ts",
             r#"import self = require("./recursiveExportAssignmentAndFindAliasedType5_moduleD");
@@ -242,24 +295,23 @@ export = ClassB;"#,
 import ClassB = require("./recursiveExportAssignmentAndFindAliasedType5_moduleB");
 export var b: ClassB;"#,
         ),
-    ]);
+    ];
 
-    let ts2303: Vec<_> = diagnostics
-        .iter()
-        .filter(|(_, code, _)| *code == 2303)
-        .collect();
-    assert!(
-        ts2303.iter().any(|(file, _, message)| {
-            file == "recursiveExportAssignmentAndFindAliasedType5_moduleD.ts"
-                && message.contains("'self'")
-        }),
-        "Expected TS2303 on moduleD's `self` alias. Actual TS2303 diagnostics: {ts2303:#?}"
+    let diagnostics = get_project_diagnostics_positioned(FILES);
+
+    assert_self_alias_cycle_sites(
+        FILES,
+        &diagnostics,
+        &[
+            "recursiveExportAssignmentAndFindAliasedType5_moduleC.ts",
+            "recursiveExportAssignmentAndFindAliasedType5_moduleD.ts",
+        ],
     );
 }
 
 #[test]
 fn recursive_export_assignment_three_file_cycle_reports_ts2303() {
-    let diagnostics = get_project_diagnostics(&[
+    const FILES: &[(&str, &str)] = &[
         (
             "recursiveExportAssignmentAndFindAliasedType6_moduleC.ts",
             r#"import self = require("./recursiveExportAssignmentAndFindAliasedType6_moduleD");
@@ -286,17 +338,17 @@ export = ClassB;"#,
 import ClassB = require("./recursiveExportAssignmentAndFindAliasedType6_moduleB");
 export var b: ClassB;"#,
         ),
-    ]);
+    ];
 
-    let ts2303: Vec<_> = diagnostics
-        .iter()
-        .filter(|(_, code, _)| *code == 2303)
-        .collect();
-    assert!(
-        ts2303.iter().any(|(file, _, message)| {
-            file == "recursiveExportAssignmentAndFindAliasedType6_moduleE.ts"
-                && message.contains("'self'")
-        }),
-        "Expected TS2303 on moduleE's `self` alias. Actual TS2303 diagnostics: {ts2303:#?}"
+    let diagnostics = get_project_diagnostics_positioned(FILES);
+
+    assert_self_alias_cycle_sites(
+        FILES,
+        &diagnostics,
+        &[
+            "recursiveExportAssignmentAndFindAliasedType6_moduleC.ts",
+            "recursiveExportAssignmentAndFindAliasedType6_moduleD.ts",
+            "recursiveExportAssignmentAndFindAliasedType6_moduleE.ts",
+        ],
     );
 }

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations_parts/part_04.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations_parts/part_04.rs
@@ -14,8 +14,70 @@ const result = parse(42);
         "Did not expect overloaded call initializer to use the first overload return type: {output}"
     );
     assert!(
-        output.contains("declare const result = 42;"),
-        "Expected overloaded call initializer to fall back without first-overload poisoning: {output}"
+        output.contains("declare const result: number;"),
+        "Expected overloaded call initializer to use the MATCHING overload return type: {output}"
+    );
+}
+
+#[test]
+fn test_overloaded_call_initializer_picks_each_matching_signature_return_type() {
+    let output = emit_dts_with_binding(
+        r#"
+function parse(input: string): string;
+function parse(input: number): number;
+function parse(input: string | number): string | number { return input; }
+const fromString = parse("hi");
+const fromNumber = parse(42);
+"#,
+    );
+
+    assert!(
+        output.contains("declare const fromString: string;"),
+        "Expected the string overload to drive the string-argument call: {output}"
+    );
+    assert!(
+        output.contains("declare const fromNumber: number;"),
+        "Expected the number overload to drive the number-argument call: {output}"
+    );
+}
+
+#[test]
+fn test_overloaded_call_initializer_reaches_past_the_first_two_signatures() {
+    let output = emit_dts_with_binding(
+        r#"
+function pick(v: boolean): boolean;
+function pick(v: string): string;
+function pick(v: number): number;
+function pick(v: unknown): unknown { return v; }
+const third = pick(7);
+const first = pick(true);
+"#,
+    );
+
+    assert!(
+        output.contains("declare const third: number;"),
+        "Expected the THIRD overload to drive a number-argument call: {output}"
+    );
+    assert!(
+        output.contains("declare const first: boolean;"),
+        "Expected the first overload to still win when it is the matching one: {output}"
+    );
+}
+
+#[test]
+fn test_overloaded_call_initializer_return_type_is_independent_of_binder_names() {
+    let output = emit_dts_with_binding(
+        r#"
+function renamedOverload(zzInput: string): string;
+function renamedOverload(zzInput: number): number;
+function renamedOverload(zzInput: string | number): string | number { return zzInput; }
+const zzResult = renamedOverload(42);
+"#,
+    );
+
+    assert!(
+        output.contains("declare const zzResult: number;"),
+        "Expected overload selection to be structural, not keyed on binder spelling: {output}"
     );
 }
 


### PR DESCRIPTION
Closes #16406.

Both tests #16406 names were red at `origin/main` because **their own expectations were wrong, not because tsz was**. I oracled each against `typescript@7.0.2` (the version pinned in `scripts/conformance/typescript-versions.json`) before touching anything, and in both cases tsz already matched tsc exactly.

**This diff touches no compiler crate.** `git diff --name-only` is two test files; no `crates/**/src` production path changes, so no semantic behaviour can move. The gate this repairs *is* the unit lane.

## Structural rule

Two rules, one per test, both confirmed against the oracle:

1. **When a `const` is initialized by a call to an overloaded function, `tsc` emits the return type of the *matching* overload** — not the first one, and not a placeholder. tsz does this already, through the emitter's DTS initializer path.
2. **When an import alias is circular, `tsc` reports `TS2303` twice per participating module** — once on the `import self = require(...)` declaration and once on the `export = self;` assignment, as two independent circular-alias sites. tsz does this already, at those exact offsets, through the checker's circular-alias check.

## What was actually wrong

### `tsz-emitter` — `test_overloaded_call_initializer_does_not_use_first_signature_return_type`

The test asserted `declare const result = 42;`. Oracle and tsz agree on something else, byte for byte:

```
declare function parse(input: string): string;
declare function parse(input: number): number;
declare const result: number;
```

The assertion encoded a *"fall back to the initializer"* placeholder from before overload resolution reached DTS emit. Once resolution started working, the test went red for doing the right thing. Its **name** was right all along — "does not use first signature return type" — so the negative half (`!contains("declare const result: string;")`) is the real invariant and is kept as-is. The bogus positive half now pins the matching overload's return type.

Adjacent rows added, all oracle-pinned:

| row | pins |
| --- | --- |
| each argument type selects its own overload (`parse("hi")` / `parse(42)`) | selection is by argument, not position |
| a **third** overload matches (`pick(7)` of `boolean`/`string`/`number`) | "not the first" cannot be satisfied by an off-by-one |
| the first overload is the matching one (`pick(true)`) | the negative assertion did not become a blanket ban on overload 1 |
| renamed binder (`zzInput` / `zzResult`) | selection is structural, not keyed on binder spelling |

### `tsz-checker` — `ts2303_tests::recursive_export_assignment_self_import_reports_ts2303`

Asserted `ts2303.len() == 1`; tsz produced `2`. The oracle produces 2 as well:

```
m4C.ts(1,1): error TS2303: Circular definition of import alias 'self'.
m4C.ts(2,1): error TS2303: Circular definition of import alias 'self'.
```

The count assertion was also **the wrong shape**, which is why it could be wrong quietly: the harness returned `(file, code, message)` and discarded start offsets, so "two diagnostics in moduleC" cannot distinguish tsc's two *distinct sites* from one site reported twice. Changing `1` to `2` would have left that hole open.

So `get_project_diagnostics` now keeps each diagnostic's `start`, and a shared `assert_self_alias_cycle_sites` helper pins every cycle member at **both** sites with **no duplicate at either**, plus the total, so no module outside the cycle may report.

The two sibling cycle tests only asserted `.any(...)` — they would have passed on almost any wrong output — and are tightened onto the same helper. That extends the pin from 2 sites to **12 across the three fixtures**, all matching the oracle:

| fixture | cycle members | oracle `TS2303` | tsz |
| --- | --- | --- | --- |
| self-import (`...Type4`) | moduleC | 2 (import + `export =`) | same |
| two-file cycle (`...Type5`) | moduleC, moduleD | 4 (2 per member) | same |
| three-file cycle (`...Type6`) | moduleC, moduleD, moduleE | 6 (2 per member) | same |

## Verification

Oracle is `typescript@7.0.2`, read from `scripts/conformance/typescript-versions.json`.

| gate | before | after |
| --- | --- | --- |
| `cargo test -p tsz-emitter --lib` | 3988 passed, **1 failed** | **3989 passed, 0 failed** |
| `cargo test -p tsz-checker --lib ts2303` | 6 passed, **1 failed** | **7 passed, 0 failed** |
| `cargo clippy --workspace --exclude tsz-conformance --all-targets` | — | exit 0, **0 warnings** |
| `python3 scripts/arch/arch_guard.py` | — | `Architecture guardrails passed.` |
| `cargo fmt --all` | — | clean |
| pre-commit hook (`-p tsz-checker -p tsz-emitter`) | — | `Local verification passed.` |

The first clippy run flagged `dead_code` on the now-orphaned 3-tuple wrapper; it is removed, and the re-run is 0 warnings (CI denies warnings, so this would have been a red lane).

**Corpus gates deliberately not run, and why that is sound here rather than owed:** `compare-to-parent.sh` measures diagnostic output, and this diff changes no production code — `git diff --name-only` is exactly `crates/tsz-checker/tests/ts2303_tests.rs` and `crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations_parts/part_04.rs`. Conformance and emit counts cannot move. Corroborating: `scripts/conformance/conformance-detail.json` lists `recursiveExportAssignmentAndFindAliasedType` rows **1, 2 and 3** as failing while **4, 5 and 6 pass**, i.e. the corpus already agrees with the behaviour these three unit tests now pin.

Full `cargo test -p tsz-checker --lib` was still running when this PR opened; I will post the count as a comment. Only the `ts2303_tests` module is touched, so the blast radius is the 7 tests above.

## Notes for the next agent

- `#16406`'s **other** two red tests are `tsz-cli`'s, tracked separately in **#16232** and untouched here.
- `cargo test -p tsz-emitter --lib` runs 3989 tests; #16406 quoted `4771/4772` from `nextest` over all targets. The named test lives in `--lib`, so `--lib` closes it, but the integration targets were not re-run here.
- `cargo build -p tsz-checker --lib --tests` still burns the whole cloud disk allowance (hit it again this session). The board's recovery recipe works in seconds. Use `--lib`.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Tourmaline

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6eo8Jy7Y5cdVFM3x8thLh)_