### PR TITLE
test(cli): correct a stale extends-cycle assertion to the post-split contract

### DIFF
--- a/crates/tsz-cli/tests/config_tests.rs
+++ b/crates/tsz-cli/tests/config_tests.rs
@@ -117,16 +117,61 @@ fn load_tsconfig_merges_extends() {
     assert_eq!(config.files, Some(vec!["main.ts".to_string()]));
 }
 
+/// An `extends` cycle is **recoverable**, not fatal: `load_tsconfig` is the
+/// diagnostic-free loader, so the cyclic base contributes nothing and the load
+/// still succeeds. `tsc` behaves the same way — it reports `TS18000` and keeps
+/// compiling rather than aborting:
+///
+/// ```text
+/// a.json extends ./b.json ;  b.json extends ./a.json
+/// tsc: error TS18000: Circularity detected while resolving configuration: {0}
+/// tsz: error TS18000: Circularity detected while resolving configuration: {0}
+/// ```
+///
+/// This test previously asserted `expect_err("cycle should error")`, which was
+/// the contract before the loader was split. `load_tsconfig_inner` now returns
+/// `Ok(TsConfig::default())` for the cyclic base by design, and the `TS18000`
+/// half lives on `load_tsconfig_with_diagnostics` — pinned in `tsz-core` by
+/// `config::tests::extends_cycle_and_jsx_factory_values`
+/// (`self_extends_cycle_reports_ts18000_and_recovers`,
+/// `two_config_extends_cycle_reports_ts18000_once`). The CLI's own output was
+/// never wrong; only this assertion lagged the split.
 #[test]
-fn load_tsconfig_detects_extends_cycle() {
+fn load_tsconfig_recovers_from_an_extends_cycle() {
     let temp = TempDir::new().expect("temp dir");
 
     write_file(&temp.path, "a.json", r#"{"extends":"./b.json"}"#);
     write_file(&temp.path, "b.json", r#"{"extends":"./a.json"}"#);
 
-    let err = load_tsconfig(&temp.path.join("a.json")).expect_err("cycle should error");
-    let message = err.to_string();
-    assert!(message.contains("extends cycle"), "{message}");
+    let config = load_tsconfig(&temp.path.join("a.json"))
+        .expect("an extends cycle is recoverable and must not abort the load");
+    assert!(
+        config.extends.is_none(),
+        "the cyclic base must contribute nothing, got: {config:?}"
+    );
+}
+
+/// Recovery must not swallow the entry config's *own* settings — only the
+/// cyclic base is dropped. Guards against "fixing" the row above by returning
+/// an empty config unconditionally.
+#[test]
+fn extends_cycle_recovery_keeps_the_entry_config_s_own_options() {
+    let temp = TempDir::new().expect("temp dir");
+
+    write_file(
+        &temp.path,
+        "a.json",
+        r#"{"extends":"./b.json","files":["a.ts"]}"#,
+    );
+    write_file(&temp.path, "b.json", r#"{"extends":"./a.json"}"#);
+
+    let config = load_tsconfig(&temp.path.join("a.json"))
+        .expect("an extends cycle is recoverable and must not abort the load");
+    assert_eq!(
+        config.files.as_deref(),
+        Some(&["a.ts".to_string()][..]),
+        "the entry config's own `files` must survive the cycle, got: {config:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Goal: hold

Closes the last **ungated** failing test I can find on `main`. Found while verifying #16583, confirmed pre-existing there rather than caused by it.

## The test asserted a contract that no longer exists

`config_tests::load_tsconfig_detects_extends_cycle` asserted `load_tsconfig(...).expect_err("cycle should error")`. That was the contract before the loader was split. `load_tsconfig_inner` now returns `Ok(TsConfig::default())` for the cyclic base **by design** — its own comment says so:

```rust
// An `extends` cycle is recoverable in tsc: the cyclic base simply
// contributes nothing and the rest of the chain still merges. See
// `load_tsconfig_inner_with_diagnostics` for the TS18000 half; this
// diagnostic-free loader only needs the recovery.
return Ok(TsConfig::default());
```

## The CLI's actual behaviour was never wrong

```
a.json extends ./b.json ;  b.json extends ./a.json

tsc: error TS18000: Circularity detected while resolving configuration: {0}
tsz: error TS18000: Circularity detected while resolving configuration: {0}
```

Byte-identical to the pinned `typescript@7.0.2`. And the `TS18000` half is already pinned in `tsz-core` by `config::tests::extends_cycle_and_jsx_factory_values` — `self_extends_cycle_reports_ts18000_and_recovers` and `two_config_extends_cycle_reports_ts18000_once`, the latter using the same two-config shape as this test. So the behaviour has real coverage; only this assertion lagged.

## The change

- `load_tsconfig_recovers_from_an_extends_cycle` — asserts the load **succeeds** and the cyclic base contributes nothing, which is the actual contract.
- `extends_cycle_recovery_keeps_the_entry_config_s_own_options` — **new**, and the reason this is not just a rubber-stamp: it pins that recovery drops *only* the cyclic base, so nobody can satisfy the first row by returning an empty config unconditionally. The entry's own `files: ["a.ts"]` must survive.
- Doc comment records the measured tsc/tsz outputs and points at the `tsz-core` tests owning the `TS18000` half, so the split is not re-derived next time.

## Verification

- `cargo nextest run -p tsz-cli -E 'test(config_tests)'` — **24/24**
- `cargo nextest run -p tsz-cli` — **2650/2654**, and the 4 remaining failures are **exactly** the four `known-failures.txt` entries for this crate:
  - `driver::core::check::check_tests::cross_file_class_namespace_merge_value_keeps_call_signature_in_import_cycle`
  - `driver::core::check::check_tests::default_lib_validation_normalizes_cross_arena_method_members_after_global_merge`
  - `driver_tests::cross_file_dependent_operand_aliases_accept_scalars_and_literal_arrays`
  - `driver_tests::declaration_emit_reports_ts7056_for_private_import_type_alias`

  Before this change the crate had 5 failures, one of them ungated — so a nightly `tsz-cli` gate run would have flagged a regression that was really a stale test.
- `scripts/arch/arch_guard.py` — rc=0
- test-only; no compiler or CLI source touched, so conformance/emit cannot move.

Worth noting `tsz-cli` is **not** in the standard unit lane, which is why this sat unnoticed: my morning gate audit (#16547) covered every `tsz-checker` target plus the four gated `tsz-cli` rows, and `config_tests` was outside that scope. Running the whole crate is what surfaced it.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5
Effort: xhigh
