### PR TITLE
fix(checker): TS6502 anchors an anonymous owner's signature through the written path (#16316)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
@@ -639,6 +639,7 @@ impl<'a> CheckerState<'a> {
                                     &expected_type_owners,
                                     &prop_name,
                                     body_idx,
+                                    prop_name_idx,
                                 );
                                 elaborated = true;
                                 continue;
@@ -661,6 +662,7 @@ impl<'a> CheckerState<'a> {
                             &expected_type_owners,
                             &prop_name,
                             body_idx,
+                            prop_name_idx,
                         );
                     } else {
                         self.with_expected_type_from_property_pointer(

--- a/crates/tsz-checker/src/error_reporter/expected_type_from_return.rs
+++ b/crates/tsz-checker/src/error_reporter/expected_type_from_return.rs
@@ -34,13 +34,30 @@
 //! route, so the owner's *written* member list is the only per-occurrence
 //! source of an anchor here.
 //!
-//! Shapes that decline rather than guess, each pinned by a test:
+//! The owner-candidate route above needs a binder symbol, which an *anonymous*
+//! owner never has — a type literal mints none at all (tsz#16443), so a nested
+//! member (`interface Outer { inner: { cb: () => string } }`), an inline
+//! annotation (`const x: { cb: () => string } = ...`) and a type-alias-to-type-
+//! literal owner all declined. When every candidate declines, the same
+//! annotation walk `missing_property_declared_here_related` uses for `TS2728`
+//! and `expected_type_from_property_related` uses for `TS6500` recovers the
+//! anchor from the object-literal syntax at the failure site instead, and then
+//! narrows from the member to its signature exactly as the symbol route does.
 //!
-//! * a member annotated with a type *reference* (`cb: Fn`) — tsc anchors inside
-//!   the alias body, which needs the alias hop this walk does not take;
+//! That walk also owns the *alias hop* the symbol route cannot take: for
+//! `type Fn = () => string; interface Ref { cb: Fn }` tsc anchors inside `Fn`'s
+//! body, not at `Fn` and not at `cb`. Following an alias means reading a
+//! declaration's `NodeIndex`, which is only sound in the arena that minted it,
+//! so the hop lives here — where every step is already checking-file-local —
+//! rather than in the cross-arena symbol route.
+//!
+//! Shapes that still decline rather than guess, each pinned by a test:
+//!
 //! * a call argument (`take(() => 7)`) — the expected type comes from a
-//!   parameter, not from an owner's member list;
-//! * an anonymous owner, which resolves to no binder symbol at all (tsz#16443).
+//!   parameter, not from an owner's member list, so there is no annotation to
+//!   walk and no owner to resolve;
+//! * an annotation that does not declare the written path, which declines at
+//!   the hop that fails rather than anchoring one member too shallow.
 
 use crate::diagnostics::{Diagnostic, diagnostic_codes, diagnostic_messages, format_message};
 use crate::state::CheckerState;
@@ -55,12 +72,19 @@ impl<'a> CheckerState<'a> {
     /// at, and a diagnostic that already carries a location pointer got it from
     /// a deeper frame that tsc's `!issuedElaboration` guard would have let keep
     /// it, so it is left alone exactly as the `TS6500` attach does.
+    ///
+    /// `annotation_anchor_idx` is the failing member's *name* node, not
+    /// `body_idx`. The annotation fallback walks the object-literal ancestry
+    /// outward, and that walk stops at the first function boundary it meets —
+    /// starting it at the arrow's body would break on the arrow itself and see
+    /// no path at all.
     pub(crate) fn attach_expected_type_from_return_pointer(
         &mut self,
         since: usize,
         owner_candidates: &[TypeId],
         property_name: &str,
         body_idx: NodeIndex,
+        annotation_anchor_idx: NodeIndex,
     ) {
         if self.ctx.diagnostics.len() <= since {
             return;
@@ -69,8 +93,11 @@ impl<'a> CheckerState<'a> {
             return;
         };
         let (body_pos, body_end) = (body_node.pos, body_node.end);
-        let Some(related) = self.expected_type_from_return_related(owner_candidates, property_name)
-        else {
+        let Some(related) = self.expected_type_from_return_related(
+            owner_candidates,
+            property_name,
+            annotation_anchor_idx,
+        ) else {
             return;
         };
         for diagnostic in self.ctx.diagnostics.iter_mut().skip(since) {
@@ -93,25 +120,189 @@ impl<'a> CheckerState<'a> {
 
     /// Build the `TS6502` entry for `property_name` on the first of
     /// `owner_candidates` whose written declaration carries that member with a
-    /// signature to point at.
+    /// signature to point at, falling back to the annotation syntax at
+    /// `annotation_anchor_idx` for an owner that resolves to no binder symbol.
     fn expected_type_from_return_related(
         &mut self,
         owner_candidates: &[TypeId],
         property_name: &str,
+        annotation_anchor_idx: NodeIndex,
     ) -> Option<crate::diagnostics::DiagnosticRelatedInformation> {
-        owner_candidates.iter().find_map(|&owner| {
-            let (start, length, file) = self.member_signature_anchor_for_owner(owner, property_name)?;
-            Some(Diagnostic::related_pointer(
-                diagnostic_codes::THE_EXPECTED_TYPE_COMES_FROM_THE_RETURN_TYPE_OF_THIS_SIGNATURE,
-                file.unwrap_or_else(|| self.ctx.file_name.clone()),
+        let anchor = owner_candidates
+            .iter()
+            .find_map(|&owner| self.member_signature_anchor_for_owner(owner, property_name))
+            .or_else(|| {
+                self.return_signature_anchor_from_annotation(annotation_anchor_idx, property_name)
+            })?;
+        let (start, length, file) = anchor;
+        Some(Diagnostic::related_pointer(
+            diagnostic_codes::THE_EXPECTED_TYPE_COMES_FROM_THE_RETURN_TYPE_OF_THIS_SIGNATURE,
+            file.unwrap_or_else(|| self.ctx.file_name.clone()),
+            start,
+            length,
+            format_message(
+                diagnostic_messages::THE_EXPECTED_TYPE_COMES_FROM_THE_RETURN_TYPE_OF_THIS_SIGNATURE,
+                &[],
+            ),
+        ))
+    }
+
+    /// `(start, length, file)` recovered from the annotation the failing
+    /// assignment was written with, for an owner with no binder symbol.
+    ///
+    /// `contextual_property_path(anchor_idx)` walks the object-literal ancestry
+    /// from the failing member's *name* node outward, so the returned path ends
+    /// with `property_name` itself — this member's value is what failed. Walking
+    /// every hop but the last through the annotation's member types lands on the
+    /// type node that actually declares `property_name`, exactly as
+    /// `expected_type_from_property_anchor_from_annotation` does for `TS6500`;
+    /// only the last step differs, narrowing from the member to its signature.
+    ///
+    /// Requiring the path to end in `property_name` is what keeps the walk
+    /// honest: a path that describes a different member than the one that
+    /// failed means the ancestry and the reported property disagree, and the
+    /// pointer declines rather than anchoring on whichever member the annotation
+    /// happens to declare under that name.
+    fn return_signature_anchor_from_annotation(
+        &mut self,
+        anchor_idx: NodeIndex,
+        property_name: &str,
+    ) -> Option<(u32, u32, Option<String>)> {
+        let annotation_idx = self.target_annotation_node(anchor_idx)?;
+        let path = self.contextual_property_path(anchor_idx);
+        if path.last().map(String::as_str) != Some(property_name) {
+            return None;
+        }
+        let mut owner_idx = annotation_idx;
+        for key in &path[..path.len() - 1] {
+            owner_idx = self.annotation_member_type_node(owner_idx, key, 0)?;
+        }
+        self.annotation_signature_anchor(owner_idx, property_name, 0)
+    }
+
+    /// `(start, length, file)` of the signature declared for `property` inside
+    /// the type annotation node `idx`, following the annotation's own syntax.
+    ///
+    /// The `TS6502` counterpart of
+    /// [`Self::annotation_property_anchor`]: same node kinds, same alias
+    /// continuation, same depth bound — it differs only in what it anchors on
+    /// once the member is found, the member's *signature* rather than its name.
+    ///
+    /// Every step stays in the checking file's own arena. A type reference to a
+    /// symbol declared elsewhere declines here rather than reading a foreign
+    /// arena's `NodeIndex` against the current one; that case is the symbol
+    /// route's, which resolves its arena from the location.
+    fn annotation_signature_anchor(
+        &mut self,
+        idx: NodeIndex,
+        property: &str,
+        depth: u32,
+    ) -> Option<(u32, u32, Option<String>)> {
+        use tsz_parser::parser::syntax_kind_ext;
+
+        if depth > Self::ANNOTATION_WALK_MAX_DEPTH {
+            return None;
+        }
+        let node = self.ctx.arena.get(idx)?;
+        if node.kind == syntax_kind_ext::PARENTHESIZED_TYPE {
+            let inner = self.ctx.arena.get_wrapped_type(node)?.type_node;
+            return self.annotation_signature_anchor(inner, property, depth + 1);
+        }
+        if node.kind == syntax_kind_ext::TYPE_LITERAL {
+            return self.declared_member_signature_anchor(idx, property, depth);
+        }
+        if node.kind != syntax_kind_ext::TYPE_REFERENCE {
+            return None;
+        }
+        let name_idx = self.ctx.arena.get_type_ref(node)?.type_name;
+        let owner_symbol = self.type_position_symbol(name_idx)?;
+        if let Some(declaration_idx) = self.local_declaration_node(owner_symbol)
+            && let Some(anchor) =
+                self.declared_member_signature_anchor(declaration_idx, property, depth)
+        {
+            return Some(anchor);
+        }
+        // An alias chain (`type Ind = Zed`) declares no member list of its own,
+        // so the step above finds nothing to anchor in. Continue through the
+        // alias body, which is itself annotation syntax.
+        let body_idx = self.local_type_alias_body(owner_symbol)?;
+        self.annotation_signature_anchor(body_idx, property, depth + 1)
+    }
+
+    /// `(start, length, file)` of the signature `property` is declared with on
+    /// the declaration node `declaration_idx`, when that declaration owns a
+    /// written member list carrying it.
+    fn declared_member_signature_anchor(
+        &mut self,
+        declaration_idx: NodeIndex,
+        property: &str,
+        depth: u32,
+    ) -> Option<(u32, u32, Option<String>)> {
+        let members = Self::declaration_member_list(self.ctx.arena, declaration_idx)?;
+        let member_idx = Self::named_member_node(self.ctx.arena, &members, property)?;
+        self.member_signature_anchor(member_idx, depth)
+    }
+
+    /// `(start, length, file)` of the signature `member_idx` declares.
+    ///
+    /// [`Self::return_type_anchor_for_member`] answers this for a member whose
+    /// signature is written directly on it. It declines for one wrapped in
+    /// parentheses (`cb: (() => string)`), which tsc still underlines *inside*
+    /// the parentheses, so the annotation is peeled here before giving up.
+    fn member_signature_anchor(
+        &mut self,
+        member_idx: NodeIndex,
+        depth: u32,
+    ) -> Option<(u32, u32, Option<String>)> {
+        use tsz_parser::parser::syntax_kind_ext;
+
+        if let Some(anchor_idx) = Self::return_type_anchor_for_member(self.ctx.arena, member_idx) {
+            let (start, length) = Self::anchor_span(self.ctx.arena, anchor_idx)?;
+            return Some((
                 start,
                 length,
-                format_message(
-                    diagnostic_messages::THE_EXPECTED_TYPE_COMES_FROM_THE_RETURN_TYPE_OF_THIS_SIGNATURE,
-                    &[],
-                ),
-            ))
-        })
+                Self::arena_file_name(self.ctx.arena, anchor_idx),
+            ));
+        }
+        let node = self.ctx.arena.get(member_idx)?;
+        if node.kind != syntax_kind_ext::PROPERTY_SIGNATURE {
+            return None;
+        }
+        let annotation_idx = self.ctx.arena.get_signature(node)?.type_annotation;
+        self.callable_type_node_anchor(annotation_idx, depth)
+    }
+
+    /// `(start, length, file)` of the function or constructor type `idx`
+    /// denotes, peeling parentheses.
+    ///
+    /// Anything else — a union, an object type, a type reference — yields no
+    /// signature of its own for tsc to point at, so it declines. A reference is
+    /// deliberately *not* followed here: the arrow-body drill this pointer hangs
+    /// off never fires for an alias-annotated member in the first place (see the
+    /// `type_reference_annotation_*` test), so a hop at this site would be
+    /// unreachable complexity on a diagnostic path.
+    fn callable_type_node_anchor(
+        &mut self,
+        idx: NodeIndex,
+        depth: u32,
+    ) -> Option<(u32, u32, Option<String>)> {
+        use tsz_parser::parser::syntax_kind_ext;
+
+        if depth > Self::ANNOTATION_WALK_MAX_DEPTH {
+            return None;
+        }
+        let node = self.ctx.arena.get(idx)?;
+        if node.kind == syntax_kind_ext::PARENTHESIZED_TYPE {
+            let inner = self.ctx.arena.get_wrapped_type(node)?.type_node;
+            return self.callable_type_node_anchor(inner, depth + 1);
+        }
+        if node.kind != syntax_kind_ext::FUNCTION_TYPE
+            && node.kind != syntax_kind_ext::CONSTRUCTOR_TYPE
+        {
+            return None;
+        }
+        let (start, length) = Self::anchor_span(self.ctx.arena, idx)?;
+        Some((start, length, Self::arena_file_name(self.ctx.arena, idx)))
     }
 
     /// `(start, length, file)` of the signature declaration for `property` on

--- a/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
+++ b/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
@@ -303,7 +303,10 @@ impl<'a> CheckerState<'a> {
     /// out indices from `0`, so a raw index from elsewhere names an unrelated
     /// node. The cross-file case is served by the symbol route, which resolves
     /// its own arena from the location.
-    fn local_declaration_node(&self, owner_symbol: tsz_binder::SymbolId) -> Option<NodeIndex> {
+    pub(super) fn local_declaration_node(
+        &self,
+        owner_symbol: tsz_binder::SymbolId,
+    ) -> Option<NodeIndex> {
         let symbol = self.ctx.binder.get_symbol(owner_symbol)?;
         let location = std::iter::once(symbol.stable_value_declaration)
             .chain(symbol.stable_declarations.iter().copied())
@@ -314,7 +317,10 @@ impl<'a> CheckerState<'a> {
 
     /// The body type node of a type alias declared in the file being checked,
     /// used to continue the annotation walk through an alias chain.
-    fn local_type_alias_body(&self, owner_symbol: tsz_binder::SymbolId) -> Option<NodeIndex> {
+    pub(super) fn local_type_alias_body(
+        &self,
+        owner_symbol: tsz_binder::SymbolId,
+    ) -> Option<NodeIndex> {
         use tsz_parser::parser::syntax_kind_ext;
 
         let decl_idx = self.local_declaration_node(owner_symbol)?;
@@ -341,7 +347,7 @@ impl<'a> CheckerState<'a> {
 
     /// The symbol a type-position name node denotes, ignoring value-only
     /// resolutions (an `import =` alias used as a bare type, for instance).
-    fn type_position_symbol(&self, name_idx: NodeIndex) -> Option<tsz_binder::SymbolId> {
+    pub(super) fn type_position_symbol(&self, name_idx: NodeIndex) -> Option<tsz_binder::SymbolId> {
         match self.resolve_identifier_symbol_in_type_position_without_tracking(name_idx) {
             crate::symbol_resolver::TypeSymbolResolution::Type(symbol_id) => Some(symbol_id),
             _ => None,
@@ -350,7 +356,7 @@ impl<'a> CheckerState<'a> {
 
     /// Bound on the annotation walk, which follows user-written type syntax and
     /// must terminate on a pathological nesting rather than recurse forever.
-    const ANNOTATION_WALK_MAX_DEPTH: u32 = 8;
+    pub(super) const ANNOTATION_WALK_MAX_DEPTH: u32 = 8;
 
     /// Resolve `owner` to its declaring symbol, find the member declaration
     /// with this name inside that symbol's own declaration, and anchor there.

--- a/crates/tsz-checker/src/tests/expected_type_from_return_tests.rs
+++ b/crates/tsz-checker/src/tests/expected_type_from_return_tests.rs
@@ -214,19 +214,156 @@ fn block_bodied_function_expression_keeps_the_property_pointer() {
     );
 }
 
-/// A member annotated with a type *reference* declines. tsc anchors inside the
-/// alias body (`type Fn = () => string` → the `() => string` there), which
-/// needs an alias hop this walk deliberately does not take; declining leaves
-/// output exactly as it was rather than anchoring at `Fn` or at `cb`. Pinned so
-/// the day the hop lands, this row's move is visible.
+/// A member annotated with a type *reference* still declines, and the reason is
+/// **not** in the pointer walk — recorded here because the obvious fix (hop the
+/// alias when anchoring) is a dead end that would add unreachable code.
+///
+/// tsc anchors inside the alias body:
+///
+/// ```text
+/// d.ts:3:29 - error TS2322: Type 'number' is not assignable to type 'string'.
+///   d.ts:1:11 - The expected type comes from the return type of this signature.
+///     1 type Fn = () => string;
+///                 ~~~~~~~~~~~~
+/// ```
+///
+/// `Ref` resolves to a real binder symbol, so the symbol route reaches `cb`
+/// fine. The gap is a whole frame earlier: the arrow-body drill in
+/// `elaboration_object_properties` never fires for an alias-annotated member,
+/// so no `TS6502` attach site is reached at all. The witness is the pointer this
+/// diagnostic *does* carry — `TS6500`, which is only attached on the
+/// **undrilled** branch. Whatever makes that branch win for a member typed
+/// through an alias owns this row.
 #[test]
-fn type_reference_annotation_declines_rather_than_anchoring_at_the_reference() {
+fn type_reference_annotation_declines_because_the_arrow_body_is_never_drilled() {
     let source =
         "type Fn = () => string;\ninterface Ref { cb: Fn; }\nconst rf: Ref = { cb: () => 6 };\n";
     let diagnostic = only(&check_source_diagnostics(source), TS2322);
     assert!(
         !has_return_pointer(&diagnostic),
-        "an alias-annotated member must decline: {diagnostic:?}"
+        "an alias-annotated member is never drilled, so no TS6502 site is reached: {diagnostic:?}"
+    );
+    assert!(
+        diagnostic
+            .related_information
+            .iter()
+            .any(|info| info.code == TS6500),
+        "the TS6500 pointer is the witness that the undrilled branch ran: {diagnostic:?}"
+    );
+}
+
+/// An alias chain in the *owner* position is followed — a different shape from
+/// the row above, where the alias sits on the member. `Ind`'s own declaration
+/// carries no member list, so the walk must continue through its body to reach
+/// the literal that declares `cb`. Oracled: `k.ts:1:18`, inside `Zed`.
+#[test]
+fn an_alias_chain_in_the_owner_position_is_followed_to_the_declaring_literal() {
+    let source =
+        "type Zed = { cb: () => string };\ntype Ind = Zed;\nconst q: Ind = { cb: () => 6 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    let (start, length, _) = return_pointer(&diagnostic);
+    assert_eq!(span_text(source, start, length), "() => string");
+    assert_eq!(start, 17, "the anchor is Zed's member, not Ind's body");
+}
+
+/// A type alias whose body is a type literal owns no interface declaration for
+/// the symbol route to walk, so this is the anonymous-owner shape reached
+/// through the annotation instead. Oracled: `a.ts:1:18`.
+#[test]
+fn a_type_alias_to_a_type_literal_anchors_at_its_member_signature() {
+    let source = "type Lit = { cb: () => string };\nconst rt: Lit = { cb: () => 6 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    let (start, length, _) = return_pointer(&diagnostic);
+    assert_eq!(span_text(source, start, length), "() => string");
+    assert_eq!(start, 17);
+}
+
+/// The method-signature shape of the row above: no separate annotation node, so
+/// the whole member is underlined, trailing `;` included. Oracled: `e.ts:1:15`,
+/// 12 columns.
+#[test]
+fn a_method_signature_inside_a_type_alias_is_underlined_whole() {
+    let source = "type Lit2 = { m(): string; };\nconst rt2: Lit2 = { m: () => 6 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    let (start, length, _) = return_pointer(&diagnostic);
+    assert_eq!(span_text(source, start, length), "m(): string;");
+}
+
+/// Renamed binders: the same annotation shape under different user names keeps
+/// the same anchor rule and only moves the span, so no identifier text can be
+/// driving the decision. Oracled: `f.ts:1:20`.
+#[test]
+fn renamed_binders_keep_the_anchor_rule_and_only_move_the_span() {
+    let source = "type Zeta = { qux: () => string };\nconst zz: Zeta = { qux: () => 6 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    let (start, length, _) = return_pointer(&diagnostic);
+    assert_eq!(span_text(source, start, length), "() => string");
+    assert_eq!(start, 19);
+}
+
+/// A *nested* member's owner is an inner type literal, which mints no binder
+/// symbol at all (tsz#16443) — the shape every owner candidate declines on.
+/// Oracled: `b.ts:1:32`, inside the inner literal.
+#[test]
+fn a_nested_type_literal_owner_anchors_through_the_written_path() {
+    let source = "interface Outer { inner: { cb: () => string }; }\nconst o: Outer = { inner: { cb: () => 6 } };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    let (start, length, _) = return_pointer(&diagnostic);
+    assert_eq!(span_text(source, start, length), "() => string");
+    assert_eq!(start, 31);
+}
+
+/// Two hops rather than one, so the walk is following the written path and not
+/// merely unwrapping a single level. Oracled: `g.ts:1:41`.
+#[test]
+fn a_twice_nested_owner_walks_every_hop_of_the_written_path() {
+    let source = "interface Outer2 { inner: { deep: { cb: () => string } }; }\nconst o2: Outer2 = { inner: { deep: { cb: () => 6 } } };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    let (start, length, _) = return_pointer(&diagnostic);
+    assert_eq!(span_text(source, start, length), "() => string");
+    assert_eq!(start, 40);
+}
+
+/// An inline annotation names no type at all, so the annotation node *is* the
+/// owner and the path needs no hop. Oracled: `c.ts:1:17`.
+#[test]
+fn an_inline_type_literal_annotation_anchors_at_its_own_member() {
+    let source = "const rt: { cb: () => string } = { cb: () => 6 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    let (start, length, _) = return_pointer(&diagnostic);
+    assert_eq!(span_text(source, start, length), "() => string");
+    assert_eq!(start, 16);
+}
+
+/// Parentheses are peeled: tsc underlines the function type itself, not the
+/// parenthesized wrapper. Oracled: `j.ts:1:19`, 12 columns — the `(` at column
+/// 18 is outside the underline.
+#[test]
+fn a_parenthesized_function_type_annotation_anchors_inside_the_parentheses() {
+    let source = "type Par = { cb: (() => string) };\nconst pp: Par = { cb: () => 6 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    let (start, length, _) = return_pointer(&diagnostic);
+    assert_eq!(span_text(source, start, length), "() => string");
+}
+
+/// The negative control for the paren peel: a member whose annotation merely
+/// *contains* a signature must never borrow one. `callable_type_node_anchor`
+/// peels the parentheses, finds a union, and declines because a union declares
+/// no signature of its own.
+///
+/// tsz drills this body where tsc does not — tsc reports the whole function
+/// type at the member with a `TS6500` pointer, tsz reports at the `6` — a
+/// pre-existing primary divergence this diff neither causes nor moves. Asserted
+/// only as "no `TS6502`", so the row pins the walk's own decision and stays
+/// honest about the frame disagreement above it.
+#[test]
+fn a_union_annotation_takes_no_return_pointer() {
+    let source =
+        "type Uni = { cb: (() => string) | undefined };\nconst uu: Uni = { cb: () => 6 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    assert!(
+        !has_return_pointer(&diagnostic),
+        "a union annotation declares no signature to point at: {diagnostic:?}"
     );
 }
 


### PR DESCRIPTION
## Goal

Goal: hold

Closes the handoff Ignimbrite left on #16535 an hour ago: *"Remaining known gap in this pointer family: `TS6502` (the arrow-body-return sibling, #16458) still explicitly declines for an anonymous owner — the same fallback shape would apply there too, untried."*

### Structural rule

**When** a drilled arrow-body member's owner resolves to no binder symbol — an anonymous type literal mints none at all (#16443) — `tsc` still anchors `TS6502` at the signature the expected return type was written with; tsz does this through the checker's `error_reporter`, recovering the anchor from the annotation syntax at the failure site instead of from the owner's symbol.

`member_signature_anchor_for_owner` needs a binder symbol. Three shapes never have one, and all three declined although `tsc` points at each:

```
interface Outer { inner: { cb: () => string }; }   // nested type literal
const rt: { cb: () => string } = ...               // inline annotation
type Lit = { cb: () => string };                   // alias to a type literal
```

The fix reuses the walk #16521 built for `TS2728` and #16535 widened to `pub(super)` for `TS6500` — `target_annotation_node` / `contextual_property_path` / `annotation_member_type_node` — and differs only in the last step, narrowing from the member to its **signature** rather than its name. `annotation_signature_anchor` is the `TS6502` counterpart of `annotation_property_anchor`: same node kinds, same alias continuation, same depth bound.

Two details worth calling out:

- **The attach site now takes the member's *name* node, not the arrow body.** `contextual_property_path` stops at the first function boundary, so starting it at `body_idx` breaks on the arrow itself and sees no path at all. `prop_name_idx` is the node that walks.
- **The alias hop lives in the annotation walk, not the symbol route.** Following an alias means reading a declaration's `NodeIndex`, which is only sound in the arena that minted it; every step of the annotation walk is checking-file-local by construction.

### Adjacent-case matrix

Every span below is `typescript@7.0.2`'s own underline, taken from an oracle run and asserted through `span_text`, not read off tsz's output.

| row | shape | before | after |
| --- | --- | --- | --- |
| alias to type literal | `type Lit = { cb: () =&gt; string }` | declined | `() =&gt; string` @ 1:18 |
| method signature in an alias | `type Lit2 = { m(): string; }` | declined | `m(): string;` @ 1:15 (whole member) |
| nested type literal | `interface Outer { inner: { cb: () =&gt; string } }` | declined | `() =&gt; string` @ 1:32 |
| twice-nested | `{ inner: { deep: { cb ... } } }` | declined | `() =&gt; string` @ 1:41 |
| inline annotation | `const rt: { cb: () =&gt; string } = ...` | declined | `() =&gt; string` @ 1:17 |
| alias chain in **owner** position | `type Ind = Zed` | declined | `() =&gt; string` in `Zed` @ 1:18 |
| renamed binders | `type Zeta = { qux: ... }` | declined | same rule, span moves |
| parenthesized annotation | `cb: (() =&gt; string)` | declined | `() =&gt; string` **inside** the parens @ 1:19 |
| union annotation | `cb: (() =&gt; string) \| undefined` | declines | **declines** (negative control) |
| type-*reference* annotation | `cb: Fn` | declines | **declines**, now with the reason recorded |
| call argument | `take(() =&gt; 7)` | declines | declines |
| matching return type | `cb: () =&gt; "s"` | no diagnostic | no diagnostic |

### Two rows deliberately left declining, with evidence

**`cb: Fn` is blocked a whole frame upstream, and the obvious fix is a dead end.** #16458 pinned this row negatively saying it "needs an alias hop this walk does not take". That premise is wrong. `Ref` resolves to a real binder symbol, so the symbol route reaches `cb` fine — but no `TS6502` attach site is reached *at all*, because the arrow-body drill in `elaboration_object_properties` never fires for an alias-annotated member. The witness is the pointer the diagnostic does carry: `TS6500`, which is only attached on the **undrilled** branch. I wrote the alias hop, measured it unreachable, and removed it rather than landing unverified complexity on a diagnostic path (the same call #16415 recorded). The test now pins the row with that diagnosis instead of the wrong one.

**The union row's primary diverges from tsc, and this diff does not move it.** tsc reports the whole function type at the member with a `TS6500` pointer; tsz drills to the body. Pre-existing, unrelated to the anchor decision. The test asserts only "no `TS6502`" so it pins this walk's own decision honestly rather than encoding a frame disagreement it does not own.

### Non-vacuity

The fallback is entirely new code reached only when every owner candidate declines; before this diff `expected_type_from_return_related` had no branch after the `find_map`. Measured directly by reverting the three `src` files at this branch's parent `c54c7da` and re-running the suite with the tests kept: **8 of the 18 rows fail**, exactly the eight new positive rows in the table above.

## Verification

Run on this seat (cloud, 4 cores), parent `c54c7da`:

- `cargo test -p tsz-checker --lib expected_type_from_return` → **18 passed / 0 failed** (10 pre-existing + 8 new positive rows; 2 pre-existing negatives rewritten with their real cause)
- adjacent families, one filtered run: `expected_type_from_property declared_here elaboration object_literal missing_property contextual callback` → **1022 passed / 0 failed**
- `cargo fmt --all` — clean
- `cargo clippy --profile ci-lint --workspace --exclude tsz-conformance --all-targets -- -D warnings` (CI's exact invocation) — **no warnings**
- `python3 scripts/arch/arch_guard.py` — `Architecture guardrails passed.`
- oracle rows generated with `typescript@7.0.2` (the pin in `scripts/conformance/typescript-versions.json`), `--noEmit --strict --pretty --target es2022 --lib es2022`, 11 fixtures

**Conformance/emit not run, and stated as an argument rather than a measurement.** This diff adds `related_information` to an existing `TS2322` and introduces no new top-level code — `TS6502` is a `Message`, never reported top-level — and `scripts/conformance/lib/results.py::compute_diff` grades `Counter(expected)` vs `Counter(actual)` over error *codes*. The same argument was confirmed by real `snapshot --workers 12 --force` runs on #16451, #16446 and #16458, each `0 regressed / 0 fixed`. A faster seat is welcome to discharge it rather than trust it; #16535 landed on the identical argument an hour ago.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Olivine

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZpJanJtezG2drEvHUYBSp)_