### PR TITLE
fix(checker): follow re-export hub chains for a qualified-type-name anchor (#16503)

### DIFF
--- a/crates/tsz-checker/src/types/queries/lib.rs
+++ b/crates/tsz-checker/src/types/queries/lib.rs
@@ -860,8 +860,71 @@ impl<'a> CheckerState<'a> {
         let resolved = self
             .resolve_alias_symbol(anchor_src, visited_aliases)
             .unwrap_or(anchor_src);
+        // `resolve_alias_symbol` stops at the first *re-export hub* alias it
+        // reaches: `resolve_cross_file_export_from_file` returns the hub's own
+        // `export { X } from "./m"` / `export { default } from "./m"` specifier
+        // (registered to the hub's file) and the alias resolver returns it
+        // without recursing, because that specifier carries no member surface of
+        // its own. `tsc` resolves the qualified-name LHS with *namespace*
+        // meaning through the entire chain, so keep following the re-export
+        // edges to the terminal declaration before the `default`-slot hop — a
+        // present member then resolves and a missing one is `TS2694`, matching a
+        // direct import, instead of collapsing to the `TS2702` "used as a
+        // namespace" gate. A non-hub anchor (already terminal, or a namespace
+        // import) is left untouched.
+        let resolved = self
+            .follow_reexport_hub_for_type_anchor(resolved)
+            .unwrap_or(resolved);
         self.default_export_namespace_qualifier_target(resolved)
             .unwrap_or(resolved)
+    }
+
+    /// Follow a re-export **hub** alias to the terminal declaration it names.
+    ///
+    /// When the qualified-name anchor resolves to an intermediate
+    /// `export { X } from "./m"` (or `export { default } from "./m"`) specifier
+    /// — an `ALIAS` that still carries an `import_module` because it re-exports
+    /// across a further module boundary — this walks the re-export chain (via
+    /// [`Self::resolve_reexport_chain_to_declaration`], reading each hop from the
+    /// file that owns it so per-file raw `SymbolId`s never collide, #16465) to
+    /// the original namespace/enum/class/type declaration and registers it
+    /// against its declaring file for the caller's owner-relative reads.
+    ///
+    /// Returns `None` — leaving the caller on its existing anchor — when the
+    /// symbol is not a named/default re-export alias (a concrete declaration, a
+    /// `default`-slot alias with no `import_module`, or a `*` namespace import),
+    /// or when the chain does not advance. The terminal's namespace meaning is
+    /// judged by the same gate the direct-import path uses, so a re-exported
+    /// class still declines to `TS2702`.
+    fn follow_reexport_hub_for_type_anchor(&self, sym_id: SymbolId) -> Option<SymbolId> {
+        // Read the alias from its owning binder: a cross-file-registered raw id
+        // read against the current file's binder can hit an unrelated local at
+        // the same numeric id (#16465).
+        let owner_file = self.ctx.resolve_symbol_file_index(sym_id)?;
+        let owner_binder = self.ctx.get_binder_for_file(owner_file)?;
+        let symbol = owner_binder.get_symbol(sym_id)?;
+        if !symbol.has_any_flags(symbol_flags::ALIAS) {
+            return None;
+        }
+        let module_specifier = symbol.import_module()?;
+        // Only a concretely-named re-export (`export { X } from` /
+        // `export { default } from`) is a hub to follow. A `*` namespace import
+        // is its own anchor, and a `default`-slot alias with no `import_module`
+        // is handled by the `default`→namespace hop, not here.
+        let export_name = symbol.import_name()?;
+        if export_name == "*" {
+            return None;
+        }
+        let target_file = self
+            .ctx
+            .resolve_import_target_from_file(owner_file, module_specifier)?;
+        // The chain starts one module past the hub and is cycle-guarded, so it
+        // can never resolve back to this hub alias itself.
+        let (terminal, terminal_file) =
+            self.resolve_reexport_chain_to_declaration(target_file, export_name)?;
+        self.ctx
+            .register_symbol_file_target(terminal, terminal_file);
+        Some(terminal)
     }
 
     /// Re-anchor a qualified-name left anchor that resolved to a synthetic

--- a/crates/tsz-checker/tests/ts2702_qualifier_namespace_meaning_tests.rs
+++ b/crates/tsz-checker/tests/ts2702_qualifier_namespace_meaning_tests.rs
@@ -584,39 +584,94 @@ fn default_exported_class_member_access_stays_ts2702_not_ts2694() {
     );
 }
 
-/// Uncovered-and-pinned: a member reached *through a re-export hub*
-/// (`export { default } from './dep'`) is not resolved — tsc follows the hub to
-/// the original namespace and reports `TS2694 Namespace 'm2' has no exported
-/// member 'Missing'`, tsz reports `TS2702` (the qualifier resolves to a type
-/// with no namespace meaning). This is not specific to `default` — a named
-/// re-export hub (`export { Foo } from './dep'`) behaves identically — so it is
-/// a pre-existing gap in following re-export chains for a *type-position*
-/// qualified-name anchor, outside #16503's default-import member routing (the
-/// default→namespace hop only fires when the `default` slot's declaration is a
-/// bare identifier, which a re-export specifier is not). Pinned as today's
-/// behaviour so a future re-export-chain fix is caught by the change.
+// ---------------------------------------------------------------------------
+// #16503 (re-export-hub residual): a namespace/enum member reached *through a
+// re-export hub* (`export { default } from './dep'` or `export { Foo } from
+// './dep'`, chained) now resolves like `tsc`. The qualified-name type anchor
+// follows the re-export chain to the terminal declaration — a hub specifier is
+// itself an `ALIAS` with an `import_module`, so alias resolution used to stop
+// on it (it owns no member surface) and the qualifier fell to the `TS2702`
+// "used as a namespace" gate. Following the chain restores the member-lookup
+// path: a present member resolves and a missing one is `TS2694`.
+//
+// Oracled against `tsc` 6.0.2 (`--noEmit --strict --pretty false --target
+// es2022 --lib es2022`); `tsc` follows both the default and the named hub:
+//   main.ts(2,12): error TS2694: Namespace 'm' has no exported member 'Missing'.
+//   emain.ts(2,12): error TS2694: Namespace 'Color' has no exported member 'Nope'.
+// The message names the *target* namespace (bare, as everywhere else in this
+// suite — tsz does not reproduce `tsc`'s `getFullyQualifiedName` module prefix,
+// a separately-tracked display divergence, not this fix's concern).
+// ---------------------------------------------------------------------------
+
+/// A `export { default } from './dep'` hub over `export default <namespace>`:
+/// the present member resolves and the missing one is `TS2694` naming the
+/// target namespace — no longer the `TS2702` qualifier error.
 #[test]
-fn reexport_hub_member_is_currently_ts2702_not_ts2694() {
-    let default_hub = multi_file_codes_global_index(
+fn reexport_default_hub_namespace_member_resolves_and_missing_is_ts2694() {
+    const DEP: &str = "namespace m { export interface foo { a: number } }\nexport default m;\n";
+    const HUB: &str = "export { default } from './dep';\n";
+
+    let present = multi_file_diags_global_index(
         &[
-            (
-                "dep.ts",
-                "namespace m { export interface foo { a: number } }\nexport default m;\n",
-            ),
-            ("hub.ts", "export { default } from './dep';\n"),
+            ("dep.ts", DEP),
+            ("hub.ts", HUB),
+            ("main.ts", "import D from './hub';\nvar ok: D.foo;\n"),
+        ],
+        "main.ts",
+    );
+    assert_eq!(
+        present,
+        Vec::<(u32, String)>::new(),
+        "a present member resolves through the default hub"
+    );
+
+    let missing = multi_file_diags_global_index(
+        &[
+            ("dep.ts", DEP),
+            ("hub.ts", HUB),
             ("main.ts", "import D from './hub';\nvar bad: D.Missing;\n"),
         ],
         "main.ts",
     );
-    assert_eq!(default_hub, vec![2702], "re-export default hub is TS2702");
+    assert_eq!(
+        missing,
+        vec![(
+            2694,
+            "Namespace 'm' has no exported member 'Missing'.".to_string()
+        )],
+        "a missing member through the default hub is TS2694 naming the target namespace"
+    );
+}
 
-    let named_hub = multi_file_codes_global_index(
+/// The named-hub twin (`export { Foo } from './dep'`): `tsc` follows it the same
+/// way, proving the fix is a general re-export-chain resolution, not a
+/// default-export special case.
+#[test]
+fn reexport_named_hub_namespace_member_resolves_and_missing_is_ts2694() {
+    const DEP: &str = "export namespace Foo { export interface bar { a: number } }\n";
+    const HUB: &str = "export { Foo } from './dep';\n";
+
+    let present = multi_file_diags_global_index(
         &[
+            ("dep.ts", DEP),
+            ("hub.ts", HUB),
             (
-                "dep.ts",
-                "export namespace Foo { export interface bar { a: number } }\n",
+                "main.ts",
+                "import { Foo } from './hub';\nvar ok: Foo.bar;\n",
             ),
-            ("hub.ts", "export { Foo } from './dep';\n"),
+        ],
+        "main.ts",
+    );
+    assert_eq!(
+        present,
+        Vec::<(u32, String)>::new(),
+        "a present member resolves through the named hub"
+    );
+
+    let missing = multi_file_diags_global_index(
+        &[
+            ("dep.ts", DEP),
+            ("hub.ts", HUB),
             (
                 "main.ts",
                 "import { Foo } from './hub';\nvar bad: Foo.Missing;\n",
@@ -625,8 +680,127 @@ fn reexport_hub_member_is_currently_ts2702_not_ts2694() {
         "main.ts",
     );
     assert_eq!(
-        named_hub,
+        missing,
+        vec![(
+            2694,
+            "Namespace 'Foo' has no exported member 'Missing'.".to_string()
+        )],
+        "a missing member through the named hub is TS2694"
+    );
+}
+
+/// The enum twin of the default hub: `enum` carries `SymbolFlags.Namespace`, so
+/// `C.Red` resolves and `C.Nope` is `TS2694` naming the enum.
+#[test]
+fn reexport_default_hub_enum_member_resolves_and_missing_is_ts2694() {
+    const DEP: &str = "enum Color { Red, Green }\nexport default Color;\n";
+    const HUB: &str = "export { default } from './edep';\n";
+
+    let present = multi_file_diags_global_index(
+        &[
+            ("edep.ts", DEP),
+            ("ehub.ts", HUB),
+            ("main.ts", "import C from './ehub';\nvar ok: C.Red;\n"),
+        ],
+        "main.ts",
+    );
+    assert_eq!(
+        present,
+        Vec::<(u32, String)>::new(),
+        "a present enum member resolves through the default hub"
+    );
+
+    let missing = multi_file_diags_global_index(
+        &[
+            ("edep.ts", DEP),
+            ("ehub.ts", HUB),
+            ("main.ts", "import C from './ehub';\nvar bad: C.Nope;\n"),
+        ],
+        "main.ts",
+    );
+    assert_eq!(
+        missing,
+        vec![(
+            2694,
+            "Namespace 'Color' has no exported member 'Nope'.".to_string()
+        )],
+        "a missing enum member through the default hub is TS2694 naming the enum"
+    );
+}
+
+/// A *chained* hub (`hub2` re-exports the `default` of `hub`, which re-exports
+/// the `default` of `dep`): each hop is an `import_module` re-export alias, so
+/// the walk must compose across all of them to the terminal namespace.
+#[test]
+fn reexport_chained_default_hub_missing_member_is_ts2694() {
+    let missing = multi_file_diags_global_index(
+        &[
+            (
+                "dep.ts",
+                "namespace m { export interface foo { a: number } }\nexport default m;\n",
+            ),
+            ("hub.ts", "export { default } from './dep';\n"),
+            ("hub2.ts", "export { default } from './hub';\n"),
+            ("main.ts", "import D from './hub2';\nvar bad: D.Missing;\n"),
+        ],
+        "main.ts",
+    );
+    assert_eq!(
+        missing,
+        vec![(
+            2694,
+            "Namespace 'm' has no exported member 'Missing'.".to_string()
+        )],
+        "a chained default hub composes to the terminal namespace"
+    );
+}
+
+/// Anti-hardcoding: the chain-follow keys on the re-export edge's flags, not on
+/// any spelling. Renaming the namespace binder, the hub's export, and the local
+/// import leaves the behaviour and the target-relative message unchanged.
+#[test]
+fn reexport_hub_rule_is_binder_name_independent() {
+    let missing = multi_file_diags_global_index(
+        &[
+            (
+                "dep.ts",
+                "export namespace Payload { export interface bar { a: number } }\n",
+            ),
+            ("hub.ts", "export { Payload } from './dep';\n"),
+            (
+                "main.ts",
+                "import { Payload as Renamed } from './hub';\nvar bad: Renamed.Missing;\n",
+            ),
+        ],
+        "main.ts",
+    );
+    assert_eq!(
+        missing,
+        vec![(
+            2694,
+            "Namespace 'Payload' has no exported member 'Missing'.".to_string()
+        )],
+        "the message names the renamed target namespace, not the local alias"
+    );
+}
+
+/// Negative control: a default-exported **class** reached through a hub has no
+/// namespace meaning, so `D.X` stays `TS2702` and never becomes a member
+/// lookup — the terminal is judged by the same namespace-meaning gate the
+/// direct default-import path uses. Oracle-verified: `tsc` reports `TS2702`.
+#[test]
+fn reexport_default_hub_class_stays_ts2702_not_ts2694() {
+    let codes = multi_file_codes_global_index(
+        &[
+            ("dep.ts", "export default class D { m: number = 0 }\n"),
+            ("hub.ts", "export { default } from './dep';\n"),
+            ("main.ts", "import D from './hub';\nvar a: D.X;\n"),
+        ],
+        "main.ts",
+    );
+    assert_eq!(
+        codes,
         vec![2702],
-        "a named re-export hub behaves the same — the gap is not default-specific"
+        "a class reached through a default hub stays TS2702, never TS2694"
     );
 }


### PR DESCRIPTION
Fixes the remaining re-export-hub residual of #16503 (the direct default-import cases landed in #16528).

## Structural rule
When the left identifier of a **type-position** qualified name (`D.Member`) is a named/default import reached **through a re-export hub** — `export { default } from './dep'` or `export { Foo } from './dep'`, possibly chained — `tsc` resolves the LHS with *namespace* meaning through the entire re-export chain: a present member resolves and a missing one is `TS2694 "Namespace 'X' has no exported member '…'"`. tsz stopped at the hub's own re-export specifier (an `ALIAS` that still carries an `import_module`, which owns no member surface) and fell to the `TS2702` "used as a namespace" gate.

Owner layer: **checker** — `qualified_type_anchor_symbol` (`crates/tsz-checker/src/types/queries/lib.rs`). A new `follow_reexport_hub_for_type_anchor` walks the hub chain to the terminal declaration via the existing `resolve_reexport_chain_to_declaration`, reading each hop from its owning binder so per-file raw `SymbolId`s never collide (#16465), then registers the terminal for owner-relative reads. It runs *before* the existing `default`-slot→namespace hop, and only for a concretely-named re-export alias (a `*` namespace import, a `default`-slot alias with no `import_module`, and any concrete declaration are left untouched). The terminal is judged by the same namespace-meaning gate the direct-import path uses, so a re-exported **class** still declines to `TS2702`.

## Adjacent matrix (new tests, all oracled against `tsc` 6.0.2 `--noEmit --strict --pretty false --target es2022 --lib es2022`)
| Shape | Before | After |
| --- | --- | --- |
| default hub over `export default <namespace>`, present member | silent | resolves |
| default hub, missing member | `TS2702` | `TS2694` naming the target namespace |
| named hub (`export { Foo } from`), present + missing | `TS2702` | resolves / `TS2694` |
| enum default hub, present + missing | `TS2702` | resolves / `TS2694` |
| chained hub (`hub2`→`hub`→`dep`), missing | `TS2702` | `TS2694` |
| renamed binders + renamed import | — | `TS2694`, target-relative name |
| default-exported **class** through a hub (negative control) | `TS2702` | `TS2702` (unchanged) |

The message names the target namespace bare (`m`/`Color`/`Foo`/`Payload`), consistent with the rest of `ts2702_qualifier_namespace_meaning_tests` — tsz does not reproduce `tsc`'s `getFullyQualifiedName` module prefix, a separately-tracked display divergence outside this fix's scope.

## Goal
Goal: green

## Verification
- New + existing rows in `ts2702_qualifier_namespace_meaning_tests` (the pinned `reexport_hub_*` residual is replaced by asserting the correct `TS2694`): **28/28 pass**.
- Targeted checker regression across the blast radius (qualified names, namespaces, re-exports, default export/import, namespace imports, export-star): **~217 tests, 0 failures**.
- Pre-commit gate: `clippy` + architecture guard passed (this is the repo's per-merge CI lane).
- Emit/DTS: untouched (checker-only diagnostic path); local emit baseline requires the TypeScript submodule, which is not provisioned in this environment. Conformance runs in nightly CI.
- All new rows oracled against `tsc` 6.0.2.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2p5GA1Nuzx3bpfYTckMh8)_