### PR TITLE
fix(solver): a union renders structurally unless the source wrote its alias

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core_alias_display.rs
@@ -53,6 +53,26 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
+        // A union is interned by content, so the reverse `TypeId -> alias body`
+        // index below cannot prove the source ever referenced the alias:
+        // `type Zed = string | number | symbol` and a longhand
+        // `string | number | symbol` annotation written elsewhere share one
+        // `TypeId`, and the index answers `Zed` for both. `tsc` names an alias
+        // only when the type node written at the site *is* the alias reference
+        // (`getUnionType` keys its cache on the member list plus the alias
+        // identity, so the two spellings are distinct `Type` objects and
+        // neither can repaint the other). tsz models the referenced spelling as
+        // `Lazy(DefId)`, which `format_type_for_assignability_message` renders
+        // from the reference before reaching here, so a union that arrives as a
+        // raw structural id was written longhand and renders structurally.
+        //
+        // This is the same policy the solver formatter already applies to
+        // anonymous composite annotations via `anonymous_composite_structural`;
+        // unions reaching this checker-side lookup had no equivalent gate.
+        if is_union {
+            return None;
+        }
+
         // If the type has a display alias (produced by evaluating a generic
         // Application like B<string>), let the formatter handle it - using the
         // raw alias name would lose the type arguments.

--- a/crates/tsz-checker/src/state/type_environment/formatting.rs
+++ b/crates/tsz-checker/src/state/type_environment/formatting.rs
@@ -191,12 +191,16 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Format a type-parameter constraint for TS2344 messages. tsc strips the
-    /// `aliasSymbol` from the constraint type before formatting, so the
-    /// canonical primitive key union (`string | number | symbol`) is rendered
-    /// structurally even though `PropertyKey` is its registered alias. Other
-    /// diagnostic surfaces keep the alias (notably TS2322 against
-    /// `Object.groupBy<K extends PropertyKey, T>`), so this is a narrow opt-in
-    /// for the constraint-not-satisfied emitter only.
+    /// `aliasSymbol` from the constraint type before formatting, so a bare
+    /// union constraint renders structurally.
+    ///
+    /// This used to need a narrow opt-in
+    /// (`with_expanded_primitive_key_union`) to escape a hardcoded
+    /// `"PropertyKey"` return in the formatter. That hardcode is gone and
+    /// structural rendering is the general rule for a union carrying no
+    /// written alias, so the opt-in was removed rather than left as a no-op.
+    /// A constraint the source spelled through an alias still renders that
+    /// alias: the spelling arrives as its own `Lazy(DefId)`.
     pub fn format_type_diagnostic_constraint(&self, type_id: TypeId) -> String {
         if let Some(sym_id) = self.ctx.resolve_type_to_symbol_id(type_id)
             && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
@@ -208,8 +212,7 @@ impl<'a> CheckerState<'a> {
         let mut formatter = self
             .ctx
             .create_diagnostic_type_formatter()
-            .with_display_properties()
-            .with_expanded_primitive_key_union();
+            .with_display_properties();
         formatter.format(type_id).into_owned()
     }
 

--- a/crates/tsz-checker/tests/union_display_alias_repaint_parity_tests.rs
+++ b/crates/tsz-checker/tests/union_display_alias_repaint_parity_tests.rs
@@ -8,11 +8,24 @@
 //! member list *plus* the alias identity, so the aliased and the longhand
 //! spelling are two distinct `Type` objects and neither can repaint the other.
 //!
-//! tsz interns one `TypeId` per content and carries the alias in a global
-//! `TypeId -> alias` side table (`TypeInterner::store_display_alias` /
-//! `get_display_alias`), so an alias declared anywhere can repaint a
-//! structurally identical type written longhand somewhere else. That is the
-//! divergence the `#[ignore]`d rows below record.
+//! tsz interns one `TypeId` per content, so a reverse `TypeId -> alias` lookup
+//! cannot prove the source ever referenced the alias, and an alias declared
+//! anywhere could repaint a structurally identical type written longhand
+//! somewhere else.
+//!
+//! For **unions** that repaint is fixed: both reverse lookups on the path now
+//! decline a union outright — `lookup_type_alias_name_for_display`
+//! (`error_reporter/core_alias_display.rs`) on the checker side, and the
+//! `find_def_for_type` alias naming in `diagnostics/format/mod.rs` on the
+//! solver side. A referenced alias survives because the spelling written at
+//! the site arrives as its own `Lazy(DefId)` and never reaches either lookup,
+//! which is what rows 6/7 pin.
+//!
+//! The `#[ignore]`d rows that remain record two *different* mechanisms, both
+//! still open: `keyof any` not being resolved eagerly for display, and an
+//! alias whose RHS **collapses** to a pre-existing type keeping its name
+//! (opposite polarity — there the alias *is* written at the site and `tsc`
+//! drops it). See #16610.
 //!
 //! Every expectation here was verified against the pinned oracle
 //! (`typescript@7.0.2`, `--noEmit --strict --lib es2022 --target es2022`), one
@@ -128,17 +141,18 @@ fn interface_declared_elsewhere_does_not_repaint_a_longhand_object() {
 }
 
 // ---------------------------------------------------------------------------
-// Tripwires: oracle-verified divergences. Expected to fail until fixed.
+// The repaint family, fixed. These were `#[ignore]`d tripwires; they are a
+// live regression floor now that neither reverse lookup names a union.
 // ---------------------------------------------------------------------------
 
-/// A longhand primitive union is repainted by a **lib** alias the source never
-/// mentions. tsz renders `PropertyKey`; tsc renders the union.
+/// A longhand primitive union must not be repainted by a **lib** alias the
+/// source never mentions.
 ///
 /// This is the widest-reach row: every `string | number | symbol` written by
-/// any user anywhere renders as `PropertyKey`, because `lib.es5.d.ts` declares
-/// that alias and the display-alias table is keyed on the interned `TypeId`.
+/// any user anywhere used to render as `PropertyKey` — `lib.es5.d.ts` declares
+/// that alias, and the solver formatter additionally carried a hardcoded
+/// `"PropertyKey"` return for any three-member string/number/symbol union.
 #[test]
-#[ignore = "known divergence: lib alias repaints a longhand primitive union (display-alias table is global by TypeId)"]
 fn longhand_primitive_union_is_not_repainted_by_an_unreferenced_lib_alias() {
     let source = "declare const value: string | number | symbol;\n\
                   const target: boolean = value;\n";
@@ -149,7 +163,6 @@ fn longhand_primitive_union_is_not_repainted_by_an_unreferenced_lib_alias() {
 /// referenced. No lib involvement, so this row rules out "the lib is stamped
 /// specially" as the cause.
 #[test]
-#[ignore = "known divergence: an unreferenced user alias repaints a longhand primitive union"]
 fn longhand_primitive_union_is_not_repainted_by_an_unreferenced_user_alias() {
     let source = "type Zed = string | number | symbol;\n\
                   declare const value: string | number | symbol;\n\
@@ -161,7 +174,6 @@ fn longhand_primitive_union_is_not_repainted_by_an_unreferenced_user_alias() {
 /// anything keyed on the specific alias name or on the three-member shape that
 /// `PropertyKey` happens to have.
 #[test]
-#[ignore = "known divergence: an unreferenced user alias repaints a longhand primitive union"]
 fn renamed_binders_longhand_two_member_union_is_not_repainted_by_its_alias() {
     let source = "type Pair = string | number;\n\
                   declare const other: string | number;\n\
@@ -173,7 +185,6 @@ fn renamed_binders_longhand_two_member_union_is_not_repainted_by_its_alias() {
 /// behaviour is not a declaration-order artifact that a source-order rule could
 /// explain away.
 #[test]
-#[ignore = "known divergence: an unreferenced user alias repaints a longhand primitive union"]
 fn an_alias_declared_after_the_use_site_does_not_repaint_the_longhand_union() {
     let source = "declare const value: string | number;\n\
                   const target: boolean = value;\n\

--- a/crates/tsz-solver/src/diagnostics/format/key.rs
+++ b/crates/tsz-solver/src/diagnostics/format/key.rs
@@ -91,12 +91,6 @@ impl<'a> TypeFormatter<'a> {
                 self.format_object_with_index(shape.as_ref()).into()
             }
             TypeData::Union(members) => {
-                if self.diagnostic_mode
-                    && !self.expand_primitive_key_union
-                    && self.is_primitive_key_union_data(key)
-                {
-                    return Cow::Borrowed("PropertyKey");
-                }
                 // tsc preserves top-level alias names that would otherwise be
                 // lost during union flattening (e.g., `T | null` should not
                 // expand to T's body). The checker records the unflattened

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -192,14 +192,6 @@ pub struct TypeFormatter<'a> {
     /// When true, generic mapped type aliases that evaluate to scalar types are
     /// displayed as their evaluated result. Used for assignability diagnostics.
     expand_scalar_mapped_alias_applications: bool,
-    /// When true, the canonical primitive key union (`string | number | symbol`,
-    /// shared by `keyof any` and the lib.d.ts alias `PropertyKey`) is rendered
-    /// in its structural form even in diagnostic mode. tsc strips the
-    /// `aliasSymbol` from the constraint type before formatting TS2344 messages
-    /// (`Type 'X' does not satisfy the constraint 'string | number | symbol'`)
-    /// while still keeping `PropertyKey` in other diagnostics. The default is
-    /// false to preserve the existing behavior across every other surface.
-    expand_primitive_key_union: bool,
     /// When true, render union members in canonical interner order even when a
     /// source/display origin was recorded. This is used by narrow diagnostic
     /// surfaces where tsc does not preserve source-written union order.
@@ -671,7 +663,6 @@ impl<'a> TypeFormatter<'a> {
             long_property_receiver_display: false,
             long_property_receiver_object_elision_end_depth: 26,
             expand_scalar_mapped_alias_applications: false,
-            expand_primitive_key_union: false,
             ignore_union_origins: false,
             application_reduction_cache: std::cell::RefCell::new(FxHashMap::default()),
             recursive_alias_base_cache: std::cell::RefCell::new(FxHashMap::default()),
@@ -720,7 +711,6 @@ impl<'a> TypeFormatter<'a> {
             long_property_receiver_display: false,
             long_property_receiver_object_elision_end_depth: 26,
             expand_scalar_mapped_alias_applications: false,
-            expand_primitive_key_union: false,
             ignore_union_origins: false,
             application_reduction_cache: std::cell::RefCell::new(FxHashMap::default()),
             recursive_alias_base_cache: std::cell::RefCell::new(FxHashMap::default()),
@@ -776,17 +766,6 @@ impl<'a> TypeFormatter<'a> {
     pub const fn with_diagnostic_mode(mut self) -> Self {
         self.skip_union_optionalize = true;
         self.diagnostic_mode = true;
-        self
-    }
-
-    /// Render the canonical primitive key union (`string | number | symbol`)
-    /// in its structural form rather than collapsing it to `PropertyKey`. tsc
-    /// strips the `aliasSymbol` from the constraint type before formatting
-    /// the TS2344 message; opt-in callers (the constraint-not-satisfied
-    /// emitter) use this to mirror that surface without affecting any other
-    /// diagnostic.
-    pub const fn with_expanded_primitive_key_union(mut self) -> Self {
-        self.expand_primitive_key_union = true;
         self
     }
 
@@ -1344,8 +1323,22 @@ impl<'a> TypeFormatter<'a> {
                             | DefKind::Variable
                     ) | (TypeData::Enum(_, _), DefKind::Enum)
                 );
-            let unproven_primitive_key_union_alias =
-                def.kind == DefKind::TypeAlias && self.is_primitive_key_union_data(&key);
+            // A union is interned by content, so a `TypeId -> def` reverse
+            // lookup cannot prove the source referenced the alias: every
+            // longhand `string | number` annotation in the program shares one
+            // id with a `type Pair = string | number` declared anywhere, and
+            // the lookup answers `Pair` for all of them. `tsc` keys its union
+            // cache on the member list *plus* the alias identity, so the
+            // aliased and the longhand spelling are distinct types and neither
+            // repaints the other; a referenced alias reaches display as its
+            // own `Lazy(DefId)` rather than through this reverse lookup.
+            //
+            // This generalizes a rule that was previously written only for the
+            // three-member property-key union (`string | number | symbol`,
+            // i.e. `keyof any`), whose shape check left every other union
+            // arity — `string | number` among them — still repaintable.
+            let unproven_union_alias =
+                def.kind == DefKind::TypeAlias && matches!(&key, TypeData::Union(_));
             // An inline / anonymous composite annotation shares its interned
             // `TypeId` with a coincidentally-shaped non-generic type-alias body,
             // so the reverse `find_def_for_type` lookup cannot prove the source
@@ -1391,10 +1384,10 @@ impl<'a> TypeFormatter<'a> {
                         // repaint user-written `{}` annotations; tsc shows `{}`
                         // structurally in that case, so we do too.
                         || is_empty_object
-                        // The canonical property-key union (`keyof any`) is a shared
-                        // structural TypeId. Ambient or local aliases with the same
-                        // body must not repaint constraint diagnostics.
-                        || unproven_primitive_key_union_alias
+                        // A union is a shared structural TypeId. Ambient or local
+                        // aliases with the same body must not repaint an
+                        // annotation that was written longhand.
+                        || unproven_union_alias
             } else {
                 // Interfaces and classes are also subject to the universal
                 // empty-shape interning: a non-empty interface/class def

--- a/crates/tsz-solver/src/diagnostics/format/tests_parts/part_00.rs
+++ b/crates/tsz-solver/src/diagnostics/format/tests_parts/part_00.rs
@@ -142,26 +142,25 @@ fn primitive_key_union_registered_to_type_alias_formats_structurally_without_ori
 }
 
 #[test]
-fn primitive_key_union_formats_as_property_key_in_diagnostic_mode() {
+fn primitive_key_union_formats_structurally_in_diagnostic_mode() {
+    // `tsc` names an alias only when the source wrote it. A bare
+    // `string | number | symbol` union carries no `aliasSymbol`, so it renders
+    // structurally on every diagnostic surface -- including the TS2344
+    // constraint message, which is why the previous opt-in
+    // (`with_expanded_primitive_key_union`) existed at all.
+    //
+    // This replaces two earlier pins: one asserting a hardcoded `"PropertyKey"`
+    // return for any three-member string/number/symbol union, and one asserting
+    // that a narrow opt-in could escape it. The hardcode contradicted the
+    // oracle-verified rows in
+    // `tsz-checker/tests/union_display_alias_repaint_parity_tests.rs`, so the
+    // general rule replaced it and the opt-in became unreachable. A source that
+    // *does* write `PropertyKey` still renders `PropertyKey`: that spelling
+    // arrives as its own `Lazy(DefId)` and never reaches this structural path.
     let db = TypeInterner::new();
     let primitive_key_union = db.union(vec![TypeId::STRING, TypeId::NUMBER, TypeId::SYMBOL]);
 
     let mut fmt = TypeFormatter::new(&db).with_diagnostic_mode();
-    assert_eq!(fmt.format(primitive_key_union), "PropertyKey");
-}
-
-#[test]
-fn primitive_key_union_formats_structurally_when_alias_collapse_is_opted_out() {
-    // tsc strips the `aliasSymbol` from the constraint type before formatting
-    // the TS2344 message, so opt-in callers (the constraint-not-satisfied
-    // emitter) get the structural form. The default diagnostic surface still
-    // collapses to `PropertyKey`; the opt-in is narrow and intentional.
-    let db = TypeInterner::new();
-    let primitive_key_union = db.union(vec![TypeId::STRING, TypeId::NUMBER, TypeId::SYMBOL]);
-
-    let mut fmt = TypeFormatter::new(&db)
-        .with_diagnostic_mode()
-        .with_expanded_primitive_key_union();
     assert_eq!(fmt.format(primitive_key_union), "string | number | symbol");
 }
 


### PR DESCRIPTION
Fixes the **repaint** half of #16610. Scoped deliberately: the *collapse* half (`type Coll = string[] & Array<string>` rendering `Coll` where tsc renders `string[]`) has opposite polarity and needs its own guard — Wolframite established that at 14:48Z on the issue, and folding them together is what their own refuted widening would have caused.

## Structural rule

**When a union arrives at the display path as a raw structural `TypeId` rather than as the alias reference the source wrote, `tsc` renders it structurally; tsz now does the same through the checker's `lookup_type_alias_name_for_display` and the solver's `find_def_for_type` alias naming.**

A union `TypeId` is interned by content, so a reverse `TypeId -> alias` lookup **cannot prove the source ever referenced the alias**. Every longhand `string | number | symbol` in the program shares one id with `lib.es5.d.ts`'s `type PropertyKey`; every longhand `string | number` shares one with any `type Pair = string | number` declared anywhere. Both reverse lookups answered from that shared id, so an alias declared anywhere repainted a structurally identical union written longhand everywhere — including an alias declared *after* the use site, and a lib alias the source never mentions.

`tsc`'s `getUnionType` keys its cache on the member list *plus* the alias identity, so the aliased and the longhand spelling are distinct `Type` objects and neither can repaint the other.

Both lookups now decline a union outright. The referenced spelling is unaffected **by construction**: it arrives as its own `Lazy(DefId)` and never reaches either lookup.

### Owner layers

| change | file | why |
|---|---|---|
| decline union in the checker's content-keyed alias lookup | `tsz-checker/src/error_reporter/core_alias_display.rs` | owner of rows 2 |
| generalize `unproven_primitive_key_union_alias` → `unproven_union_alias` | `tsz-solver/src/diagnostics/format/mod.rs` | owner of rows 3/4 — the rule already existed but was written only for the **three-member** property-key union, so every other union arity stayed repaintable |
| delete hardcoded `return Cow::Borrowed("PropertyKey")` | `tsz-solver/src/diagnostics/format/key.rs` | owner of row 1 |

### Anti-hardcoding

The `key.rs` deletion removes a literal `"PropertyKey"` string returned for any three-member string/number/symbol union **regardless of what the source wrote** — a rendered name synthesized from a hardcode rather than from a def. Its narrow escape hatch `with_expanded_primitive_key_union` existed so the TS2344 constraint emitter could get the structural form; structural is the general rule now, so the flag and its one call site (`state/type_environment/formatting.rs`) are removed rather than left as a no-op. No name, alias, or file-name string drives any decision in this diff — both guards test `TypeData::Union(_)`, a structural shape.

### A correction this surfaced

`format_type_diagnostic_constraint`'s doc claimed *"tsc strips the `aliasSymbol` from the constraint type before formatting"*. The oracle says otherwise — a constraint written as an alias keeps its name:

```
declare function f<K extends PropertyKey>(k: K): void; f<boolean>(true);
  tsc: Type 'boolean' does not satisfy the constraint 'PropertyKey'.
type Zed = string | number | symbol; declare function g<K extends Zed>(k: K): void; g<boolean>(true);
  tsc: Type 'boolean' does not satisfy the constraint 'Zed'.
```

So the old opt-in was wrong in the *other* direction — it forced structural rendering even for a constraint the source spelled as an alias. Removing it lets the written spelling decide, which is the same rule as the rest of this diff. Doc comment corrected.

## Verification

Oracle is the pinned `typescript@7.0.2` (already vendored at `scripts/node_modules`; the container's global `/opt/node22` typescript is **6.0.2** — do not oracle against it by reflex). `--noEmit --strict --pretty false --lib es2024 --target es2022`.

**The sharp control — both spellings in one file, oracled:**

```ts
declare const k: PropertyKey;
declare const j: string | number | symbol;
const a: boolean = k;   // tsc: Type 'PropertyKey' is not assignable to type 'boolean'.
const b: boolean = j;   // tsc: Type 'string | number | symbol' is not assignable to type 'boolean'.
```

tsc renders the two differently **in the same program**, which is exactly the rule this PR implements and rules out any "the alias is in scope" explanation.

| gate | before | after |
|---|---|---|
| `union_display_alias_repaint_parity_tests` (live) | 8 passed, 8 ignored | **12 passed, 4 ignored** |
| same, `-- --ignored` | 0 passed, 8 failed | **0 passed, 4 failed** (all out of scope) |
| `cargo test -p tsz-solver --lib` | 7649 passed | **7649 passed, 0 failed** |
| `cargo fmt --all` | — | clean |

The four rows promoted from tripwire to live regression floor are the repaint family: lib-alias repaint, user-alias repaint, renamed-binder two-member union, and alias-declared-after-use-site. The four still `#[ignore]`d pin the two mechanisms that stay open on #16610 (`keyof any` not resolved eagerly; alias-RHS-collapse).

**Adjacent matrix** — already in the pinned file, and it varies binders (`Zed` / `Pair` / `Later` / `Mapped` / `Rest`) so nothing is keyed on a name from the reported repro. Positive *and* negative sides both pinned: rows 6/7 assert an alias written at the site still renders (`Zed`, `PropertyKey`), and rows 8/9/10 assert the object/interface paths were already correct and stay correct.

### Verification I did NOT run — please treat as owed

- **`cargo test -p tsz-checker --lib`** — started, still executing at session end (~30 min in a debug binary; `setup.sh` reported *"Could not install mold automatically, build will use system linker"*, which is the cost). It compiled clean and its one compile-time catch is already fixed in this diff. **Not green-signed.**
- **Conformance.** This is a diagnostic-text change, so it is corpus-visible: `DiagnosticFingerprint.message_key` is the **full interpolated message**, whitespace-normalized only (`crates/conformance/src/tsc_results.rs`), and `compare_diagnostics` diffs fingerprint sets whenever both sides are non-empty. A code-only reading of the gate would be wrong here. `compare-to-parent.sh` did not fit this seat.
- **Emit.** `./scripts/emit/run.sh` unavailable — `setup.sh`'s npm step hung for 59+ min in this container and never completed.

Direction of expected movement: every row this changes moves tsz *toward* the structural form tsc prints, so fingerprint matches should improve rather than regress. That is a prediction, not a measurement — a warm seat with the corpus should confirm before this lands.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Gabbro

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHrMEfVasPRZFHhY4nmFUX)_