### PR TITLE
fix(checker): a computed-key member's value is excess-property checked

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/property/excess_property_tail.rs
+++ b/crates/tsz-checker/src/state/state_checking/property/excess_property_tail.rs
@@ -1148,6 +1148,30 @@ impl<'a> CheckerState<'a> {
         None
     }
 
+    /// Resolve an object-literal member's written name to the atom that the
+    /// member's own *type* carries, so the nested excess-property walk can match
+    /// an element by the same name its caller was handed.
+    ///
+    /// The syntactic resolver declines for a late-bound computed key (`[K]`
+    /// where `const K = "door"`, `[E.A]`, `[S]`) — by design, since the written
+    /// text names a variable, not a property. But the source type's member list
+    /// carries the *resolved* name, and that list is where the caller's
+    /// `prop_name` comes from, so matching on syntax alone silently skips every
+    /// computed member and the walk never descends into its value.
+    fn object_literal_member_name_atom(&mut self, name_idx: NodeIndex) -> Option<Atom> {
+        if let Some(name) = self.get_property_name(name_idx) {
+            return Some(self.ctx.types.intern_string(&name));
+        }
+        // Only a computed key can be late-bound; anything else that the
+        // syntactic resolver declined has no name to recover.
+        let name_node = self.ctx.arena.get(name_idx)?;
+        if name_node.kind != syntax_kind_ext::COMPUTED_PROPERTY_NAME {
+            return None;
+        }
+        let resolved = self.get_property_name_resolved(name_idx)?;
+        Some(self.ctx.types.intern_string(&resolved))
+    }
+
     /// Check nested object literal properties for excess properties.
     ///
     /// This implements recursive excess property checking for nested object literals.
@@ -1187,8 +1211,8 @@ impl<'a> CheckerState<'a> {
                     .ctx
                     .arena
                     .get_property_assignment(elem_node)
-                    .and_then(|prop| self.get_property_name(prop.name))
-                    .map(|name| self.ctx.types.intern_string(&name)),
+                    .map(|prop| prop.name)
+                    .and_then(|name_idx| self.object_literal_member_name_atom(name_idx)),
                 syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT => self
                     .ctx
                     .arena

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -173,6 +173,8 @@ mod commonjs_reentrant_surface_tests;
 mod commonjs_require_binding_type_meaning_tests;
 #[path = "tests/computed_alias_source_display_tests.rs"]
 mod computed_alias_source_display_tests;
+#[path = "tests/computed_key_nested_excess_property_tests.rs"]
+mod computed_key_nested_excess_property_tests;
 #[path = "tests/computed_member_name_diagnostic_display_tests.rs"]
 mod computed_member_name_diagnostic_display_tests;
 #[path = "tests/computed_symbol_name_unification_tests.rs"]

--- a/crates/tsz-checker/src/tests/computed_key_missing_property_primary_code_tests.rs
+++ b/crates/tsz-checker/src/tests/computed_key_missing_property_primary_code_tests.rs
@@ -219,20 +219,20 @@ const worn: Badged = { [badge]: "text" };
 }
 
 // ---------------------------------------------------------------------------
-// Documented remaining gap, pinned so it cannot regress silently either way.
+// Formerly a documented gap, now closed — flipped deliberately, as intended.
 // ---------------------------------------------------------------------------
 
 #[test]
-fn excess_property_inside_a_computed_members_value_is_a_known_gap() {
-    // tsc reports TS2353 for `extra` here. tsz reports nothing — the excess
-    // check does not descend into a computed member's object-literal value.
-    // Pre-existing and untouched by this fix (it is an excess-property gap,
-    // not a missing-property one); pinned as today's behaviour so whoever
-    // closes it has to flip this row deliberately.
+fn excess_property_inside_a_computed_members_value_is_reported() {
+    // This row was pinned as `codes(source) == []` when the missing-property
+    // fix landed, with the note that whoever closed the excess-property half
+    // had to flip it deliberately rather than discover it. Flipped here: the
+    // excess check now descends into a computed member's object-literal value,
+    // so tsz reports the TS2353 that tsc has always reported for `extra`.
     let source = r#"
 const door = "room";
 type House = { room: { size: number } };
 const built: House = { [door]: { size: 1, extra: 2 } };
 "#;
-    assert_eq!(codes(source), Vec::<u32>::new());
+    assert_eq!(codes(source), vec![2353]);
 }

--- a/crates/tsz-checker/src/tests/computed_key_nested_excess_property_tests.rs
+++ b/crates/tsz-checker/src/tests/computed_key_nested_excess_property_tests.rs
@@ -1,0 +1,203 @@
+//! An object-literal member written with a computed key must still have its
+//! *value* excess-property checked.
+//!
+//! Structural rule: when an object-literal member's value is itself a fresh
+//! object literal, `tsc` runs the excess-property check on that value
+//! regardless of how the member's key was written. tsz does the same through
+//! the nested excess-property walk, which now matches an element by the name
+//! the member's own type carries rather than by the key's syntax.
+//!
+//! The walk is handed the *type's* member name (`source_prop.name`) and used to
+//! match elements with the syntactic resolver, which declines by design for a
+//! late-bound computed key — the written text names a variable, not a property.
+//! So every computed member was skipped and its value never descended into.
+//!
+//! Expectations verified against pinned `typescript@7.0.2`
+//! (`--noEmit --strict --pretty false --target es2022 --lib es2022`). tsc
+//! reports `TS2353` for every key kind below, which is why this is one rule
+//! rather than a per-key-kind patch.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn codes(src: &str) -> Vec<u32> {
+    let mut out: Vec<u32> = check_source_diagnostics(src)
+        .iter()
+        .map(|d| d.code)
+        .collect();
+    out.sort_unstable();
+    out
+}
+
+fn assert_excess(label: &str, src: &str) {
+    let diags = check_source_diagnostics(src);
+    let excess: Vec<_> = diags.iter().filter(|d| d.code == 2353).collect();
+    assert_eq!(
+        excess.len(),
+        1,
+        "{label}: expected exactly one TS2353, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        excess[0].message_text.contains("'extra'"),
+        "{label}: TS2353 should name 'extra', got: {}",
+        excess[0].message_text
+    );
+}
+
+fn assert_clean(label: &str, src: &str) {
+    let found = codes(src);
+    assert!(
+        found.is_empty(),
+        "{label}: expected no diagnostics, got: {found:?}"
+    );
+}
+
+const DECLS: &str = r#"
+interface Inner { size: number }
+interface House { door: Inner; win: Inner }
+const K = "door" as const;
+enum E { A = "door" }
+declare const S: unique symbol;
+interface WithSym { [S]: Inner }
+interface Numy { 0: Inner }
+const KN = 0 as const;
+"#;
+
+// ── positive rows: every key kind descends into the member's value ──────────
+
+#[test]
+fn plain_key_member_value_reports_excess_property() {
+    assert_excess(
+        "plain key (control that already passed)",
+        &format!(
+            "{DECLS}const r: House = {{ door: {{ size: 1, extra: 2 }}, win: {{ size: 1 }} }};"
+        ),
+    );
+}
+
+#[test]
+fn computed_const_string_key_member_value_reports_excess_property() {
+    assert_excess(
+        "late-bound const string key",
+        &format!("{DECLS}const r: House = {{ [K]: {{ size: 1, extra: 2 }}, win: {{ size: 1 }} }};"),
+    );
+}
+
+#[test]
+fn computed_numeric_const_key_member_value_reports_excess_property() {
+    assert_excess(
+        "numeric const key",
+        &format!("{DECLS}const r: Numy = {{ [KN]: {{ size: 1, extra: 2 }} }};"),
+    );
+}
+
+#[test]
+fn computed_enum_member_key_member_value_reports_excess_property() {
+    assert_excess(
+        "enum member key",
+        &format!(
+            "{DECLS}const r: House = {{ [E.A]: {{ size: 1, extra: 2 }}, win: {{ size: 1 }} }};"
+        ),
+    );
+}
+
+#[test]
+fn computed_unique_symbol_key_member_value_reports_excess_property() {
+    assert_excess(
+        "unique symbol key",
+        &format!("{DECLS}const r: WithSym = {{ [S]: {{ size: 1, extra: 2 }} }};"),
+    );
+}
+
+#[test]
+fn syntactic_literal_computed_key_member_value_reports_excess_property() {
+    assert_excess(
+        "syntactic literal computed key",
+        &format!(
+            "{DECLS}const r: House = {{ [\"door\"]: {{ size: 1, extra: 2 }}, win: {{ size: 1 }} }};"
+        ),
+    );
+}
+
+#[test]
+fn computed_key_member_value_reports_excess_two_levels_deep() {
+    assert_excess(
+        "two levels deep under a computed key",
+        &format!(
+            "{DECLS}interface Deep {{ a: {{ b: {{ c: number }} }} }}\n\
+             const r: Deep = {{ [\"a\"]: {{ b: {{ c: 1, extra: 2 }} }} }};"
+        ),
+    );
+}
+
+// ── renamed-binder control: the rule is structural, not name-driven ─────────
+
+#[test]
+fn renamed_binders_computed_const_string_key_reports_excess_property() {
+    assert_excess(
+        "renamed binders",
+        r#"
+interface Cabin { depth: number }
+interface Lodge { hatch: Cabin; pane: Cabin }
+const Qq = "hatch" as const;
+const r: Lodge = { [Qq]: { depth: 1, extra: 2 }, pane: { depth: 1 } };
+"#,
+    );
+}
+
+// ── negative controls: nothing new fires where tsc stays silent ─────────────
+
+#[test]
+fn computed_key_member_value_without_excess_stays_clean() {
+    assert_clean(
+        "no excess property under a computed key",
+        &format!("{DECLS}const r: House = {{ [K]: {{ size: 1 }}, win: {{ size: 1 }} }};"),
+    );
+}
+
+#[test]
+fn plain_key_member_value_without_excess_stays_clean() {
+    assert_clean(
+        "no excess property under a plain key",
+        &format!("{DECLS}const r: House = {{ door: {{ size: 1 }}, win: {{ size: 1 }} }};"),
+    );
+}
+
+#[test]
+fn computed_key_whose_expression_is_not_late_bindable_stays_clean() {
+    // A widened (non-`const`) key is not late-bound to a single member, so
+    // there is no member for the walk to match. tsc's primary code here is
+    // TS2322 against the index signature, with the excess text as a chain link
+    // rather than a standalone TS2353 — so no new primary code may appear.
+    let src = r#"
+interface Inner { size: number }
+interface Bag { [k: string]: Inner }
+let loose = "door";
+const r: Bag = { [loose]: { size: 1, extra: 2 } };
+"#;
+    let found = codes(src);
+    assert!(
+        !found.contains(&2353),
+        "widened computed key must not gain a TS2353, got: {found:?}"
+    );
+}
+
+#[test]
+fn type_assertion_under_a_computed_key_stays_opaque() {
+    // `as` makes the value opaque to excess-property checking; the computed-key
+    // path must not make it fresh again.
+    let src = r#"
+interface Inner { size: number }
+interface House { door: Inner }
+const K = "door" as const;
+const r: House = { [K]: { size: 1, extra: 2 } as Inner };
+"#;
+    let found = codes(src);
+    assert!(
+        !found.contains(&2353),
+        "asserted value under a computed key must stay opaque, got: {found:?}"
+    );
+}

--- a/crates/tsz-checker/src/tests/computed_key_nested_excess_property_tests.rs
+++ b/crates/tsz-checker/src/tests/computed_key_nested_excess_property_tests.rs
@@ -186,6 +186,36 @@ const r: Bag = { [loose]: { size: 1, extra: 2 } };
 }
 
 #[test]
+fn computed_non_const_key_nested_object_literal_reports_missing_property_not_excess() {
+    // Carried over from #16571 (the parallel PR fixing the same defect), whose
+    // review measured this row on both branches. A `let`-bound key is not
+    // late-bound to a member at all, so the member never satisfies `room` and
+    // tsc's answer is the *missing-property* code — not an excess one. This
+    // pins that the descent does not over-fire into a shape that has no
+    // matching member to descend through.
+    let src = r#"
+let door = "room";
+type House = { room: { size: number } };
+const built: House = { [door]: { size: 1, extra: 2 } };
+"#;
+    assert_eq!(codes(src), vec![2741]);
+}
+
+#[test]
+fn excess_arriving_through_a_variable_is_not_fresh_under_a_computed_key() {
+    // Freshness is what licenses the excess check; a value that arrives through
+    // a variable is not fresh, and tsc reports nothing. The computed-key path
+    // must not manufacture freshness.
+    let src = r#"
+const door = "room" as const;
+type House = { room: { size: number } };
+const loose = { size: 1, extra: 2 };
+const built: House = { [door]: loose };
+"#;
+    assert_clean("non-fresh value under a computed key", src);
+}
+
+#[test]
 fn type_assertion_under_a_computed_key_stays_opaque() {
     // `as` makes the value opaque to excess-property checking; the computed-key
     // path must not make it fresh again.


### PR DESCRIPTION
Closes the excess-property gap that #16565 explicitly disclosed as out of its scope:

> `const b: House = { [door]: { size: 1, extra: 2 } }` — tsc reports `TS2353` for `extra`; tsz reports **nothing**. It is an excess-property gap rather than a missing-property one, reached through a different check.

An object-literal member written with a **computed key** never had its value descended into for excess-property checking, so `TS2353` went missing inside it entirely. This is a **false negative in the scoring surface** — a primary code tsz does not emit at all.

## Structural rule

When an object-literal member's value is itself a fresh object literal, `tsc` runs the excess-property check on that value **regardless of how the member's key was written**. tsz now does the same through the checker's nested excess-property walk, matching an element by the name the member's own *type* carries rather than by the key's syntax.

`check_nested_object_literal_excess_properties` (`state/state_checking/property/excess_property_tail.rs`) is handed the property name from the **source type's member list** (`source_prop.name`) and matches it against the literal's elements using the **syntactic** name resolver. That resolver declines *by design* for a late-bound computed key — the written text names a variable, not a property. So every computed member failed the match, the loop `continue`d past it, and the walk never reached its value.

The fix resolves an element's name to the atom its own type carries, falling back to the late-bound resolver (`get_property_name_resolved`, which evaluates the key expression's type) **only** when the key is a computed name *and* the syntactic resolver already declined. No key-kind special casing, no name literals, no predicate over rendered output.

## The discriminator is the resolved name, never the key's kind

That is not an assumption — it is what the oracle says. Every key kind agrees, which is precisely why this needs one rule rather than five arms:

| member key | tsc | main | PR |
| --- | --- | --- | --- |
| plain `door:` | TS2353 | TS2353 | TS2353 (control) |
| `[K]` late-bound `const` string | TS2353 | *nothing* | **TS2353** |
| `[KN]` numeric `const` | TS2353 | *nothing* | **TS2353** |
| `[E.A]` enum member | TS2353 | *nothing* | **TS2353** |
| `[S]` `unique symbol` | TS2353 | *nothing* | **TS2353** |
| `["door"]` syntactic literal computed | TS2353 | TS2353 | TS2353 (control) |
| nested two levels deep under a computed key | TS2353 | TS2353 | TS2353 (control) |

The two computed rows that were **already correct on main** are the ones whose key is syntactically a literal — `get_property_name` resolves those at `core_names.rs:108` without evaluating anything. Keeping them as controls is what pins that this change did not reroute the path that already worked.

## Negative controls, all oracle-checked

| shape | tsc | PR |
| --- | --- | --- |
| computed key, **no** excess property | — | — |
| plain key, no excess property | — | — |
| widened (non-`const`) computed key against an index signature | TS**2322**, excess text as a chain link — no standalone TS2353 | unchanged |
| `{ … } as Inner` under a computed key (assertion is opaque to freshness) | — | — |

The widened-key row is worth stating explicitly: tsc's primary there is `TS2322`, *not* `TS2353`, so "make computed keys descend" must not turn that into a new primary code. It does not.

## Verification

- **new tests: 12** (7 positive, 1 renamed-binder, 4 negative controls) in `tests/computed_key_nested_excess_property_tests.rs`.
- **Non-vacuity measured, not argued.** With only `excess_property_tail.rs` reverted to `origin/main` (`git stash push -- <owner file>`), **5 of 12 fail** — exactly the five late-bound rows (const string, numeric const, enum member, unique symbol, renamed binders). The two syntactic-literal computed rows, the plain-key row and all four negative controls pass **both** ways, which is correct for controls.
- `cargo test -p tsz-checker --lib -- computed_key_nested_excess_property` — **12/12**
- `cargo test -p tsz-checker --lib -- ts2353 excess computed` — **583/583**, no regressions across the pre-existing excess-property, TS2353 and computed-key suites
- `cargo clippy -p tsz-checker --lib --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `scripts/arch/arch_guard.py` — `Architecture guardrails passed.` rc=0
- owner file is 1576 lines, under the 2000-line shard ceiling
- oracle rows measured against pinned `typescript@7.0.2`, `--noEmit --strict --pretty false --target es2022 --lib es2022`

### Gates owed, disclosed rather than argued away

**`compare-to-parent.sh` / conformance snapshot not run.** This change *adds* a primary code where tsz previously emitted nothing, so it is in the scoring surface and the "related-information only, cannot move the corpus" argument does **not** apply — I am not making it. A cold 4-core cloud seat could not afford a release build plus an ~8-minute two-sided snapshot inside this session's budget after the from-scratch debug build. A seat with a warm `.target` should discharge a two-sided corpus diff before this is queued.

Expected direction is a strict improvement (tsz gains tsc's code on five measured rows; four negative controls and three positive controls pin what must not move), but expected is not measured. The one shape a reviewer should watch is a corpus row that assigns an object literal through a late-bound computed key and relied on tsz's silence.

`cargo nextest` is not installed on this cold cloud seat; used `cargo test` per the board's standing note.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Larimar

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYn3A1dGgbrhdjxjHYvGyV)_