### PR TITLE
fix(checker): a class is not a namespace, so a qualified type name rooted at one is TS2713/TS2702

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -372,6 +372,9 @@ mod ts2589_tests;
 #[path = "../tests/ts2683_tests.rs"]
 mod ts2683_tests;
 #[cfg(test)]
+#[path = "../tests/ts2702_qualifier_namespace_meaning_tests.rs"]
+mod ts2702_qualifier_namespace_meaning_tests;
+#[cfg(test)]
 #[path = "../tests/ts2774_tests.rs"]
 mod ts2774_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
+++ b/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
@@ -165,10 +165,17 @@ impl<'a> CheckerState<'a> {
                     let lib_binders = self.get_lib_binders();
                     if let Some(symbol) = self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders)
                     {
+                        // tsc's `SymbolFlags.Namespace` is `ValueModule |
+                        // NamespaceModule | Enum` — a *class* is not in it. A
+                        // class declaration alone therefore has no namespace
+                        // meaning, and `C.m` in type position is
+                        // TS2713/TS2702, not a member lookup. A class merged
+                        // with a namespace declaration carries the module flags
+                        // in the merged symbol, so the merge keeps working
+                        // through those flags rather than through `CLASS`.
                         let valid_namespace_flags = symbol_flags::MODULE
                             | symbol_flags::NAMESPACE_MODULE
                             | symbol_flags::VALUE_MODULE
-                            | symbol_flags::CLASS
                             | symbol_flags::ENUM
                             | symbol_flags::REGULAR_ENUM
                             | symbol_flags::CONST_ENUM
@@ -187,9 +194,41 @@ impl<'a> CheckerState<'a> {
                                         self.ctx.alias_partners_contains(self.ctx.binder, resolved)
                                     },
                                 );
+                        // tsc resolves the left name with `SymbolFlags.Namespace`
+                        // as the requested meaning, so a nearer declaration that
+                        // has no namespace meaning does not shadow an outer one
+                        // that does — `var x = class C { prop: C.type }` finds the
+                        // outer `namespace C`, not the class expression's own
+                        // name. tsz resolves the name first and filters by meaning
+                        // second, so re-ask the file scope for a namespace-meaning
+                        // declaration before treating the qualifier as unusable.
+                        // Same fallback shape as the type-parameter case above.
+                        let outer_namespace_meaning_exists = self
+                            .ctx
+                            .binder
+                            .file_locals
+                            .get(&left_name)
+                            .map(|file_sym| {
+                                let mut visited = AliasCycleTracker::new();
+                                self.resolve_alias_symbol(file_sym, &mut visited)
+                                    .unwrap_or(file_sym)
+                            })
+                            .and_then(|resolved| {
+                                let lib_binders = self.get_lib_binders();
+                                self.ctx
+                                    .binder
+                                    .get_symbol_with_libs(resolved, &lib_binders)
+                                    .map(|outer| {
+                                        outer.has_any_flags(
+                                            valid_namespace_flags | symbol_flags::ALIAS,
+                                        )
+                                    })
+                            })
+                            .unwrap_or(false);
                         if !symbol.has_any_flags(valid_namespace_flags)
                             && !is_alias
                             && !has_alias_partner
+                            && !outer_namespace_meaning_exists
                             && !self.ctx.has_parse_errors
                         {
                             let right_name = if let Some(right_node) = self.ctx.arena.get(qn.right)
@@ -226,12 +265,27 @@ impl<'a> CheckerState<'a> {
                             //
                             // For type parameters, get_type_of_symbol may not return the
                             // TypeParameter type. Check the type_parameter_scope first.
+                            //
+                            // The question this branch asks is the one tsc asks in
+                            // `getTypeFromTypeReference`: does the type *the left name
+                            // denotes in type space* have this property? For a class
+                            // that is the instance side, so the probe resolves the
+                            // type-reference type rather than the symbol's value type
+                            // — `class C { m: number }` makes `C.m` a TS2713
+                            // indexed-access suggestion, while a static-only member
+                            // stays TS2702 because the instance side does not carry it.
+                            // The type-reference type of an interface is a
+                            // `Lazy(DefId)` semantic ref, which carries no member
+                            // surface of its own; evaluate before asking.
                             let left_type_id = self
                                 .ctx
                                 .type_parameter_scope
                                 .get(&left_name)
                                 .copied()
-                                .unwrap_or_else(|| self.get_type_of_symbol(sym_id));
+                                .unwrap_or_else(|| {
+                                    let referenced = self.type_reference_symbol_type(sym_id);
+                                    self.evaluate_type_with_env(referenced)
+                                });
                             let prop_exists =
                                 crate::query_boundaries::property_access::type_has_property(
                                     self.ctx.types,

--- a/crates/tsz-checker/tests/ts2702_qualifier_namespace_meaning_tests.rs
+++ b/crates/tsz-checker/tests/ts2702_qualifier_namespace_meaning_tests.rs
@@ -1,0 +1,317 @@
+//! A qualified type name whose root has no *namespace* meaning.
+//!
+//! `tsc`'s `SymbolFlags.Namespace` is `ValueModule | NamespaceModule | Enum`.
+//! A **class** is not in it: a class declaration alone cannot serve as the
+//! left-hand side of a qualified type name, and `resolveEntityName` never asks
+//! it for a member. So `C.m` in type position is one of two errors, chosen by
+//! whether the type `C` *denotes in type space* — its instance side — carries
+//! the property:
+//!
+//! - it does → `TS2713` "Cannot access 'C.m' because 'C' is a type, but not a
+//!   namespace. Did you mean to retrieve the type of the property 'm' in 'C'
+//!   with `C["m"]`?"
+//! - it does not → `TS2702` "'C' only refers to a type, but is being used as a
+//!   namespace here."
+//!
+//! tsz treated a class as namespace-like, which sent the whole family down the
+//! member-lookup path (`TS2694` "Namespace 'C' has no exported member 'm'.") or,
+//! once a member did resolve, the value-in-type-position path (`TS2749`). A
+//! class *merged* with a namespace declaration keeps working through the merged
+//! symbol's module flags, so the merge rows below are unchanged.
+//!
+//! Every row is measured against `typescript@7.0.2` with
+//! `--noEmit --strict --target es2015`; the residual rows at the bottom are
+//! pinned as they behave today rather than left to drift.
+
+use crate::test_utils::{check_multi_file, check_source_diagnostics};
+use tsz_common::CheckerOptions;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|diagnostic| diagnostic.code)
+        .collect()
+}
+
+fn messages(source: &str) -> Vec<String> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|diagnostic| diagnostic.message_text)
+        .collect()
+}
+
+fn multi_file_codes(files: &[(&str, &str)], entry: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    };
+    check_multi_file(files, entry, options)
+        .into_iter()
+        .map(|diagnostic| diagnostic.code)
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// A class has no namespace meaning: the missing-member rows
+// ---------------------------------------------------------------------------
+
+/// `class Local {}` + `Local.X`: no such property on the instance side, so the
+/// qualifier itself is the error. tsz reported `TS2694` here, treating the class
+/// as a namespace with an export list.
+#[test]
+fn class_qualifier_with_no_such_member_reports_type_used_as_namespace() {
+    assert_eq!(codes("class Local {}\nvar a: Local.X;\n"), vec![2702]);
+}
+
+/// Anti-hardcoding: the rule keys on the qualifier symbol's flags, not on any
+/// identifier. Renamed binders behave identically.
+#[test]
+fn class_qualifier_rule_is_binder_name_independent() {
+    let rendered = messages("class Widget {}\nvar registry: Widget.Registry;\n");
+    assert_eq!(rendered.len(), 1, "exactly one diagnostic: {rendered:?}");
+    assert_eq!(
+        rendered[0],
+        "'Widget' only refers to a type, but is being used as a namespace here."
+    );
+}
+
+/// A *static*-only member is still not on the instance side, so `tsc` reports
+/// the plain qualifier error rather than the indexed-access suggestion.
+#[test]
+fn class_qualifier_with_static_only_member_reports_type_used_as_namespace() {
+    assert_eq!(
+        codes("class C2 { static S: number = 0 }\nvar a: C2.S;\n"),
+        vec![2702]
+    );
+}
+
+/// A type-*query* through the static side is legal and must stay clean —
+/// `typeof C.S` is not a qualified type name and never reaches this rule.
+#[test]
+fn static_member_type_query_stays_clean() {
+    assert_eq!(
+        codes("class C3 { static S: number = 0 }\nlet a: typeof C3.S;\n"),
+        Vec::<u32>::new()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A class has no namespace meaning: the TS2713 indexed-access rows
+// ---------------------------------------------------------------------------
+
+/// The instance side *does* carry `m`, so `tsc` suggests the indexed access.
+/// tsz reported `TS2749` ("refers to a value, but is being used as a type").
+#[test]
+fn class_qualifier_with_instance_property_suggests_indexed_access() {
+    let rendered = messages("class C { m: number = 0 }\nvar a: C.m;\n");
+    assert_eq!(rendered.len(), 1, "exactly one diagnostic: {rendered:?}");
+    assert_eq!(
+        rendered[0],
+        "Cannot access 'C.m' because 'C' is a type, but not a namespace. \
+         Did you mean to retrieve the type of the property 'm' in 'C' with 'C[\"m\"]'?"
+    );
+}
+
+/// An ambient class declaration takes the same path as a concrete one.
+#[test]
+fn ambient_class_qualifier_with_instance_property_suggests_indexed_access() {
+    assert_eq!(
+        codes("declare class Amb { p: number }\nvar a: Amb.p;\n"),
+        vec![2713]
+    );
+}
+
+/// A *generic* class resolves its instance side for the probe without needing
+/// type arguments — `tsc` reports `TS2713` here and no missing-type-argument
+/// error, so the probe must not synthesize an arity diagnostic either.
+#[test]
+fn generic_class_qualifier_with_instance_property_suggests_indexed_access() {
+    assert_eq!(
+        codes("class G<T> { g: T | undefined }\nvar a: G.g;\n"),
+        vec![2713]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Qualifiers that DO have namespace meaning stay on the member-lookup path
+// ---------------------------------------------------------------------------
+
+/// A class merged with a namespace declaration keeps namespace meaning through
+/// the merged symbol's module flags: the exported member resolves.
+#[test]
+fn class_merged_with_namespace_resolves_its_exported_member() {
+    assert_eq!(
+        codes("class M {}\nnamespace M { export interface I { k: number } }\nvar a: M.I;\n"),
+        Vec::<u32>::new()
+    );
+}
+
+/// ...and a genuinely absent export on that merge is still `TS2694`, not the
+/// qualifier error — this is the row that would break if the fix keyed on the
+/// class-ness of the declaration instead of the merged symbol's flags.
+#[test]
+fn class_merged_with_namespace_keeps_ts2694_for_a_missing_export() {
+    assert_eq!(
+        codes("class M2 {}\nnamespace M2 { export interface I { k: number } }\nvar a: M2.Nope;\n"),
+        vec![2694]
+    );
+}
+
+/// Enums, enum members and namespaces are unaffected: they are in `tsc`'s
+/// `SymbolFlags.Namespace` and keep the member-lookup path.
+#[test]
+fn enum_and_namespace_qualifiers_keep_the_member_lookup_path() {
+    assert_eq!(codes("enum E0 { A }\nvar a: E0.A;\n"), Vec::<u32>::new());
+    assert_eq!(codes("enum E { A }\nvar b: E.Missing;\n"), vec![2694]);
+    assert_eq!(
+        codes("namespace NS { export interface I { k: number } }\nvar c: NS.Missing;\n"),
+        vec![2694]
+    );
+}
+
+/// Interfaces and type aliases were already on the correct path in both
+/// directions; they are pinned here because the fix re-points the property
+/// probe at the type-reference type, and an interface's type-reference type is
+/// a semantic ref that carries no member surface until it is evaluated.
+#[test]
+fn interface_and_alias_qualifiers_are_unchanged_in_both_directions() {
+    assert_eq!(
+        codes("interface I2 { k: number }\nvar a: I2.k;\n"),
+        vec![2713]
+    );
+    assert_eq!(
+        codes("type A2 = { k: number };\nvar a: A2.k;\n"),
+        vec![2713]
+    );
+    assert_eq!(
+        codes("interface Iface { k: number }\nvar d: Iface.Missing;\n"),
+        vec![2702]
+    );
+    assert_eq!(
+        codes("type Alias = { k: number };\nvar e: Alias.Missing;\n"),
+        vec![2702]
+    );
+    assert_eq!(
+        codes("type Fn = (x: number) => void;\nvar a: Fn.x;\n"),
+        vec![2702]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cross-file: a named-imported class takes the same two branches
+// ---------------------------------------------------------------------------
+
+/// An imported class is still a class: `Plain.X` is the qualifier error and
+/// `Plain.m` the indexed-access suggestion. The second row was `TS2702` before,
+/// because the probe read the class's static side and found no `m` there.
+#[test]
+fn named_imported_class_qualifier_takes_both_branches() {
+    assert_eq!(
+        multi_file_codes(
+            &[
+                ("/q1.ts", "export class Plain { m: number = 0 }\n"),
+                (
+                    "/q2.ts",
+                    "import { Plain } from \"./q1\";\nvar a: Plain.X;\nvar b: Plain.m;\n"
+                ),
+            ],
+            "/q2.ts",
+        ),
+        vec![2702, 2713]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Residuals — pinned as they behave today, tracked in their own issue
+// ---------------------------------------------------------------------------
+
+/// A *default*-imported class used as a namespace qualifier. `export default`
+/// carries only the class's type/value meaning — never a merged namespace's —
+/// so `tsc` reports `TS2702` on the qualifier for every row here.
+///
+/// tsz still reports `TS2694`: the qualifier is an `ALIAS` symbol, and this
+/// rule's gate skips alias symbols wholesale rather than resolving the alias and
+/// asking its target for namespace meaning. Pinned as today's behaviour, not as
+/// the correct one.
+#[test]
+fn default_imported_class_used_as_namespace_is_a_known_residual() {
+    for (files, entry) in [
+        (
+            vec![
+                ("/t1.ts", "export default class D {}\n"),
+                ("/t2.ts", "import D from \"./t1\";\nvar a: D.X;\n"),
+            ],
+            "/t2.ts",
+        ),
+        (
+            vec![
+                (
+                    "/m1.ts",
+                    "export default class Decl {}\nexport namespace Decl { export interface I { q: number } }\n",
+                ),
+                ("/m2.ts", "import Entity from \"./m1\";\nvar y: Entity.I;\n"),
+            ],
+            "/m2.ts",
+        ),
+        (
+            vec![
+                (
+                    "/u1.ts",
+                    "export default interface OnlyType { k: number }\n",
+                ),
+                (
+                    "/u2.ts",
+                    "import OnlyType from \"./u1\";\nvar a: OnlyType.X;\n",
+                ),
+            ],
+            "/u2.ts",
+        ),
+    ] {
+        assert_eq!(
+            multi_file_codes(&files, entry),
+            vec![2694],
+            "residual: tsc reports TS2702 for {entry}"
+        );
+    }
+}
+
+/// A named-imported class *merged* with a namespace loses the namespace meaning
+/// across the file boundary: `tsc` accepts `Named.I` and reports `TS2694` for
+/// `Named.Missing`, while tsz reports a single `TS2702`. Same alias gate as
+/// above, seen from the opposite side — here it costs a false positive on valid
+/// code. Pinned so the follow-up has a failing witness to flip.
+#[test]
+fn cross_file_class_namespace_merge_is_a_known_residual() {
+    assert_eq!(
+        multi_file_codes(
+            &[
+                (
+                    "/n1.ts",
+                    "export class Named {}\nexport namespace Named { export interface I { q: number } }\n"
+                ),
+                (
+                    "/n2.ts",
+                    "import { Named } from \"./n1\";\nvar y: Named.I;\nvar z: Named.Missing;\n"
+                ),
+            ],
+            "/n2.ts",
+        ),
+        vec![2702],
+        "residual: tsc accepts `Named.I` and reports TS2694 for `Named.Missing`"
+    );
+}
+
+/// A namespace import is a module namespace and keeps the member-lookup path.
+#[test]
+fn namespace_import_qualifier_keeps_the_member_lookup_path() {
+    assert_eq!(
+        multi_file_codes(
+            &[
+                ("/p1.ts", "export default class D {}\n"),
+                ("/p2.ts", "import * as NsD from \"./p1\";\nvar b: NsD.X;\n"),
+            ],
+            "/p2.ts",
+        ),
+        vec![2694]
+    );
+}


### PR DESCRIPTION
`tsc`'s `SymbolFlags.Namespace` is `ValueModule | NamespaceModule | Enum` — a **class is not in it**. tsz treated a class symbol as namespace-like in `resolve_qualified_name`, so the whole family went down the wrong path.

```ts
class C { m: number = 0 }
var a: C.m;   // tsc: TS2713 (indexed-access suggestion)   tsz: TS2749
var b: C.X;   // tsc: TS2702 (used as a namespace)         tsz: TS2694
```

**Structural rule.** When the left-hand side of a qualified type name resolves to a symbol with no namespace meaning, `tsc` never asks it for a member; it reports one of two errors, chosen by whether the type that name denotes *in type space* — for a class, its **instance** side — carries the property. It does → `TS2713` "Cannot access 'C.m' because 'C' is a type, but not a namespace. Did you mean to retrieve the type of the property 'm' in 'C' with `C["m"]`?". It does not → `TS2702` "'C' only refers to a type, but is being used as a namespace here." tsz now does the same, through the checker's `resolve_qualified_name` gate that already owned the `TS2713`/`TS2702` split for interfaces and type aliases.

### Three parts, all inside that one gate

1. **`CLASS` leaves `valid_namespace_flags`.** A class merged with a namespace declaration carries the module flags in the *merged* symbol, so `M.I` on a real merge still resolves and `M2.Nope` on a real merge is still `TS2694`. The fix keys on the merged symbol's flags, never on the declaration being a class — that distinction is what the two merge rows in the matrix protect.

2. **The `TS2713`-vs-`TS2702` probe reads the type-reference type, not the symbol's value type.** For a class the value type is the *static* side, which is why the two rows were inverted against `tsc`: a static-only member produced the indexed-access suggestion and a genuine instance member did not. The probe now resolves the type-reference type and evaluates it — an interface's type-reference type is a `Lazy(DefId)` semantic ref with no member surface of its own, and skipping the evaluation regressed `interface I2 { k: number }` / `I2.k` from `TS2713` to `TS2702` (caught by the matrix, not by reasoning).

3. **A namespace-meaning fallback for the shadowing shape.** `tsc` resolves the left name *with* `SymbolFlags.Namespace` as the requested meaning, so a nearer declaration lacking namespace meaning does not shadow an outer one that has it:

   ```ts
   namespace C { export interface type {} }
   var x = class C { prop: C.type };   // resolves to the outer namespace
   ```

   tsz resolves the name first and filters by meaning second, so the file scope is re-asked for a namespace-meaning declaration before the qualifier is treated as unusable. This is the same fallback shape the gate already used for type parameters. `test_ts2564_named_class_expression_prefers_outer_namespace_member_resolution` is the pre-existing test that caught this; it passes.

**Anti-hardcoding.** The decision reads binder symbol flags and the evaluated type's member surface. No identifier, property, alias or file-name literal; no predicate over rendered diagnostic text. The renamed-binder row is in the matrix for that reason.

## Goal
Goal: hold

## Verification

**Oracle matrix, `typescript@7.0.2`**, `--noEmit --strict --target es2015` (plus `--module commonjs` for the multi-file rows). Every row measured on `main` (`7dcf0dd`) and on this branch:

| row | witness | tsc | main | branch |
| --- | --- | --- | --- | --- |
| class, absent member | `class Local {}` / `Local.X` | `TS2702` | `TS2694` | **fixed** |
| renamed binders | `class Widget {}` / `Widget.Registry` | `TS2702` | `TS2694` | **fixed** |
| class, instance member | `class C { m: number }` / `C.m` | `TS2713` | `TS2749` | **fixed** |
| class, static-only member | `class C2 { static S: number }` / `C2.S` | `TS2702` | `TS2749` | **fixed** |
| ambient class | `declare class Amb { p: number }` / `Amb.p` | `TS2713` | `TS2749` | **fixed** |
| generic class | `class G[ T ] { g: T }` / `G.g` | `TS2713` | `TS2749` | **fixed** |
| named-imported class | `import { Plain }` / `Plain.X`, `Plain.m` | `TS2702`, `TS2713` | `TS2702`, `TS2702` | **fixed** (2nd row) |
| class+namespace merge, present | `M.I` | none | none | unchanged |
| class+namespace merge, absent | `M2.Nope` | `TS2694` | `TS2694` | unchanged |
| static member type query | `typeof C3.S` | none | none | unchanged |
| interface, member present | `I2.k` | `TS2713` | `TS2713` | unchanged |
| interface, member absent | `Iface.Missing` | `TS2702` | `TS2702` | unchanged |
| type alias, member present | `A2.k` | `TS2713` | `TS2713` | unchanged |
| type alias, member absent | `Alias.Missing` | `TS2702` | `TS2702` | unchanged |
| function-type alias | `Fn.x` | `TS2702` | `TS2702` | unchanged |
| enum member | `E0.A` | none | none | unchanged |
| enum, absent member | `E.Missing` | `TS2694` | `TS2694` | unchanged |
| namespace, absent member | `NS.Missing` | `TS2694` | `TS2694` | unchanged |
| namespace import | `import * as NsD` / `NsD.X` | `TS2694` | `TS2694` | unchanged |
| default-imported class | `import D from` / `D.X` | `TS2702` | `TS2694` | `TS2694` (**residual**) |
| default import, merged ns | `import Entity from` / `Entity.I` | `TS2702` | `TS2694` | `TS2694` (**residual**) |
| default-imported interface | `import OnlyType from` / `OnlyType.X` | `TS2702` | `TS2694` | `TS2694` (**residual**) |
| cross-file class+ns merge | `import { Named }` / `Named.I` | none | `TS2702` | `TS2702` (**residual**) |

**6 fixed / 0 broken.** The four residual rows are the import-alias half of the family: the gate skips `ALIAS` symbols wholesale instead of resolving the alias and asking its target for namespace meaning. They are **pinned as they behave today** in the new test file rather than left to drift, and split out to **#16465** with the full oracle evidence — including that the same gate costs a *false positive* in the other direction (`Named.I` is valid TypeScript and tsz rejects it), and that the three `TS2702` rows are the only failures in three conformance rows (`decoratorMetadataWithImportDeclarationNameCollision7`, `defaultExportsCannotMerge02`, `defaultExportsCannotMerge03`).

**Suites**

- `cargo test -p tsz-checker --lib ts2702_qualifier_namespace_meaning` — **15 passed, 0 failed** (new file, 15 rows). Every positive row was measured against `main` first, so none is vacuous.
- `cargo test -p tsz-checker --lib` — full crate, **9726 tests**. Baseline run on this branch's first revision found exactly **2** failures: `test_ts2564_named_class_expression_prefers_outer_namespace_member_resolution` (a real regression from part 1, which is why part 3 exists — now passing) and `suppresses_ts1361_for_computed_property_in_type_literal`, which **fails identically on `main`** (verified by stashing the `src` change and re-running: `0 passed; 1 failed`). That test is not in `scripts/ci/known-failures.txt`; it is a pre-existing main-red unit test, unrelated to qualified names (`import type { key }` + a computed property in a type literal). Full re-run at the final head posted as a comment.
- `cargo fmt --all`, `cargo clippy -p tsz-checker --all-targets -- -D warnings` — clean. Pre-commit clippy + architecture guard passed.
- **Corpus gate: owed, not yet run.** This is a semantic change (diagnostic selection), so `compare-to-parent.sh` is the right gate; a cold cloud seat measures 55-90 min for the two-sided run, past this session. Recorded honestly rather than argued away. The conformance rows this family touches are enumerated above and none of them can move without the alias half (#16465): every row in this diff's blast radius is a *non-alias* class qualifier, and the committed `conformance-detail.json` (11491/12043) lists no failing row whose signature contains `TS2713`/`TS2749` for a non-alias class.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Malachite

---
_Generated by [Claude Code](https://claude.ai/code/session_018mxkCwZxgPVaVW1jnGBuAV)_