### PR TITLE
fix(checker): render union TS2322 constituent by source-annotation provenance (#16513)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1092,6 +1092,9 @@ path = "tests/union_source_structural_elaboration_tests.rs"
 name = "union_source_enum_elaboration_order_tests"
 path = "tests/union_source_enum_elaboration_order_tests.rs"
 [[test]]
+name = "union_source_elaboration_constituent_tests"
+path = "tests/union_source_elaboration_constituent_tests.rs"
+[[test]]
 name = "ts2353_omit_pick_excess_property_tests"
 path = "tests/ts2353_omit_pick_excess_property_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -1135,6 +1135,66 @@ impl<'a> CheckerState<'a> {
         )
     }
 
+    /// Display a single failing union constituent honoring the source
+    /// annotation's provenance: an inline `{ ... }` constituent (an anonymous
+    /// composite the user wrote directly) shows its structural shape, while a
+    /// named reference keeps its name. Falls back to the ordinary diagnostic
+    /// display when the source expression carries no anonymous-composite
+    /// annotation. See issue #16513.
+    fn union_source_member_display(
+        &mut self,
+        anchor_idx: tsz_parser::parser::NodeIndex,
+        member: TypeId,
+    ) -> String {
+        self.anonymous_composite_annotation_source_display(anchor_idx, member)
+            .unwrap_or_else(|| self.format_type_diagnostic(member))
+    }
+
+    /// Render a depth-0 plain-leaf union-source mismatch (`Type 'A | B' is not
+    /// assignable to type 'T'.` -> `Type '<failing member>' is not assignable to
+    /// type 'T'.`), displaying the failing constituent with the source
+    /// annotation's provenance so an inline `{ ... }` constituent shows its
+    /// structural shape rather than a coincidentally same-shaped alias reached
+    /// through the reverse type-to-def lookup. See issue #16513.
+    ///
+    /// Only invoked at chain depth 0 (the primary assignment diagnostic). The
+    /// `member_type` is the solver's selected failing constituent; the solver
+    /// already walks the union in source order (#16523 reorders enum slots by
+    /// declaration), so this path corrects only the member *display*, not the
+    /// selection.
+    ///
+    /// The outer-line + generalize + `push_elaboration_in_span` scaffolding
+    /// mirrors the depth-0 plain-leaf branch of
+    /// [`Self::render_parent_with_child_relation`] — the two must stay in
+    /// lockstep. The sole divergence is `union_source_member_display` (annotation
+    /// provenance) in place of that renderer's plain `format_type_diagnostic`.
+    fn render_union_source_plain_leaf_member(
+        &mut self,
+        ctx: &RenderContext,
+        target_type: TypeId,
+        member_type: TypeId,
+    ) -> Diagnostic {
+        let mut diag = self.render_type_mismatch(ctx);
+        // The leaf generalizes the same way as the outer line (tsc runs
+        // `reportRelationError` on every relation line): an all-unit member
+        // widens to its base against a non-singleton target.
+        let display_member =
+            self.generalize_nested_relation_source_for_display(member_type, target_type);
+        let member_str = self.union_source_member_display(ctx.idx, display_member);
+        let target_str = self.format_type_diagnostic(target_type);
+        diag.push_elaboration_in_span(
+            ctx.start,
+            ctx.length,
+            format_message(
+                diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+                &[&member_str, &target_str],
+            ),
+            diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            0,
+        );
+        diag
+    }
+
     /// Render a union-source mismatch: a union type that is not assignable to
     /// the target because one of its members fails.
     ///
@@ -1170,6 +1230,18 @@ impl<'a> CheckerState<'a> {
         member_type: TypeId,
         nested_reason: &tsz_solver::SubtypeFailureReason,
     ) -> Diagnostic {
+        // A whole-constituent (plain-leaf) rejection carries no member-specific
+        // structure — its nested reason is just `member <: target`. An inline
+        // `{ ... }` constituent has no `aliasSymbol`, but the reverse
+        // type-to-def lookup repaints it with a coincidentally same-shaped alias
+        // declared elsewhere in the file (`{ m: number }` -> `U`). Render the
+        // failing member honoring the source annotation's provenance instead.
+        // Scoped to depth-0 plain-leaf: a structural or nested member failure
+        // binds its `nested_reason` to a specific member and self-heads its own
+        // line, so it keeps the established rendering. See issue #16513.
+        if ctx.depth == 0 && Self::nested_reason_is_plain_type_mismatch(nested_reason) {
+            return self.render_union_source_plain_leaf_member(ctx, target_type, member_type);
+        }
         if !Self::union_member_nested_needs_header(nested_reason) {
             return self.render_parent_with_child_relation(
                 ctx,

--- a/crates/tsz-checker/tests/union_source_elaboration_constituent_tests.rs
+++ b/crates/tsz-checker/tests/union_source_elaboration_constituent_tests.rs
@@ -1,0 +1,160 @@
+//! Union-source TS2322 elaboration must render the failing constituent *as it
+//! appears in the union* — an inline `{ ... }` shows its structural shape, not a
+//! coincidentally same-shaped display alias reached through the reverse
+//! type-to-def lookup; a named reference keeps its name. Regression coverage for
+//! the display half of issue #16513 (the constituent *selection* half — naming
+//! the first source-order enum — is owned by the solver reorder in #16523 and
+//! its `union_source_enum_elaboration_order_tests`; the enum cases here are the
+//! integration check that this display path preserves that selection).
+
+use tsz_checker::test_utils::check_source_strict;
+use tsz_common::diagnostics::Diagnostic;
+
+/// The nested elaboration lines (depth, code, text) of the first TS2322.
+fn ts2322_chain(diags: &[Diagnostic]) -> Vec<(u8, u32, String)> {
+    diags
+        .iter()
+        .find(|d| d.code == 2322)
+        .map(|d| {
+            d.related_information
+                .iter()
+                .map(|r| (r.depth, r.code, r.message_text.clone()))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn chain_texts(diags: &[Diagnostic]) -> Vec<String> {
+    ts2322_chain(diags).into_iter().map(|(_, _, m)| m).collect()
+}
+
+#[test]
+fn anonymous_object_union_member_is_not_named_by_a_shape_matched_alias() {
+    // `U` is a *later* type alias whose reduced body coincides structurally
+    // with `c1`'s first constituent. tsc names the anonymous constituent
+    // `{ m: number; }`, never the unrelated alias `U`.
+    let diags = check_source_strict(
+        r#"
+declare const c1: { m: number } | { m: string };
+const y1: boolean = c1;
+type U = { m: number } | { m: number };
+"#,
+    );
+    let texts = chain_texts(&diags);
+    assert!(
+        texts
+            .iter()
+            .any(|m| m.contains("Type '{ m: number; }' is not assignable to type 'boolean'")),
+        "expected the anonymous constituent `{{ m: number; }}` in the elaboration; got {texts:?}"
+    );
+    assert!(
+        !texts.iter().any(|m| m.contains("Type 'U'")),
+        "elaboration must not name the unrelated alias `U`; got {texts:?}"
+    );
+}
+
+#[test]
+fn enum_union_member_elaboration_names_first_declared_constituent() {
+    // Every constituent of `E1 | E2` fails against `boolean`; tsc reports the
+    // *first* one in source order (`E1`).
+    let diags = check_source_strict(
+        r#"
+enum E1 { A }
+enum E2 { A }
+declare const e: E1 | E2;
+const ee: boolean = e;
+"#,
+    );
+    let texts = chain_texts(&diags);
+    assert!(
+        texts
+            .iter()
+            .any(|m| m == "Type 'E1' is not assignable to type 'boolean'."),
+        "expected the first source-order constituent `E1`; got {texts:?}"
+    );
+    assert!(
+        !texts
+            .iter()
+            .any(|m| m == "Type 'E2' is not assignable to type 'boolean'."),
+        "elaboration must name `E1`, not the second constituent `E2`; got {texts:?}"
+    );
+}
+
+#[test]
+fn enum_union_member_elaboration_follows_declaration_order_when_reversed() {
+    // Same union, enums declared in the opposite order: the first source-order
+    // constituent is now `E2`, and that is what must be named.
+    let diags = check_source_strict(
+        r#"
+enum E2 { A }
+enum E1 { A }
+declare const e: E1 | E2;
+const ee: boolean = e;
+"#,
+    );
+    let texts = chain_texts(&diags);
+    assert!(
+        texts
+            .iter()
+            .any(|m| m == "Type 'E2' is not assignable to type 'boolean'."),
+        "expected the first source-order constituent `E2`; got {texts:?}"
+    );
+}
+
+#[test]
+fn all_object_union_names_first_source_order_constituent() {
+    let diags = check_source_strict(
+        r#"
+declare const e: { m: number } | { n: string };
+const ee: boolean = e;
+"#,
+    );
+    let texts = chain_texts(&diags);
+    assert!(
+        texts
+            .iter()
+            .any(|m| m.contains("Type '{ m: number; }' is not assignable to type 'boolean'")),
+        "expected the first constituent `{{ m: number; }}`; got {texts:?}"
+    );
+}
+
+#[test]
+fn mixed_object_then_enum_union_names_first_source_order_object() {
+    // Ground truth (tsc): the object literal is written first, so it is the
+    // named constituent even though the enum was declared earlier.
+    let diags = check_source_strict(
+        r#"
+enum E1 { A }
+declare const e: { m: number } | E1;
+const ee: boolean = e;
+"#,
+    );
+    let texts = chain_texts(&diags);
+    assert!(
+        texts
+            .iter()
+            .any(|m| m.contains("Type '{ m: number; }' is not assignable to type 'boolean'")),
+        "expected the first source-order constituent `{{ m: number; }}`; got {texts:?}"
+    );
+}
+
+#[test]
+fn named_type_alias_union_members_keep_their_names() {
+    // Named references carry an `aliasSymbol`, so they must keep their names —
+    // the anonymous-constituent structural display must not fire here.
+    let diags = check_source_strict(
+        r#"
+type Foo = { a: number };
+type Bar = { b: string };
+declare const x: Foo | Bar;
+const c: boolean = x;
+"#,
+    );
+    let texts = chain_texts(&diags);
+    assert!(
+        texts
+            .iter()
+            .any(|m| m == "Type 'Foo' is not assignable to type 'boolean'."),
+        "expected the named alias `Foo`; got {texts:?}"
+    );
+}


### PR DESCRIPTION
Completes the fix for #16513. The nested elaboration under a union `TS2322`
named a type alias that is **not a member of the union at all**.

`tsc` elaborates a failed `union <: target` assignment by naming the failing
constituent **as it appears in the source**. An inline `{ ... }` constituent
carries no `aliasSymbol`, so `tsc` renders its structural shape — but tsz's
reverse type-to-def lookup repainted it with a coincidentally same-shaped type
alias declared elsewhere in the file:

```ts
declare const c1: { m: number } | { m: string };
const y1: boolean = c1;
type U = { m: number } | { m: number };
```

```
tsc     Type '{ m: number; } | { m: string; }' is not assignable to type 'boolean'.
          Type '{ m: number; }' is not assignable to type 'boolean'.
before    Type 'U' is not assignable to type 'boolean'.               ← U is not in the union
after     Type '{ m: number; }' is not assignable to type 'boolean'.  ✓
```

**Structural rule.** When a union source fails a `TS2322` assignment at the top
level and the failing member is rejected wholesale (a plain-leaf relation), tsc
renders the member with the source annotation's provenance; tsz now does the
same through the checker `error_reporter`. An inline `{ ... }` annotation shows
its structural shape; a named reference (`Foo`, `E1`) keeps its name. The arbiter
is the source annotation's AST (`anonymous_composite_annotation_source_display`),
the same signal the top-level union line already uses, so the member line and the
union line agree. `render_union_source_plain_leaf_member` mirrors
`render_parent_with_child_relation`'s plain-leaf branch, diverging only in the
member display; the solver's `UnionSourceMismatch` reason and member selection
are unchanged.

The **constituent-selection** half of #16513 (naming the first *declared* enum
when two enums share a shape) was already fixed in the solver by #16523; this PR
is the **display** complement.

Adjacent-case matrix, verified against `typescript@6.0.2`:

| source union | tsc names | before | after |
| --- | --- | --- | --- |
| `{ m: number } \| { m: string }` | `{ m: number; }` | `U` | `{ m: number; }` ✓ |
| `{ m: number } \| { n: string }` | `{ m: number; }` | `{ m: number; }` | `{ m: number; }` ✓ |
| `{ m: number } \| E1` | `{ m: number; }` | `{ m: number; }` | `{ m: number; }` ✓ |
| `E1 \| E2` | `E1` | `E1` (via #16523) | `E1` ✓ |
| `Foo \| Bar` (named aliases) | `Foo` | `Foo` | `Foo` ✓ (name kept) |

Scoped to depth-0 plain-leaf: a structural/nested member failure binds its reason
to a specific member and self-heads its own line, so those keep their established
rendering. A mixed `enum | { ... }` written enum-first still names the object
rather than the enum — a pre-existing selection gap in the solver's member walk,
out of scope here and for #16523.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts2322_tests` (308) and the union-source
  elaboration suites — `union_source_elaboration_constituent_tests` (new),
  #16523's `union_source_enum_elaboration_order_tests`,
  `union_source_structural_elaboration_tests`,
  `union_source_missing_property_elaboration_tests`,
  `union_target_missing_property_elaboration_tests` — all green.
- `cargo test -p tsz-solver` — full suite green.
- Conformance snapshot (`--workers 12 --force`): 95.4%, no regression — a
  message-text-only change (same `TS2322` code and location), invisible to the
  code-set conformance scoring per the issue.
- `cargo clippy` and the architecture guard pass (member display stays out of
  the raw-assignability-predicate boundary, #8227).
- `tsz --noEmit` matches `tsc` for every row in the matrix. Emit is untouched
  (no `crates/tsz-emitter` / emit-path change).

## Provenance
Machine: cloud
Assistant: claude-code
Model: Opus
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_012NbJfhomnj3Sdc9F7NznoF)_