### PR TITLE
fix(checker): the operand of a `typeof` type query is a value read, not a type reference

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -975,6 +975,8 @@ mod unique_symbol_assignment_ts2322_tests;
 mod unique_symbol_member_lookup_family_tests;
 #[path = "tests/unresolved_def_eval_cache_backstop_tests.rs"]
 mod unresolved_def_eval_cache_backstop_tests;
+#[path = "tests/unused_typeof_type_query_reference_tests.rs"]
+mod unused_typeof_type_query_reference_tests;
 #[path = "tests/using_declaration_implicit_any_tests.rs"]
 mod using_declaration_implicit_any_tests;
 #[path = "tests/variadic_tuple_alias_display_tests.rs"]

--- a/crates/tsz-checker/src/tests/function_type_parameter_grammar_tests.rs
+++ b/crates/tsz-checker/src/tests/function_type_parameter_grammar_tests.rs
@@ -10,275 +10,272 @@
 //! anchor column: TS1014 sits on the `...` token, TS1015/TS1016 on the
 //! offending parameter's name.
 
-#[cfg(test)]
-mod function_type_parameter_grammar_tests {
-    use crate::test_utils::check_source_diagnostics;
+use crate::test_utils::check_source_diagnostics;
 
-    /// `(code, byte offset)` for every diagnostic, in source order.
-    fn codes_at(source: &str) -> Vec<(u32, u32)> {
-        let mut found: Vec<(u32, u32)> = check_source_diagnostics(source)
-            .iter()
-            .map(|diag| (diag.code, diag.start))
-            .collect();
-        found.sort_unstable();
-        found
+/// `(code, byte offset)` for every diagnostic, in source order.
+fn codes_at(source: &str) -> Vec<(u32, u32)> {
+    let mut found: Vec<(u32, u32)> = check_source_diagnostics(source)
+        .iter()
+        .map(|diag| (diag.code, diag.start))
+        .collect();
+    found.sort_unstable();
+    found
+}
+
+/// Byte offset of the `nth` (0-based) occurrence of `needle`.
+fn offset_of(source: &str, needle: &str, nth: usize) -> u32 {
+    let mut from = 0usize;
+    for _ in 0..nth {
+        let at = source[from..]
+            .find(needle)
+            .expect("fewer occurrences than requested");
+        from += at + needle.len();
     }
+    let at = source[from..].find(needle).expect("needle not found");
+    u32::try_from(from + at).expect("offset fits in u32")
+}
 
-    /// Byte offset of the `nth` (0-based) occurrence of `needle`.
-    fn offset_of(source: &str, needle: &str, nth: usize) -> u32 {
-        let mut from = 0usize;
-        for _ in 0..nth {
-            let at = source[from..]
-                .find(needle)
-                .expect("fewer occurrences than requested");
-            from += at + needle.len();
-        }
-        let at = source[from..].find(needle).expect("needle not found");
-        u32::try_from(from + at).expect("offset fits in u32")
-    }
+fn expect_only(source: &str, code: u32, needle: &str) {
+    let expected = vec![(code, offset_of(source, needle, 0))];
+    assert_eq!(
+        codes_at(source),
+        expected,
+        "unexpected diagnostics for: {source}"
+    );
+}
 
-    fn expect_only(source: &str, code: u32, needle: &str) {
-        let expected = vec![(code, offset_of(source, needle, 0))];
-        assert_eq!(
-            codes_at(source),
-            expected,
-            "unexpected diagnostics for: {source}"
-        );
-    }
+fn expect_clean(source: &str) {
+    assert_eq!(
+        codes_at(source),
+        Vec::new(),
+        "expected no diagnostics for: {source}"
+    );
+}
 
-    fn expect_clean(source: &str) {
-        assert_eq!(
-            codes_at(source),
-            Vec::new(),
-            "expected no diagnostics for: {source}"
-        );
-    }
+// ---------------------------------------------------------------------
+// TS1014 — a rest parameter must be last
+// ---------------------------------------------------------------------
 
-    // ---------------------------------------------------------------------
-    // TS1014 — a rest parameter must be last
-    // ---------------------------------------------------------------------
+#[test]
+fn function_type_alias_reports_rest_not_last() {
+    expect_only("type F = (...a: number[], b: string) => void;", 1014, "...");
+}
 
-    #[test]
-    fn function_type_alias_reports_rest_not_last() {
-        expect_only("type F = (...a: number[], b: string) => void;", 1014, "...");
-    }
+#[test]
+fn inline_function_type_annotation_reports_rest_not_last() {
+    expect_only(
+        "declare let f: (...a: number[], b: string) => void;",
+        1014,
+        "...",
+    );
+}
 
-    #[test]
-    fn inline_function_type_annotation_reports_rest_not_last() {
-        expect_only(
-            "declare let f: (...a: number[], b: string) => void;",
-            1014,
-            "...",
-        );
-    }
+#[test]
+fn generic_function_type_reports_rest_not_last() {
+    expect_only("type F = <T>(...a: T[], b: T) => void;", 1014, "...");
+}
 
-    #[test]
-    fn generic_function_type_reports_rest_not_last() {
-        expect_only("type F = <T>(...a: T[], b: T) => void;", 1014, "...");
-    }
+#[test]
+fn constructor_type_reports_rest_not_last() {
+    expect_only(
+        "type C = new (...a: number[], b: string) => object;",
+        1014,
+        "...",
+    );
+}
 
-    #[test]
-    fn constructor_type_reports_rest_not_last() {
-        expect_only(
-            "type C = new (...a: number[], b: string) => object;",
-            1014,
-            "...",
-        );
-    }
+#[test]
+fn abstract_constructor_type_reports_rest_not_last() {
+    expect_only(
+        "type C = abstract new (...a: number[], b: string) => object;",
+        1014,
+        "...",
+    );
+}
 
-    #[test]
-    fn abstract_constructor_type_reports_rest_not_last() {
-        expect_only(
-            "type C = abstract new (...a: number[], b: string) => object;",
-            1014,
-            "...",
-        );
-    }
+#[test]
+fn function_type_as_a_parameter_annotation_reports_rest_not_last() {
+    expect_only(
+        "declare function use(cb: (...a: number[], b: string) => void): void;",
+        1014,
+        "...",
+    );
+}
 
-    #[test]
-    fn function_type_as_a_parameter_annotation_reports_rest_not_last() {
-        expect_only(
-            "declare function use(cb: (...a: number[], b: string) => void): void;",
-            1014,
-            "...",
-        );
-    }
+#[test]
+fn function_type_inside_a_union_reports_rest_not_last() {
+    expect_only(
+        "type F = ((...a: number[], b: string) => void) | string;",
+        1014,
+        "...",
+    );
+}
 
-    #[test]
-    fn function_type_inside_a_union_reports_rest_not_last() {
-        expect_only(
-            "type F = ((...a: number[], b: string) => void) | string;",
-            1014,
-            "...",
-        );
-    }
+#[test]
+fn function_type_as_an_interface_property_reports_rest_not_last() {
+    expect_only(
+        "interface I { f: (...a: number[], b: string) => void }",
+        1014,
+        "...",
+    );
+}
 
-    #[test]
-    fn function_type_as_an_interface_property_reports_rest_not_last() {
-        expect_only(
-            "interface I { f: (...a: number[], b: string) => void }",
-            1014,
-            "...",
-        );
-    }
+// ---------------------------------------------------------------------
+// TS1016 — a required parameter cannot follow an optional one
+// ---------------------------------------------------------------------
 
-    // ---------------------------------------------------------------------
-    // TS1016 — a required parameter cannot follow an optional one
-    // ---------------------------------------------------------------------
+#[test]
+fn function_type_alias_reports_required_after_optional() {
+    expect_only("type F = (a?: number, b: string) => void;", 1016, "b:");
+}
 
-    #[test]
-    fn function_type_alias_reports_required_after_optional() {
-        expect_only("type F = (a?: number, b: string) => void;", 1016, "b:");
-    }
+#[test]
+fn inline_function_type_annotation_reports_required_after_optional() {
+    expect_only(
+        "declare let f: (a?: number, b: string) => void;",
+        1016,
+        "b:",
+    );
+}
 
-    #[test]
-    fn inline_function_type_annotation_reports_required_after_optional() {
-        expect_only(
-            "declare let f: (a?: number, b: string) => void;",
-            1016,
-            "b:",
-        );
-    }
+#[test]
+fn generic_function_type_reports_required_after_optional() {
+    expect_only("type F = <T>(a?: T, b: T) => void;", 1016, "b:");
+}
 
-    #[test]
-    fn generic_function_type_reports_required_after_optional() {
-        expect_only("type F = <T>(a?: T, b: T) => void;", 1016, "b:");
-    }
+#[test]
+fn constructor_type_reports_required_after_optional() {
+    expect_only(
+        "type C = new (a?: number, b: string) => object;",
+        1016,
+        "b:",
+    );
+}
 
-    #[test]
-    fn constructor_type_reports_required_after_optional() {
-        expect_only(
-            "type C = new (a?: number, b: string) => object;",
-            1016,
-            "b:",
-        );
-    }
+#[test]
+fn abstract_constructor_type_reports_required_after_optional() {
+    expect_only(
+        "type C = abstract new (a?: number, b: string) => object;",
+        1016,
+        "b:",
+    );
+}
 
-    #[test]
-    fn abstract_constructor_type_reports_required_after_optional() {
-        expect_only(
-            "type C = abstract new (a?: number, b: string) => object;",
-            1016,
-            "b:",
-        );
-    }
+#[test]
+fn function_type_as_an_object_type_member_reports_required_after_optional() {
+    expect_only(
+        "type T = { f: (a?: number, b: string) => void };",
+        1016,
+        "b:",
+    );
+}
 
-    #[test]
-    fn function_type_as_an_object_type_member_reports_required_after_optional() {
-        expect_only(
-            "type T = { f: (a?: number, b: string) => void };",
-            1016,
-            "b:",
-        );
-    }
+#[test]
+fn function_type_in_an_array_type_reports_required_after_optional() {
+    expect_only("type F = ((a?: number, b: string) => void)[];", 1016, "b:");
+}
 
-    #[test]
-    fn function_type_in_an_array_type_reports_required_after_optional() {
-        expect_only("type F = ((a?: number, b: string) => void)[];", 1016, "b:");
-    }
+// ---------------------------------------------------------------------
+// TS1015 — `?` together with an initializer
+// ---------------------------------------------------------------------
 
-    // ---------------------------------------------------------------------
-    // TS1015 — `?` together with an initializer
-    // ---------------------------------------------------------------------
+#[test]
+fn function_type_reports_question_mark_with_initializer_alongside_ts2371() {
+    // tsc reports TS1015 and TS2371 at the same anchor: the grammar arm and
+    // the "initializer only in an implementation" rule are independent.
+    let source = "type F = (a?: number = 1) => void;";
+    let anchor = offset_of(source, "a?", 0);
+    assert_eq!(codes_at(source), vec![(1015, anchor), (2371, anchor)]);
+}
 
-    #[test]
-    fn function_type_reports_question_mark_with_initializer_alongside_ts2371() {
-        // tsc reports TS1015 and TS2371 at the same anchor: the grammar arm and
-        // the "initializer only in an implementation" rule are independent.
-        let source = "type F = (a?: number = 1) => void;";
-        let anchor = offset_of(source, "a?", 0);
-        assert_eq!(codes_at(source), vec![(1015, anchor), (2371, anchor)]);
-    }
+// ---------------------------------------------------------------------
+// tsc reports at most ONE diagnostic per parameter list
+// ---------------------------------------------------------------------
 
-    // ---------------------------------------------------------------------
-    // tsc reports at most ONE diagnostic per parameter list
-    // ---------------------------------------------------------------------
+#[test]
+fn a_misplaced_rest_wins_over_a_later_required_after_optional() {
+    // `checkGrammarParameterList` returns at the first failing parameter,
+    // so the trailing `b?`/`c` pair never reaches the TS1016 arm.
+    expect_only(
+        "type F = (...a: number[], b?: string, c: string) => void;",
+        1014,
+        "...",
+    );
+}
 
-    #[test]
-    fn a_misplaced_rest_wins_over_a_later_required_after_optional() {
-        // `checkGrammarParameterList` returns at the first failing parameter,
-        // so the trailing `b?`/`c` pair never reaches the TS1016 arm.
-        expect_only(
-            "type F = (...a: number[], b?: string, c: string) => void;",
-            1014,
-            "...",
-        );
-    }
+#[test]
+fn only_the_first_required_after_optional_is_reported() {
+    expect_only(
+        "type F = (a?: number, b: string, c: string) => void;",
+        1016,
+        "b:",
+    );
+}
 
-    #[test]
-    fn only_the_first_required_after_optional_is_reported() {
-        expect_only(
-            "type F = (a?: number, b: string, c: string) => void;",
-            1016,
-            "b:",
-        );
-    }
+// ---------------------------------------------------------------------
+// Negative controls
+// ---------------------------------------------------------------------
 
-    // ---------------------------------------------------------------------
-    // Negative controls
-    // ---------------------------------------------------------------------
+#[test]
+fn optional_after_required_is_clean() {
+    expect_clean("type F = (a: number, b?: string) => void;");
+}
 
-    #[test]
-    fn optional_after_required_is_clean() {
-        expect_clean("type F = (a: number, b?: string) => void;");
-    }
+#[test]
+fn a_trailing_rest_after_an_optional_is_clean() {
+    expect_clean("type F = (a?: number, ...rest: string[]) => void;");
+}
 
-    #[test]
-    fn a_trailing_rest_after_an_optional_is_clean() {
-        expect_clean("type F = (a?: number, ...rest: string[]) => void;");
-    }
+#[test]
+fn an_initialized_parameter_does_not_make_the_next_one_required_after_optional() {
+    // tsc's `isOptionalParameter` compares the index against the minimum
+    // argument count, so a leading `a = 1` is not optional here.
+    expect_clean("function f(a = 1, b: number) {}");
+}
 
-    #[test]
-    fn an_initialized_parameter_does_not_make_the_next_one_required_after_optional() {
-        // tsc's `isOptionalParameter` compares the index against the minimum
-        // argument count, so a leading `a = 1` is not optional here.
-        expect_clean("function f(a = 1, b: number) {}");
-    }
+#[test]
+fn a_parameter_with_an_initializer_is_not_required_after_an_optional_one() {
+    // Only TS2371 survives — the initializer keeps `b` out of the TS1016
+    // arm, exactly as in tsc.
+    let source = "type F = (a?: number, b = 1) => void;";
+    assert_eq!(codes_at(source), vec![(2371, offset_of(source, "b =", 0))]);
+}
 
-    #[test]
-    fn a_parameter_with_an_initializer_is_not_required_after_an_optional_one() {
-        // Only TS2371 survives — the initializer keeps `b` out of the TS1016
-        // arm, exactly as in tsc.
-        let source = "type F = (a?: number, b = 1) => void;";
-        assert_eq!(codes_at(source), vec![(2371, offset_of(source, "b =", 0))]);
-    }
+#[test]
+fn binding_pattern_parameters_are_clean() {
+    expect_clean("type F = ({ a }: { a: number }, c?: string) => void;");
+}
 
-    #[test]
-    fn binding_pattern_parameters_are_clean() {
-        expect_clean("type F = ({ a }: { a: number }, c?: string) => void;");
-    }
+#[test]
+fn a_this_parameter_before_the_optional_run_is_clean() {
+    expect_clean("type F = (this: object, a: number, b?: string) => void;");
+}
 
-    #[test]
-    fn a_this_parameter_before_the_optional_run_is_clean() {
-        expect_clean("type F = (this: object, a: number, b?: string) => void;");
-    }
+#[test]
+fn an_empty_parameter_list_is_clean() {
+    expect_clean("type F = () => void;");
+}
 
-    #[test]
-    fn an_empty_parameter_list_is_clean() {
-        expect_clean("type F = () => void;");
-    }
+// ---------------------------------------------------------------------
+// One diagnostic per written signature, not per use
+// ---------------------------------------------------------------------
 
-    // ---------------------------------------------------------------------
-    // One diagnostic per written signature, not per use
-    // ---------------------------------------------------------------------
+#[test]
+fn a_reused_alias_reports_its_signature_once() {
+    let source = concat!(
+        "type Bad = (...a: number[], b: string) => void;\n",
+        "declare const x1: Bad;\n",
+        "declare const x2: Bad;\n"
+    );
+    assert_eq!(codes_at(source), vec![(1014, offset_of(source, "...", 0))]);
+}
 
-    #[test]
-    fn a_reused_alias_reports_its_signature_once() {
-        let source = concat!(
-            "type Bad = (...a: number[], b: string) => void;\n",
-            "declare const x1: Bad;\n",
-            "declare const x2: Bad;\n"
-        );
-        assert_eq!(codes_at(source), vec![(1014, offset_of(source, "...", 0))]);
-    }
-
-    #[test]
-    fn a_generic_alias_instantiated_twice_reports_its_signature_once() {
-        let source = concat!(
-            "type G<T> = (a?: T, b: T) => void;\n",
-            "declare const g1: G<number>;\n",
-            "declare const g2: G<string>;\n"
-        );
-        assert_eq!(codes_at(source), vec![(1016, offset_of(source, "b:", 0))]);
-    }
+#[test]
+fn a_generic_alias_instantiated_twice_reports_its_signature_once() {
+    let source = concat!(
+        "type G<T> = (a?: T, b: T) => void;\n",
+        "declare const g1: G<number>;\n",
+        "declare const g2: G<string>;\n"
+    );
+    assert_eq!(codes_at(source), vec![(1016, offset_of(source, "b:", 0))]);
 }

--- a/crates/tsz-checker/src/tests/unused_typeof_type_query_reference_tests.rs
+++ b/crates/tsz-checker/src/tests/unused_typeof_type_query_reference_tests.rs
@@ -1,0 +1,229 @@
+//! Regression tests for `TS6133` against the operand of a `typeof` type query.
+//!
+//! Structural rule (pinned against `typescript@7.0.2`, the conformance pin):
+//! a `TYPE_QUERY` is syntactically a type node, but its entity name resolves in
+//! the **value** namespace — tsc's `checkTypeQuery` routes it through
+//! `checkExpressionOrQualifiedName`, so `typeof x` is a genuine read of `x`.
+//! A binding whose only reference is the operand of a `typeof` is therefore
+//! *used*, and neither `--noUnusedLocals` nor `--noUnusedParameters` reports it.
+//!
+//! tsz decides this in the checker's unused-identifier pass
+//! (`types/type_checking/unused.rs`). `is_parameter_only_type_referenced`
+//! re-scans same-named identifiers and discounts the ones sitting in a type
+//! context, so that a parameter shadowed by a same-named *type*
+//! (`interface Zed {}` + `function o(Zed: number) { let v: Zed; }`) is still
+//! reported — tsc reports that one. The classifier behind it,
+//! `node_is_in_type_context`, answered `true` for the operand of a `typeof`
+//! because `TYPE_QUERY` answers `is_type_node()`, which made every
+//! `typeof`-only reference invisible and produced a false `TS6133`.
+//!
+//! Corpus witness: `compiler/unusedParameterUsedInTypeOf.ts`, a pure
+//! false-positive row (extra `TS6133`, nothing missing) in
+//! `scripts/conformance/conformance-detail.json`.
+//!
+//! Every row below was measured against the pin with
+//! `--strict --target es2022 --lib es2022 --noUnusedLocals --noUnusedParameters`.
+//! Binder names are varied across rows: the rule is structural, so no row may
+//! depend on a particular identifier spelling.
+
+use crate::context::ScriptTarget;
+use crate::test_utils::check_source;
+use crate::{CheckerOptions, diagnostics::Diagnostic};
+
+fn check_unused(source: &str) -> Vec<Diagnostic> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            no_unused_locals: true,
+            no_unused_parameters: true,
+            target: ScriptTarget::ES2022,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+fn unused_codes(source: &str) -> Vec<u32> {
+    check_unused(source)
+        .into_iter()
+        .map(|diagnostic| diagnostic.code)
+        .collect()
+}
+
+/// The corpus witness, reduced: a parameter whose only reference is a sibling
+/// parameter's `typeof`.
+///
+/// ```text
+/// tsc: (no output)
+/// ```
+#[test]
+fn a_parameter_read_by_a_sibling_parameter_type_query_is_used() {
+    let codes = unused_codes("function f1(a: number, b: typeof a) { return b; }\nf1(1, 2);\n");
+
+    assert!(
+        !codes.contains(&6133),
+        "a parameter named by a sibling parameter's `typeof` is read; tsc reports nothing. Got: {codes:?}"
+    );
+}
+
+/// Same shape, different binder names — the rule must not key on `a`/`b`.
+#[test]
+fn the_type_query_read_does_not_depend_on_the_binder_spelling() {
+    let codes = unused_codes(
+        "export function zeta(kappa: string, lambda: typeof kappa) { return lambda; }\n",
+    );
+
+    assert!(
+        !codes.contains(&6133),
+        "renamed binders must behave identically. Got: {codes:?}"
+    );
+}
+
+/// The query in a *return* type annotation rather than a parameter's.
+#[test]
+fn a_parameter_read_by_a_return_type_query_is_used() {
+    let codes = unused_codes("export function k(a: number): typeof a { return a; }\n");
+
+    assert!(
+        !codes.contains(&6133),
+        "a return-type `typeof` reads its operand. Got: {codes:?}"
+    );
+}
+
+/// A query nested inside a surrounding type literal — the walk must reach the
+/// `TYPE_QUERY` through the intervening type nodes.
+#[test]
+fn a_parameter_read_by_a_nested_type_query_is_used() {
+    let codes =
+        unused_codes("export function p(a: number, b: { deep: { q: typeof a } }) { return b; }\n");
+
+    assert!(
+        !codes.contains(&6133),
+        "a `typeof` nested inside a type literal still reads its operand. Got: {codes:?}"
+    );
+}
+
+/// A qualified operand (`typeof ns.p`): the identifier's parent is a
+/// `QUALIFIED_NAME`, so the walk reaches `TYPE_QUERY` one hop later.
+#[test]
+fn a_parameter_read_by_a_qualified_type_query_is_used() {
+    let codes =
+        unused_codes("export function n(ns: { p: number }, q: typeof ns.p) { return q; }\n");
+
+    assert!(
+        !codes.contains(&6133),
+        "the root of a qualified `typeof` operand is read. Got: {codes:?}"
+    );
+}
+
+/// A query written inside the function body rather than in a signature.
+#[test]
+fn a_parameter_read_by_a_body_local_type_query_is_used() {
+    let codes = unused_codes("export function q(a: number) { const t: typeof a = 1; return t; }\n");
+
+    assert!(
+        !codes.contains(&6133),
+        "a body-local `typeof` annotation reads its operand. Got: {codes:?}"
+    );
+}
+
+/// The `--noUnusedLocals` half of the same rule: a local whose only reference is
+/// a `typeof`.
+#[test]
+fn a_local_read_only_by_a_type_query_is_used() {
+    let codes =
+        unused_codes("export function h() { const w = 1; const r: typeof w = 1; return r; }\n");
+
+    assert!(
+        !codes.contains(&6133),
+        "a local named by a `typeof` is read. Got: {codes:?}"
+    );
+}
+
+/// Module-scope local read only by a `typeof` in an exported type alias.
+#[test]
+fn a_module_local_read_by_an_exported_type_alias_query_is_used() {
+    let codes = unused_codes("const uu = 1;\nexport type UU = typeof uu;\n");
+
+    assert!(
+        !codes.contains(&6133),
+        "a module-scope local named by an exported alias's `typeof` is read. Got: {codes:?}"
+    );
+}
+
+/// Tripwire for the one spelling this fix does **not** reach: a `typeof` written
+/// inside the **type arguments** of a type reference. Measured through the built
+/// CLI (`--strict --target es2022 --noUnusedLocals --noUnusedParameters`), the
+/// parameter is still reported as unread for `Wrap<typeof a>`, `Array<typeof a>`,
+/// `ReadonlyArray<typeof a>`, `Map<string, typeof a>` and `Wrap<(typeof a)>`,
+/// while every non-type-argument spelling above is now correct. tsc reports
+/// nothing for any of them.
+///
+/// The `--noUnusedLocals` half of the same spelling is already correct
+/// (`const w = 1; export const y: Wrap<typeof w> = { v: 1 };` is clean), which
+/// places the remaining defect on the parameter re-scan rather than on reference
+/// tracking. Left as a failing assertion under `#[ignore]` so it flips loudly
+/// when the type-argument cell is closed rather than sitting as a silent absence.
+#[test]
+#[ignore = "type-argument-nested typeof is a separate open cell; see the module docs"]
+fn a_parameter_read_by_a_type_argument_type_query_is_used() {
+    let codes = unused_codes(
+        "type Wrap<T> = { v: T };\nexport function m2(a: number, b: Wrap<typeof a>) { return b; }\n",
+    );
+
+    assert!(
+        !codes.contains(&6133),
+        "a `typeof` in type-argument position reads its operand. Got: {codes:?}"
+    );
+}
+
+/// Negative control: a genuinely unread parameter still reports `TS6133`.
+///
+/// ```text
+/// tsc: error TS6133: 'unusedParam' is declared but its value is never read.
+/// ```
+#[test]
+fn a_parameter_with_no_reference_at_all_still_reports_ts6133() {
+    let codes = unused_codes("export function bad(unusedParam: number) { return 1; }\n");
+
+    assert!(
+        codes.contains(&6133),
+        "an unread parameter must still report TS6133. Got: {codes:?}"
+    );
+}
+
+/// Negative control, and the reason `is_parameter_only_type_referenced` exists:
+/// a parameter shadowed by a same-named *type*. The `Zed` in `v: Zed` resolves
+/// to the interface, not to the parameter, so the parameter is unread.
+///
+/// ```text
+/// tsc: error TS6133: 'Zed' is declared but its value is never read.
+/// ```
+#[test]
+fn a_parameter_shadowed_by_a_same_named_type_reference_still_reports_ts6133() {
+    let codes = unused_codes(
+        "interface Zed { z: number }\nexport function o(Zed: number) { const v: Zed = { z: 1 }; return v; }\n",
+    );
+
+    assert!(
+        codes.contains(&6133),
+        "a same-named *type* reference is not a read of the parameter. Got: {codes:?}"
+    );
+}
+
+/// Negative control on the other side of the new branch: a parameter named only
+/// by a same-named type reference nested *inside* a `typeof`-bearing signature
+/// stays unread. The `typeof` here names a different binding, so the type-only
+/// reference must not be laundered into a read.
+#[test]
+fn a_type_only_reference_beside_an_unrelated_type_query_still_reports_ts6133() {
+    let codes = unused_codes(
+        "interface Wye { w: number }\nexport function s(Wye: number, other: string, t: typeof other) { const v: Wye = { w: 1 }; return [v, t]; }\n",
+    );
+
+    assert!(
+        codes.contains(&6133),
+        "an unrelated `typeof` in the same signature must not mark `Wye` as read. Got: {codes:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/type_checking/unused.rs
+++ b/crates/tsz-checker/src/types/type_checking/unused.rs
@@ -1177,6 +1177,14 @@ impl<'a> CheckerState<'a> {
         false
     }
 
+    /// Whether `idx` sits in a position that resolves in the **type** namespace.
+    ///
+    /// The entity name of a `typeof` type query is deliberately excluded: a
+    /// `TYPE_QUERY` is syntactically a type node, but its operand is resolved in
+    /// the value namespace and is a genuine read of the value it names, exactly
+    /// as `tsc` treats it (`checkTypeQuery` routes the entity name through
+    /// `checkExpressionOrQualifiedName`). Classifying it as a type context makes
+    /// `typeof x` invisible to the unused-identifier reference scan.
     fn node_is_in_type_context(&self, idx: NodeIndex) -> bool {
         let mut current = idx;
         for _ in 0..20 {
@@ -1190,6 +1198,14 @@ impl<'a> CheckerState<'a> {
             let Some(parent_node) = self.ctx.arena.get(parent) else {
                 return false;
             };
+            // Checked before the generic type-node test: `TYPE_QUERY` answers
+            // `is_type_node()`, so the operand of `typeof` would otherwise be
+            // classified as a type reference. A type argument written on the
+            // query (`typeof f<string>`) still reaches its own type node first
+            // and keeps the type-context answer.
+            if parent_node.kind == syntax_kind_ext::TYPE_QUERY {
+                return false;
+            }
             if parent_node.is_type_node()
                 || parent_node.kind == syntax_kind_ext::EXPRESSION_WITH_TYPE_ARGUMENTS
             {


### PR DESCRIPTION
Closes a pure false-positive conformance row: `compiler/unusedParameterUsedInTypeOf.ts`.

*(Type-argument lists below are written with **square** brackets: this tracker strips real angle brackets from issue and PR bodies, including inside code spans. The runnable forms live in the test module named at the bottom. This body was rewritten once after confirming the first version came back mangled.)*

**Wrong semantic operation:** symbol resolution / reference classification in the checker's unused-identifier pass — not diagnostic display, and not the relation.

**Structural rule.** When an identifier is the entity name of a `typeof` type query, `tsc` resolves it in the **value** namespace (`checkTypeQuery` routes it through `checkExpressionOrQualifiedName`), so it is a genuine read of the value it names and neither `--noUnusedLocals` nor `--noUnusedParameters` reports the binding. tsz does that through the checker's `node_is_in_type_context` classifier in `types/type_checking/unused.rs`.

`TYPE_QUERY` answers `is_type_node()`, so the classifier returned `true` for the operand of a `typeof`. Its consumer, `is_parameter_only_type_referenced`, re-scans same-named identifiers and deliberately discounts the ones sitting in a type context — that is how a parameter shadowed by a same-named *type* stays reported, which `tsc` also reports. A `typeof`-only reference was swept up by the same discount and the parameter was declared unread.

The fix is one branch, ordered before the generic type-node test. A type argument written on the query (`typeof f[ T ]`) still reaches its own type node first and keeps the type-context answer, so only the entity-name path changes.

Anti-hardcoding: the discriminator is the parent node's syntax kind. No identifier, alias, property or file-name string participates; every positive row below is repeated under different binder spellings.

### Oracle matrix

Measured against the conformance pin `typescript@7.0.2` with `--strict --target es2022 --lib es2022 --noUnusedLocals --noUnusedParameters`, and through the built CLI at the same settings.

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `function f1(a: number, b: typeof a)` (the corpus row) | clean | **TS6133** | clean |
| same, renamed binders (`kappa` / `lambda`) | clean | **TS6133** | clean |
| return-type query `function k(a: number): typeof a` | clean | **TS6133** | clean |
| query nested in a type literal, `b: { deep: { q: typeof a } }` | clean | **TS6133** | clean |
| qualified operand, `q: typeof ns.p` | clean | **TS6133** | clean |
| body-local annotation, `const t: typeof a = 1` | clean | **TS6133** | clean |
| parenthesized/array, `b: (typeof a)[]` | clean | clean | clean |
| local read only by a query (`--noUnusedLocals` half) | clean | clean | clean |
| module local read by an exported alias's query | clean | clean | clean |
| **negative:** parameter with no reference at all | TS6133 | TS6133 | TS6133 |
| **negative:** parameter shadowed by a same-named *type* | TS6133 | TS6133 | TS6133 |
| **negative:** same, beside an unrelated `typeof` in the same signature | TS6133 | TS6133 | TS6133 |

Non-vacuity: applied to `main` without the `unused.rs` change, the new module fails **5 of 12** — exactly the five parameter rows the classifier decides. The three `--noUnusedLocals` rows and all three negative controls pass on both sides, so they are regression guards rather than evidence.

### One cell deliberately left open — #16680

A `typeof` written inside the **type arguments** of a type reference is still reported: `Wrap[ typeof a ]`, `Array[ typeof a ]`, `ReadonlyArray[ typeof a ]`, `Map[ string, typeof a ]` and `Wrap[ (typeof a) ]`. `tsc` is clean on all five.

The `--noUnusedLocals` half of that same spelling is already correct on `main` (`const w = 1; export const y: Wrap[ typeof w ] = { v: 1 };` reports nothing), which places the remaining defect on the parameter re-scan rather than on reference tracking — a different mechanism from the one fixed here. A second, non-type-argument `typeof` in the same signature resolves correctly while the type-argument one does not, so the new branch does fire. Pinned as `#[ignore]`d `a_parameter_read_by_a_type_argument_type_query_is_used` carrying its oracle row, so it flips loudly instead of sitting as a silent absence. Filed with the full matrix and the next probe as **#16680**.

### Second commit — currently fleet-blocking, unrelated

`cargo clippy --profile ci-lint --workspace --all-targets -- -D warnings` (the real per-merge gate) is red on unmodified `main` with `clippy::module_inception`: `crates/tsz-checker/src/tests/function_type_parameter_grammar_tests.rs` is already declared as that module via `#[path]` in `test_module_registry.rs` and additionally wraps its body in a same-named inline module. #16665 carried this fix and was closed superseded by #16670, which took only its *first* commit — so the gate is still red and every open PR's clippy check fails for a reason that is not its own diff. Bundled here as its own commit: pure code motion, the wrapper removed and the body dedented one level (`cargo fmt` then rejoins the lines that now fit inside 100 columns). All 27 tests in the file still pass, unchanged.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib unused_typeof_type_query` — **11 passed, 0 failed, 1 ignored** (the type-argument tripwire; it fails as intended under `-- --ignored`). Against `main` without the `unused.rs` change: **6 passed, 5 failed**.
- `cargo test -p tsz-checker --lib -- unused ts6133 ts6138 ts6192 ts6196 ts6198 ts6199 type_query typeof` — **249 passed, 0 failed**.
- `cargo test -p tsz-checker` over the nine standalone unused/TS6133 integration targets (`ts6133_unused_type_params_tests`, `ts6133_write_only_destructuring_tests`, `unused_catch_binding_tests`, `unused_internal_name_suppression_tests`, `unused_jsdoc_pattern_comment_scoped_tests`, `unused_jsdoc_template_declaration_tests`, `unused_nested_destructured_param_tests`, `unused_parameter_tests`, `unused_react_jsx_factory_suppression_tests`) — **58 passed, 0 failed**.
- `cargo test -p tsz-checker --lib function_type_parameter_grammar` — **27 passed, 0 failed** after the code motion.
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings` — exit 0 (checked with `set -o pipefail`).
- `python3 scripts/arch/arch_guard.py` — passed. `cargo fmt` — clean. Repo `pre-commit` hook verification passed on the fix commit's content.
- End-to-end through the built CLI (`.target/debug/tsz`) on all twelve matrix rows plus the reduced corpus fixture at `--target es2015`: matches the table above. (The fixture header says `//@target: ES5, ES2015`; the ES5 leg is `TS5108` — that target is removed in this compiler — so only the ES2015 leg is meaningful.)
- **Corpus gate owed, disclosed:** the TypeScript submodule is not checked out on this seat, so `compare-to-parent.sh` / `conformance.sh` were not runnable. The change can only *remove* a diagnostic in the `typeof`-operand shape and the pinned matrix covers both directions, but it was not measured against the corpus this session.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Serpentine