### PR TITLE
fix(solver): weak-type scan uses declared properties, not synthesized call/apply

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -531,7 +531,6 @@ mod jsdoc_enum_circular_tests;
 #[cfg(test)]
 #[path = "../tests/jsdoc_function_return_type_anchor_tests.rs"]
 mod jsdoc_function_return_type_anchor_tests;
-
 #[cfg(test)]
 #[path = "../tests/position_invalid_export_specifier_resolution_tests.rs"]
 mod position_invalid_export_specifier_resolution_tests;

--- a/crates/tsz-checker/tests/function_source_apparent_function_surface_tests.rs
+++ b/crates/tsz-checker/tests/function_source_apparent_function_surface_tests.rs
@@ -177,6 +177,70 @@ fn function_does_not_satisfy_a_weak_target_naming_no_function_member() {
     assert!(!is_clean("var w3: { zzz?: string } = () => {};"));
 }
 
+// -------------------------------------------------------------------------
+// #16485: `call`/`apply` are synthesized apparent names, not declared
+// properties — a weak target naming either one must reject exactly like
+// `length`/`zzz` above, not short-circuit to accepted because the name
+// happens to match the synthesized pair the non-weak side uses.
+// -------------------------------------------------------------------------
+
+#[test]
+fn function_does_not_satisfy_a_weak_target_naming_call() {
+    assert!(
+        !is_clean("var w4: { call?: any } = () => {};"),
+        "`call` is a synthesized apparent name, not a declared property — the weak scan must still reject"
+    );
+}
+
+#[test]
+fn function_does_not_satisfy_a_weak_target_naming_apply() {
+    assert!(!is_clean("var w6: { apply?: any } = () => {};"));
+}
+
+#[test]
+fn a_declared_function_does_not_satisfy_a_weak_target_naming_call() {
+    // Binder-name variation: a `function` declaration, not an arrow.
+    assert!(!is_clean(
+        r#"
+function renamedFn() {}
+var w5: { call?: any } = renamedFn;
+"#
+    ));
+}
+
+#[test]
+fn a_callable_interface_with_no_declared_call_property_does_not_satisfy_a_weak_call_target() {
+    // Generic/concrete form: a `Callable` interface's call signature must not
+    // leak a synthesized `call` name into the weak scan either — only its own
+    // declared properties count.
+    assert!(!is_clean(
+        r#"
+interface Copyable {
+    (x: number): number;
+}
+declare const c: Copyable;
+var w10: { call?: any } = c;
+"#
+    ));
+}
+
+#[test]
+fn a_callable_interface_with_a_real_declared_property_satisfies_a_matching_weak_target() {
+    // Positive control: the fix must not turn every callable source into a
+    // blanket weak-type rejection — a genuinely declared property shared with
+    // the target still passes.
+    assert!(is_clean(
+        r#"
+interface Copyable {
+    (x: number): number;
+    tag?: string;
+}
+declare const c: Copyable;
+var w11: { tag?: string } = c;
+"#
+    ));
+}
+
 #[test]
 fn function_stays_a_member_of_an_intersection_with_a_weak_object_part() {
     // The intersection-member arm suppresses the weak rule; tsc accepts.

--- a/crates/tsz-solver/src/relations/compat.rs
+++ b/crates/tsz-solver/src/relations/compat.rs
@@ -342,65 +342,44 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         }
     }
 
-    fn function_like_weak_type_properties(
+    /// Declared properties of `source` for the weak-type common-name scan, plus
+    /// whether an index signature waives the rule and whether the source is
+    /// function-like (has a call or construct signature).
+    ///
+    /// tsc's weak-type rule (`hasCommonProperties` in `checker.ts`) walks
+    /// `getPropertiesOfType(source)` — the source's own *declared* members —
+    /// and separately triggers on `typeHasCallOrConstructSignatures(source)`.
+    /// The apparent `Function` surface (`call`, `apply`, `prototype`) never
+    /// enters that scan, so a bare function's declared-property set is empty:
+    /// it triggers the rule but shares no name with anything, and every
+    /// all-optional target — `{ call?: any }` included — is rejected. Earlier
+    /// tsz synthesized `call`/`apply`/`prototype` into this scan to give a
+    /// bare function *some* declared-looking name to match against, which let
+    /// a weak target naming one of those three names wrongly short-circuit to
+    /// accepted (#16485) — and, once `has_common_property_name`'s merge scan
+    /// assumed those synthesized names arrived pre-sorted by `Atom` and they
+    /// did not, made `call` and `apply` diverge from each other on top of
+    /// diverging from `tsc`.
+    fn weak_type_source_properties(
         &self,
-        mut props: Vec<PropertyInfo>,
-        has_call_signatures: bool,
-        has_construct_signatures: bool,
-    ) -> Vec<PropertyInfo> {
-        let mut ensure_prop = |name: &str| {
-            let atom = self.interner.intern_string(name);
-            if !props.iter().any(|prop| prop.name == atom) {
-                props.push(PropertyInfo::new(atom, TypeId::ANY));
-            }
-        };
-
-        if has_call_signatures {
-            // Function-like values expose Function members even when the callable
-            // shape itself does not materialize them. Weak-type overlap checks need
-            // to see those stable property names so unrelated weak object targets
-            // don't incorrectly accept function/class values.
-            ensure_prop("call");
-            ensure_prop("apply");
-        }
-
-        if has_construct_signatures {
-            ensure_prop("prototype");
-        }
-
-        props
-    }
-
-    fn weak_type_source_properties(&self, source: TypeId) -> Option<(Vec<PropertyInfo>, bool)> {
+        source: TypeId,
+    ) -> Option<(Vec<PropertyInfo>, bool, bool)> {
         if source == TypeId::FUNCTION {
-            return Some((
-                self.function_like_weak_type_properties(Vec::new(), true, false),
-                false,
-            ));
+            return Some((Vec::new(), false, true));
         }
 
         match self.interner.lookup(source) {
             Some(TypeData::Callable(shape_id)) => {
                 let shape = self.interner.callable_shape(shape_id);
-                let props = self.function_like_weak_type_properties(
-                    shape.properties.clone(),
-                    !shape.call_signatures.is_empty(),
-                    !shape.construct_signatures.is_empty(),
-                );
+                let is_function_like =
+                    !shape.call_signatures.is_empty() || !shape.construct_signatures.is_empty();
                 Some((
-                    props,
+                    shape.properties.clone(),
                     shape.string_index.is_some() || shape.number_index.is_some(),
+                    is_function_like,
                 ))
             }
-            Some(TypeData::Function(shape_id)) => {
-                let shape = self.interner.function_shape(shape_id);
-                let props = self.function_like_weak_type_properties(
-                    Vec::new(),
-                    !shape.is_constructor,
-                    shape.is_constructor,
-                );
-                Some((props, false))
-            }
+            Some(TypeData::Function(_)) => Some((Vec::new(), false, true)),
             _ => {
                 let mut extractor = ShapeExtractor::new(self.interner, self.subtype.resolver);
                 let source_shape_id = extractor.extract(source)?;
@@ -410,6 +389,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
                 Some((
                     source_shape.properties.clone(),
                     source_shape.string_index.is_some() || source_shape.number_index.is_some(),
+                    false,
                 ))
             }
         }

--- a/crates/tsz-solver/src/relations/compat_weak.rs
+++ b/crates/tsz-solver/src/relations/compat_weak.rs
@@ -213,7 +213,8 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
             return false;
         }
 
-        let Some((source_props, has_index_signature)) = self.weak_type_source_properties(source)
+        let Some((source_props, has_index_signature, is_function_like)) =
+            self.weak_type_source_properties(source)
         else {
             // No extractable object/function-like shape. For primitive types
             // (string/number/boolean/bigint/symbol literals, enum members, etc.),
@@ -231,8 +232,12 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         }
 
         // Empty objects are assignable to weak types (all optional properties).
-        // Only trigger weak type violation if source has properties that don't overlap.
-        !source_props.is_empty() && !self.has_common_property(source_props.as_slice(), target_props)
+        // Only trigger a weak type violation if the source has declared properties
+        // that don't overlap, OR is function-like (`typeHasCallOrConstructSignatures`
+        // in tsc): a bare function declares no properties at all, but still triggers
+        // the rule and — having none — never shares a name with the target.
+        (!source_props.is_empty() || is_function_like)
+            && !self.has_common_property(source_props.as_slice(), target_props)
     }
 
     /// Check if a primitive source type violates a weak type target by having
@@ -428,7 +433,8 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         }
 
         // Use visitor for Object types
-        let Some((source_props, has_index_signature)) = self.weak_type_source_properties(source)
+        let Some((source_props, has_index_signature, is_function_like)) =
+            self.weak_type_source_properties(source)
         else {
             // Array/Tuple types are objects but not extractable. They rarely
             // share property names with arbitrary union members, so treat as
@@ -444,7 +450,11 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
             return false;
         }
 
-        if source_props.is_empty() {
+        // A bare function declares no properties at all but is still
+        // function-like (`typeHasCallOrConstructSignatures`), so it must not
+        // take the early "no properties to compare" exit — it has none to
+        // share with any union member, which is exactly the violation.
+        if source_props.is_empty() && !is_function_like {
             return false;
         }
 


### PR DESCRIPTION
`var w4: { call?: any } = () => {}` was silently accepted; tsc reports TS2559. `{ apply?: any }` and every other name already rejected correctly, which is what made this a one-name asymmetry rather than the whole weak-type model being wrong.

## Structural rule

tsc's weak-type rule (`hasCommonProperties` in checker.ts) scans the source's own **declared** properties (`getPropertiesOfType`) and separately triggers whenever the source is function-like (`typeHasCallOrConstructSignatures`). The apparent `Function` surface never enters that scan, so a bare function's declared-property set is empty: the rule still fires (function-like), but an empty set shares no name with anything, so every all-optional target is rejected — `{ call?: any }` included.

tsz's `CompatChecker::weak_type_source_properties` (`relations/compat.rs`) instead synthesized `call`/`apply`/`prototype` into the scanned property set via `function_like_weak_type_properties`, giving a bare function a declared-looking name to match against. That let a weak target naming one of those three names wrongly short-circuit to accepted. It also made `call` and `apply` diverge from *each other*: the synthesized names were pushed in insertion order (`call` then `apply`), not sorted by `Atom`, but `has_common_property_name`'s merge scan (`relations/utils/mod.rs`) assumes both operand lists are sorted ascending by `Atom` — so whichever of the two happened to intern with the higher id broke the scan's sortedness assumption and was silently missed when it was the target's only property.

## Owner layer

`CompatChecker`'s own weak-scan (Lawyer layer, `crates/tsz-solver/src/relations/compat.rs` + `compat_weak.rs`). The unrelated solver-owned `core_dispatch::function_apparent_object_shape` (used for *required*-property targets, deliberately untouched by #16483) still synthesizes `call`/`apply`/`prototype` for that separate, non-weak arm and is out of scope here.

## Fix

`weak_type_source_properties` now returns the source's real declared properties (empty for a bare function/`FunctionShape`, the interface's own `properties` for a `CallableShape`) plus an `is_function_like` flag (`!call_signatures.is_empty() || !construct_signatures.is_empty()`). `violates_weak_type_with_target_props` and `source_lacks_union_common_property` now trigger the rule on `!source_props.is_empty() || is_function_like` instead of `!source_props.is_empty()` alone, matching tsc's two-part condition. No synthesized names enter the common-name scan; a genuinely declared property on a callable interface (e.g. a real `tag?: string` member alongside a call signature) still participates correctly.

## Adjacent-case matrix

`crates/tsz-checker/tests/function_source_apparent_function_surface_tests.rs`:
- `call` weak target: arrow source (the repro) and a renamed `function` declaration source
- `apply` weak target (the previously-correct sibling, now pinned explicitly)
- a `CallableShape` interface with a call signature and no declared `call` property still rejects a `{ call?: any }` target
- positive control: a `CallableShape` interface with a genuinely declared optional property still satisfies a weak target naming that property

Closes #16485.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib weak`: **41/41** (5 new, 0 regressed)
- Repro rows against `typescript@7.0.2` (`--noEmit --strict --lib es2022 --target es2022`): `{ call?: any }`, `{ apply?: any }`, `{ zzz?: any }` all `TS2559`; tsz now matches on all three (previously `call` alone was accepted)
- `cargo clippy --profile dist-fast -p tsz-checker -p tsz-solver --lib -- -D warnings`: clean (pre-commit gate)
- `python3 scripts/arch/check-checker-boundaries.sh`: passed (pre-commit gate)
- `cargo fmt --all`: clean
- `compare-to-parent.sh` / broader conformance: **owed** — this touches `CompatChecker`'s shared weak-type gate used across many assignability call sites, so a full two-sided run is warranted before merge; not run this session due to time budget. Expected signature per the board's standing pattern for this family: 0 newly-failing (the change only ever turns a previously-silent accept into a correctly-reported reject on a narrow synthesized-name shape), some newly-passing possible if the corpus exercises `call`/`apply`/`prototype`-named weak targets against function sources.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNZtbz6RS4pHwQsfxC8brL)_