### PR TITLE
fix(parser): #16403's declare/abstract export-modifier residual (namespace, export=)

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -225,6 +225,8 @@ mod cross_module_generic_interface_heritage_tests;
 mod declaration_extract_key_path_tests;
 #[path = "tests/declare_export_default_modifier_order_ts1319_dedup_tests.rs"]
 mod declare_export_default_modifier_order_ts1319_dedup_tests;
+#[path = "tests/declare_export_equals_ambient_ts2714_tests.rs"]
+mod declare_export_equals_ambient_ts2714_tests;
 #[path = "tests/declare_private_member_implicit_any_tests.rs"]
 mod declare_private_member_implicit_any_tests;
 #[path = "tests/declared_signature_return_literal_display_tests.rs"]

--- a/crates/tsz-checker/src/tests/declare_export_equals_ambient_ts2714_tests.rs
+++ b/crates/tsz-checker/src/tests/declare_export_equals_ambient_ts2714_tests.rs
@@ -1,0 +1,65 @@
+//! `declare export = <non-identifier>;` (#16403 residual). The resulting
+//! `ExportAssignment` node's `declare`/`export` modifiers were dropped at
+//! parse time (`parse_export_assignment` always built
+//! `ExportAssignmentData { modifiers: None, .. }`), so
+//! `is_in_ambient_context` — which reads a declaration's own modifier list
+//! before walking to its parent — had no way to see the `declare` keyword on
+//! this node. Since the statement sits at the source file's own top level (no
+//! ambient ancestor either), the ambient gate in
+//! `check_export_declarations_and_assignments` read `false` and TS2714 ("The
+//! expression of an export assignment must be an identifier or qualified
+//! name in an ambient context.") never fired — even though the sibling
+//! parser-level TS1120 ("An export assignment cannot have modifiers.")
+//! already did, since that diagnostic is emitted directly at parse time and
+//! does not depend on the node's `modifiers` field. This harness
+//! (`check_source_codes`) only surfaces checker diagnostics, so TS1120 itself
+//! is covered separately in `tsz-parser`'s
+//! `parser_declare_export_default_tests.rs`.
+//!
+//! Every expectation oracle-pinned against `typescript@7.0.2`
+//! (`--strict --target es2022 --module es2022`).
+
+use crate::test_utils::check_source_codes;
+
+const THE_EXPRESSION_OF_AN_EXPORT_ASSIGNMENT_MUST_BE_AN_IDENTIFIER_OR_QUALIFIED_NAME_IN_AN_AMBIENT_CONTEXT: u32 =
+    2714;
+
+#[test]
+fn declare_export_equals_numeric_literal_reports_ts2714() {
+    let codes = check_source_codes("declare export = 1;");
+    assert!(
+        codes.contains(
+            &THE_EXPRESSION_OF_AN_EXPORT_ASSIGNMENT_MUST_BE_AN_IDENTIFIER_OR_QUALIFIED_NAME_IN_AN_AMBIENT_CONTEXT
+        ),
+        "expected TS2714 — the `declare` modifier must reach ambient-context \
+         detection on this node; got {codes:?}"
+    );
+}
+
+#[test]
+fn declare_export_equals_object_literal_reports_ts2714() {
+    let codes = check_source_codes("declare export = { a: 1 };");
+    assert!(codes.contains(
+        &THE_EXPRESSION_OF_AN_EXPORT_ASSIGNMENT_MUST_BE_AN_IDENTIFIER_OR_QUALIFIED_NAME_IN_AN_AMBIENT_CONTEXT
+    ));
+}
+
+// Negative control: an identifier expression is a valid ambient export
+// assignment target, so TS2714 must not fire.
+#[test]
+fn declare_export_equals_identifier_reports_no_ts2714() {
+    let codes = check_source_codes("declare const X: number;\ndeclare export = X;");
+    assert!(!codes.contains(
+        &THE_EXPRESSION_OF_AN_EXPORT_ASSIGNMENT_MUST_BE_AN_IDENTIFIER_OR_QUALIFIED_NAME_IN_AN_AMBIENT_CONTEXT
+    ));
+}
+
+// Negative control: a plain (non-ambient) `export = <expr>;` must not gain
+// TS2714 — the file is not ambient at all.
+#[test]
+fn plain_export_equals_numeric_literal_reports_no_ts2714() {
+    let codes = check_source_codes("export = 1;");
+    assert!(!codes.contains(
+        &THE_EXPRESSION_OF_AN_EXPORT_ASSIGNMENT_MUST_BE_AN_IDENTIFIER_OR_QUALIFIED_NAME_IN_AN_AMBIENT_CONTEXT
+    ));
+}

--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -97,6 +97,9 @@ mod parser_class_body_modifier_recovery_tests;
 #[path = "../../tests/parser_declare_export_default_tests.rs"]
 mod parser_declare_export_default_tests;
 #[cfg(test)]
+#[path = "../../tests/parser_declare_export_module_namespace_ts1029_tests.rs"]
+mod parser_declare_export_module_namespace_ts1029_tests;
+#[cfg(test)]
 #[path = "../../tests/parser_export_specifier_from_tests.rs"]
 mod parser_export_specifier_from_tests;
 #[cfg(test)]

--- a/crates/tsz-parser/src/parser/state_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_declarations.rs
@@ -1755,8 +1755,11 @@ impl ParserState {
                 // Also skip in block context: tsc emits TS1029 via grammarErrorOnNode
                 // in the checker, which is suppressed by hasParseDiagnostics when
                 // TS1184 (Modifiers cannot appear here) is already emitted.
-                // Also skip for `declare export module/namespace` — tsc 6.0 accepts this
-                // form without TS1029 for ambient module/namespace declarations.
+                // `declare export module/namespace` DOES still get TS1029 on current
+                // pinned tsc (7.0.2, oracle-confirmed both at the source-file top level
+                // and inside a namespace body) — an earlier version of this comment
+                // claimed tsc 6.0 silenced it, which is no longer true and was never
+                // re-verified against the current pin (#16403 residual).
                 // Also skip for a plain export declaration (`{ }` / `*` / type-only
                 // `type { }` / `type *`) — tsc emits TS1193 alone there, never TS1029
                 // alongside it (oracle-confirmed). Also skip for the `default <expr>`
@@ -1765,8 +1768,6 @@ impl ParserState {
                 if !self.in_block_context()
                     && !self.is_token(SyntaxKind::AsKeyword)
                     && !self.is_token(SyntaxKind::EqualsToken)
-                    && !self.is_token(SyntaxKind::ModuleKeyword)
-                    && !self.is_token(SyntaxKind::NamespaceKeyword)
                     && !self.is_token(SyntaxKind::OpenBraceToken)
                     && !self.is_token(SyntaxKind::AsteriskToken)
                     && !is_type_only_export
@@ -1838,7 +1839,7 @@ impl ParserState {
                                 diagnostic_codes::AN_EXPORT_ASSIGNMENT_CANNOT_HAVE_MODIFIERS,
                             );
                         }
-                        self.parse_export_assignment(error_start)
+                        self.parse_export_assignment(error_start, Some(modifiers))
                     }
                     SyntaxKind::ImportKeyword => {
                         // `declare export import a = x.c;`

--- a/crates/tsz-parser/src/parser/state_declarations_exports.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_exports.rs
@@ -8,7 +8,7 @@ use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages};
 use super::state::{CONTEXT_FLAG_DISALLOW_IN, ParserState};
 use crate::parser::parse_rules::look_ahead_is;
 use crate::parser::{
-    NodeIndex,
+    NodeIndex, NodeList,
     node::{
         BlockData, ExportAssignmentData, ExportDeclData, IfStatementData, LiteralData, LoopData,
         NamedImportsData, ReturnData, SwitchData, VariableData, VariableDeclarationData,
@@ -28,7 +28,18 @@ impl ParserState {
     // export function `f()` {}
     // export class C {}
     pub(crate) fn parse_export_declaration(&mut self) -> NodeIndex {
-        let start_pos = self.token_pos();
+        self.parse_export_declaration_from(self.token_pos())
+    }
+
+    /// Same as [`Self::parse_export_declaration`], but lets the caller supply the
+    /// node's start position instead of defaulting to the `export` keyword's own
+    /// position. Needed when `export` is reached after a stray modifier
+    /// (`abstract export = 1`, `static export = 1`, ...) that the caller already
+    /// consumed: tsc anchors the resulting declaration's span — and therefore any
+    /// position-sensitive diagnostic that reads it, e.g. TS1203 for `export =`
+    /// under an ECMAScript module target — at the *first* modifier, not at
+    /// `export` (oracle-confirmed across every modifier family, #16403 residual).
+    pub(crate) fn parse_export_declaration_from(&mut self, start_pos: u32) -> NodeIndex {
         self.seen_module_indicator = true;
         self.parse_expected(SyntaxKind::ExportKeyword);
 
@@ -98,7 +109,7 @@ impl ParserState {
 
         // export = expression (CommonJS-style export)
         if self.is_token(SyntaxKind::EqualsToken) {
-            return self.parse_export_assignment(start_pos);
+            return self.parse_export_assignment(start_pos, None);
         }
 
         // export as namespace Foo (UMD global namespace declaration)
@@ -326,7 +337,11 @@ impl ParserState {
     }
 
     // Parse export = expression (CommonJS-style default export)
-    pub(crate) fn parse_export_assignment(&mut self, start_pos: u32) -> NodeIndex {
+    pub(crate) fn parse_export_assignment(
+        &mut self,
+        start_pos: u32,
+        modifiers: Option<NodeList>,
+    ) -> NodeIndex {
         self.parse_expected(SyntaxKind::EqualsToken);
         let expression = self.parse_assignment_expression();
         if expression == NodeIndex::NONE {
@@ -341,7 +356,7 @@ impl ParserState {
             start_pos,
             end_pos,
             ExportAssignmentData {
-                modifiers: None,
+                modifiers,
                 is_export_equals: true,
                 expression,
             },

--- a/crates/tsz-parser/src/parser/state_exports_recovery.rs
+++ b/crates/tsz-parser/src/parser/state_exports_recovery.rs
@@ -136,7 +136,7 @@ impl ParserState {
                         diagnostic_messages::AN_EXPORT_ASSIGNMENT_CANNOT_HAVE_MODIFIERS,
                         diagnostic_codes::AN_EXPORT_ASSIGNMENT_CANNOT_HAVE_MODIFIERS,
                     );
-                    self.parse_export_assignment(start_pos)
+                    self.parse_export_assignment(start_pos, None)
                 } else {
                     // Genuine duplicate export modifier
                     self.parse_error_at(

--- a/crates/tsz-parser/src/parser/state_statements_keywords.rs
+++ b/crates/tsz-parser/src/parser/state_statements_keywords.rs
@@ -480,7 +480,7 @@ impl ParserState {
             SyntaxKind::DeclareKeyword => self.parse_ambient_declaration_with_modifiers(modifiers),
             SyntaxKind::ExportKeyword => {
                 if self.look_ahead_export_starts_export_declaration() {
-                    return self.parse_export_declaration();
+                    return self.parse_export_declaration_from(start_pos);
                 }
                 let export_start = self.token_pos();
                 self.parse_expected(SyntaxKind::ExportKeyword);
@@ -1157,12 +1157,19 @@ impl ParserState {
                 | SyntaxKind::GlobalKeyword => self
                     .look_ahead_is_module_declaration()
                     .then_some(AbstractExportTarget::PositionErrorWins),
-                // A named or star export declaration. `export = ...` is
-                // deliberately not here: tsc routes it through TS1120, not
-                // this modifier run.
+                // A named or star export declaration.
                 SyntaxKind::OpenBraceToken | SyntaxKind::AsteriskToken => {
                     Some(AbstractExportTarget::PositionErrorWins)
                 }
+                // `abstract export = expr` — an `ExportAssignment` node, same
+                // as `abstract export default <expr>` below: `abstract` is
+                // never legal on it, so tsc reports the modifier's own
+                // "can only appear on a class, method, or property
+                // declaration" message (TS1242) rather than an ordering
+                // violation, silenced the same wider way — a Block or a
+                // namespace body, not just a Block — by the assignment's own
+                // placement diagnostic (oracle-confirmed, #16403 residual).
+                SyntaxKind::EqualsToken => Some(AbstractExportTarget::ExportAssignment),
                 // `export default class C {}` (named or anonymous) reads the
                 // same modifier run `[abstract, export, default]` as the bare
                 // `export class` arm above, and `abstract` is legal on a

--- a/crates/tsz-parser/tests/parser_abstract_before_export_declaration_tests.rs
+++ b/crates/tsz-parser/tests/parser_abstract_before_export_declaration_tests.rs
@@ -456,3 +456,34 @@ fn abstract_export_default_expression_reports_ts1242_only_outside_a_block_or_nam
         }
     }
 }
+
+// -- `abstract export = expr`: #16403's residual. Same `ExportAssignment`
+//    node kind as `abstract export default <expr>` above, and oracle-
+//    confirmed (`typescript@7.0.2`) to take the identical single-diagnostic
+//    answer — TS1242 alone outside a Block/namespace body, silenced inside
+//    both by the assignment's own placement diagnostic (TS1231/TS1063,
+//    checker-side). Before this fix `export =` was not recognized as a
+//    target at all, so `abstract` fell through to a bare identifier
+//    expression and the trailing `export = 1;` was parsed as its own
+//    statement — spurious TS2304 on `abstract`, no TS1242. --
+
+#[test]
+fn abstract_export_equals_reports_ts1242_only_outside_a_block_or_namespace() {
+    for index in 0..CONTAINERS.len() {
+        let source = in_container(index, "abstract export = 1;");
+        if is_block(index) || index == 3 {
+            assert_eq!(
+                codes(&source),
+                Vec::<u32>::new(),
+                "expected no modifier diagnostic for {source:?}, got {:?}",
+                codes(&source)
+            );
+        } else {
+            assert_diag_at_abstract(
+                &source,
+                diagnostic_codes::ABSTRACT_MODIFIER_CAN_ONLY_APPEAR_ON_A_CLASS_METHOD_OR_PROPERTY_DECLARATION,
+            );
+        }
+        assert_no_cannot_find_name(&source);
+    }
+}

--- a/crates/tsz-parser/tests/parser_declare_export_module_namespace_ts1029_tests.rs
+++ b/crates/tsz-parser/tests/parser_declare_export_module_namespace_ts1029_tests.rs
@@ -1,0 +1,91 @@
+//! `declare export namespace N {}` / `declare export module M {}` (#16403
+//! residual). `parse_ambient_declaration_with_modifiers`'s `ExportKeyword` arm
+//! had an explicit exclusion that skipped TS1029 ("'export' modifier must
+//! precede 'declare' modifier.") for these two forms, with a comment claiming
+//! "tsc 6.0 accepts this form without TS1029 for ambient module/namespace
+//! declarations." That is no longer true on the pinned oracle: `tsc` 7.0.2
+//! reports TS1029 for both forms, at the source-file top level and nested in
+//! a namespace body alike — only a Block silences it (the nested-namespace's
+//! own TS1235 wins there instead, matching every sibling modifier family).
+//!
+//! Every expectation oracle-pinned against `typescript@7.0.2`
+//! (`--strict --target es2022 --module es2022`).
+
+use crate::parser::test_fixture::parse_source;
+use tsz_common::diagnostics::diagnostic_codes;
+
+fn codes(source: &str) -> Vec<u32> {
+    let (parser, _root) = parse_source(source);
+    let mut codes: Vec<u32> = parser.get_diagnostics().iter().map(|d| d.code).collect();
+    codes.sort_unstable();
+    codes.dedup();
+    codes
+}
+
+fn assert_ts1029_export_before_declare(source: &str) {
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+    let export_pos = source.find("export").unwrap() as u32;
+    assert!(
+        diagnostics.iter().any(
+            |d| d.code == diagnostic_codes::MODIFIER_MUST_PRECEDE_MODIFIER && d.start == export_pos
+        ),
+        "expected TS1029 anchored at 'export' ({export_pos}) for {source:?}, got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn declare_export_namespace_at_top_level_reports_ts1029() {
+    assert_ts1029_export_before_declare("declare export namespace N {}");
+}
+
+#[test]
+fn declare_export_module_at_top_level_reports_ts1029() {
+    assert_ts1029_export_before_declare("declare export module M {}");
+}
+
+#[test]
+fn declare_export_namespace_dotted_name_at_top_level_reports_ts1029() {
+    assert_ts1029_export_before_declare("declare export namespace N.M {}");
+}
+
+#[test]
+fn declare_export_namespace_in_a_namespace_body_reports_ts1029() {
+    // Nesting is legal here (unlike a Block), so tsc still reports the
+    // ordering violation — the same "namespace body is not a Block" split
+    // every sibling modifier family already draws.
+    assert_ts1029_export_before_declare("namespace M { declare export namespace N {} }");
+}
+
+#[test]
+fn declare_export_namespace_in_a_block_reports_no_modifier_diagnostic() {
+    // A nested namespace declaration is itself illegal inside a Block
+    // (TS1235, checker-side, outside this parser-only harness) and that
+    // placement diagnostic wins outright — no TS1029 alongside it, matching
+    // every sibling modifier family's own `ModuleDeclaration` handling.
+    let source = "function f() { declare export namespace N {} }";
+    assert_eq!(
+        codes(source),
+        Vec::<u32>::new(),
+        "expected no parser diagnostic for {source:?}, got {:?}",
+        codes(source)
+    );
+}
+
+#[test]
+fn plain_declare_namespace_without_export_stays_clean() {
+    // Negative control: no stray `export` before `declare`, nothing to
+    // reorder.
+    assert_eq!(codes("declare namespace N {}"), Vec::<u32>::new());
+}
+
+#[test]
+fn declare_export_namespace_already_ambient_reports_no_ts1029() {
+    // Nested inside another ambient declaration, tsc emits TS1038 instead
+    // (checker-side) and never TS1029 alongside it — the pre-existing
+    // ambient-context exclusion in the same guard, unaffected by this fix.
+    assert_eq!(
+        codes("declare module \"m\" { declare export namespace N {} }"),
+        Vec::<u32>::new()
+    );
+}


### PR DESCRIPTION
Closes the three remaining mismatches from #16403's 120-row modifier × export-form matrix (left open by my own earlier #16452): `declare export namespace N {}` / `declare export module M {}` (missed TS1029 entirely), `declare export = <non-identifier>;` (missed TS2714), and `abstract export = 1;` (wrong code and position).

## Structural rule

A stray modifier before `export ...` reads as one modifier run, and tsc's `checkGrammarModifiers` reports exactly one diagnostic for it, chosen by the node kind `export` decorates and anchored at the run's *first* modifier — never at `export` itself. tsz's parser already had this policy for most modifier families; three gaps remained, all fixed at the parser layer:

1. **`declare export namespace/module` had an explicit TS1029 exclusion** whose comment claimed "tsc 6.0 accepts this form without TS1029" — false on the current pin (`typescript@7.0.2`, oracle-confirmed both at top level and nested in a namespace body; only a Block silences it, matching every sibling family). Removed the exclusion.
2. **`parse_export_assignment` unconditionally built `ExportAssignmentData { modifiers: None, .. }`**, discarding the `declare`/`export` modifiers the caller had already consumed. Since `is_in_ambient_context` reads a node's own modifier list before walking to its parent, a top-level `declare export = <expr>;` was invisible to ambient-context detection and TS2714 never fired. Threaded the modifiers through (`Option<NodeList>` parameter); the two other call sites (bare `export = expr`, `export export = x`) pass `None`, unaffected.
3. **`abstract`'s `export` classifier had no arm for `SyntaxKind::EqualsToken`**, so `abstract export = 1;` fell through to a bare identifier-expression parse of `abstract`, giving a spurious TS2304 instead of TS1242. Added the arm, mapping to the same `ExportAssignment` target `abstract export default <expr>` already used (identical tsc answer, oracle-confirmed).

**Adjacent bug found while fixing #3 and generalized rather than patched locally:** the shared `ExportKeyword` reroute in `parse_accessor_modified_statement` (used by every modifier family — `static`/`readonly`/`public`/`protected`/`private`/`override`/`async`/`accessor`/`abstract`) called the parameterless `parse_export_declaration()`, which starts the resulting node's span at `export`'s own position. tsc starts an `ExportAssignment`'s span at the first modifier. This only surfaces user-visibly for TS1203 (checker-side, `export=` under an ECMAScript module target), which reads the node's own span — oracle-confirmed broken identically for every one of the 10 modifier families, not just `abstract`. Added `parse_export_declaration_from(start_pos)` and threaded the caller's original `start_pos` through the reroute.

**Owner layer:** parser (`tsz-parser`). One checker-side beneficiary (TS2714's existing ambient gate needed no changes — only the AST modifiers it reads).

## Goal
Goal: hold

## Verification
- 3×120-row oracle-diffed cross product (10 modifiers × 12 export forms), `typescript@7.0.2`, both `--module commonjs` and `--module es2022`, plus a block/namespace-body container sweep: **0 mismatches** after this fix (10 rows in the container sweep remain wrong, all pre-existing and unrelated — `<modifier> export default class` inside a Block emitting a duplicate TS1184 — confirmed present on the pre-fix binary too via a `git stash` A/B, unaffected by this diff).
- `cargo test -p tsz-parser --lib`: **1960/1960** (7 new).
- `cargo test -p tsz-checker --lib declare_export_equals_ambient_ts2714 / export / namespace / ambient`: all passing (4 new + 367 pre-existing).
- `cargo clippy -p tsz-parser -p tsz-checker --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt --all`, `python3 scripts/arch/arch_guard.py`: clean.
- Direct before/after binary diff (`git stash` A/B) on the 4 real TypeScript corpus files matching these shapes (`TypeScript/tests/cases/compiler/`): `privacyImportParseErrors.ts` gains exactly the TS1029 the pinned `typescript@7.0.2` baseline expects at the corresponding line/col (a real conformance improvement, not a neutral change); `exportAssignmentWithDeclareModifier.ts` and `...WithDeclareAndExportModifiers.ts` are unaffected under their pragma's `@module: commonjs` (still TS1120 alone, matching baseline exactly); `privacyImport.ts`'s match is a comment, inert.
- Full `compare-to-parent.sh`/`conformance.sh snapshot` not run this session (disclosed, not silently skipped): the corpus search plus the direct before/after diff above already show the one real corpus row this diff can move, and it moves toward the pinned oracle.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4h5jCUMzi9yhKXSDfPsaq)_