### PR TITLE
fix(solver): an all-nullish union reduces to the scalar `null`, not a surviving union

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -641,6 +641,8 @@ mod nonstrict_nullish_widening_generic_call_tests;
 mod nonstrict_nullish_widening_mutable_binding_tests;
 #[path = "tests/nonstrict_nullish_widening_nested_leaf_tests.rs"]
 mod nonstrict_nullish_widening_nested_leaf_tests;
+#[path = "tests/nonstrict_union_nullish_absorption_tests.rs"]
+mod nonstrict_union_nullish_absorption_tests;
 #[path = "tests/nonstrict_union_nullish_scalar_reduction_tests.rs"]
 mod nonstrict_union_nullish_scalar_reduction_tests;
 #[path = "tests/nonunique_symbol_property_access_tests.rs"]

--- a/crates/tsz-checker/src/tests/non_strict_non_null_check_narrows_tests.rs
+++ b/crates/tsz-checker/src/tests/non_strict_non_null_check_narrows_tests.rs
@@ -502,30 +502,41 @@ fn strict_mode_keeps_the_two_cause_answer_for_an_interface_member() {
 }
 
 #[test]
-fn interface_index_signature_value_is_a_known_unfixed_residual() {
-    // NOT fixed here — documented so a future fix has a red test to turn
-    // green, and so this stays visibly a residual rather than silently
-    // regressing further. An index-signature member never reaches the
-    // interface fast path at all (`try_lower_simple_local_interface_object`
-    // rejects any non-`PROPERTY_SIGNATURE` member outright), so it always
-    // falls through to `tsz-lowering`'s `TypeLowering`, whose
-    // `strict_null_checks` field is not reliably wired to the real compiler
-    // option — see the strict-mode control above and this PR's review
-    // discussion. Fixing this either needs fast-path support for index
-    // signatures (mirroring the property-signature handling) or properly
-    // plumbing the option through `tsz-lowering`; both are out of scope for
-    // this fix. Behavior is unchanged from before this PR in both modes.
+fn interface_index_signature_value_reports_the_reduced_single_cause() {
+    // Was pinned here as a known-unfixed residual: the index-signature value
+    // `null | undefined` stayed a *union* in non-strict mode, and a union never
+    // triggers the non-strict arm (see this file's header), so the row reported
+    // nothing while tsc reported TS18047.
+    //
+    // #16580 fixed it at the real owner. With `strictNullChecks` off, tsc's
+    // `addTypeToUnion` drops every nullish constituent and `getUnionType` falls
+    // back to `null` (preferred over `undefined`) when nothing else remains, so
+    // this value's type is the *scalar* `null` — whose own `type.flags` are
+    // `TypeFlags.Nullable`, which is exactly what the non-strict arm keys on.
+    // The single-cause TS18047 is therefore the correct answer, not a
+    // regression, and this row doubles as the most direct observable witness of
+    // the `null`-preferred all-nullish fallback.
+    //
+    // Oracle, `typescript@7.0.2`:
+    //   --strict false --strictNullChecks false -> TS18047 'i.m' is possibly 'null'.
+    //   --strict                                -> TS18049 'i.m' is possibly 'null' or 'undefined'.
     let source = "interface I { [k: string]: null | undefined }\ndeclare const i: I;\ni.m.foo;";
     let lax = nullish_codes(&non_strict(source));
-    assert!(
-        lax.is_empty(),
-        "index-signature value nullish collapse remains unfixed (non-strict), got: {lax:?}"
+    assert_eq!(
+        lax,
+        vec![TS18047],
+        "non-strict reduces the index-signature value to `null` and reports the single-cause TS18047, got: {lax:?}"
     );
     let strict = check_source_strict_codes(source);
     assert_eq!(
         count(&strict, 18049),
         1,
-        "strict mode already reports the two-cause TS18049 for an interface index signature, got: {strict:?}"
+        "strict mode keeps the two-cause TS18049 for an interface index signature, got: {strict:?}"
+    );
+    assert_eq!(
+        count(&strict, TS18047),
+        0,
+        "strict mode must not collapse to the single-cause TS18047, got: {strict:?}"
     );
 }
 

--- a/crates/tsz-checker/src/tests/nonstrict_union_nullish_absorption_tests.rs
+++ b/crates/tsz-checker/src/tests/nonstrict_union_nullish_absorption_tests.rs
@@ -1,0 +1,432 @@
+//! Regression tests for #16580: with `strictNullChecks` off, `null`/`undefined`
+//! are absorbed out of *every* union, not just array-literal element unions.
+//!
+//! Structural rule: when `strictNullChecks` is off, `null` and `undefined` are
+//! subtypes of every type, so tsc's `addTypeToUnion` never adds either to a
+//! union's member set — it records only that one was seen, and `getUnionType`
+//! falls back to `null` (preferred over `undefined`) when *nothing else*
+//! remains. tsz applied that reduction only on the array-literal element path
+//! (#16578, a checker-side post-pass); it now happens in the solver's union
+//! construction itself, so annotations, aliases, return types, property types
+//! and inferred unions all get it.
+//!
+//! Two constituents that look nullish but are not: `void` is not
+//! `TypeFlags.Nullable` in tsc and must survive, and an *all-nullish* union has
+//! no non-nullish sibling to absorb into, so it stays nullish rather than
+//! collapsing to `never`.
+//!
+//! Each row reads the rendered source type out of a `TS2322` produced by
+//! assigning the value to an incompatible type — the same methodology the issue
+//! used against a pinned `typescript@7.0.2` oracle
+//! (`--strict false --strictNullChecks false --target es2015`). Binder names are
+//! varied across rows so no row can be satisfied by a name-shaped predicate.
+
+use crate::test_utils::{check_with_options_code_messages, non_strict_checker_options};
+
+fn nonstrict_messages(source: &str) -> Vec<(u32, String)> {
+    check_with_options_code_messages(source, non_strict_checker_options())
+}
+
+/// Assign to `string` and read the rendered source type out of the `TS2322`.
+fn assert_renders_as(source: &str, expected_type: &str, context: &str) {
+    assert_renders_as_against(source, expected_type, "string", context);
+}
+
+/// The same, for rows whose own type is `string` and so need a different
+/// incompatible target to provoke the `TS2322`.
+fn assert_renders_as_against(source: &str, expected_type: &str, target: &str, context: &str) {
+    let messages = nonstrict_messages(source);
+    assert_eq!(
+        messages,
+        vec![(
+            2322,
+            format!("Type '{expected_type}' is not assignable to type '{target}'.")
+        )],
+        "{context}: {messages:?}"
+    );
+}
+
+fn assert_clean(source: &str, context: &str) {
+    let messages = nonstrict_messages(source);
+    assert!(messages.is_empty(), "{context}: {messages:?}");
+}
+
+// ── The reported witness: a declared return type ──
+
+/// #16580's repro. `declare function f(): number | null` returns `number` with
+/// the flag off, so the `TS2322` names `number`, not `number | null`.
+#[test]
+fn declared_return_union_absorbs_null() {
+    assert_renders_as(
+        "\
+declare function supply(): number | null;
+var probe: string = supply();
+",
+        "number",
+        "a declared return type absorbs its null constituent",
+    );
+}
+
+#[test]
+fn declared_return_union_absorbs_undefined() {
+    assert_renders_as(
+        "\
+declare function fetchValue(): number | undefined;
+var sink: string = fetchValue();
+",
+        "number",
+        "a declared return type absorbs its undefined constituent",
+    );
+}
+
+// ── Annotations, including the array-element form the issue measured as a1 ──
+
+#[test]
+fn variable_annotation_absorbs_null() {
+    assert_renders_as(
+        "\
+declare var quantity: number | null;
+var probe: string = quantity;
+",
+        "number",
+        "a variable annotation absorbs its null constituent",
+    );
+}
+
+/// The issue's a1: the annotation `(number | null)[]` renders `number[]`, so the
+/// reduction has to happen inside the array's *element* type as constructed from
+/// the annotation, not only on the array-literal inference path.
+#[test]
+fn array_annotation_element_union_absorbs_null() {
+    assert_renders_as(
+        "\
+var readings: (number | null)[] = [1, null];
+var probe: string = readings;
+",
+        "number[]",
+        "an array annotation's element union absorbs its null constituent",
+    );
+}
+
+/// A nullish constituent buried under an object type's property annotation.
+#[test]
+fn property_annotation_absorbs_undefined() {
+    assert_renders_as(
+        "\
+declare var record: { tally: number | undefined };
+var probe: string = record;
+",
+        "{ tally: number; }",
+        "a property annotation absorbs its undefined constituent",
+    );
+}
+
+// ── Aliases: the same root cause surfacing as a naming difference ──
+
+/// The issue's a3. Once the union reduces to a single member there is no alias
+/// left to print, so tsc renders `number`. This must come from the reduction,
+/// not from teaching the printer to expand aliases.
+#[test]
+fn alias_of_union_with_undefined_renders_as_its_survivor() {
+    assert_renders_as(
+        "\
+type Tally = number | undefined;
+declare var counted: Tally;
+var probe: string = counted;
+",
+        "number",
+        "an alias whose union reduces to one member prints that member",
+    );
+}
+
+/// The issue's a5: both nullish constituents at once.
+#[test]
+fn alias_of_union_with_both_nullish_renders_as_its_survivor() {
+    assert_renders_as_against(
+        "\
+type Zqq = string | null | undefined;
+declare var widget: Zqq;
+var probe: number = widget;
+",
+        "string",
+        "number",
+        "an alias absorbs both nullish constituents",
+    );
+}
+
+/// An alias that still has two survivors keeps its alias name — the reduction
+/// removes the nullish member without disturbing alias display.
+#[test]
+fn alias_with_two_survivors_keeps_its_name() {
+    assert_renders_as(
+        "\
+type Payload = number | boolean | null;
+declare var carried: Payload;
+var probe: string = carried;
+",
+        "Payload",
+        "an alias with two survivors still prints as the alias",
+    );
+}
+
+/// A generic alias instantiated with a concrete argument: the reduction happens
+/// after instantiation, on the instantiated member list.
+#[test]
+fn generic_alias_instantiation_absorbs_null() {
+    assert_renders_as(
+        "\
+type Slot<TValue> = TValue | null;
+declare var held: Slot<number>;
+var probe: string = held;
+",
+        "number",
+        "a generic alias absorbs null after instantiation",
+    );
+}
+
+// ── Negative controls: what must NOT be absorbed ──
+
+/// The issue's a6, and the important negative: an all-nullish union has no
+/// non-nullish sibling to absorb into. It must stay nullish — which in non-strict
+/// mode is assignable to `string`, so the row is clean rather than a `TS2322`
+/// naming `never`.
+#[test]
+fn all_nullish_union_does_not_collapse() {
+    assert_clean(
+        "\
+declare var vacant: null | undefined;
+var probe: string = vacant;
+",
+        "an all-nullish union keeps a nullish result",
+    );
+}
+
+/// The alias form of the same negative.
+#[test]
+fn all_nullish_alias_does_not_collapse() {
+    assert_clean(
+        "\
+type Absent = undefined | null;
+declare var missing: Absent;
+var probe: string = missing;
+",
+        "an all-nullish alias keeps a nullish result",
+    );
+}
+
+// ── What the all-nullish union actually reduces *to* ──
+//
+// The rows above only establish that it stays nullish. They cannot tell a
+// surviving `null | undefined` union from the scalar `null`, because both are
+// assignable to everything with the flag off. The non-strict non-null arm keys
+// on `type.flags & Nullable`, and a `Union`'s flags are `Union`, so it is the
+// one observable that discriminates them.
+//
+// Oracle, `typescript@7.0.2`, `--strict false --strictNullChecks false`:
+//   declare var a: null | undefined; a.foo;  -> TS18047 'a' is possibly 'null'.
+//   declare var b: undefined | null; b.foo;  -> TS18047 'b' is possibly 'null'.
+//   declare var d: undefined;        d.foo;  -> TS18048 'd' is possibly 'undefined'.
+//
+// Non-vacuity, stated honestly: these four rows pass *with or without* the
+// solver-side collapse, because a directly-written annotation is also handled by
+// #16593's syntactic union-type-node resolver. They are here to pin that the two
+// paths agree. The rows that actually isolate the solver seam are
+// `interface_index_signature_value_reports_the_reduced_single_cause` (the
+// index-signature value is lowered by `tsz-lowering`, which no syntactic
+// resolver sees) and the interner-level
+// `nonstrict_all_nullish_union_collapses_to_the_scalar_null`; both fail with
+// `crates/tsz-solver/src/intern/normalize.rs` reverted to its pre-fix state.
+
+fn nonstrict_codes(source: &str) -> Vec<u32> {
+    nonstrict_messages(source)
+        .into_iter()
+        .map(|(c, _)| c)
+        .collect()
+}
+
+/// `null | undefined` is the scalar `null`, so the non-null arm fires TS18047.
+#[test]
+fn all_nullish_union_reduces_to_the_scalar_null() {
+    assert_eq!(
+        nonstrict_codes("declare var vacant: null | undefined;\nvacant.foo;\n"),
+        vec![18047],
+        "an all-nullish union reduces to the scalar null"
+    );
+}
+
+/// `null` wins on presence, not position — the reversed order is the same type.
+#[test]
+fn all_nullish_union_prefers_null_regardless_of_order() {
+    assert_eq!(
+        nonstrict_codes("declare var hollow: undefined | null;\nhollow.foo;\n"),
+        vec![18047],
+        "undefined | null still reduces to the scalar null"
+    );
+}
+
+/// Through an alias, so the reduction is not a property of the annotation site.
+#[test]
+fn all_nullish_alias_reduces_to_the_scalar_null() {
+    assert_eq!(
+        nonstrict_codes("type Absent = undefined | null;\ndeclare var gone: Absent;\ngone.foo;\n"),
+        vec![18047],
+        "an all-nullish alias reduces to the scalar null"
+    );
+}
+
+/// The discriminating negative: with no `null` among the members, `undefined`
+/// is the survivor and the arm reports TS18048 instead.
+#[test]
+fn bare_undefined_stays_undefined() {
+    assert_eq!(
+        nonstrict_codes("declare var unset: undefined;\nunset.foo;\n"),
+        vec![18048],
+        "a bare undefined is not rewritten to null"
+    );
+}
+
+/// `void` is not `TypeFlags.Nullable` in tsc and survives union construction
+/// with the flag off. This is what separates the fix from a blanket
+/// "drop anything nullable" rule. The `void | string` member order is tsc's own
+/// (oracle-confirmed), not a display choice of this fix.
+#[test]
+fn void_constituent_survives() {
+    assert_renders_as_against(
+        "\
+declare var outcome: string | void;
+var probe: number = outcome;
+",
+        "void | string",
+        "number",
+        "void is not nullable and survives the reduction",
+    );
+}
+
+/// `void` beside a nullish constituent: the nullish one goes, `void` stays, and
+/// because two members survive the alias still has something to name.
+#[test]
+fn void_survives_beside_an_absorbed_null() {
+    assert_renders_as_against(
+        "\
+type WithVoid = string | void | null;
+declare var mixedv: WithVoid;
+var probe: number = mixedv;
+",
+        "WithVoid",
+        "number",
+        "void survives while its null sibling is absorbed",
+    );
+}
+
+/// A union with no nullish constituent at all is untouched.
+#[test]
+fn union_without_nullish_is_unchanged() {
+    assert_renders_as(
+        "\
+declare var mixed: number | boolean;
+var probe: string = mixed;
+",
+        "number | boolean",
+        "a union with no nullish constituent is unchanged",
+    );
+}
+
+/// A bare `null` annotation is not a union and is not reduced away.
+#[test]
+fn bare_null_annotation_is_untouched() {
+    assert_clean(
+        "\
+declare var blank: null;
+var probe: string = blank;
+",
+        "a bare null annotation stays null",
+    );
+}
+
+// ── The array-literal path #16578 already owned still holds ──
+
+/// Guards against the checker-side post-pass and the new solver-side reduction
+/// disagreeing: the inferred element type still widens `"s"` to `string` before
+/// the nullish sibling is absorbed.
+#[test]
+fn array_literal_element_union_still_widens_then_absorbs() {
+    assert_renders_as(
+        "\
+var samples = [\"s\", undefined];
+var probe: string = samples;
+",
+        "string[]",
+        "the array-literal element union widens the literal, then absorbs undefined",
+    );
+}
+
+// ── Unions the solver constructs, never written in source ──
+//
+// These are the shapes a checker-layer fix over syntactic union type nodes
+// (#16593) structurally cannot reach: the union that survives conditional-type
+// resolution, a mapped type's instantiated property type, and the union a
+// function's return type is *inferred* from. All three are oracle-pinned to
+// `number` against `typescript@7.0.2`.
+
+/// The false branch of a resolved conditional still carries its nullish
+/// constituent unless the reduction happens where the branch type is built.
+#[test]
+fn resolved_conditional_branch_absorbs_undefined() {
+    assert_renders_as(
+        "\
+type Verdict<TIn> = TIn extends string ? string | null : number | undefined;
+declare var settled: Verdict<number>;
+var probe: string = settled;
+",
+        "number",
+        "a resolved conditional branch absorbs its undefined constituent",
+    );
+}
+
+/// A mapped type's property type is instantiated by the solver, not resolved
+/// from the source union node.
+#[test]
+fn mapped_type_property_absorbs_null() {
+    assert_renders_as(
+        "\
+type Lookup = { [K in \"a\"]: number | null };
+declare var table: Lookup;
+var probe: string = table.a;
+",
+        "number",
+        "a mapped type's property type absorbs its null constituent",
+    );
+}
+
+/// Still red, and **not** this seam's bug — pinned here so the distinction is
+/// recorded rather than rediscovered.
+///
+/// tsz reports *nothing* for this row. If the inferred return type were
+/// `number | null` the assignment would report `TS2322` naming `number | null`,
+/// which the reduction would then fix. It reports nothing because `return null`
+/// in non-strict mode widens to `any` before any union is built
+/// (`widen_nullish_to_any_deep`, the #16384/#16393/#16396 widening-provenance
+/// family), so the BCT over the return statements is `any` and no union with a
+/// nullish constituent is ever constructed. There is nothing for union
+/// construction to absorb.
+///
+/// Fixing it means the widening gate must not treat a bare `return null` beside
+/// a non-nullish `return` as a widening source — a different owner from this
+/// change, and a false negative rather than a display difference.
+#[test]
+#[ignore = "belongs to the non-strict nullish *widening* family (#16384/#16396), not union construction: `return null` widens to `any` before any union exists"]
+fn inferred_return_union_absorbs_null() {
+    assert_renders_as(
+        "\
+function tally() {
+    if (1) {
+        return 1;
+    }
+    return null;
+}
+var probe: string = tally();
+",
+        "number",
+        "an inferred return union absorbs its null constituent",
+    );
+}

--- a/crates/tsz-solver/src/intern/core/interner_tests.rs
+++ b/crates/tsz-solver/src/intern/core/interner_tests.rs
@@ -835,20 +835,54 @@ mod nonstrict_nullish_union_tests {
     }
 
     #[test]
-    fn nonstrict_keeps_all_nullish_union() {
+    fn nonstrict_all_nullish_union_collapses_to_the_scalar_null() {
         let interner = nonstrict();
-        // No non-nullish sibling to absorb into: the union must stay as-is, never
-        // collapse to `never` (#16580 row a6).
-        let all_nullish = interner.union(vec![TypeId::NULL, TypeId::UNDEFINED]);
-        assert_ne!(
-            all_nullish,
-            TypeId::NEVER,
-            "null | undefined must not become never"
+        // tsc's `addTypeToUnion` exclusion is unconditional, so an all-nullish
+        // union leaves `typeSet` empty and `getUnionType`'s empty-set branch
+        // returns a *scalar*: `null` if seen, else `undefined`, else `never`.
+        // It must not become `never` (#16580 row a6), and it must not stay a
+        // two-member union either — a `Union`'s flags are `Union`, not
+        // `Nullable`, so a surviving union is invisible to the non-strict
+        // non-null arm.
+        //
+        // Oracle, `typescript@7.0.2`, `--strict false --strictNullChecks false`:
+        //   declare var a: null | undefined; a.foo;  -> TS18047 possibly 'null'
+        //   declare var b: undefined | null; b.foo;  -> TS18047 possibly 'null'
+        //   declare var d: undefined;        d.foo;  -> TS18048 possibly 'undefined'
+        assert_eq!(
+            interner.union(vec![TypeId::NULL, TypeId::UNDEFINED]),
+            TypeId::NULL,
+            "null | undefined -> null"
         );
-        let members = union_members(&interner, all_nullish).expect("all-nullish stays a union");
+        // `null` wins regardless of the order the members arrive in: tsc keys on
+        // `includes & TypeFlags.Null` having been *seen*, not on position.
+        assert_eq!(
+            interner.union(vec![TypeId::UNDEFINED, TypeId::NULL]),
+            TypeId::NULL,
+            "undefined | null -> null, order-independent"
+        );
+        // With no `null` seen, `undefined` is the survivor rather than `never`.
+        assert_eq!(
+            interner.union(vec![TypeId::UNDEFINED, TypeId::NEVER]),
+            TypeId::UNDEFINED,
+            "undefined | never -> undefined"
+        );
+        // A lone nullish scalar is untouched in both flavours.
+        assert_eq!(interner.union(vec![TypeId::NULL]), TypeId::NULL);
+        assert_eq!(interner.union(vec![TypeId::UNDEFINED]), TypeId::UNDEFINED);
+    }
+
+    #[test]
+    fn strict_keeps_the_all_nullish_union_intact() {
+        // The negative control for the collapse above: with `strictNullChecks`
+        // on, `null | undefined` is a real two-member union and must stay one.
+        let interner = TypeInterner::new();
+        interner.set_strict_null_checks(true);
+        let all_nullish = interner.union(vec![TypeId::NULL, TypeId::UNDEFINED]);
+        let members = union_members(&interner, all_nullish).expect("strict keeps a union");
         assert!(
             members.contains(&TypeId::NULL) && members.contains(&TypeId::UNDEFINED),
-            "all-nullish union must keep both members: {members:?}"
+            "strict mode must keep both members: {members:?}"
         );
     }
 

--- a/crates/tsz-solver/src/intern/normalize.rs
+++ b/crates/tsz-solver/src/intern/normalize.rs
@@ -131,10 +131,26 @@ impl TypeInterner {
     /// tsc's `addTypeToUnion` drops a `null`/`undefined` constituent from every
     /// union it constructs when `strictNullChecks` is off: the nullable is a
     /// subtype of every non-nullish type there, so it is never added to the member
-    /// set (`checker.ts`), independent of the requested `UnionReduction` mode. The
-    /// lone survivor is an *all-nullish* union (`null | undefined`, or `null`
-    /// alone) — with no non-nullish sibling to absorb into, tsc keeps the nullish
-    /// members rather than collapsing to `never`.
+    /// set (`checker.ts`), independent of the requested `UnionReduction` mode.
+    ///
+    /// The exclusion is **unconditional**, so an *all-nullish* union leaves
+    /// `typeSet` empty and `getUnionType` falls through to its empty-set branch:
+    ///
+    /// ```text
+    /// includes & TypeFlags.Null      ? nullType :
+    /// includes & TypeFlags.Undefined ? undefinedType :
+    ///                                  neverType
+    /// ```
+    ///
+    /// So `null | undefined` is the **scalar** `null` — `null` preferred over
+    /// `undefined` — not a surviving two-member union, and not `never`. The
+    /// distinction is invisible to assignability (both answers are assignable
+    /// everywhere with the flag off) and shows up only where a check keys on
+    /// `type.flags & Nullable`: a `Union`'s flags are `Union`, so the non-strict
+    /// non-null arm stays silent on a union and fires on the scalar. That is what
+    /// makes `interface I { [k: string]: null | undefined }` report tsc's
+    /// `TS18047` — see `non_strict_non_null_check_narrows_tests`, whose header
+    /// documents the rule ("a union never triggers the non-strict arm").
     ///
     /// This is the general union-construction seam #16580 calls for. The checker's
     /// array-literal element path (#16574) was one witness of a rule that has to
@@ -154,16 +170,33 @@ impl TypeInterner {
         if self.strict_null_checks() {
             return;
         }
-        let mut has_nullish = false;
+        let mut has_null = false;
+        let mut has_undefined = false;
         let mut has_non_nullish = false;
         for &id in flat.iter() {
-            if id == TypeId::NULL || id == TypeId::UNDEFINED {
-                has_nullish = true;
+            if id == TypeId::NULL {
+                has_null = true;
+            } else if id == TypeId::UNDEFINED {
+                has_undefined = true;
             } else if id != TypeId::NEVER {
                 has_non_nullish = true;
             }
         }
-        if !has_nullish || !has_non_nullish {
+        if !has_null && !has_undefined {
+            return;
+        }
+        if !has_non_nullish {
+            // Every member was nullish (`never` aside), so tsc's `typeSet` is
+            // empty and the empty-set branch picks a single scalar. Collapsing to
+            // that scalar rather than leaving the union intact is what lets a
+            // `type.flags & Nullable` check see it.
+            let survivor = if has_null {
+                TypeId::NULL
+            } else {
+                TypeId::UNDEFINED
+            };
+            flat.clear();
+            flat.push(survivor);
             return;
         }
         flat.retain(|id| *id != TypeId::NULL && *id != TypeId::UNDEFINED);


### PR DESCRIPTION
Rebased onto current `main` (`1b0cd96`) and re-aimed, as suggested. Head `398aa1c`.

**This is now a much smaller and more specific PR than it was.** #16602 landed the construction-seam move, and I confirmed it closed rows b2/b3 of #16580 — all 18 of my original absorption rows pass on current `main` with `crates/tsz-solver/` untouched. That part of my branch is genuinely superseded and is gone. What is left is one real gap in #16602, plus the tests.

## The gap

`reduce_nonstrict_nullish_members` (`intern/normalize.rs:166`) returns early when there is no non-nullish sibling, leaving `null | undefined` as a **two-member union**. Its doc comment states the model: *"with no non-nullish sibling to absorb into, tsc keeps the nullish members rather than collapsing to `never`."*

That is half right. tsc's `addTypeToUnion` exclusion is **unconditional** — both nullish members are excluded regardless of what else is present — so an all-nullish union leaves `typeSet` empty and `getUnionType` falls through to its empty-set branch:

```ts
includes & TypeFlags.Null      ? nullType :
includes & TypeFlags.Undefined ? undefinedType :
                                 neverType
```

The answer is the **scalar `null`** — not a surviving union, and (correctly, as #16602 says) not `never`.

### Why nobody caught it

The two answers are indistinguishable to every assignability test, because `null | undefined` and `null` are both assignable to everything with the flag off. #16580's own a6 row is clean under either. The distinction is observable only where a check keys on `type.flags & Nullable`: a `Union`'s flags are `Union`, so a surviving union is **silent** exactly where the scalar reports.

That check is the non-strict non-null arm, and `non_strict_non_null_check_narrows_tests`'s own header already states the rule — *"a union never triggers the non-strict arm"*.

### Oracle, `typescript@7.0.2`, `--strict false --strictNullChecks false --target es2015`

```
declare var a: null | undefined; a.foo;   -> TS18047 'a' is possibly 'null'.
declare var b: undefined | null; b.foo;   -> TS18047 'b' is possibly 'null'.
type Both = undefined | null; c.foo;      -> TS18047 'c' is possibly 'null'.
declare var d: undefined;        d.foo;   -> TS18048 'd' is possibly 'undefined'.
declare var e: null;             e.foo;   -> TS18047 'e' is possibly 'null'.
```

Rows 1 and 2 together pin that `null` wins on **presence, not position** — tsc keys on `includes & TypeFlags.Null` having been seen, not on member order. Row 4 is the discriminating negative: with no `null` among the members, `undefined` survives and the arm reports `TS18048`, so this is not "rewrite nullish to null".

## Two tests were pinning the wrong answer

- **`nonstrict_keeps_all_nullish_union`** (`interner_tests.rs`, from #16602) asserted the union survives with both members. Re-pinned to the scalar, with a new strict-mode control asserting the two-member union *is* kept when the flag is on.
- **`interface_index_signature_value_is_a_known_unfixed_residual`** asserted the non-strict row reports nothing; tsc reports `TS18047`. An index-signature value is lowered by `tsz-lowering`, which no syntactic resolver sees, making it the one end-to-end witness in the tree that isolates this seam. Renamed to `interface_index_signature_value_reports_the_reduced_single_cause` and re-pinned in both modes, with the strict-mode `TS18047`-must-be-zero control kept.

## Non-vacuity, stated precisely

With `crates/tsz-solver/src/intern/normalize.rs` reverted to `main` (`git diff origin/main` on that path verified empty), **two tests fail**:

```
tsz-solver  nonstrict_all_nullish_union_collapses_to_the_scalar_null
              left: TypeId(130)   right: TypeId(7)        # a Union node vs NULL
tsz-checker interface_index_signature_value_reports_the_reduced_single_cause
              left: []            right: [18047]
```

And the honest converse, which is in the test file as a comment: the **four** directly-annotated all-nullish rows (`declare var vacant: null | undefined; vacant.foo;` and friends) pass with *or without* this change, because #16593's syntactic resolver also handles a written annotation. They are there to pin that the two paths agree, not as evidence. I would rather say which rows discriminate than let a green count imply they all do.

## Also kept

`nonstrict_union_nullish_absorption_tests.rs` (22 rows + 1 `#[ignore]`d). All pass on `main` today; retained as a regression floor at your request, oracle-pinned, binder names varied per row. It covers a matrix distinct from #16593's and #16602's files: `void` alone and `void` beside an absorbed `null`, alias-display preservation when two members survive, generic-alias instantiation, and the array-literal path from #16578.

The `#[ignore]`d row is #16580's b5, with its owner recorded: tsz reports **nothing** for `function g() { if (1) return 1; return null }` because `return null` widens to `any` before any union is constructed (`widen_nullish_to_any_deep`, the #16384/#16393/#16396 widening-provenance family), so no nullish-carrying union ever exists to reduce. Different owner; it should stay open on #16580 after this lands. b2/b3 are closed by #16602.

## Goal
Goal: hold

## Verification

At head `398aa1c` on base `1b0cd96`:

- `cargo fmt --all` — clean. `cargo clippy -p tsz-solver -p tsz-checker --lib --all-features -- -D warnings` — clean. Pre-commit clippy + arch-size guard passed.
- `cargo test -p tsz-solver --lib` — **7651 / 0**.
- `cargo test -p tsz-checker --lib` targeted: `nonstrict` **88 / 0**, `non_strict_non_null` **27 / 0**, `null` **442 / 0**, `narrow` **435 / 0**, `union` **719 / 0**, `optional` **310 / 0**.
- Negative control above.
- Oracle rows all confirmed against a real `typescript@7.0.2` run.

**Owed:** conformance and emit have not been re-run since the rebase. The prior head measured conformance byte-identical to `main`, but this diff is *different* from that one — the all-nullish collapse is new — so that result does not carry over. Blast radius is narrower than before (only all-nullish member sets, only non-strict), but `./scripts/emit/run.sh --skip-build` (JS 11562 / DTS 1375, zero headroom) and a conformance pass should exist before this queues. Happy to have you re-run the matrix as offered.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Cinnabar