### PR TITLE
fix(checker): a default-exported namespace/enum identifier keeps its namespace meaning through a default import (#16486)

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
+++ b/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
@@ -217,6 +217,55 @@ impl<'a> CheckerState<'a> {
                         // (`import * as X`, no single named target) or when
                         // `name` isn't a local import alias at all — callers
                         // fall back to their own, more conservative answer.
+                        // `export default <expr>` always synthesizes a fresh
+                        // "default" symbol with hardcoded `ALIAS` flags — see
+                        // `bind_export_declaration` in
+                        // `crates/tsz-binder/src/modules/import_export.rs` —
+                        // regardless of what the clause actually denotes.
+                        // When the clause is an inline declaration (`export
+                        // default class Decl {}`), that wrapper's meaning IS
+                        // the declaration's own kind, and a class merged with
+                        // a same-named namespace elsewhere in the file still
+                        // reports TS2702 through `default` (tsc only folds the
+                        // merge into the *named* binding, never the synthetic
+                        // default slot) — see
+                        // `default_imported_class_used_as_namespace_reports_type_used_as_namespace`.
+                        // But when the clause is a bare identifier reference
+                        // (`export default m;`, `m` declared elsewhere in the
+                        // same file), the wrapper is a true alias and tsc asks
+                        // the referenced declaration for its own (possibly
+                        // merged) namespace meaning — #16486. Detect that case
+                        // by reading the wrapper's own `value_declaration`
+                        // from its own file's arena: an `Identifier` node
+                        // means "alias to a same-file declaration", so resolve
+                        // that identifier one hop further in the *target's own*
+                        // file scope before giving up on it.
+                        let default_export_alias_target_has_namespace_meaning =
+                            |target_id: SymbolId, target: &tsz_binder::Symbol| -> Option<bool> {
+                                if !target.has_any_flags(symbol_flags::ALIAS)
+                                    || target.import_module().is_some()
+                                {
+                                    return None;
+                                }
+                                let file_idx = self.ctx.resolve_symbol_file_index(target_id)?;
+                                let decl_node = self
+                                    .ctx
+                                    .get_arena_for_file(file_idx as u32)
+                                    .get(target.value_declaration)?;
+                                if decl_node.kind != SyntaxKind::Identifier as u16 {
+                                    return None;
+                                }
+                                let ref_name = self
+                                    .ctx
+                                    .get_arena_for_file(file_idx as u32)
+                                    .get_identifier(decl_node)?
+                                    .escaped_text
+                                    .as_str();
+                                let target_binder = self.ctx.get_binder_for_file(file_idx)?;
+                                let ref_id = target_binder.file_locals.get(ref_name)?;
+                                let ref_symbol = target_binder.get_symbol(ref_id)?;
+                                Some(ref_symbol.has_any_flags(valid_namespace_flags))
+                            };
                         let resolve_import_target_has_namespace_meaning =
                             |name: &str| -> Option<bool> {
                                 let local_id = self.ctx.binder.file_locals.get(name)?;
@@ -230,7 +279,17 @@ impl<'a> CheckerState<'a> {
                                     self.ctx.resolve_import_alias_and_register(local_id)?;
                                 let target =
                                     self.get_symbol_from_registered_file_target(target_id)?;
-                                Some(target.has_any_flags(valid_namespace_flags))
+                                if target.has_any_flags(valid_namespace_flags) {
+                                    return Some(true);
+                                }
+                                if let Some(has_meaning) =
+                                    default_export_alias_target_has_namespace_meaning(
+                                        target_id, target,
+                                    )
+                                {
+                                    return Some(has_meaning);
+                                }
+                                Some(false)
                             };
                         let alias_target_lacks_namespace_meaning = is_alias
                             && resolve_import_target_has_namespace_meaning(&left_name)

--- a/crates/tsz-checker/tests/ts2702_qualifier_namespace_meaning_tests.rs
+++ b/crates/tsz-checker/tests/ts2702_qualifier_namespace_meaning_tests.rs
@@ -23,7 +23,9 @@
 //! `--noEmit --strict --target es2015`; the residual rows at the bottom are
 //! pinned as they behave today rather than left to drift.
 
-use crate::test_utils::{check_multi_file, check_source_diagnostics};
+use crate::test_utils::{
+    check_multi_file, check_multi_file_with_global_index, check_source_diagnostics,
+};
 use tsz_common::CheckerOptions;
 
 fn codes(source: &str) -> Vec<u32> {
@@ -46,6 +48,27 @@ fn multi_file_codes(files: &[(&str, &str)], entry: &str) -> Vec<u32> {
         ..CheckerOptions::default()
     };
     check_multi_file(files, entry, options)
+        .into_iter()
+        .map(|diagnostic| diagnostic.code)
+        .collect()
+}
+
+/// Like `multi_file_codes`, but wires the production `global_symbol_file_index`
+/// before checking, matching the real CLI driver instead of the plain
+/// in-memory `check_multi_file` pipeline's dynamic overlay. #16465/#16486's
+/// own test suite (`qualified_name_default_import_namespace_meaning_tests.rs`,
+/// #16479) established this as the harness for a default-import qualifier's
+/// namespace-meaning gate — the no-lib `check_multi_file` overlay does not
+/// reliably surface the downstream missing-member `TS2694` in this shape, so
+/// the load-bearing assertion for the regression is "does not report
+/// `TS2702`", not "reports `TS2694`" (see the comment on
+/// `export_default_namespace_keeps_namespace_meaning` in that suite).
+fn multi_file_codes_global_index(files: &[(&str, &str)], entry: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    };
+    check_multi_file_with_global_index(files, entry, options)
         .into_iter()
         .map(|diagnostic| diagnostic.code)
         .collect()
@@ -307,5 +330,125 @@ fn namespace_import_qualifier_keeps_the_member_lookup_path() {
             "/p2.ts",
         ),
         vec![2694]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// `export default <identifier>` re-exporting a namespace/enum keeps namespace
+// meaning through the default import (closes #16486, a regression from
+// #16480: that PR's alias-target check stopped at the synthesized `default`
+// wrapper symbol's own flags, which are always bare `ALIAS` regardless of
+// what the identifier denotes)
+// ---------------------------------------------------------------------------
+
+/// `export default m;` where `m` is a previously-declared namespace: `tsc`
+/// resolves `D.foo` as a member lookup, never `TS2702` — the default export is
+/// an alias to `m`'s own declaration, not a fresh symbol with its own
+/// (non-namespace) meaning. As `qualified_name_default_import_namespace_meaning_tests`'s
+/// own `export_default_namespace_keeps_namespace_meaning` control documents,
+/// the no-lib multi-file harness does not reliably surface the downstream
+/// missing-member `TS2694` for this shape; the load-bearing assertion for this
+/// regression is the absence of `TS2702` on both a present and a missing
+/// member.
+#[test]
+fn default_exported_namespace_identifier_keeps_namespace_meaning() {
+    let present = multi_file_codes_global_index(
+        &[
+            (
+                "dep.ts",
+                "namespace m { export interface foo { a: number } }\nexport default m;\n",
+            ),
+            ("main.ts", "import D from './dep';\nvar q: D.foo;\n"),
+        ],
+        "main.ts",
+    );
+    assert!(
+        !present.contains(&2702),
+        "a present member of an export-default namespace must not be TS2702, got: {present:?}"
+    );
+
+    let missing = multi_file_codes_global_index(
+        &[
+            (
+                "dep.ts",
+                "namespace m { export interface foo { a: number } }\nexport default m;\n",
+            ),
+            ("main.ts", "import D from './dep';\nvar bad: D.Missing;\n"),
+        ],
+        "main.ts",
+    );
+    assert!(
+        !missing.contains(&2702),
+        "a missing member of an export-default namespace must not become TS2702, got: {missing:?}"
+    );
+}
+
+/// `export default Color;` where `Color` is a previously-declared enum: an
+/// enum carries `SymbolFlags.Namespace` (`Enum` is in the set), so it must
+/// never report `TS2702` through a default-exported identifier alias, matching
+/// the namespace case above.
+#[test]
+fn default_exported_enum_identifier_keeps_namespace_meaning() {
+    let codes = multi_file_codes_global_index(
+        &[
+            ("e.ts", "enum Color { Red, Green }\nexport default Color;\n"),
+            ("main.ts", "import C from './e';\nvar bad: C.Nope;\n"),
+        ],
+        "main.ts",
+    );
+    assert!(
+        !codes.contains(&2702),
+        "an enum default export keeps namespace meaning (no TS2702), got: {codes:?}"
+    );
+}
+
+/// The local binding name at the import site is irrelevant — resolution goes
+/// through the `default` export slot's own target, not the local spelling.
+#[test]
+fn renamed_default_import_of_namespace_identifier_keeps_namespace_meaning() {
+    let codes = multi_file_codes_global_index(
+        &[
+            (
+                "dep2.ts",
+                "namespace m { export interface foo { a: number } }\nexport default m;\n",
+            ),
+            (
+                "main2.ts",
+                "import Renamed from './dep2';\nvar bad: Renamed.Missing;\n",
+            ),
+        ],
+        "main2.ts",
+    );
+    assert!(
+        !codes.contains(&2702),
+        "renaming the local binding must not affect the default export's namespace meaning, got: {codes:?}"
+    );
+}
+
+/// Negative control, restated from `default_imported_class_used_as_namespace_reports_type_used_as_namespace`:
+/// a default-exported class *merged* with a same-named namespace still
+/// reports `TS2702` through the `default` slot specifically — tsc only folds
+/// the merge into the *named* binding (`Decl`), never the synthetic `default`
+/// wrapper. This must NOT regress when the identifier-hop above is added: the
+/// hop only fires when `default`'s own `value_declaration` is a bare
+/// `Identifier`, and `export default class Decl {}` makes it the class
+/// declaration node itself.
+#[test]
+fn default_exported_class_merged_with_namespace_still_reports_ts2702() {
+    assert_eq!(
+        multi_file_codes(
+            &[
+                (
+                    "/dep3.ts",
+                    "export default class Decl {}\nexport namespace Decl { export interface I { q: number } }\n",
+                ),
+                (
+                    "/main3.ts",
+                    "import Entity from \"./dep3\";\nvar y: Entity.I;\n"
+                ),
+            ],
+            "/main3.ts",
+        ),
+        vec![2702]
     );
 }


### PR DESCRIPTION
`export default <expr>` always synthesizes a fresh "default" symbol with hardcoded `ALIAS` flags (`bind_export_declaration`, `crates/tsz-binder/src/modules/import_export.rs`), regardless of what the clause actually denotes. #16480's alias-target check (`resolve_import_target_has_namespace_meaning` in `crates/tsz-checker/src/state/type_analysis/qualified_names.rs`) stopped at that wrapper symbol's own flags, which are never in `SymbolFlags.Namespace` — correct for an inline class/interface/function default, but wrong for `export default m;` where `m` is a previously-declared namespace or enum: the wrapper is a true alias to `m`'s own (possibly merged) declaration, and tsc asks *that* declaration for its namespace meaning, not the synthetic default slot. This regressed a false `TS2702` on valid code (#16486).

**Structural rule.** When a default-export wrapper symbol is itself an `ALIAS` with no `import_module` (i.e. an intra-file re-export of a bare identifier, not a cross-file import) and its own `value_declaration` node is an `Identifier`, tsz now resolves that identifier one hop further in the target's own file scope and asks the referenced declaration for namespace meaning instead of the wrapper. When the clause is an inline declaration (`export default class Decl {}`), `value_declaration` is the declaration node itself, not an identifier, so the hop does not fire — a class merged with a same-named namespace still reports `TS2702` through the `default` slot specifically, matching tsc (which only folds the merge into the *named* binding, never the synthetic `default` wrapper).

Owner: the qualified-name gate's alias-target check in `crates/tsz-checker/src/state/type_analysis/qualified_names.rs`.

## Adjacent-case matrix

Added to `ts2702_qualifier_namespace_meaning_tests.rs`:
- default-exported namespace identifier, present member (no `TS2702`)
- default-exported namespace identifier, missing member (no `TS2702`)
- default-exported enum identifier (no `TS2702`)
- renamed local import binding of a default-exported namespace (no `TS2702`, proves the local spelling is irrelevant)
- negative control, restated: a default-exported class *merged* with a same-named namespace still reports `TS2702` (proves the hop is scoped to bare-identifier defaults only, not inline declarations)

All 7 tests from the original #16479 PR that first diagnosed this family (`qualified_name_default_import_namespace_meaning_tests.rs`) were fetched from that closed PR's branch and run unmodified against this fix — all pass, including the three (`export_default_namespace_keeps_namespace_meaning`, `valid_namespace_member_through_default_namespace_import_is_not_flagged`, and the merged-class control) that #16486 reports as currently broken/at-risk on main.

Refs #16486, #16480, #16465.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib ts2702_qualifier_namespace_meaning` — 19/19 passed (16 pre-existing + 3 new positive tests + 1 restated negative control; a 4th new test was folded into an existing one for a present+missing pair).
- Original #16479 regression suite (`qualified_name_default_import_namespace_meaning_tests.rs`, fetched from `origin/pr-16479` and run as a temporary `[[test]]` target, then removed) — 7/7 passed against this fix.
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings` — clean.
- `cargo fmt --all` — clean (no changes).
- `python3 scripts/arch/arch_guard.py` — passed.
- `cargo test -p tsz-checker --lib` (full suite) — running; will report the exact pass count as a PR comment once it completes (no regressions expected: this is a strict widening of when the alias-target check treats a symbol as namespace-capable, and the new/restated tests cover the class-merge case that would catch an over-widened hop).
- This is a harness-visible-only regression per #16486's own analysis ("the CLI matches tsc on both controls... so a CLI sweep cannot see it") — conformance is not expected to move; `compare-to-parent.sh` not run for this reason, matching #16480's own "conformance REG 0" note for the same code path.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: Serpentine

---
_Generated by [Claude Code](https://claude.ai/code/session_018aUPcBQbJiKoHPTHAZJMhy)_