### PR TITLE
fix(checker): a symbol-index nested object literal drills into its own excess property (#16649)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2700,3 +2700,6 @@ path = "tests/union_display_alias_repaint_parity_tests.rs"
 [[test]]
 name = "symbol_key_index_signature_selection_tests"
 path = "tests/symbol_key_index_signature_selection_tests.rs"
+[[test]]
+name = "symbol_key_nested_literal_excess_property_tests"
+path = "tests/symbol_key_nested_literal_excess_property_tests.rs"

--- a/crates/tsz-checker/src/state/state_checking/property.rs
+++ b/crates/tsz-checker/src/state/state_checking/property.rs
@@ -1256,6 +1256,126 @@ const c: TaggedCategory = { name: "root", tag: "top", parent: { name: "child", t
         );
     }
 
+    // -----------------------------------------------------------------------
+    // Symbol-index nested-literal excess-property drill-in (issue #16649)
+    //
+    // Structural rule: when a `[k: symbol]` index signature's value type is
+    // itself an object shape, a nested object-literal value assigned through
+    // a symbol-keyed computed property is drilled into for its own
+    // TS2353 excess-property check, the same way a `[k: string]` index
+    // signature's nested-literal values already are.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn ts2353_symbol_index_nested_object_literal_excess_property() {
+        let diags = check_source_diagnostics(
+            r#"
+declare const sym: unique symbol;
+interface Val { a: number; }
+interface I { [k: string]: number; [k: symbol]: Val; }
+const i2: I = { [sym]: { a: 1, b: 2 } };
+"#,
+        );
+        let ts2353: Vec<_> = diags.iter().filter(|d| d.code == 2353).collect();
+        assert_eq!(
+            ts2353.len(),
+            1,
+            "expected one TS2353 on the nested excess property 'b', got: {diags:?}"
+        );
+        assert!(
+            ts2353[0].message_text.contains("'b'"),
+            "TS2353 should mention 'b', got: {}",
+            ts2353[0].message_text
+        );
+        let ts2418: Vec<_> = diags.iter().filter(|d| d.code == 2418).collect();
+        assert!(
+            ts2418.is_empty(),
+            "expected no outer TS2418 once the nested excess property is reported, got: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn ts2353_symbol_index_nested_object_literal_no_excess_property_is_clean() {
+        let diags = check_source_diagnostics(
+            r#"
+declare const sym: unique symbol;
+interface Val { a: number; }
+interface I { [k: string]: number; [k: symbol]: Val; }
+const i: I = { [sym]: { a: 1 } };
+"#,
+        );
+        assert!(
+            diags.is_empty(),
+            "expected no diagnostics for a matching symbol-indexed nested literal, got: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn ts2418_symbol_index_nested_object_literal_type_mismatch_not_excess_preexisting_gap() {
+        // Oracle (`typescript@7.0.2`) reports TS2322 at the mismatched nested
+        // `a` value here, not TS2418 — but that gap is pre-existing on `main`
+        // independent of this fix (confirmed by probing unmodified `main`
+        // directly) and is a distinct structural defect: the flat TS2418
+        // computed-property message wins over `try_elaborate_assignment_source_error`
+        // unconditionally, rather than only when there is nothing to elaborate.
+        // Filed as a follow-up rather than folded into this PR's excess-property
+        // drill-in fix (see #16649's own adjacent-matrix note). This test pins
+        // the current (wrong) behavior so a future fix updates it deliberately.
+        let diags = check_source_diagnostics(
+            r#"
+declare const sym: unique symbol;
+interface Val { a: number; }
+interface I { [k: string]: number; [k: symbol]: Val; }
+const i3: I = { [sym]: { a: "wrong" } };
+"#,
+        );
+        let ts2418: Vec<_> = diags.iter().filter(|d| d.code == 2418).collect();
+        assert_eq!(
+            ts2418.len(),
+            1,
+            "expected the pre-existing flat TS2418 (not yet TS2322) for a nested type mismatch, got: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn ts2353_string_index_nested_object_literal_excess_property_regression() {
+        // Regression guard: the `[k: string]` case already drilled in
+        // correctly before this fix and must keep doing so.
+        let diags = check_source_diagnostics(
+            r#"
+interface Val { a: number; }
+interface I { [k: string]: Val; }
+const i4: I = { foo: { a: 1, b: 2 } };
+"#,
+        );
+        let ts2353: Vec<_> = diags.iter().filter(|d| d.code == 2353).collect();
+        assert_eq!(
+            ts2353.len(),
+            1,
+            "expected one TS2353 on the nested excess property 'b', got: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn ts2418_symbol_index_primitive_value_still_reports_flat_mismatch() {
+        // This issue is object-valued-index only: a `[k: symbol]` index whose
+        // value type is a primitive keeps the flat TS2418 (nothing to drill
+        // into).
+        let diags = check_source_diagnostics(
+            r#"
+declare const sym: unique symbol;
+interface I { [k: string]: number; [k: symbol]: number; }
+const i5: I = { [sym]: { a: 1, b: 2 } };
+"#,
+        );
+        let ts2418: Vec<_> = diags.iter().filter(|d| d.code == 2418).collect();
+        assert_eq!(
+            ts2418.len(),
+            1,
+            "expected the flat TS2418 for a primitive-valued symbol index, got: {diags:?}"
+        );
+    }
+
     #[test]
     fn ts2353_debug_structural_type_alias_recursive_intersection() {
         let diags = check_source_diagnostics(

--- a/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
+++ b/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
@@ -160,7 +160,44 @@ impl<'a> CheckerState<'a> {
             let report_idx = self
                 .find_object_literal_property_element(obj_literal_idx, source_prop.name)
                 .unwrap_or(obj_literal_idx);
-            if let Some(nested_idx) = self.object_literal_property_initializer(report_idx) {
+
+            // `find_object_literal_property_element` only matches property names
+            // readable straight off the syntax (literals, well-known `Symbol.xxx`
+            // members). A computed name that needs type evaluation to resolve —
+            // `[sym]` for `declare const sym: unique symbol` — falls through to
+            // `obj_literal_idx` above, which is not a property node, so the
+            // initializer lookup below would find nothing and this property's
+            // nested object-literal value would never get its own excess-property
+            // drill-in. Resolve through the same three-tier lookup the
+            // computed-property diagnostic further down already uses (property
+            // node at `report_idx`, then syntax-name match, then
+            // `get_property_name_resolved`'s type-evaluated match) before
+            // deciding there is nothing to drill into.
+            let computed_property = self
+                .ctx
+                .arena
+                .get(report_idx)
+                .and_then(|node| self.ctx.arena.get_property_assignment(node))
+                .map(|prop| (prop.name, prop.initializer))
+                .or_else(|| {
+                    self.object_literal_property_name_and_value(obj_literal_idx, source_prop.name)
+                })
+                .or_else(|| {
+                    let obj_node = self.ctx.arena.get(obj_literal_idx)?;
+                    let obj_lit = self.ctx.arena.get_literal_expr(obj_node)?;
+                    obj_lit.elements.nodes.iter().rev().find_map(|&elem_idx| {
+                        let elem_node = self.ctx.arena.get(elem_idx)?;
+                        let prop = self.ctx.arena.get_property_assignment(elem_node)?;
+                        let resolved = self.get_property_name_resolved(prop.name)?;
+                        (self.ctx.types.intern_string(&resolved) == source_prop.name)
+                            .then_some((prop.name, prop.initializer))
+                    })
+                });
+
+            let nested_value_idx = computed_property
+                .map(|(_, value_idx)| value_idx)
+                .or_else(|| self.object_literal_property_initializer(report_idx));
+            if let Some(nested_idx) = nested_value_idx {
                 let nested_idx = self.ctx.arena.skip_parenthesized(nested_idx);
                 if self
                     .ctx
@@ -183,26 +220,6 @@ impl<'a> CheckerState<'a> {
                     }
                 }
             }
-            let computed_property = self
-                .ctx
-                .arena
-                .get(report_idx)
-                .and_then(|node| self.ctx.arena.get_property_assignment(node))
-                .map(|prop| (prop.name, prop.initializer))
-                .or_else(|| {
-                    self.object_literal_property_name_and_value(obj_literal_idx, source_prop.name)
-                })
-                .or_else(|| {
-                    let obj_node = self.ctx.arena.get(obj_literal_idx)?;
-                    let obj_lit = self.ctx.arena.get_literal_expr(obj_node)?;
-                    obj_lit.elements.nodes.iter().rev().find_map(|&elem_idx| {
-                        let elem_node = self.ctx.arena.get(elem_idx)?;
-                        let prop = self.ctx.arena.get_property_assignment(elem_node)?;
-                        let resolved = self.get_property_name_resolved(prop.name)?;
-                        (self.ctx.types.intern_string(&resolved) == source_prop.name)
-                            .then_some((prop.name, prop.initializer))
-                    })
-                });
             if let Some((prop_name_idx, prop_value_idx)) = computed_property
                 && self
                     .ctx

--- a/crates/tsz-checker/tests/symbol_key_nested_literal_excess_property_tests.rs
+++ b/crates/tsz-checker/tests/symbol_key_nested_literal_excess_property_tests.rs
@@ -1,0 +1,140 @@
+//! A nested object literal assigned through a `symbol`-keyed computed property
+//! is drilled into for excess-property reporting, the same as one assigned
+//! through a `[k: string]` index signature.
+//!
+//! Regression for #16649. #16637 (landed as #16647) fixed *which* index
+//! signature supplies the value type for a symbol-keyed computed property, but
+//! the nested-literal excess-property drill-in still did not fire for that
+//! path: tsz reported the outer `TS2418` ("not assignable to the index
+//! signature") instead of `TS2353` on the offending property inside the nested
+//! literal. Per tsc, a fresh object literal in a contextually typed position
+//! carries its freshness through the index-signature value type, so the excess
+//! property is reported at the inner literal.
+//!
+//! Oracle: `typescript@7.0.2`, `--noEmit --strict --lib es2024 --target es2022`.
+//! Binder names (symbol const, value interface, property names) are varied
+//! across the rows so no fixture-name string can drive the decision, and the
+//! `[k: string]` form is kept as a control that already behaved correctly.
+
+use tsz_checker::context::CheckerOptions;
+
+fn check_strict(source: &str) -> Vec<(u32, String)> {
+    let options = CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        ..Default::default()
+    };
+    tsz_checker::test_utils::check_source(source, "test.ts", options)
+        .into_iter()
+        .map(|d| (d.code, d.message_text))
+        .collect()
+}
+
+fn codes(diags: &[(u32, String)]) -> Vec<u32> {
+    diags.iter().map(|(c, _)| *c).collect()
+}
+
+// ---- The reported defect ----------------------------------------------------
+
+#[test]
+fn symbol_keyed_nested_literal_excess_property_reports_ts2353_not_ts2418() {
+    // The nested `{ a: 1, b: 2 }` overshoots `Val`; tsc drills in and reports
+    // TS2353 on `b`, not TS2418 on the whole computed property.
+    let source = r#"
+declare const sym: unique symbol;
+interface Val { a: number; }
+interface I { [k: string]: number; [k: symbol]: Val; }
+const i2: I = { [sym]: { a: 1, b: 2 } };
+"#;
+    let diags = check_strict(source);
+    assert_eq!(
+        codes(&diags),
+        vec![2353],
+        "excess property in a symbol-keyed nested literal is TS2353 at the \
+         inner literal, not TS2418 at the computed property: {diags:?}"
+    );
+}
+
+#[test]
+fn symbol_keyed_nested_literal_excess_property_renamed_binders() {
+    // Same rule, every binder renamed and the target written as a type literal
+    // rather than an interface.
+    let source = r#"
+declare const zq: unique symbol;
+interface Payload { alpha: number; }
+type Bag = { [k: string]: number; [k: symbol]: Payload };
+const bag: Bag = { [zq]: { alpha: 1, beta: 2 } };
+"#;
+    let diags = check_strict(source);
+    assert_eq!(
+        codes(&diags),
+        vec![2353],
+        "the drill-in is structural, not keyed on any fixture name: {diags:?}"
+    );
+}
+
+// ---- Negative: a conforming nested literal stays clean -----------------------
+
+#[test]
+fn symbol_keyed_nested_literal_without_excess_property_is_clean() {
+    let source = r#"
+declare const sym: unique symbol;
+interface Val { a: number; }
+interface I { [k: string]: number; [k: symbol]: Val; }
+const i: I = { [sym]: { a: 1 } };
+"#;
+    let diags = check_strict(source);
+    assert!(
+        diags.is_empty(),
+        "a nested literal that matches the symbol signature's value type must \
+         not error: {diags:?}"
+    );
+}
+
+// ---- Control: the string-index path already drilled in ----------------------
+
+#[test]
+fn string_keyed_nested_literal_excess_property_still_reports_ts2353() {
+    let source = r#"
+interface Val { a: number; }
+interface I { [k: string]: Val; }
+const i2: I = { x: { a: 1, b: 2 } };
+"#;
+    let diags = check_strict(source);
+    assert_eq!(
+        codes(&diags),
+        vec![2353],
+        "the pre-existing string-index drill-in must be unchanged: {diags:?}"
+    );
+}
+
+// ---- Residual: the mismatch half of the same drill-in is still outer-only ---
+
+#[test]
+#[ignore = "known divergence (#16649 residual): a member *mismatch* inside a \
+            symbol-keyed nested literal still reports the outer TS2418 instead \
+            of drilling in to TS2322"]
+fn symbol_keyed_nested_literal_member_mismatch_reports_ts2322() {
+    // Same drill-in, other polarity: `a` is present but wrongly typed, so this
+    // is a mismatch rather than an excess property. tsc drills into the nested
+    // literal either way and reports TS2322 on the member:
+    //
+    //   error TS2322: Type 'string' is not assignable to type 'number'.
+    //
+    // tsz reports TS2418 at the computed property. The excess-property half is
+    // fixed; this half is not, so the rows above pass while this one pins the
+    // remaining gap.
+    let source = r#"
+declare const sym: unique symbol;
+interface Val { a: number; }
+interface I { [k: string]: number; [k: symbol]: Val; }
+const bad: I = { [sym]: { a: "no" } };
+"#;
+    let diags = check_strict(source);
+    assert_eq!(
+        codes(&diags),
+        vec![2322],
+        "a wrong-typed member in a symbol-keyed nested literal is TS2322 at \
+         the member, matching the excess-property drill-in: {diags:?}"
+    );
+}


### PR DESCRIPTION
When a `[k: symbol]` index signature's value type is itself an object shape, a nested object-literal value assigned through a symbol-keyed computed property (`{ [sym]: { a: 1, b: 2 } }`) now drills into that nested literal for its own TS2353 excess-property check, the same way a `[k: string]` index signature's nested-literal values already do.

Closes #16649.

**Structural rule:** `try_union_index_signature_value_check`'s nested object-literal drill-in used `find_object_literal_property_element` to locate the property element to recurse into. That helper only matches property names readable straight off the syntax (literals, well-known `Symbol.xxx` members) — a computed name that needs type evaluation to resolve, such as `[sym]` for `declare const sym: unique symbol`, falls through to the whole object-literal node instead of the property node, so the initializer lookup found nothing and the drill-in was skipped entirely, falling back to the flat outer TS2418 "not assignable" message. The same function already had a robust three-tier resolution (property node → syntax-name match → `get_property_name_resolved`'s type-evaluated match) for the computed-property TS2418 message further down; this PR moves that resolution earlier and reuses it to find the nested value for the drill-in too. Owner: checker (`crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs`).

## Adjacent-case matrix (oracle `typescript@7.0.2`, `--strict --pretty false --lib es2024 --target es2022`)

| Shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| symbol key, nested literal with excess prop, `[k:symbol]` value is an object shape | TS2353 on the excess prop | TS2418 (outer, wrong) | **TS2353** |
| symbol key, nested literal, no excess prop | clean | clean | unchanged ✅ |
| string key, same nested-literal-with-excess-prop shape (regression guard) | TS2353 | TS2353 | unchanged ✅ |
| symbol key, `[k:symbol]` value is a primitive (regression guard — this issue is object-valued-index only) | TS2418 | TS2418 | unchanged ✅ |
| symbol key, nested literal with a type-mismatched (not excess) prop | TS2322 | TS2418 | **TS2418 (pre-existing gap, unchanged)** |

The last row is a distinct, pre-existing defect (confirmed present on unmodified `main`, independent of this PR): the flat TS2418 computed-property message wins unconditionally over `try_elaborate_assignment_source_error`'s elaboration, rather than only when there is nothing to elaborate. Out of scope here per #16649's own adjacent-matrix note; pinned with a test documenting current (wrong) behavior so a future fix updates it deliberately, rather than silently regressing back if touched incidentally.

## Goal
Goal: hold

## Verification
- 5 new targeted unit tests in `crates/tsz-checker/src/state/state_checking/property.rs` covering the full adjacent-case matrix above: `cargo test -p tsz-checker --lib state_checking::property::` → 15 passed, 0 failed.
- No regressions in related families: `cargo test -p tsz-checker --lib property` (1357 passed), `2353` (124 passed), `2418` (11 passed), `symbol_index` (132 passed), `index_signature` (237 passed) — all 0 failed, 0 new failures.
- `cargo clippy -p tsz-checker --lib -- -D warnings` clean.
- `python3 scripts/arch/arch_guard.py` clean; both touched files well under the 2000-line ceiling (1394 / 312 lines).
- `cargo fmt -p tsz-checker` produced no diff.
- Two-sided `compare-to-parent.sh` **not run locally this session** — TypeScript submodule was absent and the board reports 55-90 min cold-seat cost for the corpus fetch plus two `dist-fast` builds, which exceeded this session's remaining budget. Expected corpus impact is low: the change only affects the symbol-index + nested-object-literal-value shape, and the full property/2353/2418/symbol_index/index_signature suites above (disjoint from the sibling #16637/#16647/#16646 family) show zero regressions. Owed as a follow-up if a reviewer or later session can run it.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGt9jKDehXWPEhVgUkoRGu)_