### PR TITLE
fix(checker): a default-exported class merged with a namespace still denies namespace meaning via a bare-identifier default export

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
+++ b/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
@@ -240,6 +240,22 @@ impl<'a> CheckerState<'a> {
                         // means "alias to a same-file declaration", so resolve
                         // that identifier one hop further in the *target's own*
                         // file scope before giving up on it.
+                        //
+                        // One exception, oracle-verified against
+                        // `typescript@7.0.2`: a resolved `Class` bit overrides
+                        // an accompanying `NamespaceModule`/`Enum` bit here
+                        // specifically. `class C {} namespace C {...}` keeps
+                        // namespace meaning through this same bare-identifier
+                        // hop when accessed via a *named* import or same-file
+                        // reference (unaffected, already covered above and
+                        // by `class_merged_with_namespace_resolves_its_exported_member`),
+                        // but tsc's *default*-export slot still denies it
+                        // (`TS2702`) for the identical merge even when the
+                        // default clause is a bare reference to it rather
+                        // than the inline declaration this hop already
+                        // excludes — the merge with a `function` does not
+                        // lose it the same way, so the override is keyed on
+                        // `Class` specifically, not "any merge."
                         let default_export_alias_target_has_namespace_meaning =
                             |target_id: SymbolId, target: &tsz_binder::Symbol| -> Option<bool> {
                                 if !target.has_any_flags(symbol_flags::ALIAS)
@@ -264,7 +280,10 @@ impl<'a> CheckerState<'a> {
                                 let target_binder = self.ctx.get_binder_for_file(file_idx)?;
                                 let ref_id = target_binder.file_locals.get(ref_name)?;
                                 let ref_symbol = target_binder.get_symbol(ref_id)?;
-                                Some(ref_symbol.has_any_flags(valid_namespace_flags))
+                                Some(
+                                    !ref_symbol.has_any_flags(symbol_flags::CLASS)
+                                        && ref_symbol.has_any_flags(valid_namespace_flags),
+                                )
                             };
                         let resolve_import_target_has_namespace_meaning =
                             |name: &str| -> Option<bool> {

--- a/crates/tsz-checker/tests/ts2702_qualifier_namespace_meaning_tests.rs
+++ b/crates/tsz-checker/tests/ts2702_qualifier_namespace_meaning_tests.rs
@@ -452,3 +452,32 @@ fn default_exported_class_merged_with_namespace_still_reports_ts2702() {
         vec![2702]
     );
 }
+
+/// The bare-identifier-reference twin of the control above (#16501): a class
+/// merged with a same-named namespace, default-exported by referencing the
+/// already-declared, already-merged name rather than declaring the class
+/// inline. The identifier-hop above *does* fire here (`export default Decl2;`
+/// makes `default`'s `value_declaration` a bare `Identifier`), so without the
+/// `Class`-bit override it would wrongly resolve `Entity3.I` as a member
+/// lookup — oracle-verified (`typescript@7.0.2`, three ways: `oracle.sh`, a
+/// bare `tsc` invocation, and with `export` dropped from the namespace) that
+/// `tsc` reports `TS2702` here exactly as it does for the inline form.
+#[test]
+fn default_exported_bare_ref_class_merged_with_namespace_still_reports_ts2702() {
+    assert_eq!(
+        multi_file_codes(
+            &[
+                (
+                    "/dep4.ts",
+                    "class Decl2 {}\nexport namespace Decl2 { export interface I { q: number } }\nexport default Decl2;\n",
+                ),
+                (
+                    "/main4.ts",
+                    "import Entity3 from \"./dep4\";\nvar y: Entity3.I;\n"
+                ),
+            ],
+            "/main4.ts",
+        ),
+        vec![2702]
+    );
+}


### PR DESCRIPTION
Rebased onto #16497, which merged while this was in review and independently fixed most of what this PR originally targeted (see the comment thread below — two of my three original tests are now redundant with it). This is now a much smaller, surgical follow-up for the one residual gap #16497 left.

## What #16497 covers, and the one row it doesn't

#16497 fixed #16486 by hopping through a bare-identifier `export default <name>;` clause to the referenced declaration's own (possibly merged) flags, when the default-export wrapper's `value_declaration` is an `Identifier` node. That hop correctly handles a bare default-exported namespace, a bare default-exported enum, and correctly *declines* to fire for an inline declaration (`export default class Decl {}`), so a class inline-merged with a namespace still reports `TS2702` — matching the pre-existing negative control in this file.

But the hop's final check (`ref_symbol.has_any_flags(valid_namespace_flags)`) doesn't exclude a `Class` bit, so it also fires — and wrongly resolves clean — for the bare-identifier-reference form of the identical class+namespace merge:

```ts
// dep4.ts
class Decl2 {}
export namespace Decl2 { export interface I { q: number } }
export default Decl2;
// main4.ts
import Entity3 from "./dep4";
var y: Entity3.I;   // main (post-#16497): resolves clean. tsc: TS2702.
```

Confirmed against the pinned `typescript@7.0.2` oracle three independent ways (`scripts/conformance/oracle.sh`, a bare `tsc` invocation, and with `export` dropped from the namespace) — all three report `TS2702`, matching the inline form exactly. Built main at `8a1f151` in a throwaway worktree and reproduced the gap directly against the compiled binary before writing this fix.

## Structural rule

Owner: the same bare-identifier hop in `crates/tsz-checker/src/state/type_analysis/qualified_names.rs` (`default_export_alias_target_has_namespace_meaning`). When that hop resolves to the referenced local symbol, a `Class` bit on that symbol overrides an accompanying `NamespaceModule`/`Enum` bit and denies namespace meaning — the merge with a `function` does not lose it the same way (unaffected, no test needed since the hop's flag check was already correct for non-`Class` merges), so the override is keyed on `Class` specifically, not "any merge."

## Verification
- `cargo test -p tsz-checker --lib ts2702_qualifier_namespace_meaning` — 20 passed, 0 failed (1 new adjacent-case test; all 19 pre-existing rows, including #16497's own additions, unchanged).
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings` — clean.
- `cargo fmt --all` — clean.
- `python3 scripts/arch/arch_guard.py` — passed.
- Diagnostic-family change confined to a narrow default-import/class-namespace-merge shape not present in the corpus (same family as #16486/#16497, both landed with conformance REG 0); `compare-to-parent.sh` not run given the surgical size of this follow-up — available on request.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: Garnet
