### PR TITLE
fix(solver): a const-asserted object-literal property widens away in generic call inference

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -195,6 +195,8 @@ mod conditional_flow_substitution_ts2344_tests;
 mod conditional_narrowed_index_through_generic_alias_tests;
 #[path = "tests/conditional_never_param_inference_tests.rs"]
 mod conditional_never_param_inference_tests;
+#[path = "tests/const_asserted_generic_inference_widen_tests.rs"]
+mod const_asserted_generic_inference_widen_tests;
 #[path = "tests/const_asserted_return_type_tests.rs"]
 mod const_asserted_return_type_tests;
 #[path = "tests/constraint_position_nullable_access_tests.rs"]

--- a/crates/tsz-checker/src/tests/const_asserted_generic_inference_widen_tests.rs
+++ b/crates/tsz-checker/src/tests/const_asserted_generic_inference_widen_tests.rs
@@ -1,0 +1,157 @@
+//! Tests for issue #16725: a per-property `as const` inside a fresh object
+//! literal passed as a generic call argument must keep its literal type
+//! through inference, not widen to the primitive base.
+//!
+//! `pick({ v: "x" as const })` for `declare function pick<T>(o: { v: T }): T`
+//! should infer `T = "x"`, matching tsc's `getRegularTypeOfLiteralType`
+//! (the property's own const assertion strips freshness regardless of
+//! whether the enclosing object literal is itself fresh). Without the fix,
+//! `constrain_properties` only propagated the *object's* `FRESH_LITERAL`
+//! flag into inference-candidate freshness and ignored the property's own
+//! `PropertyInfo::non_widening`, so the candidate was treated as a fresh
+//! literal and widened to `string`/`number`.
+
+use crate::test_utils::check_source_diagnostics;
+
+#[test]
+fn const_asserted_property_string_literal_preserved_through_generic_inference() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function pick<T>(o: { v: T }): T;
+const r = pick({ v: "x" as const });
+const ok: "x" = r;
+"#,
+    );
+
+    let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert!(
+        ts2322.is_empty(),
+        "Expected T to infer as \"x\", not widen to string, got: {:?}",
+        ts2322.iter().map(|d| &d.message_text).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn const_asserted_property_number_literal_preserved_through_generic_inference() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function pick<T>(o: { v: T }): T;
+const r = pick({ v: 1 as const });
+const ok: 1 = r;
+"#,
+    );
+
+    let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert!(
+        ts2322.is_empty(),
+        "Expected T to infer as 1, not widen to number, got: {:?}",
+        ts2322.iter().map(|d| &d.message_text).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn const_asserted_property_preserved_with_renamed_binders() {
+    // Anti-hardcoding: vary the function, property, and value-binder names.
+    let diags = check_source_diagnostics(
+        r#"
+declare function unwrap<Value>(box: { payload: Value }): Value;
+const outcome = unwrap({ payload: "done" as const });
+const done: "done" = outcome;
+"#,
+    );
+
+    let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert!(
+        ts2322.is_empty(),
+        "Expected name-independent const-assert preservation through inference, got: {:?}",
+        ts2322.iter().map(|d| &d.message_text).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn non_asserted_property_still_widens_through_generic_inference() {
+    // Regression guard: a plain (non-const-asserted) property in the same
+    // fresh-object-argument shape must still widen — only the property's own
+    // `as const` should suppress widening, not the mere presence of a
+    // sibling const assertion or the call being generic at all.
+    let diags = check_source_diagnostics(
+        r#"
+declare function pick<T>(o: { v: T }): T;
+const r = pick({ v: "x" });
+const bad: "x" = r;
+"#,
+    );
+
+    let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "Expected exactly one TS2322 — a plain literal property must still widen to string, got: {:?}",
+        ts2322.iter().map(|d| &d.message_text).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn whole_object_const_assertion_still_preserved() {
+    // Positive control from the issue's adjacent-case matrix: asserting the
+    // whole object literal (rather than one property) was already correct
+    // before this fix and must stay correct.
+    let diags = check_source_diagnostics(
+        r#"
+declare function unbox<T>(o: { v: T }): T;
+const r = unbox({ v: 1 } as const);
+const ok: 1 = r;
+"#,
+    );
+
+    let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert!(
+        ts2322.is_empty(),
+        "Expected whole-object const assertion to keep preserving the literal, got: {:?}",
+        ts2322.iter().map(|d| &d.message_text).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn primitive_constrained_type_param_still_preserved_without_const() {
+    // Positive control: a type parameter constrained to a primitive already
+    // preserves the literal without any `as const` (the constraint path is a
+    // separate mechanism from the freshness fix here) and must stay that way.
+    let diags = check_source_diagnostics(
+        r#"
+declare function unbox<T extends number>(o: { v: T }): T;
+const r = unbox({ v: 1 as const });
+const ok: 1 = r;
+"#,
+    );
+
+    let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert!(
+        ts2322.is_empty(),
+        "Expected constrained type parameter to keep preserving the literal, got: {:?}",
+        ts2322.iter().map(|d| &d.message_text).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn mixed_asserted_and_plain_sibling_properties_infer_independently() {
+    // Two independently-inferred type parameters on sibling properties of the
+    // same fresh object literal: only the const-asserted one keeps its
+    // literal, the plain sibling still widens.
+    let diags = check_source_diagnostics(
+        r#"
+declare function pair<A, B>(o: { a: A; b: B }): [A, B];
+const [a, b] = pair({ a: "x" as const, b: "y" });
+const okA: "x" = a;
+const okB: "y" = b;
+"#,
+    );
+
+    let a_ok: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert_eq!(
+        a_ok.len(),
+        1,
+        "Expected exactly one TS2322 — the const-asserted `a` stays literal, only the plain `b` widens and fails, got: {:?}",
+        a_ok.iter().map(|d| &d.message_text).collect::<Vec<_>>()
+    );
+}

--- a/crates/tsz-solver/src/operations/constraints/signatures.rs
+++ b/crates/tsz-solver/src/operations/constraints/signatures.rs
@@ -97,6 +97,15 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             match source.name.cmp(&target.name) {
                 std::cmp::Ordering::Equal => {
                     let property_index = source_idx as u32;
+                    // A property carrying its own `as const` (or other
+                    // non-widening source, see `PropertyInfo::non_widening`)
+                    // is a *regular*, not fresh, literal type in tsc's terms
+                    // even when the enclosing object literal itself is fresh
+                    // — `getRegularTypeOfLiteralType` is applied at the
+                    // property, not the object. Excluding it here keeps the
+                    // inferred candidate out of `is_fresh_literal`, so
+                    // `widen_resolved_inference` never widens it away.
+                    let property_is_fresh = source_is_fresh && !source.non_widening;
                     if let Some(&var) = var_map.get(&target.type_id) {
                         ctx.add_property_candidate_with_index(
                             var,
@@ -104,7 +113,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                             priority,
                             property_index,
                             Some(source.name),
-                            source_is_fresh,
+                            property_is_fresh,
                         );
                     } else {
                         let was_pending_method = ctx.pending_target_method;
@@ -131,7 +140,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                                 priority,
                                 property_index,
                                 Some(source.name),
-                                source_is_fresh,
+                                property_is_fresh,
                             );
                         } else {
                             // Skip the reverse-direction write_type constraint when


### PR DESCRIPTION
Fixes #16725.

`pick({ v: "x" as const })` for `declare function pick<T>(o: { v: T }): T` inferred `T = string` instead of `"x"` — tsc 7.0.2 accepts `const ok: "x" = pick({ v: "x" as const })`, tsz rejected it with `TS2322`.

**Structural rule.** tsc's fresh/regular literal-type duality (`getRegularTypeOfLiteralType`) is decided per property, not per object: a fresh object literal's property carrying its own `as const` (or other non-widening source — a plain `as T`/`<T>expr` assertion, a non-widening-declared identifier, a literal index access) holds a *regular* literal that never widens, even though the enclosing object literal itself is fresh. tsz already tracks this exact distinction on `PropertyInfo::non_widening` (populated by the checker at object-literal construction and already consumed by the object-widening passes in `operations/widening.rs` and `widening/annotation.rs`), but the inference-candidate collector never read it: `constrain_properties` (`crates/tsz-solver/src/operations/constraints/signatures.rs`) propagated only the *enclosing object's* `ObjectFlags::FRESH_LITERAL` bit into `add_property_candidate_with_index`'s `source_is_fresh` argument, so a const-asserted property's inference candidate was still marked `is_fresh_literal = true` and `widen_resolved_inference` (`infer_resolve.rs:1255`) widened it to the primitive base.

Fixed by ANDing the object-level freshness with `!source.non_widening` per property before it reaches the candidate collector — both the read-type (`type_id`) and write-type candidates in the two `add_property_candidate_with_index` call sites in `constrain_properties`. Owner: `crates/tsz-solver/src/operations/constraints/signatures.rs`, the shared inference-constraint walker used by all three `constrain_properties` callers (`walker.rs` x2, `walker_helpers.rs`), so the fix applies uniformly regardless of call shape.

**Adjacent-case matrix** (`crates/tsz-checker/src/tests/const_asserted_generic_inference_widen_tests.rs`, 7 new tests):

| case | expected | before | after |
| --- | --- | --- | --- |
| `pick({ v: "x" as const })` — unconstrained, per-property, string | preserve `"x"` | widened to `string`, TS2322 | preserved |
| `pick({ v: 1 as const })` — same, numeric | preserve `1` | widened to `number`, TS2322 | preserved |
| renamed binders (`unwrap`/`payload`/`Value`) | preserve literal | TS2322 | preserved |
| `pick({ v: "x" })` — no `as const` (regression guard) | still widens | widened (correct) | still widens (unchanged) |
| `unbox({ v: 1 } as const)` — whole-object assertion (positive control) | preserve `1` | already correct | unchanged |
| `unbox<T extends number>({ v: 1 as const })` — constrained param (positive control) | preserve `1` | already correct (separate mechanism) | unchanged |
| `pair({ a: "x" as const, b: "y" })` — mixed asserted/plain siblings, independent type params | only `a` preserved | both TS2322-safe path wrong for `a` | `a` preserved, `b` still widens |

**Scope / risk.** The gate only flips for candidates where `PropertyInfo::non_widening` is `true`, which the checker sets exclusively for `as const`/type-assertion/non-widening-identifier/literal-index-access property values (`object_property_value_is_non_widening` in `crates/tsz-checker/src/types/computation/object_literal/computation_support.rs`) — a plain literal property is untouched (see the regression-guard case above). This can only turn a previously-over-widened literal into the correctly-preserved one; it cannot cause a previously-passing program to newly fail unless that program's correctness accidentally depended on the pre-fix mis-widening, which would itself be a `tsc` incompatibility.

## Goal
Goal: hold

## Verification
- New suite: `cargo test -p tsz-checker --lib -- const_asserted_generic_inference_widen` — 7/7 passed.
- `cargo test -p tsz-solver --lib` — 7654/7654 passed.
- `cargo test -p tsz-checker --lib -- widening const_assert inference literal generic_call generator_yield_literal array_literal_spread inferred_return object_return` — 1401/1401 passed (targeted blast-radius sweep across every widening/inference/const-assertion family in the crate).
- `cargo clippy -p tsz-solver -p tsz-checker --lib --all-features -- -D warnings` — clean.
- `cargo fmt -p tsz-solver -p tsz-checker -- --check` — clean.
- Pre-commit hook (fmt + clippy + architecture guard) — passed.
- Full `cargo test -p tsz-checker --lib` (~10.5k tests): running past this session's hour; will report the final count in a follow-up comment. No failures observed in the completed portion before hand-off.
- Two-sided `compare-to-parent.sh` corpus set-difference: not run this session (owed) — the change is inference-scope-narrowed as argued above and touches no display/emit path, so a corpus regression would require a project literal that depends on the old mis-widening.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_018VyorUU1wP7adZ3qbJHLLh)_