### PR TITLE
fix(checker): overload flag-agreement canonical is the first signature in source order

### DIFF
--- a/crates/tsz-checker/src/tests/ts2383_overload_flag_agreement_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2383_overload_flag_agreement_tests.rs
@@ -452,3 +452,59 @@ fn ambient_namespace_body_mixed_export_stays_exempt() {
                   }\n";
     assert_family_exactly(source, &[]);
 }
+
+// -- No-implementation groups: canonical is the FIRST signature in SOURCE
+// -- order, so the deviator is always the later one (#16742 follow-up). The
+// -- binder's declaration push order differs from source order for an
+// -- `export default`-wrapped member, which mis-anchored the first row.
+
+/// A default-exported signature above a plain one: the plain signature
+/// deviates.
+///
+/// ```text
+/// tsc: (2,10) TS2383 (+ TS2391, outside this filter)
+/// ```
+#[test]
+fn no_impl_default_then_plain_blames_the_plain_signature() {
+    let source = "export default function Execute(): void;\n\
+                  function Execute(): void;\n";
+    assert_family_exactly(source, &[DiagnosticShape::code(2383).at(2, 10)]);
+}
+
+/// Reverse order: the default-exported signature deviates from the plain
+/// canonical one.
+///
+/// ```text
+/// tsc: (2,25) TS2383
+/// ```
+#[test]
+fn no_impl_plain_then_default_blames_the_default_signature() {
+    let source = "function Launch(): void;\n\
+                  export default function Launch(): void;\n";
+    assert_family_exactly(source, &[DiagnosticShape::code(2383).at(2, 25)]);
+}
+
+/// Named-export variant: the plain signature deviates from the exported
+/// canonical one.
+///
+/// ```text
+/// tsc: (2,10) TS2383
+/// ```
+#[test]
+fn no_impl_export_then_plain_blames_the_plain_signature() {
+    let source = "export function relay(x: string): string;\n\
+                  function relay(x: number): number;\n";
+    assert_family_exactly(source, &[DiagnosticShape::code(2383).at(2, 10)]);
+}
+
+/// Named-export variant, reverse order: the exported signature deviates.
+///
+/// ```text
+/// tsc: (2,17) TS2383
+/// ```
+#[test]
+fn no_impl_plain_then_export_blames_the_export_signature() {
+    let source = "function relay(x: string): string;\n\
+                  export function relay(x: number): number;\n";
+    assert_family_exactly(source, &[DiagnosticShape::code(2383).at(2, 17)]);
+}

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_flag_agreement.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_flag_agreement.rs
@@ -65,6 +65,16 @@ impl<'a> CheckerState<'a> {
                 }
             }
         }
+        // tsc's `getCanonicalOverload` falls back to the group's FIRST
+        // overload in source order, but the binder's declaration push order
+        // can differ from source order for an `export default`-wrapped
+        // member — picking `[0]` unsorted then blames the wrong declaration
+        // in a no-implementation mixed run. Every member is local (same
+        // arena), so positions are comparable. The `TS2385`/`TS2386` arms
+        // consuming the returned list assume source order for the same
+        // reason.
+        overload_signatures
+            .sort_by_key(|&idx| self.ctx.arena.get(idx).map(|n| n.pos).unwrap_or(u32::MAX));
         let export_mismatch = has_exported_func && has_non_exported_func;
         let ambient_mismatch = has_ambient_func && has_non_ambient_func;
         // The flag-agreement check only runs when the group has at least one


### PR DESCRIPTION
Follow-up to #16752 (which closed #16742): fixes a wrong TS2383 anchor its new flag-agreement pass inherits from binder declaration order, caught while my original, now-superseded version of this PR built its adjacent-case matrix.

## Goal
Goal: hold

## Supersession note

This PR originally carried the TS2652 function-group exemption for #16742. While it was in flight, #16752 (Breccia's session) landed a broader rework of the same arm — new `duplicate_identifiers_flag_agreement.rs` module owning TS2383/TS2384 with export-over-ambient precedence — which covers everything my original diff did. This PR is now trimmed to the one defect that survives #16752, rebased onto current `main` (`3e37dae`); the superseded head was `d1c6732`.

## Structural rule

When an overload group has no implementation, tsc's `getCanonicalOverload` falls back to the group's FIRST overload signature in source order, and `checkFlagAgreementBetweenOverloads` blames the declarations deviating from that canonical. tsz does this through `check_overload_flag_agreement` (`duplicate_identifiers_flag_agreement.rs`), which picked `overload_signatures[0]` in the binder's declaration push order — that order differs from source order for an `export default`-wrapped member, so tsz picked the plain signature as canonical and blamed the default-exported one.

Wrong semantic operation: diagnostic anchor decision (canonical-overload selection) in the checker's flag-agreement pass.

## Witness (reproduced on `main` at `3e37dae`, post-#16752)

```
export default function Execute(): void;
function Execute(): void;
```

tsc (pinned `typescript@7.0.2`, `--noEmit --strict false --module commonjs --target es2015`): `(2,10) TS2383` — the plain signature deviates from the default-exported canonical.
tsz before: `(1,25) TS2383` — canonical and deviator swapped.
tsz after: `(2,10) TS2383`.

Fix: source-order `overload_signatures` before canonical selection. All members are local (same arena), so positions are comparable. The returned list feeds the TS2385/TS2386 arms, which take their reference from index 0 and assume source order for the same reason.

## Adjacent-case matrix (every row oracle-pinned, no implementation in the group)

| shape | tsc | covered by |
| --- | --- | --- |
| `export default` sig, then plain sig | `(2,10) TS2383` | `no_impl_default_then_plain_blames_the_plain_signature` |
| plain sig, then `export default` sig | `(2,25) TS2383` | `no_impl_plain_then_default_blames_the_default_signature` |
| `export` sig, then plain sig | `(2,10) TS2383` | `no_impl_export_then_plain_blames_the_plain_signature` |
| plain sig, then `export` sig | `(2,17) TS2383` | `no_impl_plain_then_export_blames_the_export_signature` |

Binder names vary across rows. Every with-implementation shape is unaffected (canonical = implementation, order irrelevant) and stays pinned by #16752's own 25-test suite.

## Verification

- `cargo test -p tsz-checker --lib ts2383_overload_flag_agreement` — 29/29 (25 from #16752 + the 4 new rows; the first new row fails on `main` before the fix, anchor at 1:25 vs tsc's 2:10)
- `cargo test -p tsz-checker --test default_export_merge_diagnostics_tests` — 10/10
- `cargo test -p tsz-checker --test overload_modifier_tests` — 57/57
- `cargo test -p tsz-checker --lib ts2391_default_export_overload_group` — 24/24; `--lib ts2385_overload_modifier` — 6/6; `--lib default_export` — 98/98; `--lib duplicate_identifier` — 13/13
- clippy + arch guard via the pre-commit gate
- Corpus exposure: the anchor only moves for no-implementation mixed-export groups; TS2391 fires alongside on every such shape, and the with-implementation corpus shapes are order-insensitive. Zero conformance movement is the expected signature; the oracle-pinned matrix is the primary evidence.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-fable-5
Effort: medium
AgentName: Gypsum

https://claude.ai/code/session_012gW7bqpKe5mGkJKsEtJys7