### PR TITLE
fix(checker): a wide/plain `symbol` computed key takes whole-object TS2322, not per-property TS2418 (#16662)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
@@ -303,6 +303,23 @@ impl<'a> CheckerState<'a> {
                 }
                 None => continue,
             };
+            // A genuine wide/plain `symbol` computed key is an index-signature
+            // contributor, not a late-bound named member: it folds into a
+            // `[k: symbol]: V` signature, so a value mismatch is owned by the
+            // whole-object relation (TS2322 with a `'symbol' index signatures
+            // are incompatible` chain), exactly like a wide `string`/`number`
+            // key — whose synthetic key name does not resolve, so it is skipped
+            // above. A bare `symbol`-typed const binding otherwise resolves to a
+            // binding-identity (`__unique_<id>`) name here and would wrongly
+            // drill into the late-bound per-property TS2418 below. A syntactic
+            // `Symbol.<member>` well-known key keeps its late-bound TS2418 (via
+            // the object-literal computation reporter) and is excluded. #16662.
+            if is_computed_property
+                && !self.computed_member_key_is_well_known_symbol_syntax(prop_name_idx)
+                && self.computed_member_key_is_wide_symbol(prop_name_idx)
+            {
+                continue;
+            }
             // Resolve the per-property target against the best-matching union
             // member when one exists (tsc's `findBestTypeForObjectLiteral`),
             // else against the whole target. A `None` here — the best member

--- a/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
@@ -561,6 +561,9 @@ impl<'a> CheckerState<'a> {
                     .unwrap_or(TypeId::ANY)
             };
 
+            // The reporter fires the per-property TS2418 only for a syntactic
+            // `Symbol.<member>` accessor key; a wide/plain `symbol` accessor key
+            // defers to the whole-object relation (TS2322). #16662.
             if prop_name_type == TypeId::SYMBOL {
                 self.report_contextual_symbol_index_value_mismatch(
                     accessor.name,

--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -942,6 +942,11 @@ impl<'a> CheckerState<'a> {
                         value_type = literal_type;
                     }
 
+                    // A `symbol`-typed computed key contributes a
+                    // `[k: symbol]: V` index signature; the reporter fires the
+                    // per-property TS2418 only for a syntactic `Symbol.<member>`
+                    // key and otherwise defers to the whole-object relation
+                    // (TS2322), like a wide `string`/`number` key. #16662.
                     if prop_name_type == TypeId::SYMBOL {
                         self.report_contextual_symbol_index_value_mismatch(
                             prop.name,
@@ -1766,6 +1771,10 @@ impl<'a> CheckerState<'a> {
                         );
                     }
 
+                    // The reporter fires the per-property TS2418 only for a
+                    // syntactic `Symbol.<member>` method key; a wide/plain
+                    // `symbol` method key defers to the whole-object relation
+                    // (TS2322). #16662.
                     if prop_name_type == TypeId::SYMBOL {
                         self.report_contextual_symbol_index_value_mismatch(
                             method.name,

--- a/crates/tsz-checker/src/types/computation/object_literal/symbol_key_routing.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/symbol_key_routing.rs
@@ -174,6 +174,40 @@ impl<'a> CheckerState<'a> {
         self.get_type_of_node(computed.expression) == TypeId::SYMBOL
     }
 
+    /// True when a computed-property name is written as the syntactic
+    /// `Symbol.<member>` (or `Symbol["<member>"]`) well-known-symbol access,
+    /// judged from the syntax alone — the base identifier is literally
+    /// `Symbol` — regardless of whether that `Symbol` resolves to the global
+    /// lib value.
+    ///
+    /// `tsc`'s `isWellKnownSymbolSyntactically` late-binds such a key to the
+    /// well-known member itself, so a value mismatch is the per-property
+    /// TS2418, not the whole-object TS2322 that a genuine wide/plain `symbol`
+    /// key (an index-signature contributor) takes. This holds even when the
+    /// `Symbol` base is locally shadowed — the case where
+    /// `computed_member_key_is_wide_symbol` returns `true` and the key would
+    /// otherwise fold into the symbol index signature. Oracled against `tsc`
+    /// 6.0.2 (`--strict`, `--checkJs`) on a JSDoc-shadowed `Symbol`. #16662.
+    pub(crate) fn computed_member_key_is_well_known_symbol_syntax(
+        &self,
+        name_idx: NodeIndex,
+    ) -> bool {
+        let Some(name_node) = self.ctx.arena.get(name_idx) else {
+            return false;
+        };
+        if name_node.kind != syntax_kind_ext::COMPUTED_PROPERTY_NAME {
+            return false;
+        }
+        let Some(computed) = self.ctx.arena.get_computed_property(name_node) else {
+            return false;
+        };
+        crate::types_domain::computed_names::well_known_symbol_access_shape(
+            self.ctx.arena,
+            computed.expression,
+        )
+        .is_some()
+    }
+
     pub(super) fn report_contextual_symbol_index_value_mismatch(
         &mut self,
         name_idx: NodeIndex,
@@ -181,6 +215,15 @@ impl<'a> CheckerState<'a> {
         source_value_type: TypeId,
         contextual_type: Option<TypeId>,
     ) -> bool {
+        // Only a syntactic `Symbol.<member>` key (well-known even when the
+        // `Symbol` base is locally shadowed) is late-bound and takes this
+        // per-property TS2418. A genuine wide/plain `symbol` key is an
+        // index-signature contributor whose value mismatch is owned by the
+        // whole-object relation (TS2322), like a wide `string`/`number` key,
+        // so it must not be reported here. #16662.
+        if !self.computed_member_key_is_well_known_symbol_syntax(name_idx) {
+            return false;
+        }
         let Some(target_value_type) = self.contextual_symbol_index_value_type(contextual_type)
         else {
             return false;

--- a/crates/tsz-checker/tests/symbol_index_signature_tests.rs
+++ b/crates/tsz-checker/tests/symbol_index_signature_tests.rs
@@ -127,7 +127,13 @@ const table: { [k: symbol]: string } = {
 }
 
 #[test]
-fn plain_symbol_property_access_reports_computed_property_value_mismatch() {
+fn plain_symbol_property_access_reports_whole_object_ts2322() {
+    // A plain (non-`unique`) `symbol`-typed property-access key that is NOT
+    // well-known syntax (`Sym.foo`, not `Symbol.foo`) is an index contributor,
+    // not a late-bound named member: it folds into a `[k: symbol]: number`
+    // index signature, so the whole-object relation owns the failure with
+    // TS2322 (`'symbol' index signatures are incompatible`), NOT a per-property
+    // TS2418. Oracled against `tsc` 6.0.2 (`--strict`). See #16662.
     let codes = diagnostic_codes_for_ts(
         r#"
 declare const Sym: { readonly foo: symbol };
@@ -139,14 +145,14 @@ const table: { [k: symbol]: string } = {
     );
 
     assert!(
-        codes.contains(
-            &diagnostic_codes::TYPE_OF_COMPUTED_PROPERTYS_VALUE_IS_WHICH_IS_NOT_ASSIGNABLE_TO_TYPE
-        ),
-        "expected TS2418 for plain-symbol property access, got {codes:?}",
+        codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "expected whole-object TS2322 for a plain-symbol index-contributor key, got {codes:?}",
     );
     assert!(
-        !codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
-        "did not expect the object-level TS2322 fallback, got {codes:?}",
+        !codes.contains(
+            &diagnostic_codes::TYPE_OF_COMPUTED_PROPERTYS_VALUE_IS_WHICH_IS_NOT_ASSIGNABLE_TO_TYPE
+        ),
+        "a wide-symbol index-contributor key must not take the late-bound TS2418, got {codes:?}",
     );
     assert!(
         !codes.contains(

--- a/crates/tsz-checker/tests/wide_symbol_computed_member_index_signature_tests.rs
+++ b/crates/tsz-checker/tests/wide_symbol_computed_member_index_signature_tests.rs
@@ -578,3 +578,153 @@ export const via: (() => number) | (() => string) = c[other];
 // compatibility check (which reads the explicit `number` index directly),
 // unrelated to the implicit-fold union this change owns. That divergence is
 // left to its own fix so this suite pins only the implicit-fold behavior.
+
+// ---------------------------------------------------------------------------
+// #16662 residual 1: a wide/plain `symbol` computed key is an index-signature
+// contributor, so a VALUE mismatch against the contextual symbol index is owned
+// by the whole-object relation (TS2322 with a `'symbol' index signatures are
+// incompatible` chain), exactly like a wide `string`/`number` key — never the
+// per-property TS2418 that a late-bound NAMED symbol key (`unique symbol`, or a
+// syntactic `Symbol.<member>` well-known key) takes. Every row below is oracled
+// against `tsc` 6.0.2 (`--strict`).
+// ---------------------------------------------------------------------------
+
+fn assert_whole_object_ts2322_not_ts2418(source: &str) {
+    let diags = check_source_diagnostics(source);
+    assert!(
+        diags.iter().any(|d| d.code == 2322),
+        "a wide-symbol index-contributor value mismatch must be the whole-object \
+         TS2322, got: {diags:?}"
+    );
+    assert!(
+        !diags.iter().any(|d| d.code == 2418),
+        "a wide-symbol index-contributor key must NOT take the late-bound \
+         per-property TS2418, got: {diags:?}"
+    );
+}
+
+#[test]
+fn wide_symbol_bare_binding_key_value_mismatch_is_whole_object_ts2322() {
+    assert_whole_object_ts2322_not_ts2418(
+        r#"
+declare const w: symbol;
+interface OnlySym { [k: symbol]: string }
+const h: OnlySym = { [w]: 1 };
+"#,
+    );
+}
+
+#[test]
+fn wide_symbol_property_access_key_value_mismatch_is_whole_object_ts2322() {
+    // `Sym.foo` is a property access whose base is NOT the syntactic `Symbol`,
+    // so it is a genuine wide-symbol index contributor, not a well-known key.
+    assert_whole_object_ts2322_not_ts2418(
+        r#"
+declare const Sym: { readonly foo: symbol };
+interface OnlySym { [k: symbol]: string }
+const h: OnlySym = { [Sym.foo]: 1 };
+"#,
+    );
+}
+
+#[test]
+fn wide_symbol_call_result_key_value_mismatch_is_whole_object_ts2322() {
+    assert_whole_object_ts2322_not_ts2418(
+        r#"
+declare function getSymbol(): symbol;
+interface OnlySym { [k: symbol]: string }
+const h: OnlySym = { [getSymbol()]: 1 };
+"#,
+    );
+}
+
+#[test]
+fn wide_symbol_element_access_key_value_mismatch_is_whole_object_ts2322() {
+    assert_whole_object_ts2322_not_ts2418(
+        r#"
+declare const box: symbol[];
+interface OnlySym { [k: symbol]: string }
+const h: OnlySym = { [box[0]]: 1 };
+"#,
+    );
+}
+
+#[test]
+fn wide_symbol_method_key_value_mismatch_is_whole_object_ts2322() {
+    assert_whole_object_ts2322_not_ts2418(
+        r#"
+declare const w: symbol;
+interface OnlySym { [k: symbol]: () => string }
+const h: OnlySym = { [w]() { return 1; } };
+"#,
+    );
+}
+
+#[test]
+fn wide_symbol_getter_key_value_mismatch_is_whole_object_ts2322() {
+    assert_whole_object_ts2322_not_ts2418(
+        r#"
+declare const w: symbol;
+interface OnlySym { [k: symbol]: string }
+const h: OnlySym = { get [w]() { return 1; } };
+"#,
+    );
+}
+
+#[test]
+fn wide_symbol_setter_key_value_mismatch_is_whole_object_ts2322() {
+    assert_whole_object_ts2322_not_ts2418(
+        r#"
+declare const w: symbol;
+interface OnlySym { [k: symbol]: string }
+const h: OnlySym = { set [w](v: number) {} };
+"#,
+    );
+}
+
+#[test]
+fn wide_symbol_key_whole_object_ts2322_renamed_binders() {
+    // Anti-hardcoding: the same shape with every identifier renamed behaves
+    // identically — the classification is structural, not name-keyed.
+    assert_whole_object_ts2322_not_ts2418(
+        r#"
+declare const registryKey: symbol;
+interface Store { [pk: symbol]: string }
+const s: Store = { [registryKey]: 42 };
+"#,
+    );
+}
+
+#[test]
+fn wide_symbol_key_ts2322_message_names_symbol_index_incompatibility() {
+    // The whole-object TS2322 carries the same index-signature-incompatible
+    // chain tsc emits, keyed on `symbol` (not `string`).
+    let diags = check_source_diagnostics(
+        r#"
+declare const w: symbol;
+interface OnlySym { [k: symbol]: string }
+const h: OnlySym = { [w]: 1 };
+"#,
+    );
+    let ts2322 = diags
+        .iter()
+        .find(|d| d.code == 2322)
+        .unwrap_or_else(|| panic!("expected a whole-object TS2322, got: {diags:?}"));
+    let full_text: String = std::iter::once(ts2322.message_text.clone())
+        .chain(
+            ts2322
+                .related_information
+                .iter()
+                .map(|info| info.message_text.clone()),
+        )
+        .collect::<Vec<_>>()
+        .join(" | ");
+    assert!(
+        full_text.contains("symbol") && full_text.contains("index signature"),
+        "TS2322 must describe the `symbol` index-signature incompatibility, got: {full_text:?}"
+    );
+}
+
+// NOTE: the well-known-syntax negative control (`[Symbol.iterator]` keeps the
+// late-bound TS2418) is pinned in `symbol_index_signature_tests.rs`, which
+// supplies the `Symbol` lib binding this suite's minimal harness does not.


### PR DESCRIPTION
Closes the wide-`symbol` slice (residual 1) of #16662.

**Structural rule.** When an object literal has a computed key of the wide/plain
`symbol` type — `[w]` for `declare const w: symbol`, `[Sym.foo]` for a plain
`symbol` member, `[getSymbol()]`, `[box[0]]`, or a method/accessor keyed the same
way — `tsc` treats it as an **index-signature contributor**: it folds into a
`[k: symbol]: V` signature on the inferred type (already done in tsz per #9755),
so a value mismatch against the target is owned by the **whole-object relation**
(TS2322, with a `'symbol' index signatures are incompatible` chain), exactly like
a wide `string`/`number` key. tsz was instead emitting a per-property **TS2418**
(`Type of computed property's value is …`). Only a *late-bound named* symbol key
— a `unique symbol`, or a syntactic `Symbol.<member>` well-known key — takes
TS2418.

Oracle (`tsc` 6.0.2, `--strict`), source type read out of the diagnostic:

| computed key | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `[w]`, `w: symbol` | TS2322 `{ [w]: number }` | TS2418 | **TS2322** |
| `[Sym.foo]`, `Sym.foo: symbol` | TS2322 | TS2418 | **TS2322** |
| `[getSymbol()]` | TS2322 `{ [x: symbol]: number }` | TS2418 | **TS2322** |
| `[box[0]]`, `box: symbol[]` | TS2322 | TS2418 | **TS2322** |
| method `[w]() {…}` / getter `get [w]() {…}` / setter `set [w](v){…}` | TS2322 | TS2418 | **TS2322** |
| `[key]`, `key: unique symbol` | TS2418 | TS2418 | TS2418 |
| `[Symbol.iterator]` (well-known syntax, incl. shadowed `Symbol`) | TS2418 | TS2418 | TS2418 |
| wide `string`/`number` analogue | TS2322 | TS2322 | TS2322 |

## Owner layer
Checker only (`crates/tsz-checker`). No solver / emitter / diagnostic-display
change; the TS2322 and its `symbol` index-signature-incompatible elaboration
chain are already produced by the existing whole-object relation (verified by the
wide-`string` sibling, which was already correct).

## Root cause
Two checker sites emitted the per-property TS2418 for a wide-symbol key that
should have deferred to the whole-object relation:

1. **Object-literal computation** ran an eager reporter
   (`report_contextual_symbol_index_value_mismatch`) at every member site
   (property assignment, method, accessor) whenever the key type was `symbol`.
   Wide `string`/`number` keys have no such reporter, which is why they were
   already correct.
2. **Assignment elaboration** (`elaboration_object_properties.rs`) drilled a bare
   `symbol`-typed `const` key into the late-bound TS2418 branch, because such a
   binding resolves to a binding-identity (`__unique_<id>`) name there — whereas
   a wide `string` key, or a `Sym.foo`/`getSymbol()` key, resolves to no name and
   is skipped, falling through to the whole-object relation.

The eager reporter is *not* deleted outright, because `tsc`'s
`isWellKnownSymbolSyntactically` is purely syntactic: a `Symbol.<member>` key is
well-known (and takes TS2418) even when `Symbol` is locally shadowed and its
member is typed plain `symbol` (a JSDoc-shadowed `Symbol` corpus shape, oracled to
TS2418). tsz classifies that shadowed key as *wide* structurally, so the reporter
is the mechanism that still yields the correct TS2418 for it.

## Fix
- New syntactic predicate
  `computed_member_key_is_well_known_symbol_syntax(name_idx)` — the base
  identifier is literally `Symbol`, judged from syntax alone (delegates to the
  existing `well_known_symbol_access_shape`), matching `tsc`.
- Gate the eager reporter (single early-return inside
  `report_contextual_symbol_index_value_mismatch`) so it fires **only** for a
  syntactic `Symbol.<member>` key; a genuine wide-symbol key no longer gets a
  per-property TS2418 and its inferred symbol index signature is judged by the
  whole-object relation.
- In the elaboration loop, skip a genuine wide-symbol key (index contributor,
  excluding syntactic `Symbol.<member>`) so it defers to the whole-object
  relation, exactly like the wide-`string` sibling.

## Adjacent matrix / anti-hardcoding
New tests in `wide_symbol_computed_member_index_signature_tests.rs` cover bare
binding / property-access / call-result / element-access / method / getter /
setter keys (all TS2322, no TS2418), a renamed-binder variant, and a
message-content check for the `symbol` index-signature-incompatible chain. The
existing `plain_symbol_property_access` test is corrected from TS2418 to the
oracle's TS2322. Negative controls (`unique symbol` → TS2418; well-known
`Symbol.iterator` → TS2418, including the JSDoc-shadowed case) remain green.

Residuals 2 (late-bound string mismatch) and 3 (well-known symbol vs declared
member) of #16662 are already resolved on `main` (#16651, #16684); verified.

## Goal
Goal: hold

## Verification
- End-to-end oracle sweep (release `tsz` vs `tsc` 6.0.2, 11 shapes incl. the
  negatives above): all match.
- `cargo test -p tsz-checker` targeted: `symbol_index_signature_tests` (94),
  `wide_symbol_computed_member_index_signature_tests` (34, incl. the new matrix),
  `symbol_index_nested_literal_drill_in_ts2353_tests` (8),
  `symbol_key_nested_literal_excess_property_tests` (5), plus 22 further
  symbol/index/object-literal integration targets — all pass.
- `cargo test -p tsz-checker --lib` filtered to
  `object_literal_relation_architecture architecture_contract symbol
  object_literal computed_key wide_symbol` — 937 pass, 0 fail.
- `cargo clippy --profile dist-fast -p tsz-checker --lib -- -D warnings` — clean;
  pre-commit hook (clippy + arch-size guard) passed on commit.
- Conformance/emit/fourslash not run locally this session (checker-only,
  no diagnostic-display/solver change); relying on the nightly gates.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
https://claude.ai/code/session_01VghJbg5SFeRXLqRxrCsC9a

---
_Generated by [Claude Code](https://claude.ai/code/session_01VghJbg5SFeRXLqRxrCsC9a)_