### PR TITLE
fix(solver): union narrowing drops a callable member subsumed only by a weak sibling's optional properties

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -264,6 +264,9 @@ path = "tests/union_protected_intersection_property_tests.rs"
 name = "weak_object_union_member_subtype_reduction_tests"
 path = "tests/weak_object_union_member_subtype_reduction_tests.rs"
 [[test]]
+name = "weak_type_union_member_instantiated_relation_tests"
+path = "tests/weak_type_union_member_instantiated_relation_tests.rs"
+[[test]]
 name = "tuple_element_mismatch_tests"
 path = "tests/tuple_element_mismatch_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/weak_type_union_member_instantiated_relation_tests.rs
+++ b/crates/tsz-checker/tests/weak_type_union_member_instantiated_relation_tests.rs
@@ -1,0 +1,177 @@
+//! Regression coverage for issue #16707: a function-shaped union member must
+//! survive union *narrowing* (redundant-member removal) against a weak
+//! (all-optional) sibling member — not just direct assignability — when the
+//! union comes from generic instantiation (a type parameter's inferred
+//! signature, or a mapped-type property) rather than a literal annotation.
+//!
+//! Rule: `tsc`'s own union-narrowing pass (`removeSubtypes`, used while
+//! building the type of an instantiated union) runs `strictSubtypeRelation`,
+//! which still performs the weak-type "no common properties" veto (TS2559)
+//! even though it isn't `ComparableRelation`. tsz's evaluator-level
+//! `remove_redundant_members` used a plain structural check with no such
+//! veto, so a callable member that shares no properties with an all-optional
+//! sibling (e.g. `(() => T) | { get?(): T }`) was wrongly treated as
+//! subsumed by it and dropped from the union — collapsing
+//! `(() => number) | Computed<number>` down to just `Computed<number>` and
+//! reporting TS2559/TS2322 against an argument that only matches the
+//! function member.
+//!
+//! The behavior keys on type structure (callable vs weak-object sibling,
+//! whether the union arrives via instantiation), never on
+//! identifier/property/type-parameter names, so these tests vary all of
+//! those.
+
+use tsz_checker::test_utils::check_source_code_messages;
+
+fn has_code(diags: &[(u32, String)], code: u32) -> bool {
+    diags.iter().any(|(c, _)| *c == code)
+}
+
+#[test]
+fn function_arg_against_inferred_union_with_weak_sibling_is_accepted() {
+    // The exact repro from #16707: T is inferred from the `() => T` member,
+    // but the union-narrowing pass must not drop that member first.
+    let diags = check_source_code_messages(
+        r#"
+type Computed<T> = { get?(): T; set?(value: T): void; };
+declare function g1<T>(x: (() => T) | Computed<T>): T;
+let b1 = g1(() => 1);
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "a callable argument must match the callable union member, not be rejected via a dropped member: {diags:?}"
+    );
+}
+
+#[test]
+fn function_arg_against_inferred_union_with_weak_sibling_first_is_accepted() {
+    // Member order must not matter — the weak member listed first.
+    let diags = check_source_code_messages(
+        r#"
+type Computed<T> = { get?(): T; set?(value: T): void; };
+declare function g1<T>(x: Computed<T> | (() => T)): T;
+let b1 = g1(() => 1);
+"#,
+    );
+    assert!(diags.is_empty(), "member order must not matter: {diags:?}");
+}
+
+#[test]
+fn function_arg_against_mapped_type_union_with_weak_sibling_is_accepted() {
+    // A mapped-type property union, concrete instantiation (issue's case C).
+    let diags = check_source_code_messages(
+        r#"
+type Computed<T> = { get?(): T; set?(value: T): void; };
+type Acc<T> = { [K in keyof T]: (() => T[K]) | Computed<T[K]> };
+declare function takeC(a: Acc<{ test: number }>): void;
+takeC({ test(): number { return 1; } });
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "mapped-type instantiation must not drop the callable member: {diags:?}"
+    );
+}
+
+#[test]
+fn function_arg_against_mapped_type_union_inferred_is_accepted() {
+    // Mapped-type property union, inferred (issue's case D).
+    let diags = check_source_code_messages(
+        r#"
+type Computed<T> = { get?(): T; set?(value: T): void; };
+type Acc<T> = { [K in keyof T]: (() => T[K]) | Computed<T[K]> };
+declare function takeD<P>(a: Acc<P>): P;
+takeD({ test(): number { return 1; } });
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "an inferred mapped-type union must not drop the callable member: {diags:?}"
+    );
+}
+
+#[test]
+fn function_arg_against_directly_annotated_union_stays_accepted() {
+    // Regression guard: the directly annotated (non-generic) union was
+    // already correct before the fix — must stay correct after it.
+    let diags = check_source_code_messages(
+        r#"
+type Computed<T> = { get?(): T; set?(value: T): void; };
+let a1: (() => number) | Computed<number> = () => 1;
+let a2: Computed<number> | (() => number) = () => 1;
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "a direct annotation must stay clean: {diags:?}"
+    );
+}
+
+#[test]
+fn renamed_binders_function_arg_against_inferred_union_is_accepted() {
+    // Anti-hardcoding: identical shape, different type/function/parameter names.
+    let diags = check_source_code_messages(
+        r#"
+type Deferred<Value> = { read?(): Value; write?(next: Value): void; };
+declare function resolveEntry<Item>(getter: (() => Item) | Deferred<Item>): Item;
+let entry = resolveEntry(() => "hi");
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "renamed binders must behave identically: {diags:?}"
+    );
+}
+
+#[test]
+fn two_weak_members_plus_callable_inferred_is_accepted() {
+    // More than one weak sibling in the union.
+    let diags = check_source_code_messages(
+        r#"
+type W<T> = { get?(): T } | { set?(v: T): void } | (() => T);
+declare function g3<T>(x: W<T>): T;
+let f1 = g3(() => 1);
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "multiple weak siblings must not change the result: {diags:?}"
+    );
+}
+
+#[test]
+fn object_arg_with_no_common_property_against_inferred_union_still_errors() {
+    // Negative control: an object literal that matches NEITHER the callable
+    // member NOR any property of the weak member must still be rejected —
+    // the fix must not disable the weak-type check outright, only stop it
+    // from wrongly collapsing the union first.
+    let diags = check_source_code_messages(
+        r#"
+type Computed<T> = { get?(): T; set?(value: T): void; };
+declare function g2<T>(x: (() => T) | Computed<T>): T;
+let e1 = g2({ nope: 1 });
+"#,
+    );
+    assert!(
+        has_code(&diags, 2353) || has_code(&diags, 2559) || has_code(&diags, 2345),
+        "an argument matching neither union member must still be rejected: {diags:?}"
+    );
+}
+
+#[test]
+fn object_matching_weak_member_against_inferred_union_is_accepted() {
+    // Positive control on the OTHER member: an object that genuinely
+    // satisfies the weak member's declared property must still be accepted.
+    let diags = check_source_code_messages(
+        r#"
+type Computed<T> = { get?(): T; set?(value: T): void; };
+declare function g4<T>(x: (() => T) | Computed<T>): T;
+let g = g4({ get() { return 1; } });
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "an object satisfying the weak member must still be accepted: {diags:?}"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate/compound_simplification.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/compound_simplification.rs
@@ -153,6 +153,21 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         checker.max_depth = MAX_SUBTYPE_DEPTH;
         checker.no_unchecked_indexed_access = self.no_unchecked_indexed_access;
         checker.exact_optional_property_types = self.exact_optional_property_types;
+        // Union narrowing must apply the same weak-type ("no common properties",
+        // TS2559) veto tsc's own `removeSubtypes` gets from `strictSubtypeRelation`:
+        // that relation is not `ComparableRelation`, so `isPerformingCommonPropertyChecks`
+        // still runs. Without this, a member that structurally satisfies an
+        // all-optional ("weak") sibling only because it shares no properties with
+        // it — e.g. `(() => T) | { get?(): T }` — reads as redundant and gets
+        // dropped, collapsing the union to just the weak member. A later
+        // assignability check against an argument that only matches the dropped
+        // member then reports TS2559 against the sole remaining (weak) member
+        // instead of succeeding through the one that was removed (#16707).
+        // Intersection simplification (`OtherSubsumedBySource`) is unaffected:
+        // tsc's intersection construction does not run this relation.
+        if matches!(direction, SubtypeDirection::SourceSubsumedByOther) {
+            checker.enforce_weak_types = true;
+        }
 
         // Snapshot per-member veto facts before the pair loop. These facts are
         // pure, per-call data, so relation probes can mutably borrow `self`


### PR DESCRIPTION
Fixes #16707.

**Structural rule.** When a union member's own subtyping verdict against another member depends only on that other member being a weak (all-optional) object type it shares no properties with, tsc's own union-narrowing pass (`removeSubtypes`, run while constructing an instantiated union's type) does not treat the first member as redundant — tsz now does the same through `crates/tsz-solver/src/evaluation/evaluate/compound_simplification.rs`'s `remove_redundant_members`.

**Root cause.** `declare function g1<T>(x: (() => T) | Computed<T>): T; g1(() => 1)` (where `Computed<T> = { get?(): T; set?(value: T): void; }`) reported `TS2559: Type '() => number' has no properties in common with type 'Computed<number>'`, even though `() => number` correctly matches the `() => T` union member and inference lands on `T = number`. Tracing (`TSZ_LOG=trace`) showed the *instantiated* parameter union `(() => number) | Computed<number>` getting collapsed down to just `Computed<number>` during `evaluate_type`'s union simplification, via `remove_redundant_members: removing member removed=<() => number> subsumed_by=<Computed<number>>`. Once the callable member is dropped, the argument is checked only against `Computed<number>` and fails the weak-type check.

The union simplifier ran a plain structural (`Judge`-layer) subtype check with no weak-type awareness — under pure structural subtyping, a callable with no named properties trivially "satisfies" an all-optional object shape, so it looked redundant. But tsc's real union-narrowing relation (`strictSubtypeRelation`) is not `ComparableRelation`, so it still runs the common-property (`isPerformingCommonPropertyChecks`/`hasCommonProperties`) veto per member pair — a callable sharing no properties with an all-optional sibling is never "subsumed" by it there, so the union stays a two-member union and the callable member survives to match the argument.

Directly-annotated unions (`let a1: (() => number) | Computed<number> = () => 1;`) were already correct, because that path never goes through `evaluate_type`'s member-removal simplification the way a freshly-instantiated generic parameter union does — only the instantiation/inference path hit the bug.

**Fix.** `crates/tsz-solver/src/relations/subtype/rules/objects.rs`'s `check_object_subtype` already has exactly the needed weak-type veto (including the function-source case via `function_apparent_object_shape`, per its own comment: *"a function is NOT a member of `Fn | Ctor | { pre?; post? }`"*), gated behind `SubtypeChecker::enforce_weak_types` (default `false`). `remove_redundant_members` built its `SubtypeChecker` with the default, so the veto never fired during union narrowing. Setting `checker.enforce_weak_types = true` for the union direction (`SubtypeDirection::SourceSubsumedByOther`) turns the existing veto on for exactly this pass — no new weak-type logic was added. Intersection simplification (`OtherSubsumedBySource`) is untouched, matching tsc (`getIntersectionType` doesn't run `strictSubtypeRelation`). The pre-existing `weak_type_sensitivity_count()` cache-safety check in `compound_subtype_cached` (added for exactly this class of enforcement-state-dependent result) already covers the new code path with no further change needed.

**Adjacent-case matrix** (`crates/tsz-checker/tests/weak_type_union_member_instantiated_relation_tests.rs`, 9 tests, oracle-verified against pinned `typescript@7.0.2`):

| case | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| inferred union, `() => T` first | clean | TS2559 | **clean** |
| inferred union, weak member first | clean | TS2559 | **clean** |
| mapped-type union, concrete instantiation | clean | TS2322 | **clean** |
| mapped-type union, inferred | clean | TS2559 | **clean** |
| direct annotation (regression guard) | clean | clean | clean (unchanged) |
| renamed binders | clean | TS2559 | **clean** |
| two weak siblings + callable | clean | TS2559 | **clean** |
| object matching neither member (negative control) | TS2353 | (already errored) | TS2353 (unchanged) |
| object matching the weak member's own property (positive control) | clean | clean | clean (unchanged) |

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test weak_type_union_member_instantiated_relation_tests` — 9 passed, 0 failed (new adjacent-case matrix).
- `cargo test -p tsz-checker --test weak_object_union_member_subtype_reduction_tests --test weak_callable_target_assignability_tests` — 8 + 6 passed, 0 failed (pre-existing sibling weak-type/union-reduction suites, unaffected).
- `cargo test -p tsz-solver --lib` — **7653 passed, 0 failed** (full solver unit suite).
- `cargo clippy -p tsz-solver -p tsz-checker --lib --all-features -- -D warnings` — clean.
- `cargo clippy -p tsz-checker --test weak_type_union_member_instantiated_relation_tests -- -D warnings` — clean.
- `cargo fmt -p tsz-solver -p tsz-checker -- --check` — clean.
- `python3 scripts/arch/arch_guard.py` — clean.
- Pre-commit hook (fmt + clippy + architecture guard + affected-crate verification for `tsz-checker`/`tsz-solver`) — passed.
- Binary-level cross-check against pinned `typescript@7.0.2`: all 4 previously-failing repro cases (B/C/D from the issue, plus the negative control) now byte-match the oracle; see matrix above.
- Owed: full `cargo test -p tsz-checker --lib` (~10.4k tests) was still running in the background at PR-open time (long-tail suite per the board's standing notes); will report the count in a follow-up comment. Two-sided `compare-to-parent.sh` corpus set-difference not run this session — measured 55-90+ min on prior cloud sessions; this is a solver-only fix scoped to union member-removal for callable-vs-weak-object pairs, and the oracle-pinned targeted matrix plus the full solver `--lib` pass are the primary evidence in the meantime.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hyq7oZj3RdesAKJ3CHLfGd)_