### PR TITLE
fix(checker): a union for-in operand is judged with ALL, not ANY

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -490,6 +490,9 @@ mod for_in_narrowing_tests;
 #[path = "../tests/for_in_self_reference_and_nullable_operand_tests.rs"]
 mod for_in_self_reference_and_nullable_operand_tests;
 #[cfg(test)]
+#[path = "../tests/for_in_union_operand_tests.rs"]
+mod for_in_union_operand_tests;
+#[cfg(test)]
 #[path = "../tests/for_of_self_reference_operand_spelling_tests.rs"]
 mod for_of_self_reference_operand_spelling_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/dispatch.rs
+++ b/crates/tsz-checker/src/query_boundaries/dispatch.rs
@@ -3,7 +3,9 @@ use tsz_solver::construction::{QueryDatabase, TypeDatabase};
 use tsz_solver::def::DefId;
 use tsz_solver::relations::subtype::TypeResolver;
 
-pub(crate) use super::common::{intersection_members, is_type_parameter_like, union_members};
+pub(crate) use super::common::{
+    get_base_constraint_of_type, intersection_members, is_type_parameter_like, union_members,
+};
 
 pub(crate) fn is_object_like_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     tsz_solver::type_queries::is_object_like_type(db, type_id)

--- a/crates/tsz-checker/src/state/variable_checking/for_loop.rs
+++ b/crates/tsz-checker/src/state/variable_checking/for_loop.rs
@@ -166,11 +166,10 @@ impl<'a> CheckerState<'a> {
                 || query::is_object_like_type(self.ctx.types, evaluated_base);
         }
 
-        if let Some(members) = query::union_members(self.ctx.types, expr_type) {
-            return members
-                .iter()
-                .any(|&member| self.is_deferred_object_like_for_in(member));
-        }
+        // No union arm: a union operand is quantified with ALL, not ANY, and is
+        // owned by `for_in_expr_type_is_valid_union`. An ANY arm here would
+        // re-accept `string | object` through the leaf path and silently
+        // bypass that predicate.
 
         if let Some(members) = query::intersection_members(self.ctx.types, expr_type) {
             return members
@@ -556,26 +555,118 @@ impl<'a> CheckerState<'a> {
             && (ty == TypeId::NULL || ty == TypeId::UNDEFINED)
     }
 
-    /// Helper for TS2407: Check if a union type contains at least one valid for-in expression type.
+    /// Helper for TS2407: whether a *union* operand is a valid for-in RHS.
+    ///
+    /// `tsc` quantifies over a union with ALL, not ANY: `allTypesAssignableToKind`
+    /// recurses into a union with `every`, so a single non-object constituent
+    /// rejects the whole operand — `declare const u: string | object` reports
+    /// TS2407 even though `object` on its own would be a fine operand. This
+    /// predicate used to return on the FIRST valid member, which silently
+    /// accepted every mixed union.
+    ///
+    /// Two constituent-level rules come with the quantifier and are not
+    /// optional; both are oracle-verified against `tsc` 7.0.2 in
+    /// `for_in_union_operand_tests.rs`:
+    ///
+    /// - `null` and `undefined` constituents are STRIPPED, not judged.
+    ///   `checkForInStatement` reads
+    ///   `getNonNullableTypeIfNeeded(checkExpression(...))`, so
+    ///   `{ a: number } | undefined` is clean (and `string | undefined` reports
+    ///   with type `'string'`). Without the strip, turning ANY into ALL would
+    ///   invent a false positive on every optional object operand.
+    /// - A type variable is accepted as a WHOLE operand by the type-parameter
+    ///   arm of [`Self::for_in_leaf_type_is_valid`], but as a CONSTITUENT only
+    ///   through an object-like base constraint. `function f<T>(u: T)` is clean
+    ///   while `function f<T>(u: T | { a: number })` reports; adding a
+    ///   constraint (`T extends object`, `T extends { a: number }`,
+    ///   `T extends unknown[]`) makes the union clean again, and
+    ///   `T extends string` keeps it reporting.
+    ///
+    /// A union with every constituent stripped (`null | undefined`) is `never`
+    /// after the strip, which is not a valid operand — hence the
+    /// `saw_unstripped_member` result rather than a vacuous `true`.
     fn for_in_expr_type_is_valid_union(&mut self, expr_type: TypeId) -> bool {
         use crate::query_boundaries::dispatch as query;
 
-        if let Some(members) = query::union_members(self.ctx.types, expr_type) {
-            for &member in &members {
-                if member == TypeId::ANY
-                    || query::is_type_parameter_like(self.ctx.types, member)
-                    || query::is_object_like_type(self.ctx.types, member)
-                    || self.is_deferred_object_like_for_in(member)
-                {
-                    return true;
-                }
-                // Recursively check nested unions
-                if self.for_in_expr_type_is_valid_union(member) {
-                    return true;
-                }
+        let Some(members) = query::union_members(self.ctx.types, expr_type) else {
+            return false;
+        };
+
+        let mut saw_unstripped_member = false;
+        for &member in &members {
+            if member == TypeId::NULL || member == TypeId::UNDEFINED {
+                continue;
+            }
+            saw_unstripped_member = true;
+            if !self.for_in_union_member_is_valid(member, &mut Vec::new()) {
+                return false;
             }
         }
-        false
+        saw_unstripped_member
+    }
+
+    /// Whether one constituent of a union for-in operand is itself acceptable.
+    ///
+    /// `tsc` reaches each constituent through
+    /// `isTypeAssignableToKind(member, NonPrimitive | InstantiableNonPrimitive)`,
+    /// whose object arm is plain assignability to `object`. So the test here is
+    /// "is this member object-like", with a type variable contributing only its
+    /// base constraint — deliberately stricter than
+    /// [`Self::for_in_leaf_type_is_valid`], which judges the operand as a whole.
+    ///
+    /// `constraint_chain` records the type variables already walked so a
+    /// mutually-recursive constraint (`T extends U`, `U extends T` — itself a
+    /// TS2313 error) terminates instead of recursing forever.
+    fn for_in_union_member_is_valid(
+        &mut self,
+        member: TypeId,
+        constraint_chain: &mut Vec<TypeId>,
+    ) -> bool {
+        if self.for_in_union_member_is_valid_shallow(member, constraint_chain) {
+            return true;
+        }
+        // Deferred members (aliases, generic applications like `Box<number>`)
+        // expose their object shape only after resolution. Resolved
+        // individually, exactly as `for_in_expr_type_is_valid_intersection`
+        // does, so one member's resolution cannot collapse the whole union.
+        let resolved = self.resolve_type_for_property_access(member);
+        resolved != member && self.for_in_union_member_is_valid_shallow(resolved, constraint_chain)
+    }
+
+    /// One resolution-free step of [`Self::for_in_union_member_is_valid`].
+    fn for_in_union_member_is_valid_shallow(
+        &mut self,
+        member: TypeId,
+        constraint_chain: &mut Vec<TypeId>,
+    ) -> bool {
+        use crate::query_boundaries::dispatch as query;
+
+        if member == TypeId::ANY {
+            return true;
+        }
+        // A nested union carries the same all-constituents rule (including the
+        // nullable strip), so route it back through the union predicate.
+        if query::union_members(self.ctx.types, member).is_some() {
+            return self.for_in_expr_type_is_valid_union(member);
+        }
+        if query::is_type_parameter_like(self.ctx.types, member) {
+            if constraint_chain.contains(&member) {
+                return false;
+            }
+            constraint_chain.push(member);
+            let constraint = query::get_base_constraint_of_type(self.ctx.types, member);
+            // An unconstrained type parameter answers `unknown` here, which is
+            // not object-like — matching `tsc`, which reports on `T | { a }`.
+            let valid = constraint != member
+                && self.for_in_union_member_is_valid(constraint, constraint_chain);
+            constraint_chain.pop();
+            return valid;
+        }
+        query::is_object_like_type(self.ctx.types, member)
+            // `A & B` is a subtype of each member, so an intersection
+            // constituent is assignable to `object` as soon as ANY of its own
+            // members is — the quantifier flips back for intersections.
+            || self.for_in_expr_type_is_valid_intersection(member)
     }
 
     /// Helper for TS2407: Check if an intersection type is a valid for-in operand.

--- a/crates/tsz-checker/tests/for_in_union_operand_tests.rs
+++ b/crates/tsz-checker/tests/for_in_union_operand_tests.rs
@@ -1,0 +1,303 @@
+//! TS2407: a *union* for-in operand is quantified with ALL, not ANY.
+//!
+//! `tsc`'s `checkForInStatement` gates the RHS on
+//! `allTypesAssignableToKind(rightType, NonPrimitive | InstantiableNonPrimitive)`,
+//! and `allTypesAssignableToKind` recurses into a union with `every`. A single
+//! non-object constituent therefore rejects the whole operand.
+//! `for_in_expr_type_is_valid_union` returned on the FIRST valid member, so
+//! every mixed union — `string | object`, `{ a: number } | number`,
+//! `Shape | number` — was silently accepted and tsz reported nothing where
+//! `tsc` reports TS2407.
+//!
+//! Every row below was run through the pinned oracle before being written
+//! (`scripts/conformance/oracle.sh <case>.ts --strict --target es2022 --lib
+//! es2022`, `tsc` 7.0.2 with the `--singleThreaded --stableTypeOrdering` flags
+//! the cache generator adds for TypeScript 7+, see #16413). The mixed-union
+//! rows were also re-run without `--strict` and behave identically.
+//!
+//! Two constituent-level rules ride along with the quantifier, both oracled:
+//!
+//! - `null`/`undefined` constituents are stripped, not judged
+//!   (`getNonNullableTypeIfNeeded`), so `{ a: number } | undefined` stays
+//!   clean. Without the strip, ALL would invent a false positive on every
+//!   optional object operand.
+//! - A type variable is a valid operand ON ITS OWN but contributes to a union
+//!   only through its base constraint: `f<T>(u: T)` is clean, `f<T>(u: T | { a:
+//!   number })` reports, and constraining `T` to an object-like type makes the
+//!   union clean again.
+//!
+//! Binder names are varied across rows (`u`, `holder`, `payload`, `subject`,
+//! `bag`) and the type-parameter rows use `T`/`Item`/`Elem`, so nothing here
+//! can be satisfied by a user-chosen identifier.
+
+use crate::test_utils::{
+    check_source_non_strict, check_source_strict_messages, diagnostic_code_messages,
+};
+
+const TS2407: u32 = 2407;
+
+fn ts2407_types(messages: &[(u32, String)]) -> Vec<String> {
+    messages
+        .iter()
+        .filter(|(code, _)| *code == TS2407)
+        .map(|(_, text)| {
+            text.rsplit_once("but here has type ").map_or_else(
+                || text.clone(),
+                |(_, ty)| ty.trim_end_matches('.').to_string(),
+            )
+        })
+        .collect()
+}
+
+/// TS2407 codes reported for `source` under `--strict`, as the operand types
+/// named by the message (empty when the operand is accepted).
+fn strict_ts2407(source: &str) -> Vec<String> {
+    ts2407_types(&check_source_strict_messages(source))
+}
+
+fn non_strict_ts2407(source: &str) -> Vec<String> {
+    ts2407_types(&diagnostic_code_messages(check_source_non_strict(source)))
+}
+
+fn assert_reports(source: &str) {
+    assert_eq!(
+        strict_ts2407(source).len(),
+        1,
+        "expected exactly one TS2407 for {source:?}, got {:?}",
+        check_source_strict_messages(source)
+    );
+}
+
+fn assert_clean(source: &str) {
+    assert!(
+        strict_ts2407(source).is_empty(),
+        "expected no TS2407 for {source:?}, got {:?}",
+        check_source_strict_messages(source)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The quantifier itself: one bad constituent rejects the union.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn union_of_string_and_object_reports() {
+    // The witness from the report: `object` alone is a fine operand, but the
+    // union is not, because `string` is not assignable to `object`.
+    assert_reports("declare const u: string | object;\nfor (var i in u) {}");
+}
+
+#[test]
+fn union_of_object_type_and_number_reports() {
+    assert_reports("declare const holder: { a: number } | number;\nfor (var key in holder) {}");
+}
+
+#[test]
+fn union_of_interface_and_number_reports() {
+    // Renamed binder + a named interface rather than an anonymous literal:
+    // the rule is structural, not keyed to any spelling.
+    assert_reports(
+        "interface Shape { side: number }\ndeclare const payload: Shape | number;\nfor (var key in payload) {}",
+    );
+}
+
+#[test]
+fn union_of_object_type_and_boolean_symbol_or_void_reports() {
+    for bad in ["boolean", "symbol", "void"] {
+        assert_reports(&format!(
+            "declare const subject: {{ a: number }} | {bad};\nfor (var key in subject) {{}}"
+        ));
+    }
+}
+
+#[test]
+fn union_of_enum_and_object_type_reports() {
+    assert_reports(
+        "enum Channel { Red }\ndeclare const bag: Channel | { a: number };\nfor (var key in bag) {}",
+    );
+}
+
+#[test]
+fn union_of_string_literals_reports() {
+    assert_reports("declare const bag: 'a' | 'b';\nfor (var key in bag) {}");
+}
+
+#[test]
+fn union_of_two_primitives_reports() {
+    assert_reports("declare const u: string | number;\nfor (var i in u) {}");
+}
+
+#[test]
+fn one_bad_constituent_among_three_reports() {
+    assert_reports("declare const u: { a: 1 } | { b: 2 } | string;\nfor (var i in u) {}");
+}
+
+#[test]
+fn nested_union_alias_hiding_a_primitive_reports() {
+    // The bad constituent is one level down, behind an alias — the ALL rule
+    // has to recurse, not just scan the top level.
+    assert_reports(
+        "type Inner = { a: number } | number;\ndeclare const u: Inner | { b: string };\nfor (var i in u) {}",
+    );
+}
+
+#[test]
+fn generic_application_union_with_a_primitive_reports() {
+    assert_reports(
+        "type Box<T> = { value: T };\ndeclare const u: Box<number> | number;\nfor (var i in u) {}",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negatives: all-object unions stay clean (no false positive from the flip).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn union_of_two_object_types_is_clean() {
+    assert_clean("declare const u: { a: number } | { b: string };\nfor (var i in u) {}");
+}
+
+#[test]
+fn union_of_three_object_types_is_clean() {
+    assert_clean("declare const u: { a: 1 } | { b: 2 } | { c: 3 };\nfor (var i in u) {}");
+}
+
+#[test]
+fn union_of_object_type_aliases_is_clean() {
+    assert_clean(
+        "type A = { a: number };\ntype B = { b: number };\ndeclare const holder: A | B;\nfor (var key in holder) {}",
+    );
+}
+
+#[test]
+fn union_of_generic_applications_is_clean() {
+    // Deferred members: `Box<number>` is object-like only after per-member
+    // resolution, which must not collapse the union.
+    assert_clean(
+        "type Box<T> = { value: T };\ndeclare const u: Box<number> | Box<string>;\nfor (var i in u) {}",
+    );
+}
+
+#[test]
+fn union_with_an_array_or_function_constituent_is_clean() {
+    assert_clean("declare const u: { a: number } | string[];\nfor (var i in u) {}");
+    assert_clean("declare const u: { a: number } | (() => void);\nfor (var i in u) {}");
+}
+
+#[test]
+fn union_with_any_is_clean() {
+    assert_clean("declare const u: { a: number } | any;\nfor (var i in u) {}");
+}
+
+#[test]
+fn union_of_object_type_and_intersection_is_clean() {
+    // The quantifier flips back inside an intersection constituent: `A & B` is
+    // a subtype of each member, so ANY object-like member suffices there.
+    assert_clean(
+        "declare const u: ({ a: number } & { b: number }) | { c: number };\nfor (var i in u) {}",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The nullable strip: `getNonNullableTypeIfNeeded`, not a judged constituent.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn optional_object_operand_is_clean() {
+    assert_clean("declare const u: { a: number } | undefined;\nfor (var i in u) {}");
+    assert_clean("declare const holder: { a: number } | null;\nfor (var key in holder) {}");
+    assert_clean(
+        "declare const payload: { a: number } | null | undefined;\nfor (var key in payload) {}",
+    );
+}
+
+#[test]
+fn optional_primitive_operand_still_reports() {
+    // The strip removes `undefined` and then judges what is left, so this must
+    // still report — it is the strip, not a blanket exemption for optionals.
+    assert_reports("declare const u: string | undefined;\nfor (var i in u) {}");
+}
+
+#[test]
+fn mixed_union_reports_in_non_strict_mode_too() {
+    // The rule is an assignability fact about the constituents, not a
+    // strictNullChecks-dependent one; oracled both ways.
+    assert_eq!(
+        non_strict_ts2407("declare const u: string | { a: number };\nfor (var i in u) {}").len(),
+        1
+    );
+    assert!(
+        non_strict_ts2407("declare const u: { a: number } | { b: string };\nfor (var i in u) {}")
+            .is_empty()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Type variables: valid alone, but only via an object-like constraint in a
+// union.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bare_type_parameter_operand_is_clean() {
+    // Unchanged by this fix, and the reason the union rule cannot simply reuse
+    // the leaf predicate.
+    assert_clean("function f<T>(u: T) { for (var i in u) {} }");
+    assert_clean("function f<Item extends string>(u: Item) { for (var i in u) {} }");
+}
+
+#[test]
+fn unconstrained_type_parameter_in_a_union_reports() {
+    assert_reports("function f<T>(u: T | { a: number }) { for (var i in u) {} }");
+    // Constituent order must not matter.
+    assert_reports("function f<T>(u: { a: number } | T) { for (var i in u) {} }");
+    assert_reports("function f<T, U>(u: T | U) { for (var i in u) {} }");
+}
+
+#[test]
+fn explicitly_unknown_constrained_type_parameter_in_a_union_reports() {
+    assert_reports(
+        "function f<Elem extends unknown>(u: Elem | { b: number }) { for (var i in u) {} }",
+    );
+}
+
+#[test]
+fn primitive_constrained_type_parameter_in_a_union_reports() {
+    assert_reports(
+        "function f<Elem extends string>(u: Elem | { b: number }) { for (var i in u) {} }",
+    );
+}
+
+#[test]
+fn object_constrained_type_parameter_in_a_union_is_clean() {
+    assert_clean("function f<T extends object>(u: T | { a: number }) { for (var i in u) {} }");
+    assert_clean(
+        "function f<Item extends { a: number }>(u: Item | { b: number }) { for (var i in u) {} }",
+    );
+    assert_clean(
+        "function f<Elem extends unknown[]>(u: Elem | { b: number }) { for (var i in u) {} }",
+    );
+}
+
+#[test]
+fn indexed_access_on_an_unconstrained_parameter_in_a_union_reports() {
+    assert_reports("function f<T>(u: T[keyof T] | { b: number }) { for (var i in u) {} }");
+}
+
+// ---------------------------------------------------------------------------
+// Non-union operands are untouched by the quantifier change.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn non_union_operands_keep_their_verdicts() {
+    assert_clean("declare const u: object;\nfor (var i in u) {}");
+    assert_clean("declare const u: { a: number };\nfor (var i in u) {}");
+    assert_clean("declare const u: any;\nfor (var i in u) {}");
+    assert_reports("declare const u: unknown;\nfor (var i in u) {}");
+    assert_reports("declare const u: string;\nfor (var i in u) {}");
+}
+
+#[test]
+fn union_collapsing_to_unknown_reports() {
+    // `{ a: number } | unknown` is `unknown`, which is not a valid operand.
+    assert_reports("declare const u: { a: number } | unknown;\nfor (var i in u) {}");
+}


### PR DESCRIPTION
**Structural rule.** When the right-hand side of a `for...in` is a **union**, tsc requires *every* constituent to be assignable to `object` (`allTypesAssignableToKind` recurses into a union with `every`); tsz does the same through the **checker TS2407 operand-validity predicate**, `for_in_expr_type_is_valid_union`.

> Note: an earlier revision of this body had its generic type arguments eaten by HTML sanitising. All signatures below are inside fenced code blocks for that reason.

The wrong semantic operation was a **quantifier inversion in a validity relation**, not a display or narrowing bug. `for_in_expr_type_is_valid_union` returned on the **first** valid member, so every mixed union was silently accepted:

```ts
declare const u: string | object;
for (var i in u) {}   // tsc: TS2407 — tsz before this PR: nothing
```

Picked up from the note ClaudeDE left while working #16530, explicitly out of scope there (that PR fixes the *message text* of a TS2407 that fires; this one fixes *whether it fires at all*). The two touch the same file but disjoint regions.

The same ANY arm also lived one layer down, inside `is_deferred_object_like_for_in`, which `for_in_leaf_type_is_valid` reaches. Fixing only the union predicate would have left `string | object` re-accepted through the leaf path, so both arms move together — the union arm there is removed and the union decision now has exactly one owner.

### Two constituent-level rules ride along, and are not optional

Both are required for the flip to be correct, and both are oracle-verified.

**1. `null` and `undefined` constituents are stripped, not judged.** `checkForInStatement` reads `getNonNullableTypeIfNeeded(checkExpression(...))`, so an optional object operand stays clean while an optional primitive still reports, and the stripped form is what gets displayed:

```ts
declare const a: { a: number } | undefined;
for (var i in a) {}            // clean

declare const b: string | undefined;
for (var i in b) {}            // TS2407, and the message names type 'string'
```

Without the strip, turning ANY into ALL would invent a false positive on **every optional object operand** — a much worse regression than the bug being fixed. This independently cross-confirms #16530's finding that a bare `null` operand displays as `never`: it is stripped to `never` before `typeToString`.

**2. A type variable is valid alone, but contributes to a union only through its base constraint.**

```ts
function f1<T>(u: T)                            { for (var i in u) {} }  // clean
function f2<Item extends string>(u: Item)       { for (var i in u) {} }  // clean

function f3<T>(u: T | { a: number })            { for (var i in u) {} }  // TS2407
function f4<T>(u: { a: number } | T)            { for (var i in u) {} }  // TS2407 (order-independent)
function f5<T, U>(u: T | U)                     { for (var i in u) {} }  // TS2407
function f6<E extends unknown>(u: E | { b: 1 }) { for (var i in u) {} }  // TS2407
function f7<E extends string>(u: E | { b: 1 })  { for (var i in u) {} }  // TS2407
function f8<T>(u: T[keyof T] | { b: 1 })        { for (var i in u) {} }  // TS2407

function g1<T extends object>(u: T | { a: 1 })          { for (var i in u) {} }  // clean
function g2<I extends { a: number }>(u: I | { b: 1 })   { for (var i in u) {} }  // clean
function g3<E extends unknown[]>(u: E | { b: 1 })       { for (var i in u) {} }  // clean
```

This asymmetry is exactly why the union predicate **cannot** reuse `for_in_leaf_type_is_valid`, and it is why the new constituent predicate is a separate function rather than a call back into the leaf one. I re-ran it six ways because it looked like an oracle artifact; it is not.

Inside an **intersection** constituent the quantifier flips back to ANY (an intersection is a subtype of each member), which the existing `for_in_expr_type_is_valid_intersection` already models correctly and is left alone.

### Adjacent-case matrix

35 rows run through the pinned oracle **before** any code was written:

```
scripts/conformance/oracle.sh CASE.ts --strict --target es2022 --lib es2022
```

tsc 7.0.2, with the `--singleThreaded --stableTypeOrdering` flags the cache generator adds for TS 7+ (see #16413). The mixed-union rows were re-run without `--strict` and behave identically. 28 tests in `crates/tsz-checker/tests/for_in_union_operand_tests.rs` encode them; tsz matches tsc on every row after this change.

Reports TS2407:

```
string | object                          <- the reported witness
{ a: number } | number
Shape | number                           <- named interface, not an anonymous literal
{ a: number } | boolean
{ a: number } | symbol
{ a: number } | void
Channel | { a: number }                  <- numeric enum constituent
'a' | 'b'
string | number
{ a: 1 } | { b: 2 } | string             <- one bad constituent out of three
Inner | { b: string }                    <- Inner = { a: number } | number, nested behind an alias
Box(number) | number                     <- generic application constituent
{ a: number } | unknown                  <- collapses to unknown
string | undefined                       <- strip, then judge what is left
```

Stays clean:

```
{ a: number } | { b: string }
{ a: 1 } | { b: 2 } | { c: 3 }
A | B                                    <- both object-type aliases
Box(number) | Box(string)                <- deferred, resolved per member
{ a: number } | string[]
{ a: number } | (() => void)
{ a: number } | any
({ a: 1 } & { b: 2 }) | { c: 3 }         <- intersection constituent
{ a: number } | undefined
{ a: number } | null
{ a: number } | null | undefined
```

Non-union operands are untouched and pinned as controls: `object`, `{ a: number }` and `any` stay clean; `unknown` and `string` keep reporting.

Binder names are varied across rows (`u`, `holder`, `payload`, `subject`, `bag`; `T` / `Item` / `Elem`) and the interface row uses a named `interface` rather than an anonymous literal, so no row can be satisfied by a user-chosen identifier. No identifier, alias, property, or file-name string drives any decision, and no predicate reads rendered printer output.

**Termination.** The constituent walk threads a `constraint_chain` of visited type variables, so a mutually-recursive constraint (`T extends U`, `U extends T` — itself a TS2313 error) terminates rather than recursing forever.

## Goal
Goal: hold

## Verification
- `cargo build -p tsz-checker --lib` — clean.
- `cargo fmt --all`, plus clippy through the repo pre-commit hook `Verifying: -p tsz-checker` leg — passed. That is the same deny set as the per-merge lane.
- `cargo test -p tsz-checker --lib for_in_union_operand` — **28 passed, 0 failed** (new suite).
- 35-row tsc 7.0.2 oracle matrix above, run before implementation, both strictness modes for the mixed-union rows.
- Corpus scan of every `for...in`-containing case under `TypeScript/tests/cases/compiler` and `.../conformance` (148 files) with a debug `tsz`, two-sided against a binary built from this PR own parent commit — results appended as a comment when they land.
- **Owed, could not run on this seat:** `scripts/conformance/compare-to-parent.sh` and a full `conformance.sh snapshot`. This is a cold 4-core container; a release build plus an 8-minute sweep does not fit the session. Emit and fourslash are untouched by this diff (no emitter or LSP code paths).
- **Do not merge** until the full `cargo test -p tsz-checker --lib` count and the two-sided corpus scan are posted green in a comment below. Both were still running when this PR was opened.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Larimar