### PR TITLE
fix(checker): a qualified name rooted at an import alias resolves the alias, not skips the namespace-meaning check

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
+++ b/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
@@ -181,12 +181,63 @@ impl<'a> CheckerState<'a> {
                             | symbol_flags::CONST_ENUM
                             | symbol_flags::ENUM_MEMBER;
 
-                        // Skip TS2713 for ALIAS symbols (imports) - they may target
-                        // namespaces in other files. Also skip when the resolved
-                        // export has an alias_partner (TYPE_ALIAS+ALIAS merge), as
-                        // the partner provides namespace access. Skip when parse
-                        // errors exist, as the qualified name may be malformed.
-                        let is_alias = symbol.has_any_flags(symbol_flags::ALIAS);
+                        // Determine `sym_id`'s own binder deterministically
+                        // rather than guessing from the raw id alone —
+                        // `resolve_symbol_file_index` is a flat map keyed by
+                        // `SymbolId`, so trusting it for an id that was not
+                        // *just* produced by a matching cross-file resolution
+                        // risks reading whichever other file's symbol last
+                        // registered under the same colliding ordinal.
+                        //
+                        // A nested qualifier (`b.a` as the LHS of `b.a.T`)
+                        // resolves `sym_id` through `resolve_qualified_symbol_
+                        // in_type_position`, which reaches cross-file members
+                        // via `resolve_export_in_target_file` and registers
+                        // the result moments before `sym_id` reaches here —
+                        // safe to read back immediately. A plain identifier
+                        // LHS may already have been walked past its alias by
+                        // `resolve_identifier_symbol_as_qualified_type_anchor`
+                        // (which calls `resolve_alias_symbol` upstream), which
+                        // has the same collision risk in the other direction —
+                        // so start fresh from `file_locals`, the raw file-scope
+                        // binding, instead of trusting that resolution here.
+                        let (alias_probe_sym_id, alias_probe_file) =
+                            if left_node.kind == syntax_kind_ext::QUALIFIED_NAME {
+                                (
+                                    sym_id,
+                                    self.ctx
+                                        .resolve_symbol_file_index(sym_id)
+                                        .unwrap_or(self.ctx.current_file_idx),
+                                )
+                            } else {
+                                (
+                                    self.ctx
+                                        .binder
+                                        .file_locals
+                                        .get(&left_name)
+                                        .unwrap_or(sym_id),
+                                    self.ctx.current_file_idx,
+                                )
+                            };
+                        let is_alias = self
+                            .ctx
+                            .get_binder_for_file(alias_probe_file)
+                            .and_then(|b| b.get_symbol(alias_probe_sym_id))
+                            .is_some_and(|s| s.has_any_flags(symbol_flags::ALIAS));
+                        // An ALIAS symbol (import) may target a namespace in
+                        // another file, so resolve it and ask the *target* —
+                        // in its own declaring binder — for namespace meaning
+                        // instead of skipping the check wholesale. Also skip
+                        // when the resolved export has an alias_partner
+                        // (TYPE_ALIAS+ALIAS merge), as the partner provides
+                        // namespace access. Skip when parse errors exist, as
+                        // the qualified name may be malformed.
+                        let alias_has_namespace_meaning = is_alias
+                            && self.alias_target_has_namespace_meaning(
+                                alias_probe_sym_id,
+                                alias_probe_file,
+                                valid_namespace_flags,
+                            );
                         let has_alias_partner =
                             self.ctx.alias_partners_contains(self.ctx.binder, sym_id)
                                 || self.ctx.binder.resolve_import_symbol(sym_id).is_some_and(
@@ -203,30 +254,38 @@ impl<'a> CheckerState<'a> {
                         // second, so re-ask the file scope for a namespace-meaning
                         // declaration before treating the qualifier as unusable.
                         // Same fallback shape as the type-parameter case above.
-                        let outer_namespace_meaning_exists = self
-                            .ctx
-                            .binder
-                            .file_locals
-                            .get(&left_name)
-                            .map(|file_sym| {
-                                let mut visited = AliasCycleTracker::new();
-                                self.resolve_alias_symbol(file_sym, &mut visited)
-                                    .unwrap_or(file_sym)
-                            })
-                            .and_then(|resolved| {
-                                let lib_binders = self.get_lib_binders();
-                                self.ctx
-                                    .binder
-                                    .get_symbol_with_libs(resolved, &lib_binders)
-                                    .map(|outer| {
-                                        outer.has_any_flags(
-                                            valid_namespace_flags | symbol_flags::ALIAS,
-                                        )
-                                    })
-                            })
-                            .unwrap_or(false);
+                        //
+                        // Skip for ALIAS symbols: `file_locals.get(&left_name)`
+                        // finds this same alias, and `resolve_alias_symbol`
+                        // reads a resolved cross-file id through *this* file's
+                        // binder — exactly the raw-`SymbolId` collision
+                        // `alias_target_has_namespace_meaning` above already
+                        // resolves correctly through the declaring binder.
+                        let outer_namespace_meaning_exists = !is_alias
+                            && self
+                                .ctx
+                                .binder
+                                .file_locals
+                                .get(&left_name)
+                                .map(|file_sym| {
+                                    let mut visited = AliasCycleTracker::new();
+                                    self.resolve_alias_symbol(file_sym, &mut visited)
+                                        .unwrap_or(file_sym)
+                                })
+                                .and_then(|resolved| {
+                                    let lib_binders = self.get_lib_binders();
+                                    self.ctx
+                                        .binder
+                                        .get_symbol_with_libs(resolved, &lib_binders)
+                                        .map(|outer| {
+                                            outer.has_any_flags(
+                                                valid_namespace_flags | symbol_flags::ALIAS,
+                                            )
+                                        })
+                                })
+                                .unwrap_or(false);
                         if !symbol.has_any_flags(valid_namespace_flags)
-                            && !is_alias
+                            && !alias_has_namespace_meaning
                             && !has_alias_partner
                             && !outer_namespace_meaning_exists
                             && !self.ctx.has_parse_errors
@@ -722,6 +781,110 @@ impl<'a> CheckerState<'a> {
             self.error_cannot_find_namespace_with_suggestion(ident.escaped_text.as_str(), qn.left);
         }
         TypeId::ERROR
+    }
+
+    /// Whether an `ALIAS` symbol's ultimate target has tsc's
+    /// `SymbolFlags.Namespace` meaning (`ValueModule | NamespaceModule |
+    /// Enum`, passed in as `valid_namespace_flags`).
+    ///
+    /// Per-file binders mint raw `SymbolId`s from zero, so a resolved
+    /// cross-file id is only meaningful when read from the binder that
+    /// minted it — this walks `(file, export name)` hops via
+    /// [`crate::context::CheckerContext::resolve_export_in_target_file`],
+    /// the same program-aware, binder-correct primitive
+    /// [`Self::resolve_member_through_namespace_import_chain`] uses, rather
+    /// than indexing a resolved id into the wrong binder.
+    ///
+    /// A namespace import (`import * as Ns`) always denotes a module
+    /// namespace object. Otherwise this follows re-export hops while the
+    /// landed symbol is itself an alias with a module specifier to follow;
+    /// it stops and reads that symbol's own flags once the trail runs out
+    /// (no further module to resolve) or a concrete declaration is reached.
+    /// A default export (`export default class D {}`) is bound as a
+    /// synthetic alias distinct from any same-named local declaration, so a
+    /// merge partner (`namespace D {}`) never contributes flags here — the
+    /// synthetic symbol's own flags (`ALIAS | EXPORT_VALUE` at most) settle
+    /// the question without needing a separate default-export rule.
+    ///
+    /// `sym_id`'s binder is `starting_file`, chosen deterministically by the
+    /// caller rather than guessed here: `resolve_symbol_file_index` is a flat
+    /// map keyed by raw `SymbolId`, so re-deriving a file from the id alone
+    /// risks landing on whichever *other* file's symbol last registered under
+    /// the same colliding ordinal. The caller either just obtained `sym_id`
+    /// from a matching cross-file resolution (safe to look up immediately) or
+    /// knows it is local to the checking file.
+    fn alias_target_has_namespace_meaning(
+        &self,
+        sym_id: SymbolId,
+        starting_file: usize,
+        valid_namespace_flags: u32,
+    ) -> bool {
+        const MAX_HOPS: usize = 32;
+
+        let Some(mut symbol) = self
+            .ctx
+            .get_binder_for_file(starting_file)
+            .and_then(|b| b.get_symbol(sym_id))
+        else {
+            return false;
+        };
+        let mut cur_file = starting_file;
+        let mut visited_files: FxHashSet<usize> = FxHashSet::default();
+
+        for _ in 0..MAX_HOPS {
+            if !symbol.has_any_flags(symbol_flags::ALIAS) {
+                return symbol.has_any_flags(valid_namespace_flags);
+            }
+
+            let Some(module_specifier) = symbol.import_module() else {
+                // No further module to chase (a local, same-file alias, or a
+                // synthetic wrapper like the `default`-export symbol): settle
+                // on this symbol's own flags rather than risk indexing a
+                // resolved id into the wrong file's binder.
+                return symbol.has_any_flags(valid_namespace_flags);
+            };
+            // `import_name` is unset for a namespace/require-style binding
+            // (`import * as X` sets it to `"*"`, but `import X = require(m)`
+            // never sets it at all) — both denote the module's namespace
+            // object as a whole, which always has namespace meaning.
+            let Some(export_name) = symbol.import_name() else {
+                return true;
+            };
+            if export_name == "*" {
+                return true;
+            }
+
+            let Some(target_file) = self
+                .ctx
+                .resolve_import_target_from_file(cur_file, module_specifier)
+            else {
+                return false;
+            };
+            if !visited_files.insert(target_file) {
+                return false;
+            }
+            let mut visited_exports = FxHashSet::default();
+            let Some(next_sym_id) = self.ctx.resolve_export_in_target_file(
+                target_file,
+                export_name,
+                &mut visited_exports,
+            ) else {
+                return false;
+            };
+            let next_file = self
+                .ctx
+                .resolve_symbol_file_index(next_sym_id)
+                .unwrap_or(target_file);
+            let Some(next_binder) = self.ctx.get_binder_for_file(next_file) else {
+                return false;
+            };
+            let Some(next_symbol) = next_binder.get_symbol(next_sym_id) else {
+                return false;
+            };
+            symbol = next_symbol;
+            cur_file = next_file;
+        }
+        false
     }
 
     /// Resolve `member_name` for a qualified-type-name anchor that is an import

--- a/crates/tsz-checker/tests/ts2702_qualifier_namespace_meaning_tests.rs
+++ b/crates/tsz-checker/tests/ts2702_qualifier_namespace_meaning_tests.rs
@@ -222,19 +222,17 @@ fn named_imported_class_qualifier_takes_both_branches() {
 }
 
 // ---------------------------------------------------------------------------
-// Residuals — pinned as they behave today, tracked in their own issue
+// Cross-file: an ALIAS qualifier is resolved to its target, not skipped
 // ---------------------------------------------------------------------------
 
 /// A *default*-imported class used as a namespace qualifier. `export default`
 /// carries only the class's type/value meaning — never a merged namespace's —
-/// so `tsc` reports `TS2702` on the qualifier for every row here.
-///
-/// tsz still reports `TS2694`: the qualifier is an `ALIAS` symbol, and this
-/// rule's gate skips alias symbols wholesale rather than resolving the alias and
-/// asking its target for namespace meaning. Pinned as today's behaviour, not as
-/// the correct one.
+/// so `tsc` reports `TS2702` on the qualifier for every row here. The default
+/// export is bound as a synthetic alias distinct from any same-named local
+/// declaration, so a merge partner (`namespace Decl {}`, row 2) never
+/// contributes namespace meaning to it either.
 #[test]
-fn default_imported_class_used_as_namespace_is_a_known_residual() {
+fn default_imported_class_used_as_namespace_reports_type_used_as_namespace() {
     for (files, entry) in [
         (
             vec![
@@ -269,19 +267,19 @@ fn default_imported_class_used_as_namespace_is_a_known_residual() {
     ] {
         assert_eq!(
             multi_file_codes(&files, entry),
-            vec![2694],
-            "residual: tsc reports TS2702 for {entry}"
+            vec![2702],
+            "tsc reports TS2702 for {entry}"
         );
     }
 }
 
-/// A named-imported class *merged* with a namespace loses the namespace meaning
-/// across the file boundary: `tsc` accepts `Named.I` and reports `TS2694` for
-/// `Named.Missing`, while tsz reports a single `TS2702`. Same alias gate as
-/// above, seen from the opposite side — here it costs a false positive on valid
-/// code. Pinned so the follow-up has a failing witness to flip.
+/// A named-imported class *merged* with a namespace keeps its namespace
+/// meaning across the file boundary: `tsc` accepts `Named.I` and reports
+/// `TS2694` for `Named.Missing`. The alias resolves to the *merged* export
+/// symbol directly (no synthetic default-export wrapper in the way), so its
+/// flags already carry the module meaning the merge produced.
 #[test]
-fn cross_file_class_namespace_merge_is_a_known_residual() {
+fn cross_file_class_namespace_merge_keeps_its_namespace_meaning() {
     assert_eq!(
         multi_file_codes(
             &[
@@ -296,8 +294,8 @@ fn cross_file_class_namespace_merge_is_a_known_residual() {
             ],
             "/n2.ts",
         ),
-        vec![2702],
-        "residual: tsc accepts `Named.I` and reports TS2694 for `Named.Missing`"
+        vec![2694],
+        "tsc accepts `Named.I` and reports TS2694 for `Named.Missing`"
     );
 }
 


### PR DESCRIPTION
## Goal
Goal: hold

## Structural rule
When the left side of a qualified type name (`X.Y`) is an `ALIAS` symbol (an
import), `tsc` resolves the alias to its target and asks *that target* for
`SymbolFlags.Namespace` (`ValueModule | NamespaceModule | Enum`) meaning
before treating `X.Y` as a member lookup. `resolve_qualified_name`'s
TS2702/TS2713 gate in `crates/tsz-checker/src/state/type_analysis/qualified_names.rs`
instead skipped the check unconditionally for any `ALIAS`, so an import was
always treated as having namespace meaning regardless of what it actually
pointed at — owner layer: checker (`state/type_analysis`), a solver-adjacent
query boundary concern (name resolution / symbol meaning), not a solver
relation change.

The fix resolves the alias — following re-export chains through
`resolve_export_in_target_file` (the same program-aware primitive
`resolve_member_through_namespace_import_chain` already uses) — and reads the
target's flags from *its own declaring binder*. Per-file binders mint raw
`SymbolId`s from zero, so a resolved cross-file id is only meaningful when
read from the binder that minted it. The declaring file is determined
deterministically by the caller (from the cross-file resolution that just
produced the id, or from `file_locals` for a plain identifier) rather than
guessed from the id alone: `resolve_symbol_file_index` is a flat map keyed by
raw `SymbolId` and can point at whichever *other* file's symbol last
registered under the same colliding ordinal if queried for an id that wasn't
just produced by a matching resolution.

`export default class D {}` binds a synthetic `ALIAS` symbol (`"default"`)
distinct from any same-named local declaration, so a same-named merge partner
(`namespace D {}`) never contributes namespace meaning to a default-imported
binding — that falls out of the synthetic symbol's own flags (`ALIAS |
EXPORT_VALUE` at most) without a separate default-export rule. A namespace
import (`import * as Ns`) or a require-style import-equals
(`import X = require(...)`) always denotes the module namespace object.

## Adjacent-case matrix
Split from #16465 (itself split from #16467, the non-alias half of the same
family). Flips the two residual tests #16465 pinned, and adds/keeps:
- Default import, plain class (`import D from "./t1"`) → TS2702.
- Default import, class merged with a same-named exported namespace in the
  declaring file (`export default class Decl {}` + `export namespace Decl`) →
  TS2702 — the merge partner never reaches the default-imported binding.
- Default import, `export default interface` → TS2702.
- Named import, class merged with a same-named exported namespace → keeps its
  namespace meaning across the file boundary (`Named.I` valid, `Named.Missing`
  → TS2694) — false positive fixed.
- Namespace import (`import * as Ns`) → unchanged, always namespace meaning.
- Named import, plain (unmerged) class → unchanged (TS2702/TS2713 branches).
- Non-alias qualifiers (class, interface, alias, enum, namespace) → unchanged,
  all still pass.
- Ambient `import X = require(...)` chained through a nested qualifier
  (`b.a.T` where `b` and `a` are both require-style import-equals in different
  `declare module` blocks) → unchanged, still clean (regression caught locally
  during this change, see Verification).

## Verification
- `cargo build -p tsz-checker --lib` and `cargo clippy -p tsz-checker --lib -- -D warnings`: clean.
- `cargo test -p tsz-checker --lib ts2702_qualifier_namespace_meaning`: 15/15
  (13 pre-existing unchanged + 2 residuals flipped to tsc's actual behavior).
- `cargo test -p tsz-checker --lib -- namespace`: 204/204 (namespace-adjacent
  families unaffected).
- `cargo test -p tsz-checker --lib -- ts2694` / `ts2713` / `ts2749` /
  `default_export`: all pass.
- `cargo test -p tsz-checker --lib "import_equals_alias_is_valid_qualified_type_anchor_across_ambient_modules"`:
  this pre-existing test regressed mid-development (nested nested nested
  qualifier through two require-style import-equals) and is now green — see
  the adjacent-case matrix above.
- Full `cargo test -p tsz-checker --lib`: two independent full runs, 0
  failures, 0 panics.
- `compare-to-parent`/full `conformance.sh snapshot` not run this session
  (time budget) — this closes 3 named conformance rows per #16465's own
  research (`decoratorMetadataWithImportDeclarationNameCollision7`,
  `defaultExportsCannotMerge02`/`03`) and fixes a false positive
  (`n1.ts`/`n2.ts` shape in the pinned test); owed as a follow-up
  measurement before merge if a reviewer wants the exact delta confirmed.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_011Lpufp5XDE4FNuHY2S6Woi)_