### PR TITLE
fix(checker): a symbol-keyed object-literal property routes through [k: symbol], not [k: string]

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1977,6 +1977,9 @@ path = "tests/lib_global_namespace_shadowing_tests.rs"
 name = "symbol_index_signature_tests"
 path = "tests/symbol_index_signature_tests.rs"
 [[test]]
+name = "mixed_string_symbol_index_signature_ts2418_tests"
+path = "tests/mixed_string_symbol_index_signature_ts2418_tests.rs"
+[[test]]
 name = "non_unique_symbol_late_bound_member_tests"
 path = "tests/non_unique_symbol_late_bound_member_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking/property.rs
+++ b/crates/tsz-checker/src/state/state_checking/property.rs
@@ -837,14 +837,34 @@ impl<'a> CheckerState<'a> {
                     }
 
                     let prop_name = self.ctx.types.resolve_atom(source_prop.name);
-                    let matches_index = self.string_index_key_accepts_property_name(
-                        idx_key_type,
-                        prop_name.as_ref(),
-                        source_prop.is_symbol_named,
-                    );
+                    // A symbol-keyed source property is never covered by the
+                    // `[k: string]` index handled by `idx_key_type` above —
+                    // check the target's dedicated `symbol_index` slot
+                    // instead (`try_union_index_signature_value_check` above
+                    // already reported any value mismatch against it and
+                    // returned early, so reaching here means it is either
+                    // covered-and-compatible or genuinely uncovered).
+                    let symbol_index = source_prop
+                        .is_symbol_named
+                        .then(|| target_shape.symbol_index_signature())
+                        .flatten();
+                    let matches_index = if source_prop.is_symbol_named {
+                        symbol_index.is_some()
+                    } else {
+                        self.string_index_key_accepts_property_name(
+                            idx_key_type,
+                            prop_name.as_ref(),
+                            false,
+                        )
+                    };
                     let target_prop = target_props.iter().find(|p| p.name == source_prop.name);
 
-                    if !matches_index && target_prop.is_none() {
+                    // An uncovered symbol key (no matching named member, no
+                    // `[k: symbol]` index) is not excess — tsc's
+                    // `getApplicableIndexInfo` simply has nothing to check it
+                    // against and leaves it alone (oracle-verified: no TS2353
+                    // for `{ [sym]: v }` against `{ [k: string]: T }` alone).
+                    if !matches_index && target_prop.is_none() && !source_prop.is_symbol_named {
                         let report_idx = self
                             .find_object_literal_property_element(
                                 object_literal_idx,
@@ -857,7 +877,11 @@ impl<'a> CheckerState<'a> {
 
                     let mut nested_types = Vec::new();
                     if matches_index {
-                        nested_types.push(idx_value_type);
+                        nested_types.push(
+                            symbol_index
+                                .map(|sig| sig.value_type)
+                                .unwrap_or(idx_value_type),
+                        );
                     }
                     if let Some(target_prop) = target_prop {
                         // Continue iterating after a mismatch — tsc reports all mismatching

--- a/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
+++ b/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
@@ -60,6 +60,35 @@ impl<'a> CheckerState<'a> {
             let mut has_deferred_index_value_type = false;
 
             for shape in union_shapes {
+                // A symbol-keyed source property is covered only by the
+                // target's `[k: symbol]` index — never by `[k: string]`/
+                // `[k: number]` (guarded out below via
+                // `string_index_key_accepts_property_name`'s `is_symbol_named`
+                // check). Checked first — and independently of the
+                // `string_index` block below, which `continue`s past the rest
+                // of this shape on a non-match — so a mixed-index target
+                // (`{ [k: string]: A; [k: symbol]: B }`) still validates the
+                // value against `B`.
+                if source_prop.is_symbol_named
+                    && let Some(symbol_index) = shape.symbol_index_signature()
+                {
+                    if self.index_value_type_is_deferred(symbol_index.value_type) {
+                        has_deferred_index_value_type = true;
+                    } else {
+                        applicable_index_value_types.push(symbol_index.value_type);
+                        if self
+                            .index_signature_relation_outcome(
+                                source_prop.type_id,
+                                symbol_index.value_type,
+                            )
+                            .related
+                        {
+                            accepted_by_index = true;
+                            break;
+                        }
+                    }
+                }
+
                 if let Some(string_index) = &shape.string_index {
                     if !self.string_index_key_accepts_property_name(
                         string_index.key_type,

--- a/crates/tsz-checker/src/state/state_checking/property_index_key_helpers.rs
+++ b/crates/tsz-checker/src/state/state_checking/property_index_key_helpers.rs
@@ -21,12 +21,18 @@ impl<'a> CheckerState<'a> {
                 || prop_name.starts_with("__@");
         }
 
-        if key_type == TypeId::STRING {
-            return true;
-        }
-
+        // A symbol-keyed property is never covered by a string/number-index
+        // key: tsc's `getApplicableIndexInfo` only routes a symbol key through
+        // a `[k: symbol]` index (or a declared named member for that exact
+        // symbol). Must run before the `STRING` short-circuit below, which
+        // would otherwise treat every property name — symbol-keyed or not —
+        // as string-index-covered.
         if is_symbol_named {
             return false;
+        }
+
+        if key_type == TypeId::STRING {
+            return true;
         }
 
         let prop_literal =

--- a/crates/tsz-checker/tests/mixed_string_symbol_index_signature_ts2418_tests.rs
+++ b/crates/tsz-checker/tests/mixed_string_symbol_index_signature_ts2418_tests.rs
@@ -1,0 +1,158 @@
+//! Regression tests for issue #16637: an object-literal computed `symbol` key
+//! validated against a target's `[k: string]` index instead of its
+//! `[k: symbol]` index when both are present on the same shape.
+//!
+//! `tsc`'s `getApplicableIndexInfo` routes a `symbol`-keyed computed property
+//! through the target's `[k: symbol]` index exclusively — a `[k: string]` (or
+//! `[k: number]`) index never applies to a symbol key, even when the target
+//! also carries one.
+//!
+//! The unit harness runs with no lib (`CheckerOptions::default()`), so
+//! `Symbol()` itself does not resolve (`TS2583`) — every case uses
+//! `declare const s: unique symbol;` instead, matching the rest of this
+//! crate's symbol-index test suite.
+
+use tsz_checker::diagnostics::diagnostic_codes;
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn diagnostic_codes_for_ts(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|diagnostic| diagnostic.code)
+        .collect()
+}
+
+fn assert_clean(source: &str) {
+    let codes = diagnostic_codes_for_ts(source);
+    assert!(codes.is_empty(), "expected no diagnostics, got {codes:?}");
+}
+
+fn assert_only_ts2418(source: &str) {
+    let codes = diagnostic_codes_for_ts(source);
+    assert_eq!(
+        codes,
+        vec![diagnostic_codes::TYPE_OF_COMPUTED_PROPERTYS_VALUE_IS_WHICH_IS_NOT_ASSIGNABLE_TO_TYPE],
+        "expected exactly one TS2418, got {codes:?}"
+    );
+}
+
+// tsc: clean — `[sym]: "x"` is checked against the `[k: symbol]: string`
+// index, not the `[k: string]: number` index. Was a false positive TS2418.
+#[test]
+fn symbol_key_matching_value_against_symbol_index_stays_clean_with_string_index_present() {
+    assert_clean(
+        r#"
+declare const sym: unique symbol;
+interface I { [k: string]: number; [k: symbol]: string; }
+const i: I = { a: 1, [sym]: "x" };
+"#,
+    );
+}
+
+// tsc: TS2418 `number` not assignable to `string` — the symbol index's value
+// type, not the string index's. Was a false negative (silently clean).
+#[test]
+fn symbol_key_mismatched_value_reports_ts2418_against_symbol_index_value_type() {
+    assert_only_ts2418(
+        r#"
+declare const sym: unique symbol;
+interface I { [k: string]: number; [k: symbol]: string; }
+const i: I = { [sym]: 1 };
+"#,
+    );
+}
+
+// tsc: clean — a symbol key uncovered by any index (string-only target) is
+// not excess and not a value mismatch; tsc has nothing to check it against.
+// Was a false positive TS2418 (matched via the string index).
+#[test]
+fn symbol_key_uncovered_by_string_only_index_stays_clean() {
+    assert_clean(
+        r#"
+declare const sym: unique symbol;
+interface I { [k: string]: number; }
+const i: I = { [sym]: "x" };
+"#,
+    );
+}
+
+// Renamed-binder control: the fix must not key off any literal identifier
+// text ("sym"/"I"), only the symbol-ness of the computed key.
+#[test]
+fn symbol_key_renamed_binders_same_behavior() {
+    assert_clean(
+        r#"
+declare const mySymbol: unique symbol;
+interface Target { [index: string]: number; [index: symbol]: string; }
+const target: Target = { field: 1, [mySymbol]: "ok" };
+"#,
+    );
+    assert_only_ts2418(
+        r#"
+declare const mySymbol: unique symbol;
+interface Target { [index: string]: number; [index: symbol]: string; }
+const target: Target = { [mySymbol]: 42 };
+"#,
+    );
+}
+
+// Negative control: an ordinary string-keyed property must still route
+// through the string index exactly as before (not affected by the
+// `is_symbol_named` guard added ahead of the `STRING` short-circuit). A
+// plain (non-computed) named-property mismatch keeps tsc's ordinary TS2322,
+// not the computed-property TS2418.
+#[test]
+fn ordinary_string_key_still_matches_string_index_with_symbol_index_present() {
+    assert_clean(
+        r#"
+interface I { [k: string]: number; [k: symbol]: string; }
+const i: I = { plain: 1 };
+"#,
+    );
+    let codes = diagnostic_codes_for_ts(
+        r#"
+interface I { [k: string]: number; [k: symbol]: string; }
+const i: I = { plain: "wrong" };
+"#,
+    );
+    assert_eq!(
+        codes,
+        vec![diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE],
+        "expected exactly one TS2322 for a plain named-property mismatch, got {codes:?}"
+    );
+}
+
+// Negative control: a numeric key must still route through the number index,
+// unaffected by the symbol-key guard (kept free of a `symbol_index` sibling
+// so it does not also exercise an unrelated, pre-existing numeric-literal
+// index-signature gap).
+#[test]
+fn numeric_key_still_matches_number_index() {
+    assert_clean(
+        r#"
+interface I { [k: number]: string; [k: string]: string; }
+const i: I = { 0: "ok" };
+"#,
+    );
+}
+
+// Positive control: a declared `unique symbol` NAMED member keeps its own
+// named-member path (unaffected — this is not an index-signature lookup at
+// all, the source and target key resolve to the same synthetic atom).
+#[test]
+fn unique_symbol_named_member_unaffected_by_symbol_index_guard() {
+    assert_clean(
+        r#"
+declare const S: unique symbol;
+interface I { [S]: number; [k: string]: string; }
+const i: I = { [S]: 1 };
+"#,
+    );
+    assert_only_ts2418(
+        r#"
+declare const S: unique symbol;
+interface I { [S]: number; [k: string]: string; }
+const i: I = { [S]: "bad" };
+"#,
+    );
+}

--- a/crates/tsz-solver/src/contextual/extractors.rs
+++ b/crates/tsz-solver/src/contextual/extractors.rs
@@ -651,9 +651,23 @@ impl<'a> PropertyExtractor<'a> {
         self.db.literal_string_atom(self.name_atom)
     }
 
+    /// True when `name_atom` is the internal `__unique_<symbol_id>` encoding
+    /// used for a `unique symbol`-keyed object-literal member (see
+    /// `property_key_type` above). A symbol-keyed property name must never
+    /// satisfy a `string`/`number` index signature — tsc's
+    /// `getApplicableIndexInfo` only routes it through a `[k: symbol]` index
+    /// (or a declared named member for that exact symbol, handled earlier in
+    /// `visit_object`/`visit_object_with_index`).
+    fn name_is_symbol_keyed(&self) -> bool {
+        self.db
+            .resolve_atom_ref(self.name_atom)
+            .starts_with("__unique_")
+    }
+
     fn index_signature_applies(&self, idx: &IndexSignature) -> bool {
         match idx.key_type {
-            TypeId::ANY | TypeId::STRING => true,
+            TypeId::ANY => true,
+            TypeId::STRING => !self.name_is_symbol_keyed(),
             TypeId::NUMBER => self.is_numeric_name,
             _ => query_relation(
                 self.db,


### PR DESCRIPTION
Closes #16637.

## Structural rule

When a target object shape carries both a `[k: string]` and a `[k: symbol]` index signature, `tsc`'s `getApplicableIndexInfo` routes a `symbol`-keyed computed property (a `unique symbol`, e.g. `const sym = Symbol(); { [sym]: v }`) through the `[k: symbol]` index **exclusively** — a `[k: string]`/`[k: number]` index never applies to a symbol key, even when the target also carries one. tsz instead matched it through the string index whenever one was present, because four separate string-index-applicability sites treated `is_symbol_named` / the internal `__unique_<id>` atom encoding as an ordinary string name, through solver-backed query boundaries and checker-owned excess-property logic:

- `crates/tsz-solver/src/contextual/extractors.rs` (`PropertyExtractor::index_signature_applies`): `key_type == STRING` short-circuited to `true` unconditionally, before consulting the symbol-ness of the name.
- `crates/tsz-checker/src/state/state_checking/property_index_key_helpers.rs` (`string_index_key_accepts_property_name`): had the identical `STRING` short-circuit placed *ahead of* its own `is_symbol_named` guard, making the guard dead code for that branch.
- `crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs` (`try_union_index_signature_value_check`, also used for non-union simple targets): never consulted a shape's `symbol_index` field at all, so a mismatched symbol-keyed value silently passed (false negative).
- `crates/tsz-checker/src/state/state_checking/property.rs` (the excess-property fallback loop): used the same string-only `matches_index`, which would (a) wrongly flag a property covered by the target's `symbol_index` as excess, and (b) push the wrong (string-index) value type into nested-literal checks.

Fixed all four sites at their owning layer (solver query boundary + checker excess-property/elaboration logic), reordering/adding the `symbol_index`-aware branch ahead of the string-index short-circuit.

## Adjacent-case matrix (oracle-verified, `typescript@7.0.2`)

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| mixed index, symbol key + compatible value (`{[k:string]:number;[k:symbol]:string}`, `{[sym]:"x"}`) | clean | **TS2418 (false positive)** | clean |
| mixed index, symbol key + mismatched value (same target, `{[sym]:1}`) | TS2418 vs `string` | **clean (false negative)** | TS2418 vs `string` |
| string-only index, uncovered symbol key (`{[k:string]:number}`, `{[sym]:"x"}`) | clean | **TS2418 (false positive)** | clean |
| renamed binders (same two shapes above) | — | — | unaffected — same result |
| ordinary string key, mixed index present | TS2322 on mismatch | unaffected | unaffected |
| numeric key, number index present | clean | unaffected | unaffected |
| declared `unique symbol` **named** member (not index-signature routed) | TS2418 on mismatch | unaffected | unaffected |

Two unrelated, pre-existing wrong-code bugs were found while building this matrix and deliberately **not** touched here (one invariant per PR): a computed literal-key mismatch (`{["lit"]:...}`) against an index-signature-only target reports tsz's TS2418 where tsc reports TS2322, and a wide (non-unique) `symbol`-typed key mismatch against a mixed-index target reports tsz's TS2418 where tsc reports the object-level TS2322 with a "symbol index signatures are incompatible" chain. Confirmed identical on `main` before this diff (`git stash` A/B). Will file separately.

## Verification

- New suite `cargo test -p tsz-checker --test mixed_string_symbol_index_signature_ts2418_tests` — 7/7 passed (registered via `[[test]]` in `Cargo.toml`, `autotests = false`).
- `cargo test -p tsz-checker --test symbol_index_signature_tests` — 93/93 passed.
- `cargo test -p tsz-checker --lib ts2418_computed_property_value_widening` — 6/6 passed.
- `cargo test -p tsz-checker --test wide_symbol_computed_member_index_signature_tests` — 25/25 passed.
- `cargo test -p tsz-checker --test well_known_symbol_syntactic_key_parity_tests` — 6/6 passed (2 ignored, pre-existing).
- `cargo test -p tsz-checker --test ts7053_unique_symbol_constrained_type_param_index_tests` — 8/8 passed.
- `cargo test -p tsz-checker --test class_implements_index_signature_tests` — 21/21 passed.
- `cargo test -p tsz-checker --test source_file_index_signatures_rewrite_tests` — 6/6 passed.
- `cargo test -p tsz-checker --test union_spread_index_bucket_tests` — 12/12 passed.
- `cargo fmt -p tsz-checker -p tsz-solver -- --check` — clean.
- `cargo clippy -p tsz-checker -p tsz-solver --lib --tests -- -D warnings` — clean.
- CLI oracle cross-check on the full adjacent matrix above via `tsz --noEmit --strict` vs `typescript@7.0.2`, A/B'd against unmodified `main` (`git stash`) to confirm the two out-of-scope bugs are pre-existing, not introduced.
- Pre-commit hook (clippy + arch-guard + affected-crate verification) passed clean at commit `1786c54`.
- Owed, disclosed: `cargo test -p tsz-checker --lib` (full suite) and `compare-to-parent.sh`/broad conformance snapshot were still running past this session's time budget (the `--lib` suite's long tail is 20+ minutes per board notes) — the change is scoped to computed-symbol-key index routing, a narrow surface already covered above by the directly relevant test families with zero regressions.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_016igWdAHCPjWcKFC3AcfXkt)_