### PR TITLE
fix(solver): union display collapses constituents on type identity, not on rendered text

### DIFF
--- a/crates/tsz-solver/src/diagnostics/format/compound/union_display.rs
+++ b/crates/tsz-solver/src/diagnostics/format/compound/union_display.rs
@@ -394,13 +394,14 @@ impl<'a> TypeFormatter<'a> {
         // tsc shows `Foo.Yep | Bar.Yep` instead of `Yep | Yep` when two different
         // types share the same name in different namespaces.
         let disambiguated = self.disambiguate_union_member_names(&ordered, formatted);
-        // If qualification couldn't break a tie (or slots were already
-        // identical), tsc collapses the duplicates to a single member.
-        // Mirror that — `Symbol | Symbol` should display as just `Symbol`.
+        // Collapse constituents that are the SAME TYPE, keyed on identity —
+        // never on the rendered string. See
+        // [`Self::union_member_display_identity`].
         let mut deduped: Vec<String> = Vec::with_capacity(disambiguated.len());
-        let mut seen: rustc_hash::FxHashSet<String> = rustc_hash::FxHashSet::default();
-        for name in disambiguated {
-            if seen.insert(name.clone()) {
+        let mut seen: rustc_hash::FxHashSet<UnionMemberDisplayIdentity> =
+            rustc_hash::FxHashSet::default();
+        for (&member, name) in ordered.iter().zip(disambiguated) {
+            if seen.insert(self.union_member_display_identity(member)) {
                 deduped.push(name);
             }
         }
@@ -1207,4 +1208,55 @@ impl<'a> TypeFormatter<'a> {
         let qualified = self.namespace_qualify_symbol_name(sym_id, base);
         Some(format!("import(\"{specifier}\").{qualified}"))
     }
+
+    /// The identity `tsc` collapses union constituents on.
+    ///
+    /// `tsc` never dedupes while printing: `typeToString` walks the union's
+    /// `types` array verbatim. Duplicates are removed once, at *construction*,
+    /// keyed on type identity. So by the time a union is printed, two handles
+    /// to one declaration (`Symbol | Symbol`) are already a single
+    /// constituent, while two separate type-literal declarations
+    /// (`{ m: number } | { m: number }`) are two distinct types and both
+    /// print. Keying the collapse on the formatted string cannot tell those
+    /// apart — and a printer-output predicate must not drive a display
+    /// decision in the first place.
+    ///
+    /// A constituent that names a declaration keys on that declaration's
+    /// `SymbolId`, which every handle to it shares regardless of whether this
+    /// slot is still a `Lazy(DefId)` or an already-resolved shape. Everything
+    /// else — anonymous object types, literals, intrinsics — keys on its own
+    /// `TypeId`, which is what interning already made canonical for it.
+    fn union_member_display_identity(&self, type_id: TypeId) -> UnionMemberDisplayIdentity {
+        match self.union_member_declaration_symbol(type_id) {
+            Some(sym_id) => UnionMemberDisplayIdentity::Declaration(sym_id.0),
+            None => UnionMemberDisplayIdentity::Anonymous(type_id.0),
+        }
+    }
+
+    /// The declaring symbol a union constituent names, when it names one.
+    ///
+    /// Deliberately narrower than [`Self::primary_symbol_for_type`], which
+    /// also falls back to `find_def_by_shape` — a *content* lookup that maps
+    /// two structurally identical anonymous type literals onto one def, which
+    /// is exactly the collapse this identity must not make.
+    fn union_member_declaration_symbol(&self, type_id: TypeId) -> Option<SymbolId> {
+        if let Some(shape) = crate::type_queries::get_object_shape(self.interner, type_id)
+            && let Some(sym_id) = shape.symbol
+        {
+            return Some(sym_id);
+        }
+        let def_store = self.def_store?;
+        let def_id = crate::type_queries::get_lazy_def_id(self.interner, type_id)
+            .or_else(|| crate::type_queries::get_enum_def_id(self.interner, type_id))?;
+        def_store.get(def_id)?.symbol_id.map(SymbolId)
+    }
+}
+
+/// Identity key produced by [`TypeFormatter::union_member_display_identity`].
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+enum UnionMemberDisplayIdentity {
+    /// A constituent that names a declaration, keyed on its `SymbolId`.
+    Declaration(u32),
+    /// Anything else, keyed on the constituent's own `TypeId`.
+    Anonymous(u32),
 }

--- a/crates/tsz-solver/tests/diagnostics_tests.rs
+++ b/crates/tsz-solver/tests/diagnostics_tests.rs
@@ -134,6 +134,113 @@ fn test_format_union_type() {
     assert!(formatted.contains(" | "));
 }
 
+/// Helper for the union-display identity tests: a user-origin type parameter
+/// named `name`, distinguished from its siblings only by `constraint`. Two of
+/// these are two different types that render the same text.
+fn distinct_type_param(interner: &TypeInterner, name: &str, constraint: TypeId) -> TypeId {
+    interner.type_param(TypeParamInfo {
+        name: interner.intern_string(name),
+        constraint: Some(constraint),
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    })
+}
+
+/// `tsc` never dedupes while printing a union: `typeToString` walks the
+/// `types` array verbatim, and duplicates were already removed at
+/// construction, keyed on type identity. So two *different* types that render
+/// the same text both print.
+///
+/// Verified against `typescript@7.0.2` (`--singleThreaded --stableTypeOrdering
+/// true`) with a shadowed binder — an outer `<T>` unioned with an inner `<T>`
+/// reports `Type 'T | T' is not assignable to type 'boolean'.`
+///
+/// Keying the collapse on the formatted string instead cannot tell two
+/// distinct declarations apart from two handles to one declaration.
+#[test]
+fn union_display_keeps_distinct_type_params_that_render_the_same() {
+    let interner = TypeInterner::new();
+    let mut formatter = TypeFormatter::new(&interner);
+
+    let outer = distinct_type_param(&interner, "T", TypeId::STRING);
+    let inner = distinct_type_param(&interner, "T", TypeId::NUMBER);
+    assert_ne!(
+        outer, inner,
+        "the two type parameters must be distinct types"
+    );
+
+    let union = interner.union_preserve_members(vec![outer, inner]);
+    assert_eq!(formatter.format(union), "T | T");
+}
+
+/// The binder name is not what makes the two constituents distinct — rename
+/// both and the same pair still prints twice.
+#[test]
+fn union_display_keeps_distinct_type_params_under_a_renamed_binder() {
+    let interner = TypeInterner::new();
+    let mut formatter = TypeFormatter::new(&interner);
+
+    let outer = distinct_type_param(&interner, "Elem", TypeId::STRING);
+    let inner = distinct_type_param(&interner, "Elem", TypeId::NUMBER);
+
+    let union = interner.union_preserve_members(vec![outer, inner]);
+    assert_eq!(formatter.format(union), "Elem | Elem");
+}
+
+/// Three shadowing levels of one binder name print three constituents, not one.
+#[test]
+fn union_display_keeps_three_distinct_type_params_that_render_the_same() {
+    let interner = TypeInterner::new();
+    let mut formatter = TypeFormatter::new(&interner);
+
+    let a = distinct_type_param(&interner, "T", TypeId::STRING);
+    let b = distinct_type_param(&interner, "T", TypeId::NUMBER);
+    let c = distinct_type_param(&interner, "T", TypeId::BOOLEAN);
+
+    let union = interner.union_preserve_members(vec![a, b, c]);
+    assert_eq!(formatter.format(union), "T | T | T");
+}
+
+/// Negative control: ONE type parameter listed twice is one type, so it prints
+/// once — this is the collapse the identity key must keep making. `tsc` agrees
+/// (`function r4<T>(a: T, b: T)` unions to `T`, not `T | T`).
+#[test]
+fn union_display_collapses_one_type_param_listed_twice() {
+    let interner = TypeInterner::new();
+    let mut formatter = TypeFormatter::new(&interner);
+
+    let param = distinct_type_param(&interner, "T", TypeId::STRING);
+
+    let union = interner.union_preserve_members(vec![param, param]);
+    assert_eq!(formatter.format(union), "T");
+}
+
+/// Negative control: distinct type parameters with distinct names were never
+/// affected by the collapse and must keep rendering both.
+#[test]
+fn union_display_keeps_distinct_type_params_with_distinct_names() {
+    let interner = TypeInterner::new();
+    let mut formatter = TypeFormatter::new(&interner);
+
+    let t = distinct_type_param(&interner, "T", TypeId::STRING);
+    let u = distinct_type_param(&interner, "U", TypeId::STRING);
+
+    let union = interner.union_preserve_members(vec![t, u]);
+    assert_eq!(formatter.format(union), "T | U");
+}
+
+/// Negative control: one interned intrinsic listed twice stays one member, so
+/// the identity key does not turn every repeated constituent into a duplicate.
+#[test]
+fn union_display_collapses_a_repeated_intrinsic_member() {
+    let interner = TypeInterner::new();
+    let mut formatter = TypeFormatter::new(&interner);
+
+    let union = interner.union_preserve_members(vec![TypeId::STRING, TypeId::STRING]);
+    assert_eq!(formatter.format(union), "string");
+}
+
 #[test]
 fn test_format_array_type() {
     let interner = TypeInterner::new();


### PR DESCRIPTION
**Structural rule.** When a union's constituents are *different types that render the same text*, `tsc` prints them all — `typeToString` walks the union's `types` array verbatim and never dedupes at print time. The collapse happens once, at *construction*, keyed on type identity. So two handles to one declaration (`Symbol | Symbol`) are already a single constituent by the time the union is printed, while two distinct declarations (an outer `<T>` and a shadowing inner `<T>`) are two, and both print. tsz now does the same through the solver's union formatter.

`format_ordered_union_members` (`crates/tsz-solver/src/diagnostics/format/compound/union_display.rs`) deduped the **formatted strings** returned by `disambiguate_union_member_names`. That is a predicate over printer output driving a display decision — the shape `.claude/CLAUDE.md`'s anti-hardcoding gate forbids ("no regex/`contains` over rendered type/printer output"; "the printer may read types; types must not read printer output") — and it cannot tell two distinct declarations apart from two handles to one.

The fix keys the collapse on identity: a constituent that names a declaration keys on that declaration's `SymbolId`, which every handle to it shares regardless of whether the slot is still a `Lazy(DefId)`, an enum def, or an already-resolved shape; everything else keys on its own `TypeId`, which is what interning already made canonical for it. The identity helper is deliberately narrower than the existing `primary_symbol_for_type`, which also falls back to `find_def_by_shape` — a *content* lookup that would map two structurally identical anonymous type literals onto one def, i.e. exactly the collapse this key must not make.

The `Symbol | Symbol` collapse the string dedup was added for (#16432) is preserved, and is now preserved *for the right reason*: same declaration, therefore same key.

### Oracle

`typescript@7.0.2` via `scripts/conformance/oracle.sh` (`--singleThreaded --stableTypeOrdering true`):

```ts
declare function pick<A, B>(a: A, b: B): A | B;
function f<T>(a: T) { function g<T>(b: T) { const u: boolean = pick(a, b); } }
```
```
tsc  error TS2322: Type 'T | T' is not assignable to type 'boolean'.
```

### Adjacent-case matrix

| case | expected | on `main` | with this change |
| --- | --- | --- | --- |
| two distinct type params, same binder name | `T \| T` | `T` ❌ | `T \| T` ✅ |
| same pair under a renamed binder (`Elem`) | `Elem \| Elem` | `Elem` ❌ | `Elem \| Elem` ✅ |
| three shadowing levels of one binder name | `T \| T \| T` | `T` ❌ | `T \| T \| T` ✅ |
| negative: one type param listed twice | `T` | `T` ✅ | `T` ✅ |
| negative: distinct type params, distinct names | `T \| U` | `T \| U` ✅ | `T \| U` ✅ |
| negative: one intrinsic listed twice | `string` | `string` ✅ | `string` ✅ |

Six tests in `crates/tsz-solver/tests/diagnostics_tests.rs`; the three positive rows fail on the unmodified printer and the three negative controls pass on both sides, so the collapse that must keep happening is pinned as tightly as the one that must stop.

### Scope — what this does *not* fix

This is one slice, not all of #16509. #16509's headline row is `declare const a: { m: number } | { m: number }`, and that one does **not** move here: measured on this branch, tsz still prints `{ m: number; }`. Two structurally identical anonymous type literals reach the formatter as a **single-member union** — they are collapsed upstream, at union construction/interning, long before display. So #16509's stated owner ("the printer's union rendering") is only half right: the printer was one collapse, and the identity-canonicalization one behind it (#14344's territory) is the other. Full evidence and the next concrete probe are posted on #16509.

## Goal
Goal: hold

## Verification
- `scripts/conformance/oracle.sh` vs pinned `typescript@7.0.2` — matrix above, 3 rows moved onto tsc, 0 moved away.
- `cargo test -p tsz-solver --lib union_display` — **6/6 pass** on this branch; with only `union_display.rs` reverted (tests kept), **3 passed / 3 failed**, which is the witness that this is a behavior change and not a refactor.
- `cargo test -p tsz-solver --lib` — full solver lib suite, running at time of writing; result posted as a PR comment.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean. `cargo fmt` clean. `arch_guard` clean (pre-commit hook).
- **Owed: the conformance corpus gate.** A message-text change is invisible to a code-set comparison, so `scripts/conformance/compare-to-parent.sh origin/main` is the only suite that can see it. It is running in-container (cold seat: both sides need a `dist-fast` build plus a full snapshot). **This should not land without that number**, and it goes on this PR as a comment before it queues.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Sodalite

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2zKU5KWtpexJuZ4NpkJtL)_