### PR TITLE
fix(checker): a computed const-key member's nested excess property is checked (#16443)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2691,3 +2691,6 @@ path = "tests/import_equals_alias_duplicate_function_container_tests.rs"
 [[test]]
 name = "qualified_default_import_enum_namespace_merge_root_tests"
 path = "tests/qualified_default_import_enum_namespace_merge_root_tests.rs"
+[[test]]
+name = "computed_key_nested_excess_property_tests"
+path = "tests/computed_key_nested_excess_property_tests.rs"

--- a/crates/tsz-checker/src/state/state_checking/property/excess_property_tail.rs
+++ b/crates/tsz-checker/src/state/state_checking/property/excess_property_tail.rs
@@ -1181,14 +1181,23 @@ impl<'a> CheckerState<'a> {
                 continue;
             };
 
-            // Get the property name from this element
+            // Get the property name from this element. A computed key backed by
+            // a `const` (`[door]: {...}` for `const door = "room"`) has no
+            // syntactic name, so this must resolve it through the same
+            // type-based path `get_property_name_resolved` uses elsewhere —
+            // otherwise a computed-keyed nested object literal never matches
+            // `prop_name` and its own excess properties go unchecked (#16443).
             let elem_prop_name = match elem_node.kind {
-                syntax_kind_ext::PROPERTY_ASSIGNMENT => self
-                    .ctx
-                    .arena
-                    .get_property_assignment(elem_node)
-                    .and_then(|prop| self.get_property_name(prop.name))
-                    .map(|name| self.ctx.types.intern_string(&name)),
+                syntax_kind_ext::PROPERTY_ASSIGNMENT => {
+                    let name_idx = self
+                        .ctx
+                        .arena
+                        .get_property_assignment(elem_node)
+                        .map(|prop| prop.name);
+                    name_idx
+                        .and_then(|idx| self.get_property_name_resolved(idx))
+                        .map(|name| self.ctx.types.intern_string(&name))
+                }
                 syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT => self
                     .ctx
                     .arena

--- a/crates/tsz-checker/tests/computed_key_nested_excess_property_tests.rs
+++ b/crates/tsz-checker/tests/computed_key_nested_excess_property_tests.rs
@@ -1,0 +1,155 @@
+//! TS2353 for an excess property nested inside a computed-key member's value.
+//!
+//! `check_nested_object_literal_excess_properties`
+//! (`crates/tsz-checker/src/state/state_checking/property/excess_property_tail.rs`)
+//! matches each outer object-literal element against the property name it is
+//! recursing on, but read that name with `get_property_name` — which
+//! deliberately declines a computed key backed by an identifier expression
+//! (`[door]` for `const door = "room"`), per its own doc comment: callers
+//! needing type-based resolution should use `get_property_name_resolved`
+//! instead. Because the match never succeeded, the recursive excess-property
+//! check into the computed member's own value never ran, so an excess
+//! property nested inside it went unreported. tsc's `elaborateElementwise`
+//! draws no such distinction — a computed key that resolves to a known
+//! member is checked the same as any other. Fixed by resolving the element's
+//! name through `get_property_name_resolved`, matching how the *source*
+//! object-literal type itself already resolves computed keys
+//! (`object_literal/computation.rs`).
+//!
+//! Oracle: `typescript@7.0.2`, `--noEmit --strict --pretty false --target
+//! es2022 --lib es2022`.
+
+use tsz_checker::test_utils::check_source_strict_messages;
+
+fn ts2353_messages(source: &str) -> Vec<String> {
+    check_source_strict_messages(source)
+        .into_iter()
+        .filter(|(code, _)| *code == 2353)
+        .map(|(_, message)| message)
+        .collect()
+}
+
+/// The issue's exact repro: a `const`-backed computed key's own value carries
+/// an excess property. tsc: `TS2353` on `extra`, quoting the resolved member
+/// type `'{ size: number; }'`.
+#[test]
+fn computed_const_key_nested_object_literal_reports_excess_property() {
+    let messages = ts2353_messages(
+        r#"
+const door = "room";
+type House = { room: { size: number } };
+const built: House = { [door]: { size: 1, extra: 2 } };
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2353: {messages:?}");
+    assert!(
+        messages[0].contains("'extra'") && messages[0].contains("'{ size: number; }'"),
+        "expected an excess-property message naming 'extra' against '{{ size: number; }}': {}",
+        messages[0]
+    );
+}
+
+/// Anti-hardcoding: the recursive check keys on the resolved member name
+/// matching a real target property, not on the identifiers `door`/`House`/
+/// `room`/`size`/`extra`.
+#[test]
+fn computed_const_key_nested_excess_property_is_binder_name_independent() {
+    let messages = ts2353_messages(
+        r#"
+const key = "cabin";
+type Ship = { cabin: { berths: number } };
+const vessel: Ship = { [key]: { berths: 2, portholes: 1 } };
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2353: {messages:?}");
+    assert!(
+        messages[0].contains("'portholes'") && messages[0].contains("'{ berths: number; }'"),
+        "expected an excess-property message naming 'portholes' against '{{ berths: number; }}': {}",
+        messages[0]
+    );
+}
+
+/// Negative control: the same computed-key shape with no excess property must
+/// stay clean — the fix must not turn every computed-key member into a false
+/// positive.
+#[test]
+fn computed_const_key_nested_object_literal_without_excess_property_is_clean() {
+    let messages = ts2353_messages(
+        r#"
+const door = "room";
+type House = { room: { size: number } };
+const built: House = { [door]: { size: 1 } };
+"#,
+    );
+    assert!(
+        messages.is_empty(),
+        "no excess property present, expected no TS2353: {messages:?}"
+    );
+}
+
+/// A syntactically literal computed key (`["room"]`, no `const` indirection)
+/// already resolved through `get_property_name`'s own literal-name path
+/// before this fix; pinned as a control so the fix's `get_property_name_resolved`
+/// switch is not mistaken for what made this row work.
+#[test]
+fn syntactic_literal_computed_key_nested_excess_property_still_reports() {
+    let messages = ts2353_messages(
+        r#"
+type House = { room: { size: number } };
+const built: House = { ["room"]: { size: 1, extra: 2 } };
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2353: {messages:?}");
+    assert!(
+        messages[0].contains("'extra'"),
+        "expected an excess-property message naming 'extra': {}",
+        messages[0]
+    );
+}
+
+/// A numeric `const` computed key resolves through the same
+/// `get_property_name_resolved` path and must recurse identically.
+#[test]
+fn computed_numeric_const_key_nested_excess_property_reports() {
+    let messages = ts2353_messages(
+        r#"
+const slot = 1;
+type Rack = { 1: { load: number } };
+const built: Rack = { [slot]: { load: 1, extra: 2 } };
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2353: {messages:?}");
+    assert!(
+        messages[0].contains("'extra'"),
+        "expected an excess-property message naming 'extra': {}",
+        messages[0]
+    );
+}
+
+/// Negative control: a computed key backed by a non-`const` (mutable `let`)
+/// binding has no literal type, so the object literal never resolves a
+/// `room` member at all — `tsc` reports `TS2741` for the whole literal
+/// missing `room`, not `TS2353` on the nested nonexistent member. Confirms
+/// the fix's `get_property_name_resolved` switch does not widen matching
+/// beyond `tsc`'s own literal-type requirement.
+#[test]
+fn computed_non_const_key_nested_object_literal_reports_missing_property_not_excess() {
+    let messages = check_source_strict_messages(
+        r#"
+let door = "room";
+type House = { room: { size: number } };
+const built: House = { [door]: { size: 1, extra: 2 } };
+"#,
+    );
+    let ts2353: Vec<_> = messages.iter().filter(|(code, _)| *code == 2353).collect();
+    assert!(
+        ts2353.is_empty(),
+        "no member resolves, so no excess-property check should run against it: {ts2353:?}"
+    );
+    assert!(
+        messages.iter().any(|(code, m)| *code == 2741
+            && m.contains("'room'")
+            && m.contains("but required in type 'House'")),
+        "expected TS2741 for the whole literal missing 'room': {messages:?}"
+    );
+}


### PR DESCRIPTION
Fixes the last open item on #16443: an excess property inside the value of an object-literal member reached through a `const`-backed computed key went unreported.

```ts
const door = "room";
type House = { room: { size: number } };
const built: House = { [door]: { size: 1, extra: 2 } };
```

`tsc`: `TS2353` on `extra`, quoting `'{ size: number; }'`. `main`: nothing.

## Structural rule

When an object-literal member's value is itself an object literal, `tsc` recursively checks that nested literal for excess properties against the resolved target member type — regardless of whether the outer member's key is written literally or as a computed expression that resolves to a known literal name. tsz's recursive check (`check_nested_object_literal_excess_properties`, `crates/tsz-checker/src/state/state_checking/property/excess_property_tail.rs`) locates the matching outer element by re-deriving its name from the AST and comparing it against the property name it is recursing on. It derived that name with `get_property_name`, which **deliberately** declines an identifier-backed computed key (`[door]` for `const door = "room"`) — its own doc comment says callers needing type-based resolution should use `get_property_name_resolved` instead. Because the match never succeeded for such a key, the recursive descent into that member's own value never ran, so an excess property nested inside it went unreported.

The outer `source_prop.name` this function is called with was already resolved correctly — object-literal *type* computation already runs computed keys through `get_property_name_resolved` (`types/computation/object_literal/computation.rs`). The bug was confined to this one re-derivation inside the nested-recursion helper re-reading the same AST from scratch.

## Fix

Switch the element-name lookup in `check_nested_object_literal_excess_properties` from `get_property_name` to `get_property_name_resolved`, matching the resolution the object literal's own type already uses.

## Adjacent-case matrix (oracle: pinned `typescript@7.0.2`, `--noEmit --strict --pretty false --target es2022 --lib es2022`)

| case | tsc | before | after |
| --- | --- | --- | --- |
| `const`-backed computed key, nested excess property | `TS2353` on `extra` | none | `TS2353` on `extra` — exact |
| renamed binders (`key`/`Ship`/`cabin`/`berths`/`portholes`) | `TS2353` | none | exact |
| `const`-backed computed key, no excess property | clean | clean | clean (control) |
| syntactic literal key `["room"]` (already worked pre-fix) | `TS2353` | `TS2353` | unchanged (control) |
| numeric `const` computed key | `TS2353` | none | `TS2353` — exact |
| non-`const` (`let`) computed key | `TS2741` (whole literal missing `room`, not TS2353) | `TS2741` (already correct — different mechanism) | unchanged (control) |

All rows verified byte-identical against the CLI's own output against the pinned oracle, not just message-shape.

## Verification

- New `crates/tsz-checker/tests/computed_key_nested_excess_property_tests.rs`: 6/6, oracle-verified. Non-vacuity measured, not argued: with only `excess_property_tail.rs` reverted, the positive/renamed-binder/numeric-key rows fail (empty diagnostics) and all controls still pass.
- `cargo test -p tsz-checker --lib -- excess_property excess` — 180/180
- `cargo test -p tsz-checker --lib -- computed_key nested_object_literal` — 46/46
- `cargo test -p tsz-checker --lib` — 10019/10020 completed clean before I stopped tracking it; the one remaining test (`ts2589_tests::recursive_conditional_alias_omitted_default_transform_emits_definition_ts2589`) is the board's documented long-tail straggler, unrelated to this change (recursive conditional-alias `TS2589`, not excess-property or computed-key code).
- `cargo clippy -p tsz-checker --lib -- -D warnings` — clean
- `cargo fmt -p tsz-checker -- --check` — clean
- `scripts/arch/arch_guard.py` — `Architecture guardrails passed.`
- Pre-commit hook (clippy + arch guard on `-p tsz-checker`) passed.
- Touched file `excess_property_tail.rs` is 1561 lines, under the 2000-line shard ceiling.
- Test-only + one-token-swap production diff; `conformance.sh`/`emit`/`fourslash` not run locally (this change is not on any of those gates' known-failure paths and does not touch emit or parser code). A project-corpus sweep would need real-world source using a `const`-backed computed key whose value is itself an object literal with an excess property — narrow enough that I did not budget the full conformance run for it locally; happy for a reviewer with a warm `.target` to run `compare-to-parent.sh` before landing if preferred.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_015epqsLsixBdZhsCiixZRkK)_