### PR TITLE
fix(checker): cross-file TS2433 reads the wrong binder and skips the ambient carve-out

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2715,3 +2715,6 @@ path = "tests/symbol_key_nested_literal_excess_property_tests.rs"
 [[test]]
 name = "symbol_index_nested_literal_drill_in_ts2353_tests"
 path = "tests/symbol_index_nested_literal_drill_in_ts2353_tests.rs"
+[[test]]
+name = "ts2433_cross_file_ambient_class_merge_tests"
+path = "tests/ts2433_cross_file_ambient_class_merge_tests.rs"

--- a/crates/tsz-checker/src/declarations/declarations_module.rs
+++ b/crates/tsz-checker/src/declarations/declarations_module.rs
@@ -1139,6 +1139,46 @@ impl<'a, 'ctx> DeclarationChecker<'a, 'ctx> {
             .map(|sym_id| (sym_id, file_idx))
     }
 
+    /// Whether every class/function declaration of `sym` found in the binder at
+    /// `binder_idx` is ambient (`declare class` / `declare function`) or a bodyless
+    /// function overload signature. Mirrors the same-file carve-out this check already
+    /// grants (a `declare class`/`declare function` merge is not an error, only a
+    /// non-ambient one is) — the cross-file candidate search skipped that carve-out
+    /// entirely, so a namespace merged across files with only an ambient class/function
+    /// falsely reported TS2433. `NodeArena::is_in_ambient_context` reads the node's own
+    /// `declare` modifier/AMBIENT flag, so it is correct against the *other* file's arena
+    /// without needing that file's name.
+    fn cross_file_class_or_function_all_ambient(
+        &self,
+        binder_idx: usize,
+        sym: &tsz_binder::Symbol,
+    ) -> bool {
+        let arena = self.ctx.get_arena_for_file(binder_idx as u32);
+        let mut found_any = false;
+        for &decl_idx in &sym.declarations {
+            let Some(decl_node) = arena.get(decl_idx) else {
+                continue;
+            };
+            let is_class = decl_node.kind == syntax_kind_ext::CLASS_DECLARATION;
+            let is_function = decl_node.kind == syntax_kind_ext::FUNCTION_DECLARATION;
+            if !is_class && !is_function {
+                continue;
+            }
+            found_any = true;
+            if arena.is_in_ambient_context(decl_idx) {
+                continue;
+            }
+            if is_function
+                && let Some(func) = arena.get_function(decl_node)
+                && func.body.is_none()
+            {
+                continue;
+            }
+            return false;
+        }
+        found_any
+    }
+
     /// Check TS2433/TS2434: Namespace merging with class/function across files or out of order.
     ///
     /// TS2433: A namespace declaration cannot be in a different file from a class or function
@@ -1242,20 +1282,33 @@ impl<'a, 'ctx> DeclarationChecker<'a, 'ctx> {
                     };
 
                 for (binder_idx, found_sym_id) in candidates {
-                    let _ = binder_idx; // used in nested path
+                    // `found_sym_id` was found in the *other* file's `file_locals`/`exports`
+                    // map, so it must be resolved against that file's own binder
+                    // (`all_binders[binder_idx]`) — `self.ctx.binder` is always the
+                    // *current* file's binder, and a raw `SymbolId` is only meaningful
+                    // within the binder that minted it.
+                    let Some(other_binder) = all_binders.get(binder_idx) else {
+                        continue;
+                    };
 
                     // For top-level namespaces (no enclosing names), check file_locals
                     if enclosing_names.is_empty() {
                         let other_sym_id = found_sym_id;
                         if other_sym_id != sym_id
-                            && let Some(other_symbol) = self.ctx.binder.get_symbol(other_sym_id)
+                            && let Some(other_symbol) = other_binder.get_symbol(other_sym_id)
                         {
                             let is_class =
                                 (other_symbol.flags & tsz_binder::symbol_flags::CLASS) != 0;
                             let is_function =
                                 (other_symbol.flags & tsz_binder::symbol_flags::FUNCTION) != 0;
 
-                            if (is_class || is_function) && !other_symbol.declarations.is_empty() {
+                            if (is_class || is_function)
+                                && !other_symbol.declarations.is_empty()
+                                && !self.cross_file_class_or_function_all_ambient(
+                                    binder_idx,
+                                    other_symbol,
+                                )
+                            {
                                 if let Some(name_node) = self.ctx.arena.get(module.name) {
                                     self.ctx.error(
                                         name_node.pos,
@@ -1279,7 +1332,7 @@ impl<'a, 'ctx> DeclarationChecker<'a, 'ctx> {
                     let mut current_sym_id = root_sym_id;
                     let mut found = true;
                     for intermediate_name in &enclosing_names[1..] {
-                        if let Some(sym) = self.ctx.binder.get_symbol(current_sym_id)
+                        if let Some(sym) = other_binder.get_symbol(current_sym_id)
                             && let Some(exports) = &sym.exports
                             && let Some(next_id) = exports.get(intermediate_name.as_str())
                         {
@@ -1295,17 +1348,21 @@ impl<'a, 'ctx> DeclarationChecker<'a, 'ctx> {
                     }
 
                     // Now look for the target name in the innermost container's exports
-                    if let Some(container_sym) = self.ctx.binder.get_symbol(current_sym_id)
+                    if let Some(container_sym) = other_binder.get_symbol(current_sym_id)
                         && let Some(exports) = &container_sym.exports
                         && let Some(target_sym_id) = exports.get(namespace_name.as_str())
                         && target_sym_id != sym_id
-                        && let Some(target_sym) = self.ctx.binder.get_symbol(target_sym_id)
+                        && let Some(target_sym) = other_binder.get_symbol(target_sym_id)
                     {
                         let is_class = (target_sym.flags & tsz_binder::symbol_flags::CLASS) != 0;
                         let is_function =
                             (target_sym.flags & tsz_binder::symbol_flags::FUNCTION) != 0;
 
-                        if (is_class || is_function) && !target_sym.declarations.is_empty() {
+                        if (is_class || is_function)
+                            && !target_sym.declarations.is_empty()
+                            && !self
+                                .cross_file_class_or_function_all_ambient(binder_idx, target_sym)
+                        {
                             if let Some(name_node) = self.ctx.arena.get(module.name) {
                                 self.ctx.error(
                                     name_node.pos,

--- a/crates/tsz-checker/tests/ts2433_cross_file_ambient_class_merge_tests.rs
+++ b/crates/tsz-checker/tests/ts2433_cross_file_ambient_class_merge_tests.rs
@@ -1,0 +1,172 @@
+//! Regression tests for TS2433 ("A namespace declaration cannot be in a
+//! different file from a class or function with which it is merged").
+//!
+//! Structural rule: when a namespace merges with a class/function declared in
+//! a *different* file, tsc does not report TS2433 if every same-named
+//! class/function declaration is ambient (`declare class` / `declare
+//! function`) — exactly the same carve-out tsc already grants when the merge
+//! is within one file. tsz's cross-file candidate search checked only the
+//! `CLASS`/`FUNCTION` symbol flags and unconditionally reported TS2433,
+//! without checking whether the found declaration was ambient, because it
+//! never consulted the *other* file's arena to find out.
+//!
+//! Oracle: `typescript@7.0.2`, matches `TypeScript/tests/cases/compiler/ambientClassDeclarationWithExtends.ts`.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_multi_file_with_global_index;
+
+// `check_multi_file` (without the global index) gives every file's binder its
+// own raw `SymbolId`s starting at 0, so two files whose sole top-level
+// declaration happens to be their first binding collide on `SymbolId(0)` and
+// get misread as the *same* symbol. `check_multi_file_with_global_index` gives
+// each file a disjoint id range, matching the production driver's bind-result
+// reducer — the invariant `check_namespace_merges_with_class_or_function`'s
+// cross-file candidate search relies on.
+fn codes(files: &[(&str, &str)], entry_file: &str) -> Vec<u32> {
+    check_multi_file_with_global_index(files, entry_file, CheckerOptions::default())
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+#[test]
+fn cross_file_namespace_merged_with_ambient_class_reports_no_ts2433() {
+    let diags = codes(
+        &[
+            (
+                "decl.ts",
+                r#"
+declare class E {
+    public bar: number;
+}
+namespace F { var y: number; }
+"#,
+            ),
+            (
+                "use.ts",
+                r#"
+declare class F extends E { }
+var f: E = new F();
+"#,
+            ),
+        ],
+        "decl.ts",
+    );
+    assert!(
+        !diags.contains(&2433),
+        "declare class merged cross-file with a namespace must not report TS2433, got: {diags:?}"
+    );
+}
+
+#[test]
+fn cross_file_namespace_merged_with_non_ambient_class_still_reports_ts2433() {
+    // Negative control: the class in the other file is NOT ambient, so tsc
+    // still reports TS2433. Proves the fix does not blanket-suppress the
+    // cross-file check.
+    let diags = codes(
+        &[
+            (
+                "decl.ts",
+                r#"
+class E {
+    bar: number = 0;
+}
+namespace F { var y: number; }
+"#,
+            ),
+            (
+                "use.ts",
+                r#"
+class F extends E { }
+var f: E = new F();
+"#,
+            ),
+        ],
+        "decl.ts",
+    );
+    assert!(
+        diags.contains(&2433),
+        "non-ambient class merged cross-file with a namespace must still report TS2433, got: {diags:?}"
+    );
+}
+
+#[test]
+fn cross_file_namespace_merged_with_ambient_function_reports_no_ts2433() {
+    let diags = codes(
+        &[
+            (
+                "decl.ts",
+                r#"
+namespace Zeta { var y: number; }
+"#,
+            ),
+            (
+                "use.ts",
+                r#"
+declare function Zeta(): void;
+"#,
+            ),
+        ],
+        "decl.ts",
+    );
+    assert!(
+        !diags.contains(&2433),
+        "declare function merged cross-file with a namespace must not report TS2433, got: {diags:?}"
+    );
+}
+
+#[test]
+fn cross_file_namespace_merged_with_non_ambient_function_still_reports_ts2433() {
+    let diags = codes(
+        &[
+            (
+                "decl.ts",
+                r#"
+namespace Zeta { var y: number; }
+"#,
+            ),
+            (
+                "use.ts",
+                r#"
+function Zeta(): void {}
+"#,
+            ),
+        ],
+        "decl.ts",
+    );
+    assert!(
+        diags.contains(&2433),
+        "non-ambient function merged cross-file with a namespace must still report TS2433, got: {diags:?}"
+    );
+}
+
+#[test]
+fn cross_file_namespace_merged_with_ambient_class_renamed_binder_reports_no_ts2433() {
+    // Same as the first test with every identifier renamed, to prove the fix
+    // is not keyed on the literal name `F`/`E` from the conformance fixture.
+    let diags = codes(
+        &[
+            (
+                "decl.ts",
+                r#"
+declare class Widget {
+    public label: string;
+}
+namespace Gadget { var count: number; }
+"#,
+            ),
+            (
+                "use.ts",
+                r#"
+declare class Gadget extends Widget { }
+var g: Widget = new Gadget();
+"#,
+            ),
+        ],
+        "decl.ts",
+    );
+    assert!(
+        !diags.contains(&2433),
+        "declare class merged cross-file with a namespace must not report TS2433 under renamed binders, got: {diags:?}"
+    );
+}


### PR DESCRIPTION
Fixes the `ambientClassDeclarationWithExtends.ts` false positive in the committed conformance false-positive queue (`a: [TS2433]`, no `m`).

When a namespace merges with a class/function declared in a *different* file, `check_namespace_merges_with_class_or_function`'s cross-file candidate search had two bugs:

1. It resolved a `SymbolId` found in the *other* file's `file_locals`/`exports` map against `self.ctx.binder` — always the *current* file's binder. A raw `SymbolId` is only meaningful within the binder that minted it, so this read an unrelated (and usually non-class/function) symbol, silently defeating the CLASS/FUNCTION flag check it was supposed to run.
2. Even when the right symbol was found, the cross-file path never checked whether the found class/function was ambient. The same-file merge path already grants a `declare class`/`declare function` merge a pass (only a non-ambient merge is TS2433); the cross-file path applied no such carve-out and unconditionally reported TS2433.

**Structural rule:** When a namespace merges with a class/function declared in a different file, and every same-named class/function declaration is ambient (`declare class`/`declare function`), tsc does not report TS2433 — tsz now does the same through `crates/tsz-checker/src/declarations/declarations_module.rs`'s cross-file candidate search in `check_namespace_merges_with_class_or_function`.

**Fix.** Both bugs are fixed at their owner, `crates/tsz-checker/src/declarations/declarations_module.rs`:
- The candidate loop now resolves `found_sym_id` against `all_binders[binder_idx]` (the binder that actually owns it) instead of `self.ctx.binder`.
- A new `cross_file_class_or_function_all_ambient` helper — using `NodeArena::is_in_ambient_context` on the *other* file's arena via `get_arena_for_file` — suppresses TS2433 when every same-named class/function declaration is ambient or a bodyless overload signature, mirroring the same-file carve-out.

**Adjacent-case matrix** in `crates/tsz-checker/tests/ts2433_cross_file_ambient_class_merge_tests.rs`: ambient class (no TS2433), non-ambient class (still TS2433, negative control), ambient function, non-ambient function (still TS2433, negative control), and a renamed-binder variant of the ambient-class case. Uses `check_multi_file_with_global_index` rather than `check_multi_file`, since the latter's non-disjoint per-file `SymbolId`s can accidentally collide across files and mask both bugs above (found the hard way: an initial version of this test using `check_multi_file` passed vacuously because of exactly this collision).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts2433_cross_file_ambient_class_merge_tests` — 5 passed, 0 failed.
- `cargo test -p tsz-checker --lib -- namespace overload ambient duplicate_identifier cross_file` — 1008 passed, 0 failed, 1 ignored.
- `cargo clippy -p tsz-checker --lib -- -D warnings` — clean.
- `cargo fmt --check -p tsz-checker` — clean.
- Pre-commit hook (fmt + clippy + architecture guard + affected-crate verification for `tsz-checker`) — passed.
- Test-only + one checker source file touched (`crates/tsz-checker/src/declarations/declarations_module.rs`); broader conformance/emit suites not run locally given the change's narrow, well-covered blast radius (a single cross-file namespace-merge decision path) — nightly CI covers the rest.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: Basanite

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMiFj5SBtVV74aPBEeT9YV)_