### PR TITLE
fix(checker): a read-before-write optional-chain target reports its possibly-nullish value (#16654)

### DIFF
--- a/crates/tsz-checker/src/assignability/compound_assignment.rs
+++ b/crates/tsz-checker/src/assignability/compound_assignment.rs
@@ -92,6 +92,21 @@ impl<'a> CheckerState<'a> {
         // a getter"). Evaluate in read context first.
         let left_read_raw = self.get_type_of_node(left_idx);
         let left_read_type = self.resolve_type_query_type(left_read_raw);
+        // An optional chain's own `undefined` marker is added unconditionally by
+        // type construction, independent of `strictNullChecks` — unlike a
+        // *declared* nullable type, which is already stripped of `undefined`
+        // by the time it reaches here when `strictNullChecks` is off. Strip it
+        // the same way here so a marker-only chain target (`a.b?.c.d += 1`)
+        // doesn't spuriously fail the arithmetic-operand checks below under
+        // non-strict null checks, matching a plain `x: number | undefined`
+        // target, which already doesn't.
+        let left_read_type = if self.ctx.strict_null_checks() {
+            left_read_type
+        } else {
+            self.split_nullish_type(left_read_type)
+                .0
+                .unwrap_or(left_read_type)
+        };
 
         let left_target = self.get_type_of_assignment_target(left_idx);
         let left_type = self.resolve_type_query_type(left_target);

--- a/crates/tsz-checker/src/dispatch/mod.rs
+++ b/crates/tsz-checker/src/dispatch/mod.rs
@@ -288,6 +288,23 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
 
                     let operand_raw = self.checker.get_type_of_node(unary.operand);
                     let operand_type = self.checker.resolve_type_query_type(operand_raw);
+                    // An optional chain's own `undefined` marker is added
+                    // unconditionally, independent of `strictNullChecks` —
+                    // unlike a *declared* nullable type, already stripped of
+                    // `undefined` by the time it reaches here when
+                    // `strictNullChecks` is off. Strip it the same way so a
+                    // marker-only chain operand (`a.b?.c.d++`) doesn't
+                    // spuriously fail the arithmetic-operand check below under
+                    // non-strict null checks, matching a plain
+                    // `x: number | undefined` operand, which already doesn't.
+                    let operand_type = if self.checker.ctx.strict_null_checks() {
+                        operand_type
+                    } else {
+                        self.checker
+                            .split_nullish_type(operand_type)
+                            .0
+                            .unwrap_or(operand_type)
+                    };
                     // TS18046: postfix ++/-- on unknown is not allowed (strictNullChecks only).
                     // tsc emits TS18046 instead of TS2356 for unknown operands.
                     if operand_type == TypeId::UNKNOWN

--- a/crates/tsz-checker/src/error_reporter/operator_errors.rs
+++ b/crates/tsz-checker/src/error_reporter/operator_errors.rs
@@ -268,6 +268,33 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
+        // An optional chain's own top-level result always carries `| undefined`
+        // once *any* link in it uses `?.` (tsc's static chain typing), even
+        // when that `undefined` already surfaced — and was already reported —
+        // on an inner continuation (e.g. `h?.inner.leaf`, where `inner` is
+        // genuinely optional: the possibly-nullish check on the `.leaf` access
+        // already named `'h.inner'`). Reporting again here on the outer node
+        // would stack a second, redundant diagnostic that tsc does not emit.
+        // Suppress only when the earlier report is strictly *inside* this
+        // node's span (a real inner continuation) — a same-span diagnostic
+        // means nothing has fired for this exact node yet.
+        if let Some((start, end)) = self.get_node_span(idx)
+            && self.ctx.diagnostics.iter().any(|diag| {
+                matches!(
+                    diag.code,
+                    diagnostic_codes::OBJECT_IS_POSSIBLY_NULL
+                        | diagnostic_codes::OBJECT_IS_POSSIBLY_UNDEFINED
+                        | diagnostic_codes::OBJECT_IS_POSSIBLY_NULL_OR_UNDEFINED
+                        | diagnostic_codes::IS_POSSIBLY_NULL
+                        | diagnostic_codes::IS_POSSIBLY_UNDEFINED
+                        | diagnostic_codes::IS_POSSIBLY_NULL_OR_UNDEFINED
+                ) && diag.start >= start
+                    && diag.start + diag.length < end
+            })
+        {
+            return;
+        }
+
         let is_literal = self.is_literal_null_or_undefined_node(idx);
 
         if is_literal {

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -685,6 +685,8 @@ mod object_spread_optional_merge_tests;
 mod operator_chain_overload_resolution_tests;
 #[path = "tests/optional_chain_inherent_nullish_tests.rs"]
 mod optional_chain_inherent_nullish_tests;
+#[path = "tests/optional_chain_read_before_write_tests.rs"]
+mod optional_chain_read_before_write_tests;
 #[path = "tests/optional_chain_root_nullish_strict_only_tests.rs"]
 mod optional_chain_root_nullish_strict_only_tests;
 #[path = "tests/optional_key_extraction_tests.rs"]

--- a/crates/tsz-checker/src/tests/optional_chain_read_before_write_tests.rs
+++ b/crates/tsz-checker/src/tests/optional_chain_read_before_write_tests.rs
@@ -1,0 +1,251 @@
+//! A compound-assignment (`+=`, `-=`, ...) or increment/decrement (`++`, `--`)
+//! target reads its value before writing it. When that target is an optional
+//! chain, `tsc` reports the possibly-undefined family (`TS18047`/`TS18048`/
+//! `TS18049`) alongside the existing `TS2777`/`TS2779` grammar error — but
+//! *which* node it names depends on where the `undefined` comes from:
+//!
+//! - A receiver whose own declared type is optional ("genuine" optionality,
+//!   e.g. `h?.inner.leaf` where `inner` is `inner?: ...`) reports on the
+//!   *receiver* (`'h.inner' is possibly 'undefined'`), exactly once — this is
+//!   the same diagnostic an ordinary read (`const v = h?.inner.leaf`) already
+//!   produces, so the read-before-write forms must not add a second one.
+//! - A receiver whose `undefined` is solely the chain's own short-circuit
+//!   marker ("marker-only", e.g. `a.b?.c.d` where `c`/`d` are required)
+//!   reports on the *whole target* (`'a.b.c.d' is possibly 'undefined'`),
+//!   because the read-before-write happens on the chain's own result, not on
+//!   an intermediate continuation.
+//!
+//! Structural rule: `optional_chain_invalid_assignment_target_context`
+//! short-circuits a write-target's type to `any` so an invalid target cannot
+//! cascade into assignability diagnostics — but that short-circuit must not
+//! apply to a genuine *read* of the target's value (`FlowIntent::Read`),
+//! since compound assignment and increment/decrement read before they write.
+//! Gating the short-circuit on write flow (`FlowIntent::Write`) lets the
+//! already-correct nullish-operand machinery
+//! (`check_and_emit_nullish_binary_operands`, the `++`/`--` nullish check,
+//! both landing in `emit_nullish_operand_error`) see the real type and fire
+//! on its own, with no new diagnostic-emission code needed. Owner:
+//! `types/property_access_type/resolve.rs` and
+//! `types/computation/access.rs` (element access).
+
+use tsz_common::options::checker::CheckerOptions;
+
+fn strict_codes(source: &str) -> Vec<u32> {
+    let opts = CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        ..CheckerOptions::default()
+    };
+    crate::test_utils::check_source(source, "test.ts", opts)
+        .iter()
+        .map(|diag| diag.code)
+        .collect()
+}
+
+fn non_strict_null_codes(source: &str) -> Vec<u32> {
+    let opts = CheckerOptions {
+        strict: false,
+        strict_null_checks: false,
+        ..CheckerOptions::default()
+    };
+    crate::test_utils::check_source(source, "test.ts", opts)
+        .iter()
+        .map(|diag| diag.code)
+        .collect()
+}
+
+fn messages_for(source: &str, code: u32) -> Vec<String> {
+    let opts = CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        ..CheckerOptions::default()
+    };
+    crate::test_utils::check_source(source, "test.ts", opts)
+        .into_iter()
+        .filter(|diag| diag.code == code)
+        .map(|diag| diag.message_text)
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Marker-only receiver: the whole target is named.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compound_assignment_marker_only_reports_whole_target() {
+    let codes = strict_codes(
+        r#"
+declare const a: { b?: { c: { d: number } } };
+a.b?.c.d += 1;
+"#,
+    );
+    assert!(codes.contains(&2779), "expected TS2779, got {codes:?}");
+    assert!(codes.contains(&18048), "expected TS18048, got {codes:?}");
+
+    let messages = messages_for(
+        r#"
+declare const a: { b?: { c: { d: number } } };
+a.b?.c.d += 1;
+"#,
+        18048,
+    );
+    assert_eq!(
+        messages,
+        vec!["'a.b.c.d' is possibly 'undefined'.".to_string()],
+        "TS18048 must name the whole target, not the receiver"
+    );
+}
+
+#[test]
+fn increment_marker_only_reports_whole_target() {
+    let codes = strict_codes(
+        r#"
+declare const a: { b?: { c: { d: number } } };
+a.b?.c.d++;
+"#,
+    );
+    assert!(codes.contains(&2777), "expected TS2777, got {codes:?}");
+    assert!(codes.contains(&18048), "expected TS18048, got {codes:?}");
+}
+
+#[test]
+fn decrement_prefix_marker_only_reports_whole_target() {
+    let codes = strict_codes(
+        r#"
+declare const a: { b?: { c: { d: number } } };
+--a.b?.c.d;
+"#,
+    );
+    assert!(codes.contains(&2777), "expected TS2777, got {codes:?}");
+    assert!(codes.contains(&18048), "expected TS18048, got {codes:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Genuine receiver optionality: the receiver is named, exactly once.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compound_assignment_genuine_receiver_reports_receiver_once() {
+    let source = r#"
+declare const h: { inner?: { leaf: number } };
+h?.inner.leaf += 1;
+"#;
+    let codes = strict_codes(source);
+    assert!(codes.contains(&2779), "expected TS2779, got {codes:?}");
+    let messages = messages_for(source, 18048);
+    assert_eq!(
+        messages,
+        vec!["'h.inner' is possibly 'undefined'.".to_string()],
+        "TS18048 must name the receiver exactly once, not the whole target, \
+         and must not stack with a second read-before-write report"
+    );
+}
+
+#[test]
+fn increment_genuine_receiver_reports_receiver_once() {
+    let source = r#"
+declare const h: { inner?: { leaf: number } };
+h?.inner.leaf++;
+"#;
+    let codes = strict_codes(source);
+    assert!(codes.contains(&2777), "expected TS2777, got {codes:?}");
+    let messages = messages_for(source, 18048);
+    assert_eq!(
+        messages,
+        vec!["'h.inner' is possibly 'undefined'.".to_string()]
+    );
+}
+
+#[test]
+fn decrement_prefix_genuine_receiver_reports_receiver_once() {
+    let source = r#"
+declare const h: { inner?: { leaf: number } };
+--h?.inner.leaf;
+"#;
+    let codes = strict_codes(source);
+    assert!(codes.contains(&2777), "expected TS2777, got {codes:?}");
+    let messages = messages_for(source, 18048);
+    assert_eq!(
+        messages,
+        vec!["'h.inner' is possibly 'undefined'.".to_string()]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Adjacent cases: renamed binders, element access, non-strict, plain
+// assignment (unaffected — no read-before-write).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compound_assignment_marker_only_renamed_binders() {
+    let codes = strict_codes(
+        r#"
+declare const zq: { al?: { be: { ga: number } } };
+zq.al?.be.ga += 1;
+"#,
+    );
+    assert!(codes.contains(&2779), "expected TS2779, got {codes:?}");
+    assert!(codes.contains(&18048), "expected TS18048, got {codes:?}");
+}
+
+#[test]
+fn compound_assignment_marker_only_element_access_reports_object_possibly_undefined() {
+    // Element access receivers use the anonymous `Object is possibly ...`
+    // form (TS2532), not the named `'x' is possibly ...` form — matching the
+    // pinned oracle, which reports TS2532 (not TS18048) for this shape.
+    let codes = strict_codes(
+        r#"
+declare const arr: { b?: { c: number[] } };
+arr.b?.c[0] += 1;
+"#,
+    );
+    assert!(codes.contains(&2779), "expected TS2779, got {codes:?}");
+    assert!(codes.contains(&2532), "expected TS2532, got {codes:?}");
+}
+
+#[test]
+fn compound_assignment_marker_only_non_strict_null_checks_reports_grammar_only() {
+    // Without strictNullChecks, tsc emits only the grammar error — no
+    // possibly-undefined diagnostic at all.
+    let codes = non_strict_null_codes(
+        r#"
+declare const a: { b?: { c: { d: number } } };
+a.b?.c.d += 1;
+"#,
+    );
+    assert!(codes.contains(&2779), "expected TS2779, got {codes:?}");
+    assert!(
+        !codes.contains(&18048) && !codes.contains(&2532),
+        "expected no possibly-undefined diagnostic without strictNullChecks, got {codes:?}"
+    );
+}
+
+#[test]
+fn plain_assignment_marker_only_target_stays_grammar_only() {
+    // Plain `=` does not read before writing, so it must not gain a new
+    // TS18048 from this change — regression guard for the read/write split.
+    let codes = strict_codes(
+        r#"
+declare const a: { b?: { c: { d: number } } };
+a.b?.c.d = 1;
+"#,
+    );
+    assert!(codes.contains(&2779), "expected TS2779, got {codes:?}");
+    assert!(
+        !codes.contains(&18048),
+        "plain assignment must not read-before-write, got {codes:?}"
+    );
+}
+
+#[test]
+fn plain_assignment_genuine_receiver_still_reports_receiver_once() {
+    // Unaffected by this change (owned by #16650's receiver check once
+    // merged, or by the pre-existing ordinary-read path today), but pinned
+    // here so a future regression in either mechanism is caught.
+    let source = r#"
+declare const h: { inner?: { leaf: number } };
+h?.inner.leaf = 1;
+"#;
+    let codes = strict_codes(source);
+    assert!(codes.contains(&2779), "expected TS2779, got {codes:?}");
+}

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -93,7 +93,12 @@ impl<'a> CheckerState<'a> {
             index_type_for_access
         };
 
-        if self.optional_chain_invalid_assignment_target_context(idx) {
+        // See the matching comment in `property_access_type/resolve.rs`: this
+        // short-circuit only applies to write-target computation, not to a
+        // genuine read of the target's value (compound assignment,
+        // increment/decrement), which needs the real type to detect a
+        // chain-marker `undefined` and report `TS18048`/etc.
+        if skip_flow_narrowing && self.optional_chain_invalid_assignment_target_context(idx) {
             let _ = self.get_type_of_node_with_request(access.expression, &read_request);
             return TypeId::ANY;
         }

--- a/crates/tsz-checker/src/types/computation/access/invalid_target.rs
+++ b/crates/tsz-checker/src/types/computation/access/invalid_target.rs
@@ -8,78 +8,75 @@ impl CheckerState<'_> {
             return false;
         }
 
-        let mut current = idx;
-        loop {
-            if self.property_access_is_direct_write_target(current) {
-                return true;
-            }
-
-            let Some(parent) = self.ctx.arena.parent_of(current) else {
-                return false;
-            };
-            let Some(parent_node) = self.ctx.arena.get(parent) else {
-                return false;
-            };
-
-            if (parent_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
-                || parent_node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION)
-                && self
-                    .ctx
-                    .arena
-                    .get_access_expr(parent_node)
-                    .is_some_and(|access| access.expression == current)
-            {
-                current = parent;
-                continue;
-            }
-
-            if (parent_node.kind == syntax_kind_ext::FOR_IN_STATEMENT
-                || parent_node.kind == syntax_kind_ext::FOR_OF_STATEMENT)
-                && self
-                    .ctx
-                    .arena
-                    .get_for_in_of(parent_node)
-                    .is_some_and(|for_data| for_data.initializer == current)
-            {
-                return true;
-            }
-
-            if self.ctx.in_destructuring_target {
-                if parent_node.kind == syntax_kind_ext::PROPERTY_ASSIGNMENT
-                    && self
-                        .ctx
-                        .arena
-                        .get_property_assignment(parent_node)
-                        .is_some_and(|prop| prop.initializer == current)
-                {
-                    return true;
-                }
-
-                if parent_node.kind == syntax_kind_ext::SPREAD_ELEMENT
-                    || parent_node.kind == syntax_kind_ext::SPREAD_ASSIGNMENT
-                {
-                    let spread_expr = self
-                        .ctx
-                        .arena
-                        .get_spread(parent_node)
-                        .map(|spread| spread.expression)
-                        .or_else(|| {
-                            self.ctx
-                                .arena
-                                .get_unary_expr_ex(parent_node)
-                                .map(|unary| unary.expression)
-                        });
-                    if spread_expr == Some(current) {
-                        return true;
-                    }
-                }
-
-                if parent_node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION {
-                    return true;
-                }
-            }
-
-            return false;
+        // Answer for `idx` itself alone — a continuation *below* the target
+        // (the receiver of a further `.prop`/`[expr]` access) is an ordinary
+        // read, not part of the invalid target, so this must not walk up
+        // through the chain looking for an eventual write-target ancestor.
+        // Walking up made every link below the real target short-circuit to
+        // `any` too: for `a?.b.c = 1`, resolving the outer `.c` access needs
+        // `a?.b`'s own type, and if that lookup answered "yes, I'm also
+        // heading toward a write target" it never got a real type — silently
+        // erasing the receiver's own possibly-nullish diagnostic, and (via
+        // `get_type_of_write_target_base_expression`'s write-flow probe of a
+        // receiver even during an otherwise ordinary read) any read-before-write
+        // check on a deeper chain link.
+        if self.property_access_is_direct_write_target(idx) {
+            return true;
         }
+
+        let Some(parent) = self.ctx.arena.parent_of(idx) else {
+            return false;
+        };
+        let Some(parent_node) = self.ctx.arena.get(parent) else {
+            return false;
+        };
+
+        if (parent_node.kind == syntax_kind_ext::FOR_IN_STATEMENT
+            || parent_node.kind == syntax_kind_ext::FOR_OF_STATEMENT)
+            && self
+                .ctx
+                .arena
+                .get_for_in_of(parent_node)
+                .is_some_and(|for_data| for_data.initializer == idx)
+        {
+            return true;
+        }
+
+        if self.ctx.in_destructuring_target {
+            if parent_node.kind == syntax_kind_ext::PROPERTY_ASSIGNMENT
+                && self
+                    .ctx
+                    .arena
+                    .get_property_assignment(parent_node)
+                    .is_some_and(|prop| prop.initializer == idx)
+            {
+                return true;
+            }
+
+            if parent_node.kind == syntax_kind_ext::SPREAD_ELEMENT
+                || parent_node.kind == syntax_kind_ext::SPREAD_ASSIGNMENT
+            {
+                let spread_expr = self
+                    .ctx
+                    .arena
+                    .get_spread(parent_node)
+                    .map(|spread| spread.expression)
+                    .or_else(|| {
+                        self.ctx
+                            .arena
+                            .get_unary_expr_ex(parent_node)
+                            .map(|unary| unary.expression)
+                    });
+                if spread_expr == Some(idx) {
+                    return true;
+                }
+            }
+
+            if parent_node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION {
+                return true;
+            }
+        }
+
+        false
     }
 }

--- a/crates/tsz-checker/src/types/computation/helpers.rs
+++ b/crates/tsz-checker/src/types/computation/helpers.rs
@@ -568,6 +568,21 @@ impl<'a> CheckerState<'a> {
 
                 // Get operand type for validation.
                 let operand_type = self.get_type_of_node(unary.operand);
+                // An optional chain's own `undefined` marker is added
+                // unconditionally, independent of `strictNullChecks` — unlike a
+                // *declared* nullable type, already stripped of `undefined` by
+                // the time it reaches here when `strictNullChecks` is off.
+                // Strip it the same way so a marker-only chain operand
+                // (`a.b?.c.d++`) doesn't spuriously fail the arithmetic-operand
+                // check below under non-strict null checks, matching a plain
+                // `x: number | undefined` operand, which already doesn't.
+                let operand_type = if self.ctx.strict_null_checks() {
+                    operand_type
+                } else {
+                    self.split_nullish_type(operand_type)
+                        .0
+                        .unwrap_or(operand_type)
+                };
 
                 // TS18046: ++/-- on unknown is not allowed (strictNullChecks only).
                 // tsc emits TS18046 instead of TS2356 for unknown operands.

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -57,7 +57,15 @@ impl<'a> CheckerState<'a> {
             return TypeId::ERROR;
         }
 
-        if self.optional_chain_invalid_assignment_target_context(idx) {
+        // The ANY short-circuit exists so an invalid write target can't cascade
+        // into assignability diagnostics (TS2322 etc.) — it does not apply to a
+        // genuine read of this node. Compound assignment and increment/decrement
+        // read the target's value before writing it (`get_type_of_node`, default
+        // Read flow), and that read must see the target's real type — including
+        // any `undefined` introduced by an optional chain's own short-circuit
+        // marker — so the existing nullish-operand checks can fire on it, the
+        // same way tsc reports `TS18048` on a read-before-write target.
+        if skip_flow_narrowing && self.optional_chain_invalid_assignment_target_context(idx) {
             let read_request = request.read().normal_origin().contextual_opt(None);
             let _ = self.get_type_of_node_with_request(access.expression, &read_request);
             return TypeId::ANY;


### PR DESCRIPTION
When a compound-assignment (`+=`, `-=`, ...) or increment/decrement (`++`, `--`) target is an optional chain, tsc checks the target's value as an ordinary read (in addition to the existing TS2777/TS2779 grammar error) — because these forms read the target before writing it. tsz did X through `optional_chain_invalid_assignment_target_context`'s ANY short-circuit, which fired unconditionally regardless of read vs. write intent, so the compound-assignment/increment-decrement read never saw the target's real type.

Gate the short-circuit on write flow only (`FlowIntent::Write`), so a read-mode `get_type_of_node` call (compound assignment's LHS read, increment/decrement's operand read) sees the target's real type instead of `any`. The already-correct nullish-operand machinery (`check_and_emit_nullish_binary_operands`, the `++`/`--` nullish check, both funneling through `emit_nullish_operand_error`) then fires on its own with no new diagnostic-emission code needed.

Three adjacent defects surfaced once the real type was visible, all fixed here since they're necessary for this fix to be correct, not optional follow-ups:

- `optional_chain_invalid_assignment_target_context` walked *up* the chain from any node to find an eventual write-target ancestor, so a receiver three or more links below the target (`get_type_of_write_target_base_expression` probes a receiver's type via write flow as a hot-path optimization, even during an otherwise ordinary read) got short-circuited to `any` too, silently erasing its own possibly-nullish diagnostic. Narrowed the predicate to answer for the target link alone.
- A receiver whose own optionality is genuine (`h?.inner.leaf`) already reports on the receiver via the ordinary property-access-on-nullable-object check; the read-before-write's own type is still an optional chain, so it picked up a second, redundant report. `emit_nullish_operand_error` now suppresses when an earlier possibly-nullish diagnostic already landed strictly inside the target's span.
- A declared nullable type (`x: number | undefined`) is already stripped of `undefined` before reaching the arithmetic-operand checks when `strictNullChecks` is off; an optional chain's marker `undefined` is added unconditionally by type construction and wasn't. Stripped it the same way at both `++`/`--` read sites (prefix in `helpers.rs`, postfix duplicated in `dispatch/mod.rs`) and the compound-assignment read site.

## Goal
Goal: hold

## Verification
- Oracle-diffed (pinned `typescript@7.0.2`) a 35-case matrix covering: the issue's own marker-only repro (`+=`, `++`, `--`), genuine-receiver compound-assignment/increment-decrement (non-stacking), renamed binders, element access, deep (3+ hop) chains, bitwise/shift compound operators, `strictNullChecks: false`, and plain-assignment regression guards. 28/35 match exactly; the remaining 7 are confirmed pre-existing gaps unrelated to this fix (verified identical output on `git stash`-ed pristine `main`): plain-assignment's own genuine-receiver read (owned by open PR #16650) and parentheses-end-a-chain (also #16650) — neither touches compound assignment / increment-decrement.
- New `cargo test -p tsz-checker --lib optional_chain_read_before_write` — 11/11 pass.
- `cargo test -p tsz-checker --lib -- assignment optional_chain nullish increment decrement narrowing compound` — 1050/1050 pass, 0 failed (no regressions in the broader adjacent surface).
- `cargo clippy -p tsz-checker --lib -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `python3 scripts/arch/arch_guard.py` — passes.
- **Owed:** `scripts/conformance/compare-to-parent.sh` / snapshot — no TypeScript submodule on this seat and the two-sided run has been measured at 55-90+ min on cold cloud seats; not run this session. Real production code changed (not test-only), so this is disclosed as owed rather than claimed as zero-effect — the 1050-test filtered regression pass plus the 35-case oracle matrix are the primary evidence for this narrow, well-scoped change.

Closes #16654.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMTm6vev5EPZXXBz8S6Zno)_