### PR TITLE
fix(cli): schedule a lib interface inheriting a user-augmented index signature for TS2430 recheck (#16474)

### DIFF
--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part5.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part5.rs
@@ -313,3 +313,68 @@ const elem = <div className={class1, class2}/>;
             "TS1347's pointer must survive tagged as a pointer: {ts1347:?}"
         );
     }
+
+    #[test]
+    fn lib_interface_inheriting_an_augmented_index_signature_is_scheduled_for_recheck() {
+        // #16474: when a user augments a lib interface with an index signature,
+        // every lib interface that inherits that index through its base chain
+        // must be scheduled for the post-merge TS2430 heritage recheck — even
+        // though it declares no index signature of its own (it declares only
+        // ordinary members like `apply`). Requiring the *derived* interface to
+        // declare an index signature asked the wrong question: an index
+        // signature reaching an interface through its base chain constrains
+        // every member that interface declares, so the recheck must run whenever
+        // it declares at least one own member.
+        //
+        // The binder names are deliberately non-`Function`/`CallableFunction`
+        // so the schedule is driven by the structural extends-an-index-augmented
+        // base relation, not by any built-in identifier string.
+        let checker_libs = checker_lib_set_for_test(&[(
+            "lib.test.d.ts",
+            r#"
+interface LibBase {
+    apply(this: LibBase, thisArg: any): any;
+}
+interface LibCallable extends LibBase {
+    apply<T, R>(this: (this: T) => R, thisArg: T): R;
+}
+interface LibNewable extends LibBase {
+    apply<T>(this: new () => T, thisArg: T): void;
+}
+interface LibEmpty extends LibBase {
+}
+"#,
+        )]);
+
+        let program = merged_program_from_owned_files(vec![(
+            "file.ts".to_string(),
+            r#"
+interface Bar { b: number }
+interface LibBase {
+    [n: number]: Bar;
+}
+"#
+            .to_string(),
+        )]);
+
+        let affected = affected_lib_interface_names(&program, &checker_libs);
+        assert!(
+            affected.contains("LibCallable") && affected.contains("LibNewable"),
+            "lib interfaces that declare members and inherit a user-augmented \
+             index signature must be scheduled for recheck, got: {affected:?}"
+        );
+        assert!(
+            !affected.contains("LibEmpty"),
+            "a memberless derived interface cannot conflict and must stay out, got: {affected:?}"
+        );
+
+        let extension = affected_lib_extension_interface_names(&program, &checker_libs, &affected);
+        assert!(
+            extension.contains("LibCallable") && extension.contains("LibNewable"),
+            "and must run heritage (TS2430) extension compatibility, got: {extension:?}"
+        );
+        assert!(
+            !extension.contains("LibEmpty"),
+            "a memberless derived interface must not run heritage compatibility, got: {extension:?}"
+        );
+    }

--- a/crates/tsz-cli/src/driver/checker_lib_diagnostics.rs
+++ b/crates/tsz-cli/src/driver/checker_lib_diagnostics.rs
@@ -590,6 +590,23 @@ fn interface_declares_index_signature(
     })
 }
 
+/// Whether a lib interface declares any member of its own.
+///
+/// An index signature that reaches an interface through its base chain (tracked
+/// by `index_signature_affected`) constrains **every** member that interface
+/// declares — not only members whose name collides with the augmentation, and
+/// not only an index signature the derived interface writes itself. So a lib
+/// interface that inherits a user-augmented index signature must be rechecked
+/// for heritage compatibility (TS2430) whenever it declares at least one own
+/// member (e.g. `CallableFunction`/`NewableFunction` declaring `apply`/`call`/
+/// `bind` while extending an augmented `Function`). An interface that declares
+/// nothing (`interface X extends Augmented {}`) cannot conflict and stays out.
+const fn interface_declares_own_member(
+    interface: &tsz_parser::parser::node::InterfaceData,
+) -> bool {
+    !interface.members.nodes.is_empty()
+}
+
 fn collect_user_global_interfaces_with_index_signatures(
     program: &MergedProgram,
 ) -> FxHashSet<String> {
@@ -758,7 +775,7 @@ pub(super) fn affected_lib_interface_names(
                 continue;
             }
             if (index_signature_affected.contains(&name)
-                && interface_declares_index_signature(lib.arena.as_ref(), interface))
+                && interface_declares_own_member(interface))
                 || interface_declares_member_named(
                     lib.arena.as_ref(),
                     interface,
@@ -868,7 +885,7 @@ pub(super) fn affected_lib_extension_interface_names(
             };
             if affected_interfaces.contains(&name)
                 && index_signature_affected.contains(&name)
-                && interface_declares_index_signature(lib.arena.as_ref(), interface)
+                && interface_declares_own_member(interface)
             {
                 extension_interfaces.insert(name);
             }


### PR DESCRIPTION
Structural rule: when a user augmentation adds an index signature to a lib interface, every lib interface that inherits that index through its base chain must be rechecked for heritage compatibility (TS2430), because a base-chain index signature constrains **every** member the derived interface declares. tsc reports TS2430 in `lib.es5.d.ts` for `CallableFunction`/`NewableFunction` extending an augmented `Function`; tsz owns the post-merge lib recheck scheduling in `crates/tsz-cli/src/driver/checker_lib_diagnostics.rs`.

Residual half of #16474 (the relation half landed in #16473).

## Goal
Goal: green

## What changed
The recheck-scheduling gate keyed relevance on the **derived** interface declaring an index signature of its own (`interface_declares_index_signature`). `CallableFunction`/`NewableFunction` declare `apply`/`call`/`bind` but no index signature, so they were excluded from both `affected_lib_interface_names` (the recheck set) and `affected_lib_extension_interface_names` (the set that runs TS2430 heritage compatibility) and were never rechecked — the wrong question, since the augmented index reaches them through `extends Function`, not through a signature they write themselves.

The gate now uses `interface_declares_own_member` (`!interface.members.nodes.is_empty()`) under the existing `index_signature_affected` base-chain propagation. A memberless `interface X extends Augmented {}` declares nothing, cannot conflict, and still stays out. The added test uses non-`Function` binder names so the schedule is driven by the structural relation, not a built-in identifier string (anti-hardcoding gate).

## Scope / honesty about the row flip
This is the **scheduling** half only. With this fix, `CallableFunction`/`NewableFunction` are correctly scheduled *and* the heritage check runs on them against the augmented `Function` — verified with `warn!` instrumentation on a real `--lib es2015` run. The four conformance rows still do **not** flip, because they are additionally blocked by a separately-root-caused solver bug: `no_erase_generics_relation_outcome` returns *related=true* for a generic method override (`call`/`apply`) whose base method's `this`-type is an object that carries an unrelated generic sibling member (`bind`), when it should return *related=false*. Minimal deterministic repros and the full root-cause are posted to #16474. That solver fix is out of scope here (load-bearing across TS2416/TS2430; unsafe to land blind). This PR is the correct, self-contained scheduling prerequisite the issue described as independently landable.

## Verification
- `cargo test -p tsz-cli --lib lib_interface_inheriting_an_augmented_index_signature_is_scheduled_for_recheck` — new test passes (asserts `LibCallable`/`LibNewable` land in both the affected and extension sets; memberless `LibEmpty` stays out).
- `cargo test -p tsz-cli --lib driver::core::check::check_tests` — 116 passed; the only 2 failures are pre-existing baselined entries in `scripts/ci/known-failures.txt`, unaffected by this change.
- `cargo clippy -p tsz-cli` clean; architecture guard passes (pre-commit hook).
- Change is a no-op for any program that does not augment a lib interface with an index signature (`index_signature_affected` is empty, so the widened conjunct never gates). Full conformance runs in CI's nightly lane (TypeScript submodule not checked out locally).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjQ1XbWR8UvVCoEc8nFmTw)_