### PR TITLE
fix(checker): a bare `keyof any`/`unknown`/`never` annotation resolves eagerly like tsc

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -156,7 +156,12 @@ impl<'a> CheckerState<'a> {
             if let Some(param) = decl_arena.get_parameter(decl)
                 && param.type_annotation.is_some()
             {
-                if self.annotation_names_type_query_alias(decl_arena, param.type_annotation) {
+                if self.annotation_names_type_query_alias(decl_arena, param.type_annotation)
+                    || Self::annotation_is_keyof_over_degenerate_operand(
+                        decl_arena,
+                        param.type_annotation,
+                    )
+                {
                     return None;
                 }
                 let mut text =
@@ -181,7 +186,12 @@ impl<'a> CheckerState<'a> {
             if let Some(var_decl) = decl_arena.get_variable_declaration(decl)
                 && var_decl.type_annotation.is_some()
             {
-                if self.annotation_names_type_query_alias(decl_arena, var_decl.type_annotation) {
+                if self.annotation_names_type_query_alias(decl_arena, var_decl.type_annotation)
+                    || Self::annotation_is_keyof_over_degenerate_operand(
+                        decl_arena,
+                        var_decl.type_annotation,
+                    )
+                {
                     return None;
                 }
                 return node_text_in_arena(decl_arena, var_decl.type_annotation).and_then(|text| {
@@ -194,7 +204,12 @@ impl<'a> CheckerState<'a> {
             if let Some(prop_decl) = decl_arena.get_property_decl(decl)
                 && prop_decl.type_annotation.is_some()
             {
-                if self.annotation_names_type_query_alias(decl_arena, prop_decl.type_annotation) {
+                if self.annotation_names_type_query_alias(decl_arena, prop_decl.type_annotation)
+                    || Self::annotation_is_keyof_over_degenerate_operand(
+                        decl_arena,
+                        prop_decl.type_annotation,
+                    )
+                {
                     return None;
                 }
                 return node_text_in_arena(decl_arena, prop_decl.type_annotation).and_then(
@@ -275,7 +290,12 @@ impl<'a> CheckerState<'a> {
         if let Some(param) = decl_arena.get_parameter(decl)
             && param.type_annotation.is_some()
         {
-            if self.annotation_names_type_query_alias(decl_arena, param.type_annotation) {
+            if self.annotation_names_type_query_alias(decl_arena, param.type_annotation)
+                || Self::annotation_is_keyof_over_degenerate_operand(
+                    decl_arena,
+                    param.type_annotation,
+                )
+            {
                 return None;
             }
             return node_text_in_arena(decl_arena, param.type_annotation).and_then(|text| {
@@ -286,7 +306,12 @@ impl<'a> CheckerState<'a> {
         if let Some(var_decl) = decl_arena.get_variable_declaration(decl)
             && var_decl.type_annotation.is_some()
         {
-            if self.annotation_names_type_query_alias(decl_arena, var_decl.type_annotation) {
+            if self.annotation_names_type_query_alias(decl_arena, var_decl.type_annotation)
+                || Self::annotation_is_keyof_over_degenerate_operand(
+                    decl_arena,
+                    var_decl.type_annotation,
+                )
+            {
                 return None;
             }
             return node_text_in_arena(decl_arena, var_decl.type_annotation).and_then(|text| {

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
@@ -134,6 +134,13 @@ impl<'a> CheckerState<'a> {
         if let Some(display) = self.longhand_primitive_union_source_display(anchor_idx, source) {
             return display;
         }
+        // A `keyof any` / `keyof unknown` / `keyof never` source annotation
+        // resolves to its fixed key-space result at type-construction time in
+        // tsc (`getIndexType`), so it likewise carries no `aliasSymbol` — same
+        // family as the longhand-union case above, different written spelling.
+        if let Some(display) = self.keyof_degenerate_operand_source_display(anchor_idx, source) {
+            return display;
+        }
         // A deferred meta-type source — a bare conditional (`T extends U ? X : Y`)
         // or indexed-access (`T["x"]`), or an `Application` of a conditional/
         // indexed-bodied alias (`T95<U>`) — that still carries free type
@@ -930,7 +937,7 @@ impl<'a> CheckerState<'a> {
     /// a coincidentally-shaped alias reached through the reverse type-to-def
     /// lookup. Shared by the anonymous-composite and longhand-primitive-union
     /// source paths, which differ only in that annotation predicate.
-    fn annotation_gated_structural_source_display(
+    pub(super) fn annotation_gated_structural_source_display(
         &mut self,
         anchor_idx: NodeIndex,
         source: TypeId,

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/keyof_source_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/keyof_source_display.rs
@@ -2,6 +2,7 @@
 
 use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
@@ -107,5 +108,30 @@ impl<'a> CheckerState<'a> {
             })
             .and_then(|def| def.body)
             .unwrap_or(ty)
+    }
+
+    /// Structural display for an assignment **source** whose declared type was
+    /// written as `keyof any` / `keyof unknown` / `keyof never`. `tsc`'s
+    /// `getIndexType` resolves such an operand to its fixed key-space result
+    /// immediately at type-construction time, so the resulting type carries no
+    /// `aliasSymbol` — the operator never reaches `typeToString`, and the
+    /// result is not distinguished from any other occurrence of the same
+    /// structural union. Without this, the reverse type-to-def lookup can
+    /// repaint the freshly-evaluated union with a coincidentally-shaped
+    /// non-generic alias (`PropertyKey`) that happens to be genuinely
+    /// referenced elsewhere (e.g. inside the loaded lib), even though this
+    /// particular occurrence was never written through it. Same family as
+    /// `longhand_primitive_union_source_display` (#16610), different written
+    /// spelling.
+    pub(in crate::error_reporter) fn keyof_degenerate_operand_source_display(
+        &mut self,
+        anchor_idx: NodeIndex,
+        source: TypeId,
+    ) -> Option<String> {
+        self.annotation_gated_structural_source_display(
+            anchor_idx,
+            source,
+            Self::annotation_is_keyof_over_degenerate_operand,
+        )
     }
 }

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/type_query_alias.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/type_query_alias.rs
@@ -151,6 +151,63 @@ impl<'a> CheckerState<'a> {
             })
     }
 
+    /// Whether `annotation_idx` is a bare `keyof any` / `keyof unknown` /
+    /// `keyof never` type operator.
+    ///
+    /// `tsc`'s `getIndexType` resolves such an operand to its fixed key-space
+    /// result (`string | number | symbol` / `never`) at type-construction time,
+    /// so the resulting type carries no `aliasSymbol` and no memory of having
+    /// been written as `keyof <operand>` — the operator never reaches
+    /// `typeToString`. tsz's declared-annotation source text fallback
+    /// (`declared_type_annotation_text_for_symbol_type` /
+    /// `declared_type_annotation_text_for_expression_with_options`) would
+    /// otherwise reproduce the written `keyof any` text verbatim for a
+    /// `value: keyof any` declaration, repainting the already-correctly-
+    /// evaluated structural union with syntax tsc never preserves. Scoped to a
+    /// literal `any`/`unknown`/`never` keyword operand — a named/aliased
+    /// operand keeps the existing `keyof Name` display path.
+    pub(in crate::error_reporter) fn annotation_is_keyof_over_degenerate_operand(
+        arena: &tsz_parser::NodeArena,
+        annotation_idx: NodeIndex,
+    ) -> bool {
+        use crate::types_domain::queries::lib_resolution::{
+            keyword_name_to_type_id, keyword_syntax_to_type_id,
+        };
+        let Some(node) = arena.get(annotation_idx) else {
+            return false;
+        };
+        if node.kind != syntax_kind_ext::TYPE_OPERATOR {
+            return false;
+        }
+        let Some(type_op) = arena.get_type_operator(node) else {
+            return false;
+        };
+        if type_op.operator != tsz_scanner::SyntaxKind::KeyOfKeyword as u16 {
+            return false;
+        }
+        let Some(operand_node) = arena.get(type_op.type_node) else {
+            return false;
+        };
+        // A primitive keyword operand (`any`, `unknown`, `never`) is parsed as
+        // a `TYPE_REFERENCE` naming the keyword, not a bare keyword token node
+        // (mirrors `type_node_is_primitive_keyword`'s two-shape check above);
+        // fall back to the raw keyword-token kind for the rarer shape where the
+        // parser does emit one directly.
+        let operand_type_id = if operand_node.kind == syntax_kind_ext::TYPE_REFERENCE {
+            arena
+                .get_type_ref(operand_node)
+                .and_then(|type_ref| arena.get(type_ref.type_name))
+                .and_then(|name_node| arena.get_identifier(name_node))
+                .and_then(|ident| keyword_name_to_type_id(&ident.escaped_text))
+        } else {
+            keyword_syntax_to_type_id(operand_node.kind)
+        };
+        matches!(
+            operand_type_id,
+            Some(TypeId::ANY | TypeId::UNKNOWN | TypeId::NEVER)
+        )
+    }
+
     pub(in crate::error_reporter) fn annotation_names_type_query_alias(
         &self,
         arena: &tsz_parser::NodeArena,

--- a/crates/tsz-checker/src/types/type_node_advanced.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced.rs
@@ -85,6 +85,17 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                         return evaluated;
                     }
                 }
+                // tsc's `getIndexType` resolves a `any`/`unknown`/`never` operand
+                // to its fixed key-space result (`string | number | symbol` /
+                // `never` / `string | number | symbol`) immediately, rather than
+                // building a deferred `IndexType` node — the operator itself
+                // never survives to the printer for these operands, so a bare
+                // `keyof any` annotation displays as the resolved union, not
+                // `keyof any`. Other operands (object/interface/generic) keep
+                // the deferred `KeyOf` node so the printer still shows `keyof T`.
+                if matches!(inner_type, TypeId::ANY | TypeId::UNKNOWN | TypeId::NEVER) {
+                    return self.ctx.types.evaluate_keyof(inner_type);
+                }
                 return factory.keyof(inner_type);
             }
 

--- a/crates/tsz-checker/tests/union_display_alias_repaint_parity_tests.rs
+++ b/crates/tsz-checker/tests/union_display_alias_repaint_parity_tests.rs
@@ -11,8 +11,9 @@
 //! tsz interns one `TypeId` per content and carries the alias in a global
 //! `TypeId -> alias` side table (`TypeInterner::store_display_alias` /
 //! `get_display_alias`), so an alias declared anywhere can repaint a
-//! structurally identical type written longhand somewhere else. That is the
-//! divergence the `#[ignore]`d rows below record.
+//! structurally identical type written longhand somewhere else — that was
+//! `store_display_alias`'s repaint divergence, fixed by #16645 (originally
+//! filed as #16610).
 //!
 //! Every expectation here was verified against the pinned oracle
 //! (`typescript@7.0.2`, `--noEmit --strict --lib es2022 --target es2022`), one
@@ -20,10 +21,10 @@
 //! which matters especially here, since the defect is precisely about one
 //! declaration reaching another site.
 //!
-//! Live rows are a regression floor for the spellings that already match.
-//! `#[ignore]`d rows are tripwires: they assert `tsc`'s answer and are expected
-//! to fail until the repaint is fixed. Run them with
-//! `cargo test -p tsz-checker --test union_display_alias_repaint_parity_tests -- --ignored`.
+//! All rows above the "second mechanism" section are a regression floor for
+//! the repaint fix. `#[ignore]`d rows below record a separate, still-open
+//! divergence (an alias whose RHS collapses to a pre-existing type). Run them
+//! with `cargo test -p tsz-checker --test union_display_alias_repaint_parity_tests -- --ignored`.
 
 use tsz_checker::CheckerOptions;
 use tsz_checker::test_utils::{check_source_with_libs_code_messages, load_default_lib_files};
@@ -128,7 +129,7 @@ fn interface_declared_elsewhere_does_not_repaint_a_longhand_object() {
 }
 
 // ---------------------------------------------------------------------------
-// Tripwires: oracle-verified divergences. Expected to fail until fixed.
+// Regression floor for the repaint fix (#16610, #16645).
 // ---------------------------------------------------------------------------
 
 /// A longhand primitive union is repainted by a **lib** alias the source never
@@ -179,17 +180,74 @@ fn an_alias_declared_after_the_use_site_does_not_repaint_the_longhand_union() {
 
 /// A separate mechanism in the same display family: tsc resolves `keyof any` to
 /// `string | number | symbol` eagerly, so the operator never reaches the
-/// printer. tsz keeps the `KeyOf` node and renders it verbatim.
+/// printer. `get_type_from_type_operator` now does the same for a bare
+/// `any`/`unknown`/`never` operand.
 ///
 /// Kept in this file because the two interact — once `keyof any` resolves to
-/// the union, it lands on exactly the `TypeId` the rows above show is
-/// repainted, so fixing this one alone would render `PropertyKey` here.
+/// the union, it lands on exactly the `TypeId` the rows above show is (no
+/// longer) repainted, so this row only stays green once the repaint rows above
+/// are also fixed.
 #[test]
-#[ignore = "known divergence: `keyof any` is not resolved to its member union for display"]
 fn keyof_any_renders_as_its_resolved_member_union() {
     let source = "declare const value: keyof any;\n\
                   const target: boolean = value;\n";
     assert_eq!(rendered_source_type(source), "string | number | symbol");
+}
+
+/// Sibling degenerate operand: `keyof never` resolves the same way as
+/// `keyof any` (`tsc`'s `getIndexType` treats both eagerly), with an
+/// unreferenced primitive-union alias in scope so the row also exercises the
+/// repaint guard above.
+#[test]
+fn keyof_never_renders_as_its_resolved_member_union() {
+    let source = "type Zed = string | number | symbol;\n\
+                  declare const value: keyof never;\n\
+                  const target: boolean = value;\n";
+    assert_eq!(rendered_source_type(source), "string | number | symbol");
+}
+
+/// Renamed binder: a differently-named unused alias in scope must not change
+/// the outcome — rules out anything keyed on the specific `Zed`/`PropertyKey`
+/// spelling.
+#[test]
+fn keyof_any_renders_as_its_resolved_member_union_with_renamed_alias_in_scope() {
+    let source = "type Zorb = string | number | symbol;\n\
+                  declare const value: keyof any;\n\
+                  const target: boolean = value;\n";
+    assert_eq!(rendered_source_type(source), "string | number | symbol");
+}
+
+/// A non-generic type alias whose body IS `keyof any`, referenced by name at
+/// the use site (`Foo`), should still render structurally — `tsc`'s
+/// `getIndexType` resolves the operand before the alias machinery can attach
+/// an `aliasSymbol` to the result, so even a genuinely-written-through alias
+/// carries none. tsz's separate "written through the alias" display path
+/// (for `declare const value: Foo`, `value`'s annotation is the `TYPE_REFERENCE`
+/// `Foo`, not `keyof any` itself, so the degenerate-operand guard above does
+/// not see it) still prints `Foo`. A real, adjacent divergence surfaced while
+/// building the guard above, but a distinct mechanism and out of this fix's
+/// scope: fixing it needs the alias-body check to propagate through the
+/// written-through-alias display path, not the annotation-node guard.
+#[test]
+#[ignore = "known divergence: a named alias whose body is `keyof any` keeps the alias name instead of resolving structurally"]
+fn keyof_any_type_alias_body_renders_structurally_even_written_through() {
+    let source = "type Foo = keyof any;\n\
+                  declare const value: Foo;\n\
+                  const target: boolean = value;\n";
+    assert_eq!(rendered_source_type(source), "string | number | symbol");
+}
+
+/// Negative control: `keyof <named interface>` is not a degenerate operand —
+/// it keeps its own `keyof Name` display (existing, unrelated mechanism),
+/// which the new guard must not disturb. Needs a literal-sensitive target
+/// (`tsc` widens a `keyof` source to `string` against any other target,
+/// independent of this fix).
+#[test]
+fn keyof_named_interface_still_renders_keyof_name() {
+    let source = "interface Widget { a: number; b: string }\n\
+                  declare const value: keyof Widget;\n\
+                  const target: \"z\" = value;\n";
+    assert_eq!(rendered_source_type(source), "keyof Widget");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/tsz-lowering/src/lower/advanced.rs
+++ b/crates/tsz-lowering/src/lower/advanced.rs
@@ -920,7 +920,20 @@ impl TypeLowering<'_> {
         // Check which operator it is
         match data.operator {
             // KeyOfKeyword = 143
-            143 => self.interner.keyof(inner_type),
+            //
+            // tsc's `getIndexType` resolves an `any`/`unknown`/`never` operand to
+            // its fixed key-space result (`string | number | symbol` / `never` /
+            // `string | number | symbol`) immediately rather than building a
+            // deferred `IndexType`, so the operator itself never survives to a
+            // declared type or the printer for these operands. Other operands
+            // (object/interface/generic) keep the deferred `KeyOf` node so later
+            // consumers still see `keyof T`.
+            143 => match inner_type {
+                TypeId::ANY | TypeId::UNKNOWN | TypeId::NEVER => {
+                    tsz_solver::computation::evaluate_keyof(self.interner, inner_type)
+                }
+                _ => self.interner.keyof(inner_type),
+            },
             // ReadonlyKeyword = 148
             148 => self.interner.readonly_type(inner_type),
             // UniqueKeyword = 158 - unique symbol


### PR DESCRIPTION
tsc's `getIndexType` resolves an `any`/`unknown`/`never` operand to its fixed key-space result (`string | number | symbol` / `never`) immediately at type-construction time, so the resulting type carries no `aliasSymbol` and the `keyof` operator never reaches `typeToString`. tsz built a deferred `KeyOf` node unconditionally in both places a `keyof` type-operator gets constructed (`crates/tsz-checker/src/types/type_node_advanced.rs`'s `get_type_from_type_operator`, and `crates/tsz-lowering/src/lower/advanced.rs`'s `lower_type_operator`), so `declare const v: keyof any;` computed the right semantic type but displayed `keyof any` verbatim.

Root cause was two independent gaps stacked on the same repro:

1. Both `keyof`-operator construction sites deferred unconditionally instead of eagerly evaluating for a degenerate `any`/`unknown`/`never` operand, matching tsc's `getIndexType`. Fixed by eagerly calling `evaluate_keyof` for exactly those three operands; every other operand (object, interface, generic) keeps the deferred `KeyOf` node so `keyof T` still displays.
2. Even after (1), the assignment-source diagnostic formatter's "declared annotation" fallback (`declared_type_annotation_text_for_symbol_type` / `declared_type_annotation_text_for_expression_with_options`) reproduces a variable's ANNOTATION SOURCE TEXT verbatim when a reverse type-to-symbol lookup finds one, regardless of whether that annotation is something tsc still preserves. For `keyof any` it isn't (per (1)) — this repainted the already-correctly-evaluated union with the literal `keyof any` text. Fixed with a new structural guard, `annotation_is_keyof_over_degenerate_operand`, declining the text fallback for exactly this annotation shape (mirrors the existing `annotation_names_type_query_alias` guard already used at every one of these call sites). A parallel `keyof_degenerate_operand_source_display` gate (same family as #16610's `longhand_primitive_union_source_display`) covers the case where the freshly-evaluated union coincidentally interns to the same `TypeId` as a genuinely-referenced `PropertyKey` elsewhere (e.g. inside the loaded lib), which would otherwise repaint it via the reverse type-to-def lookup.

While investigating, found that #16610's core repaint bug (rows 1-4) and its TS2344 sibling #16663 were BOTH already fixed on main by #16645 (`3b916ec`) — closed both issues with test-run evidence rather than re-deriving a fix that had already landed, and picked up the one genuinely open row from #16610's own matrix (row 5, `keyof any` display) as this PR.

Adjacent-case matrix (`union_display_alias_repaint_parity_tests.rs`, oracle-verified against pinned `typescript@7.0.2`):

| case | tsc | before | after |
| --- | --- | --- | --- |
| `keyof any` (unreferenced alias in scope) | structural | `keyof any` | structural |
| `keyof never` (sibling degenerate operand) | structural | `keyof never` | structural |
| renamed unused alias in scope | structural | `keyof any` | structural |
| `keyof <named interface>` (negative control) | `keyof Name` | `keyof Name` | `keyof Name` (unchanged) |
| named alias whose body is `keyof any`, referenced by name | structural | `Foo` | `Foo` (pinned `#[ignore]`d tripwire — separate, deeper mechanism, out of this PR's scope) |

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test union_display_alias_repaint_parity_tests --test ts2344_primitive_key_union_alias_constraint_display_tests` — 28 passed, 0 failed, 4 ignored (5 new live rows, 1 new documented tripwire; re-verified after rebasing onto main tip `8ceb4ae`, which independently fixed the pre-existing alias-chain tripwire in the same test file).
- `cargo build -p tsz-checker -p tsz-lowering --lib` — clean.
- `cargo clippy -p tsz-checker -p tsz-lowering --lib --all-features -- -D warnings` — clean.
- `cargo fmt -p tsz-checker -p tsz-lowering -- --check` — clean.
- `python3 scripts/arch/arch_guard.py` — clean (split `keyof_degenerate_operand_source_display` into `keyof_source_display.rs` to keep `assignment_formatting.rs` under the 2000-line ceiling).
- Manual cross-check against pinned `typescript@7.0.2` for every row in the adjacent matrix above.
- Owed: full `cargo test -p tsz-checker --lib` (~10.4k tests) was still running in the background at push time (long-tail suite per the board's standing notes, and this cloud container is disk-constrained); will report the count in a follow-up comment if it turns up anything.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7MdYjx42AfdbkKmmYNEv6)_