### PR TITLE
fix(checker): raise the interface heritage-merge depth guard past real chain lengths (#16308)

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -461,6 +461,8 @@ mod interface_extends_generic_override_variance_tests;
 mod interface_heritage_alias_arg_substitution_tests;
 #[path = "tests/interface_heritage_index_relation_routing_arch_tests.rs"]
 mod interface_heritage_index_relation_routing_arch_tests;
+#[path = "tests/interface_heritage_merge_depth_tests.rs"]
+mod interface_heritage_merge_depth_tests;
 #[path = "tests/interface_heritage_property_index_relation_routing_arch_tests.rs"]
 mod interface_heritage_property_index_relation_routing_arch_tests;
 #[path = "tests/interface_index_conflict_relation_routing_arch_tests.rs"]

--- a/crates/tsz-checker/src/tests/interface_heritage_merge_depth_tests.rs
+++ b/crates/tsz-checker/src/tests/interface_heritage_merge_depth_tests.rs
@@ -1,0 +1,188 @@
+//! Regression tests for #16308: a deep, non-cyclic same-file interface
+//! `extends` chain silently dropped its `Array<T>` base.
+//!
+//! Structural rule: when a user interface's `extends` clause resolution
+//! nests through several other user-declared interfaces before reaching its
+//! ultimate base (here, a lib generic like `Array<T>`), `tsc` merges the
+//! full chain regardless of how many interfaces are in it — nesting depth
+//! alone is not a cycle. tsz's `merge_interface_heritage_types_inner`
+//! (`crates/tsz-checker/src/types/interface_type.rs`) bounds its own
+//! recursion with a `heritage_merge_depth` counter; the previous limit of 5
+//! bailed to the partially-merged type (own members only, base dropped) on
+//! the sixth nested call, with no "incomplete" signal, so the truncated type
+//! was then cached and reused by everything above it in the chain — exactly
+//! the shape reported against the real mobx corpus row
+//! (`IObservableArray<T> extends Array<T>`, reached through mobx's own
+//! multi-file interface hierarchy). The fix raises the bound to match the
+//! already-battle-tested analogous guard for lib-interface heritage
+//! (`LIB_HERITAGE_MERGE_MAX_DEPTH`, 50).
+//!
+//! Binder names are varied (`Chain`/`Link` prefix vs `I`) so no identifier
+//! is load-bearing.
+
+use crate::context::CheckerOptions;
+use crate::diagnostics::diagnostic_codes;
+use crate::test_utils::{check_source_with_libs, load_default_lib_files};
+
+fn strict_codes_with_libs(source: &str) -> Vec<u32> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|d| d.code)
+    .collect()
+}
+
+fn assert_no_missing_property(codes: &[u32], context: &str) {
+    assert!(
+        !codes.contains(&diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE),
+        "{context}: expected inherited Array<T> members to resolve, got {codes:?}",
+    );
+}
+
+/// Core witness: a six-level same-file interface chain terminating in
+/// `extends Array<T>`. Below the fix, the sixth nested heritage-merge call
+/// (processing `I6 extends Array<T>`) hit the depth guard and returned only
+/// `I6`'s own member, dropping every `Array` member from `I1` on up.
+#[test]
+fn six_level_chain_to_array_base_resolves_inherited_members() {
+    let codes = strict_codes_with_libs(
+        r#"
+        interface I1<T> extends I2<T> { own1(): void }
+        interface I2<T> extends I3<T> { own2(): void }
+        interface I3<T> extends I4<T> { own3(): void }
+        interface I4<T> extends I5<T> { own4(): void }
+        interface I5<T> extends I6<T> { own5(): void }
+        interface I6<T> extends Array<T> { own6(): void }
+
+        declare const x: I1<number>;
+        x.map((v) => v);
+        x.slice(0);
+        x.own1();
+        "#,
+    );
+    assert_no_missing_property(&codes, "six-level chain");
+}
+
+/// Negative control: five levels sits exactly at the pre-fix boundary (the
+/// fifth call, processing `I5 extends Array<T>`, saw a depth of 4 and never
+/// tripped the old `>= 5` guard). Must stay clean both before and after the
+/// fix — this pins the boundary itself, not just the regression side.
+#[test]
+fn five_level_chain_to_array_base_resolves_inherited_members() {
+    let codes = strict_codes_with_libs(
+        r#"
+        interface I1<T> extends I2<T> { own1(): void }
+        interface I2<T> extends I3<T> { own2(): void }
+        interface I3<T> extends I4<T> { own3(): void }
+        interface I4<T> extends I5<T> { own4(): void }
+        interface I5<T> extends Array<T> { own5(): void }
+
+        declare const x: I1<number>;
+        x.map((v) => v);
+        x.own1();
+        "#,
+    );
+    assert_no_missing_property(&codes, "five-level chain (pre-fix boundary control)");
+}
+
+/// Renamed-binder control: identical shape, different identifiers, so no
+/// binder name is load-bearing for the fix.
+#[test]
+fn six_level_chain_renamed_binders_resolves_inherited_members() {
+    let codes = strict_codes_with_libs(
+        r#"
+        interface ChainRoot<T> extends ChainB<T> { rootMember(): void }
+        interface ChainB<T> extends ChainC<T> { bMember(): void }
+        interface ChainC<T> extends ChainD<T> { cMember(): void }
+        interface ChainD<T> extends ChainE<T> { dMember(): void }
+        interface ChainE<T> extends ChainLeaf<T> { eMember(): void }
+        interface ChainLeaf<T> extends Array<T> { leafMember(): void }
+
+        declare const y: ChainRoot<string>;
+        y.forEach((v) => v);
+        y.rootMember();
+        "#,
+    );
+    assert_no_missing_property(&codes, "renamed-binder six-level chain");
+}
+
+/// A much deeper (well beyond the new 50-level bound is not exercised here,
+/// but comfortably beyond the old 5-level one) chain must still resolve, so
+/// the fix is not itself narrowly tuned to exactly six levels.
+#[test]
+fn twelve_level_chain_to_array_base_resolves_inherited_members() {
+    let codes = strict_codes_with_libs(
+        r#"
+        interface L1<T> extends L2<T> {}
+        interface L2<T> extends L3<T> {}
+        interface L3<T> extends L4<T> {}
+        interface L4<T> extends L5<T> {}
+        interface L5<T> extends L6<T> {}
+        interface L6<T> extends L7<T> {}
+        interface L7<T> extends L8<T> {}
+        interface L8<T> extends L9<T> {}
+        interface L9<T> extends L10<T> {}
+        interface L10<T> extends L11<T> {}
+        interface L11<T> extends L12<T> {}
+        interface L12<T> extends Array<T> {}
+
+        declare const z: L1<boolean>;
+        z.map((v) => v);
+        "#,
+    );
+    assert_no_missing_property(&codes, "twelve-level chain");
+}
+
+/// Negative control: a member that genuinely does not exist anywhere in the
+/// chain (own members or the inherited `Array<T>` base) must still be
+/// reported. The depth-guard fix must not turn off TS2339 wholesale.
+#[test]
+fn six_level_chain_still_reports_genuinely_missing_member() {
+    let codes = strict_codes_with_libs(
+        r#"
+        interface I1<T> extends I2<T> { own1(): void }
+        interface I2<T> extends I3<T> { own2(): void }
+        interface I3<T> extends I4<T> { own3(): void }
+        interface I4<T> extends I5<T> { own4(): void }
+        interface I5<T> extends I6<T> { own5(): void }
+        interface I6<T> extends Array<T> { own6(): void }
+
+        declare const x: I1<number>;
+        x.thisMemberDoesNotExistAnywhere();
+        "#,
+    );
+    assert!(
+        codes.contains(&diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE),
+        "expected a genuinely missing member to still report TS2339, got {codes:?}",
+    );
+}
+
+/// Concrete (non-generic) base control: the same chain shape with a
+/// concrete `extends Array<string>` leaf instead of a passed-through type
+/// parameter.
+#[test]
+fn six_level_chain_concrete_array_base_resolves_inherited_members() {
+    let codes = strict_codes_with_libs(
+        r#"
+        interface I1 extends I2 { own1(): void }
+        interface I2 extends I3 { own2(): void }
+        interface I3 extends I4 { own3(): void }
+        interface I4 extends I5 { own4(): void }
+        interface I5 extends I6 { own5(): void }
+        interface I6 extends Array<string> { own6(): void }
+
+        declare const x: I1;
+        x.map((v) => v);
+        x.own1();
+        "#,
+    );
+    assert_no_missing_property(&codes, "six-level chain, concrete Array<string> base");
+}

--- a/crates/tsz-checker/src/types/interface_type.rs
+++ b/crates/tsz-checker/src/types/interface_type.rs
@@ -25,6 +25,14 @@ use tsz_solver::Visibility;
 // Interface Type Resolution
 // =============================================================================
 
+/// Maximum nesting for `merge_interface_heritage_types_inner`'s
+/// `heritage_merge_depth` counter (#16308). Mirrors `LIB_HERITAGE_MERGE_MAX_DEPTH`
+/// in `lib_resolution_heritage.rs`: real chains stay far under this; it is
+/// pure backstop against a pathologically deep distinct-name chain, since
+/// genuine cycles are already caught by `check_interface_inheritance_cycle`
+/// (TS2310) and OS-stack risk is bounded separately by `with_stack_guard`.
+const INTERFACE_HERITAGE_MERGE_MAX_DEPTH: u32 = 50;
+
 /// Debug kill-switch for #14101 part-4 (heritage base-member incorporation).
 ///
 /// When a heritage base classifies as `Other` but still has an extractable
@@ -794,10 +802,17 @@ impl<'a> CheckerState<'a> {
         // Depth guard: heritage merging can trigger get_type_of_symbol on base
         // interfaces, which in turn calls compute_type_of_symbol →
         // merge_interface_heritage_types again for cross-referencing interfaces.
-        // Use a dedicated counter with a tight limit (10) because each heritage
-        // merge cycle is expensive (it resolves full interface types).
+        //
+        // #16308: a legitimate, non-cyclic same-file six-level chain (real
+        // shape: mobx's `IObservableArray<T> extends Array<T>`, reached
+        // through several layers of the project's own interfaces) used to
+        // hit the old limit of 5 on its sixth nested call and silently drop
+        // the `Array<T>` base with no "incomplete" signal — so the truncated
+        // type then got cached as final by every caller. See
+        // `INTERFACE_HERITAGE_MERGE_MAX_DEPTH`'s doc comment for why raising
+        // this bound is safe (cycles and OS-stack risk are caught elsewhere).
         let heritage_depth = self.ctx.heritage_merge_depth.get();
-        if heritage_depth >= 5 {
+        if heritage_depth >= INTERFACE_HERITAGE_MERGE_MAX_DEPTH {
             return derived_type;
         }
         // Bail out early if type resolution fuel is exhausted.


### PR DESCRIPTION
## Summary

Fixes the root mechanism behind #16308 (mobx `IObservableArray<T> extends Array<T>` losing every inherited `Array` member cross-file, 10/33 diagnostics on that row).

## Structural rule

When a user interface's `extends` clause resolution legitimately nests through several other user-declared interfaces before reaching its ultimate base (e.g. a lib generic like `Array<T>`), `tsc` merges the full chain regardless of nesting depth — depth alone is not a cycle.

`merge_interface_heritage_types_inner` (`crates/tsz-checker/src/types/interface_type.rs`) bounds its own recursion with a `heritage_merge_depth` counter. The previous limit (`>= 5`) treated a legitimate six-level chain exactly like a pathological/cyclic one: on the sixth nested call it silently returned the partially-merged type (own members only, base dropped) with **no "incomplete" signal**, so the truncated type was then permanently cached as final by every caller (`compute_type_of_symbol`, cross-file interface caching) — the same failure shape as the closed #12299, but on the *user*-interface heritage path rather than the lib-interface path #12299 fixed.

Genuine unbounded/cyclic heritage is already caught elsewhere: `check_interface_inheritance_cycle` (TS2310) runs before type resolution, and `with_stack_guard` is the dedicated OS-stack breaker that survives cross-arena context hops. So this counter's only remaining job is bounding legitimate-but-expensive fan-out, and it now uses the same generous bound (50) as the already-battle-tested analogous guard for lib-interface heritage, `LIB_HERITAGE_MERGE_MAX_DEPTH` in `lib_resolution_heritage.rs`.

Owner layer: checker (`crates/tsz-checker/src/types/interface_type.rs`), a solver-adjacent type-resolution query the checker owns directly (no solver/relation involvement — this is heritage-clause structural merging, not a relation decision).

## Reproduction

Minimized to a same-file, non-cyclic 6-level interface chain (mobx's real graph needed cross-file, multi-interface nesting to reach depth 5+; this reproduces the identical mechanism deterministically without the corpus):

```ts
interface I1<T> extends I2<T> { own1(): void }
interface I2<T> extends I3<T> { own2(): void }
interface I3<T> extends I4<T> { own3(): void }
interface I4<T> extends I5<T> { own4(): void }
interface I5<T> extends I6<T> { own5(): void }
interface I6<T> extends Array<T> { own6(): void }

declare const x: I1<number>;
x.map(v => v); // was: TS2339 "Property 'map' does not exist on type 'I1<number>'."
```

`tsc` 7.0.2 (`--noEmit --strict --lib es2022 --target es2022`): exit 0. tsz before this fix: `TS2339` on `map`/`slice`. Verified the exact boundary: a 5-level chain (`I5 extends Array<T>` directly) never tripped the old guard (`heritage_depth` was 4 when `I5` was processed); 6 levels always did.

## Adjacent-case matrix (all in `interface_heritage_merge_depth_tests.rs`)

| Case | Purpose |
| --- | --- |
| 6-level chain, generic `Array<T>` base | core witness |
| 5-level chain, generic `Array<T>` base | negative control pinning the exact pre-fix boundary |
| 6-level chain, renamed binders (`ChainRoot`/`ChainB`/…) | no identifier is load-bearing |
| 12-level chain | fix is not narrowly tuned to exactly 6 |
| 6-level chain, genuinely missing member | TS2339 must still fire — the guard change doesn't turn off the diagnostic wholesale |
| 6-level chain, concrete `Array<string>` base | non-generic base control |

Non-vacuity: reverting only the source fix (keeping the tests) fails exactly the 4 tests that exercise >5-level chains; the 5-level boundary control and the genuinely-missing-member control pass either way, as expected.

## What's not covered here

The real mobx row needed *cross-file* nesting to reach the guard (a simple linear cross-file chain up to 13 levels did not reproduce it in testing — cross-file heritage for a locally-declared base appears to route through a different, eagerly-resolved path in most shapes). This fix addresses the depth-guard mechanism itself, which is provably the same mechanism (confirmed via the same-file reproduction above, using the exact same counter and code path `IObservableArray`'s own heritage merge would go through). Re-running the mobx `project-compile-guard` row against this fix to confirm the full 10-diagnostic family clears is owed as a follow-up — not run in this session due to time budget (a cold dist-fast build + fresh corpus checkout).

## Verification

- New test file `crates/tsz-checker/src/tests/interface_heritage_merge_depth_tests.rs`, 6 tests, registered in `test_module_registry.rs`: **6/6 pass** with the fix; **4/6 fail** with only the source fix reverted (non-vacuity).
- `cargo test -p tsz-checker --lib -- interface_heritage interface_extends heritage_merge`: **66/66 pass** (existing interface-heritage-adjacent suites unaffected).
- `cargo clippy -p tsz-checker --lib --all-targets -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- `scripts/arch/arch_guard.py`: `Architecture guardrails passed.`
- Pre-commit hook (fmt + clippy `-p tsz-checker` + arch guard): passed.
- **Owed**: a full `cargo test -p tsz-checker --lib` run was started but not awaited to completion (this session's time budget), and `conformance.sh snapshot` / `scripts/emit/run.sh` were not run — this change touches only checker type-resolution (`interface_type.rs`), not the emitter, and is scoped to a single guard constant plus comments, so emit risk is low, but the conformance snapshot is genuinely owed before landing.

## Goal
Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude


---
_Generated by [Claude Code](https://claude.ai/code/session_01QVksREhHiSHrniukzUPJLb)_