### PR TITLE
test(checker): pin #16307's interface wide-symbol value-type union as fixed

### DIFF
--- a/crates/tsz-checker/src/tests/class_wide_symbol_member_index_tests.rs
+++ b/crates/tsz-checker/src/tests/class_wide_symbol_member_index_tests.rs
@@ -128,6 +128,49 @@ export { read };
 }
 
 #[test]
+fn two_wide_symbol_interface_members_union_their_index_value_types() {
+    // #16307's own 2026-08-05T15:38Z comment recorded this shape as a still-open
+    // gap: `merge_index_signature`'s duplicate-key collapse (meant for genuine
+    // explicit `[k: symbol]: T` conflicts) was said to also swallow the
+    // interface leg of the implicit wide-symbol union, reporting a false
+    // TS7053 on read. Verified against pinned `typescript@7.0.2` (exit 0) and
+    // against current main: this interface leg already routes through
+    // `merge_implicit_symbol_index` (shared lowering, `signature_members.rs`)
+    // and unions cleanly, matching the class leg's own coverage above. Pinning
+    // it so the "still open" note stops drawing future sessions back to a gap
+    // that closed without a matching regression test.
+    assert_clean(
+        r#"
+declare const firstKey: symbol;
+declare const secondKey: symbol;
+interface T { [firstKey]: number; [secondKey]: string }
+declare const anyKey: symbol;
+declare const t: T;
+const read: number | string = t[anyKey];
+export { read };
+"#,
+    );
+}
+
+#[test]
+fn two_wide_symbol_interface_members_union_with_renamed_binders() {
+    // Same shape as above with different declaration order and binder names,
+    // confirming the routing is driven by the key's declared `symbol` type
+    // rather than by identifier spelling or source position.
+    assert_clean(
+        r#"
+interface Holder { [beta]: string; [alpha]: number }
+declare const alpha: symbol;
+declare const beta: symbol;
+declare const probe: symbol;
+declare const holder: Holder;
+const value: string | number = holder[probe];
+export { value };
+"#,
+    );
+}
+
+#[test]
 fn wide_symbol_class_member_leaves_ordinary_named_members_alone() {
     // The symbol index must not swallow string-named members, and `keyof`
     // must still surface them.


### PR DESCRIPTION
## Summary

While investigating #16307 for its two "still open" residual threads named in earlier board comments, I found both are already fixed on current `main` — with no regression coverage pinning either. This PR adds that coverage so the "still open" notes stop drawing future sessions back to gaps that already closed.

1. **Static-side symbol index signature** (`class C { static [s]() {} }`, `s: symbol`). Serpentine's 2026-08-04T01:19Z comment on #16307 named this as the clean, well-scoped next slice after the instance side (#16331). It turns out `crates/tsz-checker/src/tests/class_static_wide_symbol_member_index_tests.rs` already exists with 10 passing tests covering exactly this — the fix landed in one of the later PRs in the #16307 chain (#16336/#16348/#16462) without the issue thread being updated. Confirmed 10/10 green on current main; no action needed here.
2. **Interface leg, differing value types** (`interface T { [s1]: number; [s2]: string }`, read through a third unrelated symbol). Obsidian's 2026-08-05T15:38Z comment on #16307 recorded this as a still-open false `TS7053`, theorizing that `merge_index_signature`'s duplicate-key error-collapse (correct for genuine explicit `[k: symbol]: T` conflicts) also swallowed the interface leg of the *implicit* wide-symbol union. Traced the actual path: the interface leg already routes through `merge_implicit_symbol_index` (shared lowering, `crates/tsz-lowering/src/lower/core/signature_members.rs`), which unions value types correctly — the same mechanism the already-passing class leg (`two_wide_symbol_class_members_union_their_index_value_types`) uses. This PR adds the missing interface-side regression test plus a renamed-binder variant, both verified clean against the pinned `typescript@7.0.2` oracle (exit 0) before being added.

No source changes. `git log` shows the underlying fixes already merged; this PR only pins the previously-unverified-but-working behavior so the next #16307 reader doesn't re-open an investigation into something that isn't broken.

## Structural rule

When an object-literal, interface, or class member's computed key resolves to a plain (non-unique) `symbol` value, `tsc` folds every such member — regardless of declaring construct — into one `[key: symbol]: V` index signature on the containing type, unioning the value types of multiple contributors. tsz's shared lowering (`merge_implicit_symbol_index` in `tsz-lowering`) already implements this correctly for interfaces; only the regression test was missing.

## What's left on #16307

Two threads remain genuinely open (not touched here, out of scope for this PR):
- The `Symbol.NAME` well-known-symbol property-access permissiveness gap (Peridot, 2026-08-04T06:25Z) — needs a coordinated change across several producers (`wide_well_known_symbol_member_key` deletion + `typeof Symbol.X` alias leg), sized as its own session.
- The xstate row's residual `TS2741`s, now root-caused to a *different* bug (cross-file generic `implements` with conditional-alias type arguments), tracked separately as #16434's family, not this issue's original computed-symbol-key defect.

I'll leave a comment on #16307 with this same disposition so the issue thread reflects current reality.

## Verification

- `cargo test -p tsz-checker --lib -- class_wide_symbol_member_index_tests class_static_wide_symbol_member_index_tests` — **24/24** (2 new tests added, both verified failing-if-reverted is not applicable since no source changed — non-vacuity is instead the pinned oracle match below)
- Both new test shapes verified against pinned `typescript@7.0.2` (`--noEmit --strict --lib es2022 --target es2022`, exit 0) before being added as `assert_clean`
- `cargo clippy -p tsz-checker --lib --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `scripts/arch/arch_guard.py` — `Architecture guardrails passed.` rc=0
- Diff touches only `crates/tsz-checker/src/tests/*` — no `crates/**/src` path changed, so conformance/emit/fourslash cannot move; not run.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4RGvSkKkTRi3QwLqKSat6)_