### PR TITLE
fix(solver,checker): union-member elaboration keeps per-occurrence literal/alias provenance (#16513)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1080,6 +1080,9 @@ path = "tests/intersection_target_missing_property_elaboration_tests.rs"
 name = "union_source_missing_property_elaboration_tests"
 path = "tests/union_source_missing_property_elaboration_tests.rs"
 [[test]]
+name = "union_source_member_provenance_display_tests"
+path = "tests/union_source_member_provenance_display_tests.rs"
+[[test]]
 name = "union_target_missing_property_elaboration_tests"
 path = "tests/union_target_missing_property_elaboration_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -1228,7 +1228,7 @@ impl<'a> CheckerState<'a> {
 
         let display_member =
             self.generalize_nested_relation_source_for_display(member_type, target_type);
-        let member_str = self.format_type_diagnostic(display_member);
+        let member_str = self.format_type_diagnostic_for_union_member(source_type, display_member);
         diag.push_elaboration_in_span(
             ctx.start,
             ctx.length,
@@ -1363,7 +1363,13 @@ impl<'a> CheckerState<'a> {
                 // every relation line).
                 let display_source = self
                     .generalize_nested_relation_source_for_display(nested_source, nested_target);
-                let source_str = self.format_type_diagnostic(display_source);
+                // `source_type` is the union whenever this leaf elaborates a
+                // `UnionSourceMismatch` member (see `render_union_source_mismatch`
+                // below); for every other caller of this shared renderer the
+                // per-union provenance lookup simply misses and falls back to
+                // the ordinary diagnostic formatting.
+                let source_str =
+                    self.format_type_diagnostic_for_union_member(source_type, display_source);
                 let target_str = self.format_type_diagnostic(nested_target);
                 diag.push_elaboration_in_span(
                     start,

--- a/crates/tsz-checker/src/state/type_environment/formatting.rs
+++ b/crates/tsz-checker/src/state/type_environment/formatting.rs
@@ -139,6 +139,42 @@ impl<'a> CheckerState<'a> {
         .expect("DefaultDiagnostic is a basic diagnostic display role")
     }
 
+    /// Format a union member's type for a failing-elaboration message
+    /// (`Type '<member>' is not assignable to type '<target>'.` beneath a
+    /// union source mismatch), rendering it structurally when it was written
+    /// as an anonymous literal directly in `union_type`.
+    ///
+    /// The member's bare `TypeId` alone cannot make that call: a named type
+    /// alias whose body happens to reduce to the same content-interned shape
+    /// also marks the global `is_literal_object_annotation` table, so
+    /// `resolve_object_shape_name`'s structural reverse lookup would repaint
+    /// a genuinely anonymous member with that unrelated alias's name (or vice
+    /// versa, structurally expand a real alias reference). The per-union
+    /// `mark_union_literal_member` record answers the narrower, sound
+    /// question — was *this* occurrence, in *this* union, syntactically
+    /// anonymous — so aliased members (`A | B`) keep their names while
+    /// anonymous members (`{ m: number } | { m: string }`) render structurally
+    /// even when an unrelated same-shaped alias exists elsewhere in the file.
+    pub fn format_type_diagnostic_for_union_member(
+        &self,
+        union_type: TypeId,
+        member_type: TypeId,
+    ) -> String {
+        if self
+            .ctx
+            .types
+            .is_union_literal_member(union_type, member_type)
+        {
+            let mut formatter = self
+                .ctx
+                .create_diagnostic_type_formatter()
+                .with_display_properties()
+                .with_anonymous_composite_structural();
+            return formatter.format(member_type).into_owned();
+        }
+        self.format_type_diagnostic(member_type)
+    }
+
     fn format_type_diagnostic_impl(&self, type_id: TypeId) -> String {
         if let Some(sym_id) = self.ctx.resolve_type_to_symbol_id(type_id)
             && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)

--- a/crates/tsz-checker/src/types/computation/type_operators.rs
+++ b/crates/tsz-checker/src/types/computation/type_operators.rs
@@ -32,9 +32,15 @@ impl<'a> CheckerState<'a> {
         // UnionType uses CompositeTypeData which has a types list
         if let Some(composite) = self.ctx.arena.get_composite_type(node) {
             let mut member_types = Vec::new();
+            let mut literal_member_nodes = Vec::new();
             for &type_idx in &composite.types.nodes {
                 // Use get_type_from_type_node to properly resolve typeof expressions via binder
                 member_types.push(self.get_type_from_type_node(type_idx));
+                literal_member_nodes.push(self.ctx.arena.get(type_idx).is_some_and(
+                    |member_node| {
+                        member_node.kind == tsz_parser::parser::syntax_kind_ext::TYPE_LITERAL
+                    },
+                ));
             }
 
             if member_types.is_empty() {
@@ -63,7 +69,25 @@ impl<'a> CheckerState<'a> {
             // (e.g., `T | null` should display as `T | null`, not as T's
             // expanded body). The interner stores at most one origin per
             // flattened TypeId; first writer wins.
-            self.ctx.types.store_union_origin(result, member_types);
+            self.ctx
+                .types
+                .store_union_origin(result, member_types.clone());
+            // Record, per member, whether it was written as an anonymous
+            // `{ ... }` literal directly in *this* union — as opposed to a
+            // named alias/interface reference whose body happens to reduce
+            // to the same content-interned shape. See
+            // `TypeInterner::mark_union_literal_member` for why the global
+            // `is_literal_object_annotation` table alone cannot make this
+            // distinction: a type alias's body also marks it whenever the
+            // alias's shape coincides with an anonymous member's shape.
+            for (&member_type, &is_literal) in member_types.iter().zip(literal_member_nodes.iter())
+            {
+                if is_literal {
+                    self.ctx
+                        .types
+                        .mark_union_literal_member(result, member_type);
+                }
+            }
             return result;
         }
 

--- a/crates/tsz-checker/src/types/type_node.rs
+++ b/crates/tsz-checker/src/types/type_node.rs
@@ -301,9 +301,15 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         // UnionType uses CompositeTypeData which has a types list
         if let Some(composite) = self.ctx.arena.get_composite_type(node) {
             let mut member_types = Vec::new();
+            let mut literal_member_nodes = Vec::new();
             for &type_idx in &composite.types.nodes {
                 // Recursively resolve each member type
                 member_types.push(self.check(type_idx));
+                literal_member_nodes.push(
+                    self.ctx.arena.get(type_idx).is_some_and(|member_node| {
+                        member_node.kind == syntax_kind_ext::TYPE_LITERAL
+                    }),
+                );
             }
 
             if member_types.is_empty() {
@@ -319,10 +325,31 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                 return collapsed;
             }
 
-            return type_construction::type_node_annotation_union_with_origin(
+            let result = type_construction::type_node_annotation_union_with_origin(
                 self.ctx.types,
-                member_types,
+                member_types.clone(),
             );
+            // Record, per member, whether it was written as an anonymous
+            // `{ ... }` literal directly in *this* union — as opposed to a
+            // named alias/interface reference whose body happens to reduce
+            // to the same content-interned shape. `mark_literal_object_annotation`
+            // (called from `get_type_from_type_literal` for every member
+            // above) cannot make that distinction on its own: a type alias's
+            // body runs through the same literal-checking path and marks the
+            // identical global table entry whenever its shape coincides.
+            // `render_union_source_mismatch`/`render_parent_with_child_relation`
+            // consult this narrower, per-union record to decide whether
+            // repainting a failing member with an unrelated same-shaped
+            // alias's name is sound for this occurrence.
+            for (&member_type, &is_literal) in member_types.iter().zip(literal_member_nodes.iter())
+            {
+                if is_literal {
+                    self.ctx
+                        .types
+                        .mark_union_literal_member(result, member_type);
+                }
+            }
+            return result;
         }
 
         TypeId::ERROR

--- a/crates/tsz-checker/tests/union_source_member_provenance_display_tests.rs
+++ b/crates/tsz-checker/tests/union_source_member_provenance_display_tests.rs
@@ -1,0 +1,165 @@
+//! Union-source elaboration must not repaint an anonymous member with an
+//! unrelated same-shaped alias's name (#16513, row 1).
+//!
+//! tsc's nested `Type '<member>' is not assignable to type '<target>'.` line
+//! under a failing union assignment names the member exactly as written: an
+//! anonymous literal (`{ m: number }`) stays anonymous, a named alias
+//! reference (`A`) keeps its name. tsz's structural interner content-interns
+//! an anonymous literal and a coincidentally-shaped alias body onto the same
+//! `TypeId`, so the elaboration's reverse-shape lookup (`resolve_object_shape_name`)
+//! could not previously tell "this occurrence was written as `{ ... }`" apart
+//! from "this occurrence merely has the same shape as some unrelated alias
+//! declared elsewhere in the file" — it repainted the former with the
+//! latter's name.
+//!
+//! The fix records, per `(union_type_id, member_type_id)`, whether a member
+//! was written as an anonymous literal directly in that union
+//! (`TypeInterner::mark_union_literal_member`, populated in
+//! `get_type_from_union_type`), and the elaboration renderer consults that
+//! narrower record instead of the global identity-keyed
+//! `is_literal_object_annotation` flag. These tests vary binder names and mix
+//! literal/named members in one union (anti-hardcoding): the behavior is
+//! per-occurrence provenance, not a name or file-scoped suppression.
+
+use tsz_checker::test_utils::check_source_diagnostics;
+use tsz_common::diagnostics::Diagnostic;
+
+fn diagnostics(source: &str) -> Vec<Diagnostic> {
+    check_source_diagnostics(source)
+}
+
+/// True when some TS2322 carries a nested elaboration line matching `predicate`.
+fn ts2322_has_nested<P: Fn(&str) -> bool>(diags: &[Diagnostic], predicate: P) -> bool {
+    diags.iter().any(|d| {
+        d.code == 2322
+            && d.related_information
+                .iter()
+                .any(|info| predicate(&info.message_text))
+    })
+}
+
+/// Row 1 from #16513: an anonymous two-member literal union assigned to an
+/// incompatible target must elaborate the failing member structurally
+/// (`{ m: number; }`), never as the unrelated later-declared alias `U` whose
+/// body happens to reduce to the same shape.
+#[test]
+fn anonymous_union_member_elaborates_structurally_despite_unrelated_same_shaped_alias() {
+    let diags = diagnostics(
+        r#"
+declare const c1: { m: number } | { m: string };
+const y1: boolean = c1;
+type U = { m: number } | { m: number };
+declare const c2: U;
+const y2: boolean = c2;
+"#,
+    );
+    assert!(
+        ts2322_has_nested(&diags, |msg| msg.contains("{ m: number; }")
+            && msg.contains("is not assignable to type 'boolean'")),
+        "expected the anonymous member to elaborate structurally as '{{ m: number; }}', got: {diags:?}"
+    );
+    assert!(
+        !ts2322_has_nested(&diags, |msg| msg.contains("'U'")),
+        "the anonymous member must never be repainted with the unrelated alias name 'U', got: {diags:?}"
+    );
+}
+
+/// Renamed-binder control for the same shape: the unrelated alias's name and
+/// property spelling both change, and the anonymous member must still render
+/// structurally rather than picking up whichever alias happens to share its
+/// shape.
+#[test]
+fn anonymous_union_member_elaborates_structurally_with_renamed_unrelated_alias() {
+    let diags = diagnostics(
+        r#"
+declare const source: { count: number } | { count: string };
+const target: boolean = source;
+type Renamed = { count: number } | { count: number };
+declare const other: Renamed;
+const alsoTarget: boolean = other;
+"#,
+    );
+    assert!(
+        ts2322_has_nested(&diags, |msg| msg.contains("{ count: number; }")),
+        "expected the anonymous member to elaborate structurally, got: {diags:?}"
+    );
+    assert!(
+        !ts2322_has_nested(&diags, |msg| msg.contains("'Renamed'")),
+        "the anonymous member must never be repainted with the unrelated alias name, got: {diags:?}"
+    );
+}
+
+/// A genuine named-alias reference inside a union keeps its alias name in the
+/// elaboration line — this is the negative control the naive
+/// `is_literal_object_annotation`-only fix broke (falsified in #16513's
+/// 03:59Z comment): `A`'s body also marks the global literal-annotation
+/// table, so a fix that consults only that table cannot distinguish this row
+/// from the anonymous-member row above.
+#[test]
+fn named_alias_union_member_keeps_alias_name_in_elaboration() {
+    let diags = diagnostics(
+        r#"
+type A = { a: number };
+type B = { b: string };
+declare const c: A | B;
+const y: boolean = c;
+"#,
+    );
+    assert!(
+        ts2322_has_nested(&diags, |msg| msg.contains("'A'")
+            && msg.contains("is not assignable to type 'boolean'")),
+        "expected the first failing union member to keep its alias name 'A', got: {diags:?}"
+    );
+    assert!(
+        !ts2322_has_nested(&diags, |msg| msg.contains("{ a: number; }")),
+        "a named alias reference must not be expanded structurally, got: {diags:?}"
+    );
+}
+
+/// Mixed union: a named-alias member and an anonymous-literal member in the
+/// same union. The alias member keeps its name; the fix must not blanket-
+/// suppress alias names for every member once any member in the union is
+/// anonymous.
+#[test]
+fn mixed_alias_and_literal_union_members_render_independently() {
+    let diags = diagnostics(
+        r#"
+type Named = { tag: number };
+declare const c: Named | { other: string };
+const y: boolean = c;
+"#,
+    );
+    assert!(
+        ts2322_has_nested(&diags, |msg| msg.contains("'Named'")),
+        "the alias member (first, and failing) must keep its name, got: {diags:?}"
+    );
+    assert!(
+        !ts2322_has_nested(&diags, |msg| msg.contains("{ tag: number; }")),
+        "the alias member must not be expanded structurally, got: {diags:?}"
+    );
+}
+
+/// A union reached through a further alias indirection: `U2`'s own written
+/// member list still carries the real per-member provenance (a named alias
+/// reference and an anonymous literal), so aliasing the whole union under a
+/// second name must not change which member elaborates with a name and which
+/// elaborates structurally.
+#[test]
+fn union_member_provenance_survives_alias_indirection() {
+    let diags = diagnostics(
+        r#"
+type A = { a: number };
+type U2 = A | { m: string };
+declare const c: U2;
+const y: boolean = c;
+"#,
+    );
+    assert!(
+        ts2322_has_nested(&diags, |msg| msg.contains("'A'")),
+        "the aliased member must keep its name through the U2 indirection, got: {diags:?}"
+    );
+    assert!(
+        !ts2322_has_nested(&diags, |msg| msg.contains("{ a: number; }")),
+        "the aliased member must not be expanded structurally, got: {diags:?}"
+    );
+}

--- a/crates/tsz-solver/src/caches/display_provenance.rs
+++ b/crates/tsz-solver/src/caches/display_provenance.rs
@@ -115,6 +115,17 @@ pub trait TypeDisplayProvenance {
         false
     }
 
+    /// Mark `member_type_id` as an anonymous object-type literal written
+    /// directly inside the union `union_type_id`. See
+    /// `TypeInterner::mark_union_literal_member`.
+    fn mark_union_literal_member(&self, _union_type_id: TypeId, _member_type_id: TypeId) {}
+
+    /// Return whether `member_type_id` was recorded as an anonymous literal
+    /// member of the union `union_type_id`.
+    fn is_union_literal_member(&self, _union_type_id: TypeId, _member_type_id: TypeId) -> bool {
+        false
+    }
+
     /// Record the as-written origin members for a flattened `Union` `TypeId`.
     ///
     /// The checker calls this from `get_type_from_union_type` so that the
@@ -275,6 +286,14 @@ impl TypeDisplayProvenance for TypeInterner {
 
     fn is_literal_object_annotation(&self, type_id: TypeId) -> bool {
         Self::is_literal_object_annotation(self, type_id)
+    }
+
+    fn mark_union_literal_member(&self, union_type_id: TypeId, member_type_id: TypeId) {
+        Self::mark_union_literal_member(self, union_type_id, member_type_id);
+    }
+
+    fn is_union_literal_member(&self, union_type_id: TypeId, member_type_id: TypeId) -> bool {
+        Self::is_union_literal_member(self, union_type_id, member_type_id)
     }
 
     fn store_union_origin(&self, union_type_id: TypeId, origin_members: Vec<TypeId>) {

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -785,6 +785,16 @@ impl TypeDisplayProvenance for QueryCache<'_> {
         self.interner.is_literal_object_annotation(type_id)
     }
 
+    fn mark_union_literal_member(&self, union_type_id: TypeId, member_type_id: TypeId) {
+        self.interner
+            .mark_union_literal_member(union_type_id, member_type_id);
+    }
+
+    fn is_union_literal_member(&self, union_type_id: TypeId, member_type_id: TypeId) -> bool {
+        self.interner
+            .is_union_literal_member(union_type_id, member_type_id)
+    }
+
     fn store_union_origin(&self, union_type_id: TypeId, origin_members: Vec<TypeId>) {
         self.interner
             .store_union_origin(union_type_id, origin_members);

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -528,6 +528,19 @@ pub struct TypeInterner {
     /// different declaration's type. Display-only — it does not affect identity
     /// or semantics. First write wins; the membership is monotonic.
     pub(super) literal_object_annotations: DashMap<TypeId, (), FxBuildHasher>,
+    /// Per-occurrence record of which union members were written as an
+    /// anonymous object-type literal directly inside a *specific* union,
+    /// keyed by `(union_type_id, member_type_id)`.
+    ///
+    /// `literal_object_annotations` above is keyed on the member's bare
+    /// `TypeId` alone, so it cannot distinguish a genuinely anonymous member
+    /// from a named type alias whose body happens to reduce to the same
+    /// content-interned shape (`type A = { a: number }` marks the same id
+    /// `mark_literal_object_annotation` would for a hand-written `{ a: number
+    /// }` union member). This table adds the union as part of the key so a
+    /// union-member elaboration can ask "was *this* occurrence, in *this*
+    /// union, written as a literal" instead of the shape-wide question.
+    pub(super) union_literal_members: DashMap<(TypeId, TypeId), (), FxBuildHasher>,
     /// As-written origin members for a Union TypeId, used to preserve top-level
     /// alias names that would otherwise be lost during union flattening.
     ///
@@ -860,6 +873,7 @@ impl TypeInterner {
             conditional_alias_bases: DashMap::with_hasher(FxBuildHasher),
             global_this_surface_display: DashMap::with_hasher(FxBuildHasher),
             literal_object_annotations: DashMap::with_hasher(FxBuildHasher),
+            union_literal_members: DashMap::with_hasher(FxBuildHasher),
             display_union_origin: DashMap::with_hasher(FxBuildHasher),
             union_complexity_overflow_by_thread: OnceLock::new(),
             union_complexity_pending_threads: AtomicUsize::new(0),

--- a/crates/tsz-solver/src/intern/core/interner/display.rs
+++ b/crates/tsz-solver/src/intern/core/interner/display.rs
@@ -411,6 +411,39 @@ impl TypeInterner {
         self.literal_object_annotations.contains_key(&type_id)
     }
 
+    /// Record that `member_type_id` was written as an anonymous object-type
+    /// literal (`{ ... }`) directly inside the union `union_type_id`, as
+    /// opposed to a named alias/interface reference whose body happens to
+    /// reduce to the same content-interned shape.
+    ///
+    /// `is_literal_object_annotation` is keyed on the member's bare `TypeId`
+    /// alone, so it cannot tell "this member is genuinely anonymous" apart
+    /// from "this member is a named alias reference whose body coincidentally
+    /// marked the same id" — a type alias's body also runs through
+    /// `get_type_from_type_literal`, which marks that global table too. This
+    /// per-union record lets a union-member elaboration ask the narrower,
+    /// sound question instead: was *this* occurrence, in *this* union,
+    /// syntactically anonymous. Display-only.
+    pub fn mark_union_literal_member(&self, union_type_id: TypeId, member_type_id: TypeId) {
+        if union_type_id.is_intrinsic() || member_type_id.is_intrinsic() {
+            return;
+        }
+        if self
+            .union_literal_members
+            .insert((union_type_id, member_type_id), ())
+            .is_none()
+        {
+            self.advance_display_provenance_generation();
+        }
+    }
+
+    /// Whether `member_type_id` was recorded as an anonymous literal member
+    /// of the union `union_type_id`.
+    pub fn is_union_literal_member(&self, union_type_id: TypeId, member_type_id: TypeId) -> bool {
+        self.union_literal_members
+            .contains_key(&(union_type_id, member_type_id))
+    }
+
     /// Record the as-written origin members for a flattened Union TypeId.
     ///
     /// Mirrors tsc's `UnionType.origin` mechanism: when `T | null` is built and


### PR DESCRIPTION
Fixes row 1 of #16513.

`tsc` names a failing union member exactly as written in the nested `Type '<member>' is not assignable to type '<target>'.` elaboration line: an anonymous literal (`{ m: number }`) stays anonymous, a named alias reference (`A`) keeps its name. tsz's structural interner content-interns an anonymous literal and a coincidentally-shaped alias body onto the same `TypeId`, so `resolve_object_shape_name`'s structural reverse lookup could not tell "this occurrence was written as `{ ... }`" apart from "this occurrence merely has the same shape as some unrelated alias declared elsewhere in the file" — it repainted the former with the latter's name (`{ m: number } | { m: string }` elaborating as the unrelated later-declared `type U = { m: number } | { m: number }`).

**Structural rule:** when a union member fails and needs elaboration, `tsc` reads the member's own written form; tsz now does this through a new per-occurrence solver provenance table (`TypeInterner::mark_union_literal_member`/`is_union_literal_member`, keyed on `(union_type_id, member_type_id)`), populated in both `get_type_from_union_type` implementations (`tsz-checker`'s `TypeNodeChecker` and `CheckerState`'s `type_operators.rs`, the path actually used for `declare const`/type-alias annotations) at the point where the AST node per member is still visible. `render_union_source_mismatch` and `render_parent_with_child_relation` (`error_reporter/render_failure/nested_application_property_mismatch.rs`) consult this narrower record through a new `format_type_diagnostic_for_union_member` helper instead of the identity-keyed `is_literal_object_annotation` flag, which cannot distinguish the two cases because a type alias's body runs through the same literal-checking path and marks the identical global table entry whenever its shape coincides.

An earlier attempt at this fix (recorded on #16513's own thread) gated `resolve_object_shape_name` directly on `is_literal_object_annotation` and broke `union_alias_reference_target_keeps_alias_names` — a genuine `A | B` alias union repainted its members structurally, since `A`'s alias body also marks that global table. The per-union table avoids this because it records the occurrence, not the shape.

**Adjacent-case matrix** (`union_source_member_provenance_display_tests.rs`): anonymous member vs. unrelated same-shaped alias (row 1's exact repro), renamed-binder control, named alias member (negative control — the case the naive fix broke), mixed alias+literal union, and provenance surviving a further alias indirection (`type U2 = A | { m: string }`).

## Goal
Goal: hold

## Verification
- New: `cargo test -p tsz-checker --test union_source_member_provenance_display_tests` — 5/5.
- `cargo test -p tsz-checker --test anonymous_object_intersection_display_tests` — 11/11 (includes the negative control `union_alias_reference_target_keeps_alias_names` that falsified the naive fix).
- `cargo test -p tsz-checker --test union_source_missing_property_elaboration_tests --test union_target_missing_property_elaboration_tests --test intersection_target_missing_property_elaboration_tests --test union_source_structural_elaboration_tests` — 19+5+22+13 = 59/59, incl. `union_member_selection_matches_tsc_declaration_order_for_same_shaped_enums` (the sibling enum-order fix, #16537's family).
- `cargo test -p tsz-checker --lib -- union` — 669/669.
- `cargo test -p tsz-checker --lib -- union_source union_target elaboration display_alias anonymous_composite object_shape` — 228/228.
- `cargo test -p tsz-solver --lib -- union_origin literal_object display_provenance` — 19/19.
- `cargo fmt -p tsz-checker -p tsz-solver -- --check` — clean.
- `cargo clippy --profile ci-lint -p tsz-checker -p tsz-solver --all-targets -- -D warnings` (CI's exact invocation) — clean.
- `python3 scripts/arch/arch_guard.py` — passed.
- Full untargeted `cargo test -p tsz-checker --lib` — was still running at push time (long-tail stragglers per the board's known gotcha); will post the result before queuing merge.
- Not run: conformance snapshot, emit, fourslash. This is a `related_information`-only change on an existing TS2322 (no new top-level diagnostic code), so `results.py::compute_diff`'s code-set comparison cannot observe it — the same argument #16535/#16458/#16541 landed on this session for the identical fingerprinting reason. Emit is untouched: this changes diagnostic-message formatting only, not declaration/annotation typing or emitted output.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8HNrbK8YEj61Lqwju7Snu)_