### PR TITLE
fix(checker): export default of an import alias to a pure type reports TS1284 alongside TS1292 under verbatimModuleSyntax

### DIFF
--- a/crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs
+++ b/crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs
@@ -373,7 +373,9 @@ impl<'a> CheckerState<'a> {
     }
 
     /// TS1284/TS1285: export default checks under verbatimModuleSyntax.
-    /// TS1292: export default of a type-only alias under isolatedModules.
+    /// TS1292: export default of a type-only alias under isolatedModules (and,
+    /// alongside TS1284, under verbatimModuleSyntax — tsc double-reports when
+    /// the exported name is an import alias resolving to a pure type).
     pub(crate) fn check_verbatim_module_syntax_export_default(&mut self, clause_idx: NodeIndex) {
         use tsz_binder::symbol_flags;
         use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
@@ -455,7 +457,8 @@ impl<'a> CheckerState<'a> {
                 return;
             }
 
-            let alias_sym_id = if sym.has_any_flags(symbol_flags::ALIAS) {
+            let sym_is_direct_alias = sym.has_any_flags(symbol_flags::ALIAS);
+            let alias_sym_id = if sym_is_direct_alias {
                 Some(sym_id)
             } else {
                 self.ctx.alias_partner_for(self.ctx.binder, sym_id)
@@ -486,6 +489,32 @@ impl<'a> CheckerState<'a> {
             let (target_has_type, target_has_value) =
                 self.lookup_imported_target_flags(module_spec, &import_name);
             if target_has_type && !target_has_value {
+                // tsc double-reports here for verbatimModuleSyntax: TS1284 is
+                // evaluated directly against `export default <name>` (the
+                // local binding "only refers to a type", same shape as the
+                // PURE_TYPE branch above) *in addition to* TS1292's deeper
+                // resolve-through-the-import check. The PURE_TYPE branch
+                // above cannot see this because a plain import alias symbol
+                // never carries INTERFACE/TYPE_ALIAS flags itself — only its
+                // resolved target does, which is exactly what
+                // `lookup_imported_target_flags` just computed. Oracle-
+                // verified against typescript@7.0.2: both codes fire at the
+                // same position for `import { Foo } from "./m"; export
+                // default Foo;` under verbatimModuleSyntax. isolatedModules
+                // alone does not get TS1284 (verbatimModuleSyntax-only, same
+                // gate as the PURE_TYPE branch).
+                if option_name == "verbatimModuleSyntax" && sym_is_direct_alias {
+                    let message = format_message(
+                        diagnostic_messages::AN_EXPORT_DEFAULT_MUST_REFERENCE_A_VALUE_WHEN_VERBATIMMODULESYNTAX_IS_ENABLED_BU,
+                        &[&name],
+                    );
+                    self.error_at_node(
+                        clause_idx,
+                        &message,
+                        diagnostic_codes::AN_EXPORT_DEFAULT_MUST_REFERENCE_A_VALUE_WHEN_VERBATIMMODULESYNTAX_IS_ENABLED_BU,
+                    );
+                }
+
                 let message = format_message(
                     diagnostic_messages::RESOLVES_TO_A_TYPE_AND_MUST_BE_MARKED_TYPE_ONLY_IN_THIS_FILE_BEFORE_RE_EXPORTING_2,
                     &[&name, option_name],

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -975,6 +975,8 @@ mod variadic_tuple_alias_display_tests;
 mod variadic_tuple_constraint_literal_preservation_tests;
 #[path = "tests/variadic_tuple_spread_element_inference_tests.rs"]
 mod variadic_tuple_spread_element_inference_tests;
+#[path = "tests/verbatim_module_syntax_export_default_alias_ts1284_tests.rs"]
+mod verbatim_module_syntax_export_default_alias_ts1284_tests;
 #[path = "tests/void_undefined_discriminant_narrowing_tests.rs"]
 mod void_undefined_discriminant_narrowing_tests;
 #[path = "tests/window_self_globalthis_resolution_tests.rs"]

--- a/crates/tsz-checker/src/tests/verbatim_module_syntax_export_default_alias_ts1284_tests.rs
+++ b/crates/tsz-checker/src/tests/verbatim_module_syntax_export_default_alias_ts1284_tests.rs
@@ -1,0 +1,183 @@
+//! `export default <name>` under `verbatimModuleSyntax`, where `<name>` is an
+//! import alias (not a local declaration) resolving to a pure type.
+//!
+//! `check_verbatim_module_syntax_export_default`'s early TS1284/TS1285 branch
+//! only inspects the local symbol's own `is_type_only`/`PURE_TYPE`
+//! (`INTERFACE`/`TYPE_ALIAS`) flags. A plain `import { Foo } from "./m"`
+//! binding never carries those flags itself — only the resolved target does,
+//! which is exactly what the later TS1292 branch (`lookup_imported_target_flags`)
+//! computes. So the early branch always falls through, and tsz emitted only
+//! TS1292, never TS1284.
+//!
+//! Oracle-confirmed against `typescript@7.0.2`: for this shape tsc reports
+//! **both** TS1284 and TS1292 at the same position under `verbatimModuleSyntax`.
+//! `isolatedModules` alone (without `verbatimModuleSyntax`) reports only
+//! TS1292 — TS1284 is verbatimModuleSyntax-only, matching the existing direct
+//! (non-alias) branch's gate.
+
+use crate::context::CheckerOptions;
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::check_multi_file;
+use tsz_common::common::ModuleKind;
+
+const EXPORT_DEFAULT_ONLY_REFERS_TO_A_TYPE: u32 = 1284;
+const EXPORT_DEFAULT_REAL_VALUE: u32 = 1285;
+const IMPORT_MUST_BE_TYPE_ONLY: u32 = 1484;
+const RESOLVES_TO_A_TYPE: u32 = 1292;
+
+fn check(files: &[(&str, &str)], entry: &str, verbatim_module_syntax: bool) -> Vec<Diagnostic> {
+    check_multi_file(
+        files,
+        entry,
+        CheckerOptions {
+            module: ModuleKind::ESNext,
+            strict: true,
+            verbatim_module_syntax,
+            isolated_modules: !verbatim_module_syntax,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+fn codes(diagnostics: &[Diagnostic]) -> Vec<u32> {
+    let mut codes: Vec<u32> = diagnostics.iter().map(|d| d.code).collect();
+    codes.sort_unstable();
+    codes
+}
+
+/// A plain import alias to an interface-only module member, referenced by
+/// `export default`, reports both TS1284 and TS1292 under
+/// `verbatimModuleSyntax`.
+#[test]
+fn import_alias_to_interface_export_default_reports_both_verbatim() {
+    let diagnostics = check(
+        &[
+            ("/types.ts", "export interface Foo { x: number }\n"),
+            (
+                "/main.ts",
+                "import { Foo } from \"./types\";\nexport default Foo;\n",
+            ),
+        ],
+        "/main.ts",
+        true,
+    );
+
+    assert_eq!(
+        codes(&diagnostics),
+        vec![
+            EXPORT_DEFAULT_ONLY_REFERS_TO_A_TYPE,
+            RESOLVES_TO_A_TYPE,
+            IMPORT_MUST_BE_TYPE_ONLY,
+        ],
+        "expected TS1284 and TS1292 (plus the pre-existing TS1484 on the import \
+         statement itself) for an import-alias export default resolving to a pure \
+         type under verbatimModuleSyntax, got: {diagnostics:?}"
+    );
+}
+
+/// Same shape, renamed on import (`Foo as Baz`) — the alias-resolution path
+/// must key off the resolved import target, not the local binding name.
+#[test]
+fn renamed_import_alias_to_interface_export_default_reports_both_verbatim() {
+    let diagnostics = check(
+        &[
+            ("/types.ts", "export interface Foo { x: number }\n"),
+            (
+                "/main.ts",
+                "import { Foo as Baz } from \"./types\";\nexport default Baz;\n",
+            ),
+        ],
+        "/main.ts",
+        true,
+    );
+
+    assert_eq!(
+        codes(&diagnostics),
+        vec![
+            EXPORT_DEFAULT_ONLY_REFERS_TO_A_TYPE,
+            RESOLVES_TO_A_TYPE,
+            IMPORT_MUST_BE_TYPE_ONLY,
+        ],
+        "expected TS1284 and TS1292 (plus the pre-existing TS1484 on the import \
+         statement itself) for a renamed import-alias export default resolving to \
+         a pure type under verbatimModuleSyntax, got: {diagnostics:?}"
+    );
+}
+
+/// Same alias shape, but only `isolatedModules` is enabled: tsc reports only
+/// TS1292 (TS1284 is verbatimModuleSyntax-only). Negative control against the
+/// same code path so the fix stays gated correctly.
+#[test]
+fn import_alias_to_interface_export_default_reports_only_1292_under_isolated_modules() {
+    let diagnostics = check(
+        &[
+            ("/types.ts", "export interface Foo { x: number }\n"),
+            (
+                "/main.ts",
+                "import { Foo } from \"./types\";\nexport default Foo;\n",
+            ),
+        ],
+        "/main.ts",
+        false,
+    );
+
+    assert_eq!(
+        codes(&diagnostics),
+        vec![RESOLVES_TO_A_TYPE],
+        "expected only TS1292 under isolatedModules (no verbatimModuleSyntax), got: {diagnostics:?}"
+    );
+}
+
+/// A LOCAL interface declared and exported default directly (no import alias
+/// in between) must keep going through the pre-existing direct `PURE_TYPE`
+/// branch — single TS1284, not the alias-resolution TS1292 path, and not a
+/// double report.
+#[test]
+fn local_interface_export_default_reports_only_1284_verbatim() {
+    let diagnostics = check(
+        &[(
+            "/main.ts",
+            "interface Foo { x: number }\nexport default Foo;\n",
+        )],
+        "/main.ts",
+        true,
+    );
+
+    assert_eq!(
+        codes(&diagnostics),
+        vec![EXPORT_DEFAULT_ONLY_REFERS_TO_A_TYPE],
+        "expected only TS1284 for a directly-declared local interface export default, got: {diagnostics:?}"
+    );
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.code == EXPORT_DEFAULT_REAL_VALUE),
+        "did not expect TS1285 here, got: {diagnostics:?}"
+    );
+}
+
+/// An import alias whose target has BOTH a type and a value meaning (a class)
+/// must not trigger either TS1284 or TS1292.
+#[test]
+fn import_alias_to_class_export_default_reports_neither_verbatim() {
+    let diagnostics = check(
+        &[
+            ("/impl.ts", "export class Bar { x = 1; }\n"),
+            (
+                "/main.ts",
+                "import { Bar } from \"./impl\";\nexport default Bar;\n",
+            ),
+        ],
+        "/main.ts",
+        true,
+    );
+
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.code == EXPORT_DEFAULT_ONLY_REFERS_TO_A_TYPE
+                || d.code == EXPORT_DEFAULT_REAL_VALUE
+                || d.code == RESOLVES_TO_A_TYPE),
+        "expected neither TS1284 nor TS1292 for a value-carrying import alias export default, got: {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
When `export default name` under `verbatimModuleSyntax` references an **import alias** (not a local declaration) that resolves to a pure type (interface/type alias, no value meaning) — `tsc` emits **both** TS1284 and TS1292 at the same position; `tsz` emits **only** TS1292 through `check_verbatim_module_syntax_export_default` (`crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs`).

## Structural rule

`check_verbatim_module_syntax_export_default`'s early TS1284/TS1285 branch inspects only the *local* symbol's own `is_type_only`/`PURE_TYPE` (`INTERFACE`/`TYPE_ALIAS`) flags. A plain `import { Foo } from "./m"` binding never carries those flags itself — only the resolved target does, and that resolution is exactly what the later TS1292 branch (`lookup_imported_target_flags`) already computes. So for an alias, the early branch always falls through, and the function only ever reached the TS1292 path, silently dropping TS1284.

The fix reuses the already-computed `target_has_type`/`target_has_value` pair: when `option_name == "verbatimModuleSyntax"` and the local symbol is a direct alias, and the resolved target is type-only, it now also emits TS1284 before TS1292 — matching tsc's double report at the same node.

## Adjacent-case matrix (oracle-verified against `typescript@7.0.2`)

| shape | verbatimModuleSyntax | isolatedModules only |
| --- | --- | --- |
| `import { Foo } from "./m"; export default Foo;` (Foo: interface) | **TS1284 + TS1292** (was: TS1292 only) | TS1292 only (unaffected) |
| `import { Foo as Baz } from "./m"; export default Baz;` (renamed) | **TS1284 + TS1292** (was: TS1292 only) | — |
| `interface Foo {} ; export default Foo;` (local declaration, no alias) | TS1284 only (unaffected — direct `PURE_TYPE` branch) | — |
| `import { Bar } from "./m"; export default Bar;` (Bar: class, has a value) | neither (unaffected) | — |

All four rows are asserted in the new test file, plus the pre-existing (unrelated, correctly-firing) TS1484 on the import statement itself is checked in the two positive cases so the assertions aren't accidentally masking it.

## Scope note: a second, unrelated bug found and left out

While building the oracle matrix I found that `import type { Foo } from "./m"; export default Foo;` under `verbatimModuleSyntax` reports **TS1284** on real `tsc`, but tsz's `sym.is_type_only` branch in the same function emits **TS1285** for that exact shape — a pre-existing wrong-code bug, unrelated to this fix (different branch, not touched by this diff). Left out per "one invariant per PR"; flagged on the coordination board (issue #15994) for a future session with its own adjacent-case matrix.

Also probed issue #16291's `verbatimModuleSyntax` cluster's still-unclaimed TS1289/1290/1291 codes against the same oracle across ~10 shapes and could not reproduce any of them — every shape I tried already resolves to an existing wired code. Recorded as a dead end on the board so the next session doesn't re-walk the same ground.

## Verification

- `cargo test -p tsz-checker --lib -- verbatim_module_syntax_export_default_alias_ts1284_tests` — 5 passed, 0 failed (new tests).
- `cargo test -p tsz-checker --lib -- export_default isolated_modules verbatim_module_syntax` — 30 passed, 0 failed (no regressions in the surrounding families).
- `cargo fmt -p tsz-checker -- --check` — clean.
- `cargo clippy -p tsz-checker --lib --tests -- -D warnings` — clean.
- `./scripts/architecture-check.sh --quick` — 0 LOC violations, 0 cross-layer imports (pre-existing boundary-bypass/diagnostic-leak counts unchanged by this diff — touches no solver import, uses the existing `error_at_node` sink).
- Pre-commit hook (clippy + arch-size guard + affected-crate verification) passed clean at commit `40f25c3`.
- Not run this session (time budget; this is a two-line-condition addition reusing already-computed alias-resolution data, gated to a narrow shape): `compare-to-parent.sh`/full conformance snapshot.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE
