### PR TITLE
fix(checker): a symbol-index nested-literal member mismatch drills into TS2322

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/property.rs
+++ b/crates/tsz-checker/src/state/state_checking/property.rs
@@ -1311,16 +1311,19 @@ const i: I = { [sym]: { a: 1 } };
     }
 
     #[test]
-    fn ts2418_symbol_index_nested_object_literal_type_mismatch_not_excess_preexisting_gap() {
-        // Oracle (`typescript@7.0.2`) reports TS2322 at the mismatched nested
-        // `a` value here, not TS2418 — but that gap is pre-existing on `main`
-        // independent of this fix (confirmed by probing unmodified `main`
-        // directly) and is a distinct structural defect: the flat TS2418
-        // computed-property message wins over `try_elaborate_assignment_source_error`
-        // unconditionally, rather than only when there is nothing to elaborate.
-        // Filed as a follow-up rather than folded into this PR's excess-property
-        // drill-in fix (see #16649's own adjacent-matrix note). This test pins
-        // the current (wrong) behavior so a future fix updates it deliberately.
+    fn ts2322_symbol_index_nested_object_literal_type_mismatch_drills_in() {
+        // This row previously pinned the *wrong* behavior on purpose — the flat
+        // TS2418 computed-property message won over
+        // `try_elaborate_assignment_source_error` unconditionally, rather than
+        // only when there was nothing to elaborate — with a note that a future
+        // fix should update it deliberately. This is that update: the
+        // elaboration now drills into the nested literal for a member
+        // *mismatch* the same way #16649/#16651 made it drill in for an excess
+        // property.
+        //
+        // Oracle (`typescript@7.0.2`, `--strict --lib es2024 --target es2022`):
+        //
+        //   error TS2322: Type 'string' is not assignable to type 'number'.
         let diags = check_source_diagnostics(
             r#"
 declare const sym: unique symbol;
@@ -1329,11 +1332,15 @@ interface I { [k: string]: number; [k: symbol]: Val; }
 const i3: I = { [sym]: { a: "wrong" } };
 "#,
         );
-        let ts2418: Vec<_> = diags.iter().filter(|d| d.code == 2418).collect();
-        assert_eq!(
-            ts2418.len(),
-            1,
-            "expected the pre-existing flat TS2418 (not yet TS2322) for a nested type mismatch, got: {diags:?}"
+        let codes: Vec<u32> = diags.iter().map(|d| d.code).collect();
+        assert!(
+            codes.contains(&2322),
+            "a nested member mismatch drills in to TS2322, got: {diags:?}"
+        );
+        assert!(
+            !codes.contains(&2418),
+            "the flat TS2418 computed-property message must not also fire once \
+             the mismatch elaborates, got: {diags:?}"
         );
     }
 

--- a/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
+++ b/crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs
@@ -218,6 +218,16 @@ impl<'a> CheckerState<'a> {
                     if self.ctx.diagnostics.len() > before_nested {
                         continue;
                     }
+                    // Other polarity of the same drill-in: a member that is
+                    // *present* but wrongly typed. tsc's `elaborateElementwise`
+                    // descends into the nested literal and anchors TS2322 at the
+                    // member either way, regardless of whether the outer key is
+                    // late-bound via a string or a symbol. Without this, a
+                    // late-bound key with a mismatched (not excess) nested member
+                    // falls through to the flat TS2418 below instead.
+                    if self.try_elaborate_assignment_source_error(nested_idx, target_value_type) {
+                        continue;
+                    }
                 }
             }
             if let Some((prop_name_idx, prop_value_idx)) = computed_property

--- a/crates/tsz-checker/tests/symbol_key_nested_literal_excess_property_tests.rs
+++ b/crates/tsz-checker/tests/symbol_key_nested_literal_excess_property_tests.rs
@@ -111,9 +111,6 @@ const i2: I = { x: { a: 1, b: 2 } };
 // ---- Residual: the mismatch half of the same drill-in is still outer-only ---
 
 #[test]
-#[ignore = "known divergence (#16649 residual): a member *mismatch* inside a \
-            symbol-keyed nested literal still reports the outer TS2418 instead \
-            of drilling in to TS2322"]
 fn symbol_keyed_nested_literal_member_mismatch_reports_ts2322() {
     // Same drill-in, other polarity: `a` is present but wrongly typed, so this
     // is a mismatch rather than an excess property. tsc drills into the nested


### PR DESCRIPTION
When a fresh object literal is contextually typed through an index signature's value type, tsc's `elaborateElementwise` descends into the nested literal for **either** failure polarity — an excess property (`TS2353`) or a member with the wrong type (`TS2322`) — and anchors the diagnostic at the member, not at the outer computed property. #16649/#16651 fixed the excess-property polarity for a `[k: symbol]` index signature (matching the pre-existing `[k: string]` behavior); the mismatch polarity was a separate, unfixed gap left as a residual, now filed as #16664.

```ts
declare const sym: unique symbol;
interface Val { a: number; }
interface I { [k: string]: number; [k: symbol]: Val; }
const bad: I = { [sym]: { a: "no" } };
```

```
tsc   error TS2322: Type 'string' is not assignable to type 'number'.
tsz   error TS2418: Type of computed property's value is '{ a: string; }', which is not assignable to type 'Val'.  (before)
```

**Structural rule.** When a late-bound computed key's value is contextually typed through a `[k: symbol]` index signature and the nested object-literal value has a member with the wrong type (not an excess property), tsc drills in and anchors `TS2322` at the member; tsz reported the outer `TS2418` instead. Owner: checker, `crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs::try_union_index_signature_value_check` — the same function and same nested-object-literal block #16651 touched for the excess-property polarity.

## Fix

The nested-object-literal block already tries `check_object_literal_excess_properties` and `continue`s past the outer TS2418 if that reports anything. This adds a second attempt — `try_elaborate_assignment_source_error` (the same generic elaboration gateway the non-computed named-property path already uses a few lines below) — when the excess-property check finds nothing, before falling through to the flat `TS2418`. By construction the source property is already known not to be assignable to the target index-signature value type at this point (guarded earlier in the loop), so if it isn't an excess property, it must be a member mismatch the elaborator can locate.

No change to the excess-property path itself, and no change to the `[k: string]` control (still exercised by `string_keyed_nested_literal_excess_property_still_reports_ts2353`).

## Adjacent-case matrix

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| symbol-index nested literal, member mismatch | TS2322 at member | TS2418 (wrong) | **TS2322 at member** |
| symbol-index nested literal, excess property (#16651) | TS2353 at excess prop | TS2353 | unchanged ✅ |
| symbol-index nested literal, renamed binders, excess property | TS2353 | TS2353 | unchanged ✅ |
| string-index nested literal, excess property (pre-existing) | TS2353 | TS2353 | unchanged ✅ |
| symbol-index nested literal, fully conforming | clean | clean | unchanged ✅ |

## Goal
Goal: hold

## Verification
- Un-ignored the pinned tripwire `symbol_keyed_nested_literal_member_mismatch_reports_ts2322` (was `#[ignore]`d on `main` as the exact acceptance criterion for #16664) — `cargo test -p tsz-checker --test symbol_key_nested_literal_excess_property_tests`: 5/5 pass (all 5 in the file, including the 4 pre-existing controls).
- `cargo test -p tsz-checker --lib -- symbol_key union_index_signature computed_property elaborat`: 342/342 pass, 0 failed — broad regression net over the touched code's neighborhood (symbol-index, computed-property, elaboration families).
- `cargo clippy -p tsz-checker --lib --test symbol_key_nested_literal_excess_property_tests -- -D warnings`: clean.
- `cargo fmt --check -p tsz-checker`: clean.
- Pre-commit hook (clippy `-D warnings` + arch-size guard + affected-crate tests) passed clean at commit `a3c6ad5`.
- Source diff confined to `crates/tsz-checker/src/state/state_checking/property/union_index_signature_diagnostics.rs`; this is an additional-diagnostic-drill-in path for a previously-flat-TS2418 shape, not a change to any existing passing diagnostic's trigger condition — no corpus regression expected. Conformance/emit not separately re-run given the narrow, single-function scope and the targeted+broad unit coverage above.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_017VbuG5G2ggJZvHxDX4yRvn)_