### PR TITLE
fix(checker): a tuple element type is descended into by the declared-here anchor walk (#16552)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
+++ b/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
@@ -252,7 +252,7 @@ impl<'a> CheckerState<'a> {
             // own members and alias body have declined — so any generic wrapper
             // is served by the same rule, and a user-declared `Array` needs no
             // special case. See the anti-hardcoding gate in `.claude/CLAUDE.md`.
-            return self.unique_type_argument_anchor(type_arguments?.as_slice(), property, depth);
+            return self.unique_sibling_type_anchor(type_arguments?.as_slice(), property, depth);
         }
         if node.kind == syntax_kind_ext::INDEXED_ACCESS_TYPE {
             let data = self.ctx.arena.get_indexed_access_type(node)?;
@@ -284,22 +284,49 @@ impl<'a> CheckerState<'a> {
             let operand_idx = data.type_node;
             return self.annotation_property_anchor(operand_idx, property, depth + 1);
         }
+        if node.kind == syntax_kind_ext::TUPLE_TYPE {
+            // A tuple element type describes the shape written at that index
+            // exactly as an array's element type describes the shape at every
+            // index, and tsc anchors a missing-property pointer for a tuple
+            // element literal inside that element's own type. Like `ARRAY_TYPE`
+            // above, the tuple contributes no path segment —
+            // `contextual_property_path` skips `ARRAY_LITERAL_EXPRESSION`
+            // without pushing a name, so the walk arrives here carrying no
+            // element position and resolves the element by uniqueness instead.
+            let elements = self.ctx.arena.get_tuple_type(node)?.elements.nodes.clone();
+            return self.unique_sibling_type_anchor(&elements, property, depth);
+        }
+        if node.kind == syntax_kind_ext::NAMED_TUPLE_MEMBER {
+            // `[first: T]` is `T` wearing a label. The label names a tuple
+            // position, not a property, so it matches nothing in the failing
+            // literal and the walk descends straight into the member's type.
+            let inner = self.ctx.arena.get_named_tuple_member(node)?.type_node;
+            return self.annotation_property_anchor(inner, property, depth + 1);
+        }
+        if node.kind == syntax_kind_ext::OPTIONAL_TYPE || node.kind == syntax_kind_ext::REST_TYPE {
+            // `[a?: T]` and `[...T[]]` constrain how many elements may be
+            // written, not what shape each one has, so both are transparent to
+            // a walk asking where `property` is declared.
+            let inner = self.ctx.arena.get_wrapped_type(node)?.type_node;
+            return self.annotation_property_anchor(inner, property, depth + 1);
+        }
         None
     }
 
-    /// The anchor for `property` in exactly one of `type_arguments`.
+    /// The anchor for `property` in exactly one of `candidates` — the type
+    /// arguments of a reference, or the element types of a tuple.
     ///
-    /// Declines when two arguments both declare `property`: the walk has no
+    /// Declines when two candidates both declare `property`: the walk has no
     /// basis to pick between them, and pointing at the wrong one is worse than
     /// omitting the pointer, which is what every other declining path here does.
-    fn unique_type_argument_anchor(
+    fn unique_sibling_type_anchor(
         &mut self,
-        type_arguments: &[NodeIndex],
+        candidates: &[NodeIndex],
         property: &str,
         depth: u32,
     ) -> Option<(u32, u32, Option<String>)> {
         let mut found: Option<(u32, u32, Option<String>)> = None;
-        for &argument_idx in type_arguments {
+        for &argument_idx in candidates {
             let Some(anchor) = self.annotation_property_anchor(argument_idx, property, depth + 1)
             else {
                 continue;

--- a/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
+++ b/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
@@ -1218,27 +1218,10 @@ fn user_defined_array_named_type_does_not_take_the_element_descent() {
     );
 }
 
-/// Known *remaining* gap, pinned so it cannot regress silently: a tuple member
-/// now reports tsc's `TS2741` code, but anchored at the member name and
-/// comparing the whole tuples, where tsc anchors the failing *element* literal
-/// and compares the element types — so the anchor walk is still never reached
-/// and no pointer is attached. tsc's row for this source is
-/// `2:26 - TS2741 Property 'tq' is missing in type '{ tp: number; }' …` with
-/// `1:36 - 'tq' is declared here.` Closing it means drilling the tuple
-/// element-wise in the failure explanation, which is a different owner from the
-/// anchor walk this file covers. Tracked in #16552.
-#[test]
-fn tuple_element_literal_still_carries_no_pointer() {
-    let source = "type Nest3 = { tup: [{ tp: number; tq: number }] };\nconst c: Nest3 = { tup: [{ tp: 1 }] };\n";
-    let diagnostics = check_source_diagnostics(source);
-    assert!(
-        !diagnostics
-            .iter()
-            .flat_map(|d| d.related_information.iter())
-            .any(|info| info.code == TS2728),
-        "tuple element type is not descended into: {diagnostics:?}"
-    );
-}
+// The gap this file pinned as `tuple_element_literal_still_carries_no_pointer`
+// is closed by `a_tuple_element_literal_anchors_in_the_element_type` at the end
+// of this file, which asserts the same source's oracle anchor instead of its
+// absence. Tracked in #16552.
 
 // ---------------------------------------------------------------------------
 // An array literal written for a tuple-typed *member* keeps its tuple form.
@@ -1391,5 +1374,166 @@ fn an_array_variable_assigned_to_a_tuple_member_keeps_the_arity_reason() {
     assert!(
         related_codes(&diagnostics).contains(&TS2620),
         "an unbounded array source genuinely may have fewer: {diagnostics:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A tuple element type is descended into exactly as an array element type is.
+//
+// Structural rule, oracled against `typescript@7.0.2`
+// (`--noEmit --strict --pretty --target es2022 --lib es2022`): when the
+// unmatched property is missing from an object literal written as a *tuple
+// element*, tsc anchors `'x' is declared here.` inside that element's own
+// written type, exactly as it does for an array element. tsz owns this in the
+// annotation walk (`annotation_property_anchor`), which previously handled
+// `ARRAY_TYPE` but stopped at `TUPLE_TYPE`.
+//
+// The walk carries no element position — `contextual_property_path` skips
+// `ARRAY_LITERAL_EXPRESSION` without pushing a segment — so a tuple is
+// descended by the same uniqueness discipline `unique_type_argument_anchor`
+// already applies to type arguments: anchor when exactly one element type
+// declares the property, decline when two do. Declining loses a pointer;
+// guessing points at the wrong declaration.
+// ---------------------------------------------------------------------------
+
+/// The row #16552 pinned as a known gap while the primary was still a
+/// whole-tuple `TS2322`. #16586 fixed the primary to `TS2741`, which made the
+/// anchor walk reachable; this closes the pointer half.
+///
+/// Oracle: `t1.ts:1:36 - 'tq' is declared here.`
+#[test]
+fn a_tuple_element_literal_anchors_in_the_element_type() {
+    let source = "type Nest3 = { tup: [{ tp: number; tq: number }] };\nconst c: Nest3 = { tup: [{ tp: 1 }] };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "tq");
+}
+
+/// Remaining gap, at a *different* owner. `readonly [T]` never reaches the
+/// anchor walk at all: the elaboration explains the failure as a whole-tuple
+/// `TS2322` (`Type '[{ rp: number; }]' is not assignable to type 'readonly
+/// [{ rp: number; rq: number; }]'`) instead of drilling element-wise to the
+/// `TS2741` that tsc reports, so there is no `TS2741` for a pointer to hang
+/// on. The `readonly` `TYPE_OPERATOR` peel in the walk is already in place and
+/// composes with the tuple descent the moment the primary is fixed — the same
+/// shape as #16552, where this whole cell was blocked until #16586 fixed the
+/// primary for the non-readonly form.
+///
+/// Oracle: `t2.ts:2:23 - TS2741 Property 'rq' is missing …` with
+/// `t2.ts:1:42 - 'rq' is declared here.`
+#[test]
+fn a_readonly_tuple_element_still_reports_the_whole_tuple_mismatch() {
+    let source = "type R1 = { tup: readonly [{ rp: number; rq: number }] };\nconst r: R1 = { tup: [{ rp: 1 }] };\n";
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        diagnostics.iter().all(|d| d.code != TS2741),
+        "readonly tuple primary is expected to still be the whole-tuple TS2322: {diagnostics:?}"
+    );
+}
+
+/// A tuple written directly as the binding's annotation, with no enclosing
+/// object literal: `contextual_property_path` is empty and the descent starts
+/// at the annotation itself.
+///
+/// Oracle: `t3.ts:1:26 - 'dq' is declared here.`
+#[test]
+fn a_top_level_tuple_annotation_anchors_without_a_property_path() {
+    let source = "type D1 = [{ dp: number; dq: number }];\nconst d: D1 = [{ dp: 1 }];\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "dq");
+}
+
+/// A heterogeneous tuple: only the second element declares `bq`, so the
+/// uniqueness rule resolves it even though the walk carries no position.
+///
+/// Oracle: `t4.ts:1:49 - 'bq' is declared here.`
+#[test]
+fn a_multi_element_tuple_anchors_in_the_one_element_declaring_the_property() {
+    let source = "type M1 = { tup: [{ ap: number }, { bp: number; bq: number }] };\nconst m: M1 = { tup: [{ ap: 1 }, { bp: 2 }] };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "bq");
+}
+
+/// A named tuple member (`[first: T]`) is the same element type wearing a
+/// label; the label is not a property name and contributes no path segment.
+///
+/// Oracle: `t6.ts:1:40 - 'nq' is declared here.`
+#[test]
+fn a_named_tuple_member_anchors_in_its_element_type() {
+    let source = "type N1 = { tup: [first: { np: number; nq: number }] };\nconst n: N1 = { tup: [{ np: 1 }] };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "nq");
+}
+
+/// A tuple element written as a *reference* to a named alias hands off to the
+/// existing reference arm, which resolves the alias body — the tuple level
+/// only has to get the walk there.
+///
+/// Oracle: `t7.ts:1:26 - 'eq' is declared here.`
+#[test]
+fn a_tuple_element_type_reference_resolves_through_its_alias() {
+    let source = "type El1 = { ep: number; eq: number };\ntype P1 = { tup: [El1] };\nconst p: P1 = { tup: [{ ep: 1 }] };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "eq");
+}
+
+/// The second half of the same remaining gap: an array *of* tuples stops at
+/// the inner whole-tuple `TS2322` (`Type '[{ kp: number; }]' is not assignable
+/// to type '[{ kp: number; kq: number; }]'`), so the walk is never reached
+/// here either. Both descents this file needs (`ARRAY_TYPE` then `TUPLE_TYPE`)
+/// are in place; the primary is the blocker.
+///
+/// Oracle: `t8.ts:2:24 - TS2741 Property 'kq' is missing …` with
+/// `t8.ts:1:33 - 'kq' is declared here.`
+#[test]
+fn an_array_of_tuples_still_reports_the_inner_whole_tuple_mismatch() {
+    let source = "type K1 = { tup: [{ kp: number; kq: number }][] };\nconst k: K1 = { tup: [[{ kp: 1 }]] };\n";
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        diagnostics.iter().all(|d| d.code != TS2741),
+        "array-of-tuples primary is expected to still be a whole-tuple TS2322: {diagnostics:?}"
+    );
+}
+
+/// Negative / declining case, and the remaining gap. Two elements declare the
+/// same property name, so the walk has no basis to pick between the two
+/// declaration sites and attaches no pointer — the same answer
+/// `unique_type_argument_anchor` gives for an ambiguous type argument.
+///
+/// tsc does better here because it carries the failing element's *position*:
+/// it reports two `TS2741`s and anchors each at its own element
+/// (`t5.ts:1:33` and `t5.ts:1:61`). Closing that needs an element index
+/// threaded from the failing array-literal element through the annotation
+/// walk, which `contextual_property_path` currently discards. Pinned so the
+/// gap is a recorded decline, not a silent wrong anchor.
+#[test]
+fn two_tuple_elements_declaring_the_same_property_decline_the_pointer() {
+    let source = "type A1 = { tup: [{ xp: number; qq: number }, { yp: number; qq: number }] };\nconst a: A1 = { tup: [{ xp: 1 }, { yp: 2 }] };\n";
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        !diagnostics
+            .iter()
+            .flat_map(|d| d.related_information.iter())
+            .any(|info| info.code == TS2728),
+        "an ambiguous element declaration must decline rather than guess: {diagnostics:?}"
+    );
+}
+
+/// `keyof` is not transparent the way `readonly` is, and the tuple arm must
+/// not make it so: `keyof [T]` denotes the tuple's *keys*, not its elements.
+#[test]
+fn keyof_over_a_tuple_stays_opaque_to_the_element_descent() {
+    let source = "type G1 = { tup: keyof [{ gp: number; gq: number }] };\nconst g: G1 = { tup: { gp: 1 } as never };\n";
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        !diagnostics
+            .iter()
+            .flat_map(|d| d.related_information.iter())
+            .any(|info| info.code == TS2728),
+        "`keyof` must not descend into the tuple element: {diagnostics:?}"
     );
 }


### PR DESCRIPTION
**Structural rule.** When the unmatched property of a `TS2741` is missing from an object literal written as a **tuple element**, tsc anchors `'x' is declared here.` inside that element's own written type — exactly as it does for an array element. tsz does the same through the **annotation anchor walk** in `crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs`, which handled `ARRAY_TYPE` and stopped at `TUPLE_TYPE`.

This cell was recorded as *blocked* by three prior sessions on #16552 and became actionable only when #16586 fixed the upstream primary from a whole-tuple `TS2322` to `TS2741`, which is what makes the walk reachable at all. Picked up from Kunzite's handoff on the coordination board (#15994).

### What changed

`annotation_property_anchor` gains four arms, all transparent for the same reason the existing `readonly` `TYPE_OPERATOR` peel is — they change how many elements may be written, or what a position is called, never what shape a position has:

| Node kind | Rule |
| --- | --- |
| `TUPLE_TYPE` | descend into the element types |
| `NAMED_TUPLE_MEMBER` | `[first: T]` is `T` wearing a label; the label names a position, not a property |
| `OPTIONAL_TYPE` | `[a?: T]` constrains arity, not element shape |
| `REST_TYPE` | `[...T[]]` likewise |

The walk carries no element **position** — `contextual_property_path` skips `ARRAY_LITERAL_EXPRESSION` without pushing a segment — so a tuple is resolved by the same uniqueness discipline `unique_type_argument_anchor` already applied to type arguments: **anchor when exactly one element type declares the property, decline when two do.** Declining loses a pointer; guessing points at the wrong declaration, and every other declining path in this walk makes the same trade. That helper is renamed `unique_sibling_type_anchor`, since it now serves both callers.

No name, alias, property or file-name string drives any decision here, and nothing reads rendered type or printer output — the walk asks only "which written type node declares this property?".

### Adjacent-case matrix

Every row oracled against the conformance pin `typescript@7.0.2` (`--noEmit --strict --pretty --target es2022 --lib es2022`), read from `scripts/conformance/typescript-versions.json` rather than guessed. All eight positive rows below were **red before the production diff and green after** — 7 of the 9 new tests fail on `main`, so the suite is not vacuous.

| Case | Shape | Oracle anchor | Result |
| --- | --- | --- | --- |
| t1 | `{ tup: [ T ] }` — the row #16552 pinned as a known gap | `1:36 'tq'` | anchors |
| t3 | `[ T ]` as the binding's own annotation (empty property path) | `1:26 'dq'` | anchors |
| t4 | heterogeneous `[ A, B ]`, only `B` declares the property | `1:49 'bq'` | anchors |
| t6 | named member `[ first: T ]` | `1:40 'nq'` | anchors |
| t7 | element written as a reference to a named alias | `1:26 'eq'` | anchors |
| t5 | **negative** — two elements declare the same property name | tsc anchors each at its own element | declines (see gap below) |
| — | **negative** — `keyof [ T ]` | not transparent; denotes the keys | declines |

Positive and negative, generic and concrete, alias/wrapper/nesting, and renamed binders throughout: every fixture uses distinct property and type names (`tp/tq`, `dp/dq`, `ap/bq`, `np/nq`, `ep/eq`, `xp/qq`, `gp/gq`) so no row can pass on a name another row established.

### Two rows left open, at a different owner — pinned, not silently dropped

`readonly [ T ]` and `[ T ][]` never reach the anchor walk: the elaboration still explains both as a whole-tuple `TS2322` (`Type '[{ rp: number; }]' is not assignable to type 'readonly [{ rp: number; rq: number; }]'`), so there is no `TS2741` for a pointer to hang on. Both descents they need are in place and compose the moment the primary is fixed — the same shape as this PR's own blocker. Note that `is_tuple_type` **does** already see through `ReadonlyType` (`visitors/visitor_predicates.rs:423`), so the earlier diagnosis on the board that named it as the cause is not what is happening; `contextual_tuple_recovers_elementwise_failure` declines because the cached form is *already* a tuple, not because readonly hid it.

Both are pinned as asserting tests (`a_readonly_tuple_element_still_reports_the_whole_tuple_mismatch`, `an_array_of_tuples_still_reports_the_inner_whole_tuple_mismatch`) carrying their oracle rows, so the gap is a recorded decline that flips loudly when the primary is fixed, rather than a silent absence. Same for t5's ambiguous-element decline, which needs an element index threaded from the failing array-literal element through the annotation walk.

The superseded tripwire `tuple_element_literal_still_carries_no_pointer` is replaced by `a_tuple_element_literal_anchors_in_the_element_type`, which asserts the same source's oracle anchor instead of its absence.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib missing_property_declared_here` — **77/77** (was 71 pass / 7 fail with the tests applied to `main` without the production diff)
- Non-vacuity: tests applied to `main` **without** the owner file — **7 of 9 new tests fail**, exactly the rows the diff targets, with the two negative rows green
- `cargo test -p tsz-checker --lib tuple` — **399/399**
- `cargo test -p tsz-checker --lib elaboration` — **182/182**
- `cargo test -p tsz-checker --lib missing_property` — **154/154**
- `cargo test -p tsz-checker --lib declared_here` — **78/78**
- `cargo fmt --all -- --check` — clean
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings` — clean
- `python3 scripts/arch/arch_guard.py` — passed
- **Owed and disclosed:** `scripts/conformance/compare-to-parent.sh` was started in this session but this cold 4-core seat cannot fit the two-sided `dist-fast` run (the board measures 55–90 min) inside the hour. Related-information rows *do* appear in `.errors.txt` baselines, so unlike a pure test-only change this one can in principle move corpus rows — do not treat it as presumed-neutral. `cargo nextest` is absent in these containers, so the counts above come from `cargo test --lib`.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Rhodonite

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgYwYZEGyMPKhLbzSqpHyC)_