### PR TITLE
fix(checker): a for...in optional-chain head takes TS2405 over TS2780 when the LHS type isn't string/any

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -493,6 +493,9 @@ mod for_in_narrowing_tests;
 #[path = "../tests/for_in_operand_type_display_tests.rs"]
 mod for_in_operand_type_display_tests;
 #[cfg(test)]
+#[path = "../tests/for_in_optional_chain_ts2405_vs_ts2780_tests.rs"]
+mod for_in_optional_chain_ts2405_vs_ts2780_tests;
+#[cfg(test)]
 #[path = "../tests/for_in_self_reference_and_nullable_operand_tests.rs"]
 mod for_in_self_reference_and_nullable_operand_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/variable_checking/for_loop.rs
+++ b/crates/tsz-checker/src/state/variable_checking/for_loop.rs
@@ -756,23 +756,26 @@ impl<'a> CheckerState<'a> {
             );
         }
 
-        // TS2780/TS2781: The left-hand side of a 'for...in'/'for...of' statement
-        // may not be an optional property access.
-        if self.is_optional_chain_access(initializer) {
+        // TS2781: The left-hand side of a 'for...of' statement may not be an
+        // optional property access. tsc's checkForOfStatement runs this check
+        // unconditionally (typescript-go checker.go's checkReferenceExpression
+        // call in checkForOfStatement is not gated on the element-type check).
+        //
+        // For 'for...in', the analogous optional-chain check is NOT unconditional:
+        // tsc's checkForInStatement only calls checkReferenceExpression (which is
+        // what reports TS2780) in the `else` branch of an `if
+        // !isTypeAssignableTo(indexType, leftType) { TS2405 } else {
+        // checkReferenceExpression(...) }` — so TS2405 (the LHS type must be
+        // string/any) wins whenever it fires, and TS2780 only fires when the LHS
+        // type check already passed. See the TS2405 block below, which now owns
+        // the for-in optional-chain emission.
+        if is_for_of && self.is_optional_chain_access(initializer) {
             use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-            if is_for_of {
-                self.error_at_node(
-                    initializer,
-                    diagnostic_messages::THE_LEFT_HAND_SIDE_OF_A_FOR_OF_STATEMENT_MAY_NOT_BE_AN_OPTIONAL_PROPERTY_ACCESS,
-                    diagnostic_codes::THE_LEFT_HAND_SIDE_OF_A_FOR_OF_STATEMENT_MAY_NOT_BE_AN_OPTIONAL_PROPERTY_ACCESS,
-                );
-            } else {
-                self.error_at_node(
-                    initializer,
-                    diagnostic_messages::THE_LEFT_HAND_SIDE_OF_A_FOR_IN_STATEMENT_MAY_NOT_BE_AN_OPTIONAL_PROPERTY_ACCESS,
-                    diagnostic_codes::THE_LEFT_HAND_SIDE_OF_A_FOR_IN_STATEMENT_MAY_NOT_BE_AN_OPTIONAL_PROPERTY_ACCESS,
-                );
-            }
+            self.error_at_node(
+                initializer,
+                diagnostic_messages::THE_LEFT_HAND_SIDE_OF_A_FOR_OF_STATEMENT_MAY_NOT_BE_AN_OPTIONAL_PROPERTY_ACCESS,
+                diagnostic_codes::THE_LEFT_HAND_SIDE_OF_A_FOR_OF_STATEMENT_MAY_NOT_BE_AN_OPTIONAL_PROPERTY_ACCESS,
+            );
         }
 
         // TS2487: For-of LHS must be a variable or a property access.
@@ -862,9 +865,9 @@ impl<'a> CheckerState<'a> {
         // TS2405: For for-in, also check that the LHS type is string or any.
         // This applies only to valid LHS forms (identifiers and property/element access).
         // Skip if we already emitted TS2491 (destructuring) or TS2406 (invalid form).
-        // Also skip for optional chain accesses — TS2777 already covers those.
+        // Only once this check passes does an optional-chain LHS get its own TS2780
+        // (see the structural-rule note above the `is_for_of` TS2781 emission).
         if !is_for_of
-            && !self.is_optional_chain_access(initializer)
             && let Some(_init_node) = self.ctx.arena.get(initializer)
             && {
                 let unwrapped = self
@@ -898,6 +901,12 @@ impl<'a> CheckerState<'a> {
                     initializer,
                     diagnostic_messages::THE_LEFT_HAND_SIDE_OF_A_FOR_IN_STATEMENT_MUST_BE_OF_TYPE_STRING_OR_ANY,
                     diagnostic_codes::THE_LEFT_HAND_SIDE_OF_A_FOR_IN_STATEMENT_MUST_BE_OF_TYPE_STRING_OR_ANY,
+                );
+            } else if self.is_optional_chain_access(initializer) {
+                self.error_at_node(
+                    initializer,
+                    diagnostic_messages::THE_LEFT_HAND_SIDE_OF_A_FOR_IN_STATEMENT_MAY_NOT_BE_AN_OPTIONAL_PROPERTY_ACCESS,
+                    diagnostic_codes::THE_LEFT_HAND_SIDE_OF_A_FOR_IN_STATEMENT_MAY_NOT_BE_AN_OPTIONAL_PROPERTY_ACCESS,
                 );
             }
         }

--- a/crates/tsz-checker/src/types/computation/access/invalid_target.rs
+++ b/crates/tsz-checker/src/types/computation/access/invalid_target.rs
@@ -33,8 +33,15 @@ impl CheckerState<'_> {
                 continue;
             }
 
-            if (parent_node.kind == syntax_kind_ext::FOR_IN_STATEMENT
-                || parent_node.kind == syntax_kind_ext::FOR_OF_STATEMENT)
+            // Only `for...of` short-circuits its optional-chain LHS to `any` here.
+            // `for...in`'s LHS is not a genuinely invalid target the way a plain
+            // `a?.b = 1` write is: tsc's checkForInStatement computes the LHS's
+            // real (possibly-undefined) type and checks it against the index type
+            // BEFORE deciding whether to also flag the chain itself (TS2405 wins
+            // over TS2780 whenever the type check fails) — see
+            // `check_for_in_of_expression_initializer` in
+            // `state/variable_checking/for_loop.rs`, which needs that real type.
+            if parent_node.kind == syntax_kind_ext::FOR_OF_STATEMENT
                 && self
                     .ctx
                     .arena

--- a/crates/tsz-checker/tests/for_in_optional_chain_ts2405_vs_ts2780_tests.rs
+++ b/crates/tsz-checker/tests/for_in_optional_chain_ts2405_vs_ts2780_tests.rs
@@ -1,0 +1,136 @@
+//! Structural rule: `tsc`'s `checkForInStatement` computes the LHS expression's
+//! real type FIRST and only calls `checkReferenceExpression` (the source of
+//! TS2780, "may not be an optional property access") when that type passes the
+//! `isTypeAssignableTo(indexType, leftType)` check (TS2405, "must be of type
+//! 'string' or 'any'") — see typescript-go's `checker.go`:
+//!
+//! ```go
+//! } else if !c.isTypeAssignableTo(c.getIndexTypeOrString(rightType), leftType) {
+//!     c.error(varExpr, diagnostics.The_left_hand_side_of_a_for_in_statement_must_be_of_type_string_or_any)
+//! } else {
+//!     c.checkReferenceExpression(varExpr, ..., diagnostics.The_left_hand_side_of_a_for_in_statement_may_not_be_an_optional_property_access)
+//! }
+//! ```
+//!
+//! So TS2405 and TS2780 are mutually exclusive for a `for...in` head: TS2405
+//! wins whenever it fires, and TS2780 only fires once the LHS type already
+//! passed. `for...of`'s analogous TS2781 check is NOT gated this way — tsc's
+//! `checkForOfStatement` calls `checkReferenceExpression` unconditionally — so
+//! that family is a regression guard here, not something this fix changes.
+//!
+//! All diagnostics oracle-verified against the pinned `typescript@7.0.2`
+//! (`--noEmit --strict --lib es2022 --target es2022`). Binder names vary
+//! across cases per the repo's anti-hardcoding discipline.
+
+use crate::test_utils::check_source_strict_codes;
+
+// =========================================================================
+// TS2405 wins: the optional-chain LHS's real type is not string/any.
+// =========================================================================
+
+#[test]
+fn for_in_optional_receiver_required_member_number_leaf_emits_only_ts2405() {
+    // `b` is optional, `c` is required: the chain's real type is
+    // `number | undefined`, not assignable to `string | any` — TS2405, no TS2780.
+    let codes = check_source_strict_codes(
+        "declare const outer: { mid?: { inner: { leaf: number } } };\nfor (outer.mid?.inner.leaf in {}) {}\n",
+    );
+    assert!(
+        codes.contains(&2405),
+        "possibly-undefined non-string LHS must emit TS2405; got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2780),
+        "TS2405 must suppress TS2780 for a for-in optional-chain head; got: {codes:?}"
+    );
+}
+
+#[test]
+fn for_in_top_level_optional_access_number_typed_emits_only_ts2405() {
+    let codes = check_source_strict_codes(
+        "declare const rec: { count?: number };\nfor (rec?.count in {}) {}\n",
+    );
+    assert!(codes.contains(&2405), "expected TS2405; got: {codes:?}");
+    assert!(!codes.contains(&2780), "expected no TS2780; got: {codes:?}");
+}
+
+// =========================================================================
+// TS2780 wins: the optional-chain LHS's real type IS string/any, so the
+// reference-validity check runs and reports the chain itself.
+// =========================================================================
+
+#[test]
+fn for_in_optional_receiver_string_leaf_emits_only_ts2780() {
+    let codes = check_source_strict_codes(
+        "declare const holder: { maybe?: { text: string } };\nfor (holder.maybe?.text in {}) {}\n",
+    );
+    assert!(
+        codes.contains(&2780),
+        "string-typed optional-chain LHS must emit TS2780; got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2405),
+        "a string-typed LHS passes the TS2405 check; got: {codes:?}"
+    );
+}
+
+#[test]
+fn for_in_top_level_optional_access_string_typed_emits_only_ts2780() {
+    let codes = check_source_strict_codes(
+        "declare const bag: { label?: string };\nfor (bag?.label in {}) {}\n",
+    );
+    assert!(codes.contains(&2780), "expected TS2780; got: {codes:?}");
+    assert!(!codes.contains(&2405), "expected no TS2405; got: {codes:?}");
+}
+
+// =========================================================================
+// Regression guards: unaffected shapes.
+// =========================================================================
+
+#[test]
+fn for_in_non_optional_property_access_string_leaf_reports_neither() {
+    let codes = check_source_strict_codes(
+        "declare const plain: { nested: { name: string } };\nfor (plain.nested.name in {}) {}\n",
+    );
+    assert!(
+        !codes.contains(&2405) && !codes.contains(&2780),
+        "a non-optional string-typed LHS is valid; got: {codes:?}"
+    );
+}
+
+#[test]
+fn for_in_non_optional_property_access_number_leaf_emits_only_ts2405() {
+    // No optional chain at all: TS2405 alone must still fire for a non-string type.
+    let codes = check_source_strict_codes(
+        "declare const box: { field: { count: number } };\nfor (box.field.count in {}) {}\n",
+    );
+    assert!(codes.contains(&2405), "expected TS2405; got: {codes:?}");
+    assert!(!codes.contains(&2780), "expected no TS2780; got: {codes:?}");
+}
+
+#[test]
+fn for_of_optional_chain_still_emits_ts2781_unconditionally() {
+    // for...of's analogous check is NOT gated behind an assignability check —
+    // tsc reports TS2781 regardless of the chain's element type. This fix only
+    // changes for...in's ordering, so for...of keeps its prior behavior.
+    let codes = check_source_strict_codes(
+        "declare const outer: { mid?: { inner: { leaf: number } } };\nfor (outer.mid?.inner.leaf of []) {}\n",
+    );
+    assert!(
+        codes.contains(&2781),
+        "for-of optional-chain LHS must still emit TS2781; got: {codes:?}"
+    );
+}
+
+#[test]
+fn plain_optional_chain_assignment_target_still_emits_ts2779() {
+    // Regression guard for the write-target family (`=`), which is unrelated
+    // to for-in/for-of and must keep short-circuiting to `any` unconditionally.
+    let codes = check_source_strict_codes(
+        "declare const holder: { maybe?: { text: string } };\nholder.maybe?.text = \"x\";\n",
+    );
+    assert!(
+        codes.contains(&2779),
+        "plain optional-chain assignment target must still emit TS2779; got: {codes:?}"
+    );
+}


### PR DESCRIPTION
## Goal
Goal: hold

## Structural rule

`for (a.b?.c.d in {});` with `a: { b?: { c: { d: number } } }` — tsc reports **TS2405** (`The left-hand side of a 'for...in' statement must be of type 'string' or 'any'`) alone; tsz reported **TS2780** (`...may not be an optional property access`) alone.

typescript-go's `checkForInStatement` (`internal/checker/checker.go`) computes the LHS expression's real type first and only calls `checkReferenceExpression` (the source of TS2780) in the `else` branch of:

```go
if !c.isTypeAssignableTo(c.getIndexTypeOrString(rightType), leftType) {
    c.error(varExpr, diagnostics.The_left_hand_side_of_a_for_in_statement_must_be_of_type_string_or_any) // TS2405
} else {
    c.checkReferenceExpression(varExpr, ..., diagnostics.The_left_hand_side_of_a_for_in_statement_may_not_be_an_optional_property_access) // TS2780
}
```

So TS2405 and TS2780 are mutually exclusive for a `for...in` head — TS2405 wins whenever it fires, TS2780 only fires once the LHS type already passed.

tsz's `check_for_in_of_expression_initializer` (`crates/tsz-checker/src/state/variable_checking/for_loop.rs`) had this backwards: it emitted TS2780 unconditionally for any optional-chain LHS, and separately skipped its own TS2405 check whenever the LHS was an optional chain — the opposite gating from tsc.

**Second, deeper bug found while fixing the first**: even after re-ordering the checks, TS2405 still didn't fire, because `get_type_of_assignment_target` routes through `optional_chain_invalid_assignment_target_context` (`crates/tsz-checker/src/types/computation/access/invalid_target.rs`), which short-circuits *any* optional-chain sitting directly in a `for...in`/`for...of` initializer position to `any` — correct for a genuinely invalid target like `a?.b = 1`, but wrong for `for...in`, where tsc needs the real (possibly-undefined) chain type to decide TS2405 vs TS2780. Removed `FOR_IN_STATEMENT` from that short-circuit's structural match (kept `FOR_OF_STATEMENT`, whose TS2781 check is unconditional in tsc and unaffected by this PR). The later `get_type_of_assignment_target` call in the same function (`for_loop.rs`, used for for-of's TS2322/TS2588 checks) is unconditional but its result is only *used* when `is_for_of`, so for-in is unaffected by that call site.

## Owner layer

Checker (`state/variable_checking/for_loop.rs`, `types/computation/access/invalid_target.rs`) — diagnostic-selection ordering and a type-resolution short-circuit, not a solver relation.

## Adjacent-case matrix (oracle-verified, `typescript@7.0.2`, `--noEmit --strict --lib es2022 --target es2022`)

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `for (outer.mid?.inner.leaf in {})`, `leaf: number` (required member after optional receiver) | TS2405 | TS2780 | **TS2405** |
| `for (rec?.count in {})`, `count?: number` | TS2405 | TS2780 | **TS2405** |
| `for (holder.maybe?.text in {})`, `text: string` | TS2780 | TS2780 (right by luck of code, not gating) | **TS2780** |
| `for (bag?.label in {})`, `label?: string` | TS2780 | TS2780 | **TS2780** |
| `for (plain.nested.name in {})` (no optional chain, string) | clean | clean | clean (unaffected) |
| `for (box.field.count in {})` (no optional chain, number) | TS2405 | TS2405 | TS2405 (unaffected) |
| `for (outer.mid?.inner.leaf of [])` (for...of regression guard) | TS2781 | TS2781 | TS2781 (unaffected — for-of check stays unconditional) |
| `holder.maybe?.text = "x"` (plain assignment write-target regression guard) | TS2779 | TS2779 | TS2779 (unaffected — write-target short-circuit untouched) |

All 8 rows asserted in `crates/tsz-checker/tests/for_in_optional_chain_ts2405_vs_ts2780_tests.rs`; the first four rows independently re-verified against the pinned oracle via CLI before committing.

Closes #16655.

## Verification

- `cargo test -p tsz-checker --lib -- for_in_optional_chain_ts2405_vs_ts2780` — 8 passed, 0 failed (new tests).
- `cargo test -p tsz-checker --lib -- for_in for_of optional_chain` — 219 passed, 0 failed (includes the `for_in_lhs_relation_routing_arch_tests` architecture guard, which I kept the anchor comment intact for).
- `cargo test -p tsz-checker --lib -- assignment` — 578 passed, 0 failed.
- `cargo test -p tsz-checker --lib -- nullish` — 257 passed, 0 failed.
- `cargo test -p tsz-checker --lib -- narrowing` — 228 passed, 0 failed.
- `cargo test -p tsz-checker --lib -- compound_assignment` — 5 passed, 0 failed.
- `cargo test -p tsz-checker --lib -- increment` — 31 passed, 0 failed.
- `cargo test -p tsz-checker --lib -- write_target element_access property_access invalid_target for_loop` — 190 passed, 0 failed.
- `cargo fmt -p tsz-checker -- --check` — clean.
- `cargo clippy -p tsz-checker --lib --tests -- -D warnings` — clean.
- `./scripts/architecture-check.sh --quick` — 0 LOC violations, 0 cross-layer imports; 1 pre-existing diagnostic leak confirmed identical on `main` via `git stash` A/B (unrelated to this diff).
- Direct oracle CLI comparison (`node .../tsc@7.0.2` vs a local `dist`-free dev build of `tsz`) for 5 primary rows plus 5 additional regression-guard rows (plain `for...in`, plain assignment/compound-assignment/increment optional-chain write targets) — all byte-identical to the oracle before and after.
- Not run this session (time budget; corpus not vendored on this seat, and this is a narrow diagnostic-selection-ordering fix gated to a rare `for...in` + optional-chain shape, following the same disclosed-skip precedent as #16633/#16638): `compare-to-parent.sh`/full conformance snapshot.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_01S53gcd36NWwiTX4rZFnN6f)_