### PR TITLE
fix(solver): QueryCache forwards compiler-option setters to its wrapped TypeInterner

### DIFF
--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -1864,14 +1864,17 @@ impl QueryDatabase for QueryCache<'_> {
 
     fn set_no_unchecked_indexed_access(&self, enabled: bool) {
         self.no_unchecked_indexed_access.set(enabled);
+        self.interner.set_no_unchecked_indexed_access(enabled);
     }
 
     fn set_exact_optional_property_types(&self, enabled: bool) {
         self.exact_optional_property_types.set(enabled);
+        self.interner.set_exact_optional_property_types(enabled);
     }
 
     fn set_strict_null_checks(&self, enabled: bool) {
         self.strict_null_checks.set(enabled);
+        self.interner.set_strict_null_checks(enabled);
     }
 
     fn get_type_param_variance(&self, def_id: DefId) -> Option<Arc<[Variance]>> {

--- a/crates/tsz-solver/tests/db_tests.rs
+++ b/crates/tsz-solver/tests/db_tests.rs
@@ -690,6 +690,55 @@ fn type_interner_element_access_respects_no_unchecked_indexed_access() {
 }
 
 #[test]
+fn query_cache_set_strict_null_checks_propagates_to_wrapped_interner() {
+    let interner = TypeInterner::new();
+    let db: &dyn QueryDatabase = &QueryCache::new(&interner);
+
+    // `CheckerContext::from_parts` only holds `&dyn QueryDatabase` (a
+    // `QueryCache` in production) and calls `set_strict_null_checks` on it.
+    // `QueryCache` used to update only its own local `Cell`, leaving the
+    // wrapped `TypeInterner`'s `AtomicBool` at its `true` default -- and
+    // union construction (`normalize_union`) reads that field directly via
+    // `TypeInterner`'s own inherent methods, never through `QueryDatabase`.
+    assert!(
+        interner.strict_null_checks(),
+        "interner starts strict by default"
+    );
+    db.set_strict_null_checks(false);
+    assert!(
+        !interner.strict_null_checks(),
+        "QueryCache::set_strict_null_checks must propagate to the wrapped TypeInterner"
+    );
+
+    // End-to-end: the same union construction the checker's non-strict
+    // member-dropping rule (`addTypeToUnion` never adds a nullish constituent
+    // when a non-nullish sibling is present) depends on must observe the
+    // propagated flag, not just `QueryCache`'s own local copy.
+    let reduced = db.union(vec![TypeId::STRING, TypeId::NULL, TypeId::UNDEFINED]);
+    assert_eq!(
+        reduced,
+        TypeId::STRING,
+        "non-strict union construction must drop nullish members once the flag is set"
+    );
+}
+
+#[test]
+fn query_cache_set_exact_optional_property_types_propagates_to_wrapped_interner() {
+    let interner = TypeInterner::new();
+    let db: &dyn QueryDatabase = &QueryCache::new(&interner);
+
+    // Same desync family as `strict_null_checks` above: tuple-element
+    // normalization (`normalize_optional_tuple_elements`) reads
+    // `exact_optional_property_types` on `TypeInterner` directly.
+    assert!(!interner.exact_optional_property_types());
+    db.set_exact_optional_property_types(true);
+    assert!(
+        interner.exact_optional_property_types(),
+        "QueryCache::set_exact_optional_property_types must propagate to the wrapped TypeInterner"
+    );
+}
+
+#[test]
 fn query_cache_statistics_reflects_cache_population() {
     let interner = TypeInterner::new();
     let cache = QueryCache::new(&interner);


### PR DESCRIPTION
When `strictNullChecks`/`exactOptionalPropertyTypes`/`noUncheckedIndexedAccess` change, `tsc` does X; tsz does X through `QueryCache`'s `QueryDatabase` impl (`crates/tsz-solver/src/caches/query_cache.rs`) forwarding to the `TypeInterner` it wraps.

`QueryCache::set_strict_null_checks`/`set_exact_optional_property_types`/`set_no_unchecked_indexed_access` only updated `QueryCache`'s own local `Cell` copies, never `self.interner` (the `TypeInterner` it wraps).

`CheckerContext::from_parts` (`crates/tsz-checker/src/context/constructors.rs:165`) only ever holds a `&dyn QueryDatabase` — in production that's a `QueryCache` — and calls `set_strict_null_checks` through the trait. Reads through the trait (the checker's own `self.strict_null_checks()` calls) always saw the correct value via `QueryCache`'s local `Cell`. But several of `TypeInterner`'s own *inherent* methods read the flags directly on `&TypeInterner`, bypassing `QueryDatabase` entirely:

- non-strict nullish-member reduction in union construction (`reduce_nonstrict_nullish_members`, `crates/tsz-solver/src/intern/normalize.rs:154` and `crates/tsz-solver/src/intern/core/constructors.rs:184,284`)
- optional tuple-element widening under `exactOptionalPropertyTypes` (`normalize_optional_tuple_elements`, `constructors.rs:1482`)

Those paths could observe a stale/default flag value depending on construction order across the shared, program-wide `TypeInterner`, independent of what `QueryCache`'s own getter correctly reported.

**Fix:** the three setters now update the local `Cell` (unchanged, keeps `QueryCache`'s own fast-path reads working) *and* forward to `self.interner.set_*` so the wrapped `TypeInterner`'s own state agrees.

**Scope note, stated plainly:** found while investigating #16620 (non-strict all-nullish index-signature value reports `TS18047` in the unit harness but nothing through the CLI). This fix addresses a distinct, real desync in the same neighborhood, proven at the `QueryCache`/`TypeInterner` boundary by new regression tests. It is a necessary prerequisite for the solver-owned nullish-reduction fixes in this area to reach the CLI at all, but **by itself does not fully close #16620** — that issue's exact repro is an *all-nullish* union (`null | undefined`, no non-nullish sibling), which `reduce_nonstrict_nullish_members`'s current early return still does not collapse (that gap belongs to #16580/#16596, separately in flight). A minimal end-to-end CLI diagnostic difference for this specific fix was not isolated within this session's time budget (tried a mixed-union index-signature repro via two full `dist-fast` builds, before/after; both produced the same correct emit output, so the divergence this fix closes did not surface through that particular path — the evidence here is the targeted unit-level regression test, not a CLI-level before/after). Leaving #16620 open; recommend re-checking its exact repro once #16596 lands on top of this.

## Goal
Goal: hold

## Verification
- New tests `query_cache_set_strict_null_checks_propagates_to_wrapped_interner` and `query_cache_set_exact_optional_property_types_propagates_to_wrapped_interner` (`crates/tsz-solver/tests/db_tests.rs`): both pass with the fix; both fail without it (verified by stashing the fix and re-running — non-vacuity confirmed).
- `cargo test -p tsz-solver --lib` — 7652 / 0.
- `cargo test -p tsz-checker --lib -- nonstrict non_strict_non_null null narrow union optional` — 1602 / 0, 1 ignored (pre-existing).
- `cargo fmt --all` — clean.
- `cargo clippy -p tsz-solver --all-targets --all-features -- -D warnings` — clean.
- Pre-commit hook (clippy + arch-size guard + crate verification) passed.
- **Owed:** conformance snapshot and emit gate not run this session (time budget). This is a narrow, solver-internal forwarding fix; expected corpus-wide effect is zero or near-zero since it only changes behavior where construction ordering previously desynced the wrapped interner from a project's real compiler options, but a conformance/emit pass is still owed before landing since it's a real code path change, not test-only.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6r9c1iCPx34aC53YhB5rL)_