### PR TITLE
fix(checker): an alias-annotated member is drilled to the arrow body, like `tsc`

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -1384,4 +1384,37 @@ impl<'a> CheckerState<'a> {
 
         None
     }
+
+    /// The expected return type governing the arrow-body drill for an object
+    /// literal member whose declared type is `ty`.
+    ///
+    /// [`Self::first_callable_return_type`] answers for a type whose callable
+    /// structure is already materialized. A member written through a type alias
+    /// (`cb: Fn` for `type Fn = () => string`) arrives as an unresolved
+    /// `TypeData::Lazy(DefId)` that it does not see through, so the drill read
+    /// "not callable" for a type `tsc` considers identical to the inline
+    /// signature and reported the `TS2322` at the property name instead of at
+    /// the offending body expression.
+    ///
+    /// The alias hop is spent on `ty` **as written** and only after the direct
+    /// probe declines. Both halves matter:
+    ///
+    /// - Resolving after the probe declines cannot change an answer it already
+    ///   gave, only add one where there was none.
+    /// - Hopping on `ty` itself rather than inside the probe keeps the hop away
+    ///   from the probe's nullish-stripping arm. An optional or explicitly
+    ///   nullable member (`cb?: Fn`, `cb: Fn | undefined`) is a union, not an
+    ///   alias, so it declines here — which is what `tsc` does: it reports the
+    ///   whole function type at the member for those, drilling neither the
+    ///   alias form nor the inline one.
+    fn callable_return_type_for_drill(&mut self, ty: TypeId) -> Option<TypeId> {
+        if let Some(found) = self.first_callable_return_type(ty) {
+            return Some(found);
+        }
+        let resolved = self.resolve_lazy_type(ty);
+        if resolved == ty {
+            return None;
+        }
+        self.first_callable_return_type(resolved)
+    }
 }

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
@@ -596,7 +596,7 @@ impl<'a> CheckerState<'a> {
                         if self.function_value_has_explicit_param_annotation(prop_value_idx) {
                             return None;
                         }
-                        let expected_ret = self.first_callable_return_type(target_prop_type)?;
+                        let expected_ret = self.callable_return_type_for_drill(target_prop_type)?;
                         if expected_ret == TypeId::VOID || expected_ret == TypeId::ANY {
                             return None;
                         }

--- a/crates/tsz-checker/src/error_reporter/expected_type_from_return.rs
+++ b/crates/tsz-checker/src/error_reporter/expected_type_from_return.rs
@@ -275,12 +275,13 @@ impl<'a> CheckerState<'a> {
     /// `(start, length, file)` of the function or constructor type `idx`
     /// denotes, peeling parentheses.
     ///
-    /// Anything else — a union, an object type, a type reference — yields no
-    /// signature of its own for tsc to point at, so it declines. A reference is
-    /// deliberately *not* followed here: the arrow-body drill this pointer hangs
-    /// off never fires for an alias-annotated member in the first place (see the
-    /// `type_reference_annotation_*` test), so a hop at this site would be
-    /// unreachable complexity on a diagnostic path.
+    /// A union or an object type yields no signature of its own for tsc to point
+    /// at, so it declines. A reference to a *type alias* is followed into the
+    /// alias body, which is where tsc underlines: for `type Fn = () => string`
+    /// and a member `cb: Fn`, tsc points at `() => string` inside `Fn`, not at
+    /// the reference. The hop stays in the checking file's own arena, so a
+    /// reference to an alias declared elsewhere declines rather than reading a
+    /// foreign `NodeIndex` against the current arena.
     fn callable_type_node_anchor(
         &mut self,
         idx: NodeIndex,
@@ -295,6 +296,12 @@ impl<'a> CheckerState<'a> {
         if node.kind == syntax_kind_ext::PARENTHESIZED_TYPE {
             let inner = self.ctx.arena.get_wrapped_type(node)?.type_node;
             return self.callable_type_node_anchor(inner, depth + 1);
+        }
+        if node.kind == syntax_kind_ext::TYPE_REFERENCE {
+            let name_idx = self.ctx.arena.get_type_ref(node)?.type_name;
+            let alias_symbol = self.type_position_symbol(name_idx)?;
+            let body_idx = self.local_type_alias_body(alias_symbol)?;
+            return self.callable_type_node_anchor(body_idx, depth + 1);
         }
         if node.kind != syntax_kind_ext::FUNCTION_TYPE
             && node.kind != syntax_kind_ext::CONSTRUCTOR_TYPE

--- a/crates/tsz-checker/src/tests/expected_type_from_return_tests.rs
+++ b/crates/tsz-checker/src/tests/expected_type_from_return_tests.rs
@@ -235,13 +235,114 @@ fn block_bodied_function_expression_keeps_the_property_pointer() {
 /// **undrilled** branch. Whatever makes that branch win for a member typed
 /// through an alias owns this row.
 #[test]
-fn type_reference_annotation_declines_because_the_arrow_body_is_never_drilled() {
+fn type_reference_annotation_anchors_inside_the_alias_body() {
     let source =
         "type Fn = () => string;\ninterface Ref { cb: Fn; }\nconst rf: Ref = { cb: () => 6 };\n";
     let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    assert_eq!(
+        diagnostic.start, 78,
+        "the TS2322 is reported at the arrow body, not the member (oracle 3:29)"
+    );
+    let (start, length, _) = return_pointer(&diagnostic);
+    assert_eq!(span_text(source, start, length), "() => string");
+    assert_eq!(start, 10, "the anchor is inside Fn's body (oracle 1:11)");
+}
+
+/// The row above with every binder renamed. A name-driven fix would move the
+/// anchor; a structural one only moves the span.
+#[test]
+fn alias_annotated_members_keep_the_anchor_rule_under_renamed_binders() {
+    let source = "type Handler = () => string;\ninterface Shape { run: Handler; }\nconst inst: Shape = { run: () => 6 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    assert_eq!(diagnostic.start, 96, "oracle 3:34");
+    let (start, length, _) = return_pointer(&diagnostic);
+    assert_eq!(span_text(source, start, length), "() => string");
+    assert_eq!(start, 15, "oracle 1:16, inside Handler's body");
+}
+
+/// An alias chain on the member: `F2` names `F1`, and tsc underlines the
+/// signature at the *end* of the chain, not the hop that named it.
+/// Oracled: `r3.ts:1:11`.
+#[test]
+fn an_alias_chain_on_the_member_is_followed_to_the_written_signature() {
+    let source = "type F1 = () => string;\ntype F2 = F1;\ninterface R3 { cb: F2; }\nconst v3: R3 = { cb: () => 6 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    assert_eq!(diagnostic.start, 90, "oracle 4:28");
+    let (start, length, _) = return_pointer(&diagnostic);
+    assert_eq!(span_text(source, start, length), "() => string");
+    assert_eq!(start, 10, "F1's signature, not F2's reference to it");
+}
+
+/// A parenthesized alias body: tsc underlines *inside* the parentheses.
+/// Oracled: `r4.ts:1:11`.
+#[test]
+fn a_parenthesized_alias_body_anchors_inside_the_parentheses() {
+    let source =
+        "type P = (() => string);\ninterface R4 { cb: P; }\nconst v4: R4 = { cb: () => 6 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    assert_eq!(diagnostic.start, 76, "oracle 3:28");
+    let (start, length, _) = return_pointer(&diagnostic);
+    assert_eq!(span_text(source, start, length), "() => string");
+    assert_eq!(start, 10);
+}
+
+/// A *generic* alias applied at the member is still not drilled — a known
+/// divergence this row pins rather than fixes, so the next session starts from
+/// a measured statement instead of re-deriving it.
+///
+/// tsc drills to the body (`r6.ts:3:28`) and anchors the pointer in the alias's
+/// own **uninstantiated** body, `() => T` at `r6.ts:1:13`, while still reporting
+/// the *instantiated* expected type in the message (`'string'`, not `'T'`).
+/// tsz reports at the member with the sibling `TS6500` instead.
+///
+/// This is deliberately out of the alias hop's reach: `G[ string ]` arrives as a
+/// type *application*, not a `Lazy(DefId)`, and following it to the alias base
+/// would hand the drill the uninstantiated `T` as the expected return type —
+/// the right anchor with the wrong message. Closing it needs the instantiated
+/// return type and the uninstantiated anchor to be sourced separately, which is
+/// a different change from alias transparency. Tracked as its own issue.
+#[test]
+fn a_generic_alias_application_is_not_drilled_and_pins_a_known_divergence() {
+    let source =
+        "type G<T> = () => T;\ninterface R6 { cb: G<string>; }\nconst v6: R6 = { cb: () => 6 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    assert_eq!(
+        diagnostic.start, 70,
+        "tsz reports at the member; tsc reports at the body (oracle 3:28 => 80)"
+    );
     assert!(
         !has_return_pointer(&diagnostic),
-        "an alias-annotated member is never drilled, so no TS6502 site is reached: {diagnostic:?}"
+        "the application declines the alias hop: {diagnostic:?}"
+    );
+}
+
+/// Alias in *both* positions — the owner is a type alias to a type literal and
+/// the member is annotated with a second alias, so the walk hops twice.
+/// Oracled: `r7.ts:1:12`.
+#[test]
+fn an_alias_owner_and_an_alias_member_are_both_followed() {
+    let source =
+        "type Fn7 = () => string;\ntype Own7 = { cb: Fn7 };\nconst v7: Own7 = { cb: () => 6 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    assert_eq!(diagnostic.start, 79, "oracle 3:30");
+    let (start, length, _) = return_pointer(&diagnostic);
+    assert_eq!(span_text(source, start, length), "() => string");
+    assert_eq!(start, 11);
+}
+
+/// Negative control: an *optional* alias-annotated member is not drilled at all
+/// — tsc reports the whole function type at the member with the sibling
+/// `TS6500` pointer, exactly as it does for an optional inline signature.
+/// Oracled: `r5.ts:3:18`, pointer `r5.ts:2:16`. The alias hop must not make the
+/// nullish member newly drillable.
+#[test]
+fn an_optional_alias_annotated_member_is_not_drilled() {
+    let source =
+        "type Fn5 = () => string;\ninterface R5 { cb?: Fn5; }\nconst v5: R5 = { cb: () => 6 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    assert!(
+        !has_return_pointer(&diagnostic),
+        "an optional member keeps the member frame: {diagnostic:?}"
     );
     assert!(
         diagnostic
@@ -249,6 +350,31 @@ fn type_reference_annotation_declines_because_the_arrow_body_is_never_drilled() 
             .iter()
             .any(|info| info.code == TS6500),
         "the TS6500 pointer is the witness that the undrilled branch ran: {diagnostic:?}"
+    );
+}
+
+/// Negative control: an explicitly annotated arrow parameter bails out of the
+/// drill before the alias hop is ever consulted, so an alias-annotated member
+/// with one still reports at the member. Oracled: `r8.ts:3:18`.
+#[test]
+fn an_annotated_parameter_still_bails_out_of_the_drill_through_an_alias() {
+    let source = "type Fn8 = (a: number) => string;\ninterface R8 { cb: Fn8; }\nconst v8: R8 = { cb: (a: number) => 6 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    assert!(
+        !has_return_pointer(&diagnostic),
+        "the annotated-parameter gate runs before the alias hop: {diagnostic:?}"
+    );
+}
+
+/// Negative control: an alias to a non-callable type yields no signature to
+/// point at, so the hop must decline rather than anchor on the alias body.
+#[test]
+fn an_alias_to_a_non_callable_type_declines_the_return_pointer() {
+    let source = "type NotFn = { a: number };\ninterface R10 { cb: NotFn; }\nconst v10: R10 = { cb: { a: \"s\" } };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    assert!(
+        !has_return_pointer(&diagnostic),
+        "a non-callable alias body carries no signature: {diagnostic:?}"
     );
 }
 


### PR DESCRIPTION
Closes #16542.

**Structural rule.** When an object-literal member's declared type is written through a type alias (`cb: Fn` for `type Fn = () => string`), `tsc`'s `elaborateArrowFunction` drills into the arrow's body and reports the `TS2322` at the offending expression, pointing `TS6502` at the signature inside the alias. tsz does the same through the checker's elaboration drill gate and its `TS6502` annotation walk.

This is a **reporting-frame** divergence on the primary diagnostic, not a pointer gap. Before this change the error landed on the property name (`cb`) instead of the body expression (`6`); the `TS6500`/`TS6502` swap was only its most visible symptom. Any object literal whose member is typed through an alias and whose arrow body returns the wrong type was affected.

> Type-parameter lists below are written with spaces inside the brackets (`G< string >`) — this tracker strips real ones. The in-repo tests carry the runnable source.

### Why it happened

A type alias mints no distinct type in `tsc` — `type Fn = () => string` and a written `() => string` are the same type object. In tsz the member arrives as an unresolved `TypeData::Lazy(DefId)`, and none of `first_callable_return_type`'s five structural probes see through it, so the drill gate read "not callable" and fell to the member frame. Confirmed as probe 2 (`elaboration_object_properties.rs:599`), as #16542 predicted; the `VOID`/`ANY` early-out is not involved.

### Owner layer — two halves

- **`callable_return_type_for_drill`** (`error_reporter/call_errors/elaboration.rs`) spends one lazy hop on the member type **as written**, and only after the direct probe declines.
- **`callable_type_node_anchor`** (`error_reporter/expected_type_from_return.rs`) follows a type-reference annotation into the alias body for the pointer anchor. This hop was written and removed in #16541 as unreachable — it was unreachable only because the drill above never fired. The premise was wrong, not the code; the doc comment stating it has been rewritten.

Both placement choices are load-bearing:

- Resolving **after** the direct probe declines means the hop can add a signature where there was none but can never change one it already found.
- Hopping on the written type rather than **inside** the shared probe keeps it away from that probe's nullish-stripping arm. My first version put it inside, and the optional-member negative control caught the regression:

| member | `tsc` |
|---|---|
| `cb: Fn` | drills to body, `TS6502` inside `Fn` |
| `cb?: Fn` | **no drill** — whole function type at the member, `TS6500` |
| `cb: Fn \| undefined` | **no drill** |
| `cb?: () => string` (inline) | **no drill** — so this is about the union, not the alias |

A union is not an alias and must decline. Siting the hop at the drill gate also leaves `first_callable_return_type`'s three other callers and `first_callable_param_count` byte-for-byte untouched.

### Deliberately not fixed: the generic form

`cb: G< string >` arrives as a type *application*, not a `Lazy`, so it declines here and is identical before and after this change (verified by running the row, not assumed). Following the application to its alias base **does** make the drill fire and anchors the pointer correctly, but hands the drill the uninstantiated `T` as the expected return type, so the message reads `'T'` where `tsc` says `'string'` — a worse diagnostic than today's. It needs the instantiated return type and the uninstantiated anchor sourced separately. Pinned here as a negative control carrying its oracle values, and filed as **#16548**.

### Adjacent-case matrix

Every row oracled against pinned `typescript@7.0.2` (`scripts/conformance/typescript-versions.json`) **before** any code was written, per the board's standing "a pinned test is not oracle evidence" gotcha.

Positive: witness; renamed binders; member alias chain (`F2` names `F1`, anchor at `F1`); parenthesized alias body (anchor *inside* the parens); alias in owner **and** member position (two hops).
Negative: optional member; explicitly annotated arrow parameter (the existing gate runs first); non-callable alias body; generic application.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib expected_type_from_return` — **26/26** (was 18/18 with one row asserting the old behaviour).
- **Non-vacuity measured**, not argued: applying the test file alone onto the parent with the three src files stashed leaves **5 of the new rows red** (witness, renamed binders, member alias chain, parenthesized alias body, alias owner + alias member). The four negative controls correctly pass at parent — they pin unchanged behaviour.
- `cargo fmt --all` — clean, no reformatting.
- Full `cargo test -p tsz-checker --lib` — running at PR-open time on this 4-core cloud seat (the documented long-tail straggler behaviour); result posted as a comment when it lands, and this PR is not queued for merge until it is green.
- `clippy` — CI's own invocation; `cargo-nextest` is absent in these containers, so `cargo test` is the substitute.
- **`compare-to-parent.sh` owed and disclosed.** Argued low-risk, not measured: the diff touches only `crates/tsz-checker/src/error_reporter/**`, emits no new diagnostic code, and changes no diagnostic count — it moves where one existing `TS2322` anchors and which pointer it carries. `results.py::compute_diff` grades codes, so zero conformance movement is the expected signature for this family (the board's standing note, and the measured outcome for #16535/#16541/#16451). Emit is untouched by construction: no `crates/tsz-emitter` path in the diff. A faster seat should still discharge the two-sided run rather than trust this.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Sunstone