### PR TITLE
fix(checker): a symbol-keyed object-literal computed property selects the [k: symbol] index signature (#16637)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2697,3 +2697,6 @@ path = "tests/qualified_default_import_enum_namespace_merge_root_tests.rs"
 [[test]]
 name = "union_display_alias_repaint_parity_tests"
 path = "tests/union_display_alias_repaint_parity_tests.rs"
+[[test]]
+name = "symbol_key_index_signature_selection_tests"
+path = "tests/symbol_key_index_signature_selection_tests.rs"

--- a/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
+++ b/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
@@ -60,6 +60,33 @@ impl<'a> CheckerState<'a> {
             let mut has_deferred_index_value_type = false;
 
             for shape in union_shapes {
+                // A symbol-keyed property is covered only by a `[k: symbol]`
+                // index signature — never by the `[k: string]`/`[k: number]`
+                // branches below. Mirrors tsc `getApplicableIndexInfo`. When the
+                // shape has no symbol signature the property is uncovered and no
+                // value check applies (`applicable_index_value_types` stays empty
+                // for this shape, so the outer guard skips it).
+                if source_prop.is_symbol_named {
+                    if let Some(symbol_index) = shape.symbol_index_signature() {
+                        if self.index_value_type_is_deferred(symbol_index.value_type) {
+                            has_deferred_index_value_type = true;
+                            continue;
+                        }
+                        applicable_index_value_types.push(symbol_index.value_type);
+                        if self
+                            .index_signature_relation_outcome(
+                                source_prop.type_id,
+                                symbol_index.value_type,
+                            )
+                            .related
+                        {
+                            accepted_by_index = true;
+                            break;
+                        }
+                    }
+                    continue;
+                }
+
                 if let Some(string_index) = &shape.string_index {
                     if !self.string_index_key_accepts_property_name(
                         string_index.key_type,

--- a/crates/tsz-checker/tests/symbol_key_index_signature_selection_tests.rs
+++ b/crates/tsz-checker/tests/symbol_key_index_signature_selection_tests.rs
@@ -1,0 +1,187 @@
+//! A `symbol`-keyed object-literal computed property is validated against the
+//! `[k: symbol]` index signature, never the `[k: string]`/`[k: number]` one.
+//!
+//! Regression for #16637. When an object-literal target carried both a string
+//! and a symbol index signature (or a string signature only), tsz resolved a
+//! `symbol`-keyed computed property's target value type through the *string*
+//! index signature instead of the *symbol* one — a false positive when the
+//! value mismatched the string signature and a false negative when it happened
+//! to satisfy it. Per tsc `getApplicableIndexInfo`, a symbol key selects the
+//! symbol index info; a string/number index info does not apply to it.
+//!
+//! Oracle: `typescript@7.0.2`, `--noEmit --strict --lib es2024 --target es2022`.
+//! Binder names (symbol const, alias, index value types) are varied across the
+//! rows so no fixture-name string can drive the decision.
+
+use tsz_checker::context::CheckerOptions;
+
+fn check_strict(source: &str) -> Vec<(u32, String)> {
+    let options = CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        ..Default::default()
+    };
+    tsz_checker::test_utils::check_source(source, "test.ts", options)
+        .into_iter()
+        .map(|d| (d.code, d.message_text))
+        .collect()
+}
+
+fn ts2418_count(diags: &[(u32, String)]) -> usize {
+    diags.iter().filter(|(c, _)| *c == 2418).count()
+}
+
+// ---- False positive: value satisfies the symbol signature -------------------
+
+#[test]
+fn both_signatures_symbol_value_ok_no_ts2418() {
+    // `[k: symbol]: string` covers `[key]: "v"`; the `[k: string]: number`
+    // signature does not apply to the symbol key.
+    let source = r#"
+declare const key: unique symbol;
+interface Bag { [s: string]: number; [s: symbol]: string; }
+const bag: Bag = { count: 1, [key]: "v" };
+"#;
+    let diags = check_strict(source);
+    assert!(
+        diags.is_empty(),
+        "symbol key satisfying the symbol signature must not error: {diags:?}"
+    );
+}
+
+#[test]
+fn both_signatures_symbol_value_ok_renamed_binders() {
+    // Same rule, different names + a type-literal target instead of an
+    // interface, and the value type swapped (symbol sig -> boolean).
+    let source = r#"
+declare const marker: unique symbol;
+type Store = { [prop: string]: number; [prop: symbol]: boolean };
+const store: Store = { [marker]: true };
+"#;
+    let diags = check_strict(source);
+    assert!(
+        diags.is_empty(),
+        "unique-symbol key satisfying the symbol signature must not error: {diags:?}"
+    );
+}
+
+#[test]
+fn string_signature_only_symbol_key_is_uncovered_no_error() {
+    // No symbol signature: the symbol key is not covered by the string
+    // signature and is not an excess property either. tsc reports nothing.
+    let source = r#"
+declare const tag: unique symbol;
+interface OnlyString { [k: string]: number; }
+const a: OnlyString = { [tag]: "not a number" };
+const b: OnlyString = { [tag]: 123 };
+"#;
+    let diags = check_strict(source);
+    assert!(
+        diags.is_empty(),
+        "a symbol key is uncovered (not string-indexed, not excess): {diags:?}"
+    );
+}
+
+// ---- False negative: value violates the symbol signature --------------------
+
+#[test]
+fn both_signatures_symbol_value_bad_emits_ts2418() {
+    // `[k: symbol]: string` requires a string; the numeric value must fail even
+    // though it would satisfy the string signature (`number`).
+    let source = r#"
+declare const key: unique symbol;
+interface Bag { [s: string]: number; [s: symbol]: string; }
+const bag: Bag = { [key]: 1 };
+"#;
+    let diags = check_strict(source);
+    assert_eq!(
+        ts2418_count(&diags),
+        1,
+        "symbol value violating the symbol signature must emit exactly one TS2418: {diags:?}"
+    );
+    let msg = &diags.iter().find(|(c, _)| *c == 2418).unwrap().1;
+    assert!(
+        msg.contains("'number'") && msg.contains("'string'"),
+        "TS2418 must compare the value against the symbol signature value type: {msg}"
+    );
+}
+
+#[test]
+fn symbol_signature_only_value_bad_emits_ts2418() {
+    // Guard: with only a symbol signature the pre-existing path already errored;
+    // it must keep doing so after the selection fix.
+    let source = r#"
+declare const s: unique symbol;
+interface SymOnly { [k: symbol]: string; }
+const v: SymOnly = { [s]: 42 };
+"#;
+    let diags = check_strict(source);
+    assert_eq!(
+        ts2418_count(&diags),
+        1,
+        "symbol-only signature still reports the value mismatch: {diags:?}"
+    );
+}
+
+#[test]
+fn both_signatures_string_and_symbol_each_reported() {
+    // A bad string-keyed value routes through the string signature (TS2322)
+    // while the bad symbol-keyed value routes through the symbol signature
+    // (TS2418): both are reported, at their own keys.
+    let source = r#"
+declare const key: unique symbol;
+interface Bag { [s: string]: number; [s: symbol]: string; }
+const bag: Bag = { named: "x", [key]: 1 };
+"#;
+    let diags = check_strict(source);
+    assert_eq!(
+        diags.iter().filter(|(c, _)| *c == 2322).count(),
+        1,
+        "the string-keyed value mismatch is TS2322: {diags:?}"
+    );
+    assert_eq!(
+        ts2418_count(&diags),
+        1,
+        "the symbol-keyed value mismatch is TS2418: {diags:?}"
+    );
+}
+
+// ---- Negative controls ------------------------------------------------------
+
+#[test]
+fn declared_unique_symbol_member_uses_the_member_not_the_index() {
+    // The target declares a named member for the unique symbol, so the value is
+    // checked against that member (`number`), not any index signature.
+    let source = r#"
+declare const K: unique symbol;
+interface Named { [K]: number; [s: string]: string; }
+const ok: Named = { [K]: 7, extra: "s" };
+const bad: Named = { [K]: "no" };
+"#;
+    let diags = check_strict(source);
+    assert_eq!(
+        ts2418_count(&diags),
+        1,
+        "only the wrong-typed named unique-symbol member errors: {diags:?}"
+    );
+    let msg = &diags.iter().find(|(c, _)| *c == 2418).unwrap().1;
+    assert!(
+        msg.contains("'string'") && msg.contains("'number'"),
+        "the named member's declared type (`number`) is the target: {msg}"
+    );
+}
+
+#[test]
+fn numeric_key_still_uses_string_signature() {
+    // A non-symbol computed key is unaffected: a numeric-named value still flows
+    // through the string signature and reports its mismatch.
+    let source = r#"
+interface Bag { [s: string]: number; [s: symbol]: string; }
+const bag: Bag = { ["0"]: "not a number" };
+"#;
+    let diags = check_strict(source);
+    assert!(
+        !diags.is_empty(),
+        "a string-literal computed key must still be checked against the string signature: {diags:?}"
+    );
+}


### PR DESCRIPTION
Fixes #16637.

When an object-literal target carries both a string and a symbol index signature
(or a string signature only), tsz validated a `symbol`-keyed computed property's
value against the **string** index signature's value type instead of the
**symbol** one — a false positive when the value mismatched the string signature
and a false negative when it happened to satisfy it.

**Structural rule:** when an object-literal computed property is `symbol`-keyed
and the target has no declared named member for that key, tsc selects the
target's `[k: symbol]` index signature as the applicable value type (and reports
the property uncovered when there is none); a `[k: string]`/`[k: number]` index
signature does not apply to it — tsc `getApplicableIndexInfo`. The generic
object→object relation already followed this rule; the divergence was confined
to the fresh object-literal `TS2418` path through
`try_union_index_signature_value_check` (checker).

Owner layer: checker — `try_union_index_signature_value_check` now routes a
symbol-named source property to the shape's symbol index signature only, and
leaves it uncovered (no diagnostic) when the shape has none.

### Adjacent matrix (oracle `typescript@7.0.2`, `--noEmit --strict --lib es2024 --target es2022`)

| source (target has the noted signatures) | before | after / tsc |
| --- | --- | --- |
| symbol key, `{[k:string]; [k:symbol]}`, value ok for symbol sig | `TS2418` (FP) | clean |
| symbol key, `{[k:string]; [k:symbol]}`, value bad for symbol sig | clean (FN) | `TS2418` |
| symbol key, `{[k:string]}` only (uncovered) | `TS2418` (FP) | clean |
| symbol key, `{[k:symbol]}` only, value bad | `TS2418` | `TS2418` (unchanged) |
| declared unique-symbol **named** member | `TS2418` | `TS2418` (member, not index — unchanged) |
| bad string value + bad symbol value | one error | `TS2322` + `TS2418` |
| string-literal / numeric computed key | `TS2418`/`TS2322`* | unchanged (string sig still applies) |

*String-literal/numeric computed keys and wide-`symbol` keys are a separate,
pre-existing `TS2418`-vs-`TS2322` code-selection matter (different mechanism);
they are out of scope here and unchanged by this diff.

## Goal
Goal: hold

## Verification
- New pin `cargo test -p tsz-checker --test symbol_key_index_signature_selection_tests` → **8 passed** (FP, FN, string-only-uncovered, symbol-only, named-member, both-signatures, numeric-key controls; binder names varied per anti-hardcoding).
- `cargo test -p tsz-checker --lib symbol` (473) / `--lib computed` (376, incl. `ts2418_computed_property_value_widening_tests`) → green.
- Symbol/index integration suites green: `symbol_index_signature_tests` (93), `object_literal_unique_symbol_member_tests` (25), `ts2353_cross_module_symbol_computed_key_tests` (3), `wide_symbol_computed_member_index_signature_tests` (10), `index_signature_*`, excess-property suites, `union_index_signature` lib tests (4).
- `cargo clippy -p tsz-checker --all-targets` clean; pre-commit architecture guard passed (LOC 0 over 2000, cross-layer 0).
- Oracle diff sweep against `typescript@7.0.2` over the adjacent-case corpus: the full unique/named-symbol family now matches; only the pre-existing string-literal / wide-symbol code-selection rows remain.
- `cargo-nextest` is absent in this container, so the above are `cargo test` per the board's standing substitute; conformance/emit/fourslash run on the nightly lane and the TypeScript submodule is not checked out here.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_011LeV4BTuwzftKDdb6PbV8R)_