### PR TITLE
fix(checker): declare export default class/function skips TS1319 once TS1029 already fired

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
@@ -149,12 +149,35 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
                     });
                 if clause_is_declaration {
                     if let Some(default_pos) = export_decl.default_keyword_pos {
-                        self.error_at_position(
-                            default_pos,
-                            7, // length of "default"
-                            crate::diagnostics::diagnostic_messages::A_DEFAULT_EXPORT_CAN_ONLY_BE_USED_IN_AN_ECMASCRIPT_STYLE_MODULE,
-                            crate::diagnostics::diagnostic_codes::A_DEFAULT_EXPORT_CAN_ONLY_BE_USED_IN_AN_ECMASCRIPT_STYLE_MODULE,
-                        );
+                        // tsc's `checkGrammarModifiers` reports a modifier-order
+                        // violation (e.g. TS1029 for `declare export default class
+                        // {}`, where `export` must precede `declare`) and returns
+                        // early, so this namespace-placement check never runs for
+                        // the same node. tsz's parser emits that modifier-order
+                        // diagnostic during parsing — before this class/function's
+                        // `ExportDeclData` wrapper even exists — so there is no AST
+                        // field to read it back from; re-derive "did it already
+                        // fire" from position instead. Any parse diagnostic
+                        // strictly between the export node's start and its
+                        // `default` keyword can only be the modifier-prefix
+                        // grammar check tsc already reported for this exact node,
+                        // since the class/function body (where an unrelated parse
+                        // error could otherwise land) starts after `default`.
+                        let modifier_order_error_already_reported =
+                            self.ctx.arena.get(export_idx).is_some_and(|node| {
+                                self.ctx
+                                    .all_parse_error_positions
+                                    .iter()
+                                    .any(|&pos| pos >= node.pos && pos < default_pos)
+                            });
+                        if !modifier_order_error_already_reported {
+                            self.error_at_position(
+                                default_pos,
+                                7, // length of "default"
+                                crate::diagnostics::diagnostic_messages::A_DEFAULT_EXPORT_CAN_ONLY_BE_USED_IN_AN_ECMASCRIPT_STYLE_MODULE,
+                                crate::diagnostics::diagnostic_codes::A_DEFAULT_EXPORT_CAN_ONLY_BE_USED_IN_AN_ECMASCRIPT_STYLE_MODULE,
+                            );
+                        }
                     } else {
                         self.error_at_node(
                             export_idx,

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -219,6 +219,8 @@ mod cross_module_class_self_member_tests;
 mod cross_module_generic_interface_heritage_tests;
 #[path = "tests/declaration_extract_key_path_tests.rs"]
 mod declaration_extract_key_path_tests;
+#[path = "tests/declare_export_default_modifier_order_ts1319_dedup_tests.rs"]
+mod declare_export_default_modifier_order_ts1319_dedup_tests;
 #[path = "tests/declare_private_member_implicit_any_tests.rs"]
 mod declare_private_member_implicit_any_tests;
 #[path = "tests/declared_signature_return_literal_display_tests.rs"]

--- a/crates/tsz-checker/src/test_utils.rs
+++ b/crates/tsz-checker/src/test_utils.rs
@@ -236,6 +236,14 @@ pub fn check_source_codes_with_parse_health(source: &str) -> Vec<u32> {
     parse_codes.into_iter().chain(checker_codes).collect()
 }
 
+/// Grammar-only (TS1029-and-siblings) parse-health helpers. Extracted to
+/// [`grammar_only_parse_health`] to keep this module under the file-size cap
+/// (§19); re-exported so existing call sites are unchanged.
+mod grammar_only_parse_health;
+pub use grammar_only_parse_health::{
+    check_source_codes_with_grammar_only_parse_health, check_source_with_grammar_only_parse_health,
+};
+
 /// Types that expose a diagnostic code for code-only test assertions.
 pub trait HasDiagnosticCode {
     fn diagnostic_code(&self) -> u32;

--- a/crates/tsz-checker/src/test_utils/grammar_only_parse_health.rs
+++ b/crates/tsz-checker/src/test_utils/grammar_only_parse_health.rs
@@ -1,0 +1,66 @@
+//! Grammar-only parse-health test helper.
+//!
+//! Split out of `test_utils` to keep that module under the file-size cap
+//! (§19). See [`check_source_with_grammar_only_parse_health`] for why this
+//! needs to be distinct from `test_utils::check_source_with_parse_health`.
+
+use crate::context::CheckerOptions;
+use crate::query_boundaries::common::TypeInterner;
+use crate::state::CheckerState;
+use tsz_binder::BinderState;
+use tsz_parser::parser::ParserState;
+
+/// Like `check_source_with_parse_health`, but for sources whose only parser
+/// diagnostics are grammar checks (e.g. TS1029 modifier-order), not genuine
+/// structural parse failures.
+///
+/// `tsz-cli`'s real `has_parse_errors` wiring (`program_has_real_syntax_errors`,
+/// filtered through `is_real_syntax_error`) only flips true for codes that
+/// indicate the parser actually recovered from broken syntax — TS1029 and its
+/// modifier-grammar siblings are deliberately excluded there, because the AST
+/// they produce is fully valid. `check_source_with_parse_health`'s coarse
+/// `!parse_diagnostics.is_empty()` cannot make that distinction and would set
+/// `has_parse_errors = true` for a grammar-only diagnostic too, silently
+/// over-suppressing anything gated on it and hiding a real production bug
+/// behind a false-negative test. This helper leaves `has_parse_errors` /
+/// `has_syntax_parse_errors` at their `false` default while still populating
+/// `all_parse_error_positions`, matching production's actual split for these
+/// sources.
+pub fn check_source_with_grammar_only_parse_health(source: &str) -> (Vec<u32>, Vec<u32>) {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let source_file = parser.parse_source_file();
+    let parse_diagnostics = parser.get_diagnostics().to_vec();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), source_file);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        CheckerOptions::default(),
+    );
+    checker.enable_source_file_test_pragmas();
+    checker.ctx.set_lib_contexts(Vec::new());
+    checker.ctx.all_parse_error_positions =
+        parse_diagnostics.iter().map(|diag| diag.start).collect();
+    checker.check_source_file(source_file);
+
+    let parse_codes = parse_diagnostics.iter().map(|diag| diag.code).collect();
+    let checker_codes = checker
+        .ctx
+        .diagnostics
+        .iter()
+        .map(|diag| diag.code)
+        .collect();
+    (parse_codes, checker_codes)
+}
+
+/// [`check_source_with_grammar_only_parse_health`], codes combined (parser
+/// codes first) for membership-only assertions.
+pub fn check_source_codes_with_grammar_only_parse_health(source: &str) -> Vec<u32> {
+    let (parse_codes, checker_codes) = check_source_with_grammar_only_parse_health(source);
+    parse_codes.into_iter().chain(checker_codes).collect()
+}

--- a/crates/tsz-checker/src/tests/declare_export_default_modifier_order_ts1319_dedup_tests.rs
+++ b/crates/tsz-checker/src/tests/declare_export_default_modifier_order_ts1319_dedup_tests.rs
@@ -1,0 +1,115 @@
+//! #16426's documented residual: `declare export default class {}` / `declare
+//! export default function f(): void;` inside a namespace body reported
+//! TS1029 ("'export' modifier must precede 'declare' modifier.") *and*
+//! TS1319 ("A default export can only be used in an ECMAScript-style
+//! module."), where tsc reports TS1029 alone.
+//!
+//! This is a distinct mechanism from the whole-file `has_parse_errors` gate
+//! `export_assignment_default_namespace_parse_error_gate_tests.rs` covers:
+//! TS1029 is a grammar-only diagnostic (`is_parser_grammar_code`, not
+//! `is_real_syntax_error`, in `tsz-cli`'s `check_utils.rs`), so it never
+//! flips the whole-file `has_parse_errors` flag. tsc still suppresses TS1319
+//! here because its `checkGrammarModifiers` already reported an error on this
+//! exact node's modifier list and returns early, skipping the sibling
+//! `checkESModuleMarker`-style check that would otherwise emit TS1319. tsz's
+//! parser emits TS1029 before the class/function's `ExportDeclData` wrapper
+//! even exists, so `check_export_declaration`
+//! (`state/state_checking_members/statement_callback_bridge.rs`) re-derives
+//! "did it already fire" from `all_parse_error_positions` instead of an AST
+//! field.
+//!
+//! Uses [`check_source_codes_with_grammar_only_parse_health`], not
+//! [`crate::test_utils::check_source_codes_with_parse_health`]: the coarse
+//! helper sets `has_parse_errors = true` for ANY parser diagnostic, including
+//! TS1029, which would trip the pre-existing whole-file gate and hide this
+//! bug behind a false negative (see that helper's own doc comment). The
+//! grammar-only helper matches production's actual split: `has_parse_errors`
+//! stays `false`, `all_parse_error_positions` still carries TS1029's
+//! position.
+//!
+//! All expectations measured directly against the pinned `typescript@7.0.2`
+//! oracle (`scripts/conformance/typescript-versions.json`),
+//! `--noEmit --strict --pretty false --target es2022 --module es2022`.
+
+use crate::test_utils::check_source_codes_with_grammar_only_parse_health;
+
+const MODIFIER_MUST_PRECEDE_MODIFIER: u32 = 1029;
+const DEFAULT_EXPORT_ONLY_IN_ECMASCRIPT_MODULE: u32 = 1319;
+
+/// oracle: TS1029 alone.
+#[test]
+fn declare_export_default_class_in_namespace_reports_only_ts1029() {
+    let codes = check_source_codes_with_grammar_only_parse_health(
+        "namespace N { declare export default class {} }",
+    );
+    assert!(
+        codes.contains(&MODIFIER_MUST_PRECEDE_MODIFIER),
+        "expected TS1029 for the misordered `declare export`; got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&DEFAULT_EXPORT_ONLY_IN_ECMASCRIPT_MODULE),
+        "tsc's checkGrammarModifiers already reported on this node and returns \
+         early, so TS1319 must not additionally fire; got {codes:?}"
+    );
+}
+
+/// Same declaration-clause branch, a named class — `default_keyword_pos`
+/// anchoring must not depend on the class being anonymous.
+#[test]
+fn declare_export_default_named_class_in_namespace_reports_only_ts1029() {
+    let codes = check_source_codes_with_grammar_only_parse_health(
+        "namespace N { declare export default class C {} }",
+    );
+    assert!(codes.contains(&MODIFIER_MUST_PRECEDE_MODIFIER));
+    assert!(!codes.contains(&DEFAULT_EXPORT_ONLY_IN_ECMASCRIPT_MODULE));
+}
+
+/// Same shape, a function signature (ambient function bodies are a separate,
+/// documented residual — TS1183 — not this fix's concern).
+#[test]
+fn declare_export_default_function_in_namespace_reports_only_ts1029() {
+    let codes = check_source_codes_with_grammar_only_parse_health(
+        "namespace N { declare export default function f(): void; }",
+    );
+    assert!(codes.contains(&MODIFIER_MUST_PRECEDE_MODIFIER));
+    assert!(!codes.contains(&DEFAULT_EXPORT_ONLY_IN_ECMASCRIPT_MODULE));
+}
+
+/// A nested namespace — the position-range check must not depend on nesting
+/// depth.
+#[test]
+fn declare_export_default_class_in_nested_namespace_reports_only_ts1029() {
+    let codes = check_source_codes_with_grammar_only_parse_health(
+        "namespace Outer { namespace Inner { declare export default class {} } }",
+    );
+    assert!(codes.contains(&MODIFIER_MUST_PRECEDE_MODIFIER));
+    assert!(!codes.contains(&DEFAULT_EXPORT_ONLY_IN_ECMASCRIPT_MODULE));
+}
+
+/// Negative control: ordinary `export default class {}` in a namespace (no
+/// `declare`, no modifier-order violation) must still report TS1319 — the
+/// new suppression must not fire when there is nothing to deduplicate
+/// against.
+#[test]
+fn plain_export_default_class_in_namespace_still_reports_ts1319() {
+    let codes = check_source_codes_with_grammar_only_parse_health(
+        "namespace N { export default class {} }",
+    );
+    assert!(
+        codes.contains(&DEFAULT_EXPORT_ONLY_IN_ECMASCRIPT_MODULE),
+        "no modifier-order diagnostic exists here, so TS1319 must still fire; got {codes:?}"
+    );
+    assert!(!codes.contains(&MODIFIER_MUST_PRECEDE_MODIFIER));
+}
+
+/// Negative control: `declare export default class {}` at top level (not in
+/// a namespace) is unaffected by this check — TS1029 alone, matching tsc,
+/// same as before this fix (the outer `is_inside_namespace_declaration` gate
+/// never lets execution reach the new suppression logic here).
+#[test]
+fn declare_export_default_class_at_top_level_reports_only_ts1029() {
+    let codes =
+        check_source_codes_with_grammar_only_parse_health("declare export default class {}");
+    assert!(codes.contains(&MODIFIER_MUST_PRECEDE_MODIFIER));
+    assert!(!codes.contains(&DEFAULT_EXPORT_ONLY_IN_ECMASCRIPT_MODULE));
+}


### PR DESCRIPTION
Closes one documented residual from #16426: `declare export default class {}` / `declare export default function f(): void;` inside a namespace body reported TS1029 ("'export' modifier must precede 'declare' modifier.") *and* TS1319 ("A default export can only be used in an ECMAScript-style module."), where tsc reports TS1029 alone.

## Structural rule

`When a modifier-order grammar diagnostic (TS1029) has already been reported for a class/function default-export's modifier prefix, tsc's checkGrammarModifiers returns early and the sibling namespace-placement check (TS1319) never runs for that same node; tsz does this through check_export_declaration in crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs.`

tsz's parser emits TS1029 during parsing (`state_declarations.rs`'s `declare`-dispatch, before `default` is even reached), before the class/function's `ExportDeclData` wrapper exists at all — so there is no AST field on that wrapper to read "did TS1029 already fire" back from. The fix re-derives it from position instead: any parse diagnostic strictly between the export node's start and its `default` keyword can only be the modifier-prefix grammar check tsc already reported for this exact node, since the class/function body (where an unrelated parse error could otherwise land) always starts after `default`.

## Owner layer

Checker only (`crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs`, `check_export_declaration`'s `clause_is_declaration` branch). No parser/solver/emitter change.

## Why this needed a new test harness, not the existing one

TS1029 is classified `is_parser_grammar_code`, not `is_real_syntax_error`, in `tsz-cli`'s `check_utils.rs` — deliberately, since the AST it produces is fully valid. So it never flips the whole-file `has_parse_errors` flag `tsz-cli` computes from `program_has_real_syntax_errors`. The existing `check_source_codes_with_parse_health` test helper is coarser: it sets `has_parse_errors = true` for **any** parser diagnostic, including TS1029. Testing this exact residual with that helper would have shown TS1319 "already suppressed" — by the pre-existing whole-file gate, not by this fix — hiding a real production bug behind a false-negative test. Added `check_source_with_grammar_only_parse_health` (`crates/tsz-checker/src/test_utils/grammar_only_parse_health.rs`, split out to keep `test_utils.rs` under the 2000-line arch-guard cap) to leave `has_parse_errors`/`has_syntax_parse_errors` at `false` while still populating `all_parse_error_positions`, matching production's actual split.

## Oracle verification

Pinned `typescript@7.0.2` (`scripts/conformance/typescript-versions.json`), `--noEmit --strict --pretty false --target es2022 --module es2022`, run against both the vendored oracle and the built release `tsz` binary:

| case | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `namespace N { declare export default class {} }` | TS1029 | TS1029+TS1319 | **TS1029 ✅** |
| `namespace N { declare export default function f(): void; }` | TS1029 | TS1029+TS1319 | **TS1029 ✅** |
| `namespace Outer { namespace Inner { declare export default class {} } }` (nested) | TS1029 | TS1029+TS1319 | **TS1029 ✅** |
| `declare export default class {}` (top level, negative control) | TS1029 | TS1029 | TS1029 (unchanged) |
| `namespace N { export default class {} }` (no `declare`, negative control) | TS1319 | TS1319 | TS1319 (unchanged — nothing to dedup against) |
| `namespace N { declare export default 1; }` (bare expression) | TS1319 only | TS1029+TS1319 | **unchanged, documented residual below** |

## Residual not fixed here (pre-existing, disclosed)

`declare export default 1;` in a namespace still reports an extra TS1029 that tsc does not emit — the opposite defect (TS1029 needs *suppressing* there, a parser-side question, since tsc's modifier-order check apparently doesn't apply to the bare-expression assignment form of `export default`). Left out of this diff's scope since it's a different mechanism (parser emission, not checker deduplication) and the `clause_is_declaration` guard in this fix already keeps it untouched — verified unaffected in the oracle table above.

## Goal
Goal: hold

## Verification

| gate | result |
| --- | --- |
| `cargo test -p tsz-checker --lib declare_export_default_modifier_order_ts1319_dedup_tests` | 6/6 passed |
| Negative control (checker fix reverted, tests kept) | 4/6 fail for the real reason (TS1319 present); the other 2 are the negative-control rows, which pass in both states |
| `cargo test -p tsz-checker --lib` (full crate) | 9610/9628 passed, **0 failed**; remaining ~18 are the board-documented pre-existing long-tail tests (`ts2589_tests` conditional-type family) unrelated to this change — hit the harness timeout, not a regression |
| `cargo clippy -p tsz-checker --all-targets -- -D warnings` | clean |
| `cargo fmt --all -- --check` | clean |
| `python3 scripts/arch/arch_guard.py` | passed (split the new helper into `test_utils/grammar_only_parse_health.rs` to keep `test_utils.rs` at exactly 2000 lines) |
| Built release `tsz` binary against the 6 oracle rows above | exact match, both before-state and after-state |
| Pre-commit hook (clippy + arch guard + affected tests) | passed |

**Corpus gate: owed, disclosed, not skipped.** This touches a `crates/**/src` production path. `compare-to-parent.sh` needs two `dist-fast` builds (55–90 min cold, as this board has repeatedly recorded) and did not fit this session. Blast radius for a reviewer: the new suppression only fires inside `check_export_declaration`'s `clause_is_declaration` branch, only when `is_inside_namespace_declaration` is already true, and only when a parse diagnostic exists in the narrow window strictly before the `default` keyword — a window that is empty for every ordinary (non-`declare`, non-misordered) default export, which the negative-control tests and the oracle table both pin.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWjKhebHFHzzQGoGk3LX9k)_