### PR TITLE
fix(checker): an arrow-body return mismatch points at the signature its expected type came from (TS6502)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
@@ -626,6 +626,17 @@ impl<'a> CheckerState<'a> {
                                 body_node.end,
                                 tsz_common::diagnostics::diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                             ) {
+                                // The body's own contextual return check already
+                                // reported here, so this frame owns no emit of
+                                // its own — but it is still the frame tsc
+                                // attaches TS6502 to, and the pointer's owner
+                                // is only known at this level.
+                                self.attach_expected_type_from_return_pointer(
+                                    0,
+                                    &expected_type_owners,
+                                    &prop_name,
+                                    body_idx,
+                                );
                                 elaborated = true;
                                 continue;
                             }
@@ -636,9 +647,16 @@ impl<'a> CheckerState<'a> {
                             elaborated = true;
                             continue;
                         }
+                        let before = self.ctx.diagnostics.len();
                         self.error_type_not_assignable_at_with_anchor(
                             body_type,
                             expected_ret,
+                            body_idx,
+                        );
+                        self.attach_expected_type_from_return_pointer(
+                            before,
+                            &expected_type_owners,
+                            &prop_name,
                             body_idx,
                         );
                     } else {

--- a/crates/tsz-checker/src/error_reporter/expected_type_from_return.rs
+++ b/crates/tsz-checker/src/error_reporter/expected_type_from_return.rs
@@ -1,0 +1,196 @@
+//! tsc's `The expected type comes from the return type of this signature.`
+//! (`TS6502`) pointer.
+//!
+//! Structural rule, oracle-pinned against `typescript@7.0.2`
+//! (`scripts/conformance/oracle.sh --strict --pretty`): when an object-literal
+//! member's value is an expression-bodied arrow and the elaboration drilled to
+//! the arrow's *body*, the `TS2322` reported there carries a pointer at the
+//! declaration of the callable the expected return type came from — never at
+//! the member's name, which is the sibling `TS6500` anchor.
+//!
+//! ```text
+//! interface Ret { cb: () => string; }
+//! const rt: Ret = { cb: () => 6 };
+//!
+//! a.ts:2:29 - error TS2322: Type 'number' is not assignable to type 'string'.
+//!   a.ts:1:21 - The expected type comes from the return type of this signature.
+//!     1 interface Ret { cb: () => string; }
+//!                           ~~~~~~~~~~~~
+//! ```
+//!
+//! The anchor is the *signature declaration*, which is why the two member
+//! shapes underline different text: a property signature annotated with a
+//! function type points at the **annotation** (`() => string`), while a method
+//! signature has no separate annotation node and points at the **whole member**
+//! (`m(): string;`, trailing semicolon included — the same span `TS2728`
+//! already uses for a method signature).
+//!
+//! Deliberately reached from syntax and not from the type. The expected return
+//! type is carried by an interned [`tsz_solver::types::FunctionShape`], which
+//! has no declaration and cannot be given one: excluded from identity it would
+//! be shared by every structurally identical signature in the program and the
+//! second occurrence would anchor into the first one's file. That is the same
+//! soundness wall that sank tsz#16454's `PropertyInfo::declared_location`
+//! route, so the owner's *written* member list is the only per-occurrence
+//! source of an anchor here.
+//!
+//! Shapes that decline rather than guess, each pinned by a test:
+//!
+//! * a member annotated with a type *reference* (`cb: Fn`) — tsc anchors inside
+//!   the alias body, which needs the alias hop this walk does not take;
+//! * a call argument (`take(() => 7)`) — the expected type comes from a
+//!   parameter, not from an owner's member list;
+//! * an anonymous owner, which resolves to no binder symbol at all (tsz#16443).
+
+use crate::diagnostics::{Diagnostic, diagnostic_codes, diagnostic_messages, format_message};
+use crate::state::CheckerState;
+use tsz_parser::parser::{NodeArena, NodeIndex};
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    /// Attach the `TS6502` pointer to every `TS2322` reported inside
+    /// `body_idx`'s span since `since`.
+    ///
+    /// Called only from the arrow-body drill: that frame is the one tsc reports
+    /// at, and a diagnostic that already carries a location pointer got it from
+    /// a deeper frame that tsc's `!issuedElaboration` guard would have let keep
+    /// it, so it is left alone exactly as the `TS6500` attach does.
+    pub(crate) fn attach_expected_type_from_return_pointer(
+        &mut self,
+        since: usize,
+        owner_candidates: &[TypeId],
+        property_name: &str,
+        body_idx: NodeIndex,
+    ) {
+        if self.ctx.diagnostics.len() <= since {
+            return;
+        }
+        let Some(body_node) = self.ctx.arena.get(body_idx) else {
+            return;
+        };
+        let (body_pos, body_end) = (body_node.pos, body_node.end);
+        let Some(related) = self.expected_type_from_return_related(owner_candidates, property_name)
+        else {
+            return;
+        };
+        for diagnostic in self.ctx.diagnostics.iter_mut().skip(since) {
+            if diagnostic.code != diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE {
+                continue;
+            }
+            if diagnostic.start < body_pos || diagnostic.start >= body_end {
+                continue;
+            }
+            if diagnostic
+                .related_information
+                .iter()
+                .any(|entry| entry.is_location_pointer())
+            {
+                continue;
+            }
+            diagnostic.related_information.push(related.clone());
+        }
+    }
+
+    /// Build the `TS6502` entry for `property_name` on the first of
+    /// `owner_candidates` whose written declaration carries that member with a
+    /// signature to point at.
+    fn expected_type_from_return_related(
+        &mut self,
+        owner_candidates: &[TypeId],
+        property_name: &str,
+    ) -> Option<crate::diagnostics::DiagnosticRelatedInformation> {
+        owner_candidates.iter().find_map(|&owner| {
+            let (start, length, file) = self.member_signature_anchor_for_owner(owner, property_name)?;
+            Some(Diagnostic::related_pointer(
+                diagnostic_codes::THE_EXPECTED_TYPE_COMES_FROM_THE_RETURN_TYPE_OF_THIS_SIGNATURE,
+                file.unwrap_or_else(|| self.ctx.file_name.clone()),
+                start,
+                length,
+                format_message(
+                    diagnostic_messages::THE_EXPECTED_TYPE_COMES_FROM_THE_RETURN_TYPE_OF_THIS_SIGNATURE,
+                    &[],
+                ),
+            ))
+        })
+    }
+
+    /// `(start, length, file)` of the signature declaration for `property` on
+    /// `owner`, in whichever arena declares it.
+    ///
+    /// Declines for an owner that resolves to no symbol, for a member this
+    /// owner does not declare, and for a member whose signature is not written
+    /// at the declaration — the three cases that would otherwise anchor a
+    /// pointer at a span tsc does not underline.
+    fn member_signature_anchor_for_owner(
+        &mut self,
+        owner: TypeId,
+        property: &str,
+    ) -> Option<(u32, u32, Option<String>)> {
+        let owner_symbol = self.ctx.resolve_type_to_symbol_id(owner).or_else(|| {
+            crate::query_boundaries::common::type_shape_symbol(self.ctx.types, owner)
+        })?;
+        let declaring_file_idx = self.ctx.resolve_symbol_file_index(owner_symbol);
+        let binder = declaring_file_idx
+            .and_then(|file_idx| self.ctx.get_binder_for_file(file_idx))
+            .filter(|binder| binder.get_symbol(owner_symbol).is_some())
+            .unwrap_or(self.ctx.binder);
+        let symbol = binder.get_symbol(owner_symbol)?;
+        let locations: Vec<tsz_binder::StableLocation> =
+            std::iter::once(symbol.stable_value_declaration)
+                .chain(symbol.stable_declarations.iter().copied())
+                .filter(tsz_binder::StableLocation::is_known)
+                .collect();
+        locations.into_iter().find_map(|location| {
+            let (decl_idx, arena) = self
+                .ctx
+                .node_at_stable_location_in_file(location, declaring_file_idx)?;
+            let members = Self::declaration_member_list(arena, decl_idx)?;
+            let member_idx = Self::named_member_node(arena, &members, property)?;
+            let anchor_idx = Self::return_type_anchor_for_member(arena, member_idx)?;
+            let (start, length) = Self::anchor_span(arena, anchor_idx)?;
+            Some((start, length, Self::arena_file_name(arena, anchor_idx)))
+        })
+    }
+
+    /// The member of `members` written with the name `property`.
+    fn named_member_node(
+        arena: &NodeArena,
+        members: &tsz_parser::parser::NodeList,
+        property: &str,
+    ) -> Option<NodeIndex> {
+        members.nodes.iter().copied().find(|&member_idx| {
+            Self::member_name_node(arena, member_idx)
+                .and_then(|name_idx| {
+                    crate::types_domain::queries::core::get_literal_property_name(arena, name_idx)
+                })
+                .is_some_and(|name| name == property)
+        })
+    }
+
+    /// The node tsc underlines as "this signature" for `member_idx`.
+    ///
+    /// A method signature *is* the signature, so it is underlined whole. A
+    /// property signature carries one only when its annotation is written as a
+    /// function or constructor type; any other annotation (a type reference, a
+    /// union, an omitted one) declines, because the signature tsc points at is
+    /// then not this node.
+    fn return_type_anchor_for_member(
+        arena: &NodeArena,
+        member_idx: NodeIndex,
+    ) -> Option<NodeIndex> {
+        use tsz_parser::parser::syntax_kind_ext;
+
+        let node = arena.get(member_idx)?;
+        if node.kind == syntax_kind_ext::METHOD_SIGNATURE {
+            return Some(member_idx);
+        }
+        if node.kind != syntax_kind_ext::PROPERTY_SIGNATURE {
+            return None;
+        }
+        let annotation_idx = arena.get_signature(node)?.type_annotation;
+        let annotation = arena.get(annotation_idx)?;
+        (annotation.kind == syntax_kind_ext::FUNCTION_TYPE
+            || annotation.kind == syntax_kind_ext::CONSTRUCTOR_TYPE)
+            .then_some(annotation_idx)
+    }
+}

--- a/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
+++ b/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
@@ -596,7 +596,7 @@ impl<'a> CheckerState<'a> {
     /// The member list a type's declaration owns: interfaces and classes carry
     /// theirs directly, a type alias carries its body's when that body is a
     /// type literal.
-    fn declaration_member_list(
+    pub(super) fn declaration_member_list(
         arena: &NodeArena,
         decl_idx: NodeIndex,
     ) -> Option<tsz_parser::parser::NodeList> {
@@ -654,7 +654,7 @@ impl<'a> CheckerState<'a> {
     /// (`PROPERTY_DECLARATION`/`METHOD_DECLARATION`) stores it on the
     /// distinct `PropertyDeclData`/`MethodDeclData` instead, so each kind
     /// needs its own accessor rather than one shared `get_signature` call.
-    fn member_name_node(arena: &NodeArena, member_idx: NodeIndex) -> Option<NodeIndex> {
+    pub(super) fn member_name_node(arena: &NodeArena, member_idx: NodeIndex) -> Option<NodeIndex> {
         use tsz_parser::parser::syntax_kind_ext;
 
         let node = arena.get(member_idx)?;
@@ -680,7 +680,7 @@ impl<'a> CheckerState<'a> {
     /// is done here against the declaration's own arena: an identifier is its
     /// escaped text, a string-literal name is its text plus the two quotes it
     /// was written with, and anything else keeps the node span.
-    fn anchor_span(arena: &NodeArena, anchor_idx: NodeIndex) -> Option<(u32, u32)> {
+    pub(super) fn anchor_span(arena: &NodeArena, anchor_idx: NodeIndex) -> Option<(u32, u32)> {
         use tsz_scanner::SyntaxKind;
 
         let node = arena.get(anchor_idx)?;
@@ -721,7 +721,7 @@ impl<'a> CheckerState<'a> {
     /// File name owning `idx` in `arena`, walked from the node itself so a
     /// cross-file declaration reports its own file rather than the file the
     /// primary diagnostic lives in.
-    fn arena_file_name(arena: &NodeArena, idx: NodeIndex) -> Option<String> {
+    pub(super) fn arena_file_name(arena: &NodeArena, idx: NodeIndex) -> Option<String> {
         let mut current = idx;
         while current.is_some() {
             let node = arena.get(current)?;

--- a/crates/tsz-checker/src/error_reporter/mod.rs
+++ b/crates/tsz-checker/src/error_reporter/mod.rs
@@ -36,6 +36,7 @@ mod core_formatting;
 pub(crate) mod display_budget;
 mod emitters;
 mod expected_type_from_property;
+mod expected_type_from_return;
 mod fingerprint_policy;
 mod generic_display_helpers;
 mod generics;

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -279,6 +279,8 @@ mod excess_prop_object_union_display_tests;
 mod expando_annotated_receiver_tests;
 #[path = "tests/expected_type_from_property_tests.rs"]
 mod expected_type_from_property_tests;
+#[path = "tests/expected_type_from_return_tests.rs"]
+mod expected_type_from_return_tests;
 #[path = "tests/explicit_alias_constraint_relation_routing_arch_tests.rs"]
 mod explicit_alias_constraint_relation_routing_arch_tests;
 #[path = "tests/explicit_type_arg_overload_pruning_tests.rs"]

--- a/crates/tsz-checker/src/tests/expected_type_from_return_tests.rs
+++ b/crates/tsz-checker/src/tests/expected_type_from_return_tests.rs
@@ -1,0 +1,262 @@
+//! Regression tests for the `TS6502` `The expected type comes from the return
+//! type of this signature.` pointer.
+//!
+//! Structural rule, pinned against `typescript@7.0.2` (the conformance pin,
+//! run through `scripts/conformance/oracle.sh --strict --pretty --target
+//! es2022 --lib es2022`): when an object-literal member's value is an
+//! expression-bodied arrow and the elaboration drilled to the arrow's *body*,
+//! the `TS2322` reported there carries a pointer at the **signature
+//! declaration** the expected return type came from — not at the member's name,
+//! which is the sibling `TS6500` anchor.
+//!
+//! Every anchor below is the byte range tsc underlines, taken from the oracle
+//! run rather than from tsz's own output, and asserted through
+//! [`span_text`] so a wrong-but-plausible span fails loudly.
+
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::check_source_diagnostics;
+use tsz_common::diagnostics::diagnostic_codes;
+
+const TS2322: u32 = diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE;
+const TS6500: u32 =
+    diagnostic_codes::THE_EXPECTED_TYPE_COMES_FROM_PROPERTY_WHICH_IS_DECLARED_HERE_ON_TYPE;
+const TS6502: u32 =
+    diagnostic_codes::THE_EXPECTED_TYPE_COMES_FROM_THE_RETURN_TYPE_OF_THIS_SIGNATURE;
+
+fn only(diags: &[Diagnostic], code: u32) -> Diagnostic {
+    let matching: Vec<_> = diags.iter().filter(|d| d.code == code).collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected exactly one TS{code}; got {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+    matching[0].clone()
+}
+
+/// The pointer's `(start, length)` plus its message, so each case can assert
+/// the anchor lands on the signature as written and nothing wider.
+fn return_pointer(diagnostic: &Diagnostic) -> (u32, u32, String) {
+    let pointers: Vec<_> = diagnostic
+        .related_information
+        .iter()
+        .filter(|info| info.code == TS6502)
+        .collect();
+    assert_eq!(
+        pointers.len(),
+        1,
+        "expected exactly one TS6502 pointer; got {:?}",
+        diagnostic
+            .related_information
+            .iter()
+            .map(|info| (info.code, info.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+    (
+        pointers[0].start,
+        pointers[0].length,
+        pointers[0].message_text.clone(),
+    )
+}
+
+fn has_return_pointer(diagnostic: &Diagnostic) -> bool {
+    diagnostic
+        .related_information
+        .iter()
+        .any(|info| info.code == TS6502)
+}
+
+fn span_text(source: &str, start: u32, length: u32) -> &str {
+    &source[start as usize..(start + length) as usize]
+}
+
+/// tsc, `a.ts`:
+///
+/// ```text
+/// a.ts:2:29 - error TS2322: Type 'number' is not assignable to type 'string'.
+///   a.ts:1:21 - The expected type comes from the return type of this signature.
+///     1 interface Ret { cb: () => string; }
+///                           ~~~~~~~~~~~~
+/// ```
+///
+/// The anchor is the property's *annotation*, not its name: a function-type
+/// annotation is the signature declaration tsc points at.
+#[test]
+fn property_signature_annotated_with_a_function_type_points_at_the_annotation() {
+    let source = "interface Ret { cb: () => string; }\nconst rt: Ret = { cb: () => 6 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    let (start, length, message) = return_pointer(&diagnostic);
+    assert_eq!(span_text(source, start, length), "() => string");
+    assert_eq!(
+        message,
+        "The expected type comes from the return type of this signature."
+    );
+}
+
+/// A method signature has no separate annotation node, so tsc underlines the
+/// whole member — trailing `;` included, exactly as the sibling `TS2728`
+/// pointer already does for a method signature. Oracled:
+///
+/// ```text
+/// d.ts:1:16 - The expected type comes from the return type of this signature.
+///     1 interface R3 { m(): string; }
+///                      ~~~~~~~~~~~~
+/// ```
+#[test]
+fn method_signature_points_at_the_whole_member() {
+    let source = "interface R3 { m(): string; }\nconst r3: R3 = { m: () => 8 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    let (start, length) = {
+        let (start, length, _) = return_pointer(&diagnostic);
+        (start, length)
+    };
+    assert_eq!(span_text(source, start, length), "m(): string;");
+}
+
+/// The anchor is the member's own declaration and not anything keyed on how it
+/// is spelled: renaming every binder must move the span and change nothing
+/// else. Pinned because a pointer that reads a name is exactly the
+/// hardcoding the repo's anti-hardcoding gate forbids.
+#[test]
+fn renamed_binders_anchor_at_their_own_signature() {
+    let source = "interface Zeta { qux: () => string; }\nconst zz: Zeta = { qux: () => 6 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    let (start, length, _) = return_pointer(&diagnostic);
+    assert_eq!(span_text(source, start, length), "() => string");
+}
+
+/// Two structurally identical signatures are one interned `FunctionShape`, so
+/// a pointer carried on the *type* would anchor both at whichever was interned
+/// first. Each must point at its own text. This is the row that proves the
+/// anchor comes from syntax, and the failure mode that sank tsz#16454.
+#[test]
+fn identical_signatures_each_point_at_their_own_text() {
+    let source = concat!(
+        "interface One { a: () => string; }\n",
+        "interface Two { b: () => string; }\n",
+        "const o: One = { a: () => 1 };\n",
+        "const t: Two = { b: () => 2 };\n",
+    );
+    let diagnostics = check_source_diagnostics(source);
+    let mismatches: Vec<_> = diagnostics.iter().filter(|d| d.code == TS2322).collect();
+    assert_eq!(
+        mismatches.len(),
+        2,
+        "expected two TS2322; got {mismatches:?}"
+    );
+    let anchors: Vec<u32> = mismatches
+        .iter()
+        .map(|d| return_pointer(d).0)
+        .collect::<Vec<_>>();
+    assert_ne!(
+        anchors[0], anchors[1],
+        "identical signatures must not share one anchor: {anchors:?}"
+    );
+    for &start in &anchors {
+        assert_eq!(span_text(source, start, 12), "() => string");
+    }
+    assert!(
+        anchors[0] < source.find("interface Two").expect("second interface") as u32,
+        "the first pointer must anchor in the first interface: {anchors:?}"
+    );
+}
+
+/// A cross-file owner points into the file that declares it, not into the file
+/// the primary diagnostic lives in.
+#[test]
+fn cross_file_owner_points_at_its_own_declaration() {
+    use crate::test_utils::check_multi_file;
+
+    let dep = "export interface Dep { cb: () => string; }\n";
+    let main = "import { Dep } from \"./dep\";\nconst d: Dep = { cb: () => 5 };\n";
+    let diagnostics = check_multi_file(
+        &[("dep.ts", dep), ("main.ts", main)],
+        "main.ts",
+        Default::default(),
+    );
+    let diagnostic = only(&diagnostics, TS2322);
+    let pointer = diagnostic
+        .related_information
+        .iter()
+        .find(|info| info.code == TS6502)
+        .expect("TS6502 pointer");
+    assert!(
+        pointer.file.ends_with("dep.ts"),
+        "pointer must anchor in the declaring file: {pointer:?}"
+    );
+    assert_eq!(
+        span_text(dep, pointer.start, pointer.length),
+        "() => string"
+    );
+}
+
+/// A block-bodied function expression is not drilled at all — tsc's
+/// `elaborateArrowFunction` only handles expression bodies — so the report
+/// stays at the member and carries the `TS6500` property pointer instead.
+/// Oracled: `b.ts:1:18 - The expected type comes from property 'cb' ...`.
+#[test]
+fn block_bodied_function_expression_keeps_the_property_pointer() {
+    let source = "interface Ret2 { cb: () => string; }\nconst rt2: Ret2 = { cb: function () { return 6; } };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    assert!(
+        !has_return_pointer(&diagnostic),
+        "an undrilled member must not carry the return pointer: {diagnostic:?}"
+    );
+    assert!(
+        diagnostic
+            .related_information
+            .iter()
+            .any(|info| info.code == TS6500),
+        "the member frame keeps its TS6500 pointer: {diagnostic:?}"
+    );
+}
+
+/// A member annotated with a type *reference* declines. tsc anchors inside the
+/// alias body (`type Fn = () => string` → the `() => string` there), which
+/// needs an alias hop this walk deliberately does not take; declining leaves
+/// output exactly as it was rather than anchoring at `Fn` or at `cb`. Pinned so
+/// the day the hop lands, this row's move is visible.
+#[test]
+fn type_reference_annotation_declines_rather_than_anchoring_at_the_reference() {
+    let source =
+        "type Fn = () => string;\ninterface Ref { cb: Fn; }\nconst rf: Ref = { cb: () => 6 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    assert!(
+        !has_return_pointer(&diagnostic),
+        "an alias-annotated member must decline: {diagnostic:?}"
+    );
+}
+
+/// A call argument's expected type comes from a *parameter*, not from an
+/// owner's member list, so this walk has no owner to resolve and declines.
+/// tsc does emit `TS6502` here (anchored in the alias body); pinned negatively
+/// so the argument route is a visible gap rather than a wrong anchor.
+#[test]
+fn call_argument_return_mismatch_declines() {
+    let source = "type Fn = () => string;\ndeclare function take(f: Fn): void;\ntake(() => 7);\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    assert!(
+        !has_return_pointer(&diagnostic),
+        "a call-argument frame has no member owner to anchor on: {diagnostic:?}"
+    );
+}
+
+/// The negative arm of the whole family: a member whose value matches its
+/// declared return type produces no diagnostic, so there is nothing to point
+/// at. Guards against an attach that fires on an unrelated buffered `TS2322`.
+#[test]
+fn a_matching_return_type_produces_no_diagnostic_and_no_pointer() {
+    let source = "interface Ok { cb: () => string; }\nconst ok: Ok = { cb: () => \"s\" };\n";
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        diagnostics.iter().all(|d| d.code != TS2322),
+        "a matching return type must not report: {diagnostics:?}"
+    );
+    assert!(
+        diagnostics.iter().all(|d| !has_return_pointer(d)),
+        "no pointer without a report: {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
## Goal

Goal: hold

Closes the second half of #16451's handoff. `TS6502` (`The expected type comes from the return type of this signature.`) existed in the message table at `part_002.rs:223` with **zero construction sites** — nothing in the compiler ever built it. This adds the construction, oracle-pinned.

### Structural rule

**When** an object-literal member's value is an expression-bodied arrow and the elaboration drilled to the arrow's *body*, `tsc` attaches a `TS6502` pointer to the `TS2322` reported there, anchored at the **signature declaration** the expected return type came from — never at the member's name, which is the sibling `TS6500` anchor. tsz does this through the checker's `error_reporter`, from the owner's *written* member list.

Oracle, `typescript@7.0.2` via `scripts/conformance/oracle.sh --strict --pretty --target es2022 --lib es2022`:

```
a.ts:2:29 - error TS2322: Type 'number' is not assignable to type 'string'.
2 const rt: Ret = { cb: () => 6 };
                              ~
  a.ts:1:21 - The expected type comes from the return type of this signature.
    1 interface Ret { cb: () => string; }
                          ~~~~~~~~~~~~
```

The two member shapes underline **different text**, because the anchor is the signature and not the member: a property signature annotated with a function type points at the *annotation* (`() => string`), a method signature has no separate annotation node and points at the *whole member* including its trailing `;` (`m(): string;` — the same span `TS2728` already uses for a method signature). Both spans come from the oracle run, not from tsz's own output.

### Owner layer, and why not the type

`crates/tsz-checker/src/error_reporter/expected_type_from_return.rs` (new), reached from the two arrow-body drill sites in `call_errors/elaboration_object_properties.rs`. The anchor is resolved from **syntax**, deliberately.

The expected return type is carried by an interned `FunctionShape`, which has no declaration and cannot be given one: excluded from identity it would be shared by every structurally identical signature in the program, and the second occurrence would anchor its pointer into the first one's file. That is precisely the wall #16454 hit with `PropertyInfo::declared_location`. The owner's written member list is the only per-occurrence source of an anchor, so that is what this walk reads.

### Adjacent-case matrix

| row | shape | result |
| --- | --- | --- |
| property signature | `cb: () => string` | pointer at `() => string` |
| method signature | `m(): string;` | pointer at `m(): string;` (whole member) |
| renamed binders | `Zeta.qux` | same anchor rule, span moves |
| identical signatures ×2 | two interfaces, byte-identical members | **distinct** anchors, each in its own interface |
| cross-file owner | owner in `dep.ts` | pointer file is `dep.ts` |
| block-bodied fn expression | `cb: function () { return 6 }` | no drill → keeps its `TS6500` pointer |
| type-reference annotation | `cb: Fn` | **declines** (tsc anchors in the alias body; needs an alias hop) |
| call argument | `take(() => 7)` | **declines** (expected type comes from a parameter, no member owner) |
| matching return type | `cb: () => "s"` | no diagnostic, no pointer |

The last three are pinned as negative tests so the remaining gaps are visible rather than silently anchoring somewhere plausible-but-wrong.

### Non-vacuity

`TS6502` had **no construction site anywhere in `crates/`** before this diff (`grep -rn 6502 --include=*.rs crates/` matched only the message table), so no code path could have produced any of the five positive rows.

## Verification

Commands actually run on this seat, at parent `d08aa43`:

- `cargo test -p tsz-checker --lib expected_type_from_return` → **9 passed / 0 failed** (new suite)
- `cargo test -p tsz-checker --lib expected_type_from_property` → **15 passed / 0 failed** (the sibling TS6500 suite, unchanged)
- adjacent families, all unchanged: `object_literal` 285/285, `elaboration` 182/182, `declared_here` 39/39, `missing_property` 82/82, `callback` 249/249, `contextual` 309/309
- `cargo fmt --all` — clean
- `cargo clippy --profile ci-lint --workspace --exclude tsz-conformance --all-targets -- -D warnings` (CI's exact invocation) — **no warnings**
- `python3 scripts/arch/arch_guard.py` — `Architecture guardrails passed.`
- oracle rows generated with `scripts/conformance/oracle.sh` (`typescript@7.0.2`, `--singleThreaded --stableTypeOrdering`), four fixtures: property signature, method signature, block-bodied function expression, call argument through an alias

**Conformance/emit not run, and here is why that is sound rather than skipped.** This diff adds `related_information` to an existing `TS2322` and introduces **no new top-level code** — `TS6502` is a `Message`, never reported top-level. `scripts/conformance/lib/results.py::compute_diff` grades `Counter(expected)` vs `Counter(actual)` over error *codes* only, so a related-information-only diff cannot move a row. That argument is not merely read off `results.py`: it was confirmed by real `snapshot --workers 12 --force` runs on both #16451 (TS6500) and #16446 (TS2741 pointer), each `11490 -> 11490, 0 regressed / 0 fixed`. The validity check — "does my diff introduce a new top-level code" — is answered no here.

The full `cargo test -p tsz-checker --lib` lane was **not** run: this seat reproduces the board's known `ts2589_tests::recursive_conditional_alias_omitted_default_transform_emits_definition_ts2589` long tail, and `cargo-nextest` is unavailable in this container. The targeted sweep above is what the change rests on, stated plainly rather than implying a lane that did not run.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Tourmaline

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pm7yQVLWRoX8JTQNJ3xafR)_