### PR TITLE
fix(checker): the TS6500 expected-type pointer rides a nested literal's missing-property leaf

### DIFF
--- a/crates/tsz-checker/src/error_reporter/expected_type_from_property.rs
+++ b/crates/tsz-checker/src/error_reporter/expected_type_from_property.rs
@@ -5,8 +5,10 @@ use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
     /// Attach tsc's `The expected type comes from property '{0}' which is
-    /// declared here on type '{1}'` (TS6500) pointer to every `TS2322` pushed
-    /// since `since`.
+    /// declared here on type '{1}'` (TS6500) pointer to every leaf report
+    /// pushed since `since` — see
+    /// [`Self::takes_expected_type_from_property_pointer`] for which codes
+    /// those are.
     ///
     /// tsc's `elaborateElementwise` adds this related entry to the diagnostic it
     /// just reported for an object-literal member, pointing at the *target*
@@ -61,20 +63,41 @@ impl<'a> CheckerState<'a> {
             return;
         };
         for diagnostic in self.ctx.diagnostics.iter_mut().skip(since) {
-            if diagnostic.code != diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE {
+            if !Self::takes_expected_type_from_property_pointer(diagnostic.code) {
                 continue;
             }
             // A leaf report that already carries a location pointer got it from
             // a deeper frame; tsc keeps that one rather than stacking a second.
-            if diagnostic
-                .related_information
-                .iter()
-                .any(|entry| entry.is_location_pointer())
-            {
+            // TS2728 is the one exception: it is this frame's own sibling
+            // pointer, not a deeper frame's, and tsc emits both on the same
+            // report (see the module docs on `missing_property_declared_here`).
+            if diagnostic.related_information.iter().any(|entry| {
+                entry.is_location_pointer() && entry.code != diagnostic_codes::IS_DECLARED_HERE
+            }) {
                 continue;
             }
             diagnostic.related_information.push(related.clone());
         }
+    }
+
+    /// Whether `code` is a leaf report tsc hangs the `TS6500` pointer on.
+    ///
+    /// tsc's `elaborateElementwise` attaches the pointer to whatever diagnostic
+    /// the member's leaf produced, and a nested object literal's leaf is a
+    /// *missing-property* report rather than `TS2322`. Oracled on
+    /// `typescript@7.0.2`: `{ inner: { op: 1 } }` against
+    /// `{ inner: { op: number; oq: number } }` carries the pointer on its
+    /// `TS2741`, and the multi-property forms carry it on `TS2739` / `TS2740` —
+    /// where tsc emits *no* `TS2728` at all, so the pointer cannot be made to
+    /// ride the sibling `TS2728` attach site instead.
+    const fn takes_expected_type_from_property_pointer(code: u32) -> bool {
+        matches!(
+            code,
+            diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
+                | diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE
+                | diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE
+                | diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE_AND_MORE
+        )
     }
 
     /// Build the TS6500 related entry for `property_name` on the first of

--- a/crates/tsz-checker/src/tests/expected_type_from_property_tests.rs
+++ b/crates/tsz-checker/src/tests/expected_type_from_property_tests.rs
@@ -358,3 +358,183 @@ fn nested_type_literal_matching_value_stays_clean() {
         "a matching nested value must not report anything"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Nested object literals: the pointer rides a *missing-property* leaf
+// ---------------------------------------------------------------------------
+//
+// When the nested literal is missing a required member rather than mismatching
+// one, the leaf tsc reports is `TS2741` / `TS2739` / `TS2740`, not `TS2322`.
+// tsc attaches the same `TS6500` pointer to it, naming the *enclosing* property
+// and the type that declares that property. Oracled on `typescript@7.0.2` with
+// `--noEmit --strict --pretty --target es2022 --lib es2022`.
+//
+// The multi-property rows are what force this to be its own attach: tsc emits
+// `TS6500` there with **no** `TS2728` at all, so the pointer cannot be folded
+// into the sibling declared-here site (#16443 item 1, Serpentine).
+
+const TS2728: u32 = diagnostic_codes::IS_DECLARED_HERE;
+const TS2739: u32 = diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE;
+const TS2740: u32 = diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE_AND_MORE;
+const TS2741: u32 = diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE;
+
+fn has_declared_here(diagnostic: &Diagnostic) -> bool {
+    diagnostic
+        .related_information
+        .iter()
+        .any(|info| info.code == TS2728)
+}
+
+/// `nested.ts:1:16` — `The expected type comes from property 'inner' which is
+/// declared here on type 'Outer'`, alongside the `TS2728` at `1:37`.
+#[test]
+fn nested_literal_missing_property_points_at_the_enclosing_property() {
+    let source = "type Outer = { inner: { op: number; oq: number } };\nconst r: Outer = { inner: { op: 1 } };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (file, start, length, message) = expected_type_pointer(&diagnostic);
+    assert_eq!(
+        message,
+        "The expected type comes from property 'inner' which is declared here on type 'Outer'"
+    );
+    assert_eq!(span_text(source, start, length), "inner");
+    assert_eq!(file, "test.ts");
+    // tsc emits both pointers on this row; the new attach must not displace the
+    // sibling declared-here that #16521 landed.
+    assert!(
+        has_declared_here(&diagnostic),
+        "TS2728 must survive alongside TS6500: {diagnostic:?}"
+    );
+}
+
+/// The owner reached through an `interface` rather than an alias renders its
+/// written name, exactly as tsc does (`on type 'IOuter'`).
+#[test]
+fn nested_literal_under_an_interface_names_the_interface() {
+    let source = "interface IOuter { inner: { op: number; oq: number } }\nconst r: IOuter = { inner: { op: 1 } };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, message) = expected_type_pointer(&diagnostic);
+    assert_eq!(
+        message,
+        "The expected type comes from property 'inner' which is declared here on type 'IOuter'"
+    );
+    assert_eq!(span_text(source, start, length), "inner");
+}
+
+/// Twice nested. The pointer names the **immediately enclosing** property and
+/// the anonymous type that declares it — `b` on `{ b: ...; }`, never the outer
+/// alias `Deep`. Oracled: `nested.ts:5:20`.
+#[test]
+fn twice_nested_literal_names_the_immediately_enclosing_owner() {
+    let source = "type Deep = { a: { b: { p: number; q: number } } };\nconst r: Deep = { a: { b: { p: 1 } } };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, message) = expected_type_pointer(&diagnostic);
+    assert_eq!(
+        message,
+        "The expected type comes from property 'b' which is declared here on type '{ b: { p: number; q: number; }; }'"
+    );
+    assert_eq!(span_text(source, start, length), "b");
+}
+
+/// The row that makes this its own attach site: `TS2739` carries the pointer
+/// and tsc emits **no** `TS2728` for a multi-property miss.
+#[test]
+fn nested_multi_property_miss_carries_the_pointer_without_a_declared_here() {
+    let source = "type Multi = { inner: { m1: number; m2: number; m3: number } };\nconst r: Multi = { inner: { m1: 1 } };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2739);
+    let (_, start, length, message) = expected_type_pointer(&diagnostic);
+    assert_eq!(
+        message,
+        "The expected type comes from property 'inner' which is declared here on type 'Multi'"
+    );
+    assert_eq!(span_text(source, start, length), "inner");
+    assert!(
+        !has_declared_here(&diagnostic),
+        "tsc emits no TS2728 on a multi-property miss: {diagnostic:?}"
+    );
+}
+
+/// The `and N more` form is a distinct code and needs its own arm.
+#[test]
+fn nested_and_more_property_miss_carries_the_pointer() {
+    let source = "type Huge = { inner: { a: number; b: number; c: number; d: number; e: number; f: number; g: number; h: number; i: number; j: number } };\nconst r: Huge = { inner: { a: 1 } };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2740);
+    let (_, start, length, message) = expected_type_pointer(&diagnostic);
+    assert_eq!(
+        message,
+        "The expected type comes from property 'inner' which is declared here on type 'Huge'"
+    );
+    assert_eq!(span_text(source, start, length), "inner");
+}
+
+/// An **optional** enclosing member still carries the pointer — the nullish
+/// half of the member type is not what gates this, unlike the arrow-body drill
+/// gate in the sibling `TS6502` family (#16550).
+#[test]
+fn optional_enclosing_member_still_carries_the_pointer() {
+    let source =
+        "type Opt = { inner?: { p: number; q: number } };\nconst r: Opt = { inner: { p: 1 } };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, message) = expected_type_pointer(&diagnostic);
+    assert_eq!(
+        message,
+        "The expected type comes from property 'inner' which is declared here on type 'Opt'"
+    );
+    assert_eq!(span_text(source, start, length), "inner");
+}
+
+/// Binder names must not matter on the missing-property leaf either.
+#[test]
+fn renamed_binders_on_a_nested_missing_property() {
+    let source = "type Zeta = { qux: { xylo: string; yak: number } };\nconst z: Zeta = { qux: { xylo: \"s\" } };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, message) = expected_type_pointer(&diagnostic);
+    assert_eq!(
+        message,
+        "The expected type comes from property 'qux' which is declared here on type 'Zeta'"
+    );
+    assert_eq!(span_text(source, start, length), "qux");
+}
+
+/// NEGATIVE CONTROL — depth 0. The literal *is* the assignment's right-hand
+/// side, so there is no enclosing property for the pointer to name and tsc
+/// emits `TS2728` alone. This is the row that would break if the new attach
+/// were reached from the top-level missing-property report rather than from
+/// the per-property elaboration leaf.
+#[test]
+fn top_level_missing_property_takes_no_expected_type_pointer() {
+    let source = "type Top = { alpha: string; beta: string };\nconst r: Top = { alpha: \"a\" };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    assert!(
+        !has_pointer(&diagnostic),
+        "a depth-0 miss has no enclosing property: {diagnostic:?}"
+    );
+    assert!(
+        has_declared_here(&diagnostic),
+        "TS2728 still fires at depth 0: {diagnostic:?}"
+    );
+}
+
+/// NEGATIVE CONTROL — an **array element**. tsc anchors the `TS2728` inside the
+/// element type but emits no `TS6500`: the frame immediately enclosing the
+/// failing literal is an array element, which has no property name to report.
+/// Oracled: `n2.ts:5:34` for the `TS2728`, no pointer line.
+#[test]
+fn array_element_literal_takes_no_expected_type_pointer() {
+    let source = "type Arr = { list: { lp: number; lq: number }[] };\nconst r: Arr = { list: [{ lp: 1 }] };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    assert!(
+        !has_pointer(&diagnostic),
+        "an array element has no enclosing property: {diagnostic:?}"
+    );
+}
+
+/// NEGATIVE CONTROL — a nested literal that type-checks cleanly must stay
+/// clean, so none of the arms above can fire as a side effect of the walk.
+#[test]
+fn nested_missing_property_negative_control_stays_clean() {
+    let source = "type Fine = { inner: { p: number; q: number } };\nconst f: Fine = { inner: { p: 1, q: 2 } };\n";
+    assert!(
+        check_source_diagnostics(source).is_empty(),
+        "a complete nested value must not report anything"
+    );
+}


### PR DESCRIPTION
Closes **item 1 of #16443** — the `TS6500` half of the nested-elaboration family, which Serpentine's 2026-08-06T01:15:23Z comment named as the biggest remaining slice and left explicitly unclaimed after landing the `TS2728` half (#16521).

tsc's `elaborateElementwise` attaches the `The expected type comes from property '{0}' which is declared here on type '{1}'` pointer to whatever diagnostic the object-literal member's **leaf** produced. When the nested literal is *missing* a required member rather than mismatching one, that leaf is `TS2741` / `TS2739` / `TS2740` — not `TS2322`. `attach_expected_type_from_property_pointer` only ever accepted `TS2322`, so every nested missing-property row silently dropped the pointer.

**Structural rule:** when an object-literal member's value is itself an object literal missing a required property, tsc anchors `TS6500` at the *immediately enclosing* property's declaration and names the type that declares it; tsz now does this through the widened code set in `takes_expected_type_from_property_pointer` (`crates/tsz-checker/src/error_reporter/expected_type_from_property.rs`).

Everything below the entry step was already finished — the annotation-syntax owner recovery that #16521 built for the sibling pointer resolves the anonymous nested owner correctly on the first try. This is a 12-line widening of *which leaves* the existing pointer attaches to, not new machinery.

### The two constraints that shaped the diff

**1. The multi-property forms force this to be its own attach, not a fold into the `TS2728` site.** Oracled: tsc emits `TS6500` on `TS2739`/`TS2740` with **no `TS2728` at all**, so there is no declared-here entry for it to ride.

**2. Rows that carry both need the existing guard to exempt `TS2728`.** The "already carries a location pointer" guard exists to defer to a *deeper frame*. `TS2728` is not a deeper frame — it is this frame's own sibling, and tsc prints both on the same report. Without the exemption the `TS2741` rows would have kept dropping the pointer even after the code set widened.

### Oracle matrix — `typescript@7.0.2`, `--noEmit --strict --pretty --target es2022 --lib es2022`

Pinned **before** writing the fix. Every row landed byte-exact on the first run, including the anonymous-owner display and both negative controls.

| row | tsc | before | after |
| --- | --- | --- | --- |
| nested alias literal (`Outer`) | `1:16` `property 'inner' … on type 'Outer'` | none | exact |
| nested `interface` member (`IOuter`) | `3:20` … `on type 'IOuter'` | none | exact |
| twice nested (`Deep`) | `5:20` `property 'b' … on type '{ b: { p: number; q: number; }; }'` | none | exact |
| multi-property `TS2739` (`Multi`) | `7:16`, **no `TS2728`** | none | exact |
| `and N more` `TS2740` (`Huge`) | `1:15` | none | exact |
| optional enclosing member (`Opt?`) | `3:14` | none | exact |
| renamed binders (`Zeta`/`qux`) | — | none | exact |
| **depth 0** (`Top`) | `TS2728` only, **no `TS6500`** | no pointer | no pointer |
| **array element** (`Arr`) | `TS2728` only, **no `TS6500`** | no pointer | no pointer |

The twice-nested row is the one that pins the *semantics*: tsc names `b` on the anonymous `{ b: …; }`, **not** the outer alias `Deep`. The two negative rows pin the boundary — a depth-0 literal has no enclosing property, and an array element's enclosing frame has no property name, so both must keep declining rather than anchoring somewhere plausible-but-wrong.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib -- expected_type_from_property` — **27/27** (17 pre-existing + 10 new), 0 regressed.
- **Non-vacuity, measured not argued.** `git stash push --` on the src file alone (Sunstone's technique), leaving the tests in place: **7 of the 7 new positive rows fail at parent**, all 3 new negative controls pass at parent and after. The change is doing the work the tests claim.
- `cargo test -p tsz-checker --lib -- missing_property_declared_here expected_type_from` — **102/102**. Confirms the sibling `TS2728` family is untouched, which the guard exemption puts directly at risk.
- `cargo test -p tsz-checker --lib -- elaboration object_literal related_information` — **460/460**.
- `cargo clippy --profile ci-lint --workspace --exclude tsz-conformance --all-targets -- -D warnings` (CI's exact invocation) — clean.
- `cargo fmt -p tsz-checker -- --check` — clean. `python3 scripts/arch/arch_guard.py` — rc=0.
- Full untargeted `cargo test -p tsz-checker --lib` was still in the board's documented long tail at PR-open time; I will post the count on this PR when it lands rather than block on it.
- **`compare-to-parent` / conformance: owed, not argued away.** This is `related_information`-only on already-emitted diagnostics — no new code is introduced and no diagnostic's code or primary message changes, so the corpus cannot move by construction, and the sibling PRs in this family (#16456, #16461, #16521, #16550) all measured exactly 0/0. But the board's standing rule is that a two-sided run beats an argument, and a cold cloud seat needs 55-90 min for it. Flagging explicitly so a faster seat can discharge it before queuing; I would not self-merge this without it.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Malachite

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZW8jzruaSN1mkwCjGceb4)_