### PR TITLE
fix(solver): correct the stale overload contextual-typing assertion leaving main red

### DIFF
--- a/crates/tsz-solver/tests/contextual_tests_parts/part_00.rs
+++ b/crates/tsz-solver/tests/contextual_tests_parts/part_00.rs
@@ -1268,9 +1268,19 @@ fn test_contextual_callable_overload_no_implicit_any_false() {
     // Use no_implicit_any: false - should return None for parameter type
     let ctx = ContextualTypeContext::with_expected_and_options(&interner, callable, false);
 
-    // With noImplicitAny: false, different parameter types are unioned
-    let expected_param0 = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
-    assert_eq!(ctx.get_parameter_type(0), Some(expected_param0));
+    // With `noImplicitAny` off, an overloaded target contributes no contextual
+    // parameter type at all — tsc's `getIntersectedSignatures` returns nil
+    // before it ever combines the signatures:
+    //
+    //     func (c *Checker) getIntersectedSignatures(signatures []*Signature) *Signature {
+    //         if !c.noImplicitAny { return nil }
+    //
+    // so the parameter stays implicitly `any` rather than being unioned. This
+    // row previously asserted `Some(string | number)`, contradicting its own
+    // comment two lines above; #16692 made the behaviour match tsc and this
+    // assertion is updated to match. The `noImplicitAny: true` sibling below
+    // still exercises the combining path.
+    assert_eq!(ctx.get_parameter_type(0), None);
 }
 
 // =============================================================================


### PR DESCRIPTION
Goal: hold

**`main` is red on the solver lane.** One stale assertion left behind by #16692.

```
cargo nextest run -p tsz-solver --lib      (at main febbcd5edb)
  7652 passed, 1 failed

FAIL  contextual::core::tests::test_contextual_callable_overload_no_implicit_any_false
      assertion `left == right` failed
        left:  None
        right: Some(TypeId(130))
```

## What is stale

The test contradicted itself — its own comment stated the correct answer while the assertion asserted the old behaviour:

```rust
// Use no_implicit_any: false - should return None for parameter type      <- correct
let ctx = ContextualTypeContext::with_expected_and_options(&interner, callable, false);

// With noImplicitAny: false, different parameter types are unioned        <- stale
let expected_param0 = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
assert_eq!(ctx.get_parameter_type(0), Some(expected_param0));
```

#16692 made the behaviour match tsc — `getIntersectedSignatures` returns nil before combining when `noImplicitAny` is off, so the parameter stays implicitly `any` — but left the assertion. Updated to `None`, with the `checker.go` excerpt recorded in the comment. The `noImplicitAny: true` sibling still covers the combining path.

## Why it escaped

#16692 touches `crates/tsz-solver/src/contextual/extractors.rs`, but its verification (mine included) ran `-p tsz-checker --lib` only. The per-merge CI lane is clippy + arch-size, and the unit lane runs nightly, so nothing built the solver tests against it. My omission — a PR that edits a solver source file needs the solver lane.

## Verification

```
cargo nextest run -p tsz-solver --lib
  before  7652 passed, 1 failed
  after   7653 passed, 0 failed

cargo nextest run -p tsz-checker --lib   10381 passed, 8 skipped
cargo clippy --profile ci-lint --workspace --all-targets -- -D warnings   rc=0
```

No behaviour change — this is an assertion correction only.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high
