### PR TITLE
fix(binder,checker): `export * from` no longer forwards a `default` export

### DIFF
--- a/crates/tsz-binder/src/state/resolution.rs
+++ b/crates/tsz-binder/src/state/resolution.rs
@@ -825,7 +825,16 @@ impl BinderState {
 
         // Check for wildcard re-exports: `export * from 'bar'`
         // A module can have multiple wildcard re-exports, check all of them.
-        if let Some(entries) = self.wildcard_reexports.get(module_specifier) {
+        //
+        // `export *` never forwards `default` (ECMAScript's
+        // `ExportStarAsNamedExports` drops the local name `default` from what a
+        // wildcard export re-exports; `tsc`'s `visitExportedUnnamedExportBindings`
+        // is only called when `specifier.name.escapedText !== InternalSymbolName.Default`).
+        // Only a *named* re-export (`export { default } from 'bar'`, handled by
+        // the `reexports` branch above) forwards a default across a barrel.
+        if export_name != "default"
+            && let Some(entries) = self.wildcard_reexports.get(module_specifier)
+        {
             // When the caller is in value context (`is_type_only = false`), a
             // type-only path found in one wildcard source must not shadow a
             // VALUE export of the same name from a later wildcard source.

--- a/crates/tsz-checker/src/state/type_resolution/module/reexports.rs
+++ b/crates/tsz-checker/src/state/type_resolution/module/reexports.rs
@@ -140,12 +140,23 @@ impl<'a> CheckerState<'a> {
         // Check wildcard re-exports before file_locals so that
         // `export * from './other'` is followed to the actual declaring file.
         // file_locals may contain merged globals that shadow re-exported symbols.
-        if let Some(source_modules) = self
-            .ctx
-            .wildcard_reexports_for_file(target_binder, &target_file_name)
-            .or_else(|| {
-                module_key.and_then(|key| self.ctx.wildcard_reexports_for_file(target_binder, key))
-            })
+        //
+        // `export *` never forwards `default`: ECMAScript's `ExportStarAsNamedExports`
+        // resolution explicitly drops the local name `default` from the list a
+        // wildcard export re-exports, so a source module's own default is never
+        // visible through a re-exporting barrel unless the barrel exports it by
+        // name (`export { default } from './m'`, tracked separately in
+        // `reexports_for_file` above). `export_name == "default"` skips this whole
+        // branch rather than filtering per-source, matching tsc's `visitExportedUnnamedExportBindings`
+        // (called only when `specifier.name.escapedText !== InternalSymbolName.Default`).
+        if export_name != "default"
+            && let Some(source_modules) = self
+                .ctx
+                .wildcard_reexports_for_file(target_binder, &target_file_name)
+                .or_else(|| {
+                    module_key
+                        .and_then(|key| self.ctx.wildcard_reexports_for_file(target_binder, key))
+                })
         {
             let source_modules = source_modules.clone();
 
@@ -338,8 +349,14 @@ impl<'a> CheckerState<'a> {
                                 .module_exports_for_module(source_binder, source_module)
                         })
                     {
+                        // `export *` never forwards `default` — see the matching
+                        // exclusion and citation in `resolve_export_in_file_uncached`
+                        // above. Without this, a wildcard-reexporting barrel's
+                        // namespace object (`import * as ns from './barrel'`) would
+                        // expose `ns.default` whenever the wildcard source has one,
+                        // even though tsc's `checker` reports TS2339 for it.
                         for (name, sym_id) in exports.iter() {
-                            if !result.has(name) {
+                            if name != "default" && !result.has(name) {
                                 result.set(name.to_string(), *sym_id);
                             }
                         }

--- a/crates/tsz-checker/src/symbols/symbol_resolver_qualified.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver_qualified.rs
@@ -1784,7 +1784,16 @@ impl<'a> CheckerState<'a> {
         // TSC behavior: If two `export *` declarations export the same name,
         // that name is considered AMBIGUOUS and is NOT exported
         // (unless explicitly re-exported by name, which is checked above).
-        if let Some(source_modules) = self.ctx.binder.wildcard_reexports.get(module_specifier) {
+        //
+        // `export *` never forwards `default` (ECMAScript's
+        // `ExportStarAsNamedExports` drops the local name `default` from what a
+        // wildcard export re-exports; `tsc`'s `visitExportedUnnamedExportBindings`
+        // is only called when `specifier.name.escapedText !== InternalSymbolName.Default`).
+        // Only a *named* re-export (`export { default } from 'bar'`, the branch
+        // above) forwards a default across a barrel.
+        if member_name != "default"
+            && let Some(source_modules) = self.ctx.binder.wildcard_reexports.get(module_specifier)
+        {
             let mut found_result: Option<SymbolId> = None;
             let mut found_count = 0;
 

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -291,6 +291,8 @@ mod explicit_type_arg_overload_pruning_tests;
 mod export_assignment_default_namespace_parse_error_gate_tests;
 #[path = "tests/export_declaration_module_element_context_tests.rs"]
 mod export_declaration_module_element_context_tests;
+#[path = "tests/export_star_default_exclusion_tests.rs"]
+mod export_star_default_exclusion_tests;
 #[path = "tests/flow_assignment_relation_routing_arch_tests.rs"]
 mod flow_assignment_relation_routing_arch_tests;
 #[path = "tests/flow_cache_policy_arch_tests.rs"]

--- a/crates/tsz-checker/src/tests/export_star_default_exclusion_tests.rs
+++ b/crates/tsz-checker/src/tests/export_star_default_exclusion_tests.rs
@@ -1,0 +1,221 @@
+//! `export * from "./m"` never forwards `m`'s `default` export.
+//!
+//! Structural rule: ECMAScript's `ExportStarAsNamedExports` resolution
+//! explicitly drops the local name `default` from the set of names a wildcard
+//! export re-exports (only `export { default } from "./m"` or
+//! `export { x as default } from "./m"` forward a default, and both are
+//! *named* re-exports tracked separately from the wildcard chain). `tsc`
+//! matches this in `visitExportedUnnamedExportBindings`, which is called only
+//! when `specifier.name.escapedText !== InternalSymbolName.Default`.
+//!
+//! Before this fix, `resolve_export_in_file_uncached`'s wildcard-reexport
+//! branch and `collect_reexported_symbols`'s namespace-member collector both
+//! walked every name in a wildcard source's export table, `default` included,
+//! so a barrel's default import silently resolved to whichever re-exported
+//! module happened to declare one — the exact opposite of `tsc`, which
+//! reports `TS1192`/`TS2305`/`TS2339` depending on the import form.
+
+use crate::context::CheckerOptions;
+use crate::diagnostics::diagnostic_codes;
+use crate::test_utils::check_multi_file;
+use tsz_common::common::ModuleKind;
+
+fn check(files: &[(&str, &str)], entry: &str) -> Vec<crate::diagnostics::Diagnostic> {
+    check_multi_file(
+        files,
+        entry,
+        CheckerOptions {
+            module: ModuleKind::ESNext,
+            strict: true,
+            no_implicit_any: true,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+fn codes(diags: &[crate::diagnostics::Diagnostic]) -> Vec<u32> {
+    diags.iter().map(|d| d.code).collect()
+}
+
+/// `import d from "./barrel"` where `barrel.ts` is `export * from "./impl"`
+/// and only `impl.ts` has a default: `tsc` reports `TS1192`, the barrel
+/// itself never gains a default just by wildcard-re-exporting one.
+#[test]
+fn default_import_through_wildcard_barrel_reports_ts1192() {
+    let diags = check(
+        &[
+            (
+                "./impl.ts",
+                r#"export default 42;
+export const named = 1;
+"#,
+            ),
+            ("./barrel.ts", r#"export * from "./impl";"#),
+            (
+                "./consumer.ts",
+                r#"import d from "./barrel";
+const y = d;
+"#,
+            ),
+        ],
+        "./consumer.ts",
+    );
+    assert!(
+        codes(&diags).contains(&diagnostic_codes::MODULE_HAS_NO_DEFAULT_EXPORT),
+        "expected TS1192, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>(),
+    );
+}
+
+/// `import * as ns from "./barrel"; ns.default` — the wildcard source's
+/// default must not leak onto the barrel's namespace object either.
+#[test]
+fn namespace_import_through_wildcard_barrel_has_no_default_member() {
+    let diags = check(
+        &[
+            (
+                "./impl.ts",
+                r#"export default 42;
+export const named = 1;
+"#,
+            ),
+            ("./barrel.ts", r#"export * from "./impl";"#),
+            (
+                "./consumer.ts",
+                r#"import * as ns from "./barrel";
+const y = ns.default;
+"#,
+            ),
+        ],
+        "./consumer.ts",
+    );
+    assert!(
+        codes(&diags).contains(&diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE),
+        "expected TS2339 for ns.default, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>(),
+    );
+}
+
+/// Positive control: a barrel that names its wildcard source's default
+/// explicitly (`export { default } from "./impl"`) still forwards it —
+/// only the *wildcard* path drops `default`, not an explicit named re-export.
+#[test]
+fn named_reexport_of_default_still_forwards_through_barrel() {
+    let diags = check(
+        &[
+            ("./impl.ts", r#"export default 42;"#),
+            (
+                "./barrel.ts",
+                r#"export * from "./impl";
+export { default } from "./impl";
+"#,
+            ),
+            (
+                "./consumer.ts",
+                r#"import d from "./barrel";
+const y: string = d;
+"#,
+            ),
+        ],
+        "./consumer.ts",
+    );
+    // `d` resolves to `number` (impl's real default), so assigning it to a
+    // `string`-typed binding is the one and only error — not TS1192.
+    assert!(
+        !codes(&diags).contains(&diagnostic_codes::MODULE_HAS_NO_DEFAULT_EXPORT),
+        "an explicit `export {{ default }}` must still forward the default: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>(),
+    );
+    assert!(
+        codes(&diags).contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "expected the number-to-string mismatch once d resolves, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>(),
+    );
+}
+
+/// Positive control: a barrel that declares its own `export default` keeps
+/// it — the fix must only suppress a *wildcard-forwarded* default, not a
+/// default declared directly in the consuming file.
+#[test]
+fn own_default_export_is_unaffected_by_wildcard_exclusion() {
+    let diags = check(
+        &[
+            ("./impl.ts", r#"export const named = 1;"#),
+            (
+                "./barrel.ts",
+                r#"export * from "./impl";
+export default "own default";
+"#,
+            ),
+            (
+                "./consumer.ts",
+                r#"import d from "./barrel";
+const y: number = d;
+"#,
+            ),
+        ],
+        "./consumer.ts",
+    );
+    assert!(
+        !codes(&diags).contains(&diagnostic_codes::MODULE_HAS_NO_DEFAULT_EXPORT),
+        "barrel's own default export must still resolve: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>(),
+    );
+    assert!(
+        codes(&diags).contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "d should resolve to the barrel's own string default, mismatching `number`: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>(),
+    );
+}
+
+/// Renamed bindings and a chained (two-hop) wildcard barrel: the exclusion
+/// must survive an extra `export *` hop and does not depend on any
+/// particular identifier spelling.
+#[test]
+fn default_exclusion_survives_a_chained_wildcard_barrel() {
+    let diags = check(
+        &[
+            (
+                "./core.ts",
+                r#"export default { version: 7 };
+export const flavor = "vanilla";
+"#,
+            ),
+            ("./mid.ts", r#"export * from "./core";"#),
+            ("./outer.ts", r#"export * from "./mid";"#),
+            (
+                "./consumer.ts",
+                r#"import wrapped from "./outer";
+const y = wrapped;
+"#,
+            ),
+        ],
+        "./consumer.ts",
+    );
+    assert!(
+        codes(&diags).contains(&diagnostic_codes::MODULE_HAS_NO_DEFAULT_EXPORT),
+        "expected TS1192 through a two-hop wildcard chain, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>(),
+    );
+}


### PR DESCRIPTION
When a barrel does `export * from "./impl"` and `impl.ts` has `export default`, tsc does X (the local name `default` is excluded from an `export *` wildcard's forwarded names, per ECMAScript's `ExportStarAsNamedExports` semantics — only an explicit named re-export like `export { default } from "./impl"` forwards one) through the checker/binder's alias-resolution layer; tsz did X through four independent wildcard-reexport walkers that all included `default` unconditionally, so a consuming `import d from "./barrel"` silently resolved `d` to the wildcard source's default instead of reporting `TS1192`.

Four call sites carried the same bug, none derived from a shared helper:

- `tsz-binder::BinderState::resolve_import_with_reexports_inner_type_only` (`crates/tsz-binder/src/state/resolution.rs`) — the authoritative value/type-only resolver every import alias's target routes through.
- `CheckerState::resolve_export_in_file_uncached` (`crates/tsz-checker/.../module/reexports.rs`) — drives the TS1192 no-default-export diagnostic itself.
- `CheckerState::collect_reexported_symbols` (same file) — builds a namespace-import's (`import * as ns`) member table.
- `CheckerState::resolve_reexported_member_symbol_inner` (`crates/tsz-checker/src/symbols/symbol_resolver_qualified.rs`) — the last-resort alias-type resolver reached once the other three correctly decline, which is why the diagnostic could already fire correctly while `d`'s *type* still silently resolved to the wrong export (found by testing after the first two fixes and still seeing a spurious downstream `TS2322`).

All four now skip their wildcard branch when the requested name is `default`, matching tsc's `visitExportedUnnamedExportBindings` (called only when `specifier.name.escapedText !== InternalSymbolName.Default`).

Adjacent-case matrix, oracle-verified against pinned `typescript@7.0.2` (all six rows byte-exact before/after, via a real `tsc` + `tsz` binary run on hand-written fixtures):

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `import d from "./barrel"` (wildcard-only) | TS1192 | silently resolved to wrong type | TS1192 ✅ |
| `import * as ns from "./barrel"; ns.default` | TS2339 | silently resolved to wrong type | TS2339 ✅ |
| `import { default as d } from "./barrel"` | TS2305 | silently resolved to wrong type | TS2305 ✅ |
| `export * from "./impl"; export { default } from "./impl"` (named re-export alongside the wildcard) | forwards default | forwards default | forwards default (unchanged) |
| barrel's own `export default` alongside `export * from` | barrel's own default | barrel's own default | barrel's own default (unchanged) |
| two-hop wildcard chain (`outer -> mid -> impl`) | TS1192 | silently resolved to wrong type | TS1192 ✅ |

New regression tests: `crates/tsz-checker/src/tests/export_star_default_exclusion_tests.rs` (5 tests — the wildcard-default negative, the namespace-member negative, and three positive controls proving named re-export / own-default / a two-hop chain are unaffected).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib export_star_default_exclusion` — 5/5 new tests pass.
- `cargo test -p tsz-checker --lib -- reexport wildcard export_star module_export` — 103 passed, 0 failed, 1 pre-existing unrelated ignore.
- `cargo test -p tsz-binder --lib` — 446/446 passed.
- `cargo clippy -p tsz-checker -p tsz-binder --all-targets -- -D warnings` — clean.
- `cargo fmt -p tsz-checker -p tsz-binder -- --check` — clean.
- `python3 scripts/arch/arch_guard.py` — passed.
- Manual 6-row oracle matrix (table above) via a real `tsc@7.0.2` + `tsz` binary run — byte-exact match after the fix.
- `cargo test -p tsz-checker --lib` (full, untargeted) was still running at PR-open time on this cloud seat (known long-tail stragglers per the coordination board); will report if it surfaces anything beyond the targeted suites above.
- `compare-to-parent.sh` / broader conformance sweep: owed, not run this session — this is a semantic-resolution change (checker + binder), not a display-only fix, so a full run is warranted; flagging for a drain-slot follow-up rather than guessing at the impact.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: Jadeite


---
_Generated by [Claude Code](https://claude.ai/code/session_01QJ6b6tZkYzNEGR76syCCjC)_