### PR TITLE
fix(checker): type-literal wide-symbol classifier publishes checking_computed_property_name

### DIFF
--- a/crates/tsz-checker/src/error_reporter/type_value.rs
+++ b/crates/tsz-checker/src/error_reporter/type_value.rs
@@ -1508,6 +1508,28 @@ type T = { [key]: any; };
     }
 
     #[test]
+    fn suppresses_ts1361_for_computed_accessor_in_type_literal() {
+        // Adjacent case to `suppresses_ts1361_for_computed_property_in_type_literal`:
+        // the get/set-accessor member arm in `get_type_from_type_literal` is a
+        // separate call site of the same wide-symbol classifier and needs the
+        // same `checking_computed_property_name` context published around it.
+        // Renamed binder from the property-signature test (#16466 adjacent-case
+        // discipline: don't let the fix look coupled to one identifier).
+        let diagnostics = check_source_diagnostics(
+            r#"
+import type { propId } from './ids';
+type WithAccessor = { get [propId](): any; };
+"#,
+        );
+
+        let ts1361_count = diagnostics.iter().filter(|d| d.code == 1361).count();
+        assert_eq!(
+            ts1361_count, 0,
+            "Should not emit TS1361 for computed accessor in type literal, got: {diagnostics:?}",
+        );
+    }
+
+    #[test]
     fn alias_merges_with_local_value_suppresses_ts1361() {
         // When import type is followed by a local const with the same name,
         // the const should shadow the import type in value position.

--- a/crates/tsz-checker/src/types/type_literal_checker.rs
+++ b/crates/tsz-checker/src/types/type_literal_checker.rs
@@ -1145,6 +1145,27 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Does this type-literal member's name node key off a plain (non-unique)
+    /// `symbol` binding — `type T = { [s]: V }` with `declare const s: symbol`?
+    ///
+    /// Classifying the key evaluates its expression in VALUE position (see
+    /// `computed_member_key_is_wide_symbol`), and a value-position evaluation
+    /// reports its own diagnostics. Several of those are suppressed only inside
+    /// a computed-property-name context — `is_in_ambient_computed_property_context`
+    /// reads `ctx.checking_computed_property_name` and returns early for an
+    /// interface/type-literal member. Publishing that context here, exactly like
+    /// `class_member_computed_key_is_wide_symbol` does for classes, is what keeps
+    /// a type-only-imported key from spuriously reporting TS1361 on
+    /// `type T = { [key]: any }` (#16466: this call site went in unwrapped when
+    /// #16462 wired the type-literal builder into the shared classifier).
+    fn type_literal_member_computed_key_is_wide_symbol(&mut self, name_idx: NodeIndex) -> bool {
+        let prev_checking = self.ctx.checking_computed_property_name;
+        self.ctx.checking_computed_property_name = Some(name_idx);
+        let is_wide = self.computed_member_key_is_wide_symbol(name_idx);
+        self.ctx.checking_computed_property_name = prev_checking;
+        is_wide
+    }
+
     /// Get type from a type literal node (anonymous object types).
     ///
     /// Type literals represent inline object types like `{ x: string; y: number }` or
@@ -1309,7 +1330,7 @@ impl<'a> CheckerState<'a> {
                         // `[Symbol.x]` syntax, `typeof Symbol.x` aliases, and genuine
                         // `unique symbol` keys are excluded by
                         // `computed_member_key_is_wide_symbol` and keep named identity.
-                        if self.computed_member_key_is_wide_symbol(sig.name) {
+                        if self.type_literal_member_computed_key_is_wide_symbol(sig.name) {
                             let readonly = self.has_readonly_modifier(&sig.modifiers);
                             let value_type = if member.kind == METHOD_SIGNATURE {
                                 let (type_params, type_param_updates) =
@@ -1604,7 +1625,7 @@ impl<'a> CheckerState<'a> {
             if (member.kind == tsz_parser::parser::syntax_kind_ext::GET_ACCESSOR
                 || member.kind == tsz_parser::parser::syntax_kind_ext::SET_ACCESSOR)
                 && let Some(accessor) = self.ctx.arena.get_accessor(member)
-                && self.computed_member_key_is_wide_symbol(accessor.name)
+                && self.type_literal_member_computed_key_is_wide_symbol(accessor.name)
             {
                 let is_getter = member.kind == tsz_parser::parser::syntax_kind_ext::GET_ACCESSOR;
                 let value_type = if is_getter {


### PR DESCRIPTION
`type T = { [key]: any; }` with `import type { key } from './keys';` reports **TS1361** ("'key' cannot be used as a value because it was imported using 'import type'.") on `main` (`905f2f2`). tsc never emits TS1361 for a computed key in a type-literal position — this is a regression from #16462 (merged this morning), filed as #16466.

## Structural rule

Classifying a computed member's key as a wide (non-`unique`) `symbol` binding evaluates the key expression in **value position** (`computed_member_key_is_wide_symbol` → `get_type_of_node`), and a value-position evaluation reports its own diagnostics. Those diagnostics are suppressed only while `ctx.checking_computed_property_name` is set — that's what `is_in_ambient_computed_property_context` reads to recognize an interface/type-literal member and decline TS1361/TS1362.

The class-member path already wraps this classifier in `class_member_computed_key_is_wide_symbol`, which publishes that context around the call. #16462 wired the checker-side type-literal builder (`get_type_from_type_literal`, used for `type` aliases and inline `{ … }` annotations) into the same shared classifier, but called it **unwrapped** at both its call sites (the property/method-signature arm and the get/set-accessor arm) — so the context was never published there, and the type-only-value check fired for real against the identifier.

Fix: `type_literal_member_computed_key_is_wide_symbol`, the type-literal twin of `class_member_computed_key_is_wide_symbol`, set/restores `checking_computed_property_name` around the same classification call. Both type-literal call sites now route through it. No routing/assignability decision changes — `computed_member_key_is_wide_symbol`'s boolean answer is identical either way; only the diagnostic side effect during classification is suppressed, matching the class and interface paths that never had this bug.

## Adjacent cases

- Property/method-signature key (`type T = { [key]: any }`): the failing test in #16466, now passing.
- Get/set-accessor key (`type WithAccessor = { get [propId](): any }`): a **separate call site**, not covered by the existing test, given its own regression test with a renamed binder (`propId`, not `key`) per the anti-hardcoding discipline.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib suppresses_ts1361_for_computed_property_in_type_literal`: 1/1 (the regression from #16466, now fixed).
- `cargo test -p tsz-checker --lib suppresses_ts1361_for_computed_accessor_in_type_literal`: 1/1 (new adjacent-case test for the accessor call site).
- `cargo test -p tsz-checker --lib error_reporter::type_value::tests`: 13/13, no regressions in the sibling TS1361/TS1362/TS2693/TS2713 suite.
- `cargo test -p tsz-checker --test wide_symbol_computed_member_index_signature_tests`: 19/19 — the full #16307/#16462 wide-symbol routing suite is unaffected (this PR changes only the diagnostic side effect during classification, not the classification's boolean result or the routing it drives).
- `cargo fmt --check -p tsz-checker`: clean. Pre-commit hook (clippy + architecture guard + local verification): passed.
- Full `cargo test -p tsz-checker --lib` (9700+ tests): running at PR-open time (this seat's long tail is a handful of named tests per the board's standing gotcha, not a sign of trouble); the count will be posted as a follow-up comment before this is queued.
- `compare-to-parent.sh`: not run. Narrow blast radius — this diff only changes whether a diagnostic fires during computed-key *classification* for a type-only-imported identifier used as a type-literal's computed property/accessor key; it does not change any relation, inference, or routing decision (the wide-symbol classifier's boolean answer, and everything downstream of it, is byte-identical before and after). This exact combination (computed key + type-only import + type-literal position) is not exercised by the conformance corpus today — the same zero-movement signature the board has documented for #16016/#16020/#16039/#16042/#16270/#16418.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_01SNkon6WrJRF2W2ge7QBVwm)_