### PR TITLE
fix(checker): an array literal in a tuple-typed element slot recovers its tuple form (#16552)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
@@ -1503,6 +1503,35 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
 
+            // An array literal written for a *tuple-typed element slot* is
+            // cached as the widened array (`{ kp: number }[]`) for exactly the
+            // reason an array literal written for a tuple-typed *property* is:
+            // its own check ran before the slot's contextual type was
+            // available. Handing that widened form to the relation loses the
+            // element count, so the failure is classified as the
+            // unbounded-source arity gap (`TS2620` "Target requires N
+            // element(s) but source may have fewer") — false on its face for a
+            // literal that wrote exactly N elements — and it hides the real
+            // per-element failure underneath.
+            //
+            // `contextual_tuple_recovers_elementwise_failure` is the same
+            // predicate the object-literal property path already applies for
+            // this shape; the element slot is the other half of `tsc`'s
+            // `elaborateElementwise`, which recurses through array and object
+            // literals alike. Restricted identically: the cached form lost
+            // tuple-ness, the contextual form regained it, and the target slot
+            // is a tuple, so the swap can only turn a whole-array arity reason
+            // into the element-wise one.
+            let elem_type = if self.contextual_tuple_recovers_elementwise_failure(
+                elem_type,
+                contextual_elem_type,
+                target_element_type,
+            ) {
+                contextual_elem_type
+            } else {
+                elem_type
+            };
+
             // For object/array literal elements, use contextually-typed type
             // to decide whether to elaborate (avoids false positives from widening).
             // Pass the target element type as contextual type so literal types
@@ -1596,6 +1625,20 @@ impl<'a> CheckerState<'a> {
                         .unwrap_or(elem_type)
                 } else {
                     elem_type
+                };
+                // The recovered source tuple slot can itself be the widened
+                // array form when the *enclosing* literal was the one cached
+                // before its contextual type arrived (a tuple of tuples). Apply
+                // the same recovery to the slot so the nested case cannot
+                // reintroduce the arity reason the rebind above removed.
+                let relation_elem_type = if self.contextual_tuple_recovers_elementwise_failure(
+                    relation_elem_type,
+                    contextual_elem_type,
+                    target_element_type,
+                ) {
+                    contextual_elem_type
+                } else {
+                    relation_elem_type
                 };
                 tracing::debug!(
                     "try_elaborate_array_literal_elements: elem_type = {:?}, target_element_type = {:?}, file = {}",

--- a/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
+++ b/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
@@ -1572,23 +1572,12 @@ fn a_tuple_element_type_reference_resolves_through_its_alias() {
     assert_eq!(span_text(source, start, length), "eq");
 }
 
-/// The second half of the same remaining gap: an array *of* tuples stops at
-/// the inner whole-tuple `TS2322` (`Type '[{ kp: number; }]' is not assignable
-/// to type '[{ kp: number; kq: number; }]'`), so the walk is never reached
-/// here either. Both descents this file needs (`ARRAY_TYPE` then `TUPLE_TYPE`)
-/// are in place; the primary is the blocker.
-///
-/// Oracle: `t8.ts:2:24 - TS2741 Property 'kq' is missing …` with
-/// `t8.ts:1:33 - 'kq' is declared here.`
-#[test]
-fn an_array_of_tuples_still_reports_the_inner_whole_tuple_mismatch() {
-    let source = "type K1 = { tup: [{ kp: number; kq: number }][] };\nconst k: K1 = { tup: [[{ kp: 1 }]] };\n";
-    let diagnostics = check_source_diagnostics(source);
-    assert!(
-        diagnostics.iter().all(|d| d.code != TS2741),
-        "array-of-tuples primary is expected to still be a whole-tuple TS2322: {diagnostics:?}"
-    );
-}
+// The second half of the same gap — an array *of* tuples stopping at the inner
+// whole-tuple `TS2322` — is closed at the elaboration owner rather than in this
+// walk; its rows live in the block at the end of this file
+// (`an_array_of_tuples_reaches_ts2741_at_the_inner_element` and siblings).
+// Both descents this file needs (`ARRAY_TYPE` then `TUPLE_TYPE`) were already
+// in place; the primary was the blocker.
 
 /// Negative / declining case, and the remaining gap. Two elements declare the
 /// same property name, so the walk has no basis to pick between the two
@@ -1626,5 +1615,190 @@ fn keyof_over_a_tuple_stays_opaque_to_the_element_descent() {
             .flat_map(|d| d.related_information.iter())
             .any(|info| info.code == TS2728),
         "`keyof` must not descend into the tuple element: {diagnostics:?}"
+    );
+}
+
+// An array literal written for a tuple-typed *element slot* recovers its
+// tuple form, exactly as one written for a tuple-typed *property* does.
+//
+// Structural rule, oracled against `typescript@7.0.2`
+// (`--noEmit --strict --pretty --target es2022 --lib es2022`): when an array
+// literal is written for a slot whose declared type is a tuple, tsc
+// (`elaborateElementwise`) compares the *written* element list against the
+// tuple, so a missing property in one of its object-literal elements is
+// reported as `TS2741` with the `'x' is declared here.` pointer into the
+// element's own written type.
+//
+// tsz cached that inner literal as the widened array (`{ kp: number }[]`) —
+// its own check ran before the slot's contextual type was available — and
+// handed the widened form to the relation. An unbounded source against a
+// closed tuple takes the arity branch, so every one of these rows reported
+// `TS2322` plus the sub-message `Target requires 1 element(s) but source may
+// have fewer.`, which is false on its face for a literal that wrote exactly
+// one element, and it hid the real missing-property failure and its pointer.
+//
+// The owner is the array-element half of the elaborator
+// (`error_reporter/call_errors/elaboration_object_properties.rs`,
+// `try_elaborate_array_literal_elements`), which now applies the same
+// `contextual_tuple_recovers_elementwise_failure` predicate the object-literal
+// property half already applied for this shape. The recovery is gated on the
+// cached form having lost tuple-ness, the contextual form having regained it,
+// and the target slot being a tuple, so a genuinely unbounded source (an array
+// *variable*, not a literal) keeps today's arity reason — see
+// `an_unbounded_array_variable_in_a_tuple_slot_keeps_the_arity_reason`.
+//
+// tsz anchors the primary at the inner array literal where tsc anchors it at
+// the failing object literal one node further in; that difference is shared
+// with the already-accepted single-level tuple rows above (where tsz anchors at
+// the property name) and is not what these rows pin. The `TS2728` offsets below
+// are the oracle's exact ones.
+// ---------------------------------------------------------------------------
+
+/// `[ T ][]` — an array of tuples, the row #16552 left open at the elaboration
+/// owner after #16599 closed the anchor walk's own tuple descent.
+///
+/// Oracle: `k1.ts:2:24 - TS2741 Property 'kq' is missing …` with
+/// `k1.ts:1:33 - 'kq' is declared here.`
+#[test]
+fn an_array_of_tuples_reaches_ts2741_at_the_inner_element() {
+    let source = "type K1 = { tup: [{ kp: number; kq: number }][] };\nconst k: K1 = { tup: [[{ kp: 1 }]] };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "kq");
+}
+
+/// The `readonly` spelling of the same array: the recovery keys on the target
+/// slot being a tuple, which `is_tuple_type` already sees through a `readonly`
+/// wrapper, so this row composes without its own arm.
+///
+/// Oracle: `k2.ts:1:42 - 'kq' is declared here.`
+#[test]
+fn a_readonly_array_of_tuples_reaches_ts2741_at_the_inner_element() {
+    let source = "type K2 = { tup: readonly [{ kp: number; kq: number }][] };\nconst k: K2 = { tup: [[{ kp: 1 }]] };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "kq");
+}
+
+/// The same array of tuples written directly as the binding's own annotation,
+/// with no enclosing object literal — the recovery is an element-slot rule, not
+/// a property-value one, so it must not depend on there being a member above.
+///
+/// Oracle: `k3.ts:1:26 - 'kq' is declared here.`
+#[test]
+fn a_directly_annotated_array_of_tuples_reaches_ts2741() {
+    let source = "type K3 = [{ kp: number; kq: number }][];\nconst k: K3 = [[{ kp: 1 }]];\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "kq");
+}
+
+/// A tuple *of* tuples: here the enclosing literal is the one whose cached form
+/// is a widened array, so the source-tuple slot the elaborator recovers is
+/// itself widened. This is the row that needs the recovery applied to the
+/// recovered slot as well as to the context-free element type.
+///
+/// Oracle: `k5.ts:1:34 - 'kq' is declared here.`
+#[test]
+fn a_tuple_of_tuples_reaches_ts2741_at_the_inner_element() {
+    let source = "type K5 = { tup: [[{ kp: number; kq: number }]] };\nconst k: K5 = { tup: [[{ kp: 1 }]] };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "kq");
+}
+
+/// Two levels of array around the tuple: the recovery runs per element slot, so
+/// it composes at every depth rather than only at the first.
+///
+/// Oracle: `m6.ts:2:25 - TS2741 …` (the pointer lands on `kq` in the element).
+#[test]
+fn an_array_of_arrays_of_tuples_reaches_ts2741_at_the_inner_element() {
+    let source = "type M6 = { tup: [{ kp: number; kq: number }][][] };\nconst m: M6 = { tup: [[[{ kp: 1 }]]] };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "kq");
+}
+
+/// The `Array< [ T ] >` spelling, which reaches the same slot through the
+/// generic reference rather than the `T[]` shorthand. Needs the real lib.
+///
+/// Oracle: `m1.ts:2:24 - TS2741 Property 'kq' is missing …`
+#[test]
+fn a_generic_array_of_tuples_reaches_ts2741_at_the_inner_element() {
+    let source = "type M1 = { tup: Array<[{ kp: number; kq: number }]> };\nconst m: M1 = { tup: [[{ kp: 1 }]] };\n";
+    let diagnostic = only(&check_source_diagnostics_with_libs(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "kq");
+}
+
+/// Renamed binders and different property names: the recovery keys on the
+/// target slot's *shape*, never on an identifier written above it.
+///
+/// Oracle: `m5.ts:2:29 - TS2741 Property 'beta' is missing …`
+#[test]
+fn the_array_of_tuples_recovery_is_not_identifier_keyed() {
+    let source = "type Roster = { rows: [{ alpha: string; beta: string }][] };\nconst r: Roster = { rows: [[{ alpha: \"a\" }]] };\n";
+    let diagnostic = only(&check_source_diagnostics(source), TS2741);
+    let (_, start, length, _) = declared_here(&diagnostic);
+    assert_eq!(span_text(source, start, length), "beta");
+}
+
+/// Negative control, and the reason the recovery is gated rather than blanket:
+/// an array *variable* handed to a tuple-typed slot really may have fewer
+/// elements, so tsc keeps the arity reason there. The contextual retype of an
+/// identifier is still the array, so the predicate declines and this row is
+/// unchanged.
+///
+/// Oracle: `m3.ts(3,23): TS2322 Type '{ kp: number; }[]' is not assignable to
+/// type '[{ kp: number; }]'.` / `Target requires 1 element(s) but source may
+/// have fewer.`
+#[test]
+fn an_unbounded_array_variable_in_a_tuple_slot_keeps_the_arity_reason() {
+    let source = "type M3 = { tup: [{ kp: number }][] };\ndeclare const loose: { kp: number }[];\nconst m: M3 = { tup: [loose] };\n";
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        diagnostics.iter().all(|d| d.code != TS2741),
+        "an unbounded array source must keep the arity reason: {diagnostics:?}"
+    );
+}
+
+/// Negative control: a *genuine* element shortfall inside the written literal
+/// stays an arity failure. Recovering the tuple form does not invent elements,
+/// so a one-element literal against a two-element tuple keeps tsc's
+/// `Source has 1 element(s) but target requires 2.`
+///
+/// Oracle: `m2.ts(2,23): TS2322 …` / `Source has 1 element(s) but target
+/// requires 2.`
+#[test]
+fn a_real_element_shortfall_inside_a_tuple_slot_stays_an_arity_failure() {
+    let source = "type M2 = { tup: [{ ka: number }, { kb: number }][] };\nconst m: M2 = { tup: [[{ ka: 1 }]] };\n";
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        diagnostics.iter().all(|d| d.code != TS2741),
+        "a real shortfall must not be recast as a missing property: {diagnostics:?}"
+    );
+}
+
+/// Negative control: a property whose *type* is wrong (not missing) inside the
+/// nested tuple element keeps the property-level `TS2322` and grows no
+/// `TS2728` pointer — `TS2728` pairs only with the missing-property form.
+///
+/// Oracle: `m4.ts(2,26): TS2322 Type 'string' is not assignable to type
+/// 'number'.`
+#[test]
+fn a_wrong_property_type_inside_a_tuple_slot_stays_ts2322() {
+    let source =
+        "type M4 = { tup: [{ kp: number }][] };\nconst m: M4 = { tup: [[{ kp: \"s\" }]] };\n";
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        diagnostics.iter().all(|d| d.code != TS2741),
+        "a wrong property type is not a missing property: {diagnostics:?}"
+    );
+    assert!(
+        !diagnostics
+            .iter()
+            .flat_map(|d| d.related_information.iter())
+            .any(|info| info.code == TS2728),
+        "no declared-here pointer belongs on a value mismatch: {diagnostics:?}"
     );
 }


### PR DESCRIPTION
Closes the array-of-tuples cell #16552 left open at the **elaboration** owner
(the anchor-walk half was already closed by #16599; the primary diagnostic was
the blocker).

**Structural rule.** When an array literal is written for a slot whose declared
type is a tuple, `tsc`'s `elaborateElementwise` compares the *written* element
list against that tuple, so a missing property in one of its object-literal
elements is reported as `TS2741` with the `'x' is declared here.` pointer into
the element's own written type. tsz does this through the array-element half of
the checker's elaborator (`error_reporter/call_errors/elaboration_object_properties.rs`,
`try_elaborate_array_literal_elements`).

**What was wrong.** tsz cached the inner literal as the *widened array*
(`{ kp: number }[]`) — its own check ran before the slot's contextual type was
available — and handed that form to the relation. An unbounded source against a
closed tuple takes the arity branch, so every array-of-tuples spelling reported

```
TS2322  Type '[{ kp: number; }]' is not assignable to type '[{ kp: number; kq: number; }]'.
          Target requires 1 element(s) but source may have fewer.
```

That sub-message is false on its face for a literal that wrote exactly one
element (the rendered source even prints as a 1-tuple — only the type the
*relation* saw was unbounded), and it hid the real missing-property failure and
its pointer.

**The fix** applies the same `contextual_tuple_recovers_elementwise_failure`
predicate the object-literal *property* half already applied for this exact
shape (#16576), at the *element* slot — the other half of `elaborateElementwise`,
which recurses through array and object literals alike. Gated identically: the
cached form lost tuple-ness, the contextual form regained it, and the target
slot is a tuple, so the swap can only turn a whole-array arity reason into the
element-wise one. A second application covers the tuple-of-tuples row, where the
*recovered source slot* is itself the widened form.

No new predicate, no name/file/printer-output check: the discriminator is
`is_tuple_type` on the target slot, which already peels `readonly`, so the
`readonly` spelling composes without its own arm.

## Measured matrix

Oracle: pinned `typescript@7.0.2`, `--noEmit --strict --pretty --target es2022 --lib es2022`.

| member type | tsc | tsz before | tsz after |
|---|---|---|---|
| `[ T ][]` | `TS2741` + `1:33 'kq' is declared here.` | `TS2322` + false `TS2620` | `TS2741` + `1:33` |
| `readonly [ T ][]` | `TS2741` + `1:42` | `TS2322` + false `TS2620` | `TS2741` + `1:42` |
| `[ T ][]` direct annotation, no member | `TS2741` + `1:26` | `TS2322` + false `TS2620` | `TS2741` + `1:26` |
| `[ [ T ] ]` tuple of tuples | `TS2741` + `1:34` | `TS2322` + false `TS2620` | `TS2741` + `1:34` |
| `[ T ][][]` array of arrays of tuples | `TS2741` | `TS2322` + false `TS2620` | `TS2741` |
| `Array< [ T ] >` | `TS2741` | `TS2322` + false `TS2620` | `TS2741` |
| renamed binders / different prop name | `TS2741` + pointer at `beta` | `TS2322` | `TS2741` + `beta` |
| array **variable** into a tuple slot | `TS2322` + `TS2620` *may have fewer* | same | **unchanged** (an unbounded array really may have fewer) |
| one element written, two required | `TS2322` + `TS2618` *Source has 1 … requires 2* | same | **unchanged** |
| element property of the **wrong type** | `TS2322` at the property | same | **unchanged**, and no pointer |
| single-level `[ T ]` member (control) | `TS2741` | `TS2741` | **unchanged** |
| **array** in a tuple slot — `[ T [] ]` (reviewer's neighbour) | `TS2741` | `TS2741` | **unchanged** — already correct |

Every `TS2728` offset above is the oracle's exact one, asserted by span text so
the rows are not identifier-keyed. The last row is the useful negative
neighbour the reviewer added: an *array* in a tuple slot was already right, so
the gap was specifically a **tuple nested in a tuple element slot**, which is
why the flat-tuple work in #16586/#16599 did not reach it.

**Disclosed divergence, unchanged by this PR:** tsz anchors the primary at the
inner array literal where tsc anchors it one node further in, at the failing
object literal. That is the same convention the already-accepted single-level
tuple rows carry (tsz anchors those at the property name), and it is not what
these rows pin. `two_tuple_elements_declaring_the_same_property_decline_the_pointer`
— the element-*position* residual — is untouched and stays #16552's open cell.

## Goal
Goal: hold

## Verification

Author, cloud seat, at head `d849cc7`:
- `cargo test -p tsz-checker --lib missing_property_declared_here` — **92/92**,
  up from 91 rows + 1 tripwire. The tripwire
  `an_array_of_tuples_still_reports_the_inner_whole_tuple_mismatch` flipped
  loudly (it asserted `TS2741` was absent; it is now present with the oracle's
  pointer) and is replaced by the 10 asserting rows in the table above.
- `cargo fmt --check` clean; pre-commit gate (`cargo clippy -p tsz-checker`,
  `arch_guard.py`) passed.

Reviewer, m4 seat, same head — this is the corpus gate the first revision of
this body recorded as **owed**; it has since been run and is no longer owed:
- `cargo nextest run -p tsz-checker --lib` — **10150 / 10150**
- conformance — **11498 / 12043**, **REG 0 / GAIN 0**, count unchanged
- `scripts/arch/arch_guard.py` rc=0; merges with `origin/main`, 0 conflicts,
  build rc=0
- Independent oracle probe: **FIXED 2 / BROKE 0**, and the six #16552 tuple rows
  already closed all still match tsc.

One conformance row moves **laterally**, disclosed rather than buried:
`conformance/es6/destructuring/declarationsAndAssignments.ts` is `FAIL` on both
sides at the same 5-of-7 match count — it gains the expected `TS2741` and loses
the expected `TS2322`, with no PASS/FAIL flip. It sits in this family's
neighbourhood and is worth its own look; it is not a cost of this PR.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Marcasite