### PR TITLE
fix(checker): merge heritage bases on the fast interface-lowering path

### DIFF
--- a/crates/tsz-checker/src/context/def_mapping/body_publication.rs
+++ b/crates/tsz-checker/src/context/def_mapping/body_publication.rs
@@ -56,6 +56,7 @@ impl CheckerContext<'_> {
     /// Publish `body` and its dependency set when it is canonical progress.
     /// Returns `false` when the candidate is a rejected registration-window
     /// placeholder or the store does not retain that exact body.
+    #[track_caller]
     pub(crate) fn publish_definition_body(&self, def_id: DefId, body: TypeId) -> bool {
         if self.is_non_progress_non_program_alias_body(def_id, body) {
             return false;
@@ -66,6 +67,7 @@ impl CheckerContext<'_> {
 
     /// Parameterized counterpart of [`Self::publish_definition_body`], with
     /// the same exact-publication return contract.
+    #[track_caller]
     pub(crate) fn publish_definition_body_with_params(
         &self,
         def_id: DefId,

--- a/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
+++ b/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
@@ -954,6 +954,17 @@ impl<'a> CheckerState<'a> {
                 };
             }
             if merged != TypeId::ERROR {
+                // `get_type_of_interface` lowers only each declaration's OWN
+                // members. An interface's type must also carry the members it
+                // inherits through `extends`, exactly as the general lowering
+                // path below does (the `merge_interface_heritage_types` call
+                // after `lower_interface_declarations_with_symbol`). Without it
+                // this fast local-declaration path returns a heritage-thin body
+                // for an interface reached through the forced-interface-decl /
+                // namespace-merge route, dropping every inherited member (e.g.
+                // `interface A2 extends A1` where `A1` is a class — the members
+                // of `A1` vanish from `A2`).
+                merged = self.merge_interface_heritage_types(&declarations, merged);
                 // Self-module augmentations before caching, so `keyof` sees them (#13509).
                 merged = self.apply_self_module_augmentations(sym_id, merged);
                 self.ctx.symbol_instance_types.insert(sym_id, merged);


### PR DESCRIPTION
`compute_interface_type_from_declarations` has two branches. The general lowering path runs `merge_interface_heritage_types` after lowering each declaration's members; the **fast local-declaration branch** (all declarations in the current arena, non-declaration file — taken for an interface reached via the forced-interface-decl / namespace-merge / class-heritage route) lowered only each declaration's OWN members through `get_type_of_interface` and returned. The interface therefore came back heritage-thin, so members inherited through `extends` vanished — e.g. `interface A2 extends A1` where `A1` is a class silently drops `A1`'s members from `A2` — which disables the missing-member checks that depend on them.

**Structural rule:** when an interface's type is materialized from its declarations it must carry the members inherited through `extends`, on **every** lowering path — not just the general one. Owned by the checker's interface-type resolution (`merge_interface_heritage_types`). This PR runs that same merge on the fast branch so both paths agree.

Also makes `CheckerContext::publish_definition_body{,_with_params}` `#[track_caller]` so the `TSZ_DEF_PUBLICATION_CENSUS` body-publication census (#13862) attributes each publication to its real registration site instead of the publish wrapper — pure instrumentation, no behaviour change.

Surfaced by the #16308 investigation. This closes the **same-file / forced-interface-decl** variant of heritage-thin interface bodies; it does **not** close mobx's #16308 row, whose cross-file `interface IObservableArray<T> extends Array<T>` additionally needs a lib-global `extends` base resolved inside a cross-arena delegation child and cross-arena def canonicalization (#14345). Full attribution + a minimized repro are posted on #16308, which stays open.

## Goal
Goal: green

## Verification
- `conformance.sh snapshot --workers 12` on this branch vs committed baseline (base `a7e892e`): **+4 fixed, 0 regressions** (552 → 548 failures), confirmed by a per-test failure-set diff. Fixed rows (a diverse adjacent-case matrix): `classImplementsClass4` (class-implements-class), `privateNamesUnique-4` (interface-extends-class reducing to a private-field shape), `typeArgumentInferenceConstructSignatures` (construct-signature inference), `decoratorMetadataWithImportDeclarationNameCollision7` (decorator metadata). All four fail without this change and pass with it. (The committed conformance snapshot is left to the usual dedicated-refresh workflow; the nightly gate recognizes improvements without a stale-baseline failure. A single-file `check_source` unit harness does not route through the fast branch, so the corpus rows are the coverage.)
- mobx guard fixture: family unchanged at 10 (out of scope; see above).
- `clippy` + `arch-size` pass (CI per-merge lane; verified locally by the pre-commit hook).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01WR9igwYWYXb8xXFmfRxc1Q)_