### PR TITLE
fix(solver): weak-type check reads declared properties, not a synthetic call/apply stand-in

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2662,3 +2662,7 @@ path = "tests/import_equals_alias_duplicate_container_tests.rs"
 [[test]]
 name = "import_equals_alias_duplicate_function_container_tests"
 path = "tests/import_equals_alias_duplicate_function_container_tests.rs"
+
+[[test]]
+name = "weak_type_function_declared_property_tests"
+path = "tests/weak_type_function_declared_property_tests.rs"

--- a/crates/tsz-checker/tests/weak_type_function_declared_property_tests.rs
+++ b/crates/tsz-checker/tests/weak_type_function_declared_property_tests.rs
@@ -1,0 +1,190 @@
+//! Regression for #16485: a weak (all-optional) object target named `call`
+//! wrongly accepted a bare function source that `tsc` rejects with TS2559;
+//! `apply` and every other name already rejected correctly.
+//!
+//! Root cause, two independent bugs stacked in the same "lawyer" (Compat)
+//! weak-type gate (`CompatChecker::violates_weak_type`,
+//! `crates/tsz-solver/src/relations/compat_weak.rs`):
+//!
+//! 1. **Structural rule.** `tsc`'s weak-type rule scans the source's own
+//!    *declared* properties (`getPropertiesOfType`) — empty for a bare
+//!    function or a callable value with no declared members — never its
+//!    apparent type. tsz instead synthesized `call`/`apply` (and `prototype`
+//!    for a constructor) as stand-in "declared" properties
+//!    (`function_like_weak_type_properties`, `crates/tsz-solver/src/relations/compat.rs`),
+//!    so a weak target that happened to name one of those two members always
+//!    read as "shares a name" and skipped the rejection tsc always reports.
+//! 2. Once (1) is fixed by using real declared properties, the synthesized
+//!    set is no longer available to trigger the rule when a source has a
+//!    call/construct signature but zero declared properties (a bare
+//!    function's declared-property list is empty, which would otherwise read
+//!    as "nothing to compare" and vacuously pass). `weak_type_source_properties`
+//!    now threads that trigger through as an explicit
+//!    `has_call_or_construct_signature` flag instead of folding it into the
+//!    property list, mirroring tsc's
+//!    `getPropertiesOfType(source).length > 0 || typeHasCallOrConstructSignatures(source)`.
+//!
+//! Separately, `crate::utils::has_common_property_name`'s merge-scan requires
+//! both property slices sorted by `Atom`; the old synthesized-name path
+//! appended `call` then `apply` in call order (not `Atom` order), which is
+//! *why* only one of the two names manifested as broken — an unsorted merge
+//! scan can walk past a real match depending on interning order. The fix
+//! removes the unsorted synthetic list entirely rather than patching its
+//! sort order.
+//!
+//! Rows pinned against `typescript@7.0.2`
+//! (`--noEmit --strict --lib es2022 --target es2022`).
+
+use tsz_checker::CheckerOptions;
+use tsz_checker::test_utils::{
+    check_source_with_libs_code_messages, has_diagnostic_code, load_default_lib_files,
+};
+
+fn get_diagnostics(source: &str) -> Vec<(u32, String)> {
+    let libs = load_default_lib_files();
+    check_source_with_libs_code_messages(source, "test.ts", CheckerOptions::default(), &libs)
+}
+
+fn has_ts2559(source: &str) -> bool {
+    has_diagnostic_code(&get_diagnostics(source), 2559)
+}
+
+fn is_clean(source: &str) -> bool {
+    get_diagnostics(source).is_empty()
+}
+
+#[test]
+fn bare_function_source_weak_target_named_call_reports_ts2559() {
+    // The exact #16485 repro: only `call` was wrongly accepted.
+    assert!(has_ts2559("var w4: { call?: any } = () => {};"));
+}
+
+#[test]
+fn bare_function_source_weak_target_named_apply_reports_ts2559() {
+    // Control: already correct before the fix, must stay correct after.
+    assert!(has_ts2559("var w6: { apply?: any } = () => {};"));
+}
+
+#[test]
+fn bare_function_source_weak_target_named_zzz_reports_ts2559() {
+    // Control: unrelated name, already correct.
+    assert!(has_ts2559("var w7: { zzz?: any } = () => {};"));
+}
+
+#[test]
+fn bare_function_source_weak_target_named_bind_reports_ts2559() {
+    assert!(has_ts2559("var w: { bind?: any } = () => {};"));
+}
+
+#[test]
+fn named_function_declaration_weak_target_named_call_reports_ts2559() {
+    // Renamed binder, declared-function form instead of an arrow literal.
+    assert!(has_ts2559(
+        r#"
+function producer() {}
+var w: { call?: any } = producer;
+"#
+    ));
+}
+
+#[test]
+fn class_constructor_weak_target_named_call_reports_ts2560() {
+    // A class constructor is call/construct-signature-like too; its own
+    // declared static members do not include `call`. tsc reports the
+    // constructible-value variant of this rule, TS2560 ("Did you mean to
+    // call it?"), not TS2559.
+    assert!(has_diagnostic_code(
+        &get_diagnostics(
+            r#"
+class Widget {}
+var w: { call?: any } = Widget;
+"#
+        ),
+        2560
+    ));
+}
+
+#[test]
+fn callable_interface_with_shared_declared_property_is_not_ts2559() {
+    // Positive control: a callable source that genuinely DECLARES a property
+    // sharing the target's name must not be rejected by the weak rule — the
+    // real per-property type check takes over instead (TS2322 here, since the
+    // types disagree).
+    let diags = get_diagnostics(
+        r#"
+interface HasA { (): void; a: string }
+declare const src: HasA;
+var w: { a?: number } = src;
+"#,
+    );
+    assert!(
+        !diags.iter().any(|(c, _)| *c == 2559),
+        "shared declared property must not trigger TS2559. Got: {diags:#?}"
+    );
+    assert!(
+        diags.iter().any(|(c, _)| *c == 2322),
+        "mismatched property type must still report TS2322. Got: {diags:#?}"
+    );
+}
+
+#[test]
+fn callable_interface_with_shared_declared_property_matching_type_is_clean() {
+    let src = r#"
+interface HasA { (): void; a: string }
+declare const src: HasA;
+var w: { a?: string } = src;
+"#;
+    assert!(is_clean(src), "Got: {:#?}", get_diagnostics(src));
+}
+
+#[test]
+fn callable_interface_without_shared_declared_property_reports_ts2559() {
+    // Negative: the callable source's declared property ("b") does not match
+    // the weak target's ("call"), so tsz must not fall back to treating
+    // `call` as an implicit member of every callable value.
+    assert!(has_ts2559(
+        r#"
+interface HasB { (): void; b: string }
+declare const src: HasB;
+var w: { call?: any } = src;
+"#
+    ));
+}
+
+#[test]
+fn required_call_only_target_still_accepts_a_function_control() {
+    // Regression guard: a *required* single-property target (`{ call(x: any): any }`)
+    // takes a different dispatcher bridge, unaffected by the weak-type fix.
+    assert!(is_clean(
+        r#"
+declare var target: { call(x: any): any };
+declare var source: (x: any) => void;
+target = source;
+"#
+    ));
+}
+
+#[test]
+fn intersection_member_weak_suppression_still_accepts_a_function_control() {
+    // Regression guard: `in_intersection_member_check` suppression (a
+    // different code path, `crates/tsz-solver/src/relations/subtype/rules/objects.rs`)
+    // must keep accepting a function as a member of an intersection whose
+    // other member is a weak object.
+    let src = r#"
+declare var value: (() => void) & { brand?: number };
+var i: (() => void) & { brand?: number } = value;
+"#;
+    assert!(is_clean(src), "Got: {:#?}", get_diagnostics(src));
+}
+
+#[test]
+fn genuine_weak_object_source_still_reports_ts2559_control() {
+    // Regression guard: a non-function weak-vs-weak mismatch is untouched.
+    assert!(has_ts2559(
+        r#"
+interface Weak { a?: 1; b?: 2 }
+declare const noCommon: { z: 3 };
+const wk: Weak = noCommon;
+"#
+    ));
+}

--- a/crates/tsz-solver/src/relations/compat.rs
+++ b/crates/tsz-solver/src/relations/compat.rs
@@ -342,65 +342,41 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         }
     }
 
-    fn function_like_weak_type_properties(
+    /// Declared properties, index-signature presence, and call/construct-signature
+    /// presence of a weak-type-check source. `tsc`'s weak-type rule
+    /// (`isWeakType` + the "no properties in common" scan) reads
+    /// `getPropertiesOfType(source)` — the source's own *declared* members, which
+    /// for a bare function or callable value never include `call`/`apply`/
+    /// `prototype`. Those apparent-type members exist only through the boxed
+    /// `Function` interface, which the weak-type rule never consults; a
+    /// synthesized stand-in here previously let a weak target that happened to
+    /// name `call` or `apply` skip the rejection tsc always reports (#16485).
+    ///
+    /// A source with a call/construct signature but no declared properties still
+    /// has to trigger the rule (its declared-property set alone is empty, which
+    /// would otherwise read as "nothing to compare" and vacuously pass), so that
+    /// case is threaded through as the third tuple element instead of folded into
+    /// the property list.
+    fn weak_type_source_properties(
         &self,
-        mut props: Vec<PropertyInfo>,
-        has_call_signatures: bool,
-        has_construct_signatures: bool,
-    ) -> Vec<PropertyInfo> {
-        let mut ensure_prop = |name: &str| {
-            let atom = self.interner.intern_string(name);
-            if !props.iter().any(|prop| prop.name == atom) {
-                props.push(PropertyInfo::new(atom, TypeId::ANY));
-            }
-        };
-
-        if has_call_signatures {
-            // Function-like values expose Function members even when the callable
-            // shape itself does not materialize them. Weak-type overlap checks need
-            // to see those stable property names so unrelated weak object targets
-            // don't incorrectly accept function/class values.
-            ensure_prop("call");
-            ensure_prop("apply");
-        }
-
-        if has_construct_signatures {
-            ensure_prop("prototype");
-        }
-
-        props
-    }
-
-    fn weak_type_source_properties(&self, source: TypeId) -> Option<(Vec<PropertyInfo>, bool)> {
+        source: TypeId,
+    ) -> Option<(Vec<PropertyInfo>, bool, bool)> {
         if source == TypeId::FUNCTION {
-            return Some((
-                self.function_like_weak_type_properties(Vec::new(), true, false),
-                false,
-            ));
+            return Some((Vec::new(), false, true));
         }
 
         match self.interner.lookup(source) {
             Some(TypeData::Callable(shape_id)) => {
                 let shape = self.interner.callable_shape(shape_id);
-                let props = self.function_like_weak_type_properties(
-                    shape.properties.clone(),
-                    !shape.call_signatures.is_empty(),
-                    !shape.construct_signatures.is_empty(),
-                );
+                let has_call_or_construct =
+                    !shape.call_signatures.is_empty() || !shape.construct_signatures.is_empty();
                 Some((
-                    props,
+                    shape.properties.clone(),
                     shape.string_index.is_some() || shape.number_index.is_some(),
+                    has_call_or_construct,
                 ))
             }
-            Some(TypeData::Function(shape_id)) => {
-                let shape = self.interner.function_shape(shape_id);
-                let props = self.function_like_weak_type_properties(
-                    Vec::new(),
-                    !shape.is_constructor,
-                    shape.is_constructor,
-                );
-                Some((props, false))
-            }
+            Some(TypeData::Function(_)) => Some((Vec::new(), false, true)),
             _ => {
                 let mut extractor = ShapeExtractor::new(self.interner, self.subtype.resolver);
                 let source_shape_id = extractor.extract(source)?;
@@ -410,6 +386,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
                 Some((
                     source_shape.properties.clone(),
                     source_shape.string_index.is_some() || source_shape.number_index.is_some(),
+                    false,
                 ))
             }
         }

--- a/crates/tsz-solver/src/relations/compat_weak.rs
+++ b/crates/tsz-solver/src/relations/compat_weak.rs
@@ -213,7 +213,8 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
             return false;
         }
 
-        let Some((source_props, has_index_signature)) = self.weak_type_source_properties(source)
+        let Some((source_props, has_index_signature, has_call_or_construct)) =
+            self.weak_type_source_properties(source)
         else {
             // No extractable object/function-like shape. For primitive types
             // (string/number/boolean/bigint/symbol literals, enum members, etc.),
@@ -231,8 +232,11 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         }
 
         // Empty objects are assignable to weak types (all optional properties).
-        // Only trigger weak type violation if source has properties that don't overlap.
-        !source_props.is_empty() && !self.has_common_property(source_props.as_slice(), target_props)
+        // A call/construct-signature source (e.g. a bare function) triggers the
+        // rule even with zero declared properties — tsc's `typeHasCallOrConstructSignatures`
+        // half of the trigger, independent of `getPropertiesOfType` being empty.
+        (has_call_or_construct || !source_props.is_empty())
+            && !self.has_common_property(source_props.as_slice(), target_props)
     }
 
     /// Check if a primitive source type violates a weak type target by having
@@ -428,7 +432,8 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         }
 
         // Use visitor for Object types
-        let Some((source_props, has_index_signature)) = self.weak_type_source_properties(source)
+        let Some((source_props, has_index_signature, has_call_or_construct)) =
+            self.weak_type_source_properties(source)
         else {
             // Array/Tuple types are objects but not extractable. They rarely
             // share property names with arbitrary union members, so treat as
@@ -444,7 +449,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
             return false;
         }
 
-        if source_props.is_empty() {
+        if source_props.is_empty() && !has_call_or_construct {
             return false;
         }
 


### PR DESCRIPTION
`{ call?: any }` (and only that name) wrongly accepted a bare function source that `tsc` rejects with TS2559 — `apply` and every other Function member name already rejected correctly. Closes #16485.

**Structural rule.** `tsc`'s weak-type rule (`isWeakType` + the "no properties in common" scan) reads `getPropertiesOfType(source)` — the source's own *declared* members, which is empty for a bare function or a callable value with no declared properties. tsz instead synthesized `call`/`apply` (and `prototype` for a constructor) into that property list (`function_like_weak_type_properties`, `crates/tsz-solver/src/relations/compat.rs`), so a weak target naming one of those two members always read as "shares a name" and skipped the rejection tsc always reports.

That synthesized list was also unsorted (`call` pushed before `apply` in call order, not `Atom` order), which is why only one of the two names manifested as broken: `crate::utils::has_common_property_name`'s merge-scan requires both property slices sorted by `Atom`, and an unsorted scan can walk past a real match depending on interning order — confirmed by tracing both cases (`crates/tsz-solver/src/relations/compat_weak.rs`) and reading the actual `Atom` comparisons rather than guessing.

**Fix.** `weak_type_source_properties` now returns the source's real declared properties (empty for a bare function/constructor, the callable shape's own `properties` otherwise) plus a separate `has_call_or_construct` flag, so a call/construct-signature source with zero declared properties still triggers the rule — mirroring tsc's `getPropertiesOfType(source).length > 0 || typeHasCallOrConstructSignatures(source)` — instead of relying on a non-empty synthetic list to do both jobs (triggering the rule *and* supplying the names to match) at once.

**Adjacent-case matrix** (12 rows, `crates/tsz-checker/tests/weak_type_function_declared_property_tests.rs`): every Function member name (`call`, `apply`, `bind`, `zzz`) against a bare function and a named function declaration; a class constructor (TS2560, tsc's constructible-value variant of the same rule — not TS2559); a callable interface that genuinely declares a shared property (must NOT reject, with a positive and a mismatched-type control); a callable interface with no shared declared property (must still reject); and three regression controls for adjacent code paths this diff does not touch: the required-single-property bridge (`{ call(x: any): any }`), intersection-member weak suppression, and a genuine non-function weak-vs-weak mismatch.

Left out of scope: a union of two weak object types (`{ call?: any } | { apply?: any }`) rejecting a function source now correctly rejects (previously silently accepted on `main`), but with TS2559 where tsc reports a plain TS2322. That's a pre-existing diagnostic-code-selection nuance in the union path (`violates_weak_union`), independent of this bug, and out of scope here — it's a strict improvement either way (was completely unrejected before).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test weak_type_function_declared_property_tests` — 12/12
- `cargo test -p tsz-checker --test weak_callable_target_assignability_tests` — 6/6 (unaffected)
- `cargo test -p tsz-checker --lib function_source_apparent_function_surface_tests` — 22/22 (unaffected)
- `cargo test -p tsz-checker --lib` (minus the pre-existing long-tail `recursive_conditional_alias_omitted_default_transform_emits_definition_ts2589`, unrelated to this change, a known board gotcha) — 9790/9790, 0 failed
- `cargo clippy -p tsz-solver -p tsz-checker --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `scripts/arch/arch_guard.py` — passed
- All 12 new rows independently cross-checked against `typescript@7.0.2` (`--noEmit --strict --lib es2022 --target es2022`)
- `compare-to-parent.sh` — not run; this is a solver-internal fix behind `CompatChecker::is_assignable_impl`'s early weak-type gate with no lib/corpus dependency (repro needs no lib types beyond bare functions/classes/interfaces), so a targeted oracle-pinned matrix is the primary evidence per the board's standing note on this class of change (zero-movement is the expected signature, not a detector). A reviewer with the corpus checked out should still run it.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_01RRSGz34ghenvqSuvMfJ756)_