### PR TITLE
fix(checker): default-imported namespace/enum members are reachable through the default import (#16503)

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/name_resolution.rs
+++ b/crates/tsz-checker/src/query_boundaries/name_resolution.rs
@@ -390,10 +390,19 @@ impl<'a> CheckerState<'a> {
             .expect("ExportedMember lookup requires parent_symbol");
 
         let lib_binders = self.get_lib_binders();
-        let parent_symbol = self
-            .ctx
-            .binder
-            .get_symbol_with_libs(parent_sym, &lib_binders);
+        // Read the parent namespace/module from its *owning* binder, not the
+        // checking file's: per-file binders mint raw `SymbolId`s from zero, so
+        // a cross-file-resolved `parent_sym` (a re-anchored default-export
+        // namespace, a named import's target) read bare from `self.ctx.binder`
+        // collides with an unrelated local at the same id — surfacing as a
+        // wrong namespace name in the `TS2694` text (a nearby `var`) and as an
+        // exports lookup against the wrong symbol (#16465/#16503). Mirrors the
+        // cross-file-first read in `classify` above.
+        let parent_symbol = self.get_cross_file_symbol(parent_sym).or_else(|| {
+            self.ctx
+                .binder
+                .get_symbol_with_libs(parent_sym, &lib_binders)
+        });
 
         let parent_name = parent_symbol
             .map(|s| {

--- a/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
+++ b/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
@@ -568,7 +568,8 @@ impl<'a> CheckerState<'a> {
             && left_node.kind == SyntaxKind::Identifier as u16
         {
             if let Some(sym_id) = self.resolve_identifier_symbol_as_qualified_type_anchor(qn.left) {
-                if let Some(symbol) = self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders) {
+                let anchor_symbol = self.qualified_anchor_symbol(sym_id, &lib_binders);
+                if let Some(symbol) = anchor_symbol.as_deref() {
                     left_sym_for_missing = Some(sym_id);
                     left_module_specifier = symbol.import_module().map(str::to_string);
                     let mut result = self.resolve_symbol_export_for(
@@ -675,11 +676,13 @@ impl<'a> CheckerState<'a> {
             return member_type;
         }
 
+        // Read the missing-member anchor from its owning binder (owned when
+        // cross-file) so its reference survives the `&mut self` calls below —
+        // same rule as the member-lookup site above (#16465/#16503).
+        let missing_owner = left_sym_for_missing
+            .and_then(|left_sym_id| self.qualified_anchor_symbol(left_sym_id, &lib_binders));
         if let Some(left_sym_id) = left_sym_for_missing
-            && let Some(symbol) = self
-                .ctx
-                .binder
-                .get_symbol_with_libs(left_sym_id, &lib_binders)
+            && let Some(symbol) = missing_owner.as_deref()
             && (symbol.flags
                 & (symbol_flags::MODULE
                     | symbol_flags::CLASS
@@ -1012,6 +1015,39 @@ impl<'a> CheckerState<'a> {
         }
 
         self.resolve_namespace_member_from_all_binders(namespace_name, member_name)
+    }
+
+    /// Read a qualified-name anchor `Symbol`, owning it only when it lives in
+    /// another file.
+    ///
+    /// A cross-file-resolved `sym_id` (a re-anchored default-export
+    /// namespace/enum, a named import's target) read bare from the *current*
+    /// file's binder collides with an unrelated local at the same raw id —
+    /// per-file binders mint `SymbolId`s from zero (#16465/#16503) — so it must
+    /// come from its owning binder. That read borrows `self`, so it is cloned to
+    /// outlive the later `&mut self` member-resolution calls. A purely-local
+    /// anchor (the common case) takes the zero-clone `'a` borrow from the
+    /// current binder instead of paying for a `Symbol` clone.
+    fn qualified_anchor_symbol<'b>(
+        &self,
+        sym_id: SymbolId,
+        lib_binders: &'b [std::sync::Arc<tsz_binder::BinderState>],
+    ) -> Option<std::borrow::Cow<'b, tsz_binder::Symbol>>
+    where
+        'a: 'b,
+    {
+        if self
+            .ctx
+            .resolve_symbol_file_index(sym_id)
+            .is_some_and(|owner| owner != self.ctx.current_file_idx)
+            && let Some(symbol) = self.get_symbol_from_registered_file_target(sym_id)
+        {
+            return Some(std::borrow::Cow::Owned(symbol.clone()));
+        }
+        self.ctx
+            .binder
+            .get_symbol_with_libs(sym_id, lib_binders)
+            .map(std::borrow::Cow::Borrowed)
     }
 
     /// Resolve a member from a symbol's exports, members, or re-exports.

--- a/crates/tsz-checker/src/symbols/symbol_resolver.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver.rs
@@ -881,10 +881,7 @@ impl<'a> CheckerState<'a> {
                     .namespace_anchor_alias_partner(sym_id, &lib_binders)
                     .unwrap_or(sym_id);
                 let mut visited_aliases = AliasCycleTracker::new();
-                Some(
-                    self.resolve_alias_symbol(anchor_src, &mut visited_aliases)
-                        .unwrap_or(anchor_src),
-                )
+                Some(self.qualified_type_anchor_symbol(anchor_src, &mut visited_aliases))
             }
             TypeSymbolResolution::ValueOnly(sym_id)
                 if self.is_import_equals_type_anchor(sym_id, &lib_binders) =>

--- a/crates/tsz-checker/src/types/queries/lib.rs
+++ b/crates/tsz-checker/src/types/queries/lib.rs
@@ -842,6 +842,69 @@ impl<'a> CheckerState<'a> {
         Some(target_sym_id)
     }
 
+    /// The qualified-name type anchor for `anchor_src`: its alias target,
+    /// followed by the namespace/enum a synthetic `export default` slot names.
+    ///
+    /// A default import of `export default <namespace|enum>` lands on the
+    /// `default` alias, which owns no member surface; hopping to the
+    /// namespace/enum it names (see
+    /// [`Self::default_export_namespace_qualifier_target`]) is what lets the
+    /// qualifier drive real member lookup — a present member resolves, a missing
+    /// one is `TS2694` — instead of collapsing. Never fails: falls back to the
+    /// alias-resolved id, then to `anchor_src`.
+    pub(crate) fn qualified_type_anchor_symbol(
+        &self,
+        anchor_src: SymbolId,
+        visited_aliases: &mut AliasCycleTracker,
+    ) -> SymbolId {
+        let resolved = self
+            .resolve_alias_symbol(anchor_src, visited_aliases)
+            .unwrap_or(anchor_src);
+        self.default_export_namespace_qualifier_target(resolved)
+            .unwrap_or(resolved)
+    }
+
+    /// Re-anchor a qualified-name left anchor that resolved to a synthetic
+    /// `export default <identifier>` alias onto the *namespace/enum* it names,
+    /// read from that declaration's own file.
+    ///
+    /// A `default` export alias carries no member surface of its own — its
+    /// type-reference type is `ERROR` for a namespace and the bare enum type
+    /// for an enum — so member lookup through it either silently drops the
+    /// qualified name (namespace) or misreads the anchor from the *current*
+    /// file's binder under the raw-`SymbolId`-collision hazard (enum), never
+    /// producing the `TS2694` a missing member deserves. Resolving the alias to
+    /// its target's real symbol, registered against its declaring file so every
+    /// downstream cross-file read lands in the right binder, restores the
+    /// member-lookup path for both.
+    ///
+    /// Returns `None` — leaving the caller on its existing anchor — unless the
+    /// target genuinely has namespace meaning (`SymbolFlags.Namespace`:
+    /// module/namespace/value-module/enum). A **class** target is excluded even
+    /// when merged with a namespace: `tsc` folds a namespace merge into the
+    /// *named* binding only, never the synthetic `default` slot, so
+    /// `export default Decl;` (a class merged with a same-named namespace) still
+    /// reports `TS2702` through the default import — the same rule the
+    /// `TS2702`/`TS2713` gate already encodes for this shape.
+    pub(crate) fn default_export_namespace_qualifier_target(
+        &self,
+        sym_id: SymbolId,
+    ) -> Option<SymbolId> {
+        // `sym_id` is (or resolved to) the synthetic `default` alias, whose
+        // declaration is the bare identifier naming the namespace/enum. Read
+        // that target from its own file and keep it only when it has namespace
+        // meaning — `SymbolFlags.Namespace` (module | namespace | value-module
+        // | enum), plus an enum member for a `export default Enum.Member` slot.
+        let target_id = self.default_export_identifier_target(sym_id)?;
+        let target = self.get_symbol_from_registered_file_target(target_id)?;
+        if target.has_any_flags(symbol_flags::CLASS) {
+            return None;
+        }
+        target
+            .has_any_flags(symbol_flags::NAMESPACE | symbol_flags::ENUM_MEMBER)
+            .then_some(target_id)
+    }
+
     /// Resolve a namespace value member by name.
     ///
     /// This function resolves value members of namespace/enum types.

--- a/crates/tsz-checker/tests/ts2702_qualifier_namespace_meaning_tests.rs
+++ b/crates/tsz-checker/tests/ts2702_qualifier_namespace_meaning_tests.rs
@@ -64,13 +64,24 @@ fn multi_file_codes(files: &[(&str, &str)], entry: &str) -> Vec<u32> {
 /// `TS2702`", not "reports `TS2694`" (see the comment on
 /// `export_default_namespace_keeps_namespace_meaning` in that suite).
 fn multi_file_codes_global_index(files: &[(&str, &str)], entry: &str) -> Vec<u32> {
+    multi_file_diags_global_index(files, entry)
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect()
+}
+
+/// Like `multi_file_codes_global_index`, but keeps `(code, message)` so the
+/// namespace name in a `TS2694` can be asserted — the load-bearing detail for
+/// #16503, where the missing-member message must name the *target* namespace,
+/// not a colliding local read from the checking file's binder.
+fn multi_file_diags_global_index(files: &[(&str, &str)], entry: &str) -> Vec<(u32, String)> {
     let options = CheckerOptions {
         strict: true,
         ..CheckerOptions::default()
     };
     check_multi_file_with_global_index(files, entry, options)
         .into_iter()
-        .map(|diagnostic| diagnostic.code)
+        .map(|diagnostic| (diagnostic.code, diagnostic.message_text))
         .collect()
 }
 
@@ -338,92 +349,13 @@ fn namespace_import_qualifier_keeps_the_member_lookup_path() {
 // meaning through the default import (closes #16486, a regression from
 // #16480: that PR's alias-target check stopped at the synthesized `default`
 // wrapper symbol's own flags, which are always bare `ALIAS` regardless of
-// what the identifier denotes)
+// what the identifier denotes). #16503 completes it: the member-lookup path
+// now hops through the `default` slot too, so a present member resolves and a
+// missing one is `TS2694` — the strict assertions live in the #16503 section
+// below (`default_exported_namespace_member_resolves_and_missing_is_ts2694`
+// and its enum / renamed twins), which supersede #16486's weaker
+// "must not be TS2702" checks.
 // ---------------------------------------------------------------------------
-
-/// `export default m;` where `m` is a previously-declared namespace: `tsc`
-/// resolves `D.foo` as a member lookup, never `TS2702` — the default export is
-/// an alias to `m`'s own declaration, not a fresh symbol with its own
-/// (non-namespace) meaning. As `qualified_name_default_import_namespace_meaning_tests`'s
-/// own `export_default_namespace_keeps_namespace_meaning` control documents,
-/// the no-lib multi-file harness does not reliably surface the downstream
-/// missing-member `TS2694` for this shape; the load-bearing assertion for this
-/// regression is the absence of `TS2702` on both a present and a missing
-/// member.
-#[test]
-fn default_exported_namespace_identifier_keeps_namespace_meaning() {
-    let present = multi_file_codes_global_index(
-        &[
-            (
-                "dep.ts",
-                "namespace m { export interface foo { a: number } }\nexport default m;\n",
-            ),
-            ("main.ts", "import D from './dep';\nvar q: D.foo;\n"),
-        ],
-        "main.ts",
-    );
-    assert!(
-        !present.contains(&2702),
-        "a present member of an export-default namespace must not be TS2702, got: {present:?}"
-    );
-
-    let missing = multi_file_codes_global_index(
-        &[
-            (
-                "dep.ts",
-                "namespace m { export interface foo { a: number } }\nexport default m;\n",
-            ),
-            ("main.ts", "import D from './dep';\nvar bad: D.Missing;\n"),
-        ],
-        "main.ts",
-    );
-    assert!(
-        !missing.contains(&2702),
-        "a missing member of an export-default namespace must not become TS2702, got: {missing:?}"
-    );
-}
-
-/// `export default Color;` where `Color` is a previously-declared enum: an
-/// enum carries `SymbolFlags.Namespace` (`Enum` is in the set), so it must
-/// never report `TS2702` through a default-exported identifier alias, matching
-/// the namespace case above.
-#[test]
-fn default_exported_enum_identifier_keeps_namespace_meaning() {
-    let codes = multi_file_codes_global_index(
-        &[
-            ("e.ts", "enum Color { Red, Green }\nexport default Color;\n"),
-            ("main.ts", "import C from './e';\nvar bad: C.Nope;\n"),
-        ],
-        "main.ts",
-    );
-    assert!(
-        !codes.contains(&2702),
-        "an enum default export keeps namespace meaning (no TS2702), got: {codes:?}"
-    );
-}
-
-/// The local binding name at the import site is irrelevant — resolution goes
-/// through the `default` export slot's own target, not the local spelling.
-#[test]
-fn renamed_default_import_of_namespace_identifier_keeps_namespace_meaning() {
-    let codes = multi_file_codes_global_index(
-        &[
-            (
-                "dep2.ts",
-                "namespace m { export interface foo { a: number } }\nexport default m;\n",
-            ),
-            (
-                "main2.ts",
-                "import Renamed from './dep2';\nvar bad: Renamed.Missing;\n",
-            ),
-        ],
-        "main2.ts",
-    );
-    assert!(
-        !codes.contains(&2702),
-        "renaming the local binding must not affect the default export's namespace meaning, got: {codes:?}"
-    );
-}
 
 /// Negative control, restated from `default_imported_class_used_as_namespace_reports_type_used_as_namespace`:
 /// a default-exported class *merged* with a same-named namespace still
@@ -479,5 +411,222 @@ fn default_exported_bare_ref_class_merged_with_namespace_still_reports_ts2702() 
             "/main4.ts",
         ),
         vec![2702]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #16503: a default-exported namespace/enum's real members are reachable
+// through the default import. #16486 only stopped the false `TS2702` at the
+// diagnostic gate; the member-lookup path still routed the synthetic `default`
+// alias, so a present member resolved only by error-masking coincidence and a
+// missing member emitted *nothing* (namespace) or `TS2503` (enum) instead of
+// tsc's `TS2694`. The anchor now hops to the real namespace/enum symbol, read
+// from its declaring binder, so both a present member and a missing one behave
+// like tsc.
+//
+// All rows oracled against the pinned `tsc` (`--noEmit --strict --pretty false
+// --target es2022 --lib es2022`). The `TS2694` names the *target* namespace
+// (`m`/`Color`), not the local import alias — tsc's `getFullyQualifiedName` of
+// the resolved namespace symbol, confirmed against the oracle:
+//   main2.ts(2,10): error TS2694: Namespace 'm2' has no exported member 'Missing'.
+//   maine.ts(2,12): error TS2694: Namespace 'Color' has no exported member 'Nope'.
+// ---------------------------------------------------------------------------
+
+/// A present member of a default-exported namespace resolves cleanly, and a
+/// missing one is `TS2694` naming the target namespace — not silence, and not
+/// `TS2702`.
+#[test]
+fn default_exported_namespace_member_resolves_and_missing_is_ts2694() {
+    const DEP: &str = "namespace m { export interface foo { a: number } }\nexport default m;\n";
+
+    let present = multi_file_diags_global_index(
+        &[
+            ("dep.ts", DEP),
+            ("main.ts", "import D from './dep';\nvar q: D.foo;\n"),
+        ],
+        "main.ts",
+    );
+    assert_eq!(
+        present,
+        Vec::<(u32, String)>::new(),
+        "a present member resolves with no diagnostic"
+    );
+
+    let missing = multi_file_diags_global_index(
+        &[
+            ("dep.ts", DEP),
+            ("main.ts", "import D from './dep';\nvar bad: D.Missing;\n"),
+        ],
+        "main.ts",
+    );
+    assert_eq!(
+        missing,
+        vec![(
+            2694,
+            "Namespace 'm' has no exported member 'Missing'.".to_string()
+        )],
+        "a missing member is TS2694 naming the target namespace"
+    );
+}
+
+/// The enum twin: `enum Color` carries `SymbolFlags.Namespace` (`Enum` is in
+/// the set), so `C.Red` resolves and `C.Nope` is `TS2694` naming `Color`.
+/// Before the fix the enum default import produced `TS2503` for both.
+#[test]
+fn default_exported_enum_member_resolves_and_missing_is_ts2694() {
+    const DEP: &str = "enum Color { Red, Green }\nexport default Color;\n";
+
+    let present = multi_file_diags_global_index(
+        &[
+            ("e.ts", DEP),
+            ("main.ts", "import C from './e';\nvar ok: C.Red;\n"),
+        ],
+        "main.ts",
+    );
+    assert_eq!(
+        present,
+        Vec::<(u32, String)>::new(),
+        "a present enum member resolves with no diagnostic"
+    );
+
+    let missing = multi_file_diags_global_index(
+        &[
+            ("e.ts", DEP),
+            ("main.ts", "import C from './e';\nvar bad: C.Nope;\n"),
+        ],
+        "main.ts",
+    );
+    assert_eq!(
+        missing,
+        vec![(
+            2694,
+            "Namespace 'Color' has no exported member 'Nope'.".to_string()
+        )],
+        "a missing enum member is TS2694 naming the enum"
+    );
+}
+
+/// Anti-hardcoding: the hop keys on the `default` slot's target flags, not on
+/// any spelling. Renaming both the namespace binder and the local import
+/// binding leaves the behaviour — and the target-relative message name —
+/// unchanged.
+#[test]
+fn default_exported_namespace_member_rule_is_binder_name_independent() {
+    let missing = multi_file_diags_global_index(
+        &[
+            (
+                "dep.ts",
+                "namespace Payload { export interface foo { a: number } }\nexport default Payload;\n",
+            ),
+            (
+                "main.ts",
+                "import Renamed from './dep';\nvar bad: Renamed.Missing;\n",
+            ),
+        ],
+        "main.ts",
+    );
+    assert_eq!(
+        missing,
+        vec![(
+            2694,
+            "Namespace 'Payload' has no exported member 'Missing'.".to_string()
+        )],
+        "the message names the renamed target namespace, not the local alias"
+    );
+}
+
+/// The same raw-`SymbolId`-collision fix restores the correct namespace name
+/// for a *named* cross-file import too: before it, the missing-member `TS2694`
+/// read the anchor from the checking file's binder and named a nearby local
+/// (`var z`). This is the pre-existing collision #16503's member-lookup read
+/// also fixed, pinned so it cannot silently regress.
+#[test]
+fn named_cross_file_namespace_missing_member_names_the_target_namespace() {
+    let missing = multi_file_diags_global_index(
+        &[
+            (
+                "n1.ts",
+                "export namespace Named { export interface I { q: number } }\n",
+            ),
+            (
+                "n2.ts",
+                "import { Named } from './n1';\nvar z: Named.Missing;\n",
+            ),
+        ],
+        "n2.ts",
+    );
+    assert_eq!(
+        missing,
+        vec![(
+            2694,
+            "Namespace 'Named' has no exported member 'Missing'.".to_string()
+        )],
+    );
+}
+
+/// Negative control for the hop's class exclusion, restated at message level:
+/// a default-exported *class* has no namespace meaning, so `D.X` stays
+/// `TS2702` and never becomes a member lookup. (Codes-level twins live in
+/// `default_imported_class_used_as_namespace_reports_type_used_as_namespace`.)
+#[test]
+fn default_exported_class_member_access_stays_ts2702_not_ts2694() {
+    let codes = multi_file_codes_global_index(
+        &[
+            ("t1.ts", "export default class D { m: number = 0 }\n"),
+            ("t2.ts", "import D from './t1';\nvar a: D.X;\n"),
+        ],
+        "t2.ts",
+    );
+    assert_eq!(
+        codes,
+        vec![2702],
+        "a default-exported class stays TS2702, never TS2694"
+    );
+}
+
+/// Uncovered-and-pinned: a member reached *through a re-export hub*
+/// (`export { default } from './dep'`) is not resolved — tsc follows the hub to
+/// the original namespace and reports `TS2694 Namespace 'm2' has no exported
+/// member 'Missing'`, tsz reports `TS2702` (the qualifier resolves to a type
+/// with no namespace meaning). This is not specific to `default` — a named
+/// re-export hub (`export { Foo } from './dep'`) behaves identically — so it is
+/// a pre-existing gap in following re-export chains for a *type-position*
+/// qualified-name anchor, outside #16503's default-import member routing (the
+/// default→namespace hop only fires when the `default` slot's declaration is a
+/// bare identifier, which a re-export specifier is not). Pinned as today's
+/// behaviour so a future re-export-chain fix is caught by the change.
+#[test]
+fn reexport_hub_member_is_currently_ts2702_not_ts2694() {
+    let default_hub = multi_file_codes_global_index(
+        &[
+            (
+                "dep.ts",
+                "namespace m { export interface foo { a: number } }\nexport default m;\n",
+            ),
+            ("hub.ts", "export { default } from './dep';\n"),
+            ("main.ts", "import D from './hub';\nvar bad: D.Missing;\n"),
+        ],
+        "main.ts",
+    );
+    assert_eq!(default_hub, vec![2702], "re-export default hub is TS2702");
+
+    let named_hub = multi_file_codes_global_index(
+        &[
+            (
+                "dep.ts",
+                "export namespace Foo { export interface bar { a: number } }\n",
+            ),
+            ("hub.ts", "export { Foo } from './dep';\n"),
+            (
+                "main.ts",
+                "import { Foo } from './hub';\nvar bad: Foo.Missing;\n",
+            ),
+        ],
+        "main.ts",
+    );
+    assert_eq!(
+        named_hub,
+        vec![2702],
+        "a named re-export hub behaves the same — the gap is not default-specific"
     );
 }


### PR DESCRIPTION
Closes the residual of #16503 (residual from #16486): a default-imported
namespace/enum's real members are now reachable through the default import.

**Structural rule.** When a qualified type name's left anchor is a default
import of `export default <namespace|enum>`, `tsc` resolves the member against
the *target* namespace/enum's exports and, for a missing member, reports
`TS2694 Namespace '<target>' has no exported member '<name>'` naming the
resolved target. tsz routed member lookup through the synthetic `default`
alias, which owns no member surface — so a present member resolved only by
error-masking coincidence and a missing member emitted *nothing* (namespace,
`left_type` collapsed to `ERROR` → early return) or `TS2503` (enum, the anchor
was misread from the checking file's binder). #16486 only patched the `TS2702`
diagnostic *gate*, not the member-lookup path.

Owner layer: the qualified-name anchor resolver
(`symbols/symbol_resolver.rs`) re-anchors through the new
`default_export_namespace_qualifier_target` query (`types/queries/lib.rs`),
built on the existing `default_export_identifier_target`. Every cross-file
symbol read on the member-lookup path now goes through the owning binder
(`get_symbol_from_registered_file_target` / `get_cross_file_symbol`) instead of
a raw-`SymbolId` read against the checking file's binder (the #16465 collision
family).

### What changed
- `symbols/symbol_resolver.rs`: the `Type` anchor arm resolves through a new
  `qualified_type_anchor_symbol` (alias-resolve + default-export hop).
- `types/queries/lib.rs`: `default_export_namespace_qualifier_target` hops the
  `default` slot to the namespace/enum it names, **excluding a class** target
  (a namespace merge folds into the named binding only, never the synthetic
  `default` slot, so a default-imported class stays `TS2702`).
- `state/type_analysis/qualified_names.rs`: both member-lookup reads go through
  the owning binder via a shared `qualified_anchor_symbol` helper that clones
  the `Symbol` only when it is cross-file (the common local anchor stays a
  zero-clone borrow).
- `query_boundaries/name_resolution.rs`: the `TS2694` parent-namespace read
  goes through the owning binder — which also corrects a **pre-existing**
  collision where a *named* cross-file import's missing-member message named a
  nearby local `var` (`Namespace 'z' …`) instead of the target namespace.

### Adjacent-case matrix (all oracled against pinned `tsc`)
| Shape | Behaviour |
| --- | --- |
| default-exported namespace, present member (`D.foo`) | resolves, no diagnostic |
| default-exported namespace, missing member (`D.Missing`) | `TS2694 Namespace 'm' …` |
| default-exported enum, present member (`C.Red`) | resolves, no diagnostic |
| default-exported enum, missing member (`C.Nope`) | `TS2694 Namespace 'Color' …` |
| renamed binders + renamed default import | same, target-relative name |
| named cross-file import, missing member | `TS2694 Namespace 'Named' …` (pre-existing name collision fixed) |
| default-exported **class** (`D.X`) | still `TS2702` (negative control) |

### Deliberately not fixed (pinned)
A member reached *through a re-export hub* (`export { default } from './dep'`)
resolves to `TS2702` where tsc follows the hub and reports `TS2694`. This is
not default-specific — a named re-export hub (`export { Foo } from './dep'`)
behaves identically — so it is a pre-existing gap in following re-export chains
for a *type-position* qualified-name anchor, outside this fix's default-import
member routing. Pinned as today's behaviour
(`reexport_hub_member_is_currently_ts2702_not_ts2694`) so a future
re-export-chain fix is caught.

## Goal
Goal: green

## Verification
- `cargo test -p tsz-checker --lib ts2702_qualifier_namespace_meaning` — 23/23
  pass (6 new #16503 rows; 3 weak #16486 "must-not-be-TS2702" rows replaced by
  strict TS2694 twins).
- `cargo test -p tsz-checker --lib` — full crate: 0 failures across ~9.9k tests
  (the one non-completion is the pre-existing `ts2589` recursive-conditional
  hang, #15338, structurally unrelated).
- `cargo clippy -p tsz-checker --all-targets` — clean; `scripts/arch/arch_guard.py`
  — clean (`symbol_resolver.rs` kept under the 2000-line cap); pre-commit gate
  (clippy + arch + verify) green.
- Oracle: pinned `tsc` `--noEmit --strict --pretty false --target es2022
  --lib es2022` on every matrix row.
- No conformance movement expected: the corpus fingerprint compares primary
  diagnostic codes; the namespace/enum rows move a missing-member edge case
  (not a required row) from no-code/`TS2503` to `TS2694`, and the named-import
  change only corrects a message string.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQJpx2DWqKNXY7UUUjzZep)_