### PR TITLE
fix(checker): parameter decorators outside a class member are TS1206 in both decorator modes

### DIFF
--- a/crates/tsz-checker/src/checkers/parameter_checker.rs
+++ b/crates/tsz-checker/src/checkers/parameter_checker.rs
@@ -967,16 +967,130 @@ impl<'a> CheckerState<'a> {
             // it's a parameter property which is only allowed in constructors.
             // Decorators on parameters are NOT parameter properties.
             // tsc reports the error at the modifier keyword, not the parameter name.
-            if let Some(modifier_idx) =
-                self.find_first_parameter_property_modifier(&param.modifiers)
-            {
+            let property_modifier = self.find_first_parameter_property_modifier(&param.modifiers);
+            let first_decorator = self.first_parameter_decorator(&param.modifiers);
+            // `param`'s borrow of the arena ends here; the reporting below
+            // needs `&mut self`.
+            if let Some(modifier_idx) = property_modifier {
                 self.error_at_node(
                     modifier_idx,
                     "A parameter property is only allowed in a constructor implementation.",
                     diagnostic_codes::A_PARAMETER_PROPERTY_IS_ONLY_ALLOWED_IN_A_CONSTRUCTOR_IMPLEMENTATION,
                 );
             }
+            self.report_invalid_parameter_decorator(param_idx, first_decorator);
         }
+    }
+
+    /// TS1206 for parameter decorators, for callers that do not already iterate
+    /// the parameter list. `check_parameter_properties` inlines the same check
+    /// (reusing its parameter walk); a constructor *implementation* skips that
+    /// call — parameter properties are legal there — so it calls this directly.
+    pub(crate) fn check_parameter_decorator_grammar(&mut self, parameters: &[NodeIndex]) {
+        for &param_idx in parameters {
+            let Some(param_node) = self.ctx.arena.get(param_idx) else {
+                continue;
+            };
+            let Some(param) = self.ctx.arena.get_parameter(param_node) else {
+                continue;
+            };
+            let first_decorator = self.first_parameter_decorator(&param.modifiers);
+            self.report_invalid_parameter_decorator(param_idx, first_decorator);
+        }
+    }
+
+    /// Emit TS1206 when a parameter's (first) decorator sits in a position
+    /// TypeScript never accepts. A parameter decorator is legal only on a class
+    /// constructor/method/set-accessor parameter under `experimentalDecorators`;
+    /// every other function-like parameter — plain functions, function/arrow
+    /// expressions, object-literal methods, interface/type-literal method and
+    /// call/construct signatures — rejects it in both decorator modes. tsc
+    /// reports once per parameter (at its first decorator) and leaves valid
+    /// positions to the class-member decorator path, which owns the decorator's
+    /// semantic checks (TS1239 and friends).
+    ///
+    /// A decorator on a `this` parameter is the exception: tsc reports the
+    /// dedicated TS1433 ("Neither decorators nor modifiers may be applied to
+    /// 'this' parameters.") and suppresses the generic TS1206, so this leaves
+    /// `this` parameters to that check.
+    fn report_invalid_parameter_decorator(
+        &mut self,
+        param_idx: NodeIndex,
+        first_decorator: Option<NodeIndex>,
+    ) {
+        let Some(decorator_idx) = first_decorator else {
+            return;
+        };
+        let is_this_parameter = self
+            .ctx
+            .arena
+            .get(param_idx)
+            .and_then(|param_node| self.ctx.arena.get_parameter(param_node))
+            .is_some_and(|param| self.is_this_parameter_name(param.name));
+        if is_this_parameter {
+            return;
+        }
+        if !self.is_valid_parameter_decorator_position(param_idx) {
+            self.error_at_node(
+                decorator_idx,
+                "Decorators are not valid here.",
+                crate::diagnostics::diagnostic_codes::DECORATORS_ARE_NOT_VALID_HERE,
+            );
+        }
+    }
+
+    /// The `NodeIndex` of the first decorator modifier on a parameter, if any.
+    pub(crate) fn first_parameter_decorator(
+        &self,
+        modifiers: &Option<tsz_parser::parser::NodeList>,
+    ) -> Option<NodeIndex> {
+        use tsz_parser::parser::syntax_kind_ext;
+        let modifiers = modifiers.as_ref()?;
+        modifiers.nodes.iter().copied().find(|&idx| {
+            self.ctx
+                .arena
+                .get(idx)
+                .is_some_and(|n| n.kind == syntax_kind_ext::DECORATOR)
+        })
+    }
+
+    /// Whether a decorator on `param_idx` sits in a position TypeScript accepts:
+    /// under `experimentalDecorators`, and belonging to a class constructor,
+    /// method, or set accessor. The immediate-parent-is-a-class test is what
+    /// separates a real class member from an object-literal method, which shares
+    /// the `MethodDeclaration` node kind but never accepts a parameter decorator.
+    /// Get accessors are excluded — they take no parameters, and tsc rejects a
+    /// decorator on their (already illegal) parameter.
+    fn is_valid_parameter_decorator_position(&self, param_idx: NodeIndex) -> bool {
+        use tsz_parser::parser::syntax_kind_ext;
+
+        if !self.ctx.compiler_options.experimental_decorators {
+            return false;
+        }
+
+        let Some(container_idx) = self.enclosing_function_like_for_parameter(param_idx) else {
+            return false;
+        };
+        let Some(container) = self.ctx.arena.get(container_idx) else {
+            return false;
+        };
+        if !matches!(
+            container.kind,
+            syntax_kind_ext::METHOD_DECLARATION
+                | syntax_kind_ext::CONSTRUCTOR
+                | syntax_kind_ext::SET_ACCESSOR
+        ) {
+            return false;
+        }
+
+        self.ctx
+            .arena
+            .get_extended(container_idx)
+            .and_then(|ext| self.ctx.arena.get(ext.parent))
+            .is_some_and(|parent| {
+                parent.kind == syntax_kind_ext::CLASS_DECLARATION
+                    || parent.kind == syntax_kind_ext::CLASS_EXPRESSION
+            })
     }
 
     /// Find the first parameter property modifier in a modifier list.

--- a/crates/tsz-checker/src/state/state_checking_members/ambient_constructor_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_constructor_checks.rs
@@ -85,6 +85,13 @@ impl<'a> CheckerState<'a> {
         // This applies to both regular constructors and ambient (declare class) constructors.
         if ctor.body.is_none() {
             self.check_parameter_properties(&ctor.parameters.nodes);
+        } else {
+            // A constructor implementation skips `check_parameter_properties`
+            // (parameter properties are legal here), but a parameter *decorator*
+            // is still only valid under `experimentalDecorators`, so run the
+            // universal TS1206 gate directly. Body-less constructors already got
+            // it through `check_parameter_properties` above.
+            self.check_parameter_decorator_grammar(&ctor.parameters.nodes);
         }
         // TS1294: erasableSyntaxOnly — parameter properties are not erasable.
         if self.ctx.compiler_options.erasable_syntax_only {

--- a/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
@@ -1565,26 +1565,34 @@ impl<'a> CheckerState<'a> {
                 _ => false,
             };
 
-            // Also need to check constructor parameter decorators
-            let has_param_decorator = match node.kind {
-                k if k == syntax_kind_ext::METHOD_DECLARATION => self
-                    .ctx
-                    .arena
-                    .get_method_decl(node)
-                    .is_some_and(|d| self.any_parameter_has_decorator(&d.parameters.nodes)),
-                k if k == syntax_kind_ext::GET_ACCESSOR || k == syntax_kind_ext::SET_ACCESSOR => {
-                    self.ctx
+            // Parameter decorators only have semantic work here under
+            // `experimentalDecorators` (the valid-position path); without it,
+            // the parameter loop bails immediately and TS1206 is owned by
+            // `check_parameter_properties`. So a member whose *only* decorators
+            // are on its parameters need not enter this function at all in the
+            // standard-decorator mode.
+            let has_param_decorator = self.ctx.compiler_options.experimental_decorators
+                && match node.kind {
+                    k if k == syntax_kind_ext::METHOD_DECLARATION => self
+                        .ctx
                         .arena
-                        .get_accessor(node)
-                        .is_some_and(|d| self.any_parameter_has_decorator(&d.parameters.nodes))
-                }
-                k if k == syntax_kind_ext::CONSTRUCTOR => self
-                    .ctx
-                    .arena
-                    .get_constructor(node)
-                    .is_some_and(|d| self.any_parameter_has_decorator(&d.parameters.nodes)),
-                _ => false,
-            };
+                        .get_method_decl(node)
+                        .is_some_and(|d| self.any_parameter_has_decorator(&d.parameters.nodes)),
+                    k if k == syntax_kind_ext::GET_ACCESSOR
+                        || k == syntax_kind_ext::SET_ACCESSOR =>
+                    {
+                        self.ctx
+                            .arena
+                            .get_accessor(node)
+                            .is_some_and(|d| self.any_parameter_has_decorator(&d.parameters.nodes))
+                    }
+                    k if k == syntax_kind_ext::CONSTRUCTOR => self
+                        .ctx
+                        .arena
+                        .get_constructor(node)
+                        .is_some_and(|d| self.any_parameter_has_decorator(&d.parameters.nodes)),
+                    _ => false,
+                };
 
             if !has_any_decorator && !has_param_decorator {
                 return;
@@ -1810,13 +1818,16 @@ impl<'a> CheckerState<'a> {
                             continue;
                         }
 
+                        // Without `experimentalDecorators` a class-member
+                        // parameter decorator is an invalid position. TS1206 is
+                        // owned by `check_parameter_properties` (the single,
+                        // universal parameter-decorator grammar gate), which
+                        // reports it once per parameter. tsc emits nothing else
+                        // for an invalidly-placed decorator — in particular it
+                        // does not resolve the decorator expression — so skip
+                        // the semantic checks below to avoid a spurious TS2304.
                         if !self.ctx.compiler_options.experimental_decorators {
-                            use crate::diagnostics::diagnostic_codes;
-                            self.error_at_node(
-                                modifier_idx,
-                                "Decorators are not valid here.",
-                                diagnostic_codes::DECORATORS_ARE_NOT_VALID_HERE,
-                            );
+                            continue;
                         }
 
                         if let Some(decorator) = self.ctx.arena.get_decorator(modifier_node) {
@@ -1838,22 +1849,20 @@ impl<'a> CheckerState<'a> {
                             // `key`; for method/accessor parameters tsc passes a
                             // string (the method name). Decorators whose `key`
                             // parameter type disagrees with the position are
-                            // rejected with TS1239. Only check under
-                            // `experimentalDecorators` since stage-3 decorators
-                            // (which use a different runtime ABI) are not yet a
-                            // supported configuration.
-                            if self.ctx.compiler_options.experimental_decorators {
-                                let is_constructor_parameter =
-                                    node.kind == syntax_kind_ext::CONSTRUCTOR;
-                                let actual_this_type = self
-                                    .call_site_receiver_type(decorator_type, decorator.expression);
-                                self.check_parameter_decorator_call_signature(
-                                    modifier_idx,
-                                    decorator_type,
-                                    is_constructor_parameter,
-                                    actual_this_type,
-                                );
-                            }
+                            // rejected with TS1239. Reached only under
+                            // `experimentalDecorators` (the early `continue`
+                            // above), the sole configuration where a parameter
+                            // decorator is a valid, semantically-checked target.
+                            let is_constructor_parameter =
+                                node.kind == syntax_kind_ext::CONSTRUCTOR;
+                            let actual_this_type =
+                                self.call_site_receiver_type(decorator_type, decorator.expression);
+                            self.check_parameter_decorator_call_signature(
+                                modifier_idx,
+                                decorator_type,
+                                is_constructor_parameter,
+                                actual_this_type,
+                            );
                         }
                     }
                 }
@@ -1863,26 +1872,12 @@ impl<'a> CheckerState<'a> {
 
     /// Quick scan to check if any parameter in a parameter list has a decorator modifier.
     fn any_parameter_has_decorator(&self, params: &[NodeIndex]) -> bool {
-        for &param_idx in params {
-            let Some(param_node) = self.ctx.arena.get(param_idx) else {
-                continue;
-            };
-            let Some(param) = self.ctx.arena.get_parameter(param_node) else {
-                continue;
-            };
-            if let Some(ref mods) = param.modifiers {
-                for &mod_idx in &mods.nodes {
-                    if self
-                        .ctx
-                        .arena
-                        .get(mod_idx)
-                        .is_some_and(|n| n.kind == syntax_kind_ext::DECORATOR)
-                    {
-                        return true;
-                    }
-                }
-            }
-        }
-        false
+        params.iter().any(|&param_idx| {
+            self.ctx
+                .arena
+                .get(param_idx)
+                .and_then(|param_node| self.ctx.arena.get_parameter(param_node))
+                .is_some_and(|param| self.first_parameter_decorator(&param.modifiers).is_some())
+        })
     }
 }

--- a/crates/tsz-checker/src/tests/parameter_checker_tests.rs
+++ b/crates/tsz-checker/src/tests/parameter_checker_tests.rs
@@ -469,3 +469,200 @@ mod jsdoc_diagnostic_integration_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod parameter_decorator_grammar_tests {
+    //! TS1206 for parameter decorators.
+    //!
+    //! Structural rule: a parameter decorator is legal only on a class
+    //! constructor/method/set-accessor parameter, and only under
+    //! `experimentalDecorators`. Every other function-like parameter position
+    //! rejects it with TS1206 in both decorator modes. tsc reports it once per
+    //! parameter (at the first decorator) and does not otherwise resolve the
+    //! decorator expression of an invalidly-placed decorator.
+    use crate::test_utils::{check_source_codes, check_source_codes_experimental_decorators};
+
+    const DEC: &str = "declare function dec(...a: any[]): any;\n";
+
+    fn count(codes: &[u32], code: u32) -> usize {
+        codes.iter().filter(|&&c| c == code).count()
+    }
+
+    // --- Non-class function-like positions: TS1206 in both modes (false-negative fix) ---
+
+    #[test]
+    fn function_declaration_parameter_decorator_is_ts1206() {
+        let src = format!("{DEC}function f(@dec a: number) {{}}");
+        assert_eq!(count(&check_source_codes(&src), 1206), 1);
+        assert_eq!(
+            count(&check_source_codes_experimental_decorators(&src), 1206),
+            1
+        );
+    }
+
+    #[test]
+    fn function_expression_parameter_decorator_is_ts1206() {
+        let src = format!("{DEC}const h = function (@dec a: number) {{}};");
+        assert_eq!(count(&check_source_codes(&src), 1206), 1);
+    }
+
+    #[test]
+    fn object_literal_method_parameter_decorator_is_ts1206() {
+        // Shares the MethodDeclaration node kind with a class method, but its
+        // parent is an object literal, so it is never a valid decorator target.
+        let src = format!("{DEC}const o = {{ m(@dec a: number) {{}} }};");
+        assert_eq!(count(&check_source_codes(&src), 1206), 1);
+        assert_eq!(
+            count(&check_source_codes_experimental_decorators(&src), 1206),
+            1
+        );
+    }
+
+    #[test]
+    fn object_literal_setter_parameter_decorator_is_ts1206() {
+        let src = format!("{DEC}const o = {{ set y(@dec v: number) {{}} }};");
+        assert_eq!(count(&check_source_codes(&src), 1206), 1);
+    }
+
+    #[test]
+    fn interface_method_signature_parameter_decorator_is_ts1206() {
+        let src = format!("{DEC}interface I {{ m(@dec a: number): void; }}");
+        assert_eq!(count(&check_source_codes(&src), 1206), 1);
+    }
+
+    #[test]
+    fn call_signature_parameter_decorator_is_ts1206() {
+        let src = format!("{DEC}interface I {{ (@dec a: number): void; }}");
+        assert_eq!(count(&check_source_codes(&src), 1206), 1);
+    }
+
+    #[test]
+    fn construct_signature_parameter_decorator_is_ts1206() {
+        let src = format!("{DEC}interface I {{ new (@dec a: number): void; }}");
+        assert_eq!(count(&check_source_codes(&src), 1206), 1);
+    }
+
+    #[test]
+    fn type_literal_method_parameter_decorator_is_ts1206() {
+        let src = format!("{DEC}type T = {{ m(@dec a: number): void }};");
+        assert_eq!(count(&check_source_codes(&src), 1206), 1);
+    }
+
+    #[test]
+    fn function_nested_in_class_method_parameter_decorator_is_ts1206() {
+        // The container is the inner function, not the enclosing class method,
+        // so nearest-enclosing-class is not enough — the immediate parent must
+        // be a class. The inner function's parent is a block.
+        let src = format!("{DEC}class C {{ m() {{ function g(@dec a: number) {{}} }} }}");
+        assert_eq!(count(&check_source_codes(&src), 1206), 1);
+        assert_eq!(
+            count(&check_source_codes_experimental_decorators(&src), 1206),
+            1
+        );
+    }
+
+    // --- Class-member positions: TS1206 only when experimentalDecorators is off ---
+
+    #[test]
+    fn class_method_parameter_decorator_ts1206_without_experimental() {
+        let src = format!("{DEC}class C {{ m(@dec a: number) {{}} }}");
+        assert_eq!(count(&check_source_codes(&src), 1206), 1);
+        assert_eq!(
+            count(&check_source_codes_experimental_decorators(&src), 1206),
+            0
+        );
+    }
+
+    #[test]
+    fn class_constructor_parameter_decorator_ts1206_without_experimental() {
+        // A constructor implementation skips check_parameter_properties, so this
+        // pins the direct decorator-grammar call on the bodied-constructor path.
+        let src = format!("{DEC}class C {{ constructor(@dec a: number) {{}} }}");
+        assert_eq!(count(&check_source_codes(&src), 1206), 1);
+        assert_eq!(
+            count(&check_source_codes_experimental_decorators(&src), 1206),
+            0
+        );
+    }
+
+    #[test]
+    fn class_setter_parameter_decorator_ts1206_without_experimental() {
+        let src = format!("{DEC}class C {{ set x(@dec v: number) {{}} }}");
+        assert_eq!(count(&check_source_codes(&src), 1206), 1);
+        assert_eq!(
+            count(&check_source_codes_experimental_decorators(&src), 1206),
+            0
+        );
+    }
+
+    #[test]
+    fn class_getter_parameter_decorator_is_ts1206_even_with_experimental() {
+        // A getter cannot carry a parameter (TS1054), and tsc rejects a
+        // decorator on that illegal parameter too — a get accessor is never a
+        // valid parameter-decorator target, so TS1206 fires in both modes.
+        let src = format!("{DEC}class C {{ get x(@dec a: number) {{ return 1; }} }}");
+        assert_eq!(count(&check_source_codes(&src), 1206), 1);
+        assert_eq!(
+            count(&check_source_codes_experimental_decorators(&src), 1206),
+            1
+        );
+    }
+
+    // --- Multiplicity: one TS1206 per parameter, not per decorator ---
+
+    #[test]
+    fn multiple_decorators_on_one_parameter_report_once() {
+        let src = format!("{DEC}function f(@dec @dec a: number) {{}}");
+        assert_eq!(count(&check_source_codes(&src), 1206), 1);
+    }
+
+    #[test]
+    fn class_method_multiple_decorators_on_one_parameter_report_once() {
+        let src = format!("{DEC}class C {{ m(@dec @dec a: number) {{}} }}");
+        assert_eq!(count(&check_source_codes(&src), 1206), 1);
+    }
+
+    #[test]
+    fn each_decorated_parameter_reports_its_own_ts1206() {
+        let src = format!("{DEC}function f(@dec a: number, @dec b: number) {{}}");
+        assert_eq!(count(&check_source_codes(&src), 1206), 2);
+    }
+
+    // --- No spurious semantic checking of an invalidly-placed decorator ---
+
+    #[test]
+    fn invalid_class_parameter_decorator_does_not_resolve_expression() {
+        // Standard mode: TS1206 fires for the invalid position and the
+        // (undefined) decorator expression is not resolved, so there is no
+        // cascaded TS2304. With experimentalDecorators the position becomes
+        // valid and TS1206 disappears.
+        let src = "class C { m(@nope a: number) {} }";
+        let std = check_source_codes(src);
+        assert_eq!(count(&std, 1206), 1);
+        assert_eq!(count(&std, 2304), 0);
+
+        let exp = check_source_codes_experimental_decorators(src);
+        assert_eq!(count(&exp, 1206), 0);
+    }
+
+    #[test]
+    fn invalid_function_parameter_decorator_does_not_resolve_expression() {
+        let src = "function f(@nope a: number) {}";
+        let codes = check_source_codes(src);
+        assert_eq!(count(&codes, 1206), 1);
+        assert_eq!(count(&codes, 2304), 0);
+    }
+
+    #[test]
+    fn this_parameter_decorator_is_not_ts1206() {
+        // A decorator on a `this` parameter is owned by TS1433 ("Neither
+        // decorators nor modifiers may be applied to 'this' parameters."), which
+        // tsc reports *instead of* the generic TS1206. The end-to-end TS1433
+        // emission is covered by the conformance suite
+        // (`decoratorOnFunctionParameter.ts`); here we pin the suppression this
+        // fix owns: the generic TS1206 must not fire on a `this` parameter.
+        let src =
+            format!("{DEC}class C {{ n = true; }}\nfunction f(@dec this: C) {{ return this.n; }}");
+        assert_eq!(count(&check_source_codes(&src), 1206), 0);
+    }
+}


### PR DESCRIPTION
When a `@decorator` sits on a function parameter, `tsc` accepts it in exactly
one place — a class constructor/method/set-accessor parameter under
`experimentalDecorators` — and reports **TS1206 "Decorators are not valid here."**
everywhere else (plain functions, function/arrow expressions, object-literal
methods, and interface/type-literal method & call/construct signatures), in
*both* decorator modes. tsz only ran this check for class-member parameters,
so it diverged from `tsc` three ways. This routes the check through the
universal `check_parameter_properties` gate, keyed structurally off the
parameter's container.

Structural rule: **when a parameter carries a decorator and its enclosing
function-like is not a class constructor/method/set-accessor under
`experimentalDecorators`, `tsc` reports TS1206 once at the parameter's first
decorator and does not resolve the decorator expression; tsz now does the same
through `checkers/parameter_checker::check_parameter_decorator_grammar`.** A
decorator on a `this` parameter is the one exception — it is TS1433 ("Neither
decorators nor modifiers may be applied to 'this' parameters."), which `tsc`
reports instead of TS1206, so `this` parameters are left to that check.

Three divergences fixed (all one family):
1. **False-negative:** parameter decorators on non-class function-likes
   (function/function-expression/object-method/interface-method/call &
   construct signature/type-literal method) emitted nothing — now TS1206.
2. **False-positive:** a class-member parameter decorator in the standard
   (non-`experimentalDecorators`) mode emitted TS1206 but still resolved the
   decorator expression, cascading a spurious TS2304 for an undefined name.
   Invalid positions are no longer semantically checked.
3. **Over-report:** several decorators on one parameter emitted TS1206 per
   decorator; `tsc` reports once per parameter.

Also corrects a get-accessor edge: a decorator on a getter's (already illegal)
parameter is TS1206 in both modes, matching `tsc`.

Owner layer: parameter-modifier grammar lives in
`CheckerState::check_parameter_properties` (which already owns the sibling
TS2369 parameter-property check). A constructor *implementation* skips that
call — parameter properties are legal there — so the bodied-constructor path
calls the shared `check_parameter_decorator_grammar` directly; body-less
constructors keep getting it through `check_parameter_properties`. The old
per-decorator TS1206 emission is removed from the class-member decorator path,
which retains only the valid-position semantic checks (TS1239/TS1497/TS1308).

Closes #16677.

## Goal
Goal: hold

## Verification
- New unit module `parameter_decorator_grammar_tests` (19 cases): non-class
  positions, class-member positions in both decorator modes, multiplicity
  (once per parameter), getter edge, `this`-parameter suppression, and
  no-spurious-expression-resolution. `cargo test -p tsz-checker --lib
  parameter_decorator_grammar` → 19/19.
- Direct `tsz` vs `tsc@7.0.2`/`6.0.2` parity sweep over 24 positions in both
  `--experimentalDecorators` modes (incl. `this`/rest params) — all match.
- `cargo clippy --profile ci-lint -p tsz-checker --lib -- -D warnings` clean;
  touched files under the 2000-line arch-size ceiling. CI Summary (clippy +
  arch-size) green on the PR head.
- Conformance snapshot (12,043 runnable) diffed against the same-base
  baseline: **0 TS1206-related changes**. The two decorator tests this change
  touches (`decoratorOnFunctionParameter.ts`, `thisTypeInFunctionsNegative.ts`)
  match `tsc`. The only remaining status flips are non-TS1206 tests exhibiting
  the documented conformance non-determinism (#16309/#16632:
  `inferenceLimit.ts`, `genericCallWithGenericSignatureArguments.ts`, optional
  chaining) — unrelated to this diff.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high