### PR TITLE
fix(checker): a function/constructor type's parameter list runs tsc's parameter grammar (TS1014/TS1015/TS1016)

### DIFF
--- a/crates/tsz-checker/src/checkers/parameter_checker.rs
+++ b/crates/tsz-checker/src/checkers/parameter_checker.rs
@@ -1702,3 +1702,120 @@ pub(crate) fn check_this_parameter_placement_in_ctx(
         }
     }
 }
+
+/// Run the parameter-list grammar of tsc's `checkGrammarParameterList` over a
+/// signature written in *type* position — a `FunctionType` or `ConstructorType`
+/// node.
+///
+/// Every other signature form reaches this grammar through
+/// `CheckerState::check_parameter_ordering`, but a function/constructor type is
+/// parsed by `parse_type_parameter_list` and typed by
+/// `get_type_from_function_type`, neither of which routes through it. tsc draws
+/// no such distinction: `checkGrammarFunctionLikeDeclaration` runs the same
+/// `checkGrammarParameterList` for `FunctionType` and `ConstructorType` as for a
+/// function declaration, so `type F = (...a: number[], b: string) =` `> void`
+/// reports TS1014 exactly like `function f(...a: number[], b: string) {}`.
+///
+/// Three arms, in tsc's own order:
+///
+/// - a rest parameter that is not last -> `TS1014`
+/// - a parameter carrying both `?` and an initializer -> `TS1015`
+/// - a required parameter after an optional one -> `TS1016`
+///
+/// Every arm in tsc is a `return grammarErrorOnNode(...)`, so **at most one**
+/// diagnostic is reported per parameter list and the walk stops at the first
+/// failing parameter. `(a?: number, b: string, c: string)` is one TS1016, not
+/// two, and `(a?: number, b: string, ...c: any[], d: any)` is that same lone
+/// TS1016 with no TS1014 behind it.
+///
+/// A parameter with an initializer is not "required" for the TS1016 arm, and it
+/// does not make the parameters after it optional either: tsc's
+/// `isOptionalParameter` compares the parameter's index against the signature's
+/// minimum argument count, so `(a = 1, b: number)` is clean on both sides.
+///
+/// Lives at context level for the same reason as
+/// `check_this_parameter_placement_in_ctx`: the callers run inside
+/// `TypeNodeChecker`, which owns the context but not the checker state.
+pub(crate) fn check_type_position_parameter_list_grammar_in_ctx(
+    ctx: &mut crate::CheckerContext,
+    parameters: &tsz_parser::parser::NodeList,
+) {
+    use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+
+    /// Width of the `...` token tsc anchors `TS1014` on.
+    const DOT_DOT_DOT_LEN: u32 = 3;
+
+    let report_at = |ctx: &mut crate::CheckerContext,
+                     anchor: NodeIndex,
+                     len: Option<u32>,
+                     message: &str,
+                     code: u32| {
+        let Some(node) = ctx.arena.get(anchor) else {
+            return;
+        };
+        let span = node.end.saturating_sub(node.pos);
+        let len = len.map_or(span, |requested| requested.min(span));
+        ctx.error(node.pos, len, message.to_string(), code);
+    };
+
+    let last_index = parameters.nodes.len().saturating_sub(1);
+    let mut seen_optional = false;
+
+    for (index, &param_idx) in parameters.nodes.iter().enumerate() {
+        let Some((is_rest, is_question, has_initializer, name_idx)) = ctx
+            .arena
+            .get(param_idx)
+            .and_then(|param_node| ctx.arena.get_parameter(param_node))
+            .map(|param| {
+                (
+                    param.dot_dot_dot_token,
+                    param.question_token,
+                    param.initializer.is_some(),
+                    param.name,
+                )
+            })
+        else {
+            continue;
+        };
+
+        if is_rest {
+            if index != last_index {
+                report_at(
+                    ctx,
+                    param_idx,
+                    Some(DOT_DOT_DOT_LEN),
+                    diagnostic_messages::A_REST_PARAMETER_MUST_BE_LAST_IN_A_PARAMETER_LIST,
+                    diagnostic_codes::A_REST_PARAMETER_MUST_BE_LAST_IN_A_PARAMETER_LIST,
+                );
+            }
+            // TS1047 (`A rest parameter cannot be optional.`) is already
+            // reported by `parse_type_parameter_list`, so the remaining rest
+            // arms of tsc's loop have no work here. A rest parameter is neither
+            // optional nor required for the arms below.
+            return;
+        }
+
+        if is_question {
+            seen_optional = true;
+            if has_initializer {
+                report_at(
+                    ctx,
+                    name_idx,
+                    None,
+                    diagnostic_messages::PARAMETER_CANNOT_HAVE_QUESTION_MARK_AND_INITIALIZER,
+                    diagnostic_codes::PARAMETER_CANNOT_HAVE_QUESTION_MARK_AND_INITIALIZER,
+                );
+                return;
+            }
+        } else if seen_optional && !has_initializer {
+            report_at(
+                ctx,
+                name_idx,
+                None,
+                diagnostic_messages::A_REQUIRED_PARAMETER_CANNOT_FOLLOW_AN_OPTIONAL_PARAMETER,
+                diagnostic_codes::A_REQUIRED_PARAMETER_CANNOT_FOLLOW_AN_OPTIONAL_PARAMETER,
+            );
+            return;
+        }
+    }
+}

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -329,6 +329,8 @@ mod fresh_object_literal_union_literal_kind_display_tests;
 mod function_callee_spread_ts2556_tests;
 #[path = "tests/function_parameter_mismatch_elaboration_tests.rs"]
 mod function_parameter_mismatch_elaboration_tests;
+#[path = "tests/function_type_parameter_grammar_tests.rs"]
+mod function_type_parameter_grammar_tests;
 #[path = "tests/function_type_relation_routing_arch_tests.rs"]
 mod function_type_relation_routing_arch_tests;
 #[path = "tests/function_type_return_node_tests.rs"]

--- a/crates/tsz-checker/src/tests/function_type_parameter_grammar_tests.rs
+++ b/crates/tsz-checker/src/tests/function_type_parameter_grammar_tests.rs
@@ -1,0 +1,284 @@
+//! Parameter-list grammar for signatures written in *type* position.
+//!
+//! `FunctionType` and `ConstructorType` nodes are parsed by
+//! `parse_type_parameter_list` and typed by `get_type_from_function_type`,
+//! neither of which routes through `CheckerState::check_parameter_ordering`, so
+//! TS1014/TS1015/TS1016 never ran for them. tsc runs the same
+//! `checkGrammarParameterList` for these nodes as for a function declaration.
+//!
+//! Every expectation here is pinned against `typescript@7.0.2`, including the
+//! anchor column: TS1014 sits on the `...` token, TS1015/TS1016 on the
+//! offending parameter's name.
+
+#[cfg(test)]
+mod function_type_parameter_grammar_tests {
+    use crate::test_utils::check_source_diagnostics;
+
+    /// `(code, byte offset)` for every diagnostic, in source order.
+    fn codes_at(source: &str) -> Vec<(u32, u32)> {
+        let mut found: Vec<(u32, u32)> = check_source_diagnostics(source)
+            .iter()
+            .map(|diag| (diag.code, diag.start))
+            .collect();
+        found.sort_unstable();
+        found
+    }
+
+    /// Byte offset of the `nth` (0-based) occurrence of `needle`.
+    fn offset_of(source: &str, needle: &str, nth: usize) -> u32 {
+        let mut from = 0usize;
+        for _ in 0..nth {
+            let at = source[from..]
+                .find(needle)
+                .expect("fewer occurrences than requested");
+            from += at + needle.len();
+        }
+        let at = source[from..].find(needle).expect("needle not found");
+        u32::try_from(from + at).expect("offset fits in u32")
+    }
+
+    fn expect_only(source: &str, code: u32, needle: &str) {
+        let expected = vec![(code, offset_of(source, needle, 0))];
+        assert_eq!(
+            codes_at(source),
+            expected,
+            "unexpected diagnostics for: {source}"
+        );
+    }
+
+    fn expect_clean(source: &str) {
+        assert_eq!(
+            codes_at(source),
+            Vec::new(),
+            "expected no diagnostics for: {source}"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // TS1014 — a rest parameter must be last
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn function_type_alias_reports_rest_not_last() {
+        expect_only("type F = (...a: number[], b: string) => void;", 1014, "...");
+    }
+
+    #[test]
+    fn inline_function_type_annotation_reports_rest_not_last() {
+        expect_only(
+            "declare let f: (...a: number[], b: string) => void;",
+            1014,
+            "...",
+        );
+    }
+
+    #[test]
+    fn generic_function_type_reports_rest_not_last() {
+        expect_only("type F = <T>(...a: T[], b: T) => void;", 1014, "...");
+    }
+
+    #[test]
+    fn constructor_type_reports_rest_not_last() {
+        expect_only(
+            "type C = new (...a: number[], b: string) => object;",
+            1014,
+            "...",
+        );
+    }
+
+    #[test]
+    fn abstract_constructor_type_reports_rest_not_last() {
+        expect_only(
+            "type C = abstract new (...a: number[], b: string) => object;",
+            1014,
+            "...",
+        );
+    }
+
+    #[test]
+    fn function_type_as_a_parameter_annotation_reports_rest_not_last() {
+        expect_only(
+            "declare function use(cb: (...a: number[], b: string) => void): void;",
+            1014,
+            "...",
+        );
+    }
+
+    #[test]
+    fn function_type_inside_a_union_reports_rest_not_last() {
+        expect_only(
+            "type F = ((...a: number[], b: string) => void) | string;",
+            1014,
+            "...",
+        );
+    }
+
+    #[test]
+    fn function_type_as_an_interface_property_reports_rest_not_last() {
+        expect_only(
+            "interface I { f: (...a: number[], b: string) => void }",
+            1014,
+            "...",
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // TS1016 — a required parameter cannot follow an optional one
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn function_type_alias_reports_required_after_optional() {
+        expect_only("type F = (a?: number, b: string) => void;", 1016, "b:");
+    }
+
+    #[test]
+    fn inline_function_type_annotation_reports_required_after_optional() {
+        expect_only(
+            "declare let f: (a?: number, b: string) => void;",
+            1016,
+            "b:",
+        );
+    }
+
+    #[test]
+    fn generic_function_type_reports_required_after_optional() {
+        expect_only("type F = <T>(a?: T, b: T) => void;", 1016, "b:");
+    }
+
+    #[test]
+    fn constructor_type_reports_required_after_optional() {
+        expect_only(
+            "type C = new (a?: number, b: string) => object;",
+            1016,
+            "b:",
+        );
+    }
+
+    #[test]
+    fn abstract_constructor_type_reports_required_after_optional() {
+        expect_only(
+            "type C = abstract new (a?: number, b: string) => object;",
+            1016,
+            "b:",
+        );
+    }
+
+    #[test]
+    fn function_type_as_an_object_type_member_reports_required_after_optional() {
+        expect_only(
+            "type T = { f: (a?: number, b: string) => void };",
+            1016,
+            "b:",
+        );
+    }
+
+    #[test]
+    fn function_type_in_an_array_type_reports_required_after_optional() {
+        expect_only("type F = ((a?: number, b: string) => void)[];", 1016, "b:");
+    }
+
+    // ---------------------------------------------------------------------
+    // TS1015 — `?` together with an initializer
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn function_type_reports_question_mark_with_initializer_alongside_ts2371() {
+        // tsc reports TS1015 and TS2371 at the same anchor: the grammar arm and
+        // the "initializer only in an implementation" rule are independent.
+        let source = "type F = (a?: number = 1) => void;";
+        let anchor = offset_of(source, "a?", 0);
+        assert_eq!(codes_at(source), vec![(1015, anchor), (2371, anchor)]);
+    }
+
+    // ---------------------------------------------------------------------
+    // tsc reports at most ONE diagnostic per parameter list
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn a_misplaced_rest_wins_over_a_later_required_after_optional() {
+        // `checkGrammarParameterList` returns at the first failing parameter,
+        // so the trailing `b?`/`c` pair never reaches the TS1016 arm.
+        expect_only(
+            "type F = (...a: number[], b?: string, c: string) => void;",
+            1014,
+            "...",
+        );
+    }
+
+    #[test]
+    fn only_the_first_required_after_optional_is_reported() {
+        expect_only(
+            "type F = (a?: number, b: string, c: string) => void;",
+            1016,
+            "b:",
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Negative controls
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn optional_after_required_is_clean() {
+        expect_clean("type F = (a: number, b?: string) => void;");
+    }
+
+    #[test]
+    fn a_trailing_rest_after_an_optional_is_clean() {
+        expect_clean("type F = (a?: number, ...rest: string[]) => void;");
+    }
+
+    #[test]
+    fn an_initialized_parameter_does_not_make_the_next_one_required_after_optional() {
+        // tsc's `isOptionalParameter` compares the index against the minimum
+        // argument count, so a leading `a = 1` is not optional here.
+        expect_clean("function f(a = 1, b: number) {}");
+    }
+
+    #[test]
+    fn a_parameter_with_an_initializer_is_not_required_after_an_optional_one() {
+        // Only TS2371 survives — the initializer keeps `b` out of the TS1016
+        // arm, exactly as in tsc.
+        let source = "type F = (a?: number, b = 1) => void;";
+        assert_eq!(codes_at(source), vec![(2371, offset_of(source, "b =", 0))]);
+    }
+
+    #[test]
+    fn binding_pattern_parameters_are_clean() {
+        expect_clean("type F = ({ a }: { a: number }, c?: string) => void;");
+    }
+
+    #[test]
+    fn a_this_parameter_before_the_optional_run_is_clean() {
+        expect_clean("type F = (this: object, a: number, b?: string) => void;");
+    }
+
+    #[test]
+    fn an_empty_parameter_list_is_clean() {
+        expect_clean("type F = () => void;");
+    }
+
+    // ---------------------------------------------------------------------
+    // One diagnostic per written signature, not per use
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn a_reused_alias_reports_its_signature_once() {
+        let source = concat!(
+            "type Bad = (...a: number[], b: string) => void;\n",
+            "declare const x1: Bad;\n",
+            "declare const x2: Bad;\n"
+        );
+        assert_eq!(codes_at(source), vec![(1014, offset_of(source, "...", 0))]);
+    }
+
+    #[test]
+    fn a_generic_alias_instantiated_twice_reports_its_signature_once() {
+        let source = concat!(
+            "type G<T> = (a?: T, b: T) => void;\n",
+            "declare const g1: G<number>;\n",
+            "declare const g2: G<string>;\n"
+        );
+        assert_eq!(codes_at(source), vec![(1016, offset_of(source, "b:", 0))]);
+    }
+}

--- a/crates/tsz-checker/src/types/type_node.rs
+++ b/crates/tsz-checker/src/types/type_node.rs
@@ -759,6 +759,16 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             &func_data.parameters,
             container_kind,
         );
+        // TS1014/TS1015/TS1016: the same parameter-list grammar every other
+        // signature form gets from `check_parameter_ordering`. tsc runs
+        // `checkGrammarParameterList` for `FunctionType`/`ConstructorType` too,
+        // so a misplaced rest or a required-after-optional parameter is an
+        // error in `(...a: number[], b: string) => void` exactly as it is in a
+        // function declaration.
+        crate::checkers_domain::parameter_checker::check_type_position_parameter_list_grammar_in_ctx(
+            self.ctx,
+            &func_data.parameters,
+        );
 
         use tsz_parser::parser::syntax_kind_ext;
 


### PR DESCRIPTION
**Structural rule.** When a signature is written in *type* position — a `FunctionType` (`type F = ( ...a: number[], b: string ) =` `> void`) or a `ConstructorType` (`new ( a?: number, b: string ) =` `> object`) — tsc runs the same `checkGrammarParameterList` it runs for a function declaration, reporting TS1014 (rest not last), TS1015 (`?` with an initializer) and TS1016 (required after optional). tsz reported none of them; it now does, through the **checker** (`checkers/parameter_checker.rs`), which already owns TS1016 and the sibling `this`-parameter placement check for these same nodes.

**Why it was invisible.** Every other signature form reaches this grammar through `CheckerState::check_parameter_ordering`. Function/constructor types do not: they are parsed by `parse_type_parameter_list` (`state_types_jsx.rs`), a separate routine from `parse_parameter_list`, and typed by `get_type_from_function_type` (`types/type_node.rs`), which never called it. The comment above that function's `this`-placement call says these nodes "do not route through `check_parameter_ordering`" — the placement check was moved over and the ordering grammar was not.

**At most one diagnostic per parameter list.** Every arm of tsc's `checkGrammarParameterList` is a `return grammarErrorOnNode(...)`, so the first failing parameter wins and the walk stops. The new helper mirrors that: `( ...a: number[], b?: string, c: string )` is TS1014 alone, and `( a?: number, b: string, c: string )` is one TS1016, not two. A parameter with an initializer is neither "required" for the TS1016 arm nor makes its successors optional, matching tsc's `isOptionalParameter` index-vs-minimum-argument-count rule — `function f(a = 1, b: number) {}` stays clean.

## Goal
Goal: hold

## Verification

All expectations pinned against `typescript@7.0.2` (`scripts/conformance/typescript-versions.json`), run through the built `tsz` CLI and the oracle side by side.

**Adjacent-case matrix — 24 shapes, tsz output now byte-identical to tsc on all of them.**

| family | shapes | before | after |
| --- | --- | --- | --- |
| TS1014 in type position | alias, inline annotation, generic, constructor type, abstract constructor type, parameter annotation, union member, array element, nested object-type member, interface property | 0 / 10 reported | **10 / 10** |
| TS1016 in type position | same 10 spellings | 0 / 10 reported | **10 / 10** |
| TS1015 in type position | `( a?: number = 1 ) =` `> void` (tsc draws TS1015 *and* TS2371 at one anchor) | TS2371 only | **TS1015 + TS2371** |
| one-error-per-list | rest-before-a-later-ordering-error; two required-after-optional | n/a (nothing reported) | **first arm only, matching tsc** |
| negative controls | optional-after-required, trailing rest after optional, initializer-not-optional, binding patterns, `this` first, empty list, declaration/interface/object-literal halves | clean | **clean** |
| once per written signature | alias used twice, generic alias instantiated twice | n/a | **1 diagnostic each, not per use** |

The sibling halves that already worked are re-verified unchanged: function, arrow, method, constructor, interface method/call/construct signature, and object-literal method all still report TS1014/TS1015/TS1016 at the same anchors as tsc.

**Commands**

- `cargo test -p tsz-checker --lib function_type_parameter_grammar` — **27 / 27** (new file, 0 before).
- `cargo test -p tsz-checker --lib parameter` — 519 / 519; `this_parameter` 58 / 58; `function_type` 142 / 142; `type_node` 8 / 8; `grammar` 188 / 188.
- Full `cargo test -p tsz-checker --lib` — started locally, still in its long tail at session end; result will be posted as a comment. Targeted lanes above are green.
- `cargo fmt --all`, `cargo clippy -p tsz-checker --lib -- -D warnings` — clean; `scripts/arch/arch_guard.py` — passed. Pre-commit hook (clippy + arch guard, `-p tsz-checker`) passed.
- `compare-to-parent.sh` **owed and disclosed, not skipped**: no TypeScript submodule on this seat and the two-sided `dist-fast` run is 55–90 min here. Risk shape is one-directional — the change can only *add* TS1014/TS1015/TS1016 on a function/constructor **type** node whose parameter list is already ill-formed; it cannot remove, relocate or alter any existing diagnostic, and it touches no relation, inference or display path. Corpus rows written to be legal are unaffected; a row that already carries one of these ill-formed type-position signatures would gain the diagnostic tsc also reports.

**Not in this PR** (filed separately): tsc's one-error-per-list rule is violated on the *declaration* half, which this change does not touch — `function d1(a?: number, b: string, c: string) {}` is one TS1016 in tsc and two in tsz, and `function d4(a?: number, b: string, ...c: any[], d: any) {}` is TS1016 alone in tsc but TS1016 + TS1014 in tsz (the TS1014 comes from the parser, the TS1016 from the checker, so neither can suppress the other). The new type-position path implements the early return correctly and does not inherit either bug.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Nephrite

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwQMDTroaoFwDgYgz8ease)_