### PR TITLE
fix(checker): a readonly tuple target's missing-property mismatch reaches TS2741 (#16552)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/render_failure_missing_property.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure_missing_property.rs
@@ -116,8 +116,7 @@ impl<'a> CheckerState<'a> {
             let target_is_array_or_tuple =
                 crate::query_boundaries::common::array_element_type(self.ctx.types, target)
                     .is_some()
-                    || crate::query_boundaries::common::tuple_list_id(self.ctx.types, target)
-                        .is_some();
+                    || crate::query_boundaries::common::is_tuple_type(self.ctx.types, target);
             let target_has_index = !target_is_array_or_tuple
                 && crate::query_boundaries::index_signature::has_string_or_number_index_signature(
                     self.ctx.types,
@@ -173,7 +172,7 @@ impl<'a> CheckerState<'a> {
         let target_evaluated = self.evaluate_type_with_env(target);
         let target_is_array_or_tuple_for_idx =
             crate::query_boundaries::common::array_element_type(self.ctx.types, target).is_some()
-                || crate::query_boundaries::common::tuple_list_id(self.ctx.types, target).is_some();
+                || crate::query_boundaries::common::is_tuple_type(self.ctx.types, target);
         let source_has_index = [source, source_evaluated].iter().any(|t| {
             crate::query_boundaries::index_signature::has_string_or_number_index_signature(
                 self.ctx.types,

--- a/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
+++ b/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
@@ -1393,3 +1393,100 @@ fn an_array_variable_assigned_to_a_tuple_member_keeps_the_arity_reason() {
         "an unbounded array source genuinely may have fewer: {diagnostics:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// A `readonly` tuple target reaches the same `TS2741` a mutable tuple does.
+//
+// Structural rule, oracled against `typescript@7.0.2`
+// (`--noEmit --strict --pretty --target es2022 --lib es2022`): tsc elaborates
+// a `readonly [T]` target's missing-property mismatch exactly like `[T]`'s —
+// the `readonly` modifier is not itself the failure. tsz's solver already
+// gets this right end-to-end (`explain_tuple_failure` returns the correct
+// `MissingProperty` reason for both), so the bug is a checker-side rendering
+// gate mis-firing, not a missing solver descent.
+//
+// Root cause: `render_missing_property`'s "target has an index signature but
+// the missing property is not one of its own named properties" bail-out
+// (`crates/tsz-checker/src/error_reporter/render_failure_missing_property.rs`)
+// decides whether the target is array/tuple-shaped with
+// `array_element_type(target).is_some() || tuple_list_id(target).is_some()`.
+// `array_element_type` (`type_queries::data::get_array_element_type`) already
+// unwraps a `ReadonlyType` wrapper, but `tuple_list_id`
+// (`visitors::visitor_extract::tuple_list_id`) does not — it matches only
+// `TypeData::Tuple` directly. For a `readonly [T]` target that asymmetry
+// makes `target_is_array_or_tuple` false, so the tuple's own implicit numeric
+// index signature is treated as a real index signature, the missing property
+// (a named property of the *element*, not the tuple) fails the "named
+// property of target" check, and the function bails to a bare `TS2322` with
+// no elaboration at all — before the tuple-element drill this file's anchor
+// walk depends on ever runs. This is exactly why `Array<T>`/`ReadonlyArray<T>`/
+// `readonly T[]` were already fixed (#16551/#16556) while the tuple spelling
+// alone stayed broken (#16552): every one of those goes through
+// `array_element_type`, which already peels `readonly`.
+//
+// The fix swaps the raw `tuple_list_id(target).is_some()` check for
+// `is_tuple_type(target)` (`visitors::visitor_predicates::is_tuple_type`),
+// which already peels `ReadonlyType`/`Substitution` — the same query this
+// file's own anchor walk and the solver's `explain.rs` already use for the
+// identical "is this shape a tuple" question. `tuple_list_id` itself is left
+// alone: it has 24 call sites across the solver's core relation dispatch, and
+// widening what it matches is a much larger blast radius than this one
+// boolean gate needs.
+// ---------------------------------------------------------------------------
+
+/// The headline row: a `readonly` tuple member's missing-property failure
+/// reaches `TS2741`, matching the mutable-tuple case
+/// (`tuple_member_missing_property_is_not_reported_as_an_arity_gap` above).
+/// Oracle: `2:23 - TS2741 Property 'rq' is missing in type '{ rp: number; }' …`
+#[test]
+fn readonly_tuple_member_missing_property_reaches_ts2741() {
+    let source = "type R1 = { tup: readonly [{ rp: number; rq: number }] };\nconst r: R1 = { tup: [{ rp: 1 }] };\n";
+    let diagnostics = check_source_diagnostics(source);
+    assert_eq!(codes(&diagnostics), vec![TS2741], "{diagnostics:?}");
+}
+
+/// The same rule for a `readonly` tuple written directly as a binding's own
+/// annotation, with no wrapping object-literal member — the bail-out this
+/// fixes runs on this shape too, and unlike the member row above needs no
+/// contextual-retype recovery at all: the literal is typed against the
+/// annotation from the start.
+/// Oracle: `2:16 - TS2741 Property 'rq' is missing in type '{ rp: number; }' …`
+#[test]
+fn readonly_tuple_direct_annotation_missing_property_reaches_ts2741() {
+    let source = "type Ro = readonly [{ rp: number; rq: number }];\nconst v: Ro = [{ rp: 1 }];\n";
+    let diagnostics = check_source_diagnostics(source);
+    assert_eq!(codes(&diagnostics), vec![TS2741], "{diagnostics:?}");
+}
+
+/// A multi-element `readonly` tuple: the fix must not just special-case a
+/// one-element tuple, and a genuinely *unrelated* missing-index-signature
+/// bail-out (a real index-signature-vs-index-signature target) must still
+/// fire for the type that is not array/tuple shaped at all.
+#[test]
+fn readonly_tuple_with_two_elements_missing_property_reaches_ts2741() {
+    let source = "type R2 = { tup: readonly [{ ra: number }, { rb: number; rc: number }] };\nconst r: R2 = { tup: [{ ra: 1 }, { rb: 2 }] };\n";
+    let diagnostics = check_source_diagnostics(source);
+    assert_eq!(codes(&diagnostics), vec![TS2741], "{diagnostics:?}");
+}
+
+/// Negative control: a genuine index-signature-to-index-signature target
+/// (not array/tuple-shaped at all) must keep the generic `TS2322` this
+/// bail-out exists for — the fix narrows `target_is_array_or_tuple`'s
+/// readonly blind spot, it does not remove the check.
+/// Oracle: a single `TS2322` — `'string' index signatures are incompatible.`
+#[test]
+fn indexed_object_target_keeps_the_generic_index_signature_mismatch() {
+    let source = "interface SrcIdx { [k: string]: boolean }\ninterface Idx { [k: string]: number }\ndeclare const s: SrcIdx;\nconst v: Idx = s;\n";
+    let diagnostics = check_source_diagnostics(source);
+    assert_eq!(codes(&diagnostics), vec![TS2322], "{diagnostics:?}");
+}
+
+/// Renamed binders and a different property name: the fix keys on the
+/// target's *shape* (readonly tuple), never on an identifier written above
+/// it.
+#[test]
+fn readonly_tuple_recovery_is_not_identifier_keyed() {
+    let source = "type Roster2 = { slots: readonly [{ alpha: string; beta: string }] };\nconst r: Roster2 = { slots: [{ alpha: \"a\" }] };\n";
+    let diagnostics = check_source_diagnostics(source);
+    assert_eq!(codes(&diagnostics), vec![TS2741], "{diagnostics:?}");
+}


### PR DESCRIPTION
Closes the `readonly [T]` row of #16552's table (the `Array`/`ReadonlyArray`/`readonly T[]` rows were already fixed by #16551/#16556; the plain `[T]` tuple row was already correct on `main`; the `TS2728` "declared here" pointer for tuple elements was added separately by #16599, now merged).

## Structural rule

When a `TS2741` missing-property failure sits inside an object literal that is an element of a **`readonly` tuple-typed** member (or a direct `readonly [T]` annotation), tsc anchors the failure at the missing property exactly as it does for a mutable tuple — the `readonly` modifier is not itself part of the failure. tsz's solver already gets this right end-to-end: `explain_tuple_failure` (`crates/tsz-solver/src/relations/subtype/explain_tuple.rs`) returns the correct `SubtypeFailureReason::MissingProperty` for both a `readonly` and a mutable tuple target — verified directly by tracing the reason at the call site before writing this fix. The bug is a **checker-side rendering gate** discarding that correct reason before it ever gets displayed.

## Root cause and owner layer

`render_missing_property` (`crates/tsz-checker/src/error_reporter/render_failure_missing_property.rs`) has a bail-out for "target has an index signature but the missing property isn't one of its own named properties" (tsc: report generic `TS2322`, not `TS2741`, when the "missing" property is really an index-signature miss). It detects an array/tuple-shaped target — which must skip this bail-out, since a tuple's implicit numeric index signature is not what tsc means here — with:

```rust
array_element_type(target).is_some() || tuple_list_id(target).is_some()
```

`array_element_type` (`type_queries::data::get_array_element_type`) already unwraps a `ReadonlyType` wrapper. `tuple_list_id` (`visitors::visitor_extract::tuple_list_id`) does not — it matches only `TypeData::Tuple` directly. For a `readonly [T]` target this asymmetry makes `target_is_array_or_tuple` **false**, so the tuple's own index signature is treated as a real one, the missing property (a named property of the *element*, not the tuple itself) fails the "named property of target" check, and the function bails to a bare `TS2322` with no elaboration — before the tuple-element drill this file's anchor walk depends on ever runs. This is exactly why the `Array`/`ReadonlyArray`/`readonly T[]` rows in #16552 were already fixed while the tuple spelling alone stayed broken: every one of those goes through `array_element_type`, which already peels `readonly`.

The fix swaps `tuple_list_id(target).is_some()` for `is_tuple_type(target)` (`visitors::visitor_predicates::is_tuple_type`, which already peels `ReadonlyType`/`Substitution` — the same query this file's own anchor walk and the solver's `explain.rs` already use for "is this shape a tuple"), at both of the two identical occurrences of this check in the file. `tuple_list_id` itself is deliberately left untouched: it has 24 call sites across the solver's core relation dispatch (`relations/subtype/rules/tuples.rs`, `core_dispatch.rs`, etc.), and widening what it matches there is a much larger, unrelated blast radius than this one boolean gate needs — the checker-layer boolean check is the correct owner for this decision, not the shared solver visitor.

## Adjacent-case matrix

Every row oracled against the pin `typescript@7.0.2` (`--noEmit --strict --pretty --target es2022 --lib es2022`, read from `scripts/conformance/typescript-versions.json`), renamed binders throughout so no row can pass on an identifier another row established:

| Case | Shape | Oracle | tsz before | tsz after |
|---|---|---|---|---|
| `readonly_tuple_member_missing_property_reaches_ts2741` | `readonly [T]` as a nested member | `TS2741` | `TS2322`, no elaboration | `TS2741` |
| `readonly_tuple_direct_annotation_missing_property_reaches_ts2741` | `readonly [T]` as the binding's own annotation (no wrapping property) | `TS2741` | `TS2322`, no elaboration | `TS2741` |
| `readonly_tuple_with_two_elements_missing_property_reaches_ts2741` | multi-element `readonly` tuple | `TS2741` | `TS2322`, no elaboration | `TS2741` |
| `readonly_tuple_recovery_is_not_identifier_keyed` | renamed binders/property names | `TS2741` | `TS2322` | `TS2741` |
| `indexed_object_target_keeps_the_generic_index_signature_mismatch` | **negative control**: a genuine index-signature-to-index-signature target (not array/tuple-shaped at all) | single `TS2322` | `TS2322` | `TS2322` (unchanged) |

All 4 positive rows were red on `main` before the production diff and green after; the negative control stays exactly the same before and after, confirming the fix narrows the readonly blind spot without removing the check it belongs to.

**Merged with `main` after #16599 landed** (the `TS2728` anchor-walk PR, unrelated but touching the same test file): #16599 had pinned `a_readonly_tuple_element_still_reports_the_whole_tuple_mismatch` as a *known gap* asserting the old whole-tuple `TS2322`. This PR's fix closes that exact gap, so the test is updated (`a_readonly_tuple_element_anchors_in_the_element_type`) to assert the correct `TS2741` **and** confirm the `TS2728` "declared here" pointer now composes end-to-end through both fixes together — the two PRs land on the same repro from different directions (primary code vs. pointer) and now agree.

## Deliberately out of scope

#16552's `[T][]` (array of tuples) row is a **different** bug at a different owner: the outer array's element (a tuple) never gets contextually re-typed as a tuple in the first place, so the failure never reaches `render_missing_property`'s reason-based path at all — it's still a bare whole-tuple `TS2322` with a (correct) arity sub-message, unlike this PR's rows which had *no* sub-message at all. Left for a follow-up; not touched here (still pinned as a known gap in `an_array_of_tuples_still_reports_the_inner_whole_tuple_mismatch`).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib missing_property_declared_here` — **82/82** (post-merge with #16599; 68 baseline + 6 new from this PR + 8 from #16599, one updated to assert the now-fixed behavior)
- Non-vacuity: all 4 new positive rows fail without the production diff, pass with it
- Blast-radius filters (pre-merge): `cargo test -p tsz-checker --lib tuple` — 395/395; `index_signature` — 236/236; `readonly` — 196/196
- `cargo fmt -p tsz-checker -p tsz-solver --check` — clean
- `cargo clippy --profile ci-lint -p tsz-checker -p tsz-solver --lib --all-targets -- -D warnings` — clean (also re-verified by the pre-commit hook on the merge commit)
- `python3 scripts/arch/arch_guard.py` — passed
- Oracle: every row in the adjacent-case matrix confirmed against a real pinned `typescript@7.0.2` run, not assumed
- **Owed, disclosed rather than hidden:** `scripts/conformance/compare-to-parent.sh` was not run this session — the board's own measured range is 55–90 min on a cold cloud seat, which didn't fit this hour alongside the diagnosis and the post-merge re-verification. Low expected risk: the change only affects a checker-side rendering gate that fires exclusively when the target is `readonly`-tuple-shaped *and* the failing property is missing rather than type-mismatched *and* the primary reason was already `MissingProperty` (verified via tracing before writing the fix) — a narrow intersection unlikely to move unrelated corpus rows, but unmeasured is unmeasured.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude
