### PR TITLE
fix(emit): drop type arguments when a d.ts application base degrades to a bare keyword

### DIFF
--- a/crates/tsz-emitter/src/emitter/types/printer/type_printing.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/type_printing.rs
@@ -827,7 +827,10 @@ impl<'a> TypePrinter<'a> {
             };
         }
 
-        if app.args.is_empty() {
+        // A base that rendered as a bare fallback keyword cannot syntactically
+        // carry type arguments, so drop them rather than emit invalid
+        // `any<...>`. See `base_text_cannot_carry_type_arguments`.
+        if app.args.is_empty() || Self::base_text_cannot_carry_type_arguments(&base_text) {
             base_text
         } else {
             let args: Vec<String> = app
@@ -843,6 +846,44 @@ impl<'a> TypePrinter<'a> {
                 format!("{base_text}<{}>", args.join(", "))
             }
         }
+    }
+
+    /// True when a type-application base rendered as a bare fallback that cannot
+    /// head a generic reference. A valid generic base is always an identifier,
+    /// qualified name, or `import("...").Name`; when the printer instead
+    /// truncates (depth cutoff → `any`), renders a bare intrinsic, or elides a
+    /// self-referential alias (`crate::ELIDED_ANY`), the result is a non-generic
+    /// keyword and appending `<...>` would emit invalid TypeScript — tsc renders
+    /// a truncated or unnameable recursive application as the bare fallback,
+    /// never as `<keyword><...>`.
+    ///
+    /// The keyword set is the *non-generic* subset of the bare renderings
+    /// `print_intrinsic_type` produces. It deliberately omits the intrinsic
+    /// renderings that are legitimate generic reference heads (`Promise`,
+    /// `Function`) and the boolean-literal renderings (`true`/`false`); keep it
+    /// in sync if a new non-generic intrinsic keyword is added there.
+    ///
+    /// (tsc additionally reports TS7056 for the *non-exported* form of this
+    /// shape — a separate alias-retention gap tracked on #15983; this guard only
+    /// keeps the emitted fallback syntactically valid.)
+    fn base_text_cannot_carry_type_arguments(base_text: &str) -> bool {
+        let trimmed = base_text.trim();
+        trimmed == crate::ELIDED_ANY
+            || matches!(
+                trimmed,
+                "any"
+                    | "unknown"
+                    | "never"
+                    | "void"
+                    | "undefined"
+                    | "null"
+                    | "object"
+                    | "string"
+                    | "number"
+                    | "boolean"
+                    | "symbol"
+                    | "bigint"
+            )
     }
 
     fn print_keyof_alias_application(
@@ -1456,6 +1497,49 @@ mod tests {
         let text = TypePrinter::new(&interner)
             .print_type(interner.intersection(vec![object_type, literal]));
         assert_eq!(text, "\"def\"");
+    }
+
+    #[test]
+    fn degraded_application_base_drops_type_arguments() {
+        // A type application whose base cannot be resolved to a nameable
+        // reference renders the base as the bare `any` fallback. Appending the
+        // type arguments would emit `any<number, string>`, which is not valid
+        // TypeScript (`any` is not generic) — the printer must drop them and
+        // keep just the fallback, matching tsc's rendering of a truncated or
+        // unnameable recursive application.
+        let interner = TypeInterner::new();
+        let base = interner.lazy(DefId(9999));
+        let app = interner.application(base, vec![TypeId::NUMBER, TypeId::STRING]);
+        let printed = TypePrinter::new(&interner).print_type(app);
+        assert!(
+            !printed.contains('<'),
+            "degraded base must not carry type arguments, got: {printed}"
+        );
+        assert_eq!(printed, "any");
+    }
+
+    #[test]
+    fn base_text_cannot_carry_type_arguments_classifies_degraded_fallbacks() {
+        assert!(TypePrinter::base_text_cannot_carry_type_arguments("any"));
+        assert!(TypePrinter::base_text_cannot_carry_type_arguments(
+            "unknown"
+        ));
+        assert!(TypePrinter::base_text_cannot_carry_type_arguments("never"));
+        assert!(TypePrinter::base_text_cannot_carry_type_arguments(
+            crate::ELIDED_ANY
+        ));
+        // Real, nameable reference heads must keep their type arguments.
+        assert!(!TypePrinter::base_text_cannot_carry_type_arguments("Foo"));
+        assert!(!TypePrinter::base_text_cannot_carry_type_arguments(
+            "Promise"
+        ));
+        assert!(!TypePrinter::base_text_cannot_carry_type_arguments(
+            "import(\"./m\").Bar"
+        ));
+        // A member named after a keyword (e.g. `ns.any`) is still a reference.
+        assert!(!TypePrinter::base_text_cannot_carry_type_arguments(
+            "ns.any"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
When declaration emit prints a type application `Base<Args>` and `Base` degrades to a bare fallback keyword — the depth-cutoff `any`, a bare intrinsic, or the `/*elided*/ any` self-referential-alias sentinel — the printer emitted `format!("{base}<...>")`, producing **invalid TypeScript** in the emitted `.d.ts` (e.g. `any<TResult1 | TResult2, any>`; `any` is not generic). `tsc` renders a truncated or unnameable recursive application as the bare fallback, never as `<keyword><...>`.

Structural rule: when a `.d.ts` type application's base renders as a non-generic keyword (a truncated/unnameable recursive alias, or the depth-cutoff fallback), `tsc` drops the type arguments and emits the bare base; tsz now does the same through the emitter's `TypePrinter::print_type_application` gateway, guarded by a new `base_text_cannot_carry_type_arguments` classifier (the non-generic subset of `print_intrinsic_type`'s bare renderings plus `ELIDED_ANY`, deliberately excluding legitimate generic heads like `Promise`/`Function`).

Surfaced while investigating the still-missing TS7056 on a non-exported recursive import alias (the `swagger-typescript-api` `TPromise` shape, tracked on #15983). The missing TS7056 diagnostic itself is a deeper alias-retention gap (tsz expands the alias inline instead of naming or deferring it) and is left tracked on #15983; this change only ensures the fallback tsz *does* emit is syntactically valid.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-emitter --lib` — 3991 passed / 0 failed (includes 2 new printer tests plus the full `declaration_emitter` suite)
- `cargo clippy -p tsz-emitter --all-targets` — clean
- `python3 scripts/arch/arch_guard.py` — rc=0
- `cargo test -p tsz-cli --test recursive_const_arrow_dts_emit_tests --test non_exported_dependency_transitive_dts_emit_tests` — pass (closest DTS-emit integration targets)
- Manual: the `TPromise` repro's emitted `Api.d.ts` now parses under `tsc@7.0.2` (was invalid `any<...>` before)
- Emit floor (`scripts/emit/run.sh`) not run locally (TypeScript submodule not checked out; nightly CI covers it). The change only converts previously-invalid output to valid, so emit-success counts cannot regress.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01XBaCdAChYK22mKKkwiMKYT)_