### PR TITLE
fix(checker): a TS2407 for-in operand reports its own checked type, not the widened property-access form

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -487,6 +487,9 @@ mod for_in_intersection_operand_tests;
 #[path = "../tests/for_in_narrowing_tests.rs"]
 mod for_in_narrowing_tests;
 #[cfg(test)]
+#[path = "../tests/for_in_operand_type_display_tests.rs"]
+mod for_in_operand_type_display_tests;
+#[cfg(test)]
 #[path = "../tests/for_in_self_reference_and_nullable_operand_tests.rs"]
 mod for_in_self_reference_and_nullable_operand_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/variable_checking/for_loop.rs
+++ b/crates/tsz-checker/src/state/variable_checking/for_loop.rs
@@ -374,19 +374,25 @@ impl<'a> CheckerState<'a> {
         // below folds the whole operand to `never` and hides the object-like members.
         let raw_intersection_is_valid = self.for_in_expr_type_is_valid_intersection(expr_type);
 
-        // Resolve lazy/application types before checking (e.g. Record<string, any>)
-        let expr_type = self.resolve_type_for_property_access(expr_type);
+        // Resolve lazy/application types before checking (e.g. Record<string, any>).
+        // This resolved form is for the validity checks below ONLY: tsc's
+        // `checkForInStatement` reports the RHS's `checkExpression` result verbatim
+        // (`typeToString(rightType)`), so a fresh literal (`for (var i in 1)`) must
+        // keep displaying `'1'`, not the widened `'number'` this resolution step
+        // produces for property-access purposes. `expr_type` (the un-resolved
+        // parameter) stays the one used in the message below.
+        let resolved_expr_type = self.resolve_type_for_property_access(expr_type);
 
         // Valid types: any, unknown, object (non-primitive), object types, type parameters
         // Invalid types: primitive types (void, null, undefined, number, string, boolean,
         // bigint, symbol) and `never` (tsc reports TS2407 for `never` as well)
         let is_valid = raw_intersection_is_valid
-            || self.for_in_leaf_type_is_valid(expr_type)
+            || self.for_in_leaf_type_is_valid(resolved_expr_type)
             // Also allow union types that contain valid types
-            || self.for_in_expr_type_is_valid_union(expr_type)
+            || self.for_in_expr_type_is_valid_union(resolved_expr_type)
             // A deferred alias that resolves to an object intersection is valid if ANY
             // member is object-like (the raw operand above was not itself an intersection).
-            || self.for_in_expr_type_is_valid_intersection(expr_type);
+            || self.for_in_expr_type_is_valid_intersection(resolved_expr_type);
 
         // Checked only on the error path, so an accepted operand never pays for
         // the walk: tsc derives a for-in loop variable's type from the loop's
@@ -399,7 +405,26 @@ impl<'a> CheckerState<'a> {
         // which is a primitive and tripped a false TS2407 on `for (var of in of)`
         // and on `recursiveLetConst.ts`'s `for (let v in v)`.
         if !is_valid && !self.for_in_operand_resolution_is_circular(expression) {
-            let type_str = self.format_type(expr_type);
+            // tsc's `checkForInStatement` reports
+            // `typeToString(getNonNullableTypeIfNeeded(checkExpression(node.expression)))`
+            // — the RHS's own checked type, not the widened form the validity
+            // checks above use. Two corrections on top of `expr_type` (which is
+            // already widened by the time it reaches this function, e.g. a
+            // fresh numeric literal `1` arrives as `number`):
+            // - `getNonNullableTypeIfNeeded` collapses a bare `null`/`undefined`
+            //   RHS to `never` before display, in both strict and non-strict
+            //   mode (verified against `tsc` 7.0.2 both ways).
+            // - Any other fresh literal keeps its literal spelling
+            //   (`for (var i in 1)` → `'1'`, not `'number'`); recovered from the
+            //   operand node the same way `emit_ts2488_not_iterable` does for
+            //   for-of's analogous message.
+            let display_type = if expr_type == TypeId::NULL || expr_type == TypeId::UNDEFINED {
+                TypeId::NEVER
+            } else {
+                self.literal_type_from_initializer(expression)
+                    .unwrap_or(expr_type)
+            };
+            let type_str = self.format_type(display_type);
             let message = format_message(
                 diagnostic_messages::THE_RIGHT_HAND_SIDE_OF_A_FOR_IN_STATEMENT_MUST_BE_OF_TYPE_ANY_AN_OBJECT_TYPE_OR,
                 &[&type_str],

--- a/crates/tsz-checker/tests/for_in_operand_type_display_tests.rs
+++ b/crates/tsz-checker/tests/for_in_operand_type_display_tests.rs
@@ -1,0 +1,143 @@
+//! Regression tests for the TS2407 message's operand type display (issue
+//! surfaced while investigating `TypeScript/tests/cases/compiler/forIn2.ts`).
+//!
+//! `tsc`'s `checkForInStatement` reports
+//! `typeToString(getNonNullableTypeIfNeeded(checkExpression(node.expression)))`
+//! — the RHS's own checked type, not a type widened for property-access
+//! purposes. tsz's `check_for_in_expression_type` widens its `expr_type`
+//! parameter internally (via `resolve_type_for_property_access`, needed for
+//! the object-type validity check) and was reusing that widened value for the
+//! message too, so `for (var i in 1)` reported `'number'` where `tsc` reports
+//! `'1'`.
+//!
+//! Two corrections, both oracle-verified against `tsc` 7.0.2
+//! (`--noEmit --pretty false --target es2015`, plus `--singleThreaded
+//! --stableTypeOrdering true` — the flags `scripts/conformance/oracle.sh` adds
+//! for TypeScript 7+, see #16413):
+//!
+//! - A fresh literal operand (`1`, `"str"`, `true`, `10n`) keeps its literal
+//!   spelling, recovered from the operand node via
+//!   `literal_type_from_initializer` — the same helper
+//!   `emit_ts2488_not_iterable` already uses for the analogous for-of message.
+//! - A bare `null`/`undefined` operand displays as `'never'`
+//!   (`getNonNullableTypeIfNeeded` collapses it before `typeToString`), in
+//!   both strict and non-strict mode. Tested here under strict mode only,
+//!   where TS2407 unambiguously fires for both operands; whether TS2407 fires
+//!   at all for a non-strict bare `null`/`undefined` operand is a pre-existing
+//!   question this file does not touch (see
+//!   `for_in_self_reference_and_nullable_operand_tests.rs`) — this file only
+//!   covers the message *text* on the error path, which is independent of
+//!   whether that path is taken.
+//!
+//! An operand that is a *declared identifier* (not a literal expression) is
+//! unaffected either way: its already-widened or already-literal declared
+//! type displays exactly as before, so `let x = 5` still reports `'number'`
+//! and `declare const n: 1` still reports `'1'`. Binder names are varied so
+//! nothing here can be satisfied by a user-chosen identifier.
+
+use crate::test_utils::check_source_strict_messages;
+
+const TS2407: u32 = 2407;
+
+fn message_for(source: &str) -> String {
+    let messages = check_source_strict_messages(source);
+    let matches: Vec<&String> = messages
+        .iter()
+        .filter(|(code, _)| *code == TS2407)
+        .map(|(_, text)| text)
+        .collect();
+    assert_eq!(
+        matches.len(),
+        1,
+        "expected exactly one TS2407 in {source:?}, got: {messages:?}"
+    );
+    matches[0].clone()
+}
+
+#[test]
+fn fresh_numeric_literal_operand_keeps_its_literal_type() {
+    assert_eq!(
+        message_for("for (var i in 42) {}"),
+        "The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type '42'."
+    );
+}
+
+#[test]
+fn fresh_string_literal_operand_keeps_its_literal_type() {
+    assert_eq!(
+        message_for("for (var reader in \"payload\") {}"),
+        "The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type '\"payload\"'."
+    );
+}
+
+#[test]
+fn fresh_boolean_literal_operand_keeps_its_literal_type() {
+    assert_eq!(
+        message_for("for (var flag in true) {}"),
+        "The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'true'."
+    );
+    assert_eq!(
+        message_for("for (var flag in false) {}"),
+        "The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'false'."
+    );
+}
+
+#[test]
+fn fresh_bigint_literal_operand_keeps_its_literal_type() {
+    assert_eq!(
+        message_for("for (var big in 10n) {}"),
+        "The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type '10n'."
+    );
+}
+
+#[test]
+fn bare_null_operand_displays_as_never() {
+    assert_eq!(
+        message_for("for (var key in null) {}"),
+        "The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'never'."
+    );
+}
+
+#[test]
+fn bare_undefined_operand_displays_as_never() {
+    assert_eq!(
+        message_for("for (var key in undefined) {}"),
+        "The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'never'."
+    );
+}
+
+#[test]
+fn declared_null_typed_identifier_operand_also_displays_as_never() {
+    // Same `never` collapse applies at the type level, not just the syntax
+    // level: a `null`-typed identifier (not a literal node) must display
+    // identically to the bare `null` literal above.
+    assert_eq!(
+        message_for("declare const holder: null; for (var key in holder) {}"),
+        "The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'never'."
+    );
+}
+
+#[test]
+fn declared_literal_typed_identifier_operand_keeps_its_declared_literal_type() {
+    // Not a literal *expression* (it is an identifier), but its declared type
+    // is already the literal `1` — the message must still show `'1'`, exactly
+    // as it did before this fix (this path never went through the widened
+    // `resolve_type_for_property_access` value for display).
+    assert_eq!(
+        message_for("declare const pinned: 1; for (var key in pinned) {}"),
+        "The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type '1'."
+    );
+}
+
+#[test]
+fn widened_let_binding_operand_still_displays_its_widened_type() {
+    // `let count = 5` infers the widened `number`, and the for-in operand is
+    // an identifier (not a literal node), so `literal_type_from_initializer`
+    // declines and the message correctly falls back to the resolved type —
+    // matching `tsc`, which also widens here (ordinary `let` inference, not a
+    // for-in-specific rule).
+    assert_eq!(
+        message_for("let count = 5; for (var key in count) {}"),
+        "The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter, but here has type 'number'."
+    );
+}


### PR DESCRIPTION
`for (var i in 1) {}` reported `'number'` where `tsc` reports `'1'`; `for (var i in null) {}` reported `'null'` where `tsc` reports `'never'`.

## Structural rule

When `check_for_in_expression_type`'s `expr_type` parameter is used for the TS2407 message, tsz does X (uses the type widened by `resolve_type_for_property_access` for the object-type validity check) where tsc does X through the checker: `checkForInStatement` reports `typeToString(getNonNullableTypeIfNeeded(checkExpression(node.expression)))` — the RHS's own checked type, never the property-access-widened form.

Owner layer: checker, `crates/tsz-checker/src/state/variable_checking/for_loop.rs`. `resolve_type_for_property_access`'s widened result now feeds the validity checks only (renamed to `resolved_expr_type`); the original, un-widened `expr_type` parameter (plus a `literal_type_from_initializer` recovery for fresh literal operands) drives the message. This mirrors the pattern `emit_ts2488_not_iterable` (for-of's analogous TS2488 message, `crates/tsz-checker/src/checkers/iterable_checker.rs`) already uses for the identical widening problem — for-of's shared `expr_type` value goes through the same statement-level "non-contextual" type query and needed the same literal recovery.

## Adjacent-case matrix

Oracle-verified against `typescript@7.0.2` with `scripts/conformance/oracle.sh`'s exact flags (`--singleThreaded --stableTypeOrdering true`, matching what `compare-to-parent.sh`/`conformance.sh` actually score — see #16413):

| operand | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `1` (fresh numeric literal) | `'1'` | `'number'` | `'1'` ✅ |
| `"str"` (fresh string literal) | `'"str"'` | `'string'` | `'"str"'` ✅ |
| `true` / `false` (fresh boolean literal) | `'true'` / `'false'` | `'boolean'` | `'true'` / `'false'` ✅ |
| `10n` (fresh bigint literal) | `'10n'` | `'bigint'` | `'10n'` ✅ |
| `null` (bare literal) | `'never'` | `'null'` | `'never'` ✅ |
| `undefined` (bare literal) | `'never'` | `'undefined'` | `'never'` ✅ |
| `declare const n: 1` (declared literal type) | `'1'` | `'1'` (already correct) | `'1'` (unchanged) |
| `declare const n: null` (declared null type) | `'never'` | `'null'` | `'never'` ✅ |
| `let x = 5` (widened declared type) | `'number'` | `'number'` (already correct) | `'number'` (unchanged) |

A declared identifier (not a literal *expression* node) is unaffected in either direction: `literal_type_from_initializer` only recovers a literal spelling from a literal AST node, so a `let`-widened or already-literal-typed variable read keeps displaying its declared type exactly as before.

**Not in scope, found while building this matrix:** `declare const u: string | object; for (var i in u) {}` — tsc reports TS2407 (`'string | object'`), tsz reports nothing (false negative). This is a pre-existing validity-check bug in `for_in_expr_type_is_valid_union`/`for_in_leaf_type_is_valid`, not a display bug, and this PR's diff never touches those functions. Noted on the coordination board as a NOTE for whoever picks it up next.

**Also not in scope:** a pre-existing conflict between `for_in_self_reference_and_nullable_operand_tests.rs`'s `null_for_in_operand_without_strict_null_checks_is_not_ts2407` (asserts no TS2407 for bare `null` under non-strict) and this session's fresh oracle run of the identical shape via `scripts/conformance/oracle.sh`, which reports TS2407. This PR's fix only changes message *text* on the already-firing error path (gated by the pre-existing `is_valid` computation, untouched here), so it cannot affect whether that test's assertion holds either way — flagging for whoever untangles it, not fixing here.

Closes the conformance fingerprint mismatch on `TypeScript/tests/cases/compiler/forIn2.ts` (now byte-exact against the pinned oracle). Found while triaging `scripts/conformance/query-conformance.py --fingerprint-only`'s queue.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib for_in` — 95/95 passed (9 new tests in `for_in_operand_type_display_tests.rs`, all pre-existing for-in suites unaffected).
- `cargo clippy -p tsz-checker --all-targets -- -D warnings` — clean.
- `cargo fmt -p tsz-checker -- --check` — clean.
- `python3 scripts/arch/arch_guard.py` — passed.
- Manual oracle diff on `TypeScript/tests/cases/compiler/forIn2.ts` via `scripts/conformance/oracle.sh` — byte-exact match after the fix (was a fingerprint mismatch before).
- Test-only + single checker file diff (`git diff --name-only` touches no other production path), so DTS/JS emit cannot move.
- `cargo test -p tsz-checker --lib` (full, untargeted) was still running in the background at PR-open time on this 4-core container; will report if it surfaces anything before queuing.
- `compare-to-parent.sh` / broader conformance sweep: owed, not run this session (single-invariant display fix, narrow single-call-site blast radius — verified via the targeted suite + oracle above instead).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_01TqW68JaVNKQBThsxMWbrHG)_