### PR TITLE
fix(checker): non-strict mode reduces null/undefined out of every union-construction seam (#16580)

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/type_predicates.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_predicates.rs
@@ -275,6 +275,22 @@ pub(crate) fn collapse_pure_nullish_union_nonstrict(
     tsz_solver::narrowing::collapse_pure_nullish_union_nonstrict(strict_null_checks, member_types)
 }
 
+/// Sibling of [`collapse_pure_nullish_union_nonstrict`] for a union that also
+/// has a non-nullish member: in non-strict mode, absorb any scalar
+/// `null`/`undefined` member out of a syntactic union type node's member list
+/// before ordinary construction (#16580). See
+/// `tsz_solver::narrowing::nonstrict_union_members_absorb_nullish_scalars` for
+/// the structural rule and the all-nullish exclusion.
+pub(crate) fn nonstrict_union_members_absorb_nullish_scalars(
+    strict_null_checks: bool,
+    member_types: &[TypeId],
+) -> Option<Vec<TypeId>> {
+    tsz_solver::narrowing::nonstrict_union_members_absorb_nullish_scalars(
+        strict_null_checks,
+        member_types,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -637,6 +637,8 @@ mod nonstrict_nullish_widening_generic_call_tests;
 mod nonstrict_nullish_widening_mutable_binding_tests;
 #[path = "tests/nonstrict_nullish_widening_nested_leaf_tests.rs"]
 mod nonstrict_nullish_widening_nested_leaf_tests;
+#[path = "tests/nonstrict_union_nullish_scalar_reduction_tests.rs"]
+mod nonstrict_union_nullish_scalar_reduction_tests;
 #[path = "tests/nonunique_symbol_property_access_tests.rs"]
 mod nonunique_symbol_property_access_tests;
 #[path = "tests/noUIA_any_index_emits_ts2322_tests.rs"]

--- a/crates/tsz-checker/src/tests/nonstrict_union_nullish_scalar_reduction_tests.rs
+++ b/crates/tsz-checker/src/tests/nonstrict_union_nullish_scalar_reduction_tests.rs
@@ -1,0 +1,158 @@
+//! Regression tests for #16580: with `strictNullChecks` off, tsc's
+//! `getUnionType(members, UnionReduction.Subtype)` absorbs a scalar
+//! `null`/`undefined` member out of *every* union it constructs whenever a
+//! non-nullish sibling is present, not just the array-literal element union
+//! #16578 already fixed. Fixed at the general syntactic-union-type-node
+//! resolvers (`types/type_node.rs`, `types/computation/type_operators.rs`,
+//! `types/type_literal_checker.rs`) via the shared solver primitive
+//! `nonstrict_union_members_absorb_nullish_scalars`.
+//!
+//! Every row is pinned against a real `typescript@7.0.2` oracle
+//! (`--strict false --strictNullChecks false`).
+
+use crate::test_utils::{
+    check_with_options_code_messages, non_strict_checker_options, strict_checker_options,
+};
+
+fn nonstrict_messages(source: &str) -> Vec<(u32, String)> {
+    check_with_options_code_messages(source, non_strict_checker_options())
+}
+
+fn strict_messages(source: &str) -> Vec<(u32, String)> {
+    check_with_options_code_messages(source, strict_checker_options())
+}
+
+/// Declared return type: `number | null` reduces to bare `number`.
+#[test]
+fn nonstrict_return_type_union_absorbs_null() {
+    let source = "\
+declare function f(): number | null;
+var probe: string = f();
+";
+    assert_eq!(
+        nonstrict_messages(source),
+        vec![(
+            2322,
+            "Type 'number' is not assignable to type 'string'.".to_string()
+        )]
+    );
+}
+
+/// Type alias whose body is exactly `number | undefined` fully reduces to
+/// `number`, and prints as the reduced primitive rather than the alias name
+/// (there is nothing left of the alias's union shape to point the origin at).
+#[test]
+fn nonstrict_type_alias_full_reduction_prints_reduced_type_not_alias_name() {
+    let source = "\
+type Widget = number | undefined;
+declare var w: Widget;
+var probe: string = w;
+";
+    assert_eq!(
+        nonstrict_messages(source),
+        vec![(
+            2322,
+            "Type 'number' is not assignable to type 'string'.".to_string()
+        )]
+    );
+}
+
+/// A 3-member alias (`string | null | undefined`) drops both nullish
+/// scalars, landing on the lone survivor `string` — renamed-binder control
+/// distinct from the previous test's names.
+#[test]
+fn nonstrict_type_alias_three_member_union_drops_both_nullish_scalars() {
+    let source = "\
+type Named = string | null | undefined;
+declare var value: Named;
+var probe: number = value;
+";
+    assert_eq!(
+        nonstrict_messages(source),
+        vec![(
+            2322,
+            "Type 'string' is not assignable to type 'number'.".to_string()
+        )]
+    );
+}
+
+/// Multiple non-nullish siblings survive the reduction as a (smaller) union,
+/// not a single type — the reduction only drops the nullish scalar members.
+#[test]
+fn nonstrict_union_keeps_remaining_non_nullish_members_as_a_union() {
+    let source = "\
+declare var q: string | number | null;
+var probe: boolean = q;
+";
+    assert_eq!(
+        nonstrict_messages(source),
+        vec![(
+            2322,
+            "Type 'string | number' is not assignable to type 'boolean'.".to_string()
+        )]
+    );
+}
+
+/// Negative control: an all-nullish union (`null | undefined`) must NOT be
+/// touched by this reduction — it stays nullable and both members are
+/// assignable to anything in non-strict mode, so this is clean.
+#[test]
+fn nonstrict_all_nullish_union_stays_untouched_and_clean() {
+    let source = "\
+declare var allNullish: null | undefined;
+var probe: string = allNullish;
+";
+    assert_eq!(nonstrict_messages(source), Vec::<(u32, String)>::new());
+}
+
+/// Negative control: under `strictNullChecks`, the reduction must not fire —
+/// `number | null` stays a union and the assignment is still an error citing
+/// the full union.
+#[test]
+fn strict_mode_return_type_union_keeps_null_member() {
+    let source = "\
+declare function f(): number | null;
+var probe: string = f();
+";
+    assert_eq!(
+        strict_messages(source),
+        vec![(
+            2322,
+            "Type 'number | null' is not assignable to type 'string'.".to_string()
+        )]
+    );
+}
+
+/// A union member written inside an inline type literal reduces the same
+/// way as a top-level annotation.
+#[test]
+fn nonstrict_type_literal_member_union_absorbs_null() {
+    let source = "\
+declare var obj: { x: number | null };
+var probe: string = obj.x;
+";
+    assert_eq!(
+        nonstrict_messages(source),
+        vec![(
+            2322,
+            "Type 'number' is not assignable to type 'string'.".to_string()
+        )]
+    );
+}
+
+/// Positive control unaffected by this change: a union with no nullish
+/// member reduces exactly as before.
+#[test]
+fn nonstrict_union_without_nullish_member_is_unaffected() {
+    let source = "\
+declare function f(): string | number;
+var probe: boolean = f();
+";
+    assert_eq!(
+        nonstrict_messages(source),
+        vec![(
+            2322,
+            "Type 'string | number' is not assignable to type 'boolean'.".to_string()
+        )]
+    );
+}

--- a/crates/tsz-checker/src/types/computation/type_operators.rs
+++ b/crates/tsz-checker/src/types/computation/type_operators.rs
@@ -59,9 +59,28 @@ impl<'a> CheckerState<'a> {
                 return collapsed;
             }
 
+            // #16580: in non-strict mode, a scalar `null`/`undefined` member
+            // sitting alongside a non-nullish sibling is absorbed out of the
+            // union before construction — same reduction #16578 already
+            // applies to array-literal elements, generalized to every
+            // syntactic union type node. `literal_member_nodes` stays keyed
+            // to the original (unreduced) `member_types` below: a dropped
+            // `null`/`undefined` member was never `TYPE_LITERAL`, so it never
+            // contributed a `mark_union_literal_member` entry either way.
+            let construction_members = crate::query_boundaries::type_predicates::nonstrict_union_members_absorb_nullish_scalars(
+                self.ctx.compiler_options.strict_null_checks,
+                &member_types,
+            );
+            if let Some(reduced) = &construction_members
+                && reduced.len() == 1
+            {
+                return reduced[0];
+            }
+            let construction_members = construction_members.unwrap_or_else(|| member_types.clone());
+
             let result = tsz_solver::utils::union_or_single_literal_reduce(
                 self.ctx.types,
-                member_types.clone(),
+                construction_members.clone(),
             );
             // Mirror tsc's `UnionType.origin`: record the as-written input
             // member list so the diagnostic printer can preserve top-level
@@ -71,7 +90,7 @@ impl<'a> CheckerState<'a> {
             // flattened TypeId; first writer wins.
             self.ctx
                 .types
-                .store_union_origin(result, member_types.clone());
+                .store_union_origin(result, construction_members);
             // Record, per member, whether it was written as an anonymous
             // `{ ... }` literal directly in *this* union — as opposed to a
             // named alias/interface reference whose body happens to reduce

--- a/crates/tsz-checker/src/types/type_literal_checker.rs
+++ b/crates/tsz-checker/src/types/type_literal_checker.rs
@@ -63,6 +63,20 @@ impl<'a> CheckerState<'a> {
                 {
                     return collapsed;
                 }
+                // #16580: same non-strict scalar null/undefined absorption
+                // as the top-level union-type-node resolvers, generalized to
+                // a union written inside a type literal member.
+                if let Some(reduced) =
+                    crate::query_boundaries::type_predicates::nonstrict_union_members_absorb_nullish_scalars(
+                        self.ctx.compiler_options.strict_null_checks,
+                        &members,
+                    )
+                {
+                    if reduced.len() == 1 {
+                        return reduced[0];
+                    }
+                    return construction_boundary::type_node_union(self.ctx.types, reduced);
+                }
                 return construction_boundary::type_node_union(self.ctx.types, members);
             }
             return TypeId::ERROR;

--- a/crates/tsz-checker/src/types/type_node.rs
+++ b/crates/tsz-checker/src/types/type_node.rs
@@ -325,9 +325,28 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                 return collapsed;
             }
 
+            // #16580: in non-strict mode, a scalar `null`/`undefined` member
+            // sitting alongside a non-nullish sibling is absorbed out of the
+            // union before construction — same reduction #16578 already
+            // applies to array-literal elements, generalized to every
+            // syntactic union type node. `literal_member_nodes` stays keyed
+            // to the original (unreduced) `member_types` below: a dropped
+            // `null`/`undefined` member was never `TYPE_LITERAL`, so it never
+            // contributed a `mark_union_literal_member` entry either way.
+            let construction_members = crate::query_boundaries::type_predicates::nonstrict_union_members_absorb_nullish_scalars(
+                self.ctx.compiler_options.strict_null_checks,
+                &member_types,
+            );
+            if let Some(reduced) = &construction_members
+                && reduced.len() == 1
+            {
+                return reduced[0];
+            }
+            let construction_members = construction_members.unwrap_or_else(|| member_types.clone());
+
             let result = type_construction::type_node_annotation_union_with_origin(
                 self.ctx.types,
-                member_types.clone(),
+                construction_members,
             );
             // Record, per member, whether it was written as an anonymous
             // `{ ... }` literal directly in *this* union — as opposed to a

--- a/crates/tsz-solver/src/narrowing/mod.rs
+++ b/crates/tsz-solver/src/narrowing/mod.rs
@@ -41,8 +41,9 @@ pub(crate) mod utils;
 // Re-export utility functions from the utils submodule
 pub use utils::{
     collapse_pure_nullish_union_nonstrict, find_discriminants, is_definitely_nullish,
-    is_nullish_type, narrow_by_discriminant, narrow_by_typeof, remove_nullish,
-    remove_nullish_query, remove_undefined, split_nullish_type, type_contains_undefined,
+    is_nullish_type, narrow_by_discriminant, narrow_by_typeof,
+    nonstrict_union_members_absorb_nullish_scalars, remove_nullish, remove_nullish_query,
+    remove_undefined, split_nullish_type, type_contains_undefined,
 };
 
 // Re-export public items from compound narrowing

--- a/crates/tsz-solver/src/narrowing/utils.rs
+++ b/crates/tsz-solver/src/narrowing/utils.rs
@@ -406,6 +406,48 @@ pub fn collapse_pure_nullish_union_nonstrict(
     }
 }
 
+/// Non-strict scalar `null`/`undefined` absorption for a syntactic union that
+/// also has a non-nullish member — the mixed-member sibling of
+/// [`collapse_pure_nullish_union_nonstrict`] above, which only handles the
+/// all-nullish case.
+///
+/// Without `strictNullChecks`, `null`/`undefined` are subtypes of every type,
+/// so tsc's `getUnionType(members, UnionReduction.Subtype)` absorbs a scalar
+/// `null`/`undefined` member out of a union whenever a non-nullish sibling is
+/// present (`number | null` resolves to plain `number`). #16578 already
+/// applies this rule to the array-literal element union as a post-pass; this
+/// is the general syntactic-union-type-node seam (type annotations, type
+/// aliases, return types) that #16578 explicitly left for a follow-up
+/// (#16580). Every member here is already a fully resolved type rather than
+/// an expression to widen/infer, so — unlike the array-literal case — it is
+/// sound to pre-filter the candidate list handed to ordinary union
+/// construction instead of post-passing the constructed result.
+///
+/// Returns `None` (caller keeps its ordinary construction) when strict, when
+/// no member is a nullish scalar, or when every member is nullish scalar —
+/// that all-nullish case belongs to `collapse_pure_nullish_union_nonstrict`
+/// and must not be touched here (a bare `null | undefined` annotation stays
+/// nullable, it does not disappear).
+pub fn nonstrict_union_members_absorb_nullish_scalars(
+    strict_null_checks: bool,
+    member_types: &[TypeId],
+) -> Option<Vec<TypeId>> {
+    if strict_null_checks {
+        return None;
+    }
+    let is_nullish_scalar = |m: &TypeId| *m == TypeId::NULL || *m == TypeId::UNDEFINED;
+    if !member_types.iter().any(is_nullish_scalar) || member_types.iter().all(is_nullish_scalar) {
+        return None;
+    }
+    Some(
+        member_types
+            .iter()
+            .copied()
+            .filter(|m| !is_nullish_scalar(m))
+            .collect(),
+    )
+}
+
 /// Check if a type is definitely nullish (only null/undefined/void).
 pub fn is_definitely_nullish(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
     if type_id.is_nullable() {


### PR DESCRIPTION
#16578 taught only the array-literal element union to absorb a scalar `null`/`undefined` member when `strictNullChecks` is off. tsc's `getUnionType(members, UnionReduction.Subtype)` applies that reduction to every union it builds in non-strict mode, so annotations, type aliases, and return types still kept the nullish constituent. Closes #16580.

## Structural rule

When `strictNullChecks` is off and a syntactic union type node has both a `null`/`undefined` scalar member and a non-nullish sibling, tsc absorbs the nullish member(s) out at union-construction time; tsz did this only in the checker's array-literal post-pass.

Adds `tsz_solver::narrowing::nonstrict_union_members_absorb_nullish_scalars`, the mixed-member sibling of the existing `collapse_pure_nullish_union_nonstrict` (which only handles the all-nullish case and must stay untouched — a bare `null | undefined` annotation does not disappear). Wired into the three syntactic union-type-node resolvers:

- `types/type_node.rs` (`TypeNodeChecker`, used by type alias declarations)
- `types/computation/type_operators.rs` (`CheckerState`'s general `get_type_from_type_node` path, used by return types and most annotations)
- `types/type_literal_checker.rs` (a union member written inside an inline type literal)

Every member here is already a fully resolved type rather than an expression needing widening/inference, so it is sound to pre-filter the candidate list before ordinary union construction — unlike the array-literal case, which must post-pass the BCT/widening result to let literal widening see the full candidate set first.

## Known follow-up (not covered here)

A generic interface property typed `T | null` still keeps the `null` member after instantiation with a concrete type argument (`Box<number>`'s `value: T | null` stays `number | null`, not `number`), so interface/generic body union construction is evidently a separate seam from the three syntactic resolvers fixed here. Left as a follow-up rather than expanding this PR's scope past the issue's own measured cases.

## Goal
Goal: hold

## Verification
- New suite `nonstrict_union_nullish_scalar_reduction_tests.rs`: **8/8 pass**, pinned against `tsc` 7.0.2 (`--strict false --strictNullChecks false`), covering return type, type alias (full reduction, printed as the reduced primitive not the alias name), 3-member alias, multi-member union (2 non-nullish survivors), type-literal member, plus negative controls (all-nullish union untouched, strict mode untouched, union without a nullish member unaffected).
- `cargo test -p tsz-checker --lib -- nullish nonstrict union_`: **836/836**
- `cargo test -p tsz-solver --lib -- narrowing`: **330/330**
- `cargo clippy -p tsz-checker --lib --tests -- -D warnings`: clean
- `cargo clippy -p tsz-solver --lib --tests -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- `scripts/arch/arch_guard.py`: `Architecture guardrails passed.`
- Pre-commit hook (fmt + clippy `-p tsz-checker -p tsz-solver` + arch guard): passed.
- **Owed**: a full conformance snapshot / emit floor check was not run this session (time budget). This change only removes a previously-kept nullish union member in non-strict mode, matching tsc more closely — the corpus is mostly strict-mode projects, so movement is expected to be small or zero, but the two-sided `compare-to-parent.sh` run is genuinely owed before landing.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzbPJ9SJd8tXay9B9dSa9F)_