### PR TITLE
fix(checker): non-strict union type nodes drop null/undefined with a non-nullish sibling

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/type_predicates.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_predicates.rs
@@ -275,6 +275,37 @@ pub(crate) fn collapse_pure_nullish_union_nonstrict(
     tsz_solver::narrowing::collapse_pure_nullish_union_nonstrict(strict_null_checks, member_types)
 }
 
+/// With `strictNullChecks` off, drop `null`/`undefined` members out of an
+/// already-constructed union type whenever a non-nullish sibling is present
+/// — e.g. `declare function f(): number | null` infers `number`, not
+/// `number | null`. `tsc`'s `getUnionType` (`addTypeToUnion`) applies this to
+/// every union it constructs; this is the single choke point both of tsz's
+/// union-type-node resolvers (`TypeNodeChecker::get_type_from_union_type` and
+/// `CheckerState::get_type_from_union_type`) call into, so the answer agrees
+/// regardless of which one a given syntactic position routes through.
+///
+/// The all-nullish case (nothing left to keep once the nullish members are
+/// gone) is handled separately by `collapse_pure_nullish_union_nonstrict`,
+/// which callers must consult first — this function leaves such a union
+/// untouched precisely because it finds no non-nullish survivor.
+pub(crate) fn strip_nullish_from_union_type_node_nonstrict(
+    db: &dyn TypeDatabase,
+    strict_null_checks: bool,
+    type_id: TypeId,
+) -> TypeId {
+    if strict_null_checks {
+        return type_id;
+    }
+    let Some(members) = tsz_solver::type_queries::get_union_members(db, type_id) else {
+        return type_id;
+    };
+    let is_nullish_scalar = |m: &TypeId| *m == TypeId::NULL || *m == TypeId::UNDEFINED;
+    if !members.iter().any(is_nullish_scalar) || !members.iter().any(|m| !is_nullish_scalar(m)) {
+        return type_id;
+    }
+    tsz_solver::narrowing::remove_nullish(db, type_id)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -637,6 +637,8 @@ mod nonstrict_nullish_widening_generic_call_tests;
 mod nonstrict_nullish_widening_mutable_binding_tests;
 #[path = "tests/nonstrict_nullish_widening_nested_leaf_tests.rs"]
 mod nonstrict_nullish_widening_nested_leaf_tests;
+#[path = "tests/nonstrict_union_type_node_nullish_absorption_tests.rs"]
+mod nonstrict_union_type_node_nullish_absorption_tests;
 #[path = "tests/nonunique_symbol_property_access_tests.rs"]
 mod nonunique_symbol_property_access_tests;
 #[path = "tests/noUIA_any_index_emits_ts2322_tests.rs"]

--- a/crates/tsz-checker/src/tests/nonstrict_union_type_node_nullish_absorption_tests.rs
+++ b/crates/tsz-checker/src/tests/nonstrict_union_type_node_nullish_absorption_tests.rs
@@ -1,0 +1,150 @@
+//! Tests for #16580: with `strictNullChecks` off, tsc's `getUnionType`
+//! (`addTypeToUnion`) drops a `null`/`undefined` constituent out of *every*
+//! union it constructs whenever a non-nullish sibling survives — not only the
+//! array-literal element path #16578 already fixed
+//! (`array_literal.rs::nonstrict_array_element_union_absorbs_nullish_scalars`).
+//! A written union type node — a return-type annotation, a type-alias body, a
+//! parameter or variable annotation — resolves through one common choke
+//! point, `TypeNodeChecker::get_type_from_union_type`, so the reduction lives
+//! there (`nonstrict_union_type_node_absorbs_nullish_scalars`).
+//!
+//! Every row is pinned against `typescript@7.0.2`,
+//! `--strict false --strictNullChecks false --target es2015`.
+//!
+//! `type Age = number | undefined` reducing to bare `number` also means the
+//! alias has nothing left to print once the nullish member is gone — tsc
+//! renders the surviving primitive, not the alias name, and so must tsz: this
+//! is a naming *consequence* of the shape reduction, not a printer defect to
+//! chase separately.
+
+use crate::test_utils::{
+    check_with_options_code_messages, non_strict_checker_options, strict_checker_options,
+};
+
+fn nonstrict_messages(source: &str) -> Vec<(u32, String)> {
+    check_with_options_code_messages(source, non_strict_checker_options())
+}
+
+fn strict_messages(source: &str) -> Vec<(u32, String)> {
+    check_with_options_code_messages(source, strict_checker_options())
+}
+
+/// Probe the reduced type by forcing it into a `TS2322` that prints it.
+fn assert_reduces_to(source: &str, rendered: &str, target: &str) {
+    let messages = nonstrict_messages(source);
+    assert_eq!(
+        messages,
+        vec![(
+            2322,
+            format!("Type '{rendered}' is not assignable to type '{target}'.")
+        )],
+        "expected the union type node to reduce to `{rendered}`: {messages:?}"
+    );
+}
+
+#[test]
+fn return_type_annotation_drops_null_with_non_nullish_sibling() {
+    assert_reduces_to(
+        "declare function f(): number | null;\nvar probe: string = f();",
+        "number",
+        "string",
+    );
+}
+
+#[test]
+fn type_alias_drops_undefined_with_non_nullish_sibling() {
+    // The alias itself has nothing left to print once `undefined` is gone —
+    // tsc renders `number`, not the alias name `Age`.
+    assert_reduces_to(
+        "type Age = number | undefined;\ndeclare var age: Age;\nvar probe: string = age;",
+        "number",
+        "string",
+    );
+}
+
+#[test]
+fn three_member_type_alias_drops_both_nullish_members() {
+    assert_reduces_to(
+        "type Zqq = string | null | undefined;\ndeclare var w: Zqq;\nvar probe: number = w;",
+        "string",
+        "number",
+    );
+}
+
+#[test]
+fn variable_annotation_union_drops_null_with_non_nullish_sibling() {
+    assert_reduces_to(
+        "declare var a: number | null;\nvar probe: string = a;",
+        "number",
+        "string",
+    );
+}
+
+#[test]
+fn parameter_type_annotation_drops_undefined_with_non_nullish_sibling() {
+    assert_reduces_to(
+        "declare function take(x: string | undefined): void;\n\
+         function wrap(x: string | undefined) {\n\
+           take(x);\n\
+           var probe: number = x;\n\
+         }",
+        "string",
+        "number",
+    );
+}
+
+#[test]
+fn multiple_non_nullish_survivors_keep_a_smaller_union() {
+    // Only the nullish member is absorbed; the two non-nullish siblings stay
+    // a union, not a single surviving type. Written directly (not through a
+    // type alias) to isolate the reduction from the pre-existing, unrelated
+    // display quirk where a multi-member all-primitive *alias* union keeps
+    // its alias name instead of expanding — reproducible on `main` with no
+    // nullish member involved at all (`type V = string | number | boolean`),
+    // so it is out of this fix's scope.
+    assert_reduces_to(
+        "declare var u: string | number | null;\nvar probe: boolean = u;",
+        "string | number",
+        "boolean",
+    );
+}
+
+#[test]
+fn renamed_binder_type_alias_still_reduces() {
+    // Anti-hardcoding control: an unrelated alias/binding name must not
+    // change the outcome.
+    assert_reduces_to(
+        "type Zorbatron = boolean | null;\ndeclare var qqxk: Zorbatron;\nvar probe: string = qqxk;",
+        "boolean",
+        "string",
+    );
+}
+
+#[test]
+fn all_nullish_union_type_node_is_untouched() {
+    // Negative control (matches #16580's `a6`): an all-nullish union has no
+    // non-nullish sibling to absorb into and must stay assignable to itself,
+    // not collapse away entirely.
+    let messages =
+        nonstrict_messages("declare var a: null | undefined;\nvar probe: null | undefined = a;");
+    assert!(
+        messages.is_empty(),
+        "an all-nullish union type node must stay clean: {messages:?}"
+    );
+}
+
+#[test]
+fn strict_mode_keeps_the_nullish_member() {
+    // Positive control: the reduction is strictNullChecks-off only. Under
+    // strict mode the union keeps its written members.
+    let messages =
+        strict_messages("declare function f(): number | null;\nvar probe: string = f();");
+    assert_eq!(
+        messages,
+        vec![(
+            2322,
+            "Type 'number | null' is not assignable to type 'string'.".to_string()
+        )],
+        "strict mode must keep `null` in the union: {messages:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/computation/type_operators.rs
+++ b/crates/tsz-checker/src/types/computation/type_operators.rs
@@ -63,6 +63,26 @@ impl<'a> CheckerState<'a> {
                 self.ctx.types,
                 member_types.clone(),
             );
+
+            // With `strictNullChecks` off, `null`/`undefined` are subtypes of
+            // every type, so tsc's `getUnionType` (`addTypeToUnion`) drops a
+            // `null`/`undefined` constituent whenever the union has at least
+            // one non-nullish sibling — matching the array-literal element
+            // path's identical reduction (#16578). The all-nullish case is
+            // handled separately above by `collapse_pure_nullish_union_nonstrict`.
+            let reduced = crate::query_boundaries::type_predicates::strip_nullish_from_union_type_node_nonstrict(
+                self.ctx.types,
+                self.ctx.compiler_options.strict_null_checks,
+                result,
+            );
+            if reduced != result {
+                // The union collapsed to a single surviving member (or a
+                // smaller union) — its identity is no longer *this* written
+                // union, so the anonymous-object-literal bookkeeping below
+                // (keyed on this union's `TypeId`) does not apply.
+                return reduced;
+            }
+
             // Mirror tsc's `UnionType.origin`: record the as-written input
             // member list so the diagnostic printer can preserve top-level
             // alias names that union flattening would otherwise dissolve

--- a/crates/tsz-checker/src/types/type_node.rs
+++ b/crates/tsz-checker/src/types/type_node.rs
@@ -329,6 +329,31 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                 self.ctx.types,
                 member_types.clone(),
             );
+
+            // With `strictNullChecks` off, `null`/`undefined` are subtypes of
+            // every type, so tsc's `getUnionType` (`addTypeToUnion`) drops a
+            // `null`/`undefined` constituent whenever the union has at least
+            // one non-nullish sibling — this applies to every union tsc
+            // constructs, not only the array-literal element path (see
+            // `nonstrict_array_element_union_absorbs_nullish_scalars` in
+            // `array_literal.rs`). The all-nullish union (nothing left to
+            // keep) is handled separately above by
+            // `collapse_pure_nullish_union_nonstrict` and must stay untouched
+            // here.
+            let reduced = crate::query_boundaries::type_predicates::strip_nullish_from_union_type_node_nonstrict(
+                self.ctx.types,
+                self.ctx.compiler_options.strict_null_checks,
+                result,
+            );
+            if reduced != result {
+                // The union collapsed to a single surviving member (or a
+                // smaller union) — its identity is no longer the original
+                // written union, so the anonymous-object-literal bookkeeping
+                // below (which is keyed on *this* union's `TypeId`) does not
+                // apply and must not be recorded against the reduced type.
+                return reduced;
+            }
+
             // Record, per member, whether it was written as an anonymous
             // `{ ... }` literal directly in *this* union — as opposed to a
             // named alias/interface reference whose body happens to reduce


### PR DESCRIPTION
Closes #16580.

With `strictNullChecks` off, `null`/`undefined` are subtypes of every type, so `tsc`'s `getUnionType` (`addTypeToUnion`) drops a `null`/`undefined` constituent out of **every** union it constructs whenever a non-nullish sibling survives — not only the array-literal element path #16578 fixed. Every other written union (return-type annotations, type-alias bodies, variable/parameter annotations) kept the nullish member, producing a false `TS2322` downstream (e.g. `declare function f(): number | null; var probe: string = f();` incorrectly reported the source type as `number | null` instead of tsc's `number`).

## Structural rule

When `strictNullChecks` is off and a union type node has both a `null`/`undefined` constituent and a non-nullish one, `tsc` reduces the nullish constituent out at type construction; tsz now does the same through a shared solver query boundary (`strip_nullish_from_union_type_node_nonstrict` in `query_boundaries/type_predicates.rs`), mirroring the array-literal element fix's own post-pass shape.

**Two call sites, not one.** `crates/tsz-checker` has two independent implementations of `get_type_from_union_type` — `TypeNodeChecker::get_type_from_union_type` (`types/type_node.rs`) and `CheckerState::get_type_from_union_type` (`types/computation/type_operators.rs`) — and `CheckerState::get_type_from_type_node` routes every union type node (return types, type-alias bodies, variable/parameter annotations) through the *second* one, not the first. An initial version of this fix only touched `TypeNodeChecker`'s copy and every test kept failing until I traced the real call path and applied the identical reduction to both, via the shared query-boundary function so the two never drift apart.

The all-nullish case (nothing left to keep) is untouched — that's handled separately, and correctly already, by the existing `collapse_pure_nullish_union_nonstrict`.

## Adjacent-case matrix (new tests, all oracle-pinned per #16580's own table against `typescript@7.0.2`)

- Return-type annotation: `declare function f(): number | null` → `number`
- Type alias, single nullish member: `type Age = number | undefined` → `number` (alias name correctly disappears — nothing left to alias)
- Type alias, two nullish members: `type Zqq = string | null | undefined` → `string`
- Variable annotation: `declare var a: number | null` → `number`
- Parameter annotation: `(x: string | undefined)` → `string`
- Multiple non-nullish survivors stay a union (not fully collapsed): `string | number | null` → `string | number`
- Renamed-binder control (anti-hardcoding)
- Negative control: an all-nullish union (`null | undefined`) stays untouched, clean
- Positive control: strict mode keeps the nullish member unreduced

Also recorded, out of scope: a **pre-existing, unrelated** display quirk where a multi-member all-primitive *type alias* union (no nullish member involved at all, e.g. `type V = string | number | boolean`) prints the alias name instead of expanding — reproducible on `main` before this change. The `multiple_non_nullish_survivors_keep_a_smaller_union` test is written against a direct (non-aliased) union annotation specifically to isolate this fix's reduction from that separate bug.

## Goal
Goal: hold

## Verification
- New suite: `cargo test -p tsz-checker --lib -- nonstrict_union_type_node_nullish_absorption_tests` — **9/9 pass**.
- Targeted blast-radius sweep: `cargo test -p tsz-checker --lib -- union nullish alias_display strict_null non_strict nonstrict` — **958 passed, 0 failed**.
- `cargo fmt -p tsz-checker -- --check`: clean.
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`: clean (also passed via the pre-commit hook).
- Full `cargo test -p tsz-checker --lib` (all ~10k tests): **started, still running at push time** — the board's standing note says this lane can take anywhere from ~3 to ~55 minutes depending on the seat, and output buffers to zero bytes until it finishes. Will report the result as a follow-up comment; the targeted 958-test sweep above already covers every union/nullish/alias-display file directly touched by this change.
- Not run this session (time budget): `compare-to-parent.sh` / full conformance snapshot. This changes the resolved type of any non-strict-mode union type node with a nullish member — a real semantic-code-path change, so conformance is not arguable away; flagging as owed for a follow-up session or before merge.
- **Emit unaffected**: diff touches only `crates/tsz-checker/src/{query_boundaries,types,tests,test_module_registry.rs}` — no emit path.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01VE8LaXwd21D2Y54iDk4Bvw)_