### PR TITLE
feat(checker): an object-literal property mismatch carries tsc's TS6500 `The expected type comes from property ...` pointer

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
@@ -228,6 +228,12 @@ impl<'a> CheckerState<'a> {
         let mut emitted_duplicate_primary: rustc_hash::FxHashSet<String> =
             rustc_hash::FxHashSet::default();
 
+        // The object type that DECLARES the members being elaborated. tsc's
+        // TS6500 pointer names this type and anchors in its declaration, so the
+        // candidates are the target as narrowed for elaboration first, then the
+        // target as written — never a property's own type.
+        let expected_type_owners = [effective_param_type, param_type];
+
         for &elem_idx in &obj.elements.nodes {
             let Some(elem_node) = self.ctx.arena.get(elem_idx) else {
                 continue;
@@ -465,10 +471,16 @@ impl<'a> CheckerState<'a> {
                             first_name_idx,
                         );
                     }
-                    self.error_type_not_assignable_at_with_display_types(
-                        source_prop_type_for_diagnostic,
-                        target_for_diag,
-                        prop_name_idx,
+                    self.with_expected_type_from_property_pointer(
+                        &expected_type_owners,
+                        &prop_name,
+                        |this| {
+                            this.error_type_not_assignable_at_with_display_types(
+                                source_prop_type_for_diagnostic,
+                                target_for_diag,
+                                prop_name_idx,
+                            );
+                        },
                     );
                     elaborated = true;
                     continue;
@@ -516,10 +528,16 @@ impl<'a> CheckerState<'a> {
                     // Keep the source/target display types stable for duplicate
                     // properties; anchor at the property name so both duplicate
                     // declarations can surface their own TS2322 positions.
-                    self.error_type_not_assignable_at_with_display_types(
-                        source_prop_type_for_diagnostic,
-                        target_for_diag,
-                        prop_name_idx,
+                    self.with_expected_type_from_property_pointer(
+                        &expected_type_owners,
+                        &prop_name,
+                        |this| {
+                            this.error_type_not_assignable_at_with_display_types(
+                                source_prop_type_for_diagnostic,
+                                target_for_diag,
+                                prop_name_idx,
+                            );
+                        },
                     );
                     elaborated = true;
                     continue;
@@ -542,10 +560,16 @@ impl<'a> CheckerState<'a> {
                     .get(prop_value_idx)
                     .is_some_and(|n| n.kind == syntax_kind_ext::METHOD_DECLARATION);
                 if is_method {
-                    self.error_type_not_assignable_at_with_anchor(
-                        source_prop_type_for_diagnostic,
-                        target_for_diag,
-                        prop_name_idx,
+                    self.with_expected_type_from_property_pointer(
+                        &expected_type_owners,
+                        &prop_name,
+                        |this| {
+                            this.error_type_not_assignable_at_with_anchor(
+                                source_prop_type_for_diagnostic,
+                                target_for_diag,
+                                prop_name_idx,
+                            );
+                        },
                     );
                 } else {
                     // For arrow/function expression property values, try deeper
@@ -618,10 +642,16 @@ impl<'a> CheckerState<'a> {
                             body_idx,
                         );
                     } else {
-                        self.error_type_not_assignable_at_with_anchor(
-                            source_prop_type_for_diagnostic,
-                            target_for_diag,
-                            prop_name_idx,
+                        self.with_expected_type_from_property_pointer(
+                            &expected_type_owners,
+                            &prop_name,
+                            |this| {
+                                this.error_type_not_assignable_at_with_anchor(
+                                    source_prop_type_for_diagnostic,
+                                    target_for_diag,
+                                    prop_name_idx,
+                                );
+                            },
                         );
                     }
                 }
@@ -873,18 +903,30 @@ impl<'a> CheckerState<'a> {
                         None
                     };
                     if target_prop_type != target_prop_type_for_diagnostic {
-                        self.error_type_not_assignable_at_with_display_types(
-                            source_prop_type_for_diagnostic,
-                            target_prop_type_for_diagnostic,
-                            prop_name_idx,
+                        self.with_expected_type_from_property_pointer(
+                            &expected_type_owners,
+                            &prop_name,
+                            |this| {
+                                this.error_type_not_assignable_at_with_display_types(
+                                    source_prop_type_for_diagnostic,
+                                    target_prop_type_for_diagnostic,
+                                    prop_name_idx,
+                                );
+                            },
                         );
                     } else {
-                        self.error_type_not_assignable_at_with_anchor_elaboration_inner_with_value_anchor(
-                            source_prop_type_for_diagnostic,
-                            target_prop_type_for_diagnostic,
-                            prop_name_idx,
-                            value_anchor_for_missing_props,
-                            value_is_this_keyword,
+                        self.with_expected_type_from_property_pointer(
+                            &expected_type_owners,
+                            &prop_name,
+                            |this| {
+                                this.error_type_not_assignable_at_with_anchor_elaboration_inner_with_value_anchor(
+                                    source_prop_type_for_diagnostic,
+                                    target_prop_type_for_diagnostic,
+                                    prop_name_idx,
+                                    value_anchor_for_missing_props,
+                                    value_is_this_keyword,
+                                );
+                            },
                         );
                     }
                 }

--- a/crates/tsz-checker/src/error_reporter/expected_type_from_property.rs
+++ b/crates/tsz-checker/src/error_reporter/expected_type_from_property.rs
@@ -1,0 +1,103 @@
+use crate::diagnostics::{Diagnostic, diagnostic_codes, diagnostic_messages, format_message};
+use crate::state::CheckerState;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    /// Attach tsc's `The expected type comes from property '{0}' which is
+    /// declared here on type '{1}'` (TS6500) pointer to every `TS2322` pushed
+    /// since `since`.
+    ///
+    /// tsc's `elaborateElementwise` adds this related entry to the diagnostic it
+    /// just reported for an object-literal member, pointing at the *target*
+    /// property's own declaration. It is the elaboration's own leaf report that
+    /// carries the pointer: when the recursion drilled further (a nested
+    /// literal, an array element, an arrow body) the inner frame already owns
+    /// the user's attention and tsc's `!issuedElaboration` guard suppresses the
+    /// outer one. Callers therefore invoke this only around a leaf emit, never
+    /// around a recursive elaboration that returned `true`.
+    ///
+    /// `owner_candidates` are the target types the caller already has in hand;
+    /// the first that resolves to a declaration owning a member with this name
+    /// wins. When none does — an anonymous shape with no symbol, an index
+    /// signature, a synthesized member — nothing is attached and output is left
+    /// exactly as it was rather than guessing at a declaration.
+    /// Run `emit` — an object-literal member's *leaf* report — and attach the
+    /// TS6500 pointer to whatever `TS2322` it produced.
+    ///
+    /// Wrapping the emit rather than editing each emitter keeps the pointer tied
+    /// to the one decision that governs it: this frame, not a deeper one, is the
+    /// frame tsc reported at.
+    pub(crate) fn with_expected_type_from_property_pointer(
+        &mut self,
+        owner_candidates: &[TypeId],
+        property_name: &str,
+        emit: impl FnOnce(&mut Self),
+    ) {
+        let before = self.ctx.diagnostics.len();
+        emit(self);
+        self.attach_expected_type_from_property_pointer(before, owner_candidates, property_name);
+    }
+
+    pub(crate) fn attach_expected_type_from_property_pointer(
+        &mut self,
+        since: usize,
+        owner_candidates: &[TypeId],
+        property_name: &str,
+    ) {
+        if self.ctx.diagnostics.len() <= since {
+            return;
+        }
+        let Some(related) =
+            self.expected_type_from_property_related(owner_candidates, property_name)
+        else {
+            return;
+        };
+        for diagnostic in self.ctx.diagnostics.iter_mut().skip(since) {
+            if diagnostic.code != diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE {
+                continue;
+            }
+            // A leaf report that already carries a location pointer got it from
+            // a deeper frame; tsc keeps that one rather than stacking a second.
+            if diagnostic
+                .related_information
+                .iter()
+                .any(|entry| entry.is_location_pointer())
+            {
+                continue;
+            }
+            diagnostic.related_information.push(related.clone());
+        }
+    }
+
+    /// Build the TS6500 related entry for `property_name` on the first of
+    /// `owner_candidates` whose declaration carries that member.
+    ///
+    /// The anchor is the same one TS2728 uses (the member's name node, or the
+    /// whole member for an interface method signature), but the *name* is
+    /// rendered differently: tsc formats TS6500's operand through
+    /// `symbolToString`, so a string-literal member reads `property 'two-part'`
+    /// where TS2728 reads `'"two-part"' is declared here.`. Passing the interned
+    /// property name — not the primary diagnostic's display string — is what
+    /// keeps the two apart.
+    fn expected_type_from_property_related(
+        &mut self,
+        owner_candidates: &[TypeId],
+        property_name: &str,
+    ) -> Option<crate::diagnostics::DiagnosticRelatedInformation> {
+        owner_candidates.iter().find_map(|&owner| {
+            let (start, length, file) =
+                self.member_declaration_anchor_for_owner(owner, property_name)?;
+            let owner_display = self.format_type_for_assignability_message(owner);
+            Some(Diagnostic::related_pointer(
+                diagnostic_codes::THE_EXPECTED_TYPE_COMES_FROM_PROPERTY_WHICH_IS_DECLARED_HERE_ON_TYPE,
+                file.unwrap_or_else(|| self.ctx.file_name.clone()),
+                start,
+                length,
+                format_message(
+                    diagnostic_messages::THE_EXPECTED_TYPE_COMES_FROM_PROPERTY_WHICH_IS_DECLARED_HERE_ON_TYPE,
+                    &[property_name, &owner_display],
+                ),
+            ))
+        })
+    }
+}

--- a/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
+++ b/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
@@ -48,6 +48,30 @@ impl<'a> CheckerState<'a> {
         property: &str,
         property_display: &str,
     ) -> Option<DiagnosticRelatedInformation> {
+        let (start, length, file) = self.member_declaration_anchor_for_owner(owner, property)?;
+        Some(Diagnostic::related_pointer(
+            diagnostic_codes::IS_DECLARED_HERE,
+            file.unwrap_or_else(|| self.ctx.file_name.clone()),
+            start,
+            length,
+            format_message(diagnostic_messages::IS_DECLARED_HERE, &[property_display]),
+        ))
+    }
+
+    /// `(start, length, file)` of the anchor tsc underlines for `property`'s own
+    /// declaration on `owner`, or `None` when `owner` does not resolve to a
+    /// declaration carrying that member.
+    ///
+    /// Shared by every pointer that names a member declaration — TS2728's
+    /// `'x' is declared here.` and TS6500's `The expected type comes from
+    /// property 'x' …` anchor identically, so the walk lives here once rather
+    /// than being re-derived per diagnostic. Only the code, message, and
+    /// name rendering differ between them, and those belong to the caller.
+    pub(super) fn member_declaration_anchor_for_owner(
+        &mut self,
+        owner: TypeId,
+        property: &str,
+    ) -> Option<(u32, u32, Option<String>)> {
         let owner_symbol = self.ctx.resolve_type_to_symbol_id(owner).or_else(|| {
             crate::query_boundaries::common::type_shape_symbol(self.ctx.types, owner)
         })?;
@@ -80,13 +104,7 @@ impl<'a> CheckerState<'a> {
             else {
                 continue;
             };
-            return Some(Diagnostic::related_pointer(
-                diagnostic_codes::IS_DECLARED_HERE,
-                file.unwrap_or_else(|| self.ctx.file_name.clone()),
-                start,
-                length,
-                format_message(diagnostic_messages::IS_DECLARED_HERE, &[property_display]),
-            ));
+            return Some((start, length, file));
         }
         for location in member_locations {
             let Some((start, length, file)) =
@@ -94,13 +112,7 @@ impl<'a> CheckerState<'a> {
             else {
                 continue;
             };
-            return Some(Diagnostic::related_pointer(
-                diagnostic_codes::IS_DECLARED_HERE,
-                file.unwrap_or_else(|| self.ctx.file_name.clone()),
-                start,
-                length,
-                format_message(diagnostic_messages::IS_DECLARED_HERE, &[property_display]),
-            ));
+            return Some((start, length, file));
         }
         None
     }

--- a/crates/tsz-checker/src/error_reporter/mod.rs
+++ b/crates/tsz-checker/src/error_reporter/mod.rs
@@ -35,6 +35,7 @@ mod core_alias_display;
 mod core_formatting;
 pub(crate) mod display_budget;
 mod emitters;
+mod expected_type_from_property;
 mod fingerprint_policy;
 mod generic_display_helpers;
 mod generics;

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -275,6 +275,8 @@ mod error_reporter_assignability_display_boundary_arch_tests;
 mod excess_prop_object_union_display_tests;
 #[path = "tests/expando_annotated_receiver_tests.rs"]
 mod expando_annotated_receiver_tests;
+#[path = "tests/expected_type_from_property_tests.rs"]
+mod expected_type_from_property_tests;
 #[path = "tests/explicit_alias_constraint_relation_routing_arch_tests.rs"]
 mod explicit_alias_constraint_relation_routing_arch_tests;
 #[path = "tests/explicit_type_arg_overload_pruning_tests.rs"]

--- a/crates/tsz-checker/src/tests/expected_type_from_property_tests.rs
+++ b/crates/tsz-checker/src/tests/expected_type_from_property_tests.rs
@@ -1,0 +1,315 @@
+//! Regression tests for the `TS6500` `The expected type comes from property
+//! '{0}' which is declared here on type '{1}'` pointer that tsc attaches to the
+//! per-property leaf of an object-literal assignment.
+//!
+//! Structural rule (pinned against `typescript@7.0.2`, the conformance pin):
+//! when an object-literal member's value fails assignment to the target
+//! property's declared type, tsc's `elaborateElementwise` anchors the `TS2322`
+//! at the member's name and attaches a related-information pointer at the
+//! *target* property's own declaration. When the elaboration drilled further —
+//! an array element, an arrow body — the inner frame owns the report and tsc's
+//! `!issuedElaboration` guard emits no pointer at this level.
+//!
+//! Two divergences from the sibling `TS2728` pointer, both oracle-pinned and
+//! both load-bearing:
+//!
+//! * `TS6500`'s property operand goes through tsc's `symbolToString`, so a
+//!   string-literal member reads `property 'two-part'` where `TS2728` reads
+//!   `'"two-part"' is declared here.`.
+//! * the message carries no trailing period.
+//!
+//! Three shapes deliberately produce **no** pointer rather than a guessed one,
+//! and are pinned negatively below so they cannot regress into a wrong anchor:
+//! an index-signature target (tsc: `TS6501`), a contextual return type inside a
+//! property initializer (tsc: `TS6502`), and an owner that is an anonymous
+//! object type — a type alias to a type literal, or a nested literal — whose
+//! declaration the binder mints no symbol for (#16443).
+
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::check_source_diagnostics;
+use tsz_common::diagnostics::diagnostic_codes;
+
+const TS2322: u32 = diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE;
+const TS6500: u32 =
+    diagnostic_codes::THE_EXPECTED_TYPE_COMES_FROM_PROPERTY_WHICH_IS_DECLARED_HERE_ON_TYPE;
+
+fn only(diags: &[Diagnostic], code: u32) -> Diagnostic {
+    let matching: Vec<_> = diags.iter().filter(|d| d.code == code).collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected exactly one TS{code}; got {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+    matching[0].clone()
+}
+
+/// The pointer's `(file, start, length)` plus its message, so each case can
+/// assert the anchor lands on the declared member and nothing wider.
+fn expected_type_pointer(diagnostic: &Diagnostic) -> (String, u32, u32, String) {
+    let pointers: Vec<_> = diagnostic
+        .related_information
+        .iter()
+        .filter(|info| info.code == TS6500)
+        .collect();
+    assert_eq!(
+        pointers.len(),
+        1,
+        "expected exactly one TS6500 pointer; got {:?}",
+        diagnostic
+            .related_information
+            .iter()
+            .map(|info| (info.code, info.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+    (
+        pointers[0].file.clone(),
+        pointers[0].start,
+        pointers[0].length,
+        pointers[0].message_text.clone(),
+    )
+}
+
+fn has_pointer(diagnostic: &Diagnostic) -> bool {
+    diagnostic
+        .related_information
+        .iter()
+        .any(|info| info.code == TS6500)
+}
+
+fn span_text(source: &str, start: u32, length: u32) -> &str {
+    &source[start as usize..(start + length) as usize]
+}
+
+/// The pointer models tsc's `relatedInformation`, not a `messageText` chain
+/// link. Oracled on `typescript@7.0.2`: `--pretty false` prints the `TS2322`
+/// line alone, `--pretty` prints the pointer with its own location and snippet.
+/// Only the tag distinguishes the two — a chain link carries a real file and a
+/// real span exactly as this entry does.
+#[test]
+fn expected_type_pointer_is_tagged_as_a_cross_location_pointer() {
+    let source = "interface Outer { inner: string; }\nconst r: Outer = { inner: 1 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    let pointer = diagnostic
+        .related_information
+        .iter()
+        .find(|info| info.code == TS6500)
+        .expect("TS6500 pointer");
+    assert!(
+        pointer.is_location_pointer(),
+        "TS6500 must be a cross-location pointer: {pointer:?}"
+    );
+    assert!(
+        diagnostic
+            .related_information
+            .iter()
+            .filter(|info| info.code != TS6500)
+            .all(|info| !info.is_location_pointer()),
+        "elaboration links on the same diagnostic stay chain links: {diagnostic:?}"
+    );
+}
+
+#[test]
+fn interface_property_points_at_its_declaration() {
+    let source = "interface Outer { inner: string; keep: number; }\nconst r: Outer = { inner: 1, keep: 2 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    let (file, start, length, message) = expected_type_pointer(&diagnostic);
+    assert_eq!(
+        message,
+        "The expected type comes from property 'inner' which is declared here on type 'Outer'"
+    );
+    assert_eq!(span_text(source, start, length), "inner");
+    assert_eq!(file, "test.ts");
+}
+
+/// Binder names must not matter: the anchor comes from the target's own member
+/// table, not from a name match against the reported text.
+#[test]
+fn renamed_binders_point_at_the_renamed_declaration() {
+    let source = "interface Coord { alpha: string; omega: number; }\nconst c: Coord = { alpha: 1, omega: 2 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    let (_, start, length, message) = expected_type_pointer(&diagnostic);
+    assert_eq!(
+        message,
+        "The expected type comes from property 'alpha' which is declared here on type 'Coord'"
+    );
+    assert_eq!(span_text(source, start, length), "alpha");
+}
+
+#[test]
+fn class_property_points_at_its_declaration() {
+    let source = "class Klass { field: string = \"\"; other = 0; }\nconst k: Klass = { field: 3, other: 4 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    let (_, start, length, message) = expected_type_pointer(&diagnostic);
+    assert_eq!(
+        message,
+        "The expected type comes from property 'field' which is declared here on type 'Klass'"
+    );
+    assert_eq!(span_text(source, start, length), "field");
+}
+
+/// A call argument reaches the same elaboration as a direct assignment, so the
+/// pointer follows the parameter's declared type rather than the call site.
+#[test]
+fn call_argument_property_points_at_the_parameter_type_declaration() {
+    let source =
+        "interface ArgT { q: string; }\nfunction take(a: ArgT) { return a; }\ntake({ q: 8 });\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    let (_, start, length, message) = expected_type_pointer(&diagnostic);
+    assert_eq!(
+        message,
+        "The expected type comes from property 'q' which is declared here on type 'ArgT'"
+    );
+    assert_eq!(span_text(source, start, length), "q");
+}
+
+/// An interface *method signature* is underlined whole, semicolon included —
+/// the same anchor rule `TS2728` follows, and the reason both share one walk.
+#[test]
+fn method_signature_member_is_underlined_whole() {
+    let source = "interface M { run(x: number): void; }\nconst m: M = { run: 1 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    let (_, start, length, message) = expected_type_pointer(&diagnostic);
+    assert_eq!(
+        message,
+        "The expected type comes from property 'run' which is declared here on type 'M'"
+    );
+    assert_eq!(span_text(source, start, length), "run(x: number): void;");
+}
+
+/// The quoted-name divergence from `TS2728`: the underline keeps the quotes the
+/// member was written with, the message does not.
+#[test]
+fn string_literal_member_name_is_unquoted_in_the_message_and_quoted_in_the_anchor() {
+    let source = "interface SL { \"two-part\": string; }\nconst sl: SL = { \"two-part\": 2 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    let (_, start, length, message) = expected_type_pointer(&diagnostic);
+    assert_eq!(
+        message,
+        "The expected type comes from property 'two-part' which is declared here on type 'SL'"
+    );
+    assert_eq!(span_text(source, start, length), "\"two-part\"");
+}
+
+#[test]
+fn optional_member_points_at_its_name_not_its_question_mark() {
+    let source = "interface Opt { maybe?: string; }\nconst o: Opt = { maybe: 3 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    let (_, start, length, message) = expected_type_pointer(&diagnostic);
+    assert_eq!(
+        message,
+        "The expected type comes from property 'maybe' which is declared here on type 'Opt'"
+    );
+    assert_eq!(span_text(source, start, length), "maybe");
+}
+
+/// A union-typed member still resolves through the same member table; the
+/// owner display is the declaring type, never the member's own type.
+#[test]
+fn union_typed_member_names_the_declaring_type() {
+    let source = "interface Union { u: string | number; }\nconst un: Union = { u: true };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    let (_, _, _, message) = expected_type_pointer(&diagnostic);
+    assert_eq!(
+        message,
+        "The expected type comes from property 'u' which is declared here on type 'Union'"
+    );
+}
+
+/// A property declared in another file points into *that* file. The owner
+/// symbol is read out of the binder that declares it, so a per-file binder's
+/// raw `SymbolId` cannot anchor the pointer in the checking file by accident.
+#[test]
+fn cross_file_property_points_into_the_declaring_file() {
+    const DEP: &str = "export interface Cross { one: string; }\n";
+    const ENTRY: &str = "import { Cross } from \"./dep\";\nconst c: Cross = { one: 1 };\n";
+    let diagnostics = crate::test_utils::check_multi_file_with_libs_stamped(
+        &[("dep.ts", DEP), ("test.ts", ENTRY)],
+        "test.ts",
+        crate::context::CheckerOptions::default(),
+        &[],
+    );
+    let diagnostic = only(&diagnostics, TS2322);
+    let (file, start, length, message) = expected_type_pointer(&diagnostic);
+    assert_eq!(
+        message,
+        "The expected type comes from property 'one' which is declared here on type 'Cross'"
+    );
+    assert_eq!(span_text(DEP, start, length), "one");
+    assert!(
+        file.ends_with("dep.ts"),
+        "pointer must name the declaring file, got {file}"
+    );
+}
+
+// --- negative rows: no pointer beats a guessed one -------------------------
+
+/// tsc reports `TS6501` (`The expected type comes from this index signature.`)
+/// here, not `TS6500`. Until that sibling is wired, the correct output is no
+/// pointer at all rather than one naming a property that was never declared.
+#[test]
+fn index_signature_target_gets_no_property_pointer() {
+    let source = "interface Idx { [k: string]: string; }\nconst ix: Idx = { any: 5 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    assert!(
+        !has_pointer(&diagnostic),
+        "an index-signature target must not claim a declared property: {diagnostic:?}"
+    );
+}
+
+/// tsc reports `TS6502` (`The expected type comes from the return type of this
+/// signature.`) at the arrow's return, anchored at the signature — a different
+/// code at a different anchor, so the property pointer must stay off.
+#[test]
+fn contextual_return_type_mismatch_gets_no_property_pointer() {
+    let source = "interface Ret { cb: () => string; }\nconst rt: Ret = { cb: () => 6 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    assert!(
+        !has_pointer(&diagnostic),
+        "a return-type frame must not carry the property pointer: {diagnostic:?}"
+    );
+}
+
+/// tsc emits no related entry for an array *element* mismatch: the element is
+/// the frame it reported at, and the enclosing property's `!issuedElaboration`
+/// guard suppresses the outer pointer.
+#[test]
+fn array_element_mismatch_gets_no_property_pointer() {
+    let source = "interface Arr { items: string[]; }\nconst ar: Arr = { items: [9] };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    assert!(
+        !has_pointer(&diagnostic),
+        "an array-element frame must not carry the enclosing property's pointer: {diagnostic:?}"
+    );
+}
+
+/// A nested literal reports at the inner property; tsc's pointer then names the
+/// *inner* anonymous type. tsz's owner walk needs a binder symbol and the
+/// binder mints none for a type literal (#16443), so it declines. Pinned so the
+/// day #16443's owner route lands, this row's regression is visible instead of
+/// silently anchoring at the outer `lvl`.
+#[test]
+fn nested_type_literal_owner_declines_rather_than_naming_the_outer_property() {
+    let source = "interface Deep { lvl: { p: string }; }\nconst d: Deep = { lvl: { p: 7 } };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    assert!(
+        !has_pointer(&diagnostic),
+        "an anonymous owner must decline, never fall back to the enclosing property: {diagnostic:?}"
+    );
+}
+
+/// Same root cause as above with the alias spelled out: `type Alias = { .. }`
+/// evaluates to an anonymous object type carrying no symbol, so the walk has no
+/// declaration to anchor in. tsc prints the pointer here.
+#[test]
+fn type_alias_to_type_literal_owner_declines() {
+    let source = "type Alias = { av: string; bv: number };\nconst al: Alias = { av: 5, bv: 6 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    assert!(
+        !has_pointer(&diagnostic),
+        "an alias-to-type-literal owner must decline rather than guess: {diagnostic:?}"
+    );
+}


### PR DESCRIPTION
tsz emits **no** `TS6500` anywhere. `THE_EXPECTED_TYPE_COMES_FROM_PROPERTY_WHICH_IS_DECLARED_HERE_ON_TYPE` has sat in `crates/tsz-common/src/diagnostics/data/parts/part_002.rs:221` with zero construction sites in all of `crates/`, and so have its two siblings `6501`/`6502` on the next two lines. It is the single most common related-information pointer tsc attaches to an object-literal assignment — every per-property mismatch carries one.

Every primary was already byte-exact against `typescript@7.0.2`. The pointer was the whole delta:

```
  a.ts:1:19 - The expected type comes from property 'inner' which is declared here on type 'Outer'
    1 interface Outer { inner: string; keep: number; }
                        ~~~~~
```

## Structural rule

When an object-literal member's value fails assignment to the target property's declared type, tsc's `elaborateElementwise` anchors the `TS2322` at the member's name and attaches a `TS6500` related pointer at the **target property's own declaration**. tsz builds that pointer in the checker's `error_reporter`, from the same declaration walk `missing_property_declared_here` already owns, and declines when the owner does not resolve to a declaration carrying that member.

When the elaboration drilled further — into a nested literal, an array element, an arrow body — the inner frame is the one tsc reported at, and its `!issuedElaboration` guard suppresses the outer pointer. That is why the pointer wraps the **leaf** emits only, never a recursive elaboration that returned `true`.

## Shape of the change

- `missing_property_declared_here.rs`: the owner-resolution + member-anchor walk is extracted to `member_declaration_anchor_for_owner`, returning `(start, length, file)`. TS2728 and TS6500 anchor identically; only the code, message, and name rendering differ, and those stay with each caller. No behaviour change on the TS2728 path.
- `expected_type_from_property.rs` (new, 103 lines): builds the entry and attaches it to `TS2322`s pushed by a wrapped leaf emit. A diagnostic that already carries a location pointer is skipped — a deeper frame supplied it, and tsc does not stack a second.
- `elaboration_object_properties.rs`: the six leaf emits in the per-property loop are wrapped. The owner candidates are the target as narrowed for elaboration and the target as written — never a property's own type.

## Two divergences from the sibling TS2728 pointer

Both oracle-pinned, both load-bearing, both would be wrong if the helper were reused unchanged:

- **Name rendering.** tsc formats TS6500's operand through `symbolToString`, so a string-literal member reads `property 'two-part'` where TS2728 reads `'"two-part"' is declared here.`. Passing the interned property name rather than the primary's display string is what keeps them apart.
- **No trailing period** on the message.

The *anchor* does agree: the member's name node, or the whole member for an interface `METHOD_SIGNATURE` (`run(x: number): void;`, semicolon included).

## Adjacent-case matrix

Oracle: `typescript@7.0.2` (the `scripts/conformance/typescript-versions.json` pin), `--noEmit --strict --pretty --target es2022 --lib es2022`.

| shape | result |
| --- | --- |
| `interface Outer { inner: string; keep: number }` | byte-exact |
| renamed binders (`Coord`/`alpha`/`omega`) | byte-exact |
| `class Klass { field: string = ""; other = 0 }` | byte-exact |
| call argument (`function take(a: ArgT)`, `take({ q: 8 })`) | byte-exact |
| method signature `run(x: number): void;` (underlined whole) | byte-exact |
| string-literal member name `"two-part"` | byte-exact |
| optional member `maybe?: string` | byte-exact |
| union-typed member `u: string \| number` | byte-exact |
| cross-file `export interface Cross` | byte-exact, anchored in `dep.ts` |
| array element (`items: [9]` vs `string[]`) | **no pointer**, matching tsc |
| index signature `[k: string]: string` | **no pointer** — tsc emits `TS6501` (residual) |
| contextual return `cb: () => string` | **no pointer** — tsc emits `TS6502` (residual) |
| `type Alias = { av: string; ... }` | **no pointer** — anonymous owner (residual) |
| nested literal `{ lvl: { p: string } }` | **no pointer** — anonymous owner (residual) |

Every residual is pinned by a **negative** test asserting no pointer, so it cannot regress into a wrong one. The two anonymous-owner rows share one root cause with #16443: the binder mints no symbol for a type literal (`symbol_flags::TYPE_LITERAL` is never set), so the owner walk has no declaration to anchor in. That is the same wall #16446 is taking from the annotation side; if it lands, these two rows are the first thing to re-measure.

## Goal
Goal: hold

## Verification

- `cargo test -p tsz-checker --lib expected_type_from_property` — **15/15** new tests (10 positive rows, 5 negative).
- `cargo test -p tsz-checker --lib` — full crate suite; result appended as a comment when the run lands (it was still in its known long tail at push time, and land-and-continue beats idling on it).
- `cargo fmt` + `cargo clippy` + architecture guard — clean, through the `pre-commit` hook (`Clippy passed. / Architecture guard passed.`).
- CLI diff against the pinned oracle on the two witness files above (`--pretty`): 9 of 14 rows moved from missing-block to byte-identical; **0** rows changed in any other way.

**Conformance and emit provably cannot move, and this is checkable rather than assumed.** `scripts/conformance/lib/results.py::compute_diff` grades `Counter(expected)` vs `Counter(actual)` over error **codes**; `TS6500` never surfaces as a top-level code, and the non-pretty output is byte-identical before and after:

```
$ .target/debug/tsz --noEmit --strict --pretty false --target es2022 --lib es2022 a.ts
a.ts(2,20): error TS2322: Type 'number' is not assignable to type 'string'.
a.ts(5,20): error TS2322: Type 'number' is not assignable to type 'string'.
a.ts(8,21): error TS2322: Type 'number' is not assignable to type 'string'.
a.ts(11,26): error TS2322: Type 'number' is not assignable to type 'string'.
a.ts(15,8): error TS2322: Type 'number' is not assignable to type 'string'.
a.ts(18,27): error TS2322: Type 'number' is not assignable to type 'string'.
```

— identical to the oracle's own plain run, and identical to tsz's output before this change. The diff adds related information to existing diagnostics and touches no emitter path, no type computation, and no relation.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Stibnite

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKPWdG7G3bHyND2deAENFc)_