### PR TITLE
fix(checker): TS2728 declared-here pointer descends through Array&lt;T&gt;/readonly T[] element types (#16443)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
+++ b/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
@@ -202,6 +202,7 @@ impl<'a> CheckerState<'a> {
         depth: u32,
     ) -> Option<(u32, u32, Option<String>)> {
         use tsz_parser::parser::syntax_kind_ext;
+        use tsz_scanner::SyntaxKind;
 
         if depth > Self::ANNOTATION_WALK_MAX_DEPTH {
             return None;
@@ -219,12 +220,20 @@ impl<'a> CheckerState<'a> {
             return Some((start, length, Self::arena_file_name(arena, anchor_idx)));
         }
         if node.kind == syntax_kind_ext::TYPE_REFERENCE {
-            let name_idx = self.ctx.arena.get_type_ref(node)?.type_name;
+            let type_ref = self.ctx.arena.get_type_ref(node)?;
+            let name_idx = type_ref.type_name;
             let owner_symbol = self.type_position_symbol(name_idx)?;
             if let Some(anchor) =
                 self.member_declaration_anchor_following_aliases(owner_symbol, property)
             {
                 return Some(anchor);
+            }
+            // `Array<T>`/`ReadonlyArray<T>` is the type-reference spelling of
+            // the same element shape `ARRAY_TYPE` (`T[]`) descends into below —
+            // tsc's checker lowers both to one internal array type, so the
+            // pointer must reach the same element node either way.
+            if let Some(element_idx) = self.lib_array_type_argument(owner_symbol, node) {
+                return self.annotation_property_anchor(element_idx, property, depth + 1);
             }
             // An alias chain (`type Indirect = Zed`) declares no member list of
             // its own, so the walk above finds nothing to anchor in. Continue
@@ -250,7 +259,50 @@ impl<'a> CheckerState<'a> {
             let element_idx = self.ctx.arena.get_array_type(node)?.element_type;
             return self.annotation_property_anchor(element_idx, property, depth + 1);
         }
+        if node.kind == syntax_kind_ext::TYPE_OPERATOR {
+            let data = self.ctx.arena.get_type_operator(node)?;
+            if data.operator == SyntaxKind::ReadonlyKeyword as u16 {
+                // `readonly T[]` and `readonly Array<T>` carry no shape of
+                // their own beyond the operand they modify.
+                return self.annotation_property_anchor(data.type_node, property, depth + 1);
+            }
+            return None;
+        }
         None
+    }
+
+    /// The sole type argument of `idx` when `owner_symbol` is the actual
+    /// global `Array` or `ReadonlyArray` lib interface, so an `Array<T>`
+    /// member type-reference can be descended into exactly like `T[]`.
+    ///
+    /// Gated on lib provenance, not name text alone: a user-defined `Array<T>`
+    /// shadowing the global must not take this path (it has its own member
+    /// list, handled by the ordinary declaration walk above). Mirrors the same
+    /// name-plus-lib-provenance check `class_implements_checker` already uses
+    /// to recognize the global `Array` for its own display/member fast path.
+    fn lib_array_type_argument(
+        &self,
+        owner_symbol: tsz_binder::SymbolId,
+        type_ref_node: &tsz_parser::parser::node::Node,
+    ) -> Option<NodeIndex> {
+        let symbol = self
+            .get_cross_file_symbol(owner_symbol)
+            .or_else(|| self.ctx.binder.get_symbol(owner_symbol))?;
+        let is_lib = self.ctx.symbol_is_from_actual_or_cloned_lib(owner_symbol)
+            || self.ctx.binder.lib_symbol_ids.contains(&owner_symbol);
+        if !is_lib || (symbol.escaped_name != "Array" && symbol.escaped_name != "ReadonlyArray") {
+            return None;
+        }
+        let args = self
+            .ctx
+            .arena
+            .get_type_ref(type_ref_node)?
+            .type_arguments
+            .as_ref()?;
+        if args.nodes.len() != 1 {
+            return None;
+        }
+        args.nodes.first().copied()
     }
 
     /// The written type node of the member named `key` on the type annotation

--- a/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
+++ b/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
@@ -19,8 +19,9 @@
 //! (`error_reporter/missing_property_declared_here.rs`), reached from the one
 //! TS2741 construction in `render_missing_property`.
 
+use crate::context::CheckerOptions;
 use crate::diagnostics::Diagnostic;
-use crate::test_utils::check_source_diagnostics;
+use crate::test_utils::{check_source_diagnostics, check_source_with_libs, load_default_lib_files};
 use tsz_common::diagnostics::diagnostic_codes;
 
 const TS2741: u32 = diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE;
@@ -1036,6 +1037,25 @@ fn computed_path_member_declines_rather_than_anchoring_shallow() {
     );
 }
 
+/// Checks `source` against the real lib `Array`/`ReadonlyArray` globals, for
+/// the shapes below that name them by their type-reference spelling
+/// (`Array<T>`, `ReadonlyArray<T>`) rather than `T[]` — the no-lib
+/// [`check_source_diagnostics`] harness above resolves no lib symbols at all,
+/// so a bare `Array` identifier would be an unresolved reference rather than
+/// the actual global interface.
+fn check_source_with_default_libs(source: &str) -> Vec<Diagnostic> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(
+        source,
+        "case.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+}
+
 /// A literal nested inside an *array* member: the path reaches the member's
 /// written type node, and `annotation_property_anchor` descends through the
 /// array type's own element type to anchor at the missing property inside it.
@@ -1087,5 +1107,102 @@ fn array_element_multi_property_failure_still_carries_no_pointer() {
             .iter()
             .any(|info| info.code == TS2728),
         "TS2739 carries no declared-here pointer: {diagnostic:?}"
+    );
+}
+
+/// `Array<T>` is the type-reference spelling of the same element shape
+/// `T[]`'s `ARRAY_TYPE` node descends into: tsc's checker lowers both to one
+/// internal array type, so `annotation_property_anchor`'s `TYPE_REFERENCE` arm
+/// must reach the same element node when the referenced symbol is the actual
+/// lib `Array` interface. Oracle: `case.ts:1:50 - 'delta' is declared here.`
+#[test]
+fn array_type_reference_argument_anchors_through_the_element_type() {
+    let source = "type Roster2 = { members: Array<{ gamma: string; delta: string }> };\nconst r2: Roster2 = { members: [{ gamma: \"g\" }] };\n";
+    let diagnostic = only(&check_source_with_default_libs(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "delta");
+}
+
+/// `ReadonlyArray<T>` is the other lib generic naming the same element shape.
+/// Oracle: `case.ts:1:53 - 'zq' is declared here.`
+#[test]
+fn readonly_array_type_reference_argument_anchors_through_the_element_type() {
+    let source = "type Nest5 = { list: ReadonlyArray<{ zp: number; zq: number }> };\nconst e: Nest5 = { list: [{ zp: 1 }] };\n";
+    let diagnostic = only(&check_source_with_default_libs(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "zq");
+}
+
+/// `readonly T[]` wraps the array type in a `TYPE_OPERATOR` node; the operator
+/// itself carries no shape and `annotation_property_anchor` must peel it
+/// exactly like `PARENTHESIZED_TYPE` before reaching the existing `ARRAY_TYPE`
+/// descent. Oracle: `case.ts:1:49 - 'rq' is declared here.`
+#[test]
+fn readonly_array_type_literal_anchors_through_the_element_type() {
+    let source = "type Nest2 = { list: readonly ({ rp: number; rq: number })[] };\nconst b: Nest2 = { list: [{ rp: 1 }] };\n";
+    let diagnostic = only(&check_source_with_default_libs(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "rq");
+}
+
+/// `readonly Array<T>` composes both the `TYPE_OPERATOR` peel and the lib
+/// `Array` type-reference descent in one annotation. tsc's own grammar check
+/// flags this spelling as `TS1354` ("'readonly' type modifier is only
+/// permitted on array and tuple literal types") but keeps checking the
+/// assignment through the error, and still attaches the pointer — asserted
+/// with `only(..., TS2741)` so the unrelated grammar diagnostic cannot affect
+/// this test. Oracle: `case.ts:1:52 - 'cq' is declared here.`
+#[test]
+fn readonly_array_type_reference_composes_with_the_type_operator_peel() {
+    let source = "type Combo = { items: readonly Array<{ cp: number; cq: number }> };\nconst c2: Combo = { items: [{ cp: 1 }] };\n";
+    let diagnostic = only(&check_source_with_default_libs(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "cq");
+}
+
+/// Negative control: a user-defined generic interface merely *named* `Array`
+/// (shadowing the lib global in its own module scope) must not take the lib
+/// fast path — it has its own member list `{ held: T }`, which owns no
+/// property matching the failing literal's shape, so this declines exactly as
+/// any other unrelated generic member type does. Proves the gate is
+/// lib-provenance, not name text alone.
+#[test]
+fn user_defined_array_named_type_does_not_take_the_lib_fast_path() {
+    let source = "interface Array<T> { held: T }\ntype Boxed = { list: Array<{ up: number; uq: number }> };\nconst u: Boxed = { list: { up: 1 } };\n";
+    let diagnostics = check_source_with_default_libs(source);
+    assert!(
+        !diagnostics
+            .iter()
+            .flat_map(|d| d.related_information.iter())
+            .any(|info| info.code == TS2728),
+        "a shadowed `Array` must not anchor through the lib element-type descent: {diagnostics:?}"
+    );
+}
+
+/// Negative control, current known gap: a tuple member type (`[T]`) is not
+/// descended into, because the failing array-literal element's *index* is not
+/// tracked anywhere on the path to the annotation walk (`ARRAY_TYPE`/`Array<T>`
+/// share one element type at every index; a tuple does not). Anchoring at a
+/// fixed slot would be wrong whenever the failure is not at that slot, so this
+/// declines rather than guessing.
+///
+/// Asserted over every diagnostic rather than a chosen one, same reasoning as
+/// [`computed_path_member_declines_rather_than_anchoring_shallow`]: tsz's
+/// *primary* diagnostic also diverges here (`TS2322` "not assignable to type
+/// '[...]'" where tsc reports `TS2741`), a distinct pre-existing defect this
+/// test must not depend on. Oracle: tsc reports `TS2741` and anchors
+/// `case.ts:1:39 - 'tq' is declared here.`; pinned here as today's behavior so
+/// a future index-aware fix flips this assertion rather than silently landing
+/// a wrong anchor.
+#[test]
+fn tuple_element_literal_still_carries_no_pointer() {
+    let source = "type Nest3 = { tup: [{ tp: number; tq: number }] };\nconst c: Nest3 = { tup: [{ tp: 1 }] };\n";
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        !diagnostics
+            .iter()
+            .flat_map(|d| d.related_information.iter())
+            .any(|info| info.code == TS2728),
+        "tuple element type is not yet descended into: {diagnostics:?}"
     );
 }


### PR DESCRIPTION
When a missing-property `TS2741` failure sits inside an object literal that is an element of an array-typed member spelled as `Array<T>`, `ReadonlyArray<T>`, or `readonly T[]`, tsc's `reportUnmatchedProperty` still anchors the `TS2728` "'x' is declared here." pointer inside the element type. #16551 taught `annotation_property_anchor` to descend through the `ARRAY_TYPE` (`T[]`) syntax node, but `Array<T>`/`ReadonlyArray<T>` parse as a `TYPE_REFERENCE` (a different node kind carrying the same semantic array type) and `readonly T[]` wraps the array in a `TYPE_OPERATOR` node — both fell through to `None` and declined.

**Structural rule:** when a member's written type resolves to the actual lib `Array`/`ReadonlyArray` interface with one type argument, or peels a `readonly` type-operator wrapper, `tsc` anchors through it exactly as it does for `T[]`; tsz now does the same through `annotation_property_anchor` (`crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs`).

The `Array`/`ReadonlyArray` recognition is gated on lib provenance (`escaped_name` plus `symbol_is_from_actual_or_cloned_lib`/`lib_symbol_ids`), the same check `class_implements_checker` already uses for its own `Array` fast path, so a user-defined type merely named `Array` does not take this route (anti-hardcoding: name text alone never decides).

Continues the `#16443` "declared-here pointer" family (Citrine's own follow-up matrix on #16551, posted unclaimed): item 3 (array-element literal) landed as `T[]` only; this closes the sibling spellings.

## Adjacent-case matrix (6 new tests, all oracle-verified against pinned `typescript@7.0.2`)

| Case | Result |
| --- | --- |
| `Array<T>` member, missing nested property | anchors, matches tsc |
| `ReadonlyArray<T>` member | anchors, matches tsc |
| `readonly T[]` member (`TYPE_OPERATOR` peel) | anchors, matches tsc |
| `readonly Array<T>` (composes both new arms) | anchors, matches tsc — despite tsc's own `TS1354` grammar diagnostic on that spelling, which does not suppress the pointer |
| negative control: user-defined `interface Array<T>` shadowing the lib global | declines (no pointer) — proves the gate is lib-provenance, not name text |
| negative control: tuple `[T]` member | declines (no pointer) — pinned as a known gap: the array-literal path tracks no element *index*, and a tuple's per-slot types make a fixed-slot anchor sometimes wrong; a future index-aware fix should flip this assertion, not guess today |

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib -- missing_property_declared_here` → 58/58 (52 pre-existing + 6 new)
- `cargo test -p tsz-checker --lib -- expected_type_from_property declared_here elaboration object_literal` → 531/531 (adjacent pointer/elaboration families, no regression)
- `cargo clippy --profile ci-lint --workspace --exclude tsz-conformance --all-targets -- -D warnings` → clean (CI's exact invocation)
- `python3 scripts/arch/arch_guard.py` → clean
- `cargo fmt --check` → clean
- Full untargeted `cargo test -p tsz-checker --lib` hit this session's documented long-tail-straggler behavior (board-recorded: 8500+/9900+ complete in minutes, a handful of named tests run long); not blocked on — targeted suites above are the primary evidence, consistent with several sibling PRs in this family this hour.
- `compare-to-parent`/conformance not run (time budget): this is a `related_information`-only addition on an existing `TS2741` (no new diagnostic code, no new code path reachable outside the pointer render), same argument #16535/#16541/#16550 used and had independently confirmed by measurement (0/0 movement) earlier this hour.
- Test-only + one src file changed (`missing_property_declared_here.rs`, `missing_property_declared_here_tests.rs`); no emit-visible surface touched.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: Amazonite

---
_Generated by [Claude Code](https://claude.ai/code/session_012WyDypyNxqjBpYM1NV4ZPV)_