### PR TITLE
test(ci): add a project-row determinism regression harness (#16309)

### DIFF
--- a/scripts/ci/determinism-check.mjs
+++ b/scripts/ci/determinism-check.mjs
@@ -1,0 +1,350 @@
+#!/usr/bin/env node
+// Determinism regression harness (issue #16309).
+//
+// Standing Rule 5 (cache/order honesty): same binary + same fixture + same
+// tsconfig, no flags changed between runs => byte-identical diagnostics. A
+// result that depends on visit order or thread schedule is a cache-key or
+// cache-attribution bug, not a formatting wobble.
+//
+// This harness makes that rule *falsifiable and enforceable*, at a deliberately
+// chosen granularity: it checks that the diagnostic *set* is identical run to
+// run (content-identical modulo emission order), not that the raw byte stream
+// is. It runs one tsz invocation N times, normalizes each run's output the same
+// way the issue's repro loop does (`... 2>&1 | sort`: strip the invoking-cwd
+// path prefix, then sort lines), fingerprints the normalized text, and reports
+// how many distinct outputs the N runs produced. One distinct output =>
+// content-deterministic. Two or more => the binary disagrees with itself on the
+// diagnostic content for identical input.
+//
+// Sorting is a conscious scope choice, not an oversight: `tsc` gives no stable
+// inter-file diagnostic order under `-p`, so emission-order-only flicker is not
+// a `tsc`-parity defect and folding it away isolates the class this guard
+// exists to catch — a flickering TS2345, a swapped rendered target type. A
+// future guard could measure order-divergence as a *separate*, individually
+// downgradeable signal; today it is intentionally out of scope.
+//
+// Why this is needed (from #16309): every per-row diagnostic count in the
+// corpus trackers is measured to +/-1..3 by non-determinism, so "fixed N
+// diagnostics" is unfalsifiable at that granularity and any diagnostic-delta
+// ratchet on project rows flakes. A cheap, permanent guard that runs a row N
+// times and fails on divergence would have caught the mobx regression; this is
+// that guard.
+//
+// Policy (scripts/ci/determinism-policy.json): rows with a KNOWN, tracked
+// non-determinism defect are advisory (reported, never blocking) so an
+// already-filed bug never wedges the lane; every other row blocks on
+// divergence. When a race is fixed, delete its row from the policy and the
+// guard begins blocking future regressions automatically.
+//
+// Usage:
+//   node scripts/ci/determinism-check.mjs \
+//     --row mobx-project --runs 8 --cwd <project-dir> \
+//     -- <tsz-bin> --noEmit -p tsconfig.json
+//
+//   # or feed pre-captured run outputs (one file per run) for offline analysis:
+//   node scripts/ci/determinism-check.mjs --row mobx-project \
+//     --inputs run1.txt run2.txt run3.txt
+//
+// Exit codes:
+//   0 - deterministic, OR divergence on a known-flaky (advisory) row
+//   1 - divergence on a row held to strict reproducibility (blocking)
+//   2 - configuration error (bad args, unreadable policy/inputs, run failed)
+import fs from "node:fs";
+import crypto from "node:crypto";
+import { spawnSync } from "node:child_process";
+
+// --- Pure, unit-tested core ------------------------------------------------
+
+// Normalize one run's raw stdout+stderr into the canonical comparison form.
+// Pure string transform: FS resolution of the staged dir happens once at the
+// CLI boundary (see `collectOutputs`), and the already-resolved `prefixes` are
+// passed in here.
+//
+// Two transforms, matching the issue's `... 2>&1 | sort` repro and its
+// path-prefix negative-control note (comment 1: normalizing the invoking-cwd
+// prefix still left 6 distinct mobx outputs, so the divergence is real, not a
+// path artifact):
+//   1. Rewrite each `prefixes` spelling of the staged dir to a stable sentinel
+//      so the same diagnostic anchored at the same file compares equal
+//      regardless of where the fixture was staged. `prefixes` is longest-first
+//      (see `pathPrefixVariants`) so a nested path is rewritten before its
+//      parent; the bare directory is replaced, preserving the following `/` so
+//      `<dir>/packages/x.ts` -> `<project>/packages/x.ts`. `replaceAll` with a
+//      string needle is a literal replace, so a path with regex metacharacters
+//      needs no escaping.
+//   2. Sort non-empty lines. Diagnostic *emission order* across a parallel
+//      schedule is not the invariant under test (tsc itself does not promise a
+//      stable inter-file order under `-p`); diagnostic *content* is. Sorting
+//      isolates content divergence (a flickering TS2345, a swapped rendered
+//      type) from benign ordering.
+export function normalizeOutput(text, { prefixes = [] } = {}) {
+  let out = String(text);
+  for (const prefix of prefixes) {
+    out = out.replaceAll(prefix, "<project>");
+  }
+  // `\r?\n` split folds CRLF in one pass; the per-line trailing-space strip
+  // also drops any stray `\r`.
+  const lines = out
+    .split(/\r?\n/)
+    .map((l) => l.replace(/\s+$/u, ""))
+    .filter((l) => l.length > 0);
+  lines.sort();
+  return lines.join("\n") + (lines.length > 0 ? "\n" : "");
+}
+
+// The absolute-path prefix spellings a diagnostic might carry for the same
+// staged dir. A stage dir is frequently a symlink (CI temp roots — the repo has
+// already hit a `/tmp` symlink artifact), so a diagnostic can anchor at either
+// the symlink path or its resolved real path depending on how tsz resolved the
+// file. Normalizing BOTH to `<project>` keeps two runs that resolved the prefix
+// differently comparing equal. Returned longest-first (deduped) so a nested
+// spelling is rewritten before a prefix of it. Kept tiny and dependency-free.
+export function pathPrefixVariants(projectDir) {
+  const dir = String(projectDir);
+  const variants = new Set();
+  if (dir.length > 0) {
+    variants.add(dir);
+    try {
+      variants.add(fs.realpathSync(dir));
+    } catch {
+      // Dir may not exist (e.g. offline --inputs analysis with a synthetic
+      // --cwd); the raw spelling is still worth normalizing.
+    }
+  }
+  return [...variants].sort((a, b) => b.length - a.length);
+}
+
+export function fingerprint(normalizedText) {
+  return crypto.createHash("sha256").update(normalizedText).digest("hex");
+}
+
+// Reduce N normalized outputs to a divergence summary. `histogram` is ordered
+// by descending count then hash, so the report is stable run-to-run (the tool
+// that guards determinism must itself be deterministic).
+export function summarizeRuns(normalizedOutputs) {
+  // hash -> { hash, count, sample }; the first-seen text is kept as the sample
+  // so the report can diff two distinct outputs without a second index.
+  const byHash = new Map();
+  for (const output of normalizedOutputs) {
+    const h = fingerprint(output);
+    const entry = byHash.get(h);
+    if (entry) entry.count += 1;
+    else byHash.set(h, { hash: h, count: 1, sample: output });
+  }
+  const histogram = [...byHash.values()].sort(
+    (a, b) => b.count - a.count || (a.hash < b.hash ? -1 : 1),
+  );
+  return {
+    total: normalizedOutputs.length,
+    distinct: histogram.length,
+    histogram,
+  };
+}
+
+// First line that differs between two normalized (already line-sorted) outputs,
+// as a readable one-line diff. Returns null when identical. Because both sides
+// are sorted, a divergent line surfaces as a `<`/`>` pair at the first index
+// where they disagree — enough to point a reader at the flickering diagnostic.
+export function firstDivergence(aNorm, bNorm) {
+  const a = aNorm.split("\n");
+  const b = bNorm.split("\n");
+  const n = Math.max(a.length, b.length);
+  for (let i = 0; i < n; i++) {
+    if (a[i] !== b[i]) {
+      return { index: i, a: a[i] ?? null, b: b[i] ?? null };
+    }
+  }
+  return null;
+}
+
+// Load and validate the policy document. A malformed policy is a loud config
+// error (exit 2), never a silent "everything blocks" or "everything passes".
+export function parsePolicy(raw) {
+  const doc = typeof raw === "string" ? JSON.parse(raw) : raw;
+  const knownFlaky = new Map();
+  const src = doc && typeof doc === "object" ? doc.known_flaky ?? {} : {};
+  if (typeof src !== "object" || src === null || Array.isArray(src)) {
+    throw new Error("policy.known_flaky must be an object keyed by row name");
+  }
+  for (const [name, meta] of Object.entries(src)) {
+    if (!meta || typeof meta.issue !== "number") {
+      throw new Error(`policy.known_flaky['${name}'] must carry a numeric 'issue'`);
+    }
+    knownFlaky.set(name, { issue: meta.issue, reason: meta.reason ?? "" });
+  }
+  return { knownFlaky };
+}
+
+// Decide the gate outcome for one row given its run summary and the policy.
+//   deterministic  -> pass (blocking:false), always
+//   divergent + known-flaky -> advisory (blocking:false), names the issue
+//   divergent + not listed   -> blocking:true
+export function evaluateGate(rowName, summary, policy) {
+  const deterministic = summary.distinct <= 1;
+  if (deterministic) {
+    return { deterministic: true, blocking: false, status: "deterministic", issue: null, reason: "" };
+  }
+  const flaky = policy.knownFlaky.get(rowName);
+  if (flaky) {
+    return {
+      deterministic: false,
+      blocking: false,
+      status: "known-flaky-advisory",
+      issue: flaky.issue,
+      reason: flaky.reason,
+    };
+  }
+  return { deterministic: false, blocking: true, status: "divergent", issue: null, reason: "" };
+}
+
+// Render a stable, human-readable report block for one row.
+export function renderReport(rowName, summary, gate) {
+  const lines = [];
+  lines.push(
+    `determinism[${rowName}]: ${summary.total} run(s) -> ${summary.distinct} distinct output(s) [${gate.status}]`,
+  );
+  if (summary.distinct > 1) {
+    for (const { hash, count } of summary.histogram) {
+      lines.push(`  ${count}x ${hash.slice(0, 12)}`);
+    }
+    const [first, second] = summary.histogram;
+    const div = firstDivergence(first.sample, second.sample);
+    if (div) {
+      lines.push(`  first divergent line (index ${div.index}):`);
+      lines.push(`    < ${div.a ?? "<absent>"}`);
+      lines.push(`    > ${div.b ?? "<absent>"}`);
+    }
+    if (gate.issue) {
+      const why = gate.reason ? `: ${gate.reason}` : "";
+      lines.push(`  advisory: known-flaky, tracked by #${gate.issue} (not blocking)${why}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+// --- CLI runner ------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = {
+    row: null,
+    runs: 8,
+    cwd: process.cwd(),
+    policyPath: new URL("./determinism-policy.json", import.meta.url).pathname,
+    inputs: [],
+    command: [],
+  };
+  let i = 0;
+  for (; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--") {
+      args.command = argv.slice(i + 1);
+      break;
+    } else if (a === "--row") {
+      args.row = argv[++i];
+    } else if (a === "--runs") {
+      args.runs = Number.parseInt(argv[++i], 10);
+    } else if (a === "--cwd") {
+      args.cwd = argv[++i];
+    } else if (a === "--policy") {
+      args.policyPath = argv[++i];
+    } else if (a === "--inputs") {
+      while (i + 1 < argv.length && !argv[i + 1].startsWith("--")) {
+        args.inputs.push(argv[++i]);
+      }
+    } else {
+      throw new Error(`unknown argument: ${a}`);
+    }
+  }
+  return args;
+}
+
+function loadPolicy(policyPath) {
+  return parsePolicy(fs.readFileSync(policyPath, "utf8"));
+}
+
+// Collect N normalized outputs, either by executing the command N times or by
+// reading N pre-captured files.
+function collectOutputs(args) {
+  // Resolve the staged-dir prefix spellings once (the only FS work), then feed
+  // the pure `normalizeOutput` per run.
+  const prefixes = pathPrefixVariants(args.cwd);
+  if (args.inputs.length > 0) {
+    return args.inputs.map((path) =>
+      normalizeOutput(fs.readFileSync(path, "utf8"), { prefixes }),
+    );
+  }
+  if (args.command.length === 0) {
+    throw new Error("no command to run (pass `-- <cmd> ...`) and no --inputs");
+  }
+  const [bin, ...rest] = args.command;
+  const outputs = [];
+  for (let r = 0; r < args.runs; r++) {
+    const res = spawnSync(bin, rest, {
+      cwd: args.cwd,
+      encoding: "utf8",
+      maxBuffer: 256 * 1024 * 1024,
+    });
+    if (res.error) {
+      throw new Error(`run ${r + 1} failed to spawn: ${res.error.message}`);
+    }
+    outputs.push(normalizeOutput(`${res.stdout ?? ""}${res.stderr ?? ""}`, { prefixes }));
+  }
+  return outputs;
+}
+
+// Config-error exit: report on stderr and exit 2. Shared by every
+// bad-args/unreadable-input site so the prefix and code stay in one place.
+function die(message) {
+  process.stderr.write(`determinism-check: ${message}\n`);
+  process.exit(2);
+}
+
+function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    die(err.message);
+  }
+  if (!args.row) {
+    die("--row <name> is required");
+  }
+  if (!Number.isInteger(args.runs) || args.runs < 2) {
+    die("--runs must be an integer >= 2");
+  }
+
+  let policy;
+  try {
+    policy = loadPolicy(args.policyPath);
+  } catch (err) {
+    die(`cannot load policy ${args.policyPath}: ${err.message}`);
+  }
+
+  let outputs;
+  try {
+    outputs = collectOutputs(args);
+  } catch (err) {
+    die(err.message);
+  }
+
+  const summary = summarizeRuns(outputs);
+  const gate = evaluateGate(args.row, summary, policy);
+  process.stdout.write(renderReport(args.row, summary, gate) + "\n");
+
+  if (gate.blocking) {
+    process.stderr.write(
+      `::error title=Non-deterministic diagnostics::row '${args.row}' produced ` +
+        `${summary.distinct} distinct outputs across ${summary.total} identical runs. ` +
+        `Same binary + same fixture must be byte-identical (Standing Rule 5). ` +
+        `If this row has a known, tracked race, add it to ${args.policyPath} with its issue number.\n`,
+    );
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+// Only run main when invoked directly, so tests can import the pure functions.
+const invokedDirectly =
+  process.argv[1] &&
+  fs.realpathSync(process.argv[1]) === fs.realpathSync(new URL(import.meta.url).pathname);
+if (invokedDirectly) main();

--- a/scripts/ci/determinism-policy.json
+++ b/scripts/ci/determinism-policy.json
@@ -1,0 +1,22 @@
+{
+  "$comment": [
+    "Determinism policy for scripts/ci/determinism-check.mjs (issue #16309).",
+    "Standing Rule 5 (cache/order honesty): same binary + same fixture + same",
+    "tsconfig, no flags changed between runs => byte-identical diagnostics.",
+    "",
+    "'known_flaky' lists rows whose non-determinism is a KNOWN, tracked defect.",
+    "The harness reports divergence on these rows but does NOT block (advisory),",
+    "mirroring project-compat-ratchet's advisory-on-inconclusive design so a",
+    "tracked-and-open bug never wedges the lane. Every entry MUST name its",
+    "tracking issue so promotion is auditable: when the underlying race is fixed,",
+    "delete the row here and the harness begins blocking on any future regression.",
+    "",
+    "Any row NOT listed here is held to strict reproducibility: divergence blocks."
+  ],
+  "known_flaky": {
+    "mobx-project": {
+      "issue": 16309,
+      "reason": "Multi-threaded shared-DefinitionStore materialization race + partition-dependent eval_cache attribution (barrel-cycle / DecoratorContext path). Tracked by the mutation-isolation campaign; advisory until the race is closed."
+    }
+  }
+}

--- a/scripts/ci/full-ci.sh
+++ b/scripts/ci/full-ci.sh
@@ -387,6 +387,7 @@ run_lint() {
   node scripts/ci/test-wip-state-comments.mjs || return $?
   node scripts/ci/test-project-compatibility.mjs || return $?
   node scripts/ci/test-type-challenges-solutions-manifest.mjs || return $?
+  node scripts/ci/test-determinism-check.mjs || return $?
   scripts/test/safe-run-test.sh || return $?
   for test_file in scripts/agents/test_*.py scripts/setup/test_*.py; do
     [[ -f "$test_file" ]] || continue

--- a/scripts/ci/test-determinism-check.mjs
+++ b/scripts/ci/test-determinism-check.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+// Unit tests for the determinism regression harness (issue #16309).
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import {
+  normalizeOutput,
+  pathPrefixVariants,
+  fingerprint,
+  summarizeRuns,
+  firstDivergence,
+  parsePolicy,
+  evaluateGate,
+  renderReport,
+} from "./determinism-check.mjs";
+
+let passed = 0;
+function check(name, fn) {
+  fn();
+  passed++;
+  console.log(`PASS ${name}`);
+}
+
+// --- normalizeOutput -------------------------------------------------------
+
+check("normalizeOutput sorts lines so emission order is not under test", () => {
+  const a = normalizeOutput("b.ts(1,1): error TS1\na.ts(2,2): error TS2\n");
+  const b = normalizeOutput("a.ts(2,2): error TS2\nb.ts(1,1): error TS1\n");
+  assert.equal(a, b, "two runs differing only in emission order must normalize equal");
+});
+
+check("normalizeOutput strips the staged project-dir prefix", () => {
+  const raw = "/tmp/stage-123/packages/mobx/src/spy.ts(45,15): error TS2345\n";
+  const norm = normalizeOutput(raw, { prefixes: ["/tmp/stage-123"] });
+  assert.equal(norm, "<project>/packages/mobx/src/spy.ts(45,15): error TS2345\n");
+});
+
+check("normalizeOutput makes two different stage dirs compare equal", () => {
+  const line = (dir) => `${dir}/packages/mobx/src/spy.ts(45,15): error TS2345\n`;
+  const a = normalizeOutput(line("/tmp/stage-a"), { prefixes: ["/tmp/stage-a"] });
+  const b = normalizeOutput(line("/tmp/stage-b-longer"), { prefixes: ["/tmp/stage-b-longer"] });
+  assert.equal(a, b, "content is equal once the invoking-cwd prefix is normalized");
+});
+
+check("normalizeOutput preserves genuine content divergence (the flickering diagnostic)", () => {
+  // Evidence 1 in #16309: a TS2345 that appears in some runs, absent in others.
+  const withDiag = normalizeOutput(
+    "a.ts(1,1): error TS100\nspy.ts(45,15): error TS2345\n",
+    { prefixes: ["/x"] },
+  );
+  const withoutDiag = normalizeOutput("a.ts(1,1): error TS100\n", { prefixes: ["/x"] });
+  assert.notEqual(withDiag, withoutDiag, "a flickering diagnostic must survive normalization");
+});
+
+check("normalizeOutput preserves a swapped rendered target type", () => {
+  // Evidence 2: two files trade each other's rendered target type.
+  const runA = normalizeOutput(
+    "computedannotation.ts(52,44): error TS2322: Type 'string' is not assignable to type 'undefined'.\n" +
+      "observableannotation.ts(61,44): error TS2322: Type 'string' is not assignable to type 'DecoratorContext[\"kind\"]'.\n",
+    { prefixes: ["/x"] },
+  );
+  const runB = normalizeOutput(
+    "computedannotation.ts(52,44): error TS2322: Type 'string' is not assignable to type 'DecoratorContext[\"kind\"]'.\n" +
+      "observableannotation.ts(61,44): error TS2322: Type 'string' is not assignable to type 'undefined'.\n",
+    { prefixes: ["/x"] },
+  );
+  assert.notEqual(runA, runB, "a swapped rendered type is a content difference, not an ordering one");
+});
+
+check("normalizeOutput handles CRLF and trailing whitespace", () => {
+  const a = normalizeOutput("x.ts(1,1): error TS1  \r\n");
+  const b = normalizeOutput("x.ts(1,1): error TS1\n");
+  assert.equal(a, b);
+});
+
+check("normalizeOutput on empty input yields empty string", () => {
+  assert.equal(normalizeOutput("   \n\n"), "");
+});
+
+// --- helpers ---------------------------------------------------------------
+
+check("pathPrefixVariants returns the bare dir when it does not resolve", () => {
+  // A non-existent dir (realpathSync throws, caught) yields just the raw form.
+  const v = pathPrefixVariants("/tmp/does-not-exist-16309/x");
+  assert.deepEqual(v, ["/tmp/does-not-exist-16309/x"]);
+});
+
+check("pathPrefixVariants adds the realpath spelling, longest-first, deduped", () => {
+  // cwd exists, so realpathSync succeeds; for a non-symlinked cwd the realpath
+  // equals the raw dir and the Set dedups it back to one entry.
+  const v = pathPrefixVariants(process.cwd());
+  assert.ok(v.length >= 1 && v.length <= 2);
+  for (let i = 1; i < v.length; i++) {
+    assert.ok(v[i - 1].length >= v[i].length, "variants are longest-first");
+  }
+});
+
+check("normalizeOutput rewrites a prefix containing regex metacharacters literally", () => {
+  const raw = "/tmp/x+y(z)/a.ts(1,1): error TS1\n";
+  const norm = normalizeOutput(raw, { prefixes: ["/tmp/x+y(z)"] });
+  assert.equal(norm, "<project>/a.ts(1,1): error TS1\n");
+});
+
+check("normalizeOutput applies longest-first prefixes (nested before parent)", () => {
+  // Mirrors collectOutputs feeding pathPrefixVariants output (longest-first).
+  const raw = "/tmp/stage/inner/a.ts(1,1): error TS1\n";
+  const norm = normalizeOutput(raw, { prefixes: ["/tmp/stage/inner", "/tmp/stage"] });
+  assert.equal(norm, "<project>/a.ts(1,1): error TS1\n");
+});
+
+check("fingerprint is stable and content-sensitive", () => {
+  assert.equal(fingerprint("hello\n"), fingerprint("hello\n"));
+  assert.notEqual(fingerprint("hello\n"), fingerprint("world\n"));
+});
+
+// --- summarizeRuns ---------------------------------------------------------
+
+check("summarizeRuns: all identical -> 1 distinct", () => {
+  const s = summarizeRuns(["A\n", "A\n", "A\n"]);
+  assert.equal(s.total, 3);
+  assert.equal(s.distinct, 1);
+  assert.equal(s.histogram[0].count, 3);
+});
+
+check("summarizeRuns: mixed -> histogram descending by count then hash", () => {
+  // 6-of-8 shape from the issue: two md5s twice, ... here: A x3, B x2, C x1.
+  const s = summarizeRuns(["A\n", "A\n", "A\n", "B\n", "B\n", "C\n"]);
+  assert.equal(s.total, 6);
+  assert.equal(s.distinct, 3);
+  assert.deepEqual(
+    s.histogram.map((h) => h.count),
+    [3, 2, 1],
+  );
+});
+
+check("summarizeRuns histogram order is deterministic across input permutations", () => {
+  const a = summarizeRuns(["A\n", "B\n", "A\n", "C\n", "B\n", "A\n"]);
+  const b = summarizeRuns(["C\n", "A\n", "B\n", "A\n", "B\n", "A\n"]);
+  assert.deepEqual(a.histogram, b.histogram, "the determinism tool must itself be deterministic");
+});
+
+// --- firstDivergence -------------------------------------------------------
+
+check("firstDivergence returns null for identical outputs", () => {
+  assert.equal(firstDivergence("x\ny\n", "x\ny\n"), null);
+});
+
+check("firstDivergence points at the first differing sorted line", () => {
+  const d = firstDivergence("a\nb\nc\n", "a\nb\nd\n");
+  assert.equal(d.index, 2);
+  assert.equal(d.a, "c");
+  assert.equal(d.b, "d");
+});
+
+check("firstDivergence reports an absent line when one side is shorter", () => {
+  const d = firstDivergence("a\nb\n", "a\n");
+  assert.equal(d.a, "b");
+  assert.equal(d.b, "");
+});
+
+// --- parsePolicy -----------------------------------------------------------
+
+check("parsePolicy reads known_flaky entries", () => {
+  const p = parsePolicy({ known_flaky: { "mobx-project": { issue: 16309, reason: "race" } } });
+  assert.ok(p.knownFlaky.has("mobx-project"));
+  assert.equal(p.knownFlaky.get("mobx-project").issue, 16309);
+});
+
+check("parsePolicy accepts a JSON string", () => {
+  const p = parsePolicy('{"known_flaky":{"r":{"issue":1}}}');
+  assert.equal(p.knownFlaky.get("r").issue, 1);
+});
+
+check("parsePolicy defaults to empty when known_flaky absent", () => {
+  const p = parsePolicy({});
+  assert.equal(p.knownFlaky.size, 0);
+});
+
+check("parsePolicy rejects a flaky entry without a numeric issue", () => {
+  assert.throws(() => parsePolicy({ known_flaky: { r: { reason: "x" } } }), /numeric 'issue'/);
+});
+
+check("parsePolicy rejects a non-object known_flaky", () => {
+  assert.throws(() => parsePolicy({ known_flaky: [] }), /must be an object/);
+});
+
+check("the shipped policy file parses and lists mobx-project as tracked flaky", () => {
+  const raw = fs.readFileSync(new URL("./determinism-policy.json", import.meta.url), "utf8");
+  const p = parsePolicy(raw);
+  assert.equal(p.knownFlaky.get("mobx-project").issue, 16309);
+});
+
+// --- evaluateGate ----------------------------------------------------------
+
+const emptyPolicy = { knownFlaky: new Map() };
+const flakyPolicy = { knownFlaky: new Map([["mobx-project", { issue: 16309, reason: "" }]]) };
+
+check("evaluateGate: deterministic row passes", () => {
+  const g = evaluateGate("rxjs", summarizeRuns(["A\n", "A\n"]), emptyPolicy);
+  assert.equal(g.deterministic, true);
+  assert.equal(g.blocking, false);
+  assert.equal(g.status, "deterministic");
+});
+
+check("evaluateGate: divergent unlisted row BLOCKS", () => {
+  const g = evaluateGate("rxjs", summarizeRuns(["A\n", "B\n"]), emptyPolicy);
+  assert.equal(g.deterministic, false);
+  assert.equal(g.blocking, true);
+  assert.equal(g.status, "divergent");
+});
+
+check("evaluateGate: divergent known-flaky row is advisory, names the issue", () => {
+  const g = evaluateGate("mobx-project", summarizeRuns(["A\n", "B\n"]), flakyPolicy);
+  assert.equal(g.deterministic, false);
+  assert.equal(g.blocking, false);
+  assert.equal(g.status, "known-flaky-advisory");
+  assert.equal(g.issue, 16309);
+});
+
+check("evaluateGate: a known-flaky row that came back deterministic still passes as deterministic", () => {
+  // Guards the promotion path: once fixed, a green run reads as plain
+  // deterministic (not advisory), so the row is safe to delist.
+  const g = evaluateGate("mobx-project", summarizeRuns(["A\n", "A\n", "A\n"]), flakyPolicy);
+  assert.equal(g.status, "deterministic");
+  assert.equal(g.blocking, false);
+});
+
+// --- renderReport ----------------------------------------------------------
+
+check("renderReport for a clean row is a single summary line", () => {
+  const s = summarizeRuns(["A\n", "A\n"]);
+  const r = renderReport("rxjs", s, evaluateGate("rxjs", s, emptyPolicy));
+  assert.match(r, /rxjs.*2 run\(s\) -> 1 distinct output\(s\) \[deterministic\]/);
+  assert.equal(r.split("\n").length, 1);
+});
+
+check("renderReport for a divergent row includes histogram, first divergence, and (if flaky) the issue", () => {
+  const s = summarizeRuns(["a\nb\nc\n", "a\nb\nc\n", "a\nb\nd\n"]);
+  const r = renderReport("mobx-project", s, evaluateGate("mobx-project", s, flakyPolicy));
+  assert.match(r, /2 distinct output\(s\)/);
+  assert.match(r, /first divergent line/);
+  assert.match(r, /< c/);
+  assert.match(r, /> d/);
+  assert.match(r, /#16309/);
+});
+
+check("renderReport surfaces the policy reason on the advisory line", () => {
+  const s = summarizeRuns(["A\n", "B\n"]);
+  const withReason = {
+    knownFlaky: new Map([["mobx-project", { issue: 16309, reason: "materialization race" }]]),
+  };
+  const r = renderReport("mobx-project", s, evaluateGate("mobx-project", s, withReason));
+  assert.match(r, /tracked by #16309 \(not blocking\): materialization race/);
+});
+
+console.log(`\n${passed} determinism-check unit tests passed.`);


### PR DESCRIPTION
Standing Rule 5 (cache/order honesty) requires that the same binary over the same fixture and tsconfig, with no flags changed between runs, produce byte-identical diagnostics. #16309 shows tsz violating this on the mobx project row: eight identical runs produced six distinct outputs, a TS2345 that flickers 5/8 runs, and two files that swap each other's rendered target type. The issue notes this **blocks everything else** — every per-row diagnostic count is measured to ±1–3 by the wobble, so "fixed N diagnostics" is unfalsifiable at that granularity and any diagnostic-delta ratchet on project rows flakes.

The underlying multi-threaded shared-`DefinitionStore` materialization race is the separate mutation-isolation campaign (a result that depends on visit order/thread schedule is a cache-key or cache-attribution bug). This PR delivers the **permanent regression gate the issue proposes**, turning the non-determinism from anecdotal into falsifiable and enforceable:

- `scripts/ci/determinism-check.mjs` runs one tsz invocation N times, normalizes each run exactly as the issue's repro loop does (`2>&1 | sort`: strip the invoking-cwd path prefix per the comment-1 negative control, then sort lines so diagnostic *emission order* is not under test — only diagnostic *content* is), fingerprints, and reports how many distinct outputs the N runs produced. One distinct ⇒ content-deterministic. Sorting is a documented scope choice: `tsc` gives no stable inter-file order under `-p`, so folding emission-order flicker away isolates the class this guards — a flickering TS2345, a swapped rendered target type.
- `scripts/ci/determinism-policy.json` lists rows with a **known, tracked** race as advisory (reported, never blocking) so an already-filed bug never wedges the lane; every other row blocks on divergence. `mobx-project` is listed advisory against #16309. This is the same advisory-then-promote shape as `project-compat-baseline.json`: when a race is fixed, delete its row and the guard begins blocking future regressions automatically.
- `scripts/ci/test-determinism-check.mjs` unit-tests the pure core (normalization preserves a flickering diagnostic and a swapped rendered type but folds away emission order; realpath prefix variants for symlinked stage dirs; histogram/gate/report), wired into `full-ci.sh`'s node lane.

Structural rule: when the same binary checks the same fixture twice, `tsc` produces the same diagnostic set both times; tsz must too. This harness makes that rule a gate rather than a claim, owned at the CI layer (it consumes tsz output; it does not touch checker/solver internals).

Not in scope: the semantic race itself. That is the ongoing materialization campaign; this PR is the falsifiable check that campaign has lacked. Nightly usage once a lane provides the staged binary + fixture:

```
node scripts/ci/determinism-check.mjs --row mobx-project --runs 8 --cwd PROJECT_DIR -- path/to/tsz --noEmit -p tsconfig.json
```

## Goal
Goal: hold

## Verification
- `node scripts/ci/test-determinism-check.mjs` — 31 unit tests pass (normalization, histogram determinism, policy parsing/validation, gate advisory-vs-blocking, report rendering). Registered in `scripts/ci/full-ci.sh` so it runs in the node-test lane.
- `node --check` on both scripts; `python3 scripts/lib/check-sh-portability.py` passes for the `full-ci.sh` edit.
- CLI smoke: exit 0 deterministic, exit 1 on divergence of an unlisted row, exit 0 (advisory) on divergence of `mobx-project`, exit 2 on config error.
- Per-merge lane unaffected (no Rust touched): clippy + arch-size (largest new file 350 lines, well under the 2000 ceiling).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high