### PR TITLE
fix(checker): a generic alias applied at an object-literal member is drilled with the instantiated return type

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -1407,14 +1407,34 @@ impl<'a> CheckerState<'a> {
     ///   alias, so it declines here — which is what `tsc` does: it reports the
     ///   whole function type at the member for those, drilling neither the
     ///   alias form nor the inline one.
+    ///
+    /// A *generic* alias application (`cb: G<string>` for `type G<T> = () =>
+    /// T`) arrives as `TypeData::Application`, whose `base` is itself an
+    /// unresolved `Lazy(DefId)` reference to `G`'s own uninstantiated body —
+    /// neither the direct probe nor the lazy hop above (which only resolves
+    /// `ty` itself, and an `Application` is not a `Lazy`) sees through it. A
+    /// third, narrower hop evaluates `ty` through the same substitution the
+    /// checker uses everywhere else a type application is finally read
+    /// ([`Self::judge_evaluate`]), so the return type driving the drill's
+    /// relation and message is the *instantiated* `string`, not the alias's
+    /// own type parameter `T`. This hop is gated on `ty` actually being an
+    /// application so it cannot fire on an unrelated declined shape.
     fn callable_return_type_for_drill(&mut self, ty: TypeId) -> Option<TypeId> {
         if let Some(found) = self.first_callable_return_type(ty) {
             return Some(found);
         }
         let resolved = self.resolve_lazy_type(ty);
-        if resolved == ty {
-            return None;
+        if resolved != ty
+            && let Some(found) = self.first_callable_return_type(resolved)
+        {
+            return Some(found);
         }
-        self.first_callable_return_type(resolved)
+        if crate::query_boundaries::diagnostics::type_application(self.ctx.types, ty).is_some() {
+            let evaluated = self.judge_evaluate(ty);
+            if evaluated != ty {
+                return self.first_callable_return_type(evaluated);
+            }
+        }
+        None
     }
 }

--- a/crates/tsz-checker/src/tests/expected_type_from_return_tests.rs
+++ b/crates/tsz-checker/src/tests/expected_type_from_return_tests.rs
@@ -286,33 +286,58 @@ fn a_parenthesized_alias_body_anchors_inside_the_parentheses() {
     assert_eq!(start, 10);
 }
 
-/// A *generic* alias applied at the member is still not drilled — a known
-/// divergence this row pins rather than fixes, so the next session starts from
-/// a measured statement instead of re-deriving it.
+/// A *generic* alias applied at the member (`cb: G<string>`) drills to the
+/// body, sourcing the relation/message's expected return type and the
+/// pointer's anchor **separately**: `G<string>` arrives as a `TypeData::
+/// Application` whose `base` is itself an unresolved `Lazy(DefId)` reference
+/// to `G`'s own uninstantiated body, so `callable_return_type_for_drill`
+/// evaluates the application (the same substitution the checker uses
+/// everywhere else a type application is read) to get the *instantiated*
+/// `string`, while the pointer anchor walk (`callable_type_node_anchor`)
+/// follows the written type-reference `G` to its **uninstantiated** body
+/// `() => T` for the span — matching tsc, which anchors in the alias's own
+/// declaration regardless of the instantiation.
 ///
-/// tsc drills to the body (`r6.ts:3:28`) and anchors the pointer in the alias's
-/// own **uninstantiated** body, `() => T` at `r6.ts:1:13`, while still reporting
-/// the *instantiated* expected type in the message (`'string'`, not `'T'`).
-/// tsz reports at the member with the sibling `TS6500` instead.
-///
-/// This is deliberately out of the alias hop's reach: `G[ string ]` arrives as a
-/// type *application*, not a `Lazy(DefId)`, and following it to the alias base
-/// would hand the drill the uninstantiated `T` as the expected return type —
-/// the right anchor with the wrong message. Closing it needs the instantiated
-/// return type and the uninstantiated anchor to be sourced separately, which is
-/// a different change from alias transparency. Tracked as its own issue.
+/// Oracle (`typescript@7.0.2`): `r6.ts:3:28` for the primary, pointer at
+/// `r6.ts:1:13` spanning `() => T`, message still naming `'string'`.
 #[test]
-fn a_generic_alias_application_is_not_drilled_and_pins_a_known_divergence() {
+fn a_generic_alias_application_is_drilled_with_the_instantiated_return_type() {
     let source =
         "type G<T> = () => T;\ninterface R6 { cb: G<string>; }\nconst v6: R6 = { cb: () => 6 };\n";
     let diagnostic = only(&check_source_diagnostics(source), TS2322);
     assert_eq!(
-        diagnostic.start, 70,
-        "tsz reports at the member; tsc reports at the body (oracle 3:28 => 80)"
+        diagnostic.start, 80,
+        "tsc drills to the body expression (oracle 3:28 => 80)"
     );
+    assert_eq!(
+        diagnostic.message_text, "Type 'number' is not assignable to type 'string'.",
+        "the message names the instantiated return type, not the alias's own type parameter"
+    );
+    let (start, length, message) = return_pointer(&diagnostic);
+    assert_eq!(
+        span_text(source, start, length),
+        "() => T",
+        "the anchor is the alias's own uninstantiated body"
+    );
+    assert_eq!(start, 12, "oracle 1:13");
+    assert_eq!(
+        message, "The expected type comes from the return type of this signature.",
+        "{diagnostic:?}"
+    );
+}
+
+/// Negative control for the fix above: a generic alias whose application
+/// declines to evaluate to anything callable (a non-function generic alias)
+/// must not be newly drilled. `judge_evaluate` on `H<number>` yields `number`,
+/// which `first_callable_return_type` correctly still declines.
+#[test]
+fn a_non_callable_generic_alias_application_still_declines_the_drill() {
+    let source =
+        "type H<T> = T;\ninterface R9 { cb: H<number>; }\nconst v9: R9 = { cb: () => 1 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
     assert!(
         !has_return_pointer(&diagnostic),
-        "the application declines the alias hop: {diagnostic:?}"
+        "an instantiation that evaluates to a non-callable type must not fabricate a signature: {diagnostic:?}"
     );
 }
 


### PR DESCRIPTION
Closes #16548.

**Structural rule.** When an object-literal member's declared type is a generic alias application (`cb: G<string>` for `type G<T> = () => T`), `tsc`'s `elaborateArrowFunction` drills to the arrow body and reports `TS2322` there, sourcing the expected return type from the **instantiated** signature (`string`) while anchoring the `TS6502` pointer in the alias's own **uninstantiated** declaration (`() => T`). tsz declined the drill entirely for this shape, reporting at the member with the sibling `TS6500` instead.

**Why it happened.** `G<string>` arrives at the drill gate (`callable_return_type_for_drill`, `crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs`) as `TypeData::Application`, whose `base` is an unresolved `Lazy(DefId)` reference to `G`'s own uninstantiated body. Neither of the function's existing two probes see through it: the direct probe's own `type_application` arm (inside `first_callable_return_type`) recurses into `app.base`, which is `Lazy` and matches none of that function's structural arms; the lazy-resolution hop only resolves `ty` itself, and an `Application` is not a `Lazy`.

**The fix.** A third hop evaluates `ty` through `judge_evaluate` — the same substitution the checker uses everywhere else a type application is finally read — before retrying the direct probe, so the return type driving the drill's relation and message is the instantiated `string`, not the alias's own type parameter `T`. The hop is gated on `ty` actually being a `type_application` so it cannot fire on an unrelated declined shape. The pointer anchor already worked (`callable_type_node_anchor`'s type-reference hop from #16550 resolves `G` by name, ignoring type arguments), so only the type half needed fixing — exactly the split #16548's own analysis called for.

**Adjacent case.** A generic alias application that evaluates to a non-callable type (`type H<T> = T` at `cb: H<number>`) must not fabricate a signature — covered by a new negative-control test.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib -- expected_type_from_return`: **27/27** (26 pre-existing + 1 new negative control; the pinned divergence test — renamed from "is_not_drilled_and_pins_a_known_divergence" to "is_drilled_with_the_instantiated_return_type" — now asserts the fixed behavior with its full oracle values: offset 80 for the primary, `() => T` at offset 12 length 7 for the `TS6502` pointer, message naming `'string'`).
- `cargo clippy -p tsz-checker --lib -- -D warnings`: clean.
- `python3 scripts/arch/arch_guard.py`: clean.
- `cargo fmt -p tsz-checker -- --check`: clean.
- Full untargeted `cargo test -p tsz-checker --lib`, `compare-to-parent.sh`, and conformance/emit snapshots not run this session (time budget on a slow cloud seat — each incremental compile of this crate took 2-3 minutes). The change is scoped to one function in `elaboration.rs` plus its own test file; no new diagnostic code, no emit path touched. Owed for a faster seat to discharge before landing.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rtcc8ijp4iRUvE3qsoYUx2)_