### PR TITLE
fix(checker): declare export default &lt;expr&gt; reports TS2714 in an ambient context (#16403)

### DIFF
--- a/crates/tsz-checker/src/declarations/import/core/module_exports.rs
+++ b/crates/tsz-checker/src/declarations/import/core/module_exports.rs
@@ -324,8 +324,22 @@ impl<'a> CheckerState<'a> {
                                             )
                                         },
                                     );
+                                // A default export nested in a namespace body is
+                                // itself invalid there (TS1319, emitted by
+                                // `check_export_declaration` in
+                                // `statement_callback_bridge.rs` under this exact
+                                // gate), and tsc's grammar check returns as soon
+                                // as that placement diagnostic fires — the
+                                // ambient-expression check never runs for the same
+                                // node. Mirror that early-return here so a
+                                // `declare`d bare-expression default export inside
+                                // a namespace does not additionally draw TS2714.
+                                let namespace_placement_wins = !self.ctx.has_parse_errors
+                                    && !self.is_in_non_module_element_context(stmt_idx)
+                                    && self.is_inside_namespace_declaration(stmt_idx);
                                 if is_ambient
                                     && !is_declaration
+                                    && !namespace_placement_wins
                                     && export_data.export_clause.is_some()
                                     && !self
                                         .is_identifier_or_qualified_name(export_data.export_clause)

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -227,6 +227,8 @@ mod cross_module_class_self_member_tests;
 mod cross_module_generic_interface_heritage_tests;
 #[path = "tests/declaration_extract_key_path_tests.rs"]
 mod declaration_extract_key_path_tests;
+#[path = "tests/declare_export_default_expression_ambient_ts2714_tests.rs"]
+mod declare_export_default_expression_ambient_ts2714_tests;
 #[path = "tests/declare_export_default_modifier_order_ts1319_dedup_tests.rs"]
 mod declare_export_default_modifier_order_ts1319_dedup_tests;
 #[path = "tests/declare_export_equals_ambient_ts2714_tests.rs"]

--- a/crates/tsz-checker/src/tests/declare_export_default_expression_ambient_ts2714_tests.rs
+++ b/crates/tsz-checker/src/tests/declare_export_default_expression_ambient_ts2714_tests.rs
@@ -1,0 +1,110 @@
+//! `declare export default <non-identifier>;` (#16403 residual, the last two
+//! rows of its 110-row modifier x export-form cross-product).
+//!
+//! Structural rule: same as the sibling `declare export = <expr>;` fix in
+//! `declare_export_equals_ambient_ts2714_tests.rs`, one node kind over. The
+//! bare-expression form of `export default` always builds an
+//! `EXPORT_DECLARATION` node via `parse_export_default`, which hardcoded
+//! `ExportDeclData { modifiers: None, .. }` regardless of whether it was
+//! reached through the ambient `declare` dispatch. `is_in_ambient_context`
+//! reads a node's own `declare` modifier before walking to its parent, and
+//! this statement sits at the source file's own top level with no ambient
+//! ancestor either, so the ambient gate in `check_export_assignment`
+//! (`crates/tsz-checker/src/declarations/import/core/module_exports.rs`)
+//! read `false` and TS2714 never fired — even though the parser's own TS1120
+//! ("An export assignment cannot have modifiers.") already did, since that
+//! diagnostic is emitted directly at parse time and does not depend on the
+//! node's `modifiers` field.
+//!
+//! `parse_export_default` now accepts the caller's modifiers and threads them
+//! onto the wrapper only for the bare-expression case (a class/function/
+//! interface/enum/type-alias default export already carries `declare` on its
+//! own inner node and is excluded from TS2714 by node kind either way).
+//!
+//! A default export nested inside a `namespace` body is a second, narrower
+//! case: TS1319 ("A default export can only be used in an ECMAScript-style
+//! module.") already reports there and tsc's grammar check returns before
+//! reaching the ambient-expression check for that same node, so TS2714 must
+//! not additionally fire — `check_export_assignment` mirrors that early
+//! return.
+//!
+//! Every expectation oracle-pinned against `typescript@7.0.2`
+//! (`--strict --target es2022 --module es2022`).
+
+use crate::test_utils::check_source_codes;
+
+const A_DEFAULT_EXPORT_CAN_ONLY_BE_USED_IN_AN_ECMASCRIPT_STYLE_MODULE: u32 = 1319;
+const THE_EXPRESSION_OF_AN_EXPORT_ASSIGNMENT_MUST_BE_AN_IDENTIFIER_OR_QUALIFIED_NAME_IN_AN_AMBIENT_CONTEXT: u32 =
+    2714;
+
+#[test]
+fn declare_export_default_numeric_literal_reports_ts2714() {
+    let codes = check_source_codes("declare export default 1;");
+    assert!(
+        codes.contains(
+            &THE_EXPRESSION_OF_AN_EXPORT_ASSIGNMENT_MUST_BE_AN_IDENTIFIER_OR_QUALIFIED_NAME_IN_AN_AMBIENT_CONTEXT
+        ),
+        "expected TS2714 — the `declare` modifier must reach ambient-context \
+         detection on the default-export wrapper node; got {codes:?}"
+    );
+}
+
+#[test]
+fn declare_export_default_string_literal_reports_ts2714() {
+    let codes = check_source_codes(r#"declare export default "hello";"#);
+    assert!(codes.contains(
+        &THE_EXPRESSION_OF_AN_EXPORT_ASSIGNMENT_MUST_BE_AN_IDENTIFIER_OR_QUALIFIED_NAME_IN_AN_AMBIENT_CONTEXT
+    ));
+}
+
+// Negative control: an identifier expression is a valid ambient default
+// export target, so TS2714 must not fire.
+#[test]
+fn declare_export_default_identifier_reports_no_ts2714() {
+    let codes = check_source_codes(
+        "declare const renamedTarget: number;\ndeclare export default renamedTarget;",
+    );
+    assert!(!codes.contains(
+        &THE_EXPRESSION_OF_AN_EXPORT_ASSIGNMENT_MUST_BE_AN_IDENTIFIER_OR_QUALIFIED_NAME_IN_AN_AMBIENT_CONTEXT
+    ));
+}
+
+// Negative control: a plain (non-ambient) `export default <expr>;` must not
+// gain TS2714 — the file is not ambient at all.
+#[test]
+fn plain_export_default_numeric_literal_reports_no_ts2714() {
+    let codes = check_source_codes("export default 1;");
+    assert!(!codes.contains(
+        &THE_EXPRESSION_OF_AN_EXPORT_ASSIGNMENT_MUST_BE_AN_IDENTIFIER_OR_QUALIFIED_NAME_IN_AN_AMBIENT_CONTEXT
+    ));
+}
+
+// Negative control: a declaration default export (class) stays excluded from
+// TS2714 by node kind, ambient or not.
+#[test]
+fn declare_export_default_class_reports_no_ts2714() {
+    let codes = check_source_codes("declare export default class {}");
+    assert!(!codes.contains(
+        &THE_EXPRESSION_OF_AN_EXPORT_ASSIGNMENT_MUST_BE_AN_IDENTIFIER_OR_QUALIFIED_NAME_IN_AN_AMBIENT_CONTEXT
+    ));
+}
+
+// A default export nested in a namespace body is invalid there (TS1319);
+// tsc's grammar check returns before the ambient-expression check runs for
+// that same node, so a `declare`d bare-expression default export must report
+// TS1319 alone, not TS1319 *and* TS2714.
+#[test]
+fn declare_export_default_expression_inside_namespace_reports_only_ts1319() {
+    let codes = check_source_codes("namespace N { declare export default 1; }");
+    assert!(
+        codes.contains(&A_DEFAULT_EXPORT_CAN_ONLY_BE_USED_IN_AN_ECMASCRIPT_STYLE_MODULE),
+        "expected TS1319; got {codes:?}"
+    );
+    assert!(
+        !codes.contains(
+            &THE_EXPRESSION_OF_AN_EXPORT_ASSIGNMENT_MUST_BE_AN_IDENTIFIER_OR_QUALIFIED_NAME_IN_AN_AMBIENT_CONTEXT
+        ),
+        "TS1319 already won the placement check for this node — TS2714 must \
+         not additionally fire; got {codes:?}"
+    );
+}

--- a/crates/tsz-parser/src/parser/state_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_declarations.rs
@@ -1963,7 +1963,7 @@ impl ParserState {
                                 diagnostic_codes::AN_EXPORT_ASSIGNMENT_CANNOT_HAVE_MODIFIERS,
                             );
                         }
-                        self.parse_export_default(start_pos)
+                        self.parse_export_default(start_pos, Some(modifiers))
                     }
                     _ => {
                         self.error_declaration_expected();

--- a/crates/tsz-parser/src/parser/state_declarations_exports.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_exports.rs
@@ -71,7 +71,7 @@ impl ParserState {
 
         // export default ...
         if self.is_token(SyntaxKind::DefaultKeyword) {
-            return self.parse_export_default(start_pos);
+            return self.parse_export_default(start_pos, None);
         }
 
         // export import X = Y (re-export of import equals)
@@ -391,7 +391,23 @@ impl ParserState {
     }
 
     // Parse export default
-    pub(crate) fn parse_export_default(&mut self, start_pos: u32) -> NodeIndex {
+    //
+    // `modifiers` carries a stray `declare` (plus the `export` it was found
+    // before) when reached from the ambient dispatch in `state_declarations.rs`
+    // (`declare export default <expr>;`); the ordinary `export default` path
+    // passes `None`. It is needed on the wrapper `EXPORT_DECLARATION` node
+    // because `is_in_ambient_context` reads a node's own `declare` modifier or
+    // walks to its parent — and a bare-expression default export is a leaf
+    // statement here, not nested inside another ambient-flagged node — so
+    // without it the checker's TS2714 ambient-expression check
+    // (`crates/tsz-checker/src/declarations/import/core/module_exports.rs`)
+    // never sees the declare context and silently drops the diagnostic
+    // (#16403 residual: `declare export default 1;` was missing TS2714).
+    pub(crate) fn parse_export_default(
+        &mut self,
+        start_pos: u32,
+        modifiers: Option<NodeList>,
+    ) -> NodeIndex {
         let default_pos = self.token_pos();
         self.parse_expected(SyntaxKind::DefaultKeyword);
 
@@ -472,13 +488,32 @@ impl ParserState {
         };
 
         let end_pos = self.token_end();
+        // Only thread the caller's modifiers onto the wrapper when the default
+        // export is a bare expression. A class/function/interface declaration
+        // already carries `declare` on its own inner node (via the dedicated
+        // `parse_declare_class`/etc. paths), and the checker's TS2714 check
+        // already excludes those kinds by node kind — attaching modifiers there
+        // too would be inert for TS2714 but is unnecessary surface area.
+        let is_declaration_expression = matches!(
+            self.arena.get(expression).map(|n| n.kind),
+            Some(k) if k == syntax_kind_ext::CLASS_DECLARATION
+                || k == syntax_kind_ext::FUNCTION_DECLARATION
+                || k == syntax_kind_ext::INTERFACE_DECLARATION
+                || k == syntax_kind_ext::ENUM_DECLARATION
+                || k == syntax_kind_ext::TYPE_ALIAS_DECLARATION
+        );
+        let wrapper_modifiers = if is_declaration_expression {
+            None
+        } else {
+            modifiers
+        };
         // Use export assignment for default exports
         self.arena.add_export_decl(
             syntax_kind_ext::EXPORT_DECLARATION,
             start_pos,
             end_pos,
             ExportDeclData {
-                modifiers: None,
+                modifiers: wrapper_modifiers,
                 is_type_only: false,
                 is_default_export: true,
                 default_keyword_pos: Some(default_pos),


### PR DESCRIPTION
Closes the last 2 of #16403's 110-row modifier x export-form cross-product. PR #16540 had already reduced the census to 108/110 (fixing the `{static,public,protected,private,readonly} export as namespace Foo;` anchor residual); this fixes the remaining `declare export default <expr>` rows.

## Structural rule

When `export default <expr>` is a bare expression (not a class/function/interface/enum/type-alias declaration) inside a `declare` context, tsc's grammar check requires the expression to be an identifier or qualified name — TS2714. tsz's parser hardcoded `ExportDeclData { modifiers: None, .. }` on the wrapper `EXPORT_DECLARATION` node for *every* `export default` form, including the ambient one built by `state_declarations.rs`'s `declare`-dispatch. `is_in_ambient_context` (`crates/tsz-parser/src/parser/node_access.rs`) reads a node's own `declare` modifier before walking to its parent, and this statement is a leaf at the source file's own top level with no ambient ancestor — so the ambient gate in `check_export_assignment` (`crates/tsz-checker/src/declarations/import/core/module_exports.rs`) read `false` and TS2714 silently never fired, even though the parser's own TS1120 ("An export assignment cannot have modifiers.") already did, since that one is emitted directly during parsing, independent of the node's `modifiers` field.

tsz now does this by threading the caller's modifiers through `parse_export_default` onto the wrapper — but only when the expression is not itself a declaration kind. A class/function/interface/enum/type-alias default export already carries `declare` on its own inner node (via `parse_declare_class`/etc.) and is already excluded from TS2714 by node kind, so attaching modifiers there too would be inert surface area.

**Second, narrower case found while verifying:** a default export nested in a `namespace` body already reports TS1319 ("A default export can only be used in an ECMAScript-style module."), and tsc's grammar check returns as soon as that placement diagnostic fires — the ambient-expression check never runs for the same node. Without a matching guard, my first version of this fix made `namespace N { declare export default 1; }` emit a spurious extra TS2714 alongside TS1319 (a regression caught by oracle-diffing the adjacent-case matrix, not by the existing suites). `check_export_assignment` now mirrors that early return.

This is the same class of fix as the sibling `declare export = <expr>;` case already pinned in `declare_export_equals_ambient_ts2714_tests.rs` (`parse_export_assignment` had the identical gap, already closed) — one export-default node kind over.

## Owner layer

Parser (`crates/tsz-parser/src/parser/state_declarations_exports.rs`, `state_declarations.rs`) threads the modifiers; checker (`crates/tsz-checker/src/declarations/import/core/module_exports.rs`) adds the namespace early-return guard. No solver/emitter change.

## Adjacent-case matrix

All rows oracle-verified against the pinned `typescript@7.0.2` (`--strict --target es2022 --module es2022`), byte-exact match on the built `.target/debug/tsz` CLI binary:

| source | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `declare export default 1;` | TS1120@1, TS2714@24 | TS1120@1 only (TS2714 missing) | **TS1120@1, TS2714@24** |
| `declare export default "hello";` | TS1120@1, TS2714@24 | TS1120@1 only | **TS1120@1, TS2714@24** |
| `declare export default identifierName;` (unresolved ident, valid ambient target shape) | TS1120@1, TS2304@24 | same | unchanged (identifier is a valid ambient target — TS2714 correctly absent both before and after) |
| `declare export default function f(): void;` | TS1029@9 | TS1029@9 | unchanged |
| `declare export default class {}` | TS1029@9 | TS1029@9 | unchanged |
| `declare module "m" { export default 1; }` (ambient via parent, not own modifier) | TS2714 | TS2714 | unchanged |
| `namespace N { declare export default 1; }` | TS1319 only | TS1319 only | **TS1319 only** (regression caught and fixed before landing — see above) |
| `export default 1;` (non-ambient control) | clean | clean | unchanged |

## Goal
Goal: hold

## Verification
- New suite `crates/tsz-checker/src/tests/declare_export_default_expression_ambient_ts2714_tests.rs`: `cargo test -p tsz-checker --lib declare_export_default_expression_ambient_ts2714` — **6/6 passed** (positive TS2714 rows, identifier/class/plain negative controls, namespace-placement-wins control).
- `cargo test -p tsz-checker --lib -- export declare namespace` (targeted blast radius) — **809/809 passed, 0 failed**.
- `cargo test -p tsz-parser --lib` (full crate, since two parser files changed) — **1966/1966 passed, 0 failed** — identical to PR #16540's own baseline.
- `cargo test -p tsz-checker --lib declare_export_equals_ambient_ts2714` (the sibling fix this mirrors) — **4/4 passed**, confirming no interaction with the `export =` path.
- `cargo clippy -p tsz-parser -p tsz-checker --lib -- -D warnings` — clean.
- `cargo fmt -p tsz-parser -p tsz-checker -- --check` — clean.
- `python3 scripts/arch/arch_guard.py` — passed.
- Pre-commit hook (clippy `-p tsz-checker -p tsz-parser` + arch guard) — passed.
- Manual byte-exact oracle diff against the built `.target/debug/tsz` CLI for all 8 matrix rows above.

**Owed, disclosed:** the full `cargo test -p tsz-checker --lib` run (~9600+ tests, board-documented long tail from a handful of named `ts2589`-family tests) did not finish inside this session's time budget; the 809-test filtered blast-radius run plus the full `tsz-parser --lib` suite are the evidence in its place. `compare-to-parent.sh`/full conformance snapshot also not run this session (two `dist-fast` builds, 55–90 min cold per the board's standing measurement) — this is a two-node-kind-narrow parser/checker change limited to the `declare export default <bare-expression>` shape, which is essentially absent from the corpus (the sibling `export =` fix and #16540's own `NamespaceExport`-anchor fix both recorded zero conformance movement for the same reason), so zero movement is the expected signature. Flagging as owed for whoever drains this rather than skipping the disclosure.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium (session default)
AgentName: Galena


---
_Generated by [Claude Code](https://claude.ai/code/session_01AnNHhrTSDKLELXMejEncEr)_