### PR TITLE
fix(solver): resolve an anonymous concrete mapped type to its member object for display (#15392)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker_mapped_type_tests.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker_mapped_type_tests.rs
@@ -469,3 +469,160 @@ const bad: { [K in E]: number } = { a: 1 };
         "inline anonymous enum mapped type renders the bare literal key (tsc 7.0.2), got: {diag:?}"
     );
 }
+
+/// Fetch the single TS2741 message for a fixture, panicking with context when
+/// absent. Shared by the anonymous-concrete-mapped display matrix below.
+fn ts2741_message(source: &str) -> String {
+    super::diagnostics_for(source)
+        .iter()
+        .find(|diag| diag.code == 2741)
+        .unwrap_or_else(|| panic!("expected TS2741 for:\n{source}"))
+        .message_text
+        .clone()
+}
+
+// A concrete (type-parameter-free) mapped type with a finite key set is
+// resolved by `tsc` to its member object for display — `{ [K in Color]: number }`
+// prints as `{ green: number; red: number; }`, never as its `{ [K in E]: V }`
+// source form. tsz keeps the `Mapped` node live for semantic identity (#15392),
+// so the printer resolves it. An *aliased* mapped keeps its alias name and a
+// *generic* / index-signature mapped keeps its source form; both are pinned as
+// negative controls. Expectations verified against `tsc` 7.0.2
+// (`--strict --target es2022 --lib es2022`).
+
+#[test]
+fn anon_concrete_enum_mapped_target_displays_resolved_member_object() {
+    let msg = ts2741_message(
+        r#"
+enum Color { Red = "red", Green = "green" }
+const bad: { [K in Color]: number } = { red: 1 };
+"#,
+    );
+    assert!(
+        msg.contains("required in type '{ green: number; red: number; }'"),
+        "anonymous concrete enum mapped must display its resolved member object, got: {msg}"
+    );
+    assert!(
+        !msg.contains("[K in"),
+        "must not leak the mapped source form, got: {msg}"
+    );
+}
+
+#[test]
+fn anon_inline_string_union_mapped_target_displays_resolved_members() {
+    let msg = ts2741_message(
+        r#"
+const bad: { [K in "a" | "b"]: number } = { a: 1 };
+"#,
+    );
+    assert!(
+        msg.contains("required in type '{ a: number; b: number; }'"),
+        "inline string-literal-union mapped must display its resolved members, got: {msg}"
+    );
+}
+
+#[test]
+fn anon_aliased_union_constraint_mapped_target_displays_resolved_members() {
+    // The key constraint is an alias reference (`Keys`), a `Lazy(DefId)` whose
+    // members only materialize with a resolver — the display path must resolve
+    // it, not fall back to the source form.
+    let msg = ts2741_message(
+        r#"
+type Keys = "a" | "b";
+const bad: { [K in Keys]: number } = { a: 1 };
+"#,
+    );
+    assert!(
+        msg.contains("required in type '{ a: number; b: number; }'"),
+        "aliased-union mapped must display its resolved members, got: {msg}"
+    );
+}
+
+#[test]
+fn nested_anon_concrete_mapped_target_displays_resolved_members() {
+    let msg = ts2741_message(
+        r#"
+enum Color { Red = "red", Green = "green" }
+const bad: { inner: { [K in Color]: number } } = { inner: { red: 1 } };
+"#,
+    );
+    assert!(
+        msg.contains("required in type '{ green: number; red: number; }'"),
+        "a nested anonymous concrete mapped must resolve for display, got: {msg}"
+    );
+}
+
+#[test]
+fn anon_concrete_mapped_display_is_not_name_specific() {
+    // Renaming the enum, its members, and the iteration variable must not change
+    // the rule — proves the resolution is structural, not keyed on a spelling.
+    let msg = ts2741_message(
+        r#"
+enum Palette { First = "one", Second = "two" }
+const bad: { [Prop in Palette]: number } = { one: 1 };
+"#,
+    );
+    assert!(
+        msg.contains("required in type '{ one: number; two: number; }'"),
+        "renamed binders must still resolve the concrete mapped for display, got: {msg}"
+    );
+}
+
+#[test]
+fn anon_concrete_mapped_display_carries_optional_and_readonly_modifiers() {
+    // The resolved member object must keep the mapped's optional modifier
+    // (`?`), matching tsc's `{ a?: number | undefined; b?: number | undefined; }`.
+    let msg = ts2741_message(
+        r#"
+declare const src: { a: number };
+const bad: { readonly [K in "a" | "b"]-?: number } = src;
+"#,
+    );
+    assert!(
+        msg.contains("required in type '{ readonly a: number; readonly b: number; }'"),
+        "modifiers must survive the resolved-member display, got: {msg}"
+    );
+}
+
+#[test]
+fn aliased_concrete_mapped_target_keeps_alias_name() {
+    // Negative control: an aliased mapped keeps its alias surface (#15392),
+    // never the expanded members — the resolution only fires for anonymous ones.
+    let msg = ts2741_message(
+        r#"
+enum Color { Red = "red", Green = "green" }
+type Palette = { [K in Color]: number };
+const bad: Palette = { red: 1 };
+"#,
+    );
+    assert!(
+        msg.contains("required in type 'Palette'"),
+        "an aliased mapped must keep its alias name, got: {msg}"
+    );
+    assert!(
+        !msg.contains("green: number"),
+        "an aliased mapped must not expand to members, got: {msg}"
+    );
+}
+
+#[test]
+fn anon_string_constraint_mapped_target_keeps_index_signature_form() {
+    // Negative control: a `string`-constrained mapped is an index signature in
+    // both printers (`{ [x: string]: string; }`), never a member object. It has
+    // no required member, so the mismatch surfaces as TS2322 rather than TS2741.
+    let msg = super::diagnostics_for(
+        r#"
+declare const src: { a: number };
+const bad: { [K in string]: string } = src;
+"#,
+    )
+    .iter()
+    .find(|diag| diag.code == 2322)
+    .expect("expected TS2322")
+    .message_text
+    .clone();
+    assert!(
+        msg.contains("{ [x: string]: string; }"),
+        "a string-constrained mapped must keep its index-signature form, got: {msg}"
+    );
+}

--- a/crates/tsz-solver/src/diagnostics/format/key.rs
+++ b/crates/tsz-solver/src/diagnostics/format/key.rs
@@ -598,6 +598,14 @@ impl<'a> TypeFormatter<'a> {
                 self.format_conditional(cond.as_ref()).into()
             }
             TypeData::Mapped(mapped_id) => {
+                // A concrete finite-key mapped type displays as its resolved
+                // member object in tsc (`{ green: number; red: number; }`),
+                // not its `{ [K in E]: V }` source form. Generic and
+                // index-signature mapped types return unchanged.
+                let resolved = self.resolve_concrete_mapped_for_display(type_id);
+                if resolved != type_id {
+                    return self.format(resolved);
+                }
                 let mapped = self.interner.mapped_type(*mapped_id);
                 self.format_mapped(mapped.as_ref()).into()
             }

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -378,6 +378,66 @@ impl<'a> TypeFormatter<'a> {
         resolved
     }
 
+    /// A concrete (type-parameter-free) mapped type whose key constraint is a
+    /// finite set of literal keys — `{ [K in Color]: number }`,
+    /// `{ [K in "a" | "b"]: number }` — is resolved by `tsc` to its member
+    /// object (`{ green: number; red: number; }`) for display, exactly as if
+    /// the members had been written out. tsz keeps the `Mapped` node live for
+    /// semantic identity (#15392), so the printer resolves it here instead.
+    ///
+    /// Returns the resolved object only when evaluation produces a plain
+    /// named-property object carrying no free type parameters and no index
+    /// signature. A generic mapped (`{ [K in keyof T]: T[K] }`) stays deferred
+    /// and a `string`/`number`/`symbol`-constrained mapped is an index
+    /// signature (`{ [x: string]: T }`, owned by `format_mapped`); both keep
+    /// their `{ [K in ...]: ... }` source form by returning `type_id`.
+    fn resolve_concrete_mapped_for_display(&self, type_id: TypeId) -> TypeId {
+        let Some(TypeData::Mapped(mapped_id)) = self.interner.lookup(type_id) else {
+            return type_id;
+        };
+        let mapped = self.interner.mapped_type(mapped_id);
+        // Gate cheaply before evaluating, mirroring
+        // `resolve_concrete_index_access_for_display`: a generic key constraint
+        // (`keyof T`) can never reduce to a concrete member object, and a
+        // `string`/`number`/`symbol` constraint is an index signature owned by
+        // `format_mapped` — neither should pay a full mapped evaluation here.
+        if crate::type_queries::contains_type_parameters_db(self.interner, mapped.constraint) {
+            return type_id;
+        }
+        // Evaluate the mapped type. A `keyof`/enum/aliased-union constraint is a
+        // `Lazy(DefId)` reference whose keys only materialize with a resolver, so
+        // back the evaluation with the formatter's `DefinitionStore` when present;
+        // an inline literal-union constraint resolves without one.
+        let resolved = match self.def_store {
+            Some(def_store) => {
+                let resolver =
+                    crate::caches::query_cache_evaluation::StoreOnlyResolver::new(def_store);
+                crate::evaluation::evaluate::evaluate_type_with_resolver(
+                    self.interner,
+                    &resolver,
+                    type_id,
+                )
+            }
+            None => crate::evaluation::evaluate::evaluate_mapped(self.interner, mapped.as_ref()),
+        };
+        // A free type parameter in the *template* (`{ [K in "a"]: T }`) keeps the
+        // mapped generic; such a result must print as written, not expanded.
+        if crate::type_queries::contains_type_parameters_db(self.interner, resolved) {
+            return type_id;
+        }
+        // Only a resolved *member* object matches tsc's expansion. A deferred
+        // result (still a `Mapped`/error) or an index-signature object
+        // (`ObjectWithIndex`) is not a plain `Object`, so it keeps its source or
+        // index-signature form via the fall-through below.
+        let Some(TypeData::Object(shape_id)) = self.interner.lookup(resolved) else {
+            return type_id;
+        };
+        if self.interner.object_shape(shape_id).properties.is_empty() {
+            return type_id;
+        }
+        resolved
+    }
+
     /// A semantic reference (`Lazy(DefId)`, or an `Application` over one)
     /// carries no members of its own, so `evaluate_index_access` cannot reduce
     /// `Iface["m"]` while the object operand is still that reference. Swap in

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -396,46 +396,99 @@ impl<'a> TypeFormatter<'a> {
             return type_id;
         };
         let mapped = self.interner.mapped_type(mapped_id);
-        // Gate cheaply before evaluating, mirroring
-        // `resolve_concrete_index_access_for_display`: a generic key constraint
-        // (`keyof T`) can never reduce to a concrete member object, and a
-        // `string`/`number`/`symbol` constraint is an index signature owned by
-        // `format_mapped` — neither should pay a full mapped evaluation here.
+        // A generic key constraint (`keyof T`, `AB[S]`) can never reduce to a
+        // concrete member object, so it prints as written.
         if crate::type_queries::contains_type_parameters_db(self.interner, mapped.constraint) {
             return type_id;
         }
-        // Evaluate the mapped type. A `keyof`/enum/aliased-union constraint is a
-        // `Lazy(DefId)` reference whose keys only materialize with a resolver, so
-        // back the evaluation with the formatter's `DefinitionStore` when present;
-        // an inline literal-union constraint resolves without one.
-        let resolved = match self.def_store {
-            Some(def_store) => {
-                let resolver =
-                    crate::caches::query_cache_evaluation::StoreOnlyResolver::new(def_store);
-                crate::evaluation::evaluate::evaluate_type_with_resolver(
-                    self.interner,
-                    &resolver,
-                    type_id,
-                )
+        // An enum / aliased-union constraint hides its keys behind a
+        // `Lazy(DefId)`; resolve one hop through the store — a direct body
+        // lookup, NOT an `evaluate`, so it registers no `store_display_alias`
+        // side effect the way a whole-mapped evaluation would.
+        let mut eff_constraint = mapped.constraint;
+        if let Some(TypeData::Lazy(def_id)) = self.interner.lookup(mapped.constraint)
+            && let Some(def_store) = self.def_store
+        {
+            use crate::def::resolver::TypeResolver;
+            let resolver = crate::caches::query_cache_evaluation::StoreOnlyResolver::new(def_store);
+            if let Some(body) = resolver.resolve_lazy(def_id, self.interner) {
+                eff_constraint = body;
             }
-            None => crate::evaluation::evaluate::evaluate_mapped(self.interner, mapped.as_ref()),
-        };
-        // A free type parameter in the *template* (`{ [K in "a"]: T }`) keeps the
-        // mapped generic; such a result must print as written, not expanded.
-        if crate::type_queries::contains_type_parameters_db(self.interner, resolved) {
+        }
+        // Only a finite literal-key constraint (a literal/enum/unique-symbol
+        // union, or a single such key) both reduces to a member object AND is
+        // safe to hand to the key collector. A `string`/`number`/`symbol`
+        // constraint is an index signature owned by `format_mapped`; an
+        // index-access / application / conditional constraint would trigger a
+        // side-effectful `evaluate` inside the collector. Either keeps the
+        // source / index-signature form via the fall-through below.
+        if !self.is_finite_literal_key_constraint(eff_constraint) {
             return type_id;
         }
-        // Only a resolved *member* object matches tsc's expansion. A deferred
-        // result (still a `Mapped`/error) or an index-signature object
-        // (`ObjectWithIndex`) is not a plain `Object`, so it keeps its source or
-        // index-signature form via the fall-through below.
-        let Some(TypeData::Object(shape_id)) = self.interner.lookup(resolved) else {
+        // Build the member object from the finite key set, mirroring
+        // `DiagnosticBuilder::materialize_finite_mapped_type_for_display` — a
+        // key query plus per-property template resolution, over a mapped
+        // carrying the resolved constraint.
+        let eff_mapped_id = if eff_constraint == mapped.constraint {
+            mapped_id
+        } else {
+            let rebuilt = self.interner.mapped(crate::types::MappedType {
+                constraint: eff_constraint,
+                ..*mapped
+            });
+            match self.interner.lookup(rebuilt) {
+                Some(TypeData::Mapped(id)) => id,
+                _ => return type_id,
+            }
+        };
+        let Some(names) =
+            crate::type_queries::collect_finite_mapped_property_names(self.interner, eff_mapped_id)
+        else {
             return type_id;
         };
-        if self.interner.object_shape(shape_id).properties.is_empty() {
+        if names.is_empty() {
             return type_id;
         }
-        resolved
+        let mut names: Vec<_> = names.into_iter().collect();
+        names.sort_by(|a, b| {
+            self.interner
+                .resolve_atom_ref(*a)
+                .cmp(&self.interner.resolve_atom_ref(*b))
+        });
+        let mut properties = Vec::with_capacity(names.len());
+        for name in names {
+            let property_name = self.interner.resolve_atom_ref(name).to_string();
+            let Some(value_type) = crate::type_queries::get_finite_mapped_property_type(
+                self.interner,
+                eff_mapped_id,
+                &property_name,
+            ) else {
+                return type_id;
+            };
+            // A free type parameter in the template (`{ [K in "a"]: T }`) keeps
+            // the mapped generic; print it as written.
+            if crate::type_queries::contains_type_parameters_db(self.interner, value_type) {
+                return type_id;
+            }
+            let mut property = crate::PropertyInfo::new(name, value_type);
+            property.optional = mapped.optional_modifier == Some(MappedModifier::Add);
+            property.readonly = mapped.readonly_modifier == Some(MappedModifier::Add);
+            properties.push(property);
+        }
+        self.interner.object(properties)
+    }
+
+    /// True when `constraint` is a finite set of literal keys — a single
+    /// literal / enum member / unique symbol, or a union of them. Such a
+    /// constraint is exactly what `resolve_concrete_mapped_for_display` can
+    /// expand to a member object, and it is safe to hand to the finite-key
+    /// collector without triggering a side-effectful `evaluate`.
+    fn is_finite_literal_key_constraint(&self, constraint: TypeId) -> bool {
+        match self.interner.lookup(constraint) {
+            Some(TypeData::Literal(_) | TypeData::Enum(_, _) | TypeData::UniqueSymbol(_)) => true,
+            Some(key @ TypeData::Union(_)) => self.union_is_all_unit_literals(&key),
+            _ => false,
+        }
     }
 
     /// A semantic reference (`Lazy(DefId)`, or an `Application` over one)


### PR DESCRIPTION
Goal: hold

Closes the display half of #15392's family for anonymous concrete mapped types.

## Structural rule

When an anonymous (no alias / no def redirect) mapped type is
type-parameter-free and its key constraint is a finite set of literal keys —
`{ [K in Color]: number }`, `{ [K in "a" | "b"]: number }`, `{ [K in Keys]: V }`
— `tsc` resolves it to its member object for display
(`{ green: number; red: number; }`). tsz rendered the unexpanded
`{ [K in E]: V }` source form instead. The mismatch is in the diagnostic type
printer only; the `Mapped` node is deliberately kept live for semantic identity
and enum-key recovery (#15392), so the printer resolves the concrete form for
display rather than materializing it at construction.

`tsc` keeps the source form for a *generic* mapped (`{ [K in keyof T]: T[K] }`,
`{ [key in AB[S]]: true }`) and the index-signature form for a
`string`/`number`/`symbol` constraint (`{ [x: string]: T }`); both are preserved.

## Owner layer

Solver diagnostics formatter (`crates/tsz-solver/src/diagnostics/format/`).
`resolve_concrete_mapped_for_display` (dispatched from the `TypeData::Mapped`
arm, mirroring the sibling `TypeData::IndexAccess` +
`resolve_concrete_index_access_for_display`) builds the member object through
the same finite-key path `DiagnosticBuilder::materialize_finite_mapped_type_for_display`
uses: `collect_finite_mapped_property_names` + `get_finite_mapped_property_type`.

It deliberately does **not** `evaluate` the whole mapped: a whole-mapped /
index-access evaluation in the display path registers `store_display_alias`
provenance as a side effect and repaints unrelated types (an earlier
whole-evaluate attempt regressed `mappedTypeErrors2.ts`, where
`{ [key in AB[S]]: true }` rendered as `T3`). An enum / aliased-union constraint
still resolves one `Lazy(DefId)` hop via the store's `resolve_lazy` (a body
lookup, not an evaluate), gated by a finite-literal-key-shape check so an
index-access / application / conditional constraint never reaches the
collector's own internal evaluate.

## Adjacent matrix (unit tests + oracle = tsc 7.0.2)

- Fixed: inline literal-union, aliased-union, enum (string + numeric), nested,
  renamed binders, `readonly`/optional modifiers, `as`-remap.
- Negative controls held: aliased mapped keeps its alias name (`Palette`);
  `string`-constrained mapped keeps `{ [x: string]: ... }`; generic mapped,
  `Partial<T>`, and an index-access constraint (`{ [key in AB[S]]: true }`) keep
  their source/alias form.

## Verification

- `cargo test -p tsz-solver --lib`: format 251 passed (full lib 7643 on the prior head).
- `cargo test -p tsz-checker --lib -- assignment_checker_mapped_type_tests property_access::tests`: 42 passed (8 new).
- CLI vs `scripts/conformance/oracle.sh` (tsc 7.0.2) byte-exact on 13 witnesses + the `mappedTypeErrors2.ts` regression fixture.
- Conformance snapshot (`conformance.sh snapshot --workers 12`): re-run on final code; result posted below.
- Emit floor (`scripts/emit/run.sh`): diagnostics-only change; result posted below.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus
Effort: high

https://claude.ai/code/session_01BtGy45F89acGF9XN1pmTBT