### PR TITLE
fix(checker): a parenthesized optional chain is not an optional-chain write target (#16678)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
@@ -165,51 +165,6 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    /// Check if a node is part of an optional chain (has `?.` somewhere in its left spine).
-    ///
-    /// Walks through property access, element access, and call expression chains looking
-    /// for any node with `question_dot_token: true` (for accesses) or the `OPTIONAL_CHAIN`
-    /// flag (for calls). For example, in `obj?.a.b`, both `obj?.a` and `obj?.a.b` are
-    /// considered part of the optional chain.
-    ///
-    /// Skips through transparent wrappers (parenthesized, non-null, type assertions, satisfies).
-    pub(crate) fn is_optional_chain_access(&self, idx: NodeIndex) -> bool {
-        let idx = self.ctx.arena.skip_parenthesized_and_assertions(idx);
-        let Some(node) = self.ctx.arena.get(idx) else {
-            return false;
-        };
-
-        match node.kind {
-            k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
-                || k == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION =>
-            {
-                if let Some(access) = self.ctx.arena.get_access_expr(node) {
-                    // This node itself is an optional chain root (has `?.`)
-                    if access.question_dot_token {
-                        return true;
-                    }
-                    // Check if the base expression is part of an optional chain
-                    self.is_optional_chain_access(access.expression)
-                } else {
-                    false
-                }
-            }
-            k if k == syntax_kind_ext::CALL_EXPRESSION => {
-                // Call expressions get the OPTIONAL_CHAIN flag from the parser
-                if node.is_optional_chain() {
-                    return true;
-                }
-                // Check if the callee is part of an optional chain
-                if let Some(call) = self.ctx.arena.get_call_expr(node) {
-                    self.is_optional_chain_access(call.expression)
-                } else {
-                    false
-                }
-            }
-            _ => false,
-        }
-    }
-
     /// Check if a node is a valid target for object rest assignment.
     /// Valid targets are identifiers, property accesses, and element accesses.
     /// Binary expressions like `a + b` are NOT valid rest targets (TS2701).

--- a/crates/tsz-checker/src/assignability/assignment_checker/mod.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/mod.rs
@@ -7,6 +7,7 @@ mod commonjs_assignment;
 mod destructuring;
 mod js_constructor_provisional;
 mod js_global_fallback;
+mod optional_chain_target;
 mod polymorphic_this_display;
 mod rhs_literal_walker;
 

--- a/crates/tsz-checker/src/assignability/assignment_checker/optional_chain_target.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/optional_chain_target.rs
@@ -1,0 +1,97 @@
+//! Optional-chain recognition for assignment-like write targets.
+//!
+//! tsc decides `a?.b.c = 1` is an optional-chain target from the syntactic
+//! chain (`NodeFlags.OptionalChain`), which the parser stops propagating at a
+//! `ParenthesizedExpression` but carries through assertions. These helpers are
+//! the tsz equivalent, and they own the TS2777/TS2779/TS2780/TS2781 predicate.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+
+impl CheckerState<'_> {
+    /// Check if a node is part of an optional chain (has `?.` somewhere in its left spine).
+    ///
+    /// Walks through property access, element access, and call expression chains looking
+    /// for any node with `question_dot_token: true` (for accesses) or the `OPTIONAL_CHAIN`
+    /// flag (for calls). For example, in `obj?.a.b`, both `obj?.a` and `obj?.a.b` are
+    /// considered part of the optional chain.
+    ///
+    /// Skips through transparent wrappers (parenthesized, non-null, type assertions, satisfies).
+    pub(crate) fn is_optional_chain_access(&self, idx: NodeIndex) -> bool {
+        // tsc's `checkReferenceExpression` looks through the outer parentheses
+        // and assertions of the target itself before testing the chain flag, so
+        // `(a?.b) = 1` is still an optional-chain target.
+        self.chain_continues_through(self.ctx.arena.skip_parenthesized_and_assertions(idx))
+    }
+
+    /// Whether `idx` carries — or continues — an optional chain.
+    ///
+    /// Parentheses END a chain: tsc's parser stops setting `NodeFlags.OptionalChain`
+    /// at a `ParenthesizedExpression`, so `(a?.b).c` is an ordinary property access
+    /// on a possibly-nullish receiver, not an optional-chain target. Assertions do
+    /// not end one — `a?.b!.c` stays a chain.
+    fn chain_continues_through(&self, idx: NodeIndex) -> bool {
+        let Some(node) = self.ctx.arena.get(idx) else {
+            return false;
+        };
+
+        match node.kind {
+            k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+                || k == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION =>
+            {
+                if let Some(access) = self.ctx.arena.get_access_expr(node) {
+                    // This node itself is an optional chain root (has `?.`)
+                    if access.question_dot_token {
+                        return true;
+                    }
+                    // Check if the base expression is part of an optional chain
+                    self.chain_continues_through(self.skip_chain_assertions(access.expression))
+                } else {
+                    false
+                }
+            }
+            k if k == syntax_kind_ext::CALL_EXPRESSION => {
+                // Call expressions get the OPTIONAL_CHAIN flag from the parser
+                if node.is_optional_chain() {
+                    return true;
+                }
+                // Check if the callee is part of an optional chain
+                if let Some(call) = self.ctx.arena.get_call_expr(node) {
+                    self.chain_continues_through(self.skip_chain_assertions(call.expression))
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        }
+    }
+
+    /// Skip the assertion forms that a chain continues through (`!`, `as`,
+    /// angle-bracket assertion, `satisfies`) without skipping parentheses.
+    fn skip_chain_assertions(&self, mut idx: NodeIndex) -> NodeIndex {
+        for _ in 0..100 {
+            let Some(node) = self.ctx.arena.get(idx) else {
+                return idx;
+            };
+            let inner = if node.kind == syntax_kind_ext::NON_NULL_EXPRESSION {
+                self.ctx.arena.get_unary_expr_ex(node).map(|u| u.expression)
+            } else if node.kind == syntax_kind_ext::AS_EXPRESSION
+                || node.kind == syntax_kind_ext::SATISFIES_EXPRESSION
+                || node.kind == syntax_kind_ext::TYPE_ASSERTION
+            {
+                self.ctx
+                    .arena
+                    .get_type_assertion(node)
+                    .map(|assertion| assertion.expression)
+            } else {
+                None
+            };
+            match inner {
+                Some(next) => idx = next,
+                None => return idx,
+            }
+        }
+        idx
+    }
+}

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -691,6 +691,8 @@ mod object_spread_optional_merge_tests;
 mod operator_chain_overload_resolution_tests;
 #[path = "tests/optional_chain_inherent_nullish_tests.rs"]
 mod optional_chain_inherent_nullish_tests;
+#[path = "tests/optional_chain_parenthesized_target_tests.rs"]
+mod optional_chain_parenthesized_target_tests;
 #[path = "tests/optional_chain_read_before_write_tests.rs"]
 mod optional_chain_read_before_write_tests;
 #[path = "tests/optional_chain_root_nullish_strict_only_tests.rs"]

--- a/crates/tsz-checker/src/tests/optional_chain_parenthesized_target_tests.rs
+++ b/crates/tsz-checker/src/tests/optional_chain_parenthesized_target_tests.rs
@@ -1,0 +1,169 @@
+//! Parentheses terminate an optional chain, so a parenthesized chain is not an
+//! optional-chain write target.
+//!
+//! Structural rule: tsc's parser stops propagating `NodeFlags.OptionalChain` at
+//! a `ParenthesizedExpression`. `(a.b?.c).d = 1` is therefore an ordinary
+//! assignment to a property of a possibly-nullish receiver — TS2532 alone —
+//! while tsz's chain walker skipped parentheses at every level of the left
+//! spine and added a spurious TS2779.
+//!
+//! The rule is "a `ParenthesizedExpression` terminates the chain WALK", not
+//! "parentheses suppress the diagnostic", and it has three distinct halves that
+//! a fix must keep apart:
+//!
+//! - Parens *inside* the spine end the chain: `(a.b?.c).d = 1` -> no TS2779.
+//! - Parens *around the whole target* do not, because tsc's
+//!   `checkReferenceExpression` skips the target's own outer parentheses before
+//!   testing the chain flag: `(a.b?.c.d) = 1` -> TS2779.
+//! - A chain that continues *after* the parenthesized part is still a chain:
+//!   `(a.b)?.c.d = 1` -> TS2779.
+//!
+//! Assertions are not parentheses and do not end a chain: `a?.b!.c = 1` keeps
+//! its TS2779.
+//!
+//! Oracle: `tsc` 7.0.2 (`scripts/conformance/typescript-versions.json`),
+//! `--noEmit --strict --target es2022 --lib es2022 --module esnext`. Every
+//! expectation below is pinned against a real run.
+
+use crate::test_utils::check_source_strict_codes as strict;
+
+const TS18048: u32 = 18048; // '<x>' is possibly 'undefined'.
+const TS2532: u32 = 2532; // Object is possibly 'undefined'.
+const TS2777: u32 = 2777; // Increment/decrement operand may not be an optional property access.
+const TS2779: u32 = 2779; // Assignment LHS may not be an optional property access.
+const TS2781: u32 = 2781; // `for...of` LHS may not be an optional property access.
+
+fn count(codes: &[u32], code: u32) -> usize {
+    codes.iter().filter(|&&c| c == code).count()
+}
+
+fn preamble(outer: &str, mid: &str, leaf: &str) -> String {
+    format!(
+        "declare const {outer}: {{ {mid}?: {{ {leaf}: number }} }};\ndeclare const items: number[];\n"
+    )
+}
+
+#[test]
+fn a_parenthesized_chain_is_not_an_optional_assignment_target() {
+    // Binders are re-spelled per row so nothing keys on identifier text.
+    for (outer, mid, leaf) in [
+        ("a", "b", "c"),
+        ("zq", "al", "be"),
+        ("holder", "inner", "leaf"),
+    ] {
+        let source = format!(
+            "{}({outer}.{mid}?.{leaf}).length = 1;",
+            format_args!(
+                "declare const {outer}: {{ {mid}?: {{ {leaf}: {{ length: number }} }} }};\n"
+            )
+        );
+        let codes = strict(&source);
+        assert_eq!(
+            count(&codes, TS2532),
+            1,
+            "`({outer}.{mid}?.{leaf}).length = 1` must report the possibly-undefined receiver, \
+             got: {codes:?}"
+        );
+        assert_eq!(
+            count(&codes, TS2779),
+            0,
+            "parentheses END the chain, so this is an ordinary assignment target and TS2779 \
+             must not fire, got: {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn a_parenthesized_chain_is_not_an_optional_increment_operand() {
+    let source = format!(
+        "{}(holder?.inner).leaf++;",
+        preamble("holder", "inner", "leaf")
+    );
+    let codes = strict(&source);
+    assert_eq!(count(&codes, TS2532), 1, "got: {codes:?}");
+    assert_eq!(
+        count(&codes, TS2777),
+        0,
+        "parentheses end the chain, so the operand is an ordinary target, got: {codes:?}"
+    );
+}
+
+#[test]
+fn a_parenthesized_chain_is_not_an_optional_for_of_head() {
+    let source = format!(
+        "{}for ((holder?.inner).leaf of items);",
+        preamble("holder", "inner", "leaf")
+    );
+    let codes = strict(&source);
+    assert_eq!(count(&codes, TS2532), 1, "got: {codes:?}");
+    assert_eq!(
+        count(&codes, TS2781),
+        0,
+        "parentheses end the chain, so the `for...of` head is an ordinary target, got: {codes:?}"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Controls: the two shapes that MUST keep reporting.
+// -------------------------------------------------------------------------
+
+#[test]
+fn parentheses_around_the_whole_target_keep_it_an_optional_chain_target() {
+    // tsc's `checkReferenceExpression` skips the target's OWN outer parentheses
+    // before testing the chain flag.
+    let source = format!(
+        "{}(holder?.inner.leaf) = 1;",
+        preamble("holder", "inner", "leaf")
+    );
+    let codes = strict(&source);
+    assert_eq!(
+        count(&codes, TS2779),
+        1,
+        "`(a?.b.c) = 1` is still an optional-chain target, got: {codes:?}"
+    );
+}
+
+#[test]
+fn a_chain_that_continues_after_a_parenthesized_receiver_is_still_a_chain() {
+    // The `?.` is OUTSIDE the parentheses here, so the chain starts after them
+    // and the target is still an optional-chain target.
+    let source = "declare const a: { b?: { c: { d: number } } };\n(a.b)?.c.d = 1;";
+    let codes = strict(source);
+    assert_eq!(
+        count(&codes, TS2779),
+        1,
+        "`(a.b)?.c.d = 1` must still report TS2779 — the rule terminates the chain WALK at a \
+         parenthesis, it does not suppress the diagnostic, got: {codes:?}"
+    );
+}
+
+#[test]
+fn an_assertion_does_not_end_a_chain() {
+    let source = format!(
+        "{}holder?.inner!.leaf = 1;",
+        preamble("holder", "inner", "leaf")
+    );
+    let codes = strict(&source);
+    assert_eq!(
+        count(&codes, TS2779),
+        1,
+        "`!` is not a parenthesis — the chain continues through it, got: {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, TS18048),
+        0,
+        "`!` removes the nullish receiver, got: {codes:?}"
+    );
+}
+
+#[test]
+fn a_parenthesized_receiver_without_any_chain_stays_clean() {
+    let source = "\
+declare const plain: { inner: { leaf: number } };
+(plain.inner).leaf = 1;";
+    let codes = strict(source);
+    assert!(
+        codes.is_empty(),
+        "a parenthesized non-optional receiver must stay clean, got: {codes:?}"
+    );
+}


### PR DESCRIPTION
Reduced to rule 2 only, as requested. Closes #16678. Rebased onto `202afa1`; the rule-1 work is gone from this branch and preserved in #16683 with its patch and evidence.

**Structural rule.** tsc's parser stops propagating `NodeFlags.OptionalChain` at a `ParenthesizedExpression`, so `(a.b?.c).d = 1` is an ordinary assignment to a property of a possibly-nullish receiver — TS2532 alone. tsz's chain walker called `skip_parenthesized_and_assertions` at *every* level of the left spine, so it read the parenthesized form as a chain and added a spurious TS2779. Owner: the checker's write-target chain recognition (`assignability/assignment_checker`), which owns the TS2777/TS2779/TS2780/TS2781 predicate.

The rule is "a `ParenthesizedExpression` terminates the chain **walk**", not "parentheses suppress the diagnostic" — three halves that must stay apart, all pinned:

| shape | why | tsc | main | this PR |
|---|---|---|---|---|
| `(a.b?.c).d = 1` | parens inside the spine end the chain | TS2532 | TS2532 **+ TS2779** | TS2532 ✅ |
| `(zq.al?.be).ga = 1` | same, renamed binders | TS2532 | TS2532 **+ TS2779** | TS2532 ✅ |
| `(a.b?.c).d++`, `for ((a.b?.c).d of xs)` | same, other write forms | TS2532 | TS2532 **+ TS2777/TS2781** | TS2532 ✅ |
| `(a.b)?.c.d = 1` | chain starts *after* the parens | TS2779 | TS2779 | TS2779 ✅ unchanged |
| `(a.b?.c.d) = 1` | target's own outer parens are skipped by `checkReferenceExpression` | TS2779 | TS2779 | TS2779 ✅ unchanged |
| `a?.b!.c = 1` | an assertion is not a parenthesis | TS2779 | TS2779 | TS2779 ✅ unchanged |
| `(plain.inner).leaf = 1` | no chain at all | clean | clean | clean ✅ |

`(a.b)?.c.d = 1` is the falsifier worth keeping: a naive "paren anywhere → skip" fix passes the headline rows and silently breaks that one.

**On the extraction you tried.** It came out byte-identical because `types/computation/access/invalid_target.rs` is rule *1*'s root cause, not rule 2 — and main already absorbed it in #16671, so your extracted copy was identical to what was already there. Rule 2 never lived in that file. It is `assignment_ops.rs::is_optional_chain_access`, now moved to `assignment_checker/optional_chain_target.rs`. The two rules touch **disjoint** file sets, which is why this split was mechanical:

- rule 2 (this PR): `assignment_checker/{assignment_ops.rs, optional_chain_target.rs, mod.rs}`
- rule 1 (#16683): `types/property_access_type/{nullish_access.rs, resolve.rs}`, `types/computation/access.rs`

I verified the split rather than assuming it: `main@202afa1` + only this PR's three files makes every parenthesis row above byte-identical to the oracle, with the rule-1 rows left exactly at main's behaviour.

## Goal
Goal: hold

## Verification

Oracle: `tsc` 7.0.2 (`scripts/conformance/typescript-versions.json`), `--noEmit --strict --target es2022 --lib es2022 --module esnext`.

- Every row in the table above is a real oracle run diffed against the built binary. The parenthesis fixtures are **byte-identical to tsc** on this branch.
- `cargo test -p tsz-checker --lib optional_chain_parenthesized` — **7/7 pass** (new `optional_chain_parenthesized_target_tests.rs`; three headline rows under three binder sets, plus all four controls).
- `cargo clippy -p tsz-checker --lib -- -D warnings`, `cargo fmt --all`, `python3 scripts/arch/arch_guard.py` — clean. The pre-commit hook's clippy + arch guard passed on the commit.
- The walk moved into its own module because it pushed `assignment_ops.rs` to 2005 lines, over the 2000-line checker ceiling.

**Owed:** `compare-to-parent` — no TypeScript submodule on this seat, and the two-sided run measures 55-90+ min on cold cloud seats. The full `--lib` lane also never completed here (long tail plus two container recycles); the targeted suites above are the evidence. This diff only narrows a predicate that gates TS2777/TS2779/TS2780/TS2781, so the corpus rows worth watching are parenthesized assignment targets.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: medium
AgentName: Aventurine