### PR TITLE
fix(parser): `declare export default class`/`function` is not a bare declaration-expected fallback (#16403)

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -94,6 +94,9 @@ mod parser_async_arrow_context_tests;
 #[path = "../../tests/parser_class_body_modifier_recovery_tests.rs"]
 mod parser_class_body_modifier_recovery_tests;
 #[cfg(test)]
+#[path = "../../tests/parser_declare_export_default_tests.rs"]
+mod parser_declare_export_default_tests;
+#[cfg(test)]
 #[path = "../../tests/parser_export_specifier_from_tests.rs"]
 mod parser_export_specifier_from_tests;
 #[cfg(test)]

--- a/crates/tsz-parser/src/parser/state_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_declarations.rs
@@ -1885,6 +1885,21 @@ impl ParserState {
                         // `declare export enum X { ... }`
                         self.parse_enum_declaration_with_modifiers(start_pos, Some(modifiers))
                     }
+                    SyntaxKind::DefaultKeyword => {
+                        // `declare export default class {}` / `declare export
+                        // default function f() {}` — tsc reads the whole
+                        // thing as a `ClassDeclaration`/`FunctionDeclaration`
+                        // carrying `declare`+`export`+`default` modifiers
+                        // (the same node kind the ordinary `export default`
+                        // path in `parse_export_default` builds), not the
+                        // `export =`-style assignment the `EqualsToken` arm
+                        // above handles. `self.context_flags` already carries
+                        // `CONTEXT_FLAG_AMBIENT` here (set at the top of this
+                        // function), so the reused declaration/expression
+                        // classification `parse_export_default` performs
+                        // still parses class/function bodies as ambient.
+                        self.parse_export_default(start_pos)
+                    }
                     _ => {
                         self.error_declaration_expected();
                         self.parse_expression_statement()

--- a/crates/tsz-parser/tests/parser_declare_export_default_tests.rs
+++ b/crates/tsz-parser/tests/parser_declare_export_default_tests.rs
@@ -1,0 +1,115 @@
+//! `declare export default class {}` / `declare export default function f()
+//! {}` (#16403). `parse_ambient_declaration_with_modifiers`'s `ExportKeyword`
+//! arm dispatches on the token that follows `export`, but had no case for
+//! `default` — so it fell into the `_ => error_declaration_expected()`
+//! fallback and reported TS1146 ("Declaration expected.") plus a cascading
+//! TS1211/TS1005 from the abandoned parse, where tsc reports TS1029
+//! ("'export' modifier must precede 'declare' modifier.") for the
+//! declaration forms.
+//!
+//! `declare export default <expr>` (no class/function keyword) is the
+//! sibling gap covered by the existing `EqualsToken`-shaped assignment path:
+//! same missing `DefaultKeyword` arm, same TS1146 fallback beforehand.
+//!
+//! Every expectation oracle-pinned against `typescript@7.0.2`
+//! (`--strict --target es2022 --module es2022`).
+//!
+//! Residual, not fixed here (see #16403 follow-up): tsc additionally reports
+//! TS1183 ("An implementation cannot be declared in ambient contexts.") for
+//! the function form, and suppresses this crate's own namespace-body TS1319
+//! ("A default export can only be used in an ECMAScript-style module.") when
+//! TS1029 already fired for the same node. Both need the `declare`/`export`
+//! modifiers threaded onto the produced node (this fix reuses
+//! `parse_export_default`, which does not carry them) rather than a parser
+//! shape change, so they are left for a follow-up slice.
+
+use crate::parser::test_fixture::parse_source;
+use tsz_common::diagnostics::diagnostic_codes;
+
+fn assert_no_declaration_expected_fallback(source: &str) {
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.code == diagnostic_codes::DECLARATION_EXPECTED),
+        "expected no TS1146 fallback for {source:?}, got {diagnostics:?}"
+    );
+}
+
+fn assert_ts1029_export_before_declare(source: &str) {
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+    let export_pos = source.find("export").unwrap() as u32;
+    assert!(
+        diagnostics.iter().any(
+            |d| d.code == diagnostic_codes::MODIFIER_MUST_PRECEDE_MODIFIER && d.start == export_pos
+        ),
+        "expected TS1029 anchored at 'export' ({export_pos}) for {source:?}, got {diagnostics:?}"
+    );
+}
+
+// -- top level --
+
+#[test]
+fn declare_export_default_class_top_level_reports_ts1029_not_ts1146() {
+    let source = "declare export default class {}";
+    assert_no_declaration_expected_fallback(source);
+    assert_ts1029_export_before_declare(source);
+}
+
+#[test]
+fn declare_export_default_function_top_level_reports_ts1029_not_ts1146() {
+    let source = "declare export default function f(): void;";
+    assert_no_declaration_expected_fallback(source);
+    assert_ts1029_export_before_declare(source);
+}
+
+#[test]
+fn declare_export_default_named_class_top_level_reports_ts1029_not_ts1146() {
+    let source = "declare export default class Foo {}";
+    assert_no_declaration_expected_fallback(source);
+    assert_ts1029_export_before_declare(source);
+}
+
+// -- namespace body --
+
+#[test]
+fn declare_export_default_class_in_namespace_reports_no_ts1146() {
+    assert_no_declaration_expected_fallback("namespace N { declare export default class {} }");
+}
+
+#[test]
+fn declare_export_default_function_in_namespace_reports_no_ts1146() {
+    assert_no_declaration_expected_fallback(
+        "namespace N { declare export default function f(): void; }",
+    );
+}
+
+// -- block body: parser must not itself emit a diagnostic here (the
+// checker's own grammar pass owns TS1184 in a Block, per the sibling
+// modifier families) but it must still classify the declaration correctly
+// rather than falling into the expression-statement recovery path.
+
+#[test]
+fn declare_export_default_class_in_block_reports_no_ts1146() {
+    assert_no_declaration_expected_fallback(
+        "function outer() { { declare export default class {} } }",
+    );
+}
+
+#[test]
+fn declare_export_default_function_in_block_reports_no_ts1146() {
+    assert_no_declaration_expected_fallback(
+        "function outer() { { declare export default function f(): void; } }",
+    );
+}
+
+// -- negative control: a non-declaration `default` expression must not be
+// swept into the declaration path (`declare export default 1;` is the
+// TS1120-style export-assignment shape, not a class/function).
+
+#[test]
+fn declare_export_default_expression_reports_no_ts1146() {
+    assert_no_declaration_expected_fallback("declare export default 1;");
+}


### PR DESCRIPTION
`declare export default class {}` and `declare export default function f(): void;` fell into `parse_ambient_declaration_with_modifiers`'s `_ => error_declaration_expected()` fallback: the `ExportKeyword` arm's inner match dispatches on the token following `export` and had cases for `class`/`function`/`interface`/`type`/`enum`/`module`/`namespace`/`import`/`=`/`*`/`{` but none for `default`, so tsc's TS1029 ("'export' modifier must precede 'declare' modifier.") never fired and tsz instead reported TS1146 ("Declaration expected.") plus a cascading TS1211/TS1005 from the abandoned expression-statement recovery.

## Structural rule

`declare` followed by `export default <class-or-function>` is still a `ClassDeclaration`/`FunctionDeclaration` carrying `declare`+`export`+`default` modifiers to tsc's grammar check, exactly like the ordinary (non-ambient) `export default` form — not the `export =`-shaped assignment the adjacent `EqualsToken` arm handles. Adding a `DefaultKeyword` arm that delegates to the same declaration/expression classification `parse_export_default` already performs (function vs. class vs. a bare expression) reaches the correct declaration path instead of duplicating that classification. `self.context_flags` already carries `CONTEXT_FLAG_AMBIENT` at this point (set at the top of `parse_ambient_declaration_with_modifiers`), so the reused call still parses class/function bodies as ambient.

## Owner layer

Parser only, `crates/tsz-parser/src/parser/state_declarations.rs`: `parse_ambient_declaration_with_modifiers`. No checker/solver/emitter change.

## Residual — not fixed here, next slice of #16403

`parse_export_default` does not thread `declare`/`export` modifiers onto the produced node (it exists for the non-ambient path, where those modifiers don't apply), so two things tsc still gets right are not yet matched:

- TS1183 ("An implementation cannot be declared in ambient contexts.") for `declare export default function f() { }` (a body, not a bare signature) — the checker's `has_declare_modifier` check on the function node finds nothing to key off.
- The checker's existing namespace-body TS1319 check (`statement_callback_bridge.rs`, "A default export can only be used in an ECMAScript-style module.") fires unconditionally for any `is_default_export` node inside a namespace and doesn't know this node's TS1029 already covered the same placement violation, so both fire together where tsc reports TS1029 alone.

Both require threading the modifiers onto the produced node rather than a parser dispatch change, so they're left for a follow-up rather than folded into this fix.

Oracle-verified (`typescript@7.0.2`, `--strict --target es2022 --module es2022`) before/after, on the 9 declare-default rows this patch touches:

| case | container | tsc | before | after |
| --- | --- | --- | --- | --- |
| `declare export default class {}` | top | TS1029@9 | TS1146+TS1211 | **TS1029@9 ✅** |
| `declare export default class {}` | namespace | TS1029@11 | TS1146+TS1211 | TS1029@11 + spurious TS1319 |
| `declare export default class {}` | block | TS1184 (checker) | TS1146+TS1211 | **matches (checker-owned) ✅** |
| `declare export default function f(){}` | top | TS1029+TS1183 | TS1146 | TS1029 (missing TS1183) |
| `declare export default function f(){}` | namespace | TS1029+TS1183 | TS1146 | TS1029 + spurious TS1319 (missing TS1183) |
| `declare export default function f(){}` | block | TS1184+TS1183 | TS1146 | TS1184 (checker-owned, missing TS1183) |
| `declare export default 1;` | top | TS1120+TS2714 | TS1146 | TS1029 (missing TS1120/TS2714 wording) |
| `declare export default 1;` | namespace | TS1319 | TS1146 | TS1029+TS1319 (extra TS1029) |
| `declare export default 1;` | block | TS1258 (checker) | TS1146 | **matches (checker-owned) ✅** |

3/9 exact matches; the other 6 moved from "completely wrong, cascading recovery garbage" to "correct order diagnostic present, one specific narrower gap remaining" — no case regressed from a previously-correct answer (all 9 were wrong before this patch).

`abstract`/`accessor` before `export default` were measured in the same 153-case oracle sweep (`declare`/`abstract`/`accessor` × 17 export forms × 3 containers) and are a separate, larger family — their own dispatchers (`look_ahead_abstract_before_export_target`, `parse_statement_accessor_keyword`) never reach this `declare`-specific code path at all. Out of scope here, left for the next #16403 slice.

## Verification

- `cargo test -p tsz-parser --lib`: **1899/1899** (was 1891; +8 new).
- Negative control: reverted only `state_declarations.rs` to parent, kept the new tests — all 8 fail for the real reason (TS1146 present).
- `cargo clippy -p tsz-parser --all-targets -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.
- `compare-to-parent.sh`: **owed** — not run this session (time budget). Blast radius: this arm only fires when the token sequence is exactly `declare export default` immediately followed by `class`/`function`/an expression, previously unreachable via any other path (the `_` fallback catches it today), so no existing passing case can regress through this new arm.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_019MwZgeUBt7pbSV4x1fruzg)_