### PR TITLE
fix(checker): a position-invalid `export default [ expr ]` stops at its placement diagnostic

### DIFF
--- a/crates/tsz-checker/src/declarations/import/context_helpers.rs
+++ b/crates/tsz-checker/src/declarations/import/context_helpers.rs
@@ -130,6 +130,144 @@ impl<'a> CheckerState<'a> {
         false
     }
 
+    /// Whether the nearest enclosing function-like body is one tsc revisits through
+    /// its *deferred* queue instead of the eager statement walk.
+    ///
+    /// `checkExportAssignment` opens with `checkGrammarModuleElementContext` and
+    /// `return`s the moment the context is invalid, so a position-invalid
+    /// `export default [ expr ]` never resolves its exported expression — the
+    /// placement diagnostic is the whole answer. The exception is a body tsc reaches
+    /// a second time through `checkFunctionExpressionOrObjectLiteralMethodDeferred`:
+    /// a function expression, an arrow function, or an object-literal method. Inside
+    /// one of those the expression *is* resolved, and an unresolved name still
+    /// reports.
+    ///
+    /// The object-literal **accessor** is the row that pins this to the deferred set
+    /// rather than to "is inside some function": tsc does not defer accessors
+    /// (`checkAccessorDeclaration` runs eagerly from `checkObjectLiteral`), and an
+    /// object-literal getter suppresses exactly like a class method does, while the
+    /// object-literal method one line away does not.
+    ///
+    /// Only meaningful for a node in a non-module-element context.
+    pub(crate) fn nearest_function_like_body_is_deferred_checked(
+        &self,
+        node_idx: NodeIndex,
+    ) -> bool {
+        let mut current = node_idx;
+        while current.is_some() {
+            let Some(ext) = self.ctx.arena.get_extended(current) else {
+                break;
+            };
+            current = ext.parent;
+            if current.is_none() {
+                break;
+            }
+            let Some(node) = self.ctx.arena.get(current) else {
+                break;
+            };
+            match node.kind {
+                k if k == syntax_kind_ext::FUNCTION_EXPRESSION
+                    || k == syntax_kind_ext::ARROW_FUNCTION =>
+                {
+                    return true;
+                }
+                k if k == syntax_kind_ext::METHOD_DECLARATION => {
+                    // An object-literal method is deferred; a class method is not.
+                    return self
+                        .ctx
+                        .arena
+                        .parent_of(current)
+                        .and_then(|p| self.ctx.arena.get(p))
+                        .is_some_and(|p| p.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION);
+                }
+                k if k == syntax_kind_ext::FUNCTION_DECLARATION
+                    || k == syntax_kind_ext::CONSTRUCTOR
+                    || k == syntax_kind_ext::GET_ACCESSOR
+                    || k == syntax_kind_ext::SET_ACCESSOR
+                    || k == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION =>
+                {
+                    return false;
+                }
+                k if k == syntax_kind_ext::SOURCE_FILE || k == syntax_kind_ext::MODULE_BLOCK => {
+                    return false;
+                }
+                _ => continue,
+            }
+        }
+        false
+    }
+
+    /// Whether `node_idx` is, or is the exported expression of, an
+    /// `export default [ expr ]` whose placement diagnostic is the whole answer.
+    ///
+    /// tsc never types the expression of such a declaration, so no walker may
+    /// demand it. tsz has two demand sites: `build_type_environment`, which types
+    /// every file symbol up front, and the statement walk in
+    /// `check_export_declaration`. Both consult this.
+    pub(crate) fn is_unchecked_position_invalid_default_export(&self, node_idx: NodeIndex) -> bool {
+        if node_idx.is_none() {
+            return false;
+        }
+        let export_idx = if self
+            .ctx
+            .arena
+            .kind_at(node_idx)
+            .is_some_and(|k| k == syntax_kind_ext::EXPORT_DECLARATION)
+        {
+            node_idx
+        } else {
+            match self.ctx.arena.parent_of(node_idx) {
+                Some(parent)
+                    if self
+                        .ctx
+                        .arena
+                        .kind_at(parent)
+                        .is_some_and(|k| k == syntax_kind_ext::EXPORT_DECLARATION) =>
+                {
+                    parent
+                }
+                _ => return false,
+            }
+        };
+
+        let Some(export_decl) = self
+            .ctx
+            .arena
+            .get(export_idx)
+            .and_then(|node| self.ctx.arena.get_export_decl(node))
+        else {
+            return false;
+        };
+        if !export_decl.is_default_export || export_decl.export_clause.is_none() {
+            return false;
+        }
+        let clause_idx = export_decl.export_clause;
+
+        self.is_in_non_module_element_context(export_idx)
+            && self.export_default_clause_is_expression(clause_idx)
+            && !self.nearest_function_like_body_is_deferred_checked(export_idx)
+    }
+
+    /// Whether an `export default` wraps a bare expression rather than a declaration.
+    ///
+    /// tsc parses `export default class C {}` / `export default function f() {}` in a
+    /// statement position as the declaration itself carrying an illegal `export`
+    /// modifier (TS1184, `checkGrammarModifiers`), not as an `ExportAssignment`, so
+    /// `checkExportAssignment`'s bail never applies and the declaration is checked
+    /// normally. Only the expression form reaches TS1258 and the bail.
+    pub(crate) fn export_default_clause_is_expression(&self, clause_idx: NodeIndex) -> bool {
+        !self.ctx.arena.kind_at(clause_idx).is_some_and(|k| {
+            k == syntax_kind_ext::CLASS_DECLARATION
+                || k == syntax_kind_ext::CLASS_EXPRESSION
+                || k == syntax_kind_ext::FUNCTION_DECLARATION
+                || k == syntax_kind_ext::VARIABLE_STATEMENT
+                || k == syntax_kind_ext::INTERFACE_DECLARATION
+                || k == syntax_kind_ext::TYPE_ALIAS_DECLARATION
+                || k == syntax_kind_ext::ENUM_DECLARATION
+                || k == syntax_kind_ext::MODULE_DECLARATION
+        })
+    }
+
     /// Whether a module element that has *already* drawn a placement diagnostic
     /// still resolves its module specifier.
     ///

--- a/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
@@ -197,6 +197,19 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
                 return;
             }
 
+            // `export default [ expr ]` in a non-module-element context: tsc's
+            // `checkExportAssignment` reports the placement diagnostic (TS1258) from
+            // `checkGrammarModuleElementContext` and `return`s before it ever types
+            // the exported expression, so an unresolved name draws no second
+            // diagnostic. The one container where it still does is a body tsc
+            // revisits through its deferred queue — see
+            // `nearest_function_like_body_is_deferred_checked`.
+            if in_non_module_context
+                && self.is_unchecked_position_invalid_default_export(export_idx)
+            {
+                return;
+            }
+
             // TS1194: Export declarations are not permitted in a namespace.
             // `export { } from "mod"` is NEVER allowed in any namespace (even declare);
             // `export { }` (no from) is only disallowed in non-ambient namespaces.

--- a/crates/tsz-checker/src/state/type_environment/core.rs
+++ b/crates/tsz-checker/src/state/type_environment/core.rs
@@ -1395,6 +1395,23 @@ impl CheckerState<'_> {
                 }
             }
 
+            // A position-invalid `export default [ expr ]` binds a symbol whose type
+            // tsc never computes: `checkExportAssignment` bails at
+            // `checkGrammarModuleElementContext`, and nothing can reference the
+            // default of a declaration that never took effect. Typing it here walks
+            // the exported expression and reports its unresolved names, which tsc
+            // does not. The declaration is still bound — only the eager demand for
+            // its type is dropped.
+            if self
+                .ctx
+                .binder
+                .get_symbol(sym_id)
+                .map(|s| s.value_declaration)
+                .is_some_and(|decl| self.is_unchecked_position_invalid_default_export(decl))
+            {
+                continue;
+            }
+
             // IMPORTANT: get_type_of_symbol internally calls compute_type_of_symbol which
             // returns both the type AND the correct type_params, then inserts them into
             // ctx.type_env. We MUST NOT separately call get_type_params_for_symbol because

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -703,6 +703,8 @@ mod parameter_checker_tests;
 mod partial_pick_indexed_access_write_tests;
 #[path = "tests/polymorphic_this_relation_routing_arch_tests.rs"]
 mod polymorphic_this_relation_routing_arch_tests;
+#[path = "tests/position_invalid_default_export_expression_tests.rs"]
+mod position_invalid_default_export_expression_tests;
 #[path = "tests/predicate_narrowed_lib_union_access_tests.rs"]
 mod predicate_narrowed_lib_union_access_tests;
 #[path = "tests/predicate_narrowed_top_type_source_display_tests.rs"]

--- a/crates/tsz-checker/src/tests/position_invalid_default_export_expression_tests.rs
+++ b/crates/tsz-checker/src/tests/position_invalid_default_export_expression_tests.rs
@@ -1,0 +1,411 @@
+//! A position-invalid `export default [ expr ]` reports its placement
+//! diagnostic and nothing else — the exported expression is never typed, so an
+//! unresolved name inside it draws no name-resolution diagnostic.
+//!
+//! tsc's `checkExportAssignment` opens with `checkGrammarModuleElementContext`
+//! and `return`s the moment the context is invalid, before it types the
+//! expression. The exception is a body tsc revisits through its *deferred*
+//! queue (`checkFunctionExpressionOrObjectLiteralMethodDeferred`): a function
+//! expression, an arrow function, or an object-literal method. Inside one of
+//! those the expression is typed and the unresolved name still reports.
+//!
+//! The object-literal accessor is the row that pins the rule to the deferred
+//! set rather than to "is inside some function": tsc does not defer accessors,
+//! so an object-literal getter suppresses exactly like a class method does
+//! while the object-literal method one line away does not.
+//!
+//! Harness note: the default unit harness does not report an unresolved name in
+//! an *expression* position at all — a plain `const zz = undefinedName;` comes
+//! back clean under it, while the same name in a heritage clause does report.
+//! The suppressing rows below therefore assert the placement diagnostic, which
+//! the harness does see, and the deferred-container rows are pinned but
+//! `#[ignore]`d; both halves are verified end to end through the CLI in the PR
+//! body. `default_exported_class_declaration_in_a_block_still_resolves_its_heritage`
+//! is the live over-reach control: it goes through a path the harness *can*
+//! observe and would fail if the suppression reached the declaration forms.
+//!
+//! Verified against the pinned tsc 7.0.2 through
+//! `scripts/conformance/oracle.sh` (which carries the
+//! `--singleThreaded --stableTypeOrdering true` flags the conformance cache
+//! generator uses), cross-checked against the default scheduler. All rows here
+//! are flag-insensitive.
+
+use crate::test_utils::check_source_diagnostics;
+
+const DEFAULT_EXPORT_TOP_LEVEL: u32 = 1258;
+const EXPORT_ASSIGNMENT_TOP_LEVEL: u32 = 1231;
+const MODIFIERS_CANNOT_APPEAR_HERE: u32 = 1184;
+const DEFAULT_EXPORT_IN_NAMESPACE: u32 = 1319;
+
+/// `Cannot find name 'x'.` and its did-you-mean variant. The default unit
+/// harness loads no lib, so which of the two fires depends on whether a
+/// suggestion candidate exists; the rule under test is about whether the name
+/// is resolved at all, so both codes count as "the expression was typed".
+const CANNOT_FIND_NAME: [u32; 2] = [2304, 2552];
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+fn resolved_the_expression(source: &str) -> bool {
+    let found = codes(source);
+    CANNOT_FIND_NAME.iter().any(|code| found.contains(code))
+}
+
+// --- Suppressing containers: everything tsc checks in the eager walk. ---
+
+#[test]
+fn bare_block_reports_placement_only() {
+    let source = "{ export default undefinedName; }\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(!resolved_the_expression(source), "codes: {found:?}");
+}
+
+#[test]
+fn function_declaration_body_reports_placement_only() {
+    let source = "function f() { export default undefinedName; }\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(!resolved_the_expression(source), "codes: {found:?}");
+}
+
+#[test]
+fn class_method_body_reports_placement_only() {
+    let source = "class C { m() { export default undefinedName; } }\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(!resolved_the_expression(source), "codes: {found:?}");
+}
+
+#[test]
+fn class_constructor_body_reports_placement_only() {
+    let source = "class C { constructor() { export default undefinedName; } }\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(!resolved_the_expression(source), "codes: {found:?}");
+}
+
+#[test]
+fn class_getter_body_reports_placement_only() {
+    let source = "class C { get x() { export default undefinedName; return 1; } }\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(!resolved_the_expression(source), "codes: {found:?}");
+}
+
+#[test]
+fn class_static_block_reports_placement_only() {
+    let source = "class D { static { export default undefinedName; } }\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(!resolved_the_expression(source), "codes: {found:?}");
+}
+
+#[test]
+fn if_block_reports_placement_only() {
+    let source = "if (true) { export default undefinedName; }\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(!resolved_the_expression(source), "codes: {found:?}");
+}
+
+#[test]
+fn loop_body_reports_placement_only() {
+    let source = "for (;;) { export default undefinedName; }\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(!resolved_the_expression(source), "codes: {found:?}");
+}
+
+#[test]
+fn nested_block_inside_a_function_declaration_reports_placement_only() {
+    let source = "function f() { { export default undefinedName; } }\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(!resolved_the_expression(source), "codes: {found:?}");
+}
+
+/// The nearest function-like container decides, not the outermost one: a
+/// function *declaration* nested inside an arrow still suppresses.
+#[test]
+fn function_declaration_inside_an_arrow_reports_placement_only() {
+    let source = "const g = () => { function inner() { export default undefinedName; } };\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(!resolved_the_expression(source), "codes: {found:?}");
+}
+
+/// tsc does not defer object-literal accessors, so this suppresses even though
+/// the object-literal *method* on the next test does not.
+#[test]
+fn object_literal_getter_reports_placement_only() {
+    let source = "const o = { get x() { export default undefinedName; return 1; } };\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(!resolved_the_expression(source), "codes: {found:?}");
+}
+
+// --- Deferred containers: tsc types the expression, and so must tsz. ---
+
+#[test]
+#[ignore = "the default unit harness does not report an unresolved name in an \
+           expression position at all — a plain `const zz = undefinedName;` is \
+           clean under it — so the deferred-container half of this rule is pinned \
+           here but verified through the CLI against `scripts/conformance/oracle.sh`; \
+           see the matrix in the PR body"]
+fn arrow_function_body_still_resolves_the_expression() {
+    let source = "const g = () => { export default undefinedName; };\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(resolved_the_expression(source), "codes: {found:?}");
+}
+
+#[test]
+#[ignore = "the default unit harness does not report an unresolved name in an \
+           expression position at all — a plain `const zz = undefinedName;` is \
+           clean under it — so the deferred-container half of this rule is pinned \
+           here but verified through the CLI against `scripts/conformance/oracle.sh`; \
+           see the matrix in the PR body"]
+fn function_expression_body_still_resolves_the_expression() {
+    let source = "const g = function () { export default undefinedName; };\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(resolved_the_expression(source), "codes: {found:?}");
+}
+
+#[test]
+#[ignore = "the default unit harness does not report an unresolved name in an \
+           expression position at all — a plain `const zz = undefinedName;` is \
+           clean under it — so the deferred-container half of this rule is pinned \
+           here but verified through the CLI against `scripts/conformance/oracle.sh`; \
+           see the matrix in the PR body"]
+fn named_function_expression_body_still_resolves_the_expression() {
+    let source = "const g = function fn() { export default undefinedName; };\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(resolved_the_expression(source), "codes: {found:?}");
+}
+
+#[test]
+#[ignore = "the default unit harness does not report an unresolved name in an \
+           expression position at all — a plain `const zz = undefinedName;` is \
+           clean under it — so the deferred-container half of this rule is pinned \
+           here but verified through the CLI against `scripts/conformance/oracle.sh`; \
+           see the matrix in the PR body"]
+fn object_literal_method_body_still_resolves_the_expression() {
+    let source = "const o = { m() { export default undefinedName; } };\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(resolved_the_expression(source), "codes: {found:?}");
+}
+
+#[test]
+#[ignore = "the default unit harness does not report an unresolved name in an \
+           expression position at all — a plain `const zz = undefinedName;` is \
+           clean under it — so the deferred-container half of this rule is pinned \
+           here but verified through the CLI against `scripts/conformance/oracle.sh`; \
+           see the matrix in the PR body"]
+fn immediately_invoked_arrow_still_resolves_the_expression() {
+    let source = "(() => { export default undefinedName; })();\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(resolved_the_expression(source), "codes: {found:?}");
+}
+
+#[test]
+#[ignore = "the default unit harness does not report an unresolved name in an \
+           expression position at all — a plain `const zz = undefinedName;` is \
+           clean under it — so the deferred-container half of this rule is pinned \
+           here but verified through the CLI against `scripts/conformance/oracle.sh`; \
+           see the matrix in the PR body"]
+fn nested_block_inside_an_arrow_still_resolves_the_expression() {
+    let source = "const g = () => { { export default undefinedName; } };\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(resolved_the_expression(source), "codes: {found:?}");
+}
+
+#[test]
+#[ignore = "the default unit harness does not report an unresolved name in an \
+           expression position at all — a plain `const zz = undefinedName;` is \
+           clean under it — so the deferred-container half of this rule is pinned \
+           here but verified through the CLI against `scripts/conformance/oracle.sh`; \
+           see the matrix in the PR body"]
+fn arrow_nested_inside_a_class_method_still_resolves_the_expression() {
+    let source = "class C { m() { const q = () => { export default undefinedName; }; } }\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(resolved_the_expression(source), "codes: {found:?}");
+}
+
+#[test]
+#[ignore = "the default unit harness does not report an unresolved name in an \
+           expression position at all — a plain `const zz = undefinedName;` is \
+           clean under it — so the deferred-container half of this rule is pinned \
+           here but verified through the CLI against `scripts/conformance/oracle.sh`; \
+           see the matrix in the PR body"]
+fn class_property_initializer_arrow_still_resolves_the_expression() {
+    let source = "class C { p = () => { export default undefinedName; }; }\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(resolved_the_expression(source), "codes: {found:?}");
+}
+
+#[test]
+#[ignore = "the default unit harness does not report an unresolved name in an \
+           expression position at all — a plain `const zz = undefinedName;` is \
+           clean under it — so the deferred-container half of this rule is pinned \
+           here but verified through the CLI against `scripts/conformance/oracle.sh`; \
+           see the matrix in the PR body"]
+fn generator_function_expression_still_resolves_the_expression() {
+    let source = "const g = function* () { export default undefinedName; };\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(resolved_the_expression(source), "codes: {found:?}");
+}
+
+// --- Controls: rows the suppression must not reach. ---
+
+/// A valid top-level `export default` is the whole point of the gate being
+/// container-scoped: it still resolves.
+#[test]
+fn top_level_default_export_draws_no_placement_diagnostic() {
+    let source = "export default undefinedName;\n";
+    let found = codes(source);
+    assert!(
+        !found.contains(&DEFAULT_EXPORT_TOP_LEVEL),
+        "codes: {found:?}"
+    );
+}
+
+/// `export default class`/`function` in a statement position is the declaration
+/// carrying an illegal modifier (TS1184), not an export assignment, so tsc
+/// checks it normally and the heritage/body names still resolve.
+#[test]
+fn default_exported_class_declaration_in_a_block_still_resolves_its_heritage() {
+    let source = "{ export default class extends undefinedBase {} }\n";
+    let found = codes(source);
+    assert!(found.contains(&MODIFIERS_CANNOT_APPEAR_HERE));
+    assert!(!found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(resolved_the_expression(source), "codes: {found:?}");
+}
+
+#[test]
+#[ignore = "the default unit harness does not report an unresolved name in an \
+           expression position at all — a plain `const zz = undefinedName;` is \
+           clean under it — so the deferred-container half of this rule is pinned \
+           here but verified through the CLI against `scripts/conformance/oracle.sh`; \
+           see the matrix in the PR body"]
+fn default_exported_function_declaration_in_a_block_still_resolves_its_body() {
+    let source = "{ export default function h() { return undefinedName; } }\n";
+    let found = codes(source);
+    assert!(found.contains(&MODIFIERS_CANNOT_APPEAR_HERE));
+    assert!(!found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(resolved_the_expression(source), "codes: {found:?}");
+}
+
+/// `export =` is a different production with its own placement diagnostic and
+/// no default symbol; it was already correct and must stay untouched.
+#[test]
+fn export_assignment_in_a_block_reports_placement_only() {
+    let source = "{ export = undefinedName; }\n";
+    let found = codes(source);
+    assert!(found.contains(&EXPORT_ASSIGNMENT_TOP_LEVEL));
+    assert!(!resolved_the_expression(source), "codes: {found:?}");
+}
+
+#[test]
+fn export_assignment_in_a_function_body_reports_placement_only() {
+    let source = "function f() { export = undefinedName; }\n";
+    let found = codes(source);
+    assert!(found.contains(&EXPORT_ASSIGNMENT_TOP_LEVEL));
+    assert!(!resolved_the_expression(source), "codes: {found:?}");
+}
+
+/// A namespace body is a *valid* module-element context, so the suppression
+/// here comes from the pre-existing TS1319 arm, not from this rule.
+#[test]
+fn namespace_body_keeps_its_own_ts1319_arm() {
+    let source = "namespace N { export default undefinedName; }\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_IN_NAMESPACE));
+    assert!(!found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(!resolved_the_expression(source), "codes: {found:?}");
+}
+
+/// Suppression is about the *expression walk*, not about the placement
+/// diagnostic: a resolvable name and a literal were already clean and stay so.
+#[test]
+fn resolvable_name_in_a_block_reports_placement_only() {
+    let source = "const known = 1;\n{ export default known; }\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(!resolved_the_expression(source), "codes: {found:?}");
+}
+
+#[test]
+fn literal_expression_in_a_block_reports_placement_only() {
+    let source = "{ export default 42; }\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(!resolved_the_expression(source), "codes: {found:?}");
+}
+
+/// A renamed binder must not change the verdict — the rule is structural.
+#[test]
+fn renamed_binder_in_a_block_reports_placement_only() {
+    let source = "{ const zzz = 1; export default zzZ; }\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(!resolved_the_expression(source), "codes: {found:?}");
+}
+
+#[test]
+#[ignore = "the default unit harness does not report an unresolved name in an \
+           expression position at all — a plain `const zz = undefinedName;` is \
+           clean under it — so the deferred-container half of this rule is pinned \
+           here but verified through the CLI against `scripts/conformance/oracle.sh`; \
+           see the matrix in the PR body"]
+fn renamed_binder_in_an_arrow_still_resolves_the_expression() {
+    let source = "const g = () => { const zzz = 1; export default zzZ; };\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(resolved_the_expression(source), "codes: {found:?}");
+}
+
+/// A non-identifier expression takes the same walk, so the suppression has to
+/// cover names nested inside it too.
+#[test]
+fn object_literal_expression_in_a_block_reports_placement_only() {
+    let source = "{ export default { a: undefinedName }; }\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(!resolved_the_expression(source), "codes: {found:?}");
+}
+
+/// A file that is genuinely a module (it has a top-level `export {}`) behaves
+/// the same: the rule is about the declaration's container, not the file kind.
+#[test]
+fn module_file_bare_block_reports_placement_only() {
+    let source = "{ export default undefinedName; }\nexport {};\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(!resolved_the_expression(source), "codes: {found:?}");
+}
+
+#[test]
+#[ignore = "the default unit harness does not report an unresolved name in an \
+           expression position at all — a plain `const zz = undefinedName;` is \
+           clean under it — so the deferred-container half of this rule is pinned \
+           here but verified through the CLI against `scripts/conformance/oracle.sh`; \
+           see the matrix in the PR body"]
+fn module_file_arrow_body_still_resolves_the_expression() {
+    let source = "const g = () => { export default undefinedName; };\nexport {};\n";
+    let found = codes(source);
+    assert!(found.contains(&DEFAULT_EXPORT_TOP_LEVEL));
+    assert!(resolved_the_expression(source), "codes: {found:?}");
+}


### PR DESCRIPTION
`{ export default undefinedName; }` reported **TS1258 and TS2552**. tsc reports TS1258 alone. The same leak hit every eager container — function-declaration body, class method, constructor, getter, static block, `if` block, loop body, and any plain block inside them.

Closes item 1 of #16410 (Azurite's 21:25Z rewrite of that issue, handed off on the coordination board as the next concrete action).

**Structural rule.** When an `export default [ expr ]` sits in a non-module-element context, tsc's `checkExportAssignment` reports the placement diagnostic from `checkGrammarModuleElementContext` and `return`s **before it ever types the exported expression**, so an unresolved name inside it draws nothing further; tsz now does the same through the checker's two demand sites for that expression.

**The carve-out is tsc's own, and it is not "is inside a function".** A body tsc revisits through its *deferred* queue — `checkFunctionExpressionOrObjectLiteralMethodDeferred`, i.e. a function expression, an arrow function, or an object-literal method — still types the expression and still reports. The row that pins this is the pair one line apart:

```ts
const o = { get x() { export default undefinedName; return 1; } };  // tsc: TS1258 alone
const o = { m()      { export default undefinedName; } };           // tsc: TS1258 + TS2552
```

tsc does not defer accessors (`checkAccessorDeclaration` runs eagerly from `checkObjectLiteral`), so an object-literal getter suppresses exactly like a class method does while the object-literal method does not. Any rule phrased over "inside a function body" gets that pair wrong in one direction or the other. The predicate is over AST kinds only — no name, file-name or rendered-text check anywhere in the diff.

This is an eager-vs-deferred inconsistency in tsc rather than a designed rule, so it is reproduced deliberately rather than corrected: parity is the goal, and patching away from it is what the repo's bug-and-fix discipline forbids. Filed upstream-side as a note on #16410 with the 37-row characterization.

**Why two call sites.** tsc types this expression lazily, so bailing out of one function is enough. tsz has two places that demand it, and both had to decline or the other one picked the diagnostic straight back up (measured — gating only the statement walk moved nothing, and gating only `compute_type_of_symbol`'s wrapper strategy just fell through to the next strategy):

| demand site | why it types the expression |
| --- | --- |
| `state/type_environment/core.rs` `build_type_environment` | types **every** file symbol up front, including the block-scoped default-export symbol; this is where the TS2552 actually came from (backtrace-confirmed) |
| `state_checking_members/statement_callback_bridge.rs` `check_export_declaration` | walks the export clause during the statement pass |

Both consult one predicate, `is_unchecked_position_invalid_default_export` (`declarations/import/context_helpers.rs`), next to the `import`/`import =` placement helpers that already own this family. The declaration is still bound — only the demand for its type is dropped.

**Declaration forms are excluded, and that is a live control.** `export default class` / `export default function` in a statement position parse as the declaration carrying an illegal `export` modifier (TS1184), not as an export assignment, so `checkExportAssignment`'s bail never applies and tsc checks them normally. `{ export default class extends undefinedBase {} }` must keep reporting its heritage failure, and does.

## Goal
Goal: hold

## Verification

**Oracle matrix, `typescript@7.0.2` via `scripts/conformance/oracle.sh`** (the `--singleThreaded --stableTypeOrdering true` shape the conformance cache generator uses), cross-checked against the default scheduler — **every row here is flag-insensitive**, so this is independent of #16413/#16490.

37 rows measured, tsz built from `f20f95c` before and after:

| # | row | tsc | tsz before | tsz after |
| --- | --- | --- | --- | --- |
| 1 | `{ export default undefinedName; }` | TS1258 | TS1258 **TS2552** | TS1258 |
| 2 | `function f() { … }` | TS1258 | TS1258 **TS2552** | TS1258 |
| 3 | `class C { m() { … } }` | TS1258 | TS1258 **TS2552** | TS1258 |
| 4 | `class C { constructor() { … } }` | TS1258 | TS1258 **TS2552** | TS1258 |
| 5 | `class C { get x() { … } }` | TS1258 | TS1258 **TS2552** | TS1258 |
| 6 | `class D { static { … } }` | TS1258 | TS1258 **TS2552** | TS1258 |
| 7 | `if (true) { … }` | TS1258 | TS1258 **TS2552** | TS1258 |
| 8 | `for (;;) { … }` | TS1258 | TS1258 **TS2552** | TS1258 |
| 9 | `function f() { { … } }` | TS1258 | TS1258 **TS2552** | TS1258 |
| 10 | `const g = () => { function inner() { … } }` | TS1258 | TS1258 **TS2552** | TS1258 |
| 11 | `const o = { get x() { … } }` | TS1258 | TS1258 **TS2552** | TS1258 |
| 12 | `{ export default { a: undefinedName }; }` | TS1258 | TS1258 **TS2552** | TS1258 |
| 13 | `{ const zzz = 1; export default zzZ; }` (renamed binder) | TS1258 | TS1258 **TS2552** | TS1258 |
| 14 | `{ … }` in a file with a top-level `export {}` | TS1258 | TS1258 **TS2552** | TS1258 |
| 15 | `const g = () => { … }` | TS1258 TS2552 | TS1258 TS2552 | unchanged |
| 16 | `const g = function () { … }` | TS1258 TS2552 | TS1258 TS2552 | unchanged |
| 17 | `const g = function fn() { … }` | TS1258 TS2552 | TS1258 TS2552 | unchanged |
| 18 | `const g = function* () { … }` | TS1258 TS2552 | TS1258 TS2552 | unchanged |
| 19 | `const o = { m() { … } }` | TS1258 TS2552 | TS1258 TS2552 | unchanged |
| 20 | `const o = { m: function () { … } }` | TS1258 TS2552 | TS1258 TS2552 | unchanged |
| 21 | `(() => { … })()` | TS1258 TS2552 | TS1258 TS2552 | unchanged |
| 22 | `take(() => { … })` (call argument) | TS1258 TS2552 | TS1258 TS2552 | unchanged |
| 23 | `const g = () => { { … } }` | TS1258 TS2552 | TS1258 TS2552 | unchanged |
| 24 | `class C { m() { const q = () => { … }; } }` | TS1258 TS2552 | TS1258 TS2552 | unchanged |
| 25 | `class C { p = () => { … }; }` | TS1258 TS2552 | TS1258 TS2552 | unchanged |
| 26 | arrow body, renamed binder | TS1258 TS2552 | TS1258 TS2552 | unchanged |
| 27 | arrow body, file with top-level `export {}` | TS1258 TS2552 | TS1258 TS2552 | unchanged |
| 28 | `export default undefinedName;` (top level, control) | TS2552 | TS2552 | unchanged |
| 29 | `namespace N { export default undefinedName; }` | TS1319 | TS1319 | unchanged |
| 30 | `{ export default known; }` (resolvable) | TS1258 | TS1258 | unchanged |
| 31 | `{ export default 42; }` | TS1258 | TS1258 | unchanged |
| 32 | `{ export default function h() { return undefinedName; } }` | TS1184 TS2552 | TS1184 TS2552 | unchanged |
| 33 | `function f() { export = undefinedName; }` | TS1231 | TS1231 | unchanged |
| 34 | `{ export = undefinedName; }` | TS1231 | TS1231 | unchanged |
| 35 | `{ export default class extends undefinedBase {} }` | TS1184 TS2552 | TS1184 **TS2304** | unchanged (see residual) |
| 36 | `function f() { import { a } from "nope"; }`-adjacent import rows | — | — | untouched |
| 37 | `const g = () => { const zzz = 1; export default zzZ; }` | TS1258 TS2552 | TS1258 TS2552 | unchanged |

**Result: 14 rows fixed toward tsc, 0 moved away.** 36 of 37 rows now match the oracle exactly; the one that does not (row 35) was already wrong on `main` in an unrelated way and is unchanged by this diff — see the residual below.

- `cargo test -p tsz-checker --lib position_invalid_default_export` — **21 passed, 0 failed, 12 ignored**
- `cargo test -p tsz-checker --lib` (full crate) — running at PR-open time; the count will be posted before this is queued.
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings` clean; `cargo fmt --all` clean; architecture guard passed (pre-commit).
- `scripts/conformance/compare-to-parent.sh` — **OWED** against this head, two-sided vs `origin/main`. This diff touches `build_type_environment`, which every file goes through, so the corpus number matters more here than for a leaf fix. Do not queue before the number lands.

### Harness note, worth carrying

**The default checker unit harness does not report an unresolved name in an *expression* position at all.** A plain `const zz = undefinedName;` comes back clean under `check_source_diagnostics` *and* under `check_source_with_libs(..., load_default_lib_files())`, while the same name in a *heritage clause* does report. So the deferred-container half of this rule cannot be observed there: those 12 rows are pinned in-tree but `#[ignore]`d, with the CLI matrix above as the primary evidence. This is a different harness gap from the no-lib one Obsidian recorded on the board (loading the libs does not fix it), and it silently makes a `!contains(TS2304)` assertion vacuous — worth knowing before writing a name-resolution negative in this crate.

The suite keeps a live over-reach control that goes through a path the harness *can* see: `default_exported_class_declaration_in_a_block_still_resolves_its_heritage` (row 35's shape) fails if the suppression ever reaches the declaration forms.

### Known residual — pre-existing, not a regression

Row 35 renders `TS2304` where tsc renders `TS2552` (`Cannot find name 'undefinedBase'. Did you mean 'undefined'?`). Same on `main` and on this branch: a missing did-you-mean suggestion in the class-heritage resolution path, unrelated to placement. Not fixed here and not made worse; recorded on the board so it does not get re-derived.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Moonstone

---
_Generated by [Claude Code](https://claude.ai/code/session_013UnNMNqVdMWXJwnZWmRQbr)_