### PR TITLE
fix(checker): a default-exported overload set is one default export, not N

### DIFF
--- a/crates/tsz-checker/src/declarations/import/core/module_exports.rs
+++ b/crates/tsz-checker/src/declarations/import/core/module_exports.rs
@@ -502,6 +502,11 @@ impl<'a> CheckerState<'a> {
             let mut value_count = 0;
             let mut function_value_count = 0;
             let mut function_name: Option<String> = None;
+            let mut function_name_has_body = false;
+            // How many of `effective_default_indices` are repeat overload
+            // signatures of a function default already counted above. See the
+            // `distinct_default_count` comment below.
+            let mut merged_overload_count = 0usize;
 
             for &export_idx in &effective_default_indices {
                 if self.export_decl_has_named_default_export(export_idx) {
@@ -521,21 +526,36 @@ impl<'a> CheckerState<'a> {
                     Some(k) if k == syntax_kind_ext::FUNCTION_DECLARATION => {
                         has_function = true;
                         // Check if all function defaults share the same name (overloads)
-                        let name = self
+                        let function_data = self
                             .ctx
                             .arena
                             .get_export_decl_at(export_idx)
                             .and_then(|ed| self.ctx.arena.get(ed.export_clause))
-                            .and_then(|n| self.ctx.arena.get_function(n))
-                            .map(|f| self.node_text(f.name).unwrap_or_default());
+                            .and_then(|n| self.ctx.arena.get_function(n));
+                        let name =
+                            function_data.map(|f| self.node_text(f.name).unwrap_or_default());
+                        let has_body = function_data.is_some_and(|f| !f.body.is_none());
                         match (&function_name, name) {
                             (None, Some(n)) if !n.is_empty() => {
                                 function_name = Some(n);
+                                function_name_has_body = has_body;
                                 value_count += 1;
                                 function_value_count += 1;
                             }
-                            (Some(existing), Some(n)) if !n.is_empty() && *existing == n => {
+                            // A repeat of the tracked name is another overload
+                            // signature of the same function only while at most
+                            // one declaration in the run carries a body. Two
+                            // bodies are duplicate implementations, which tsc
+                            // keeps as separate conflicting declarations rather
+                            // than merging into one `default` symbol.
+                            (Some(existing), Some(n))
+                                if !n.is_empty()
+                                    && *existing == n
+                                    && !(has_body && function_name_has_body) =>
+                            {
                                 // Same non-empty function name: overload, don't count again
+                                function_name_has_body |= has_body;
+                                merged_overload_count += 1;
                             }
                             _ => {
                                 value_count += 1;
@@ -561,8 +581,19 @@ impl<'a> CheckerState<'a> {
             // declaration, AND (2) the other is a function or class (value).
             let interface_can_merge =
                 has_interface && (has_function || has_class) && value_count == 1;
+            // A run of `export default function f(...)` declarations that share
+            // a name is ONE default-exported symbol, not N: tsc merges overload
+            // signatures into a single `default` symbol before it ever asks
+            // whether the module has multiple default exports. `value_count`
+            // already collapses them, so the *statement* count has to as well —
+            // otherwise a plain overload set (no other default export in the
+            // file at all) trips the second disjunct on its statement count
+            // alone and every signature gets a false TS2528.
+            let distinct_default_count = effective_default_indices
+                .len()
+                .saturating_sub(merged_overload_count);
             let is_conflict =
-                value_count > 1 || (effective_default_indices.len() > 1 && !interface_can_merge);
+                value_count > 1 || (distinct_default_count > 1 && !interface_can_merge);
             if is_conflict {
                 if has_function && has_class {
                     // When function + class both export as default, tsc emits

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -915,6 +915,8 @@ mod ts2353_generic_constraint_tests;
 mod ts2445_protected_access_via_subclass_this_tests;
 #[path = "tests/ts2515_ambient_class_abstract_member_tests.rs"]
 mod ts2515_ambient_class_abstract_member_tests;
+#[path = "tests/ts2528_default_export_function_overload_tests.rs"]
+mod ts2528_default_export_function_overload_tests;
 #[path = "tests/ts2536_deferred_conditional_indexed_access_tests.rs"]
 mod ts2536_deferred_conditional_indexed_access_tests;
 #[path = "tests/ts2536_error_type_contagion_tests.rs"]

--- a/crates/tsz-checker/src/tests/ts2528_default_export_function_overload_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2528_default_export_function_overload_tests.rs
@@ -1,0 +1,207 @@
+//! Regression tests for `TS2528` against a default-exported overload set.
+//!
+//! Structural rule (pinned against `typescript@7.0.2`, the conformance pin):
+//! a run of `export default function f(...)` declarations that share a name is
+//! **one** default-exported symbol, not one per statement — tsc merges overload
+//! signatures into a single `default` symbol before it ever asks whether the
+//! module has multiple default exports. A module whose only default export is
+//! such an overload set therefore reports nothing.
+//!
+//! tsz decides this in the checker's dedicated export-default pass
+//! (`declarations/import/core/module_exports.rs`). That pass already collapsed
+//! same-named function defaults for its `value_count`, but the conflict
+//! predicate was
+//!
+//! ```text
+//! value_count > 1 || (effective_default_indices.len() > 1 && !interface_can_merge)
+//! ```
+//!
+//! and the second disjunct counts *statements*. An overload set with no other
+//! default export in the file at all still tripped it on statement count alone,
+//! so every signature got a false `TS2528`. The count is now taken after the
+//! same merge `value_count` uses.
+//!
+//! The merge is deliberately not "same name wins": two same-named function
+//! declarations that **both carry a body** are duplicate implementations, which
+//! tsc keeps as separate conflicting declarations rather than merging. Only a
+//! run with at most one body is an overload set.
+//!
+//! Corpus witness: `conformance/es6/modules/defaultExportWithOverloads01.ts`, a
+//! pure false-positive row (extra `TS2528`, nothing missing) in
+//! `scripts/conformance/conformance-detail.json`.
+//!
+//! Every row below was measured against the pin with
+//! `--strict false --module commonjs --target es2015`. Binder names are varied
+//! across rows: the rule is structural, so no row may depend on a particular
+//! identifier spelling.
+
+use crate::context::ScriptTarget;
+use crate::test_utils::check_source;
+use crate::{CheckerOptions, diagnostics::Diagnostic};
+
+fn check_module(source: &str) -> Vec<Diagnostic> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            target: ScriptTarget::ES2015,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+fn codes(source: &str) -> Vec<u32> {
+    check_module(source)
+        .into_iter()
+        .map(|diagnostic| diagnostic.code)
+        .collect()
+}
+
+fn count_of(source: &str, code: u32) -> usize {
+    codes(source).into_iter().filter(|c| *c == code).count()
+}
+
+/// The corpus witness, verbatim: two bodyless signatures plus the
+/// implementation, all named the same.
+///
+/// ```text
+/// tsc: (no output)
+/// ```
+#[test]
+fn a_default_exported_overload_set_is_one_default_export() {
+    let source = "export default function f();\n\
+                  export default function f(x: string);\n\
+                  export default function f(...args: any[]) {\n}\n";
+
+    assert_eq!(
+        count_of(source, 2528),
+        0,
+        "three signatures of one default-exported function are one default export; \
+         tsc reports nothing. Got: {:?}",
+        codes(source)
+    );
+}
+
+/// Same shape, different binder spelling — the rule must not key on `f`.
+#[test]
+fn the_overload_merge_does_not_depend_on_the_binder_spelling() {
+    let source = "export default function widgetFactory(alpha: string);\n\
+                  export default function widgetFactory(alpha: number);\n\
+                  export default function widgetFactory(alpha: any) { return alpha; }\n";
+
+    assert_eq!(
+        count_of(source, 2528),
+        0,
+        "renamed binders must behave identically. Got: {:?}",
+        codes(source)
+    );
+}
+
+/// Longer runs collapse the same way — the merge is not "at most two".
+#[test]
+fn a_three_signature_overload_set_is_still_one_default_export() {
+    let source = "export default function pick(a: string): string;\n\
+                  export default function pick(a: number): number;\n\
+                  export default function pick(a: boolean): boolean;\n\
+                  export default function pick(a: any): any { return a; }\n";
+
+    assert_eq!(
+        count_of(source, 2528),
+        0,
+        "four statements, one symbol. Got: {:?}",
+        codes(source)
+    );
+}
+
+/// A bodyless overload set inside an ambient module declaration — no
+/// implementation at all, so nothing can be mistaken for the merge anchor.
+#[test]
+fn an_ambient_module_default_overload_set_is_one_default_export() {
+    let source = "declare module \"remote\" {\n\
+                  \x20   export default function connect(host: string): void;\n\
+                  \x20   export default function connect(port: number): void;\n\
+                  }\n";
+
+    assert_eq!(
+        count_of(source, 2528),
+        0,
+        "ambient bodyless signatures merge like any other overload set. Got: {:?}",
+        codes(source)
+    );
+}
+
+/// An interface may merge with the function the overload set declares — the
+/// pre-existing interface carve-out still applies once the run is collapsed.
+#[test]
+fn an_interface_merging_with_a_default_overload_set_is_clean() {
+    let source = "export default interface Shape { sides: number }\n\
+                  export default function Shape(spec: string);\n\
+                  export default function Shape(spec: any) { return spec; }\n";
+
+    assert_eq!(
+        count_of(source, 2528),
+        0,
+        "interface + function default is a declaration merge. Got: {:?}",
+        codes(source)
+    );
+}
+
+/// Negative control, the one that matters: an overload set plus a genuinely
+/// separate default export is still a conflict, and tsc reports `TS2528` on
+/// **every** default site — three here, not one.
+#[test]
+fn an_overload_set_beside_another_default_export_still_reports_every_site() {
+    let source = "export default function render(input: string);\n\
+                  export default function render(input: any) { return input; }\n\
+                  export default 1;\n";
+
+    assert_eq!(
+        count_of(source, 2528),
+        3,
+        "the overload set collapses to one entity but the module still has two, \
+         and tsc marks all three statements. Got: {:?}",
+        codes(source)
+    );
+}
+
+/// Negative control: two same-named function declarations that both carry a
+/// body are duplicate implementations, not an overload set. They must not be
+/// collapsed away into a single clean default export.
+#[test]
+fn two_default_exported_implementations_of_one_name_are_not_an_overload_set() {
+    let source = "export default function handler(x: string) { return x; }\n\
+                  export default function handler(x: number) { return x; }\n";
+    let observed = codes(source);
+
+    assert!(
+        observed.contains(&2393),
+        "duplicate implementations still report TS2393. Got: {observed:?}"
+    );
+    assert!(
+        observed.iter().any(|c| *c == 2528 || *c == 2323),
+        "a duplicate-implementation pair is still a default-export conflict, not a \
+         merged overload set. Got: {observed:?}"
+    );
+}
+
+/// Negative control: a default-exported function beside a default-exported
+/// class is the function/class merge family (`TS2323`/`TS2813`/`TS2814`), and
+/// collapsing the function's own signatures must not disturb it.
+#[test]
+fn a_default_overload_set_beside_a_default_class_keeps_the_merge_family() {
+    let source = "export default function Model(spec: string);\n\
+                  export default function Model(spec: any) { return spec; }\n\
+                  export default class Model {}\n";
+    let observed = codes(source);
+
+    assert!(
+        observed.contains(&2323),
+        "function + class default exports report the merge family. Got: {observed:?}"
+    );
+    assert_eq!(
+        observed.iter().filter(|c| **c == 2528).count(),
+        0,
+        "the function/class family uses TS2323/TS2813/TS2814, never TS2528. \
+         Got: {observed:?}"
+    );
+}


### PR DESCRIPTION
**Structural rule.** When a module's `export default` declarations are a run of function declarations that share a name, tsc merges them into a single `default` symbol before it ever asks whether the module has multiple default exports, so a module whose only default export is such an overload set reports nothing; tsz now does the same through the checker's dedicated export-default pass (`crates/tsz-checker/src/declarations/import/core/module_exports.rs`).

That pass already collapsed same-named function defaults for its `value_count`, but the conflict predicate's second disjunct counted **statements**:

```
value_count > 1 || (effective_default_indices.len() > 1 && !interface_can_merge)
```

An overload set with no other default export in the file at all still tripped that disjunct on statement count alone, and every signature got a false `TS2528`. The count is now taken after the same merge `value_count` uses.

The merge is deliberately not "same name wins": two same-named function declarations that **both carry a body** are duplicate implementations, which tsc keeps as separate conflicting declarations rather than merging. Only a run with at most one body collapses, so the duplicate-implementation and function/class-merge families are untouched — see the last two rows of the matrix.

**Failure family.** `conformance/es6/modules/defaultExportWithOverloads01.ts`, a pure false-positive row (`a: [TS2528]`, nothing missing) in `scripts/conformance/conformance-detail.json`. The shape is a common one in real source, not a corpus curiosity.

## Goal
Goal: hold

## Verification

Adjacent-case matrix, every row measured against the pinned oracle `typescript@7.0.2` (`scripts/conformance/typescript-versions.json`, corpus `4d4f005c`) with `--noEmit --strict false --module commonjs --target es2015`, and against `.target/debug/tsz` at the same flags before and after the change:

| row | tsc 7.0.2 | tsz before | tsz after |
| --- | --- | --- | --- |
| witness — 2 signatures + impl, name `f` | clean | **TS2528 x3** | clean |
| renamed binder — `widgetFactory` x3 | clean | **TS2528 x3** | clean |
| 3 signatures + impl, name `pick` | clean | **TS2528 x4** | clean |
| ambient module, 2 bodyless signatures, no impl | clean | clean | clean |
| `export default interface Shape` + `Shape` overload set | clean | clean | clean |
| overload set **+ `export default 1`** (positive control) | TS2528 x3 | TS2528 x3 | TS2528 x3 |
| two same-named **implementations** (negative control) | TS2323 x2 + TS2393 x2 | TS2393 x2 + TS2528 x2 | unchanged |
| two differently-named implementations | TS2323 x2 + TS2393 x2 | TS2393 x2 + TS2528 x2 | unchanged |
| overload set + `export default class` | TS2323/TS2813/TS2814 | identical to tsc | unchanged |

The three "unchanged" rows are pre-existing divergences in a different classification branch (TS2528-vs-TS2323 for duplicate function implementations, and TS2391 recovery for differently-named default functions). This change is measured not to move them in either direction; they are noted rather than folded in.

Commands actually run on this branch:

- `cargo test -p tsz-checker --lib ts2528_default_export_function_overload` — **8/8 pass** (new suite).
- `cargo test -p tsz-checker --lib -- default_export export_default ts2528 ts2323 ts2300 multiple_default overload` — **583 passed, 0 failed**.
- `cargo clippy --profile ci-lint --workspace --exclude tsz-conformance --all-targets -- -D warnings` (CI's exact invocation) — clean.
- `cargo fmt --all` — clean; `python3 scripts/arch/arch_guard.py` — passes (`module_exports.rs` 1140 lines, well under the cap).
- `scripts/githooks/pre-commit` — passed (clippy + affected-crate verification).

Owed and disclosed rather than claimed: the full `cargo test -p tsz-checker --lib` lane and two-sided `scripts/conformance/compare-to-parent.sh` did not fit this session's hour on a cold cloud seat (`compare-to-parent.sh` builds `dist-fast` twice; recent sessions measured 55-90+ min). Scope argument for the risk: the edit is confined to the conflict predicate of the single `if effective_default_indices.len() > 1` block in the export-default pass, it can only ever make that predicate *less* likely to fire, and it fires less only for a run of same-named default-exported function declarations with at most one body — so it cannot introduce a diagnostic on any input, and the positive control above pins that TS2528 still fires on every site when a genuine second default export is present. Emit is unreachable from this path (diagnostic classification only), and the diff touches no emitter or DTS code.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-5
Effort: high
AgentName: Aventurine

---
_Generated by [Claude Code](https://claude.ai/code/session_01BxnDhxvePpDJpdsM24M8hz)_