### PR TITLE
fix(checker): non-strict array-literal element union reduces out scalar null/undefined (#16574)

### DIFF
--- a/crates/tsz-checker/src/tests/nonstrict_nullish_widening_generic_call_tests.rs
+++ b/crates/tsz-checker/src/tests/nonstrict_nullish_widening_generic_call_tests.rs
@@ -250,7 +250,6 @@ var e: string = v;
 /// green on its own when the reduction is fixed instead of freezing today's
 /// divergence into an expectation.
 #[test]
-#[ignore = "known gap: non-strict union reduction does not absorb `undefined` from an element union; independent of leg A's widening seam — see #16384"]
 fn mixed_array_reduces_undefined_out_of_the_element_union() {
     assert_infers(
         "\

--- a/crates/tsz-checker/src/tests/nonstrict_nullish_widening_nested_leaf_tests.rs
+++ b/crates/tsz-checker/src/tests/nonstrict_nullish_widening_nested_leaf_tests.rs
@@ -152,53 +152,19 @@ var probe: string = deep;
 
 // ── Mixed literals: one non-widening leaf decides the whole literal ──
 
-/// A genuine widening source (`undefined` keyword) beside a declared
-/// `undefined[]` leaf: the enclosing `all` means one non-widening element makes
-/// the whole literal non-widening, so the declared leaf keeps `undefined[]`
-/// rather than becoming `any[]` — which is the half this fix owns.
-///
-/// The residual `| undefined` is a *different*, separately tracked defect: with
-/// `strictNullChecks` off tsc reduces `undefined` out of an element union, so it
-/// renders `undefined[][]` where tsz renders `(undefined[] | undefined)[]`. That
-/// is the non-strict union-reduction gap recorded on #16384/#16393, not a
-/// widening-flavour question — a widening "fix" for it would produce `any[][]`,
-/// wrong in the other direction. Twins asserting tsc's full answer are the two
-/// `#[ignore]`d rows below, so they flip green on their own when that gap
-/// closes.
-#[test]
-fn undefined_keyword_sibling_does_not_rescue_an_undefined_array_leaf() {
-    assert_inferred(
-        "\
-declare function collect(): undefined[];
-var mixed = [collect(), undefined];
-var probe: string = mixed;
-",
-        "(undefined[] | undefined)[]",
-        "one non-widening element makes the whole literal non-widening",
-    );
-}
+// The declared `undefined[]` leaf beside a genuine widening source (the
+// `undefined` keyword or an elided hole) keeps `undefined[]` rather than becoming
+// `any[]` (the widening half, #16384/#16393), and with `strictNullChecks` off the
+// scalar `undefined` sibling is then reduced out of the element union (#16574), so
+// the literal renders tsc's `undefined[][]` — the two rows below prove both halves
+// at once. A widening "fix" for the union-reduction half would instead produce
+// `any[][]`, wrong in the other direction, so these rows guard against regressing
+// either way.
 
-/// The elided-hole carve-out (#16393) is permissive on its own and decisive
-/// nowhere: a hole beside a declared `undefined[]` leaf must not widen it.
-/// Same `| undefined` residual as the row above, same separate owner.
+/// tsc's full answer for the mixed `[collect(), undefined]` row: the declared
+/// `undefined[]` leaf stays unwidened (not `any[]`) and the scalar `undefined`
+/// sibling is reduced out of the element union (#16574).
 #[test]
-fn elided_hole_sibling_does_not_rescue_an_undefined_array_leaf() {
-    assert_inferred(
-        "\
-declare function gather(): undefined[];
-var sparse = [, gather()];
-var probe: string = sparse;
-",
-        "(undefined[] | undefined)[]",
-        "an elided hole must not rescue a non-widening sibling leaf",
-    );
-}
-
-/// tsc's full answer for the mixed row above. Blocked only on non-strict union
-/// reduction absorbing `undefined` out of the element union (#16384/#16393);
-/// the widening half is already correct. Flips green when that gap closes.
-#[test]
-#[ignore = "blocked on non-strict union reduction absorbing `undefined` (#16384/#16393)"]
 fn undefined_keyword_sibling_mixed_literal_matches_tsc() {
     assert_inferred(
         "\
@@ -211,9 +177,10 @@ var probe: string = mixed;
     );
 }
 
-/// tsc's full answer for the elided-hole row above. Same blocker.
+/// tsc's full answer for the elided-hole `[, gather()]` row: the elided hole
+/// does not rescue the declared `undefined[]` leaf into `any[]`, and the scalar
+/// `undefined` hole is reduced out of the element union (#16574).
 #[test]
-#[ignore = "blocked on non-strict union reduction absorbing `undefined` (#16384/#16393)"]
 fn elided_hole_sibling_sparse_literal_matches_tsc() {
     assert_inferred(
         "\

--- a/crates/tsz-checker/src/types/computation/array_literal.rs
+++ b/crates/tsz-checker/src/types/computation/array_literal.rs
@@ -437,6 +437,39 @@ impl<'a> CheckerState<'a> {
         applicable_shape
     }
 
+    /// Non-strict Subtype union reduction for array-literal elements, mirroring
+    /// tsc's `getUnionType(elementTypes, UnionReduction.Subtype)`.
+    ///
+    /// With `strictNullChecks` off, `null` and `undefined` are subtypes of every
+    /// non-nullish type, so a scalar `null`/`undefined` element is absorbed out of
+    /// the element union whenever a non-nullish sibling is present:
+    /// `["s", undefined]` reduces to `string`, `[collect(), undefined]` (with
+    /// `collect(): undefined[]`) reduces to `undefined[]`. This is a *reduction*,
+    /// not a widening — it removes the scalar nullish member rather than rewriting
+    /// any leaf to `any`, so it composes with (and runs before) the compound
+    /// widening seam below without producing the wrong-direction `any[]`.
+    ///
+    /// A pure-nullish literal (`[undefined]`, `[null, undefined]`) is left
+    /// untouched: with no non-nullish supertype to be absorbed into there is
+    /// nothing to reduce against, and its own widening seam turns it into `any[]`.
+    /// The reduction is `strictNullChecks`-off only; under `strict`, a scalar
+    /// nullish element is retained so a genuine strict-null mismatch still
+    /// surfaces. Only the *scalar* `null`/`undefined` members are removed — a
+    /// member that merely *contains* `undefined` (e.g. `string | undefined`) is a
+    /// non-nullish sibling that stays and legitimately absorbs the scalar.
+    fn reduce_nonstrict_nullish_array_elements(&self, element_types: Vec<TypeId>) -> Vec<TypeId> {
+        let is_nullish_scalar = |&t: &TypeId| t == TypeId::NULL || t == TypeId::UNDEFINED;
+        if !element_types.iter().any(is_nullish_scalar)
+            || !element_types.iter().any(|t| !is_nullish_scalar(t))
+        {
+            return element_types;
+        }
+        element_types
+            .into_iter()
+            .filter(|t| !is_nullish_scalar(t))
+            .collect()
+    }
+
     /// Get type of array literal.
     ///
     /// Computes the type of array literals like `[1, 2, 3]` or `["a", "b"]`.
@@ -1358,6 +1391,19 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        // Non-strict Subtype union reduction: with `strictNullChecks` off, a
+        // scalar `null`/`undefined` element is absorbed out of the element union
+        // whenever a non-nullish sibling is present (tsc's
+        // `getUnionType(_, UnionReduction.Subtype)`). Runs before both the
+        // preserve-literals union and the BCT/pre-widen path below so neither
+        // sees a spurious `| undefined`. Strict mode and pure-nullish literals
+        // (which the widening seam turns into `any[]`) are left untouched.
+        let element_types = if self.ctx.strict_null_checks() {
+            element_types
+        } else {
+            self.reduce_nonstrict_nullish_array_elements(element_types)
+        };
+
         // Snapshot the solver's worker-local complexity epoch before computing
         // this array's element union. A recursive
         // type-alias evaluation triggered while computing the *contextual* element
@@ -1414,7 +1460,7 @@ impl<'a> CheckerState<'a> {
             || preserve_tuple_spread_literals
             || preserve_const_asserted_element_literals
         {
-            array_surfaces::element_union(self.ctx.types, element_types.clone())
+            array_surfaces::element_union(self.ctx.types, element_types)
         } else {
             // A nested array/tuple literal element (e.g. `[[null]]` inside
             // `[[[null]],[undefined]]`) resolves its own `null`/`undefined`
@@ -1447,7 +1493,7 @@ impl<'a> CheckerState<'a> {
             // leaves are genuine widening sources still collapses its siblings
             // post-widening and one whose leaves are declared values does not.
             let bct_element_types: Vec<TypeId> = if self.ctx.strict_null_checks() {
-                element_types.clone()
+                element_types
             } else {
                 let widened: Vec<TypeId> = element_types
                     .iter()
@@ -1468,7 +1514,7 @@ impl<'a> CheckerState<'a> {
                 if widened == element_types || self.initializer_nullish_leaves_are_widening(idx) {
                     widened
                 } else {
-                    element_types.clone()
+                    element_types
                 }
             };
             expr_ops::compute_best_common_type_cached(


### PR DESCRIPTION
Closes #16574.

**Structural rule.** When a non-contextual array literal in non-strict mode
(`strictNullChecks` off) has both a scalar `null`/`undefined` element and a
non-nullish element, tsc reduces the `null`/`undefined` out of the element
union; tsz kept it. With `strictNullChecks` off, `null` and `undefined` are
subtypes of every type, so tsc's array-literal element type
(`getUnionType(elementTypes, UnionReduction.Subtype)`) absorbs a scalar
`null`/`undefined` element out of the element union whenever a non-nullish
sibling is present. tsz now does the same through the array-literal
element-type construction seam in the checker
(`crates/tsz-checker/src/types/computation/array_literal.rs`).

This is the **union-reduction** half of the `#16384`/`#16393` non-strict nullish
family; those closed the widening-flavour legs and left this half pinned as
`#[ignore]`d rows.

## What changed

`reduce_nonstrict_nullish_array_elements` drops the scalar `NULL`/`UNDEFINED`
members from the element list when at least one non-nullish member is present,
gated to non-strict mode, applied once before **both** the preserve-literals
union and the BCT / non-strict pre-widen path. It is a *reduction*, not a
widening — it removes the scalar nullish member rather than rewriting any leaf
to `any` — so it composes with the existing compound-widening seam without
producing the wrong-direction `any[]`. Only the *scalar* `null`/`undefined`
members are removed; a member that merely contains `undefined` (e.g.
`string | undefined`) is a non-nullish sibling that stays and legitimately
absorbs the scalar.

Controls left untouched, matching tsc:
- **pure-nullish** literal (`[undefined]`) — no non-nullish supertype to absorb
  into, so nothing is reduced and its own widening seam yields `any[]`;
- **strict mode** — a scalar nullish element is retained so a genuine
  strict-null mismatch still surfaces.

| source (`--strict false`) | tsc | tsz before | tsz after |
|---|---|---|---|
| `var v = id(["s", undefined])` (`id(x:T):T`) | `string[]` | `(string \| undefined)[]` | `string[]` |
| `var mixed = [collect(), undefined]` (`collect(): undefined[]`) | `undefined[][]` | `(undefined[] \| undefined)[]` | `undefined[][]` |
| `var sparse = [, gather()]` (`gather(): undefined[]`) | `undefined[][]` | `(undefined[] \| undefined)[]` | `undefined[][]` |
| `var v = id([undefined])` (pure nullish) | `any[]` | `any[]` | `any[]` (control) |
| any of the above under `--strict` | keeps `undefined` | keeps `undefined` | keeps `undefined` (control) |

The three `#[ignore]`d rows flip green; the two rows that pinned the old
`(undefined[] | undefined)[]` output are dropped, superseded by their
matches-tsc twins.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib nonstrict_nullish` — **45 passed; 0 failed;
  1 ignored** (the remaining ignored row is an unrelated leg-B nested-BCT
  follow-up, not this gap). The three previously-`#[ignore]`d matches-tsc rows
  are green; all strict-mode / pure-nullish / widening controls hold.
- **Conformance** (`compare-to-parent.sh HEAD~1`, both sides same methodology):
  base failing=543, branch failing=543 — **0 newly passing, 0 newly failing,
  0 fingerprint changes** across 12043 runnable tests. (Expected: this
  false-negative surfaces in element-type display / downstream assignability,
  which the corpus primary-code fingerprint does not score.)
- **Emit floors held exactly** (`scripts/emit/run.sh`): JavaScript **11562**
  passed, Declaration **1375** passed. The standing baseline failures are
  unaffected — the one array-shaped DTS failure,
  `declarationEmitInferredUndefinedPropFromFunctionInArray`, is an array of two
  object literals with no scalar `null`/`undefined` element, so the reduction is
  a no-op there.
- `cargo clippy -p tsz-checker` + architecture guard — clean (pre-commit gate);
  CI `clippy` + `arch-size` green.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high