### PR TITLE
fix(checker): a colliding `import =` group resolves only its first specifier (#16527 item 2)

### DIFF
--- a/crates/tsz-checker/src/declarations/import/context_helpers.rs
+++ b/crates/tsz-checker/src/declarations/import/context_helpers.rs
@@ -376,7 +376,108 @@ impl<'a> CheckerState<'a> {
         }
         let top_level_block = self.position_invalid_module_element_resolves_specifier(node_idx);
         let is_module = self.ctx.is_external_module_file();
+
+        // A colliding `import x = ...` group (same name, same container — the
+        // TS2300 duplicate set) resolves at most one specifier. Each alias binds
+        // its own distinct `SymbolId` (aliases never merge, so the duplicate
+        // diagnostics survive), and `tsc` reaches `resolveExternalModuleName`
+        // only for the group's *first* declaration by source position; every
+        // later duplicate is silent. Both the script top-level-block auto-resolve
+        // and the reference test therefore apply to the first declaration alone,
+        // and the reference test spans the whole group's symbols (measured
+        // against the pinned `typescript@7.0.2` oracle; #16527 item 2).
+        //
+        // A namespace body reaches TS2307 through a *separate* module-not-found
+        // gate (`should_emit_module_not_found` via
+        // `namespace_import_alias_is_referenced`, interleaved with the TS1147
+        // rule), not this one, so the group gate stays out of that subsystem
+        // rather than double-gating it.
+        if !self.is_inside_namespace_declaration(node_idx)
+            && let Some(group) = self.import_equals_colliding_group(node_idx)
+        {
+            if group.first() != Some(&node_idx) {
+                return false;
+            }
+            return (top_level_block && !is_module)
+                || self.import_equals_group_is_referenced(&group);
+        }
+
         (top_level_block && !is_module) || self.import_element_alias_is_referenced(node_idx)
+    }
+
+    /// Whether any member of a colliding `import x = ...` group is *referenced* —
+    /// a genuine value/type use of any of the group's alias symbols, anywhere in
+    /// the source file. The scan skips binding names (`markAliasReferenced` never
+    /// fires on the name that declares a symbol), which is essential here: every
+    /// member's own binding name resolves to a group symbol, so without that
+    /// guard a group would always count itself referenced.
+    fn import_equals_group_is_referenced(&self, group: &[NodeIndex]) -> bool {
+        let symbols: Vec<tsz_binder::SymbolId> = group
+            .iter()
+            .flat_map(|&member| self.import_binding_symbols(member))
+            .collect();
+        if symbols.is_empty() {
+            return false;
+        }
+        let Some(scan_root) = self.enclosing_source_file(group[0]) else {
+            return false;
+        };
+        self.subtree_has_reference(scan_root, &symbols, true, None)
+    }
+
+    /// Whether any identifier under `scan_root` is a genuine *reference* to one
+    /// of `symbols` — the shared `markAliasReferenced` scan.
+    ///
+    /// `skip_binding_names` rejects declaration-name positions; the colliding
+    /// group needs it because every member's own binding name resolves to a
+    /// group symbol, so a group would otherwise count itself referenced. The
+    /// single-alias caller instead prunes its own declaration subtree via
+    /// `skip_node` (only the alias's own binding name lives there, and the
+    /// module reference is not an alias symbol), so it leaves the flag off.
+    fn subtree_has_reference(
+        &self,
+        scan_root: NodeIndex,
+        symbols: &[tsz_binder::SymbolId],
+        skip_binding_names: bool,
+        skip_node: Option<NodeIndex>,
+    ) -> bool {
+        let mut stack: Vec<NodeIndex> = self.ctx.arena.get_children(scan_root);
+        while let Some(current) = stack.pop() {
+            if Some(current) == skip_node {
+                continue;
+            }
+            if let Some(node) = self.ctx.arena.get(current)
+                && node.kind == SyntaxKind::Identifier as u16
+                && !(skip_binding_names && self.is_declaration_name_position(current))
+                && self
+                    .resolve_identifier_symbol(current)
+                    .is_some_and(|sym| symbols.contains(&sym))
+            {
+                return true;
+            }
+            stack.extend(self.ctx.arena.get_children(current));
+        }
+        false
+    }
+
+    /// The `SourceFile` node enclosing `node_idx`, walking the parent chain.
+    fn enclosing_source_file(&self, node_idx: NodeIndex) -> Option<NodeIndex> {
+        let mut cursor = node_idx;
+        loop {
+            if self
+                .ctx
+                .arena
+                .get(cursor)
+                .is_some_and(|node| node.kind == syntax_kind_ext::SOURCE_FILE)
+            {
+                return Some(cursor);
+            }
+            let ext = self.ctx.arena.get_extended(cursor)?;
+            if ext.parent.is_none() {
+                return None;
+            }
+            cursor = ext.parent;
+        }
     }
 
     /// Whether an import statement introduces a local binding: an `import =`
@@ -450,45 +551,11 @@ impl<'a> CheckerState<'a> {
         if symbols.is_empty() {
             return false;
         }
-
-        let mut scan_root = node_idx;
-        loop {
-            if self
-                .ctx
-                .arena
-                .get(scan_root)
-                .is_some_and(|node| node.kind == syntax_kind_ext::SOURCE_FILE)
-            {
-                break;
-            }
-            let Some(ext) = self.ctx.arena.get_extended(scan_root) else {
-                return false;
-            };
-            if ext.parent.is_none() {
-                return false;
-            }
-            scan_root = ext.parent;
-        }
-
-        let mut stack: Vec<NodeIndex> = self.ctx.arena.get_children(scan_root);
-        while let Some(current) = stack.pop() {
-            // The declaration's own subtree is the binding site, not a use.
-            if current == node_idx {
-                continue;
-            }
-            let Some(node) = self.ctx.arena.get(current) else {
-                continue;
-            };
-            if node.kind == SyntaxKind::Identifier as u16
-                && self
-                    .resolve_identifier_symbol(current)
-                    .is_some_and(|sym| symbols.contains(&sym))
-            {
-                return true;
-            }
-            stack.extend(self.ctx.arena.get_children(current));
-        }
-        false
+        let Some(scan_root) = self.enclosing_source_file(node_idx) else {
+            return false;
+        };
+        // The declaration's own subtree is the binding site, not a use.
+        self.subtree_has_reference(scan_root, &symbols, false, Some(node_idx))
     }
 
     /// Whether a position-invalid `export ... from "m"` still resolves its module

--- a/crates/tsz-checker/src/declarations/import/import_alias_duplicates.rs
+++ b/crates/tsz-checker/src/declarations/import/import_alias_duplicates.rs
@@ -162,25 +162,11 @@ impl<'a> CheckerState<'a> {
         }
 
         for stmt_idx in collected {
-            let Some(node) = self.ctx.arena.get(stmt_idx) else {
+            // `collect_import_equals_transparently` yields only `import =` nodes.
+            let Some(alias_name) = self.import_equals_alias_name(stmt_idx) else {
                 continue;
             };
-
-            let Some(import_decl) = self.ctx.arena.get_import_decl(node) else {
-                continue;
-            };
-
-            let Some(alias_node) = self.ctx.arena.get(import_decl.import_clause) else {
-                continue;
-            };
-            let Some(alias_id) = self.ctx.arena.get_identifier(alias_node) else {
-                continue;
-            };
-
-            alias_map
-                .entry(alias_id.escaped_text.to_string())
-                .or_default()
-                .push(stmt_idx);
+            alias_map.entry(alias_name).or_default().push(stmt_idx);
         }
 
         for (alias_name, indices) in alias_map {
@@ -243,6 +229,59 @@ impl<'a> CheckerState<'a> {
             cursor = self.ctx.arena.parent_of(cursor)?;
         }
         None
+    }
+
+    /// The alias name an `import X = ...` declaration binds, or `None` for a
+    /// non-alias node.
+    fn import_equals_alias_name(&self, idx: NodeIndex) -> Option<String> {
+        let node = self.ctx.arena.get(idx)?;
+        if node.kind != syntax_kind_ext::IMPORT_EQUALS_DECLARATION {
+            return None;
+        }
+        let import_decl = self.ctx.arena.get_import_decl(node)?;
+        let alias_node = self.ctx.arena.get(import_decl.import_clause)?;
+        let alias_id = self.ctx.arena.get_identifier(alias_node)?;
+        Some(alias_id.escaped_text.to_string())
+    }
+
+    /// Every `import X = ...` declaration that collides with the one at
+    /// `node_idx` — same alias name, same nearest declaration container — as a
+    /// group of two or more, or `None` when `node_idx` is not a colliding alias.
+    ///
+    /// This is the grouping [`Self::check_import_alias_duplicates`] and
+    /// [`Self::check_import_alias_duplicates_in_nested_containers`] key TS2300
+    /// on, reused from the specifier-resolution side: `tsc` resolves at most one
+    /// specifier per colliding group (the first declaration by source position),
+    /// because each alias binds its own distinct `SymbolId` and only the group's
+    /// first reaches `resolveExternalModuleName`. Returned in source-position
+    /// order so the caller can identify that first declaration.
+    pub(crate) fn import_equals_colliding_group(
+        &self,
+        node_idx: NodeIndex,
+    ) -> Option<Vec<NodeIndex>> {
+        // Name first: it short-circuits (and skips the container parent-walk) for
+        // a non-`import =` node, the common caller.
+        let name = self.import_equals_alias_name(node_idx)?;
+        let container = self.nearest_alias_container(node_idx)?;
+
+        let mut group: Vec<NodeIndex> = self
+            .ctx
+            .arena
+            .nodes
+            .iter()
+            .enumerate()
+            .filter(|(_, node)| node.kind == syntax_kind_ext::IMPORT_EQUALS_DECLARATION)
+            .map(|(raw, _)| NodeIndex(raw as u32))
+            // Name match (a few arena reads) before the container parent-walk.
+            .filter(|&idx| self.import_equals_alias_name(idx).as_deref() == Some(name.as_str()))
+            .filter(|&idx| self.nearest_alias_container(idx) == Some(container))
+            .collect();
+
+        if group.len() <= 1 {
+            return None;
+        }
+        group.sort_by_key(|&idx| self.ctx.arena.get(idx).map(|n| n.pos).unwrap_or(u32::MAX));
+        Some(group)
     }
 
     /// TS2300 for duplicate `import X = ...` aliases inside a function-like

--- a/crates/tsz-checker/src/types/type_checking/unused.rs
+++ b/crates/tsz-checker/src/types/type_checking/unused.rs
@@ -1295,7 +1295,11 @@ impl<'a> CheckerState<'a> {
             .is_some_and(|sym_id| sym_id != target_sym_id)
     }
 
-    fn is_declaration_name_position(&self, idx: NodeIndex) -> bool {
+    /// Whether `idx` is the *binding name* of its parent declaration — a name in
+    /// a declaration position rather than a reference. Covers every declaration
+    /// [`Self::get_declaration_name_node`] names, plus type parameters and
+    /// property/method signatures whose name field it does not.
+    pub(crate) fn is_declaration_name_position(&self, idx: NodeIndex) -> bool {
         let Some(ext) = self.ctx.arena.get_extended(idx) else {
             return false;
         };

--- a/crates/tsz-checker/tests/position_invalid_import_equals_container_scope_tests.rs
+++ b/crates/tsz-checker/tests/position_invalid_import_equals_container_scope_tests.rs
@@ -378,36 +378,22 @@ fn nested_block_referenced_alias_inside_static_block_resolves_the_specifier() {
     );
 }
 
-// #16527 item 2 (colliding aliases inside a static block) is a real, still
-// open, oracle-confirmed defect — the row below stays red. It is deeper than
-// "skip a sibling declaration's own subtree": each `import x = ...` alias
-// binds its own distinct `SymbolId` (aliases deliberately do not merge,
-// `crates/tsz-binder/src/nodes/binding.rs` around the `ALIAS && ALIAS` branch
-// of `declare_symbol`), and only the *first* declaration for a colliding name
-// ever reaches `resolveExternalModuleName` in `tsc` — verified with the
-// pinned oracle:
-//
-// - 2/3 colliding aliases, no reference: no specifier ever resolves.
-// - 2/3 colliding aliases, one explicit reference: only the *first*
-//   declaration's specifier resolves (`TS2307` lands on its position, not the
-//   later duplicates' — confirmed by column offset).
-// - Even the "unused resolves in a script's top-level block" row (#16505) is
-//   suppressed once a name collides — a bare top-level block with two
-//   colliding aliases and no reference at all resolves neither, where a
-//   single non-colliding alias in the same position would resolve.
-//
-// A correct fix needs a first-declaration-in-group gate plus a group-wide
-// (not single-symbol) reference scan, and the full unused/script/module axis
-// re-measured under collision — scoped as its own session rather than
-// folded into this one.
+// #16527 item 2 (colliding `import x = ...` aliases) — now fixed. Each alias
+// binds its own distinct `SymbolId` (aliases deliberately do not merge, so the
+// duplicate diagnostics survive — `ALIAS && ALIAS` branch of `declare_symbol`
+// in `crates/tsz-binder/src/nodes/binding.rs`), and `tsc` reaches
+// `resolveExternalModuleName` for at most the group's *first* declaration by
+// source position. `position_invalid_import_resolves_specifier` gates on
+// `import_equals_colliding_group`: a non-first member never resolves, and the
+// first resolves under the ordinary rule with a *group-wide* reference scan.
+// The whole matrix below is measured against the pinned `typescript@7.0.2`
+// oracle (`--singleThreaded --stableTypeOrdering`, `--module commonjs`); this
+// `check` runs a script (no top-level `import`/`export`).
+
 #[test]
-#[ignore = "#16527 item 2: still open. Each colliding `import x = ...` alias binds its own \
-     distinct SymbolId (aliases deliberately do not merge), so a naive own-subtree skip \
-     cannot see a sibling duplicate as a binding site — the sibling's own name resolves \
-     through scope shadowing to whichever declaration is currently live, not to its \
-     originally-bound symbol. A real fix needs a first-declaration-in-group gate plus a \
-     group-wide reference scan; see the module comment above this test."]
 fn static_block_two_colliding_aliases_do_not_resolve_the_specifier() {
+    // Static block is not a top-level block, and neither alias is used, so the
+    // first declaration resolves nothing either — the group is silent.
     assert_codes(
         r#"class E {
   static {
@@ -416,7 +402,78 @@ fn static_block_two_colliding_aliases_do_not_resolve_the_specifier() {
   }
 }"#,
         &[1232, 1232, 2300, 2300],
-        "#16450: the duplicate-alias TS2300 pair (#16437) rides along, but neither specifier resolves",
+        "#16527: an unused colliding group in a static block resolves no specifier",
+    );
+}
+
+#[test]
+fn static_block_colliding_aliases_used_resolves_only_the_first() {
+    // A genuine reference marks the group referenced, so its *first* declaration
+    // resolves — exactly one TS2307, on `nonexistent-a`, never the duplicate.
+    assert_codes(
+        r#"class E {
+  static {
+    import victor = require("nonexistent-a");
+    import victor = require("nonexistent-b");
+    victor;
+  }
+}"#,
+        &[1232, 1232, 2300, 2300, 2307],
+        "#16527: a referenced colliding group resolves only its first declaration",
+    );
+}
+
+#[test]
+fn top_level_block_colliding_aliases_unused_resolves_only_the_first_in_a_script() {
+    // A script's top-level bare block resolves a bound-but-unused alias (#16505),
+    // but under a collision only the *first* declaration rides that rule.
+    assert_codes(
+        r#"{
+  import xray = require("nonexistent-a");
+  import xray = require("nonexistent-b");
+}"#,
+        &[1232, 1232, 2300, 2300, 2307],
+        "#16527: only the first of a colliding group takes the script top-level-block auto-resolve",
+    );
+}
+
+#[test]
+fn top_level_block_three_colliding_aliases_unused_resolves_only_the_first_in_a_script() {
+    assert_codes(
+        r#"{
+  import yankee = require("nonexistent-a");
+  import yankee = require("nonexistent-b");
+  import yankee = require("nonexistent-c");
+}"#,
+        &[1232, 1232, 1232, 2300, 2300, 2300, 2307],
+        "#16527: a three-way collision still resolves exactly one specifier — the first",
+    );
+}
+
+#[test]
+fn function_body_colliding_aliases_unused_resolves_none() {
+    // A function body is neither a top-level block nor referenced here, so the
+    // group is silent — the collision does not change that.
+    assert_codes(
+        r#"function f() {
+  import zulu = require("nonexistent-a");
+  import zulu = require("nonexistent-b");
+}"#,
+        &[1232, 1232, 2300, 2300],
+        "#16527: an unused colliding group in a function body resolves nothing",
+    );
+}
+
+#[test]
+fn function_body_colliding_aliases_used_resolves_only_the_first() {
+    assert_codes(
+        r#"function f() {
+  import alfa = require("nonexistent-a");
+  import alfa = require("nonexistent-b");
+  alfa;
+}"#,
+        &[1232, 1232, 2300, 2300, 2307],
+        "#16527: a referenced colliding group in a function body resolves only its first",
     );
 }
 

--- a/crates/tsz-checker/tests/position_invalid_module_element_module_axis_tests.rs
+++ b/crates/tsz-checker/tests/position_invalid_module_element_module_axis_tests.rs
@@ -226,6 +226,36 @@ fn used_import_equals_in_top_level_block_resolves_in_a_module() {
 }
 
 // ---------------------------------------------------------------------------
+// Colliding `import x = ...` aliases (#16527 item 2): a group resolves at most
+// one specifier — the first declaration by source position — and the module
+// axis still gates the first. In a module there is no top-level-block
+// auto-resolve, so an unused colliding group resolves nothing; a referenced one
+// resolves only its first. Measured against the pinned oracle.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn colliding_import_equals_unused_in_top_level_block_resolves_none_in_a_module() {
+    assert_codes(
+        &format!(
+            r#"{MODULE}{{ import x = require("nonexistent-a"); import x = require("nonexistent-b"); }}"#
+        ),
+        &[1232, 1232, 2300, 2300],
+        "a module has no top-level-block auto-resolve, so an unused colliding group is silent",
+    );
+}
+
+#[test]
+fn colliding_import_equals_used_in_top_level_block_resolves_only_first_in_a_module() {
+    assert_codes(
+        &format!(
+            r#"{MODULE}{{ import x = require("nonexistent-a"); import x = require("nonexistent-b"); x; }}"#
+        ),
+        &[1232, 1232, 2300, 2300, 2307],
+        "a referenced colliding group resolves only its first declaration in a module too",
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Side-effect `import "m"`: binds no name, so it never resolves in a wrong
 // context (script or module) — only at a valid position.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #16527 item 2 (the colliding-`import =` defect the maintainer left `#[ignore]`d with a full oracle write-up).

**Structural rule.** When two or more `import x = ...` aliases collide on one name in one declaration container (the TS2300 duplicate set), `tsc` reaches `resolveExternalModuleName` for **at most the group's first declaration by source position** — every later duplicate is silent, and the "script top-level block resolves a bound-but-unused alias" rule (#16505) is suppressed for non-first members. tsz resolved each member independently and counted a *sibling's binding name* as a use, so an unused colliding group emitted a spurious `TS2307` (and a used group could resolve the wrong module).

tsz now owns this through `position_invalid_import_resolves_specifier` (checker import-side demand model): it gates on `import_equals_colliding_group` (reusing the TS2300 container/name grouping in `import_alias_duplicates.rs`). A non-first member never resolves; the first resolves under the ordinary rule with a **group-wide** reference scan that skips binding names (`markAliasReferenced` never fires on a name that declares a symbol). A namespace body reaches `TS2307` through its own separate `should_emit_module_not_found` gate and is deliberately excluded rather than double-gated.

The single-alias and group reference scans were unified into one `subtree_has_reference` primitive; the SourceFile parent-walk was extracted to `enclosing_source_file`.

**Adjacent matrix** (all measured against the pinned oracle): static block, function body, script top-level bare block, and the module axis; 2- and 3-way collisions; unused (no member resolves, except the first in a script top-level block) vs referenced (only the first resolves).

## Goal
Goal: hold

## Verification
- `scripts/conformance/oracle.sh` (pinned `typescript@7.0.2`, `--singleThreaded --stableTypeOrdering`) used to derive every expectation in the two test files (which container / which module resolves, by column).
- `cargo test -p tsz-checker --test position_invalid_import_equals_container_scope_tests` — 28 passed (6 new colliding-group rows; the previously `#[ignore]`d row is live).
- `cargo test -p tsz-checker --test import_equals_alias_duplicate_container_tests --test import_equals_alias_duplicate_function_container_tests --test position_invalid_import_specifier_resolution_tests` — 9 + 16 + 21 passed.
- `cargo test -p tsz-checker --lib` covering `position_invalid_module_element_module_axis` / `*_specifier_resolution` / `import_equals_referenced_alias_resolution` — 84 passed (2 new module-axis collide rows).
- Full `cargo test -p tsz-checker --lib` — 9950 passed, 0 failed. `cargo clippy -p tsz-checker --lib` clean. `scripts/architecture-check.sh` — 0 LOC violations, 0 cross-layer imports.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xfbaz2tWpeM5s5aGKuNgw5)_