### PR TITLE
fix(checker): an invalid optional-chain write target must not seed an expando property type

### DIFF
--- a/crates/tsz-checker/src/tests/optional_chain_write_target_nullish_tests.rs
+++ b/crates/tsz-checker/src/tests/optional_chain_write_target_nullish_tests.rs
@@ -448,3 +448,53 @@ q.w.e = 1;
         vec!["'q.w' is possibly 'undefined'.".to_string()]
     );
 }
+
+#[test]
+fn ts16710_optional_chain_write_target_does_not_seed_expando_type() {
+    // #16710: `obj?.a = 1` is an invalid write target (TS2779, optional
+    // chains can never be assignment targets) and must not be read back as
+    // an expando-property declaration for later reads of `obj?.a` — tsc
+    // keeps the receiver's `any` type. Oracle-verified against
+    // `typescript@7.0.2`: TS2779 only, no TS2322.
+    let source = r#"
+declare const obj: any;
+obj?.a = 1;
+let x: string = obj?.a;
+"#;
+    assert_eq!(strict_codes(source), vec![ASSIGNMENT_TARGET]);
+}
+
+#[test]
+fn ts16710_nonoptional_write_target_control_is_unchanged() {
+    // Regression guard: the already-correct non-optional case (`obj.a = 1`
+    // never went through the expando fast path in the first place) must
+    // stay clean.
+    let source = r#"
+declare const obj: any;
+obj.a = 1;
+let x: string = obj.a;
+"#;
+    assert_eq!(strict_codes(source), Vec::<u32>::new());
+}
+
+#[test]
+fn ts16710_plain_identifier_any_control_is_unchanged() {
+    // Regression guard: plain-identifier `any` narrowing (unrelated to
+    // property access) must stay clean.
+    let source = r#"
+let x: any;
+x = 1;
+let y: string = x;
+"#;
+    assert_eq!(strict_codes(source), Vec::<u32>::new());
+}
+
+#[test]
+fn ts16710_renamed_binder_does_not_change_the_outcome() {
+    let source = r#"
+declare const holder: any;
+holder?.value = 42;
+let out: string = holder?.value;
+"#;
+    assert_eq!(strict_codes(source), vec![ASSIGNMENT_TARGET]);
+}

--- a/crates/tsz-checker/src/types/property_access_helpers/expando.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/expando.rs
@@ -1683,12 +1683,24 @@ impl<'a> CheckerState<'a> {
                 .map(|ident| ident.escaped_text.to_string()),
             syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION => {
                 let access = self.ctx.arena.get_access_expr(node)?;
+                // An optional-chain hop (`obj?.a = 1`) is never a valid
+                // assignment target (TS2779) and tsc's expando/special-property
+                // detection requires a "bindable static name expression" — a
+                // chain of plain property accesses, which an optional hop is
+                // not. Such a write must not be read back as an expando
+                // property declaration on a later access of the same name.
+                if access.question_dot_token {
+                    return None;
+                }
                 let left = self.expando_assignment_access_key(access.expression)?;
                 let right = self.ctx.arena.get_identifier_at(access.name_or_argument)?;
                 Some(format!("{left}.{}", right.escaped_text))
             }
             syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION => {
                 let access = self.ctx.arena.get_access_expr(node)?;
+                if access.question_dot_token {
+                    return None;
+                }
                 let left = self.expando_assignment_access_key(access.expression)?;
                 let right = self.expando_element_key_name(access.name_or_argument)?;
                 Some(format!("{left}.{right}"))


### PR DESCRIPTION
Fixes #16710.

`obj?.a = 1` is always an invalid assignment target (TS2779 — optional chains can never be assignment targets), but tsz's expando-property fast path for optional-chain reads on an `any`-typed receiver (`try_resolve_optional_property_chain_fast_path` -> `refine_expando_property_read_type`) walked the file for any *textual* `obj.a = <rhs>` assignment reaching the read position and used it as the property's type, without checking whether that assignment's own LHS was itself a valid ("bindable static name expression", in tsc's terms) target. `expando_assignment_access_key` built the same key `"obj.a"` for both `obj.a = 1` and `obj?.a = 1`, so the invalid write got read back as a declared expando type for later reads of `obj?.a`, narrowing it away from `any`.

**Structural rule.** tsc's special-property/expando-assignment detection requires a chain of plain (non-optional) property/element accesses on the LHS; an optional-chain hop breaks that shape, so an invalid `obj?.a = 1` write is never treated as declaring an expando property. Fixed at the owner, `crates/tsz-checker/src/types/property_access_helpers/expando.rs`'s `expando_assignment_access_key`, by returning `None` (no key, so the statement is never collected as a candidate declaration) when the property/element-access hop carries `question_dot_token`.

This mechanism is exclusive to the optional-chain fast path (`refine_expando_property_read_type` has no other caller) — the plain non-optional case never went through it, which is why `obj.a = 1; obj.a` was already correct on `main`.

**How this was found.** Filed by a prior session while addressing review feedback on #16708 (reland of #16660/#16668, the `for...in` TS2405-vs-TS2780 precedence fix): the reviewer's isolated repro showed `obj?.a = 1; for (obj?.a in {})` incorrectly reporting TS2405 instead of TS2780, because the for-in precedence probe's speculative read of the head's type saw the wrongly-narrowed `number` instead of `any`. Root-caused with a debug-build trace (`apply_flow_narrowing_with_initial_type`'s optional-chain early-return correctly returns the *declared* type unchanged — the bug is upstream of it, in what `finalize_resolved_property_access_result` receives as that declared type) to this exact mechanism.

**Adjacent-case matrix** (`crates/tsz-checker/src/tests/optional_chain_write_target_nullish_tests.rs`):

| case | tsc / expected | before | after |
| --- | --- | --- | --- |
| `obj?.a = 1; let x: string = obj?.a;` | TS2779 only | TS2779, **TS2322** | **TS2779 only** |
| `obj.a = 1; let x: string = obj.a;` (non-optional control) | clean | clean | clean (unchanged) |
| `let x: any; x = 1; let y: string = x;` (plain-identifier control) | clean | clean | clean (unchanged) |
| `holder?.value = 42; let out: string = holder?.value;` (renamed binder) | TS2779 only | TS2779, TS2322 | TS2779 only |

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib -- ts16710 optional_chain_write_target_nullish` — 26 passed, 0 failed (4 new + 22 pre-existing in the same file, including the sibling `?.` write-target nullish-receiver family from #16691).
- `cargo test -p tsz-checker --lib -- expando optional_chain property_access js_file` — 299 passed, 0 failed (broader blast-radius sweep: expando, optional-chain, property-access, and JS-file families, since expando tracking is JS-file-heavy).
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings` — clean.
- `cargo fmt -p tsz-checker -- --check` — clean.
- Pre-commit hook (fmt + clippy + architecture guard + affected-crate verification) — passed.
- Full `cargo test -p tsz-checker --lib` (~10.4k tests): running past this session's hour on the known long-tail `ts2589_tests::recursive_conditional_alias_omitted_default_transform_emits_definition_ts2589` case (documented on the coordination board as a 30+ minute outlier on some cloud seats); all other tests observed passing before the tail. Will report the final count in a follow-up comment.
- Two-sided `compare-to-parent.sh` corpus set-difference: not run this session — the change only *removes* a false narrowing of `any` for a specifically-invalid (`?.`) write-target key that could previously match, so it can only fix false positives, not introduce new ones on a syntactic shape that was already clean. Owed as a nice-to-have before merge per repo convention for solver/checker fixes in this area.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZPsB9XCaiG7bi5DLTDMko)_