### PR TITLE
fix(checker): TS2383 export-agreement doesn't apply inside an ambient module/namespace

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -19,6 +19,7 @@ use crate::state::CheckerState;
 use rustc_hash::FxHashSet;
 use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
 
 pub(super) type OuterDeclResult = Option<(tsz_binder::SymbolId, Vec<(NodeIndex, u32)>)>;
 type DuplicateDeclList = Vec<(NodeIndex, u32, bool, bool, DuplicateDeclarationOrigin)>;
@@ -60,6 +61,33 @@ impl<'a> CheckerState<'a> {
             return Some((start, node.end.saturating_sub(start)));
         }
         None
+    }
+
+    /// `true` when `decl_idx`'s nearest enclosing `MODULE_DECLARATION` (namespace
+    /// or `module`/`declare module "x"`) is itself ambient and is not a global
+    /// augmentation (`declare global { ... }`). Used to exempt overload-signature
+    /// members of an ambient module/namespace body from the TS2383 export-
+    /// consistency check, which tsc does not apply there.
+    fn is_within_ambient_module_container(&self, decl_idx: NodeIndex) -> bool {
+        let mut current = decl_idx;
+        for _ in 0..100 {
+            let Some(ext) = self.ctx.arena.get_extended(current) else {
+                return false;
+            };
+            if ext.parent.is_none() {
+                return false;
+            }
+            let parent = ext.parent;
+            let Some(parent_node) = self.ctx.arena.get(parent) else {
+                return false;
+            };
+            if parent_node.kind == syntax_kind_ext::MODULE_DECLARATION {
+                return !parent_node.is_global_augmentation()
+                    && self.is_ambient_declaration(parent);
+            }
+            current = parent;
+        }
+        false
     }
 
     /// Check for duplicate identifiers (TS2300, TS2451, TS2392).
@@ -291,7 +319,19 @@ impl<'a> CheckerState<'a> {
             // TS2383: all bodyless overload signatures must agree on export status.
             // The rule applies when 2+ overload signatures exist; the implementation
             // is not an overload signature and is not checked for export agreement.
-            if func_decls_for_2384.len() >= 2 {
+            //
+            // tsc does not apply this check to overloads declared directly inside an
+            // ambient module/namespace body (`declare namespace M { ... }` /
+            // `declare module "m" { ... }`, including namespaces nested inside one):
+            // `export` on a member of an ambient module body does not carry the same
+            // meaning as a module-level `export`, so mismatched `export` keywords
+            // there are not overload-consistency errors. `declare global { ... }` is
+            // a global augmentation, not an ambient module, and stays subject to the
+            // check, as does a bare top-level `declare function` with no enclosing
+            // namespace/module.
+            if func_decls_for_2384.len() >= 2
+                && !self.is_within_ambient_module_container(func_decls_for_2384[0])
+            {
                 // Restrict to bodyless overload signatures only by looking up export
                 // status for each entry in func_decls_for_2384. The implementation
                 // (absent from func_decls_for_2384) must not influence the check.

--- a/crates/tsz-checker/tests/overload_modifier_tests.rs
+++ b/crates/tsz-checker/tests/overload_modifier_tests.rs
@@ -64,6 +64,93 @@ export function baz(s?: string) { }
     assert!(!has_error(source, 2383));
 }
 
+// TS2383: overloads declared directly inside an ambient module/namespace body
+// are exempt from the export-consistency check (tsc: `export` on a member of
+// an ambient module body doesn't carry module-export meaning). `declare
+// global` is a global augmentation, not an ambient module, and stays subject
+// to the check, as does a bare top-level ambient overload set with no
+// enclosing namespace.
+
+#[test]
+fn ts2383_ambient_namespace_mixed_export_no_error() {
+    let source = r#"
+declare namespace Widgets {
+    function make(): void;
+    export function make(): void;
+    function make(): void;
+}
+"#;
+    assert!(!has_error(source, 2383));
+}
+
+#[test]
+fn ts2383_non_ambient_namespace_mixed_export_error() {
+    let source = r#"
+namespace Widgets {
+    function make(): void;
+    export function make(): void;
+    function make(): void {}
+}
+"#;
+    assert!(has_error(source, 2383));
+}
+
+#[test]
+fn ts2383_ambient_module_string_literal_mixed_export_no_error() {
+    let source = r#"
+declare module "widgets" {
+    function make(): void;
+    export function make(): void;
+}
+"#;
+    assert!(!has_error(source, 2383));
+}
+
+#[test]
+fn ts2383_non_ambient_namespace_nested_inside_ambient_namespace_no_error() {
+    let source = r#"
+declare namespace Outer {
+    namespace Inner {
+        function make(): void;
+        export function make(): void;
+    }
+}
+"#;
+    assert!(!has_error(source, 2383));
+}
+
+#[test]
+fn ts2383_declare_global_mixed_export_still_errors() {
+    let source = r#"
+declare global {
+    function make(): void;
+    export function make(): void;
+}
+export {};
+"#;
+    assert!(has_error(source, 2383));
+}
+
+#[test]
+fn ts2383_bare_top_level_ambient_overloads_mixed_export_still_errors() {
+    let source = r#"
+declare function make(): void;
+export declare function make(): void;
+"#;
+    assert!(has_error(source, 2383));
+}
+
+#[test]
+fn ts2383_ambient_namespace_mixed_export_generic_overloads_no_error() {
+    let source = r#"
+declare namespace Registry {
+    function get<T>(key: string): T;
+    export function get<T>(key: string, fallback: T): T;
+}
+"#;
+    assert!(!has_error(source, 2383));
+}
+
 // TS2386: optionality agreement on interface method overloads
 
 #[test]


### PR DESCRIPTION
Fixes the `mixedExports.ts` false positive in the committed conformance false-positive queue (`scripts/conformance/conformance-detail.json`, `x: [TS2383]`, no `m`).

`declare namespace M { function foo(); export function foo(); function foo(); }` is clean under tsc (0 diagnostics); tsz reported a spurious `TS2383` on the exported overload.

**Structural rule:** tsc's overload export-consistency check (`Overload_signatures_must_all_be_exported_or_non_exported`) does not apply to bodyless overload signatures declared directly inside an ambient module/namespace body (`declare namespace X { ... }` / `declare module "x" { ... }`, including a namespace nested inside one, which inherits ambient-ness). It still applies to `declare global { ... }` (a global augmentation, not an ambient module) and to a bare top-level `declare function` overload set with no enclosing namespace/module. tsz now enforces this through a new `is_within_ambient_module_container` guard in `crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs`, which walks to the nearest enclosing `MODULE_DECLARATION` and skips the TS2383 loop when that container is ambient and not a global augmentation.

Confirmed empirically against the pinned oracle (`typescript@7.0.2`, `--strict false --target es2015`) with 6 isolated repros before writing the fix: ambient namespace (suppressed), non-ambient namespace (still errors — regression guard), ambient string-module (suppressed), non-ambient namespace nested inside an ambient one (suppressed via inherited ambient-ness), `declare global` (still errors — not an ambient module), and a bare top-level `declare function` overload set (still errors — no enclosing namespace/module).

Adjacent-case matrix added to `crates/tsz-checker/tests/overload_modifier_tests.rs` (renamed binders throughout, per the anti-hardcoding contract): ambient namespace mixed export (no error), non-ambient namespace equivalent (still errors), ambient `declare module "x"` string form (no error), non-ambient namespace nested inside an ambient namespace (no error), `declare global` (still errors), bare top-level ambient overloads (still errors), and a generic-overload variant inside an ambient namespace (no error).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test overload_modifier_tests` — **55 passed, 0 failed** (7 new tests + all 48 pre-existing TS2383/2385/2386/2394 tests, including the pre-existing non-ambient-mismatch and single-overload no-error cases, unaffected).
- Targeted filters against the full `--lib` suite's compiled binary (reused, no rebuild) to sweep the blast radius of touching `duplicate_identifiers.rs`: `-- namespace` **234 passed**, `-- overload` **333 passed**, `-- ambient` **92 passed**, `-- duplicate_identifier` **13 passed** — all 0 failed.
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings` — clean. `cargo fmt --all -- --check` — clean. Pre-commit hook (fmt + clippy + architecture guard + affected-crate verification) passed.
- Binary-level check against the reduced repro and all 6 oracle cases with `.target/dist-fast/tsz --noEmit --target es2015 --strict false`: matches tsc exactly in every case (0 errors where tsc gives 0, `TS2383` where tsc gives `TS2383`).
- Owed: the full `cargo test -p tsz-checker --lib` run (10,358 tests) and a `conformance.sh` snapshot did not finish within the session (unusually slow this run, likely resource contention from the targeted filter passes above sharing the same build). The change is a single additive guard scoped to the TS2383 branch only — no other diagnostic code path is touched — and the directly relevant families (namespace/overload/ambient/duplicate-identifier, 727 tests) are all green.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbbwwR75ysaTqWbacVed1w)_