### PR TITLE
fix(checker): TS2430's overload-coverage pass reads a cross-arena base through the wrong arena

### DIFF
--- a/crates/tsz-checker/src/classes/class_checker_compat.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat.rs
@@ -1856,6 +1856,7 @@ impl<'a> CheckerState<'a> {
                         iface_name: iface_data.name,
                         derived_name: &derived_name,
                         base_name: &base_name,
+                        base_sym_id,
                         base_iface_indices: &base_iface_indices,
                         derived_member_names: &derived_member_names,
                         derived_members: &derived_members,

--- a/crates/tsz-checker/src/classes/class_checker_compat_overloads.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat_overloads.rs
@@ -9,6 +9,7 @@ pub(crate) struct InterfaceOverloadCoverageCtx<'a> {
     pub(crate) iface_name: NodeIndex,
     pub(crate) derived_name: &'a str,
     pub(crate) base_name: &'a str,
+    pub(crate) base_sym_id: tsz_binder::SymbolId,
     pub(crate) base_iface_indices: &'a [NodeIndex],
     pub(crate) derived_member_names: &'a rustc_hash::FxHashSet<String>,
     pub(crate) derived_members: &'a [(String, TypeId, NodeIndex, u16, bool, bool)],
@@ -25,6 +26,7 @@ impl<'a> CheckerState<'a> {
             iface_name,
             derived_name,
             base_name,
+            base_sym_id,
             base_iface_indices,
             derived_member_names,
             derived_members,
@@ -36,36 +38,90 @@ impl<'a> CheckerState<'a> {
             let mut by_name: rustc_hash::FxHashMap<String, Vec<TypeId>> =
                 rustc_hash::FxHashMap::default();
             for &base_iface_idx in base_iface_indices {
-                if let Some(base_node) = self.ctx.arena.get(base_iface_idx)
-                    && let Some(base_iface) = self.ctx.arena.get_interface(base_node)
-                {
-                    for &base_member_idx in &base_iface.members.nodes {
-                        let Some(base_member_node) = self.ctx.arena.get(base_member_idx) else {
-                            continue;
-                        };
-                        if base_member_node.kind != METHOD_SIGNATURE {
-                            continue;
-                        }
-                        let Some(sig) = self.ctx.arena.get_signature(base_member_node) else {
-                            continue;
-                        };
-                        let Some(name) = self.get_property_name(sig.name) else {
-                            continue;
-                        };
-                        if !derived_member_names.contains(&name) {
-                            continue;
-                        }
-                        let base_type = crate::query_boundaries::class::maybe_substitute_this_type(
-                            self.ctx.types,
-                            instantiate_type(
-                                self.ctx.types,
-                                self.get_type_of_interface_member(base_member_idx),
-                                substitution,
-                            ),
-                            interface_self_type,
-                        );
-                        by_name.entry(name).or_default().push(base_type);
+                // `base_iface_idx` is only guaranteed valid against the arena
+                // that owns `base_sym_id`'s declaration — which is a foreign
+                // (e.g. lib) arena whenever this coverage check runs against
+                // an interface being rechecked from a different file's
+                // context (the `CallableFunction`/`NewableFunction` vs.
+                // user-augmented `Function` family). Reading it through
+                // `self.ctx.arena` used to silently miss (`NodeArena::get`
+                // returns `None` for a foreign index), dropping the base's
+                // whole overloaded-method set and producing a false-negative
+                // TS2430.
+                let decl_arena = self.ctx.binder.arena_for_declaration_or(
+                    base_sym_id,
+                    base_iface_idx,
+                    self.ctx.arena,
+                );
+                let Some(base_node) = decl_arena.get(base_iface_idx) else {
+                    continue;
+                };
+                let Some(base_iface) = decl_arena.get_interface(base_node) else {
+                    continue;
+                };
+
+                let method_member_indices: Vec<NodeIndex> = base_iface
+                    .members
+                    .nodes
+                    .iter()
+                    .copied()
+                    .filter(|&member_idx| {
+                        decl_arena
+                            .get(member_idx)
+                            .is_some_and(|node| node.kind == METHOD_SIGNATURE)
+                    })
+                    .collect();
+                if method_member_indices.is_empty() {
+                    continue;
+                }
+
+                let cross_arena = !std::ptr::eq(decl_arena, self.ctx.arena);
+                let delegated_types = if cross_arena {
+                    self.delegate_cross_arena_interface_member_simple_types(
+                        base_iface_idx,
+                        &method_member_indices,
+                        decl_arena,
+                        None,
+                        false,
+                    )
+                } else {
+                    None
+                };
+
+                for &base_member_idx in &method_member_indices {
+                    let Some(base_member_node) = decl_arena.get(base_member_idx) else {
+                        continue;
+                    };
+                    let Some(sig) = decl_arena.get_signature(base_member_node) else {
+                        continue;
+                    };
+                    let Some(name) =
+                        crate::types_domain::queries::core::get_literal_or_well_known_property_name(
+                            decl_arena, sig.name,
+                        )
+                    else {
+                        continue;
+                    };
+                    if !derived_member_names.contains(&name) {
+                        continue;
                     }
+                    let raw_type = if cross_arena {
+                        let Some(t) = delegated_types
+                            .as_ref()
+                            .and_then(|types| types.get(&base_member_idx).copied())
+                        else {
+                            continue;
+                        };
+                        t
+                    } else {
+                        self.get_type_of_interface_member(base_member_idx)
+                    };
+                    let base_type = crate::query_boundaries::class::maybe_substitute_this_type(
+                        self.ctx.types,
+                        instantiate_type(self.ctx.types, raw_type, substitution),
+                        interface_self_type,
+                    );
+                    by_name.entry(name).or_default().push(base_type);
                 }
             }
             base_method_groups = by_name.into_iter().collect();

--- a/crates/tsz-checker/tests/ts2430_cross_arena_index_signature_tests.rs
+++ b/crates/tsz-checker/tests/ts2430_cross_arena_index_signature_tests.rs
@@ -90,3 +90,85 @@ interface CompletelyDifferentName extends Array<string> {
         "renaming the derived interface must not suppress the TS2430 report"
     );
 }
+
+// =========================================================================
+// Overloaded base method coverage across arenas
+//
+// `check_interface_extension_compatibility` defers a method name to
+// `check_interface_overload_coverage` whenever either side declares more
+// than one signature for it (the N x M overload-set rule). That deferred
+// pass re-read each heritage base declaration through `self.ctx.arena`
+// directly instead of resolving the declaration's own arena first - the
+// same defect class the index-signature tests above cover for a derived
+// interface's *own* index signature. Because a lib generic's declaration
+// lives in a lib arena, `self.ctx.arena.get(..)` silently missed,
+// `base_method_groups` came back empty for every overloaded lib method
+// name, and the entire overload-set comparison for that member was
+// skipped - an incompatible override went unreported.
+// =========================================================================
+
+/// Reported repro shape (oracled `typescript@7.0.2`): a derived interface's
+/// own overloaded `concat` that does not cover `Array<T>`'s inherited
+/// `concat` overload set must report TS2430.
+#[test]
+fn extends_array_incompatible_overloaded_method_reports_ts2430() {
+    let source = r#"
+interface MyArray<T> extends Array<T> {
+    concat(x: string): T[];
+    concat(y: number): T[];
+}
+"#;
+    assert!(
+        lib_codes(source).contains(&2430),
+        "a derived interface's own overloaded method incompatible with Array's inherited overload set must report TS2430"
+    );
+}
+
+/// Negative: re-declaring the base's own overload set verbatim is a valid,
+/// trivially-assignable override and must not report TS2430.
+#[test]
+fn extends_array_identical_overloaded_method_no_ts2430() {
+    let source = r#"
+interface MyArray<T> extends Array<T> {
+    concat(...items: ConcatArray<T>[]): T[];
+    concat(...items: (T | ConcatArray<T>)[]): T[];
+}
+"#;
+    assert!(
+        !lib_codes(source).contains(&2430),
+        "re-declaring Array's own concat overload set verbatim must not report TS2430"
+    );
+}
+
+/// Adjacent: renaming the derived interface must not change the outcome —
+/// the fix must not key off any user-chosen identifier.
+#[test]
+fn extends_array_incompatible_overloaded_method_renamed_binder_reports_ts2430() {
+    let source = r#"
+interface CompletelyDifferentArrayName<T> extends Array<T> {
+    concat(x: string): T[];
+    concat(y: number): T[];
+}
+"#;
+    assert!(
+        lib_codes(source).contains(&2430),
+        "renaming the derived interface must not suppress the TS2430 report"
+    );
+}
+
+/// Adjacent: the concrete (non-generic-reparameterized) heritage form —
+/// `extends Array<string>` instead of `extends Array<T>` — must apply the
+/// same rule.
+#[test]
+fn extends_array_concrete_incompatible_overloaded_method_reports_ts2430() {
+    let source = r#"
+interface MyStringArray extends Array<string> {
+    concat(x: symbol): string[];
+    concat(y: boolean): string[];
+}
+"#;
+    assert!(
+        lib_codes(source).contains(&2430),
+        "a concrete (non-reparameterized) heritage form must still report TS2430 for an incompatible overloaded override"
+    );
+}


### PR DESCRIPTION
Closes the cross-arena half of the false-negative family in #16525 (a distinct, deeper solver `this`-parameter-bivariance gap remains open there for the `CallableFunction`/`NewableFunction` repro specifically — see note below).

## Structural rule

When `check_interface_extension_compatibility` defers a heritage method name to `check_interface_overload_coverage` (because either side declares more than one signature for it — the N×M overload-set rule), `tsc` always resolves the base's signatures regardless of which file declared them. tsz's overload-coverage pass instead read each base interface declaration and its members through `self.ctx.arena` directly. Whenever the base's declaration lives in a different arena than the interface being checked — the ordinary case of a user interface extending a lib generic such as `Array<T>`, or any cross-file heritage — `NodeArena::get` silently missed on the foreign index, `base_method_groups` came back empty for that base, and the entire overload-set comparison for the affected method name was skipped. An incompatible overloaded override went unreported (false negative TS2430).

This is the same defect class #16524 fixed for the sibling `base_root_idx` read and a derived interface's own index-signature annotations in `check_interface_extension_compatibility` — `check_interface_overload_coverage` was left behind as a separate, un-migrated read site.

## What changed

- `crates/tsz-checker/src/classes/class_checker_compat_overloads.rs`: `InterfaceOverloadCoverageCtx` now carries `base_sym_id`. Each `base_iface_idx` resolves its own declaration's arena via `arena_for_declaration_or` before reading it, instead of assuming `self.ctx.arena`. Member types route through the existing `delegate_cross_arena_interface_member_simple_types` helper when that arena differs from the checking file's (same helper already used by the sibling cross-arena paths in `class_checker_compat.rs`).
- `crates/tsz-checker/src/classes/class_checker_compat.rs`: threads `base_sym_id` (already in scope in the heritage loop) into the ctx at the one call site.

## Adjacent-case matrix (all oracled against pinned `typescript@7.0.2`)

| Case | Result |
| --- | --- |
| `MyArray<T> extends Array<T>` with an incompatible overloaded `concat` override | TS2430 (was: nothing) |
| Renamed derived binder (`CompletelyDifferentArrayName<T>`) | TS2430 — unaffected by the rename, confirming no identifier-keyed logic |
| Concrete (non-reparameterized) heritage form (`extends Array<string>`) | TS2430 |
| Re-declaring the base's own overload set verbatim (negative) | no TS2430 |

Manually confirmed via the CLI on the reported repro shape (`interface MyArray<T> extends Array<T> { concat(x: string): T[]; concat(y: number): T[]; }`) that tsz now reports `TS2430: Interface 'MyArray<T>' incorrectly extends interface 'Array<T>'.` at the same code and location as `tsc`, and confirmed absent before this fix (reverted the diff and rebuilt to check).

## What this does *not* fix

#16525's own `CallableFunction`/`NewableFunction extends Function` repro is **still a false negative** after this PR. Tracing confirmed this fix does make `check_interface_overload_coverage` reach and evaluate `apply`/`bind`/`call` for that pair now (previously `base_method_groups` was empty, so it never ran at all) — but the underlying relation, `are_this_parameters_compatible` (`crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs`), applies bivariant `this`-parameter comparison for methods (checks either direction, accepts if either succeeds). For `CallableFunction.apply`'s overloaded `this: (this: T) => R` against `Function.apply`'s `this: Function`, the bivariant OR makes source-assignable-to-target trivially true (any function is structurally assignable to the loose `Function` interface), even though tsc's own oracle output shows it checks this pair contravariant-only (`Function` is not assignable to `(this: any) => any`) and correctly reports TS2430. That is a distinct, higher-risk solver-relation change (touches a load-bearing, broadly-used comparison — the existing `this`-in-parameter regression tests in `ts2430_tests.rs` exist precisely because bivariance here is deliberate for other shapes) that needs its own scoped investigation and full conformance verification, not bundled into this arena-read fix. Left open on #16525 with this finding.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib ts2430` — 58/58 pass (0 regressed).
- `cargo test -p tsz-checker --test ts2430_cross_arena_index_signature_tests` — 8/8 pass (4 new + 4 pre-existing, 0 regressed).
- `cargo test -p tsz-checker --lib` (full crate): 9899 passed, 4 failed, 1 non-completing. The 4 failures are `position_invalid_module_element_module_axis_tests::*` — pre-existing on `main`, already tracked as the unrelated #16522 "main is red" regression (confirmed via `git log -1` at the base of this branch, `0fb8742`, predating this diff). The 1 non-completion is the pre-existing `ts2589` recursive-conditional hang (#15338), structurally unrelated to interface heritage.
- `cargo clippy -p tsz-checker --lib --tests -- -D warnings` — clean.
- Pre-commit gate (fmt + clippy `-p tsz-checker` + architecture guard + crate verification) — passed.
- Manual CLI oracle comparison against pinned `typescript@7.0.2` (`scripts/conformance/typescript-versions.json`) on 4 fixtures (positive, negative, renamed-binder, concrete-form) — byte-exact code+location match on all 4; confirmed the positive case was a false negative before this fix by reverting and rebuilding.
- Test-only-adjacent diff touches `crates/tsz-checker/src/classes/*.rs` (production) plus a new-tests-only file; broader `conformance.sh`/`emit`/`fourslash` not run this session (time-boxed hourly session) — owed if this PR's diagnostic-code movement needs corpus confirmation, though the change is additive-only (previously-silent skips now correctly compare) so no existing passing row should move.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzkyhKR22fxhJxTqxUFX88)_