### PR TITLE
fix(checker): a default-exported namespace/enum keeps its namespace meaning through a default import

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2665,3 +2665,7 @@ path = "tests/import_equals_alias_duplicate_container_tests.rs"
 [[test]]
 name = "import_equals_alias_duplicate_function_container_tests"
 path = "tests/import_equals_alias_duplicate_function_container_tests.rs"
+
+[[test]]
+name = "ts16486_default_export_namespace_meaning_regression_tests"
+path = "tests/ts16486_default_export_namespace_meaning_regression_tests.rs"

--- a/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
+++ b/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
@@ -230,7 +230,31 @@ impl<'a> CheckerState<'a> {
                                     self.ctx.resolve_import_alias_and_register(local_id)?;
                                 let target =
                                     self.get_symbol_from_registered_file_target(target_id)?;
-                                Some(target.has_any_flags(valid_namespace_flags))
+                                if target.has_any_flags(valid_namespace_flags) {
+                                    return Some(true);
+                                }
+                                // `export default <identifier>` (e.g. `export
+                                // default m;` re-exporting a namespace/enum
+                                // `m`) synthesizes a fresh "default" ALIAS
+                                // symbol whose own flags never carry the
+                                // referenced declaration's meaning — only its
+                                // identifier-reference declaration does. This
+                                // is distinct from an actual cross-file import
+                                // alias (which does carry `import_module()`),
+                                // so follow the synthetic default's own
+                                // identifier-reference declaration one more
+                                // hop before concluding "no namespace
+                                // meaning".
+                                if target.has_any_flags(symbol_flags::ALIAS)
+                                    && target.import_module().is_none()
+                                    && let Some(referenced_id) =
+                                        self.default_export_identifier_target(target_id)
+                                    && let Some(referenced) =
+                                        self.get_symbol_from_registered_file_target(referenced_id)
+                                {
+                                    return Some(referenced.has_any_flags(valid_namespace_flags));
+                                }
+                                Some(false)
                             };
                         let alias_target_lacks_namespace_meaning = is_alias
                             && resolve_import_target_has_namespace_meaning(&left_name)

--- a/crates/tsz-checker/tests/ts16486_default_export_namespace_meaning_regression_tests.rs
+++ b/crates/tsz-checker/tests/ts16486_default_export_namespace_meaning_regression_tests.rs
@@ -1,0 +1,153 @@
+//! Regression probe for #16486: `export default <namespace>` / `export
+//! default <enum>` lost their namespace meaning after #16480.
+//!
+//! Structural rule: `resolve_qualified_name`'s TS2702/TS2713 gate
+//! (`crates/tsz-checker/src/state/type_analysis/qualified_names.rs`) asks a
+//! default import's *target* for namespace meaning through
+//! `resolve_import_target_has_namespace_meaning`. For `export default m;`
+//! re-exporting a namespace/enum `m`, the binder's synthetic "default" ALIAS
+//! symbol carries none of the referenced declaration's flags itself -- only
+//! its identifier-reference declaration does -- so the gate must chase one
+//! more hop (`default_export_identifier_target`) before concluding "no
+//! namespace meaning". #16480 introduced the target-namespace-meaning check
+//! without that hop, so a default-exported namespace/enum was wrongly
+//! treated as namespace-less and every qualified access through it became a
+//! spurious TS2702.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_multi_file_with_libs_stamped, load_lib_files};
+use tsz_common::common::ModuleKind;
+use tsz_common::diagnostics::Diagnostic;
+
+fn strict_options() -> CheckerOptions {
+    CheckerOptions {
+        module: ModuleKind::CommonJS,
+        strict: true,
+        ..CheckerOptions::default()
+    }
+}
+
+fn check(files: &[(&str, &str)], entry: &str) -> Vec<Diagnostic> {
+    let libs = load_lib_files(&["lib.es5.d.ts"]);
+    check_multi_file_with_libs_stamped(files, entry, strict_options(), &libs)
+}
+
+fn codes(files: &[(&str, &str)], entry: &str) -> Vec<u32> {
+    check(files, entry).into_iter().map(|d| d.code).collect()
+}
+
+/// The reported regression: a present member through a default-exported
+/// namespace must resolve cleanly, never TS2702.
+#[test]
+fn export_default_namespace_keeps_namespace_meaning() {
+    assert_eq!(
+        codes(
+            &[
+                (
+                    "/dep.ts",
+                    "namespace m { export interface foo { a: number } }\nexport default m;\n"
+                ),
+                ("/main.ts", "import D from \"./dep\";\nvar q: D.foo;\n"),
+            ],
+            "/main.ts",
+        ),
+        Vec::<u32>::new(),
+        "tsc resolves D.foo cleanly"
+    );
+}
+
+/// Renamed-binder / different-declaration-kind adjacent case: a
+/// default-exported *enum* (not namespace) member access through a renamed
+/// import binding.
+///
+/// Known residual, tracked in #16499: the member-lookup path
+/// (`resolve_symbol_export_for`/`left_sym_for_missing` in
+/// `resolve_qualified_name`) reads the *un-followed* default-import alias
+/// symbol for its own namespace flags, which is exactly the gap this PR's
+/// TS2702 gate fix chases through -- but that chase lives only in the gate,
+/// not in the member-lookup path, so an enum member access (present or
+/// missing) through a default import still misfires here. This pins today's
+/// behavior rather than leaving it to drift while #16499 is open; the point
+/// of this test is that it is NOT TS2702 (this PR's actual fix).
+#[test]
+fn export_default_enum_member_access_through_default_import_is_never_ts2702() {
+    let codes = codes(
+        &[
+            (
+                "/e2.ts",
+                "enum Color2 { Red, Green }\nexport default Color2;\n",
+            ),
+            (
+                "/main3.ts",
+                "import Palette from \"./e2\";\nvar ok: Palette.Red;\n",
+            ),
+        ],
+        "/main3.ts",
+    );
+    assert!(
+        !codes.contains(&2702),
+        "a present member of a default-exported enum must not be TS2702, got: {codes:?}"
+    );
+    assert_eq!(
+        codes,
+        vec![2503],
+        "known residual tracked in #16499, got: {codes:?}"
+    );
+}
+
+/// A default-exported *class* (no merge partner) still has no namespace
+/// meaning -- this must NOT regress to TS2694/clean just because the
+/// identifier-hop above now exists. Negative control for the fix's scope.
+#[test]
+fn export_default_class_keeps_no_namespace_meaning() {
+    assert_eq!(
+        codes(
+            &[
+                ("/cls.ts", "export default class Widget {}\n"),
+                (
+                    "/main4.ts",
+                    "import W from \"./cls\";\nvar a: W.NotAMember;\n"
+                ),
+            ],
+            "/main4.ts",
+        ),
+        vec![2702],
+        "a default-exported class keeps reporting TS2702, unaffected by the namespace/enum hop"
+    );
+}
+
+/// The missing-member half of the regression: a missing member on a
+/// default-exported enum must never surface as TS2702 ("used as a
+/// namespace") -- the enum *has* namespace meaning, so a miss is a
+/// member-lookup failure, not a meaning failure.
+///
+/// Known residual, tracked in #16499: tsz currently reports TS2503 ("cannot
+/// find namespace") here instead of tsc's TS2694 ("no exported member") --
+/// `left_sym_for_missing`'s namespace-flags gate in `resolve_qualified_name`
+/// reads the *un-followed* default-import alias symbol, which does not itself
+/// carry the enum's flags either. This assertion pins today's behavior (never
+/// TS2702) without claiming full parity on the exact code.
+#[test]
+fn valid_namespace_member_through_default_namespace_import_is_never_ts2702() {
+    let codes = codes(
+        &[
+            (
+                "/e.ts",
+                "enum Color { Red, Green }\nexport default Color;\n",
+            ),
+            ("/main2.ts", "import C from \"./e\";\nvar bad: C.Nope;\n"),
+        ],
+        "/main2.ts",
+    );
+    assert!(
+        !codes.contains(&2702),
+        "a missing member of a default-exported enum must not be TS2702, got: {codes:?}"
+    );
+    // Pin the current (not-yet-parity) shape so this doesn't silently drift
+    // further from tsc while #16499 is open.
+    assert_eq!(
+        codes,
+        vec![2503],
+        "known residual tracked in #16499, got: {codes:?}"
+    );
+}


### PR DESCRIPTION
`export default m;` / `export default E;` re-exporting a namespace/enum
carries namespace meaning in tsc — a present member resolves cleanly and a
missing member is `TS2694`, never `TS2702`. #16480 introduced a
target-namespace-meaning check in the qualified-name `TS2702`/`TS2713` gate
that read the binder's synthetic `"default"` ALIAS symbol's *own* flags
directly. That symbol never carries the referenced declaration's meaning —
only its identifier-reference declaration does — so a default-exported
namespace/enum was wrongly judged namespace-less and every qualified access
through it (`D.foo`) became a spurious `TS2702`.

**Structural rule.** When a default import's target is itself a same-file
`ALIAS` symbol with no `import_module()` (the synthetic
`export default <identifier>` shape, as opposed to an actual cross-file
import alias), tsc resolves the *referenced declaration*'s own meaning; tsz
now does the same through the checker's qualified-name gate
(`crates/tsz-checker/src/state/type_analysis/qualified_names.rs`), by
chasing one more hop via the existing `default_export_identifier_target`
helper (already used elsewhere for the identical synthetic-symbol shape)
before concluding "no namespace meaning".

## Adjacent cases (new test file)

- `export_default_namespace_keeps_namespace_meaning` — the reported
  regression: a present member through a default-exported namespace resolves
  cleanly.
- `export_default_class_keeps_no_namespace_meaning` — negative control: a
  default-exported class (no merge partner) keeps reporting `TS2702`,
  unaffected by the namespace/enum hop.
- `export_default_enum_member_access_through_default_import_is_never_ts2702`
  and `valid_namespace_member_through_default_namespace_import_is_never_ts2702`
  — a default-exported *enum*'s present/missing member access is never
  `TS2702` (this PR's fix), though the exact diagnostic code on those two
  rows is a narrower, pre-existing residual in a different code path
  (member-lookup, not the TS2702 gate) — filed as #16499 rather than folded
  into this diff, since it needs a different owner site
  (`resolve_symbol_export_for`/`resolve_alias_import_member`) and carries its
  own regression risk.

## Goal
Goal: hold

## Verification
- New suite `crates/tsz-checker/tests/ts16486_default_export_namespace_meaning_regression_tests.rs`
  (4 cases) — `cargo test -p tsz-checker --test ts16486_default_export_namespace_meaning_regression_tests`:
  4 passed, 0 failed.
- Pre-existing family suites, unaffected: `cargo test -p tsz-checker --lib ts2702_qualifier_namespace_meaning`
  (15 passed), `--lib qualified_name` (5 passed), `--lib default_export` (4
  passed), `--lib import_alias` (7 passed) — 0 failed, 0 regressions across
  all four.
- `cargo fmt --all -- --check` clean.
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`
  clean.
- `scripts/architecture-check.sh`: 0 LOC violations, 0 cross-layer-import
  violations (the `nextest` step itself fails only because `cargo-nextest`
  is absent in this container — a known environment gap, not from this
  change).
- Diagnostic-code-only, single-file production diff
  (`crates/tsz-checker/src/state/type_analysis/qualified_names.rs`, +25/-1);
  no lib-general-purpose paths touched. `compare-to-parent.sh` /
  `conformance.sh` not run this session — the two repro shapes require the
  lib-stamped multi-file harness to reproduce at all (per the issue, the CLI
  cannot see this), so I don't expect this to move the corpus-snapshot
  fingerprint tally, but that is not independently confirmed here.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: Jadeite


---
_Generated by [Claude Code](https://claude.ai/code/session_01SKpHrVyhfFYa92EraUrh88)_