### PR TITLE
fix(checker): a literal-spelled computed key is an ordinary property name, not a TS2418 site

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
@@ -833,12 +833,18 @@ impl<'a> CheckerState<'a> {
                 }
 
                 // TS2418 applies when:
-                //   (a) the key is computed, AND
-                //   (b) either the key is a symbol (unique/well-known, never TS2322)
-                //       or the key is a numeric/string literal but the target has
-                //       no named property for it (matches only via index signature).
-                // When a literal key like `[0]` or `["x"]` resolves to a named
-                // property in the target, tsc uses TS2322 instead.
+                //   (a) the key is computed AND late-bound — an identifier over
+                //       a `const`, an enum member, or a symbol reference — since
+                //       tsc's `isComputedNonLiteralName` is false for a
+                //       literal-spelled computed name (`["x"]`, `[0]`,
+                //       `` [`x`] ``), which is an ordinary property name and
+                //       takes TS2322/TS2353 no matter how the target matches it,
+                //       AND
+                //   (b) the late-bound key has no named property in the target
+                //       (it matches only via an index signature), since a
+                //       late-bound key resolving to a named member takes TS2322.
+                let key_is_late_bound = is_computed_property
+                    && !self.computed_member_name_is_literal_spelled(prop_name_idx);
                 let target_has_named_member_for_key = is_computed_property
                     && self.target_has_named_property_for_key(effective_param_type, &prop_name);
                 // A *missing-property* failure keeps its own code even when the
@@ -862,7 +868,7 @@ impl<'a> CheckerState<'a> {
                                 | RelationFailure::MissingProperties { .. }
                         )
                     );
-                if is_computed_property
+                if key_is_late_bound
                     && !(is_computed_literal_key && target_has_named_member_for_key)
                     && !computed_failure_is_missing_property
                 {

--- a/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
+++ b/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
@@ -203,12 +203,22 @@ impl<'a> CheckerState<'a> {
                             .then_some((prop.name, prop.initializer))
                     })
                 });
+            // A computed name spelled with a literal (`["p"]`, `[0]`,
+            // `` [`p`] ``) is not a late-bound name: tsc's
+            // `isComputedNonLiteralName` is false for it, so it never reaches
+            // the computed-property message and is judged as the ordinary
+            // property it is. Only a late-bound spelling (`[label]` for a
+            // `const`, `[E.A]`, `[sym]`, `[Symbol.iterator]`) takes TS2418
+            // when it matches the target through an index signature. Falling
+            // through hands a literal-spelled name to the elaboration below,
+            // which anchors at the value and reports TS2322/TS2353.
             if let Some((prop_name_idx, prop_value_idx)) = computed_property
                 && self
                     .ctx
                     .arena
                     .get(prop_name_idx)
                     .is_some_and(|node| node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME)
+                && !self.computed_member_name_is_literal_spelled(prop_name_idx)
             {
                 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
 

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -573,6 +573,8 @@ mod lazy_lib_member_access_tests;
 mod lib_abstract_member_ts2515_tests;
 #[path = "tests/libtype_structural_name_lookup_arch_tests.rs"]
 mod libtype_structural_name_lookup_arch_tests;
+#[path = "tests/literal_spelled_computed_key_index_signature_code_tests.rs"]
+mod literal_spelled_computed_key_index_signature_code_tests;
 #[path = "tests/local_type_alias_shadowing_tests.rs"]
 mod local_type_alias_shadowing_tests;
 #[path = "tests/logical_assignment_member_narrowing_tests.rs"]

--- a/crates/tsz-checker/src/tests/literal_spelled_computed_key_index_signature_code_tests.rs
+++ b/crates/tsz-checker/src/tests/literal_spelled_computed_key_index_signature_code_tests.rs
@@ -1,0 +1,253 @@
+//! A computed key spelled with a *literal* is an ordinary property name, so it
+//! never takes the computed-property diagnostic TS2418 — not even when the
+//! target matches it only through an index signature.
+//!
+//! Structural rule, oracled against `typescript@7.0.2`: tsc's
+//! `isComputedNonLiteralName` is **false** for a computed name written as a
+//! string, numeric, or no-substitution-template literal (`["p"]`, `[0]`,
+//! `` [`p`] ``). Such a name is not late-bound at all, so a value mismatch
+//! under it reports `TS2322` anchored at the value and an excess property
+//! reports `TS2353`, exactly as the plainly written `{ p: ... }` does. Only a
+//! *late-bound* spelling — an identifier over a `const`, an enum member, or a
+//! symbol reference — reaches
+//! `Type of computed property's value is '{0}', which is not assignable to
+//! type '{1}'` (TS2418).
+//!
+//! tsz applied TS2418 to every computed key that matched the target through an
+//! index signature, regardless of spelling. The existing literal-key exemption
+//! was conditioned on the target having a *named* member for the key, so it
+//! covered `{ member: number } = { ["member"]: "text" }` and missed every
+//! index-signature target. Both the contextual index-signature reporter and
+//! the call-argument elaborator carried the same gap, which is why the rows
+//! below are paired across an initializer and a call argument.
+//!
+//! The negative controls are the load-bearing half: each literal spelling is
+//! paired with the late-bound spelling of the *same* target, so a later
+//! widening of this exemption cannot silently capture `[label]`, `[E.A]`,
+//! `[sym]`, or `[Symbol.iterator]`. Binder names are varied throughout so no
+//! identifier string is load-bearing.
+
+use crate::test_utils::check_source_strict_messages;
+
+fn codes(source: &str) -> Vec<u32> {
+    let mut codes: Vec<u32> = check_source_strict_messages(source)
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect();
+    codes.sort_unstable();
+    codes
+}
+
+fn message_for(source: &str, code: u32) -> Option<String> {
+    check_source_strict_messages(source)
+        .into_iter()
+        .find(|(c, _)| *c == code)
+        .map(|(_, message)| message)
+}
+
+// ---------------------------------------------------------------------------
+// Literal-spelled computed keys against an index-signature target: TS2322.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_string_literal_computed_key_against_a_string_index_reports_ts2322() {
+    let source = r#"
+interface Registry { [entry: string]: string }
+const listing: Registry = { ["alpha"]: 1 };
+"#;
+    assert_eq!(codes(source), vec![2322]);
+    let message = message_for(source, 2322).expect("TS2322 for the value mismatch");
+    assert!(
+        message.contains("'number'") && message.contains("'string'"),
+        "the ordinary assignability message must name value and target, got: {message}"
+    );
+}
+
+#[test]
+fn a_numeric_literal_computed_key_against_a_number_index_reports_ts2322() {
+    let source = r#"
+interface Slots { [slot: number]: string }
+const filled: Slots = { [0]: 1 };
+"#;
+    assert_eq!(codes(source), vec![2322]);
+}
+
+#[test]
+fn a_no_substitution_template_computed_key_against_a_string_index_reports_ts2322() {
+    let source = r#"
+interface Catalog { [item: string]: string }
+const stocked: Catalog = { [`beta`]: 1 };
+"#;
+    assert_eq!(codes(source), vec![2322]);
+}
+
+#[test]
+fn a_string_literal_computed_key_against_a_symbol_and_string_index_reports_ts2322() {
+    // The target carries both index signatures; the string one owns a
+    // literal-spelled key, so the symbol half must not pull it into TS2418.
+    let source = r#"
+interface Mixed { [text: string]: string; [tag: symbol]: string }
+const blended: Mixed = { ["gamma"]: 1 };
+"#;
+    assert_eq!(codes(source), vec![2322]);
+}
+
+#[test]
+fn a_literal_spelled_key_in_a_call_argument_reports_ts2322() {
+    // The call-argument elaborator is a second owner of the same decision.
+    let source = r#"
+interface Ledger { [row: string]: string }
+declare function post(book: Ledger): void;
+post({ ["delta"]: 1 });
+"#;
+    assert_eq!(codes(source), vec![2322]);
+}
+
+#[test]
+fn a_numeric_literal_spelled_key_in_a_call_argument_reports_ts2322() {
+    let source = r#"
+interface Rows { [row: number]: string }
+declare function submit(sheet: Rows): void;
+submit({ [0]: 1 });
+"#;
+    assert_eq!(codes(source), vec![2322]);
+}
+
+#[test]
+fn a_literal_spelled_key_with_an_object_value_anchors_the_nested_mismatch() {
+    // Falling out of the computed branch hands the member to the ordinary
+    // elaborator, which descends into an elaboratable value and reports the
+    // leaf — `string` -> `number` at `depth`, not an aggregate at the key.
+    let source = r#"
+interface Shelf { [slot: string]: { depth: number } }
+const stacked: Shelf = { ["epsilon"]: { depth: "deep" } };
+"#;
+    assert_eq!(codes(source), vec![2322]);
+    let message = message_for(source, 2322).expect("TS2322 for the nested mismatch");
+    assert!(
+        message.contains("'string'") && message.contains("'number'"),
+        "the leaf mismatch must be reported, not the aggregate object type, got: {message}"
+    );
+    assert!(
+        !message.contains("depth:"),
+        "an aggregate object-type message means the nested elaboration did not run, got: {message}"
+    );
+}
+
+#[test]
+fn a_literal_spelled_key_with_an_excess_nested_property_reports_ts2353() {
+    let source = r#"
+interface Bay { [slot: string]: { width: number } }
+const parked: Bay = { ["zeta"]: { width: 1, height: 2 } };
+"#;
+    assert_eq!(codes(source), vec![2353]);
+}
+
+#[test]
+fn one_object_literal_can_mix_both_spellings_and_gets_both_codes() {
+    // The decision is per-member, not per-literal.
+    let source = r#"
+const marker = "eta";
+interface Book { [page: string]: string }
+const opened: Book = { ["theta"]: 1, [marker]: 2 };
+"#;
+    assert_eq!(codes(source), vec![2322, 2418]);
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls: every late-bound spelling keeps TS2418.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_late_bound_const_string_key_against_an_index_target_keeps_ts2418() {
+    let source = r#"
+const heading = "iota";
+interface Index { [term: string]: string }
+const built: Index = { [heading]: 1 };
+"#;
+    assert_eq!(codes(source), vec![2418]);
+}
+
+#[test]
+fn a_late_bound_const_number_key_against_an_index_target_keeps_ts2418() {
+    let source = r#"
+const position = 0;
+interface Grid { [cell: number]: string }
+const drawn: Grid = { [position]: 1 };
+"#;
+    assert_eq!(codes(source), vec![2418]);
+}
+
+#[test]
+fn an_enum_member_key_against_an_index_target_keeps_ts2418() {
+    let source = r#"
+enum Channel { Primary = "primary" }
+interface Feed { [name: string]: string }
+const wired: Feed = { [Channel.Primary]: 1 };
+"#;
+    assert_eq!(codes(source), vec![2418]);
+}
+
+#[test]
+fn a_unique_symbol_key_against_a_symbol_index_target_keeps_ts2418() {
+    let source = r#"
+declare const token: unique symbol;
+interface Vault { [held: symbol]: string }
+const sealed: Vault = { [token]: 1 };
+"#;
+    assert_eq!(codes(source), vec![2418]);
+}
+
+// A well-known symbol key (`[Symbol.iterator]`) is the fourth late-bound
+// spelling and is *not* pinned here: this harness compiles without the es2015
+// lib, so `Symbol` does not resolve and the row would assert TS2583 rather than
+// the code under test. It is covered by the enum-member row above, which
+// exercises the same property-access spelling through the same predicate, and
+// was verified directly against the pinned `typescript@7.0.2` — both report
+// TS2418 for `{ [held: symbol]: string } = { [Symbol.iterator]: 1 }`.
+
+#[test]
+fn a_late_bound_key_in_a_call_argument_keeps_ts2418() {
+    let source = r#"
+const column = "kappa";
+interface Table { [field: string]: string }
+declare function insert(into: Table): void;
+insert({ [column]: 1 });
+"#;
+    assert_eq!(codes(source), vec![2418]);
+}
+
+// ---------------------------------------------------------------------------
+// Named-member targets are unchanged: this fix only widens the index-signature
+// half of the existing literal-key exemption.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_literal_spelled_key_against_a_named_member_still_reports_ts2322() {
+    let source = r#"
+type Record = { lambda: number };
+const kept: Record = { ["lambda"]: "text" };
+"#;
+    assert_eq!(codes(source), vec![2322]);
+}
+
+#[test]
+fn a_late_bound_key_against_a_named_member_still_reports_ts2418() {
+    let source = r#"
+const field = "mu";
+type Holder = { mu: number };
+const stored: Holder = { [field]: "text" };
+"#;
+    assert_eq!(codes(source), vec![2418]);
+}
+
+#[test]
+fn a_matching_literal_spelled_key_against_an_index_target_is_clean() {
+    // The non-error direction: the exemption must not manufacture a
+    // diagnostic where the value is assignable.
+    let source = r#"
+interface Store { [key: string]: string }
+const saved: Store = { ["nu"]: "ok", [`xi`]: "ok", [0]: "ok" };
+"#;
+    assert_eq!(codes(source), Vec::<u32>::new());
+}

--- a/crates/tsz-checker/src/types/queries/core_names.rs
+++ b/crates/tsz-checker/src/types/queries/core_names.rs
@@ -54,6 +54,28 @@ impl<'a> CheckerState<'a> {
             || kind == SyntaxKind::NoSubstitutionTemplateLiteral as u16
     }
 
+    /// Whether `name_idx` is a *computed* name spelled with a literal —
+    /// `["p"]`, `[0]`, `` [`p`] `` — as opposed to a late-bound one (`[label]`
+    /// for a `const`, `[E.A]`, `[sym]`, `[Symbol.iterator]`).
+    ///
+    /// This is tsc's `isComputedNonLiteralName` negated, and it is what
+    /// selects between the computed-property diagnostic `TS2418` and ordinary
+    /// property assignability: a literal-spelled computed name is not a
+    /// late-bound name at all, so a value mismatch under it reports `TS2322`
+    /// and an excess property reports `TS2353` — whether the target matches
+    /// the name by a declared member or only by an index signature. Distinct
+    /// from `is_eagerly_bound_member_name`, which answers `true` for every
+    /// non-computed name; callers here have already established that the
+    /// member carries a computed name and need the two computed spellings
+    /// told apart.
+    pub(crate) fn computed_member_name_is_literal_spelled(&self, name_idx: NodeIndex) -> bool {
+        self.ctx
+            .arena
+            .get(name_idx)
+            .is_some_and(|node| node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME)
+            && self.is_eagerly_bound_member_name(name_idx)
+    }
+
     /// Check if a computed property name resolves to a string literal type
     /// (e.g. `[hundredStr]` where `const hundredStr = "100"`).
     pub(crate) fn is_computed_string_property_name(&mut self, name_idx: NodeIndex) -> bool {

--- a/crates/tsz-checker/tests/symbol_index_signature_tests.rs
+++ b/crates/tsz-checker/tests/symbol_index_signature_tests.rs
@@ -1293,23 +1293,58 @@ const o: { foo: string } = { ["foo"]: 42 };
     );
 }
 
-// Negative: a computed key against a real index signature must still use TS2418.
+// A *literal-spelled* computed key against a real index signature uses TS2322,
+// not TS2418 — the same code it uses when the key resolves to a named property
+// just above. This test previously asserted the opposite, drawing the boundary
+// at named-member-vs-index-signature; the real boundary is how the key is
+// *spelled*. `tsc` 7.0.2 on the exact fixture below:
+//
+//   $ tsc --noEmit --strict --pretty false --target es2020 exact.ts
+//   exact.ts(1,38): error TS2322: Type 'number' is not assignable to type 'string'.
+//
+// `isComputedNonLiteralName` is false for `[0]`, so the member is an ordinary
+// property and never reaches the computed-property message. The negative
+// control for the index-signature half is the late-bound row below.
 #[test]
-fn computed_key_against_real_number_index_signature_keeps_ts2418() {
+fn literal_spelled_computed_key_against_real_number_index_signature_uses_ts2322() {
     let codes = diagnostic_codes_for_ts(
         r#"
 const o: { [k: number]: string } = { [0]: 42 };
 "#,
     );
     assert!(
+        codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "expected TS2322 for a literal-spelled computed key against a number index signature, got {codes:?}",
+    );
+    assert!(
+        !codes.contains(
+            &diagnostic_codes::TYPE_OF_COMPUTED_PROPERTYS_VALUE_IS_WHICH_IS_NOT_ASSIGNABLE_TO_TYPE
+        ),
+        "did not expect TS2418 for a literal-spelled computed key, got {codes:?}",
+    );
+}
+
+// Negative: a *late-bound* computed key against a real index signature does
+// still use TS2418. Same target, same value, different spelling — this is the
+// row that stops the rule above from widening into "every computed key against
+// an index signature takes TS2322".
+#[test]
+fn late_bound_computed_key_against_real_number_index_signature_keeps_ts2418() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+const slot = 0;
+const o: { [k: number]: string } = { [slot]: 42 };
+"#,
+    );
+    assert!(
         codes.contains(
             &diagnostic_codes::TYPE_OF_COMPUTED_PROPERTYS_VALUE_IS_WHICH_IS_NOT_ASSIGNABLE_TO_TYPE
         ),
-        "expected TS2418 for computed key against a number index signature, got {codes:?}",
+        "expected TS2418 for a late-bound computed key against a number index signature, got {codes:?}",
     );
     assert!(
         !codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
-        "did not expect TS2322 for index-signature mismatch, got {codes:?}",
+        "did not expect TS2322 for a late-bound key, got {codes:?}",
     );
 }
 


### PR DESCRIPTION
**Structural rule.** When an object-literal member's name is a computed name spelled with a string, numeric, or no-substitution-template literal — `["p"]`, `[0]`, `` [`p`] `` — tsc's `isComputedNonLiteralName` is **false**: the name is not late-bound at all, so a value mismatch reports **TS2322** anchored at the value and an excess property reports **TS2353**, exactly as the plainly written `{ p: ... }` does — whether the target matches the name by a *declared member* or only by an *index signature*. Only a late-bound spelling (an identifier over a `const`, an enum member, or a symbol reference) reaches `Type of computed property's value is '{0}', which is not assignable to type '{1}'` (TS2418). tsz does this through the **checker**, at the two sites that own the decision.

tsz reached TS2418 for every computed key that matched the target through an index signature, regardless of spelling. The existing literal-key exemption was conditioned on the target having a *named* member for the key, so it covered `{ member: number } = { ["member"]: "text" }` (pinned by `computed_key_missing_property_primary_code_tests`) and missed the entire index-signature half.

**Owner layer.** Two sites carried the same gap, which is why the matrix below is paired across an initializer and a call argument:

- `state/state_checking/property/union_index_signature_diagnostics.rs` — the contextual index-signature reporter. Its computed branch fired on *any* `COMPUTED_PROPERTY_NAME`.
- `error_reporter/call_errors/elaboration_object_properties.rs` — the call-argument elaborator. Its `is_computed_literal_key` exemption was `&&`-gated on `target_has_named_member_for_key`.

The predicate is new but the classification is not: `computed_member_name_is_literal_spelled` (`types/queries/core_names.rs`) composes the existing **purely syntactic** `is_eagerly_bound_member_name`, so it never evaluates the key expression's type and cannot be confused by a `const` whose type happens to resolve to a string literal. No identifier, alias, property, or file-name string drives the decision, and nothing reads rendered printer output.

A second fix falls out of the same change: a literal-spelled key now falls *through* to the ordinary elaboration path, which descends into an elaboratable value and anchors the leaf. `{ [k: string]: { b: number } } = { ["p"]: { b: "no" } }` moves from an aggregate TS2418 at the key to `string` → `number` at the nested `b`, matching tsc.

## Goal
Goal: hold

## Verification

Oracle is the pinned `typescript@7.0.2` (`npm i typescript@7.0.2`), run as `tsc --noEmit --strict --pretty false --target es2020` against the identical fixture. Every row below was measured on both sides, before and after.

**Adjacent-case matrix — rows FIXED (12 witnesses, tsc ↔ tsz now byte-identical):**

| # | shape | tsc | tsz before | tsz after |
|---|---|---|---|---|
| 1 | `{[k:string]:string} = { ["p"]: 1 }` | TS2322 @value | TS2418 | TS2322 ✅ |
| 2 | `{[k:number]:string} = { [0]: 1 }` | TS2322 @value | TS2418 | TS2322 ✅ |
| 3 | ``{[k:string]:string} = { [`p`]: 1 }`` | TS2322 @value | TS2418 | TS2322 ✅ |
| 4 | `{[k:string]:string; [k:symbol]:string} = { ["p"]: 1 }` | TS2322 @value | TS2418 | TS2322 ✅ |
| 5 | `{ ["p"]:"ok", ["q"]:1 }` (2nd member) | TS2322 @value | TS2418 | TS2322 ✅ |
| 6 | `{[k:string]:{b:number}} = { ["p"]: {b:"no"} }` | TS2322 @nested `b` | TS2418 @key | TS2322 @nested ✅ |
| 7 | call arg `f({ ["p"]: 1 })`, `[k:string]:string` | TS2322 | TS2418 | TS2322 ✅ |
| 8 | call arg `f({ [0]: 1 })`, `[k:number]:string` | TS2322 | TS2418 | TS2322 ✅ |
| 9–12 | the same four spellings against a `[k:symbol]`-bearing target and in the mixed-member literal | TS2322 | TS2418 | TS2322 ✅ |

**Negative controls — rows that must NOT move, and did not:**

| shape | tsc | tsz before | tsz after |
|---|---|---|---|
| `const label = "count"` → `{[k:string]:string} = { [label]: 1 }` | TS2418 | TS2418 | TS2418 ✅ |
| `const pos = 0` → `{[k:number]:string} = { [pos]: 1 }` | TS2418 | TS2418 | TS2418 ✅ |
| `enum E { A = "a" }` → `{[k:string]:string} = { [E.A]: 1 }` | TS2418 | TS2418 | TS2418 ✅ |
| `declare const s: unique symbol` → `{[k:symbol]:string} = { [s]: 1 }` | TS2418 | TS2418 | TS2418 ✅ |
| `{[k:symbol]:string} = { [Symbol.iterator]: 1 }` | TS2418 | TS2418 | TS2418 ✅ |
| call arg with a late-bound key | TS2418 | TS2418 | TS2418 ✅ |
| `{ member: number } = { ["member"]: "text" }` (named member, literal key) | TS2322 | TS2322 | TS2322 ✅ |
| `{ mu: number } = { [field]: "text" }` (named member, late-bound) | TS2418 | TS2418 | TS2418 ✅ |
| assignable values under every spelling | clean | clean | clean ✅ |
| wide `[ws]`/`[wn]` computed key | whole-object TS2322 | whole-object TS2322 | unchanged ✅ |

Binder names are varied across every test (`alpha`/`beta`/`gamma`/`heading`/`position`/`Channel.Primary`/`token`), so no identifier string is load-bearing.

**Commands actually run:**

- `cargo test -p tsz-checker --lib -- literal_spelled_computed_key` — **17 passed, 0 failed** (new module; 9 positive rows incl. both owners, 6 late-bound negative controls, 2 named-member controls, 1 clean-direction control).
- `cargo test -p tsz-checker --lib -- computed index_signature` — **593 tests, 0 failures** after the fix (the one failure seen mid-session was my own `Symbol.iterator` row, which asserts TS2583 because this harness compiles without the es2015 lib; that row was removed and the shape is pinned against the oracle via the CLI instead — see the module doc comment).
- `cargo test -p tsz-checker --lib` (full crate) — running at PR-open time; result posted to this thread before anyone lands it.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py` — 0 failure blocks (grepped for `ARCH GUARD FAILURES`, not trusted by exit code).
- `cargo fmt --all` — clean; pre-commit hook verification passed.

**Owed gate, disclosed:** the TypeScript submodule is absent on this seat, so `scripts/conformance/compare-to-parent.sh` and `conformance.sh` were **not runnable** and are owed. The change is a diagnostic-code selection narrowing gated on a purely syntactic predicate, with the negative-control half of the matrix pinned in both directions, but a two-sided corpus diff is still the gate that would catch what a targeted matrix cannot. A reviewer with a warm corpus running it before merge would be the right call.

**Residuals found and deliberately left out of scope** (each verified to pre-exist this diff, i.e. identical on `main`):

1. `{[k:symbol]:{b:number}} = { [s]: {b:1,extra:2} }` — nested excess under a *symbol* key. This is **#16649**, already fixed by **#16651** (ClaudeT, open). Not touched here; my predicate leaves every symbol spelling on its current path.
2. `{[k:string]:{b:number}} = { [label]: {b:"no"} }` — a *late-bound* key with an object value should still elaborate into the leaf (tsc TS2322 @nested; tsz TS2418 @key). Same family as #16649's row 5, which its author flagged as a distinct defect. My fix covers only the literal-spelled spelling of it (row 6 above).
3. `declare const w: symbol` → `{[k:symbol]:string} = { [w]: 1 }` — a *wide* symbol key contributes an index signature, so tsc reports a whole-object TS2322 with `'symbol' index signatures are incompatible`; tsz reports TS2418 at the key. Left deliberately: excluding it here would swap one wrong answer for a different wrong answer rather than fix it.
4. `{ [Symbol.iterator]: string } = { [Symbol.iterator]: 1 }` (well-known symbol against a *declared* member) — tsc TS2418, tsz TS2322. The mirror-image overreach of the bug fixed here, in the pre-existing `is_computed_literal_key && target_has_named_member_for_key` exemption, whose `is_computed_literal_key` is true for `Symbol.iterator` because `get_property_name` resolves it. Unchanged by this diff.
5. Whole-object TS2322 for a wide computed key renders `{ [x: string]: number; }` where tsc renders `{ [ws]: number; }` — a printer difference, pre-existing, unrelated.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Obsidian

---
_Generated by [Claude Code](https://claude.ai/code/session_01FM9MTEUk6qaKU2Q7YW7oCx)_