### PR TITLE
fix(checker): a missing required property on a tuple/array element is reported per element and anchored by position (#16552)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -11,6 +11,8 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
+#[path = "elaboration_object_literal_completeness.rs"]
+mod elaboration_object_literal_completeness;
 #[path = "elaboration_object_properties.rs"]
 mod elaboration_object_properties;
 

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_literal_completeness.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_literal_completeness.rs
@@ -1,0 +1,120 @@
+//! Whether an object-literal element that failed the whole-collection relation
+//! did so only through literal widening (suppress) or through a genuinely
+//! missing required property (surface per element). Split out of
+//! `elaboration_object_properties.rs` to keep that file under the 2000-line cap.
+
+use crate::query_boundaries::common as query_common;
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    /// Check if all properties of an object literal are assignable to the
+    /// target type when using literal types from the initializers. This catches
+    /// cases where the widened object type (e.g., `{ kind: string }`) fails
+    /// assignability against a discriminated union, but the literal property
+    /// values (e.g., `"bluray"`) actually match a union member.
+    pub(super) fn all_object_literal_properties_assignable_with_literals(
+        &mut self,
+        obj_idx: NodeIndex,
+        source_type: TypeId,
+        target_type: TypeId,
+    ) -> bool {
+        use tsz_parser::parser::syntax_kind_ext;
+
+        let obj_node = match self.ctx.arena.get(obj_idx) {
+            Some(node) if node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION => node,
+            _ => return false,
+        };
+
+        let obj = match self.ctx.arena.get_literal_expr(obj_node) {
+            Some(obj) => obj.clone(),
+            None => return false,
+        };
+
+        if obj.elements.nodes.is_empty() {
+            return false;
+        }
+
+        for &elem_idx in &obj.elements.nodes {
+            let Some(elem_node) = self.ctx.arena.get(elem_idx) else {
+                continue;
+            };
+
+            let (prop_name_idx, prop_value_idx) = match elem_node.kind {
+                k if k == syntax_kind_ext::PROPERTY_ASSIGNMENT => {
+                    match self.ctx.arena.get_property_assignment(elem_node) {
+                        Some(prop) => (prop.name, prop.initializer),
+                        None => continue,
+                    }
+                }
+                k if k == syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT => {
+                    match self.ctx.arena.get_shorthand_property(elem_node) {
+                        Some(prop) => (prop.name, prop.name),
+                        None => continue,
+                    }
+                }
+                _ => continue,
+            };
+
+            let Some(prop_name) = self.object_literal_property_name_text(prop_name_idx) else {
+                continue;
+            };
+
+            let Some((target_prop_type, _)) =
+                self.object_literal_target_property_type(target_type, prop_name_idx, &prop_name)
+            else {
+                // Target doesn't have this property — can't confirm assignability
+                return false;
+            };
+
+            if target_prop_type == TypeId::ERROR || target_prop_type == TypeId::ANY {
+                continue;
+            }
+
+            // Try literal type first, then cached type
+            let source_prop_type =
+                if let Some(literal_type) = self.literal_type_from_initializer(prop_value_idx) {
+                    literal_type
+                } else {
+                    self.get_type_of_node(prop_value_idx)
+                };
+
+            if source_prop_type == TypeId::ERROR || source_prop_type == TypeId::ANY {
+                continue;
+            }
+
+            if !self
+                .call_arg_relation_outcome(source_prop_type, target_prop_type)
+                .related
+            {
+                return false;
+            }
+        }
+
+        // Every property the literal *wrote* is assignable, so the failure is
+        // not a per-property type mismatch. It can still be a genuinely *missing*
+        // required target property — the loop above only walks the source's own
+        // members and never notices one the target requires but the literal omits.
+        // That is a real `TS2741`, not the widening-only false positive this
+        // suppression exists for (a discriminated-union literal that relates once
+        // its property literals are preserved), so it must surface per element
+        // rather than being swallowed into the coarse whole-array/tuple relation.
+        // Decline the suppression when the analyzed failure is a missing property;
+        // the widening case reports a literal/type mismatch reason instead and
+        // stays suppressed. `source_type` is the element's already-computed type
+        // from the caller's loop, so this reuses it rather than re-deriving it.
+        if matches!(
+            self.analyze_assignability_failure(source_type, target_type)
+                .failure_reason,
+            Some(
+                query_common::SubtypeFailureReason::MissingProperty { .. }
+                    | query_common::SubtypeFailureReason::MissingProperties { .. }
+            )
+        ) {
+            return false;
+        }
+
+        true
+    }
+}

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
@@ -1596,6 +1596,7 @@ impl<'a> CheckerState<'a> {
                 if elem_node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
                     && self.all_object_literal_properties_assignable_with_literals(
                         elem_idx,
+                        elem_type,
                         target_element_type,
                     )
                 {
@@ -1766,91 +1767,6 @@ impl<'a> CheckerState<'a> {
             &message,
             diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
         );
-        true
-    }
-
-    /// Check if all properties of an object literal are assignable to the
-    /// target type when using literal types from the initializers. This catches
-    /// cases where the widened object type (e.g., `{ kind: string }`) fails
-    /// assignability against a discriminated union, but the literal property
-    /// values (e.g., `"bluray"`) actually match a union member.
-    fn all_object_literal_properties_assignable_with_literals(
-        &mut self,
-        obj_idx: NodeIndex,
-        target_type: TypeId,
-    ) -> bool {
-        use tsz_parser::parser::syntax_kind_ext;
-
-        let obj_node = match self.ctx.arena.get(obj_idx) {
-            Some(node) if node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION => node,
-            _ => return false,
-        };
-
-        let obj = match self.ctx.arena.get_literal_expr(obj_node) {
-            Some(obj) => obj.clone(),
-            None => return false,
-        };
-
-        if obj.elements.nodes.is_empty() {
-            return false;
-        }
-
-        for &elem_idx in &obj.elements.nodes {
-            let Some(elem_node) = self.ctx.arena.get(elem_idx) else {
-                continue;
-            };
-
-            let (prop_name_idx, prop_value_idx) = match elem_node.kind {
-                k if k == syntax_kind_ext::PROPERTY_ASSIGNMENT => {
-                    match self.ctx.arena.get_property_assignment(elem_node) {
-                        Some(prop) => (prop.name, prop.initializer),
-                        None => continue,
-                    }
-                }
-                k if k == syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT => {
-                    match self.ctx.arena.get_shorthand_property(elem_node) {
-                        Some(prop) => (prop.name, prop.name),
-                        None => continue,
-                    }
-                }
-                _ => continue,
-            };
-
-            let Some(prop_name) = self.object_literal_property_name_text(prop_name_idx) else {
-                continue;
-            };
-
-            let Some((target_prop_type, _)) =
-                self.object_literal_target_property_type(target_type, prop_name_idx, &prop_name)
-            else {
-                // Target doesn't have this property — can't confirm assignability
-                return false;
-            };
-
-            if target_prop_type == TypeId::ERROR || target_prop_type == TypeId::ANY {
-                continue;
-            }
-
-            // Try literal type first, then cached type
-            let source_prop_type =
-                if let Some(literal_type) = self.literal_type_from_initializer(prop_value_idx) {
-                    literal_type
-                } else {
-                    self.get_type_of_node(prop_value_idx)
-                };
-
-            if source_prop_type == TypeId::ERROR || source_prop_type == TypeId::ANY {
-                continue;
-            }
-
-            if !self
-                .call_arg_relation_outcome(source_prop_type, target_prop_type)
-                .related
-            {
-                return false;
-            }
-        }
-
         true
     }
 

--- a/crates/tsz-checker/src/error_reporter/expected_type_from_property.rs
+++ b/crates/tsz-checker/src/error_reporter/expected_type_from_property.rs
@@ -192,7 +192,8 @@ impl<'a> CheckerState<'a> {
         for key in &path[..path.len() - 1] {
             owner_idx = self.annotation_member_type_node(owner_idx, key, 0)?;
         }
-        let (start, length, file) = self.annotation_property_anchor(owner_idx, property_name, 0)?;
+        let (start, length, file) =
+            self.annotation_property_anchor(owner_idx, property_name, None, 0)?;
         Some((owner_idx, start, length, file))
     }
 }

--- a/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
+++ b/crates/tsz-checker/src/error_reporter/missing_property_declared_here.rs
@@ -85,16 +85,7 @@ impl<'a> CheckerState<'a> {
             let Some(node) = self.ctx.arena.get(current) else {
                 break;
             };
-            if node.kind == syntax_kind_ext::VARIABLE_DECLARATION
-                || node.kind == syntax_kind_ext::PARAMETER
-                || node.kind == syntax_kind_ext::PROPERTY_DECLARATION
-                || node.kind == syntax_kind_ext::FUNCTION_DECLARATION
-                || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                || node.kind == syntax_kind_ext::ARROW_FUNCTION
-                || node.kind == syntax_kind_ext::METHOD_DECLARATION
-                || node.kind == syntax_kind_ext::BLOCK
-                || node.kind == syntax_kind_ext::SOURCE_FILE
-            {
+            if Self::is_contextual_walk_boundary(node.kind) {
                 break;
             }
             let name_idx = if node.kind == syntax_kind_ext::PROPERTY_ASSIGNMENT {
@@ -124,6 +115,61 @@ impl<'a> CheckerState<'a> {
         }
         path.reverse();
         path
+    }
+
+    /// The declaration/function/block boundary an upward contextual walk stops
+    /// at, so it never crosses out of the assignment being described. Shared by
+    /// [`Self::contextual_property_path`] and
+    /// [`Self::contextual_tuple_element_index`] so the two walks provably agree
+    /// on where one assignment ends.
+    const fn is_contextual_walk_boundary(kind: u16) -> bool {
+        use tsz_parser::parser::syntax_kind_ext;
+
+        kind == syntax_kind_ext::VARIABLE_DECLARATION
+            || kind == syntax_kind_ext::PARAMETER
+            || kind == syntax_kind_ext::PROPERTY_DECLARATION
+            || kind == syntax_kind_ext::FUNCTION_DECLARATION
+            || kind == syntax_kind_ext::FUNCTION_EXPRESSION
+            || kind == syntax_kind_ext::ARROW_FUNCTION
+            || kind == syntax_kind_ext::METHOD_DECLARATION
+            || kind == syntax_kind_ext::BLOCK
+            || kind == syntax_kind_ext::SOURCE_FILE
+    }
+
+    /// The index of the failing element inside its nearest enclosing array
+    /// literal, or `None` when the failure is not an array-literal element.
+    ///
+    /// A missing-property failure on a tuple element is reported per element, so
+    /// each diagnostic anchors at its own element literal; that literal's
+    /// position is the tuple index tsc points its `'x' is declared here.` at when
+    /// two elements declare the same property and uniqueness cannot choose. The
+    /// walk stops at the same declaration/function boundaries
+    /// [`Self::contextual_property_path`] uses so an array literal from an
+    /// unrelated outer assignment is never attributed here. A parenthesized
+    /// element (`[({ ... })]`) is handled by the plain parent walk: the paren
+    /// node is itself the array literal's element, so it matches directly.
+    pub(super) fn contextual_tuple_element_index(&self, anchor_idx: NodeIndex) -> Option<usize> {
+        use tsz_parser::parser::syntax_kind_ext;
+
+        let mut current = anchor_idx;
+        let mut guard = 0u32;
+        while current.is_some() {
+            guard += 1;
+            if guard > 32 {
+                return None;
+            }
+            let parent = self.ctx.arena.get_extended(current).map(|ext| ext.parent)?;
+            let parent_node = self.ctx.arena.get(parent)?;
+            if parent_node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION {
+                let arr = self.ctx.arena.get_literal_expr(parent_node)?;
+                return arr.elements.nodes.iter().position(|&elem| elem == current);
+            }
+            if Self::is_contextual_walk_boundary(parent_node.kind) {
+                return None;
+            }
+            current = parent;
+        }
+        None
     }
 
     /// Anchor recovered from the type annotation the failing assignment was
@@ -158,8 +204,16 @@ impl<'a> CheckerState<'a> {
         // taken, so an annotation that does not declare the path declines here
         // exactly as it does at the top level.
         let path = self.contextual_property_path(anchor_idx);
+        // The failure's position inside its nearest enclosing array literal is
+        // the tuple element index tsc anchors by: two tuple elements that both
+        // declare the missing property are disambiguated by *which* element
+        // literal failed, which uniqueness alone cannot recover. `None` when the
+        // failure is not an array-literal element (a plain object member), where
+        // the tuple arm falls back to uniqueness. The index is consumed only at
+        // the member-level tuple (see `annotation_property_anchor`).
+        let element_index = self.contextual_tuple_element_index(anchor_idx);
         let anchor = if path.is_empty() {
-            self.annotation_property_anchor(annotation_idx, property, 0)
+            self.annotation_property_anchor(annotation_idx, property, element_index, 0)
         } else {
             let mut member_type_idx = annotation_idx;
             let mut walked = Some(());
@@ -172,7 +226,9 @@ impl<'a> CheckerState<'a> {
                     }
                 }
             }
-            walked.and_then(|()| self.annotation_property_anchor(member_type_idx, property, 0))
+            walked.and_then(|()| {
+                self.annotation_property_anchor(member_type_idx, property, element_index, 0)
+            })
         };
         let (start, length, file) = anchor?;
         Some(Diagnostic::related_pointer(
@@ -199,6 +255,7 @@ impl<'a> CheckerState<'a> {
         &mut self,
         idx: NodeIndex,
         property: &str,
+        element_index: Option<usize>,
         depth: u32,
     ) -> Option<(u32, u32, Option<String>)> {
         use tsz_parser::parser::syntax_kind_ext;
@@ -208,8 +265,10 @@ impl<'a> CheckerState<'a> {
         }
         let node = self.ctx.arena.get(idx)?;
         if node.kind == syntax_kind_ext::PARENTHESIZED_TYPE {
+            // A parenthesis wraps the same collection, so a tuple position
+            // written as `([T, T])` still selects by index inside — propagate it.
             let inner = self.ctx.arena.get_wrapped_type(node)?.type_node;
-            return self.annotation_property_anchor(inner, property, depth + 1);
+            return self.annotation_property_anchor(inner, property, element_index, depth + 1);
         }
         if node.kind == syntax_kind_ext::TYPE_LITERAL {
             let arena = self.ctx.arena;
@@ -233,10 +292,16 @@ impl<'a> CheckerState<'a> {
                 }
                 // An alias chain (`type Indirect = Zed`) declares no member list of
                 // its own, so the walk above finds nothing to anchor in. Continue
-                // through the alias body, which is itself annotation syntax.
+                // through the alias body, which is itself annotation syntax. A
+                // tuple aliased directly (`type T = [A, B]`) keeps the element
+                // index, so `member: T` still selects by position.
                 if let Some(body_idx) = self.local_type_alias_body(owner_symbol)
-                    && let Some(anchor) =
-                        self.annotation_property_anchor(body_idx, property, depth + 1)
+                    && let Some(anchor) = self.annotation_property_anchor(
+                        body_idx,
+                        property,
+                        element_index,
+                        depth + 1,
+                    )
                 {
                     return Some(anchor);
                 }
@@ -244,7 +309,8 @@ impl<'a> CheckerState<'a> {
             // The reference itself declares no `property`, so look in what it is
             // parameterized by: `Array<T>` and `ReadonlyArray<T>` hold the written
             // element shape in a type argument exactly as `T[]` holds it in its
-            // element type, and `tsc` anchors there identically.
+            // element type, and `tsc` anchors there identically. Type arguments
+            // are not tuple positions, so the element index does not apply here.
             //
             // This is deliberately not keyed to the global array types. The
             // question the walk answers is "where is `property` written?", and a
@@ -259,7 +325,7 @@ impl<'a> CheckerState<'a> {
             let (object_idx, index_idx) = (data.object_type, data.index_type);
             let key = self.written_index_key(index_idx)?;
             let member_type_idx = self.annotation_member_type_node(object_idx, &key, depth)?;
-            return self.annotation_property_anchor(member_type_idx, property, depth + 1);
+            return self.annotation_property_anchor(member_type_idx, property, None, depth + 1);
         }
         if node.kind == syntax_kind_ext::ARRAY_TYPE {
             // `T[]` and `T` describe the same element shape at every index, so
@@ -268,32 +334,48 @@ impl<'a> CheckerState<'a> {
             // `T`-typed member. The array itself contributes no path segment
             // (`contextual_property_path` already skips over
             // `ARRAY_LITERAL_EXPRESSION` without pushing a name), so this is a
-            // plain descent into the element type, not a new path step.
+            // plain descent into the element type, not a new path step. An
+            // element index belongs to *this* array's own literal, whose element
+            // type is index-independent; any tuple nested deeper is a different
+            // literal level and resolves by uniqueness, so drop the index.
             let element_idx = self.ctx.arena.get_array_type(node)?.element_type;
-            return self.annotation_property_anchor(element_idx, property, depth + 1);
+            return self.annotation_property_anchor(element_idx, property, None, depth + 1);
         }
         if node.kind == syntax_kind_ext::TYPE_OPERATOR {
             let data = self.ctx.arena.get_type_operator(node)?;
-            // `readonly T[]` describes the same element shape as `T[]`, so the
-            // operator contributes no path segment and the walk descends into
-            // its operand. `keyof`/`unique` are *not* transparent this way —
-            // `keyof T` denotes T's keys, not T — so they decline here.
+            // `readonly T[]` / `readonly [T, T]` describe the same element shapes
+            // as their operand, so the operator contributes no path segment and
+            // the walk descends into its operand, keeping the element index so a
+            // `readonly` tuple position still selects by index. `keyof`/`unique`
+            // are *not* transparent this way — `keyof T` denotes T's keys, not T
+            // — so they decline here.
             if data.operator != tsz_scanner::SyntaxKind::ReadonlyKeyword as u16 {
                 return None;
             }
             let operand_idx = data.type_node;
-            return self.annotation_property_anchor(operand_idx, property, depth + 1);
+            return self.annotation_property_anchor(
+                operand_idx,
+                property,
+                element_index,
+                depth + 1,
+            );
         }
         if node.kind == syntax_kind_ext::TUPLE_TYPE {
             // A tuple element type describes the shape written at that index
             // exactly as an array's element type describes the shape at every
             // index, and tsc anchors a missing-property pointer for a tuple
-            // element literal inside that element's own type. Like `ARRAY_TYPE`
-            // above, the tuple contributes no path segment —
-            // `contextual_property_path` skips `ARRAY_LITERAL_EXPRESSION`
-            // without pushing a name, so the walk arrives here carrying no
-            // element position and resolves the element by uniqueness instead.
+            // element literal inside that element's own type. When the failing
+            // array-literal element's position is known (`element_index`), select
+            // that element directly — two elements declaring the same property
+            // are disambiguated by position, matching tsc. Without a position
+            // (e.g. an indexed access reached this tuple), fall back to
+            // uniqueness: anchor when exactly one element declares the property.
             let elements = self.ctx.arena.get_tuple_type(node)?.elements.nodes.clone();
+            if let Some(index) = element_index
+                && let Some(&element_idx) = elements.get(index)
+            {
+                return self.annotation_property_anchor(element_idx, property, None, depth + 1);
+            }
             return self.unique_sibling_type_anchor(&elements, property, depth);
         }
         if node.kind == syntax_kind_ext::NAMED_TUPLE_MEMBER {
@@ -301,14 +383,14 @@ impl<'a> CheckerState<'a> {
             // position, not a property, so it matches nothing in the failing
             // literal and the walk descends straight into the member's type.
             let inner = self.ctx.arena.get_named_tuple_member(node)?.type_node;
-            return self.annotation_property_anchor(inner, property, depth + 1);
+            return self.annotation_property_anchor(inner, property, None, depth + 1);
         }
         if node.kind == syntax_kind_ext::OPTIONAL_TYPE || node.kind == syntax_kind_ext::REST_TYPE {
             // `[a?: T]` and `[...T[]]` constrain how many elements may be
             // written, not what shape each one has, so both are transparent to
             // a walk asking where `property` is declared.
             let inner = self.ctx.arena.get_wrapped_type(node)?.type_node;
-            return self.annotation_property_anchor(inner, property, depth + 1);
+            return self.annotation_property_anchor(inner, property, None, depth + 1);
         }
         None
     }
@@ -319,6 +401,8 @@ impl<'a> CheckerState<'a> {
     /// Declines when two candidates both declare `property`: the walk has no
     /// basis to pick between them, and pointing at the wrong one is worse than
     /// omitting the pointer, which is what every other declining path here does.
+    /// Used only when no element position is available; a known tuple position
+    /// is resolved directly by [`Self::annotation_property_anchor`].
     fn unique_sibling_type_anchor(
         &mut self,
         candidates: &[NodeIndex],
@@ -327,7 +411,8 @@ impl<'a> CheckerState<'a> {
     ) -> Option<(u32, u32, Option<String>)> {
         let mut found: Option<(u32, u32, Option<String>)> = None;
         for &argument_idx in candidates {
-            let Some(anchor) = self.annotation_property_anchor(argument_idx, property, depth + 1)
+            let Some(anchor) =
+                self.annotation_property_anchor(argument_idx, property, None, depth + 1)
             else {
                 continue;
             };

--- a/crates/tsz-checker/src/tests/call_elaboration_mutual_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/call_elaboration_mutual_relation_routing_arch_tests.rs
@@ -178,7 +178,11 @@ fn call_elaboration_object_array_helpers_use_relation_outcome_boundary() {
 
     assert_eq!(
         helpers.matches("call_arg_relation_outcome(").count(),
-        6,
+        // One probe moved out with `all_object_literal_properties_assignable_with_literals`
+        // when it was split into `elaboration_object_literal_completeness.rs` to
+        // hold the file under the 2000-line cap; that helper's boundary usage is
+        // asserted against its own file below.
+        5,
         "object/array call elaboration helper probes should route through call_arg_relation_outcome"
     );
     assert_eq!(
@@ -195,5 +199,22 @@ fn call_elaboration_object_array_helpers_use_relation_outcome_boundary() {
     assert!(
         !helpers.contains("diagnostic_relation_boolean_guard("),
         "object/array elaboration helpers should not use raw relation guards"
+    );
+
+    // The split-out object-literal-completeness helper carries the moved probe,
+    // and must keep routing it through the same boundary rather than a raw guard.
+    let completeness = fs::read_to_string(
+        "src/error_reporter/call_errors/elaboration_object_literal_completeness.rs",
+    )
+    .expect("failed to read elaboration_object_literal_completeness.rs");
+    assert_eq!(
+        completeness.matches("call_arg_relation_outcome(").count(),
+        1,
+        "the split-out completeness helper should route its per-property probe through call_arg_relation_outcome"
+    );
+    assert!(
+        !completeness.contains("assign_relation_outcome(")
+            && !completeness.contains("diagnostic_relation_boolean_guard("),
+        "the split-out completeness helper should not use generic or raw relation guards"
     );
 }

--- a/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
+++ b/crates/tsz-checker/src/tests/missing_property_declared_here_tests.rs
@@ -87,6 +87,22 @@ fn span_text(source: &str, start: u32, length: u32) -> &str {
     &source[start as usize..(start + length) as usize]
 }
 
+/// Each `TS2741`'s declared-here `(anchor start, anchor text)`, in source order
+/// of the diagnostics themselves. Shared by the per-element tuple rows, which
+/// all assert that every failing element carries its own pointer.
+fn ts2741_anchors_in_order(source: &str) -> Vec<(u32, String)> {
+    let diagnostics = check_source_diagnostics(source);
+    let mut ts2741: Vec<_> = diagnostics.iter().filter(|d| d.code == TS2741).collect();
+    ts2741.sort_by_key(|d| d.start);
+    ts2741
+        .iter()
+        .map(|d| {
+            let (_, start, length, _) = declared_here(d);
+            (start, span_text(source, start, length).to_string())
+        })
+        .collect()
+}
+
 /// The pointer models tsc's `relatedInformation`, not a `messageText` chain
 /// link, so it must carry that tag through to the reporter. Oracled on
 /// `typescript@7.0.2`: `tsc --noEmit --strict --pretty false` on this source
@@ -1572,35 +1588,85 @@ fn a_tuple_element_type_reference_resolves_through_its_alias() {
     assert_eq!(span_text(source, start, length), "eq");
 }
 
-// The second half of the same gap — an array *of* tuples stopping at the inner
-// whole-tuple `TS2322` — is closed at the elaboration owner rather than in this
-// walk; its rows live in the block at the end of this file
-// (`an_array_of_tuples_reaches_ts2741_at_the_inner_element` and siblings).
-// Both descents this file needs (`ARRAY_TYPE` then `TUPLE_TYPE`) were already
-// in place; the primary was the blocker.
+// The array-*of*-tuples half of the gap — an array literal in a tuple-typed
+// element slot stopping at the inner whole-tuple `TS2322` — is closed at the
+// elaboration owner (#16631) rather than in this walk; its rows live in the
+// block at the end of this file (`an_array_of_tuples_reaches_ts2741_at_the_inner_element`
+// and siblings). Both descents this file needs (`ARRAY_TYPE` then `TUPLE_TYPE`)
+// were already in place; the primary was the blocker.
 
-/// Negative / declining case, and the remaining gap. Two elements declare the
-/// same property name, so the walk has no basis to pick between the two
-/// declaration sites and attaches no pointer — the same answer
-/// `unique_type_argument_anchor` gives for an ambiguous type argument.
-///
-/// tsc does better here because it carries the failing element's *position*:
-/// it reports two `TS2741`s and anchors each at its own element
-/// (`t5.ts:1:33` and `t5.ts:1:61`). Closing that needs an element index
-/// threaded from the failing array-literal element through the annotation
-/// walk, which `contextual_property_path` currently discards. Pinned so the
-/// gap is a recorded decline, not a silent wrong anchor.
+/// Two elements declare the *same* property name. Each failing element is a
+/// distinct literal, so each is reported as its own `TS2741`, and the pointer
+/// is resolved by the failing element's *position* — the first `qq` anchors in
+/// the first element's type, the second in the second's. tsc does exactly this
+/// (`t5.ts:1:33` and `t5.ts:1:61`); uniqueness alone could not choose between
+/// the two identical declarations, so the element index threaded from the
+/// failing array-literal element is what disambiguates.
 #[test]
-fn two_tuple_elements_declaring_the_same_property_decline_the_pointer() {
+fn two_tuple_elements_declaring_the_same_property_anchor_by_position() {
     let source = "type A1 = { tup: [{ xp: number; qq: number }, { yp: number; qq: number }] };\nconst a: A1 = { tup: [{ xp: 1 }, { yp: 2 }] };\n";
-    let diagnostics = check_source_diagnostics(source);
-    assert!(
-        !diagnostics
-            .iter()
-            .flat_map(|d| d.related_information.iter())
-            .any(|info| info.code == TS2728),
-        "an ambiguous element declaration must decline rather than guess: {diagnostics:?}"
+    let anchors = ts2741_anchors_in_order(source);
+    assert_eq!(
+        anchors.len(),
+        2,
+        "each failing tuple element is its own TS2741"
     );
+    // Both name `qq`, but each points at a *different* `qq` declaration — the
+    // one inside its own element's type, in source order.
+    assert_eq!(anchors[0].1, "qq");
+    assert_eq!(anchors[1].1, "qq");
+    assert_eq!(
+        anchors[0].0,
+        source.find("qq").unwrap() as u32,
+        "first element points at the first qq"
+    );
+    assert_eq!(
+        anchors[1].0,
+        source.rfind("qq").unwrap() as u32,
+        "second element points at the second qq"
+    );
+}
+
+/// The false-negative twin: two elements each miss a *different* required
+/// property. tsz used to report only the first (`ax`) and silently drop the
+/// second; tsc reports both. Each is now its own `TS2741` anchored at its own
+/// element.
+#[test]
+fn two_tuple_elements_missing_different_properties_both_report() {
+    let source = "type B1 = { tup: [{ xp: number; ax: number }, { yp: number; by: number }] };\nconst b: B1 = { tup: [{ xp: 1 }, { yp: 2 }] };\n";
+    let names: Vec<String> = ts2741_anchors_in_order(source)
+        .into_iter()
+        .map(|(_, name)| name)
+        .collect();
+    assert_eq!(
+        names,
+        vec!["ax", "by"],
+        "each element anchors its own missing prop"
+    );
+}
+
+/// Renamed binders: the per-element anchoring keys on structure and position,
+/// never on the property spelling, so renaming every binder leaves the two
+/// same-named-property pointers landing on their own elements.
+#[test]
+fn two_tuple_elements_same_property_position_is_binder_name_independent() {
+    let source = "type Payload = { slots: [{ alpha: number; shared: number }, { beta: number; shared: number }] };\nconst p: Payload = { slots: [{ alpha: 1 }, { beta: 2 }] };\n";
+    let anchors = ts2741_anchors_in_order(source);
+    assert_eq!(anchors.len(), 2);
+    assert_eq!(anchors[0].0, source.find("shared").unwrap() as u32);
+    assert_eq!(anchors[1].0, source.rfind("shared").unwrap() as u32);
+}
+
+/// A `readonly` two-element tuple: the `readonly` `TYPE_OPERATOR` peel is
+/// transparent and carries the element index through, so both same-named
+/// pointers still land by position.
+#[test]
+fn readonly_two_tuple_elements_same_property_anchor_by_position() {
+    let source = "type R2 = { tup: readonly [{ xp: number; qq: number }, { yp: number; qq: number }] };\nconst r: R2 = { tup: [{ xp: 1 }, { yp: 2 }] };\n";
+    let anchors = ts2741_anchors_in_order(source);
+    assert_eq!(anchors.len(), 2);
+    assert_eq!(anchors[0].0, source.find("qq").unwrap() as u32);
+    assert_eq!(anchors[1].0, source.rfind("qq").unwrap() as u32);
 }
 
 /// `keyof` is not transparent the way `readonly` is, and the tuple arm must


### PR DESCRIPTION
Closes the two open cells of #16552 (per-element tuple/array missing-property diagnostics), building on #16631.

**Structural rule.** When an object literal written as a tuple or array element is missing a required target property, `tsc`'s `elaborateElementwise` reports it per element (one `TS2741` at that element, with the `'x' is declared here.` pointer into the element's own written type). tsz collapsed it: `all_object_literal_properties_assignable_with_literals` only walked the source's *present* members, so a genuinely **missing** required property looked like the widening-only false positive that suppression exists for. The element drill was declined and a single whole-tuple `TS2741` naming only the *first* missing property was emitted — silently dropping every other failing element (a false negative).

Two changes, both in the checker's error reporter:

1. **Suppression gate** (`elaboration_object_literal_completeness.rs`, split out of `elaboration_object_properties.rs`): decline the widening suppression when `analyze_assignability_failure` reports the failure as `MissingProperty`/`MissingProperties`, so each failing element surfaces its own `TS2741`. The widening/discriminated-union case reports a literal/type-mismatch reason instead and stays suppressed. Reusing the relation's own reason keeps union-member selection consistent with the rendered diagnostic (a structural "does the source provide every required property" check is ill-defined for a union target).

2. **Element-position anchoring** (`missing_property_declared_here.rs`): thread the failing array-literal element's index through `annotation_property_anchor`, consuming it at the `TUPLE_TYPE` arm so two elements declaring the *same* property are disambiguated by position (matching `tsc`) instead of declining on ambiguity. The index propagates through the transparent `readonly`/parenthesized/direct-alias hops and is dropped at array and indexed-access levels, where uniqueness still applies.

Anti-hardcoding: no identifier/name/file-string checks; the tuple position keys on the source AST's element index and the target's structural shape. Adjacent matrix covered by tests: same-property two-element, different-property two-element (the dropped-`by` false negative), renamed binders, `readonly` tuple, single-element, `keyof` negative control.

A file split was required because #16631 left `elaboration_object_properties.rs` at 1999 lines; the self-contained completeness helper moved to a new sibling module keeps every file under the 2000-line cap.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib missing_property_declared_here_tests` — 94 passed (includes the two-element position rows and #16631's array-of-tuples rows).
- `cargo test -p tsz-checker --lib -- tuple array_literal elaboration discriminated assignability readonly excess object_literal declared_here` — 1539 passed after the routing-arch test was updated for the split (which itself now passes).
- `cargo test -p tsz-checker --lib` — full run: 10141 explicit passes, 0 failed (one pre-existing env-sensitive recursive-conditional checker hang, #15338, unrelated to this change and passing in isolation in 2.31s).
- `cargo clippy -p tsz-checker` — clean; `scripts/arch/arch_guard.py` — passed (all files under 2000 LOC).
- Conformance/emit not run locally: the TypeScript submodule cases tree is not checked out in this environment; the full CI suite covers them. This change tightens diagnostics toward `tsc`, so it can only shrink message-text diffs against the tsc cache.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjU5h2NKaiYD5Ce3Hn1UbA)_