### PR TITLE
fix(checker): a position-invalid import in a top-level block of an external module still resolves its specifier (#16505)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2659,6 +2659,10 @@ name = "position_invalid_import_equals_container_scope_tests"
 path = "tests/position_invalid_import_equals_container_scope_tests.rs"
 
 [[test]]
+name = "position_invalid_import_specifier_resolution_tests"
+path = "tests/position_invalid_import_specifier_resolution_tests.rs"
+
+[[test]]
 name = "import_equals_alias_duplicate_container_tests"
 path = "tests/import_equals_alias_duplicate_container_tests.rs"
 

--- a/crates/tsz-checker/src/declarations/import/context_helpers.rs
+++ b/crates/tsz-checker/src/declarations/import/context_helpers.rs
@@ -334,6 +334,48 @@ impl<'a> CheckerState<'a> {
         true
     }
 
+    /// Whether a position-invalid `import ... from "m"` or `import x =
+    /// require("m")` — already outside a function body and a namespace body,
+    /// i.e. still left in the source file's own scope by
+    /// [`Self::position_invalid_module_element_resolves_specifier`] — still
+    /// resolves its module specifier.
+    ///
+    /// The import side does not share `export ... from`'s per-clause table
+    /// story (#16504): every clause-bearing form (`import { a }`, `import a`,
+    /// `import * as ns`, `import a, { b }`, `import type { a }`, and
+    /// `import x = require(...)`) binds the same way regardless of which
+    /// clause it is, so there is only one axis here — whether the file is an
+    /// external module — not a clause-kind split. `tsc`'s
+    /// `checkImportDeclaration` has already returned at the placement
+    /// diagnostic (TS1232), so whatever still resolves comes from a later
+    /// pass; a script file still runs that pass, an external module's does
+    /// not (measured against the pinned oracle, #16505).
+    ///
+    /// A bare `import "m"` (no clause at all) is the one form that answers
+    /// differently: its resolution diagnostic (TS2882/TS2307) never fires
+    /// outside a declaration scope, in a script or a module alike — the
+    /// opposite of every clause-bearing form.
+    ///
+    /// Deliberately not covered by this predicate, and not by its caller
+    /// either: a plain import nested inside a namespace body's own block
+    /// (`namespace N { { import { a } from "m"; } }`) turns on whether the
+    /// imported binding is later *referenced*, the same discriminator
+    /// `import x = require(...)` already applies through
+    /// `namespace_import_alias_is_referenced` — not on module-ness. tsz has
+    /// no equivalent reference check for the plain-import clause forms yet,
+    /// so that shape is left exactly as it already was rather than folded
+    /// into this predicate; both call sites guard this out via
+    /// `!is_inside_namespace_declaration`.
+    pub(crate) fn position_invalid_import_declaration_resolves_specifier(
+        &self,
+        has_import_clause: bool,
+    ) -> bool {
+        if !has_import_clause {
+            return false;
+        }
+        !self.ctx.is_external_module_file()
+    }
+
     /// Check if a node is inside a module augmentation
     /// (`declare module "string" { ... }`).  Module augmentations have a
     /// `MODULE_DECLARATION` ancestor whose name is a string literal.

--- a/crates/tsz-checker/src/declarations/import/declaration_check_body.rs
+++ b/crates/tsz-checker/src/declarations/import/declaration_check_body.rs
@@ -252,6 +252,24 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
+        // Outside a declaration scope, `checkImportDeclaration` has already
+        // returned at the TS1232 placement diagnostic above; whatever still
+        // resolves comes from a later pass whose reach depends on the
+        // import's own shape and the file's module-ness
+        // (`position_invalid_import_declaration_resolves_specifier`, #16505).
+        // `!is_inside_namespace_declaration` excludes a block nested inside a
+        // namespace body — that shape turns on whether the binding is
+        // referenced, not on module-ness, and is deliberately left alone (see
+        // the helper's doc comment).
+        if in_wrong_context
+            && !self.is_inside_namespace_declaration(stmt_idx)
+            && !self.position_invalid_import_declaration_resolves_specifier(
+                import.import_clause.is_some(),
+            )
+        {
+            return;
+        }
+
         // Extract module specifier data eagerly so direct import diagnostics like
         // TS6137 can run even when unresolved-import reporting is disabled.
         let module_specifier_idx = import.module_specifier;

--- a/crates/tsz-checker/src/declarations/import/equals.rs
+++ b/crates/tsz-checker/src/declarations/import/equals.rs
@@ -842,6 +842,24 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
+        // A bare block, an `if` body and a loop body resolve however the alias is
+        // used, but only in a *script*. The comment above predates this axis:
+        // measured against the pinned oracle (#16505), the same non-declaration-
+        // scope `import x = require(...)` stays silent past TS1232 when the file
+        // is an external module — the same rule
+        // `position_invalid_import_declaration_resolves_specifier` now gives the
+        // plain `import ... from` forms, since neither production's specifier
+        // resolution reaches a later pass once the file already has a module
+        // table. `!inside_namespace` keeps this from overriding the
+        // referenced-alias verdict just above/below, which owns that shape.
+        if in_wrong_context
+            && !self.is_inside_function_body(stmt_idx)
+            && !inside_namespace
+            && !self.position_invalid_import_declaration_resolves_specifier(true)
+        {
+            return;
+        }
+
         if force_module_not_found {
             if !should_emit_module_not_found {
                 return;

--- a/crates/tsz-checker/tests/position_invalid_import_specifier_resolution_tests.rs
+++ b/crates/tsz-checker/tests/position_invalid_import_specifier_resolution_tests.rs
@@ -1,0 +1,344 @@
+//! A position-invalid `import ... from "m"` or `import x = require("m")`
+//! outside a declaration scope resolves its module specifier only when the
+//! file is *not* an external module — the import-side half of #16495's
+//! inversion (#16505), split out once the export side landed in #16504.
+//!
+//! `tsc`'s `checkImportDeclaration` reports the placement diagnostic (TS1232)
+//! and returns, so `resolveExternalModuleName` never runs from that call.
+//! Outside a declaration scope (a bare block, an `if`/loop body — a function
+//! body, a method, a `static { }` block and a namespace body are still
+//! declaration scopes and are unaffected by this file, see
+//! `position_invalid_import_equals_container_scope_tests.rs` and
+//! `import_namespace_ts1147_tests.rs`), what still resolves comes from a
+//! later pass that only exists when the file is *not* an external module.
+//!
+//! Every clause-bearing form (`import { a }`, `import a`, `import * as ns`,
+//! `import a, { b }`, `import type { a }`, and `import x = require(...)`)
+//! shares this one axis; there is no clause-kind split the way `export ...
+//! from` has one (#16504). A side-effect-only `import "m"` is the exception:
+//! its own diagnostic (TS2882/TS2307) never fires outside a declaration
+//! scope, in a script or a module alike.
+//!
+//! Every expectation below is measured against the pinned `typescript@7.0.2`
+//! oracle through `scripts/conformance/oracle.sh`, with
+//! `--strict --lib es2022 --target es2022 --module esnext --moduleResolution
+//! bundler`.
+
+use tsz_binder::BinderState;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::state::CheckerState;
+use tsz_parser::parser::ParserState;
+use tsz_solver::construction::TypeInterner;
+
+/// Check a single source with unresolved-import reporting on, so a module
+/// specifier naming a nonexistent module reports TS2307/TS2882 if it is
+/// resolved at all.
+fn check(source: &str) -> Vec<u32> {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        CheckerOptions {
+            module: tsz_common::common::ModuleKind::ESNext,
+            target: tsz_common::common::ScriptTarget::ESNext,
+            ..CheckerOptions::default()
+        },
+    );
+    checker.ctx.report_unresolved_imports = true;
+    checker.check_source_file(root);
+    let mut codes: Vec<u32> = checker.ctx.diagnostics.iter().map(|d| d.code).collect();
+    codes.sort_unstable();
+    codes
+}
+
+fn assert_codes(source: &str, expected: &[u32], what: &str) {
+    let actual = check(source);
+    assert_eq!(actual, expected, "{what}\nsource:\n{source}");
+}
+
+// ---------------------------------------------------------------------------
+// A script (no module indicator): every form still resolves in a bare block,
+// an `if` body and a loop body — unchanged by this PR.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn named_import_in_a_bare_block_of_a_script_reports_ts2307() {
+    assert_codes(
+        r#"{
+  import { a } from "nonexistent-module";
+}"#,
+        &[1232, 2307],
+        "a script still has no export/import table gate; the named form keeps resolving",
+    );
+}
+
+#[test]
+fn default_import_in_an_if_body_of_a_script_reports_ts2307() {
+    assert_codes(
+        r#"if (true) {
+  import a from "nonexistent-module";
+}"#,
+        &[1232, 2307],
+        "container kind does not matter, only module-ness",
+    );
+}
+
+#[test]
+fn namespace_import_in_a_loop_body_of_a_script_reports_ts2307() {
+    assert_codes(
+        r#"for (;;) {
+  import * as ns from "nonexistent-module";
+}"#,
+        &[1232, 2307],
+        "the namespace-import form takes the same path as the named form on this axis",
+    );
+}
+
+#[test]
+fn default_plus_named_import_in_a_bare_block_of_a_script_reports_ts2307() {
+    assert_codes(
+        r#"{
+  import a, { b } from "nonexistent-module";
+}"#,
+        &[1232, 2307],
+        "combined default+named clause behaves like the plain named clause",
+    );
+}
+
+#[test]
+fn type_only_import_in_a_bare_block_of_a_script_reports_ts2307() {
+    assert_codes(
+        r#"{
+  import type { a } from "nonexistent-module";
+}"#,
+        &[1232, 2307],
+        "a type-only clause is still a clause for this axis",
+    );
+}
+
+#[test]
+fn import_equals_require_in_a_bare_block_of_a_script_reports_ts2307() {
+    assert_codes(
+        r#"{
+  import x = require("nonexistent-module");
+}"#,
+        &[1232, 2307],
+        "import-equals shares the clause-bearing axis, not the export side's own rule",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// THE DISCRIMINATOR: the same forms in an external module report TS1232
+// alone. This is the bug #16505 tracks.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn named_import_in_a_bare_block_of_a_module_reports_ts1232_alone() {
+    assert_codes(
+        r#"export {};
+{
+  import { a } from "nonexistent-module";
+}"#,
+        &[1232],
+        "an external module never reaches a later pass for a position-invalid named import",
+    );
+}
+
+#[test]
+fn default_import_in_an_if_body_of_a_module_reports_ts1232_alone() {
+    assert_codes(
+        r#"export {};
+if (true) {
+  import a from "nonexistent-module";
+}"#,
+        &[1232],
+        "the module-ness axis is independent of which non-declaration container it is",
+    );
+}
+
+#[test]
+fn namespace_import_in_a_loop_body_of_a_module_reports_ts1232_alone() {
+    assert_codes(
+        r#"export {};
+for (;;) {
+  import * as ns from "nonexistent-module";
+}"#,
+        &[1232],
+        "the namespace-import form swaps roles with the export side's own `export * as ns`",
+    );
+}
+
+#[test]
+fn default_plus_named_import_in_a_bare_block_of_a_module_reports_ts1232_alone() {
+    assert_codes(
+        r#"export {};
+{
+  import a, { b } from "nonexistent-module";
+}"#,
+        &[1232],
+        "combined default+named clause behaves like the plain named clause",
+    );
+}
+
+#[test]
+fn type_only_import_in_a_bare_block_of_a_module_reports_ts1232_alone() {
+    assert_codes(
+        r#"export {};
+{
+  import type { a } from "nonexistent-module";
+}"#,
+        &[1232],
+        "a type-only clause is still a clause for this axis",
+    );
+}
+
+#[test]
+fn import_equals_require_in_a_bare_block_of_a_module_reports_ts1232_alone() {
+    assert_codes(
+        r#"export {};
+{
+  import x = require("nonexistent-module");
+}"#,
+        &[1232],
+        "import-equals shares the clause-bearing axis, via its own gate in equals.rs",
+    );
+}
+
+#[test]
+fn a_module_indicator_other_than_export_braces_also_flips_the_named_import() {
+    assert_codes(
+        r#"export const q = 1;
+{
+  import { a } from "nonexistent-module";
+}"#,
+        &[1232],
+        "the gate reads the file's module-ness, not the `export {}` spelling",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A side-effect-only import is the one form that answers differently: it
+// never resolves outside a declaration scope, in a script or a module alike.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn side_effect_import_in_a_bare_block_of_a_script_reports_ts1232_alone() {
+    assert_codes(
+        r#"{
+  import "nonexistent-module";
+}"#,
+        &[1232],
+        "a side-effect import's own diagnostic never fires outside a declaration \
+         scope, unlike every clause-bearing form above",
+    );
+}
+
+#[test]
+fn side_effect_import_in_a_bare_block_of_a_module_reports_ts1232_alone() {
+    assert_codes(
+        r#"export {};
+{
+  import "nonexistent-module";
+}"#,
+        &[1232],
+        "module-ness does not matter for a side-effect import either",
+    );
+}
+
+#[test]
+fn a_side_effect_import_at_a_valid_position_still_resolves() {
+    assert_codes(
+        r#"import "nonexistent-module";"#,
+        &[2882],
+        "control: a valid-position side-effect import still reports its own \
+         TS2882, so this PR only changes the wrong-context answer",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Declaration scopes still win over module-ness, exactly as they did before
+// this PR — a function body, a method body and a `static { }` block suppress
+// regardless of the file's module-ness.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn named_import_in_a_function_body_of_a_module_reports_ts1232_alone() {
+    assert_codes(
+        r#"export {};
+function f() {
+  import { a } from "nonexistent-module";
+}"#,
+        &[1232],
+        "a declaration scope is unaffected by this PR's module-ness refinement",
+    );
+}
+
+#[test]
+fn named_import_in_a_class_static_block_of_a_module_reports_ts1232_alone() {
+    assert_codes(
+        r#"export {};
+class C {
+  static {
+    import { a } from "nonexistent-module";
+  }
+}"#,
+        &[1232],
+        "a `static { }` block is a declaration scope in a module as well",
+    );
+}
+
+#[test]
+fn named_import_in_a_function_body_of_a_script_reports_ts1232_alone() {
+    assert_codes(
+        r#"function f() {
+  import { a } from "nonexistent-module";
+}"#,
+        &[1232],
+        "the function-body answer does not depend on module-ness either",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Resolvability of the specifier does not change the verdict, on either side
+// of the module-ness axis — matching what #16504 already established for the
+// export side rather than assuming it carries over unmeasured.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_resolvable_named_import_in_a_bare_block_of_a_script_still_reports_the_member_error() {
+    assert_codes(
+        r#"declare module "amb" {
+  export const a: number;
+}
+{
+  import { b } from "amb";
+}"#,
+        &[1232, 2305],
+        "a script keeps resolving even when the specifier resolves; the member \
+         lookup then reports its own TS2305",
+    );
+}
+
+#[test]
+fn a_resolvable_named_import_in_a_bare_block_of_a_module_reports_ts1232_alone() {
+    assert_codes(
+        r#"export {};
+declare module "amb" {
+  export const a: number;
+}
+{
+  import { b } from "amb";
+}"#,
+        &[1232, 2664],
+        "a module suppresses the member lookup too — resolvability of the \
+         specifier never enters into it; TS2664 is the unrelated ambient-module \
+         augmentation diagnostic and fires regardless of this gate",
+    );
+}


### PR DESCRIPTION
`{ import { a } from "nope"; }` reports TS1232+TS2307 in a script (unchanged, matches `tsc` under the `--singleThreaded --stableTypeOrdering true` invocation `generate-tsc-cache.rs`/`conformance.sh` actually score) but wrongly *also* added TS2307 in an external module, where `tsc` reports TS1232 alone. `tsc`'s `checkImportDeclaration` has already returned at the placement diagnostic in both cases, so whatever still resolves comes from a later pass that only exists when the file is not a module — mirroring the export side's own module-ness axis (#16504) but with the import side's own rule, since every clause-bearing import form (named, default, namespace, default+named, type-only, `import x = require(...)`) shares one axis rather than splitting by clause kind the way `export ... from` does. A side-effect-only `import "m"` is the one form that answers differently: its diagnostic never fires outside a declaration scope, in a script or a module alike.

(The PR title/commit-message description had script and module backwards in the opening sentence — a wording-only error, not a code error. The code, every helper doc-comment, and every test were already correct in the module-vs-script direction; a reviewer's PR comment caught the prose swap and this body has been corrected accordingly. See that thread for the measurements that confirm the code side was right all along.)

Closes #16505 (the import-side half of #16495's inversion, split out once the export side landed in #16504).

## Structural rule

When a position-invalid `import` (a bare block / `if` body / loop body — not a function body, method, `static { }` block, or namespace body, which are still declaration scopes and unaffected) reaches `tsc`'s already-returned `checkImportDeclaration`, whether the module specifier still resolves through a later pass depends only on whether the file is an external module — never on which import clause it is, and never on whether the specifier itself resolves. tsz now answers the same way through a new checker-owned predicate.

## Owner

| site | change |
| --- | --- |
| `declarations/import/context_helpers.rs` | new `position_invalid_import_declaration_resolves_specifier(has_import_clause) -> bool`: `false` for a side-effect import (no clause) regardless of module-ness; otherwise `!is_external_module_file()`. |
| `declarations/import/declaration_check_body.rs` | plain `import ... from` gates its module-resolution pass on the new predicate, guarded by `!is_inside_namespace_declaration` (see below). |
| `declarations/import/equals.rs` | `import x = require(...)` gets its own call to the same predicate, placed after the existing function-body/referenced-alias early return so that nuance stays untouched. |

Two call sites rather than one shared gate, because the two productions were already structured independently before this PR and `equals.rs` carries its own referenced-alias logic for function bodies (#16489) that this change must not disturb. `position_invalid_export_declaration_resolves_specifier` (#16504, merged into `main` and rebased onto here) is a sibling helper in the same file for the export side; the two do not share logic because the export side splits by clause kind and the import side does not.

## Adjacent-case matrix

Measured a 63-row grid via `scripts/conformance/oracle.sh` (pinned `typescript@7.0.2`, which the wrapper itself invokes with `--singleThreaded --stableTypeOrdering true` — the exact flags `generate-tsc-cache.rs`/`conformance.sh` score, per #16413/#16457) across the 7 import forms (`import { a }`, `import a`, `import * as ns`, `import a, { b }`, `import "m"`, `import x = require(...)`, `import type { a }`) x {script, module} x {bare block, `if` body, loop body}, plus function-body/method/`static {}` negative controls (21 rows). **63/63 match after the fix; 24 rows were wrong before** (all 24 were the **module** case wrongly reporting TS2307/TS2882 in addition to TS1232 — the script case matched the oracle both before and after this PR and is a negative control, not a changed row).

Also verified, not assumed:
- Resolvability of the specifier does not change the verdict on either side of the module-ness axis (mirrors what #16504 already established for the export side) — checked with a `declare module "amb"` ambient-module control in both a script and a module, in both cases with the block containing a real `import { b } from "amb"` where `amb` doesn't export `b`.
- A side-effect import at a *valid* position still reports its own TS2882 — this PR only changes the wrong-context module answer.
- A module indicator other than `export {}` (e.g. `export const q = 1;`) also flips the verdict — the gate reads the file's actual module-ness, not one specific spelling.

**Found but deliberately not fixed here:** a plain import nested inside a namespace body's own block (`namespace N { { import { a } from "m"; } }`) turns on whether the binding is later *referenced* — the same discriminator `import x = require(...)` already applies via `namespace_import_alias_is_referenced` — not on module-ness. tsz has no equivalent reference check for the plain-import clause forms yet, so that shape is left exactly as it already was; both call sites guard it out via `!is_inside_namespace_declaration` rather than folding an unmeasured rule into this predicate. Flagged on the board (#15994) for whoever picks it up next.

## Goal
Goal: hold

## Verification
- New `[[test]]` target `position_invalid_import_specifier_resolution_tests`: **21/21 passed** (covers the full axis: script vs module for 6 clause forms, side-effect-import's own always-suppressed rule, function-body/static-block negative controls, and the resolvable-specifier controls).
- `cargo test -p tsz-checker --test import_namespace_ts1147_tests`: 9/9 passed (TS1147 namespace gate unaffected).
- `cargo test -p tsz-checker --test import_equals_alias_duplicate_container_tests --test import_equals_alias_duplicate_function_container_tests`: 16/16 + 11/11 passed.
- `cargo test -p tsz-checker --lib import_equals_referenced_alias_resolution`: 17/17 passed (post-rebase).
- `cargo test -p tsz-checker --lib position_invalid_export_specifier_resolution`: 40/40 passed (#16504's own suite, rebased in, unaffected).
- `cargo test -p tsz-checker --lib ts2702_qualifier_namespace_meaning`: 20/20 passed (#16501's own suite, rebased in, unaffected).
- `cargo test -p tsz-checker --lib import`: 317/317 passed (pre-rebase; re-checked post-rebase via the individual suites above).
- `cargo test -p tsz-checker --test position_invalid_import_equals_container_scope_tests`: 20/22 passed. The 2 failures (`static_block_referenced_alias_still_does_not_resolve_the_specifier`, `static_block_two_colliding_aliases_do_not_resolve_the_specifier`) are **pre-existing on `main`** — confirmed identical via `git stash` + rerun before making any change; unrelated to this PR (#16450 territory).
- The 63-row oracle sweep above was re-run after the merge/rebase onto `main` (post #16504/#16501/#16510) with 0 diffs, confirming the rebase didn't change the verdict.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings` and `cargo clippy -p tsz-checker -p tsz-solver --all-targets -- -D warnings` (post-merge, via the pre-commit hook): clean.
- `cargo fmt --all -- --check`: clean.
- `python3 scripts/arch/arch_guard.py`: passed (also via pre-commit hook on the merge commit).
- `scripts/conformance/compare-to-parent.sh` / full `conformance.sh` snapshot: **not run** — this container has 4 cores and the two-sided run is measured at 55-90+ min on this hardware per the board, which didn't fit this session's budget. The change only fires for imports already in an invalid module-element position (malformed/unusual code shape), so real-world corpus impact is expected to be at or near zero; owed as a follow-up drain step.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE