### PR TITLE
fix(solver): a generic call's closest-miss argument check honors strictFunctionTypes for callback variance (#16632)

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -355,6 +355,8 @@ mod generator_yieldstar_symbol_iterator_contribution_tests;
 mod generic_alias_application_display_tests;
 #[path = "tests/generic_argument_suppression_relation_routing_arch_tests.rs"]
 mod generic_argument_suppression_relation_routing_arch_tests;
+#[path = "tests/generic_call_bivariant_callback_nonstrict_tests.rs"]
+mod generic_call_bivariant_callback_nonstrict_tests;
 #[path = "tests/generic_call_enclosing_type_param_return_tests.rs"]
 mod generic_call_enclosing_type_param_return_tests;
 #[path = "tests/generic_call_non_fresh_object_widening_tests.rs"]

--- a/crates/tsz-checker/src/tests/generic_call_bivariant_callback_nonstrict_tests.rs
+++ b/crates/tsz-checker/src/tests/generic_call_bivariant_callback_nonstrict_tests.rs
@@ -1,0 +1,119 @@
+//! Regression tests for generic-call overload resolution honoring the
+//! `strictFunctionTypes` option when comparing callback arguments.
+//!
+//! Structural rule: when `strictFunctionTypes` is disabled, `tsc` compares
+//! function/method parameters bivariantly in *every* relation — its
+//! `strictVariance` (in `compareSignaturesRelated`) reads the global option,
+//! not which relation is running. A generic call's final "closest-miss"
+//! argument check must therefore also be bivariant when the option is off.
+//!
+//! Before the fix, the generic-call resolver's final check routed callback
+//! arguments through the solver's *strict* assignability relation
+//! (`CompatChecker::is_assignable_strict`), which forced
+//! `strict_function_types = true` regardless of the compiler option. When no
+//! inference candidate succeeded outright (the union-param + union-return shape
+//! of `PromiseLike.then`), the reported closest miss compared the callback
+//! parameter contravariantly and manufactured a spurious `TS2345` that the
+//! plain (non-generic) assignability path never reports.
+//!
+//! Witness (issue #16632): `Promise.all(xs.map(populate)).then(cb)` under
+//! `--strict false`. The reduced, lib-independent form used here is a
+//! hand-written `PromiseLike`-shaped interface whose `then` parameter is a
+//! union `((value: T) => U | Like<U>) | null` — the union parameter plus the
+//! union callback return are what force resolution onto the closest-miss path.
+
+use crate::test_utils::check_source_diagnostics;
+
+/// A `PromiseLike`-shaped interface with the union parameter + union return
+/// that reproduces the closest-miss path. `like`/`t`/`u` vary the interface and
+/// type-parameter binders so the fix cannot be a name-scoped special case.
+fn like_iface(like: &str, t: &str, u: &str) -> String {
+    format!(
+        r#"
+interface {like}<{t}> {{
+    then<{u} = {t}>(
+        cb?: ((value: {t}) => {u} | {like}<{u}>) | null
+    ): {like}<{u}>;
+}}
+"#
+    )
+}
+
+fn ts2345_messages(diags: &[crate::diagnostics::Diagnostic]) -> Vec<String> {
+    diags
+        .iter()
+        .filter(|d| d.code == 2345)
+        .map(|d| d.message_text.clone())
+        .collect()
+}
+
+#[test]
+fn nonstrict_generic_then_accepts_narrower_callback_parameter() {
+    // `--strict false` ⇒ strictFunctionTypes off ⇒ bivariant callback params.
+    // `b: Like<unknown[]>` binds the callback parameter to `unknown[]`; the
+    // supplied callback takes `number[]`. Bivariance accepts it (tsc: clean).
+    let source = format!(
+        "// @strict: false\n{}\ndeclare const b: Like<unknown[]>;\nb.then((value: number[]) => {{ }});\n",
+        like_iface("Like", "T", "U")
+    );
+    let diags = check_source_diagnostics(&source);
+    assert!(
+        ts2345_messages(&diags).is_empty(),
+        "Expected no TS2345 for a narrower callback parameter under --strict false, got: {:?}",
+        ts2345_messages(&diags)
+    );
+}
+
+#[test]
+fn nonstrict_generic_then_bivariance_survives_renamed_binders() {
+    // Same shape with every binder renamed — no user-name/file-name literal can
+    // be driving the decision.
+    let source = format!(
+        "// @strict: false\n{}\ndeclare const p: Thenable<unknown[]>;\np.then((incoming: number[]) => {{ }});\n",
+        like_iface("Thenable", "Elem", "Res")
+    );
+    let diags = check_source_diagnostics(&source);
+    assert!(
+        ts2345_messages(&diags).is_empty(),
+        "Expected no TS2345 (renamed binders) under --strict false, got: {:?}",
+        ts2345_messages(&diags)
+    );
+}
+
+#[test]
+fn strict_generic_then_still_rejects_contravariant_callback_parameter() {
+    // Adjacent negative case: with `--strict true` (strictFunctionTypes on) the
+    // same call is a genuine contravariance error — `unknown[]` is not
+    // assignable to `number[]`. tsc reports TS2345; the fix must not suppress it.
+    let source = format!(
+        "// @strict: true\n{}\ndeclare const b: Like<unknown[]>;\nb.then((value: number[]) => {{ }});\n",
+        like_iface("Like", "T", "U")
+    );
+    let diags = check_source_diagnostics(&source);
+    assert!(
+        !ts2345_messages(&diags).is_empty(),
+        "Expected TS2345 under --strict true (strictFunctionTypes contravariance), got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn nonstrict_generic_then_accepts_widening_callback_parameter() {
+    // Positive control: a callback parameter that is a *supertype* of the bound
+    // element type is assignable in every mode. This must stay clean before and
+    // after the fix, confirming the change only relaxes the previously
+    // over-strict direction.
+    let source = format!(
+        "// @strict: false\n{}\ndeclare const b: Like<number[]>;\nb.then((value: unknown[]) => {{ }});\n",
+        like_iface("Like", "T", "U")
+    );
+    let diags = check_source_diagnostics(&source);
+    assert!(
+        ts2345_messages(&diags).is_empty(),
+        "Expected no TS2345 for a widening callback parameter, got: {:?}",
+        ts2345_messages(&diags)
+    );
+}

--- a/crates/tsz-solver/src/operations/call_args/strict_assignability.rs
+++ b/crates/tsz-solver/src/operations/call_args/strict_assignability.rs
@@ -140,7 +140,22 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         }
 
         if strict {
-            let related = self.checker.is_assignable_to_strict(actual, expected);
+            // A function-valued argument follows the compiler's
+            // `strictFunctionTypes` option for parameter variance (see
+            // `AssignabilityChecker::strict_function_types`): when it is off the
+            // closest-miss check must compare bivariantly, or it manufactures a
+            // `TS2345` the plain assignability path never reports (#16632). The
+            // `strict` flag still governs rest-binder raw-surface exactness in the
+            // `raw_sensitive` branch above; it must not force function
+            // contravariance the user opted out of. Non-callable arguments keep
+            // the existing strict relation.
+            let honor_bivariant_callback = !self.checker.strict_function_types()
+                && crate::type_queries::is_callable_type(self.interner, actual);
+            let related = if honor_bivariant_callback {
+                self.checker.is_assignable_to(actual, expected)
+            } else {
+                self.checker.is_assignable_to_strict(actual, expected)
+            };
             related
                 || (allow_contextual_retry
                     && self.is_assignable_via_contextual_signatures_strict(actual, expected))

--- a/crates/tsz-solver/src/operations/core/call_evaluator.rs
+++ b/crates/tsz-solver/src/operations/core/call_evaluator.rs
@@ -74,6 +74,19 @@ pub trait AssignabilityChecker {
         self.is_assignable_to(source, target)
     }
 
+    /// Whether the compiler's `strictFunctionTypes` option is enabled.
+    ///
+    /// `tsc` decides function/method parameter variance from this global option
+    /// in every relation (its `strictVariance` in `compareSignaturesRelated`
+    /// reads the option, not which relation is running). The generic-call final
+    /// argument check consults it to pick a bivariant callback comparison when
+    /// the user has disabled `strictFunctionTypes`, matching the non-generic
+    /// assignability path. Defaults to `true` (sound) for checkers that do not
+    /// track the option.
+    fn strict_function_types(&self) -> bool {
+        true
+    }
+
     /// Evaluate/expand a type using the checker's resolver context.
     /// This is needed during inference constraint collection, where Application types
     /// like `Func<T>` must be expanded to their structural form (e.g., a Callable).

--- a/crates/tsz-solver/src/relations/compat.rs
+++ b/crates/tsz-solver/src/relations/compat.rs
@@ -1855,6 +1855,10 @@ impl<'a, R: TypeResolver> AssignabilityChecker for CompatChecker<'a, R> {
         self.is_assignable_impl(source, target, false)
     }
 
+    fn strict_function_types(&self) -> bool {
+        self.strict_function_types
+    }
+
     fn evaluate_type(&mut self, type_id: TypeId) -> TypeId {
         self.subtype.evaluate_type(type_id)
     }


### PR DESCRIPTION
When `strictFunctionTypes` is disabled, `tsc` compares function/method parameters bivariantly in **every** relation — its `strictVariance` (in `compareSignaturesRelated`) reads the global option, not which relation is running. tsz's generic-call final **"closest-miss"** argument check (`argument_assignable_preserving_rest_surface`) instead routed a function-valued argument through the strict relation (`CompatChecker::is_assignable_strict`), which forces contravariant parameter checking regardless of the option. When no inference candidate succeeds outright — the union-parameter + union-return shape of `PromiseLike.then` — the reported closest miss compared the callback parameter contravariantly and manufactured a spurious `TS2345` (#16632).

**Structural rule:** when `strictFunctionTypes` is off, a generic call's callback argument is compared bivariantly, exactly like the non-generic call path and `tsc`. The `strict` flag on this path still governs rest-binder raw-surface exactness — it must not override the user's function-variance choice.

**Owner layer:** solver — `crates/tsz-solver/src/operations/call_args/strict_assignability.rs`, gated on a new `AssignabilityChecker::strict_function_types()` accessor (default `true`, overridden by `CompatChecker`).

### Fix
- Expose the compiler option through `AssignabilityChecker::strict_function_types()` (default `true` = sound; `CompatChecker` returns its real field).
- In the generic-call final argument check, route a **callable** argument through the flag-honoring `is_assignable_to` (bivariant when the option is off) instead of `is_assignable_to_strict`. Non-callable arguments and the rest-binder `raw_sensitive` branch are unchanged.
- Under `strictFunctionTypes` **on** (the sound default), the code path is byte-identical to before — the change only affects `--strict false` / `--strictFunctionTypes false` programs.

**Deliberate scope:** an earlier, broader attempt to make the relation-layer `is_assignable_strict` honor the flag globally caused an infinite-recursion **stack overflow** in an unrelated recursive-tuple-alias assignment (a different caller of the strict relation). The fix is therefore confined to the generic-call argument path.

### Adjacent-case matrix (behavioral, lib-independent repros)
| shape | `--strict false` | `--strict true` |
|---|---|---|
| bare callback param `(value: T) => U` | clean (already) | clean |
| **union param + union return** `((value:T)=>U\|L<U>)\|null` (the bug) | **clean (was TS2345)** | TS2345 (contravariant — correct) |
| widening callback param (supertype) | clean | clean |
| renamed binders (`Thenable`/`Elem`/`Res`) | clean | — |
| issue's `Promise.all(...).then(cb)` witness | clean | — |

### Known adjacent gaps (follow-up, rarer shapes)
- A callback nested inside an **object-typed** argument, or a rest-binder callback (`raw_sensitive` branch), still uses the strict relation and would remain over-strict under `--strict false`. These are separate, rarer shapes; broadening to them shifts the `any`/excess/weak dimensions for non-callable args and was left out of this change's verified scope.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-solver --lib` → **7650 passed / 0 failed** (includes the two `operations::tests` unit tests whose intent — contravariant/strict raw-rest rejection — is preserved unchanged).
- `cargo test -p tsz-checker --lib` → green; **4 new regression tests** in `generic_call_bivariant_callback_nonstrict_tests.rs` pass (narrower-param accepted, renamed-binders, widening control, and a `--strict true` negative that still reports TS2345). Full checker suite passes (the recursive-tuple-alias and `ts2589` tests need `RUST_MIN_STACK`/`nextest` here — a pre-existing `cargo test` stack-size artifact, not this change).
- **Conformance** (`snapshot --workers 12 --force` at pinned TS SHA `4d4f005c`): net-positive, **0 regressions**. No test went PASS→FAIL. The two diffs vs the committed baseline were both proven neutral by A/B (base binary vs fixed binary, byte-identical output): `declarationsAndAssignments.ts` is stale-baseline drift, and `typeArgumentInferenceConstructSignatures.ts` is a pre-existing non-termination (hangs on the base binary too — the #13508 family) that timed out under this machine's load. The regenerated baseline was **not** committed (machine-specific).
- `cargo clippy` on `tsz-solver` + `tsz-checker`, `cargo fmt --all --check`, and `python3 scripts/arch/arch_guard.py` — all clean (also enforced by the pre-commit hook).
- Emit gate not run: the Node runner could not bootstrap its `npm install` in this network-restricted environment. The change is emit-neutral by construction — it only flips accept/reject of a generic-call argument (a diagnostic); it never changes an inferred type (the issue confirms the DTS-emitted `Promise<unknown[]>` is byte-identical) and JS emit does not run the checker.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJ8LAHuRVcmzYNGoeWTNZ5)_