### PR TITLE
fix(checker): yield* over a union/intersection delegate contributes the union of member element types (#15632)

### DIFF
--- a/crates/tsz-checker/src/checkers/iterable_checker.rs
+++ b/crates/tsz-checker/src/checkers/iterable_checker.rs
@@ -451,14 +451,38 @@ impl<'a> CheckerState<'a> {
             return TypeId::ANY;
         }
 
-        if let ForOfElementKind::TypeParameter { constraint } =
-            classify_for_of_element_type(self.ctx.types, iterable_type)
-        {
-            return constraint
-                .map(|constraint| {
-                    self.for_of_element_type_with_depth(constraint, is_async, depth + 1)
-                })
-                .unwrap_or(TypeId::ANY);
+        match classify_for_of_element_type(self.ctx.types, iterable_type) {
+            ForOfElementKind::TypeParameter { constraint } => {
+                return constraint
+                    .map(|constraint| {
+                        self.for_of_element_type_with_depth(constraint, is_async, depth + 1)
+                    })
+                    .unwrap_or(TypeId::ANY);
+            }
+            // Distribute async iteration over a union/intersection delegate
+            // member-by-member. The sync `for_of_element_type_classified`
+            // fallback below walks `[Symbol.iterator]`, so an async-only member
+            // (`AsyncGenerator<T>`, `AsyncIterable<T>`) inside a union would
+            // collapse to `ANY` there; resolving each constituent through this
+            // async-aware entry recovers it. tsc's iteration type over a
+            // union/intersection is the union/intersection of the members'.
+            // (The sync arm already distributes inside
+            // `for_of_element_type_classified`, so this is gated on `is_async`.)
+            ForOfElementKind::Union(members) if is_async => {
+                let element_types = members
+                    .into_iter()
+                    .map(|member| self.for_of_element_type_with_depth(member, is_async, depth + 1))
+                    .collect();
+                return union_element_type(self.ctx.types, element_types);
+            }
+            ForOfElementKind::Intersection(members) if is_async => {
+                let element_types = members
+                    .into_iter()
+                    .map(|member| self.for_of_element_type_with_depth(member, is_async, depth + 1))
+                    .collect();
+                return intersection_element_type(self.ctx.types, element_types);
+            }
+            _ => {}
         }
 
         if is_async {

--- a/crates/tsz-checker/src/dispatch/yield_.rs
+++ b/crates/tsz-checker/src/dispatch/yield_.rs
@@ -538,42 +538,45 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                     // Always collect regardless of contextual yield type — the final
                     // generator yield type must come from actual body yields, not context
                     // (see function_type.rs comment on final_generator_yield_type).
-                    if let Some(ref i) = async_info {
-                        self.checker.ctx.push_generator_yield_star_contribution(
-                            i.yield_type,
-                            yield_star_next_type,
-                        );
-                        // When yield* delegates to an async iterable with `any` element
-                        // type, suppress TS7055 at the function level (see sync path).
-                        if i.yield_type == TypeId::ANY {
-                            self.checker.ctx.generator_had_ts7057 = true;
-                        }
-                    } else {
-                        // `get_iterator_info` is a pure structural solver query: its
-                        // `[Symbol.asyncIterator]` lookup cannot evaluate through the
-                        // `TypeData::Lazy(DefId)` alias body that every non-array/tuple
-                        // lib iterable (`AsyncGenerator<T>`, `AsyncIterable<T>`,
-                        // `Generator<T>`, `Set<T>`, `string`) exposes its iterator
-                        // member behind, so it answers `None` and the aggregated yield
-                        // type silently collapsed to `any`. This is the same blind spot
-                        // #16030 fixed on the sync arm; `for await..of` already escapes
-                        // it through the checker's env-aware property-access chain
-                        // (async protocol first, then sync + `Awaited`), which is the
-                        // same iteration semantics `tsc` uses for an async `yield*`
-                        // (`IterationUse.AsyncYieldStar`). Reuse that query rather than
-                        // defaulting the aggregate to `any`.
-                        //
-                        // `ANY` is this chain's unresolved sentinel as well as a real
-                        // answer, so it keeps the pre-existing behaviour exactly —
-                        // contribute nothing, set no flag — rather than widening the
-                        // aggregate or newly suppressing TS7055 on a shape this arm
-                        // has never spoken for.
-                        let resolved = self.checker.for_of_element_type(expression_type, true);
-                        if resolved != TypeId::ANY {
+                    //
+                    // `get_iterator_info` is a pure structural solver query that answers
+                    // its `ANY` sentinel (or `None`) for two shapes it cannot resolve: a
+                    // lib iterable behind a `TypeData::Lazy(DefId)` alias body
+                    // (`AsyncGenerator<T>`, `AsyncIterable<T>`, `Generator<T>`, `Set<T>`,
+                    // `string`) whose `[Symbol.asyncIterator]` lookup can't evaluate through
+                    // the alias, and a **union/intersection** delegate, which it never
+                    // distributes over. `for await..of` already escapes both through the
+                    // checker's env-aware, union-distributing chain (async protocol first,
+                    // then sync + `Awaited`), which is the same iteration semantics `tsc`
+                    // uses for an async `yield*` (`IterationUse.AsyncYieldStar`). Reuse that
+                    // query rather than defaulting the aggregate to `any`.
+                    match async_info {
+                        Some(ref i) if i.yield_type != TypeId::ANY => {
                             self.checker.ctx.push_generator_yield_star_contribution(
-                                resolved,
+                                i.yield_type,
                                 yield_star_next_type,
                             );
+                        }
+                        resolved_via_solver => {
+                            let resolved = self.checker.for_of_element_type(expression_type, true);
+                            if resolved != TypeId::ANY {
+                                self.checker.ctx.push_generator_yield_star_contribution(
+                                    resolved,
+                                    yield_star_next_type,
+                                );
+                            } else if resolved_via_solver.is_some() {
+                                // The solver resolved the delegate but only to `ANY`, and
+                                // the env-aware chain could not refine it (e.g. `yield*` of
+                                // an `any`-typed async iterable): preserve the pre-existing
+                                // behaviour of contributing `ANY` and suppressing the
+                                // function-level TS7055. The bare-`None` case still
+                                // contributes nothing and sets no flag, as before.
+                                self.checker.ctx.push_generator_yield_star_contribution(
+                                    TypeId::ANY,
+                                    yield_star_next_type,
+                                );
+                                self.checker.ctx.generator_had_ts7057 = true;
+                            }
                         }
                     }
                     element
@@ -599,7 +602,9 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                     // generator yield type must come from actual body yields, not context
                     // (see function_type.rs comment on final_generator_yield_type).
                     let yield_type = match info {
-                        Some(ref i) => {
+                        // A resolved, non-`ANY` structural answer (arrays/tuples, and the
+                        // `never` empty-array case handled just below) is authoritative.
+                        Some(ref i) if i.yield_type != TypeId::ANY => {
                             // In non-strict mode (strictNullChecks: false), an empty iterable
                             // like `[]` produces `never[]` (element type: `never`). But tsc
                             // treats the element type as `undefined` for generator yield
@@ -618,22 +623,18 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                                 i.yield_type
                             }
                         }
-                        None => {
-                            // `get_iterator_info` is a pure structural (solver-only) query:
-                            // its `[Symbol.iterator]` lookup cannot evaluate through a
-                            // `TypeData::Lazy(DefId)` alias body, which is how every
-                            // non-array/tuple lib iterable (`Set<T>`, `Iterable<T>`,
-                            // `Generator<T>`, a delegate through another generator
-                            // declaration) exposes that member — the lookup instead
-                            // resolves the method to `ANY`, which the `ThisType`
-                            // fallback then re-interprets as "the delegate IS the
-                            // iterator", so `next()` is never found and the whole query
-                            // returns `None`. `for..of` already solves this exact gap
-                            // (`ForOfElementKind::Other` in `for_of_element_type_classified`)
-                            // via the checker's env-aware property-access chain; reuse the
-                            // same query here instead of silently collapsing to `any`.
-                            self.checker.resolve_iterator_element_type(expression_type)
-                        }
+                        // `get_iterator_info` is a pure structural (solver-only) query that
+                        // answers its `ANY` sentinel (or `None`) for two shapes it cannot
+                        // resolve: (1) a lib iterable behind a `TypeData::Lazy(DefId)` alias
+                        // body — its `[Symbol.iterator]` lookup can't evaluate through the
+                        // alias, so every non-array/tuple lib iterable (`Set<T>`,
+                        // `Iterable<T>`, `Generator<T>`, a delegate through another
+                        // generator) collapses; and (2) a **union/intersection** delegate,
+                        // which it never distributes over. `for..of` already solves both via
+                        // the checker's env-aware, union-distributing chain
+                        // (`for_of_element_type` → `for_of_element_type_classified`); reuse
+                        // it here instead of silently collapsing to `any`.
+                        _ => self.checker.for_of_element_type(expression_type, false),
                     };
                     self.checker
                         .ctx

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -351,6 +351,8 @@ mod generator_yield_self_similar_nesting_tests;
 mod generator_yield_star_next_type_tests;
 #[path = "tests/generator_yieldstar_symbol_iterator_contribution_tests.rs"]
 mod generator_yieldstar_symbol_iterator_contribution_tests;
+#[path = "tests/generator_yieldstar_union_delegate_contribution_tests.rs"]
+mod generator_yieldstar_union_delegate_contribution_tests;
 #[path = "tests/generic_alias_application_display_tests.rs"]
 mod generic_alias_application_display_tests;
 #[path = "tests/generic_argument_suppression_relation_routing_arch_tests.rs"]

--- a/crates/tsz-checker/src/tests/async_generator_yieldstar_contribution_tests.rs
+++ b/crates/tsz-checker/src/tests/async_generator_yieldstar_contribution_tests.rs
@@ -432,17 +432,15 @@ wants(d());
     );
 }
 
-/// Both union rows are red on `main` and stay red with this fix, for a reason
-/// that has nothing to do with the contribution: tsz reports a spurious
-/// **TS1320** on a union of `AsyncGenerator`s. That diagnostic is raised by
-/// `async_iterator_has_invalid_thenable_next_result`, *upstream* of the
-/// contribution in the same arm, and it fires on both the mismatched and the
-/// matching instantiation — including the row that `tsc` reports nothing on at
-/// all. Kept as documented `#[ignore]`s rather than deleted: they are the two
-/// rows that pin the union axis of this family, and they become live the
-/// moment that separate defect is fixed.
+/// The union axis of this family. Both rows were previously blocked on two
+/// independent defects on the union arm: a spurious **TS1320** raised by
+/// `async_iterator_has_invalid_thenable_next_result` (fixed by #16116, which
+/// distributes that predicate over union members), and the contribution itself
+/// collapsing to `any` because `get_iterator_info` never distributes over a
+/// union delegate. Both are now fixed — the `yield*` element resolution routes
+/// through the checker's env-aware, union-distributing chain — so these rows
+/// are live regression guards.
 #[test]
-#[ignore = "pre-existing spurious TS1320 on a union delegate: see the doc comment"]
 fn union_delegate_contributes_the_union_of_element_types() {
     let codes = strict_codes(
         r#"

--- a/crates/tsz-checker/src/tests/generator_yieldstar_union_delegate_contribution_tests.rs
+++ b/crates/tsz-checker/src/tests/generator_yieldstar_union_delegate_contribution_tests.rs
@@ -1,0 +1,281 @@
+//! Regression tests for the last open slice of #15632: a `yield*` **union or
+//! intersection** delegate contributes nothing to an unannotated generator's
+//! inferred yield type, so the aggregate collapses to `any` and a mismatched
+//! `Generator` instantiation is silently accepted.
+//!
+//! Root cause: the `yield*` element resolution called the solver's structural
+//! `get_iterator_info`, which answers its `ANY` sentinel for a union delegate
+//! (it never distributes over the constituents) and for any lib iterable behind
+//! a `TypeData::Lazy(DefId)` alias body, then only fell back to the
+//! non-distributing `resolve_iterator_element_type`. `for..of` already handled
+//! unions via `for_of_element_type_classified`'s `ForOfElementKind::Union` /
+//! `Intersection` arms; the fix routes `yield*` through that same env-aware,
+//! union-distributing chain (`for_of_element_type`), and teaches its async
+//! entry to distribute over members using the async protocol (the sync
+//! classified fallback can only resolve members through `[Symbol.iterator]`).
+//!
+//! tsc's iteration type over a union delegate is the **union** of the members'
+//! element types, and over an intersection the **intersection**. Every negative
+//! row feeds the delegate to a deliberately wrong `Generator` instantiation, so
+//! a missing `TS2345` means the union contribution collapsed to `any`; each is
+//! paired with a positive control that must stay clean (a narrower-but-wrong
+//! inferred type would also satisfy the negative row). All rows were oracled
+//! against `tsc@7.0.2` (`--noEmit --strict`).
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_source_with_libs, load_default_lib_files};
+
+fn strict_codes(source: &str) -> Vec<u32> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|diagnostic| diagnostic.code)
+    .collect()
+}
+
+/// Core repro: a union of two differently-instantiated `Generator`s must
+/// contribute `string | number`, not collapse to `any`.
+#[test]
+fn union_of_generators_contributes_the_union_of_element_types() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const src: Generator<string> | Generator<number>;
+declare function wants(g: Generator<boolean>): void;
+const d = function* () { yield* src; };
+wants(d());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "a union of Generators must contribute `string | number`, not `any`: {codes:?}"
+    );
+}
+
+#[test]
+fn union_of_generators_correct_instantiation_stays_clean() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const src: Generator<string> | Generator<number>;
+declare function wants(g: Generator<string | number>): void;
+const d = function* () { yield* src; };
+wants(d());
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "the matching instantiation must stay clean — a narrower-but-wrong yield type would also satisfy the TS2345 row: {codes:?}"
+    );
+}
+
+/// The array/tuple fast path is a different `get_iterator_info` branch, but the
+/// union of two arrays is not itself an array, so it hit the same collapse.
+#[test]
+fn union_of_arrays_contributes_the_union_of_element_types() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const src: string[] | number[];
+declare function wants(g: Generator<boolean>): void;
+const d = function* () { yield* src; };
+wants(d());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "a union of arrays must contribute `string | number`: {codes:?}"
+    );
+}
+
+#[test]
+fn union_of_tuples_contributes_the_union_of_element_types() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const src: [string, string] | [number, number];
+declare function wants(g: Generator<boolean>): void;
+const d = function* () { yield* src; };
+wants(d());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "a union of tuples must contribute `string | number`: {codes:?}"
+    );
+}
+
+/// `Iterable<T>` reaches its iterator member through a `Lazy(DefId)` alias body,
+/// which the structural solver query cannot see — the union stacks that blind
+/// spot on top of the non-distribution one.
+#[test]
+fn union_of_iterables_contributes_the_union_of_element_types() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const src: Iterable<string> | Iterable<number>;
+declare function wants(g: Generator<boolean>): void;
+const d = function* () { yield* src; };
+wants(d());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "a union of Iterables must contribute `string | number`: {codes:?}"
+    );
+}
+
+#[test]
+fn union_of_sets_contributes_the_union_of_element_types() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const src: Set<string> | Set<number>;
+declare function wants(g: Generator<boolean>): void;
+const d = function* () { yield* src; };
+wants(d());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "a union of Sets must contribute `string | number`: {codes:?}"
+    );
+}
+
+/// Members of different iterable *kinds* (array fast path + lazy lib iterable)
+/// in one union: each must resolve through its own path and still union.
+#[test]
+fn union_of_mixed_iterable_kinds_contributes_the_union() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const src: string[] | Generator<number>;
+declare function wants(g: Generator<boolean>): void;
+const d = function* () { yield* src; };
+wants(d());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "a union mixing an array and a Generator must contribute `string | number`: {codes:?}"
+    );
+}
+
+/// A string-literal member is iterable and contributes `string`.
+#[test]
+fn union_with_a_string_member_contributes_string() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const src: Generator<number> | "ab";
+declare function wants(g: Generator<boolean>): void;
+const d = function* () { yield* src; };
+wants(d());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "a union with a string member must contribute `string | number`: {codes:?}"
+    );
+}
+
+/// An **intersection** delegate contributes the intersection of the members'
+/// element types (`{ a } & { b }`), not their union and not `any`.
+#[test]
+fn intersection_delegate_contributes_the_intersection_of_element_types() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const src: Iterable<{ a: number }> & Iterable<{ b: number }>;
+declare function wants(g: Generator<{ c: number }>): void;
+const d = function* () { yield* src; };
+wants(d());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "an intersection delegate must contribute `{{ a }} & {{ b }}`: {codes:?}"
+    );
+}
+
+#[test]
+fn intersection_delegate_correct_instantiation_stays_clean() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const src: Iterable<{ a: number }> & Iterable<{ b: number }>;
+declare function wants(g: Generator<{ a: number }>): void;
+const d = function* () { yield* src; };
+wants(d());
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "`{{ a }} & {{ b }}` is assignable to `{{ a }}`, so the matching instantiation must stay clean: {codes:?}"
+    );
+}
+
+/// A plain `yield` and a delegated union `yield*` must **union** into the
+/// aggregate, not replace one another.
+#[test]
+fn plain_and_delegated_union_yields_join_rather_than_replace() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const src: Generator<string> | Generator<number>;
+declare function wants(g: Generator<string | number | boolean>): void;
+const d = function* () { yield true; yield* src; };
+wants(d());
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "the plain and delegated union yields must join into `string | number | boolean`: {codes:?}"
+    );
+}
+
+/// Anti-hardcoding control: the fix is structural, so renaming every binder and
+/// the local relay must not change the result.
+#[test]
+fn renamed_binders_union_delegate_still_contributes() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const zqFeed: Generator<string> | Generator<number>;
+declare function zzConsume(gRelay: Generator<boolean>): void;
+const zRelay = function* () { yield* zqFeed; };
+zzConsume(zRelay());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "renamed binders must not change the union contribution: {codes:?}"
+    );
+}
+
+/// Baseline control: a single (non-union) delegate already worked and must keep
+/// working — this fix only adds the union/intersection distribution.
+#[test]
+fn single_generator_delegate_stays_correct() {
+    let codes = strict_codes(
+        r#"
+export {};
+declare const src: Generator<string>;
+declare function wants(g: Generator<boolean>): void;
+const d = function* () { yield* src; };
+wants(d());
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "a single Generator delegate must keep contributing its element type: {codes:?}"
+    );
+}


### PR DESCRIPTION
Closes the last open slice of #15632. Supersedes #16585 (an earlier session's PR from the same conceptual fix), which went stale against current `main` and had a real merge conflict — closing it in favor of this one.

**Structural rule.** When an unannotated generator delegates with `yield* e` and `e` is a **union or intersection** iterable, tsc contributes the *union* (resp. *intersection*) of the members' iteration yield types to the aggregated yield type, exactly like a plain `yield`. tsz contributed nothing, so the inferred signature collapsed to `any` and a mismatched `Generator`/`AsyncGenerator` instantiation was silently accepted. tsz now does the same through the **checker's env-aware iterator element-type chain** (`for_of_element_type` → `for_of_element_type_classified`), the same one `for..of` already uses.

This is general — every union member shape failed, not just lib iterables. Delegate → tsc / tsz-before / tsz-after (all `--noEmit --strict`, deliberately-wrong instantiation so the correct answer is TS2345):

- `yield* (string[] | number[])` → TS2345 / none / **TS2345**
- `yield* (Generator<a> | Generator<b>)` → TS2345 / none / **TS2345**
- `yield* (Iterable<a> | Iterable<b>)` → TS2345 / none / **TS2345**
- `yield* (Set<a> | Set<b>)` → TS2345 / none / **TS2345**
- async `yield* (AsyncGenerator<a> | AsyncGenerator<b>)` → TS2345 / none / **TS2345**
- `yield* (Iterable<{a}> & Iterable<{b}>)` → element `{a}&{b}` / `any` / **`{a}&{b}`**

Single (non-union) delegates already worked, and `for..of` over the same unions already worked — the divergence was entirely in the `yield*` path.

## Owner layer
Checker only (`crates/tsz-checker`). No solver / emitter / diagnostic-display change.

**Root cause.** The `yield*` element resolution called the solver's structural `get_iterator_info`, which returns its `ANY` sentinel for (1) a lib iterable behind a `TypeData::Lazy(DefId)` alias body and (2) a **union/intersection** delegate, which it never distributes over — then only fell back to the non-distributing `resolve_iterator_element_type` on `None`, so a `Some { yield_type: ANY }` masked the fallback entirely. `for..of` avoids this by routing through `for_of_element_type_classified`, whose `ForOfElementKind::Union`/`Intersection` arms distribute.

**Two coordinated changes:**
1. `dispatch/yield_.rs` (sync + async arms): route the unresolved case (`ANY` sentinel *or* `None`, not only `None`) through `for_of_element_type`, the env-aware distributing chain. The genuinely-`any` delegate keeps its `ANY` contribution and TS7055/7057 suppression exactly as before. This composes with the `TNext`-contribution and TS2766 plumbing two other #15632 slices (`e4eb097`, `d9271ce`) landed in the same function since the original attempt at this fix — the union/intersection distribution reuses the same `push_generator_yield_star_contribution(yield_type, yield_star_next_type)` call sites rather than reverting them.
2. `checkers/iterable_checker.rs`: `for_of_element_type_with_depth` distributes async iteration over union/intersection members member-by-member — the sync `for_of_element_type_classified` fallback walks `[Symbol.iterator]`, so an async-only member (`AsyncGenerator`) inside a union would collapse to `ANY` there.

**Adjacent matrix** (all oracled against `tsc@7.0.2`, `--noEmit --strict`): union of arrays / tuples / Generators / Iterables / Sets / strings / mixed member kinds; intersection (positive + assignable-narrowing control); mixed plain + delegated yields; renamed binders (anti-hardcoding); async unions (AsyncGenerator/AsyncIterable). As a bonus the async union distribution also fixes `for await..of` over a union of `AsyncGenerator`s, and unblocks two previously-`#[ignore]`d async union-contribution regression tests that were only pinned pending a separate TS1320 fix (#16116, already landed on `main`).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib -- generator_yieldstar_union_delegate_contribution async_generator_yieldstar_contribution generator_yieldstar_symbol_iterator_contribution` — 45/45 pass, 1 pre-existing unrelated ignore (new suite + both touched existing suites, including the two previously-`#[ignore]`d union rows now un-ignored and green).
- `cargo test -p tsz-checker --lib -- yield iterat for_of forof for_await generator iterable` — **424 pass, 0 fail** (broad iterator/generator regression net).
- `cargo clippy --profile dist-fast -p tsz-checker --lib -- -D warnings` — clean. `cargo fmt` clean. Pre-commit hook (clippy + arch-size guard) passed on commit.
- `cargo test -p tsz-checker --lib` (full crate) — started; this crate's long tail (a handful of named tests) had not finished printing a summary at PR-open time. Will append the result once it lands; the 424-test targeted net above already covers every iterator/generator-adjacent test in the crate.
- Conformance two-sided compare-to-parent — not yet run this session (time budget); flagged as owed. The prior attempt at this exact fix (#16585) recorded a byte-identical two-sided fingerprint (0 newly-failing/passing) against its own parent, and this change is checker-only with no diagnostic-display or solver change, so no corpus movement is expected, but the number is owed rather than assumed.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBHAF6zyajF4ZR3WdD3o6a)_