### PR TITLE
fix(checker): reland #16660 without leaking diagnostics from the for-in TS2405/TS2780 precedence probe

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -499,6 +499,9 @@ mod for_in_narrowing_tests;
 #[path = "../tests/for_in_operand_type_display_tests.rs"]
 mod for_in_operand_type_display_tests;
 #[cfg(test)]
+#[path = "../tests/for_in_optional_chain_ts2405_vs_ts2780_tests.rs"]
+mod for_in_optional_chain_ts2405_vs_ts2780_tests;
+#[cfg(test)]
 #[path = "../tests/for_in_self_reference_and_nullable_operand_tests.rs"]
 mod for_in_self_reference_and_nullable_operand_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/variable_checking/for_loop.rs
+++ b/crates/tsz-checker/src/state/variable_checking/for_loop.rs
@@ -756,23 +756,23 @@ impl<'a> CheckerState<'a> {
             );
         }
 
-        // TS2780/TS2781: The left-hand side of a 'for...in'/'for...of' statement
-        // may not be an optional property access.
-        if self.is_optional_chain_access(initializer) {
+        // TS2781: The left-hand side of a 'for...of' statement may not be an
+        // optional property access. tsc's checkForOfStatement calls
+        // checkReferenceExpression (the source of TS2781) unconditionally.
+        //
+        // 'for...in' is NOT unconditional this way: tsc's checkForInStatement
+        // only calls checkReferenceExpression (source of TS2780) in the `else`
+        // branch of `if !isTypeAssignableTo(indexType, leftType) { TS2405 }
+        // else { checkReferenceExpression(...) }` — TS2405 wins whenever it
+        // fires. See the TS2405 block below, which owns for-in's TS2780
+        // emission for optional-chain heads once the type check passes.
+        if is_for_of && self.is_optional_chain_access(initializer) {
             use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-            if is_for_of {
-                self.error_at_node(
-                    initializer,
-                    diagnostic_messages::THE_LEFT_HAND_SIDE_OF_A_FOR_OF_STATEMENT_MAY_NOT_BE_AN_OPTIONAL_PROPERTY_ACCESS,
-                    diagnostic_codes::THE_LEFT_HAND_SIDE_OF_A_FOR_OF_STATEMENT_MAY_NOT_BE_AN_OPTIONAL_PROPERTY_ACCESS,
-                );
-            } else {
-                self.error_at_node(
-                    initializer,
-                    diagnostic_messages::THE_LEFT_HAND_SIDE_OF_A_FOR_IN_STATEMENT_MAY_NOT_BE_AN_OPTIONAL_PROPERTY_ACCESS,
-                    diagnostic_codes::THE_LEFT_HAND_SIDE_OF_A_FOR_IN_STATEMENT_MAY_NOT_BE_AN_OPTIONAL_PROPERTY_ACCESS,
-                );
-            }
+            self.error_at_node(
+                initializer,
+                diagnostic_messages::THE_LEFT_HAND_SIDE_OF_A_FOR_OF_STATEMENT_MAY_NOT_BE_AN_OPTIONAL_PROPERTY_ACCESS,
+                diagnostic_codes::THE_LEFT_HAND_SIDE_OF_A_FOR_OF_STATEMENT_MAY_NOT_BE_AN_OPTIONAL_PROPERTY_ACCESS,
+            );
         }
 
         // TS2487: For-of LHS must be a variable or a property access.
@@ -860,11 +860,15 @@ impl<'a> CheckerState<'a> {
         }
 
         // TS2405: For for-in, also check that the LHS type is string or any.
-        // This applies only to valid LHS forms (identifiers and property/element access).
-        // Skip if we already emitted TS2491 (destructuring) or TS2406 (invalid form).
-        // Also skip for optional chain accesses — TS2777 already covers those.
+        // This applies only to valid LHS forms (identifiers and property/element
+        // access, including optional chains). Skip if we already emitted TS2491
+        // (destructuring) or TS2406 (invalid form).
+        //
+        // TS2780: Only once the TS2405 check passes does an optional-chain LHS
+        // get its own TS2780 ("may not be an optional property access") — tsc's
+        // checkForInStatement calls checkReferenceExpression (the source of
+        // TS2780) only in the `else` branch of the type-assignability check.
         if !is_for_of
-            && !self.is_optional_chain_access(initializer)
             && let Some(_init_node) = self.ctx.arena.get(initializer)
             && {
                 let unwrapped = self
@@ -880,7 +884,22 @@ impl<'a> CheckerState<'a> {
             }
         {
             use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-            let var_type = self.get_type_of_assignment_target(initializer);
+            let is_optional_chain = self.is_optional_chain_access(initializer);
+            // The precedence decision needs the head's real type, computed the
+            // way tsc's checkExpression computes it for `leftType` — a plain
+            // read, not the assignment-target/write-target path (which
+            // short-circuits optional chains to `any` for real writes and has
+            // its own nullish-receiver diagnostic). Speculative because this
+            // is a probe for a precedence decision, not a checked position:
+            // any diagnostic the read itself would raise along the chain is
+            // not this check's diagnostic to emit — the real read at the end
+            // of this function (which does NOT short-circuit for for-in) owns
+            // that.
+            let var_type = if is_optional_chain {
+                self.speculative_type_of_node(initializer, &TypingRequest::NONE)
+            } else {
+                self.get_type_of_assignment_target(initializer)
+            };
             // The LHS type must accept the for-in element type. TSC checks
             // `isTypeAssignableTo(indexType, variableType)` where indexType
             // comes from the source expression's key type (keyof T & string
@@ -898,6 +917,12 @@ impl<'a> CheckerState<'a> {
                     initializer,
                     diagnostic_messages::THE_LEFT_HAND_SIDE_OF_A_FOR_IN_STATEMENT_MUST_BE_OF_TYPE_STRING_OR_ANY,
                     diagnostic_codes::THE_LEFT_HAND_SIDE_OF_A_FOR_IN_STATEMENT_MUST_BE_OF_TYPE_STRING_OR_ANY,
+                );
+            } else if is_optional_chain {
+                self.error_at_node(
+                    initializer,
+                    diagnostic_messages::THE_LEFT_HAND_SIDE_OF_A_FOR_IN_STATEMENT_MAY_NOT_BE_AN_OPTIONAL_PROPERTY_ACCESS,
+                    diagnostic_codes::THE_LEFT_HAND_SIDE_OF_A_FOR_IN_STATEMENT_MAY_NOT_BE_AN_OPTIONAL_PROPERTY_ACCESS,
                 );
             }
         }

--- a/crates/tsz-checker/tests/for_in_optional_chain_ts2405_vs_ts2780_tests.rs
+++ b/crates/tsz-checker/tests/for_in_optional_chain_ts2405_vs_ts2780_tests.rs
@@ -1,0 +1,210 @@
+//! Structural rule: `tsc`'s `checkForInStatement` computes the LHS expression's
+//! real type FIRST and only calls `checkReferenceExpression` (the source of
+//! TS2780, "may not be an optional property access") when that type passes the
+//! `isTypeAssignableTo(indexType, leftType)` check (TS2405, "must be of type
+//! 'string' or 'any'") — see typescript-go's `checker.go`:
+//!
+//! ```go
+//! } else if !c.isTypeAssignableTo(c.getIndexTypeOrString(rightType), leftType) {
+//!     c.error(varExpr, diagnostics.The_left_hand_side_of_a_for_in_statement_must_be_of_type_string_or_any)
+//! } else {
+//!     c.checkReferenceExpression(varExpr, ..., diagnostics.The_left_hand_side_of_a_for_in_statement_may_not_be_an_optional_property_access)
+//! }
+//! ```
+//!
+//! So TS2405 and TS2780 are mutually exclusive for a `for...in` head: TS2405
+//! wins whenever it fires, and TS2780 only fires once the LHS type already
+//! passed. `for...of`'s analogous TS2781 check is NOT gated this way — tsc's
+//! `checkForOfStatement` calls `checkReferenceExpression` unconditionally — so
+//! that family is a regression guard here, not something this fix changes.
+//!
+//! The precedence decision computes the head's type as a plain read (matching
+//! tsc's `checkExpression`), not through the assignment-target/write-target
+//! path — that path short-circuits an optional-chain receiver to `any` for a
+//! genuine write and carries its own nullish-receiver diagnostic, neither of
+//! which belongs to this probe. The read is speculative: any diagnostic the
+//! type computation itself would raise along the chain (e.g. on a receiver
+//! whose own type is `any`, or on a non-optional continuation past an
+//! optional link) is not this check's diagnostic to emit — the unconditional
+//! real read later in `check_for_in_of_expression_initializer` owns that.
+//!
+//! All diagnostics oracle-verified against the pinned `typescript@7.0.2`
+//! (`--noEmit --strict --lib es2022 --target es2022`). Binder names vary
+//! across cases per the repo's anti-hardcoding discipline.
+
+use crate::test_utils::check_source_strict_codes;
+
+// =========================================================================
+// TS2405 wins: the optional-chain LHS's real type is not string/any.
+// =========================================================================
+
+#[test]
+fn for_in_optional_receiver_required_member_number_leaf_emits_only_ts2405() {
+    // `b` is optional, `c` is required: the chain's real type is
+    // `number | undefined`, not assignable to `string | any` — TS2405, no TS2780.
+    let codes = check_source_strict_codes(
+        "declare const outer: { mid?: { inner: { leaf: number } } };\nfor (outer.mid?.inner.leaf in {}) {}\n",
+    );
+    assert!(
+        codes.contains(&2405),
+        "possibly-undefined non-string LHS must emit TS2405; got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2780),
+        "TS2405 must suppress TS2780 for a for-in optional-chain head; got: {codes:?}"
+    );
+}
+
+#[test]
+fn for_in_top_level_optional_access_number_typed_emits_only_ts2405() {
+    let codes = check_source_strict_codes(
+        "declare const rec: { count?: number };\nfor (rec?.count in {}) {}\n",
+    );
+    assert!(codes.contains(&2405), "expected TS2405; got: {codes:?}");
+    assert!(!codes.contains(&2780), "expected no TS2780; got: {codes:?}");
+}
+
+// =========================================================================
+// TS2780 wins: the optional-chain LHS's real type IS string/any, so the
+// reference-validity check runs and reports the chain itself.
+// =========================================================================
+
+#[test]
+fn for_in_optional_receiver_string_leaf_emits_only_ts2780() {
+    let codes = check_source_strict_codes(
+        "declare const holder: { maybe?: { text: string } };\nfor (holder.maybe?.text in {}) {}\n",
+    );
+    assert!(
+        codes.contains(&2780),
+        "string-typed optional-chain LHS must emit TS2780; got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2405),
+        "a string-typed LHS passes the TS2405 check; got: {codes:?}"
+    );
+}
+
+#[test]
+fn for_in_top_level_optional_access_string_typed_emits_only_ts2780() {
+    let codes = check_source_strict_codes(
+        "declare const bag: { label?: string };\nfor (bag?.label in {}) {}\n",
+    );
+    assert!(codes.contains(&2780), "expected TS2780; got: {codes:?}");
+    assert!(!codes.contains(&2405), "expected no TS2405; got: {codes:?}");
+}
+
+#[test]
+fn for_in_any_typed_optional_chain_receiver_emits_only_ts2780() {
+    // Regression guard for the exact shape that broke the first reland
+    // attempt (#16660/#16667): a receiver typed `any` (`declare const obj:
+    // any;`) makes every link of the chain `any`, so the precedence probe
+    // must not synthesize a TS2339/TS7053 anywhere along the chain — it must
+    // see `any`, pass the TS2405 check, and land on TS2780 alone.
+    let codes = check_source_strict_codes("declare const obj: any;\nfor (obj?.a in {}) {}\n");
+    assert!(codes.contains(&2780), "expected TS2780; got: {codes:?}");
+    assert!(!codes.contains(&2405), "expected no TS2405; got: {codes:?}");
+    assert!(
+        !codes.contains(&2339) && !codes.contains(&7053),
+        "an `any`-typed receiver must not leak property-lookup diagnostics \
+         from the precedence probe; got: {codes:?}"
+    );
+}
+
+#[test]
+fn for_in_any_typed_optional_chain_with_trailing_access_emits_only_ts2780() {
+    let codes = check_source_strict_codes("declare const obj: any;\nfor (obj?.a.b in {}) {}\n");
+    assert!(codes.contains(&2780), "expected TS2780; got: {codes:?}");
+    assert!(!codes.contains(&2405), "expected no TS2405; got: {codes:?}");
+    assert!(
+        !codes.contains(&2339) && !codes.contains(&7053),
+        "an `any`-typed receiver must not leak property-lookup diagnostics \
+         from the precedence probe; got: {codes:?}"
+    );
+}
+
+#[test]
+fn for_in_any_typed_optional_chain_element_access_emits_only_ts2780() {
+    let codes = check_source_strict_codes("declare const obj: any;\nfor (obj?.[\"a\"] in {}) {}\n");
+    assert!(codes.contains(&2780), "expected TS2780; got: {codes:?}");
+    assert!(!codes.contains(&2405), "expected no TS2405; got: {codes:?}");
+    assert!(
+        !codes.contains(&2339) && !codes.contains(&7053),
+        "an `any`-typed receiver must not leak property-lookup diagnostics \
+         from the precedence probe; got: {codes:?}"
+    );
+}
+
+// =========================================================================
+// Regression guards: unaffected shapes.
+// =========================================================================
+
+#[test]
+fn for_in_non_optional_property_access_string_leaf_reports_neither() {
+    let codes = check_source_strict_codes(
+        "declare const plain: { nested: { name: string } };\nfor (plain.nested.name in {}) {}\n",
+    );
+    assert!(
+        !codes.contains(&2405) && !codes.contains(&2780),
+        "a non-optional string-typed LHS is valid; got: {codes:?}"
+    );
+}
+
+#[test]
+fn for_in_non_optional_property_access_number_leaf_emits_only_ts2405() {
+    // No optional chain at all: TS2405 alone must still fire for a non-string type.
+    let codes = check_source_strict_codes(
+        "declare const box: { field: { count: number } };\nfor (box.field.count in {}) {}\n",
+    );
+    assert!(codes.contains(&2405), "expected TS2405; got: {codes:?}");
+    assert!(!codes.contains(&2780), "expected no TS2780; got: {codes:?}");
+}
+
+#[test]
+fn for_of_optional_chain_still_emits_ts2781_unconditionally() {
+    // for...of's analogous check is NOT gated behind an assignability check —
+    // tsc reports TS2781 regardless of the chain's element type. This fix only
+    // changes for...in's ordering, so for...of keeps its prior behavior.
+    let codes = check_source_strict_codes(
+        "declare const outer: { mid?: { inner: { leaf: number } } };\nfor (outer.mid?.inner.leaf of []) {}\n",
+    );
+    assert!(
+        codes.contains(&2781),
+        "for-of optional-chain LHS must still emit TS2781; got: {codes:?}"
+    );
+}
+
+#[test]
+fn for_of_any_typed_optional_chain_still_emits_ts2781_only() {
+    let codes = check_source_strict_codes("declare const obj: any;\nfor (obj?.a of []) {}\n");
+    assert!(
+        codes.contains(&2781),
+        "for-of optional-chain LHS must still emit TS2781; got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2339) && !codes.contains(&7053),
+        "for-of's unconditional check must not leak property-lookup \
+         diagnostics either; got: {codes:?}"
+    );
+}
+
+#[test]
+fn plain_optional_chain_assignment_target_still_emits_ts2779() {
+    // Regression guard for the write-target family (`=`), which is unrelated
+    // to for-in/for-of and must keep short-circuiting to `any` unconditionally.
+    let codes = check_source_strict_codes(
+        "declare const holder: { maybe?: { text: string } };\nholder.maybe?.text = \"x\";\n",
+    );
+    assert!(
+        codes.contains(&2779),
+        "plain optional-chain assignment target must still emit TS2779; got: {codes:?}"
+    );
+}
+
+#[test]
+fn renamed_binders_do_not_change_the_outcome() {
+    let codes = check_source_strict_codes(
+        "declare const zq: { al?: { be: { ga: number } } };\nfor (zq.al?.be.ga in {}) {}\n",
+    );
+    assert!(codes.contains(&2405), "expected TS2405; got: {codes:?}");
+    assert!(!codes.contains(&2780), "expected no TS2780; got: {codes:?}");
+}


### PR DESCRIPTION
Fixes #16668. Relands #16660 (reverted in #16667) without the diagnostic leak.

**Structural rule.** `for (a.b?.c.d in {})` should report **TS2405** ("The left-hand side of a 'for...in' statement must be of type 'string' or 'any'") when the head's type is not `string`/`any`; tsc picks the type diagnostic over the optional-chain grammar one (**TS2780**). tsc's `checkForInStatement` computes the LHS expression's real type first and only calls `checkReferenceExpression` (the source of TS2780) in the `else` branch of `if !isTypeAssignableTo(indexType, leftType) { TS2405 } else { checkReferenceExpression(...) }` — TS2405 wins whenever it fires. `for...of`'s analogous TS2781 check is *not* gated this way; tsc calls `checkReferenceExpression` unconditionally there, so that family is unchanged.

**Why #16660 leaked and this reland doesn't.** #16660 computed the precedence-decision type via `get_type_of_assignment_target` — the assignment-target/write-target path. For an optional-chain head, that path is normally short-circuited to `any` by `optional_chain_invalid_assignment_target_context` in `invalid_target.rs` (which also reports its own nullish-receiver diagnostic when relevant) — but #16660 had to remove for-in from that short-circuit so the real type could be computed, and that turned on the write-target property-resolution machinery for real on a shape (for-in optional-chain heads) it had never run against before. That machinery's own diagnostics leaked into the precedence probe, regressing `propertyAccessChain.3.ts`/`elementAccessChain.3.ts` (`obj: any`, `for (obj?.a in {})`) with spurious `TS2339`/`TS2405`/`TS7053`.

This reland leaves `invalid_target.rs`'s short-circuit **untouched** for both for-in and for-of — the real (non-speculative) assignment-target computation later in `check_for_in_of_expression_initializer` still short-circuits an optional-chain for-in head to `any`, exactly as on `main` today. The precedence decision itself now computes the head's type as a **plain read** (`speculative_type_of_node` with a `TypingRequest::NONE`/read request) — matching what tsc's `checkExpression` actually computes for `leftType` — wrapped in a diagnostic-speculation snapshot so the probe's own diagnostics can never leak, regardless of what the chain's real type turns out to be. Owner layer: checker (`crates/tsz-checker/src/state/variable_checking/for_loop.rs`); no solver change.

**Adjacent-case matrix** (`crates/tsz-checker/tests/for_in_optional_chain_ts2405_vs_ts2780_tests.rs`, 13 tests — includes the reverted PR's original 8 plus 5 new ones targeting the exact regression shape):

| shape | tsc | main (before) | this PR |
| --- | --- | --- | --- |
| `for (outer.mid?.inner.leaf in {})` — possibly-undefined number leaf | TS2405 | TS2780 | **TS2405** |
| `for (holder.maybe?.text in {})` — possibly-undefined string leaf | TS2780 | TS2780 | **TS2780** (unchanged) |
| `declare const obj: any; for (obj?.a in {})` | TS2780, no TS2339/TS2405/TS7053 | TS2780 | **TS2780, no leak** (the exact conformance regression shape) |
| `declare const obj: any; for (obj?.a.b in {})` | TS2780, no leak | TS2780 | **TS2780, no leak** |
| `declare const obj: any; for (obj?.["a"] in {})` | TS2780, no leak | TS2780 | **TS2780, no leak** |
| `for (box.field.count in {})` — plain, non-optional, number | TS2405 | TS2405 | TS2405 (unchanged) |
| `for (outer.mid?.inner.leaf of [])` | TS2781 | TS2781 | TS2781 (unchanged — for-of is unconditional) |
| `holder.maybe?.text = "x"` | TS2779 | TS2779 | TS2779 (unchanged — plain write-target family) |
| renamed binders (`zq.al?.be.ga`) | TS2405 | TS2780 | **TS2405** |

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib -- for_in_optional_chain_ts2405_vs_ts2780` — **13 passed, 0 failed** (new adjacent-case matrix, including the `obj: any` regression-guard shapes matching the two conformance fixtures that broke #16660).
- `cargo test -p tsz-checker --lib -- for_in for_of optional_chain` — **272 passed, 0 failed** (includes the `for_in_lhs_relation_routing_arch_tests` architecture guard and the pre-existing `optional_chain_write_target_nullish_tests` suite covering the untouched `invalid_target.rs` short-circuit).
- `cargo clippy -p tsz-checker --lib --all-features` — clean.
- `cargo fmt -p tsz-checker -- --check` — clean.
- Pinned-oracle cache cross-check: `scripts/conformance/tsc-cache-full.json` confirms the expected `error_codes` for both regressing fixtures (`propertyAccessChain.3.ts`, `elementAccessChain.3.ts`) are exactly `[2777, 2778, 2779, 2780, 2781]` — the new `for_in_any_typed_optional_chain_*` tests reproduce their `declare const obj: any` for-in lines directly and assert no `TS2339`/`TS7053` leak.
- Owed: `cargo test -p tsz-checker --lib` (full suite, ~10.4k tests) was running in the background at PR-open time; will report the count in a follow-up comment. Two-sided `compare-to-parent.sh` corpus set-difference not run this session (measured 55-90+ min on prior cloud sessions per the board) — this is a checker-only diagnostic-precedence fix scoped to for-in optional-chain heads, and the targeted matrix above is oracle-verified against the pinned `typescript@7.0.2` cache, but the full set-difference is still owed before merge per the issue's acceptance criteria ("verified by set-difference, not by failing count").

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJwNAp5erahJQrF6iPAnqn)_