### PR TITLE
fix(cli): route parse-diagnostic post-filter suppression trigger through the canonical hasParseDiagnostics predicate

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -314,29 +314,25 @@ pub(super) fn filtered_parse_diagnostics(
         .iter()
         .any(|diagnostic| is_real_syntax_error(diagnostic.code));
 
-    // tsc emits these codes via grammarErrorOnNode in the checker, which checks
-    // hasParseDiagnostics(sourceFile) and suppresses when any parse error exists.
-    // In tsz, these are emitted by the parser. We post-filter them here to match
-    // tsc's suppression behavior. We only suppress grammar codes when there's a
-    // non-grammar parse error present (e.g., TS1005, TS1109) to avoid suppressing
-    // grammar codes that are the file's only diagnostic.
+    // tsc emits many grammar codes via grammarErrorOnNode in the checker, which
+    // suppresses them when `hasParseDiagnostics(sourceFile)` is true. tsz emits
+    // them from the parser instead, so we post-filter here to match. A grammar
+    // code is suppressed only when the file also carries a genuinely *suppressing*
+    // parse error — one that is NOT `is_non_suppressing_parse_error`. That is the
+    // single canonical model of tsc's `hasParseDiagnostics`; the checker gate sets
+    // `ctx.has_syntax_parse_errors` from the identical call (`check.rs`,
+    // `check_file.rs`), so this trigger cannot drift from it.
     //
-    // `is_real_syntax_error` is NOT a substitute for this exemption tuple: TS1260
-    // (keyword containing an escape character, e.g. `default:`) is neither a
-    // structural failure nor a listed grammar code, yet per the pinned tsc oracle
-    // it DOES trigger file-wide suppression of sibling grammar codes
-    // (switchStatementsWithMultipleDefaults.ts reports only TS1260, dropping every
-    // TS1113 duplicate-default diagnostic) — so "not exempted" must stay the
-    // default for anything not proven to need exemption, not "not a real syntax
-    // error". 1009/1185/1214/1262/1359/18012 are themselves parser-emitted
-    // strict-mode/grammar checks (not structural failures) that must NOT count as
-    // the trigger: e.g. plainJSBinderErrors.ts reports TS1101, TS1359, and TS18012
-    // ('#constructor' is a reserved word) all together with no structural parse
-    // error at all, per the same oracle.
-    let has_non_grammar_parse_error = parse_diagnostics.iter().any(|d| {
-        !matches!(d.code, 1009 | 1185 | 1214 | 1262 | 1359 | 18012)
-            && !is_parser_grammar_code(d.code)
-    });
+    // This replaced a hand-kept complement that #16279 showed was load-bearing in
+    // both directions (an unnamed non-suppressing code silently deleted every
+    // grammar sibling in its file). The unclassified-code default stays
+    // "suppressing" on purpose: TS1260 is neither structural nor a grammar code
+    // yet tsc still suppresses siblings for it, so it must never join
+    // `is_non_suppressing_parse_error`. See `filter_trigger_unification_tests` for
+    // the oracle-pinned witnesses and the full history.
+    let has_non_grammar_parse_error = parse_diagnostics
+        .iter()
+        .any(|d| !is_non_suppressing_parse_error(d.code));
 
     // TS1359 for `await` is parser-emitted in tsz. Keep it alongside unrelated
     // parse diagnostics (tsc does this in plain JS binder errors), but suppress
@@ -1680,6 +1676,13 @@ pub(super) const fn is_non_suppressing_parse_error(code: u32) -> bool {
                    // with string-literal escapes — so it stays enumerated here.
             | 17019 // '?' at end of type is not valid TS syntax (parser recovers valid AST)
             | 17020 // '?' at start of type is not valid TS syntax (parser recovers valid AST)
+            | 18012 // '#constructor' is a reserved word. tsc raises this from the
+                    // binder/checker, so it is never in `sourceFile.parseDiagnostics`;
+                    // tsz emits it from the parser instead. Oracle-pinned against
+                    // `typescript@7.0.2`: `class D { #constructor = 1; }` reports
+                    // TS18012 *alongside* a sibling getter's TS1054 and a semantic
+                    // TS2304 in the same file (plainJSBinderErrors.ts does the same
+                    // with TS1101/TS1359), so it must not set has_syntax_parse_errors.
     )
 }
 
@@ -1732,3 +1735,7 @@ mod parser_grammar_non_suppressing_tests;
 #[cfg(test)]
 #[path = "check_utils/for_in_using_declaration_grammar_tests.rs"]
 mod for_in_using_declaration_grammar_tests;
+
+#[cfg(test)]
+#[path = "check_utils/filter_trigger_unification_tests.rs"]
+mod filter_trigger_unification_tests;

--- a/crates/tsz-cli/src/driver/check_utils/filter_trigger_unification_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/filter_trigger_unification_tests.rs
@@ -1,0 +1,195 @@
+//! Unit tests for the CLI parse-diagnostic post-filter's suppression *trigger*.
+//!
+//! `filtered_parse_diagnostics` suppresses a listed `is_parser_grammar_code`
+//! diagnostic only when the file also carries a genuinely suppressing parse
+//! error — tsz's stand-in for tsc's `hasParseDiagnostics(sourceFile)`. #16279
+//! showed the trigger used to be the *complement* of a hand-kept six-code
+//! exemption tuple plus `is_parser_grammar_code`, so any parser-emitted
+//! non-suppressing code the tuple did not name (the whole `1499..=1538` regex
+//! band, TS1492, TS1487, TS17019/TS17020) counted as a real parse error and
+//! silently deleted every listed grammar sibling in the file.
+//!
+//! The trigger now routes through the single canonical
+//! `is_non_suppressing_parse_error` predicate — the same one the checker gate
+//! uses to set `ctx.has_syntax_parse_errors` (`check.rs`, `check_file.rs`) — so
+//! the two can no longer drift.
+//!
+//! # Oracle evidence
+//!
+//! Every "keeps" witness below was pinned against `typescript@7.0.2`
+//! (`--noEmit --strict --pretty false --lib es2022 --target es2022`): each
+//! non-suppressing code reports *alongside* a getter's TS1054 in the same file.
+//! The discriminating control is a genuine structural error (TS1109,
+//! `Expression expected.`), which drops the TS1054 in both compilers.
+
+use super::*;
+use tsz::parser::ParseDiagnostic;
+
+/// Build a two-diagnostic file: a getter's TS1054 (a listed grammar code) plus
+/// one sibling `code`. The offsets are arbitrary; only the codes drive the
+/// trigger.
+fn grammar_plus_sibling(code: u32, message: &str) -> Vec<ParseDiagnostic> {
+    vec![
+        ParseDiagnostic {
+            start: 18,
+            length: 2,
+            message: "A 'get' accessor cannot have parameters.".to_string(),
+            code: 1054,
+        },
+        ParseDiagnostic {
+            start: 52,
+            length: 2,
+            message: message.to_string(),
+            code,
+        },
+    ]
+}
+
+/// A non-suppressing sibling must never delete the getter's TS1054. Each case is
+/// oracle-pinned: tsc 7.0.2 reports both codes together.
+#[test]
+fn non_suppressing_sibling_keeps_listed_grammar_ts1054() {
+    // (sibling code, message, why it is non-suppressing)
+    let cases: &[(u32, &str)] = &[
+        // Regex grammar band `1499..=1538` — tsc validates the pattern from the
+        // checker (scanRange), so it is never a parse diagnostic. `/abc/gg`. The
+        // whole band is exhausted by `every_regex_band_code_keeps_a_listed_grammar_sibling`;
+        // this is the named exemplar carrying the real tsc message.
+        (1500, "A regular expression flag cannot be repeated."),
+        // `using {a} = obj;` — a binding pattern on a `using` declaration; the AST
+        // is valid, tsc reports it from the checker grammar phase.
+        (1492, "'using' declarations may not have binding patterns."),
+        // Octal escape shared with string literals — valid AST.
+        (
+            1487,
+            "Octal escape sequences are not allowed. Use the syntax '{0}'.",
+        ),
+        // `?`-recovery type spellings — parser recovers a valid AST.
+        (
+            17019,
+            "'{0}' at the end of a type is not valid TypeScript syntax.",
+        ),
+        (
+            17020,
+            "'{0}' at the start of a type is not valid TypeScript syntax.",
+        ),
+        // '#constructor' is a reserved word — binder/checker-raised in tsc.
+        (18012, "'#constructor' is a reserved word."),
+    ];
+
+    for &(code, message) in cases {
+        let diagnostics = grammar_plus_sibling(code, message);
+        let filtered = filtered_parse_diagnostics(&diagnostics, false);
+        let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+        assert!(
+            codes.contains(&1054),
+            "TS1054 must survive alongside non-suppressing sibling TS{code}, got: {codes:?}"
+        );
+        assert!(
+            codes.contains(&code),
+            "sibling TS{code} must survive alongside TS1054, got: {codes:?}"
+        );
+    }
+}
+
+/// The whole regex band, checked as a range so a newly wired regex diagnostic
+/// cannot reopen the gap by omission — the same reason
+/// `is_non_suppressing_parse_error` matches `1499..=1538` as a range.
+#[test]
+fn every_regex_band_code_keeps_a_listed_grammar_sibling() {
+    for code in 1499..=1538_u32 {
+        let diagnostics = grammar_plus_sibling(code, "regex grammar diagnostic");
+        let filtered = filtered_parse_diagnostics(&diagnostics, false);
+        let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+        assert!(
+            codes.contains(&1054),
+            "TS1054 must survive alongside regex-band sibling TS{code}, got: {codes:?}"
+        );
+    }
+}
+
+/// The discriminating control: a genuine structural parse error still triggers
+/// file-wide suppression of the listed grammar sibling, so the fix above is not
+/// indistinguishable from deleting the trigger entirely. Oracle: `const x = ;`
+/// (TS1109) drops the getter's TS1054 in tsc.
+#[test]
+fn structural_error_still_suppresses_listed_grammar_ts1054() {
+    let diagnostics = grammar_plus_sibling(1109, "Expression expected.");
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&1054),
+        "TS1054 must be suppressed by a structural TS1109 sibling, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1109),
+        "the structural TS1109 itself must survive, got: {codes:?}"
+    );
+}
+
+/// A grammar code that is the file's only diagnostic is always kept — the fix
+/// must not make any grammar code suppress itself.
+#[test]
+fn lone_grammar_code_is_kept() {
+    let diagnostics = vec![ParseDiagnostic {
+        start: 18,
+        length: 2,
+        message: "A 'get' accessor cannot have parameters.".to_string(),
+        code: 1054,
+    }];
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    assert_eq!(filtered.len(), 1, "a lone grammar code must survive");
+    assert_eq!(filtered[0].code, 1054);
+}
+
+/// The CLI post-filter's trigger and the checker gate's `has_syntax_parse_errors`
+/// must be the *same* function of a code, not two hand-kept lists that can drift.
+/// `filtered_parse_diagnostics` suppresses a listed grammar sibling exactly when
+/// some diagnostic is `!is_non_suppressing_parse_error`; assert that equivalence
+/// directly over the whole diagnostic range.
+#[test]
+fn post_filter_trigger_matches_checker_gate_predicate() {
+    for code in 0..20_000_u32 {
+        let diagnostics = grammar_plus_sibling(code, "sibling");
+        let filtered = filtered_parse_diagnostics(&diagnostics, false);
+        let ts1054_kept = filtered.iter().any(|d| d.code == 1054);
+        // The sibling suppresses TS1054 iff it is a genuinely suppressing parse
+        // error — i.e. NOT non-suppressing — and is not TS1054 itself.
+        let sibling_suppresses = code != 1054 && !is_non_suppressing_parse_error(code);
+        assert_eq!(
+            ts1054_kept, !sibling_suppresses,
+            "TS1054 retention disagrees with the checker-gate predicate for sibling TS{code}"
+        );
+    }
+}
+
+/// The six-code exemption tuple the old complement named explicitly is fully
+/// covered by `is_non_suppressing_parse_error`, so replacing the tuple is a
+/// faithful superset rather than a behaviour change for those codes.
+#[test]
+fn legacy_exemption_tuple_is_covered_by_the_canonical_predicate() {
+    for code in [1009_u32, 1185, 1214, 1262, 1359, 18012] {
+        assert!(
+            is_non_suppressing_parse_error(code),
+            "TS{code} was in the old exemption tuple and must stay non-suppressing"
+        );
+    }
+}
+
+/// TS1260 must NOT be classified non-suppressing: it is neither structural nor a
+/// grammar code, yet tsc treats it as a real parse diagnostic
+/// (switchStatementsWithMultipleDefaults.ts reports only TS1260, dropping every
+/// TS1113). Pins that the "default is suppressing" invariant is preserved.
+#[test]
+fn ts1260_stays_suppressing() {
+    assert!(
+        !is_non_suppressing_parse_error(1260),
+        "TS1260 must remain a suppressing trigger"
+    );
+    let diagnostics = grammar_plus_sibling(1260, "Keyword cannot contain escape characters.");
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    assert!(
+        !filtered.iter().any(|d| d.code == 1054),
+        "TS1260 must suppress a listed grammar sibling, matching tsc"
+    );
+}


### PR DESCRIPTION
Structural rule: when a source file contains a parser-emitted diagnostic that tsc does **not** put in `sourceFile.parseDiagnostics` (a grammar code tsc raises from `grammarErrorOnNode`, a regex-band code, etc.), tsc's `hasParseDiagnostics(sourceFile)` stays false and every other grammar check in the file still fires. tsz must model that through the CLI parse-diagnostic post-filter (`crates/tsz-cli/src/driver/check_utils.rs`, `filtered_parse_diagnostics`).

## What / why

`filtered_parse_diagnostics` decided whether to suppress a parser-emitted grammar code by asking whether the file had a "non-grammar parse error". That trigger was computed as the **complement** of a hand-kept six-code exemption tuple `{1009,1185,1214,1262,1359,18012}` plus `is_parser_grammar_code`.

Per #16279 that complement is load-bearing in **both** directions: any parser-emitted *non-suppressing* code the tuple failed to name counted as a real parse error and silently deleted every listed grammar sibling in the file — a false negative surfacing in codes no one touched. The tuple was missing the whole `1499..=1538` regex band plus `TS1492`/`TS1487`/`TS17019`/`TS17020`, all of which the checker gate's own `is_non_suppressing_parse_error` predicate already classifies correctly. So a malformed regex literal (`TS1500`), a `using { a } = obj` (`TS1492`), or similar would drop a co-located getter's `TS1054` that tsc keeps.

Fix: compute the trigger as `any(|d| !is_non_suppressing_parse_error(d.code))` — the single canonical model of tsc's `hasParseDiagnostics(sourceFile)` that `check.rs`/`check_file.rs` already use for `ctx.has_syntax_parse_errors`, so the CLI post-filter can no longer drift from the checker gate. The tuple's only member not already covered, `TS18012` (`'#constructor' is a reserved word`), is added to `is_non_suppressing_parse_error`; the oracle confirms it is non-suppressing for both grammar-sibling and semantic diagnostics. The unclassified-code default stays "suppressing" so `TS1260` (a genuine tsc parse diagnostic that is neither structural nor a grammar code) keeps triggering.

Owner layer: CLI driver diagnostic post-filter (`tsz-cli`), reusing the solver/checker-shared `is_non_suppressing_parse_error` predicate. No checker/solver algorithm change.

Scope note: this fixes the trigger-side self-suppression *mechanism* #16279 describes; the separate enumeration audit of missing `is_parser_grammar_code` members continues (tracked in #16291). `Refs #16279`, not `Closes`.

## Goal
Goal: hold

## Verification
Behavioral delta (exactly): `1499..=1538`, `TS1492`, `TS1487`, `TS17019`, `TS17020` no longer over-trigger file-wide grammar suppression; `TS18012` unified into the canonical predicate. All oracle-verified toward parity; unclassified-code default and `TS1260` behavior unchanged.

- Oracle (`typescript@7.0.2`, `--noEmit --strict --lib es2022 --target es2022`): `TS1500`+`TS1054`, `TS1492`+`TS1054`, `TS18012`+`TS1054` each report **both**; `TS1109`+`TS1054` reports only `TS1109`. Confirmed end-to-end in the release `tsz` binary (matches).
- `cargo nextest run -p tsz-cli -E 'test(/filter_trigger_unification|filtered_parse_diagnostics|non_suppressing|regex_grammar|for_in_|audit_round/)'` — green; adds `filter_trigger_unification_tests` (7 tests) pinning the witnesses, the whole regex band as a range, the `TS1260` control, the legacy-tuple coverage, and an invariant tying the filter to the predicate over `0..20000`.
- `cargo clippy -p tsz-cli --all-targets` — clean; local pre-commit (clippy + arch-size + arch guard) passed.
- Conformance `compare-to-parent.sh origin/main` — running; results appended below.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_019iUbk9RCoeAVLJDGwyZRpA)_