### PR TITLE
fix(checker): a fresh literal source is preserved against a nullable-union alias target (#15368)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -1135,8 +1135,32 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
+        let original_target = target;
         let target = self.evaluate_type_for_assignability(target);
         if target == TypeId::UNDEFINED || target == TypeId::NULL {
+            return true;
+        }
+        // tsc's `reportErrorResults` restores an alias-named target to its whole
+        // (unreduced) form before the source-literal generalization gate runs, so
+        // a nullable-union *alias* (`type U<T> = T | undefined`) keeps the literal
+        // source that a structurally identical *inline* `T | undefined` — which the
+        // relation reduces to its non-nullish member for the report — widens.
+        //
+        // The alias surface is read from the pre-evaluation target (evaluation
+        // flattens the application to the raw union, dropping it), and the whole
+        // resolved type is judged through the solver's resolver-aware singleton
+        // predicate, which counts the `undefined`/`null` union members that the
+        // reduced-target `_inner` path below deliberately ignores (that omission is
+        // exactly the nullish-strip a non-alias union already gets).
+        if crate::query_boundaries::diagnostics::type_keeps_alias_symbol_surface(
+            self.ctx.types.as_type_database(),
+            &self.ctx.definition_store,
+            original_target,
+        ) && crate::query_boundaries::diagnostics::relation_target_could_hold_singleton(
+            self.ctx.types,
+            &self.ctx,
+            target,
+        ) {
             return true;
         }
         // A deferred generic indexed access `O[K]` (K a type parameter, e.g.

--- a/crates/tsz-checker/src/tests/alias_application_display_retention_tests.rs
+++ b/crates/tsz-checker/src/tests/alias_application_display_retention_tests.rs
@@ -9,6 +9,13 @@
 //! render `Name<Args>`; a nullable union target that keeps its alias is not
 //! stripped to its non-nullish member.
 //!
+//! The same alias restoration also governs the *source* side: when the target is
+//! a generic union-alias application whose whole (restored) type is singleton-
+//! capable through a `null`/`undefined` member, a fresh literal source is kept
+//! (`Type '5'`) rather than generalized to its base (`Type 'number'`), mirroring
+//! tsc's `reportErrorResults` restoring `originalTarget` before the source-literal
+//! generalization gate.
+//!
 //! Owners: `tsz_solver::diagnostics::format::application_reduction` (shared
 //! display reduction), `type_queries::application_base_reducing_alias_body_kind`,
 //! and the checker's `render_missing_property` primitive-source target display.
@@ -167,9 +174,15 @@ type OrMissing<S> = S | undefined;
 const wrong: OrMissing<{ u: string }> = 5;
 "#,
     );
+    // The alias is restored over the reduced target (tsc `reportErrorResults`),
+    // so the reported target is the whole `OrMissing<{ u: string; }>` union —
+    // singleton-capable through its `undefined` member — and the literal source
+    // `5` is preserved rather than generalized to `number`. Oracle
+    // `typescript@7.0.2`: `Type '5' is not assignable to type
+    // 'OrMissing<{ u: string; }>'.`
     assert_eq!(
         message,
-        "Type 'number' is not assignable to type 'OrMissing<{ u: string; }>'."
+        "Type '5' is not assignable to type 'OrMissing<{ u: string; }>'."
     );
 }
 
@@ -181,6 +194,15 @@ type MaybeBox = { u: string } | undefined;
 const wrong: MaybeBox = 5;
 "#,
     );
+    // Residual: the target name `MaybeBox` is kept, but the literal source is
+    // still widened. The alias-restore source-literal fix lands for *generic*
+    // alias applications (the `OrMissing<..>` case above), which reach the
+    // source-display gate as an `Application` carrying the alias surface; a
+    // *non-generic* alias reaches it already reduced, so `original_target` no
+    // longer answers `type_keeps_alias_symbol_surface`. Oracle `typescript@7.0.2`
+    // preserves the literal here too (`Type '5' is not assignable to type
+    // 'MaybeBox'.`); pinning current output so a follow-up on the non-generic
+    // path updates this deliberately rather than silently.
     assert_eq!(
         message,
         "Type 'number' is not assignable to type 'MaybeBox'."

--- a/crates/tsz-checker/src/tests/generic_alias_application_display_tests.rs
+++ b/crates/tsz-checker/src/tests/generic_alias_application_display_tests.rs
@@ -23,9 +23,14 @@
 //! * `keyof`-bodied applications reduce to a *union* whose member ordering tsz
 //!   sorts canonically rather than by declaration position (the separate
 //!   union-ordering concern), so they stay on the alias surface;
-//! * mapped/union-bodied applications (`MappedAlias`, `UnionAlias`) are
-//!   over-reduced by an upstream checker path that hands the reporter an
-//!   already-evaluated target — a separate mechanism from this display strategy.
+//! * mapped-bodied applications (`MappedAlias`) are over-reduced by an upstream
+//!   checker path that hands the reporter an already-evaluated target — a
+//!   separate mechanism from this display strategy;
+//! * a union-bodied application (`UnionAlias<T> = T | undefined`) keeps its alias
+//!   name *and* its literal source: the literal-source half was the last
+//!   residual and is now fixed — a `T | undefined`/`T | null` target is
+//!   singleton-capable (`undefined`/`null` are unit types), so the source `5`
+//!   survives rather than generalizing to `number`.
 use crate::test_utils::check_source_diagnostics;
 
 #[track_caller]
@@ -133,21 +138,38 @@ const x: MappedAlias<{ m: string }> = 0;
 }
 
 // A union-bodied application is a surviving constructor: tsc keeps its alias
-// symbol (`UnionAlias<{ u: string; }>`) and the literal source. tsz currently
-// over-reduces it through the separate upstream mechanism (residual). Pin the
-// current output so a future fix updates this deliberately, not silently.
+// symbol (`UnionAlias<{ u: string; }>`) and the literal source `5`. The alias
+// target was restored by the main #15368 fix; the *source* literal now survives
+// too because the `T | undefined` target is singleton-capable (`undefined` is a
+// unit type), so the diagnostic must not generalize `5` to `number`.
 #[test]
-fn union_application_current_behavior() {
+fn union_application_keeps_literal_source_against_undefined_member() {
     let msg = ts2322_msg(
         r#"
 type UnionAlias<T> = T | undefined;
 const x: UnionAlias<{ u: string }> = 5;
 "#,
     );
-    // tsc: keeps `UnionAlias<{ u: string; }>` and literal `5` — residual (#15368).
     assert!(
-        msg.contains("{ u: string; }"),
-        "unexpected union-application render: {msg}"
+        msg.contains("Type '5'") && msg.contains("{ u: string; }"),
+        "expected literal source `5` preserved against a singleton-capable union alias, got: {msg}"
+    );
+}
+
+// The same rule with a `null` member — `null` is a unit type just like
+// `undefined`, so the literal source is preserved. Renamed binder proves the
+// decision is structural, not keyed on the alias/parameter spelling.
+#[test]
+fn union_application_keeps_literal_source_against_null_member_renamed() {
+    let msg = ts2322_msg(
+        r#"
+type Nullable<Val> = Val | null;
+const y: Nullable<{ u: string }> = 5;
+"#,
+    );
+    assert!(
+        msg.contains("Type '5'") && msg.contains("{ u: string; }"),
+        "expected literal source `5` preserved against a `| null` union alias, got: {msg}"
     );
 }
 

--- a/crates/tsz-checker/tests/ts2322_undefined_null_target_literal_display_tests.rs
+++ b/crates/tsz-checker/tests/ts2322_undefined_null_target_literal_display_tests.rs
@@ -6,6 +6,13 @@
 //! primitive base. tsz mirrors this for boolean keywords, string literals,
 //! template literals, and signed numeric / bigint literals.
 //!
+//! The same preservation extends to a *nullable union type-alias application*
+//! (`type Maybe<T> = T | undefined`): its alias symbol is restored over the
+//! relation's reduced target (tsc `reportErrorResults`), so the reported target
+//! is the whole singleton-capable union and the literal source survives — while a
+//! structurally identical *inline* `string | undefined` (no alias) reports against
+//! its reduced non-nullish member and widens. Both directions are pinned below.
+//!
 //! Conformance test: `invalidUndefinedValues.ts`.
 
 fn compile_diagnostics(source: &str) -> Vec<(u32, String)> {
@@ -64,6 +71,83 @@ x = true;
         msgs.iter()
             .any(|m| m.contains("Type 'true'") && m.contains("'undefined'")),
         "expected preserved 'true' against 'undefined', got: {msgs:?}"
+    );
+}
+
+// A generic type-alias application whose body is a nullable union
+// (`type Maybe<T> = T | undefined`) carries an alias symbol, which tsc's
+// `reportErrorResults` restores over the relation's reduced target — so the
+// reported target is the *whole* `Maybe<string>` union, which is singleton-
+// capable through its `undefined` member, and the literal source `5` is
+// preserved rather than generalized to `number`. This is the #15368 f-source
+// residual.
+#[test]
+fn ts2322_preserves_number_literal_against_nullable_union_alias() {
+    let diags = compile_diagnostics(
+        r#"
+type Maybe<T> = T | undefined;
+const m: Maybe<string> = 5;
+"#,
+    );
+    let msgs = ts2322(&diags);
+    assert!(
+        msgs.iter()
+            .any(|m| m.contains("Type '5'") && m.contains("Maybe<string>")),
+        "expected literal '5' preserved against nullable union alias 'Maybe<string>', got: {msgs:?}"
+    );
+}
+
+// Same rule with a `| null` member and an object argument (the issue's own
+// witness shape), and a renamed binder to prove the decision is structural.
+#[test]
+fn ts2322_preserves_number_literal_against_null_union_alias_renamed() {
+    let diags = compile_diagnostics(
+        r#"
+type OrNull<Val> = Val | null;
+const c: OrNull<{ u: string }> = 5;
+"#,
+    );
+    let msgs = ts2322(&diags);
+    assert!(
+        msgs.iter()
+            .any(|m| m.contains("Type '5'") && m.contains("OrNull<{ u: string; }>")),
+        "expected literal '5' preserved against null union alias 'OrNull<...>', got: {msgs:?}"
+    );
+}
+
+// Negative control #1: a structurally identical *inline* nullable union carries
+// no alias symbol, so tsc reports against the reduced non-nullish member and
+// generalizes the literal to its base. The fix must not preserve here.
+#[test]
+fn ts2322_widens_number_literal_against_inline_nullable_union() {
+    let diags = compile_diagnostics(
+        r#"
+const x: string | undefined = 5;
+"#,
+    );
+    let msgs = ts2322(&diags);
+    assert!(
+        msgs.iter().any(|m| m.contains("Type 'number'"))
+            && !msgs.iter().any(|m| m.contains("Type '5'")),
+        "expected literal '5' widened to 'number' against inline 'string | undefined', got: {msgs:?}"
+    );
+}
+
+// Negative control #2: a plain, non-singleton-capable target still generalizes
+// the literal source to its primitive base, exactly as tsc does.
+#[test]
+fn ts2322_widens_number_literal_against_plain_string_target() {
+    let diags = compile_diagnostics(
+        r#"
+var x: string;
+x = 5;
+"#,
+    );
+    let msgs = ts2322(&diags);
+    assert!(
+        msgs.iter()
+            .any(|m| m.contains("Type 'number'") && m.contains("'string'")),
+        "expected literal '5' widened to 'number' against plain 'string', got: {msgs:?}"
     );
 }
 


### PR DESCRIPTION
Closes #15368's residual 1 (source-literal display).

## Structural rule

When the target of a `TS2322`/`TS2345` assignment error is a **generic union-alias application** whose body carries a `null`/`undefined` member (`type UnionAlias<T> = T | undefined`), tsc keeps a fresh literal source verbatim in the message (`Type '5'`), because `reportErrorResults` restores `originalTarget` whenever it carried an `aliasSymbol` before the source-literal generalization gate — so the reported target is the *whole* `{ u: string } | undefined` union, which is singleton-capable through its `undefined` member. A structurally identical **inline** `T | undefined` (no alias) is reduced by the relation to its non-nullish member, so tsc generalizes the literal to its base (`Type 'number'`).

tsz generalized the source in **both** cases. `is_literal_sensitive_assignment_target` (checker `error_reporter/core/diagnostic_source.rs`) evaluated the target via `evaluate_type_for_assignability` *before* the singleton-capacity check, and that flattens the alias application to its raw union and drops the alias surface — so the alias union became indistinguishable from the inline one and fell to the reduced-target path (`is_literal_sensitive_assignment_target_inner`), which deliberately does not count `undefined`/`null` union members (that omission is exactly the nullish-strip a non-alias union already gets).

## What changed

`is_literal_sensitive_assignment_target` now reads the alias surface from the **pre-evaluation** target via `type_keeps_alias_symbol_surface` (the solver's `aliasSymbol` analog, already used by `render_failure.rs`), and when it is an alias judges singleton-capacity through the solver's resolver-aware `relation_target_could_hold_singleton` (which counts the nullish union members). Non-alias targets are untouched and keep the existing reduced-target behavior.

- Owner layer: checker diagnostic renderer (display only). No assignability outcome, diagnostic code, or emitter output changes — only the source type *string* in the message.
- The two-path shape is deliberate: wholesale-delegating `_inner` to the solver predicate would make non-alias nullable unions start preserving literals too, regressing the exact case this fix distinguishes (confirmed by review).

## Adjacent-case matrix (oracled against pinned `typescript@7.0.2`)

| Target | tsc | tsz (this PR) |
| --- | --- | --- |
| generic alias `UnionAlias<{u:string}> = 5` | `Type '5'` | `Type '5'` ✅ (was `number`) |
| generic `| null` alias `OrNull<{u:string}> = 5` | `Type '5'` | `Type '5'` ✅ |
| inline `string | undefined = 5` | `Type 'number'` | `Type 'number'` ✅ |
| inline `{u:string} | null = 5` | `Type 'number'` | `Type 'number'` ✅ |
| `object | null` call arg `takes(1)` | `number` | `number` ✅ |
| `1 | 2 = 5` | `Type '5'` | `Type '5'` ✅ |
| bare `undefined = 5` | `Type '5'` | `Type '5'` ✅ |
| plain object / `string = 5` | `Type 'number'` | `Type 'number'` ✅ |

## Deliberately out of scope (documented residual)

The **non-generic** union alias (`type MaybeBox = {u:string} | undefined; const x: MaybeBox = 5`) still widens — its target reaches the gate already reduced, so `type_keeps_alias_symbol_surface` doesn't fire. tsc preserves there too; pinned as a residual with the oracle value in `alias_application_display_retention_tests.rs`.

## Goal
Goal: hold

## Verification
- Manual CLI oracle vs pinned `typescript@7.0.2` (`scripts/conformance/oracle.sh`) on the full matrix above — byte-exact.
- New/updated unit + integration tests (message text): `generic_alias_application_display_tests` (8/8), `alias_application_display_retention_tests` (16/16, updated the `union_bodied_alias_application_…` pin to the tsc value), `ts2322_undefined_null_target_literal_display_tests` (8/8, +3 new: generic alias preserve, inline-union widen guard, plain-string widen guard).
- Regression clusters green (ci-unit): `literal_source` (25), `source_display` (99), `generalization` (11), `ts2345_call_argument_display`/`_call_parameter_display` (9), `ts2322` (part_04 mapped now passing), `assignab` (315), `relation_leaf_literal_generalization` (29), `literal_source_widening_position_parity` (6), `template_intrinsic_literal_union_alias_display` (5), `optional_property_target_undefined_display` (4).
- Full `-p tsz-checker --lib` run: only pre-existing failures remain — `import_equals_referenced_alias_resolution_tests::referenced_alias_in_static_block_resolves_the_specifier` (#16411/#16527 family, red on `main`, fixed by #16533) and the #15338 `ts2589` hang. Both are structurally unrelated to this display change.
- `cargo fmt`, pre-commit clippy (`-p tsz-checker`), architecture guard, crate verification — all passed.
- Conformance snapshot / emit not run: display-only change (source type string), so the code-based conformance fingerprint and JS/DTS emit are unchanged by construction; the TypeScript submodule is not checked out in this environment.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZqxSStLHLPyuBzQH7M9Vk)_