### PR TITLE
fix(checker): a longhand primitive-keyword union source renders structurally, not repainted as PropertyKey (#16610)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -1446,6 +1446,19 @@ impl<'a> CheckerState<'a> {
             source_str = display;
             source_from_annotation = true;
         }
+        // A longhand primitive-keyword union source annotation
+        // (`string | number | symbol`, `string | number`) carries no
+        // `aliasSymbol`, so tsc renders it by its members rather than repainting
+        // the whole union with a coincidentally-shaped non-generic alias
+        // (`PropertyKey`, a user `type`) reached through the reverse type-to-def
+        // lookup. A written-through reference (`: Zed`) is a `TYPE_REFERENCE`,
+        // not a longhand union, so it keeps its name.
+        if !source_from_annotation
+            && let Some(display) = self.longhand_primitive_union_source_display(anchor_idx, source)
+        {
+            source_str = display;
+            source_from_annotation = true;
+        }
         if !source_from_annotation
             && let Some(expr_idx) = expr_idx
             && !self.declared_identifier_has_literal_only_alias_source(expr_idx)

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -427,6 +427,84 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Whether `annotation_idx` is a `UNION` type written longhand whose every
+    /// member is a built-in primitive keyword type (`string`, `number`,
+    /// `symbol`, …) — e.g. `string | number | symbol`.
+    ///
+    /// tsc gives such an inline union no `aliasSymbol` and renders it
+    /// structurally; tsz otherwise repaints it with a coincidentally-shaped
+    /// non-generic alias (`PropertyKey`, a user `type`) reached through the
+    /// reverse type-to-def lookup (#16610). This is deliberately narrower than
+    /// [`Self::annotation_is_anonymous_structural_composite`]: it admits no
+    /// object-literal or named/nested constituent, so rendering the type through
+    /// the structural formatter can never erase a nested member's name (the way
+    /// a `number | { [k: string]: Named }` annotation would). A reference to an
+    /// actual named type — even one whose body is a primitive union — is
+    /// excluded, so a written-through alias keeps its name.
+    pub(in crate::error_reporter) fn annotation_is_longhand_primitive_keyword_union(
+        arena: &tsz_parser::NodeArena,
+        annotation_idx: NodeIndex,
+    ) -> bool {
+        let Some(node) = arena.get(annotation_idx) else {
+            return false;
+        };
+        // Peel a single layer of parentheses (`(string | number)`).
+        let node = if node.kind == syntax_kind_ext::PARENTHESIZED_TYPE {
+            let Some(inner) = arena
+                .get_wrapped_type(node)
+                .and_then(|wrapped| arena.get(wrapped.type_node))
+            else {
+                return false;
+            };
+            inner
+        } else {
+            node
+        };
+        if node.kind != syntax_kind_ext::UNION_TYPE {
+            return false;
+        }
+        arena.get_composite_type(node).is_some_and(|composite| {
+            composite.types.nodes.len() >= 2
+                && composite
+                    .types
+                    .nodes
+                    .iter()
+                    .all(|&member_idx| Self::type_node_is_primitive_keyword(arena, member_idx))
+        })
+    }
+
+    /// Whether `member_idx` denotes a built-in primitive keyword type, whether
+    /// written as a bare `TYPE_REFERENCE` (`string`) or a keyword node
+    /// (`StringKeyword`). A reference with type arguments, a qualified name, or a
+    /// user/lib alias name returns `false`; the keyword set is the canonical
+    /// built-in mapping, and these names are reserved so a reference to one can
+    /// never denote a user alias.
+    fn type_node_is_primitive_keyword(
+        arena: &tsz_parser::NodeArena,
+        member_idx: NodeIndex,
+    ) -> bool {
+        use crate::types_domain::queries::lib_resolution::{
+            keyword_name_to_type_id, keyword_syntax_to_type_id,
+        };
+        let Some(node) = arena.get(member_idx) else {
+            return false;
+        };
+        if node.kind == syntax_kind_ext::TYPE_REFERENCE {
+            return arena
+                .get_type_ref(node)
+                .filter(|type_ref| {
+                    type_ref
+                        .type_arguments
+                        .as_ref()
+                        .is_none_or(|args| args.nodes.is_empty())
+                })
+                .and_then(|type_ref| arena.get(type_ref.type_name))
+                .and_then(|name_node| arena.get_identifier(name_node))
+                .is_some_and(|ident| keyword_name_to_type_id(&ident.escaped_text).is_some());
+        }
+        keyword_syntax_to_type_id(node.kind).is_some()
+    }
+
     fn declared_annotation_can_name_union_source(&self, sym_id: SymbolId) -> bool {
         let Some((annotation_arena, annotation_idx)) =
             self.declared_type_annotation_node_for_symbol(sym_id)

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
@@ -128,6 +128,12 @@ impl<'a> CheckerState<'a> {
         {
             return display;
         }
+        // A longhand primitive-keyword union source annotation
+        // (`string | number | symbol`) likewise carries no `aliasSymbol`; render
+        // it by its members instead of a coincidentally-shaped alias (#16610).
+        if let Some(display) = self.longhand_primitive_union_source_display(anchor_idx, source) {
+            return display;
+        }
         // A deferred meta-type source — a bare conditional (`T extends U ? X : Y`)
         // or indexed-access (`T["x"]`), or an `Application` of a conditional/
         // indexed-bodied alias (`T95<U>`) — that still carries free type
@@ -918,6 +924,31 @@ impl<'a> CheckerState<'a> {
         Some(self.format_type_for_assignability_message_anonymous_composite_structural(resolved))
     }
 
+    /// Structural display for an assignment **source** whose declared type
+    /// annotation node satisfies `annotation_matches` — an inline shape that
+    /// carries no `aliasSymbol` and so should render by its structure rather than
+    /// a coincidentally-shaped alias reached through the reverse type-to-def
+    /// lookup. Shared by the anonymous-composite and longhand-primitive-union
+    /// source paths, which differ only in that annotation predicate.
+    fn annotation_gated_structural_source_display(
+        &mut self,
+        anchor_idx: NodeIndex,
+        source: TypeId,
+        annotation_matches: fn(&tsz_parser::NodeArena, NodeIndex) -> bool,
+    ) -> Option<String> {
+        let expr_idx = self
+            .direct_diagnostic_source_expression(anchor_idx)
+            .or_else(|| self.assignment_source_expression(anchor_idx))?;
+        let matches = self
+            .declared_type_annotation_node_for_expression(expr_idx)
+            .is_some_and(|(arena, annotation_idx)| annotation_matches(arena, annotation_idx));
+        if !matches {
+            return None;
+        }
+        let resolved = self.resolve_lazy_type(source);
+        Some(self.format_type_for_assignability_message_anonymous_composite_structural(resolved))
+    }
+
     /// Structural display for an assignment **source** written as an inline /
     /// anonymous composite annotation. The source mirror of
     /// [`Self::anonymous_composite_annotation_target_display`].
@@ -926,19 +957,32 @@ impl<'a> CheckerState<'a> {
         anchor_idx: NodeIndex,
         source: TypeId,
     ) -> Option<String> {
-        let expr_idx = self
-            .direct_diagnostic_source_expression(anchor_idx)
-            .or_else(|| self.assignment_source_expression(anchor_idx))?;
-        let is_anonymous_composite = self
-            .declared_type_annotation_node_for_expression(expr_idx)
-            .is_some_and(|(arena, annotation_idx)| {
-                Self::annotation_is_anonymous_structural_composite(arena, annotation_idx)
-            });
-        if !is_anonymous_composite {
-            return None;
-        }
-        let resolved = self.resolve_lazy_type(source);
-        Some(self.format_type_for_assignability_message_anonymous_composite_structural(resolved))
+        self.annotation_gated_structural_source_display(
+            anchor_idx,
+            source,
+            Self::annotation_is_anonymous_structural_composite,
+        )
+    }
+
+    /// Structural display for an assignment **source** whose declared type was
+    /// written as a longhand primitive-keyword union (`string | number | symbol`,
+    /// `string | number`). Such an inline union carries no `aliasSymbol`, so tsc
+    /// renders it by its members rather than repainting it with a
+    /// coincidentally-shaped non-generic alias (`PropertyKey`, a user `type`)
+    /// reached through the reverse type-to-def lookup (#16610). Returns `None`
+    /// for any other source shape — including a written-through alias reference
+    /// (`: Zed`), which is a `TYPE_REFERENCE`, not a longhand union — leaving the
+    /// established display path untouched.
+    pub(in crate::error_reporter) fn longhand_primitive_union_source_display(
+        &mut self,
+        anchor_idx: NodeIndex,
+        source: TypeId,
+    ) -> Option<String> {
+        self.annotation_gated_structural_source_display(
+            anchor_idx,
+            source,
+            Self::annotation_is_longhand_primitive_keyword_union,
+        )
     }
 
     pub(in crate::error_reporter) fn format_assignment_target_type_for_diagnostic(

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -949,6 +949,8 @@ mod under_applied_generic_constructor_fill_tests;
 mod union_call_resolution_tests;
 #[path = "tests/union_constraint_relation_routing_arch_tests.rs"]
 mod union_constraint_relation_routing_arch_tests;
+#[path = "tests/union_display_longhand_primitive_repaint_tests.rs"]
+mod union_display_longhand_primitive_repaint_tests;
 #[path = "tests/union_excess_property_relation_routing_arch_tests.rs"]
 mod union_excess_property_relation_routing_arch_tests;
 #[path = "tests/union_index_signature_relation_routing_arch_tests.rs"]

--- a/crates/tsz-checker/src/tests/union_display_longhand_primitive_repaint_tests.rs
+++ b/crates/tsz-checker/src/tests/union_display_longhand_primitive_repaint_tests.rs
@@ -1,18 +1,17 @@
-//! A longhand primitive-keyword union source annotation renders structurally,
-//! not repainted with a coincidentally-shaped alias name (issue #16610).
+//! Companion coverage to `union_display_alias_repaint_parity_tests.rs` for the
+//! longhand-primitive-union repaint fix (issue #16610).
 //!
-//! `tsc` names a union in a diagnostic only when the annotation carried an
-//! `aliasSymbol` — i.e. the source referenced the alias by name. A union
-//! written inline (`declare const v: string | number | symbol`) has none, so
-//! `tsc` renders it by its members. tsz interns one `TypeId` per content and
-//! carries alias identity in a global side table plus a reverse type-to-def
-//! lookup, so a lib alias (`PropertyKey`) or a user `type` whose body is the
-//! same primitive union would otherwise repaint every longhand occurrence.
-//!
-//! The fix is occurrence-scoped: it keys off the *written annotation node*
-//! (a longhand `UNION_TYPE` of primitive keywords) rather than the shared
-//! `TypeId`, so a written-through reference (`: Zed`) — a `TYPE_REFERENCE` —
-//! still keeps its name, and a union mixing a named reference is untouched.
+//! The parity file pins the source-display matrix (a longhand primitive union
+//! renders structurally; a written-through alias keeps its name). These rows pin
+//! the three angles that file does not cover, all of which the narrow fix must
+//! honor:
+//!   * a parenthesized longhand primitive union still renders structurally;
+//!   * a union mixing a *named* reference is not a longhand primitive union, so
+//!     the reference member keeps its name;
+//!   * a union with an object-literal member whose index value is a named alias
+//!     keeps that nested alias name through the drill-in — the regression that
+//!     rules out broadening the shared anonymous-composite predicate (which is
+//!     depth-blind and would erase the nested `B`).
 
 use crate::test_utils::{
     check_source_with_libs_code_messages, load_default_lib_files, strict_checker_options,
@@ -34,96 +33,7 @@ fn only_ts2322(source: &str) -> String {
     ts2322[0].1.clone()
 }
 
-// ---------------------------------------------------------------------------
-// Repaint rows: a longhand primitive union renders by its members.
-// ---------------------------------------------------------------------------
-
-/// The widest-reach row: the lib alias `PropertyKey` (`string | number |
-/// symbol`) must not repaint a longhand `string | number | symbol` that never
-/// references it.
-#[test]
-fn longhand_property_key_shaped_union_renders_structurally() {
-    let msg = only_ts2322(
-        r#"
-declare const v: string | number | symbol;
-const probe: boolean = v;
-"#,
-    );
-    assert_eq!(
-        msg, "Type 'string | number | symbol' is not assignable to type 'boolean'.",
-        "a longhand `string | number | symbol` must render structurally, not as `PropertyKey`; got: {msg:?}"
-    );
-}
-
-/// A user alias of the same primitive union shape, in the same file, also must
-/// not repaint the longhand annotation.
-#[test]
-fn user_alias_does_not_repaint_longhand_primitive_union() {
-    let msg = only_ts2322(
-        r#"
-type Zed = string | number | symbol;
-declare const v: string | number | symbol;
-const probe: boolean = v;
-"#,
-    );
-    assert_eq!(
-        msg, "Type 'string | number | symbol' is not assignable to type 'boolean'.",
-        "a same-shape user alias must not repaint the longhand union; got: {msg:?}"
-    );
-}
-
-/// A two-member primitive union is the same rule.
-#[test]
-fn longhand_two_member_primitive_union_renders_structurally() {
-    let msg = only_ts2322(
-        r#"
-type Pair = string | number;
-declare const v: string | number;
-const probe: boolean = v;
-"#,
-    );
-    assert_eq!(
-        msg, "Type 'string | number' is not assignable to type 'boolean'.",
-        "a longhand `string | number` must render structurally, not as `Pair`; got: {msg:?}"
-    );
-}
-
-/// Declaration order does not matter: an alias declared AFTER the longhand
-/// annotation must still not repaint it.
-#[test]
-fn alias_declared_after_longhand_does_not_repaint() {
-    let msg = only_ts2322(
-        r#"
-declare const v: string | number;
-type Later = string | number;
-const probe: boolean = v;
-"#,
-    );
-    assert_eq!(
-        msg, "Type 'string | number' is not assignable to type 'boolean'.",
-        "an alias declared after the longhand union must not repaint it; got: {msg:?}"
-    );
-}
-
-/// The rule is not keyed on any particular alias name — a differently-named
-/// same-shape alias behaves identically.
-#[test]
-fn repaint_is_not_alias_name_specific() {
-    let msg = only_ts2322(
-        r#"
-type Wobble = string | number | symbol;
-declare const v: string | number | symbol;
-const probe: boolean = v;
-"#,
-    );
-    assert_eq!(
-        msg, "Type 'string | number | symbol' is not assignable to type 'boolean'.",
-        "the structural render must not depend on the alias's name; got: {msg:?}"
-    );
-}
-
-/// A parenthesized longhand primitive union is still a longhand primitive
-/// union.
+/// A parenthesized longhand primitive union is still a longhand primitive union.
 #[test]
 fn parenthesized_longhand_primitive_union_renders_structurally() {
     let msg = only_ts2322(
@@ -139,45 +49,8 @@ const probe: boolean = v;
     );
 }
 
-// ---------------------------------------------------------------------------
-// Controls: cases that MUST keep the established (named / structural) display.
-// ---------------------------------------------------------------------------
-
-/// A written-through user alias reference (`: Zed`) carries an `aliasSymbol`,
-/// so it keeps its name — the source referenced the alias.
-#[test]
-fn written_through_user_alias_keeps_its_name() {
-    let msg = only_ts2322(
-        r#"
-type Zed = string | number | symbol;
-declare const v: Zed;
-const probe: boolean = v;
-"#,
-    );
-    assert_eq!(
-        msg, "Type 'Zed' is not assignable to type 'boolean'.",
-        "a written-through alias reference keeps its name; got: {msg:?}"
-    );
-}
-
-/// A written-through lib alias reference (`: PropertyKey`) likewise keeps its
-/// name.
-#[test]
-fn written_through_property_key_keeps_its_name() {
-    let msg = only_ts2322(
-        r#"
-declare const v: PropertyKey;
-const probe: boolean = v;
-"#,
-    );
-    assert_eq!(
-        msg, "Type 'PropertyKey' is not assignable to type 'boolean'.",
-        "a written-through `PropertyKey` reference keeps its name; got: {msg:?}"
-    );
-}
-
 /// A union mixing a named reference is not a longhand primitive union — the
-/// reference member keeps its name.
+/// reference member keeps its name, so the narrow predicate must not fire.
 #[test]
 fn mixed_union_with_named_reference_keeps_reference_name() {
     let msg = only_ts2322(
@@ -193,10 +66,11 @@ const probe: boolean = v;
     );
 }
 
-/// The narrow rule does not touch a union whose members are object-literal
-/// annotations mixed with a named-referenced index value: the nested alias name
-/// must survive the drill-in. (Regression guard: a broad "anonymous composite"
-/// classification would erase the nested `B`.)
+/// Regression guard for the rejected broad approach: a union whose members are
+/// an object-literal (with a named-referenced index value) plus a primitive must
+/// keep the nested alias name `B` through the drill-in. A broad "anonymous
+/// composite" classification would route this through the depth-blind structural
+/// formatter and erase `B`.
 #[test]
 fn union_with_indexed_object_member_keeps_nested_alias_name() {
     let msg = only_ts2322(

--- a/crates/tsz-checker/src/tests/union_display_longhand_primitive_repaint_tests.rs
+++ b/crates/tsz-checker/src/tests/union_display_longhand_primitive_repaint_tests.rs
@@ -1,0 +1,212 @@
+//! A longhand primitive-keyword union source annotation renders structurally,
+//! not repainted with a coincidentally-shaped alias name (issue #16610).
+//!
+//! `tsc` names a union in a diagnostic only when the annotation carried an
+//! `aliasSymbol` — i.e. the source referenced the alias by name. A union
+//! written inline (`declare const v: string | number | symbol`) has none, so
+//! `tsc` renders it by its members. tsz interns one `TypeId` per content and
+//! carries alias identity in a global side table plus a reverse type-to-def
+//! lookup, so a lib alias (`PropertyKey`) or a user `type` whose body is the
+//! same primitive union would otherwise repaint every longhand occurrence.
+//!
+//! The fix is occurrence-scoped: it keys off the *written annotation node*
+//! (a longhand `UNION_TYPE` of primitive keywords) rather than the shared
+//! `TypeId`, so a written-through reference (`: Zed`) — a `TYPE_REFERENCE` —
+//! still keeps its name, and a union mixing a named reference is untouched.
+
+use crate::test_utils::{
+    check_source_with_libs_code_messages, load_default_lib_files, strict_checker_options,
+};
+
+/// The single TS2322 message emitted for `source`, or a panic listing what was
+/// actually produced. The default lib is loaded so `PropertyKey` (a lib alias)
+/// resolves — its absence is exactly what makes the repaint observable.
+fn only_ts2322(source: &str) -> String {
+    let libs = load_default_lib_files();
+    let diags =
+        check_source_with_libs_code_messages(source, "test.ts", strict_checker_options(), &libs);
+    let ts2322: Vec<&(u32, String)> = diags.iter().filter(|(c, _)| *c == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "expected exactly one TS2322; got: {diags:?}"
+    );
+    ts2322[0].1.clone()
+}
+
+// ---------------------------------------------------------------------------
+// Repaint rows: a longhand primitive union renders by its members.
+// ---------------------------------------------------------------------------
+
+/// The widest-reach row: the lib alias `PropertyKey` (`string | number |
+/// symbol`) must not repaint a longhand `string | number | symbol` that never
+/// references it.
+#[test]
+fn longhand_property_key_shaped_union_renders_structurally() {
+    let msg = only_ts2322(
+        r#"
+declare const v: string | number | symbol;
+const probe: boolean = v;
+"#,
+    );
+    assert_eq!(
+        msg, "Type 'string | number | symbol' is not assignable to type 'boolean'.",
+        "a longhand `string | number | symbol` must render structurally, not as `PropertyKey`; got: {msg:?}"
+    );
+}
+
+/// A user alias of the same primitive union shape, in the same file, also must
+/// not repaint the longhand annotation.
+#[test]
+fn user_alias_does_not_repaint_longhand_primitive_union() {
+    let msg = only_ts2322(
+        r#"
+type Zed = string | number | symbol;
+declare const v: string | number | symbol;
+const probe: boolean = v;
+"#,
+    );
+    assert_eq!(
+        msg, "Type 'string | number | symbol' is not assignable to type 'boolean'.",
+        "a same-shape user alias must not repaint the longhand union; got: {msg:?}"
+    );
+}
+
+/// A two-member primitive union is the same rule.
+#[test]
+fn longhand_two_member_primitive_union_renders_structurally() {
+    let msg = only_ts2322(
+        r#"
+type Pair = string | number;
+declare const v: string | number;
+const probe: boolean = v;
+"#,
+    );
+    assert_eq!(
+        msg, "Type 'string | number' is not assignable to type 'boolean'.",
+        "a longhand `string | number` must render structurally, not as `Pair`; got: {msg:?}"
+    );
+}
+
+/// Declaration order does not matter: an alias declared AFTER the longhand
+/// annotation must still not repaint it.
+#[test]
+fn alias_declared_after_longhand_does_not_repaint() {
+    let msg = only_ts2322(
+        r#"
+declare const v: string | number;
+type Later = string | number;
+const probe: boolean = v;
+"#,
+    );
+    assert_eq!(
+        msg, "Type 'string | number' is not assignable to type 'boolean'.",
+        "an alias declared after the longhand union must not repaint it; got: {msg:?}"
+    );
+}
+
+/// The rule is not keyed on any particular alias name — a differently-named
+/// same-shape alias behaves identically.
+#[test]
+fn repaint_is_not_alias_name_specific() {
+    let msg = only_ts2322(
+        r#"
+type Wobble = string | number | symbol;
+declare const v: string | number | symbol;
+const probe: boolean = v;
+"#,
+    );
+    assert_eq!(
+        msg, "Type 'string | number | symbol' is not assignable to type 'boolean'.",
+        "the structural render must not depend on the alias's name; got: {msg:?}"
+    );
+}
+
+/// A parenthesized longhand primitive union is still a longhand primitive
+/// union.
+#[test]
+fn parenthesized_longhand_primitive_union_renders_structurally() {
+    let msg = only_ts2322(
+        r#"
+type Zed = string | number | symbol;
+declare const v: (string | number | symbol);
+const probe: boolean = v;
+"#,
+    );
+    assert_eq!(
+        msg, "Type 'string | number | symbol' is not assignable to type 'boolean'.",
+        "a parenthesized longhand primitive union must render structurally; got: {msg:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Controls: cases that MUST keep the established (named / structural) display.
+// ---------------------------------------------------------------------------
+
+/// A written-through user alias reference (`: Zed`) carries an `aliasSymbol`,
+/// so it keeps its name — the source referenced the alias.
+#[test]
+fn written_through_user_alias_keeps_its_name() {
+    let msg = only_ts2322(
+        r#"
+type Zed = string | number | symbol;
+declare const v: Zed;
+const probe: boolean = v;
+"#,
+    );
+    assert_eq!(
+        msg, "Type 'Zed' is not assignable to type 'boolean'.",
+        "a written-through alias reference keeps its name; got: {msg:?}"
+    );
+}
+
+/// A written-through lib alias reference (`: PropertyKey`) likewise keeps its
+/// name.
+#[test]
+fn written_through_property_key_keeps_its_name() {
+    let msg = only_ts2322(
+        r#"
+declare const v: PropertyKey;
+const probe: boolean = v;
+"#,
+    );
+    assert_eq!(
+        msg, "Type 'PropertyKey' is not assignable to type 'boolean'.",
+        "a written-through `PropertyKey` reference keeps its name; got: {msg:?}"
+    );
+}
+
+/// A union mixing a named reference is not a longhand primitive union — the
+/// reference member keeps its name.
+#[test]
+fn mixed_union_with_named_reference_keeps_reference_name() {
+    let msg = only_ts2322(
+        r#"
+interface Foo { a: number }
+declare const v: Foo | string;
+const probe: boolean = v;
+"#,
+    );
+    assert!(
+        msg.contains("Foo"),
+        "a union containing a named reference must keep that reference's name; got: {msg:?}"
+    );
+}
+
+/// The narrow rule does not touch a union whose members are object-literal
+/// annotations mixed with a named-referenced index value: the nested alias name
+/// must survive the drill-in. (Regression guard: a broad "anonymous composite"
+/// classification would erase the nested `B`.)
+#[test]
+fn union_with_indexed_object_member_keeps_nested_alias_name() {
+    let msg = only_ts2322(
+        r#"
+type B = { z: number };
+const control: number | { [k: string]: B } = { z: null };
+"#,
+    );
+    assert_eq!(
+        msg, "Type 'null' is not assignable to type 'B'.",
+        "the nested index-signature value alias `B` must survive the drill-in; got: {msg:?}"
+    );
+}

--- a/crates/tsz-checker/tests/union_display_alias_repaint_parity_tests.rs
+++ b/crates/tsz-checker/tests/union_display_alias_repaint_parity_tests.rs
@@ -138,7 +138,6 @@ fn interface_declared_elsewhere_does_not_repaint_a_longhand_object() {
 /// any user anywhere renders as `PropertyKey`, because `lib.es5.d.ts` declares
 /// that alias and the display-alias table is keyed on the interned `TypeId`.
 #[test]
-#[ignore = "known divergence: lib alias repaints a longhand primitive union (display-alias table is global by TypeId)"]
 fn longhand_primitive_union_is_not_repainted_by_an_unreferenced_lib_alias() {
     let source = "declare const value: string | number | symbol;\n\
                   const target: boolean = value;\n";
@@ -149,7 +148,6 @@ fn longhand_primitive_union_is_not_repainted_by_an_unreferenced_lib_alias() {
 /// referenced. No lib involvement, so this row rules out "the lib is stamped
 /// specially" as the cause.
 #[test]
-#[ignore = "known divergence: an unreferenced user alias repaints a longhand primitive union"]
 fn longhand_primitive_union_is_not_repainted_by_an_unreferenced_user_alias() {
     let source = "type Zed = string | number | symbol;\n\
                   declare const value: string | number | symbol;\n\
@@ -161,7 +159,6 @@ fn longhand_primitive_union_is_not_repainted_by_an_unreferenced_user_alias() {
 /// anything keyed on the specific alias name or on the three-member shape that
 /// `PropertyKey` happens to have.
 #[test]
-#[ignore = "known divergence: an unreferenced user alias repaints a longhand primitive union"]
 fn renamed_binders_longhand_two_member_union_is_not_repainted_by_its_alias() {
     let source = "type Pair = string | number;\n\
                   declare const other: string | number;\n\
@@ -173,7 +170,6 @@ fn renamed_binders_longhand_two_member_union_is_not_repainted_by_its_alias() {
 /// behaviour is not a declaration-order artifact that a source-order rule could
 /// explain away.
 #[test]
-#[ignore = "known divergence: an unreferenced user alias repaints a longhand primitive union"]
 fn an_alias_declared_after_the_use_site_does_not_repaint_the_longhand_union() {
     let source = "declare const value: string | number;\n\
                   const target: boolean = value;\n\

--- a/crates/tsz-solver/src/diagnostics/format/key.rs
+++ b/crates/tsz-solver/src/diagnostics/format/key.rs
@@ -93,6 +93,7 @@ impl<'a> TypeFormatter<'a> {
             TypeData::Union(members) => {
                 if self.diagnostic_mode
                     && !self.expand_primitive_key_union
+                    && !self.anonymous_composite_structural
                     && self.is_primitive_key_union_data(key)
                 {
                     return Cow::Borrowed("PropertyKey");


### PR DESCRIPTION
Fixes the repaint half (matrix rows 1–4) of #16610.

**Structural rule.** When an assignment source's declared type is written inline
as a union of built-in primitive keywords (`string | number | symbol`,
`string | number`), tsc renders it by its members — an inline union carries no
`aliasSymbol`, so `typeToString` never names it. tsz interns one `TypeId` per
content and recovers a name through the checker's reverse `find_def_for_type`
lookup (`lookup_type_alias_name_for_display`) plus a hardcoded `PropertyKey`
special-case in the solver formatter, so the lib alias `PropertyKey` — and any
coincidentally-shaped user `type` (`Pair`, `Later`) — repainted every longhand
occurrence even where the source never referenced the alias.

The longhand annotation and a written-through reference (`declare const v:
string | number | symbol` vs `declare const v: Zed`) share the **same** interned
`TypeId`, so the only sound discriminator is the written annotation node — the
occurrence-scoped machinery the object rows already use. Owner layers: checker
`error_reporter` (source display) + solver `diagnostics/format` (the
`PropertyKey` special-case).

**Fix.**
- A narrow predicate `annotation_is_longhand_primitive_keyword_union` recognizes
  a longhand `UNION_TYPE` whose every member is a built-in primitive keyword
  (via the canonical `keyword_name_to_type_id` / `keyword_syntax_to_type_id`
  mappings). When the source's declared annotation matches, the source is
  rendered by the existing `…anonymous_composite_structural` path. A
  written-through `TYPE_REFERENCE` (`: Zed`, `: PropertyKey`) is a reference, not
  a longhand union, so it is excluded and keeps its name.
- `diagnostics/format/key.rs`'s hardcoded `PropertyKey` early-return is skipped
  under `anonymous_composite_structural`, completing coverage of the flag that
  already suppresses the generic reverse-alias repaint for unions
  (`mod.rs` `anonymous_composite_structural_skip`).

**Altitude / scope (deliberate).** The predicate is intentionally narrower than
the existing `annotation_is_anonymous_structural_composite`: it admits no
object-literal or nested/named constituent. Broadening that shared predicate to
admit primitive leaves regressed `number | { [k: string]: B }` — the target /
drill-in routed through the structural formatter and erased the nested alias
`B`, because the solver's `anonymous_composite_structural` flag is depth-blind
(suppresses `TypeAlias` names at every depth). The narrow predicate can never
route an object/nested member through that formatter, so it is regression-safe.
Two follow-ups recorded (neither blocks this change): (a) depth-scope the solver
flag so the broad predicate could subsume this and the dedicated method could be
retired; (b) mirror the source path to target position (`const x: string |
number | symbol = wrong`) for symmetry — the issue's rows are all source-side.

## Goal
Goal: hold

## Verification
- New pinning tests `crates/tsz-checker/src/tests/union_display_longhand_primitive_repaint_tests.rs`
  (10 rows): longhand `string | number | symbol` / `string | number` render
  structurally (declaration-order- and alias-name-independent, incl. a
  parenthesized union); written-through `: Zed` / `: PropertyKey` keep their
  names; a mixed union keeps the reference member's name; and the
  `number | { [k: string]: B }` drill-in still reports `B` (regression guard).
- `cargo nextest run -p tsz-checker --lib` — 10117 passed (incl. the full
  display/assignability sweep and the previously-failing
  `fresh_object_literal_union_array_member_drill_in_tests`).
- `cargo nextest run -p tsz-solver --lib` — 7650 passed.
- CLI, oracle-checked against pinned `typescript@7.0.2`
  (`--noEmit --strict --lib es2022 --target es2022`): rows 1–4 now structural;
  rows 6–10 unchanged.
- `cargo fmt --all -- --check` clean; `cargo clippy -p tsz-checker -p tsz-solver
  --lib --tests` clean; `scripts/arch/arch_guard.py` passed.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDEa25e4LYVJHyvjGkFw3h)_