### PR TITLE
fix(checker): a call-reduced nominal generic container keeps its type-argument display (#16191)

### DIFF
--- a/crates/tsz-checker/src/state/type_environment/application.rs
+++ b/crates/tsz-checker/src/state/type_environment/application.rs
@@ -339,10 +339,28 @@ impl<'a> CheckerState<'a> {
         }
         let evaluated = self.evaluate_type_with_env(instantiated);
         if evaluated == TypeId::ERROR {
-            instantiated
-        } else {
-            evaluated
+            return instantiated;
         }
+        // Record the display back-reference from the evaluated structural form
+        // to the nominal `Application` it came from, mirroring the solver's
+        // `store_parametric_structural_back_reference` on the ordinary
+        // application-evaluation path. This path materializes a cross-file
+        // generic interface/class receiver (`application` is `Name<args>` over a
+        // program-file `Interface`/`Class` base — the caller has already
+        // excluded lib/`declare`/same-file and non-nominal bases), so the
+        // evaluated body carries the base's nominal `symbol` but no type
+        // arguments of its own. Without the provenance the printer renders it as
+        // a bare `Name`, dropping every argument — the shape #16191 observes
+        // when an unannotated named generator's `AsyncGenerator<Y, R, N>`
+        // container is eagerly reduced at its call site and shows as a bare
+        // `AsyncGenerator`. `store_display_alias_preferring_application` applies
+        // its own alloc-order/intrinsic/self-reference gates, so a result that
+        // already owns a stable spelling is left untouched.
+        self.ctx
+            .types
+            .as_type_database()
+            .store_display_alias_preferring_application(evaluated, application);
+        evaluated
     }
 
     /// Recover a property-access receiver whose cross-arena type-parameter push

--- a/crates/tsz-checker/src/tests/generator_yield_self_similar_nesting_tests.rs
+++ b/crates/tsz-checker/src/tests/generator_yield_self_similar_nesting_tests.rs
@@ -74,11 +74,13 @@
 //! anonymous   AsyncGenerator<AsyncGenerator<number>>   (no diagnostic)
 //! ```
 //!
-//! `tsc` renders the full application for both forms, so the **anonymous** form
-//! is the one holding the correct container type — it is not the broken half,
-//! it is the half where only the relation loses. Making anonymous match named
-//! would be chasing a second defect, not fixing this one. That degradation is
-//! its own row below.
+//! `tsc` renders the full application for both forms. The named form's bare
+//! rendering is fixed in #16191 (see
+//! `named_form_container_keeps_its_type_arguments_in_the_message` below): the
+//! container was reduced to its structural shape at the call return without a
+//! display back-reference to its `AsyncGenerator<...>` application. The
+//! anonymous form always held the correct container type; the relation-side
+//! self-similar loss on both forms is the separate, still-open #16125 defect.
 //!
 //! Three directions are measured dead, so they are not worth re-attempting
 //! without new evidence (each was built, measured on this suite, and reverted;
@@ -481,13 +483,17 @@ wants(d());
 /// `AsyncGenerator<AsyncGenerator<string, any, any>, void, unknown>` here; tsz
 /// renders a bare `AsyncGenerator`, dropping every type argument.
 ///
-/// This is the failure mode `unannotated_generator_return_type`'s own comment
-/// says its `evaluate_type_with_env` cache-warming exists to prevent (#16119),
-/// so the warming is not holding on the named path. Kept red rather than
-/// asserting today's wrong text, so a fix for it cannot land unnoticed.
+/// Fixed in #16191: the named form's container reached the diagnostic through
+/// `finalize_call_return_like_success`, which eagerly reduces a monomorphic
+/// `Application` return type to its structural shape at the call site. That
+/// reduction (`instantiate_application_body_for_property_access`) dropped the
+/// display back-reference to the originating `AsyncGenerator<...>` application,
+/// so the printer showed a bare `AsyncGenerator`. Recording the back-reference
+/// on that path — the checker-side counterpart to the solver's
+/// `store_parametric_structural_back_reference` — restores the type arguments
+/// without touching the structural type, so this is display-only and the
+/// self-similar relation rows above (the separate #16125 defect) are unmoved.
 #[test]
-#[ignore = "#16125 open, separate defect: the named form's container degrades \
-            to a bare unsubstituted `AsyncGenerator` in the message text"]
 fn named_form_container_keeps_its_type_arguments_in_the_message() {
     let libs = load_default_lib_files();
     let messages = crate::test_utils::check_source_with_libs_code_messages(
@@ -515,5 +521,75 @@ wants(d());
     assert!(
         text.contains("AsyncGenerator<AsyncGenerator<string"),
         "the named form must keep its type arguments the way tsc renders them: {text:?}"
+    );
+}
+
+/// Adjacent case for #16191: the **sync** `Generator` named form keeps its
+/// type arguments too. The fix is on the container's display provenance, not on
+/// anything async-specific, so `Generator<...>` must recover its arguments the
+/// same way `AsyncGenerator<...>` does. Renders `Generator<string, ...>` on a
+/// non-self-similar target so the relation genuinely rejects and the message is
+/// the artifact under test.
+#[test]
+fn sync_named_form_container_keeps_its_type_arguments_in_the_message() {
+    let libs = load_default_lib_files();
+    let messages = crate::test_utils::check_source_with_libs_code_messages(
+        r#"
+export {};
+declare function wants(h: Generator<{ x: number }>): void;
+function* d() {
+    yield "s";
+}
+wants(d());
+"#,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    );
+    let text = messages
+        .iter()
+        .find(|(code, _)| *code == 2345)
+        .map(|(_, message)| message.clone())
+        .unwrap_or_default();
+    assert!(
+        text.contains("Generator<string"),
+        "the sync named form must keep its type arguments: {text:?}"
+    );
+}
+
+/// Adjacent case for #16191: the binder names must not matter. A renamed
+/// callee/target still recovers the container's type arguments, since the fix
+/// keys on the nominal `Application` provenance and never on any identifier.
+#[test]
+fn renamed_binder_named_form_container_keeps_its_type_arguments_in_the_message() {
+    let libs = load_default_lib_files();
+    let messages = crate::test_utils::check_source_with_libs_code_messages(
+        r#"
+export {};
+declare const zzOther: AsyncGenerator<string>;
+declare function accept(container: AsyncGenerator<{ y: number }>): void;
+async function* produce() {
+    yield zzOther;
+}
+accept(produce());
+"#,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    );
+    let text = messages
+        .iter()
+        .find(|(code, _)| *code == 2345)
+        .map(|(_, message)| message.clone())
+        .unwrap_or_default();
+    assert!(
+        text.contains("AsyncGenerator<AsyncGenerator<string"),
+        "renamed binders must not change the recovered display: {text:?}"
     );
 }


### PR DESCRIPTION
Fixes the named-generator half of #16191, at a broader altitude than the generator repro.

`finalize_call_return_like_success` eagerly reduces a monomorphic `Application` return type to its structural shape at the call site, via `instantiate_application_body_for_property_access`. For a cross-file **nominal generic** interface/class receiver, that reduction produced the substituted body carrying the base's nominal `symbol` but recorded **no display back-reference** to the originating `Name<args>` application — so the printer rendered a bare `Name`, dropping every type argument.

The #16191 witness: an unannotated **named** generator's inferred `AsyncGenerator<Y, R, N>` container is reduced this way at its call site and shows as a bare `AsyncGenerator` in diagnostics, while the anonymous form (which never routes through this reduction) keeps its arguments. The fix records the missing provenance through the solver's `store_display_alias_preferring_application` — the checker-side counterpart to `store_parametric_structural_back_reference` on the ordinary application-evaluation path.

This is **display-only**: the structural type is unchanged, so relations, `yield*` contribution, and emit are untouched, and the separate relation-side self-similar loss (#16125) is deliberately left as-is (its `#[ignore]`d rows stay red, identically). The recorder's own alloc-order / intrinsic / self-reference gates keep any result that already owns a stable spelling untouched, and the reduction path has already excluded lib / `declare` / same-file and non-nominal bases before reaching this point — so no user-name or file-name string drives the decision.

## Goal
Goal: hold

<!-- output-parity gap in diagnostic text; harness-observable, no conformance-code movement -->

## Verification
- `cargo test -p tsz-checker --lib named_form_container_keeps_its_type_arguments_in_the_message` — now green (was a red `#[ignore]`), plus two new adjacent tests (`sync_named_form_container_...`, `renamed_binder_named_form_container_...`) green.
- `cargo nextest run -p tsz-checker --lib` — 9667 passed, 0 failed (16 skipped `#[ignore]`).
- `cargo nextest run -p tsz-solver -p tsz-emitter --lib` — 11626 + emitter passed, 0 failed.
- `cargo nextest run -p tsz-cli --test generator_expression_initializer_dts_emit_tests` — 7 passed (incl. the named-declaration DTS shape), confirming DTS emit is unchanged.
- `cargo clippy -p tsz-checker` — clean; pre-commit arch-size guard passed.
- Full emit / conformance / fourslash require the TypeScript submodule and run in CI on this PR.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01VqMqHEK7Xupp8TCFNwj5cg)_