### PR TITLE
fix(checker): async modifier order violation silences the async-illegal-here diagnostic (#16403)

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
@@ -36,13 +36,67 @@ impl<'a> CheckerState<'a> {
         modifiers: &Option<tsz_parser::parser::NodeList>,
     ) {
         use crate::diagnostics::diagnostic_codes;
-        if let Some(async_mod_idx) = self.find_async_modifier(modifiers) {
-            self.error_at_node(
-                async_mod_idx,
-                "'async' modifier cannot be used here.",
-                diagnostic_codes::MODIFIER_CANNOT_BE_USED_HERE,
-            );
+        let Some(async_mod_idx) = self.find_async_modifier(modifiers) else {
+            return;
+        };
+        // tsc's `checkGrammarModifiers` reports at most one diagnostic per
+        // modifier list and returns immediately after: for `async export
+        // class C {}` (`async` misordered before `export`) it reports only
+        // the order violation (TS1029, anchored on `export`) and never goes
+        // on to ask whether `async` is legal on this declaration kind at
+        // all. tsz's parser reports that same TS1029 eagerly during parsing
+        // (`look_ahead_async_before_export_target` /
+        // `parse_statement_async_declaration_or_expression`, #16403 slice
+        // 3) — before this class/interface/enum/namespace's own modifier
+        // list even exists as a checked unit — so this independent checker
+        // pass has no AST field to read "did it already fire" back from.
+        // Re-derive it from position instead, the same way
+        // `check_export_declaration`'s TS1319 dedup does for the sibling
+        // `declare export default` shape: any parse-diagnostic position
+        // strictly inside this modifier list's own span can only be the
+        // order-violation grammar check tsc already reported for this exact
+        // node, since the declaration body (where an unrelated parse error
+        // could otherwise land) starts only after the last modifier.
+        if self.modifier_run_already_has_parse_error(modifiers) {
+            return;
         }
+        self.error_at_node(
+            async_mod_idx,
+            "'async' modifier cannot be used here.",
+            diagnostic_codes::MODIFIER_CANNOT_BE_USED_HERE,
+        );
+    }
+
+    /// Whether any parse-time diagnostic landed strictly inside `modifiers`'
+    /// own span (first modifier's start through last modifier's end).
+    /// `NodeList::pos`/`end` are not populated for a modifier list built from
+    /// individually-parsed tokens (`Parser::make_node_list` always zeroes
+    /// them), so the span is recomputed from the member nodes' own
+    /// positions rather than trusted from the list itself.
+    fn modifier_run_already_has_parse_error(
+        &self,
+        modifiers: &Option<tsz_parser::parser::NodeList>,
+    ) -> bool {
+        let Some(modifiers) = modifiers else {
+            return false;
+        };
+        let mut span: Option<(u32, u32)> = None;
+        for &mod_idx in &modifiers.nodes {
+            let Some(node) = self.ctx.arena.get(mod_idx) else {
+                continue;
+            };
+            span = Some(match span {
+                Some((start, end)) => (start.min(node.pos), end.max(node.end)),
+                None => (node.pos, node.end),
+            });
+        }
+        let Some((start, end)) = span else {
+            return false;
+        };
+        self.ctx
+            .all_parse_error_positions
+            .iter()
+            .any(|&pos| pos >= start && pos < end)
     }
 
     /// TS1277: `const` modifier can only appear on function, method, or class type parameters.

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -61,6 +61,8 @@ mod assignability_reporter_relation_routing_arch_tests;
 mod assignability_type_comparability_relation_routing_arch_tests;
 #[path = "tests/assignment_ops_relation_routing_arch_tests.rs"]
 mod assignment_ops_relation_routing_arch_tests;
+#[path = "tests/async_export_modifier_order_ts1042_dedup_tests.rs"]
+mod async_export_modifier_order_ts1042_dedup_tests;
 #[path = "tests/async_generator_yieldstar_contribution_tests.rs"]
 mod async_generator_yieldstar_contribution_tests;
 #[path = "tests/async_generator_yieldstar_union_delegate_tests.rs"]

--- a/crates/tsz-checker/src/tests/async_export_modifier_order_ts1042_dedup_tests.rs
+++ b/crates/tsz-checker/src/tests/async_export_modifier_order_ts1042_dedup_tests.rs
@@ -1,0 +1,119 @@
+//! `async export class C {}` / `async export interface I {}` /
+//! `async export enum E {}` / `async export namespace N {}` reported TS1029
+//! ("'export' modifier must precede 'async' modifier.") *and* TS1042
+//! ("'async' modifier cannot be used here."), where tsc reports TS1029
+//! alone.
+//!
+//! Same mechanism as `declare_export_default_modifier_order_ts1319_dedup_tests`:
+//! TS1029 is a grammar-only diagnostic (`is_parser_grammar_code`, not
+//! `is_real_syntax_error`, in `tsz-cli`'s `check_utils.rs`), so it never
+//! flips the whole-file `has_parse_errors` gate. tsc still suppresses TS1042
+//! here because its `checkGrammarModifiers` already reported an error on
+//! this exact modifier list and returns early, skipping the sibling check
+//! that would otherwise ask whether `async` is legal on a class/interface/
+//! enum/namespace declaration at all. tsz's parser emits TS1029 eagerly
+//! during parsing (`look_ahead_async_before_export_target`,
+//! `parse_statement_async_declaration_or_expression`, #16403 slice 3) —
+//! before the declaration's own modifier list is checked as a unit — so
+//! `check_async_modifier_on_declaration`
+//! (`state/state_checking_members/member_declaration_checks.rs`) re-derives
+//! "did it already fire" from `all_parse_error_positions` instead of an AST
+//! field.
+//!
+//! Uses [`check_source_codes_with_grammar_only_parse_health`], not
+//! [`crate::test_utils::check_source_codes_with_parse_health`]: the coarse
+//! helper sets `has_parse_errors = true` for ANY parser diagnostic,
+//! including TS1029, which would trip the pre-existing whole-file gate and
+//! hide this bug behind a false negative.
+//!
+//! All expectations measured directly against the pinned `typescript@7.0.2`
+//! oracle (`scripts/conformance/typescript-versions.json`),
+//! `--noEmit --strict --pretty false --target es2022 --module es2022`.
+
+use crate::test_utils::check_source_codes_with_grammar_only_parse_health;
+
+const MODIFIER_MUST_PRECEDE_MODIFIER: u32 = 1029;
+const ASYNC_MODIFIER_CANNOT_BE_USED_HERE: u32 = 1042;
+
+/// oracle: TS1029 alone.
+#[test]
+fn async_export_class_reports_only_ts1029() {
+    let codes = check_source_codes_with_grammar_only_parse_health("async export class C {}");
+    assert!(
+        codes.contains(&MODIFIER_MUST_PRECEDE_MODIFIER),
+        "expected TS1029 for the misordered `async export`; got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&ASYNC_MODIFIER_CANNOT_BE_USED_HERE),
+        "tsc's checkGrammarModifiers already reported on this node and returns \
+         early, so TS1042 must not additionally fire; got {codes:?}"
+    );
+}
+
+/// oracle: TS1029 alone.
+#[test]
+fn async_export_interface_reports_only_ts1029() {
+    let codes = check_source_codes_with_grammar_only_parse_health("async export interface I {}");
+    assert!(codes.contains(&MODIFIER_MUST_PRECEDE_MODIFIER));
+    assert!(!codes.contains(&ASYNC_MODIFIER_CANNOT_BE_USED_HERE));
+}
+
+/// oracle: TS1029 alone.
+#[test]
+fn async_export_enum_reports_only_ts1029() {
+    let codes = check_source_codes_with_grammar_only_parse_health("async export enum E { A }");
+    assert!(codes.contains(&MODIFIER_MUST_PRECEDE_MODIFIER));
+    assert!(!codes.contains(&ASYNC_MODIFIER_CANNOT_BE_USED_HERE));
+}
+
+/// oracle: TS1029 alone.
+#[test]
+fn async_export_namespace_reports_only_ts1029() {
+    let codes = check_source_codes_with_grammar_only_parse_health("async export namespace N {}");
+    assert!(codes.contains(&MODIFIER_MUST_PRECEDE_MODIFIER));
+    assert!(!codes.contains(&ASYNC_MODIFIER_CANNOT_BE_USED_HERE));
+}
+
+/// A nested container — the position-range check must not depend on nesting
+/// depth or on the enclosing container kind.
+#[test]
+fn async_export_class_in_namespace_body_reports_only_ts1029() {
+    let codes = check_source_codes_with_grammar_only_parse_health(
+        "namespace N { async export class C {} }",
+    );
+    assert!(codes.contains(&MODIFIER_MUST_PRECEDE_MODIFIER));
+    assert!(!codes.contains(&ASYNC_MODIFIER_CANNOT_BE_USED_HERE));
+}
+
+/// Negative control: a bare `async class C {}` (no `export`, so no
+/// modifier-order violation exists to deduplicate against) must still report
+/// TS1042 alone — the new suppression must not fire when nothing preceded
+/// it.
+#[test]
+fn plain_async_class_still_reports_ts1042() {
+    let codes = check_source_codes_with_grammar_only_parse_health("async class C {}");
+    assert!(
+        codes.contains(&ASYNC_MODIFIER_CANNOT_BE_USED_HERE),
+        "no modifier-order diagnostic exists here, so TS1042 must still fire; got {codes:?}"
+    );
+    assert!(!codes.contains(&MODIFIER_MUST_PRECEDE_MODIFIER));
+}
+
+/// Negative control: a bare `async enum E {}`.
+#[test]
+fn plain_async_enum_still_reports_ts1042() {
+    let codes = check_source_codes_with_grammar_only_parse_health("async enum E { A }");
+    assert!(codes.contains(&ASYNC_MODIFIER_CANNOT_BE_USED_HERE));
+    assert!(!codes.contains(&MODIFIER_MUST_PRECEDE_MODIFIER));
+}
+
+/// Negative control: `async function f() {}` is unaffected — `async` is
+/// legal on a function declaration, so `check_async_modifier_on_declaration`
+/// (which only ever runs for class/interface/enum/module declarations) is
+/// not in the picture at all, and this must stay diagnostic-free.
+#[test]
+fn plain_async_function_reports_no_modifier_diagnostic() {
+    let codes = check_source_codes_with_grammar_only_parse_health("async function f() {}");
+    assert!(!codes.contains(&ASYNC_MODIFIER_CANNOT_BE_USED_HERE));
+    assert!(!codes.contains(&MODIFIER_MUST_PRECEDE_MODIFIER));
+}


### PR DESCRIPTION
`async export class C {}` / `async export interface I {}` / `async export enum E {}` / `async export namespace N {}` reported TS1029 (`'export' modifier must precede 'async' modifier.`) *and* TS1042 (`'async' modifier cannot be used here.`), where tsc reports TS1029 alone.

## Structural rule

tsc's `checkGrammarModifiers` reports at most one diagnostic per modifier list and returns immediately after — for a misordered `async export`, that is the order violation alone; it never goes on to ask whether `async` is legal on the declaration kind at all. tsz's parser already reports that same TS1029 eagerly during parsing (`look_ahead_async_before_export_target`, #16403 slice 3, #16420) *before* the declaration's own modifier list exists as a checked unit, so the checker's independent `check_async_modifier_on_declaration` (`state/state_checking_members/member_declaration_checks.rs`, called from class/interface/enum/namespace checking) has no AST field to read "did it already fire" back from. It now re-derives that from `all_parse_error_positions` — the same mechanism `check_export_declaration`'s TS1319 dedup already uses for the sibling `declare export default` shape (#16426, see `crates/tsz-checker/src/tests/declare_export_default_modifier_order_ts1319_dedup_tests.rs`).

**Owner layer:** checker only. No parser or solver change.

## Oracle verification

`typescript@7.0.2` (`scripts/conformance/typescript-versions.json` pin), full 10-modifier × 12-export-form matrix (120 rows), `--strict --pretty false --target es2022 --module es2022`:

| | mismatches |
| --- | --- |
| before | 7 (all 4 `async` × class/interface/enum/namespace rows among them) |
| after | 3 |

The 3 remaining mismatches (`declare export namespace`, `declare export = 1`, `abstract export = 1`) are unrelated export-assignment edge cases, out of scope here — #16403 itself is left open for them.

## Adjacent-case matrix

`class`/`interface`/`enum`/`namespace` targets, plus a namespace-body container to confirm the position check is nesting-depth-independent. Negative controls: a bare `async class`/`async enum` (no `export`, nothing to deduplicate against) must still report TS1042 alone; `async function` (async is legal there) must stay diagnostic-free — `check_async_modifier_on_declaration` is never called for it.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib async_export_modifier_order_ts1042_dedup_tests`: 8/8 passed (new)
- `cargo clippy -p tsz-checker --lib --tests --all-features -- -D warnings`: clean
- `cargo fmt -p tsz-checker -- --check`: clean
- `python3 scripts/arch/arch_guard.py`: passed
- Pre-commit hook (clippy + affected-crate tests + arch-guard): passed
- Oracle matrix (typescript@7.0.2, 120 rows): mismatches 7 → 3, exactly the 4 `async` rows fixed, nothing else moved
- `cargo test -p tsz-checker --lib` (full crate): launched in background, did not finish inside the session window (board's documented long tail for this suite); the pre-commit hook's own affected-tests pass plus the targeted 8/8 are the verified local signal
- `scripts/conformance/compare-to-parent.sh`: not run — narrow blast radius disclosed instead: `async export class/interface/enum/namespace` is a syntax error in every case (`async` is never a legal modifier on any of these four declaration kinds), and this change only ever removes a redundant diagnostic tsc does not emit. It cannot turn a passing file into a failing one.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZe2dHEfFodhWH3xgvAHDy)_