### PR TITLE
test(checker): give multi-file harness binders globally-unique SymbolId bases (#15983)

### DIFF
--- a/crates/tsz-checker/src/test_utils/multi_file.rs
+++ b/crates/tsz-checker/src/test_utils/multi_file.rs
@@ -12,8 +12,40 @@ use crate::query_boundaries::common::TypeInterner;
 use crate::state::CheckerState;
 use std::sync::Arc;
 use tsz_binder::BinderState;
+use tsz_binder::SymbolArena;
 use tsz_binder::lib_loader::LibFile;
 use tsz_parser::parser::ParserState;
+
+/// Stride between the per-file `SymbolId` bases handed to multi-file harness
+/// binders.
+///
+/// The production driver's bind-result reducer remaps every file's raw
+/// `SymbolId`s into one program-global id space, so no two files ever share a
+/// raw id and `global_symbol_file_index` / `cross_file_symbol_targets` can be
+/// keyed by the bare `SymbolId` unambiguously. These in-process helpers build
+/// per-file binders directly and never run that reducer, so a binder created
+/// with [`BinderState::new`] restarts `SymbolId` from 0 for every file — file
+/// B's `SymbolId(1)` then aliases file A's `SymbolId(1)` in the shared overlay,
+/// and a cross-file alias resolves through the wrong binder's identically
+/// numbered symbol (the #15983 false-positive family). Giving each file's
+/// binder a distinct base restores the driver's globally-unique-`SymbolId`
+/// invariant on the in-process path. `1 << 20` leaves room for 255 files below
+/// [`SymbolArena::CHECKER_SYMBOL_BASE`] while allowing ~1M symbols per file.
+const PER_FILE_SYMBOL_BASE_STRIDE: u32 = 1 << 20;
+
+/// Build an empty binder whose `SymbolId`s start at a file-unique base, so the
+/// production-faithful multi-file helpers never collide in the shared symbol-id
+/// space the way per-file binders built with [`BinderState::new`] do.
+fn new_binder_for_file(file_idx: usize) -> BinderState {
+    let base = u32::try_from(file_idx)
+        .ok()
+        .and_then(|idx| idx.checked_mul(PER_FILE_SYMBOL_BASE_STRIDE))
+        .filter(|base| *base < SymbolArena::CHECKER_SYMBOL_BASE)
+        .expect("multi-file test project exceeds the per-file symbol-id base range");
+    let mut binder = BinderState::new();
+    binder.symbols = SymbolArena::new_with_base(base);
+    binder
+}
 
 /// Build the test-harness `SymbolId -> file_idx` disambiguation index.
 ///
@@ -129,10 +161,10 @@ pub fn check_multi_file_with_global_index(
     let mut roots = Vec::with_capacity(files.len());
     let file_names: Vec<String> = files.iter().map(|(name, _)| (*name).to_string()).collect();
 
-    for (name, source) in files {
+    for (file_idx, (name, source)) in files.iter().enumerate() {
         let mut parser = ParserState::new((*name).to_string(), (*source).to_string());
         let root = parser.parse_source_file();
-        let mut binder = BinderState::new();
+        let mut binder = new_binder_for_file(file_idx);
         binder.bind_source_file(parser.get_arena(), root);
         arenas.push(Arc::new(parser.get_arena().clone()));
         binders.push(Arc::new(binder));
@@ -190,10 +222,10 @@ pub fn check_all_multi_file_with_global_index(
     let mut roots = Vec::with_capacity(files.len());
     let file_names: Vec<String> = files.iter().map(|(name, _)| (*name).to_string()).collect();
 
-    for (name, source) in files {
+    for (file_idx, (name, source)) in files.iter().enumerate() {
         let mut parser = ParserState::new((*name).to_string(), (*source).to_string());
         let root = parser.parse_source_file();
-        let mut binder = BinderState::new();
+        let mut binder = new_binder_for_file(file_idx);
         binder.bind_source_file(parser.get_arena(), root);
         arenas.push(Arc::new(parser.get_arena().clone()));
         binders.push(Arc::new(binder));


### PR DESCRIPTION
Fixes the no-lib alias-family rows of #15983.

## Structural rule

When several files are checked together, the production driver's bind-result
reducer (`crates/tsz-core/src/parallel/core/bind_result_reducer.rs`) remaps
every file's raw `SymbolId` into **one program-global id space** (`id_remap`),
so no two files ever share a raw id. That is the invariant that lets
`global_symbol_file_index` and the `cross_file_symbol_targets` overlay
(`context/symbol_file_targets.rs`, keyed by the bare `SymbolId`) resolve a
symbol to its owning file unambiguously.

The in-process test harness broke that invariant. `check_multi_file_with_global_index`
and `check_all_multi_file_with_global_index` built each file's binder with
`BinderState::new()` (base offset `0`) and **never ran the reducer**, so every
file restarted `SymbolId` from `0`. File B's `SymbolId(1)` then aliased file A's
`SymbolId(1)` in the shared overlay, and a cross-file alias resolved through the
wrong binder's identically-numbered symbol — the #15983 false-positive family
(false `TS2538`/`TS18046`/`TS2353` on cross-file alias intersections and
symbol-keyed members).

This is a **harness-fidelity** gap, not a product defect: the same fixtures are
clean through the real `tsz` binary and through `tsc`, because the driver keeps
`SymbolId`s globally unique. The fix restores that invariant on the in-process
path by giving each file's binder a distinct `SymbolId` base
(`SymbolArena::new_with_base(file_idx * stride)`), so the shared overlay is
collision-free exactly as in production. No checker/solver/emitter logic
changes; the diff is confined to `crates/tsz-checker/src/test_utils/multi_file.rs`.

`SymbolId`'s sentinel is `u32::MAX`, so `SymbolId(0)` stays a valid id and the
base offsets stay below `SymbolArena::CHECKER_SYMBOL_BASE` (`0x1000_0000`);
`SymbolArena::get` already rejects an id below its arena's base, so a foreign
id never resolves to a wrong local symbol.

## Adjacent-case matrix

All rows below use the two production-faithful helpers this PR touches. Each
previously-failing row now passes; the previously-passing rows are unchanged.

| Row | Suite | Before | After |
| --- | --- | --- | --- |
| `renamed_binders_member_read_is_clean` | `cross_file_recursive_alias_intersection_tests` | false `TS18046` | clean |
| `member_read_through_imported_alias_intersection_is_clean` | same | false `TS18046` | clean |
| `const_assignment_to_imported_alias_intersection_is_clean` | same | false `TS2353` | clean |
| `direct_import_symbol_keyed_member_is_clean` | `reexported_symbol_keyed_member_tests` | false `TS2538` | clean |
| renamed/aliased/reexported positive controls | both suites | passing | passing |

## Deliberately out of scope

The two remaining #15983 alias rows — `imported_conditional_builder_alias_*`
(`kysely_callback_context_tests`) and
`builtin_object_assign_reports_nonportable_...` (`object_assign_identity_tests`)
— run through the **lib-aware** helpers (`check_multi_file_with_libs` /
`_stamped`). They share this exact root cause, but a per-file base offset is
unsafe there: `merge_lib_symbols` folds the shared lib symbols into the same
arena, so a whole-arena base would give the *same* lib symbol a different id per
file and break cross-file lib identity. Making only the module-local suffix
per-file-unique needs the driver's full id-remap table, which is a larger,
separate slice. The other ledger rows (`test_class_duplicate_getter_2300`,
`strict_bind_call_apply_..._ts2769`, the two tsz-cli rows) are single-file /
real-driver failures unrelated to this collision class. All are left tracked
under #15983.

## Goal
Goal: hold

## Verification

Blast radius is exactly the callers of the two changed helpers; all were run
locally (`CARGO_PROFILE_DEV_DEBUG=0`, this container has no `cargo-nextest`).

- `cargo test -p tsz-checker --test cross_file_recursive_alias_intersection_tests --test reexported_symbol_keyed_member_tests` — **9/9 pass** (4 rows were failing on `main`).
- **18 registered integration binaries** that consume the two helpers — **0 regressions** (`qualified_namespace_generic_substitution_tests`, `declare_global_interface_keyof_merge_tests`, `hkt_self_augmentation_keyof_repro`, `cross_file_generic_alias_call_inference_tests`, `mapped_keyof_index_access_tests`, `export_default_interface_type_import_tests`, `order_independent_alias_resolution_tests`, `generic_default_recursive_alias_diagnostics_tests`, `cross_file_generic_class_implements_tests`, `default_imported_generic_alias_assertion_tests`, `cross_file_generic_interface_mapped_filter_tests`, `module_augmentation_declaration_identity_tests`, `cross_file_delegation_lookup_consolidation_tests`, `ts4105_signature_position_indexed_access_tests`, `global_this_type_position_member_tests`, `cross_file_function_node_index_collision_tests`, `hkt_cross_file_augmentation_13653_repro`, `ts2300_reexport_augmentation_tests`).
- **7 lib-test modules** that consume the two helpers, incl. the `#[path]`-included `ts2702_qualifier_namespace_meaning_tests` / `cross_file_interface_merge_ts2717_tests` — run together (`--lib`, 87 passed / 0 failed / 2 ignored) and each alone — **0 regressions**.
- Pre-commit hook (fmt + clippy `-p tsz-checker` + architecture guard + crate verification): passed.
- Conformance/emit/fourslash: not affected — test-harness-only change (`test_utils/multi_file.rs`), no production path touched, so the corpus fingerprint and emit counts cannot move.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
