### PR TITLE
perf(solver): store eval-cache dependency lists as boxed slices; unify the RefCell indexes

### DIFF
--- a/crates/tsz-solver/src/caches/application_eval_index.rs
+++ b/crates/tsz-solver/src/caches/application_eval_index.rs
@@ -1,25 +1,14 @@
+use crate::caches::dependency_index::{self, DependencyIndex, DependencyIndexState};
 use crate::caches::shared_instantiation::collect_application_eval_entry_def_dependencies;
 use crate::caches::shared_query_cache::ApplicationEvalCacheKey;
 use crate::def::{DefId, DefinitionStore};
 use crate::intern::TypeInterner;
 use crate::types::TypeId;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use std::cell::RefCell;
 
-#[derive(Default)]
-pub(super) struct ApplicationEvalDependencyIndexState {
-    pub(super) reverse: FxHashMap<DefId, FxHashSet<ApplicationEvalCacheKey>>,
-    pub(super) key_dependencies: FxHashMap<ApplicationEvalCacheKey, FxHashSet<DefId>>,
-}
-
-impl ApplicationEvalDependencyIndexState {
-    pub(super) fn clear(&mut self) {
-        self.reverse.clear();
-        self.key_dependencies.clear();
-    }
-}
-
-pub(super) type ApplicationEvalDependencyIndex = RefCell<ApplicationEvalDependencyIndexState>;
+pub(super) type ApplicationEvalDependencyIndexState = DependencyIndexState<ApplicationEvalCacheKey>;
+pub(super) type ApplicationEvalDependencyIndex = DependencyIndex<ApplicationEvalCacheKey>;
 
 pub(super) fn record_dependencies(
     interner: &TypeInterner,
@@ -29,20 +18,9 @@ pub(super) fn record_dependencies(
     old_result: Option<TypeId>,
     result: TypeId,
 ) {
-    let mut index = index.borrow_mut();
-    if old_result.is_some() {
-        remove_dependencies(&mut index, key);
-    }
     let deps =
         collect_application_eval_entry_def_dependencies(interner, definition_store, key, result);
-    if deps.is_empty() {
-        return;
-    }
-    let deps: FxHashSet<_> = deps.into_iter().collect();
-    for &def_id in &deps {
-        index.reverse.entry(def_id).or_default().insert(key.clone());
-    }
-    index.key_dependencies.insert(key.clone(), deps);
+    dependency_index::record_dependencies(index, key.clone(), old_result.is_some(), deps);
 }
 
 pub(super) fn invalidate_for_def(
@@ -50,16 +28,7 @@ pub(super) fn invalidate_for_def(
     cache: &RefCell<FxHashMap<ApplicationEvalCacheKey, TypeId>>,
     def_id: DefId,
 ) {
-    let Some(keys) = index.borrow_mut().reverse.remove(&def_id) else {
-        return;
-    };
-    let mut cache = cache.borrow_mut();
-    let mut index = index.borrow_mut();
-    for key in keys {
-        if cache.remove(&key).is_some() {
-            remove_dependencies(&mut index, &key);
-        }
-    }
+    dependency_index::invalidate_for_def(index, cache, def_id);
 }
 
 #[cfg(test)]
@@ -68,23 +37,5 @@ pub(super) fn key_count(index: &ApplicationEvalDependencyIndex, def_id: DefId) -
         .borrow()
         .reverse
         .get(&def_id)
-        .map_or(0, FxHashSet::len)
-}
-
-fn remove_dependencies(
-    index: &mut ApplicationEvalDependencyIndexState,
-    key: &ApplicationEvalCacheKey,
-) {
-    let Some(deps) = index.key_dependencies.remove(key) else {
-        return;
-    };
-    for def_id in deps {
-        let Some(keys) = index.reverse.get_mut(&def_id) else {
-            continue;
-        };
-        keys.remove(key);
-        if keys.is_empty() {
-            index.reverse.remove(&def_id);
-        }
-    }
+        .map_or(0, rustc_hash::FxHashSet::len)
 }

--- a/crates/tsz-solver/src/caches/dependency_index.rs
+++ b/crates/tsz-solver/src/caches/dependency_index.rs
@@ -1,0 +1,95 @@
+use crate::def::DefId;
+use crate::types::TypeId;
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::cell::RefCell;
+use std::hash::Hash;
+
+/// Reverse dependency index shared by the evaluation and application-eval
+/// caches, generic over the cache key `K`.
+///
+/// `reverse` maps each `DefId` to the set of cache keys that depend on it, so a
+/// `DefId`-scoped invalidation can find every entry to drop. `key_dependencies`
+/// maps each cache key back to its dependency list.
+///
+/// The dependency list is already de-duplicated by `collect_def_dependencies`'
+/// `seen` set, and it is only ever iterated (never membership-queried), so it is
+/// stored as a compact boxed slice rather than re-hashed into a second
+/// `FxHashSet` on every cache write.
+pub(super) struct DependencyIndexState<K> {
+    pub(super) reverse: FxHashMap<DefId, FxHashSet<K>>,
+    pub(super) key_dependencies: FxHashMap<K, Box<[DefId]>>,
+}
+
+impl<K> Default for DependencyIndexState<K> {
+    fn default() -> Self {
+        Self {
+            reverse: FxHashMap::default(),
+            key_dependencies: FxHashMap::default(),
+        }
+    }
+}
+
+impl<K> DependencyIndexState<K> {
+    pub(super) fn clear(&mut self) {
+        self.reverse.clear();
+        self.key_dependencies.clear();
+    }
+}
+
+pub(super) type DependencyIndex<K> = RefCell<DependencyIndexState<K>>;
+
+/// Record the dependency list for `key`. `remove_old` requests that the entry's
+/// previous dependencies be dropped first (callers pass `old_result.is_some()`).
+/// `deps` must already be de-duplicated.
+pub(super) fn record_dependencies<K: Eq + Hash + Clone>(
+    index: &DependencyIndex<K>,
+    key: K,
+    remove_old: bool,
+    deps: Vec<DefId>,
+) {
+    let mut index = index.borrow_mut();
+    if remove_old {
+        remove_dependencies(&mut index, &key);
+    }
+    if deps.is_empty() {
+        return;
+    }
+    for &def_id in &deps {
+        index.reverse.entry(def_id).or_default().insert(key.clone());
+    }
+    index.key_dependencies.insert(key, deps.into_boxed_slice());
+}
+
+/// Drop every cache key that depends on `def_id`, from both `cache` and the
+/// index itself.
+pub(super) fn invalidate_for_def<K: Eq + Hash>(
+    index: &DependencyIndex<K>,
+    cache: &RefCell<FxHashMap<K, TypeId>>,
+    def_id: DefId,
+) {
+    let Some(keys) = index.borrow_mut().reverse.remove(&def_id) else {
+        return;
+    };
+    let mut cache = cache.borrow_mut();
+    let mut index = index.borrow_mut();
+    for key in keys {
+        if cache.remove(&key).is_some() {
+            remove_dependencies(&mut index, &key);
+        }
+    }
+}
+
+fn remove_dependencies<K: Eq + Hash>(index: &mut DependencyIndexState<K>, key: &K) {
+    let Some(deps) = index.key_dependencies.remove(key) else {
+        return;
+    };
+    for def_id in deps.iter() {
+        let Some(keys) = index.reverse.get_mut(def_id) else {
+            continue;
+        };
+        keys.remove(key);
+        if keys.is_empty() {
+            index.reverse.remove(def_id);
+        }
+    }
+}

--- a/crates/tsz-solver/src/caches/eval_dependency_index.rs
+++ b/crates/tsz-solver/src/caches/eval_dependency_index.rs
@@ -1,25 +1,14 @@
+use crate::caches::dependency_index::{self, DependencyIndex, DependencyIndexState};
 use crate::caches::shared_instantiation::collect_eval_entry_def_dependencies;
 use crate::def::{DefId, DefinitionStore};
 use crate::evaluation::request::EvaluationCacheKey;
 use crate::intern::TypeInterner;
 use crate::types::TypeId;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use std::cell::RefCell;
 
-#[derive(Default)]
-pub(super) struct EvalDependencyIndexState {
-    pub(super) reverse: FxHashMap<DefId, FxHashSet<EvaluationCacheKey>>,
-    pub(super) key_dependencies: FxHashMap<EvaluationCacheKey, FxHashSet<DefId>>,
-}
-
-impl EvalDependencyIndexState {
-    pub(super) fn clear(&mut self) {
-        self.reverse.clear();
-        self.key_dependencies.clear();
-    }
-}
-
-pub(super) type EvalDependencyIndex = RefCell<EvalDependencyIndexState>;
+pub(super) type EvalDependencyIndexState = DependencyIndexState<EvaluationCacheKey>;
+pub(super) type EvalDependencyIndex = DependencyIndex<EvaluationCacheKey>;
 
 pub(super) fn record_dependencies(
     interner: &TypeInterner,
@@ -29,19 +18,8 @@ pub(super) fn record_dependencies(
     old_result: Option<TypeId>,
     result: TypeId,
 ) {
-    let mut index = index.borrow_mut();
-    if old_result.is_some() {
-        remove_dependencies(&mut index, key);
-    }
     let deps = collect_eval_entry_def_dependencies(interner, definition_store, key, result);
-    if deps.is_empty() {
-        return;
-    }
-    let deps: FxHashSet<_> = deps.into_iter().collect();
-    for &def_id in &deps {
-        index.reverse.entry(def_id).or_default().insert(key);
-    }
-    index.key_dependencies.insert(key, deps);
+    dependency_index::record_dependencies(index, key, old_result.is_some(), deps);
 }
 
 pub(super) fn invalidate_for_def(
@@ -49,29 +27,5 @@ pub(super) fn invalidate_for_def(
     cache: &RefCell<FxHashMap<EvaluationCacheKey, TypeId>>,
     def_id: DefId,
 ) {
-    let Some(keys) = index.borrow_mut().reverse.remove(&def_id) else {
-        return;
-    };
-    let mut cache = cache.borrow_mut();
-    let mut index = index.borrow_mut();
-    for key in keys {
-        if cache.remove(&key).is_some() {
-            remove_dependencies(&mut index, key);
-        }
-    }
-}
-
-fn remove_dependencies(index: &mut EvalDependencyIndexState, key: EvaluationCacheKey) {
-    let Some(deps) = index.key_dependencies.remove(&key) else {
-        return;
-    };
-    for def_id in deps {
-        let Some(keys) = index.reverse.get_mut(&def_id) else {
-            continue;
-        };
-        keys.remove(&key);
-        if keys.is_empty() {
-            index.reverse.remove(&def_id);
-        }
-    }
+    dependency_index::invalidate_for_def(index, cache, def_id);
 }

--- a/crates/tsz-solver/src/caches/mod.rs
+++ b/crates/tsz-solver/src/caches/mod.rs
@@ -1,6 +1,7 @@
 mod application_eval_index;
 pub(crate) mod db;
 mod db_base_traits;
+mod dependency_index;
 pub(crate) mod display_provenance;
 mod eval_dependency_index;
 pub(crate) mod instantiation_cache;

--- a/crates/tsz-solver/src/caches/query_cache_size.rs
+++ b/crates/tsz-solver/src/caches/query_cache_size.rs
@@ -43,9 +43,10 @@ impl QueryCache<'_> {
             size += index.key_dependencies.capacity()
                 * (BUCKET_OVERHEAD
                     + std::mem::size_of::<EvaluationCacheKey>()
-                    + std::mem::size_of::<FxHashSet<DefId>>());
+                    + std::mem::size_of::<Box<[DefId]>>());
             for deps in index.key_dependencies.values() {
-                size += deps.capacity() * (BUCKET_OVERHEAD + std::mem::size_of::<DefId>());
+                // Boxed slice: one contiguous allocation, no per-element bucket.
+                size += deps.len() * std::mem::size_of::<DefId>();
             }
         }
 
@@ -70,9 +71,10 @@ impl QueryCache<'_> {
             size += index.key_dependencies.capacity()
                 * (BUCKET_OVERHEAD
                     + std::mem::size_of::<EvaluationCacheKey>()
-                    + std::mem::size_of::<FxHashSet<DefId>>());
+                    + std::mem::size_of::<Box<[DefId]>>());
             for deps in index.key_dependencies.values() {
-                size += deps.capacity() * (BUCKET_OVERHEAD + std::mem::size_of::<DefId>());
+                // Boxed slice: one contiguous allocation, no per-element bucket.
+                size += deps.len() * std::mem::size_of::<DefId>();
             }
         }
 
@@ -126,9 +128,10 @@ impl QueryCache<'_> {
             size += index.key_dependencies.capacity()
                 * (BUCKET_OVERHEAD
                     + std::mem::size_of::<ApplicationEvalCacheKey>()
-                    + std::mem::size_of::<FxHashSet<DefId>>());
+                    + std::mem::size_of::<Box<[DefId]>>());
             for (key, deps) in &index.key_dependencies {
-                size += deps.capacity() * (BUCKET_OVERHEAD + std::mem::size_of::<DefId>());
+                // Boxed slice: one contiguous allocation, no per-element bucket.
+                size += deps.len() * std::mem::size_of::<DefId>();
                 if key.1.spilled() {
                     size += key.1.capacity() * std::mem::size_of::<TypeId>();
                 }

--- a/crates/tsz-solver/src/caches/shared_query_cache.rs
+++ b/crates/tsz-solver/src/caches/shared_query_cache.rs
@@ -58,14 +58,14 @@ pub(super) type ApplicationEvalCacheKey = (DefId, smallvec::SmallVec<[TypeId; 4]
 pub struct SharedQueryCache {
     pub(super) eval_cache: DashMap<EvaluationCacheKey, TypeId, FxBuildHasher>,
     pub(super) eval_dependency_index: DashMap<DefId, FxHashSet<EvaluationCacheKey>, FxBuildHasher>,
-    eval_key_dependency_index: DashMap<EvaluationCacheKey, FxHashSet<DefId>, FxBuildHasher>,
+    eval_key_dependency_index: DashMap<EvaluationCacheKey, Box<[DefId]>, FxBuildHasher>,
     pub(super) subtype_cache: DashMap<RelationCacheKey, RelationCacheValue, FxBuildHasher>,
     pub(super) assignability_cache: DashMap<RelationCacheKey, RelationCacheValue, FxBuildHasher>,
     pub(super) application_eval_cache: DashMap<ApplicationEvalCacheKey, TypeId, FxBuildHasher>,
     pub(super) application_eval_dependency_index:
         DashMap<DefId, FxHashSet<ApplicationEvalCacheKey>, FxBuildHasher>,
     application_eval_key_dependency_index:
-        DashMap<ApplicationEvalCacheKey, FxHashSet<DefId>, FxBuildHasher>,
+        DashMap<ApplicationEvalCacheKey, Box<[DefId]>, FxBuildHasher>,
     pub(super) instantiation_cache: DashMap<InstantiationCacheKey, TypeId, FxBuildHasher>,
     share_instantiation_family: bool,
 }
@@ -127,14 +127,14 @@ impl SharedQueryCache {
         if deps.is_empty() {
             return;
         }
-        let deps: FxHashSet<_> = deps.into_iter().collect();
         for &def_id in &deps {
             self.application_eval_dependency_index
                 .entry(def_id)
                 .or_default()
                 .insert(key.clone());
         }
-        self.application_eval_key_dependency_index.insert(key, deps);
+        self.application_eval_key_dependency_index
+            .insert(key, deps.into_boxed_slice());
     }
 
     pub(super) fn invalidate_application_eval_cache_for_def(
@@ -206,22 +206,22 @@ impl SharedQueryCache {
         if deps.is_empty() {
             return;
         }
-        let deps: FxHashSet<_> = deps.into_iter().collect();
         for &def_id in &deps {
             self.eval_dependency_index
                 .entry(def_id)
                 .or_default()
                 .insert(key);
         }
-        self.eval_key_dependency_index.insert(key, deps);
+        self.eval_key_dependency_index
+            .insert(key, deps.into_boxed_slice());
     }
 
     fn remove_eval_dependencies(&self, key: EvaluationCacheKey, _result: TypeId) {
         let Some((_, deps)) = self.eval_key_dependency_index.remove(&key) else {
             return;
         };
-        for def_id in deps {
-            let Some(mut keys) = self.eval_dependency_index.get_mut(&def_id) else {
+        for def_id in deps.iter() {
+            let Some(mut keys) = self.eval_dependency_index.get_mut(def_id) else {
                 continue;
             };
             keys.remove(&key);
@@ -229,7 +229,7 @@ impl SharedQueryCache {
             drop(keys);
             if empty {
                 self.eval_dependency_index
-                    .remove_if(&def_id, |_, keys| keys.is_empty());
+                    .remove_if(def_id, |_, keys| keys.is_empty());
             }
         }
     }
@@ -238,8 +238,8 @@ impl SharedQueryCache {
         let Some((_, deps)) = self.application_eval_key_dependency_index.remove(key) else {
             return;
         };
-        for def_id in deps {
-            let Some(mut keys) = self.application_eval_dependency_index.get_mut(&def_id) else {
+        for def_id in deps.iter() {
+            let Some(mut keys) = self.application_eval_dependency_index.get_mut(def_id) else {
                 continue;
             };
             keys.remove(key);
@@ -247,7 +247,7 @@ impl SharedQueryCache {
             drop(keys);
             if empty {
                 self.application_eval_dependency_index
-                    .remove_if(&def_id, |_, keys| keys.is_empty());
+                    .remove_if(def_id, |_, keys| keys.is_empty());
             }
         }
     }
@@ -273,14 +273,15 @@ impl SharedQueryCache {
         size += self.eval_key_dependency_index.len()
             * (DASHMAP_ENTRY_OVERHEAD
                 + std::mem::size_of::<EvaluationCacheKey>()
-                + std::mem::size_of::<FxHashSet<DefId>>());
+                + std::mem::size_of::<Box<[DefId]>>());
         for keys in &self.eval_dependency_index {
             let keys = keys.value();
             size +=
                 keys.len() * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<EvaluationCacheKey>());
         }
         for deps in &self.eval_key_dependency_index {
-            size += deps.value().len() * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<DefId>());
+            // Boxed slice: one contiguous allocation, no per-element bucket.
+            size += deps.value().len() * std::mem::size_of::<DefId>();
         }
         size += (self.subtype_cache.len() + self.assignability_cache.len())
             * (DASHMAP_ENTRY_OVERHEAD
@@ -297,14 +298,15 @@ impl SharedQueryCache {
         size += self.application_eval_key_dependency_index.len()
             * (DASHMAP_ENTRY_OVERHEAD
                 + std::mem::size_of::<ApplicationEvalCacheKey>()
-                + std::mem::size_of::<FxHashSet<DefId>>());
+                + std::mem::size_of::<Box<[DefId]>>());
         for keys in &self.application_eval_dependency_index {
             let keys = keys.value();
             size += keys.len()
                 * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<ApplicationEvalCacheKey>());
         }
         for deps in &self.application_eval_key_dependency_index {
-            size += deps.value().len() * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<DefId>());
+            // Boxed slice: one contiguous allocation, no per-element bucket.
+            size += deps.value().len() * std::mem::size_of::<DefId>();
         }
         size += self.instantiation_cache.len()
             * (DASHMAP_ENTRY_OVERHEAD


### PR DESCRIPTION
The evaluation and application-eval caches keep a reverse dependency index so a
`DefId` change can invalidate exactly the cache entries that depend on it. Each
cache key's dependency list was stored as an `FxHashSet<DefId>`, **rebuilt on
every cache write** from the already-deduplicated `Vec<DefId>` that
`collect_def_dependencies` returns (its `seen` set does the dedup during the
graph walk). That second hash is pure waste: the list is unique on arrival, and
`key_dependencies` is only ever *iterated* during invalidation — never
membership-queried.

Structural rule: when the eval/application-eval cache records an entry's
dependencies, the list is already unique and write-once, so it is stored as a
compact `Box<[DefId]>` (owner layer: the solver cache indexes) instead of being
re-hashed into a second `FxHashSet`. One shrink `memcpy` per write replaces N
`hashbrown::insert` calls plus a `HashSet` allocation, and long-lived storage is
tighter (no bucket slack).

This targets the deterministic, arch-independent cost center the comlink
Callgrind profile in #16554 identified — ~20% of that compile sits in
`hashbrown::insert`, much of it in this eval-cache dependency collector. It is
not the wall-clock regression that issue tracks (prior sessions showed that is
not reproducible off an `m1`/`dist` machine); it is the behavior-neutral
`fast`-goal reduction the same profile surfaced.

Applied across all five sites — eval + application, in both the per-checker
`RefCell` caches and the shared-instantiation `DashMap` caches — with the
memory-size accounting updated to count one contiguous slice. The two
near-identical `RefCell` index modules are folded into one generic
`DependencyIndex<K>` so the record/invalidate/remove algorithm lives once
(`crates/tsz-solver/src/caches/dependency_index.rs`) instead of being
hand-copied per key type.

Behavior is identical: the stored dependency set is unchanged and every
invalidation path iterates the same `DefId`s, so no diagnostic, inferred type,
or emitted output can move — the change only affects how an already-computed
dependency list is stored for cache invalidation.

## Goal
Goal: fast

## Verification
- `cargo test -p tsz-solver --lib` — **7643 passed; 0 failed** (re-run after both
  the representation swap and the generic consolidation).
- `cargo clippy --profile ci-lint --workspace --all-targets -- -D warnings` —
  clean (the per-merge CI clippy lane, run locally).
- `python3 scripts/arch/arch_guard.py` — architecture guardrails passed (the
  per-merge CI arch-size lane).
- Pre-commit hook (fmt + `-p tsz-solver` clippy + arch guard) — passed.
- Conformance / emit not run locally (heavy; need the TypeScript submodule).
  This change is diagnostically inert by construction — it alters only the
  in-memory representation of the eval-cache dependency list, which feeds cache
  invalidation, not any type/diagnostic/emit result — so the parity floor
  (`hold`) cannot move. The `#16554` Callgrind analysis independently confirms
  the collector is behavior-neutral.

## Provenance
Machine: cloud
Assistant: claude-code
Model: Claude Opus
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_018C7WcMiHa2tdek4f7C3j6t)_