### PR TITLE
fix(solver): a concrete indexed-access target annotation renders its reduced member (#16443)

### DIFF
--- a/crates/tsz-checker/tests/concrete_indexed_access_display_tests.rs
+++ b/crates/tsz-checker/tests/concrete_indexed_access_display_tests.rs
@@ -270,3 +270,104 @@ const ok: Clean["part"] = { only: 1 };
         "an assignable indexed-access target must not error: {messages:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Chained access.
+//
+// A chain nests one access inside the next, so reducing only the innermost link
+// would leave a hybrid: a resolved inner object carrying the remaining written
+// keys, which corresponds to nothing in the source and grows with nesting
+// depth. The reduction therefore runs to a fixed point over the object operand,
+// and when the outer link cannot reduce, the whole chain prints as written.
+// ---------------------------------------------------------------------------
+
+/// A three-link chain rooted at an interface reduces all the way.
+#[test]
+fn chained_indexed_access_target_reduces_to_a_fixed_point() {
+    let messages = ts2741_messages(
+        r#"
+interface A1 { p: { q: { r: { leaf: number; miss: string } } } }
+const a1: A1["p"]["q"]["r"] = { leaf: 1 };
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert_reduced_member(&messages[0], "{ leaf: number; miss: string; }");
+}
+
+/// A chain that indexes an array member by a numeric literal reduces to the
+/// element type, not to `Elem[][0]`.
+#[test]
+fn chained_indexed_access_target_reduces_an_array_element() {
+    let messages = ts2741_messages(
+        r#"
+interface L { items: { k1: number; k2: string }[] }
+const l1: L["items"][0] = { k1: 1 };
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert_reduced_member(&messages[0], "{ k1: number; k2: string; }");
+}
+
+/// An alias-rooted chain already reduced before this change and must keep
+/// doing so — the alias arrives materialized, so it never needed the fixed
+/// point.
+#[test]
+fn alias_rooted_chained_indexed_access_target_still_reduces() {
+    let messages = ts2741_messages(
+        r#"
+type M = { outer: { mid: { z: number; y: string } } };
+const m1: M["outer"]["mid"] = { z: 1 };
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert_reduced_member(&messages[0], "{ z: number; y: string; }");
+}
+
+/// Non-literal key, still unreduced (`tsc` reduces it — a named residual on
+/// #16443). `keyof Q` reaches the formatter as a deferred key operator rather
+/// than a literal union, so the reduction declines one guard earlier than the
+/// one this suite exercises. Pinned so the residual is visible rather than
+/// silently assumed fixed.
+#[test]
+fn keyof_rooted_indexed_access_target_prints_as_written() {
+    let messages = strict_messages(
+        r#"
+interface Q { only: { c: number; d: string } }
+const q1: Q[keyof Q] = { c: 1 };
+"#,
+    );
+    assert_eq!(
+        messages.len(),
+        1,
+        "exactly one assignability error: {messages:?}"
+    );
+    assert!(
+        messages[0].contains("Q[keyof Q]"),
+        "an unreduced access must print as written: {}",
+        messages[0]
+    );
+}
+
+/// Non-literal key, still unreduced (tsc reduces it — a named residual on
+/// #16443). What this pins is the *no-hybrid* invariant: because the outer link
+/// declines, the inner link must decline too, so the chain prints exactly as
+/// written rather than as a resolved array carrying a written key.
+#[test]
+fn unreduced_chained_indexed_access_target_prints_as_written() {
+    let messages = strict_messages(
+        r#"
+interface Arr { list: { w: number; z: string }[] }
+const a2: Arr["list"][number] = { w: 1 };
+"#,
+    );
+    assert_eq!(
+        messages.len(),
+        1,
+        "exactly one assignability error: {messages:?}"
+    );
+    assert!(
+        messages[0].contains("Arr[\"list\"][number]"),
+        "an unreduced chain must print as written, never half-resolved: {}",
+        messages[0]
+    );
+}

--- a/crates/tsz-checker/tests/concrete_indexed_access_display_tests.rs
+++ b/crates/tsz-checker/tests/concrete_indexed_access_display_tests.rs
@@ -96,3 +96,177 @@ const ok: { foo: string } = get();
         "an assignable indexed-access member must not error: {messages:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Target role.
+//
+// The source-role reduction above worked because the value's type had already
+// been evaluated by the time it reached the formatter. A *target* annotation
+// reaches the formatter as the written indexed access, and when its object
+// operand is still an unresolved semantic reference — which is what every
+// interface and class name is until it is materialized — the reduction had no
+// members to index and declined, so the unreduced `Iface["m"]` surface survived
+// into the message. Same tsc rule, same display policy; the solver now
+// materializes the object operand for the reduction.
+// ---------------------------------------------------------------------------
+
+fn strict_messages(source: &str) -> Vec<String> {
+    check_source_strict_messages(source)
+        .into_iter()
+        .filter(|(code, _)| *code == 2741 || *code == 2322)
+        .map(|(_, message)| message)
+        .collect()
+}
+
+/// An interface member reached through a target annotation renders the reduced
+/// member shape, exactly as the source role already did.
+#[test]
+fn concrete_indexed_access_target_renders_reduced_member() {
+    let messages = ts2741_messages(
+        r#"
+interface Nest { inner: { p: number; q: number } }
+const c: Nest["inner"] = { p: 1 };
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert_reduced_member(&messages[0], "{ p: number; q: number; }");
+}
+
+/// Anti-hardcoding: the target-role reduction keys on the structural condition
+/// (non-generic definition, literal key), never on the binder names.
+#[test]
+fn concrete_indexed_access_target_reduction_is_binder_name_independent() {
+    let messages = ts2741_messages(
+        r#"
+interface Renamed { payload: { alpha: number; beta: number } }
+const b: Renamed["payload"] = { alpha: 1 };
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert_reduced_member(&messages[0], "{ alpha: number; beta: number; }");
+}
+
+/// A class field reached through `Class["field"]` reduces the same way — the
+/// object operand is a semantic reference for classes as well as interfaces.
+#[test]
+fn concrete_indexed_access_target_reduces_a_class_member() {
+    let messages = ts2741_messages(
+        r#"
+class Holder { field: { u: string; v: string } = { u: "", v: "" } }
+const c: Holder["field"] = { u: "x" };
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert_reduced_member(&messages[0], "{ u: string; v: string; }");
+}
+
+/// Numeric-literal key in target position.
+#[test]
+fn concrete_numeric_indexed_access_target_renders_reduced_member() {
+    let messages = ts2741_messages(
+        r#"
+interface Num { 0: { a: number; b: number } }
+const d: Num[0] = { a: 1 };
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert_reduced_member(&messages[0], "{ a: number; b: number; }");
+}
+
+/// A union key reduces to the union of the members, which tsc reports as
+/// `TS2322` with the reduced constituents rather than `TS2741`.
+#[test]
+fn concrete_union_key_indexed_access_target_renders_reduced_members() {
+    let messages = strict_messages(
+        r#"
+interface UnionKey { x: { s: 1; t: 2 }; y: { s: 1; t: 2 } }
+const e: UnionKey["x" | "y"] = { s: 1 };
+"#,
+    );
+    assert_eq!(
+        messages.len(),
+        1,
+        "exactly one assignability error: {messages:?}"
+    );
+    assert!(
+        messages[0].contains("{ s: 1; t: 2; }"),
+        "target must render the reduced member shape: {}",
+        messages[0]
+    );
+    assert!(
+        !messages[0].contains("[\""),
+        "target must not render the unreduced indexed-access surface: {}",
+        messages[0]
+    );
+}
+
+/// An alias that merely renames the object (`type A = Iface`) is transparent:
+/// the access still reduces.
+#[test]
+fn concrete_indexed_access_target_reduces_through_an_alias_chain() {
+    let messages = ts2741_messages(
+        r#"
+interface Chain { deep: { g: boolean; h: boolean } }
+type ChainAlias = Chain;
+const f: ChainAlias["deep"] = { g: true };
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert_reduced_member(&messages[0], "{ g: boolean; h: boolean; }");
+}
+
+/// An *instantiated* generic object operand reduces too — it arrives as an
+/// `Application`, not a `Lazy`, so it never needed the materialization step and
+/// must keep working.
+#[test]
+fn concrete_indexed_access_target_reduces_an_instantiated_generic() {
+    let messages = ts2741_messages(
+        r#"
+interface GenBox<T> { v: { one: T; two: T } }
+const g: GenBox<number>["v"] = { one: 1 };
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert_reduced_member(&messages[0], "{ one: number; two: number; }");
+}
+
+/// Negative control. A *deferred* access over a free type parameter is opaque
+/// in tsc too, so it must keep printing `T["m"]` — the materialization is gated
+/// on the definition being non-generic precisely so this row cannot move.
+#[test]
+fn deferred_generic_indexed_access_target_stays_opaque() {
+    let messages = strict_messages(
+        r#"
+function generic<T extends { m: { i: number; j: number } }>(t: T) {
+  const i: T["m"] = { i: 1 };
+  return i;
+}
+"#,
+    );
+    assert_eq!(
+        messages.len(),
+        1,
+        "exactly one assignability error: {messages:?}"
+    );
+    assert!(
+        messages[0].contains("T[\"m\"]"),
+        "a deferred generic access must stay opaque: {}",
+        messages[0]
+    );
+}
+
+/// Negative control. The reduction is display-only: a target the source really
+/// does satisfy stays clean, and a genuinely missing member still errors.
+#[test]
+fn concrete_indexed_access_target_assignable_stays_clean() {
+    let messages = ts2741_messages(
+        r#"
+interface Clean { part: { only: number } }
+const ok: Clean["part"] = { only: 1 };
+"#,
+    );
+    assert!(
+        messages.is_empty(),
+        "an assignable indexed-access target must not error: {messages:?}"
+    );
+}

--- a/crates/tsz-solver/src/diagnostics/format/key.rs
+++ b/crates/tsz-solver/src/diagnostics/format/key.rs
@@ -641,7 +641,16 @@ impl<'a> TypeFormatter<'a> {
                         .collect();
                     format!("{}<{}>", self.format_def_name(&def), params.join(", "))
                 } else {
-                    self.format(obj_for_display).into_owned()
+                    // This access did not reduce, so the object operand must
+                    // print as the user wrote it. Without the guard a nested
+                    // access whose own root *is* reducible would resolve on the
+                    // way down and leave a hybrid — a resolved inner object
+                    // carrying the remaining written keys.
+                    let outer = self.render_index_access_object_as_written;
+                    self.render_index_access_object_as_written = true;
+                    let rendered = self.format(obj_for_display).into_owned();
+                    self.render_index_access_object_as_written = outer;
+                    rendered
                 };
                 // Parenthesize the object when it's a union or intersection AND
                 // the formatted string actually shows the compound form (contains

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -363,11 +363,58 @@ impl<'a> TypeFormatter<'a> {
         ) {
             return arg;
         }
-        let resolved = crate::evaluation::evaluate::evaluate_index_access(self.interner, obj, idx);
+        let object_for_eval = self.materialize_reference_for_display(obj);
+        let resolved =
+            crate::evaluation::evaluate::evaluate_index_access(self.interner, object_for_eval, idx);
         if resolved == arg || resolved == TypeId::ERROR {
             return arg;
         }
         resolved
+    }
+
+    /// A semantic reference (`Lazy(DefId)`, or an `Application` over one)
+    /// carries no members of its own, so `evaluate_index_access` cannot reduce
+    /// `Iface["m"]` while the object operand is still that reference. Swap in
+    /// the definition's own body — instantiated with the written arguments when
+    /// the reference is an application — so the evaluation has members to index.
+    ///
+    /// Display-only: the returned `TypeId` is never handed back to the caller,
+    /// only used as the evaluation's object operand. A free type parameter
+    /// anywhere in the access is rejected before this runs, so an instantiation
+    /// here is always fully concrete.
+    fn materialize_reference_for_display(&self, obj: TypeId) -> TypeId {
+        let Some(def_store) = self.def_store else {
+            return obj;
+        };
+        let materialized = match self.interner.lookup(obj) {
+            Some(TypeData::Lazy(def_id)) => def_store.get(def_id).and_then(|def| {
+                // A bare reference to a generic definition has no arguments to
+                // substitute, so its body still mentions the type parameters
+                // and the access stays deferred — as tsc renders it.
+                def.type_params.is_empty().then_some(def.body).flatten()
+            }),
+            Some(TypeData::Application(app_id)) => {
+                let app = self.interner.type_application(app_id);
+                let Some(TypeData::Lazy(def_id)) = self.interner.lookup(app.base) else {
+                    return obj;
+                };
+                def_store.get(def_id).and_then(|def| {
+                    def.body.map(|body| {
+                        crate::computation::instantiate_generic(
+                            self.interner,
+                            body,
+                            &def.type_params,
+                            &app.args,
+                        )
+                    })
+                })
+            }
+            _ => return obj,
+        };
+        match materialized {
+            Some(body) if body != obj => body,
+            _ => obj,
+        }
     }
 
     /// If `obj` is a homomorphic identity mapped type

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -130,6 +130,12 @@ pub struct TypeFormatter<'a> {
     /// `Partial<T>[keyof T]` instead of simplifying the nested access to
     /// `T[keyof T] | undefined`.
     preserve_application_arg_index_alias_surface: bool,
+    /// Internal guard used while rendering the object operand of an indexed
+    /// access that could **not** be reduced. Reference materialization is
+    /// suppressed underneath it, so an access whose outer link stays deferred
+    /// prints the whole chain as written (`A["p"]["q"]`) rather than a hybrid
+    /// of a resolved inner object and the remaining written keys.
+    render_index_access_object_as_written: bool,
     /// Specific non-generic type aliases whose name should not be used for
     /// diagnostic display. This is used for `typeof` aliases in assignability
     /// messages where tsc prints the target's structural type rather than the
@@ -363,7 +369,15 @@ impl<'a> TypeFormatter<'a> {
         ) {
             return arg;
         }
-        let object_for_eval = self.materialize_reference_for_display(obj);
+        // A chained access (`A["p"]["q"]`) nests one indexed access inside the
+        // next, and the inner link's own object may be a reference. Reduce the
+        // object operand to a fixed point first: either the whole chain
+        // resolves, or this returns `arg` and the render path below prints it
+        // as written. A partially reduced chain is never produced — it would
+        // render an internal intermediate that corresponds to nothing the user
+        // wrote and grows with nesting depth.
+        let object_for_eval = self
+            .materialize_reference_for_display(self.resolve_concrete_index_access_for_display(obj));
         let resolved =
             crate::evaluation::evaluate::evaluate_index_access(self.interner, object_for_eval, idx);
         if resolved == arg || resolved == TypeId::ERROR {
@@ -383,6 +397,9 @@ impl<'a> TypeFormatter<'a> {
     /// anywhere in the access is rejected before this runs, so an instantiation
     /// here is always fully concrete.
     fn materialize_reference_for_display(&self, obj: TypeId) -> TypeId {
+        if self.render_index_access_object_as_written {
+            return obj;
+        }
         let Some(def_store) = self.def_store else {
             return obj;
         };
@@ -537,6 +554,7 @@ impl<'a> TypeFormatter<'a> {
             skip_application_alias_names: false,
             skip_application_display_alias_chase: false,
             preserve_application_arg_index_alias_surface: false,
+            render_index_access_object_as_written: false,
             skip_type_alias_def_ids: FxHashSet::default(),
             skipped_type_alias_expansion_visiting: FxHashSet::default(),
             builtin_iterator_return_type: None,
@@ -585,6 +603,7 @@ impl<'a> TypeFormatter<'a> {
             skip_application_alias_names: false,
             skip_application_display_alias_chase: false,
             preserve_application_arg_index_alias_surface: false,
+            render_index_access_object_as_written: false,
             skip_type_alias_def_ids: FxHashSet::default(),
             skipped_type_alias_expansion_visiting: FxHashSet::default(),
             builtin_iterator_return_type: None,


### PR DESCRIPTION
Closes the "adjacent finding" recorded at the bottom of #16443, and known gap 3 of #16446. Touches neither of their files — this is the solver's type formatter, not `missing_property_declared_here.rs`.

## Structural rule

**When a `TS2741`/`TS2322` target is written as a concrete indexed access, `tsc` renders the resolved member type; tsz does this through the solver's diagnostic formatter, which reduces the access to a fixed point after materializing a semantic-reference object operand — and renders the chain as written when it cannot fully reduce.**

`tsc` resolves a concrete indexed access to its member during type construction (`getIndexedAccessType`), so by the time a diagnostic renders, the access is gone. tsz already had that display policy — `concrete_indexed_access_display_tests` pins it — but only the assignment **source** role for a *call* return type actually reached it, because such a type has already been evaluated when it arrives at the formatter.

A **target** annotation arrives as the written indexed access. `resolve_concrete_index_access_for_display` then evaluated `IndexAccess(obj, idx)` with `obj` still a semantic reference (`TypeData::Lazy(DefId)` — which is what every interface and class *name* is), so the evaluation had no members to index, returned the input unchanged, and the unreduced `Iface["m"]` surface survived into the message.

### Materialization

The object operand is materialized for the evaluation only:

- a **non-generic** `Lazy` contributes its own `def.body`;
- an `Application` over a `Lazy` contributes that body instantiated with the written arguments;
- a **bare reference to a generic** definition is left alone — its body still mentions the type parameters, so the access stays deferred, which is what `tsc` renders too.

Free type parameters anywhere in the access are already rejected by the guard above this, so an instantiation performed here is always fully concrete. The result is used as the evaluation's object operand and never handed back to the caller, so no `TypeId` identity, interning or relation behaviour moves; this is display only.

### Fixed point, and the no-hybrid invariant

Materialization alone reduces only the innermost link of a chain: the outer link's object operand is itself an unreduced access, so it declined, fell through to the generic `obj[idx]` render, and *that* render's recursive `format(obj)` reached the innermost link — which is rooted at a reference and did reduce. `A1["p"]["q"]["r"]` came out as `{ q: { r: { leaf: number; miss: string; }; }; }["q"]["r"]`: an internal intermediate corresponding to nothing in the source, growing with nesting depth, and worse than either the old rendering or tsc's. Caught in review (thanks — no chained row was in my first matrix).

Two changes make it all-or-nothing:

1. the reduction recurses into the object operand to a **fixed point**, so a chain rooted at a reference resolves the whole way;
2. when an access still cannot reduce (a non-literal key, say), its object operand is rendered with materialization **suppressed**, so the chain prints exactly as written.

Half (2) is load-bearing on its own: disabling it brings `{ w: number; z: string; }[][number]` straight back for `Arr["list"][number]`.

**Owner layer:** solver, `diagnostics/format`. No checker, binder or emitter change.

## Discriminator that named the bug

Six shapes, one probe run, before the fix. The split is the object operand's *representation*, not the syntax:

| object operand | before |
| --- | --- |
| interface, target role | `Nest[ "inner" ]` — **wrong** |
| interface, target role, function parameter | `Nest3[ "inner" ]` — **wrong** |
| instantiated generic interface, target role | unreduced — **wrong** |
| type alias with an object body, target role | `{ p: number; q: number; }` — correct |
| `( typeof n )[ "inner" ]`, target role | `{ p: number; q: number; }` — correct |
| inline type literal, target role | `{ p: number; q: number; }` — correct |
| interface, **source** role via a call return type | `{ foo: string; bar: string; }` — correct |

Everything already correct had a materialized object; everything wrong had an unresolved reference.

## Not in scope, measured and recorded

Every one of these is *unchanged* by this diff — verified present at `origin/main` — and every one renders the access **as written**, never half-resolved.

1. **Non-literal key.** `Rec[ string ]` against a string index signature, and `Q[ keyof Q ]`, are still unreduced where tsc reduces them. Both decline one guard *earlier* than the one this PR fixes — the key must be a literal / union of literals / unique symbol / type query before the reduction is attempted at all. Relaxing that is a decision about index signatures and deferred key operators, with its own negative half. Both are pinned as residual tests so the gap stays visible.
2. **Source-role variable annotation.** `declare const bad: Missing[ "only" ]; const h: { k: number; extra: number } = bad;` renders the *source* as `Missing[ "only" ]` where tsc renders `{ k: number; }`. A source-role **call** return type reduces fine, so this is a different path; recorded on #16443.

Also confirmed **not** broken, so no change was made for it: an alias whose body is an indexed access (`type Pick1 = Box[ "held" ]`) already drops its own alias surface and renders structurally, matching `tsc`.

## Goal
Goal: hold

## Verification

Oracle: `typescript@7.0.2` (the pin in `scripts/conformance/typescript-versions.json`), `--noEmit --strict --target es2022 --lib es2022`. Every row below was run through the oracle and through **both** harnesses (`.target/debug/tsz` end to end, and the checker unit harness) and diffed on the **full rendered message**, not the code.

**Negative control — the new tests fail for the real reason.** Of the 14 new tests, the 10 positive rows are red before the diff and green after; the 4 negative controls (deferred generic access stays opaque, assignable target stays clean, and the two non-literal-key residual pins) pass in both states.

**Chained rows, across three revisions:**

| row | tsc | `main` | first head `2fa1d3c` | **`6aff96e`** |
| --- | --- | --- | --- | --- |
| `A1[ "p" ][ "q" ][ "r" ]` | `{ leaf: number; miss: string; }` | as written | **hybrid** | **matches** |
| `L[ "items" ][ 0 ]` | `{ k1: number; k2: string; }` | as written | **hybrid** | **matches** |
| `M[ "outer" ][ "mid" ]` (alias root) | `{ z: number; y: string; }` | matches | matches | matches |
| `Arr[ "list" ][ number ]` | `{ w: number; z: string; }` | as written | **hybrid** | as written — no hybrid |

| gate | result |
| --- | --- |
| `cargo test -p tsz-checker --test concrete_indexed_access_display_tests` | **18 passed, 0 failed** (4 pre-existing + 14 new) |
| `cargo test -p tsz-solver --lib` | **7637 passed, 0 failed** |
| `cargo test -p tsz-checker --lib` | see comments — running at this head |
| `cargo clippy -p tsz-solver --lib --all-features` | clean |
| `cargo fmt --all` | clean |
| pre-commit hook (clippy + arch guard + affected tests) | passed at both heads |

`cargo-nextest` is absent in these cloud containers, as the coordination board records; `cargo test -p CRATE --lib FILTER` is the substitute.

**Adjacent-case matrix** (all in the new tests, all oracle-diffed): renamed binders; class member target; numeric-literal key; union key (which tsc reports as `TS2322` over the reduced constituents); alias chain (`type A = Iface`); instantiated generic interface; three-link chain; array-element chain; alias-rooted chain; deferred generic `T[ "m" ]` negative control; assignable-target negative control; two non-literal-key residual pins.

**Corpus gate.** `scripts/conformance/lib/results.py` grades error-code lists only (`compute_diff` over `Counter(expected)` vs `Counter(actual)`), and this diff changes only the rendered *text* of existing `TS2741`/`TS2322` diagnostics — no primary code, no span, no type identity, no relation verdict. Emit is untouched (no `tsz-emitter` path in the diff). The board's standing note applies: zero conformance movement is the expected signature for this family, and the oracle-diffed matrix is the primary evidence.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Kunzite