### PR TITLE
fix(checker): a TS2741 single-missing-property target reduces a concrete keyof indexed access (#16443)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/type_display_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/type_display_policy.rs
@@ -214,8 +214,17 @@ impl<'a> CheckerState<'a> {
             // A bare, concrete (type-parameter-free) indexed access is reduced
             // to its member type, matching tsc's eager `getIndexedAccessType`.
             // Generic/deferred accesses stay opaque (see the helper's docs).
+            // `FlattenedDiagnostic` is the TS2741 single-missing-property
+            // target: it is a distinct role from `AssignmentTarget`, but tsc
+            // draws no such distinction — the target it quotes in "but
+            // required in type '_'" is the same annotated type either
+            // message reaches, so it needs the identical pre-resolution or a
+            // concrete `keyof` access reaches this role's message still
+            // unreduced (the shared formatter's own gate excludes `keyof`
+            // unconditionally; see `is_display_reducible_index_key`).
             DiagnosticTypeDisplayRole::AssignmentSource { .. }
-            | DiagnosticTypeDisplayRole::AssignmentTarget { .. } => {
+            | DiagnosticTypeDisplayRole::AssignmentTarget { .. }
+            | DiagnosticTypeDisplayRole::FlattenedDiagnostic => {
                 self.resolve_concrete_indexed_access_for_display(ty)
             }
             _ => ty,

--- a/crates/tsz-checker/tests/concrete_indexed_access_display_tests.rs
+++ b/crates/tsz-checker/tests/concrete_indexed_access_display_tests.rs
@@ -351,28 +351,56 @@ const m1: M["outer"]["mid"] = { z: 1 };
 }
 
 /// `keyof`-keyed access in the **missing-property (TS2741) target** message.
-/// The assignment display gate now admits a concrete `keyof` key, but a
-/// TS2741 target renders through a *different* path than the reduced type it
-/// receives, so this row still prints the access as written. The source-role
-/// and TS2322-whole-type keyof rows below *are* reduced; this is the residual
-/// TS2741-target cell (tsc reduces it — tracked with the wider #16443 family).
+/// The TS2741 single-missing-property target renders through the
+/// `FlattenedDiagnostic` role, a distinct path from `AssignmentTarget` that
+/// used to skip the keyof-aware pre-resolution entirely and fall through to
+/// the shared formatter's `keyof`-excluding gate. Routing `FlattenedDiagnostic`
+/// through the same `resolve_concrete_indexed_access_for_display` step as
+/// `AssignmentTarget` closes this row — matching tsc, which draws no such
+/// distinction for the type it quotes in "but required in type '_'".
 #[test]
-fn keyof_rooted_indexed_access_target_prints_as_written() {
-    let messages = strict_messages(
+fn keyof_rooted_indexed_access_target_renders_reduced_member() {
+    let messages = ts2741_messages(
         r#"
 interface Q { only: { c: number; d: string } }
 const q1: Q[keyof Q] = { c: 1 };
 "#,
     );
-    assert_eq!(
-        messages.len(),
-        1,
-        "exactly one assignability error: {messages:?}"
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert_reduced_member(&messages[0], "{ c: number; d: string; }");
+}
+
+/// Anti-hardcoding: the TS2741-target `keyof` reduction keys on the concrete
+/// `keyof`-access structure, not on the identifiers `Q`/`only`/`c`/`d`.
+#[test]
+fn keyof_rooted_indexed_access_target_reduction_is_binder_name_independent() {
+    let messages = ts2741_messages(
+        r#"
+interface Registry { entry: { alpha: number; beta: string } }
+const reg1: Registry[keyof Registry] = { alpha: 1 };
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert_reduced_member(&messages[0], "{ alpha: number; beta: string; }");
+}
+
+/// Negative control mirroring the source-role guard: when the reduced `keyof`
+/// access carries an ambiguous `display_alias` (a sibling generic alias
+/// instantiates to the same `TypeId`), the TS2741 target must stay as
+/// written rather than repaint with the unrelated alias name.
+#[test]
+fn keyof_rooted_indexed_access_target_with_sibling_alias_prints_as_written() {
+    let messages = strict_messages(
+        r#"
+type Boxes<T> = { [K in keyof T]: { tag: K; val: T[K] } };
+type Boxed<T> = Boxes<T>[keyof T];
+type FB = { a: string; b: number };
+const boxed: Boxes<FB>[keyof FB] = {};
+"#,
     );
     assert!(
-        messages[0].contains("Q[keyof Q]"),
-        "an unreduced access must print as written: {}",
-        messages[0]
+        messages.iter().any(|m| m.contains("Boxes<FB>[keyof FB]")),
+        "an alias-ambiguous keyof access must print as written, not repaint with the sibling alias: {messages:?}"
     );
 }
 


### PR DESCRIPTION
When a keyof-keyed indexed access is concrete (no free type parameters) and its evaluated result carries no ambiguous `display_alias`, `tsc`'s `getIndexedAccessType` reduces it during type construction, so the type quoted in `Property 'x' is missing in type '_' but required in type '_'` is never the access itself. tsz does this reduction through `checker::error_reporter::type_display_policy::resolve_concrete_indexed_access_for_display` for the `AssignmentSource`/`AssignmentTarget` roles (#16493), but the TS2741 single-missing-property message renders its target through a separate `FlattenedDiagnostic` role that skipped that checker-owned pre-resolution entirely and fell straight to the shared solver formatter — whose classifier deliberately excludes `keyof` (to avoid repainting a reduced access with an unrelated sibling alias's display name).

This is the last open cell of #16443's `keyof` matrix: source role (#16493), TS2322 whole-type (#16493/#16461), literal/union/chained target keys (#16456/#16469) all already reduce; only the TS2741 single-property target stayed opaque because it never reached the gate at all.

Fix: route `FlattenedDiagnostic` through the same `resolve_concrete_indexed_access_for_display` call as `AssignmentTarget` in `type_display_policy.rs` — one match arm, no new logic. The existing alias-ambiguity guard (only reduce when the result carries no `display_alias`) applies unchanged, so the repaint hazard #16493 built that guard for is still covered.

Adjacent cases in `concrete_indexed_access_display_tests.rs`:
- basic reduction (`Q[keyof Q]` → the object's member shape)
- renamed binders (anti-hardcoding — the reduction keys on the concrete-`keyof` structure, not on identifiers)
- alias-ambiguous negative control (a sibling generic alias sharing the reduced `TypeId`) — stays as written, matching the source-role guard

One residual discovered while writing this PR, **not** fixed here: a `keyof` target reducing to a union of two *distinct declarations* that happen to be structurally identical (e.g. `interface Two { p: { m: number }; q: { m: number } }`, `Two[keyof Two]`) collapses to a single member in tsz because anonymous object types intern by structure ("one semantic type universe" per `CLAUDE.md`), while `tsc` keeps each declaration's own anonymous type distinct in the union. That's a much deeper identity-model question (`crates/tsz-solver` object-type interning vs. per-declaration-site type identity), unrelated to this display-routing fix, and out of scope for this PR — flagged on the board (#15994) and on #16443 for whoever picks up that thread.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test concrete_indexed_access_display_tests`: 39/39 (updated the residual negative test to a positive one, added 2 adjacent cases)
- `cargo test -p tsz-checker --test mapped_indexed_access_diagnostic_tests`: 3/3 (the alias-repaint regression guard #16493 registered)
- `cargo test -p tsz-checker --test deferred_keyof_index_access_assignability_tests`: 17/17
- `cargo test -p tsz-checker --test keyof_source_display_tests`: 7/7
- `cargo test -p tsz-checker --test keyof_call_parameter_display_tests`: 2/2
- `cargo clippy -p tsz-checker --all-targets -- -D warnings`: clean
- `cargo build -p tsz-checker --lib`: clean
- Test-only + one `match` arm in `crates/tsz-checker/src/error_reporter/type_display_policy.rs`; no solver/binder/emit paths touched, so conformance/emit counts are not expected to move — this is a display-role dispatch fix scoped to one call site (`render_missing_property`'s single-property TS2741 path).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_01W5tS8P7Z8W67XPLQWedTuA)_