### PR TITLE
test(checker): unique module-local SymbolIds fix kysely cross-file conditional-builder rows (#15983)

### DIFF
--- a/crates/tsz-checker/src/test_utils.rs
+++ b/crates/tsz-checker/src/test_utils.rs
@@ -1262,7 +1262,7 @@ mod multi_file;
 pub use multi_file::{
     check_all_multi_file_with_global_index, check_multi_file, check_multi_file_with_global_index,
     check_multi_file_with_libs, check_multi_file_with_libs_stamped,
-    check_multi_file_with_type_params_cache,
+    check_multi_file_with_libs_unique_module_locals, check_multi_file_with_type_params_cache,
 };
 
 #[cfg(test)]

--- a/crates/tsz-checker/src/test_utils/multi_file.rs
+++ b/crates/tsz-checker/src/test_utils/multi_file.rs
@@ -47,6 +47,39 @@ fn new_binder_for_file(file_idx: usize) -> BinderState {
     binder
 }
 
+/// Place a lib-aware file's module-local symbols in a raw-id range disjoint
+/// from every other file's, without disturbing the shared lib prefix.
+///
+/// The whole-arena per-file *base* used by [`new_binder_for_file`] cannot be
+/// reused here: `merge_lib_symbols` folds the shared lib universe into this
+/// binder's arena at ids `[0, lib_count)`, and those ids must stay identical
+/// across files (the driver merges each lib symbol to a single global id, and
+/// the in-process type caches key on the raw id — a per-file base would give
+/// the same lib type a different id per file and split its identity). So the
+/// lib prefix keeps its ids and only the module-local *suffix* is shifted:
+/// after the lib merge, reserve placeholder ids up to `next_base` (the running
+/// high-water mark of module-local ids handed out by earlier files, or the
+/// current arena length when that is higher) so the first symbol this file
+/// binds lands above every earlier file's module-local range. This gives
+/// module-scoped declarations the file-disjoint ids the dynamic cross-file
+/// overlay (`cross_file_symbol_targets`, keyed by the bare `SymbolId`) needs to
+/// tell two files' same-named module exports apart. It reproduces only the
+/// *id-disjointness* of the driver's remap, not its `decl_file_idx` stamping or
+/// `global_symbol_file_index` (use [`check_multi_file_with_libs_stamped`] for
+/// those). `reserve_symbol_ids` is a no-op when the arena already reaches
+/// `next_base`, so file 0's suffix follows its lib prefix with no gap and the
+/// reserved ranges stay tightly packed.
+///
+/// Each file keeps its own binder/arena, so the caller threads `next_base`
+/// forward as a running high-water mark. Total placeholder count therefore
+/// grows as O(files² · module-locals) — negligible for the small fixtures these
+/// helpers target, but a project of dozens of files with hundreds of symbols
+/// each would want a sparse two-region arena instead.
+fn reserve_module_local_symbol_base(binder: &mut BinderState, next_base: usize) {
+    let base = binder.symbols.len().max(next_base);
+    binder.symbols.reserve_symbol_ids(base);
+}
+
 /// Build the test-harness `SymbolId -> file_idx` disambiguation index.
 ///
 /// The driver's `build_global_symbol_file_index` maps only symbols the
@@ -283,7 +316,40 @@ pub fn check_multi_file_with_libs(
     options: CheckerOptions,
     lib_files: &[Arc<LibFile>],
 ) -> Vec<Diagnostic> {
-    check_multi_file_with_libs_impl(files, entry_file, options, lib_files, false)
+    check_multi_file_with_libs_impl(files, entry_file, options, lib_files, LibHelperMode::Plain)
+}
+
+/// Like [`check_multi_file_with_libs`] but with the driver's
+/// globally-unique-`SymbolId` invariant restored for module-scoped
+/// declarations (see [`reserve_module_local_symbol_base`]).
+///
+/// The plain helpers build every per-file binder with a base-0 arena, so file
+/// B's first module-local `SymbolId` aliases file A's — and the dynamic
+/// cross-file overlay (`cross_file_symbol_targets`), keyed by the bare
+/// `SymbolId`, then cannot tell two files' distinct-but-same-named module
+/// exports apart. In production the bind-result reducer remaps every file's
+/// module-local ids into one program-global space, so this never happens.
+///
+/// Use this for cross-file regressions where distinct module-scoped
+/// declarations share a name or shape across files and must resolve to their
+/// own declaring file — e.g. an imported conditional-builder alias whose
+/// helper (`ResultBuilder`, `SelectionCallback`, …) is also declared, with a
+/// different body, in another project file. The lib prefix keeps its shared
+/// ids, so lib-type identity is unaffected; only the module-local suffix is
+/// made file-unique.
+pub fn check_multi_file_with_libs_unique_module_locals(
+    files: &[(&str, &str)],
+    entry_file: &str,
+    options: CheckerOptions,
+    lib_files: &[Arc<LibFile>],
+) -> Vec<Diagnostic> {
+    check_multi_file_with_libs_impl(
+        files,
+        entry_file,
+        options,
+        lib_files,
+        LibHelperMode::UniqueModuleLocals,
+    )
 }
 
 /// Like [`check_multi_file_with_libs`] but production-faithful with respect to
@@ -303,40 +369,72 @@ pub fn check_multi_file_with_libs_stamped(
     options: CheckerOptions,
     lib_files: &[Arc<LibFile>],
 ) -> Vec<Diagnostic> {
-    check_multi_file_with_libs_impl(files, entry_file, options, lib_files, true)
+    check_multi_file_with_libs_impl(
+        files,
+        entry_file,
+        options,
+        lib_files,
+        LibHelperMode::Stamped,
+    )
 }
 
-/// Shared body for [`check_multi_file_with_libs`] and
-/// [`check_multi_file_with_libs_stamped`]. When `stamp` is set, each binder is
-/// given its file index before binding (so `stamp_file_idx` records
-/// `decl_file_idx`) and the `global_symbol_file_index` is wired — matching the
-/// production driver. When unset, this is the lib-aware counterpart to
-/// [`check_multi_file`] that leaves `decl_file_idx == u32::MAX`.
+/// How [`check_multi_file_with_libs_impl`] should build each file's binder.
+/// The three lib-aware entry points map one-to-one onto these variants, so the
+/// otherwise-invalid combinations (e.g. stamped *and* unique module locals) are
+/// unrepresentable.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum LibHelperMode {
+    /// Base-0 arenas, `decl_file_idx == u32::MAX`, no `global_symbol_file_index`.
+    Plain,
+    /// Driver-faithful provenance: `set_file_idx` before binding (so
+    /// `stamp_file_idx` records `decl_file_idx`) and the
+    /// `global_symbol_file_index` wired.
+    Stamped,
+    /// Module-local `SymbolId`s made file-disjoint (see
+    /// [`reserve_module_local_symbol_base`]); shared lib prefix keeps its ids.
+    UniqueModuleLocals,
+}
+
+/// Shared body for [`check_multi_file_with_libs`],
+/// [`check_multi_file_with_libs_stamped`], and
+/// [`check_multi_file_with_libs_unique_module_locals`]; the [`LibHelperMode`]
+/// selects which per-file binder layout each uses.
 fn check_multi_file_with_libs_impl(
     files: &[(&str, &str)],
     entry_file: &str,
     options: CheckerOptions,
     lib_files: &[Arc<LibFile>],
-    stamp: bool,
+    mode: LibHelperMode,
 ) -> Vec<Diagnostic> {
     let mut arenas = Vec::with_capacity(files.len());
     let mut binders = Vec::with_capacity(files.len());
     let mut roots = Vec::with_capacity(files.len());
     let file_names: Vec<String> = files.iter().map(|(name, _)| (*name).to_string()).collect();
 
+    // Running high-water mark of module-local `SymbolId`s already handed out by
+    // earlier files (only consulted in `UniqueModuleLocals` mode).
+    let mut next_module_local_base = 0usize;
     for (file_idx, (name, source)) in files.iter().enumerate() {
         let mut parser = ParserState::new((*name).to_string(), (*source).to_string());
         let root = parser.parse_source_file();
         let mut binder = BinderState::new();
-        if stamp {
+        if mode == LibHelperMode::Stamped {
             // Stamp the driver-assigned file index before binding so that
             // `stamp_file_idx` runs at bind end and records `decl_file_idx`.
             binder.set_file_idx(file_idx as u32);
         }
-        if lib_files.is_empty() {
-            binder.bind_source_file(parser.get_arena(), root);
-        } else {
-            binder.bind_source_file_with_libs(parser.get_arena(), root, lib_files);
+        // `bind_source_file_with_libs` is exactly merge-libs-then-bind; the
+        // steps are spelled out here so the per-file id-gap reservation can be
+        // wedged between the lib merge and binding this file's own declarations.
+        if !lib_files.is_empty() {
+            binder.merge_lib_symbols(lib_files);
+        }
+        if mode == LibHelperMode::UniqueModuleLocals {
+            reserve_module_local_symbol_base(&mut binder, next_module_local_base);
+        }
+        binder.bind_source_file(parser.get_arena(), root);
+        if mode == LibHelperMode::UniqueModuleLocals {
+            next_module_local_base = binder.symbols.len();
         }
         arenas.push(Arc::new(parser.get_arena().clone()));
         binders.push(Arc::new(binder));
@@ -381,7 +479,7 @@ fn check_multi_file_with_libs_impl(
         .set_resolved_module_paths(Arc::new(resolved_module_paths));
     checker.ctx.set_resolved_modules(resolved_modules);
 
-    if stamp {
+    if mode == LibHelperMode::Stamped {
         let symbol_file_index = build_test_symbol_file_index(&all_binders);
         checker
             .ctx

--- a/crates/tsz-checker/tests/kysely_callback_context_tests.rs
+++ b/crates/tsz-checker/tests/kysely_callback_context_tests.rs
@@ -1,7 +1,8 @@
 use tsz_checker::context::CheckerOptions;
 use tsz_checker::diagnostics::Diagnostic;
 use tsz_checker::test_utils::{
-    check_multi_file_with_libs, check_multi_file_with_libs_stamped, check_source_with_libs,
+    check_multi_file_with_libs, check_multi_file_with_libs_stamped,
+    check_multi_file_with_libs_unique_module_locals, check_source_with_libs,
     diagnostic_line_column, load_default_lib_files,
 };
 
@@ -370,10 +371,11 @@ query.select((reader) => [
         ),
     ];
 
-    let diagnostics = check_multi_file_with_libs(&files, "main.ts", options, &lib_files)
-        .into_iter()
-        .filter(|diagnostic| diagnostic.code != 2318)
-        .collect::<Vec<_>>();
+    let diagnostics =
+        check_multi_file_with_libs_unique_module_locals(&files, "main.ts", options, &lib_files)
+            .into_iter()
+            .filter(|diagnostic| diagnostic.code != 2318)
+            .collect::<Vec<_>>();
 
     assert!(
         lacks_any_diagnostic_code(&diagnostics, &[2339, 2347, 7006]),
@@ -471,10 +473,11 @@ query.select((reader) => [
         ),
     ];
 
-    let diagnostics = check_multi_file_with_libs(&files, "main.ts", options, &lib_files)
-        .into_iter()
-        .filter(|diagnostic| diagnostic.code != 2318)
-        .collect::<Vec<_>>();
+    let diagnostics =
+        check_multi_file_with_libs_unique_module_locals(&files, "main.ts", options, &lib_files)
+            .into_iter()
+            .filter(|diagnostic| diagnostic.code != 2318)
+            .collect::<Vec<_>>();
 
     assert!(
         lacks_any_diagnostic_code(&diagnostics, &[2339, 2347, 7006]),

--- a/scripts/ci/known-failures.txt
+++ b/scripts/ci/known-failures.txt
@@ -88,6 +88,15 @@
 # Fix-or-remove tracked in #15983 and #15396/#13979 respectively; #15999
 # closed as superseded (its other three sections were independently fixed by
 # #16002/#16003/#16006/#16007).
+# 2026-08-06 shrink (no generation bump — removals are always allowed): the two
+# kysely_callback_context_tests conditional-builder rows now pass. They were the
+# #15983 SymbolId-collision family surfacing through the lib-aware multi-file
+# harness: base-0 per-file binders aliased distinct-but-same-named module
+# exports (e.g. two files' `ResultBuilder`) on one raw SymbolId, which the
+# dynamic cross-file overlay could not disambiguate. Fixed by migrating the two
+# rows to the new production-faithful `check_multi_file_with_libs_unique_module_locals`
+# helper, which gives each file's module-local suffix a disjoint id range while
+# keeping the shared lib prefix's ids (mirroring the driver's bind-result reducer).
 # baseline-status: reconciled r10
 
 tsz-checker::commonjs_module_export_alias_tests::test_module_exports_forward_read_reports_ts2565
@@ -118,8 +127,6 @@ tsz-checker::js_export_surface_tests::part_01::test_current_file_module_exports_
 tsz-checker::js_jsdoc_diagnostics_tests::checked_js_async_jsdoc_expression_body_ts2322_anchors_on_return_expr
 tsz-checker::jsdoc_constructor_typeof_source_display_tests::ts2345_jsdoc_constructor_function_decl_displays_plain_function_source
 tsz-checker::jsdoc_constructor_typeof_source_display_tests::ts2345_jsdoc_constructor_var_displays_plain_function_source
-tsz-checker::kysely_callback_context_tests::imported_conditional_builder_alias_materializes_callback_context
-tsz-checker::kysely_callback_context_tests::imported_conditional_builder_alias_uses_declaring_file_for_duplicate_helper_names
 tsz-checker::nonnull_contextual_type_arg_inference_tests::contextual_return_can_refine_transparent_wrapper_inference
 tsz-checker::raw_builder_return_context_inference_tests::different_base_and_ambiguous_union_do_not_pin_the_tag
 tsz-checker::reexported_symbol_keyed_member_tests::direct_import_symbol_keyed_member_is_clean


### PR DESCRIPTION
When two project files declare distinct-but-same-named module exports (e.g. each has its own `ResultBuilder`), `tsc` keeps them separate. tsz's lib-aware multi-file **test harness** conflated them: `check_multi_file_with_libs*` builds every per-file binder with a base-0 arena, so file B's first module-local `SymbolId` aliases file A's. The dynamic cross-file overlay (`cross_file_symbol_targets`), keyed by the bare `SymbolId`, then resolved an imported conditional-builder alias through the *wrong* file's helper, dropping the callback context (false `TS2339`/`TS2347`/`TS7006`).

Structural rule: **when distinct module-scoped declarations across files share a raw module-local `SymbolId`, `tsc` still keeps them separate; tsz does too in production — the bind-result reducer remaps every file's module-local ids into one program-global space — but the in-process harness never ran that reducer.** This is the #15983 `SymbolId`-collision family surfacing only through the harness (the real driver + `tsc` are clean on these fixtures).

Fix: add an opt-in, production-faithful helper `check_multi_file_with_libs_unique_module_locals` that keeps the shared lib prefix at identical ids across files (so lib-type identity is untouched) and reserves a per-file gap so each file's module-local **suffix** lands in a disjoint id range. Migrate the two `kysely_callback_context_tests` conditional-builder rows to it and drop them from the known-failures baseline (a shrink).

Rejected alternatives (both verified to regress):
- A whole-arena per-file base (as the lib-absent helpers use) gives the same lib type a different id per file and splits lib-type identity (broke the freeze-factory row).
- Making the scheme the default for all lib-aware helpers splits shared lib/global-augmentation identity that other cross-file tests rely on (e.g. the xstate `Symbol.observable` witness, `lib_resolution`, reexport identity).

Scoping this to an opt-in helper keeps the `Plain`/`Stamped` paths **byte-identical**, so no other test changes behavior. The two bools on the shared impl are replaced by a `LibHelperMode` enum so the invalid `stamped + unique` combination is unrepresentable.

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-checker --test kysely_callback_context_tests` — 9/9 pass (was 2 failing: the two `imported_conditional_builder_alias_*` rows).
- Per-binary re-run of the previously-affected suites confirms no new failures vs clean `main` (e.g. `generic_call_assignment_flow_tests` still shows exactly its 2 pre-existing failures; `wide_symbol`/`lib_resolution` xstate/iterator rows pass; `cross_file_lib_interface_identity_tests` unchanged).
- `cargo clippy -p tsz-checker --tests` clean; `bash scripts/ci/check-unit-gate-contracts.sh` passes (known-failures growth gate recognizes the 2-entry shrink).
- Arch-size: `multi_file.rs` is 554 lines (< 2000 cap).

## Provenance
Machine: cloud
Assistant: claude-code
Model: Claude Code (Opus-class)
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRcXxNLUMVgzGz2mdYjxCi)_