### PR TITLE
fix(checker): a symbol-index nested literal elaborates a member mismatch too (#16649 follow-up)

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/property.rs
+++ b/crates/tsz-checker/src/state/state_checking/property.rs
@@ -1311,16 +1311,13 @@ const i: I = { [sym]: { a: 1 } };
     }
 
     #[test]
-    fn ts2418_symbol_index_nested_object_literal_type_mismatch_not_excess_preexisting_gap() {
-        // Oracle (`typescript@7.0.2`) reports TS2322 at the mismatched nested
-        // `a` value here, not TS2418 — but that gap is pre-existing on `main`
-        // independent of this fix (confirmed by probing unmodified `main`
-        // directly) and is a distinct structural defect: the flat TS2418
-        // computed-property message wins over `try_elaborate_assignment_source_error`
-        // unconditionally, rather than only when there is nothing to elaborate.
-        // Filed as a follow-up rather than folded into this PR's excess-property
-        // drill-in fix (see #16649's own adjacent-matrix note). This test pins
-        // the current (wrong) behavior so a future fix updates it deliberately.
+    fn ts2322_symbol_index_nested_object_literal_type_mismatch_elaborates() {
+        // The other polarity of the same drill-in: `a` is present but wrongly
+        // typed (a mismatch, not an excess property). tsc drills into the
+        // nested literal for a mismatch exactly as it does for an excess
+        // property and reports TS2322 at the member, not the outer TS2418.
+        // `try_elaborate_assignment_source_error` must run before the flat
+        // computed-property TS2418 message, not after it.
         let diags = check_source_diagnostics(
             r#"
 declare const sym: unique symbol;
@@ -1329,11 +1326,16 @@ interface I { [k: string]: number; [k: symbol]: Val; }
 const i3: I = { [sym]: { a: "wrong" } };
 "#,
         );
-        let ts2418: Vec<_> = diags.iter().filter(|d| d.code == 2418).collect();
+        let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
         assert_eq!(
-            ts2418.len(),
+            ts2322.len(),
             1,
-            "expected the pre-existing flat TS2418 (not yet TS2322) for a nested type mismatch, got: {diags:?}"
+            "expected one TS2322 for the mismatched nested 'a' value, got: {diags:?}"
+        );
+        let ts2418: Vec<_> = diags.iter().filter(|d| d.code == 2418).collect();
+        assert!(
+            ts2418.is_empty(),
+            "expected no outer TS2418 once the nested mismatch is elaborated, got: {diags:?}"
         );
     }
 

--- a/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
+++ b/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
@@ -220,6 +220,42 @@ impl<'a> CheckerState<'a> {
                     }
                 }
             }
+            // tsc's `elaborateElementwise` descends into an elaboratable property
+            // value matched here only through an index signature and anchors the
+            // deepest leaf mismatch, exactly as it does for named-property targets
+            // — it does not report the property-level aggregate. So
+            // `{ [k: string]: { n: number } } = { foo: { n: "x" } }` reports
+            // `string`->`number` at the inner `n`, not a redundant
+            // `{ n: string }`->`{ n: number }` at `foo` the way
+            // `_without_source_elaboration` would (and a fresh function value
+            // anchors at its return expression). This routes through the same
+            // `try_elaborate_assignment_source_error` gateway the named-property
+            // path uses, with the identical elaboratable-source kinds; a
+            // non-elaboratable value (a reference, a call result, ...) keeps the
+            // property-level aggregate below, which is what tsc reports for it.
+            //
+            // This must run BEFORE the flat computed-property TS2418 message
+            // below: tsc always prefers drilling into an elaboratable value —
+            // an excess property or a member mismatch alike — over the
+            // property-level aggregate. Checking `computed_property`'s
+            // COMPUTED_PROPERTY_NAME kind first (as this used to) fired the
+            // flat message unconditionally for any computed key, even when the
+            // value was a nested literal with its own elaboratable mismatch.
+            if let Some(value_idx) = nested_value_idx {
+                let value_idx = self.ctx.arena.skip_parenthesized(value_idx);
+                if self.ctx.arena.get(value_idx).is_some_and(|node| {
+                    matches!(
+                        node.kind,
+                        syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+                            | syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
+                            | syntax_kind_ext::ARROW_FUNCTION
+                            | syntax_kind_ext::FUNCTION_EXPRESSION
+                    )
+                }) && self.try_elaborate_assignment_source_error(value_idx, target_value_type)
+                {
+                    continue;
+                }
+            }
             if let Some((prop_name_idx, prop_value_idx)) = computed_property
                 && self
                     .ctx
@@ -248,34 +284,6 @@ impl<'a> CheckerState<'a> {
                     diagnostic_codes::TYPE_OF_COMPUTED_PROPERTYS_VALUE_IS_WHICH_IS_NOT_ASSIGNABLE_TO_TYPE,
                 );
                 continue;
-            }
-            // tsc's `elaborateElementwise` descends into an elaboratable property
-            // value matched here only through an index signature and anchors the
-            // deepest leaf mismatch, exactly as it does for named-property targets
-            // — it does not report the property-level aggregate. So
-            // `{ [k: string]: { n: number } } = { foo: { n: "x" } }` reports
-            // `string`->`number` at the inner `n`, not a redundant
-            // `{ n: string }`->`{ n: number }` at `foo` the way
-            // `_without_source_elaboration` would (and a fresh function value
-            // anchors at its return expression). This routes through the same
-            // `try_elaborate_assignment_source_error` gateway the named-property
-            // path uses, with the identical elaboratable-source kinds; a
-            // non-elaboratable value (a reference, a call result, ...) keeps the
-            // property-level aggregate below, which is what tsc reports for it.
-            if let Some(value_idx) = self.object_literal_property_initializer(report_idx) {
-                let value_idx = self.ctx.arena.skip_parenthesized(value_idx);
-                if self.ctx.arena.get(value_idx).is_some_and(|node| {
-                    matches!(
-                        node.kind,
-                        syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
-                            | syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
-                            | syntax_kind_ext::ARROW_FUNCTION
-                            | syntax_kind_ext::FUNCTION_EXPRESSION
-                    )
-                }) && self.try_elaborate_assignment_source_error(value_idx, target_value_type)
-                {
-                    continue;
-                }
             }
 
             // tsc's `elaborateDidYouMeanToCallOrConstruct` applies to an

--- a/crates/tsz-checker/src/tests/function_type_parameter_grammar_tests.rs
+++ b/crates/tsz-checker/src/tests/function_type_parameter_grammar_tests.rs
@@ -10,275 +10,272 @@
 //! anchor column: TS1014 sits on the `...` token, TS1015/TS1016 on the
 //! offending parameter's name.
 
-#[cfg(test)]
-mod function_type_parameter_grammar_tests {
-    use crate::test_utils::check_source_diagnostics;
+use crate::test_utils::check_source_diagnostics;
 
-    /// `(code, byte offset)` for every diagnostic, in source order.
-    fn codes_at(source: &str) -> Vec<(u32, u32)> {
-        let mut found: Vec<(u32, u32)> = check_source_diagnostics(source)
-            .iter()
-            .map(|diag| (diag.code, diag.start))
-            .collect();
-        found.sort_unstable();
-        found
+/// `(code, byte offset)` for every diagnostic, in source order.
+fn codes_at(source: &str) -> Vec<(u32, u32)> {
+    let mut found: Vec<(u32, u32)> = check_source_diagnostics(source)
+        .iter()
+        .map(|diag| (diag.code, diag.start))
+        .collect();
+    found.sort_unstable();
+    found
+}
+
+/// Byte offset of the `nth` (0-based) occurrence of `needle`.
+fn offset_of(source: &str, needle: &str, nth: usize) -> u32 {
+    let mut from = 0usize;
+    for _ in 0..nth {
+        let at = source[from..]
+            .find(needle)
+            .expect("fewer occurrences than requested");
+        from += at + needle.len();
     }
+    let at = source[from..].find(needle).expect("needle not found");
+    u32::try_from(from + at).expect("offset fits in u32")
+}
 
-    /// Byte offset of the `nth` (0-based) occurrence of `needle`.
-    fn offset_of(source: &str, needle: &str, nth: usize) -> u32 {
-        let mut from = 0usize;
-        for _ in 0..nth {
-            let at = source[from..]
-                .find(needle)
-                .expect("fewer occurrences than requested");
-            from += at + needle.len();
-        }
-        let at = source[from..].find(needle).expect("needle not found");
-        u32::try_from(from + at).expect("offset fits in u32")
-    }
+fn expect_only(source: &str, code: u32, needle: &str) {
+    let expected = vec![(code, offset_of(source, needle, 0))];
+    assert_eq!(
+        codes_at(source),
+        expected,
+        "unexpected diagnostics for: {source}"
+    );
+}
 
-    fn expect_only(source: &str, code: u32, needle: &str) {
-        let expected = vec![(code, offset_of(source, needle, 0))];
-        assert_eq!(
-            codes_at(source),
-            expected,
-            "unexpected diagnostics for: {source}"
-        );
-    }
+fn expect_clean(source: &str) {
+    assert_eq!(
+        codes_at(source),
+        Vec::new(),
+        "expected no diagnostics for: {source}"
+    );
+}
 
-    fn expect_clean(source: &str) {
-        assert_eq!(
-            codes_at(source),
-            Vec::new(),
-            "expected no diagnostics for: {source}"
-        );
-    }
+// ---------------------------------------------------------------------
+// TS1014 — a rest parameter must be last
+// ---------------------------------------------------------------------
 
-    // ---------------------------------------------------------------------
-    // TS1014 — a rest parameter must be last
-    // ---------------------------------------------------------------------
+#[test]
+fn function_type_alias_reports_rest_not_last() {
+    expect_only("type F = (...a: number[], b: string) => void;", 1014, "...");
+}
 
-    #[test]
-    fn function_type_alias_reports_rest_not_last() {
-        expect_only("type F = (...a: number[], b: string) => void;", 1014, "...");
-    }
+#[test]
+fn inline_function_type_annotation_reports_rest_not_last() {
+    expect_only(
+        "declare let f: (...a: number[], b: string) => void;",
+        1014,
+        "...",
+    );
+}
 
-    #[test]
-    fn inline_function_type_annotation_reports_rest_not_last() {
-        expect_only(
-            "declare let f: (...a: number[], b: string) => void;",
-            1014,
-            "...",
-        );
-    }
+#[test]
+fn generic_function_type_reports_rest_not_last() {
+    expect_only("type F = <T>(...a: T[], b: T) => void;", 1014, "...");
+}
 
-    #[test]
-    fn generic_function_type_reports_rest_not_last() {
-        expect_only("type F = <T>(...a: T[], b: T) => void;", 1014, "...");
-    }
+#[test]
+fn constructor_type_reports_rest_not_last() {
+    expect_only(
+        "type C = new (...a: number[], b: string) => object;",
+        1014,
+        "...",
+    );
+}
 
-    #[test]
-    fn constructor_type_reports_rest_not_last() {
-        expect_only(
-            "type C = new (...a: number[], b: string) => object;",
-            1014,
-            "...",
-        );
-    }
+#[test]
+fn abstract_constructor_type_reports_rest_not_last() {
+    expect_only(
+        "type C = abstract new (...a: number[], b: string) => object;",
+        1014,
+        "...",
+    );
+}
 
-    #[test]
-    fn abstract_constructor_type_reports_rest_not_last() {
-        expect_only(
-            "type C = abstract new (...a: number[], b: string) => object;",
-            1014,
-            "...",
-        );
-    }
+#[test]
+fn function_type_as_a_parameter_annotation_reports_rest_not_last() {
+    expect_only(
+        "declare function use(cb: (...a: number[], b: string) => void): void;",
+        1014,
+        "...",
+    );
+}
 
-    #[test]
-    fn function_type_as_a_parameter_annotation_reports_rest_not_last() {
-        expect_only(
-            "declare function use(cb: (...a: number[], b: string) => void): void;",
-            1014,
-            "...",
-        );
-    }
+#[test]
+fn function_type_inside_a_union_reports_rest_not_last() {
+    expect_only(
+        "type F = ((...a: number[], b: string) => void) | string;",
+        1014,
+        "...",
+    );
+}
 
-    #[test]
-    fn function_type_inside_a_union_reports_rest_not_last() {
-        expect_only(
-            "type F = ((...a: number[], b: string) => void) | string;",
-            1014,
-            "...",
-        );
-    }
+#[test]
+fn function_type_as_an_interface_property_reports_rest_not_last() {
+    expect_only(
+        "interface I { f: (...a: number[], b: string) => void }",
+        1014,
+        "...",
+    );
+}
 
-    #[test]
-    fn function_type_as_an_interface_property_reports_rest_not_last() {
-        expect_only(
-            "interface I { f: (...a: number[], b: string) => void }",
-            1014,
-            "...",
-        );
-    }
+// ---------------------------------------------------------------------
+// TS1016 — a required parameter cannot follow an optional one
+// ---------------------------------------------------------------------
 
-    // ---------------------------------------------------------------------
-    // TS1016 — a required parameter cannot follow an optional one
-    // ---------------------------------------------------------------------
+#[test]
+fn function_type_alias_reports_required_after_optional() {
+    expect_only("type F = (a?: number, b: string) => void;", 1016, "b:");
+}
 
-    #[test]
-    fn function_type_alias_reports_required_after_optional() {
-        expect_only("type F = (a?: number, b: string) => void;", 1016, "b:");
-    }
+#[test]
+fn inline_function_type_annotation_reports_required_after_optional() {
+    expect_only(
+        "declare let f: (a?: number, b: string) => void;",
+        1016,
+        "b:",
+    );
+}
 
-    #[test]
-    fn inline_function_type_annotation_reports_required_after_optional() {
-        expect_only(
-            "declare let f: (a?: number, b: string) => void;",
-            1016,
-            "b:",
-        );
-    }
+#[test]
+fn generic_function_type_reports_required_after_optional() {
+    expect_only("type F = <T>(a?: T, b: T) => void;", 1016, "b:");
+}
 
-    #[test]
-    fn generic_function_type_reports_required_after_optional() {
-        expect_only("type F = <T>(a?: T, b: T) => void;", 1016, "b:");
-    }
+#[test]
+fn constructor_type_reports_required_after_optional() {
+    expect_only(
+        "type C = new (a?: number, b: string) => object;",
+        1016,
+        "b:",
+    );
+}
 
-    #[test]
-    fn constructor_type_reports_required_after_optional() {
-        expect_only(
-            "type C = new (a?: number, b: string) => object;",
-            1016,
-            "b:",
-        );
-    }
+#[test]
+fn abstract_constructor_type_reports_required_after_optional() {
+    expect_only(
+        "type C = abstract new (a?: number, b: string) => object;",
+        1016,
+        "b:",
+    );
+}
 
-    #[test]
-    fn abstract_constructor_type_reports_required_after_optional() {
-        expect_only(
-            "type C = abstract new (a?: number, b: string) => object;",
-            1016,
-            "b:",
-        );
-    }
+#[test]
+fn function_type_as_an_object_type_member_reports_required_after_optional() {
+    expect_only(
+        "type T = { f: (a?: number, b: string) => void };",
+        1016,
+        "b:",
+    );
+}
 
-    #[test]
-    fn function_type_as_an_object_type_member_reports_required_after_optional() {
-        expect_only(
-            "type T = { f: (a?: number, b: string) => void };",
-            1016,
-            "b:",
-        );
-    }
+#[test]
+fn function_type_in_an_array_type_reports_required_after_optional() {
+    expect_only("type F = ((a?: number, b: string) => void)[];", 1016, "b:");
+}
 
-    #[test]
-    fn function_type_in_an_array_type_reports_required_after_optional() {
-        expect_only("type F = ((a?: number, b: string) => void)[];", 1016, "b:");
-    }
+// ---------------------------------------------------------------------
+// TS1015 — `?` together with an initializer
+// ---------------------------------------------------------------------
 
-    // ---------------------------------------------------------------------
-    // TS1015 — `?` together with an initializer
-    // ---------------------------------------------------------------------
+#[test]
+fn function_type_reports_question_mark_with_initializer_alongside_ts2371() {
+    // tsc reports TS1015 and TS2371 at the same anchor: the grammar arm and
+    // the "initializer only in an implementation" rule are independent.
+    let source = "type F = (a?: number = 1) => void;";
+    let anchor = offset_of(source, "a?", 0);
+    assert_eq!(codes_at(source), vec![(1015, anchor), (2371, anchor)]);
+}
 
-    #[test]
-    fn function_type_reports_question_mark_with_initializer_alongside_ts2371() {
-        // tsc reports TS1015 and TS2371 at the same anchor: the grammar arm and
-        // the "initializer only in an implementation" rule are independent.
-        let source = "type F = (a?: number = 1) => void;";
-        let anchor = offset_of(source, "a?", 0);
-        assert_eq!(codes_at(source), vec![(1015, anchor), (2371, anchor)]);
-    }
+// ---------------------------------------------------------------------
+// tsc reports at most ONE diagnostic per parameter list
+// ---------------------------------------------------------------------
 
-    // ---------------------------------------------------------------------
-    // tsc reports at most ONE diagnostic per parameter list
-    // ---------------------------------------------------------------------
+#[test]
+fn a_misplaced_rest_wins_over_a_later_required_after_optional() {
+    // `checkGrammarParameterList` returns at the first failing parameter,
+    // so the trailing `b?`/`c` pair never reaches the TS1016 arm.
+    expect_only(
+        "type F = (...a: number[], b?: string, c: string) => void;",
+        1014,
+        "...",
+    );
+}
 
-    #[test]
-    fn a_misplaced_rest_wins_over_a_later_required_after_optional() {
-        // `checkGrammarParameterList` returns at the first failing parameter,
-        // so the trailing `b?`/`c` pair never reaches the TS1016 arm.
-        expect_only(
-            "type F = (...a: number[], b?: string, c: string) => void;",
-            1014,
-            "...",
-        );
-    }
+#[test]
+fn only_the_first_required_after_optional_is_reported() {
+    expect_only(
+        "type F = (a?: number, b: string, c: string) => void;",
+        1016,
+        "b:",
+    );
+}
 
-    #[test]
-    fn only_the_first_required_after_optional_is_reported() {
-        expect_only(
-            "type F = (a?: number, b: string, c: string) => void;",
-            1016,
-            "b:",
-        );
-    }
+// ---------------------------------------------------------------------
+// Negative controls
+// ---------------------------------------------------------------------
 
-    // ---------------------------------------------------------------------
-    // Negative controls
-    // ---------------------------------------------------------------------
+#[test]
+fn optional_after_required_is_clean() {
+    expect_clean("type F = (a: number, b?: string) => void;");
+}
 
-    #[test]
-    fn optional_after_required_is_clean() {
-        expect_clean("type F = (a: number, b?: string) => void;");
-    }
+#[test]
+fn a_trailing_rest_after_an_optional_is_clean() {
+    expect_clean("type F = (a?: number, ...rest: string[]) => void;");
+}
 
-    #[test]
-    fn a_trailing_rest_after_an_optional_is_clean() {
-        expect_clean("type F = (a?: number, ...rest: string[]) => void;");
-    }
+#[test]
+fn an_initialized_parameter_does_not_make_the_next_one_required_after_optional() {
+    // tsc's `isOptionalParameter` compares the index against the minimum
+    // argument count, so a leading `a = 1` is not optional here.
+    expect_clean("function f(a = 1, b: number) {}");
+}
 
-    #[test]
-    fn an_initialized_parameter_does_not_make_the_next_one_required_after_optional() {
-        // tsc's `isOptionalParameter` compares the index against the minimum
-        // argument count, so a leading `a = 1` is not optional here.
-        expect_clean("function f(a = 1, b: number) {}");
-    }
+#[test]
+fn a_parameter_with_an_initializer_is_not_required_after_an_optional_one() {
+    // Only TS2371 survives — the initializer keeps `b` out of the TS1016
+    // arm, exactly as in tsc.
+    let source = "type F = (a?: number, b = 1) => void;";
+    assert_eq!(codes_at(source), vec![(2371, offset_of(source, "b =", 0))]);
+}
 
-    #[test]
-    fn a_parameter_with_an_initializer_is_not_required_after_an_optional_one() {
-        // Only TS2371 survives — the initializer keeps `b` out of the TS1016
-        // arm, exactly as in tsc.
-        let source = "type F = (a?: number, b = 1) => void;";
-        assert_eq!(codes_at(source), vec![(2371, offset_of(source, "b =", 0))]);
-    }
+#[test]
+fn binding_pattern_parameters_are_clean() {
+    expect_clean("type F = ({ a }: { a: number }, c?: string) => void;");
+}
 
-    #[test]
-    fn binding_pattern_parameters_are_clean() {
-        expect_clean("type F = ({ a }: { a: number }, c?: string) => void;");
-    }
+#[test]
+fn a_this_parameter_before_the_optional_run_is_clean() {
+    expect_clean("type F = (this: object, a: number, b?: string) => void;");
+}
 
-    #[test]
-    fn a_this_parameter_before_the_optional_run_is_clean() {
-        expect_clean("type F = (this: object, a: number, b?: string) => void;");
-    }
+#[test]
+fn an_empty_parameter_list_is_clean() {
+    expect_clean("type F = () => void;");
+}
 
-    #[test]
-    fn an_empty_parameter_list_is_clean() {
-        expect_clean("type F = () => void;");
-    }
+// ---------------------------------------------------------------------
+// One diagnostic per written signature, not per use
+// ---------------------------------------------------------------------
 
-    // ---------------------------------------------------------------------
-    // One diagnostic per written signature, not per use
-    // ---------------------------------------------------------------------
+#[test]
+fn a_reused_alias_reports_its_signature_once() {
+    let source = concat!(
+        "type Bad = (...a: number[], b: string) => void;\n",
+        "declare const x1: Bad;\n",
+        "declare const x2: Bad;\n"
+    );
+    assert_eq!(codes_at(source), vec![(1014, offset_of(source, "...", 0))]);
+}
 
-    #[test]
-    fn a_reused_alias_reports_its_signature_once() {
-        let source = concat!(
-            "type Bad = (...a: number[], b: string) => void;\n",
-            "declare const x1: Bad;\n",
-            "declare const x2: Bad;\n"
-        );
-        assert_eq!(codes_at(source), vec![(1014, offset_of(source, "...", 0))]);
-    }
-
-    #[test]
-    fn a_generic_alias_instantiated_twice_reports_its_signature_once() {
-        let source = concat!(
-            "type G<T> = (a?: T, b: T) => void;\n",
-            "declare const g1: G<number>;\n",
-            "declare const g2: G<string>;\n"
-        );
-        assert_eq!(codes_at(source), vec![(1016, offset_of(source, "b:", 0))]);
-    }
+#[test]
+fn a_generic_alias_instantiated_twice_reports_its_signature_once() {
+    let source = concat!(
+        "type G<T> = (a?: T, b: T) => void;\n",
+        "declare const g1: G<number>;\n",
+        "declare const g2: G<string>;\n"
+    );
+    assert_eq!(codes_at(source), vec![(1016, offset_of(source, "b:", 0))]);
 }

--- a/crates/tsz-checker/tests/symbol_key_nested_literal_excess_property_tests.rs
+++ b/crates/tsz-checker/tests/symbol_key_nested_literal_excess_property_tests.rs
@@ -108,12 +108,9 @@ const i2: I = { x: { a: 1, b: 2 } };
     );
 }
 
-// ---- Residual: the mismatch half of the same drill-in is still outer-only ---
+// ---- The other polarity of the same drill-in: a member mismatch -------------
 
 #[test]
-#[ignore = "known divergence (#16649 residual): a member *mismatch* inside a \
-            symbol-keyed nested literal still reports the outer TS2418 instead \
-            of drilling in to TS2322"]
 fn symbol_keyed_nested_literal_member_mismatch_reports_ts2322() {
     // Same drill-in, other polarity: `a` is present but wrongly typed, so this
     // is a mismatch rather than an excess property. tsc drills into the nested
@@ -121,9 +118,10 @@ fn symbol_keyed_nested_literal_member_mismatch_reports_ts2322() {
     //
     //   error TS2322: Type 'string' is not assignable to type 'number'.
     //
-    // tsz reports TS2418 at the computed property. The excess-property half is
-    // fixed; this half is not, so the rows above pass while this one pins the
-    // remaining gap.
+    // Previously tsz reported the outer TS2418 at the computed property
+    // instead: the flat computed-property message fired as soon as the
+    // property name resolved to a `COMPUTED_PROPERTY_NAME` node, before
+    // `try_elaborate_assignment_source_error` ever got a chance to drill in.
     let source = r#"
 declare const sym: unique symbol;
 interface Val { a: number; }


### PR DESCRIPTION
Follow-up to #16651 (merged) — a reviewer verified that fix, pushed proper integration tests to the branch, and flagged one residual: the excess-property drill-in was fixed but a genuine **member mismatch** in the same symbol-keyed nested-literal position still reported the flat outer `TS2418` instead of tsc's elaborated `TS2322`. This PR closes that residual.

## Commit 1 — the residual fix

**Structural rule:** `try_union_index_signature_value_check` tried the flat "computed property's value is not assignable" TS2418 message *unconditionally* whenever the resolved property name was a `COMPUTED_PROPERTY_NAME` node — before `try_elaborate_assignment_source_error` ever got a chance to drill into an elaboratable nested value (object/array/arrow/function literal). tsc always prefers elaboration when the value is elaboratable, for a member mismatch exactly as for an excess property. This moves the existing elaboration attempt to run *before* the flat TS2418 special-case, so the flat message is now only reached when there's nothing to elaborate — matching how the excess-property branch immediately above it already behaved after #16651.

| shape | tsc | before this PR | after |
| --- | --- | --- | --- |
| `{ [sym]: { a: "no" } }` against `[k:symbol]: Val` (`Val.a: number`) | `TS2322` at nested `a` | `TS2418` (outer, wrong) | **`TS2322`** |

Un-ignores `symbol_keyed_nested_literal_member_mismatch_reports_ts2322` (the reviewer's tripwire test in `crates/tsz-checker/tests/symbol_key_nested_literal_excess_property_tests.rs`) now that it passes, and updates this crate's own unit test (which had pinned the prior wrong TS2418 behavior as a documented pre-existing gap) to assert the now-correct TS2322 instead.

## Commit 2 — unrelated but currently fleet-blocking

`cargo clippy --all-targets` (the actual CI gate: `--profile ci-lint --workspace --all-targets -- -D warnings`) is red on unmodified `main` right now with `clippy::module_inception` in `crates/tsz-checker/src/tests/function_type_parameter_grammar_tests.rs`, landed by the just-merged #16643: the file is included as module `function_type_parameter_grammar_tests` via `#[path]` in `test_module_registry.rs` (itself `#[cfg(test)]`-gated at the crate root), but the file's own content additionally wraps everything in a same-named `mod function_type_parameter_grammar_tests { ... }`. This blocks the clippy gate for *every* open PR against `main`, including this one, so it's bundled here as its own separate commit (pure code motion — drop the redundant wrapper, dedent one level, no logic change) rather than waiting on a separate PR to land first.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib state_checking::property::` → 15 passed, 0 failed.
- `cargo test -p tsz-checker --test symbol_key_nested_literal_excess_property_tests` → 5 passed, 0 failed, 0 ignored (residual test un-ignored and green).
- `cargo test -p tsz-checker --lib function_type_parameter_grammar_tests` → 27 passed, 0 failed (pre-existing tests, content unchanged — confirmed via `git diff -b`).
- No regressions: `cargo test -p tsz-checker --lib property` (1361 passed), `2353` (124 passed), `2418` (10 passed), `2322` (697 passed) — all 0 failed.
- `cargo clippy -p tsz-checker --lib --tests -- -D warnings` clean (was failing on `module_inception` before commit 2).
- `python3 scripts/arch/arch_guard.py` clean.
- `cargo fmt -p tsz-checker` produced no diff.
- Branch was restarted from `origin/main` after #16651 merged (per repo convention for a fresh follow-up on a used-up branch) and force-pushed with lease; the discarded remote history was exactly what's already squash-merged into `main` as `a05bcf5` — verified before pushing.
- Two-sided `compare-to-parent.sh` not run locally this session (same TypeScript-submodule-absent / cold-seat-cost constraint as #16651). Expected impact low: commit 1 only affects the same narrow symbol-index shape #16651 already isolated with zero regressions; commit 2 is test-only code motion with zero production-path diff.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGt9jKDehXWPEhVgUkoRGu)_