### PR TITLE
fix(checker): non-strict array-literal element union absorbs scalar null/undefined

### DIFF
--- a/crates/tsz-checker/src/tests/nonstrict_nullish_widening_generic_call_tests.rs
+++ b/crates/tsz-checker/src/tests/nonstrict_nullish_widening_generic_call_tests.rs
@@ -238,19 +238,13 @@ var e: string = v;
     );
 }
 
-/// Known gap, unchanged by this fix and recorded on #16384: a mixed
-/// non-nullish/nullish array. tsc says `string[]` — but it reaches that through
-/// non-strict **union reduction** (`undefined` is absorbed out of
+/// A mixed non-nullish/nullish array. tsc says `string[]` — it reaches that
+/// through non-strict **union reduction** (`undefined` is absorbed out of
 /// `string | undefined` when `strictNullChecks` is off), not through the
-/// widening flavour this change is about. tsz says `(string | undefined)[]`
-/// both before and after the candidate-seam fix, so the residual divergence
-/// belongs to the reduction mechanism, in a different owner.
-///
-/// Pinned to tsc's answer rather than to tsz's current output, so it flips
-/// green on its own when the reduction is fixed instead of freezing today's
-/// divergence into an expectation.
+/// widening flavour this file otherwise covers. Fixed by #16574: see
+/// `nonstrict_array_element_union_absorbs_nullish_scalars` in
+/// `types/computation/array_literal.rs`.
 #[test]
-#[ignore = "known gap: non-strict union reduction does not absorb `undefined` from an element union; independent of leg A's widening seam — see #16384"]
 fn mixed_array_reduces_undefined_out_of_the_element_union() {
     assert_infers(
         "\

--- a/crates/tsz-checker/src/tests/nonstrict_nullish_widening_nested_leaf_tests.rs
+++ b/crates/tsz-checker/src/tests/nonstrict_nullish_widening_nested_leaf_tests.rs
@@ -155,16 +155,11 @@ var probe: string = deep;
 /// A genuine widening source (`undefined` keyword) beside a declared
 /// `undefined[]` leaf: the enclosing `all` means one non-widening element makes
 /// the whole literal non-widening, so the declared leaf keeps `undefined[]`
-/// rather than becoming `any[]` — which is the half this fix owns.
-///
-/// The residual `| undefined` is a *different*, separately tracked defect: with
-/// `strictNullChecks` off tsc reduces `undefined` out of an element union, so it
-/// renders `undefined[][]` where tsz renders `(undefined[] | undefined)[]`. That
-/// is the non-strict union-reduction gap recorded on #16384/#16393, not a
-/// widening-flavour question — a widening "fix" for it would produce `any[][]`,
-/// wrong in the other direction. Twins asserting tsc's full answer are the two
-/// `#[ignore]`d rows below, so they flip green on their own when that gap
-/// closes.
+/// rather than becoming `any[]` — that is the widening half this file's leaf
+/// rule owns. The `| undefined` sibling is then absorbed by non-strict union
+/// reduction (#16574), so tsc's full answer is `undefined[][]`, not
+/// `(undefined[] | undefined)[]` or `any[][]` (the widening-only answer would
+/// be wrong in the other direction).
 #[test]
 fn undefined_keyword_sibling_does_not_rescue_an_undefined_array_leaf() {
     assert_inferred(
@@ -173,14 +168,14 @@ declare function collect(): undefined[];
 var mixed = [collect(), undefined];
 var probe: string = mixed;
 ",
-        "(undefined[] | undefined)[]",
-        "one non-widening element makes the whole literal non-widening",
+        "undefined[][]",
+        "one non-widening element makes the whole literal non-widening, then non-strict reduction absorbs `undefined`",
     );
 }
 
 /// The elided-hole carve-out (#16393) is permissive on its own and decisive
 /// nowhere: a hole beside a declared `undefined[]` leaf must not widen it.
-/// Same `| undefined` residual as the row above, same separate owner.
+/// Same non-strict union-reduction absorption as the row above (#16574).
 #[test]
 fn elided_hole_sibling_does_not_rescue_an_undefined_array_leaf() {
     assert_inferred(
@@ -189,40 +184,8 @@ declare function gather(): undefined[];
 var sparse = [, gather()];
 var probe: string = sparse;
 ",
-        "(undefined[] | undefined)[]",
-        "an elided hole must not rescue a non-widening sibling leaf",
-    );
-}
-
-/// tsc's full answer for the mixed row above. Blocked only on non-strict union
-/// reduction absorbing `undefined` out of the element union (#16384/#16393);
-/// the widening half is already correct. Flips green when that gap closes.
-#[test]
-#[ignore = "blocked on non-strict union reduction absorbing `undefined` (#16384/#16393)"]
-fn undefined_keyword_sibling_mixed_literal_matches_tsc() {
-    assert_inferred(
-        "\
-declare function collect(): undefined[];
-var mixed = [collect(), undefined];
-var probe: string = mixed;
-",
         "undefined[][]",
-        "tsc reduces `undefined` out of the element union",
-    );
-}
-
-/// tsc's full answer for the elided-hole row above. Same blocker.
-#[test]
-#[ignore = "blocked on non-strict union reduction absorbing `undefined` (#16384/#16393)"]
-fn elided_hole_sibling_sparse_literal_matches_tsc() {
-    assert_inferred(
-        "\
-declare function gather(): undefined[];
-var sparse = [, gather()];
-var probe: string = sparse;
-",
-        "undefined[][]",
-        "tsc reduces `undefined` out of the element union",
+        "an elided hole must not rescue a non-widening sibling leaf, then non-strict reduction absorbs `undefined`",
     );
 }
 

--- a/crates/tsz-checker/src/types/computation/array_literal.rs
+++ b/crates/tsz-checker/src/types/computation/array_literal.rs
@@ -1478,6 +1478,7 @@ impl<'a> CheckerState<'a> {
                 Some(&self.ctx), // Pass TypeResolver for class hierarchy BCT
             )
         };
+        let element_type = self.nonstrict_array_element_union_absorbs_nullish_scalars(element_type);
 
         // TS2590: Also check the solver's flag in case the union was constructed
         // through a different path (e.g., preserve_literal_types or internal union ops).
@@ -1499,6 +1500,41 @@ impl<'a> CheckerState<'a> {
         }
 
         array_surfaces::array_type(self.ctx.types, element_type)
+    }
+
+    /// With `strictNullChecks` off, `null`/`undefined` are subtypes of every
+    /// type, so tsc's array-literal element type
+    /// (`getUnionType(elementTypes, UnionReduction.Subtype)`) absorbs a scalar
+    /// `null`/`undefined` element out of the union whenever a non-nullish
+    /// sibling is present — e.g. `["s", undefined]` infers `string[]`, not
+    /// `(string | undefined)[]`.
+    ///
+    /// Applied as a post-pass over the already-built element union/BCT result,
+    /// not by pre-filtering the candidate list handed to
+    /// `compute_best_common_type_cached`: BCT's literal-widening and subtype
+    /// tournament must still see the full candidate set, or a literal that
+    /// happens to be the lone non-nullish survivor would skip widening (e.g.
+    /// `["s", undefined]` must still widen `"s"` to `string`, not stay `"s"`).
+    /// The solver's `element_union`/BCT primitives are unchanged; this is a
+    /// checker-owned reduction over their result.
+    fn nonstrict_array_element_union_absorbs_nullish_scalars(
+        &self,
+        element_type: TypeId,
+    ) -> TypeId {
+        if self.ctx.strict_null_checks() {
+            return element_type;
+        }
+        let Some(members) =
+            crate::query_boundaries::common::union_members(self.ctx.types, element_type)
+        else {
+            return element_type;
+        };
+        let is_nullish_scalar = |m: &TypeId| *m == TypeId::NULL || *m == TypeId::UNDEFINED;
+        if !members.iter().any(is_nullish_scalar) || !members.iter().any(|m| !is_nullish_scalar(m))
+        {
+            return element_type;
+        }
+        crate::query_boundaries::common::remove_nullish(self.ctx.types, element_type)
     }
 
     /// When the contextual type is a generic application like `Definition<Schema>`, the


### PR DESCRIPTION
Closes #16574.

<!-- Describe what and why. For semantic fixes, state the structural rule:
     when <structural condition>, tsc does X; tsz does X through <owner layer>.
     Name the benchmark row or failure family when relevant. -->

## Structural rule

With `strictNullChecks` off, `null`/`undefined` are subtypes of every type, so
`tsc`'s array-literal element type (`getUnionType(elementTypes,
UnionReduction.Subtype)`) absorbs a scalar `null`/`undefined` element out of
the union whenever a non-nullish sibling is present: `["s", undefined]`
infers `string[]`, not `(string | undefined)[]`. tsz kept the nullish member.

**When** a non-contextual array literal in non-strict mode has both a scalar
`null`/`undefined` element and a non-nullish element, **tsc** reduces the
`null`/`undefined` out of the element union; **tsz** now does the same
through **the checker's array-literal element-type construction**
(`crates/tsz-checker/src/types/computation/array_literal.rs`), the same seam
that already owns the non-strict pre-widen for the sibling widening-flavour
gap (#16384/#16393).

## Why this lives in the checker, not the solver

The fix is a post-pass over the already-built element union/BCT result
(`nonstrict_array_element_union_absorbs_nullish_scalars`), not a change to
`compute_best_common_type_cached`'s "preserve nullish members" tournament
guard or to the raw `element_union`/`db.union` construction. Both of those
solver primitives are shared by many other call sites (conditional
expressions, spreads, generic inference), and `compute_best_common_type_cached`
always constructs its internal `SubtypeChecker` with `strict_null_checks:
true` regardless of the real compiler option — threading the real flag through
would be a much wider-blast-radius change than this one bug needs. Filtering
the *candidate list* before BCT was also tried and rejected: BCT's literal
widening only fires when ≥2 candidates remain, so pre-filtering
`["s", undefined]` down to a single `"s"` candidate would skip widening and
produce `("s")[]` instead of `string[]`. Applying the reduction to BCT's
*result* instead preserves widening and only touches the array-literal seam.

## Adjacent cases

| source | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `id(["s", undefined])` (generic call) | `string[]` | `(string \| undefined)[]` | `string[]` ✅ |
| `[collect(), undefined]` (`collect(): undefined[]`) | `undefined[][]` | `(undefined[] \| undefined)[]` | `undefined[][]` ✅ |
| `[, gather()]` (`gather(): undefined[]`) | `undefined[][]` | `(undefined[] \| undefined)[]` | `undefined[][]` ✅ |
| `id([undefined])` (pure nullish) | `any[]` | `any[]` | `any[]` (unchanged, widening seam) |
| any of the above under `--strict` | keeps `undefined` | keeps `undefined` | keeps `undefined` (unchanged — gated on `!strict_null_checks()`) |
| `[q]` (`q: undefined`, no sibling) | `undefined[]` | `undefined[]` | `undefined[]` (unchanged, single-candidate, no union) |

## Verification

- `cargo test -p tsz-checker --lib nonstrict_nullish_widening`: **45 passed, 0
  failed, 1 ignored** (the remaining ignored row is leg B's unrelated
  `#16384` follow-up). Un-ignores the three rows this issue pinned and
  updates two now-obsolete "current wrong answer" duplicate tests in
  `nonstrict_nullish_widening_nested_leaf_tests.rs` to tsc's real answer.
- `cargo test -p tsz-checker --lib array_literal`: **72 passed, 0 failed**.
- `cargo test -p tsz-checker --lib -- nonstrict nullish`: **240 passed, 0
  failed, 1 ignored** (same unrelated leg-B row).
- `cargo test -p tsz-checker --lib` (full lib suite): in progress at PR-open
  time — will confirm in a follow-up comment.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p tsz-checker --lib --all-targets -- -D warnings`: clean.
- `scripts/arch/arch_guard.py`: `Architecture guardrails passed.` rc=0.
- File size: `array_literal.rs` is 1667 lines, under the 2000-line shard cap.

### Gate owed

This is a real behavior change (inferred types for non-strict array literals
with mixed nullish/non-nullish elements), so it is in the conformance/emit
scoring surface in principle, though the affected shape (non-strict mode +
mixed scalar-nullish array literal) is narrow. Conformance snapshot and emit
floor check are still owed before landing; will run and record here.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANzxhqRFiQaHb54Bq9RdFM)_