### PR TITLE
fix(checker): a symbol-keyed object-literal property selects the [k: symbol] index signature, not [k: string] (#16637)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1977,6 +1977,9 @@ path = "tests/lib_global_namespace_shadowing_tests.rs"
 name = "symbol_index_signature_tests"
 path = "tests/symbol_index_signature_tests.rs"
 [[test]]
+name = "symbol_computed_key_index_signature_selection_tests"
+path = "tests/symbol_computed_key_index_signature_selection_tests.rs"
+[[test]]
 name = "non_unique_symbol_late_bound_member_tests"
 path = "tests/non_unique_symbol_late_bound_member_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking/property.rs
+++ b/crates/tsz-checker/src/state/state_checking/property.rs
@@ -844,6 +844,15 @@ impl<'a> CheckerState<'a> {
                     );
                     let target_prop = target_props.iter().find(|p| p.name == source_prop.name);
 
+                    // A `symbol`-keyed property is covered only by a `[k: symbol]`
+                    // signature (checked in `try_union_index_signature_value_check`
+                    // above) or a declared named member. It is never excess against
+                    // a string index and is never checked against the string/number
+                    // index value, so skip it here unless it names a declared member.
+                    if source_prop.is_symbol_named && target_prop.is_none() {
+                        continue;
+                    }
+
                     if !matches_index && target_prop.is_none() {
                         let report_idx = self
                             .find_object_literal_property_element(

--- a/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
+++ b/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
@@ -60,6 +60,30 @@ impl<'a> CheckerState<'a> {
             let mut has_deferred_index_value_type = false;
 
             for shape in union_shapes {
+                // A `symbol`-keyed property is covered only by the target's
+                // `[k: symbol]` signature (tsc `getApplicableIndexInfo`); the
+                // `[k: string]`/`[k: number]` signatures this loop otherwise
+                // selects never apply to it. Route the value check to the symbol
+                // signature so a mismatch surfaces (TS2418) and a match is
+                // accepted — and, when the target has no symbol signature, the
+                // property is left uncovered (not excess), matching `tsc`. The
+                // trailing `continue` keeps a symbol key from ever falling
+                // through to the string/number branches below.
+                if source_prop.is_symbol_named {
+                    if let Some(symbol_index) = shape.symbol_index_signature()
+                        && self.record_applicable_index_value(
+                            source_prop.type_id,
+                            symbol_index.value_type,
+                            &mut applicable_index_value_types,
+                            &mut has_deferred_index_value_type,
+                        )
+                    {
+                        accepted_by_index = true;
+                        break;
+                    }
+                    continue;
+                }
+
                 if let Some(string_index) = &shape.string_index {
                     if !self.string_index_key_accepts_property_name(
                         string_index.key_type,
@@ -68,39 +92,28 @@ impl<'a> CheckerState<'a> {
                     ) {
                         continue;
                     }
-                    if self.index_value_type_is_deferred(string_index.value_type) {
-                        has_deferred_index_value_type = true;
-                        continue;
-                    }
-                    applicable_index_value_types.push(string_index.value_type);
-                    if self
-                        .index_signature_relation_outcome(
-                            source_prop.type_id,
-                            string_index.value_type,
-                        )
-                        .related
-                    {
+                    if self.record_applicable_index_value(
+                        source_prop.type_id,
+                        string_index.value_type,
+                        &mut applicable_index_value_types,
+                        &mut has_deferred_index_value_type,
+                    ) {
                         accepted_by_index = true;
                         break;
                     }
                 }
 
-                if is_numeric_name && let Some(number_index) = &shape.number_index {
-                    if self.index_value_type_is_deferred(number_index.value_type) {
-                        has_deferred_index_value_type = true;
-                        continue;
-                    }
-                    applicable_index_value_types.push(number_index.value_type);
-                    if self
-                        .index_signature_relation_outcome(
-                            source_prop.type_id,
-                            number_index.value_type,
-                        )
-                        .related
-                    {
-                        accepted_by_index = true;
-                        break;
-                    }
+                if is_numeric_name
+                    && let Some(number_index) = &shape.number_index
+                    && self.record_applicable_index_value(
+                        source_prop.type_id,
+                        number_index.value_type,
+                        &mut applicable_index_value_types,
+                        &mut has_deferred_index_value_type,
+                    )
+                {
+                    accepted_by_index = true;
+                    break;
                 }
             }
 
@@ -264,5 +277,27 @@ impl<'a> CheckerState<'a> {
         }
 
         self.ctx.diagnostics.len() > diag_count_before
+    }
+
+    /// Record `value_type` as an applicable index-signature value for the
+    /// property under check, returning `true` when the property's type is
+    /// assignable to it — i.e. an accepting signature was found and the caller
+    /// should stop scanning. A deferred value type is noted in
+    /// `has_deferred_index_value_type` and never counts as accepting. Shared by
+    /// the symbol / string / number branches of the per-shape scan.
+    fn record_applicable_index_value(
+        &mut self,
+        source_type: TypeId,
+        value_type: TypeId,
+        applicable_index_value_types: &mut Vec<TypeId>,
+        has_deferred_index_value_type: &mut bool,
+    ) -> bool {
+        if self.index_value_type_is_deferred(value_type) {
+            *has_deferred_index_value_type = true;
+            return false;
+        }
+        applicable_index_value_types.push(value_type);
+        self.index_signature_relation_outcome(source_type, value_type)
+            .related
     }
 }

--- a/crates/tsz-checker/src/state/state_checking/property_index_key_helpers.rs
+++ b/crates/tsz-checker/src/state/state_checking/property_index_key_helpers.rs
@@ -21,12 +21,17 @@ impl<'a> CheckerState<'a> {
                 || prop_name.starts_with("__@");
         }
 
-        if key_type == TypeId::STRING {
-            return true;
-        }
-
+        // A `symbol`-keyed property is covered only by a `[k: symbol]` index
+        // signature (tsc `getApplicableIndexInfo`); a `[k: string]`/`[k: number]`
+        // key — broad or template-literal — never applies to it. This guard must
+        // precede the broad `TypeId::STRING` acceptance below, which would
+        // otherwise claim every symbol-keyed property for the string signature.
         if is_symbol_named {
             return false;
+        }
+
+        if key_type == TypeId::STRING {
+            return true;
         }
 
         let prop_literal =

--- a/crates/tsz-checker/tests/symbol_computed_key_index_signature_selection_tests.rs
+++ b/crates/tsz-checker/tests/symbol_computed_key_index_signature_selection_tests.rs
@@ -1,0 +1,141 @@
+//! Parity pins for #16637: a `symbol`-keyed computed property in a fresh
+//! object literal must select the target's **symbol** index signature (or a
+//! declared symbol-named member), never the `[k: string]` / `[k: number]`
+//! signature.
+//!
+//! tsc's rule (`getApplicableIndexInfo`): a `symbol`-keyed property is covered
+//! only by a `[k: symbol]` index signature (or a declared named member for
+//! that unique symbol). A `[k: string]` (or `[k: number]`) index signature does
+//! not apply to symbol-keyed properties. Oracled against `typescript@7.0.2`,
+//! `--noEmit --strict --target es2022`.
+//!
+//! A `unique symbol` key stands in for the issue's `const sym = Symbol()`
+//! witness; both are a unique-symbol computed key, and using `declare const`
+//! keeps the fixtures independent of which `lib` provides `Symbol`.
+
+use tsz_checker::diagnostics::diagnostic_codes;
+use tsz_checker::test_utils::check_source_diagnostics;
+
+const TS2418: u32 =
+    diagnostic_codes::TYPE_OF_COMPUTED_PROPERTYS_VALUE_IS_WHICH_IS_NOT_ASSIGNABLE_TO_TYPE;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|diagnostic| diagnostic.code)
+        .collect()
+}
+
+// ── false positive: value ok for the symbol signature ────────────────────────
+// tsc: clean (`[sym]: "x"` checked against `[k: symbol]: string`).
+#[test]
+fn symbol_key_value_ok_for_symbol_signature_is_clean() {
+    let source = r#"
+declare const sym: unique symbol;
+interface I { [k: string]: number; [k: symbol]: string; }
+const i: I = { a: 1, [sym]: "x" };
+"#;
+    assert_eq!(codes(source), Vec::<u32>::new());
+}
+
+// ── false negative: value bad for the symbol signature ───────────────────────
+// tsc: TS2418 (`number` is not assignable to the symbol signature's `string`).
+#[test]
+fn symbol_key_value_bad_for_symbol_signature_reports_ts2418() {
+    let source = r#"
+declare const sym: unique symbol;
+interface I { [k: string]: number; [k: symbol]: string; }
+const i: I = { [sym]: 1 };
+"#;
+    assert_eq!(codes(source), vec![TS2418]);
+}
+
+// ── string-only signature: symbol key is uncovered, not an error ─────────────
+// tsc: clean (the symbol property is not covered by the string signature and is
+// not excess).
+#[test]
+fn symbol_key_against_string_only_signature_is_uncovered_and_clean() {
+    let source = r#"
+declare const sym: unique symbol;
+interface I { [k: string]: number; }
+const i: I = { [sym]: "x" };
+"#;
+    assert_eq!(codes(source), Vec::<u32>::new());
+}
+
+// ── symbol-only signature: value bad still reports (already correct) ──────────
+#[test]
+fn symbol_key_against_symbol_only_signature_reports_ts2418_on_mismatch() {
+    let source = r#"
+declare const sym: unique symbol;
+interface I { [k: symbol]: string; }
+const i: I = { [sym]: 1 };
+"#;
+    assert_eq!(codes(source), vec![TS2418]);
+}
+
+// ── declared symbol-named member: named-member path, unchanged ───────────────
+// A `unique symbol` NAMED member is checked as a property, not through any
+// index signature.
+#[test]
+fn declared_symbol_named_member_value_mismatch_reports_ts2418() {
+    let source = r#"
+declare const sym: unique symbol;
+interface I { [sym]: number; }
+const i: I = { [sym]: "x" };
+"#;
+    assert_eq!(codes(source), vec![TS2418]);
+}
+
+#[test]
+fn declared_symbol_named_member_value_ok_is_clean() {
+    let source = r#"
+declare const sym: unique symbol;
+interface I { [sym]: number; }
+const i: I = { [sym]: 1 };
+"#;
+    assert_eq!(codes(source), Vec::<u32>::new());
+}
+
+// ── negative controls: string / numeric literal keys still use the string /
+//    number signature (symbol selection must not steal them) ─────────────────
+#[test]
+fn string_literal_key_still_uses_string_signature() {
+    // `["a"]: "x"` against `[k: string]: number` — the string signature applies,
+    // so the mismatch is reported.
+    let source = r#"
+interface I { [k: string]: number; [k: symbol]: string; }
+const i: I = { ["a"]: "x" };
+"#;
+    assert_eq!(codes(source), vec![TS2418]);
+}
+
+#[test]
+fn string_literal_key_value_ok_for_string_signature_is_clean() {
+    let source = r#"
+interface I { [k: string]: number; [k: symbol]: string; }
+const i: I = { ["a"]: 1 };
+"#;
+    assert_eq!(codes(source), Vec::<u32>::new());
+}
+
+// ── renamed binders: the rule is structural, not tied to `sym`/`I`/`k` ───────
+#[test]
+fn renamed_binders_symbol_key_value_ok_is_clean() {
+    let source = r#"
+declare const marker: unique symbol;
+interface Bag { [key: string]: number; [key: symbol]: string; }
+const b: Bag = { [marker]: "ok" };
+"#;
+    assert_eq!(codes(source), Vec::<u32>::new());
+}
+
+#[test]
+fn renamed_binders_symbol_key_value_bad_reports_ts2418() {
+    let source = r#"
+declare const marker: unique symbol;
+interface Bag { [key: string]: number; [key: symbol]: string; }
+const b: Bag = { [marker]: 1 };
+"#;
+    assert_eq!(codes(source), vec![TS2418]);
+}


### PR DESCRIPTION
Fixes #16637.

## Structural rule

When a fresh object literal has a `symbol`-keyed computed property, `tsc`'s
`getApplicableIndexInfo` covers it only by a `[k: symbol]` index signature (or a
declared symbol-named member); a `[k: string]`/`[k: number]` signature **never**
applies. tsz resolved such a property through string-name index selection, so a
co-existing `[k: string]` signature was chosen. That produced, against
`interface I { [k: string]: number; [k: symbol]: string }` with a
`unique symbol` key `sym`:

| source | tsc@7.0.2 | tsz (before) | tsz (after) |
| --- | --- | --- | --- |
| `const i: I = { a: 1, [sym]: "x" }` | clean | **TS2418** (`string`→`number`) | clean |
| `const i: I = { [sym]: 1 }` | **TS2418** (`number`→`string`) | clean | TS2418 |
| `[k: string]`-only target, `{ [sym]: "x" }` | clean (uncovered) | **TS2418** | clean |

So a false positive, a false negative, and a spurious TS2418 against a
string-only target — all from the same wrong applicable-index selection.

The divergence lives in the object-literal excess / index-signature checking
path (checker), not the call-argument elaboration, which skips symbol keys
(name-text resolution returns `None`). Three touch-points, all in that owner:

- `string_index_key_accepts_property_name`: a symbol-named property is rejected
  by broad/template `[k: string]`/`[k: number]` keys — the `is_symbol_named`
  guard now precedes the unconditional `TypeId::STRING` acceptance.
- `try_union_index_signature_value_check`: a symbol-named property routes its
  value check to the shape's `[k: symbol]` signature; with no symbol signature
  the property is left **uncovered** (not excess) rather than checked against
  the string/number value. The shared deferred/record/relation tail of the
  three index branches is factored into `record_applicable_index_value`.
- string-index excess loop (`property.rs`): a symbol-named property with no
  declared named member is neither excess nor string-index-checked.

A declared symbol-named member (`interface I { [sym]: number }`) is unchanged —
it is filtered out ahead of the index scan (named member wins) and checked as an
ordinary named property, so the named-member-plus-symbol-index edge case does
not over-report.

No user-name / file-name literals drive logic; no formatted diagnostic string is
used as a predicate; the decision keys on the `is_symbol_named` structural flag
and the shape's `[k: symbol]` signature.

Follow-up (out of scope): the symbol-vs-string-vs-number applicable-index
decision is open-coded here and in the solver's property-access path; a shared
`getApplicableIndexInfo`-style selector (and an `IndexKind::Symbol` variant)
would centralize it.

## Goal
Goal: hold

## Verification

- `cargo test -p tsz-checker --test symbol_computed_key_index_signature_selection_tests`
  → **10 passed** (new adjacent-matrix pins: FP, FN, string-only-uncovered,
  symbol-only-signature, declared-named-member ×2, string/numeric-literal-key
  controls ×2, renamed-binder ×2).
- Symbol / index-signature / excess / object-literal integration suites green:
  `symbol_index_signature_tests`, `object_literal_unique_symbol_member_tests`,
  `wide_symbol_computed_member_index_signature_tests`, `ts2353_*`,
  `index_signature_*`, and ~40 more (470 tests, 0 failed).
- `cargo test -p tsz-checker --lib` filtered to the affected modules
  (`ts2418`, `object_literal`, `computed_key`, `symbol`, `index_signature`,
  `excess`) → **1007 passed, 0 failed**; the full lib run reported 10,147 `ok`
  / 0 failed before three pre-existing slow stragglers were interrupted
  (recursive-conditional TS2589, static-init hierarchy, generic factories —
  none touch symbol-keyed object literals).
- `cargo clippy -p tsz-checker` clean.
- `cargo-nextest` is absent in this container, so the above are `cargo test`
  invocations per the board's standing substitute. Conformance / emit /
  fourslash run on the nightly lane; the TypeScript submodule tree is not
  checked out in this environment.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Smg7gNAQzfJnMEAztMHv4g)_