### PR TITLE
fix(solver): an unconstrained type parameter exposes Object.prototype members when strictNullChecks is off

### DIFF
--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -702,6 +702,47 @@ impl<'a> CheckerContext<'a> {
         )
     }
 
+    /// Like [`Self::with_cache`], but for callers whose `compiler_options` is
+    /// already fully resolved (strict family expanded with individual
+    /// overrides honored) instead of a raw `strict` umbrella.
+    ///
+    /// `with_cache`'s `EXPAND_STRICT_LOCALLY` policy re-runs
+    /// `apply_strict_defaults()`, which re-expands from `options.strict` and
+    /// silently clobbers an explicit per-member override back to the
+    /// umbrella's value when `strict` itself was never set to `false` (e.g.
+    /// `--strictNullChecks false` alone, with no `--strict` flag, leaves
+    /// `options.strict` at its default `true`). The CLI driver's per-file
+    /// cached path hits exactly this: its `compiler_options` already went
+    /// through `strict_family::apply_strict_family`, so re-expanding here
+    /// discards that resolution — and because `types` is one `QueryDatabase`
+    /// shared across every file in the compilation, a cached lib file
+    /// checked through this path clobbers `strict_null_checks` for every
+    /// file checked afterwards, not just itself.
+    pub fn with_cache_pre_resolved(
+        arena: &'a NodeArena,
+        binder: &'a BinderState,
+        types: &'a dyn QueryDatabase,
+        file_name: String,
+        cache: TypeCache,
+        compiler_options: CheckerOptions,
+    ) -> Self {
+        Self::from_parts(
+            arena,
+            binder,
+            types,
+            ContextParts {
+                file_name,
+                compiler_options,
+                options_policy: OptionsPolicy::PRE_RESOLVED,
+                def_store: DefStorePlan::PerFile,
+                cache: Some(cache),
+                cache_order: CacheRestoreOrder::BeforeWarm,
+                inherit_has_lib: false,
+                symbol_cache_capacity: None,
+            },
+        )
+    }
+
     /// Create a new `CheckerContext` with explicit compiler options and a persistent cache.
     ///
     /// Creates a pre-populated `DefinitionStore` from the binder's
@@ -767,6 +808,18 @@ impl<'a> CheckerContext<'a> {
     /// Important: only caches keyed by globally stable ids (e.g. `TypeId`, `RelationCacheKey`)
     /// are copied from the parent. Arena/binder-local ids (`SymbolId`, `NodeIndex`, `FlowNodeId`)
     /// must be reset to avoid cross-arena cache poisoning.
+    ///
+    /// `compiler_options` is always inherited from a parent context (the sole
+    /// production caller, `CheckerState::delegate_for_arena`, passes
+    /// `parent.ctx.compiler_options.clone()`), so it is already fully
+    /// resolved — never a raw `strict` umbrella needing local expansion.
+    /// `PRE_RESOLVED` avoids re-running `apply_strict_defaults()`, which
+    /// would re-expand from `options.strict` and clobber an explicit
+    /// per-member override the parent already resolved (e.g.
+    /// `strictNullChecks: false` with no `--strict` flag leaves
+    /// `options.strict` at its default `true`) — and because `types` is a
+    /// `QueryDatabase` shared with the parent (and every other file in the
+    /// same compilation), that clobbered flag leaks beyond this one child.
     pub fn with_parent_cache(
         arena: &'a NodeArena,
         binder: &'a BinderState,
@@ -782,7 +835,7 @@ impl<'a> CheckerContext<'a> {
             ContextParts {
                 file_name,
                 compiler_options,
-                options_policy: OptionsPolicy::EXPAND_STRICT_LOCALLY,
+                options_policy: OptionsPolicy::PRE_RESOLVED,
                 // The shared store is installed from the parent below.
                 def_store: DefStorePlan::Deferred,
                 cache: None,

--- a/crates/tsz-checker/src/state/state.rs
+++ b/crates/tsz-checker/src/state/state.rs
@@ -310,6 +310,30 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Like [`Self::with_cache`], but for callers whose `compiler_options` is
+    /// already fully resolved. See
+    /// [`CheckerContext::with_cache_pre_resolved`] for why this matters.
+    pub fn with_cache_pre_resolved(
+        arena: &'a NodeArena,
+        binder: &'a BinderState,
+        types: &'a dyn QueryDatabase,
+        file_name: String,
+        cache: crate::TypeCache,
+        compiler_options: CheckerOptions,
+    ) -> Self {
+        tsz_common::perf_counters::record_checker_state_constructed();
+        CheckerState {
+            ctx: CheckerContext::with_cache_pre_resolved(
+                arena,
+                binder,
+                types,
+                file_name,
+                cache,
+                compiler_options,
+            ),
+        }
+    }
+
     /// Thread-local guard for cross-arena delegation depth.
     /// All cross-arena delegation points (`delegate_cross_arena_symbol_resolution`,
     /// `get_type_params_for_symbol`, `type_of_value_declaration`) MUST call this

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -1383,7 +1383,17 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
                 .and_then(|cache| cache.type_caches.remove(&file_path));
             let compiler_options = options.checker.clone();
             let mut checker = if let Some(cached) = cached {
-                CheckerState::with_cache(
+                // `compiler_options` already went through
+                // `strict_family::apply_strict_family` in the driver's plan
+                // step, so its strict-family members are fully resolved
+                // (including per-member overrides that leave `options.strict`
+                // at its default while overriding one member — #3861's
+                // shape). `with_cache` re-runs `apply_strict_defaults()` and
+                // would silently clobber that override back to the umbrella;
+                // `with_cache_pre_resolved` skips the re-expansion, matching
+                // what the uncached branch below already gets for free via
+                // `CheckerState::new`'s `PRE_RESOLVED` policy.
+                CheckerState::with_cache_pre_resolved(
                     &file.arena,
                     &binder,
                     &query_cache,

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -53,7 +53,7 @@ mod resolver;
 // under both `exactOptionalPropertyTypes` settings (matching tsc), so the result
 // does not depend on that option and it is intentionally not part of this key.
 type ElementAccessTypeCacheKey = (TypeId, TypeId, Option<u32>, bool);
-type PropertyAccessCacheKey = (TypeId, Atom, bool, bool);
+type PropertyAccessCacheKey = (TypeId, Atom, bool, bool, bool);
 type ConditionalBranchVerdictCacheKey = (TypeId, TypeId, bool, bool);
 type PermissiveFalseBranchCacheKey = (TypeId, TypeId, bool, bool);
 

--- a/crates/tsz-solver/src/caches/query_cache_property.rs
+++ b/crates/tsz-solver/src/caches/query_cache_property.rs
@@ -20,11 +20,19 @@ impl QueryCache<'_> {
         // PropertyAccessEvaluator with the current QueryDatabase.
         let exact_optional_property_types =
             crate::caches::db::TypeCompilerOptions::exact_optional_property_types(self);
+        // strictNullChecks must be part of the key: an unconstrained type
+        // parameter's Object.prototype-member fallback is gated on it, so the
+        // same (object_type, prop_atom) pair resolves differently depending on
+        // this flag (#16701's end-to-end gap — the flag-aware answer was
+        // computed correctly but a strictNullChecks-oblivious cache entry from
+        // elsewhere in the same compilation could still win the lookup).
+        let strict_null_checks = crate::caches::db::TypeCompilerOptions::strict_null_checks(self);
         let key = (
             object_type,
             prop_atom,
             no_unchecked_indexed_access,
             exact_optional_property_types,
+            strict_null_checks,
         );
         if let Some(result) = self.check_property_cache(key) {
             return result;

--- a/crates/tsz-solver/src/operations/property.rs
+++ b/crates/tsz-solver/src/operations/property.rs
@@ -1089,16 +1089,24 @@ impl<'a> PropertyAccessEvaluator<'a> {
 
                     self.skip_this_binding.set(prev);
                     result
-                } else {
-                    // Unconstrained type parameters have no properties in tsc.
-                    // In TypeScript 6.0+, an unconstrained T is treated as `{}`
-                    // which does NOT include Object prototype methods (toString,
-                    // valueOf, hasOwnProperty, etc.). Accessing any property on
-                    // bare T emits TS2339 "Property X does not exist on type T".
+                } else if self.db.strict_null_checks() {
+                    // Under strictNullChecks, tsc's unconstrained-type-parameter
+                    // apparent type does not expose Object.prototype's members:
+                    // `function f<T>(x: T) { x.toString(); }` reports TS2339 on
+                    // `toString` itself, not just on a genuinely missing member.
                     PropertyAccessResult::PropertyNotFound {
                         type_id: obj_type,
                         property_name: prop_atom,
                     }
+                } else {
+                    // With strictNullChecks off, an unconstrained type parameter's
+                    // apparent type is the empty object type `{}`, which exposes
+                    // `Object.prototype`'s members (`toString`, `valueOf`,
+                    // `hasOwnProperty`, ...) but nothing else. Mirrors the
+                    // `IntrinsicKind::Object` case above via the same global-`Object`
+                    // fallback, so arbitrary properties still emit TS2339 while the
+                    // apparent members resolve.
+                    self.resolve_object_member_or_not_found(obj_type, prop_atom)
                 }
             }
 

--- a/crates/tsz-solver/tests/property_helpers_tests_parts/part_00.rs
+++ b/crates/tsz-solver/tests/property_helpers_tests_parts/part_00.rs
@@ -573,8 +573,9 @@ fn test_union_with_deferred_member_and_concrete_member_property_found() {
 }
 
 #[test]
-fn test_unconstrained_type_parameter_has_no_properties() {
+fn test_unconstrained_type_parameter_has_no_properties_under_strict_null_checks() {
     let interner = TypeInterner::new();
+    interner.set_strict_null_checks(true);
     let evaluator = PropertyAccessEvaluator::new(&interner);
 
     let t_info = TypeParamInfo {
@@ -586,10 +587,41 @@ fn test_unconstrained_type_parameter_has_no_properties() {
     };
     let t_param = interner.intern(TypeData::TypeParameter(t_info));
 
-    // tsc 6.0: unconstrained T has NO properties. The implicit constraint is {}
-    // which does NOT include Object prototype methods. Accessing toString on
-    // bare T emits TS2339 "Property 'toString' does not exist on type 'T'".
+    // Under strictNullChecks, tsc's unconstrained T does NOT expose Object
+    // prototype methods. `function f<T>(x: T) { x.toString(); }` reports
+    // TS2339 on `toString` itself under the pinned tsc 7.0.2 oracle with
+    // strictNullChecks on (the default).
     assert_property_not_found(&evaluator.resolve_property_access(t_param, "toString"));
+    assert_property_not_found(&evaluator.resolve_property_access(t_param, "nonExistentProp"));
+}
+
+#[test]
+fn test_unconstrained_type_parameter_exposes_object_prototype_members_without_strict_null_checks() {
+    let interner = TypeInterner::new();
+    interner.set_strict_null_checks(false);
+    let evaluator = PropertyAccessEvaluator::new(&interner);
+
+    let t_info = TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    };
+    let t_param = interner.intern(TypeData::TypeParameter(t_info));
+
+    // With strictNullChecks off, an unconstrained T's apparent type is the
+    // empty object type `{}`, which (per tsc) exposes `Object.prototype`'s
+    // members (toString, valueOf, ...) but nothing else.
+    // `function f<T>(x: T) { x.toString(); x.b; }` compiles clean on
+    // `x.toString()` and reports TS2339 only on `x.b` under the pinned tsc
+    // 7.0.2 oracle with `strictNullChecks: false`.
+    assert!(
+        evaluator
+            .resolve_property_access(t_param, "toString")
+            .is_success(),
+        "unconstrained type parameter should expose Object.prototype members when strictNullChecks is off"
+    );
     assert_property_not_found(&evaluator.resolve_property_access(t_param, "nonExistentProp"));
 }
 


### PR DESCRIPTION
Fixes the `propertyAccessOnTypeParameterWithoutConstraints.ts` false positives in the committed conformance false-positive queue (`x: [TS2339]`, no `m`).

**Structural rule.** When `strictNullChecks` is off, tsc's apparent type for an unconstrained type parameter `T` falls back to the empty object type `{}`, which still exposes `Object.prototype`'s members (`toString`, `valueOf`, `hasOwnProperty`, ...) — arbitrary properties still fail. Under `strictNullChecks` (tsc's default), `T` has no properties at all, not even `toString`. tsz's solver unconditionally treated every unconstrained type parameter as having no properties, regardless of `strictNullChecks`.

**Wrong semantic operation:** property lookup (apparent-type resolution for an unconstrained `TypeData::TypeParameter`/`TypeData::Infer`), not the checker's TS2339 emission path. Fixed at its owner in `crates/tsz-solver/src/operations/property.rs`'s `resolve_property_access_inner`, gated on `self.db.strict_null_checks()`: the `strictNullChecks: false` branch now falls through to the existing `resolve_object_member_or_not_found` helper — the same global-`Object`-member fallback `IntrinsicKind::Object` (i.e. bare `object`) already uses — instead of a hardcoded `PropertyAccessResult::PropertyNotFound`. No property name is hardcoded in the fix path; `resolve_object_member_or_not_found`/`apparent_object_member_kind` is the existing, already-shared bootstrap-fallback lookup used by every other apparent-Object-member call site in this file.

Confirmed empirically against the pinned oracle (`typescript@7.0.2`) before writing the fix:
```ts
function f<T>(x: T) {
    x.toString();      // strictNullChecks:false -> clean; strictNullChecks:true -> TS2339
    x.hasOwnProperty(); // same
    x.b;                // TS2339 either way — never an Object member
}
```
The `strictNullChecks`-gating itself (not just the plain toString case) was found by a genuine regression: a pre-existing checker unit test (`direct_callback_body_property_error_on_outer_type_param_is_retained`, using the checker's default options — strictNullChecks on) asserted TS2339 for `t.toString()` on an unconstrained outer `T`. An unconditional fix broke it; re-running the identical repro through the oracle with `--strictNullChecks`/`--strictNullChecks false` isolated the exact TS flag that gates the behavior.

**Owner layer.** Solver (`crates/tsz-solver/src/operations/property.rs`). The checker's separate "unconstrained type parameter → TS2339" special case in `crates/tsz-checker/src/types/property_access_type/identifier_resolution.rs` only fires when the solver *already* returned `PropertyNotFound`, so it needed no change — with the solver now returning `Success` for `toString` (when `strictNullChecks` is off), that checker branch is simply not reached for that property.

**Adjacent-case matrix**, `crates/tsz-solver/tests/property_helpers_tests_parts/part_00.rs` (renamed the old wrongly-asserting test, added its `strictNullChecks:true` counterpart):
| case | strictNullChecks | property | expected | before | after |
| --- | --- | --- | --- | --- | --- |
| unconstrained `T` | true | `toString` | not found (TS2339) | not found | not found (unchanged) |
| unconstrained `T` | true | `nonExistentProp` | not found | not found | not found (unchanged) |
| unconstrained `T` | **false** | `toString` | **success** | not found (bug) | **success** |
| unconstrained `T` | false | `nonExistentProp` | not found | not found | not found (unchanged) |
| `T extends object` | either | `toString` | success | success | success (unaffected — different branch) |

## Second commit: a cache-keying bug the first commit exposed

Review (thank you!) caught that the solver-level fix didn't reach the CLI end-to-end. Root cause: `QueryCache`'s property-access memoization key was `(object_type, prop_atom, no_unchecked_indexed_access, exact_optional_property_types)` — it never included `strict_null_checks`. The first commit made an unconstrained type parameter's property resolution *depend* on that flag for the first time, but the cache key didn't partition on it, so a cached result computed under one `strictNullChecks` state could win a lookup under the other within the same compilation. Fixed in `6990ca4`: `PropertyAccessCacheKey` now has 5 elements (`crates/tsz-solver/src/caches/query_cache.rs`), and `query_cache_property.rs` reads `strict_null_checks` into the key, matching the existing `no_unchecked_indexed_access`/`exact_optional_property_types` pattern.

End-to-end, `--strict false` (tsc's own idiomatic flag) now matched at every target tested, but the **standalone** `--strictNullChecks false` flag (not routed through `--strict`) still reproduced the false positive for `--target es2020` and later.

## Third commit: the actual end-to-end root cause

`TSZ_LOG` tracing (added and removed this session) on a debug build showed the solver reading `strict_null_checks=true` at the exact `TypeParameter` lookup, immediately after a *different* file's `CheckerContext::from_parts` call — for `lib.es2020.intl.d.ts` — had set it back to `true` on the same shared `QueryDatabase`.

Root cause: `CheckerState::delegate_for_arena` (the single canonical factory for cross-file/lib-symbol delegation — fires for essentially any lib type reference) builds its child `CheckerContext` via `with_parent_cache` using `OptionsPolicy::EXPAND_STRICT_LOCALLY`. That policy re-runs `CheckerOptions::apply_strict_defaults()`, which re-expands from `options.strict` whenever it's `true` and stomps every strict-family member — including `strict_null_checks`, even though the driver had already resolved it to an explicit `false`. `--strict false` sets `options.strict = false`, so the re-expansion is a no-op there (correct by accident). `--strictNullChecks false` alone leaves `options.strict` at its default `true` (tsc 6.0's `#3861` shape — umbrella untouched, one member explicitly overridden), so the re-expansion clobbers the override back to `true`. Because `types` is one `QueryDatabase` shared across every file in the compilation, that clobber on a delegate child leaks into the user file's own subsequent lookups.

`with_parent_cache`'s only production caller always passes `parent.ctx.compiler_options.clone()` — by definition already fully resolved — so re-expanding it is never correct. `135e2f1` switches its policy to `PRE_RESOLVED`, and adds `with_cache_pre_resolved` (switching the CLI driver's per-file cached-checker branch to it) for the same clobbering shape on the driver's other already-resolved-options call site — latent, not the one observed live, but the same bug.

All 5 flag/target combinations tested (`--strictNullChecks false`/`--strict false` × `es2015`/`es2022`/`esnext`) now report exactly one `TS2339` on `b`, matching tsc.

## What stays open, disclosed rather than claimed

The same conformance fixture has a second, unrelated false positive on `a().toString()` where `a: { <T>(): T }` is called with no arguments and no contextual type to infer `T` from. tsz's inferred result there resolves through the `unknown` intrinsic (`IntrinsicKind::Unknown` in the same file, line ~767, `PropertyAccessResult::IsUnknown`), and per the oracle `unknown.toString()` has the **same** `strictNullChecks`-gated Object.prototype-member exception this PR fixes for type parameters — `unknown.toString()` is clean with `strictNullChecks: false`, TS18046 with it on. `IsUnknown` is consumed at ~15 call sites across the checker (diagnostic code selection differs: TS2339 vs TS18046 vs TS7053 depending on caller), so gating it correctly is a separate, wider-blast-radius change and is left for a follow-up rather than bundled here (one invariant per PR). Noted on the board.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-solver --lib -- unconstrained_type_parameter constrained_object_like` — 4 passed, 0 failed (2 new/renamed + the pre-existing constrained-parameter and assignability regression tests).
- `cargo test -p tsz-checker --lib -- type_param property_access unconstrained` — 646 passed, 0 failed (includes `direct_callback_body_property_error_on_outer_type_param_is_retained`, the test that caught the initial unconditional-fix regression).
- `cargo test -p tsz-checker --lib -- ts2339_not_suppressed_for_unconstrained_type_param ts2339_suppressed_for_circular` — 4 passed, 0 failed.
- `cargo test -p tsz-checker --test in_chain_narrows_unconstrained_type_param_tests` — 22 passed, 0 failed.
- `cargo test -p tsz-solver --lib` (full solver unit suite) — **7654 passed, 0 failed**.
- `cargo test -p tsz-checker --test conformance_issues_features` — 385 passed / 3 failed, all 3 confirmed pre-existing on `main` via `git stash` (unrelated: JSDoc parse recovery and a function-literal-return-type display case, neither touches property access).
- `cargo test -p tsz-checker --lib -- type_param property_access unconstrained delegate parent_cache` (third commit) — 740 passed, 0 failed, 1 ignored.
- Binary-level, third commit (`135e2f1`), clean single rebuild: all 5 flag/target combinations (`--strictNullChecks false`/`--strict false` × `es2015`/`es2022`/`esnext`) report exactly one TS2339 (on `b`) for `function f<T>(x: T) { x.toString(); x.b; }` — matching tsc exactly, including the reviewer's own repro and acceptance criterion.
- Binary-level check against the actual conformance fixture with the rebuilt `.target/dist-fast/tsz` (`--target es2015 --strict false`, the fixture's own pinned directives): both `x['toString']()` (line 7) and `x.toString()` (line 29) false positives are gone; the unrelated `unknown` residual on line 23 remains, as expected and disclosed above.
- `cargo fmt`/clippy/architecture guard: enforced by the pre-commit hook on all three commits, all clean.
- Full `cargo test -p tsz-checker --lib` (~10.4k tests) and the two-sided `compare-to-parent.sh` corpus gate were started but did not finish within this session's time budget (the full-lib suite has a known long tail past the 30-minute mark on this hardware) — owed. The targeted `type_param`/`property_access`/`unconstrained`/`delegate`/`parent_cache` slice (740 tests, spanning all three commits) covers this change's direct blast radius in the meantime.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: Malachite