### PR TITLE
fix(checker): TS1286 wires up alongside TS1295 for CJS+verbatimModuleSyntax

### DIFF
--- a/crates/tsz-checker/src/declarations/import/verbatim.rs
+++ b/crates/tsz-checker/src/declarations/import/verbatim.rs
@@ -1,4 +1,4 @@
-//! verbatimModuleSyntax import/export checks (TS1282, TS1283, TS1295, TS1484, TS1485, TS2748).
+//! verbatimModuleSyntax import/export checks (TS1282, TS1283, TS1286, TS1295, TS1484, TS1485, TS2748).
 
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
@@ -132,9 +132,9 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        // TS1295: In CJS+VMS mode, ESM import syntax is forbidden entirely.
-        // Emit TS1295 on the import clause and skip ESM-specific checks.
-        // TSC skips this check for .d.ts files.
+        // TS1286/TS1295: In CJS+VMS mode, ESM import syntax is forbidden entirely.
+        // Emit TS1286 (extension-locked) or TS1295 (adjustable) on the import
+        // clause and skip ESM-specific checks. TSC skips this check for .d.ts files.
         if self.is_current_file_commonjs_for_vms() && !self.ctx.is_declaration_file() {
             // TSC positions the error at the binding NAME:
             // - Default import `import X from ...` → at X
@@ -173,11 +173,18 @@ impl<'a> CheckerState<'a> {
             } else {
                 import.import_clause
             };
-            self.error_at_node(
-                error_node,
-                diagnostic_messages::ECMASCRIPT_IMPORTS_AND_EXPORTS_CANNOT_BE_WRITTEN_IN_A_COMMONJS_FILE_UNDER_VERBAT_2,
-                diagnostic_codes::ECMASCRIPT_IMPORTS_AND_EXPORTS_CANNOT_BE_WRITTEN_IN_A_COMMONJS_FILE_UNDER_VERBAT_2,
-            );
+            let (message, code) = if self.current_file_commonjs_is_extension_locked() {
+                (
+                    diagnostic_messages::ECMASCRIPT_IMPORTS_AND_EXPORTS_CANNOT_BE_WRITTEN_IN_A_COMMONJS_FILE_UNDER_VERBAT,
+                    diagnostic_codes::ECMASCRIPT_IMPORTS_AND_EXPORTS_CANNOT_BE_WRITTEN_IN_A_COMMONJS_FILE_UNDER_VERBAT,
+                )
+            } else {
+                (
+                    diagnostic_messages::ECMASCRIPT_IMPORTS_AND_EXPORTS_CANNOT_BE_WRITTEN_IN_A_COMMONJS_FILE_UNDER_VERBAT_2,
+                    diagnostic_codes::ECMASCRIPT_IMPORTS_AND_EXPORTS_CANNOT_BE_WRITTEN_IN_A_COMMONJS_FILE_UNDER_VERBAT_2,
+                )
+            };
+            self.error_at_node(error_node, message, code);
             return;
         }
 
@@ -628,5 +635,17 @@ impl<'a> CheckerState<'a> {
             return !is_esm;
         }
         !self.ctx.compiler_options.module.is_es_module()
+    }
+
+    /// Whether the current file's CommonJS-ness is locked in by a fixed file
+    /// extension (`.cts`/`.cjs`), as opposed to `module`/`moduleResolution`
+    /// config or a `package.json` `"type"` field. tsc picks between two
+    /// messages for the same "ESM import/export syntax in a CJS file" defect
+    /// on exactly this distinction: TS1286 when the extension already fixes
+    /// the file's module kind (adjusting `package.json` cannot help), TS1295
+    /// when the CJS classification came from config and could be adjusted.
+    pub(crate) fn current_file_commonjs_is_extension_locked(&self) -> bool {
+        let current_file = &self.ctx.file_name;
+        current_file.ends_with(".cts") || current_file.ends_with(".cjs")
     }
 }

--- a/crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs
+++ b/crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs
@@ -5,7 +5,7 @@ use tsz_parser::parser::NodeIndex;
 
 impl<'a> CheckerState<'a> {
     // =========================================================================
-    // verbatimModuleSyntax / isolatedModules Export Checks (TS1205, TS1284, TS1285, TS1448)
+    // verbatimModuleSyntax / isolatedModules Export Checks (TS1205, TS1284, TS1285, TS1286, TS1448)
     // =========================================================================
 
     /// TS1205: Re-exporting a type when 'verbatimModuleSyntax' or 'isolatedModules' is enabled
@@ -336,7 +336,7 @@ impl<'a> CheckerState<'a> {
         !self.ctx.compiler_options.module.is_es_module()
     }
 
-    /// TS1295: ESM exports cannot be written in a CommonJS file under verbatimModuleSyntax.
+    /// TS1286/TS1295: ESM exports cannot be written in a CommonJS file under verbatimModuleSyntax.
     /// TS1287: top-level export on value declarations in CJS.
     /// Returns true if a CJS-specific diagnostic was emitted.
     pub(crate) fn check_verbatim_module_syntax_cjs_export(
@@ -363,11 +363,18 @@ impl<'a> CheckerState<'a> {
                 diagnostic_codes::A_TOP_LEVEL_EXPORT_MODIFIER_CANNOT_BE_USED_ON_VALUE_DECLARATIONS_IN_A_COMMONJS_M,
             );
         } else {
-            self.error_at_node(
-                export_idx,
-                diagnostic_messages::ECMASCRIPT_IMPORTS_AND_EXPORTS_CANNOT_BE_WRITTEN_IN_A_COMMONJS_FILE_UNDER_VERBAT_2,
-                diagnostic_codes::ECMASCRIPT_IMPORTS_AND_EXPORTS_CANNOT_BE_WRITTEN_IN_A_COMMONJS_FILE_UNDER_VERBAT_2,
-            );
+            let (message, code) = if self.current_file_commonjs_is_extension_locked() {
+                (
+                    diagnostic_messages::ECMASCRIPT_IMPORTS_AND_EXPORTS_CANNOT_BE_WRITTEN_IN_A_COMMONJS_FILE_UNDER_VERBAT,
+                    diagnostic_codes::ECMASCRIPT_IMPORTS_AND_EXPORTS_CANNOT_BE_WRITTEN_IN_A_COMMONJS_FILE_UNDER_VERBAT,
+                )
+            } else {
+                (
+                    diagnostic_messages::ECMASCRIPT_IMPORTS_AND_EXPORTS_CANNOT_BE_WRITTEN_IN_A_COMMONJS_FILE_UNDER_VERBAT_2,
+                    diagnostic_codes::ECMASCRIPT_IMPORTS_AND_EXPORTS_CANNOT_BE_WRITTEN_IN_A_COMMONJS_FILE_UNDER_VERBAT_2,
+                )
+            };
+            self.error_at_node(export_idx, message, code);
         }
         true
     }

--- a/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
@@ -689,7 +689,7 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
             return;
         };
 
-        // TS1295: dynamic import() in CJS+VMS
+        // TS1286/TS1295: dynamic import() in CJS+VMS
         if expr_node.kind == syntax_kind_ext::CALL_EXPRESSION {
             let is_import_call = self
                 .ctx
@@ -698,11 +698,18 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
                 .and_then(|call| self.ctx.arena.get(call.expression))
                 .is_some_and(|callee| callee.kind == SyntaxKind::ImportKeyword as u16);
             if is_import_call && self.is_current_file_commonjs_for_vms() {
-                self.error_at_node(
-                    expr_idx,
-                    crate::diagnostics::diagnostic_messages::ECMASCRIPT_IMPORTS_AND_EXPORTS_CANNOT_BE_WRITTEN_IN_A_COMMONJS_FILE_UNDER_VERBAT_2,
-                    crate::diagnostics::diagnostic_codes::ECMASCRIPT_IMPORTS_AND_EXPORTS_CANNOT_BE_WRITTEN_IN_A_COMMONJS_FILE_UNDER_VERBAT_2,
-                );
+                let (message, code) = if self.current_file_commonjs_is_extension_locked() {
+                    (
+                        crate::diagnostics::diagnostic_messages::ECMASCRIPT_IMPORTS_AND_EXPORTS_CANNOT_BE_WRITTEN_IN_A_COMMONJS_FILE_UNDER_VERBAT,
+                        crate::diagnostics::diagnostic_codes::ECMASCRIPT_IMPORTS_AND_EXPORTS_CANNOT_BE_WRITTEN_IN_A_COMMONJS_FILE_UNDER_VERBAT,
+                    )
+                } else {
+                    (
+                        crate::diagnostics::diagnostic_messages::ECMASCRIPT_IMPORTS_AND_EXPORTS_CANNOT_BE_WRITTEN_IN_A_COMMONJS_FILE_UNDER_VERBAT_2,
+                        crate::diagnostics::diagnostic_codes::ECMASCRIPT_IMPORTS_AND_EXPORTS_CANNOT_BE_WRITTEN_IN_A_COMMONJS_FILE_UNDER_VERBAT_2,
+                    )
+                };
+                self.error_at_node(expr_idx, message, code);
             }
         }
 

--- a/crates/tsz-checker/tests/conformance_issues/core/helpers/regression_tests.rs
+++ b/crates/tsz-checker/tests/conformance_issues/core/helpers/regression_tests.rs
@@ -920,6 +920,169 @@ export const enum E {
     );
 }
 
+/// tsc picks between two messages for the same "ESM import/export syntax
+/// written in a CommonJS file under verbatimModuleSyntax" defect, keyed on
+/// whether the file's CommonJS-ness is locked in by a fixed extension
+/// (`.cts`/`.cjs`, where adjusting `package.json` cannot help — TS1286) or
+/// came from `module`/`moduleResolution` config or an adjustable
+/// `package.json` (TS1295, which suggests adjusting it). Oracle:
+/// `typescript@7.0.2`, `--strict --verbatimModuleSyntax --module commonjs`.
+#[test]
+fn test_verbatim_module_syntax_cjs_import_extension_locked_reports_ts1286() {
+    let diagnostics = compile_named_files_get_diagnostics_with_options(
+        &[
+            (
+                "a.cts",
+                "import { y } from \"./mod.cjs\";\nexport const z = y;\n",
+            ),
+            ("mod.cts", "export const y = 1;\n"),
+        ],
+        "a.cts",
+        CheckerOptions {
+            target: ScriptTarget::ES2022,
+            module: ModuleKind::CommonJS,
+            verbatim_module_syntax: true,
+            ..CheckerOptions::default()
+        },
+    );
+
+    assert!(
+        has_error(&diagnostics, 1286),
+        "Expected TS1286 for a `.cts` file, got: {diagnostics:?}"
+    );
+    assert!(
+        !has_error(&diagnostics, 1295),
+        "Expected no TS1295 for a `.cts` file (extension-locked, package.json can't help), got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_verbatim_module_syntax_cjs_import_adjustable_reports_ts1295() {
+    let diagnostics = compile_named_files_get_diagnostics_with_options(
+        &[
+            (
+                "a.ts",
+                "import { y } from \"./mod\";\nexport const z = y;\n",
+            ),
+            ("mod.ts", "export const y = 1;\n"),
+        ],
+        "a.ts",
+        CheckerOptions {
+            target: ScriptTarget::ES2022,
+            module: ModuleKind::CommonJS,
+            verbatim_module_syntax: true,
+            ..CheckerOptions::default()
+        },
+    );
+
+    assert!(
+        has_error(&diagnostics, 1295),
+        "Expected TS1295 for a `.ts` file under `module: commonjs`, got: {diagnostics:?}"
+    );
+    assert!(
+        !has_error(&diagnostics, 1286),
+        "Expected no TS1286 for a `.ts` file (CJS-ness is config-adjustable), got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_verbatim_module_syntax_cjs_export_default_extension_locked_reports_ts1286() {
+    let diagnostics = compile_and_get_raw_diagnostics_named(
+        "a.cts",
+        r#"const x = 1;
+export default x;
+"#,
+        CheckerOptions {
+            target: ScriptTarget::ES2022,
+            module: ModuleKind::CommonJS,
+            verbatim_module_syntax: true,
+            ..CheckerOptions::default()
+        },
+    );
+
+    assert!(
+        diagnostics.iter().any(|d| d.code == 1286),
+        "Expected TS1286 for `export default` in a `.cts` file, got: {diagnostics:?}"
+    );
+    assert!(
+        !diagnostics.iter().any(|d| d.code == 1295),
+        "Expected no TS1295 for `export default` in a `.cts` file, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_verbatim_module_syntax_cjs_export_default_adjustable_reports_ts1295() {
+    let diagnostics = compile_and_get_raw_diagnostics_named(
+        "a.ts",
+        r#"const x = 1;
+export default x;
+"#,
+        CheckerOptions {
+            target: ScriptTarget::ES2022,
+            module: ModuleKind::CommonJS,
+            verbatim_module_syntax: true,
+            ..CheckerOptions::default()
+        },
+    );
+
+    assert!(
+        diagnostics.iter().any(|d| d.code == 1295),
+        "Expected TS1295 for `export default` in a `.ts` file under `module: commonjs`, got: {diagnostics:?}"
+    );
+    assert!(
+        !diagnostics.iter().any(|d| d.code == 1286),
+        "Expected no TS1286 for `export default` in a `.ts` file, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_verbatim_module_syntax_cjs_dynamic_import_extension_locked_reports_ts1286() {
+    let diagnostics = compile_and_get_raw_diagnostics_named(
+        "a.cts",
+        r#"import("./mod.cjs");
+"#,
+        CheckerOptions {
+            target: ScriptTarget::ES2022,
+            module: ModuleKind::CommonJS,
+            verbatim_module_syntax: true,
+            ..CheckerOptions::default()
+        },
+    );
+
+    assert!(
+        diagnostics.iter().any(|d| d.code == 1286),
+        "Expected TS1286 for dynamic `import()` in a `.cts` file, got: {diagnostics:?}"
+    );
+    assert!(
+        !diagnostics.iter().any(|d| d.code == 1295),
+        "Expected no TS1295 for dynamic `import()` in a `.cts` file, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_verbatim_module_syntax_cjs_dynamic_import_adjustable_reports_ts1295() {
+    let diagnostics = compile_and_get_raw_diagnostics_named(
+        "a.ts",
+        r#"import("./mod");
+"#,
+        CheckerOptions {
+            target: ScriptTarget::ES2022,
+            module: ModuleKind::CommonJS,
+            verbatim_module_syntax: true,
+            ..CheckerOptions::default()
+        },
+    );
+
+    assert!(
+        diagnostics.iter().any(|d| d.code == 1295),
+        "Expected TS1295 for dynamic `import()` in a `.ts` file under `module: commonjs`, got: {diagnostics:?}"
+    );
+    assert!(
+        !diagnostics.iter().any(|d| d.code == 1286),
+        "Expected no TS1286 for dynamic `import()` in a `.ts` file, got: {diagnostics:?}"
+    );
+}
+
 #[test]
 fn test_window_console_resolves_through_global_this_alias() {
     let diagnostics = without_missing_global_type_errors(compile_and_get_diagnostics_with_lib(


### PR DESCRIPTION
When ESM import/export syntax appears in a file `tsc` treats as CommonJS under `verbatimModuleSyntax`, `tsc` picks between two messages for the same defect depending on **why** the file is CommonJS:

- **TS1286** (no suggestion) — a fixed file extension (`.cts`/`.cjs`) already locks the module kind, so adjusting `package.json` cannot help.
- **TS1295** (suggests adjusting `package.json`'s `"type"` field or `verbatimModuleSyntax`/`module`/`moduleResolution`) — the CJS classification came from config and could be changed.

tsz only ever emitted TS1295, at the three sites that share this defect: named imports (`check_verbatim_module_syntax_imports`), export declarations (`check_verbatim_module_syntax_cjs_export`), and dynamic `import()` (`check_expression_statement`). TS1286 was a fully dead diagnostic-table entry — part of tech-debt issue #16291's unwired-code enumeration (`crates/tsz-common/src/diagnostics/data/parts/part_000.rs:241`, zero non-table references before this PR).

Structural rule: **when a CJS+verbatimModuleSyntax file's module-kind classification is extension-locked (`.cts`/`.cjs`), tsc emits TS1286; when it comes from `module`/`moduleResolution` config or an adjustable `package.json`, tsc emits TS1295** — same trigger condition, different message, decided at the checker's existing CJS-detection call sites (`crates/tsz-checker/src/declarations/import/verbatim.rs`, `crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs`, `crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs`).

## Fix

Adds `current_file_commonjs_is_extension_locked()` next to the existing `is_current_file_commonjs_for_vms()` / `is_current_file_commonjs()` helpers and threads it through all three call sites to pick the message. No change to **when** the defect fires — only to **which** of the two existing messages is used. TS1287 (top-level `export` modifier on a value declaration) is unaffected: tsc uses one message there regardless of extension-lock, confirmed against the oracle.

## Adjacent-case matrix (oracle `typescript@7.0.2`, `--strict --verbatimModuleSyntax --module commonjs`)

| Shape | File | tsc | tsz before | tsz after |
| --- | --- | --- | --- | --- |
| `import { y } from "./mod.cjs"` | `.cts` | TS1286 | TS1295 (wrong) | **TS1286** |
| `import { y } from "./mod"` | `.ts` | TS1295 | TS1295 | unchanged ✅ |
| `export default x;` | `.cts` | TS1286 | TS1295 (wrong) | **TS1286** |
| `export default x;` | `.ts` | TS1295 | TS1295 | unchanged ✅ |
| `import("./mod.cjs");` | `.cts` | TS1286 | TS1295 (wrong) | **TS1286** |
| `import("./mod");` | `.ts` | TS1295 | TS1295 | unchanged ✅ |
| `export const x = 1;` (value export) | `.cts` or `.ts` | TS1287 | TS1287 | unchanged ✅ (single message, no extension-lock distinction — confirmed via oracle) |
| unresolvable module specifier | either | only TS2307, no TS1286/1295 | same | unchanged ✅ (matches tsc: the ESM-syntax check never fires when the import target does not resolve at all) |

Out of scope, noted but not fixed here (pre-existing, narrower trigger gap unrelated to message selection): the dynamic-`import()` check in `check_expression_statement` only fires for a bare expression-statement `import(...)`, not `const m = await import(...)` — tsc reports the same diagnostic in both shapes. Left as-is since widening the trigger is a separate defect from picking the right message.

## Goal
Goal: hold

## Verification
- 6 new targeted unit tests added (`crates/tsz-checker/tests/conformance_issues/core/helpers/regression_tests.rs`), covering all three call sites × extension-locked/adjustable — all pass: `cargo test -p tsz-checker --test conformance_issues_modules -- verbatim_module_syntax_cjs` → 6 passed, 0 failed.
- Existing `test_verbatim_module_syntax_const_enum_in_esnext_does_not_report_cjs_errors` (ESNext, no VMS-CJS errors expected) still passes — confirms no regression on the non-CJS path.
- `cargo test -p tsz-checker --test conformance_issues_modules` (full target, 267 tests): 264 passed, 3 pre-existing failures unrelated to this change (`test_commonjs_chained_prototype_assignment_preserves_imported_constructor_methods`, `test_commonjs_exported_js_constructor_index_errors_use_function_name`, `test_commonjs_exported_js_constructor_with_prototype_writes_is_constructable` — verified these fail identically on unmodified `main` at `1a5d06d`, gated on `verbatim_module_syntax` being false so unreachable by this diff).
- Pre-commit hook (clippy `-D warnings` + arch-size guard + affected-crate test run) passed clean at commit `6624b8f`.
- This is a message-selection change on an already-dead-then-newly-wired diagnostic code (TS1286 had zero prior emit sites), not a change to any existing passing diagnostic's trigger condition — no corpus regression expected. Conformance/emit gates not separately re-run given the source diff is confined to `crates/tsz-checker/src/declarations/**` and `state_checking_members/statement_callback_bridge.rs` CJS-detection branches with no change to trigger conditions, only message/code selection on a code that never fired before.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hzsbh4rQF2PWcfqHdqkiHf)_