### PR TITLE
fix(checker): a for...in optional-chain head takes TS2405 over TS2780 when its type is not string/any (#16668)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -499,6 +499,9 @@ mod for_in_narrowing_tests;
 #[path = "../tests/for_in_operand_type_display_tests.rs"]
 mod for_in_operand_type_display_tests;
 #[cfg(test)]
+#[path = "../tests/for_in_optional_chain_ts2405_vs_ts2780_tests.rs"]
+mod for_in_optional_chain_ts2405_vs_ts2780_tests;
+#[cfg(test)]
 #[path = "../tests/for_in_self_reference_and_nullable_operand_tests.rs"]
 mod for_in_self_reference_and_nullable_operand_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/variable_checking/for_loop.rs
+++ b/crates/tsz-checker/src/state/variable_checking/for_loop.rs
@@ -725,6 +725,39 @@ impl<'a> CheckerState<'a> {
         false
     }
 
+    /// Whether an optional-chain access is rooted on an `any`/error receiver.
+    ///
+    /// tsc propagates `any` through an optional chain, so `any?.b.c` (or a chain
+    /// whose root identifier is `any`) is itself `any`. Walking to the root and
+    /// testing its type is more reliable than the chain's evaluated type for the
+    /// for-in TS2405/TS2780 decision: a preceding invalid `root?.b = <literal>`
+    /// can leave a stale assigned-value type on the chain result even though the
+    /// root — and therefore the whole chain per tsc — is `any`.
+    fn optional_chain_root_receiver_is_any_like(&mut self, idx: NodeIndex) -> bool {
+        use tsz_parser::parser::syntax_kind_ext;
+        let mut current = self.ctx.arena.skip_parenthesized_and_assertions(idx);
+        loop {
+            let Some(node) = self.ctx.arena.get(current) else {
+                return false;
+            };
+            let next = match node.kind {
+                k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+                    || k == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION =>
+                {
+                    self.ctx.arena.get_access_expr(node).map(|a| a.expression)
+                }
+                k if k == syntax_kind_ext::CALL_EXPRESSION => {
+                    self.ctx.arena.get_call_expr(node).map(|c| c.expression)
+                }
+                _ => break,
+            };
+            let Some(expr) = next else { return false };
+            current = self.ctx.arena.skip_parenthesized_and_assertions(expr);
+        }
+        let root_type = self.get_type_of_node(current);
+        root_type == TypeId::ANY || root_type == TypeId::ERROR
+    }
+
     /// Check assignability for for-in/of expression initializer (non-declaration case).
     ///
     /// For `for (v of expr)` where `v` is a pre-declared variable (not `var v`/`let v`/`const v`),
@@ -756,23 +789,26 @@ impl<'a> CheckerState<'a> {
             );
         }
 
-        // TS2780/TS2781: The left-hand side of a 'for...in'/'for...of' statement
-        // may not be an optional property access.
-        if self.is_optional_chain_access(initializer) {
+        // TS2781: The left-hand side of a 'for...of' statement may not be an
+        // optional property access. tsc's `checkForOfStatement` calls
+        // `checkReferenceExpression` unconditionally, so this fires regardless
+        // of the chain's element type.
+        //
+        // The analogous TS2780 for `for...in` is NOT unconditional. tsc's
+        // `checkForInStatement` computes the head's real type first and only
+        // reaches `checkReferenceExpression` (the TS2780 source) in the `else`
+        // branch of `if !isTypeAssignableTo(indexType, leftType) { TS2405 }
+        // else { checkReferenceExpression(...) }` — so TS2405 wins whenever the
+        // LHS type is not string/any, and TS2780 only fires once that type check
+        // passes. The for-in TS2405/TS2780 selection is owned by the optional-
+        // chain block below, which computes the head's read type to decide.
+        if is_for_of && self.is_optional_chain_access(initializer) {
             use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-            if is_for_of {
-                self.error_at_node(
-                    initializer,
-                    diagnostic_messages::THE_LEFT_HAND_SIDE_OF_A_FOR_OF_STATEMENT_MAY_NOT_BE_AN_OPTIONAL_PROPERTY_ACCESS,
-                    diagnostic_codes::THE_LEFT_HAND_SIDE_OF_A_FOR_OF_STATEMENT_MAY_NOT_BE_AN_OPTIONAL_PROPERTY_ACCESS,
-                );
-            } else {
-                self.error_at_node(
-                    initializer,
-                    diagnostic_messages::THE_LEFT_HAND_SIDE_OF_A_FOR_IN_STATEMENT_MAY_NOT_BE_AN_OPTIONAL_PROPERTY_ACCESS,
-                    diagnostic_codes::THE_LEFT_HAND_SIDE_OF_A_FOR_IN_STATEMENT_MAY_NOT_BE_AN_OPTIONAL_PROPERTY_ACCESS,
-                );
-            }
+            self.error_at_node(
+                initializer,
+                diagnostic_messages::THE_LEFT_HAND_SIDE_OF_A_FOR_OF_STATEMENT_MAY_NOT_BE_AN_OPTIONAL_PROPERTY_ACCESS,
+                diagnostic_codes::THE_LEFT_HAND_SIDE_OF_A_FOR_OF_STATEMENT_MAY_NOT_BE_AN_OPTIONAL_PROPERTY_ACCESS,
+            );
         }
 
         // TS2487: For-of LHS must be a variable or a property access.
@@ -894,6 +930,57 @@ impl<'a> CheckerState<'a> {
                     .for_in_lhs_relation_outcome(element_type, var_type)
                     .related
             {
+                self.error_at_node(
+                    initializer,
+                    diagnostic_messages::THE_LEFT_HAND_SIDE_OF_A_FOR_IN_STATEMENT_MUST_BE_OF_TYPE_STRING_OR_ANY,
+                    diagnostic_codes::THE_LEFT_HAND_SIDE_OF_A_FOR_IN_STATEMENT_MUST_BE_OF_TYPE_STRING_OR_ANY,
+                );
+            }
+        }
+
+        // TS2405 vs TS2780 for an optional-chain for-in head. tsc gates these
+        // mutually exclusively: `checkForInStatement` computes the head
+        // expression's real type (`checkExpression`, a READ) and reports TS2405
+        // when that type is not assignable from the index type (i.e. not
+        // string/any), otherwise reaches `checkReferenceExpression`, which
+        // reports TS2780 for the optional chain itself.
+        //
+        // The head's type is read through the value path (`get_type_of_node`),
+        // NOT the write-target path (`get_type_of_assignment_target`): a for-in
+        // optional-chain head is a write-target context, so that path
+        // short-circuits to `any` (erasing the type this decision needs) and,
+        // when forced to resolve the chain, runs write-flow probes that leak the
+        // spurious TS2339/TS7053 that got #16660 reverted. The read path returns
+        // the chain's genuine `T | undefined` type and emits only the
+        // diagnostics tsc's `checkExpression` itself would.
+        if !is_for_of && self.is_optional_chain_access(initializer) {
+            use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+            let head_type = self.get_type_of_node(initializer);
+            // `isTypeAssignableTo(indexType, leftType)` — TS2405 fires only when
+            // the LHS type rejects the for-in key type. `unknown` and the error
+            // type are permissive on both sides, matching tsc's assignability.
+            //
+            // `any` propagates through an optional chain: when the chain's root
+            // receiver is `any`/error, the whole head is `any` (tsc), so the type
+            // check passes and TS2780 owns the head. This is checked directly on
+            // the root because an invalid prior `a?.b = <literal>` (itself TS2779)
+            // can leave a stale assigned-value type on the chain result even on a
+            // bare `any` receiver — the root's own type is the reliable witness of
+            // the any-propagation `tsc` performs through the chain.
+            let lhs_type_accepts_index = head_type == TypeId::STRING
+                || head_type == TypeId::ANY
+                || head_type == TypeId::UNKNOWN
+                || self.optional_chain_root_receiver_is_any_like(initializer)
+                || self
+                    .for_in_lhs_relation_outcome(element_type, head_type)
+                    .related;
+            if lhs_type_accepts_index {
+                self.error_at_node(
+                    initializer,
+                    diagnostic_messages::THE_LEFT_HAND_SIDE_OF_A_FOR_IN_STATEMENT_MAY_NOT_BE_AN_OPTIONAL_PROPERTY_ACCESS,
+                    diagnostic_codes::THE_LEFT_HAND_SIDE_OF_A_FOR_IN_STATEMENT_MAY_NOT_BE_AN_OPTIONAL_PROPERTY_ACCESS,
+                );
+            } else {
                 self.error_at_node(
                     initializer,
                     diagnostic_messages::THE_LEFT_HAND_SIDE_OF_A_FOR_IN_STATEMENT_MUST_BE_OF_TYPE_STRING_OR_ANY,

--- a/crates/tsz-checker/tests/for_in_optional_chain_ts2405_vs_ts2780_tests.rs
+++ b/crates/tsz-checker/tests/for_in_optional_chain_ts2405_vs_ts2780_tests.rs
@@ -1,0 +1,268 @@
+//! `for...in` optional-chain head: TS2405 (must be `string`/`any`) vs TS2780
+//! (may not be an optional property access).
+//!
+//! Structural rule: `tsc`'s `checkForInStatement` computes the head
+//! expression's real type FIRST — via `checkExpression` (a READ, not a
+//! write-target resolution) — and only calls `checkReferenceExpression` (the
+//! source of TS2780) in the `else` branch of the type check:
+//!
+//! ```go
+//! } else if !c.isTypeAssignableTo(c.getIndexTypeOrString(rightType), leftType) {
+//!     c.error(varExpr, diagnostics.The_left_hand_side_of_a_for_in_statement_must_be_of_type_string_or_any)
+//! } else {
+//!     c.checkReferenceExpression(varExpr, ..., diagnostics.The_left_hand_side_of_a_for_in_statement_may_not_be_an_optional_property_access)
+//! }
+//! ```
+//!
+//! So TS2405 and TS2780 are mutually exclusive for a `for...in` head: TS2405
+//! wins whenever the head's type is not string/any, and TS2780 only fires once
+//! that type check passes. The discriminating control is the **string-LHS**
+//! row: precedence keys on the LHS *type*, not on "is an optional chain".
+//!
+//! `for...of`'s analogous TS2781 check is NOT gated this way — tsc's
+//! `checkForOfStatement` calls `checkReferenceExpression` unconditionally — so
+//! that family is a regression guard here, not something this fix changes.
+//!
+//! The head type is read through the value path precisely so the chain's
+//! property/element lookups do not leak the spurious TS2339/TS7053 that the
+//! write-target path produced (the leak that reverted #16660). These tests
+//! therefore include element-access chains and deeper nesting as leak guards.
+//!
+//! All diagnostics oracle-verified against the pinned `typescript@7.0.2`
+//! (`--strict --target es2022`). Binder names vary across cases per the repo's
+//! anti-hardcoding discipline.
+
+use crate::test_utils::check_source_strict_codes;
+
+// =========================================================================
+// TS2405 wins: the optional-chain head's real type is not string/any.
+// =========================================================================
+
+#[test]
+fn for_in_optional_receiver_required_member_number_leaf_emits_only_ts2405() {
+    // `mid` is optional, `inner`/`leaf` required: the chain's real type is
+    // `number | undefined`, not assignable to `string` — TS2405, no TS2780.
+    let codes = check_source_strict_codes(
+        "declare const outer: { mid?: { inner: { leaf: number } } };\nfor (outer.mid?.inner.leaf in {}) {}\n",
+    );
+    assert!(
+        codes.contains(&2405),
+        "possibly-undefined non-string LHS must emit TS2405; got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2780),
+        "TS2405 must suppress TS2780 for a for-in optional-chain head; got: {codes:?}"
+    );
+}
+
+#[test]
+fn for_in_renamed_binders_number_leaf_emits_only_ts2405() {
+    // Same shape, completely different identifiers — the decision must be
+    // structural, never keyed on any particular name.
+    let codes = check_source_strict_codes(
+        "declare const zq: { al?: { be: { ga: number } } };\nfor (zq.al?.be.ga in {}) {}\n",
+    );
+    assert!(codes.contains(&2405), "expected TS2405; got: {codes:?}");
+    assert!(!codes.contains(&2780), "expected no TS2780; got: {codes:?}");
+}
+
+#[test]
+fn for_in_top_level_optional_access_number_typed_emits_only_ts2405() {
+    let codes = check_source_strict_codes(
+        "declare const rec: { count?: number };\nfor (rec?.count in {}) {}\n",
+    );
+    assert!(codes.contains(&2405), "expected TS2405; got: {codes:?}");
+    assert!(!codes.contains(&2780), "expected no TS2780; got: {codes:?}");
+}
+
+#[test]
+fn for_in_optional_element_access_number_leaf_emits_only_ts2405() {
+    // Element-access chain form (mirrors elementAccessChain.3.ts): the leak
+    // guard for spurious TS7053 on the value read of a bracketed access.
+    let codes = check_source_strict_codes(
+        "declare const store: { slot?: { cell: { value: number } } };\nfor (store.slot?.[\"cell\"][\"value\"] in {}) {}\n",
+    );
+    assert!(codes.contains(&2405), "expected TS2405; got: {codes:?}");
+    assert!(!codes.contains(&2780), "expected no TS2780; got: {codes:?}");
+    assert!(
+        !codes.contains(&7053),
+        "value-path read must not leak TS7053 for a valid element-access chain; got: {codes:?}"
+    );
+}
+
+// =========================================================================
+// TS2780 wins: the head's real type IS string/any, so the reference-validity
+// check runs and reports the chain itself.
+// =========================================================================
+
+#[test]
+fn for_in_optional_receiver_string_leaf_emits_only_ts2780() {
+    let codes = check_source_strict_codes(
+        "declare const holder: { maybe?: { text: string } };\nfor (holder.maybe?.text in {}) {}\n",
+    );
+    assert!(
+        codes.contains(&2780),
+        "string-typed optional-chain head must emit TS2780; got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2405),
+        "a string-typed head passes the TS2405 check; got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2339),
+        "value-path read must not leak TS2339 for a valid chain; got: {codes:?}"
+    );
+}
+
+#[test]
+fn for_in_top_level_optional_access_string_typed_emits_only_ts2780() {
+    let codes = check_source_strict_codes(
+        "declare const bag: { label?: string };\nfor (bag?.label in {}) {}\n",
+    );
+    assert!(codes.contains(&2780), "expected TS2780; got: {codes:?}");
+    assert!(!codes.contains(&2405), "expected no TS2405; got: {codes:?}");
+}
+
+#[test]
+fn for_in_optional_element_access_string_leaf_emits_only_ts2780() {
+    let codes = check_source_strict_codes(
+        "declare const dict: { entry?: { name: string } };\nfor (dict.entry?.[\"name\"] in {}) {}\n",
+    );
+    assert!(codes.contains(&2780), "expected TS2780; got: {codes:?}");
+    assert!(!codes.contains(&2405), "expected no TS2405; got: {codes:?}");
+    assert!(
+        !codes.contains(&7053),
+        "value-path read must not leak TS7053; got: {codes:?}"
+    );
+}
+
+#[test]
+fn for_in_optional_any_leaf_emits_only_ts2780() {
+    // An `any`-typed leaf passes the TS2405 type check — TS2780 owns the head.
+    let codes = check_source_strict_codes(
+        "declare const anyBag: { blob?: { payload: any } };\nfor (anyBag.blob?.payload in {}) {}\n",
+    );
+    assert!(codes.contains(&2780), "expected TS2780; got: {codes:?}");
+    assert!(!codes.contains(&2405), "expected no TS2405; got: {codes:?}");
+}
+
+// =========================================================================
+// Regression guards: unaffected shapes.
+// =========================================================================
+
+#[test]
+fn for_in_non_optional_property_access_string_leaf_reports_neither() {
+    let codes = check_source_strict_codes(
+        "declare const plain: { nested: { name: string } };\nfor (plain.nested.name in {}) {}\n",
+    );
+    assert!(
+        !codes.contains(&2405) && !codes.contains(&2780),
+        "a non-optional string-typed head is valid; got: {codes:?}"
+    );
+}
+
+#[test]
+fn for_in_non_optional_property_access_number_leaf_emits_only_ts2405() {
+    // No optional chain at all: TS2405 alone must still fire for a non-string type.
+    let codes = check_source_strict_codes(
+        "declare const box: { field: { count: number } };\nfor (box.field.count in {}) {}\n",
+    );
+    assert!(codes.contains(&2405), "expected TS2405; got: {codes:?}");
+    assert!(!codes.contains(&2780), "expected no TS2780; got: {codes:?}");
+}
+
+#[test]
+fn for_of_optional_chain_still_emits_ts2781_unconditionally() {
+    // for...of's analogous check is NOT gated behind an assignability check —
+    // tsc reports TS2781 regardless of the chain's element type. This fix only
+    // changes for...in's ordering, so for...of keeps its prior behavior.
+    let codes = check_source_strict_codes(
+        "declare const outer: { mid?: { inner: { leaf: number } } };\nfor (outer.mid?.inner.leaf of []) {}\n",
+    );
+    assert!(
+        codes.contains(&2781),
+        "for-of optional-chain head must still emit TS2781; got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2405),
+        "for-of never routes through the TS2405 type gate; got: {codes:?}"
+    );
+}
+
+#[test]
+fn for_of_optional_chain_string_leaf_still_emits_ts2781() {
+    // The string-LHS control on the for...of side: still TS2781 (unconditional),
+    // never TS2780/TS2405, confirming the gating change is for...in-only.
+    let codes = check_source_strict_codes(
+        "declare const holder: { maybe?: { text: string } };\nfor (holder.maybe?.text of []) {}\n",
+    );
+    assert!(codes.contains(&2781), "expected TS2781; got: {codes:?}");
+    assert!(!codes.contains(&2780), "expected no TS2780; got: {codes:?}");
+    assert!(!codes.contains(&2405), "expected no TS2405; got: {codes:?}");
+}
+
+#[test]
+fn plain_optional_chain_assignment_target_still_emits_ts2779() {
+    // Regression guard for the write-target family (`=`), which is unrelated
+    // to for-in/for-of and must keep short-circuiting to `any` unconditionally.
+    let codes = check_source_strict_codes(
+        "declare const holder: { maybe?: { text: string } };\nholder.maybe?.text = \"x\";\n",
+    );
+    assert!(
+        codes.contains(&2779),
+        "plain optional-chain assignment target must still emit TS2779; got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2405) && !codes.contains(&2780),
+        "an assignment target is neither a for-in nor a for-of head; got: {codes:?}"
+    );
+}
+
+#[test]
+fn for_in_head_ignores_narrowing_from_prior_invalid_optional_chain_assignment() {
+    // `obj?.a = 1` is a hard error (TS2779) and records no narrowing, so the
+    // later `for (obj?.a in {})` head keeps `obj?.a`'s declared type (`any`),
+    // selecting TS2780 — not TS2405 off a bogus `1`-narrowed value. This is the
+    // discriminating shape of `propertyAccessChain.3.ts`. `obj` is `any`, so a
+    // correct read is `any`; only a spurious assignment-narrowing turns it to a
+    // number.
+    let codes =
+        check_source_strict_codes("declare const obj: any;\nobj?.a = 1;\nfor (obj?.a in {}) {}\n");
+    assert!(
+        codes.contains(&2780),
+        "an `any` head must select TS2780, ignoring the invalid prior assignment; got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2405),
+        "the invalid optional-chain assignment must not narrow the head to a number; got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&2779),
+        "the invalid optional-chain assignment target itself still emits TS2779; got: {codes:?}"
+    );
+}
+
+#[test]
+fn for_in_head_ignores_narrowing_from_prior_deep_optional_chain_assignment() {
+    // The continuation-chain spelling (`obj?.a.b`) is likewise not narrowed by
+    // its own invalid assignment — both `propertyAccessChain.3.ts` for-in heads
+    // must land on TS2780.
+    let codes = check_source_strict_codes(
+        "declare const obj: any;\nobj?.a.b = 1;\nfor (obj?.a.b in {}) {}\n",
+    );
+    assert!(codes.contains(&2780), "expected TS2780; got: {codes:?}");
+    assert!(!codes.contains(&2405), "expected no TS2405; got: {codes:?}");
+}
+
+#[test]
+fn for_in_optional_chain_increment_target_still_emits_ts2777() {
+    // The increment/decrement family (`++`) is likewise unconditional and
+    // unaffected by the for-in type gate.
+    let codes = check_source_strict_codes(
+        "declare const holder: { maybe?: { text: number } };\nholder.maybe?.text++;\n",
+    );
+    assert!(
+        codes.contains(&2777),
+        "optional-chain increment target must still emit TS2777; got: {codes:?}"
+    );
+}


### PR DESCRIPTION
Closes #16668. Relands #16660 (reverted in #16667) without the diagnostic leak that got it reverted.

**Structural rule.** When a `for...in` head is an optional chain, `tsc`'s `checkForInStatement` computes the head's real type via `checkExpression` (a READ) and reports **TS2405** ("must be of type 'string' or 'any'") when that type is not assignable from the for-in index type, otherwise reaches `checkReferenceExpression`, which reports **TS2780** ("may not be an optional property access"). The two are mutually exclusive — TS2405 wins whenever the LHS type is not string/any, TS2780 only once the type check passes. tsz previously emitted TS2780 for *any* optional-chain for-in head unconditionally, through the checker (`crates/tsz-checker/src/state/variable_checking/for_loop.rs`).

**Why #16660 was reverted, and why this reland does not leak.** #16660 computed the head type through the *write-target* path (`get_type_of_assignment_target`). A for-in optional-chain head is a write-target context, so that path short-circuits the chain to `any` (erasing the type the decision needs) and, when forced to resolve, runs write-flow probes that emitted spurious **TS2339/TS7053** on richer shapes — the leak that regressed `propertyAccessChain.3.ts` / `elementAccessChain.3.ts`. This reland reads the head through the **value path** (`get_type_of_node`), mirroring tsc's `checkExpression`: it returns the chain's genuine `T | undefined` type and emits only the diagnostics tsc itself would.

**Any-propagation.** `any` propagates through an optional chain, so a chain rooted on an `any`/error receiver is itself `any` and takes TS2780. This is checked directly on the chain root (`optional_chain_root_receiver_is_any_like`) because a preceding invalid `root?.b = <literal>` (itself TS2779) can leave a stale assigned-value type on the chain read even on a bare `any` receiver — where the non-optional `root.b = <literal>` does not narrow. The root's own type is the reliable witness of the any-propagation tsc performs; the deeper narrowing quirk is left untouched to keep the blast radius contained to for-in heads.

`for...of`'s analogous TS2781 stays unconditional (tsc's `checkForOfStatement` calls `checkReferenceExpression` regardless of the element type).

Owner layer: checker (for-in statement checking). No solver/binder changes.

### Adjacent-case matrix (oracle-verified vs `typescript@7.0.2`)

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `a.b?.c.d in {}` — number LHS | TS2405 | TS2780 | **TS2405** |
| renamed binders `zq.al?.be.ga in {}` — number | TS2405 | TS2780 | **TS2405** |
| `s.t?.u in {}` — **string** LHS | TS2780 | TS2780 | TS2780 |
| `o.p.q in {}` — plain, string | clean | clean | clean |
| `n.p.q in {}` — plain, number | TS2405 | TS2405 | TS2405 |
| `a.b?.c.d of []` | TS2781 | TS2781 | TS2781 |
| `a.b?.c.d = 1` | TS2779 | TS2779 | TS2779 |
| `obj?.a = 1; for (obj?.a in {})` (obj: `any`) | TS2780 | TS2780 | TS2780 (any-propagation) |

## Goal
Goal: hold

## Verification
- New module `crates/tsz-checker/tests/for_in_optional_chain_ts2405_vs_ts2780_tests.rs`: `cargo test -p tsz-checker --lib for_in_optional_chain_ts2405_vs_ts2780` — **16 passed, 0 failed** (includes leak guards asserting no TS2339/TS7053 on valid chains, renamed-binder cases per the anti-hardcoding rule, element-access chains, and the invalid-prior-assignment any-receiver case).
- Broad regression net: `cargo test -p tsz-checker --lib -- for_in for_of optional_chain narrowing` — **501 passed, 0 failed**.
- Conformance set-difference on the two fixtures that reverted #16660, via the built CLI at `--strict --target es2015`: both `propertyAccessChain.3.ts` and `elementAccessChain.3.ts` now produce exactly `2777,2778,2779,2780,2781` (matching the pinned `typescript@7.0.2` oracle) — no extra TS2339/TS2405/TS7053, no lost TS2780.
- All 7 oracle rows from #16668 verified end-to-end through the built CLI, matching tsc exactly.
- `cargo clippy --profile ci-lint -p tsz-checker --lib --tests -- -D warnings` — clean. `cargo fmt --all -- --check` — clean. `python3 scripts/arch/arch_guard.py` — passed.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPMLe8ymTRA3eGayWu7H7C)_