### PR TITLE
fix(checker): a write-only optional-chain target reports its genuinely-nullish receiver (#16683)

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -697,6 +697,8 @@ mod optional_chain_parenthesized_target_tests;
 mod optional_chain_read_before_write_tests;
 #[path = "tests/optional_chain_root_nullish_strict_only_tests.rs"]
 mod optional_chain_root_nullish_strict_only_tests;
+#[path = "tests/optional_chain_write_target_nullish_tests.rs"]
+mod optional_chain_write_target_nullish_tests;
 #[path = "tests/optional_key_extraction_tests.rs"]
 mod optional_key_extraction_tests;
 #[path = "tests/optional_private_field_undefined_tests.rs"]

--- a/crates/tsz-checker/src/tests/optional_chain_write_target_nullish_tests.rs
+++ b/crates/tsz-checker/src/tests/optional_chain_write_target_nullish_tests.rs
@@ -1,0 +1,450 @@
+//! A write-only optional-chain target (`=`, a `for...in`/`for...of` head) whose
+//! *receiver* carries genuine optionality reports the possibly-nullish family
+//! (`TS18047`/`TS18048`/`TS18049`) on that receiver, alongside the existing
+//! `TS2779`/`TS2781`/`TS2405` grammar error.
+//!
+//! This is the write-only companion of `optional_chain_read_before_write_tests`.
+//! The discriminator is *not* "write-only forms never report" — it is **which
+//! `undefined` the receiver carries**:
+//!
+//! - `a.b?.c.d = 1` (`c` required): the receiver's `undefined` is the chain's
+//!   own short-circuit marker. `tsc` strips the marker before checking the
+//!   continuation, so nothing is reported. `TS2779` alone.
+//! - `q?.w.e = 1` (`w?` optional): the receiver's `undefined` is real
+//!   optionality and survives the strip. `TS18048 'q.w'` + `TS2779`.
+//! - `z.y?.x.v = 1` (`y?` and `x?` both optional): the receiver carries both a
+//!   marker *and* real optionality. The real one survives.
+//!   `TS18048 'z.y.x'` + `TS2779`.
+//!
+//! Structural rule: the write-target short-circuits in
+//! `types/property_access_type/resolve.rs` and `types/computation/access.rs`
+//! compute the receiver's type (so its own diagnostics still fire) and then
+//! discard it before returning `TypeId::ANY`. Routing that already-computed
+//! type through `report_write_target_chain_nullish_receiver`
+//! (`types/property_access_type/nullish_access.rs`), which applies
+//! `remove_optional_chain_marker` first, is the whole fix. Owner:
+//! `types/property_access_type/nullish_access.rs`.
+//!
+//! The marker strip is load-bearing, not defensive: reporting without it makes
+//! every marker-only chain (`a.b?.c.d = 1`) report a `TS18048` `tsc` does not.
+//!
+//! Every expectation below is pinned against `typescript@7.0.2`
+//! (`--noEmit --strict --target es2022 --lib es2022 --module esnext`). The
+//! message is asserted, not just the code: this diagnostic and the
+//! read-before-write one from #16671 fire at the same anchor with the same
+//! code and differ only by the name they carry, so a code-only assertion
+//! cannot tell a correct fix from a wrong one. Where a row's point is that a
+//! diagnostic fires exactly *once*, the offsets are asserted too.
+//!
+//! Note on ordering: both diagnostics on a reported row share one anchor, and
+//! at a shared anchor tsz's emission order is not stable across the paths
+//! involved (the increment path yields the nullish error first, the assignment
+//! path yields the grammar error first). The helpers therefore sort by
+//! `(offset, code)`, which puts the lower-numbered grammar code first — the
+//! reverse of how `tsc` prints the pair. That tie order is a presentation
+//! artifact of the unit harness, not a parity claim; the parity claims here
+//! are the code set, the anchors, the counts, and the messages.
+
+use tsz_common::options::checker::CheckerOptions;
+
+fn options(strict: bool) -> CheckerOptions {
+    CheckerOptions {
+        strict,
+        strict_null_checks: strict,
+        ..CheckerOptions::default()
+    }
+}
+
+/// Diagnostic codes ordered by source offset, then by code — the same order
+/// `tsc` prints them in, so an expected vector here can be read straight off
+/// the oracle output. The unit harness itself yields diagnostics in emission
+/// order, which puts the grammar error before the nullish one; sorting keeps
+/// these assertions comparable to the oracle instead of frozen to whichever
+/// checker pass happens to run first.
+fn codes_at(source: &str, strict: bool) -> Vec<u32> {
+    let mut diags = crate::test_utils::check_source(source, "test.ts", options(strict));
+    diags.sort_by_key(|diag| (diag.start, diag.code));
+    diags.iter().map(|diag| diag.code).collect()
+}
+
+fn strict_codes(source: &str) -> Vec<u32> {
+    codes_at(source, true)
+}
+
+fn non_strict_null_codes(source: &str) -> Vec<u32> {
+    codes_at(source, false)
+}
+
+fn messages_for(source: &str, code: u32) -> Vec<String> {
+    let mut diags = crate::test_utils::check_source(source, "test.ts", options(true));
+    diags.sort_by_key(|diag| (diag.start, diag.code));
+    diags
+        .into_iter()
+        .filter(|diag| diag.code == code)
+        .map(|diag| diag.message_text)
+        .collect()
+}
+
+/// `(start offset, code)` pairs, sorted. Used where the point of the row is
+/// that two diagnostics share an anchor, or that a diagnostic fires exactly
+/// once — a code-only assertion cannot express either.
+fn sites_for(source: &str, code: u32) -> Vec<u32> {
+    let mut diags = crate::test_utils::check_source(source, "test.ts", options(true));
+    diags.sort_by_key(|diag| (diag.start, diag.code));
+    diags
+        .into_iter()
+        .filter(|diag| diag.code == code)
+        .map(|diag| diag.start)
+        .collect()
+}
+
+const POSSIBLY_UNDEFINED: u32 = 18048;
+const POSSIBLY_NULL: u32 = 18047;
+const POSSIBLY_NULL_OR_UNDEFINED: u32 = 18049;
+const ASSIGNMENT_TARGET: u32 = 2779;
+const FOR_OF_TARGET: u32 = 2781;
+const INCREMENT_TARGET: u32 = 2777;
+
+// ---------------------------------------------------------------------------
+// Genuine receiver optionality, plain assignment.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn assignment_genuine_receiver_optionality_reports_the_receiver() {
+    let source = r#"
+declare const q: { w?: { e: number } };
+q?.w.e = 1;
+"#;
+    // tsc 7.0.2: TS18048 'q.w' is possibly 'undefined'. + TS2779
+    assert_eq!(
+        strict_codes(source),
+        vec![ASSIGNMENT_TARGET, POSSIBLY_UNDEFINED]
+    );
+    assert_eq!(
+        messages_for(source, POSSIBLY_UNDEFINED),
+        vec!["'q.w' is possibly 'undefined'.".to_string()]
+    );
+}
+
+#[test]
+fn assignment_genuine_receiver_optionality_survives_renamed_binders() {
+    // Same shape, every binder renamed: the rule is structural, not a name.
+    let source = r#"
+declare const holder: { slot?: { leaf: number } };
+holder?.slot.leaf = 1;
+"#;
+    assert_eq!(
+        strict_codes(source),
+        vec![ASSIGNMENT_TARGET, POSSIBLY_UNDEFINED]
+    );
+    assert_eq!(
+        messages_for(source, POSSIBLY_UNDEFINED),
+        vec!["'holder.slot' is possibly 'undefined'.".to_string()]
+    );
+}
+
+#[test]
+fn assignment_marker_and_genuine_optionality_reports_the_genuine_one() {
+    // `y?` makes the chain short-circuit (marker) and `x?` is genuinely
+    // optional. The genuine `undefined` survives `remove_optional_chain_marker`.
+    let source = r#"
+declare const z: { y?: { x?: { v: number } } };
+z.y?.x.v = 1;
+"#;
+    assert_eq!(
+        strict_codes(source),
+        vec![ASSIGNMENT_TARGET, POSSIBLY_UNDEFINED]
+    );
+    assert_eq!(
+        messages_for(source, POSSIBLY_UNDEFINED),
+        vec!["'z.y.x' is possibly 'undefined'.".to_string()]
+    );
+}
+
+#[test]
+fn element_access_write_target_genuine_receiver_optionality_reports_the_receiver() {
+    // The element-access path is a *separate* short-circuit site
+    // (`types/computation/access.rs`), so it needs its own row.
+    let source = r#"
+declare const idx: { list?: number[] };
+idx?.list[0] = 1;
+"#;
+    assert_eq!(
+        strict_codes(source),
+        vec![ASSIGNMENT_TARGET, POSSIBLY_UNDEFINED]
+    );
+    assert_eq!(
+        messages_for(source, POSSIBLY_UNDEFINED),
+        vec!["'idx.list' is possibly 'undefined'.".to_string()]
+    );
+}
+
+#[test]
+fn assignment_null_only_receiver_reports_possibly_null() {
+    let source = r#"
+declare const q: { w: { e: number } | null };
+q?.w.e = 1;
+"#;
+    assert_eq!(strict_codes(source), vec![ASSIGNMENT_TARGET, POSSIBLY_NULL]);
+    assert_eq!(
+        messages_for(source, POSSIBLY_NULL),
+        vec!["'q.w' is possibly 'null'.".to_string()]
+    );
+}
+
+#[test]
+fn assignment_nullish_receiver_reports_possibly_null_or_undefined() {
+    let source = r#"
+declare const q: { w: { e: number } | null | undefined };
+q?.w.e = 1;
+"#;
+    assert_eq!(
+        strict_codes(source),
+        vec![ASSIGNMENT_TARGET, POSSIBLY_NULL_OR_UNDEFINED]
+    );
+    assert_eq!(
+        messages_for(source, POSSIBLY_NULL_OR_UNDEFINED),
+        vec!["'q.w' is possibly 'null' or 'undefined'.".to_string()]
+    );
+}
+
+#[test]
+fn assignment_generic_receiver_constrained_to_optional_member_reports() {
+    // The receiver's optionality arrives through a type parameter's
+    // constraint rather than a written object literal type.
+    let source = r#"
+function g<T extends { w?: { e: number } }>(t: T) {
+  t?.w.e = 1;
+}
+"#;
+    assert_eq!(
+        strict_codes(source),
+        vec![ASSIGNMENT_TARGET, POSSIBLY_UNDEFINED]
+    );
+    assert_eq!(
+        messages_for(source, POSSIBLY_UNDEFINED),
+        vec!["'t.w' is possibly 'undefined'.".to_string()]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Marker-only receiver: silent, exactly as in a read position.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn assignment_marker_only_receiver_reports_nothing_extra() {
+    // `c` is required, so the receiver `a.b?.c` is undefined *only* because
+    // the chain may short-circuit. tsc reports TS2779 alone.
+    let source = r#"
+declare const a: { b?: { c: { d: number } } };
+a.b?.c.d = 1;
+"#;
+    assert_eq!(strict_codes(source), vec![ASSIGNMENT_TARGET]);
+}
+
+#[test]
+fn element_access_marker_only_receiver_reports_nothing_extra() {
+    let source = r#"
+declare const a: { b?: { c: number[] } };
+a.b?.c[0] = 1;
+"#;
+    assert_eq!(strict_codes(source), vec![ASSIGNMENT_TARGET]);
+}
+
+#[test]
+fn assignment_marker_only_receiver_survives_renamed_binders() {
+    let source = r#"
+declare const root: { mid?: { inner: { leaf: number } } };
+root.mid?.inner.leaf = 1;
+"#;
+    assert_eq!(strict_codes(source), vec![ASSIGNMENT_TARGET]);
+}
+
+// ---------------------------------------------------------------------------
+// `for...of` / `for...in` heads — the other write-only forms.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn for_of_head_genuine_receiver_optionality_reports_the_receiver() {
+    let source = r#"
+declare const q: { w?: { e: number } };
+declare const items: number[];
+for (q?.w.e of items);
+"#;
+    assert_eq!(
+        strict_codes(source),
+        vec![FOR_OF_TARGET, POSSIBLY_UNDEFINED]
+    );
+    assert_eq!(
+        messages_for(source, POSSIBLY_UNDEFINED),
+        vec!["'q.w' is possibly 'undefined'.".to_string()]
+    );
+}
+
+#[test]
+fn for_of_head_marker_only_receiver_reports_nothing_extra() {
+    let source = r#"
+declare const a: { b?: { c: { d: number } } };
+declare const items: number[];
+for (a.b?.c.d of items);
+"#;
+    assert_eq!(strict_codes(source), vec![FOR_OF_TARGET]);
+}
+
+#[test]
+fn for_in_head_genuine_receiver_optionality_reports_the_receiver() {
+    // Deliberately asserts only the possibly-nullish half. tsc pairs this row
+    // with TS2405 (`the left-hand side must be of type 'string' or 'any'`);
+    // tsz still reports TS2780 (`may not be an optional property access`).
+    // That divergence is a *separate* defect on the same construct, tracked by
+    // #16655, and this fix neither causes nor cures it — so pinning the
+    // grammar code here either way would freeze someone else's open bug.
+    let source = r#"
+declare const q: { w?: { e: number } };
+declare const keys: string[];
+for (q?.w.e in keys);
+"#;
+    let codes = strict_codes(source);
+    assert!(
+        codes.contains(&POSSIBLY_UNDEFINED),
+        "expected TS18048 on a for-in head receiver, got {codes:?}"
+    );
+    assert_eq!(
+        messages_for(source, POSSIBLY_UNDEFINED),
+        vec!["'q.w' is possibly 'undefined'.".to_string()]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Overlap with the read-before-write half (#16671): exactly one TS18048.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compound_assignment_genuine_receiver_reports_the_receiver_exactly_once() {
+    // `+=` reads before writing, so #16671's machinery also runs here. tsc
+    // reports a single TS18048 naming the *receiver*; the two reports must
+    // not stack.
+    let source = r#"
+declare const q: { w?: { e: number } };
+q?.w.e += 1;
+"#;
+    assert_eq!(
+        strict_codes(source),
+        vec![ASSIGNMENT_TARGET, POSSIBLY_UNDEFINED]
+    );
+    assert_eq!(
+        messages_for(source, POSSIBLY_UNDEFINED),
+        vec!["'q.w' is possibly 'undefined'.".to_string()]
+    );
+    // The count is the point: #16671's read-before-write report and this
+    // receiver report both have a claim on this row, and they must not stack.
+    assert_eq!(sites_for(source, POSSIBLY_UNDEFINED).len(), 1);
+}
+
+#[test]
+fn increment_genuine_receiver_reports_the_receiver_exactly_once() {
+    let source = r#"
+declare const q: { w?: { e: number } };
+q?.w.e++;
+"#;
+    assert_eq!(
+        strict_codes(source),
+        vec![INCREMENT_TARGET, POSSIBLY_UNDEFINED]
+    );
+    assert_eq!(
+        messages_for(source, POSSIBLY_UNDEFINED),
+        vec!["'q.w' is possibly 'undefined'.".to_string()]
+    );
+    assert_eq!(sites_for(source, POSSIBLY_UNDEFINED).len(), 1);
+}
+
+#[test]
+fn compound_assignment_marker_only_still_names_the_whole_target() {
+    // #16671's row, unchanged by this fix: a marker-only read-before-write
+    // target names the whole target, not the receiver.
+    let source = r#"
+declare const a: { b?: { c: { d: number } } };
+a.b?.c.d += 1;
+"#;
+    assert_eq!(
+        strict_codes(source),
+        vec![ASSIGNMENT_TARGET, POSSIBLY_UNDEFINED]
+    );
+    assert_eq!(
+        messages_for(source, POSSIBLY_UNDEFINED),
+        vec!["'a.b.c.d' is possibly 'undefined'.".to_string()]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn guarded_link_reports_nothing_extra() {
+    // The `.e` link carries its own `?.`, so the chain guards the receiver.
+    let source = r#"
+declare const q: { w?: { e: number } };
+q?.w?.e = 1;
+"#;
+    assert_eq!(strict_codes(source), vec![ASSIGNMENT_TARGET]);
+}
+
+#[test]
+fn non_null_asserted_receiver_reports_nothing_extra() {
+    let source = r#"
+declare const q: { w?: { e: number } };
+q?.w!.e = 1;
+"#;
+    assert_eq!(strict_codes(source), vec![ASSIGNMENT_TARGET]);
+}
+
+#[test]
+fn non_optional_receiver_reports_nothing_extra() {
+    // No optionality anywhere below the target: the chain's own `?.` on a
+    // non-nullable root cannot short-circuit.
+    let source = r#"
+declare const q: { w: { e: number } };
+q?.w.e = 1;
+"#;
+    assert_eq!(strict_codes(source), vec![ASSIGNMENT_TARGET]);
+}
+
+#[test]
+fn non_strict_null_checks_reports_nothing_extra() {
+    let source = r#"
+declare const q: { w?: { e: number } };
+q?.w.e = 1;
+"#;
+    assert_eq!(non_strict_null_codes(source), vec![ASSIGNMENT_TARGET]);
+}
+
+#[test]
+fn ordinary_read_of_the_same_chain_is_unchanged() {
+    // The read position already reported this receiver before the fix; it
+    // must still report it exactly once and name the same node.
+    let source = r#"
+declare const q: { w?: { e: number } };
+const v = q?.w.e;
+"#;
+    assert_eq!(strict_codes(source), vec![POSSIBLY_UNDEFINED]);
+    assert_eq!(
+        messages_for(source, POSSIBLY_UNDEFINED),
+        vec!["'q.w' is possibly 'undefined'.".to_string()]
+    );
+}
+
+#[test]
+fn plain_non_chain_write_to_an_optional_member_is_unchanged() {
+    // No optional chain at all: the write-target short-circuit never runs,
+    // and tsc reports the receiver through the ordinary access path.
+    let source = r#"
+declare const q: { w?: { e: number } };
+q.w.e = 1;
+"#;
+    assert_eq!(strict_codes(source), vec![POSSIBLY_UNDEFINED]);
+    assert_eq!(
+        messages_for(source, POSSIBLY_UNDEFINED),
+        vec!["'q.w' is possibly 'undefined'.".to_string()]
+    );
+}

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -99,7 +99,13 @@ impl<'a> CheckerState<'a> {
         // increment/decrement), which needs the real type to detect a
         // chain-marker `undefined` and report `TS18048`/etc.
         if skip_flow_narrowing && self.optional_chain_invalid_assignment_target_context(idx) {
-            let _ = self.get_type_of_node_with_request(access.expression, &read_request);
+            let receiver_type =
+                self.get_type_of_node_with_request(access.expression, &read_request);
+            self.report_write_target_chain_nullish_receiver(
+                access.expression,
+                access.question_dot_token,
+                receiver_type,
+            );
             return TypeId::ANY;
         }
 

--- a/crates/tsz-checker/src/types/property_access_type/nullish_access.rs
+++ b/crates/tsz-checker/src/types/property_access_type/nullish_access.rs
@@ -238,6 +238,43 @@ impl<'a> CheckerState<'a> {
         )
     }
 
+    /// Report the possibly-nullish receiver of an optional-chain continuation
+    /// that sits in a write position (assignment target, increment/decrement
+    /// operand, `for...in`/`for...of` head).
+    ///
+    /// The write-target paths in `property_access_type::resolve` and
+    /// `computation::access` short-circuit to `TypeId::ANY` so an invalid
+    /// target cannot cascade into assignability diagnostics. tsc still checks
+    /// the receiver of that target, so the receiver type they compute has to
+    /// reach the possibly-nullish reporter instead of being discarded.
+    ///
+    /// A link that carries its own `?.` is guarded by the chain and reports
+    /// nothing, exactly as in a read position.
+    ///
+    /// The receiver's `undefined` only counts when it is real optionality. A
+    /// chain whose receiver is undefined solely because the chain itself may
+    /// short-circuit (`a.b?.c` where `c` is a required member) carries the
+    /// chain marker, which tsc strips before checking the continuation.
+    pub(crate) fn report_write_target_chain_nullish_receiver(
+        &mut self,
+        receiver: NodeIndex,
+        link_has_question_dot: bool,
+        receiver_type: TypeId,
+    ) {
+        if link_has_question_dot || !self.ctx.compiler_options.strict_null_checks {
+            return;
+        }
+        let receiver_type = self.remove_optional_chain_marker(receiver, receiver_type);
+        let (_, nullish) = self.split_nullish_type(receiver_type);
+        let Some(cause) = nullish else {
+            return;
+        };
+        if cause == TypeId::ERROR || cause == TypeId::ANY || cause == TypeId::UNKNOWN {
+            return;
+        }
+        self.report_possibly_nullish_expression(receiver, cause);
+    }
+
     /// Report a possibly-nullish `expression` the way tsc's
     /// `reportObjectPossiblyNullOrUndefinedError` does: a literal `null` or
     /// `undefined` reports TS18050, entity names report the

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -67,7 +67,13 @@ impl<'a> CheckerState<'a> {
         // same way tsc reports `TS18048` on a read-before-write target.
         if skip_flow_narrowing && self.optional_chain_invalid_assignment_target_context(idx) {
             let read_request = request.read().normal_origin().contextual_opt(None);
-            let _ = self.get_type_of_node_with_request(access.expression, &read_request);
+            let receiver_type =
+                self.get_type_of_node_with_request(access.expression, &read_request);
+            self.report_write_target_chain_nullish_receiver(
+                access.expression,
+                access.question_dot_token,
+                receiver_type,
+            );
             return TypeId::ANY;
         }
 


### PR DESCRIPTION
Closes #16683. Third and last half of the optional-chain write-target family, after #16671 (read-before-write) and #16650 (parenthesized target).

**Structural rule:** when an optional-chain continuation sits in a write position (assignment target, `for...in`/`for...of` head) and its receiver's `undefined` survives `remove_optional_chain_marker` — i.e. it is real optionality, not the chain's own short-circuit marker — `tsc` reports TS18047/TS18048/TS18049 naming the **receiver**, alongside the existing TS2777/TS2779/TS2781 grammar error. tsz now does the same through `types/property_access_type/nullish_access.rs`.

**Wrong semantic operation:** property-access type resolution on a write target. Both write-target short-circuits already computed the receiver's type (so the receiver's own diagnostics could still fire) and then **discarded** it before returning `TypeId::ANY`. Routing that already-computed type through the new `report_write_target_chain_nullish_receiver` is the whole fix — **no new type is read**, which is the property that made #16660 leak diagnostics and get reverted.

The marker strip is load-bearing, not defensive: without it every marker-only chain (`a.b?.c.d = 1`, `c` required) would gain a TS18048 `tsc` does not report. That was #16650's first version, and it broke four shapes.

### The discriminator is not "write-only forms never report"

| target | receiver's `undefined` | tsc 7.0.2 | before | after |
| --- | --- | --- | --- | --- |
| `a.b?.c.d = 1` (`c` required) | chain marker only | TS2779 | TS2779 | TS2779 |
| `q?.w.e = 1` (`w?`) | genuine | TS18048 `'q.w'` + TS2779 | TS2779 | matches |
| `idx?.list[0] = 1` (`list?`) | genuine, element access | TS18048 `'idx.list'` + TS2779 | TS2779 | matches |
| `z.y?.x.v = 1` (`y?` and `x?`) | marker **and** genuine | TS18048 `'z.y.x'` + TS2779 | TS2779 | matches |
| `for (q?.w.e of items)` | genuine | TS18048 `'q.w'` + TS2781 | TS2781 | matches |
| `q?.w.e += 1` | genuine, read-before-write | exactly one TS18048 `'q.w'` | already correct | unchanged |

`q?.w.e += 1` is the overlap row: #16671's report and this one both have a claim on it, and `tsc` emits exactly one. The suite pins the **count and offsets**, not just the code, because the two fire at the same anchor with the same code and differ only by the name they carry.

## Goal
Goal: hold

## Verification

**Oracle:** `typescript@7.0.2` (the pin in `scripts/conformance/typescript-versions.json`), `--noEmit --strict --target es2022 --lib es2022 --module esnext`. 18-row fixture plus 9 single-case adjacent rows, all diffed against a locally built binary rather than inferred from the issue.

| lane | before | after |
| --- | --- | --- |
| new suite `optional_chain_write_target_nullish_tests` | **9 failed / 13 passed** | **22 passed / 0 failed** |
| whole `optional_chain` family (incl. #16671's suite) | — | **76 passed / 0 failed** |
| `-p tsz-checker --lib -- optional_chain nullish possibly_null assignment_target destructur for_of for_in property_access element_access` | — | **792 passed / 0 failed** |
| `cargo clippy --profile ci-lint --workspace --all-targets -- -D warnings` | — | clean (3m49s) |
| `cargo fmt --all` + pre-commit hook (clippy, arch guard, `-p tsz-checker`) | — | clean |

**Non-vacuity is measured, not asserted.** With the three source files stashed and only the test file present, 9 of the 22 rows fail on `main@fb6b919`. The 13 that pass without the fix are the controls — marker-only, `?.`-guarded, `!`-asserted, non-optional receiver, non-strict, ordinary read, plain non-chain write, and both #16671 overlap rows — so the suite detects exactly this false negative and pins the behaviour that must not move.

**Targeted corpus gate — two-sided, 1521 rows, 0 moved.** `compare-to-parent.sh` needs the TypeScript submodule, which is absent on this seat and costs 55–90 min to materialize and run. Instead I built **both** binaries (`main@fb6b919` and this head), fetched every `conformance-baseline.txt` row matching the areas where the changed predicate can fire from `raw.githubusercontent.com` at the pinned corpus SHA `4d4f005`, and diffed their output byte-for-byte:

- 38 rows matching `optionalChain` — **38 unchanged, 0 moved** (includes `propertyAccessChain.3.ts` and `elementAccessChain.3.ts`, the two rows #16660 regressed)
- 1483 further rows matching `assign|destructur|forOf|forIn|increment|chain|optional|nullish|elementAccess|propertyAccess` — **1483 unchanged, 0 moved**

The diff loop is proven non-vacuous: the same two binaries differ on 6 of the fixture's rows. A full `conformance.sh snapshot` is still owed and disclosed as such — this gate covers the area the change can reach, not the whole corpus.

### Out of scope, deliberately

`for (q?.w.e in keys)` gains its TS18048 here, but the paired grammar code stays tsz's TS2780 where `tsc` reports TS2405. That is a separate defect on the same construct, tracked by #16655 and untouched by this diff. The `for...in` test asserts only the possibly-nullish half, with a comment saying why — pinning the grammar code either way would freeze someone else's open bug.

### Note on assertion ordering

Both diagnostics on a reported row share one anchor, and at a shared anchor tsz's emission order is **not stable across paths** (the increment path yields the nullish error first, the assignment path the grammar error first). The helpers sort by `(offset, code)`, which puts the lower-numbered grammar code first — the reverse of how `tsc` prints the pair. That tie order is a presentation artifact of the unit harness, documented in the module header; the parity claims are the code set, the anchors, the counts, and the messages.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Sphene

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lw1wqMiR1FWsPUYMNbUHvr)_