### PR TITLE
refactor(checker): broaden and simplify typeof-in-type-argument read marking (#16680)

### DIFF
--- a/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
+++ b/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
@@ -160,34 +160,25 @@ impl<'a> CheckerState<'a> {
             if node.kind == syntax_kind_ext::TYPE_REFERENCE {
                 // A `typeof` type query nested in a type argument
                 // (`Wrap<typeof a>`, `Map<string, typeof a>`, …) is a value read
-                // of its operand, exactly as tsc treats it. Unlike every other
-                // type-node kind — which reaches a nested query through the
-                // per-child `check` traversal that records the read — a type
-                // reference lowers its whole subtree in one non-`import()` pass
-                // whose value resolver never touches `referenced_symbols`, and
-                // the cache short-circuits below can return before it runs at
-                // all. Record the reads here so an operand read only by such a
-                // query is not falsely reported unused (#16680). Gated to
-                // references that actually carry type arguments — a bare
-                // reference cannot contain a query.
-                if self.ctx.arena.get_type_ref(node).is_some_and(|type_ref| {
+                // of its operand, exactly as tsc treats it. A type reference
+                // lowers its whole subtree in one non-`import()` pass whose value
+                // resolver never touches `referenced_symbols`, and the cache
+                // short-circuits below can return before it runs at all. Record
+                // the reads here so an operand read only by such a query is not
+                // falsely reported unused (#16680). Gated to references that
+                // actually carry type arguments — a bare reference cannot
+                // contain a query.
+                let has_type_args = self.ctx.arena.get_type_ref(node).is_some_and(|type_ref| {
                     type_ref
                         .type_arguments
                         .as_ref()
                         .is_some_and(|args| !args.nodes.is_empty())
-                }) {
+                });
+                if has_type_args {
                     self.mark_nested_type_query_reads(idx);
                 }
-                let should_refresh_cached_defaulted_reference =
-                    self.ctx.arena.get_type_ref(node).is_some_and(|type_ref| {
-                        let has_type_args = type_ref
-                            .type_arguments
-                            .as_ref()
-                            .is_some_and(|args| !args.nodes.is_empty());
-                        if has_type_args {
-                            return false;
-                        }
-
+                let should_refresh_cached_defaulted_reference = !has_type_args
+                    && self.ctx.arena.get_type_ref(node).is_some_and(|type_ref| {
                         let sym_id = match self
                             .resolve_identifier_symbol_in_type_position(type_ref.type_name)
                         {
@@ -402,6 +393,11 @@ impl<'a> CheckerState<'a> {
                 return result;
             }
             if node.kind == syntax_kind_ext::TYPE_LITERAL {
+                // A type literal lowers monolithically, so a member that is
+                // itself a type reference (`{ f: Wrap<typeof a> }`) never routes
+                // its `typeof` operand back through the marking path. Record the
+                // reads before the cache short-circuits below. See #16680.
+                self.mark_nested_type_query_reads(idx);
                 // Type literals should use checker resolution so type parameters resolve correctly.
                 // Check cache first - allow re-resolution of ERROR when type params in scope
                 if let Some(&cached) = self.ctx.node_types.get(&idx.0) {
@@ -579,6 +575,22 @@ impl<'a> CheckerState<'a> {
         // `ensure_type_alias_resolved_inner` then bails at the TYPE_ALIAS guard for interfaces,
         // leaving an orphan `Lazy(DefId)` (refs #12951).
         self.pre_warm_namespace_qualified_interface_types(idx);
+        // A compound type reached here lowers monolithically through
+        // `TypeNodeChecker`, so a nested type reference (`(p: Wrap<typeof a>) =>
+        // void`, `[Wrap<typeof a>]`, `{ [K in keyof T]: Wrap<typeof a> }`) never
+        // routes its `typeof` operand back through the marking path. Record the
+        // reads before lowering, mirroring the `TYPE_REFERENCE`/`TYPE_LITERAL`
+        // branches above; kinds that recurse per-child (union, intersection,
+        // array, conditional) already reach their queries and are no-ops here
+        // via the walk's `visited` dedup. See #16680.
+        if self
+            .ctx
+            .arena
+            .get(idx)
+            .is_some_and(|node| Self::type_node_lowers_monolithically(node.kind))
+        {
+            self.mark_nested_type_query_reads(idx);
+        }
         // For other type nodes, delegate to TypeNodeChecker
         let mut checker = crate::TypeNodeChecker::new(&mut self.ctx);
         let result = checker.check(idx);
@@ -601,77 +613,82 @@ impl<'a> CheckerState<'a> {
         result
     }
 
+    /// Whether a type node of `kind`, when reached by the compound fallthrough
+    /// of [`Self::get_type_from_type_node`], lowers its whole subtree in one
+    /// `TypeNodeChecker` pass — so a nested type reference does not route its
+    /// `typeof` operands back through the reference-marking path and must be
+    /// walked explicitly (see [`Self::mark_nested_type_query_reads`]). Kinds
+    /// that resolve their children through `get_type_from_type_node` again
+    /// (union, intersection, array, conditional, parenthesized) are omitted:
+    /// their nested queries are already recorded when the child is evaluated.
+    const fn type_node_lowers_monolithically(kind: u16) -> bool {
+        matches!(
+            kind,
+            k if k == syntax_kind_ext::FUNCTION_TYPE
+                || k == syntax_kind_ext::CONSTRUCTOR_TYPE
+                || k == syntax_kind_ext::TUPLE_TYPE
+                || k == syntax_kind_ext::NAMED_TUPLE_MEMBER
+                || k == syntax_kind_ext::MAPPED_TYPE
+                || k == syntax_kind_ext::TEMPLATE_LITERAL_TYPE
+                || k == syntax_kind_ext::INDEXED_ACCESS_TYPE
+                || k == syntax_kind_ext::TYPE_OPERATOR
+                || k == syntax_kind_ext::OPTIONAL_TYPE
+                || k == syntax_kind_ext::REST_TYPE
+        )
+    }
+
     /// Record the value read performed by every `typeof` type query nested in
     /// the type-node subtree rooted at `root`.
     ///
     /// A `TYPE_QUERY`'s entity name resolves in the *value* namespace and is a
     /// genuine read of the binding it names — tsc routes it through
-    /// `checkExpressionOrQualifiedName` in `checkTypeQuery`. Most type-node
-    /// kinds (array, tuple, union, type literal, conditional, mapped, …) reach a
-    /// nested query through the per-child `check` traversal, whose identifier
-    /// resolution records the read into `referenced_symbols`. A type reference
-    /// is the exception: its non-`import()` form lowers the whole
-    /// `TYPE_REFERENCE` subtree in one pass (`lower_with_resolvers`), and that
-    /// lowering's value resolver deliberately does not touch
-    /// `referenced_symbols`. So a `typeof` nested in a type argument
-    /// (`Wrap<typeof a>`) never recorded its operand read, and a parameter or
-    /// local whose only use was such a query was falsely reported unused
-    /// (`TS6133`/`TS6196`). Walking the subtree here and resolving each query's
-    /// root identifier in the value namespace records the reads the lowering
-    /// skips, mirroring the direct-`typeof` path. See #16680.
-    pub(super) fn mark_nested_type_query_reads(&self, root: NodeIndex) {
+    /// `checkExpressionOrQualifiedName` in `checkTypeQuery`. Reference tracking
+    /// for the unused-identifier pass (`referenced_symbols`) records that read
+    /// as a side effect of identifier resolution during type-node evaluation —
+    /// but only where evaluation actually resolves the operand. Type references
+    /// (`Wrap<typeof a>`) and the compound types that lower monolithically
+    /// (`FUNCTION_TYPE`, `CONSTRUCTOR_TYPE`, `TUPLE_TYPE`, `TYPE_LITERAL`, …)
+    /// resolve their whole subtree in one `lower_with_resolvers` pass whose
+    /// value resolver deliberately does not touch `referenced_symbols`, so a
+    /// `typeof` nested inside them never recorded its operand read and a
+    /// parameter or local read only by such a query was falsely reported unused
+    /// (`TS6133`/`TS6196`). This walk resolves each nested query's root
+    /// identifier in the value namespace, recording the reads the monolithic
+    /// lowering skips — mirroring the direct-`typeof` path. It is called at
+    /// each dispatch outcome in [`Self::get_type_from_type_node`] where a
+    /// subtree is lowered monolithically (the `TYPE_REFERENCE` and
+    /// `TYPE_LITERAL` branches, and the compound-type fallthrough beside
+    /// [`Self::check_nested_type_refs_for_ts2314`]); kinds that recurse
+    /// per-child (union, intersection, array, conditional) reach their nested
+    /// queries on their own and are covered without a walk. The `visited` set
+    /// makes re-entry from an enclosing walk idempotent. See #16680.
+    pub(crate) fn mark_nested_type_query_reads(&self, root: NodeIndex) {
         use tsz_parser::parser::node::NodeAccess;
 
+        // Same stack/`visited` DFS shape as the sibling `check_nested_type_refs_for_ts2314`.
+        // `visited` guards against a node being reached twice (and terminates
+        // even if an arena ever presented a cycle).
         let mut stack = vec![root];
-        // Real annotations are shallow; the budget only guards against a
-        // pathological arena (it is far above any genuine type-node depth).
-        let mut budget = 0u32;
+        let mut visited = FxHashSet::default();
         while let Some(idx) = stack.pop() {
-            budget += 1;
-            if budget > 8192 {
-                break;
+            if idx.is_none() || !visited.insert(idx) {
+                continue;
             }
             let Some(node) = self.ctx.arena.get(idx) else {
                 continue;
             };
             if node.kind == syntax_kind_ext::TYPE_QUERY
                 && let Some(query) = self.ctx.arena.get_type_query(node)
+                && let Some(root_ident) = self.leftmost_entity_name_node(query.expr_name)
             {
-                let root_ident = self.entity_name_root_identifier(query.expr_name);
-                if !root_ident.is_none() {
-                    // The identifier's parent is the `TYPE_QUERY`, so it is not
-                    // classified as a type context: this resolves `X` in the
-                    // value namespace and records the read, exactly as the
-                    // top-level `typeof X` annotation path does.
-                    self.resolve_identifier_symbol(root_ident);
-                }
+                // The identifier's parent is the `TYPE_QUERY`, so it is not
+                // classified as a type context: this resolves `X` in the value
+                // namespace and records the read, exactly as the top-level
+                // `typeof X` annotation path does.
+                self.resolve_identifier_symbol(root_ident);
             }
-            for child in self.ctx.arena.get_children(idx) {
-                stack.push(child);
-            }
+            stack.extend(self.ctx.arena.get_children(idx));
         }
-    }
-
-    /// The leftmost identifier of an entity name (`ns.a.b` → `ns`), or
-    /// `NodeIndex::NONE` when the entity name is not an identifier-rooted chain.
-    fn entity_name_root_identifier(&self, mut idx: NodeIndex) -> NodeIndex {
-        use tsz_scanner::SyntaxKind;
-        for _ in 0..64 {
-            let Some(node) = self.ctx.arena.get(idx) else {
-                return NodeIndex::NONE;
-            };
-            if node.kind == SyntaxKind::Identifier as u16 {
-                return idx;
-            }
-            if node.kind == syntax_kind_ext::QUALIFIED_NAME
-                && let Some(qn) = self.ctx.arena.get_qualified_name(node)
-            {
-                idx = qn.left;
-                continue;
-            }
-            return NodeIndex::NONE;
-        }
-        NodeIndex::NONE
     }
 
     /// Walk the AST subtree rooted at `idx` and emit TS2314 for any

--- a/crates/tsz-checker/src/tests/unused_typeof_type_query_reference_tests.rs
+++ b/crates/tsz-checker/src/tests/unused_typeof_type_query_reference_tests.rs
@@ -230,6 +230,51 @@ fn a_qualified_type_argument_type_query_reads_its_root() {
     );
 }
 
+/// The type-argument family also has to be reached when the bearing type
+/// reference is itself nested inside a compound type that lowers monolithically
+/// — a function/constructor type, a tuple, a mapped type, or a type literal —
+/// none of which route their inner references back through the per-reference
+/// marking path. tsc reports nothing for any of these; each operand is read.
+#[test]
+fn a_type_argument_type_query_inside_a_compound_type_reads_its_operand() {
+    let rows = [
+        // parameter type of a function type
+        "type Wrap<T> = { v: T };\nexport function c1(a: number, b: (p: Wrap<typeof a>) => void) { return b; }\n",
+        // return type of a function type
+        "type Wrap<T> = { v: T };\nexport function c2(a: number, b: () => Wrap<typeof a>) { return b; }\n",
+        // constructor type
+        "type Wrap<T> = { v: T };\nexport function c3(a: number, b: new () => Wrap<typeof a>) { return b; }\n",
+        // tuple element
+        "type Wrap<T> = { v: T };\nexport function c4(a: number, b: [Wrap<typeof a>]) { return b; }\n",
+        // type-literal member
+        "type Wrap<T> = { v: T };\nexport function c5(a: number, b: { readonly f: Wrap<typeof a> }) { return b; }\n",
+        // mapped-type value position
+        "type Wrap<T> = { v: T };\nexport function c6(a: number, b: { [K in 'x']: Wrap<typeof a> }) { return b; }\n",
+    ];
+    for row in rows {
+        let codes = unused_codes(row);
+        assert!(
+            !codes.contains(&6133),
+            "a `typeof` in a type argument nested in a compound type reads its operand. Row: {row:?} Got: {codes:?}"
+        );
+    }
+}
+
+/// Negative control for the compound broadening: an unread parameter beside a
+/// compound-nested type-argument `typeof` of a *different* binding still
+/// reports `TS6133` — the walk records only the read the `typeof` performs.
+#[test]
+fn an_unread_parameter_beside_a_compound_nested_type_query_still_reports_ts6133() {
+    let codes = unused_codes(
+        "type Wrap<T> = { v: T };\nexport function c7(used: number, unread: number, b: (p: Wrap<typeof used>) => void) { return b; }\n",
+    );
+
+    assert!(
+        codes.contains(&6133),
+        "an unread parameter must still report even beside a compound-nested type-argument `typeof`. Got: {codes:?}"
+    );
+}
+
 /// Negative control: a genuinely unread parameter still reports `TS6133`.
 ///
 /// ```text

--- a/crates/tsz-checker/src/types/queries/type_only.rs
+++ b/crates/tsz-checker/src/types/queries/type_only.rs
@@ -756,7 +756,7 @@ impl<'a> CheckerState<'a> {
         (has_type && !has_value).then_some(root_name)
     }
 
-    fn leftmost_entity_name_node(&self, idx: NodeIndex) -> Option<NodeIndex> {
+    pub(crate) fn leftmost_entity_name_node(&self, idx: NodeIndex) -> Option<NodeIndex> {
         let node = self.ctx.arena.get(idx)?;
         if node.kind == SyntaxKind::Identifier as u16 {
             return Some(idx);


### PR DESCRIPTION
Follow-up to #16703 (merged), which fixed the false **TS6133** for a `typeof` type query nested in a type reference's **type arguments** (`Wrap<typeof a>`). This PR simplifies that pass (from the review) and **broadens** it to the compound types that also lower monolithically.

**Structural rule (unchanged):** a `TYPE_QUERY`'s entity name is a value read of its operand; the unused-identifier pass must record it into `referenced_symbols`. Reference tracking records that read as a side effect of identifier resolution during type-node evaluation — but a subtree lowered in one `lower_with_resolvers` pass never resolves the operand, so the read went unrecorded.

**Broaden — the residual gap #16703 left:** a type reference nested inside a compound type that lowers monolithically does not route its inner reference back through the per-reference marking path, so its `typeof` operand's binding was still falsely reported unused. Confirmed (all clean under tsc):
- `(p: Wrap<typeof a>) => void` — function-type parameter
- `() => Wrap<typeof a>` — function-type return
- `new () => Wrap<typeof a>` — constructor type
- `[Wrap<typeof a>]` — tuple element
- `{ f: Wrap<typeof a> }` — type-literal member
- `{ [K in 'x']: Wrap<typeof a> }` — mapped-type value

`mark_nested_type_query_reads` is now invoked at every `get_type_from_type_node` dispatch outcome that lowers a subtree monolithically — the `TYPE_REFERENCE` and `TYPE_LITERAL` branches, and the compound-type fallthrough (function / constructor / tuple / named-tuple / mapped / template-literal / indexed-access / type-operator / optional / rest), colocated with `check_nested_type_refs_for_ts2314`. Kinds that recurse per-child (union, intersection, array, conditional) reach their queries on their own and are idempotent no-ops via the walk's `visited` dedup. The pass stays purely additive — it only records genuine `typeof` value reads, so it can only remove false unused diagnostics, never add one (negative controls hold: an unread parameter beside a compound-nested `typeof` of a *different* binding, and a bare type-argument type reference, both still report).

**Simplifications (review follow-up):**
- Reuse the existing `leftmost_entity_name_node` for the query operand's root identifier instead of a second hand-rolled `QUALIFIED_NAME` walk.
- Match the sibling `check_nested_type_refs_for_ts2314` DFS convention — a `visited` set instead of a numeric budget counter.
- Compute `has_type_args` once in the `TYPE_REFERENCE` branch instead of re-reading `get_type_ref` for both the mark gate and the defaulted-reference refresh.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib unused_typeof_type_query_reference_tests` — 19/19 (added the compound-nesting family — function/constructor/tuple/type-literal/mapped — and a compound negative control).
- Targeted area suites green from the crate dir: `unused` (65), `typeof` (169), `type_reference` (36), `type_query` (53), `type_node` (8), `type_argument` (80), `type_arg` (148), `ref_type_params` (35).
- End-to-end through the release CLI (`--strict --noUnusedLocals --noUnusedParameters`): all compound-nested shapes now clean; the unread-param, bare-`Wrap<Fx>`, and unread-beside-compound negatives still emit TS6133.
- `clippy` clean; pre-commit architecture guard + local verification passed.
- Conformance snapshot (12043 runnable): **11499 → 11512 passed (+13 net)**; 15 cases fixed vs baseline (was 6 with the type-argument-only pass) — the extra nine are compound/overload-signature typeofs (`contextualTyping`, `contextualTypingOfLambdaWithMultipleSignatures2`, `mixedExports`, `recursiveExportAssignmentAndFindAliasedType1/2/3`, `varianceCantBeStrictWhileStructureIsnt`, `functionLiteralForOverloads`, `genericCallWithOverloadedFunctionTypedArguments`). Zero real regressions: the one flip (`arbitraryModuleNamespaceIdentifiers_syntax.ts`) contains no `typeof`, so this pass is a strict no-op on it — it is the known parallel-run flakiness (#16309), and single-file runs are deterministic.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_017kmPv4uyPuWexXSFFRCUcD)_