### PR TITLE
fix(checker): one owner for the position-invalid import specifier decision — main is red (#16522)

### DIFF
--- a/crates/tsz-checker/src/declarations/import/context_helpers.rs
+++ b/crates/tsz-checker/src/declarations/import/context_helpers.rs
@@ -551,48 +551,6 @@ impl<'a> CheckerState<'a> {
         is_named_exports && !self.ctx.is_external_module_file()
     }
 
-    /// Whether a position-invalid `import ... from "m"` or `import x =
-    /// require("m")` — already outside a function body and a namespace body,
-    /// i.e. still left in the source file's own scope by
-    /// [`Self::position_invalid_module_element_resolves_specifier`] — still
-    /// resolves its module specifier.
-    ///
-    /// The import side does not share `export ... from`'s per-clause table
-    /// story (#16504): every clause-bearing form (`import { a }`, `import a`,
-    /// `import * as ns`, `import a, { b }`, `import type { a }`, and
-    /// `import x = require(...)`) binds the same way regardless of which
-    /// clause it is, so there is only one axis here — whether the file is an
-    /// external module — not a clause-kind split. `tsc`'s
-    /// `checkImportDeclaration` has already returned at the placement
-    /// diagnostic (TS1232), so whatever still resolves comes from a later
-    /// pass; a script file still runs that pass, an external module's does
-    /// not (measured against the pinned oracle, #16505).
-    ///
-    /// A bare `import "m"` (no clause at all) is the one form that answers
-    /// differently: its resolution diagnostic (TS2882/TS2307) never fires
-    /// outside a declaration scope, in a script or a module alike — the
-    /// opposite of every clause-bearing form.
-    ///
-    /// Deliberately not covered by this predicate, and not by its caller
-    /// either: a plain import nested inside a namespace body's own block
-    /// (`namespace N { { import { a } from "m"; } }`) turns on whether the
-    /// imported binding is later *referenced*, the same discriminator
-    /// `import x = require(...)` already applies through
-    /// `namespace_import_alias_is_referenced` — not on module-ness. tsz has
-    /// no equivalent reference check for the plain-import clause forms yet,
-    /// so that shape is left exactly as it already was rather than folded
-    /// into this predicate; both call sites guard this out via
-    /// `!is_inside_namespace_declaration`.
-    pub(crate) fn position_invalid_import_declaration_resolves_specifier(
-        &self,
-        has_import_clause: bool,
-    ) -> bool {
-        if !has_import_clause {
-            return false;
-        }
-        !self.ctx.is_external_module_file()
-    }
-
     /// Check if a node is inside a module augmentation
     /// (`declare module "string" { ... }`).  Module augmentations have a
     /// `MODULE_DECLARATION` ancestor whose name is a string literal.

--- a/crates/tsz-checker/src/declarations/import/declaration_check_body.rs
+++ b/crates/tsz-checker/src/declarations/import/declaration_check_body.rs
@@ -257,23 +257,12 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        // Outside a declaration scope, `checkImportDeclaration` has already
-        // returned at the TS1232 placement diagnostic above; whatever still
-        // resolves comes from a later pass whose reach depends on the
-        // import's own shape and the file's module-ness
-        // (`position_invalid_import_declaration_resolves_specifier`, #16505).
-        // `!is_inside_namespace_declaration` excludes a block nested inside a
-        // namespace body — that shape turns on whether the binding is
-        // referenced, not on module-ness, and is deliberately left alone (see
-        // the helper's doc comment).
-        if in_wrong_context
-            && !self.is_inside_namespace_declaration(stmt_idx)
-            && !self.position_invalid_import_declaration_resolves_specifier(
-                import.import_clause.is_some(),
-            )
-        {
-            return;
-        }
+        // The position-invalid specifier decision is made once, above, by
+        // `position_invalid_import_resolves_specifier`. A second module-ness-only
+        // guard used to stand here (#16505/#16517); it was written before the
+        // `markAliasReferenced` disjunct (#16516) and answered the same question
+        // without it, so on a module file it re-suppressed a *used* binding the
+        // guard above had already resolved (#16522).
 
         // Extract module specifier data eagerly so direct import diagnostics like
         // TS6137 can run even when unresolved-import reporting is disabled.

--- a/crates/tsz-checker/src/declarations/import/equals.rs
+++ b/crates/tsz-checker/src/declarations/import/equals.rs
@@ -832,23 +832,13 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        // A bare block, an `if` body and a loop body resolve however the alias is
-        // used, but only in a *script*. The comment above predates this axis:
-        // measured against the pinned oracle (#16505), the same non-declaration-
-        // scope `import x = require(...)` stays silent past TS1232 when the file
-        // is an external module — the same rule
-        // `position_invalid_import_declaration_resolves_specifier` now gives the
-        // plain `import ... from` forms, since neither production's specifier
-        // resolution reaches a later pass once the file already has a module
-        // table. `!inside_namespace` keeps this from overriding the
-        // referenced-alias verdict just above/below, which owns that shape.
-        if in_wrong_context
-            && !self.is_inside_function_body(stmt_idx)
-            && !inside_namespace
-            && !self.position_invalid_import_declaration_resolves_specifier(true)
-        {
-            return;
-        }
+        // The position-invalid specifier decision is made once, above, by
+        // `position_invalid_import_resolves_specifier`. A second module-ness-only
+        // guard used to stand here (#16505/#16517), mirroring the one on the
+        // plain-`import` side; it predates the `markAliasReferenced` disjunct
+        // (#16516) and answered the same question without it, so on a module file
+        // it re-suppressed a *used* alias the guard above had already resolved
+        // (#16522).
 
         if force_module_not_found {
             if !should_emit_module_not_found {


### PR DESCRIPTION
Fixes #16522 — `main` is red. `cargo test -p tsz-checker --lib position_invalid_module_element_module_axis` is **16/20** at `b767f3e9a1` and at `b172b6b`; four rows drop the `TS2307` that `tsc` reports for a **used** position-invalid import in an external module.

**Structural rule.** When a position-invalid import binding is **referenced**, `tsc` reaches `resolveExternalModuleName` under `markAliasReferenced` and resolves the specifier wherever the binding sits — position is not the discriminator, use is. tsz does the same through the checker's single `position_invalid_import_resolves_specifier` predicate (`declarations/import/context_helpers.rs`), which owns this decision.

## What actually broke — not what the issue's localization predicted

#16522's localization comment verifies that the call site (`declaration_check_body.rs:177`, twin `equals.rs:831`) and the predicate (`context_helpers.rs:376`) both survived the merge intact, and concludes the fault must be in `import_element_alias_is_referenced`. **That function is fine** — I checked both of its predicted failure modes (empty `import_binding_symbols` for a block-nested binding; the upward walk bailing before `SOURCE_FILE`) and neither reproduces.

The real cause: **#16516 and #16517 each landed a predicate *and* a call site for the same decision, and the merge kept both pairs.**

| | predicate | logic |
| --- | --- | --- |
| **A** — #16516, `declaration_check_body.rs:177` / `equals.rs:831` | `position_invalid_import_resolves_specifier(stmt_idx)` | `binds_name && ((top_level_block && !is_module) \|\| referenced)` |
| **B** — #16517, `declaration_check_body.rs:271` / `equals.rs:848` | `position_invalid_import_declaration_resolves_specifier(has_clause)` | `has_clause && !is_module` |

**B is A with the `markAliasReferenced` disjunct and the scope walk deleted** — it is the *unused-binding row* of the very same table, written before #16516 existed. Nothing conflicted textually because the two guards sit ~90 lines apart in one function, so there was no merge marker and no reviewer prompt.

Because A runs first and `return`s on suppression, **B is only ever reached on rows A already resolved** — it can only further suppress. So the entire behavioural difference is the set where `A = true ∧ B = false`, which reduces to `is_module && referenced`: exactly the four failing rows, and exactly what this issue oracled as `1232 2307`.

## Why deleting B is behaviour-preserving everywhere else

This PR removes the predicate and both call sites. Case analysis, confirmed by the suites below:

- **every unused row** (all 23 in #16517's own `position_invalid_import_specifier_resolution_tests`): A already returns first with the same verdict. Including `named_import_in_a_function_body_of_a_script_reports_ts1232_alone`, where A suppresses via its scope walk and B alone would have *resolved* — A was doing that work already.
- **`import "m"`** (no clause): A's `import_element_binds_a_name` already declines, so A returns first.
- **`is_module && referenced`**: the spurious second suppression disappears. This is the fix.

No new predicate, no new axis, no identifier or file-name string anywhere in the decision — this is strictly the removal of a subsumed duplicate so one decision has one owner, per the layer rules in `.claude/CLAUDE.md`.

## Goal
Goal: hold

## Verification

Commands actually run on this 4-core cloud seat, before and after:

| suite | before (clean `main`) | after |
| --- | --- | --- |
| `--lib position_invalid_module_element_module_axis` | **16/20** | **20/20** |
| `--test position_invalid_import_specifier_resolution_tests` | 23/23 | **23/23** unchanged |
| `--test position_invalid_import_equals_container_scope_tests` | **20/22** | **20/22** unchanged |

The four rows fixed are exactly the four this issue names:

```
used_named_import_in_top_level_block_resolves_in_a_module     ok
used_named_import_in_a_function_body_resolves                 ok
used_import_equals_in_top_level_block_resolves_in_a_module     ok
renamed_binders_do_not_change_the_module_axis_verdict          ok
```

`renamed_binders_...` is the anti-hardcoding row and passes on both of its halves (unused `qqzz` → `1232`; used `qqzz` → `1232, 2307`), so the verdict is symbol identity, not the chosen name.

- `cargo fmt --all` — clean.
- `cargo clippy` (pre-commit hook, warnings denied) — **passed**.
- `scripts/arch/arch_guard.py` (pre-commit hook) — **passed**.
- `cargo test -p tsz-checker --lib` (full, 9914 rows) — launched; it runs long on this seat and had not returned when this PR was opened. I will post the count as a comment and will not queue this PR before it is green.

**The 2 red rows in `position_invalid_import_equals_container_scope_tests` are not mine.** I stashed this diff, rebuilt at clean `main`, and reproduced **byte-identical** failing values (`[1232, 2307]` vs `[1232]`, and `[1232, 1232, 2300, 2300, 2307]` vs `[1232, 1232, 2300, 2300]`). They are pre-existing and independent, and they are invisible to `--lib` — which is the command #16522 documents for reproducing, so **`main` is redder than that issue reports**. Filed separately as **#16527** with the root cause (the referenced-alias disjunct has no scope test, so a used alias in a class `static {}` block resolves where #16450 says it must not; and two colliding aliases each count the *other's* binding identifier as a use). Deliberately not folded in here — that one needs its own oracle grid before the scope line can be drawn honestly.

**Corpus gate.** `scripts/conformance/compare-to-parent.sh` is **owed** — measured at ~50 min on a cold 4-core seat by an independent session tonight, and it did not fit alongside the cold rebuild this cold container needed. Weighing it: this diff only *removes* a suppression on `is_module && referenced`, restoring a `TS2307` `tsc` emits, and the conformance corpus was reported unaffected by this family in #16522 itself (`11493, REG 0`). That is an argument, not a measurement — flagged for a drain step or a faster seat.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Zircon

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRMiVecZ1YKatwTqCB7f6o)_