### PR TITLE
fix(checker): an identifier source annotated with a concrete indexed access renders its reduced member (#16443)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_alias_display.rs
@@ -227,6 +227,18 @@ impl<'a> CheckerState<'a> {
         if self.declared_source_annotation_alias_displayed_as_underlying(expr_idx) {
             return None;
         }
+        // A *concrete* indexed access (`Obj["m"]`) is resolved to its member
+        // type during type construction in tsc, so the written access never
+        // reaches a diagnostic — `source_display` already carries the reduced
+        // member. Repainting it with the annotation as written would restore
+        // the unreduced surface. Same rule, same owner helper as the
+        // missing-property path's guard in
+        // `should_prefer_declared_source_annotation_display`; a deferred
+        // `T["m"]` still declines and keeps its written spelling.
+        let declared_source_type = self.get_type_of_node(expr_idx);
+        if self.source_declared_type_reduces_as_concrete_indexed_access(declared_source_type) {
+            return None;
+        }
         if annotation_text == source_display
             || annotation_text.trim_start().starts_with("typeof ")
             // No structural query for module-import types yet; keep as display fallback.

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -554,6 +554,16 @@ impl<'a> CheckerState<'a> {
         if self.source_declared_type_is_displayed_as_underlying(expr_type) {
             return false;
         }
+        // A *concrete* indexed access (`Obj["m"]`: no free type parameters, a
+        // single string/number literal key) is resolved to its member type
+        // during type construction in tsc (`getIndexedAccessType`), so the
+        // written access is never what a diagnostic renders. The assignment
+        // roles already perform that reduction in `format_type_for_diagnostic_role`;
+        // preferring the annotation as written here would paint the unreduced
+        // surface straight back over the reduced member.
+        if self.source_declared_type_reduces_as_concrete_indexed_access(expr_type) {
+            return false;
+        }
         if annotation.contains("`${") {
             return true;
         }
@@ -619,6 +629,22 @@ impl<'a> CheckerState<'a> {
     /// [`crate::query_boundaries::assignability_alias_display::type_displayed_as_underlying`],
     /// which owns the `Lazy(DefId)` / resolved-shape resolution behind the query
     /// boundary.
+    /// Whether a declared source type is a concrete indexed access that the
+    /// shared display policy reduces to its member type.
+    ///
+    /// The reducibility decision is delegated wholesale to
+    /// [`Self::resolve_concrete_indexed_access_for_display`], which owns the
+    /// "tsc resolved this at construction time" rule: it declines for a
+    /// non-literal key, for a free type parameter anywhere in the object, and
+    /// for anything that fails to evaluate. So a deferred `T["m"]` — which tsc
+    /// also renders as written — still keeps its annotation surface here.
+    pub(in crate::error_reporter) fn source_declared_type_reduces_as_concrete_indexed_access(
+        &mut self,
+        ty: TypeId,
+    ) -> bool {
+        self.resolve_concrete_indexed_access_for_display(ty) != ty
+    }
+
     fn source_declared_type_is_displayed_as_underlying(&self, ty: TypeId) -> bool {
         crate::query_boundaries::assignability_alias_display::type_displayed_as_underlying(
             self.ctx.types.as_type_database(),

--- a/crates/tsz-checker/tests/concrete_indexed_access_display_tests.rs
+++ b/crates/tsz-checker/tests/concrete_indexed_access_display_tests.rs
@@ -371,3 +371,257 @@ const a2: Arr["list"][number] = { w: 1 };
         messages[0]
     );
 }
+
+// ---------------------------------------------------------------------------
+// Source role reached through an *identifier* whose declaration carries the
+// indexed-access annotation.
+//
+// The source-role rows at the top of this file all reach the access through a
+// call return, a property access or an argument — positions where the type is
+// evaluated before the diagnostic is built, so the reduced member is what the
+// display policy receives. A bare identifier is different: the assignment
+// display policy prefers the declaration's annotation *as written* over the
+// computed type, which painted the unreduced `Obj["m"]` surface straight back
+// over the member the role dispatch had already reduced.
+//
+// `tsc` resolves a concrete indexed access in `getIndexedAccessType`, during
+// type construction, so no diagnostic ever sees the access — the annotation
+// surface is not something it can prefer. Both annotation-repaint gates (the
+// missing-property one and the TS2322 alias-pair one) now decline for a
+// declared type the shared display policy reduces. Deferred accesses keep
+// their spelling in both, because the same policy declines for them.
+//
+// Every expectation below is oracle-pinned against `typescript@7.0.2` with the
+// conformance gate's own flags (`--singleThreaded --stableTypeOrdering true`,
+// see #16457).
+// ---------------------------------------------------------------------------
+
+/// The witness: a `const` annotated with a concrete indexed access renders the
+/// reduced member, not the annotation as written.
+#[test]
+fn concrete_indexed_access_identifier_source_renders_reduced_member() {
+    let messages = ts2741_messages(
+        r#"
+interface Missing { only: { k: number } }
+declare const bad: Missing["only"];
+const h: { k: number; extra: number } = bad;
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert_reduced_member(&messages[0], "{ k: number; }");
+}
+
+/// Anti-hardcoding: the gate keys on the declared type being a reducible
+/// concrete access, never on the binder spellings.
+#[test]
+fn concrete_indexed_access_identifier_source_is_binder_name_independent() {
+    let messages = ts2741_messages(
+        r#"
+interface Wrapper { payload: { alpha: number } }
+declare const value: Wrapper["payload"];
+const dest: { alpha: number; beta: number } = value;
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert_reduced_member(&messages[0], "{ alpha: number; }");
+}
+
+/// A `return` statement is the same assignment-source role reached through a
+/// different anchor.
+#[test]
+fn concrete_indexed_access_identifier_source_reduces_in_a_return_statement() {
+    let messages = ts2741_messages(
+        r#"
+interface Missing { only: { k: number } }
+declare const bad: Missing["only"];
+function f(): { k: number; extra: number } { return bad; }
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert_reduced_member(&messages[0], "{ k: number; }");
+}
+
+/// A function parameter's annotation is the same declaration shape as a
+/// variable's.
+#[test]
+fn concrete_indexed_access_parameter_source_renders_reduced_member() {
+    let messages = ts2741_messages(
+        r#"
+interface Missing { only: { k: number } }
+function g(bad: Missing["only"]) {
+  const h: { k: number; extra: number } = bad;
+}
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert_reduced_member(&messages[0], "{ k: number; }");
+}
+
+/// A class member reached through `Class["field"]` in the annotation.
+#[test]
+fn concrete_indexed_access_identifier_source_reduces_a_class_member() {
+    let messages = ts2741_messages(
+        r#"
+class Holder { slot!: { k: number }; }
+declare const bad: Holder["slot"];
+const h: { k: number; extra: number } = bad;
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert_reduced_member(&messages[0], "{ k: number; }");
+}
+
+/// Numeric-literal key in the declared annotation.
+#[test]
+fn concrete_numeric_indexed_access_identifier_source_renders_reduced_member() {
+    let messages = ts2741_messages(
+        r#"
+interface Wrap { 0: { a: number } }
+declare const bad: Wrap[0];
+const h: { a: number; b: number } = bad;
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert_reduced_member(&messages[0], "{ a: number; }");
+}
+
+/// A three-link chain in the annotation reduces all the way, never to a hybrid
+/// of a resolved inner object and the remaining written keys.
+#[test]
+fn chained_indexed_access_identifier_source_reduces_to_a_fixed_point() {
+    let messages = ts2741_messages(
+        r#"
+interface A1 { p: { q: { leaf: number } } }
+declare const bad: A1["p"]["q"];
+const h: { leaf: number; extra: number } = bad;
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert_reduced_member(&messages[0], "{ leaf: number; }");
+}
+
+/// An instantiated generic object operand arrives as an `Application` and
+/// reduces the same way.
+#[test]
+fn concrete_indexed_access_identifier_source_reduces_an_instantiated_generic() {
+    let messages = ts2741_messages(
+        r#"
+interface Box<T> { item: T }
+declare const bad: Box<{ k: number }>["item"];
+const h: { k: number; extra: number } = bad;
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert_reduced_member(&messages[0], "{ k: number; }");
+}
+
+/// An alias that merely renames the object is transparent.
+#[test]
+fn concrete_indexed_access_identifier_source_reduces_through_an_alias_chain() {
+    let messages = ts2741_messages(
+        r#"
+interface Missing { only: { k: number } }
+type Alias = Missing;
+declare const bad: Alias["only"];
+const h: { k: number; extra: number } = bad;
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert_reduced_member(&messages[0], "{ k: number; }");
+}
+
+/// The TS2322 whole-type message takes a *different* annotation-repaint gate
+/// (the generic-alias assignment-pair rewrite), so it needs its own row: a
+/// property-type mismatch renders the reduced member too.
+#[test]
+fn concrete_indexed_access_identifier_source_reduces_in_a_ts2322_message() {
+    let messages = strict_messages(
+        r#"
+interface Missing { only: { k: string } }
+declare const bad: Missing["only"];
+const h: { k: number } = bad;
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("Type '{ k: string; }' is not assignable")),
+        "TS2322 source must render the reduced member: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("[\"")),
+        "no unreduced indexed-access surface may survive: {messages:?}"
+    );
+}
+
+/// Negative control for the missing-property gate. A *deferred* access over a
+/// free type parameter is opaque in tsc too, so the annotation surface stays.
+#[test]
+fn deferred_generic_indexed_access_identifier_source_stays_opaque() {
+    let messages = ts2741_messages(
+        r#"
+interface Missing { only: { k: number } }
+function f<T extends Missing>(bad: T["only"]) {
+  const h: { k: number; extra: number } = bad;
+}
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert!(
+        messages[0].contains("T[\"only\"]"),
+        "a deferred access keeps its written spelling: {}",
+        messages[0]
+    );
+}
+
+/// Negative control for the TS2322 gate, same deferred shape.
+#[test]
+fn deferred_generic_indexed_access_identifier_source_stays_opaque_in_ts2322() {
+    let messages = strict_messages(
+        r#"
+interface Missing { only: { k: string } }
+function f<T extends Missing>(bad: T["only"]) {
+  const h: { k: number } = bad;
+}
+"#,
+    );
+    assert!(
+        messages.iter().any(|m| m.contains("T[\"only\"]")),
+        "a deferred access keeps its written spelling: {messages:?}"
+    );
+}
+
+/// Negative control. The reduction is display-only: an annotation the target
+/// really does accept stays clean.
+#[test]
+fn concrete_indexed_access_identifier_source_assignable_stays_clean() {
+    let messages = strict_messages(
+        r#"
+interface Missing { only: { k: number } }
+declare const bad: Missing["only"];
+const h: { k: number } = bad;
+"#,
+    );
+    assert!(messages.is_empty(), "must stay clean: {messages:?}");
+}
+
+/// Residual, pinned rather than assumed fixed: a non-literal key declines the
+/// shared display policy one guard earlier, so the annotation surface is kept
+/// and the whole chain prints as written. `tsc` reduces this one (recorded on
+/// #16443 as the non-literal-key residual).
+#[test]
+fn nonliteral_key_indexed_access_identifier_source_prints_as_written() {
+    let messages = ts2741_messages(
+        r#"
+interface Arr { list: { k: number }[] }
+declare const bad: Arr["list"][number];
+const h: { k: number; extra: number } = bad;
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert!(
+        messages[0].contains("Arr[\"list\"][number]"),
+        "an unreduced chain must print as written, never half-resolved: {}",
+        messages[0]
+    );
+}


### PR DESCRIPTION
Closes residual 2 of #16443, recorded unclaimed in Kunzite's #16456 handoff: *"a source-role variable annotation renders unreduced where a source-role call return type reduces fine."*

```ts
interface Missing { only: { k: number } }
declare const bad: Missing["only"];
const h: { k: number; extra: number } = bad;
```

| | source renders as |
| --- | --- |
| `tsc` 7.0.2 | `{ k: number; }` |
| tsz on `main` | `Missing["only"]` |
| tsz on this branch | `{ k: number; }` |

**Structural rule.** When an assignment source is an identifier whose declaration annotates it with a *concrete* indexed access — no free type parameters, a single string/number literal key — `tsc` has already resolved that access to its member type in `getIndexedAccessType`, during type construction, so no diagnostic ever sees the written access; tsz now renders the reduced member too, through the checker's `error_reporter` display policy.

**Why it was only the identifier positions.** #16456 established the reduction for the `AssignmentSource`/`AssignmentTarget` roles, and it does run here — `format_type_for_diagnostic_role` reduces the source before dispatching. Every source-role row that already worked reaches the access through a call return, an argument, or a property access. A bare identifier is different: two *later* annotation-repaint gates prefer the declaration's annotation as written over the computed type, and they painted the unreduced surface straight back over the member the role dispatch had just reduced. Instrumented the render path end to end to pin this rather than infer it — the repaint calls are frames 3 and 4 below the role dispatch, not a decline inside the reduction.

A repaint may not override this particular reduction, because the surface it restores corresponds to a type `tsc` never constructs at all. Both gates now decline for a declared type the shared display policy reduces:

- `should_prefer_declared_source_annotation_display` (`core/diagnostic_source.rs`) — the missing-property TS2741 path, shared by three call sites in `assignment_formatting.rs`.
- `declared_generic_alias_assignment_pair_display` (`assignability_alias_display.rs`) — the TS2322 whole-type message, which reaches its repaint through a different gate and so needed its own guard. Found by re-measuring after the first fix rather than assuming one gate covered the family.

Both delegate the entire reducibility decision to the existing `resolve_concrete_indexed_access_for_display`, the same helper the role dispatch uses. Nothing new decides what "concrete" means, and the guards inherit its declines for free: a deferred `T["m"]`, a non-literal key, and anything that fails to evaluate all keep their written spelling in **both** messages, exactly as `tsc` renders them.

**Anti-hardcoding.** The gate reads the declared type's structure, never the annotation's spelling — no identifier, alias, property or file-name literal, and no predicate over rendered output. The renamed-binder row is in the matrix for that reason, and the deferred rows are unmoved in both directions.

## Goal
Goal: hold

## Verification

**Oracle matrix, `typescript@7.0.2`** via `scripts/conformance/oracle.sh` (#16448), i.e. with the conformance gate's own `--singleThreaded --stableTypeOrdering true`, plus `--strict --lib es2022 --target es2022 --module esnext --moduleResolution bundler`. Every row measured on `main` and on this branch:

| row | tsc | main | branch |
| --- | --- | --- | --- |
| variable annotation | `{ k: number; }` | `Missing["only"]` | **fixed** |
| renamed binders | `{ alpha: number; }` | `Wrapper["payload"]` | **fixed** |
| `return` statement | `{ k: number; }` | `Missing["only"]` | **fixed** |
| function parameter | `{ k: number; }` | `Missing["only"]` | **fixed** |
| class member `Holder["slot"]` | `{ k: number; }` | `Holder["slot"]` | **fixed** |
| numeric key `Wrap[0]` | `{ a: number; }` | `Wrap[0]` | **fixed** |
| chain `A1["p"]["q"]` | `{ leaf: number; }` | `A1["p"]["q"]` | **fixed** |
| instantiated generic `Box<{k}>["item"]` | `{ k: number; }` | `Box<{ k: number; }>["item"]` | **fixed** |
| alias chain `Alias["only"]` | `{ k: number; }` | `Alias["only"]` | **fixed** |
| TS2322 property mismatch | `{ k: string; }` | `Missing["only"]` | **fixed** |
| call return (control) | `{ k: number; }` | ok | unchanged |
| argument (control) | `{ k: number; }` | ok | unchanged |
| property access (control) | `{ k: number; }` | ok | unchanged |
| deferred `T["only"]`, TS2741 | `T["only"]` | `T["only"]` | unchanged |
| deferred `T["only"]`, TS2322 | `T["only"]` | `T["only"]` | unchanged |
| assignable source (clean control) | no error | clean | clean |
| non-literal key `Arr["list"][number]` | `{ k: number; }` | as written | as written (**residual**) |

10 fixed / 0 broken. The last row is #16443's known non-literal-key residual (declines a guard earlier than anything this PR touches) — pinned by a test rather than left to drift, matching how #16456 pinned it in the target role. Union-key (`U["a" | "b"]`) and `keyof`-key (`Q[keyof Q]`) sources are the same residual seen from two more angles; `tsc` reduces both.

**Suites**

- `cargo test -p tsz-checker --test concrete_indexed_access_display_tests` — **32 passed, 0 failed** (18 pre-existing + 14 new). All 14 new rows were measured against `main`'s behaviour before the fix; the 10 positive ones reproduce the unreduced surface there, so none is vacuous.
- `cargo test -p tsz-checker --lib` — full crate, result posted below before this is queued.
- `cargo fmt --all`, `cargo clippy -p tsz-checker --all-targets -- -D warnings` — clean. Pre-commit architecture guard passed.
- Corpus gate: **not owed.** `scripts/conformance/lib/results.py::compute_diff` grades `Counter(expected)` vs `Counter(actual)` over error *codes* only, and this diff moves the rendered text of existing TS2741/TS2322 diagnostics — no code, span, type identity, relation verdict, or emitter path changes. The same reasoning was predicted and then confirmed by a real run on #16446 and #16456, both in this family (`11490 -> 11490`, 0 regressed / 0 fixed).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Larimar

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLn3hfhj6dDZnwokeGdZUd)_