### PR TITLE
chore(readme): refresh conformance stats to 11,490

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ test suite against it.
 
 <!-- CONFORMANCE_START -->
 ```
-Progress: [███████████████████░] 95.3% (11,482/12,043 runnable tests)
+Progress: [███████████████████░] 95.4% (11,490/12,043 runnable tests)
 Candidates: 12,585 (12,043 runnable, 507 unsupported, 35 skipped)
 ```
 <!-- CONFORMANCE_END -->


### PR DESCRIPTION
Goal: hold

Complements #16442, which refreshed the two benchmark chart PNGs but changed no
README text (`gh pr view 16442 --json files` shows only
`readme-perf-dark.png` and `readme-perf-light.png`, +0/-0 textual). The
conformance block was therefore still publishing `11,482` after it landed.

Measured at `0b0fd11e40` -- the head produced by merging #16442 -- with zero
drift, so the published figure describes exactly the tree it names.

Single line changes: `95.3% (11,482/12,043)` -> `95.4% (11,490/12,043)`.

Generated via `scripts/refresh-readme.py --write --skip-performance`; no
hand-edited numbers. The committed value was read back out of the commit
(`git show HEAD:README.md`) before the conformance snapshot tree was discarded,
confirming the published figure is the measured one.

Emit metrics left untouched -- the script declined to rewrite them
(`preserving README emit metrics because scripts/emit/emit-detail.json is
behind the existing README emit block`). Fourslash metrics already accurate.
Performance chart skipped: #16442 regenerated it minutes ago.

## Verification

Measured at `0b0fd11e40` (zero drift at publish time):

- conformance: `11490 / 12043` runnable (95.4%), 12585 candidates, 507
  unsupported, 35 skipped

Full suite run earlier the same day at `1a4228ea56` (68 commits on from the
prior day's measurement):

- conformance `11489 / 12043` (95.4%)
- emit JS `11562 / 11563`, emit DTS `1375 / 1390` -- both exactly at the parity
  floor, now unmoved across roughly 270 commits this week
- fourslash `6558 / 6562` baseline held. Complete run (`6562/6562` executed), 0
  watchdog kills, 8 tests reporting "Test completed but took Xms" (those passed,
  over the 15s wall clock under concurrent load). The 4 failures are exactly the
  known baseline set: `completionListFunctionExpression`,
  `importFixesWithPackageJsonInSideAnotherPackage`,
  `importNameCodeFix_importType`, `autoImportProvider_importsMap1`.
- benchmark: script score `tsz 94 vs tsgo 4`. Run was gated on machine load
  settling below 4 before starting (start load 3.77, end 4.15), which matters --
  see below.

Fast-goal gaps, measured: comlink `2.74 ± 0.03`, ts-toolbelt `2.52 ± 0.03`,
vite-vanilla-ts-app `1.75 ± 0.11`, recursive utility aliases `1.11 ± 0.02`.

The prior day's run was contended and produced comlink `2.62 ± 0.22` and vite
`1.61 ± 0.44`. Those means looked like 3% and 9% improvements but sat well
inside their own error bars; today's gated run returns both to their 08-03
values (`2.70 ± 0.02`, `1.77 ± 0.03`). Reporting yesterday's numbers as progress
would have made today's honest measurement read as a regression across 68
commits. These four gaps are stable, not drifting.

Rows that do not complete, reported separately from the `fast` gaps above:
`large-ts-repo` (tsz exit 124, killed at the 1500s ceiling; tsgo 34.9s, itself
non-zero), `zod-project` and `kysely-project` (`tsz error; tsc ok`). The harness
prints a bare "42.99 times faster than tsz" line for large-ts-repo, but that is
`timeout_ceiling / tsgo_time`, not a speed measurement -- hyperfine emits it as
`Time (abs =)` with no stddev because only one killed run was collected.

## Provenance

Machine: m1
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high

AgentName: M1FableArchitect