### PR TITLE
refactor(solver): simplify the Function-index guard (post-#16561 /simplify follow-up)

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
+++ b/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
@@ -928,21 +928,18 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             if self.is_callable_type(source) && !indexed_target {
                 return SubtypeResult::True;
             }
-            // A non-callable object source (e.g. `class Foo extends Function {}`)
-            // falls through to structural checking.
+            // Only a non-callable *object* source (e.g. `class Foo extends
+            // Function {}`, or a source declaring its own index) may still relate,
+            // via the structural object-to-object comparison below. A bare
+            // function/callable against an `indexed_target` is rejected here rather
+            // than falling through: the structural arms key off `target`'s
+            // unresolved shape and would miss an intrinsic/boxed augmentation.
             let source_is_object = object_shape_id(self.interner, source).is_some()
                 || object_with_index_shape_id(self.interner, source).is_some();
-            if indexed_target && !source_is_object {
-                // A bare function/callable cannot satisfy the index; reject
-                // directly — the structural arms below key off `target`'s
-                // unresolved shape and would miss an intrinsic/boxed augmentation.
+            if !(source_is_object && (is_function_structural || indexed_target)) {
                 return SubtypeResult::False;
             }
-            if (is_function_structural && source_is_object) || indexed_target {
-                // Fall through to structural object-to-object comparison below.
-            } else {
-                return SubtypeResult::False;
-            }
+            // else: fall through to structural object-to-object comparison below.
         }
 
         // Check if target is the global `Object` interface from lib.d.ts.

--- a/crates/tsz-solver/src/relations/subtype/rules/intrinsics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/intrinsics.rs
@@ -405,18 +405,14 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             return false;
         };
         let shape = self.interner.object_shape(shape_id);
-        if let Some(string_index) = shape.string_index.as_ref()
-            && string_index.key_type != TypeId::SYMBOL
-        {
-            if self.target_string_index_any_waives_missing_index(string_index.value_type) {
-                // An `any`-valued string index waives every index obligation.
-                return false;
-            }
-            // A concrete-valued string index is unsatisfiable by a bare function.
-            return true;
+        if let Some(string_index) = shape.string_index_signature() {
+            // An `any`-valued string index waives every index obligation; any
+            // concrete-valued one is unsatisfiable by a bare function.
+            return !self.target_string_index_any_waives_missing_index(string_index.value_type);
         }
+        // No (non-symbol) string index means no `any`-string waiver is possible,
+        // so an inherited numeric index is unsatisfiable on its own.
         shape.number_index.is_some()
-            && !self.target_dual_any_index_waives_missing_number_index(&shape)
     }
 
     /// Whether the target — understood as (a reference to) the *global*


### PR DESCRIPTION
Behavior-preserving cleanup of the `function_target_has_unwaived_index` helper family that #16561 introduced (the fix for #16525). A `/simplify` review pass found three in-scope quality improvements; this applies them.

## What changed

- `function_structural_target_has_unwaived_index` (`rules/intrinsics.rs`): reuse `ObjectShape::string_index_signature()` instead of the open-coded `shape.string_index.as_ref()` + `key_type != TypeId::SYMBOL` filter (the invariant that helper was created to centralize), and drop the now-dead `target_dual_any_index_waives_missing_number_index` call — the numeric tail is only reached after the string-index branch has already returned for every non-symbol string index, so the dual-`any` predicate (which requires an `any`-valued non-symbol string index) can never fire there. Collapses to `shape.number_index.is_some()`.
- `core_dispatch.rs` (`is_function_target` block): collapse the separate reject-guard + fall-through condition into a single `if !(source_is_object && (is_function_structural || indexed_target)) { return False }`. Verified equivalent across all cases — the earlier reject guaranteed `indexed_target ⇒ source_is_object` by the time the fall-through ran, so the two branches fold into one.

No behavior change — the merged decision logic is identical; this only removes a dead predicate call, a re-derived symbol-key filter, and one redundant branch.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts2430_global_function_numeric_index_tests` (11), `--test function_source_numeric_index_target_tests` (17), `--test function_source_any_index_waiver_tests` (11) — all green on top of the merged fix.
- Pre-commit gate (fmt + clippy `-p tsz-checker -p tsz-solver`) passed locally.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMmmanpH9sfzPj1wj4YoEK)_