### PR TITLE
fix(checker): a `ThisType[ T ]` marker on an enclosing object literal types `this` in a nested literal's members

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -677,6 +677,8 @@ mod object_define_property_identity_tests;
 mod object_global_identity_helper_tests;
 #[path = "tests/object_literal_computed_symbol_member_tests.rs"]
 mod object_literal_computed_symbol_member_tests;
+#[path = "tests/object_literal_enclosing_this_type_marker_tests.rs"]
+mod object_literal_enclosing_this_type_marker_tests;
 #[path = "tests/object_literal_method_body_check_tests.rs"]
 mod object_literal_method_body_check_tests;
 #[path = "tests/object_literal_method_this_parameter_contextual_tests.rs"]

--- a/crates/tsz-checker/src/tests/object_literal_enclosing_this_type_marker_tests.rs
+++ b/crates/tsz-checker/src/tests/object_literal_enclosing_this_type_marker_tests.rs
@@ -1,0 +1,313 @@
+//! A `ThisType[ T ]` marker on an *enclosing* object literal's contextual type
+//! types `this` inside a nested literal's members.
+//!
+//! `tsc`'s `getContextualThisParameter` climbs outward from the literal that
+//! directly contains the member:
+//!
+//! ```text
+//! while (type) {
+//!     const thisType = getThisTypeFromContextualType(type);
+//!     if (thisType) { return ...; }
+//!     if (literal.parent.kind !== SyntaxKind.PropertyAssignment) break;
+//!     literal = literal.parent.parent;
+//!     type = getApparentTypeOfContextualType(literal);
+//! }
+//! ```
+//!
+//! tsz used to stop at the innermost literal, so the Vue options shape
+//! (`ThisType[ D & M & P ] & { methods?: M }`) and the
+//! `Object.defineProperties` shape (`PropDescMap[ U ] & ThisType[ T ]`) typed
+//! `this` as the nested literal itself and reported spurious `TS2339` — plus
+//! the `TS7023` that the resulting self-reference triggers.
+//!
+//! Corpus witness: `conformance/types/thisType/thisTypeInObjectLiterals2.ts`.
+//!
+//! These fixtures need the real `ThisType` marker interface, so they run
+//! through `check_source_with_libs` with the default libs rather than the
+//! no-lib `check_source_*` helpers: without a lib, `ThisType` never resolves
+//! to the registered marker definition and the negative controls stop
+//! discriminating.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_source_with_libs, load_default_lib_files};
+
+fn diagnostics_text(source: &str) -> Vec<String> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            strict_null_checks: true,
+            no_implicit_any: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|d| format!("TS{}: {}", d.code, d.message_text))
+    .collect()
+}
+
+fn codes(source: &str) -> Vec<u32> {
+    diagnostics_text(source)
+        .iter()
+        .filter_map(|d| d.split_once(':').and_then(|(c, _)| c[2..].parse().ok()))
+        .collect()
+}
+
+fn this_typing_errors(source: &str) -> Vec<String> {
+    diagnostics_text(source)
+        .into_iter()
+        .filter(|d| d.starts_with("TS2339:") || d.starts_with("TS7023:"))
+        .collect()
+}
+
+#[test]
+fn a_marker_on_the_literal_itself_types_this_in_its_own_methods() {
+    // Control: the already-working shape, where the marker sits on the same
+    // literal's contextual type.
+    let source = r"
+type Data = { x: number; };
+type Options = { move(dx: number): void; } & ThisType<Data>;
+declare function configure(options: Options): void;
+configure({
+    move(dx) {
+        this.x += dx;
+    }
+});
+";
+    assert!(
+        this_typing_errors(source).is_empty(),
+        "unexpected: {:?}",
+        this_typing_errors(source)
+    );
+}
+
+#[test]
+fn a_marker_on_the_enclosing_literal_types_this_in_a_nested_literal_method() {
+    let source = r"
+type Data = { x: number; };
+type Methods = { move(dx: number): void; };
+type Options = ThisType<Data & Methods> & { methods?: Methods; };
+declare function configure(options: Options): void;
+configure({
+    methods: {
+        move(dx) {
+            this.x += dx;
+        }
+    }
+});
+";
+    assert!(
+        this_typing_errors(source).is_empty(),
+        "unexpected: {:?}",
+        this_typing_errors(source)
+    );
+}
+
+#[test]
+fn a_marker_on_the_enclosing_literal_types_this_in_a_nested_accessor() {
+    let source = r"
+type Data = { x: number; };
+type Slot = { readonly doubled?: number; };
+type Options = ThisType<Data> & { slot?: Slot; };
+declare function configure(options: Options): void;
+configure({
+    slot: {
+        get doubled() {
+            return this.x * 2;
+        }
+    }
+});
+";
+    assert!(
+        this_typing_errors(source).is_empty(),
+        "unexpected: {:?}",
+        this_typing_errors(source)
+    );
+}
+
+#[test]
+fn the_walk_climbs_more_than_one_property_assignment() {
+    let source = r"
+type Data = { x: number; };
+type Inner = { move?(dx: number): void; };
+type Outer = { inner?: Inner; };
+type Options = ThisType<Data> & { outer?: Outer; };
+declare function configure(options: Options): void;
+configure({
+    outer: {
+        inner: {
+            move(dx) {
+                this.x += dx;
+            }
+        }
+    }
+});
+";
+    assert!(
+        this_typing_errors(source).is_empty(),
+        "unexpected: {:?}",
+        this_typing_errors(source)
+    );
+}
+
+#[test]
+fn a_nearer_marker_wins_over_an_enclosing_one() {
+    // The innermost marker is found first, so `this` is `Near`, not `Far`.
+    // `far` exists only on `Far`, so reading it must still be an error.
+    let source = r"
+type Far = { far: number; };
+type Near = { near: number; };
+type Inner = { read?(): number; } & ThisType<Near>;
+type Options = ThisType<Far> & { inner?: Inner; };
+declare function configure(options: Options): void;
+configure({
+    inner: {
+        read() {
+            return this.near;
+        }
+    }
+});
+";
+    assert!(
+        this_typing_errors(source).is_empty(),
+        "expected the nearer marker to apply, got {:?}",
+        this_typing_errors(source)
+    );
+
+    let shadowed = r"
+type Far = { far: number; };
+type Near = { near: number; };
+type Inner = { read?(): number; } & ThisType<Near>;
+type Options = ThisType<Far> & { inner?: Inner; };
+declare function configure(options: Options): void;
+configure({
+    inner: {
+        read() {
+            return this.far;
+        }
+    }
+});
+";
+    assert!(
+        codes(shadowed).contains(&2339),
+        "the enclosing marker must not leak past a nearer one, got {:?}",
+        diagnostics_text(shadowed)
+    );
+}
+
+#[test]
+fn renamed_binders_do_not_change_the_outcome() {
+    let source = r"
+type Store = { counter: number; };
+type Handlers = { bump(step: number): void; };
+type Config = ThisType<Store & Handlers> & { handlers?: Handlers; };
+declare function register(config: Config): void;
+register({
+    handlers: {
+        bump(step) {
+            this.counter += step;
+        }
+    }
+});
+";
+    assert!(
+        this_typing_errors(source).is_empty(),
+        "unexpected: {:?}",
+        this_typing_errors(source)
+    );
+}
+
+#[test]
+fn a_member_missing_from_the_marker_type_still_reports_ts2339() {
+    // Negative control: the walk must not make `this` permissive.
+    let source = r"
+type Data = { x: number; };
+type Methods = { move(dx: number): void; };
+type Options = ThisType<Data & Methods> & { methods?: Methods; };
+declare function configure(options: Options): void;
+configure({
+    methods: {
+        move(dx) {
+            this.notAMember += dx;
+        }
+    }
+});
+";
+    assert!(
+        codes(source).contains(&2339),
+        "expected TS2339 for `this.notAMember`, got {:?}",
+        diagnostics_text(source)
+    );
+}
+
+#[test]
+fn a_nested_literal_without_any_enclosing_marker_keeps_its_own_this() {
+    // No marker anywhere: `this` inside the nested literal's method stays the
+    // nested literal, so a member of the *outer* literal is not reachable.
+    let source = r"
+let o = {
+    x: 1,
+    inner: {
+        read() {
+            return this.x;
+        }
+    }
+};
+";
+    assert!(
+        codes(source).contains(&2339),
+        "expected TS2339 for `this.x` in the nested literal, got {:?}",
+        diagnostics_text(source)
+    );
+}
+
+#[test]
+fn the_walk_stops_at_a_non_property_assignment_parent() {
+    // `tsc` breaks the climb when the literal's parent is not a
+    // `PropertyAssignment`. An array-literal element is such a parent, so the
+    // enclosing `ThisType` marker must not reach the method inside it.
+    let source = r"
+type Data = { x: number; };
+type Entry = { read?(): number; };
+type Options = ThisType<Data> & { entries?: Entry[]; };
+declare function configure(options: Options): void;
+configure({
+    entries: [
+        {
+            read() {
+                return this.x;
+            }
+        }
+    ]
+});
+";
+    assert!(
+        codes(source).contains(&2339),
+        "the marker must not climb through an array literal, got {:?}",
+        diagnostics_text(source)
+    );
+}
+
+#[test]
+fn a_plain_nested_literal_under_a_marker_free_context_is_unaffected() {
+    let source = r"
+type Inner = { read(): number };
+type Outer = { inner: Inner; value: number };
+let o: Outer = {
+    value: 1,
+    inner: {
+        read() {
+            return 42;
+        }
+    }
+};
+";
+    assert!(
+        diagnostics_text(source).is_empty(),
+        "unexpected: {:?}",
+        diagnostics_text(source)
+    );
+}

--- a/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
@@ -287,7 +287,14 @@ impl<'a> CheckerState<'a> {
             }
 
             if elem_node.kind == syntax_kind_ext::GET_ACCESSOR {
-                if accessor.type_annotation.is_none() {
+                // A `ThisType[ T ]` marker makes `this` denote `T`, not the
+                // literal under construction, so `this.<member>` in the body
+                // reads a member of `T` and can never be the getter's own
+                // circular self-reference. Without this gate the receiver
+                // heuristic in `object_literal_getter_has_self_reference` —
+                // which treats every `this.` receiver as the literal — turns a
+                // legitimate `this.x` under a marker into a spurious TS7023.
+                if accessor.type_annotation.is_none() && marker_this_type.is_none() {
                     use crate::diagnostics::diagnostic_codes;
                     if self.object_literal_getter_has_self_reference(elem_idx, accessor.body, &name)
                     {

--- a/crates/tsz-checker/src/types/computation/object_literal/computation_request_facts.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation_request_facts.rs
@@ -138,11 +138,9 @@ impl<'a> CheckerState<'a> {
         // Check for ThisType<T> marker in contextual type (Vue 2 / Options API
         // pattern) after union narrowing so discriminated object literals choose
         // the matching union member's marker.
-        let marker_this_type: Option<TypeId> = if let Some(ctx_type) = contextual_type {
-            self.contextual_this_type_from_marker(ctx_type)
-        } else {
-            None
-        };
+        let marker_this_type: Option<TypeId> = contextual_type
+            .and_then(|ctx_type| self.contextual_this_type_from_marker(ctx_type))
+            .or_else(|| self.enclosing_object_literal_this_type_marker(idx));
 
         // Push this type onto stack if found (methods will pick it up)
         if let Some(mut this_type) = marker_this_type {
@@ -195,6 +193,67 @@ impl<'a> CheckerState<'a> {
             contextual_receiver_this_type,
             base_request,
             partial_initializer_stack_index,
+        }
+    }
+
+    /// The `ThisType[ T ]` marker owned by an *enclosing* object literal, found
+    /// by walking outward from `literal_idx` through property assignments.
+    ///
+    /// `tsc`'s `getContextualThisParameter` does not stop at the literal that
+    /// directly contains the member. When that literal's own contextual type
+    /// carries no marker it re-reads the contextual type of the enclosing
+    /// literal, and keeps climbing for as long as the current literal sits in a
+    /// `PropertyAssignment`:
+    ///
+    /// ```text
+    /// while (type) {
+    ///     const thisType = getThisTypeFromContextualType(type);
+    ///     if (thisType) { return ...; }
+    ///     if (literal.parent.kind !== SyntaxKind.PropertyAssignment) break;
+    ///     literal = literal.parent.parent;
+    ///     type = getApparentTypeOfContextualType(literal);
+    /// }
+    /// ```
+    ///
+    /// That climb is what makes the Vue options shape work: in
+    /// `new Vue({ methods: { f() { return this.x; } } })` with
+    /// `VueOptions[ D, M, P ] = ThisType[ D & M & P ] & { methods?: M; ... }`,
+    /// the inner `methods` literal is contextually typed by bare `M` — the
+    /// marker lives one level out, on the options literal. The same applies to
+    /// the `Object.defineProperties` shape, where
+    /// `PropDescMap[ U ] & ThisType[ T ]` types the outer descriptor map and
+    /// each per-key descriptor literal only sees `PropDesc[ U ]`.
+    ///
+    /// The enclosing literal is always computed before its property
+    /// initializers, so its (nullish-stripped, discriminant-narrowed)
+    /// contextual type is already recorded in
+    /// `object_literal_tracking.contextual_targets`; an ancestor with no
+    /// recorded contextual type ends the walk, mirroring the `while (type)`
+    /// condition.
+    fn enclosing_object_literal_this_type_marker(
+        &mut self,
+        literal_idx: NodeIndex,
+    ) -> Option<TypeId> {
+        let mut literal_idx = literal_idx;
+        loop {
+            let property_idx = self.ctx.arena.get_extended(literal_idx)?.parent;
+            if self.ctx.arena.get(property_idx)?.kind != syntax_kind_ext::PROPERTY_ASSIGNMENT {
+                return None;
+            }
+            let enclosing_idx = self.ctx.arena.get_extended(property_idx)?.parent;
+            if self.ctx.arena.get(enclosing_idx)?.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+            {
+                return None;
+            }
+            let enclosing_contextual_type = *self
+                .ctx
+                .object_literal_tracking
+                .contextual_targets
+                .get(&enclosing_idx)?;
+            if let Some(marker) = self.contextual_this_type_from_marker(enclosing_contextual_type) {
+                return Some(marker);
+            }
+            literal_idx = enclosing_idx;
         }
     }
 }


### PR DESCRIPTION
**Structural rule.** When an object-literal member needs a `this` type and the literal's *own* contextual type carries no `ThisType[ T ]` marker, `tsc` climbs outward to the enclosing literal's contextual type and keeps climbing for as long as the current literal sits in a `PropertyAssignment`; tsz now does the same, through the object-literal request-facts prescan in `types/computation/object_literal/computation_request_facts.rs`.

`getContextualThisParameter`, verbatim:

```
while (type) {
    const thisType = getThisTypeFromContextualType(type);
    if (thisType) { return ...; }
    if (literal.parent.kind !== SyntaxKind.PropertyAssignment) break;
    literal = literal.parent.parent;
    type = getApparentTypeOfContextualType(literal);
}
```

tsz stopped at the innermost literal. Marker extraction itself was already implemented and correct — this is a missing *ancestor walk* inside a working feature, not a missing feature. The two shapes that put the marker one level out both mistyped `this` as the nested literal itself:

- the Vue options shape, `VueOptions[ D, M, P ] = ThisType[ D & M & P ] & { methods?: M; ... }`, where the `methods` literal is contextually typed by bare `M`;
- the `Object.defineProperties` shape, `PropDescMap[ U ] & ThisType[ T ]`, where each per-key descriptor literal only sees `PropDesc[ U ]`.

Both produced spurious `TS2339` on every member access off `this` in the nested bodies, plus the `TS7023` that the resulting apparent self-reference induces.

> Note for readers: this board/PR surface strips real angle brackets, so generics below are written with square brackets. The in-repo test file
> `crates/tsz-checker/src/tests/object_literal_enclosing_this_type_marker_tests.rs` carries the runnable source.

Two edits:

1. `computation_request_facts.rs` — `enclosing_object_literal_this_type_marker`, the climb. The enclosing literal is always computed before its property initializers, so its (nullish-stripped, discriminant-narrowed) contextual type is already recorded in `object_literal_tracking.contextual_targets`; an ancestor with no recorded contextual type ends the walk, mirroring the `while (type)` condition, and a non-`PropertyAssignment` parent ends it too. No new contextual-type derivation, no new solver call — the marker still comes out of the existing `contextual_this_type_from_marker` query boundary.
2. `accessor_element.rs` — the get-accessor `TS7023` self-reference check is now gated on `marker_this_type.is_none()`. With a marker in play `this` denotes the marker type, not the literal under construction, so a member access off `this` can never be the getter's own circular return; the `this`-receiver heuristic in `object_literal_getter_has_self_reference` would otherwise report one the moment the climb starts supplying a `this`.

**Corpus witness.** `conformance/types/thisType/thisTypeInObjectLiterals2.ts`, one of the 104 pure-false-positive rows in the committed `conformance-detail.json` (`x` present, no `m`) and clean in `tsc` end to end. Measured on the same `dist-fast` binary before and after, with the pinned `typescript@7.0.2` oracle as the reference:

| section | tsc 7.0.2 | tsz before | tsz after |
| --- | --- | --- | --- |
| whole fixture | *(clean)* | `TS7023` x1, `TS2339` x4, `TS2322` x1 | `TS2322` x1 |
| `defineProp`/`defineProps` | clean | `TS2339` x2 | clean |
| Vue options | clean | `TS7023` x1, `TS2339` x4, `TS2322` x1 | `TS2322` x1 |
| `obj1` / contextual `Point` / `makeObject` | clean | clean | clean |

**The row still fails, and the residual is a different bug.** The last `TS2322` says `() => number` is not assignable to `Computed[ number ] | (() => number)` on `computed: { test(): number { ... } }` against `Accessors[ P ] = { [K in keyof P]: (() => P[K]) | Computed[ P[K] ] }`. It is not a `this`-typing failure and it does not need an object literal at all — reduced (square-bracket generics; runnable form in the linked issue):

```
type Computed[ T ] = { get?(): T; set?(value: T): void; }
let a1: (() => number) | Computed[ number ] = () => 1;   // clean in tsz, either member order
declare function g1[ T ](x: (() => T) | Computed[ T ]): T;
let b1 = g1(() => 1);                                    // tsz: TS2559, tsc: clean
```

A concrete union target is fine in either member order; only the *generic* / mapped-instantiated union target reports the weak-type "no properties in common" against `Computed[ T ]` instead of falling through to the function member. `tsc` runs that common-property check with `reportErrors: false` while iterating union constituents, so it silently rejects the weak member and succeeds on the function one. That is a solver relation bug in a different owner layer, filed separately rather than folded in here.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib object_literal_enclosing_this_type_marker` — **10 passed / 0 failed** with the fix; **6 passed / 4 failed** with the two production files stashed and the suite unchanged (non-vacuity measured, not asserted). Matrix: marker on the literal itself (control), marker one level out on a nested method, on a nested get-accessor, two `PropertyAssignment` levels up, renamed binders, a nearer marker shadowing a farther one *plus* its negative half (the farther marker must not leak past it), a member genuinely absent from the marker type still `TS2339`, a nested literal with no marker anywhere keeping its own `this`, the climb stopping at a non-`PropertyAssignment` parent (array-literal element), and a marker-free nested literal left alone.
- Targeted lanes on the already-built `--lib` binary: `object_literal` 311/311, `contextual` 310/310, `this_type` 69/69, `accessor` 67/67, `marker` 29/29, `vue` 1/1 — all pass.
- `cargo test -p tsz-checker --lib` (full lane, 10408 tests): 10397 reported `ok` with zero failures at the time of writing; the run was still in the known five-test long tail (`ts2589_tests::recursive_conditional_alias_omitted_default_transform_emits_definition_ts2589`, over 60s). Final count confirmed in a comment below.
- `cargo fmt --all` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean; `python3 scripts/arch/arch_guard.py` — "Architecture guardrails passed."
- Conformance: `conformance.sh run --filter thisType` in flight on this seat, `compare-to-parent.sh` queued behind it. Numbers follow in a comment — **disclosed as owed, not claimed.** The semantic blast radius is bounded by construction: the climb only changes behaviour when an ancestor literal's contextual type contains a `ThisType[ T ]` marker, and exactly 11 files under `TypeScript/tests/cases` mention `ThisType` at all (two of them fourslash).

Anti-hardcoding: no identifier, alias, property or file-name string drives the new code; the climb is a pure AST-shape walk (`PropertyAssignment` -> `ObjectLiteralExpression`) and the marker decision stays inside the existing `contextual_this_type_from_marker` boundary. Tests vary the binder names (`Data`/`Methods`/`move` vs `Store`/`Handlers`/`bump`) and assert both directions.

## Provenance
Machine: cloud
Assistant: claude-code
Model: opus
Effort: high
AgentName: Malachite