### PR TITLE
test(checker): pin keyof T[K] conditional-check collapse inside a mapped body (#15983)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2049,6 +2049,9 @@ path = "tests/string_mapping_alias_display_tests.rs"
 name = "template_intrinsic_literal_union_alias_display_tests"
 path = "tests/template_intrinsic_literal_union_alias_display_tests.rs"
 [[test]]
+name = "mapped_conditional_keyof_indexed_access_tests"
+path = "tests/mapped_conditional_keyof_indexed_access_tests.rs"
+[[test]]
 name = "class_field_mapped_type_indexed_access_tests"
 path = "tests/class_field_mapped_type_indexed_access_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/mapped_conditional_keyof_indexed_access_tests.rs
+++ b/crates/tsz-checker/tests/mapped_conditional_keyof_indexed_access_tests.rs
@@ -1,0 +1,168 @@
+//! Boundary tests for a `keyof T[K]` conditional *check* inside a generic
+//! mapped-type body — the `Kysely`-style dependent-operand family.
+//!
+//! Structural rule: when a generic mapped type
+//! `{ [P in Keys]: Lit extends keyof Obj[P] ? Obj[P][Lit] : never }` is
+//! instantiated (`P := "row"`), tsc substitutes the mapped key into the
+//! conditional's *check* type and evaluates
+//! `Lit extends keyof Obj["row"]` against the fully materialised
+//! `keyof Obj["row"]`. The true branch is taken and the member type resolves
+//! to `Obj["row"][Lit]`.
+//!
+//! tsz currently diverges only in this one shape: the conditional's extends
+//! type `keyof Obj[P]` (after `P := "row"`, a `KeyOf(IndexAccess(Lazy(Obj),
+//! "row"))`) is *not* materialised before the branch relation runs, so
+//! `Lit extends keyof Obj["row"]` is judged `false` and the whole member
+//! collapses to `never`. Every valid value is then rejected with a spurious
+//! `TS2322`/`TS2345`. This is the root cause of the still-failing driver row
+//! `tsz-cli::driver_tests::cross_file_dependent_operand_aliases_accept_scalars_and_literal_arrays`
+//! (#15983): the widened `string[]` reported there is a downstream symptom —
+//! the `DependentOperand<…>` target itself accepts *nothing* because its
+//! nested `FieldLookup` mapped/conditional collapses to `never`.
+//!
+//! It belongs to the unmaterialised-`Lazy`/`Application`-operand family
+//! (#15396): a decision site (the conditional branch relation) judges an
+//! operand — `keyof Obj[P]` — that a resolver-backed materialisation would
+//! have expanded.
+//!
+//! The passing controls below fence off the exact working neighbours so a
+//! future fix (or refactor of the mapped/conditional evaluation path) cannot
+//! silently regress them, and pin the single failing shape as an ignored,
+//! oracle-annotated red signal that is far cheaper to iterate on than the
+//! six-file driver fixture. Binder names deliberately differ from the driver
+//! fixture (`Registry`/`entries`) — see `.claude/CLAUDE.md` §25.
+
+use tsz_checker::test_utils::check_source_strict;
+
+/// Assert `source` produces no assignability diagnostics (TS2322 / TS2345) at
+/// the annotation seams the repros exercise — i.e. the annotated type resolved
+/// to a shape that accepts the assigned value.
+fn assert_resolves(source: &str, msg: &str) {
+    let codes: Vec<u32> = check_source_strict(source)
+        .iter()
+        .map(|d| d.code)
+        .filter(|&c| c == 2322 || c == 2345)
+        .collect();
+    assert_eq!(codes, Vec::<u32>::new(), "{msg}");
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Passing controls: the working neighbours of the failing shape.
+// ──────────────────────────────────────────────────────────────────────────
+
+/// `keyof Obj[K]` in a conditional *check* with an ordinary type parameter `K`
+/// (not a mapped key) materialises correctly: `Store<"row">` is `"yes"`.
+#[test]
+fn keyof_indexed_access_check_with_plain_type_param_resolves() {
+    assert_resolves(
+        r#"
+interface StoreRow { title: string; kind: 'alpha' | 'beta' }
+interface Store { row: StoreRow }
+type Probe<K extends keyof Store> = 'kind' extends keyof Store[K] ? 'yes' : 'no'
+const ok: Probe<'row'> = 'yes'
+"#,
+        "keyof Store[K] in a conditional check with a plain type param must resolve to the true branch",
+    );
+}
+
+/// `keyof Obj[P]` used directly as a mapped-type *value* (no surrounding
+/// conditional) materialises correctly: `Cols<"row">` is `keyof StoreRow`.
+#[test]
+fn keyof_indexed_access_as_mapped_value_resolves() {
+    assert_resolves(
+        r#"
+interface StoreRow { title: string; kind: 'alpha' | 'beta' }
+interface Store { row: StoreRow }
+type Cols<Tb extends keyof Store> = { [P in Tb]: keyof Store[P] }[Tb]
+const ok: Cols<'row'> = 'title'
+const ok2: Cols<'row'> = 'kind'
+"#,
+        "keyof Store[P] as a mapped value must resolve to keyof StoreRow",
+    );
+}
+
+/// A conditional *check* inside a mapped body that does NOT read the mapped key
+/// (`RowShape extends Store[P]` uses `Store[P]` only on the extends side, and
+/// the check `Lit extends keyof RowShape` reads a concrete object) resolves.
+#[test]
+fn mapped_conditional_check_without_mapped_key_keyof_resolves() {
+    assert_resolves(
+        r#"
+interface StoreRow { title: string; kind: 'alpha' | 'beta' }
+interface Store { row: StoreRow }
+type Pick1<Tb extends keyof Store> =
+  { [P in Tb]: 'kind' extends keyof StoreRow ? StoreRow['kind'] : never }[Tb]
+const ok: Pick1<'row'> = 'alpha'
+"#,
+        "a mapped conditional whose check reads a concrete object (not keyof of the mapped key) resolves",
+    );
+}
+
+/// A conditional inside a mapped body whose *check* reads the mapped key
+/// through a plain `extends` (no `keyof`) resolves — isolating that the
+/// divergence is the `keyof` wrapper, not indexed access of the mapped key.
+#[test]
+fn mapped_conditional_check_indexed_by_mapped_key_without_keyof_resolves() {
+    assert_resolves(
+        r#"
+interface StoreRow { title: string; kind: 'alpha' | 'beta' }
+interface Store { row: StoreRow }
+type Pick2<Tb extends keyof Store> =
+  { [P in Tb]: StoreRow extends Store[P] ? StoreRow['kind'] : never }[Tb]
+const ok: Pick2<'row'> = 'alpha'
+"#,
+        "a mapped conditional whose check indexes the mapped key without keyof resolves",
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// The failing shape (ignored red signal).
+// ──────────────────────────────────────────────────────────────────────────
+
+/// A generic mapped type whose conditional *check* is
+/// `Name extends keyof Obj[P]` (a `keyof` of the mapped-key-indexed access)
+/// must, after instantiation, take the true branch and resolve the member to
+/// `Obj[P][Name]`.
+///
+/// Oracle (`tsc` 7.0.2, `--strict`): `FieldLookup<Store, 'row', 'kind'>` is
+/// `'alpha' | 'beta'`, so `const ok = 'alpha'` is accepted.
+///
+/// tsz today collapses the member to `never` (the extends type
+/// `keyof Store['row']` is judged without materialising it), rejecting every
+/// value. Un-ignore when the unmaterialised-`keyof(IndexAccess(Lazy))` branch
+/// relation is fixed (#15396 family; driver row in #15983).
+#[test]
+#[ignore = "keyof(IndexAccess(Lazy)) conditional check collapses to never inside a mapped body — #15983 / #15396"]
+fn mapped_conditional_keyof_mapped_key_check_resolves() {
+    assert_resolves(
+        r#"
+interface StoreRow { title: string; kind: 'alpha' | 'beta' }
+interface Store { row: StoreRow }
+type FieldLookup<Db, Tb extends keyof Db, Name> =
+  { [P in Tb]: Name extends keyof Db[P] ? Db[P][Name] : never }[Tb]
+type Looked = FieldLookup<Store, 'row', 'kind'>
+const ok: Looked = 'alpha'
+"#,
+        "FieldLookup<Store, 'row', 'kind'> must resolve to 'alpha' | 'beta', not never",
+    );
+}
+
+/// The same defect reached through `keyof Db` as the second argument (as the
+/// driver fixture spells its `TB`), confirming the collapse is not keyed on the
+/// concrete-literal `Tb` form. Oracle (`tsc` 7.0.2, `--strict`):
+/// `FieldLookup<Store, keyof Store, 'kind'>` is `'alpha' | 'beta'`.
+#[test]
+#[ignore = "keyof(IndexAccess(Lazy)) conditional check collapses to never inside a mapped body — #15983 / #15396"]
+fn mapped_conditional_keyof_mapped_key_check_keyof_arg_resolves() {
+    assert_resolves(
+        r#"
+interface StoreRow { title: string; kind: 'alpha' | 'beta' }
+interface Store { row: StoreRow }
+type FieldLookup<Db, Tb extends keyof Db, Name> =
+  { [P in Tb]: Name extends keyof Db[P] ? Db[P][Name] : never }[Tb]
+type Looked = FieldLookup<Store, keyof Store, 'kind'>
+const ok: Looked = 'alpha'
+"#,
+        "FieldLookup<Store, keyof Store, 'kind'> must resolve to 'alpha' | 'beta', not never",
+    );
+}


### PR DESCRIPTION
Structural rule: when a generic mapped type
`{ [P in Keys]: Lit extends keyof Obj[P] ? Obj[P][Lit] : never }` is
instantiated (`P := "row"`), `tsc` substitutes the mapped key into the
conditional **check** and evaluates `Lit extends keyof Obj["row"]` against the
fully materialised `keyof Obj["row"]`; the true branch is taken and the member
resolves to `Obj["row"][Lit]`. tsz collapses that member to `never`: the extends
type `keyof Obj["row"]` — a `KeyOf(IndexAccess(Lazy(Obj), "row"))` — is judged by
the conditional branch relation **without being materialised**, so the check is
taken as `false`. Owner: the solver's conditional branch relation judging an
unmaterialised `Lazy`/`Application` operand (the #15396 family).

### Root cause of the still-failing driver row
This is the underlying cause of the known-failing
`tsz-cli::driver_tests::cross_file_dependent_operand_aliases_accept_scalars_and_literal_arrays`
(#15983). The `TS2345 string[]` reported there is a **downstream symptom**:
`DependentOperand<Registry, keyof Registry, "category">` accepts *nothing* valid
(even `'one'`, even `['one','two'] as const`) because its nested
`FieldLookup<…>` mapped/conditional evaluates to `never`. Reduced from the
six-file driver fixture to a single-file, sub-second repro:

```ts
interface StoreRow { title: string; kind: 'alpha' | 'beta' }
interface Store { row: StoreRow }
type FieldLookup<Db, Tb extends keyof Db, Name> =
  { [P in Tb]: Name extends keyof Db[P] ? Db[P][Name] : never }[Tb]
type Looked = FieldLookup<Store, 'row', 'kind'>;
const ok: Looked = 'alpha'; // tsc: ok · tsz: TS2322 (Looked is `never`)
```

Boundary confirmed by the passing controls: the same shape resolves correctly
when the conditional check uses a **plain type param** (`keyof Store[K]`), when
`keyof Store[P]` is a **mapped value** (no conditional), and when the check does
**not** `keyof` the mapped key — so the divergence is precisely the
`keyof(IndexAccess(mapped-key))` in the conditional check.

### What this PR does
Adds a fast checker-level pinning suite. This is a `hold` contribution: it
**does not change product behaviour**. It fences the working neighbours as green
regression protection and pins the failing shape as oracle-annotated `#[ignore]`
red signals (far cheaper to iterate on than the driver fixture) for whoever
takes the #15396 materialise-or-defer fix. No production code is touched.

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-checker --test mapped_conditional_keyof_indexed_access_tests` — 4 passed, 2 skipped (CI mode)
- `cargo nextest run -p tsz-checker --test mapped_conditional_keyof_indexed_access_tests --run-ignored all` — 4 passed, 2 failed (the two ignored rows are verified red today)
- `cargo clippy -p tsz-checker --test mapped_conditional_keyof_indexed_access_tests` — clean
- New file is ~165 lines (well under the 2000-line arch-size cap)

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_013QwgjwzTNL9WeCfvXgVZPf)_