### PR TITLE
fix(solver): checker-pool cross-file eval_cache refuses registration-window artifacts (#16553)

### DIFF
--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -1413,6 +1413,23 @@ impl QueryDatabase for QueryCache<'_> {
         // dependent way — the exact non-determinism that makes
         // recursive-utility fixtures flip with surrounding code.
         //
+        // The same key shape makes this cache cross-file (it is also mirrored
+        // into `shared` below), so a registration-window artifact is just as
+        // dangerous as a depth-bailed one: a top-level result computed while
+        // some `Lazy`/`Ref` operand's definition had not yet registered
+        // (`unresolved_def_seen`, e.g. a checker-pool file partition
+        // evaluating a cross-file interface union before every constituent's
+        // body is available) must not be published either, or a later file in
+        // the same partition reads the under-resolved answer back after the
+        // real definition registers (#16553). `is_stable_for_run_wide_cache`
+        // checks the raw `EvaluationRequestStability` directly rather than
+        // going through `EvaluationMemoResult::is_stable_for_depth_agnostic_cache`,
+        // which deliberately tolerates `UnresolvedDef` for run/query-scoped
+        // memo consumers — a tolerance that is unsound for this cross-file
+        // cache. Mirrors the same direct-request-state check
+        // `closed_eval::commit_closed_eval_writes` uses for its own run-wide
+        // cache.
+        //
         // The discrimination is per-entry (issue #13241, extending the
         // PR #12902 application-eval epoch split): the top-level result uses
         // the named `EvaluationMemoResult` stability verdict (#14346), which
@@ -1427,7 +1444,7 @@ impl QueryDatabase for QueryCache<'_> {
         // limit epoch, so it conservatively suppresses all writes, as before.
         let union_complexity_stable =
             limit_snapshot.union_complexity_stayed_stable_after(self.interner);
-        let top_level_clean = evaluation_memo_result.is_stable_for_depth_agnostic_cache();
+        let top_level_clean = evaluation_memo_result.is_stable_for_run_wide_cache();
         if union_complexity_stable
             && (top_level_clean || crate::limits::limit_result_cache_enabled())
         {

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -1402,8 +1402,26 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             // kill switch for entries computed after a limit event this run.
             // The last clause skips the write only when the `TS2590` flag is
             // newly set relative to the construction snapshot.
+            //
+            // `self.limit_epoch != epoch_at_entry` above only tells us whether
+            // *this node's own* window saw a NEW limit event; it says nothing
+            // about a run-scoped taint an EARLIER, unrelated node already
+            // recorded before this node's window opened. Once
+            // `mark_unresolved_def_seen` fires anywhere in this evaluator's
+            // request, every later node's own window looks "clean" by the
+            // epoch-delta test alone (the epoch simply never moves again), yet
+            // that later node may still be a sibling/dependent of the
+            // under-resolved one — nothing about node-local epoch stability
+            // proves it is not (#16553: a checker-pool partition evaluating a
+            // cross-file interface union hits this after the pool's shared,
+            // long-lived `eval_cache` mirrors this write cross-file). The
+            // explicit `is_unresolved_def_seen()` check closes that gap; it
+            // mirrors the identical guard the silent-depth-bail arm above
+            // already applies to its own `memo_insert` call for the same
+            // registration-window reason (#12101).
             if self.persistent_memo_reads
                 && !type_id.is_intrinsic()
+                && !self.is_unresolved_def_seen()
                 && (self.limit_epoch == 0 || crate::limits::limit_result_cache_enabled())
                 && !self
                     .interner

--- a/crates/tsz-solver/src/evaluation/result.rs
+++ b/crates/tsz-solver/src/evaluation/result.rs
@@ -324,6 +324,32 @@ impl EvaluationMemoResult {
         self.cache_stability.is_stable_for_depth_agnostic_cache()
     }
 
+    /// Whether this result is safe to publish into a cross-file, run-wide
+    /// durable cache whose key does not capture per-run resolver-registration
+    /// state — the checker pool's shared `eval_cache`
+    /// (`crate::caches::query_cache::QueryCache::evaluate_type_with_options`).
+    ///
+    /// Stricter than [`Self::is_stable_for_depth_agnostic_cache`]: that check
+    /// goes through [`EvaluationMemoStability`], which deliberately tolerates
+    /// `UnresolvedDef` (see
+    /// [`EvaluationRequestStability::allows_complete_memo_result`]) to
+    /// preserve legacy behavior for "ordinary eval memo consumers" — readers
+    /// scoped to one run or one query window, where a registration-window
+    /// artifact is safe to reuse because the window ends before the next
+    /// registration can occur. A run-wide cache has no such window: a result
+    /// observed while a cross-file `Lazy`/`Ref` definition had not yet
+    /// registered would otherwise be published under a `(TypeId, options)`
+    /// key with no resolver-identity component and silently shadow the real
+    /// answer for every later file that hits the same key after the
+    /// definition registers — the same registration-window hazard
+    /// `closed_eval`'s `run_state_cache_stability` gate already guards
+    /// against for its own run-wide cache, checking the raw
+    /// [`EvaluationRequestStability`] directly rather than going through
+    /// [`EvaluationMemoStability`].
+    pub(crate) const fn is_stable_for_run_wide_cache(self) -> bool {
+        self.result.is_complete() && self.request_stability.is_stable_for_depth_agnostic_cache()
+    }
+
     /// Whether this result can be stored in the thread-local per-query memo.
     ///
     /// The per-query memo is window-scoped (cleared when a fresh top-level query
@@ -459,6 +485,12 @@ mod tests {
         );
         assert!(unresolved_def_named.is_stable_for_depth_agnostic_cache());
         assert!(unresolved_def_named.is_stable_for_per_query_memo());
+        // `is_stable_for_run_wide_cache` is intentionally stricter than the
+        // loose `is_stable_for_depth_agnostic_cache` gate above: a run/query-
+        // scoped memo may reuse an `UnresolvedDef` result within its own
+        // window, but a cross-file durable cache (#16553) must refuse it —
+        // see `is_stable_for_run_wide_cache`'s doc comment.
+        assert!(!unresolved_def_named.is_stable_for_run_wide_cache());
 
         let incomplete =
             EvaluationResult::incomplete(TypeId::NUMBER, TerminationKind::DepthExceeded);
@@ -472,6 +504,45 @@ mod tests {
             EvaluationMemoStability::Unstable
         );
         assert!(!typed_tainted.is_stable_for_depth_agnostic_cache());
+    }
+
+    #[test]
+    fn run_wide_cache_stability_refuses_every_non_stable_request_verdict() {
+        // #16553 adjacent matrix: `is_stable_for_run_wide_cache` must accept
+        // only a complete result with a `Stable` request verdict — every
+        // other request-state taint, plus any incomplete termination, must be
+        // refused even though some of them are tolerated by the looser
+        // `is_stable_for_depth_agnostic_cache` gate above.
+        let complete = EvaluationResult::complete(TypeId::STRING);
+
+        let stable = EvaluationMemoResult::for_depth_agnostic_memo(
+            complete,
+            EvaluationRequestStability::Stable,
+        );
+        assert!(stable.is_stable_for_run_wide_cache());
+
+        for tainted_state in [
+            EvaluationRequestStability::UnresolvedDef,
+            EvaluationRequestStability::RecursionLimit,
+            EvaluationRequestStability::IncompleteVerdict,
+        ] {
+            let memo = EvaluationMemoResult::for_depth_agnostic_memo(complete, tainted_state);
+            assert!(
+                !memo.is_stable_for_run_wide_cache(),
+                "{tainted_state:?} must be refused by the run-wide cache gate"
+            );
+        }
+
+        // A `Stable` request verdict paired with a guard-truncated (incomplete)
+        // termination must also be refused: the collapsed `type_id` is only a
+        // partial approximation, not a converged answer.
+        let incomplete =
+            EvaluationResult::incomplete(TypeId::NUMBER, TerminationKind::DepthExceeded);
+        let incomplete_memo = EvaluationMemoResult::for_depth_agnostic_memo(
+            incomplete,
+            EvaluationRequestStability::Stable,
+        );
+        assert!(!incomplete_memo.is_stable_for_run_wide_cache());
     }
 
     #[test]

--- a/crates/tsz-solver/tests/architecture_guards.rs
+++ b/crates/tsz-solver/tests/architecture_guards.rs
@@ -297,7 +297,13 @@ fn evaluation_engine_keeps_request_stage_boundary() {
             .contains("use crate::evaluation::request::{EvaluationCacheKey, EvaluationRequest};")
             && query_cache_rs.contains("request.cache_key()")
             && query_cache_rs.contains("evaluate_request_memo_result(request)")
-            && query_cache_rs.contains("is_stable_for_depth_agnostic_cache()")
+            // #16553: the durable, cross-file `eval_cache` write needs the
+            // stricter `EvaluationMemoResult::is_stable_for_run_wide_cache`
+            // gate (refuses `UnresolvedDef`), not the looser
+            // `is_stable_for_depth_agnostic_cache` that run/query-scoped
+            // memo consumers use — but both are still typed
+            // `EvaluationMemoResult` methods, not a rebuilt ad-hoc predicate.
+            && query_cache_rs.contains("is_stable_for_run_wide_cache()")
             && !query_cache_rs
                 .contains("evaluation_result.is_complete() && !evaluator.recursion_limit_hit()"),
         "query cache evaluation entries must derive option-sensitive keys from EvaluationRequest and consume EvaluationMemoResult stability instead of rebuilding termination predicates"

--- a/crates/tsz-solver/tests/db_tests.rs
+++ b/crates/tsz-solver/tests/db_tests.rs
@@ -164,6 +164,53 @@ fn property_cache_keeps_resolved_object_property_result() {
     );
 }
 
+/// #16553: a top-level `evaluate_type` result observed while an `IndexAccess`
+/// object operand's `Lazy` definition had not yet registered (the checker
+/// pool's cross-file registration-window artifact) must not publish into the
+/// cross-file `eval_cache` — that cache's `(TypeId, options)` key has no
+/// resolver-identity component, so a later file in the same pool partition
+/// would read the under-resolved answer back after the real definition
+/// registers instead of recomputing it.
+#[test]
+fn eval_cache_skips_unresolved_lazy_index_access_result() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let key = interner.literal_string("kind");
+    let unresolved = interner.lazy(crate::def::DefId(9003));
+    let index_access = interner.index_access(unresolved, key);
+
+    db.evaluate_type(index_access);
+
+    assert_eq!(
+        db.eval_cache_len(),
+        0,
+        "an index access into an unresolved Lazy def must not publish into the \
+         cross-file eval_cache"
+    );
+}
+
+/// Adjacent positive control for the test above: an `IndexAccess` whose
+/// object is already a concrete, resolved `Object` type is a stable function
+/// of its `TypeId` and should still publish into the cross-file `eval_cache`
+/// as before.
+#[test]
+fn eval_cache_keeps_resolved_object_index_access_result() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let key_atom = interner.intern_string("kind");
+    let key_type = interner.literal_string("kind");
+    let obj = interner.object(vec![PropertyInfo::new(key_atom, TypeId::NUMBER)]);
+    let index_access = interner.index_access(obj, key_type);
+
+    let result = db.evaluate_type(index_access);
+
+    assert_eq!(result, TypeId::NUMBER);
+    assert!(
+        db.eval_cache_len() > 0,
+        "a resolved object index access should still publish into the eval_cache"
+    );
+}
+
 /// Test cache poisoning prevention.
 ///
 /// CRITICAL: This test ensures that separate caches don't interfere.


### PR DESCRIPTION
When a top-level type evaluation observes an unresolved cross-file `Lazy`/
`Ref` definition (`unresolved_def_seen`, the checker-pool's registration-
window case), the result is a function of the registration window it ran
in, not of the input `TypeId` alone. tsz's persistent, cross-file
`QueryCache.eval_cache` published such results anyway through two
independent gaps, so a later file in the same pool partition read the
under-resolved answer back after the real definition registered instead
of recomputing it — matching #16553's mobx-project witness exactly
(`DecoratorContext["kind"]` collapsing to `undefined` and leaking across
`computedannotation.ts`/`observableannotation.ts`/etc).

## Structural rule

When a persisted evaluation result observed an unresolved cross-file definition mid-evaluation, tsc's equivalent (a single-pass, fully-resolved checker) never has this state to begin with; tsz's checker-pool amortizes evaluation across files through a durable `eval_cache` owned by the solver (`crates/tsz-solver/src/caches/query_cache.rs`), and that cache must refuse to publish a result whose stability depended on the registration window it ran in.

**Gap 1** (`query_cache.rs::evaluate_type_with_options`): the top-level `key -> result` write used `EvaluationMemoResult::is_stable_for_depth_agnostic_cache`, which deliberately tolerates `UnresolvedDef` to preserve legacy behavior for run/query-scoped memo consumers. That tolerance is unsound for a cross-file durable cache. Added `EvaluationMemoResult::is_stable_for_run_wide_cache`, which checks the raw `EvaluationRequestStability` directly (mirroring `closed_eval::commit_closed_eval_writes`'s own run-wide gate), and use it for this write.

**Gap 2** (`evaluate.rs::memo_insert`, issue #13097's persistent write-through): a node is only tainted when `self.limit_epoch` moves *during its own evaluation window*. A node evaluated after an unrelated sibling already bumped the epoch looks locally clean and fell through to `insert_eval_memo` — the same cross-file `eval_cache` — unconditionally, since `limit_result_cache_enabled()` defaults true and makes the existing `self.limit_epoch == 0` guard a no-op. Added an explicit `!self.is_unresolved_def_seen()` check, mirroring the identical guard the silent-depth-bail arm already applies to its own `memo_insert` call (#12101).

`is_structurally_eval_inert`'s own write path was checked and is already correct — it descends the full structural surface and excludes any type containing an unresolved `Lazy`, confirmed by its own existing test.

## Goal
Goal: hold

## Verification
- New unit tests pin the exact repro: `eval_cache_skips_unresolved_lazy_index_access_result` (an IndexAccess into an unresolved Lazy must not publish) and its adjacent positive control `eval_cache_keeps_resolved_object_index_access_result` (a resolved object index access still publishes).
- `run_wide_cache_stability_refuses_every_non_stable_request_verdict` pins the adjacent matrix on `EvaluationMemoResult` directly: `Stable` accepted, `UnresolvedDef`/`RecursionLimit`/`IncompleteVerdict` and any incomplete termination refused.
- `cargo test -p tsz-solver --lib`: **7646/7646 passed** — re-verified fresh on this PR's exact head (`c362e10`, cherry-picked cleanly onto current `main`).
- `cargo clippy -p tsz-solver --lib --tests -- -D warnings`: clean (re-verified on this head).
- `cargo fmt --all -- --check`: clean (re-verified on this head).
- `scripts/arch/arch_guard.py`: clean (re-verified on this head).
- Updated the `evaluation_engine_keeps_request_stage_boundary` architecture guard's expected method name (it textually pins `is_stable_for_depth_agnostic_cache()` appearing in query_cache.rs; now pins the new, stricter `is_stable_for_run_wide_cache()` instead — same typed-`EvaluationMemoResult`-method spirit the guard enforces).
- **Owed**: conformance snapshot / emit floor check and an end-to-end mobx-project re-run of #16553's own single-threaded pool-vs-fresh-checker repro. This cold seat's build budget went to re-verifying the crate-local suite rather than a `dist-fast` binary build (compare-to-parent.sh measured 55-90 min on this class of seat per the board's standing note). This is purely a caching-**eligibility restriction** — it can only make a previously poisoned/flaky checker-pool cross-file result correct or force a recompute, never introduce a new wrong answer on a path that was already publishing — but the measured before/after is still owed per repo convention, and a future session (or the nightly conformance/unit lane) should confirm it and close #16553.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_019beR2x3pB1NFsLQgA4kfHP)_