### PR TITLE
fix(checker): interface `extends (expr)` reports TS2499 once, not twice

### DIFF
--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part3.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part3.rs
@@ -1063,6 +1063,136 @@ interface Node {
         );
     }
 
+    // TS2499 ("An interface can only extend an identifier/qualified-name with
+    // optional type arguments") for a parenthesized/bracketed heritage
+    // expression is reported by both the parser
+    // (`parse_interface_heritage_type_reference`) and the checker's
+    // independent generic heritage walk (`heritage.rs`) for the same node.
+    // tsc emits it exactly once (oracle: `typescript@7.0.2`); these pin the
+    // dedup in `post_process_checker_diagnostics` and the Direction-B
+    // suppression via `is_parser_grammar_code`.
+
+    fn ts2499_count(diagnostics: &[Diagnostic], file: &str) -> usize {
+        diagnostics
+            .iter()
+            .filter(|diag| diag.file == file && diag.code == 2499)
+            .count()
+    }
+
+    #[test]
+    fn interface_extends_parenthesized_expression_reports_ts2499_once() {
+        let diagnostics =
+            collect_test_diagnostics(&[("/a.ts", "interface I extends (1 + 2) {}\n")]);
+        assert_eq!(
+            ts2499_count(&diagnostics, "/a.ts"),
+            1,
+            "expected exactly one TS2499, not a parser+checker double-report: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn interface_extends_bracketed_expression_reports_ts2499_once() {
+        let diagnostics =
+            collect_test_diagnostics(&[("/a.ts", "interface I extends [1, 2] {}\n")]);
+        assert_eq!(
+            ts2499_count(&diagnostics, "/a.ts"),
+            1,
+            "expected exactly one TS2499, not a parser+checker double-report: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn interface_extends_class_expression_reports_ts2499_once() {
+        // Checker-only shape: the parenthesized operand is a class
+        // expression rather than a binary/array literal, but the parser's
+        // open-paren grammar check still fires alongside the checker's
+        // generic heritage walk, so this exercises the same dedup.
+        let diagnostics =
+            collect_test_diagnostics(&[("/a.ts", "interface I extends (class {}) {}\n")]);
+        assert_eq!(
+            ts2499_count(&diagnostics, "/a.ts"),
+            1,
+            "expected exactly one TS2499: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn interface_extends_renamed_binder_reports_ts2499_once() {
+        // Anti-hardcoding: a differently-named interface/binder must not
+        // change the dedup outcome.
+        let diagnostics =
+            collect_test_diagnostics(&[("/a.ts", "interface Zeta extends (99 - 1) {}\n")]);
+        assert_eq!(
+            ts2499_count(&diagnostics, "/a.ts"),
+            1,
+            "expected exactly one TS2499: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn two_invalid_interface_heritage_clauses_each_report_ts2499_once() {
+        // Distinct nodes at distinct positions must not cross-cancel each
+        // other in the position-keyed dedup.
+        let diagnostics = collect_test_diagnostics(&[(
+            "/a.ts",
+            "interface A extends (1 + 2) {}\ninterface B extends [3, 4] {}\n",
+        )]);
+        assert_eq!(
+            ts2499_count(&diagnostics, "/a.ts"),
+            2,
+            "expected one TS2499 per interface, not merged or duplicated: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn real_syntax_error_suppresses_parenthesized_interface_heritage_ts2499() {
+        // Direction B: tsc's grammar-error suppression (hasParseDiagnostics)
+        // drops TS2499 program-wide when a real, unrelated syntax error is
+        // also present — matching the already-listed grammar codes' behavior.
+        let diagnostics = collect_test_diagnostics(&[(
+            "/a.ts",
+            "interface I extends (1 + 2) {}\nlet x: = 1;\n",
+        )]);
+        assert_eq!(
+            ts2499_count(&diagnostics, "/a.ts"),
+            0,
+            "expected TS2499 to be suppressed alongside a real syntax error: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn interface_extends_valid_qualified_name_reports_no_ts2499() {
+        // Negative control: a genuinely valid heritage clause (a namespaced
+        // qualified name) must not trip either emission site.
+        let diagnostics = collect_test_diagnostics(&[(
+            "/a.ts",
+            "declare namespace N { interface Base {} }\ninterface I extends N.Base {}\n",
+        )]);
+        assert_eq!(
+            ts2499_count(&diagnostics, "/a.ts"),
+            0,
+            "expected no TS2499 for a valid qualified-name heritage clause: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn class_implements_parenthesized_expression_still_reports_ts2500_once() {
+        // Negative control for the fix's blast radius: TS2500 (class
+        // `implements`) has no parser-side emission site for this shape, so
+        // it must be unaffected by the new TS2499-specific dedup and
+        // grammar-list entry.
+        let diagnostics =
+            collect_test_diagnostics(&[("/a.ts", "class C implements (1 as any) {}\n")]);
+        assert_eq!(
+            diagnostics
+                .iter()
+                .filter(|diag| diag.file == "/a.ts" && diag.code == 2500)
+                .count(),
+            1,
+            "expected exactly one TS2500: {diagnostics:?}"
+        );
+    }
+
     // --- topological_file_order tests ---
 
     #[test]

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -686,6 +686,24 @@ const fn is_parser_grammar_code(code: u32) -> bool {
                // error (`let x: = 1;`) elsewhere in the file drops TS1326
                // entirely on the real compiler. Sole emission site, no
                // checker-side counterpart, so no double-emission risk.
+        | 2499 // An interface can only extend an identifier/qualified-name
+               // with optional type arguments. tsc's checker rejects a
+               // parenthesized or bracketed `extends` operand
+               // (`interface I extends (1 + 2) {}`); tsz's parser
+               // (`parse_interface_heritage_type_reference`,
+               // `state_statements_class_declarations.rs`) already
+               // special-cases that shape and reports TS2499 itself, at the
+               // same position the checker's independent generic heritage
+               // walk (`heritage.rs`) also reports it — a genuine
+               // double-emission this list alone cannot fix (see
+               // `post_process_checker_diagnostics`'s TS2499 position-match
+               // filter for that half). Oracle-confirmed
+               // (`typescript@7.0.2`) — Direction A, `interface I extends
+               // (1 + 2) {}` alone reports TS2499 exactly once; Direction B,
+               // the same line plus an unrelated real syntax error
+               // (`let x: = 1;`) elsewhere in the file drops TS2499
+               // entirely on the real compiler, which tsz's parser-emitted
+               // copy did not (round 7 of the #16279 audit).
     )
 }
 

--- a/crates/tsz-cli/src/driver/checker_diagnostics.rs
+++ b/crates/tsz-cli/src/driver/checker_diagnostics.rs
@@ -217,6 +217,30 @@ pub(super) fn post_process_checker_diagnostics(
         });
     }
 
+    // TS2499 ("An interface can only extend an identifier/qualified-name
+    // with optional type arguments") is grammar-decidable at parse time for
+    // a parenthesized or bracketed heritage expression
+    // (`interface I extends (1 + 2) {}`), and the parser
+    // (`parse_interface_heritage_type_reference`) already reports it there
+    // at tsc's own position. The checker's independent, more general
+    // heritage walk (`heritage.rs`) does not know the parser already
+    // flagged that exact node — it structurally rejects anything that is
+    // not an identifier/qualified-name chain — so it reports TS2499 again
+    // for the same span. tsc emits this diagnostic exactly once; drop the
+    // checker's copy wherever a parser TS2499 already covers the same
+    // position, keeping any TS2499 the checker alone finds (e.g. non-paren
+    // heritage shapes the parser's grammar check does not special-case).
+    let parser_ts2499_positions: std::collections::HashSet<u32> = file
+        .parse_diagnostics
+        .iter()
+        .filter(|d| d.code == 2499)
+        .map(|d| d.start)
+        .collect();
+    if !parser_ts2499_positions.is_empty() {
+        checker_diagnostics
+            .retain(|diag| diag.code != 2499 || !parser_ts2499_positions.contains(&diag.start));
+    }
+
     // When TS5107/TS5101 deprecation diagnostics are present, suppress the most
     // common type relationship errors that tsc would not emit. Parser errors
     // (<2000) are handled separately and not affected by this filter.


### PR DESCRIPTION
When an interface's heritage clause is a parenthesized or bracketed expression (`interface I extends (1 + 2) {}`), tsc's checker rejects it exactly once with TS2499. tsz reported it twice: the parser (`parse_interface_heritage_type_reference`) already special-cases that syntactic shape and emits TS2499 itself, and the checker's independent, more general heritage walk (`heritage.rs`) also rejects the same node because it is not an identifier/qualified-name chain — neither owner knew about the other.

Structural rule: when a heritage expression is syntactically decidable as invalid (starts with `(` or `[`), tsc's grammar check and tsz's parser agree at parse time; the checker's semantic walk must not re-report the same node. Fix at the merge boundary (`post_process_checker_diagnostics`, the established owner for this class of parser-vs-checker interaction — see the existing TS2427/TS2754 filters beside it): drop a checker-emitted TS2499 whenever a parser-emitted TS2499 already covers the same position.

Also closes the matching Direction-B gap: TS2499 was missing from `is_parser_grammar_code`, so tsc's suppression of TS2499 alongside an unrelated real syntax error elsewhere in the file (`interface I extends (1 + 2) {}` next to `let x: = 1;`) was not modeled — tsz kept the parser's copy where tsc drops it entirely. This is round 7 of the #16279 grammar-suppression audit, picking up the exact "future slice" its round-6 comment named: re-deriving the TS2427/TS2457/TS2499 parser-vs-checker interaction before touching either side. TS2427 turned out not to double-report in practice (existing dedup in this same file already covers it); TS2499 did.

Adjacent matrix, all oracle-verified against pinned `typescript@7.0.2`: parenthesized and bracketed operands, a checker-only shape routed through the same parser branch (`(class {})`), a renamed binder, two distinct invalid interfaces in one file (must not cross-cancel by position), a real syntax error elsewhere (must suppress program-wide), a valid qualified-name heritage clause (negative control), and TS2500 (class `implements`, which has no parser-side emission site for this shape and must be unaffected).

## Goal
Goal: hold

## Verification
- Oracle matrix (`typescript@7.0.2`) vs rebuilt `dist-fast` binary for all 8 adjacent cases above: byte-identical output before fixing (confirmed the double-report and the missing Direction-B suppression) and after (all match).
- `cargo test -p tsz-cli --lib -- ts2499`: 7/7 new tests pass.
- `cargo test -p tsz-cli --lib -- ts2500`: 1/1 new control test passes.
- `cargo test -p tsz-cli --lib -- 2427 interface_ heritage`: 88/88 pass, no regressions in the existing interface/heritage/TS2427 suite.
- `cargo test -p tsz-cli --lib`: 1746/1764 pass; the 18 failures are pre-existing on `main` (confirmed by stashing this diff and re-running those exact 18 test names against unmodified `main` — reproduces there too), unrelated to this change (CLI --version/--help output, tsbuildinfo, jsdoc constructor inference, unrelated cross-file class merges).
- `cargo clippy --profile ci-lint -p tsz-cli --all-targets -- -D warnings`: clean.
- `python3 scripts/arch/arch_guard.py`: passes.
- `cargo fmt --check`: clean.
- `grep -c 2499 scripts/conformance/conformance-detail.json`: 0 — this diagnostic does not appear in the committed conformance corpus, so a full conformance snapshot cannot move on this change; not run locally given the ~8 min two-build cost for a family with no corpus exposure (matches this repo's own standing note: an oracle-pinned targeted matrix is the primary evidence for a narrow, corpus-unexercised diagnostic family, and the corpus sweep is a regression floor rather than a detector for it).
- Diff touches only `crates/tsz-cli/src/driver/*` (diagnostic merge/filter policy) plus its own test file — no `crates/tsz-checker` or `crates/tsz-parser` production path changed, so JS/DTS emit floors are unaffected and were not re-run.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

Claude-Session: https://claude.ai/code/session_01R1xEkpYuz7bKX7HEDQw4wC

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1xEkpYuz7bKX7HEDQw4wC)_