### PR TITLE
fix(solver): a longhand union is not repainted with a non-generic alias name (#16610)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core_alias_display.rs
@@ -82,6 +82,17 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
+        // A union the user wrote longhand carries no `aliasSymbol` in `tsc`, so
+        // it renders structurally rather than picking up a non-generic alias name
+        // from the reverse registrations below (#16610). The occurrence is
+        // distinguished by `mark_longhand_union_annotation` (an alias reference
+        // such as `T1 & T2` is never marked and still recovers `T1`; a genuine
+        // `declare const v: Zed` reaches the formatter as a `Lazy(DefId)` resolved
+        // before this helper). See `TypeInterner::longhand_union_annotations`.
+        if is_union && self.ctx.types.is_longhand_union_annotation(ty) {
+            return None;
+        }
+
         if let Some(def_id) = self.ctx.definition_store.find_def_for_type(ty)
             && let Some(def) = self.ctx.definition_store.get(def_id)
             && def.kind != tsz_solver::def::DefKind::TypeAlias

--- a/crates/tsz-checker/src/types/computation/type_operators.rs
+++ b/crates/tsz-checker/src/types/computation/type_operators.rs
@@ -5,7 +5,37 @@ use super::super::unique_symbol_construction::unique_symbol_type_for_operator;
 use crate::query_boundaries::type_computation::complex as query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::NodeArena;
 use tsz_solver::TypeId;
+
+/// True when the `UnionType` node `idx` is (possibly through parenthesized
+/// wrappers) the body of a type-alias declaration.
+///
+/// A union written as an alias body carries the alias's `aliasSymbol` in `tsc`,
+/// so referencing the alias (`T1 & T2`, `T1 | null`) must keep the name; only a
+/// union written longhand at another site is alias-less and renders
+/// structurally. This gates `mark_longhand_union_annotation` so the two
+/// occurrences of the same interned union `TypeId` are not conflated (#16610).
+pub(crate) fn union_type_node_is_alias_body(arena: &NodeArena, idx: NodeIndex) -> bool {
+    let mut current = idx;
+    // Bounded to guard against a malformed parent cycle; a well-formed arena
+    // terminates far sooner when `parent_of` reaches the root (`NodeIndex::NONE`,
+    // for which `get` returns `None`).
+    for _ in 0..64 {
+        let Some(parent) = arena.parent_of(current) else {
+            return false;
+        };
+        let Some(parent_node) = arena.get(parent) else {
+            return false;
+        };
+        if parent_node.kind == tsz_parser::parser::syntax_kind_ext::PARENTHESIZED_TYPE {
+            current = parent;
+            continue;
+        }
+        return arena.get_type_alias(parent_node).is_some();
+    }
+    false
+}
 
 impl<'a> CheckerState<'a> {
     /// Get type from a union type node (A | B).
@@ -106,6 +136,13 @@ impl<'a> CheckerState<'a> {
                         .types
                         .mark_union_literal_member(result, member_type);
                 }
+            }
+            // Record that this union was written *longhand* at an annotation
+            // site (not as a type-alias body), so the diagnostic printer refuses
+            // to recover a non-generic alias name for it from the interner's
+            // global reverse tables. See `mark_longhand_union_annotation`.
+            if !union_type_node_is_alias_body(self.ctx.arena, idx) {
+                self.ctx.types.mark_longhand_union_annotation(result);
             }
             return result;
         }

--- a/crates/tsz-checker/src/types/type_node.rs
+++ b/crates/tsz-checker/src/types/type_node.rs
@@ -368,6 +368,18 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                         .mark_union_literal_member(result, member_type);
                 }
             }
+            // See the sibling `get_type_from_union_type`
+            // (`computation::type_operators`): a longhand union annotation is
+            // recorded so the diagnostic printer refuses to repaint it with a
+            // non-generic alias name recovered from the interner's reverse tables
+            // (#16610). Alias bodies are excluded so referencing the alias keeps
+            // its name.
+            if !super::computation::type_operators::union_type_node_is_alias_body(
+                self.ctx.arena,
+                idx,
+            ) {
+                self.ctx.types.mark_longhand_union_annotation(result);
+            }
             return result;
         }
 

--- a/crates/tsz-checker/tests/union_display_alias_repaint_parity_tests.rs
+++ b/crates/tsz-checker/tests/union_display_alias_repaint_parity_tests.rs
@@ -8,11 +8,13 @@
 //! member list *plus* the alias identity, so the aliased and the longhand
 //! spelling are two distinct `Type` objects and neither can repaint the other.
 //!
-//! tsz interns one `TypeId` per content and carries the alias in a global
-//! `TypeId -> alias` side table (`TypeInterner::store_display_alias` /
-//! `get_display_alias`), so an alias declared anywhere can repaint a
-//! structurally identical type written longhand somewhere else. That is the
-//! divergence the `#[ignore]`d rows below record.
+//! tsz interns one `TypeId` per content and recovered the alias from global
+//! reverse tables (`body -> alias`, `type -> def`, `store_display_alias` /
+//! `get_display_alias`), so an alias declared anywhere used to repaint a
+//! structurally identical union written longhand somewhere else. #16610 fixes
+//! that for the directly-written union family: `mark_longhand_union_annotation`
+//! records the longhand occurrence at type-node resolution, and the diagnostic
+//! display gateways refuse the repaint for a marked union.
 //!
 //! Every expectation here was verified against the pinned oracle
 //! (`typescript@7.0.2`, `--noEmit --strict --lib es2022 --target es2022`), one
@@ -20,9 +22,11 @@
 //! which matters especially here, since the defect is precisely about one
 //! declaration reaching another site.
 //!
-//! Live rows are a regression floor for the spellings that already match.
-//! `#[ignore]`d rows are tripwires: they assert `tsc`'s answer and are expected
-//! to fail until the repaint is fixed. Run them with
+//! Live rows are the regression floor: the spellings that already matched and
+//! the longhand-union family fixed by #16610. The remaining `#[ignore]`d rows
+//! are tripwires for two *separate* mechanisms — `keyof any` operator resolution
+//! and the collapsing-alias display — expected to fail until each is fixed. Run
+//! them with
 //! `cargo test -p tsz-checker --test union_display_alias_repaint_parity_tests -- --ignored`.
 
 use tsz_checker::CheckerOptions;
@@ -128,17 +132,22 @@ fn interface_declared_elsewhere_does_not_repaint_a_longhand_object() {
 }
 
 // ---------------------------------------------------------------------------
-// Tripwires: oracle-verified divergences. Expected to fail until fixed.
+// Regression floor: the longhand-union repaint family, fixed in #16610.
+//
+// A longhand-written primitive/literal union carries no `aliasSymbol` in `tsc`,
+// so a non-generic type-alias name is no longer recovered for it from the
+// interner's global reverse tables: `mark_longhand_union_annotation` records the
+// occurrence at type-node resolution, and the diagnostic display gateways refuse
+// the repaint for a marked union. A genuine alias reference reaches display as a
+// `Lazy(DefId)` and keeps its name, so referencing the alias is unaffected.
 // ---------------------------------------------------------------------------
 
-/// A longhand primitive union is repainted by a **lib** alias the source never
-/// mentions. tsz renders `PropertyKey`; tsc renders the union.
-///
-/// This is the widest-reach row: every `string | number | symbol` written by
-/// any user anywhere renders as `PropertyKey`, because `lib.es5.d.ts` declares
-/// that alias and the display-alias table is keyed on the interned `TypeId`.
+/// A longhand primitive union is not repainted by a **lib** alias the source
+/// never mentions. Widest-reach row: before the fix every
+/// `string | number | symbol` a user wrote rendered as `PropertyKey`, because
+/// `lib.es5.d.ts` declares that alias and the reverse tables are keyed on the
+/// interned `TypeId`.
 #[test]
-#[ignore = "known divergence: lib alias repaints a longhand primitive union (display-alias table is global by TypeId)"]
 fn longhand_primitive_union_is_not_repainted_by_an_unreferenced_lib_alias() {
     let source = "declare const value: string | number | symbol;\n\
                   const target: boolean = value;\n";
@@ -149,7 +158,6 @@ fn longhand_primitive_union_is_not_repainted_by_an_unreferenced_lib_alias() {
 /// referenced. No lib involvement, so this row rules out "the lib is stamped
 /// specially" as the cause.
 #[test]
-#[ignore = "known divergence: an unreferenced user alias repaints a longhand primitive union"]
 fn longhand_primitive_union_is_not_repainted_by_an_unreferenced_user_alias() {
     let source = "type Zed = string | number | symbol;\n\
                   declare const value: string | number | symbol;\n\
@@ -161,7 +169,6 @@ fn longhand_primitive_union_is_not_repainted_by_an_unreferenced_user_alias() {
 /// anything keyed on the specific alias name or on the three-member shape that
 /// `PropertyKey` happens to have.
 #[test]
-#[ignore = "known divergence: an unreferenced user alias repaints a longhand primitive union"]
 fn renamed_binders_longhand_two_member_union_is_not_repainted_by_its_alias() {
     let source = "type Pair = string | number;\n\
                   declare const other: string | number;\n\
@@ -173,7 +180,6 @@ fn renamed_binders_longhand_two_member_union_is_not_repainted_by_its_alias() {
 /// behaviour is not a declaration-order artifact that a source-order rule could
 /// explain away.
 #[test]
-#[ignore = "known divergence: an unreferenced user alias repaints a longhand primitive union"]
 fn an_alias_declared_after_the_use_site_does_not_repaint_the_longhand_union() {
     let source = "declare const value: string | number;\n\
                   const target: boolean = value;\n\
@@ -185,9 +191,9 @@ fn an_alias_declared_after_the_use_site_does_not_repaint_the_longhand_union() {
 /// `string | number | symbol` eagerly, so the operator never reaches the
 /// printer. tsz keeps the `KeyOf` node and renders it verbatim.
 ///
-/// Kept in this file because the two interact — once `keyof any` resolves to
-/// the union, it lands on exactly the `TypeId` the rows above show is
-/// repainted, so fixing this one alone would render `PropertyKey` here.
+/// Unblocked by the #16610 fix above — the resolved union now renders
+/// structurally rather than `PropertyKey` — but resolving the `keyof any`
+/// operator for display is its own change and stays a tripwire.
 #[test]
 #[ignore = "known divergence: `keyof any` is not resolved to its member union for display"]
 fn keyof_any_renders_as_its_resolved_member_union() {

--- a/crates/tsz-solver/src/caches/display_provenance.rs
+++ b/crates/tsz-solver/src/caches/display_provenance.rs
@@ -115,6 +115,17 @@ pub trait TypeDisplayProvenance {
         false
     }
 
+    /// Mark `type_id` as a union the user wrote longhand at a type-annotation
+    /// site (not as an alias body). See
+    /// `TypeInterner::mark_longhand_union_annotation`.
+    fn mark_longhand_union_annotation(&self, _type_id: TypeId) {}
+
+    /// Return whether `type_id` was recorded as a longhand-written union
+    /// annotation.
+    fn is_longhand_union_annotation(&self, _type_id: TypeId) -> bool {
+        false
+    }
+
     /// Mark `member_type_id` as an anonymous object-type literal written
     /// directly inside the union `union_type_id`. See
     /// `TypeInterner::mark_union_literal_member`.
@@ -286,6 +297,14 @@ impl TypeDisplayProvenance for TypeInterner {
 
     fn is_literal_object_annotation(&self, type_id: TypeId) -> bool {
         Self::is_literal_object_annotation(self, type_id)
+    }
+
+    fn mark_longhand_union_annotation(&self, type_id: TypeId) {
+        Self::mark_longhand_union_annotation(self, type_id);
+    }
+
+    fn is_longhand_union_annotation(&self, type_id: TypeId) -> bool {
+        Self::is_longhand_union_annotation(self, type_id)
     }
 
     fn mark_union_literal_member(&self, union_type_id: TypeId, member_type_id: TypeId) {

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -785,6 +785,14 @@ impl TypeDisplayProvenance for QueryCache<'_> {
         self.interner.is_literal_object_annotation(type_id)
     }
 
+    fn mark_longhand_union_annotation(&self, type_id: TypeId) {
+        self.interner.mark_longhand_union_annotation(type_id);
+    }
+
+    fn is_longhand_union_annotation(&self, type_id: TypeId) -> bool {
+        self.interner.is_longhand_union_annotation(type_id)
+    }
+
     fn mark_union_literal_member(&self, union_type_id: TypeId, member_type_id: TypeId) {
         self.interner
             .mark_union_literal_member(union_type_id, member_type_id);

--- a/crates/tsz-solver/src/diagnostics/format/key.rs
+++ b/crates/tsz-solver/src/diagnostics/format/key.rs
@@ -91,9 +91,17 @@ impl<'a> TypeFormatter<'a> {
                 self.format_object_with_index(shape.as_ref()).into()
             }
             TypeData::Union(members) => {
+                // The canonical `string | number | symbol` collapses to
+                // `PropertyKey` in diagnostics, EXCEPT when the user wrote the
+                // union longhand: `tsc` carries no `aliasSymbol` on a longhand
+                // union, so it renders structurally (#16610). A genuine
+                // `PropertyKey` reference reaches display as a `Lazy(DefId)` and
+                // never lands here; an instantiated/evaluated key union carries no
+                // longhand mark, so it still collapses.
                 if self.diagnostic_mode
                     && !self.expand_primitive_key_union
                     && self.is_primitive_key_union_data(key)
+                    && !self.interner.is_longhand_union_annotation(type_id)
                 {
                     return Cow::Borrowed("PropertyKey");
                 }

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -318,6 +318,15 @@ impl<'a> TypeFormatter<'a> {
             && members.contains(&TypeId::SYMBOL)
     }
 
+    /// True when `key`/`type_id` is a union the user wrote longhand at an
+    /// annotation site (recorded by `mark_longhand_union_annotation`). `tsc`
+    /// carries no `aliasSymbol` on such a union, so diagnostic alias-name
+    /// recovery must be refused for it (#16610). The cheap `Union` discriminant
+    /// check short-circuits the side-table probe for non-union keys.
+    fn is_longhand_annotation_union(&self, key: &TypeData, type_id: TypeId) -> bool {
+        matches!(key, TypeData::Union(_)) && self.interner.is_longhand_union_annotation(type_id)
+    }
+
     /// True when `key` is a `Union` whose members are all unit types: literal
     /// values, enum members, or unique symbols. Such a union is exactly what a
     /// user can spell directly as an annotation (`"a" | "b"`, `0 | 1`), so it
@@ -1344,8 +1353,18 @@ impl<'a> TypeFormatter<'a> {
                             | DefKind::Variable
                     ) | (TypeData::Enum(_, _), DefKind::Enum)
                 );
-            let unproven_primitive_key_union_alias =
-                def.kind == DefKind::TypeAlias && self.is_primitive_key_union_data(&key);
+            // Refuse a non-generic type-alias name for a union in two cases:
+            //   (1) the canonical property-key union (`string | number | symbol`)
+            //       is a shared structural sentinel (`keyof any` / `PropertyKey`)
+            //       and must never be repainted by an unrelated same-body alias;
+            //   (2) any union the user wrote longhand carries no `aliasSymbol` in
+            //       `tsc` (#16610), tracked via `mark_longhand_union_annotation`.
+            // A genuine alias reference (`T1 & T2`) whose body is interned to the
+            // same shape but is neither canonical nor written longhand keeps `T1`.
+            let unproven_primitive_key_union_alias = def.kind == DefKind::TypeAlias
+                && (self.is_primitive_key_union_data(&key)
+                    || (def.type_params.is_empty()
+                        && self.is_longhand_annotation_union(&key, type_id)));
             // An inline / anonymous composite annotation shares its interned
             // `TypeId` with a coincidentally-shaped non-generic type-alias body,
             // so the reverse `find_def_for_type` lookup cannot prove the source
@@ -1672,7 +1691,8 @@ impl<'a> TypeFormatter<'a> {
             // aggregate diagnostics.
             let skip_literal_annotation_application_alias = is_literal_object_annotation
                 && self.application_alias_base_has_mapped_body(alias_origin);
-            let skip_primitive_key_union_type_alias = self.is_primitive_key_union_data(&key)
+            let skip_primitive_key_union_type_alias = (self.is_primitive_key_union_data(&key)
+                || self.is_longhand_annotation_union(&key, type_id))
                 && matches!(
                     self.interner.lookup(alias_origin),
                     Some(TypeData::Lazy(def_id))

--- a/crates/tsz-solver/src/diagnostics/format/tests_parts/part_00.rs
+++ b/crates/tsz-solver/src/diagnostics/format/tests_parts/part_00.rs
@@ -143,11 +143,29 @@ fn primitive_key_union_registered_to_type_alias_formats_structurally_without_ori
 
 #[test]
 fn primitive_key_union_formats_as_property_key_in_diagnostic_mode() {
+    // A canonical key union that was NOT written longhand (e.g. an
+    // instantiated/evaluated `PropertyKey` / `keyof any` result) collapses to
+    // `PropertyKey` in diagnostic mode, matching `tsc`'s `aliasSymbol` display.
     let db = TypeInterner::new();
     let primitive_key_union = db.union(vec![TypeId::STRING, TypeId::NUMBER, TypeId::SYMBOL]);
 
     let mut fmt = TypeFormatter::new(&db).with_diagnostic_mode();
     assert_eq!(fmt.format(primitive_key_union), "PropertyKey");
+}
+
+#[test]
+fn longhand_primitive_key_union_formats_structurally_in_diagnostic_mode() {
+    // A `string | number | symbol` the user wrote longhand carries no
+    // `aliasSymbol` in `tsc`, so it renders structurally rather than as
+    // `PropertyKey` (#16610). The checker records the occurrence via
+    // `mark_longhand_union_annotation`; the formatter refuses the `PropertyKey`
+    // collapse for such a marked union.
+    let db = TypeInterner::new();
+    let primitive_key_union = db.union(vec![TypeId::STRING, TypeId::NUMBER, TypeId::SYMBOL]);
+    db.mark_longhand_union_annotation(primitive_key_union);
+
+    let mut fmt = TypeFormatter::new(&db).with_diagnostic_mode();
+    assert_eq!(fmt.format(primitive_key_union), "string | number | symbol");
 }
 
 #[test]

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -541,6 +541,25 @@ pub struct TypeInterner {
     /// union-member elaboration can ask "was *this* occurrence, in *this*
     /// union, written as a literal" instead of the shape-wide question.
     pub(super) union_literal_members: DashMap<(TypeId, TypeId), (), FxBuildHasher>,
+    /// Union `TypeId`s that were written *longhand* at a type-annotation site —
+    /// a `UnionType` node that is not itself a type-alias body.
+    ///
+    /// `tsc` stamps a union's `aliasSymbol` only on the `Type` built at the
+    /// alias's own `getUnionType(members, …, aliasSymbol)` call, so a
+    /// structurally identical union written longhand elsewhere is a distinct,
+    /// alias-less `Type` that renders structurally. tsz interns one `TypeId` for
+    /// both spellings and would otherwise recover a non-generic alias name from
+    /// its global reverse tables (`body -> alias`, `type -> def`, `PropertyKey`)
+    /// for the longhand occurrence too, repainting every longhand
+    /// `string | number | symbol` as `PropertyKey` and every `A | B` as an
+    /// unrelated same-shaped alias declared elsewhere (#16610). Recording which
+    /// ids the user actually wrote longhand lets the diagnostic printer refuse
+    /// that repaint for those — while a genuine alias reference, whose body is
+    /// interned to the same id but is *not* written longhand anywhere, keeps its
+    /// name. Alias bodies are deliberately excluded from this table so that
+    /// referencing the alias (`T1 & T2`, `T1 | null`) still renders `T1`.
+    /// Display-only; first write wins; membership is monotonic.
+    pub(super) longhand_union_annotations: DashMap<TypeId, (), FxBuildHasher>,
     /// As-written origin members for a Union TypeId, used to preserve top-level
     /// alias names that would otherwise be lost during union flattening.
     ///
@@ -874,6 +893,7 @@ impl TypeInterner {
             global_this_surface_display: DashMap::with_hasher(FxBuildHasher),
             literal_object_annotations: DashMap::with_hasher(FxBuildHasher),
             union_literal_members: DashMap::with_hasher(FxBuildHasher),
+            longhand_union_annotations: DashMap::with_hasher(FxBuildHasher),
             display_union_origin: DashMap::with_hasher(FxBuildHasher),
             union_complexity_overflow_by_thread: OnceLock::new(),
             union_complexity_pending_threads: AtomicUsize::new(0),

--- a/crates/tsz-solver/src/intern/core/interner/display.rs
+++ b/crates/tsz-solver/src/intern/core/interner/display.rs
@@ -411,6 +411,32 @@ impl TypeInterner {
         self.literal_object_annotations.contains_key(&type_id)
     }
 
+    /// Record that `type_id` is a union the user wrote *longhand* at a
+    /// type-annotation site (a `UnionType` node that is not a type-alias body).
+    ///
+    /// See [`Self::longhand_union_annotations`]: the diagnostic printer consults
+    /// this to refuse repainting a longhand union with a non-generic alias name
+    /// recovered from the interner's global reverse tables. Callers must not mark
+    /// a union written as an alias body, so that referencing the alias still
+    /// renders its name. Display-only provenance.
+    pub fn mark_longhand_union_annotation(&self, type_id: TypeId) {
+        if type_id.is_intrinsic() {
+            return;
+        }
+        if self
+            .longhand_union_annotations
+            .insert(type_id, ())
+            .is_none()
+        {
+            self.advance_display_provenance_generation();
+        }
+    }
+
+    /// Whether `type_id` is a recorded longhand-written union annotation.
+    pub fn is_longhand_union_annotation(&self, type_id: TypeId) -> bool {
+        self.longhand_union_annotations.contains_key(&type_id)
+    }
+
     /// Record that `member_type_id` was written as an anonymous object-type
     /// literal (`{ ... }`) directly inside the union `union_type_id`, as
     /// opposed to a named alias/interface reference whose body happens to


### PR DESCRIPTION
Fixes the longhand-union display-repaint family from #16610: a union the user
wrote **longhand** was repainted with a non-generic type-alias name recovered
from the interner's global reverse tables — every `string | number | symbol` a
user writes rendered as `PropertyKey`, and every `"a" | "b"` / `string | number`
as an unrelated same-shaped alias declared elsewhere.

## Structural rule

When a union is written **longhand** at an annotation site (a `UnionType` node
that is *not* a type-alias body), `tsc` stamps no `aliasSymbol` on it —
`getUnionType` keys its cache on the member list *plus* the alias identity, so
the aliased and longhand spellings are distinct `Type` objects and neither
repaints the other. tsz interns one `TypeId` for both spellings and recovers a
name from global reverse tables (`body -> alias`, `type -> def`, the
`PropertyKey` shortcut), which cannot tell the two occurrences apart.

The fix records the occurrence: the checker marks a longhand union annotation
(`TypeInterner::mark_longhand_union_annotation`, set in `get_type_from_union_type`
only when the `UnionType` node is not an alias body), and the diagnostic
alias-recovery paths refuse a non-generic alias name for a marked union. A
genuine alias reference (`declare const v: Zed`) reaches display as a
`Lazy(DefId)` and keeps its name through the lazy path — the bare union arriving
at these gates is always the longhand occurrence. This mirrors the object path,
where `mark_literal_object_annotation` already distinguishes a hand-written
`{ p: number }` from a same-shaped alias body.

## Owner layer

- Solver — new display-only occurrence marker `longhand_union_annotations` on
  `TypeInterner` (sibling of `literal_object_annotations` / `union_literal_members`),
  plumbed through `TypeDisplayProvenance`.
- Checker — `get_type_from_union_type` marks the longhand occurrence;
  `union_type_node_is_alias_body` (syntactic parent-walk, unwrapping
  `PARENTHESIZED_TYPE`) excludes alias bodies so referencing an alias keeps its
  name.
- Diagnostic display gateways refuse the repaint for a marked union:
  `lookup_type_alias_name_for_display` (checker), and the solver formatter's
  `unproven_primitive_key_union_alias` / `skip_primitive_key_union_type_alias`
  guards and the `PropertyKey` shortcut in `key.rs`. The pre-existing canonical
  `is_primitive_key_union_data` guard is retained as a second sufficient reason
  (an evaluated `keyof any` produces the shared sentinel with no longhand mark
  and must still not be repainted).

No user-name/file-name literals drive logic; no formatted diagnostic string is
used as a predicate. The only string return is the pre-existing `PropertyKey`
shortcut, now gated by a `TypeId` provenance query.

## Matrix (each row a live parity pin; oracle `typescript@7.0.2`, `--noEmit --strict --lib es2022 --target es2022`)

| source | tsc / tsz (after) |
| --- | --- |
| `declare const v: string \| number \| symbol` (no alias) | `string \| number \| symbol` |
| `type Zed = string\|number\|symbol;` + longhand annotation | `string \| number \| symbol` |
| `type Pair = string\|number;` + longhand (renamed binders) | `string \| number` |
| longhand `string \| number`, alias declared **after** | `string \| number` |
| `declare const v: Zed` (through the alias) | `Zed` |
| `declare const v: PropertyKey` | `PropertyKey` |
| `type T1 = \`…\` \| undefined; f(x: T1 \| null, y: T1 & T2)` | `T1 & T2` / `T1 \| null` (alias reference preserved) |
| object / object-member-union / interface controls | unchanged (already structural) |

Row 5 of #16610 (`keyof any` rendering `keyof any` instead of its resolved
member union) is a **separate** operator-resolution mechanism and remains an
`#[ignore]`d tripwire in the parity file; it is unblocked by this change (the
resolved union now renders structurally rather than `PropertyKey`) but is left
for a follow-up.

Follow-up noted: the four display gateways each recover an alias name by default
and now subtract the longhand case; the deeper fix is a default-deny inversion
(a union earns a name only via genuine `Lazy(DefId)` provenance). That is a large
behavioral refactor, out of scope here.

## Goal
Goal: hold

## Verification

- `cargo test -p tsz-checker --test union_display_alias_repaint_parity_tests` →
  **12 passed, 4 ignored** (the four formerly-`#[ignore]`d longhand-union rows
  from #16612 are now live parity pins; the remaining ignored rows are two
  separate mechanisms — `keyof any` operator resolution and the collapsing-alias
  display added in #16615, still genuinely red under `-- --ignored`).
- `cargo test -p tsz-checker --test union_origin_display_tests
  --test union_source_member_provenance_display_tests` → green (alias-reference
  `T1 & T2` / `T1 | null` display preserved — the occurrence mark distinguishes
  it from a longhand union).
- `cargo test -p tsz-solver --lib` → **7651 passed**; solver `diagnostics::format`
  unit tests updated for the new contract (canonical union collapses to
  `PropertyKey` unless marked longhand).
- Targeted display-sensitive checker suites green (mapped-type errors,
  symbol/index-signature, in-operator key type, homomorphic mapped display,
  keyless record inference, well-known-symbol key parity, ts2322 null/undefined
  target display).
- `cargo clippy -p tsz-solver -p tsz-checker --all-targets` clean;
  `scripts/architecture-check.sh` → 0 LOC violations, 0 cross-layer imports.
- `cargo-nextest` is absent in this container, so the above are `cargo test`
  invocations per the board's standing substitute. Conformance/emit/fourslash
  run on the nightly lane; the TypeScript submodule tree is not checked out in
  this environment.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01WA37NdBefpXW21J26jUnMZ)_