### PR TITLE
fix(cli): TS1013 joins the rest-parameter family in is_parser_grammar_code

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -541,7 +541,17 @@ fn is_hard_keyword_interface_name_2427_parse_diagnostic(diagnostic: &ParseDiagno
 const fn is_parser_grammar_code(code: u32) -> bool {
     matches!(
         code,
-        1014 // A rest parameter must be last in a parameter list
+        1013 // A rest parameter or binding pattern may not have a trailing
+             // comma. tsc's checkGrammarParameterList/checkGrammarAccessor/
+             // checkGrammarMethod report this from the checker for a rest
+             // parameter or destructuring binding pattern; tsz emits it from
+             // the parser at four sites (state_expressions_literals.rs,
+             // state_types_jsx.rs, state_statements_class.rs). A distinct
+             // checker-emitted site (assignment_ops.rs) also reports this code
+             // for a destructuring-*assignment* target's trailing comma, but
+             // that is a `CheckerDiagnostic`, never a `ParseDiagnostic`, so it
+             // never reaches this filter and is unaffected by this entry.
+        | 1014 // A rest parameter must be last in a parameter list
         | 1017 // An index signature cannot have a rest parameter
         | 1018 // An index signature parameter cannot have an accessibility modifier
         | 1101 // 'with' statements are not allowed in strict mode. tsc's

--- a/crates/tsz-cli/src/driver/check_utils/rest_parameter_grammar_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/rest_parameter_grammar_tests.rs
@@ -16,8 +16,107 @@
 //! parameter) belong to the same tsc function but are checker-emitted in tsz
 //! (`crates/tsz-checker/src/checkers/parameter_checker.rs`), so they must not
 //! get an entry here.
+//!
+//! TS1013 (a rest parameter or binding pattern may not have a trailing comma)
+//! is a sibling from the same `checkGrammarParameterList` family (also shared
+//! with `checkGrammarAccessor`/`checkGrammarMethod` for a rest binding-pattern
+//! element), oracle-confirmed (`typescript@7.0.2`) to follow the same
+//! suppress-alongside-a-real-syntax-error rule as TS1014/1047/1048. It was
+//! unlisted until now. tsz also reports TS1013 from the checker
+//! (`crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs`)
+//! for a destructuring-*assignment* target's trailing comma — a
+//! `CheckerDiagnostic`, never a `ParseDiagnostic`, so it cannot reach
+//! `filtered_parse_diagnostics` and this entry cannot affect it.
 
 use super::*;
+
+#[test]
+fn filtered_parse_diagnostics_suppresses_ts1013_when_real_parse_error_present() {
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 20,
+            length: 1,
+            message: "A rest parameter or binding pattern may not have a trailing comma."
+                .to_string(),
+            code: 1013,
+        },
+        ParseDiagnostic {
+            start: 60,
+            length: 1,
+            message: "Type expected.".to_string(),
+            code: 1110,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&1013),
+        "TS1013 should be suppressed when a real parse error (TS1110) is present, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1110),
+        "TS1110 (real parse error) should survive, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_keeps_ts1013_when_alone() {
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![ParseDiagnostic {
+        start: 20,
+        length: 1,
+        message: "A rest parameter or binding pattern may not have a trailing comma.".to_string(),
+        code: 1013,
+    }];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&1013),
+        "TS1013 should be kept when it is the only diagnostic, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_ts1013_does_not_self_suppress_listed_sibling() {
+    use tsz::parser::ParseDiagnostic;
+
+    // Before the fix, TS1013 was unlisted in `is_parser_grammar_code`, so it
+    // counted as a "real" non-grammar parse error under
+    // `has_non_grammar_parse_error` and silently deleted every *listed*
+    // sibling in the same file — here, the already-listed TS1014 from an
+    // unrelated function's rest parameter.
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 12,
+            length: 6,
+            message: "A rest parameter must be last in a parameter list.".to_string(),
+            code: 1014,
+        },
+        ParseDiagnostic {
+            start: 80,
+            length: 1,
+            message: "A rest parameter or binding pattern may not have a trailing comma."
+                .to_string(),
+            code: 1013,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&1014),
+        "TS1014 must not be self-suppressed by unlisted TS1013, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1013),
+        "TS1013 should survive when it is the only non-grammar-looking diagnostic, got: {codes:?}"
+    );
+}
 
 #[test]
 fn filtered_parse_diagnostics_suppresses_ts1047_when_real_parse_error_present() {


### PR DESCRIPTION
## Goal
Goal: hold

Continuing #16279's mechanical audit (already sliced today by ClaudeT as #16584/#16597, earlier by Beryl as #16320).

## Structural rule

`is_parser_grammar_code` (`crates/tsz-cli/src/driver/check_utils.rs`) lists codes tsc emits from the checker via `grammarErrorOnNode` but which tsz emits from the parser instead — membership is load-bearing in both directions per #16279: an unlisted parser-emitted grammar code is treated as a real parse error and silently deletes every *listed* sibling in the same file.

tsc's `checkGrammarParameterList`/`checkGrammarAccessor`/`checkGrammarMethod` all report **TS1013** ("A rest parameter or binding pattern may not have a trailing comma") from the checker, alongside siblings TS1014/1047/1048 — already listed. TS1013 itself was unlisted. tsz emits TS1013 from the parser at four sites (`state_expressions_literals.rs` ×2, `state_types_jsx.rs`, `state_statements_class.rs`), so it had the same self-suppression gap its siblings had before #16320/earlier slices fixed them.

Found via a grep-and-diff sweep of `crates/tsz-parser/src`'s `diagnostic_codes::*` references cross-referenced against the pinned corpus's `checker.ts` (`microsoft/TypeScript@4d4f005c8541e0255a9d8791205fdce326e462bc`, fetched via raw.githubusercontent.com) to enumerate each `checkGrammar*` function's full sibling-code membership — the recipe #16279's own comment history left for the next slice.

## Why this one is safe (the double-emission caveat #16279 warns about)

tsz also reports TS1013 from the **checker** (`crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs`), for a destructuring-*assignment* target's trailing comma (`[...rest,] = arr`, as opposed to a rest *parameter* or *binding-pattern declaration*). That site produces a `CheckerDiagnostic`, never a `ParseDiagnostic` — `filtered_parse_diagnostics` (and thus `is_parser_grammar_code`) only ever sees `&[ParseDiagnostic]`, so this entry cannot affect it. Verified this is the same non-interacting shape the file's own header already documents for TS1015/TS1016 (checker-emitted siblings correctly left out).

## Oracle verification (typescript@7.0.2)

**Direction A** (the false negative — alone, tsc reports it):
```ts
function f(...args: number[],) {}
```
→ `TS1013` alone. Same result for the destructuring-binding-pattern shape (`const [...rest,] = [1, 2, 3];`).

**Direction B** (the new suppression — alongside a real syntax error, tsc drops it):
```ts
function f(...args: number[],) {}
let y: = 1;
```
→ only `TS1110` (Type expected) — `TS1013` is dropped entirely, confirming it genuinely belongs in the suppression list. Same result for the destructuring-binding-pattern shape.

## Verification

- `cargo test -p tsz-cli --lib -- check_utils::rest_parameter_grammar_tests` — **9 passed, 0 failed** (3 new tests for TS1013 alongside the existing TS1014/1047/1048 tests).
- `cargo test -p tsz-cli --lib -- check_utils` (full module) — **165 passed, 0 failed** — no regression to any sibling grammar-audit suite.
- `cargo fmt -p tsz-cli -- --check` — clean.
- `cargo clippy -p tsz-cli --lib --tests -- -D warnings` — clean.
- `./scripts/architecture-check.sh --quick` — 0 LOC violations, 0 cross-layer imports (both touched files stay well under the 2000-line ceiling: 1817 and 283 lines).
- Pre-commit hook (clippy + arch-size guard + affected-crate verification) passed clean at commit `4a4bedd`.
- Not run this session (time budget, and per direct precedent from #16320/#16584/#16597, each independently measuring 0 newly failing/0 newly passing for this same additive-list-entry shape): `compare-to-parent.sh`/full conformance snapshot. This is a single-code addition to the same `matches!` list as those three prior slices, gated on a rare trailing-comma-plus-unrelated-syntax-error shape.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_01VfdNm3D1B4BDm51ck6SbCu)_