### PR TITLE
fix(solver): a function source is compared against the whole global `Function` surface

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -493,6 +493,9 @@ mod for_of_self_reference_operand_spelling_tests;
 #[path = "../tests/fresh_object_literal_union_array_member_drill_in_tests.rs"]
 mod fresh_object_literal_union_array_member_drill_in_tests;
 #[cfg(test)]
+#[path = "../tests/function_source_apparent_function_surface_tests.rs"]
+mod function_source_apparent_function_surface_tests;
+#[cfg(test)]
 #[path = "../tests/function_source_numeric_index_target_tests.rs"]
 mod function_source_numeric_index_target_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/tests/function_source_apparent_function_surface_tests.rs
+++ b/crates/tsz-checker/tests/function_source_apparent_function_surface_tests.rs
@@ -1,0 +1,264 @@
+//! A function source is compared against the whole global `Function` surface.
+//!
+//! `tsc` models a function value's apparent type as its call and construct
+//! signatures plus every member of the global `Function` interface — `length`,
+//! `name`, `bind`, `call`, `apply`, `toString`, `arguments`, `caller`,
+//! `prototype`. A target requiring any of those is satisfied by any function.
+//!
+//! tsz synthesized a two-name stub instead (`call`/`apply` for a callable,
+//! `prototype` for a constructor), which is the property set the weak-type rule
+//! needs, not the apparent surface. Every other `Function` member therefore read
+//! as absent and the target's required property failed with a spurious
+//! `TS2322`.
+//!
+//! The member *types* have to come from the interface too, not from a widened
+//! stub of `any`s: `{ length: string }` must still be rejected, because
+//! `Function` declares `length: number`.
+//!
+//! Rows below were pinned against `typescript@7.0.2`
+//! (`--noEmit --strict --lib es2022 --target es2022`).
+
+use tsz_checker::CheckerOptions;
+use tsz_checker::test_utils::{
+    check_source_with_libs_code_messages, has_diagnostic_code, load_default_lib_files,
+};
+
+/// The apparent surface under test *is* the global `Function` interface, so
+/// every row runs against the real lib bundle — with no lib loaded there is no
+/// interface to resolve and the synthesized two-name stub is the whole answer.
+fn get_diagnostics(source: &str) -> Vec<(u32, String)> {
+    let libs = load_default_lib_files();
+    check_source_with_libs_code_messages(source, "test.ts", CheckerOptions::default(), &libs)
+}
+
+fn has_error_with_code(source: &str, code: u32) -> bool {
+    has_diagnostic_code(&get_diagnostics(source), code)
+}
+
+fn is_clean(source: &str) -> bool {
+    get_diagnostics(source).is_empty()
+}
+
+// =========================================================================
+// Required `Function` members on the target: tsc accepts, tsz rejected
+// =========================================================================
+
+#[test]
+fn function_satisfies_a_length_target() {
+    assert!(
+        is_clean("var q1: { length: number } = () => {};"),
+        "`Function` declares `length: number`, so every function provides it"
+    );
+}
+
+#[test]
+fn function_satisfies_a_name_target() {
+    assert!(is_clean("var q2: { name: string } = () => {};"));
+}
+
+#[test]
+fn function_satisfies_a_bind_target() {
+    assert!(is_clean("var q3: { bind(...a: any[]): any } = () => {};"));
+}
+
+#[test]
+fn function_satisfies_an_arguments_target() {
+    assert!(is_clean("var q7: { arguments: any } = () => {};"));
+}
+
+#[test]
+fn function_satisfies_a_caller_target() {
+    assert!(is_clean("var q8: { caller: Function } = () => {};"));
+}
+
+#[test]
+fn function_satisfies_a_prototype_target() {
+    // `Function` declares `prototype: any`, so a plain arrow satisfies this too —
+    // not only a constructor.
+    assert!(is_clean("var q9: { prototype: any } = () => {};"));
+}
+
+#[test]
+fn function_satisfies_a_multi_member_function_surface_target() {
+    assert!(is_clean(
+        "var q10: { length: number; name: string } = () => {};"
+    ));
+}
+
+#[test]
+fn a_declared_function_satisfies_a_length_target() {
+    // Binder-name variation: a `function` declaration, not an arrow.
+    assert!(is_clean(
+        r#"
+function namedFn(alpha: number, beta: number) {}
+var d1: { length: number } = namedFn;
+"#
+    ));
+}
+
+#[test]
+fn an_aliased_target_type_satisfies_the_same_surface() {
+    // Alias/wrapper form of the same target.
+    assert!(is_clean(
+        r#"
+type Sized = { length: number };
+type Named = { name: string };
+var a1: Sized = () => {};
+var a2: Named = function renamedBinder() {};
+"#
+    ));
+}
+
+#[test]
+fn a_nested_target_position_satisfies_the_same_surface() {
+    // The relation is reached as a nested property value, not a direct assignment.
+    assert!(is_clean(
+        r#"
+var nested: { outer: { length: number } } = { outer: () => {} };
+"#
+    ));
+}
+
+#[test]
+fn a_generic_parameter_constrained_to_the_function_surface_accepts_a_function() {
+    assert!(is_clean(
+        r#"
+declare function takesSized<T extends { length: number }>(value: T): T;
+takesSized(() => {});
+"#
+    ));
+}
+
+// =========================================================================
+// Negative rows: the surface is the real interface, not a widened stub
+// =========================================================================
+
+#[test]
+fn function_does_not_satisfy_a_wrongly_typed_length_target() {
+    assert!(
+        has_error_with_code("var q11: { length: string } = () => {};", 2322),
+        "`Function.length` is `number`; a `string` target must still fail"
+    );
+}
+
+#[test]
+fn function_does_not_satisfy_a_target_requiring_a_non_function_member() {
+    assert!(has_error_with_code(
+        "var q12: { zzz: number } = () => {};",
+        2322
+    ));
+}
+
+#[test]
+fn function_does_not_satisfy_a_mixed_target_with_one_foreign_member() {
+    assert!(
+        has_error_with_code("var q13: { length: number; zzz: number } = () => {};", 2322),
+        "one unsatisfiable member is enough, even beside a real `Function` member"
+    );
+}
+
+// =========================================================================
+// Weak targets: owned by the weak-type rule, deliberately untouched
+// =========================================================================
+
+#[test]
+fn function_does_not_satisfy_a_weak_target_naming_a_function_member() {
+    // tsc rejects with TS2559 ("no properties in common"): its weak-type rule
+    // scans the source's *declared* properties, which a bare function has none
+    // of — the apparent `Function` surface never enters that scan.
+    assert!(
+        !is_clean("var w1: { length?: number } = () => {};"),
+        "widening the apparent surface must not silence the weak-type rejection"
+    );
+}
+
+#[test]
+fn function_does_not_satisfy_a_weak_target_naming_no_function_member() {
+    assert!(!is_clean("var w3: { zzz?: string } = () => {};"));
+}
+
+#[test]
+fn function_stays_a_member_of_an_intersection_with_a_weak_object_part() {
+    // The intersection-member arm suppresses the weak rule; tsc accepts.
+    assert!(is_clean(
+        r#"
+declare var value: (() => void) & { brand?: number };
+var i1: (() => void) & { brand?: number } = value;
+"#
+    ));
+}
+
+// =========================================================================
+// Constructor sources: same surface
+// =========================================================================
+
+#[test]
+fn a_class_constructor_satisfies_the_function_surface() {
+    assert!(is_clean(
+        r#"
+class Renamed {}
+var c1: { prototype: any } = Renamed;
+var c2: { length: number } = Renamed;
+var c3: { name: string } = Renamed;
+var c4: { bind(...a: any[]): any } = Renamed;
+"#
+    ));
+}
+
+#[test]
+fn a_class_constructor_with_statics_still_satisfies_the_function_surface() {
+    // The callable-shape arm (source has its own declared properties) takes the
+    // same second opinion as the bare-function arm.
+    assert!(is_clean(
+        r#"
+class WithStatics {
+    static tag = "t";
+}
+var s1: { length: number } = WithStatics;
+var s2: { tag: string } = WithStatics;
+"#
+    ));
+}
+
+#[test]
+fn a_constructor_does_not_satisfy_a_target_requiring_a_non_function_member() {
+    // The oracle reports the missing-property spelling here (`TS2741`), not the
+    // generic `TS2322` it uses for the arrow-function rows above.
+    assert!(has_error_with_code(
+        r#"
+class Renamed {}
+var c9: { zzz: number } = Renamed;
+"#,
+        2741
+    ));
+}
+
+// =========================================================================
+// The sibling rules this arm shares with #16473 / #16481 stay put
+// =========================================================================
+
+#[test]
+fn function_still_fails_a_numeric_index_target() {
+    // #16473's rule: a function's apparent type carries no numeric index
+    // signature, and the wider surface must not resurrect one.
+    assert!(has_error_with_code(
+        r#"
+interface Bar { b: number; }
+declare var target: { [n: number]: Bar };
+declare var source: (x: any) => void;
+target = source;
+"#,
+        2322
+    ));
+}
+
+#[test]
+fn function_still_satisfies_a_call_only_target() {
+    assert!(is_clean(
+        r#"
+declare var target: { call(x: any): any };
+declare var source: (x: any) => void;
+target = source;
+"#
+    ));
+}

--- a/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
+++ b/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
@@ -1701,13 +1701,14 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 }
                 // If source is a CallableShape with properties, check structural compatibility
                 if let Some(ref s_shape) = source_props {
-                    return self.check_object_subtype(
+                    let result = self.check_object_subtype(
                         s_shape,
                         None,
                         Some(source),
                         &t_shape,
                         Some(target),
                     );
+                    return self.or_global_function_interface_surface(target, &t_shape, result);
                 }
                 // A bare `FunctionShape` has no user-declared properties, so model
                 // it as an object whose only members are the function's stable
@@ -1731,13 +1732,14 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 // *required* property likewise still fails inside
                 // `check_object_subtype`.
                 let apparent_source = self.function_apparent_object_shape(source);
-                return self.check_object_subtype(
+                let result = self.check_object_subtype(
                     &apparent_source,
                     None,
                     Some(source),
                     &t_shape,
                     Some(target),
                 );
+                return self.or_global_function_interface_surface(target, &t_shape, result);
             }
             if let Some(t_shape_id) = object_with_index_shape_id(self.interner, target) {
                 let t_shape = self.interner.object_shape(t_shape_id);
@@ -1941,6 +1943,55 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             }
         }
 
+        result
+    }
+
+    /// Second opinion for a function-like source that a synthesized apparent
+    /// shape just rejected: relate the registered global `Function` interface to
+    /// the same target.
+    ///
+    /// `tsc` compares a function value against its *apparent type* — the call
+    /// and construct signatures plus every member of the global `Function`
+    /// interface (`length`, `name`, `bind`, `call`, `apply`, `toString`,
+    /// `arguments`, `caller`, `prototype`). The shapes built above carry only
+    /// the source's own declared properties plus the two synthesized names the
+    /// weak-type rule needs, so a target requiring any other `Function` member
+    /// reads as unsatisfied even though every function provides it.
+    ///
+    /// Asking the boxed-type registry for the real interface (the same
+    /// binder/global-builtin id `visitor.rs` uses for the intersection-member
+    /// arm) keeps the member *types* honest too: `{ length: string }` still
+    /// fails, because the interface declares `length: number`.
+    ///
+    /// This is purely a second opinion — it can only turn a rejection into
+    /// acceptance:
+    ///
+    /// * A **weak** target (all-optional, no index signature) is left to the
+    ///   verdict it already has. That verdict is owned by the weak-type rule in
+    ///   `check_object_subtype`, which deliberately scans the synthesized names
+    ///   and nothing else; widening the surface underneath it would silently
+    ///   accept `{ length?: number }`, which `tsc` rejects with `TS2559`.
+    /// * With no lib loaded the registry is empty and the synthesized verdict
+    ///   stands unchanged.
+    fn or_global_function_interface_surface(
+        &mut self,
+        target: TypeId,
+        target_shape: &ObjectShape,
+        result: SubtypeResult,
+    ) -> SubtypeResult {
+        if result.is_true() || Self::is_weak_type_shape(target_shape) {
+            return result;
+        }
+        let Some(boxed_function) = self
+            .resolver
+            .get_boxed_type(IntrinsicKind::Function)
+            .or_else(|| self.interner.get_boxed_type(IntrinsicKind::Function))
+        else {
+            return result;
+        };
+        if self.check_subtype(boxed_function, target).is_true() {
+            return SubtypeResult::True;
+        }
         result
     }
 


### PR DESCRIPTION
Closes #16478.

**Structural rule.** When the source is function-like and the target is a non-weak object type, `tsc` compares the source's *apparent type* — its call and construct signatures plus every member of the global `Function` interface (`length`, `name`, `bind`, `call`, `apply`, `toString`, `arguments`, `caller`, `prototype`) — so a target requiring any of those members is satisfied by any function. tsz now does the same through the **solver**, in the function-like arm of `relations/subtype/core_dispatch.rs`, by resolving the real interface from the binder/global-builtin boxed-type registry.

The arm previously compared the target against a synthesized **two-name stub** (`call`/`apply` for a callable, `prototype` for a constructor). That stub is the property set the *weak-type* rule needs, not the apparent surface, so every other `Function` member read as absent and plain required-property targets were rejected with a spurious `TS2322`.

When the synthesized shape rejects a **non-weak** object target, the arm now takes a second opinion from the registered global `Function` interface itself — the same boxed-type id the intersection-member arm in `subtype/visitor.rs` already uses. Resolving the real interface (rather than growing the hand-written stub with `any`s) keeps the member types honest: `{ length: string }` still fails, because `Function` declares `length: number`.

The second opinion is deliberately narrow — it can only turn a rejection into acceptance:

- A **weak** target (all-optional, no index signature) keeps the verdict it already has. That verdict is owned by the weak-type rule, which scans the synthesized names and nothing else. Widening the surface underneath it would silently accept `{ length?: number }`, which the oracle rejects with `TS2559` — `tsc`'s weak rule consults the source's *declared* properties, and a bare function has none. This is why the `CompatChecker::function_like_weak_type_properties` mirror does **not** move here: nothing on the weak side changed.
- With no lib loaded the boxed registry is empty and the synthesized verdict stands unchanged (`noLib` behavior is untouched).
- `#16473`'s rule (a function never satisfies a numeric index signature) is decided above this arm and is pinned by a test here.

### Oracle matrix

`typescript@7.0.2`, `--noEmit --strict --lib es2022 --target es2022`.

| target | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `{ length: number }` | accepted | **TS2322** | accepted |
| `{ name: string }` | accepted | **TS2322** | accepted |
| `{ bind(...a: any[]): any }` | accepted | **TS2322** | accepted |
| `{ arguments: any }` | accepted | **TS2322** | accepted |
| `{ caller: Function }` | accepted | **TS2322** | accepted |
| `{ prototype: any }` (arrow source) | accepted | **TS2322** | accepted |
| `{ length: number; name: string }` | accepted | **TS2322** | accepted |
| `{ length: string }` | TS2322 | TS2322 | TS2322 |
| `{ zzz: number }` | TS2322 | TS2322 | TS2322 |
| `{ length: number; zzz: number }` | TS2322 | TS2322 | TS2322 |
| `{ length?: number }` (weak) | TS2559 | rejected | rejected |
| `{ zzz?: string }` (weak) | TS2559 | rejected | rejected |
| `(() => void) & { brand?: number }` | accepted | accepted | accepted |
| `{ [n: number]: Bar }` | TS2322 | TS2322 | TS2322 |

Adjacent cases in the new suite: renamed binders (`namedFn`, `renamedBinder`, `Renamed`, `WithStatics`), alias/wrapper targets (`type Sized = { length: number }`), nested target position (object-literal property value), generic form (`T extends { length: number }` inference site), constructor sources both bare and with statics (the callable-shape arm takes the same second opinion), and the negative/fallback rows above.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib function_source_apparent` — **22/22** in the new `function_source_apparent_function_surface_tests` suite (14 of them fail on this branch's parent; the 7 accept-rows plus their adjacent forms are exactly the #16478 family).
- `cargo test -p tsz-checker --lib function_source_numeric_index` — the #16473 suite still passes; its rule is re-pinned inside the new suite too.
- Full `cargo test -p tsz-checker --lib` — running at push time; result posted as a follow-up comment. Parent count is 9739 (recorded on #16473), expected 9761 with the 22 new tests.
- `cargo fmt` clean; pre-commit hook ran `clippy` (`-p tsz-checker -p tsz-solver`) and `arch_guard.py` — both passed.
- **Owed:** `scripts/conformance/compare-to-parent.sh`. This is a semantic change (some `TS2322` rejections become acceptances), so the corpus can see it. This is a cold cloud seat with no `.target` and no `TypeScript/` checkout; two `dist-fast` builds plus two snapshots did not fit the session. The change is additive-only on non-weak targets, but that is an argument, not a measurement — please treat the corpus diff as required before merge.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Obsidian

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMRXWLtCK8K2sgHQyEyzFx)_