### PR TITLE
fix(solver): an all-nullish union interns as the scalar survivor in non-strict mode (#16657)

### DIFF
--- a/crates/tsz-solver/src/intern/core/interner_tests.rs
+++ b/crates/tsz-solver/src/intern/core/interner_tests.rs
@@ -835,20 +835,87 @@ mod nonstrict_nullish_union_tests {
     }
 
     #[test]
-    fn nonstrict_keeps_all_nullish_union() {
+    fn nonstrict_all_nullish_collapses_to_scalar_null() {
         let interner = nonstrict();
-        // No non-nullish sibling to absorb into: the union must stay as-is, never
-        // collapse to `never` (#16580 row a6).
-        let all_nullish = interner.union(vec![TypeId::NULL, TypeId::UNDEFINED]);
+        // tsc's `addTypeToUnion` exclusion is unconditional, so an all-nullish set
+        // leaves `typeSet` empty and `getUnionType` yields the scalar survivor —
+        // `null` preferred over `undefined` on presence, not written position, and
+        // never a surviving `Union` node or `never` (#16657).
+        assert_eq!(
+            interner.union(vec![TypeId::NULL, TypeId::UNDEFINED]),
+            TypeId::NULL,
+            "null | undefined -> scalar null"
+        );
+        // Order must not matter: `null` wins on presence, not position.
+        assert_eq!(
+            interner.union(vec![TypeId::UNDEFINED, TypeId::NULL]),
+            TypeId::NULL,
+            "undefined | null -> scalar null"
+        );
+        // Discriminating negative: with no `null` in the set, `undefined` is the
+        // survivor — this is not "rewrite every nullish to null". `never` is the
+        // union identity and must not keep the set from collapsing to the scalar.
+        assert_eq!(
+            interner.union(vec![TypeId::UNDEFINED, TypeId::NEVER]),
+            TypeId::UNDEFINED,
+            "undefined | never -> scalar undefined (never stripped, no null present)"
+        );
+        // `void` is not `TypeFlags.Nullable`, so it is a genuine non-nullish sibling
+        // that absorbs the dropped `undefined`: `undefined | void` reduces to the
+        // scalar `void`, matching tsc's unconditional nullish exclusion — this path
+        // is the sibling-present drop, not the all-nullish collapse.
+        assert_eq!(
+            interner.union(vec![TypeId::UNDEFINED, TypeId::VOID]),
+            TypeId::VOID,
+            "undefined | void -> void (undefined dropped, void survives)"
+        );
+        // An all-nullish set must never collapse to `never` (#16580 row a6).
         assert_ne!(
-            all_nullish,
+            interner.union(vec![TypeId::NULL, TypeId::UNDEFINED]),
             TypeId::NEVER,
             "null | undefined must not become never"
         );
-        let members = union_members(&interner, all_nullish).expect("all-nullish stays a union");
-        assert!(
-            members.contains(&TypeId::NULL) && members.contains(&TypeId::UNDEFINED),
-            "all-nullish union must keep both members: {members:?}"
+    }
+
+    #[test]
+    fn nonstrict_all_nullish_collapse_is_uniform_across_every_seam() {
+        let interner = nonstrict();
+        // The collapse lives in the shared construction primitive, so every union
+        // constructor reaches the same scalar `null` for an all-nullish set
+        // (one-universe invariant), just as the sibling-present drop does.
+        assert_eq!(
+            interner.union(vec![TypeId::NULL, TypeId::UNDEFINED]),
+            TypeId::NULL
+        );
+        assert_eq!(
+            interner.union_from_slice(&[TypeId::NULL, TypeId::UNDEFINED]),
+            TypeId::NULL
+        );
+        assert_eq!(
+            interner.union2(TypeId::NULL, TypeId::UNDEFINED),
+            TypeId::NULL
+        );
+        assert_eq!(
+            interner.union2(TypeId::UNDEFINED, TypeId::NULL),
+            TypeId::NULL
+        );
+        assert_eq!(
+            interner.union3(TypeId::NULL, TypeId::UNDEFINED, TypeId::NEVER),
+            TypeId::NULL
+        );
+        // The all-nullish collapse replaces the buffer with the lone survivor, so
+        // it holds on `union_from_sorted_vec` regardless of the input member order.
+        assert_eq!(
+            interner.union_from_sorted_vec(vec![TypeId::NULL, TypeId::UNDEFINED]),
+            TypeId::NULL
+        );
+        assert_eq!(
+            interner.union_preserve_members(vec![TypeId::NULL, TypeId::UNDEFINED]),
+            TypeId::NULL
+        );
+        assert_eq!(
+            interner.union_literal_reduce(vec![TypeId::NULL, TypeId::UNDEFINED]),
+            TypeId::NULL
         );
     }
 

--- a/crates/tsz-solver/src/intern/normalize.rs
+++ b/crates/tsz-solver/src/intern/normalize.rs
@@ -131,10 +131,25 @@ impl TypeInterner {
     /// tsc's `addTypeToUnion` drops a `null`/`undefined` constituent from every
     /// union it constructs when `strictNullChecks` is off: the nullable is a
     /// subtype of every non-nullish type there, so it is never added to the member
-    /// set (`checker.ts`), independent of the requested `UnionReduction` mode. The
-    /// lone survivor is an *all-nullish* union (`null | undefined`, or `null`
-    /// alone) — with no non-nullish sibling to absorb into, tsc keeps the nullish
-    /// members rather than collapsing to `never`.
+    /// set (`checker.ts`), independent of the requested `UnionReduction` mode. That
+    /// exclusion is **unconditional** — both are held out regardless of what else
+    /// is in the set — so an all-nullish input leaves tsc's `typeSet` empty and
+    /// `getUnionType` falls through to its empty-set branch, which prefers the
+    /// scalar `null` over `undefined` (on presence, not position) over `never`:
+    ///
+    /// ```text
+    /// includes & TypeFlags.Null      ? nullType :
+    /// includes & TypeFlags.Undefined ? undefinedType :
+    ///                                  neverType
+    /// ```
+    ///
+    /// So `null | undefined` (in either written order) interns as the scalar
+    /// `null`, `undefined` alone as the scalar `undefined`, and only a genuinely
+    /// empty set becomes `never`. Modelling this as "no sibling to absorb into, so
+    /// leave the union alone" got the union-vs-scalar distinction wrong: a
+    /// two-member `Union` node carries `Union` flags, so every `type.flags &
+    /// Nullable` reader (e.g. the possibly-null/undefined diagnostics) stays silent
+    /// where the scalar would report (#16657).
     ///
     /// This is the general union-construction seam #16580 calls for. The checker's
     /// array-literal element path (#16574) was one witness of a rule that has to
@@ -154,19 +169,39 @@ impl TypeInterner {
         if self.strict_null_checks() {
             return;
         }
-        let mut has_nullish = false;
+        let mut has_null = false;
+        let mut has_undefined = false;
         let mut has_non_nullish = false;
         for &id in flat.iter() {
-            if id == TypeId::NULL || id == TypeId::UNDEFINED {
-                has_nullish = true;
+            if id == TypeId::NULL {
+                has_null = true;
+            } else if id == TypeId::UNDEFINED {
+                has_undefined = true;
             } else if id != TypeId::NEVER {
                 has_non_nullish = true;
             }
         }
-        if !has_nullish || !has_non_nullish {
+        if !has_null && !has_undefined {
             return;
         }
-        flat.retain(|id| *id != TypeId::NULL && *id != TypeId::UNDEFINED);
+        if has_non_nullish {
+            // A surviving non-nullish sibling absorbs every nullish member.
+            flat.retain(|id| !id.is_nullish());
+            return;
+        }
+        // All-nullish set (optionally with the `never` identity): collapse to the
+        // scalar survivor tsc's empty-`typeSet` branch yields — `null` preferred
+        // over `undefined` on presence, not written position. `narrowing`'s
+        // `collapse_pure_nullish_union_nonstrict` encodes the same survivor rule a
+        // layer up as a pre-construction origin gate; if this rule ever changes,
+        // both must move together.
+        let survivor = if has_null {
+            TypeId::NULL
+        } else {
+            TypeId::UNDEFINED
+        };
+        flat.clear();
+        flat.push(survivor);
     }
 
     /// Apply [`reduce_nonstrict_nullish_members`](Self::reduce_nonstrict_nullish_members)


### PR DESCRIPTION
When `strictNullChecks` is off, tsc's `addTypeToUnion` excludes `null`/`undefined`
**unconditionally**, so an all-nullish member set leaves `typeSet` empty and
`getUnionType` falls through to its empty-set branch, yielding the scalar `null`
(preferred over `undefined` on presence, not position), never a surviving union.
tsz's interner modelled this as "no non-nullish sibling to absorb into, so leave
the union alone", which got `never` right but interned `null | undefined` as a
two-member `Union`. A `Union` node carries `Union` flags, so every
`type.flags & Nullable` reader (the possibly-null/undefined diagnostics) stays
silent exactly where the scalar would report — a latent divergence masked only by
compensating fixes one layer up (#16629 lowering, #16652 return inference, #16593
syntactic resolvers). Any future path that builds an all-nullish union without
routing through one of those layers would surface it as a missing possibly-null
diagnostic with no obvious link to union construction.

Structural rule: when `strictNullChecks` is off and a union member set is
all-nullish (only `null`/`undefined`, optionally with the `never` identity), tsc
collapses it to the scalar survivor; tsz now does the same through the solver
interner's `reduce_nonstrict_nullish_members` construction primitive.

Fixed at the single shared seam rather than adding a fourth compensating layer:
all four union constructors (`union_from_sorted_vec`, `union_preserve_members`,
`normalize_union`, `normalize_union_literal_only`) funnel through
`reduce_and_collapse_nonstrict`, so the collapse now holds uniformly at every
union seam — annotations, aliases, return types, and flow joins alike — keeping
one canonical identity per member set. `void` is deliberately not collapsed
(tsc's `TypeFlags.Nullable` is `Undefined | Null` only), and the sibling-present
drop path is unchanged.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-solver --lib` — 7653 passed, 0 failed (includes the re-pinned
  `nonstrict_all_nullish_collapses_to_scalar_null` and new
  `nonstrict_all_nullish_collapse_is_uniform_across_every_seam`, which asserts the
  scalar result across all 8 constructor entry points).
- `cargo test -p tsz-checker` non-strict-nullish integration suites
  (`nullable_union_assignability_target_display_tests`,
  `nullable_union_missing_property_tests`, `nullish_non_strict_assignability_tests`,
  `optional_chain_literal_nullish_ts2339_tests`, `ts2869_syntactic_never_nullish_tests`,
  `ts2871_always_nullish_tests`) — 61 passed, 0 failed.
- `cargo clippy -p tsz-solver` — clean.
- Adjacent matrix covered by the re-pinned solver tests: order-independence
  (`null | undefined` and `undefined | null` both → `null`), the discriminating
  negative (`undefined | never` → scalar `undefined`, so this is not
  "rewrite every nullish to null"), `void` as a genuine non-nullish sibling
  (`undefined | void` → `void`), the strict-mode control (both members kept), and
  the `never`-not-`never` guard (`null | undefined` must not become `never`).
- Not run locally: full conformance/emit snapshots (the TypeScript corpus
  submodule is not materialized in this environment). Behavior is guarded by the
  solver + checker suites above; nightly CI covers conformance/emit. The printer
  renders a one-member union and the scalar identically and assignability is
  identical under the flag, so no rendered-diagnostic drift is expected — the only
  observable difference is `type.flags & Nullable` readers now firing where tsc
  fires.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

Closes #16657

---
_Generated by [Claude Code](https://claude.ai/code/session_01XX1xSGJzsDBE6ecpfimP34)_