### PR TITLE
fix(checker): a required-after-optional parameter draws only one TS1016 per list (#16644)

### DIFF
--- a/crates/tsz-checker/src/checkers/parameter_checker.rs
+++ b/crates/tsz-checker/src/checkers/parameter_checker.rs
@@ -703,6 +703,10 @@ impl<'a> CheckerState<'a> {
                     diagnostic_messages::PARAMETER_CANNOT_HAVE_QUESTION_MARK_AND_INITIALIZER,
                     diagnostic_codes::PARAMETER_CANNOT_HAVE_QUESTION_MARK_AND_INITIALIZER,
                 );
+                // tsc's `checkGrammarParameterList` returns at the first grammar
+                // error found anywhere in the list, so this parameter list draws
+                // no further TS1015/TS1016 diagnostics.
+                break;
             }
 
             // Rest parameter ends the check - rest params don't count as optional/required in this context
@@ -736,6 +740,10 @@ impl<'a> CheckerState<'a> {
                         diagnostic_messages::A_REQUIRED_PARAMETER_CANNOT_FOLLOW_AN_OPTIONAL_PARAMETER,
                         diagnostic_codes::A_REQUIRED_PARAMETER_CANNOT_FOLLOW_AN_OPTIONAL_PARAMETER,
                     );
+                    // tsc reports at most one grammar diagnostic per parameter
+                    // list and stops walking; every later required parameter in
+                    // this same list would otherwise draw its own TS1016.
+                    break;
                 }
             }
         }

--- a/crates/tsz-checker/src/tests/parameter_checker_tests.rs
+++ b/crates/tsz-checker/src/tests/parameter_checker_tests.rs
@@ -469,3 +469,139 @@ mod jsdoc_diagnostic_integration_tests {
         );
     }
 }
+
+/// #16644: tsc's `checkGrammarParameterList` reports at most one grammar
+/// diagnostic per parameter list and returns at the first offending
+/// parameter. `(a?: number, b: string, c: string)` has TWO required
+/// parameters following the optional `a` (`b` and `c`), and tsc reports
+/// TS1016 only for `b`. Oracle-pinned (`typescript@7.0.2`) across every
+/// signature-form owner of `check_parameter_ordering`.
+#[cfg(test)]
+mod ts1016_single_diagnostic_per_list_tests {
+    use crate::test_utils::check_source_diagnostics;
+
+    fn ts1016_positions(source: &str) -> Vec<u32> {
+        check_source_diagnostics(source)
+            .iter()
+            .filter(|d| d.code == 1016)
+            .map(|d| d.start)
+            .collect()
+    }
+
+    #[test]
+    fn function_declaration_reports_only_the_first() {
+        let positions = ts1016_positions("function d1(a?: number, b: string, c: string) {}");
+        assert_eq!(positions, vec![24], "expected exactly one TS1016 on `b`");
+    }
+
+    #[test]
+    fn function_expression_reports_only_the_first() {
+        let positions =
+            ts1016_positions("const d2 = function(a?: number, b: string, c: string) {};");
+        assert_eq!(
+            positions.len(),
+            1,
+            "expected exactly one TS1016: {positions:?}"
+        );
+    }
+
+    #[test]
+    fn arrow_function_reports_only_the_first() {
+        let positions = ts1016_positions("const d3 = (a?: number, b: string, c: string) => {};");
+        assert_eq!(
+            positions.len(),
+            1,
+            "expected exactly one TS1016: {positions:?}"
+        );
+    }
+
+    #[test]
+    fn class_method_reports_only_the_first() {
+        let positions = ts1016_positions("class C1 { m(a?: number, b: string, c: string) {} }");
+        assert_eq!(
+            positions.len(),
+            1,
+            "expected exactly one TS1016: {positions:?}"
+        );
+    }
+
+    #[test]
+    fn constructor_reports_only_the_first() {
+        let positions =
+            ts1016_positions("class C2 { constructor(a?: number, b: string, c: string) {} }");
+        assert_eq!(
+            positions.len(),
+            1,
+            "expected exactly one TS1016: {positions:?}"
+        );
+    }
+
+    #[test]
+    fn interface_method_signature_reports_only_the_first() {
+        let positions =
+            ts1016_positions("interface I1 { m(a?: number, b: string, c: string): void; }");
+        assert_eq!(
+            positions.len(),
+            1,
+            "expected exactly one TS1016: {positions:?}"
+        );
+    }
+
+    #[test]
+    fn interface_call_signature_reports_only_the_first() {
+        let positions =
+            ts1016_positions("interface I2 { (a?: number, b: string, c: string): void; }");
+        assert_eq!(
+            positions.len(),
+            1,
+            "expected exactly one TS1016: {positions:?}"
+        );
+    }
+
+    #[test]
+    fn interface_construct_signature_reports_only_the_first() {
+        let positions =
+            ts1016_positions("interface I3 { new (a?: number, b: string, c: string): I3; }");
+        assert_eq!(
+            positions.len(),
+            1,
+            "expected exactly one TS1016: {positions:?}"
+        );
+    }
+
+    #[test]
+    fn object_literal_method_reports_only_the_first() {
+        let positions = ts1016_positions("const o1 = { m(a?: number, b: string, c: string) {} };");
+        assert_eq!(
+            positions.len(),
+            1,
+            "expected exactly one TS1016: {positions:?}"
+        );
+    }
+
+    /// A TS1015 (question mark + initializer) is itself a grammar error that
+    /// ends the walk — tsc never reaches the later required parameter, so no
+    /// TS1016 rides along behind it.
+    #[test]
+    fn question_and_initializer_suppresses_a_later_ts1016() {
+        let diags = check_source_diagnostics("function d4(a?: number = 1, b: string) {}");
+        assert!(
+            diags.iter().any(|d| d.code == 1015),
+            "expected TS1015: {diags:?}"
+        );
+        assert!(
+            !diags.iter().any(|d| d.code == 1016),
+            "TS1015 should suppress the trailing TS1016: {diags:?}"
+        );
+    }
+
+    /// All-required and all-optional lists still take no diagnostic (control).
+    #[test]
+    fn no_ts1016_when_ordering_is_valid() {
+        let diags = check_source_diagnostics("function ok(a: number, b?: string) {}");
+        assert!(
+            !diags.iter().any(|d| d.code == 1016),
+            "valid ordering should not report TS1016: {diags:?}"
+        );
+    }
+}


### PR DESCRIPTION
tsc's `checkGrammarParameterList` reports at most one grammar diagnostic per parameter list — every arm (`TS1014` rest-not-last, `TS1015` question-mark-and-initializer, `TS1016` required-after-optional) is a `return grammarErrorOnNode(...)`, so the first offending parameter wins and the walk over the rest of the list stops. tsz's `check_parameter_ordering` (`crates/tsz-checker/src/checkers/parameter_checker.rs`) had no such early return on either its TS1015 or TS1016 arm, so every required parameter following an optional run drew its own TS1016, and a TS1015 hit did not suppress a later TS1016 in the same list either.

Structural rule: when a parameter list's grammar check has already reported one diagnostic (TS1015 or TS1016), tsc stops walking that list and reports nothing further; tsz now does the same through the two `break` statements added to `check_parameter_ordering`'s per-parameter loop.

This closes the TS1016-duplication half of #16644 (Nephrite's own scoped "cheap, self-contained slice"). The TS1014-behind-TS1016 layer split from the same issue (TS1014 lives in the parser, TS1016 in the checker, so today the parser can't know a later grammar check will fire) is a separate follow-up per the issue's own guidance — it needs TS1014 to move into the checker rather than an early return, and is left open on #16644.

`check_parameter_ordering` is the single shared owner for function declarations, function/arrow expressions, class methods, constructors, interface method/call/construct signatures, and object-literal methods, so this one fix covers all of them — verified below.

## Goal
Goal: hold

## Verification
- Oracle differential (`typescript@7.0.2 --noEmit --strict --pretty false --target es2022 --lib es2022`) across 10 fixtures — function declaration, function expression, arrow function, class method, constructor, interface method/call/construct signature, object-literal method, and a TS1015-then-TS1016 interaction case: **tsz output byte-identical to tsc on all 10**, after the fix.
- Same 10 fixtures against unmodified `main` (`d184df0`, via `git stash`): 3 spot-checked (declaration, constructor, TS1015-interaction) all showed the extra diagnostic before the fix — confirms this is a real regression fix, not a no-op.
- `cargo test -p tsz-checker --lib parameter_checker_tests`: 43 passed / 0 failed, including a new `ts1016_single_diagnostic_per_list_tests` module pinning all 10 adjacent-case rows plus a valid-ordering control.
- `cargo clippy -p tsz-checker --lib -- -D warnings`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.
- `cargo test -p tsz-checker --lib` (full suite, all ~10k tests): started before push, still running in the background at push time due to the suite's long tail (board-documented: 8522/8527 finish in ~6 min, the rest are five long-running named tests) — no failures observed in the completed portion; will report the tail result as a follow-up comment if anything surfaces.
- Diff is checker-only (`crates/tsz-checker/src/checkers/parameter_checker.rs`, plus a test-only addition to `crates/tsz-checker/src/tests/parameter_checker_tests.rs`); this is a diagnostic-count-only grammar edge case (duplicate/extra TS1015/TS1016 on rare malformed parameter lists), so a broad conformance corpus move is unlikely — full `compare-to-parent.sh` not run this session given the board's documented 55-90+ min cold-seat cost for a two-sided run; owed if a reviewer wants it before landing.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_01DQPF4ydmQho2E3SFgcW8gm)_