### PR TITLE
fix(parser): `declare export default &lt;expr&gt;` reports its assignment-form diagnostic, not TS1029

### DIFF
--- a/crates/tsz-parser/src/parser/state_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_declarations.rs
@@ -1720,6 +1720,33 @@ impl ParserState {
                     self.current_token = current;
                     is_type_only
                 };
+                // `declare export default <expr>` where `default` is followed
+                // by neither a class nor a function declaration is an
+                // `ExportAssignment` node (a value expression carrying
+                // `default`), not a `ClassDeclaration`/`FunctionDeclaration`
+                // carrying a `default` modifier — the same class-vs-expression
+                // split the sibling `async` family already draws for `default`
+                // (`look_ahead_async_before_export_target`, #16403). tsc's
+                // modifier-order check (TS1029) never applies to that
+                // assignment form; only `AN_EXPORT_ASSIGNMENT_CANNOT_HAVE_MODIFIERS`
+                // (TS1120) does, handled below alongside the declaration match
+                // (residual #16432 disclosed and left unfixed).
+                let is_export_default_assignment_form = self.is_token(SyntaxKind::DefaultKeyword)
+                    && {
+                        let snapshot = self.scanner.save_state();
+                        let current = self.current_token;
+                        self.next_token(); // skip `default`
+                        let starts_declaration = matches!(
+                            self.token(),
+                            SyntaxKind::ClassKeyword
+                                | SyntaxKind::AbstractKeyword
+                                | SyntaxKind::FunctionKeyword
+                        ) || (self.token() == SyntaxKind::AsyncKeyword
+                            && self.look_ahead_is_async_function());
+                        self.scanner.restore_state(snapshot);
+                        self.current_token = current;
+                        !starts_declaration
+                    };
                 // TS1029: 'export' modifier must precede 'declare' modifier.
                 // Skip for `declare export as namespace` (valid UMD pattern) and
                 // `declare export = expr` (export assignment — TS1120 handles it).
@@ -1732,7 +1759,9 @@ impl ParserState {
                 // form without TS1029 for ambient module/namespace declarations.
                 // Also skip for a plain export declaration (`{ }` / `*` / type-only
                 // `type { }` / `type *`) — tsc emits TS1193 alone there, never TS1029
-                // alongside it (oracle-confirmed).
+                // alongside it (oracle-confirmed). Also skip for the `default <expr>`
+                // assignment form above — TS1120 handles it below, the same way
+                // `EqualsToken` is skipped here.
                 if !self.in_block_context()
                     && !self.is_token(SyntaxKind::AsKeyword)
                     && !self.is_token(SyntaxKind::EqualsToken)
@@ -1741,6 +1770,7 @@ impl ParserState {
                     && !self.is_token(SyntaxKind::OpenBraceToken)
                     && !self.is_token(SyntaxKind::AsteriskToken)
                     && !is_type_only_export
+                    && !is_export_default_assignment_form
                     && (saved_flags & crate::parser::state::CONTEXT_FLAG_AMBIENT) == 0
                 {
                     self.parse_error_at(
@@ -1898,6 +1928,31 @@ impl ParserState {
                         // function), so the reused declaration/expression
                         // classification `parse_export_default` performs
                         // still parses class/function bodies as ambient.
+                        //
+                        // `declare export default <expr>` (no class/function
+                        // following `default`) is instead the `ExportAssignment`
+                        // node the `EqualsToken` arm handles, and tsc reports
+                        // its modifier violation the same way: TS1120 at the
+                        // source file's own top level, silenced everywhere
+                        // else by the node's own placement diagnostic (TS1258
+                        // in a Block, TS1319 in a namespace body) — oracle-
+                        // pinned residual #16432 disclosed and left for this.
+                        if is_export_default_assignment_form
+                            && !self.in_block_context()
+                            && !self.in_module_body_context()
+                        {
+                            use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages};
+                            let error_start = all_modifiers
+                                .first()
+                                .and_then(|idx| self.arena.get(*idx))
+                                .map_or(start_pos, |node| node.pos);
+                            self.parse_error_at(
+                                error_start,
+                                self.token_pos() - error_start,
+                                diagnostic_messages::AN_EXPORT_ASSIGNMENT_CANNOT_HAVE_MODIFIERS,
+                                diagnostic_codes::AN_EXPORT_ASSIGNMENT_CANNOT_HAVE_MODIFIERS,
+                            );
+                        }
                         self.parse_export_default(start_pos)
                     }
                     _ => {

--- a/crates/tsz-parser/tests/parser_declare_export_default_tests.rs
+++ b/crates/tsz-parser/tests/parser_declare_export_default_tests.rs
@@ -22,9 +22,40 @@
 //! modifiers threaded onto the produced node (this fix reuses
 //! `parse_export_default`, which does not carry them) rather than a parser
 //! shape change, so they are left for a follow-up slice.
+//!
+//! `declare export default <expr>` (the bare-expression assignment form, not
+//! class/function) is a distinct node from the declaration forms above and
+//! was left with the wrong diagnostic entirely: it fell through the
+//! unconditional TS1029 pre-check meant for the declaration forms, giving
+//! TS1029 everywhere tsc gives TS1120 (top level) or nothing at all
+//! (namespace body / Block, where the node's own placement diagnostic wins
+//! outright) — the residual #16432 documented and deliberately left.
 
 use crate::parser::test_fixture::parse_source;
 use tsz_common::diagnostics::diagnostic_codes;
+
+fn assert_no_ts1029_export_before_declare(source: &str) {
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.code == diagnostic_codes::MODIFIER_MUST_PRECEDE_MODIFIER),
+        "expected no TS1029 for {source:?}, got {diagnostics:?}"
+    );
+}
+
+fn assert_ts1120_export_assignment_cannot_have_modifiers(source: &str) {
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+    let declare_pos = source.find("declare").unwrap() as u32;
+    assert!(
+        diagnostics.iter().any(|d| d.code
+            == diagnostic_codes::AN_EXPORT_ASSIGNMENT_CANNOT_HAVE_MODIFIERS
+            && d.start == declare_pos),
+        "expected TS1120 anchored at 'declare' ({declare_pos}) for {source:?}, got {diagnostics:?}"
+    );
+}
 
 fn assert_no_declaration_expected_fallback(source: &str) {
     let (parser, _root) = parse_source(source);
@@ -112,4 +143,59 @@ fn declare_export_default_function_in_block_reports_no_ts1146() {
 #[test]
 fn declare_export_default_expression_reports_no_ts1146() {
     assert_no_declaration_expected_fallback("declare export default 1;");
+}
+
+// -- assignment form (`declare export default <expr>`, no class/function
+// keyword): the #16432 residual. tsc treats this as an `ExportAssignment`
+// throughout, never the modifier-order check the declaration forms above
+// take, oracle-pinned against `typescript@7.0.2`.
+
+#[test]
+fn declare_export_default_literal_top_level_reports_ts1120_not_ts1029() {
+    let source = "declare export default 1;";
+    assert_no_ts1029_export_before_declare(source);
+    assert_ts1120_export_assignment_cannot_have_modifiers(source);
+}
+
+#[test]
+fn declare_export_default_identifier_top_level_reports_ts1120_not_ts1029() {
+    let source = "declare export default X;\ndeclare const X: any;";
+    assert_no_ts1029_export_before_declare(source);
+    assert_ts1120_export_assignment_cannot_have_modifiers(source);
+}
+
+#[test]
+fn declare_export_default_literal_in_namespace_reports_no_ts1029() {
+    // tsc: TS1319 alone (own placement diagnostic wins); no TS1029, no TS1120.
+    assert_no_ts1029_export_before_declare("namespace N { declare export default 1; }");
+}
+
+#[test]
+fn declare_export_default_literal_in_nested_namespace_reports_no_ts1029() {
+    assert_no_ts1029_export_before_declare(
+        "namespace Outer { namespace Inner { declare export default 1; } }",
+    );
+}
+
+#[test]
+fn declare_export_default_literal_in_block_reports_no_ts1029() {
+    // tsc: TS1258 alone (own placement diagnostic wins); no TS1029, no TS1120.
+    assert_no_ts1029_export_before_declare("function outer() { declare export default 1; }");
+}
+
+// -- negative control: the declaration forms must keep TS1029 exactly as
+// #16432 pinned them — `abstract class` and `async function` are also
+// declaration targets, not just the plain `class`/`function` rows already
+// covered above.
+
+#[test]
+fn declare_export_default_abstract_class_in_namespace_still_reports_ts1029() {
+    assert_ts1029_export_before_declare("namespace N { declare export default abstract class {} }");
+}
+
+#[test]
+fn declare_export_default_async_function_in_namespace_still_reports_ts1029() {
+    assert_ts1029_export_before_declare(
+        "namespace N { declare export default async function f(): Promise<void>; }",
+    );
 }


### PR DESCRIPTION
Closes the residual ClaudeDE's #16432 documented and deliberately left, opposite direction from that PR's own fix.

## Structural rule

`default` decorates two structurally different node kinds, and tsc's `checkGrammarModifiers` answers each one differently:

- When `default` is followed by `class` / `abstract class` / `function` / `async function`, tsc reads the whole thing as a `ClassDeclaration`/`FunctionDeclaration` carrying `declare`+`export`+`default` modifiers — tsz already gets this right (TS1029, fixed by #16432).
- When `default` is followed by anything else (a bare expression: a literal, an identifier, ...), tsc reads the node as an `ExportAssignment` — the same node kind `export =` produces — so it takes *that* node's own diagnostic instead: `AN_EXPORT_ASSIGNMENT_CANNOT_HAVE_MODIFIERS` (TS1120) at the source file's own top level, silenced everywhere else by the node's own placement diagnostic (TS1258 in a Block, TS1319 in a namespace body) — the same "own placement diagnostic wins in Block and namespace body, modifier diagnostic survives only at top level" shape the sibling `async`/`accessor`/`abstract` `ExportAssignment` variants already implement (#16403).

tsz's `parse_ambient_declaration_with_modifiers` ran the TS1029 pre-check unconditionally for `default`, before it was even known which of the two node kinds `default` would produce — so the assignment form got the wrong diagnostic everywhere: TS1029 instead of TS1120 at top level, and an extra TS1029 alongside TS1319/TS1258 in a namespace body/Block, where tsc reports the placement diagnostic alone.

## Owner layer

Parser only, `crates/tsz-parser/src/parser/state_declarations.rs`, `parse_ambient_declaration_with_modifiers`'s `ExportKeyword` arm. Adds `is_export_default_assignment_form`, a lookahead mirroring the existing `look_ahead_async_before_export_target`'s class-vs-expression split for `default` (`#16403`'s `async` slice), gates the pre-check TS1029 on it, and emits TS1120 in the `DefaultKeyword` match arm under the same block/namespace-body silencing the TS1029 pre-check already uses. No checker/solver/emitter change.

## Oracle verification

`typescript@7.0.2` (`--strict --target es2022 --module es2022`), against both the vendored oracle and the built release `tsz` binary:

| case | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `namespace N { declare export default 1; }` | TS1319 | TS1319 **+ TS1029** | **TS1319 ✅** |
| `namespace Outer { namespace Inner { declare export default 1; } }` | TS1319 | TS1319 **+ TS1029** | **TS1319 ✅** |
| `declare export default 1;` (top level) | TS1120 | **TS1029** | **TS1120 ✅** |
| `declare export default X;\ndeclare const X: any;` (top level, identifier) | TS1120 | **TS1029** | **TS1120 ✅** |
| `function outer() { declare export default 1; }` (Block) | TS1258 | TS1258 (unaffected — block already excluded TS1029) | TS1258 (unchanged) |
| `namespace N { declare export default class {} }` | TS1029 | TS1029 | TS1029 (unchanged, negative control) |
| `namespace N { declare export default abstract class {} }` | TS1029 | TS1029 | TS1029 (unchanged, negative control) |
| `namespace N { declare export default async function f(): Promise<void>; }` | TS1029 | TS1029 | TS1029 (unchanged, negative control) |

## Adjacent-case matrix

New tests in `crates/tsz-parser/tests/parser_declare_export_default_tests.rs`: assignment-form top level (literal + identifier target), namespace body, nested namespace body, Block, plus negative controls pinning that `class`/`abstract class`/`function`/`async function` targets keep TS1029 exactly as #16432 left them.

## Residual, out of scope, disclosed

`declare export = x;` inside a namespace body currently reports `TS1120 + TS1063` where tsc reports `TS1063` alone — the same "own placement diagnostic should silence the modifier diagnostic" shape this PR builds for `default`, but on the sibling `EqualsToken` arm a few lines up, which this diff does not touch. Left for a follow-up slice; oracle-confirmed pre-existing on `main`, unaffected by this change either way.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-parser --lib declare_export_default`: **15/15 passed** (was 8/8 before this PR's 7 new tests; 4 fail for the correct reason when the source fix alone is reverted via `git stash`, keeping the tests — the 4 new positive assignment-form rows).
- `cargo test -p tsz-parser --lib` (full crate): **1926 passed, 0 failed**.
- `cargo clippy -p tsz-parser --all-targets -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.
- Built release `tsz` binary spot-checked against all 9 oracle rows above (plus the disclosed `declare export = x` namespace residual) — exact match on every row this PR is responsible for.
- `scripts/conformance/compare-to-parent.sh` — **not run** (disclosed, not skipped silently): the two-`dist-fast`-build two-sided run measures 55–90 min cold on this board's own record and did not fit the session. Blast radius for a reviewer: the new branch only activates when the current token is `DefaultKeyword` immediately after `declare export`, and only changes behavior when the token after `default` is *not* `class`/`abstract`/`function`/`async function` — a narrow, always-erroneous ambient-export grammar shape (`declare export default <expr>` is illegal in every container). The change can only move a corpus row that already contains this exact stray-modifier combination from a wrong diagnostic to the correct one; it cannot introduce a new false positive on ordinary code.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01F56UyVQdc4Pf8Hs4ZAW3WW)_