### PR TITLE
test(ci): shrink the known-failures gate by six passing rows and correct a wrong TS2741 expectation

### DIFF
--- a/crates/tsz-checker/tests/conformance_issues/types/optional_chain.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/optional_chain.rs
@@ -983,11 +983,27 @@ c2 = c;
         has_error(&relevant_diagnostics, 2720),
         "Expected TS2720 for implementing class A, got: {relevant_diagnostics:#?}"
     );
-    // tsc expects TS2741: "Property 'x' is missing in type 'C' but required in type 'A'."
-    // for the `c2 = c` assignment (C -> C2 where C2 requires private x from A).
+    // The `c2 = c` assignment (C -> C2, where C2 inherits A's private `x`) reports
+    // TS2322, not a standalone TS2741. Verified against the pinned typescript@7.0.2:
+    //
+    //   t.ts(5,7):  error TS2720: Class 'C' incorrectly implements class 'A'. ...
+    //     Property 'x' is missing in type 'C' but required in type 'A'.
+    //   t.ts(16,1): error TS2322: Type 'C' is not assignable to type 'C2'.
+    //     Property 'x' is missing in type 'C' but required in type 'A'.
+    //
+    // "Property 'x' is missing ..." is *nested related information* under each
+    // anchor, never its own top-level TS2741. The previous TS2741 assertion was an
+    // unverified expectation; it passed only while tsz emitted a spurious TS2741
+    // instead of TS2322 (the same divergence conformance recorded on
+    // classImplementsClass4.ts as `actual:[TS2720,TS2741]`, now passing).
     assert!(
-        has_error(&relevant_diagnostics, 2741),
-        "Expected TS2741 for missing private property 'x', got: {relevant_diagnostics:#?}"
+        has_error(&relevant_diagnostics, 2322),
+        "Expected TS2322 for the C -> C2 assignment, got: {relevant_diagnostics:#?}"
+    );
+    assert!(
+        !has_error(&relevant_diagnostics, 2741),
+        "TS2741 is not a top-level diagnostic here; tsc nests the missing-property \
+         line under TS2720/TS2322. Got: {relevant_diagnostics:#?}"
     );
 }
 

--- a/scripts/ci/known-failures.txt
+++ b/scripts/ci/known-failures.txt
@@ -99,6 +99,14 @@
 # keeping the shared lib prefix's ids (mirroring the driver's bind-result reducer).
 # baseline-status: reconciled r10
 
+# 2026-08-06 shrink (no generation bump — removals are always allowed): six
+# rows now pass on main @ 0001e7a725, verified with per-target runs
+# (`cargo nextest run -p <pkg> --test <target>`), not a scoped filter. Three
+# alias-intersection rows and the reexported-symbol row are #15983 entries that
+# the cross-file identity landings have since fixed; the ts2303 self-import row
+# and the tsz-emitter overloaded-initializer row likewise pass. Full per-target
+# sweep of every target holding a gate entry: 30 failing, all remaining entries
+# still reproduce.
 tsz-checker::commonjs_module_export_alias_tests::test_module_exports_forward_read_reports_ts2565
 tsz-checker::conditional_application_display_tests::deferred_generic_conditional_keeps_branch_union
 tsz-checker::conformance_issues_features::features::namespace_construct_signature::part_00::test_js_void_zero_expando_reports_named_receiver_type
@@ -107,9 +115,6 @@ tsz-checker::conformance_issues_types::types::fp_repro_audit_2026::issue_14944_g
 tsz-checker::conformance_issues_types::types::r#enum::test_jsdoc_object_literal_property_types_do_not_trigger_self_tdz
 tsz-checker::conformance_issues_types::types::r#enum::test_jsdoc_object_literal_shorthand_and_default_param_preserve_source_types
 tsz-checker::contravariant_app_constrained_type_param_target_tests::same_base_mapped_record_alias_keeps_tsc_variance_quirk
-tsz-checker::cross_file_recursive_alias_intersection_tests::const_assignment_to_imported_alias_intersection_is_clean
-tsz-checker::cross_file_recursive_alias_intersection_tests::member_read_through_imported_alias_intersection_is_clean
-tsz-checker::cross_file_recursive_alias_intersection_tests::renamed_binders_member_read_is_clean
 tsz-checker::cross_module_nested_interface_tests::test_cross_module_nested_interface_method_arg_check
 tsz-checker::cross_module_nested_interface_tests::test_three_file_namespace_import_property_type
 tsz-checker::cross_module_nested_interface_tests::test_workspace_method_type_resolution
@@ -129,11 +134,8 @@ tsz-checker::jsdoc_constructor_typeof_source_display_tests::ts2345_jsdoc_constru
 tsz-checker::jsdoc_constructor_typeof_source_display_tests::ts2345_jsdoc_constructor_var_displays_plain_function_source
 tsz-checker::nonnull_contextual_type_arg_inference_tests::contextual_return_can_refine_transparent_wrapper_inference
 tsz-checker::raw_builder_return_context_inference_tests::different_base_and_ambiguous_union_do_not_pin_the_tag
-tsz-checker::reexported_symbol_keyed_member_tests::direct_import_symbol_keyed_member_is_clean
 tsz-checker::simple_local_interface_fastpath_tests::missing_interface_lib_rows_keep_lib_shapes
-tsz-checker::ts2303_tests::recursive_export_assignment_self_import_reports_ts2303
 tsz-cli::driver::core::check::check_tests::cross_file_class_namespace_merge_value_keeps_call_signature_in_import_cycle
 tsz-cli::driver::core::check::check_tests::default_lib_validation_normalizes_cross_arena_method_members_after_global_merge
 tsz-cli::driver_tests::cross_file_dependent_operand_aliases_accept_scalars_and_literal_arrays
 tsz-cli::driver_tests::declaration_emit_reports_ts7056_for_private_import_type_alias
-tsz-emitter::declaration_emitter::tests::simple_declarations::test_overloaded_call_initializer_does_not_use_first_signature_return_type


### PR DESCRIPTION
Goal: hold

Makes the known-failures gate reflect reality. A full **per-target** sweep of every target holding a `scripts/ci/known-failures.txt` entry — `cargo nextest run -p <pkg> --test <target>`, not a scoped `-E` filter — found the gate had drifted in both directions.

## 1. Six rows now pass — removed (shrink, no generation bump)

Per the file's own policy, "in normal PRs this list may only shrink". Each verified by running its **whole** target, not just the named test:

| row | target result |
|---|---|
| `cross_file_recursive_alias_intersection_tests::const_assignment_to_imported_alias_intersection_is_clean` | 5/5 pass |
| `cross_file_recursive_alias_intersection_tests::member_read_through_imported_alias_intersection_is_clean` | 5/5 pass |
| `cross_file_recursive_alias_intersection_tests::renamed_binders_member_read_is_clean` | 5/5 pass |
| `reexported_symbol_keyed_member_tests::direct_import_symbol_keyed_member_is_clean` | 4/4 pass |
| `ts2303_tests::recursive_export_assignment_self_import_reports_ts2303` | 7/7 pass |
| `tsz-emitter::...::test_overloaded_call_initializer_does_not_use_first_signature_return_type` | passes; `-p tsz-emitter` is 4775/4775 |

Three of these are **#15983** rows that the cross-file identity landings have since fixed (#16538 removed that issue's two kysely rows earlier today).

## 2. One wrong expectation — corrected

`conformance_issues_types::types::optional_chain::test_class_implements_class_reports_private_member_incompatibility_on_assignment` was failing **and ungated**. It asserted a standalone `TS2741`. The pinned `typescript@7.0.2` emits no such diagnostic:

```
t.ts(5,7):  error TS2720: Class 'C' incorrectly implements class 'A'. ...
  Property 'x' is missing in type 'C' but required in type 'A'.
t.ts(16,1): error TS2322: Type 'C' is not assignable to type 'C2'.
  Property 'x' is missing in type 'C' but required in type 'A'.
```

"Property 'x' is missing …" is **nested related information** under each anchor, never its own top-level code — and tsz's top-level codes already match tsc exactly. The assertion passed only while tsz emitted a spurious `TS2741` *instead of* `TS2322`; conformance recorded the same divergence on `classImplementsClass4.ts` as `actual:[TS2720,TS2741]`, which now passes. So the compiler got more correct and the stale assertion is what broke.

Corrected to assert `TS2322` **and** to assert `TS2741` is absent, so the test now pins the tsc-correct shape in both directions rather than re-admitting the old bug.

## 3. One genuine gap — filed, not hidden

`js_jsdoc_diagnostics_tests::checked_js_elided_default_namespace_import_reports_duplicate_and_value_errors` is a **real false-negative** (tsc: `TS2300 Duplicate identifier`; tsz: `[]`). Filed as **#16546** with the measured repro rather than added to the gate — an addition would need a generation bump, and the failure deserves a fix. Not caused by any recent landing: verified failing at `b6b1fecadb`, before #16537/#16539/#16540/#16541.

## Verification

- per-target sweep, 20 checker `[[test]]` targets + `tsz-cli` + `tsz-emitter` rows: **30 failing, all remaining gate entries still reproduce**
- corrected test: **passes**; the four targets holding removed rows: **5/5, 4/4, 7/7, 4775/4775**
- the three still-failing `tsz-cli` gate rows re-verified as still failing, so they stay
- `cargo nextest run -p tsz-checker --lib` — 9965/9965 · `-p tsz-core` 3284/3284 · `-p tsz-solver` 7675/7675 · `-p tsz-binder` 580/580 · `-p tsz-scanner` 424/424 · `-p tsz-parser` 1966/1966 · `-p tsz-emitter` 4775/4775
- pre-push hook: clippy + architecture guard passed
- no compiler source touched — gate file and one test assertion only

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5
Effort: xhigh
