### PR TITLE
fix(checker): drop the redundant module wrapper in function-type parameter grammar tests

### DIFF
--- a/crates/tsz-checker/src/tests/function_type_parameter_grammar_tests.rs
+++ b/crates/tsz-checker/src/tests/function_type_parameter_grammar_tests.rs
@@ -10,275 +10,272 @@
 //! anchor column: TS1014 sits on the `...` token, TS1015/TS1016 on the
 //! offending parameter's name.
 
-#[cfg(test)]
-mod function_type_parameter_grammar_tests {
-    use crate::test_utils::check_source_diagnostics;
+use crate::test_utils::check_source_diagnostics;
 
-    /// `(code, byte offset)` for every diagnostic, in source order.
-    fn codes_at(source: &str) -> Vec<(u32, u32)> {
-        let mut found: Vec<(u32, u32)> = check_source_diagnostics(source)
-            .iter()
-            .map(|diag| (diag.code, diag.start))
-            .collect();
-        found.sort_unstable();
-        found
+/// `(code, byte offset)` for every diagnostic, in source order.
+fn codes_at(source: &str) -> Vec<(u32, u32)> {
+    let mut found: Vec<(u32, u32)> = check_source_diagnostics(source)
+        .iter()
+        .map(|diag| (diag.code, diag.start))
+        .collect();
+    found.sort_unstable();
+    found
+}
+
+/// Byte offset of the `nth` (0-based) occurrence of `needle`.
+fn offset_of(source: &str, needle: &str, nth: usize) -> u32 {
+    let mut from = 0usize;
+    for _ in 0..nth {
+        let at = source[from..]
+            .find(needle)
+            .expect("fewer occurrences than requested");
+        from += at + needle.len();
     }
+    let at = source[from..].find(needle).expect("needle not found");
+    u32::try_from(from + at).expect("offset fits in u32")
+}
 
-    /// Byte offset of the `nth` (0-based) occurrence of `needle`.
-    fn offset_of(source: &str, needle: &str, nth: usize) -> u32 {
-        let mut from = 0usize;
-        for _ in 0..nth {
-            let at = source[from..]
-                .find(needle)
-                .expect("fewer occurrences than requested");
-            from += at + needle.len();
-        }
-        let at = source[from..].find(needle).expect("needle not found");
-        u32::try_from(from + at).expect("offset fits in u32")
-    }
+fn expect_only(source: &str, code: u32, needle: &str) {
+    let expected = vec![(code, offset_of(source, needle, 0))];
+    assert_eq!(
+        codes_at(source),
+        expected,
+        "unexpected diagnostics for: {source}"
+    );
+}
 
-    fn expect_only(source: &str, code: u32, needle: &str) {
-        let expected = vec![(code, offset_of(source, needle, 0))];
-        assert_eq!(
-            codes_at(source),
-            expected,
-            "unexpected diagnostics for: {source}"
-        );
-    }
+fn expect_clean(source: &str) {
+    assert_eq!(
+        codes_at(source),
+        Vec::new(),
+        "expected no diagnostics for: {source}"
+    );
+}
 
-    fn expect_clean(source: &str) {
-        assert_eq!(
-            codes_at(source),
-            Vec::new(),
-            "expected no diagnostics for: {source}"
-        );
-    }
+// ---------------------------------------------------------------------
+// TS1014 — a rest parameter must be last
+// ---------------------------------------------------------------------
 
-    // ---------------------------------------------------------------------
-    // TS1014 — a rest parameter must be last
-    // ---------------------------------------------------------------------
+#[test]
+fn function_type_alias_reports_rest_not_last() {
+    expect_only("type F = (...a: number[], b: string) => void;", 1014, "...");
+}
 
-    #[test]
-    fn function_type_alias_reports_rest_not_last() {
-        expect_only("type F = (...a: number[], b: string) => void;", 1014, "...");
-    }
+#[test]
+fn inline_function_type_annotation_reports_rest_not_last() {
+    expect_only(
+        "declare let f: (...a: number[], b: string) => void;",
+        1014,
+        "...",
+    );
+}
 
-    #[test]
-    fn inline_function_type_annotation_reports_rest_not_last() {
-        expect_only(
-            "declare let f: (...a: number[], b: string) => void;",
-            1014,
-            "...",
-        );
-    }
+#[test]
+fn generic_function_type_reports_rest_not_last() {
+    expect_only("type F = <T>(...a: T[], b: T) => void;", 1014, "...");
+}
 
-    #[test]
-    fn generic_function_type_reports_rest_not_last() {
-        expect_only("type F = <T>(...a: T[], b: T) => void;", 1014, "...");
-    }
+#[test]
+fn constructor_type_reports_rest_not_last() {
+    expect_only(
+        "type C = new (...a: number[], b: string) => object;",
+        1014,
+        "...",
+    );
+}
 
-    #[test]
-    fn constructor_type_reports_rest_not_last() {
-        expect_only(
-            "type C = new (...a: number[], b: string) => object;",
-            1014,
-            "...",
-        );
-    }
+#[test]
+fn abstract_constructor_type_reports_rest_not_last() {
+    expect_only(
+        "type C = abstract new (...a: number[], b: string) => object;",
+        1014,
+        "...",
+    );
+}
 
-    #[test]
-    fn abstract_constructor_type_reports_rest_not_last() {
-        expect_only(
-            "type C = abstract new (...a: number[], b: string) => object;",
-            1014,
-            "...",
-        );
-    }
+#[test]
+fn function_type_as_a_parameter_annotation_reports_rest_not_last() {
+    expect_only(
+        "declare function use(cb: (...a: number[], b: string) => void): void;",
+        1014,
+        "...",
+    );
+}
 
-    #[test]
-    fn function_type_as_a_parameter_annotation_reports_rest_not_last() {
-        expect_only(
-            "declare function use(cb: (...a: number[], b: string) => void): void;",
-            1014,
-            "...",
-        );
-    }
+#[test]
+fn function_type_inside_a_union_reports_rest_not_last() {
+    expect_only(
+        "type F = ((...a: number[], b: string) => void) | string;",
+        1014,
+        "...",
+    );
+}
 
-    #[test]
-    fn function_type_inside_a_union_reports_rest_not_last() {
-        expect_only(
-            "type F = ((...a: number[], b: string) => void) | string;",
-            1014,
-            "...",
-        );
-    }
+#[test]
+fn function_type_as_an_interface_property_reports_rest_not_last() {
+    expect_only(
+        "interface I { f: (...a: number[], b: string) => void }",
+        1014,
+        "...",
+    );
+}
 
-    #[test]
-    fn function_type_as_an_interface_property_reports_rest_not_last() {
-        expect_only(
-            "interface I { f: (...a: number[], b: string) => void }",
-            1014,
-            "...",
-        );
-    }
+// ---------------------------------------------------------------------
+// TS1016 — a required parameter cannot follow an optional one
+// ---------------------------------------------------------------------
 
-    // ---------------------------------------------------------------------
-    // TS1016 — a required parameter cannot follow an optional one
-    // ---------------------------------------------------------------------
+#[test]
+fn function_type_alias_reports_required_after_optional() {
+    expect_only("type F = (a?: number, b: string) => void;", 1016, "b:");
+}
 
-    #[test]
-    fn function_type_alias_reports_required_after_optional() {
-        expect_only("type F = (a?: number, b: string) => void;", 1016, "b:");
-    }
+#[test]
+fn inline_function_type_annotation_reports_required_after_optional() {
+    expect_only(
+        "declare let f: (a?: number, b: string) => void;",
+        1016,
+        "b:",
+    );
+}
 
-    #[test]
-    fn inline_function_type_annotation_reports_required_after_optional() {
-        expect_only(
-            "declare let f: (a?: number, b: string) => void;",
-            1016,
-            "b:",
-        );
-    }
+#[test]
+fn generic_function_type_reports_required_after_optional() {
+    expect_only("type F = <T>(a?: T, b: T) => void;", 1016, "b:");
+}
 
-    #[test]
-    fn generic_function_type_reports_required_after_optional() {
-        expect_only("type F = <T>(a?: T, b: T) => void;", 1016, "b:");
-    }
+#[test]
+fn constructor_type_reports_required_after_optional() {
+    expect_only(
+        "type C = new (a?: number, b: string) => object;",
+        1016,
+        "b:",
+    );
+}
 
-    #[test]
-    fn constructor_type_reports_required_after_optional() {
-        expect_only(
-            "type C = new (a?: number, b: string) => object;",
-            1016,
-            "b:",
-        );
-    }
+#[test]
+fn abstract_constructor_type_reports_required_after_optional() {
+    expect_only(
+        "type C = abstract new (a?: number, b: string) => object;",
+        1016,
+        "b:",
+    );
+}
 
-    #[test]
-    fn abstract_constructor_type_reports_required_after_optional() {
-        expect_only(
-            "type C = abstract new (a?: number, b: string) => object;",
-            1016,
-            "b:",
-        );
-    }
+#[test]
+fn function_type_as_an_object_type_member_reports_required_after_optional() {
+    expect_only(
+        "type T = { f: (a?: number, b: string) => void };",
+        1016,
+        "b:",
+    );
+}
 
-    #[test]
-    fn function_type_as_an_object_type_member_reports_required_after_optional() {
-        expect_only(
-            "type T = { f: (a?: number, b: string) => void };",
-            1016,
-            "b:",
-        );
-    }
+#[test]
+fn function_type_in_an_array_type_reports_required_after_optional() {
+    expect_only("type F = ((a?: number, b: string) => void)[];", 1016, "b:");
+}
 
-    #[test]
-    fn function_type_in_an_array_type_reports_required_after_optional() {
-        expect_only("type F = ((a?: number, b: string) => void)[];", 1016, "b:");
-    }
+// ---------------------------------------------------------------------
+// TS1015 — `?` together with an initializer
+// ---------------------------------------------------------------------
 
-    // ---------------------------------------------------------------------
-    // TS1015 — `?` together with an initializer
-    // ---------------------------------------------------------------------
+#[test]
+fn function_type_reports_question_mark_with_initializer_alongside_ts2371() {
+    // tsc reports TS1015 and TS2371 at the same anchor: the grammar arm and
+    // the "initializer only in an implementation" rule are independent.
+    let source = "type F = (a?: number = 1) => void;";
+    let anchor = offset_of(source, "a?", 0);
+    assert_eq!(codes_at(source), vec![(1015, anchor), (2371, anchor)]);
+}
 
-    #[test]
-    fn function_type_reports_question_mark_with_initializer_alongside_ts2371() {
-        // tsc reports TS1015 and TS2371 at the same anchor: the grammar arm and
-        // the "initializer only in an implementation" rule are independent.
-        let source = "type F = (a?: number = 1) => void;";
-        let anchor = offset_of(source, "a?", 0);
-        assert_eq!(codes_at(source), vec![(1015, anchor), (2371, anchor)]);
-    }
+// ---------------------------------------------------------------------
+// tsc reports at most ONE diagnostic per parameter list
+// ---------------------------------------------------------------------
 
-    // ---------------------------------------------------------------------
-    // tsc reports at most ONE diagnostic per parameter list
-    // ---------------------------------------------------------------------
+#[test]
+fn a_misplaced_rest_wins_over_a_later_required_after_optional() {
+    // `checkGrammarParameterList` returns at the first failing parameter,
+    // so the trailing `b?`/`c` pair never reaches the TS1016 arm.
+    expect_only(
+        "type F = (...a: number[], b?: string, c: string) => void;",
+        1014,
+        "...",
+    );
+}
 
-    #[test]
-    fn a_misplaced_rest_wins_over_a_later_required_after_optional() {
-        // `checkGrammarParameterList` returns at the first failing parameter,
-        // so the trailing `b?`/`c` pair never reaches the TS1016 arm.
-        expect_only(
-            "type F = (...a: number[], b?: string, c: string) => void;",
-            1014,
-            "...",
-        );
-    }
+#[test]
+fn only_the_first_required_after_optional_is_reported() {
+    expect_only(
+        "type F = (a?: number, b: string, c: string) => void;",
+        1016,
+        "b:",
+    );
+}
 
-    #[test]
-    fn only_the_first_required_after_optional_is_reported() {
-        expect_only(
-            "type F = (a?: number, b: string, c: string) => void;",
-            1016,
-            "b:",
-        );
-    }
+// ---------------------------------------------------------------------
+// Negative controls
+// ---------------------------------------------------------------------
 
-    // ---------------------------------------------------------------------
-    // Negative controls
-    // ---------------------------------------------------------------------
+#[test]
+fn optional_after_required_is_clean() {
+    expect_clean("type F = (a: number, b?: string) => void;");
+}
 
-    #[test]
-    fn optional_after_required_is_clean() {
-        expect_clean("type F = (a: number, b?: string) => void;");
-    }
+#[test]
+fn a_trailing_rest_after_an_optional_is_clean() {
+    expect_clean("type F = (a?: number, ...rest: string[]) => void;");
+}
 
-    #[test]
-    fn a_trailing_rest_after_an_optional_is_clean() {
-        expect_clean("type F = (a?: number, ...rest: string[]) => void;");
-    }
+#[test]
+fn an_initialized_parameter_does_not_make_the_next_one_required_after_optional() {
+    // tsc's `isOptionalParameter` compares the index against the minimum
+    // argument count, so a leading `a = 1` is not optional here.
+    expect_clean("function f(a = 1, b: number) {}");
+}
 
-    #[test]
-    fn an_initialized_parameter_does_not_make_the_next_one_required_after_optional() {
-        // tsc's `isOptionalParameter` compares the index against the minimum
-        // argument count, so a leading `a = 1` is not optional here.
-        expect_clean("function f(a = 1, b: number) {}");
-    }
+#[test]
+fn a_parameter_with_an_initializer_is_not_required_after_an_optional_one() {
+    // Only TS2371 survives — the initializer keeps `b` out of the TS1016
+    // arm, exactly as in tsc.
+    let source = "type F = (a?: number, b = 1) => void;";
+    assert_eq!(codes_at(source), vec![(2371, offset_of(source, "b =", 0))]);
+}
 
-    #[test]
-    fn a_parameter_with_an_initializer_is_not_required_after_an_optional_one() {
-        // Only TS2371 survives — the initializer keeps `b` out of the TS1016
-        // arm, exactly as in tsc.
-        let source = "type F = (a?: number, b = 1) => void;";
-        assert_eq!(codes_at(source), vec![(2371, offset_of(source, "b =", 0))]);
-    }
+#[test]
+fn binding_pattern_parameters_are_clean() {
+    expect_clean("type F = ({ a }: { a: number }, c?: string) => void;");
+}
 
-    #[test]
-    fn binding_pattern_parameters_are_clean() {
-        expect_clean("type F = ({ a }: { a: number }, c?: string) => void;");
-    }
+#[test]
+fn a_this_parameter_before_the_optional_run_is_clean() {
+    expect_clean("type F = (this: object, a: number, b?: string) => void;");
+}
 
-    #[test]
-    fn a_this_parameter_before_the_optional_run_is_clean() {
-        expect_clean("type F = (this: object, a: number, b?: string) => void;");
-    }
+#[test]
+fn an_empty_parameter_list_is_clean() {
+    expect_clean("type F = () => void;");
+}
 
-    #[test]
-    fn an_empty_parameter_list_is_clean() {
-        expect_clean("type F = () => void;");
-    }
+// ---------------------------------------------------------------------
+// One diagnostic per written signature, not per use
+// ---------------------------------------------------------------------
 
-    // ---------------------------------------------------------------------
-    // One diagnostic per written signature, not per use
-    // ---------------------------------------------------------------------
+#[test]
+fn a_reused_alias_reports_its_signature_once() {
+    let source = concat!(
+        "type Bad = (...a: number[], b: string) => void;\n",
+        "declare const x1: Bad;\n",
+        "declare const x2: Bad;\n"
+    );
+    assert_eq!(codes_at(source), vec![(1014, offset_of(source, "...", 0))]);
+}
 
-    #[test]
-    fn a_reused_alias_reports_its_signature_once() {
-        let source = concat!(
-            "type Bad = (...a: number[], b: string) => void;\n",
-            "declare const x1: Bad;\n",
-            "declare const x2: Bad;\n"
-        );
-        assert_eq!(codes_at(source), vec![(1014, offset_of(source, "...", 0))]);
-    }
-
-    #[test]
-    fn a_generic_alias_instantiated_twice_reports_its_signature_once() {
-        let source = concat!(
-            "type G<T> = (a?: T, b: T) => void;\n",
-            "declare const g1: G<number>;\n",
-            "declare const g2: G<string>;\n"
-        );
-        assert_eq!(codes_at(source), vec![(1016, offset_of(source, "b:", 0))]);
-    }
+#[test]
+fn a_generic_alias_instantiated_twice_reports_its_signature_once() {
+    let source = concat!(
+        "type G<T> = (a?: T, b: T) => void;\n",
+        "declare const g1: G<number>;\n",
+        "declare const g2: G<string>;\n"
+    );
+    assert_eq!(codes_at(source), vec![(1016, offset_of(source, "b:", 0))]);
 }


### PR DESCRIPTION
`crates/tsz-checker/src/test_module_registry.rs` already declares this file as a test module via `#[path]`:

```rust
#[path = "tests/function_type_parameter_grammar_tests.rs"]
mod function_type_parameter_grammar_tests;
```

The file itself, introduced by #16643, additionally wraps its entire body in a same-named `mod function_type_parameter_grammar_tests { ... }`. `clippy::module_inception` (part of `-D clippy::style`, which this repo denies) rejects that as a hard compile error:

```
error: module has the same name as its containing module
 --> crates/tsz-checker/src/tests/function_type_parameter_grammar_tests.rs:14:1
   = note: `-D clippy::module-inception` implied by `-D clippy::style`
```

This is a **required-check blocker on current `main`** — every PR built on top of #16643 fails `clippy`. I hit it first as an apparently-unrelated CI failure on my own #16670 (already merged); it reproduces identically on a clean `main` checkout, confirming it predates and is unrelated to that diff.

**Structural rule.** No sibling file in `crates/tsz-checker/src/tests/` nests a same-named `mod { ... }` wrapper — they all rely on the registry's `#[path]` declaration alone for the module name (e.g. `computed_key_missing_property_primary_code_tests.rs`, `parameter_checker_tests.rs` — which nests a *differently*-named inner module for scoping, not an inception). This file is the one outlier. Owner: test-only, no `crates/**/src` production path touched.

## Fix

Dedent the file: drop the `#[cfg(test)] mod function_type_parameter_grammar_tests {` opening and its matching closing `}`, un-indent the body one level. The registry module already carries `#[cfg(test)]` at its own declaration site (see that file's own doc comment), so the per-file `#[cfg(test)]` was redundant too. Zero behavior change — the same 27 tests exist, now addressed as `test_module_registry::function_type_parameter_grammar_tests::*` instead of a doubly-nested path.

## Goal
Goal: hold

## Verification
- `cargo clippy -p tsz-checker --lib --tests -- -D warnings`: clean (reproduced the failure on unmodified `main` first, then confirmed clean after the fix).
- `cargo test -p tsz-checker --lib -- function_type_parameter_grammar_tests`: 27/27 pass, 0 failed — same test count and names as before, now unnested.
- `cargo fmt --check -p tsz-checker`: clean.
- Pre-commit hook (clippy `-D warnings` + arch-size guard + affected-crate tests) passed clean at commit `00d453a`.
- Test-only diff, no `crates/**/src` production path touched — conformance and emit counts cannot move; no corpus gate owed.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_017VbuG5G2ggJZvHxDX4yRvn)_