### PR TITLE
fix(checker): a legacy parameter decorator's return type is judged against `void` (TS1271)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -615,6 +615,9 @@ path = "tests/ts1240_accessor_decorator_tests.rs"
 name = "ts1241_method_decorator_tests"
 path = "tests/ts1241_method_decorator_tests.rs"
 [[test]]
+name = "ts1271_parameter_decorator_return_type_tests"
+path = "tests/ts1271_parameter_decorator_return_type_tests.rs"
+[[test]]
 name = "ts1249_method_overload_decorator_tests"
 path = "tests/ts1249_method_overload_decorator_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
@@ -416,11 +416,7 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        let has_too_few_args =
-            Self::decorator_signature_param_counts(self.ctx.types, decorator_type)
-                .is_some_and(|counts| !counts.is_empty() && counts.iter().all(|&n| n == 0));
-
-        if has_too_few_args {
+        if Self::decorator_signature_accepts_no_arguments(self.ctx.types, decorator_type) {
             let name = self.get_decorator_expression_name(decorator_expr);
             let msg = diagnostic_messages::ACCEPTS_TOO_FEW_ARGUMENTS_TO_BE_USED_AS_A_DECORATOR_HERE_DID_YOU_MEAN_TO_CALL_IT
                 .replace("{0}", &name);
@@ -433,6 +429,23 @@ impl<'a> CheckerState<'a> {
         }
 
         false
+    }
+
+    /// Whether every call signature of a decorator expression takes zero
+    /// parameters — the shape of a decorator factory written without its
+    /// call (`@factory` rather than `@factory()`).
+    ///
+    /// Mirrors tsc's `isPotentiallyUncalledDecorator` for the common
+    /// zero-parameter case. tsc reports only the TS1329 "did you mean to call
+    /// it first" hint for these, so every other decorator diagnostic that
+    /// would otherwise fall out of the failed call — the signature failure and
+    /// the return-type check alike — must stand down.
+    fn decorator_signature_accepts_no_arguments(
+        db: &dyn tsz_solver::construction::TypeDatabase,
+        decorator_type: TypeId,
+    ) -> bool {
+        Self::decorator_signature_param_counts(db, decorator_type)
+            .is_some_and(|counts| !counts.is_empty() && counts.iter().all(|&n| n == 0))
     }
 
     fn es_method_or_accessor_decorator_args(
@@ -843,13 +856,76 @@ impl<'a> CheckerState<'a> {
             actual_this_type,
         );
 
-        if !matches!(result, CallResult::Success(_)) {
-            self.error_at_node(
-                self.decorator_failure_anchor(decorator_node, resolved, 3),
-                diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_PARAMETER_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
-                diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_PARAMETER_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
-            );
+        let return_type = match result {
+            CallResult::Success(return_type) => Some(return_type),
+            _ => {
+                self.error_at_node(
+                    self.decorator_failure_anchor(decorator_node, resolved, 3),
+                    diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_PARAMETER_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
+                    diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_PARAMETER_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
+                );
+                // tsc keeps checking the return type after a failed signature
+                // resolution — `@bad` whose call fails AND whose return type is
+                // not `void` draws TS1239 and TS1271 at the same anchor. Recover
+                // the return type the same way the property-decorator path does.
+                self.recover_decorator_return_type_with_any_args(resolved)
+                    .or_else(|| {
+                        crate::query_boundaries::checkers::call::stable_call_recovery_return_type(
+                            self.ctx.types,
+                            resolved,
+                        )
+                    })
+            }
+        };
+
+        self.check_parameter_decorator_return_type(decorator_node, resolved, return_type);
+    }
+
+    /// TS1271 for legacy parameter decorators.
+    ///
+    /// The runtime discards a parameter decorator's result, so tsc requires the
+    /// return type to be assignable to `void` (`any` short-circuits). This is
+    /// the sibling of the identical check
+    /// [`Self::check_legacy_property_decorator_call_signature`] runs for
+    /// property decorators; the parameter half was never wired, so a parameter
+    /// decorator returning a value was silently accepted.
+    fn check_parameter_decorator_return_type(
+        &mut self,
+        decorator_node: NodeIndex,
+        resolved: TypeId,
+        return_type: Option<TypeId>,
+    ) {
+        // An uncalled zero-parameter decorator factory draws only the TS1329
+        // "did you mean to call it first" hint; its (unreachable) return type is
+        // not judged.
+        if Self::decorator_signature_accepts_no_arguments(self.ctx.types, resolved) {
+            return;
         }
+
+        let Some(return_type) = return_type else {
+            return;
+        };
+        let return_type = self.evaluate_type_for_assignability(return_type);
+        if matches!(return_type, TypeId::ERROR | TypeId::ANY) {
+            return;
+        }
+        if self
+            .return_relation_outcome(return_type, TypeId::VOID)
+            .related
+        {
+            return;
+        }
+
+        let return_str = self.format_type_diagnostic(return_type);
+        let message = format_message(
+            diagnostic_messages::DECORATOR_FUNCTION_RETURN_TYPE_IS_BUT_IS_EXPECTED_TO_BE_VOID_OR_ANY,
+            &[&return_str],
+        );
+        self.error_at_node(
+            self.decorator_expression_anchor(decorator_node),
+            &message,
+            diagnostic_codes::DECORATOR_FUNCTION_RETURN_TYPE_IS_BUT_IS_EXPECTED_TO_BE_VOID_OR_ANY,
+        );
     }
 
     fn get_decorator_expression_name(&self, expr: NodeIndex) -> String {

--- a/crates/tsz-checker/tests/ts1271_parameter_decorator_return_type_tests.rs
+++ b/crates/tsz-checker/tests/ts1271_parameter_decorator_return_type_tests.rs
@@ -1,0 +1,323 @@
+//! Tests for TS1271 on legacy (`experimentalDecorators`) parameter decorators.
+//!
+//! Structural rule: when a parameter decorator's resolved call returns a type
+//! that is not assignable to `void` (and is not `any`), `tsc` reports TS1271
+//! (`Decorator function return type is '{0}' but is expected to be 'void' or
+//! 'any'.`) at the decorator's expression; tsz reports it through the checker's
+//! `check_parameter_decorator_return_type`, the sibling of the identical check
+//! already run for property decorators.
+//!
+//! Before this pin the parameter half of that predicate did not exist: the
+//! checker resolved the `(target, key, index)` call only to decide TS1239 and
+//! discarded the return type, so a value-returning parameter decorator was
+//! silently accepted.
+//!
+//! Every row is oracle-verified against the pinned `typescript@7.0.2`, and the
+//! binder names are varied across rows so nothing keys on a user-chosen
+//! spelling (anti-hardcoding per CLAUDE.md).
+
+use tsz_checker::test_utils::{check_source_codes, check_source_codes_experimental_decorators};
+
+fn check_experimental(source: &str) -> Vec<u32> {
+    check_source_codes_experimental_decorators(source)
+}
+
+/// tsc: `m.ts(12,7): error TS1271 ... return type is 'number' ...`
+#[test]
+fn method_parameter_decorator_returning_a_value_emits_ts1271() {
+    let codes = check_experimental(
+        r#"
+declare function logged(target: any, key: string | undefined, index: number): number;
+
+class Service {
+    handle(@logged payload: number) {}
+}
+"#,
+    );
+
+    assert!(
+        codes.contains(&1271),
+        "Expected TS1271 for a value-returning method parameter decorator, got: {codes:?}"
+    );
+}
+
+/// The same rule at the constructor-parameter position, where the runtime
+/// passes `undefined` for the key rather than a string.
+#[test]
+fn constructor_parameter_decorator_returning_a_value_emits_ts1271() {
+    let codes = check_experimental(
+        r#"
+declare function inject(subject: any, member: string | undefined, ordinal: number): number;
+
+class Container {
+    constructor(@inject dependency: number) {}
+}
+"#,
+    );
+
+    assert!(
+        codes.contains(&1271),
+        "Expected TS1271 for a value-returning constructor parameter decorator, got: {codes:?}"
+    );
+}
+
+/// `unknown` is not assignable to `void`, so it is rejected exactly like a
+/// concrete value type — the same row the property-decorator suite pins.
+#[test]
+fn parameter_decorator_returning_unknown_emits_ts1271() {
+    let codes = check_experimental(
+        r#"
+declare function audited(host: any, slot: string | undefined, at: number): unknown;
+
+class Recorder {
+    write(@audited entry: number) {}
+}
+"#,
+    );
+
+    assert!(
+        codes.contains(&1271),
+        "Expected TS1271 for an unknown-returning parameter decorator, got: {codes:?}"
+    );
+}
+
+/// A decorator factory (`@make()`) whose produced decorator returns a value is
+/// judged on the produced decorator's return type, not the factory's.
+#[test]
+fn parameter_decorator_factory_returning_a_value_decorator_emits_ts1271() {
+    let codes = check_experimental(
+        r#"
+declare function make(): (owner: any, field: string | undefined, position: number) => number;
+
+class Widget {
+    render(@make() options: number) {}
+}
+"#,
+    );
+
+    assert!(
+        codes.contains(&1271),
+        "Expected TS1271 for a factory-produced value-returning parameter decorator, got: {codes:?}"
+    );
+}
+
+/// tsc reports TS1239 and TS1271 together at the same anchor when the call
+/// fails AND the recovered return type is not `void` — the failure does not
+/// suppress the return-type check.
+#[test]
+fn parameter_decorator_with_failing_call_emits_both_ts1239_and_ts1271() {
+    let codes = check_experimental(
+        r#"
+declare function mismatched(scope: any, label: any, slot: string): number;
+
+class Pipeline {
+    step(@mismatched stage: number) {}
+}
+"#,
+    );
+
+    assert!(
+        codes.contains(&1239) && codes.contains(&1271),
+        "Expected TS1239 and TS1271 together for a failing value-returning parameter decorator, got: {codes:?}"
+    );
+}
+
+/// Negative control for the row above: the same failing call with a `void`
+/// return keeps TS1239 alone. This is what proves the new check reads the
+/// return type rather than piggybacking on the failure.
+#[test]
+fn parameter_decorator_with_failing_call_and_void_return_keeps_ts1239_alone() {
+    let codes = check_experimental(
+        r#"
+declare function mismatchedVoid(scope: any, label: any, slot: string): void;
+
+class Conduit {
+    step(@mismatchedVoid stage: number) {}
+}
+"#,
+    );
+
+    assert!(
+        codes.contains(&1239),
+        "Expected TS1239 for a parameter decorator whose call cannot resolve, got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&1271),
+        "A void-returning parameter decorator must not draw TS1271, got: {codes:?}"
+    );
+}
+
+/// An uncalled zero-argument decorator factory draws only the TS1329
+/// "did you mean to call it first" hint; tsc does not judge its return type.
+#[test]
+fn uncalled_zero_arg_parameter_decorator_factory_does_not_emit_ts1271() {
+    let codes = check_experimental(
+        r#"
+declare function bare(): (holder: any, tag: any, spot: number) => number;
+
+class Uncalled {
+    invoke(@bare argument: number) {}
+}
+"#,
+    );
+
+    assert!(
+        !codes.contains(&1271),
+        "An uncalled zero-arg decorator factory must not draw TS1271, got: {codes:?}"
+    );
+}
+
+/// `void`, `any`, `undefined` and `never` returns are all accepted: the first
+/// two by tsc's own short-circuits, the last two because both are assignable
+/// to `void`.
+#[test]
+fn parameter_decorators_returning_void_any_undefined_or_never_are_accepted() {
+    for (label, annotation) in [
+        ("void", "void"),
+        ("any", "any"),
+        ("undefined", "undefined"),
+        ("never", "never"),
+    ] {
+        let source = format!(
+            r#"
+declare function marker(anchor: any, moniker: string | undefined, seat: number): {annotation};
+
+class Accepting {{
+    execute(@marker input: number) {{}}
+}}
+"#
+        );
+        let codes = check_experimental(&source);
+        assert!(
+            !codes.contains(&1271),
+            "A parameter decorator returning `{label}` must not draw TS1271, got: {codes:?}"
+        );
+    }
+}
+
+/// The corpus-realistic shape: the decorator's return type is INFERRED from its
+/// body rather than annotated. A body that falls off the end infers `void` and
+/// stays clean; one that returns a value infers that value's type and is
+/// rejected; a bare `return;` guard still infers `void`.
+///
+/// This is the row that matters for regression risk — an unannotated
+/// `function dec(t, k, i) {}` is how nearly every real parameter decorator is
+/// written, and it must not start drawing TS1271.
+#[test]
+fn parameter_decorator_return_type_is_judged_on_the_inferred_body_type() {
+    let implicit_void = check_experimental(
+        r#"
+function plain(target: any, key: any, index: number) { }
+
+class Plain {
+    method(@plain arg: number) {}
+}
+"#,
+    );
+    assert!(
+        !implicit_void.contains(&1271),
+        "A parameter decorator whose body infers `void` must stay clean, got: {implicit_void:?}"
+    );
+
+    let guarded_void = check_experimental(
+        r#"
+function guarded(target: any, key: any, index: number) { if (index) { return; } }
+
+class Guarded {
+    method(@guarded arg: number) {}
+}
+"#,
+    );
+    assert!(
+        !guarded_void.contains(&1271),
+        "A bare `return;` guard still infers `void`, got: {guarded_void:?}"
+    );
+
+    let inferred_value = check_experimental(
+        r#"
+function producing(target: any, key: any, index: number) { return 1; }
+
+class Producing {
+    method(@producing arg: number) {}
+}
+"#,
+    );
+    assert!(
+        inferred_value.contains(&1271),
+        "A parameter decorator whose body infers a value type must draw TS1271, got: {inferred_value:?}"
+    );
+}
+
+/// A decorator whose type is `any` is unchecked — no signature resolution, so
+/// no return type to judge.
+#[test]
+fn parameter_decorator_typed_any_is_not_judged() {
+    let codes = check_experimental(
+        r#"
+declare const opaque: any;
+
+class Opaque {
+    run(@opaque value: number) {}
+}
+"#,
+    );
+
+    assert!(
+        !codes.contains(&1271) && !codes.contains(&1239),
+        "An `any`-typed parameter decorator must not draw TS1239/TS1271, got: {codes:?}"
+    );
+}
+
+/// The check is gated on `experimentalDecorators`. Without it the parameter
+/// decorator is rejected outright (TS1206) and its return type is never judged.
+#[test]
+fn parameter_decorator_return_type_is_not_judged_without_experimental_decorators() {
+    let codes = check_source_codes(
+        r#"
+declare function tagged(carrier: any, name: string | undefined, idx: number): number;
+
+class Stage3 {
+    apply(@tagged amount: number) {}
+}
+"#,
+    );
+
+    assert!(
+        !codes.contains(&1271),
+        "TS1271 is an experimentalDecorators-only check, got: {codes:?}"
+    );
+}
+
+/// The property-decorator sibling this fix mirrors must keep behaving exactly
+/// as before — the shared zero-argument-factory predicate was extracted, not
+/// re-specified.
+#[test]
+fn property_decorator_return_type_check_is_unchanged() {
+    let value_returning = check_experimental(
+        r#"
+declare function stamped(container: any, member: string): number;
+
+class Stamped {
+    @stamped amount: number = 0;
+}
+"#,
+    );
+    assert!(
+        value_returning.contains(&1271),
+        "Expected TS1271 for a value-returning property decorator, got: {value_returning:?}"
+    );
+
+    let void_returning = check_experimental(
+        r#"
+declare function sealed(container: any, member: string): void;
+
+class Sealed {
+    @sealed amount: number = 0;
+}
+"#,
+    );
+    assert!(
+        !void_returning.contains(&1271),
+        "A void-returning property decorator must stay clean, got: {void_returning:?}"
+    );
+}


### PR DESCRIPTION
**Structural rule.** When a legacy (`experimentalDecorators`) parameter decorator's resolved call returns a type that is not assignable to `void` — and is not `any` — tsc reports **TS1271** (`Decorator function return type is '{0}' but is expected to be 'void' or 'any'.`) anchored at the decorator's *expression*; tsz now reports it through the **checker**'s `check_parameter_decorator_return_type` in `crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs`.

**The wrong semantic operation was a missing half of an existing predicate, not a new rule.** `check_parameter_decorator_call_signature` resolved the runtime `(target, key, index)` call *only* to decide TS1239, and returned without ever looking at the return type on the success path. Its sibling in the same file, `check_legacy_property_decorator_call_signature`, already ran precisely this check for property decorators. So TS1271 fired for `@dec p: number` and was silent for `m(@dec p: number)`.

This is the shape #16291's both-halves scan is documented as structurally unable to find: TS1271 has plenty of emit sites, so it never appears on the unwired list — the same class as ClaudeT's TS1003 export-specifier finding.

Two secondary corrections fall out of matching tsc:

- **The failure path keeps checking.** tsc reports TS1239 *and* TS1271 together at the same anchor when the call cannot resolve and the recovered return type is still not `void`. The property path already recovered a return type after a failed call; the parameter path now does the same.
- **An uncalled zero-argument factory stands down.** tsc reports only the TS1329 "did you mean to call it first" hint for `@factory` (uncalled), and does not judge its unreachable return type. The property path expressed that inside `decorator_has_zero_arg_factory_shape`, which also *emits* TS1329 — so the shape test is extracted into a pure `decorator_signature_accepts_no_arguments` and reused, leaving TS1329 emission on the parameter path exactly as it was.

Also closes out a stale row on #16291: **TS1236/TS1237 are unreachable in TypeScript 7** and should come off the 38-code list. Both a property and a parameter decorator returning `number` report **TS1271** on the pinned oracle; TS1236/1237 are tsc's legacy `chainDiagnosticMessages` sub-messages, which TS7 no longer emits as standalone codes. Same "stale-because-never-reachable" class as TS1022/TS1195/TS1339.

No identifier, alias, property or file-name string drives any decision here; the predicate is `return_relation_outcome(return_type, TypeId::VOID)` plus the existing signature-shape probe. Binder names are varied across the test rows.

## Goal
Goal: hold

## Verification

Oracle: `typescript@7.0.2` (the repo pin), installed into a scratch dir and run as `tsc -p tsconfig.json` with `experimentalDecorators: true`. Every row below was confirmed against it under both `strict: true` and `strict: false` (identical results apart from the unrelated `undefined`→`string` TS1239).

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| method param decorator returns `number` | TS1271 | *(silent)* | TS1271 |
| constructor param decorator returns `number` | TS1271 | *(silent)* | TS1271 |
| returns `unknown` | TS1271 | *(silent)* | TS1271 |
| factory `@make()` produces a `number`-returning decorator | TS1271 | *(silent)* | TS1271 |
| body infers a value type (`{ return 1; }`) | TS1271 | *(silent)* | TS1271 |
| failing call + `number` return | TS1239 + TS1271 | TS1239 | TS1239 + TS1271 |
| failing call + `void` return | TS1239 | TS1239 | TS1239 |
| returns `void` / `any` / `undefined` / `never` | clean | clean | clean |
| body infers `void` (`function d(t, k, i) {}`) | clean | clean | clean |
| bare `return;` guard | clean | clean | clean |
| uncalled zero-arg factory `@bare` | TS1329 only | TS1329 only | TS1329 only |
| decorator typed `any` | clean | clean | clean |
| no `experimentalDecorators` | no TS1271 | no TS1271 | no TS1271 |
| property decorator sibling (`@dec p: number` / `void`) | TS1271 / clean | TS1271 / clean | TS1271 / clean |

Commands actually run:

- `cargo test -p tsz-checker --test ts1271_parameter_decorator_return_type_tests` — **12 passed, 0 failed** (new file, 270+ lines, 15 pinned shapes).
- **Before/after control**: reverted only the production diff and re-ran the same file — **5 failed / 6 passed**, and the five failures are exactly the five positive rows. Every negative control passes on both sides, so no row in this file is vacuous.
- Every decorator-adjacent test target, all green, **121 passed / 0 failed**: `ts1238_tests` (14), `ts1238_generic_decorator_tests` (2), `ts1239_parameter_decorator_tests` (5), `ts1240_tests` (4), `ts1240_accessor_decorator_tests` (16), `ts1241_method_decorator_tests` (18), `ts1249_method_overload_decorator_tests` (2), `es_member_decorator_arity_tests` (15), `ts2449_parameter_decorator_no_tdz_tests` (2), `decorator_method_tdz_tests` (10), `decorator_this_binding_tests` (16), `issue_7681_super_decorator_tests` (7), `ts18036_class_decorator_static_private_identifier_tests` (10).
- `cargo fmt --all`; `cargo clippy -p tsz-checker --lib -- -D warnings` and `cargo clippy -p tsz-checker --test ts1271_parameter_decorator_return_type_tests -- -D warnings` — both clean. The `pre-commit` hook's own clippy + arch-guard pass reported `Clippy passed. / Architecture guard passed.`
- `cargo test -p tsz-checker --lib` was started and had not returned when this PR was opened (it buffers to zero bytes against a non-tty until it finishes). Disclosed rather than claimed; I will post the count on this PR when it lands.

**Owed, disclosed rather than skipped:** `scripts/conformance/compare-to-parent.sh`. This container has no TypeScript submodule checkout, and the two-sided `dist-fast` run is measured at 55–90 min on a cold cloud seat — it does not fit the session. Risk shape is narrow and one-directional: the change can only **add** TS1271 on a parameter decorator under `experimentalDecorators` whose resolved return type is not `void`/`any`/error, and it never removes or relocates an existing diagnostic. The corpus-realistic unannotated shape (`function dec(t, k, i) {}`, inferring `void`) is pinned clean above precisely because that is the row a corpus regression would come through.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Sphalerite

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHLKgixQb4GGf1jPqVcRho)_