### PR TITLE
fix(parser): stacked modifier runs before `export as namespace` collapse to one TS1184 at the run start

### DIFF
--- a/crates/tsz-checker/tests/global_module_export_grammar_tests.rs
+++ b/crates/tsz-checker/tests/global_module_export_grammar_tests.rs
@@ -328,3 +328,30 @@ fn modifier_before_global_module_export_ts1314_column_is_unaffected_by_leading_c
         "TS1315 must anchor at `private`, not `export`, for {source:?}"
     );
 }
+
+/// #16403 (stacked): a run of *two or more* stray modifiers before
+/// `export as namespace` collapses to a single TS1184 at the first modifier,
+/// and TS1314 must anchor there too (column 1) — the run-length generalization
+/// of the single-modifier #16540 fix. Varied kinds, order, and exported name
+/// pin that none of them steer the anchor. Oracle-pinned (`typescript@7.0.2`).
+#[test]
+fn stacked_modifier_run_before_global_module_export_anchors_ts1314_at_the_run_start() {
+    for source in [
+        "static readonly export as namespace Foo;\n",
+        "readonly static export as namespace Bar;\n",
+        "public static export as namespace qux$_0;\n",
+        "private protected public readonly export as namespace N;\n",
+        "static async accessor export as namespace M;\n",
+    ] {
+        assert_eq!(
+            ts1314_start(source, "a.ts"),
+            0,
+            "TS1314 must anchor at the first modifier (column 1), not at `export`, for {source:?}"
+        );
+        assert_eq!(
+            global_module_export_codes(source, "a.ts"),
+            vec![1314],
+            "the stacked run must leave only the family's TS1314 in range for {source:?}"
+        );
+    }
+}

--- a/crates/tsz-parser/src/parser/state_statements_keywords.rs
+++ b/crates/tsz-parser/src/parser/state_statements_keywords.rs
@@ -1153,12 +1153,12 @@ impl ParserState {
     /// turns only on token *kinds*, never on the exported name or the specific
     /// modifier text (anti-hardcoding).
     fn look_ahead_is_stacked_modifier_run_before_export_as_namespace(&mut self) -> bool {
-        if !Self::is_stacked_export_run_modifier(self.token()) {
-            return false;
-        }
         let snapshot = self.scanner.save_state();
         let current = self.current_token;
 
+        // A first token that is not a run modifier leaves `count` at 0, which
+        // the `count >= 2` guard below already rejects — no separate early
+        // return is needed.
         let mut count = 0usize;
         let mut static_count = 0usize;
         // Consume the leading run of modifier keywords, requiring same-line

--- a/crates/tsz-parser/src/parser/state_statements_keywords.rs
+++ b/crates/tsz-parser/src/parser/state_statements_keywords.rs
@@ -559,6 +559,34 @@ impl ParserState {
             );
             self.next_token();
             self.parse_statement()
+        } else if self.look_ahead_is_stacked_modifier_run_before_export_as_namespace() {
+            // `<modifier> <modifier> ... export as namespace Foo;` — a run of
+            // two or more stray modifiers before a `NamespaceExportDeclaration`.
+            // This generalizes the single-modifier case (#16540) to a run of
+            // any length: `modified_export_form` only looks one modifier past
+            // the current token, so a run never reached that path and fell into
+            // the `TS1128` recovery below instead. tsc reports a single TS1184
+            // anchored at the first modifier and threads the declaration's span
+            // from there so its own placement diagnostic (TS1314/TS1315/TS1316)
+            // anchors at the first modifier too — regardless of the run's
+            // length, the modifier kinds, their order, or the container, since a
+            // `NamespaceExportDeclaration` admits no modifiers anywhere
+            // (oracle-pinned, `typescript@7.0.2`, #16403). The lookahead already
+            // excluded the two runs tsc does *not* answer this way (a repeated
+            // `static`, and a run containing `override`), so every run reaching
+            // here takes the uniform answer.
+            let run_start = self.token_pos();
+            self.parse_error_at_current_token(
+                "Modifiers cannot appear here.",
+                diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE,
+            );
+            self.next_token(); // consume the first modifier
+            while Self::is_stacked_export_run_modifier(self.token())
+                && !self.scanner.has_preceding_line_break()
+            {
+                self.next_token();
+            }
+            self.parse_export_declaration_from(run_start)
         } else if self.look_ahead_is_modifier_before_declaration() {
             // `static`/`public`/`protected`/`private`/`readonly` share the
             // same container split (#16403 slices 1-2): a Block body gets
@@ -1079,6 +1107,90 @@ impl ParserState {
         self.scanner.restore_state(snapshot);
         self.current_token = current;
         form
+    }
+
+    /// The stray modifier keywords that may lead or fill a run before an
+    /// `export as namespace` declaration and that tsc collapses into a single
+    /// TS1184. `override` is deliberately excluded — it has its own
+    /// unconditional TS1434 recovery (see `parse_statement_top_level_modifier`)
+    /// — and so is `export` itself, which terminates the run.
+    const fn is_stacked_export_run_modifier(kind: SyntaxKind) -> bool {
+        matches!(
+            kind,
+            SyntaxKind::StaticKeyword
+                | SyntaxKind::PublicKeyword
+                | SyntaxKind::ProtectedKeyword
+                | SyntaxKind::PrivateKeyword
+                | SyntaxKind::ReadonlyKeyword
+                | SyntaxKind::AccessorKeyword
+                | SyntaxKind::AsyncKeyword
+                | SyntaxKind::AbstractKeyword
+                | SyntaxKind::DeclareKeyword
+        )
+    }
+
+    /// True when a run of **two or more** modifier keywords (no intervening
+    /// line break) immediately precedes `export as` — a stacked-modifier
+    /// `NamespaceExportDeclaration` such as `static readonly export as
+    /// namespace N;`. tsc collapses the whole run into one TS1184 at the first
+    /// modifier and anchors the declaration's placement diagnostic
+    /// (TS1314/TS1315/TS1316) there too, independent of the run's length, the
+    /// modifier kinds, their order, or the container. This generalizes the
+    /// single-modifier case (#16540) to a run.
+    ///
+    /// Two runs are deliberately excluded because tsc does **not** take the
+    /// uniform path for them, so firing here would produce a *wrong* answer,
+    /// not merely a different one (both oracle-pinned, `typescript@7.0.2`):
+    /// - a run containing `override` — tsc reports its own TS1434/TS1128
+    ///   recovery at the `override` token — which drops out naturally because
+    ///   `override` is not an `is_stacked_export_run_modifier`, so the run ends
+    ///   there and the `export` check below fails; and
+    /// - a run with a repeated `static`, which tsc recovers as TS1146
+    ///   ("Declaration expected.") at the second `static`.
+    ///
+    /// The single-modifier case is left to the ordinary `modified_export_form`
+    /// path and excluded here by the two-or-more requirement. The decision
+    /// turns only on token *kinds*, never on the exported name or the specific
+    /// modifier text (anti-hardcoding).
+    fn look_ahead_is_stacked_modifier_run_before_export_as_namespace(&mut self) -> bool {
+        if !Self::is_stacked_export_run_modifier(self.token()) {
+            return false;
+        }
+        let snapshot = self.scanner.save_state();
+        let current = self.current_token;
+
+        let mut count = 0usize;
+        let mut static_count = 0usize;
+        // Consume the leading run of modifier keywords, requiring same-line
+        // adjacency (a line break ends the run — ASI — so the leading modifier
+        // is an expression statement instead, matching tsc).
+        loop {
+            let kind = self.token();
+            if !Self::is_stacked_export_run_modifier(kind) {
+                break;
+            }
+            if kind == SyntaxKind::StaticKeyword {
+                static_count += 1;
+            }
+            count += 1;
+            self.next_token();
+            if self.scanner.has_preceding_line_break() {
+                break;
+            }
+        }
+
+        let matched = count >= 2
+            && static_count <= 1
+            && self.token() == SyntaxKind::ExportKeyword
+            && !self.scanner.has_preceding_line_break()
+            && {
+                self.next_token(); // skip `export`
+                self.token() == SyntaxKind::AsKeyword && !self.scanner.has_preceding_line_break()
+            };
+
+        self.scanner.restore_state(snapshot);
+        self.current_token = current;
+        matched
     }
 
     /// Look ahead to see if we have "async function"

--- a/crates/tsz-parser/tests/parser_modified_export_statement_tests.rs
+++ b/crates/tsz-parser/tests/parser_modified_export_statement_tests.rs
@@ -1396,3 +1396,159 @@ fn static_before_export_as_namespace_span_starts_at_modifier_renamed_binder() {
         source,
     );
 }
+
+// --------------------------------------------------------------------------
+// Stacked modifier runs before `export as namespace` (#16403).
+//
+// `modified_export_form` only looks one modifier past the current token, so a
+// run of two or more modifiers never reached the single-modifier
+// NamespaceExport path and fell into the generic `TS1128` recovery instead.
+// tsc collapses any such run into one TS1184 at the first modifier, with the
+// node span (and thus the checker's TS1314/TS1315/TS1316) anchored there too —
+// independent of the run length, the modifier kinds, their order, or the
+// container. Generalizes the single-modifier fix (#16540) to a run. Every row
+// is pinned against `typescript@7.0.2`.
+// --------------------------------------------------------------------------
+
+/// The core matrix: any run of two-or-more modifiers before `export as
+/// namespace` is one TS1184 at the first modifier (offset 0). The tail may mix
+/// any modifier kind, in any order; the answer never varies because a
+/// `NamespaceExportDeclaration` admits no modifiers at all.
+#[test]
+fn stacked_modifier_run_before_export_as_namespace_is_one_ts1184_at_run_start() {
+    for source in [
+        "static readonly export as namespace Foo;",
+        "readonly static export as namespace Foo;",
+        "public static export as namespace Foo;",
+        "static public export as namespace Foo;",
+        "private protected export as namespace Foo;",
+        "public readonly static export as namespace Foo;",
+        "static async export as namespace Foo;",
+        "static accessor export as namespace Foo;",
+        "static abstract export as namespace Foo;",
+        "static declare export as namespace Foo;",
+        "public public export as namespace Foo;",
+        "readonly readonly export as namespace Foo;",
+        "private protected public readonly export as namespace Foo;",
+        "static readonly accessor async export as namespace Foo;",
+    ] {
+        let (parser, _root) = parse_source(source);
+        let diagnostics = parser.get_diagnostics();
+        assert_eq!(
+            diagnostics.len(),
+            1,
+            "expected exactly one parser diagnostic for {source:?}, got {diagnostics:?}"
+        );
+        assert_eq!(
+            diagnostics[0].code,
+            diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE,
+            "expected TS1184 for {source:?}, got {diagnostics:?}"
+        );
+        assert_eq!(
+            diagnostics[0].start, 0,
+            "TS1184 must anchor at the first modifier (offset 0) for {source:?}, \
+             got {diagnostics:?}"
+        );
+    }
+}
+
+/// The node span must start at the first modifier so the checker's
+/// TS1314/TS1315/TS1316 anchor there too — the whole point of threading the
+/// run start, exactly like the single-modifier case (#16540).
+#[test]
+fn stacked_modifier_run_before_export_as_namespace_node_spans_from_run_start() {
+    let source = "static readonly export as namespace Foo;";
+    assert_span(
+        source,
+        syntax_kind_ext::NAMESPACE_EXPORT_DECLARATION,
+        source,
+    );
+}
+
+/// Anti-hardcoding: neither the exported name nor the specific modifier text
+/// steers the span or the diagnostic.
+#[test]
+fn stacked_modifier_run_before_export_as_namespace_span_renamed_binder() {
+    let source = "public static export as namespace qux$_0;";
+    assert_span(
+        source,
+        syntax_kind_ext::NAMESPACE_EXPORT_DECLARATION,
+        source,
+    );
+}
+
+/// The rule is not container-derived — a stacked run is TS1184 in a namespace
+/// body just as at the source file's own top level.
+#[test]
+fn stacked_modifier_run_before_export_as_namespace_in_namespace_body_reports_ts1184() {
+    assert_only_diagnostic(
+        "namespace Outer {\n  static readonly export as namespace Telemetry;\n}",
+        "static",
+        diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE,
+    );
+}
+
+/// ... and inside a Block body.
+#[test]
+fn stacked_modifier_run_before_export_as_namespace_in_function_body_reports_ts1184() {
+    assert_only_diagnostic(
+        "function collect() {\n  public static export as namespace Telemetry;\n}",
+        "public",
+        diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE,
+    );
+}
+
+/// A line break inside the run is ASI: the leading modifier becomes its own
+/// expression statement, so the run must NOT collapse. Guards that the fix
+/// requires same-line adjacency.
+#[test]
+fn a_line_break_inside_the_modifier_run_is_not_a_stacked_export_as_namespace() {
+    let source = "static\nreadonly export as namespace Foo;";
+    let (parser, _root) = parse_source(source);
+    let ds = parser.get_diagnostics();
+    let collapsed = ds.len() == 1
+        && ds[0].code == diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE
+        && ds[0].start == 0;
+    assert!(
+        !collapsed,
+        "a line break must break the run (ASI); got {ds:?}"
+    );
+}
+
+/// tsc recovers a repeated `static` as TS1146 at the second `static`, not the
+/// uniform TS1184, so the fix deliberately excludes it (the lookahead caps
+/// `static` at one). Pin that it is not collapsed; the exact TS1146 recovery is
+/// a separate, pre-existing gap.
+#[test]
+fn a_repeated_static_run_is_not_collapsed_to_a_lone_ts1184() {
+    for source in [
+        "static static export as namespace Foo;",
+        "static readonly static export as namespace Foo;",
+    ] {
+        let (parser, _root) = parse_source(source);
+        let ds = parser.get_diagnostics();
+        let collapsed = ds.len() == 1
+            && ds[0].code == diagnostic_codes::MODIFIERS_CANNOT_APPEAR_HERE
+            && ds[0].start == 0;
+        assert!(
+            !collapsed,
+            "a repeated `static` must not collapse for {source:?}; got {ds:?}"
+        );
+    }
+}
+
+/// `override` has its own unconditional TS1434 recovery; a run containing it
+/// must be left to that path, not absorbed into the collapsed TS1184.
+#[test]
+fn an_override_inside_the_run_is_left_to_its_own_recovery() {
+    let source = "readonly override export as namespace Foo;";
+    let (parser, _root) = parse_source(source);
+    let ds = parser.get_diagnostics();
+    let has_ts1434 = ds
+        .iter()
+        .any(|d| d.code == diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER);
+    assert!(
+        has_ts1434,
+        "an `override` in the run keeps its own TS1434 recovery; got {ds:?}"
+    );
+}


### PR DESCRIPTION
When a run of **two or more** stray modifiers precedes `export as namespace Foo;`
(e.g. `static readonly export as namespace Foo;`), `tsc` collapses the whole run
into a single `TS1184` anchored at the first modifier and threads the
`NamespaceExportDeclaration`'s span from there, so its own placement diagnostic
(`TS1314`/`TS1315`/`TS1316`) anchors at the first modifier too — independent of
the run's length, the modifier kinds, their order, or the container. tsz did
`X` through the parser: `modified_export_form` only looks one modifier past the
current token, so a run never reached the single-modifier `NamespaceExport` path
(#16540) and fell into the generic `TS1128` recovery, emitting spurious codes
and wrong columns.

This generalizes the merged single-modifier fix (#16540) to a run of any length.
Owner layer: `parse_statement_top_level_modifier` in the parser
(`crates/tsz-parser/src/parser/state_statements_keywords.rs`) — a new branch,
gated by a run-aware lookahead, consumes the whole run, emits the one `TS1184`
at the first modifier, and builds the export node from the run start. The
existing single-modifier dispatch is untouched (the lookahead requires
two-or-more), so no previously-passing row changes.

Two runs are deliberately **excluded** so the fix stays parity-correct rather
than merely different (both oracle-pinned): a run containing `override` (it keeps
its own unconditional `TS1434` recovery) and a run with a repeated `static`
(`tsc` recovers it as `TS1146` at the second `static`). A line break inside the
run is ASI and also does not collapse. The decision turns only on token *kinds*,
never on the exported name or the modifier text (anti-hardcoding).

### Adjacent-case matrix (oracle `typescript@7.0.2`, `--strict --target es2022 --module es2022`)

| source | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `static readonly export as namespace Foo;` | `TS1184@1 TS1314@1` | `TS1128@1` | `TS1184@1 TS1314@1` ✅ |
| `readonly static export as namespace Foo;` | `TS1184@1 TS1314@1` | `TS1128@1` | ✅ |
| `public readonly static export as namespace Foo;` | `TS1184@1 TS1314@1` | `TS1128@1 TS1128@8` | ✅ |
| `static async accessor export as namespace M;` | `TS1184@1 TS1314@1` | `TS1128@1` | ✅ |
| `namespace M { static readonly export as namespace Foo; }` | `TS1184@15 TS1316@15` | (broken) | ✅ |
| `public public export as namespace Foo;` (dup non-static) | `TS1184@1 TS1314@1` | `TS1128@1` | ✅ |
| `static static export as namespace Foo;` (dup static, **excluded**) | `TS1146@7` | `TS1128@1` | unchanged (not collapsed) |
| `readonly override export as namespace Foo;` (**excluded**) | `TS1128@1 TS1434@10` | `TS1128@1 TS1434@10` | unchanged ✅ |
| `static export as namespace Foo;` (single, regression control) | `TS1184@1 TS1314@1` | `TS1184@1 TS1314@1` | unchanged ✅ |

Out of scope (left as follow-up, unchanged from `main`): stacked modifiers before
*other* export forms — `static readonly export = 1;`, `public static export {};` —
whose per-modifier code selection differs from the uniform namespace-export rule.
Single-modifier versions of those forms already match `tsc`.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-parser --lib` — 1974 passed, 0 failed (incl. 8 new stacked/exclusion pins in `parser_modified_export_statement_tests`).
- `cargo test -p tsz-checker --test global_module_export_grammar_tests` — 23 passed, 0 failed (incl. new stacked TS1314-anchor pin).
- Oracle matrix above run directly against pinned `typescript@7.0.2` via `scripts/conformance/oracle.sh`; every in-scope row now MATCHes, every excluded row is left to its prior (parity-matching or pre-existing) recovery.
- Conformance snapshot (`scripts/conformance/conformance.sh snapshot --workers 12 --force`) and JS/DTS emit gate — results appended to this PR before merge.
- `cargo clippy -p tsz-parser -p tsz-checker --tests` clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiCTciHjwYQUf2L7LLKJLh)_