### PR TITLE
chore(readme): refresh conformance stats to 11,494

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ test suite against it.
 
 <!-- CONFORMANCE_START -->
 ```
-Progress: [███████████████████░] 95.4% (11,490/12,043 runnable tests)
+Progress: [███████████████████░] 95.4% (11,494/12,043 runnable tests)
 Candidates: 12,585 (12,043 runnable, 507 unsupported, 35 skipped)
 ```
 <!-- CONFORMANCE_END -->


### PR DESCRIPTION
Goal: hold

Refreshes the generated README conformance block from a snapshot measured at
`0e5d58a40c`. Generated via `scripts/refresh-readme.py --write
--skip-performance`; no hand-edited numbers. The committed value was read back
out of the commit (`git show HEAD:README.md`) before the conformance snapshot
tree was discarded, confirming the published figure is the measured one.

Single line changes: `11,490/12,043` -> `11,494/12,043` (both render 95.4%).

Emit metrics left untouched -- the script declined to rewrite them
(`preserving README emit metrics because scripts/emit/emit-detail.json is
behind the existing README emit block`). Fourslash metrics already accurate.
Performance chart skipped; see the note on benchmark scope below.

## Verification

Measured locally at `0e5d58a40c`:

- conformance: `11494 / 12043` runnable (95.4%), 12585 candidates, 507
  unsupported, 35 skipped -- up 4 from 11490
- emit JS: `11562 / 11563`, emit DTS: `1375 / 1390` -- both exactly at the
  parity floor, now unmoved across roughly 350 commits
- fourslash: `6558 / 6562` baseline held. Complete run (`6562/6562` executed),
  0 watchdog kills, 6 tests reporting "Test completed but took Xms" (those
  passed, over the 15s wall clock under concurrent load). The 4 failures are
  exactly the known baseline set: `completionListFunctionExpression`,
  `importFixesWithPackageJsonInSideAnotherPackage`,
  `importNameCodeFix_importType`, `autoImportProvider_importsMap1`.

## Benchmark scope, stated explicitly

This cycle ran a **targeted** benchmark (`--filter 'comlink|toolbelt'`), not a
full sweep. A full run is ~6 hours -- measured, `05:56:35` elapsed at 75/99
comparisons on an idle machine -- which does not fit the current 6h cadence and
would have overlapped the next firing. The other 95 rows were last measured at
`b32223c21d` and were unchanged (`Score: tsz 94 vs tsgo 4`).

The targeted run confirmed a real regression, filed as #16554:
`comlink-project` went `307.9 ms ± 1.1` -> `321.1 ms ± 2.1` (+4.3%), widening
the tsgo gap `2.74x` -> `2.84x`. tsgo is pinned and stable at ~113 ms across all
runs, so this is tsz slowing, not tsgo speeding up. `ts-toolbelt-project` was
measured in the same runs as a control and is flat (`2.52` -> `2.50` -> `2.51`),
which rules out a machine- or harness-level cause. Confirmed twice on SHAs 56
commits apart. Bisect window `0b0fd11e40..b32223c21d` (24 commits).

Conformance was flat at `11,490` across that same window, so no recorded parity
gain offsets the cost.

## Provenance

Machine: m1
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high

AgentName: M1FableArchitect