### PR TITLE
fix(solver): reduce non-strict null/undefined at the union-construction seam (#16580)

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -631,6 +631,8 @@ mod non_generic_spread_tuple_alias_display_tests;
 mod non_strict_non_null_check_narrows_tests;
 #[path = "tests/non_strict_nullish_return_widening_tests.rs"]
 mod non_strict_nullish_return_widening_tests;
+#[path = "tests/nonstrict_nullish_union_reduction_tests.rs"]
+mod nonstrict_nullish_union_reduction_tests;
 #[path = "tests/nonstrict_nullish_widening_generic_call_tests.rs"]
 mod nonstrict_nullish_widening_generic_call_tests;
 #[path = "tests/nonstrict_nullish_widening_mutable_binding_tests.rs"]

--- a/crates/tsz-checker/src/tests/nonstrict_nullish_union_reduction_tests.rs
+++ b/crates/tsz-checker/src/tests/nonstrict_nullish_union_reduction_tests.rs
@@ -1,0 +1,182 @@
+//! Regression tests for #16580: with `strictNullChecks` off, tsc drops a
+//! `null`/`undefined` constituent from *every* union it builds, not just the
+//! array-literal element path fixed by #16574.
+//!
+//! Structural rule: when `strictNullChecks` is off and a union has both a
+//! `null`/`undefined` constituent and a non-nullish one, tsc's `addTypeToUnion`
+//! never adds the nullable to the member set (it is a subtype of every non-nullish
+//! type there), so the union reduces at construction — annotations, aliases,
+//! function return types and array-element types alike. The one survivor is an
+//! *all-nullish* union (`null | undefined`), which has no non-nullish sibling to
+//! absorb into and must stay as-is rather than collapse to `never`.
+//!
+//! Owner: the solver's union-construction seam
+//! (`TypeInterner::reduce_nonstrict_nullish_members`), applied uniformly across
+//! every union constructor so a member set keeps one canonical identity per
+//! program.
+//!
+//! Each positive row forces the reduced type into a `TS2322` whose rendered
+//! source (or target) type is the observable. Expectations are the tsc renderings
+//! pinned in #16580 (`typescript@7.0.2`, `--strict false --strictNullChecks
+//! false`). The strict-mode controls prove the change is a no-op under
+//! `strictNullChecks`, and the renamed-binder rows keep it structural rather than
+//! keyed on any identifier.
+
+use crate::test_utils::{
+    check_with_options_code_messages, non_strict_checker_options, strict_checker_options,
+};
+
+fn nonstrict(source: &str) -> Vec<(u32, String)> {
+    check_with_options_code_messages(source, non_strict_checker_options())
+}
+
+fn strict(source: &str) -> Vec<(u32, String)> {
+    check_with_options_code_messages(source, strict_checker_options())
+}
+
+/// The reduced source type is rendered by assigning to an incompatible target.
+fn assert_source_renders(source: &str, rendered_source: &str, target: &str) {
+    let messages = nonstrict(source);
+    assert_eq!(
+        messages,
+        vec![(
+            2322,
+            format!("Type '{rendered_source}' is not assignable to type '{target}'.")
+        )],
+        "expected source to render `{rendered_source}`: {messages:?}"
+    );
+}
+
+// --- #16580 positive rows: the nullish constituent is dropped ----------------
+
+/// Row a4 (the issue's repro): a function whose declared return type is
+/// `number | null` returns `number` in non-strict mode.
+#[test]
+fn return_type_drops_null() {
+    assert_source_renders(
+        "declare function f(): number | null;\nvar probe: string = f();\n",
+        "number",
+        "string",
+    );
+}
+
+/// Row a3: a type alias `number | undefined` renders as `number`. This surfaces
+/// as a naming difference — once the union reduces there is no alias left to
+/// print — and must be fixed at construction, not by expanding the alias in the
+/// printer.
+#[test]
+fn alias_of_number_or_undefined_drops_undefined() {
+    assert_source_renders(
+        "type T = number | undefined;\ndeclare var a: T;\nvar e: string = a;\n",
+        "number",
+        "string",
+    );
+}
+
+/// Row a5: `string | null | undefined` renders as `string` (both nullish members
+/// dropped), also collapsing the alias.
+#[test]
+fn alias_of_string_or_null_or_undefined_drops_both() {
+    assert_source_renders(
+        "type Zqq = string | null | undefined;\ndeclare var w: Zqq;\nvar e: number = w;\n",
+        "string",
+        "number",
+    );
+}
+
+/// Row a1: the element annotation `(number | null)[]` renders as `number[]`.
+#[test]
+fn array_element_annotation_drops_null() {
+    assert_source_renders(
+        "declare var a: (number | null)[];\nvar e: string = a;\n",
+        "number[]",
+        "string",
+    );
+}
+
+/// The generic-instantiation seam #16593 left as a documented follow-up: a
+/// generic interface property typed `T | null` must reduce to `number` after
+/// instantiation with `T = number`. The `T | null` union is rebuilt during
+/// instantiation (substituting `T`), which bypasses the syntactic union-type-node
+/// resolvers #16593 patched but flows through the solver union-construction seam
+/// this change owns. Property access renders the instantiated member type.
+#[test]
+fn generic_property_union_reduces_after_instantiation() {
+    assert_source_renders(
+        "interface Box<T> { value: T | null; }\ndeclare const b: Box<number>;\nvar e: string = b.value;\n",
+        "number",
+        "string",
+    );
+}
+
+// --- Anti-hardcoding: renamed binders reach the same rule --------------------
+
+#[test]
+fn renamed_alias_and_function_still_reduce() {
+    // A differently-named alias.
+    assert_source_renders(
+        "type Foo = boolean | null;\ndeclare var q: Foo;\nvar e: number = q;\n",
+        "boolean",
+        "number",
+    );
+    // A differently-named function with `undefined`.
+    assert_source_renders(
+        "declare function gg(): bigint | undefined;\nvar e: string = gg();\n",
+        "bigint",
+        "string",
+    );
+}
+
+// --- Negative controls -------------------------------------------------------
+
+/// Row a2: `number | null` with an initializer already renders `number` (agreed
+/// before this change); it must still render `number`, not regress to a
+/// collapsed-away or widened form.
+#[test]
+fn declared_number_or_null_still_number() {
+    assert_source_renders(
+        "var a: number | null = 1;\nvar e: string = a;\n",
+        "number",
+        "string",
+    );
+}
+
+/// Row a6: an all-nullish union has no non-nullish sibling to absorb into and
+/// must stay as-is — never collapse to `never`. The bare declaration is clean, as
+/// tsc reports.
+#[test]
+fn all_nullish_union_stays_clean() {
+    let messages = nonstrict("declare var a: null | undefined;\nvar b: null | undefined = a;\n");
+    assert!(
+        messages.is_empty(),
+        "all-nullish union must remain a valid, clean type (not collapsed): {messages:?}"
+    );
+}
+
+// --- Strict-mode controls: the change is a no-op under strictNullChecks -------
+
+#[test]
+fn strict_mode_keeps_null_in_return_type() {
+    let messages = strict("declare function f(): number | null;\nvar probe: string = f();\n");
+    assert_eq!(
+        messages,
+        vec![(
+            2322,
+            "Type 'number | null' is not assignable to type 'string'.".to_string()
+        )],
+        "strict mode must keep the null constituent: {messages:?}"
+    );
+}
+
+#[test]
+fn strict_mode_keeps_alias_and_undefined() {
+    let messages = strict("type T = number | undefined;\ndeclare var a: T;\nvar e: string = a;\n");
+    assert_eq!(
+        messages,
+        vec![(
+            2322,
+            "Type 'T' is not assignable to type 'string'.".to_string()
+        )],
+        "strict mode must keep the alias and its undefined: {messages:?}"
+    );
+}

--- a/crates/tsz-checker/src/tests/nonstrict_nullish_widening_generic_call_tests.rs
+++ b/crates/tsz-checker/src/tests/nonstrict_nullish_widening_generic_call_tests.rs
@@ -241,9 +241,10 @@ var e: string = v;
 /// A mixed non-nullish/nullish array. tsc says `string[]` — it reaches that
 /// through non-strict **union reduction** (`undefined` is absorbed out of
 /// `string | undefined` when `strictNullChecks` is off), not through the
-/// widening flavour this file otherwise covers. Fixed by #16574: see
-/// `nonstrict_array_element_union_absorbs_nullish_scalars` in
-/// `types/computation/array_literal.rs`.
+/// widening flavour this file otherwise covers. First fixed by #16574 on the
+/// array-literal path; the reduction now lives at the solver union-construction
+/// seam (`TypeInterner::reduce_nonstrict_nullish_members`, #16580), which this
+/// row continues to witness.
 #[test]
 fn mixed_array_reduces_undefined_out_of_the_element_union() {
     assert_infers(

--- a/crates/tsz-checker/src/types/computation/array_literal.rs
+++ b/crates/tsz-checker/src/types/computation/array_literal.rs
@@ -1478,7 +1478,9 @@ impl<'a> CheckerState<'a> {
                 Some(&self.ctx), // Pass TypeResolver for class hierarchy BCT
             )
         };
-        let element_type = self.nonstrict_array_element_union_absorbs_nullish_scalars(element_type);
+        // Non-strict `null`/`undefined` element absorption (#16574) is now owned by
+        // the solver union-construction seam (`reduce_nonstrict_nullish_members`,
+        // #16580), applied when the BCT union above is interned.
 
         // TS2590: Also check the solver's flag in case the union was constructed
         // through a different path (e.g., preserve_literal_types or internal union ops).
@@ -1500,41 +1502,6 @@ impl<'a> CheckerState<'a> {
         }
 
         array_surfaces::array_type(self.ctx.types, element_type)
-    }
-
-    /// With `strictNullChecks` off, `null`/`undefined` are subtypes of every
-    /// type, so tsc's array-literal element type
-    /// (`getUnionType(elementTypes, UnionReduction.Subtype)`) absorbs a scalar
-    /// `null`/`undefined` element out of the union whenever a non-nullish
-    /// sibling is present — e.g. `["s", undefined]` infers `string[]`, not
-    /// `(string | undefined)[]`.
-    ///
-    /// Applied as a post-pass over the already-built element union/BCT result,
-    /// not by pre-filtering the candidate list handed to
-    /// `compute_best_common_type_cached`: BCT's literal-widening and subtype
-    /// tournament must still see the full candidate set, or a literal that
-    /// happens to be the lone non-nullish survivor would skip widening (e.g.
-    /// `["s", undefined]` must still widen `"s"` to `string`, not stay `"s"`).
-    /// The solver's `element_union`/BCT primitives are unchanged; this is a
-    /// checker-owned reduction over their result.
-    fn nonstrict_array_element_union_absorbs_nullish_scalars(
-        &self,
-        element_type: TypeId,
-    ) -> TypeId {
-        if self.ctx.strict_null_checks() {
-            return element_type;
-        }
-        let Some(members) =
-            crate::query_boundaries::common::union_members(self.ctx.types, element_type)
-        else {
-            return element_type;
-        };
-        let is_nullish_scalar = |m: &TypeId| *m == TypeId::NULL || *m == TypeId::UNDEFINED;
-        if !members.iter().any(is_nullish_scalar) || !members.iter().any(|m| !is_nullish_scalar(m))
-        {
-            return element_type;
-        }
-        crate::query_boundaries::common::remove_nullish(self.ctx.types, element_type)
     }
 
     /// When the contextual type is a generic application like `Definition<Schema>`, the

--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -176,6 +176,20 @@ impl TypeInterner {
             return flat[0];
         }
 
+        // Non-strict absorption applies at every union seam, not just the
+        // normalizing ones, so a sorted-and-deduped list built by narrowing or
+        // object-literal construction reaches the same canonical identity as the
+        // `normalize_union` path. `retain` preserves the sort order. Gated on the
+        // mode so a strict run keeps its byte-identical fast path.
+        if !self.strict_null_checks() {
+            let mut reduced: TypeListBuffer = flat.iter().copied().collect();
+            if let Some(collapsed) = self.reduce_and_collapse_nonstrict(&mut reduced) {
+                return collapsed;
+            }
+            let list_id = self.intern_type_list_from_slice(&reduced);
+            return self.intern(TypeData::Union(list_id));
+        }
+
         let list_id = self.intern_type_list(flat);
         self.intern(TypeData::Union(list_id))
     }
@@ -236,11 +250,14 @@ impl TypeInterner {
         flat.dedup();
         flat.retain(|id| *id != TypeId::NEVER);
 
-        if flat.is_empty() {
-            return TypeId::NEVER;
-        }
-        if flat.len() == 1 {
-            return flat[0];
+        // The structure this path preserves is *subtype* structure
+        // (`Derived1 | Derived2` stays split for narrowing); non-strict nullish
+        // absorption is orthogonal and still applies (tsc's narrowing unions run
+        // the same `addTypeToUnion` exclusion), holding one-universe identity
+        // against `normalize_union`. The shared helper also folds the post-`never`
+        // length collapse this path already needed.
+        if let Some(collapsed) = self.reduce_and_collapse_nonstrict(&mut flat) {
+            return collapsed;
         }
 
         let list_id = self.intern_type_list_from_slice(&flat);
@@ -258,6 +275,14 @@ impl TypeInterner {
         }
         if right == TypeId::NEVER {
             return left;
+        }
+        // With `strictNullChecks` off, union construction drops `null`/`undefined`,
+        // so the identity fast paths below — which assume both operands survive —
+        // do not hold; route the pair through the normalizing constructor, which
+        // applies the drop (`reduce_nonstrict_nullish_members`). Strict is
+        // unchanged.
+        if !self.strict_null_checks() {
+            return self.union_from_iter([left, right]);
         }
         // Fast path: `T | undefined`, `T | null`, `T | void` where T is a union
         // already containing the nullable member.  This avoids the full
@@ -833,7 +858,13 @@ impl TypeInterner {
     /// constantly (the interner sees ~97% repeat hits on type-level-heavy
     /// projects). Key is the exact pre-normalization member list, so repeats
     /// skip straight to the previously interned result.
-    pub(super) fn normalize_union(&self, flat: TypeListBuffer) -> TypeId {
+    pub(super) fn normalize_union(&self, mut flat: TypeListBuffer) -> TypeId {
+        // Non-strict nullish absorption runs before the length gate and the result
+        // memo, so the cache key is the *reduced* member set: a `strictNullChecks`-off
+        // run keys `[number]` where a strict run keys `[number, null]`, never colliding.
+        if let Some(collapsed) = self.reduce_and_collapse_nonstrict(&mut flat) {
+            return collapsed;
+        }
         if flat.len() > Self::UNION_NORMALIZE_CACHE_MAX_LEN {
             return self.normalize_union_uncached(flat);
         }
@@ -1069,6 +1100,11 @@ impl TypeInterner {
     /// `TSZ_UNION_LITERAL_DEFAULT` flag so this path (reached from the >1000-member
     /// object-union guard in `normalize_union`) stays byte-identical when OFF.
     fn normalize_union_literal_only(&self, mut flat: TypeListBuffer) -> TypeId {
+        // The `.Literal`-equivalent path drops non-strict nullish too: tsc's
+        // `addTypeToUnion` exclusion is independent of the reduction mode.
+        if let Some(collapsed) = self.reduce_and_collapse_nonstrict(&mut flat) {
+            return collapsed;
+        }
         self.sort_union_members(&mut flat);
         flat.dedup();
 

--- a/crates/tsz-solver/src/intern/core/interner_tests.rs
+++ b/crates/tsz-solver/src/intern/core/interner_tests.rs
@@ -767,3 +767,149 @@ mod string_cache {
         assert_eq!(&*interner.resolve_atom_ref(a0), long);
     }
 }
+
+/// Non-strict (`strictNullChecks` off) `null`/`undefined` absorption at the
+/// union-construction seam (#16580). tsc's `addTypeToUnion` never adds a nullable
+/// constituent to a union in non-strict mode; it survives only when the set would
+/// otherwise be empty (an all-nullish union). The interner must apply this
+/// uniformly across every union constructor so a member set keeps one canonical
+/// identity per program.
+mod nonstrict_nullish_union_tests {
+    use super::*;
+
+    fn nonstrict() -> TypeInterner {
+        let interner = TypeInterner::new();
+        interner.set_strict_null_checks(false);
+        interner
+    }
+
+    fn union_members(interner: &TypeInterner, id: TypeId) -> Option<Vec<TypeId>> {
+        match interner.lookup(id)? {
+            TypeData::Union(list_id) => Some(interner.type_list(list_id).to_vec()),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn nonstrict_drops_nullish_when_a_non_nullish_sibling_is_present() {
+        let interner = nonstrict();
+        assert_eq!(
+            interner.union(vec![TypeId::NUMBER, TypeId::NULL]),
+            TypeId::NUMBER,
+            "number | null -> number"
+        );
+        assert_eq!(
+            interner.union(vec![TypeId::NUMBER, TypeId::UNDEFINED]),
+            TypeId::NUMBER,
+            "number | undefined -> number"
+        );
+        assert_eq!(
+            interner.union(vec![TypeId::STRING, TypeId::NULL, TypeId::UNDEFINED]),
+            TypeId::STRING,
+            "string | null | undefined -> string"
+        );
+    }
+
+    #[test]
+    fn nonstrict_keeps_void_and_never_semantics() {
+        let interner = nonstrict();
+        // `void` is not `TypeFlags.Nullable`: it stays in the union.
+        let with_void = interner.union(vec![TypeId::NUMBER, TypeId::VOID]);
+        let members = union_members(&interner, with_void).expect("number | void stays a union");
+        assert!(
+            members.contains(&TypeId::VOID) && members.contains(&TypeId::NUMBER),
+            "void must survive non-strict union construction: {members:?}"
+        );
+        // `never` is stripped and never counts as the non-nullish sibling, so a
+        // nullish + never set is all-nullish and keeps its nullish member.
+        assert_eq!(
+            interner.union(vec![TypeId::NULL, TypeId::NEVER]),
+            TypeId::NULL,
+            "null | never -> null (never stripped, null kept)"
+        );
+        assert_eq!(
+            interner.union(vec![TypeId::NUMBER, TypeId::NULL, TypeId::NEVER]),
+            TypeId::NUMBER,
+            "number | null | never -> number"
+        );
+    }
+
+    #[test]
+    fn nonstrict_keeps_all_nullish_union() {
+        let interner = nonstrict();
+        // No non-nullish sibling to absorb into: the union must stay as-is, never
+        // collapse to `never` (#16580 row a6).
+        let all_nullish = interner.union(vec![TypeId::NULL, TypeId::UNDEFINED]);
+        assert_ne!(
+            all_nullish,
+            TypeId::NEVER,
+            "null | undefined must not become never"
+        );
+        let members = union_members(&interner, all_nullish).expect("all-nullish stays a union");
+        assert!(
+            members.contains(&TypeId::NULL) && members.contains(&TypeId::UNDEFINED),
+            "all-nullish union must keep both members: {members:?}"
+        );
+    }
+
+    #[test]
+    fn nonstrict_reduction_is_uniform_across_every_seam() {
+        let interner = nonstrict();
+        // Every union constructor must reach the same canonical identity for the
+        // same member set (one-universe invariant).
+        assert_eq!(
+            interner.union(vec![TypeId::NUMBER, TypeId::NULL]),
+            TypeId::NUMBER
+        );
+        assert_eq!(
+            interner.union_from_slice(&[TypeId::NUMBER, TypeId::NULL]),
+            TypeId::NUMBER
+        );
+        assert_eq!(
+            interner.union2(TypeId::NUMBER, TypeId::NULL),
+            TypeId::NUMBER
+        );
+        assert_eq!(
+            interner.union2(TypeId::NULL, TypeId::NUMBER),
+            TypeId::NUMBER
+        );
+        assert_eq!(
+            interner.union3(TypeId::NUMBER, TypeId::NULL, TypeId::UNDEFINED),
+            TypeId::NUMBER
+        );
+        // `union_from_sorted_vec` requires a pre-sorted list: NUMBER(9) < NULL(15).
+        assert_eq!(
+            interner.union_from_sorted_vec(vec![TypeId::NUMBER, TypeId::NULL]),
+            TypeId::NUMBER
+        );
+        assert_eq!(
+            interner.union_preserve_members(vec![TypeId::NUMBER, TypeId::NULL]),
+            TypeId::NUMBER
+        );
+        assert_eq!(
+            interner.union_literal_reduce(vec![TypeId::NUMBER, TypeId::NULL]),
+            TypeId::NUMBER
+        );
+    }
+
+    #[test]
+    fn strict_mode_keeps_every_nullish_member() {
+        // The default interner is strict: the reduction is a no-op, so all the
+        // seams retain `null`/`undefined` exactly as before.
+        let interner = TypeInterner::new();
+        for id in [
+            interner.union(vec![TypeId::NUMBER, TypeId::NULL]),
+            interner.union2(TypeId::NUMBER, TypeId::NULL),
+            interner.union_preserve_members(vec![TypeId::NUMBER, TypeId::NULL]),
+            interner.union_from_sorted_vec(vec![TypeId::NUMBER, TypeId::NULL]),
+            interner.union_literal_reduce(vec![TypeId::NUMBER, TypeId::NULL]),
+        ] {
+            let members = union_members(&interner, id)
+                .unwrap_or_else(|| panic!("strict number | null must stay a union: {id:?}"));
+            assert!(
+                members.contains(&TypeId::NULL) && members.contains(&TypeId::NUMBER),
+                "strict mode must keep null: {members:?}"
+            );
+        }
+    }
+}

--- a/crates/tsz-solver/src/intern/normalize.rs
+++ b/crates/tsz-solver/src/intern/normalize.rs
@@ -128,6 +128,68 @@ struct LiteralOccurrence {
 type LiteralOccurrencesByDomain = SmallVec<[(LiteralDomain, SmallVec<[LiteralOccurrence; 4]>); 4]>;
 
 impl TypeInterner {
+    /// tsc's `addTypeToUnion` drops a `null`/`undefined` constituent from every
+    /// union it constructs when `strictNullChecks` is off: the nullable is a
+    /// subtype of every non-nullish type there, so it is never added to the member
+    /// set (`checker.ts`), independent of the requested `UnionReduction` mode. The
+    /// lone survivor is an *all-nullish* union (`null | undefined`, or `null`
+    /// alone) — with no non-nullish sibling to absorb into, tsc keeps the nullish
+    /// members rather than collapsing to `never`.
+    ///
+    /// This is the general union-construction seam #16580 calls for. The checker's
+    /// array-literal element path (#16574) was one witness of a rule that has to
+    /// hold wherever a union is built — annotations, aliases, return types, flow
+    /// joins alike. The interner's union constructors all call it so a member set
+    /// keeps a single canonical identity per program: `strictNullChecks` is a
+    /// whole-program constant, so unlike a per-site reduction mode this never forks
+    /// one member set into two canonical types.
+    ///
+    /// `void` is deliberately **not** dropped: tsc's `TypeFlags.Nullable` is
+    /// `Undefined | Null` only, and `number | void` keeps its `void` in non-strict
+    /// mode exactly as in strict mode. `never` never counts as the non-nullish
+    /// sibling that keeps a nullish member alive — it is the identity of union and
+    /// is stripped anyway — so `null | never` reduces to `null`, not to `never`.
+    #[inline]
+    pub(crate) fn reduce_nonstrict_nullish_members(&self, flat: &mut TypeListBuffer) {
+        if self.strict_null_checks() {
+            return;
+        }
+        let mut has_nullish = false;
+        let mut has_non_nullish = false;
+        for &id in flat.iter() {
+            if id == TypeId::NULL || id == TypeId::UNDEFINED {
+                has_nullish = true;
+            } else if id != TypeId::NEVER {
+                has_non_nullish = true;
+            }
+        }
+        if !has_nullish || !has_non_nullish {
+            return;
+        }
+        flat.retain(|id| *id != TypeId::NULL && *id != TypeId::UNDEFINED);
+    }
+
+    /// Apply [`reduce_nonstrict_nullish_members`](Self::reduce_nonstrict_nullish_members)
+    /// then collapse the buffer to a terminal `TypeId` when it no longer needs a
+    /// `Union` node: `Some(never)`/`Some(only_member)` for the empty/singleton
+    /// cases, `None` when `>= 2` members remain and the caller should intern a
+    /// union. Shared by every buffer-level union constructor so the reduce-then-
+    /// collapse tail lives in one place. In strict mode the reduction is a no-op,
+    /// so this still folds an already-singleton buffer (e.g. after `never`
+    /// stripping) the same way.
+    #[inline]
+    pub(crate) fn reduce_and_collapse_nonstrict(
+        &self,
+        flat: &mut TypeListBuffer,
+    ) -> Option<TypeId> {
+        self.reduce_nonstrict_nullish_members(flat);
+        match flat.len() {
+            0 => Some(TypeId::NEVER),
+            1 => Some(flat[0]),
+            _ => None,
+        }
+    }
+
     pub(crate) fn intersection_has_disjoint_primitives(&self, members: &[TypeId]) -> bool {
         let mut class: Option<PrimitiveClass> = None;
         let mut has_non_primitive = false;


### PR DESCRIPTION
Generalizes the non-strict `null`/`undefined` union reduction (#16580) from the three *syntactic* union-type-node resolvers #16593 patched to the **solver union-construction seam itself** — the one choke point every union flows through — so the rule holds wherever a union is built, not only where it is written.

#16593 explicitly left a follow-up it could not reach: a generic interface property typed `T | null` still kept the null member *after instantiation* (`Box<number>`'s `value: T | null` stayed `number | null`, not `number`), because "interface/generic body union construction is evidently a separate seam from the three syntactic resolvers." That union is rebuilt during instantiation, bypassing the syntactic resolvers but flowing through the solver seam this PR owns. Flow joins and other instantiation-time unions were likewise out of reach of a syntactic pre-filter.

### Structural rule

When `strictNullChecks` is off, tsc's `addTypeToUnion` never adds a `null`/`undefined` constituent to a union that has a non-nullish, non-`never` sibling, independent of the requested `UnionReduction` mode; an all-nullish union (`null | undefined`) has no sibling to absorb into and stays as-is (never collapses to `never`). tsz now does this through `TypeInterner::reduce_nonstrict_nullish_members`, applied uniformly across `normalize_union`, `normalize_union_literal_only`, `union_from_sorted_vec`, `union_preserve_members`, and `union2` via the shared `reduce_and_collapse_nonstrict` helper (owner layer: solver).

`strictNullChecks` is a whole-program constant, so this keeps one canonical identity per member set (no per-site fork the way a per-construction reduction mode would); the reduction runs *before* the `normalize_union` result memo so its cache key reflects the reduced set and never collides across modes. `void` is not dropped (tsc's `TypeFlags.Nullable` is `Undefined | Null` only).

The change is a **no-op under `strictNullChecks`**, so the blast radius is non-strict compilations only. It **complements #16593** (whose syntactic pre-filter also manages union-display origin) rather than replacing it, and subsumes the now-redundant checker-side array-literal post-pass from #16574 (`nonstrict_array_element_union_absorbs_nullish_scalars`), which is removed — the BCT element union is built through the interner after literal widening, so the solver seam covers it.

### Adjacent-case matrix (tests)

- The generic-instantiation follow-up #16593 could not close: `Box<number>.value: T | null` → `number`.
- The issue's rows a1/a3/a4/a5 (annotation array element, alias `number | undefined`, return type, `string | null | undefined`).
- Negatives: a2 (`number | null = 1` → `number`), a6 (all-nullish `null | undefined` stays, never `never`).
- Renamed binders (anti-hardcoding): differently-named aliases and functions.
- Strict-mode controls proving the no-op (`number | null` and alias `T` render unchanged under `strictNullChecks`).

## Goal
Goal: hold

## Verification
- New solver interner tests (5) + checker end-to-end tests (10). #16593's `nonstrict_union_nullish_scalar_reduction_tests` (8) still pass with both mechanisms present.
- `cargo test -p tsz-solver --lib` — 7648/0. `cargo test -p tsz-checker --lib -- narrow nonstrict non_strict nullish optional union widening` — 1550/0. `cargo test -p tsz-checker --lib -- nonstrict_nullish array_literal` — 124/0 (incl. the #16574 witness now served by the solver seam).
- **Conformance** (snapshot on the rebased base, diffed against the committed baseline): this change **fixes one false positive** — `conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts` drops a spurious `TS2322` (FAIL→PASS) — and is otherwise neutral. The one other delta, `awaitUsingDeclarations.14.ts` gaining `TS2853`, is **pre-existing #16597 drift** not caused by this PR: the committed baseline was last refreshed at #16570 (before #16597), and #16597 moved `TS18054` into `is_parser_grammar_code`, which un-suppresses the sibling `TS2853` on that `class { static { await using } }` test. This change is confined to the solver union interner and cannot affect `TS2853` (a grammar/module-context diagnostic).
- **Emit**: JS 11562 / DTS 1375 — unchanged (byte-identical snapshot).
- `cargo clippy --profile ci-lint --workspace --exclude tsz-conformance --all-targets -- -D warnings` clean; `cargo fmt` clean; `arch_guard.py` passes (`constructors.rs` 2008 ≤ 2026 ratchet).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high