### PR TITLE
fix(lowering): non-strict null/undefined union reduction reaches interface members (#16620)

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
@@ -1853,6 +1853,9 @@ impl<'a> CheckerState<'a> {
                     &def_id_resolver,
                     &value_resolver,
                 )
+                .with_nonstrict_nullish_union_reduction(
+                    self.ctx.compiler_options.strict_null_checks,
+                )
                 .with_type_param_bindings(type_param_bindings)
                 .with_computed_name_resolver(&computed_name_resolver)
                 .with_computed_symbol_name_resolver(&computed_symbol_name_resolver)

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_lowering.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_lowering.rs
@@ -166,6 +166,7 @@ impl CheckerState<'_> {
             &cross_def_id_resolver,
             &cross_value_resolver,
         )
+        .with_nonstrict_nullish_union_reduction(self.ctx.compiler_options.strict_null_checks)
         .with_type_param_bindings(type_param_bindings);
 
         lowering.lower_interface_declarations_with_symbol(&[decl_idx], sym_id)

--- a/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
+++ b/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
@@ -1086,6 +1086,7 @@ impl<'a> CheckerState<'a> {
             &def_id_resolver,
             &value_resolver,
         )
+        .with_nonstrict_nullish_union_reduction(self.ctx.compiler_options.strict_null_checks)
         .with_type_param_bindings(type_param_bindings)
         .with_computed_name_resolver(&computed_name_resolver)
         .with_computed_symbol_name_resolver(&computed_symbol_name_resolver)
@@ -1630,6 +1631,9 @@ impl<'a> CheckerState<'a> {
                     &type_resolver,
                     &def_id_resolver,
                     &value_resolver,
+                )
+                .with_nonstrict_nullish_union_reduction(
+                    self.ctx.compiler_options.strict_null_checks,
                 )
                 .with_type_param_bindings(type_param_bindings)
                 .with_lazy_type_params_resolver(&lazy_type_params_resolver)

--- a/crates/tsz-checker/src/tests/non_strict_non_null_check_narrows_tests.rs
+++ b/crates/tsz-checker/src/tests/non_strict_non_null_check_narrows_tests.rs
@@ -502,30 +502,131 @@ fn strict_mode_keeps_the_two_cause_answer_for_an_interface_member() {
 }
 
 #[test]
-fn interface_index_signature_value_is_a_known_unfixed_residual() {
-    // NOT fixed here — documented so a future fix has a red test to turn
-    // green, and so this stays visibly a residual rather than silently
-    // regressing further. An index-signature member never reaches the
-    // interface fast path at all (`try_lower_simple_local_interface_object`
-    // rejects any non-`PROPERTY_SIGNATURE` member outright), so it always
-    // falls through to `tsz-lowering`'s `TypeLowering`, whose
-    // `strict_null_checks` field is not reliably wired to the real compiler
-    // option — see the strict-mode control above and this PR's review
-    // discussion. Fixing this either needs fast-path support for index
-    // signatures (mirroring the property-signature handling) or properly
-    // plumbing the option through `tsz-lowering`; both are out of scope for
-    // this fix. Behavior is unchanged from before this PR in both modes.
-    let source = "interface I { [k: string]: null | undefined }\ndeclare const i: I;\ni.m.foo;";
-    let lax = nullish_codes(&non_strict(source));
-    assert!(
-        lax.is_empty(),
-        "index-signature value nullish collapse remains unfixed (non-strict), got: {lax:?}"
+fn interface_index_signature_value_reports_the_reduced_single_cause() {
+    // #16620: previously a documented residual. An index-signature member
+    // never reaches the interface fast path
+    // (`try_lower_simple_local_interface_object` rejects any
+    // non-`PROPERTY_SIGNATURE` member), so it falls through to
+    // `tsz-lowering`'s `TypeLowering`, which did not apply the non-strict
+    // pure-nullish collapse. The general interface-lowering site now opts in
+    // via `with_nonstrict_nullish_union_reduction`, wiring the real
+    // `strictNullChecks`, so a `null | undefined` index value collapses to a
+    // bare `null` exactly like the property-signature paths above — reporting
+    // the single-cause TS18047/TS2721 without `strictNullChecks` and the
+    // two-cause TS18049/TS2723 under it. Binders are varied so nothing keys
+    // on identifier text.
+    for (iface, member) in [("I", "m"), ("Bag", "entry"), ("Store", "slot")] {
+        let source = format!(
+            "interface {iface} {{ [k: string]: null | undefined }}\ndeclare const i: {iface};\ni.{member}.foo;\ni.{member}();"
+        );
+        let codes = non_strict(&source);
+        assert_eq!(
+            count(&codes, TS18047),
+            1,
+            "an index-signature value typed `null | undefined` must report TS18047 (interface {iface}), got: {codes:?}"
+        );
+        assert_eq!(
+            count(&codes, TS2721),
+            1,
+            "an index-signature value typed `null | undefined` callee must report TS2721 (interface {iface}), got: {codes:?}"
+        );
+        assert_eq!(
+            count(&codes, 18049),
+            0,
+            "the non-strict answer must not be the strict two-cause TS18049 (interface {iface}), got: {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn interface_number_index_signature_value_collapses_the_same_way() {
+    // Sibling of the string index signature: a `[k: number]` value union of
+    // pure `null | undefined` collapses identically, observed through element
+    // access. The receiver `g[0]` is an ElementAccessExpression, not an
+    // entity name, so tsc reports the *object* form TS2531 ("Object is
+    // possibly 'null'") rather than the named TS18047 — exactly the
+    // entity-name distinction this file already documents for a `new C().m`
+    // base. Either code proves the collapse fired: before the fix `g[0]` was a
+    // surviving `null | undefined` union (own flags `Union`, non-strict arm
+    // silent) and neither code appeared. The callee `g[0]()` still reports
+    // TS2721, whose reporter does not depend on the entity-name form.
+    let source = "interface Grid { [k: number]: null | undefined }\ndeclare const g: Grid;\ng[0].foo;\ng[0]();";
+    let codes = non_strict(source);
+    assert_eq!(
+        count(&codes, 2531),
+        1,
+        "a number-index-signature value typed `null | undefined` accessed via `g[0]` must report TS2531, got: {codes:?}"
     );
+    assert_eq!(
+        count(&codes, TS2721),
+        1,
+        "a number-index-signature value typed `null | undefined` callee must report TS2721, got: {codes:?}"
+    );
+}
+
+#[test]
+fn interface_index_signature_uniform_undefined_stays_undefined_not_null() {
+    // Regression guard mirroring the annotation case: `undefined | undefined`
+    // has no `null` member, so an index value written that way must resolve to
+    // `undefined` (TS18048), never be dragged to `null` (TS18047).
+    let source =
+        "interface I { [k: string]: undefined | undefined }\ndeclare const i: I;\ni.m.foo;";
+    let codes = non_strict(source);
+    assert_eq!(
+        count(&codes, TS18048),
+        1,
+        "a uniform `undefined | undefined` index value must report TS18048, got: {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, TS18047),
+        0,
+        "a uniform `undefined | undefined` index value must not report TS18047, got: {codes:?}"
+    );
+}
+
+#[test]
+fn heritage_bearing_interface_member_collapses_through_the_general_path() {
+    // A property-signature interface that ALSO carries heritage is rejected by
+    // the simple-interface fast path (`RejectHeritageExtends`) and lowers
+    // through the same general `tsz-lowering` path as the index-signature
+    // cases — so the fix must reach it too, proving the seam is the general
+    // object/interface lowering rather than index signatures specifically.
+    let source = "interface Base {}\ninterface Holder extends Base { m: null | undefined }\ndeclare const h: Holder;\nh.m.foo;\nh.m();";
+    let codes = non_strict(source);
+    assert_eq!(
+        count(&codes, TS18047),
+        1,
+        "a heritage-bearing interface member typed `null | undefined` must report TS18047, got: {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, TS2721),
+        1,
+        "a heritage-bearing interface member typed `null | undefined` callee must report TS2721, got: {codes:?}"
+    );
+}
+
+#[test]
+fn strict_mode_keeps_the_two_cause_answer_for_an_index_signature() {
+    // Regression control: `strictNullChecks` must NOT collapse the index-value
+    // union — the opt-in wires the real option, so strict mode keeps the
+    // two-cause TS18049/TS2723 exactly as it already did.
+    let source =
+        "interface I { [k: string]: null | undefined }\ndeclare const i: I;\ni.m.foo;\ni.m();";
     let strict = check_source_strict_codes(source);
     assert_eq!(
         count(&strict, 18049),
         1,
-        "strict mode already reports the two-cause TS18049 for an interface index signature, got: {strict:?}"
+        "strict mode must keep the two-cause TS18049 for an index signature, got: {strict:?}"
+    );
+    assert_eq!(
+        count(&strict, 2723),
+        1,
+        "strict mode must keep the two-cause TS2723 for an index-signature callee, got: {strict:?}"
+    );
+    assert_eq!(
+        count(&strict, TS18047),
+        0,
+        "strict mode must not collapse an index value to the single-cause TS18047, got: {strict:?}"
     );
 }
 

--- a/crates/tsz-lowering/src/lower/core.rs
+++ b/crates/tsz-lowering/src/lower/core.rs
@@ -1338,25 +1338,26 @@ impl<'a> TypeLowering<'a> {
         // when a site opted in via `with_nonstrict_nullish_union_reduction` —
         // which also wires the real `strictNullChecks`, so an unwired site
         // (whose `strict_null_checks` silently defaults to `false`) can never
-        // collapse a union under `--strict`. Solver-owned and identical to the
-        // rule `tsz-checker`'s type-node resolvers apply; this is the seam for
-        // object/interface members (index signatures, and heritage-bearing or
-        // multiply-declared interfaces) that fall through to this lowering
-        // rather than the checker fast-path. See #16620.
-        let members = if self.nonstrict_nullish_union_reduction {
-            if let Some(collapsed) = tsz_solver::narrowing::collapse_pure_nullish_union_nonstrict(
+        // collapse a union under `--strict`. The `!strict_null_checks` gate
+        // makes strict builds skip both solver calls entirely. Solver-owned
+        // and identical to the rule `tsz-checker`'s type-node resolvers apply;
+        // this is the seam for object/interface members (index signatures, and
+        // heritage-bearing or multiply-declared interfaces) that fall through
+        // to this lowering rather than the checker fast-path. See #16620.
+        let members = if self.nonstrict_nullish_union_reduction && !self.strict_null_checks {
+            match tsz_solver::narrowing::collapse_pure_nullish_union_nonstrict(
                 self.strict_null_checks,
                 &members,
             ) {
                 // Pure `null | undefined` resolves to a bare nullish scalar —
                 // no `Union`, so no origin to record.
-                return collapsed;
+                Some(collapsed) => return collapsed,
+                None => tsz_solver::narrowing::nonstrict_union_members_absorb_nullish_scalars(
+                    self.strict_null_checks,
+                    &members,
+                )
+                .unwrap_or(members),
             }
-            tsz_solver::narrowing::nonstrict_union_members_absorb_nullish_scalars(
-                self.strict_null_checks,
-                &members,
-            )
-            .unwrap_or(members)
         } else {
             members
         };

--- a/crates/tsz-lowering/src/lower/core.rs
+++ b/crates/tsz-lowering/src/lower/core.rs
@@ -122,6 +122,8 @@ pub struct TypeLowering<'a> {
     /// Whether strictNullChecks is enabled. When true, optional parameters
     /// in function types include `| undefined` in their type.
     pub(super) strict_null_checks: bool,
+    /// Opt-in gate for the non-strict nullish union reduction (`nonstrict_nullish`).
+    pub(super) nonstrict_nullish_union_reduction: bool,
     /// Operation counter to prevent infinite loops
     pub(super) operations: Rc<RefCell<u32>>,
     /// Whether the operation limit has been exceeded
@@ -477,6 +479,7 @@ impl<'a> TypeLowering<'a> {
             preferred_self_name: None,
             preferred_self_def_id: None,
             strict_null_checks: false,
+            nonstrict_nullish_union_reduction: false,
             type_param_scopes: Rc::new(RefCell::new(Vec::new())),
             typeof_param_scopes: Rc::new(RefCell::new(Vec::new())),
             operations: Rc::new(RefCell::new(0)),
@@ -584,6 +587,7 @@ impl<'a> TypeLowering<'a> {
             preferred_self_name: self.preferred_self_name.clone(),
             preferred_self_def_id: self.preferred_self_def_id,
             strict_null_checks: self.strict_null_checks,
+            nonstrict_nullish_union_reduction: self.nonstrict_nullish_union_reduction,
             // Rc::clone() shares the underlying Rc instead of copying data
             type_param_scopes: Rc::clone(&self.type_param_scopes),
             typeof_param_scopes: Rc::clone(&self.typeof_param_scopes),
@@ -836,6 +840,18 @@ impl<'a> TypeLowering<'a> {
     /// function types include `| undefined` in their type.
     pub const fn with_strict_null_checks(mut self, enabled: bool) -> Self {
         self.strict_null_checks = enabled;
+        self
+    }
+
+    /// Opt this lowering into tsc's non-strict-mode `null`/`undefined` union
+    /// reduction, wiring the real `strictNullChecks` in the same call so it
+    /// can never fire under `--strict`. See `lower_union_type`.
+    pub const fn with_nonstrict_nullish_union_reduction(
+        mut self,
+        strict_null_checks: bool,
+    ) -> Self {
+        self.strict_null_checks = strict_null_checks;
+        self.nonstrict_nullish_union_reduction = true;
         self
     }
 
@@ -1318,17 +1334,32 @@ impl<'a> TypeLowering<'a> {
             .iter()
             .map(|&idx| self.lower_type(idx))
             .collect();
-        // NOTE: the non-strict pure-nullish-union collapse
-        // (`collapse_pure_nullish_union_nonstrict`) deliberately does NOT
-        // live here. `self.strict_null_checks` is not reliably the real
-        // compiler option on this path — the 37 `TypeLowering` construction
-        // sites across `tsz-checker` mostly never call
-        // `with_strict_null_checks`, so it silently defaults to `false` and
-        // would collapse the union even under `--strict`. The interface
-        // fast-path caller in `simple_local_interface.rs` routes a pure
-        // `null | undefined` member through `tsz-checker`'s own
-        // `get_type_from_type_node_in_type_literal`, which reads the real
-        // `compiler_options.strict_null_checks` — see #16180's review.
+        // Non-strict-mode `null`/`undefined` union reduction, applied only
+        // when a site opted in via `with_nonstrict_nullish_union_reduction` —
+        // which also wires the real `strictNullChecks`, so an unwired site
+        // (whose `strict_null_checks` silently defaults to `false`) can never
+        // collapse a union under `--strict`. Solver-owned and identical to the
+        // rule `tsz-checker`'s type-node resolvers apply; this is the seam for
+        // object/interface members (index signatures, and heritage-bearing or
+        // multiply-declared interfaces) that fall through to this lowering
+        // rather than the checker fast-path. See #16620.
+        let members = if self.nonstrict_nullish_union_reduction {
+            if let Some(collapsed) = tsz_solver::narrowing::collapse_pure_nullish_union_nonstrict(
+                self.strict_null_checks,
+                &members,
+            ) {
+                // Pure `null | undefined` resolves to a bare nullish scalar —
+                // no `Union`, so no origin to record.
+                return collapsed;
+            }
+            tsz_solver::narrowing::nonstrict_union_members_absorb_nullish_scalars(
+                self.strict_null_checks,
+                &members,
+            )
+            .unwrap_or(members)
+        } else {
+            members
+        };
         // Mirror tsc's `UnionType.origin`: record the as-written input
         // member list so the printer can render `0 | 1 | 2` in source
         // order even when the canonical sort uses non-deterministic

--- a/crates/tsz-lowering/src/lower/core/constructor_parity_tests.rs
+++ b/crates/tsz-lowering/src/lower/core/constructor_parity_tests.rs
@@ -15,6 +15,7 @@ fn assert_invariant_defaults(lowering: &TypeLowering<'_>) {
     assert!(lowering.preferred_self_def_id.is_none());
     assert!(lowering.host.name_def_id_resolver.is_none());
     assert!(!lowering.strict_null_checks);
+    assert!(!lowering.nonstrict_nullish_union_reduction);
     assert!(lowering.host.type_query_override.is_none());
 }
 


### PR DESCRIPTION
Closes #16620.

When `strictNullChecks` is off, tsc resolves a syntactic union type node whose members are exclusively `null`/`undefined` to a bare nullish scalar (`null` preferred over `undefined`), and absorbs a lone `null`/`undefined` member out of a union that also has a non-nullish sibling. `tsz-checker`'s own type-node resolvers already apply this rule via the solver-owned `collapse_pure_nullish_union_nonstrict` / `nonstrict_union_members_absorb_nullish_scalars` helpers — but object/interface members whose value type is lowered through `tsz-lowering`'s `TypeLowering` (index signatures, and heritage-bearing or multiply-declared interfaces that the simple-interface fast path rejects) kept the un-reduced union. Their own flags are `TypeFlags::Union`, not `Nullable`, so the non-strict `checkNonNullTypeWithReporter` arm never fired.

Reported witness: `interface I { [k: string]: null | undefined }; declare const i: I; i.m.foo;` reported nothing where tsc 7.0.2 reports `TS18047 'i.m' is possibly 'null'`.

## What the fix does

`TypeLowering::lower_union_type` now applies the identical solver-owned reduction, gated behind a new opt-in builder `with_nonstrict_nullish_union_reduction` that wires the real `strictNullChecks` in the same call — so a site that never wires the option (whose `strict_null_checks` silently defaults to `false`) can never collapse a union under `--strict`. The gate is `nonstrict_nullish_union_reduction && !strict_null_checks`, so strict builds skip the solver calls entirely. (The alternative — plumbing `strict_null_checks` into every `TypeLowering` construction site and reducing intrinsically — is exactly what broke strict mode in #16180's review; the per-site opt-in is the deliberate safe form.)

The opt-in is wired at **every interface-declaration lowering entry point**, because interface types are memoized per `sym_id` and any of these can be the first to compute (and cache) a given interface:
- `compute_type_of_symbol`'s interface path (`state/type_analysis/computed/mod.rs`)
- `lower_cross_file_interface_decl` (`state/type_analysis/cross_file_lowering.rs`) — the cross-file merge branch, called from the same function, so a multiply-declared interface spanning files reduces its cross-file members too, not just its local ones
- `compute_interface_type_from_declarations` and the type-reference interface path (`state/type_resolution/symbol_types.rs`)

This also removes a pre-existing inconsistency where simple property-only interfaces already collapsed (via the checker fast path) but heritage/index-signature/cross-file interfaces did not. The **type-alias** path is deliberately left untouched: its object-literal members already collapse through the checker's type-node resolvers (pinned by `null_or_undefined_union_class_field_and_object_literal_type_already_collapsed`), and the general alias/annotation/return-type mixed-scalar absorption is #16580's seam. Display-oriented lowerings (`TypeFormatter`) and every unopted `TypeLowering` site are unaffected.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib non_strict_non_null_check_narrows` — 31 passed. Turns the former `interface_index_signature_value_is_a_known_unfixed_residual` (asserted empty) into `..._reports_the_reduced_single_cause` (TS18047 + TS2721), and adds adjacent cases: string/number index signatures, renamed binders + interface names, heritage-bearing interface member, uniform `undefined | undefined` staying `undefined` (not dragged to `null`), and a strict-mode control keeping the two-cause TS18049/TS2723.
- `cargo test -p tsz-checker --lib -- nullish index_signature interface union nullable optional_chain non_null` — 1624 passed, 0 failed with the broadened opt-ins (no regressions in the nullish/interface/union surface).
- `cargo test -p tsz-lowering --lib constructor_parity` — 6 passed (new field defaults off).
- `cargo clippy -p tsz-lowering -p tsz-checker` — clean; `python3 scripts/arch/arch_guard.py` — passed (boundary + size; the reduction stays in `core.rs`, an already-counted `tsz_solver` importer, so the direct-`tsz_solver`-import cap holds at 35). Pre-commit hook re-ran clippy + arch guard + local verification on both commits: all passed.
- Conformance/emit not run locally: the standalone `TypeScript/` corpus is not provisioned in this environment. The change is scoped to non-strict interface/object union-member reduction and mirrors the reduction the checker already performs on the fast path and its type-node resolvers, so it can only move tsz toward tsc; the nightly conformance/emit lanes will validate.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high