### PR TITLE
fix(lowering): interface computed symbol members fold into a unioned symbol index

### DIFF
--- a/crates/tsz-checker/src/tests/nonunique_symbol_property_access_tests.rs
+++ b/crates/tsz-checker/src/tests/nonunique_symbol_property_access_tests.rs
@@ -61,8 +61,36 @@ const _v: string = o[myKey];
 // ── multiple non-unique symbol properties on the same type ────────────────────
 
 #[test]
-fn multiple_nonunique_symbol_props_resolved_independently() {
-    let diags = check_source_diagnostics(
+fn multiple_nonunique_symbol_props_fold_into_union_index() {
+    // tsc folds several plain-`symbol` computed members into ONE `[key: symbol]`
+    // index whose value is the UNION of the members' value types, so any
+    // `symbol`-keyed read yields `number | string`. Reading into that union is
+    // clean; reading into a single member's narrow type is a genuine TS2322
+    // (issue #16307 — tsz used to error-collapse the mismatched value types to
+    // `error` and wrongly accepted the narrow reads).
+    let clean = check_source_diagnostics(
+        r#"
+declare const k1: symbol;
+declare const k2: symbol;
+interface Multi {
+  [k1]: number;
+  [k2]: string;
+}
+declare const m: Multi;
+const _u: number | string = m[k1];
+"#,
+    );
+    assert!(
+        clean.iter().all(|d| d.code != 2322),
+        "reading the folded symbol index into its own `number | string` union \
+         must not report TS2322; got: {:?}",
+        clean
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+
+    let narrow = check_source_diagnostics(
         r#"
 declare const k1: symbol;
 declare const k2: symbol;
@@ -72,14 +100,13 @@ interface Multi {
 }
 declare const m: Multi;
 const _n: number = m[k1];
-const _s: string = m[k2];
 "#,
     );
-    let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
     assert!(
-        ts2322.is_empty(),
-        "each non-unique symbol property should resolve to its own type; got: {:?}",
-        diags
+        narrow.iter().any(|d| d.code == 2322),
+        "reading the folded `number | string` symbol index into `number` must \
+         report TS2322 like tsc; got: {:?}",
+        narrow
             .iter()
             .map(|d| (d.code, &d.message_text))
             .collect::<Vec<_>>()

--- a/crates/tsz-checker/tests/non_unique_symbol_late_bound_member_tests.rs
+++ b/crates/tsz-checker/tests/non_unique_symbol_late_bound_member_tests.rs
@@ -120,15 +120,54 @@ const _x: number = obj[k];
 // ── Multiple non-unique symbol members ────────────────────────────────────────
 
 #[test]
-fn interface_multiple_non_unique_symbol_members_no_false_positive() {
+fn interface_multiple_non_unique_symbol_members_union_read_no_false_positive() {
+    // tsc folds several plain-`symbol` computed members into ONE `[key: symbol]`
+    // index whose value is the UNION of their value types, so a `symbol`-keyed
+    // read yields `number | string`. Assigning that union to a `number | string`
+    // annotation must NOT produce a false positive.
     assert!(!has_2322(
         r#"
 const a: symbol = Symbol("a");
 const b: symbol = Symbol("b");
 interface Multi { [a]: number; [b]: string; }
 declare const obj: Multi;
+const _x: number | string = obj[a];
+const _y: number | string = obj[b];
+"#
+    ));
+}
+
+#[test]
+fn interface_multiple_non_unique_symbol_members_narrow_read_reports_ts2322() {
+    // The other side of the union fold (issue #16307): because the members
+    // union into `[key: symbol]: number | string`, reading and assigning to a
+    // single member's type is a genuine TS2322 under tsc — NOT clean. tsz used
+    // to collapse the mismatched value types to `error` (which is assignable to
+    // anything) and wrongly accepted this; the fix must report the error tsc
+    // reports here.
+    assert!(has_2322(
+        r#"
+const a: symbol = Symbol("a");
+const b: symbol = Symbol("b");
+interface Multi { [a]: number; [b]: string; }
+declare const obj: Multi;
 const _x: number = obj[a];
-const _y: string = obj[b];
+"#
+    ));
+}
+
+#[test]
+fn interface_multiple_non_unique_symbol_members_same_value_type_stays_narrow() {
+    // When every plain-`symbol` member shares one value type the union folds
+    // back to that single type, so a narrow read stays clean — proving the fold
+    // is a real union, not an unconditional widen-to-error.
+    assert!(!has_2322(
+        r#"
+const a: symbol = Symbol("a");
+const b: symbol = Symbol("b");
+interface Multi { [a]: number; [b]: number; }
+declare const obj: Multi;
+const _x: number = obj[a];
 "#
     ));
 }

--- a/crates/tsz-checker/tests/wide_symbol_computed_member_index_signature_tests.rs
+++ b/crates/tsz-checker/tests/wide_symbol_computed_member_index_signature_tests.rs
@@ -454,3 +454,127 @@ export const bad: Other = h;
          unrelated interface via a symbol index signature, got: {diags:?}"
     );
 }
+
+// ── Distinct-value symbol members fold into a UNION index (#16307 residual) ────
+//
+// tsc folds several plain-`symbol` computed members on one interface into a
+// single `[key: symbol]` index whose value type is the UNION of the members'
+// value types. tsz's interface lowerer used to collapse a value-type mismatch
+// to `error` (assignable to anything), producing a false TS7053 on the read and
+// losing the union. These cases pin the corrected behavior; every one is
+// `tsc` 6.0.2 exit 0 (or the reported TS2322) on the same source.
+
+/// Read of a `symbol`-keyed member on an interface carrying two distinct-value
+/// symbol members yields the union of both value types.
+#[test]
+fn interface_distinct_value_symbol_members_read_yields_union() {
+    assert_clean(
+        r#"
+declare const s1: symbol;
+declare const s2: symbol;
+declare const other: symbol;
+interface Implicit { [s1]: number; [s2]: string }
+declare const i: Implicit;
+export const readUnion: number | string = i[other];
+"#,
+    );
+}
+
+/// The folded index is a real `[key: symbol]` signature, so `keyof` surfaces
+/// `symbol` and the interface is mutually assignable with an explicit
+/// union-valued symbol index signature — in both directions.
+#[test]
+fn interface_distinct_value_symbol_members_mutual_with_explicit_index() {
+    assert_clean(
+        r#"
+declare const s1: symbol;
+declare const s2: symbol;
+interface Implicit { [s1]: number; [s2]: string }
+interface Explicit { [key: symbol]: number | string }
+declare const i: Implicit;
+declare const e: Explicit;
+export const iToE: Explicit = i;
+export const eToI: Implicit = e;
+export const k: symbol = null as unknown as keyof Implicit;
+"#,
+    );
+}
+
+/// The fold is a genuine union, not an unconditional widen: reading and
+/// assigning to a SINGLE member's narrow type is the TS2322 tsc reports, and
+/// tsz must report it too (the pre-fix `error` collapse silently accepted it).
+#[test]
+fn interface_distinct_value_symbol_members_narrow_read_reports_ts2322() {
+    let diags = check_source_diagnostics(
+        r#"
+declare const s1: symbol;
+declare const s2: symbol;
+interface Implicit { [s1]: number; [s2]: string }
+declare const i: Implicit;
+export const narrow: number = i[s1];
+"#,
+    );
+    assert!(
+        diags.iter().any(|d| d.code == 2322),
+        "reading a folded `number | string` symbol index into `number` must \
+         report TS2322 like tsc, got: {diags:?}"
+    );
+}
+
+/// Three distinct-value members fold into the three-way union, and the fold is
+/// insensitive to the binder names (renamed identifiers must behave identically).
+#[test]
+fn interface_three_distinct_value_symbol_members_renamed_binders_union() {
+    assert_clean(
+        r#"
+declare const alpha: symbol;
+declare const beta: symbol;
+declare const gamma: symbol;
+interface Three { [alpha]: number; [beta]: string; [gamma]: boolean }
+declare const t: Three;
+export const r: number | string | boolean = t[alpha];
+"#,
+    );
+}
+
+/// An ordinary named member coexisting with the folded symbol index keeps its
+/// own type; the symbol index still unions independently.
+#[test]
+fn interface_named_member_alongside_folded_symbol_index() {
+    assert_clean(
+        r#"
+declare const s1: symbol;
+declare const s2: symbol;
+declare const other: symbol;
+interface Mixed { readonly tag: boolean; [s1]: number; [s2]: string }
+declare const m: Mixed;
+export const viaSymbol: number | string = m[other];
+export const viaName: boolean = m.tag;
+"#,
+    );
+}
+
+/// Method-signature members keyed by plain symbols fold the same way as
+/// property members (the lowerer routes both through the implicit-symbol path).
+#[test]
+fn interface_distinct_value_symbol_method_members_union() {
+    assert_clean(
+        r#"
+declare const s1: symbol;
+declare const s2: symbol;
+declare const other: symbol;
+interface Callable { [s1](): number; [s2](): string }
+declare const c: Callable;
+export const via: (() => number) | (() => string) = c[other];
+"#,
+    );
+}
+
+// NOTE: the mixed case — an explicit `[key: symbol]: T` signature coexisting
+// with an implicit computed-`symbol` member of a different value type
+// (`interface M { [key: symbol]: number; [s1]: string }`) — is intentionally
+// NOT covered here. tsc accepts it (exit 0), but tsz reports a separate,
+// pre-existing false-positive `TS2411` from the checker-side index-member
+// compatibility check (which reads the explicit `number` index directly),
+// unrelated to the implicit-fold union this change owns. That divergence is
+// left to its own fix so this suite pins only the implicit-fold behavior.

--- a/crates/tsz-lowering/src/lower/core.rs
+++ b/crates/tsz-lowering/src/lower/core.rs
@@ -145,6 +145,17 @@ pub(super) struct ObjectTypeParts {
     /// type can carry a `symbol` index alongside `string`/`number` ones
     /// (e.g. `{ [k: string]: A; [k: symbol]: B }`) without the two colliding.
     pub(super) symbol_index: Option<IndexSignature>,
+    /// Additional symbol-keyed index signatures beyond the first, collected for
+    /// a deferred value-type union in `finish_object_type_parts` (the type
+    /// interner is unavailable at merge time). tsc folds several computed
+    /// members keyed by a plain `symbol` (`interface T { [s1]: A; [s2]: B }`)
+    /// into one `[key: symbol]` index whose value is the UNION of their value
+    /// types (`[key: symbol]: A | B`) — mirroring the `extra_string_indices`
+    /// deferral for distinct string-key patterns. Only the implicit-from-
+    /// computed-name form routes here (via `merge_implicit_symbol_index`); two
+    /// *explicit* `[k: symbol]: T` declarations keep the duplicate-index
+    /// error-collapse in `merge_index_signature` that pairs with TS2374.
+    pub(super) extra_symbol_indices: Vec<IndexSignature>,
     /// True when at least one member has a computed property name that could not
     /// be resolved to a literal string/symbol key (e.g. `[sym]` where `sym` has
     /// type `symbol` rather than a unique-symbol type).  The resulting object
@@ -193,6 +204,7 @@ impl ObjectTypeParts {
             extra_string_indices: Vec::new(),
             number_index: None,
             symbol_index: None,
+            extra_symbol_indices: Vec::new(),
             has_late_bound_members: false,
             current_pass_base: 0,
             // 1-based: declaration_order 0 is the interner constructors'
@@ -384,6 +396,28 @@ impl ObjectTypeParts {
             }
         } else {
             self.string_index = Some(index);
+        }
+    }
+
+    /// Merge an *implicit* symbol index signature — one synthesized from a
+    /// computed member whose key is a plain `symbol` (`[s]: V`). Unlike an
+    /// explicit `[k: symbol]: T` declaration (which goes through
+    /// `merge_index_signature` and error-collapses on a duplicate), tsc folds
+    /// several such members into one `[key: symbol]` index by UNIONING their
+    /// value types. The interner is not available at merge time, so extras are
+    /// collected and unioned in `finish_object_type_parts` — the same deferral
+    /// `extra_string_indices` uses for distinct string-key patterns.
+    pub(super) fn merge_implicit_symbol_index(&mut self, value_type: TypeId, readonly: bool) {
+        let index = IndexSignature {
+            key_type: TypeId::SYMBOL,
+            value_type,
+            readonly,
+            param_name: None,
+        };
+        if self.symbol_index.is_none() {
+            self.symbol_index = Some(index);
+        } else {
+            self.extra_symbol_indices.push(index);
         }
     }
 }

--- a/crates/tsz-lowering/src/lower/core/signature_members.rs
+++ b/crates/tsz-lowering/src/lower/core/signature_members.rs
@@ -145,12 +145,7 @@ impl<'a> TypeLowering<'a> {
                                 tsz_scanner::SyntaxKind::ReadonlyKeyword,
                             );
                             let value_type = self.lower_method_signature(sig);
-                            parts.merge_index_signature(IndexSignature {
-                                key_type: TypeId::SYMBOL,
-                                value_type,
-                                readonly,
-                                param_name: None,
-                            });
+                            parts.merge_implicit_symbol_index(value_type, readonly);
                         } else if let Some(name) = self.lower_signature_name(sig.name) {
                             let is_symbol_named =
                                 self.lower_signature_name_is_symbol_named(sig.name);
@@ -182,12 +177,7 @@ impl<'a> TypeLowering<'a> {
                                 tsz_scanner::SyntaxKind::ReadonlyKeyword,
                             );
                             let value_type = self.lower_type(sig.type_annotation);
-                            parts.merge_index_signature(IndexSignature {
-                                key_type: TypeId::SYMBOL,
-                                value_type,
-                                readonly,
-                                param_name: None,
-                            });
+                            parts.merge_implicit_symbol_index(value_type, readonly);
                         } else if let Some(prop) = self.lower_type_element(idx) {
                             parts.merge_property(prop);
                         } else if self.is_unresolved_computed_property_name(sig.name) {
@@ -224,12 +214,7 @@ impl<'a> TypeLowering<'a> {
                             self.lower_type(param.type_annotation)
                         })
                 };
-                parts.merge_index_signature(IndexSignature {
-                    key_type: TypeId::SYMBOL,
-                    value_type,
-                    readonly: is_getter,
-                    param_name: None,
-                });
+                parts.merge_implicit_symbol_index(value_type, is_getter);
             } else if member.is_accessor()
                 && let Some(accessor) = self.arena.get_accessor(member)
                 && let Some(name) = self.lower_signature_name(accessor.name)
@@ -425,6 +410,23 @@ impl<'a> TypeLowering<'a> {
                 existing.readonly &= extra.readonly;
             } else {
                 parts.string_index = Some(extra);
+            }
+        }
+
+        // When an interface (or merged group) carries several computed members
+        // keyed by a plain `symbol` (`interface T { [s1]: A; [s2]: B }`), tsc
+        // folds them into a single `[key: symbol]` index whose value is the
+        // UNION of the members' value types. Do that fold here, where the type
+        // interner is available — mirroring the string-index deferral above.
+        for extra in parts.extra_symbol_indices.drain(..) {
+            if let Some(ref mut existing) = parts.symbol_index {
+                if existing.value_type != extra.value_type {
+                    existing.value_type =
+                        self.interner.union2(existing.value_type, extra.value_type);
+                }
+                existing.readonly &= extra.readonly;
+            } else {
+                parts.symbol_index = Some(extra);
             }
         }
 


### PR DESCRIPTION
Closes the interface leg of the #16307 residual (`false-positive`, `checker`/`solver`).

## Structural rule

When an interface member is keyed by a plain (non-`unique`) `symbol`, tsc treats
it as a contribution to the containing type's `[key: symbol]` index rather than a
named member. When several such members carry **different** value types, tsc folds
them into one index whose value is the **union** of the members' value types —
`interface T { [s1]: A; [s2]: B }` reads as `[key: symbol]: A | B`.

tsz's interface lowerer instead collapsed a value-type mismatch to `error` in
`ObjectTypeParts::merge_index_signature` (owner: `tsz-lowering`, interface/type
lowering). Because `error` is assignable to anything, a `symbol`-keyed read wrongly
surfaced `TS7053`, and narrow reads (`const n: number = obj[s1]`) were silently
accepted — both diverging from tsc (verified against `tsc` 6.0.2).

Adjacent legs already matched tsc before this change: the **type-literal** leg
landed in #16462, and the **object-literal** and **class** legs already unioned
(`route_computed_member_value_to_index_signature` collects into a `Vec`;
`merge_union_index_signature` on the class path). This PR finishes the interface leg.

## What changed

- Route the implicit symbol members synthesized from wide-symbol computed names
  (method, property, and accessor forms) through a new
  `ObjectTypeParts::merge_implicit_symbol_index`, which defers the value-type union
  to `finish_object_type_parts` where the type interner is available — mirroring the
  existing `extra_string_indices` deferral for distinct string-key patterns.
- The explicit `[k: symbol]: T` path is unchanged: two explicit signatures keep the
  duplicate-index error-collapse that pairs with `TS2374`.

The change is minimal and structural — one new deferred-union field, one merge
helper, three call sites, one fold loop. No user-name/file-name literals, no
formatted-diagnostic predicates; the fix is name-agnostic (regression tests vary
binders).

## Adjacent-case matrix (all checked against `tsc` 6.0.2)

| Shape | tsc | tsz (this PR) |
|---|---|---|
| `interface { [s1]: number; [s2]: string }`, read into `number \| string` | ok | ok |
| ...read into narrow `number` | TS2322 | TS2322 |
| same value type on both members, narrow read | ok | ok |
| three distinct members, renamed binders | union | union |
| named member alongside folded symbol index | ok | ok |
| method-signature symbol members | union | union |
| mutual assignability with explicit `[k: symbol]: number \| string` | ok | ok |
| two explicit `[k: symbol]` duplicates | TS2374 | TS2374 (error-collapse, unchanged) |

### Out of scope (documented, not fixed here)

The mixed shape — an explicit `[key: symbol]: T` **and** an implicit computed-`symbol`
member of a different value type on the same interface — is left alone. tsc accepts it
(exit 0), but tsz reports a **separate, pre-existing** false-positive `TS2411` from the
checker-side index-member compatibility check (its message names the explicit index
type `number`, proving it reads the explicit declaration directly, independent of this
lowerer fold — folding to `number | string` does not change it). That belongs to its
own fix; a code comment in `wide_symbol_computed_member_index_signature_tests.rs`
records it.

## Goal
Goal: green

## Verification
- `cargo nextest run -p tsz-lowering` — 167/167 passed.
- `cargo nextest run -p tsz-checker --lib` + 15 symbol/index integration binaries
  (`wide_symbol_computed_member_index_signature_tests`, `symbol_index_signature_tests`,
  `non_unique_symbol_late_bound_member_tests`, `ts2411*`, `ts2374_lib_merged_index_signature_tests`,
  `callable_interface_index_tests`, `class_implements_index_signature_tests`,
  `cross_file_symbol_keyed_member_instantiation_tests`, `keyof_well_known_symbol_key_tests`, …)
  — all green (9920 tests). Two lib/integration tests that had encoded the pre-fix
  ERROR-collapse behaviour (`multiple_nonunique_symbol_props_*`,
  `interface_multiple_non_unique_symbol_members_*`) were corrected to tsc's actual
  behaviour (narrow read is a genuine TS2322; union read is clean).
  - One pre-existing failure, `reexported_symbol_keyed_member_tests::direct_import_symbol_keyed_member_is_clean`
    (TS2538), reproduces identically with the parent lowerer — not caused by this change.
- Pre-commit gate (matches CI per-merge lane): `clippy` + `arch-size` + local
  `cargo check` — passed. PR-head `CI Summary` green.
- Every fixture in the matrix above was run against `tsc` 6.0.2 as the oracle.
- `./scripts/emit/run.sh` — in progress (DTS of these interfaces now renders
  `[key: symbol]: A | B`); no JS-emit change expected.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high