### PR TITLE
docs(conformance): manual oracle must run --singleThreaded to match the gate (#16413)

### DIFF
--- a/.agents/skills/tsz-conformance/SKILL.md
+++ b/.agents/skills/tsz-conformance/SKILL.md
@@ -30,12 +30,26 @@ Artifacts: `conformance-detail.json`, `conformance-snapshot.json`,
 
 ## Oracle
 
-Semantics come from the **pinned** compiler, not from any other copy on the box:
+Semantics come from the **pinned** compiler, not from any other copy on the box.
+Run manual spot-checks through the wrapper so they match what the gate scores:
 
 ```bash
+scripts/conformance/oracle.sh case.ts --strict --lib es2022 --target es2022
 node scripts/node_modules/typescript/lib/tsc.js --version   # Version 7.0.2
 ```
 
+- **Use `oracle.sh`, not a bare `tsc.js` invocation.** It runs the pinned
+  `typescript@7.0.2` with the same `--singleThreaded --stableTypeOrdering true`
+  flags `generate-tsc-cache.rs` uses for TypeScript 7+. This is not just about
+  ordering: `typescript@7.0.2` (typescript-go) reports a *different diagnostic
+  set* under `--singleThreaded`. A position-invalid import in a bare `{ }` block
+  (or `if`/loop/`try` body) gets `TS2307`/`TS2305` only single-threaded, not
+  under the default concurrent scheduler; the same import in a function, class
+  `static { }`, or namespace body gets neither, in both modes (#16413).
+  `compare-to-parent.sh`/`conformance.sh` score the single-threaded cache, so a
+  plain `tsc.js case.ts` silently disagrees with the gate — hand-oracling
+  without the flag reads a fix as passing that the gate then fails (this
+  mis-scoped #16409/#16411).
 - `TypeScript/` (submodule) and any container-global
   `/opt/**/node_modules/typescript` are the **6.0** line. They are corpus and
   test *cases* only — never the source of a semantic rule.


### PR DESCRIPTION
The `tsz-conformance` skill's Oracle section documented the manual oracle as a
bare `node scripts/node_modules/typescript/lib/tsc.js case.ts`, which silently
disagrees with what the conformance gate actually scores — the exact defect
behind #16413, and the reason #16409/#16411 were tuned to the wrong oracle.

Root cause, empirically confirmed against the pinned `typescript@7.0.2`
(typescript-go): `generate-tsc-cache.rs` runs tsc with
`--singleThreaded --stableTypeOrdering true` for TypeScript 7+, and `7.0.2`
reports a different diagnostic **set** — not just ordering — under
`--singleThreaded`. A position-invalid import in a bare `{ }` / `if` / loop /
`try` block gets `TS2307`/`TS2305` **only** single-threaded; the same import in
a function, class `static { }`, or namespace body gets neither, in both modes.
`compare-to-parent.sh`/`conformance.sh` score the single-threaded cache, so a
plain `tsc.js case.ts` reads a fix as passing that the gate then fails.

The fix points manual spot-checks at `scripts/conformance/oracle.sh` (added in
#16448), which reproduces the generator's exact flag shape, and states the
mode-dependence so the next agent does not re-walk it. The cache itself is
**correct, not stale**: `generate-tsc-cache` regenerates
`moduleElementsInWrongContext{,2,3}.ts` byte-identically to the committed
entries with these flags.

## Goal
Goal: hold

## Verification
- `typescript@7.0.2` oracle, `--target es2015`: bare `{}` / `if` / loop / `try`
  block with `import x = require("nonexistent")` → `TS1232 + TS2307` under
  `--singleThreaded`, `TS1232` alone under the default scheduler; `static {}`,
  function, and namespace-nested blocks → `TS1232` alone in **both** modes.
- `generate-tsc-cache --filter moduleElementsInWrongContext` with the pinned
  `7.0.2` reproduces the three committed cache entries exactly (fixture 1:
  `1184,1231,1232,1233,1234,1235,1258,2305,2307`), confirming the gate oracle is
  the `--singleThreaded` one.
- `scripts/agents/llm-context-audit.py`: no new findings (the 2 reported
  pre-exist on `main`, in `rust-debugger/SKILL.md`). `tsz-conformance/SKILL.md`
  is 87 lines / 476 words, within the 120-line / 900-word skill budget.
- Docs/skill-only change: the per-merge `clippy` + `arch-size` gates are
  unaffected.

## Provenance
Machine: cloud
Assistant: claude-code
Model: Opus 4.8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01QfpChnMqYLMUcAuHJbMmi5)_