### PR TITLE
fix(solver): keep a redundant array/tuple supertype in an intersection (#16095)

### DIFF
--- a/crates/tsz-checker/tests/conditional_extends_redundant_intersection_identity_tests.rs
+++ b/crates/tsz-checker/tests/conditional_extends_redundant_intersection_identity_tests.rs
@@ -174,27 +174,19 @@ fn distinct_object_intersections_are_not_identical() {
 // Array shape (#16095). Array members of an intersection are never merged at
 // intern time, so unlike the object rows above the intersection itself survives
 // interning here (pinned by `redundant_array_intersection_survives_interning`
-// in the solver's `intern/normalize_tests.rs`). What goes wrong is
-// downstream of interning: something subtype-reduces `string[] & (string |
-// number)[]` to plain `string[]` — the element relation is a simple covariant
-// check, which is exactly why the tuple witness at the top of this file is
-// unaffected — and once both sides of the `IfEquals` trick hold the same
-// TypeId, `check_subtype`'s identity fast path answers before the extends
-// clause identity guard in `relations::subtype::rules::conditionals` runs.
-// tsc does not subtype-reduce intersections at all, and compares extends
-// clauses with `isTypeIdenticalTo`, so the two stay distinct there.
-//
-// The two rows below are `#[ignore]`d rather than deleted so they go live the
-// moment the reduction is fixed. Everything else in this section passes today
-// and is a live control: the identity guard is doing its job wherever the
-// operands still reach it, which is what makes the two ignored rows a
-// statement about *where* the operands are lost rather than about the guard.
+// in the solver's `intern/normalize_tests.rs`). The remaining defect was
+// downstream: the evaluator's intersection simplifier
+// (`remove_redundant_members`) subtype-reduced `string[] & (string | number)[]`
+// to plain `string[]` — a covariant element check makes the wider member a
+// supertype, so it was dropped — after which both sides of the `IfEquals` trick
+// held the same `TypeId` and `check_subtype`'s identity fast path answered
+// before the extends-clause identity guard ever ran. tsc does not subtype-reduce
+// an array/tuple intersection at all (`A[] & B[]` stays a two-member
+// `IntersectionType`), so the simplifier now vetoes dropping an array/tuple
+// supertype member and the two extends clauses stay distinct.
 // ---------------------------------------------------------------------------
 
 #[test]
-#[ignore = "#16095: tsz answers EQ, tsc TS2344. The extends clause is subtype-reduced \
-     to plain `string[]` before the identity guard can see it, so both sides of the \
-     IfEquals trick become the same TypeId. See the module comment above."]
 fn redundant_array_intersection_is_not_identical_to_its_subsumed_member() {
     let source = format!(
         "{IF_EQUALS_PRELUDE}\n\
@@ -209,8 +201,6 @@ fn redundant_array_intersection_is_not_identical_to_its_subsumed_member() {
 }
 
 #[test]
-#[ignore = "#16095: same defect as the row above, renamed binders. Pinned so the \
-     renamed-binder control goes live with the fix rather than after it."]
 fn redundant_array_intersection_under_alpha_renamed_type_parameters() {
     let source = r#"
 type Equal<L, R, T = "EQ", F = "DIFF"> =

--- a/crates/tsz-solver/src/evaluation/evaluate/compound_simplification.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/compound_simplification.rs
@@ -202,6 +202,29 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             let union_candidate_removable =
                 matches!(direction, SubtypeDirection::SourceSubsumedByOther)
                     && Self::union_member_removable_as_subtype(&member_facts[i], has_empty_object);
+            // tsc keeps a redundant *concrete* array/tuple supertype member in
+            // an intersection: `string[] & (string | number)[]` stays a
+            // two-member `IntersectionType`, it does not collapse to `string[]`
+            // the way object members merge. Dropping the wider element-typed
+            // sibling makes `T extends (A & B)` and `T extends A` intern to one
+            // `TypeId`, defeating the higher-order `Equal<A & B, A>` identity
+            // probe (#16095).
+            //
+            // The `any`-containing case is the exception, and tsc drops it: in
+            // `[any] & [1]` / `any[] & 1[]` the `any`-typed container is the
+            // supertype, and tsc removes it so an array/tuple *literal* is
+            // contextually typed by the concrete member (`[1]` / `1[]`) rather
+            // than widening its elements through `any`
+            // (`contextualTypeBasedOnIntersectionWithAnyInTheMix3`). So the veto
+            // fires only for a container with no `any` anywhere in it.
+            //
+            // Objects still merge, and `never`/literal/duplicate reductions are
+            // unaffected. Depends only on `members[i]`, so like
+            // `union_candidate_removable` it is computed once per `i`.
+            let intersection_candidate_is_container =
+                matches!(direction, SubtypeDirection::OtherSubsumedBySource)
+                    && crate::type_queries::is_array_or_tuple_type(self.interner, members[i])
+                    && !Self::container_element_contains_any(self.interner, members[i]);
             for j in 0..len {
                 if i == j || keep & (1u32 << j) == 0 {
                     continue;
@@ -243,6 +266,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                             self.compound_subtype_cached(&mut checker, members[j], members[i]);
                         related
                             && !dropped.is_opaque_under_bypass_eval
+                            && !intersection_candidate_is_container
                             && !Self::has_unique_properties_cached(
                                 &dropped.property_names,
                                 &kept.property_names,
@@ -483,6 +507,33 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             db.lookup(type_id),
             Some(TypeData::Application(_) | TypeData::Lazy(_))
         )
+    }
+
+    /// Whether an array/tuple reaches `any` through its element type(s).
+    ///
+    /// `contains_any_type` treats an array/tuple as an opaque reference and
+    /// never descends into it, so walk the element types explicitly. Used to
+    /// exempt an `any`-elemented container supertype from the redundant-member
+    /// veto: tsc drops `[any]`/`any[]` from an intersection so a literal is
+    /// contextually typed by the concrete member, whereas a concrete container
+    /// like `(string | number)[]` is kept (#16095 vs
+    /// `contextualTypeBasedOnIntersectionWithAnyInTheMix3`).
+    fn container_element_contains_any(
+        db: &dyn crate::caches::db::TypeDatabase,
+        type_id: TypeId,
+    ) -> bool {
+        let element_reaches_any = |elem: TypeId| {
+            crate::visitors::visitor_predicates::contains_any_type(db, elem)
+                || Self::container_element_contains_any(db, elem)
+        };
+        match db.lookup(type_id) {
+            Some(TypeData::Array(elem)) => element_reaches_any(elem),
+            Some(TypeData::Tuple(list_id)) => db
+                .tuple_list(list_id)
+                .iter()
+                .any(|e| element_reaches_any(e.type_id)),
+            _ => false,
+        }
     }
 
     /// Check whether a union member is a literal that's only "subsumed" by a


### PR DESCRIPTION
Fixes the array/tuple rows of #16095.

## Structural rule

When an intersection contains a redundant **concrete array/tuple** supertype member — `string[] & (string | number)[]`, where `string[] <: (string | number)[]` by a covariant element check — `tsc` keeps it as a two-member `IntersectionType`; it does not collapse the intersection to its narrower member the way object members merge. tsz's evaluator collapsed it: `remove_redundant_members` (`crates/tsz-solver/src/evaluation/evaluate/compound_simplification.rs`) drops a member whenever a sibling is its subtype, so the wider-element array was dropped and `string[] & (string | number)[]` reduced to `string[]`.

That reduction is invisible for ordinary assignability (the narrower member already dominates) but wrong for **type identity**. tsc compares a conditional's `extends` clause with `isTypeIdenticalTo`, which treats `T extends (A & B)` and `T extends A` as distinct type nodes. Once the intersection reduced, both sides of the higher-order `Equal<A & B, A>` probe (`(<T>() => T extends X ? 1 : 2)`) interned to one `TypeId`, so `check_subtype`'s identity fast path answered `EQ` before the extends-clause identity guard in `relations::subtype::rules::conditionals` ever ran — a false `Equal = true` where tsc reports `false` (the derived `const r: R = "DIFF"` then falsely errored).

The intersection simplifier now vetoes dropping a **concrete** `Array`/`Tuple` supertype member (reusing `type_queries::is_array_or_tuple_type`, computed once per candidate). The **`any`-elemented** container is exempt and still drops: in `[any] & [1]` / `any[] & 1[]` tsc removes the `any` container so an array/tuple *literal* is contextually typed by the concrete member (`[1]` / `1[]`) rather than widening its elements through `any` (`contextualTypeBasedOnIntersectionWithAnyInTheMix3`). Objects still merge; `never`/literal/duplicate reductions are unaffected.

## Goal
Goal: hold

## Verification
- `conditional_extends_redundant_intersection_identity_tests -- --include-ignored`: **16/16 pass** — the two `#[ignore]`d array witnesses this issue filed are now live (`redundant_array_intersection_is_not_identical_to_its_subsumed_member` + renamed-binder sibling); object/tuple/plain rows unchanged as controls.
- `cargo test -p tsz-solver --lib`: **7643 passed, 0 failed**; `-p tsz-solver --tests`: all pass, 0 failed.
- **Emit parity held at the floor**: `scripts/emit/run.sh` → **11562 JS / 1375 DTS** passed (the 1 JS + 15 DTS failures are the pre-existing accepted set).
- **Conformance** (`conformance.sh run --workers 12`, vs committed `conformance-baseline.txt`): **0 regressions**, Net 11491 → 11495 (+4). The 4 improvements (`classImplementsClass4`, `decoratorMetadataWithImportDeclarationNameCollision7`, `forIn2`, `privateNamesUnique-4`) predate this branch (they land via #16518's family after the baseline snapshot); this change contributes no corpus regression. `contextualTypeBasedOnIntersectionWithAnyInTheMix3` — which an earlier, unconditional version of the veto regressed — is clean under the `any`-exemption.
- Pre-commit gate (fmt + clippy `-p tsz-solver` + arch guard): passed. Base CI (clippy + arch-size) green on the pushed head.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high