### PR TITLE
fix(checker): a class static block is not eligible for the top-level await-using family (#16598)

### DIFF
--- a/crates/tsz-checker/src/tests/await_static_block_grammar_tests.rs
+++ b/crates/tsz-checker/src/tests/await_static_block_grammar_tests.rs
@@ -363,3 +363,93 @@ class Harness { static { const build = function () { return await 2; }; void bui
          block; got {codes:?}"
     );
 }
+
+/// `await using`'s TS2853 twin of the TS1375/TS1378 exclusivity above (#16598).
+///
+/// `static_block_direct_await_using_reports_only_ts18054` (above) uses the
+/// parse-health-*aware* helper, which sets `has_syntax_parse_errors` from the
+/// coarse `!parse_diagnostics.is_empty()` signal — true here because TS18054
+/// is itself a parser diagnostic — so that test's passing tells us nothing
+/// about `check_variable_declaration_list_with_request`'s own logic: the
+/// blanket `!self.ctx.has_syntax_parse_errors` guard already skips the whole
+/// TS2852/2853/2854 family before the static-block question is ever asked.
+/// `check_source_codes` never wires that flag at all (see its doc comment's
+/// warning about `is_non_suppressing_parse_error`/`is_parser_grammar_code`),
+/// so it is the one instrument that exercises `is_directly_at_source_file_top_level`
+/// on its own — and before this fix, that predicate did not stop at
+/// `CLASS_STATIC_BLOCK_DECLARATION`, so it walked all the way up to
+/// `SOURCE_FILE` and misread the static block's `await using` as top level,
+/// firing TS2853 (non-module file) alongside TS18054. Confirmed against
+/// `typescript@7.0.2`: only TS18054.
+#[test]
+fn static_block_direct_await_using_reports_no_top_level_diagnostics_in_the_checker_walk_without_suppression()
+ {
+    let codes = crate::test_utils::check_source_codes(
+        r#"
+class Gate { static { await using x = 1; } }
+"#,
+    );
+    assert!(
+        !codes.contains(&2852) && !codes.contains(&2853) && !codes.contains(&2854),
+        "tsc's checkGrammarAwaitOrAwaitUsing puts the whole TS2852/TS2853/TS2854 \
+         family behind the same class-static-block exclusivity as the bare-`await` \
+         family; the checker walk must decline here on its own; got {codes:?}"
+    );
+}
+
+/// Same exclusivity, exercised through a `for`-head `await using` rather than
+/// a plain statement — a different declaration-list constructor
+/// (`parse_for_variable_declaration`), same `check_variable_declaration_list_with_request`
+/// call site once bound.
+#[test]
+fn static_block_for_of_await_using_reports_no_top_level_diagnostics_in_the_checker_walk_without_suppression()
+ {
+    let codes = crate::test_utils::check_source_codes(
+        r#"
+class Gate { static { for (await using x of []) { } } }
+"#,
+    );
+    assert!(
+        !codes.contains(&2852) && !codes.contains(&2853) && !codes.contains(&2854),
+        "got {codes:?}"
+    );
+}
+
+/// The same walk must still speak for an `await using` that is *not* in a
+/// static block, in a file that also has one — the sibling case for TS2853's
+/// family, same shape as `sibling_await_outside_a_static_block_still_reports_in_the_checker_walk`.
+#[test]
+fn sibling_await_using_outside_a_static_block_still_reports_in_the_checker_walk() {
+    let codes = crate::test_utils::check_source_codes(
+        r#"
+class Latch { static { await using seeded = 1; } }
+await using top = 2;
+"#,
+    );
+    assert!(
+        codes.contains(&2853),
+        "the true top-level `await using` outside the static block is unaffected \
+         by the sibling static block, and this file has no imports/exports, so \
+         tsc reports TS2853 for it; got {codes:?}"
+    );
+}
+
+/// Container-walk boundary for `await using`: nested inside a *non-async*
+/// function inside a static block, it is that function's own top-level-eligibility
+/// question, not the static block's — mirroring
+/// `await_in_a_non_async_function_nested_in_a_static_block_still_reports`.
+/// A non-async function body is never top level, so this answers TS2852
+/// (nested `await using` requires an async function), not TS2853/TS2854.
+#[test]
+fn await_using_in_a_non_async_function_nested_in_a_static_block_reports_ts2852() {
+    let codes = crate::test_utils::check_source_codes(
+        r#"
+class Harness { static { const build = function () { await using x = 1; }; void build; } }
+"#,
+    );
+    assert!(
+        codes.contains(&2852),
+        "the nested function expression is its own container, so its `await using` \
+         answers TS2852 rather than deferring to the enclosing static block; got {codes:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/type_checking/core.rs
+++ b/crates/tsz-checker/src/types/type_checking/core.rs
@@ -1604,24 +1604,24 @@ impl<'a> CheckerState<'a> {
             return;
         };
 
-        // Check if this is a using/await using declaration list.
         // Only check the USING bit (bit 2) — AWAIT_USING (6) = CONST (2) | USING (4),
-        // so checking just the USING bit correctly matches both using and await using
-        // but not const.
+        // so this matches both `using` and `await using` but not plain `const`.
         use tsz_parser::parser::flags::node_flags;
         let flags_u32 = node.flags as u32;
         let is_using = (flags_u32 & node_flags::USING) != 0;
         let is_await_using = node_flags::is_await_using(flags_u32);
 
-        // TS1545/TS1546/TS1547/TS1548: where a `using` / `await using` list is
-        // allowed to stand at all. tsc checks this in `checkGrammarVariableDeclarationList`,
-        // ahead of the `await using` placement family below, and returns at the first
-        // failure — so a placement error replaces those diagnostics rather than
-        // accompanying them.
+        // TS1545-TS1548: where a `using`/`await using` list may stand at all;
+        // a placement error replaces the family below (`checkGrammarVariableDeclarationList`).
         let placement_error =
             is_using && self.check_grammar_using_declaration_placement(list_idx, is_await_using);
 
-        if is_await_using && !placement_error && !self.ctx.has_syntax_parse_errors {
+        // A static block answers only TS18054, never TS2852/2853/2854 (#16598).
+        if is_await_using
+            && !placement_error
+            && !self.ctx.has_syntax_parse_errors
+            && !self.await_container_is_class_static_block(list_idx)
+        {
             use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
 
             // Same top-level-await-eligibility predicate as `check_await_expression`

--- a/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
+++ b/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
@@ -1015,7 +1015,15 @@ impl<'a> CheckerState<'a> {
     /// block anywhere above, so an `await` inside a function nested in a static
     /// block (`class C { static { void (async () => await 1); } }`) keeps
     /// answering from its own function.
-    fn await_container_is_class_static_block(&self, idx: NodeIndex) -> bool {
+    ///
+    /// `pub(crate)` (not private) because `check_variable_declaration_list_with_request`
+    /// in the sibling `core` module shares this exclusivity rule for `await using`
+    /// (see #16598: `is_directly_at_source_file_top_level` treats a class static
+    /// block as an ordinary non-disqualifying container, so an `await using`
+    /// directly inside one walks all the way up to `SOURCE_FILE` and reads as
+    /// top level — the same bug the `AWAIT_EXPRESSION` walk below already closes
+    /// with this exact predicate).
+    pub(crate) fn await_container_is_class_static_block(&self, idx: NodeIndex) -> bool {
         let mut current = idx;
         let mut iterations = 0;
         loop {


### PR DESCRIPTION
## Goal
Goal: hold

`checkGrammarAwaitOrAwaitUsing` puts the whole TS2852/TS2853/TS2854 family behind tsc's class-static-block exclusivity test, the same way `checkAwaitExpression` does for TS1308/TS1375/TS1378 (already handled by `await_container_is_class_static_block`, added for #16068/#16072). The `await using` sibling path in `check_variable_declaration_list_with_request` never got that gate: `is_directly_at_source_file_top_level` does not stop at `CLASS_STATIC_BLOCK_DECLARATION`, so it walks through the static block, the class, and up to `SOURCE_FILE`, misreading the declaration as top level and firing TS2853 alongside the parser's TS18054.

**Structural rule:** when an `await using` declaration list's nearest function-like-or-class-static-block ancestor is a class static block, tsc answers only TS18054 and never the TS2852/2853/2854 family; tsz now does this through the checker's `check_variable_declaration_list_with_request`, reusing `await_container_is_class_static_block` (bumped to `pub(crate)` so the sibling `core` module can call it).

The existing `static_block_direct_await_using_reports_only_ts18054` test passed on `main` despite the bug: it uses the parse-health-*aware* harness, whose coarse `!parse_diagnostics.is_empty()` signal already treats TS18054 (a parser diagnostic) as blocking the whole TS2852/2853/2854 walk before the static-block question is ever asked — unlike the CLI's `is_parser_grammar_code` classification that #16597 landed (which is what unmasked this bug in the real binary; see #16598's own repro history). The new adjacent-case matrix uses the parse-health-*blind* `check_source_codes` helper, which exercises the checker logic directly:
- direct statement inside a static block
- `for (await using x of ...)` head inside a static block
- sibling top-level `await using` outside the block (still reports, unaffected)
- a non-async function nested in the block (own container, reports TS2852 rather than deferring)

Trimmed a few pre-existing comments in `check_variable_declaration_list_with_request` to keep `core.rs` at the 2000-line architecture cap (it was already exactly at the limit); no behavior change in the trimmed lines.

Closes #16598.

## Verification
- `cargo test -p tsz-checker --lib await_static_block_grammar_tests`: 23/23 (19 pre-existing + 4 new).
- `cargo test -p tsz-checker --lib top_level_await_boundary_tests`: 16/16.
- `cargo test -p tsz-checker --lib ts1309_top_level_await_commonjs_file_tests`: 27/27.
- `cargo clippy -p tsz-checker --lib --tests -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- Architecture guard (`core.rs` LOC cap): passed via pre-commit hook.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgrZWSRtyHBXF2gLpmDfum)_