### PR TITLE
test(checker): pin #16498's default-imported enum/function+namespace qualified-name root as fixed

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2678,3 +2678,7 @@ path = "tests/import_equals_alias_duplicate_container_tests.rs"
 [[test]]
 name = "import_equals_alias_duplicate_function_container_tests"
 path = "tests/import_equals_alias_duplicate_function_container_tests.rs"
+
+[[test]]
+name = "qualified_default_import_enum_namespace_merge_root_tests"
+path = "tests/qualified_default_import_enum_namespace_merge_root_tests.rs"

--- a/crates/tsz-checker/tests/qualified_default_import_enum_namespace_merge_root_tests.rs
+++ b/crates/tsz-checker/tests/qualified_default_import_enum_namespace_merge_root_tests.rs
@@ -1,0 +1,226 @@
+//! Regression coverage for #16498: a default-imported `enum` or
+//! `function`+`namespace` merge must resolve as a qualified-name ROOT.
+//!
+//! `tsc` reports `TS2694` for a missing member (the target has namespace
+//! meaning: `Enum` is part of `SymbolFlags.Namespace = ValueModule |
+//! NamespaceModule | Enum`) or is clean for a present member. #16498 reported
+//! tsz instead resolving `TS2503 "Cannot find namespace 'C'."` for both,
+//! because the identifier `C` failed to resolve with *any* type meaning at
+//! all — before `qualified_names.rs`'s namespace-meaning gate (the one
+//! #16486 fixed) is ever reached.
+//!
+//! **Verified already fixed on current `main` before writing any src change**
+//! (checked with both `check_multi_file_with_global_index`, the production-
+//! faithful harness the sibling `ts2702_qualifier_namespace_meaning_tests.rs`
+//! suite uses, and `check_multi_file_with_libs_stamped`, the harness #16498's
+//! own repro specified) — every row below already matches `tsc` 7.0.2. Pinning
+//! the adjacent matrix as a regression floor rather than leaving this
+//! unverified on the board a second time.
+
+use tsz_checker::test_utils::{
+    check_multi_file_with_global_index, check_multi_file_with_libs_stamped,
+};
+use tsz_common::CheckerOptions;
+
+fn multi_file_diags(files: &[(&str, &str)], entry: &str) -> Vec<(u32, String)> {
+    let options = CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    };
+    check_multi_file_with_global_index(files, entry, options)
+        .into_iter()
+        .map(|diagnostic| (diagnostic.code, diagnostic.message_text))
+        .collect()
+}
+
+fn multi_file_codes(files: &[(&str, &str)], entry: &str) -> Vec<u32> {
+    multi_file_diags(files, entry)
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect()
+}
+
+/// Like `multi_file_codes`, but through `check_multi_file_with_libs_stamped`
+/// (empty lib set) -- the exact harness #16498 used for its own repro.
+fn stamped_codes(files: &[(&str, &str)], entry: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    };
+    check_multi_file_with_libs_stamped(files, entry, options, &[])
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+/// Default-imported enum, missing member: `tsc` -> `TS2694`. #16498 reported
+/// `TS2503`, because `C` never resolved as a type-position identifier.
+#[test]
+fn default_imported_enum_missing_member_reports_ts2694_not_ts2503() {
+    let diags = multi_file_diags(
+        &[
+            (
+                "e1.ts",
+                "export enum Color { Red, Green }\nexport default Color;\n",
+            ),
+            ("e2.ts", "import C from \"./e1\";\nvar bad: C.Nope;\n"),
+        ],
+        "e2.ts",
+    );
+    assert_eq!(
+        diags,
+        vec![(
+            2694,
+            "Namespace 'Color' has no exported member 'Nope'.".to_string()
+        )],
+        "expected TS2694 naming the resolved namespace, got {diags:?}"
+    );
+}
+
+/// Same shape through the `check_multi_file_with_libs_stamped` harness
+/// #16498's repro specified.
+#[test]
+fn default_imported_enum_missing_member_reports_ts2694_stamped_harness() {
+    let codes = stamped_codes(
+        &[
+            (
+                "e1.ts",
+                "export enum Color { Red, Green }\nexport default Color;\n",
+            ),
+            ("e2.ts", "import C from \"./e1\";\nvar bad: C.Nope;\n"),
+        ],
+        "e2.ts",
+    );
+    assert_eq!(codes, vec![2694], "got {codes:?}");
+}
+
+/// Default-imported enum, present member: `tsc` is clean.
+#[test]
+fn default_imported_enum_present_member_is_clean() {
+    let codes = multi_file_codes(
+        &[
+            (
+                "e1.ts",
+                "export enum Color { Red, Green }\nexport default Color;\n",
+            ),
+            ("e2.ts", "import C from \"./e1\";\nvar ok: C.Red;\n"),
+        ],
+        "e2.ts",
+    );
+    assert_eq!(codes, Vec::<u32>::new(), "expected clean, got {codes:?}");
+}
+
+#[test]
+fn default_imported_enum_present_member_is_clean_stamped_harness() {
+    let codes = stamped_codes(
+        &[
+            (
+                "e1.ts",
+                "export enum Color { Red, Green }\nexport default Color;\n",
+            ),
+            ("e2.ts", "import C from \"./e1\";\nvar ok: C.Red;\n"),
+        ],
+        "e2.ts",
+    );
+    assert_eq!(codes, Vec::<u32>::new(), "expected clean, got {codes:?}");
+}
+
+/// A `function` + `namespace` merge, default-exported: `tsc` is clean for a
+/// present member (a `Function+NamespaceModule` merge keeps namespace
+/// meaning).
+#[test]
+fn default_imported_function_namespace_merge_member_is_clean() {
+    let codes = multi_file_codes(
+        &[
+            (
+                "f1.ts",
+                "export function Decl3() {}\nexport namespace Decl3 { export interface I { q: number } }\nexport default Decl3;\n",
+            ),
+            ("f2.ts", "import F from \"./f1\";\nvar y: F.I;\n"),
+        ],
+        "f2.ts",
+    );
+    assert_eq!(codes, Vec::<u32>::new(), "expected clean, got {codes:?}");
+}
+
+#[test]
+fn default_imported_function_namespace_merge_member_is_clean_stamped_harness() {
+    let codes = stamped_codes(
+        &[
+            (
+                "f1.ts",
+                "export function Decl3() {}\nexport namespace Decl3 { export interface I { q: number } }\nexport default Decl3;\n",
+            ),
+            ("f2.ts", "import F from \"./f1\";\nvar y: F.I;\n"),
+        ],
+        "f2.ts",
+    );
+    assert_eq!(codes, Vec::<u32>::new(), "expected clean, got {codes:?}");
+}
+
+/// Negative control: a bare default-exported `namespace` (no enum/function
+/// merge) already resolves correctly -- must keep working.
+#[test]
+fn default_imported_bare_namespace_member_is_clean() {
+    let codes = multi_file_codes(
+        &[
+            (
+                "n1.ts",
+                "namespace m { export interface Foo { q: number } }\nexport default m;\n",
+            ),
+            ("n2.ts", "import D from \"./n1\";\nvar y: D.Foo;\n"),
+        ],
+        "n2.ts",
+    );
+    assert_eq!(codes, Vec::<u32>::new(), "expected clean, got {codes:?}");
+}
+
+/// Renamed binders: the rule must key on symbol flags, not identifier
+/// spelling.
+#[test]
+fn default_imported_enum_renamed_binders_missing_member_reports_ts2694() {
+    let diags = multi_file_diags(
+        &[
+            (
+                "palette.ts",
+                "export enum Hue { Amber, Cerulean }\nexport default Hue;\n",
+            ),
+            (
+                "consumer.ts",
+                "import Local from \"./palette\";\nvar wrong: Local.Nonexistent;\n",
+            ),
+        ],
+        "consumer.ts",
+    );
+    assert_eq!(
+        diags,
+        vec![(
+            2694,
+            "Namespace 'Hue' has no exported member 'Nonexistent'.".to_string()
+        )],
+        "expected TS2694 naming the resolved namespace, got {diags:?}"
+    );
+}
+
+/// Negative control: a genuinely missing member on a default-imported class
+/// must still be an error (not silently accepted) -- classes have no
+/// namespace meaning on their own, so this stays TS2702/TS2713, never
+/// TS2694/TS2503.
+#[test]
+fn default_imported_class_qualifier_is_not_a_namespace() {
+    let codes = multi_file_codes(
+        &[
+            ("c1.ts", "export class Widget {}\nexport default Widget;\n"),
+            ("c2.ts", "import W from \"./c1\";\nvar bad: W.Nope;\n"),
+        ],
+        "c2.ts",
+    );
+    assert!(
+        codes.contains(&2702) || codes.contains(&2713),
+        "expected TS2702/TS2713 (class has no namespace meaning), got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2503) && !codes.contains(&2694),
+        "class qualifier must not be treated as a namespace, got {codes:?}"
+    );
+}


### PR DESCRIPTION
Investigated #16498 (a default-imported `enum` or `function`+`namespace` merge allegedly can't resolve as a qualified-name root at all — `TS2503 "Cannot find namespace 'C'"` where `tsc` reports `TS2694` on a missing member, or is clean on a present one).

**Already fixed on current `main` before I wrote any src change.** I built the exact repro from the issue plus an adjacent matrix and it all matches `tsc` today:

- default-imported enum, missing member → `TS2694 "Namespace 'Color' has no exported member 'Nope'."` (not `TS2503`)
- default-imported enum, present member → clean
- default-imported `function`+`namespace` merge, present member → clean
- renamed binders → same `TS2694`, correct namespace name
- negative control: bare default-exported `namespace` → still clean
- negative control: default-imported `class` (no namespace meaning) → still `TS2702`/`TS2713`, never `TS2503`/`TS2694`

Checked on two harnesses independently: `check_multi_file_with_global_index` (the production-faithful harness the sibling `ts2702_qualifier_namespace_meaning_tests.rs` suite uses) and `check_multi_file_with_libs_stamped` (the exact harness #16498's own repro specified, run with an empty lib set). Both agree.

I don't know which prior landed PR fixed this (likely a side effect of #16486's qualifier-anchor fix, since #16498 explicitly noted the bug was upstream of and independent from #16486's own gate — but the surrounding machinery apparently moved enough to also cover this). Rather than leave it unverified a second time, this PR pins the adjacent matrix as a permanent regression floor and closes the issue with the evidence.

Structural rule (now holding, not being introduced): when a default-imported identifier's ultimate alias target carries `Enum` or `Function+NamespaceModule`-merge meaning, `tsc` resolves it with namespace meaning (`SymbolFlags.Namespace = ValueModule | NamespaceModule | Enum`) for qualified-name root purposes; tsz does the same through `crates/tsz-checker/src/symbols/symbol_resolver.rs`'s alias-target classification path.

## Goal
Goal: hold

## Verification
- New tests: `crates/tsz-checker/tests/qualified_default_import_enum_namespace_merge_root_tests.rs` — `cargo test -p tsz-checker --test qualified_default_import_enum_namespace_merge_root_tests`: **9/9 passed** (both harnesses × 3 positive shapes, plus 3 negative/renamed controls).
- `cargo clippy -p tsz-checker --lib --tests -- -D warnings`: clean.
- `cargo fmt -p tsz-checker -- --check`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.
- Test-only diff (`git diff --name-only` touches no `crates/**/src` production path plus one `Cargo.toml` `[[test]]` registration) — conformance/emit counts cannot move; not run, per the board's standing note on test-only diffs.
- Pre-commit hook's own `cargo clippy -p tsz-checker` + architecture guard: passed at commit time.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_01BX6o35XPpjeeGhgky6ub12)_