### PR TITLE
fix(checker): a `typeof` operand in a type reference's type arguments is a value read (TS6133) (#16680)

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
@@ -478,33 +478,37 @@ impl<'a> CheckerState<'a> {
                 if self.missing_name_type_ref_is_bare_scoped_type_parameter(type_idx) {
                     return;
                 }
-                if !self.ctx.symbol_resolution_set.is_empty()
-                    && let Some(type_ref) = self.ctx.arena.get_type_ref(node)
-                    && let Some(sym_id) = self
-                        .resolve_type_symbol_for_lowering(type_ref.type_name)
-                        .map(tsz_binder::SymbolId)
-                    // Only check direct self-references. Transitive walks through
-                    // type_alias_reaches_resolving_alias are too aggressive: cycles
-                    // through object/interface members are productive recursion that
-                    // tsc allows without emitting TS2577.
-                    && self.ctx.symbol_resolution_set.contains(&sym_id)
-                {
-                    // For circular references, still check type arguments for missing
-                    // names. The main resolution is skipped to avoid infinite recursion,
-                    // but type arguments may contain unresolvable names that need TS2304.
-                    let arg_indices: Vec<NodeIndex> = self
-                        .ctx
-                        .arena
-                        .get_type_ref(node)
-                        .and_then(|tr| tr.type_arguments.as_ref())
-                        .map(|args| args.nodes.clone())
-                        .unwrap_or_default();
-                    for arg_idx in arg_indices {
+                // The arena is `&'a NodeArena`, so this borrow outlives the
+                // `&mut self` calls below and can be reused for both the self-
+                // reference check and the type-argument walk.
+                let type_ref = self.ctx.arena.get_type_ref(node);
+                // Only skip the main resolution for a *direct* self-reference —
+                // resolving it would recurse forever. Transitive walks through
+                // `type_alias_reaches_resolving_alias` are too aggressive: cycles
+                // through object/interface members are productive recursion that
+                // tsc allows without emitting TS2577.
+                let is_direct_self_reference = !self.ctx.symbol_resolution_set.is_empty()
+                    && type_ref
+                        .and_then(|type_ref| {
+                            self.resolve_type_symbol_for_lowering(type_ref.type_name)
+                                .map(tsz_binder::SymbolId)
+                        })
+                        .is_some_and(|sym_id| self.ctx.symbol_resolution_set.contains(&sym_id));
+                if !is_direct_self_reference {
+                    let _ = self.get_type_from_type_reference(type_idx);
+                }
+                // Walk the type arguments either way. tsc's `checkTypeReferenceNode`
+                // runs `checkSourceElement` over each argument, so an unresolvable
+                // name (TS2304) or a nested `typeof` operand — which resolves in the
+                // value namespace and reads the value it names — is checked here even
+                // when the reference itself is circular or already resolved. Without
+                // this, a `typeof x` written inside a reference's type arguments never
+                // reaches `get_type_from_type_query`, and `x` is missed as a read.
+                if let Some(args) = type_ref.and_then(|tr| tr.type_arguments.as_ref()) {
+                    for &arg_idx in &args.nodes {
                         self.check_type_for_missing_names(arg_idx);
                     }
-                    return;
                 }
-                let _ = self.get_type_from_type_reference(type_idx);
             }
             k if k == syntax_kind_ext::TYPE_QUERY => {
                 let _ = self.get_type_from_type_query(type_idx);

--- a/crates/tsz-checker/src/tests/unused_typeof_type_query_reference_tests.rs
+++ b/crates/tsz-checker/src/tests/unused_typeof_type_query_reference_tests.rs
@@ -161,12 +161,16 @@ fn a_module_local_read_by_an_exported_type_alias_query_is_used() {
 /// nothing for any of them.
 ///
 /// The `--noUnusedLocals` half of the same spelling is already correct
-/// (`const w = 1; export const y: Wrap<typeof w> = { v: 1 };` is clean), which
-/// places the remaining defect on the parameter re-scan rather than on reference
-/// tracking. Left as a failing assertion under `#[ignore]` so it flips loudly
-/// when the type-argument cell is closed rather than sitting as a silent absence.
+/// (`const w = 1; export const y: Wrap<typeof w> = { v: 1 };` is clean). The
+/// defect was in reference tracking after all: `check_type_for_missing_names`
+/// routes a top-level `typeof a` through `get_type_from_type_query` (which
+/// resolves the operand via the *tracking* value resolver and marks it read),
+/// but its `TYPE_REFERENCE` arm delegated the whole reference — type arguments
+/// included — to `get_type_from_type_reference`, whose lowering never resolves a
+/// nested `typeof` operand through the tracking path. Recursing the walk into a
+/// reference's type arguments (as tsc's `checkSourceElement` does) reaches the
+/// nested query and closes every row below.
 #[test]
-#[ignore = "type-argument-nested typeof is a separate open cell; see the module docs"]
 fn a_parameter_read_by_a_type_argument_type_query_is_used() {
     let codes = unused_codes(
         "type Wrap<T> = { v: T };\nexport function m2(a: number, b: Wrap<typeof a>) { return b; }\n",
@@ -175,6 +179,76 @@ fn a_parameter_read_by_a_type_argument_type_query_is_used() {
     assert!(
         !codes.contains(&6133),
         "a `typeof` in type-argument position reads its operand. Got: {codes:?}"
+    );
+}
+
+/// The same rule through a lib generic (`Array<typeof a>`) rather than a
+/// user-declared alias, so the fix cannot key on the `Wrap` declaration.
+#[test]
+fn a_parameter_read_by_a_type_query_in_a_lib_generic_argument_is_used() {
+    let codes = unused_codes(
+        "export function ar(alpha: number, beta: Array<typeof alpha>) { return beta; }\n",
+    );
+
+    assert!(
+        !codes.contains(&6133),
+        "a `typeof` inside `Array<...>` reads its operand. Got: {codes:?}"
+    );
+}
+
+/// A `typeof` in the *second* type argument (`Map<string, typeof a>`): the walk
+/// must visit every argument node, not just the first.
+#[test]
+fn a_parameter_read_by_a_type_query_in_a_later_type_argument_is_used() {
+    let codes = unused_codes(
+        "export function mp(gamma: number, delta: Map<string, typeof gamma>) { return delta; }\n",
+    );
+
+    assert!(
+        !codes.contains(&6133),
+        "a `typeof` in a non-first type argument reads its operand. Got: {codes:?}"
+    );
+}
+
+/// A parenthesized query inside a type argument (`Wrap<(typeof a)>`): the walk
+/// reaches the `TYPE_QUERY` through the intervening `PARENTHESIZED_TYPE`.
+#[test]
+fn a_parameter_read_by_a_parenthesized_type_argument_query_is_used() {
+    let codes = unused_codes(
+        "type Box<T> = { v: T };\nexport function pz(epsilon: number, zeta: Box<(typeof epsilon)>) { return zeta; }\n",
+    );
+
+    assert!(
+        !codes.contains(&6133),
+        "a parenthesized `typeof` in a type argument reads its operand. Got: {codes:?}"
+    );
+}
+
+/// A query nested two type-argument levels deep (`Outer<Inner<typeof a>>`): the
+/// recursion must descend through the inner reference's own type arguments.
+#[test]
+fn a_parameter_read_by_a_doubly_nested_type_argument_query_is_used() {
+    let codes = unused_codes(
+        "type Outer<T> = { o: T };\ntype Inner<T> = { i: T };\nexport function nn(eta: number, theta: Outer<Inner<typeof eta>>) { return theta; }\n",
+    );
+
+    assert!(
+        !codes.contains(&6133),
+        "a `typeof` nested inside two type-argument levels reads its operand. Got: {codes:?}"
+    );
+}
+
+/// A `typeof` in a type argument of a *return* type reference, rather than a
+/// parameter's annotation.
+#[test]
+fn a_parameter_read_by_a_type_argument_query_in_a_return_type_is_used() {
+    let codes = unused_codes(
+        "type Wrap<T> = { v: T };\nexport function rt(iota: number): Wrap<typeof iota> { return { v: iota }; }\n",
+    );
+
+    assert!(
+        !codes.contains(&6133),
+        "a `typeof` in a return-type's type argument reads its operand. Got: {codes:?}"
     );
 }
 


### PR DESCRIPTION
Fixes #16680.

When a parameter is read only by a `typeof` written inside a type reference's **type arguments** (`b: Wrap<typeof a>`, `Array<typeof a>`, `Map<string, typeof a>`), tsc treats the `typeof` operand as a value read and reports nothing; tsz falsely reported `TS6133 'a' is declared but its value is never read`. Every non-type-argument spelling (`b: typeof a`, `{ q: typeof a }`, return-type `typeof a`, body-local) was already correct.

**Structural rule.** When a `typeof e` type query appears anywhere in a type annotation, `e`'s entity name resolves in the **value** namespace and is a genuine read of the value it names (tsc's `checkTypeQuery` routes it through `checkExpressionOrQualifiedName`); tsz must mark it read. tsz does this through the checker's recursive type-annotation walk `check_type_for_missing_names` → `get_type_from_type_query`, whose operand resolution goes through the *tracking* value resolver (`resolve_value_symbol_for_lowering` → `resolve_identifier_symbol`). The bug: the walk's `TYPE_REFERENCE` arm delegated the whole reference — type arguments included — to `get_type_from_type_reference`, whose lowering never routes a nested `typeof` operand through the tracking path, so a query in type-argument position was never marked read.

**Owner layer / fix.** Recurse the walk into a reference's type arguments, matching tsc's `checkTypeReferenceNode` → `forEach(typeArguments, checkSourceElement)` and the way every other composite arm of the same function (union, tuple, array, conditional, indexed-access, type-literal) already descends into its children — `TYPE_REFERENCE` was the only composite arm that dropped its children. The circular-self-reference sub-branch already recursed the arguments for the same reason (unresolvable names still need TS2304); the two paths now share one arg walk gated on `is_direct_self_reference`. This is a reference-tracking gap, not the parameter re-scan the issue initially suspected — confirmed by instrumenting `is_parameter_only_type_referenced` (never reached for `a`) and back-tracing the tracking site in the passing sibling case.

**Adjacent matrix.** Un-ignores the acceptance row and adds coverage that a fundamental fix carries and a name-keyed one would miss: lib generic (`Array<typeof a>`), later type argument (`Map<string, typeof a>`), parenthesized query (`Box<(typeof a)>`), doubly-nested arguments (`Outer<Inner<typeof a>>`), and a return-type reference (`(): Wrap<typeof a>`). Renamed binders throughout; negative controls (unread parameter, same-named-type shadow, unrelated `typeof`) preserved.

**Fallback / sibling gap (follow-up, not in scope).** `check_type_for_missing_names` has no `IMPORT_TYPE` arm, so `import("m").Foo<typeof a>` carries the identical latent gap. Flagged for a separate change rather than expanded into an untested surface here.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib -- unused_typeof_type_query_reference_tests` — 17 passed (12 original incl. the un-ignored acceptance row + 5 new adjacent), 0 ignored.
- Targeted regression sweep (`unused`, `type_query`, `type_reference`, `missing_name`, `cannot_find`, `ts2304`, `ts2693`, `ts6133`) — 457 passed, 0 failed.
- `cargo clippy -p tsz-checker --lib` — clean; pre-commit architecture guard + local verification passed.
- Conformance snapshot vs `main` baseline (SHA dc9d656): **+15 fixed, 0 real regressions** (11499 → 11512 pass). Fixes include the exact corpus witness `compiler/unusedParameterUsedInTypeOf.ts`, plus overload/generic-inference rows whose signature type arguments are now walked. The one flipped row (`arbitraryModuleNamespaceIdentifiers_syntax.ts`) is a **fingerprint-only** diff — a parser `TS1003` position on `export { "s" as baz }` specifiers (codes match both sides), architecturally unreachable from this checker change and consistent with the non-reproducible-diagnostics flakiness tracked in #16309.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFSrD9562WRMLosKhvUfbZ)_