### PR TITLE
test(checker): un-ignore five stale pins whose defects are fixed

### DIFF
--- a/crates/tsz-checker/src/tests/architecture_contract_tests/part_00.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests/part_00.rs
@@ -1825,7 +1825,6 @@ fn test_no_push_diagnostic_outside_error_reporter() {
 /// Files exceeding the limit are grandfathered with a ceiling that can only shrink.
 /// New files must stay under 2000 lines.
 #[test]
-#[ignore = "ratchet guard is currently red in the direct unit CI job"]
 fn checker_files_stay_under_loc_limit() {
     let checker_src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
     let loc_limit: usize = 2000;

--- a/crates/tsz-checker/src/tests/async_generator_yieldstar_contribution_tests.rs
+++ b/crates/tsz-checker/src/tests/async_generator_yieldstar_contribution_tests.rs
@@ -462,7 +462,6 @@ wants(d());
 }
 
 #[test]
-#[ignore = "pre-existing spurious TS1320 on a union delegate: see the doc comment above"]
 fn union_delegate_correct_instantiation_stays_clean() {
     let codes = strict_codes(
         r#"

--- a/crates/tsz-checker/src/tests/cross_file_generic_implements_type_param_arena_tests.rs
+++ b/crates/tsz-checker/src/tests/cross_file_generic_implements_type_param_arena_tests.rs
@@ -56,9 +56,6 @@ fn implements_member_errors(diagnostics: &[Diagnostic]) -> Vec<(u32, String)> {
 }
 
 #[test]
-#[ignore = "root cause one layer deeper than this PR's fix: get_cross_file_symbol's \
-            local_import_alias check re-reads an already-resolved cross-file SymbolId \
-            against the CURRENT file's own binder, see module docs and #16434"]
 fn cross_file_generic_interface_implements_substitutes_type_argument() {
     let types_src = r#"
 export interface Plain<T> {
@@ -117,9 +114,6 @@ export class Actor implements Plain<number> {
 }
 
 #[test]
-#[ignore = "root cause one layer deeper than this PR's fix: get_cross_file_symbol's \
-            local_import_alias check re-reads an already-resolved cross-file SymbolId \
-            against the CURRENT file's own binder, see module docs and #16434"]
 fn cross_file_generic_interface_implements_renamed_binders() {
     // Same shape, different identifiers throughout — guards against any
     // identifier-specific logic sneaking into the fix.

--- a/crates/tsz-checker/src/tests/nonstrict_nullish_widening_mutable_binding_tests.rs
+++ b/crates/tsz-checker/src/tests/nonstrict_nullish_widening_mutable_binding_tests.rs
@@ -204,7 +204,6 @@ var e: string = av;
 /// for the direct-expression push site, not the hole/spread/rest ones) — a
 /// distinct owner-site fix, left for a follow-up.
 #[test]
-#[ignore = "known gap: nested fresh array literal still over-widens through array_literal.rs's BCT pre-widening, see #16384 leg B follow-up"]
 fn declared_undefined_in_nested_array_keeps_unwidened() {
     let source = "\
 declare var q: undefined;


### PR DESCRIPTION
Goal: hold

Five `#[ignore]`d tests in `tsz-checker` pin defects that **no longer reproduce**. They have been silently dormant — a normal test run reports them as "skipped" and nothing flags that they would now pass.

## How they were found

`cargo nextest run -p tsz-checker --lib --run-ignored only`

```
before: 13 tests run: 5 passed, 8 failed     <- the 5 are stale pins
after : 8 tests run: 0 passed, 8 failed      <- every remaining ignore genuinely red
```

I picked this check up from #16615, which used it to prove its own tripwires were red. I had been auditing only the *passing* side of these matrices all day and never this one. It is the same failure mode as a stale `known-failures.txt` entry — masking a fixed bug rather than a broken one — and it is invisible to every routine run.

All five pass on **3 consecutive runs**, so this is not flakiness.

## What is restored

| test | was ignored for | now |
|---|---|---|
| `architecture_contract_tests::checker_files_stay_under_loc_limit` | *"ratchet guard is currently red in the direct unit CI job"* | **passes** |
| `cross_file_generic_implements_type_param_arena_tests::cross_file_generic_interface_implements_substitutes_type_argument` | #16434 — `get_cross_file_symbol` re-reading a resolved cross-file `SymbolId` against the current file's binder | **passes** |
| `…::cross_file_generic_interface_implements_renamed_binders` | same | **passes** |
| `nonstrict_nullish_widening_mutable_binding_tests::declared_undefined_in_nested_array_keeps_unwidened` | #16384 leg B — nested fresh array literal over-widening through `array_literal.rs`'s BCT pre-widening | **passes** |
| `async_generator_yieldstar_contribution_tests::union_delegate_correct_instantiation_stays_clean` | pre-existing spurious `TS1320` on a union delegate | **passes** |

**The LOC ratchet is the one that matters most.** It enforces `.claude/CLAUDE.md`'s 2000-line checker-file limit and has been dark. That is why `core.rs` sitting *exactly* at 2000 only surfaced through `scripts/arch/arch_guard.py` when I hit it earlier today — the in-crate contract test that should also have caught it was ignored. Two layers exist precisely so one can catch what the other misses; one of them was switched off.

The other four are plausibly closed by this week's cross-file identity, non-strict nullish, and `yield*` landings, but I have not bisected each to a specific PR — the claim here is only that they pass now and pass repeatably.

## Verification

- `-p tsz-checker --lib` — **10135 run, 10135 passed, 8 skipped** (was 10130 run / 13 skipped): exactly the 5 moved from dormant to live, none failing
- `--run-ignored only` — **0 passed, 8 failed**: every remaining `#[ignore]` is genuinely red, so no stale pin is left behind
- `scripts/arch/arch_guard.py` — rc=0
- test-only; the sole non-test edit is removing an `#[ignore]` attribute, so conformance and emit cannot move

## Note for the nightly lane

`checker_files_stay_under_loc_limit` was ignored because it was *"red in the direct unit CI job"*. It is green locally on 3 runs and its input — source line counts — is deterministic from the tree, so a local pass should imply a CI pass. If it does turn red there, that is worth knowing rather than staying hidden, and the fix is to shrink the offending file, not to re-ignore.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5
Effort: xhigh
