### PR TITLE
test(checker): pin the collapsing-alias display mechanism as distinct from the repaint (#16610)

### DIFF
--- a/crates/tsz-checker/tests/union_display_alias_repaint_parity_tests.rs
+++ b/crates/tsz-checker/tests/union_display_alias_repaint_parity_tests.rs
@@ -195,3 +195,79 @@ fn keyof_any_renders_as_its_resolved_member_union() {
                   const target: boolean = value;\n";
     assert_eq!(rendered_source_type(source), "string | number | symbol");
 }
+
+// ---------------------------------------------------------------------------
+// Second mechanism: an alias whose RHS COLLAPSES to a pre-existing type.
+//
+// Opposite polarity to the rows above, and a different owner. There, the alias
+// is *not* written at the site and tsz adds it. Here, the alias *is* written at
+// the site and tsc drops it: when an alias's RHS reduces to a type that already
+// exists, `getIntersectionType`/`getTypeAliasInstantiation` return that existing
+// type object, which never carried the alias, so `typeToString` has no alias to
+// print. tsz keeps the written spelling.
+//
+// The distinction matters because the obvious unifying rule — "an alias whose
+// RHS interns to the same `TypeId` as the value being rendered" — is refuted by
+// `longhand_collapsing_intersection_renders_structurally` below: there the RHS
+// does intern to the rendered value's `TypeId` and tsz is already correct.
+// ---------------------------------------------------------------------------
+
+/// The control that separates the two mechanisms, and the reason the rules
+/// cannot be merged: with the *same* alias in scope, the longhand spelling of a
+/// collapsing intersection already renders structurally. So the global
+/// display-alias table is not what drives the failing row below — the alias
+/// being written at the site is.
+#[test]
+fn longhand_collapsing_intersection_renders_structurally() {
+    let source = "type Coll = string[] & Array<string>;\n\
+                  declare const value: string[] & Array<string>;\n\
+                  const target: boolean = value;\n";
+    assert_eq!(rendered_source_type(source), "string[]");
+}
+
+/// A non-collapsing intersection keeps its alias on both sides. Bounds the
+/// mechanism to the collapse, rather than to intersections generally.
+#[test]
+fn non_collapsing_intersection_alias_renders_the_alias() {
+    let source = "type Both = { p: number } & { q: string };\n\
+                  declare const value: Both;\n\
+                  const target: boolean = value;\n";
+    assert_eq!(rendered_source_type(source), "Both");
+}
+
+/// `string[] & Array<string>` are the same type, so the intersection collapses
+/// to the pre-existing `string[]` and tsc loses the alias. tsz renders `Coll`.
+#[test]
+#[ignore = "known divergence: an alias whose RHS collapses to a pre-existing type keeps its name"]
+fn collapsing_intersection_alias_renders_the_collapsed_type() {
+    let source = "type Coll = string[] & Array<string>;\n\
+                  declare const value: Coll;\n\
+                  const target: boolean = value;\n";
+    assert_eq!(rendered_source_type(source), "string[]");
+}
+
+/// Same mechanism reached through a homomorphic mapped type over an array: the
+/// mapped type reduces to the array itself, so the alias is dropped by tsc.
+/// Renamed binders relative to the row above, and no intersection involved.
+#[test]
+#[ignore = "known divergence: an alias whose RHS collapses to a pre-existing type keeps its name"]
+fn mapped_over_array_alias_renders_the_collapsed_array() {
+    let source = "type Copy<T> = { [K in keyof T]: T[K] };\n\
+                  type Mapped = Copy<1[]>;\n\
+                  declare const value: Mapped;\n\
+                  const target: number = value;\n";
+    assert_eq!(rendered_source_type(source), "1[]");
+}
+
+/// And through a conditional with a variadic `infer` tail, whose result is an
+/// ordinary tuple that already exists. Three different evaluation routes to one
+/// collapse, so a fix cannot be keyed on any single type constructor.
+#[test]
+#[ignore = "known divergence: an alias whose RHS collapses to a pre-existing type keeps its name"]
+fn variadic_infer_tail_alias_renders_the_collapsed_tuple() {
+    let source = "type Tail<T> = T extends [infer _H, ...infer R] ? R : never;\n\
+                  type Rest = Tail<[1, 2, 3]>;\n\
+                  declare const value: Rest;\n\
+                  const target: boolean = value;\n";
+    assert_eq!(rendered_source_type(source), "[2, 3]");
+}


### PR DESCRIPTION
Follow-up to #16612 (merged). Acting on the reviewer's report there that the display family reaches intersections through a user alias — with a correction to the conclusion they drew from it.

## The reported row is real; the widening it suggested is not

They reported `type A = string[] & Array<string>` rendering as `A` where tsc renders `string[]`, and proposed widening #16610's structural rule from "a type alias's RHS is a primitive union" to **"any alias whose RHS interns to the same `TypeId` as the value being rendered."**

I verified the row against the pinned oracle — it reproduces exactly as described. Then I ran the control it was missing, and it refutes the widening:

| # | source | tsc | tsz | |
| --- | --- | --- | --- | --- |
| 1 | `type Coll = string[] & Array<string>;` + `declare const v: Coll` | `string[]` | **`Coll`** | ✗ reported row |
| 2 | same alias in scope, annotation written **longhand** | `string[]` | `string[]` | ✓ **the control** |
| 3 | `type Both = { p: number } & { q: string };` + `declare const v: Both` | `Both` | `Both` | ✓ |

Row 2 is the one that matters. Under the proposed rule it should fail — the alias's RHS *does* intern to the same `TypeId` as the rendered value, and the alias *is* in scope — yet tsz is already correct there. So the global display-alias table is not what drives row 1.

## Two mechanisms, opposite polarity

- **The repaint (#16612's rows).** The alias is **not** written at the site; tsz adds it. `string | number | symbol` written longhand renders as `PropertyKey`.
- **The collapse (this PR).** The alias **is** written at the site; tsc *drops* it. When an alias's RHS reduces to a type that already exists, `getIntersectionType` / `getTypeAliasInstantiation` return that existing type object, which never carried the alias, so `typeToString` has no alias to print. tsz keeps the written spelling.

Merging them into one rule would send whoever takes #16610 looking for a single guard, and row 2 says no single guard spans both. Row 3 bounds the second one further: a non-collapsing intersection keeps its alias on both sides, so the trigger is the collapse, not intersections.

## Three routes to the same collapse

Rather than pin the reported shape alone, the tripwires reach the collapse three structurally different ways, so a fix cannot be keyed on one type constructor:

| route | alias RHS | tsc renders |
| --- | --- | --- |
| intersection dedup | `string[] & Array<string>` | `string[]` |
| homomorphic mapped type over an array | `Copy<1[]>` | `1[]` |
| conditional with a variadic `infer` tail | `Tail<[1, 2, 3]>` | `[2, 3]` |

The latter two are rows from #16612's original 36-row sweep that I measured but had set aside as an uncharacterised second family; the reviewer's intersection row is what identified them as one mechanism. Renamed binders throughout, so nothing is keyed on a name from the reported repro.

Test-only, same file, same `[[test]]` target — no production diff and no new registration.

## Goal
Goal: hold

## Verification
- Oracle: pinned `typescript@7.0.2`, `--noEmit --strict --lib es2022 --target es2022`, one file per row. All four new fixtures verified byte-for-byte as written, including the two live controls.
- `cargo test -p tsz-checker --test union_display_alias_repaint_parity_tests` → **8 passed, 0 failed, 8 ignored** (was 6/5 at #16612).
- `... -- --ignored` → **0 passed, 8 failed** — all eight tripwires genuinely red, including the three new ones.
- Pre-commit gate (fmt + clippy `-p tsz-checker` + arch guard) passed.
- **No corpus gate owed.** `git diff --name-only origin/main...HEAD` is the single test file; no `crates/**/src` path, so conformance and emit counts cannot move.

Branch note: `claude/magical-brown-gu7d2q` was restarted from `origin/main` after #16612 squash-merged, so this is a fresh single commit and not stacked on merged history. The force-with-lease that repointed the branch discarded only `acd5001`, which is already in `main` as `2f873ad`.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Wolframite

---
_Generated by [Claude Code](https://claude.ai/code/session_019QpAzMMsAqAgvtfpEpTjfk)_