### PR TITLE
fix(binder): a position-invalid `import =` binds to its nearest declaration container, not the enclosing block (#16410 item 4)

### DIFF
--- a/crates/tsz-binder/src/modules/import_export.rs
+++ b/crates/tsz-binder/src/modules/import_export.rs
@@ -200,9 +200,20 @@ impl BinderState {
                     self.file_import_sources.push(spec.clone());
                 }
 
-                // Create symbol with ALIAS flag
-                let sym_id =
-                    self.declare_symbol(arena, name, symbol_flags::ALIAS, idx, is_exported);
+                // Create symbol with ALIAS flag.
+                //
+                // An alias is not a block-scoped declaration, so it belongs to
+                // the nearest declaration container, never to a plain `Block`
+                // that happens to enclose it. That only matters for a
+                // *position-invalid* `import x = ...` (TS1232) — anywhere it is
+                // legal the container already is the current scope and the
+                // retarget is a no-op — but it is what makes the alias visible
+                // to the rest of the container the way `tsc` binds it, instead
+                // of dying with the block.
+                let container_scope = self.nearest_declaration_container_scope(arena);
+                let sym_id = self.with_declaration_scope(container_scope, |binder| {
+                    binder.declare_symbol(arena, name, symbol_flags::ALIAS, idx, is_exported)
+                });
 
                 if let Some(sym) = self.symbols.get_mut(sym_id) {
                     let span = arena.get(idx).map(|node| (node.pos, node.end));

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -629,6 +629,56 @@ impl BinderState {
             .map(|scope| &mut scope.table)
     }
 
+    /// The nearest enclosing scope that is a *declaration container*, i.e. the
+    /// scope `tsc` would record a non-block-scoped declaration in.
+    ///
+    /// `tsc` keeps two separate cursors while binding: `container` (source
+    /// file, module body, class body, or any function-like node) and
+    /// `blockScopeContainer` (additionally every plain `Block`). Only
+    /// block-scoped declarations — `let`, `const`, `class`, and friends — land
+    /// in the block scope; everything else is declared in the container. tsz
+    /// models both cursors with the single `current_scope_id`, so a caller that
+    /// needs the container half asks for it here.
+    ///
+    /// The walk skips `ContainerKind::Block` scopes, with one exception: a
+    /// class static block is function-like in `tsc` and therefore *is* a
+    /// container, even though tsz gives its body a block scope. Stopping there
+    /// keeps a declaration inside a static block out of the class body's table.
+    pub(crate) fn nearest_declaration_container_scope(&self, arena: &NodeArena) -> ScopeId {
+        let mut scope_id = self.current_scope_id;
+        while let Some(scope) = self.scopes.get(scope_id.0 as usize) {
+            if scope.kind != ContainerKind::Block || scope.parent.is_none() {
+                break;
+            }
+            let is_static_block = arena
+                .get(scope.container_node)
+                .is_some_and(|node| node.kind == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION);
+            if is_static_block {
+                break;
+            }
+            scope_id = scope.parent;
+        }
+        scope_id
+    }
+
+    /// Run `f` with the declaration cursor retargeted to `scope_id`.
+    ///
+    /// Every declaration path reads `current_scope_id` — `current_scope`,
+    /// `current_scope_mut`, `current_container_symbol` and
+    /// `declare_in_persistent_scope_with_atom` all resolve through it — so
+    /// swapping it for the duration of `f` retargets the whole path, including
+    /// the merge/duplicate lookup, rather than only the final table write.
+    pub(crate) fn with_declaration_scope<R>(
+        &mut self,
+        scope_id: ScopeId,
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        let saved = std::mem::replace(&mut self.current_scope_id, scope_id);
+        let result = f(self);
+        self.current_scope_id = saved;
+        result
+    }
+
     /// Symbol of the container node owning the current persistent scope
     /// (namespace, class, function, ...), if one has been bound.
     pub(crate) fn current_container_symbol(&self) -> Option<SymbolId> {

--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2640,3 +2640,7 @@ path = "tests/ts18036_class_decorator_static_private_identifier_tests.rs"
 [[test]]
 name = "import_namespace_ts1147_tests"
 path = "tests/import_namespace_ts1147_tests.rs"
+
+[[test]]
+name = "position_invalid_import_equals_container_scope_tests"
+path = "tests/position_invalid_import_equals_container_scope_tests.rs"

--- a/crates/tsz-checker/tests/position_invalid_import_equals_container_scope_tests.rs
+++ b/crates/tsz-checker/tests/position_invalid_import_equals_container_scope_tests.rs
@@ -1,0 +1,345 @@
+//! A position-invalid `import x = ...` alias binds to the nearest *declaration
+//! container*, not to the plain `Block` that encloses it.
+//!
+//! `tsc`'s binder carries two cursors: `container` (source file, module body,
+//! class body, or any function-like node) and `blockScopeContainer` (which
+//! additionally advances into every plain `Block`). Only block-scoped
+//! declarations — `let`, `const`, `class` — are recorded in the block scope;
+//! everything else goes to the container. An import alias is not block-scoped,
+//! so `{ import x = require("m"); }` records `x` in the enclosing *container*
+//! even though the declaration's position is illegal (TS1232).
+//!
+//! That is observable two ways, and `tsz` was wrong in both before this suite
+//! existed: a reference outside the block reported TS2304 ("Cannot find name")
+//! on a name `tsc` resolves, and the resolution that `tsc` performs for the
+//! reference — TS2307 on the specifier — never happened.
+//!
+//! The container is the *nearest* one, not the file: an alias in a block inside
+//! a function is visible in that function and nowhere else. A class static
+//! block is function-like in `tsc`, so it is itself a container and does not
+//! leak into the class body, even though `tsz` models its body as a block
+//! scope.
+//!
+//! All expectations were measured against `typescript@7.0.2` with
+//! `--noEmit --strict --pretty false --target es2015 --module commonjs`.
+//!
+//! Rows whose *only* residual delta is the separate unreferenced-alias gate
+//! (#16410 item 2: `tsz` reports TS2307 for an unreferenced block-scoped alias
+//! that `tsc` leaves alone, and swallows the one `tsc` reports inside a
+//! function body) assert the absence of TS2304 rather than a full code vector,
+//! so this suite pins the scoping rule without freezing a bug it does not own.
+
+use tsz_binder::BinderState;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::state::CheckerState;
+use tsz_parser::parser::ParserState;
+use tsz_solver::construction::TypeInterner;
+
+/// Check a single source with unresolved-import reporting on, so a specifier
+/// naming a nonexistent module reports TS2307 exactly when it is resolved.
+fn check(source: &str) -> Vec<u32> {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        CheckerOptions {
+            module: tsz_common::common::ModuleKind::CommonJS,
+            target: tsz_common::common::ScriptTarget::ES2015,
+            ..CheckerOptions::default()
+        },
+    );
+    checker.ctx.report_unresolved_imports = true;
+    checker.check_source_file(root);
+    let mut codes: Vec<u32> = checker.ctx.diagnostics.iter().map(|d| d.code).collect();
+    codes.sort_unstable();
+    codes
+}
+
+fn assert_codes(source: &str, expected: &[u32], what: &str) {
+    let actual = check(source);
+    assert_eq!(actual, expected, "{what}\nsource:\n{source}");
+}
+
+/// The half of a row this change owns: the alias resolves, so no TS2304.
+fn assert_alias_resolves(source: &str, what: &str) {
+    let actual = check(source);
+    assert!(
+        !actual.contains(&2304),
+        "{what}: expected the alias to resolve (no TS2304), got {actual:?}\nsource:\n{source}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Block-like containers: the alias escapes to the enclosing container.
+//
+// Every binder name below is distinct so no assertion can be satisfied by a
+// name-keyed shortcut.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bare_block_alias_is_visible_after_the_block() {
+    assert_codes(
+        r#"{
+  import alpha = require("nonexistent-module");
+}
+alpha;"#,
+        &[1232, 2307],
+        "the primary repro from #16410 item 4",
+    );
+}
+
+#[test]
+fn bare_block_alias_is_visible_from_a_sibling_block() {
+    assert_codes(
+        r#"{
+  import bravo = require("nonexistent-module");
+}
+{
+  bravo;
+}"#,
+        &[1232, 2307],
+        "a sibling block sees it too — the alias is not in either block's scope",
+    );
+}
+
+#[test]
+fn bare_block_alias_is_visible_before_the_declaring_block() {
+    assert_codes(
+        r#"charlie;
+{
+  import charlie = require("nonexistent-module");
+}"#,
+        &[1232, 2307],
+        "container-scoped declarations are visible before their declaration site",
+    );
+}
+
+#[test]
+fn if_block_alias_is_visible_after_the_statement() {
+    assert_codes(
+        r#"if (true) {
+  import delta = require("nonexistent-module");
+}
+delta;"#,
+        &[1232, 2307],
+        "an `if` block is a block scope, not a container",
+    );
+}
+
+#[test]
+fn loop_body_alias_is_visible_after_the_loop() {
+    assert_codes(
+        r#"for (;;) {
+  import echo = require("nonexistent-module");
+  break;
+}
+echo;"#,
+        &[1232, 2307],
+        "a loop body is a block scope, not a container",
+    );
+}
+
+#[test]
+fn try_block_alias_is_visible_after_the_statement() {
+    assert_codes(
+        r#"try {
+  import foxtrot = require("nonexistent-module");
+} catch {}
+foxtrot;"#,
+        &[1232, 2307],
+        "a `try` block is a block scope, not a container",
+    );
+}
+
+#[test]
+fn switch_case_block_alias_is_visible_after_the_statement() {
+    assert_codes(
+        r#"switch (1) {
+  case 1: {
+    import golf = require("nonexistent-module");
+  }
+}
+golf;"#,
+        &[1232, 2307],
+        "a case block is a block scope, not a container",
+    );
+}
+
+#[test]
+fn nested_blocks_walk_all_the_way_out_to_the_container() {
+    assert_codes(
+        r#"{
+  {
+    import hotel = require("nonexistent-module");
+  }
+}
+hotel;"#,
+        &[1232, 2307],
+        "the walk skips every intervening block, not just the innermost one",
+    );
+}
+
+#[test]
+fn qualified_name_form_takes_the_same_scope() {
+    // `import x = N.M` is the other `import =` production. tsc reports TS1232
+    // alone here: the alias resolves at top level, so there is no TS2304 and no
+    // module specifier to fail on.
+    assert_codes(
+        r#"{
+  import india = November.Mike;
+}
+india;
+namespace November {
+  export namespace Mike {
+    export const q = 1;
+  }
+}"#,
+        &[1232],
+        "the qualified-name form is not block-scoped either",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The container is the *nearest* one, not the source file.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn block_inside_a_function_binds_to_that_function_not_the_file() {
+    assert_codes(
+        r#"function outer() {
+  {
+    import juliett = require("nonexistent-module");
+  }
+}
+juliett;"#,
+        &[1232, 2304],
+        "the alias stops at the function; the file-level reference stays unresolved",
+    );
+}
+
+#[test]
+fn block_inside_a_function_is_visible_within_that_function() {
+    assert_alias_resolves(
+        r#"function outer() {
+  {
+    import kilo = require("nonexistent-module");
+  }
+  kilo;
+}"#,
+        "the same alias resolves inside its own function",
+    );
+}
+
+#[test]
+fn block_inside_a_namespace_binds_to_that_namespace() {
+    assert_codes(
+        r#"namespace Lima {
+  {
+    import mike = require("nonexistent-module");
+  }
+  mike;
+}"#,
+        &[1232, 2307],
+        "a namespace body is a container, so the alias stops there and resolves",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative half: containers that must NOT leak.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn function_body_alias_does_not_escape_the_function() {
+    assert_codes(
+        r#"function outer() {
+  import november = require("nonexistent-module");
+}
+november;"#,
+        &[1232, 2304],
+        "a function body is a container — TS2304 outside it is correct",
+    );
+}
+
+#[test]
+fn method_body_alias_does_not_escape_the_method() {
+    assert_codes(
+        r#"class Oscar {
+  m() {
+    import papa = require("nonexistent-module");
+  }
+}
+papa;"#,
+        &[1232, 2304],
+        "a method body is a container",
+    );
+}
+
+#[test]
+fn class_static_block_alias_does_not_escape_the_class() {
+    // A class static block is function-like in tsc, so it is a container even
+    // though tsz gives its body a `ContainerKind::Block` scope. The carve-out
+    // in `nearest_declaration_container_scope` is what keeps TS2304 here.
+    let actual = check(
+        r#"class Quebec {
+  static {
+    import romeo = require("nonexistent-module");
+  }
+}
+romeo;"#,
+    );
+    assert!(
+        actual.contains(&2304),
+        "a static block must not leak into the class body, got {actual:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Positions where the retarget must be a no-op: the container already *is* the
+// current scope, so nothing about a legal `import =` moves.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn top_level_import_equals_is_unchanged() {
+    assert_codes(
+        r#"import sierra = require("nonexistent-module");
+sierra;"#,
+        &[2307],
+        "a legal top-level `import =` still resolves and reports only TS2307",
+    );
+}
+
+#[test]
+fn namespace_body_import_equals_is_unchanged() {
+    assert_codes(
+        r#"namespace Tango {
+  import uniform = require("nonexistent-module");
+  uniform;
+}"#,
+        // A namespace body is already a container, so the walk is a no-op here.
+        // TS1147 rides along because a namespace `import =` may not reference an
+        // external module at all — an orthogonal rule, and one tsz already
+        // matches; the point of the row is that the alias still resolves.
+        &[1147, 2307],
+        "a namespace-body `import =` is untouched by the container walk",
+    );
+}
+
+#[test]
+fn top_level_qualified_import_equals_is_unchanged() {
+    assert_codes(
+        r#"namespace Victor {
+  export const w = 1;
+}
+import whiskey = Victor;
+whiskey.w;"#,
+        &[],
+        "the legal qualified form stays clean",
+    );
+}


### PR DESCRIPTION
Closes #16410 item 4. Owner layer is the **binder** — neither #16409 nor #16411 touches it, so this does not collide with the open drafts on the sibling items.

## Structural rule

`tsc`'s binder carries two cursors: `container` (source file, module body, class body, or any function-like node) and `blockScopeContainer`, which *additionally* advances into every plain `Block`. Only block-scoped declarations — `let`, `const`, `class` — are recorded in the block scope; everything else is declared in the container.

**When an `import x = require("m")` / `import x = A.B` declaration sits in a position-invalid block-like container (bare block, `if`/`else` body, loop body, `try`/`catch` block, `switch` case block), tsc records the alias in the nearest *declaration container* enclosing that block — an alias is not a block-scoped declaration. tsz does this through the binder's `nearest_declaration_container_scope`.**

tsz declared the alias into `current_scope_id`, which for a `{ ... }` body is the block, so the alias died with the block. That is a wrong diagnostic *and* a missing one:

```ts
{ import x = require("nonexistent-module"); }
x;
// tsc:  TS1232 + TS2307
// tsz:  TS1232 + TS2304   ("Cannot find name 'x'")
```

### The open question this had to answer first

The issue's item-4 report only exercised bare blocks, and the follow-up note on #16410 flagged the unresolved half explicitly: *is the leak `Block`-only, or does a `Function` body (and a class static block) do the same?* Oracled before any code was written — **it is block-like containers only**:

| form | tsc | reads as |
| --- | --- | --- |
| `{ import x = ...; } x;` | TS1232 + TS2307 | alias escaped the block |
| `function f() { import x = ...; } x;` | TS1232 + **TS2304** | function body is a container |
| `class C { m() { import x = ...; } } x;` | TS1232 + **TS2304** | method body is a container |
| `class C { static { import x = ...; } } x;` | TS1232 + **TS2304** | static block is function-like → a container |
| `{ import x = require("a"); } { import x = require("b"); x; }` | TS1232, **TS2300**, TS2307, TS1232, **TS2300** | two blocks collide → both in the file table |
| `function f() { import x = require("a"); } function g() { import x = require("b"); x; }` | TS1232, TS1232, TS2307 — **no TS2300** | function bodies do not collide |

The two collision rows are the decisive pair: aliases in two different *blocks* are duplicate identifiers, aliases in two different *functions* are not.

And the container is the **nearest** one, not the file — a further row the report did not cover:

```ts
function f() { { import x = require("nonexistent-a"); } x; }   // tsc: TS1232 + TS2307   (resolves inside f)
function f() { { import x = require("nonexistent-a"); } } x;   // tsc: TS1232 + TS2304   (not outside f)
```

So the rule is "skip `Block` scopes", not "hop to file scope", and the class-static-block carve-out is load-bearing: tsz models a static block body as `ContainerKind::Block`, but tsc treats it as function-like, so the walk must stop there or the alias leaks into the class body.

## Implementation

Two helpers in `crates/tsz-binder/src/state/core.rs`, one call site in `modules/import_export.rs`:

- `nearest_declaration_container_scope(arena)` — walks `scope.parent` past `ContainerKind::Block` scopes, stopping at a scope whose `container_node` is a `CLASS_STATIC_BLOCK_DECLARATION`.
- `with_declaration_scope(scope_id, f)` — swaps `current_scope_id` for the duration of `f`. Every step of the declaration path resolves through that one field (`current_scope`, `current_scope_mut`, `current_container_symbol`, `declare_in_persistent_scope_with_atom`), so the retarget covers the merge/duplicate lookup too, not just the final table write.

The retarget is **a no-op wherever an `import =` is legal** — at top level or in a namespace body the container already *is* the current scope — so no separate "is this position invalid" predicate is needed, and none is introduced.

## Goal
Goal: hold

## Verification

Oracle: `typescript@7.0.2`, `--noEmit --strict --pretty false --target es2015 --module commonjs`. 24 rows run against both compilers before and after.

### Rows this change fixes (tsz before → after, tsc in bold agreement)

| row | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `{ import x = ...; } x;` | 1232, 2307 | 1232, 2307, **2304** | 1232, 2307 ✅ |
| sibling block reference | 1232, 2307 | + 2304 | 1232, 2307 ✅ |
| reference *before* the block | 1232, 2307 | + 2304 | 1232, 2307 ✅ |
| `if` block | 1232, 2307 | + 2304 | 1232, 2307 ✅ |
| loop body | 1232, 2307 | + 2304 | 1232, 2307 ✅ |
| `try` block | 1232, 2307 | + 2304 | 1232, 2307 ✅ |
| `switch` case block | 1232, 2307 | + 2304 | 1232, 2307 ✅ |
| doubly nested blocks | 1232, 2307 | + 2304 | 1232, 2307 ✅ |
| `{ import x = N.M; } x;` (qualified form) | 1232 | 1232, **2304** | 1232 ✅ |
| block inside a namespace body | 1232, 2307 | 1232, **2304** | 1232, 2307 ✅ |
| block inside a function, referenced in it | 1232, 2307 | 1232, **2304** | 1232 *(2307 residual, see below)* |

### Rows that must not move, and did not

| row | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| function body, referenced outside | 1232, 2304 | 1232, 2304 | 1232, 2304 ✅ |
| method body, referenced outside | 1232, 2304 | 1232, 2304 | 1232, 2304 ✅ |
| static block, referenced outside | 1232, 2304 | 2304 present | 2304 present ✅ |
| block in a function, referenced outside it | 1232, 2304 | 1232, 2304 | 1232, 2304 ✅ |
| legal top-level `import =` | 2307 | 2307 | 2307 ✅ |
| legal namespace-body `import =` | 1147, 2307 | 1147, 2307 | 1147, 2307 ✅ |
| legal qualified `import x = N` | *(clean)* | *(clean)* | *(clean)* ✅ |

### Suites

| gate | result |
| --- | --- |
| `cargo test -p tsz-checker --test position_invalid_import_equals_container_scope_tests` | **18 passed, 0 failed** (new file) |
| **negative control** — same 18 tests with only the two binder files reverted to the parent | **11 failed, 7 passed** (the 7 are the must-not-move rows, which pass in both states) |
| `cargo test -p tsz-binder --lib` | 446 passed, 0 failed |
| `import_namespace_ts1147_tests` | 11 passed |
| `order_independent_alias_resolution_tests` | 4 passed |
| `recursive_alias_resolution_tests` | 6 passed |
| `ambient_module_import_alias_defid_collision_tests` | 6 passed |
| `cross_module_unimported_name_resolution_tests` | 6 passed |
| `cargo clippy -p tsz-binder -p tsz-checker --all-targets -- -D warnings` | exit 0, 0 warnings |
| `cargo fmt --all` | clean |

`cargo-nextest` is absent in these cloud containers (as several board records note); `cargo test -p CRATE --test NAME` is the substitute.

**Corpus gate: owed, disclosed, not skipped.** This touches a `crates/**/src` production path, so conformance counts can move. `compare-to-parent.sh` needs two `dist-fast` builds and measures 55–90 min in a cold seat — it did not fit this session. Blast radius for a reviewer: the retarget fires only inside `bind_import_equals_declaration`, and only when the alias's current persistent scope is a `ContainerKind::Block` — i.e. only for a declaration that is already a TS1232 syntax error. Every legal `import =` takes the identical path it took before, which the three "legal position" rows above pin. `cargo test -p tsz-checker --lib` was launched and is still running at PR-open time; the count will be posted as a comment.

## Residuals (not this change's, recorded so nobody reads them as regressions)

- **#16410 item 2** (Azurite's open draft #16411) is the other column of the same matrix and is untouched here: tsz reports TS2307 for an *unreferenced* block-scoped alias that tsc leaves alone, and swallows the TS2307 tsc reports for a referenced alias inside a *function body*. Rows whose only residual is that gate assert the absence of TS2304 instead of a full code vector, so this suite pins the scoping rule without freezing a bug it does not own.
- **Duplicate-alias detection is separate.** With the aliases now correctly in one table, `{ import x = require("a"); } { import x = require("b"); x; }` still reports no TS2300 — tsz's `declare_symbol` merges two `ALIAS` symbols where tsc's `AliasExcludes` makes them a duplicate. That is a symbol-merge rule, not a scoping one; filing it separately rather than widening this diff.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Onyx

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoGzjLgSBciXtyZTD5XyYf)_