### PR TITLE
fix(checker): namespace export=/export default parse-error gate (#16416)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2637,3 +2637,6 @@ path = "tests/ts1501_tests.rs"
 [[test]]
 name = "ts18036_class_decorator_static_private_identifier_tests"
 path = "tests/ts18036_class_decorator_static_private_identifier_tests.rs"
+[[test]]
+name = "namespace_export_assignment_default_parse_error_gate_tests"
+path = "tests/namespace_export_assignment_default_parse_error_gate_tests.rs"

--- a/crates/tsz-checker/src/declarations/import/core/module_exports.rs
+++ b/crates/tsz-checker/src/declarations/import/core/module_exports.rs
@@ -49,12 +49,18 @@ impl<'a> CheckerState<'a> {
                     // TS1063: export assignment cannot be used in a namespace.
                     // Emit the error and skip further checking of the statement
                     // (tsc does not resolve the expression when it's invalid).
+                    // Suppressed when the file has a real syntax error (matches
+                    // `check_grammar_module_element_context`'s policy): a statement
+                    // with its own genuine parse error reports that error alone.
                     let is_export_assign = self
                         .ctx
                         .arena
                         .get(stmt_idx)
                         .is_some_and(|n| n.kind == syntax_kind_ext::EXPORT_ASSIGNMENT);
-                    if is_export_assign && !is_ambient_external_module {
+                    if is_export_assign
+                        && !is_ambient_external_module
+                        && !self.ctx.has_syntax_parse_errors
+                    {
                         self.error_at_node(
                             stmt_idx,
                             diagnostic_messages::AN_EXPORT_ASSIGNMENT_CANNOT_BE_USED_IN_A_NAMESPACE,

--- a/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
@@ -127,7 +127,13 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
             // diagnostics like TS1194 or TS1319.
             let in_non_module_context = self.is_in_non_module_element_context(export_idx);
 
-            if !in_non_module_context
+            // TS1319: like the TS1194 check above, this is a check-time grammar
+            // diagnostic suppressed when the program has a real parse error (the
+            // campaign's `has_parse_errors` policy gate) — e.g. a genuine syntax
+            // error elsewhere on the same statement (`override export default 1;`
+            // in a namespace) reports that parse error alone, not TS1319 too.
+            if !self.ctx.has_parse_errors
+                && !in_non_module_context
                 && export_decl.is_default_export
                 && self.is_inside_namespace_declaration(export_idx)
             {

--- a/crates/tsz-checker/tests/namespace_export_assignment_default_parse_error_gate_tests.rs
+++ b/crates/tsz-checker/tests/namespace_export_assignment_default_parse_error_gate_tests.rs
@@ -1,0 +1,118 @@
+//! Regression tests for #16416: `module_exports.rs`'s TS1063 ("An export
+//! assignment cannot be used in a namespace.") and `check_export_declaration`'s
+//! TS1319 ("A default export can only be used in an ECMAScript-style module.")
+//! namespace-body checks must be suppressed when the same statement already
+//! carries a genuine syntax error, the way the sibling TS1194
+//! (`export ... from` in a namespace) and `check_grammar_module_element_context`
+//! diagnostics already are.
+//!
+//! Background
+//! ----------
+//! `override` is never a valid statement modifier outside a class member, so
+//! tsc's parser fails on it (TS1434) before anything downstream runs — the
+//! namespace-body checks must not additionally fire for the same statement.
+//! Split off #16412's pinned residual; oracle-pinned against `typescript@7.0.2`
+//! with `--noEmit --strict --lib es2022 --target es2022 --module es2022`.
+//!
+//! Binder names are varied across cases so no fix can key on an identifier.
+
+use tsz_checker::test_utils::check_source_codes_with_parse_health as check_source_codes;
+
+fn count(codes: &[u32], code: u32) -> usize {
+    codes.iter().filter(|&&c| c == code).count()
+}
+
+#[test]
+fn override_before_export_assignment_in_namespace_reports_ts1434_alone() {
+    let source = "namespace Alpha { override export = 1; }\n";
+    let codes = check_source_codes(source);
+    assert_eq!(
+        count(&codes, 1434),
+        1,
+        "expected TS1434 for the illegal `override` modifier, got {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, 1063),
+        0,
+        "TS1063 must not accompany a genuine parse error on the same statement, got {codes:?}"
+    );
+}
+
+#[test]
+fn override_before_export_default_in_namespace_reports_ts1434_alone() {
+    let source = "namespace Beta { override export default 1; }\n";
+    let codes = check_source_codes(source);
+    assert_eq!(
+        count(&codes, 1434),
+        1,
+        "expected TS1434 for the illegal `override` modifier, got {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, 1319),
+        0,
+        "TS1319 must not accompany a genuine parse error on the same statement, got {codes:?}"
+    );
+}
+
+#[test]
+fn export_assignment_in_namespace_without_parse_error_still_reports_ts1063() {
+    // Control: no genuine parse error on this statement, so the namespace-body
+    // check must still fire as before.
+    let source = "namespace Gamma { export = 1; }\n";
+    let codes = check_source_codes(source);
+    assert_eq!(
+        count(&codes, 1063),
+        1,
+        "expected TS1063 for a plain `export =` in a namespace, got {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, 1434),
+        0,
+        "no parse error expected, got {codes:?}"
+    );
+}
+
+#[test]
+fn export_default_in_namespace_without_parse_error_still_reports_ts1319() {
+    let source = "namespace Delta { export default 1; }\n";
+    let codes = check_source_codes(source);
+    assert_eq!(
+        count(&codes, 1319),
+        1,
+        "expected TS1319 for a plain `export default` in a namespace, got {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, 1434),
+        0,
+        "no parse error expected, got {codes:?}"
+    );
+}
+
+#[test]
+fn override_before_export_assignment_at_top_level_reports_ts1434_alone() {
+    // Control: `override` is illegal at top level for an unrelated reason
+    // (no enclosing class), and there is no namespace body check to suppress
+    // in the first place — this must stay TS1434 alone regardless of the fix.
+    let source = "override export = 1;\n";
+    let codes = check_source_codes(source);
+    assert_eq!(
+        count(&codes, 1434),
+        1,
+        "expected TS1434 for the illegal `override` modifier, got {codes:?}"
+    );
+    assert_eq!(count(&codes, 1063), 0, "got {codes:?}");
+}
+
+#[test]
+fn unrelated_parse_error_elsewhere_in_file_still_suppresses_ts1063() {
+    // A genuine syntax error anywhere in the file sets the file-wide
+    // `has_syntax_parse_errors` gate this fix relies on, matching
+    // `check_grammar_module_element_context`'s existing policy.
+    let source = "let x: ;\nnamespace Epsilon { export = 1; }\n";
+    let codes = check_source_codes(source);
+    assert_eq!(
+        count(&codes, 1063),
+        0,
+        "a file-wide parse error must suppress TS1063 too, got {codes:?}"
+    );
+}


### PR DESCRIPTION
`module_exports.rs`'s TS1063 ("An export assignment cannot be used in a namespace.") and `check_export_declaration`'s TS1319 ("A default export can only be used in an ECMAScript-style module.") namespace-body checks fire independently of `has_syntax_parse_errors`/`has_parse_errors`, unlike the sibling TS1194 check in the same function (`check_export_declaration`, statement_callback_bridge.rs) and `check_grammar_module_element_context`'s dispatcher-wide gate.

**Structural rule.** When a statement carries its own genuine syntax error, tsc's parser fails on it (e.g. TS1434 for `override`, never a legal statement modifier outside a class member) before any downstream check runs — the namespace-placement check for that same statement must not additionally fire. tsz already models this for the sibling `export ... from` (TS1194) check and for `check_grammar_module_element_context`'s import/export-declaration diagnostics; the export-assignment (TS1063) and export-default (TS1319) namespace checks were the two remaining gaps.

Repro (oracle-pinned, `typescript@7.0.2`, `--noEmit --strict --lib es2022 --target es2022 --module es2022`):

```
namespace N { override export = 1; }
```
tsc: TS1434 alone. tsz main: TS1434 + TS1063.

```
namespace N { override export default 1; }
```
tsc: TS1434 alone. tsz main: TS1434 + TS1319.

**Owner layer:** checker. Two independent sites, each gated on the flag its nearest sibling already uses rather than a new shared mechanism:
- `crates/tsz-checker/src/declarations/import/core/module_exports.rs` (TS1063 site): gated on `has_syntax_parse_errors`, matching this file's existing TS1203-family gate a few lines below (line 391).
- `crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs` (TS1319 site): gated on `has_parse_errors`, matching the TS1194 check immediately above it in the same function (`check_export_declaration`), which already documents itself as "the campaign's `has_parse_errors` policy gate".

### Adjacent cases covered

New unit suite `tests/namespace_export_assignment_default_parse_error_gate_tests.rs` (binder names varied: `Alpha`/`Beta`/`Gamma`/`Delta`/`Epsilon`), oracle-verified against `typescript@7.0.2`:
- `override` before `export =` / `export default` in a namespace → TS1434 alone (both diagnostics suppressed).
- Plain `export =` / `export default` in a namespace with **no** parse error → TS1063 / TS1319 still fire (regression control, unchanged behavior).
- `override` before `export =` at **top level** (no namespace-body check in the picture at all) → TS1434 alone, unaffected by this change (regression control).
- A genuine parse error **elsewhere** in the file (`let x: ;`) still suppresses TS1063 for an otherwise-plain `export =` in a namespace later in the same file — `has_syntax_parse_errors` is a file-wide flag, oracle-confirmed this matches tsc (issue's own "Scope" note: not `override`-specific).

Split off #16412's pinned residual (#16416).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test namespace_export_assignment_default_parse_error_gate_tests`: 6/6.
- `cargo test -p tsz-parser --lib parser_modified_export_statement_tests`: 71/71 (unaffected sibling #16412 family).
- `cargo test -p tsz-parser --lib parser_top_level_modifier_ts1044_ts1184_tests`: 7/7.
- `cargo test -p tsz-checker --lib export_declaration` / `export_assignment` / `export_equals` (substring filters): 24/24, 9/9, 17/17 — no regressions in adjacent export-diagnostic suites.
- `cargo clippy -p tsz-checker --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt -p tsz-checker -- --check`: clean.
- Pre-commit hook (clippy + arch guard + local verification for `-p tsz-checker`): passed.
- Test-only + one crate's production code touched (`crates/tsz-checker/src`); `compare-to-parent`/broad conformance not run — this is a checker-only diagnostic-suppression fix reached only when a statement already carries a genuine parse error, so it cannot move JS/DTS emit counts, and the corpus is thin on files pairing an illegal statement modifier with a namespace-scoped `export =`/`export default` (same signature the board has recorded for this diagnostic family, e.g. #16403/#16412's own slices).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRnRk4XHfFsMMHU3MksBrj)_