### PR TITLE
fix(checker): an all-function default-export run reports TS2323/TS2393, never TS2528 (#16719)

### DIFF
--- a/crates/tsz-checker/src/declarations/import/core/module_exports.rs
+++ b/crates/tsz-checker/src/declarations/import/core/module_exports.rs
@@ -503,6 +503,8 @@ impl<'a> CheckerState<'a> {
             let mut function_value_count = 0;
             let mut function_name: Option<String> = None;
             let mut function_name_has_body = false;
+            let mut all_function_defaults = true;
+            let mut function_body_count = 0usize;
             // How many of `effective_default_indices` are repeat overload
             // signatures of a function default already counted above. See the
             // `distinct_default_count` comment below.
@@ -522,6 +524,7 @@ impl<'a> CheckerState<'a> {
                 match wrapped_kind {
                     Some(k) if k == syntax_kind_ext::INTERFACE_DECLARATION => {
                         has_interface = true;
+                        all_function_defaults = false;
                     }
                     Some(k) if k == syntax_kind_ext::FUNCTION_DECLARATION => {
                         has_function = true;
@@ -535,6 +538,9 @@ impl<'a> CheckerState<'a> {
                         let name =
                             function_data.map(|f| self.node_text(f.name).unwrap_or_default());
                         let has_body = function_data.is_some_and(|f| !f.body.is_none());
+                        if has_body {
+                            function_body_count += 1;
+                        }
                         match (&function_name, name) {
                             (None, Some(n)) if !n.is_empty() => {
                                 function_name = Some(n);
@@ -566,9 +572,11 @@ impl<'a> CheckerState<'a> {
                     Some(k) if k == syntax_kind_ext::CLASS_DECLARATION => {
                         has_class = true;
                         value_count += 1;
+                        all_function_defaults = false;
                     }
                     _ => {
                         value_count += 1;
+                        all_function_defaults = false;
                     }
                 }
             }
@@ -595,7 +603,42 @@ impl<'a> CheckerState<'a> {
             let is_conflict =
                 value_count > 1 || (distinct_default_count > 1 && !interface_can_merge);
             if is_conflict {
-                if has_function && has_class {
+                if all_function_defaults {
+                    // A run of default-exported function declarations binds one
+                    // exported `default` symbol regardless of the declared
+                    // names, so tsc never reports TS2528 here. Conflicts
+                    // surface through the duplicate-implementation family
+                    // instead: with two or more bodies in the run, every
+                    // declaration that carries a body redeclares the exported
+                    // binding (TS2323) and every declaration in the run —
+                    // overload signatures included — is a duplicate
+                    // implementation site (TS2393). With at most one body the
+                    // run is an overload set and this pass reports nothing;
+                    // TS2391/TS2394 belong to function implementation checking.
+                    if function_body_count > 1 {
+                        for &export_idx in &effective_default_indices {
+                            let has_body = self
+                                .ctx
+                                .arena
+                                .get_export_decl_at(export_idx)
+                                .and_then(|ed| self.ctx.arena.get(ed.export_clause))
+                                .and_then(|n| self.ctx.arena.get_function(n))
+                                .is_some_and(|f| !f.body.is_none());
+                            if has_body {
+                                self.error_at_default_export_anchor(
+                                    export_idx,
+                                    "Cannot redeclare exported variable 'default'.",
+                                    diagnostic_codes::CANNOT_REDECLARE_EXPORTED_VARIABLE,
+                                );
+                            }
+                            self.error_at_default_export_anchor(
+                                export_idx,
+                                diagnostic_messages::DUPLICATE_FUNCTION_IMPLEMENTATION,
+                                diagnostic_codes::DUPLICATE_FUNCTION_IMPLEMENTATION,
+                            );
+                        }
+                    }
+                } else if has_function && has_class {
                     // When function + class both export as default, tsc emits
                     // TS2323 + TS2813 + TS2814 (merge conflict diagnostics).
                     self.emit_function_class_default_merge_errors(&effective_default_indices);
@@ -831,8 +874,10 @@ impl<'a> CheckerState<'a> {
 
                 // TS2393: Duplicate function implementation.
                 // When multiple `export default function` declarations have bodies,
-                // tsc emits TS2393 on each, regardless of whether they are named or anonymous.
-                if has_function {
+                // tsc emits TS2393 on each, regardless of whether they are named or
+                // anonymous. The all-function arm above already owns TS2393 for a
+                // pure-function run (where signatures are duplicate sites too).
+                if has_function && !all_function_defaults {
                     let func_impls: Vec<NodeIndex> = effective_default_indices
                         .iter()
                         .filter_map(|&idx| {

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -899,6 +899,8 @@ mod ts2322_readonly_array_element_elaboration_tests;
 mod ts2322_same_generic_type_argument_elaboration_tests;
 #[path = "tests/ts2323_block_scoped_conflict_message_tests.rs"]
 mod ts2323_block_scoped_conflict_message_tests;
+#[path = "tests/ts2323_default_export_dual_implementation_tests.rs"]
+mod ts2323_default_export_dual_implementation_tests;
 #[path = "tests/ts2323_export_var_namespace_merge_tests.rs"]
 mod ts2323_export_var_namespace_merge_tests;
 #[path = "tests/ts2323_mixed_exportedness_two_table_tests.rs"]

--- a/crates/tsz-checker/src/tests/ts2323_default_export_dual_implementation_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2323_default_export_dual_implementation_tests.rs
@@ -1,0 +1,230 @@
+//! Regression tests for the all-function default-export run (`TS2323` vs
+//! `TS2528`), issue #16719.
+//!
+//! Structural rule (pinned against `typescript@7.0.2`, the conformance pin):
+//! a run of `export default function` declarations — regardless of the names
+//! they declare — binds **one** exported `default` symbol, so tsc never
+//! reports `TS2528` ("A module cannot have multiple default exports") for a
+//! module whose default exports are all function declarations. Conflicts
+//! inside the run surface through the duplicate-implementation family
+//! instead: with two or more bodies, every declaration that carries a body
+//! redeclares the exported binding (`TS2323`, "Cannot redeclare exported
+//! variable 'default'.") and every declaration in the run — overload
+//! signatures included — is a duplicate implementation site (`TS2393`). With
+//! at most one body the run is an overload set and the export-default pass
+//! reports nothing.
+//!
+//! tsz decides this in the checker's export-default pass
+//! (`declarations/import/core/module_exports.rs`), in a dedicated emission
+//! arm ahead of the mixed-kind arms. The mixed-kind arms (function + class,
+//! function + expression, ...) are untouched: `export default function`
+//! beside `export default 1` still reports `TS2528` at every site.
+//!
+//! Diagnostics are asserted by (offset, code) pairs, not code counts alone: a
+//! count cannot tell "two sites" from "one site reported twice", and tsc
+//! anchors these at the function *name* (or the statement for an anonymous
+//! function), which the pre-fix code got wrong for `TS2393`.
+//!
+//! Every row below was measured against the pin with
+//! `--strict false --module commonjs --target es2015`. Binder names vary
+//! across rows: the rule is structural, so no row may depend on a particular
+//! identifier spelling.
+
+use crate::context::ScriptTarget;
+use crate::test_utils::check_source;
+use crate::{CheckerOptions, diagnostics::Diagnostic};
+
+fn check_module(source: &str) -> Vec<Diagnostic> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            target: ScriptTarget::ES2015,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+/// The (offset, code) pairs of every emitted diagnostic, sorted.
+fn sites(source: &str) -> Vec<(u32, u32)> {
+    let mut sites: Vec<(u32, u32)> = check_module(source)
+        .into_iter()
+        .map(|diagnostic| (diagnostic.start, diagnostic.code))
+        .collect();
+    sites.sort_unstable();
+    sites
+}
+
+/// Byte offset of the `nth` occurrence (0-based) of `needle` in `source`.
+fn offset_of(source: &str, needle: &str, nth: usize) -> u32 {
+    let mut from = 0;
+    for _ in 0..=nth {
+        let found = source[from..]
+            .find(needle)
+            .unwrap_or_else(|| panic!("occurrence {nth} of {needle:?} not found"));
+        from += found + 1;
+    }
+    (from - 1) as u32
+}
+
+/// The issue witness: two same-named implementations. tsc reports `TS2323` +
+/// `TS2393` at each function name and no `TS2528`.
+///
+/// ```text
+/// tsc: (1,25) TS2323, (1,25) TS2393, (2,25) TS2323, (2,25) TS2393
+/// ```
+#[test]
+fn two_same_named_default_implementations_redeclare_the_exported_binding() {
+    let source = "export default function handler(x: string) { return x; }\n\
+                  export default function handler(x: number) { return x; }\n";
+    let first = offset_of(source, "handler", 0);
+    let second = offset_of(source, "handler", 1);
+
+    assert_eq!(
+        sites(source),
+        vec![(first, 2323), (first, 2393), (second, 2323), (second, 2393)],
+        "duplicate default implementations are TS2323 + TS2393 at each name, never TS2528"
+    );
+}
+
+/// The names do not have to match: the exported binding is `default` either
+/// way, so two different-named implementations conflict identically.
+#[test]
+fn two_different_named_default_implementations_conflict_the_same_way() {
+    let source = "export default function alpha(a: string): string { return a; }\n\
+                  export default function omega(a: number): number { return a; }\n";
+    let first = offset_of(source, "alpha", 0);
+    let second = offset_of(source, "omega", 0);
+
+    assert_eq!(
+        sites(source),
+        vec![(first, 2323), (first, 2393), (second, 2323), (second, 2393)],
+        "the conflict is on the exported `default` binding, not the declared names"
+    );
+}
+
+/// Three implementations mark every site — the rule is per declaration, not
+/// "everything after the first".
+#[test]
+fn a_three_implementation_run_marks_every_site() {
+    let source = "export default function f(a: string) { return a; }\n\
+                  export default function g(a: number) { return a; }\n\
+                  export default function h(a: boolean) { return a; }\n";
+    let expected: Vec<(u32, u32)> = {
+        let mut expected = Vec::new();
+        for name in ["function f", "function g", "function h"] {
+            let offset = offset_of(source, name, 0) + "function ".len() as u32;
+            expected.push((offset, 2323));
+            expected.push((offset, 2393));
+        }
+        expected.sort_unstable();
+        expected
+    };
+
+    assert_eq!(sites(source), expected);
+}
+
+/// An overload signature mixed into a dual-implementation run gets `TS2393`
+/// but not `TS2323` — only declarations that carry a body redeclare the
+/// exported binding.
+///
+/// ```text
+/// tsc: (1,25) TS2393, (2,25) TS2323, (2,25) TS2393, (3,25) TS2323, (3,25) TS2393
+/// ```
+#[test]
+fn a_signature_in_a_dual_implementation_run_is_a_duplicate_site_but_not_a_redeclaration() {
+    let source = "export default function build(a: string): string;\n\
+                  export default function build(a: any): any { return a; }\n\
+                  export default function make(a: number): number { return a; }\n";
+    let signature = offset_of(source, "build", 0);
+    let first_impl = offset_of(source, "build", 1);
+    let second_impl = offset_of(source, "make", 0);
+
+    assert_eq!(
+        sites(source),
+        vec![
+            (signature, 2393),
+            (first_impl, 2323),
+            (first_impl, 2393),
+            (second_impl, 2323),
+            (second_impl, 2393)
+        ],
+        "TS2323 is per body; TS2393 covers signatures in the run too"
+    );
+}
+
+/// Anonymous default functions anchor at the statement instead of a name and
+/// conflict the same way.
+#[test]
+fn two_anonymous_default_implementations_anchor_at_the_statements() {
+    let source = "export default function (x: string) { return x; }\n\
+                  export default function (x: number) { return x; }\n";
+    let first = offset_of(source, "export", 0);
+    let second = offset_of(source, "export", 1);
+
+    assert_eq!(
+        sites(source),
+        vec![(first, 2323), (first, 2393), (second, 2323), (second, 2393)],
+        "anonymous implementations conflict identically, anchored at the statement"
+    );
+}
+
+/// A cross-name run with at most one body is still an overload set of the
+/// merged `default` symbol as far as this pass is concerned: no `TS2323`, no
+/// `TS2528`. (tsc's residual `TS2391`/`TS2394` for the unimplemented
+/// signature belong to function-implementation checking, a different owner.)
+#[test]
+fn a_cross_name_run_with_one_body_reports_no_default_export_conflict() {
+    let source = "export default function first(a: string): string;\n\
+                  export default function second(a: number): number;\n\
+                  export default function second(a: number): number { return a; }\n";
+    let observed = sites(source);
+
+    assert!(
+        !observed
+            .iter()
+            .any(|(_, code)| *code == 2528 || *code == 2323),
+        "one body means no redeclaration and no multiple-default-exports report. \
+         Got: {observed:?}"
+    );
+}
+
+/// Positive control: a function implementation beside a non-function default
+/// export is not an all-function run — the mixed arms still own it and tsc
+/// reports `TS2528` at both sites.
+#[test]
+fn an_implementation_beside_an_expression_default_still_reports_ts2528() {
+    let source = "export default function router(x: string) { return x; }\n\
+                  export default 1;\n";
+    let function_site = offset_of(source, "router", 0);
+    let expression_site = offset_of(source, "export", 1);
+
+    assert_eq!(
+        sites(source),
+        vec![(function_site, 2528), (expression_site, 2528)],
+        "function + expression defaults keep the TS2528 classification"
+    );
+}
+
+/// Positive control from the #16714 suite, re-pinned by position: an overload
+/// set beside a separate default export marks all three statements with
+/// `TS2528` and nothing else.
+#[test]
+fn an_overload_set_beside_an_expression_default_marks_all_three_sites() {
+    let source = "export default function render(input: string): void;\n\
+                  export default function render(input: any): void {}\n\
+                  export default 2;\n";
+    let signature = offset_of(source, "render", 0);
+    let implementation = offset_of(source, "render", 1);
+    let expression = offset_of(source, "export", 2);
+
+    assert_eq!(
+        sites(source),
+        vec![
+            (signature, 2528),
+            (implementation, 2528),
+            (expression, 2528)
+        ],
+        "the collapsed overload set still counts as one of two default exports"
+    );
+}


### PR DESCRIPTION
Fixes #16719.

## Structural rule

When a module's default exports are **all function declarations**, tsc binds them into one exported `default` symbol regardless of the declared names, so it never reports TS2528 ("A module cannot have multiple default exports") for such a run. Conflicts surface through the duplicate-implementation family instead: with two or more bodies in the run, every declaration that carries a body redeclares the exported binding (TS2323, "Cannot redeclare exported variable 'default'.") and every declaration in the run — overload signatures included — is a duplicate implementation site (TS2393). With at most one body the run is an overload set and the pass reports nothing. tsz now does the same through a dedicated first emission arm in the checker's export-default pass (`crates/tsz-checker/src/declarations/import/core/module_exports.rs`), gated on `all_function_defaults`.

Two defects fixed by the one arm, both oracle-measured:

1. **Classification**: the all-function run fell through to the fallback `else` and got TS2528 per site instead of TS2323 per body.
2. **TS2393 anchoring and coverage**: the old trailing TS2393 block anchored at the export *statement* (`(1,1)`) where tsc anchors at the function *name* (`(1,25)`), and it skipped overload signatures, which tsc marks as duplicate sites too when the run has two or more bodies.

The mixed-kind arms are untouched: `all_function_defaults` is false the moment any default export is a class, interface, identifier, or expression, so every existing classification (function+class merge family, TS2528 for function+expression, interface merges) runs exactly the code it ran before. The trailing TS2393 block now yields to the new arm only for pure-function runs.

## Adjacent-case matrix

All rows measured against pinned oracle `typescript@7.0.2` (`scripts/conformance/typescript-versions.json`), flags `--noEmit --strict false --module commonjs --target es2015`, compared by **(position, code)**, not counts. "IDENTICAL" = byte-identical position+code sets.

| row | tsc 7.0.2 | tsz before | tsz after |
| --- | --- | --- | --- |
| same-name 2 impls (issue witness) | TS2323+TS2393 at each name `(1,25)/(2,25)` | TS2393 at `(1,1)/(2,1)` + TS2528 at names | IDENTICAL |
| different-name 2 impls (`f`/`g`) | same as above | same wrong shape | IDENTICAL |
| renamed binder (`widgetFactory`) | same as above | same wrong shape | IDENTICAL |
| 3 impls (`f`/`g`/`h`) | TS2323+TS2393 x3 | TS2393 x3 + TS2528 x3 | IDENTICAL |
| sig + impl + impl (`f` sig, `f` impl, `g` impl) | TS2393 on sig; TS2323+TS2393 on both impls | TS2528 x3 + TS2393 x2 | IDENTICAL |
| two overload pairs (`f` sig+impl, `g` sig+impl) | TS2393 x4, TS2323 on the 2 impls | — | IDENTICAL |
| two anonymous impls | TS2323+TS2393 at `(1,1)/(2,1)` | TS2393+TS2528 | IDENTICAL |
| overload set (sig,sig,impl) — #16714 rule | clean | clean | clean |
| overload set + `export default 1` (positive control) | TS2528 x3 | TS2528 x3 | TS2528 x3 |
| impl + `export default 1` (positive control) | TS2528 x2 | TS2528 x2 | TS2528 x2 |
| single impl (negative control) | clean | clean | clean |
| `export default interface` + same-named function impl (merge) | clean | clean | clean |
| cross-name one-body run (`f` sig, `g` sig, `g` impl) | TS2391+TS2394 | TS2528 x3 | silent — see below |

The last row is the deliberate residual: tsz stops fabricating TS2528 x3 but does not yet produce the TS2391/TS2394 tsc derives from the merged group. That is a different semantic operation — function-implementation grouping, which keys off declared names and does not know cross-name default exports merge — filed as #16723 with measurements for the one-body and zero-body shapes. Net for that row: 3 wrong + 2 missing before, 2 missing after.

Corpus rows checked directly (fixtures fetched from the pinned corpus, run through both compilers): `defaultExportWithOverloads01` stays clean; `multipleDefaultExports01/02/04` and `defaultExportsCannotMerge01/02/03` are single-default or mixed-kind fixtures, provably outside the new arm's gate (`effective_default_indices.len() <= 1` or `all_function_defaults == false`), and their remaining pre-existing deltas are unchanged in kind (unrelated `m2.ts` import-call divergences).

## Goal
Goal: hold

## Verification
- New suite `cargo test -p tsz-checker --lib ts2323_default_export_dual_implementation`: 8/8 (position-pinned `(offset, code)` assertions, per the board's "counts cannot tell two sites from one site reported twice").
- `cargo test -p tsz-checker --lib ts2323`: 59/59. `cargo test -p tsz-checker --lib -- default_export export_default ts2528 ts2323 ts2300 multiple_default overload duplicate_function`: 591/591 (583 pre-existing + 8 new; the #16714 suite unchanged and green).
- 14-fixture oracle matrix above: 13 byte-identical by position+code, 1 deliberate residual filed as #16723.
- CI's exact clippy invocation (`cargo clippy --profile ci-lint --workspace --all-targets -- -D warnings`): clean, exit 0. `python3 scripts/arch/arch_guard.py`: passes. `cargo fmt`: clean. Pre-commit hook (clippy gate + arch guard) passed.
- Full `cargo test -p tsz-checker --lib` running at post time; count to follow in a comment.
- Owed and disclosed: two-sided `compare-to-parent.sh` (55–90+ min on a cloud seat per the board) did not fit the hour. Scope argument: the new arm only runs where the old code emitted TS2528 for every effective default index (`is_conflict && all_function_defaults`), so no input gains a diagnostic family it did not already report except the strictly-narrower TS2323/TS2393 replacement; the two positive controls pin TS2528 still firing whenever a non-function default is present.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-fable-5
Effort: medium
AgentName: Galena

https://claude.ai/code/session_01NZsdpDpop3nQS6HgsWzmmN

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZsdpDpop3nQS6HgsWzmmN)_