### PR TITLE
fix(parser): `declare export = x` silences TS1120 outside the top level

### DIFF
--- a/crates/tsz-parser/src/parser/state_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_declarations.rs
@@ -1816,19 +1816,28 @@ impl ParserState {
                         .parse_variable_statement_with_modifiers(Some(start_pos), Some(modifiers)),
                     SyntaxKind::EqualsToken => {
                         // `declare export = expr` or `export declare export = expr`
-                        // tsc reports TS1120: An export assignment cannot have modifiers.
+                        // tsc reports TS1120: An export assignment cannot have modifiers —
+                        // but only at the top level. In a namespace body or a Block, the
+                        // `ExportAssignment` node's own placement diagnostic (TS1063 in a
+                        // namespace, TS1231 in a Block) wins instead and TS1120 does not
+                        // fire alongside it — the same "own placement diagnostic silences
+                        // the modifier diagnostic outside top level" shape the sibling
+                        // `default <expr>` assignment form already implements below
+                        // (#16403/#16440).
                         // Error span starts from the first modifier (export if present, else declare).
-                        use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages};
                         let error_start = all_modifiers
                             .first()
                             .and_then(|idx| self.arena.get(*idx))
                             .map_or(start_pos, |node| node.pos);
-                        self.parse_error_at(
-                            error_start,
-                            self.token_pos() - error_start,
-                            diagnostic_messages::AN_EXPORT_ASSIGNMENT_CANNOT_HAVE_MODIFIERS,
-                            diagnostic_codes::AN_EXPORT_ASSIGNMENT_CANNOT_HAVE_MODIFIERS,
-                        );
+                        if !self.in_block_context() && !self.in_module_body_context() {
+                            use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages};
+                            self.parse_error_at(
+                                error_start,
+                                self.token_pos() - error_start,
+                                diagnostic_messages::AN_EXPORT_ASSIGNMENT_CANNOT_HAVE_MODIFIERS,
+                                diagnostic_codes::AN_EXPORT_ASSIGNMENT_CANNOT_HAVE_MODIFIERS,
+                            );
+                        }
                         self.parse_export_assignment(error_start)
                     }
                     SyntaxKind::ImportKeyword => {

--- a/crates/tsz-parser/tests/state_declaration_tests.rs
+++ b/crates/tsz-parser/tests/state_declaration_tests.rs
@@ -854,6 +854,48 @@ fn export_assignment_with_export_declare_modifiers_emits_ts1120() {
     assert_eq!(ts1120.start, 7, "TS1120 should start at `export` position");
 }
 
+// `declare export = x` outside the top level: tsc's own placement diagnostic
+// for the `ExportAssignment` node wins instead of TS1120 — TS1063 ("An export
+// assignment cannot be used in a namespace.") in a namespace body, TS1231
+// ("An export assignment must be at the top level of a file or module
+// declaration.") in a Block. Both are checker-emitted (this crate only
+// verifies the parser stays silent), oracle-pinned against `typescript@7.0.2`
+// (`--strict --target es2022 --module es2022`). Residual left by #16440 for
+// the sibling `default <expr>` assignment form on this same match arm.
+
+#[test]
+fn export_assignment_with_declare_modifier_in_namespace_emits_no_ts1120() {
+    let source = "namespace N { declare export = 1; }";
+    let (parser, _root) = parse_source(source);
+    let codes: Vec<u32> = parser.get_diagnostics().iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&1120),
+        "Expected no TS1120 for `declare export = x` in a namespace body (tsc: TS1063 alone), got: {codes:?}"
+    );
+}
+
+#[test]
+fn export_assignment_with_declare_modifier_in_nested_namespace_emits_no_ts1120() {
+    let source = "namespace Outer { namespace Inner { declare export = 1; } }";
+    let (parser, _root) = parse_source(source);
+    let codes: Vec<u32> = parser.get_diagnostics().iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&1120),
+        "Expected no TS1120 for `declare export = x` in a nested namespace body, got: {codes:?}"
+    );
+}
+
+#[test]
+fn export_assignment_with_declare_modifier_in_block_emits_no_ts1120() {
+    let source = "function outer() { declare export = 1; }";
+    let (parser, _root) = parse_source(source);
+    let codes: Vec<u32> = parser.get_diagnostics().iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&1120),
+        "Expected no TS1120 for `declare export = x` in a Block (tsc: TS1231 alone), got: {codes:?}"
+    );
+}
+
 /// `import\nimport { foo } from './0';` — the first `import` has no clause and a reserved
 /// keyword (`import`) follows on the next line. tsc emits TS1109 "Expression expected" at
 /// the second `import` position (the module specifier path fails to find a string literal)


### PR DESCRIPTION
Closes the exact residual #16440's own PR body disclosed and deliberately left, on the sibling arm of the same match statement it fixed.

## Structural rule

`declare export = expr` (an `ExportAssignment` carrying illegal modifiers) gets two independent diagnostics from tsc depending on where it appears, and only one of them ever fires at once:

- At the top level, the `ExportAssignment` node itself is valid there, so its only problem is the modifiers: tsc reports `TS1120` ("An export assignment cannot have modifiers.") alone.
- In a namespace body, the node's own placement is already illegal (an export assignment cannot be used inside a namespace at all), so tsc reports `TS1063` ("An export assignment cannot be used in a namespace.") alone — the modifier diagnostic never fires alongside it.
- In a `Block`, same shape: tsc reports `TS1231` ("An export assignment must be at the top level of a file or module declaration.") alone.

This is the identical "own placement diagnostic silences the modifier diagnostic outside top level" rule #16440 built for the sibling `default <expr>` assignment form a few lines below this arm in the same `match self.token()` — #16440's PR body named this exact spot as a disclosed, unfixed residual: "the same shape this PR just built for `default`, but on the sibling `EqualsToken` arm a few lines up in the same match, untouched."

**Owner layer:** parser only, `crates/tsz-parser/src/parser/state_declarations.rs`, `parse_ambient_declaration_with_modifiers`'s `EqualsToken` arm. `TS1063`/`TS1231` are checker-emitted (`crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs`) — this PR only stops the parser's own unconditional `TS1120` from firing alongside them; no checker change.

## Oracle verification (`typescript@7.0.2`, `--strict --target es2022 --module es2022`)

| case | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `namespace N { declare export = 1; }` | TS1063 | TS1063 **+ TS1120** | **TS1063 ✅** |
| `namespace Outer { namespace Inner { declare export = 1; } }` | TS1063 | TS1063 **+ TS1120** | **TS1063 ✅** |
| `function outer() { declare export = 1; }` (Block) | TS1231 | TS1231 **+ TS1120** | **TS1231 ✅** |
| `declare export = 1;` (top level) | TS1120 (+unrelated TS2714) | TS1120 (unchanged) | TS1120 (unchanged, negative control) |
| `var x;\nexport declare export = x;` (top level, both modifiers) | TS1120 anchored at `export` | TS1120 anchored at `export` | TS1120 anchored at `export` (unchanged, negative control — node span preserved) |

## Adjacent-case matrix

New tests in `crates/tsz-parser/tests/state_declaration_tests.rs`: namespace body, nested namespace body, and Block, each asserting the parser no longer emits `TS1120`. Existing top-level tests (`declare export = x`, `export declare export = x`) kept as negative controls pinning the unaffected top-level `TS1120` anchor position exactly as before.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-parser --lib state_declaration_tests`: 80/80 passed (3 new)
- `cargo test -p tsz-parser --lib` (full crate): 1929 passed, 0 failed
- `cargo clippy -p tsz-parser --all-targets -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- `python3 scripts/arch/arch_guard.py`: passed
- Built debug `tsz` binary spot-checked against all 5 oracle rows above — exact match on every row this PR is responsible for
- `scripts/conformance/compare-to-parent.sh` — not run (disclosed, not skipped silently): this is a narrow, always-erroneous ambient-export grammar shape (`declare export =` outside the top level is illegal in every container); the change can only move a corpus row that already contains this exact stray-modifier combination from a wrong diagnostic to the correct one, and cannot introduce a new false positive on ordinary code. Same class of change and same disclosure #16440 made for the sibling `default` arm.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpHkJe9gY5jrSRsqy8kRRJ)_