### PR TITLE
fix(checker): repair red main — inner declared-here helper returns an anchor, not a diagnostic

### DIFF
--- a/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
+++ b/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
@@ -87,13 +87,12 @@ impl<'a> CheckerState<'a> {
         let mut symbol_id = owner_symbol;
         let mut declaring_file_idx = self.ctx.resolve_symbol_file_index(symbol_id);
         for _ in 0..MAX_ALIAS_HOPS {
-            if let Some(related) = self.declared_here_related_for_declared_symbol(
+            if let Some(anchor) = self.member_declaration_anchor_for_declared_symbol(
                 symbol_id,
                 declaring_file_idx,
                 property,
-                property_display,
             ) {
-                return Some(related);
+                return Some(anchor);
             }
             let (next_symbol, next_file_idx) =
                 self.alias_target_symbol(symbol_id, declaring_file_idx)?;
@@ -106,15 +105,18 @@ impl<'a> CheckerState<'a> {
         None
     }
 
-    /// The `TS2728` pointer for a symbol that is expected to own the member
-    /// list directly, with no alias following.
-    fn declared_here_related_for_declared_symbol(
+    /// The `(start, length, file)` anchor for a symbol that is expected to own
+    /// the member list directly, with no alias following.
+    ///
+    /// Returns the raw anchor rather than a built diagnostic because both
+    /// `TS2728` and `TS6500` underline the same span and differ only in code,
+    /// message, and name rendering — those belong to the caller.
+    fn member_declaration_anchor_for_declared_symbol(
         &mut self,
         owner_symbol: tsz_binder::SymbolId,
         declaring_file_idx: Option<usize>,
         property: &str,
-        property_display: &str,
-    ) -> Option<DiagnosticRelatedInformation> {
+    ) -> Option<(u32, u32, Option<String>)> {
         let binder = declaring_file_idx
             .and_then(|file_idx| self.ctx.get_binder_for_file(file_idx))
             .filter(|binder| binder.get_symbol(owner_symbol).is_some())


### PR DESCRIPTION
Goal: hold

**`main` does not compile.** Fixing it.

```
cargo build --profile dist-fast -p tsz-cli --bin tsz     # at 459d47a90b
error[E0425]: cannot find value `property_display` in this scope
error[E0308]: expected `(u32, u32, Option<String>)`, found `DiagnosticRelatedInformation`
error[E0308]: expected `DiagnosticRelatedInformation`, found `(u32, u32, Option<String>)`  (x2)
error: could not compile `tsz-checker` (lib) due to 4 previous errors
```

## Structural rule

When two PRs change opposite sides of one function boundary, each merging cleanly against a base that lacks the other, the result can be textually conflict-free and semantically broken. That is what happened here:

- **#16430** rewrote the owner walk to hop aliases to the original declaration, leaving `declared_here_related_for_declared_symbol` returning a built `DiagnosticRelatedInformation`.
- **#16451** then made the outer `member_declaration_anchor_for_owner` return a shared `(start, length, file)` anchor so `TS2728` and `TS6500` could both consume it, and dropped its `property_display` parameter.

The inner helper kept #16430's signature while its body already returned #16451's tuples, and the call site still passed a `property_display` that no longer exists in that scope.

**Neither PR's CI could have caught it.** The per-merge lane builds each PR *head*; nothing builds the result of merging both. I merged #16430 myself after a full local pass, and it was correct against the main of that moment.

## The fix

The tuple is the right shape — **both** callers of `member_declaration_anchor_for_owner` destructure it (`TS2728` here, `TS6500` in `expected_type_from_property.rs`). So the inner helper is renamed to `member_declaration_anchor_for_declared_symbol` and declared to return the anchor it was already returning.

**No behaviour change**: every `return` in that body was already `Some((start, length, file))`. This is the signature catching up to the body.

## Verification

- `cargo build --profile dist-fast -p tsz-cli --bin tsz`: **rc=0** (was rc=101)
- `cargo clippy -p tsz-checker --all-targets -- -D warnings`: **rc=0**
- `cargo nextest run -p tsz-checker --lib`: **9666/9666 passed, 0 failed**
- `arch_guard.py`: rc=0 (via pre-commit hook)

Conformance/emit are not meaningful until main builds; I will re-measure the floors once this lands.

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: xhigh
