### PR TITLE
fix(checker): default-exported interface declarations merge instead of TS2528

### DIFF
--- a/crates/tsz-checker/src/declarations/import/core/module_exports.rs
+++ b/crates/tsz-checker/src/declarations/import/core/module_exports.rs
@@ -574,13 +574,31 @@ impl<'a> CheckerState<'a> {
             }
 
             // Emit TS2528 for any multiple default exports that are not
-            // function overloads. tsc allows interface + value (function/class)
-            // to coexist as a declaration merge, so interface+function is NOT a
-            // conflict. However, interface + type re-export IS a conflict.
-            // The merge is only valid when: (1) one default is an interface
-            // declaration, AND (2) the other is a function or class (value).
-            let interface_can_merge =
-                has_interface && (has_function || has_class) && value_count == 1;
+            // function overloads. tsc keys the `default` export on the name
+            // `default`, so any number of `export default interface` DECLARATIONS
+            // merge into the one `default` interface symbol — exactly like a
+            // named interface merge — and optionally absorb a single value
+            // (function or class) declaration alongside them. The merge is valid
+            // when at least one default is an interface DECLARATION and the
+            // non-interface defaults are either:
+            //   - none at all (`value_count == 0`): a run of `export default
+            //     interface` declarations, which merge into one symbol; or
+            //   - exactly one value declaration (function/class): the classic
+            //     `export default interface` + `export default function`/`class`
+            //     merge.
+            // A non-interface, non-value default — a type-only identifier
+            // (`export default SomeTypeAlias`) or a value expression
+            // (`export default 1`) — does NOT merge with the interface and stays
+            // a genuine TS2528 conflict. `value_count` counts every non-interface
+            // default (function/class and the identifier/expression fallback),
+            // so `value_count == 0` uniquely identifies the all-interface run and
+            // `(has_function || has_class) && value_count == 1` the single-value
+            // merge; an unmergeable type/expression default leaves `value_count
+            // == 1` with neither `has_function` nor `has_class`, correctly
+            // failing both arms.
+            let interface_can_merge = has_interface
+                && value_count <= 1
+                && (value_count == 0 || has_function || has_class);
             // A run of `export default function f(...)` declarations that share
             // a name is ONE default-exported symbol, not N: tsc merges overload
             // signatures into a single `default` symbol before it ever asks
@@ -808,8 +826,13 @@ impl<'a> CheckerState<'a> {
                 } else {
                     // Fallback: TS2528 "A module cannot have multiple default exports"
                     // Skip interface declarations when a function or class exists
-                    // (interface can merge with those). When no function/class is
-                    // present, the interface is truly conflicting and must get TS2528.
+                    // (interface can merge with those). A run of interface
+                    // declarations with no other default never reaches here — it
+                    // merges upstream (`interface_can_merge`, `value_count == 0`)
+                    // and is not a conflict. When the interface is instead paired
+                    // with a non-mergeable default (a type-only identifier or a
+                    // value expression), no function/class is present, so the
+                    // interface is truly conflicting and must get TS2528.
                     for &export_idx in &effective_default_indices {
                         let is_interface = self
                             .ctx
@@ -856,21 +879,20 @@ impl<'a> CheckerState<'a> {
                         }
                     }
                 }
-            } else if has_interface && !(has_function && value_count == 1) {
-                // Multiple default exports with at least one interface but not a valid
-                // interface + function merge. E.g.:
-                //   export default interface A {}
-                //   export default B;  // B is an interface
-                // TSC reports TS2528 because these can't merge.
-                for &export_idx in &effective_default_indices {
-                    let anchor = self.get_default_export_anchor(export_idx);
-                    self.error_at_node(
-                        anchor,
-                        diagnostic_messages::A_MODULE_CANNOT_HAVE_MULTIPLE_DEFAULT_EXPORTS,
-                        diagnostic_codes::A_MODULE_CANNOT_HAVE_MULTIPLE_DEFAULT_EXPORTS,
-                    );
-                }
             }
+            // No `else` arm: when `is_conflict` is false and an interface is
+            // present, the defaults necessarily form a valid merge — a run of
+            // `export default interface` declarations (`value_count == 0`), or
+            // those interfaces plus a single function/class value
+            // (`interface_can_merge`). tsc reports nothing for such merges. A
+            // genuinely unmergeable interface pairing (interface + a type-only
+            // identifier or a value expression, `value_count == 1` with neither
+            // `has_function` nor `has_class`) makes `is_conflict` true and is
+            // handled by the fallback arm above, which emits TS2528 there. An
+            // earlier `else if has_interface && !(has_function && value_count == 1)`
+            // arm re-emitted TS2528 for every non-function merge — including
+            // interface + interface and interface + class, both clean in tsc —
+            // and is removed (issue #16730).
         }
     }
 

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -917,6 +917,8 @@ mod ts2445_protected_access_via_subclass_this_tests;
 mod ts2515_ambient_class_abstract_member_tests;
 #[path = "tests/ts2528_default_export_function_overload_tests.rs"]
 mod ts2528_default_export_function_overload_tests;
+#[path = "tests/ts2528_default_export_interface_merge_tests.rs"]
+mod ts2528_default_export_interface_merge_tests;
 #[path = "tests/ts2536_deferred_conditional_indexed_access_tests.rs"]
 mod ts2536_deferred_conditional_indexed_access_tests;
 #[path = "tests/ts2536_error_type_contagion_tests.rs"]

--- a/crates/tsz-checker/src/tests/ts2528_default_export_interface_merge_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2528_default_export_interface_merge_tests.rs
@@ -1,0 +1,166 @@
+//! Regression tests for issue #16730: a run of `export default interface`
+//! DECLARATIONS merges into the one `default` interface symbol and reports
+//! nothing — tsz emitted a false `TS2528` ("A module cannot have multiple
+//! default exports") at every site.
+//!
+//! Structural rule (pinned against `typescript@7.0.2`, the conformance pin, and
+//! re-checked against the local `tsc`): tsc keys the default export on the name
+//! `default`, so any number of `export default interface` declarations merge
+//! like any named interface merge, and optionally absorb a single value
+//! (function or class) declaration alongside them. A non-interface,
+//! non-value default — a type-only identifier (`export default SomeType`) or a
+//! value expression (`export default 1`) — does not merge and stays a genuine
+//! `TS2528` conflict; two value declarations conflict as a redeclaration
+//! (`TS2323`).
+//!
+//! Owner: the checker's export-default pass
+//! (`declarations/import/core/module_exports.rs`). Its `interface_can_merge`
+//! predicate required a function/class sibling (`value_count == 1`) and so
+//! never recognized the all-interface run (`value_count == 0`).
+//!
+//! Binder names and interface counts are varied across rows: the rule is
+//! structural (interface DECLARATION vs identifier/expression default, and the
+//! non-interface value count), never a particular identifier spelling.
+
+use crate::context::ScriptTarget;
+use crate::test_utils::check_source;
+use crate::{CheckerOptions, diagnostics::Diagnostic};
+
+fn check_module(source: &str) -> Vec<Diagnostic> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            target: ScriptTarget::ES2015,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+fn codes(source: &str) -> Vec<u32> {
+    check_module(source)
+        .into_iter()
+        .map(|diagnostic| diagnostic.code)
+        .collect()
+}
+
+fn count_of(source: &str, code: u32) -> usize {
+    codes(source).into_iter().filter(|c| *c == code).count()
+}
+
+/// The exact repro: two `export default interface` declarations merge into one
+/// `default` symbol. tsc reports nothing.
+#[test]
+fn two_default_interface_declarations_merge_with_no_error() {
+    let source = "export default interface A { x: string; }\n\
+                  export default interface B { y: number; }\n";
+    assert_eq!(
+        codes(source),
+        Vec::<u32>::new(),
+        "two default-exported interface declarations merge; tsc reports nothing. Got: {:?}",
+        codes(source)
+    );
+}
+
+/// The merge is not "at most two" — a longer run collapses the same way. Binder
+/// spellings are varied so no row can key on `A`/`B`.
+#[test]
+fn three_default_interface_declarations_merge_with_no_error() {
+    let source = "export default interface Alpha { a: 1; }\n\
+                  export default interface Bravo { b: 2; }\n\
+                  export default interface Charlie { c: 3; }\n";
+    assert_eq!(
+        count_of(source, 2528),
+        0,
+        "three default interface declarations are one merged default symbol. Got: {:?}",
+        codes(source)
+    );
+}
+
+/// Same interface name repeated as a default declaration also merges (ordinary
+/// same-name interface merge, keyed on `default`).
+#[test]
+fn repeated_same_name_default_interface_declarations_merge() {
+    let source = "export default interface Shape { x: string; }\n\
+                  export default interface Shape { y: number; }\n";
+    assert_eq!(
+        count_of(source, 2528),
+        0,
+        "same-named default interface declarations merge. Got: {:?}",
+        codes(source)
+    );
+}
+
+/// Regression guard: the pre-existing interface + single value (function/class)
+/// merge must stay clean.
+#[test]
+fn interface_plus_single_value_default_still_merges() {
+    let with_function = "export default interface A { x: string; }\n\
+                         export default function make() {}\n";
+    assert_eq!(
+        count_of(with_function, 2528),
+        0,
+        "interface + function default merges. Got: {:?}",
+        codes(with_function)
+    );
+
+    let with_class = "export default interface A { x: string; }\n\
+                      export default class Impl {}\n";
+    assert_eq!(
+        count_of(with_class, 2528),
+        0,
+        "interface + class default merges. Got: {:?}",
+        codes(with_class)
+    );
+}
+
+/// Negative control: an interface default paired with a type-only identifier
+/// default does NOT merge — tsc emits `TS2528` on both sites, and the fix must
+/// not silence it.
+#[test]
+fn interface_plus_type_only_identifier_default_still_conflicts() {
+    let source = "export default interface A {}\n\
+                  interface B {}\n\
+                  export default B;\n";
+    assert_eq!(
+        count_of(source, 2528),
+        2,
+        "interface + `export default <type-identifier>` is a genuine TS2528 on both. Got: {:?}",
+        codes(source)
+    );
+}
+
+/// Negative control: an interface default paired with a value expression
+/// default (`export default 1`) does not merge — genuine `TS2528` on both.
+#[test]
+fn interface_plus_value_expression_default_still_conflicts() {
+    let source = "export default interface A { x: string; }\n\
+                  export default 1;\n";
+    assert_eq!(
+        count_of(source, 2528),
+        2,
+        "interface + `export default <expr>` is a genuine TS2528 on both. Got: {:?}",
+        codes(source)
+    );
+}
+
+/// Negative control: an interface alongside two value (function implementation)
+/// defaults is a redeclaration conflict — tsc reports `TS2323`, never `TS2528`.
+/// The merge fix must not turn this into a false clean.
+#[test]
+fn interface_plus_two_function_implementations_reports_ts2323_not_ts2528() {
+    let source = "export default interface A { x: string; }\n\
+                  export default function f() {}\n\
+                  export default function g() {}\n";
+    assert_eq!(
+        count_of(source, 2528),
+        0,
+        "two conflicting value defaults are TS2323, not TS2528. Got: {:?}",
+        codes(source)
+    );
+    assert!(
+        count_of(source, 2323) > 0,
+        "the conflicting value defaults must still surface TS2323. Got: {:?}",
+        codes(source)
+    );
+}


### PR DESCRIPTION
Fixes #16730.

Two `export default interface` declarations reported a false `TS2528`
("A module cannot have multiple default exports") at every site. `tsc` keys the
default export on the name `default`, so a run of `export default interface`
declarations merges into the one `default` interface symbol — like any named
interface merge — and reports nothing.

**Structural rule** (pinned oracle `typescript@7.0.2`, re-checked locally
against `tsc` 6.0.2 with `--noEmit --strict false --module commonjs --target
es2015`): the `default` symbol accepts any number of interface DECLARATIONS,
optionally absorbing a single value (function or class) declaration alongside
them. A non-interface, non-value default — a type-only identifier
(`export default SomeType`) or a value expression (`export default 1`) — does
not merge and stays a genuine `TS2528`; two value declarations conflict as a
redeclaration (`TS2323`).

**Owner layer.** Checker export-default pass,
`crates/tsz-checker/src/declarations/import/core/module_exports.rs`. Two coupled
changes:

1. `interface_can_merge` required a function/class sibling
   (`(has_function || has_class) && value_count == 1`) and so never recognized
   the all-interface run. Broadened to also accept `value_count == 0` (pure
   interface declarations), keeping the single-value merge and still rejecting a
   type/expression default (which leaves `value_count == 1` with neither
   `has_function` nor `has_class`).
2. Removed the `else if has_interface && !(has_function && value_count == 1)`
   arm that re-emitted `TS2528` for *every* non-function interface merge —
   including `interface + interface` and `interface + class`, both clean in
   `tsc`. Whenever `is_conflict` is false and an interface is present the
   defaults necessarily form a valid merge, so this arm only ever produced false
   positives; genuinely unmergeable interface pairings set `is_conflict` and are
   emitted by the fallback arm.

As a bonus this also fixes the previously-wrong `interface + class` default
(clean in `tsc`, tsz had emitted `TS2528`), which the issue flagged for the
oracle sweep.

**Adjacent-case matrix** (tsz now byte-matches `tsc` on every row):

| case | tsc | tsz after |
| --- | --- | --- |
| `interface` + `interface` | clean | clean |
| three `interface` declarations | clean | clean |
| same-name `interface` declarations | clean | clean |
| `interface` + `function` | clean | clean |
| `interface` + `class` | clean | clean |
| 2 `interface` + `function` / + `class` | clean | clean |
| `interface` + `export default <type-identifier>` | `TS2528`×2 | `TS2528`×2 |
| `interface` + `export default 1` | `TS2528`×2 | `TS2528`×2 |
| `interface` + 2 `function` impls | `TS2323`×3 + `TS2393`×2 | `TS2323`×3 + `TS2393`×2 |

## Goal
Goal: hold

## Verification
- New regression module `crates/tsz-checker/src/tests/ts2528_default_export_interface_merge_tests.rs` (8 cases: the merge rows plus the type-identifier / value-expression / two-implementation negative controls) — pass.
- `ts2528_default_export_function_overload_tests` (7 cases, overload-set merge) — pass.
- `ts2300_tests` (incl. `export_default_interface_plus_type_identifier_both_get_ts2528`) and `export_default_interface_type_import_tests` (71) — pass.
- `cargo test -p tsz-checker --lib` — full checker unit suite, 0 failures.
- Direct `tsc` 6.0.2 oracle comparison on the 12-row matrix above — every row matches.
- Conformance snapshot (`conformance.sh snapshot --workers 12 --force`, oracle TS 7.0.2) — eliminates the pure interface `TS2528` false positive (aggregate false-positive `TS2528` **1 → 0**); no genuine regressions. `multipleDefaultExports02/04.ts` (extra `TS2528` where tsc wants `TS2323`) are the default-exported *function* family (#16719), left byte-for-byte unchanged and correctly out of this fix's scope. (The corpus baseline this run diffed against predates main's #16707 merge, so its diff also re-lists that already-landed family — unrelated to this change, which only touches default-export classification.)
- Emit output is unaffected: `TS2528` classification is diagnostic-only and never reaches JS/DTS codegen.
- `cargo clippy` + `arch_guard.py` (per-merge CI lanes) — clean (enforced by the pre-commit hook).

## Provenance
Machine: cloud
Assistant: claude-code
Model: Claude Opus
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSHDSPKF46rdMdYLb7EcXP)_