### PR TITLE
fix(checker): a plain symbol-keyed computed member is late-bound against an explicit symbol index (TS2411)

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
@@ -205,6 +205,17 @@ impl<'a> CheckerState<'a> {
         // vs from another merged body of the same interface.
         let has_extends_clause = self.container_has_extends_clause(container_node);
 
+        // A class's own symbol-keyed members are always checked against a
+        // declared symbol index signature; the late-bound exemption below
+        // (a plain, non-`unique` `symbol`-typed computed key) applies only to
+        // interfaces and type literals. Measured against tsc 7.0.2: the same
+        // `[s1]: string` member alongside `[key: symbol]: number` is clean in
+        // an interface/type literal but still reports TS2411 in a class.
+        let is_class_container = self.ctx.arena.get(container_node).is_some_and(|n| {
+            n.kind == syntax_kind_ext::CLASS_DECLARATION
+                || n.kind == syntax_kind_ext::CLASS_EXPRESSION
+        });
+
         let mut inherited_symbol_value_type =
             index_info.symbol_index.as_ref().map(|idx| idx.value_type);
         // Keep accepting older encoded shapes that carried a `symbol` index in
@@ -772,9 +783,13 @@ impl<'a> CheckerState<'a> {
 
             // Symbol-keyed properties are NOT checked against string or number
             // index signatures, but they ARE checked against symbol index
-            // signatures (TS2411).
+            // signatures (TS2411) -- unless the key itself is late-bound (see
+            // `is_late_bound_symbol_key`), in which case it contributes to the
+            // symbol index rather than being independently checked against it.
             if self.is_symbol_named_property(name_idx) {
-                if !self.type_contains_error(prop_type) {
+                if !self.type_contains_error(prop_type)
+                    && (is_class_container || !self.is_late_bound_symbol_key(name_idx))
+                {
                     let applicable_symbol_value = if is_static_member {
                         static_symbol_value_type
                     } else {
@@ -1373,6 +1388,33 @@ impl<'a> CheckerState<'a> {
             }
             _ => false,
         }
+    }
+
+    /// Whether a symbol-keyed computed member's key has no fixed compile-time
+    /// identity: a plain identifier of type `symbol` (not `unique symbol`).
+    ///
+    /// `[Symbol.iterator]` and a `unique symbol`-typed key both denote a
+    /// specific, statically known symbol and are always checked against a
+    /// declared symbol index signature. A plain `symbol`-typed variable's
+    /// runtime identity is unknown, so tsc folds its contribution into the
+    /// index instead of requiring the member itself to satisfy it (#16477).
+    fn is_late_bound_symbol_key(&mut self, name_idx: NodeIndex) -> bool {
+        let Some(name_node) = self.ctx.arena.get(name_idx) else {
+            return false;
+        };
+        if name_node.kind != syntax_kind_ext::COMPUTED_PROPERTY_NAME {
+            return false;
+        }
+        let Some(computed) = self.ctx.arena.get_computed_property(name_node) else {
+            return false;
+        };
+        let Some(expr_node) = self.ctx.arena.get(computed.expression) else {
+            return false;
+        };
+        if expr_node.kind != tsz_scanner::SyntaxKind::Identifier as u16 {
+            return false;
+        }
+        self.get_type_of_node(computed.expression) == TypeId::SYMBOL
     }
 
     fn is_symbol_or_unique_symbol(&self, type_id: TypeId) -> bool {

--- a/crates/tsz-checker/tests/ts2411_tests.rs
+++ b/crates/tsz-checker/tests/ts2411_tests.rs
@@ -753,3 +753,147 @@ class C {
         get_diagnostics(source)
     );
 }
+
+// =========================================================================
+// #16477: an explicit `[key: symbol]` index does not dominate an implicit
+// computed member keyed by a plain (non-`unique`) `symbol`-typed variable.
+//
+// Structural rule: when a computed property's key expression is a plain
+// identifier of type `symbol` (not `unique symbol`), its runtime identity is
+// unknown, so tsc treats the member as an implicit, late-bound contribution
+// to the containing interface/type-literal's symbol index rather than a
+// property independently checked against it. Members with a *fixed* symbol
+// identity -- `unique symbol`, or a well-known `Symbol.x` access -- keep the
+// TS2411 check. Classes never get this exemption, even for a plain `symbol`
+// key: tsc still reports TS2411 there (measured against tsc 7.0.2).
+// =========================================================================
+
+#[test]
+fn explicit_symbol_index_dominates_implicit_member_implicit_first() {
+    let source = r#"
+declare const s1: symbol;
+declare const other: symbol;
+interface M { [s1]: string; [key: symbol]: number }
+declare const m: M;
+export const r: number = m[other];
+"#;
+    assert!(
+        !has_error_with_code(source, 2411),
+        "a plain symbol-keyed member is late-bound and is not checked \
+         against the interface's own explicit symbol index: {:?}",
+        get_diagnostics(source)
+    );
+}
+
+#[test]
+fn explicit_symbol_index_dominates_implicit_member_explicit_first() {
+    // Order-independence: swapping which member comes first must not change
+    // the outcome.
+    let source = r#"
+declare const s1: symbol;
+interface M { [key: symbol]: number; [s1]: string; }
+declare const m: M;
+"#;
+    assert!(
+        !has_error_with_code(source, 2411),
+        "declaration order of the index signature vs. the late-bound member \
+         must not matter: {:?}",
+        get_diagnostics(source)
+    );
+}
+
+#[test]
+fn explicit_symbol_index_dominates_implicit_member_type_literal() {
+    // Adjacent container form: a type literal follows the same rule as an
+    // interface (both are non-class object types).
+    let source = r#"
+declare const s1: symbol;
+type M = { [s1]: string; [key: symbol]: number };
+declare const m: M;
+"#;
+    assert!(
+        !has_error_with_code(source, 2411),
+        "a type literal exempts a late-bound symbol-keyed member the same \
+         way an interface does: {:?}",
+        get_diagnostics(source)
+    );
+}
+
+#[test]
+fn explicit_symbol_index_dominates_implicit_member_renamed_binder() {
+    // Prove the rule is structural (any plain-`symbol`-typed variable), not
+    // tied to a specific identifier spelling.
+    let source = r#"
+declare const myOwnKey: symbol;
+interface M { [myOwnKey]: boolean; [key: symbol]: number }
+declare const m: M;
+"#;
+    assert!(
+        !has_error_with_code(source, 2411),
+        "the exemption must not be keyed to the identifier's name: {:?}",
+        get_diagnostics(source)
+    );
+}
+
+#[test]
+fn class_symbol_keyed_member_still_checks_explicit_symbol_index() {
+    // Negative case: unlike an interface/type-literal, a class's own
+    // plain-symbol-keyed member is still checked against a declared symbol
+    // index -- tsc reports TS2411 here (measured against tsc 7.0.2).
+    let source = r#"
+declare const s1: symbol;
+class C { [s1]: string = ""; [key: symbol]: number; }
+"#;
+    assert!(
+        has_error_with_code(source, 2411),
+        "a class does not get the late-bound exemption an interface gets: {:?}",
+        get_diagnostics(source)
+    );
+}
+
+#[test]
+fn class_static_symbol_keyed_member_still_checks_explicit_symbol_index() {
+    // Adjacent form: the static side of a class follows the same rule as the
+    // instance side.
+    let source = r#"
+declare const s1: symbol;
+class C { static [s1]: string = ""; static [key: symbol]: number; }
+"#;
+    assert!(
+        has_error_with_code(source, 2411),
+        "a class's static side does not get the late-bound exemption either: {:?}",
+        get_diagnostics(source)
+    );
+}
+
+#[test]
+fn unique_symbol_keyed_member_still_checks_explicit_symbol_index() {
+    // Negative case: a `unique symbol` has a fixed compile-time identity, so
+    // it keeps the strict TS2411 check even in an interface (measured against
+    // tsc 7.0.2).
+    let source = r#"
+declare const s1: unique symbol;
+interface M { [s1]: string; [key: symbol]: number }
+declare const m: M;
+"#;
+    assert!(
+        has_error_with_code(source, 2411),
+        "a unique symbol key has a fixed identity and is not late-bound: {:?}",
+        get_diagnostics(source)
+    );
+}
+
+#[test]
+fn well_known_symbol_keyed_member_still_checks_explicit_symbol_index() {
+    // Negative case: a well-known symbol access (`Symbol.iterator`) also has a
+    // fixed identity and keeps the strict check (measured against tsc 7.0.2).
+    let source = r#"
+interface M { [Symbol.iterator]: string; [key: symbol]: number }
+declare const m: M;
+"#;
+    assert!(
+        has_error_with_code(source, 2411),
+        "a well-known symbol key has a fixed identity and is not late-bound: {:?}",
+        get_diagnostics(source)
+    );
+}


### PR DESCRIPTION
When a computed property's key is a plain identifier of type `symbol` (not `unique symbol`), tsc treats it as late-bound: its runtime identity is unknown, so it contributes to the containing interface/type-literal's declared symbol index instead of being independently checked against it. `check_index_signature_compatibility` (`crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs`) treated every symbol-keyed member the same way via `is_symbol_named_property`, checking it strictly against a declared `[key: symbol]` index and reporting a spurious TS2411.

Structural rule: when a computed member's key expression is a plain identifier whose type is exactly `symbol` (not `unique symbol`, not a well-known `Symbol.x` access) inside an interface or type literal, tsc folds it as an implicit contribution to the declared symbol index rather than checking it against that index; tsz now does the same through a new `is_late_bound_symbol_key` gate in `check_index_signature_compatibility`. Fixed-identity forms (`unique symbol`, well-known `Symbol.iterator`-style access) keep the strict check, and **classes never get the exemption** — tsc still reports TS2411 there (measured directly against tsc 7.0.2, see adjacent cases below).

Closes #16477. Two of the issue's own predecessor tests (`explicit_symbol_index_dominates_implicit_member_implicit_first`/`..._explicit_first`, deleted before #16471 merged) are restored, renamed to match the current file's naming, in `crates/tsz-checker/tests/ts2411_tests.rs`.

## Adjacent-case matrix (`crates/tsz-checker/tests/ts2411_tests.rs`)

| Case | tsc 7.0.2 | tsz (after) |
| --- | --- | --- |
| Interface, implicit member first, explicit index second | clean | clean |
| Interface, explicit index first, implicit member second (order-independence) | clean | clean |
| Type literal (adjacent container form) | clean | clean |
| Interface, renamed binder (`myOwnKey`, structural not name-based) | clean | clean |
| Class instance member (negative control — no exemption) | TS2411 | TS2411 |
| Class static member (negative control) | TS2411 | TS2411 |
| `unique symbol` key (negative control — fixed identity) | TS2411 | TS2411 |
| Well-known `Symbol.iterator` key (negative control — fixed identity) | TS2411 | TS2411 |

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts2411_tests`: 47/47 passed (9 new).
- `cargo test -p tsz-checker --lib index_signature`: 235/235 passed, 0 regressed.
- `cargo test -p tsz-checker --test wide_symbol_computed_member_index_signature_tests --test non_unique_symbol_late_bound_member_tests`: 25/25 + 12/12 passed (the adjacent late-bound-member/`#16307` families, unaffected).
- `cargo fmt --check -p tsz-checker`: clean.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings`: clean.
- `compare-to-parent.sh` / broader conformance snapshot: **owed** — not run this session (two-sided `dist-fast` build measured 55-90+ min on recent cloud sessions per the coordination board, outside this session's remaining budget). This is a diagnostic-*presence* change (removes a false-positive TS2411 in a narrow, oracle-verified condition), so the corpus can in principle see it, though the exact repro shape (an explicit `symbol` index alongside a plain-`symbol`-keyed computed member in the same interface/type-literal body) is uncommon.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_013Mt2AMg9Q24sNawT1nTnsm)_