### PR TITLE
perf(solver): the eval-cache dependency collector stops re-deduplicating the lazy-def walk

### DIFF
--- a/crates/tsz-solver/src/caches/shared_instantiation.rs
+++ b/crates/tsz-solver/src/caches/shared_instantiation.rs
@@ -46,9 +46,12 @@ fn collect_def_dependencies(
     }
 
     for root in roots {
-        for def_id in crate::visitors::visitor::collect_lazy_def_ids(interner, root) {
+        // `push_def_dependency` already de-duplicates through `seen`, so feed
+        // the walk straight in rather than materializing a deduped `Vec` from
+        // `collect_lazy_def_ids` only to de-duplicate it a second time here.
+        crate::visitors::visitor::for_each_lazy_def_id(interner, root, |def_id| {
             push_def_dependency(def_id, &mut seen, &mut deps, &mut pending);
-        }
+        });
     }
 
     let Some(store) = definition_store else {

--- a/crates/tsz-solver/src/visitors/visitor.rs
+++ b/crates/tsz-solver/src/visitors/visitor.rs
@@ -485,18 +485,33 @@ pub(crate) fn walk_referenced_types_with_policy<F>(
     });
 }
 
+/// Invoke `f` for every lazy `DefId` reachable from `root`, in walk order and
+/// **without** de-duplication — a `DefId` reachable by more than one path is
+/// reported once per occurrence.
+///
+/// This is the allocation-free core of [`collect_lazy_def_ids`]. A caller that
+/// already maintains its own visited set (the eval-cache dependency collector
+/// does) feeds this directly instead of materializing an intermediate deduped
+/// `Vec` only to re-deduplicate it, which is redundant work on a hot memoization
+/// path.
+pub fn for_each_lazy_def_id(types: &dyn TypeDatabase, root: TypeId, mut f: impl FnMut(DefId)) {
+    walk_referenced_types(types, root, |type_id| {
+        if type_id.is_intrinsic() {
+            return;
+        }
+        if let Some(TypeData::Lazy(def_id)) = types.lookup(type_id) {
+            f(def_id);
+        }
+    });
+}
+
 /// Collect all unique lazy `DefIds` reachable from `root`.
 pub fn collect_lazy_def_ids(types: &dyn TypeDatabase, root: TypeId) -> Vec<DefId> {
     let mut out = Vec::new();
     let mut seen = FxHashSet::default();
 
-    walk_referenced_types(types, root, |type_id| {
-        if type_id.is_intrinsic() {
-            return;
-        }
-        if let Some(TypeData::Lazy(def_id)) = types.lookup(type_id)
-            && seen.insert(def_id)
-        {
+    for_each_lazy_def_id(types, root, |def_id| {
+        if seen.insert(def_id) {
             out.push(def_id);
         }
     });


### PR DESCRIPTION
`collect_def_dependencies` — the eval-cache invalidation-dependency collector in `caches/shared_instantiation.rs` — already maintains its own `seen` set as it folds every reachable lazy `DefId` into `push_def_dependency`. It fed that set from `collect_lazy_def_ids`, which builds a **separate** `FxHashSet` plus an intermediate `Vec` to return an already-deduplicated slice. So every root was walked, deduplicated once into a throwaway `Vec`, then deduplicated a **second** time into `seen`.

**Structural rule.** When a caller of the reachable-lazy-`DefId` walk already owns a visited set, it should not pay for a private `HashSet` + `Vec` and a redundant second dedup. This PR adds `for_each_lazy_def_id` — the allocation-free core of `collect_lazy_def_ids` — and feeds the dependency collector straight from the walk. `collect_lazy_def_ids` now delegates to `for_each_lazy_def_id`, so its public, de-duplicated behavior is unchanged. The collected dependency set is **byte-for-byte identical**; only the redundant allocation and second dedup are removed.

This was found while profiling **#16554** (comlink perf). That issue's specific +4.3% wall-clock step does **not** reproduce in any deterministic execution metric on x86/Linux (instructions, data accesses, L1/LL cache misses, branch mispredictions are all flat across the regression window — evidence posted on the issue). This change is an independent, architecture-independent reduction in the same hot path, not a fix for that regression.

## Goal
Goal: fast

## Verification
- **Callgrind instruction count** on comlink's own source (`comlink@4.4.1`: `comlink.ts` 622 + `node-adapter.ts` 49 + `protocol.ts` 111 = 782 lines, `--strict --target es2022 --lib es2022,dom`), a fast-goal benchmark row: `4,468,832,845 → 4,462,447,299` (**−6,385,546, −0.14%**), with **zero** diagnostic delta (identical output).
- `cargo test -p tsz-solver --lib` — 99 visitor + 635 instantiation/cache tests pass.
- Conformance snapshot (`conformance.sh snapshot --workers 12`): **11,499 passing, no regression** vs the committed baseline. The dependency set is unchanged, so eval-cache invalidation is unaffected — the change is behavior-identical by construction and confirmed end-to-end.
- `cargo clippy -p tsz-solver` clean; architecture size guard passes (both touched files well under 2000 lines).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01BcXbbU7NaTQaN8QzjddMmv)_