### PR TITLE
fix(checker): a class static block's import = never resolves, referenced or not (#16527)

### DIFF
--- a/crates/tsz-checker/src/declarations/import/context_helpers.rs
+++ b/crates/tsz-checker/src/declarations/import/context_helpers.rs
@@ -298,6 +298,15 @@ impl<'a> CheckerState<'a> {
         &self,
         node_idx: NodeIndex,
     ) -> bool {
+        self.nearest_declaration_scope_ancestor(node_idx).is_none()
+    }
+
+    /// Walks from `node_idx` to the nearest declaration-scope-opening
+    /// ancestor and returns it: a function-like node (the same set
+    /// `is_inside_function_body` walks, including a class `static { }` block,
+    /// #16450) or a `ModuleBlock`. Returns `None` when the walk reaches the
+    /// `SourceFile` first, meaning no declaration scope encloses `node_idx`.
+    fn nearest_declaration_scope_ancestor(&self, node_idx: NodeIndex) -> Option<NodeIndex> {
         let mut current = node_idx;
         while current.is_some() {
             let Some(ext) = self.ctx.arena.get_extended(current) else {
@@ -311,8 +320,6 @@ impl<'a> CheckerState<'a> {
                 break;
             };
             match node.kind {
-                // Function-like ancestors are the same set `is_inside_function_body`
-                // walks, including a class `static { }` block (#16450).
                 k if k == syntax_kind_ext::FUNCTION_DECLARATION
                     || k == syntax_kind_ext::FUNCTION_EXPRESSION
                     || k == syntax_kind_ext::ARROW_FUNCTION
@@ -322,17 +329,34 @@ impl<'a> CheckerState<'a> {
                     || k == syntax_kind_ext::SET_ACCESSOR
                     || k == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION =>
                 {
-                    return false;
+                    return Some(current);
                 }
                 // Reaching a `ModuleBlock` from a position-invalid node means the
                 // node is nested *inside* a namespace/module body rather than being
                 // one of its own elements, so the body is a scope it sits within.
-                k if k == syntax_kind_ext::MODULE_BLOCK => return false,
-                k if k == syntax_kind_ext::SOURCE_FILE => return true,
+                k if k == syntax_kind_ext::MODULE_BLOCK => return Some(current),
+                k if k == syntax_kind_ext::SOURCE_FILE => return None,
                 _ => continue,
             }
         }
-        true
+        None
+    }
+
+    /// Whether the nearest declaration scope enclosing `node_idx` is a class
+    /// `static { }` block. #16450/#16527: a static block's own body never
+    /// resolves an enclosed `import =`'s specifier, referenced or not — the
+    /// one exception to "a used binding resolves wherever it sits" in
+    /// [`Self::position_invalid_import_resolves_specifier`]'s table. Every
+    /// other function-like container (and `ModuleBlock`) resolves normally on
+    /// a reference, so only this one ancestor kind short-circuits.
+    fn nearest_declaration_scope_is_class_static_block(&self, node_idx: NodeIndex) -> bool {
+        self.nearest_declaration_scope_ancestor(node_idx)
+            .is_some_and(|ancestor| {
+                self.ctx
+                    .arena
+                    .kind_at(ancestor)
+                    .is_some_and(|k| k == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION)
+            })
     }
 
     /// Whether a position-invalid `import`/`import =` still resolves its module
@@ -366,12 +390,23 @@ impl<'a> CheckerState<'a> {
     /// [`Self::position_invalid_export_declaration_resolves_specifier`]; the two
     /// rules cannot be shared.
     ///
+    /// The table's "bound & used" row has one exception the oracle does not
+    /// share with any other function-like container: a class `static { }`
+    /// block never resolves, referenced or not (#16450/#16527), so it is
+    /// checked and short-circuited before the table's rules apply.
+    ///
     /// Only meaningful for a node in a non-module-element context; callers guard
     /// with [`Self::is_in_non_module_element_context`].
     pub(crate) fn position_invalid_import_resolves_specifier(&self, node_idx: NodeIndex) -> bool {
         // A side-effect import binds no name, so nothing triggers its specifier
         // resolution here.
         if !self.import_element_binds_a_name(node_idx) {
+            return false;
+        }
+        // #16450/#16527: a class static block never resolves, referenced or
+        // not — checked before the reference scan so a use inside the block
+        // cannot re-trigger resolution the way every other container allows.
+        if self.nearest_declaration_scope_is_class_static_block(node_idx) {
             return false;
         }
         let top_level_block = self.position_invalid_module_element_resolves_specifier(node_idx);
@@ -451,6 +486,21 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
+        // Every declaration contributing to one of these symbols is a binding
+        // site, not a use — including a colliding duplicate alias declared
+        // elsewhere in the file (#16527 item 2), whose own binding identifier
+        // would otherwise resolve to the same merged symbol and read back as
+        // a "use" of itself.
+        let mut own_declarations: Vec<NodeIndex> = Vec::new();
+        for &sym in &symbols {
+            if let Some(symbol) = self.ctx.binder.get_symbol(sym) {
+                own_declarations.extend(symbol.all_declarations());
+            }
+        }
+        if !own_declarations.contains(&node_idx) {
+            own_declarations.push(node_idx);
+        }
+
         let mut scan_root = node_idx;
         loop {
             if self
@@ -472,8 +522,8 @@ impl<'a> CheckerState<'a> {
 
         let mut stack: Vec<NodeIndex> = self.ctx.arena.get_children(scan_root);
         while let Some(current) = stack.pop() {
-            // The declaration's own subtree is the binding site, not a use.
-            if current == node_idx {
+            // Every binding declaration's own subtree is a binding site, not a use.
+            if own_declarations.contains(&current) {
                 continue;
             }
             let Some(node) = self.ctx.arena.get(current) else {

--- a/crates/tsz-checker/tests/position_invalid_import_equals_container_scope_tests.rs
+++ b/crates/tsz-checker/tests/position_invalid_import_equals_container_scope_tests.rs
@@ -365,6 +365,63 @@ fn static_block_two_colliding_aliases_do_not_resolve_the_specifier() {
 }
 
 // ---------------------------------------------------------------------------
+// #16527 adjacent cases: the referenced-alias short-circuit and the
+// colliding-alias binding-vs-use distinction, exercised beyond the minimal
+// pinning rows above.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nested_block_referenced_alias_inside_static_block_still_does_not_resolve_the_specifier() {
+    assert_codes(
+        r#"class E {
+  static {
+    {
+      import whiskey = require("nonexistent-module");
+      whiskey;
+    }
+  }
+}"#,
+        &[1232],
+        "#16527: a reference from a plain block nested inside the static block must not \
+         re-trigger resolution either — the static-block carve-out applies through nesting",
+    );
+}
+
+#[test]
+fn static_block_three_colliding_aliases_do_not_resolve_the_specifier() {
+    assert_codes(
+        r#"class E {
+  static {
+    import xray = require("nonexistent-a");
+    import xray = require("nonexistent-b");
+    import xray = require("nonexistent-c");
+  }
+}"#,
+        &[1232, 1232, 1232, 2300, 2300, 2300],
+        "#16527: the binding-vs-use fix generalizes past a single colliding pair — none of \
+         three colliding aliases' own names may satisfy each other's reference scan",
+    );
+}
+
+#[test]
+fn top_level_colliding_aliases_each_independently_resolve() {
+    // A legal top-level `import =` is not position-invalid, so it never
+    // reaches `position_invalid_import_resolves_specifier` at all — its
+    // specifier always resolves regardless of reference or collision. This
+    // is the control row for the two static-block collision tests above: it
+    // pins that the binding-vs-use fix is scoped to the position-invalid
+    // reference scan and does not touch the always-resolves path.
+    assert_codes(
+        r#"import yankee = require("nonexistent-a");
+import yankee = require("nonexistent-b");
+yankee;"#,
+        &[2300, 2300, 2307, 2307],
+        "#16527: outside a static block, each colliding top-level alias resolves its own \
+         specifier independently — unaffected by the binding-vs-use fix",
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Positions where the retarget must be a no-op: the container already *is* the
 // current scope, so nothing about a legal `import =` moves.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
When a class `static { }` block encloses a position-invalid `import =` declaration, tsc never resolves the specifier — not even when the alias is referenced inside the block, and not when the alias collides with a sibling declaration of the same name. tsz did through `CheckerState::position_invalid_import_resolves_specifier` (`crates/tsz-checker/src/declarations/import/context_helpers.rs`), which had two independent defects both surfacing as a spurious `TS2307`:

1. **Static block is not scope-checked before the reference scan.** `import_element_alias_is_referenced` unconditionally scans the whole file for a use of the alias's symbol; the caller OR'd that result in with no positional guard. `#16450` had already established a static block never resolves, but nothing enforced it once the alias was *referenced* inside the block — the scope walk that protects the "unused" row (`top_level_block`) has no equivalent on the "used" row. Fix: short-circuit `position_invalid_import_resolves_specifier` on the nearest declaration-scope ancestor being `CLASS_STATIC_BLOCK_DECLARATION`, before the reference scan runs at all.
2. **The reference scan only excludes its own declaration's subtree.** `current == node_idx` skips only the alias's own binding site. When two `import x = require(...)` declarations collide on one merged symbol (`TS2300`), each declaration's own binding identifier resolves to that shared symbol, so declaration B's name satisfies declaration A's "is it referenced?" scan and vice versa. Fix: collect every declaration contributing to the bound symbol(s) via `Symbol::all_declarations()` and skip all of their subtrees, not just `node_idx`'s.

Refactored the existing ancestor walk in `position_invalid_module_element_resolves_specifier` into a shared `nearest_declaration_scope_ancestor` helper so the new static-block check reuses it instead of duplicating the walk.

Rebased onto `main` after #16531 (Zircon's `position_invalid_module_element_module_axis` fix for #16522) landed underneath this branch — no textual overlap (that PR removed a since-dead sibling predicate ~150 lines below the code this PR touches), and the two fixes compose cleanly (verified below).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test position_invalid_import_equals_container_scope_tests`: **25/25** (20/22 on main — the two pre-existing false positives from #16527, plus 3 new adjacent-case tests)
- `cargo test -p tsz-checker --test position_invalid_import_specifier_resolution_tests`: 21/21 unchanged
- `cargo test -p tsz-checker --test import_equals_alias_duplicate_container_tests`: 9/9 unchanged
- `cargo test -p tsz-checker --test import_equals_alias_duplicate_function_container_tests`: 16/16 unchanged
- `cargo test -p tsz-checker --test ambient_module_import_alias_defid_collision_tests`: 6/6 unchanged
- `cargo test -p tsz-checker --test self_namespace_import_alias_leak_tests`: 4/4 unchanged
- `cargo test -p tsz-checker --lib position_invalid_module_element_module_axis`: 20/20 unchanged (confirms this fix composes with #16531, which landed underneath this branch)
- `cargo clippy -p tsz-checker --lib --tests`: clean, zero warnings
- Adjacent-case matrix added: a referenced alias one block deeper inside the static block (nesting), three colliding aliases (generalizes past a pairwise collision), and a top-level control row confirming colliding aliases *outside* a static block still resolve independently (that path never reaches the changed function — a legal top-level `import =` isn't position-invalid).
- Conformance snapshot / `compare-to-parent.sh` not run this session (time budget); this change is scoped to the position-invalid `import =`-inside-a-static-block path, which is vanishingly rare in real-world corpora, so zero conformance movement is the expected signature (consistent with the board's standing note on this class of fix). Flagging as owed if anyone wants the two-sided confirmation before landing.

Closes #16527.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_012cDniLiyXQJiRg77QPnHUT)_