### PR TITLE
fix(checker): duplicate default-exported function implementations report TS2323, not TS2528

### DIFF
--- a/crates/tsz-checker/src/declarations/import/core/module_exports.rs
+++ b/crates/tsz-checker/src/declarations/import/core/module_exports.rs
@@ -805,6 +805,14 @@ impl<'a> CheckerState<'a> {
                             diagnostic_codes::A_MODULE_CANNOT_HAVE_MULTIPLE_DEFAULT_EXPORTS,
                         );
                     }
+                } else if has_function && !has_interface && value_count == function_value_count {
+                    // Every conflicting default export is a function declaration.
+                    // tsc binds each of them to the single `default` export
+                    // symbol regardless of the local name, so the
+                    // multiple-default complaint (TS2528) never fires for this
+                    // shape: duplicate bodies surface as TS2323 + TS2393 (the
+                    // shared block below), and a run of signature-only groups
+                    // is left to overload validation.
                 } else {
                     // Fallback: TS2528 "A module cannot have multiple default exports"
                     // Skip interface declarations when a function or class exists
@@ -829,11 +837,18 @@ impl<'a> CheckerState<'a> {
                     }
                 }
 
-                // TS2393: Duplicate function implementation.
-                // When multiple `export default function` declarations have bodies,
-                // tsc emits TS2393 on each, regardless of whether they are named or anonymous.
+                // TS2393 + TS2323: duplicate default function implementations.
+                // When two or more `export default function` declarations carry
+                // bodies, tsc treats them as duplicate implementations of the one
+                // merged `default` symbol: TS2393 goes on *every* function
+                // declaration in the set (overload signatures included), and
+                // TS2323 on each declaration that carries a body — never on a
+                // signature. Both anchor at the function name (or the statement
+                // when anonymous). TS2323 is owned by the class/interface/named
+                // arms above when those shapes are present, so it is only added
+                // here for the function-only and function+value-expression arms.
                 if has_function {
-                    let func_impls: Vec<NodeIndex> = effective_default_indices
+                    let func_decls: Vec<(NodeIndex, bool)> = effective_default_indices
                         .iter()
                         .filter_map(|&idx| {
                             let ed = self.ctx.arena.get_export_decl_at(idx)?;
@@ -842,14 +857,24 @@ impl<'a> CheckerState<'a> {
                                 return None;
                             }
                             let func = self.ctx.arena.get_function(clause_node)?;
-                            if func.body.is_some() { Some(idx) } else { None }
+                            Some((idx, func.body.is_some()))
                         })
                         .collect();
+                    let impl_count = func_decls.iter().filter(|(_, has_body)| *has_body).count();
 
-                    if func_impls.len() > 1 {
-                        for &impl_idx in &func_impls {
-                            self.error_at_node(
-                                impl_idx,
+                    if impl_count > 1 {
+                        let emit_redeclare =
+                            !has_class && !has_interface && !has_named_default_export;
+                        for &(decl_idx, has_body) in &func_decls {
+                            if emit_redeclare && has_body {
+                                self.error_at_default_export_anchor(
+                                    decl_idx,
+                                    "Cannot redeclare exported variable 'default'.",
+                                    diagnostic_codes::CANNOT_REDECLARE_EXPORTED_VARIABLE,
+                                );
+                            }
+                            self.error_at_default_export_anchor(
+                                decl_idx,
                                 diagnostic_messages::DUPLICATE_FUNCTION_IMPLEMENTATION,
                                 diagnostic_codes::DUPLICATE_FUNCTION_IMPLEMENTATION,
                             );
@@ -1079,16 +1104,42 @@ impl<'a> CheckerState<'a> {
         use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
 
         // TS2323: "Cannot redeclare exported variable 'default'." on every declaration
-        for &export_idx in export_default_indices {
-            let message = format_message(
-                diagnostic_messages::CANNOT_REDECLARE_EXPORTED_VARIABLE,
-                &["default"],
-            );
-            self.error_at_default_export_anchor(
-                export_idx,
-                &message,
-                diagnostic_codes::CANNOT_REDECLARE_EXPORTED_VARIABLE,
-            );
+        // that contributes a value: a class, or a function declaration carrying a
+        // body. Overload signatures never redeclare anything, so a signature-only
+        // function set beside a class reports the merge family alone.
+        let value_sites: Vec<NodeIndex> = export_default_indices
+            .iter()
+            .copied()
+            .filter(|&export_idx| {
+                let Some(clause_node) = self
+                    .ctx
+                    .arena
+                    .get_export_decl_at(export_idx)
+                    .and_then(|ed| self.ctx.arena.get(ed.export_clause))
+                else {
+                    return true;
+                };
+                if clause_node.kind != syntax_kind_ext::FUNCTION_DECLARATION {
+                    return true;
+                }
+                self.ctx
+                    .arena
+                    .get_function(clause_node)
+                    .is_some_and(|func| func.body.is_some())
+            })
+            .collect();
+        if value_sites.len() > 1 {
+            for &export_idx in &value_sites {
+                let message = format_message(
+                    diagnostic_messages::CANNOT_REDECLARE_EXPORTED_VARIABLE,
+                    &["default"],
+                );
+                self.error_at_default_export_anchor(
+                    export_idx,
+                    &message,
+                    diagnostic_codes::CANNOT_REDECLARE_EXPORTED_VARIABLE,
+                );
+            }
         }
 
         // TS2813: "Class declaration cannot implement overload list for 'default'." on class

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -899,6 +899,8 @@ mod ts2322_readonly_array_element_elaboration_tests;
 mod ts2322_same_generic_type_argument_elaboration_tests;
 #[path = "tests/ts2323_block_scoped_conflict_message_tests.rs"]
 mod ts2323_block_scoped_conflict_message_tests;
+#[path = "tests/ts2323_default_export_duplicate_implementation_tests.rs"]
+mod ts2323_default_export_duplicate_implementation_tests;
 #[path = "tests/ts2323_export_var_namespace_merge_tests.rs"]
 mod ts2323_export_var_namespace_merge_tests;
 #[path = "tests/ts2323_mixed_exportedness_two_table_tests.rs"]

--- a/crates/tsz-checker/src/tests/ts2323_default_export_duplicate_implementation_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2323_default_export_duplicate_implementation_tests.rs
@@ -1,0 +1,278 @@
+//! Regression tests for the `TS2323`/`TS2393`/`TS2528` classification of
+//! duplicate default-exported function implementations (#16719).
+//!
+//! Structural rule (pinned against `typescript@7.0.2`, the conformance pin):
+//! tsc binds every `export default function` declaration — whatever its local
+//! name — to the single `default` export symbol, so a module whose conflicting
+//! default exports are all function declarations never reports `TS2528`.
+//! Duplicate bodies surface instead as the redeclare family:
+//!
+//! - `TS2393` ("Duplicate function implementation.") on **every** function
+//!   declaration in the set, overload signatures included, once two or more
+//!   declarations carry bodies;
+//! - `TS2323` ("Cannot redeclare exported variable 'default'.") on each
+//!   declaration that **carries a body** — never on a signature.
+//!
+//! Both anchor at the function name, or at the statement when the function is
+//! anonymous. When a non-function default export is also present, `TS2528`
+//! still fires at every default site alongside the redeclare family. In the
+//! function/class merge arm, `TS2323` likewise marks only value sites (bodies
+//! and the class), so a signature-only overload set beside a class reports the
+//! merge family alone.
+//!
+//! tsz decides all of this in the checker's export-default pass
+//! (`declarations/import/core/module_exports.rs`).
+//!
+//! Every row below was measured against the pin with
+//! `--strict false --module commonjs --target es2015`. Binder names are varied
+//! across rows: the rule is structural, so no row may depend on a particular
+//! identifier spelling. Known, deliberately unasserted gap: tsc also runs
+//! overload-consistency validation over the merged `default` symbol
+//! (`TS2391`/`TS2394` on signature-only groups); tsz does not yet.
+
+use crate::context::ScriptTarget;
+use crate::test_utils::{DiagnosticShape, assert_diagnostic_shapes_exactly, check_source};
+use crate::{CheckerOptions, diagnostics::Diagnostic};
+
+fn check_module(source: &str) -> Vec<Diagnostic> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            target: ScriptTarget::ES2015,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+fn codes(source: &str) -> Vec<u32> {
+    check_module(source)
+        .into_iter()
+        .map(|diagnostic| diagnostic.code)
+        .collect()
+}
+
+/// The issue witness: two same-named implementations are duplicate
+/// implementations of the one `default` symbol, not multiple default exports.
+///
+/// ```text
+/// tsc: (1,25) TS2323 + TS2393, (2,25) TS2323 + TS2393
+/// ```
+#[test]
+fn two_same_named_implementations_report_the_redeclare_family() {
+    let source = "export default function handler(x: string) { return x; }\n\
+                  export default function handler(x: number) { return x; }\n";
+    assert_diagnostic_shapes_exactly(
+        source,
+        &check_module(source),
+        &[
+            DiagnosticShape::code(2323).at(1, 25),
+            DiagnosticShape::code(2393).at(1, 25),
+            DiagnosticShape::code(2323).at(2, 25),
+            DiagnosticShape::code(2393).at(2, 25),
+        ],
+    );
+}
+
+/// The local names do not matter — tsc merges by the export name `default`,
+/// so differently-named implementations are the exact same conflict.
+#[test]
+fn differently_named_implementations_are_the_same_conflict() {
+    let source = "export default function alpha(a: string): string { return a; }\n\
+                  export default function omega(a: number): number { return a; }\n";
+    assert_diagnostic_shapes_exactly(
+        source,
+        &check_module(source),
+        &[
+            DiagnosticShape::code(2323).at(1, 25),
+            DiagnosticShape::code(2393).at(1, 25),
+            DiagnosticShape::code(2323).at(2, 25),
+            DiagnosticShape::code(2393).at(2, 25),
+        ],
+    );
+}
+
+/// A signature in the run gets `TS2393` (tsc marks every declaration of the
+/// merged symbol) but never `TS2323` (a signature redeclares nothing).
+#[test]
+fn an_overload_signature_gets_ts2393_but_never_ts2323() {
+    let source = "export default function make(a: string): string;\n\
+                  export default function make(a: string | number) { return a; }\n\
+                  export default function build(a: number): number { return a; }\n";
+    assert_diagnostic_shapes_exactly(
+        source,
+        &check_module(source),
+        &[
+            DiagnosticShape::code(2393).at(1, 25),
+            DiagnosticShape::code(2323).at(2, 25),
+            DiagnosticShape::code(2393).at(2, 25),
+            DiagnosticShape::code(2323).at(3, 25),
+            DiagnosticShape::code(2393).at(3, 25),
+        ],
+    );
+}
+
+/// Anonymous implementations anchor at the statement, exactly like tsc.
+#[test]
+fn anonymous_implementations_anchor_at_the_statement() {
+    let source = "export default function (a: string) { return a; }\n\
+                  export default function (a: number) { return a; }\n";
+    assert_diagnostic_shapes_exactly(
+        source,
+        &check_module(source),
+        &[
+            DiagnosticShape::code(2323).at(1, 1),
+            DiagnosticShape::code(2393).at(1, 1),
+            DiagnosticShape::code(2323).at(2, 1),
+            DiagnosticShape::code(2393).at(2, 1),
+        ],
+    );
+}
+
+/// With at most one body across multiple signature groups nothing in this
+/// family fires: no `TS2528` (all defaults are functions), no `TS2323`, and no
+/// `TS2393` (only one implementation).
+#[test]
+fn signature_only_groups_report_nothing_from_the_default_export_pass() {
+    let source = "export default function req(a: string): string;\n\
+                  export default function res(a: number): number;\n\
+                  export default function res(a: number): number { return a; }\n";
+    let observed = codes(source);
+    for code in [2528, 2323, 2393] {
+        assert_eq!(
+            observed.iter().filter(|c| **c == code).count(),
+            0,
+            "a run of signature groups with one body is left to overload \
+             validation; TS{code} must not fire. Got: {observed:?}"
+        );
+    }
+}
+
+/// Two bodyless signatures with different names likewise stay clear of the
+/// multiple-default complaint entirely.
+#[test]
+fn two_signature_only_defaults_never_report_ts2528() {
+    let source = "export default function first(a: string): string;\n\
+                  export default function second(a: number): number;\n";
+    let observed = codes(source);
+    for code in [2528, 2323, 2393] {
+        assert_eq!(
+            observed.iter().filter(|c| **c == code).count(),
+            0,
+            "two signature-only defaults are one merged symbol short of an \
+             implementation, not a conflict; TS{code} must not fire. \
+             Got: {observed:?}"
+        );
+    }
+}
+
+/// The same rule holds inside an ambient module, where no declaration can
+/// carry a body at all.
+#[test]
+fn ambient_module_signature_defaults_stay_clean() {
+    let source = "declare module \"remote\" {\n\
+                  \x20   export default function connect(host: string): void;\n\
+                  \x20   export default function listen(port: number): void;\n\
+                  }\n";
+    let observed = codes(source);
+    assert_eq!(
+        observed.iter().filter(|c| **c == 2528).count(),
+        0,
+        "ambient signature-only defaults merge into one symbol. Got: {observed:?}"
+    );
+}
+
+/// Positive control: a non-function default beside two implementations keeps
+/// `TS2528` at every default site, on top of the redeclare family.
+///
+/// ```text
+/// tsc: (1,25) TS2323 + TS2393 + TS2528, (2,25) TS2323 + TS2393 + TS2528,
+///      (3,1) TS2528
+/// ```
+#[test]
+fn a_value_default_beside_two_implementations_keeps_ts2528_everywhere() {
+    let source = "export default function render(a: string) { return a; }\n\
+                  export default function paint(a: number) { return a; }\n\
+                  export default 1;\n";
+    assert_diagnostic_shapes_exactly(
+        source,
+        &check_module(source),
+        &[
+            DiagnosticShape::code(2323).at(1, 25),
+            DiagnosticShape::code(2393).at(1, 25),
+            DiagnosticShape::code(2528).at(1, 25),
+            DiagnosticShape::code(2323).at(2, 25),
+            DiagnosticShape::code(2393).at(2, 25),
+            DiagnosticShape::code(2528).at(2, 25),
+            DiagnosticShape::code(2528).at(3, 1),
+        ],
+    );
+}
+
+/// Function/class merge arm: a signature-only overload set beside a class has
+/// no value site pair, so no `TS2323` fires — only the merge family.
+#[test]
+fn a_signature_only_function_beside_a_class_reports_no_redeclare() {
+    let source = "export default function zeta(a: string): string;\n\
+                  export default class Store {}\n";
+    let observed = codes(source);
+    assert_eq!(
+        observed.iter().filter(|c| **c == 2323).count(),
+        0,
+        "a signature redeclares nothing, and one class alone is not a \
+         redeclaration pair. Got: {observed:?}"
+    );
+    assert!(
+        observed.contains(&2813) && observed.contains(&2814),
+        "the merge family itself still fires. Got: {observed:?}"
+    );
+}
+
+/// Function/class merge arm: the body and the class are the two value sites;
+/// the signature in front of them still gets no `TS2323`.
+///
+/// ```text
+/// tsc: (1,25) TS2814, (2,25) TS2323 + TS2814, (3,22) TS2323 + TS2813
+/// ```
+#[test]
+fn a_signature_in_a_function_class_merge_gets_no_redeclare() {
+    let source = "export default function open(a: string): string;\n\
+                  export default function open(a: string) { return a; }\n\
+                  export default class Session {}\n";
+    assert_diagnostic_shapes_exactly(
+        source,
+        &check_module(source),
+        &[
+            DiagnosticShape::code(2814).at(1, 25),
+            DiagnosticShape::code(2323).at(2, 25),
+            DiagnosticShape::code(2814).at(2, 25),
+            DiagnosticShape::code(2323).at(3, 22),
+            DiagnosticShape::code(2813).at(3, 22),
+        ],
+    );
+}
+
+/// Guard: a single implementation beside a class keeps both redeclare sites —
+/// the value-site filter must not eat the plain function/class conflict.
+#[test]
+fn an_implementation_beside_a_class_keeps_both_redeclare_sites() {
+    let source = "export default function fetch_(a: string) { return a; }\n\
+                  export default class Client {}\n";
+    let observed = codes(source);
+    assert_eq!(
+        observed.iter().filter(|c| **c == 2323).count(),
+        2,
+        "one body plus one class are two value sites. Got: {observed:?}"
+    );
+}
+
+/// Guard: a lone default-exported implementation reports nothing at all.
+#[test]
+fn a_single_default_implementation_stays_clean() {
+    let source = "export default function only(a: string) { return a; }\n";
+    assert_eq!(
+        codes(source),
+        Vec::<u32>::new(),
+        "one default export is no conflict"
+    );
+}


### PR DESCRIPTION
Fixes #16719 (Aventurine's handoff from #16714).

## Goal
Goal: hold

## Structural rule

When every conflicting default export in a module is a function declaration, tsc binds each of them — whatever its local name — to the single `default` export symbol, so the multiple-default complaint (`TS2528`) never fires for that shape; tsz now does the same through the checker's export-default pass (`crates/tsz-checker/src/declarations/import/core/module_exports.rs`). Duplicate bodies surface as the redeclare family instead:

- `TS2393` ("Duplicate function implementation.") on **every** function declaration in the set — overload signatures included — once ≥2 declarations carry bodies, anchored at the function name (statement when anonymous). Previously tsz marked only the body-carrying statements, anchored at column 1.
- `TS2323` ("Cannot redeclare exported variable 'default'.") on each declaration that **carries a body**, never on a signature. Previously missing entirely in the function-only shape.
- When a non-function default (`export default 1`) is also present, `TS2528` still fires at every default site alongside the redeclare family (previously the redeclare family was missing there).
- The function/class merge arm follows the same value-site rule: `TS2323` marks bodies and the class only, and only when there are ≥2 value sites — a signature-only overload set beside a class reports just the merge family (`TS2391`+`TS2813`/`TS2814` in tsc; tsz previously added two spurious `TS2323`).

Three edits, all in `module_exports.rs`: a new no-op arm in the `is_conflict` chain for the all-function shape (suppresses the fallback `TS2528`), the shared `TS2393` block extended to signatures/name anchors and now also emitting the body-site `TS2323` (gated off when the class/interface/named arms own `TS2323`), and a value-site filter in `emit_function_class_default_merge_errors`.

## Adjacent-case matrix

22 fixtures, all oracle-pinned against `typescript@7.0.2` (the conformance pin) with `--noEmit --strict false --module commonjs --target es2015`, diffed byte-for-byte (file/line/col/code/message):

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| 2 same-name impls (issue witness) | TS2323 x2 + TS2393 x2 | TS2393 x2 (wrong anchor) + TS2528 x2 | **identical** |
| 2 different-name impls | TS2323 x2 + TS2393 x2 | TS2393 x2 + TS2528 x2 | **identical** |
| 3 same-name impls | family x3 | TS2528 x3 + TS2393 x3 | **identical** |
| 2 anonymous impls / anon+named | family x2, statement anchor | TS2528 + wrong mix | **identical** |
| sig + impl + impl (renamed binders) | TS2393 x3, TS2323 at the 2 bodies | TS2528 x3 + TS2393 x2 | **identical** |
| impl + sig + impl | TS2393 x3, TS2323 at bodies (+TS2394) | TS2528 x3 + TS2393 x2 | identical except missing TS2394 (pre-existing gap, see below) |
| 2 impls + `export default 1` | TS2323 x2 + TS2393 x2 + TS2528 x3 | TS2528 x3 + TS2393 x2 | **identical** |
| sig + impl + impl + `export default 1` | TS2393 x3 + TS2323 x2 + TS2528 x4 | TS2528 x4 + TS2393 x2 | **identical** |
| `f(sig); g(sig); g(impl)` (issue's related row) | TS2391 + TS2394 | **TS2528 x3** | clean (missing TS2391/TS2394, pre-existing gap) |
| 2 sig-only defaults | TS2391 x2 | **TS2528 x2** | clean (missing TS2391 x2, pre-existing gap) |
| ambient module, 2 sig-only defaults | clean | **TS2528 x2** | **identical (clean)** |
| overload set (3 sigs + impl) | clean | clean (#16714) | **identical (clean)** |
| overload set + `export default 1` | TS2528 x3 | TS2528 x3 | **identical** |
| interface + 2 impls | TS2323 x3 + TS2393 x2 | TS2393 anchor off | **identical** |
| sig-only + class | TS2391 + TS2813 + TS2814 | **TS2323 x2 extra** | identical except missing TS2391 |
| 1 impl + class | TS2323 x2 + TS2813 + TS2814 | identical | **identical** (guarded) |
| sig + impl + class | TS2814 x2 + TS2323 x2 + TS2813 | **TS2323 x3** (extra at sig) | **identical** |
| sig + 2 impls + class | TS2323 at bodies+class, TS2393 x3, TS2813/14 | extra TS2323 at sig, TS2393 x2 wrong anchor | **identical** |
| single default impl | clean | clean | **identical (clean)** (negative control) |

16/22 rows byte-identical after (was 7/22); the remaining 6 diverge **only by missing** `TS2391`/`TS2394` (5 rows) and the pre-existing two-default-interface `TS2528` divergence (1 row) — zero extra diagnostics remain in any row of the family. The `TS2391`/`TS2394` gap is tsc's overload-consistency validation running over the merged `default` symbol, machinery tsz does not yet route default-exported functions through — pre-existing (tsz emitted nothing there before either), filed as #16729. Same for two default-exported *interfaces* (tsc: clean; tsz: TS2528 x2), filed as #16730, untouched here.

## Scope argument

The `TS2528` suppression fires only when `has_function && !has_interface && value_count == function_value_count` inside an already-detected conflict — i.e. every counted value is a function declaration — so it cannot change any row containing a class, interface, named default export, or expression default. tsc provably never emits TS2528 for that shape (oracle rows above, incl. ambient). The new `TS2323`/`TS2393` emissions are gated on ≥2 function bodies, and the positive control pins TS2528 still firing on every site when a genuine non-function default is present.

## Verification

- New suite `cargo test -p tsz-checker --lib -- ts2323_default_export_duplicate_implementation`: **12/12**.
- `cargo test -p tsz-checker --lib -- ts2528 ts2323 default_export export_default multiple_default`: **136/136**.
- `cargo test -p tsz-checker --lib -- ts2393 overload duplicate_function`: **355/355**.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean. `cargo fmt`: clean. `python3 scripts/arch/arch_guard.py`: passes.
- 22-fixture oracle diff (table above): 7/22 → 16/22 byte-identical, 0 extra diagnostics remaining.
- `scripts/conformance/compare-to-parent.sh` (two-sided, HEAD vs parent): running at PR-open time on this seat; result will be posted as a comment when it completes. Scope argument above bounds the risk in the interim.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-fable-5
Effort: high
AgentName: Nephrite (posted as "Obsidian" before discovering the roster collision; renamed per the board's later-claimant-renames rule)