### PR TITLE
fix(checker): exported function declarations join statement-level overload grouping (#16723)

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/default_export_overload_group.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/default_export_overload_group.rs
@@ -1,0 +1,263 @@
+//! Merged `default`-export function group checks (TS2391/TS2394).
+//!
+//! tsc binds every `export default function` declaration — whatever its local
+//! name — to the single `default` export symbol, then runs
+//! `checkFunctionOrConstructorSymbol` over that merged declaration list in
+//! addition to the per-local-name runs. Two behaviors only exist in the merged
+//! run:
+//!
+//! - anonymous default-exported signatures (no local name, so the name-keyed
+//!   statement walk cannot group them): a bodyless anonymous signature with no
+//!   implementation gets `TS2391`, anchored at the whole statement; only the
+//!   last of a consecutive bodyless run is reported;
+//! - `TS2394`: every bodyless signature of the merged group is checked against
+//!   the group's *first* implementation body, in declaration order, and only
+//!   the first incompatible signature is reported (oracle-pinned against
+//!   `typescript@7.0.2`: a cross-name signature is incompatible with another
+//!   name's body, and a signature whose own name has a compatible body still
+//!   reports against an earlier body of a different name).
+//!
+//! - `TS2391` on a body-carrying declaration whose group continues past a
+//!   textual gap (`export default function a() {...}` / other statements /
+//!   `export default function b(): void;` marks `a` too — oracle-pinned).
+//!
+//! Named signatures' terminal/gap `TS2391`/`TS2389` mostly coincide with what
+//! the name-keyed walk in `check_function_implementations` reports (tsc emits
+//! them from the per-local-name run as well and deduplicates); the checker's
+//! diagnostic sink dedups by (start, code), so this pass mirrors tsc's walk
+//! faithfully instead of special-casing the overlap.
+
+use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+
+struct DefaultFunctionEntry {
+    /// Position in the statement list, used for tsc's textual-adjacency test
+    /// (`previousDeclaration.end !== node.pos`) at statement granularity.
+    list_pos: usize,
+    /// The statement node (export wrapper) — the anchor for anonymous errors.
+    stmt_idx: NodeIndex,
+    /// The function declaration node inside the wrapper.
+    fn_idx: NodeIndex,
+    has_body: bool,
+}
+
+impl<'a> CheckerState<'a> {
+    /// Run the merged `default`-symbol half of function-implementation
+    /// checking over a statement list. See the module docs for scope.
+    pub(crate) fn check_default_export_function_group(&mut self, statements: &[NodeIndex]) {
+        let mut entries: Vec<DefaultFunctionEntry> = Vec::new();
+        for (list_pos, &stmt_idx) in statements.iter().enumerate() {
+            let Some((fn_idx, true)) = self.statement_function_declaration_view(stmt_idx) else {
+                continue;
+            };
+            let Some(fn_node) = self.ctx.arena.get(fn_idx) else {
+                continue;
+            };
+            let Some(func) = self.ctx.arena.get_function(fn_node) else {
+                continue;
+            };
+            // tsc resets its walk at ambient declarations; a declaration-file
+            // or `declare module` body contributes nothing to this pass.
+            if self.is_ambient_declaration(fn_idx) {
+                continue;
+            }
+            entries.push(DefaultFunctionEntry {
+                list_pos,
+                stmt_idx,
+                fn_idx,
+                has_body: func.body.is_some(),
+            });
+        }
+        if entries.is_empty() {
+            return;
+        }
+
+        // tsc's walk: when a group member is not textually adjacent to its
+        // predecessor, the predecessor gets an implementation-expected report
+        // (unless the member is a duplicate implementation, which the
+        // `TS2393` family in `module_exports.rs` owns); a bodyless final
+        // member gets the terminal report. A consecutive bodyless run
+        // therefore reports only its last member.
+        let mut body_decl_seen = false;
+        let mut prev: Option<usize> = None;
+        for (pos, entry) in entries.iter().enumerate() {
+            if entry.has_body && body_decl_seen {
+                // Duplicate implementation: redeclare family, owned elsewhere.
+            } else if let Some(prev_pos) = prev
+                && entry.list_pos != entries[prev_pos].list_pos + 1
+            {
+                self.report_implementation_expected(&entries[prev_pos], statements);
+            }
+            if entry.has_body {
+                body_decl_seen = true;
+            }
+            prev = Some(pos);
+        }
+        if let Some(last) = entries.last()
+            && !last.has_body
+        {
+            self.report_implementation_expected(last, statements);
+        }
+
+        // TS2394 over the merged group: each bodyless signature against the
+        // group's first implementation, first incompatible only.
+        if !entries.iter().any(|e| !e.has_body) {
+            return;
+        }
+        let Some(impl_entry_fn) = entries.iter().find(|e| e.has_body).map(|e| e.fn_idx) else {
+            return;
+        };
+        let signature_entries: Vec<(NodeIndex, NodeIndex)> = entries
+            .iter()
+            .filter(|e| !e.has_body)
+            .map(|e| (e.fn_idx, e.stmt_idx))
+            .collect();
+        self.report_first_incompatible_default_overload(impl_entry_fn, &signature_entries);
+    }
+
+    /// tsc's `reportImplementationExpectedError` for a merged-`default`-group
+    /// member: peek at the textually adjacent next statement; a same-named
+    /// function is a grouping question, not a missing implementation; an
+    /// adjacent differently-named implementation gets `TS2389`; everything
+    /// else is `TS2391` at the member's name, or at the whole export
+    /// statement for an anonymous member (tsc anchors at the declaration
+    /// node, whose span includes the `export default` modifiers).
+    fn report_implementation_expected(
+        &mut self,
+        entry: &DefaultFunctionEntry,
+        statements: &[NodeIndex],
+    ) {
+        // Mirror the name-keyed walk's parser-recovery suppression.
+        if self.has_syntax_parse_errors()
+            && let Some(stmt_node) = self.ctx.arena.get(entry.stmt_idx)
+            && self
+                .ctx
+                .syntax_parse_error_positions
+                .iter()
+                .any(|&p| p >= stmt_node.pos && p <= stmt_node.end)
+        {
+            return;
+        }
+        let entry_name = self.get_function_name_from_node(entry.fn_idx);
+        if let Some(&next_stmt) = statements.get(entry.list_pos + 1)
+            && let Some((next_fn_idx, _)) = self.statement_function_declaration_view(next_stmt)
+            && let Some(next_node) = self.ctx.arena.get(next_fn_idx)
+            && let Some(next_func) = self.ctx.arena.get_function(next_node)
+        {
+            let next_name = self.get_function_name_from_node(next_fn_idx);
+            if entry_name.is_some() && next_name.is_some() && entry_name == next_name {
+                return;
+            }
+            if next_func.body.is_some()
+                && let Some(expected) = entry_name.as_deref()
+            {
+                let impl_error_node = if next_func.name.is_some() {
+                    next_func.name
+                } else {
+                    next_stmt
+                };
+                self.error_at_node(
+                    impl_error_node,
+                    &format!("Function implementation name must be '{expected}'."),
+                    diagnostic_codes::FUNCTION_IMPLEMENTATION_NAME_MUST_BE,
+                );
+                return;
+            }
+        }
+        let error_node = self
+            .ctx
+            .arena
+            .get(entry.fn_idx)
+            .and_then(|n| self.ctx.arena.get_function(n))
+            .map(|f| f.name)
+            .filter(|n| n.is_some())
+            .unwrap_or(entry.stmt_idx);
+        self.error_at_node(
+            error_node,
+            "Function implementation is missing or not immediately following the declaration.",
+            diagnostic_codes::FUNCTION_IMPLEMENTATION_IS_MISSING_OR_NOT_IMMEDIATELY_FOLLOWING_THE_DECLARATION,
+        );
+    }
+
+    /// Check each bodyless default-exported signature against the merged
+    /// group's implementation and report `TS2394` at the first incompatible
+    /// one. Anchors at the signature's name, or at the statement for an
+    /// anonymous signature.
+    fn report_first_incompatible_default_overload(
+        &mut self,
+        impl_fn_idx: NodeIndex,
+        signature_entries: &[(NodeIndex, NodeIndex)],
+    ) {
+        use crate::query_boundaries::assignability::get_function_return_type;
+        use crate::query_boundaries::assignability::replace_function_return_type;
+
+        let type_resolver = |node_idx: NodeIndex| -> Option<u32> {
+            self.ctx.binder.get_node_symbol(node_idx).map(|id| id.0)
+        };
+        let value_resolver = |node_idx: NodeIndex| -> Option<u32> {
+            self.ctx.binder.get_node_symbol(node_idx).map(|id| id.0)
+        };
+        let lowering = tsz_lowering::TypeLowering::with_resolvers(
+            self.ctx.arena,
+            self.ctx.types,
+            &type_resolver,
+            &value_resolver,
+        );
+
+        // Implementation type: manual lowering, with the same inferred-return
+        // fallbacks the symbol-driven `check_overload_compatibility` applies.
+        let impl_return_override = self.get_impl_return_type_override(impl_fn_idx);
+        let mut impl_type =
+            lowering.lower_signature_from_declaration(impl_fn_idx, impl_return_override);
+        if impl_type == tsz_solver::TypeId::ERROR {
+            let node_type = self.get_type_of_node(impl_fn_idx);
+            if node_type == tsz_solver::TypeId::ERROR {
+                return;
+            }
+            impl_type = node_type;
+        }
+        if impl_return_override.is_some() {
+            let inferred_type = self.get_type_of_node(impl_fn_idx);
+            if inferred_type != tsz_solver::TypeId::ERROR
+                && let Some(ret) = get_function_return_type(self.ctx.types, inferred_type)
+                && ret != tsz_solver::TypeId::ERROR
+            {
+                impl_type = replace_function_return_type(self.ctx.types, impl_type, ret);
+            }
+        }
+        impl_type = self.fix_error_params_in_function(impl_type);
+
+        for &(sig_fn_idx, sig_stmt_idx) in signature_entries {
+            let overload_return_override = self.get_overload_return_type_override(sig_fn_idx);
+            let mut overload_type =
+                lowering.lower_signature_from_declaration(sig_fn_idx, overload_return_override);
+            if overload_type == tsz_solver::TypeId::ERROR {
+                let node_type = self.get_type_of_node(sig_fn_idx);
+                if node_type == tsz_solver::TypeId::ERROR {
+                    continue;
+                }
+                overload_type = node_type;
+            }
+            overload_type = self.fix_error_params_in_function(overload_type);
+
+            if !self.is_implementation_compatible_with_overload(impl_type, overload_type) {
+                let error_node = self
+                    .ctx
+                    .arena
+                    .get(sig_fn_idx)
+                    .and_then(|n| self.ctx.arena.get_function(n))
+                    .map(|f| f.name)
+                    .filter(|n| n.is_some())
+                    .unwrap_or(sig_stmt_idx);
+                self.error_at_node(
+                    error_node,
+                    diagnostic_messages::THIS_OVERLOAD_SIGNATURE_IS_NOT_COMPATIBLE_WITH_ITS_IMPLEMENTATION_SIGNATURE,
+                    diagnostic_codes::THIS_OVERLOAD_SIGNATURE_IS_NOT_COMPATIBLE_WITH_ITS_IMPLEMENTATION_SIGNATURE,
+                );
+                // tsc reports only the first incompatible overload per symbol.
+                break;
+            }
+        }
+    }
+}

--- a/crates/tsz-checker/src/state/state_checking_members/mod.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/mod.rs
@@ -9,6 +9,7 @@ mod class_member_context;
 mod class_member_modifiers;
 mod class_type_param_checks;
 mod decorator_signature_checks;
+mod default_export_overload_group;
 mod function_declaration_checks;
 mod implicit_any_checks;
 mod implicit_any_param_context;

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -915,6 +915,8 @@ mod ts2339_js_this_function_name_display_tests;
 mod ts2341_private_access_via_type_param_constraint_tests;
 #[path = "tests/ts2353_generic_constraint_tests.rs"]
 mod ts2353_generic_constraint_tests;
+#[path = "tests/ts2391_default_export_overload_group_tests.rs"]
+mod ts2391_default_export_overload_group_tests;
 #[path = "tests/ts2445_protected_access_via_subclass_this_tests.rs"]
 mod ts2445_protected_access_via_subclass_this_tests;
 #[path = "tests/ts2515_ambient_class_abstract_member_tests.rs"]

--- a/crates/tsz-checker/src/tests/ts2391_default_export_overload_group_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2391_default_export_overload_group_tests.rs
@@ -1,0 +1,350 @@
+//! Regression tests for statement-level function-implementation grouping of
+//! exported function declarations (#16723).
+//!
+//! Structural rule (pinned against `typescript@7.0.2` with
+//! `--strict false --module commonjs --target es2015`): the parser wraps
+//! `export function ...` and `export default function ...` in an
+//! `EXPORT_DECLARATION` node, and the checker's statement walk must see
+//! through that wrapper — an exported function declaration joins the same
+//! name-keyed overload grouping as a bare one (`TS2391`/`TS2389`), exactly as
+//! tsc's per-local-name `checkFunctionOrConstructorSymbol` run does.
+//!
+//! Additionally, tsc binds every `export default function` — whatever its
+//! local name — to the single `default` export symbol and runs the same
+//! validation over that merged list: anonymous signatures group there
+//! (`TS2391` anchored at the whole statement), a body-carrying member whose
+//! group continues past a textual gap is marked too, and every bodyless
+//! signature is checked against the group's *first* implementation with only
+//! the first incompatible one reported (`TS2394`). tsz implements the merged
+//! half in `check_default_export_function_group`
+//! (`state_checking_members/default_export_overload_group.rs`).
+//!
+//! Binder names vary across rows; no row depends on identifier spelling.
+//! Known residuals deliberately not asserted here: mixed default/non-default
+//! same-name runs (tsc: `TS2383`; tsz currently reports `TS2652`) and
+//! export/non-export flag agreement (`TS2383`), which belong to a different
+//! diagnostic family.
+
+use crate::context::ScriptTarget;
+use crate::test_utils::{DiagnosticShape, assert_diagnostic_shapes_exactly, check_source};
+use crate::{CheckerOptions, diagnostics::Diagnostic};
+
+fn check_module(source: &str) -> Vec<Diagnostic> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            target: ScriptTarget::ES2015,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+/// Diagnostics restricted to the function-implementation grouping family, so
+/// rows stay pinned even when an unrelated family fires on the same fixture.
+fn family(source: &str) -> Vec<Diagnostic> {
+    check_module(source)
+        .into_iter()
+        .filter(|d| matches!(d.code, 2389 | 2391 | 2394))
+        .collect()
+}
+
+fn assert_family_exactly(source: &str, shapes: &[DiagnosticShape]) {
+    assert_diagnostic_shapes_exactly(source, &family(source), shapes);
+}
+
+/// #16723 witness: a cross-name default-exported signature is an orphan for
+/// its own local name (TS2391) and incompatible with the merged group's
+/// implementation (TS2394).
+///
+/// ```text
+/// tsc: (1,25) TS2391 + TS2394
+/// ```
+#[test]
+fn cross_name_default_signature_gets_orphan_and_incompatibility() {
+    let source = "export default function f(a: string): string;\n\
+                  export default function g(a: number): number;\n\
+                  export default function g(a: number): number { return a; }\n";
+    assert_family_exactly(
+        source,
+        &[
+            DiagnosticShape::code(2391).at(1, 25),
+            DiagnosticShape::code(2394).at(1, 25),
+        ],
+    );
+}
+
+/// #16723 witness: two cross-name bodyless defaults each orphan their own
+/// local name.
+#[test]
+fn two_cross_name_signature_only_defaults_each_get_ts2391() {
+    let source = "export default function head(a: string): string;\n\
+                  export default function tail(a: number): number;\n";
+    assert_family_exactly(
+        source,
+        &[
+            DiagnosticShape::code(2391).at(1, 25),
+            DiagnosticShape::code(2391).at(2, 25),
+        ],
+    );
+}
+
+/// A same-named default-exported overload set is clean, exactly like a bare
+/// one.
+#[test]
+fn same_named_default_overload_set_is_clean() {
+    let source = "export default function make(a: string): string;\n\
+                  export default function make(a: string): string { return a; }\n";
+    assert_family_exactly(source, &[]);
+}
+
+/// A compatible cross-name implementation adjacent to the signature reports
+/// the wrong-name diagnostic, not the orphan one.
+#[test]
+fn adjacent_cross_name_implementation_reports_ts2389() {
+    let source = "export default function alpha(a: string): string;\n\
+                  export default function beta(a: string): string { return a; }\n";
+    assert_family_exactly(source, &[DiagnosticShape::code(2389).at(2, 25)]);
+}
+
+/// Order flip: the implementation first, then an incompatible signature —
+/// terminal TS2391 plus merged-group TS2394, both at the signature.
+#[test]
+fn implementation_before_incompatible_signature() {
+    let source = "export default function beta(a: number): number { return a; }\n\
+                  export default function alpha(a: string): string;\n";
+    assert_family_exactly(
+        source,
+        &[
+            DiagnosticShape::code(2391).at(2, 25),
+            DiagnosticShape::code(2394).at(2, 25),
+        ],
+    );
+}
+
+/// A compatible cross-name signature gets only the orphan diagnostic — no
+/// TS2394 when the merged implementation accepts it.
+#[test]
+fn compatible_cross_name_signature_gets_only_ts2391() {
+    let source = "export default function one(a: number): number;\n\
+                  export default function two(a: number): number;\n\
+                  export default function two(a: number): number { return a; }\n";
+    assert_family_exactly(source, &[DiagnosticShape::code(2391).at(1, 25)]);
+}
+
+/// Same-name incompatible pair: the classic TS2394, now reachable through the
+/// export wrapper.
+#[test]
+fn same_named_incompatible_default_pair_reports_ts2394() {
+    let source = "export default function pick(a: string): number;\n\
+                  export default function pick(a: string): string { return a; }\n";
+    assert_family_exactly(source, &[DiagnosticShape::code(2394).at(1, 25)]);
+}
+
+/// Three names: only the FIRST incompatible signature of the merged group is
+/// reported (tsc breaks after one TS2394 per symbol), and the middle name's
+/// orphan resolves to a wrong-name report at the adjacent implementation.
+#[test]
+fn merged_group_reports_only_first_incompatible_signature() {
+    let source = "export default function f(a: string): string;\n\
+                  export default function g(a: number): number;\n\
+                  export default function h(a: number): number { return a; }\n";
+    assert_family_exactly(
+        source,
+        &[
+            DiagnosticShape::code(2391).at(1, 25),
+            DiagnosticShape::code(2394).at(1, 25),
+            DiagnosticShape::code(2389).at(3, 25),
+        ],
+    );
+}
+
+/// A non-function statement between the signature and the group's
+/// implementation is a textual gap: orphan plus incompatibility at the
+/// signature.
+#[test]
+fn statement_gap_before_implementation_is_an_orphan() {
+    let source = "export default function f(a: string): string;\n\
+                  const x = 1;\n\
+                  export default function g(a: number): number { return a; }\n";
+    assert_family_exactly(
+        source,
+        &[
+            DiagnosticShape::code(2391).at(1, 25),
+            DiagnosticShape::code(2394).at(1, 25),
+        ],
+    );
+}
+
+/// A gap after a body-carrying member whose group continues also marks the
+/// implementation itself (oracle-pinned: tsc reports both sites).
+#[test]
+fn gap_after_implementation_marks_the_implementation_too() {
+    let source = "export default function beta(a: number): number { return a; }\n\
+                  const z = 1;\n\
+                  export default function alpha(a: string): string;\n";
+    assert_family_exactly(
+        source,
+        &[
+            DiagnosticShape::code(2391).at(1, 25),
+            DiagnosticShape::code(2391).at(3, 25),
+            DiagnosticShape::code(2394).at(3, 25),
+        ],
+    );
+}
+
+/// A same-named implementation separated from its signature by a statement is
+/// only the signature's orphan — the implementation is not marked.
+#[test]
+fn same_name_gap_reports_only_the_signature() {
+    let source = "export default function a1(x: string): string;\n\
+                  const q = 1;\n\
+                  export default function a1(x: string): string { return x; }\n";
+    assert_family_exactly(source, &[DiagnosticShape::code(2391).at(1, 25)]);
+}
+
+/// An anonymous default signature anchors its orphan at the whole statement.
+#[test]
+fn anonymous_default_signature_anchors_at_the_statement() {
+    let source = "export default function (a: string): string;\n";
+    assert_family_exactly(source, &[DiagnosticShape::code(2391).at(1, 1)]);
+}
+
+/// Consecutive anonymous bodyless defaults report only the last one, like a
+/// same-named overload run.
+#[test]
+fn consecutive_anonymous_signatures_report_only_the_last() {
+    let source = "export default function (a: string): string;\n\
+                  export default function (a: string): string;\n";
+    assert_family_exactly(source, &[DiagnosticShape::code(2391).at(2, 1)]);
+}
+
+/// An anonymous signature satisfied by an adjacent anonymous implementation is
+/// clean.
+#[test]
+fn anonymous_signature_with_anonymous_implementation_is_clean() {
+    let source = "export default function (a: string): string;\n\
+                  export default function (a: string): string { return a; }\n";
+    assert_family_exactly(source, &[]);
+}
+
+/// An anonymous signature satisfied by an adjacent NAMED implementation is
+/// clean too — the merged `default` group does not care about local names.
+#[test]
+fn anonymous_signature_with_named_implementation_is_clean() {
+    let source = "export default function (a: string): string;\n\
+                  export default function g(a: string): string { return a; }\n";
+    assert_family_exactly(source, &[]);
+}
+
+/// A named signature followed by an anonymous implementation demands the
+/// name, anchored at the implementation statement.
+#[test]
+fn named_signature_with_anonymous_implementation_reports_ts2389() {
+    let source = "export default function s(a: string): string;\n\
+                  export default function (a: string): string { return a; }\n";
+    assert_family_exactly(source, &[DiagnosticShape::code(2389).at(2, 1)]);
+}
+
+/// An anonymous signature incompatible with the anonymous implementation gets
+/// TS2394 at the signature statement.
+#[test]
+fn anonymous_incompatible_signature_reports_ts2394_at_the_statement() {
+    let source = "export default function (a: string): string;\n\
+                  export default function (a: number): number { return a; }\n";
+    assert_family_exactly(source, &[DiagnosticShape::code(2394).at(1, 1)]);
+}
+
+/// A signature whose own name has a compatible implementation still checks
+/// against the merged group's FIRST body: `q`'s signature is validated
+/// against `p`'s implementation. The redeclare family keeps its own sites.
+#[test]
+fn signature_checks_against_the_groups_first_body() {
+    let source = "export default function p(a: string): string;\n\
+                  export default function p(a: string): string { return a; }\n\
+                  export default function q(a: number): number;\n\
+                  export default function q(a: number): number { return a; }\n";
+    let observed: Vec<Diagnostic> = check_module(source)
+        .into_iter()
+        .filter(|d| matches!(d.code, 2389 | 2391 | 2394 | 2393 | 2323))
+        .collect();
+    assert_diagnostic_shapes_exactly(
+        source,
+        &observed,
+        &[
+            DiagnosticShape::code(2393).at(1, 25),
+            DiagnosticShape::code(2323).at(2, 25),
+            DiagnosticShape::code(2393).at(2, 25),
+            DiagnosticShape::code(2394).at(3, 25),
+            DiagnosticShape::code(2393).at(3, 25),
+            DiagnosticShape::code(2323).at(4, 25),
+            DiagnosticShape::code(2393).at(4, 25),
+        ],
+    );
+}
+
+/// Non-default `export function` declarations join the grouping too: a
+/// cross-name exported implementation reports the wrong-name diagnostic.
+#[test]
+fn exported_cross_name_implementation_reports_ts2389() {
+    let source = "export function a(x: string): string;\n\
+                  export function b(x: string): string { return x; }\n";
+    assert_family_exactly(source, &[DiagnosticShape::code(2389).at(2, 17)]);
+}
+
+/// A lone exported bodyless signature is an orphan, exactly like a bare one.
+#[test]
+fn lone_exported_signature_reports_ts2391() {
+    let source = "export function solo2(a: string): string;\n";
+    assert_family_exactly(source, &[DiagnosticShape::code(2391).at(1, 17)]);
+}
+
+/// Positive controls: the bare-function paths keep their behavior.
+#[test]
+fn bare_function_grouping_is_unchanged() {
+    let orphan = "function solo(a: string): string;\n";
+    assert_family_exactly(orphan, &[DiagnosticShape::code(2391).at(1, 10)]);
+
+    let cross = "function a(x: string): string;\n\
+                 function b(x: string): string { return x; }\n";
+    assert_family_exactly(cross, &[DiagnosticShape::code(2389).at(2, 10)]);
+}
+
+/// Exported signatures inside a namespace body group as well.
+#[test]
+fn namespace_exported_signatures_join_the_grouping() {
+    let orphan = "namespace N {\n\
+                  \x20   export function inner(a: string): string;\n\
+                  }\n\
+                  export {};\n";
+    assert_family_exactly(orphan, &[DiagnosticShape::code(2391).at(2, 21)]);
+
+    let cross = "namespace M {\n\
+                 \x20   export function u(a: string): string;\n\
+                 \x20   export function v(a: string): string { return a; }\n\
+                 }\n\
+                 export {};\n";
+    assert_family_exactly(cross, &[DiagnosticShape::code(2389).at(3, 21)]);
+}
+
+/// Negative controls: ambient declarations stay silent — a `declare module`
+/// body full of bodyless defaults and an `export declare` signature are fine.
+#[test]
+fn ambient_signatures_stay_clean() {
+    let ambient_module = "declare module \"remote\" {\n\
+                          \x20   export default function connect(host: string): void;\n\
+                          \x20   export default function listen(port: number): void;\n\
+                          }\n";
+    assert_family_exactly(ambient_module, &[]);
+
+    let export_declare = "export declare function amb(a: string): string;\n";
+    assert_family_exactly(export_declare, &[]);
+}
+
+/// Negative control: a single default-exported implementation reports nothing
+/// from this family.
+#[test]
+fn single_default_implementation_is_clean() {
+    let source = "export default function only(a: string) { return a; }\n";
+    assert_family_exactly(source, &[]);
+}

--- a/crates/tsz-checker/src/types/queries/class.rs
+++ b/crates/tsz-checker/src/types/queries/class.rs
@@ -1184,31 +1184,63 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Resolve a statement to the function declaration it contributes to
+    /// statement-level function-implementation grouping, seeing through the
+    /// parser's `EXPORT_DECLARATION` wrapper (`export function ...` /
+    /// `export default function ...`). Returns the function node and whether
+    /// the statement is a default export.
+    pub(crate) fn statement_function_declaration_view(
+        &self,
+        stmt_idx: NodeIndex,
+    ) -> Option<(NodeIndex, bool)> {
+        let node = self.ctx.arena.get(stmt_idx)?;
+        if node.kind == syntax_kind_ext::FUNCTION_DECLARATION {
+            return Some((stmt_idx, false));
+        }
+        if node.kind == syntax_kind_ext::EXPORT_DECLARATION {
+            let export_decl = self.ctx.arena.get_export_decl(node)?;
+            let clause = self.ctx.arena.get(export_decl.export_clause)?;
+            if clause.kind == syntax_kind_ext::FUNCTION_DECLARATION {
+                return Some((export_decl.export_clause, export_decl.is_default_export));
+            }
+        }
+        None
+    }
+
     /// Check that all top-level function overload signatures have implementations.
     /// Reports errors 2389, 2391.
+    ///
+    /// The walk sees through export wrappers, so `export function` and
+    /// `export default function` declarations join the same name-keyed
+    /// grouping as bare declarations. Anonymous default-exported functions
+    /// have no local name to group under; they are handled by the merged
+    /// `default`-symbol pass (`check_default_export_function_group`), which
+    /// also owns the cross-name TS2394 check tsc runs over the one `default`
+    /// export symbol.
     pub(crate) fn check_function_implementations(&mut self, statements: &[NodeIndex]) {
         use crate::diagnostics::diagnostic_codes;
 
         let mut i = 0;
         while i < statements.len() {
             let stmt_idx = statements[i];
-            let Some(node) = self.ctx.arena.get(stmt_idx) else {
+            let Some((fn_idx, _)) = self.statement_function_declaration_view(stmt_idx) else {
                 i += 1;
                 continue;
             };
 
-            if node.kind == syntax_kind_ext::FUNCTION_DECLARATION
-                && let Some(func) = self.ctx.arena.get_function(node)
+            if let Some(stmt_node) = self.ctx.arena.get(stmt_idx)
+                && let Some(fn_node) = self.ctx.arena.get(fn_idx)
+                && let Some(func) = self.ctx.arena.get_function(fn_node)
                 && func.body.is_none()
             {
-                // Suppress TS2391 when a parse error occurs within the function declaration span.
-                // When `body.is_none()` and there are parse errors within the function span,
+                // Suppress TS2391 when a parse error occurs within the statement span.
+                // When `body.is_none()` and there are parse errors within the span,
                 // the function was likely malformed (e.g. `function f() => 4;`).
                 // This doesn't affect cases like `function f(a {` because the parser gives
                 // those a body (`body_none=false`) so they never reach this path.
                 if self.has_syntax_parse_errors() {
-                    let fn_start = node.pos;
-                    let fn_end = node.end;
+                    let fn_start = stmt_node.pos;
+                    let fn_end = stmt_node.end;
                     let has_error_in_fn = self
                         .ctx
                         .syntax_parse_error_positions
@@ -1219,7 +1251,7 @@ impl<'a> CheckerState<'a> {
                         continue;
                     }
                 }
-                let is_declared = self.is_ambient_declaration(stmt_idx);
+                let is_declared = self.is_ambient_declaration(fn_idx);
                 // Use func.is_async as the parser stores async as a flag, not a modifier
                 let is_async = func.is_async;
                 // TSC reports TS2389/TS2391 at the function name, not the declaration.
@@ -1240,13 +1272,13 @@ impl<'a> CheckerState<'a> {
                 }
 
                 if is_declared {
-                    if let Some(name) = self.get_function_name_from_node(stmt_idx) {
-                        let (has_impl, impl_name, impl_idx) =
+                    if let Some(name) = self.get_function_name_from_node(fn_idx) {
+                        let (has_impl, impl_name, impl_stmt_idx) =
                             self.find_function_impl(statements, i + 1, &name);
                         if has_impl
                             && impl_name.as_deref() == Some(name.as_str())
-                            && let Some(impl_idx) = impl_idx
-                            && !self.is_ambient_declaration(impl_idx)
+                            && let Some(impl_stmt_idx) = impl_stmt_idx
+                            && !self.is_ambient_declaration(impl_stmt_idx)
                         {
                             self.error_at_node(
                                 error_node,
@@ -1265,21 +1297,22 @@ impl<'a> CheckerState<'a> {
                 // Function overload signature - check for implementation.
                 // TSC only reports TS2391 on the LAST overload in a consecutive
                 // group with the same name, so skip ahead to find it.
-                let func_name = self.get_function_name_from_node(stmt_idx);
+                let func_name = self.get_function_name_from_node(fn_idx);
                 if let Some(name) = func_name {
                     // Advance past consecutive bodyless overloads with the same name.
                     let mut last_overload_i = i;
                     let mut j = i + 1;
                     while j < statements.len() {
-                        let next_idx = statements[j];
-                        let Some(next_node) = self.ctx.arena.get(next_idx) else {
+                        let Some((next_fn_idx, _)) =
+                            self.statement_function_declaration_view(statements[j])
+                        else {
                             break;
                         };
-                        if next_node.kind == syntax_kind_ext::FUNCTION_DECLARATION
+                        if let Some(next_node) = self.ctx.arena.get(next_fn_idx)
                             && let Some(next_func) = self.ctx.arena.get_function(next_node)
                             && next_func.body.is_none()
                         {
-                            let next_name = self.get_function_name_from_node(next_idx);
+                            let next_name = self.get_function_name_from_node(next_fn_idx);
                             if next_name.as_deref() == Some(name.as_str()) {
                                 last_overload_i = j;
                                 j += 1;
@@ -1292,15 +1325,14 @@ impl<'a> CheckerState<'a> {
                     // Report at the last overload in the group
                     let report_stmt_idx = statements[last_overload_i];
                     let report_error_node = self
-                        .ctx
-                        .arena
-                        .get(report_stmt_idx)
+                        .statement_function_declaration_view(report_stmt_idx)
+                        .and_then(|(f, _)| self.ctx.arena.get(f))
                         .and_then(|n| self.ctx.arena.get_function(n))
                         .map(|f| f.name)
                         .filter(|n| n.is_some())
                         .unwrap_or(report_stmt_idx);
 
-                    let (has_impl, impl_name, impl_idx) =
+                    let (has_impl, impl_name, impl_stmt_idx) =
                         self.find_function_impl(statements, last_overload_i + 1, &name);
                     if !has_impl {
                         self.error_at_node(
@@ -1308,26 +1340,26 @@ impl<'a> CheckerState<'a> {
                                     "Function implementation is missing or not immediately following the declaration.",
                                     diagnostic_codes::FUNCTION_IMPLEMENTATION_IS_MISSING_OR_NOT_IMMEDIATELY_FOLLOWING_THE_DECLARATION
                                 );
-                    } else if let Some(impl_idx) = impl_idx {
-                        if let Some(actual_name) = impl_name
-                            && actual_name != name
-                        {
-                            // Implementation has wrong name — report at the implementation name.
+                    } else if let Some(impl_stmt_idx) = impl_stmt_idx {
+                        if impl_name.as_deref() != Some(name.as_str()) {
+                            // Wrong (or missing) implementation name — report at the
+                            // implementation name. An anonymous default-exported
+                            // implementation has no name node; tsc anchors at the
+                            // whole declaration statement then.
                             let impl_error_node = self
-                                .ctx
-                                .arena
-                                .get(impl_idx)
+                                .statement_function_declaration_view(impl_stmt_idx)
+                                .and_then(|(f, _)| self.ctx.arena.get(f))
                                 .and_then(|n| self.ctx.arena.get_function(n))
                                 .map(|f| f.name)
                                 .filter(|n| n.is_some())
-                                .unwrap_or(impl_idx);
+                                .unwrap_or(impl_stmt_idx);
                             self.error_at_node(
                                 impl_error_node,
                                 &format!("Function implementation name must be '{name}'."),
                                 diagnostic_codes::FUNCTION_IMPLEMENTATION_NAME_MUST_BE,
                             );
                         } else {
-                            let impl_is_declared = self.is_ambient_declaration(impl_idx);
+                            let impl_is_declared = self.is_ambient_declaration(impl_stmt_idx);
                             if is_declared != impl_is_declared {
                                 self.error_at_node(
                                     report_error_node,
@@ -1344,6 +1376,8 @@ impl<'a> CheckerState<'a> {
             }
             i += 1;
         }
+
+        self.check_default_export_function_group(statements);
     }
 
     // Section 42: Class Member Utilities

--- a/crates/tsz-checker/src/types/type_checking/unused.rs
+++ b/crates/tsz-checker/src/types/type_checking/unused.rs
@@ -1592,24 +1592,26 @@ impl<'a> CheckerState<'a> {
         }
 
         let stmt_idx = statements[start];
-        let Some(node) = self.ctx.arena.get(stmt_idx) else {
-            return (false, None, None);
-        };
 
-        if node.kind == syntax_kind_ext::FUNCTION_DECLARATION
+        // See through `export`/`export default` wrappers: an exported function
+        // declaration groups with bare declarations of the same name.
+        if let Some((fn_idx, _)) = self.statement_function_declaration_view(stmt_idx)
+            && let Some(node) = self.ctx.arena.get(fn_idx)
             && let Some(func) = self.ctx.arena.get_function(node)
         {
             // Check if this is an implementation (has body)
             if func.body.is_some() {
-                // This is an implementation - check if name matches
-                let impl_name = self.get_function_name_from_node(stmt_idx);
+                // This is an implementation - check if name matches.
+                // Returns the statement index so callers can anchor anonymous
+                // implementations at the whole (wrapper) statement.
+                let impl_name = self.get_function_name_from_node(fn_idx);
                 return (true, impl_name, Some(stmt_idx));
             }
 
             // Another overload signature without body - need to look further
             // but we should check if this is the same function name
-            let overload_name = self.get_function_name_from_node(stmt_idx);
-            if overload_name.as_ref() == Some(&name.to_string()) {
+            let overload_name = self.get_function_name_from_node(fn_idx);
+            if overload_name.as_deref() == Some(name) {
                 // Same function, continue looking for implementation
                 return self.find_function_impl(statements, start + 1, name);
             }


### PR DESCRIPTION
Fixes #16723 (cross-name default-exported function signatures never join one implementation group), and the wider hole it sat in: the parser wraps `export function ...` and `export default function ...` in an `EXPORT_DECLARATION` node, so the checker's statement-level function-implementation walk (TS2391/TS2389) never saw *any* exported function declaration — `export function solo(a: string): string;` reported nothing at all.

**Structural rule:** when a statement list contains function declarations, tsc's per-local-name `checkFunctionOrConstructorSymbol` run groups them by declared name regardless of export modifiers (orphaned signature → TS2391 at the name; adjacent differently-named implementation → TS2389 at the implementation's name); additionally, every `export default function` — whatever its local name — binds to the single `default` export symbol, and tsc runs the same validation over that merged list: anonymous signatures group there (TS2391 anchored at the whole statement, last of a consecutive run only), a body-carrying member whose group continues past a textual gap is marked too, and each bodyless signature is checked against the group's **first** implementation with only the first incompatible one reported (TS2394). tsz does X through the checker's statement walk (`check_function_implementations`, `types/queries/class.rs`), which now sees through the export wrapper via `statement_function_declaration_view`, plus a new merged-group pass `check_default_export_function_group` (`state_checking_members/default_export_overload_group.rs`) whose TS2394 compat reuses the existing solver-backed `is_implementation_compatible_with_overload` machinery. The diagnostic sink's (start, code) dedup absorbs the overlap between the two runs, exactly like tsc's `sortAndDeduplicateDiagnostics`.

**Adjacent-case matrix** (28 rows, every one byte-identical to pinned `typescript@7.0.2` with `--noEmit --strict false --module commonjs --target es2015`; binder names varied across rows): both #16723 witnesses; same-name overload set (clean); adjacent cross-name impl (TS2389); impl-first order flip; compatible cross-name sig (TS2391 only, no TS2394); same-name incompatible (TS2394); three-name run (first-incompatible-only + TS2389); statement gap before impl; gap **after** impl (marks the implementation too — oracle-pinned); same-name gap (signature only); anonymous: solo sig, consecutive sigs (last only), anon+anon impl (clean), anon+named impl (clean), named sig+anon impl (TS2389 at statement), anon incompatible (TS2394 at statement); two same-name groups (q's sig validated against p's impl); non-default `export function` cross-name and solo; bare-function positive controls (unchanged); namespace-body exported sigs; ambient negatives (`declare module` defaults, `export declare`) and single-default-impl negative.

**Known residuals, deliberately out of scope** (different diagnostic family, measured and left unasserted): mixed default/non-default same-name runs (tsc: TS2383 "Overload signatures must all be exported or non-exported"; tsz currently reports TS2652×2) and `export`/non-export flag agreement generally (tsz has no TS2383 for functions). Filing separately.

## Goal
Goal: hold

## Verification
- New position-pinned suite `crates/tsz-checker/src/tests/ts2391_default_export_overload_group_tests.rs`: 24 passed / 0 failed (was: every exported-function row reported nothing; 28-row probe matrix all matched the pinned oracle before assertions were written).
- `cargo test -p tsz-checker --lib ts2323_default_export` 12/0, `ts2528` 11/0, `overload` 375/0, `export_default` 35/0, `default_export` 88/0, `2391` 24/0, `2389` 3/0, `function_implementation` 2/0.
- Full `cargo test -p tsz-checker --lib` running at PR-open time; count will be posted as a PR comment (land-and-continue).
- `cargo fmt`; clippy (workspace, warnings denied) + architecture guard via the pre-commit gate: passed.
- Owed and disclosed: two-sided `scripts/conformance/compare-to-parent.sh` does not fit this cloud seat's hour (55–90+ min measured on these seats). Scope argument: the walk change only *adds* visibility for statements that are `EXPORT_DECLARATION`-wrapped function declarations (previously invisible, so previously-silent rows can only gain the diagnostics tsc also reports); bare-function paths are covered by the unchanged positive controls above. The corpus set-difference (baseline ~529 failing) is the one check my local suites cannot replace — expect `conformance/es6/modules/defaultExportWithOverloads02.ts`-family rows to move toward tsc, 0 broken.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-fable-5
Effort: medium
AgentName: Breccia

---
_Generated by [Claude Code](https://claude.ai/code/session_011zpzyd8A23pfByckqPasuS)_