### PR TITLE
fix(checker): a type literal routes a plain-symbol computed key to a symbol index signature (#16307)

### DIFF
--- a/crates/tsz-checker/src/types/type_literal_checker.rs
+++ b/crates/tsz-checker/src/types/type_literal_checker.rs
@@ -1113,6 +1113,38 @@ impl<'a> CheckerState<'a> {
     // Type Literal Resolution
     // =========================================================================
 
+    /// Merge one wide-`symbol`-keyed computed member's value into a type
+    /// literal's symbol index signature. Several `symbol`-keyed members
+    /// contribute to ONE `[key: symbol]: V` signature whose value type is the
+    /// UNION of their values, matching tsc: `{ [s1]: number; [s2]: string }`
+    /// reads as `[key: symbol]: string | number`, and the index is `readonly`
+    /// only when every contributor is (a getter contributes readonly, a setter
+    /// or property writable). Unlike two EXPLICIT `[k: symbol]` index signatures
+    /// — a genuine duplicate — distinct computed keys never collide.
+    fn merge_type_literal_symbol_index(
+        &self,
+        symbol_index: &mut Option<tsz_solver::IndexSignature>,
+        value_type: TypeId,
+        readonly: bool,
+    ) {
+        let info = crate::query_boundaries::type_construction::declared_index_signature(
+            TypeId::SYMBOL,
+            value_type,
+            readonly,
+            None,
+        );
+        match symbol_index.as_mut() {
+            None => *symbol_index = Some(info),
+            Some(existing) => {
+                super::interface_type::merge_string_index_by_union(
+                    existing,
+                    info,
+                    self.ctx.types.factory(),
+                );
+            }
+        }
+    }
+
     /// Get type from a type literal node (anonymous object types).
     ///
     /// Type literals represent inline object types like `{ x: string; y: number }` or
@@ -1264,6 +1296,56 @@ impl<'a> CheckerState<'a> {
                         self.pop_type_parameters(type_param_updates);
                     }
                     METHOD_SIGNATURE | PROPERTY_SIGNATURE => {
+                        // A computed key whose expression is a plain (non-unique)
+                        // `symbol` binding contributes a `[key: symbol]: V` index
+                        // signature to the containing type, exactly like tsc
+                        // (#16307) — never a synthetic named member. The interface
+                        // lowering and object-literal paths already route this way;
+                        // this checker-side type-literal builder must match, or a
+                        // `type`/inline `{ [s]: T }` mints a `__symbol_<file>_<sym>`
+                        // named member instead, and two independently `symbol`-keyed
+                        // type literals become mutually unassignable (TS2741) with
+                        // the placeholder key leaking into diagnostic text. Well-known
+                        // `[Symbol.x]` syntax, `typeof Symbol.x` aliases, and genuine
+                        // `unique symbol` keys are excluded by
+                        // `computed_member_key_is_wide_symbol` and keep named identity.
+                        if self.computed_member_key_is_wide_symbol(sig.name) {
+                            let readonly = self.has_readonly_modifier(&sig.modifiers);
+                            let value_type = if member.kind == METHOD_SIGNATURE {
+                                let (type_params, type_param_updates) =
+                                    self.push_type_parameters(&sig.type_parameters);
+                                let (params, this_type) =
+                                    self.extract_params_from_signature_in_type_literal(sig);
+                                let (return_type, type_predicate) = self
+                                    .return_type_and_predicate_in_type_literal(
+                                        sig.type_annotation,
+                                        &params,
+                                        crate::signature_builder::signature_param_nodes(
+                                            &sig.parameters,
+                                        ),
+                                    );
+                                let call_sig = signature_building_boundary::call_signature(
+                                    type_params,
+                                    params,
+                                    this_type,
+                                    return_type,
+                                    type_predicate,
+                                    true,
+                                );
+                                self.pop_type_parameters(type_param_updates);
+                                method_function_type_from_call_signature(self.ctx.types, &call_sig)
+                            } else if sig.type_annotation.is_some() {
+                                self.get_type_from_type_node_in_type_literal(sig.type_annotation)
+                            } else {
+                                TypeId::ANY
+                            };
+                            self.merge_type_literal_symbol_index(
+                                &mut symbol_index,
+                                value_type,
+                                readonly,
+                            );
+                            continue;
+                        }
                         let Some(name) = self.get_property_name_resolved(sig.name) else {
                             if self
                                 .ctx
@@ -1512,6 +1594,41 @@ impl<'a> CheckerState<'a> {
                         }
                     }
                 }
+                continue;
+            }
+
+            // A get/set accessor keyed by a plain `symbol` binding routes into
+            // the symbol index signature (getter contributes a readonly value,
+            // setter a writable one) exactly like the interface-lowering path
+            // (#16307), rather than minting a synthetic `__symbol_` named member.
+            if (member.kind == tsz_parser::parser::syntax_kind_ext::GET_ACCESSOR
+                || member.kind == tsz_parser::parser::syntax_kind_ext::SET_ACCESSOR)
+                && let Some(accessor) = self.ctx.arena.get_accessor(member)
+                && self.computed_member_key_is_wide_symbol(accessor.name)
+            {
+                let is_getter = member.kind == tsz_parser::parser::syntax_kind_ext::GET_ACCESSOR;
+                let value_type = if is_getter {
+                    if accessor.type_annotation.is_some() {
+                        self.get_type_from_type_node_in_type_literal(accessor.type_annotation)
+                    } else {
+                        TypeId::ANY
+                    }
+                } else {
+                    accessor
+                        .parameters
+                        .nodes
+                        .first()
+                        .and_then(|&param_idx| self.ctx.arena.get(param_idx))
+                        .and_then(|param_node| self.ctx.arena.get_parameter(param_node))
+                        .map_or(TypeId::UNKNOWN, |param| {
+                            if param.type_annotation.is_some() {
+                                self.get_type_from_type_node_in_type_literal(param.type_annotation)
+                            } else {
+                                TypeId::ANY
+                            }
+                        })
+                };
+                self.merge_type_literal_symbol_index(&mut symbol_index, value_type, is_getter);
                 continue;
             }
 

--- a/crates/tsz-checker/tests/wide_symbol_computed_member_index_signature_tests.rs
+++ b/crates/tsz-checker/tests/wide_symbol_computed_member_index_signature_tests.rs
@@ -111,6 +111,152 @@ export const called: number = h[other]();
 }
 
 #[test]
+fn type_alias_wide_symbol_computed_member_routes_to_symbol_index() {
+    // #16307 type-literal leg: the interface, object-literal and class paths
+    // route a plain-`symbol`-keyed computed member into the containing type's
+    // symbol index signature, but the CHECKER-side type-literal builder
+    // (`get_type_from_type_literal`) minted a synthetic `__symbol_<file>_<sym>`
+    // NAMED member instead — so a `type` alias with a `symbol`-keyed member was
+    // NOT mutually assignable with an explicit `[k: symbol]` alias, the
+    // placeholder key leaked into TS2741 text, and `t[other]` reported TS7053.
+    // tsc 7.0.2: exit 0 on every line below.
+    assert_clean(
+        r#"
+declare const s: symbol;
+declare const other: symbol;
+type Implicit = { [s]: number };
+type Explicit = { [k: symbol]: number };
+declare const i: Implicit;
+declare const e: Explicit;
+export const readImplicit: number = i[other];
+export const implicitToExplicit: Explicit = i;
+export const explicitToImplicit: Implicit = e;
+"#,
+    );
+}
+
+#[test]
+fn inline_type_literal_wide_symbol_computed_member_routes_to_symbol_index() {
+    // Same rule for an inline `{ [s]: T }` annotation written directly (no
+    // alias), both assignability directions.
+    assert_clean(
+        r#"
+declare const s: symbol;
+declare const ex: { [k: symbol]: number };
+declare const im: { [s]: number };
+export const toExplicit: { [k: symbol]: number } = im;
+export const toImplicit: { [s]: number } = ex;
+"#,
+    );
+}
+
+#[test]
+fn two_independent_wide_symbol_keyed_type_aliases_are_mutually_assignable() {
+    // Type-literal counterpart of the interface case: two aliases each keyed by
+    // a DIFFERENT `symbol`-typed const still describe the same member set.
+    assert_clean(
+        r#"
+declare const symA: symbol;
+declare const symB: symbol;
+type FromA = { [symA]: number };
+type FromB = { [symB]: number };
+declare const a: FromA;
+declare const b: FromB;
+export const aToB: FromB = a;
+export const bToA: FromA = b;
+"#,
+    );
+}
+
+#[test]
+fn type_alias_wide_symbol_index_alongside_named_members() {
+    // A `symbol`-keyed computed member and ordinary named members coexist on the
+    // same type literal: the named members stay named, the symbol member becomes
+    // the symbol index signature.
+    assert_clean(
+        r#"
+declare const s: symbol;
+declare const other: symbol;
+type Mixed = { name: string; [s]: number };
+declare const m: Mixed;
+export const nameRead: string = m.name;
+export const symbolRead: number = m[other];
+"#,
+    );
+}
+
+#[test]
+fn type_alias_wide_symbol_computed_member_renamed_binders() {
+    // Anti-hardcoding: rename every identifier so nothing keys off a specific
+    // binder name.
+    assert_clean(
+        r#"
+declare const registryKey: symbol;
+declare const lookupKey: symbol;
+type Registry = { [registryKey]: string };
+type SymbolBag = { [pk: symbol]: string };
+declare const reg: Registry;
+declare const bag: SymbolBag;
+export const readReg: string = reg[lookupKey];
+export const regToBag: SymbolBag = reg;
+export const bagToReg: Registry = bag;
+"#,
+    );
+}
+
+#[test]
+fn type_alias_distinct_wide_symbols_union_their_value_types() {
+    // Distinct `symbol`-keyed computed members contribute to ONE symbol index
+    // signature whose value type is the UNION of their values — they do not
+    // collide. tsc reads `t[other]` here as `string | number` (exit 0); the
+    // element access must not report TS7053.
+    assert_clean(
+        r#"
+declare const s1: symbol;
+declare const s2: symbol;
+declare const other: symbol;
+type T = { [s1]: number; [s2]: string };
+declare const t: T;
+export const r: string | number = t[other];
+"#,
+    );
+}
+
+#[test]
+fn type_alias_wide_symbol_method_member_routes_to_symbol_index() {
+    // Method form of the type-literal computed `symbol` key.
+    assert_clean(
+        r#"
+declare const s: symbol;
+declare const other: symbol;
+type HasMethod = { [s](): number };
+declare const h: HasMethod;
+export const called: number = h[other]();
+"#,
+    );
+}
+
+#[test]
+fn inline_type_literal_unique_symbol_member_keeps_named_identity() {
+    // Negative control for the type-literal leg: a genuine `unique symbol` key
+    // must NOT fold into a symbol index signature. Assigning a `[k: symbol]`
+    // index-signature value to a `unique`-keyed type literal is a real mismatch,
+    // exactly as tsc reports (the `unique symbol` member is missing).
+    let source = r#"
+declare const u: unique symbol;
+type Unique = { [u]: number };
+declare const ex: { [k: symbol]: number };
+export const bad: Unique = ex;
+"#;
+    let diags = check_source_diagnostics(source);
+    assert!(
+        diags.iter().any(|d| d.code == 2322 || d.code == 2741),
+        "a `unique symbol`-keyed type literal must keep its named identity, not \
+         accept an arbitrary symbol index signature, got: {diags:?}"
+    );
+}
+
+#[test]
 fn unique_symbol_computed_member_keeps_distinct_identity_not_index() {
     // Negative control: a genuine `unique symbol` key must NOT be folded
     // into a symbol index signature — it keeps its own named identity, so


### PR DESCRIPTION
Goal: green

## Structural rule

When a computed member name is keyed by a plain `symbol` binding — `declare const s: symbol`, not a `unique symbol`, not a well-known `Symbol.x`, not a string/number literal — `tsc` contributes a **symbol index signature** (`[key: symbol]: T`) to the containing type rather than minting a named member. Two type literals keyed by different `symbol`-typed consts therefore describe the same member set and stay mutually assignable, `obj[someSymbol]` is indexable, and no placeholder key exists to leak into diagnostic text.

tsz already routed this correctly for **interfaces** (via the lowerer + `precompute_wide_symbol_computed_property_names`), **object literals**, and **classes**. But the checker-side **type-literal** builder — `CheckerState::get_type_from_type_literal` in `type_literal_checker.rs`, used for `type` aliases and inline `{ … }` annotations — bypasses the lowerer's `collect_object_type_members` routing entirely and minted a synthetic `__symbol_<file>_<sym>` **named** member instead. Consequences, all matching the original #16307 report but surviving only on the type-literal path:

1. `type T = { [s]: number }` was **not** mutually assignable with `type Ex = { [k: symbol]: number }` → false `TS2741`/`TS2322`;
2. `t[other]` against such a type reported false `TS7053`;
3. the internal `__symbol_<file>_<sym>` key leaked into `TS2741` text.

Owner: `tsz_checker` type-literal member construction (`get_type_from_type_literal`). Fix: before resolving a computed property/method/accessor key into a named member, check `computed_member_key_is_wide_symbol` (the same checker detector the object-literal and class-member paths already use) and, when true, route the value into the type literal's `symbol_index` via a new `merge_type_literal_symbol_index` helper. Several `symbol`-keyed members contribute to ONE `[key: symbol]: V` signature whose value type is the **union** of their values (tsc: `{ [s1]: number; [s2]: string }` reads as `[key: symbol]: string | number`), and the index is `readonly` only when every contributor is. Well-known `[Symbol.x]` syntax, `typeof Symbol.x` aliases, and genuine `unique symbol` keys are excluded by `computed_member_key_is_wide_symbol` and keep named identity.

Note: the interface path also mis-handles the *different-value-type* conflict (`interface T { [s1]: number; [s2]: string }` collapses to a `TS7053`-triggering `ERROR` via the lowerer's `merge_index_signature`) — a pre-existing gap not introduced here; this PR gets the type-literal path fully correct and leaves the shared-lowerer union for a separate change.

## Adjacent-case matrix (oracle-pinned, `tsc` 7.0.2)

| Shape | tsc | tsz before | tsz after |
|---|---|---|---|
| `type T = { [s]: number }` ↔ `{ [k: symbol]: number }` (both directions) | ok | **TS2741** | ok |
| inline `const b: { [s]: number } = ex` | ok | **TS2741** | ok |
| `t[other]` read on `type T = { [s]: number }` | ok | **TS7053** | ok |
| two aliases keyed by different `symbol` consts (same value type) | ok | **TS2741** | ok |
| `{ [s1]: number; [s2]: string }`, `t[other]` reads `string \| number` | ok | **TS7053** | ok |
| `symbol` index alongside named members on same literal | ok | ok | ok |
| method form `type T = { [s](): number }` | ok | **TS2741** | ok |
| renamed binders (anti-hardcoding) | ok | **TS2741** | ok |
| `unique symbol` key in a type literal (negative control) | mismatch | mismatch | mismatch |
| interface / object-literal / class forms (already correct) | ok | ok | ok |

## Verification

- New oracle-pinned unit tests in `crates/tsz-checker/tests/wide_symbol_computed_member_index_signature_tests.rs` (type-alias, inline, both directions, index read, mutual assignability, mixed named+symbol, method form, renamed binders, distinct-symbol union, and a `unique symbol` negative control).
- `cargo build -p tsz-checker` clean; clippy + architecture guard pass.
- Targeted unit suites all green: `wide_symbol_computed_member_index_signature_tests` (19), `symbol_index_signature_tests` (93), `cross_file_symbol_keyed_member_instantiation_tests` (11).
- Emit floor: `./scripts/emit/run.sh --skip-build` (11562 JS / 1375 DTS).
- Conformance snapshot diffed against baseline.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mu7cq53ZT155Uj7rgf51ES)_