### PR TITLE
fix(parser): a string-literal export-specifier local name without `from` reports TS1003 (#16291)

### DIFF
--- a/crates/tsz-parser/src/parser/state_declarations_exports.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_exports.rs
@@ -601,6 +601,14 @@ impl ParserState {
             NodeIndex::NONE
         };
 
+        // TS1003: without a `from` clause, the *local* name of an export specifier
+        // (the part before `as`) must be an identifier, not a string literal. This is
+        // the export mirror of the import-specifier string-binding check; see
+        // `report_export_specifier_string_local_names` for the full rule.
+        if module_specifier.is_none() {
+            self.report_export_specifier_string_local_names(export_clause);
+        }
+
         // Parse optional import attributes: with { ... } or assert { ... }
         let attributes = if module_specifier.is_none() {
             NodeIndex::NONE

--- a/crates/tsz-parser/src/parser/state_declarations_modules.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_modules.rs
@@ -1358,5 +1358,51 @@ impl ParserState {
         self.parse_import_or_export_specifier(syntax_kind_ext::IMPORT_SPECIFIER)
     }
 
+    /// TS1003 for export specifiers whose local name is a string literal, the
+    /// export mirror of the string-binding check in
+    /// `parse_import_or_export_specifier`.
+    ///
+    /// In an export declaration with NO module specifier (`from`), the *local*
+    /// name of an export specifier — the part before `as`, stored as
+    /// `property_name` — must be an identifier, not a string literal. Unlike the
+    /// import check (imports always have a `from`, so their binding can never be a
+    /// string), this one is gated on the absence of `from`: with a module
+    /// specifier the string re-exports a string-named module binding
+    /// (`export { "q" as y } from "m"`), which tsc accepts. The exported alias may
+    /// itself be a string (`export { x as "s" }`), and a bare `{ "q" }` with no
+    /// `as` is also allowed — matching tsc's `checkExportSpecifier` /
+    /// `checkModuleExportName`. Callers must invoke this only when there is no
+    /// module specifier; `export_clause` is the `NAMED_EXPORTS` node.
+    pub(crate) fn report_export_specifier_string_local_names(&mut self, export_clause: NodeIndex) {
+        use tsz_common::diagnostics::diagnostic_codes;
+        let specifiers: Vec<NodeIndex> = self
+            .arena
+            .get_named_imports_at(export_clause)
+            .map(|named| named.elements.nodes.clone())
+            .unwrap_or_default();
+        for spec in specifiers {
+            let Some(property_name) = self
+                .arena
+                .get_specifier_at(spec)
+                .map(|data| data.property_name)
+            else {
+                continue;
+            };
+            let Some(name_node) = self.arena.get(property_name) else {
+                continue;
+            };
+            if name_node.is_string_literal() {
+                let name_start = name_node.pos;
+                let name_len = name_node.end.saturating_sub(name_node.pos);
+                self.parse_error_at(
+                    name_start,
+                    name_len,
+                    "Identifier expected.",
+                    diagnostic_codes::IDENTIFIER_EXPECTED,
+                );
+            }
+        }
+    }
+
     // Export declarations and control flow statements → state_declarations_exports.rs
 }

--- a/crates/tsz-parser/tests/state_declaration_tests.rs
+++ b/crates/tsz-parser/tests/state_declaration_tests.rs
@@ -643,6 +643,91 @@ import { from as fromObservable } from "./from";
     );
 }
 
+/// Mirror of `import_specifier_string_literal_binding_names_emit_ts1003` for the
+/// *export* side. Without a `from` clause, the local name of an export specifier
+/// (the part before `as`, i.e. the `property_name`) must be an identifier; a
+/// string literal there is TS1003 "Identifier expected." in `tsc`. The exported
+/// alias (after `as`) and a bare `{ "q" }` name may be string literals, so only
+/// the `property_name` position is flagged.
+#[test]
+fn export_specifier_string_literal_local_names_without_from_emit_ts1003() {
+    // Names are varied so nothing keys on a specific identifier.
+    let source = r#"
+export { "aa" as bb };
+export type { "cc" as dd };
+export { ee, "ff" as gg };
+export { "hh" as "ii" };
+"#;
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+    let ts1003_count = diagnostics
+        .iter()
+        .filter(|d| d.code == diagnostic_codes::IDENTIFIER_EXPECTED)
+        .count();
+    assert_eq!(
+        ts1003_count, 4,
+        "expected TS1003 for every string-literal export local name, got {diagnostics:?}"
+    );
+}
+
+/// The TS1003 anchor must sit on the offending string literal itself, exactly
+/// where `tsc` points it.
+#[test]
+fn export_specifier_string_local_name_ts1003_anchors_on_the_string() {
+    // `export { "q" as y };` — the `"q"` literal begins at byte offset 9.
+    let (parser, _root) = parse_source(r#"export { "q" as y };"#);
+    let diagnostics = parser.get_diagnostics();
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == diagnostic_codes::IDENTIFIER_EXPECTED && d.start == 9),
+        "expected TS1003 anchored at the string literal (offset 9), got {diagnostics:?}"
+    );
+}
+
+/// With a `from` clause the string local name re-exports a string-named module
+/// binding, which `tsc` accepts — so no TS1003.
+#[test]
+fn export_specifier_string_local_name_is_valid_with_from() {
+    let source = r#"
+export { "aa" as bb } from "./m";
+export type { "cc" as dd } from "./m";
+export { "hh" as "ii" } from "./m";
+"#;
+    let (parser, _root) = parse_source(source);
+    let ts1003_count = parser
+        .get_diagnostics()
+        .iter()
+        .filter(|d| d.code == diagnostic_codes::IDENTIFIER_EXPECTED)
+        .count();
+    assert_eq!(
+        ts1003_count, 0,
+        "a string local name re-exporting through `from` must not emit TS1003"
+    );
+}
+
+/// Negative controls without a `from` clause: a string *alias* (after `as`), a
+/// bare string name with no `as`, and all-identifier specifiers are each valid.
+#[test]
+fn export_specifier_string_alias_and_bare_string_without_from_are_valid() {
+    let source = r#"
+const jj = 1;
+export { jj as "kk" };
+export { "ll" };
+export { jj as nn };
+"#;
+    let (parser, _root) = parse_source(source);
+    let ts1003_count = parser
+        .get_diagnostics()
+        .iter()
+        .filter(|d| d.code == diagnostic_codes::IDENTIFIER_EXPECTED)
+        .count();
+    assert_eq!(
+        ts1003_count, 0,
+        "string aliases and bare string export names must not emit TS1003"
+    );
+}
+
 #[test]
 fn conditional_tuple_element_inside_conditional_extends_type_parses() {
     let (parser, _root) = parse_source(


### PR DESCRIPTION
Wires the **export-specifier** half of the string-literal-local-name grammar
check (part of #16291's unwired-diagnostic effort — the both-halves instance
named in [that issue's 19:01Z comment](https://github.com/tsz-org/tsz/issues/16291#issuecomment-5208399043):
*"tsz never reports TS1003 for `export { "q" as y }` … the parser has the check
for `IMPORT_SPECIFIER` only and the export mirror was never added"*).

tsz already reports `TS1003 Identifier expected.` when a string literal is used
as the local binding of an *import* specifier (`import { foo as "s" }`). The
*export* mirror was missing, so `export { "q" as y }` was silently accepted
where `tsc` reports TS1003.

## Structural rule

When an export declaration has **no** module specifier (`from`) and an export
specifier's *local* name — the part before `as`, stored as `property_name` — is
a string literal, `tsc` reports TS1003 anchored on that literal; tsz now does the
same. The check lives in the parser at `parse_export_named`
(`crates/tsz-parser/src/parser/state_declarations_exports.rs`), *after* the
`from` clause is parsed, so it is from-aware — unlike the unconditional
import-specifier check, since imports always have a `from` and their local
binding can never be a string. All `export { … }` forms (plain,
`export type { … }`, modifier-carrying, and export-recovery) route through
`parse_export_named`, so the single seam covers them all; the check body is a
helper colocated with its import sibling in `state_declarations_modules.rs`.

Only `property_name` is flagged: with a `from` clause the string re-exports a
string-named module binding (`export { "q" as y } from "m"`), the exported alias
may itself be a string (`export { x as "s" }`), and a bare `{ "q" }` with no
`as` is allowed — matching `tsc`'s `checkExportSpecifier` / `checkModuleExportName`.

TS1003 is already in `is_parser_grammar_code`, so it is non-suppressing
(`is_non_suppressing_parse_error`): `tsc` emits this grammar error alongside
same-file semantic diagnostics, and tsz keeps them too (row 2 below).

## Matrix (oracle-pinned, `typescript@7.0.2`, `--noEmit --module esnext --target es2022`)

| source | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `export { "q" as y };` | TS1003 @1,10 | (nothing) | TS1003 @1,10 |
| `export { "q" as y }; const z: string = 1;` | TS1003 + TS2322 | TS2322 only | TS1003 + TS2322 |
| `export { "a" as "b" };` | TS1003 @1,10 only | (nothing) | TS1003 @1,10 only |
| `export type { "q" as y };` | TS1003 @1,15 | (nothing) | TS1003 @1,15 |
| `export { a, "q" as y };` | TS1003 @1,24 | (nothing) | TS1003 @1,24 |
| `export { "q" as y } from "./m";` | clean | clean | clean |
| `export { x as "s" };` | clean | clean | clean |
| `export { "q" };` | clean | clean | clean |
| `import { x as "s" } from "./m";` (baseline) | TS1003 | TS1003 | TS1003 |

## Goal
Goal: hold

## Verification
- Oracle-pinned 10-row matrix above against `typescript@7.0.2`; the built
  `tsz` CLI matches `tsc` on every row, including column anchors and the
  TS1003+TS2322 coexistence.
- New sibling tests in `crates/tsz-parser/tests/state_declaration_tests.rs`
  (`export_specifier_string_literal_local_names_without_from_emit_ts1003`,
  `export_specifier_string_local_name_ts1003_anchors_on_the_string`,
  `export_specifier_string_local_name_is_valid_with_from`,
  `export_specifier_string_alias_and_bare_string_without_from_are_valid`),
  next to the existing import sibling. `cargo test -p tsz-parser --lib
  specifier_string` → 6 passed.
- `cargo clippy -p tsz-parser -- -D warnings` and `arch_guard.py` (the per-merge
  CI lane) clean; both touched files stay under the 2000-line ceiling.
- Additive parser grammar diagnostic that matches `tsc` exactly in the one
  malformed-export position; conformance/emit are the nightly gates.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_015zuKTbizinnK9SkNGx7Mcp

---
_Generated by [Claude Code](https://claude.ai/code/session_015zuKTbizinnK9SkNGx7Mcp)_