### PR TITLE
fix(checker): an empty callback body keeps `void` under a union return context (#16632)

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -373,6 +373,8 @@ mod generic_callback_outer_context_tests;
 mod generic_callback_return_outer_annotation_leak_tests;
 #[path = "tests/generic_callback_sibling_arg_inference_tests.rs"]
 mod generic_callback_sibling_arg_inference_tests;
+#[path = "tests/generic_callback_union_return_void_body_tests.rs"]
+mod generic_callback_union_return_void_body_tests;
 #[path = "tests/generic_checker_mod_relation_routing_arch_tests.rs"]
 mod generic_checker_mod_relation_routing_arch_tests;
 #[path = "tests/generic_class_constructor_literal_preservation_tests.rs"]

--- a/crates/tsz-checker/src/tests/generic_callback_union_return_void_body_tests.rs
+++ b/crates/tsz-checker/src/tests/generic_callback_union_return_void_body_tests.rs
@@ -1,0 +1,157 @@
+//! An empty (`void`) callback body inferring a naked type parameter that sits
+//! inside a **union** callback-return target.
+//!
+//! For `m<U>(cb: (v: T) => U | X): U`, a callback with an empty body returns
+//! `void`, so `tsc` infers `U = void` from the naked `U` arm of the union. tsz
+//! computed the empty body's return type from the contextual return type: an
+//! empty body was narrowed to `undefined` whenever `undefined` was assignable to
+//! the contextual return — including a `void | X` union that also accepts `void`.
+//! Because the contextual return is itself the inference target `U | X`, that
+//! narrowing made the inferred body type oscillate between `void` and
+//! `undefined` as `U` was fixed and re-substituted across inference rounds, so
+//! `U` resolved to `undefined`/`any` instead of `void`. Under
+//! `strictNullChecks: false` the target return then dropped its `undefined` arm
+//! and the callback's `void` return no longer matched, producing a spurious
+//! `TS2345` — the false positive tracked in #16632 (the `Promise.all(...).then`
+//! shape of `inferenceLimit.ts`).
+//!
+//! The fix keeps `void` whenever the contextual return type accepts `void` (or
+//! is still an unresolved inference target), and only substitutes `undefined`
+//! when the context needs `undefined` specifically (`() => undefined`).
+//!
+//! Binder names are varied across cases per the anti-hardcoding contract; every
+//! case is pinned against `typescript@7.0.2` (`--strict false`).
+
+use crate::test_utils::{check_source_non_strict_codes, check_source_strict_codes};
+
+fn codes(src: &str) -> Vec<u32> {
+    check_source_non_strict_codes(src)
+}
+
+fn only(src: &str, code: u32) -> Vec<u32> {
+    codes(src).into_iter().filter(|&c| c == code).collect()
+}
+
+/// The core repro: a method-declared generic callback whose return target is
+/// `U | number`, called with an empty-body lambda. No spurious `TS2345`.
+#[test]
+fn method_union_return_void_body_no_ts2345() {
+    assert_eq!(
+        only(
+            "interface Box<Elem> { run<Res>(cb: (item: Elem) => Res | number): Res; }\n\
+             declare const box: Box<unknown[]>;\n\
+             box.run((rows) => {});",
+            2345,
+        ),
+        Vec::<u32>::new(),
+    );
+}
+
+/// The `T | PromiseLike<T>`-shaped union (the `.then` shape) is likewise clean.
+#[test]
+fn method_thenable_union_return_void_body_no_ts2345() {
+    assert_eq!(
+        only(
+            "interface Chain<Seed> { step<Out>(cb: (seed: Seed) => Out | PromiseLike<Out>): Chain<Out>; }\n\
+             declare const chain: Chain<unknown[]>;\n\
+             chain.step((orders) => { });",
+            2345,
+        ),
+        Vec::<u32>::new(),
+    );
+}
+
+/// A `U | U[]` union arm containing the naked parameter structurally is also
+/// clean — the empty body must not be widened away from `void`.
+#[test]
+fn method_array_union_return_void_body_no_ts2345() {
+    assert_eq!(
+        only(
+            "interface Sink<In> { push<Val>(fn: (arg: In) => Val | Val[]): Val; }\n\
+             declare const sink: Sink<unknown[]>;\n\
+             sink.push((entries) => {});",
+            2345,
+        ),
+        Vec::<u32>::new(),
+    );
+}
+
+/// Not a method: a function-property callback slot behaves the same (the bug was
+/// never about method bivariance — it is the empty-body return type).
+#[test]
+fn function_property_union_return_void_body_no_ts2345() {
+    assert_eq!(
+        only(
+            "interface Holder<Cell> { apply: <Yield>(cb: (cell: Cell) => Yield | number) => Yield; }\n\
+             declare const holder: Holder<unknown[]>;\n\
+             holder.apply((cells) => {});",
+            2345,
+        ),
+        Vec::<u32>::new(),
+    );
+}
+
+/// The inferred result must be `void`, not `any`: consuming it where a `number`
+/// is required is a real `TS2322`. Under the bug `U` inferred `any`, which would
+/// silence this — so the presence of `TS2322` pins the correct `void` inference.
+#[test]
+fn empty_body_union_return_infers_void_not_any() {
+    assert_eq!(
+        only(
+            "interface Maker<Src> { make<Made>(cb: (src: Src) => Made | number): Made; }\n\
+             declare const maker: Maker<unknown[]>;\n\
+             const produced = maker.make((parts) => {});\n\
+             const asNumber: number = produced;",
+            2322,
+        ),
+        vec![2322],
+    );
+    // And consuming the same result where `void` is expected is clean.
+    assert_eq!(
+        only(
+            "interface Maker<Src> { make<Made>(cb: (src: Src) => Made | number): Made; }\n\
+             declare const maker: Maker<unknown[]>;\n\
+             const produced = maker.make((parts) => {});\n\
+             const asVoid: void = produced;",
+            2322,
+        ),
+        Vec::<u32>::new(),
+    );
+}
+
+/// A concrete-value body still infers the value's type through the union — the
+/// naked arm is not swallowed by the structured `PromiseLike` arm.
+#[test]
+fn concrete_body_union_return_infers_value_type() {
+    // `Res` is `number`, so a `string` consumer is a real `TS2322`.
+    assert_eq!(
+        only(
+            "interface Pipe<Feed> { via<Res>(cb: (feed: Feed) => Res | Res[]): Res; }\n\
+             declare const pipe: Pipe<unknown[]>;\n\
+             const out = pipe.via((feed) => 5);\n\
+             const asString: string = out;",
+            2322,
+        ),
+        vec![2322],
+    );
+}
+
+/// Regression guard for the preserved behavior: an empty body contextually typed
+/// by a return that needs `undefined` specifically (not `void`) is still
+/// narrowed to `undefined`, so `() => undefined = () => {}` stays clean. This is
+/// the `strictNullChecks` case, where `void` is genuinely not assignable to
+/// `undefined` and the coercion is the only thing that keeps the assignment
+/// clean — exactly the behavior the fix must not disturb.
+#[test]
+fn empty_body_undefined_only_context_still_coerces() {
+    assert_eq!(
+        check_source_strict_codes(
+            "const cb: () => undefined = () => {};\n\
+             const used: undefined = cb();",
+        )
+        .into_iter()
+        .filter(|&c| c == 2322)
+        .collect::<Vec<u32>>(),
+        Vec::<u32>::new(),
+    );
+}

--- a/crates/tsz-checker/src/tests/return_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/return_relation_routing_arch_tests.rs
@@ -79,12 +79,31 @@ fn return_statement_diagnostics_use_return_relation_outcome_boundary() {
             .contains("diagnostic_relation_boolean_guard(when_false,expected_return_type)"),
         "expression-bodied conditional false returns should not pre-gate with a raw boolean relation"
     );
+    // The `return;`/fall-through empty-body coercion decision is centralized in
+    // `empty_body_prefers_undefined`, which both inference sites call. That helper
+    // must reach its answer through the return-shaped relation outcome — for
+    // `undefined` (the coerced type) and for `void` (whose acceptance keeps the
+    // natural `void` return) — never a raw boolean assignability probe.
     assert_eq!(
         compact_return_type_source
             .matches("return_relation_outcome(TypeId::UNDEFINED,ctx).related")
             .count(),
+        1,
+        "empty/fallthrough return inference should use a single return-shaped `undefined` relation outcome"
+    );
+    assert_eq!(
+        compact_return_type_source
+            .matches("return_relation_outcome(TypeId::VOID,ctx).related")
+            .count(),
+        1,
+        "empty/fallthrough return inference should gate `undefined` on a return-shaped `void` relation outcome"
+    );
+    assert_eq!(
+        compact_return_type_source
+            .matches("empty_body_prefers_undefined(ctx)")
+            .count(),
         2,
-        "contextual empty/fallthrough return inference should use return-shaped relation outcomes"
+        "both the `return;` and fall-through inference sites should route through the shared helper"
     );
     assert!(
         !compact_return_type_source.contains("is_assignable_to(TypeId::UNDEFINED,ctx)"),

--- a/crates/tsz-checker/src/types/utilities/return_type.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type.rs
@@ -984,6 +984,38 @@ impl<'a> CheckerState<'a> {
         hasher.finish()
     }
 
+    /// Whether an empty (or `return;`-only) function body contextually typed by
+    /// `ctx` should infer `undefined` rather than its natural `void`.
+    ///
+    /// An empty body returns `void`. `tsc` lets it be treated as `undefined` only
+    /// when the contextual return type needs `undefined` specifically — e.g.
+    /// `const f: () => undefined = () => {}`. When the context also accepts `void`
+    /// (a bare `void`, a `void | T` union, or a still-unresolved generic return
+    /// position a `void` lower bound satisfies), `void` is correct. Preferring
+    /// `undefined` there is unsound for generic-call inference: a naked type
+    /// parameter in a callback-return union (`(v) => U | X`) would infer
+    /// `U = undefined` instead of `void`, and the inferred body type would
+    /// oscillate between `void` and `undefined` across inference rounds as `U` is
+    /// fixed and re-substituted — corrupting the call and producing spurious
+    /// `TS2345`s (#16632).
+    fn empty_body_prefers_undefined(&mut self, ctx: TypeId) -> bool {
+        // Keep the natural `void` whenever the context accepts it — the top types
+        // (`any`/`unknown`), `void` itself, or a still-unresolved inference target
+        // (a type parameter or, since that predicate also matches them, an `infer`
+        // placeholder).
+        if ctx == TypeId::VOID
+            || ctx == TypeId::ANY
+            || ctx == TypeId::UNKNOWN
+            || self.contains_type_parameters_cached(ctx)
+        {
+            return false;
+        }
+        // Otherwise narrow to `undefined` only when the context needs it
+        // specifically: it accepts `undefined` but not `void` (`() => undefined`).
+        self.return_relation_outcome(TypeId::UNDEFINED, ctx).related
+            && !self.return_relation_outcome(TypeId::VOID, ctx).related
+    }
+
     /// Inner implementation of return type inference (no diagnostic/cache cleanup).
     fn infer_return_type_from_body_inner(
         &mut self,
@@ -1071,14 +1103,13 @@ impl<'a> CheckerState<'a> {
             // (e.g., `number`), fall through to the void/contextual check below.
             if saw_empty {
                 if let Some(ctx) = return_context {
-                    // Only narrow to `undefined` when the contextual return type is a
-                    // specific undefined-compatible type (not `any`/`unknown`/`void`).
-                    // `any`/`unknown` accept everything — don't change inference for them.
-                    if ctx != TypeId::VOID
-                        && ctx != TypeId::ANY
-                        && ctx != TypeId::UNKNOWN
-                        && self.return_relation_outcome(TypeId::UNDEFINED, ctx).related
-                    {
+                    // Only narrow to `undefined` when the context needs it
+                    // specifically. Keep the natural `void` whenever the context
+                    // also accepts `void` (`void`, `void | T`, or a not-yet-fixed
+                    // inference target): coercing those to `undefined` makes an
+                    // empty callback body's inferred return type oscillate as a
+                    // contextual union's type parameters get fixed (see below).
+                    if self.empty_body_prefers_undefined(ctx) {
                         return TypeId::UNDEFINED;
                     }
                 } else {
@@ -1094,13 +1125,8 @@ impl<'a> CheckerState<'a> {
                 // When contextual return type expects `undefined` (not void/any/unknown),
                 // use `undefined` so `const f: () => undefined = () => {}` doesn't produce TS2322.
                 // tsc applies contextual typing to infer the return type of such lambdas.
-                // Exclude `any`/`unknown` — they accept everything and shouldn't change inference.
-                if let Some(ctx) = return_context
-                    && ctx != TypeId::VOID
-                    && ctx != TypeId::ANY
-                    && ctx != TypeId::UNKNOWN
-                    && self.return_relation_outcome(TypeId::UNDEFINED, ctx).related
-                {
+                // Keep `void` whenever the context also accepts it (see the helper).
+                if return_context.is_some_and(|ctx| self.empty_body_prefers_undefined(ctx)) {
                     TypeId::UNDEFINED
                 } else {
                     TypeId::VOID


### PR DESCRIPTION
Fixes #16632.

An empty (or `return;`-only) function body returns `void`. `tsc` infers a naked type parameter that sits in a callback-return **union** — `(v) => U | X` — as `U = void` from that body. tsz instead narrowed the empty body to `undefined` whenever `undefined` was assignable to the contextual return type, **including** a `void | X` union (or the still-unresolved `U | X`) that also accepts `void`. Because that contextual return is itself the inference target, the coerced `undefined` made the inferred body type oscillate between `void` and `undefined` as `U` was fixed and re-substituted across inference rounds, so `U` resolved to `undefined`/`any` instead of `void`. Under `strictNullChecks: false` the target return then dropped its `undefined` arm and the callback's `void` return no longer matched, producing a spurious `TS2345` — the `Promise.all(...).then` false positive of `inferenceLimit.ts`.

**Structural rule:** when an empty body is contextually typed by a return type that accepts `void`, `tsc` infers `void`; tsz now does too, through `infer_return_type_from_body` (`crates/tsz-checker/src/types/utilities/return_type.rs`). The empty-body `void`→`undefined` coercion is gated on the shared `empty_body_prefers_undefined`, which keeps `void` for any context that accepts `void` (`void`, `void | T`, the top types) or that is still an unresolved inference target (a type parameter / `infer`), and only substitutes `undefined` when the context needs it specifically (`() => undefined`). Both empty-body coercion sites route through the one helper; the return-relation-routing architecture test is updated for that consolidation.

Adjacent matrix covered by the new test module: method vs function-property callback slots; union arms `U | number`, `U | U[]`, `U | PromiseLike<U>` (the `.then` shape); inferred result pinned to `void` (a `number` consumer is a real `TS2322`, which the `any` bug would have silenced) and to concrete types for value-returning bodies; and the preserved `strict` `() => undefined = () => {}` coercion. Binder names are varied per the anti-hardcoding contract; every case is pinned against `typescript@7.0.2`.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib` — green (new `generic_callback_union_return_void_body_tests`, 7 cases; `return_relation_routing_arch_tests` updated for the shared-helper consolidation; `non_strict_nullish_return_widening_tests` from #16580 still pass on top).
- Conformance snapshot (`conformance.sh snapshot --workers 12 --force`, TS 7.0.2 corpus): **0 regressions**, **+2** newly passing (`typeArgumentInferenceConstructSignatures.ts`, `promisePermutations.ts`). `inferenceLimit.ts` passes before and after on `main` (its regression only surfaces atop #16624, unmerged; verified fixed there by an A/B build).
- Repro (`--strict false --target es6`): the reduced witnesses (`interface Obj { m<U>(cb: (v: unknown[]) => U | PromiseLike<U>): Obj }; o.m((x) => {})` and siblings) go from `TS2345` to clean, matching `tsc`.
- `cargo fmt --all`, `cargo clippy -p tsz-checker`, architecture size guard: clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01H6zz6uPNXzVK1WeghRM2WU