### PR TITLE
fix(checker): a qualified name rooted at an import alias resolves the alias's target for namespace meaning

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
+++ b/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
@@ -163,8 +163,19 @@ impl<'a> CheckerState<'a> {
             match sym_res {
                 TypeSymbolResolution::Type(sym_id) => {
                     let lib_binders = self.get_lib_binders();
-                    if let Some(symbol) = self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders)
-                    {
+                    // Prefer the cross-file-registered owner when `sym_id` was
+                    // pinned to a foreign file by an earlier resolution step
+                    // (e.g. a cross-file alias target): per-file binders mint
+                    // raw `SymbolId`s from zero, so reading `sym_id` from the
+                    // *current* file's binder can silently collide with an
+                    // unrelated local declaration at the same numeric id —
+                    // see #16465. A `sym_id` never registered cross-file (the
+                    // common, purely-local case) falls back to the plain
+                    // local/lib read unchanged.
+                    let symbol_lookup = self
+                        .get_symbol_from_registered_file_target(sym_id)
+                        .or_else(|| self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders));
+                    if let Some(symbol) = symbol_lookup {
                         // tsc's `SymbolFlags.Namespace` is `ValueModule |
                         // NamespaceModule | Enum` — a *class* is not in it. A
                         // class declaration alone therefore has no namespace
@@ -181,12 +192,49 @@ impl<'a> CheckerState<'a> {
                             | symbol_flags::CONST_ENUM
                             | symbol_flags::ENUM_MEMBER;
 
-                        // Skip TS2713 for ALIAS symbols (imports) - they may target
-                        // namespaces in other files. Also skip when the resolved
-                        // export has an alias_partner (TYPE_ALIAS+ALIAS merge), as
-                        // the partner provides namespace access. Skip when parse
+                        // Skip TS2713/TS2702 for ALIAS symbols (imports) - a
+                        // namespace import (`import * as X`) may target a
+                        // namespace in another file with no single member to
+                        // resolve here. Also skip when the resolved export has
+                        // an alias_partner (TYPE_ALIAS+ALIAS merge), as the
+                        // partner provides namespace access. Skip when parse
                         // errors exist, as the qualified name may be malformed.
                         let is_alias = symbol.has_any_flags(symbol_flags::ALIAS);
+                        // A *named* or *default* import has one specific
+                        // target, and it is the target's own namespace
+                        // meaning — not "is this local binding an alias" —
+                        // that decides TS2702/TS2713. `sym_id`/`symbol` above
+                        // may already be misread: per-file binders mint raw
+                        // `SymbolId`s from zero, so a cross-file-resolved id
+                        // can collide with an unrelated local declaration when
+                        // read back from the *current* file's binder (`self.
+                        // ctx.binder`) — see #16465. Re-derive the alias from
+                        // `name`'s own local binding in the current file (a
+                        // same-file, unambiguous lookup) and resolve it
+                        // through the owner-carrying cross-file path, which
+                        // reads the target from *its own* declaring binder.
+                        // Returns `None` for a namespace/require import
+                        // (`import * as X`, no single named target) or when
+                        // `name` isn't a local import alias at all — callers
+                        // fall back to their own, more conservative answer.
+                        let resolve_import_target_has_namespace_meaning =
+                            |name: &str| -> Option<bool> {
+                                let local_id = self.ctx.binder.file_locals.get(name)?;
+                                let local = self.ctx.binder.get_symbol(local_id)?;
+                                if !local.has_any_flags(symbol_flags::ALIAS)
+                                    || local.import_name().is_none()
+                                {
+                                    return None;
+                                }
+                                let target_id =
+                                    self.ctx.resolve_import_alias_and_register(local_id)?;
+                                let target =
+                                    self.get_symbol_from_registered_file_target(target_id)?;
+                                Some(target.has_any_flags(valid_namespace_flags))
+                            };
+                        let alias_target_lacks_namespace_meaning = is_alias
+                            && resolve_import_target_has_namespace_meaning(&left_name)
+                                == Some(false);
                         let has_alias_partner =
                             self.ctx.alias_partners_contains(self.ctx.binder, sym_id)
                                 || self.ctx.binder.resolve_import_symbol(sym_id).is_some_and(
@@ -203,6 +251,12 @@ impl<'a> CheckerState<'a> {
                         // second, so re-ask the file scope for a namespace-meaning
                         // declaration before treating the qualifier as unusable.
                         // Same fallback shape as the type-parameter case above.
+                        // When the outer declaration is itself a named/default
+                        // import alias, ask its resolved target for namespace
+                        // meaning (same rule as above) rather than assuming
+                        // every ALIAS qualifies; fall back to the old
+                        // conservative `true` when that can't be determined
+                        // (a namespace import, or resolution failure).
                         let outer_namespace_meaning_exists = self
                             .ctx
                             .binder
@@ -219,14 +273,17 @@ impl<'a> CheckerState<'a> {
                                     .binder
                                     .get_symbol_with_libs(resolved, &lib_binders)
                                     .map(|outer| {
-                                        outer.has_any_flags(
-                                            valid_namespace_flags | symbol_flags::ALIAS,
-                                        )
+                                        outer.has_any_flags(valid_namespace_flags)
+                                            || (outer.has_any_flags(symbol_flags::ALIAS)
+                                                && resolve_import_target_has_namespace_meaning(
+                                                    &left_name,
+                                                )
+                                                .unwrap_or(true))
                                     })
                             })
                             .unwrap_or(false);
                         if !symbol.has_any_flags(valid_namespace_flags)
-                            && !is_alias
+                            && (!is_alias || alias_target_lacks_namespace_meaning)
                             && !has_alias_partner
                             && !outer_namespace_meaning_exists
                             && !self.ctx.has_parse_errors

--- a/crates/tsz-checker/tests/ts2702_qualifier_namespace_meaning_tests.rs
+++ b/crates/tsz-checker/tests/ts2702_qualifier_namespace_meaning_tests.rs
@@ -222,19 +222,15 @@ fn named_imported_class_qualifier_takes_both_branches() {
 }
 
 // ---------------------------------------------------------------------------
-// Residuals — pinned as they behave today, tracked in their own issue
+// Cross-file: an import alias resolves to its target's namespace meaning,
+// not the local binding's ALIAS flag (closes #16465)
 // ---------------------------------------------------------------------------
 
 /// A *default*-imported class used as a namespace qualifier. `export default`
 /// carries only the class's type/value meaning — never a merged namespace's —
 /// so `tsc` reports `TS2702` on the qualifier for every row here.
-///
-/// tsz still reports `TS2694`: the qualifier is an `ALIAS` symbol, and this
-/// rule's gate skips alias symbols wholesale rather than resolving the alias and
-/// asking its target for namespace meaning. Pinned as today's behaviour, not as
-/// the correct one.
 #[test]
-fn default_imported_class_used_as_namespace_is_a_known_residual() {
+fn default_imported_class_used_as_namespace_reports_type_used_as_namespace() {
     for (files, entry) in [
         (
             vec![
@@ -269,19 +265,17 @@ fn default_imported_class_used_as_namespace_is_a_known_residual() {
     ] {
         assert_eq!(
             multi_file_codes(&files, entry),
-            vec![2694],
-            "residual: tsc reports TS2702 for {entry}"
+            vec![2702],
+            "tsc reports TS2702 for {entry}"
         );
     }
 }
 
-/// A named-imported class *merged* with a namespace loses the namespace meaning
-/// across the file boundary: `tsc` accepts `Named.I` and reports `TS2694` for
-/// `Named.Missing`, while tsz reports a single `TS2702`. Same alias gate as
-/// above, seen from the opposite side — here it costs a false positive on valid
-/// code. Pinned so the follow-up has a failing witness to flip.
+/// A named-imported class *merged* with a namespace keeps its namespace
+/// meaning across the file boundary: `tsc` accepts `Named.I` and reports
+/// `TS2694` for `Named.Missing`.
 #[test]
-fn cross_file_class_namespace_merge_is_a_known_residual() {
+fn cross_file_class_namespace_merge_keeps_the_member_lookup_path() {
     assert_eq!(
         multi_file_codes(
             &[
@@ -296,8 +290,8 @@ fn cross_file_class_namespace_merge_is_a_known_residual() {
             ],
             "/n2.ts",
         ),
-        vec![2702],
-        "residual: tsc accepts `Named.I` and reports TS2694 for `Named.Missing`"
+        vec![2694],
+        "tsc accepts `Named.I` and reports TS2694 for `Named.Missing`"
     );
 }
 


### PR DESCRIPTION
When a qualified type name's root is an import alias, `tsc` decides TS2702/TS2713 (namespace-meaning errors) vs. the member-lookup path (TS2694/TS2749) by resolving the alias to its *target* and asking the target — in its own declaring binder — for `SymbolFlags.Namespace` meaning. tsz instead used the *local* import alias binding for that decision, through `resolve_qualified_name`'s ALIAS skip in `crates/tsz-checker/src/state/type_analysis/qualified_names.rs`, which is wrong in both directions.

## Structural rule

When a qualified type name's root resolves through an import alias, `tsc` asks the alias's *resolved target* — read from the target's own declaring binder — whether it carries `ValueModule | NamespaceModule | Enum` meaning; tsz now does the same through the checker's cross-file symbol-owner machinery (`get_symbol_from_registered_file_target`, `resolve_import_alias_and_register`) instead of trusting the local ALIAS flag or a same-binder raw-id read.

Two independent defects were hiding behind the old unconditional `!is_alias` skip:

- **Direction A — missing TS2702 (3 conformance rows).** `export default` carries only the exported declaration's own type/value meaning, never a same-named merge partner's namespace. But a default import's qualifier stays the raw, un-dealiased local `ALIAS` symbol at this gate (the binder's synthesized `export default` symbol has no `import_module` for the existing `resolve_alias_symbol` chain to follow further), so the blanket skip fired regardless of what the target actually is.
- **Direction B — false positive on valid code.** Per-file binders mint raw `SymbolId`s from zero (the same family as #15983/#16415/#16419), so a cross-file-resolved id can collide with an unrelated local declaration when read back from the *current* file's own binder. A named import of a class merged with a namespace in its *own* declaring file was silently misread as whatever local symbol happened to sit at the same numeric id in the *importing* file, losing the merge's namespace meaning entirely.

Both were found with a temporary instrumented `panic!` at the gate (removed before commit) rather than by fully tracing the cross-file resolution machinery statically — the actual runtime `SymbolId`/flags disagreed with what static reading of `resolve_alias_symbol` predicted in both directions.

Fix, in `resolve_qualified_name`:
1. Prefer `get_symbol_from_registered_file_target(sym_id)` over the current-file-only `get_symbol_with_libs` read for the base `symbol` lookup — a `sym_id` never registered cross-file (the common, purely-local case) falls back to the old read unchanged. Fixes direction B.
2. For a named/default import specifically, resolve the alias's target through the owner-carrying cross-file path (`resolve_import_alias_and_register` + `get_symbol_from_registered_file_target`) and ask *it* for namespace meaning, instead of trusting the local `ALIAS` flag. A namespace/require import (`import * as X`) has no single named target and keeps the old conservative skip. Fixes direction A.
3. The same "ALIAS implies namespace meaning" shortcut was duplicated in this function's `outer_namespace_meaning_exists` shadow-resolution check (`| symbol_flags::ALIAS` in its mask) and silently overrode fix 2 for the common non-shadowed case until it got the identical treatment.

## Adjacent-case matrix

All cases live in `crates/tsz-checker/tests/ts2702_qualifier_namespace_meaning_tests.rs` (15 tests). The two rows previously pinned as "known residuals" are renamed and now assert tsc's real behavior instead of tsz's old wrong one:
- `default_imported_class_used_as_namespace_reports_type_used_as_namespace` — 3 sub-witnesses: plain default class, default class merged with a same-named namespace in its own file (the row that proves the default export never carries the merge's meaning), default-exported interface.
- `cross_file_class_namespace_merge_keeps_the_member_lookup_path` — a named import of a class+namespace merge now accepts the real member and still reports TS2694 for a missing one.
- Unchanged and re-verified as controls: plain named import (no merge, both TS2702/TS2713 branches), namespace import (`import * as X`, must keep the member-lookup path unconditionally), same-file class+namespace merge, interface/type-alias qualifiers, static-only vs. instance member distinction, generic and ambient class qualifiers.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib ts2702_qualifier_namespace_meaning_tests`: 15/15 (before: 15/15 passed but 2 asserted tsz's wrong behavior; after: 15/15 asserting tsc's real behavior).
- `cargo test -p tsz-checker --lib -- qualified_name cross_file_import_alias raw_symbol_collision ts2702 ts2694 ts2713 ts2749`: 50/50, including the exact #16419 raw-`SymbolId`-collision regression suite (`imported_type_reference_raw_symbol_collision_tests`, 12/12) — confirms this change doesn't reopen that family.
- `cargo clippy -p tsz-checker --lib --tests`: clean.
- `cargo fmt -p tsz-checker -- --check`: clean.
- Full `cargo test -p tsz-checker --lib` (~9700+ tests) was still in its known slow tail (five long-running tests, board-documented) at PR-open time; will post the final count as a follow-up before queuing.
- `compare-to-parent.sh` not run this session (55–90 min on a cold cloud seat, past this session's budget) — **owed**. This is a diagnostic-*code* change (TS2694/TS2749 ↔ TS2702/TS2713), so unlike the display-only PRs in this family the corpus can see it; the 3 conformance rows named in #16465 (`decoratorMetadataWithImportDeclarationNameCollision7.ts`, `defaultExportsCannotMerge02.ts`, `defaultExportsCannotMerge03.ts`) are the predicted flips.

Closes #16465.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01QwyLyjQZFQmwbXn2EFw9Yp)_