### PR TITLE
fix(checker): a pure-write optional-chain target reports its genuinely-optional receiver (#16683)

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -697,6 +697,8 @@ mod optional_chain_parenthesized_target_tests;
 mod optional_chain_read_before_write_tests;
 #[path = "tests/optional_chain_root_nullish_strict_only_tests.rs"]
 mod optional_chain_root_nullish_strict_only_tests;
+#[path = "tests/optional_chain_write_target_nullish_tests.rs"]
+mod optional_chain_write_target_nullish_tests;
 #[path = "tests/optional_key_extraction_tests.rs"]
 mod optional_key_extraction_tests;
 #[path = "tests/optional_private_field_undefined_tests.rs"]

--- a/crates/tsz-checker/src/tests/optional_chain_read_before_write_tests.rs
+++ b/crates/tsz-checker/src/tests/optional_chain_read_before_write_tests.rs
@@ -239,13 +239,22 @@ a.b?.c.d = 1;
 
 #[test]
 fn plain_assignment_genuine_receiver_still_reports_receiver_once() {
-    // Unaffected by this change (owned by #16650's receiver check once
-    // merged, or by the pre-existing ordinary-read path today), but pinned
-    // here so a future regression in either mechanism is caught.
+    // The write-position half of this family (#16683): a plain `=` reads
+    // nothing, so the read-before-write path never fires, but the receiver's
+    // genuine optionality still reports on the receiver exactly once, via
+    // `report_write_target_chain_nullish_receiver`. See
+    // `optional_chain_write_target_nullish_tests` for the full matrix.
     let source = r#"
 declare const h: { inner?: { leaf: number } };
 h?.inner.leaf = 1;
 "#;
     let codes = strict_codes(source);
     assert!(codes.contains(&2779), "expected TS2779, got {codes:?}");
+    let messages = messages_for(source, 18048);
+    assert_eq!(
+        messages,
+        vec!["'h.inner' is possibly 'undefined'.".to_string()],
+        "plain assignment with a genuinely-optional receiver reports on the \
+         receiver exactly once"
+    );
 }

--- a/crates/tsz-checker/src/tests/optional_chain_write_target_nullish_tests.rs
+++ b/crates/tsz-checker/src/tests/optional_chain_write_target_nullish_tests.rs
@@ -1,0 +1,351 @@
+//! A *pure-write* optional-chain target (`q?.w.e = 1`, a `for...of`/`for...in`
+//! head) reads nothing, so the read-before-write machinery
+//! (`optional_chain_read_before_write_tests`) never fires on it. But `tsc`
+//! still reports the possibly-nullish family (`TS18047`/`TS18048`/`TS18049`)
+//! on the target's *receiver* when that receiver carries GENUINE optionality,
+//! alongside the grammar error (`TS2779` for `=`, `TS2781`/`TS2779` for the
+//! `for` heads).
+//!
+//! The discriminator is *which* `undefined` the receiver carries, not the
+//! write form:
+//!
+//! | target | receiver's `undefined` | tsc |
+//! |---|---|---|
+//! | `a.b?.c.d = 1` (`c` required) | chain marker only | grammar only |
+//! | `q?.w.e = 1` (`w?` optional) | genuine | `TS18048 'q.w'` + grammar |
+//! | `z.y?.x.v = 1` (`x?` optional) | marker **and** genuine | `TS18048 'z.y.x'` + grammar |
+//!
+//! `tsc` strips an optional chain's own short-circuit marker
+//! (`removeOptionalTypeMarker`) before checking a continuation, so a receiver
+//! that is undefined *only* because the chain may short-circuit reports
+//! nothing — but real member optionality survives the strip and reports, in
+//! every write form including plain `=`. This is the write-position half of
+//! the family whose read-before-write half (`+=`/`++`/`--`) landed in #16671;
+//! the two fire on different nodes (receiver vs. whole target) and never
+//! stack. Owner: `report_write_target_chain_nullish_receiver` in
+//! `types/property_access_type/nullish_access.rs`, wired at the write-target
+//! short-circuit in `types/property_access_type/resolve.rs` (property access)
+//! and `types/computation/access.rs` (element access). #16683.
+
+use tsz_common::options::checker::CheckerOptions;
+
+fn strict_codes(source: &str) -> Vec<u32> {
+    let opts = CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        ..CheckerOptions::default()
+    };
+    crate::test_utils::check_source(source, "test.ts", opts)
+        .iter()
+        .map(|diag| diag.code)
+        .collect()
+}
+
+fn non_strict_null_codes(source: &str) -> Vec<u32> {
+    let opts = CheckerOptions {
+        strict: false,
+        strict_null_checks: false,
+        ..CheckerOptions::default()
+    };
+    crate::test_utils::check_source(source, "test.ts", opts)
+        .iter()
+        .map(|diag| diag.code)
+        .collect()
+}
+
+fn strict_messages_for(source: &str, code: u32) -> Vec<String> {
+    let opts = CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        ..CheckerOptions::default()
+    };
+    crate::test_utils::check_source(source, "test.ts", opts)
+        .into_iter()
+        .filter(|diag| diag.code == code)
+        .map(|diag| diag.message_text)
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Genuine receiver optionality: the receiver is named, exactly once, in every
+// write form.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn plain_assignment_genuine_receiver_reports_receiver() {
+    let source = r#"
+declare const q: { w?: { e: number } };
+q?.w.e = 1;
+"#;
+    let codes = strict_codes(source);
+    assert!(
+        codes.contains(&2779),
+        "expected TS2779 grammar error, got {codes:?}"
+    );
+    assert!(
+        codes.contains(&18048),
+        "expected TS18048 on the receiver, got {codes:?}"
+    );
+    let messages = strict_messages_for(source, 18048);
+    assert_eq!(
+        messages,
+        vec!["'q.w' is possibly 'undefined'.".to_string()],
+        "TS18048 must name the receiver (`q.w`), exactly once"
+    );
+}
+
+#[test]
+fn plain_assignment_both_marker_and_genuine_reports_receiver() {
+    // `y?` makes the chain able to short-circuit (marker) AND `x?` is genuine
+    // optionality: the marker strip is a no-op once the member carries its own
+    // `undefined`, so the receiver still reports.
+    let source = r#"
+declare const z: { y?: { x?: { v: number } } };
+z.y?.x.v = 1;
+"#;
+    let codes = strict_codes(source);
+    assert!(codes.contains(&2779), "expected TS2779, got {codes:?}");
+    let messages = strict_messages_for(source, 18048);
+    assert_eq!(
+        messages,
+        vec!["'z.y.x' is possibly 'undefined'.".to_string()],
+        "TS18048 must name the receiver (`z.y.x`), exactly once"
+    );
+}
+
+#[test]
+fn element_access_target_genuine_receiver_reports_receiver() {
+    // The write target is element access `[0]`, but its receiver `idx.list` is
+    // a nameable property access with genuine optionality (`list?`).
+    let source = r#"
+declare const idx: { list?: number[] };
+idx?.list[0] = 1;
+"#;
+    let codes = strict_codes(source);
+    assert!(codes.contains(&2779), "expected TS2779, got {codes:?}");
+    let messages = strict_messages_for(source, 18048);
+    assert_eq!(
+        messages,
+        vec!["'idx.list' is possibly 'undefined'.".to_string()],
+        "TS18048 must name the element-access receiver (`idx.list`)"
+    );
+}
+
+#[test]
+fn for_of_head_genuine_receiver_reports_receiver() {
+    let source = r#"
+declare const q: { w?: { e: number } };
+declare const items: number[];
+for (q?.w.e of items);
+"#;
+    let codes = strict_codes(source);
+    assert!(
+        codes.contains(&2781),
+        "expected TS2781 for...of grammar error, got {codes:?}"
+    );
+    let messages = strict_messages_for(source, 18048);
+    assert_eq!(
+        messages,
+        vec!["'q.w' is possibly 'undefined'.".to_string()],
+        "TS18048 must name the receiver in a for...of head"
+    );
+}
+
+#[test]
+fn for_in_head_genuine_receiver_reports_receiver() {
+    let source = r#"
+declare const q: { w?: { e: number } };
+declare const obj: { [k: string]: unknown };
+for (q?.w.e in obj);
+"#;
+    let messages = strict_messages_for(source, 18048);
+    assert_eq!(
+        messages,
+        vec!["'q.w' is possibly 'undefined'.".to_string()],
+        "TS18048 must name the receiver in a for...in head"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Marker-only receiver: no possibly-undefined report at all (the strip
+// removes the chain-introduced `undefined`).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn plain_assignment_marker_only_receiver_stays_grammar_only() {
+    // `c` is a required member, so `a.b?.c`'s `undefined` is purely the chain
+    // short-circuit marker; the strip removes it and nothing is reported.
+    let source = r#"
+declare const a: { b?: { c: { d: number } } };
+a.b?.c.d = 1;
+"#;
+    let codes = strict_codes(source);
+    assert!(codes.contains(&2779), "expected TS2779, got {codes:?}");
+    assert!(
+        !codes.contains(&18048) && !codes.contains(&18047) && !codes.contains(&18049),
+        "marker-only receiver must not report possibly-nullish, got {codes:?}"
+    );
+}
+
+#[test]
+fn element_access_marker_only_receiver_stays_grammar_only() {
+    let source = r#"
+declare const arr: { b?: { c: number[] } };
+arr.b?.c[0] = 1;
+"#;
+    let codes = strict_codes(source);
+    assert!(codes.contains(&2779), "expected TS2779, got {codes:?}");
+    assert!(
+        !codes.contains(&18048) && !codes.contains(&2532),
+        "marker-only element receiver must not report possibly-nullish, got {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// null / null|undefined variants: the reporter names the right cause.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn plain_assignment_null_or_undefined_member_reports_null_or_undefined() {
+    // `w?` contributes `undefined`; the member type also admits `null`, so the
+    // receiver is `{ e } | null | undefined` → TS18049.
+    let source = r#"
+declare const q: { w?: { e: number } | null };
+q?.w.e = 1;
+"#;
+    let messages = strict_messages_for(source, 18049);
+    assert_eq!(
+        messages,
+        vec!["'q.w' is possibly 'null' or 'undefined'.".to_string()],
+        "a null|undefined receiver must report the combined TS18049 form"
+    );
+}
+
+#[test]
+fn plain_assignment_pure_null_receiver_reports_null() {
+    // `x` is a *required* member (no genuine `undefined`), so the only chain
+    // `undefined` is the short-circuit marker from `z.y?`. The marker strip
+    // removes it, but the member's declared `| null` survives → pure `null`
+    // cause → TS18047. This is the discriminating third cause the family
+    // advertises alongside 18048/18049.
+    let source = r#"
+declare const z: { y?: { x: { v: number } | null } };
+z.y?.x.v = 1;
+"#;
+    let codes = strict_codes(source);
+    assert!(codes.contains(&2779), "expected TS2779, got {codes:?}");
+    let messages = strict_messages_for(source, 18047);
+    assert_eq!(
+        messages,
+        vec!["'z.y.x' is possibly 'null'.".to_string()],
+        "a pure-null receiver (chain marker stripped) must report TS18047"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Generic receiver constrained by a type parameter: the constraint's
+// optionality drives the report (no reliance on a concrete object shape).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn plain_assignment_generic_constrained_receiver_reports() {
+    let source = r#"
+function f<T extends { w?: { e: number } }>(q: T) {
+    q?.w.e = 1;
+}
+"#;
+    let codes = strict_codes(source);
+    assert!(codes.contains(&2779), "expected TS2779, got {codes:?}");
+    assert!(
+        codes.contains(&18048),
+        "a generic constrained receiver with optional member must report TS18048, got {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Binder-name invariance: the same structural shape under different identifier
+// names produces the same diagnostics (anti-hardcoding gate).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn genuine_receiver_report_is_binder_name_invariant() {
+    let source = r#"
+declare const outer: { middle?: { inner: number } };
+outer?.middle.inner = 1;
+"#;
+    let messages = strict_messages_for(source, 18048);
+    assert_eq!(
+        messages,
+        vec!["'outer.middle' is possibly 'undefined'.".to_string()],
+        "the report follows the structure, not the identifier spelling"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negatives: guarded continuation, non-null assertion, non-strict mode.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn guarded_continuation_link_reports_nothing() {
+    // The final link carries its own `?.`, so the continuation is guarded and
+    // tsc reports no possibly-undefined on it.
+    let source = r#"
+declare const q: { w?: { e: number } };
+q?.w?.e = 1;
+"#;
+    let codes = strict_codes(source);
+    assert!(
+        !codes.contains(&18048),
+        "a `?.`-guarded continuation must not report TS18048, got {codes:?}"
+    );
+}
+
+#[test]
+fn non_null_asserted_receiver_reports_nothing() {
+    // `!` removes the receiver's `undefined`, so there is nothing to report.
+    let source = r#"
+declare const q: { w?: { e: number } };
+q?.w!.e = 1;
+"#;
+    let codes = strict_codes(source);
+    assert!(
+        !codes.contains(&18048),
+        "a non-null-asserted receiver must not report TS18048, got {codes:?}"
+    );
+}
+
+#[test]
+fn non_strict_null_checks_reports_grammar_only() {
+    // Without strictNullChecks the possibly-nullish family does not fire.
+    let codes = non_strict_null_codes(
+        r#"
+declare const q: { w?: { e: number } };
+q?.w.e = 1;
+"#,
+    );
+    assert!(codes.contains(&2779), "expected TS2779, got {codes:?}");
+    assert!(
+        !codes.contains(&18048),
+        "no possibly-undefined diagnostic without strictNullChecks, got {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Overlap with the read-before-write path: a compound assignment reads before
+// writing, so the write-target reporter must NOT stack a second diagnostic.
+// The result is exactly one TS18048 naming the receiver.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compound_assignment_overlap_reports_receiver_exactly_once() {
+    let source = r#"
+declare const q: { w?: { e: number } };
+q?.w.e += 1;
+"#;
+    let messages = strict_messages_for(source, 18048);
+    assert_eq!(
+        messages,
+        vec!["'q.w' is possibly 'undefined'.".to_string()],
+        "the read-before-write and write-target reporters must not stack on `+=`"
+    );
+}

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -99,8 +99,15 @@ impl<'a> CheckerState<'a> {
         // increment/decrement), which needs the real type to detect a
         // chain-marker `undefined` and report `TS18048`/etc.
         if skip_flow_narrowing && self.optional_chain_invalid_assignment_target_context(idx) {
-            let _ = self.get_type_of_node_with_request(access.expression, &read_request);
-            return TypeId::ANY;
+            // Mirror `property_access_type/resolve.rs`: keep the receiver type so
+            // a pure-write optional-chain element target (`idx?.list[0] = 1`)
+            // whose receiver carries genuine optionality reports on the receiver;
+            // a marker-only receiver (`arr.b?.c[0] = 1`) stays silent.
+            return self.short_circuit_optional_chain_write_target(
+                access.expression,
+                access.question_dot_token,
+                &read_request,
+            );
         }
 
         // Get the type of the object. In write context, prefer the receiver's

--- a/crates/tsz-checker/src/types/property_access_type/nullish_access.rs
+++ b/crates/tsz-checker/src/types/property_access_type/nullish_access.rs
@@ -4,6 +4,7 @@
 //! declaration-inferred call-callee companion in
 //! `computation::call_quick_type_nullish`.
 
+use crate::context::TypingRequest;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_scanner::SyntaxKind;
@@ -236,6 +237,76 @@ impl<'a> CheckerState<'a> {
             skip_flow_narrowing,
             false,
         )
+    }
+
+    /// The write-target short-circuit shared by property-access
+    /// (`property_access_type/resolve.rs`) and element-access
+    /// (`computation/access.rs`) resolution. An invalid optional-chain
+    /// assignment target resolves to `any` so it cannot cascade into
+    /// assignability diagnostics, but the receiver's type is *not* thrown away
+    /// first: a receiver carrying genuine optionality is reported via
+    /// [`report_write_target_chain_nullish_receiver`](Self::report_write_target_chain_nullish_receiver).
+    /// Returns the `any` short-circuit type both callers propagate. Resolving
+    /// `receiver`'s type here is also what populates its optional-chain marker
+    /// bit, which the reporter's marker strip then reads.
+    pub(crate) fn short_circuit_optional_chain_write_target(
+        &mut self,
+        receiver: NodeIndex,
+        link_has_question_dot: bool,
+        read_request: &TypingRequest,
+    ) -> TypeId {
+        let receiver_type = self.get_type_of_node_with_request(receiver, read_request);
+        self.report_write_target_chain_nullish_receiver(
+            receiver,
+            link_has_question_dot,
+            receiver_type,
+        );
+        TypeId::ANY
+    }
+
+    /// Report the possibly-nullish receiver of an optional-chain continuation
+    /// that sits in a *pure-write* position — an assignment target, or a
+    /// `for...in`/`for...of` head — i.e. the write forms that route through the
+    /// write-target short-circuit and never read the target's current value.
+    /// (`+=`/`++`/`--` read before they write and are owned by the
+    /// read-before-write path in `optional_chain_read_before_write_tests`; the
+    /// two mechanisms fire on different nodes and never stack.)
+    ///
+    /// Two conditions gate the report, matching tsc's continuation check:
+    ///
+    /// - A continuation link that carries its own `?.` (`q?.w?.e = 1`) is
+    ///   guarded by the chain and reports nothing, exactly as in a read
+    ///   position — so `link_has_question_dot` suppresses it.
+    /// - The receiver's `undefined` counts only when it is *genuine*
+    ///   optionality. A chain whose receiver is undefined solely because the
+    ///   chain itself may short-circuit (`a.b?.c` where `c` is a required
+    ///   member) carries the chain marker, which tsc's `removeOptionalTypeMarker`
+    ///   strips before checking the continuation. Real member optionality
+    ///   (`q?.w` where `w?` is declared optional) survives the strip and
+    ///   reports; a receiver that is undefined for *both* reasons still reports,
+    ///   because the marker strip is a no-op once the member carries its own
+    ///   `undefined`.
+    ///
+    /// The report names the *receiver* (`'q.w'`), which is what distinguishes it
+    /// from the read-before-write path's whole-target report (`'a.b.c.d'`).
+    pub(crate) fn report_write_target_chain_nullish_receiver(
+        &mut self,
+        receiver: NodeIndex,
+        link_has_question_dot: bool,
+        receiver_type: TypeId,
+    ) {
+        if link_has_question_dot || !self.ctx.compiler_options.strict_null_checks {
+            return;
+        }
+        let receiver_type = self.remove_optional_chain_marker(receiver, receiver_type);
+        let (_, nullish) = self.split_nullish_type(receiver_type);
+        let Some(cause) = nullish else {
+            return;
+        };
+        if matches!(cause, TypeId::ERROR | TypeId::ANY | TypeId::UNKNOWN) {
+            return;
+        }
+        self.report_possibly_nullish_expression(receiver, cause);
     }
 
     /// Report a possibly-nullish `expression` the way tsc's

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -67,8 +67,11 @@ impl<'a> CheckerState<'a> {
         // same way tsc reports `TS18048` on a read-before-write target.
         if skip_flow_narrowing && self.optional_chain_invalid_assignment_target_context(idx) {
             let read_request = request.read().normal_origin().contextual_opt(None);
-            let _ = self.get_type_of_node_with_request(access.expression, &read_request);
-            return TypeId::ANY;
+            return self.short_circuit_optional_chain_write_target(
+                access.expression,
+                access.question_dot_token,
+                &read_request,
+            );
         }
 
         let optional_property_chain_cache_key =


### PR DESCRIPTION
Fixes the write-position half of the optional-chain possibly-nullish family (#16683), the half #16671 (read-before-write) did not cover.

**Structural rule.** When a pure-write optional-chain target (`q?.w.e = 1`, a `for...of`/`for...in` head) has a receiver carrying *genuine* member optionality, tsc reports the possibly-nullish family (TS18047/TS18048/TS18049) on that receiver alongside the grammar error (TS2779 for `=`, TS2781 for `for...of`); tsz now does the same through `report_write_target_chain_nullish_receiver` in the checker (`types/property_access_type/nullish_access.rs`).

The discriminator is *which* `undefined` the receiver carries, not the write form. tsc strips an optional chain's own short-circuit marker (`removeOptionalTypeMarker`) before checking a continuation:

| target | receiver's `undefined` | tsc | before | after |
|---|---|---|---|---|
| `a.b?.c.d = 1` (`c` required) | chain marker only | grammar only | grammar only ✅ | grammar only ✅ |
| `q?.w.e = 1` (`w?` optional) | genuine | TS18048 `'q.w'` + grammar | grammar only ❌ | TS18048 `'q.w'` ✅ |
| `z.y?.x.v = 1` (`x?` optional) | marker **and** genuine | TS18048 `'z.y.x'` + grammar | grammar only ❌ | TS18048 `'z.y.x'` ✅ |
| `z.y?.x.v = 1` (`x` required, `\| null`) | marker; member `null` | TS18047 `'z.y.x'` + grammar | grammar only ❌ | TS18047 `'z.y.x'` ✅ |

**Owner layer.** The two write-target short-circuits — property access (`types/property_access_type/resolve.rs`) and element access (`types/computation/access.rs`) — previously discarded the receiver type. They now share `short_circuit_optional_chain_write_target`, which keeps the receiver type and routes it through the reporter. The reporter reuses the existing marker-strip infrastructure (`optional_chain_marker_only_nodes` / `remove_optional_chain_marker`) — the same authoritative record the read-before-write path uses — so the two paths agree by construction. The report names the receiver (`'q.w'`), distinguishing it from the read-before-write path's whole-target report (`'a.b.c.d'`); the two fire on different nodes and never stack (pinned on the `q?.w.e += 1` overlap row).

**Adjacent matrix.** New 15-case suite `optional_chain_write_target_nullish_tests`: every write form (`=`, `for...of`, `for...in`) and both access sites (property, element); the marker-only / genuine / both split; null / undefined / null|undefined causes; a generic constrained receiver; binder-name invariance; and the guarded-continuation / non-null-assertion / non-strict negatives. The sibling read-before-write test's plain-assignment genuine-receiver case is strengthened to assert the receiver report it now produces.

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-checker --lib` → 10293 passed, 0 failed (includes the new 15-case suite and the full 69-test `optional_chain` family).
- `cargo nextest run -p tsz-checker --lib optional_chain_write_target` → 15/15.
- Pre-commit local verification (clippy + architecture guard + size ratchet) passed; the shared-helper extraction keeps `resolve.rs` under its per-file size cap.
- Conformance snapshot (HEAD vs base `fad3af6`, isolating this change): _running; results appended in a comment once the paired runs complete._

## Provenance
Machine: cloud
Assistant: claude-code
Model: Claude Opus
Effort: high


https://claude.ai/code/session_01N19fJML3W7dt6rm6RQRSg2

---
_Generated by [Claude Code](https://claude.ai/code/session_01N19fJML3W7dt6rm6RQRSg2)_