### PR TITLE
fix(parser): #16403's 3 remaining modifier-before-export mismatches

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -839,6 +839,8 @@ mod ts1318_abstract_accessor_implementation_tests;
 mod ts1361_ambient_computed_property_name_tests;
 #[path = "tests/ts1539_bigint_literal_property_name_tests.rs"]
 mod ts1539_bigint_literal_property_name_tests;
+#[path = "tests/ts16403_declare_abstract_export_equals_residual_tests.rs"]
+mod ts16403_declare_abstract_export_equals_residual_tests;
 #[path = "tests/ts18010_jsdoc_tag_anchor_tests.rs"]
 mod ts18010_jsdoc_tag_anchor_tests;
 #[path = "tests/ts18017_ts18018_private_identifier_shadow_related_info_tests.rs"]

--- a/crates/tsz-checker/src/test_utils.rs
+++ b/crates/tsz-checker/src/test_utils.rs
@@ -240,9 +240,7 @@ pub fn check_source_codes_with_parse_health(source: &str) -> Vec<u32> {
 /// [`grammar_only_parse_health`] to keep this module under the file-size cap
 /// (§19); re-exported so existing call sites are unchanged.
 mod grammar_only_parse_health;
-pub use grammar_only_parse_health::{
-    check_source_codes_with_grammar_only_parse_health, check_source_with_grammar_only_parse_health,
-};
+pub use grammar_only_parse_health::*;
 
 /// Types that expose a diagnostic code for code-only test assertions.
 pub trait HasDiagnosticCode {

--- a/crates/tsz-checker/src/test_utils/grammar_only_parse_health.rs
+++ b/crates/tsz-checker/src/test_utils/grammar_only_parse_health.rs
@@ -27,6 +27,17 @@ use tsz_parser::parser::ParserState;
 /// `all_parse_error_positions`, matching production's actual split for these
 /// sources.
 pub fn check_source_with_grammar_only_parse_health(source: &str) -> (Vec<u32>, Vec<u32>) {
+    check_source_with_grammar_only_parse_health_and_options(source, CheckerOptions::default())
+}
+
+/// [`check_source_with_grammar_only_parse_health`], with caller-supplied
+/// `CheckerOptions` — needed whenever the diagnostic under test also depends
+/// on compiler options the default doesn't set (e.g. TS1203's ES-module
+/// `--module` gate).
+pub fn check_source_with_grammar_only_parse_health_and_options(
+    source: &str,
+    options: CheckerOptions,
+) -> (Vec<u32>, Vec<u32>) {
     let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
     let source_file = parser.parse_source_file();
     let parse_diagnostics = parser.get_diagnostics().to_vec();
@@ -40,7 +51,7 @@ pub fn check_source_with_grammar_only_parse_health(source: &str) -> (Vec<u32>, V
         &binder,
         &types,
         "test.ts".to_string(),
-        CheckerOptions::default(),
+        options,
     );
     checker.enable_source_file_test_pragmas();
     checker.ctx.set_lib_contexts(Vec::new());
@@ -63,4 +74,51 @@ pub fn check_source_with_grammar_only_parse_health(source: &str) -> (Vec<u32>, V
 pub fn check_source_codes_with_grammar_only_parse_health(source: &str) -> Vec<u32> {
     let (parse_codes, checker_codes) = check_source_with_grammar_only_parse_health(source);
     parse_codes.into_iter().chain(checker_codes).collect()
+}
+
+/// `(code, start)` pairs for a diagnostic list — a code plus the byte offset
+/// it anchors on.
+pub type DiagnosticCodePositions = Vec<(u32, u32)>;
+
+/// [`check_source_with_grammar_only_parse_health_and_options`], keeping each
+/// diagnostic's start offset alongside its code as `(code, start)` — needed
+/// for tests that must additionally pin *where* a diagnostic anchors (e.g. a
+/// modifier-prefixed `export =`'s TS1203/TS1120/TS2714 all read the node's
+/// own start position, not just whether the code fires).
+pub fn check_source_with_grammar_only_parse_health_positions(
+    source: &str,
+    options: CheckerOptions,
+) -> (DiagnosticCodePositions, DiagnosticCodePositions) {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let source_file = parser.parse_source_file();
+    let parse_diagnostics = parser.get_diagnostics().to_vec();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), source_file);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        options,
+    );
+    checker.enable_source_file_test_pragmas();
+    checker.ctx.set_lib_contexts(Vec::new());
+    checker.ctx.all_parse_error_positions =
+        parse_diagnostics.iter().map(|diag| diag.start).collect();
+    checker.check_source_file(source_file);
+
+    let parse = parse_diagnostics
+        .iter()
+        .map(|diag| (diag.code, diag.start))
+        .collect();
+    let chk = checker
+        .ctx
+        .diagnostics
+        .iter()
+        .map(|diag| (diag.code, diag.start))
+        .collect();
+    (parse, chk)
 }

--- a/crates/tsz-checker/src/tests/ts16403_declare_abstract_export_equals_residual_tests.rs
+++ b/crates/tsz-checker/src/tests/ts16403_declare_abstract_export_equals_residual_tests.rs
@@ -1,0 +1,303 @@
+//! #16403's three remaining mismatches left open by #16452 (the `async`
+//! slice): `declare export namespace N {}`, `declare export = <expr>`, and
+//! `abstract export = <expr>`.
+//!
+//! **`declare export namespace N {}` missed TS1029 entirely.** The parser's
+//! TS1029 gate (`state_declarations.rs`'s `parse_ambient_declaration_with_modifiers`,
+//! `SyntaxKind::ExportKeyword` arm) carried a stale exclusion for
+//! `ModuleKeyword`/`NamespaceKeyword`, commented as "tsc 6.0 accepts this form
+//! without TS1029" — measured false against the pinned `typescript@7.0.2`
+//! oracle: a `declare export namespace` at the source file's own top level or
+//! inside a namespace body reports TS1029 like every other `declare export
+//! <declaration>` form; only a Block silences it (there, the nested module
+//! declaration's own TS1235 wins, oracle-confirmed, itself unaffected by this
+//! fix since it is checker-side).
+//!
+//! **`declare export = <expr>` and `abstract export = <expr>` both picked a
+//! wrong code or position.** The root cause is one structural bug shared by
+//! every modifier family: `parse_export_assignment` hard-coded
+//! `ExportAssignmentData.modifiers: None`, so no modifier-prefixed `export =`
+//! node ever carried its `declare` (or any other) modifier. Two independent
+//! checker checks read that field through `is_in_ambient_context`'s walk over
+//! `get_declaration_modifiers`:
+//!
+//! - TS1203 ("Export assignment cannot be used when targeting ECMAScript
+//!   modules") is suppressed for an *ambient* `export =`; without the
+//!   `declare` modifier attached, `declare export = 1;` incorrectly kept
+//!   TS1203 instead of suppressing it, and the ambient-only TS2714 ("The
+//!   expression of an export assignment must be an identifier or qualified
+//!   name in an ambient context") never fired at all.
+//! - Separately, `parse_accessor_modified_statement`'s `ExportKeyword` arm
+//!   (shared by every modifier family reaching it — `static`/`readonly`/
+//!   `public`/`protected`/`private`/`abstract`) delegated `export = <expr>`
+//!   straight to `parse_export_declaration()`, which recomputes its own
+//!   `start_pos` from the *current* `export` token and drops every modifier
+//!   collected so far — so TS1203's node-anchored position landed on
+//!   `export`, not on the modifier that actually starts the statement
+//!   (oracle-confirmed: tsc anchors both TS1044/TS1242-family and TS1203 on
+//!   the modifier, not on `export`).
+//!
+//! `abstract` additionally never recognized `export =` as a target at all
+//! (`look_ahead_abstract_before_export_target`'s comment called it "routed
+//! through TS1120" — that claim does not hold against the oracle either:
+//! `abstract` gets its own per-modifier TS1242, not the generic TS1120
+//! `declare`/`export export =` share), so `abstract export = 1;` degraded
+//! `abstract` to a bare identifier expression (dropping TS1242 outright) and
+//! then re-parsed `export = 1;` as an unrelated, unmodified top-level
+//! statement.
+//!
+//! All expectations measured directly against the pinned `typescript@7.0.2`
+//! oracle (`scripts/conformance/typescript-versions.json`),
+//! `--noEmit --strict --pretty false --target es2022 --module es2022`.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{
+    DiagnosticCodePositions, check_source_with_grammar_only_parse_health_positions,
+};
+use tsz_common::common::ModuleKind;
+
+const MODIFIER_MUST_PRECEDE_MODIFIER: u32 = 1029;
+const A_NAMESPACE_DECLARATION_IS_ONLY_ALLOWED_AT_THE_TOP_LEVEL: u32 = 1235;
+const AN_EXPORT_ASSIGNMENT_CANNOT_HAVE_MODIFIERS: u32 = 1120;
+const AN_EXPORT_ASSIGNMENT_MUST_BE_AT_THE_TOP_LEVEL: u32 = 1231;
+const AN_EXPORT_ASSIGNMENT_CANNOT_BE_USED_IN_A_NAMESPACE: u32 = 1063;
+const ABSTRACT_MODIFIER_CAN_ONLY_APPEAR_ON_A_CLASS_METHOD_OR_PROPERTY_DECLARATION: u32 = 1242;
+const EXPORT_ASSIGNMENT_CANNOT_BE_USED_WHEN_TARGETING_ECMASCRIPT_MODULES: u32 = 1203;
+const THE_EXPRESSION_OF_AN_EXPORT_ASSIGNMENT_MUST_BE_AN_IDENTIFIER: u32 = 2714;
+const MODIFIER_CANNOT_APPEAR_ON_A_MODULE_OR_NAMESPACE_ELEMENT: u32 = 1044;
+
+fn diagnostics(source: &str) -> (DiagnosticCodePositions, DiagnosticCodePositions) {
+    let options = CheckerOptions {
+        module: ModuleKind::ES2022,
+        ..CheckerOptions::default()
+    };
+    check_source_with_grammar_only_parse_health_positions(source, options)
+}
+
+fn all_codes(source: &str) -> Vec<u32> {
+    let (parse, chk) = diagnostics(source);
+    parse.into_iter().chain(chk).map(|(code, _)| code).collect()
+}
+
+// -- `declare export namespace N {}`: oracle TS1029 alone at top level and
+//    inside a namespace body; a Block silences it (the nested module
+//    declaration's own TS1235 wins instead, checker-side and unaffected). --
+
+#[test]
+fn declare_export_namespace_reports_ts1029_at_top_level() {
+    let source = "declare export namespace N {}";
+    let (parse, chk) = diagnostics(source);
+    let export_start = source.find("export").unwrap() as u32;
+    assert_eq!(
+        parse,
+        vec![(MODIFIER_MUST_PRECEDE_MODIFIER, export_start)],
+        "expected TS1029 alone anchored on `export`, got parse={parse:?} checker={chk:?}"
+    );
+    assert!(chk.is_empty(), "unexpected checker diagnostics: {chk:?}");
+}
+
+#[test]
+fn declare_export_namespace_reports_ts1029_in_a_namespace_body() {
+    let source = "namespace M { declare export namespace N {} }";
+    let (parse, chk) = diagnostics(source);
+    let export_start = source.find("export").unwrap() as u32;
+    assert_eq!(
+        parse,
+        vec![(MODIFIER_MUST_PRECEDE_MODIFIER, export_start)],
+        "expected TS1029 alone anchored on `export`, got parse={parse:?} checker={chk:?}"
+    );
+    assert!(chk.is_empty(), "unexpected checker diagnostics: {chk:?}");
+}
+
+#[test]
+fn declare_export_namespace_in_a_block_yields_to_ts1235_alone() {
+    let source = "function f() { declare export namespace N {} }";
+    let (parse, chk) = diagnostics(source);
+    assert!(
+        parse.is_empty(),
+        "a Block must not additionally gain TS1029: {parse:?}"
+    );
+    let declare_start = source.find("declare").unwrap() as u32;
+    assert_eq!(
+        chk,
+        vec![(
+            A_NAMESPACE_DECLARATION_IS_ONLY_ALLOWED_AT_THE_TOP_LEVEL,
+            declare_start
+        )],
+        "expected TS1235 alone anchored on the modifier run's start, got {chk:?}"
+    );
+}
+
+// -- `declare export = <expr>`: oracle TS1120 + TS2714 at top level (the
+//    ambient `declare` suppresses TS1203 and enables the ambient-expression
+//    check instead); TS1231/TS1063 alone in a Block / namespace body. --
+
+#[test]
+fn declare_export_equals_reports_ts1120_and_ts2714_at_top_level() {
+    let source = "declare export = 1;";
+    let (parse, chk) = diagnostics(source);
+    assert_eq!(
+        parse,
+        vec![(AN_EXPORT_ASSIGNMENT_CANNOT_HAVE_MODIFIERS, 0)],
+        "expected TS1120 anchored at the statement's own start, got {parse:?}"
+    );
+    let expr_start = source.find('1').unwrap() as u32;
+    assert_eq!(
+        chk,
+        vec![(
+            THE_EXPRESSION_OF_AN_EXPORT_ASSIGNMENT_MUST_BE_AN_IDENTIFIER,
+            expr_start
+        )],
+        "expected TS2714 alone (ambient `declare` must suppress TS1203), got {chk:?}"
+    );
+}
+
+#[test]
+fn declare_export_equals_in_a_block_yields_to_ts1231_alone() {
+    let source = "function f() { declare export = 1; }";
+    let (parse, chk) = diagnostics(source);
+    assert!(parse.is_empty(), "unexpected parse diagnostics: {parse:?}");
+    let declare_start = source.find("declare").unwrap() as u32;
+    assert_eq!(
+        chk,
+        vec![(AN_EXPORT_ASSIGNMENT_MUST_BE_AT_THE_TOP_LEVEL, declare_start)],
+        "expected TS1231 alone anchored on the modifier run's start, got {chk:?}"
+    );
+}
+
+#[test]
+fn declare_export_equals_in_a_namespace_body_yields_to_ts1063_alone() {
+    let source = "namespace M { declare export = 1; }";
+    let (parse, chk) = diagnostics(source);
+    assert!(parse.is_empty(), "unexpected parse diagnostics: {parse:?}");
+    let declare_start = source.find("declare").unwrap() as u32;
+    assert_eq!(
+        chk,
+        vec![(
+            AN_EXPORT_ASSIGNMENT_CANNOT_BE_USED_IN_A_NAMESPACE,
+            declare_start
+        )],
+        "expected TS1063 alone anchored on the modifier run's start, got {chk:?}"
+    );
+}
+
+// -- `abstract export = <expr>`: oracle TS1242 + TS1203 at top level (both
+//    anchored on `abstract`, not `export`); TS1231/TS1063 alone in a Block /
+//    namespace body, same silencing shape as `abstract export default`. --
+
+#[test]
+fn abstract_export_equals_reports_ts1242_and_ts1203_at_top_level() {
+    let source = "abstract export = 1;";
+    let (parse, chk) = diagnostics(source);
+    assert_eq!(
+        parse,
+        vec![(
+            ABSTRACT_MODIFIER_CAN_ONLY_APPEAR_ON_A_CLASS_METHOD_OR_PROPERTY_DECLARATION,
+            0
+        )],
+        "expected TS1242 anchored on `abstract`, got {parse:?}"
+    );
+    assert_eq!(
+        chk,
+        vec![(
+            EXPORT_ASSIGNMENT_CANNOT_BE_USED_WHEN_TARGETING_ECMASCRIPT_MODULES,
+            0
+        )],
+        "expected TS1203 anchored on the statement's own start (not `export`), got {chk:?}"
+    );
+}
+
+#[test]
+fn abstract_export_equals_in_a_block_yields_to_ts1231_alone() {
+    let source = "function f() { abstract export = 1; }";
+    let (parse, chk) = diagnostics(source);
+    assert!(parse.is_empty(), "unexpected parse diagnostics: {parse:?}");
+    let abstract_start = source.find("abstract").unwrap() as u32;
+    assert_eq!(
+        chk,
+        vec![(
+            AN_EXPORT_ASSIGNMENT_MUST_BE_AT_THE_TOP_LEVEL,
+            abstract_start
+        )],
+        "expected TS1231 alone anchored on the modifier run's start, got {chk:?}"
+    );
+}
+
+#[test]
+fn abstract_export_equals_in_a_namespace_body_yields_to_ts1063_alone() {
+    let source = "namespace M { abstract export = 1; }";
+    let (parse, chk) = diagnostics(source);
+    assert!(parse.is_empty(), "unexpected parse diagnostics: {parse:?}");
+    let abstract_start = source.find("abstract").unwrap() as u32;
+    assert_eq!(
+        chk,
+        vec![(
+            AN_EXPORT_ASSIGNMENT_CANNOT_BE_USED_IN_A_NAMESPACE,
+            abstract_start
+        )],
+        "expected TS1063 alone anchored on the modifier run's start, got {chk:?}"
+    );
+}
+
+// -- The shared `parse_accessor_modified_statement` fix benefits every
+//    modifier family reaching it, not just `abstract` — `static`'s own
+//    TS1044 + TS1203 pair must anchor on `static`, not `export`, exactly the
+//    same way. --
+
+#[test]
+fn static_export_equals_anchors_both_diagnostics_on_static_not_export() {
+    let source = "static export = 1;";
+    let (parse, chk) = diagnostics(source);
+    assert_eq!(
+        parse,
+        vec![(MODIFIER_CANNOT_APPEAR_ON_A_MODULE_OR_NAMESPACE_ELEMENT, 0)],
+        "expected TS1044 anchored on `static`, got {parse:?}"
+    );
+    assert_eq!(
+        chk,
+        vec![(
+            EXPORT_ASSIGNMENT_CANNOT_BE_USED_WHEN_TARGETING_ECMASCRIPT_MODULES,
+            0
+        )],
+        "expected TS1203 anchored on the statement's own start (not `export`), got {chk:?}"
+    );
+}
+
+// -- Negative controls: shapes this fix must leave exactly as they were. --
+
+#[test]
+fn plain_export_equals_is_unaffected() {
+    let source = "const a = {}; export = a;";
+    let (parse, chk) = diagnostics(source);
+    assert!(parse.is_empty());
+    let export_start = source.find("export").unwrap() as u32;
+    assert_eq!(
+        chk,
+        vec![(
+            EXPORT_ASSIGNMENT_CANNOT_BE_USED_WHEN_TARGETING_ECMASCRIPT_MODULES,
+            export_start
+        )]
+    );
+}
+
+#[test]
+fn abstract_export_default_expression_is_unaffected() {
+    // A pre-existing, already-correct sibling shape (no `=`, so it never
+    // touches the new `EqualsToken` lookahead arm or the export-assignment
+    // routing fix): still TS1242 alone, anchored on `abstract`.
+    assert_eq!(
+        all_codes("abstract export default 1;"),
+        vec![ABSTRACT_MODIFIER_CAN_ONLY_APPEAR_ON_A_CLASS_METHOD_OR_PROPERTY_DECLARATION]
+    );
+}
+
+#[test]
+fn abstract_export_class_is_unaffected() {
+    // `abstract` is legal on a class — still TS1029 alone, anchored on
+    // `export`, the pre-existing #16389 answer.
+    let source = "abstract export class C {}";
+    let (parse, chk) = diagnostics(source);
+    let export_start = source.find("export").unwrap() as u32;
+    assert_eq!(parse, vec![(MODIFIER_MUST_PRECEDE_MODIFIER, export_start)]);
+    assert!(chk.is_empty());
+}

--- a/crates/tsz-parser/src/parser/state_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_declarations.rs
@@ -1752,11 +1752,14 @@ impl ParserState {
                 // `declare export = expr` (export assignment — TS1120 handles it).
                 // Also skip when already in an ambient context (e.g. inside `declare module`),
                 // because the checker will emit TS1038 instead and tsc does not emit both.
-                // Also skip in block context: tsc emits TS1029 via grammarErrorOnNode
-                // in the checker, which is suppressed by hasParseDiagnostics when
-                // TS1184 (Modifiers cannot appear here) is already emitted.
-                // Also skip for `declare export module/namespace` — tsc 6.0 accepts this
-                // form without TS1029 for ambient module/namespace declarations.
+                // Also skip in block context: `declare export namespace N {}` inside a
+                // Block reports the nested-module-declaration's own TS1235 alone
+                // (oracle-confirmed) — `declare export module/namespace` at the
+                // source file's own top level or inside a namespace body keeps
+                // TS1029 like every other `declare export <declaration>` form
+                // (oracle-confirmed against `typescript@7.0.2`; a stale prior
+                // comment here claimed tsc accepted this form without TS1029,
+                // which no longer holds against the pinned version, #16403).
                 // Also skip for a plain export declaration (`{ }` / `*` / type-only
                 // `type { }` / `type *`) — tsc emits TS1193 alone there, never TS1029
                 // alongside it (oracle-confirmed). Also skip for the `default <expr>`
@@ -1765,8 +1768,6 @@ impl ParserState {
                 if !self.in_block_context()
                     && !self.is_token(SyntaxKind::AsKeyword)
                     && !self.is_token(SyntaxKind::EqualsToken)
-                    && !self.is_token(SyntaxKind::ModuleKeyword)
-                    && !self.is_token(SyntaxKind::NamespaceKeyword)
                     && !self.is_token(SyntaxKind::OpenBraceToken)
                     && !self.is_token(SyntaxKind::AsteriskToken)
                     && !is_type_only_export
@@ -1838,7 +1839,13 @@ impl ParserState {
                                 diagnostic_codes::AN_EXPORT_ASSIGNMENT_CANNOT_HAVE_MODIFIERS,
                             );
                         }
-                        self.parse_export_assignment(error_start)
+                        // Carry `declare` (+ `export`) onto the node itself so
+                        // `is_ambient_declaration` sees it: TS1203 (ESM export=)
+                        // must stay suppressed and TS2714 (ambient export=
+                        // expression shape) must fire instead, the same way an
+                        // ambient `export =` written without a leading `declare`
+                        // modifier already does (#16403).
+                        self.parse_export_assignment_with_modifiers(error_start, Some(modifiers))
                     }
                     SyntaxKind::ImportKeyword => {
                         // `declare export import a = x.c;`

--- a/crates/tsz-parser/src/parser/state_declarations_exports.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_exports.rs
@@ -327,6 +327,21 @@ impl ParserState {
 
     // Parse export = expression (CommonJS-style default export)
     pub(crate) fn parse_export_assignment(&mut self, start_pos: u32) -> NodeIndex {
+        self.parse_export_assignment_with_modifiers(start_pos, None)
+    }
+
+    /// [`parse_export_assignment`], carrying the statement's leading modifier
+    /// run (`declare`, a misplaced `abstract`/`static`/..., or both) onto the
+    /// resulting node. A plain `export = expr` has none; a modifier-prefixed
+    /// one (`declare export = expr`, `abstract export = expr`) needs its
+    /// `declare` modifier attached so `is_in_ambient_context`'s walk over
+    /// `get_declaration_modifiers` can see it — that gate is what silences
+    /// TS1203 and enables TS2714 in an ambient `export =` (#16403).
+    pub(crate) fn parse_export_assignment_with_modifiers(
+        &mut self,
+        start_pos: u32,
+        modifiers: Option<crate::parser::NodeList>,
+    ) -> NodeIndex {
         self.parse_expected(SyntaxKind::EqualsToken);
         let expression = self.parse_assignment_expression();
         if expression == NodeIndex::NONE {
@@ -341,7 +356,7 @@ impl ParserState {
             start_pos,
             end_pos,
             ExportAssignmentData {
-                modifiers: None,
+                modifiers,
                 is_export_equals: true,
                 expression,
             },

--- a/crates/tsz-parser/src/parser/state_statements_keywords.rs
+++ b/crates/tsz-parser/src/parser/state_statements_keywords.rs
@@ -480,6 +480,35 @@ impl ParserState {
             SyntaxKind::DeclareKeyword => self.parse_ambient_declaration_with_modifiers(modifiers),
             SyntaxKind::ExportKeyword => {
                 if self.look_ahead_export_starts_export_declaration() {
+                    // `export = expr` specifically needs the statement's own
+                    // leading modifiers (already collected in `modifiers`,
+                    // e.g. a misplaced `declare`/`static`/`abstract`) folded
+                    // onto the resulting node and its start position pinned
+                    // to `start_pos` — the node's own structural checks
+                    // (TS1203's ESM gate, TS1120's dedup, TS2714's ambient
+                    // shape check) all read `is_ambient_declaration`/the
+                    // node's own span, which `parse_export_declaration`
+                    // cannot supply: it recomputes `start_pos` from the
+                    // current `export` token and passes no modifiers through
+                    // at all (#16403). Every other export form's own
+                    // placement diagnostic doesn't depend on either, so it
+                    // keeps delegating.
+                    if self.look_ahead_export_is_assignment() {
+                        let export_start = self.token_pos();
+                        self.parse_expected(SyntaxKind::ExportKeyword);
+                        let export_end = self.token_end();
+                        let export_modifier = self.arena.add_token(
+                            SyntaxKind::ExportKeyword as u16,
+                            export_start,
+                            export_end,
+                        );
+                        let mut export_modifiers = modifiers;
+                        export_modifiers.push(export_modifier);
+                        return self.parse_export_assignment_with_modifiers(
+                            start_pos,
+                            Some(Self::make_node_list(export_modifiers)),
+                        );
+                    }
                     return self.parse_export_declaration();
                 }
                 let export_start = self.token_pos();
@@ -496,6 +525,20 @@ impl ParserState {
             }
             _ => self.parse_statement(),
         }
+    }
+
+    /// Look ahead to see if `export` is immediately followed by `=` — the
+    /// `export = expr` assignment form specifically, as opposed to every
+    /// other export form `look_ahead_export_starts_export_declaration` also
+    /// recognizes.
+    fn look_ahead_export_is_assignment(&mut self) -> bool {
+        let snapshot = self.scanner.save_state();
+        let current = self.current_token;
+        self.next_token();
+        let result = self.is_token(SyntaxKind::EqualsToken);
+        self.scanner.restore_state(snapshot);
+        self.current_token = current;
+        result
     }
 
     fn look_ahead_export_starts_export_declaration(&mut self) -> bool {
@@ -1157,12 +1200,18 @@ impl ParserState {
                 | SyntaxKind::GlobalKeyword => self
                     .look_ahead_is_module_declaration()
                     .then_some(AbstractExportTarget::PositionErrorWins),
-                // A named or star export declaration. `export = ...` is
-                // deliberately not here: tsc routes it through TS1120, not
-                // this modifier run.
+                // A named or star export declaration.
                 SyntaxKind::OpenBraceToken | SyntaxKind::AsteriskToken => {
                     Some(AbstractExportTarget::PositionErrorWins)
                 }
+                // `abstract export = expr` — an `ExportAssignment` node, the
+                // same structural mismatch `abstract export default <expr>`
+                // below already models (`abstract` is illegal on it in every
+                // container): TS1242 wins outright at the source file's own
+                // top level, silenced by the assignment's own placement
+                // diagnostic in both a Block (TS1231) and a namespace body
+                // (TS1063) — oracle-confirmed, #16403.
+                SyntaxKind::EqualsToken => Some(AbstractExportTarget::ExportAssignment),
                 // `export default class C {}` (named or anonymous) reads the
                 // same modifier run `[abstract, export, default]` as the bare
                 // `export class` arm above, and `abstract` is legal on a

--- a/crates/tsz-parser/tests/parser_abstract_before_export_declaration_tests.rs
+++ b/crates/tsz-parser/tests/parser_abstract_before_export_declaration_tests.rs
@@ -456,3 +456,54 @@ fn abstract_export_default_expression_reports_ts1242_only_outside_a_block_or_nam
         }
     }
 }
+
+// -- `abstract export = <expr>`: #16403's residual. `export = ...` was
+//    deliberately excluded from the original lookahead (routed instead to
+//    `abstract` degrading to a bare identifier expression, then `export =
+//    <expr>` re-parsed as an unrelated, unmodified top-level statement) —
+//    silently dropping TS1242 everywhere and, at the source file's own top
+//    level, also mis-anchoring the checker's TS1203 at `export` instead of
+//    `abstract` (oracle-confirmed against `typescript@7.0.2`; TS1203 itself
+//    is checker-side and outside this parser-only harness). `export =` is
+//    the same `ExportAssignment` node kind as `export default <expr>`, so it
+//    takes the identical container split: TS1242 wins outright at the
+//    source file's own top level, and is silenced by the assignment's own
+//    placement diagnostic in both a Block (TS1231) and a namespace body
+//    (TS1063).
+#[test]
+fn abstract_export_equals_assignment_reports_ts1242_only_outside_a_block_or_namespace() {
+    for index in 0..CONTAINERS.len() {
+        let source = in_container(index, "abstract export = 1;");
+        if is_block(index) || index == 3 {
+            assert_eq!(
+                codes(&source),
+                Vec::<u32>::new(),
+                "expected no modifier diagnostic for {source:?}, got {:?}",
+                codes(&source)
+            );
+        } else {
+            assert_diag_at_abstract(
+                &source,
+                diagnostic_codes::ABSTRACT_MODIFIER_CAN_ONLY_APPEAR_ON_A_CLASS_METHOD_OR_PROPERTY_DECLARATION,
+            );
+        }
+        assert_no_cannot_find_name(&source);
+    }
+}
+
+#[test]
+fn a_line_break_between_abstract_and_export_equals_is_not_a_modifier_run() {
+    let source = "abstract\nexport = 1;";
+    assert!(
+        !codes(source).contains(
+            &diagnostic_codes::ABSTRACT_MODIFIER_CAN_ONLY_APPEAR_ON_A_CLASS_METHOD_OR_PROPERTY_DECLARATION
+        ),
+        "ASI must cut `abstract` off into its own statement, got {:?}",
+        codes(source)
+    );
+}
+
+#[test]
+fn a_valid_export_equals_assignment_stays_clean() {
+    assert_eq!(codes("export = 1;"), Vec::<u32>::new());
+}


### PR DESCRIPTION
`declare export namespace N {}` missed TS1029 entirely. `declare export = expr` and `abstract export = expr` both picked a wrong code or position. These are the 3 remaining mismatches #16452 (the `async` slice) left open in #16403.

## Structural rule

**`declare export namespace N {}`:** the parser's TS1029 gate (`parse_ambient_declaration_with_modifiers`'s `ExportKeyword` arm, `state_declarations.rs`) carried a stale exclusion for `ModuleKeyword`/`NamespaceKeyword`, commented as "tsc 6.0 accepts this form without TS1029" — measured false against the pinned `typescript@7.0.2` oracle. A `declare export namespace` at the source file's own top level or inside a namespace body reports TS1029 like every other `declare export` declaration form; only a Block silences it there (the nested module declaration's own TS1235 wins instead, checker-side and untouched by this fix).

**`declare export = expr` and `abstract export = expr`:** one shared root cause. `parse_export_assignment` hard-coded `ExportAssignmentData.modifiers: None`, so no modifier-prefixed `export =` node ever carried its `declare` modifier onto the AST. Two independent checker checks read that field through `is_in_ambient_context`'s walk over `get_declaration_modifiers`:
- TS1203 ("Export assignment cannot be used when targeting ECMAScript modules") is suppressed for an *ambient* `export =`. Without the `declare` modifier attached, `declare export = 1;` incorrectly kept TS1203 instead of suppressing it, and the ambient-only TS2714 ("expression of an export assignment must be an identifier or qualified name in an ambient context") never fired at all.
- Separately, `parse_accessor_modified_statement`'s `ExportKeyword` arm (shared by every modifier family reaching it — `static`/`readonly`/`public`/`protected`/`private`/`abstract`) delegated `export = expr` straight to `parse_export_declaration()`, which recomputes its own `start_pos` from the *current* `export` token and drops every modifier collected so far — so TS1203's node-anchored position landed on `export`, not on the modifier that actually starts the statement (oracle-confirmed: tsc anchors both the TS1044/TS1242-family diagnostic and TS1203 on the modifier).

`abstract` additionally never recognized `export =` as a target at all (`look_ahead_abstract_before_export_target`'s own comment claimed "tsc routes it through TS1120" — false against the oracle: `abstract` gets its own TS1242, not the generic TS1120 `declare`/`export export =` share), so `abstract export = 1;` degraded `abstract` to a bare identifier expression, dropping TS1242 outright, and then re-parsed `export = 1;` as an unrelated, unmodified top-level statement.

**Owner layer:** parser only (`crates/tsz-parser/src/parser/state_declarations.rs`, `state_declarations_exports.rs`, `state_statements_keywords.rs`). No checker or solver change — the checker-side TS1203/TS2714/TS1231/TS1063 checks were already correct; they just never saw the modifier data.

The fix that builds the `ExportAssignment` node correctly (`parse_export_assignment_with_modifiers`, called with the real modifier list and start position instead of `parse_export_declaration`'s self-recomputed state) lives in the *shared* `parse_accessor_modified_statement` path, so it benefits every modifier family reaching it, not just `abstract`/`declare` — `static export = 1;`'s TS1203 was also mis-anchored on `export` instead of `static` before this fix, oracle-confirmed and now fixed as a side effect.

## Oracle verification

`typescript@7.0.2` (`scripts/conformance/typescript-versions.json` pin), `--strict --pretty false --target es2022 --module es2022`:

| statement | container | tsc | main | branch |
| --- | --- | --- | --- | --- |
| `declare export namespace N {}` | top level | TS1029 | (silent) | TS1029 fixed |
| `declare export namespace N {}` | namespace body | TS1029 | (silent) | TS1029 fixed |
| `declare export namespace N {}` | Block | TS1235 | TS1235 | TS1235 (unchanged) |
| `declare export = 1;` | top level | TS1120 + TS2714 | TS1120 + wrong TS1203 | TS1120 + TS2714 fixed |
| `declare export = 1;` | Block | TS1231 | TS1231 | TS1231 (unchanged) |
| `declare export = 1;` | namespace body | TS1063 | TS1063 | TS1063 (unchanged) |
| `abstract export = 1;` | top level | TS1242 + TS1203 | wrong-position TS1203, wrong TS2304 | TS1242 + TS1203 fixed |
| `abstract export = 1;` | Block | TS1231 | TS1231 | TS1231 (unchanged) |
| `abstract export = 1;` | namespace body | TS1063 | TS1063 | TS1063 (unchanged) |
| `static export = 1;` (side effect) | top level | TS1044@1 + TS1203@1 | TS1044@1 + TS1203@10 (wrong) | TS1044@1 + TS1203@1 fixed |

## Adjacent-case matrix

- `crates/tsz-parser/tests/parser_abstract_before_export_declaration_tests.rs`: new `abstract export = expr` rows across the same 5-container matrix (top level, function body, nested block, namespace body, static block) the file's existing `abstract export default expr` test uses, plus ASI and a negative control.
- `crates/tsz-checker/src/tests/ts16403_declare_abstract_export_equals_residual_tests.rs`: full parser+checker diagnostic matrix (code and position) for all 3 residual shapes across top level / Block / namespace body, plus a `static export =` side-effect check and negative controls (`abstract export default 1;`, `abstract export class C {}`, plain `export = a;`).

## Known residual (pre-existing, unaffected)

`function f() { static export namespace N {} }` still mis-anchors TS1235 at `export` (offset 22) instead of the modifier run's start (`static`, offset 15) — tsc anchors at `static`. This is a separate, pre-existing defect in `parse_statement_top_level_modifier`'s `ModuleDeclaration` container-split arm, untouched by this PR (different code path from the `abstract`/`declare` arms this PR fixes). Noted on the coordination board for a future session.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-parser --lib`: 1952 passed, 0 failed (full crate, includes all pre-existing abstract/async/declare/export-modifier test files)
- `cargo test -p tsz-checker --lib -- ts16403_declare_abstract_export_equals_residual_tests async_export_modifier_order_ts1042_dedup_tests declare_export_default_modifier_order_ts1319_dedup_tests`: 27 passed, 0 failed
- `cargo test -p tsz-checker --test ts1203_node_esm_tests`: 14 passed, 0 failed
- `cargo clippy -p tsz-parser -p tsz-checker --all-targets -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- `python3 scripts/arch/arch_guard.py`: passed
- Narrow blast radius: every touched shape (a modifier run before `export =`) is a syntax error under every tsc answer; the emitter never reads `ExportAssignmentData.modifiers` (grep-confirmed across `crates/tsz-emitter`), so JS/DTS emit floors cannot move. Full `compare-to-parent.sh` not run given the session time budget — these shapes cannot appear in valid, already-passing conformance fixtures, the same disclosed-narrow-blast-radius pattern #16452 (this issue's prior slice) used.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_016xvyQnuLsMMGJbis9HbNsM)_