### PR TITLE
fix(checker): non-strict inferred return unions drop null/undefined before widening (#16580)

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -643,6 +643,8 @@ mod nonstrict_nullish_widening_generic_call_tests;
 mod nonstrict_nullish_widening_mutable_binding_tests;
 #[path = "tests/nonstrict_nullish_widening_nested_leaf_tests.rs"]
 mod nonstrict_nullish_widening_nested_leaf_tests;
+#[path = "tests/nonstrict_return_union_nullish_reduction_tests.rs"]
+mod nonstrict_return_union_nullish_reduction_tests;
 #[path = "tests/nonstrict_union_nullish_scalar_reduction_tests.rs"]
 mod nonstrict_union_nullish_scalar_reduction_tests;
 #[path = "tests/nonunique_symbol_property_access_tests.rs"]

--- a/crates/tsz-checker/src/tests/nonstrict_return_union_nullish_reduction_tests.rs
+++ b/crates/tsz-checker/src/tests/nonstrict_return_union_nullish_reduction_tests.rs
@@ -1,0 +1,244 @@
+//! Tests for the non-strict (`strictNullChecks: false`) subtype reduction of a
+//! block-bodied function's **inferred return union** (#16580 b5).
+//!
+//! tsc computes the inferred return type as
+//! `getWidenedType(getUnionType(returns, UnionReduction.Subtype))`. Without
+//! `strictNullChecks`, `null`/`undefined` are subtypes of every type, so
+//! `getUnionType` drops a nullish return contribution whenever a non-nullish
+//! sibling exists, and only widens the survivor afterwards:
+//!
+//! ```ts
+//! function g() { if (c) return 1; return null; }   // () => number
+//! function h(x) { if (x) return 1; }               // () => number (implicit undefined dropped)
+//! ```
+//!
+//! tsz previously widened each nullish contribution to `any` *per branch, before*
+//! the union, so `1 | null` collapsed to `any` and the later assignment was
+//! silently accepted — a false negative. The widening is now deferred past the
+//! reduction, so a sole-nullish return still reaches `any`
+//! (`function f() { return null; }` → `any`) while a mixed union reduces to its
+//! non-nullish survivor and widens it.
+//!
+//! Every case is pinned against `typescript@7.0.2`
+//! (`--noEmit --strict false --target es2015`). Binder names are varied across
+//! cases per the anti-hardcoding contract.
+
+use crate::test_utils::{
+    check_source_strict_codes, check_with_options_code_messages, non_strict_checker_options,
+};
+
+fn non_strict_2322_messages(src: &str) -> Vec<String> {
+    check_with_options_code_messages(src, non_strict_checker_options())
+        .into_iter()
+        .filter(|(code, _)| *code == 2322)
+        .map(|(_, msg)| msg)
+        .collect()
+}
+
+fn non_strict_2322_present(src: &str) -> bool {
+    check_with_options_code_messages(src, non_strict_checker_options())
+        .iter()
+        .any(|(code, _)| *code == 2322)
+}
+
+// ---------------------------------------------------------------------------
+// Row b5: the headline false negative. `1 | null` reduces to `number`, so the
+// `string` assignment is rejected — previously the union collapsed to `any` and
+// nothing was reported.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mixed_number_and_null_return_reduces_to_number() {
+    let messages = non_strict_2322_messages(
+        "function pickCount() { if (1) return 1; return null; }\n\
+         var label: string = pickCount();",
+    );
+    assert_eq!(
+        messages.len(),
+        1,
+        "expected exactly one TS2322: {messages:?}"
+    );
+    assert!(
+        messages[0].contains("Type 'number' is not assignable to type 'string'"),
+        "survivor should widen to `number`, not stay `1 | null`/`any`: {}",
+        messages[0]
+    );
+}
+
+#[test]
+fn mixed_literal_and_undefined_return_reduces_and_widens() {
+    // `"a" | undefined` → drop `undefined` → `"a"` → widen → `string`.
+    let messages = non_strict_2322_messages(
+        "function chooseTag(flag: boolean) { if (flag) return \"a\"; return undefined; }\n\
+         var count: number = chooseTag(true);",
+    );
+    assert_eq!(
+        messages.len(),
+        1,
+        "expected exactly one TS2322: {messages:?}"
+    );
+    assert!(
+        messages[0].contains("Type 'string' is not assignable to type 'number'"),
+        "survivor should widen to `string`: {}",
+        messages[0]
+    );
+}
+
+#[test]
+fn implicit_fall_through_undefined_is_dropped() {
+    // `function h(x) { if (x) return 1; }` — the implicit fall-through
+    // `undefined` is dropped in non-strict, so the inferred return is `number`.
+    let messages = non_strict_2322_messages(
+        "function measure(active: boolean) { if (active) return 1; }\n\
+         var name: string = measure(true);",
+    );
+    assert_eq!(
+        messages.len(),
+        1,
+        "expected exactly one TS2322: {messages:?}"
+    );
+    assert!(
+        messages[0].contains("Type 'number' is not assignable to type 'string'"),
+        "implicit undefined must be dropped, leaving `number`: {}",
+        messages[0]
+    );
+}
+
+#[test]
+fn bare_empty_return_undefined_is_dropped() {
+    // A bare `return;` contributes `undefined`, dropped the same way.
+    let messages = non_strict_2322_messages(
+        "function tally(seen: boolean) { if (seen) return 1; return; }\n\
+         var text: string = tally(true);",
+    );
+    assert_eq!(
+        messages.len(),
+        1,
+        "expected exactly one TS2322: {messages:?}"
+    );
+    assert!(
+        messages[0].contains("Type 'number' is not assignable to type 'string'"),
+        "bare `return;` undefined must be dropped: {}",
+        messages[0]
+    );
+}
+
+#[test]
+fn non_literal_survivor_beside_null_reduces_to_the_survivor() {
+    // A non-literal survivor (`number`, from a parameter) beside a `null` return
+    // reduces to plain `number` — no literal-widening ambiguity, just the drop.
+    let messages = non_strict_2322_messages(
+        "function classify(n: number, seen: boolean) {\n\
+         \x20   if (seen) return n;\n\
+         \x20   return null;\n\
+         }\n\
+         var ok: boolean = classify(0, true);",
+    );
+    assert_eq!(
+        messages.len(),
+        1,
+        "expected exactly one TS2322: {messages:?}"
+    );
+    assert!(
+        messages[0].contains("Type 'number' is not assignable to type 'boolean'"),
+        "null dropped, survivor is `number`: {}",
+        messages[0]
+    );
+}
+
+#[test]
+fn dropped_null_is_absent_from_the_rendered_survivor_union() {
+    // With two non-nullish survivors the exact literal-widening is a separate
+    // concern; the invariant the reduction owns is that `null` is gone from the
+    // rendered source type (previously it collapsed the whole union to `any`).
+    let messages = non_strict_2322_messages(
+        "function route(n: number, s: string, flag: boolean) {\n\
+         \x20   if (flag) return n;\n\
+         \x20   if (n === 1) return s;\n\
+         \x20   return null;\n\
+         }\n\
+         var ok: boolean = route(0, \"x\", true);",
+    );
+    assert_eq!(
+        messages.len(),
+        1,
+        "expected exactly one TS2322: {messages:?}"
+    );
+    assert!(
+        !messages[0].contains("null"),
+        "`null` must be dropped from the inferred return union: {}",
+        messages[0]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Positive controls: a SOLE nullish return is a widening source and still
+// infers `any`, so these assignments stay clean.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sole_null_return_still_widens_to_any() {
+    // `function f() { return null; }` → `any`; `string` assignment is fine.
+    assert!(
+        !non_strict_2322_present(
+            "function emptySlot() { return null; }\n\
+             var handle: string = emptySlot();",
+        ),
+        "a sole `return null` must still widen to `any`",
+    );
+}
+
+#[test]
+fn sole_undefined_return_still_widens_to_any() {
+    assert!(
+        !non_strict_2322_present(
+            "function blank() { return undefined; }\n\
+             var handle: number = blank();",
+        ),
+        "a sole `return undefined` must still widen to `any`",
+    );
+}
+
+#[test]
+fn two_null_returns_still_widen_to_any() {
+    // Every contribution is a widening-source nullish → `any`.
+    assert!(
+        !non_strict_2322_present(
+            "function twoWays(flag: boolean) { if (flag) return null; return null; }\n\
+             var handle: string = twoWays(true);",
+        ),
+        "an all-null return must still widen to `any`",
+    );
+}
+
+#[test]
+fn nested_undefined_array_return_still_widens_in_place() {
+    // `return [undefined]` → `any[]` (nested-composite widening is untouched by
+    // the top-level reduction).
+    assert!(
+        !non_strict_2322_present(
+            "function makeRow() { return [undefined]; }\n\
+             var row: string[] = makeRow();",
+        ),
+        "a nested nullish leaf must still widen to `any[]`",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative control: strict mode keeps every nullish member, so the reduction
+// must not fire.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn strict_mode_keeps_the_null_member() {
+    // Under `--strict`, `number | null` survives and the `string` assignment is
+    // rejected with the union rendered intact.
+    let codes = check_source_strict_codes(
+        "function pickCount() { if (1) return 1; return null; }\n\
+         var label: string = pickCount();",
+    );
+    assert!(
+        codes.contains(&2322),
+        "strict mode must keep `number | null` and report TS2322: {codes:?}",
+    );
+}

--- a/crates/tsz-checker/src/types/utilities/mod.rs
+++ b/crates/tsz-checker/src/types/utilities/mod.rs
@@ -16,5 +16,6 @@ pub(crate) mod heritage_walk_state;
 pub(crate) mod mutable_binding_nullish;
 pub(crate) mod overlap_relation_helpers;
 pub(crate) mod return_type;
+pub(crate) mod return_type_any_assertion;
 pub(crate) mod return_type_nullish;
 pub(crate) mod widening;

--- a/crates/tsz-checker/src/types/utilities/return_type.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type.rs
@@ -23,6 +23,17 @@ use tsz_solver::TypeId;
 struct ReturnContribution {
     type_id: TypeId,
     widen_expr: Option<NodeIndex>,
+    /// `Some(expr)` when this is a bare top-level `null`/`undefined` contribution
+    /// whose non-strict `-> any` widening was DEFERRED past the union reduction
+    /// (#16580 b5). tsc computes the return union with `UnionReduction.Subtype`
+    /// and widens the survivor afterwards (`getWidenedType(getUnionType(...))`),
+    /// so a nullish member is dropped when a non-nullish sibling exists
+    /// (`if (c) return 1; return null` → `number`) and only a *surviving*
+    /// widening-source nullish widens to `any` (`return null` → `any`). Widening
+    /// per branch first (the old behavior) let the resulting `any` swallow the
+    /// whole union. `expr` re-runs the widening-source-aware widen after the
+    /// reduction so the sole-nullish case still reaches `any`.
+    nullish_widen_expr: Option<NodeIndex>,
 }
 
 impl<'a> CheckerState<'a> {
@@ -316,185 +327,6 @@ impl<'a> CheckerState<'a> {
         false
     }
 
-    /// Infer the return type of a function body by collecting return expressions.
-    ///
-    /// This function walks through all statements in a function body, collecting
-    /// the types of all return expressions. It then infers the return type as:
-    /// - `void`: If there are no return expressions
-    /// - `union` of all return types: If there are multiple return expressions
-    /// - The single return type: If there's only one return expression
-    ///
-    /// ## Parameters:
-    /// - `body_idx`: The function body node index
-    /// - `return_context`: Optional contextual type for return expressions
-    ///
-    /// ## Examples:
-    /// ```typescript
-    /// // No returns → void
-    /// function foo() {}
-    ///
-    /// // Single return → string
-    /// function bar() { return "hello"; }
-    ///
-    /// // Multiple returns → string | number
-    /// function baz() {
-    ///     if (cond) return "hello";
-    ///     return 42;
-    /// }
-    ///
-    /// // Empty return included → string | number | void
-    /// function qux() {
-    ///     if (cond) return;
-    ///     return "hello";
-    /// }
-    /// ```
-    pub(crate) fn has_only_explicit_any_assertion_returns(&mut self, body_idx: NodeIndex) -> bool {
-        if body_idx.is_none() {
-            return false;
-        }
-        let mut saw_value_return = false;
-        let mut all_value_returns_explicit_any = true;
-        self.collect_explicit_any_assertion_returns(
-            body_idx,
-            &mut saw_value_return,
-            &mut all_value_returns_explicit_any,
-        );
-        saw_value_return && all_value_returns_explicit_any
-    }
-
-    fn collect_explicit_any_assertion_returns(
-        &mut self,
-        stmt_idx: NodeIndex,
-        saw_value_return: &mut bool,
-        all_value_returns_explicit_any: &mut bool,
-    ) {
-        let Some(node) = self.ctx.arena.get(stmt_idx) else {
-            return;
-        };
-
-        match node.kind {
-            syntax_kind_ext::RETURN_STATEMENT => {
-                if let Some(return_data) = self.ctx.arena.get_return_statement(node)
-                    && return_data.expression.is_some()
-                {
-                    *saw_value_return = true;
-                    if !self.is_explicit_any_assertion_expression(return_data.expression) {
-                        *all_value_returns_explicit_any = false;
-                    }
-                }
-            }
-            syntax_kind_ext::BLOCK => {
-                if let Some(block) = self.ctx.arena.get_block(node) {
-                    for &stmt in &block.statements.nodes {
-                        self.collect_explicit_any_assertion_returns(
-                            stmt,
-                            saw_value_return,
-                            all_value_returns_explicit_any,
-                        );
-                    }
-                }
-            }
-            syntax_kind_ext::IF_STATEMENT => {
-                if let Some(if_data) = self.ctx.arena.get_if_statement(node) {
-                    self.collect_explicit_any_assertion_returns(
-                        if_data.then_statement,
-                        saw_value_return,
-                        all_value_returns_explicit_any,
-                    );
-                    if if_data.else_statement.is_some() {
-                        self.collect_explicit_any_assertion_returns(
-                            if_data.else_statement,
-                            saw_value_return,
-                            all_value_returns_explicit_any,
-                        );
-                    }
-                }
-            }
-            syntax_kind_ext::SWITCH_STATEMENT => {
-                if let Some(switch_data) = self.ctx.arena.get_switch(node)
-                    && let Some(case_block_node) = self.ctx.arena.get(switch_data.case_block)
-                    && let Some(case_block) = self.ctx.arena.get_block(case_block_node)
-                {
-                    for &clause_idx in &case_block.statements.nodes {
-                        if let Some(clause_node) = self.ctx.arena.get(clause_idx)
-                            && let Some(clause) = self.ctx.arena.get_case_clause(clause_node)
-                        {
-                            for &stmt in &clause.statements.nodes {
-                                self.collect_explicit_any_assertion_returns(
-                                    stmt,
-                                    saw_value_return,
-                                    all_value_returns_explicit_any,
-                                );
-                            }
-                        }
-                    }
-                }
-            }
-            syntax_kind_ext::TRY_STATEMENT => {
-                if let Some(try_data) = self.ctx.arena.get_try(node) {
-                    self.collect_explicit_any_assertion_returns(
-                        try_data.try_block,
-                        saw_value_return,
-                        all_value_returns_explicit_any,
-                    );
-                    if try_data.catch_clause.is_some() {
-                        self.collect_explicit_any_assertion_returns(
-                            try_data.catch_clause,
-                            saw_value_return,
-                            all_value_returns_explicit_any,
-                        );
-                    }
-                    if try_data.finally_block.is_some() {
-                        self.collect_explicit_any_assertion_returns(
-                            try_data.finally_block,
-                            saw_value_return,
-                            all_value_returns_explicit_any,
-                        );
-                    }
-                }
-            }
-            syntax_kind_ext::CATCH_CLAUSE => {
-                if let Some(catch_data) = self.ctx.arena.get_catch_clause(node) {
-                    self.collect_explicit_any_assertion_returns(
-                        catch_data.block,
-                        saw_value_return,
-                        all_value_returns_explicit_any,
-                    );
-                }
-            }
-            syntax_kind_ext::WHILE_STATEMENT
-            | syntax_kind_ext::DO_STATEMENT
-            | syntax_kind_ext::FOR_STATEMENT => {
-                if let Some(loop_data) = self.ctx.arena.get_loop(node) {
-                    self.collect_explicit_any_assertion_returns(
-                        loop_data.statement,
-                        saw_value_return,
-                        all_value_returns_explicit_any,
-                    );
-                }
-            }
-            syntax_kind_ext::FOR_IN_STATEMENT | syntax_kind_ext::FOR_OF_STATEMENT => {
-                if let Some(for_in_of_data) = self.ctx.arena.get_for_in_of(node) {
-                    self.collect_explicit_any_assertion_returns(
-                        for_in_of_data.statement,
-                        saw_value_return,
-                        all_value_returns_explicit_any,
-                    );
-                }
-            }
-            syntax_kind_ext::LABELED_STATEMENT => {
-                if let Some(labeled_data) = self.ctx.arena.get_labeled_statement(node) {
-                    self.collect_explicit_any_assertion_returns(
-                        labeled_data.statement,
-                        saw_value_return,
-                        all_value_returns_explicit_any,
-                    );
-                }
-            }
-            _ => {}
-        }
-    }
-
     /// Apply literal widening to a single return expression's inferred type,
     /// matching tsc's `getReturnTypeFromBody` widening rules per-contribution:
     ///
@@ -569,6 +401,17 @@ impl<'a> CheckerState<'a> {
             return self.is_fresh_literal_expression(expr_idx);
         }
         self.is_enum_member_type_for_widening(type_id)
+    }
+
+    /// Whether a return contribution is a bare top-level `null`/`undefined`
+    /// scalar whose non-strict `-> any` widening must be DEFERRED past the return
+    /// union reduction (#16580 b5). `has_ts_nullable_flag` matches exactly `null`
+    /// and `undefined` — never `void`, never a union — which is the set the
+    /// reduction may drop or collapse; a nullish leaf nested in a fresh composite
+    /// (`return [undefined]`) is a composite type here and widens in place.
+    const fn is_bare_nonstrict_nullish_return(&self, type_id: TypeId) -> bool {
+        !self.ctx.strict_null_checks()
+            && crate::query_boundaries::type_predicates::has_ts_nullable_flag(type_id)
     }
 
     /// Whether a single return-expression contribution would be widened by
@@ -810,26 +653,6 @@ impl<'a> CheckerState<'a> {
                 && let Some(assertion) = self.ctx.arena.get_type_assertion(node)
             {
                 return self.is_const_assertion_type_node(assertion.type_node);
-            }
-            return false;
-        }
-        false
-    }
-
-    fn is_explicit_any_assertion_expression(&mut self, expr_idx: NodeIndex) -> bool {
-        let mut current = expr_idx;
-        while let Some(node) = self.ctx.arena.get(current) {
-            if node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION
-                && let Some(paren) = self.ctx.arena.get_parenthesized(node)
-            {
-                current = paren.expression;
-                continue;
-            }
-            if (node.kind == syntax_kind_ext::AS_EXPRESSION
-                || node.kind == syntax_kind_ext::TYPE_ASSERTION)
-                && let Some(assertion) = self.ctx.arena.get_type_assertion(node)
-            {
-                return self.get_type_from_type_node(assertion.type_node) == TypeId::ANY;
             }
             return false;
         }
@@ -1185,6 +1008,12 @@ impl<'a> CheckerState<'a> {
 
         let mut return_types = Vec::new();
         let mut saw_empty = false;
+        // Records whether the implicit fall-through / bare-`return;` `undefined`
+        // contribution was added below. tsc gives that member the *non-widening*
+        // `undefinedType` (not `undefinedWideningType`), so a return union that
+        // reduces to only nullish members must stay `null`/`undefined` rather
+        // than widen to `any` when this implicit member is one of them.
+        let mut pushed_implicit_undefined = false;
 
         if let Some(block) = self.ctx.arena.get_block(node) {
             for &stmt_idx in &block.statements.nodes {
@@ -1292,7 +1121,9 @@ impl<'a> CheckerState<'a> {
             return_types.push(ReturnContribution {
                 type_id: TypeId::UNDEFINED,
                 widen_expr: None,
+                nullish_widen_expr: None,
             });
+            pushed_implicit_undefined = true;
         }
 
         // NOTE: error-typed contributions are intentionally NOT filtered here.
@@ -1318,17 +1149,67 @@ impl<'a> CheckerState<'a> {
         // expression's AST-aware widener — preserving per-property `const`
         // subtrees (#14530).
         let widen_expr = return_types.iter().find_map(|c| c.widen_expr);
-        let union = factory.union(return_types.iter().map(|c| c.type_id).collect());
-        // tsc computes this union with `UnionReduction.Subtype`, so
-        // `if (c) return new Base(); return new Derived();` infers `Base`. The
-        // plain constructor keeps `Lazy` class refs deferred; run the
-        // class-scoped, heritage-guarded reduction with the checker resolver.
+        let nullish_widen_expr = return_types.iter().find_map(|c| c.nullish_widen_expr);
+
+        // tsc computes the return union with `UnionReduction.Subtype`, which in
+        // non-strict mode drops a scalar `null`/`undefined` member whenever a
+        // non-nullish sibling exists (`if (c) return 1; return null` → `number`;
+        // the implicit fall-through `undefined` is dropped the same way). Apply
+        // that reduction here with the checker's authoritative `strictNullChecks`,
+        // mirroring the written-union seam in `get_type_from_union_type`: the
+        // interner-level reduction is not reliably threaded through this
+        // construction path (#16624), which made the drop path-dependent
+        // (#16309 / #16580 b5). The bare-nullish contributions were collected
+        // WITHOUT the per-branch `-> any` widening for exactly this reason, so the
+        // drop can see the raw `null`/`undefined` scalars.
+        //
+        // This explicit block can be retired once #16624 threads the real
+        // `strictNullChecks` flag into the `factory.union` interner path below,
+        // whose own `reduce_and_collapse_nonstrict` already performs the same
+        // drop when the flag is set — unlike the `type_node.rs` seam, whose
+        // constructor never subtype-reduces and so must keep pre-reducing here.
+        let strict = self.ctx.strict_null_checks();
+        let contribution_types: Vec<TypeId> = return_types.iter().map(|c| c.type_id).collect();
+        let all_nullish_collapse =
+            crate::query_boundaries::type_predicates::collapse_pure_nullish_union_nonstrict(
+                strict,
+                &contribution_types,
+            );
+        let all_nullish_collapsed = all_nullish_collapse.is_some();
+        let reduced_members = match all_nullish_collapse {
+            Some(collapsed) => vec![collapsed],
+            None => crate::query_boundaries::type_predicates::nonstrict_union_members_absorb_nullish_scalars(
+                strict,
+                &contribution_types,
+            )
+            .unwrap_or(contribution_types),
+        };
+
+        let union = factory.union(reduced_members);
+        // The plain constructor keeps `Lazy` class refs deferred; run the
+        // class-scoped, heritage-guarded reduction with the checker resolver so
+        // `if (c) return new Base(); return new Derived();` infers `Base`.
         let union =
             crate::query_boundaries::type_computation::core::reduce_class_subtype_union_members(
                 self.ctx.types,
                 &self.ctx,
                 union,
             );
+
+        // getWidenedType over a *surviving* widening-source nullish: when the
+        // union reduced to only `null`/`undefined` (a sole-nullish return), the
+        // `null` keyword / global `undefined` carries tsc's widening flavour and
+        // widens to `any` (`function f() { return null; }` → `any`), while a
+        // *typed* nullish stays `null`/`undefined`. Skip this when the implicit
+        // fall-through `undefined` is part of the collapse: tsc gives that member
+        // the non-widening `undefinedType`, so the union keeps its nullish scalar.
+        if all_nullish_collapsed
+            && !pushed_implicit_undefined
+            && let Some(expr_idx) = nullish_widen_expr
+        {
+            return self.widen_nullish_return_contribution(expr_idx, union);
+        }
+
         if let Some(expr_idx) = widen_expr
             && crate::query_boundaries::common::is_literal_type(self.ctx.types, union)
         {
@@ -1666,7 +1547,7 @@ impl<'a> CheckerState<'a> {
                             return_type,
                             return_context,
                         );
-                        let (contribution_type, widen_expr) = if widenable
+                        let contribution = if widenable
                             && !crate::query_boundaries::common::is_literal_type(
                                 self.ctx.types,
                                 return_type,
@@ -1683,23 +1564,50 @@ impl<'a> CheckerState<'a> {
                                     return_type,
                                 );
                             let widened = self.widen_enum_member_type(widened);
-                            // Non-strict nullish widening, the block-body twin of
-                            // the expression-body seam in
-                            // `maybe_widen_return_contribution`: under
-                            // `strictNullChecks: false` tsc maps the widening
-                            // `null`/`undefined` leaves of a fresh return
-                            // contribution to `any`, so `return [undefined]`
-                            // infers `any[]`, not `undefined[]`.
-                            let widened = self
-                                .widen_nullish_return_contribution(return_data.expression, widened);
-                            (widened, None)
+                            if self.is_bare_nonstrict_nullish_return(widened) {
+                                // DEFER a bare top-level `null`/`undefined` (the `null`
+                                // keyword) past the union reduction (#16580 b5): widening
+                                // it to `any` here would let `any` swallow a non-nullish
+                                // sibling. A nullish leaf *nested* in a fresh composite
+                                // (`return [undefined]` → `any[]`) is not a bare scalar
+                                // and still widens in place below.
+                                ReturnContribution {
+                                    type_id: widened,
+                                    widen_expr: None,
+                                    nullish_widen_expr: Some(return_data.expression),
+                                }
+                            } else {
+                                // Non-strict nullish widening, the block-body twin of
+                                // the expression-body seam in
+                                // `maybe_widen_return_contribution`: under
+                                // `strictNullChecks: false` tsc maps the widening
+                                // `null`/`undefined` leaves of a fresh return
+                                // contribution to `any`, so `return [undefined]`
+                                // infers `any[]`, not `undefined[]`.
+                                let widened = self.widen_nullish_return_contribution(
+                                    return_data.expression,
+                                    widened,
+                                );
+                                ReturnContribution {
+                                    type_id: widened,
+                                    widen_expr: None,
+                                    nullish_widen_expr: None,
+                                }
+                            }
                         } else {
-                            (return_type, widenable.then_some(return_data.expression))
+                            // A raw scalar `null`/`undefined` contribution (e.g. a
+                            // non-widenable global `undefined` reference) also defers its
+                            // widening to the union reduction, so a nullish sibling is
+                            // dropped rather than kept alongside a non-nullish member.
+                            ReturnContribution {
+                                type_id: return_type,
+                                widen_expr: widenable.then_some(return_data.expression),
+                                nullish_widen_expr: self
+                                    .is_bare_nonstrict_nullish_return(return_type)
+                                    .then_some(return_data.expression),
+                            }
                         };
-                        return_types.push(ReturnContribution {
-                            type_id: contribution_type,
-                            widen_expr,
-                        });
+                        return_types.push(contribution);
                     }
                 }
             }

--- a/crates/tsz-checker/src/types/utilities/return_type_any_assertion.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type_any_assertion.rs
@@ -1,0 +1,184 @@
+//! "All value returns are an explicit `any` assertion" detection for
+//! `CheckerState`.
+//!
+//! Split out of `return_type.rs`, which sits at the checker's 2000-line
+//! boundary. A body whose every value-returning path is a literal
+//! `return x as any` / `return <any>x` is treated specially by overload
+//! resolution (`state_checking_members::overload_compatibility`), so this walk
+//! is a self-contained feature rather than part of return-type *inference*.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_solver::TypeId;
+
+impl CheckerState<'_> {
+    /// Whether the body has at least one value-returning path and every such
+    /// path returns an explicit `any` assertion (`return x as any`).
+    pub(crate) fn has_only_explicit_any_assertion_returns(&mut self, body_idx: NodeIndex) -> bool {
+        if body_idx.is_none() {
+            return false;
+        }
+        let mut saw_value_return = false;
+        let mut all_value_returns_explicit_any = true;
+        self.collect_explicit_any_assertion_returns(
+            body_idx,
+            &mut saw_value_return,
+            &mut all_value_returns_explicit_any,
+        );
+        saw_value_return && all_value_returns_explicit_any
+    }
+
+    fn collect_explicit_any_assertion_returns(
+        &mut self,
+        stmt_idx: NodeIndex,
+        saw_value_return: &mut bool,
+        all_value_returns_explicit_any: &mut bool,
+    ) {
+        let Some(node) = self.ctx.arena.get(stmt_idx) else {
+            return;
+        };
+
+        match node.kind {
+            syntax_kind_ext::RETURN_STATEMENT => {
+                if let Some(return_data) = self.ctx.arena.get_return_statement(node)
+                    && return_data.expression.is_some()
+                {
+                    *saw_value_return = true;
+                    if !self.is_explicit_any_assertion_expression(return_data.expression) {
+                        *all_value_returns_explicit_any = false;
+                    }
+                }
+            }
+            syntax_kind_ext::BLOCK => {
+                if let Some(block) = self.ctx.arena.get_block(node) {
+                    for &stmt in &block.statements.nodes {
+                        self.collect_explicit_any_assertion_returns(
+                            stmt,
+                            saw_value_return,
+                            all_value_returns_explicit_any,
+                        );
+                    }
+                }
+            }
+            syntax_kind_ext::IF_STATEMENT => {
+                if let Some(if_data) = self.ctx.arena.get_if_statement(node) {
+                    self.collect_explicit_any_assertion_returns(
+                        if_data.then_statement,
+                        saw_value_return,
+                        all_value_returns_explicit_any,
+                    );
+                    if if_data.else_statement.is_some() {
+                        self.collect_explicit_any_assertion_returns(
+                            if_data.else_statement,
+                            saw_value_return,
+                            all_value_returns_explicit_any,
+                        );
+                    }
+                }
+            }
+            syntax_kind_ext::SWITCH_STATEMENT => {
+                if let Some(switch_data) = self.ctx.arena.get_switch(node)
+                    && let Some(case_block_node) = self.ctx.arena.get(switch_data.case_block)
+                    && let Some(case_block) = self.ctx.arena.get_block(case_block_node)
+                {
+                    for &clause_idx in &case_block.statements.nodes {
+                        if let Some(clause_node) = self.ctx.arena.get(clause_idx)
+                            && let Some(clause) = self.ctx.arena.get_case_clause(clause_node)
+                        {
+                            for &stmt in &clause.statements.nodes {
+                                self.collect_explicit_any_assertion_returns(
+                                    stmt,
+                                    saw_value_return,
+                                    all_value_returns_explicit_any,
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+            syntax_kind_ext::TRY_STATEMENT => {
+                if let Some(try_data) = self.ctx.arena.get_try(node) {
+                    self.collect_explicit_any_assertion_returns(
+                        try_data.try_block,
+                        saw_value_return,
+                        all_value_returns_explicit_any,
+                    );
+                    if try_data.catch_clause.is_some() {
+                        self.collect_explicit_any_assertion_returns(
+                            try_data.catch_clause,
+                            saw_value_return,
+                            all_value_returns_explicit_any,
+                        );
+                    }
+                    if try_data.finally_block.is_some() {
+                        self.collect_explicit_any_assertion_returns(
+                            try_data.finally_block,
+                            saw_value_return,
+                            all_value_returns_explicit_any,
+                        );
+                    }
+                }
+            }
+            syntax_kind_ext::CATCH_CLAUSE => {
+                if let Some(catch_data) = self.ctx.arena.get_catch_clause(node) {
+                    self.collect_explicit_any_assertion_returns(
+                        catch_data.block,
+                        saw_value_return,
+                        all_value_returns_explicit_any,
+                    );
+                }
+            }
+            syntax_kind_ext::WHILE_STATEMENT
+            | syntax_kind_ext::DO_STATEMENT
+            | syntax_kind_ext::FOR_STATEMENT => {
+                if let Some(loop_data) = self.ctx.arena.get_loop(node) {
+                    self.collect_explicit_any_assertion_returns(
+                        loop_data.statement,
+                        saw_value_return,
+                        all_value_returns_explicit_any,
+                    );
+                }
+            }
+            syntax_kind_ext::FOR_IN_STATEMENT | syntax_kind_ext::FOR_OF_STATEMENT => {
+                if let Some(for_in_of_data) = self.ctx.arena.get_for_in_of(node) {
+                    self.collect_explicit_any_assertion_returns(
+                        for_in_of_data.statement,
+                        saw_value_return,
+                        all_value_returns_explicit_any,
+                    );
+                }
+            }
+            syntax_kind_ext::LABELED_STATEMENT => {
+                if let Some(labeled_data) = self.ctx.arena.get_labeled_statement(node) {
+                    self.collect_explicit_any_assertion_returns(
+                        labeled_data.statement,
+                        saw_value_return,
+                        all_value_returns_explicit_any,
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn is_explicit_any_assertion_expression(&mut self, expr_idx: NodeIndex) -> bool {
+        let mut current = expr_idx;
+        while let Some(node) = self.ctx.arena.get(current) {
+            if node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION
+                && let Some(paren) = self.ctx.arena.get_parenthesized(node)
+            {
+                current = paren.expression;
+                continue;
+            }
+            if (node.kind == syntax_kind_ext::AS_EXPRESSION
+                || node.kind == syntax_kind_ext::TYPE_ASSERTION)
+                && let Some(assertion) = self.ctx.arena.get_type_assertion(node)
+            {
+                return self.get_type_from_type_node(assertion.type_node) == TypeId::ANY;
+            }
+            return false;
+        }
+        false
+    }
+}


### PR DESCRIPTION
Closes the remaining open shape (**b5**) of #16580.

**Structural rule.** When `strictNullChecks` is off, tsc computes an inferred return type as `getWidenedType(getUnionType(returns, UnionReduction.Subtype))`: a `null`/`undefined` return contribution is dropped whenever a non-nullish sibling exists, and only a *surviving* sole-nullish return widens to `any`. tsz widened each nullish contribution to `any` **per branch, before** the union — so `if (c) return 1; return null` collapsed to `any` and the later assignment was silently accepted (a false negative). The implicit fall-through / bare `return;` `undefined` was likewise kept where tsc drops it.

**Owner layer.** Checker return-type inference (`crates/tsz-checker/src/types/utilities/return_type.rs`). The fix defers the per-branch `null`/`undefined` → `any` widening for *bare top-level* nullish contributions past the union, then applies the same non-strict subtype reduction the written-union type-node seam already uses (`collapse_pure_nullish_union_nonstrict` / `nonstrict_union_members_absorb_nullish_scalars`, backed by `tsz_solver::narrowing`) with the checker's authoritative `strictNullChecks`. Applying it at the checker seam also makes the drop deterministic where it was interner-flag-path-dependent (a #16309 symptom): the same body inferred `1` in the DTS path but `number | undefined` in the diagnostic path before this change.

**Adjacent matrix (all now match pinned `typescript@7.0.2`, `--strict false --target es2015`):**

| input | tsc | tsz before | tsz after |
|---|---|---|---|
| `if (c) return 1; return null` | `number` | `any` (no diag) | `number` |
| `if (c) return "a"; return undefined` | `string` | `string \| undefined` | `string` |
| `function h(x){ if(x) return 1; }` (fall-through) | `number` | `number \| undefined` | `number` |
| `return null` (sole) | `any` | `any` | `any` |
| `return undefined` (sole) | `any` | `any` | `any` |
| `return [undefined]` (nested composite) | `any[]` | `any[]` | `any[]` |
| `return void 0` | `void` | `void` | `void` |
| strict mode `number \| null` | keeps `null` | keeps `null` | keeps `null` |

**Fallback / negative controls:** a sole widening-source nullish return still widens to `any`; a nullish leaf nested in a fresh composite still widens in place (`any[]`); `void` is not treated as nullish; strict mode is unchanged.

A self-contained "all value returns are an explicit `any` assertion" walk moves verbatim from `return_type.rs` into a new `return_type_any_assertion.rs` sibling to keep both files under the 2000-line checker guard (no behavior change).

## Goal
Goal: hold

## Verification
Local `tsz-checker` lib suite (release CLI cross-checked against pinned `typescript@7.0.2`):
- New pinned matrix `nonstrict_return_union_nullish_reduction` — **11 passed**.
- Regression, 0 failures: `nullish` (268), `nonstrict` (77), `ts2322` (636), `widen` (275), `non_strict_nullish_return_widening` (16), `explicit_any` (4, covering the moved code).
- `cargo clippy -p tsz-checker --lib -- -D warnings` clean; arch-size guard green (all touched files ≤ 2000 lines).
- Conformance / emit / fourslash run in CI (nightly / workflow_dispatch); this is a broad non-strict seam so the corpus (largely non-strict) is the authoritative gate and is expected to move toward parity.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsSba2kAnDS1DTVYeKoab6)_