### PR TITLE
fix(checker): every element target of an array destructuring assignment is judged against its source element type (TS2322)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
@@ -731,12 +731,17 @@ impl<'a> CheckerState<'a> {
                                 target_idx,
                             );
                         }
-                    } else if self.ctx.no_unchecked_indexed_access() && !is_spread {
+                    } else if self.ctx.no_unchecked_indexed_access() {
                         // With noUncheckedIndexedAccess, the element type includes
                         // `| undefined`. Check that this augmented type is assignable
                         // to the target variable's declared type. E.g.,
                         // `[target_string] = strArray` should error when
                         // `target_string: string` but element type is `string | undefined`.
+                        //
+                        // This branch owns the flag because the augmented
+                        // `check_type` is the thing being judged; the general
+                        // branch below re-resolves the element type from
+                        // `source_type` and would drop the added `undefined`.
                         let target_type = self.get_type_of_assignment_target(target_idx);
                         if target_type != TypeId::ANY
                             && target_type != TypeId::ERROR
@@ -749,6 +754,46 @@ impl<'a> CheckerState<'a> {
                                 check_type,
                                 target_type,
                                 target_idx,
+                                target_idx,
+                            );
+                        }
+                    } else {
+                        // tsc's `checkArrayLiteralDestructuringElementAssignment`
+                        // judges every non-spread element target against the
+                        // source's element type at that index, exactly as the
+                        // object half of this walk judges each property target.
+                        // tsz ran that check only under `noUncheckedIndexedAccess`,
+                        // so an ordinary `[a, b] = [b, a]` reported nothing: the
+                        // whole-pattern relation is deliberately skipped for
+                        // destructuring assignments — tsc processes elements
+                        // individually — and no per-element judgement replaced it.
+                        //
+                        // `check_destructuring_leaf_assignability*` is the shared
+                        // leaf owner already used by the object half. It resolves
+                        // the source type by numeric index, applies tsc's
+                        // default-initializer rule (for `[s = 2] = [s]` the
+                        // *default* is what fails against the target), and anchors
+                        // TS2322 on the target rather than on the whole pattern.
+                        let index_key = index.to_string();
+                        let default_shape = self.ctx.arena.get(target_idx).and_then(|node| {
+                            if node.kind != syntax_kind_ext::BINARY_EXPRESSION {
+                                return None;
+                            }
+                            let bin = self.ctx.arena.get_binary_expr(node)?;
+                            (bin.operator_token == SyntaxKind::EqualsToken as u16)
+                                .then_some((bin.left, bin.right))
+                        });
+                        if let Some((leaf_idx, default_idx)) = default_shape {
+                            self.check_destructuring_leaf_assignability_with_default(
+                                &index_key,
+                                source_type,
+                                leaf_idx,
+                                default_idx,
+                            );
+                        } else {
+                            self.check_destructuring_leaf_assignability(
+                                &index_key,
+                                source_type,
                                 target_idx,
                             );
                         }

--- a/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
@@ -470,6 +470,21 @@ impl<'a> CheckerState<'a> {
         pattern_idx: NodeIndex,
         source_type: TypeId,
     ) {
+        self.check_destructuring_pattern_against_source(pattern_idx, source_type, true);
+    }
+
+    /// `positional_source` records whether `source_type` still supports asking
+    /// "what is the type at element index `i`". It is true for the type a
+    /// pattern is destructured from directly and for every type reached by a
+    /// property or element lookup on it, and false once a rest element has
+    /// collapsed a positional slice into an array — see the element judgement
+    /// at the end of the array walk, which is the only reader.
+    fn check_destructuring_pattern_against_source(
+        &mut self,
+        pattern_idx: NodeIndex,
+        source_type: TypeId,
+        positional_source: bool,
+    ) {
         if source_type == TypeId::ANY || source_type == TypeId::ERROR {
             return;
         }
@@ -518,9 +533,10 @@ impl<'a> CheckerState<'a> {
                                 let prop_type = self
                                     .resolve_property_type_for_destructuring(source_type, &name);
                                 if let Some(prop_type) = prop_type {
-                                    self.check_destructuring_property_accessibility(
+                                    self.check_destructuring_pattern_against_source(
                                         prop.initializer,
                                         prop_type,
+                                        positional_source,
                                     );
                                 }
                             } else if value_node.kind == syntax_kind_ext::BINARY_EXPRESSION {
@@ -539,8 +555,10 @@ impl<'a> CheckerState<'a> {
                                                 &name,
                                             );
                                         if let Some(prop_type) = prop_type {
-                                            self.check_destructuring_property_accessibility(
-                                                bin.left, prop_type,
+                                            self.check_destructuring_pattern_against_source(
+                                                bin.left,
+                                                prop_type,
+                                                positional_source,
                                             );
                                         }
                                     } else {
@@ -695,7 +713,15 @@ impl<'a> CheckerState<'a> {
                     if target_node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
                         || target_node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
                     {
-                        self.check_destructuring_property_accessibility(target_idx, check_type);
+                        // A rest element's own pattern is destructured from the
+                        // *slice* type, which today falls back to the whole
+                        // source when that source is not a tuple — so element
+                        // index `i` inside it no longer names a position.
+                        self.check_destructuring_pattern_against_source(
+                            target_idx,
+                            check_type,
+                            positional_source && !is_spread,
+                        );
                     } else if target_node.kind == syntax_kind_ext::BINARY_EXPRESSION
                         && let Some(bin) = self.ctx.arena.get_binary_expr(target_node)
                         && bin.operator_token == SyntaxKind::EqualsToken as u16
@@ -703,7 +729,11 @@ impl<'a> CheckerState<'a> {
                         && (lhs_node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
                             || lhs_node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION)
                     {
-                        self.check_destructuring_property_accessibility(bin.left, check_type);
+                        self.check_destructuring_pattern_against_source(
+                            bin.left,
+                            check_type,
+                            positional_source && !is_spread,
+                        );
                     } else if is_spread {
                         // For spread elements targeting simple expressions (identifiers,
                         // property accesses), check that the rest type is assignable to
@@ -774,6 +804,35 @@ impl<'a> CheckerState<'a> {
                         // default-initializer rule (for `[s = 2] = [s]` the
                         // *default* is what fails against the target), and anchors
                         // TS2322 on the target rather than on the whole pattern.
+                        //
+                        // Two source shapes cannot answer "what is the type at
+                        // index `i`" today, and a judgement made against what
+                        // they *do* answer is a false positive rather than a
+                        // weaker one:
+                        //
+                        //   - a non-positional source (`positional_source`),
+                        //     which is a rest element's slice that fell back to
+                        //     the whole array — every index then reports the
+                        //     merged element type, so `[...[a, b = 0]] = ["", 1]`
+                        //     would judge both bindings against `string | number`;
+                        //   - a union source, where tsc's element type is the
+                        //     union of each constituent's element at that index
+                        //     (`[boolean] | [string, number]` has `string |
+                        //     boolean` at 0), while the array fallback here
+                        //     flattens every position of every constituent
+                        //     together.
+                        //
+                        // Both make no judgement rather than a wrong one; the
+                        // precise element types they need are follow-up work at
+                        // the rest-slice and union-constituent owners.
+                        if !positional_source
+                            || crate::query_boundaries::common::is_union_type(
+                                self.ctx.types,
+                                source_type,
+                            )
+                        {
+                            continue;
+                        }
                         let index_key = index.to_string();
                         let default_shape = self.ctx.arena.get(target_idx).and_then(|node| {
                             if node.kind != syntax_kind_ext::BINARY_EXPRESSION {

--- a/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
@@ -876,6 +876,13 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Resolve the element type at a given index from an array/tuple type.
+    ///
+    /// A rest element (`[string, ...number[]]`) holds the *array* type it was
+    /// written as, so every position it covers has that array's element type,
+    /// not the array itself. Positions after a rest element that is not last
+    /// (`[string, ...number[], boolean]`) have no fixed index at all, and get
+    /// `None` rather than the element that happens to sit at that offset in the
+    /// declaration.
     fn resolve_element_type_for_destructuring(
         &mut self,
         source_type: TypeId,
@@ -885,6 +892,19 @@ impl<'a> CheckerState<'a> {
         if let Some(elems) =
             crate::query_boundaries::common::tuple_elements(self.ctx.types, source_type)
         {
+            let first_rest = elems.iter().position(|elem| elem.rest);
+            if let Some(first_rest) = first_rest
+                && index >= first_rest
+            {
+                // Only a trailing rest keeps later positions determinate.
+                if first_rest + 1 != elems.len() {
+                    return None;
+                }
+                return crate::query_boundaries::common::array_element_type(
+                    self.ctx.types,
+                    elems[first_rest].type_id,
+                );
+            }
             if index < elems.len() {
                 return Some(elems[index].type_id);
             }

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -29,6 +29,8 @@ mod application_target_any_arg_assignability_tests;
 mod application_unknown_args_assignability_tests;
 #[path = "tests/architecture_contract_tests.rs"]
 mod architecture_contract_tests_src;
+#[path = "tests/array_destructuring_assignment_element_ts2322_tests.rs"]
+mod array_destructuring_assignment_element_ts2322_tests;
 #[path = "tests/array_elaboration_relation_routing_arch_tests.rs"]
 mod array_elaboration_relation_routing_arch_tests;
 #[path = "tests/array_like_constraint_relation_routing_arch_tests.rs"]

--- a/crates/tsz-checker/src/tests/array_destructuring_assignment_element_ts2322_tests.rs
+++ b/crates/tsz-checker/src/tests/array_destructuring_assignment_element_ts2322_tests.rs
@@ -393,3 +393,89 @@ fn a_rest_element_with_a_simple_target_still_reports() {
     let source = "\ndeclare let s: string;\ndeclare let sa: string[];\n[s, ...sa] = [s, s];\n";
     assert_eq!(ts2322(source), vec![]);
 }
+
+// ---------------------------------------------------------------------------
+// Rest elements in the SOURCE tuple. A rest element holds the array type it was
+// written as, so every position it covers has that array's element type — not
+// the array itself. Reduced from conformance/types/tuple/unionsOfTupleTypes1.ts,
+// which regressed on the second revision of this change.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_trailing_rest_element_supplies_its_element_type_not_the_array() {
+    // `T3 = [string, ...number[]]` — index 1 and index 2 are both `number`.
+    // Handing back the rest element's `number[]` reported a false TS2322 on
+    // `d31` reading `Type 'number[]' is not assignable to type 'number'.`
+    let source = concat!(
+        "\ntype T3 = [string, ...number[]];",
+        "\ndeclare let d30: string;",
+        "\ndeclare let d31: number;",
+        "\ndeclare let d32: number;",
+        "\ndeclare let t3: T3;",
+        "\n[d30, d31, d32] = t3;\n"
+    );
+    assert_eq!(ts2322(source), vec![]);
+}
+
+#[test]
+fn a_trailing_rest_element_still_reports_a_real_mismatch() {
+    // The same source, but the target at the rest position is a `string`:
+    // tsc reports `Type 'number' is not assignable to type 'string'.` — so the
+    // fix above is "use the element type", not "stop judging rest positions".
+    let source = concat!(
+        "\ntype C = [string, ...number[]];",
+        "\ndeclare let c0: string;",
+        "\ndeclare let c1: string;",
+        "\ndeclare let tc: C;",
+        "\n[c0, c1] = tc;\n"
+    );
+    assert_eq!(
+        ts2322(source),
+        vec![(
+            2322,
+            offset_of(source, "[c0, c1] =", 0) + 5,
+            "c1".to_string(),
+            "Type 'number' is not assignable to type 'string'.".to_string(),
+        )],
+    );
+}
+
+#[test]
+fn a_rest_position_target_typed_as_the_array_is_the_inverse_mismatch() {
+    // The exact inverse of the regression: a target declared `number[]` at a
+    // rest position must now FAIL, where handing back the rest array made it
+    // silently pass. tsc: `Type 'number' is not assignable to type 'number[]'.`
+    let source = concat!(
+        "\ndeclare let d0: number[];",
+        "\ndeclare let td: [string, ...number[]];",
+        "\n[, d0] = td;\n"
+    );
+    assert_eq!(
+        ts2322(source),
+        vec![(
+            2322,
+            offset_of(source, "[, d0] =", 0) + 3,
+            "d0".to_string(),
+            "Type 'number' is not assignable to type 'number[]'.".to_string(),
+        )],
+    );
+}
+
+#[test]
+fn a_rest_element_that_is_not_last_makes_no_positional_judgement() {
+    // `[string, ...number[], boolean]` — tsc gives position 1 and 2 the union
+    // `number | boolean` and reports two TS2322 here. Positions after a
+    // non-trailing rest have no fixed index, so this makes no judgement rather
+    // than judging against whichever element sits at that declaration offset;
+    // the two diagnostics tsc reports are a known missing-diagnostic residual,
+    // not a false positive.
+    let source = concat!(
+        "\ntype B = [string, ...number[], boolean];",
+        "\ndeclare let b0: string;",
+        "\ndeclare let b1: number;",
+        "\ndeclare let b2: boolean;",
+        "\ndeclare let tb: B;",
+        "\n[b0, b1, b2] = tb;\n"
+    );
+    assert_eq!(ts2322(source), vec![]);
+}

--- a/crates/tsz-checker/src/tests/array_destructuring_assignment_element_ts2322_tests.rs
+++ b/crates/tsz-checker/src/tests/array_destructuring_assignment_element_ts2322_tests.rs
@@ -1,0 +1,351 @@
+//! TS2322 parity for the elements of an array destructuring **assignment**.
+//!
+//! Structural rule: when an array destructuring assignment pattern's element is
+//! a non-spread target (an identifier, a property access, an element access, or
+//! any of those carrying a default), `tsc` judges the source's element type at
+//! that index against the target's own type and reports TS2322 anchored on the
+//! target — `checkArrayLiteralDestructuringElementAssignment`, the array half of
+//! the same walk that already judges each property target of an object pattern.
+//! tsz runs that judgement through the checker's shared destructuring
+//! leaf-assignability owner.
+//!
+//! The whole-pattern relation is deliberately skipped for destructuring
+//! assignments (`assignment_ops.rs`: "tsc processes each property/element
+//! individually"), so before this fix nothing at all was reported for the plain
+//! `[a, b] = [b, a]` shape — the per-element judgement only ran when
+//! `noUncheckedIndexedAccess` was on.
+//!
+//! Every expectation here is pinned against `typescript@7.0.2`, the version in
+//! `scripts/conformance/typescript-versions.json`. The witness comes from
+//! `conformance/es6/destructuring/declarationsAndAssignments.ts`, whose `f18`
+//! row expects exactly this pair of diagnostics.
+//!
+//! The decision is structural, never keyed on a binder's name: the renamed-
+//! binder case below writes the same shape with different identifiers and
+//! expects the same two diagnostics.
+
+use crate::test_utils::check_source_non_strict;
+
+/// `(code, anchor byte offset, anchored source text, message)` for every
+/// diagnostic, in source order.
+///
+/// The offset is part of the row on purpose: an assertion that discards
+/// position cannot tell "two targets each reported once" from "one target
+/// reported twice", and this family reports one diagnostic per element.
+fn rows(source: &str) -> Vec<(u32, u32, String, String)> {
+    let mut out: Vec<(u32, u32, String, String)> = check_source_non_strict(source)
+        .into_iter()
+        .map(|d| {
+            let start = d.start as usize;
+            let end = start + d.length as usize;
+            let text = source.get(start..end).unwrap_or_default().to_string();
+            (d.code, d.start, text, d.message_text)
+        })
+        .collect();
+    out.sort_by_key(|row| row.1);
+    out
+}
+
+/// Byte offset of the `nth` (0-based) occurrence of `needle` in `source`.
+fn offset_of(source: &str, needle: &str, nth: usize) -> u32 {
+    let mut from = 0usize;
+    for _ in 0..nth {
+        from = source[from..].find(needle).expect("needle occurrence") + from + needle.len();
+    }
+    u32::try_from(source[from..].find(needle).expect("needle occurrence") + from).expect("offset")
+}
+
+fn ts2322(source: &str) -> Vec<(u32, u32, String, String)> {
+    rows(source).into_iter().filter(|r| r.0 == 2322).collect()
+}
+
+// ---------------------------------------------------------------------------
+// The witness: the conformance row's own shape.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn swapped_element_targets_each_report_their_own_ts2322() {
+    // conformance/es6/destructuring/declarationsAndAssignments.ts, `f18`.
+    // tsc 7.0.2:
+    //   (4,2): Type 'string' is not assignable to type 'number'.
+    //   (4,5): Type 'number' is not assignable to type 'string'.
+    let source = "\ndeclare let n: number;\ndeclare let s: string;\n[n, s] = [s, n];\n";
+    let pattern = offset_of(source, "[n, s]", 0);
+    assert_eq!(
+        ts2322(source),
+        vec![
+            (
+                2322,
+                pattern + 1,
+                "n".to_string(),
+                "Type 'string' is not assignable to type 'number'.".to_string(),
+            ),
+            (
+                2322,
+                pattern + 4,
+                "s".to_string(),
+                "Type 'number' is not assignable to type 'string'.".to_string(),
+            ),
+        ],
+    );
+}
+
+#[test]
+fn renamed_binders_report_the_same_two_diagnostics() {
+    // Same shape, different identifiers: the rule is positional, not name-driven.
+    let source = "\ndeclare let alpha: number;\ndeclare let omega: string;\n[alpha, omega] = [omega, alpha];\n";
+    let pattern = offset_of(source, "[alpha, omega] =", 0);
+    assert_eq!(
+        ts2322(source),
+        vec![
+            (
+                2322,
+                pattern + 1,
+                "alpha".to_string(),
+                "Type 'string' is not assignable to type 'number'.".to_string(),
+            ),
+            (
+                2322,
+                pattern + 8,
+                "omega".to_string(),
+                "Type 'number' is not assignable to type 'string'.".to_string(),
+            ),
+        ],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Source spellings: the element type comes from a tuple, an array, or a
+// literal, and all three reach the same judgement.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tuple_typed_source_variable_reports_per_element() {
+    let source = "\ndeclare let n: number;\ndeclare let s: string;\ndeclare let tup: [string, number];\n[n, s] = tup;\n";
+    let pattern = offset_of(source, "[n, s] = tup", 0);
+    assert_eq!(
+        ts2322(source),
+        vec![
+            (
+                2322,
+                pattern + 1,
+                "n".to_string(),
+                "Type 'string' is not assignable to type 'number'.".to_string(),
+            ),
+            (
+                2322,
+                pattern + 4,
+                "s".to_string(),
+                "Type 'number' is not assignable to type 'string'.".to_string(),
+            ),
+        ],
+    );
+}
+
+#[test]
+fn array_typed_source_variable_reports_its_element_type() {
+    // An unbounded `string[]` source: every index has element type `string`.
+    let source = "\ndeclare let n: number;\ndeclare let sa: string[];\n[n] = sa;\n";
+    assert_eq!(
+        ts2322(source),
+        vec![(
+            2322,
+            offset_of(source, "[n] = sa", 0) + 1,
+            "n".to_string(),
+            "Type 'string' is not assignable to type 'number'.".to_string(),
+        )],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Target spellings other than a bare identifier.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn element_access_target_is_judged_like_an_identifier() {
+    let source = "\ndeclare let n: number;\ndeclare let s: string;\ndeclare let na: number[];\n[na[0], s] = [s, n];\n";
+    let pattern = offset_of(source, "[na[0], s]", 0);
+    assert_eq!(
+        ts2322(source),
+        vec![
+            (
+                2322,
+                pattern + 1,
+                "na[0]".to_string(),
+                "Type 'string' is not assignable to type 'number'.".to_string(),
+            ),
+            (
+                2322,
+                pattern + 8,
+                "s".to_string(),
+                "Type 'number' is not assignable to type 'string'.".to_string(),
+            ),
+        ],
+    );
+}
+
+#[test]
+fn property_access_target_is_judged_like_an_identifier() {
+    let source = "\ndeclare let n: number;\ndeclare let s: string;\ndeclare let o: { p: number };\n[o.p, s] = [s, n];\n";
+    let pattern = offset_of(source, "[o.p, s]", 0);
+    // The anchored slice for the first row is `o.p,` — one token too long. A
+    // property-access node used as an array-pattern element ends at the token
+    // AFTER it, so the span swallows the `,` here and the `]` in the control
+    // below. That end is the parser's to fix (the `#16251`/`#16259` node-span
+    // family), not this judgement's, and it is deliberately left alone here:
+    // the reported *start* is correct in both spellings, and start is what
+    // tsc's line/column and the conformance fingerprint are scored on. Pinned
+    // rather than papered over so the follow-up has a live witness.
+    assert_eq!(
+        ts2322(source),
+        vec![
+            (
+                2322,
+                pattern + 1,
+                "o.p,".to_string(),
+                "Type 'string' is not assignable to type 'number'.".to_string(),
+            ),
+            (
+                2322,
+                pattern + 6,
+                "s".to_string(),
+                "Type 'number' is not assignable to type 'string'.".to_string(),
+            ),
+        ],
+    );
+}
+
+#[test]
+fn property_access_target_span_over_extends_by_one_token() {
+    // Control for the span quirk noted above: the extra character is whatever
+    // token follows the target, so as the only element it swallows the `]`
+    // rather than a comma. Same correct start, same message.
+    let source = "\ndeclare let s: string;\ndeclare let o: { p: number };\n[o.p] = [s];\n";
+    assert_eq!(
+        ts2322(source),
+        vec![(
+            2322,
+            offset_of(source, "[o.p] =", 0) + 1,
+            "o.p]".to_string(),
+            "Type 'string' is not assignable to type 'number'.".to_string(),
+        )],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Defaults: tsc judges the DEFAULT against the target, and leaves the element
+// alone when the source supplies it.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_default_that_mismatches_reports_the_defaults_type() {
+    // tsc 7.0.2 reports exactly one diagnostic here, on `s`, about the default
+    // `2` — the source element for index 1 is a `string` and is fine.
+    let source = "\ndeclare let n: number;\ndeclare let s: string;\n[n = 1, s = 2] = [n, s];\n";
+    assert_eq!(
+        ts2322(source),
+        vec![(
+            2322,
+            offset_of(source, "[n = 1, s = 2]", 0) + 8,
+            "s".to_string(),
+            "Type 'number' is not assignable to type 'string'.".to_string(),
+        )],
+    );
+}
+
+#[test]
+fn a_matching_default_is_clean() {
+    // conformance/es6/destructuring/declarationsAndAssignments.ts, `f18`'s last
+    // row: `[a = 1, b = "abc"] = [2, "def"];` is clean under tsc.
+    let source =
+        "\ndeclare let n: number;\ndeclare let s: string;\n[n = 1, s = \"abc\"] = [2, \"def\"];\n";
+    assert_eq!(ts2322(source), vec![]);
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls — shapes that must stay clean, so the new judgement cannot
+// be read as "report whenever the element list is not identical".
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_well_typed_swap_free_assignment_is_clean() {
+    let source = "\ndeclare let n: number;\ndeclare let s: string;\n[n, s] = [n, s];\n";
+    assert_eq!(ts2322(source), vec![]);
+}
+
+#[test]
+fn an_any_source_is_clean() {
+    let source =
+        "\ndeclare let n: number;\ndeclare let s: string;\ndeclare let a: any;\n[n, s] = a;\n";
+    assert_eq!(ts2322(source), vec![]);
+}
+
+#[test]
+fn an_any_typed_target_is_clean() {
+    let source = "\ndeclare let a: any;\ndeclare let s: string;\n[a, s] = [s, s];\n";
+    assert_eq!(ts2322(source), vec![]);
+}
+
+#[test]
+fn a_widening_union_target_accepts_both_element_types() {
+    let source = "\ndeclare let u: number | string;\ndeclare let v: number | string;\n[u, v] = [1, \"x\"];\n";
+    assert_eq!(ts2322(source), vec![]);
+}
+
+#[test]
+fn an_omitted_element_does_not_shift_the_index() {
+    // `[, s] = [n, n]` — the hole occupies index 0, so `s` is judged against
+    // index 1 (`number`), not index 0. tsc reports one diagnostic, on `s`.
+    let source = "\ndeclare let n: number;\ndeclare let s: string;\n[, s] = [n, n];\n";
+    assert_eq!(
+        ts2322(source),
+        vec![(
+            2322,
+            offset_of(source, "[, s] =", 0) + 3,
+            "s".to_string(),
+            "Type 'number' is not assignable to type 'string'.".to_string(),
+        )],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Nesting: the element judgement must not swallow the recursion that already
+// handles nested patterns, and must not fire on the pattern node itself.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_nested_array_pattern_reports_inside_the_nested_pattern() {
+    let source = "\ndeclare let n: number;\ndeclare let s: string;\n[[n], s] = [[s], n];\n";
+    let pattern = offset_of(source, "[[n], s]", 0);
+    assert_eq!(
+        ts2322(source),
+        vec![
+            (
+                2322,
+                pattern + 2,
+                "n".to_string(),
+                "Type 'string' is not assignable to type 'number'.".to_string(),
+            ),
+            (
+                2322,
+                pattern + 6,
+                "s".to_string(),
+                "Type 'number' is not assignable to type 'string'.".to_string(),
+            ),
+        ],
+    );
+}
+
+#[test]
+fn a_nested_object_pattern_in_an_element_slot_reports_on_its_leaf() {
+    let source = "\ndeclare let n: number;\ndeclare let s: string;\n[{ p: n }] = [{ p: s }];\n";
+    assert_eq!(
+        ts2322(source),
+        vec![(
+            2322,
+            offset_of(source, "[{ p: n }] =", 0) + 6,
+            "n".to_string(),
+            "Type 'string' is not assignable to type 'number'.".to_string(),
+        )],
+    );
+}

--- a/crates/tsz-checker/src/tests/array_destructuring_assignment_element_ts2322_tests.rs
+++ b/crates/tsz-checker/src/tests/array_destructuring_assignment_element_ts2322_tests.rs
@@ -349,3 +349,47 @@ fn a_nested_object_pattern_in_an_element_slot_reports_on_its_leaf() {
         )],
     );
 }
+
+// ---------------------------------------------------------------------------
+// Sources that cannot answer "what is the type at index i" make no judgement.
+// Both rows were real conformance regressions caught by a reviewer's corpus
+// run on the first revision of this change; both are `tsc`-clean.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_rest_elements_own_pattern_is_not_judged_positionally() {
+    // conformance/es6/destructuring/restElementWithAssignmentPattern1.ts.
+    // The rest slice falls back to the whole array when the source is not a
+    // tuple, so index 0 and index 1 both report the merged `string | number`.
+    // tsc types the source as `[string, number]` and is clean; judging against
+    // the merged type would report two false TS2322.
+    let source = "\ndeclare let a: string;\ndeclare let b: number;\n[...[a, b = 0]] = [\"\", 1];\n";
+    assert_eq!(ts2322(source), vec![]);
+}
+
+#[test]
+fn a_union_of_tuples_source_is_not_judged() {
+    // conformance/types/tuple/unionsOfTupleTypes1.ts. tsc's element type at
+    // index `i` is the union of each constituent's element at `i` — for
+    // `[boolean] | [string, number]` that is `string | boolean` at 0 — while
+    // the array fallback flattens every position of every constituent into
+    // `string | number | boolean`. tsc reports no TS2322 on this row.
+    let source = concat!(
+        "\ntype T2 = [boolean] | [string, number];",
+        "\ndeclare let d20: string | boolean;",
+        "\ndeclare let d21: number | undefined;",
+        "\ndeclare let d22: undefined;",
+        "\ndeclare let t2: T2;",
+        "\n[d20, d21, d22] = t2;\n"
+    );
+    assert_eq!(ts2322(source), vec![]);
+}
+
+#[test]
+fn a_rest_element_with_a_simple_target_still_reports() {
+    // The rest *target* itself is judged by the pre-existing spread branch,
+    // which this containment does not touch: only the recursion into a rest
+    // element's own nested pattern is de-positioned.
+    let source = "\ndeclare let s: string;\ndeclare let sa: string[];\n[s, ...sa] = [s, s];\n";
+    assert_eq!(ts2322(source), vec![]);
+}


### PR DESCRIPTION
**Structural rule.** When an array destructuring *assignment* pattern's element is a non-spread target — an identifier, a property access, an element access, or any of those carrying a default — `tsc` (`checkArrayLiteralDestructuringElementAssignment`) judges the source's element type at that index against the target's own type and reports **TS2322 anchored on the target**. tsz now does the same through the checker's shared destructuring leaf-assignability owner (`assignability/assignment_checker/destructuring.rs`).

**What was wrong.** tsz ran that per-element judgement **only under `noUncheckedIndexedAccess`**. Everywhere else nothing judged the element at all: the whole-pattern relation is deliberately skipped for destructuring assignments (`assignment_ops.rs` — "tsc processes each property/element individually, which correctly handles private members"), and no per-element check replaced it on the array side. The object side of the very same walk has judged each property target all along (`check_destructuring_leaf_assignability`), so this was a both-halves blind spot, not a missing feature.

Result on current `main`, with the pinned `typescript@7.0.2` oracle beside it:

```
declare let n: number;
declare let s: string;
[n, s] = [s, n];

tsc  : (3,2) TS2322 Type 'string' is not assignable to type 'number'.
       (3,5) TS2322 Type 'number' is not assignable to type 'string'.
tsz  : (clean)
```

**Owner and mechanism.** The general branch delegates to `check_destructuring_leaf_assignability*`, the leaf owner the object half already uses, so the element case inherits its behaviour rather than growing a parallel one: numeric-index element resolution over tuples and arrays, `tsc`'s default-initializer rule (for `[s = 2] = [s]` it is the *default* that fails against the target, not the source element), the `any`/error bailouts, and the target-node anchor. The `noUncheckedIndexedAccess` branch keeps ownership of its own case because the augmented `element | undefined` type is what it judges, and re-resolving from the source would drop the added `undefined`; the two branches are mutually exclusive and the flag one is unchanged.

No name, alias, property or file-name string drives the decision — the judgement is positional (the element's index) and structural (spread vs not, pattern vs leaf). `renamed_binders_report_the_same_two_diagnostics` writes the same shape with different identifiers and expects the same two rows.

**Witness.** `conformance/es6/destructuring/declarationsAndAssignments.ts`, function `f18`. That row's expected set is `[TS2322, TS2339, TS2353, TS2403, TS2488, TS2493, TS2741]`; on `main` the actual set had lost `TS2322` entirely. Marcasite flagged it at 18:41Z as a row that moved *laterally* across #16631 — gaining the expected `TS2741`, losing the expected `TS2322`, at an unchanged 5-of-7 match count, which is exactly the shape a count-only conformance check cannot see. The `TS2322` half is what this PR restores. (`TS2403` on that row is a separate, still-open gap.)

## Goal
Goal: hold

## Verification

**Targeted unit suite (new).** `crates/tsz-checker/src/tests/array_destructuring_assignment_element_ts2322_tests.rs`, 16 rows, every expectation pinned against `typescript@7.0.2`:

```
cargo test -p tsz-checker --lib array_destructuring_assignment_element_ts2322
before: 0 tests (file did not exist); the shapes were silently clean
after : 16 passed / 0 failed
```

Rows: the witness swap; renamed binders; tuple-typed source variable; array-typed source variable; element-access target; property-access target; a mismatching default; a matching default; a well-typed swap-free assignment (clean); an `any` source (clean); an `any` target (clean); a union target that accepts both element types (clean); an omitted element that must not shift the index; a nested array pattern; a nested object pattern in an element slot; the property-access span control described below.

**Oracle matrix, `tsz` CLI vs `node typescript@7.0.2/bin/tsc --noEmit --target es2015`.** 14 shapes covering the judgement, then 10 more chosen to break it:

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `[n, s] = [s, n]` | 2 x TS2322 | — | 2 x TS2322, same anchors |
| `[n, s] = tup` (tuple variable) | 2 x TS2322 | — | matches |
| `[n] = sa` (array variable) | TS2322 | — | matches |
| `[n, s] = [n, s]` | clean | clean | clean |
| `[na[0], s] = [s, n]` | 2 x TS2322 | — | matches |
| `[o.p, s] = [s, n]` | 2 x TS2322 | — | matches |
| `[n = 1, s = 2] = [n, s]` | TS2322 on the default | — | matches |
| `[s = 2] = [s]` | TS2322 on the default | — | matches |
| `[n, s] = anyv` | clean | clean | clean |
| `[, s] = [n, n]` (hole) | TS2322 at index 1 | — | matches |
| `[[n], s] = [[s], n]` (nested array) | 2 x TS2322 | — | matches |
| `[{ p: n }] = [{ p: s }]` (nested object) | TS2322 | — | matches |
| narrowed target `let x: string \| number = 1; [x] = ["hello"]` | clean | clean | **clean** |
| `for ([a, b] of pairs)` | clean | clean | clean |
| generic `let v: T; [v] = arr` | clean | clean | clean |
| `readonly` tuple source | clean | clean | clean |
| `const r = ([n2] = [1])` (assignment as a value) | clean | clean | clean |
| `[onlyNum] = [ns]` (union into narrower) | TS2322 | — | matches (code + anchor) |
| `[this.p] = ["s"]` in a class method | TS2322 | TS2322 | unchanged |
| `[p1] = [p2] = [1]` (chained) | clean | clean | clean |

The narrowed-target row is the one that mattered most: `[x] = ["hello"]` where `x` is declared `string | number` but flow-narrowed to `number` must stay clean, and it does — the leaf owner reads the assignment target's declared type, not its narrowed one.

**Gates.**
- `cargo fmt --all` — clean.
- `cargo clippy` via the `pre-commit` hook for `-p tsz-checker` — passed, warnings denied.
- Architecture guard via the same hook — passed.
- `cargo test -p tsz-checker --lib` (whole lane, not just the filter) — running at time of opening; result posted as a comment on this PR. **Do not merge before that comment lands**: a green targeted matrix is not evidence a guard is the right width (#16625's retraction this same day).
- Conformance/emit corpus not run: no TypeScript submodule on this seat and `compare-to-parent.sh` measured 55-90+ min on cold cloud seats. The row-level evidence above is the oracle-pinned matrix; the corpus sweep is owed as a regression floor.

**Residuals deliberately not fixed here** (one invariant per PR), each with a live witness:
- A property-access target's diagnostic span over-extends by one token — `o.p,` with a following comma, `o.p]` as the last element. The *start* is correct in both, which is what tsc's line/column and the conformance fingerprint score, so this is the parser node-span family (#16251 / #16259), not this judgement. Pinned by two tests rather than papered over.
- `[n, s] = [n]` — tsc adds `TS2322 Type 'undefined' is not assignable to type 'string'` alongside the TS2493 it already shares with tsz. Out-of-range tuple indices resolve to `None` in `resolve_element_type_for_destructuring`, so no source type reaches the judgement.
- `[m] = opt` where `opt: [number?]` — tsc reports `number | undefined` against `number`; tsz's optional tuple element does not carry the `undefined`.
- The rest-element branch (`[n, ...sa] = [s, n]`) reports TS2719 where tsc reports TS2322 with a nested elaboration. That branch is evaluated *before* the one this diff adds, so a spread element cannot reach the new code — untouched here.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Travertine

---
_Generated by [Claude Code](https://claude.ai/code/session_01S1xThXksYjo86DfVjS1TwW)_