### PR TITLE
fix(emit): a computed type reference renders every type argument (#15632)

### DIFF
--- a/crates/tsz-cli/tests/generator_yield_star_dts_emit_tests.rs
+++ b/crates/tsz-cli/tests/generator_yield_star_dts_emit_tests.rs
@@ -59,23 +59,28 @@ fn find_tsz_binary() -> Option<PathBuf> {
 }
 
 fn emit_dts(name: &str, source: &str) -> Option<String> {
+    emit_dts_with_args(name, source, &["--target", "es2015", "--lib", "es6"])
+}
+
+/// Emit with the default (es2018) lib so `AsyncGenerator` and a bare `Generator`
+/// delegate resolve. Used by the delegated-`TNext` pins, whose delegate carries
+/// `TNext = any` from the lib default — a shape the es6-only harness cannot name.
+fn emit_dts_default_lib(name: &str, source: &str) -> Option<String> {
+    emit_dts_with_args(name, source, &["--target", "es2018"])
+}
+
+fn emit_dts_with_args(name: &str, source: &str, extra_args: &[&str]) -> Option<String> {
     let tsz_bin = find_tsz_binary()?;
     let temp = TempDir::new(name).expect("temp dir");
     let src_path = temp.path.join("repro.ts");
     std::fs::write(&src_path, source).expect("write repro file");
 
+    let mut args = vec!["repro.ts", "--declaration", "--emitDeclarationOnly"];
+    args.extend_from_slice(extra_args);
+    args.extend_from_slice(&["--pretty", "false"]);
+
     let output = Command::new(tsz_bin)
-        .args([
-            "repro.ts",
-            "--declaration",
-            "--emitDeclarationOnly",
-            "--target",
-            "es2015",
-            "--lib",
-            "es6",
-            "--pretty",
-            "false",
-        ])
+        .args(&args)
         .current_dir(&temp.path)
         .output()
         .expect("run tsz declaration emit");
@@ -215,5 +220,106 @@ fn yield_star_unresolvable_operand_keeps_any_fallback() {
     assert!(
         dts.contains("gen(x: Iterable<unknown>): Generator<"),
         "unresolvable yield* should still emit a Generator return type:\n{dts}"
+    );
+}
+
+/// Delegating to a bare `Generator` (`Generator<unknown, any, any>`) contributes
+/// the delegate's own `TNext` — `any` — to the enclosing generator's inferred
+/// `TNext`. `tsc` renders a *computed* generator return type with all three type
+/// arguments and never drops a trailing one that equals its default, so the
+/// delegated `any` survives:
+///
+/// ```ts
+/// declare function src(): Generator;
+/// function* relay() { yield* src(); }
+/// // tsc: relay(): Generator<unknown, void, any>
+/// ```
+///
+/// tsz previously trimmed the trailing `any` because it equaled the lib default,
+/// emitting `Generator<unknown, void>` — the divergence #15632 tracks. The
+/// declaration function, the function expression, and a renamed binder all share
+/// the same body-driven inference, so all three must keep the third argument.
+#[test]
+fn yield_star_bare_generator_delegation_keeps_any_next_type() {
+    let Some(dts) = emit_dts_default_lib(
+        "bare_next",
+        r#"
+declare function src(): Generator;
+function* relay() { yield* src(); }
+const relayExpr = function* () { yield* src(); };
+function* zzz() { yield* src(); }
+export { relay, relayExpr, zzz };
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("relay(): Generator<unknown, void, any>"),
+        "a bare-`Generator` delegate contributes `TNext = any`; the trailing \
+         argument must not be trimmed against the lib default:\n{dts}"
+    );
+    assert!(
+        dts.contains("relayExpr: () => Generator<unknown, void, any>"),
+        "the function-expression path shares the same delegated-`TNext`:\n{dts}"
+    );
+    assert!(
+        dts.contains("zzz(): Generator<unknown, void, any>"),
+        "the delegated-`TNext` rendering must not depend on the binder name:\n{dts}"
+    );
+    assert!(
+        !dts.contains("Generator<unknown, void>"),
+        "the trailing `any` must not be elided as a default:\n{dts}"
+    );
+}
+
+/// The async arm carries the same delegated `TNext = any` into `AsyncGenerator`.
+#[test]
+fn async_yield_star_bare_generator_delegation_keeps_any_next_type() {
+    let Some(dts) = emit_dts_default_lib(
+        "bare_next_async",
+        r#"
+declare function asrc(): AsyncGenerator;
+async function* arelay() { yield* asrc(); }
+export { arelay };
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("arelay(): AsyncGenerator<unknown, void, any>"),
+        "async delegation to a bare `AsyncGenerator` must keep the delegated \
+         `TNext = any`:\n{dts}"
+    );
+}
+
+/// The same all-arguments rule beyond generators: a *computed* re-export of a
+/// value whose type instantiates a generic with trailing arguments equal to
+/// their defaults keeps every argument, matching `tsc`
+/// (`const r = w` where `w: Foo<boolean, string>` emits
+/// `Foo<boolean, string, number>`, not `Foo<boolean>`). This guards the printer
+/// change from being narrowed back to a generator-only special case.
+#[test]
+fn computed_reexport_keeps_all_default_equal_type_arguments() {
+    let Some(dts) = emit_dts_default_lib(
+        "computed_defaults",
+        r#"
+interface Foo<A, B = string, C = number> { a: A; b: B; c: C; }
+declare const w: Foo<boolean, string>;
+const r = w;
+export { r };
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("r: Foo<boolean, string, number>"),
+        "a computed reference renders its full argument list, including trailing \
+         arguments that equal their defaults:\n{dts}"
     );
 }

--- a/crates/tsz-emitter/src/declaration_emitter/tests/type_info.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/type_info.rs
@@ -1647,7 +1647,14 @@ export namespace C {
 }
 
 #[test]
-fn test_type_application_elides_trailing_default_type_argument() {
+fn test_type_application_keeps_trailing_default_type_argument() {
+    // A *computed* type reference renders its full argument list; `tsc`'s
+    // `typeToTypeNodeHelper` never trims a trailing argument that equals its
+    // type parameter's default. Oracled: `const c = w` where
+    // `w: TPromise<string, any>` (`RejectType = any`) emits
+    // `TPromise<string, any>`, not `TPromise<string>`. (Trailing defaults are
+    // only dropped on the node-reuse path, which copies a written annotation
+    // verbatim and never reaches this printer.)
     let (parser, _root) = parse_test_source("");
     let binder = BinderState::new();
 
@@ -1687,7 +1694,7 @@ fn test_type_application_elides_trailing_default_type_argument() {
     let emitter = DeclarationEmitter::with_type_info(&parser.arena, type_cache, &interner, &binder);
     let printed = emitter.print_type_id(promise_type);
 
-    assert_eq!(printed, "TPromise<string>");
+    assert_eq!(printed, "TPromise<string, any>");
 }
 
 #[test]

--- a/crates/tsz-emitter/src/emitter/types/printer/type_printing.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/type_printing.rs
@@ -813,7 +813,7 @@ impl<'a> TypePrinter<'a> {
         if let Some(def_id) = base_def_id
             && self.printed_as_elided_local_alias_name(def_id, &base_text)
         {
-            let visible = self.visible_type_application_arg_count(app.base, &app.args);
+            let visible = self.elided_alias_visible_arg_count(app.base, &app.args);
             let mut visible_args = app.args.iter().copied().take(visible);
             return match (visible_args.next(), visible_args.next()) {
                 (Some(only_arg), None) => {
@@ -833,18 +833,25 @@ impl<'a> TypePrinter<'a> {
         if app.args.is_empty() || Self::base_text_cannot_carry_type_arguments(&base_text) {
             base_text
         } else {
+            // Print every type argument. `tsc` reconstructs a *computed* type
+            // reference (`typeToTypeNodeHelper`) with all its arguments up to
+            // arity and never trims a trailing one that happens to equal its
+            // default — `const g = mk<number>()` emits `Box<number, number>`,
+            // an unannotated `function* g() { yield* src(); }` emits
+            // `Generator<unknown, void, any>`. Trailing defaults are only
+            // dropped on the node-reuse path, where a *written* annotation is
+            // copied verbatim (`const g: Generator<number>` stays
+            // `Generator<number>`); that path never reaches this printer, so a
+            // computed reference must render its full argument list.
             let args: Vec<String> = app
                 .args
                 .iter()
-                .take(self.visible_type_application_arg_count(app.base, &app.args))
                 .enumerate()
                 .map(|(index, &id)| self.print_type_argument(id, index == 0))
                 .collect();
-            if args.is_empty() {
-                base_text
-            } else {
-                format!("{base_text}<{}>", args.join(", "))
-            }
+            // `app.args` is non-empty here (the outer guard returns early
+            // otherwise) and the map is 1:1, so `args` is always non-empty.
+            format!("{base_text}<{}>", args.join(", "))
         }
     }
 
@@ -1045,7 +1052,14 @@ impl<'a> TypePrinter<'a> {
         parts
     }
 
-    fn visible_type_application_arg_count(&self, base: TypeId, args: &[TypeId]) -> usize {
+    /// Trailing-default-trimmed argument count, used *only* by the elided
+    /// local-alias fallback above to decide between `X | any` and a bare `any`
+    /// for an unnameable recursive alias (#16594). This is deliberately **not**
+    /// applied to the ordinary `Name<...>` render path: `tsc` never trims a
+    /// trailing type argument that equals its default on a computed type
+    /// reference, so a nameable application prints its full argument list. Do
+    /// not reintroduce this as a general arg-count policy.
+    fn elided_alias_visible_arg_count(&self, base: TypeId, args: &[TypeId]) -> usize {
         let Some(type_params) = self.type_application_type_params(base) else {
             return args.len();
         };


### PR DESCRIPTION
An unannotated generator that delegates with `yield*` to a bare `Generator`
infers `TNext = any`, and its return type is built as the three-argument
application. The declaration printer dropped the delegated `TNext`, because
`TypePrinter::print_type_application`
(`crates/tsz-emitter/src/emitter/types/printer/type_printing.rs`) trimmed every
trailing type argument that equalled its type parameter's default — and `any` is
the lib default for `TNext`.

**Structural rule:** when rendering a *computed* type reference, `tsc` does not
trim trailing defaults — `typeToTypeNodeHelper` reconstructs the reference with
its full argument list up to arity and keeps a trailing argument even when it
equals the default. tsz did the trimming in the emitter's `TypePrinter` (owner
layer: emit), diverging. Trailing defaults are dropped only on the node-reuse
path, which copies a *written* annotation verbatim and never reaches this
printer. The fix makes the printer render the full argument list for a computed
application. The change is general (every computed reference), not a
generator special-case.

Oracled against `tsc@6.0.2 --declaration --emitDeclarationOnly --strict`:

```text
source (computed type)                              tsc                              tsz before             tsz after
function* relayD() { yield* src(); }  src():Generator Generator<unknown, void, any>    Generator<unknown,void> Generator<unknown, void, any>
const relayA = async function*(){ yield* asrc(); }  AsyncGenerator<unknown,void,any>  AsyncGenerator<u,void>  AsyncGenerator<unknown, void, any>
const r = w   where  w: Foo<boolean, string>        Foo<boolean, string, number>     Foo<boolean>           Foo<boolean, string, number>
computed  TPromise<string, any>  (RejectType = any) TPromise<string, any>            TPromise<string>       TPromise<string, any>
function* plain() { yield 1; }                      Generator<number, void, unknown> (same)                 unchanged
written  const g: Generator<number>  (node-reuse)   Generator<number>                (same)                 unchanged
```

This resolves the last residual slice of #15632 (the delegated `TNext` dropped in
declaration emit; the `TNext` *inference* was already correct — the `.next(arg)`
argument-checking suite confirms it). The separate partial-application
default-*filling* gap (a computed re-export of a `Generator<number>`-typed value
emits `Generator<number>` where tsc fills and prints `Generator<number, any, any>`)
is unaffected and left to its own slice.

The emitter's `TypePrinter` is used only for emit (no crate outside `tsz-emitter`
imports it); diagnostics render types through the solver-side formatter and LSP
hover consumes checker/solver APIs, so diagnostic codes/messages and hover text
are unchanged. Conformance and fourslash are therefore not affected by this
printer change.

## Goal
Goal: hold

## Verification
- `./scripts/emit/run.sh` (parity floor): JS 11562 passed / DTS 1375 passed — held exactly. `emit-detail.json` byte-identical to the committed baseline (16-test failing set unchanged): no regression, no drift.
- `cargo test -p tsz-cli --test generator_yield_star_dts_emit_tests` — 9 passing, including 3 new pins (`yield_star_bare_generator_delegation_keeps_any_next_type`, `async_yield_star_bare_generator_delegation_keeps_any_next_type`, `computed_reexport_keeps_all_default_equal_type_arguments`).
- `cargo test -p tsz-emitter` — full emitter suite green (3990 passing); corrected the one unit test that pinned the old (non-tsc) elision.
- Pre-commit local verification (clippy + `arch-size` guard + `-p tsz-cli -p tsz-emitter`) passed.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high