### PR TITLE
fix(solver): a union-source TS2322 elaboration names the wrong enum when two members share a shape

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1086,6 +1086,9 @@ path = "tests/union_generic_class_shared_member_tests.rs"
 name = "union_source_structural_elaboration_tests"
 path = "tests/union_source_structural_elaboration_tests.rs"
 [[test]]
+name = "union_source_enum_elaboration_order_tests"
+path = "tests/union_source_enum_elaboration_order_tests.rs"
+[[test]]
 name = "ts2353_omit_pick_excess_property_tests"
 path = "tests/ts2353_omit_pick_excess_property_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/union_source_enum_elaboration_order_tests.rs
+++ b/crates/tsz-checker/tests/union_source_enum_elaboration_order_tests.rs
@@ -1,0 +1,183 @@
+//! A union-source `TS2322` elaboration must drill the first-*declared* failing
+//! member, even when that member is an enum sharing another enum's structural
+//! shape.
+//!
+//! `tsc` always elaborates a failing union assignment with the union's first
+//! member (in the order the union was written); on a tie between two members
+//! of the same `TypeFlags` rank (two enums, no other tiebreaker), the printer's
+//! own TS7 stable order already keeps enum members in declaration order. The
+//! solver's interned union member list, however, is ordered by allocation
+//! identity (needed so `E1 | E2` and `E2 | E1` intern to one canonical
+//! `TypeId`) — an enum's `DefId`/`TypeId` is allocated lazily, in whatever
+//! order the checker first requests its type, which does not track source
+//! position. Elaboration selection that walks the interned list directly can
+//! therefore name the wrong enum entirely, not just the wrong order.
+//!
+//! Structural rule: `SubtypeChecker::reorder_enum_members_by_declaration`
+//! (`crates/tsz-solver/src/relations/subtype/explain.rs`) reorders only the
+//! enum-typed slots of a union-source elaboration list into declaration order
+//! before the first-failing-member scan, leaving every other member's slot —
+//! and the existing nullish-first order — untouched.
+//!
+//! Regression guard for #16513.
+
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn single(source: &str, code: u32) -> Diagnostic {
+    let diagnostics: Vec<Diagnostic> = check_source_diagnostics(source)
+        .into_iter()
+        .filter(|diagnostic| diagnostic.code == code)
+        .collect();
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "expected exactly one TS{code} diagnostic, got {diagnostics:#?}"
+    );
+    diagnostics.into_iter().next().unwrap()
+}
+
+fn related(diagnostic: &Diagnostic) -> Vec<String> {
+    diagnostic
+        .related_information
+        .iter()
+        .map(|related| related.message_text.clone())
+        .collect()
+}
+
+fn has_related(diagnostic: &Diagnostic, expected: &str) -> bool {
+    related(diagnostic)
+        .iter()
+        .any(|message| message == expected)
+}
+
+// ---------------------------------------------------------------------------
+// Two same-shaped enums: the elaboration must name whichever is declared
+// first, independent of the union annotation's own written order and
+// independent of the enums' names (varied below to rule out an alphabetical
+// coincidence).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn union_of_two_enums_elaborates_the_first_declared() {
+    let source = "
+        enum E1 { A }
+        enum E2 { A }
+        declare const e: E1 | E2;
+        const ee: boolean = e;
+    ";
+    let diagnostic = single(source, 2322);
+    assert!(
+        has_related(
+            &diagnostic,
+            "Type 'E1' is not assignable to type 'boolean'."
+        ),
+        "expected the first-declared enum E1 in the elaboration, got {:?}",
+        related(&diagnostic)
+    );
+    assert!(
+        !has_related(
+            &diagnostic,
+            "Type 'E2' is not assignable to type 'boolean'."
+        ),
+        "must not elaborate the second-declared enum E2, got {:?}",
+        related(&diagnostic)
+    );
+}
+
+/// Same shape, renamed binders, and declaration order reversed relative to the
+/// annotation's written order (`Beta` declared first, `Alpha` second, but the
+/// annotation reads `Alpha | Beta`) — rules out both an alphabetical-name
+/// coincidence and a written-annotation-order coincidence.
+#[test]
+fn union_of_two_enums_elaborates_by_declaration_order_not_annotation_or_name_order() {
+    let source = "
+        enum Beta { A }
+        enum Alpha { A }
+        declare const e: Alpha | Beta;
+        const ee: boolean = e;
+    ";
+    let diagnostic = single(source, 2322);
+    assert!(
+        has_related(
+            &diagnostic,
+            "Type 'Beta' is not assignable to type 'boolean'."
+        ),
+        "expected the first-declared enum Beta in the elaboration, got {:?}",
+        related(&diagnostic)
+    );
+    assert!(
+        !has_related(
+            &diagnostic,
+            "Type 'Alpha' is not assignable to type 'boolean'."
+        ),
+        "must not elaborate the second-declared enum Alpha, got {:?}",
+        related(&diagnostic)
+    );
+}
+
+/// Three same-shaped enums: the elaboration must still name the first
+/// declared, not merely "not last".
+#[test]
+fn union_of_three_enums_elaborates_the_first_declared() {
+    let source = "
+        enum A1 { X }
+        enum A2 { X }
+        enum A3 { X }
+        declare const e: A1 | A2 | A3;
+        const ee: boolean = e;
+    ";
+    let diagnostic = single(source, 2322);
+    assert!(
+        has_related(
+            &diagnostic,
+            "Type 'A1' is not assignable to type 'boolean'."
+        ),
+        "expected the first-declared enum A1 in the elaboration, got {:?}",
+        related(&diagnostic)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls: shapes the enum-declaration reorder must leave alone.
+// ---------------------------------------------------------------------------
+
+/// A single enum in the union (no tie to break) keeps naming that enum.
+#[test]
+fn union_of_enum_and_primitive_still_elaborates_the_failing_member() {
+    let source = "
+        enum E1 { A }
+        declare const e: E1 | string;
+        const ee: boolean = e;
+    ";
+    let diagnostic = single(source, 2322);
+    assert!(
+        has_related(
+            &diagnostic,
+            "Type 'string' is not assignable to type 'boolean'."
+        ),
+        "expected the lower-ranked primitive member in the elaboration, got {:?}",
+        related(&diagnostic)
+    );
+}
+
+/// A nullish member ahead of two enums keeps the existing nullish-first
+/// elaboration order — the enum-declaration reorder must not disturb it.
+#[test]
+fn union_of_undefined_and_two_enums_still_elaborates_undefined_first() {
+    let source = "
+        enum E1 { A }
+        enum E2 { A }
+        declare const v: undefined | E1 | E2;
+        const ee: boolean = v;
+    ";
+    let diagnostic = single(source, 2322);
+    assert!(
+        has_related(
+            &diagnostic,
+            "Type 'undefined' is not assignable to type 'boolean'."
+        ),
+        "expected the nullish member ahead of both enums in the elaboration, got {:?}",
+        related(&diagnostic)
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -9,6 +9,7 @@ use crate::diagnostics::SubtypeFailureReason;
 use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
 use crate::relations::subtype::SubtypeChecker;
 use crate::relations::subtype::explain_guard::{ExplainFuelState, ExplainRecursionEntryState};
+use crate::relations::subtype::explain_union_order::reorder_union_members_nullish_first;
 use crate::type_queries::data::get_object_symbol;
 use crate::types::{
     IntrinsicKind, LiteralValue, ObjectShape, ObjectShapeId, PropertyInfo, TupleElement,
@@ -33,35 +34,6 @@ use crate::visitor::{
 /// magnitude mirrors the proven eval-fuel bound added to the diagnostic display
 /// pass in PR #13176.
 pub(crate) const EXPLAIN_EVAL_BUDGET: u32 = 16_000;
-
-/// Reorder a source union's members into tsc's relation-iteration order for
-/// error elaboration.
-///
-/// `eachTypeRelatedToType` walks `source.types` in ascending type-id order, and
-/// the intrinsic `undefined` and `null` types are allocated before any user
-/// type — so tsc examines them first and elaborates a failing nullish member
-/// ahead of the others. tsz stores union members with `undefined`/`null` last
-/// (that is tsc's *printer* order, keyed by `builtin_sort_key`), so this
-/// restores the relation order used to pick the first failing member:
-/// `undefined`, then `null`, then the remaining members unchanged. Non-nullish
-/// unions keep their stored order, which already matches tsc's relation order.
-fn reorder_union_members_nullish_first(members: &[TypeId]) -> Vec<TypeId> {
-    let mut ordered = Vec::with_capacity(members.len());
-    // `undefined` before `null` (their intrinsic allocation order), then the
-    // remaining members in their stored order.
-    for nullish in [TypeId::UNDEFINED, TypeId::NULL] {
-        if members.contains(&nullish) {
-            ordered.push(nullish);
-        }
-    }
-    ordered.extend(
-        members
-            .iter()
-            .copied()
-            .filter(|&m| m != TypeId::UNDEFINED && m != TypeId::NULL),
-    );
-    ordered
-}
 
 impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// Array element type, transparently peeling a single `readonly` array
@@ -1254,7 +1226,21 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             // first), not tsz's stored *printer* order (nullish last) — see
             // `reorder_union_members_nullish_first`. Example: `number | undefined`
             // -> `string` drills the `undefined` member, matching tsc.
-            let ordered = reorder_union_members_nullish_first(&members);
+            let mut ordered = reorder_union_members_nullish_first(&members);
+            // Same-rank enum members: `sort_union_members` orders the interned
+            // list by allocation identity (needed so `E1 | E2` and `E2 | E1`
+            // intern to one canonical `TypeId`), which does not track
+            // declaration order — an enum's `DefId`/`TypeId` can be allocated
+            // lazily, in whatever order the checker first requests its type,
+            // independent of source position (issue #16513). tsc always
+            // elaborates the union's first-declared failing member, and the
+            // printer's own tie-break already keeps enum members in
+            // declaration order (`order_union_members_by_source`). Reorder
+            // just the enum members among themselves — by declaration
+            // position, in place, leaving every other member's slot and the
+            // rest of the nullish-first order untouched — so elaboration
+            // selection agrees with what the union header already displays.
+            self.reorder_enum_members_by_declaration(&mut ordered);
             for &member in ordered.iter() {
                 if member == source || member == union_member_source {
                     // Defensive: avoid self-recursion on a degenerate union.

--- a/crates/tsz-solver/src/relations/subtype/explain_union_order.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain_union_order.rs
@@ -1,0 +1,98 @@
+//! Ordering helpers for union-source failure elaboration.
+//!
+//! `SubtypeChecker::explain_failure_guarded`'s union-source arm needs the
+//! union's members in the order `tsc`'s relation walk would examine them, to
+//! pick the same "first failing member" `tsc` elaborates beneath the
+//! union-to-target line. The interner's own stored member order is a
+//! *canonicalization* order (needed so `A | B` and `B | A` intern to one
+//! `TypeId`), not the source-declaration order — these two reorders bridge
+//! that gap without touching the interned identity itself.
+
+use crate::def::resolver::TypeResolver;
+use crate::relations::subtype::SubtypeChecker;
+use crate::types::TypeId;
+
+/// Reorder a source union's members into tsc's relation-iteration order for
+/// error elaboration.
+///
+/// `eachTypeRelatedToType` walks `source.types` in ascending type-id order, and
+/// the intrinsic `undefined` and `null` types are allocated before any user
+/// type — so tsc examines them first and elaborates a failing nullish member
+/// ahead of the others. tsz stores union members with `undefined`/`null` last
+/// (that is tsc's *printer* order, keyed by `builtin_sort_key`), so this
+/// restores the relation order used to pick the first failing member:
+/// `undefined`, then `null`, then the remaining members unchanged. Non-nullish
+/// unions keep their stored order, which matches tsc's relation order except
+/// for same-rank enum members — see [`SubtypeChecker::reorder_enum_members_by_declaration`].
+pub(super) fn reorder_union_members_nullish_first(members: &[TypeId]) -> Vec<TypeId> {
+    let mut ordered = Vec::with_capacity(members.len());
+    // `undefined` before `null` (their intrinsic allocation order), then the
+    // remaining members in their stored order.
+    for nullish in [TypeId::UNDEFINED, TypeId::NULL] {
+        if members.contains(&nullish) {
+            ordered.push(nullish);
+        }
+    }
+    ordered.extend(
+        members
+            .iter()
+            .copied()
+            .filter(|&m| m != TypeId::UNDEFINED && m != TypeId::NULL),
+    );
+    ordered
+}
+
+impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
+    /// Reorder same-rank enum members of a union-source elaboration list into
+    /// declaration order, in place.
+    ///
+    /// `sort_union_members` (the interner's canonicalization pass) orders a
+    /// union's stored member list by allocation identity so that `E1 | E2`
+    /// and `E2 | E1` intern to one canonical `TypeId` — a `DefId`/`TypeId` is
+    /// allocated lazily, in whatever order the checker first requests an
+    /// enum's type, which does not track source position. `tsc` always
+    /// elaborates the union's first-*declared* failing member, and the
+    /// printer's own tie-break for same-rank union members keeps enum
+    /// members in declaration order (`order_union_members_by_source`'s
+    /// `compare_union_member_names` exception for enums). Without this, the
+    /// elaboration line can name the wrong enum entirely — not just the wrong
+    /// order, but a sibling enum with an unrelated declaration (#16513).
+    ///
+    /// Only the slots already holding an enum member are touched: their
+    /// values are reassigned by ascending `(file_id, span_start)`, leaving
+    /// every other member's position — and the nullish-first order already
+    /// applied — untouched. A union with 0 or 1 enum members is a no-op.
+    pub(in crate::relations::subtype) fn reorder_enum_members_by_declaration(
+        &self,
+        members: &mut [TypeId],
+    ) {
+        let Some(def_store) = self
+            .query_db
+            .and_then(|db| db.definition_store_for_inference())
+        else {
+            return;
+        };
+        let mut enum_slots: Vec<usize> = Vec::new();
+        let mut keyed: Vec<((u32, u32), TypeId)> = Vec::new();
+        for (idx, &member) in members.iter().enumerate() {
+            let Some(def_id) = crate::type_queries::get_enum_def_id(self.interner, member) else {
+                continue;
+            };
+            let Some(def) = def_store.get(def_id) else {
+                continue;
+            };
+            let (Some(file_id), Some((span_start, _))) = (def.file_id, def.span) else {
+                continue;
+            };
+            enum_slots.push(idx);
+            keyed.push(((file_id, span_start), member));
+        }
+        if keyed.len() < 2 {
+            return;
+        }
+        keyed.sort_by_key(|&(pos, _)| pos);
+        for (&idx, &(_, member)) in enum_slots.iter().zip(keyed.iter()) {
+            members[idx] = member;
+        }
+    }
+}

--- a/crates/tsz-solver/src/relations/subtype/mod.rs
+++ b/crates/tsz-solver/src/relations/subtype/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod explain_function;
 pub(crate) mod explain_guard;
 pub(crate) mod explain_indexes;
 pub(crate) mod explain_tuple;
+pub(crate) mod explain_union_order;
 pub(crate) mod helpers;
 pub(crate) mod overlap;
 pub(crate) mod rules;


### PR DESCRIPTION
When a union assignment fails and two or more of the union's members are enums of the same structural shape (e.g. two single-member numeric enums), `tsc` always elaborates the union's first-*declared* failing member — but tsz could name a completely different, unrelated enum.

## Structural rule

`sort_union_members` (the interner's canonicalization pass) orders a union's interned member list by allocation identity, so that `E1 | E2` and `E2 | E1` intern to one canonical `TypeId`. An enum's `DefId`/`TypeId` is allocated lazily — whenever the checker first requests that enum's type — which does not track source declaration position. `tsc` always elaborates a failing union assignment with the union's first-*declared* member; on a same-rank tie (two enums, no other tiebreaker) that is also exactly what the printer's own TS7 stable order already produces for the union's header line (`order_union_members_by_source`'s enum exception). The solver's union-source elaboration in `explain.rs` assumed the interned member order already matched that relation order and walked it directly — so on a tie it could name a *different, unrelated* enum entirely, not merely the wrong order.

```ts
enum E1 { A }
enum E2 { A }
declare const e: E1 | E2;
const ee: boolean = e;
```

- `tsc`: `Type 'E1' is not assignable to type 'boolean'.`
- tsz before: `Type 'E2' is not assignable to type 'boolean'.` (names the wrong enum)
- tsz after: `Type 'E1' is not assignable to type 'boolean'.`

`SubtypeChecker::reorder_enum_members_by_declaration` (in the new `explain_union_order.rs`, split out from `explain.rs` to stay under the 2000-line arch-size ceiling) reorders only the enum-typed slots of the elaboration list into declaration order (`(file_id, span_start)`, read through the shared `DefinitionStore` the same way `get_source_position_for_type` already does for display), leaving every other member's slot and the existing nullish-first order untouched.

## Adjacent-case matrix (oracle-confirmed against pinned `typescript@7.0.2`)

| case | tsc | before | after |
| --- | --- | --- | --- |
| `E1 \| E2` (E1 declared first) | names `E1` | names `E2` ❌ | names `E1` ✅ |
| `E2 \| E1` (E2 declared first, annotation reversed) | names `E2` | names `E1` ❌ | names `E2` ✅ |
| renamed binders (`Beta` declared first, `Alpha` second, annotation `Alpha \| Beta`) | names `Beta` | names `Alpha` ❌ | names `Beta` ✅ |
| three same-shaped enums `A1 \| A2 \| A3` | names `A1` | names a different one ❌ | names `A1` ✅ |
| negative: `E1 \| string` (no tie) | names `string` | names `string` ✅ | names `string` ✅ |
| negative: `undefined \| E1 \| E2` (nullish-first still applies) | names `undefined` | names `undefined` ✅ | names `undefined` ✅ |

This is issue #16513's row 2. Row 1 of that issue (an unrelated object-literal alias-repaint defect) is a separate owner mechanism and is **not** touched by this PR — left open with a traced next probe in a comment on #16513.

## Goal
Goal: hold

## Verification
- New integration test `crates/tsz-checker/tests/union_source_enum_elaboration_order_tests.rs`: 5/5 passed (two/three-enum positive cases with varied binder names and declaration/annotation order, plus negative controls for a single enum and a nullish-ahead-of-two-enums union).
- `cargo test -p tsz-solver --lib`: 7643/7643 passed (no regressions).
- `cargo test -p tsz-solver --lib union_display`: 6/6 passed (no interaction with #16512's identity-keyed dedup fix).
- `cargo test -p tsz-checker --test enum_nominality_tests`: 43/43 passed.
- `cargo test -p tsz-checker --test union_source_missing_property_elaboration_tests --test union_source_structural_elaboration_tests --test union_target_missing_property_elaboration_tests --test array_source_tuple_target_elaboration_tests`: 5/5, 21/21, 13/13, 10/10 passed.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --profile ci-lint -p tsz-solver -p tsz-checker --all-targets -- -D warnings`: clean.
- `python3 scripts/arch/arch_guard.py`: clean (explain.rs 2004/2026 lines after the split).
- `scripts/conformance/compare-to-parent.sh origin/main`: running at PR open (cold-seat two-sided build, ~50-90 min per board notes); will post the newly-failing count as a follow-up comment. This is a message-text-only change gated on two structurally-identical enums appearing in one failing union assignment — expected near-zero corpus impact, matching the established pattern for this class of display fix (#16512).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01448bfzFbAhWpp2QjGGUvgN)_