### PR TITLE
fix(checker): a class static block short-circuits the top-level `await using` grammar family (TS2853/TS2854/TS2852)

### DIFF
--- a/crates/tsz-checker/src/tests/await_static_block_grammar_tests.rs
+++ b/crates/tsz-checker/src/tests/await_static_block_grammar_tests.rs
@@ -161,10 +161,20 @@ class Gate { static { let x = 1; while (x) { x = 0; } } }
 /// `in_static_block_context()` gate. tsc never pairs this with TS2853
 /// ("...only allowed at the top level of a file...") — the two are mutually
 /// exclusive by container (`getContainingFunctionOrClassStaticBlock`
-/// resolving to the static block short-circuits tsc's top-level-await-using
-/// eligibility check entirely) — which also exercises the
-/// `is_directly_at_source_file_top_level` fix that added
-/// `CLASS_STATIC_BLOCK_DECLARATION` to its disqualifying-container list.
+/// resolving to the static block short-circuits tsc's top-level-`await using`
+/// eligibility check entirely). The checker declines the whole
+/// TS2852/TS2853/TS2854 family via the `find_enclosing_static_block` guard in
+/// `check_variable_declaration_list_with_request` (#16598).
+///
+/// This parse-health-aware helper cannot, on its own, prove the checker
+/// declines: it sets `has_syntax_parse_errors` from *any* parser diagnostic,
+/// so the parser's TS18054 suppresses this whole checker block regardless of
+/// the guard. Production is stricter — TS18054 is `is_parser_grammar_code`
+/// (non-suppressing) since #16597, so the checker walk actually runs there.
+/// The blind-helper test
+/// `static_block_await_using_is_silent_in_the_checker_walk_without_suppression`
+/// below is the one that pins the fix; this case pins the parser+checker
+/// combined verdict a user sees.
 #[test]
 fn static_block_direct_await_using_reports_only_ts18054() {
     let codes = check_source_codes_with_parse_health(
@@ -361,5 +371,88 @@ class Harness { static { const build = function () { return await 2; }; void bui
         "the nested function expression is its own container, so its non-async \
          `await` answers TS1308 rather than deferring to the enclosing static \
          block; got {codes:?}"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// #16598: the `await using` twin of the exclusivity above, isolated from
+// parse-health suppression.
+//
+// The parse-health-aware helper cannot see this bug: it sets
+// `has_syntax_parse_errors` from the parser's TS18054, which suppresses the
+// checker's whole top-level-`await using` block, so TS2853 never surfaces there
+// even without the fix. Production is stricter — TS18054 is
+// `is_parser_grammar_code` (non-suppressing) since #16597 — so the checker walk
+// actually runs and, before #16598, leaked TS2853/TS2854 (or nested TS2852).
+// `check_source_codes` is the parse-health-*blind* helper (never wires
+// `has_syntax_parse_errors`), so it shows exactly what the checker walk decides
+// on its own — the same instrument the `await`-expression twin above uses.
+// -----------------------------------------------------------------------------
+
+/// The core of #16598: a static block's own `await using` must draw none of the
+/// top-level-`await using` family from the checker walk, with nothing
+/// suppressing it. `find_enclosing_static_block` declines at the source.
+#[test]
+fn static_block_await_using_is_silent_in_the_checker_walk_without_suppression() {
+    let codes = crate::test_utils::check_source_codes(
+        r#"
+class Gate { static { await using x = 1; } }
+"#,
+    );
+    assert!(
+        !codes.contains(&2853) && !codes.contains(&2854) && !codes.contains(&2852),
+        "tsc's checkGrammarAwaitOrAwaitUsing short-circuits on the containing \
+         class static block, so the whole TS2852/2853/2854 family must decline \
+         here on its own rather than relying on the parser's TS18054 to suppress \
+         it; got {codes:?}"
+    );
+}
+
+/// Module-ness is irrelevant to the static-block short-circuit: even with
+/// `export {}` present (which would otherwise clear TS2853 for a *real*
+/// top-level `await using`), a static block's `await using` still draws nothing
+/// from the walk — and the sibling top-level `await using` in the same file
+/// *does*, proving the guard is scoped to the static block and not the file.
+#[test]
+fn static_block_await_using_is_silent_but_a_sibling_top_level_one_still_reports() {
+    let codes = crate::test_utils::check_source_codes(
+        r#"
+await using outer = 1;
+class Latch { static { await using inner = 2; } }
+"#,
+    );
+    // The file is not a module (no import/export), so the real top-level
+    // `await using outer` draws TS2853; the static block's `inner` must not add
+    // a second one.
+    assert_eq!(
+        codes.iter().filter(|&&c| c == 2853).count(),
+        1,
+        "exactly the module-scope `await using` earns TS2853; the static block's \
+         must stay silent; got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2852),
+        "the static block's `await using` must not fall through to the nested \
+         TS2852 arm either; got {codes:?}"
+    );
+}
+
+/// Container-walk boundary twin: an `await using` inside a function *nested* in
+/// a static block answers from its own function (TS2852, non-async), not from
+/// the static block. `find_enclosing_static_block` stops at the first function
+/// boundary rather than searching upward, matching
+/// `getContainingFunctionOrClassStaticBlock`.
+#[test]
+fn await_using_in_a_non_async_function_nested_in_a_static_block_still_reports() {
+    let codes = crate::test_utils::check_source_codes(
+        r#"
+class Harness { static { function build() { await using r = 1; return r; } void build; } }
+"#,
+    );
+    assert!(
+        codes.contains(&2852),
+        "the nested non-async function is its own container, so its `await using` \
+         answers TS2852 rather than deferring to the enclosing static block; got \
+         {codes:?}"
     );
 }

--- a/crates/tsz-checker/src/types/type_checking/core.rs
+++ b/crates/tsz-checker/src/types/type_checking/core.rs
@@ -1623,12 +1623,12 @@ impl<'a> CheckerState<'a> {
 
         if is_await_using && !placement_error && !self.ctx.has_syntax_parse_errors {
             use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-
-            // Same top-level-await-eligibility predicate as `check_await_expression`
-            // (#16072): a namespace body disqualifies `await using` from being
-            // top level without being function-like, so this is not
-            // `function_depth == 0`.
-            if self.is_directly_at_source_file_top_level(list_idx) {
+            // A class static block short-circuits the whole top-level-`await using`
+            // family (TS2852/2853/2854): tsc answers only the parser's TS18054
+            // there. A dedicated guard, since a static block is not the file's top
+            // level and `is_directly_…` would else fall through to TS2852 (#16598).
+            if self.find_enclosing_static_block(list_idx).is_some() {
+            } else if self.is_directly_at_source_file_top_level(list_idx) {
                 // TS2853: Top-level 'await using' is only valid in modules.
                 if self.top_level_await_requires_module_diagnostic() {
                     self.error_at_node(


### PR DESCRIPTION
Fixes #16598.

**Structural rule:** When an `await using` declaration's containing function-or-class-static-block resolves to a **class static block**, `tsc`'s `checkGrammarAwaitOrAwaitUsing` answers only the static-block grammar diagnostic (TS18054) and short-circuits before the top-level-`await using` eligibility check — so the whole `TS2852`/`TS2853`/`TS2854` family is unreachable there. tsz now does the same through the checker (`check_variable_declaration_list_with_request`), via `find_enclosing_static_block`.

### What was wrong
The `await using` path had no static-block short-circuit. `is_directly_at_source_file_top_level` walks *past* a class static block (it is not function-like) up to the source file and answers `true`, so:

```ts
declare function foo(): any;
class C { static { await using x = foo(); } }
```

drew a spurious `TS2853` alongside the correct `TS18054`. `tsc@7.0.2` reports only `TS18054`.

The leak stayed masked until #16597 made `TS18054` a non-suppressing `is_parser_grammar_code` (matching tsc keeping `hasParseDiagnostics` false). Before that, the parser's `TS18054` set `has_syntax_parse_errors`, which suppressed this entire checker block by accident. The checker now declines on its own — mirroring the sibling `await` expression (`await_container_is_class_static_block`) and `for await` (`find_enclosing_static_block`) paths.

### Owner layer & altitude
Checker (`crates/tsz-checker/.../type_checking/core.rs`). A **dedicated guard**, not a `CLASS_STATIC_BLOCK_DECLARATION` case in `is_directly_at_source_file_top_level`: a static block is not the file's own top level, so that predicate must keep answering `false` there — otherwise the walk falls through to the `TS2852` "only allowed within async functions" arm, which tsc does not emit for a static block either. Only suppressing the whole family matches tsc. This routes the third `await`-grammar construct through the already-shared `find_enclosing_static_block` helper (used by `for await`), reducing divergence rather than adding a fourth ad-hoc predicate.

### Adjacent-case matrix (all covered by tests)
- static block `await using` → only `TS18054`, none of `TS2852/2853/2854` (positive)
- module-scope `await using` in the same file → still `TS2853` (guard is scoped to the block, not the file)
- `await using` in a non-async function nested in a static block → still `TS2852` (container-walk boundary)
- `await using` in a nested async arrow inside a static block → clean (its own container licenses it)
- for-of / C-style-for `await using` heads → same funnel, covered
- plain (non-await) `using` in a static block → unaffected
- renamed binders throughout

The new tests use the parse-health-**blind** checker helper: the existing parse-health-aware test could not catch this because that helper sets `has_syntax_parse_errors` from the parser's `TS18054`, suppressing the checker block regardless of the guard — the scoped-gate blind spot that hid this from the unit layer. The blind helper shows the checker walk declining on its own.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib await_static_block_grammar` — 22 passed (incl. 3 new blind-helper tests)
- `cargo test -p tsz-checker --test ts2852_await_using_context_tests --test top_level_await_grammar_diagnostics_tests --test using_declaration_placement_grammar_tests` — 6 / 6 / 30 passed
- `cargo test -p tsz-checker --lib top_level_await` — 62 passed
- `cargo test -p tsz-cli class_static_block_grammar` — 5 passed
- `cargo clippy -p tsz-checker --lib` — clean; architecture guard passes (core.rs at 2000-line limit)
- Built `--release` binary, oracle repro: static-block `await using` → only `TS18054`; control top-level `await using` (non-module) → still `TS2853`

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcujFvQ1HAroZ8wiyvyNBW)_