### PR TITLE
fix(solver): a tuple spreading a recursive conditional's own result flattens for display

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -783,6 +783,8 @@ mod recursive_accumulator_depth_tests;
 mod recursive_callable_infer_cycle_tests;
 #[path = "tests/recursive_conditional_infer_termination_tests.rs"]
 mod recursive_conditional_infer_termination_tests;
+#[path = "tests/recursive_conditional_tuple_spread_display_tests.rs"]
+mod recursive_conditional_tuple_spread_display_tests;
 #[path = "tests/recursive_generic_arrow_tests.rs"]
 mod recursive_generic_arrow_tests;
 #[path = "tests/recursive_mapped_intersection_nested_excess_property_tests.rs"]

--- a/crates/tsz-checker/src/tests/recursive_conditional_tuple_spread_display_tests.rs
+++ b/crates/tsz-checker/src/tests/recursive_conditional_tuple_spread_display_tests.rs
@@ -1,0 +1,143 @@
+//! A tuple that spreads the result of its own recursive conditional
+//! application (`[H, ...Split<R>]` where `Split<S> = S extends ... ? [H,
+//! ...Split<R>] : [S]`) must display flattened, matching tsc.
+//!
+//! Structural rule: `tsc` always flattens a rest element whose type is a
+//! concrete tuple, at construction and after instantiation. tsz already does
+//! this at intern time (`splice_concrete_tuple_spreads`), but a
+//! self-referential spread's rest element is still an unresolved generic
+//! `Application` at that point — the nested `Split<R>` hasn't evaluated yet —
+//! so the intern-time splice cannot fire (documented as its own caveat). By
+//! the time the whole recursion bottoms out, the outer `Tuple` is already
+//! interned with that unresolved rest element, and nothing re-visits it. The
+//! printer (`TypeFormatter::format_tuple`) now re-checks the same splice rule
+//! at display time, resolving a rest element's type through the same
+//! `Application` display-reduction chase the formatter already uses when
+//! rendering that node standalone. The underlying type is unaffected — this is
+//! a display-only fix (`#16732`); assignability already treated the nested and
+//! flattened forms identically.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn ts2322_messages(source: &str) -> Vec<String> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .filter(|d| d.code == 2322)
+        .map(|d| d.message_text)
+        .collect()
+}
+
+/// The issue's own witness: a two-segment split renders as a flat 2-tuple,
+/// not `["a", ...["b"]]`.
+#[test]
+fn two_level_recursive_conditional_spread_displays_flattened() {
+    let messages = ts2322_messages(
+        r#"
+type Split<S extends string> = S extends `${infer H}.${infer R}` ? [H, ...Split<R>] : [S];
+type P = Split<"a.b">;
+const bad: ["z"] = null as unknown as P;
+"#,
+    );
+    assert!(
+        messages.iter().any(|m| m.contains(r#"["a", "b"]"#)),
+        "two-level recursive split should display as a flat tuple, got: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("...[")),
+        "no nested-spread residue should remain in the display, got: {messages:?}"
+    );
+}
+
+/// Deeper recursion nests further without the fix (`["a", ...["b", ...["c"]]]`)
+/// — every level must flatten, not just the outermost one.
+#[test]
+fn three_level_recursive_conditional_spread_displays_flattened() {
+    let messages = ts2322_messages(
+        r#"
+type Split<S extends string> = S extends `${infer H}.${infer R}` ? [H, ...Split<R>] : [S];
+type P = Split<"a.b.c">;
+const bad: ["z"] = null as unknown as P;
+"#,
+    );
+    assert!(
+        messages.iter().any(|m| m.contains(r#"["a", "b", "c"]"#)),
+        "three-level recursive split should display as a flat tuple, got: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("...[")),
+        "no nested-spread residue should remain in the display, got: {messages:?}"
+    );
+}
+
+/// tsc relabels the spliced elements from whichever branch actually
+/// contributed them (`head` from the recursive arm, `tail` from the base
+/// case) — not a generic `rest` label carried from the recursive rest
+/// element. The splice must reuse the resolved inner tuple's own element
+/// metadata, not just its types.
+#[test]
+fn recursive_conditional_spread_preserves_resolved_element_labels() {
+    let messages = ts2322_messages(
+        r#"
+type SplitNamed<S extends string> = S extends `${infer H}.${infer R}` ? [head: H, ...rest: SplitNamed<R>] : [tail: S];
+type PN = SplitNamed<"a.b">;
+const bad: ["z"] = null as unknown as PN;
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains(r#"[head: "a", tail: "b"]"#)),
+        "labels should come from whichever branch resolved each element, got: {messages:?}"
+    );
+}
+
+/// Renamed alias/binder control: the flattening is structural, not keyed on
+/// the alias or parameter names `Split`/`S`/`H`/`R`.
+#[test]
+fn renamed_recursive_conditional_spread_still_flattens() {
+    let messages = ts2322_messages(
+        r#"
+type Segments<Path extends string> = Path extends `${infer First}.${infer Rest}` ? [First, ...Segments<Rest>] : [Path];
+type Q = Segments<"a.b">;
+const bad: ["z"] = null as unknown as Q;
+"#,
+    );
+    assert!(
+        messages.iter().any(|m| m.contains(r#"["a", "b"]"#)),
+        "a renamed recursive conditional spread should still flatten, got: {messages:?}"
+    );
+}
+
+/// Negative control: a hand-written nested spread (no recursion involved)
+/// already flattened before this fix and must keep doing so.
+#[test]
+fn hand_written_nested_spread_still_flattens() {
+    let messages = ts2322_messages(
+        r#"
+type T = ["a", ...["b", ...["c"]]];
+const bad: ["z"] = null as unknown as T;
+"#,
+    );
+    assert!(
+        messages.iter().any(|m| m.contains(r#"["a", "b", "c"]"#)),
+        "hand-written nested spread should stay flattened, got: {messages:?}"
+    );
+}
+
+/// Negative control: a rest element typed as a plain (non-tuple) generic
+/// array must not be treated as a concrete tuple and spliced away — `S[]` has
+/// no fixed element count to inline, so it keeps its `...` rest display.
+#[test]
+fn array_typed_rest_element_is_not_spliced() {
+    let messages = ts2322_messages(
+        r#"
+function f(x: [string, ...number[]]): ["z"] {
+  return x;
+}
+"#,
+    );
+    assert!(
+        messages.iter().any(|m| m.contains("[string, ...number[]]")),
+        "an array-typed rest element must keep its variadic display, got: {messages:?}"
+    );
+}

--- a/crates/tsz-solver/src/diagnostics/format/compound.rs
+++ b/crates/tsz-solver/src/diagnostics/format/compound.rs
@@ -8,7 +8,7 @@ use super::TypeFormatter;
 use crate::types::{
     CallSignature, CallableShape, ConditionalType, FunctionShape, LiteralValue, MappedModifier,
     MappedType, ObjectShape, ParamInfo, PropertyInfo, SymbolRef, TemplateSpan, TupleElement,
-    TypeData, TypeId, TypeParamInfo,
+    TupleListId, TypeData, TypeId, TypeParamInfo,
 };
 use std::borrow::Cow;
 use tsz_binder::SymbolId;

--- a/crates/tsz-solver/src/diagnostics/format/compound/intersection_constructs.rs
+++ b/crates/tsz-solver/src/diagnostics/format/compound/intersection_constructs.rs
@@ -238,6 +238,8 @@ impl<'a> TypeFormatter<'a> {
                 return inner.into_owned();
             }
         }
+        let spliced = self.splice_concrete_rest_elements_for_display(elements);
+        let elements: &[TupleElement] = spliced.as_deref().unwrap_or(elements);
         // Format each element's type independently, then apply namespace
         // disambiguation across elements whose display names collide —
         // e.g. `[Foo.Yep, Bar.Yep]` instead of `[Yep, Yep]` when two different
@@ -278,6 +280,125 @@ impl<'a> TypeFormatter<'a> {
 
     pub fn format_tuple_elements_for_diagnostic(&mut self, elements: &[TupleElement]) -> String {
         self.format_tuple(elements)
+    }
+
+    /// Splice a rest element whose type *evaluates* to a concrete tuple
+    /// inline, mirroring `splice_concrete_tuple_spreads` (intern-time
+    /// construction) at display time.
+    ///
+    /// A recursive-conditional spread (`[H, ...Split]` where `Split<S> = S
+    /// extends ... ? [H, ...Split<R>] : [S]`) interns its rest element while
+    /// the nested `Split<R>` application is still unresolved, so the
+    /// construction-time splice can't fire (matching its own documented
+    /// caveat: a self-referential spread never resolves to a concrete tuple
+    /// *at that point*). By the time the whole recursion bottoms out, the
+    /// rest element's `type_id` now evaluates to a concrete tuple, but the
+    /// outer `Tuple` was already interned — nothing re-visits it to splice.
+    /// `tsc` never has this two-phase gap (its recursive instantiation
+    /// resolves the spread before the tuple is ever materialized), so this
+    /// re-checks the same splice rule here, using an evaluated read rather
+    /// than a raw lookup. Returns `None` when nothing changes, so the caller
+    /// can keep formatting the original slice without an extra allocation.
+    ///
+    /// A single pass only resolves one recursion level: splicing in a resolved
+    /// inner tuple can itself introduce a fresh rest element that is *still*
+    /// an unresolved `Application` one level deeper (`Split<"a.b.c">` resolves
+    /// its immediate rest to `["b", ...Split<"c">]`, whose own rest hasn't
+    /// been re-checked yet). Re-run the splice on the result until it stops
+    /// changing, bounded the same way `reducing_application_display` bounds
+    /// its own alias-chain walk.
+    fn splice_concrete_rest_elements_for_display(
+        &self,
+        elements: &[TupleElement],
+    ) -> Option<Vec<TupleElement>> {
+        let mut current = self.splice_concrete_rest_elements_for_display_once(elements)?;
+        for _ in 0..8 {
+            match self.splice_concrete_rest_elements_for_display_once(&current) {
+                Some(next) => current = next,
+                None => break,
+            }
+        }
+        Some(current)
+    }
+
+    fn splice_concrete_rest_elements_for_display_once(
+        &self,
+        elements: &[TupleElement],
+    ) -> Option<Vec<TupleElement>> {
+        let parent_rest_count = elements.iter().filter(|e| e.rest).count();
+        if parent_rest_count == 0 {
+            return None;
+        }
+        let has_spliceable = elements.iter().any(|e| {
+            e.rest && !e.optional && self.resolve_display_concrete_tuple(e.type_id).is_some()
+        });
+        if !has_spliceable {
+            return None;
+        }
+        let last_index = elements.len().saturating_sub(1);
+        let mut out: Vec<TupleElement> = Vec::with_capacity(elements.len());
+        for (index, elem) in elements.iter().enumerate() {
+            if elem.rest
+                && !elem.optional
+                && let Some(inner_list) = self.resolve_display_concrete_tuple(elem.type_id)
+            {
+                let inner = self.interner.tuple_list(inner_list);
+                let (inner_rest_count, inner_has_optional) =
+                    inner.iter().fold((0usize, false), |(rests, optional), e| {
+                        (rests + usize::from(e.rest), optional || e.optional)
+                    });
+                // Same shape guard as the construction-time splice: only
+                // inline a middle-position variadic inner tuple when it
+                // won't push an optional element ahead of a required suffix,
+                // and only ever keep the result down to one rest element.
+                let splice_middle = inner_rest_count == 1 && !inner_has_optional;
+                let splice_variadic =
+                    parent_rest_count == 1 && (index == last_index || splice_middle);
+                if inner_rest_count == 0 || splice_variadic {
+                    out.extend(inner.iter().copied());
+                    continue;
+                }
+            }
+            out.push(*elem);
+        }
+        Some(out)
+    }
+
+    /// Resolve `type_id` (through one `readonly` wrapper and, for an
+    /// `Application`, the same alias-reduction chase the formatter already
+    /// applies when rendering that node directly) to a concrete tuple's
+    /// element list for display splicing, or `None` if it doesn't resolve to
+    /// one. Read-only: never interns or mutates a type.
+    ///
+    /// A bare `evaluate_type` cannot do this on its own — the display-time
+    /// evaluator has no def-store resolver (see `reducing_application_display`'s
+    /// own doc comment), so an `Application` referencing a generic alias
+    /// (`Split<R>`) evaluates to itself unchanged. `application_display_reduction`
+    /// is the mechanism the formatter already uses to turn that same
+    /// `Application` into its evaluated form when formatting it as a standalone
+    /// type; reusing it here is what lets a self-referential recursive
+    /// conditional's rest element (`[H, ...Split]`) resolve to a concrete tuple.
+    fn resolve_display_concrete_tuple(&self, type_id: TypeId) -> Option<TupleListId> {
+        let unwrap_readonly = |id: TypeId| match self.interner.lookup(id) {
+            Some(TypeData::ReadonlyType(inner)) => inner,
+            _ => id,
+        };
+        let peeled = unwrap_readonly(type_id);
+        if let Some(TypeData::Tuple(list_id)) = self.interner.lookup(peeled) {
+            return Some(list_id);
+        }
+        let Some(TypeData::Application(app_id)) = self.interner.lookup(peeled) else {
+            return None;
+        };
+        let app = self.interner.type_application(app_id);
+        let reduced = match self.application_display_reduction(peeled, &app)? {
+            super::application_reduction::ApplicationDisplayReduction::Type(reduced) => reduced,
+            _ => return None,
+        };
+        match self.interner.lookup(unwrap_readonly(reduced)) {
+            Some(TypeData::Tuple(list_id)) => Some(list_id),
+            _ => None,
+        }
     }
 
     pub(super) fn format_function(&mut self, shape: &FunctionShape) -> String {


### PR DESCRIPTION
When a rest element's type resolves to a concrete tuple, `tsc` always flattens it (`createNormalizedTupleType`, at construction and after instantiation). tsz already does this at intern time (`splice_concrete_tuple_spreads`), but a self-referential recursive-conditional spread (`[H, ...Split<R>]` where `Split<S> = S extends ... ? [H, ...Split<R>] : [S]`) interns its rest element while the nested `Split<R>` application is still unresolved — the intern-time splice's own doc comment already names this as its one caveat. By the time the recursion bottoms out, the outer `Tuple` is already interned with that unresolved rest element, and nothing re-visits it, so `format_tuple` printed `["a", ...["b"]]` instead of tsc's `["a", "b"]`. The underlying type was always correct — both compilers accept/reject identical assignments — so this is a display-only fix. Closes #16732.

**Structural rule.** When a tuple's rest element resolves (through evaluation, not just a raw lookup) to a concrete tuple, `tsc` flattens it into the parent at display time; tsz does so through `TypeFormatter::format_tuple` (`crates/tsz-solver/src/diagnostics/format/compound/intersection_constructs.rs`).

**Owner layer.** `TypeFormatter::format_tuple` re-checks the same splice rule the intern-time constructor (`splice_concrete_tuple_spreads`) applies, but at display time — resolving a rest element's type through `application_display_reduction`, the same alias-reduction chase the formatter already uses when rendering that `Application` node standalone. A bare `evaluate_type` can't do this on its own: the display-time evaluator has no def-store resolver (per `reducing_application_display`'s own doc comment), so an `Application` referencing a generic alias evaluates to itself unchanged. Splicing loops (bounded, 8 iterations, mirroring `reducing_application_display`'s own bound) because one resolution step can itself surface a fresh unresolved rest one level deeper — a 3+-level recursion needs more than one pass.

**Adjacent-case matrix** (`recursive_conditional_tuple_spread_display_tests.rs`, oracle-verified against pinned `typescript@7.0.2`):

| case | tsc | before | after |
| --- | --- | --- | --- |
| 2-level recursive split (`Split<"a.b">`) | `["a", "b"]` | `["a", ...["b"]]` | `["a", "b"]` |
| 3-level recursive split (`Split<"a.b.c">`) | `["a", "b", "c"]` | `["a", "b", ...["c"]]` | `["a", "b", "c"]` |
| named elements through recursion | labels from whichever branch resolved them (`[head: "a", tail: "b"]`) | wrong label carried from the recursive rest | matches |
| renamed alias/parameter binders | structural | structural | structural (unaffected — proves the rule isn't name-keyed) |
| hand-written nested spread, no recursion | flattened | flattened (already worked) | flattened (unchanged) |
| array-typed (non-tuple) rest element | keeps `...` | keeps `...` | keeps `...` (negative control, unaffected) |

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib recursive_conditional_tuple_spread_display_tests` — 6/6 passed (new suite)
- `cargo test -p tsz-solver --lib` — 7654/7654 passed
- `cargo test -p tsz-checker --lib -- format_tuple tuple_display spread_tuple tuple_alias display_alias union_display` — 76/76 passed (existing display-family regression check)
- `cargo test -p tsz-solver --lib -- tuple` — 622/622 passed
- `cargo clippy -p tsz-solver -p tsz-checker --lib --all-features -- -D warnings` — clean
- `cargo fmt -p tsz-solver -p tsz-checker -- --check` — clean
- `python3 scripts/arch/arch_guard.py` — clean
- Manual cross-check against pinned `typescript@7.0.2` for every row in the adjacent matrix above
- Owed: the full `cargo test -p tsz-checker --lib` run (~10.5k tests) did not finish within this cloud container's time budget (a known long-tail suite per the coordination board's standing notes) — the targeted display/tuple families above are the evidence in the meantime; will report the full count in a follow-up comment if it turns up anything. This is a display-only change scoped to `format_tuple`'s rest-element handling, so its blast radius is exactly the suites already run.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_013LboTw8tJUksp8acky6Vht)_