### PR TITLE
fix(checker): a class `static {}` block never resolves a position-invalid `import =` specifier (#16450)

### DIFF
--- a/crates/tsz-checker/src/declarations/import/context_helpers.rs
+++ b/crates/tsz-checker/src/declarations/import/context_helpers.rs
@@ -91,6 +91,11 @@ impl<'a> CheckerState<'a> {
 
     /// Check if a node is inside a function/method body.
     /// Walks up the parent chain to find a function-like ancestor.
+    ///
+    /// A class `static { }` block is function-like for this purpose: tsc's
+    /// binder gives it its own `container` cursor, same as a function body,
+    /// and it never resolves a position-invalid `import`/`import =` module
+    /// specifier inside one (#16450).
     pub(crate) fn is_inside_function_body(&self, node_idx: NodeIndex) -> bool {
         let mut current = node_idx;
         while current.is_some() {
@@ -111,7 +116,8 @@ impl<'a> CheckerState<'a> {
                     || k == syntax_kind_ext::METHOD_DECLARATION
                     || k == syntax_kind_ext::CONSTRUCTOR
                     || k == syntax_kind_ext::GET_ACCESSOR
-                    || k == syntax_kind_ext::SET_ACCESSOR =>
+                    || k == syntax_kind_ext::SET_ACCESSOR
+                    || k == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION =>
                 {
                     return true;
                 }

--- a/crates/tsz-checker/tests/position_invalid_import_equals_container_scope_tests.rs
+++ b/crates/tsz-checker/tests/position_invalid_import_equals_container_scope_tests.rs
@@ -286,17 +286,81 @@ fn class_static_block_alias_does_not_escape_the_class() {
     // A class static block is function-like in tsc, so it is a container even
     // though tsz gives its body a `ContainerKind::Block` scope. The carve-out
     // in `nearest_declaration_container_scope` is what keeps TS2304 here.
-    let actual = check(
+    assert_codes(
         r#"class Quebec {
   static {
     import romeo = require("nonexistent-module");
   }
 }
 romeo;"#,
+        &[1232, 2304],
+        "a static block must not leak into the class body, and (#16450) must not resolve the specifier either",
     );
-    assert!(
-        actual.contains(&2304),
-        "a static block must not leak into the class body, got {actual:?}"
+}
+
+// ---------------------------------------------------------------------------
+// #16450: a class static block must not resolve a position-invalid `import =`
+// specifier, same as any other function-like container. `tsc` reports TS1232
+// alone in every row below; tsz additionally reported a spurious TS2307
+// because `is_inside_function_body` did not recognize
+// `CLASS_STATIC_BLOCK_DECLARATION` as a function-like ancestor, so the
+// `in_wrong_context && is_inside_function_body` short-circuit in
+// `check_import_equals_declaration` never fired for a static block.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn static_block_single_alias_does_not_resolve_the_specifier() {
+    assert_codes(
+        r#"class E {
+  static {
+    import sierra = require("nonexistent-module");
+  }
+}"#,
+        &[1232],
+        "#16450: one alias, unreferenced",
+    );
+}
+
+#[test]
+fn static_block_referenced_alias_still_does_not_resolve_the_specifier() {
+    assert_codes(
+        r#"class E {
+  static {
+    import tango = require("nonexistent-module");
+    tango;
+  }
+}"#,
+        &[1232],
+        "#16450: referencing the alias must not trigger resolution either",
+    );
+}
+
+#[test]
+fn nested_block_inside_a_static_block_still_does_not_resolve_the_specifier() {
+    assert_codes(
+        r#"class E {
+  static {
+    {
+      import uniform = require("nonexistent-module");
+    }
+  }
+}"#,
+        &[1232],
+        "#16450: a plain block nested inside the static block is still part of that container",
+    );
+}
+
+#[test]
+fn static_block_two_colliding_aliases_do_not_resolve_the_specifier() {
+    assert_codes(
+        r#"class E {
+  static {
+    import victor = require("nonexistent-a");
+    import victor = require("nonexistent-b");
+  }
+}"#,
+        &[1232, 1232, 2300, 2300],
+        "#16450: the duplicate-alias TS2300 pair (#16437) rides along, but neither specifier resolves",
     );
 }
 


### PR DESCRIPTION
Closes #16450, closes #16449.

## Structural rule

A position-invalid `import x = require("...")` — one that already earned TS1232 for not being at the top level of a namespace or module — has its module specifier resolved by nobody in `tsc`, in every function-like container (function body, method body, constructor body, accessor body, function-expression body, arrow body, **and a class `static {}` block**). `tsz` matched this in every container except the static block, where it still resolved the specifier and reported a spurious TS2307.

## Root cause

`is_inside_function_body` (`crates/tsz-checker/src/declarations/import/context_helpers.rs`) walks up the parent chain looking for a function-like ancestor to decide whether a wrong-context `import`/`import =` should skip module-specifier resolution. Its match arm listed `FUNCTION_DECLARATION`, `FUNCTION_EXPRESSION`, `ARROW_FUNCTION`, `METHOD_DECLARATION`, `CONSTRUCTOR`, `GET_ACCESSOR`, `SET_ACCESSOR` — but not `CLASS_STATIC_BLOCK_DECLARATION`, even though tsc's binder gives a static block its own `container` cursor exactly like a function body (an existing test file already documents this: `position_invalid_import_equals_container_scope_tests.rs`'s `class_static_block_alias_does_not_escape_the_class`).

So in `check_import_equals_declaration` (`declarations/import/equals.rs:826`), the `in_wrong_context && is_inside_function_body(stmt_idx)` short-circuit correctly computed `in_wrong_context = true` (the static block's statement list hangs directly off the `CLASS_STATIC_BLOCK_DECLARATION` node, not a `SOURCE_FILE`/`MODULE_BLOCK`) but `is_inside_function_body` returned `false`, so the guard never fired and the code fell through to real module resolution.

**Owner layer:** checker only (import/export declaration validation). No parser, solver, or emitter change.

`is_inside_function_body` is shared by 6 call sites, all gating the identical "wrong-context import must not run module semantics" rule, so extending this one helper is the single owning fix rather than a per-diagnostic patch:
- `declarations/import/equals.rs` (TS1202 exception, TS2307/module-not-found gate)
- `declarations/import/declaration_check_body.rs` (plain `import ... from` TS2307/member gate) — verified oracle-adjacent below
- `declarations/module_checker.rs` (re-export member validation gate)
- `declarations/import/core/import_members.rs` (ambient-module named-import gate)

## Oracle matrix

`typescript@7.0.2`, `--noEmit --singleThreaded --stableTypeOrdering true --module commonjs --target es2022` (via this repo's new `scripts/conformance/oracle.sh`, matching what the conformance cache actually scores):

| form | tsc 7.0.2 | tsz before | tsz after |
| --- | --- | --- | --- |
| static block, one alias, unreferenced | TS1232 | TS1232 + **TS2307** | TS1232 |
| static block, alias referenced | TS1232 | TS1232 + **TS2307** | TS1232 |
| nested block inside a static block | TS1232 | TS1232 + **TS2307** | TS1232 |
| static block, two colliding aliases | TS1232×2, TS2300×2 | TS1232×2, TS2300×2, **TS2307×2** | TS1232×2, TS2300×2 |
| static block, plain `import { a } from "..."` (adjacent, not `import =`) | TS1232 | *(not covered by this PR's test suite — same helper, verified via oracle only)* | — |
| method / ctor / accessor / function / arrow, one alias | TS1232 | TS1232 ✅ (unaffected) | TS1232 ✅ (unaffected) |

The plain-`import`-declaration row confirms `tsc` applies the identical rule to non-`import =` module elements in a static block; `declaration_check_body.rs`'s use of the same `is_inside_function_body` helper means it now matches too, though no adjacent test was added for it in this PR (scope kept to the reported `import =` family).

## Adjacent-case matrix (new tests, `position_invalid_import_equals_container_scope_tests.rs`)

- `static_block_single_alias_does_not_resolve_the_specifier` — one alias, unreferenced.
- `static_block_referenced_alias_still_does_not_resolve_the_specifier` — referencing the alias must not trigger resolution either (rules out an "only resolves if referenced" explanation).
- `nested_block_inside_a_static_block_still_does_not_resolve_the_specifier` — a plain block nested inside the static block is still part of that container.
- `static_block_two_colliding_aliases_do_not_resolve_the_specifier` — the #16437 TS2300 duplicate-alias diagnostic still fires; only the specifier resolution is suppressed.
- Upgraded the pre-existing `class_static_block_alias_does_not_escape_the_class` from a partial (`contains(&2304)`) assertion to a full `assert_codes` now that the TS2307 residual it was written around is fixed.

Negative/unaffected rows (already-passing containers) reverified via the full existing suite, not newly added.

## Goal
Goal: hold

## Verification

| gate | result |
| --- | --- |
| `cargo test -p tsz-checker --test position_invalid_import_equals_container_scope_tests` | **22 passed, 0 failed** (18 pre-existing + 4 new #16450 rows, all green) |
| `cargo test -p tsz-checker --test import_equals_alias_duplicate_function_container_tests` | 16 passed, 0 failed (sibling suite, TS2300/TS1232-only assertions, confirms no interference) |
| `cargo test -p tsz-checker --lib import_equals` | 19 passed, 0 failed |
| `cargo test -p tsz-checker --test import_namespace_ts1147_tests` | 11 passed, 0 failed (TS1147 namespace-import gate, shares `is_in_non_module_element_context`) |
| `cargo clippy -p tsz-checker --all-targets` | exit 0, 0 warnings |
| `cargo fmt --all -- --check` | clean |
| `pre-commit` hook (clippy + arch guard + affected tests) | passed |

**Corpus gate:** `scripts/conformance/compare-to-parent.sh main` started in this container; cold two-`dist-fast`-build runs measure 55-90 min per the board's recent figures and had not finished at PR-open time. Blast radius for a reviewer: `is_inside_function_body` only changes answer for one previously-unhandled node kind (`CLASS_STATIC_BLOCK_DECLARATION`), and every one of its 6 call sites only branches on it inside an already-illegal "wrong module-element context" path (a position that is a hard error in every case: TS1232 for `import =`, an analogous grammar error for plain imports). Will report the compare-to-parent result as a follow-up comment once it completes.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_01QBDs6sSvXDv48qRRB2CjGo)_