### PR TITLE
test(checker): pin the well-known-symbol syntactic key parity matrix (#16307)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1113,6 +1113,9 @@ path = "tests/ts2353_generic_constraint_excess_property_tests.rs"
 name = "ts2353_cross_module_symbol_computed_key_tests"
 path = "tests/ts2353_cross_module_symbol_computed_key_tests.rs"
 [[test]]
+name = "well_known_symbol_syntactic_key_parity_tests"
+path = "tests/well_known_symbol_syntactic_key_parity_tests.rs"
+[[test]]
 name = "wide_symbol_computed_member_index_signature_tests"
 path = "tests/wide_symbol_computed_member_index_signature_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/well_known_symbol_syntactic_key_parity_tests.rs
+++ b/crates/tsz-checker/tests/well_known_symbol_syntactic_key_parity_tests.rs
@@ -1,0 +1,202 @@
+//! Parity matrix for the well-known-symbol *syntactic* key rule (#16307).
+//!
+//! `tsc` decides whether `Symbol.<member>` denotes the well-known symbol itself
+//! from the SYNTAX (`isWellKnownSymbolSyntactically`) — reach to the global
+//! `Symbol` value — never from `<member>`'s declared kind on the (possibly
+//! user-augmented) `SymbolConstructor` interface. So a `declare global`
+//! augmentation that types a member as plain `symbol` (xstate's
+//! `Symbol.observable` interop convention) does NOT make `[Symbol.observable]`
+//! fold into a symbol index signature: it stays its own named member, and a
+//! wide `symbol` key cannot index the containing type.
+//!
+//! Every row below was oracle-verified against the pinned `typescript@7.0.2`
+//! (`scripts/conformance/typescript-versions.json`) with
+//! `--noEmit --strict --lib esnext --target es2022`.
+//!
+//! Coverage history, because this issue has repeatedly been mis-tracked: the
+//! *assignability* half of this rule is pinned in
+//! `wide_symbol_computed_member_index_signature_tests.rs`, but the ELEMENT
+//! ACCESS half — the reads that must report `TS7053` — had no coverage at all,
+//! which is why two board sessions carried it as "still open" for two days
+//! after it had actually started passing. Same failure mode #16572 was opened
+//! to fix for the two other legs of this issue.
+
+use tsz_checker::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs, load_default_lib_files};
+
+fn diagnostic_codes(source: &str) -> Vec<u32> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(source, "test.ts", CheckerOptions::default(), &libs)
+        .iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+fn assert_reports_ts7053(label: &str, source: &str) {
+    let codes = diagnostic_codes(source);
+    assert!(
+        codes.contains(&7053),
+        "{label}: a wide `symbol` key cannot index a type with no symbol index \
+         signature; tsc 7.0.2 reports TS7053 here, got: {codes:?}"
+    );
+}
+
+#[test]
+fn wide_symbol_read_against_a_well_known_keyed_interface_reports_ts7053() {
+    // `[Symbol.observable]` is a NAMED member even though the augmentation
+    // types `observable` as plain `symbol`, so `I` has no symbol index
+    // signature and `i[other]` is an implicit-any element access.
+    assert_reports_ts7053(
+        "interface",
+        r#"
+declare global { interface SymbolConstructor { readonly observable: symbol } }
+declare const other: symbol;
+interface I { [Symbol.observable]: number }
+declare const i: I;
+export const a = i[other];
+"#,
+    );
+}
+
+#[test]
+fn wide_symbol_read_against_a_well_known_keyed_class_reports_ts7053() {
+    assert_reports_ts7053(
+        "class",
+        r#"
+declare global { interface SymbolConstructor { readonly observable: symbol } }
+declare const other: symbol;
+class C { [Symbol.observable]() { return 1 } }
+declare const c: C;
+export const b = c[other];
+"#,
+    );
+}
+
+#[test]
+fn wide_symbol_read_against_a_well_known_keyed_object_literal_reports_ts7053() {
+    assert_reports_ts7053(
+        "object literal",
+        r#"
+declare global { interface SymbolConstructor { readonly observable: symbol } }
+declare const other: symbol;
+const o = { [Symbol.observable]: 1 };
+export const d = o[other];
+"#,
+    );
+}
+
+#[test]
+fn wide_symbol_read_against_a_plain_named_interface_reports_ts7053() {
+    // Negative control on the other axis: no symbols are involved in the
+    // TARGET at all. The rule is about the receiver lacking a symbol index
+    // signature, not about how its members were keyed — so a plain interface
+    // must report the same TS7053, and a fix in this family must not be
+    // narrowed to symbol-keyed receivers.
+    assert_reports_ts7053(
+        "plain named interface",
+        r#"
+declare const other: symbol;
+interface P { m: number }
+declare const p: P;
+export const e = p[other];
+"#,
+    );
+}
+
+#[test]
+fn wide_symbol_read_against_a_genuine_well_known_keyed_interface_reports_ts7053() {
+    // `Symbol.iterator` is a real `unique symbol` on `SymbolConstructor`, so
+    // this row must behave identically to the augmented-wide rows above —
+    // proving the reported behaviour does not depend on the declared kind.
+    assert_reports_ts7053(
+        "Symbol.iterator",
+        r#"
+declare const other: symbol;
+interface H { [Symbol.iterator](): number }
+declare const h: H;
+export const f = h[other];
+"#,
+    );
+}
+
+#[test]
+fn well_known_keyed_interface_is_not_assignable_to_a_symbol_index_signature() {
+    // The assignability consequence of the same rule, in the direction the
+    // element-access rows above do not cover: because `[Symbol.observable]` is
+    // a named member and not an index signature, `I` does not satisfy
+    // `{ [k: symbol]: number }`. tsc 7.0.2 reports TS2322 with
+    // "Index signature for type 'symbol' is missing in type 'I'".
+    let codes = diagnostic_codes(
+        r#"
+declare global { interface SymbolConstructor { readonly observable: symbol } }
+interface I { [Symbol.observable]: number }
+declare const i: I;
+export const t: { [k: symbol]: number } = i;
+"#,
+    );
+    assert!(
+        codes.contains(&2322),
+        "a well-known-keyed interface supplies no symbol index signature, so \
+         tsc reports TS2322; got: {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Known-failing rows, filed as their own issue rather than fixed here.
+//
+// The two rows below are `keyof` / indexed-access over a WELL-KNOWN symbol
+// key. They are the same `UniqueSymbol(SymbolRef)` <-> `[Symbol.xxx]` atom
+// round-trip that `TypeEvaluator::symbol_named_atom_from_unique_symbol_ref`
+// exists for, not applied on these two paths. Pinned as asserting `#[ignore]`d
+// tests carrying their oracle rows so they flip loudly when the round-trip is
+// fixed, instead of staying a silent absence.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "known failure: keyof over a well-known-symbol-keyed interface does not reduce to the well-known symbol (false TS2322)"]
+fn keyof_a_well_known_symbol_keyed_interface_reduces_to_the_well_known_symbol() {
+    // tsc 7.0.2: exit 0 — `keyof I` IS `typeof Symbol.iterator`.
+    // tsz today: TS2322 "Type 'keyof I' is not assignable to type 'unique symbol'."
+    //
+    // The equivalent shape keyed by a user-authored `unique symbol` binding
+    // (`declare const u: unique symbol; interface I { [u]: number }`) is
+    // already clean, so the gap is specific to the well-known leg.
+    let codes = diagnostic_codes(
+        r#"
+interface I { [Symbol.iterator]: number }
+type K = keyof I;
+declare const k: K;
+export const a: typeof Symbol.iterator = k;
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "keyof over a well-known-symbol-keyed interface must reduce to that \
+         symbol, so the assignment is clean like tsc; got: {codes:?}"
+    );
+}
+
+#[test]
+#[ignore = "known failure: indexed access by a well-known symbol type leaks the __unique_N placeholder (TS2339/TS2538)"]
+fn indexed_access_by_a_well_known_symbol_type_resolves_the_member() {
+    // tsc 7.0.2: exit 0 — `I[typeof Symbol.iterator]` is `number`.
+    // tsz today, three diagnostics, the first of which leaks an internal key
+    // into user-facing text exactly as #16307's title describes:
+    //   TS2339 "Property '__unique_5' does not exist on type 'I'."
+    //   TS2538 "Type 'unique symbol' cannot be used as an index type."
+    //   TS2322 "Type 'undefined' is not assignable to type 'number'."
+    let codes = diagnostic_codes(
+        r#"
+interface I { [Symbol.iterator]: number }
+declare const i: I;
+export const a: number = i[Symbol.iterator];
+type V = I[typeof Symbol.iterator];
+export const b: number = null as any as V;
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "an indexed access keyed by a well-known symbol type must resolve the \
+         member stored under its canonical `[Symbol.xxx]` atom; got: {codes:?}"
+    );
+}


### PR DESCRIPTION
## Goal

Goal: hold

## Structural rule

When a computed member key is written as the property access `Symbol.[ member ]`, `tsc` decides it denotes the well-known symbol itself from the SYNTAX (`isWellKnownSymbolSyntactically`) — reach to the global `Symbol` value — never from `[ member ]`'s declared kind on the (possibly user-augmented) `SymbolConstructor`. So a `declare global` augmentation typing the member as plain `symbol` (xstate's `Symbol.observable` interop convention) leaves `[Symbol.observable]` a **named** member, the containing type gains **no** symbol index signature, and a wide `symbol` key therefore cannot index it — `TS7053`. tsz does this through the checker's `well_known_symbol_property_name` / `is_well_known_symbol_syntax` discriminator plus the element-access wide-symbol path in `types/computation/access.rs`.

**tsz already matches `tsc` on every row.** This PR adds no source change; it pins the rule.

## Why this was worth an hour

This is the last item #16307 carried as "still open" — filed by one session on 2026-08-04 and re-listed as unfixed by another at 08:00Z today, both times sized as its own session of work. It is not open. It closed at some point in the eight-PR chain on that issue, and nothing detected that, because **the element-access half of the rule had zero test coverage** — the assignability half is pinned in `wide_symbol_computed_member_index_signature_tests.rs`, the reads were not pinned anywhere. That is exactly the condition #16572 was opened to fix for the two *other* legs of the same issue.

The named site in the original filing (`wide_well_known_symbol_member_key`) no longer exists in the tree, so the suggested fix could not have been applied verbatim either.

## What lands

Six rows, all currently green, all oracle-verified against the pinned `typescript@7.0.2`:

| Row | tsc 7.0.2 | tsz `f079f80` |
|---|---|---|
| `interface I { [Symbol.observable]: number }`, read `i[other]` | TS7053 | TS7053 |
| `class C { [Symbol.observable]() {} }`, read `c[other]` | TS7053 | TS7053 |
| `const o = { [Symbol.observable]: 1 }`, read `o[other]` | TS7053 | TS7053 |
| plain `interface P { m: number }`, read `p[other]` | TS7053 | TS7053 |
| genuine well-known `[Symbol.iterator]`, read `h[other]` | TS7053 | TS7053 |
| `const t: { [k: symbol]: number } = i` | TS2322 | TS2322 |

Rows 4 and 5 are deliberate controls on the two axes a future fix could wrongly narrow to: row 4 has no symbols in the receiver at all (the rule is about the receiver lacking a symbol index signature, not about how its members were keyed), row 5 uses a member declared `unique symbol` on `SymbolConstructor` (proving the behaviour does not depend on the declared kind).

## Two genuinely-failing rows found while sweeping, pinned as `#[ignore]`d

Both are the `UniqueSymbol(SymbolRef)` &lt;-&gt; `[Symbol.xxx]` atom round-trip that `TypeEvaluator::symbol_named_atom_from_unique_symbol_ref` (`evaluate_rules/keyof.rs`) exists for, not applied on these two paths. Filed as **#16605**; pinned here as asserting `#[ignore]`d tests carrying their oracle output so they flip loudly when fixed rather than staying a silent absence.

1. `keyof` over a well-known-symbol-keyed interface does not reduce to that symbol — false `TS2322: Type 'keyof I' is not assignable to type 'unique symbol'` where tsc is clean. The same shape keyed by a user-authored `unique symbol` binding is already clean, so the gap is specific to the well-known leg.
2. An indexed access keyed by a well-known symbol type leaks the internal placeholder: `TS2339: Property '__unique_5' does not exist on type 'I'` — the exact leak #16307's title describes, at a site nobody had covered.

## Verification

- `cargo test -p tsz-checker --test well_known_symbol_syntactic_key_parity_tests` — **6 passed, 2 ignored**.
- Same target with `-- --ignored` — **0 passed, 2 failed**, confirming the two known-failing rows are real assertions and not vacuous.
- `cargo test -p tsz-checker --test wide_symbol_computed_member_index_signature_tests` — 26/26, unchanged.
- `cargo fmt --all -- --check` clean; `cargo clippy -p tsz-checker --test well_known_symbol_syntactic_key_parity_tests -- -D warnings` clean; `scripts/arch/arch_guard.py` passed. Pre-commit hook (clippy + affected-crate tests + arch guard) passed.
- Oracle: pinned `typescript@7.0.2` per `scripts/conformance/typescript-versions.json`, `--noEmit --strict --lib esnext --target es2022`, every row run in both directions.
- **No corpus gate owed.** `git diff --name-only origin/main...HEAD` is `crates/tsz-checker/Cargo.toml` and `crates/tsz-checker/tests/well_known_symbol_syntactic_key_parity_tests.rs` — no `crates/**/src` production path, so conformance and emit counts cannot move.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Sunstone