### PR TITLE
fix(checker): for-of circularity is decided by symbol identity, not identifier spelling

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -484,6 +484,9 @@ mod for_in_narrowing_tests;
 #[path = "../tests/for_in_self_reference_and_nullable_operand_tests.rs"]
 mod for_in_self_reference_and_nullable_operand_tests;
 #[cfg(test)]
+#[path = "../tests/for_of_self_reference_operand_spelling_tests.rs"]
+mod for_of_self_reference_operand_spelling_tests;
+#[cfg(test)]
 #[path = "../tests/fresh_object_literal_union_array_member_drill_in_tests.rs"]
 mod fresh_object_literal_union_array_member_drill_in_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/variable_checking/for_loop.rs
+++ b/crates/tsz-checker/src/state/variable_checking/for_loop.rs
@@ -495,11 +495,10 @@ impl<'a> CheckerState<'a> {
     /// TS7022: report a for-in loop variable whose own operand references it.
     ///
     /// The for-of twin (`check_for_of_self_reference_circularity`) additionally
-    /// walks iterator-protocol return sites and falls back to an identifier-name
-    /// match; neither applies here. for-in has no iterator protocol, and the
-    /// name fallback would misfire on a member name that merely spells the loop
-    /// variable — `for (const v in o.v) {}` is clean in tsc — so this path is
-    /// symbol-identity only.
+    /// walks iterator-protocol return sites; that does not apply here, because
+    /// for-in has no iterator protocol. Both paths decide the reference itself
+    /// through binder symbol identity only, never through the identifier's
+    /// spelling — `for (const v in o.v) {}` is clean in tsc.
     pub(crate) fn check_for_in_self_reference_circularity(
         &mut self,
         decl_list_idx: NodeIndex,
@@ -1026,10 +1025,7 @@ impl<'a> CheckerState<'a> {
                 }
             }
             let has_direct_reference = self.expression_references_symbol(expression_idx, sym_id);
-            let has_name_reference = var_name.as_ref().is_some_and(|name| {
-                self.expression_references_identifier_name(expression_idx, name)
-            });
-            if circular_return_sites.is_empty() && !has_direct_reference && !has_name_reference {
+            if circular_return_sites.is_empty() && !has_direct_reference {
                 continue;
             }
 
@@ -1601,51 +1597,28 @@ impl<'a> CheckerState<'a> {
             return self.expression_references_symbol(access.expression, target_sym);
         }
 
-        // Recurse into children
-        for child_idx in self.ctx.arena.get_children(node_idx) {
-            if self.expression_references_symbol(child_idx, target_sym) {
-                return true;
-            }
-        }
-
-        false
-    }
-
-    fn expression_references_identifier_name(
-        &self,
-        node_idx: NodeIndex,
-        target_name: &str,
-    ) -> bool {
-        let Some(node) = self.ctx.arena.get(node_idx) else {
-            return false;
-        };
-
-        if node.kind == SyntaxKind::Identifier as u16
+        // A *written* property name in an object literal is a name, not a value
+        // binding either — `pick({ v: 1 })` reads nothing called `v`, so only
+        // the initializer side is walked. Two neighbours deliberately keep
+        // their default recursion because they really do read the binding: a
+        // computed name (`{ [v]: 1 }`) evaluates `v`, and a shorthand
+        // (`{ v }`) is a `ShorthandPropertyAssignment` whose name *is* the
+        // reference. `tsc` reports the circularity for both and not for the
+        // written name.
+        if node.kind == syntax_kind_ext::PROPERTY_ASSIGNMENT
+            && let Some(assignment) = self.ctx.arena.get_property_assignment(node)
             && self
                 .ctx
                 .arena
-                .get_identifier(node)
-                .is_some_and(|ident| ident.escaped_text.as_str() == target_name)
+                .get(assignment.name)
+                .is_some_and(|name| name.kind != syntax_kind_ext::COMPUTED_PROPERTY_NAME)
         {
-            return true;
+            return self.expression_references_symbol(assignment.initializer, target_sym);
         }
 
-        if matches!(
-            node.kind,
-            syntax_kind_ext::FUNCTION_DECLARATION
-                | syntax_kind_ext::FUNCTION_EXPRESSION
-                | syntax_kind_ext::ARROW_FUNCTION
-                | syntax_kind_ext::METHOD_DECLARATION
-                | syntax_kind_ext::GET_ACCESSOR
-                | syntax_kind_ext::SET_ACCESSOR
-                | syntax_kind_ext::CLASS_DECLARATION
-                | syntax_kind_ext::CLASS_EXPRESSION
-        ) {
-            return false;
-        }
-
+        // Recurse into children
         for child_idx in self.ctx.arena.get_children(node_idx) {
-            if self.expression_references_identifier_name(child_idx, target_name) {
+            if self.expression_references_symbol(child_idx, target_sym) {
                 return true;
             }
         }

--- a/crates/tsz-checker/tests/for_of_self_reference_operand_spelling_tests.rs
+++ b/crates/tsz-checker/tests/for_of_self_reference_operand_spelling_tests.rs
@@ -1,0 +1,278 @@
+//! Regression tests for TS7022 on `for-of` operands that only *spell* the loop
+//! variable's name without referencing its binding.
+//!
+//! `tsc` decides for-of circularity by resolving the operand and watching
+//! `pushTypeResolution` fail on the loop variable's own symbol — an identity
+//! question. tsz's `check_for_of_self_reference_circularity` asked it twice:
+//! once through binder symbol identity, and once through a raw walk that
+//! matched any identifier in the operand subtree whose *text* equalled the loop
+//! variable's name. The two were or-ed together, so the spelling walk decided
+//! every row the identity walk declined.
+//!
+//! The identity walk was narrowed (for-in twin, #16144) to skip a property
+//! access's member name, because `o.alpha` reads no binding called `alpha`.
+//! The spelling walk was not, and because the two were or-ed that narrowing
+//! could never bind on the for-of side.
+//!
+//! Every row below is oracle-verified against `tsc` 7.0.2
+//! (`--noEmit --strict --pretty false --target es2015 --lib es2015`).
+//!
+//! The load-bearing asymmetry, pinned as a matched pair over one operand type:
+//! `for (const alpha of holder.alpha)` is **clean** (a member name is not a
+//! value reference) while `for (const alpha of holder[alpha])` **reports**
+//! (an element access genuinely reads the binding). Both operands are
+//! `number[]`; only the access kind differs.
+//!
+//! Binder names are varied across rows so nothing here can be satisfied by a
+//! user-chosen identifier.
+
+use crate::test_utils::check_source_strict_codes;
+
+const TS7022: u32 = 7022;
+
+fn assert_no_7022(source: &str, label: &str) {
+    let codes = check_source_strict_codes(source);
+    assert!(
+        !codes.contains(&TS7022),
+        "{label}: expected no TS7022 (tsc resolves this operand normally), got codes: {codes:?}"
+    );
+}
+
+fn assert_has_7022(source: &str, label: &str) {
+    let codes = check_source_strict_codes(source);
+    assert!(
+        codes.contains(&TS7022),
+        "{label}: expected TS7022 (tsc reports a circular loop variable), got codes: {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The matched pair: same operand type, same holder, only the access kind moves.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn property_access_member_name_spelling_the_loop_variable_is_not_circular() {
+    assert_no_7022(
+        r"
+declare const holder: { alpha: number[]; [k: string]: number[] };
+for (const alpha of holder.alpha) { alpha; }
+        ",
+        "for (const alpha of holder.alpha)",
+    );
+}
+
+#[test]
+fn element_access_reading_the_loop_variable_is_still_circular() {
+    assert_has_7022(
+        r"
+declare const holder: { alpha: number[]; [k: string]: number[] };
+for (const alpha of holder[alpha]) { alpha; }
+        ",
+        "for (const alpha of holder[alpha])",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative rows — the operand only spells the name, never reads the binding.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nested_property_access_member_names_are_not_circular() {
+    assert_no_7022(
+        r"
+declare const outer: { inner: { beta: number[] } };
+for (const beta of outer.inner.beta) { beta; }
+        ",
+        "for (const beta of outer.inner.beta)",
+    );
+}
+
+#[test]
+fn optional_property_access_member_name_is_not_circular() {
+    assert_no_7022(
+        r"
+declare const maybe: { gamma: number[] } | undefined;
+for (const gamma of maybe?.gamma ?? []) { gamma; }
+        ",
+        "for (const gamma of maybe?.gamma ?? [])",
+    );
+}
+
+#[test]
+fn object_literal_property_name_spelling_the_loop_variable_is_not_circular() {
+    assert_no_7022(
+        r"
+declare function pick(source: { delta: number[] }): number[];
+for (const delta of pick({ delta: [1] })) { delta; }
+        ",
+        "for (const delta of pick({ delta: [1] }))",
+    );
+}
+
+#[test]
+fn member_name_in_a_call_chain_is_not_circular() {
+    assert_no_7022(
+        r"
+declare const bag: { epsilon: number[]; widen(seed: number[]): number[] };
+for (const epsilon of bag.widen(bag.epsilon)) { epsilon; }
+        ",
+        "for (const epsilon of bag.widen(bag.epsilon))",
+    );
+}
+
+#[test]
+fn method_call_member_name_spelling_the_loop_variable_is_not_circular() {
+    assert_no_7022(
+        r"
+declare const source: { zeta(): number[] };
+for (const zeta of source.zeta()) { zeta; }
+        ",
+        "for (const zeta of source.zeta())",
+    );
+}
+
+/// Renamed binder: the rule is about the access position, not about any
+/// particular spelling, so a differently-named pair behaves identically.
+#[test]
+fn renamed_binder_member_name_is_not_circular() {
+    assert_no_7022(
+        r"
+declare const registry: { qux: number[] };
+for (const qux of registry.qux) { qux; }
+        ",
+        "for (const qux of registry.qux)",
+    );
+}
+
+/// Two loops whose operands both spell `theta` as a member name: neither reads
+/// a binding called `theta`, so the identity walk declines both.
+#[test]
+fn same_spelling_property_on_an_unrelated_object_is_not_circular() {
+    assert_no_7022(
+        r"
+declare const first: { theta: number[] };
+declare const second: { theta: number[] };
+for (const theta of first.theta) { theta; }
+for (const iota of second.theta) { iota; }
+        ",
+        "two loops over same-spelled members",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Positive rows — real value references must keep reporting.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn direct_self_reference_is_circular() {
+    assert_has_7022(
+        r"
+for (var lambda of lambda) { lambda; }
+        ",
+        "for (var lambda of lambda)",
+    );
+}
+
+#[test]
+fn renamed_binder_direct_self_reference_is_circular() {
+    assert_has_7022(
+        r"
+for (var omega of omega) { omega; }
+        ",
+        "for (var omega of omega)",
+    );
+}
+
+#[test]
+fn array_literal_containing_the_loop_variable_is_circular() {
+    assert_has_7022(
+        r"
+for (var sigma of [sigma]) { sigma; }
+        ",
+        "for (var sigma of [sigma])",
+    );
+}
+
+#[test]
+fn loop_variable_read_on_the_object_side_of_a_property_access_is_circular() {
+    assert_has_7022(
+        r"
+for (var kappa of kappa.items) { kappa; }
+        ",
+        "for (var kappa of kappa.items)",
+    );
+}
+
+/// The *initializer* side of an object-literal property is a real expression
+/// position — skipping the written name must not skip the value with it.
+#[test]
+fn object_literal_property_initializer_reading_the_loop_variable_is_circular() {
+    assert_has_7022(
+        r"
+declare function pick(source: { other: number[] }): number[];
+for (const eta of pick({ other: eta })) { eta; }
+        ",
+        "for (const eta of pick({ other: eta }))",
+    );
+}
+
+/// A computed property name evaluates its expression, so it reads the binding
+/// even though it sits in the same syntactic slot as the written name.
+#[test]
+fn computed_property_name_reading_the_loop_variable_is_circular() {
+    assert_has_7022(
+        r"
+declare function pick(source: { [k: string]: number[] }): number[];
+for (const rho of pick({ [rho]: [1] })) { rho; }
+        ",
+        "for (const rho of pick({ [rho]: [1] }))",
+    );
+}
+
+/// A shorthand property's name *is* the reference — a different node kind from
+/// the written name, and it must keep its default recursion.
+#[test]
+fn shorthand_property_reading_the_loop_variable_is_circular() {
+    assert_has_7022(
+        r"
+declare function pick(source: { mu: number[] }): number[];
+declare const mu: number[];
+for (const mu of pick({ mu })) { mu; }
+        ",
+        "for (const mu of pick({ mu }))",
+    );
+}
+
+/// The same walk backs the for-in twin (#16144), so the object-literal rule
+/// lands on both loop forms at once.
+#[test]
+fn for_in_object_literal_property_name_is_not_circular() {
+    assert_no_7022(
+        r"
+for (const nu in { nu: 1 }) { nu; }
+        ",
+        "for (const nu in { nu: 1 })",
+    );
+}
+
+#[test]
+fn for_in_property_access_member_name_is_not_circular() {
+    assert_no_7022(
+        r"
+declare const box: { psi: { inner: number } };
+for (const psi in box.psi) { psi; }
+        ",
+        "for (const psi in box.psi)",
+    );
+}
+
+#[test]
+fn header_shadowing_self_reference_is_circular() {
+    assert_has_7022(
+        r"
+let tau = [1];
+for (let tau of tau) { tau; }
+        ",
+        "for (let tau of tau) shadowing an outer binding",
+    );
+}


### PR DESCRIPTION
`check_for_of_self_reference_circularity` asked "does this operand reference the loop variable?" **twice**, and or-ed the answers:

- `expression_references_symbol` — binder symbol identity, the correct predicate.
- `expression_references_identifier_name` — a raw walk matching *any* identifier in the operand subtree whose text equalled the loop variable's name.

#16144 narrowed the identity walk to skip a property access's member name (`holder.alpha` reads no binding called `alpha`). The spelling walk was never narrowed, and because the two were or-ed, that narrowing **could not bind on the for-of side**. Every for-of operand that merely *spelled* the loop variable in a member-name position reported a false TS7022.

This was also a standing anti-hardcoding violation: a user-chosen identifier's text used directly as a semantic predicate.

Left as an explicit handoff by Schist on #16141 (2026-08-01) when the for-in half landed as #16144; still live on `main` four days later.

## Structural rule

When a for-of or for-in operand mentions the loop variable's spelling in a position that is **not a value reference to it** — a property-access member name, a written object-literal property name — `tsc` resolves the operand normally and reports nothing. tsz now decides that question through binder symbol identity in the checker's for-loop variable checking (`crates/tsz-checker/src/state/variable_checking/for_loop.rs`), never through spelling.

The asymmetry #16144 pinned is preserved and re-pinned here as a **matched pair over one operand type**, so the rule cannot be satisfied by a coincidence of shape:

| operand | tsc 7.0.2 | why |
| --- | --- | --- |
| `for (const alpha of holder.alpha)` | clean | a member name is not a value reference |
| `for (const alpha of holder[alpha])` | TS7022 | an element access genuinely reads the binding |

Both operands are `number[]`; only the access kind moves.

## What changed

1. **The spelling walk is gone.** `expression_references_identifier_name` is deleted, not narrowed — an identifier's text is not a semantic predicate, so patching it would have preserved the wrong shape.
2. **The identity walk is completed** for the one non-reference name position it was still missing: a *written* property name in an object literal (`pick({ alpha: 1 })`) now walks only the initializer side. Two neighbours deliberately keep default recursion because they really do read the binding — a computed name (`{ [alpha]: 1 }`) evaluates it, and a shorthand (`{ alpha }`) is a `ShorthandPropertyAssignment` whose name *is* the reference. Both oracle-confirmed as TS7022.

Removing the spelling walk alone left 13/14 rows green; the object-literal row is the one that was false-positiving through the *identity* walk, which is why the second half is here rather than in a follow-up.

The same walk backs the for-in twin, so the object-literal rule lands on both loop forms at once (two for-in rows pinned).

## Goal
Goal: hold

## Verification

All 19 rows oracle-pinned against `typescript@7.0.2` (`--noEmit --strict --pretty false --target es2015 --lib es2015`) **before** any code was written — the fix was written to the oracle, not the oracle to the fix.

| gate | result |
| --- | --- |
| `cargo test -p tsz-checker --lib for_of_self_reference_operand_spelling` | **19 passed, 0 failed** |
| **negative control** — new suite kept, production diff reverted | **8 failed / 6 passed**; the 8 are exactly the negative rows, all 6 positive rows green in both states |
| `cargo test -p tsz-checker --lib -- for_of for_in 7022 7023 circular implicit_any` | 317 passed, 0 failed |
| `cargo test -p tsz-checker --lib -- iterator iterable spread destructur narrowing loop` | 797 passed, 0 failed |
| `cargo clippy -p tsz-checker --all-targets -- -D warnings` | exit 0 |
| `cargo fmt --all` | clean |
| `python3 scripts/arch/arch_guard.py` | passed |
| `python3 scripts/ci/check-test-file-reachability.py` | 0 known orphans, 0 new |
| pre-commit hook (clippy + affected crate tests) | passed |

Full `cargo test -p tsz-checker --lib`: 7955+ passed / 0 failed at the point this PR was opened, still running into the board-documented `ts2589_tests` long-tail stall that no cloud container has been able to terminate. Final count posted as a comment.

**`compare-to-parent.sh` is owed and disclosed, not silently skipped** — the two-sided run measures 55–90 min on a cold cloud seat per three independent board reports, and does not fit this session. Blast-radius argument: the diff can only ever *remove* a TS7022 (deleting an or-ed disjunct, plus one additional skip inside the surviving walk) except where the surviving identity walk already fired. A conformance row therefore cannot flip pass→fail on the removal; it can only flip fail→pass, or stay put. The one direction worth checking is a row that *expects* a TS7022 which was previously reached only through the spelling walk — the 19-row matrix covers every such shape I could oracle, including all three "must still report" guards around the new skip.

### Negative-control detail

Reverting only the production diff and keeping the new suite:

```
failures:
    member_name_in_a_call_chain_is_not_circular
    method_call_member_name_spelling_the_loop_variable_is_not_circular
    nested_property_access_member_names_are_not_circular
    object_literal_property_name_spelling_the_loop_variable_is_not_circular
    optional_property_access_member_name_is_not_circular
    property_access_member_name_spelling_the_loop_variable_is_not_circular
    renamed_binder_member_name_is_not_circular
    same_spelling_property_on_an_unrelated_object_is_not_circular

test result: FAILED. 6 passed; 8 failed
```

Binder names are varied across every row (`alpha`/`beta`/`gamma`/`delta`/`epsilon`/`zeta`/`qux`/`theta`/`lambda`/`omega`/`sigma`/`kappa`/`eta`/`rho`/`mu`/`nu`/`psi`/`tau`), so no row can be satisfied by a user-chosen identifier.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Malachite

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQhCBDTFsdMxqVuBnAYsyd)_