### PR TITLE
fix(checker): report TS2300 duplicate parameters in arrow/function-expression/object-method forms

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -145,6 +145,9 @@ mod control_flow_type_guard_tests;
 #[path = "../tests/definite_assignment_tests.rs"]
 mod definite_assignment_tests;
 #[cfg(test)]
+#[path = "../tests/duplicate_parameter_names_function_expression_forms_tests.rs"]
+mod duplicate_parameter_names_function_expression_forms_tests;
+#[cfg(test)]
 #[path = "../tests/dynamic_import_defer_tests.rs"]
 mod dynamic_import_defer_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -1251,7 +1251,12 @@ impl<'a> CheckerState<'a> {
             // Method shorthand: { foo() {} }
             else if let Some(method) = self.ctx.arena.get_method_decl(elem_node) {
                 // TS1015/TS1016: parameter grammar runs for object-literal
-                // methods like any other function-like signature.
+                // methods like any other function-like signature. TS2300 for
+                // duplicate parameter names runs here too: an object-literal
+                // method is a `METHOD_DECLARATION`, so `get_type_of_function`'s
+                // shared signature-grammar block skips it (that block is gated
+                // to the non-method function-expression forms).
+                self.check_duplicate_parameters(&method.parameters, method.body.is_some());
                 self.check_parameter_ordering(&method.parameters, Some(elem_idx));
                 // Always type-check computed property name expressions for methods,
                 // even when the identifier can be resolved as a literal name.

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -117,6 +117,9 @@ impl<'a> CheckerState<'a> {
         let is_arrow_function = node.kind == syntax_kind_ext::ARROW_FUNCTION;
 
         if !is_function_declaration && !is_method_or_constructor {
+            // TS2300 for function expressions, arrows and accessors (the other
+            // forms run it via their own declaration/object-literal check sites).
+            self.check_duplicate_parameters(parameters, body.is_some());
             self.check_parameter_ordering(parameters, Some(idx));
             self.check_binding_pattern_optionality(&parameters.nodes, body.is_some(), Some(idx));
             self.check_rest_parameter_types(&parameters.nodes);

--- a/crates/tsz-checker/tests/duplicate_parameter_names_function_expression_forms_tests.rs
+++ b/crates/tsz-checker/tests/duplicate_parameter_names_function_expression_forms_tests.rs
@@ -1,0 +1,178 @@
+//! Duplicate parameter names (TS2300) for the function-*expression* forms.
+//!
+//! `tsc` reports `TS2300 Duplicate identifier '<name>'` on every occurrence of a
+//! repeated parameter name in any function-like signature, whatever syntactic
+//! form it takes. tsz already covered the named *declaration* forms — function
+//! declarations, class methods, constructors, interface methods and ambient
+//! (`declare`) function declarations — because those route through their own
+//! declaration checkers, which call `check_duplicate_parameters`.
+//!
+//! The function-*expression* forms did not: an arrow function, a function
+//! expression and an object-literal method reach their signature grammar checks
+//! (`check_parameter_ordering`, rest-parameter typing, …) through
+//! `get_type_of_function`/the object-literal computation instead, and the
+//! duplicate check was simply never wired in alongside them. So
+//!
+//! ```ts
+//! const f = (a: number, a: string) => a;   // tsc: TS2300 x2, tsz: (nothing)
+//! ```
+//!
+//! compiled clean on tsz while `function f(a: number, a: string) {}` did not.
+//! Every row below is oracle-pinned against `typescript@7.0.2`
+//! (`--noEmit --strict`); the exact-code assertions also prove no *other*
+//! diagnostic fires on these signatures.
+//!
+//! Scope note: this fixes the *call-site* gap for simple (identifier)
+//! parameters. Two neighbouring gaps are pre-existing and orthogonal — they
+//! affect the declaration forms too and are left for a follow-up: duplicate
+//! *binding-pattern* names (`function f({ a, a }) {}`) and the function-*type*
+//! form (`type F = (a, a) => void`) reporting one occurrence instead of two.
+
+use crate::test_utils::check_source_strict_codes as codes;
+
+// ---------------------------------------------------------------------------
+// The forms that regressed: function-expression shapes now report TS2300.
+// tsc reports the code once per occurrence, so a two-parameter clash is two
+// diagnostics — and nothing else.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn arrow_function_duplicate_parameter_reports_ts2300() {
+    assert_eq!(
+        codes("const f = (a: number, a: string) => a;\n"),
+        vec![2300, 2300]
+    );
+}
+
+#[test]
+fn function_expression_duplicate_parameter_reports_ts2300() {
+    assert_eq!(
+        codes("const f = function (a: number, a: string) { return a; };\n"),
+        vec![2300, 2300],
+    );
+}
+
+#[test]
+fn object_literal_method_duplicate_parameter_reports_ts2300() {
+    assert_eq!(
+        codes("const o = { m(a: number, a: string) { return a; } };\n"),
+        vec![2300, 2300],
+    );
+}
+
+/// A statement-position function expression is checked through both the
+/// statement callback and `get_type_of_function`; the exact-code assertion
+/// proves the diagnostic does not double up (two occurrences, not four).
+#[test]
+fn statement_position_function_expression_reports_ts2300_once_per_occurrence() {
+    assert_eq!(
+        codes("(function (a: number, a: string) { return a; });\n"),
+        vec![2300, 2300],
+    );
+}
+
+/// A nested arrow inside another function is still a distinct signature and is
+/// checked on its own.
+#[test]
+fn nested_arrow_duplicate_parameter_reports_ts2300() {
+    assert_eq!(
+        codes("function outer() { const g = (b: number, b: string) => b; return g; }\n"),
+        vec![2300, 2300],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Anti-hardcoding: the rule keys on the parameter *name* collision, not on any
+// particular spelling. Renamed binders behave identically.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn arrow_duplicate_parameter_rule_is_binder_name_independent() {
+    assert_eq!(
+        codes("const f = (payload: 1, payload: 2) => payload;\n"),
+        vec![2300, 2300]
+    );
+    assert_eq!(
+        codes("const g = function (widget: 1, widget: 2) { return widget; };\n"),
+        vec![2300, 2300],
+    );
+    assert_eq!(
+        codes("const o = { run(ctx: 1, ctx: 2) { return ctx; } };\n"),
+        vec![2300, 2300]
+    );
+}
+
+/// Three occurrences draw three diagnostics — one per parameter — matching
+/// `tsc`, and a non-adjacent duplicate (separated by a distinct parameter) is
+/// still caught.
+#[test]
+fn arrow_triple_and_non_adjacent_duplicates() {
+    assert_eq!(
+        codes("const f = (a: 1, a: 2, a: 3) => a;\n"),
+        vec![2300, 2300, 2300]
+    );
+    assert_eq!(
+        codes("const f = (a: 1, b: 2, a: 3) => a;\n"),
+        vec![2300, 2300]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The declaration forms were already correct — pin them so the shared
+// `check_duplicate_parameters` wiring cannot start double-reporting them.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn declaration_forms_still_report_exactly_two() {
+    assert_eq!(
+        codes("function f(a: number, a: string) {}\n"),
+        vec![2300, 2300]
+    );
+    assert_eq!(
+        codes("class C { m(a: number, a: string) {} }\n"),
+        vec![2300, 2300]
+    );
+    assert_eq!(
+        codes("class D { constructor(a: number, a: string) {} }\n"),
+        vec![2300, 2300]
+    );
+    assert_eq!(
+        codes("interface I { m(a: number, a: string): void; }\n"),
+        vec![2300, 2300]
+    );
+    assert_eq!(
+        codes("declare function g(a: number, a: string): void;\n"),
+        vec![2300, 2300]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Distinct parameter names stay clean on every form — the wiring must not
+// invent a collision.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn distinct_parameters_stay_clean_on_every_form() {
+    assert_eq!(
+        codes("const f = (a: number, b: string) => a;\n"),
+        Vec::<u32>::new()
+    );
+    assert_eq!(
+        codes("const f = function (a: number, b: string) { return a; };\n"),
+        Vec::<u32>::new(),
+    );
+    assert_eq!(
+        codes("const o = { m(a: number, b: string) { return a; } };\n"),
+        Vec::<u32>::new()
+    );
+    // A getter takes no parameters and a setter takes one, so neither can carry
+    // a duplicate; they must stay clean rather than trip the new wiring.
+    assert_eq!(
+        codes("const o = { get p() { return 1; } };\n"),
+        Vec::<u32>::new()
+    );
+    assert_eq!(
+        codes("const o = { set p(v: number) {} };\n"),
+        Vec::<u32>::new()
+    );
+}


### PR DESCRIPTION
Fixes #16636

Duplicate parameter names went unreported for the function-*expression*
forms. When two parameters share a name, `tsc` reports `TS2300 Duplicate
identifier '<name>'` on every occurrence, in any function-like signature. tsz
already covered the named *declaration* forms — function declarations, class
methods, constructors, interface methods and ambient (`declare`) functions —
because those route through their own declaration checkers, which call
`check_duplicate_parameters`. The function-expression forms did not:

```ts
const f = (a: number, a: string) => a;             // tsc: TS2300 x2, tsz was silent
const g = function (a: number, a: string) {};      // tsc: TS2300 x2, tsz was silent
const o = { m(a: number, a: string) {} };          // tsc: TS2300 x2, tsz was silent
```

Structural rule: when a function-like signature repeats a parameter name, tsc
reports `TS2300` on every occurrence. tsz owns this in `check_duplicate_parameters`
(`crates/tsz-checker/src/checkers/parameter_checker.rs`). Arrow functions,
function expressions and accessors reach their signature grammar checks through
`get_type_of_function` (`types/function_type.rs`), and object-literal methods
through the object-literal computation — both already run the sibling checks
(`check_parameter_ordering`, rest-parameter typing) but never invoked the
duplicate check. This PR wires `check_duplicate_parameters` in alongside them,
next to the existing `check_parameter_ordering` at each site. The declaration
forms keep getting it through their own paths (the `function_type.rs` site is
gated `!is_function_declaration && !is_method_or_constructor`), so nothing
double-reports.

Scope: this closes the *call-site* gap for simple (identifier) parameters. Two
neighbouring gaps are pre-existing, affect the declaration forms too, and are
left for a follow-up: duplicate *binding-pattern* names
(`function f({ a, a }) {}` — even on a function declaration) and the
function-*type* form (`type F = (a, a) => void`) reporting one occurrence
instead of two.

## Goal
Goal: hold

## Verification
- New test `duplicate_parameter_names_function_expression_forms_tests` (9 tests),
  oracle-pinned against `typescript@7.0.2` (`--noEmit --strict`): arrow /
  function-expression / object-literal-method / nested-arrow / statement-position
  function expression report `TS2300` once per occurrence; renamed binders
  behave identically; declaration forms still report exactly two (no
  double-report); distinct params and get/set accessors stay clean.
- `cargo nextest run -p tsz-checker --lib`: all passing (10158 tests on the
  merge base), 0 failed.
- `cargo clippy -p tsz-checker --all-targets`: clean.
- `python3 scripts/arch/arch_guard.py`: passed (`function_type.rs` kept under
  the 2000-line ceiling).
- Differential vs the pinned `typescript@7.0.2` oracle across arrow / fnexpr /
  objmethod / accessor / function-declaration / method / constructor / interface
  witnesses: tsz now matches tsc; no false positives on clean signatures.
- Emit and conformance suites were not run locally (TypeScript submodule not
  present in this environment). The change is checker-only — the emitter
  (`crates/tsz-emitter`) is untouched, so JS/DTS emit is unaffected — and it is a
  diagnostic *addition* that matches `tsc` exactly with no false positives, so
  conformance can only move toward parity.

## Provenance
Machine: cloud
Assistant: claude-code
Model: Claude (Claude Code)
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_019ANKuEJh1wiFhUTcy9oELA)_