### PR TITLE
fix(checker): TS6500 anchors a nested object-literal's property through the written path (#16443)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
@@ -474,6 +474,7 @@ impl<'a> CheckerState<'a> {
                     self.with_expected_type_from_property_pointer(
                         &expected_type_owners,
                         &prop_name,
+                        prop_value_idx,
                         |this| {
                             this.error_type_not_assignable_at_with_display_types(
                                 source_prop_type_for_diagnostic,
@@ -531,6 +532,7 @@ impl<'a> CheckerState<'a> {
                     self.with_expected_type_from_property_pointer(
                         &expected_type_owners,
                         &prop_name,
+                        prop_value_idx,
                         |this| {
                             this.error_type_not_assignable_at_with_display_types(
                                 source_prop_type_for_diagnostic,
@@ -563,6 +565,7 @@ impl<'a> CheckerState<'a> {
                     self.with_expected_type_from_property_pointer(
                         &expected_type_owners,
                         &prop_name,
+                        prop_value_idx,
                         |this| {
                             this.error_type_not_assignable_at_with_anchor(
                                 source_prop_type_for_diagnostic,
@@ -663,6 +666,7 @@ impl<'a> CheckerState<'a> {
                         self.with_expected_type_from_property_pointer(
                             &expected_type_owners,
                             &prop_name,
+                            prop_value_idx,
                             |this| {
                                 this.error_type_not_assignable_at_with_anchor(
                                     source_prop_type_for_diagnostic,
@@ -924,6 +928,7 @@ impl<'a> CheckerState<'a> {
                         self.with_expected_type_from_property_pointer(
                             &expected_type_owners,
                             &prop_name,
+                            prop_value_idx,
                             |this| {
                                 this.error_type_not_assignable_at_with_display_types(
                                     source_prop_type_for_diagnostic,
@@ -936,6 +941,7 @@ impl<'a> CheckerState<'a> {
                         self.with_expected_type_from_property_pointer(
                             &expected_type_owners,
                             &prop_name,
+                            prop_value_idx,
                             |this| {
                                 this.error_type_not_assignable_at_with_anchor_elaboration_inner_with_value_anchor(
                                     source_prop_type_for_diagnostic,

--- a/crates/tsz-checker/src/error_reporter/expected_type_from_property.rs
+++ b/crates/tsz-checker/src/error_reporter/expected_type_from_property.rs
@@ -1,5 +1,6 @@
 use crate::diagnostics::{Diagnostic, diagnostic_codes, diagnostic_messages, format_message};
 use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
@@ -31,11 +32,17 @@ impl<'a> CheckerState<'a> {
         &mut self,
         owner_candidates: &[TypeId],
         property_name: &str,
+        anchor_idx: NodeIndex,
         emit: impl FnOnce(&mut Self),
     ) {
         let before = self.ctx.diagnostics.len();
         emit(self);
-        self.attach_expected_type_from_property_pointer(before, owner_candidates, property_name);
+        self.attach_expected_type_from_property_pointer(
+            before,
+            owner_candidates,
+            property_name,
+            anchor_idx,
+        );
     }
 
     pub(crate) fn attach_expected_type_from_property_pointer(
@@ -43,12 +50,13 @@ impl<'a> CheckerState<'a> {
         since: usize,
         owner_candidates: &[TypeId],
         property_name: &str,
+        anchor_idx: NodeIndex,
     ) {
         if self.ctx.diagnostics.len() <= since {
             return;
         }
         let Some(related) =
-            self.expected_type_from_property_related(owner_candidates, property_name)
+            self.expected_type_from_property_related(owner_candidates, property_name, anchor_idx)
         else {
             return;
         };
@@ -79,12 +87,20 @@ impl<'a> CheckerState<'a> {
     /// where TS2728 reads `'"two-part"' is declared here.`. Passing the interned
     /// property name — not the primary diagnostic's display string — is what
     /// keeps the two apart.
+    ///
+    /// `owner_candidates` resolve through a binder symbol, which a *nested*
+    /// object-literal target does not have — a type literal mints no symbol at
+    /// all (tsz#16443). When every candidate declines, `anchor_idx` (the
+    /// failing member's own value node) recovers the same anchor tsc reports
+    /// through the object-literal syntax at the failure site, mirroring the
+    /// walk `missing_property_declared_here_related` already uses for TS2728.
     fn expected_type_from_property_related(
         &mut self,
         owner_candidates: &[TypeId],
         property_name: &str,
+        anchor_idx: NodeIndex,
     ) -> Option<crate::diagnostics::DiagnosticRelatedInformation> {
-        owner_candidates.iter().find_map(|&owner| {
+        if let Some(related) = owner_candidates.iter().find_map(|&owner| {
             let (start, length, file) =
                 self.member_declaration_anchor_for_owner(owner, property_name)?;
             let owner_display = self.format_type_for_assignability_message(owner);
@@ -98,6 +114,62 @@ impl<'a> CheckerState<'a> {
                     &[property_name, &owner_display],
                 ),
             ))
-        })
+        }) {
+            return Some(related);
+        }
+        let (owner_node_idx, start, length, file) =
+            self.expected_type_from_property_anchor_from_annotation(anchor_idx, property_name)?;
+        // `owner_node_idx` is the node the anchor was found *inside* — a type
+        // literal for a nested owner, or (when the path needed no hop at all) the
+        // annotation's own type-reference node, which keeps an aliased owner's
+        // display as its written name (`Alias`) rather than its expanded body.
+        // Either way it is the same node tsc's own display resolves against, so
+        // evaluating it directly reuses the one formatter every other owner
+        // display already goes through.
+        let owner_type = self.get_type_from_type_node(owner_node_idx);
+        let owner_display = self.format_type_for_assignability_message(owner_type);
+        Some(Diagnostic::related_pointer(
+            diagnostic_codes::THE_EXPECTED_TYPE_COMES_FROM_PROPERTY_WHICH_IS_DECLARED_HERE_ON_TYPE,
+            file.unwrap_or_else(|| self.ctx.file_name.clone()),
+            start,
+            length,
+            format_message(
+                diagnostic_messages::THE_EXPECTED_TYPE_COMES_FROM_PROPERTY_WHICH_IS_DECLARED_HERE_ON_TYPE,
+                &[property_name, &owner_display],
+            ),
+        ))
+    }
+
+    /// `(owner node, start, length, file)` recovered from the annotation syntax
+    /// for a target with no binder symbol at all — the anonymous-nested-owner
+    /// case `member_declaration_anchor_for_owner` cannot reach.
+    ///
+    /// `contextual_property_path(anchor_idx)` walks the object-literal ancestry
+    /// from the failing *value* node outward, so unlike TS2728's use of the same
+    /// helper (whose `anchor_idx` sits one level up, at the object literal
+    /// missing a property that is never itself in the path), the returned path
+    /// here ends with `property_name` as its own last element — this member's
+    /// value is what failed. Walking every hop but the last through the
+    /// annotation's member types lands on the owner that actually declares
+    /// `property_name`, exactly as `declared_here_related_from_annotation` does
+    /// for TS2728, just stopping one hop earlier — which is also why the node
+    /// this stops on, not the leaf's own anchor, is the right one to read the
+    /// owner's display type from.
+    fn expected_type_from_property_anchor_from_annotation(
+        &mut self,
+        anchor_idx: NodeIndex,
+        property_name: &str,
+    ) -> Option<(NodeIndex, u32, u32, Option<String>)> {
+        let annotation_idx = self.target_annotation_node(anchor_idx)?;
+        let path = self.contextual_property_path(anchor_idx);
+        if path.last().map(String::as_str) != Some(property_name) {
+            return None;
+        }
+        let mut owner_idx = annotation_idx;
+        for key in &path[..path.len() - 1] {
+            owner_idx = self.annotation_member_type_node(owner_idx, key, 0)?;
+        }
+        let (start, length, file) = self.annotation_property_anchor(owner_idx, property_name, 0)?;
+        Some((owner_idx, start, length, file))
     }
 }

--- a/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
+++ b/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
@@ -71,7 +71,7 @@ impl<'a> CheckerState<'a> {
     /// always describe one assignment. Returns empty for a failure that is not
     /// inside an object literal at all (an array element, a call argument),
     /// which declines the pointer rather than guessing.
-    fn contextual_property_path(&self, anchor_idx: NodeIndex) -> Vec<String> {
+    pub(super) fn contextual_property_path(&self, anchor_idx: NodeIndex) -> Vec<String> {
         use tsz_parser::parser::syntax_kind_ext;
 
         let mut path: Vec<String> = Vec::new();
@@ -195,7 +195,7 @@ impl<'a> CheckerState<'a> {
     /// as a resolved target does. An indexed access resolves its written key
     /// against the object type's members and continues into that member's type
     /// node.
-    fn annotation_property_anchor(
+    pub(super) fn annotation_property_anchor(
         &mut self,
         idx: NodeIndex,
         property: &str,
@@ -249,7 +249,7 @@ impl<'a> CheckerState<'a> {
     /// here rather than reading a foreign arena's `NodeIndex` against the
     /// current one — per-file arenas make a raw index from another file name an
     /// unrelated node.
-    fn annotation_member_type_node(
+    pub(super) fn annotation_member_type_node(
         &mut self,
         idx: NodeIndex,
         key: &str,

--- a/crates/tsz-checker/src/tests/expected_type_from_property_tests.rs
+++ b/crates/tsz-checker/src/tests/expected_type_from_property_tests.rs
@@ -18,12 +18,19 @@
 //!   `'"two-part"' is declared here.`.
 //! * the message carries no trailing period.
 //!
-//! Three shapes deliberately produce **no** pointer rather than a guessed one,
+//! Two shapes deliberately produce **no** pointer rather than a guessed one,
 //! and are pinned negatively below so they cannot regress into a wrong anchor:
-//! an index-signature target (tsc: `TS6501`), a contextual return type inside a
-//! property initializer (tsc: `TS6502`), and an owner that is an anonymous
-//! object type — a type alias to a type literal, or a nested literal — whose
-//! declaration the binder mints no symbol for (#16443).
+//! an index-signature target (tsc: `TS6501`) and a contextual return type
+//! inside a property initializer (tsc: `TS6502`).
+//!
+//! An owner that is an anonymous object type — a type alias to a type
+//! literal, or a nested literal — has no binder symbol to resolve through
+//! (#16443: a type literal mints none at all), so the owner-candidate walk
+//! alone declines. The annotation-syntax fallback recovers it anyway, from
+//! the object-literal path at the failure site — the same per-occurrence
+//! provenance argument #16521 already established for the sibling `TS2728`
+//! pointer, since an interned anonymous shape can never carry its own source
+//! location for the direct route to find.
 
 use crate::diagnostics::Diagnostic;
 use crate::test_utils::check_source_diagnostics;
@@ -287,29 +294,67 @@ fn array_element_mismatch_gets_no_property_pointer() {
 }
 
 /// A nested literal reports at the inner property; tsc's pointer then names the
-/// *inner* anonymous type. tsz's owner walk needs a binder symbol and the
-/// binder mints none for a type literal (#16443), so it declines. Pinned so the
-/// day #16443's owner route lands, this row's regression is visible instead of
-/// silently anchoring at the outer `lvl`.
+/// *inner* anonymous type. The owner has no binder symbol at all — a type
+/// literal mints none (#16443) — so `member_declaration_anchor_for_owner`
+/// still declines, but the annotation-syntax fallback recovers the same
+/// per-occurrence path #16521 gave the sibling `TS2728` pointer: walk the
+/// object-literal ancestry from the failing value out to `Deep`, then back
+/// down through `lvl`'s own written type to `p`.
 #[test]
-fn nested_type_literal_owner_declines_rather_than_naming_the_outer_property() {
+fn nested_type_literal_owner_points_at_the_inner_anonymous_type() {
     let source = "interface Deep { lvl: { p: string }; }\nconst d: Deep = { lvl: { p: 7 } };\n";
     let diagnostic = only(&check_source_diagnostics(source), TS2322);
-    assert!(
-        !has_pointer(&diagnostic),
-        "an anonymous owner must decline, never fall back to the enclosing property: {diagnostic:?}"
+    let (_, start, length, message) = expected_type_pointer(&diagnostic);
+    assert_eq!(
+        message,
+        "The expected type comes from property 'p' which is declared here on type '{ p: string; }'"
     );
+    assert_eq!(span_text(source, start, length), "p");
 }
 
 /// Same root cause as above with the alias spelled out: `type Alias = { .. }`
-/// evaluates to an anonymous object type carrying no symbol, so the walk has no
-/// declaration to anchor in. tsc prints the pointer here.
+/// evaluates to an anonymous object type carrying no symbol, so the direct
+/// owner-candidate walk declines. Unlike the nested case, the annotation walk
+/// needs no hop at all — `path` is just `["av"]` — so it stops on the
+/// `Alias` type-reference node itself, which is also why the owner displays
+/// as the alias's own written name rather than its expanded body.
 #[test]
-fn type_alias_to_type_literal_owner_declines() {
+fn type_alias_to_type_literal_owner_points_at_its_member() {
     let source = "type Alias = { av: string; bv: number };\nconst al: Alias = { av: 5, bv: 6 };\n";
     let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    let (_, start, length, message) = expected_type_pointer(&diagnostic);
+    assert_eq!(
+        message,
+        "The expected type comes from property 'av' which is declared here on type 'Alias'"
+    );
+    assert_eq!(span_text(source, start, length), "av");
+}
+
+/// Binder names must not matter here either: the annotation-syntax fallback
+/// matches members by the path recovered from the object-literal source, not
+/// by any name coincidence with the primary diagnostic's own display text.
+#[test]
+fn renamed_binders_point_at_the_inner_anonymous_type() {
+    let source = "interface Zeta { qux: { xylo: string; yak: number }; }\nconst z: Zeta = { qux: { xylo: 9 } };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    let (_, start, length, message) = expected_type_pointer(&diagnostic);
+    assert_eq!(
+        message,
+        "The expected type comes from property 'xylo' which is declared here on type '{ xylo: string; yak: number; }'"
+    );
+    assert_eq!(span_text(source, start, length), "xylo");
+}
+
+/// Negative control for both rows above: a nested literal that type-checks
+/// cleanly must stay clean — the fallback only ever activates once a `TS2322`
+/// has already been reported for this member, never as a side effect of
+/// walking the annotation.
+#[test]
+fn nested_type_literal_matching_value_stays_clean() {
+    let source =
+        "interface Deep { lvl: { p: string }; }\nconst d: Deep = { lvl: { p: \"ok\" } };\n";
     assert!(
-        !has_pointer(&diagnostic),
-        "an alias-to-type-literal owner must decline rather than guess: {diagnostic:?}"
+        check_source_diagnostics(source).is_empty(),
+        "a matching nested value must not report anything"
     );
 }


### PR DESCRIPTION
When the target of a `TS2322` property mismatch is an anonymous nested object literal (`interface Outer { inner: { p: string } }`), tsc's `elaborateElementwise` still attaches the `TS6500` "The expected type comes from property ... which is declared here on type ..." pointer, anchored inside the nested literal. tsz's owner-candidate walk (`member_declaration_anchor_for_owner`) requires a binder symbol, which a type literal never has (#16443), so it declined for every nested owner — and also for a top-level type-alias-to-type-literal target.

**Structural rule.** When `TS6500`'s owner-candidate walk finds no declaring symbol, tsc still resolves the pointer through the object-literal syntax at the failure site — the same per-occurrence provenance argument #16521 already established for the sibling `TS2728` pointer. This change reuses that PR's `contextual_property_path`/`target_annotation_node`/`annotation_member_type_node`/`annotation_property_anchor` walk (widened to `pub(super)`) as a fallback in `expected_type_from_property.rs`, owned by the checker's `error_reporter`, stopping one hop earlier than `TS2728`'s walk does: `TS6500`'s own anchor node (the failing value) already sits inside the leaf property, so the recovered path's last segment *is* the target property, and the owner to render is whatever node the walk stops on one hop before that leaf.

## Adjacent-case matrix

Oracled against `typescript@7.0.2` (`--noEmit --strict --pretty --target es2022`):

| shape | tsc | before | after |
| --- | --- | --- | --- |
| nested interface member (`Deep.lvl.p`) | `1:25` on `p`, owner `{ p: string; }` | none | exact |
| type-alias-to-type-literal (`Alias.av`) | `1:16` on `av`, owner `Alias` | none | exact |
| renamed binders (nested) | exact | none | exact |
| negative: matching nested value | clean | clean | clean |

Two existing negative tests (`nested_type_literal_owner_declines...`, `type_alias_to_type_literal_owner_declines`) asserted "no pointer" for exactly these two rows; both are now positive assertions matching tsc, per the anti-hardcoding matrix requirement (renamed binders included, adjacent negative control included).

## Goal
Goal: hold

## Verification

- `cargo test -p tsz-checker --lib expected_type_from_property` — 17/17 (15 existing + 2 new: renamed binders + negative control).
- `cargo test -p tsz-checker --lib -- missing_property_declared_here elaboration object_literal` — 505/505, no regressions.
- `cargo test -p tsz-checker --lib` (full crate, 9924 tests) — 9901 passed, 4 failed. All 4 are the pre-existing, already-tracked `position_invalid_module_element_module_axis_tests` regression (#16522, unrelated family — position-invalid import resolution — fixed separately in #16531); confirmed present on `main` before this diff. 0 failures attributable to this change.
- CLI diff against the pinned oracle, byte-exact on every row in the matrix above.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy --profile ci-lint --workspace --exclude tsz-conformance --all-targets -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py` — passed.

Conformance/emit not run: this diff adds `related_information` to an existing `TS2322` and touches no top-level diagnostic code, no emitter path, and no relation — the same argument #16451/#16458 already made and had confirmed by measurement for this exact message family (`11490 -> 11490, 0 regressed / 0 fixed` on both).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: Ignimbrite

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGwpVzeYfshzGVHLfWipfp)_