### PR TITLE
fix(checker): a typeof read of a parameter in a type reference's type arguments is still reported unused (#16680)

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/core_type_query.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core_type_query.rs
@@ -190,6 +190,16 @@ impl<'a> CheckerState<'a> {
             && let Some(ref name) = name_text
             && let Some(&param_type) = self.ctx.typeof_param_scope.get(name.as_str())
         {
+            // This branch answers `typeof <name>` from the precomputed
+            // signature-scope type rather than by resolving `expr_name`
+            // through the normal identifier path, so the resolver that
+            // marks a symbol as read (`resolve_identifier_symbol`) never
+            // runs for it. tsc's `checkTypeQuery` always routes the operand
+            // through `checkExpressionOrQualifiedName`, i.e. every `typeof`
+            // operand is a genuine read regardless of which path answers its
+            // type; mark it explicitly here so `--noUnusedParameters` does
+            // not report the named parameter as unread.
+            self.resolve_identifier_symbol(type_query.expr_name);
             return param_type;
         }
 

--- a/crates/tsz-checker/src/tests/unused_typeof_type_query_reference_tests.rs
+++ b/crates/tsz-checker/src/tests/unused_typeof_type_query_reference_tests.rs
@@ -152,21 +152,17 @@ fn a_module_local_read_by_an_exported_type_alias_query_is_used() {
     );
 }
 
-/// Tripwire for the one spelling this fix does **not** reach: a `typeof` written
-/// inside the **type arguments** of a type reference. Measured through the built
-/// CLI (`--strict --target es2022 --noUnusedLocals --noUnusedParameters`), the
-/// parameter is still reported as unread for `Wrap<typeof a>`, `Array<typeof a>`,
-/// `ReadonlyArray<typeof a>`, `Map<string, typeof a>` and `Wrap<(typeof a)>`,
-/// while every non-type-argument spelling above is now correct. tsc reports
-/// nothing for any of them.
-///
-/// The `--noUnusedLocals` half of the same spelling is already correct
-/// (`const w = 1; export const y: Wrap<typeof w> = { v: 1 };` is clean), which
-/// places the remaining defect on the parameter re-scan rather than on reference
-/// tracking. Left as a failing assertion under `#[ignore]` so it flips loudly
-/// when the type-argument cell is closed rather than sitting as a silent absence.
+/// A `typeof` written inside the **type arguments** of a type reference
+/// (`Wrap<typeof a>`). The signature-building pass answers this query from
+/// `typeof_param_scope` (a precomputed name → `TypeId` map covering exactly
+/// this shape) rather than by resolving `expr_name` through the normal
+/// identifier path, so the resolver that marks a symbol as read never ran for
+/// it — the type-argument spelling never got a second, post-signature
+/// evaluation the way a direct annotation spelling does. Fixed by marking the
+/// operand referenced directly inside that shortcut branch
+/// (`get_type_from_type_query_flow_sensitive_with_request` in
+/// `state/type_analysis/core_type_query.rs`).
 #[test]
-#[ignore = "type-argument-nested typeof is a separate open cell; see the module docs"]
 fn a_parameter_read_by_a_type_argument_type_query_is_used() {
     let codes = unused_codes(
         "type Wrap<T> = { v: T };\nexport function m2(a: number, b: Wrap<typeof a>) { return b; }\n",
@@ -175,6 +171,55 @@ fn a_parameter_read_by_a_type_argument_type_query_is_used() {
     assert!(
         !codes.contains(&6133),
         "a `typeof` in type-argument position reads its operand. Got: {codes:?}"
+    );
+}
+
+/// Same shape, a lib-builtin generic instead of a local alias — the fix lives
+/// in the general `typeof_param_scope` shortcut, not in local-alias handling.
+#[test]
+fn a_parameter_read_by_a_typeof_type_argument_to_a_builtin_generic_is_used() {
+    let codes = unused_codes("export function m3(a: number, b: Array<typeof a>) { return b; }\n");
+
+    assert!(
+        !codes.contains(&6133),
+        "a `typeof` type argument to a builtin generic reads its operand. Got: {codes:?}"
+    );
+}
+
+/// The second of two type arguments (`Map<string, typeof a>`) — the fix must
+/// not depend on the query sitting in the first argument slot.
+#[test]
+fn a_parameter_read_by_a_typeof_second_type_argument_is_used() {
+    let codes =
+        unused_codes("export function m4(a: number, b: Map<string, typeof a>) { return b; }\n");
+
+    assert!(
+        !codes.contains(&6133),
+        "a `typeof` in a later type-argument slot reads its operand. Got: {codes:?}"
+    );
+}
+
+/// Parenthesized inside the type argument (`Wrap<(typeof a)>`) — a separate,
+/// still-open residual. Traced live (`TSZ_LOG`, dev CLI build): neither the
+/// `typeof_param_scope` shortcut in
+/// `get_type_from_type_query_flow_sensitive_with_request`
+/// (`state/type_analysis/core_type_query.rs`, fixed by this PR for the
+/// unparenthesized sibling) nor the mirrored `type_query_override` shortcut
+/// in `lower_with_resolvers_impl` (`type_node_lowering.rs`, also fixed here)
+/// is ever entered for this shape — zero hits on both, confirmed by tracing
+/// every call to each. The parenthesized type argument resolves through a
+/// third, unidentified path. Left `#[ignore]`d with its own oracle row
+/// rather than banked, per #16704's next-probe note.
+#[test]
+#[ignore = "parenthesized-type-argument typeof is a separate open cell (neither known typeof_param_scope shortcut is entered); see #16704"]
+fn a_parameter_read_by_a_parenthesized_type_argument_type_query_is_used() {
+    let codes = unused_codes(
+        "type Wrap<T> = { v: T };\nexport function m5(a: number, b: Wrap<(typeof a)>) { return b; }\n",
+    );
+
+    assert!(
+        !codes.contains(&6133),
+        "a parenthesized `typeof` type argument reads its operand. Got: {codes:?}"
     );
 }
 

--- a/crates/tsz-checker/src/types/type_node_lowering.rs
+++ b/crates/tsz-checker/src/types/type_node_lowering.rs
@@ -249,6 +249,20 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                 && let Some(&param_type) =
                     self.ctx.typeof_param_scope.get(ident.escaped_text.as_str())
             {
+                // Mirrors the `typeof_param_scope` shortcut in
+                // `get_type_from_type_query_flow_sensitive_with_request`
+                // (`state/type_analysis/core_type_query.rs`): this answers
+                // `typeof <name>` from the precomputed signature-scope type
+                // instead of resolving `expr_name_idx` through the normal
+                // identifier path, so mark the operand referenced explicitly
+                // — every `typeof` operand is a genuine read regardless of
+                // which path answers its type.
+                if let Some(sym_id) = value_resolver(expr_name_idx) {
+                    self.ctx
+                        .referenced_symbols
+                        .borrow_mut()
+                        .insert(tsz_binder::SymbolId(sym_id));
+                }
                 return Some(param_type);
             }
 


### PR DESCRIPTION
Closes the type-argument residual of #16680 for the unparenthesized spelling.

**Structural rule.** `typeof x` always reads the value `x`, regardless of where in a type annotation it sits — tsc's `checkTypeQuery` routes the operand through `checkExpressionOrQualifiedName` unconditionally. tsz decides "was this parameter read" from a side set (`referenced_symbols`) populated by the resolver that answers each identifier's type; whichever code path never calls that resolver for an occurrence never marks it, and the unused-parameter check (`types/type_checking/unused.rs`) then reports `TS6133`.

(Note: this description writes generic type arguments with square brackets instead of angle brackets — this repo's GitHub API strips literal angle brackets from issue/PR bodies, including inside fenced code blocks. The actual code and tests use real angle-bracket syntax; see `crates/tsz-checker/src/tests/unused_typeof_type_query_reference_tests.rs` for runnable source.)

## Root cause

`typeof paramName` inside a function signature is answered from `typeof_param_scope` — a precomputed name → `TypeId` map built while the signature is still being constructed, so a parameter's own `typeof` can resolve before its neighbor's declared type exists yet. Two independent call sites implement this identical shortcut, and both return the cached type **without ever resolving the operand through the normal identifier path**:

1. `get_type_from_type_query_flow_sensitive_with_request` (`state/type_analysis/core_type_query.rs`) — the interactive per-node dispatcher.
2. `type_query_override`, a closure inside `lower_with_resolvers_impl` (`types/type_node_lowering.rs`) — the generic-instantiation lowering path (`tsz_lowering::TypeLowering`) that a type reference's type *arguments* go through.

A **direct** parameter-type annotation (`b: typeof a`) happens to get a second, later evaluation after `typeof_param_scope` has been popped post-signature, and that second evaluation does go through the normal path and marks the reference — which is why only the **type-argument** spelling (`b: Wrap[typeof a]`) was broken: its type gets cached from the one-and-only signature-building evaluation and is never revisited, so it stayed permanently unmarked.

## Fix

Both shortcuts now mark the `typeof` operand referenced explicitly at the point they answer the query, instead of relying on a possible second evaluation elsewhere. This is structurally justified independent of the type-argument case — the second-evaluation dependency was already fragile.

## Adjacent-case matrix

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `Wrap[typeof a]` (local generic alias, the acceptance test) | clean | TS6133 | **clean** |
| `Array[typeof a]` (builtin generic) | clean | TS6133 | **clean** |
| `Map[string, typeof a]` (typeof in the *second* argument slot) | clean | TS6133 | **clean** |
| `Wrap[(typeof a)]` (parenthesized) | clean | TS6133 | **still TS6133 — separate cell** |
| every non-type-argument spelling from #16680's original fix (sibling param, return type, nested type literal, qualified name, body-local, module-scope local via exported alias) | clean | clean | clean (regression net, unchanged) |
| unread parameter (negative control) | TS6133 | TS6133 | TS6133 (unchanged) |
| parameter shadowed by a same-named type (negative control) | TS6133 | TS6133 | TS6133 (unchanged) |

## What's still open

`Wrap[(typeof a)]` (parenthesized) takes a **third** code path — traced live through the dev CLI (`TSZ_LOG`, JSON format): neither shortcut above is ever entered for it (zero hits on both, instrumented and confirmed with temporary tracing that was removed before this diff — `git diff --stat` on the final commit touches only the three files listed below). Left `#[ignore]`d with the tracing evidence in the test module, and filed as #16704 with a concrete next probe (instrument `tsz_lowering::TypeLowering`'s own `PARENTHESIZED_TYPE` handling, a different crate, rather than continuing to look in `tsz-checker`).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib unused_typeof_type_query_reference` — **14 passed, 0 failed, 1 ignored** (the ignored parenthesized case, filed as #16704).
- `cargo test -p tsz-checker --lib -- typeof generic_alias type_reference signature_scope type_argument` — **338 passed, 0 failed, 1 ignored**.
- `cargo test -p tsz-checker --lib -- unused typeof_ type_query` — **240 passed, 0 failed, 1 ignored**.
- `cargo fmt -p tsz-checker -- --check` — clean.
- `cargo clippy --profile ci-lint -p tsz-checker --lib -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py` — passed.
- Pre-commit hook (fmt + clippy + arch-size + local verification) passed.
- Conformance/emit/fourslash not run locally this session (checker-only change, additive reference-marking with no new diagnostic paths); relying on the nightly gates. The corpus witness for the base issue is `compiler/unusedParameterUsedInTypeOf.ts`.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude