### PR TITLE
fix(checker): a concrete keyof indexed access reduces its member for assignment display (#16463)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1392,6 +1392,9 @@ path = "tests/ts2367_comparison_overlap_tests.rs"
 name = "concrete_indexed_access_display_tests"
 path = "tests/concrete_indexed_access_display_tests.rs"
 [[test]]
+name = "mapped_indexed_access_diagnostic_tests"
+path = "tests/mapped_indexed_access_diagnostic_tests.rs"
+[[test]]
 name = "enum_indexed_access_tests"
 path = "tests/enum_indexed_access_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/error_reporter/type_display_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/type_display_policy.rs
@@ -97,13 +97,31 @@ impl<'a> CheckerState<'a> {
             return ty;
         };
         // The key must be a shape tsc reduces eagerly (literal, union, unique
-        // symbol, typeof query, or the bare string/number primitive — the
-        // array/tuple element idiom `Arr[number]`); a still-deferred key
-        // shape (type parameter, conditional, another indexed access, keyof,
-        // ...) keeps tsc's own indexed access deferred too. `keyof` is
-        // excluded deliberately, not just unimplemented — see
-        // `is_display_reducible_index_key`'s doc comment.
-        if !common::is_display_reducible_index_key(db, indexed.index_type) {
+        // symbol, typeof query, the bare string/number primitive — the
+        // array/tuple element idiom `Arr[number]` — or a `keyof` operator over a
+        // concrete operand). A still-deferred key shape (type parameter,
+        // conditional, another indexed access) keeps tsc's own indexed access
+        // deferred too, and the free-type-parameter guard below rejects a
+        // generic `keyof T`.
+        //
+        // `keyof` is admitted here rather than in the shared
+        // `is_display_reducible_index_key` classifier for two reasons. First, it
+        // confines the widening to the assignment-display gate and leaves the
+        // solver's application-argument / index-object display paths (which share
+        // the narrower classifier) untouched. Second, a reduced `keyof` access
+        // can intern onto the very `TypeId` that a *sibling* expression already
+        // stamped with a `display_alias` — `type Pair<T> = Pairs<T>[keyof T]`
+        // reduces `Pairs<FooBar>[keyof FooBar]` onto the same union `Pair<FooBar>`
+        // instantiates to, and the members can equally carry their *own* alias
+        // (`Q[keyof Q]` where every member is `Partial<X>`). tsz's
+        // `TypeId`-keyed `display_alias` table cannot tell tsc's per-reference
+        // `aliasSymbol` apart from either, so the reduced result is only used
+        // when it carries *no* alias at all (the `keyof`-only guard below).
+        // Otherwise the access is left as written — tsc's safe fallback, matching
+        // the residual policy #16461 / #16469 already established for the deferred
+        // rows — rather than risk repainting it with an unrelated name.
+        let index_is_keyof = common::is_keyof_type(db, indexed.index_type);
+        if !common::is_display_reducible_index_key(db, indexed.index_type) && !index_is_keyof {
             return ty;
         }
         // A free type parameter anywhere in the object or index means the
@@ -124,6 +142,16 @@ impl<'a> CheckerState<'a> {
                 resolved,
             )
         {
+            return ty;
+        }
+        // `keyof`-only conservative guard: only reduce when the result carries no
+        // ambiguous `display_alias`. When it does (a sibling alias, or the
+        // members' own), leave the access as written so the reduction never
+        // repaints it with the wrong name and never pre-empts the target role's
+        // union member-splitting path (which already renders these correctly).
+        // The literal / union / primitive-key reductions are unaffected — they
+        // keep reducing unconditionally, exactly as before.
+        if index_is_keyof && self.ctx.types.get_display_alias(resolved).is_some() {
             return ty;
         }
         resolved

--- a/crates/tsz-checker/tests/concrete_indexed_access_display_tests.rs
+++ b/crates/tsz-checker/tests/concrete_indexed_access_display_tests.rs
@@ -350,19 +350,12 @@ const m1: M["outer"]["mid"] = { z: 1 };
     assert_reduced_member(&messages[0], "{ z: number; y: string; }");
 }
 
-/// Non-literal key, still unreduced by design (`tsc` reduces it — the
-/// remaining #16443 non-literal-key residual). Widening the shared display
-/// key gate to admit bare `KeyOf` reduces `Q[keyof Q]` correctly in
-/// isolation, but the reduced result can land on the same `TypeId` a
-/// *different*, aliased expression already stamped with its own display
-/// alias (a generic alias `Pair<T> = Pairs<T>[keyof T]` interns to the same
-/// evaluated union as the raw `Pairs<FooBar>[keyof FooBar]` once both are
-/// concrete), and the general formatter then paints that unrelated alias
-/// name over this reference —
-/// `mapped_indexed_access_discriminated_union_reports_outer_assignment`
-/// caught this as a real regression. Closing this row needs a route that
-/// skips the shared, `TypeId`-keyed display-alias lookup for a freshly
-/// reduced indexed access, not just admitting the key shape.
+/// `keyof`-keyed access in the **missing-property (TS2741) target** message.
+/// The assignment display gate now admits a concrete `keyof` key, but a
+/// TS2741 target renders through a *different* path than the reduced type it
+/// receives, so this row still prints the access as written. The source-role
+/// and TS2322-whole-type keyof rows below *are* reduced; this is the residual
+/// TS2741-target cell (tsc reduces it — tracked with the wider #16443 family).
 #[test]
 fn keyof_rooted_indexed_access_target_prints_as_written() {
     let messages = strict_messages(
@@ -645,4 +638,112 @@ const h: { k: number; extra: number } = bad;
     );
     assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
     assert_reduced_member(&messages[0], "{ k: number; }");
+}
+
+// ---------------------------------------------------------------------------
+// `keyof`-keyed access in the source / TS2322-whole-type roles.
+//
+// `tsc` resolves a concrete `Obj[keyof Obj]` through `getIndexedAccessType`
+// during type construction, so the reduced member/union is what a diagnostic
+// renders — never the `Obj[keyof Obj]` surface. The assignment display gate now
+// admits a concrete `keyof` key. Because a reduced `keyof` access can intern
+// onto the same `TypeId` a *sibling* generic alias (`type Alias<T> =
+// Src<T>[keyof T]`) also stamps a `display_alias` on, the reduction is only
+// used when the result carries no alias — otherwise the access is left as
+// written (the safe fallback), and the target role's union member-splitting
+// path renders the aliased case (see
+// `mapped_indexed_access_discriminated_union_reports_outer_assignment`).
+// ---------------------------------------------------------------------------
+
+/// `Obj[keyof Obj]` over a primitive-valued interface reduces to the key-set's
+/// value union in a TS2322 whole-type source message, matching `tsc`
+/// (`string | number`, never `Obj[keyof Obj]`).
+#[test]
+fn concrete_keyof_indexed_access_source_reduces_in_ts2322_whole_type() {
+    let messages = strict_messages(
+        r#"
+interface Q { a: number; b: string }
+declare const x: Q[keyof Q];
+const t: boolean = x;
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("Type 'string | number' is not assignable to type 'boolean'")),
+        "keyof source must reduce to the value union: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("[keyof ")),
+        "no unreduced keyof indexed-access surface may survive: {messages:?}"
+    );
+}
+
+/// Anti-hardcoding: the reduction keys on the concrete `keyof`-access structure,
+/// not on the identifiers `Q`/`a`/`b`. Renamed binders behave identically.
+#[test]
+fn concrete_keyof_source_reduction_is_binder_name_independent() {
+    let messages = strict_messages(
+        r#"
+interface Registry { alpha: number; beta: string }
+declare const item: Registry[keyof Registry];
+const flag: boolean = item;
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("Type 'string | number' is not assignable to type 'boolean'")),
+        "keyof source must reduce regardless of binder names: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("Registry[keyof")),
+        "no unreduced keyof indexed-access surface may survive: {messages:?}"
+    );
+}
+
+/// An object-valued `keyof` access reduces to the full member union in the
+/// source role. The reduced union carries no alias here (the sibling
+/// `type Boxed<T> = Boxes<T>[keyof T]` is never instantiated), so the display
+/// gate reduces it and the members render structurally — matching `tsc`, and
+/// never repainting with the sibling alias name.
+#[test]
+fn concrete_keyof_object_union_source_reduces_to_full_union() {
+    let messages = strict_messages(
+        r#"
+type Boxes<T> = { [K in keyof T]: { tag: K; val: T[K] } };
+type Boxed<T> = Boxes<T>[keyof T];
+type FB = { a: string; b: number };
+declare const raw: Boxes<FB>[keyof FB];
+const bad: boolean = raw;
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("{ tag: \"a\"; val: string; } | { tag: \"b\"; val: number; }")),
+        "keyof object-union source must reduce to the full member union: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("Boxed")),
+        "the reduced access must never be repainted with the sibling alias name: {messages:?}"
+    );
+}
+
+/// Negative control: a *generic* `keyof` access carries a free type parameter,
+/// so it is legitimately deferred — `tsc` renders `T[keyof T]` too — and the
+/// free-type-parameter guard keeps it as written.
+#[test]
+fn deferred_generic_keyof_indexed_access_source_stays_opaque() {
+    let messages = strict_messages(
+        r#"
+function f<T extends { a: number; b: string }>(x: T[keyof T]) {
+  const t: boolean = x;
+}
+"#,
+    );
+    assert!(
+        messages.iter().any(|m| m.contains("T[keyof T]")),
+        "a deferred generic keyof access keeps its written spelling: {messages:?}"
+    );
 }


### PR DESCRIPTION
`tsc` resolves a concrete indexed access (`Obj[keyof Obj]`, no free type parameters) through `getIndexedAccessType` during type construction, so a diagnostic never renders the `Obj[keyof Obj]` surface — it shows the reduced member/value union. tsz left `keyof`-keyed accesses deferred, leaking the unreduced surface into `TS2322` source messages (`Type 'Q[keyof Q]' is not assignable ...` where tsc says `Type 'string | number' ...`). This is the `keyof` residual left open by #16469 / #16443 (issue #16463; its literal `[number]`/`[0]` witnesses already landed via #16456/#16461/#16469).

Structural rule: when a concrete `Obj[keyof Obj]` reaches an assignment-display role and its `getIndexedAccessType` result carries no display alias, tsz renders the reduced member/union (matching tsc's `typeToString`); an alias-bearing result stays as written. Owner layer: `error_reporter::type_display_policy` (`resolve_concrete_indexed_access_for_display`).

`keyof` was deliberately excluded from the shared `is_display_reducible_index_key` classifier because a reduced `keyof` access can intern onto the same `TypeId` a *sibling* generic alias (`type Pair<T> = Pairs<T>[keyof T]`) already stamped with a `display_alias`, and the general formatter would then repaint the raw access with that unrelated name. tsz's `TypeId`-keyed `display_alias` table cannot tell tsc's per-reference `aliasSymbol` apart from a member's own alias. This PR:

- admits `keyof` in the **assignment-display gate only** — the solver's application-argument / index-object display paths keep the narrower classifier, so their surface is untouched;
- uses the reduced result **only when it carries no ambiguous `display_alias`**. When it does, the access is left as written — tsc's safe fallback, matching the residual policy #16461/#16469 established for the deferred rows — so the reduction never repaints with the wrong name and never pre-empts the target role's union member-splitting path (which already renders the aliased case correctly, e.g. `Pairs<FooBar>[keyof FooBar]` as its evaluated union).

Adjacent matrix (oracled against `tsc` 6.0.2, `--noEmit --strict --pretty false --target es2022 --lib es2022`):

| case | before | after / tsc |
| --- | --- | --- |
| `Q[keyof Q]` source (primitive members) | `Q[keyof Q]` | `string \| number` |
| renamed binders (`Registry[keyof Registry]`) | `Registry[keyof Registry]` | `string \| number` |
| `Boxes<FB>[keyof FB]` source (object union, no sibling instantiated) | `Boxes<FB>[keyof FB]` | `{ tag: "a"; val: string; } \| { tag: "b"; val: number; }` |
| `Pairs<FooBar>[keyof FooBar]` target with instantiated sibling `Pair<T>` | union (member-split) | union (unchanged — no repaint) |
| `Pair<FooBar>` (aliased reference) | `Pair<FooBar>` | `Pair<FooBar>` (unchanged) |
| generic `T[keyof T]` (free type param) | `T[keyof T]` | `T[keyof T]` (deferred, unchanged) |
| literal/numeric/array-element keys | reduced | reduced (unchanged) |

Also registers `mapped_indexed_access_diagnostic_tests` in `Cargo.toml` — the recorded regression guard for the sibling-alias repaint was orphaned (`autotests = false`, no `[[test]]` entry) and never compiled in CI.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --release --test concrete_indexed_access_display_tests` — 37 pass (incl. 4 new `keyof` rows + binder-name-independent control + deferred-generic negative control)
- `cargo test -p tsz-checker --release --test mapped_indexed_access_diagnostic_tests` — 3 pass (now registered; pins pair1 keeps alias / pair2 shows evaluated union)
- 271-target checker display/assignment/elaboration/keyof/mapped/index sweep — 0 new failures (the single failure, `deferred_generic_conditional_keeps_branch_union`, reproduces on `main` and is unrelated, per #15983)
- `cargo clippy --profile ci-lint --workspace --all-targets -- -D warnings` — clean
- `python3 scripts/arch/arch_guard.py` — pass (0 files over 2000 LOC)

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgTHVGnQnWQ7fhdwY4vMfr)_