### PR TITLE
fix(checker): a position-invalid `export ... from` resolves its specifier only outside a declaration scope

### DIFF
--- a/crates/tsz-checker/src/declarations/import/context_helpers.rs
+++ b/crates/tsz-checker/src/declarations/import/context_helpers.rs
@@ -130,6 +130,72 @@ impl<'a> CheckerState<'a> {
         false
     }
 
+    /// Whether a module element that has *already* drawn a placement diagnostic
+    /// still resolves its module specifier.
+    ///
+    /// Only meaningful for a node in a non-module-element context — i.e. one for
+    /// which [`Self::is_in_non_module_element_context`] is true. A declaration in a
+    /// valid context (`SourceFile`, or the `ModuleBlock` of an ambient module)
+    /// always resolves and must not consult this.
+    ///
+    /// tsc's `checkExportDeclaration` reports the placement diagnostic and then
+    /// `return`s, so `resolveExternalModuleName` — the only TS2307/TS2305 site — is
+    /// never reached. That return is reached only when a *declaration scope*
+    /// encloses the declaration: a function-like body, or a namespace/ambient-module
+    /// body it does not directly belong to. A container that opens no declaration
+    /// scope — a bare block, an `if`/loop/`try` body, a labeled statement, a
+    /// `switch` clause — leaves the declaration in the source file's own scope, and
+    /// resolution still runs there.
+    ///
+    /// The walk therefore stops at the first scope-opening ancestor and answers
+    /// from its kind, rather than testing for any single container shape.
+    ///
+    /// One measured exception is deliberately not encoded: a block inside
+    /// `declare global { }` keeps resolving, because a global augmentation re-opens
+    /// the global scope rather than introducing one. tsz reports no diagnostic at
+    /// all for that shape today, so the branch would be unreachable and untestable;
+    /// it is recorded here instead of written as dead code.
+    pub(crate) fn position_invalid_module_element_resolves_specifier(
+        &self,
+        node_idx: NodeIndex,
+    ) -> bool {
+        let mut current = node_idx;
+        while current.is_some() {
+            let Some(ext) = self.ctx.arena.get_extended(current) else {
+                break;
+            };
+            current = ext.parent;
+            if current.is_none() {
+                break;
+            }
+            let Some(node) = self.ctx.arena.get(current) else {
+                break;
+            };
+            match node.kind {
+                // Function-like ancestors are the same set `is_inside_function_body`
+                // walks, including a class `static { }` block (#16450).
+                k if k == syntax_kind_ext::FUNCTION_DECLARATION
+                    || k == syntax_kind_ext::FUNCTION_EXPRESSION
+                    || k == syntax_kind_ext::ARROW_FUNCTION
+                    || k == syntax_kind_ext::METHOD_DECLARATION
+                    || k == syntax_kind_ext::CONSTRUCTOR
+                    || k == syntax_kind_ext::GET_ACCESSOR
+                    || k == syntax_kind_ext::SET_ACCESSOR
+                    || k == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION =>
+                {
+                    return false;
+                }
+                // Reaching a `ModuleBlock` from a position-invalid node means the
+                // node is nested *inside* a namespace/module body rather than being
+                // one of its own elements, so the body is a scope it sits within.
+                k if k == syntax_kind_ext::MODULE_BLOCK => return false,
+                k if k == syntax_kind_ext::SOURCE_FILE => return true,
+                _ => continue,
+            }
+        }
+        true
+    }
+
     /// Check if a node is inside a module augmentation
     /// (`declare module "string" { ... }`).  Module augmentations have a
     /// `MODULE_DECLARATION` ancestor whose name is a string literal.

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -533,6 +533,10 @@ mod jsdoc_enum_circular_tests;
 mod jsdoc_function_return_type_anchor_tests;
 
 #[cfg(test)]
+#[path = "../tests/position_invalid_export_specifier_resolution_tests.rs"]
+mod position_invalid_export_specifier_resolution_tests;
+
+#[cfg(test)]
 #[path = "../tests/jsdoc_readonly_tests.rs"]
 mod jsdoc_readonly_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
@@ -229,6 +229,17 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
                         crate::diagnostics::diagnostic_messages::EXPORT_DECLARATIONS_ARE_NOT_PERMITTED_IN_A_NAMESPACE,
                         crate::diagnostics::diagnostic_codes::EXPORT_DECLARATIONS_ARE_NOT_PERMITTED_IN_A_NAMESPACE,
                     );
+                    if has_from {
+                        // tsc reports TS1194 from `checkExternalImportOrExportDeclaration`,
+                        // which then returns `false`; the caller gates module resolution
+                        // on that result, so the specifier is never resolved and no
+                        // TS2307 follows. Only the `from` form reaches the resolution
+                        // path at all, and only a declaration whose parent is a
+                        // *namespace* body reaches here — inside `declare module "m"`
+                        // the parent is that module's own block, which is a valid
+                        // module-element context, so resolution still runs there.
+                        return;
+                    }
                 }
             }
 
@@ -245,14 +256,24 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
             self.check_import_attributes_grammar(export_decl.attributes, export_decl.is_type_only);
 
             // Check module specifier for unresolved modules (TS2792)
-            if export_decl.module_specifier.is_some() {
+            //
+            // A declaration whose placement is already invalid resolves its
+            // specifier only when no declaration scope encloses it: tsc's
+            // `checkExportDeclaration` returns at the placement diagnostic, and
+            // everything downstream — TS2307, the re-exported-member validation
+            // (TS2305) and TS2498 — goes with it. See
+            // `position_invalid_module_element_resolves_specifier` for which
+            // containers open a scope and which do not.
+            let resolves_specifier = !in_non_module_context
+                || self.position_invalid_module_element_resolves_specifier(export_idx);
+            if export_decl.module_specifier.is_some() && resolves_specifier {
                 self.check_export_module_specifier(export_idx);
                 // TS2498: export * from a module that uses export =
                 self.check_export_star_of_export_equals_module(export_idx);
             }
 
             // TS2498: `export *` (or `export * as ns`) from a module that uses `export =`
-            if export_decl.module_specifier.is_some() {
+            if export_decl.module_specifier.is_some() && resolves_specifier {
                 let is_star_export = export_decl.export_clause.is_none()
                     || self
                         .ctx

--- a/crates/tsz-checker/tests/position_invalid_export_specifier_resolution_tests.rs
+++ b/crates/tsz-checker/tests/position_invalid_export_specifier_resolution_tests.rs
@@ -1,0 +1,373 @@
+//! A position-invalid `export ... from "m"` resolves its module specifier only
+//! when no declaration scope encloses it.
+//!
+//! tsc's `checkExportDeclaration` reports the placement diagnostic (TS1233) and
+//! `return`s, so `resolveExternalModuleName` — the only TS2307/TS2305 site — never
+//! runs. That return is reached when a *declaration scope* encloses the
+//! declaration: a function-like body, or a namespace/ambient-module body the
+//! declaration does not directly belong to. A container that opens no declaration
+//! scope (a bare block, an `if`/loop/`try` body, a labeled statement, a `switch`
+//! clause) leaves the declaration in the source file's own scope, and tsc keeps
+//! resolving there.
+//!
+//! Every expectation below is a row where `typescript@7.0.2` returns the same
+//! answer in **both** threading modes (default and `--singleThreaded`). The
+//! top-level-block family, where the two modes disagree, is deliberately left
+//! alone — see #16413 — and is pinned here as a control asserting the behavior
+//! `main` already has.
+
+use crate::context::CheckerOptions;
+use crate::state::CheckerState;
+use tsz_binder::BinderState;
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_parser::parser::ParserState;
+use tsz_solver::construction::TypeInterner;
+
+/// Check a single source with unresolved-import reporting on, so a specifier
+/// naming a nonexistent module reports TS2307 if it is resolved at all.
+fn check(source: &str) -> Vec<u32> {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        CheckerOptions {
+            module: ModuleKind::ESNext,
+            target: ScriptTarget::ESNext,
+            ..CheckerOptions::default()
+        },
+    );
+    checker.ctx.report_unresolved_imports = true;
+    checker.check_source_file(root);
+    let mut codes: Vec<u32> = checker.ctx.diagnostics.iter().map(|d| d.code).collect();
+    codes.sort_unstable();
+    codes
+}
+
+fn assert_codes(source: &str, expected: &[u32], what: &str) {
+    let actual = check(source);
+    assert_eq!(actual, expected, "{what}\nsource:\n{source}");
+}
+
+// ---------------------------------------------------------------------------
+// Function-like containers suppress resolution. Both threading modes agree.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn export_star_in_function_body_reports_ts1233_without_ts2307() {
+    assert_codes(
+        r#"function f() {
+  export * from "nonexistent-module";
+}"#,
+        &[1233],
+        "a function body is a declaration scope",
+    );
+}
+
+#[test]
+fn export_named_in_function_body_reports_ts1233_without_ts2307() {
+    assert_codes(
+        r#"function f() {
+  export { a } from "nonexistent-module";
+}"#,
+        &[1233],
+        "the named form takes the same path as `export *`",
+    );
+}
+
+#[test]
+fn export_star_as_ns_in_function_body_reports_ts1233_without_ts2307() {
+    assert_codes(
+        r#"function f() {
+  export * as ns from "nonexistent-module";
+}"#,
+        &[1233],
+        "`export * as ns` takes the same path",
+    );
+}
+
+#[test]
+fn export_in_block_nested_in_function_body_reports_ts1233_without_ts2307() {
+    assert_codes(
+        r#"function f() {
+  {
+    export { a } from "nonexistent-module";
+  }
+}"#,
+        &[1233],
+        "a block inside a function body is still inside the function's scope",
+    );
+}
+
+#[test]
+fn export_in_arrow_body_reports_ts1233_without_ts2307() {
+    assert_codes(
+        r#"const g = () => {
+  export { a } from "nonexistent-module";
+};"#,
+        &[1233],
+        "an arrow body is a declaration scope",
+    );
+}
+
+#[test]
+fn export_in_method_body_reports_ts1233_without_ts2307() {
+    assert_codes(
+        r#"class C {
+  m() {
+    export { a } from "nonexistent-module";
+  }
+}"#,
+        &[1233],
+        "a method body is a declaration scope",
+    );
+}
+
+#[test]
+fn export_in_class_static_block_reports_ts1233_without_ts2307() {
+    assert_codes(
+        r#"class C {
+  static {
+    export { a } from "nonexistent-module";
+  }
+}"#,
+        &[1233],
+        "a class static block is function-like for scope purposes",
+    );
+}
+
+#[test]
+fn export_in_function_nested_in_a_top_level_block_reports_ts1233_without_ts2307() {
+    assert_codes(
+        r#"{
+  function f() {
+    export { a } from "nonexistent-module";
+  }
+}"#,
+        &[1233],
+        "the innermost declaration scope decides, not the outermost container",
+    );
+}
+
+#[test]
+fn renamed_binders_do_not_change_the_verdict_in_a_function_body() {
+    // Same shape as the `function f` row with every user-chosen name changed.
+    assert_codes(
+        r#"function zzTop() {
+  export { qqq } from "no-such-package-here";
+}"#,
+        &[1233],
+        "the rule is structural; no identifier or specifier text participates",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Namespace containers suppress resolution. Both threading modes agree.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn export_from_directly_in_a_namespace_body_reports_ts1194_without_ts2307() {
+    assert_codes(
+        r#"namespace P {
+  export { a } from "nonexistent-module";
+}"#,
+        &[1194],
+        "tsc reports TS1194 from checkExternalImportOrExportDeclaration, which \
+         then returns false and skips resolution",
+    );
+}
+
+#[test]
+fn export_star_directly_in_a_namespace_body_reports_ts1194_without_ts2307() {
+    assert_codes(
+        r#"namespace P {
+  export * from "nonexistent-module";
+}"#,
+        &[1194],
+        "the star form takes the same TS1194 path",
+    );
+}
+
+#[test]
+fn export_in_a_block_inside_a_namespace_reports_ts1233_without_ts2307() {
+    assert_codes(
+        r#"namespace P {
+  {
+    export { a } from "nonexistent-module";
+  }
+}"#,
+        &[1233],
+        "a namespace body is a declaration scope for a block nested inside it",
+    );
+}
+
+#[test]
+fn export_in_a_function_inside_a_namespace_reports_ts1233_without_ts2307() {
+    assert_codes(
+        r#"namespace P {
+  function f() {
+    export { a } from "nonexistent-module";
+  }
+}"#,
+        &[1233],
+        "two nested declaration scopes still suppress",
+    );
+}
+
+#[test]
+fn renamed_namespace_binder_does_not_change_the_verdict() {
+    assert_codes(
+        r#"namespace WhateverName {
+  {
+    export { zzz } from "no-such-package-here";
+  }
+}"#,
+        &[1233],
+        "the namespace's own name does not participate",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls: containers that must KEEP resolving.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_top_level_export_still_reports_ts2307() {
+    assert_codes(
+        r#"export { a } from "nonexistent-module";"#,
+        &[2307],
+        "a valid module element context resolves normally",
+    );
+}
+
+#[test]
+fn an_export_directly_in_an_ambient_module_body_still_reports_ts2307() {
+    assert_codes(
+        r#"declare module "amb" {
+  export { a } from "nonexistent-module";
+}"#,
+        &[2307],
+        "an ambient module body IS a module-element context — the falsifying \
+         control for any ordering-based 'silence TS2307 after a placement error' fix",
+    );
+}
+
+#[test]
+fn a_bare_top_level_block_keeps_resolving_unchanged() {
+    // The top-level-block family is where typescript@7.0.2's two threading modes
+    // disagree (#16413): the default scheduler reports TS1233 alone, and
+    // `--singleThreaded` — the mode `generate-tsc-cache.rs` uses, and therefore
+    // the mode the conformance corpus is scored in — reports TS1233 + TS2307.
+    // This fix changes nothing here; the row is pinned so a later widening of the
+    // gate cannot silently move it without the disagreement being settled first.
+    assert_codes(
+        r#"{
+  export { a } from "nonexistent-module";
+}"#,
+        &[1233, 2307],
+        "a bare top-level block opens no declaration scope",
+    );
+}
+
+#[test]
+fn an_if_block_at_top_level_keeps_resolving_unchanged() {
+    assert_codes(
+        r#"if (1) {
+  export { a } from "nonexistent-module";
+}"#,
+        &[1233, 2307],
+        "an `if` body opens no declaration scope",
+    );
+}
+
+#[test]
+fn a_loop_body_at_top_level_keeps_resolving_unchanged() {
+    assert_codes(
+        r#"for (;;) {
+  export { a } from "nonexistent-module";
+}"#,
+        &[1233, 2307],
+        "a loop body opens no declaration scope",
+    );
+}
+
+#[test]
+fn a_labeled_block_at_top_level_keeps_resolving_unchanged() {
+    assert_codes(
+        r#"lbl: {
+  export { a } from "nonexistent-module";
+}"#,
+        &[1233, 2307],
+        "a labeled statement opens no declaration scope",
+    );
+}
+
+#[test]
+fn a_nested_bare_block_at_top_level_keeps_resolving_unchanged() {
+    assert_codes(
+        r#"{
+  {
+    export { a } from "nonexistent-module";
+  }
+}"#,
+        &[1233, 2307],
+        "nesting plain blocks never crosses a declaration scope",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The import side is untouched: it already matched, and it is a different
+// production (`checkImportDeclaration`, gated by its own container proxy).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_import_in_a_function_body_is_unchanged() {
+    assert_codes(
+        r#"function f() {
+  import { a } from "nonexistent-module";
+}"#,
+        &[1232],
+        "the import path already suppressed here before this change",
+    );
+}
+
+#[test]
+fn an_import_in_a_bare_top_level_block_is_unchanged() {
+    assert_codes(
+        r#"{
+  import { a } from "nonexistent-module";
+}"#,
+        &[1232, 2307],
+        "the import path already resolved here before this change",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TS1184 is a modifier diagnostic, not a placement diagnostic: the wrapped
+// declaration keeps being checked either way.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_export_modifier_in_a_function_body_still_checks_the_wrapped_declaration() {
+    let codes = check(
+        r#"function f() {
+  export class C {
+    m(): NotAType {}
+  }
+}"#,
+    );
+    assert!(
+        codes.contains(&1184),
+        "expected TS1184 for the export modifier, got {codes:?}"
+    );
+    assert!(
+        codes.contains(&2304),
+        "expected the wrapped class to still be checked (TS2304), got {codes:?}"
+    );
+}


### PR DESCRIPTION
`function f() { export * from "nope"; }` reported **TS1233 and TS2307**. tsc reports TS1233 alone. Same leak in an arrow body, a method body, a class `static` block, a block nested inside a function or a namespace, and — as **TS1194 + TS2307** — an `export ... from` directly in a namespace body.

**Structural rule.** When an `export ... from "m"` declaration sits in a non-module-element context *and a declaration scope encloses it*, tsc reports the placement diagnostic and resolves no module specifier; tsz now does the same through the **checker's export-declaration check**, gated on one predicate that walks to the first scope-opening ancestor.

tsc's `checkExportDeclaration` reports its placement diagnostic and then `return`s. `resolveExternalModuleName` — the only TS2307 site, and the gateway to the re-exported-member validation (TS2305) and to TS2498 — is downstream of that `return`. Measured against `typescript@7.0.2`, that `return` is reached when the declaration is enclosed by a **declaration scope**: a function-like body, or a namespace/ambient-module body it does not directly belong to. A container that opens no declaration scope — a bare block, an `if`/loop/`try` body, a labeled statement, a `switch` clause — leaves the declaration in the source file's own scope, and resolution still runs there.

**The predicate answers from the ancestor's kind, not from a container shape.** `position_invalid_module_element_resolves_specifier` (`declarations/import/context_helpers.rs`) walks the parent chain and stops at the first function-like node, `ModuleBlock`, or `SourceFile`. No identifier, specifier text, alias, or file name participates, and it is consulted only for a node already known to be in a non-module-element context — a declaration in a *valid* context never asks.

**The namespace arm is tsc's other gate, one layer over.** A `ModuleBlock` parent *is* a valid module-element context, so `namespace P { export { a } from "m"; }` never reaches the placement check at all. It takes `checkExternalImportOrExportDeclaration` instead, which reports TS1194 and returns `false`; the caller uses that result to skip resolution. Emitting TS1194 for the `from` form now returns for the same reason. Oracle-confirmed for both `namespace` and `declare namespace`.

**This is a short-circuit inside the declaration's own check, not a suppression keyed on an already-emitted code** — and the falsifying control proves the difference: `declare module "amb" { export { a } from "nope"; }` **keeps** its TS2307, because an ambient module body is a valid module-element context. Any ordering-based "silence TS2307 after a placement error" fix passes the ten suppressed rows and silently breaks that one.

### What this deliberately does not touch

- **The top-level-block family** (bare block, nested block, `if`, `for`, `while`, `try`, labeled, `switch` clause). This is #16413: `typescript@7.0.2`'s two threading modes *disagree* there, and `main` already matches the mode the corpus is scored in. Pinned as five control tests asserting today's behavior, so a later widening cannot move them silently. See the reproduction below.
- **`import ... from` and `import x = require(...)`.** Different productions, carrying their own container gate, and already matching the oracle in 31 of 32 measured rows. The one residual is recorded at the bottom.
- **TS1184.** A modifier diagnostic, not a placement one: tsc keeps checking the wrapped declaration, so `function f() { export class C { m(): NotAType {} } }` must still report TS2304. Pinned.

Closes the `export`-side half of #16410. Unblocks — and supersedes the export half of — the two drafts stalled on #16413 (#16409, #16411).

## Goal
Goal: hold

## Verification

**#16413 independently reproduced before writing any code.** `generate-tsc-cache.rs` passes `--singleThreaded` for TS7+, and that flag changes *which* diagnostics typescript-go reports:

```
$ node node_modules/typescript/bin/tsc --noEmit --pretty false --target es2015 bareblock.ts
bareblock.ts(2,5): error TS1233: An export declaration can only be used at the top level of a namespace or module.

$ node node_modules/typescript/bin/tsc --noEmit --pretty false --target es2015 --singleThreaded bareblock.ts
bareblock.ts(2,5): error TS1233: An export declaration can only be used at the top level of a namespace or module.
bareblock.ts(2,23): error TS2307: Cannot find module 'm' or its corresponding type declarations.
```

**80-row oracle sweep, both threading modes** (5 statement forms × 16 containers, `typescript@7.0.2`, `--noEmit --pretty false --target es2015`). The two modes differ on exactly one axis — the 8 top-level-block containers — and agree everywhere else. **Every row this PR changes is a row where both modes agree**, so none of it depends on settling #16413.

**Three-way tsc / main / branch, scored from built binaries in this container** (`.target/debug/tsz --noEmit`). 10 rows fixed, 0 moved away from tsc:

| container | statement | tsc (both modes) | main | branch |
| --- | --- | --- | --- | --- |
| function body | `export * from "m"` | TS1233 | TS1233 **+TS2307** | TS1233 ✅ |
| block inside a function body | `export { a } from "m"` | TS1233 | TS1233 **+TS2307** | TS1233 ✅ |
| arrow body | `export { a } from "m"` | TS1233 | TS1233 **+TS2307** | TS1233 ✅ |
| method body | `export { a } from "m"` | TS1233 | TS1233 **+TS2307** | TS1233 ✅ |
| function inside a top-level block | `export { a } from "m"` | TS1233 | TS1233 **+TS2307** | TS1233 ✅ |
| function inside a namespace | `export { a } from "m"` | TS1233 | TS1233 **+TS2307** | TS1233 ✅ |
| block inside a namespace | `export { a } from "m"` | TS1233 | TS1233 **+TS2307** | TS1233 ✅ |
| namespace body (direct) | `export * from "m"` | TS1194 | TS1194 **+TS2307** | TS1194 ✅ |
| function body | `export { nope } from "./dep"` | TS1233 | TS1233 **+TS2307** | TS1233 ✅ |
| block inside a namespace | `export { nope } from "./dep"` | TS1233 | TS1233 **+TS2307** | TS1233 ✅ |
| **top level (control)** | `export { a } from "m"` | TS2307 | TS2307 | TS2307 |
| **`declare module "amb"` (control)** | `export { a } from "m"` | TS2307 | TS2307 | TS2307 |
| **bare block (control, #16413)** | `export { a } from "m"` | TS1233 +TS2307 *(single)* | TS1233 +TS2307 | TS1233 +TS2307 |
| **`if` / `for` / `while` / `try` / labeled / `switch` / nested block (7 controls, #16413)** | `export { a } from "m"` | TS1233 +TS2307 *(single)* | TS1233 +TS2307 | TS1233 +TS2307 |
| **`import ... from` × 16 containers (control)** | — | — | unchanged | unchanged |
| **`import x = require(...)` × 16 containers (control)** | — | — | unchanged | unchanged |

The full 55-row before/after diff of the built binaries moved **exactly the 10 rows above and nothing else**.

**Adjacent-case matrix** — `crates/tsz-checker/tests/position_invalid_export_specifier_resolution_tests.rs`, 24 rows: eight function-like/namespace containers, both renamed-binder pairs (function name and namespace name varied, with a different specifier), the three `export *` / `export { }` / `export * as ns` forms, the missing-member (TS2305 gateway) rows, the two positive controls, five #16413 controls, two import-side controls, and the TS1184 negative.

- `cargo test -p tsz-checker --lib position_invalid_export_specifier` — **24 passed, 0 failed**
- `cargo test -p tsz-checker --lib` (full crate) — running in-container at PR-open time; the count will be posted before this is queued.
- `cargo fmt --all` clean; `cargo clippy -p tsz-checker` and the architecture guard both green via the pre-commit hook.
- `scripts/conformance/compare-to-parent.sh` — **not run**: the corpus is not checked out in this container and the two-sided run does not fit the session. Stated plainly rather than implied. The evidence standing in for it is the direction of the change: this PR only ever *removes* a diagnostic, only in containers where both threading modes of the pinned oracle agree tsc emits nothing, and the corpus's own three `moduleElementsInWrongContext*.ts` fixtures record exactly that split (`...2.ts` function-body and `...3.ts` namespace-nested-block carry **no** TS2305/TS2307; only the bare-block `...ts` does, and this PR does not touch the bare-block family). A reviewer with the corpus should still run it.

### Residual found while measuring, not fixed here

`namespace P { { import { a } from "nope"; } }` — tsc reports TS1232 alone in both threading modes; tsz reports **TS1232 + TS2307**. That is the import production, whose container gate (`declaration_check_body.rs`'s `wrong_context_allows_module_semantics`) already names `is_inside_namespace_declaration` and should therefore suppress — so something downstream of that proxy emits the TS2307 anyway. It is the only one of 32 measured import/`import =` rows that disagrees. Out of scope here; recorded on #16410 and the coordination board.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Kunzite

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdEUKKBBeq2mf1Q1VJ4r8M)_