### PR TITLE
fix(checker): fire TS2766 when a yield* container's TNext is unknown (#16591)

### DIFF
--- a/crates/tsz-checker/src/checkers/iterable_checker.rs
+++ b/crates/tsz-checker/src/checkers/iterable_checker.rs
@@ -1689,10 +1689,14 @@ impl<'a> CheckerState<'a> {
             None => return true, // Can't determine - don't emit false positive
         };
 
-        // If either side is any/unknown, or the iterator accepts undefined, avoid
-        // a false positive. `yield*` commonly delegates from generators whose
-        // containing TNext is explicitly `unknown`.
-        if sent_type == TypeId::ANY || sent_type == TypeId::UNKNOWN {
+        // `any` sent into any `next()` parameter is always compatible. `unknown`
+        // is NOT: it is assignable only to `unknown`/`any`, so a container whose
+        // declared `TNext` is `unknown` (the most common annotated shape) can
+        // still forward an `unknown` into a delegate whose `next()` expects a
+        // concrete type — `tsc` reports TS2763-TS2766 there. Let the assignability
+        // check below decide `unknown`; the concrete/`unknown`/`undefined` next
+        // type is already short-circuited on the target side just after this.
+        if sent_type == TypeId::ANY {
             return true;
         }
 

--- a/crates/tsz-checker/src/dispatch/yield_.rs
+++ b/crates/tsz-checker/src/dispatch/yield_.rs
@@ -399,10 +399,17 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                 // iterator whose next() expects type X, the containing generator
                 // must send a compatible type.
                 if let Some(expected_generator) = self.get_expected_generator_type(idx) {
+                    // When the container's declared return type carries no
+                    // resolvable `TNext` (e.g. an `Iterable<T>` annotation, which
+                    // has no next type at all), `tsc` treats the send type as
+                    // `any` (`signatureNextType = iterationTypes?.nextType ?? anyType`)
+                    // and reports nothing. Defaulting to `undefined` instead would
+                    // manufacture a false-positive TS2766 against any concrete
+                    // delegate `next()` parameter.
                     let containing_next = self
                         .checker
                         .get_generator_next_type_argument(expected_generator)
-                        .unwrap_or(TypeId::UNDEFINED);
+                        .unwrap_or(TypeId::ANY);
                     self.checker.check_iterator_next_type_assignability(
                         expression_type,
                         containing_next,

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -166,6 +166,9 @@ mod fresh_literal_boundary_tests;
 #[path = "../tests/generator_union_return_type_tests.rs"]
 mod generator_union_return_type_tests;
 #[cfg(test)]
+#[path = "../tests/generator_yield_star_next_type_tests.rs"]
+mod generator_yield_star_next_type_tests;
+#[cfg(test)]
 #[path = "../tests/heritage_type_only_tests.rs"]
 mod heritage_type_only_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/tests/generator_yield_star_next_type_tests.rs
+++ b/crates/tsz-checker/tests/generator_yield_star_next_type_tests.rs
@@ -1,0 +1,228 @@
+//! Tests for the TS2766 send-type check on `yield*` delegation.
+//!
+//! When a generator with a declared `TNext` delegates with `yield* e`, the
+//! container forwards whatever its own caller sends straight into the
+//! delegate's `next()`. `tsc` therefore requires the container's `TNext` to be
+//! assignable to the delegate iterator's `TNext`, and reports TS2766 when it is
+//! not:
+//!
+//! ```text
+//! error TS2766: Cannot delegate iteration to value because the 'next' method
+//! of its iterator expects type 'string', but the containing generator will
+//! always send 'unknown'.
+//! ```
+//!
+//! The regression these tests pin: an annotated container whose `TNext` is
+//! `unknown` (the most common shape) delegating to an iterator with a concrete
+//! `TNext` produced no diagnostic, because the send-type check short-circuited
+//! on `unknown` before ever asking whether `unknown` is assignable to the
+//! delegate's `next()` parameter (it is not).
+//!
+//! These run against the real bundled lib assets rather than hand-rolled
+//! stubs: the container/delegate `next()` shapes come straight from
+//! `Generator`/`AsyncGenerator`, and a generator function *expression* assigned
+//! to a `const` only materializes correctly with the full iterator protocol
+//! wired in.
+
+use std::sync::Arc;
+
+use crate::test_utils::{check_source_with_libs, load_default_lib_files, strict_checker_options};
+use tsz_binder::lib_loader::LibFile;
+
+fn codes_with(source: &str, libs: &[Arc<LibFile>]) -> Vec<u32> {
+    check_source_with_libs(source, "test.ts", strict_checker_options(), libs)
+        .iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+// =========================================================================
+// The regression: an `unknown`-TNext container into a concrete-TNext delegate.
+// =========================================================================
+
+#[test]
+fn unknown_container_next_into_concrete_delegate_reports_ts2766() {
+    let libs = load_default_lib_files();
+    let src = r#"
+declare function srcStr(): Generator<string, void, string>;
+function* annotated(): Generator<string, void, unknown> {
+    yield* srcStr();
+}
+"#;
+    assert!(
+        codes_with(src, &libs).contains(&2766),
+        "unknown container TNext delegating to a `string` next() must report TS2766"
+    );
+}
+
+#[test]
+fn concrete_incompatible_container_next_reports_ts2766() {
+    // container sends `number`, delegate's next() expects `string`.
+    let libs = load_default_lib_files();
+    let src = r#"
+declare function srcStr(): Generator<string, void, string>;
+function* annotated(): Generator<string, void, number> {
+    yield* srcStr();
+}
+"#;
+    assert!(codes_with(src, &libs).contains(&2766));
+}
+
+#[test]
+fn union_container_next_not_assignable_reports_ts2766() {
+    // container sends `string | number`, delegate expects only `string`.
+    let libs = load_default_lib_files();
+    let src = r#"
+declare function srcStr(): Generator<string, void, string>;
+function* annotated(): Generator<string, void, string | number> {
+    yield* srcStr();
+}
+"#;
+    assert!(codes_with(src, &libs).contains(&2766));
+}
+
+// =========================================================================
+// Compatible containers must stay silent.
+// =========================================================================
+
+#[test]
+fn matching_container_next_is_silent() {
+    let libs = load_default_lib_files();
+    let src = r#"
+declare function srcStr(): Generator<string, void, string>;
+function* annotated(): Generator<string, void, string> {
+    yield* srcStr();
+}
+"#;
+    assert!(!codes_with(src, &libs).contains(&2766));
+}
+
+#[test]
+fn subtype_container_next_is_silent() {
+    // container sends `string`, delegate accepts `string | number`.
+    let libs = load_default_lib_files();
+    let src = r#"
+declare function srcStr(): Generator<string, void, string | number>;
+function* annotated(): Generator<string, void, string> {
+    yield* srcStr();
+}
+"#;
+    assert!(!codes_with(src, &libs).contains(&2766));
+}
+
+#[test]
+fn any_container_next_is_silent() {
+    let libs = load_default_lib_files();
+    let src = r#"
+declare function srcStr(): Generator<string, void, string>;
+function* annotated(): Generator<string, void, any> {
+    yield* srcStr();
+}
+"#;
+    assert!(!codes_with(src, &libs).contains(&2766));
+}
+
+// =========================================================================
+// Delegates that declare no TNext must stay silent.
+// =========================================================================
+
+#[test]
+fn array_delegate_is_silent() {
+    let libs = load_default_lib_files();
+    let src = r#"
+declare function srcArr(): string[];
+function* annotated(): Generator<string, void, unknown> {
+    yield* srcArr();
+}
+"#;
+    assert!(!codes_with(src, &libs).contains(&2766));
+}
+
+#[test]
+fn container_annotated_without_next_type_is_silent() {
+    // `Iterable<string>` has no `TNext`; the container's send type is unknowable,
+    // so `tsc` falls back to `any` and reports nothing. This pins the
+    // fallback: the unresolved container next type must default to `any`, not
+    // `undefined` (which would manufacture a false-positive TS2766 against the
+    // delegate's `string` next() parameter).
+    let libs = load_default_lib_files();
+    let src = r#"
+declare function srcStr(): Generator<string, void, string>;
+function* annotated(): Iterable<string> {
+    yield* srcStr();
+}
+"#;
+    assert!(!codes_with(src, &libs).contains(&2766));
+}
+
+// =========================================================================
+// Async generators behave identically.
+// =========================================================================
+
+#[test]
+fn async_unknown_container_next_reports_ts2766() {
+    let libs = load_default_lib_files();
+    let src = r#"
+declare function srcStr(): AsyncGenerator<string, void, string>;
+async function* annotated(): AsyncGenerator<string, void, unknown> {
+    yield* srcStr();
+}
+"#;
+    assert!(codes_with(src, &libs).contains(&2766));
+}
+
+#[test]
+fn async_matching_container_next_is_silent() {
+    let libs = load_default_lib_files();
+    let src = r#"
+declare function srcStr(): AsyncGenerator<string, void, string>;
+async function* annotated(): AsyncGenerator<string, void, string> {
+    yield* srcStr();
+}
+"#;
+    assert!(!codes_with(src, &libs).contains(&2766));
+}
+
+// =========================================================================
+// Generator methods and function expressions, and renamed binders.
+// =========================================================================
+
+#[test]
+fn generator_method_unknown_container_reports_ts2766() {
+    let libs = load_default_lib_files();
+    let src = r#"
+declare function srcStr(): Generator<string, void, string>;
+class Host {
+    *gen(): Generator<string, void, unknown> {
+        yield* srcStr();
+    }
+}
+"#;
+    assert!(codes_with(src, &libs).contains(&2766));
+}
+
+#[test]
+fn generator_function_expression_unknown_container_reports_ts2766() {
+    let libs = load_default_lib_files();
+    let src = r#"
+declare function srcStr(): Generator<string, void, string>;
+const gen = function* (): Generator<string, void, unknown> {
+    yield* srcStr();
+};
+"#;
+    assert!(codes_with(src, &libs).contains(&2766));
+}
+
+#[test]
+fn renamed_binders_still_report_ts2766() {
+    // Binder names carry no semantic weight: renaming everything must not change
+    // the diagnostic.
+    let libs = load_default_lib_files();
+    let src = r#"
+declare function produce(): Generator<string, void, string>;
+function* consume(): Generator<string, void, unknown> {
+    yield* produce();
+}
+"#;
+    assert!(codes_with(src, &libs).contains(&2766));
+}

--- a/crates/tsz-checker/tests/yield_star_return_type_tests.rs
+++ b/crates/tsz-checker/tests/yield_star_return_type_tests.rs
@@ -122,7 +122,12 @@ function* f(): Generator<"outer", number, unknown> {
 }
 
 #[test]
-fn yield_star_allows_unknown_containing_next_type() {
+fn yield_star_unknown_containing_next_type_reports_ts2766() {
+    // A container whose declared `TNext` is `unknown` forwards `unknown` into
+    // the delegate's `next()`. `unknown` is assignable only to `unknown`/`any`,
+    // so delegating to a `Generator<..., string>` — whose `next()` expects
+    // `string` — is unsound, and `tsc` reports TS2766. (This previously asserted
+    // the inverse, encoding the #16591 false-negative.)
     let source = r#"
 declare const gen: Generator<string, void, string>;
 function* f(): Generator<string, void, unknown> {
@@ -131,8 +136,8 @@ function* f(): Generator<string, void, unknown> {
 "#;
     let diags = codes_with_strict(source);
     assert!(
-        !diags.contains(&2766),
-        "yield* should not emit TS2766 when the containing generator TNext is unknown, got: {diags:?}"
+        diags.contains(&2766),
+        "yield* must emit TS2766 when the container always sends `unknown` into a `string` next(), got: {diags:?}"
     );
 }
 


### PR DESCRIPTION
Fixes #16591.

**Structural rule:** when a generator with a declared `TNext` delegates with
`yield* e`, the container forwards whatever its own caller sends straight into
the delegate's `next()`, so `tsc` requires the container's `TNext` to be
assignable to the delegate iterator's `TNext` and reports **TS2766** when it is
not. tsz reported nothing for the most common shape of that failure — a
container annotated with `TNext = unknown` delegating to an iterator with a
concrete `TNext`. The wrong operation lived in the checker's iterable-check
boundary (`check_iterator_next_type_assignability`) and the `yield*` send-type
resolution in `dispatch/yield_.rs`.

Two fixes, both owned by the checker:

1. `check_iterator_next_type_assignability` force-accepted every `unknown` send
   type. `unknown` is assignable only to `unknown`/`any`, so a container that
   always sends `unknown` into a delegate whose `next()` expects `string` is
   unsound — exactly what TS2766 is for. The `unknown` short-circuit is dropped
   so the shared assignability relation decides; the `any` fast-path stays
   (`any` is genuinely compatible), and the target-side `unknown`/`undefined`
   short-circuit already keeps compatible delegates silent.
2. The container's send type fell back to `undefined` when its declared return
   type carried no resolvable `TNext` (e.g. an `Iterable<T>` annotation). `tsc`
   models this as `signatureNextType = iterationTypes?.nextType ?? anyType`, so
   the fallback becomes `any`, not `undefined` — otherwise a concrete delegate
   `next()` parameter draws a false-positive TS2766.

Both changes are effectively scoped to `yield*`: for-of / spread / destructuring
always send `undefined`, never `unknown`, so their send-type checks are
unchanged (verified — `iterator_next_send_type_call_result_tests` stays green).

**Adjacent matrix** (new `generator_yield_star_next_type_tests.rs`, real bundled
libs): declaration / method / function-expression containers; async generators;
concrete-incompatible (`number`) and union (`string | number`) send types; the
compatible / subtype / `any` container cases (silent); no-`TNext` delegates
(arrays) and no-`TNext` containers (`Iterable`, silent, pins the fallback);
renamed binders. A stale assertion in `yield_star_return_type_tests.rs` that had
encoded the false-negative is flipped to expect TS2766.

**Anti-hardcoding:** no identifier/file-name/printer-string predicate added; the
decision routes through the existing `call_arg_relation_outcome` relation and the
generator-arg extraction query. Tests vary binder names.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib generator_yield_star_next_type_tests` — 13/13 pass (real libs).
- `cargo test -p tsz-checker --lib yield_star_return_type_tests` — 11/11 (flipped assertion).
- `cargo test -p tsz-checker --lib ts7057_yield` / filter `yield` / `generator` — green (pre-existing `*_arch_tests` failures confirmed on `main`, unrelated).
- `cargo test -p tsz-checker --test iterator_next_send_type_call_result_tests` — 8/8 (for-of/spread/destructuring unaffected).
- Release CLI on the #16591 repro + adjacent files (real libs): declaration, function-expression, method, async, variable-delegate forms all emit TS2766; compatible / `Iterable`-container / array-delegate forms stay clean.
- `./scripts/emit/run.sh --skip-build` — passed.
- clippy + `arch-size` (2000-line) guard — passed via pre-commit hook (all touched files ≤ 1770 lines).
- **Conformance** (local, vs the checked-in tsc cache): **11499/12043 (95.5%), byte-identical to the baseline snapshot** — 0 crashes, 0 timeouts. **Zero TS2766 fingerprint mismatches** both before and after (`missing=0, extra=0`), so the fix adds no false positives and regresses nothing. The change can only touch TS2763–TS2766; TS2763/2764/2765 send `undefined` and are unchanged. The #16591 shape is a hand-minimal repro not isolated by any corpus row, so the aggregate is neutral — the improvement is pinned by the new unit tests and CLI checks above.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high