### PR TITLE
fix(solver): union subtype reduction keeps a member whose index-signature key kind the subsuming sibling lacks

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -981,6 +981,8 @@ mod union_constraint_relation_routing_arch_tests;
 mod union_display_longhand_primitive_repaint_tests;
 #[path = "tests/union_excess_property_relation_routing_arch_tests.rs"]
 mod union_excess_property_relation_routing_arch_tests;
+#[path = "tests/union_index_signature_kind_subtype_reduction_tests.rs"]
+mod union_index_signature_kind_subtype_reduction_tests;
 #[path = "tests/union_index_signature_relation_routing_arch_tests.rs"]
 mod union_index_signature_relation_routing_arch_tests;
 #[path = "tests/union_multi_overload_unified_sig_tests.rs"]

--- a/crates/tsz-checker/src/tests/union_index_signature_kind_subtype_reduction_tests.rs
+++ b/crates/tsz-checker/src/tests/union_index_signature_kind_subtype_reduction_tests.rs
@@ -1,0 +1,153 @@
+//! Regression tests for union subtype reduction dropping a member whose
+//! index-signature KEY KIND the surviving sibling lacks (TS2353 false
+//! positive, `compiler/unionExcessPropertyCheckNoApparentPropTypeMismatchErrors.ts`).
+//!
+//! Structural rule: `{ [k: string]: V }` is a structural subtype of
+//! `{ [k: number]: V }` (a string index covers numeric keys), but when a
+//! declared union carries both, tsc's `isKnownProperty` consults the union as
+//! written, so a fresh object literal's string-keyed property is admitted
+//! through the string-indexed member. tsz preserves that member through the
+//! kind-aware index-signature veto in the solver's compound simplification
+//! (`remove_redundant_members` in
+//! `crates/tsz-solver/src/evaluation/evaluate/compound_simplification.rs`):
+//! a member is not removable when it carries an index-signature key kind
+//! (`string` / `number` / `symbol`) the subsuming sibling lacks.
+//!
+//! Oracle: `typescript@7.0.2` (`--strict false --target es2015`) reports
+//! nothing for every "clean" row below.
+
+use crate::test_utils::{check_source_codes, check_source_diagnostics};
+
+#[test]
+fn string_index_member_survives_number_index_sibling_in_call_argument() {
+    // Witness (reduced from the conformance fixture): the string-keyed
+    // property is admitted through the string-indexed union member; the
+    // number-indexed sibling must not swallow it via subtype reduction.
+    let codes = check_source_codes(
+        r#"
+interface WordCounts { [word: string]: number; }
+interface SlotCounts { [slot: number]: number; }
+declare function tally(from: WordCounts | SlotCounts): void;
+tally({ total: 123 });
+"#,
+    );
+    assert!(
+        !codes.contains(&2353),
+        "string-keyed property admitted by the string-indexed union member must not be excess, got: {codes:?}"
+    );
+}
+
+#[test]
+fn union_member_order_does_not_change_the_verdict() {
+    // Same shape with the members swapped: removal used to be order-blind, so
+    // the fix must be too.
+    let codes = check_source_codes(
+        r#"
+interface WordCounts { [word: string]: number; }
+interface SlotCounts { [slot: number]: number; }
+declare function tally(from: SlotCounts | WordCounts): void;
+tally({ total: 123 });
+"#,
+    );
+    assert!(
+        !codes.contains(&2353),
+        "member order must not affect index-signature admission, got: {codes:?}"
+    );
+}
+
+#[test]
+fn generic_instantiated_union_admits_string_keyed_property() {
+    // The conformance fixture's own shape: generic dictionary interfaces
+    // instantiated through call-site inference, including the
+    // `Object.prototype`-named key `toString` the fixture uses.
+    let codes = check_source_codes(
+        r#"
+interface IStringDictionary<V> { [name: string]: V; }
+interface INumberDictionary<V> { [idx: number]: V; }
+declare function forEach<T>(
+    from: IStringDictionary<T> | INumberDictionary<T>,
+    callback: (entry: { key: any; value: T; }, remove: () => void) => any,
+): void;
+let count = 0;
+forEach({ toString: 123 }, () => count++);
+"#,
+    );
+    assert!(
+        !codes.contains(&2353),
+        "the conformance fixture's call must not report an excess property, got: {codes:?}"
+    );
+}
+
+#[test]
+fn assignment_position_union_stays_clean() {
+    // The assignment path already consulted the declared union; keep it that
+    // way.
+    let codes = check_source_codes(
+        r#"
+interface WordCounts { [word: string]: number; }
+interface SlotCounts { [slot: number]: number; }
+var counts: WordCounts | SlotCounts = { total: 123 };
+"#,
+    );
+    assert!(
+        !codes.contains(&2353),
+        "assignment to the declared union must stay clean, got: {codes:?}"
+    );
+}
+
+#[test]
+fn value_mismatch_against_the_index_value_type_still_errors() {
+    // Negative control: the property name is admitted, but its VALUE violates
+    // the index value type — tsc reports TS2322 here (elaborated member
+    // mismatch), not silence.
+    let diags = check_source_diagnostics(
+        r#"
+interface WordCounts { [word: string]: number; }
+interface SlotCounts { [slot: number]: number; }
+declare function tally(from: WordCounts | SlotCounts): void;
+tally({ total: "not a number" });
+"#,
+    );
+    assert!(
+        diags.iter().any(|d| d.code == 2322),
+        "a value mismatch against the admitting index signature must still error, got: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn plain_object_union_still_reports_excess_property() {
+    // Positive control: with no index signatures anywhere in the union, an
+    // unknown property is still excess (TS2353 must keep firing).
+    let codes = check_source_codes(
+        r#"
+interface Circle { radius: number; }
+interface Square { side: number; }
+declare function area(shape: Circle | Square): void;
+area({ radius: 1, bogus: 2 });
+"#,
+    );
+    assert!(
+        codes.contains(&2353),
+        "a genuinely unknown property against a plain object union must stay excess, got: {codes:?}"
+    );
+}
+
+#[test]
+fn same_kind_index_members_still_reduce_without_regression() {
+    // Two string-indexed members where one genuinely subsumes the other:
+    // reduction (or not) must never manufacture an excess-property report,
+    // since both members admit every string key.
+    let codes = check_source_codes(
+        r#"
+interface Narrow { [k: string]: number; }
+interface Wide { [k: string]: number | string; }
+declare function eat(from: Narrow | Wide): void;
+eat({ anything: 5 });
+"#,
+    );
+    assert!(
+        !codes.contains(&2353),
+        "string-keyed property against string-indexed members is never excess, got: {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate/compound_simplification.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/compound_simplification.rs
@@ -20,7 +20,10 @@ type MemberModifierMap = Option<FxHashMap<u32, (bool, bool)>>;
 struct CompoundMemberFacts {
     property_names: MemberPropertyNames,
     property_modifiers: MemberModifierMap,
-    carries_index_signature: bool,
+    /// Bitset of [`INDEX_KIND_STRING`] / [`INDEX_KIND_NUMBER`] /
+    /// [`INDEX_KIND_SYMBOL`] recording which index-signature key kinds this
+    /// member carries. Zero means no index signatures at all.
+    index_signature_kinds: u8,
     is_empty_object_type: bool,
     is_intrinsic: bool,
     is_intrinsic_or_literal_type: bool,
@@ -29,6 +32,17 @@ struct CompoundMemberFacts {
     is_opaque_under_bypass_eval: bool,
     is_branded_primitive_intersection: bool,
 }
+
+/// The member carries a `[k: string]`-keyed index signature (including
+/// template-literal and other string-domain key types).
+const INDEX_KIND_STRING: u8 = 1 << 0;
+/// The member carries a `[k: number]`-keyed index signature.
+const INDEX_KIND_NUMBER: u8 = 1 << 1;
+/// The member carries a `[k: symbol]`-keyed index signature.
+const INDEX_KIND_SYMBOL: u8 = 1 << 2;
+/// A mapped type's key domain is its constraint, which is not inspectable
+/// here without evaluation; treat it as covering every kind.
+const INDEX_KIND_ALL: u8 = INDEX_KIND_STRING | INDEX_KIND_NUMBER | INDEX_KIND_SYMBOL;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 struct CompoundMemberFactsKey {
@@ -422,7 +436,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         let facts = CompoundMemberFacts {
             property_names,
             property_modifiers,
-            carries_index_signature: Self::carries_index_signature(self.interner, type_id),
+            index_signature_kinds: Self::index_signature_kinds(self.interner, type_id),
             is_empty_object_type: crate::visitors::visitor_predicates::is_empty_object_type(
                 self.interner,
                 type_id,
@@ -582,22 +596,60 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         has_widening_primitive && has_empty_object
     }
 
-    /// Check if `candidate` has an index signature that `subsuming` lacks.
+    /// Check if `candidate` carries an index signature of a key kind
+    /// (`string` / `number` / `symbol`) that `subsuming` lacks.
+    ///
+    /// Kind-blind comparison is not enough: `{ [k: string]: number }` is a
+    /// structural subtype of `{ [k: number]: number }` (a string index covers
+    /// numeric keys), but dropping the string-indexed member from a union
+    /// shrinks the union's admitted key domain — a fresh object literal's
+    /// string-keyed property then reads as excess (TS2353) against the
+    /// surviving number-indexed member even though tsc admits it through the
+    /// removed sibling (`isKnownProperty` over the union as written).
     const fn has_index_signature_not_in(
         candidate: &CompoundMemberFacts,
         subsuming: &CompoundMemberFacts,
     ) -> bool {
-        candidate.carries_index_signature && !subsuming.carries_index_signature
+        candidate.index_signature_kinds & !subsuming.index_signature_kinds != 0
     }
 
-    fn carries_index_signature(db: &dyn crate::caches::db::TypeDatabase, type_id: TypeId) -> bool {
+    /// Which index-signature key kinds (`string` / `number` / `symbol`) the
+    /// member carries, as an `INDEX_KIND_*` bitset.
+    fn index_signature_kinds(db: &dyn crate::caches::db::TypeDatabase, type_id: TypeId) -> u8 {
         match db.lookup(type_id) {
-            Some(TypeData::ObjectWithIndex(_) | TypeData::Mapped(_)) => true,
+            Some(TypeData::ObjectWithIndex(shape_id)) => {
+                let shape = db.object_shape(shape_id);
+                let mut kinds = 0;
+                if shape.string_index_signature().is_some() {
+                    kinds |= INDEX_KIND_STRING;
+                }
+                if shape.number_index.is_some() {
+                    kinds |= INDEX_KIND_NUMBER;
+                }
+                if shape.symbol_index_signature().is_some() {
+                    kinds |= INDEX_KIND_SYMBOL;
+                }
+                kinds
+            }
+            Some(TypeData::Mapped(_)) => INDEX_KIND_ALL,
             Some(TypeData::Callable(shape_id)) => {
                 let shape = db.callable_shape(shape_id);
-                shape.string_index.is_some() || shape.number_index.is_some()
+                let mut kinds = 0;
+                // `CallableShape` keeps the single-slot convention: a `symbol`
+                // index rides in `string_index` discriminated by its key type.
+                if let Some(string_index) = &shape.string_index {
+                    if string_index.key_type == TypeId::SYMBOL {
+                        kinds |= INDEX_KIND_SYMBOL;
+                    } else {
+                        kinds |= INDEX_KIND_STRING;
+                    }
+                }
+                if shape.number_index.is_some() {
+                    kinds |= INDEX_KIND_NUMBER;
+                }
+                kinds
             }
-            _ => false,
+            _ => 0,
         }
     }
 
@@ -814,7 +866,7 @@ mod tests {
         let evaluator = TypeEvaluator::new(&interner);
 
         let indexed_facts = evaluator.compound_member_facts(indexed, true);
-        assert!(indexed_facts.carries_index_signature);
+        assert_eq!(indexed_facts.index_signature_kinds, INDEX_KIND_STRING);
         assert!(
             indexed_facts
                 .property_names


### PR DESCRIPTION
Fixes the pure-false-positive conformance row `compiler/unionExcessPropertyCheckNoApparentPropTypeMismatchErrors.ts` (`a: [TS2353]`, tsc reports nothing).

**Structural rule:** when a declared union carries members with different index-signature key kinds — e.g. `IStringDictionary[T] | INumberDictionary[T]` — tsc's `isKnownProperty` consults the union as written, so a fresh object literal's string-keyed property is admitted through the string-indexed member; tsz preserves that member through the kind-aware index-signature veto in the solver's union subtype reduction (`remove_redundant_members`, `crates/tsz-solver/src/evaluation/evaluate/compound_simplification.rs`).

**Root cause.** `{ [k: string]: number }` is a structural subtype of `{ [k: number]: number }` (a string index covers numeric keys), so union simplification dropped the string-indexed member during evaluation of the call target. The collapsed target then failed the fresh-literal excess check for any string-keyed property: `forEach({ toString: 123 })` reported `TS2353 ... does not exist in type 'INumberDictionary[number]'`. The existing veto (`has_index_signature_not_in`) was kind-blind — it kept the candidate only when the subsuming sibling had NO index signature at all, so a number-indexed sibling swallowed a string-indexed member. The assignment path (which reads the declared union) was already clean; only evaluated targets (the call-argument path) collapsed.

**Fix.** `CompoundMemberFacts` now records which index-signature key kinds (string / number / symbol) each member carries, and removal is vetoed when the candidate carries a kind the subsuming member lacks. Mapped types keep their conservative treatment (covers every kind); `CallableShape`'s single-slot symbol-in-string-index convention is discriminated by key type. Both union and intersection directions share the veto, as before.

**Adjacent-case matrix** (new suite `union_index_signature_kind_subtype_reduction_tests.rs`, all oracle-pinned against `typescript@7.0.2 --strict false --target es2015`; before/after captured with the compiled CLI):

| row | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| witness: concrete `{[k:string]} \| {[k:number]}` call arg, string-keyed prop | clean | TS2353 | clean |
| member order swapped | clean | TS2353 | clean |
| generic instantiated (the fixture's own shape, `toString` key) | clean | TS2353 | clean |
| assignment position | clean | clean | clean |
| negative: value mismatch `{ total: "not a number" }` | TS2322 | TS2353 | TS2322 |
| positive control: plain object union, unknown prop | TS2353 | TS2353 | TS2353 |
| same-kind string-index members | clean | clean | clean |

**Evidence note (post-merge clarification, per the reviewer's comment):** the new unit suite also passes on pre-fix main — the no-lib unit harness does not reach the evaluated-call-target path where the collapse happens, so those tests pin the behaviour as regression guards rather than demonstrating the flip. The before/after evidence for the flip is the compiled-CLI matrix above and the reviewer's isolated conformance run: **+1 fixed (`unionExcessPropertyCheckNoApparentPropTypeMismatchErrors.ts`), 0 broken**, attributed to this PR alone (built in isolation from its batch-sibling #16736).

Residual divergence, deliberately left: on the value-mismatch row tsc elaborates against `Object.prototype.toString`'s type (`() =&gt; string`) when the key is `toString`, while tsz elaborates against the index value type (`number`). Same diagnostic code (TS2322), different displayed target type; separate display concern from this reduction fix.

## Goal
Goal: hold

## Verification
- New suite: `cargo test -p tsz-checker --lib union_index_signature_kind_subtype_reduction` — 7/7 (guards; see evidence note above).
- `cargo test -p tsz-solver --lib` — **7653 passed / 0 failed** (includes the compound-simplification unit tests; one updated for the renamed fact field).
- Targeted checker families: `cargo test -p tsz-checker --lib -- union excess index_signature ts2353 dictionary` — **1183 passed / 0 failed**.
- Reviewer (m4), full lanes at this head: `cargo nextest run -p tsz-checker --lib` **10510 passed / 7 skipped**; `cargo nextest run -p tsz-solver --lib` **7654 passed**.
- Reviewer conformance set-difference, this PR built in isolation: **1 fixed / 0 broken**.
- CLI before/after on the conformance fixture and 9 reduced probes: FP gone, negative + positive controls hold (table above).
- `cargo fmt --check` clean; `cargo clippy -p tsz-solver -p tsz-checker --lib` clean; pre-commit hook (fmt + clippy + arch guard + affected-crate verification) passed.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-fable-5
Effort: medium
AgentName: Cuprite