### PR TITLE
fix(checker): non-strict array literals reduce null/undefined out of the element union (#16574)

### DIFF
--- a/crates/tsz-checker/src/tests/nonstrict_nullish_widening_generic_call_tests.rs
+++ b/crates/tsz-checker/src/tests/nonstrict_nullish_widening_generic_call_tests.rs
@@ -238,19 +238,15 @@ var e: string = v;
     );
 }
 
-/// Known gap, unchanged by this fix and recorded on #16384: a mixed
-/// non-nullish/nullish array. tsc says `string[]` — but it reaches that through
-/// non-strict **union reduction** (`undefined` is absorbed out of
-/// `string | undefined` when `strictNullChecks` is off), not through the
-/// widening flavour this change is about. tsz says `(string | undefined)[]`
-/// both before and after the candidate-seam fix, so the residual divergence
-/// belongs to the reduction mechanism, in a different owner.
-///
-/// Pinned to tsc's answer rather than to tsz's current output, so it flips
-/// green on its own when the reduction is fixed instead of freezing today's
-/// divergence into an expectation.
+/// A mixed non-nullish/nullish array through generic-call inference. tsc says
+/// `string[]`: with `strictNullChecks` off it reduces the scalar `undefined`
+/// out of the array-literal element union (`getUnionType(...,
+/// UnionReduction.Subtype)`, where `undefined` is a subtype of every type)
+/// before inferring `T`, so `T` never sees `undefined`. This is the reduction
+/// mechanism, distinct from #16384 leg A's widening flavour; the argument here
+/// routes through the literal-preserving `element_union`, which the same
+/// element-list reduction now covers.
 #[test]
-#[ignore = "known gap: non-strict union reduction does not absorb `undefined` from an element union; independent of leg A's widening seam — see #16384"]
 fn mixed_array_reduces_undefined_out_of_the_element_union() {
     assert_infers(
         "\

--- a/crates/tsz-checker/src/tests/nonstrict_nullish_widening_nested_leaf_tests.rs
+++ b/crates/tsz-checker/src/tests/nonstrict_nullish_widening_nested_leaf_tests.rs
@@ -151,54 +151,22 @@ var probe: string = deep;
 }
 
 // ── Mixed literals: one non-widening leaf decides the whole literal ──
+//
+// A genuine widening source (the `undefined` keyword, or an elided hole) beside
+// a declared `undefined[]` leaf keeps the declared leaf as `undefined[]` rather
+// than widening it to `any[]` — the widening half, owned by #16383/#16387. With
+// `strictNullChecks` off tsc then reduces the scalar `undefined` out of the
+// element union (`getUnionType(..., UnionReduction.Subtype)`, where `undefined`
+// is a subtype of every type), so the full inferred type is `undefined[][]`,
+// not `(undefined[] | undefined)[]`. Both halves now hold; the two rows below
+// assert tsc's full answer for the keyword and elided-hole forms. A widening
+// "fix" for the reduction half would instead produce `any[][]`, wrong in the
+// other direction, so the declared `undefined[]` leaf surviving verbatim is the
+// load-bearing part of each expectation.
 
-/// A genuine widening source (`undefined` keyword) beside a declared
-/// `undefined[]` leaf: the enclosing `all` means one non-widening element makes
-/// the whole literal non-widening, so the declared leaf keeps `undefined[]`
-/// rather than becoming `any[]` — which is the half this fix owns.
-///
-/// The residual `| undefined` is a *different*, separately tracked defect: with
-/// `strictNullChecks` off tsc reduces `undefined` out of an element union, so it
-/// renders `undefined[][]` where tsz renders `(undefined[] | undefined)[]`. That
-/// is the non-strict union-reduction gap recorded on #16384/#16393, not a
-/// widening-flavour question — a widening "fix" for it would produce `any[][]`,
-/// wrong in the other direction. Twins asserting tsc's full answer are the two
-/// `#[ignore]`d rows below, so they flip green on their own when that gap
-/// closes.
+/// tsc reduces the scalar `undefined` keyword out of the element union while the
+/// declared `undefined[]` leaf survives unwidened: `undefined[][]`.
 #[test]
-fn undefined_keyword_sibling_does_not_rescue_an_undefined_array_leaf() {
-    assert_inferred(
-        "\
-declare function collect(): undefined[];
-var mixed = [collect(), undefined];
-var probe: string = mixed;
-",
-        "(undefined[] | undefined)[]",
-        "one non-widening element makes the whole literal non-widening",
-    );
-}
-
-/// The elided-hole carve-out (#16393) is permissive on its own and decisive
-/// nowhere: a hole beside a declared `undefined[]` leaf must not widen it.
-/// Same `| undefined` residual as the row above, same separate owner.
-#[test]
-fn elided_hole_sibling_does_not_rescue_an_undefined_array_leaf() {
-    assert_inferred(
-        "\
-declare function gather(): undefined[];
-var sparse = [, gather()];
-var probe: string = sparse;
-",
-        "(undefined[] | undefined)[]",
-        "an elided hole must not rescue a non-widening sibling leaf",
-    );
-}
-
-/// tsc's full answer for the mixed row above. Blocked only on non-strict union
-/// reduction absorbing `undefined` out of the element union (#16384/#16393);
-/// the widening half is already correct. Flips green when that gap closes.
-#[test]
-#[ignore = "blocked on non-strict union reduction absorbing `undefined` (#16384/#16393)"]
 fn undefined_keyword_sibling_mixed_literal_matches_tsc() {
     assert_inferred(
         "\
@@ -211,9 +179,10 @@ var probe: string = mixed;
     );
 }
 
-/// tsc's full answer for the elided-hole row above. Same blocker.
+/// The elided-hole form of the row above: a hole contributes a scalar
+/// `undefined` that is reduced out while the declared `undefined[]` leaf keeps
+/// its shape. tsc: `undefined[][]`.
 #[test]
-#[ignore = "blocked on non-strict union reduction absorbing `undefined` (#16384/#16393)"]
 fn elided_hole_sibling_sparse_literal_matches_tsc() {
     assert_inferred(
         "\

--- a/crates/tsz-checker/src/types/computation/array_literal.rs
+++ b/crates/tsz-checker/src/types/computation/array_literal.rs
@@ -1403,6 +1403,34 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        // Non-strict subtype reduction of the array-literal element union
+        // (tsc `getUnionType(..., UnionReduction.Subtype)`). With
+        // `strictNullChecks` off, `null` and `undefined` are subtypes of every
+        // type, so tsc absorbs a scalar `null`/`undefined` element out of the
+        // element union whenever a non-nullish sibling is present: `["s",
+        // undefined]` is `string[]` (not `(string | undefined)[]`), and
+        // `[collect(), undefined]` with `collect(): undefined[]` is
+        // `undefined[][]` (not `(undefined[] | undefined)[]`). A pure-nullish
+        // element set (`[undefined]`, `[null, undefined]`) is left intact —
+        // there is no non-nullish supertype to absorb into — and the
+        // fresh-literal widening seam maps it to `any` on its own. Strict mode
+        // keeps every `undefined` so strict-null mismatches still surface. This
+        // runs before the preserve-literal and BCT branches below so the
+        // generic-call argument path (`id(["s", undefined])`, which routes
+        // through the literal-preserving `element_union`) reduces the same way.
+        let element_types = if self.ctx.strict_null_checks()
+            || element_types
+                .iter()
+                .all(|&t| t == TypeId::NULL || t == TypeId::UNDEFINED)
+        {
+            element_types
+        } else {
+            element_types
+                .into_iter()
+                .filter(|&t| t != TypeId::NULL && t != TypeId::UNDEFINED)
+                .collect()
+        };
+
         // Use Solver API for Best Common Type computation (Solver-First architecture)
         // When preserve_literal_types is set (e.g., inside generic call argument collection),
         // skip BCT's literal widening by computing the union directly. This preserves
@@ -1414,7 +1442,7 @@ impl<'a> CheckerState<'a> {
             || preserve_tuple_spread_literals
             || preserve_const_asserted_element_literals
         {
-            array_surfaces::element_union(self.ctx.types, element_types.clone())
+            array_surfaces::element_union(self.ctx.types, element_types)
         } else {
             // A nested array/tuple literal element (e.g. `[[null]]` inside
             // `[[[null]],[undefined]]`) resolves its own `null`/`undefined`
@@ -1447,7 +1475,7 @@ impl<'a> CheckerState<'a> {
             // leaves are genuine widening sources still collapses its siblings
             // post-widening and one whose leaves are declared values does not.
             let bct_element_types: Vec<TypeId> = if self.ctx.strict_null_checks() {
-                element_types.clone()
+                element_types
             } else {
                 let widened: Vec<TypeId> = element_types
                     .iter()
@@ -1468,7 +1496,7 @@ impl<'a> CheckerState<'a> {
                 if widened == element_types || self.initializer_nullish_leaves_are_widening(idx) {
                     widened
                 } else {
-                    element_types.clone()
+                    element_types
                 }
             };
             expr_ops::compute_best_common_type_cached(


### PR DESCRIPTION
When a non-contextual array literal in non-strict mode (`strictNullChecks: false`) has both a scalar `null`/`undefined` element and a non-nullish sibling, `tsc` reduces the `null`/`undefined` out of the element union — `getUnionType(..., UnionReduction.Subtype)`, where with `strictNullChecks` off `null`/`undefined` are subtypes of every type. `tsz` kept it, through the array-literal element-type owner (`crates/tsz-checker/src/types/computation/array_literal.rs`), producing a spurious `| undefined`.

Examples (`--strict false`, oracle `typescript@7.0.2`):

| source | tsc | tsz before | tsz after |
|---|---|---|---|
| `id(["s", undefined])` (`id<T>(x:T):T`) | `string[]` | `(string \| undefined)[]` | `string[]` |
| `[collect(), undefined]` (`collect(): undefined[]`) | `undefined[][]` | `(undefined[] \| undefined)[]` | `undefined[][]` |
| `[, gather()]` (`gather(): undefined[]`) | `undefined[][]` | `(undefined[] \| undefined)[]` | `undefined[][]` |
| `[undefined]` (pure nullish) | `any[]` | `any[]` | `any[]` (unchanged) |
| any of the above under `--strict` | keeps `undefined` | keeps `undefined` | keeps `undefined` (unchanged) |

The reduction runs at the single element-type finalization point, before both the literal-preserving (`element_union`) and best-common-type branches, so the generic-call argument path (which routes through `element_union`, skipping BCT) reduces the same way. A pure-nullish element set (`[undefined]`, `[null, undefined]`) is left intact — there is no non-nullish supertype to absorb into — and the fresh-literal widening seam maps it to `any` on its own. Strict mode is untouched so real strict-null mismatches still surface. The change keys only on the built-in `TypeId::NULL`/`UNDEFINED` intrinsics and the `strictNullChecks` option — no user names, file names, or printer output.

Closes the union-reduction half that the closed #16384/#16393 left as documented `#[ignore]`d gaps; tracked as #16574.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib nonstrict_nullish_widening` — 45 passed, 0 failed, 1 ignored (an unrelated leg-B gap). The three previously-`#[ignore]`d tsc-parity rows (`mixed_array_reduces_undefined_out_of_the_element_union`, `undefined_keyword_sibling_mixed_literal_matches_tsc`, `elided_hole_sibling_sparse_literal_matches_tsc`) now pass; the now-redundant intermediate-state twins are folded into them.
- Conformance snapshot (`conformance.sh snapshot --workers 12 --force`): **11491 → 11499 passed** (552 → 544 failed). Per-test diff: **8 rows fixed, 0 regressions** (`classImplementsClass4`, `forIn2`, `decoratorMetadataWithImportDeclarationNameCollision7`, `privateNamesUnique-4`, `augmentedTypeAssignmentCompatIndexSignature`, `augmentedTypeBracketAccessIndexSignature`, `objectTypeWithCallSignatureHidingMembersOfExtendedFunction`, `objectTypeWithConstructSignatureHidingMembersOfExtendedFunction`).
- `clippy` + `arch-size` (the per-merge CI lane): green locally (pre-commit hook).
- Emit floors (11562 JS / 1375 DTS) and the full `tsz-checker` unit suite: verification in progress; will confirm in a follow-up comment.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01PojXg29e3iFMUWqcpxJwyD)_