### PR TITLE
test(checker): correct a TS2300 expectation that was a /tmp symlink artifact (#16546)

### DIFF
--- a/crates/tsz-checker/tests/js_jsdoc_diagnostics_tests.rs
+++ b/crates/tsz-checker/tests/js_jsdoc_diagnostics_tests.rs
@@ -458,8 +458,33 @@ fn checked_js_cross_file_typedef_and_script_globals_duplicate() {
     );
 }
 
+/// A default-imported, type-only `namespace` used as a value reports `TS2708`
+/// at each value position — and reports **nothing** on the declaration file.
+///
+/// This test previously also asserted `TS2300 "Duplicate identifier"` on the
+/// `.d.ts`. That expectation was an artifact of how it was oracled, not a rule.
+/// Reproducing the fixture under `/tmp` on macOS makes tsc load the declaration
+/// file **twice** — once as an explicit root spelled `/tmp/...` and once through
+/// module resolution spelled `/private/tmp/...`, because `/tmp` is a symlink —
+/// so the `declare module` block is declared twice and *that* is what collides.
+/// Measured against the pinned `typescript@7.0.2`:
+///
+/// ```text
+/// # fixture under /tmp (symlinked): the same file, reported under two paths
+/// ../../private/tmp/.../index.d.ts(8,20): error TS2300: Duplicate identifier 'TruffleContract'.
+/// node_modules/@truffle/contract/index.d.ts(8,20): error TS2300: Duplicate identifier 'TruffleContract'.
+///
+/// # same fixture under a real (non-symlinked) directory: no TS2300 at all
+/// caller.ts(2,20): error TS2708: Cannot use namespace 'TruffleContract' as a value.
+/// caller.ts(2,37): error TS2708: Cannot use namespace 'TruffleContract' as a value.
+/// ```
+///
+/// Same family as the `typingsLookup3` case-insensitive-filesystem trap: an
+/// environment artifact that reads as a language rule. The declaration file is
+/// now asserted clean of `TS2300` so the corrected expectation is pinned in
+/// both directions rather than merely dropped.
 #[test]
-fn checked_js_elided_default_namespace_import_reports_duplicate_and_value_errors() {
+fn checked_js_elided_default_namespace_import_reports_value_errors() {
     let files = [
         (
             "node_modules/@truffle/contract/index.d.ts",
@@ -500,8 +525,9 @@ console.log(typeof TruffleContract, TruffleContract);
         .map(|(code, _)| *code)
         .collect();
     assert!(
-        declaration_codes.contains(&2300),
-        "Expected TS2300 for default export colliding with namespace. Actual diagnostics: {declaration_diagnostics:#?}"
+        !declaration_codes.contains(&2300),
+        "A namespace and an `export default` naming it do not collide; the pinned \
+         tsc reports no TS2300 here. Actual diagnostics: {declaration_diagnostics:#?}"
     );
 
     let caller_diagnostics = compile_named_files(


### PR DESCRIPTION
Goal: hold

Closes #16546 — **by correcting the test, not the compiler.** I filed that issue this morning after measuring a `TS2300` that turned out to be an environment artifact. This documents and fixes it.

## What the failing assertion actually measured

`checked_js_elided_default_namespace_import_reports_duplicate_and_value_errors` asserted `TS2300 "Duplicate identifier 'TruffleContract'"` on the declaration file. Reproducing the fixture under `/tmp` on macOS, the pinned `typescript@7.0.2` does emit it — **twice, under two different spellings of the same file**:

```
../../private/tmp/.../node_modules/@truffle/contract/index.d.ts(8,20): error TS2300: Duplicate identifier 'TruffleContract'.
node_modules/@truffle/contract/index.d.ts(8,20): error TS2300: Duplicate identifier 'TruffleContract'.
```

`/tmp` is a symlink to `/private/tmp`, so the `.d.ts` is loaded once as an explicit root and once through module resolution. The `declare module "@truffle/contract"` block is therefore **declared twice**, and that is what collides — not the namespace against its own `export default`.

Re-running the identical fixture from a real, non-symlinked directory:

```
caller.ts(2,20): error TS2708: Cannot use namespace 'TruffleContract' as a value.
caller.ts(2,37): error TS2708: Cannot use namespace 'TruffleContract' as a value.
```

**No TS2300 at all.** A namespace and an `export default` naming it do not collide.

Same family as the `typingsLookup3` case-insensitive-filesystem trap: an environment artifact that reads as a language rule.

## What tsz actually does on this fixture — it is right

Measured without the symlink, `--allowJs --checkJs`:

| | tsc | tsz |
|---|---|---|
| `caller.js(1,8)` | `TS18042` | `TS18042` ✅ |
| `caller.js(2,20)` | `TS2708` | `TS2708` ✅ |
| `caller.js(2,37)` | `TS2708` | `TS2708` ✅ |
| declaration file | *(clean)* | *(clean)* ✅ |

So the test was failing because it demanded a diagnostic the pinned compiler does not produce.

## The change

- Corrected the assertion to `!contains(2300)`, so the right expectation is **pinned in both directions** rather than deleted — this shape must stay clean.
- Renamed to `checked_js_elided_default_namespace_import_reports_value_errors`; "duplicate" was never accurate.
- Kept the existing `TS2708 >= 2` caller assertion unchanged — that half was always correct and still passes.
- Recorded the symlink mechanism in a doc comment with both measured outputs, so it is not re-derived from scratch next time.

## Two real defects found while measuring — filed, not folded in

1. **`TS2708` is lost through a default import from an ambient module.** tsz reports it correctly for a *local* namespace (`namespace N { export type T = number } ; N` → `TS2708`, matching tsc, including under renamed binders) and correctly stays silent when the namespace has a value member. It emits **nothing** when the namespace is reached via `import Thing from "@pkg/thing"` against a `declare module` that does `export default Thing`. Narrow, real, and separate from this test.
2. **`TS18042` message text differs.** tsc says `Use 'import("@truffle/contract")'`; tsz says `Use 'import("@truffle/contract").TruffleContract'` — an extra `.TruffleContract` suffix.

Both go on #16546, which I have re-scoped away from the retracted `TS2300` premise.

## Verification

- `cargo nextest run -p tsz-checker --test js_jsdoc_diagnostics_tests` — **22/23**, and the single remaining failure is `checked_js_async_jsdoc_expression_body_ts2322_anchors_on_return_expr`, which **is** a `known-failures.txt` entry. Before this change the target had 2 failures, one of them ungated.
- `cargo nextest run -p tsz-checker --lib` — **10004/10004**
- `scripts/arch/arch_guard.py` — rc=0
- test-only; no compiler source touched, so conformance/emit cannot move.

This removes the last **ungated** failing test I found in this morning's gate audit (#16547 handled the other one and the six stale entries).

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5
Effort: xhigh
