### PR TITLE
fix(checker): class-implements instantiates a cross-file generic heritage target

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -152,6 +152,9 @@ path = "tests/cross_file_delegation_lookup_consolidation_tests.rs"
 name = "cross_file_generic_alias_call_inference_tests"
 path = "tests/cross_file_generic_alias_call_inference_tests.rs"
 [[test]]
+name = "cross_file_generic_class_implements_tests"
+path = "tests/cross_file_generic_class_implements_tests.rs"
+[[test]]
 name = "cross_file_generic_interface_mapped_filter_tests"
 path = "tests/cross_file_generic_interface_mapped_filter_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/classes/class_implements_checker/core.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/core.rs
@@ -1205,19 +1205,37 @@ impl<'a> CheckerState<'a> {
                     let (mut interface_type_params, interface_type_param_updates) =
                         self.push_type_parameters(&interface_type_params);
 
-                    // Fallback: when the interface declaration's AST lives in a different
-                    // arena (e.g. lib types like `AsyncIterator<T, TReturn, TNext>`), the
-                    // local arena walk above leaves `interface_type_params` empty. Look up
-                    // the canonical type parameters via the solver-side definition store
-                    // so the substitution we build below correctly maps interface type
-                    // parameters to the supplied type arguments.
-                    if interface_type_params.is_empty()
-                        && let Some(def_id) = self.ctx.definition_store.find_def_by_symbol(sym_id.0)
-                        && let Some(store_params) =
-                            self.ctx.definition_store.get_type_params(def_id)
-                        && !store_params.is_empty()
-                    {
-                        interface_type_params = store_params;
+                    // Fallback: when the interface/class declaration's AST lives in a
+                    // different arena (a lib type like `AsyncIterator<T, TReturn, TNext>`,
+                    // or any interface/class declared in another *user* file), the local
+                    // arena walk above leaves `interface_type_params` empty because it
+                    // always reads `self.ctx.arena` (the CURRENT file), never a foreign
+                    // heritage declaration's own arena.
+                    //
+                    // Previously this fell back to `definition_store.find_def_by_symbol`,
+                    // a raw-`SymbolId`-keyed lookup that only succeeds if some earlier,
+                    // unrelated reference to the same name had already warmed the
+                    // definition store's cache for this exact `SymbolId` — and, since
+                    // `DefinitionInfo::type_params` defaults to empty on first
+                    // registration, a `Plain<number>` type annotation resolved anywhere
+                    // else in the file (e.g. a sibling function signature) could win that
+                    // race and permanently pin an empty entry before the implements-clause
+                    // check ever ran, independent of source order. Re-derive the declared
+                    // type parameters instead through the same reference-aware,
+                    // arena-correct path heritage `extends` clauses already use for TS2314
+                    // arity (`get_reference_type_params_for_symbol` /
+                    // `extract_declared_type_params_for_reference_symbol`), keyed off the
+                    // heritage clause's own written name so a renamed re-export still
+                    // resolves. Without this, the substitution built below degenerates to
+                    // the identity for a cross-file generic heritage target and every
+                    // member compares against its own unsubstituted type parameter instead
+                    // of the supplied type argument (#16434).
+                    if interface_type_params.is_empty() {
+                        let resolved =
+                            self.get_reference_type_params_for_symbol(raw_sym_id, &interface_name);
+                        if !resolved.is_empty() {
+                            interface_type_params = resolved;
+                        }
                     }
 
                     // Fill in missing type arguments with defaults/constraints/unknown

--- a/crates/tsz-checker/tests/cross_file_generic_class_implements_tests.rs
+++ b/crates/tsz-checker/tests/cross_file_generic_class_implements_tests.rs
@@ -1,0 +1,301 @@
+//! `class C implements Generic<Arg>` across a file boundary (#16434).
+//!
+//! Structural rule: when a class implements a generic interface, `tsc`
+//! instantiates the interface with the written type arguments before
+//! comparing members. tsz does this through the class-implements checker
+//! (`crates/tsz-checker/src/classes/class_implements_checker/core.rs`) — but
+//! only reliably when the interface is declared in the same file as the
+//! class. When the heritage target is declared in another file, the
+//! type-parameter-collecting AST walk indexes the CURRENT file's arena, so it
+//! finds nothing for a foreign declaration; `interface_type_params` stays
+//! empty, the substitution built from it degenerates to the identity, and
+//! every interface member is compared against its own unsubstituted type
+//! parameter (`() => T` vs `() => number`) instead of the instantiated type.
+//!
+//! The fix forces `delegate_cross_arena_interface_type` to resolve the
+//! foreign interface's own type before the definition-store fallback reads
+//! it, since that resolution registers the interface's type parameters into
+//! the store as a side effect. Previously that resolution only happened
+//! later (while building `raw_interface_type`), after the fallback had
+//! already run and found nothing.
+//!
+//! The matrix varies: generic vs. non-generic, same-file vs. cross-file,
+//! `import` vs. `import type`, renamed binders, multiple type parameters, and
+//! a genuine mismatch that must still be reported (proving the fix
+//! instantiates correctly rather than suppressing checking).
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_multi_file_with_global_index;
+use tsz_common::common::ModuleKind;
+use tsz_common::diagnostics::Diagnostic;
+
+fn opts() -> CheckerOptions {
+    CheckerOptions {
+        module: ModuleKind::CommonJS,
+        strict: true,
+        ..CheckerOptions::default()
+    }
+}
+
+fn check(files: &[(&str, &str)], entry: &str) -> Vec<Diagnostic> {
+    check_multi_file_with_global_index(files, entry, opts())
+}
+
+fn codes(diags: &[Diagnostic]) -> Vec<u32> {
+    diags.iter().map(|d| d.code).collect()
+}
+
+fn assert_clean(diags: &[Diagnostic], label: &str) {
+    let cs = codes(diags);
+    assert!(
+        !cs.contains(&2416) && !cs.contains(&2345) && !cs.contains(&2420),
+        "[{label}] expected no TS2416/TS2345/TS2420 for a correctly-implemented cross-file \
+         generic interface, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+// ── Positive: the reported bug, and its adjacent shapes ─────────────────────
+
+#[test]
+fn cross_file_generic_interface_single_type_param() {
+    let types_ts = r#"
+        export interface Plain<T> { plain(): T }
+    "#;
+    let actor_ts = r#"
+        import { Plain } from "./types";
+        export class Actor implements Plain<number> {
+            public plain(): number { return 1 }
+        }
+        declare function want(r: Plain<number>): void;
+        declare const a: Actor;
+        want(a);
+    "#;
+    let diags = check(
+        &[("actor.ts", actor_ts), ("types.ts", types_ts)],
+        "actor.ts",
+    );
+    assert_clean(&diags, "single-type-param");
+}
+
+#[test]
+fn cross_file_generic_interface_import_type() {
+    let types_ts = r#"
+        export interface Plain<T> { plain(): T }
+    "#;
+    let actor_ts = r#"
+        import type { Plain } from "./types";
+        export class Actor implements Plain<number> {
+            public plain(): number { return 1 }
+        }
+    "#;
+    let diags = check(
+        &[("actor.ts", actor_ts), ("types.ts", types_ts)],
+        "actor.ts",
+    );
+    assert_clean(&diags, "import-type");
+}
+
+#[test]
+fn cross_file_generic_interface_renamed_binders() {
+    // Vary every identifier and file name so the fix is not tied to the
+    // literal names in the reported repro (anti-hardcoding: nothing in the
+    // resolution path reads a user-chosen name).
+    let contract_ts = r#"
+        export interface Codec<Payload> { encode(): Payload }
+    "#;
+    let worker_ts = r#"
+        import { Codec } from "./contract";
+        export class JsonWorker implements Codec<string> {
+            public encode(): string { return "{}" }
+        }
+        declare function accepts(c: Codec<string>): void;
+        declare const w: JsonWorker;
+        accepts(w);
+    "#;
+    let diags = check(
+        &[("worker.ts", worker_ts), ("contract.ts", contract_ts)],
+        "worker.ts",
+    );
+    assert_clean(&diags, "renamed-binders");
+}
+
+#[test]
+fn cross_file_generic_interface_multiple_type_params_one_used() {
+    let types_ts = r#"
+        export interface Pair<K, V> {
+            key(): K;
+            value(): V;
+        }
+    "#;
+    let main_ts = r#"
+        import { Pair } from "./types";
+        export class Entry implements Pair<string, number> {
+            public key(): string { return "k" }
+            public value(): number { return 1 }
+        }
+    "#;
+    let diags = check(&[("main.ts", main_ts), ("types.ts", types_ts)], "main.ts");
+    assert_clean(&diags, "multi-param");
+}
+
+#[test]
+fn cross_file_generic_interface_two_hop_reexport() {
+    // The interface is declared in `dep.ts`, re-exported through `hub.ts`,
+    // and implemented from `main.ts` — the heritage target's own declaration
+    // is two module hops away from the implementing class.
+    let dep_ts = r#"
+        export interface Box<T> { get(): T }
+    "#;
+    let hub_ts = r#"
+        export { Box } from "./dep";
+    "#;
+    let main_ts = r#"
+        import { Box } from "./hub";
+        export class NumberBox implements Box<number> {
+            public get(): number { return 1 }
+        }
+    "#;
+    let diags = check(
+        &[("main.ts", main_ts), ("hub.ts", hub_ts), ("dep.ts", dep_ts)],
+        "main.ts",
+    );
+    assert_clean(&diags, "two-hop-reexport");
+}
+
+#[test]
+fn cross_file_generic_class_heritage_target() {
+    // The heritage target itself is a CLASS, not an interface — a class may
+    // structurally `implements` another class in TS. The type-parameter
+    // AST walk this fix touches collects params from both CLASS_DECLARATION
+    // and INTERFACE_DECLARATION heritage nodes, so this must be fixed too.
+    let base_ts = r#"
+        export class Box<T> {
+            value!: T;
+            get(): T { return this.value }
+        }
+    "#;
+    let main_ts = r#"
+        import { Box } from "./base";
+        export class NumberBox implements Box<number> {
+            value = 0;
+            get(): number { return this.value }
+        }
+    "#;
+    let diags = check(&[("main.ts", main_ts), ("base.ts", base_ts)], "main.ts");
+    assert_clean(&diags, "class-heritage-target");
+}
+
+#[test]
+fn cross_file_generic_interface_alongside_unrelated_type_annotation() {
+    // Regression witness for the specific failure mode that surfaced while
+    // fixing #16434: a `Plain<number>` type annotation appearing ANYWHERE
+    // ELSE in the file (here, an unrelated ambient function signature) can
+    // resolve and cache the interface's own type first. A fix that only
+    // works on a cold cache passed every other case in this file and still
+    // produced a false TS2416 here, because the earlier resolution reused
+    // the same `DefId` without ever deriving its type parameters.
+    let types_ts = r#"
+        export interface Plain<T> { plain(): T }
+    "#;
+    let actor_ts = r#"
+        import { Plain } from "./types";
+        export class Actor implements Plain<number> {
+            public plain(): number { return 1 }
+        }
+        declare function unrelated(r: Plain<number>): void;
+    "#;
+    let diags = check(
+        &[("actor.ts", actor_ts), ("types.ts", types_ts)],
+        "actor.ts",
+    );
+    assert_clean(&diags, "alongside-unrelated-annotation");
+}
+
+// ── Negative controls: must not move ─────────────────────────────────────────
+
+#[test]
+fn same_file_generic_interface_stays_clean() {
+    let source = r#"
+        interface Plain<T> { plain(): T }
+        class Actor implements Plain<number> {
+            public plain(): number { return 1 }
+        }
+    "#;
+    let diags = check(&[("actor.ts", source)], "actor.ts");
+    assert_clean(&diags, "same-file");
+}
+
+#[test]
+fn cross_file_non_generic_interface_stays_clean() {
+    let types_ts = r#"
+        export interface Named { name(): string }
+    "#;
+    let main_ts = r#"
+        import { Named } from "./types";
+        export class Thing implements Named {
+            public name(): string { return "x" }
+        }
+    "#;
+    let diags = check(&[("main.ts", main_ts), ("types.ts", types_ts)], "main.ts");
+    assert_clean(&diags, "non-generic");
+}
+
+#[test]
+fn cross_file_generic_interface_real_mismatch_still_reported() {
+    // The fix must instantiate the interface correctly, not stop checking it.
+    // `plain(): string` does not satisfy `Plain<number>`'s `plain(): number`,
+    // so tsc still reports TS2420 (class does not correctly implement).
+    let types_ts = r#"
+        export interface Plain<T> { plain(): T }
+    "#;
+    let actor_ts = r#"
+        import { Plain } from "./types";
+        export class Actor implements Plain<number> {
+            public plain(): string { return "x" }
+        }
+    "#;
+    let diags = check(
+        &[("actor.ts", actor_ts), ("types.ts", types_ts)],
+        "actor.ts",
+    );
+    let cs = codes(&diags);
+    assert!(
+        cs.contains(&2420) || cs.contains(&2416),
+        "expected a real TS2420/TS2416 mismatch (plain(): string vs Plain<number>'s \
+         plain(): number) to still be reported after instantiation, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn cross_file_generic_interface_wrong_type_argument_still_reported() {
+    // `Plain<number>` implemented with a `string`-returning method is wrong
+    // regardless of cross-file resolution; must not be silently accepted.
+    let types_ts = r#"
+        export interface Container<T> { value: T }
+    "#;
+    let main_ts = r#"
+        import { Container } from "./types";
+        export class StringBox implements Container<number> {
+            public value: string = "x";
+        }
+    "#;
+    let diags = check(&[("main.ts", main_ts), ("types.ts", types_ts)], "main.ts");
+    let cs = codes(&diags);
+    assert!(
+        cs.contains(&2416) || cs.contains(&2322) || cs.contains(&2420),
+        "expected the value:string vs Container<number>'s value:number mismatch to still \
+         be reported, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
Closes #16434.

## Structural rule

When a class implements a generic interface (or class), `tsc` instantiates the heritage type with the written type arguments before comparing members. tsz does this through the class-implements checker (`crates/tsz-checker/src/classes/class_implements_checker/core.rs`) — but the type-parameter-collecting AST walk there only ever reads `self.ctx.arena` (the CURRENT file's arena), never a foreign heritage declaration's own arena. For a heritage target declared in another file, that walk finds nothing, `interface_type_params` stays empty, the substitution built from it degrades to the identity, and every member of the heritage target is compared against its own unsubstituted type parameter (`() =&gt; T`) instead of the supplied type argument (`() =&gt; number`) — a false TS2416 on every member, cascading to a false TS2345 at each call site.

## Why the previous fallback wasn't enough

The existing fallback for this case fell back to `definition_store.find_def_by_symbol(sym_id.0)`, a raw-`SymbolId`-keyed lookup. I first tried forcing `delegate_cross_arena_interface_type` to run earlier so its `insert_def_type_params` side effect would populate that store before the fallback read it — this passed the reported repro in isolation, but a probe test (`cross_file_generic_interface_alongside_unrelated_type_annotation`) still failed: an *unrelated* `Plain&lt;number&gt;` type annotation anywhere else in the same file (e.g. a sibling `declare function` signature) could resolve and cache the interface's own type first, via a path that registers a `DefId` for the symbol with its `type_params` field defaulted to empty — and once that entry exists, nothing overwrites it. The bug was order-dependent on unrelated file content, not on my call ordering within the implements checker.

## The actual fix

Re-derive the declared type parameters through the same reference-aware, arena-correct path heritage `extends` clauses already use for TS2314 arity checking (`get_reference_type_params_for_symbol` / `extract_declared_type_params_for_reference_symbol`, `crates/tsz-checker/src/state/type_resolution/reference_type_params.rs` and `reference_helpers.rs`), keyed off the heritage clause's own written name (`heritage_name_text`) so a renamed re-export still resolves. This reads the correct declaration's AST type-parameter list directly and is immune to the caching-order issue above, since it doesn't depend on any prior resolution having warmed a shared cache.

Owner layer: checker only (`class_implements_checker/core.rs`). No parser/solver/emitter change; `get_reference_type_params_for_symbol` is an existing, already-tested checker query used elsewhere for the identical problem on `extends` clauses.

## Adjacent-case matrix

All cases oracle-shaped against the discriminator table in #16434 and additionally covered here:

| case | before | after |
| --- | --- | --- |
| cross-file generic interface, single type param | false TS2416 | clean |
| `import type` variant | false TS2416 | clean |
| renamed binders (`Codec&lt;Payload&gt;`/`JsonWorker`, different file names) | false TS2416 | clean |
| multiple type params, one used | false TS2416 | clean |
| two-hop re-export chain (`dep.ts` → `hub.ts` → `main.ts`) | false TS2416 | clean |
| cross-file generic **class** heritage target (`implements`) | already clean on parent | clean (unaffected, confirmed) |
| unrelated `Plain&lt;number&gt;` type annotation elsewhere in the same file | false TS2416 (survived my first fix attempt) | clean |
| same-file generic interface (must not move) | clean | clean |
| cross-file non-generic interface (must not move) | clean | clean |
| real mismatch (`plain(): string` vs `Plain&lt;number&gt;`'s `plain(): number`) | TS2420/TS2416 reported | still reported — the fix instantiates correctly, it does not stop checking |
| wrong type argument on a property (`value: string` vs `Container&lt;number&gt;`) | reported | still reported |

`grow`-style anti-hardcoding: the renamed-binders and two-hop-reexport cases vary every identifier and file name; nothing in the resolution path reads a user-chosen name — it resolves through the module graph and the heritage clause's written text, matching the pattern already established for `extends`.

## Goal
Goal: green

## Verification

| gate | result |
| --- | --- |
| `cargo test -p tsz-checker --test cross_file_generic_class_implements_tests` (new suite, 11 cases) | 11/11 passed |
| Negative control (checker fix reverted via `git stash`, tests kept) | 6/11 fail for the right reason (false TS2416 reappears); the other 5 (same-file, non-generic, both "must still report a real mismatch" cases, and the class-heritage case, which was already clean on the parent) pass unchanged in both states |
| `cargo test -p tsz-checker --lib` (full crate) | 9604 passed, 0 failed, 0 newly ignored; 3 tests still running at the 900s harness timeout are the board-documented pre-existing long-tail hang (`ts2589_tests` conditional-type family + two unrelated `class_static_init`/`contextual_return_wrapper` tests), unrelated to this change |
| `cargo clippy -p tsz-checker --all-targets -- -D warnings` | clean |
| `cargo fmt --all -- --check` | clean |
| Pre-commit hook (clippy + arch guard + affected-crate verification) | passed |

**Corpus gate (compare-to-parent / conformance snapshot): not run this session, disclosed rather than skipped silently.** This is a checker-owned semantic fix reachable whenever a class/interface `implements` a generic interface or class declared in another file — real-world impact expected (it's the residual behind #16307's xstate row, 21/105 diagnostics per that issue). Blast radius for a reviewer: the new code path only replaces an already-broken fallback that fired *only* when the local same-arena AST walk found nothing (i.e. only for cross-file/cross-arena heritage targets); same-file heritage resolution is untouched (see the same-file negative control above, and the full `--lib` run shows 0 newly failing anywhere in the crate). The two-sided `dist-fast` run has been measured at 55–90 min cold on this board and did not fit this session's time budget; a follow-up run against this branch is worthwhile before landing if anyone has the window.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_017hUvssvWS3dSrydHBwvSd2)_