### PR TITLE
fix(tooling): publish current-tree README metrics instead of a monotonic high-water mark

### DIFF
--- a/scripts/ci/test_refresh_readme.py
+++ b/scripts/ci/test_refresh_readme.py
@@ -86,7 +86,14 @@ Declaration: [███████████████████░] 97.0
             "dtsTotal": 1669,
         }
 
-        selected = refresh_readme.prefer_readme_emit_summary(snapshot_summary, readme_summary)
+        # A snapshot with no recorded tree (git_sha) is treated as possibly
+        # stale, so the higher README block is kept.
+        with redirect_stderr(io.StringIO()):
+            selected = refresh_readme.resolve_published_summary(
+                snapshot_summary, readme_summary, {}, refresh_readme.ROOT / "emit-detail.json",
+                is_ahead=refresh_readme.readme_emit_summary_is_ahead,
+                suite_label="emit",
+            )
 
         self.assertEqual(selected["jsPass"], 13401)
         self.assertEqual(selected["dtsPass"], 1619)
@@ -139,7 +146,13 @@ Progress: [███████████████████░] 90.0% (
             "total": 9,
         }
 
-        selected = refresh_readme.prefer_readme_suite_summary(snapshot_summary, readme_summary)
+        # No recorded tree -> possibly stale -> the higher README block wins.
+        with redirect_stderr(io.StringIO()):
+            selected = refresh_readme.resolve_published_summary(
+                snapshot_summary, readme_summary, {}, refresh_readme.ROOT / "conformance-snapshot.json",
+                is_ahead=refresh_readme.readme_suite_summary_is_ahead,
+                suite_label="conformance",
+            )
 
         self.assertEqual(selected["passed"], 9)
         self.assertEqual(selected["total"], 10)
@@ -161,10 +174,14 @@ Progress: [████████████████████] 100.0% 
             "skipped": 1,
         }
 
-        selected = refresh_readme.prefer_readme_suite_summary(
-            artifact_summary,
-            readme_summary,
-        )
+        # The partition-aware artifact carries a candidate domain the legacy
+        # README block lacks, so it is NOT ahead and the artifact is published.
+        with redirect_stderr(io.StringIO()):
+            selected = refresh_readme.resolve_published_summary(
+                artifact_summary, readme_summary, {}, refresh_readme.ROOT / "conformance-snapshot.json",
+                is_ahead=refresh_readme.readme_suite_summary_is_ahead,
+                suite_label="conformance",
+            )
 
         self.assertEqual(selected, artifact_summary)
 
@@ -221,6 +238,157 @@ Progress: [████████████████████] 100.0% 
         self.assertEqual(selected["total"], 10)
         self.assertIn("preserving README conformance metrics", stderr.getvalue())
         self.assertIn("scripts/conformance/conformance-snapshot.json", stderr.getvalue())
+
+    def test_artifact_sha_reads_recorded_tree_and_rejects_unknown(self):
+        self.assertEqual(
+            refresh_readme.artifact_sha({"git_sha": "abc1234def"}), "abc1234def"
+        )
+        self.assertEqual(
+            refresh_readme.artifact_sha({"git_sha": " abc1234def "}), "abc1234def"
+        )
+        self.assertIsNone(refresh_readme.artifact_sha({"git_sha": "unknown"}))
+        self.assertIsNone(refresh_readme.artifact_sha({"git_sha": ""}))
+        self.assertIsNone(refresh_readme.artifact_sha({}))
+        self.assertIsNone(refresh_readme.artifact_sha(None))
+
+    def test_artifact_describes_current_tree_matches_full_and_short_sha(self):
+        head = "0123456789abcdef0123456789abcdef01234567"
+        # Exact match.
+        self.assertTrue(
+            refresh_readme.artifact_describes_current_tree({"git_sha": head}, head)
+        )
+        # Abbreviated recorded SHA still identifies the same commit.
+        self.assertTrue(
+            refresh_readme.artifact_describes_current_tree(
+                {"git_sha": head[:12]}, head
+            )
+        )
+        # A different commit is not the current tree.
+        self.assertFalse(
+            refresh_readme.artifact_describes_current_tree(
+                {"git_sha": "fedcba9876543210"}, head
+            )
+        )
+        # Too few shared characters to trust as an identity.
+        self.assertFalse(
+            refresh_readme.artifact_describes_current_tree({"git_sha": "012"}, head)
+        )
+        # No HEAD (not a git checkout) -> fall back to the magnitude guard.
+        self.assertFalse(
+            refresh_readme.artifact_describes_current_tree({"git_sha": head}, None)
+        )
+        # No recorded SHA -> fall back to the magnitude guard.
+        self.assertFalse(
+            refresh_readme.artifact_describes_current_tree({}, head)
+        )
+
+    def test_conformance_zero_drift_publishes_downward_reading(self):
+        head = "0123456789abcdef0123456789abcdef01234567"
+        with TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            snapshot_path = root / "scripts" / "conformance" / "conformance-snapshot.json"
+            snapshot_path.parent.mkdir(parents=True)
+            snapshot_path.write_text(json.dumps({
+                "git_sha": head,
+                "summary": {"passed": 8, "total_tests": 10},
+            }))
+            args = types.SimpleNamespace(conformance_metrics_json=None)
+            readme_text = """<!-- CONFORMANCE_START -->
+```
+Progress: [██████████████████░░] 90.0% (9/10 tests)
+```
+<!-- CONFORMANCE_END -->"""
+
+            old_root = refresh_readme.ROOT
+            old_head = refresh_readme.current_head_sha
+            stderr = io.StringIO()
+            try:
+                refresh_readme.ROOT = root
+                refresh_readme.current_head_sha = lambda: head
+                with redirect_stderr(stderr):
+                    selected = refresh_readme.load_conformance(args, readme_text)
+            finally:
+                refresh_readme.ROOT = old_root
+                refresh_readme.current_head_sha = old_head
+
+        # The lower, current-tree reading wins over the README's higher block.
+        self.assertEqual(selected["passed"], 8)
+        self.assertEqual(selected["total"], 10)
+        self.assertIn("current HEAD", stderr.getvalue())
+
+    def test_conformance_stale_artifact_still_preserves_readme_reading(self):
+        with TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            snapshot_path = root / "scripts" / "conformance" / "conformance-snapshot.json"
+            snapshot_path.parent.mkdir(parents=True)
+            snapshot_path.write_text(json.dumps({
+                "git_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "summary": {"passed": 8, "total_tests": 10},
+            }))
+            args = types.SimpleNamespace(conformance_metrics_json=None)
+            readme_text = """<!-- CONFORMANCE_START -->
+```
+Progress: [██████████████████░░] 90.0% (9/10 tests)
+```
+<!-- CONFORMANCE_END -->"""
+
+            old_root = refresh_readme.ROOT
+            old_head = refresh_readme.current_head_sha
+            stderr = io.StringIO()
+            try:
+                refresh_readme.ROOT = root
+                refresh_readme.current_head_sha = (
+                    lambda: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                )
+                with redirect_stderr(stderr):
+                    selected = refresh_readme.load_conformance(args, readme_text)
+            finally:
+                refresh_readme.ROOT = old_root
+                refresh_readme.current_head_sha = old_head
+
+        # SHA mismatch -> the artifact is treated as possibly stale, README wins.
+        self.assertEqual(selected["passed"], 9)
+        self.assertEqual(selected["total"], 10)
+        self.assertIn("preserving README conformance metrics", stderr.getvalue())
+
+    def test_emit_zero_drift_publishes_downward_reading(self):
+        head = "0123456789abcdef0123456789abcdef01234567"
+        with TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            detail_path = root / "scripts" / "emit" / "emit-detail.json"
+            detail_path.parent.mkdir(parents=True)
+            detail_path.write_text(json.dumps({
+                "git_sha": head,
+                "summary": {
+                    "jsPass": 13094,
+                    "jsTotal": 13530,
+                    "dtsPass": 1606,
+                    "dtsTotal": 1669,
+                },
+            }))
+            args = types.SimpleNamespace(emit_metrics_json=None)
+            readme_text = """<!-- EMIT_START -->
+```
+JavaScript:  [████████████████████] 99.5% (13,459 / 13,530 tests)
+Declaration: [████████████████████] 98.5% (1,644 / 1,669 tests)
+```
+<!-- EMIT_END -->"""
+
+            old_root = refresh_readme.ROOT
+            old_head = refresh_readme.current_head_sha
+            stderr = io.StringIO()
+            try:
+                refresh_readme.ROOT = root
+                refresh_readme.current_head_sha = lambda: head
+                with redirect_stderr(stderr):
+                    selected = refresh_readme.load_emit(args, readme_text)
+            finally:
+                refresh_readme.ROOT = old_root
+                refresh_readme.current_head_sha = old_head
+
+        self.assertEqual(selected["jsPass"], 13094)
+        self.assertEqual(selected["dtsPass"], 1606)
+        self.assertIn("current HEAD", stderr.getvalue())
 
 
 if __name__ == "__main__":

--- a/scripts/conformance/build-snapshot-detail.py
+++ b/scripts/conformance/build-snapshot-detail.py
@@ -155,7 +155,7 @@ def build_aggregates(tests):
     }
 
 
-def build_snapshot_detail(tests):
+def build_snapshot_detail(tests, git_sha=None):
     """Build the compact detail artifact with explicit runnable accounting."""
     aggregates = build_aggregates(tests)
 
@@ -199,7 +199,7 @@ def build_snapshot_detail(tests):
                 entry["reason"] = reason
         fail_detail[path] = entry
 
-    return {
+    detail = {
         "summary": {
             "candidates": candidates,
             # `total` remains the backward-compatible pass denominator.
@@ -217,16 +217,28 @@ def build_snapshot_detail(tests):
         "failures": fail_detail,
         "unsupported": unsupported_detail,
     }
+    # Stamp the measured tree so `refresh-readme.py` can tell a current reading
+    # from a stale local artifact (zero-drift downward writes are legitimate).
+    if git_sha and git_sha.lower() != "unknown":
+        detail["git_sha"] = git_sha
+    return detail
 
 
 def main():
     parser = argparse.ArgumentParser(description="Build conformance detail snapshot")
     parser.add_argument("input_file", help="Raw runner output file (--print-test mode)")
     parser.add_argument("--output", "-o", required=True, help="Output JSON path")
+    parser.add_argument(
+        "--git-sha",
+        default=None,
+        help="commit SHA the runner output was measured against; stamped into "
+        "the artifact so refresh-readme.py can distinguish a current reading "
+        "from a stale local snapshot",
+    )
     args = parser.parse_args()
 
     tests = parse_runner_output(args.input_file)
-    output = build_snapshot_detail(tests)
+    output = build_snapshot_detail(tests, git_sha=args.git_sha)
 
     with open(args.output, "w") as f:
         json.dump(output, f, separators=(",", ":"))

--- a/scripts/conformance/conformance.sh
+++ b/scripts/conformance/conformance.sh
@@ -846,6 +846,7 @@ print(f'{prev - curr:.1f}')
     local detail_file="$REPO_ROOT/scripts/conformance/conformance-detail.json"
     python3 "$REPO_ROOT/scripts/conformance/build-snapshot-detail.py" "$tmpfile" \
         --output "$detail_file" \
+        --git-sha "$git_sha" \
         || { echo "ERROR: failed to build conformance detail snapshot"; return 1; }
 
     # 4) Run analyze with JSON output

--- a/scripts/conformance/test_build_snapshot_detail.py
+++ b/scripts/conformance/test_build_snapshot_detail.py
@@ -63,6 +63,26 @@ class BuildSnapshotDetailTests(unittest.TestCase):
         )
         self.assertEqual(set(detail["failures"]), {"fail.ts"})
 
+    def test_git_sha_is_stamped_when_provided(self):
+        tests = {"pass.ts": {"status": "PASS", "expected": [], "actual": []}}
+
+        detail = build_snapshot_detail.build_snapshot_detail(
+            tests, git_sha="0123456789abcdef0123456789abcdef01234567"
+        )
+
+        self.assertEqual(
+            detail["git_sha"], "0123456789abcdef0123456789abcdef01234567"
+        )
+
+    def test_unknown_git_sha_is_not_stamped(self):
+        tests = {"pass.ts": {"status": "PASS", "expected": [], "actual": []}}
+
+        for value in (None, "unknown", "UNKNOWN", ""):
+            detail = build_snapshot_detail.build_snapshot_detail(
+                tests, git_sha=value
+            )
+            self.assertNotIn("git_sha", detail)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/emit/src/runner.ts
+++ b/scripts/emit/src/runner.ts
@@ -10,7 +10,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { createHash } from 'node:crypto';
-import { execFile as execFileCb } from 'node:child_process';
+import { execFile as execFileCb, execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'url';
 import { promisify } from 'node:util';
 import pc from 'picocolors';
@@ -1610,8 +1610,22 @@ async function main() {
 
     const jsTotal = jsPass + jsFail;
     const dtsTotal = dtsPass + dtsFail;
+    // Stamp the measured tree so refresh-readme.py can distinguish a current
+    // reading from a stale local artifact (zero-drift downward writes are
+    // legitimate). Degrades to undefined off a git checkout rather than failing
+    // the emit run.
+    let gitSha: string | undefined;
+    try {
+      gitSha = execFileSync('git', ['rev-parse', 'HEAD'], {
+        cwd: ROOT_DIR,
+        encoding: 'utf8',
+      }).trim() || undefined;
+    } catch {
+      gitSha = undefined;
+    }
     const detail = {
       timestamp: new Date().toISOString(),
+      ...(gitSha ? { git_sha: gitSha } : {}),
       detailFingerprint: detailRowsFingerprint(allResults),
       detailResultCount: allResults.length,
       summary: {

--- a/scripts/refresh-readme.py
+++ b/scripts/refresh-readme.py
@@ -20,6 +20,7 @@ Usage:
 """
 
 import argparse
+import functools
 import json
 import os
 import re
@@ -49,6 +50,103 @@ def progress_bar(current, total, width=20):
 def load_metric_json(path):
     with open(path) as f:
         return json.load(f)
+
+
+@functools.lru_cache(maxsize=1)
+def current_head_sha():
+    """Return the repo's current ``HEAD`` SHA, or ``None`` when unavailable.
+
+    Used to decide whether a suite artifact describes the tree the README is
+    being refreshed for. Any failure (not a git checkout, git missing, a
+    detached or unborn ``HEAD``) degrades to ``None`` so the caller keeps the
+    magnitude-based staleness guard rather than crashing the refresh. Cached
+    because ``HEAD`` cannot move within one refresh and both suite loaders ask.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    sha = result.stdout.strip()
+    return sha or None
+
+
+def artifact_sha(data):
+    """Return the git SHA a suite artifact recorded for its measured tree.
+
+    Suite snapshots stamp the commit they measured under ``git_sha``.
+    ``conformance.sh`` writes the literal ``"unknown"`` when ``git rev-parse``
+    fails during a snapshot; that is not a tree identity, so it is treated as
+    absent. Returns ``None`` when the artifact does not self-identify its tree.
+    """
+    if not isinstance(data, dict):
+        return None
+    sha = data.get("git_sha")
+    if not isinstance(sha, str):
+        return None
+    sha = sha.strip()
+    if not sha or sha.lower() == "unknown":
+        return None
+    return sha
+
+
+def artifact_describes_current_tree(data, head_sha):
+    """True when ``data`` was measured against the repo's current ``HEAD``.
+
+    Zero drift is the one case where a *lower* number is known to be a current
+    reading rather than a stale local artifact left over from an older tree, so
+    the monotonic publish guard must yield to it and let a genuine regression
+    surface. The comparison is prefix-tolerant so an abbreviated recorded
+    ``git_sha`` still matches a full 40-char ``HEAD``; fewer than 7 shared
+    characters is too little to trust as a commit identity.
+    """
+    recorded = artifact_sha(data)
+    if recorded is None or not head_sha:
+        return False
+    shared = min(len(recorded), len(head_sha))
+    if shared < 7:
+        return False
+    return recorded[:shared] == head_sha[:shared]
+
+
+def resolve_published_summary(
+    summary, readme_summary, data, path, *, is_ahead, suite_label
+):
+    """Pick between a freshly measured artifact summary and the README's block.
+
+    A local suite artifact may be stale, so the default is to keep the README's
+    higher block when it is ``is_ahead``. But when the artifact records the
+    current ``HEAD`` it is a *current* reading -- not a stale leftover -- and is
+    published even downward so a genuine regression, or a flaky run the monotonic
+    guard would otherwise ratchet in permanently, can surface. ``is_ahead`` is
+    the suite's magnitude guard; ``suite_label`` names the suite in the stderr
+    note/warning.
+    """
+    rel = path.relative_to(ROOT)
+    if artifact_describes_current_tree(data, current_head_sha()):
+        if is_ahead(summary, readme_summary):
+            print(
+                f"note: publishing {suite_label} metrics from {rel} even though "
+                "they are below the existing README block, because the artifact "
+                "records the current HEAD (zero drift -- a current reading, not a "
+                "stale artifact)",
+                file=sys.stderr,
+            )
+        return summary
+    if is_ahead(summary, readme_summary):
+        print(
+            f"warning: preserving README {suite_label} metrics because {rel} is "
+            f"behind the existing README {suite_label} block and does not record "
+            "the current HEAD",
+            file=sys.stderr,
+        )
+        return readme_summary
+    return summary
 
 
 def normalize_suite_summary(data, suite):
@@ -178,12 +276,6 @@ def readme_suite_summary_is_ahead(candidate, readme_summary):
     )
 
 
-def prefer_readme_suite_summary(candidate, readme_summary):
-    if readme_suite_summary_is_ahead(candidate, readme_summary):
-        return readme_summary
-    return candidate
-
-
 def load_conformance(args, readme_text):
     readme_summary = conformance_summary_from_readme(readme_text)
     explicit_path = args.conformance_metrics_json
@@ -195,19 +287,18 @@ def load_conformance(args, readme_text):
     for p in suite_metric_candidates(explicit_path, default_paths):
         if not p.exists():
             continue
-        summary = normalize_suite_summary(load_metric_json(p), "conformance")
+        data = load_metric_json(p)
+        summary = normalize_suite_summary(data, "conformance")
         if summary is None:
             continue
         if summary.get("passed") is None or summary.get("total") is None:
             continue
         if explicit_path is None and p in default_paths[1:]:
-            if readme_suite_summary_is_ahead(summary, readme_summary):
-                print(
-                    "warning: preserving README conformance metrics because "
-                    f"{p.relative_to(ROOT)} is behind the existing README conformance block",
-                    file=sys.stderr,
-                )
-            return prefer_readme_suite_summary(summary, readme_summary)
+            return resolve_published_summary(
+                summary, readme_summary, data, p,
+                is_ahead=readme_suite_summary_is_ahead,
+                suite_label="conformance",
+            )
         return summary
     return None
 
@@ -260,12 +351,6 @@ def emit_summary_from_readme(text):
     return None
 
 
-def prefer_readme_emit_summary(candidate, readme_summary):
-    if readme_emit_summary_is_ahead(candidate, readme_summary):
-        return readme_summary
-    return candidate
-
-
 def readme_emit_summary_is_ahead(candidate, readme_summary):
     if readme_summary is None:
         return False
@@ -302,13 +387,11 @@ def load_emit(args, readme_text):
         summary = normalize_emit_summary(data)
         if summary is not None:
             if args.emit_metrics_json is None and p == ROOT / "scripts" / "emit" / "emit-detail.json":
-                if readme_emit_summary_is_ahead(summary, readme_summary):
-                    print(
-                        "warning: preserving README emit metrics because "
-                        f"{p.relative_to(ROOT)} is behind the existing README emit block",
-                        file=sys.stderr,
-                    )
-                return prefer_readme_emit_summary(summary, readme_summary)
+                return resolve_published_summary(
+                    summary, readme_summary, data, p,
+                    is_ahead=readme_emit_summary_is_ahead,
+                    suite_label="emit",
+                )
             return summary
     return None
 


### PR DESCRIPTION
Fixes #16653.

The README conformance/emit publish guard in `refresh-readme.py` decided staleness by **magnitude** — "the artifact's number is lower than the README block ⇒ the artifact is stale" — via `readme_*_summary_is_ahead` / `prefer_readme_*`. That conflation is the root bug: a lower number can equally be a *genuine current regression*. Because the guard always kept the higher README value, the published figure became a **monotonic high-water mark** — regressions could never surface, and a single lucky/flaky run ratcheted the number up permanently ("it never goes down" carried no information).

**Structural rule:** the question a publish guard actually needs to answer is *"does this artifact describe the current tree?"*, not *"is this number lower?"* — magnitude fails precisely on regressions, the case we most need to publish. So replace the magnitude proxy with a **provenance signal**: each guarded suite artifact records the `git_sha` it measured; the refresh compares it to the current `HEAD` and, on **zero drift**, publishes that reading even downward (a current reading, not a stale one), while keeping the magnitude guard for artifacts that describe a *different* tree.

The mechanism is suite-agnostic and wired uniformly into **both** guarded suites (conformance and emit) through one shared `resolve_published_summary` resolver. Fourslash has no monotonic guard (it always publishes the artifact), so it already surfaces current readings and is left unchanged.

### Changes
- `scripts/refresh-readme.py`: new `current_head_sha` (memoized), `artifact_sha` (treats `"unknown"`/absent as no-identity), `artifact_describes_current_tree` (prefix-tolerant SHA match), and a shared `resolve_published_summary` used by both the conformance and emit guards. Removed the now-dead `prefer_readme_*` wrappers (their logic is the resolver's fallback branch).
- `scripts/conformance/build-snapshot-detail.py` + `scripts/conformance/conformance.sh`: stamp `git_sha` into `conformance-detail.json` (`conformance-snapshot.json` already carried it).
- `scripts/emit/src/runner.ts`: stamp `git_sha` into `emit-detail.json` (degrades to omitted off a git checkout rather than failing the run).

Behavior when the artifact is from a different tree is unchanged (the conservative magnitude guard still preserves the README block), confirmed by the dry-run against the current checkout whose local snapshot SHA ≠ `HEAD`.

Note: this PR does not hand-edit the published `11,499` number — correcting it requires a measured zero-drift snapshot (~8 min, needs the TypeScript submodule + release build). With this fix, the next zero-drift `--write` publishes the true current reading (up or down) on its own.

## Goal
Goal: hold

## Verification
- `python3 scripts/ci/test_refresh_readme.py` — 14 tests pass (adds provenance-helper tests, zero-drift downward-publish tests for conformance and emit, and a stale-artifact-preserves-README test; the three pre-existing "not downgraded by old snapshot" tests were repointed at the real `resolve_published_summary` path, strengthening coverage).
- `python3 scripts/conformance/test_build_snapshot_detail.py` — 3 tests pass (adds `git_sha` stamped / `"unknown"`-omitted tests).
- Regression check on adjacent consumers: `test_snapshot_accounting.py`, `test_full_ci_conformance_artifacts.py`, `test_query_conformance.py`, `test_link_regression_issues.py` — all pass (added `git_sha` key is additive).
- `python3 scripts/lib/check-sh-portability.py` — passes (merge-lane gate; `conformance.sh` edit).
- `python3 scripts/refresh-readme.py --skip-performance` dry-run — local snapshot SHA ≠ `HEAD`, so the magnitude guard correctly preserves the README block (conservative path exercised end-to-end).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXo89i3PGssaBiYKTF7LNJ)_