### PR TITLE
fix(cli): TS18054 joins the class-static-block grammar family in is_parser_grammar_code

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -581,6 +581,7 @@ const fn is_parser_grammar_code(code: u32) -> bool {
         | 8038 // Decorators may not appear after 'export' or 'export default' if they also appear before 'export'
         | 18037 // 'await' expression cannot be used inside a class static block
         | 18041 // A 'return' statement cannot be used inside a class static block
+        | 18054 // 'await using' statements cannot be used inside a class static block
     )
 }
 
@@ -1739,3 +1740,7 @@ mod for_in_using_declaration_grammar_tests;
 #[cfg(test)]
 #[path = "check_utils/filter_trigger_unification_tests.rs"]
 mod filter_trigger_unification_tests;
+
+#[cfg(test)]
+#[path = "check_utils/class_static_block_grammar_tests.rs"]
+mod class_static_block_grammar_tests;

--- a/crates/tsz-cli/src/driver/check_utils/class_static_block_grammar_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/class_static_block_grammar_tests.rs
@@ -1,0 +1,157 @@
+//! Unit tests for the class-static-block slice of `is_parser_grammar_code`
+//! (#16279's general shape). Split into its own file rather than growing
+//! `tests.rs` past the 2000-line limit (already over before this change).
+//!
+//! tsc's class-static-block grammar check reports TS18037 ('await' expression
+//! cannot be used inside a class static block), TS18041 (a 'return' statement
+//! cannot be used inside a class static block) and TS18054 ('await using'
+//! statements cannot be used inside a class static block) for violations
+//! inside the same construct, all parser-emitted in tsz
+//! (`crates/tsz-parser/src/parser/state_expressions_unary.rs`,
+//! `state_statements.rs`, `state_declarations_exports.rs`). Before this fix,
+//! `is_parser_grammar_code` listed TS18037/TS18041 but not TS18054, so an
+//! `await using` violation inside a static block counted as a "real" parse
+//! error and silently deleted the listed TS18037/TS18041 diagnostics from the
+//! same file, while itself never being suppressed alongside an unrelated real
+//! syntax error the way tsc suppresses it.
+//!
+//! Oracle-verified against `typescript@7.0.2`:
+//! - Direction A: a static block with both `await using x = foo();` and a
+//!   bare `await bar();` reports both TS18054 and TS18037.
+//! - Direction B: the same `await using` violation plus an unrelated real
+//!   syntax error (`let y: = 1;`) reports only the real syntax error
+//!   (TS1110) — tsc drops TS18054 entirely, confirming it belongs in the
+//!   suppression list alongside its siblings.
+
+use super::*;
+
+#[test]
+fn filtered_parse_diagnostics_suppresses_ts18054_when_real_parse_error_present() {
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 20,
+            length: 6,
+            message: "'await using' statements cannot be used inside a class static block."
+                .to_string(),
+            code: 18054,
+        },
+        ParseDiagnostic {
+            start: 60,
+            length: 1,
+            message: "Type expected.".to_string(),
+            code: 1110,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&18054),
+        "TS18054 should be suppressed when a real parse error (TS1110) is present, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1110),
+        "TS1110 (real parse error) should survive, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_keeps_ts18054_when_alone() {
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![ParseDiagnostic {
+        start: 20,
+        length: 6,
+        message: "'await using' statements cannot be used inside a class static block.".to_string(),
+        code: 18054,
+    }];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&18054),
+        "TS18054 should be kept when it is the only diagnostic, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_ts18054_does_not_self_suppress_listed_sibling() {
+    use tsz::parser::ParseDiagnostic;
+
+    // Before the fix, TS18054 was unlisted in `is_parser_grammar_code`, so it
+    // counted as a "real" non-grammar parse error under
+    // `has_non_grammar_parse_error` and silently deleted every *listed*
+    // sibling in the same file — here, the already-listed TS18037 from the
+    // same static block.
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 12,
+            length: 6,
+            message: "'await' expression cannot be used inside a class static block.".to_string(),
+            code: 18037,
+        },
+        ParseDiagnostic {
+            start: 80,
+            length: 6,
+            message: "'await using' statements cannot be used inside a class static block."
+                .to_string(),
+            code: 18054,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&18037),
+        "TS18037 must not be self-suppressed by unlisted TS18054, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&18054),
+        "TS18054 should survive when it is the only non-grammar-looking diagnostic, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_ts18054_does_not_self_suppress_ts18041_sibling() {
+    use tsz::parser::ParseDiagnostic;
+
+    // Same shape as above, against the other already-listed static-block
+    // sibling: TS18041 (a 'return' statement inside a class static block).
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 12,
+            length: 6,
+            message: "A 'return' statement cannot be used inside a class static block.".to_string(),
+            code: 18041,
+        },
+        ParseDiagnostic {
+            start: 80,
+            length: 6,
+            message: "'await using' statements cannot be used inside a class static block."
+                .to_string(),
+            code: 18054,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&18041),
+        "TS18041 must not be self-suppressed by unlisted TS18054, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&18054),
+        "TS18054 should survive when it is the only non-grammar-looking diagnostic, got: {codes:?}"
+    );
+}
+
+#[test]
+fn is_parser_grammar_code_accepts_class_static_block_family() {
+    // Guard the full three-member family together so a future edit cannot
+    // silently drop one while touching the others.
+    assert!(is_parser_grammar_code(18037));
+    assert!(is_parser_grammar_code(18041));
+    assert!(is_parser_grammar_code(18054));
+}


### PR DESCRIPTION
Closes another slice of #16279 (my own #16584 already landed the using-declaration family — TS1492 alongside TS1493/TS1494).

## The gap

tsc's class-static-block grammar check reports three sibling codes for violations inside a `static {}` block, all parser-emitted in tsz:

- TS18037 — `'await' expression cannot be used inside a class static block.` (`state_expressions_unary.rs`)
- TS18041 — `A 'return' statement cannot be used inside a class static block.` (`state_statements.rs`)
- TS18054 — `'await using' statements cannot be used inside a class static block.` (`state_statements.rs`, `state_declarations_exports.rs`)

`is_parser_grammar_code` (`crates/tsz-cli/src/driver/check_utils.rs`) listed TS18037 and TS18041 but not TS18054. Per #16279's mechanism, `has_non_grammar_parse_error` (now routed through `is_non_suppressing_parse_error` since #16583) treats an unlisted parser-emitted grammar code as a genuine structural parse error — so a file with an `await using` violation inside a static block silently lost every *listed* sibling grammar diagnostic in that same file, and TS18054 itself was never suppressed alongside an unrelated real syntax error the way tsc suppresses it.

## Structural rule

When a class static block contains an `await using` declaration, `tsc` suppresses `TS18054` alongside a real syntax error in the same file, exactly like its `TS18037`/`TS18041` siblings; tsz now does the same through `is_parser_grammar_code` (checker.rs's `grammarErrorOnNode`-equivalent suppression list), which `is_non_suppressing_parse_error` already builds on by construction.

## Oracle verification (typescript@7.0.2)

**Direction A** — both siblings alone in a file, no real syntax error:
```ts
declare function foo(): any;
declare function bar(): any;
class C {
  static {
    await using x = foo();
    await bar();
  }
}
```
tsc reports both `TS18054` (5,5) and `TS18037` (6,5).

**Direction B** — the candidate plus a genuinely unrelated syntax error:
```ts
declare function foo(): any;
class C {
  static {
    await using x = foo();
  }
}
let y: = 1;
```
tsc reports only `TS1110` (Type expected) — `TS18054` is dropped entirely, confirming it belongs in the suppression list.

## Verification

- `cargo test -p tsz-cli --lib -- check_utils::class_static_block_grammar_tests check_utils::rest_parameter_grammar_tests check_utils::for_in_using_declaration_grammar_tests check_utils::for_in_of_single_declaration_grammar_tests check_utils::audit_round_3_grammar_tests check_utils::parser_grammar_non_suppressing_tests check_utils::regex_grammar_suppression_tests check_utils::heritage_clause_tests check_utils::filter_trigger_unification_tests`: **53 passed, 0 failed** — 5 new tests plus every sibling grammar-audit suite, confirming no regression to the existing family entries.
- `cargo fmt -p tsz-cli -- --check`: clean.
- Pre-commit hook (clippy `-p tsz-cli` + architecture guard + local verification): passed at the committed head.
- New tests live in their own file (`check_utils/class_static_block_grammar_tests.rs`), not `tests.rs`, which is already over the repo's 2000-line ceiling.
- Not run this session (time budget): `compare-to-parent.sh` / the full conformance snapshot. Expected conformance-neutral per direct precedent — this is a single-code addition to the same `matches!` list as #16584/#16320/#16278, each of which independently measured 0 newly failing / 0 newly passing, gated on a rare static-block-plus-unrelated-syntax-error shape the TypeScript conformance corpus is not known to contain. A future session should confirm with `compare-to-parent.sh` before this lands if a stricter gate is wanted.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01KvPyY8Xk3QBkGcznZAytvF)_