### PR TITLE
test(checker): pin the display-alias repaint matrix for longhand unions (#16610)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2694,3 +2694,6 @@ path = "tests/import_equals_alias_duplicate_function_container_tests.rs"
 [[test]]
 name = "qualified_default_import_enum_namespace_merge_root_tests"
 path = "tests/qualified_default_import_enum_namespace_merge_root_tests.rs"
+[[test]]
+name = "union_display_alias_repaint_parity_tests"
+path = "tests/union_display_alias_repaint_parity_tests.rs"

--- a/crates/tsz-checker/tests/union_display_alias_repaint_parity_tests.rs
+++ b/crates/tsz-checker/tests/union_display_alias_repaint_parity_tests.rs
@@ -1,0 +1,197 @@
+//! Parity pins for the display alias a rendered type picks up in a diagnostic.
+//!
+//! `tsc` decides the displayed name of a type from the **type node that was
+//! written at the site**: an annotation spelled `Zed` renders as `Zed`, and an
+//! annotation spelled `string | number | symbol` renders structurally, even
+//! when a `type Zed = string | number | symbol` declaration elsewhere in the
+//! program describes exactly that type. `getUnionType` keys its cache on the
+//! member list *plus* the alias identity, so the aliased and the longhand
+//! spelling are two distinct `Type` objects and neither can repaint the other.
+//!
+//! tsz interns one `TypeId` per content and carries the alias in a global
+//! `TypeId -> alias` side table (`TypeInterner::store_display_alias` /
+//! `get_display_alias`), so an alias declared anywhere can repaint a
+//! structurally identical type written longhand somewhere else. That is the
+//! divergence the `#[ignore]`d rows below record.
+//!
+//! Every expectation here was verified against the pinned oracle
+//! (`typescript@7.0.2`, `--noEmit --strict --lib es2022 --target es2022`), one
+//! file per row so no row can be perturbed by another row's declarations —
+//! which matters especially here, since the defect is precisely about one
+//! declaration reaching another site.
+//!
+//! Live rows are a regression floor for the spellings that already match.
+//! `#[ignore]`d rows are tripwires: they assert `tsc`'s answer and are expected
+//! to fail until the repaint is fixed. Run them with
+//! `cargo test -p tsz-checker --test union_display_alias_repaint_parity_tests -- --ignored`.
+
+use tsz_checker::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs_code_messages, load_default_lib_files};
+
+/// The rendered source-type name from the single `TS2322` a row produces.
+///
+/// Every fixture below assigns some value to a `boolean` annotation, so the
+/// message is always `Type 'X' is not assignable to type 'boolean'.` and `X` is
+/// the display surface under test.
+fn rendered_source_type(source: &str) -> String {
+    let diagnostics = check_source_with_libs_code_messages(
+        source,
+        "case.ts",
+        CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+        &load_default_lib_files(),
+    );
+    let assignability: Vec<&(u32, String)> = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 2322)
+        .collect();
+    assert_eq!(
+        assignability.len(),
+        1,
+        "expected exactly one TS2322 for this fixture, got {diagnostics:?}"
+    );
+    let message = &assignability[0].1;
+    let rest = message
+        .strip_prefix("Type '")
+        .unwrap_or_else(|| panic!("unexpected TS2322 shape: {message}"));
+    let end = rest
+        .find("' is not assignable")
+        .unwrap_or_else(|| panic!("unexpected TS2322 shape: {message}"));
+    rest[..end].to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Live rows: spellings whose display already matches tsc. Regression floor.
+// ---------------------------------------------------------------------------
+
+/// An annotation written *through* a user alias renders as that alias.
+#[test]
+fn union_annotation_written_through_its_alias_renders_the_alias() {
+    let source = "type Zed = string | number | symbol;\n\
+                  declare const value: Zed;\n\
+                  const target: boolean = value;\n";
+    assert_eq!(rendered_source_type(source), "Zed");
+}
+
+/// Same rule for a lib-declared alias the source actually references.
+#[test]
+fn union_annotation_written_through_a_lib_alias_renders_the_lib_alias() {
+    let source = "declare const value: PropertyKey;\n\
+                  const target: boolean = value;\n";
+    assert_eq!(rendered_source_type(source), "PropertyKey");
+}
+
+/// An object alias declared but not used does not repaint a longhand object
+/// literal of the same shape. This is the control that separates the defect
+/// family from "aliases repaint everything": objects are already correct.
+#[test]
+fn object_alias_declared_elsewhere_does_not_repaint_a_longhand_object() {
+    let source = "type Obj = { p: number };\n\
+                  declare const value: { p: number };\n\
+                  const target: boolean = value;\n";
+    assert_eq!(rendered_source_type(source), "{ p: number; }");
+}
+
+/// The positive half of the same object pair.
+#[test]
+fn object_annotation_written_through_its_alias_renders_the_alias() {
+    let source = "type Obj = { p: number };\n\
+                  declare const value: Obj;\n\
+                  const target: boolean = value;\n";
+    assert_eq!(rendered_source_type(source), "Obj");
+}
+
+/// A union whose members are *object* types is likewise not repainted — the
+/// sharpest available discriminator on the defect's boundary. The failing rows
+/// below differ from this one only in that their union members are primitives.
+#[test]
+fn object_member_union_alias_declared_elsewhere_does_not_repaint_the_longhand_union() {
+    let source = "type Qux = { p: number } | { q: string };\n\
+                  declare const value: { p: number } | { q: string };\n\
+                  const target: boolean = value;\n";
+    assert_eq!(
+        rendered_source_type(source),
+        "{ p: number; } | { q: string; }"
+    );
+}
+
+/// An interface (rather than an alias) never lends its name to a structurally
+/// identical anonymous object.
+#[test]
+fn interface_declared_elsewhere_does_not_repaint_a_longhand_object() {
+    let source = "interface Iface { p: number }\n\
+                  declare const value: { p: number };\n\
+                  const target: boolean = value;\n";
+    assert_eq!(rendered_source_type(source), "{ p: number; }");
+}
+
+// ---------------------------------------------------------------------------
+// Tripwires: oracle-verified divergences. Expected to fail until fixed.
+// ---------------------------------------------------------------------------
+
+/// A longhand primitive union is repainted by a **lib** alias the source never
+/// mentions. tsz renders `PropertyKey`; tsc renders the union.
+///
+/// This is the widest-reach row: every `string | number | symbol` written by
+/// any user anywhere renders as `PropertyKey`, because `lib.es5.d.ts` declares
+/// that alias and the display-alias table is keyed on the interned `TypeId`.
+#[test]
+#[ignore = "known divergence: lib alias repaints a longhand primitive union (display-alias table is global by TypeId)"]
+fn longhand_primitive_union_is_not_repainted_by_an_unreferenced_lib_alias() {
+    let source = "declare const value: string | number | symbol;\n\
+                  const target: boolean = value;\n";
+    assert_eq!(rendered_source_type(source), "string | number | symbol");
+}
+
+/// The same repaint from a **user** alias declared in the same file and never
+/// referenced. No lib involvement, so this row rules out "the lib is stamped
+/// specially" as the cause.
+#[test]
+#[ignore = "known divergence: an unreferenced user alias repaints a longhand primitive union"]
+fn longhand_primitive_union_is_not_repainted_by_an_unreferenced_user_alias() {
+    let source = "type Zed = string | number | symbol;\n\
+                  declare const value: string | number | symbol;\n\
+                  const target: boolean = value;\n";
+    assert_eq!(rendered_source_type(source), "string | number | symbol");
+}
+
+/// Renamed binders, and a two-member union, so the row cannot be satisfied by
+/// anything keyed on the specific alias name or on the three-member shape that
+/// `PropertyKey` happens to have.
+#[test]
+#[ignore = "known divergence: an unreferenced user alias repaints a longhand primitive union"]
+fn renamed_binders_longhand_two_member_union_is_not_repainted_by_its_alias() {
+    let source = "type Pair = string | number;\n\
+                  declare const other: string | number;\n\
+                  const sink: boolean = other;\n";
+    assert_eq!(rendered_source_type(source), "string | number");
+}
+
+/// The alias declared *after* the use site repaints it just the same, so the
+/// behaviour is not a declaration-order artifact that a source-order rule could
+/// explain away.
+#[test]
+#[ignore = "known divergence: an unreferenced user alias repaints a longhand primitive union"]
+fn an_alias_declared_after_the_use_site_does_not_repaint_the_longhand_union() {
+    let source = "declare const value: string | number;\n\
+                  const target: boolean = value;\n\
+                  type Later = string | number;\n";
+    assert_eq!(rendered_source_type(source), "string | number");
+}
+
+/// A separate mechanism in the same display family: tsc resolves `keyof any` to
+/// `string | number | symbol` eagerly, so the operator never reaches the
+/// printer. tsz keeps the `KeyOf` node and renders it verbatim.
+///
+/// Kept in this file because the two interact — once `keyof any` resolves to
+/// the union, it lands on exactly the `TypeId` the rows above show is
+/// repainted, so fixing this one alone would render `PropertyKey` here.
+#[test]
+#[ignore = "known divergence: `keyof any` is not resolved to its member union for display"]
+fn keyof_any_renders_as_its_resolved_member_union() {
+    let source = "declare const value: keyof any;\n\
+                  const target: boolean = value;\n";
+    assert_eq!(rendered_source_type(source), "string | number | symbol");
+}


### PR DESCRIPTION
Pins a previously-uncovered display divergence found by a 36-row oracle differential sweep over type-level constructs (template literals, conditionals/`infer`, mapped types, `keyof`/indexed access). 9 of 36 rows diverged; they collapse into the family below, filed as #16610.

**Structural rule.** When a type alias's RHS is a **primitive union**, `tsc` still renders a structurally identical union written *longhand* at another site structurally — `getUnionType` keys its cache on the member list *plus* the alias identity, so the aliased and longhand spellings are two distinct `Type` objects and neither repaints the other. tsz interns one `TypeId` per content and carries the alias in a global `TypeId -> alias` side table (`TypeInterner::store_display_alias` / `get_display_alias`, `crates/tsz-solver/src/intern/core/interner/display.rs`), so an alias declared anywhere repaints the longhand spelling everywhere. Widest-reach consequence: **every `string | number | symbol` a user writes renders as `PropertyKey`**, with no reference to `PropertyKey` in the source — `lib.es5.d.ts` declares it and that is enough.

**This PR adds no production diff.** It lands the executable red/green signal the family had nothing of, plus the controls that bound it. Owner layer and next probe are on #16610; I did not isolate which of the ~20 `store_display_alias` call sites writes the mapping, and said so there rather than guessing.

The controls are the substantive part. Rows 8/9/10 below show an object alias, an *object-member* union alias, and an interface all correctly fail to repaint their longhand twins — only **primitive**-member unions repaint. Together with rows 6/7 (the alias renders correctly when the annotation *was* written through it, from the same content-interned `TypeId`), that says occurrence information already survives to the printer on the object path. So this is **not** the "needs occurrence-scoped provenance, size it under #14344" wall #16509 hit, and the next session should not re-derive that conclusion. It is also why a blanket refusal to store the mapping is the wrong fix: it would flip row 6 and trade one divergence for another.

| # | source | tsc | tsz | pinned as |
| --- | --- | --- | --- | --- |
| 1 | `declare const v: string \| number \| symbol` | `string \| number \| symbol` | **`PropertyKey`** | `#[ignore]` tripwire |
| 2 | `type Zed = string \| number \| symbol;` + longhand annotation | `string \| number \| symbol` | **`Zed`** | `#[ignore]` tripwire |
| 3 | `type Pair = string \| number;` + longhand (renamed binders) | `string \| number` | **`Pair`** | `#[ignore]` tripwire |
| 4 | longhand annotation, alias declared **after** it | `string \| number` | **`Later`** | `#[ignore]` tripwire |
| 5 | `declare const v: keyof any` | `string \| number \| symbol` | **`keyof any`** | `#[ignore]` tripwire |
| 6 | `declare const v: Zed` (written through the alias) | `Zed` | `Zed` | live |
| 7 | `declare const v: PropertyKey` | `PropertyKey` | `PropertyKey` | live |
| 8 | `type Obj = { p: number };` + longhand `{ p: number }` | `{ p: number; }` | `{ p: number; }` | live |
| 9 | `type Qux = { p: number } \| { q: string };` + longhand | `{ p: number; } \| { q: string; }` | same | live |
| 10 | `interface Iface { p: number }` + longhand `{ p: number }` | `{ p: number; }` | `{ p: number; }` | live |

Row 2 rules out "the lib is stamped specially" (a plain user alias does it too). Row 3 varies the binder name *and* the member count, so nothing keyed on `PropertyKey`'s specific name or three-member shape can satisfy it. Row 4 rules out a declaration-order explanation. Row 5 is a second mechanism (`keyof any` never resolved for display) kept in the same file because fixing it *alone* makes output worse — the resolved union lands on exactly the `TypeId` row 1 shows is repainted.

Not a duplicate of #16509: that is a union **dropping** a duplicate constituent; this is a union **gaining a name it was never written with**. Row 9 separates them — an object-member union does not repaint here, and #16509's dedup does not depend on member kind.

## Goal
Goal: hold

## Verification
- Oracle: pinned `typescript@7.0.2` (per `scripts/conformance/typescript-versions.json`), `--noEmit --strict --lib es2022 --target es2022`, **one file per row** — deliberately not one combined file, since the defect is precisely one declaration reaching another site and a shared file would contaminate every row.
- `cargo test -p tsz-checker --test union_display_alias_repaint_parity_tests` → **6 passed, 0 failed, 5 ignored**.
- `cargo test -p tsz-checker --test union_display_alias_repaint_parity_tests -- --ignored` → **0 passed, 5 failed**, i.e. all five tripwires are genuinely red rather than silently passing.
- `cargo fmt --check` clean. `cargo clippy -p tsz-checker --test union_display_alias_repaint_parity_tests -- -D warnings` clean. Pre-commit gate (fmt + clippy `-p tsz-checker` + arch guard) passed.
- **No corpus gate owed.** `git diff --name-only origin/main...HEAD` is `crates/tsz-checker/Cargo.toml` and `crates/tsz-checker/tests/union_display_alias_repaint_parity_tests.rs` — no `crates/**/src` production path, so conformance and emit counts cannot move.
- `cargo-nextest` is absent in this container (confirmed again this session), so the above are `cargo test` invocations per the board's standing substitute.

Invocation note for reviewers: `crates/tsz-checker/Cargo.toml` has `autotests = false`, so this is a registered `[[test]]` target. A `--lib -E` invocation against it reports `0 tests run`, which reads as "no coverage" rather than as a wrong invocation.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Wolframite

---
_Generated by [Claude Code](https://claude.ai/code/session_019QpAzMMsAqAgvtfpEpTjfk)_