### PR TITLE
fix(parser): abstract before export default function/expr takes its own diagnostic (#16403 slice 6)

### DIFF
--- a/crates/tsz-parser/src/parser/state_statements_keywords.rs
+++ b/crates/tsz-parser/src/parser/state_statements_keywords.rs
@@ -59,6 +59,15 @@ pub(crate) enum AbstractExportTarget {
     /// (TS1235), `export { }` and `export * from "m"` (TS1233). Outside a Block
     /// the modifier diagnostic is reported as usual.
     PositionErrorWins,
+    /// `abstract export default <expr>` where `default` decorates a value
+    /// expression rather than a class/function declaration — an
+    /// `ExportAssignment` node, on which `abstract` is illegal everywhere.
+    /// Its own placement diagnostic wins in *both* a Block (TS1258) and a
+    /// namespace body (TS1319), wider than `PositionErrorWins`'s Block-only
+    /// silencing, so TS1242 survives only at the source file's own top
+    /// level — the same shape the sibling `async`/`accessor` families give
+    /// their own `ExportAssignment` variant.
+    ExportAssignment,
 }
 
 /// Which grammar diagnostic `checkGrammarModifiers` picks for a stray `async`
@@ -255,6 +264,11 @@ impl ParserState {
                 // The trailing form reports its own position error inside a
                 // Block (TS1235 / TS1233) and no modifier error at all.
                 AbstractExportTarget::PositionErrorWins if in_block => {}
+                // `export default <expr>`'s own placement diagnostic
+                // (TS1258 in a Block, TS1319 in a namespace body) wins in
+                // both containers, not just a Block.
+                AbstractExportTarget::ExportAssignment
+                    if in_block || self.in_module_body_context() => {}
                 // Everything else follows the same container split the sibling
                 // `abstract` var/function path uses (#16368/#16375): a Block
                 // body gets the generic TS1184, a module/namespace body or the
@@ -1095,16 +1109,34 @@ impl ParserState {
                 // `export default abstract class` tail that
                 // `parse_export_declaration` already parses standalone, and
                 // tsc's own diagnostic set for that shape is still exactly
-                // one TS1029 (oracle-confirmed). Every other
-                // `export default <expr>` form admits no `abstract` modifier
-                // at all and is left to its existing, unaffected path.
+                // one TS1029 (oracle-confirmed). `export default function`
+                // (named, anonymous, or async) admits no `abstract` either,
+                // but `export` is still a legal modifier position on a
+                // function declaration, so it takes the ordinary
+                // `ModifierRun` container split rather than `Class`'s
+                // unconditional TS1029 (oracle-confirmed: TS1242 outside a
+                // Block, TS1184 inside one, unaffected by a namespace body).
+                // Every other `export default <expr>` form is a value
+                // expression, which takes `ExportAssignment`'s wider
+                // silencing instead (oracle-confirmed). A second `abstract`
+                // is only ever legal directly before `class`; anywhere else
+                // it is a separate, pre-existing gap (`abstract export
+                // default abstract;`, #16425) and left untouched here.
                 SyntaxKind::DefaultKeyword => {
                     self.next_token(); // skip `default`
-                    if self.is_token(SyntaxKind::AbstractKeyword) {
-                        self.next_token(); // skip a second, legal `abstract`
+                    match self.token() {
+                        SyntaxKind::AbstractKeyword => {
+                            self.next_token(); // skip a second, legal `abstract`
+                            matches!(self.token(), SyntaxKind::ClassKeyword)
+                                .then_some(AbstractExportTarget::Class)
+                        }
+                        SyntaxKind::ClassKeyword => Some(AbstractExportTarget::Class),
+                        SyntaxKind::FunctionKeyword => Some(AbstractExportTarget::ModifierRun),
+                        SyntaxKind::AsyncKeyword => self
+                            .look_ahead_is_async_function()
+                            .then_some(AbstractExportTarget::ModifierRun),
+                        _ => Some(AbstractExportTarget::ExportAssignment),
                     }
-                    matches!(self.token(), SyntaxKind::ClassKeyword)
-                        .then_some(AbstractExportTarget::Class)
                 }
                 // `export type { x }` / `export type * from "m"` is a type-only
                 // export declaration, not the type-alias form — same lookahead

--- a/crates/tsz-parser/tests/parser_abstract_before_export_declaration_tests.rs
+++ b/crates/tsz-parser/tests/parser_abstract_before_export_declaration_tests.rs
@@ -137,6 +137,9 @@ fn abstract_export_modifier_run_splits_ts1242_and_ts1184_by_container() {
         "abstract export interface II {}",
         "abstract export type TT = number;",
         "abstract export enum EE { A }",
+        "abstract export default function f() {}",
+        "abstract export default function() {}",
+        "abstract export default async function g() {}",
     ];
     for statement in statements {
         for index in 0..CONTAINERS.len() {
@@ -395,19 +398,61 @@ fn a_valid_export_default_class_stays_clean() {
 
 #[test]
 fn abstract_export_default_non_class_forms_are_not_read_as_the_class_arm() {
-    // `abstract` admits no other `export default <expr>` form at all — this
-    // fix must not widen the classification past `class`. Left to its
-    // existing (separately tracked) path.
+    // None of `abstract`'s other `export default <expr>` forms are legal on
+    // a class, so this fix must never widen the ordering-violation TS1029
+    // classification past `class`, in any container.
     for statement in [
         "abstract export default function f() {}",
         "abstract export default 1;",
         "abstract export default (class {});",
     ] {
-        let source = in_container(0, statement);
-        assert!(
-            !codes(&source).contains(&diagnostic_codes::MODIFIER_MUST_PRECEDE_MODIFIER),
-            "must not report the class-ordering TS1029 for {source:?}: {:?}",
-            codes(&source)
-        );
+        for index in 0..CONTAINERS.len() {
+            let source = in_container(index, statement);
+            assert!(
+                !codes(&source).contains(&diagnostic_codes::MODIFIER_MUST_PRECEDE_MODIFIER),
+                "must not report the class-ordering TS1029 for {source:?}: {:?}",
+                codes(&source)
+            );
+        }
+    }
+}
+
+// -- `abstract export default <expr>`: previously a completely silent parse
+//    (`abstract` degraded to an identifier expression with no modifier
+//    diagnostic at all, in every container). `function`/`async function`
+//    take the ordinary `ModifierRun` container split (covered above, folded
+//    into `abstract_export_modifier_run_splits_ts1242_and_ts1184_by_container`);
+//    every other expression takes the `ExportAssignment` node's own, wider
+//    silencing. --
+
+#[test]
+fn abstract_export_default_expression_reports_ts1242_only_outside_a_block_or_namespace() {
+    // `export default <expr>` is an `ExportAssignment` node — its own
+    // placement diagnostic (TS1258 in a Block, TS1319 in a namespace body,
+    // both checker-side and outside this parser-only harness) wins in both
+    // containers, so the parser's TS1242 modifier error survives only at
+    // the source file's own top level. Oracle-confirmed against
+    // `typescript@7.0.2`.
+    for statement in [
+        "abstract export default 1;",
+        "abstract export default (class {});",
+    ] {
+        for index in 0..CONTAINERS.len() {
+            let source = in_container(index, statement);
+            if is_block(index) || index == 3 {
+                assert_eq!(
+                    codes(&source),
+                    Vec::<u32>::new(),
+                    "expected no modifier diagnostic for {source:?}, got {:?}",
+                    codes(&source)
+                );
+            } else {
+                assert_diag_at_abstract(
+                    &source,
+                    diagnostic_codes::ABSTRACT_MODIFIER_CAN_ONLY_APPEAR_ON_A_CLASS_METHOD_OR_PROPERTY_DECLARATION,
+                );
+            }
+            assert_no_cannot_find_name(&source);
+        }
     }
 }


### PR DESCRIPTION
`abstract export default function f() {}` and `abstract export default 1;` were silently dropped by the parser: no modifier diagnostic at all, in any container. Every other `abstract export [declaration]` form (`class`/const/let/var/function/interface/type/enum) already dispatches through `look_ahead_abstract_before_export_target` (#16389/#16398); the `DefaultKeyword` arm only recognized a trailing `class`, so every other `export default [...]` form fell through to the unrelated `look_ahead_is_abstract_before_var_or_function` and expression-statement fallback paths and produced nothing.

## Structural rule

`export default function`/`async function` (named or anonymous) is not legal with `abstract`, but `export` is still a legal modifier position on a function declaration, so it takes the ordinary `ModifierRun` container split already used by `const`/`let`/`var`/`interface`/`type`/`enum`: TS1242 outside a Block, TS1184 inside one, unaffected by a namespace body.

Every other `export default [expr]` form is a value expression — an `ExportAssignment` node — which takes that node's own, wider silencing: its own placement diagnostic (TS1258 in a Block, TS1319 in a namespace body, both checker-side) wins in *both* of those containers, so TS1242 survives only at the source file's own top level — the same shape the sibling `async`/`accessor` families (#16403 slices 3 and 5, this session) already give their own `ExportAssignment` variant.

**Owner layer:** parser only, `crates/tsz-parser/src/parser/state_statements_keywords.rs`. Adds a new `AbstractExportTarget::ExportAssignment` variant alongside the existing `Class`/`ModifierRun`/`PositionErrorWins`, and extends the `DefaultKeyword` lookahead arm to classify `function`/`async function` as `ModifierRun` and any other trailing expression as `ExportAssignment`. The pre-existing "skip a second, legal `abstract`" step stays scoped to the `class` check only, so `abstract export default abstract;` (a separate, already-documented pre-existing gap noted on #16425) is untouched.

## Oracle matrix

`typescript@7.0.2`, `--strict --pretty false --target es2022 --module es2022`. 3 containers x default-export forms:

| form | top level | namespace body | block |
| --- | --- | --- | --- |
| `abstract export default function f() {}` | TS1242 | TS1242 | TS1184 |
| `abstract export default function() {}` | TS1242 | TS1242 | TS1184 |
| `abstract export default async function g() {}` | TS1242 | TS1242 | TS1184 |
| `abstract export default 1;` | TS1242 | TS1319 (no TS1242) | TS1258 (no TS1242) |
| `abstract export default (class {});` | TS1242 | TS1319 (no TS1242) | TS1258 (no TS1242) |

Before this fix, all ten rows above reported nothing.

## Goal
Goal: hold

## Verification
| gate | before | after |
| --- | --- | --- |
| new/updated tests in `parser_abstract_before_export_declaration_tests.rs` | — | 20/20 |
| negative control (only `state_statements_keywords.rs` reverted to parent, tests kept) | 18 passed, **2 failed** | (n/a — confirms the 2 new assertions fail for the fix's own mechanism) |
| `cargo test -p tsz-parser --lib` (full crate) | — | **1919/1919, 0 failed** |
| `cargo clippy -p tsz-parser --all-targets -- -D warnings` | — | clean |
| `cargo fmt --all -- --check` | — | clean |
| `python3 scripts/arch/arch_guard.py` | — | passed |

`scripts/conformance/compare-to-parent.sh origin/main` launched at PR-open time; will post the two-sided count before queuing. Blast radius: two new match arms gated on a stray `abstract` immediately before `export default function`/`[expr]` on the same line — a syntax error in every case, since `abstract` is not a legal modifier on any of these forms. This session's sibling slices on the same shared classifier (`async` in #16420, `accessor` in #16427) both measured 0 newly-failing when the count came back.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT
