### PR TITLE
test(source-map): ratchet computed-property-names ES6 parity to 3 missing (#16395)

### DIFF
--- a/crates/tsz-core/tests/source_map_tests_1_parts/part_09.rs
+++ b/crates/tsz-core/tests/source_map_tests_1_parts/part_09.rs
@@ -1336,7 +1336,7 @@ fn test_sourcemap_parity_computed_property_names_es6() {
 
     // Track parity progress: fail if we regress (more missing than expected).
     // Update EXPECTED_MISSING as we fix more mappings.
-    const EXPECTED_MISSING: usize = 4;
+    const EXPECTED_MISSING: usize = 3;
     let num_missing = missing.len();
     if num_missing > EXPECTED_MISSING {
         let mut msg = format!(


### PR DESCRIPTION
Fixes an unbaselined red on `main`: `cargo nextest run -p tsz-core --lib` had one failure, `source_map_tests_1::test_sourcemap_parity_computed_property_names_es6`, not present in `scripts/ci/known-failures.txt` (#16395).

## Structural rule

`test_sourcemap_parity_computed_property_names_es6` is a self-ratcheting parity test: it compares tsz's generated source-map mappings against tsc's recorded baseline for `computedPropertyNamesSourceMap1_ES6.js.map`, and intentionally `panic!`s on *either* side of drift from a hardcoded `EXPECTED_MISSING` count — too many missing mappings is a REGRESSION, but *fewer* missing mappings than recorded is flagged as an unrecorded IMPROVEMENT, forcing the constant to be updated rather than silently going green.

Reproduced on current `main` (`b9f310e`):
```
IMPROVEMENT: only 3 tsc mappings missing (was 4). Update EXPECTED_MISSING to 3.
```

This is the test doing exactly what it was built to do: the recent computed-property-name emit/lowering campaign (#16256/#16261/#16270/#16271/#16319/#16327/#16329/#16331/#16336/#16362 per #16395's own list) closed one of the four previously-missing tsc mappings for this fixture, and nobody re-derived the ratchet afterward — it is a stale expected-value constant, not a wrong assertion or an emitter regression. Per #16395's own checklist: this is a position/count delta on an in-repo literal baseline (not a `tsc`-recorded-and-stale case), and `git log` shows the constant predates the computed-name campaign that improved it.

## Owner layer

Test-only change in `crates/tsz-core/tests/source_map_tests_1_parts/part_09.rs`: `EXPECTED_MISSING: usize = 4` → `3` in `test_sourcemap_parity_computed_property_names_es6`. No production code (emitter/lowering/checker) touched — the emit improvement that earned this already landed via the computed-property-name campaign; this PR only updates the test's own tracked floor.

## Verification
- `cargo test -p tsz-core --lib source_map_tests_1::test_sourcemap_parity_computed_property_names_es6`: FAILED (`IMPROVEMENT: only 3 ... was 4`) before the edit, **ok** after.
- `cargo test -p tsz-core --lib`: 3283/3283 passed after the edit (previously 3283 passed / 1 failed). One *unrelated* pre-existing flaky test noted below, not touched.
- `cargo clippy -p tsz-core --all-targets -- -D warnings`: clean.
- `cargo fmt --all`: clean (via pre-commit hook).
- Pre-commit gate (clippy + arch-guard + local verification): passed.
- Test-only diff (`git diff --name-only` touches no `crates/**/src` production path) — no conformance/emit gate is owed.

### Unrelated finding, not fixed here

`cargo test -p tsz-core --lib` (full run, parallel) also intermittently fails `isolated_test_runner::tests::test_isolated_runner_timeout` — passes reliably with `--test-threads=1` or run alone, fails under parallel load. This is a timing-sensitive test unrelated to source maps or this fixture; posting as a board NOTE for whoever owns `tsz-core` flakiness next rather than folding an unrelated fix into this PR.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: Amazonite

---
_Generated by [Claude Code](https://claude.ai/code/session_01TsKdBgQFQHAXuaW8gEhG3n)_