### PR TITLE
fix(checker): a TS2344 constraint through an alias-to-alias chain renders the underlying alias, not the head (#16663)

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_display_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_display_helpers.rs
@@ -90,33 +90,116 @@ impl<'a> CheckerState<'a> {
     ) -> Option<String> {
         use tsz_solver::def::DefKind;
         let db = self.ctx.types.as_type_database();
-        let def_id = query_common::lazy_def_id(db, constraint)?;
-        let def = self.ctx.definition_store.get(def_id)?;
+        let head_def_id = query_common::lazy_def_id(db, constraint)?;
+        // tsc keeps a type's `aliasSymbol` on the alias whose declaration body is
+        // *directly* the structural type. A pure alias-to-alias indirection
+        // (`type B = A`) never mints its own alias, so `getDeclaredTypeOfSymbol`
+        // returns `A`'s type object and `K extends B` renders the underlying `A`.
+        // tsz inlines every non-generic alias body to one shared union `TypeId`,
+        // so the indirection is invisible semantically; recover it by walking the
+        // *source* declaration chain to the alias that directly owns the union.
+        let owner_def_id = self.underlying_alias_owner_def(head_def_id);
+        let def = self.ctx.definition_store.get(owner_def_id)?;
         if def.kind != DefKind::TypeAlias || !def.type_params.is_empty() {
             return None;
         }
-        // The written spelling at the site is this head alias; its name is what
-        // renders, regardless of any intermediate aliases the body chains
-        // through (`type B = A; type A = string | number | symbol` still renders
-        // `B`).
-        let name = db.resolve_atom_ref(def.name).to_string();
-        // Follow the non-generic alias chain to its underlying body, one hop at
-        // a time via the shared single-hop resolver, and accept only the
-        // canonical key-union shape. The bound is a cycle guard against a
-        // mutually-recursive alias (`type A = B; type B = A`); a genuine chain
-        // terminates earlier when a hop stops making progress.
-        let mut body = def.body?;
-        for _ in 0..8 {
-            if self.is_primitive_key_union_type(body) {
-                return Some(name);
-            }
-            let next = self.resolve_non_generic_alias_body_for_display(body);
-            if next == body {
-                break;
-            }
-            body = next;
+        // Only the canonical key union reaches the force-expand display path this
+        // recovery counters; every other alias body already renders its own name
+        // through the ordinary `Lazy` display path, and a primitive-bodied alias
+        // (`type S = string`) is stripped to its primitive by tsc. Gating on the
+        // key-union shape keeps those untouched.
+        if self.is_primitive_key_union_type(def.body?) {
+            return Some(db.resolve_atom_ref(def.name).to_string());
         }
         None
+    }
+
+    /// Walk the pure non-generic alias-to-alias chain rooted at `def_id` through
+    /// the *source* declarations, returning the `DefId` of the alias whose
+    /// declaration body is directly a structural type rather than a bare
+    /// reference to another type alias. tsc resolves `type B = A` to `A`'s type
+    /// object, so the underlying alias — not the head written at the site — owns
+    /// the displayed name.
+    ///
+    /// The chain is followed only while each hop's declaration is reachable in
+    /// the current file's AST and its body is a bare non-generic alias
+    /// reference; a hop whose target declaration lives in another file (e.g. the
+    /// lib `PropertyKey`) terminates the walk at that target, which is treated as
+    /// the owning alias. The bound guards a mutually-recursive alias cycle
+    /// (`type A = B; type B = A`).
+    fn underlying_alias_owner_def(&self, def_id: tsz_solver::DefId) -> tsz_solver::DefId {
+        let mut current = def_id;
+        for _ in 0..8 {
+            match self.bare_alias_reference_target_def(current) {
+                Some(next) => current = next,
+                None => return current,
+            }
+        }
+        current
+    }
+
+    /// When the non-generic type-alias `def_id`'s source declaration body is a
+    /// bare reference (no type arguments) to another non-generic type alias,
+    /// return that alias's `DefId`. Returns `None` for any other body shape (a
+    /// union/object/operator written directly, a generic reference, or a
+    /// reference to a non-alias) and when the declaration is not reachable in the
+    /// current file's AST.
+    fn bare_alias_reference_target_def(
+        &self,
+        def_id: tsz_solver::DefId,
+    ) -> Option<tsz_solver::DefId> {
+        use tsz_solver::def::DefKind;
+        let sym_raw = self.ctx.definition_store.get(def_id)?.symbol_id?;
+        let symbol = self.ctx.binder.get_symbol(tsz_binder::SymbolId(sym_raw))?;
+        if !symbol.has_any_flags(tsz_binder::symbol_flags::TYPE_ALIAS)
+            || symbol.declarations.len() != 1
+        {
+            return None;
+        }
+        let decl_node = self.ctx.arena.get(symbol.declarations[0])?;
+        let type_alias = self.ctx.arena.get_type_alias(decl_node)?;
+        if type_alias
+            .type_parameters
+            .as_ref()
+            .is_some_and(|params| !params.nodes.is_empty())
+        {
+            return None;
+        }
+        // Unwrap a parenthesized body (`type B = (A)`), then require a bare type
+        // reference carrying no type arguments — anything else means this alias
+        // owns its structural body directly, so no hop is taken.
+        let body_idx = self.unwrap_parenthesized_type(type_alias.type_node)?;
+        let body_node = self.ctx.arena.get(body_idx)?;
+        if body_node.kind != syntax_kind_ext::TYPE_REFERENCE {
+            return None;
+        }
+        let type_ref = self.ctx.arena.get_type_ref(body_node)?;
+        if type_ref
+            .type_arguments
+            .as_ref()
+            .is_some_and(|args| !args.nodes.is_empty())
+        {
+            return None;
+        }
+        let target_raw = self.resolve_type_symbol_for_lowering(type_ref.type_name)?;
+        let target_sym = tsz_binder::SymbolId(target_raw);
+        let target_symbol = self
+            .ctx
+            .binder
+            .get_symbol(target_sym)
+            .or_else(|| self.get_cross_file_symbol(target_sym))?;
+        if !target_symbol.has_any_flags(tsz_binder::symbol_flags::TYPE_ALIAS) {
+            return None;
+        }
+        // Read-only: a display path must not mint a fresh `DefId`. Any alias
+        // reachable while emitting TS2344 already has one from checking; a miss
+        // is the correct chain terminus.
+        let target_def_id = self.ctx.get_existing_def_id(target_sym)?;
+        let target_def = self.ctx.definition_store.get(target_def_id)?;
+        if target_def.kind != DefKind::TypeAlias || !target_def.type_params.is_empty() {
+            return None;
+        }
+        Some(target_def_id)
     }
 
     pub(super) fn written_keyof_constraint_display(

--- a/crates/tsz-checker/tests/ts2344_primitive_key_union_alias_constraint_display_tests.rs
+++ b/crates/tsz-checker/tests/ts2344_primitive_key_union_alias_constraint_display_tests.rs
@@ -115,18 +115,54 @@ fn renamed_binders_user_key_union_alias_constraint_renders_the_alias() {
 /// ```
 ///
 /// `type B = A` is a pure alias-to-alias indirection, so `B` never gets its own
-/// `aliasSymbol`; the constraint type carries `A`'s. tsz renders `B` today, so
-/// this row is pinned as the remaining gap rather than asserted as correct —
-/// the single-hop rows above are what this PR actually fixes.
+/// `aliasSymbol`; the constraint type carries `A`'s. The fix walks the chain and
+/// renders the alias whose body is *directly* the key union.
 #[test]
-#[ignore = "known divergence: an alias-to-alias chain renders the written alias \
-            (`B`) where tsc renders the underlying one (`A`)"]
 fn alias_chain_to_key_union_constraint_renders_the_underlying_alias() {
     let source = "type A = string | number | symbol;\n\
                   type B = A;\n\
                   type G<K extends B> = K;\n\
                   type Bad = G<boolean>;\n";
     assert_eq!(rendered_constraint(source), "A");
+}
+
+/// A three-hop chain resolves to the same underlying alias `A`: every pure
+/// indirection defers to the type object `A` created, so `C` and `B` never
+/// carry their own `aliasSymbol`. Verified against pinned `typescript@7.0.2`
+/// (`… does not satisfy the constraint 'A'.`).
+#[test]
+fn multi_hop_alias_chain_to_key_union_constraint_renders_the_root_alias() {
+    let source = "type A = string | number | symbol;\n\
+                  type B = A;\n\
+                  type C = B;\n\
+                  type G<K extends C> = K;\n\
+                  type Bad = G<boolean>;\n";
+    assert_eq!(rendered_constraint(source), "A");
+}
+
+/// Renamed binders and a reordered key union across the chain, so the row
+/// cannot be satisfied by anything keyed on the specific `A`/`B` spelling or on
+/// the canonical `string | number | symbol` member order. Renders the
+/// underlying `Base`.
+#[test]
+fn renamed_binders_alias_chain_to_key_union_constraint_renders_the_root_alias() {
+    let source = "type Base = symbol | string | number;\n\
+                  type Ref = Base;\n\
+                  type H<Q extends Ref> = Q;\n\
+                  type Bad = H<boolean>;\n";
+    assert_eq!(rendered_constraint(source), "Base");
+}
+
+/// A user alias that is a pure indirection to the *lib* `PropertyKey` resolves
+/// to `PropertyKey`, the underlying alias whose body is the key union — not the
+/// head `MyKey` written at the site. Verified against pinned `typescript@7.0.2`
+/// (`… does not satisfy the constraint 'PropertyKey'.`).
+#[test]
+fn user_alias_indirection_to_lib_property_key_renders_the_lib_alias() {
+    let source = "type MyKey = PropertyKey;\n\
+                  type G<K extends MyKey> = K;\n\
+                  type Bad = G<boolean>;\n";
+    assert_eq!(rendered_constraint(source), "PropertyKey");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #16663 (and the constraint-display half of the #16610 repaint family).

**Structural rule:** when a type-parameter constraint is a pure non-generic
alias-to-alias indirection (`type A = string | number | symbol; type B = A;
K extends B`), tsc keeps the type's `aliasSymbol` on the alias whose declaration
body is *directly* the structural type. `getDeclaredTypeOfSymbol(B)` returns
`A`'s type object, which carries `A`'s alias, so tsc renders the constraint as
the underlying `A` — not the head `B` written at the site. tsz rendered `B`.

**Why (owner layer):** tsz inlines every non-generic alias body to one shared
union `TypeId`, so `B`→`A`→union collapses to a single `def.body` and the
indirection is invisible semantically. The canonical `string | number | symbol`
key union is also deliberately routed around the general `find_def_for_type`
alias-display path (it is a shared sentinel; `is_primitive_key_union_data` /
`skip_primitive_key_union_type_alias` force-expand it), so a dedicated recovery
already existed — `written_primitive_key_union_alias_display`, called from the
generic constraint validator. That recovery returned the head alias's name.

**Fix:** the recovery now walks the *source declaration* chain — the only
surface where the erased indirection still exists — following bare non-generic
`TYPE_REFERENCE` alias hops to the alias that directly owns the key union, and
renders that alias's name. A cross-file hop (a user alias to the lib
`PropertyKey`) terminates the walk at the target, treated as the owner. It stays
gated on the canonical key union, so every other alias body keeps rendering its
own name through the ordinary `Lazy` display path and a primitive-bodied alias
(`type S = string`) stays stripped to its primitive.

**Adjacent matrix** (all oracle-verified against `typescript@7.0.2`):
- single-hop `type Zed = …; K extends Zed` → `Zed` (unchanged);
- two-hop `type A = …; type B = A; K extends B` → `A` (the fixed row);
- three-hop `C = B; B = A; A = …; K extends C` → `A`;
- renamed binders + reordered union `symbol | string | number` → underlying `Base`;
- user-alias indirection to the lib `PropertyKey` → `PropertyKey`.
- Fallbacks unchanged: longhand `K extends string | number | symbol` → structural;
  `keyof any` → structural; `type Pair = string | number` → `Pair`; object /
  primitive aliases untouched.

**Review cleanups** (from `/simplify`): reuse `unwrap_parenthesized_type` instead
of a hand-rolled paren-unwrap loop; use the read-only `get_existing_def_id`
rather than the mint-capable `get_or_create_def_id` on a display-only path.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts2344_primitive_key_union_alias_constraint_display_tests -- --include-ignored` — **12/12** (un-ignored the alias-chain tripwire; added multi-hop, renamed-binder, and lib-`PropertyKey`-indirection rows).
- `cargo test -p tsz-checker --test union_display_alias_repaint_parity_tests` — **12 passed / 4 ignored**, unchanged (sibling #16610 repaint floor holds).
- `clippy` clean; pre-commit **architecture guard** + local verification passed.
- Conformance snapshot: running; results to follow in a comment. The change only alters the rendered constraint string in TS2344 for key-union alias-chain constraints (returns `None`/prior behavior otherwise), so blast radius is confined to that message family.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01LyCBZc3ntFkM9xZutQe5y1)_