### PR TITLE
fix(checker): a global-augmentation namespace export= cycle reports TS2303 at both sites

### DIFF
--- a/crates/tsz-checker/src/declarations/import/core/module_exports.rs
+++ b/crates/tsz-checker/src/declarations/import/core/module_exports.rs
@@ -234,12 +234,25 @@ impl<'a> CheckerState<'a> {
                                     ident.escaped_text.as_str(),
                                 )
                         {
+                            // tsc reports TS2303 at EVERY alias declaration
+                            // participating in the cycle (module_checker.rs'
+                            // check_circular_import_aliases documents the
+                            // same rule for the general case): both the
+                            // `export = X` statement itself and the
+                            // `export as namespace X` that closes the loop
+                            // back to the `declare global` namespace X.
+                            let message = format_message(
+                                diagnostic_messages::CIRCULAR_DEFINITION_OF_IMPORT_ALIAS,
+                                &[ident.escaped_text.as_str()],
+                            );
+                            self.error_at_node(
+                                stmt_idx,
+                                &message,
+                                diagnostic_codes::CIRCULAR_DEFINITION_OF_IMPORT_ALIAS,
+                            );
                             self.error_at_node(
                                 report_node,
-                                &format_message(
-                                    diagnostic_messages::CIRCULAR_DEFINITION_OF_IMPORT_ALIAS,
-                                    &[ident.escaped_text.as_str()],
-                                ),
+                                &message,
                                 diagnostic_codes::CIRCULAR_DEFINITION_OF_IMPORT_ALIAS,
                             );
                         } else if let Some(expected_type) =

--- a/crates/tsz-checker/tests/ts2303_tests.rs
+++ b/crates/tsz-checker/tests/ts2303_tests.rs
@@ -222,6 +222,58 @@ declare module "moduleC" {
     );
 }
 
+/// tsc reports `TS2303` once at EVERY alias declaration participating in a
+/// cycle (the general rule `check_circular_import_aliases` in
+/// `module_checker.rs` already documents), not once for the whole cycle. For
+/// `declare global { namespace N {} } export = N; export as namespace N;`
+/// that means two sites — the `export = N` assignment AND the
+/// `export as namespace N` declaration that closes the loop back to the
+/// global augmentation's `N` — confirmed against the pinned `typescript@7.0.2`
+/// oracle (`a.d.ts(2,1)` and `a.d.ts(3,1)`, both `Circular definition of
+/// import alias 'N'.`).
+fn assert_global_augmentation_cycle_sites(source: &str, file_name: &str, ident: &str) {
+    let diagnostics = get_diagnostics_positioned(source, file_name);
+    let ts2303: Vec<_> = diagnostics
+        .iter()
+        .filter(|(code, _, _)| *code == 2303)
+        .collect();
+
+    let export_equals_site = u32::try_from(
+        source
+            .find(&format!("export = {ident}"))
+            .expect("export= site"),
+    )
+    .unwrap();
+    let export_as_namespace_site = u32::try_from(
+        source
+            .find(&format!("export as namespace {ident}"))
+            .expect("export as namespace site"),
+    )
+    .unwrap();
+
+    assert!(
+        ts2303
+            .iter()
+            .any(|(_, start, _)| *start == export_equals_site),
+        "Expected TS2303 at the `export = {ident}` statement. Got: {ts2303:#?}"
+    );
+    assert!(
+        ts2303
+            .iter()
+            .any(|(_, start, _)| *start == export_as_namespace_site),
+        "Expected TS2303 at the `export as namespace {ident}` statement. Got: {ts2303:#?}"
+    );
+    assert_eq!(
+        ts2303.len(),
+        2,
+        "Expected exactly the two cycle sites, no more. Got: {ts2303:#?}"
+    );
+    assert!(
+        diagnostics.iter().all(|(code, _, _)| *code != 2686),
+        "Did not expect TS2686 for the export= cycle case. Got: {diagnostics:#?}"
+    );
+}
+
 #[test]
 fn export_equals_global_augmentation_namespace_cycle_reports_ts2303_not_ts2686() {
     let source = r#"
@@ -229,15 +281,45 @@ declare global { namespace N {} }
 export = N;
 export as namespace N;
 "#;
+    assert_global_augmentation_cycle_sites(source, "a.d.ts", "N");
+}
 
-    let diagnostics = get_diagnostics(source, "a.d.ts");
+#[test]
+fn export_equals_global_augmentation_namespace_cycle_is_order_independent() {
+    // Same cycle, `export as namespace` written before `export =` — the scan
+    // is over all of the file's statements, not a fixed sequence, and a
+    // renamed binder (`M`, not `N`) so the fix cannot be keyed off the name.
+    let source = r#"
+declare global { namespace M {} }
+export as namespace M;
+export = M;
+"#;
+    assert_global_augmentation_cycle_sites(source, "swapped.d.ts", "M");
+}
+
+#[test]
+fn export_equals_global_augmentation_namespace_cycle_renamed_binder() {
+    let source = r#"
+declare global { namespace Widget {} }
+export = Widget;
+export as namespace Widget;
+"#;
+    assert_global_augmentation_cycle_sites(source, "renamed.d.ts", "Widget");
+}
+
+#[test]
+fn export_equals_without_matching_umd_export_is_not_circular() {
+    // `export = N` alone, with no `export as namespace N` to close the loop,
+    // is not a cycle — the global augmentation's `N` is a genuine value
+    // target, not an alias back to itself.
+    let source = r#"
+declare global { namespace N {} }
+export = N;
+"#;
+    let diagnostics = get_diagnostics(source, "no-umd.d.ts");
     assert!(
-        diagnostics.iter().any(|(code, _)| *code == 2303),
-        "Expected TS2303 for export= cycle through global augmentation namespace. Got: {diagnostics:?}"
-    );
-    assert!(
-        diagnostics.iter().all(|(code, _)| *code != 2686),
-        "Did not expect TS2686 for the export= cycle case. Got: {diagnostics:?}"
+        diagnostics.iter().all(|(code, _)| *code != 2303),
+        "Did not expect TS2303 without a matching `export as namespace`. Got: {diagnostics:?}"
     );
 }
 


### PR DESCRIPTION
Fixes `compiler/exportAsNamespaceConflict.ts`'s missing `TS2303` site (part of the committed conformance false-negative queue).

**Structural rule.** When a file has `declare global { namespace X {} }` plus `export = X` plus `export as namespace X`, `X` closes a cycle: the UMD export re-exports the file's own surface, which resolves `X` back to itself through the global augmentation. `tsc` reports `TS2303` ("Circular definition of import alias 'X'") **at every alias declaration participating in the cycle** — the `export = X` assignment and the `export as namespace X` declaration both get their own report. tsz has a dedicated detector for exactly this shape, `global_augmentation_namespace_export_cycle_report_node` in `crates/tsz-checker/src/declarations/import/core/helpers.rs`, but its only call site (`check_export_assignment` in `module_exports.rs`) reported solely at the helper's returned `report_node` (the `export as namespace X` statement), leaving the `export = X` statement — `stmt_idx`, already in scope in the same loop — unreported.

**Why the general cycle walker doesn't cover this.** `module_checker.rs`'s `check_circular_import_aliases` is the general TS2303 detector and already documents "report at every alias declaration in the cycle," but it explicitly excludes `is_umd_export` symbols from its `local_alias_ids` collection (`!s.is_umd_export`), so a UMD `export as namespace` alias never starts (or is reached by) that walk. This global-augmentation shape needed its own syntactic detector because `export = X` never becomes a declaration of `X`'s own symbol (the binder records `"export="` as a second key in `file_locals`, not a new declaration) — the same reason the general walker's own `export_equals_sites_for_cyclic_alias` companion-scan exists.

**Fix.** `crates/tsz-checker/src/declarations/import/core/module_exports.rs`'s `check_export_assignment`: when the helper finds the cycle, emit `TS2303` at both `stmt_idx` (the `export = X` statement) and `report_node` (the `export as namespace X` statement) instead of only the latter.

**Owner layer.** Checker (`declarations/import/core/module_exports.rs`), the existing owner of this detector — no solver/binder change needed; the binder's alias-symbol model (`export=` as a `file_locals` key, not a declaration) was already correctly understood by the surrounding code, this call site just didn't use the node it already had.

**Adjacent-case matrix** (`crates/tsz-checker/tests/ts2303_tests.rs`, all oracle-confirmed against pinned `typescript@7.0.2`):

| case | tsc | before | after |
| --- | --- | --- | --- |
| `declare global{namespace N{}} export=N; export as namespace N;` | 2 sites (`export=`, `export as namespace`) | 1 (`export as namespace` only) | **2** |
| same, `export as namespace` written *before* `export=` | 2 sites | — | **2** (order-independent) |
| renamed binder (`Widget` instead of `N`) | 2 sites | — | **2** (not name-keyed) |
| `export=N` with **no** matching `export as namespace N` | clean | clean | clean (unaffected — no cycle without the UMD export) |
| `export=React; export as namespace React;` with plain `declare namespace React` (no `declare global`) | clean | clean | clean (unaffected — different shape, existing test) |

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts2303_tests` — 14/14 pass (1 updated to assert both sites + offsets instead of "any", 3 new adjacent cases added).
- `cargo test -p tsz-checker --lib -- ts2303 export_assignment global_augmentation umd export_equals circular_import namespace_export` — 79/79 pass, 0 failed (blast-radius net around the touched call site and its neighbors).
- `cargo test -p tsz-checker --lib -- ts2686` — 1/1 pass (the sibling detector this cycle-check must not misfire into stays clean).
- Binary-level check with the rebuilt debug `tsz` CLI against the actual conformance fixture (`declare global { namespace N {} } export = N; export as namespace N;`): before `a.d.ts(3,1)` only; after `a.d.ts(2,1)` **and** `a.d.ts(3,1)`, both byte-identical to the pinned `typescript@7.0.2` oracle's fingerprints (`{code:2303, file:"a.d.ts", line:2, col:1}` / `{line:3, col:1}` from `scripts/conformance/tsc-cache-full.json`).
- All 5 adjacent-matrix fixtures cross-checked directly against the pinned oracle binary (`node .../typescript/bin/tsc`) — exact match on every row, including the two negative controls staying clean.
- `cargo fmt --check -p tsz-checker` and `cargo clippy -p tsz-checker --all-targets --all-features -- -D warnings` — clean.
- Pre-commit hook (clippy + architecture guard + local verification on `-p tsz-checker`) — passed.
- Scope: the change only fires inside the one call site gated by `global_augmentation_namespace_export_cycle_report_node`, which requires the exact `declare global` + `export=` + `export as namespace` shape with matching names — it cannot affect any other TS2303 row or diagnostic family. Full `conformance.sh`/`compare-to-parent.sh` not run this session (owed); the change is diagnostic-additive-only within a single guarded branch, so risk of an unrelated regression is low.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude


---
_Generated by [Claude Code](https://claude.ai/code/session_01LaJiwUMHpo5e98jwsszxkJ)_