### PR TITLE
fix(checker): a class static block short-circuits the await-using top-level grammar (no spurious TS2853) (#16598)

### DIFF
--- a/crates/tsz-checker/src/tests/await_static_block_grammar_tests.rs
+++ b/crates/tsz-checker/src/tests/await_static_block_grammar_tests.rs
@@ -162,9 +162,15 @@ class Gate { static { let x = 1; while (x) { x = 0; } } }
 /// ("...only allowed at the top level of a file...") — the two are mutually
 /// exclusive by container (`getContainingFunctionOrClassStaticBlock`
 /// resolving to the static block short-circuits tsc's top-level-await-using
-/// eligibility check entirely) — which also exercises the
-/// `is_directly_at_source_file_top_level` fix that added
-/// `CLASS_STATIC_BLOCK_DECLARATION` to its disqualifying-container list.
+/// eligibility check entirely). `check_variable_declaration_list_with_request`
+/// declines the whole TS2852/TS2853/TS2854 family behind
+/// `await_container_is_class_static_block`, the same container gate the
+/// bare-`await` family uses.
+///
+/// This helper is parse-health-*aware*, so TS18054 sets `has_syntax_parse_errors`
+/// and the await-using walk is suppressed regardless of the container gate; the
+/// `..._without_suppression` test below is the one that actually exercises the
+/// gate (see #16598).
 #[test]
 fn static_block_direct_await_using_reports_only_ts18054() {
     let codes = check_source_codes_with_parse_health(
@@ -361,5 +367,73 @@ class Harness { static { const build = function () { return await 2; }; void bui
         "the nested function expression is its own container, so its non-async \
          `await` answers TS1308 rather than deferring to the enclosing static \
          block; got {codes:?}"
+    );
+}
+
+/// #16598: the `await using` sibling of
+/// `static_block_await_is_silent_in_the_checker_walk_without_suppression`.
+///
+/// `check_source_codes` is the parse-health-*blind* helper: it leaves
+/// `has_syntax_parse_errors` false, exactly as the compiled CLI does once
+/// TS18054 became a non-suppressing parser-grammar code (#16597). With the
+/// suppression gone, the checker's await-using grammar walk runs on its own —
+/// and before #16598 it fired TS2853 (or the nested TS2852, depending on
+/// module settings) for `await using` inside a class static block, because
+/// `is_directly_at_source_file_top_level` climbs past the static block to the
+/// source file. `await_container_is_class_static_block` now declines the whole
+/// family at the source, matching tsc's container short-circuit. This test is
+/// non-vacuous: reverting the gate makes it fail with a TS2853.
+#[test]
+fn static_block_await_using_is_silent_in_the_checker_walk_without_suppression() {
+    let codes = crate::test_utils::check_source_codes(
+        r#"
+class Gate { static { await using x = 1; } }
+"#,
+    );
+    assert!(
+        !codes.contains(&2853) && !codes.contains(&2852) && !codes.contains(&2854),
+        "tsc's checkGrammarAwaitOrAwaitUsing puts the whole TS2852/TS2853/TS2854 \
+         family in the `else` of its class-static-block test, so the walk must \
+         decline here on its own rather than relying on a parse-error \
+         suppression; got {codes:?}"
+    );
+}
+
+/// The same walk must still speak for an `await using` that is *not* in a
+/// static block, in a file that also has one — the container gate keys on the
+/// declaration's own container, never on the file. Here the sibling
+/// `await using` sits at the source-file top level of a non-module file, so it
+/// still answers TS2853; renamed binders throughout.
+#[test]
+fn sibling_await_using_outside_a_static_block_still_reports_in_the_checker_walk() {
+    let codes = crate::test_utils::check_source_codes(
+        r#"
+class Latch { static { await using seeded = 1; } }
+await using loose = 2;
+"#,
+    );
+    assert!(
+        codes.contains(&2853),
+        "the top-level `await using` in a non-module file is unaffected by the \
+         sibling static block; tsc reports TS2853 for it alongside the static \
+         block's TS18054; got {codes:?}"
+    );
+}
+
+/// Container-walk boundary: an `await using` inside a non-async function
+/// *nested* in a static block answers from its own function (TS2852, nested
+/// outside async), not from the static block. Without stopping the walk at the
+/// first function-like ancestor, this would be silently swallowed.
+#[test]
+fn await_using_in_a_non_async_function_nested_in_a_static_block_still_reports() {
+    let codes = crate::test_utils::check_source_codes(
+        r#"
+class Harness { static { function build() { await using r = 1; void r; } void build; } }
+"#,
+    );
+    assert!(
+        codes.contains(&2852),
+        "the nested function is its own container, so its `await using` answers \
+         TS2852 rather than deferring to the enclosing static block; got {codes:?}"
     );
 }

--- a/crates/tsz-checker/src/types/type_checking/core.rs
+++ b/crates/tsz-checker/src/types/type_checking/core.rs
@@ -5,7 +5,6 @@
 //! Type alias declaration checking and type node validation are in
 //! `type_alias_checking.rs`.
 
-use super::core_statement_checks::TopLevelAwaitVerdict;
 use crate::context::TypingRequest;
 use crate::state::CheckerState;
 use rustc_hash::FxHashSet;
@@ -1621,74 +1620,12 @@ impl<'a> CheckerState<'a> {
         let placement_error =
             is_using && self.check_grammar_using_declaration_placement(list_idx, is_await_using);
 
-        // tsc's `checkGrammarAwaitOrAwaitUsing` opens with the same
-        // containing-function-or-class-static-block test that
-        // `checkAwaitExpression` does, and the entire TS2852/TS2853/TS2854/TS1309
-        // family lives in its `else` — so a class static block short-circuits the
-        // top-level-eligibility question outright, answering only TS18054
-        // ('await using' cannot be used inside a class static block, emitted by
-        // the parser grammar). Without this gate the top-level walk below
-        // (`is_directly_at_source_file_top_level`) climbs past the static block to
-        // the source file and spuriously fires TS2853; adding the block to that
-        // walk's disqualifying list instead would only swap TS2853 for the nested
-        // TS2852 arm, so the container short-circuit is the tsc-faithful fix. This
-        // mirrors `check_await_expression`'s `await_container_is_class_static_block`
-        // gate for the bare-`await` family. Before #16597 the guard below was
-        // reached only when TS18054 still set `has_syntax_parse_errors`, which
-        // masked this; TS18054 is now non-suppressing, so the decline has to be
-        // made here on its own.
-        if is_await_using
-            && !placement_error
-            && !self.ctx.has_syntax_parse_errors
-            && !self.await_container_is_class_static_block(list_idx)
-        {
-            use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-
-            // Same top-level-await-eligibility predicate as `check_await_expression`
-            // (#16072): a namespace body disqualifies `await using` from being
-            // top level without being function-like, so this is not
-            // `function_depth == 0`.
-            if self.is_directly_at_source_file_top_level(list_idx) {
-                // TS2853: Top-level 'await using' is only valid in modules.
-                if self.top_level_await_requires_module_diagnostic() {
-                    self.error_at_node(
-                        list_idx,
-                        diagnostic_messages::AWAIT_USING_STATEMENTS_ARE_ONLY_ALLOWED_AT_THE_TOP_LEVEL_OF_A_FILE_WHEN_THAT_FIL,
-                        diagnostic_codes::AWAIT_USING_STATEMENTS_ARE_ONLY_ALLOWED_AT_THE_TOP_LEVEL_OF_A_FILE_WHEN_THAT_FIL,
-                    );
-                }
-
-                // TS1309 when a Node module kind pairs with a CommonJS-format
-                // file; otherwise TS2854, which requires specific module +
-                // target options. Both answers come from the shared
-                // `checkGrammarAwaitOrAwaitUsing` switch, which routes the
-                // module/target half through the environment capability
-                // boundary.
-                match self.top_level_await_verdict() {
-                    TopLevelAwaitVerdict::Allowed => {}
-                    TopLevelAwaitVerdict::CommonJsFile => {
-                        self.error_at_node(
-                            list_idx,
-                            diagnostic_messages::THE_CURRENT_FILE_IS_A_COMMONJS_MODULE_AND_CANNOT_USE_AWAIT_AT_THE_TOP_LEVEL,
-                            diagnostic_codes::THE_CURRENT_FILE_IS_A_COMMONJS_MODULE_AND_CANNOT_USE_AWAIT_AT_THE_TOP_LEVEL,
-                        );
-                    }
-                    TopLevelAwaitVerdict::UnsupportedModuleOrTarget => {
-                        self.error_at_node(
-                            list_idx,
-                            diagnostic_messages::TOP_LEVEL_AWAIT_USING_STATEMENTS_ARE_ONLY_ALLOWED_WHEN_THE_MODULE_OPTION_IS_SET,
-                            diagnostic_codes::TOP_LEVEL_AWAIT_USING_STATEMENTS_ARE_ONLY_ALLOWED_WHEN_THE_MODULE_OPTION_IS_SET,
-                        );
-                    }
-                }
-            } else if !self.enclosing_function_allows_await_using(list_idx) {
-                // TS2852: Nested 'await using' is only valid inside async functions.
-                self.error_at_node(
-                    list_idx,
-                    diagnostic_messages::AWAIT_USING_STATEMENTS_ARE_ONLY_ALLOWED_WITHIN_ASYNC_FUNCTIONS_AND_AT_THE_TOP_LE,
-                    diagnostic_codes::AWAIT_USING_STATEMENTS_ARE_ONLY_ALLOWED_WITHIN_ASYNC_FUNCTIONS_AND_AT_THE_TOP_LE,
-                );
-            }
+        // TS2852/TS2853/TS2854/TS1309: the module/target/async-context grammar
+        // for an `await using` list, once its TS1545-family placement is cleared.
+        // A class static block short-circuits the whole family (answering only
+        // the parser's TS18054) — see `check_await_using_context`.
+        if is_await_using {
+            self.check_await_using_context(list_idx, placement_error);
         }
 
         // VariableDeclarationList uses the same VariableData structure
@@ -1714,30 +1651,6 @@ impl<'a> CheckerState<'a> {
                 );
             }
         }
-    }
-
-    fn enclosing_function_allows_await_using(&self, idx: NodeIndex) -> bool {
-        let Some(function_idx) = self.find_enclosing_function(idx) else {
-            return false;
-        };
-        let Some(node) = self.ctx.arena.get(function_idx) else {
-            return false;
-        };
-
-        self.ctx
-            .arena
-            .get_function(node)
-            .is_some_and(|function| function.is_async)
-            || self
-                .ctx
-                .arena
-                .get_method_decl(node)
-                .is_some_and(|method| self.has_async_modifier(&method.modifiers))
-            || self
-                .ctx
-                .arena
-                .get_accessor(node)
-                .is_some_and(|accessor| self.has_async_modifier(&accessor.modifiers))
     }
 
     /// TS2492: Check if any `let`/`const` declaration in a catch block shadows

--- a/crates/tsz-checker/src/types/type_checking/core.rs
+++ b/crates/tsz-checker/src/types/type_checking/core.rs
@@ -1621,7 +1621,27 @@ impl<'a> CheckerState<'a> {
         let placement_error =
             is_using && self.check_grammar_using_declaration_placement(list_idx, is_await_using);
 
-        if is_await_using && !placement_error && !self.ctx.has_syntax_parse_errors {
+        // tsc's `checkGrammarAwaitOrAwaitUsing` opens with the same
+        // containing-function-or-class-static-block test that
+        // `checkAwaitExpression` does, and the entire TS2852/TS2853/TS2854/TS1309
+        // family lives in its `else` — so a class static block short-circuits the
+        // top-level-eligibility question outright, answering only TS18054
+        // ('await using' cannot be used inside a class static block, emitted by
+        // the parser grammar). Without this gate the top-level walk below
+        // (`is_directly_at_source_file_top_level`) climbs past the static block to
+        // the source file and spuriously fires TS2853; adding the block to that
+        // walk's disqualifying list instead would only swap TS2853 for the nested
+        // TS2852 arm, so the container short-circuit is the tsc-faithful fix. This
+        // mirrors `check_await_expression`'s `await_container_is_class_static_block`
+        // gate for the bare-`await` family. Before #16597 the guard below was
+        // reached only when TS18054 still set `has_syntax_parse_errors`, which
+        // masked this; TS18054 is now non-suppressing, so the decline has to be
+        // made here on its own.
+        if is_await_using
+            && !placement_error
+            && !self.ctx.has_syntax_parse_errors
+            && !self.await_container_is_class_static_block(list_idx)
+        {
             use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
 
             // Same top-level-await-eligibility predicate as `check_await_expression`

--- a/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
+++ b/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
@@ -1015,7 +1015,7 @@ impl<'a> CheckerState<'a> {
     /// block anywhere above, so an `await` inside a function nested in a static
     /// block (`class C { static { void (async () => await 1); } }`) keeps
     /// answering from its own function.
-    fn await_container_is_class_static_block(&self, idx: NodeIndex) -> bool {
+    pub(crate) fn await_container_is_class_static_block(&self, idx: NodeIndex) -> bool {
         let mut current = idx;
         let mut iterations = 0;
         loop {

--- a/crates/tsz-checker/src/types/type_checking/using_declaration_placement.rs
+++ b/crates/tsz-checker/src/types/type_checking/using_declaration_placement.rs
@@ -1,14 +1,120 @@
-//! Placement grammar for `using` / `await using` declaration lists —
-//! TS1545, TS1546, TS1547, TS1548.
+//! Grammar for `using` / `await using` declaration lists: the TS1545-TS1548
+//! placement rules and the `await using` module/target/async-context family
+//! (TS2852, TS2853, TS2854, TS1309).
 //!
-//! Extracted from `core.rs` to keep module size manageable; the single caller is
-//! `check_variable_declaration_list_with_request` there.
+//! Extracted from `core.rs` to keep module size manageable; the entry points
+//! (`check_grammar_using_declaration_placement`, `check_await_using_context`)
+//! are both driven from `check_variable_declaration_list_with_request` there.
 
+use super::core_statement_checks::TopLevelAwaitVerdict;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 
 impl CheckerState<'_> {
+    /// TS2852/TS2853/TS2854/TS1309: the module/target/async-context grammar for
+    /// an `await using` declaration list, once its TS1545-family placement has
+    /// been cleared. The caller gates this on the list actually being an
+    /// `await using` (the `USING`-with-`CONST` flag pair); `placement_error`
+    /// carries whether `check_grammar_using_declaration_placement` already
+    /// reported, which suppresses this family the way tsc's early return does.
+    ///
+    /// tsc's `checkGrammarAwaitOrAwaitUsing` opens with the same
+    /// containing-function-or-class-static-block test that `checkAwaitExpression`
+    /// does, and this whole family lives in its `else` — so a class static block
+    /// short-circuits the top-level-eligibility question outright, answering only
+    /// TS18054 (`'await using'` cannot be used inside a class static block,
+    /// emitted by the parser grammar). Without the
+    /// `await_container_is_class_static_block` gate the top-level walk
+    /// (`is_directly_at_source_file_top_level`) climbs past the static block to
+    /// the source file and spuriously fires TS2853; adding the block to that
+    /// walk's disqualifying list instead would only swap TS2853 for the nested
+    /// TS2852 arm, so the container short-circuit is the tsc-faithful fix,
+    /// mirroring `check_await_expression`'s gate for the bare-`await` family.
+    /// Before #16597 this was reached only when TS18054 still set
+    /// `has_syntax_parse_errors`; TS18054 is now non-suppressing, so the decline
+    /// is made here on its own.
+    pub(super) fn check_await_using_context(&mut self, list_idx: NodeIndex, placement_error: bool) {
+        use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+
+        if placement_error
+            || self.ctx.has_syntax_parse_errors
+            || self.await_container_is_class_static_block(list_idx)
+        {
+            return;
+        }
+
+        // Same top-level-await-eligibility predicate as `check_await_expression`
+        // (#16072): a namespace body disqualifies `await using` from being top
+        // level without being function-like, so this is not `function_depth == 0`.
+        if self.is_directly_at_source_file_top_level(list_idx) {
+            // TS2853: Top-level 'await using' is only valid in modules.
+            if self.top_level_await_requires_module_diagnostic() {
+                self.error_at_node(
+                    list_idx,
+                    diagnostic_messages::AWAIT_USING_STATEMENTS_ARE_ONLY_ALLOWED_AT_THE_TOP_LEVEL_OF_A_FILE_WHEN_THAT_FIL,
+                    diagnostic_codes::AWAIT_USING_STATEMENTS_ARE_ONLY_ALLOWED_AT_THE_TOP_LEVEL_OF_A_FILE_WHEN_THAT_FIL,
+                );
+            }
+
+            // TS1309 when a Node module kind pairs with a CommonJS-format file;
+            // otherwise TS2854, which requires specific module + target options.
+            // Both answers come from the shared `checkGrammarAwaitOrAwaitUsing`
+            // switch, which routes the module/target half through the environment
+            // capability boundary.
+            match self.top_level_await_verdict() {
+                TopLevelAwaitVerdict::Allowed => {}
+                TopLevelAwaitVerdict::CommonJsFile => {
+                    self.error_at_node(
+                        list_idx,
+                        diagnostic_messages::THE_CURRENT_FILE_IS_A_COMMONJS_MODULE_AND_CANNOT_USE_AWAIT_AT_THE_TOP_LEVEL,
+                        diagnostic_codes::THE_CURRENT_FILE_IS_A_COMMONJS_MODULE_AND_CANNOT_USE_AWAIT_AT_THE_TOP_LEVEL,
+                    );
+                }
+                TopLevelAwaitVerdict::UnsupportedModuleOrTarget => {
+                    self.error_at_node(
+                        list_idx,
+                        diagnostic_messages::TOP_LEVEL_AWAIT_USING_STATEMENTS_ARE_ONLY_ALLOWED_WHEN_THE_MODULE_OPTION_IS_SET,
+                        diagnostic_codes::TOP_LEVEL_AWAIT_USING_STATEMENTS_ARE_ONLY_ALLOWED_WHEN_THE_MODULE_OPTION_IS_SET,
+                    );
+                }
+            }
+        } else if !self.enclosing_function_allows_await_using(list_idx) {
+            // TS2852: Nested 'await using' is only valid inside async functions.
+            self.error_at_node(
+                list_idx,
+                diagnostic_messages::AWAIT_USING_STATEMENTS_ARE_ONLY_ALLOWED_WITHIN_ASYNC_FUNCTIONS_AND_AT_THE_TOP_LE,
+                diagnostic_codes::AWAIT_USING_STATEMENTS_ARE_ONLY_ALLOWED_WITHIN_ASYNC_FUNCTIONS_AND_AT_THE_TOP_LE,
+            );
+        }
+    }
+
+    /// Whether the nearest enclosing function of `idx` is `async`, which is what
+    /// licenses a non-top-level `await using` (the TS2852 negative arm).
+    fn enclosing_function_allows_await_using(&self, idx: NodeIndex) -> bool {
+        let Some(function_idx) = self.find_enclosing_function(idx) else {
+            return false;
+        };
+        let Some(node) = self.ctx.arena.get(function_idx) else {
+            return false;
+        };
+
+        self.ctx
+            .arena
+            .get_function(node)
+            .is_some_and(|function| function.is_async)
+            || self
+                .ctx
+                .arena
+                .get_method_decl(node)
+                .is_some_and(|method| self.has_async_modifier(&method.modifiers))
+            || self
+                .ctx
+                .arena
+                .get_accessor(node)
+                .is_some_and(|accessor| self.has_async_modifier(&accessor.modifiers))
+    }
+
     /// TS1545/TS1546/TS1547/TS1548: where a `using` / `await using` declaration
     /// list is allowed to stand.
     ///


### PR DESCRIPTION
Fixes #16598.

When `await using` is written inside a class static block, `tsc@7.0.2` reports **only** TS18054 (`'await using' statements cannot be used inside a class static block`). tsz additionally fired a spurious TS2853 (`'await using' statements are only allowed at the top level of a file when that file is a module...`).

```ts
declare function foo(): any;
class C {
  static {
    await using x = foo();   // tsc: TS18054 only; tsz (before): TS18054 + TS2853
  }
}
```

## Structural rule

When an `await using` declaration's containing-function-or-class-static-block is a **class static block**, tsc does not ask the top-level-await-using eligibility question at all — its `checkGrammarAwaitOrAwaitUsing` opens with the same class-static-block test that `checkAwaitExpression` does, and the entire TS2852 / TS2853 / TS2854 / TS1309 family lives in its `else` branch. So a static block short-circuits the family outright, answering only the parser-emitted TS18054.

tsz answered this through `check_variable_declaration_list_with_request` (solver-adjacent checker grammar, `types/type_checking/core.rs`), which routed `await using` straight into `is_directly_at_source_file_top_level`. That walk climbs past a class static block to the source file and returns `true`, so TS2853 fired. The bare-`await` path already guards this with `await_container_is_class_static_block`; the `await using` path had no equivalent gate.

The bug was previously masked: TS18054 used to set `has_syntax_parse_errors`, which the `!has_syntax_parse_errors` guard on the await-using block relied on to skip. #16597 correctly moved TS18054 into `is_parser_grammar_code` (non-suppressing), removing that accidental masking and exposing the missing container gate.

## Fix

Owner layer: checker grammar (`core.rs`). Gate the whole await-using top-level/nested family behind `!await_container_is_class_static_block(list_idx)`, mirroring the bare-`await` family. Adding `CLASS_STATIC_BLOCK_DECLARATION` to `is_directly_at_source_file_top_level`'s disqualifying-container list instead would only swap TS2853 for the nested TS2852 arm (tsc emits neither), so the container short-circuit is the tsc-faithful fix.

Adjacent-case matrix (all new tests, parse-health-blind harness so `has_syntax_parse_errors` stays false exactly as the compiled CLI does post-#16597):
- static block `await using` → silent of TS2852/2853/2854 (the fix); renamed-binder control.
- sibling top-level `await using` in the same non-module file → still TS2853 (gate is per-declaration container, never file-wide).
- `await using` in a non-async function nested in the static block → still TS2852 (walk stops at the first function-like ancestor).
- pre-existing parse-health-aware tests (TS18054 present, TS2853 absent) continue to hold.

Also corrects a stale doc comment on `static_block_direct_await_using_reports_only_ts18054` that described a `CLASS_STATIC_BLOCK_DECLARATION`-in-disqualifying-list mechanism that was never actually in the code.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib await_static_block` — 22 passed / 0 failed (includes 3 new non-vacuous regression tests).
- Related targets: `ts2852_await_using_context_tests`, `top_level_await_grammar_diagnostics_tests`, `using_declaration_placement_grammar_tests`, `class_member_body_function_boundary_tests`.
- Checker-only, diagnostic-only change: no emitter surface touched, so JS/DTS emit counts are unaffected.
- clippy + arch-size (the per-merge CI lane).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoYCazSiYkCgQ6EzwbFZDr)_