### PR TITLE
fix(cli): TS1326 (import type-argument call) joins the parser-grammar suppression list

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -513,6 +513,31 @@ fn is_hard_keyword_interface_name_2427_parse_diagnostic(diagnostic: &ParseDiagno
 /// modifier error, already listed above); tsz's `main` before this entry
 /// reported only TS1492, silently dropping TS1079 because the unlisted TS1492
 /// counted as a "real" parse error.
+///
+/// #16279 audit round 6: full re-derivation of the grep-and-diff recipe (every
+/// `diagnostic_codes::*` name emitted from `crates/tsz-parser/src`, resolved
+/// to codes, diffed against this list) surfaced 132 unlisted candidates.
+/// Batch Direction-A/B oracle testing against `typescript@7.0.2` found one
+/// genuine addition: TS1326 (see its own comment below) — and several
+/// look-alikes that were tested and correctly rejected because they survive
+/// Direction B (tsc does **not** suppress them alongside an unrelated real
+/// syntax error, so they must stay unlisted): TS1034 (`'super' must be
+/// followed by an argument list or member access`), TS1477 (`an
+/// instantiation expression cannot be followed by a property access`),
+/// TS2754 (`'super' may not use type arguments`), TS18009 (`private
+/// identifiers cannot be used as parameters`), TS18029 (`private identifiers
+/// are not allowed in variable declarations`), and TS18030 (`an optional
+/// chain cannot contain private identifiers` — already handled by a
+/// different mechanism, see `is_real_syntax_error` below).
+///
+/// **Not pursued, flagged for a future slice**: TS18016 (`private
+/// identifiers are not allowed outside class bodies`) is also Direction-B
+/// suppressible, but unlike TS1326 it has four checker-side emission sites
+/// (`types/type_checking/core.rs`, `assignability/assignment_checker/
+/// assignment_ops.rs`, `state/type_analysis/computed_helpers_private.rs`)
+/// alongside its five parser sites — the same double-emission shape that
+/// blocked TS2499 in round 3. Adding it here only patches the parser-emitted
+/// occurrences and needs the checker-side sites audited first, same caveat.
 const fn is_parser_grammar_code(code: u32) -> bool {
     matches!(
         code,
@@ -598,6 +623,18 @@ const fn is_parser_grammar_code(code: u32) -> bool {
         | 18037 // 'await' expression cannot be used inside a class static block
         | 18041 // A 'return' statement cannot be used inside a class static block
         | 18054 // 'await using' statements cannot be used inside a class static block
+        | 1326 // This use of 'import' is invalid. 'import()' calls can be written,
+               // but they must have parentheses and cannot have type arguments.
+               // tsc's checkGrammarImportCallExpression reports this from the
+               // checker (`import<T>("m")`); tsz emits it from the parser
+               // (`state_expressions_literals.rs`). #16279 audit round 6:
+               // oracle-confirmed against `typescript@7.0.2` — Direction A,
+               // `import<number>("mod")` alone reports TS1326 (plus the
+               // unrelated TS2307 for the unresolved module specifier);
+               // Direction B, the same line plus an unrelated real syntax
+               // error (`let x: = 1;`) elsewhere in the file drops TS1326
+               // entirely on the real compiler. Sole emission site, no
+               // checker-side counterpart, so no double-emission risk.
     )
 }
 
@@ -1764,3 +1801,7 @@ mod filter_trigger_unification_tests;
 #[cfg(test)]
 #[path = "check_utils/class_static_block_grammar_tests.rs"]
 mod class_static_block_grammar_tests;
+
+#[cfg(test)]
+#[path = "check_utils/import_call_type_arguments_grammar_tests.rs"]
+mod import_call_type_arguments_grammar_tests;

--- a/crates/tsz-cli/src/driver/check_utils/import_call_type_arguments_grammar_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/import_call_type_arguments_grammar_tests.rs
@@ -2,7 +2,7 @@
 //! (#16279's general shape, audit round 6).
 //!
 //! tsc's `checkGrammarImportCallExpression` reports TS1326 ("This use of
-//! 'import' is invalid. 'import()' calls can be written, but they must have
+//! 'import' is invalid. '`import()`' calls can be written, but they must have
 //! parentheses and cannot have type arguments.") from the checker for
 //! `import<T>("m")`. tsz emits it from the parser
 //! (`crates/tsz-parser/src/parser/state_expressions_literals.rs`). Before

--- a/crates/tsz-cli/src/driver/check_utils/import_call_type_arguments_grammar_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/import_call_type_arguments_grammar_tests.rs
@@ -1,0 +1,115 @@
+//! Unit tests for the TS1326 slice of `is_parser_grammar_code`
+//! (#16279's general shape, audit round 6).
+//!
+//! tsc's `checkGrammarImportCallExpression` reports TS1326 ("This use of
+//! 'import' is invalid. 'import()' calls can be written, but they must have
+//! parentheses and cannot have type arguments.") from the checker for
+//! `import<T>("m")`. tsz emits it from the parser
+//! (`crates/tsz-parser/src/parser/state_expressions_literals.rs`). Before
+//! this fix, TS1326 was entirely absent from `is_parser_grammar_code`, so it
+//! counted as a "real" non-grammar parse error under
+//! `has_non_grammar_parse_error` and would silently delete an unrelated
+//! *listed* sibling from the same file, while itself never being suppressed
+//! alongside a real syntax error the way tsc suppresses it.
+//!
+//! Oracle-verified against `typescript@7.0.2`:
+//! - Direction A: `import<number>("mod");` alone reports TS1326 (plus the
+//!   unrelated TS2307 for the unresolved module specifier).
+//! - Direction B: the same line plus an unrelated real syntax error
+//!   (`let x: = 1;`) elsewhere in the file reports only the real syntax
+//!   error (TS1110) — tsc drops TS1326 entirely, confirming it belongs in
+//!   the suppression list alongside its siblings.
+
+use super::*;
+
+#[test]
+fn filtered_parse_diagnostics_suppresses_ts1326_when_real_parse_error_present() {
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 40,
+            length: 6,
+            message: "This use of 'import' is invalid. 'import()' calls can be written, but they must have parentheses and cannot have type arguments.".to_string(),
+            code: 1326,
+        },
+        ParseDiagnostic {
+            start: 6,
+            length: 1,
+            message: "Type expected.".to_string(),
+            code: 1110,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&1326),
+        "TS1326 should be suppressed when a real parse error (TS1110) is present, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1110),
+        "TS1110 (real parse error) should survive, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_keeps_ts1326_when_alone() {
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![ParseDiagnostic {
+        start: 40,
+        length: 6,
+        message: "This use of 'import' is invalid. 'import()' calls can be written, but they must have parentheses and cannot have type arguments.".to_string(),
+        code: 1326,
+    }];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&1326),
+        "TS1326 should be kept when it is the only diagnostic, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_ts1326_does_not_self_suppress_listed_sibling() {
+    use tsz::parser::ParseDiagnostic;
+
+    // Before the fix, TS1326 was unlisted in `is_parser_grammar_code`, so it
+    // counted as a "real" non-grammar parse error under
+    // `has_non_grammar_parse_error` and silently deleted every *listed*
+    // sibling in the same file — here, the already-listed TS1079 (a
+    // `declare`-on-an-import-declaration modifier error).
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 10,
+            length: 7,
+            message: "A 'declare' modifier cannot be used with an import declaration."
+                .to_string(),
+            code: 1079,
+        },
+        ParseDiagnostic {
+            start: 80,
+            length: 6,
+            message: "This use of 'import' is invalid. 'import()' calls can be written, but they must have parentheses and cannot have type arguments.".to_string(),
+            code: 1326,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&1079),
+        "TS1079 must not be self-suppressed by unlisted TS1326, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1326),
+        "TS1326 should survive when it is the only non-grammar-looking diagnostic, got: {codes:?}"
+    );
+}
+
+#[test]
+fn is_parser_grammar_code_accepts_ts1326() {
+    assert!(is_parser_grammar_code(1326));
+}


### PR DESCRIPTION
Continuation of #16279's audit (round 6).

## Structural rule

When a source file has a real syntax error, tsc suppresses every diagnostic that reaches the checker through `grammarErrorOnNode` (`hasParseDiagnostics(sourceFile)`), including `checkGrammarImportCallExpression`'s TS1326 for `import("m")`. tsz emits TS1326 from the parser instead (`crates/tsz-parser/src/parser/state_expressions_literals.rs`), through `is_parser_grammar_code` (`crates/tsz-cli/src/driver/check_utils.rs`). TS1326 was absent from that list, so it counted as a "real" non-grammar parse error: it would itself never be suppressed alongside an unrelated real syntax error (diverging from tsc), and its mere presence would silently delete any *listed* grammar sibling from the same file — the self-suppression trap #16279 documents.

## What changed

Added TS1326 to `is_parser_grammar_code`, plus a dedicated test file (`check_utils/import_call_type_arguments_grammar_tests.rs` — `tests.rs` is already over the repo's 2000-line ceiling per a standing note on #16279, so new coverage goes in its own file, matching the pattern of the other `*_grammar_tests.rs` files in that directory).

Re-ran #16279's own grep-and-diff recipe (every `diagnostic_codes::*` name emitted from `crates/tsz-parser/src`, resolved to codes, diffed against the current list — 132 unlisted candidates) and batch Direction-A/B oracle-tested the most plausible ones. Only TS1326 came back positive; the rest were correctly rejected and are recorded in the source comment so nobody re-tests them:

| code | Direction A (fires alone) | Direction B (survives a real syntax error) | verdict |
|---|---|---|---|
| **1326** | yes | **no — suppressed** | **added** |
| 1034 ('super' must be followed by...) | yes | yes | stays unlisted |
| 1477 (instantiation expression...property access) | yes | yes | stays unlisted |
| 2754 ('super' may not use type arguments) | yes | yes | stays unlisted |
| 18009 (private id as parameter) | yes | yes | stays unlisted |
| 18029 (private id in var decl) | yes | yes | stays unlisted |
| 18030 (private id in optional chain) | yes | yes | stays unlisted (already handled via `is_real_syntax_error`, a different mechanism) |
| 18016 (private id outside class body) | yes | **no — suppressed** | **not added**: 4 checker-side emission sites alongside its parser sites — same double-emission shape that blocked TS2499 in round 3. Flagged in the source comment for a future slice. |

## Verification

Oracle: `typescript@7.0.2` (pinned per `scripts/conformance/typescript-versions.json`).
- Direction A: `import("mod");` alone → tsc reports TS1326 (+ unrelated TS2307).
- Direction B: same line + `let x: = 1;` elsewhere in the file → tsc reports only TS1110, drops TS1326 entirely.
- **End-to-end regression proof against the rebuilt `tsz` binary** (not just the synthetic-diagnostic unit test): pre-fix, `tsz` reported TS1326 alongside the unrelated TS1110 where tsc reports neither; post-fix, `tsz` matches tsc byte-for-byte on the same fixture.
- Positive control: `declare export { x }` (TS1193) + `import("mod")` (TS1326), no unrelated syntax error — both survive on tsc and on `tsz` before and after this change (confirms the fix doesn't touch the non-suppressing case).
- `cargo test -p tsz-cli --lib check_utils` — 162 passed, 0 failed (includes the 4 new TS1326 tests).
- `cargo test -p tsz-cli --lib` (full crate) — 1726 passed, 19 failed. All 19 failures are pre-existing and unrelated: confirmed by reproducing the same failures on unmodified `main` (`git stash`) before this change — they are environment-dependent (`tsbuildinfo`-not-writable assumes non-root, `--help`/tsc-parity tests diff against an external `tsc`/`tsgo` binary not matched in this container). None reference TS1326 or `import`.
- `cargo clippy -p tsz-cli --all-targets --all-features -- -D warnings` — clean (the `--lib`-only run originally missed a `clippy::doc_markdown` hit inside `#[cfg(test)]` code; fixed in `b0f47d4`). `cargo fmt --all` — clean. Pre-commit hook (clippy + arch-size guard) passed.
- **`scripts/conformance/compare-to-parent.sh 2f873ad` (merge-base with `origin/main`)** — two-sided `dist-fast` build + snapshot, both sides: `12585 candidates, 12043 runnable, 11499 passed, 507 unsupported, 35 skipped (95.5%)`. `base failing=543 branch failing=543`. **NEWLY PASSING (0), NEWLY FAILING (0), fingerprint-changed (0).** Confirms the disclosed prediction: this is a single, extremely rare parser diagnostic (`import<T>(...)` type-argument call — nobody writes this shape) with no corpus footprint.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sk3gD7dPdAELbtH8yjRgNp)_