### PR TITLE
tool(conformance): add oracle.sh, a manual tsc spot-check matching the cache

### DIFF
--- a/scripts/conformance/oracle.sh
+++ b/scripts/conformance/oracle.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Run the pinned tsc oracle with the exact flags the conformance cache
+# generator uses, so a manual spot-check agrees with what
+# compare-to-parent.sh/conformance.sh actually score.
+#
+# Without this, a plain `tsc file.ts` can silently disagree with the cache:
+# typescript@7.0.2 (typescript-go) reports different diagnostics for an
+# unlabeled/bare block statement depending on --singleThreaded, which
+# generate-tsc-cache.rs always passes for TypeScript 7+ (see #16413). This
+# wrapper reproduces that exact invocation shape so the two never diverge.
+#
+# Uses a small dedicated scratch install (not scripts/node_modules) so a
+# cold container only fetches the `typescript` package itself, not every
+# unrelated dependency in scripts/package.json.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERSIONS_FILE="$SCRIPT_DIR/typescript-versions.json"
+CACHE_DIR="${TSZ_ORACLE_CACHE_DIR:-${TMPDIR:-/tmp}/tsz-oracle}"
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/conformance/oracle.sh <file.ts> [extra tsc flags...]
+
+Runs the pinned typescript-go oracle (scripts/conformance/typescript-versions.json)
+with the same --singleThreaded/--stableTypeOrdering flags the conformance cache
+generator uses for TypeScript 7+, so the result matches what
+compare-to-parent.sh / conformance.sh actually score.
+
+Installs the pinned TypeScript into a small scratch cache dir on first use
+(override with TSZ_ORACLE_CACHE_DIR), separate from scripts/node_modules.
+
+Example:
+  scripts/conformance/oracle.sh case.ts --strict --lib es2022 --target es2022
+EOF
+}
+
+if [ $# -lt 1 ] || [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
+    usage
+    exit "$([ $# -lt 1 ] && echo 2 || echo 0)"
+fi
+
+FILE="$1"
+shift
+
+if [ ! -f "$VERSIONS_FILE" ]; then
+    echo "ERROR: Missing versions file: $VERSIONS_FILE" >&2
+    exit 1
+fi
+
+PINNED_VERSION="$(node -e "const fs = require('fs'); const cfg = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); const current = cfg.current || ''; const mapped = current && cfg.mappings && cfg.mappings[current] && cfg.mappings[current].npm; const fallback = cfg.default && cfg.default.npm; process.stdout.write(mapped || fallback || '');" "$VERSIONS_FILE")"
+
+if [ -z "$PINNED_VERSION" ]; then
+    echo "ERROR: Could not resolve pinned TypeScript version from $VERSIONS_FILE" >&2
+    exit 1
+fi
+
+mkdir -p "$CACHE_DIR"
+INSTALLED_VERSION=""
+PACKAGE_JSON="$CACHE_DIR/node_modules/typescript/package.json"
+if [ -f "$PACKAGE_JSON" ]; then
+    INSTALLED_VERSION="$(node -e "try { process.stdout.write(require(process.argv[1]).version); } catch {}" "$PACKAGE_JSON")"
+fi
+
+if [ "$INSTALLED_VERSION" != "$PINNED_VERSION" ]; then
+    echo "# installing pinned typescript@$PINNED_VERSION into $CACHE_DIR ..." >&2
+    (cd "$CACHE_DIR" && npm install --silent --no-audit --no-fund --no-save --no-package-lock "typescript@${PINNED_VERSION}" >&2)
+fi
+
+TSC_JS="$CACHE_DIR/node_modules/typescript/lib/tsc.js"
+if [ ! -f "$TSC_JS" ]; then
+    echo "ERROR: pinned tsc not found at $TSC_JS after install" >&2
+    exit 1
+fi
+
+TSC_MAJOR="${PINNED_VERSION%%.*}"
+EXTRA_FLAGS=()
+if [ "$TSC_MAJOR" -ge 7 ] 2>/dev/null; then
+    EXTRA_FLAGS+=(--singleThreaded --stableTypeOrdering true)
+fi
+
+echo "# oracle: typescript@$PINNED_VERSION ${EXTRA_FLAGS[*]:-}" >&2
+exec node "$TSC_JS" --noEmit --pretty false "${EXTRA_FLAGS[@]}" "$@" "$FILE"


### PR DESCRIPTION
## Goal
Goal: hold

Root-caused #16413 (the conformance cache and a hand-run `tsc` oracle disagreeing on `moduleElementsInWrongContext.ts`): `crates/conformance/src/bin/generate-tsc-cache.rs` always adds `--singleThreaded --stableTypeOrdering true` for TypeScript 7+ (needed for deterministic parallel cache generation). `typescript@7.0.2` (typescript-go) genuinely reports different diagnostics under `--singleThreaded` than under its default concurrent scheduling — isolated to a minimal 2-line repro, and scoped to exactly one container:

```ts
{
    export { a } from "m";
}
```

`--noEmit --target es2015`: default gives `TS1233` alone; adding `--singleThreaded` adds `TS2307` ("Cannot find module 'm'"). The same statement wrapped in a function body or nested inside a namespace does not pick up the extra code under `--singleThreaded` — only an unlabeled/bare block does. Full evidence on #16413.

**Structural rule:** the conformance cache is generated with `--singleThreaded --stableTypeOrdering true`, and `compare-to-parent.sh`/`conformance.sh` score against that cache — so that invocation shape is the actual oracle, not `tsc file.ts` alone. The board's documented "cheap oracle" recipe (`node .../tsc.js --noEmit --strict --lib es2022 --target es2022 case.ts`) and #16413's own CLI table both omit `--singleThreaded`, so a hand-verified fix can look correct and still disagree with what the corpus gate measures — which is exactly what happened to #16409/#16411.

This PR adds `scripts/conformance/oracle.sh`, a thin wrapper that:
- Resolves the pinned TypeScript version from `scripts/conformance/typescript-versions.json` (the same source of truth `ensure-pinned-typescript.sh` uses).
- Installs it into a small dedicated scratch cache dir (`${TSZ_ORACLE_CACHE_DIR:-$TMPDIR/tsz-oracle}`), not `scripts/node_modules` — reusing `scripts/`'s own `package.json` as the install target would pull in every unrelated dependency there (`@google/generative-ai`, etc.) on a cold container, turning a ~3s check into a multi-minute one.
- Adds `--singleThreaded --stableTypeOrdering true` for TypeScript 7+, matching `generate-tsc-cache.rs`'s exact flag logic.

No production code changes; this only adds a verification tool.

## Verification
- `bash -n scripts/conformance/oracle.sh`: clean.
- Cold run (`rm -rf /tmp/tsz-oracle`): installs the pinned `typescript@7.0.2` in ~3.4s, then reports `TS1233 + TS2307` on the minimal bare-block repro above — matches the `--singleThreaded` oracle exactly. A cached re-run completes in ~0.75s.
- Ran it against the real `moduleElementsInWrongContext.ts` fixture (fetched from the pinned corpus SHA): output is byte-identical (codes, lines, columns, up to the `// @target` header's one-line offset) to the committed `scripts/conformance/tsc-cache-full.json` entry for `compiler/moduleElementsInWrongContext.ts` (`TS2305@19/27:14`, `TS2307@24:25` in the header-stripped cache coordinates).
- Test-only/tooling diff — no `crates/**/src` path touched, so conformance/emit counts cannot move; not run.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4hdqx33SvsBTiww4oYaX2)_