### PR TITLE
fix(checker): a position-invalid `export ... from` outside a declaration scope resolves its specifier only when its clause matches the file's export table

### DIFF
--- a/crates/tsz-checker/src/declarations/import/context_helpers.rs
+++ b/crates/tsz-checker/src/declarations/import/context_helpers.rs
@@ -196,6 +196,66 @@ impl<'a> CheckerState<'a> {
         true
     }
 
+    /// Whether a position-invalid `export ... from "m"` still resolves its module
+    /// specifier, refining [`Self::position_invalid_module_element_resolves_specifier`]
+    /// with the export side's own demand model.
+    ///
+    /// [`Self::position_invalid_module_element_resolves_specifier`] answers whether a
+    /// *declaration scope* encloses the declaration. When one does, nothing resolves
+    /// and that answer is final. When one does not — a top-level bare block, an
+    /// `if`/loop/`try` body, a labeled statement, a `switch` clause — the declaration
+    /// is left in the source file's own scope, and the export side then diverges from
+    /// the import side: `checkExportDeclaration` has already returned at the placement
+    /// diagnostic, so whatever resolution still happens comes from a *later* pass over
+    /// whichever symbol table the binder put the declaration in, and which table that
+    /// is depends on the file.
+    ///
+    /// In an external module the file symbol carries an export table, so `export *`
+    /// binds as an export-star entry that computing that table resolves eagerly, while
+    /// a named or namespace export clause binds an alias resolved only on reference —
+    /// and a position-invalid one is never referenced. In a file that is *not* a
+    /// module there is no export table to compute, so the export-star is never
+    /// resolved at all, and only the individual specifiers of a named clause bind as
+    /// ordinary aliases that a later pass reaches.
+    ///
+    /// The two forms therefore swap roles across that one axis, measured against the
+    /// pinned oracle (#16495):
+    ///
+    /// | clause | external module | not a module |
+    /// | --- | --- | --- |
+    /// | `export * from "m"` | resolves | silent |
+    /// | `export * as ns from "m"` | silent | silent |
+    /// | `export { a } from "m"` | silent | resolves |
+    ///
+    /// Only the export side consults this. `import`/`import =` keep resolving in every
+    /// one of these containers, which is why the rule cannot be shared with them.
+    pub(crate) fn position_invalid_export_declaration_resolves_specifier(
+        &self,
+        export_idx: NodeIndex,
+        export_clause: NodeIndex,
+    ) -> bool {
+        if !self.position_invalid_module_element_resolves_specifier(export_idx) {
+            return false;
+        }
+
+        if export_clause.is_none() {
+            // Bare `export * from "m"`: an export-star entry, resolved only when the
+            // file actually has a module export table to compute.
+            return self.ctx.is_external_module_file();
+        }
+
+        let is_named_exports = self
+            .ctx
+            .arena
+            .get(export_clause)
+            .is_some_and(|n| n.kind == syntax_kind_ext::NAMED_EXPORTS);
+
+        // A named clause's specifiers bind as plain aliases outside a module; inside
+        // one they land in the export table and stay lazy. `export * as ns` is an
+        // alias either way, so it never resolves here.
+        is_named_exports && !self.ctx.is_external_module_file()
+    }
+
     /// Check if a node is inside a module augmentation
     /// (`declare module "string" { ... }`).  Module augmentations have a
     /// `MODULE_DECLARATION` ancestor whose name is a string literal.

--- a/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
@@ -264,8 +264,19 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
             // (TS2305) and TS2498 — goes with it. See
             // `position_invalid_module_element_resolves_specifier` for which
             // containers open a scope and which do not.
+            //
+            // Outside a declaration scope the declaration is left in the source
+            // file's own scope, where the export side resolves through a later
+            // pass rather than through the check that just returned — so which
+            // export clause it carries, and whether the file is an external
+            // module, decide whether anything reaches the specifier at all
+            // (#16495). `position_invalid_export_declaration_resolves_specifier`
+            // owns that refinement; the import side does not share it.
             let resolves_specifier = !in_non_module_context
-                || self.position_invalid_module_element_resolves_specifier(export_idx);
+                || self.position_invalid_export_declaration_resolves_specifier(
+                    export_idx,
+                    export_decl.export_clause,
+                );
             if export_decl.module_specifier.is_some() && resolves_specifier {
                 self.check_export_module_specifier(export_idx);
                 // TS2498: export * from a module that uses export =

--- a/crates/tsz-checker/tests/position_invalid_export_specifier_resolution_tests.rs
+++ b/crates/tsz-checker/tests/position_invalid_export_specifier_resolution_tests.rs
@@ -10,11 +10,21 @@
 //! clause) leaves the declaration in the source file's own scope, and tsc keeps
 //! resolving there.
 //!
-//! Every expectation below is a row where `typescript@7.0.2` returns the same
-//! answer in **both** threading modes (default and `--singleThreaded`). The
-//! top-level-block family, where the two modes disagree, is deliberately left
-//! alone — see #16413 — and is pinned here as a control asserting the behavior
-//! `main` already has.
+//! Outside a declaration scope that answer is not the whole rule. The check has
+//! already returned, so whatever still resolves comes from a later pass over the
+//! symbol table the binder used — and which table that is depends on the file. In
+//! an external module the file symbol carries an export table whose computation
+//! resolves an `export *` entry eagerly, while a named or namespace clause stays a
+//! lazily-resolved alias nothing references; in a file that is not a module there
+//! is no export table to compute, so `export *` is never resolved and only a named
+//! clause's specifiers bind as aliases a later pass reaches. The two forms swap
+//! roles across that one axis (#16495).
+//!
+//! Every expectation below is measured against the pinned `typescript@7.0.2`
+//! oracle through `scripts/conformance/oracle.sh`, which pins the
+//! `--singleThreaded --stableTypeOrdering` invocation the conformance cache
+//! generator uses — the disagreement recorded here as #16413 was an artifact of
+//! comparing against a bare `tsc` run, and is settled.
 
 use crate::context::CheckerOptions;
 use crate::state::CheckerState;
@@ -318,6 +328,213 @@ fn a_nested_bare_block_at_top_level_keeps_resolving_unchanged() {
 }"#,
         &[1233, 2307],
         "nesting plain blocks never crosses a declaration scope",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Outside a declaration scope, the export clause and the file's module-ness
+// decide together (#16495).
+//
+// The check has already returned at the placement diagnostic, so anything that
+// still resolves comes from a later pass over whichever symbol table the binder
+// used. In an external module the file symbol has an export table, and computing
+// it resolves the export-star entry eagerly while a named/namespace clause stays
+// a lazily-resolved alias nothing references. With no export table to compute,
+// the export-star is never resolved at all and only a named clause's individual
+// specifiers bind as ordinary aliases a later pass reaches.
+//
+// So the two forms swap roles across that one axis. Every row below is measured
+// against the pinned `typescript@7.0.2` oracle through `scripts/conformance/oracle.sh`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn export_star_in_a_bare_top_level_block_of_a_script_reports_ts1233_alone() {
+    assert_codes(
+        r#"{
+  export * from "nonexistent-module";
+}"#,
+        &[1233],
+        "no export table to compute, so the export-star entry is never resolved",
+    );
+}
+
+#[test]
+fn export_star_in_an_if_body_of_a_script_reports_ts1233_alone() {
+    assert_codes(
+        r#"if (1) {
+  export * from "nonexistent-module";
+}"#,
+        &[1233],
+        "an `if` body opens no declaration scope, but the file is not a module",
+    );
+}
+
+#[test]
+fn export_star_in_a_loop_body_of_a_script_reports_ts1233_alone() {
+    assert_codes(
+        r#"for (;;) {
+  export * from "nonexistent-module";
+}"#,
+        &[1233],
+        "a loop body opens no declaration scope, but the file is not a module",
+    );
+}
+
+#[test]
+fn export_star_in_a_while_body_of_a_script_reports_ts1233_alone() {
+    assert_codes(
+        r#"while (1) {
+  export * from "nonexistent-module";
+}"#,
+        &[1233],
+        "a `while` body behaves as the `for` body does",
+    );
+}
+
+#[test]
+fn export_star_in_a_try_body_of_a_script_reports_ts1233_alone() {
+    assert_codes(
+        r#"try {
+  export * from "nonexistent-module";
+} catch {}"#,
+        &[1233],
+        "a `try` body behaves as any other non-declaration-scope container",
+    );
+}
+
+#[test]
+fn export_star_in_a_labeled_block_of_a_script_reports_ts1233_alone() {
+    assert_codes(
+        r#"lbl: {
+  export * from "nonexistent-module";
+}"#,
+        &[1233],
+        "a labeled statement opens no declaration scope",
+    );
+}
+
+#[test]
+fn export_star_in_a_nested_bare_block_of_a_script_reports_ts1233_alone() {
+    assert_codes(
+        r#"{
+  {
+    export * from "nonexistent-module";
+  }
+}"#,
+        &[1233],
+        "nesting plain blocks never crosses a declaration scope, and never \
+         creates an export table either",
+    );
+}
+
+#[test]
+fn export_star_as_ns_in_a_bare_top_level_block_of_a_script_reports_ts1233_alone() {
+    assert_codes(
+        r#"{
+  export * as ns from "nonexistent-module";
+}"#,
+        &[1233],
+        "a namespace export clause is an alias, so it resolves in neither file kind",
+    );
+}
+
+#[test]
+fn a_renamed_namespace_export_binder_does_not_change_the_verdict() {
+    assert_codes(
+        r#"{
+  export * as zzQq from "nonexistent-module";
+}"#,
+        &[1233],
+        "the verdict is over the clause kind, never over the binder's spelling",
+    );
+}
+
+#[test]
+fn export_star_in_a_bare_top_level_block_of_a_module_reports_ts2307() {
+    assert_codes(
+        r#"export {};
+{
+  export * from "nonexistent-module";
+}"#,
+        &[1233, 2307],
+        "THE DISCRIMINATOR: the same block in a module has an export table, and \
+         computing it resolves the export-star entry",
+    );
+}
+
+#[test]
+fn export_star_in_an_if_body_of_a_module_reports_ts2307() {
+    assert_codes(
+        r#"export {};
+if (1) {
+  export * from "nonexistent-module";
+}"#,
+        &[1233, 2307],
+        "the module-ness axis is independent of which non-declaration container it is",
+    );
+}
+
+#[test]
+fn a_module_indicator_other_than_export_braces_also_flips_the_export_star() {
+    assert_codes(
+        r#"export const q = 1;
+{
+  export * from "nonexistent-module";
+}"#,
+        &[1233, 2307],
+        "the gate reads the file's module-ness, not the `export {}` spelling",
+    );
+}
+
+#[test]
+fn export_named_in_a_bare_top_level_block_of_a_module_reports_ts1233_alone() {
+    assert_codes(
+        r#"export {};
+{
+  export { a } from "nonexistent-module";
+}"#,
+        &[1233],
+        "THE INVERSION: a named clause resolves in a script and stays silent in a \
+         module — exactly the opposite of the export-star above",
+    );
+}
+
+#[test]
+fn export_star_as_ns_in_a_bare_top_level_block_of_a_module_reports_ts1233_alone() {
+    assert_codes(
+        r#"export {};
+{
+  export * as ns from "nonexistent-module";
+}"#,
+        &[1233],
+        "a namespace export clause stays an unreferenced alias in a module too",
+    );
+}
+
+#[test]
+fn a_declaration_scope_still_wins_over_module_ness() {
+    assert_codes(
+        r#"export {};
+function f() {
+  export * from "nonexistent-module";
+}"#,
+        &[1233],
+        "the declaration-scope answer is final; module-ness only refines the case \
+         where no declaration scope encloses the declaration",
+    );
+}
+
+#[test]
+fn a_class_static_block_in_a_module_still_wins_over_module_ness() {
+    assert_codes(
+        r#"export {};
+class C {
+  static {
+    export * from "nonexistent-module";
+  }
+}"#,
+        &[1233],
+        "a `static { }` block is a declaration scope in a module as well",
     );
 }
 

--- a/crates/tsz-checker/tests/position_invalid_export_specifier_resolution_tests.rs
+++ b/crates/tsz-checker/tests/position_invalid_export_specifier_resolution_tests.rs
@@ -270,12 +270,12 @@ fn an_export_directly_in_an_ambient_module_body_still_reports_ts2307() {
 
 #[test]
 fn a_bare_top_level_block_keeps_resolving_unchanged() {
-    // The top-level-block family is where typescript@7.0.2's two threading modes
-    // disagree (#16413): the default scheduler reports TS1233 alone, and
-    // `--singleThreaded` — the mode `generate-tsc-cache.rs` uses, and therefore
-    // the mode the conformance corpus is scored in — reports TS1233 + TS2307.
-    // This fix changes nothing here; the row is pinned so a later widening of the
-    // gate cannot silently move it without the disagreement being settled first.
+    // A named clause in a file that is not a module is the one cell of the
+    // #16495 table that really does resolve: with no export table to compute,
+    // the specifiers bind as ordinary aliases that a later pass reaches. This
+    // row was previously pinned on the belief that typescript@7.0.2's two
+    // threading modes disagree about it (#16413) — they do not, and it is
+    // oracle-measured now rather than pinned to whatever `main` happened to do.
     assert_codes(
         r#"{
   export { a } from "nonexistent-module";


### PR DESCRIPTION
`{ export * from "nope"; }` reported **TS1233 and TS2307**. tsc reports TS1233 alone. Same for an `if` body, a loop body, a `while` body, a `try` body, a labeled statement and a nested block.

Closes #16495.

## The measurement changed the rule

#16495 framed this as 3 rows and named the open question as *"does `export * from` suppress because the placement is invalid, or only when the specifier does not resolve?"* — the resolvable-vs-unresolvable axis, because #16409's diff had died on `moduleElementsInWrongContext.ts`, whose `"ambient"` specifier resolves.

**Resolvability is not the axis.** Measured through `scripts/conformance/oracle.sh`, a block-level `export * from` stays silent whether or not its specifier resolves, and a block-level `export { b } from` reports whether or not it resolves (TS2307 unresolvable / TS2305 resolvable-but-no-such-member). The real discriminator is the **export clause**, crossed with **whether the file is an external module** — and across that second axis the two clause forms *swap roles*:

| clause, in a top-level block / `if` / loop | file is a module | file is not a module |
| --- | --- | --- |
| `export * from "m"` | **TS1233 + TS2307** | **TS1233 alone** |
| `export * as ns from "m"` | TS1233 alone | TS1233 alone |
| `export { a } from "m"` | **TS1233 alone** | **TS1233 + TS2307** |

That inversion is the whole finding, and neither half of it was in the issue.

**Structural rule.** When an `export ... from` sits in a container that opens no declaration scope, tsc has already returned from `checkExportDeclaration` at the placement diagnostic, so anything that still resolves comes from a *later* pass over whichever symbol table the binder used — and which table that is depends on the file. An external module's file symbol carries an export table; computing it resolves an `export *` entry eagerly, while a named or namespace clause stays a lazily-resolved alias that a position-invalid declaration never references. A file that is not a module has no export table to compute, so the `export *` entry is never resolved at all, and only a named clause's individual specifiers bind as ordinary aliases a later pass reaches. tsz now answers the same way through the checker's existing export-side placement helper.

The declaration-scope answer stays final and is unchanged: a function body, arrow, method, constructor, accessor, `static { }` block or enclosing namespace body suppresses regardless of module-ness (`a_declaration_scope_still_wins_over_module_ness`, `a_class_static_block_in_a_module_still_wins_over_module_ness`).

**The import side is deliberately not shared with this rule.** `import { a } from` and `import x = require(...)` keep resolving in a bare block in a script file, which is exactly where two prior PRs went wrong from opposite ends — #16409 generalised the export rule onto blocks flatly, #16411's original draft generalised the `import =` rule onto blocks and would have regressed five green rows. The predicate is over AST clause kind plus the file's module-ness; no name, file-name or rendered-text check anywhere in the diff.

## Owner

| site | change |
| --- | --- |
| `declarations/import/context_helpers.rs` | new `position_invalid_export_declaration_resolves_specifier`, next to the placement helpers that already own this family. It defers to the existing `position_invalid_module_element_resolves_specifier` for the declaration-scope answer and refines only the case where that returns true. |
| `state_checking_members/statement_callback_bridge.rs` | the export-side gate calls the new helper instead of the shared one. Import call sites untouched. |

Module-ness is read through the existing `CheckerContext::is_external_module_file()`, which prefers the CLI driver's per-file cache and falls back to the binder — no new module-detection mechanism.

## Goal
Goal: hold

## Verification

**Oracle matrix, `typescript@7.0.2` via `scripts/conformance/oracle.sh`** (the `--singleThreaded --stableTypeOrdering true` shape the conformance cache generator uses). 33 rows, tsz built from `b7e05e6` before and after. **9 rows fixed toward tsc, 0 moved away; all 33 now match the oracle exactly.**

| # | row | tsc | tsz before | tsz after |
| --- | --- | --- | --- | --- |
| 1 | `{ export * from "nope"; }` | TS1233 | TS1233 **TS2307** | TS1233 |
| 2 | `if (true) { export * from "nope"; }` | TS1233 | TS1233 **TS2307** | TS1233 |
| 3 | `for (;;) { export * from "nope"; }` | TS1233 | TS1233 **TS2307** | TS1233 |
| 4 | `while (true) { export * from "nope"; }` | TS1233 | TS1233 **TS2307** | TS1233 |
| 5 | `try { export * from "nope"; } catch {}` | TS1233 | TS1233 **TS2307** | TS1233 |
| 6 | `{ { export * from "nope"; } }` | TS1233 | TS1233 **TS2307** | TS1233 |
| 7 | `{ export * as ns from "nope"; }` | TS1233 | TS1233 **TS2307** | TS1233 |
| 8 | `export {}; { export * as ns from "nope"; }` | TS1233 | TS1233 **TS2307** | TS1233 |
| 9 | `export {}; { export { b } from "nope"; }` | TS1233 | TS1233 **TS2307** | TS1233 |
| 10 | `export {}; { export * from "nope"; }` | TS1233 TS2307 | TS1233 TS2307 | unchanged — **the discriminator** |
| 11 | `export {}; if (true) { export * from "nope"; }` | TS1233 TS2307 | TS1233 TS2307 | unchanged |
| 12 | `export const q = 1; { export * from "nope"; }` | TS1233 TS2307 | TS1233 TS2307 | unchanged — a different module indicator |
| 13 | `import "side"; { export * from "nope"; }` | TS2882 TS1233 TS2307 | same | unchanged |
| 14 | `{ export { b } from "nope"; }` | TS1233 TS2307 | TS1233 TS2307 | unchanged — **the inversion** |
| 15 | `if (true) { export { b } from "nope"; }` | TS1233 TS2307 | TS1233 TS2307 | unchanged |
| 16 | `for (;;) { export { b } from "nope"; }` | TS1233 TS2307 | TS1233 TS2307 | unchanged |
| 17 | `declare module "amb" {…} { export { b } from "amb"; }` | TS1233 TS2305 | TS1233 TS2305 | unchanged — resolvable specifier |
| 18 | `{ declare module "amb" {…} export { b } from "amb"; }` | TS1234 TS1233 TS2305 | same | unchanged — the fixture's shape |
| 19 | `declare module "amb" {…} { export { a } from "amb"; }` | TS1233 | TS1233 | unchanged |
| 20 | `{ declare module "amb" {} export * from "amb"; }` | TS1234 TS1233 | TS1234 TS1233 | unchanged |
| 21 | `declare module "amb" {} { export * from "amb"; }` | TS1233 | TS1233 | unchanged |
| 22 | `{ export * from "nope"; export { b } from "nope2"; }` | TS1233 ×2 TS2307 | same | unchanged — both forms, one block |
| 23 | `export {}; { export * from "nope"; export { b } from "nope2"; }` | TS1233 ×2 TS2307 | same | unchanged — inverted, same block |
| 24 | `function f() { export * from "nope"; }` | TS1233 | TS1233 | unchanged |
| 25 | `function f() { export { b } from "nope"; }` | TS1233 | TS1233 | unchanged |
| 26 | `class C { m() { export { b } from "nope"; } }` | TS1233 | TS1233 | unchanged |
| 27 | `export {}; function f() { export * from "nope"; }` | TS1233 | TS1233 | unchanged — scope beats module-ness |
| 28 | `export {}; class C { static { export * from "nope"; } }` | TS1233 | TS1233 | unchanged |
| 29 | `namespace N { export * from "nope"; }` | TS1194 | TS1194 | unchanged |
| 30 | `export * from "nope";` (valid position, control) | TS2307 | TS2307 | unchanged |
| 31 | `{ import { a } from "nope"; }` (negative control) | TS1232 TS2307 | TS1232 TS2307 | unchanged |
| 32 | `{ import x = require("nope"); }` (negative control) | TS1232 TS2307 | TS1232 TS2307 | unchanged |
| 33 | `declare module "amb" {…} { import { b } from "amb"; }` | TS1232 TS2305 | TS1232 TS2305 | unchanged |

**The hazard fixture from #16495 is unchanged, and by construction rather than by luck.** `compiler/moduleElementsInWrongContext.ts` is one top-level bare block with no top-level module indicator, so it is a *script*. Its two TS2305 come from `export { baz as b } from "ambient"` and `import { baz } from "ambient"` — a named clause in a script, which this rule keeps resolving — and its single TS2307 comes from `import I2 = require("foo")`, the import side. #16409's flat suppression killed the export-side TS2305 and that is why it measured `NEWLY FAILING (1)`. Oracle and tsz agree row for row after this diff:

```
tsc:  2×TS1184  1×TS1231  6×TS1232  3×TS1233  1×TS1234  3×TS1235  1×TS1258  2×TS2305  1×TS2307
tsz:  2×TS1184  1×TS1231  6×TS1232  3×TS1233  1×TS1234  3×TS1235  1×TS1258  2×TS2305  1×TS2307
```

- `cargo test -p tsz-checker --lib position_invalid_export_specifier` — **40 passed, 0 failed** (24 pre-existing rows unchanged, 16 new). The 6 pre-existing top-level-block controls all use a *named* clause in a script and therefore keep asserting TS1233 + TS2307; they pass untouched, which is itself evidence the gate is scoped to the right form.
- `cargo fmt --all` clean; `cargo clippy -p tsz-checker --all-targets --all-features -- -D warnings` **EXIT=0**; architecture guard passed (pre-commit).
- `scripts/conformance/compare-to-parent.sh origin/main` — **running**, two-sided against `b7e05e6`. The number will be posted as a PR comment before this is queued; per #16495 this gate is mandatory for this diff shape and the PR should not land without it.

### Stale control corrected

The suite header claimed the top-level-block family was left alone because `typescript@7.0.2`'s two threading modes disagree on it (#16413). They do not disagree — that was an artifact of comparing against a bare `tsc` invocation, which is exactly what `oracle.sh` was built to prevent, and #16413 is settled. The header now records the real rule and every row is oracle-measured through the wrapper.

### Adjacent divergence found, not fixed here

The **import** side has the same module-ness inversion and is still wrong on it:

```
{ import { a } from "nope"; }                 tsc: TS1232 + TS2307   tsz: TS1232 + TS2307   ok
export {}; { import { a } from "nope"; }      tsc: TS1232 alone      tsz: TS1232 + TS2307   spurious
```

Deliberately out of scope: touching the import gate is precisely the generalisation that sank #16409 and #16411's draft, and it deserves its own oracle sweep over the `import`/`import =`/side-effect-import forms rather than being folded in behind this diff's evidence. Filed separately.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Kyanite

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6w8ouK44GVZRPL3edtL3U)_