### PR TITLE
fix(checker): an overloaded callable target contextually types nothing without noImplicitAny

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -721,6 +721,8 @@ mod overload_param_relation_routing_arch_tests;
 mod overload_two_pass_any_source_tests;
 #[path = "tests/overload_union_context_callback_tests.rs"]
 mod overload_union_context_callback_tests;
+#[path = "tests/overloaded_callable_param_no_implicit_any_tests.rs"]
+mod overloaded_callable_param_no_implicit_any_tests;
 #[path = "tests/overloaded_contextual_rest_tuple_tests.rs"]
 mod overloaded_contextual_rest_tuple_tests;
 #[path = "tests/override_incompatibility_elaboration_tests.rs"]

--- a/crates/tsz-checker/src/tests/overloaded_callable_param_no_implicit_any_tests.rs
+++ b/crates/tsz-checker/src/tests/overloaded_callable_param_no_implicit_any_tests.rs
@@ -1,0 +1,214 @@
+//! An overloaded (non-generic) callable target contextually types a function
+//! expression's parameter only under `noImplicitAny`.
+//!
+//! Structural rule (`typescript-go` `internal/checker/checker.go`,
+//! `getContextualCallSignature` / `getIntersectedSignatures`): when a
+//! contextual type's callable shape carries more than one arity-applicable
+//! call signature, tsc returns a *combined* signature only when
+//! `noImplicitAny` is on:
+//!
+//! ```go
+//! func (c *Checker) getIntersectedSignatures(signatures []*Signature) *Signature {
+//!     if !c.noImplicitAny {
+//!         return nil
+//!     }
+//!     ...
+//! }
+//! ```
+//!
+//! Under a non-strict program (`noImplicitAny` off), an overloaded callable
+//! target — even one whose signatures agree at every position — yields NO
+//! contextual signature at all, so the parameter falls back to implicit
+//! `any` and the body free-checks. tsz's `ParameterExtractor::visit_callable`
+//! (`tsz-solver/src/contextual/extractors.rs`) previously combined multiple
+//! signatures unconditionally, unioning disagreeing positions or reusing an
+//! agreed-upon type — correct only for the `noImplicitAny` branch, wrongly
+//! also applied when it is off. Confirmed against pinned `typescript@7.0.2`
+//! oracle for every case below.
+
+use crate::context::CheckerOptions;
+
+// `CheckerOptions::default()` sets `no_implicit_any: true` (a checker-test
+// convenience default, unrelated to tsc's own project default), so the
+// non-strict cases below must explicitly turn it off.
+fn diagnostics(source: &str) -> Vec<(u32, String)> {
+    crate::test_utils::check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            no_implicit_any: false,
+            ..CheckerOptions::default()
+        },
+    )
+    .into_iter()
+    .map(|d| (d.code, d.message_text))
+    .collect()
+}
+
+fn diagnostics_no_implicit_any(source: &str) -> Vec<(u32, String)> {
+    crate::test_utils::check_source(source, "test.ts", CheckerOptions::default())
+        .into_iter()
+        .map(|d| (d.code, d.message_text))
+        .collect()
+}
+
+fn no_errors(source: &str) {
+    let diags = diagnostics(source);
+    assert!(
+        diags.is_empty(),
+        "expected no errors under default (non-strict) options, got: {diags:#?}\nsource:\n{source}"
+    );
+}
+
+// ── Positive: same-arity overloads with disagreeing parameter types ────────
+
+#[test]
+fn disagreeing_overload_params_stay_untyped_without_no_implicit_any() {
+    // TypeScript/tests/cases/compiler/functionLiteralForOverloads.ts (trimmed
+    // to the `f` case). tsc reports nothing.
+    no_errors(
+        r#"
+var f: {
+    (x: string): string;
+    (x: number): number;
+} = (x) => x;
+"#,
+    );
+}
+
+#[test]
+fn disagreeing_overload_params_stay_untyped_generic_return() {
+    // Same fixture's `f4`: generic return type on both overloads.
+    no_errors(
+        r#"
+var f4: {
+    <T>(x: string): T;
+    <T>(x: number): T;
+} = (x) => x;
+"#,
+    );
+}
+
+#[test]
+fn reassigned_overloaded_target_property_access_no_error() {
+    // TypeScript/tests/cases/compiler/contextualTypingOfLambdaWithMultipleSignatures2.ts
+    // `a` must stay implicit `any`, so `a.asdf` does not report TS2339.
+    no_errors(
+        r#"
+var f: {
+    (x: string): string;
+    (x: number): string
+};
+
+f = (a) => { return a.asdf }
+"#,
+    );
+}
+
+#[test]
+fn overloaded_callback_argument_no_error() {
+    // TypeScript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithOverloadedFunctionTypedArguments.ts
+    // (`NonGenericParameter` block). `x => x` must not be checked against a
+    // synthesized union parameter type.
+    no_errors(
+        r#"
+namespace NonGenericParameter {
+    var a: {
+        (x: boolean): boolean;
+        (x: string): string;
+    }
+
+    function foo4(cb: typeof a) {
+        return cb;
+    }
+
+    var r4 = foo4(x => x);
+}
+"#,
+    );
+}
+
+// ── Positive: identical same-position overload parameter types ─────────────
+
+#[test]
+fn identical_overload_params_still_stay_untyped_without_no_implicit_any() {
+    // tsc gives NO contextual signature at all once there are 2+
+    // arity-applicable signatures, even when they happen to agree —
+    // `getIntersectedSignatures` bails on `!noImplicitAny` before comparing
+    // shapes. Oracle-verified: `x.bogusProp` reports nothing under
+    // `--strict false`.
+    no_errors(
+        r#"
+var f: {
+    (x: string): void;
+    (x: string): void;
+} = (x) => { x.bogusProp; };
+"#,
+    );
+}
+
+// ── Renamed binder control ──────────────────────────────────────────────────
+
+#[test]
+fn disagreeing_overload_params_stay_untyped_renamed_binder() {
+    no_errors(
+        r#"
+var handler: {
+    (value: string): string;
+    (value: number): number;
+} = (value) => value;
+"#,
+    );
+}
+
+// ── Negative control: noImplicitAny still combines and still reports ───────
+
+#[test]
+fn no_implicit_any_still_unions_disagreeing_overload_params() {
+    // Same shape as `identical_overload_params_still_stay_untyped_...` but
+    // with disagreeing positions and `noImplicitAny` on: tsc DOES combine
+    // (`x: string | number`) and DOES report the member missing on one arm.
+    let diags = diagnostics_no_implicit_any(
+        r#"
+var f: {
+    (x: string): void;
+    (x: number): void;
+} = (x) => { x.length; };
+"#,
+    );
+    assert!(
+        diags.iter().any(|(code, _)| *code == 2339),
+        "expected TS2339 for `.length` on the unioned `string | number` param under noImplicitAny, got: {diags:#?}"
+    );
+}
+
+#[test]
+fn no_implicit_any_allows_common_member_on_unioned_overload_params() {
+    let diags = diagnostics_no_implicit_any(
+        r#"
+var f: {
+    (x: string): void;
+    (x: number): void;
+} = (x) => { x.toString(); };
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "`.toString()` exists on both string and number, expected no errors, got: {diags:#?}"
+    );
+}
+
+// ── Negative control: a genuinely single-signature target still contextually types ──
+
+#[test]
+fn single_signature_target_still_contextually_types_without_no_implicit_any() {
+    let diags = diagnostics(
+        r#"
+var f: (x: string) => void = (x) => { x.bogusProp; };
+"#,
+    );
+    assert!(
+        diags.iter().any(|(code, _)| *code == 2339),
+        "a single-signature target must still contextually type its parameter, got: {diags:#?}"
+    );
+}

--- a/crates/tsz-checker/src/types/function_type_helpers.rs
+++ b/crates/tsz-checker/src/types/function_type_helpers.rs
@@ -238,7 +238,31 @@ impl<'a> CheckerState<'a> {
                 evaluated_type,
                 self.ctx.compiler_options.no_implicit_any,
             );
-            let evaluated_type = if helper_probe.get_this_type().is_none()
+            // tsc's `getIntersectedSignatures` (the >1-signature branch of
+            // `getContextualCallSignature`) returns undefined outright unless
+            // `noImplicitAny` is on — an overloaded, non-generic callable target
+            // contextually types nothing at all under a non-strict program, even
+            // when the probe above found no per-position type through the
+            // ordinary extractor. Synthesizing a merged mono `FunctionShape` here
+            // regardless of `noImplicitAny` would reintroduce that same
+            // cross-signature union the extractor now declines, just through this
+            // fallback instead. A single-signature callable is unaffected: tsc
+            // returns it unconditionally, so the merge below is a no-op there.
+            let overloaded_without_no_implicit_any = !self.ctx.compiler_options.no_implicit_any
+                && crate::query_boundaries::common::callable_shape_id(
+                    self.ctx.types,
+                    evaluated_type,
+                )
+                .is_some_and(|shape_id| {
+                    self.ctx
+                        .types
+                        .callable_shape(shape_id)
+                        .call_signatures
+                        .len()
+                        > 1
+                });
+            let evaluated_type = if !overloaded_without_no_implicit_any
+                && helper_probe.get_this_type().is_none()
                 && helper_probe.get_return_type().is_none()
                 && helper_probe.get_parameter_type(0).is_none()
                 && helper_probe.get_rest_parameter_type(0).is_none()

--- a/crates/tsz-checker/src/types/utilities/contextual_parameters.rs
+++ b/crates/tsz-checker/src/types/utilities/contextual_parameters.rs
@@ -171,6 +171,28 @@ impl<'a> CheckerState<'a> {
             return true;
         }
 
+        // tsc's `getContextualCallSignature` only returns a signature outright
+        // when exactly one arity-applicable call signature exists; with 2+ it
+        // defers to `getIntersectedSignatures`, which returns `undefined`
+        // unconditionally unless `noImplicitAny` is on. An overloaded
+        // (non-generic) callable target therefore contextually types nothing
+        // at all under a non-strict program — skip the `get_contextual_signature`
+        // fallback below rather than let it read a merged signature's combined
+        // parameter/rest type back in.
+        if !self.ctx.compiler_options.no_implicit_any
+            && crate::query_boundaries::common::callable_shape_id(self.ctx.types, expected)
+                .is_some_and(|shape_id| {
+                    self.ctx
+                        .types
+                        .callable_shape(shape_id)
+                        .call_signatures
+                        .len()
+                        > 1
+                })
+        {
+            return true;
+        }
+
         let Some(shape) = crate::query_boundaries::checkers::call::get_contextual_signature(
             self.ctx.types,
             expected,

--- a/crates/tsz-solver/src/contextual/extractors.rs
+++ b/crates/tsz-solver/src/contextual/extractors.rs
@@ -1260,6 +1260,29 @@ impl TypeVisitor for ParameterExtractor<'_> {
             return None;
         }
 
+        // tsc's getContextualCallSignature only returns a signature directly
+        // when exactly one arity-applicable signature exists; with 2+ it defers
+        // to getIntersectedSignatures, which itself returns undefined outright
+        // unless `noImplicitAny` is on:
+        //
+        //   func (c *Checker) getIntersectedSignatures(signatures []*Signature) *Signature {
+        //       if !c.noImplicitAny { return nil }
+        //       ...
+        //   }
+        //
+        // So under a non-strict / non-noImplicitAny program, an overloaded
+        // (non-generic) callable target never contextually types a function
+        // expression's parameters at all — even when every signature agrees on
+        // the parameter type at this position — and the parameter falls back to
+        // implicit `any`. Confirmed against `typescript@7.0.2`: two identical
+        // `(x: string): void` overloads still leave `x` untyped (`x.bogus`
+        // reports nothing) under `--strict false`, but the same shape under
+        // `--noImplicitAny` unions mismatched positions (`x: string | number`)
+        // and reports TS2339 for a member missing on one arm.
+        if shape.call_signatures.len() > 1 && !self.no_implicit_any {
+            return None;
+        }
+
         // Collect parameter types from all signatures at the given index.
         let param_types: Vec<TypeId> = shape
             .call_signatures


### PR DESCRIPTION
When `<structural condition>` a contextual type's callable shape carries more than one arity-applicable, non-generic call signature, `tsc` does X: `getContextualCallSignature` returns the signature directly only when exactly one is applicable; with 2+ it defers to `getIntersectedSignatures`, which returns `undefined` unconditionally unless `noImplicitAny` is on:

```go
func (c *Checker) getIntersectedSignatures(signatures []*Signature) *Signature {
    if !c.noImplicitAny {
        return nil
    }
    ...
}
```

tsz does X through the solver's contextual-typing layer, but previously combined multiple call signatures unconditionally (unioning disagreeing positions, or reusing an agreed-upon type) regardless of `noImplicitAny`. Under a non-strict program this produced false `TS2322`/`TS2339` for `var f: {(x:string):string;(x:number):number} = (x) => x` and `f = (a) => { return a.asdf }`-shaped code, because the parameter was contextually typed to a synthesized union instead of falling back to implicit `any`.

Fixes three pure-noise (`{a,x}`, no missing diagnostic) rows in the committed `conformance-detail.json` false-positive queue:
- `TypeScript/tests/cases/conformance/types/specifyingTypes/typeLiterals/functionLiteralForOverloads.ts`
- `TypeScript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithOverloadedFunctionTypedArguments.ts`
- `TypeScript/tests/cases/compiler/contextualTypingOfLambdaWithMultipleSignatures2.ts`

All three confirmed oracle-clean against pinned `typescript@7.0.2` before and after.

The gate needed three call sites, all guarded by the same rule (2+ call signatures on a single, non-union callable shape, `!no_implicit_any`):
- `ParameterExtractor::visit_callable` (`crates/tsz-solver/src/contextual/extractors.rs`) — the per-position parameter extractor (already carried an unused `no_implicit_any` field; now actually applied).
- `should_skip_contextual_signature_fallback_for_parameter` (`crates/tsz-checker/src/types/utilities/contextual_parameters.rs`) — the fallback that re-reads a merged signature's parameter/rest type when the extractor above declines.
- `function_contextual_type_context`'s last-resort probe (`crates/tsz-checker/src/types/function_type_helpers.rs`) — otherwise synthesizes a merged mono `FunctionShape` from the same combine when every other probe came up empty.

A single-signature callable is unaffected at all three sites: `tsc` returns it unconditionally, matching the pre-existing `len() == 1` fast paths. The `noImplicitAny`-on branch is untouched — it keeps producing the existing union/report behavior (verified by negative controls below).

Adjacent-case matrix (`crates/tsz-checker/src/tests/overloaded_callable_param_no_implicit_any_tests.rs`): disagreeing param types, identical param types (still no context — `tsc` never dedups the 2+-signature case even when they agree), generic return position, callback argument (not just a var-decl initializer), renamed binder, plus negative controls proving the `noImplicitAny` branch keeps unioning/reporting and that a genuine single-signature target still contextually types under non-strict.

## Goal
Goal: hold

## Verification
- Oracle-pinned matrix against `typescript@7.0.2` for all three fixture reductions (`functionLiteralForOverloads.ts`, `genericCallWithOverloadedFunctionTypedArguments.ts`, `contextualTypingOfLambdaWithMultipleSignatures2.ts`): all clean before and after against the built `tsz` CLI, matching `tsc`'s zero-diagnostic result. `noImplicitAny`-on controls (mixed-signature union still reports the expected `TS2339`, common-member access still clean) unchanged.
- `cargo test -p tsz-checker --lib -- overloaded_callable_param_no_implicit_any overloaded_contextual_rest_tuple`: 16/16 passed (new adjacent-case matrix plus the pre-existing overloaded-rest-tuple family, unaffected).
- `cargo test -p tsz-checker --lib -- contextual overload multi_signature multiple_signature`: 628/628 passed (broad collateral net over every contextual-typing/overload-adjacent test).
- `cargo clippy -p tsz-checker -p tsz-solver --all-targets -- -D warnings`: clean.
- Not run this session (test-file-adjacent Rust change, no corpus/emit-path touched by the diff itself, but a semantic behavior change still owes the full-suite gate): `conformance.sh snapshot`, `scripts/emit/run.sh`, `scripts/fourslash/run-fourslash.sh`. The TypeScript submodule corpus was fetched (sparse) only to read fixture text for the oracle matrix, not to run the full conformance harness. Flagging as owed for a warm-corpus follow-up session or reviewer.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_0195AcbKPY7ms7aZdGGotcnY)_