### PR TITLE
fix(checker): an alias cycle inside an ambient module reports TS2303 at its `export =` too

### DIFF
--- a/crates/tsz-checker/src/declarations/module_checker.rs
+++ b/crates/tsz-checker/src/declarations/module_checker.rs
@@ -1335,6 +1335,101 @@ impl<'a> CheckerState<'a> {
         None
     }
 
+    /// Walk up from `node_idx` to the enclosing `declare module "<specifier>"`
+    /// declaration and return both its specifier text and its body node.
+    ///
+    /// `enclosing_ambient_module_specifier` answers "which module am I in?";
+    /// this answers "which statement list declares me?", which is what the
+    /// TS2303 companion-`export =` scan needs in order to look inside an
+    /// ambient module body instead of only at file top level.
+    fn enclosing_ambient_module_block(&self, node_idx: NodeIndex) -> Option<(String, NodeIndex)> {
+        use tsz_parser::parser::syntax_kind_ext;
+        let mut current = node_idx;
+        for _ in 0..64 {
+            let ext = self.ctx.arena.get_extended(current)?;
+            let parent = ext.parent;
+            if parent == NodeIndex::NONE || parent == current {
+                return None;
+            }
+            let parent_node = self.ctx.arena.get(parent)?;
+            if parent_node.kind == syntax_kind_ext::MODULE_DECLARATION
+                && let Some(module) = self.ctx.arena.get_module(parent_node)
+                && let Some(name_node) = self.ctx.arena.get(module.name)
+                && let Some(lit) = self.ctx.arena.get_literal(name_node)
+            {
+                return Some((lit.text.to_string(), module.body));
+            }
+            current = parent;
+        }
+        None
+    }
+
+    /// The statements of the container that declares `decl_idx`, paired with a
+    /// check of whether that container's `export =` names `sym_id`.
+    ///
+    /// An `export = X` never becomes a declaration of `X`'s symbol (see the
+    /// call site), so the export side has to be found syntactically, within
+    /// whichever statement list actually declares the alias: an ambient
+    /// module's body when the alias sits in one, the source file otherwise.
+    fn export_equals_sites_for_cyclic_alias(
+        &self,
+        decl_idx: NodeIndex,
+        sym_id: tsz_binder::SymbolId,
+    ) -> Vec<NodeIndex> {
+        use tsz_parser::parser::syntax_kind_ext;
+
+        let (owns_export_equals, statements) = match self.enclosing_ambient_module_block(decl_idx) {
+            Some((specifier, body)) => {
+                let owns = self
+                    .ctx
+                    .binder
+                    .module_exports
+                    .get(&specifier)
+                    .and_then(|exports| exports.get("export="))
+                    == Some(sym_id);
+                let statements = self
+                    .ctx
+                    .arena
+                    .get(body)
+                    .filter(|body_node| body_node.kind == syntax_kind_ext::MODULE_BLOCK)
+                    .and_then(|body_node| self.ctx.arena.get_module_block(body_node))
+                    .and_then(|block| block.statements.as_ref())
+                    .map(|statements| statements.nodes.clone())
+                    .unwrap_or_default();
+                (owns, statements)
+            }
+            None => {
+                let owns = self.ctx.binder.file_locals.get("export=") == Some(sym_id);
+                let statements = self
+                    .ctx
+                    .arena
+                    .source_files
+                    .first()
+                    .map(|source_file| source_file.statements.nodes.clone())
+                    .unwrap_or_default();
+                (owns, statements)
+            }
+        };
+
+        if !owns_export_equals {
+            return Vec::new();
+        }
+
+        statements
+            .into_iter()
+            .filter(|&stmt_idx| {
+                self.ctx.arena.get(stmt_idx).is_some_and(|stmt_node| {
+                    stmt_node.kind == syntax_kind_ext::EXPORT_ASSIGNMENT
+                        && self
+                            .ctx
+                            .arena
+                            .get_export_assignment(stmt_node)
+                            .is_some_and(|assign| assign.is_export_equals)
+                })
+            })
+            .collect()
+    }
+
     /// Eagerly checks all alias symbols in the current file for circular definitions.
     /// Emits TS2303 for any alias that circularly references itself.
     pub(crate) fn check_circular_import_aliases(&mut self) {
@@ -1701,31 +1796,15 @@ impl<'a> CheckerState<'a> {
                 // from the import side.
                 //
                 // tsc reports at EVERY alias declaration in the cycle, so when
-                // this file's `export =` targets the cyclic symbol, emit there
-                // too. Scanning only this file's statements preserves the
-                // current-file ownership the collection scan above is built on.
-                if self.ctx.binder.file_locals.get("export=") == Some(sym_id)
-                    && let Some(source_file) = self.ctx.arena.source_files.first()
-                {
-                    let export_equals_stmts: Vec<NodeIndex> = source_file
-                        .statements
-                        .nodes
-                        .iter()
-                        .copied()
-                        .filter(|&stmt_idx| {
-                            self.ctx.arena.get(stmt_idx).is_some_and(|stmt_node| {
-                                stmt_node.kind == syntax_kind_ext::EXPORT_ASSIGNMENT
-                                    && self
-                                        .ctx
-                                        .arena
-                                        .get_export_assignment(stmt_node)
-                                        .is_some_and(|assign| assign.is_export_equals)
-                            })
-                        })
-                        .collect();
-                    for stmt_idx in export_equals_stmts {
-                        self.error_at_node(stmt_idx, &message, code);
-                    }
+                // the `export =` that owns this symbol names it, emit there
+                // too. The scan is scoped to the container that declares the
+                // alias — an ambient module's own body when the cycle is
+                // written inside `declare module "..."`, the source file
+                // otherwise — which preserves the current-file ownership the
+                // collection scan above is built on while still reaching a
+                // cycle nested in an ambient module.
+                for stmt_idx in self.export_equals_sites_for_cyclic_alias(decl_idx, sym_id) {
+                    self.error_at_node(stmt_idx, &message, code);
                 }
             }
         }

--- a/crates/tsz-checker/tests/ts2303_tests.rs
+++ b/crates/tsz-checker/tests/ts2303_tests.rs
@@ -352,3 +352,176 @@ export var b: ClassB;"#,
         ],
     );
 }
+
+// ---------------------------------------------------------------------------
+// Ambient-module alias cycles
+//
+// `declare module "m" { import self = require("m"); export = self; }` is the
+// same cycle as the file-level `recursiveExportAssignmentAndFindAliasedType4-6`
+// shapes above, written inside an ambient module body instead of at file top
+// level. `tsc` reports TS2303 identically in both: once at the `import` and
+// once at the `export =`. These pin the ambient half, whose `export =` site
+// lives in the module block rather than in `SourceFile.statements`.
+//
+// Offsets are pinned rather than counted: a count-only assertion cannot tell
+// "two sites" from "one site reported twice", which is exactly the distinction
+// at issue here.
+// ---------------------------------------------------------------------------
+
+/// Single-file diagnostics carrying the start offset of each report.
+fn get_diagnostics_positioned(source: &str, file_name: &str) -> Vec<(u32, u32, String)> {
+    let mut parser = ParserState::new(file_name.to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        file_name.to_string(),
+        CheckerOptions {
+            module: ModuleKind::CommonJS,
+            isolated_modules: true,
+            ..Default::default()
+        },
+    );
+
+    checker.check_source_file(root);
+    checker
+        .ctx
+        .diagnostics
+        .iter()
+        .map(|d| (d.code, d.start, d.message_text.clone()))
+        .collect()
+}
+
+/// Start offsets of every TS2303 in `source`, sorted.
+///
+/// Sorting is deliberate: the emission order of the import site and its
+/// companion `export =` site is a checker-traversal artifact, not a parity
+/// claim, so only the set of anchors is asserted on.
+fn ts2303_offsets(source: &str, file_name: &str) -> Vec<u32> {
+    let mut offsets: Vec<u32> = get_diagnostics_positioned(source, file_name)
+        .into_iter()
+        .filter(|(code, _, _)| *code == 2303)
+        .map(|(_, start, _)| start)
+        .collect();
+    offsets.sort_unstable();
+    offsets
+}
+
+/// Byte offset of the `nth` (0-based) occurrence of `needle` in `source`.
+fn nth_offset(source: &str, needle: &str, nth: usize) -> u32 {
+    let mut from = 0usize;
+    for _ in 0..nth {
+        let at = source[from..]
+            .find(needle)
+            .unwrap_or_else(|| panic!("occurrence {nth} of {needle:?} not found"));
+        from += at + needle.len();
+    }
+    let at = source[from..]
+        .find(needle)
+        .unwrap_or_else(|| panic!("occurrence {nth} of {needle:?} not found"));
+    u32::try_from(from + at).unwrap()
+}
+
+#[test]
+fn ambient_module_self_alias_cycle_reports_ts2303_at_import_and_export_equals() {
+    // `recursiveExportAssignmentAndFindAliasedType1`. tsc 7.0.2:
+    //   def.d.ts(2,5) TS2303  <- import self = require("moduleC");
+    //   def.d.ts(3,5) TS2303  <- export = self;
+    const SOURCE: &str = r#"declare module "moduleC" {
+    import self = require("moduleC");
+    export = self;
+}
+"#;
+
+    assert_eq!(
+        ts2303_offsets(SOURCE, "def.d.ts"),
+        vec![
+            nth_offset(SOURCE, "import self", 0),
+            nth_offset(SOURCE, "export = self", 0),
+        ],
+        "Expected TS2303 at both the import and the `export =` inside the ambient module"
+    );
+}
+
+#[test]
+fn ambient_module_two_module_alias_cycle_reports_ts2303_at_every_site() {
+    // `recursiveExportAssignmentAndFindAliasedType2`: a two-module cycle whose
+    // members each contribute an import site and an `export =` site (4 total).
+    const SOURCE: &str = r#"declare module "moduleC" {
+    import self = require("moduleD");
+    export = self;
+}
+declare module "moduleD" {
+    import self = require("moduleC");
+    export = self;
+}
+"#;
+
+    assert_eq!(
+        ts2303_offsets(SOURCE, "def.d.ts"),
+        vec![
+            nth_offset(SOURCE, "import self", 0),
+            nth_offset(SOURCE, "export = self", 0),
+            nth_offset(SOURCE, "import self", 1),
+            nth_offset(SOURCE, "export = self", 1),
+        ],
+        "Expected TS2303 at all four alias sites of the two-module ambient cycle"
+    );
+}
+
+#[test]
+fn ambient_module_alias_cycle_export_site_does_not_depend_on_the_binder_name() {
+    // Same cycle as above with the alias renamed: the `export =` companion is
+    // found through the enclosing module's export table, never by name.
+    const SOURCE: &str = r#"declare module "cyc" {
+    import zzz = require("cyc");
+    export = zzz;
+}
+"#;
+
+    assert_eq!(
+        ts2303_offsets(SOURCE, "renamed.d.ts"),
+        vec![
+            nth_offset(SOURCE, "import zzz", 0),
+            nth_offset(SOURCE, "export = zzz", 0),
+        ],
+        "Renaming the alias must not change which sites report TS2303"
+    );
+}
+
+#[test]
+fn ambient_module_export_equals_outside_the_cycle_stays_clean() {
+    // Negative control, and the reason the companion scan is scoped to the
+    // container that declares the alias: two more ambient modules in the SAME
+    // file each carry their own `export =`, and neither is circular. A scan
+    // that walked the file rather than the cyclic alias's own module body
+    // would light all three up.
+    const SOURCE: &str = r#"declare module "cyc" {
+    import zzz = require("cyc");
+    export = zzz;
+}
+declare module "sane" {
+    class Real { }
+    export = Real;
+}
+declare module "borrows" {
+    import ok = require("sane");
+    export = ok;
+}
+"#;
+
+    assert_eq!(
+        ts2303_offsets(SOURCE, "mixed.d.ts"),
+        vec![
+            nth_offset(SOURCE, "import zzz", 0),
+            nth_offset(SOURCE, "export = zzz", 0),
+        ],
+        "Only the circular ambient module may report TS2303; its non-circular siblings' `export =` must stay clean"
+    );
+}


### PR DESCRIPTION
**Structural rule.** When an import-alias cycle is declared inside an ambient module body (`declare module "m" { import self = require("m"); export = self; }`), tsc reports `TS2303` at **both** the import declaration and the `export =` assignment; tsz now does the same, through the checker's `check_circular_import_aliases` companion-export scan in `crates/tsz-checker/src/declarations/module_checker.rs`.

Wrong semantic operation: **diagnostic display / anchor selection**, not cycle detection. tsz already detects every one of these cycles correctly — it just reported one of the two sites.

### Why the export site needs a syntactic scan at all

`export = X` never becomes a declaration of `X`'s symbol. The binder records `"export="` as a second *key* onto `X`'s existing `SymbolId` and never registers the `ExportAssignment` node among `X`'s declarations, so the export side is unreachable from the symbol and has to be found by scanning statements. That companion scan already existed (it is what makes the file-level `recursiveExportAssignmentAndFindAliasedType4-6` rows pass today) — but it looked only at `SourceFile.statements` and gated only on `file_locals["export="]`, so a cycle nested one level down in an ambient module body was invisible to it.

The scan is now scoped to **the container that declares the alias**: the ambient module's own body, gated on that module's `module_exports["export="]`, when the alias sits in one; the source file, gated on `file_locals["export="]`, otherwise.

Both gates read binder export tables — no identifier, alias, module-name or file-name string drives the decision, and nothing reads rendered diagnostic text.

### Failure family

Four corpus rows fail today with `expected:[TS2303] actual:[TS2303]` — same code set, wrong site count, so only the fingerprint comparison catches them. Three are fixed here:

| row | tsc 7.0.2 | tsz before | tsz after |
| --- | --- | --- | --- |
| `compiler/recursiveExportAssignmentAndFindAliasedType1.ts` | 2 sites | 1 | **2, byte-identical** |
| `compiler/recursiveExportAssignmentAndFindAliasedType2.ts` | 4 sites | 2 | **4, byte-identical** |
| `compiler/recursiveExportAssignmentAndFindAliasedType3.ts` | 6 sites | 3 | **6, byte-identical** |

**Deliberately out of scope, and still failing** — same &#34;missing the companion export site&#34; shape, different mechanism, so they are not silently claimed:

- `conformance/externalModules/typeOnly/circular3.ts` — the companion is an **export specifier** (`export type { A as B }`), a distinct alias *symbol* rather than a second key onto one. tsz reports 2 of tsc's 4.
- `compiler/exportAsNamespaceConflict.ts` — tsz reports the `export as namespace N` site but not the `export = N` one; the cyclic symbol here comes from a `declare global` namespace.

Both are written up in the board handoff with their measured before/after.

## Goal
Goal: hold

## Verification

Oracle is tsc **7.0.2**, the version pinned for the current corpus SHA in `scripts/conformance/typescript-versions.json`. Every fixture below was run through both binaries and diffed line-for-line.

**Corpus rows, tsz vs tsc, exact text** — all three now match byte-for-byte (full transcripts in the board comment). Non-vacuity is measured, not assumed: the same binary before the patch emitted 1 / 2 / 3 sites for these three rows, so the diff loop demonstrably moves them.

**Adjacent-case matrix**, 4 new tests in `crates/tsz-checker/tests/ts2303_tests.rs`, offsets pinned rather than counted (a count-only assertion cannot tell &#34;two sites&#34; from &#34;one site reported twice&#34;, which is exactly the distinction at issue):

| case | assertion |
| --- | --- |
| single-module ambient self cycle | TS2303 at the `import` **and** the `export =` |
| two-module ambient cycle | all four sites, none duplicated |
| renamed binder (`zzz` for `self`) | identical site set — the companion is found via the export table, never by name |
| **negative control**: two non-circular ambient siblings carrying their own `export =` in the same file | only the circular module reports; both siblings stay clean |

The negative control is the one that pins the scoping decision: a scan that walked the file instead of the alias's own module body would light all three modules up. Verified against tsc on the same fixture — it reports exactly the two sites too.

**Regression guard.** The file-level shape (`recursiveExportAssignmentAndFindAliasedType4`, currently passing) is unchanged: tsz and tsc both report `moduleC.ts(1,1)` + `moduleC.ts(2,1)` before and after.

```
cargo test -p tsz-checker --lib ts2303                    11 passed / 0 failed  (7 pre-existing + 4 new)
cargo test -p tsz-checker --lib -- ts2303 ts2300 ts2309  133 passed / 0 failed
pre-commit hook (clippy + arch guard + affected crate)   Clippy passed. Architecture guard passed.
```

**Not run, and disclosed rather than implied:** the full `conformance.sh snapshot` and `compare-to-parent.sh`. This is a submodule-less cloud seat and the two-sided run is 55-90 min here. The change is confined to the TS2303 companion-export anchor and adds diagnostics only where a cycle was *already* detected and *already* reported at its import site, so it cannot introduce a diagnostic on a file that was previously clean — but that is an argument, not a measurement, and the three corpus rows above are the direct evidence.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Cinnabar

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzrvhUGYNDxM6w325XR5pe)_