### PR TITLE
fix(checker): drill an object-literal arrow body typed through a type alias, instantiated (#16542, #16548)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -1356,13 +1356,49 @@ impl<'a> CheckerState<'a> {
     }
 
     fn first_callable_return_type(&mut self, ty: TypeId) -> Option<TypeId> {
-        use crate::query_boundaries::diagnostics::{
-            callable_shape_for_type, function_shape, type_application,
-        };
+        use crate::query_boundaries::diagnostics::type_application;
 
         if let (Some(non_nullish), Some(_nullish_cause)) = self.split_nullish_type(ty) {
             return self.first_callable_return_type(non_nullish);
         }
+
+        if let Some(return_type) = self.resolved_callable_return_type(ty) {
+            return Some(return_type);
+        }
+
+        // An alias reference (`type Fn = () => string`) or a generic
+        // application (`G<string>` for `type G<T> = () => T`) exposes a
+        // callable only after evaluation. Evaluation also *instantiates*, so
+        // the application yields the instantiated return type (`string`), not
+        // the bare type parameter (`T`) an uninstantiated base would hand back
+        // — the distinction between a correct message and `not assignable to
+        // 'T'`. Only the return type crosses this boundary; the arrow-body
+        // drill's pointer is anchored from syntax, so a shared interned
+        // callable never leaks a foreign declaration here.
+        let evaluated = self.judge_evaluate(ty);
+        if evaluated != ty
+            && let Some(return_type) = self.resolved_callable_return_type(evaluated)
+        {
+            return Some(return_type);
+        }
+
+        // An application whose instantiation did not resolve to a callable
+        // still carries its base's signature (e.g. a partially applied or
+        // deferred form): fall back to the uninstantiated base.
+        if let Some(app) = type_application(self.ctx.types, ty) {
+            return self.first_callable_return_type(app.base);
+        }
+
+        None
+    }
+
+    /// The return type of `ty`'s first call signature, when `ty` is *already* a
+    /// materialized callable — a bare function type, a callable object, or an
+    /// interface with call signatures. Declines for a reference or application
+    /// that has not been evaluated to its callable form yet; those are resolved
+    /// by [`Self::first_callable_return_type`] through evaluation.
+    fn resolved_callable_return_type(&mut self, ty: TypeId) -> Option<TypeId> {
+        use crate::query_boundaries::diagnostics::{callable_shape_for_type, function_shape};
 
         if let Some(shape) = function_shape(self.ctx.types, ty) {
             return Some(shape.return_type);
@@ -1376,10 +1412,6 @@ impl<'a> CheckerState<'a> {
 
         if let Some(shape) = callable_shape_for_type(self.ctx.types, ty) {
             return shape.call_signatures.first().map(|sig| sig.return_type);
-        }
-
-        if let Some(app) = type_application(self.ctx.types, ty) {
-            return self.first_callable_return_type(app.base);
         }
 
         None

--- a/crates/tsz-checker/src/error_reporter/expected_type_from_return.rs
+++ b/crates/tsz-checker/src/error_reporter/expected_type_from_return.rs
@@ -273,14 +273,24 @@ impl<'a> CheckerState<'a> {
     }
 
     /// `(start, length, file)` of the function or constructor type `idx`
-    /// denotes, peeling parentheses.
+    /// denotes, peeling parentheses and following a type-alias reference into
+    /// its body.
     ///
-    /// Anything else — a union, an object type, a type reference — yields no
-    /// signature of its own for tsc to point at, so it declines. A reference is
-    /// deliberately *not* followed here: the arrow-body drill this pointer hangs
-    /// off never fires for an alias-annotated member in the first place (see the
-    /// `type_reference_annotation_*` test), so a hop at this site would be
-    /// unreachable complexity on a diagnostic path.
+    /// A member typed through an alias (`cb: Fn` for `type Fn = () => string`,
+    /// or a generic `cb: G<string>` for `type G<T> = () => T`) reaches here as a
+    /// type reference. Once the arrow-body drill fires for such a member — which
+    /// it now does, sourcing the *instantiated* return type through evaluation —
+    /// tsc anchors the pointer inside the alias's *own* declaration, at the
+    /// function type written there. So the reference is followed one alias hop:
+    /// `get_type_ref(..).type_name` resolves the alias regardless of any type
+    /// arguments, and the body is anchored **uninstantiated** (`() => T`, never
+    /// `() => string`) — the instantiated type the message names was already
+    /// sourced separately at the drill gate. The hop stays checking-file-local
+    /// (`local_type_alias_body`); an alias declared in another file declines
+    /// here rather than reading a foreign arena's `NodeIndex`.
+    ///
+    /// Anything else — a union, an object type, an unresolved reference — yields
+    /// no signature of its own for tsc to point at, so it declines.
     fn callable_type_node_anchor(
         &mut self,
         idx: NodeIndex,
@@ -295,6 +305,12 @@ impl<'a> CheckerState<'a> {
         if node.kind == syntax_kind_ext::PARENTHESIZED_TYPE {
             let inner = self.ctx.arena.get_wrapped_type(node)?.type_node;
             return self.callable_type_node_anchor(inner, depth + 1);
+        }
+        if node.kind == syntax_kind_ext::TYPE_REFERENCE {
+            let name_idx = self.ctx.arena.get_type_ref(node)?.type_name;
+            let owner_symbol = self.type_position_symbol(name_idx)?;
+            let body_idx = self.local_type_alias_body(owner_symbol)?;
+            return self.callable_type_node_anchor(body_idx, depth + 1);
         }
         if node.kind != syntax_kind_ext::FUNCTION_TYPE
             && node.kind != syntax_kind_ext::CONSTRUCTOR_TYPE

--- a/crates/tsz-checker/src/tests/expected_type_from_return_tests.rs
+++ b/crates/tsz-checker/src/tests/expected_type_from_return_tests.rs
@@ -214,11 +214,11 @@ fn block_bodied_function_expression_keeps_the_property_pointer() {
     );
 }
 
-/// A member annotated with a type *reference* still declines, and the reason is
-/// **not** in the pointer walk — recorded here because the obvious fix (hop the
-/// alias when anchoring) is a dead end that would add unreachable code.
+/// A member typed through a *type alias* (`cb: Fn` for `type Fn = () => string`)
+/// drills to the arrow body exactly as the inline form does, and the `TS6502`
+/// anchors inside the alias's own body — the frame tsz#16542 pinned as wrong.
 ///
-/// tsc anchors inside the alias body:
+/// tsc, oracle `d.ts` (`typescript@7.0.2 --strict --pretty`):
 ///
 /// ```text
 /// d.ts:3:29 - error TS2322: Type 'number' is not assignable to type 'string'.
@@ -227,29 +227,122 @@ fn block_bodied_function_expression_keeps_the_property_pointer() {
 ///                 ~~~~~~~~~~~~
 /// ```
 ///
-/// `Ref` resolves to a real binder symbol, so the symbol route reaches `cb`
-/// fine. The gap is a whole frame earlier: the arrow-body drill in
-/// `elaboration_object_properties` never fires for an alias-annotated member,
-/// so no `TS6502` attach site is reached at all. The witness is the pointer this
-/// diagnostic *does* carry — `TS6500`, which is only attached on the
-/// **undrilled** branch. Whatever makes that branch win for a member typed
-/// through an alias owns this row.
+/// The message names `string` (the alias's resolved return type), the primary
+/// lands on the offending `6`, and the pointer underlines `() => string` inside
+/// `Fn`, not `Fn` and not `cb`. The sibling `TS6500` — the witness of the old
+/// undrilled member frame — must be gone.
 #[test]
-fn type_reference_annotation_declines_because_the_arrow_body_is_never_drilled() {
+fn a_type_reference_annotated_member_drills_into_the_alias_body() {
     let source =
         "type Fn = () => string;\ninterface Ref { cb: Fn; }\nconst rf: Ref = { cb: () => 6 };\n";
     let diagnostic = only(&check_source_diagnostics(source), TS2322);
-    assert!(
-        !has_return_pointer(&diagnostic),
-        "an alias-annotated member is never drilled, so no TS6502 site is reached: {diagnostic:?}"
+    assert_eq!(
+        diagnostic.message_text, "Type 'number' is not assignable to type 'string'.",
+        "the drilled body names the alias's resolved return type: {diagnostic:?}"
     );
+    assert_eq!(
+        span_text(source, diagnostic.start, diagnostic.length),
+        "6",
+        "the primary anchors at the offending body expression: {diagnostic:?}"
+    );
+    let (start, length, _) = return_pointer(&diagnostic);
+    assert_eq!(span_text(source, start, length), "() => string");
+    assert_eq!(start, 10, "the anchor is inside Fn's body, not at Fn or cb");
     assert!(
         diagnostic
             .related_information
             .iter()
-            .any(|info| info.code == TS6500),
-        "the TS6500 pointer is the witness that the undrilled branch ran: {diagnostic:?}"
+            .all(|info| info.code != TS6500),
+        "the drilled frame drops the undrilled-branch TS6500 pointer: {diagnostic:?}"
     );
+}
+
+/// The generic-application form of the row above (tsz#16548): `cb: G<string>`
+/// for `type G<T> = () => T`. The trap that split it out is that the two halves
+/// disagree on instantiation — the message must name the *instantiated* return
+/// type `string`, while the pointer anchors in the alias body *uninstantiated*,
+/// underlining `() => T` (not `() => string`).
+///
+/// tsc, oracle `r6.ts`:
+///
+/// ```text
+/// r6.ts:3:28 - error TS2322: Type 'number' is not assignable to type 'string'.
+///   r6.ts:1:13 - The expected type comes from the return type of this signature.
+///     1 type G<T> = () => T;
+///                   ~~~~~~~
+/// ```
+#[test]
+fn a_generic_alias_application_drills_with_instantiated_return_and_uninstantiated_anchor() {
+    let source =
+        "type G<T> = () => T;\ninterface R6 { cb: G<string>; }\nconst v6: R6 = { cb: () => 6 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    assert_eq!(
+        diagnostic.message_text, "Type 'number' is not assignable to type 'string'.",
+        "the message names the instantiated return type, not the bare parameter T: {diagnostic:?}"
+    );
+    assert_eq!(span_text(source, diagnostic.start, diagnostic.length), "6");
+    let (start, length, _) = return_pointer(&diagnostic);
+    assert_eq!(
+        span_text(source, start, length),
+        "() => T",
+        "the pointer anchors the alias body uninstantiated"
+    );
+    assert_eq!(start, 12);
+    assert!(
+        diagnostic
+            .related_information
+            .iter()
+            .all(|info| info.code != TS6500),
+    );
+}
+
+/// Renamed binders: the alias-drill rule is structural, not keyed on any user
+/// name. Every binder is renamed and the anchor still lands inside the alias
+/// body, only the span moving. Oracled by construction from the row above.
+#[test]
+fn a_renamed_alias_reference_keeps_the_drill_rule() {
+    let source = "type Zed = () => string;\ninterface Zref { qux: Zed; }\nconst zz: Zref = { qux: () => 6 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    assert_eq!(
+        diagnostic.message_text,
+        "Type 'number' is not assignable to type 'string'."
+    );
+    let (start, length, _) = return_pointer(&diagnostic);
+    assert_eq!(span_text(source, start, length), "() => string");
+    assert_eq!(start, 11);
+}
+
+/// An alias *chain* (`type B = A` for `type A = () => string`): the drill
+/// resolves `B` to `A`'s function signature, and the anchor follows both hops to
+/// the function type declared in `A`'s body.
+#[test]
+fn an_alias_chain_reference_is_followed_to_the_declaring_alias_body() {
+    let source = "type A = () => string;\ntype B = A;\ninterface Rc { cb: B; }\nconst rc: Rc = { cb: () => 6 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    assert_eq!(
+        diagnostic.message_text,
+        "Type 'number' is not assignable to type 'string'."
+    );
+    let (start, length, _) = return_pointer(&diagnostic);
+    assert_eq!(span_text(source, start, length), "() => string");
+    assert_eq!(start, 9, "the anchor is in A's body, the chain's terminus");
+}
+
+/// A two-parameter generic application (`G2<number, string>` for
+/// `type G2<A, B> = () => B`): instantiation must select the *second* argument
+/// for the return type, so the message names `string` while the uninstantiated
+/// anchor underlines `() => B`.
+#[test]
+fn a_multi_parameter_generic_application_instantiates_the_right_argument() {
+    let source = "type G2<A, B> = () => B;\ninterface R2 { cb: G2<number, string>; }\nconst v2: R2 = { cb: () => 6 };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2322);
+    assert_eq!(
+        diagnostic.message_text, "Type 'number' is not assignable to type 'string'.",
+        "the return type is instantiated to the second argument: {diagnostic:?}"
+    );
+    let (start, length, _) = return_pointer(&diagnostic);
+    assert_eq!(span_text(source, start, length), "() => B");
+    assert_eq!(start, 16);
 }
 
 /// An alias chain in the *owner* position is followed — a different shape from


### PR DESCRIPTION
When an object-literal member's value is an expression-bodied arrow and the member is typed through a type alias (`cb: Fn` for `type Fn = () => string`) or a generic alias application (`cb: G<string>` for `type G<T> = () => T`), tsc's `elaborateArrowFunction` drills to the arrow **body**: the primary `TS2322` lands on the offending expression and carries a `TS6502` pointer anchored inside the alias's own declaration. tsz reported one frame too shallow — at the member name — with the sibling `TS6500` pointer instead.

**Structural rule.** When an object-literal member typed through a (possibly generic) type-alias reference is assigned an expression-bodied arrow whose body return mismatches, tsc drills to the body and anchors `TS6502` in the alias body; tsz now does the same through the checker's arrow-body drill (`elaboration_object_properties`) and the `TS6502` anchor walk (`expected_type_from_return`).

Two owners, fixed together — the drill needs the *instantiated* return type for its message while the pointer needs the *uninstantiated* declaration node, so they are sourced separately:

- **Drill gate** (`first_callable_return_type`): when the direct shape queries decline, resolve an alias reference / generic application through `judge_evaluate` before reading its return type. Evaluation instantiates, so `G<string>` yields the instantiated return type `string` — not the bare type parameter `T` that the uninstantiated `application.base` hop would hand back (the wrong-message trap #16548 documents).
- **Anchor** (`callable_type_node_anchor`): follow one checking-file-local type-alias hop (`type_position_symbol` + `local_type_alias_body`) into the alias body and underline the function type written there, **uninstantiated** (`() => T`), reusing the alias-hop primitives the sibling `annotation_signature_anchor` already uses.

Both issue witnesses now match the `typescript@7.0.2` oracle byte-for-byte — message names `string`, primary at the `6`, pointer at `() => string` / `() => T`. Adjacent cases pinned: renamed binders, an alias chain (`type B = A`), a two-parameter generic (`G2<number, string>` selecting the second argument), and an alias-to-type-literal.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib expected_type_from_return_tests` — 22/22 pass (the two pinned `#16542`/`#16548` rows flipped from asserting the divergence to asserting oracle parity; 4 new adjacent-case tests added).
- Ran the affected elaboration/return/object-literal modules together: 142 pass, 0 fail.
- `cargo clippy -p tsz-checker` clean; architecture size guard passes (all touched files < 2000 lines).
- Conformance snapshot (`conformance.sh snapshot --workers 12`) run against the saved baseline to confirm no regression — result appended in a comment.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01BcXbbU7NaTQaN8QzjddMmv)_