### PR TITLE
fix(checker): a `yield*` delegate contributes its `TNext` to the inferred generator signature (#15632)

### DIFF
--- a/crates/tsz-checker/src/context/generator_yield_contribution.rs
+++ b/crates/tsz-checker/src/context/generator_yield_contribution.rs
@@ -1,0 +1,66 @@
+//! One `yield` operand's contribution to the enclosing unannotated generator's
+//! inferred signature, and the collection API the yield dispatcher pushes
+//! through.
+
+use super::CheckerContext;
+use tsz_solver::TypeId;
+
+/// One `yield` operand's contribution to an unannotated generator's inferred
+/// yield type.
+///
+/// `tsc` widens the aggregated yield type only when it is a single literal that
+/// is *fresh* (`getWidenedLiteralType` inside
+/// `getWidenedLiteralLikeTypeForContextualIterationTypeIfNeeded`). tsz does not
+/// carry freshness on types, so each collection site records whether its
+/// operand expression was a widenable (fresh) literal contribution; the
+/// aggregation site widens the collapsed literal union only when every
+/// contribution agreed.
+#[derive(Clone, Copy, Debug)]
+pub struct GeneratorYieldContribution {
+    /// The yielded value type (element type for `yield*`).
+    pub type_id: TypeId,
+    /// Whether the operand was a fresh literal expression (or fresh enum-member
+    /// access) with no `const`-assertion pinning — i.e. `tsc` would widen it.
+    pub widenable: bool,
+    /// For a `yield*` operand, the delegate's own declared `TNext` — the type
+    /// its `next()` accepts. `tsc` aggregates these across every delegation in
+    /// the body (`checkAndAggregateYieldOperandTypes` collects
+    /// `getIterationTypeOfIterable(IterationTypeKind.Next, ...)`, then
+    /// `getIntersectionType`) and uses the result as the enclosing unannotated
+    /// generator's `TNext`. `None` for a plain `yield`, and for a delegate that
+    /// declares no `TNext` of its own — those contribute nothing, leaving the
+    /// slot at its `unknown` default.
+    pub delegated_next_type: Option<TypeId>,
+}
+
+impl CheckerContext<'_> {
+    /// Record one `yield` operand's contribution to the enclosing unannotated
+    /// generator's inferred yield type. Pass `widenable: false` for delegated
+    /// (`yield*`) element types — they come from another iterator's declared
+    /// type, never a fresh literal.
+    pub fn push_generator_yield_contribution(&mut self, type_id: TypeId, widenable: bool) {
+        self.generator_yield_operand_types
+            .push(GeneratorYieldContribution {
+                type_id,
+                widenable,
+                delegated_next_type: None,
+            });
+    }
+
+    /// Record one `yield*` operand's contribution: the delegated element type
+    /// plus the delegate's own `TNext`, which feeds the enclosing unannotated
+    /// generator's `TNext` slot. Delegated element types are never fresh
+    /// literals, so `widenable` is always `false` here.
+    pub fn push_generator_yield_star_contribution(
+        &mut self,
+        type_id: TypeId,
+        delegated_next_type: Option<TypeId>,
+    ) {
+        self.generator_yield_operand_types
+            .push(GeneratorYieldContribution {
+                type_id,
+                widenable: false,
+                delegated_next_type,
+            });
+    }
+}

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -40,6 +40,8 @@ pub(crate) mod env_eval_cache;
 #[cfg(debug_assertions)]
 pub(crate) mod eval_memo_purity;
 mod file_session_reset;
+mod generator_yield_contribution;
+pub use generator_yield_contribution::GeneratorYieldContribution;
 pub mod lifetime_shells;
 pub use lifetime_shells::{FileSession, LspPersistentCache, SpeculationScope, WorkerContext};
 mod def_declaration;
@@ -249,36 +251,6 @@ pub enum PendingImplicitAnyKind {
     /// Evolving `any[]` variables become errors at unsafe reads before their
     /// element type is fixed.
     EvolvingArray,
-}
-
-/// One `yield` operand's contribution to an unannotated generator's inferred
-/// yield type.
-///
-/// `tsc` widens the aggregated yield type only when it is a single literal that
-/// is *fresh* (`getWidenedLiteralType` inside
-/// `getWidenedLiteralLikeTypeForContextualIterationTypeIfNeeded`). tsz does not
-/// carry freshness on types, so each collection site records whether its
-/// operand expression was a widenable (fresh) literal contribution; the
-/// aggregation site widens the collapsed literal union only when every
-/// contribution agreed.
-#[derive(Clone, Copy, Debug)]
-pub struct GeneratorYieldContribution {
-    /// The yielded value type (element type for `yield*`).
-    pub type_id: TypeId,
-    /// Whether the operand was a fresh literal expression (or fresh enum-member
-    /// access) with no `const`-assertion pinning — i.e. `tsc` would widen it.
-    pub widenable: bool,
-}
-
-impl CheckerContext<'_> {
-    /// Record one `yield` operand's contribution to the enclosing unannotated
-    /// generator's inferred yield type. Pass `widenable: false` for delegated
-    /// (`yield*`) element types — they come from another iterator's declared
-    /// type, never a fresh literal.
-    pub fn push_generator_yield_contribution(&mut self, type_id: TypeId, widenable: bool) {
-        self.generator_yield_operand_types
-            .push(GeneratorYieldContribution { type_id, widenable });
-    }
 }
 
 /// Persistent cache for type checking results across LSP queries.

--- a/crates/tsz-checker/src/dispatch/yield_.rs
+++ b/crates/tsz-checker/src/dispatch/yield_.rs
@@ -411,6 +411,27 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                     );
                 }
 
+                // The delegate's own `TNext`, contributed to an *unannotated*
+                // enclosing generator's `TNext` slot (`tsc`:
+                // `checkAndAggregateYieldOperandTypes` collects
+                // `getIterationTypeOfIterable(IterationTypeKind.Next, ...)` for
+                // every `yield*` and intersects them).
+                //
+                // Deliberately the declared-type-argument query rather than
+                // `get_iterator_info(...).next_type`: that structural query
+                // reports `undefined` for the `Array`/`Tuple` fast paths, but
+                // the lib's real `ArrayIterator<T>` declares `TNext = unknown`,
+                // so routing arrays through it would replace today's correct
+                // `unknown` with a wrong `undefined`. The declared-argument
+                // query answers `None` for a delegate that has no `TNext` of
+                // its own (arrays, tuples, `string`, `Set<T>`), which leaves
+                // the slot at the same `unknown` default `tsc` lands on for
+                // those shapes — so this only ever speaks where the delegate
+                // actually declares a `TNext`.
+                let yield_star_next_type = self
+                    .checker
+                    .get_generator_next_type_argument(expression_type);
+
                 if is_async_generator {
                     if self
                         .checker
@@ -511,9 +532,10 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                     // generator yield type must come from actual body yields, not context
                     // (see function_type.rs comment on final_generator_yield_type).
                     if let Some(ref i) = async_info {
-                        self.checker
-                            .ctx
-                            .push_generator_yield_contribution(i.yield_type, false);
+                        self.checker.ctx.push_generator_yield_star_contribution(
+                            i.yield_type,
+                            yield_star_next_type,
+                        );
                         // When yield* delegates to an async iterable with `any` element
                         // type, suppress TS7055 at the function level (see sync path).
                         if i.yield_type == TypeId::ANY {
@@ -541,9 +563,10 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                         // has never spoken for.
                         let resolved = self.checker.for_of_element_type(expression_type, true);
                         if resolved != TypeId::ANY {
-                            self.checker
-                                .ctx
-                                .push_generator_yield_contribution(resolved, false);
+                            self.checker.ctx.push_generator_yield_star_contribution(
+                                resolved,
+                                yield_star_next_type,
+                            );
                         }
                     }
                     element
@@ -607,7 +630,7 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                     };
                     self.checker
                         .ctx
-                        .push_generator_yield_contribution(yield_type, false);
+                        .push_generator_yield_star_contribution(yield_type, yield_star_next_type);
                     // When yield* delegates to an iterable with `any` element type
                     // (e.g. `any[]`), suppress TS7055 at the function level.
                     // tsc considers the `any` yield type to be "explained" by

--- a/crates/tsz-checker/src/query_boundaries/function_returns.rs
+++ b/crates/tsz-checker/src/query_boundaries/function_returns.rs
@@ -17,6 +17,14 @@ pub(crate) fn function_return_union(db: &dyn TypeDatabase, members: Vec<TypeId>)
     db.union(members)
 }
 
+/// Combine the `TNext`s an unannotated generator's `yield*` delegations
+/// declared. `tsc` uses `getIntersectionType` here, not a union: a value sent
+/// into the outer generator can be forwarded to any of its delegates, so it
+/// must satisfy all of them.
+pub(crate) fn function_return_intersection(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {
+    common::intersection_or_single(db, members)
+}
+
 pub(crate) fn function_return_lazy_type(db: &dyn TypeDatabase, def_id: DefId) -> TypeId {
     db.lazy(def_id)
 }

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -345,6 +345,8 @@ mod generator_yield_invalid_thenable_tests;
 mod generator_yield_literal_widening_tests;
 #[path = "tests/generator_yield_self_similar_nesting_tests.rs"]
 mod generator_yield_self_similar_nesting_tests;
+#[path = "tests/generator_yield_star_next_type_tests.rs"]
+mod generator_yield_star_next_type_tests;
 #[path = "tests/generator_yieldstar_symbol_iterator_contribution_tests.rs"]
 mod generator_yieldstar_symbol_iterator_contribution_tests;
 #[path = "tests/generic_alias_application_display_tests.rs"]

--- a/crates/tsz-checker/src/tests/generator_yield_star_next_type_tests.rs
+++ b/crates/tsz-checker/src/tests/generator_yield_star_next_type_tests.rs
@@ -1,0 +1,378 @@
+//! Regression tests for the `TNext` slot of an unannotated generator whose
+//! body delegates with `yield*` (#15632, `TNext` half).
+//!
+//! Structural rule: when an unannotated generator's body contains `yield* e`,
+//! `tsc` contributes `e`'s own `TNext` — the type its `next()` accepts — to the
+//! enclosing generator's `TNext`, intersecting one contribution per delegation
+//! (`checkAndAggregateYieldOperandTypes` collects
+//! `getIterationTypeOfIterable(IterationTypeKind.Next, ...)`, then
+//! `getIntersectionType`). tsz never collected it: the slot was hardcoded to
+//! `unknown` unless a *contextual* `Generator<Y, R, N>` supplied one, so every
+//! delegating generator's `.next()` accepted any argument at all.
+//!
+//! `unknown` is the correct answer only when nothing contributes, which is why
+//! the delegate-has-no-`TNext` rows below (array, tuple, `string`) are load-
+//! bearing negative controls rather than filler: the fix must stay silent on
+//! them. That is also why the contribution reads the delegate's *declared*
+//! `TNext` type argument instead of `get_iterator_info(...).next_type` — the
+//! latter reports `undefined` for the `Array`/`Tuple` fast paths, which would
+//! replace a correct `unknown` with a wrong `undefined`.
+//!
+//! The oracle is `.next(arg)` argument checking, not rendered type text: with
+//! `TNext = unknown` every argument is accepted, so a missing contribution is
+//! observable as a *missing* TS2345. Every expectation below was pinned against
+//! `tsc` 6.0.2 (`--strict --target es2022 --lib es2022`); the `[] | [string]`
+//! parameter shape in those diagnostics is `Generator.next`'s own overload
+//! tuple, which is what makes the slot observable at a call site.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_source_with_libs, load_default_lib_files};
+
+fn strict_codes(source: &str) -> Vec<u32> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|diagnostic| diagnostic.code)
+    .collect()
+}
+
+/// Delegate sources. Binder names are varied per test (see
+/// `renamed_binders_*`) so no identifier here is load-bearing.
+const PREAMBLE: &str = r#"
+export {};
+declare function srcStr(): Generator<number, void, string>;
+declare function srcNum(): Generator<number, void, number>;
+declare function srcStrOrUndef(): Generator<number, void, string | undefined>;
+declare function asrcStr(): AsyncGenerator<number, void, string>;
+"#;
+
+const TS2345: u32 = 2345;
+
+fn check(body: &str) -> Vec<u32> {
+    strict_codes(&format!("{PREAMBLE}{body}"))
+}
+
+// ── Core witness: a plain declaration delegating to a generator ──
+
+#[test]
+fn delegated_next_type_rejects_incompatible_next_argument() {
+    let codes = check(
+        r#"
+function* relay() { yield* srcStr(); }
+relay().next(42);
+"#,
+    );
+    assert_eq!(
+        codes,
+        vec![TS2345],
+        "`yield* srcStr()` must give `relay` the delegate's `TNext` (`string`), \
+         so `.next(42)` is TS2345. Before the fix `TNext` stayed `unknown` and \
+         this call was silently accepted."
+    );
+}
+
+#[test]
+fn delegated_next_type_accepts_compatible_next_argument() {
+    let codes = check(
+        r#"
+function* relay() { yield* srcStr(); }
+relay().next("ok");
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "a `string` argument satisfies the delegated `TNext`; got {codes:?}"
+    );
+}
+
+// ── Negative controls: shapes that must keep the `unknown` default ──
+
+#[test]
+fn plain_yield_only_generator_keeps_unknown_next_type() {
+    let codes = check(
+        r#"
+function* plain() { yield 1; }
+plain().next(42);
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "no delegation contributes nothing, so `TNext` stays `unknown` and \
+         every argument is accepted; got {codes:?}"
+    );
+}
+
+#[test]
+fn array_delegate_keeps_unknown_next_type() {
+    let codes = check(
+        r#"
+function* fromArray() { yield* [1, 2]; }
+fromArray().next(42);
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "an array delegate declares no `TNext` of its own, so the slot stays \
+         `unknown` — matching tsc. Reading the structural iterator info here \
+         would wrongly pin it to `undefined`; got {codes:?}"
+    );
+}
+
+#[test]
+fn tuple_delegate_keeps_unknown_next_type() {
+    let codes = check(
+        r#"
+function* fromTuple() { yield* [1, "a"] as [number, string]; }
+fromTuple().next(42);
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "tuple delegate: same negative control as the array row; got {codes:?}"
+    );
+}
+
+#[test]
+fn string_delegate_keeps_unknown_next_type() {
+    let codes = check(
+        r#"
+function* fromString() { yield* "ab"; }
+fromString().next(42);
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "`string`'s iterator declares no `TNext`; got {codes:?}"
+    );
+}
+
+// ── Aggregation across several delegations: intersection, not union ──
+
+#[test]
+fn two_delegates_intersect_their_next_types() {
+    let codes = check(
+        r#"
+function* two() { yield* srcStr(); yield* srcStrOrUndef(); }
+two().next("ok");
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "`string & (string | undefined)` still admits a string; got {codes:?}"
+    );
+}
+
+#[test]
+fn two_delegates_reject_argument_only_one_admits() {
+    let codes = check(
+        r#"
+function* two() { yield* srcStr(); yield* srcStrOrUndef(); }
+two().next(undefined);
+"#,
+    );
+    assert_eq!(
+        codes,
+        vec![TS2345],
+        "intersection, not union: a value sent into `two` can reach either \
+         delegate, so it must satisfy both. `undefined` satisfies only the \
+         second."
+    );
+}
+
+#[test]
+fn disjoint_delegate_next_types_intersect_to_never() {
+    let codes = check(
+        r#"
+function* conflict() { yield* srcStr(); yield* srcNum(); }
+conflict().next("ok");
+"#,
+    );
+    assert_eq!(
+        codes,
+        vec![TS2345],
+        "`string & number` is `never`: no argument can be forwarded to both \
+         delegates, which is exactly what tsc reports here."
+    );
+}
+
+// ── Mixed plain + delegated bodies ──
+
+#[test]
+fn plain_yield_does_not_erase_the_delegated_next_type() {
+    let codes = check(
+        r#"
+function* mixed() { yield 1; yield* srcStr(); }
+mixed().next(42);
+"#,
+    );
+    assert_eq!(
+        codes,
+        vec![TS2345],
+        "a plain `yield` alongside the delegation contributes nothing to \
+         `TNext` and must not wash the delegated contribution out"
+    );
+}
+
+#[test]
+fn delegation_after_plain_yield_order_independent() {
+    let codes = check(
+        r#"
+function* mixed() { yield* srcStr(); yield 1; }
+mixed().next(42);
+"#,
+    );
+    assert_eq!(
+        codes,
+        vec![TS2345],
+        "source order of the plain and delegated yields must not matter"
+    );
+}
+
+// ── Adjacent forms: expression, async, method, custom iterable ──
+
+#[test]
+fn generator_function_expression_gets_the_delegated_next_type() {
+    let codes = check(
+        r#"
+const relayExpr = function* () { yield* srcStr(); };
+relayExpr().next(42);
+"#,
+    );
+    assert_eq!(
+        codes,
+        vec![TS2345],
+        "the expression path builds its signature through the same body-check \
+         aggregation as a declaration"
+    );
+}
+
+#[test]
+fn async_generator_gets_the_delegated_next_type() {
+    let codes = check(
+        r#"
+async function* arelay() { yield* asrcStr(); }
+arelay().next(42);
+"#,
+    );
+    assert_eq!(
+        codes,
+        vec![TS2345],
+        "the async arm collects the delegated `TNext` too, into `AsyncGenerator`"
+    );
+}
+
+#[test]
+fn generator_method_gets_the_delegated_next_type() {
+    let codes = check(
+        r#"
+const host = { *relay() { yield* srcStr(); } };
+host.relay().next(42);
+"#,
+    );
+    assert_eq!(
+        codes,
+        vec![TS2345],
+        "a generator *method* shares the same aggregation path"
+    );
+}
+
+#[test]
+fn custom_iterable_delegate_contributes_its_declared_next_type() {
+    let codes = check(
+        r#"
+interface Custom { [Symbol.iterator](): Iterator<number, void, string>; }
+declare const custom: Custom;
+function* fromCustom() { yield* custom; }
+fromCustom().next(42);
+"#,
+    );
+    assert_eq!(
+        codes,
+        vec![TS2345],
+        "not just lib `Generator`: a user iterable whose iterator declares \
+         `TNext` contributes it as well"
+    );
+}
+
+#[test]
+fn nested_delegation_through_a_sibling_generator_propagates_next_type() {
+    let codes = check(
+        r#"
+function* inner() { yield* srcStr(); }
+function* outer() { yield* inner(); }
+outer().next(42);
+"#,
+    );
+    assert_eq!(
+        codes,
+        vec![TS2345],
+        "`inner`'s own inferred `TNext` must be visible to `outer`'s \
+         delegation — the fix has to compose with itself"
+    );
+}
+
+// ── Binder-name independence ──
+
+#[test]
+fn renamed_binders_behave_identically() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare function zzz(): Generator<number, void, string>;
+function* qqq() { yield* zzz(); }
+qqq().next(42);
+"#,
+    );
+    assert_eq!(codes, vec![TS2345], "no identifier drives this decision");
+}
+
+#[test]
+fn renamed_binders_negative_case_behaves_identically() {
+    let codes = strict_codes(
+        r#"
+export {};
+function* qqq() { yield* [1, 2]; }
+qqq().next(42);
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "renamed negative control stays silent; got {codes:?}"
+    );
+}
+
+// ── An explicit annotation still wins ──
+
+#[test]
+fn explicit_return_annotation_overrides_the_delegated_next_type() {
+    let codes = check(
+        r#"
+function* annotated(): Generator<number, void, unknown> { yield* srcStr(); }
+annotated().next(42);
+"#,
+    );
+    // What this fix owns: an *annotated* generator's `TNext` comes from its
+    // annotation, never from the delegation, so the delegated `string` must not
+    // leak into the signature and make `.next(42)` an error.
+    assert!(
+        !codes.contains(&TS2345),
+        "the declared `TNext` is `unknown`, so `.next(42)` is accepted; the \
+         delegated contribution is only ever consulted for an *unannotated* \
+         generator's inferred signature. Got {codes:?}"
+    );
+    // Deliberately NOT pinned either way: tsc additionally reports TS2766 at
+    // the delegation itself here (the container will always send `unknown`,
+    // which the delegate's `next(value: string)` does not accept). tsz misses
+    // it — a pre-existing false negative on the *annotated*-container arm of
+    // `check_iterator_next_type_assignability`, unrelated to and unchanged by
+    // this fix, which never runs for an annotated generator. Tracked separately
+    // so this suite does not bake the gap in as expected behaviour.
+}

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -9,7 +9,7 @@ mod literal_context;
 use self::generator_declaration_yield::GeneratorDeclarationYieldCtx;
 use super::function_type_helpers::{
     ExpressionBodyReturnCheckCtx, FunctionBodyReturnTypeCtx, FunctionFinalReturnTypeCtx,
-    GeneratorBodyReturnCheckCtx,
+    GeneratorBodyReturnCheckCtx, InferredGeneratorYield,
 };
 use crate::context::TypingRequest;
 use crate::context::speculation::DiagnosticSpeculationSnapshot;
@@ -1329,7 +1329,7 @@ impl<'a> CheckerState<'a> {
         let mut has_contextual_return = false;
         let mut return_context_for_circularity = None;
         let mut early_yield_type: Option<TypeId> = None;
-        let mut final_generator_yield_type: Option<TypeId> = None;
+        let mut inferred_gen_yield = InferredGeneratorYield::NONE;
         let mut early_gen_return_type: Option<TypeId> = None;
         let mut early_gen_next_type: Option<TypeId> = None;
 
@@ -1883,7 +1883,7 @@ impl<'a> CheckerState<'a> {
                     snap.rollback(&mut self.ctx.diagnostic_state());
                 }
 
-                final_generator_yield_type =
+                inferred_gen_yield =
                     self.check_generator_body_return(GeneratorBodyReturnCheckCtx {
                         is_generator,
                         has_type_annotation,
@@ -1906,9 +1906,9 @@ impl<'a> CheckerState<'a> {
             if is_function_declaration
                 && is_generator
                 && !has_type_annotation
-                && final_generator_yield_type.is_none()
+                && inferred_gen_yield.yield_type.is_none()
             {
-                final_generator_yield_type =
+                inferred_gen_yield =
                     self.infer_generator_declaration_yield_type(GeneratorDeclarationYieldCtx {
                         body,
                         contextual_type,
@@ -1946,9 +1946,10 @@ impl<'a> CheckerState<'a> {
             function_is_generator,
             annotated_return_type,
             return_type,
-            final_generator_yield_type,
+            final_generator_yield_type: inferred_gen_yield.yield_type,
             early_gen_return_type,
             early_gen_next_type,
+            delegated_gen_next_type: inferred_gen_yield.delegated_next_type,
         });
 
         let params = if inherited_contextual_generics {

--- a/crates/tsz-checker/src/types/function_type/generator_declaration_yield.rs
+++ b/crates/tsz-checker/src/types/function_type/generator_declaration_yield.rs
@@ -1,4 +1,4 @@
-use super::super::function_type_helpers::GeneratorBodyReturnCheckCtx;
+use super::super::function_type_helpers::{GeneratorBodyReturnCheckCtx, InferredGeneratorYield};
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
@@ -28,7 +28,7 @@ impl CheckerState<'_> {
     pub(super) fn infer_generator_declaration_yield_type(
         &mut self,
         ctx: GeneratorDeclarationYieldCtx,
-    ) -> Option<TypeId> {
+    ) -> InferredGeneratorYield {
         let GeneratorDeclarationYieldCtx {
             body,
             contextual_type,
@@ -55,7 +55,7 @@ impl CheckerState<'_> {
         // gate is that shape structurally — an ordinary delegate (array,
         // annotated generator, `const` binding, type parameter) infers through.
         if self.generator_body_delegates_to_evolving_binding(body, true) {
-            return None;
+            return InferredGeneratorYield::NONE;
         }
 
         let yield_snapshot = self.ctx.snapshot_return_type();
@@ -77,13 +77,21 @@ impl CheckerState<'_> {
             name_node: None,
             name_for_error: None,
         });
-        let final_yield = self.concrete_or_empty_generator_yield(body, inferred_yield);
+        let final_yield = self.concrete_or_empty_generator_yield(body, inferred_yield.yield_type);
+        // A dropped yield type (an empty/never aggregate) means this speculative
+        // pass had nothing to say about the signature at all, so its delegated
+        // `TNext` is dropped with it rather than being applied to a `Generator`
+        // whose `TYield` came from somewhere else.
+        let delegated_next_type = final_yield.and(inferred_yield.delegated_next_type);
 
         self.ctx.generator_yield_operand_types = saved_yield_collection;
         self.ctx.generator_had_ts7057 = saved_had_ts7057;
         self.ctx.exit_function_like_control_flow(saved_cf_context);
         yield_snapshot.rollback(&mut self.ctx.speculation_state());
-        final_yield
+        InferredGeneratorYield {
+            yield_type: final_yield,
+            delegated_next_type,
+        }
     }
 
     fn concrete_or_empty_generator_yield(

--- a/crates/tsz-checker/src/types/function_type_helpers.rs
+++ b/crates/tsz-checker/src/types/function_type_helpers.rs
@@ -51,6 +51,24 @@ pub(crate) struct FunctionFinalReturnTypeCtx {
     pub(crate) final_generator_yield_type: Option<TypeId>,
     pub(crate) early_gen_return_type: Option<TypeId>,
     pub(crate) early_gen_next_type: Option<TypeId>,
+    /// Intersection of the `TNext`s the body's `yield*` delegations declared.
+    pub(crate) delegated_gen_next_type: Option<TypeId>,
+}
+
+/// What checking an unannotated generator's body inferred for its signature:
+/// the aggregated yield type, and the `TNext` its `yield*` delegations imply.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct InferredGeneratorYield {
+    pub(crate) yield_type: Option<TypeId>,
+    pub(crate) delegated_next_type: Option<TypeId>,
+}
+
+impl InferredGeneratorYield {
+    /// Nothing inferred — the function is not an unannotated generator.
+    pub(crate) const NONE: Self = Self {
+        yield_type: None,
+        delegated_next_type: None,
+    };
 }
 
 pub(crate) struct GeneratorBodyReturnCheckCtx<'b> {
@@ -295,12 +313,38 @@ impl<'a> CheckerState<'a> {
         (contributions, inferred)
     }
 
+    /// Intersect the `TNext` every `yield*` in the just-checked body
+    /// contributed. `tsc`'s `checkAndAggregateYieldOperandTypes` pushes one
+    /// `getIterationTypeOfIterable(IterationTypeKind.Next, ...)` per delegation
+    /// and combines them with `getIntersectionType`, which is what a caller
+    /// sending a value through the outer generator must satisfy: the value has
+    /// to be acceptable to *every* delegate it can reach. `None` when no
+    /// delegation declared a `TNext`, leaving the slot at its `unknown` default.
+    fn delegated_generator_next_type(
+        &self,
+        contributions: &[crate::context::GeneratorYieldContribution],
+    ) -> Option<TypeId> {
+        let next_types: Vec<TypeId> = contributions
+            .iter()
+            .filter_map(|c| c.delegated_next_type)
+            .collect();
+        if next_types.is_empty() {
+            return None;
+        }
+        Some(
+            crate::query_boundaries::function_returns::function_return_intersection(
+                self.ctx.types,
+                next_types,
+            ),
+        )
+    }
+
     pub(crate) fn check_generator_body_return(
         &mut self,
         ctx: GeneratorBodyReturnCheckCtx<'_>,
-    ) -> Option<TypeId> {
+    ) -> InferredGeneratorYield {
         if !ctx.is_generator {
-            return None;
+            return InferredGeneratorYield::NONE;
         }
 
         if ctx.has_type_annotation {
@@ -317,10 +361,11 @@ impl<'a> CheckerState<'a> {
                 declared_type,
                 error_node,
             );
-            return None;
+            return InferredGeneratorYield::NONE;
         }
 
         let (yield_contributions, inferred_yield) = self.take_generator_yield_union();
+        let delegated_next_type = self.delegated_generator_next_type(&yield_contributions);
         // tsc's `getWidenedLiteralLikeTypeForContextualIterationTypeIfNeeded` +
         // `getWidenedType(getUnionType(...))`: widen only a union collapsed to a
         // single *fresh* literal (or enum member) that the contextual yield
@@ -382,7 +427,10 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        Some(final_yield)
+        InferredGeneratorYield {
+            yield_type: Some(final_yield),
+            delegated_next_type,
+        }
     }
 
     pub(crate) fn function_body_return_type(&mut self, ctx: FunctionBodyReturnTypeCtx) -> TypeId {
@@ -1024,7 +1072,16 @@ impl<'a> CheckerState<'a> {
         let return_t = body_return_t
             .or(ctx.early_gen_return_type)
             .unwrap_or(TypeId::VOID);
-        let next_t = ctx.early_gen_next_type.unwrap_or(TypeId::UNKNOWN);
+        // A contextual `Generator<Y, R, N>` still wins: it is the declared shape
+        // the generator is being checked against, and `tsc` reads plain yields'
+        // next contributions out of exactly that contextual type. The delegated
+        // aggregate speaks only where tsz previously had nothing to say and fell
+        // through to `unknown` — an unannotated, uncontextualized generator whose
+        // body delegates.
+        let next_t = ctx
+            .early_gen_next_type
+            .or(ctx.delegated_gen_next_type)
+            .unwrap_or(TypeId::UNKNOWN);
 
         let application = return_type_construction::function_return_application(
             self.ctx.types,


### PR DESCRIPTION
Closes the `TNext` half of #15632. The `TYield` halves of that issue landed earlier; re-measuring the issue's own repro on current `main` showed yield-type inference is now correct everywhere, and the one surviving delta across a 15-row matrix was the third `Generator` slot.

## Structural rule

When an unannotated generator's body contains `yield* e`, `tsc` contributes `e`'s own `TNext` — the type its `next()` accepts — to the enclosing generator's `TNext`, intersecting one contribution per delegation (`checkAndAggregateYieldOperandTypes` collects `getIterationTypeOfIterable(IterationTypeKind.Next, ...)`, then `getIntersectionType`). tsz does the same through the checker's yield dispatcher and the generator signature-construction path.

**Wrong semantic operation:** iteration-type evaluation for the `Next` kind was never queried on a `yield*` operand. `unannotated_generator_return_type` hardcoded the slot to `ctx.early_gen_next_type.unwrap_or(UNKNOWN)` — i.e. `unknown` unless a *contextual* `Generator<Y, R, N>` supplied one — so every delegating generator's `.next()` accepted any argument at all.

**Owner layer:** checker. `dispatch/yield_.rs` collects the contribution (alongside the delegated `TReturn` it already collects two lines away); `types/function_type_helpers.rs` aggregates and fills the slot; the intersection itself goes through the `query_boundaries::function_returns` gateway rather than touching the interner directly.

## Why the delegate's *declared* `TNext`, not `get_iterator_info(...).next_type`

`get_iterator_info`'s `Array`/`Tuple` fast paths report `next_type: undefined`, but the lib's real `ArrayIterator<T>` declares `TNext = unknown`. Routing arrays through the structural query would replace today's *correct* `unknown` with a wrong `undefined`. The declared-type-argument query (`get_generator_next_type_argument`, already used by the adjacent TS2766 check on the *containing* generator) answers `None` for a delegate with no `TNext` of its own — array, tuple, `string`, `Set<T>` — leaving the slot at the same `unknown` default `tsc` lands on for those shapes. It only ever speaks where the delegate actually declares a `TNext`.

An explicit return annotation still wins, and a contextual `Generator<Y, R, N>` still wins over the delegated aggregate: the new contribution speaks only where tsz previously had nothing to say.

## Reproduction and oracle

Rendered type text is a weak oracle here (`Generator`'s `TNext` default is `any`, which the DTS printer elides). The strong one is `.next(arg)` argument checking — with `TNext = unknown` every argument is accepted, so a missing contribution shows up as a **missing** TS2345:

```ts
declare function srcStr(): Generator<number, void, string>;
function* relay() { yield* srcStr(); }
relay().next(42);   // tsc: TS2345. tsz before this fix: accepted.
```

All 10 rows of a CLI matrix (`--strict --target es2022 --lib es2022`) now match `tsc` 6.0.2 **exactly**, diagnostic-for-diagnostic and line-for-line, including both intersection rows and the custom-iterable row. Before the fix, every TS2345 below was absent.

## Adjacent-case matrix

19 tests in `crates/tsz-checker/src/tests/generator_yield_star_next_type_tests.rs`, every expectation pinned against a real `tsc` run:

| Case | Expectation |
| --- | --- |
| declaration delegating to `Generator<_, _, string>` | TS2345 on `.next(42)` — core witness |
| same, `.next("ok")` | clean — positive control |
| plain `yield` only | clean — `unknown` default preserved |
| array / tuple / `string` delegate | clean — delegate declares no `TNext`; these are the rows that would break if the structural query were used |
| two delegates, `string` + `string \| undefined` | `.next("ok")` clean, `.next(undefined)` TS2345 — intersection, not union |
| two delegates, `string` + `number` | TS2345 — intersects to `never` |
| plain + delegated, both orders | TS2345 — a plain yield must not wash the contribution out |
| generator function *expression* | TS2345 — expression path |
| `async function*` delegating to `AsyncGenerator` | TS2345 — async arm |
| generator *method* | TS2345 |
| custom `interface { [Symbol.iterator](): Iterator<number, void, string> }` | TS2345 — not just lib `Generator` |
| nested delegation through a sibling inferred generator | TS2345 — the fix composes with itself |
| renamed binders, positive and negative | identical — no identifier drives the decision |
| explicit `Generator<number, void, unknown>` annotation | no TS2345 — annotation wins |

## Verification

- `cargo test -p tsz-checker --lib -- generator`: **188 passed, 0 failed** (8 pre-existing ignored). The 19 new tests are included; 18 of 19 passed on first run, and the one that did not exposed a *pre-existing, unrelated* gap rather than a fault in this change (below).
- `cargo test -p tsz-checker --lib -- generator_yield_star_next_type`: **19/19**.
- CLI matrix vs `tsc` 6.0.2: 10/10 rows identical; before the fix, 7 of those rows were missing their diagnostic entirely.
- `cargo fmt --all`, `cargo clippy -p tsz-checker` (warnings denied), `scripts/arch/arch_guard.py`: all clean (pre-commit hook ran all three).
- **Owed, not run in this session:** `scripts/emit/run.sh` and a conformance snapshot. See the risk note below — a follow-up comment will carry the emit numbers.

### DTS emit note (read before merging)

This changes the *printed* declaration text for an inferred delegating generator: `Generator<number, void, unknown>` → `Generator<number, void>`. Neither form is `tsc`'s (`Generator<number, void, any>`), so this is not a parity regression — but it is a text change. The cause is that `TNext` is now correctly `any`, and the DTS emitter deliberately elides a trailing type argument identical to its declared default (`test_type_application_elides_trailing_default_type_argument`); `unknown` was never elided because it differed from the default. The emitted DTS remains semantically identical to `tsc`'s, since the elided argument *is* the default. Whether that elision should apply to a synthesized generator return type is a separate printer question and is not touched here.

### Pre-existing gap found, deliberately not pinned

`function* g(): Generator<number, void, unknown> { yield* srcStr(); }` — `tsc` reports TS2766 at the delegation (the container will always send `unknown`, which the delegate's `next(value: string)` rejects); tsz reports nothing. This is on the *annotated*-container arm of `check_iterator_next_type_assignability`, which this change never runs through, and it reproduces identically on `main`. The test documents it in prose instead of asserting it either way, so the suite does not bake the gap in as expected behaviour.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Basalt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1f4pcfr8hvCJDaZHbRTt9)_