### PR TITLE
fix(checker): a default-import qualifier asks its default export for namespace meaning (TS2702)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -68,6 +68,9 @@ path = "tests/predicate_callback_any_inference_tests.rs"
 name = "qualified_alias_default_fill_tests"
 path = "tests/qualified_alias_default_fill_tests.rs"
 [[test]]
+name = "qualified_name_default_import_namespace_meaning_tests"
+path = "tests/qualified_name_default_import_namespace_meaning_tests.rs"
+[[test]]
 name = "enum_literal_comparison_overlap_tests"
 path = "tests/enum_literal_comparison_overlap_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
+++ b/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
@@ -187,10 +187,30 @@ impl<'a> CheckerState<'a> {
                                         self.ctx.alias_partners_contains(self.ctx.binder, resolved)
                                     },
                                 );
-                        if !symbol.has_any_flags(valid_namespace_flags)
+                        // A *default* import binds transparently to the imported
+                        // declaration, so the anchor resolver follows it to that
+                        // symbol whose CLASS/ENUM/MODULE flag would otherwise
+                        // satisfy `valid_namespace_flags`. When the flag-based skip
+                        // does not already apply, recover the unfollowed local
+                        // `import D from "./m"` alias from `file_locals` and ask
+                        // whether its `default` export denotes a namespace: a
+                        // default export of a class/interface/function does not, so
+                        // `D.Member` is TS2702 ("used as a namespace"), never a
+                        // spurious TS2694 from navigating into the class's exports.
+                        // Named/namespace imports keep the historical `is_alias`
+                        // skip — their namespace half is provided by the
+                        // alias-partner path above. The cross-file resolution runs
+                        // only for a parse-clean identifier qualifier the flag skip
+                        // did not already cover.
+                        let flag_skip_applies = !symbol.has_any_flags(valid_namespace_flags)
                             && !is_alias
-                            && !has_alias_partner
-                            && !self.ctx.has_parse_errors
+                            && !has_alias_partner;
+                        if !self.ctx.has_parse_errors
+                            && (flag_skip_applies
+                                || (left_node.kind == SyntaxKind::Identifier as u16
+                                    && self.qualifier_default_import_lacks_namespace_meaning(
+                                        &left_name, sym_id,
+                                    )))
                         {
                             let right_name = if let Some(right_node) = self.ctx.arena.get(qn.right)
                                 && let Some(id) = self.ctx.arena.get_identifier(right_node)
@@ -668,6 +688,225 @@ impl<'a> CheckerState<'a> {
             self.error_cannot_find_namespace_with_suggestion(ident.escaped_text.as_str(), qn.left);
         }
         TypeId::ERROR
+    }
+
+    /// Whether the leftmost identifier of a qualified type name is a
+    /// namespace-less **default** import — an `import D from "./m"` whose
+    /// default export denotes no namespace — recovered from `file_locals`
+    /// because a default import of a class/interface binds transparently to the
+    /// imported declaration (leaving no distinct alias at the resolved id).
+    ///
+    /// Scoped deliberately to default imports: their semantics are unambiguous
+    /// (a default export never carries a merge partner), whereas a named or
+    /// namespace import's namespace half is supplied by the alias-partner path
+    /// and must keep its historical `is_alias` skip. `resolved_sym_id` is the
+    /// symbol the qualifier resolved to *after* following the alias; requiring
+    /// the local alias to actually reach it guards against a more-local binding
+    /// shadowing the import at the use site.
+    ///
+    /// The `default` export is resolved and asked — in *its own* declaring
+    /// binder, never through a raw `SymbolId` read against the current binder —
+    /// whether it denotes a namespace/enum. Returns `false` (keep the historical
+    /// skip, no diagnostic) whenever the default carries namespace meaning or
+    /// cannot be resolved confidently; only a positively-confirmed
+    /// namespace-less default returns `true`, so this can add a `TS2702` but
+    /// never invent one on code it failed to analyze.
+    fn qualifier_default_import_lacks_namespace_meaning(
+        &self,
+        qualifier_name: &str,
+        resolved_sym_id: SymbolId,
+    ) -> bool {
+        let Some(alias_id) = self.ctx.binder.file_locals.get(qualifier_name) else {
+            return false;
+        };
+        let Some(alias) = self.ctx.binder.get_symbol(alias_id) else {
+            return false;
+        };
+        // Must be a default ES import (`import D from "..."`). Named and
+        // namespace imports keep the historical `is_alias` skip.
+        if !alias.has_any_flags(symbol_flags::ALIAS) || alias.import_name() != Some("default") {
+            return false;
+        }
+        let Some(module) = alias.import_module() else {
+            return false;
+        };
+        // The qualifier must resolve through this very alias, or a same-named
+        // local binding shadowing the import at the use site would borrow the
+        // import's (missing) namespace meaning.
+        let mut visited = AliasCycleTracker::new();
+        let followed = self
+            .resolve_alias_symbol(alias_id, &mut visited)
+            .unwrap_or(alias_id);
+        if alias_id != resolved_sym_id && followed != resolved_sym_id {
+            return false;
+        }
+        // Resolve the module's `default` export from the alias's *own* declaring
+        // file (a re-export hub's specifier is relative to that hub) and ask it
+        // for namespace meaning.
+        let source_file = if alias.decl_file_idx == u32::MAX {
+            self.ctx.current_file_idx
+        } else {
+            alias.decl_file_idx as usize
+        };
+        let Some(target_file) = self
+            .ctx
+            .resolve_import_target_from_file(source_file, module)
+        else {
+            return false;
+        };
+        let mut visited_files = FxHashSet::default();
+        let Some(export_sym) =
+            self.ctx
+                .resolve_export_in_target_file(target_file, "default", &mut visited_files)
+        else {
+            return false;
+        };
+        !self.export_denotes_namespace(export_sym, target_file, 0, true)
+    }
+
+    /// Whether a resolved export symbol denotes a namespace, reading its flags
+    /// from the binder of the file that actually declares it and following one
+    /// alias hop at a time for re-export chains.
+    ///
+    /// `via_default` marks that the export was reached through a module's
+    /// `default` slot. A default export contributes only the *default-exported
+    /// declaration's* own meaning, never a same-named merge partner's, so a
+    /// merged `export default class Decl {} / export namespace Decl {}` is not a
+    /// namespace when imported by `import D from …` — even though its symbol
+    /// carries the merged `NamespaceModule` flag. The only default with
+    /// namespace meaning is `export default <identifier>` naming a namespace/enum
+    /// (`export default namespace`/`enum` is not legal syntax), so under
+    /// `via_default` the merged flags are ignored and only an `ExportAssignment`'s
+    /// target is followed.
+    ///
+    /// Conservative on any failure to resolve, returning `true` so a diagnostic
+    /// is never invented on code that could not be analyzed.
+    fn export_denotes_namespace(
+        &self,
+        sym_id: SymbolId,
+        hint_file: usize,
+        depth: usize,
+        via_default: bool,
+    ) -> bool {
+        // Bound the alias walk; chains this long are pathological (mirrors the
+        // re-export guard in `resolve_member_through_namespace_import_chain`).
+        const MAX_ALIAS_HOPS: usize = 16;
+        if depth > MAX_ALIAS_HOPS {
+            return true;
+        }
+
+        let file = self
+            .ctx
+            .resolve_symbol_file_index(sym_id)
+            .unwrap_or(hint_file);
+        let Some(binder) = self.ctx.get_binder_for_file(file) else {
+            return true;
+        };
+        let Some(sym) = binder.get_symbol(sym_id) else {
+            return true;
+        };
+
+        // Follow a re-export alias hop first (`export { default } from "./m"`,
+        // `export * from …`), preserving the `default` context.
+        if sym.has_any_flags(symbol_flags::ALIAS)
+            && let Some(inner_module) = sym.import_module()
+        {
+            let inner_name = sym.import_name().unwrap_or(sym.escaped_name.as_str());
+            if inner_name == "*" {
+                return true;
+            }
+            let hop_via_default = via_default || inner_name == "default";
+            if let Some(inner_file) = self.ctx.resolve_import_target_from_file(file, inner_module) {
+                let mut visited_files = FxHashSet::default();
+                if let Some(inner_sym) = self.ctx.resolve_export_in_target_file(
+                    inner_file,
+                    inner_name,
+                    &mut visited_files,
+                ) {
+                    return self.export_denotes_namespace(
+                        inner_sym,
+                        inner_file,
+                        depth + 1,
+                        hop_via_default,
+                    );
+                }
+            }
+            // Could not follow the import chain: stay conservative.
+            return true;
+        }
+
+        let arena = self.ctx.get_arena_for_file(file as u32);
+
+        // Under the `default` slot, a same-named namespace/enum that merely
+        // *merges* with the default-exported class/interface/function is not
+        // part of the default export (`export default class Decl {}` beside
+        // `export namespace Decl {}` — the illegal merge tsc flags TS2652).
+        // Namespace meaning under a default therefore requires the default
+        // entity to be a namespace/enum in its own right, not a merge partner.
+        if via_default {
+            // `export default <identifier>` — resolve the referenced entity in
+            // the declaring file and ask for ITS own meaning (no longer via the
+            // default slot). A non-identifier default (`export default C.x`, a
+            // literal) resolves to nothing here and has no namespace meaning.
+            let assignment_target = sym.declarations.iter().find_map(|&decl| {
+                let node = arena.get(decl)?;
+                if node.kind != syntax_kind_ext::EXPORT_ASSIGNMENT {
+                    return None;
+                }
+                let export_assign = arena.get_export_assignment(node)?;
+                if export_assign.is_export_equals {
+                    return None;
+                }
+                let name = arena
+                    .get_identifier_at(export_assign.expression)?
+                    .escaped_text
+                    .as_str();
+                binder.file_locals.get(name)
+            });
+            if let Some(target_sym) = assignment_target {
+                return self.export_denotes_namespace(target_sym, file, depth + 1, false);
+            }
+            // A namespace/enum reached directly through the default slot
+            // (`export default m` resolving straight to `m`) keeps its meaning,
+            // but only when it is *not* competing with a default-exported
+            // class/interface/function of the same name — the merge case above.
+            let competing_default_entity = symbol_flags::CLASS
+                | symbol_flags::INTERFACE
+                | symbol_flags::FUNCTION
+                | symbol_flags::TYPE_ALIAS;
+            if sym.has_any_flags(competing_default_entity) {
+                return false;
+            }
+        }
+
+        Self::symbol_denotes_namespace(sym, arena)
+    }
+
+    /// A symbol denotes a namespace when it carries a module/enum flag or one of
+    /// its declarations is a `namespace`/`enum` declaration in `arena` (a
+    /// namespace whose export symbol did not inherit the module flag is still a
+    /// namespace anchor).
+    fn symbol_denotes_namespace(
+        sym: &tsz_binder::Symbol,
+        arena: &tsz_parser::parser::NodeArena,
+    ) -> bool {
+        let namespace_flags = symbol_flags::MODULE
+            | symbol_flags::NAMESPACE_MODULE
+            | symbol_flags::VALUE_MODULE
+            | symbol_flags::ENUM
+            | symbol_flags::REGULAR_ENUM
+            | symbol_flags::CONST_ENUM;
+        if sym.has_any_flags(namespace_flags) {
+            return true;
+        }
+        sym.declarations.iter().any(|&decl| {
+            arena.get(decl).is_some_and(|node| {
+                matches!(
+                    node.kind,
+                    syntax_kind_ext::MODULE_DECLARATION | syntax_kind_ext::ENUM_DECLARATION
+                )
+            })
+        })
     }
 
     /// Resolve `member_name` for a qualified-type-name anchor that is an import

--- a/crates/tsz-checker/tests/qualified_name_default_import_namespace_meaning_tests.rs
+++ b/crates/tsz-checker/tests/qualified_name_default_import_namespace_meaning_tests.rs
@@ -1,0 +1,221 @@
+//! Regression tests: a qualified type name rooted at an IMPORT ALIAS must ask
+//! the alias's *target* for namespace meaning, not skip the question.
+//!
+//! Structural rule: for `Alias.Member` in type position, tsc resolves `Alias`
+//! requesting namespace meaning. A *default* import (`import D from "./m"`)
+//! binds the module's `default` export, which contributes only the
+//! default-exported declaration's own meaning — never a same-named merge
+//! partner's. A default import of a class/interface/function is therefore not a
+//! namespace: `import D from "./m"; type X = D.Member` is `TS2702` ("only
+//! refers to a type, but is being used as a namespace here"), never `TS2694`
+//! ("no exported member"). The fix is scoped to default imports; named and
+//! whole-module namespace imports keep their existing resolution. Owner: the
+//! qualified-name gate in `state/type_analysis/qualified_names.rs`.
+//!
+//! Before the fix the gate skipped every import alias unconditionally, so a
+//! default-imported class was treated as a namespace anchor and a missing
+//! member surfaced `TS2694`. These cases pin the three flipped conformance
+//! rows (`decoratorMetadataWithImportDeclarationNameCollision7`,
+//! `defaultExportsCannotMerge02`, `defaultExportsCannotMerge03`) and the
+//! controls that must NOT move: an `export default <namespace>`/`<enum>` that
+//! keeps its namespace meaning, and a whole-module namespace import.
+//!
+//! Cases vary the exporting declaration (class / interface / merged), the local
+//! binding name, and the imported member name to prove the rule is structural
+//! and not keyed to any single spelling.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_multi_file_with_global_index;
+
+fn opts() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    }
+}
+
+/// Error codes emitted for the entry file of a multi-file project.
+fn codes(files: &[(&str, &str)], entry: &str) -> Vec<u32> {
+    check_multi_file_with_global_index(files, entry, opts())
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+// ───────────────────── default import of a class ─────────────────────
+
+#[test]
+fn default_imported_class_used_as_namespace_is_ts2702() {
+    // `import D from "./dep"; var a: D.X` — the default export is a class, which
+    // has no namespace meaning, so `D.X` is TS2702, not TS2694.
+    let codes = codes(
+        &[
+            ("dep.ts", "export default class D {}\n"),
+            ("main.ts", "import D from './dep';\nvar a: D.X;\n"),
+        ],
+        "main.ts",
+    );
+    assert!(
+        codes.contains(&2702),
+        "default-imported class used as a namespace must be TS2702, got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2694),
+        "must not fall through to the missing-member TS2694 path, got: {codes:?}"
+    );
+}
+
+#[test]
+fn renamed_default_import_of_class_used_as_namespace_is_ts2702() {
+    // Vary the local binding name: the class is `Widget`, the import binding is
+    // `Gadget`. The rule must not depend on the names matching.
+    let codes = codes(
+        &[
+            ("widget.ts", "export default class Widget {}\n"),
+            (
+                "use.ts",
+                "import Gadget from './widget';\nvar g: Gadget.Missing;\n",
+            ),
+        ],
+        "use.ts",
+    );
+    assert!(
+        codes.contains(&2702),
+        "renamed default import of a class used as a namespace must be TS2702, got: {codes:?}"
+    );
+    assert!(!codes.contains(&2694), "got: {codes:?}");
+}
+
+#[test]
+fn default_imported_inline_interface_used_as_namespace_is_ts2702() {
+    // `export default interface OnlyType { ... }` — a pure type default. Used as
+    // a namespace it is TS2702.
+    let codes = codes(
+        &[
+            (
+                "dep.ts",
+                "export default interface OnlyType { k: number }\n",
+            ),
+            (
+                "main.ts",
+                "import OnlyType from './dep';\nvar a: OnlyType.X;\n",
+            ),
+        ],
+        "main.ts",
+    );
+    assert!(
+        codes.contains(&2702),
+        "default-imported interface used as a namespace must be TS2702, got: {codes:?}"
+    );
+    assert!(!codes.contains(&2694), "got: {codes:?}");
+}
+
+#[test]
+fn default_imported_class_merged_with_namespace_is_ts2702() {
+    // The `defaultExportsCannotMerge02` shape: `export default class Decl {}`
+    // beside an exported `namespace Decl` — the illegal merge tsc flags TS2652.
+    // The default export is still only the class, so `Entity.I` is TS2702 even
+    // though the namespace exports `I`.
+    let codes = codes(
+        &[
+            (
+                "m1.ts",
+                "export default class Decl {}\nexport namespace Decl { export interface I { q: number } }\n",
+            ),
+            ("m2.ts", "import Entity from './m1';\nvar y: Entity.I;\n"),
+        ],
+        "m2.ts",
+    );
+    assert!(
+        codes.contains(&2702),
+        "a merged default class+namespace used as a namespace must be TS2702, got: {codes:?}"
+    );
+    assert!(!codes.contains(&2694), "got: {codes:?}");
+}
+
+// ───────────────────── controls that must NOT move ─────────────────────
+
+#[test]
+fn export_default_namespace_keeps_namespace_meaning() {
+    // `export default m` naming a namespace DOES carry namespace meaning, so a
+    // present member resolves with no error and a MISSING member is TS2694
+    // (never TS2702). This is the direct-namespace-default control.
+    let present = codes(
+        &[
+            (
+                "dep.ts",
+                "namespace m { export interface foo { a: number } }\nexport default m;\n",
+            ),
+            ("main.ts", "import D from './dep';\nvar q: D.foo;\n"),
+        ],
+        "main.ts",
+    );
+    assert!(
+        !present.contains(&2702) && !present.contains(&2694),
+        "export default <namespace> member must resolve cleanly, got: {present:?}"
+    );
+
+    // A missing member must NOT flip to TS2702 (the regression this fix must
+    // avoid). Whether the no-lib multi-file harness also surfaces the TS2694
+    // member-lookup diagnostic is asserted end-to-end by the conformance suite;
+    // here the load-bearing guard is that the default-imported namespace keeps
+    // its namespace meaning.
+    let missing = codes(
+        &[
+            (
+                "dep.ts",
+                "namespace m { export interface foo { a: number } }\nexport default m;\n",
+            ),
+            ("main.ts", "import D from './dep';\nvar q: D.bar;\n"),
+        ],
+        "main.ts",
+    );
+    assert!(
+        !missing.contains(&2702),
+        "a missing member of an export-default namespace must not become TS2702, got: {missing:?}"
+    );
+}
+
+#[test]
+fn namespace_import_qualifier_keeps_member_lookup() {
+    // The `import * as NS` control: a whole-module namespace import is always a
+    // namespace anchor, so a missing member is TS2694, never TS2702.
+    let codes = codes(
+        &[
+            (
+                "dep.ts",
+                "export interface Thing { a: number }\nexport interface Other { b: number }\n",
+            ),
+            (
+                "main.ts",
+                "import * as NS from './dep';\nvar a: NS.Missing;\n",
+            ),
+        ],
+        "main.ts",
+    );
+    assert!(
+        codes.contains(&2694),
+        "a namespace-import qualifier must keep the TS2694 member-lookup path, got: {codes:?}"
+    );
+    assert!(!codes.contains(&2702), "got: {codes:?}");
+}
+
+#[test]
+fn valid_namespace_member_through_default_namespace_import_is_not_flagged() {
+    // Enum default export retains namespace meaning through a default import:
+    // `import E from "./e"; type X = E.Member` for an `export default <enum>`
+    // is NOT a TS2702 (an enum is a namespace-capable value).
+    let codes = codes(
+        &[
+            ("e.ts", "enum Color { Red, Green }\nexport default Color;\n"),
+            ("main.ts", "import C from './e';\nvar bad: C.Nope;\n"),
+        ],
+        "main.ts",
+    );
+    // `Nope` is not a member of the enum, so TS2694 (member lookup), never
+    // TS2702 (enum has namespace meaning).
+    assert!(
+        !codes.contains(&2702),
+        "an enum default export keeps namespace meaning (no TS2702), got: {codes:?}"
+    );
+}


### PR DESCRIPTION
A qualified type name rooted at a **default import** (`import D from "./m"; type X = D.Member`) reported a spurious **TS2694** ("Namespace has no exported member") instead of tsc's **TS2702** (`'D' only refers to a type, but is being used as a namespace here`). Fixes the checker half of #16465 (Direction A).

**When** the qualifier of a qualified type name is a default import, **tsc** resolves the module's `default` export and asks it for namespace meaning — a class/interface/function default carries none, so `D.Member` is TS2702. **tsz** now does the same through the qualified-name gate in `crates/tsz-checker/src/state/type_analysis/qualified_names.rs`.

The subtlety: a default import binds *transparently* to the imported declaration, so the anchor resolver follows it to the class/interface symbol whose `CLASS`/`ENUM` flag would otherwise satisfy the namespace-anchor gate. The fix recovers the unfollowed local alias from `file_locals`, then resolves the module's `default` export **in its own declaring binder** (never a raw `SymbolId` read against the current binder) and asks whether it denotes a namespace/enum.

Merge partners are handled per tsc's rule that a default export contributes only the default-exported declaration's own meaning:
- `export default class Decl {}` beside `export namespace Decl {}` → still only the class (the illegal merge tsc flags TS2652) → **TS2702**.
- `export default m` naming a namespace, or `export default E` naming an enum → keeps namespace meaning → member lookup / TS2694, **never** TS2702.

Scoped deliberately to **default** imports. Named imports and whole-module namespace imports (`import * as NS`) keep their existing `is_alias`/alias-partner resolution untouched, so Direction B (already correct) does not regress.

## Goal
Goal: green

## Verification
- New unit suite `crates/tsz-checker/tests/qualified_name_default_import_namespace_meaning_tests.rs` (7 cases, all pass): default-imported class / renamed / inline interface / class+namespace merge all flip to TS2702; controls — `export default <namespace>` and `export default <enum>` keep namespace meaning, `import * as NS` keeps member lookup.
- The three flipped conformance rows verified TS2694 → TS2702 via the release CLI against the reduced repros from the tsc cache (`typescript@7.0.2`, `--noEmit --strict --target es2022 --lib es2022`), expected fingerprints from `scripts/conformance/tsc-cache-full.json`:
  - `compiler/decoratorMetadataWithImportDeclarationNameCollision7.ts` — TS2702 at (7,9) and (9,21)
  - `conformance/es6/modules/defaultExportsCannotMerge02.ts` — TS2702 at m2.ts(6,8)
  - `conformance/es6/modules/defaultExportsCannotMerge03.ts` — TS2702 at m2b.ts(6,8)
- Regression controls verified on the CLI: named class+namespace merge (`import { Named }`) stays TS2694; `export default <namespace>` present member resolves cleanly and missing member stays TS2694; local class/interface qualifiers unchanged.
- Adjacent unit suites green (namespace / qualified-name / import-alias / export-default families). Pre-commit `clippy` + `arch_guard` + local verify pass. (One unrelated pre-existing failure on `main`, `commonjs_module_export_alias_tests::test_module_exports_forward_read_reports_ts2565` (TS2565, CommonJS), reproduces with this change reverted.)

Known residual (out of scope, noted for parity): `import D from "./m"; var y: D.I` where a same-named exported namespace genuinely exports `I` currently produces no error via a separate `ValueOnly`/`NotFound` resolution path rather than tsc's TS2702 — a missing diagnostic, not a wrong one, and not one of the scored conformance rows.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mt6NNjve8YMGnQTx5qRHhQ)_