### PR TITLE
fix(solver): carry merged-intersection origin through the conditional object-operand normalizer (#16095)

### DIFF
--- a/crates/tsz-checker/tests/conditional_extends_redundant_intersection_identity_tests.rs
+++ b/crates/tsz-checker/tests/conditional_extends_redundant_intersection_identity_tests.rs
@@ -121,12 +121,57 @@ fn intersection_member_order_does_not_affect_identity() {
 // intersections over the same members stay identical.
 // ---------------------------------------------------------------------------
 
-// NOT covered here, and deliberately: `{ a: 1 } & { a: 1 | number }` vs
-// `{ a: 1 }`. When the merge result is structurally equal to one of the
-// members it *is* that member's interned type, so no distinguishing origin can
-// be recorded without making every plain `{ a: 1 }` claim an intersection
-// provenance it does not have. tsc reports TS2344 there; tsz still answers EQ.
-// Tracked as the remaining half of #16095.
+// The subsumed-member object row (#16095). `{ a: 1 } & { a: 1 | number }` vs
+// `{ a: 1 }`: the two objects merge into one synthesized shape whose sole
+// property `a` is the *unreduced* intersection `1 & (1 | number)`, and the
+// interner records the pre-merge members as the merge origin. tsc keeps the
+// written `IntersectionType` distinct from the plain `{ a: 1 }`, so the higher-
+// order probe must answer DIFF; tsz used to answer EQ because evaluation
+// reduced the property `1 & (1 | number)` to `1`, collapsing the merged object
+// to the plain `{ a: 1 }` before the extends-clause identity guard ever ran.
+#[test]
+fn redundant_object_intersection_is_not_identical_to_its_subsumed_member() {
+    let source = format!(
+        "{IF_EQUALS_PRELUDE}\n\
+        type R = IfEquals<{{ a: 1 }} & {{ a: 1 | number }}, {{ a: 1 }}, \"EQ\", \"DIFF\">;\n\
+        const r: R = \"DIFF\";\n"
+    );
+    let diags = check(&source);
+    assert!(
+        error_codes(&diags).is_empty(),
+        "A redundant object intersection and its subsumed member are different types to tsc's isTypeIdenticalTo; got: {diags:#?}"
+    );
+}
+
+#[test]
+fn redundant_object_intersection_under_alpha_renamed_type_parameters() {
+    let source = r#"
+type Equal<L, R, T = "EQ", F = "DIFF"> =
+  (<U>() => U extends L ? 1 : 2) extends
+  (<U>() => U extends R ? 1 : 2) ? T : F;
+type R = Equal<{ p: 2 } & { p: 2 | string }, { p: 2 }>;
+const r: R = "DIFF";
+"#;
+    let diags = check(source);
+    assert!(
+        error_codes(&diags).is_empty(),
+        "Renamed binders must not change the object-intersection identity answer; got: {diags:#?}"
+    );
+}
+
+#[test]
+fn redundant_object_intersection_is_not_identical_to_the_wider_member_either() {
+    let source = format!(
+        "{IF_EQUALS_PRELUDE}\n\
+        type R = IfEquals<{{ a: 1 }} & {{ a: 1 | number }}, {{ a: 1 | number }}, \"EQ\", \"DIFF\">;\n\
+        const r: R = \"DIFF\";\n"
+    );
+    let diags = check(&source);
+    assert!(
+        error_codes(&diags).is_empty(),
+        "The merge kept the narrower property, so pin the wider-member side too; got: {diags:#?}"
+    );
+}
 
 #[test]
 fn merged_object_intersection_is_not_identical_to_the_flattened_object() {

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -135,7 +135,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             index.value_type = v;
         }
 
-        if with_index {
+        let result = if with_index {
             self.interner().object_with_index(ObjectShape {
                 flags,
                 properties,
@@ -147,6 +147,56 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         } else {
             self.interner()
                 .object_with_flags_and_symbol(properties, flags, symbol)
+        };
+
+        // Re-interning the object under evaluated property types produces a
+        // fresh `TypeId` that has no provenance of its own. Carry the source's
+        // merged-intersection origin (and its display alias) across so an
+        // eagerly merged object intersection stays recoverable as an
+        // intersection after its members reduce.
+        //
+        // Without this, `{ a: 1 } & { a: 1 | number }` — merged at intern time
+        // into `{ a: 1 & (1 | number) }` with a recorded origin — loses that
+        // origin here once the property intersection evaluates to `1`, leaving
+        // a bare object that the conditional extends-clause identity guard
+        // (`intersection_member_set`) can no longer distinguish from a plain
+        // `{ a: 1 }`. tsc keeps the written `IntersectionType` distinct from
+        // the flattened object under `isTypeIdenticalTo`, so the higher-order
+        // `Equal<A & M, A>` probe must answer `false` (#16095).
+        self.propagate_merged_object_operand_provenance(type_id, result);
+
+        result
+    }
+
+    /// Carry merged-intersection provenance from a conditional object operand to
+    /// the re-interned, property-evaluated `result`. First-write-wins on the
+    /// interner side, so this is a no-op when `result` already carries its own
+    /// origin (or when `result` is unchanged from `source`).
+    fn propagate_merged_object_operand_provenance(&mut self, source: TypeId, result: TypeId) {
+        if source == result {
+            return;
+        }
+        let Some(origin) = self.interner().get_merged_intersection_origin(source) else {
+            return;
+        };
+        // Never stamp an intersection origin onto a `result` that is itself one
+        // of the origin's own members. Once a property intersection reduces, the
+        // re-interned object can hash-cons to a plain member (`{ a: 1 } & { a: 1
+        // | number }` → `{ a: 1 }`), and that member `TypeId` is shared with
+        // every unrelated `{ a: 1 }` in the program. Giving it a phantom
+        // intersection provenance would mis-elaborate diagnostics on code that
+        // never wrote an intersection. This mirrors the guard in
+        // `normalize_intersection` that records an origin only for a genuinely
+        // distinct merged object.
+        if let Some(TypeData::Intersection(list)) = self.interner().lookup(origin)
+            && self.interner().type_list(list).contains(&result)
+        {
+            return;
+        }
+        self.interner()
+            .store_merged_intersection_origin(result, origin);
+        if let Some(alias) = self.interner().get_display_alias(source) {
+            self.interner().store_display_alias(result, alias);
         }
     }
 


### PR DESCRIPTION
Fixes the remaining **subsumed-object row** of #16095 (the last open half after #16096 / #16101 / #16575).

## Structural rule

When an object intersection has a member that subsumes the whole — `{ a: 1 } & { a: 1 | number }`, where `{ a: 1 } <: { a: 1 | number }` — `tsc` keeps it as a distinct `IntersectionType`; `isTypeIdenticalTo` reports it and the plain `{ a: 1 }` as **different type nodes**, so the higher-order `Equal<A & M, A>` probe answers `false`. tsz answered `true`.

Root cause (measured on a dev build, not inferred — the earlier hash-consing explanation was already retracted in the issue thread):

- `{ a: 1 } & { a: 1 | number }` merges at intern time into a distinct object `{ a: 1 & (1 | number) }` that **does** record a merge origin (`store_merged_intersection_origin`).
- `resolve_operands` runs `normalize_conditional_object_operand` on the evaluated conditional extends-type, which re-interns the object under evaluated property types (`1 & (1 | number)` → `1`). The re-interned object is structurally the subsumed member and **carried no provenance**, so the extends-clause identity guard (`intersection_member_set`) read `(None, None)` and the mutual-assignability fallback re-admitted identity → false `EQ`.

The interner already preserves this origin across interning and across *instantiation* (`propagate_instantiated_merged_intersection_origin`); the conditional-operand normalizer was the one rebuild site with no provenance-carry step.

## Fix

`normalize_conditional_object_operand` now propagates the source object's merged-intersection origin (and its display alias) to the re-interned, property-evaluated result — first-write-wins, and only when the object actually changed. It **skips** stamping when the result hash-consed to one of the origin's own members (that `TypeId` is shared with every plain object of the same shape, so a phantom intersection provenance would mis-elaborate unrelated diagnostics — mirrors the guard `normalize_intersection` uses when recording the origin). The identity guard then recovers `{ {a:1}, {a:1|number} }` for the merged operand and `None` for the plain `{ a: 1 }`, yielding DIFF. This is the object-family analogue of #16575's array/tuple fix, one layer up (evaluation-time provenance instead of intern-time reduction veto).

Adjacent coverage added next to the existing array/tuple pins in `conditional_extends_redundant_intersection_identity_tests`: subsumed narrower member, subsumed **wider** member, and alpha-renamed binders. The stale "NOT covered here" note for this row is replaced by the live tests.

## Goal
Goal: hold

## Verification
- **`conditional_extends_redundant_intersection_identity_tests`: 19/19 pass** — the 3 new object-subsumed rows are live; array/tuple/object controls unchanged.
- **`cargo test -p tsz-solver --lib`: 7650 passed, 0 failed.**
- **Checker diagnostic-elaboration modules: 1072 passed, 0 failed** (`ts2322 ts2344 ts2345 ts2416 ts2741 equal identity display_alias`), plus `conditional` 246 and `intersection` 247 — these exercise the error-reporter merge-origin path the fix touches. (The full `-p tsz-checker --lib` suite exceeds 40 min on this 4-core container and could not complete locally; the 12043-test conformance corpus below — far more type-checking work — ran in ~10 min, so this is a box limitation, not a perf regression.)
- **Conformance (`conformance.sh snapshot`, vs committed baseline): 11499 passed, 0 regressions, net +1.**
  - `expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts`: **FAIL → PASS** — the fix removed a spurious false-positive `TS2322`.
  - `es6/destructuring/declarationsAndAssignments.ts`: FAIL → FAIL (unchanged pass state) — an already-failing test where an emitted code shifted `TS2322` → `TS2741`; both are in tsc's expected set for this file, and `TS2741` is the more specific property-level elaboration. Deterministic across runs; not member-collision pollution (the member guard above leaves it unchanged).
- **Emit** (`scripts/emit/run.sh`): could not run locally — the runner's npm dependency-install step hangs on this container's network across three attempts. The change is emit-neutral (solver-only conditional-type evaluation; the emitter does no semantic validation and cannot alter JS/DTS byte output), so the floor is unaffected; covered by nightly CI.
- Pre-commit gate: **fmt + clippy (`-p tsz-solver`) + architecture guard passed.**

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high