### PR TITLE
fix(checker): a TS2741 inside a nested object literal anchors its declared-here pointer through the written path (#16443)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
+++ b/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
@@ -62,6 +62,70 @@ impl<'a> CheckerState<'a> {
         self.declared_here_related_from_annotation(anchor_idx, &property, property_display)
     }
 
+    /// Property names, outermost first, naming the object-literal members the
+    /// failure at `anchor_idx` sits inside — the syntactic path from the
+    /// annotated binding down to the failing literal.
+    ///
+    /// Bounded by the same ancestor walk [`Self::target_annotation_node`] uses,
+    /// and stopping at the same declaration and function boundaries, so the two
+    /// always describe one assignment. Returns empty for a failure that is not
+    /// inside an object literal at all (an array element, a call argument),
+    /// which declines the pointer rather than guessing.
+    fn contextual_property_path(&self, anchor_idx: NodeIndex) -> Vec<String> {
+        use tsz_parser::parser::syntax_kind_ext;
+
+        let mut path: Vec<String> = Vec::new();
+        let mut current = anchor_idx;
+        let mut guard = 0u32;
+        while current.is_some() {
+            guard += 1;
+            if guard > 32 {
+                break;
+            }
+            let Some(node) = self.ctx.arena.get(current) else {
+                break;
+            };
+            if node.kind == syntax_kind_ext::VARIABLE_DECLARATION
+                || node.kind == syntax_kind_ext::PARAMETER
+                || node.kind == syntax_kind_ext::PROPERTY_DECLARATION
+                || node.kind == syntax_kind_ext::FUNCTION_DECLARATION
+                || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
+                || node.kind == syntax_kind_ext::ARROW_FUNCTION
+                || node.kind == syntax_kind_ext::METHOD_DECLARATION
+                || node.kind == syntax_kind_ext::BLOCK
+                || node.kind == syntax_kind_ext::SOURCE_FILE
+            {
+                break;
+            }
+            let name_idx = if node.kind == syntax_kind_ext::PROPERTY_ASSIGNMENT {
+                self.ctx.arena.get_property_assignment(node).map(|p| p.name)
+            } else if node.kind == syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT {
+                self.ctx.arena.get_shorthand_property(node).map(|p| p.name)
+            } else {
+                None
+            };
+            if let Some(name_idx) = name_idx {
+                match crate::types_domain::queries::core::get_literal_property_name(
+                    self.ctx.arena,
+                    name_idx,
+                ) {
+                    Some(name) => path.push(name),
+                    // A computed or otherwise non-literal member name cannot be
+                    // matched against the written annotation by name. Abandon
+                    // the whole path rather than skipping the level, which would
+                    // anchor one member too shallow.
+                    None => return Vec::new(),
+                }
+            }
+            let Some(parent) = self.ctx.arena.get_extended(current).map(|ext| ext.parent) else {
+                break;
+            };
+            current = parent;
+        }
+        path.reverse();
+        path
+    }
+
     /// Anchor recovered from the type annotation the failing assignment was
     /// declared with, for targets that resolve to no binder symbol.
     ///
@@ -83,7 +147,34 @@ impl<'a> CheckerState<'a> {
         property_display: &str,
     ) -> Option<DiagnosticRelatedInformation> {
         let annotation_idx = self.target_annotation_node(anchor_idx)?;
-        let (start, length, file) = self.annotation_property_anchor(annotation_idx, property, 0)?;
+        // A failure inside a *nested* object literal names a property of an
+        // inner member type, not of the annotation itself: `oq` is no member of
+        // `Outer` in `const r: Outer = { inner: { op: 1 } }`. Resolving the leaf
+        // name straight against the annotation therefore declines, and tsc still
+        // reports the pointer — `reportUnmatchedProperty` draws no distinction
+        // between an inner and an outer literal. The missing step is the path,
+        // which the object-literal syntax at the failure site supplies; each
+        // member is validated against the written annotation before the next is
+        // taken, so an annotation that does not declare the path declines here
+        // exactly as it does at the top level.
+        let path = self.contextual_property_path(anchor_idx);
+        let anchor = if path.is_empty() {
+            self.annotation_property_anchor(annotation_idx, property, 0)
+        } else {
+            let mut member_type_idx = annotation_idx;
+            let mut walked = Some(());
+            for key in &path {
+                match self.annotation_member_type_node(member_type_idx, key, 0) {
+                    Some(next) => member_type_idx = next,
+                    None => {
+                        walked = None;
+                        break;
+                    }
+                }
+            }
+            walked.and_then(|()| self.annotation_property_anchor(member_type_idx, property, 0))
+        };
+        let (start, length, file) = anchor?;
         Some(Diagnostic::related_pointer(
             diagnostic_codes::IS_DECLARED_HERE,
             file.unwrap_or_else(|| self.ctx.file_name.clone()),

--- a/crates/tsz-checker/src/error_reporter/render_failure_missing_property.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure_missing_property.rs
@@ -646,14 +646,26 @@ impl<'a> CheckerState<'a> {
         // with a TS2728 pointer at that property's own declaration. The
         // multi-property forms (TS2739/TS2740) above return before this point
         // and carry no pointer, matching tsc.
-        if depth == 0
-            && let Some(related) = self.missing_property_declared_here_related(
-                &[target, target_type],
-                idx,
-                property_name,
-                &prop_name_display,
-            )
-        {
+        // A nested frame reaches the same pointer through the path-aware route:
+        // tsc draws no depth distinction here, but the leaf property name alone
+        // does not locate a member of the *outer* annotation, so the object
+        // literal's own syntax supplies the path first.
+        // Only the leaf target is offered to the symbol route on a nested frame:
+        // the *outer* target is a different type that legitimately does not
+        // declare this property, and asking it would either decline anyway or,
+        // for a same-named member, anchor in the wrong declaration.
+        let owner_candidates: &[TypeId] = if depth == 0 {
+            &[target, target_type]
+        } else {
+            &[target_type]
+        };
+        let declared_here = self.missing_property_declared_here_related(
+            owner_candidates,
+            idx,
+            property_name,
+            &prop_name_display,
+        );
+        if let Some(related) = declared_here {
             diagnostic.related_information.push(related);
         }
         diagnostic

--- a/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
+++ b/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
@@ -916,3 +916,140 @@ fn named_target_still_anchors_through_the_symbol_route() {
         "the anchor is `Want`'s own member, not anything in `Src`"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Nested elaboration: a property missing from an *inner* object literal.
+//
+// tsc's `reportUnmatchedProperty` draws no distinction between an inner and an
+// outer literal — every row below carries the pointer in `typescript@7.0.2`.
+// The leaf property name alone cannot locate it: `oq` is no member of `Outer`
+// in `const r: Outer = { inner: { op: 1 } }`, so the annotation walk first
+// follows the path the object-literal syntax at the failure site spells out.
+// ---------------------------------------------------------------------------
+
+/// Row 1 of #16443's nested-elaboration table. Oracle (`typescript@7.0.2`,
+/// `--noEmit --strict --pretty --target es2022 --lib es2022`):
+/// `matrix.ts:1:37 - 'oq' is declared here.`
+#[test]
+fn nested_object_literal_pointer_anchors_in_the_inner_type_literal() {
+    let source = "type Outer = { inner: { op: number; oq: number } };\nconst r: Outer = { inner: { op: 1 } };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, message) = declared_here(&diagnostic);
+    assert_eq!(
+        span_text(source, start, length),
+        "oq",
+        "the anchor underlines the inner member's own name node"
+    );
+    assert!(
+        message.contains("'oq'"),
+        "pointer names the property: {message}"
+    );
+}
+
+/// Anti-hardcoding: the walk keys on the nesting structure, not on the
+/// identifiers `Outer`/`inner`/`oq`. Renamed binders anchor identically.
+#[test]
+fn nested_pointer_is_binder_name_independent() {
+    let source = "type Envelope = { payload: { alpha: number; beta: number } };\nconst env: Envelope = { payload: { alpha: 1 } };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "beta");
+}
+
+/// The same nesting written as an `interface` rather than a type alias. The
+/// annotation walk reaches an interface's member list through the same
+/// declaration route, so the interface and alias forms must not diverge.
+/// Oracle: `matrix.ts:3:41 - 'oq' is declared here.`
+#[test]
+fn nested_pointer_anchors_through_an_interface_annotation() {
+    let source = "interface OuterI { inner: { op: number; oq: number } }\nconst ri: OuterI = { inner: { op: 1 } };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "oq");
+}
+
+/// Two levels of nesting: the anchor follows the whole path, not just the
+/// first hop. Oracle: `matrix.ts:6:36 - 'q' is declared here.`
+#[test]
+fn twice_nested_object_literal_pointer_anchors_at_the_innermost_member() {
+    let source = "type Deep = { a: { b: { p: number; q: number } } };\nconst rd: Deep = { a: { b: { p: 1 } } };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "q");
+    // The outer member `b` shares no name with the leaf, but a path walk that
+    // stopped one hop early would still find *a* plausible member; pin the
+    // offset so a shallow anchor cannot pass.
+    assert_eq!(length, 1, "underlines `q` alone, not a wider member span");
+}
+
+/// A nested member written as a *named* alias resolves through the symbol
+/// route with no path walk at all — the alias declares the property itself.
+/// Oracle: `matrix.ts:3:29 - 'iq' is declared here.` (in `Inner2`'s own body).
+#[test]
+fn nested_member_named_alias_anchors_in_the_alias_body() {
+    let source = "type Inner2 = { ip: number; iq: number };\ntype Outer2 = { inner: Inner2 };\nconst r2: Outer2 = { inner: { ip: 1 } };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "iq");
+}
+
+/// Negative arm, unchanged by the path walk: more than one unmatched property
+/// is TS2739, and tsc attaches no `'x' is declared here.` pointer to it at any
+/// depth. Oracle row 5 of the matrix carries only the TS6500 entry.
+#[test]
+fn nested_multi_property_failure_still_carries_no_pointer() {
+    let source = "type Multi = { inner: { m1: number; m2: number; m3: number } };\nconst rm: Multi = { inner: { m1: 1 } };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2739);
+    assert!(
+        !diagnostic
+            .related_information
+            .iter()
+            .any(|info| info.code == TS2728),
+        "TS2739 carries no declared-here pointer: {diagnostic:?}"
+    );
+}
+
+/// A computed member name in the path is not matchable against the written
+/// annotation by name, so the walk abandons the whole path rather than
+/// skipping the level and anchoring one member too shallow.
+///
+/// tsc *does* resolve this row (`matrix.ts:9:36`) because `K` is a `const` with
+/// a literal type — declining here is a known, safe gap, not parity. What this
+/// test pins is that the decline stays a decline: no pointer is better than a
+/// pointer into the wrong member, which is the failure mode the name+kind guard
+/// exists to prevent.
+///
+/// Asserted over every diagnostic rather than a chosen one: this witness also
+/// diverges on its *primary* code (tsz reports TS2418 where tsc reports
+/// TS2741), which is a separate defect from the pointer and must not decide
+/// whether this test passes.
+#[test]
+fn computed_path_member_declines_rather_than_anchoring_shallow() {
+    let source = "const K = \"inner\";\ntype Comp = { inner: { cp: number; cq: number } };\nconst rc: Comp = { [K]: { cp: 1 } };\n";
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        !diagnostics
+            .iter()
+            .flat_map(|d| d.related_information.iter())
+            .any(|info| info.code == TS2728),
+        "a computed path member produces no anchor at all: {diagnostics:?}"
+    );
+}
+
+/// A literal nested inside an *array* member: the path reaches the member's
+/// written type node, but that node is an array type rather than a type
+/// literal, so the leaf resolution declines. tsc anchors this row
+/// (`matrix.ts:13:34`); pinned as a decline so the remaining gap is visible and
+/// cannot silently become a wrong anchor.
+#[test]
+fn array_element_literal_declines_rather_than_anchoring_wrongly() {
+    let source = "type Arr = { list: { lp: number; lq: number }[] };\nconst ra: Arr = { list: [{ lp: 1 }] };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    assert!(
+        !diagnostic
+            .related_information
+            .iter()
+            .any(|info| info.code == TS2728),
+        "an array-typed member produces no anchor at all: {diagnostic:?}"
+    );
+}

--- a/crates/tsz-checker/src/tests/override_incompatibility_elaboration_tests.rs
+++ b/crates/tsz-checker/src/tests/override_incompatibility_elaboration_tests.rs
@@ -17,6 +17,15 @@
 //!
 //! The rule is structural (independent of identifier spelling), so the cases
 //! below vary binder names where a name appears in the rendered output.
+//!
+//! `elaboration` folds in every related-information line, so the trailing
+//! `'x' is declared here.` (`TS2728`) in the expectations below is part of the
+//! rendered output tsc produces, not an extra chain frame. tsc emits that
+//! pointer on a *nested* missing-property frame exactly as it does on a
+//! top-level one; tsz dropped it at `depth > 0` until #16443's nested-
+//! elaboration fix. Oracled on `typescript@7.0.2` with `--noEmit --strict
+//! --pretty --target es2022 --lib es2022`: the parameter-chain case anchors on
+//! `bark` at `2:28`, the renamed-binder case on `howl` at `2:40`.
 
 use crate::context::CheckerOptions;
 use crate::test_utils::{check_source_codes, check_with_options, strict_checker_options};
@@ -69,7 +78,8 @@ class Derived extends Base { handler: (value: Dog) => void = () => {}; }
         "Property 'handler' in type 'Derived' is not assignable to the same property in base type 'Base'.\n\
          Type '(value: Dog) => void' is not assignable to type '(value: Animal) => void'.\n\
          Types of parameters 'value' and 'value' are incompatible.\n\
-         Property 'bark' is missing in type 'Animal' but required in type 'Dog'.",
+         Property 'bark' is missing in type 'Animal' but required in type 'Dog'.\n\
+         'bark' is declared here.",
     );
 }
 
@@ -151,7 +161,8 @@ class Refined extends Origin { onPick: (subject: HoundKind) => void = () => {}; 
         "Property 'onPick' in type 'Refined' is not assignable to the same property in base type 'Origin'.\n\
          Type '(subject: HoundKind) => void' is not assignable to type '(subject: CreatureKind) => void'.\n\
          Types of parameters 'subject' and 'subject' are incompatible.\n\
-         Property 'howl' is missing in type 'CreatureKind' but required in type 'HoundKind'.",
+         Property 'howl' is missing in type 'CreatureKind' but required in type 'HoundKind'.\n\
+         'howl' is declared here.",
     );
 }
 

--- a/crates/tsz-checker/src/tests/type_predicate_assignability_elaboration_tests.rs
+++ b/crates/tsz-checker/src/tests/type_predicate_assignability_elaboration_tests.rs
@@ -115,6 +115,11 @@ guard = isNumber;
 /// Same rule, renamed binders — the predicate subject and interface names
 /// must not leak into the structural decision.
 #[test]
+/// The trailing `'meow' is declared here.` is tsc's `TS2728` pointer, folded in
+/// by `elaboration` with every other related-information line — not an extra
+/// chain frame. tsc emits it on this nested missing-property frame; tsz dropped
+/// it at `depth > 0` until #16443's nested-elaboration fix. Oracled on
+/// `typescript@7.0.2`: `pred.ts:1:17` on `meow`.
 fn incompatible_type_guards_reports_ts1226_renamed_binders() {
     let text = elaboration(
         r#"
@@ -130,7 +135,8 @@ guard = isDog;
         text,
         "Type '(value: unknown) => value is Dog' is not assignable to type '(value: unknown) => value is Cat'.\n\
          Type predicate 'value is Dog' is not assignable to 'value is Cat'.\n\
-         Property 'meow' is missing in type 'Dog' but required in type 'Cat'.",
+         Property 'meow' is missing in type 'Dog' but required in type 'Cat'.\n\
+         'meow' is declared here.",
     );
 }
 


### PR DESCRIPTION
Closes the nested-elaboration row of #16443 — recorded on that issue by #16446's own comment as "found while building the matrix and not previously recorded here", and unclaimed since.

**Structural rule.** When exactly one required property of a *nested* target frame is unmatched, `tsc`'s `reportUnmatchedProperty` attaches the `TS2728` `'x' is declared here.` pointer exactly as it does at the top level — it draws no distinction between an inner and an outer frame. tsz does the same through the checker's assignability renderer (`error_reporter/missing_property_declared_here.rs`), which owns this pointer.

**What was wrong, in two independent halves.**

1. *The anonymous-target half.* The leaf property name alone cannot locate the declaration: `oq` is no member of `Outer` in `const r: Outer = { inner: { op: 1 } }`, so resolving it straight against the annotation declined. The missing step is the **path**, which the object-literal syntax at the failure site spells out and which is per-occurrence by construction — the same syntactic-provenance argument that already backs this module's annotation route, since (as the module header records) an interned anonymous shape can never carry its own source location. `contextual_property_path` recovers it by the same bounded ancestor walk `target_annotation_node` already uses, stopping at the same declaration and function boundaries so the two always describe one assignment.

2. *The named-target half.* A `depth == 0` guard at the attach site suppressed the pointer on every nested frame, including targets that resolve to a real declaring symbol and needed no path walk at all. Removing it is what fixes the three chain-elaboration rows in the second commit.

Each hop is validated against the written member list before the next is taken, so an annotation that does not declare the path declines rather than anchoring somewhere plausible-but-wrong — the #16322 name+kind guard stays load-bearing and untouched. A nested frame also offers only the **leaf** target to the symbol route: the outer target legitimately does not declare this property, and a same-named member there would anchor in the wrong declaration.

**Note for #16443's readers:** that issue predicted the blocker was the `depth == 0` guard. It is half right, and misleading on the rows it was written about — the four nested-object-literal rows are reported at `depth == 0` with the anchor already inside the inner literal, so the guard is never consulted for them. I loosened it first, measured zero change, and only then found the annotation walk. The guard turned out to matter for a *different* set of rows (the chain elaborations below).

This is the pointer only. `tsc`'s sibling `TS6500` is still absent on these rows; it has a different emitter (`expected_type_from_property.rs`) and fires on `TS2739` too, so it is left as its own slice and written up on #16443.

## Goal
Goal: hold

## Verification

Every row oracled against `typescript@7.0.2` (the conformance pin) with `--noEmit --strict --pretty --target es2022 --lib es2022`. Anchors are byte-exact: the offsets tsz emits (36 / 40 / 35) are `tsc`'s reported columns 37 / 41 / 36 on those lines.

**New behaviour (commit 1) — nested object literals:**

| row | tsc | before | after |
| --- | --- | --- | --- |
| nested alias-literal target (`Outer`) | `1:37` on `oq` | none | `oq`, exact |
| nested `interface` member | `3:41` on `oq` | none | `oq`, exact |
| twice nested (`Deep`) | `6:36` on `q` | none | `q`, exact |
| nested member as a named alias (`Inner2`) | `3:29` on `iq` | none | `iq`, exact (symbol route) |
| renamed binders (anti-hardcoding) | — | none | `beta`, exact |
| **negative:** nested multi-property (`TS2739`) | no pointer | no pointer | no pointer |
| **negative:** computed path member (`[K]`) | anchors | none | none (declines) |
| **negative:** array-element literal | anchors | none | none (declines) |

The last two are honest remaining gaps pinned as declines, not parity: `tsc` resolves both. Pinned so a decline cannot silently become a wrong anchor; recorded on #16443 for follow-up.

**Fallout (commit 2) — three chain elaborations, all in tsz's favour.** The full `--lib` run surfaced three reds. Every one was a *stale expectation*, not a regression: each was written against tsz's own output while the pointer was suppressed, so it asserted a chain `tsc` does not produce. Oracled individually before touching them, and `tsc` emits the pointer in all three:

| test | tsc | now |
| --- | --- | --- |
| `extends_property_function_override_elaborates_parameter_chain` | `ovr2.ts:2:28` on `bark` | emitted |
| `override_elaboration_is_structural_not_identifier_keyed` | `ovr.ts:2:40` on `howl` | emitted |
| `incompatible_type_guards_reports_ts1226_renamed_binders` | `pred.ts:1:17` on `meow` | emitted |

Both helpers fold every related-information line into the text they compare, so the pointer surfaces as a trailing line rather than an extra chain frame — recorded at each site and in the module header. So the change closes three further parity gaps beyond the four rows it was written for.

Commands actually run, on this 4-core cloud seat:

- `cargo test -p tsz-checker --lib missing_property_declared_here` — **49/49** (42 pre-existing + 7 new). Was 42/42.
- `cargo test -p tsz-checker --lib override_incompatibility_elaboration` — **7/7**. `... type_predicate_assignability_elaboration` — **7/7**.
- `cargo test -p tsz-checker --lib` — full suite. First run: 9902 tests, exactly the 3 reds above and nothing else. Re-run after the expectation fix is in progress at time of writing, **0 failures** through the point reached; the pre-commit hook's own `-p tsz-checker` verification passed in full on both commits.
- `cargo fmt --all`, `cargo clippy` (pre-commit hook, warnings denied) — **clean** on both commits.
- `scripts/arch/arch_guard.py` — **rc=0**.

**Corpus gate.** `scripts/conformance/compare-to-parent.sh` is **owed** — the two-sided `dist-fast` build measured 55-90+ min on cold cloud seats and did not fit this session. Weighing that: this diff adds a `relatedInformation` entry and changes no diagnostic code, no primary message text, and no relation verdict, so the corpus (which scores primaries) cannot move on it. That is an argument, not a measurement — flagged for a drain step or a faster seat.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Serpentine