### PR TITLE
fix(checker): duplicate `import =` aliases in a function body or static block report TS2300

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2648,3 +2648,7 @@ path = "tests/position_invalid_import_equals_container_scope_tests.rs"
 [[test]]
 name = "import_equals_alias_duplicate_container_tests"
 path = "tests/import_equals_alias_duplicate_container_tests.rs"
+
+[[test]]
+name = "import_equals_alias_duplicate_function_container_tests"
+path = "tests/import_equals_alias_duplicate_function_container_tests.rs"

--- a/crates/tsz-checker/src/declarations/import/import_alias_duplicates.rs
+++ b/crates/tsz-checker/src/declarations/import/import_alias_duplicates.rs
@@ -4,6 +4,53 @@ use crate::state::CheckerState;
 use std::collections::HashMap;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 
+/// Whether `kind` starts a new declaration container for an `import X = ...`
+/// alias.
+///
+/// `tsc`'s binder advances its `container` cursor at the source file, a module
+/// (namespace) body, a class body, and every function-like node — never at a
+/// plain `Block` or other block-scope-only construct, because an alias is not
+/// block-scoped. Grouping duplicate aliases therefore has to key on these
+/// nodes, and the set is exactly the complement of the transparent statements
+/// [`CheckerState::collect_import_equals_transparently`] walks through.
+const fn is_alias_declaration_container(kind: u16) -> bool {
+    matches!(
+        kind,
+        syntax_kind_ext::SOURCE_FILE
+            | syntax_kind_ext::MODULE_DECLARATION
+            | syntax_kind_ext::MODULE_BLOCK
+            | syntax_kind_ext::CLASS_DECLARATION
+            | syntax_kind_ext::CLASS_EXPRESSION
+            | syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION
+            | syntax_kind_ext::FUNCTION_DECLARATION
+            | syntax_kind_ext::FUNCTION_EXPRESSION
+            | syntax_kind_ext::ARROW_FUNCTION
+            | syntax_kind_ext::METHOD_DECLARATION
+            | syntax_kind_ext::CONSTRUCTOR
+            | syntax_kind_ext::GET_ACCESSOR
+            | syntax_kind_ext::SET_ACCESSOR
+    )
+}
+
+/// Whether a container of `kind` already has its own
+/// [`CheckerState::check_import_alias_duplicates`] call site.
+///
+/// The source file and namespace bodies are scanned directly from
+/// `check_source_file` / the module-declaration bridge; re-grouping them in the
+/// nested-container sweep would report every duplicate twice. A class body is
+/// listed here too — an `import X = ...` cannot be a direct class member, so an
+/// alias whose nearest container is the class itself does not exist.
+const fn container_has_dedicated_scan(kind: u16) -> bool {
+    matches!(
+        kind,
+        syntax_kind_ext::SOURCE_FILE
+            | syntax_kind_ext::MODULE_DECLARATION
+            | syntax_kind_ext::MODULE_BLOCK
+            | syntax_kind_ext::CLASS_DECLARATION
+            | syntax_kind_ext::CLASS_EXPRESSION
+    )
+}
+
 impl<'a> CheckerState<'a> {
     /// Collect every `import X = ...` declaration reachable from `stmt_idx`
     /// without crossing a declaration-container boundary.
@@ -137,44 +184,153 @@ impl<'a> CheckerState<'a> {
         }
 
         for (alias_name, indices) in alias_map {
-            if indices.len() <= 1 {
+            self.report_duplicate_alias_group(&alias_name, &indices);
+        }
+    }
+
+    /// Report TS2300 (or the wrong-meaning diagnostic) at every alias in one
+    /// same-name group. A group of one is not a duplicate and reports nothing.
+    fn report_duplicate_alias_group(&mut self, alias_name: &str, indices: &[NodeIndex]) {
+        if indices.len() <= 1 {
+            return;
+        }
+
+        for &import_idx in indices {
+            let Some(import_node) = self.ctx.arena.get(import_idx) else {
+                continue;
+            };
+            let Some(import_decl) = self.ctx.arena.get_import_decl(import_node) else {
+                continue;
+            };
+
+            let alias_node = import_decl.import_clause;
+            let Some(sym_id) = self.resolve_identifier_symbol(alias_node) else {
+                tracing::trace!("Could not resolve identifier symbol");
+                continue;
+            };
+            let symbol = self
+                .ctx
+                .binder
+                .symbols
+                .get(sym_id)
+                .expect("sym_id resolved from resolve_identifier_symbol");
+            tracing::trace!("Symbol flags: {:?}", symbol.flags);
+            if self.symbol_is_value_only(sym_id, Some(alias_name)) {
+                self.report_wrong_meaning_diagnostic(
+                    alias_name,
+                    import_decl.import_clause,
+                    crate::query_boundaries::name_resolution::NameLookupKind::Value,
+                );
+            } else {
+                self.error_at_node(
+                    import_decl.import_clause,
+                    &format!("Duplicate identifier '{alias_name}'."),
+                    crate::diagnostics::diagnostic_codes::DUPLICATE_IDENTIFIER,
+                );
+            }
+        }
+    }
+
+    /// The nearest enclosing declaration container of `idx`, or `None` when the
+    /// parent chain is incomplete.
+    fn nearest_alias_container(&self, idx: NodeIndex) -> Option<NodeIndex> {
+        let mut cursor = self.ctx.arena.parent_of(idx)?;
+        while cursor.is_some() {
+            let kind = self.ctx.arena.get(cursor)?.kind;
+            if is_alias_declaration_container(kind) {
+                return Some(cursor);
+            }
+            cursor = self.ctx.arena.parent_of(cursor)?;
+        }
+        None
+    }
+
+    /// TS2300 for duplicate `import X = ...` aliases inside a function-like
+    /// body or a class static block.
+    ///
+    /// [`Self::check_import_alias_duplicates`] is only ever invoked with a
+    /// source file's or a namespace body's statement list, and its transparent
+    /// walk deliberately stops at a function body — so two same-name aliases
+    /// directly inside `function f() { ... }`, a method, a constructor, an
+    /// accessor, an arrow/function expression body, or a `static { ... }` block
+    /// were never grouped by anything and reported only TS1232. `tsc` reports
+    /// TS1232 *and* TS2300 at each of them, because its binder records a
+    /// non-block-scoped alias in the enclosing container and the redeclaration
+    /// collides there.
+    ///
+    /// This sweep closes that gap for every such container at once by grouping
+    /// each alias under [`Self::nearest_alias_container`] instead of relying on
+    /// a call site per container kind — arrow and function-expression bodies
+    /// hang off expressions, so no statement-list-driven pass reaches them.
+    /// Containers that already have a dedicated scan are skipped, so nothing is
+    /// reported twice.
+    pub(crate) fn check_import_alias_duplicates_in_nested_containers(&mut self) {
+        // Aliases are rare and the pools are per-file; skip the sweep entirely
+        // when the file parsed no import-like declaration at all.
+        if self.ctx.arena.import_decls.is_empty() {
+            return;
+        }
+
+        // One sequential pass over the thin node headers. Aliases are rare, so
+        // the parent walk and the grouping below only run for the few hits;
+        // everything else costs a single `u16` compare over contiguous memory.
+        let alias_nodes: Vec<NodeIndex> = self
+            .ctx
+            .arena
+            .nodes
+            .iter()
+            .enumerate()
+            .filter(|(_, node)| node.kind == syntax_kind_ext::IMPORT_EQUALS_DECLARATION)
+            .map(|(raw, _)| NodeIndex(raw as u32))
+            .collect();
+        if alias_nodes.is_empty() {
+            return;
+        }
+
+        let mut groups: HashMap<(NodeIndex, String), Vec<NodeIndex>> = HashMap::new();
+        // Grouping keys are recorded in arena order so the diagnostics this
+        // sweep emits do not depend on `HashMap` iteration order.
+        let mut group_order: Vec<(NodeIndex, String)> = Vec::new();
+
+        for idx in alias_nodes {
+            let Some(node) = self.ctx.arena.get(idx) else {
+                continue;
+            };
+            let Some(container) = self.nearest_alias_container(idx) else {
+                continue;
+            };
+            let Some(container_kind) = self.ctx.arena.get(container).map(|n| n.kind) else {
+                continue;
+            };
+            if container_has_dedicated_scan(container_kind) {
                 continue;
             }
 
-            for &import_idx in &indices {
-                let Some(import_node) = self.ctx.arena.get(import_idx) else {
-                    continue;
-                };
-                let Some(import_decl) = self.ctx.arena.get_import_decl(import_node) else {
-                    continue;
-                };
+            let Some(import_decl) = self.ctx.arena.get_import_decl(node) else {
+                continue;
+            };
+            let Some(alias_node) = self.ctx.arena.get(import_decl.import_clause) else {
+                continue;
+            };
+            let Some(alias_id) = self.ctx.arena.get_identifier(alias_node) else {
+                continue;
+            };
 
-                let alias_node = import_decl.import_clause;
-                let Some(sym_id) = self.resolve_identifier_symbol(alias_node) else {
-                    tracing::trace!("Could not resolve identifier symbol");
-                    continue;
-                };
-                let symbol = self
-                    .ctx
-                    .binder
-                    .symbols
-                    .get(sym_id)
-                    .expect("sym_id resolved from resolve_identifier_symbol");
-                tracing::trace!("Symbol flags: {:?}", symbol.flags);
-                if self.symbol_is_value_only(sym_id, Some(&alias_name)) {
-                    self.report_wrong_meaning_diagnostic(
-                        &alias_name,
-                        import_decl.import_clause,
-                        crate::query_boundaries::name_resolution::NameLookupKind::Value,
-                    );
-                } else {
-                    self.error_at_node(
-                        import_decl.import_clause,
-                        &format!("Duplicate identifier '{alias_name}'."),
-                        crate::diagnostics::diagnostic_codes::DUPLICATE_IDENTIFIER,
-                    );
-                }
-            }
+            let key = (container, alias_id.escaped_text.to_string());
+            groups
+                .entry(key.clone())
+                .or_insert_with(|| {
+                    group_order.push(key.clone());
+                    Vec::new()
+                })
+                .push(idx);
+        }
+
+        for key in group_order {
+            let Some(indices) = groups.remove(&key) else {
+                continue;
+            };
+            self.report_duplicate_alias_group(&key.1, &indices);
         }
     }
 

--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -567,6 +567,11 @@ impl CheckerState<'_> {
         // TS7: JS `module.exports = X` mixed with sibling property exports (2309)
         self.check_js_commonjs_export_assignment_conflict();
         self.check_import_alias_duplicates(&sf.statements.nodes);
+        // Function-like bodies and class static blocks are declaration
+        // containers with no statement-list call site of their own; sweep them
+        // from here so `function f() { import a = ...; import a = ...; }` gets
+        // its TS2300 alongside the two TS1232s.
+        self.check_import_alias_duplicates_in_nested_containers();
         self.check_import_declaration_duplicate_bindings(&sf.statements.nodes);
 
         // TS4094: exported `export default <call-returning-anonymous-class>` patterns.

--- a/crates/tsz-checker/tests/import_equals_alias_duplicate_function_container_tests.rs
+++ b/crates/tsz-checker/tests/import_equals_alias_duplicate_function_container_tests.rs
@@ -1,0 +1,274 @@
+//! Two `import x = ...` aliases sharing a name inside one function-like body
+//! or class static block report TS2300 at each of them.
+//!
+//! `tsc`'s binder keeps two cursors while binding: `container` and
+//! `blockScopeContainer`. An alias is not block-scoped, so a position-invalid
+//! `import x = ...` is recorded in the enclosing *container* — and a function
+//! body, method body, constructor body, accessor body, function-expression
+//! body, arrow body and `static { }` block are all containers. A second alias
+//! of the same name in that container is a redeclaration, so `declareSymbol`
+//! reports TS2300 for both, alongside the TS1232 each one already earns for
+//! being position-invalid.
+//!
+//! #16429/#16435 taught `check_import_alias_duplicates` to recurse *through*
+//! transparent block-like statements, but the scan is still only ever invoked
+//! with a source file's or a namespace body's statement list — it has no call
+//! site at a function body or static block at all. So two aliases directly
+//! inside `function f() { ... }` were grouped by nothing and reported TS1232
+//! alone. `check_import_alias_duplicates_in_nested_containers` closes that by
+//! grouping each alias under its nearest declaration container rather than
+//! adding a call site per container kind: arrow and function-expression bodies
+//! hang off *expressions*, so no statement-list-driven pass reaches them.
+//!
+//! All expectations were measured against `typescript@7.0.2` with
+//! `--noEmit --strict --pretty false --target es2015 --module commonjs`,
+//! matching the harness options below.
+//!
+//! ## Deliberately not asserted here
+//!
+//! TS2307 counts. Inside a function body `tsc` resolves no module specifier at
+//! all for these aliases, and `tsz` keeps a distinct symbol per colliding alias
+//! declaration (the #16410 item 2 / #16411 alias-merge residual, which predates
+//! this fix). These rows assert the TS2300 and TS1232 counts, which is exactly
+//! the behaviour this fix owns.
+
+use tsz_binder::BinderState;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::state::CheckerState;
+use tsz_parser::parser::ParserState;
+use tsz_solver::construction::TypeInterner;
+
+fn check(source: &str) -> Vec<u32> {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        CheckerOptions {
+            module: tsz_common::common::ModuleKind::CommonJS,
+            target: tsz_common::common::ScriptTarget::ES2015,
+            ..CheckerOptions::default()
+        },
+    );
+    checker.ctx.report_unresolved_imports = true;
+    checker.check_source_file(root);
+    let mut codes: Vec<u32> = checker.ctx.diagnostics.iter().map(|d| d.code).collect();
+    codes.sort_unstable();
+    codes
+}
+
+fn count(codes: &[u32], code: u32) -> usize {
+    codes.iter().filter(|&&c| c == code).count()
+}
+
+/// Assert the oracle-pinned TS2300 and TS1232 counts for one row.
+fn assert_counts(source: &str, duplicates: usize, position_invalid: usize, what: &str) {
+    let codes = check(source);
+    assert_eq!(
+        count(&codes, 2300),
+        duplicates,
+        "{what}: expected {duplicates} TS2300, got {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, 1232),
+        position_invalid,
+        "{what}: expected {position_invalid} TS1232, got {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Positive: every function-like container, plus the class static block.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn function_declaration_body_aliases_collide() {
+    assert_counts(
+        r#"function f() { import x = require("nonexistent-a"); import x = require("nonexistent-b"); }
+"#,
+        2,
+        2,
+        "function declaration body",
+    );
+}
+
+#[test]
+fn arrow_function_body_aliases_collide() {
+    assert_counts(
+        r#"const g = () => { import x = require("nonexistent-a"); import x = require("nonexistent-b"); };
+"#,
+        2,
+        2,
+        "arrow function body",
+    );
+}
+
+#[test]
+fn function_expression_body_aliases_collide() {
+    assert_counts(
+        r#"const h = function () { import x = require("nonexistent-a"); import x = require("nonexistent-b"); };
+"#,
+        2,
+        2,
+        "function expression body",
+    );
+}
+
+#[test]
+fn method_body_aliases_collide() {
+    assert_counts(
+        r#"class K { m() { import x = require("nonexistent-a"); import x = require("nonexistent-b"); } }
+"#,
+        2,
+        2,
+        "method body",
+    );
+}
+
+#[test]
+fn constructor_body_aliases_collide() {
+    assert_counts(
+        r#"class K { constructor() { import x = require("nonexistent-a"); import x = require("nonexistent-b"); } }
+"#,
+        2,
+        2,
+        "constructor body",
+    );
+}
+
+#[test]
+fn accessor_body_aliases_collide() {
+    assert_counts(
+        r#"class K { get p(): number { import x = require("nonexistent-a"); import x = require("nonexistent-b"); return 1; } }
+"#,
+        2,
+        2,
+        "get accessor body",
+    );
+}
+
+#[test]
+fn static_block_aliases_collide() {
+    assert_counts(
+        r#"class K { static { import x = require("nonexistent-a"); import x = require("nonexistent-b"); } }
+"#,
+        2,
+        2,
+        "class static block",
+    );
+}
+
+/// The transparent-block recursion #16435 added has to keep working *inside* a
+/// function body: the two aliases sit in sibling blocks of one container.
+#[test]
+fn sibling_blocks_inside_a_function_body_collide() {
+    assert_counts(
+        r#"function f() { { import x = require("nonexistent-a"); } { import x = require("nonexistent-b"); } }
+"#,
+        2,
+        2,
+        "sibling blocks inside a function body",
+    );
+}
+
+#[test]
+fn three_aliases_in_a_function_body_all_flagged() {
+    assert_counts(
+        r#"function f() { import x = require("nonexistent-a"); import x = require("nonexistent-b"); import x = require("nonexistent-c"); }
+"#,
+        3,
+        3,
+        "three colliding aliases in one function body",
+    );
+}
+
+/// A function body nested in a namespace is still its own container — the
+/// namespace-body scan must not be what reports this, and must not double it.
+#[test]
+fn function_body_inside_a_namespace_collides_once_each() {
+    assert_counts(
+        r#"namespace M { function f() { import x = require("nonexistent-a"); import x = require("nonexistent-b"); } }
+"#,
+        2,
+        2,
+        "function body inside a namespace",
+    );
+}
+
+/// Binder names must not drive the decision.
+#[test]
+fn renamed_binders_collide_the_same_way() {
+    assert_counts(
+        r#"function outer() { import zeta = require("nonexistent-a"); import zeta = require("nonexistent-b"); }
+"#,
+        2,
+        2,
+        "renamed colliding binders",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative: container boundaries must still separate.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sibling_functions_do_not_collide() {
+    assert_counts(
+        r#"function f1() { import x = require("nonexistent-a"); }
+function f2() { import x = require("nonexistent-b"); }
+"#,
+        0,
+        2,
+        "same name in two sibling function bodies",
+    );
+}
+
+#[test]
+fn a_function_body_does_not_collide_with_the_file_top_level() {
+    assert_counts(
+        r#"import x = require("nonexistent-a");
+function f() { import x = require("nonexistent-b"); }
+"#,
+        0,
+        1,
+        "function-body alias shadowing a top-level alias",
+    );
+}
+
+#[test]
+fn a_nested_function_body_does_not_collide_with_its_enclosing_function() {
+    assert_counts(
+        r#"function outer() { import x = require("nonexistent-a"); function inner() { import x = require("nonexistent-b"); } }
+"#,
+        0,
+        2,
+        "inner function body shadowing its enclosing function body",
+    );
+}
+
+#[test]
+fn differently_named_aliases_in_one_function_body_do_not_collide() {
+    assert_counts(
+        r#"function f() { import alpha = require("nonexistent-a"); import beta = require("nonexistent-b"); }
+"#,
+        0,
+        2,
+        "two differently named aliases in one function body",
+    );
+}
+
+#[test]
+fn a_single_alias_in_a_function_body_does_not_collide() {
+    assert_counts(
+        r#"function f() { import x = require("nonexistent-a"); }
+"#,
+        0,
+        1,
+        "a lone position-invalid alias in a function body",
+    );
+}


### PR DESCRIPTION
**Structural rule.** When two `import X = ...` aliases share a name inside one declaration container, `tsc` reports TS2300 at each of them — and a function body, method body, constructor body, accessor body, function-expression body, arrow body and class `static { }` block are all declaration containers, not transparent blocks. `tsz` now does the same through the **checker** (`crates/tsz-checker/src/declarations/import/import_alias_duplicates.rs`), the same owner layer #16429/#16435 landed in.

Reported and deliberately left unfixed in #16435's own closing notes:

> Two same-name aliases DIRECTLY in the same function body (or class static block) still report NO TS2300 — `check_import_alias_duplicates` has zero call sites at function-body/static-block level, only source-file top level and namespace bodies.

**Mechanism.** `tsc`'s binder keeps a `container` cursor and a `blockScopeContainer` cursor. An alias is not block-scoped, so a position-invalid `import x = ...` is recorded in the enclosing *container*; a second alias of the same name there is a redeclaration and `declareSymbol` reports TS2300 for both, alongside the TS1232 each already earns for being position-invalid.

`check_import_alias_duplicates` is only ever invoked with a source file's or a namespace body's statement list, and #16435's transparent-block recursion deliberately *stops* at a function body (correctly — it is a real container boundary). The two halves left a hole in the middle: aliases inside a function body were grouped by nothing at all, so `function f() { import x = ...; import x = ...; }` reported the two TS1232s and neither TS2300.

**Why one sweep rather than a call site per container kind.** Arrow bodies and function-expression bodies hang off *expressions* (`const g = () => { ... }`), so no statement-list-driven pass reaches them — a per-kind call site would have needed plumbing into six checker paths and still missed those two. Instead `check_import_alias_duplicates_in_nested_containers` groups each alias under its nearest declaration container (`nearest_alias_container`, a `parent_of` walk mirroring `nearest_declaration_container_scope`), which covers every container kind uniformly. Containers that already have a dedicated scan — source file, namespace body, class body — are skipped, so nothing is reported twice; #16435's and #16428's suites confirm that (below).

The reporting tail of the existing scan is extracted to `report_duplicate_alias_group` and shared by both paths, so the wrong-meaning/TS2300 split stays in one place.

**Cost.** One sequential pass over the thin node headers per source file, gated on the per-file `import_decls` pool being non-empty (an `IMPORT_EQUALS_DECLARATION`'s data lives in that pool, so an empty pool provably means no aliases). The `parent_of` walk and the grouping run only for the few alias hits; every other node costs one `u16` compare over contiguous memory. Grouping keys are recorded in arena order so emission does not depend on `HashMap` iteration order.

**Anti-hardcoding.** No identifier, alias, property or file-name literal drives any decision; the container set is `SyntaxKind` constants only. `renamed_binders_collide_the_same_way` varies the binder name (`zeta`) against the `x` used elsewhere.

## Goal
Goal: hold

## Verification

All 16 rows were measured against `typescript@7.0.2` (the pin in `scripts/conformance/typescript-versions.json`) with `--noEmit --strict --pretty false --target es2015 --module commonjs` **before** any code was written — I re-oracled every row rather than taking #16435's note at face value. Every row reproduced.

| container | tsc 7.0.2 | tsz before | tsz after |
| --- | --- | --- | --- |
| function declaration body | TS1232 ×2 + **TS2300 ×2** | TS1232 ×2 | ✅ match |
| arrow function body | TS1232 ×2 + **TS2300 ×2** | TS1232 ×2 | ✅ match |
| function expression body | TS1232 ×2 + **TS2300 ×2** | TS1232 ×2 | ✅ match |
| method body | TS1232 ×2 + **TS2300 ×2** | TS1232 ×2 | ✅ match |
| constructor body | TS1232 ×2 + **TS2300 ×2** | TS1232 ×2 | ✅ match |
| get accessor body | TS1232 ×2 + **TS2300 ×2** | TS1232 ×2 | ✅ match |
| class `static { }` block | TS1232 ×2 + **TS2300 ×2** | TS1232 ×2 | ✅ match |
| sibling blocks inside a function body | TS1232 ×2 + **TS2300 ×2** | TS1232 ×2 | ✅ match |
| three aliases in one function body | TS1232 ×3 + **TS2300 ×3** | TS1232 ×3 | ✅ match |
| function body inside a namespace | TS1232 ×2 + **TS2300 ×2** | TS1232 ×2 | ✅ match |
| renamed binders (`zeta`) | TS1232 ×2 + **TS2300 ×2** | TS1232 ×2 | ✅ match |
| *neg:* two sibling function bodies | TS1232 ×2, no TS2300 | same | ✅ unchanged |
| *neg:* function body vs file top level | TS1232 ×1, no TS2300 | same | ✅ unchanged |
| *neg:* inner function vs enclosing function | TS1232 ×2, no TS2300 | same | ✅ unchanged |
| *neg:* two differently named aliases | TS1232 ×2, no TS2300 | same | ✅ unchanged |
| *neg:* one lone alias | TS1232 ×1, no TS2300 | same | ✅ unchanged |

Commands actually run:

- `cargo test -p tsz-checker --test import_equals_alias_duplicate_function_container_tests` — **16 passed, 0 failed** (new suite).
- **Negative control**: with only `state_checking/source_file.rs` reverted (`git stash push`) and the tests kept — **11 failed, 5 passed**. Exactly the 11 positive rows fail; all 5 container-boundary negatives pass unchanged in both states, so they are not being carried by the fix.
- `cargo test -p tsz-checker --test import_equals_alias_duplicate_container_tests` — **9/9** (#16435's suite: no double-reporting at the source-file/namespace call sites).
- `cargo test -p tsz-checker --test position_invalid_import_equals_container_scope_tests` — **18/18** (#16428's suite, same code path).
- `cargo test -p tsz-checker --lib` — **9610 passed, 0 failed** before the run stalled on `ts2589_tests::recursive_conditional_alias_omitted_default_transform_emits_definition_ts2589`. That is the long-tail `cargo test` hang this board has documented repeatedly (thread-stack, not code; `nextest` clears it in <1s but `cargo-nextest` is absent in these cloud containers). Same test, same point as #16435's own run. Not caused by this diff.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean, exit 0.
- `cargo fmt --all` — clean.
- `python3 scripts/arch/arch_guard.py` — `Architecture guardrails passed.` Modified file is 431 lines, well under the 2000-line cap.
- `python3 scripts/ci/check-test-file-reachability.py` — `0 known orphan(s), 0 new.`
- Pre-commit hook (clippy + affected-crate verification + architecture guard) passed on commit.

**compare-to-parent: owed, and disclosed rather than claimed.** `conformance.sh`/`compare-to-parent.sh` build `dist-fast` twice and were measured at 55–90+ min on cold cloud seats on 2026-08-04/05 (Azurite, ClaudeDE, ClaudeT independently) — it does not fit in the remaining session budget, and ClaudeT's 07:24Z note records that backgrounding it with `nohup` does not survive between tool calls in this container. Blast-radius argument for landing without it: the new sweep can only *add* TS2300, only at an `import X = ...` whose nearest container is function-like or a static block, i.e. only at a construct that is already a TS1232 hard error in every one of those positions. Conformance rows in that state are already failing on the TS1232; a corpus row cannot flip from passing to failing on a diagnostic that only appears next to an error the row must already expect. The three existing suites over this exact code path (43 tests total) are green.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Vanadinite

---
_Generated by [Claude Code](https://claude.ai/code/session_016CM3KArYKcFJwRvQRdgbfb)_