### PR TITLE
fix(checker): a concrete indexed-access display reduces literal-union, keyof, and array-numeric keys (#16443)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/type_display_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/type_display_policy.rs
@@ -86,7 +86,9 @@ impl<'a> CheckerState<'a> {
     /// generic forms — so those are left opaque. This mirrors the deliberate
     /// exclusion of [`Self::resolve_indexed_access_alias_for_display`] from the
     /// assignment roles, but is strictly narrower: only a bare,
-    /// type-parameter-free indexed access with a literal key is touched.
+    /// type-parameter-free indexed access with a literal-shaped key (a single
+    /// literal, a union of literals, a `keyof` query, or `number` against an
+    /// array/tuple object) is touched.
     pub(in crate::error_reporter) fn resolve_concrete_indexed_access_for_display(
         &mut self,
         ty: TypeId,
@@ -96,23 +98,38 @@ impl<'a> CheckerState<'a> {
         let Some(indexed) = common::get_indexed_access_type(db, ty) else {
             return ty;
         };
-        // Only a single string/number literal key reduces to one member;
-        // `keyof`/union keys keep the indexed-access form in tsc too. A literal
-        // key also structurally carries no free type parameters, so only the
-        // object side is checked for deferral below.
-        if !matches!(
-            common::classify_literal_type(db, indexed.index_type),
-            common::LiteralTypeKind::String(_) | common::LiteralTypeKind::Number(_)
-        ) {
+        // A free type parameter anywhere in the key means the access is
+        // legitimately deferred (tsc renders `Obj[T]`/`Obj[keyof U]` with a
+        // free `U` as written); never force-evaluate those.
+        if common::contains_free_type_parameters(db, indexed.object_type)
+            || common::contains_free_type_parameters(db, indexed.index_type)
+        {
             return ty;
         }
-        // A free type parameter in the object means the access is legitimately
-        // deferred (tsc renders `T["m"]`); never force-evaluate those.
-        if common::contains_free_type_parameters(db, indexed.object_type) {
+        let key_is_literal_shaped = common::is_literal_shaped_index_key(db, indexed.index_type);
+        if !key_is_literal_shaped && indexed.index_type != TypeId::NUMBER {
             return ty;
+        }
+        if !key_is_literal_shaped {
+            // `index_type == TypeId::NUMBER`: only a numeric index into an
+            // array/tuple-shaped object reduces for display. A chained
+            // access's object (e.g. `Arr["list"]` inside `Arr["list"][number]`)
+            // is itself an unresolved indexed access at this point, so it must
+            // be evaluated before its shape can be inspected. An intrinsic
+            // `number` key on any other object shape (e.g. a `[k: number]: V`
+            // index signature) stays deferred — that is a decision about index
+            // signatures with its own negative half, out of scope here.
+            let evaluated_object = self.evaluate_type_with_env(indexed.object_type);
+            let db = self.ctx.types.as_type_database();
+            if !common::is_array_type(db, evaluated_object)
+                && !common::is_tuple_type(db, evaluated_object)
+            {
+                return ty;
+            }
         }
         let resolved = self.evaluate_type_with_env(ty);
         if resolved == ty
+            || resolved == TypeId::ERROR
             || crate::query_boundaries::diagnostics::is_unresolved_for_display(
                 self.ctx.types.as_type_database(),
                 resolved,

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -669,6 +669,13 @@ pub(crate) fn classify_literal_type(db: &dyn TypeDatabase, type_id: TypeId) -> L
     tsz_solver::type_queries::extended::classify_literal_type(db, type_id)
 }
 
+/// True when an indexed-access key is a shape tsc's `getIndexedAccessType`
+/// resolves eagerly on its own: a single string/number literal, a union of
+/// such literals, or a `keyof` query.
+pub(crate) fn is_literal_shaped_index_key(db: &dyn TypeDatabase, index_type: TypeId) -> bool {
+    tsz_solver::type_queries::is_literal_shaped_index_key(db, index_type)
+}
+
 /// Check if a type is a generic type application.
 pub(crate) fn is_generic_application(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     tsz_solver::query::is_generic_application(db, type_id)

--- a/crates/tsz-checker/tests/concrete_indexed_access_display_tests.rs
+++ b/crates/tsz-checker/tests/concrete_indexed_access_display_tests.rs
@@ -9,10 +9,12 @@
 //! `Obj["m"]` surface in `TS2741`/`TS2322` assignability messages.
 //!
 //! The display policy now reduces a bare, type-parameter-free indexed access
-//! with a literal key to its member type for the assignment source/target
-//! roles, matching `tsc`. Generic/deferred accesses (a free type parameter in
-//! the object or key) stay opaque — `tsc` renders `T["m"]` there too — and are
-//! guarded by the existing `deferred_keyof_index_access_assignability_tests` /
+//! with a literal-shaped key — a single literal, a union of literals, a
+//! `keyof` query, or `number` against an array/tuple-shaped object — to its
+//! member type for the assignment source/target roles, matching `tsc`.
+//! Generic/deferred accesses (a free type parameter in the object or key)
+//! stay opaque — `tsc` renders `T["m"]` there too — and are guarded by the
+//! existing `deferred_keyof_index_access_assignability_tests` /
 //! `deferred_conditional_indexed_access_tests` suites.
 
 use tsz_checker::test_utils::check_source_strict_messages;
@@ -323,11 +325,20 @@ const m1: M["outer"]["mid"] = { z: 1 };
     assert_reduced_member(&messages[0], "{ z: number; y: string; }");
 }
 
-/// Non-literal key, still unreduced (`tsc` reduces it — a named residual on
-/// #16443). `keyof Q` reaches the formatter as a deferred key operator rather
-/// than a literal union, so the reduction declines one guard earlier than the
-/// one this suite exercises. Pinned so the residual is visible rather than
-/// silently assumed fixed.
+/// Non-literal key, still unreduced in the *target* role (`tsc` reduces it —
+/// the one piece of #16443's non-literal-key residual this PR leaves open).
+/// This is a genuinely different gate than the one this suite otherwise
+/// exercises: for a target annotation, `keyof Q` never reaches
+/// `resolve_concrete_indexed_access_for_display` at all — the annotation's
+/// `TypeId` is already the reduced object shape by the time it gets there
+/// (confirmed by direct inspection), so the unreduced `Q[keyof Q]` text comes
+/// from a separate declared-annotation-text preference specific to the
+/// target/assignment-pair display, not from the key-shape gate this PR
+/// widens. The identifier-source twin below
+/// (`keyof_indexed_access_identifier_source_renders_reduced_member`) *is*
+/// closed by this PR, because a source identifier's declared annotation
+/// reaches the widened gate as the written (still-deferred) access. Pinned so
+/// the remaining gap is visible rather than silently assumed fixed.
 #[test]
 fn keyof_rooted_indexed_access_target_prints_as_written() {
     let messages = strict_messages(
@@ -348,28 +359,24 @@ const q1: Q[keyof Q] = { c: 1 };
     );
 }
 
-/// Non-literal key, still unreduced (tsc reduces it — a named residual on
-/// #16443). What this pins is the *no-hybrid* invariant: because the outer link
-/// declines, the inner link must decline too, so the chain prints exactly as
-/// written rather than as a resolved array carrying a written key.
+/// Numeric index into an array-typed member (#16443's non-literal-key
+/// residual, closed) in the target role: `Arr["list"][number]` reduces to
+/// the element type. What this also pins is the *no-hybrid* invariant: the
+/// inner link (`Arr["list"]`, a literal-string key) must resolve to a fixed
+/// point before the outer numeric index can inspect its array shape, so the
+/// chain either reduces all the way or (per the deferred-generic negative
+/// controls elsewhere in this suite) not at all — never a half-resolved
+/// hybrid.
 #[test]
-fn unreduced_chained_indexed_access_target_prints_as_written() {
-    let messages = strict_messages(
+fn numeric_index_into_array_member_target_renders_reduced_element() {
+    let messages = ts2741_messages(
         r#"
 interface Arr { list: { w: number; z: string }[] }
 const a2: Arr["list"][number] = { w: 1 };
 "#,
     );
-    assert_eq!(
-        messages.len(),
-        1,
-        "exactly one assignability error: {messages:?}"
-    );
-    assert!(
-        messages[0].contains("Arr[\"list\"][number]"),
-        "an unreduced chain must print as written, never half-resolved: {}",
-        messages[0]
-    );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert_reduced_member(&messages[0], "{ w: number; z: string; }");
 }
 
 // ---------------------------------------------------------------------------
@@ -605,12 +612,14 @@ const h: { k: number } = bad;
     assert!(messages.is_empty(), "must stay clean: {messages:?}");
 }
 
-/// Residual, pinned rather than assumed fixed: a non-literal key declines the
-/// shared display policy one guard earlier, so the annotation surface is kept
-/// and the whole chain prints as written. `tsc` reduces this one (recorded on
-/// #16443 as the non-literal-key residual).
+/// Numeric index into an array-typed member (#16443's non-literal-key
+/// residual, closed): `Arr["list"][number]` reduces to the element type
+/// instead of printing the written chain. The outer link's key is the
+/// `number` intrinsic, not a literal — it only reduces because the inner
+/// link (`Arr["list"]`, a literal-string key) is resolved to a fixed point
+/// first, exposing the array shape the outer numeric index needs.
 #[test]
-fn nonliteral_key_indexed_access_identifier_source_prints_as_written() {
+fn numeric_index_into_array_member_identifier_source_renders_reduced_element() {
     let messages = ts2741_messages(
         r#"
 interface Arr { list: { k: number }[] }
@@ -619,9 +628,40 @@ const h: { k: number; extra: number } = bad;
 "#,
     );
     assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
-    assert!(
-        messages[0].contains("Arr[\"list\"][number]"),
-        "an unreduced chain must print as written, never half-resolved: {}",
-        messages[0]
+    assert_reduced_member(&messages[0], "{ k: number; }");
+}
+
+/// `keyof` key (#16443's non-literal-key residual, closed): `Q[keyof Q]`
+/// reduces to `Q`'s own member type, matching tsc's eager
+/// `getIndexedAccessType`.
+#[test]
+fn keyof_indexed_access_identifier_source_renders_reduced_member() {
+    let messages = ts2741_messages(
+        r#"
+interface Q { only: { c: number; d: string } }
+declare const bad: Q[keyof Q];
+const h: { c: number; extra: number } = bad;
+"#,
     );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert_reduced_member(&messages[0], "{ c: number; d: string; }");
+}
+
+/// Literal-union key (#16443's non-literal-key residual, closed) in the
+/// identifier-source role — the target-role twin
+/// (`concrete_union_key_indexed_access_target_renders_reduced_members`,
+/// above) already reduced before this change; the source role reached the
+/// same guard through the declared-annotation preference gate and needed the
+/// same widening.
+#[test]
+fn union_key_indexed_access_identifier_source_renders_reduced_member() {
+    let messages = ts2741_messages(
+        r#"
+interface UnionKey { x: { s: number }; y: { s: number } }
+declare const bad: UnionKey["x" | "y"];
+const h: { s: number; extra: number } = bad;
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert_reduced_member(&messages[0], "{ s: number; }");
 }

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -358,15 +358,22 @@ impl<'a> TypeFormatter<'a> {
         }
         // Idx must be a literal (or union of literals) for tsc's unfold —
         // a generic key would also be deferred even when the obj is concrete.
-        if !matches!(
+        // `keyof` joins the family here (`Q[keyof Q]`); `number` against an
+        // array/tuple object is the one shape tsc also unfolds without a
+        // literal key at all, checked separately below once the object
+        // operand is resolved, since a chained access's object is itself
+        // unresolved at this point.
+        let idx_is_literal_shaped = matches!(
             self.interner.lookup(idx),
             Some(
                 TypeData::Literal(_)
                     | TypeData::Union(_)
                     | TypeData::UniqueSymbol(_)
                     | TypeData::TypeQuery(_)
+                    | TypeData::KeyOf(_)
             )
-        ) {
+        );
+        if !idx_is_literal_shaped && idx != TypeId::NUMBER {
             return arg;
         }
         // A chained access (`A["p"]["q"]`) nests one indexed access inside the
@@ -378,6 +385,18 @@ impl<'a> TypeFormatter<'a> {
         // wrote and grows with nesting depth.
         let object_for_eval = self
             .materialize_reference_for_display(self.resolve_concrete_index_access_for_display(obj));
+        if !idx_is_literal_shaped {
+            // `idx == TypeId::NUMBER`: only a numeric index into an
+            // array/tuple-shaped object reduces for display. An intrinsic
+            // `number` key on any other object shape (e.g. a `[k: number]:
+            // V` index signature) stays deferred — that is a decision about
+            // index signatures with its own negative half, out of scope here.
+            if !crate::type_queries::is_array_type(self.interner, object_for_eval)
+                && !crate::type_queries::is_tuple_type(self.interner, object_for_eval)
+            {
+                return arg;
+            }
+        }
         let resolved =
             crate::evaluation::evaluate::evaluate_index_access(self.interner, object_for_eval, idx);
         if resolved == arg || resolved == TypeId::ERROR {

--- a/crates/tsz-solver/src/type_queries/extended.rs
+++ b/crates/tsz-solver/src/type_queries/extended.rs
@@ -102,6 +102,44 @@ pub fn classify_literal_type(db: &dyn TypeDatabase, type_id: TypeId) -> LiteralT
     }
 }
 
+/// True when `index_type` is a key shape tsc's `getIndexedAccessType`
+/// resolves eagerly at type-construction time on its own — independent of
+/// the object operand's shape: a single string/number literal, a union
+/// whose members are all such literals (`"a" | "b"`), or a `keyof` query.
+///
+/// `number` against an array/tuple-shaped object is also eagerly resolved by
+/// tsc, but that pairing is a joint fact about both operands, not the key
+/// alone — callers that need it check the object's shape separately (see
+/// `is_array_type`/`is_tuple_type` in this module's parent) rather than
+/// through this classification.
+pub fn is_literal_shaped_index_key(db: &dyn TypeDatabase, index_type: TypeId) -> bool {
+    if matches!(
+        classify_literal_type(db, index_type),
+        LiteralTypeKind::String(_) | LiteralTypeKind::Number(_)
+    ) {
+        return true;
+    }
+    if is_keyof_type(db, index_type) {
+        return true;
+    }
+    if index_type.is_intrinsic() {
+        return false;
+    }
+    match db.lookup(index_type) {
+        Some(TypeData::Union(list_id)) => {
+            let members = db.type_list(list_id);
+            !members.is_empty()
+                && members.iter().all(|&m| {
+                    matches!(
+                        classify_literal_type(db, m),
+                        LiteralTypeKind::String(_) | LiteralTypeKind::Number(_)
+                    )
+                })
+        }
+        _ => false,
+    }
+}
+
 /// Check if a type is a string literal type.
 pub fn is_string_literal(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     matches!(

--- a/crates/tsz-solver/src/type_queries/mod.rs
+++ b/crates/tsz-solver/src/type_queries/mod.rs
@@ -86,9 +86,9 @@ pub use extended::{
     create_number_literal_type, create_string_literal_type, get_application_base,
     get_invalid_index_type_member, get_invalid_index_type_member_strict, get_literal_property_name,
     get_number_literal_value, get_string_literal_value, get_tuple_list_id, is_literal_enum_member,
-    is_number_literal, is_object_with_index_type, is_string_like_type, is_string_literal,
-    key_matches_number_index, key_matches_string_index, string_like_type_for_type,
-    type_contains_string_literal, widen_literal_to_primitive,
+    is_literal_shaped_index_key, is_number_literal, is_object_with_index_type, is_string_like_type,
+    is_string_literal, key_matches_number_index, key_matches_string_index,
+    string_like_type_for_type, type_contains_string_literal, widen_literal_to_primitive,
 };
 pub use extended_constructors::{
     AbstractClassCheckKind, AbstractConstructorAnchor, BaseInstanceMergeKind, ClassDeclTypeKind,


### PR DESCRIPTION
`tsc`'s `getIndexedAccessType` eagerly resolves an indexed access whose key is a literal, a union of literals, a `keyof` query, or `number` against an array/tuple-shaped object — so none of these ever render as the unreduced `Obj[K]` surface in a diagnostic. tsz's display gate (`resolve_concrete_index_access_for_display` in the solver, `resolve_concrete_indexed_access_for_display` in the checker) previously required the key to be a single string/number literal, leaving three witnesses unreduced: `U["a" | "b"]`, `Q[keyof Q]`, and `Arr["list"][number]` — the non-literal-key residual named on #16443.

## Structural rule

When an indexed access's key is a union of string/number literals, a `keyof` query, or the `number` intrinsic paired with an array/tuple-shaped object — and neither operand carries a free type parameter — tsc resolves it to the member type at type-construction time; tsz now does the same through the shared display-only reduction gate, not through evaluation itself (`evaluate_index_access` already handled all three shapes; only the gate declined to attempt them).

## Owner layer

Solver (`crates/tsz-solver/src/type_queries/extended.rs`, `crates/tsz-solver/src/diagnostics/format/mod.rs`) owns the key-shape classification and the Application-arg display reduction. Checker (`crates/tsz-checker/src/error_reporter/type_display_policy.rs`) proxies the classification through `query_boundaries/common.rs` and owns the assignment source/target display reduction, which needs the checker's `TypeEnvironment`-backed evaluator.

## Adjacent-case matrix

Closed: numeric index into an array member (both target and identifier-source roles), `keyof` key (identifier-source role), literal-union key (identifier-source role — the target-role twin already worked before this change through an unrelated upstream evaluation path, confirmed by baseline testing on `main`).

Left open, pinned rather than silently assumed fixed: `keyof` key in the *target* role. Direct inspection (temporary instrumentation, removed before commit) confirmed the target annotation's `TypeId` is already the reduced object shape by the time it reaches this gate, so the unreduced `Q[keyof Q]` text comes from a separate declared-annotation preference specific to target/assignment-pair display — a different, deeper gate than the one this PR widens. Pinned in `keyof_rooted_indexed_access_target_prints_as_written` with an updated doc comment explaining why.

Negative controls verified unaffected: a free type parameter anywhere in the key or object keeps the access deferred (`T["m"]`, `T[keyof U]`); an intrinsic `number` key against a non-array/tuple object (e.g. a `[k: number]: V` index signature) stays deferred too — that is a decision about index signatures with its own negative half, out of scope here. The all-or-nothing chain invariant (no half-resolved hybrid) is preserved: a chained access's object is resolved to a fixed point before the outer link's key shape is inspected.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test concrete_indexed_access_display_tests`: 34/34.
- `cargo test -p tsz-checker --lib application_arg_concrete_index_access`: 2/2.
- `cargo test -p tsz-checker --test deferred_keyof_index_access_assignability_tests`: 17/17.
- `cargo test -p tsz-checker --test deferred_conditional_indexed_access_tests`: 22/22.
- `cargo test -p tsz-checker --lib ts2536_deferred_conditional_indexed_access`: 6/6.
- `cargo test -p tsz-solver --lib`: 7637/7637.
- `cargo clippy -p tsz-solver -p tsz-checker --all-targets -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.
- Full `cargo test -p tsz-checker --lib` (9700+ tests): reached its known slow tail (`ts2589_tests::...`) with zero failures observed in the tests that completed before it was stopped for time; will post the final count as a follow-up.
- `compare-to-parent` not run: `git diff --name-only` touches only display formatting (`error_reporter/type_display_policy.rs`, `diagnostics/format/mod.rs`, a pure classification query in `type_queries/extended.rs`, and a query-boundary proxy) — no relation, routing, or diagnostic-code decision changes, so conformance/emit counts cannot move. Same argument this family's parent PRs (#16446, #16456, #16461) used successfully.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01294VCF5LKfu5ceEs2yemGy)_