### PR TITLE
fix(checker): TS2728 declared-here pointer descends through array-like member spellings (#16552)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
+++ b/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
@@ -219,18 +219,40 @@ impl<'a> CheckerState<'a> {
             return Some((start, length, Self::arena_file_name(arena, anchor_idx)));
         }
         if node.kind == syntax_kind_ext::TYPE_REFERENCE {
-            let name_idx = self.ctx.arena.get_type_ref(node)?.type_name;
-            let owner_symbol = self.type_position_symbol(name_idx)?;
-            if let Some(anchor) =
-                self.member_declaration_anchor_following_aliases(owner_symbol, property)
-            {
-                return Some(anchor);
+            let type_ref = self.ctx.arena.get_type_ref(node)?;
+            let name_idx = type_ref.type_name;
+            let type_arguments = type_ref
+                .type_arguments
+                .as_ref()
+                .map(|list| list.nodes.clone());
+            if let Some(owner_symbol) = self.type_position_symbol(name_idx) {
+                if let Some(anchor) =
+                    self.member_declaration_anchor_following_aliases(owner_symbol, property)
+                {
+                    return Some(anchor);
+                }
+                // An alias chain (`type Indirect = Zed`) declares no member list of
+                // its own, so the walk above finds nothing to anchor in. Continue
+                // through the alias body, which is itself annotation syntax.
+                if let Some(body_idx) = self.local_type_alias_body(owner_symbol)
+                    && let Some(anchor) =
+                        self.annotation_property_anchor(body_idx, property, depth + 1)
+                {
+                    return Some(anchor);
+                }
             }
-            // An alias chain (`type Indirect = Zed`) declares no member list of
-            // its own, so the walk above finds nothing to anchor in. Continue
-            // through the alias body, which is itself annotation syntax.
-            let body_idx = self.local_type_alias_body(owner_symbol)?;
-            return self.annotation_property_anchor(body_idx, property, depth + 1);
+            // The reference itself declares no `property`, so look in what it is
+            // parameterized by: `Array<T>` and `ReadonlyArray<T>` hold the written
+            // element shape in a type argument exactly as `T[]` holds it in its
+            // element type, and `tsc` anchors there identically.
+            //
+            // This is deliberately not keyed to the global array types. The
+            // question the walk answers is "where is `property` written?", and a
+            // type argument is the only place left to look once the reference's
+            // own members and alias body have declined — so any generic wrapper
+            // is served by the same rule, and a user-declared `Array` needs no
+            // special case. See the anti-hardcoding gate in `.claude/CLAUDE.md`.
+            return self.unique_type_argument_anchor(type_arguments?.as_slice(), property, depth);
         }
         if node.kind == syntax_kind_ext::INDEXED_ACCESS_TYPE {
             let data = self.ctx.arena.get_indexed_access_type(node)?;
@@ -250,7 +272,44 @@ impl<'a> CheckerState<'a> {
             let element_idx = self.ctx.arena.get_array_type(node)?.element_type;
             return self.annotation_property_anchor(element_idx, property, depth + 1);
         }
+        if node.kind == syntax_kind_ext::TYPE_OPERATOR {
+            let data = self.ctx.arena.get_type_operator(node)?;
+            // `readonly T[]` describes the same element shape as `T[]`, so the
+            // operator contributes no path segment and the walk descends into
+            // its operand. `keyof`/`unique` are *not* transparent this way —
+            // `keyof T` denotes T's keys, not T — so they decline here.
+            if data.operator != tsz_scanner::SyntaxKind::ReadonlyKeyword as u16 {
+                return None;
+            }
+            let operand_idx = data.type_node;
+            return self.annotation_property_anchor(operand_idx, property, depth + 1);
+        }
         None
+    }
+
+    /// The anchor for `property` in exactly one of `type_arguments`.
+    ///
+    /// Declines when two arguments both declare `property`: the walk has no
+    /// basis to pick between them, and pointing at the wrong one is worse than
+    /// omitting the pointer, which is what every other declining path here does.
+    fn unique_type_argument_anchor(
+        &mut self,
+        type_arguments: &[NodeIndex],
+        property: &str,
+        depth: u32,
+    ) -> Option<(u32, u32, Option<String>)> {
+        let mut found: Option<(u32, u32, Option<String>)> = None;
+        for &argument_idx in type_arguments {
+            let Some(anchor) = self.annotation_property_anchor(argument_idx, property, depth + 1)
+            else {
+                continue;
+            };
+            if found.is_some() {
+                return None;
+            }
+            found = Some(anchor);
+        }
+        found
     }
 
     /// The written type node of the member named `key` on the type annotation

--- a/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
+++ b/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
@@ -1181,3 +1181,55 @@ fn ambiguous_type_arguments_decline_rather_than_guessing() {
         );
     }
 }
+
+// The three tests below were written for #16559, which fixed the same family
+// with a lib-provenance gate. They are salvaged here so its coverage survives
+// the merge, adapted to this file's helper names; the `Array`-shadow control
+// holds for a different reason under this walk (see its own comment).
+
+/// `readonly Array<T>` puts the operator peel and the type-argument descent in
+/// one annotation; both must compose.
+/// Oracle: `case.ts:1:53 - 'cq' is declared here.`
+#[test]
+fn readonly_array_type_reference_composes_with_the_type_operator_peel() {
+    let source = "type Combo = { items: readonly Array<{ cp: number; cq: number }> };\nconst c2: Combo = { items: [{ cp: 1 }] };\n";
+    let diagnostic = only(&check_source_diagnostics_with_libs(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "cq");
+}
+
+/// A user-defined generic interface merely *named* `Array` must not be given
+/// the global's treatment. This walk never asks whether a reference is the lib
+/// `Array` — it asks whether the reference's own members or alias body declare
+/// the property, and only then looks at the type arguments. Here the shadowing
+/// `Array<T>` declares `held`, the failing literal is reached through the
+/// `list` path segment, and nothing anchors: the same answer a lib-provenance
+/// gate gives, arrived at without consulting the name.
+#[test]
+fn user_defined_array_named_type_does_not_take_the_element_descent() {
+    let source = "interface Array<T> { held: T }\ntype Boxed = { list: Array<{ up: number; uq: number }> };\nconst u: Boxed = { list: { up: 1 } };\n";
+    let diagnostics = check_source_diagnostics_with_libs(source);
+    assert!(
+        !diagnostics
+            .iter()
+            .flat_map(|d| d.related_information.iter())
+            .any(|info| info.code == TS2728),
+        "a shadowed `Array` must not anchor through the element descent: {diagnostics:?}"
+    );
+}
+
+/// Known gap, pinned so it cannot regress silently: a tuple member reports
+/// TS2322 whole-tuple assignability rather than TS2741 at the failing element,
+/// so the anchor walk is never reached. Tracked in #16552.
+#[test]
+fn tuple_element_literal_still_carries_no_pointer() {
+    let source = "type Nest3 = { tup: [{ tp: number; tq: number }] };\nconst c: Nest3 = { tup: [{ tp: 1 }] };\n";
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        !diagnostics
+            .iter()
+            .flat_map(|d| d.related_information.iter())
+            .any(|info| info.code == TS2728),
+        "tuple element type is not descended into: {diagnostics:?}"
+    );
+}

--- a/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
+++ b/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
@@ -19,9 +19,25 @@
 //! (`error_reporter/missing_property_declared_here.rs`), reached from the one
 //! TS2741 construction in `render_missing_property`.
 
+use crate::CheckerOptions;
 use crate::diagnostics::Diagnostic;
-use crate::test_utils::check_source_diagnostics;
+use crate::test_utils::{check_source_diagnostics, check_source_with_libs, load_default_lib_files};
+use std::sync::{Arc, OnceLock};
+use tsz_binder::lib_loader::LibFile;
 use tsz_common::diagnostics::diagnostic_codes;
+
+/// The array-like rows below name `Array` / `ReadonlyArray`, so they need the
+/// real lib on the side; `check_source_diagnostics` runs lib-free and would
+/// report TS2318 `Cannot find global type 'Array'` instead of the TS2741 under
+/// test. Loaded once for the whole suite.
+fn default_libs() -> &'static [Arc<LibFile>] {
+    static DEFAULT_LIBS: OnceLock<Vec<Arc<LibFile>>> = OnceLock::new();
+    DEFAULT_LIBS.get_or_init(load_default_lib_files)
+}
+
+fn check_source_diagnostics_with_libs(source: &str) -> Vec<Diagnostic> {
+    check_source_with_libs(source, "test.ts", CheckerOptions::default(), default_libs())
+}
 
 const TS2741: u32 = diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE;
 const TS2739: u32 = diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE;
@@ -1088,4 +1104,80 @@ fn array_element_multi_property_failure_still_carries_no_pointer() {
             .any(|info| info.code == TS2728),
         "TS2739 carries no declared-here pointer: {diagnostic:?}"
     );
+}
+
+/// `Array<T>` holds the written element shape in a type argument exactly as
+/// `T[]` holds it in its element type, and tsc anchors there identically.
+/// Oracle: `case.ts:1:41 - 'lq' is declared here.`
+#[test]
+fn generic_array_type_argument_anchors_like_an_array_element() {
+    let source = "type ArrG = { list: Array<{ lp: number; lq: number }> };\nconst ra: ArrG = { list: [{ lp: 1 }] };\n";
+    let diagnostic = only(&check_source_diagnostics_with_libs(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "lq");
+}
+
+/// `ReadonlyArray<T>` is the same shape reached through a different global
+/// name — the walk must not be keyed to either one.
+/// Oracle: `case.ts:1:47 - 'lq' is declared here.`
+#[test]
+fn readonly_array_type_argument_anchors_like_an_array_element() {
+    let source = "type ArrR = { list: ReadonlyArray<{ lp: number; lq: number }> };\nconst ra: ArrR = { list: [{ lp: 1 }] };\n";
+    let diagnostic = only(&check_source_diagnostics_with_libs(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "lq");
+}
+
+/// `readonly T[]` describes the same element shape as `T[]`, so the operator is
+/// transparent to the walk. Oracle: `case.ts:1:44 - 'lq' is declared here.`
+#[test]
+fn readonly_operator_is_transparent_to_the_element_walk() {
+    let source = "type ArrRO = { list: readonly { lp: number; lq: number }[] };\nconst ra: ArrRO = { list: [{ lp: 1 }] };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "lq");
+}
+
+/// The array-like descents must not depend on the identifiers chosen: the same
+/// shapes under renamed binders anchor at the renamed property.
+#[test]
+fn array_like_type_argument_anchor_is_not_identifier_keyed() {
+    let source = "type Roster = { members: Array<{ alpha: string; beta: string }> };\nconst r: Roster = { members: [{ alpha: \"a\" }] };\n";
+    let diagnostic = only(&check_source_diagnostics_with_libs(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "beta");
+}
+
+/// `keyof T` denotes T's *keys*, not T, so the type operator is not blanket
+/// transparent — only `readonly` is. This pins the scoping of the operator
+/// case; tsc reports a plain TS2322 here with no missing-property pointer.
+#[test]
+fn keyof_operator_is_not_transparent_to_the_element_walk() {
+    let source =
+        "type K = { obj: keyof { aa: number; ab: number } };\nconst k: K = { obj: \"zz\" };\n";
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        diagnostics.iter().all(|d| d.code != TS2741),
+        "keyof denotes keys, not the object shape: {diagnostics:?}"
+    );
+}
+
+/// When two type arguments both declare the property the walk has no basis to
+/// choose, and pointing at the wrong occurrence is worse than omitting the
+/// pointer. Reaching tsc's answer here needs type-parameter substitution
+/// through the alias body (`p.a` -> `A` -> the first written argument), which
+/// this walk does not model; see #16552.
+#[test]
+fn ambiguous_type_arguments_decline_rather_than_guessing() {
+    let source = "type Pair<A, B> = { a: A; b: B };\ntype W = { p: Pair<{ lq: number }, { lq: string }> };\nconst w: W = { p: { a: {}, b: { lq: \"x\" } } };\n";
+    let diagnostics = check_source_diagnostics(source);
+    for diagnostic in diagnostics.iter().filter(|d| d.code == TS2741) {
+        assert!(
+            diagnostic
+                .related_information
+                .iter()
+                .all(|info| info.code != TS2728),
+            "two arguments declare 'lq'; the walk must decline: {diagnostic:?}"
+        );
+    }
 }


### PR DESCRIPTION
Goal: hold

Closes the in-scope part of #16552. #16551 taught the `TS2728 'x' is declared here.` anchor walk to descend through `ARRAY_TYPE`; the same construct in its other spellings still declined the pointer.

## Structural rule

When a `TS2741` missing-property failure sits inside an object literal that is an element of an **array-like** member, `tsc` anchors the pointer at the property inside the written element shape — for every spelling of "array-like", not only `T[]`. tsz does the same through the checker's `annotation_property_anchor` walk (`error_reporter/missing_property_declared_here.rs`).

Two additions:

- **`TYPE_OPERATOR`** — `readonly T[]` describes the same element shape as `T[]`, so the operator is transparent and the walk descends into its operand. Scoped to `readonly`: `keyof T` denotes T's *keys*, not T, and declines.
- **`TYPE_REFERENCE` type arguments** — when the reference's own members and its alias body both decline, the walk looks in what the reference is parameterized by. `Array<T>` / `ReadonlyArray<T>` hold the written element shape in a type argument exactly as `T[]` holds it in its element type.

### On the anti-hardcoding gate

The type-argument descent is deliberately **not** keyed to the global array types — no `name == "Array"`, no builtin id. The question the walk answers is "where is `property` written?", and a type argument is the only place left to look once the reference's own members and alias body have declined. That serves any generic wrapper by the same rule and needs no special case for a user-declared `Array`. When two type arguments both declare the property the walk **declines rather than guessing** — a wrong anchor is worse than none, which is what every other declining path here already does.

## Measured (pinned `typescript@7.0.2`, `--pretty true`)

`TS2728` is related information and is **invisible under `--pretty false`** — a code-set or plain-text probe scores this fix as a no-op. Compare with pretty on.

| # | member type | tsc | main | PR | |
|---|---|---|---|---|---|
| b4 | `Array<{ lp; lq }>` | `1:41` | — | `1:41` | **FIXED** |
| b5 | `readonly { lp; lq }[]` | `1:44` | — | `1:44` | **FIXED** |
| b9 | `ReadonlyArray<{ lp; lq }>` | `1:47` | — | `1:47` | **FIXED** |
| b6 | renamed binders `Array<{ alpha; beta }>` | `1:40` | — | `1:40` | **FIXED** |
| b1 | `{ lp; lq }[]` (#16551) | `1:34` | `1:34` | `1:34` | ok |
| b2 | plain non-array member | `1:34` | `1:34` | `1:34` | ok |
| b3 | `{ lp; lq }[][]` | `1:35` | `1:35` | `1:35` | ok |
| b8 | complete object (negative) | none | none | none | ok |

**FIXED 4 / BROKE 0.**

## Deliberately left open, with the reason

- `Box<{ lp; lq }>` — a user generic reached **through a path segment** (`b.inner`) needs type-parameter substitution (`inner: T` → the written argument), which this walk does not model. tsc anchors at `2:33`; tsz emits no pointer, unchanged.
- `Pair<{ lq }, { lq }>` — tsc reaches its answer the same way (`p.a` → `A` → first argument). With two arguments declaring `lq` this PR declines by design.
- **Tuple members are not an anchor gap at all** and are out of scope: tsz reports `TS2322` (whole-tuple assignability) where tsc reports `TS2741` at the failing element, so the walk never runs. That is a tuple-relation/elaboration fix. I corrected #16552's body on this point — the original issue text mis-scoped it.

## Verification

- new tests: 6 added (4 positive, 2 negative controls). **Non-vacuity:** reverting only `missing_property_declared_here.rs` to `origin/main` makes **4 of them fail**; the 2 controls pass both ways, which is correct for controls.
- `cargo nextest run -p tsz-checker --lib` — **9983/9983**
- `cargo nextest run -p tsz-checker --test conformance_issues_types` — 453/456; the 3 failures are **exactly** the 3 `known-failures.txt` entries for that target, no new ones
- `cargo nextest run -p tsz-emitter` — 4775/4775
- conformance snapshot — **11494 / 12043 runnable**; baseline diff vs a main-equivalent tree is **0 lines**, byte-identical
- `scripts/arch/arch_guard.py` — rc=0
- owner file is 890 lines, well under the 2000-line shard ceiling

One test-harness note worth recording: `check_source_diagnostics` runs **lib-free**, so the `Array`/`ReadonlyArray` rows reported `TS2318 Cannot find global type 'Array'` instead of the `TS2741` under test. They use a `check_source_with_libs` helper with `load_default_lib_files()` instead — a lib-free harness silently converts these rows into a different assertion.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5
Effort: xhigh
