### PR TITLE
fix(checker): two `import =` aliases sharing a name across sibling blocks report TS2300

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2644,3 +2644,7 @@ path = "tests/import_namespace_ts1147_tests.rs"
 [[test]]
 name = "position_invalid_import_equals_container_scope_tests"
 path = "tests/position_invalid_import_equals_container_scope_tests.rs"
+
+[[test]]
+name = "import_equals_alias_duplicate_container_tests"
+path = "tests/import_equals_alias_duplicate_container_tests.rs"

--- a/crates/tsz-checker/src/declarations/import/import_alias_duplicates.rs
+++ b/crates/tsz-checker/src/declarations/import/import_alias_duplicates.rs
@@ -5,21 +5,119 @@ use std::collections::HashMap;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 
 impl<'a> CheckerState<'a> {
+    /// Collect every `import X = ...` declaration reachable from `stmt_idx`
+    /// without crossing a declaration-container boundary.
+    ///
+    /// `tsc`'s binder keeps two cursors while binding: `container` (source
+    /// file, module body, class body, or any function-like node) and
+    /// `blockScopeContainer` (additionally every plain `Block`/`if`/`for`/
+    /// `try`/`switch`/... body). An alias is not block-scoped, so a
+    /// position-invalid `import x = ...` nested inside `if`/`for`/`try`/
+    /// `switch`/labeled/`with` bodies is recorded in the *container*, exactly
+    /// like a bare `{ }` block (see #16428). This walk mirrors that
+    /// transparency so two aliases nested in different blocks of the same
+    /// container are grouped together for the TS2300 check below, while a
+    /// function body, class body, or nested namespace — genuine containers —
+    /// stop the walk, matching `nearest_declaration_container_scope`.
+    fn collect_import_equals_transparently(&self, stmt_idx: NodeIndex, out: &mut Vec<NodeIndex>) {
+        let Some(node) = self.ctx.arena.get(stmt_idx) else {
+            return;
+        };
+        match node.kind {
+            k if k == syntax_kind_ext::IMPORT_EQUALS_DECLARATION => out.push(stmt_idx),
+            syntax_kind_ext::BLOCK => {
+                // `get_block` also covers CLASS_STATIC_BLOCK_DECLARATION and
+                // CASE_BLOCK, both excluded above/below — this arm only ever
+                // sees a plain `{ }` block here.
+                if let Some(block) = self.ctx.arena.get_block(node) {
+                    for &inner in &block.statements.nodes {
+                        self.collect_import_equals_transparently(inner, out);
+                    }
+                }
+            }
+            syntax_kind_ext::IF_STATEMENT => {
+                if let Some(if_stmt) = self.ctx.arena.get_if_statement(node) {
+                    self.collect_import_equals_transparently(if_stmt.then_statement, out);
+                    if if_stmt.else_statement.is_some() {
+                        self.collect_import_equals_transparently(if_stmt.else_statement, out);
+                    }
+                }
+            }
+            syntax_kind_ext::WHILE_STATEMENT
+            | syntax_kind_ext::DO_STATEMENT
+            | syntax_kind_ext::FOR_STATEMENT => {
+                if let Some(loop_data) = self.ctx.arena.get_loop(node) {
+                    self.collect_import_equals_transparently(loop_data.statement, out);
+                }
+            }
+            syntax_kind_ext::FOR_IN_STATEMENT | syntax_kind_ext::FOR_OF_STATEMENT => {
+                if let Some(for_in_of) = self.ctx.arena.get_for_in_of(node) {
+                    self.collect_import_equals_transparently(for_in_of.statement, out);
+                }
+            }
+            syntax_kind_ext::WITH_STATEMENT => {
+                if let Some(with_stmt) = self.ctx.arena.get_with_statement(node) {
+                    self.collect_import_equals_transparently(with_stmt.then_statement, out);
+                }
+            }
+            syntax_kind_ext::TRY_STATEMENT => {
+                if let Some(try_data) = self.ctx.arena.get_try(node) {
+                    self.collect_import_equals_transparently(try_data.try_block, out);
+                    if try_data.catch_clause.is_some()
+                        && let Some(catch_node) = self.ctx.arena.get(try_data.catch_clause)
+                        && let Some(catch_data) = self.ctx.arena.get_catch_clause(catch_node)
+                    {
+                        self.collect_import_equals_transparently(catch_data.block, out);
+                    }
+                    if try_data.finally_block.is_some() {
+                        self.collect_import_equals_transparently(try_data.finally_block, out);
+                    }
+                }
+            }
+            syntax_kind_ext::SWITCH_STATEMENT => {
+                if let Some(switch_data) = self.ctx.arena.get_switch(node)
+                    && let Some(case_block_node) = self.ctx.arena.get(switch_data.case_block)
+                    && let Some(case_block) = self.ctx.arena.get_block(case_block_node)
+                {
+                    for &clause_idx in &case_block.statements.nodes {
+                        let Some(clause_node) = self.ctx.arena.get(clause_idx) else {
+                            continue;
+                        };
+                        if let Some(clause) = self.ctx.arena.get_case_clause(clause_node) {
+                            for &inner in &clause.statements.nodes {
+                                self.collect_import_equals_transparently(inner, out);
+                            }
+                        }
+                    }
+                }
+            }
+            syntax_kind_ext::LABELED_STATEMENT => {
+                if let Some(labeled) = self.ctx.arena.get_labeled_statement(node) {
+                    self.collect_import_equals_transparently(labeled.statement, out);
+                }
+            }
+            _ => {}
+        }
+    }
+
     /// Check for duplicate import alias declarations within a scope.
     ///
     /// TS2300: Emitted when multiple `import X = ...` declarations have the same name
-    /// within the same scope (namespace, module, or file).
+    /// within the same scope (namespace, module, or file), including a
+    /// position-invalid alias nested in a different block of that scope
+    /// (`{ import x = ...; } { import x = ...; }`, #16429).
     pub(crate) fn check_import_alias_duplicates(&mut self, statements: &[NodeIndex]) {
         let mut alias_map: HashMap<String, Vec<NodeIndex>> = HashMap::new();
 
+        let mut collected = Vec::new();
         for &stmt_idx in statements {
+            self.collect_import_equals_transparently(stmt_idx, &mut collected);
+        }
+
+        for stmt_idx in collected {
             let Some(node) = self.ctx.arena.get(stmt_idx) else {
                 continue;
             };
-
-            if node.kind != syntax_kind_ext::IMPORT_EQUALS_DECLARATION {
-                continue;
-            }
 
             let Some(import_decl) = self.ctx.arena.get_import_decl(node) else {
                 continue;

--- a/crates/tsz-checker/tests/import_equals_alias_duplicate_container_tests.rs
+++ b/crates/tsz-checker/tests/import_equals_alias_duplicate_container_tests.rs
@@ -1,0 +1,230 @@
+//! Two `import x = ...` aliases sharing a name in the same declaration
+//! container report TS2300, even when they sit in different nested blocks
+//! of that container.
+//!
+//! `tsc`'s `AliasExcludes` is exactly `Alias`, so a second alias declared
+//! with the same name as an existing one is a redeclaration conflict and
+//! `declareSymbol` reports TS2300 for both. Position-invalid `import =`
+//! binds to its nearest *declaration container*, not the `Block` that
+//! encloses it (#16428) — so two aliases nested in two different blocks of
+//! one container (`{ import x = ...; } { import x = ...; }`) are, in
+//! `tsc`'s model, two declarations of the same name in the same container
+//! and collide exactly like two adjacent ones would.
+//!
+//! `tsz`'s checker-side duplicate-alias scan (`check_import_alias_duplicates`)
+//! only walked the direct statement list it was handed (source file top
+//! level, or one namespace body), so two aliases in sibling blocks were
+//! invisible to it even though the binder now (correctly, since #16428)
+//! resolves them through the same container scope. This suite pins the fix:
+//! the scan recurses through the same "transparent" block-like statements
+//! (`if`/`for`/`while`/`try`/`switch`/labeled/bare `{ }`) the binder treats
+//! as non-containers, stopping at genuine declaration-container boundaries
+//! (function bodies, class bodies/static blocks, nested namespaces) exactly
+//! like `nearest_declaration_container_scope` does.
+//!
+//! All expectations were measured against `typescript@7.0.2` with
+//! `--noEmit --strict --pretty false --target es2015 --module commonjs`.
+//!
+//! ## Known residual, not owned by this suite
+//!
+//! Once two aliases collide, `tsc` resolves the module specifier of only the
+//! *first* declaration (one TS2307), because the colliding declarations are
+//! one merged symbol in `tsc`'s model and `resolveAlias` follows a single
+//! declaration. `tsz` keeps a distinct symbol per colliding alias declaration
+//! (deliberately — see `declare_symbol` in `crates/tsz-binder/src/nodes/binding.rs`,
+//! which preserves each duplicate as its own binding so a later value-bearing
+//! alias can still shadow an earlier type-only one in expression resolution),
+//! so each still resolves its own specifier independently. That is the same
+//! "resolve only when referenced" alias-merge mechanism tracked separately
+//! (#16410 item 2 / #16411) and predates this fix — it does not regress here,
+//! and rows below assert the TS2300 count rather than the full TS2307 count
+//! where the two diverge.
+
+use tsz_binder::BinderState;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::state::CheckerState;
+use tsz_parser::parser::ParserState;
+use tsz_solver::construction::TypeInterner;
+
+fn check(source: &str) -> Vec<u32> {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        CheckerOptions {
+            module: tsz_common::common::ModuleKind::CommonJS,
+            target: tsz_common::common::ScriptTarget::ES2015,
+            ..CheckerOptions::default()
+        },
+    );
+    checker.ctx.report_unresolved_imports = true;
+    checker.check_source_file(root);
+    let mut codes: Vec<u32> = checker.ctx.diagnostics.iter().map(|d| d.code).collect();
+    codes.sort_unstable();
+    codes
+}
+
+fn duplicate_count(codes: &[u32]) -> usize {
+    codes.iter().filter(|&&c| c == 2300).count()
+}
+
+// ---------------------------------------------------------------------------
+// Positive: same container, different nested blocks -> collides.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cross_block_same_name_aliases_collide() {
+    let source = r#"{ import x = require("nonexistent-a"); }
+{ import x = require("nonexistent-b"); x; }
+"#;
+    let codes = check(source);
+    assert_eq!(
+        duplicate_count(&codes),
+        2,
+        "two same-name aliases in sibling blocks of the file container must both report TS2300, got {codes:?}"
+    );
+    assert_eq!(
+        codes.iter().filter(|&&c| c == 1232).count(),
+        2,
+        "both aliases stay position-invalid (TS1232), got {codes:?}"
+    );
+}
+
+#[test]
+fn three_same_name_aliases_all_flagged() {
+    let source = r#"{ import x = require("nonexistent-a"); }
+{ import x = require("nonexistent-b"); }
+{ import x = require("nonexistent-c"); }
+"#;
+    let codes = check(source);
+    assert_eq!(
+        duplicate_count(&codes),
+        3,
+        "every one of 3 colliding aliases reports its own TS2300, got {codes:?}"
+    );
+}
+
+#[test]
+fn same_namespace_two_blocks_collide() {
+    let source = r#"namespace N {
+  { import x = require("nonexistent-a"); }
+  { import x = require("nonexistent-b"); x; }
+}
+"#;
+    let codes = check(source);
+    assert_eq!(
+        codes,
+        vec![1232, 1232, 2300, 2300, 2307],
+        "namespace-body container: matches tsc exactly (single TS2307, the alias-merge \
+         residual noted above does not appear here because only the referenced alias's \
+         group needed to resolve once), got {codes:?}"
+    );
+}
+
+#[test]
+fn switch_case_and_try_block_aliases_collide() {
+    let source = r#"switch (1) {
+  case 1:
+    import x = require("nonexistent-a");
+    break;
+}
+try {
+  import x = require("nonexistent-b");
+  x;
+} catch {}
+"#;
+    let codes = check(source);
+    assert_eq!(
+        duplicate_count(&codes),
+        2,
+        "a `switch`-case alias and a `try`-block alias in the same file container collide, got {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative: a genuine container boundary must not collide across it.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn different_function_bodies_do_not_collide() {
+    let source = r#"function f() { import a = require("nonexistent-a"); }
+function g() { import a = require("nonexistent-b"); }
+"#;
+    let codes = check(source);
+    assert_eq!(
+        codes,
+        vec![1232, 1232],
+        "each function body is its own container; same-name aliases in two different \
+         functions must not report TS2300, got {codes:?}"
+    );
+}
+
+#[test]
+fn different_namespaces_do_not_collide() {
+    let source = r#"namespace N1 { import x = require("nonexistent-a"); }
+namespace N2 { import x = require("nonexistent-b"); }
+"#;
+    let codes = check(source);
+    assert_eq!(
+        codes,
+        vec![1147, 1147],
+        "two different namespace bodies are two different containers, got {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative: an alias never conflicts with a block-scoped variable, in either
+// order (`AliasExcludes` is only `Alias`; oracle-confirmed both directions).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn let_then_alias_stays_clean() {
+    let source = r#"let x = 1;
+{ import x = require("nonexistent-a"); }
+"#;
+    let codes = check(source);
+    assert_eq!(
+        duplicate_count(&codes),
+        0,
+        "a block-scoped `let` does not exclude a later alias, got {codes:?}"
+    );
+}
+
+#[test]
+fn alias_then_let_stays_clean() {
+    let source = r#"{ import x = require("nonexistent-a"); }
+let x = 1;
+"#;
+    let codes = check(source);
+    assert_eq!(
+        duplicate_count(&codes),
+        0,
+        "an alias does not exclude a later block-scoped `let` either — oracle-confirmed \
+         symmetric, not the asymmetry #16429 speculated, got {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Position-valid form (not this bug's trigger condition): already correct
+// before this fix, pinned so a future change to the shared scan can't move it.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn top_level_position_valid_duplicate_unchanged() {
+    let source = r#"import a = require("nonexistent-a");
+import a = require("nonexistent-b");
+"#;
+    let codes = check(source);
+    assert_eq!(
+        codes,
+        vec![2300, 2300, 2307, 2307],
+        "ordinary top-level duplicate aliases were already correct, got {codes:?}"
+    );
+}


### PR DESCRIPTION
Closes #16429.

`{ import x = require("a"); } { import x = require("b"); x; }` reported `TS1232 + TS2307` twice and silently dropped tsc's `TS2300` pair.

## Structural rule

tsc's `AliasExcludes` is exactly `Alias`, so a second same-name `import =` alias is a redeclaration conflict (`TS2300`) regardless of which block it sits in — once #16428 made a position-invalid `import =` bind to its nearest declaration container instead of the enclosing `Block`, two aliases in sibling blocks of that container are, in tsc's model, two declarations of the same name in the same container.

tsz's binder already refuses to *merge* two `ALIAS`-flagged symbols (it keeps each as its own symbol, so a later value-bearing alias can still shadow an earlier type-only one in expression resolution — see the comment in `declare_symbol`, `crates/tsz-binder/src/nodes/binding.rs`) and relies on the checker's syntactic `check_import_alias_duplicates` scan to report the duplicate instead. That scan only walked the *direct* statement list it was handed (source-file top level, or one namespace body) and never recursed into nested blocks, so two aliases in sibling blocks of the same container were invisible to it even though #16428 made the binder resolve them through that shared container.

**Fix, checker-owned, no binder change**: the scan now recurses through the same "transparent" block-like statements (`if`/`for`/`while`/`try`/`switch`/labeled/bare `{ }`) that the binder's `nearest_declaration_container_scope` treats as non-containers, stopping at genuine container boundaries (function bodies, class bodies/static blocks, nested namespaces) — mirroring the exact transparency rule #16428 introduced on the binder side, in `crates/tsz-checker/src/declarations/import/import_alias_duplicates.rs`.

## Oracle matrix

`typescript@7.0.2`, `--noEmit --strict --pretty false --target es2015 --module commonjs`.

| case | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| two aliases, sibling blocks of the file | `1232,1232,2300,2300,2307` | `1232,1232,2307,2307` | `1232,1232,2300,2300,`**`2307,2307`*** |
| three aliases, three sibling blocks | `1232×3,2300×3` | `1232×3,2307×3` | `1232×3,2300×3,`**`2307×3`*** |
| two aliases, sibling blocks of one namespace body | `1232,1232,2300,2300,2307` | `1232,1232,2307` | `1232,1232,2300,2300,2307` ✅ exact |
| `switch`-case alias + `try`-block alias, same file | `1232,1232,2300,2300,2307` | `1232,1232,2307,2307` | `1232,1232,2300,2300,`**`2307,2307`*** |
| two aliases, two different function bodies (negative) | `1232,1232` | `1232,1232` | `1232,1232` (unchanged) |
| two aliases, two different namespaces (negative) | `1147,1147` | `1147,1147` | `1147,1147` (unchanged) |
| `let x` then alias (negative) | `1232` | `1232` | `1232` (unchanged) |
| alias then `let x` (negative) | `1232` | `1232` | `1232` (unchanged) — falsifies the issue's own speculated asymmetry |
| top-level position-valid duplicate (negative, already correct) | `2300,2300,2307,2307` | `2300,2300,2307,2307` | unchanged |

\* Bolded `2307,2307` is a **known, pre-existing residual, not fixed here** (see below) — present identically before and after this diff.

## Known residual (not fixed here, documented in the test file)

Once two aliases collide, tsc resolves the module specifier of only the *first* declaration (one `TS2307`), because the colliding declarations are one merged symbol in tsc's model and `resolveAlias` follows a single declaration. tsz keeps a **distinct symbol per colliding alias** by design (to preserve the shadowing behavior noted above), so each independently resolves its own specifier — extra `TS2307`s. This is the same "resolve only when referenced" alias-merge mechanism tracked separately as #16410 item 2 / the in-flight #16411, and is unaffected by this fix in either direction (confirmed identical residual count before/after on every affected row via negative control).

## Adjacent-case matrix

`crates/tsz-checker/tests/import_equals_alias_duplicate_container_tests.rs`, 9 rows: cross-block collision (2 and 3 aliases), same-namespace-body collision, `switch`/`try` nesting, two negative container-boundary rows (different function bodies, different namespaces), the `let`/alias ordering pair (both directions, falsifying the issue's own speculated asymmetry), and the already-correct top-level position-valid form pinned as a must-not-move row.

## Goal
Goal: hold

## Verification

**Negative control** — reverted only `import_alias_duplicates.rs` to its parent revision, keeping the new tests: **4 of 9 fail** (exactly the four rows this fix targets — cross-block ×2, three-alias, switch/try), the other 5 (container-boundary negatives, let/alias ordering, top-level control) pass unchanged in both states.

| gate | result |
| --- | --- |
| `cargo test -p tsz-checker --test import_equals_alias_duplicate_container_tests` (new suite) | 9/9 passed |
| `cargo test -p tsz-checker --test position_invalid_import_equals_container_scope_tests` (#16428's suite, same code path) | 18/18 passed, no regressions |
| `cargo test -p tsz-checker --test import_namespace_ts1147_tests --test ts2303_tests --test ts2307_per_site_dedup_tests --test order_independent_alias_resolution_tests --test commonjs_module_export_alias_tests` | 1 pre-existing failure (`test_module_exports_forward_read_reports_ts2565`), confirmed via `git stash` to fail identically on parent `d8936fc` — unrelated to this diff |
| `cargo clippy -p tsz-checker --all-targets -- -D warnings` | clean, exit 0 |
| `cargo fmt --all` | clean, no diff |
| pre-commit hook (clippy + arch guard + affected tests) | passed |
| `cargo test -p tsz-checker --lib` (full crate) | started before push; long-tail test still running at push time, will report before queuing merge |

Test-only + one checker file diff (`crates/tsz-checker/src/declarations/import/import_alias_duplicates.rs`); this touches a `crates/**/src` production path so a corpus check is owed, not exempt — the trigger condition (two `import =` statements sharing a name across two *different* blocks, at least one position-invalid) is narrow enough that I'll report a bounded corpus sweep or `compare-to-parent.sh` result on this PR before queuing.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_01SSBjvZSWKBEK2JYHB6pBDa)_