### PR TITLE
fix(checker): TS2728 declared-here pointer descends through an array member's element type

### DIFF
--- a/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
+++ b/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
@@ -239,6 +239,17 @@ impl<'a> CheckerState<'a> {
             let member_type_idx = self.annotation_member_type_node(object_idx, &key, depth)?;
             return self.annotation_property_anchor(member_type_idx, property, depth + 1);
         }
+        if node.kind == syntax_kind_ext::ARRAY_TYPE {
+            // `T[]` and `T` describe the same element shape at every index, so
+            // tsc anchors a missing-property pointer for an array-element
+            // literal inside the element type exactly as it would for a bare
+            // `T`-typed member. The array itself contributes no path segment
+            // (`contextual_property_path` already skips over
+            // `ARRAY_LITERAL_EXPRESSION` without pushing a name), so this is a
+            // plain descent into the element type, not a new path step.
+            let element_idx = self.ctx.arena.get_array_type(node)?.element_type;
+            return self.annotation_property_anchor(element_idx, property, depth + 1);
+        }
         None
     }
 

--- a/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
+++ b/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
@@ -1037,19 +1037,55 @@ fn computed_path_member_declines_rather_than_anchoring_shallow() {
 }
 
 /// A literal nested inside an *array* member: the path reaches the member's
-/// written type node, but that node is an array type rather than a type
-/// literal, so the leaf resolution declines. tsc anchors this row
-/// (`matrix.ts:13:34`); pinned as a decline so the remaining gap is visible and
-/// cannot silently become a wrong anchor.
+/// written type node, and `annotation_property_anchor` descends through the
+/// array type's own element type to anchor at the missing property inside it.
+/// `T[]` and `T` describe the same shape at every index, so no path segment is
+/// consumed by the array itself. Oracle: `case.ts:1:34 - 'lq' is declared
+/// here.`
 #[test]
-fn array_element_literal_declines_rather_than_anchoring_wrongly() {
+fn array_element_literal_anchors_through_the_element_type() {
     let source = "type Arr = { list: { lp: number; lq: number }[] };\nconst ra: Arr = { list: [{ lp: 1 }] };\n";
     let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "lq");
+}
+
+/// Renamed binders: the array-element anchor must not depend on the
+/// particular identifiers chosen above, only on the structural shape.
+/// Oracle: `case.ts:2:43 - 'beta' is declared here.`
+#[test]
+fn array_element_literal_anchor_is_not_identifier_keyed() {
+    let source = "type Roster = { members: { alpha: string; beta: string }[] };\nconst r: Roster = { members: [{ alpha: \"a\" }] };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "beta");
+}
+
+/// The array's element type can itself be a named alias rather than an inline
+/// type literal; the existing alias-chain fallback in
+/// `annotation_property_anchor` composes with the new array-type descent with
+/// no further change. Oracle: `case.ts:1:27 - 'lq' is declared here.` (inside
+/// `Item`'s own body, not the array member's).
+#[test]
+fn array_element_named_alias_anchors_in_the_alias_body() {
+    let source = "type Item = { lp: number; lq: number };\ntype ArrOfAlias = { list: Item[] };\nconst ra: ArrOfAlias = { list: [{ lp: 1 }] };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "lq");
+}
+
+/// Negative control: more than one unmatched property inside an array element
+/// is `TS2739`, which — same as the non-array nested case — carries no
+/// `'x' is declared here.` pointer at all.
+#[test]
+fn array_element_multi_property_failure_still_carries_no_pointer() {
+    let source = "type Multi = { list: { m1: number; m2: number; m3: number }[] };\nconst rm: Multi = { list: [{ m1: 1 }] };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2739);
     assert!(
         !diagnostic
             .related_information
             .iter()
             .any(|info| info.code == TS2728),
-        "an array-typed member produces no anchor at all: {diagnostic:?}"
+        "TS2739 carries no declared-here pointer: {diagnostic:?}"
     );
 }


### PR DESCRIPTION
When a `TS2741` "missing property" failure sits inside an object literal that is itself an element of an **array-typed** member (`type Arr = { list: { lp: number; lq: number }[] }`), `tsc`'s `reportUnmatchedProperty` still anchors the `TS2728` `'x' is declared here.` pointer inside the array's element type — `T[]` and `T` describe the same shape at every index. tsz's `annotation_property_anchor` walk (`crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs`) handled `PARENTHESIZED_TYPE` / `TYPE_LITERAL` / `TYPE_REFERENCE` / `INDEXED_ACCESS_TYPE` but had no case for `ARRAY_TYPE`, so it fell through to `None` and the pointer silently declined instead of anchoring.

**Structural rule:** when a nested-object-literal `TS2741` failure's syntactic path leads through an array-typed member, `tsc` anchors `TS2728` inside the array's element type; tsz now does this through `annotation_property_anchor`'s new `ARRAY_TYPE` arm, which descends into `ArrayTypeData::element_type` and recurses.

This closes the "array-element literal" row of #16443's declared-here pointer family — the row Serpentine's 2026-08-06T01:15:23Z comment on that issue left explicitly unclaimed, having already scoped it as "a small, contained extension of `annotation_property_anchor`". No other row of that issue is touched.

`contextual_property_path` already skips over `ARRAY_LITERAL_EXPRESSION` without pushing a path segment (array elements are positional, not named), so this required no change on the path-walk side — only the leaf-type descent. The fix also composes for free with the existing alias-chain fallback: an array whose element type is a named alias (`type Item = {...}; type Arr = { list: Item[] }`) already anchors correctly through `local_type_alias_body`, verified by a new adjacent test.

## Goal
Goal: hold

## Verification
- New tests in `crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs`: positive case (basic array-element anchor), renamed-binder control (not identifier-keyed), named-alias element type (alias-chain composition), and a `TS2739` multi-property negative control (no pointer, matching the non-array nested case).
- All four rows oracle-verified byte-exact against pinned `typescript@7.0.2` before writing the fix (`case.ts:1:34` on `lq`, `case2.ts:2:43` on `beta`, `case2.ts:6:27` on `lq` inside the alias body, and the `TS2739` row carries no related-information line).
- `cargo test -p tsz-checker --lib -- missing_property_declared_here`: **52/52** (48 pre-existing + 4 new), 0 regressed.
- `cargo clippy -p tsz-checker --lib --tests -- -D warnings`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.
- `cargo fmt -p tsz-checker -- --check`: clean.
- Full `cargo test -p tsz-checker --lib` was still running past the 25+ minute long-tail mark at PR-open time (a documented straggler-suite behavior on this seat, not a suspicious result) — will report a comment when it finishes. The targeted filter above is strong positive evidence for a change scoped to one file pair.
- `compare-to-parent.sh` / conformance snapshot not run this session (time budget) — this is a display/pointer-only change (`related_information` on an existing `TS2741`), and the board's standing note is that zero conformance movement is the expected signature for this class of fix (multiple sibling PRs in the same #16443 family recorded `compare-to-parent 0/0`). Flagging as owed if anyone wants the two-sided confirmation before landing.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: Citrine

---
_Generated by [Claude Code](https://claude.ai/code/session_01FjcpdHuwFbDcDj9tsiSshK)_