### PR TITLE
fix(checker): report TS7005 for an uninitialized plain `using`, matching `const`/`await using`

### DIFF
--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -834,10 +834,19 @@ impl<'a> CheckerState<'a> {
                     var_decl.initializer,
                 );
             }
-            let emit_declaration_site_implicit_any = (self.is_const_variable_declaration(decl_idx)
-                && !is_in_for_in_or_for_of)
-                || is_exported
-                || (is_ambient && !self.ctx.is_declaration_file());
+            // A const-*like* binding — `const`, `using`, or `await using` (tsc's
+            // `isVarConstLike`) — cannot be reassigned, so an uninitialized one
+            // never becomes an evolving/"auto" any that control flow later fixes:
+            // tsc reports its implicit-any at the declaration site (TS7005), not
+            // deferred like `let`/`var`. Gate on `is_var_const_like_declaration`
+            // rather than `is_const_variable_declaration`, which tests only the
+            // `CONST` bit — plain `using` sets only `USING` (4) and would slip
+            // through, while `await using` (6 = `CONST | USING`) already carried
+            // `CONST` and was the only one reported before.
+            let emit_declaration_site_implicit_any =
+                (self.ctx.arena.is_var_const_like_declaration(decl_idx) && !is_in_for_in_or_for_of)
+                    || is_exported
+                    || (is_ambient && !self.ctx.is_declaration_file());
             if self.ctx.no_implicit_any()
                 && !self.ctx.has_real_syntax_errors
                 && var_decl.type_annotation.is_none()

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -963,6 +963,8 @@ mod unique_symbol_assignment_ts2322_tests;
 mod unique_symbol_member_lookup_family_tests;
 #[path = "tests/unresolved_def_eval_cache_backstop_tests.rs"]
 mod unresolved_def_eval_cache_backstop_tests;
+#[path = "tests/using_declaration_implicit_any_tests.rs"]
+mod using_declaration_implicit_any_tests;
 #[path = "tests/variadic_tuple_alias_display_tests.rs"]
 mod variadic_tuple_alias_display_tests;
 #[path = "tests/variadic_tuple_constraint_literal_preservation_tests.rs"]

--- a/crates/tsz-checker/src/tests/using_declaration_implicit_any_tests.rs
+++ b/crates/tsz-checker/src/tests/using_declaration_implicit_any_tests.rs
@@ -1,0 +1,147 @@
+//! An uninitialized `using` / `await using` binding is const-*like*: it cannot
+//! be reassigned, so it never becomes an evolving ("auto") `any` that control
+//! flow later fixes. `tsc` reports its implicit-any at the declaration site
+//! (TS7005) under `noImplicitAny`, exactly as it does for `const` — and unlike
+//! `let` / `var`, which stay silent because a later assignment may still give
+//! them a concrete type.
+//!
+//! tsz's declaration-site implicit-any gate keyed on
+//! `is_const_variable_declaration`, which tests only the `CONST` node-flag bit.
+//! `await using` carries it (flag `6 = CONST | USING`) and so was reported;
+//! plain `using` sets only `USING` (`4`) and slipped through into the deferred
+//! `let`/`var` path, which never fires for a binding that can't be reassigned —
+//! so `using x;` silently lost its TS7005. The gate now uses
+//! `is_var_const_like_declaration` (tsc's `isVarConstLike`: `const` | `using` |
+//! `await using`), so all three const-like forms report uniformly.
+//!
+//! Oracle-verified against `tsc` (`--strict`): `using x;` reports TS1155 +
+//! TS7005; `let x;` / `var x;` report neither; `using x: number;` reports only
+//! TS1155 (the annotation supplies the type).
+
+use crate::test_utils::check_source_strict_codes;
+
+/// The core regression: a bare uninitialized `using` reports the implicit-any
+/// at its declaration site, not just the must-initialize TS1155.
+#[test]
+fn uninitialized_using_reports_ts7005_implicit_any() {
+    let codes = check_source_strict_codes("using x;\n");
+    assert!(
+        codes.contains(&1155),
+        "an uninitialized `using` still needs TS1155 (must be initialized); got {codes:?}"
+    );
+    assert!(
+        codes.contains(&7005),
+        "a `using` binding is const-like, so its uninitialized implicit-any is \
+         reported at the declaration site (TS7005) like `const`; got {codes:?}"
+    );
+}
+
+/// Parity control that pins the fix's motivation: `await using` already
+/// reported TS7005 (its flag carried `CONST`); plain `using` must now match it.
+#[test]
+fn uninitialized_await_using_and_plain_using_agree_on_ts7005() {
+    let plain = check_source_strict_codes("using a;\n");
+    let awaited = check_source_strict_codes("async function f() { await using b; }\n");
+    assert!(
+        plain.contains(&7005),
+        "plain `using` must report TS7005; got {plain:?}"
+    );
+    assert!(
+        awaited.contains(&7005),
+        "`await using` reports TS7005; got {awaited:?}"
+    );
+}
+
+/// Negative control: `let` / `var` are NOT const-like — an uninitialized one is
+/// an evolving `any` that a later assignment may fix, so tsc stays silent and
+/// tsz must too. This is the boundary the fix must not cross.
+#[test]
+fn uninitialized_let_and_var_do_not_report_ts7005() {
+    for src in ["let x;\n", "var x;\n", "let y;\ny;\n", "var z;\nz;\n"] {
+        let codes = check_source_strict_codes(src);
+        assert!(
+            !codes.contains(&7005),
+            "`let`/`var` get evolving-any treatment, not a declaration-site \
+             TS7005; source {src:?} got {codes:?}"
+        );
+    }
+}
+
+/// An annotated `using` supplies its own type, so only TS1155 fires — the
+/// implicit-any gate is correctly skipped when a type annotation is present.
+#[test]
+fn annotated_uninitialized_using_reports_only_ts1155_not_ts7005() {
+    let codes = check_source_strict_codes("using x: number;\n");
+    assert!(codes.contains(&1155), "got {codes:?}");
+    assert!(
+        !codes.contains(&7005),
+        "the `: number` annotation supplies the type, so no implicit-any; got {codes:?}"
+    );
+}
+
+/// An initialized `using` has a real type from its initializer — neither
+/// TS1155 nor TS7005 applies. Guards against the gate over-firing on the common
+/// valid form.
+#[test]
+fn initialized_using_reports_neither_ts1155_nor_ts7005() {
+    let codes = check_source_strict_codes("using x = null as any;\n");
+    assert!(
+        !codes.contains(&1155) && !codes.contains(&7005),
+        "an initialized `using` is well-formed; got {codes:?}"
+    );
+}
+
+/// The fix scales to every uninitialized declarator in a multi-declarator
+/// list, and leaves initialized siblings alone.
+#[test]
+fn multi_declarator_using_reports_ts7005_per_uninitialized_binding() {
+    let both_uninit = check_source_strict_codes("using a, b;\n");
+    assert_eq!(
+        both_uninit.iter().filter(|&&c| c == 7005).count(),
+        2,
+        "each uninitialized `using` declarator earns its own TS7005; got {both_uninit:?}"
+    );
+
+    let one_each = check_source_strict_codes("using a = null as any, b;\n");
+    assert_eq!(
+        one_each.iter().filter(|&&c| c == 7005).count(),
+        1,
+        "only the uninitialized `b` earns TS7005; the initialized `a` does not; got {one_each:?}"
+    );
+}
+
+/// Container independence: the const-like implicit-any verdict comes from the
+/// declaration form, not where it sits. A `using` in a plain block, a function
+/// body, and an async function body all report TS7005 the same way. Renamed
+/// binders throughout so no name drives the result.
+#[test]
+fn uninitialized_using_reports_ts7005_in_every_container() {
+    for src in [
+        "{ using blockScoped; }\n",
+        "function make() { using localHandle; }\n",
+        "async function run() { using asyncLocal; }\n",
+    ] {
+        let codes = check_source_strict_codes(src);
+        assert!(
+            codes.contains(&7005),
+            "a `using` binding is const-like regardless of container; source {src:?} \
+             got {codes:?}"
+        );
+    }
+}
+
+/// Non-strict / `noImplicitAny: false` control: TS7005 is a `noImplicitAny`
+/// diagnostic, so it must not fire when the flag is off — the must-initialize
+/// TS1155 still does (it is a grammar rule, not an implicit-any one).
+#[test]
+fn uninitialized_using_without_no_implicit_any_reports_only_ts1155() {
+    let codes = crate::test_utils::check_source_non_strict_codes("using x;\n");
+    assert!(
+        codes.contains(&1155),
+        "TS1155 is a grammar rule, unaffected by noImplicitAny; got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&7005),
+        "TS7005 is gated on noImplicitAny, which is off here; got {codes:?}"
+    );
+}


### PR DESCRIPTION
Fixes #16614.

**Structural rule:** When a variable is declared const-*like* — `const`, `using`, or `await using` (tsc's `isVarConstLike`) — it cannot be reassigned, so an uninitialized one never becomes an evolving ("auto") `any` that control flow later fixes. `tsc` reports its implicit-any at the *declaration site* (TS7005) under `noImplicitAny`, unlike `let`/`var`, which stay silent because a later assignment may still give them a concrete type. tsz now matches this for all three const-like forms.

### What was wrong
The declaration-site implicit-any gate in `check_variable_declaration` (`state/variable_checking/core.rs`) keyed on `is_const_variable_declaration`, which tests only the `CONST` node-flag bit:

- `await using` carries it (flag `6 = CONST | USING`) → was reported ✅
- plain `using` sets only `USING` (`4`) → slipped through into the deferred `let`/`var` path (`pending_implicit_any_vars`), which never fires for a binding that can't be reassigned → `using x;` silently lost its TS7005 ❌

Oracle (`tsc --strict`):
```
using x;   // TS1155 (must be initialized) + TS7005 (implicit any)
```
tsz emitted only TS1155.

### The fix — one predicate, at the right altitude
Gate on `is_var_const_like_declaration` — the helper already present in the codebase that mirrors tsc's `isVarConstLike` (`const | using | await using`) — instead of `is_const_variable_declaration`. This is the general fix, not a witness patch: it corrects every uninitialized-`using` shape, and the `await using` case keeps reporting through the same unified path rather than by an accident of the `CONST` bit.

### Owner layer
Checker (`crates/tsz-checker/src/state/variable_checking/core.rs`), at the `noImplicitAny` declaration-site gate. No new helper, no name/flag special-case — it routes the third const-like form through the existing tsc-faithful predicate.

### Adjacent-case matrix (all covered by new tests, oracle-verified)
- `using x;` → TS1155 + TS7005 (was missing TS7005)
- plain `using` and `await using` now agree on TS7005
- `let x;` / `var x;` → neither (evolving any) — the boundary the fix must not cross
- `using x: number;` → only TS1155 (annotation supplies the type)
- `using x = null as any;` (initialized) → neither
- `using a, b;` → one TS7005 per uninitialized declarator; `using a = …, b;` → only `b`
- same verdict in a block, a function body, and an async function body (container-independent; renamed binders throughout)
- `noImplicitAny: false` → only TS1155 (TS7005 is gated on the flag)

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib using_declaration_implicit_any` — 8 new tests pass
- Targeted regression subsets (compiled lib binary): `implicit_any` 95, `using` 33, `disposable` 4, `ts7005` 8, `evolving` 4, `variable_check` 114, `for_loop` 9, `definite_assignment` 85 — all pass
- `cargo clippy -p tsz-checker --lib` — clean; pre-commit architecture guard passes
- Oracle diff vs `tsc 6.0.2 --strict`: `using x;` now matches (TS1155 + TS7005); `let`/`var` unchanged (no TS7005)

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high