### PR TITLE
fix(checker): a computed key keeps its missing-property primary code (#16443)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
@@ -4,6 +4,7 @@ use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
 use crate::error_reporter::fingerprint_policy::DiagnosticAnchorKind;
 use crate::query_boundaries::common as query_common;
 use crate::query_boundaries::common::ContextualTypeContext;
+use crate::query_boundaries::relation_types::RelationFailure;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -835,8 +836,30 @@ impl<'a> CheckerState<'a> {
                 // property in the target, tsc uses TS2322 instead.
                 let target_has_named_member_for_key = is_computed_property
                     && self.target_has_named_property_for_key(effective_param_type, &prop_name);
+                // A *missing-property* failure keeps its own code even when the
+                // member was written with a computed key. `tsc` runs
+                // `reportUnmatchedProperty` on the property relation itself and
+                // only a failure that is not missing-property falls back to the
+                // computed-property message, so the discriminator is the shape
+                // of the relation failure — never the kind of the key. Measured
+                // against `typescript@7.0.2` across every key kind that reaches
+                // here (late-bound `const` string, numeric `const`, enum member,
+                // `unique symbol`, well-known symbol): all report TS2741/TS2739.
+                // The negative control is a union-typed target member, whose
+                // failure is not missing-property and which keeps TS2418.
+                let computed_failure_is_missing_property = is_computed_property
+                    && target_has_named_member_for_key
+                    && matches!(
+                        self.call_arg_relation_outcome(source_prop_type, target_prop_type)
+                            .failure,
+                        Some(
+                            RelationFailure::MissingProperty { .. }
+                                | RelationFailure::MissingProperties { .. }
+                        )
+                    );
                 if is_computed_property
                     && !(is_computed_literal_key && target_has_named_member_for_key)
+                    && !computed_failure_is_missing_property
                 {
                     // `tsc` widens a computed-property value in `TS2418` only when
                     // the key resolves through an index signature (the contextual
@@ -844,17 +867,30 @@ impl<'a> CheckerState<'a> {
                     // the key matches a declared named member — e.g. a
                     // `unique symbol` property whose declared type is a literal —
                     // the fresh literal type is preserved instead.
-                    let computed_source = if target_has_named_member_for_key {
-                        self.expression_display_type_preferring_literal(
-                            prop_value_idx,
-                            source_prop_type,
-                        )
-                    } else {
-                        let widened = self
-                            .literal_type_from_initializer(prop_value_idx)
-                            .unwrap_or(source_prop_type);
-                        self.widen_literal_type(widened)
-                    };
+                    //
+                    // "Declared type is a literal" is the operative half, and it
+                    // is a property of the *target member type*, not of the key:
+                    // this is ordinary object-literal freshness, where a fresh
+                    // literal widens unless the contextual type is literal-
+                    // bearing. Oracled on `typescript@7.0.2`: a `unique symbol`
+                    // key against `{ [S]: 1 }` keeps `'2'`, and the same key
+                    // against `{ [S]: number }` widens to `'string'` — as does a
+                    // late-bound `const` string key against `{ inner: number }`.
+                    // Keyed on the target so both key kinds get one rule.
+                    let target_member_is_literal_bearing = self
+                        .computed_member_target_is_literal_bearing(target_prop_type_for_diagnostic);
+                    let computed_source =
+                        if target_has_named_member_for_key && target_member_is_literal_bearing {
+                            self.expression_display_type_preferring_literal(
+                                prop_value_idx,
+                                source_prop_type,
+                            )
+                        } else {
+                            let widened = self
+                                .literal_type_from_initializer(prop_value_idx)
+                                .unwrap_or(source_prop_type);
+                            self.widen_literal_type(widened)
+                        };
                     let src_str = self.format_type_for_assignability_message(computed_source);
                     let tgt_str =
                         self.format_type_for_assignability_message(target_prop_type_for_diagnostic);
@@ -1160,6 +1196,23 @@ impl<'a> CheckerState<'a> {
                         |ms| ms.iter().copied().any(has_named),
                     )
             })
+    }
+
+    /// `true` when `target_type` is a literal type, or a union any member of
+    /// which is, so a fresh literal written under it keeps its literal type
+    /// instead of widening. This is the contextual half of ordinary
+    /// object-literal freshness, asked of the computed member's *target* type.
+    fn computed_member_target_is_literal_bearing(&mut self, target_type: TypeId) -> bool {
+        let evaluated = self.evaluate_type_with_env(target_type);
+        let is_literal = |type_id: TypeId| {
+            crate::query_boundaries::common::is_literal_type(self.ctx.types, type_id)
+        };
+        [target_type, evaluated].into_iter().any(|candidate| {
+            crate::query_boundaries::common::union_members(self.ctx.types, candidate).map_or_else(
+                || is_literal(candidate),
+                |ms| ms.iter().copied().any(is_literal),
+            )
+        })
     }
 
     fn type_has_indexed_access_surface(&self, target_type: TypeId, depth: usize) -> bool {

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -173,6 +173,8 @@ mod commonjs_reentrant_surface_tests;
 mod commonjs_require_binding_type_meaning_tests;
 #[path = "tests/computed_alias_source_display_tests.rs"]
 mod computed_alias_source_display_tests;
+#[path = "tests/computed_key_missing_property_primary_code_tests.rs"]
+mod computed_key_missing_property_primary_code_tests;
 #[path = "tests/computed_member_name_diagnostic_display_tests.rs"]
 mod computed_member_name_diagnostic_display_tests;
 #[path = "tests/computed_symbol_name_unification_tests.rs"]

--- a/crates/tsz-checker/src/tests/call_elaboration_mutual_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/call_elaboration_mutual_relation_routing_arch_tests.rs
@@ -143,7 +143,11 @@ fn call_elaboration_object_literal_properties_use_relation_outcome_boundary() {
 
     assert_eq!(
         helper.matches("call_arg_relation_outcome(").count(),
-        7,
+        // 8th probe added by #16443 item 2: the computed-key branch decides
+        // from the relation's `RelationFailure` (missing-property or not)
+        // rather than from the kind of the key, so it asks the same boundary
+        // this contract exists to enforce.
+        8,
         "object literal property elaboration should route parameter-derived probes through call_arg_relation_outcome"
     );
     assert_eq!(

--- a/crates/tsz-checker/src/tests/computed_key_missing_property_primary_code_tests.rs
+++ b/crates/tsz-checker/src/tests/computed_key_missing_property_primary_code_tests.rs
@@ -1,0 +1,238 @@
+//! #16443 item 2 — an object-literal member written with a computed key keeps
+//! the *missing-property* primary code instead of collapsing to TS2418.
+//!
+//! Structural rule, oracled against `typescript@7.0.2`: when an object-literal
+//! property whose name is a computed key resolves to a named member of the
+//! target, and that member's own relation failure is a **missing-property**
+//! failure, `tsc` reports the missing-property code (TS2741 / TS2739) exactly
+//! as it does for a plainly written key. Only a failure that is *not*
+//! missing-property falls back to `Type of computed property's value is '{0}',
+//! which is not assignable to type '{1}'` (TS2418). tsz previously reported
+//! TS2418 for every non-syntactically-literal computed key, so
+//! `const rc: Comp = { [K]: { cp: 1 } }` lost the TS2741 that the identical
+//! `{ inner: { cp: 1 } }` and `{ ["inner"]: { cp: 1 } }` both produce.
+//!
+//! The discriminator is the **shape of the relation failure, never the kind of
+//! the key**. The oracle agrees across every key kind that reaches this site —
+//! a late-bound `const` string, a numeric `const`, an enum member, and a
+//! `unique symbol` — which is why the fix asks the relation gateway for its
+//! `RelationFailure` rather than inspecting the key expression.
+//!
+//! The second rule pinned here is the source display inside TS2418 itself.
+//! `tsc` widens a fresh literal value unless the *target member type* is
+//! literal-bearing — ordinary object-literal freshness, asked of the target
+//! rather than of the key. So `{ [S]: 2 }` against `{ [S]: 1 }` keeps `'2'`
+//! while `{ [S]: "s" }` against `{ [S]: number }` widens to `'string'`, and a
+//! late-bound string key behaves identically. tsz keyed that choice on whether
+//! the key named a member at all, so it printed the unwidened `'"s"'`.
+//!
+//! Binder names are varied throughout so no identifier string is load-bearing,
+//! and the negative controls (a union-typed target member, a literal-typed
+//! target member, a syntactically literal key) pin the shapes that must keep
+//! their current code and display.
+
+use crate::test_utils::check_source_strict_messages;
+
+fn codes(source: &str) -> Vec<u32> {
+    let mut codes: Vec<u32> = check_source_strict_messages(source)
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect();
+    codes.sort_unstable();
+    codes
+}
+
+fn message_for(source: &str, code: u32) -> Option<String> {
+    check_source_strict_messages(source)
+        .into_iter()
+        .find(|(c, _)| *c == code)
+        .map(|(_, message)| message)
+}
+
+// ---------------------------------------------------------------------------
+// Positive rows: the missing-property code survives a computed key.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn late_bound_const_string_key_keeps_ts2741_for_a_single_missing_property() {
+    let source = r#"
+const holder = "nested";
+type Wrapper = { nested: { alpha: number; beta: number } };
+const value: Wrapper = { [holder]: { alpha: 1 } };
+"#;
+    assert_eq!(codes(source), vec![2741]);
+    let message = message_for(source, 2741).expect("TS2741 for the missing member");
+    assert!(
+        message.contains("'beta'"),
+        "TS2741 must name the missing member, got: {message}"
+    );
+}
+
+#[test]
+fn late_bound_const_string_key_keeps_ts2739_for_several_missing_properties() {
+    let source = r#"
+const pick = "slot";
+type Holder = { slot: { first: number; second: number } };
+const built: Holder = { [pick]: {} };
+"#;
+    assert_eq!(codes(source), vec![2739]);
+}
+
+#[test]
+fn a_numeric_const_key_keeps_the_missing_property_code() {
+    let source = r#"
+const index = 0;
+type Slots = { 0: { lead: number; trail: number } };
+const filled: Slots = { [index]: { lead: 1 } };
+"#;
+    assert_eq!(codes(source), vec![2741]);
+}
+
+#[test]
+fn an_enum_member_key_keeps_the_missing_property_code() {
+    let source = r#"
+enum Names { Chosen = "chosen" }
+type Bag = { chosen: { one: number; two: number } };
+const packed: Bag = { [Names.Chosen]: { one: 1 } };
+"#;
+    assert_eq!(codes(source), vec![2741]);
+}
+
+#[test]
+fn a_unique_symbol_key_keeps_the_missing_property_code() {
+    let source = r#"
+declare const marker: unique symbol;
+type Marked = { [marker]: { left: number; right: number } };
+const tagged: Marked = { [marker]: { left: 1 } };
+"#;
+    assert_eq!(codes(source), vec![2741]);
+}
+
+#[test]
+fn a_non_elaboratable_value_still_reports_the_missing_property_code() {
+    // The value is a bare reference, so there is no nested object literal to
+    // descend into. tsc still reports the missing-property code, which is why
+    // the fix keys on the relation failure rather than on whether the value
+    // expression happens to be elaboratable.
+    let source = r#"
+const route = "carried";
+type Carrier = { carried: { near: number; far: number } };
+declare const supplied: {};
+const moved: Carrier = { [route]: supplied };
+"#;
+    assert_eq!(codes(source), vec![2739]);
+}
+
+#[test]
+fn renamed_binders_do_not_change_the_outcome() {
+    let source = r#"
+const zzz_key = "qqq_member";
+type Zzz_Target = { qqq_member: { mmm: number; nnn: number } };
+const zzz_value: Zzz_Target = { [zzz_key]: { mmm: 1 } };
+"#;
+    assert_eq!(codes(source), vec![2741]);
+    let message = message_for(source, 2741).expect("TS2741 for the missing member");
+    assert!(
+        message.contains("'nnn'"),
+        "TS2741 must name the missing member, got: {message}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls: shapes that must keep TS2418.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_union_typed_target_member_keeps_ts2418() {
+    // The failure is not a missing-property failure, so the computed-property
+    // message stands. This is the control that stops the fix from widening
+    // into "every computed key takes the named path".
+    let source = r#"
+const gate = "either";
+type Choice = { either: { only: number } | number };
+const chosen: Choice = { [gate]: {} };
+"#;
+    assert_eq!(codes(source), vec![2418]);
+}
+
+#[test]
+fn a_literal_typed_target_member_keeps_ts2418_and_its_unwidened_source() {
+    // Guards the display half: the target member is literal-bearing, so the
+    // fresh literal value must NOT widen.
+    let source = r#"
+declare const stamp: unique symbol;
+type Stamped = { [stamp]: 1 };
+const applied: Stamped = { [stamp]: 2 };
+"#;
+    assert_eq!(codes(source), vec![2418]);
+    let message = message_for(source, 2418).expect("TS2418 for the literal mismatch");
+    assert!(
+        message.contains("'2'") && message.contains("'1'"),
+        "the literal source must be preserved against a literal target, got: {message}"
+    );
+}
+
+#[test]
+fn a_syntactically_literal_computed_key_still_uses_the_plain_assignability_code() {
+    // `["member"]` is a property name, not a late-bound key: tsc reports
+    // TS2322 here, never TS2418. Unchanged by this fix, pinned so a later
+    // widening of the computed branch cannot silently capture it.
+    let source = r#"
+type Plain = { member: number };
+const written: Plain = { ["member"]: "text" };
+"#;
+    assert_eq!(codes(source), vec![2322]);
+}
+
+// ---------------------------------------------------------------------------
+// The TS2418 source display widens against a non-literal target member.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_late_bound_string_key_widens_its_source_against_a_non_literal_target() {
+    let source = r#"
+const label = "count";
+type Counter = { count: number };
+const tally: Counter = { [label]: "text" };
+"#;
+    assert_eq!(codes(source), vec![2418]);
+    let message = message_for(source, 2418).expect("TS2418 for the value mismatch");
+    assert!(
+        message.contains("'string'") && !message.contains("'\"text\"'"),
+        "a fresh literal must widen against a non-literal target, got: {message}"
+    );
+}
+
+#[test]
+fn a_unique_symbol_key_widens_its_source_against_a_non_literal_target() {
+    let source = r#"
+declare const badge: unique symbol;
+type Badged = { [badge]: number };
+const worn: Badged = { [badge]: "text" };
+"#;
+    assert_eq!(codes(source), vec![2418]);
+    let message = message_for(source, 2418).expect("TS2418 for the value mismatch");
+    assert!(
+        message.contains("'string'") && !message.contains("'\"text\"'"),
+        "a fresh literal must widen against a non-literal target, got: {message}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Documented remaining gap, pinned so it cannot regress silently either way.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn excess_property_inside_a_computed_members_value_is_a_known_gap() {
+    // tsc reports TS2353 for `extra` here. tsz reports nothing — the excess
+    // check does not descend into a computed member's object-literal value.
+    // Pre-existing and untouched by this fix (it is an excess-property gap,
+    // not a missing-property one); pinned as today's behaviour so whoever
+    // closes it has to flip this row deliberately.
+    let source = r#"
+const door = "room";
+type House = { room: { size: number } };
+const built: House = { [door]: { size: 1, extra: 2 } };
+"#;
+    assert_eq!(codes(source), Vec::<u32>::new());
+}


### PR DESCRIPTION
Closes **#16443 item 2** — the one row left in that family inside the corpus's **scoring surface**, since every other remaining row is `related_information` only.

An object-literal member written with a computed key lost its `TS2741`/`TS2739` missing-property code and reported `TS2418` instead. The computed branch in `elaboration_object_properties.rs` was selected from the **kind of the key** rather than from the shape of the relation failure.

## Structural rule

When an object-literal property whose name is a **computed key** resolves to a named member of the target, and that member's own relation failure is a **missing-property** failure, `tsc` reports the missing-property code exactly as it does for a plainly written key. Only a failure that is *not* missing-property falls back to `TS2418`. tsz now does the same through the checker's call-elaboration reporter, asking the relation gateway for its `RelationFailure` instead of inspecting the key expression.

The discriminator is the **shape of the failure, never the kind of the key** — that is not an assumption, it is what the oracle says. Every key kind that reaches this site agrees:

| key kind | oracle |
| --- | --- |
| late-bound `const` string | `TS2741` / `TS2739` |
| numeric `const` | `TS2741` |
| enum member | `TS2741` |
| `unique symbol` | `TS2741` |
| well-known symbol | `TS2741` (already correct on main) |

That uniformity is why the fix needs no key-kind special-casing, and it is what a naive "late-bound string keys take the named path" patch would have got wrong in four places.

### Second rule, same block: TS2418's own source display

`tsc` widens a fresh literal value unless the **target member type** is literal-bearing — ordinary object-literal freshness, asked of the *target* rather than of the key. tsz keyed that choice on whether the key named a member at all, so it printed the unwidened `'"s"'` where tsc prints `'string'`.

| shape | tsc | main | PR |
| --- | --- | --- | --- |
| `{ [S]: 2 }` against `{ [S]: 1 }` | `'2'` | `'2'` | `'2'` (control) |
| `{ [S]: "s" }` against `{ [S]: number }` | `'string'` | `'"s"'` | `'string'` |
| `{ [K]: "s" }` against `{ inner: number }` | `'string'` | `'"s"'` | `'string'` |

Both halves live in the same ~30-line block and are separable if a reviewer wants them split.

## Measured (pinned `typescript@7.0.2`, `--noEmit --strict --target es2022 --lib es2022`)

Four oracle files, 30 rows. **After this PR three of the four are byte-identical to tsc**, and the fourth differs only in one pre-existing row unrelated to this fix.

| # | shape | tsc | main | PR | |
|---|---|---|---|---|---|
| 1 | `[K]` const key, one missing prop | `TS2741` | `TS2418` | `TS2741` | **FIXED** |
| 2 | `[K]` const key, two missing props | `TS2739` | `TS2418` | `TS2739` | **FIXED** |
| 3 | `[K]` const key, five missing props | `TS2739` | `TS2418` | `TS2739` | **FIXED** |
| 4 | `[KN]` numeric const key, missing prop | `TS2741` | `TS2418` | `TS2741` | **FIXED** |
| 5 | `[E.A]` enum-member key, missing prop | `TS2741` | `TS2418` | `TS2741` | **FIXED** |
| 6 | `[S]` unique-symbol key, missing prop | `TS2741` | `TS2418` | `TS2741` | **FIXED** |
| 7 | `[K]` const key, **non-elaboratable** value | `TS2739` | `TS2418` | `TS2739` | **FIXED** |
| 8 | `[K]: "s"` vs `number` (display) | `'string'` | `'"s"'` | `'string'` | **FIXED** |
| 9 | `[S]: "s"` vs `number` (display) | `'string'` | `'"s"'` | `'string'` | **FIXED** |
| 10 | **union-typed** target member | `TS2418` | `TS2418` | `TS2418` | control |
| 11 | `[S]: 2` vs `{ [S]: 1 }` | `TS2418` `'2'` | same | same | control |
| 12 | `["inner"]` syntactic literal key | `TS2322` | same | same | control |
| 13 | `[LK]` non-const (widened) key | whole-object `TS2741` | same | same | control |
| 14 | `[Symbol.iterator]`, missing prop | `TS2741` | `TS2741` | `TS2741` | control |
| 15 | plain `inner:` key, missing prop | `TS2741` | same | same | control |

**FIXED 9 / BROKE 0.**

Row 7 is the row that settles the design. My first hypothesis was tsc's "descend into the value first, property-level message only if nothing deeper fired" — a bare reference value has nothing to descend into, and tsc *still* reports `TS2739`. Elaboratability is not the discriminator; the failure shape is.

## Deliberately left open, with the reason

**Excess property inside a computed member's value.** `const b: House = { [door]: { size: 1, extra: 2 } }` — tsc reports `TS2353` for `extra`; tsz reports **nothing**, before and after this diff. It is an excess-property gap rather than a missing-property one, reached through a different check, and it is unchanged here. Pinned as a test asserting today's empty output so whoever closes it has to flip the row deliberately rather than discover it.

## Verification

- new tests: **13 added** (7 positive, 4 negative controls, 1 renamed-binder control, 1 pinned known gap). **Non-vacuity measured, not argued:** with only `elaboration_object_properties.rs` reverted to `origin/main` (`git stash push -- <that file>`), **9 of 13 fail** — the 7 missing-property rows plus both widening rows — and all 4 controls pass both ways, which is correct for controls.
- `cargo test -p tsz-checker --lib -- computed_key_missing_property_primary_code` — **13/13**
- `cargo test -p tsz-checker --lib -- computed` — **pass** (pre-existing computed-key suites, no regressions)
- `cargo clippy -p tsz-checker --lib --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `scripts/arch/arch_guard.py` — `Architecture guardrails passed.` rc=0
- owner file is 1922 lines, under the 2000-line shard ceiling

### Gates owed, disclosed rather than argued away

- **Full untargeted `cargo test -p tsz-checker --lib`** hit this seat's documented long-tail-straggler behaviour (exceeded the 10-minute command cap; left running in the background past the point I could block on it). Targeted suites above are the primary evidence. I will post the count on this PR when it lands.
- **`compare-to-parent.sh` / conformance not run.** Unlike the rest of the #16443 family this change *is* in the scoring surface — it changes a primary code — so the usual "related-information only, cannot move the corpus" argument does **not** apply here and I am not making it. A seat with a warm `.target` should discharge a two-sided corpus diff before this is queued. The expected direction is a strict improvement (tsz's code moves onto tsc's on every measured row, with 4 controls pinning what must not move), but expected is not measured.
- `cargo nextest` is not installed on this cold cloud seat; used `cargo test` per the board's standing note.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Obsidian

---
_Generated by [Claude Code](https://claude.ai/code/session_013E3Wu8oToopuQygEtS3dvJ)_