### PR TITLE
fix(solver): the Function-interface fast path ignores a string index signature

### DIFF
--- a/crates/tsz-checker/tests/function_source_apparent_function_surface_tests.rs
+++ b/crates/tsz-checker/tests/function_source_apparent_function_surface_tests.rs
@@ -317,6 +317,36 @@ target = source;
 }
 
 #[test]
+fn function_still_fails_a_string_index_target() {
+    // #16525's sibling rule: a function's apparent type carries no string
+    // index signature either, so a `Function`-surface target that also
+    // declares one must reject a bare function just like the numeric case.
+    assert!(has_error_with_code(
+        r#"
+interface Bar { b: number; }
+declare var target: { [x: string]: Bar };
+declare var source: (x: any) => void;
+target = source;
+"#,
+        2322
+    ));
+}
+
+#[test]
+fn function_satisfies_an_any_valued_string_index_target() {
+    // A lone `any`-valued string index waives the requirement outright
+    // (`tsc`'s `indexSignaturesRelatedTo` short-circuit) — unlike the
+    // numeric case, it needs no paired `any`-valued number index.
+    assert!(is_clean(
+        r#"
+declare var target: { [x: string]: any };
+declare var source: (x: any) => void;
+target = source;
+"#
+    ));
+}
+
+#[test]
 fn function_still_satisfies_a_call_only_target() {
     assert!(is_clean(
         r#"

--- a/crates/tsz-solver/src/relations/compat.rs
+++ b/crates/tsz-solver/src/relations/compat.rs
@@ -1286,18 +1286,23 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
 
         // Function interface. A callable value satisfies the Function surface
         // (apply/call/bind) — unless the target additionally declares a numeric
-        // index signature (a user `interface Function { [n: number]: T }`
-        // augmentation), which a function's apparent type cannot satisfy. Such a
-        // target defers to the full structural comparison below, which rejects a
-        // bare function and still accepts a source that provides a numeric index.
-        // The intrinsic `Function` and the un-augmented global interface carry no
-        // such index and keep the fast-path. Mirror of the subtype-checker guard
-        // in `core_dispatch`/`visitor`. Companion to #16473.
+        // or string index signature (a user `interface Function { [n: number]: T
+        // }` or `interface Function { [x: string]: T }` augmentation), which a
+        // function's apparent type cannot satisfy. Such a target defers to the
+        // full structural comparison below, which rejects a bare function and
+        // still accepts a source that provides a matching index. The intrinsic
+        // `Function` and the un-augmented global interface carry no such index
+        // and keep the fast-path. Mirror of the subtype-checker guard in
+        // `core_dispatch`/`visitor`. Companion to #16473 (number index) and
+        // #16525 (string index sibling).
         if self.is_function_target_member(target)
             && crate::type_queries::is_callable_type(self.interner, source)
             && !self
                 .subtype
                 .function_structural_target_has_unwaived_number_index(target)
+            && !self
+                .subtype
+                .function_structural_target_has_unwaived_string_index(target)
         {
             return true;
         }

--- a/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
+++ b/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
@@ -916,17 +916,24 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             )
             || is_function_structural;
         if is_function_target {
-            // A function's apparent type carries no numeric index, so a target
-            // that structurally matches the Function interface (apply/call/bind)
-            // but ALSO declares one — a user `interface Function { [n: number]: T }`
-            // augmentation — is not satisfied by a bare function. Defer it to the
-            // structural arms below (which reject a function and still accept a
-            // source that provides a numeric index) instead of the callable
-            // fast-path. Companion to #16473, which fixed the callable/object arms
-            // it did not reach; the intrinsic/un-augmented `Function` keeps `True`.
+            // A function's apparent type carries no numeric or string index, so
+            // a target that structurally matches the Function interface
+            // (apply/call/bind) but ALSO declares one — a user `interface
+            // Function { [n: number]: T }` or `interface Function { [x: string]:
+            // T }` augmentation — is not satisfied by a bare function. Defer it
+            // to the structural arms below (which reject a function and still
+            // accept a source that provides a matching index) instead of the
+            // callable fast-path. Companion to #16473 (number index), which
+            // fixed the callable/object arms it did not reach, and #16525
+            // (string index sibling); the intrinsic/un-augmented `Function`
+            // keeps `True`.
             let structural_number_index_target = is_function_structural
                 && self.function_structural_target_has_unwaived_number_index(target);
-            if self.is_callable_type(source) && !structural_number_index_target {
+            let structural_string_index_target = is_function_structural
+                && self.function_structural_target_has_unwaived_string_index(target);
+            let structural_index_target =
+                structural_number_index_target || structural_string_index_target;
+            if self.is_callable_type(source) && !structural_index_target {
                 return SubtypeResult::True;
             }
             // For structural Function interface targets (object types with apply/call/bind),
@@ -937,7 +944,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             // assignable to the Function interface.
             let source_is_object = object_shape_id(self.interner, source).is_some()
                 || object_with_index_shape_id(self.interner, source).is_some();
-            if (is_function_structural && source_is_object) || structural_number_index_target {
+            if (is_function_structural && source_is_object) || structural_index_target {
                 // Fall through to structural object-to-object comparison below
             } else {
                 return SubtypeResult::False;

--- a/crates/tsz-solver/src/relations/subtype/rules/intrinsics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/intrinsics.rs
@@ -414,6 +414,38 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             && !self.target_dual_any_index_waives_missing_number_index(&shape)
     }
 
+    /// Whether a structural-`Function` target (apply/call/bind) additionally
+    /// declares a string index signature that a bare function cannot satisfy.
+    ///
+    /// Same rationale as [`Self::function_structural_target_has_unwaived_number_index`]
+    /// (companion to #16473), extended to the string-index sibling: a function
+    /// value's apparent type carries no string index either, so a target that
+    /// matches the `Function` surface but also declares `[x: string]: T` is not
+    /// satisfied by a function no matter which other members it requires.
+    ///
+    /// Unlike the number-index case, a lone `any`-valued string index waives the
+    /// requirement outright (`tsc`'s `indexSignaturesRelatedTo` treats a target
+    /// string index of `any` as satisfied by anything, string-indexed or not —
+    /// [`Self::target_string_index_any_waives_missing_index`]); it does not need
+    /// a paired `any`-valued number index the way the dual-any waiver does.
+    pub(crate) fn function_structural_target_has_unwaived_string_index(
+        &self,
+        target: TypeId,
+    ) -> bool {
+        let shape_id = crate::visitors::visitor_extract::object_shape_id(self.interner, target)
+            .or_else(|| {
+                crate::visitors::visitor_extract::object_with_index_shape_id(self.interner, target)
+            });
+        let Some(shape_id) = shape_id else {
+            return false;
+        };
+        let shape = self.interner.object_shape(shape_id);
+        shape
+            .string_index
+            .as_ref()
+            .is_some_and(|idx| !self.target_string_index_any_waives_missing_index(idx.value_type))
+    }
+
     /// Get the apparent primitive shape for a type.
     ///
     /// When primitives are used in object-like operations (e.g., `"hello".length`),

--- a/crates/tsz-solver/src/relations/subtype/visitor.rs
+++ b/crates/tsz-solver/src/relations/subtype/visitor.rs
@@ -861,16 +861,21 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
             && !self
                 .checker
                 .function_structural_target_has_unwaived_number_index(self.target)
+            && !self
+                .checker
+                .function_structural_target_has_unwaived_string_index(self.target)
         {
             // Function expressions are assignable to the global `Function` interface.
             // Avoid expanding and comparing every `Function` interface member.
             //
-            // Excluded: a target that also declares a numeric index signature — the
-            // shape a user `interface Function { [n: number]: T }` augmentation gives
-            // the global interface. A function value's apparent type carries no
-            // numeric index, so it cannot satisfy such a target; it falls through to
+            // Excluded: a target that also declares a numeric or string index
+            // signature — the shape a user `interface Function { [n: number]: T }`
+            // or `interface Function { [x: string]: T }` augmentation gives the
+            // global interface. A function value's apparent type carries neither
+            // index, so it cannot satisfy such a target; it falls through to
             // the structural object arm below, which rejects it via the boxed
-            // (index-free) `Function` interface. Companion to #16473.
+            // (index-free) `Function` interface. Companion to #16473 (number
+            // index) and #16525 (string index sibling).
             SubtypeResult::True
         } else if object_shape_id(self.checker.interner, self.target).is_some()
             || object_with_index_shape_id(self.checker.interner, self.target).is_some()
@@ -931,12 +936,16 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
             && !self
                 .checker
                 .function_structural_target_has_unwaived_number_index(self.target)
+            && !self
+                .checker
+                .function_structural_target_has_unwaived_string_index(self.target)
         {
             // Callable object types are assignable to the global `Function` interface,
-            // except when the target also declares a numeric index signature the
-            // callable's apparent type does not provide — then defer to the
-            // index-aware object arms below (`check_object_to_indexed`), which compare
-            // the callable's own indexes against the target's. Companion to #16473.
+            // except when the target also declares a numeric or string index
+            // signature the callable's apparent type does not provide — then defer
+            // to the index-aware object arms below (`check_object_to_indexed`),
+            // which compare the callable's own indexes against the target's.
+            // Companion to #16473 (number index) and #16525 (string index sibling).
             SubtypeResult::True
         } else if let Some(t_shape_id) = object_shape_id(self.checker.interner, self.target) {
             // Callable <: Object — check callable's properties against object's required properties.


### PR DESCRIPTION
Structural rule: when a target structurally matches the global `Function` interface (declares apply/call/bind) but ALSO carries a string index signature — a user `interface Function { [x: string]: T }` augmentation — a bare function or callable value's apparent type provides no string index, so `tsc` rejects the assignment. Confirmed against pinned `typescript@7.0.2`: `interface Function { [x: string]: Object }` alone reproduces the two lib-internal `TS2430`s on `CallableFunction`/`NewableFunction`; a plain extra member with no index signature does not trigger anything. tsz's "assignable to `Function`" fast path only excluded an unwaived *numeric* index signature (#16473); a string index signature fell through the same fast path uncontested, so the callable was wrongly accepted regardless of the missing index.

The fix mirrors #16473's guard: `function_structural_target_has_unwaived_string_index` (`crates/tsz-solver/src/relations/subtype/rules/intrinsics.rs`) is the string sibling of the existing number-index guard, wired into the same four call sites the number guard already reaches — `visitor.rs`'s `visit_function`/`visit_callable` arms, `core_dispatch.rs`'s instanceof-adjacent Function check, and `compat.rs`'s `AnyPropagationRules` mirror. Per the oracle, a lone `any`-valued string index waives the requirement outright (unlike the numeric case, which needs a *paired* `any`-valued number index) — matching the existing `target_string_index_any_waives_missing_index` semantics.

**This does not close #16525.** Probing the real `CallableFunction`/`NewableFunction extends Function` repro through both the unit-test harness and the CLI (with this fix applied) shows tsz never surfaces the `TS2430` at all, independent of this guard — the interface-heritage recheck that #16534 confirmed (via tracing) reaches `apply`'s this-parameter comparison does not fire through either harness for this exact case. That is a separate, deeper gate this session did not track down (posted as a NOTE on #16525's board thread and issue).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib function_source_apparent_function_surface_tests`: 29/29
- `cargo test -p tsz-solver --lib -- intrinsics compat`: 277/277
- `cargo test -p tsz-checker --test ts2430_cross_arena_index_signature_tests`: 8/8 (sibling #16534 family, no regression)
- `cargo test -p tsz-solver --lib`: 7643/7643
- `cargo test -p tsz-checker --lib`: 9977 passed, 0 failed; the only non-completing test is the pre-existing `ts2589` recursive-conditional hang (#15338), structurally unrelated to this change (matches #16534's own verification note).
- `cargo clippy --workspace --exclude tsz-conformance --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean
- `python3 scripts/arch/arch_guard.py`: clean
- Oracle-verified against pinned `typescript@7.0.2` for every row this session added: string index triggers, number index still triggers (regression guard for #16473), any-valued string index waives, any-valued number index alone does not waive (dual-any quirk needs a pair), plain extra member does not trigger.
- `compare-to-parent`/conformance snapshot not run this session (time-boxed hourly session): the diff is additive-only (previously-silent-true fast path now correctly declines in a narrow, oracle-pinned edge case), so no currently-passing row should move. Owed if a faster seat wants to confirm 0/0.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTp7yTZ8SWNQwnbKoEoAVw)_