### PR TITLE
fix(checker): a re-exported TS2741 target points at its original declaration (#16415 row 3)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
+++ b/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
@@ -5,6 +5,15 @@ use crate::state::CheckerState;
 use tsz_parser::parser::{NodeArena, NodeIndex};
 use tsz_solver::TypeId;
 
+/// Alias edges followed from the reported target before giving up.
+///
+/// One hop covers `import { X } from "./hub"` reaching a hub's own
+/// `export { X } from "./dep"`, which is the shape tsc's `resolveAlias`
+/// terminates on. A small bound above that leaves room for an alias whose
+/// target is itself locally re-aliased, while keeping a cyclic re-export graph
+/// from spinning; the equal-hop check below catches a self-edge immediately.
+const MAX_ALIAS_HOPS: usize = 4;
+
 impl<'a> CheckerState<'a> {
     /// Build tsc's `'{0}' is declared here.` (TS2728) pointer for the single
     /// unmatched property of a `TS2741` failure.
@@ -51,7 +60,37 @@ impl<'a> CheckerState<'a> {
         let owner_symbol = self.ctx.resolve_type_to_symbol_id(owner).or_else(|| {
             crate::query_boundaries::common::type_shape_symbol(self.ctx.types, owner)
         })?;
-        let declaring_file_idx = self.ctx.resolve_symbol_file_index(owner_symbol);
+        let mut symbol_id = owner_symbol;
+        let mut declaring_file_idx = self.ctx.resolve_symbol_file_index(symbol_id);
+        for _ in 0..MAX_ALIAS_HOPS {
+            if let Some(related) = self.declared_here_related_for_declared_symbol(
+                symbol_id,
+                declaring_file_idx,
+                property,
+                property_display,
+            ) {
+                return Some(related);
+            }
+            let (next_symbol, next_file_idx) =
+                self.alias_target_symbol(symbol_id, declaring_file_idx)?;
+            if next_symbol == symbol_id && declaring_file_idx == Some(next_file_idx) {
+                return None;
+            }
+            symbol_id = next_symbol;
+            declaring_file_idx = Some(next_file_idx);
+        }
+        None
+    }
+
+    /// The `TS2728` pointer for a symbol that is expected to own the member
+    /// list directly, with no alias following.
+    fn declared_here_related_for_declared_symbol(
+        &mut self,
+        owner_symbol: tsz_binder::SymbolId,
+        declaring_file_idx: Option<usize>,
+        property: &str,
+        property_display: &str,
+    ) -> Option<DiagnosticRelatedInformation> {
         let binder = declaring_file_idx
             .and_then(|file_idx| self.ctx.get_binder_for_file(file_idx))
             .filter(|binder| binder.get_symbol(owner_symbol).is_some())
@@ -103,6 +142,158 @@ impl<'a> CheckerState<'a> {
             ));
         }
         None
+    }
+
+    /// Follow one alias edge from `symbol_id` to the symbol the alias names in
+    /// the module it imports from, returning it with the file index that
+    /// declares it.
+    ///
+    /// A target reached through `export { X } from "./dep"` resolves to the
+    /// *hub's own export specifier*, which owns no member list, so the walk
+    /// above declines. tsc's `resolveAlias` follows the alias to the original
+    /// declaration; the pointer must anchor there and never on the re-export
+    /// clause.
+    ///
+    /// The hop is deliberately made through the module graph — module specifier
+    /// resolved from the *alias's own* file, then the exported **name** looked
+    /// up in the target module's public surface — and not by following a raw
+    /// `SymbolId`. Per-file binders mint colliding ids from `0`, so both the
+    /// hub's specifier and the original declaration are `SymbolId(0)` in their
+    /// own binders and a symbol-level alias resolution is a measured no-op
+    /// (#16415). `resolve_export_in_target_file` is program-aware and already
+    /// walks named and wildcard re-export edges, so a chain of hubs terminates
+    /// in one hop.
+    fn alias_target_symbol(
+        &self,
+        symbol_id: tsz_binder::SymbolId,
+        declaring_file_idx: Option<usize>,
+    ) -> Option<(tsz_binder::SymbolId, usize)> {
+        let source_file_idx = declaring_file_idx?;
+        let binder = self.ctx.get_binder_for_file(source_file_idx)?;
+        let symbol = binder.get_symbol(symbol_id)?;
+        let locations: Vec<tsz_binder::StableLocation> =
+            std::iter::once(symbol.stable_value_declaration)
+                .chain(symbol.stable_declarations.iter().copied())
+                .filter(tsz_binder::StableLocation::is_known)
+                .collect();
+        for location in locations {
+            let Some((decl_idx, arena)) = self
+                .ctx
+                .node_at_stable_location_in_file(location, Some(source_file_idx))
+            else {
+                continue;
+            };
+            let Some((imported_name, module_specifier)) = Self::alias_import_edge(arena, decl_idx)
+            else {
+                continue;
+            };
+            let Some(target_idx) = self
+                .ctx
+                .resolve_import_target_from_file(source_file_idx, &module_specifier)
+            else {
+                continue;
+            };
+            let mut visited = rustc_hash::FxHashSet::default();
+            let Some(target_symbol) =
+                self.ctx
+                    .resolve_export_in_target_file(target_idx, &imported_name, &mut visited)
+            else {
+                continue;
+            };
+            // The resolver registers the terminal symbol's own file; keep
+            // `target_idx` only as the fallback for a same-file answer.
+            let target_file_idx = self
+                .ctx
+                .resolve_symbol_file_index(target_symbol)
+                .filter(|&idx| {
+                    self.ctx
+                        .get_binder_for_file(idx)
+                        .is_some_and(|binder| binder.get_symbol(target_symbol).is_some())
+                })
+                .unwrap_or(target_idx);
+            // Guard the hop the same way the anchor walk guards its span: a
+            // resolved id whose symbol does not exist in the file it was
+            // resolved to, or names something else, is a collision, not a
+            // target. `default` is exempt — the exported name and the declared
+            // name legitimately differ there.
+            let names_the_target = self
+                .ctx
+                .get_binder_for_file(target_file_idx)
+                .and_then(|binder| binder.get_symbol(target_symbol))
+                .is_some_and(|symbol| {
+                    imported_name == "default" || symbol.escaped_name == imported_name
+                });
+            if !names_the_target {
+                continue;
+            }
+            return Some((target_symbol, target_file_idx));
+        }
+        None
+    }
+
+    /// `(imported name, module specifier)` for an alias declaration that names
+    /// exactly one export of another module.
+    ///
+    /// A named specifier imports its `property_name` when it was renamed
+    /// (`export { Cross as Renamed }` names `Cross` in the target module) and
+    /// its own name otherwise; a default import clause names `default`. A
+    /// namespace import binds the whole module rather than one export and is
+    /// deliberately not an edge here.
+    fn alias_import_edge(arena: &NodeArena, decl_idx: NodeIndex) -> Option<(String, String)> {
+        use tsz_parser::parser::syntax_kind_ext;
+
+        let node = arena.get(decl_idx)?;
+        let imported_name = if node.kind == syntax_kind_ext::IMPORT_SPECIFIER
+            || node.kind == syntax_kind_ext::EXPORT_SPECIFIER
+        {
+            let specifier = arena.get_specifier(node)?;
+            Self::identifier_text(arena, specifier.property_name)
+                .or_else(|| Self::identifier_text(arena, specifier.name))?
+        } else if node.kind == syntax_kind_ext::IMPORT_CLAUSE {
+            "default".to_string()
+        } else {
+            return None;
+        };
+        Some((
+            imported_name,
+            Self::alias_module_specifier(arena, decl_idx)?,
+        ))
+    }
+
+    /// The module specifier of the import/export declaration `decl_idx` sits
+    /// inside, as written.
+    fn alias_module_specifier(arena: &NodeArena, decl_idx: NodeIndex) -> Option<String> {
+        use tsz_parser::parser::syntax_kind_ext;
+
+        let mut current = decl_idx;
+        while current.is_some() {
+            let node = arena.get(current)?;
+            let specifier_idx = if node.kind == syntax_kind_ext::IMPORT_DECLARATION {
+                arena.get_import_decl(node)?.module_specifier
+            } else if node.kind == syntax_kind_ext::EXPORT_DECLARATION {
+                arena.get_export_decl(node)?.module_specifier
+            } else {
+                let ext = arena.get_extended(current)?;
+                if ext.parent.is_none() {
+                    break;
+                }
+                current = ext.parent;
+                continue;
+            };
+            return arena
+                .get(specifier_idx)
+                .and_then(|node| arena.get_literal(node))
+                .map(|literal| literal.text.clone());
+        }
+        None
+    }
+
+    /// Escaped text of an identifier node, when `idx` is one.
+    fn identifier_text(arena: &NodeArena, idx: NodeIndex) -> Option<String> {
+        arena
+            .get(idx)
+            .and_then(|node| arena.get_identifier(node))
+            .map(|identifier| identifier.escaped_text.to_string())
     }
 
     /// `(start, length, file)` for a member symbol's own declaration, used when

--- a/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
+++ b/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
@@ -419,3 +419,253 @@ fn multiple_missing_cross_file_properties_carry_no_pointer() {
         "the two-missing form is TS2739, not TS2741: {diagnostics:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Re-export hubs (#16415 row 3).
+//
+// A target reached through `export { X } from "./dep"` resolves to the *hub's*
+// export specifier, which owns no member list, so the walk declined and no
+// pointer was produced. tsc's `resolveAlias` follows the alias to the original
+// declaration and anchors there, never on the re-export clause.
+//
+// Every row is pinned against `typescript@7.0.2` (`--noEmit --strict --pretty
+// --target es2022 --lib es2022`) and the oracle's reported location is quoted
+// on each case. In all four the pointer lands in `dep.ts` and `hub.ts` is
+// never mentioned.
+// ---------------------------------------------------------------------------
+
+const HUB_DEP: &str = "export interface Cross { one: number; two: number; }\nexport class Shape { held: number = 0; away: number = 0; }\n";
+
+/// `dep.ts:1:39 - 'two' is declared here.`, underlining `two`.
+#[test]
+fn reexport_hub_points_at_the_original_declaration() {
+    let diagnostic = only(
+        &check_stamped(
+            &[
+                ("dep.ts", HUB_DEP),
+                ("hub.ts", "export { Cross } from \"./dep\";\n"),
+                (
+                    "test.ts",
+                    "import { Cross } from \"./hub\";\nconst c: Cross = { one: 1 };\n",
+                ),
+            ],
+            "test.ts",
+        ),
+        TS2741,
+    );
+    let (file, start, length, message) = declared_here(&diagnostic);
+    assert_eq!(message, "'two' is declared here.");
+    assert_eq!(file, "dep.ts");
+    assert_eq!(span_text(HUB_DEP, start, length), "two");
+}
+
+/// A renamed re-export names the *original* export in the target module, and
+/// the pointer still lands on that original name:
+/// `dep.ts:1:39 - 'two' is declared here.` for `export { Cross as Renamed }`.
+#[test]
+fn renamed_reexport_hub_points_at_the_original_declaration() {
+    let diagnostic = only(
+        &check_stamped(
+            &[
+                ("dep.ts", HUB_DEP),
+                ("hub.ts", "export { Cross as Renamed } from \"./dep\";\n"),
+                (
+                    "test.ts",
+                    "import { Renamed } from \"./hub\";\nconst r: Renamed = { one: 1 };\n",
+                ),
+            ],
+            "test.ts",
+        ),
+        TS2741,
+    );
+    let (file, start, length, message) = declared_here(&diagnostic);
+    assert_eq!(message, "'two' is declared here.");
+    assert_eq!(file, "dep.ts");
+    assert_eq!(span_text(HUB_DEP, start, length), "two");
+}
+
+/// A wildcard hub carries no specifier for the name at all, so the edge is the
+/// re-export index rather than a written clause. Oracle:
+/// `dep.ts:2:40 - 'away' is declared here.`, underlining `away`. A *class*
+/// target through the hub also pins that the member-list walk reaches class
+/// members, not only interface ones.
+#[test]
+fn wildcard_reexport_hub_points_at_the_original_declaration() {
+    let diagnostic = only(
+        &check_stamped(
+            &[
+                ("dep.ts", HUB_DEP),
+                ("hub.ts", "export * from \"./dep\";\n"),
+                (
+                    "test.ts",
+                    "import { Shape } from \"./hub\";\nconst s: Shape = { held: 1 };\n",
+                ),
+            ],
+            "test.ts",
+        ),
+        TS2741,
+    );
+    let (file, start, length, message) = declared_here(&diagnostic);
+    assert_eq!(message, "'away' is declared here.");
+    assert_eq!(file, "dep.ts");
+    assert_eq!(span_text(HUB_DEP, start, length), "away");
+}
+
+/// Two hubs in a row: `test.ts -> hub2.ts -> hub.ts -> dep.ts`. Oracle points
+/// at `dep.ts:1:39` — neither hub is ever mentioned.
+#[test]
+fn two_hop_reexport_chain_points_at_the_original_declaration() {
+    let diagnostic = only(
+        &check_stamped(
+            &[
+                ("dep.ts", HUB_DEP),
+                ("hub.ts", "export { Cross } from \"./dep\";\n"),
+                ("hub2.ts", "export { Cross } from \"./hub\";\n"),
+                (
+                    "test.ts",
+                    "import { Cross } from \"./hub2\";\nconst c: Cross = { one: 1 };\n",
+                ),
+            ],
+            "test.ts",
+        ),
+        TS2741,
+    );
+    let (file, start, length, message) = declared_here(&diagnostic);
+    assert_eq!(message, "'two' is declared here.");
+    assert_eq!(file, "dep.ts");
+    assert_eq!(span_text(HUB_DEP, start, length), "two");
+}
+
+/// The same shape with every binder renamed: the hop is driven by the module
+/// graph and the exported name, so nothing about it may depend on the
+/// particular identifiers a user chose.
+#[test]
+fn renamed_hub_binders_point_at_the_renamed_original_declaration() {
+    let dep = "export interface Widget { alpha: number; omega: number; }\n";
+    let diagnostic = only(
+        &check_stamped(
+            &[
+                ("catalog.ts", dep),
+                ("barrel.ts", "export { Widget } from \"./catalog\";\n"),
+                (
+                    "test.ts",
+                    "import { Widget } from \"./barrel\";\nconst w: Widget = { alpha: 1 };\n",
+                ),
+            ],
+            "test.ts",
+        ),
+        TS2741,
+    );
+    let (file, start, length, message) = declared_here(&diagnostic);
+    assert_eq!(message, "'omega' is declared here.");
+    assert_eq!(file, "catalog.ts");
+    assert_eq!(span_text(dep, start, length), "omega");
+}
+
+/// The negative arm holds through a hub: two unmatched properties is `TS2739`
+/// and tsc attaches no pointer to it.
+#[test]
+fn multiple_missing_properties_through_a_hub_carry_no_pointer() {
+    let diagnostics = check_stamped(
+        &[
+            ("dep.ts", HUB_DEP),
+            ("hub.ts", "export { Cross } from \"./dep\";\n"),
+            (
+                "test.ts",
+                "import { Cross } from \"./hub\";\nconst c: Cross = {};\n",
+            ),
+        ],
+        "test.ts",
+    );
+    let diagnostic = only(&diagnostics, TS2739);
+    assert!(
+        diagnostic
+            .related_information
+            .iter()
+            .all(|info| info.code != TS2728),
+        "TS2739 carries no declared-here pointer: {diagnostic:?}"
+    );
+}
+
+/// The pointer through a hub is still a cross-location pointer, so
+/// `--pretty false` suppresses it exactly as tsc does.
+#[test]
+fn reexport_hub_pointer_is_tagged_as_a_cross_location_pointer() {
+    let diagnostic = only(
+        &check_stamped(
+            &[
+                ("dep.ts", HUB_DEP),
+                ("hub.ts", "export { Cross } from \"./dep\";\n"),
+                (
+                    "test.ts",
+                    "import { Cross } from \"./hub\";\nconst c: Cross = { one: 1 };\n",
+                ),
+            ],
+            "test.ts",
+        ),
+        TS2741,
+    );
+    let pointer = diagnostic
+        .related_information
+        .iter()
+        .find(|info| info.code == TS2728)
+        .expect("a TS2728 pointer");
+    assert!(
+        pointer.is_location_pointer(),
+        "the hub pointer is a cross-location pointer, not a message-chain link: {pointer:?}"
+    );
+}
+
+/// A hub does not make the *primary* diagnostic move: the reported target is
+/// still the name the entry file wrote, and the message is untouched.
+#[test]
+fn reexport_hub_leaves_the_primary_diagnostic_unchanged() {
+    let diagnostic = only(
+        &check_stamped(
+            &[
+                ("dep.ts", HUB_DEP),
+                ("hub.ts", "export { Cross } from \"./dep\";\n"),
+                (
+                    "test.ts",
+                    "import { Cross } from \"./hub\";\nconst c: Cross = { one: 1 };\n",
+                ),
+            ],
+            "test.ts",
+        ),
+        TS2741,
+    );
+    assert_eq!(
+        diagnostic.message_text,
+        "Property 'two' is missing in type '{ one: number; }' but required in type 'Cross'."
+    );
+}
+
+/// #16415 row 2 is out of scope and must stay that way: an imported type alias
+/// whose body is a type literal resolves to no symbol at all, so there is no
+/// alias edge to follow and the pointer is still declined rather than guessed.
+#[test]
+fn imported_type_literal_alias_still_declines_the_pointer() {
+    let diagnostic = only(
+        &check_stamped(
+            &[
+                (
+                    "dep.ts",
+                    "export type Lit = { alpha: string; beta: string };\n",
+                ),
+                (
+                    "test.ts",
+                    "import { Lit } from \"./dep\";\nconst l: Lit = { alpha: \"a\" };\n",
+                ),
+            ],
+            "test.ts",
+        ),
+        TS2741,
+    );
+    assert!(
+        diagnostic
+            .related_information
+            .iter()
+            .all(|info| info.code != TS2728),
+        "row 2 is unchanged by the alias hop: {diagnostic:?}"
+    );
+}


### PR DESCRIPTION
Closes #16415 row 3.

**Structural rule.** When the target of a single-missing-property `TS2741` is reached through a re-export hub, tsc's `resolveAlias` follows the alias to the *original* declaration and anchors the `TS2728` `'x' is declared here.` pointer there, never on the re-export clause; tsz does the same through the **checker's assignability error reporter** (`error_reporter/missing_property_declared_here.rs`), by hopping the module graph.

Before, the owner symbol resolved to the hub's own export specifier — which owns no member list — so the walk declined and **no pointer was produced at all**:

```
dep.ts:   export interface Cross { one: number; two: number; }
hub.ts:   export { Cross } from "./dep";
test.ts:  import { Cross } from "./hub";
          const c: Cross = { one: 1 };

tsc: TS2741 + dep.ts:1:39 - 'two' is declared here.
tsz (before): TS2741, no pointer
tsz (after):  TS2741 + dep.ts:1:39 - 'two' is declared here.
```

The primary diagnostic was already correct in every row here and is unchanged — this adds the missing pointer only.

### Why the hop is through the module graph and not a `SymbolId`

#16415 records a symbol-level alias retry (`resolve_alias_symbol` on the owner id) as a **measured no-op**, and that result is the reason for the shape of this fix. Per-file binders mint raw `SymbolId`s from `0`, so `dep.ts`'s `Cross` interface and `hub.ts`'s `Cross` export specifier are *both* `SymbolId(0)` in their own binders; there is nothing for a symbol-level resolution to move to.

The edge here is taken from the alias's own declaration node instead: the module specifier is resolved from the **alias's** file (`resolve_import_target_from_file`), then the **exported name** — `property_name` when the clause renamed it — is looked up in the target module's public surface (`resolve_export_in_target_file`). That resolver is already program-aware and walks named and wildcard re-export edges, so a chain of hubs terminates in a single hop. Two guards keep a collision from becoming a wrong anchor: the resolved symbol must exist in the file it was resolved to and its `escaped_name` must be the name that was imported (`default` exempted, where the two legitimately differ), and #16322's existing member-name/kind guard on the anchor itself is untouched.

### Adjacent-case matrix

All rows pinned against `typescript@7.0.2` (`--noEmit --strict --pretty --target es2022 --lib es2022`).

| row | shape | before | after |
| --- | --- | --- | --- |
| plain hub | `export { Cross } from "./dep"` | no pointer | `dep.ts` `two` |
| renamed hub | `export { Cross as Renamed } from "./dep"` | no pointer | `dep.ts` `two` |
| two-hop chain | `test -> hub2 -> hub -> dep` | no pointer | `dep.ts` `two` |
| renamed binders | `catalog.ts`/`barrel.ts`/`Widget`/`omega` | no pointer | `catalog.ts` `omega` |
| wildcard hub, class target | `export * from "./dep"`, `class Shape` | already correct | unchanged |
| pointer kind through a hub | must stay a cross-location pointer so `--pretty false` suppresses it | — | holds |
| primary message through a hub | must not move | — | holds |
| negative: two missing props | `TS2739`, tsc attaches no pointer | no pointer | no pointer |
| negative: #16415 row 2 | imported type-literal alias — resolves to no symbol, so no edge exists | no pointer | no pointer |

The **wildcard row already passed on the parent** — a `export * from` hub has no written specifier for the name, so the owner already resolved past it. It is pinned here anyway because it is the one row that exercises a *class* member list through a hub.

`grow`-style anti-hardcoding: the `renamed_hub_binders_*` row varies every identifier and file name in the fixture; nothing in the hop reads a user-chosen name, only the module specifier as written and the exported name as bound.

### Deliberately out of scope

#16415 **row 2** (imported type alias whose body is a type literal) is untouched and pinned as a must-not-move row. It declines *earlier* than this fix acts: `resolve_type_to_symbol_id` and `type_shape_symbol` both return `None` for it, so there is no owner symbol and therefore no alias edge to follow. ClaudeDE's 04:02Z DROP on that row (it wants the type formatter's `skip_alias` decision extracted into a solver-owned query) still stands.

**#16415 row 1 is already fixed on `main`** and I removed nothing for it — see the verification below.

## Goal
Goal: hold

## Verification

- `cargo test -p tsz-checker --lib missing_property_declared_here` — **26 passed, 0 failed** (17 before, 9 new).
- **Negative control**: with *only* `error_reporter/missing_property_declared_here.rs` reverted to the parent and the new tests kept, **5 of the 9 new tests fail** (`reexport_hub_points_at_the_original_declaration`, `renamed_reexport_hub_*`, `two_hop_reexport_chain_*`, `renamed_hub_binders_*`, `reexport_hub_pointer_is_tagged_*`). The other 4 are must-not-move rows and pass in both states, as intended.
- `cargo test -p tsz-checker --lib -- reexport cross_file import_alias declared_here ts2741` — **441 passed, 0 failed, 1 ignored**.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings` — exit 0, no warnings. `cargo fmt --all` clean. Pre-commit hook (clippy + arch guard + affected-crate verification) passed.
- **#16415 row 1 re-measured on `main` before writing anything**: it is **already fixed**, presumably by #16419. `Property 'away' is missing in type '{ held: number; }' but required in type 'Shape'.` with a correct `dep.ts` `away` pointer, where the issue records `Property 'prototype' ... in type 'Unused'`. The issue text is stale for row 1; no code here addresses it.

**compare-to-parent is owed and disclosed, not skipped.** This container is a cold cloud seat and the two-sided `dist-fast` run has been measured at 55–90 min repeatedly on this board, which does not fit the session. Blast radius for the risk assessment: the new code runs **only** after a `TS2741` has already been constructed *and* the existing direct member-list walk has already declined, and it can only add a `TS2728` related entry or decline. The conformance fingerprint compares primary codes, and no primary is touched (pinned by `reexport_hub_leaves_the_primary_diagnostic_unchanged`). One side effect worth naming for whoever runs it: `resolve_export_in_target_file` calls `register_symbol_file_target`, so the hop can populate the symbol→file overlay — the 441-test cross-file/module sweep above is the guard I ran against that.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Selenite

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbjsZQyr9cTkXWXrUHVuFB)_