### PR TITLE
fix(parser): modifier-before-`export as namespace` node anchors at the modifier, not `export`

### DIFF
--- a/crates/tsz-checker/tests/global_module_export_grammar_tests.rs
+++ b/crates/tsz-checker/tests/global_module_export_grammar_tests.rs
@@ -19,7 +19,8 @@
 //! oracle run as
 //! `tsc --noEmit --strict --target es2022 --module esnext --lib esnext`.
 
-use tsz_checker::test_utils::check_source_codes_named;
+use tsz_checker::CheckerOptions;
+use tsz_checker::test_utils::{check_source, check_source_codes_named};
 
 /// Only this family's codes. The surrounding fixtures deliberately carry
 /// unrelated diagnostics in a few rows (an unresolved import specifier, for
@@ -271,5 +272,59 @@ fn a_namespace_export_inside_a_namespace_is_not_confused_with_a_global_module_ex
             "a.ts"
         ),
         Vec::<u32>::new(),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #16403 residual: TS1314's own COLUMN when a stray modifier precedes
+// `export as namespace`. This is a checker diagnostic, so it reads whatever
+// span the parser gave the `NamespaceExportDeclaration` node — tsc anchors it
+// at the modifier (column 1), not at `export`, matching TS1184 alongside it.
+// A code-set comparison cannot see this: TS1314 fires either way, only the
+// column differs. Oracle-pinned (`typescript@7.0.2`) for every modifier in
+// this family; `accessor`/`async` already anchored correctly before this fix.
+// ---------------------------------------------------------------------------
+
+fn ts1314_start(source: &str, file_name: &str) -> u32 {
+    let diags = check_source(source, file_name, CheckerOptions::default());
+    diags
+        .iter()
+        .find(|d| d.code == 1314)
+        .unwrap_or_else(|| panic!("expected TS1314 for {source:?}, got {diags:?}"))
+        .start
+}
+
+#[test]
+fn modifier_before_global_module_export_anchors_ts1314_at_the_modifier() {
+    for modifier in ["static", "public", "protected", "private", "readonly"] {
+        let source = format!("{modifier} export as namespace Foo;\n");
+        assert_eq!(
+            ts1314_start(&source, "a.ts"),
+            0,
+            "tsc anchors TS1314 at the modifier (column 1), not at `export`, for {source:?}"
+        );
+    }
+}
+
+#[test]
+fn modifier_before_global_module_export_ts1314_column_is_unaffected_by_leading_content() {
+    // Same rule, with the declaration not at the very start of the file, so a
+    // fix that merely special-cased offset 0 would not be caught by the test
+    // above.
+    let source = "export {};\nprivate export as namespace Foo;\n";
+    let diags = check_source(source, "a.ts", CheckerOptions::default());
+    // `export {};\n` makes the file an external module, so TS1314 (step 2:
+    // "not an external module") no longer applies — this reaches TS1315
+    // instead (step 3: module file, not a declaration file). Confirms the
+    // node span fix generalizes to a differently-positioned declaration by
+    // checking the sibling code in the same family anchors correctly too.
+    let ts1315 = diags
+        .iter()
+        .find(|d| d.code == 1315)
+        .unwrap_or_else(|| panic!("expected TS1315 for {source:?}, got {diags:?}"));
+    assert_eq!(
+        ts1315.start,
+        "export {};\n".len() as u32,
+        "TS1315 must anchor at `private`, not `export`, for {source:?}"
     );
 }

--- a/crates/tsz-parser/src/parser/state_statements_keywords.rs
+++ b/crates/tsz-parser/src/parser/state_statements_keywords.rs
@@ -633,12 +633,26 @@ impl ParserState {
                     // TS1184 in a Block, in a namespace body, and at the
                     // source file's own top level alike — where a modified
                     // *declaration* would keep TS1044 in the latter two.
+                    //
+                    // The checker's own TS1314 (global-module-exports
+                    // placement) reads the `NamespaceExportDeclaration` node's
+                    // span, and tsc anchors that span at the first modifier,
+                    // not at `export` (#16403 residual, oracle-confirmed for
+                    // `static`/`public`/`protected`/`private`/`readonly`
+                    // — the sibling `accessor`/`async` dispatch already
+                    // threads `start_pos` through `parse_export_declaration_from`
+                    // for this same reason). Capture the modifier's position
+                    // before consuming it and hand the node construction to
+                    // that shared helper instead of dropping straight to a
+                    // fresh `parse_statement()`, which would re-anchor the
+                    // node at `export`.
+                    let start_pos = self.token_pos();
                     self.parse_error_at_current_token(
                         "Modifiers cannot appear here.",
                         diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE,
                     );
                     self.next_token();
-                    self.parse_statement()
+                    self.parse_export_declaration_from(start_pos)
                 }
                 _ => {
                     // Every other shape reaching this branch — a plain

--- a/crates/tsz-parser/tests/parser_modified_export_statement_tests.rs
+++ b/crates/tsz-parser/tests/parser_modified_export_statement_tests.rs
@@ -26,7 +26,8 @@
 //! code. Verified locally: with #16367's containment applied, these sources
 //! report the full tsc pair.
 
-use crate::parser::test_fixture::parse_source;
+use crate::parser::syntax_kind_ext;
+use crate::parser::test_fixture::{assert_span, parse_source};
 use tsz_common::diagnostics::diagnostic_codes;
 
 fn diagnostic_codes_at(source: &str, needle: &str) -> Vec<u32> {
@@ -1330,5 +1331,68 @@ fn accessor_before_type_only_export_splits_by_container() {
     );
     assert_no_parser_diagnostics(
         "function collect() {\n  accessor export type * from \"./source\";\n}",
+    );
+}
+
+// --------------------------------------------------------------------------
+// #16403 residual: the `NamespaceExportDeclaration` node built after a stray
+// `static`/`public`/`protected`/`private`/`readonly` modifier must span from
+// the MODIFIER, not from `export`. TS1184 (above) is unaffected — it anchors
+// on the modifier token directly, before this node is even built — but the
+// checker's own TS1314/TS1316 read this node's own `pos`/`end`
+// (`crates/tsz-checker/src/state/state_checking/source_file.rs`), so a node
+// that starts at `export` misreports their column even though the CODE is
+// already right (a code-set comparison cannot see this). The accessor/async
+// dispatch already threads the modifier's start position through
+// `parse_export_declaration_from`; this dispatch (`static`/`public`/
+// `protected`/`private`/`readonly`, `parse_statement_top_level_modifier`) used
+// to drop straight to a fresh `parse_statement()` after reporting TS1184,
+// which re-anchored the node at `export`. Oracle-pinned: tsc anchors both
+// TS1184 and TS1314 at column 1 (the modifier) for every row below.
+// --------------------------------------------------------------------------
+
+fn assert_namespace_export_span_starts_at_modifier(modifier: &str) {
+    let source = format!("{modifier} export as namespace Foo;");
+    assert_span(
+        &source,
+        syntax_kind_ext::NAMESPACE_EXPORT_DECLARATION,
+        &source,
+    );
+}
+
+#[test]
+fn static_before_export_as_namespace_span_starts_at_modifier() {
+    assert_namespace_export_span_starts_at_modifier("static");
+}
+
+#[test]
+fn public_before_export_as_namespace_span_starts_at_modifier() {
+    assert_namespace_export_span_starts_at_modifier("public");
+}
+
+#[test]
+fn protected_before_export_as_namespace_span_starts_at_modifier() {
+    assert_namespace_export_span_starts_at_modifier("protected");
+}
+
+#[test]
+fn private_before_export_as_namespace_span_starts_at_modifier() {
+    assert_namespace_export_span_starts_at_modifier("private");
+}
+
+#[test]
+fn readonly_before_export_as_namespace_span_starts_at_modifier() {
+    assert_namespace_export_span_starts_at_modifier("readonly");
+}
+
+/// Renamed-binder control: the exported name is arbitrary and must not affect
+/// where the node's span starts.
+#[test]
+fn static_before_export_as_namespace_span_starts_at_modifier_renamed_binder() {
+    let source = "static export as namespace qux$_0;";
+    assert_span(
+        source,
+        syntax_kind_ext::NAMESPACE_EXPORT_DECLARATION,
+        source,
     );
 }


### PR DESCRIPTION
When a stray `static`/`public`/`protected`/`private`/`readonly` modifier precedes `export as namespace Foo;`, tsc anchors both TS1184 ("Modifiers cannot appear here") and the checker's own TS1314/TS1316 at the **start of the modifier run**. tsz already anchored TS1184 correctly, but the `NamespaceExportDeclaration` node itself was built by a fresh `parse_statement()` call after the modifier was discarded — so the node started at `export` instead. A code-set comparison can't see this (TS1314 fires either way), but the checker's TS1314, which reads that node's own span (`crates/tsz-checker/src/state/state_checking/source_file.rs`), landed on the wrong column, predicted exactly by `len(modifier)+2` (the `export` keyword's own offset).

**Structural rule:** when a `NamespaceExportDeclaration` is reached after a stray statement-level modifier, `tsc` anchors the node (and everything downstream that reads its span) at the first modifier; tsz does this through `crates/tsz-parser/src/parser/state_statements_keywords.rs`'s `parse_statement_top_level_modifier`.

The sibling `accessor`/`async` dispatch already threads the modifier's start position through `parse_export_declaration_from` for exactly this reason (and the `declare` dispatch in `state_declarations.rs` does too). `parse_statement_top_level_modifier`'s `NamespaceExport` arm — the one owning `static`/`public`/`protected`/`private`/`readonly` — was the last dispatch that still dropped straight to a fresh `parse_statement()` after reporting TS1184, discarding the modifier's position. The fix captures the modifier's position before consuming it and hands node construction to the same shared `parse_export_declaration_from` helper the other dispatches already use.

This closes the last 5/110 rows of #16403's modifier × export-form cross-product (Serpentine's 2026-08-05 census): `{static, public, protected, private, readonly} export as namespace Foo;`.

## Goal
Goal: hold

## Verification
- New parser regression tests (`crates/tsz-parser/tests/parser_modified_export_statement_tests.rs`): the `NamespaceExportDeclaration` node's span starts at the modifier for all 5 affected modifiers, plus a renamed-binder control. `cargo test -p tsz-parser --lib parser_modified_export_statement_tests`: **119/119** (113 pre-existing + 6 new), 0 regressed.
- New checker regression tests (`crates/tsz-checker/tests/global_module_export_grammar_tests.rs`): TS1314's column pins at the modifier (not `export`) for all 5 modifiers, plus a non-zero-offset control that exercises the sibling TS1315 code in the same family. `cargo test -p tsz-checker --test global_module_export_grammar_tests`: **22/22** (20 pre-existing + 2 new), 0 regressed.
- Full `cargo test -p tsz-parser --lib`: **1966/1966**, 0 regressed.
- Filtered `cargo test -p tsz-checker --lib export_declaration` (24/24) and `... modifier` (142/142), 0 regressed.
- Manual byte-exact check against the pinned `typescript@7.0.2` oracle for all 5 target rows (`{static,public,protected,private,readonly} export as namespace Foo;`, `--target es2022 --module es2022`): tsz output now matches tsc exactly (`TS1184@1`, `TS1314@1`).
- Full 10-modifier × 11-export-form cross-product (110 rows) re-run against both tsz and the pinned oracle (code-set comparison): 108/110 match; the remaining 2 mismatches (`declare export default function`/`declare export default 1;`) are pre-existing, on a different dispatch path (`declare`, in `state_declarations.rs`) untouched by this change, and already tracked by #16403's own census as an open `declare`-family gap.
- `cargo clippy -p tsz-parser -p tsz-checker --lib --tests -- -D warnings`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.
- `cargo fmt -p tsz-parser -p tsz-checker -- --check`: clean.
- Conformance snapshot / `compare-to-parent.sh` not run this session (time budget). This is a narrow parser-position fix for a rare modifier+`export as namespace` shape; per the board's standing note, zero conformance movement is the expected signature for this class of fix (several sibling PRs in the same #16403 family recorded `compare-to-parent 0/0`). Flagging as owed if anyone wants the two-sided confirmation before landing.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hsu68KGYbT7K6N4YyR8Zo4)_