### PR TITLE
fix(solver): a bare function is not assignable to an index-augmented global Function (#16525)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -891,6 +891,9 @@ path = "tests/ts2430_cross_file_generic_heritage_tests.rs"
 name = "ts2430_cross_arena_index_signature_tests"
 path = "tests/ts2430_cross_arena_index_signature_tests.rs"
 [[test]]
+name = "ts2430_global_function_numeric_index_tests"
+path = "tests/ts2430_global_function_numeric_index_tests.rs"
+[[test]]
 name = "readonly_apparent_type_generic_constraint_tests"
 path = "tests/readonly_apparent_type_generic_constraint_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/ts2430_global_function_numeric_index_tests.rs
+++ b/crates/tsz-checker/tests/ts2430_global_function_numeric_index_tests.rs
@@ -1,0 +1,246 @@
+//! Augmenting the *global* `Function` interface with a numeric index signature
+//! makes a bare function value no longer assignable to `Function` — and, because
+//! `lib.es5.d.ts` declares `CallableFunction`/`NewableFunction extends Function`
+//! with `apply`/`call`/`bind` overloads whose `this` parameter is a function
+//! type, exposes those overrides as incompatible (`TS2430`).
+//!
+//! This is #16525's residual. #16473/#16519/#16534 made the overload-coverage
+//! pass reach the member comparison, but the underlying relation
+//! `check_subtype(fn, Function)` still answered assignable: the boxed-`Function`
+//! "second opinion" substitutes the global interface for the source, and when
+//! the target *is* the augmented global `Function`, that substitution is
+//! identity-true and masks the missing numeric index a concrete function value
+//! does not carry.
+//!
+//! `tsc` (6.0.2, `--target es2015 --lib es2015`, non-strict) reports `TS2322`
+//! for the direct `const g: Function = fn` assignment ("Index signature for type
+//! 'number' is missing") and `TS2430` for a user interface that extends the
+//! augmented `Function` with such an override. The un-augmented interface, a
+//! *string*-index augmentation, and the dual-`any`-index waiver all still accept
+//! a function, so the rule is scoped to an unwaived numeric index.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs_code_messages, load_compiled_lib_files};
+
+const TS2322: u32 = 2322;
+const TS2430: u32 = 2430;
+
+fn diags(source: &str) -> Vec<(u32, String)> {
+    // The full (compiled) `lib.es5.d.ts` is required: the numeric-index rule is
+    // exposed by `CallableFunction`/`NewableFunction extends Function`, and a
+    // user `interface Function` augmentation must merge into the *same* global
+    // interface the way the driver merges it. The stripped test lib does not.
+    let libs = load_compiled_lib_files(&["lib.es5.d.ts"]);
+    assert!(
+        !libs.is_empty(),
+        "compiled es5 lib fixture should be available"
+    );
+    check_source_with_libs_code_messages(source, "test.ts", CheckerOptions::default(), &libs)
+}
+
+fn has_code(source: &str, code: u32) -> bool {
+    diags(source).iter().any(|(c, _)| *c == code)
+}
+
+// =========================================================================
+// Direct assignment (TS2322): the relation `check_subtype(fn, Function)`.
+// =========================================================================
+
+#[test]
+fn augmented_global_function_rejects_a_bare_function_assignment() {
+    let source = r#"
+interface Bar { b: number; }
+interface Function { [n: number]: Bar; }
+declare const fn: (this: any) => any;
+const g: Function = fn;
+"#;
+    assert!(
+        has_code(source, TS2322),
+        "once `Function` carries a numeric index a bare function no longer \
+         satisfies it, got {:?}",
+        diags(source)
+    );
+}
+
+#[test]
+fn augmented_global_function_rejects_via_renamed_augmentation_members() {
+    // Nothing keys on the augmentation's member/value spelling — only on the
+    // fact that the *global* `Function` gained a numeric index.
+    let source = r#"
+interface Widget { payload: string; }
+interface Function { [slot: number]: Widget; }
+declare const handler: () => void;
+const stored: Function = handler;
+"#;
+    assert!(has_code(source, TS2322), "got {:?}", diags(source));
+}
+
+// =========================================================================
+// Interface heritage (TS2430): a user interface that extends the augmented
+// *global* `Function` with an *overloaded* `apply` whose `this` is a function
+// type — the user-space witness of `lib.es5.d.ts`'s
+// `CallableFunction`/`NewableFunction extends Function`. Two-or-more overloads
+// route the member through `check_interface_overload_coverage` →
+// `check_callable_subtype` → `are_this_parameters_compatible`, the exact path
+// the four conformance fixtures exercise on the lib interfaces.
+//
+// (The single-override form takes a different member path that this harness
+// does not reach for a lib base; the lib interfaces' overloads are what the
+// conformance fixtures actually score.)
+// =========================================================================
+
+#[test]
+fn overloaded_this_override_extending_augmented_global_function_is_ts2430() {
+    let source = r#"
+interface Bar { b: number; }
+interface Function { [n: number]: Bar; }
+interface MyCallable extends Function {
+    apply<T, R>(this: (this: T) => R, thisArg: T): R;
+    apply<T, A extends any[], R>(this: (this: T, ...args: A) => R, thisArg: T, args: A): R;
+}
+"#;
+    assert!(
+        has_code(source, TS2430),
+        "an overloaded function-typed `this` override cannot satisfy a base whose \
+         type (the augmented global `Function`) carries a numeric index, got {:?}",
+        diags(source)
+    );
+}
+
+#[test]
+fn renamed_binders_overloaded_override_extending_augmented_global_function_is_ts2430() {
+    // Nothing keys on the derived interface name or the augmentation's spelling.
+    let source = r#"
+interface Element { count: number; }
+interface Function { [slot: number]: Element; }
+interface Fluent extends Function {
+    apply<T, R>(this: (this: T) => R, thisArg: T): R;
+    apply<T, A extends any[], R>(this: (this: T, ...args: A) => R, thisArg: T, args: A): R;
+}
+"#;
+    assert!(has_code(source, TS2430), "got {:?}", diags(source));
+}
+
+#[test]
+fn overloaded_override_without_numeric_index_stays_silent() {
+    // The negative that localizes the rule to the numeric index: drop only the
+    // index augmentation and the overloaded function-typed `this` override is
+    // accepted (matching tsc, which flags these overrides only once `Function`
+    // becomes numeric-indexed).
+    let source = r#"
+interface MyCallable extends Function {
+    apply<T, R>(this: (this: T) => R, thisArg: T): R;
+    apply<T, A extends any[], R>(this: (this: T, ...args: A) => R, thisArg: T, args: A): R;
+}
+"#;
+    assert!(
+        !has_code(source, TS2430),
+        "without a numeric index on `Function` the override is valid, got {:?}",
+        diags(source)
+    );
+}
+
+// =========================================================================
+// String-index augmentation (concrete value): the same rule holds for a
+// non-`any` string index — the shape `objectTypeWithCallSignature-` /
+// `objectTypeWithConstructSignatureHidingMembersOfExtendedFunction.ts` give
+// `Function` (`data: number; [x: string]: Object`). tsc emits the same two
+// `this`-type `TS2430`s there. Only an `any`-valued string index is waived.
+// =========================================================================
+
+#[test]
+fn concrete_valued_string_index_augmentation_rejects_a_function() {
+    let source = r#"
+interface Function { data: number; [x: string]: Object; }
+declare const fn: (this: any) => any;
+const g: Function = fn;
+"#;
+    assert!(
+        has_code(source, TS2322),
+        "a concrete-valued string index is unsatisfiable by a bare function, got {:?}",
+        diags(source)
+    );
+}
+
+#[test]
+fn overloaded_override_extending_concrete_string_indexed_function_is_ts2430() {
+    let source = r#"
+interface Function { data: number; [x: string]: Object; }
+interface MyCallable extends Function {
+    apply<T, R>(this: (this: T) => R, thisArg: T): R;
+    apply<T, A extends any[], R>(this: (this: T, ...args: A) => R, thisArg: T, args: A): R;
+}
+"#;
+    assert!(has_code(source, TS2430), "got {:?}", diags(source));
+}
+
+// =========================================================================
+// Negatives: the rule must be scoped to an *unwaived* index on the
+// *global* `Function`.
+// =========================================================================
+
+#[test]
+fn unaugmented_global_function_still_accepts_a_function() {
+    let source = r#"
+declare const fn: (value: number) => string;
+const g: Function = fn;
+"#;
+    assert!(
+        !has_code(source, TS2322),
+        "with no augmentation a function is still assignable to `Function`, got {:?}",
+        diags(source)
+    );
+}
+
+#[test]
+fn any_valued_string_index_augmentation_still_accepts_a_function() {
+    // A permissive `any`-valued string index waives every index obligation
+    // (`indexSignaturesRelatedTo` short-circuit), so a function is still
+    // assignable. Only this `any` form is waived — see the concrete-valued
+    // cases below.
+    let source = r#"
+interface Function { [k: string]: any; }
+declare const fn: (this: any) => any;
+const g: Function = fn;
+"#;
+    assert!(
+        !has_code(source, TS2322),
+        "an `any`-valued string-index augmentation does not reject a function, got {:?}",
+        diags(source)
+    );
+}
+
+#[test]
+fn dual_any_index_augmentation_still_accepts_a_function() {
+    // A co-present `any`-valued string index waives the missing numeric index,
+    // matching tsc's `indexSignaturesRelatedTo` short-circuit.
+    let source = r#"
+interface Function { [k: string]: any; [n: number]: any; }
+declare const fn: (this: any) => any;
+const g: Function = fn;
+"#;
+    assert!(
+        !has_code(source, TS2322),
+        "a dual-any-index augmentation waives the numeric requirement, got {:?}",
+        diags(source)
+    );
+}
+
+#[test]
+fn compatible_override_under_augmented_global_function_stays_silent() {
+    // A `this: Function` override (not a function-typed `this`) still satisfies
+    // the augmented base, so the augmentation alone must not manufacture a
+    // TS2430 for every extender.
+    let source = r#"
+interface Bar { b: number; }
+interface Function { [n: number]: Bar; }
+interface Compatible extends Function {
+    apply(this: Function, thisArg: any): any;
+}
+"#;
+    assert!(
+        !has_code(source, TS2430),
+        "an override whose `this` is `Function` itself is still compatible, got {:?}",
+        diags(source)
+    );
+}

--- a/crates/tsz-solver/src/relations/compat.rs
+++ b/crates/tsz-solver/src/relations/compat.rs
@@ -1292,14 +1292,29 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         // bare function and still accepts a source that provides a numeric index.
         // The intrinsic `Function` and the un-augmented global interface carry no
         // such index and keep the fast-path. Mirror of the subtype-checker guard
-        // in `core_dispatch`/`visitor`. Companion to #16473.
+        // in `core_dispatch`/`visitor`. Companion to #16473;
+        // `function_target_has_unwaived_index` (vs the structural-only
+        // predicate) also resolves the augmentation on the intrinsic/boxed/`Lazy`
+        // `Function` reference — the receiver of `const g: Function = fn` — which
+        // is where this lawyer fast-path was still masking it (#16525).
         if self.is_function_target_member(target)
             && crate::type_queries::is_callable_type(self.interner, source)
-            && !self
-                .subtype
-                .function_structural_target_has_unwaived_number_index(target)
         {
-            return true;
+            if !self.subtype.function_target_has_unwaived_index(target) {
+                return true;
+            }
+            // The target requires a numeric index. A function value's apparent
+            // `Function` surface carries none, so a bare function/callable is
+            // *not* assignable — reject directly rather than falling through to
+            // the structural comparison, whose boxed-`Function` apparent surface
+            // (identical to the augmented target) would credit the source with
+            // the very index it lacks and wrongly accept (#16525). A hybrid
+            // callable that declares its *own* numeric index still defers to the
+            // structural comparison, which adjudicates that index against the
+            // target's.
+            if !self.subtype.callable_source_declares_index(source) {
+                return false;
+            }
         }
 
         // TS2859 complexity guard: check constituent-count cross-product before

--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -830,7 +830,21 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             )
         {
             let source_eval = self.evaluate_type(source);
-            if self.is_callable_type(source_eval) {
+            // A callable value satisfies the `Function` surface — EXCEPT when a
+            // user `interface Function { [n: number]: T }` augmentation gave the
+            // global interface an unwaived numeric index. A function value's
+            // apparent type carries no numeric index, so a bare callable no longer
+            // satisfies it; only a source that declares its own compatible numeric
+            // index does. Withhold this identity fast-path in that case and let the
+            // structural dispatch below reject it, matching `tsc`. This is the
+            // earliest of the function→`Function` acceptance sites and the one the
+            // `CallableFunction`/`NewableFunction extends Function` `this`-parameter
+            // comparison reaches (#16525); without this guard every downstream
+            // guard is dead code for that path.
+            if self.is_callable_type(source_eval)
+                && (!self.function_target_has_unwaived_index(target)
+                    || self.callable_source_declares_index(source_eval))
+            {
                 // North Star Fix: is_callable_type now respects allow_any correctly.
                 // If it returned true, it means either we're in permissive mode OR
                 // the source is genuinely a callable type.

--- a/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
+++ b/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
@@ -916,29 +916,30 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             )
             || is_function_structural;
         if is_function_target {
-            // A function's apparent type carries no numeric index, so a target
-            // that structurally matches the Function interface (apply/call/bind)
-            // but ALSO declares one — a user `interface Function { [n: number]: T }`
-            // augmentation — is not satisfied by a bare function. Defer it to the
-            // structural arms below (which reject a function and still accept a
-            // source that provides a numeric index) instead of the callable
-            // fast-path. Companion to #16473, which fixed the callable/object arms
-            // it did not reach; the intrinsic/un-augmented `Function` keeps `True`.
-            let structural_number_index_target = is_function_structural
-                && self.function_structural_target_has_unwaived_number_index(target);
-            if self.is_callable_type(source) && !structural_number_index_target {
+            // A function's apparent type carries no index signature, so a target
+            // that matches the `Function` surface but ALSO declares one (a user
+            // `interface Function { [n: number]: T }` / `{ [x: string]: Object }`
+            // augmentation) is not satisfied by a bare function. `function_target_
+            // has_unwaived_index` resolves the augmentation even when `target` is
+            // the intrinsic/boxed/`Lazy` global `Function` reference (the spelling
+            // `CallableFunction`/`NewableFunction extends Function` hands it),
+            // which #16473's structural-only check missed (#16525).
+            let indexed_target = self.function_target_has_unwaived_index(target);
+            if self.is_callable_type(source) && !indexed_target {
                 return SubtypeResult::True;
             }
-            // For structural Function interface targets (object types with apply/call/bind),
-            // allow non-callable object types to fall through to structural checking.
-            // This handles class instances that extend Function (e.g., `class Foo extends Function {}`),
-            // where the instance type has apply/call/bind methods but no call signature.
-            // TypeScript allows such types as valid instanceof RHS because they're structurally
-            // assignable to the Function interface.
+            // A non-callable object source (e.g. `class Foo extends Function {}`)
+            // falls through to structural checking.
             let source_is_object = object_shape_id(self.interner, source).is_some()
                 || object_with_index_shape_id(self.interner, source).is_some();
-            if (is_function_structural && source_is_object) || structural_number_index_target {
-                // Fall through to structural object-to-object comparison below
+            if indexed_target && !source_is_object {
+                // A bare function/callable cannot satisfy the index; reject
+                // directly — the structural arms below key off `target`'s
+                // unresolved shape and would miss an intrinsic/boxed augmentation.
+                return SubtypeResult::False;
+            }
+            if (is_function_structural && source_is_object) || indexed_target {
+                // Fall through to structural object-to-object comparison below.
             } else {
                 return SubtypeResult::False;
             }

--- a/crates/tsz-solver/src/relations/subtype/function_apparent.rs
+++ b/crates/tsz-solver/src/relations/subtype/function_apparent.rs
@@ -43,6 +43,14 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         if result.is_true() || Self::is_weak_type_shape(target_shape) {
             return result;
         }
+        // The boxed `Function` surface must not satisfy an unwaived numeric index
+        // the target requires — a concrete function value's apparent type carries
+        // none. When the target *is* the (augmented) global `Function`,
+        // `check_subtype(boxed_function, target)` would be identity-true and mask
+        // that deficit, so keep the existing rejection (#16525).
+        if self.function_target_has_unwaived_index(target) {
+            return result;
+        }
         let Some(boxed_function) = self
             .resolver
             .get_boxed_type(IntrinsicKind::Function)

--- a/crates/tsz-solver/src/relations/subtype/rules/intrinsics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/intrinsics.rs
@@ -384,24 +384,19 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         crate::type_queries::matches_global_function_interface_shape(self.interner, target)
     }
 
-    /// Whether a structural-`Function` target (apply/call/bind) additionally
-    /// declares a numeric index signature that a bare function cannot satisfy.
+    /// Whether `target`'s own object shape declares an index signature — of
+    /// *either* kind — that a bare function/callable value cannot satisfy.
     ///
-    /// `tsc` models a function value's apparent type as its call signatures plus
-    /// the members of the global `Function` interface, and that apparent type
-    /// carries **no** numeric index signature. So a target that matches the
-    /// Function surface but also declares `[n: number]: T` — the shape a user
-    /// `interface Function { [n: number]: T }` augmentation produces — is not
-    /// satisfied by a function no matter which other members it requires. The
-    /// intrinsic `Function` and the un-augmented global interface carry no such
-    /// index and are unaffected. Mirrors the dual-`any`-index waiver the object
-    /// index path already honors (`indexSignaturesRelatedTo` short-circuits a
-    /// target whose numeric and string indexes are both `any`), so the two paths
-    /// agree on `{ [k: string]: any; [n: number]: any }`.
-    pub(crate) fn function_structural_target_has_unwaived_number_index(
-        &self,
-        target: TypeId,
-    ) -> bool {
+    /// A function value's apparent type carries no index signature of its own, so
+    /// any index obligation the target declares is unsatisfiable — except the
+    /// waivers `tsc`'s `indexSignaturesRelatedTo` encodes: a `string` index whose
+    /// value type is `any` waives every index obligation for a non-primitive
+    /// source (`{ [k: string]: any }` / `Record<string, any>`), which subsumes
+    /// the numeric-only dual-`any` case. A non-`any` string index (e.g.
+    /// `[x: string]: Object`, the shape `objectTypeWith*HidingMembersOfExtended-
+    /// Function.ts` augment `Function` with) or a numeric index with no waiving
+    /// `any` string index is unsatisfiable.
+    fn function_structural_target_has_unwaived_index(&self, target: TypeId) -> bool {
         let shape_id = crate::visitors::visitor_extract::object_shape_id(self.interner, target)
             .or_else(|| {
                 crate::visitors::visitor_extract::object_with_index_shape_id(self.interner, target)
@@ -410,8 +405,96 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             return false;
         };
         let shape = self.interner.object_shape(shape_id);
+        if let Some(string_index) = shape.string_index.as_ref()
+            && string_index.key_type != TypeId::SYMBOL
+        {
+            if self.target_string_index_any_waives_missing_index(string_index.value_type) {
+                // An `any`-valued string index waives every index obligation.
+                return false;
+            }
+            // A concrete-valued string index is unsatisfiable by a bare function.
+            return true;
+        }
         shape.number_index.is_some()
             && !self.target_dual_any_index_waives_missing_number_index(&shape)
+    }
+
+    /// Whether the target — understood as (a reference to) the *global*
+    /// `Function` interface — carries an unwaived index signature (numeric or a
+    /// concrete-valued string index) that a bare function value cannot satisfy.
+    ///
+    /// [`Self::function_structural_target_has_unwaived_index`] answers this from
+    /// the target's *own* object shape, which suffices when the target has
+    /// already been expanded to that shape (the user-space
+    /// `interface MyFunction { …; [n: number]: T }` heritage form the
+    /// `function_source_numeric_index_target` tests pin). But when the target is
+    /// the intrinsic / boxed / still-`Lazy` reference to the global `Function`
+    /// interface — the type `Function.apply`'s `this: Function` parameter
+    /// carries, and the receiver of `const g: Function = fn` — its augmentation
+    /// is not visible on that bare reference. Resolve the reference (and, as a
+    /// fallback, the registered boxed `Function`) to its object shape and
+    /// re-check, so a user `interface Function { [n: number]: T }` (or
+    /// `{ [x: string]: Object }`) augmentation of the *global* interface is
+    /// honored no matter which spelling of it the relation is handed. This is
+    /// what closes #16525's `CallableFunction`/`NewableFunction extends Function`
+    /// residual: those overrides' `this`-parameter comparison resolves the base
+    /// `this` type to the global `Function`, which the augmentation makes
+    /// index-signed.
+    ///
+    /// Deliberately scoped to the global `Function` identity: a plain object
+    /// target without its own index is never made index-signed by an
+    /// augmentation living on `Function`.
+    pub(crate) fn function_target_has_unwaived_index(&mut self, target: TypeId) -> bool {
+        if self.function_structural_target_has_unwaived_index(target) {
+            return true;
+        }
+        // A global-`Function` reference the augmentation gave an index can reach
+        // here as a `Lazy(DefId)`/boxed/intrinsic handle rather than a raw shape
+        // (e.g. the `this: Function` parameter inside `lib.es5.d.ts`). Resolve it
+        // and re-check.
+        let resolved = self.evaluate_type(target);
+        if resolved != target && self.function_structural_target_has_unwaived_index(resolved) {
+            return true;
+        }
+        let is_global_function = intrinsic_kind(self.interner, target)
+            == Some(IntrinsicKind::Function)
+            || crate::type_queries::is_global_interface_by_identity_with_resolver(
+                self.interner,
+                self.resolver,
+                target,
+                IntrinsicKind::Function,
+            );
+        if !is_global_function {
+            return false;
+        }
+        // The intrinsic `Function` keyword evaluates to itself, not the interface
+        // shape; the augmentation lives on the boxed global `Function`. Resolve it.
+        let boxed = self
+            .resolver
+            .get_boxed_type(IntrinsicKind::Function)
+            .or_else(|| self.interner.get_boxed_type(IntrinsicKind::Function));
+        if let Some(boxed) = boxed {
+            let boxed_resolved = self.evaluate_type(boxed);
+            if self.function_structural_target_has_unwaived_index(boxed_resolved) {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Whether a function-like `source` declares its *own* index signature
+    /// (numeric or string). A bare function type never does; a hybrid callable
+    /// object may (`{ (): void; [n: number]: T }`). Used to decide whether a
+    /// callable source can satisfy a target that requires an index — its apparent
+    /// `Function` surface cannot, but its own declared index can (adjudicated by
+    /// the structural comparison).
+    pub(crate) fn callable_source_declares_index(&self, source: TypeId) -> bool {
+        crate::visitors::visitor_extract::callable_shape_id(self.interner, source).is_some_and(
+            |id| {
+                let shape = self.interner.callable_shape(id);
+                shape.number_index.is_some() || shape.string_index.is_some()
+            },
+        )
     }
 
     /// Get the apparent primitive shape for a type.

--- a/crates/tsz-solver/src/relations/subtype/visitor.rs
+++ b/crates/tsz-solver/src/relations/subtype/visitor.rs
@@ -858,9 +858,7 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
                 .check_function_to_callable_subtype(FunctionShapeId(shape_id), t_callable_id)
         } else if (self.target == TypeId::FUNCTION
             || self.checker.is_function_interface_structural(self.target))
-            && !self
-                .checker
-                .function_structural_target_has_unwaived_number_index(self.target)
+            && !self.checker.function_target_has_unwaived_index(self.target)
         {
             // Function expressions are assignable to the global `Function` interface.
             // Avoid expanding and comparing every `Function` interface member.
@@ -870,7 +868,10 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
             // the global interface. A function value's apparent type carries no
             // numeric index, so it cannot satisfy such a target; it falls through to
             // the structural object arm below, which rejects it via the boxed
-            // (index-free) `Function` interface. Companion to #16473.
+            // (index-free) `Function` interface. Companion to #16473;
+            // `function_target_has_unwaived_index` (vs the structural-only
+            // predicate) also catches the augmentation on the intrinsic/boxed/`Lazy`
+            // `Function` reference (#16525).
             SubtypeResult::True
         } else if object_shape_id(self.checker.interner, self.target).is_some()
             || object_with_index_shape_id(self.checker.interner, self.target).is_some()
@@ -893,18 +894,28 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
             // *direct* assignment to a weak type still triggers TS2559 because the
             // boxed `Function` interface has properties yet none in common with the
             // weak target.
-            let boxed_function = self
-                .checker
-                .resolver
-                .get_boxed_type(IntrinsicKind::Function)
-                .or_else(|| {
-                    self.checker
-                        .interner
-                        .get_boxed_type(IntrinsicKind::Function)
-                });
-            match boxed_function {
-                Some(boxed) => self.checker.check_subtype(boxed, self.target),
-                None => SubtypeResult::False,
+            //
+            // But the boxed `Function` substitution must not satisfy an unwaived
+            // numeric index the target requires: a concrete function value's
+            // apparent type carries none. When the target *is* the (augmented)
+            // global `Function`, `check_subtype(boxed_function, target)` would be
+            // identity-true and mask the deficit, so reject up front (#16525).
+            if self.checker.function_target_has_unwaived_index(self.target) {
+                SubtypeResult::False
+            } else {
+                let boxed_function = self
+                    .checker
+                    .resolver
+                    .get_boxed_type(IntrinsicKind::Function)
+                    .or_else(|| {
+                        self.checker
+                            .interner
+                            .get_boxed_type(IntrinsicKind::Function)
+                    });
+                match boxed_function {
+                    Some(boxed) => self.checker.check_subtype(boxed, self.target),
+                    None => SubtypeResult::False,
+                }
             }
         } else {
             SubtypeResult::False
@@ -928,15 +939,15 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
                 .check_callable_to_function_subtype(CallableShapeId(shape_id), t_fn_id)
         } else if (self.target == TypeId::FUNCTION
             || self.checker.is_function_interface_structural(self.target))
-            && !self
-                .checker
-                .function_structural_target_has_unwaived_number_index(self.target)
+            && !self.checker.function_target_has_unwaived_index(self.target)
         {
             // Callable object types are assignable to the global `Function` interface,
             // except when the target also declares a numeric index signature the
             // callable's apparent type does not provide — then defer to the
             // index-aware object arms below (`check_object_to_indexed`), which compare
-            // the callable's own indexes against the target's. Companion to #16473.
+            // the callable's own indexes against the target's. Companion to #16473;
+            // `function_target_has_unwaived_index` also catches the
+            // augmentation on the intrinsic/boxed/`Lazy` `Function` reference (#16525).
             SubtypeResult::True
         } else if let Some(t_shape_id) = object_shape_id(self.checker.interner, self.target) {
             // Callable <: Object — check callable's properties against object's required properties.


### PR DESCRIPTION
Closes #16525.

## Structural rule

When the global `Function` interface is augmented with an **unwaived index signature** — a user `interface Function { [n: number]: T }` or `{ [x: string]: Object }` — a bare function/callable value is no longer assignable to `Function`. A function value's apparent type carries no index signature of its own, and only an `any`-valued string index (which subsumes the dual-`any` numeric case) waives that obligation.

So `tsc` reports the two `lib.es5.d.ts` `TS2430`s for `CallableFunction`/`NewableFunction extends Function` (their `apply`/`call`/`bind` overloads take a function-typed `this` whose comparison against the now-indexed base `Function` fails) and `TS2322` for a direct `const g: Function = fn`. tsz did neither — every function→`Function` acceptance site answered assignable without consulting the augmentation.

This is the residual of #16525 after #16473/#16519/#16534 (which made the overload-coverage pass *reach* the member comparison). The comparison reached `are_this_parameters_compatible` correctly; the underlying `check_subtype((this: T) => R, Function)` still returned `true`.

## Owner layer

Solver relation (`tsz-solver`). The function→`Function` acceptance is decided at several layered sites; the earliest shadowed the rest:

- `relations/subtype/cache.rs` — the `is_global_interface_by_identity` fast-path (callable source → `True`) that runs **before** evaluation/dispatch. This is the site the `this`-parameter comparison reaches; unguarded, it made every downstream guard dead code.
- `relations/subtype/core_dispatch.rs`, `visitor.rs` (`visit_function`/`visit_callable`), `function_apparent.rs` (the boxed-`Function` "second opinion") — the structural arms.
- `relations/compat.rs` — the `CompatChecker` ("lawyer") fast-path.

New shared helper `function_target_has_unwaived_index` (`rules/intrinsics.rs`) answers "does this `Function` target carry an index a bare function can't satisfy", **resolving the augmentation even when the target is the intrinsic/boxed/`Lazy` global `Function` reference** (not a pre-expanded shape) — the spelling the lib `this: Function` parameter hands the relation. A callable source that declares its *own* index still defers to the structural comparison.

## Adjacent-case matrix

Oracle: `typescript@6.0.2`, `--target es2015 --lib es2015 --strict false`.

| case | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| all four conformance fixtures | 2× `TS2430` each | 0 | 2× `TS2430` each |
| `interface Function { [n: number]: Bar }` (numeric) | 2× `TS2430` | none | 2× `TS2430` |
| `interface Function { data; [x: string]: Object }` (concrete string) | 2× `TS2430` | none | 2× `TS2430` |
| `const g: Function = fn` (numeric / concrete-string aug) | `TS2322` | none | `TS2322` |
| un-augmented `Function` | ok | ok | ok |
| `[k: string]: any` / dual-`any` aug | ok | ok | ok |
| user interface extending augmented global `Function`, overloaded `this` override | `TS2430` | none | `TS2430` |
| renamed binders | same verdict (no name-keying) | — | same |

## Goal
Goal: hold

## Verification
- **Four conformance fixtures** via the release CLI against the pinned lib — each now emits exactly the two `lib.es5.d.ts` `TS2430`s at the same locations as tsc, with **no spurious user-code diagnostics**: `augmentedTypeBracketAccessIndexSignature`, `augmentedTypeAssignmentCompatIndexSignature`, `objectTypeWithCallSignatureHidingMembersOfExtendedFunction`, `objectTypeWithConstructSignatureHidingMembersOfExtendedFunction`.
- New `crates/tsz-checker/tests/ts2430_global_function_numeric_index_tests.rs` (11 tests: numeric/string/renamed/negatives/overloaded-heritage) — all green.
- `cargo test -p tsz-solver --lib` — 7643 passed, 0 failed.
- Adjacent suites green: `function_source_numeric_index_target_tests` (17), `function_source_any_index_waiver_tests` (11), `global_function_intrinsic_assignability_tests` (5), `ts2430_tests` (53), `function_bivariance` (11), `ts2430_cross_arena_index_signature_tests` (8), `weak_callable_target_assignability_tests` (6).
- `cargo clippy -p tsz-solver -p tsz-checker --lib --tests -- -D warnings` — clean.
- Arch line-size guard — all touched files ≤ 2000 lines.
- The change is additive (previously-silent acceptances now reject **only** for the augmented-`Function` shape; un-augmented `Function` is unchanged), so no existing passing row should move. `conformance.sh`/`emit`/`fourslash` not run locally (TypeScript submodule not checked out; the four rows are verified directly via the CLI above).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMmmanpH9sfzPj1wj4YoEK)_