### PR TITLE
fix(checker): report one grammar diagnostic per parameter list (#16644)

### DIFF
--- a/crates/tsz-checker/src/checkers/parameter_checker.rs
+++ b/crates/tsz-checker/src/checkers/parameter_checker.rs
@@ -678,11 +678,24 @@ impl<'a> CheckerState<'a> {
             None
         };
 
-        let mut seen_optional = false;
-
         self.check_this_parameter_placement(parameters, func_idx);
 
-        for &param_idx in &parameters.nodes {
+        // Mirror tsc's `checkGrammarParameterList`: it walks the parameter list
+        // once and every arm is `return grammarErrorOnNode(...)`, so it reports
+        // **at most one** ordering-grammar diagnostic per list — the first
+        // offending parameter wins and the walk stops. tsz splits this across
+        // layers: TS1015/TS1016 are checker-owned (here), while the rest-param
+        // grammar (TS1014 rest-not-last, TS1047 rest-optional, TS1048
+        // rest-initializer) is parser-emitted. A rest parameter is therefore a
+        // hard stop: reaching one means no checker-owned error fired earlier
+        // (otherwise we would already have returned), so the parser's own
+        // diagnostic for it is the list's single winner and the walk ends.
+        // When a checker-owned error *does* win, any parser rest-grammar
+        // diagnostic on a *later* parameter is a loser tsc never reached, so we
+        // record its span for the driver to drop.
+        let mut seen_optional = false;
+
+        for (index, &param_idx) in parameters.nodes.iter().enumerate() {
             let Some(param_node) = self.ctx.arena.get(param_idx) else {
                 continue;
             };
@@ -690,24 +703,10 @@ impl<'a> CheckerState<'a> {
                 continue;
             };
 
-            // TS1015: Parameter cannot have question mark and initializer.
-            // This is a grammar check (in tsc it lives in the checker, not the parser).
-            // Suppress when the file has syntax parse errors — tsc skips grammar checks
-            // on subtrees from parser-recovery artifacts (e.g. broken arrow functions).
-            if param.question_token
-                && param.initializer.is_some()
-                && !self.has_syntax_parse_errors()
-            {
-                self.error_at_node(
-                    param.name,
-                    diagnostic_messages::PARAMETER_CANNOT_HAVE_QUESTION_MARK_AND_INITIALIZER,
-                    diagnostic_codes::PARAMETER_CANNOT_HAVE_QUESTION_MARK_AND_INITIALIZER,
-                );
-            }
-
-            // Rest parameter ends the check - rest params don't count as optional/required in this context
+            // A rest parameter is tsc's return point (its rest-grammar codes are
+            // parser-emitted in tsz). Stop the checker-side walk here.
             if param.dot_dot_dot_token {
-                break;
+                return;
             }
 
             // Check if this parameter is optional via `?` token or JSDoc annotations
@@ -725,19 +724,76 @@ impl<'a> CheckerState<'a> {
 
             if is_optional {
                 seen_optional = true;
+                // TS1015: Parameter cannot have question mark and initializer.
+                // A grammar check that lives in the checker in tsc. Suppress when
+                // the file has syntax parse errors — tsc skips grammar checks on
+                // subtrees from parser-recovery artifacts (e.g. broken arrows).
+                if param.question_token
+                    && param.initializer.is_some()
+                    && !self.has_syntax_parse_errors()
+                {
+                    self.error_at_node(
+                        param.name,
+                        diagnostic_messages::PARAMETER_CANNOT_HAVE_QUESTION_MARK_AND_INITIALIZER,
+                        diagnostic_codes::PARAMETER_CANNOT_HAVE_QUESTION_MARK_AND_INITIALIZER,
+                    );
+                    self.record_rest_grammar_suppression_after(parameters, index);
+                    return;
+                }
             } else if seen_optional {
-                // A parameter is "required" only if it has neither `?` nor an initializer.
-                // Parameters with initializers (e.g., `options = {}`) are effectively optional
-                // and don't trigger TS1016 even after `?` parameters.
-                let has_initializer = param.initializer.is_some();
-                if !has_initializer {
+                // A parameter is "required" only if it has neither `?` nor an
+                // initializer. Parameters with initializers (e.g. `options = {}`)
+                // are effectively optional and don't trigger TS1016.
+                if param.initializer.is_none() {
                     self.error_at_node(
                         param.name,
                         diagnostic_messages::A_REQUIRED_PARAMETER_CANNOT_FOLLOW_AN_OPTIONAL_PARAMETER,
                         diagnostic_codes::A_REQUIRED_PARAMETER_CANNOT_FOLLOW_AN_OPTIONAL_PARAMETER,
                     );
+                    self.record_rest_grammar_suppression_after(parameters, index);
+                    return;
                 }
             }
+        }
+    }
+
+    /// Record the half-open `[pos, boundary)` span of every rest parameter that
+    /// appears *after* `winner_index` in `parameters`, so the driver drops the
+    /// parser-emitted rest-grammar diagnostics (TS1014/TS1047/TS1048) anchored
+    /// there. tsc's `checkGrammarParameterList` returned at `winner_index` and
+    /// never reached those parameters, so their diagnostics are losers of the
+    /// single-diagnostic-per-list rule.
+    ///
+    /// The three anchors all sit in the parameter's *head* — TS1014 at the
+    /// `...` token (`pos`), TS1048 on the name, TS1047 on the `?` token — which
+    /// always precedes any type annotation or default value. `boundary` is
+    /// therefore the start of the first of those subtrees, or the parameter's
+    /// end when it has neither: a nested function's own parameter-list grammar
+    /// inside a type annotation or default value starts at/after `boundary` and
+    /// is never caught.
+    fn record_rest_grammar_suppression_after(
+        &mut self,
+        parameters: &tsz_parser::parser::NodeList,
+        winner_index: usize,
+    ) {
+        for &param_idx in parameters.nodes.iter().skip(winner_index + 1) {
+            let Some(param_node) = self.ctx.arena.get(param_idx) else {
+                continue;
+            };
+            let Some(param) = self.ctx.arena.get_parameter(param_node) else {
+                continue;
+            };
+            if !param.dot_dot_dot_token {
+                continue;
+            }
+            let boundary = [param.type_annotation, param.initializer]
+                .into_iter()
+                .filter_map(|child| self.ctx.arena.pos_at(child))
+                .min()
+                .unwrap_or(param_node.end);
+            self.ctx
+                .parameter_grammar_suppress_spans
+                .push((param_node.pos, boundary));
         }
     }
 

--- a/crates/tsz-checker/src/context/checker_context_lifetimes.toml
+++ b/crates/tsz-checker/src/context/checker_context_lifetimes.toml
@@ -114,6 +114,7 @@ has_real_syntax_errors = { lifetime = "DiagnosticsOnly", capability = "Diagnosti
 has_structural_parse_errors = { lifetime = "DiagnosticsOnly", capability = "DiagnosticState", reason = "diagnostic emission, dedupe, or suppression state; clear at file-session boundary" }
 real_syntax_error_positions = { lifetime = "DiagnosticsOnly", capability = "DiagnosticState", reason = "diagnostic emission, dedupe, or suppression state; clear at file-session boundary" }
 all_parse_error_positions = { lifetime = "DiagnosticsOnly", capability = "DiagnosticState", reason = "diagnostic emission, dedupe, or suppression state; clear at file-session boundary" }
+parameter_grammar_suppress_spans = { lifetime = "DiagnosticsOnly", capability = "DiagnosticState", reason = "diagnostic emission, dedupe, or suppression state; clear at file-session boundary" }
 nullable_type_parse_error_positions = { lifetime = "DiagnosticsOnly", capability = "DiagnosticState", reason = "diagnostic emission, dedupe, or suppression state; clear at file-session boundary" }
 diagnostics = { lifetime = "DiagnosticsOnly", capability = "DiagnosticState", reason = "diagnostic emission, dedupe, or suppression state; clear at file-session boundary" }
 diagnostic_indices = { lifetime = "DiagnosticsOnly", capability = "DiagnosticState", reason = "diagnostic dedupe and auxiliary suppression indices; clear at file-session boundary and rebuild after speculation rollbacks" }

--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -352,6 +352,7 @@ impl<'a> CheckerContext<'a> {
             real_syntax_error_positions: Vec::new(),
             all_parse_error_positions: Vec::new(),
             nullable_type_parse_error_positions: Vec::new(),
+            parameter_grammar_suppress_spans: Vec::new(),
             diagnostics: Vec::new(),
             diagnostics_discarded: false,
             diagnostic_indices: DiagnosticIndices::default(),

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -1184,6 +1184,15 @@ pub struct CheckerContext<'a> {
     /// Used by TS2677 to widen predicate types to `T | null | undefined`.
     /// Excludes `!T` / `T!` errors which should not trigger widening.
     pub nullable_type_parse_error_positions: Vec<u32>,
+    /// Half-open `[start, end)` spans of rest parameters whose parser-emitted
+    /// grammar diagnostics (TS1014/TS1047/TS1048) must be suppressed because tsc's
+    /// single-early-return `checkGrammarParameterList` already reported an
+    /// earlier-positioned grammar error on the same parameter list
+    /// (TS1015/TS1016) and never reached the rest parameter. Populated by
+    /// `check_parameter_ordering`; consumed by the driver's per-file merge
+    /// (`run_check_on_existing_checker`) which drops the losing parse
+    /// diagnostics before combining them with checker diagnostics.
+    pub parameter_grammar_suppress_spans: Vec<(u32, u32)>,
     pub diagnostics: Vec<Diagnostic>,
     /// Whether this context's `diagnostics` are never surfaced to the user.
     ///

--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -405,6 +405,9 @@ impl CheckerState<'_> {
         // so any `__infer_*` witness that surfaces in a diagnostic is stable
         // across runs and across parallel file checks.
         self.ctx.begin_file_inference_placeholders();
+        // Parameter-list grammar suppression spans are recomputed per file by
+        // `check_parameter_ordering`; clear any left over from a reused checker.
+        self.ctx.parameter_grammar_suppress_spans.clear();
         let Some(root_idx) = self.prepare_source_file_for_checking(root_idx) else {
             return;
         };

--- a/crates/tsz-cli/src/driver/check_file.rs
+++ b/crates/tsz-cli/src/driver/check_file.rs
@@ -318,6 +318,17 @@ fn run_check_on_existing_checker<'a>(
         // file boundary so the distinct-`TypeId` high-water / over-cache
         // buckets attribute thrash per file. No-op when counters are disabled.
         tsz_common::perf_counters::record_interner_working_set_for_file();
+        // tsc reports at most one grammar diagnostic per parameter list. When
+        // the checker's `check_parameter_ordering` won that race with a
+        // TS1015/TS1016 on an earlier parameter, drop the parser-emitted
+        // rest-parameter grammar diagnostics (TS1014/TS1047/TS1048) tsc's
+        // single-early-return `checkGrammarParameterList` never reached. The
+        // spans are recomputed per file (cleared at `check_source_file` entry),
+        // so borrowing them here is safe across a reused checker.
+        suppress_parameter_grammar_losers(
+            &mut file_diagnostics,
+            &checker.ctx.parameter_grammar_suppress_spans,
+        );
         let mut checker_diagnostics = std::mem::take(&mut checker.ctx.diagnostics);
         let effective_options = ResolvedCompilerOptions {
             check_js,

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -378,6 +378,47 @@ pub(super) fn filtered_parse_diagnostics(
         .collect()
 }
 
+/// Parser-emitted rest-parameter grammar codes that belong to tsc's single
+/// `checkGrammarParameterList` early-return chain: TS1014 (a rest parameter
+/// must be last), TS1047 (a rest parameter cannot be optional), and TS1048 (a
+/// rest parameter cannot have an initializer). `is_parser_grammar_code` and
+/// `is_non_suppressing_parse_error` also list these three (as `const fn` match
+/// arms that cannot reference a slice), so this constant is the single source
+/// for *this* pass rather than a global unification of the family.
+const PARAMETER_LIST_REST_GRAMMAR_CODES: [u32; 3] = [1014, 1047, 1048];
+
+fn is_parameter_grammar_rest_code(code: u32) -> bool {
+    PARAMETER_LIST_REST_GRAMMAR_CODES.contains(&code)
+}
+
+/// Drop parser-emitted rest-parameter grammar diagnostics that lost tsc's
+/// one-diagnostic-per-parameter-list rule.
+///
+/// `suppress_spans` are half-open `[pos, boundary)` ranges recorded by the
+/// checker (`check_parameter_ordering`) for each rest parameter that follows an
+/// earlier checker-owned grammar error (TS1015/TS1016) in the same list. tsc's
+/// `checkGrammarParameterList` returns at that earlier parameter and never
+/// evaluates the rest parameter, so its TS1014/TS1047/TS1048 must not surface.
+/// `boundary` stops before the parameter's type annotation and default value,
+/// so a nested function's own rest-grammar diagnostic (which anchors inside
+/// those subtrees) is never caught here.
+pub(super) fn suppress_parameter_grammar_losers(
+    diagnostics: &mut Vec<Diagnostic>,
+    suppress_spans: &[(u32, u32)],
+) {
+    if suppress_spans.is_empty() {
+        return;
+    }
+    diagnostics.retain(|diagnostic| {
+        if !is_parameter_grammar_rest_code(diagnostic.code) {
+            return true;
+        }
+        !suppress_spans
+            .iter()
+            .any(|&(start, end)| diagnostic.start >= start && diagnostic.start < end)
+    });
+}
+
 fn is_hard_keyword_interface_name_2427_parse_diagnostic(diagnostic: &ParseDiagnostic) -> bool {
     diagnostic.code == 2427
         && (diagnostic.message == "Interface name cannot be 'void'."

--- a/crates/tsz-cli/src/driver/check_utils/rest_parameter_grammar_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/rest_parameter_grammar_tests.rs
@@ -182,3 +182,47 @@ fn filtered_parse_diagnostics_ts1015_ts1016_are_not_listed() {
     assert!(!is_parser_grammar_code(1015));
     assert!(!is_parser_grammar_code(1016));
 }
+
+/// `suppress_parameter_grammar_losers` drops exactly the rest-parameter
+/// grammar codes (TS1014/1047/1048) whose anchor falls inside a checker-
+/// recorded half-open span, and nothing else (#16644). The span models the
+/// loser rest parameter tsc's single-early-return `checkGrammarParameterList`
+/// never reached after an earlier TS1015/TS1016 already won the list: it runs
+/// `[..., boundary)` where `boundary` is the start of the parameter's type
+/// annotation or default value, so the parameter head's three anchors are
+/// caught but the subtrees (which can carry a nested function's own grammar)
+/// are not.
+#[test]
+fn suppress_parameter_grammar_losers_drops_only_in_span_rest_codes() {
+    let make = |code: u32, start: u32| Diagnostic::error("main.ts", start, 1, "m", code);
+    // Winner recorded a loser rest parameter whose head spans [40, 50); its
+    // type annotation / default value subtree begins at 50.
+    let spans = [(40u32, 50u32)];
+
+    let mut diagnostics = vec![
+        make(1016, 30), // the winner, earlier than the span — must survive
+        make(1014, 40), // loser rest-not-last at the `...` token (span start) — dropped
+        make(1048, 42), // loser rest-initializer on the name — dropped
+        make(1047, 44), // loser rest-optional on the `?` token — dropped
+        make(1014, 50), // a nested grammar error at the boundary (subtree start) — survives
+        make(1014, 80), // an unrelated rest-not-last outside the span — survives
+        make(2322, 42), // a non-family code inside the span — never touched
+    ];
+    suppress_parameter_grammar_losers(&mut diagnostics, &spans);
+
+    let survivors: Vec<(u32, u32)> = diagnostics.iter().map(|d| (d.code, d.start)).collect();
+    assert_eq!(
+        survivors,
+        vec![(1016, 30), (1014, 50), (1014, 80), (2322, 42)],
+        "only in-head rest-grammar codes should be dropped, got: {survivors:?}"
+    );
+}
+
+/// With no recorded spans the pass is a no-op — a lone rest-grammar diagnostic
+/// (its list's own winner) is never dropped.
+#[test]
+fn suppress_parameter_grammar_losers_is_noop_without_spans() {
+    let mut diagnostics = vec![Diagnostic::error("main.ts", 18, 1, "m", 1014)];
+    suppress_parameter_grammar_losers(&mut diagnostics, &[]);
+    assert_eq!(diagnostics.len(), 1, "no spans means nothing is suppressed");
+}

--- a/crates/tsz-cli/src/lib.rs
+++ b/crates/tsz-cli/src/lib.rs
@@ -83,6 +83,9 @@ mod lib_interface_merge_flatarray_cli_tests;
 #[path = "../tests/lib_shadow_cli_tests.rs"]
 mod lib_shadow_cli_tests;
 #[cfg(test)]
+#[path = "../tests/parameter_list_grammar_one_per_list_tests.rs"]
+mod parameter_list_grammar_one_per_list_tests;
+#[cfg(test)]
 #[path = "../tests/prettify_empty_object_intersection_cli_tests.rs"]
 mod prettify_empty_object_intersection_cli_tests;
 #[cfg(test)]

--- a/crates/tsz-cli/tests/parameter_list_grammar_one_per_list_tests.rs
+++ b/crates/tsz-cli/tests/parameter_list_grammar_one_per_list_tests.rs
@@ -1,0 +1,179 @@
+//! tsc reports **at most one** parameter-list ordering-grammar diagnostic per
+//! parameter list: `checkGrammarParameterList` walks the list once and every
+//! arm is `return grammarErrorOnNode(...)`, so the first offending parameter
+//! wins and the walk stops (#16644).
+//!
+//! tsz split this family across layers — TS1015/TS1016 are checker-owned
+//! (`check_parameter_ordering`), while the rest-parameter grammar (TS1014
+//! rest-not-last, TS1047 rest-optional, TS1048 rest-initializer) is
+//! parser-emitted — so before the fix the declaration path both (a) kept
+//! reporting TS1016 for every required parameter after the optional run
+//! instead of only the first, and (b) let a later parser-emitted TS1014 ride
+//! along behind a checker TS1016 that tsc's early return had already made the
+//! sole winner.
+//!
+//! The checker's `check_parameter_ordering` now early-returns at the first
+//! violation and records the spans of any rest parameters that follow a
+//! checker-owned winner; the driver drops the parser's rest-grammar
+//! diagnostics anchored there (`suppress_parameter_grammar_losers`).
+//!
+//! Expectations are oracle-pinned against `typescript@7.0.2`
+//! (`--noEmit --strict --pretty false --target es2022 --lib es2022`).
+
+use crate::args::CliArgs;
+use clap::Parser;
+use tsz_checker::diagnostics::Diagnostic;
+
+/// Compile a single-file `source` with `--strict` and return its diagnostics.
+fn compile_source(source: &str) -> Vec<Diagnostic> {
+    let dir = tempfile::tempdir().expect("temp dir");
+    std::fs::write(dir.path().join("main.ts"), source).expect("write repro file");
+
+    let argv = vec![
+        "tsz",
+        "--ignoreConfig",
+        "--noEmit",
+        "--strict",
+        "--target",
+        "es2022",
+        "--lib",
+        "es2022",
+        "main.ts",
+    ];
+    let args = CliArgs::try_parse_from(argv).expect("parse args");
+    crate::driver::compile(&args, dir.path())
+        .expect("compile should succeed")
+        .diagnostics
+}
+
+fn count_code(diagnostics: &[Diagnostic], code: u32) -> usize {
+    diagnostics.iter().filter(|d| d.code == code).count()
+}
+
+/// d1 witness: three parameters, one optional followed by two required. tsc
+/// reports a single TS1016 on the first required parameter, not one per
+/// required parameter.
+#[test]
+fn required_after_optional_reports_single_ts1016() {
+    let diags = compile_source("function d1(a?: number, b: string, c: string) {}");
+    assert_eq!(
+        count_code(&diags, 1016),
+        1,
+        "expected exactly one TS1016 for `(a?, b, c)`, got: {diags:?}"
+    );
+}
+
+/// d4 witness: a checker-owned TS1016 wins over a later parser-emitted TS1014
+/// (rest-not-last). tsc returns at the TS1016 and never reaches the rest
+/// parameter, so the TS1014 must not surface.
+#[test]
+fn ts1016_winner_suppresses_later_rest_not_last_ts1014() {
+    let diags = compile_source("function d4(a?: number, b: string, ...c: any[], d: any) {}");
+    assert_eq!(
+        count_code(&diags, 1016),
+        1,
+        "expected exactly one TS1016 for `(a?, b, ...c, d)`, got: {diags:?}"
+    );
+    assert_eq!(
+        count_code(&diags, 1014),
+        0,
+        "TS1014 must be suppressed behind the earlier TS1016, got: {diags:?}"
+    );
+}
+
+/// The one-per-list rule holds across every signature form, not just function
+/// declarations.
+#[test]
+fn required_after_optional_single_ts1016_across_signature_forms() {
+    let cases = [
+        (
+            "function expression",
+            "const f = function (a?: number, b: string, c: string) {};",
+        ),
+        (
+            "arrow function",
+            "const f = (a?: number, b: string, c: string) => {};",
+        ),
+        (
+            "method",
+            "class K { m(a?: number, b: string, c: string) {} }",
+        ),
+        (
+            "constructor",
+            "class K { constructor(a?: number, b: string, c: string) {} }",
+        ),
+        (
+            "object-literal method",
+            "const o = { m(a?: number, b: string, c: string) {} };",
+        ),
+        (
+            "interface method signature",
+            "interface I { m(a?: number, b: string, c: string): void; }",
+        ),
+        (
+            "interface call signature",
+            "interface I { (a?: number, b: string, c: string): void; }",
+        ),
+        (
+            "interface construct signature",
+            "interface I { new (a?: number, b: string, c: string): void; }",
+        ),
+    ];
+    for (label, source) in cases {
+        let diags = compile_source(source);
+        assert_eq!(
+            count_code(&diags, 1016),
+            1,
+            "expected exactly one TS1016 for {label} `{source}`, got: {diags:?}"
+        );
+    }
+}
+
+/// Negative control: rest-not-last with no earlier ordering violation must
+/// still report TS1014 — nothing preceded it, so it is the list's own winner.
+#[test]
+fn lone_rest_not_last_still_reports_ts1014() {
+    let diags = compile_source("function f(...a: any[], b: number) {}");
+    assert_eq!(
+        count_code(&diags, 1014),
+        1,
+        "a lone rest-not-last must still report TS1014, got: {diags:?}"
+    );
+}
+
+/// Negative control: the suppression must be scoped to the parameter that
+/// actually follows the winner. A nested function inside a *default value* of
+/// a parameter that comes *before* the outer winner runs its own
+/// `checkGrammarParameterList`, so its rest-not-last TS1014 must survive
+/// alongside the outer TS1016.
+#[test]
+fn nested_function_rest_grammar_survives_outer_ts1016() {
+    let diags = compile_source(
+        "function outer(a?: number, b: () => void = function (...x: any[], y: number) {}, c: number) {}",
+    );
+    assert_eq!(
+        count_code(&diags, 1016),
+        1,
+        "outer list should report exactly one TS1016, got: {diags:?}"
+    );
+    assert_eq!(
+        count_code(&diags, 1014),
+        1,
+        "the nested function's rest-not-last TS1014 must survive, got: {diags:?}"
+    );
+}
+
+/// Negative control: a required-after-optional violation is unrelated to a
+/// separate valid signature — each list is judged independently, so a clean
+/// sibling list stays clean.
+#[test]
+fn clean_sibling_list_stays_clean() {
+    let diags = compile_source(
+        "function bad(a?: number, b: string) {}\nfunction good(a: number, b?: string) {}",
+    );
+    assert_eq!(
+        count_code(&diags, 1016),
+        1,
+        "only the `bad` list should report TS1016, got: {diags:?}"
+    );
+}

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -1213,7 +1213,11 @@ STRUCT_FIELD_COUNT_CHECKS = [
         "Checker boundary: CheckerContext field count (architecture health metric 1)",
         ROOT / "crates" / "tsz-checker" / "src" / "context" / "mod.rs",
         "CheckerContext",
-        255,
+        # 255 -> 256: `parameter_grammar_suppress_spans` records the rest
+        # parameters whose parser-emitted grammar diagnostics tsc's single
+        # early-return `checkGrammarParameterList` never reached, so the driver
+        # can drop them (#16644).
+        256,
     ),
 ]
 


### PR DESCRIPTION
Fixes #16644.

When a parameter list has an ordering-grammar violation, tsc reports **at most one** diagnostic for the whole list: `checkGrammarParameterList` walks the parameters once and every arm is `return grammarErrorOnNode(...)`, so the first offending parameter wins and the walk stops. tsz splits that single family across two layers — TS1015/TS1016 are checker-owned (`check_parameter_ordering`) while the rest-parameter grammar (TS1014 rest-not-last, TS1047 rest-optional, TS1048 rest-initializer) is parser-emitted — so the declaration path had no early return and no cross-layer coordination:

| input | tsc 7.0.2 | tsz (before) |
| --- | --- | --- |
| `function d1(a?: number, b: string, c: string) {}` | `(1,25) TS1016` | `(1,25)` **and** `(1,36)` TS1016 |
| `function d4(a?: number, b: string, ...c: any[], d: any) {}` | `(1,25) TS1016` | `(1,25) TS1016` **and** `(1,36) TS1014` |

**Structural rule:** when a parameter list contains an ordering-grammar violation, tsc reports exactly one diagnostic, at the first offending parameter, and returns. tsz now does the same through `check_parameter_ordering` (checker) plus a per-file driver reconciliation for the parser-owned codes.

- `check_parameter_ordering` mirrors tsc's single-early-return walk: it stops at the first TS1015/TS1016, and treats a rest parameter as a hard stop (reaching one means no checker-owned error fired earlier, so the parser's own diagnostic is the list's sole winner).
- When a checker-owned error wins, the checker records the head span `[pos, boundary)` of every following rest parameter into `CheckerContext::parameter_grammar_suppress_spans`, where `boundary` is the start of that parameter's type annotation or default value. The driver's per-file merge drops the parser rest-grammar diagnostics anchored there (`suppress_parameter_grammar_losers`). Truncating before the annotation/default subtrees keeps a nested function's own parameter-list grammar untouched.

Adjacent matrix covered (each reports exactly one TS1016): function declaration/expression, arrow, method, constructor, object-literal method, and interface method/call/construct signatures. Negative controls pinned: a lone rest-not-last still reports TS1014; a nested function's rest-not-last survives an outer TS1016; a clean sibling signature stays clean. Signatures in **type** position (`FunctionType`/`ConstructorType`) are a separate pre-existing gap tracked by #16643 and are untouched here.

## Goal
Goal: hold

## Verification
- New end-to-end tests `crates/tsz-cli/tests/parameter_list_grammar_one_per_list_tests.rs` (6 cases: d1, d4, 8-form matrix, 3 negative controls) — pass.
- New unit tests for `suppress_parameter_grammar_losers` in `crates/tsz-cli/src/driver/check_utils/rest_parameter_grammar_tests.rs` — pass.
- Witnesses `d1`/`d4` and an 8-form adjacent matrix diffed against the pinned `typescript@7.0.2` oracle (`--noEmit --strict --pretty false --target es2022 --lib es2022`) — grammar codes match exactly.
- `cargo test -p tsz-checker --lib parameter` (492 tests) and CLI grammar suites — pass.
- Conformance snapshot (`conformance.sh snapshot --workers 12 --force`): **0 regressions**, 3 tests flip to passing (incl. `compiler/optionalArgsWithDefaultValues.ts`).
- Pre-commit hook: clippy, architecture guard (`CheckerContext` field cap 255 → 256, documented at the guard site), local verification — pass.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_019i1WB5twz881rxSqKJUkk7)_