### PR TITLE
revert(checker): #16533's static-block import = premise was wrong — restore correct resolution

### DIFF
--- a/crates/tsz-checker/src/declarations/import/context_helpers.rs
+++ b/crates/tsz-checker/src/declarations/import/context_helpers.rs
@@ -298,15 +298,6 @@ impl<'a> CheckerState<'a> {
         &self,
         node_idx: NodeIndex,
     ) -> bool {
-        self.nearest_declaration_scope_ancestor(node_idx).is_none()
-    }
-
-    /// Walks from `node_idx` to the nearest declaration-scope-opening
-    /// ancestor and returns it: a function-like node (the same set
-    /// `is_inside_function_body` walks, including a class `static { }` block,
-    /// #16450) or a `ModuleBlock`. Returns `None` when the walk reaches the
-    /// `SourceFile` first, meaning no declaration scope encloses `node_idx`.
-    fn nearest_declaration_scope_ancestor(&self, node_idx: NodeIndex) -> Option<NodeIndex> {
         let mut current = node_idx;
         while current.is_some() {
             let Some(ext) = self.ctx.arena.get_extended(current) else {
@@ -320,6 +311,8 @@ impl<'a> CheckerState<'a> {
                 break;
             };
             match node.kind {
+                // Function-like ancestors are the same set `is_inside_function_body`
+                // walks, including a class `static { }` block (#16450).
                 k if k == syntax_kind_ext::FUNCTION_DECLARATION
                     || k == syntax_kind_ext::FUNCTION_EXPRESSION
                     || k == syntax_kind_ext::ARROW_FUNCTION
@@ -329,34 +322,17 @@ impl<'a> CheckerState<'a> {
                     || k == syntax_kind_ext::SET_ACCESSOR
                     || k == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION =>
                 {
-                    return Some(current);
+                    return false;
                 }
                 // Reaching a `ModuleBlock` from a position-invalid node means the
                 // node is nested *inside* a namespace/module body rather than being
                 // one of its own elements, so the body is a scope it sits within.
-                k if k == syntax_kind_ext::MODULE_BLOCK => return Some(current),
-                k if k == syntax_kind_ext::SOURCE_FILE => return None,
+                k if k == syntax_kind_ext::MODULE_BLOCK => return false,
+                k if k == syntax_kind_ext::SOURCE_FILE => return true,
                 _ => continue,
             }
         }
-        None
-    }
-
-    /// Whether the nearest declaration scope enclosing `node_idx` is a class
-    /// `static { }` block. #16450/#16527: a static block's own body never
-    /// resolves an enclosed `import =`'s specifier, referenced or not — the
-    /// one exception to "a used binding resolves wherever it sits" in
-    /// [`Self::position_invalid_import_resolves_specifier`]'s table. Every
-    /// other function-like container (and `ModuleBlock`) resolves normally on
-    /// a reference, so only this one ancestor kind short-circuits.
-    fn nearest_declaration_scope_is_class_static_block(&self, node_idx: NodeIndex) -> bool {
-        self.nearest_declaration_scope_ancestor(node_idx)
-            .is_some_and(|ancestor| {
-                self.ctx
-                    .arena
-                    .kind_at(ancestor)
-                    .is_some_and(|k| k == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION)
-            })
+        true
     }
 
     /// Whether a position-invalid `import`/`import =` still resolves its module
@@ -390,23 +366,12 @@ impl<'a> CheckerState<'a> {
     /// [`Self::position_invalid_export_declaration_resolves_specifier`]; the two
     /// rules cannot be shared.
     ///
-    /// The table's "bound & used" row has one exception the oracle does not
-    /// share with any other function-like container: a class `static { }`
-    /// block never resolves, referenced or not (#16450/#16527), so it is
-    /// checked and short-circuited before the table's rules apply.
-    ///
     /// Only meaningful for a node in a non-module-element context; callers guard
     /// with [`Self::is_in_non_module_element_context`].
     pub(crate) fn position_invalid_import_resolves_specifier(&self, node_idx: NodeIndex) -> bool {
         // A side-effect import binds no name, so nothing triggers its specifier
         // resolution here.
         if !self.import_element_binds_a_name(node_idx) {
-            return false;
-        }
-        // #16450/#16527: a class static block never resolves, referenced or
-        // not — checked before the reference scan so a use inside the block
-        // cannot re-trigger resolution the way every other container allows.
-        if self.nearest_declaration_scope_is_class_static_block(node_idx) {
             return false;
         }
         let top_level_block = self.position_invalid_module_element_resolves_specifier(node_idx);
@@ -486,21 +451,6 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        // Every declaration contributing to one of these symbols is a binding
-        // site, not a use — including a colliding duplicate alias declared
-        // elsewhere in the file (#16527 item 2), whose own binding identifier
-        // would otherwise resolve to the same merged symbol and read back as
-        // a "use" of itself.
-        let mut own_declarations: Vec<NodeIndex> = Vec::new();
-        for &sym in &symbols {
-            if let Some(symbol) = self.ctx.binder.get_symbol(sym) {
-                own_declarations.extend(symbol.all_declarations());
-            }
-        }
-        if !own_declarations.contains(&node_idx) {
-            own_declarations.push(node_idx);
-        }
-
         let mut scan_root = node_idx;
         loop {
             if self
@@ -522,8 +472,8 @@ impl<'a> CheckerState<'a> {
 
         let mut stack: Vec<NodeIndex> = self.ctx.arena.get_children(scan_root);
         while let Some(current) = stack.pop() {
-            // Every binding declaration's own subtree is a binding site, not a use.
-            if own_declarations.contains(&current) {
+            // The declaration's own subtree is the binding site, not a use.
+            if current == node_idx {
                 continue;
             }
             let Some(node) = self.ctx.arena.get(current) else {

--- a/crates/tsz-checker/tests/position_invalid_import_equals_container_scope_tests.rs
+++ b/crates/tsz-checker/tests/position_invalid_import_equals_container_scope_tests.rs
@@ -299,13 +299,23 @@ romeo;"#,
 }
 
 // ---------------------------------------------------------------------------
-// #16450: a class static block must not resolve a position-invalid `import =`
-// specifier, same as any other function-like container. `tsc` reports TS1232
-// alone in every row below; tsz additionally reported a spurious TS2307
-// because `is_inside_function_body` did not recognize
-// `CLASS_STATIC_BLOCK_DECLARATION` as a function-like ancestor, so the
-// `in_wrong_context && is_inside_function_body` short-circuit in
-// `check_import_equals_declaration` never fired for a static block.
+// #16450: a class static block must not resolve an *unreferenced*
+// position-invalid `import =` specifier, same as any other function-like
+// container's unused row. `tsc` reports TS1232 alone for the unreferenced row
+// below; tsz additionally reported a spurious TS2307 because
+// `is_inside_function_body` did not recognize `CLASS_STATIC_BLOCK_DECLARATION`
+// as a function-like ancestor, so the `in_wrong_context &&
+// is_inside_function_body` short-circuit in `check_import_equals_declaration`
+// never fired for a static block.
+//
+// A *referenced* alias is a different row of the table, and tsz was already
+// correct there: measured against the pinned oracle (#16527 review), a
+// static block resolves on a genuine reference exactly like any other
+// function-like container — there is no static-block carve-out for that row.
+// An earlier revision of this suite pinned the opposite (no resolution even
+// when referenced) without oracling it, which made a correct row read as
+// failing; a #16533 revision oracled it and corrected the assertion instead
+// of "fixing" already-correct code to match the wrong pin.
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -322,7 +332,7 @@ fn static_block_single_alias_does_not_resolve_the_specifier() {
 }
 
 #[test]
-fn static_block_referenced_alias_still_does_not_resolve_the_specifier() {
+fn static_block_referenced_alias_resolves_the_specifier_like_any_function_body() {
     assert_codes(
         r#"class E {
   static {
@@ -330,8 +340,9 @@ fn static_block_referenced_alias_still_does_not_resolve_the_specifier() {
     tango;
   }
 }"#,
-        &[1232],
-        "#16450: referencing the alias must not trigger resolution either",
+        &[1232, 2307],
+        "referencing the alias resolves the specifier — a static block is not exempt from \
+         the general 'bound & used' row (pinned oracle, #16527 review)",
     );
 }
 
@@ -351,6 +362,51 @@ fn nested_block_inside_a_static_block_still_does_not_resolve_the_specifier() {
 }
 
 #[test]
+fn nested_block_referenced_alias_inside_static_block_resolves_the_specifier() {
+    assert_codes(
+        r#"class E {
+  static {
+    {
+      import whiskey = require("nonexistent-module");
+      whiskey;
+    }
+  }
+}"#,
+        &[1232, 2307],
+        "a reference from a plain block nested inside the static block resolves the \
+         specifier the same as a direct reference — nesting does not change the container",
+    );
+}
+
+// #16527 item 2 (colliding aliases inside a static block) is a real, still
+// open, oracle-confirmed defect — the row below stays red. It is deeper than
+// "skip a sibling declaration's own subtree": each `import x = ...` alias
+// binds its own distinct `SymbolId` (aliases deliberately do not merge,
+// `crates/tsz-binder/src/nodes/binding.rs` around the `ALIAS && ALIAS` branch
+// of `declare_symbol`), and only the *first* declaration for a colliding name
+// ever reaches `resolveExternalModuleName` in `tsc` — verified with the
+// pinned oracle:
+//
+// - 2/3 colliding aliases, no reference: no specifier ever resolves.
+// - 2/3 colliding aliases, one explicit reference: only the *first*
+//   declaration's specifier resolves (`TS2307` lands on its position, not the
+//   later duplicates' — confirmed by column offset).
+// - Even the "unused resolves in a script's top-level block" row (#16505) is
+//   suppressed once a name collides — a bare top-level block with two
+//   colliding aliases and no reference at all resolves neither, where a
+//   single non-colliding alias in the same position would resolve.
+//
+// A correct fix needs a first-declaration-in-group gate plus a group-wide
+// (not single-symbol) reference scan, and the full unused/script/module axis
+// re-measured under collision — scoped as its own session rather than
+// folded into this one.
+#[test]
+#[ignore = "#16527 item 2: still open. Each colliding `import x = ...` alias binds its own \
+     distinct SymbolId (aliases deliberately do not merge), so a naive own-subtree skip \
+     cannot see a sibling duplicate as a binding site — the sibling's own name resolves \
+     through scope shadowing to whichever declaration is currently live, not to its \
+     originally-bound symbol. A real fix needs a first-declaration-in-group gate plus a \
+     group-wide reference scan; see the module comment above this test."]
 fn static_block_two_colliding_aliases_do_not_resolve_the_specifier() {
     assert_codes(
         r#"class E {
@@ -361,63 +417,6 @@ fn static_block_two_colliding_aliases_do_not_resolve_the_specifier() {
 }"#,
         &[1232, 1232, 2300, 2300],
         "#16450: the duplicate-alias TS2300 pair (#16437) rides along, but neither specifier resolves",
-    );
-}
-
-// ---------------------------------------------------------------------------
-// #16527 adjacent cases: the referenced-alias short-circuit and the
-// colliding-alias binding-vs-use distinction, exercised beyond the minimal
-// pinning rows above.
-// ---------------------------------------------------------------------------
-
-#[test]
-fn nested_block_referenced_alias_inside_static_block_still_does_not_resolve_the_specifier() {
-    assert_codes(
-        r#"class E {
-  static {
-    {
-      import whiskey = require("nonexistent-module");
-      whiskey;
-    }
-  }
-}"#,
-        &[1232],
-        "#16527: a reference from a plain block nested inside the static block must not \
-         re-trigger resolution either — the static-block carve-out applies through nesting",
-    );
-}
-
-#[test]
-fn static_block_three_colliding_aliases_do_not_resolve_the_specifier() {
-    assert_codes(
-        r#"class E {
-  static {
-    import xray = require("nonexistent-a");
-    import xray = require("nonexistent-b");
-    import xray = require("nonexistent-c");
-  }
-}"#,
-        &[1232, 1232, 1232, 2300, 2300, 2300],
-        "#16527: the binding-vs-use fix generalizes past a single colliding pair — none of \
-         three colliding aliases' own names may satisfy each other's reference scan",
-    );
-}
-
-#[test]
-fn top_level_colliding_aliases_each_independently_resolve() {
-    // A legal top-level `import =` is not position-invalid, so it never
-    // reaches `position_invalid_import_resolves_specifier` at all — its
-    // specifier always resolves regardless of reference or collision. This
-    // is the control row for the two static-block collision tests above: it
-    // pins that the binding-vs-use fix is scoped to the position-invalid
-    // reference scan and does not touch the always-resolves path.
-    assert_codes(
-        r#"import yankee = require("nonexistent-a");
-import yankee = require("nonexistent-b");
-yankee;"#,
-        &[2300, 2300, 2307, 2307],
-        "#16527: outside a static block, each colliding top-level alias resolves its own \
-         specifier independently — unaffected by the binding-vs-use fix",
     );
 }
 


### PR DESCRIPTION
#16533 (merged as `b8cf640`) claimed a class `static { }` block's `import =` never resolves its specifier, referenced or not, and additionally tried to fix a colliding-duplicate-alias false positive by skipping every declaration bound to the same merged `Symbol`.

[@mohsen1's review on #16533](https://github.com/tsz-org/tsz/pull/16533#issuecomment-5199851887) caught this: measured against the pinned `typescript@7.0.2` oracle, a referenced static-block alias DOES resolve, identically to a function body — there is no static-block carve-out for the "bound & used" row. tsz was already correct there; the test #16533 "fixed" was itself wrong (pinned under #16450 without oracling the referenced case). #16533's src change turned a correct diagnostic into a dropped `TS2307` — a real regression, confirmed independently for both the 2-alias and 3-alias collision rows too, since defect 2's fix relied on `Symbol::all_declarations()` merging duplicate aliases into one symbol — they deliberately do not, per the `ALIAS && ALIAS` branch of `declare_symbol` in `crates/tsz-binder/src/nodes/binding.rs` — so the fix was an ineffective no-op that #16533's own defect-1 short-circuit was silently masking.

## Structural rule

When a position-invalid `import =` inside a class `static { }` block is genuinely referenced, `tsc` reaches `resolveExternalModuleName` under `markAliasReferenced` exactly like any other function-like container; `tsz` already did this correctly through `CheckerState::position_invalid_import_resolves_specifier` before #16533. There is no static-block exception to that row of the table.

## What this PR does

- Restores `crates/tsz-checker/src/declarations/import/context_helpers.rs` to its pre-#16533 (`8e8d55b`) content exactly (verified via `git diff 8e8d55b -- <file>` = empty).
- Fixes the two test rows that were pinned wrong: a referenced static-block alias now asserts `[1232, 2307]` (oracle-confirmed), plus one new adjacent case for a reference nested one block deeper.
- Leaves `static_block_two_colliding_aliases_do_not_resolve_the_specifier` `#[ignore]`d with a full oracle write-up (module comment directly above it): the real fix needs a first-declaration-in-group gate plus a group-wide reference scan, and the "unused resolves in a script top-level block" rule (#16505) is itself suppressed once a name collides — verified with 5 additional oracle probes this session. Tracked at #16527 item 2, still open (not closed by this PR).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test position_invalid_import_equals_container_scope_tests`: 22/22 (1 ignored, documented with the full oracle matrix)
- `cargo test -p tsz-checker --test position_invalid_import_specifier_resolution_tests`: 21/21
- `cargo test -p tsz-checker --test import_equals_alias_duplicate_container_tests`: 9/9
- `cargo test -p tsz-checker --test import_equals_alias_duplicate_function_container_tests`: 16/16
- `cargo test -p tsz-checker --lib position_invalid_module_element_module_axis`: 23/23
- `cargo clippy -p tsz-checker --lib --tests`: clean, zero warnings
- Pinned-oracle matrix gathered this session (`typescript@7.0.2`, `--noEmit --strict --pretty false --target es2015 --module commonjs`): single referenced alias in a static block resolves in both module and script mode; single unused alias never resolves; 2/3 colliding aliases with no reference never resolve (any of them); 2/3 colliding aliases with one explicit reference resolve only for the *first* declaration (by source position, confirmed via column offset); a top-level (position-valid) collision resolves independently per declaration, unaffected.

Closes nothing (does not close #16527 — item 2 stays open and tracked). Fixes the regression #16533 introduced.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE