### PR TITLE
fix(checker): all-function overload groups never emit TS2652 on default-export mismatch

### DIFF
--- a/crates/tsz-checker/src/tests/ts2391_default_export_overload_group_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2391_default_export_overload_group_tests.rs
@@ -20,10 +20,9 @@
 //! (`state_checking_members/default_export_overload_group.rs`).
 //!
 //! Binder names vary across rows; no row depends on identifier spelling.
-//! Known residuals deliberately not asserted here: mixed default/non-default
-//! same-name runs (tsc: `TS2383`; tsz currently reports `TS2652`) and
-//! export/non-export flag agreement (`TS2383`), which belong to a different
-//! diagnostic family.
+//! Mixed default/non-default same-name runs and plain export/non-export flag
+//! agreement (`TS2383`) belong to a different diagnostic family and are
+//! covered by the `mixed_export_visibility` tests below.
 
 use crate::context::ScriptTarget;
 use crate::test_utils::{DiagnosticShape, assert_diagnostic_shapes_exactly, check_source};
@@ -347,4 +346,101 @@ fn ambient_signatures_stay_clean() {
 fn single_default_implementation_is_clean() {
     let source = "export default function only(a: string) { return a; }\n";
     assert_family_exactly(source, &[]);
+}
+
+/// #16742: a same-named function overload run mixing `export default` and
+/// plain (non-exported) declarations is a flag-agreement mismatch (`TS2383`),
+/// not a merged-declaration/default-export conflict. tsc reports exactly one
+/// `TS2383` here; tsz previously reported two spurious `TS2652`s instead
+/// (`MERGED_DECLARATION_CANNOT_INCLUDE_A_DEFAULT_EXPORT_DECLARATION...`)
+/// because the merged-declaration scan's `all_functions` exemption only
+/// covered `TS2395`, not the analogous `TS2652` default-export branch.
+mod mixed_export_visibility {
+    use crate::context::ScriptTarget;
+    use crate::test_utils::{DiagnosticShape, assert_diagnostic_shapes_exactly, check_source};
+    use crate::{CheckerOptions, diagnostics::Diagnostic};
+
+    fn check_module(source: &str) -> Vec<Diagnostic> {
+        check_source(
+            source,
+            "test.ts",
+            CheckerOptions {
+                target: ScriptTarget::ES2015,
+                ..CheckerOptions::default()
+            },
+        )
+    }
+
+    /// Diagnostics restricted to the export/default-export flag-agreement
+    /// family (`TS2383`, `TS2395`, `TS2652`).
+    fn family(source: &str) -> Vec<Diagnostic> {
+        check_module(source)
+            .into_iter()
+            .filter(|d| matches!(d.code, 2383 | 2395 | 2652))
+            .collect()
+    }
+
+    fn assert_family_exactly(source: &str, shapes: &[DiagnosticShape]) {
+        assert_diagnostic_shapes_exactly(source, &family(source), shapes);
+    }
+
+    /// Default-exported signature, plain (non-exported) implementation: only
+    /// `TS2383` at the deviating signature, never `TS2652`.
+    #[test]
+    fn default_exported_signature_then_plain_implementation_reports_only_ts2383() {
+        let source = "export default function fn(a: string): string;\n\
+                      function fn(a: string): string { return a; }\n\
+                      export {};\n";
+        assert_family_exactly(source, &[DiagnosticShape::code(2383).at(1, 25)]);
+    }
+
+    /// Order flipped: plain signature first, default-exported implementation
+    /// second — same single `TS2383`, anchored at the signature.
+    #[test]
+    fn plain_signature_then_default_exported_implementation_reports_only_ts2383() {
+        let source = "function fn(a: string): string;\n\
+                      export default function fn(a: string): string { return a; }\n\
+                      export {};\n";
+        assert_family_exactly(source, &[DiagnosticShape::code(2383).at(1, 10)]);
+    }
+
+    /// Renamed binder: the same shape under a different local name stays
+    /// clean of `TS2652`. The name's own length doesn't shift the anchor —
+    /// `export default function ` is a fixed-width prefix, so the signature's
+    /// name always starts at column 25 regardless of spelling.
+    #[test]
+    fn default_exported_signature_then_plain_implementation_renamed_binder() {
+        let source = "export default function widget(a: number): number;\n\
+                      function widget(a: number): number { return a; }\n\
+                      export {};\n";
+        assert_family_exactly(source, &[DiagnosticShape::code(2383).at(1, 25)]);
+    }
+
+    /// Plain `export` (non-default) signature mixed with a non-exported
+    /// implementation: still `TS2383`, not `TS2395`/`TS2652` — `all_functions`
+    /// groups never hit the merged-declaration branches.
+    #[test]
+    fn exported_signature_then_plain_implementation_reports_only_ts2383() {
+        let source = "export function c(x: string): string;\n\
+                      function c(x: string): string { return x; }\n";
+        assert_family_exactly(source, &[DiagnosticShape::code(2383).at(1, 17)]);
+    }
+
+    /// Positive control: a default-exported class colliding with a local
+    /// interface in TYPE space is a genuine merged-declaration conflict
+    /// (`defaultExportsCannotMerge03`-shaped, pinned separately in
+    /// `tests/default_export_merge_diagnostics_tests.rs`) — not an
+    /// `all_functions` group, so the `TS2652` exemption must not apply here.
+    #[test]
+    fn default_exported_class_and_local_interface_still_reports_ts2652() {
+        let source = "export default class Model {}\n\
+                      interface Model {}\n";
+        assert_family_exactly(
+            source,
+            &[
+                DiagnosticShape::code(2652).at(1, 22),
+                DiagnosticShape::code(2652).at(2, 11),
+            ],
+        );
+    }
 }

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -515,9 +515,8 @@ impl<'a> CheckerState<'a> {
             // Default exports are a third visibility class, distinct from ordinary
             // exported declarations. A merged declaration whose default-exported
             // type/value/namespace space intersects any non-default declaration
-            // reports TS2652. Only ordinary exported-vs-local intersections report
-            // TS2395, and a declaration claimed by TS2652 must not also report
-            // TS2395.
+            // reports TS2652; only ordinary exported-vs-local intersections report
+            // TS2395, and a TS2652-claimed declaration never also reports TS2395.
             let mut ts2652_error_nodes: Vec<NodeIndex> = Vec::new();
             let mut ts2395_error_nodes: Vec<NodeIndex> = Vec::new();
             // A symbol whose local declarations are all plain variables is
@@ -634,7 +633,12 @@ impl<'a> CheckerState<'a> {
                         }
                     }
                     let non_default_spaces = exported_spaces | non_exported_spaces;
-                    let default_conflict_spaces = default_exported_spaces & non_default_spaces;
+                    // An all-function run is one overload group, not a merged declaration; TS2383 above owns default-vs-non-default mismatches too (#16742).
+                    let default_conflict_spaces = if all_functions {
+                        0
+                    } else {
+                        default_exported_spaces & non_default_spaces
+                    };
                     let export_local_conflict_spaces =
                         if all_functions || suppress_ts2395_for_ambient {
                             0

--- a/crates/tsz-checker/tests/default_export_merge_diagnostics_tests.rs
+++ b/crates/tsz-checker/tests/default_export_merge_diagnostics_tests.rs
@@ -171,15 +171,23 @@ function overload(value: string | number): void {}
 }
 
 #[test]
-fn all_function_group_still_reports_default_non_default_overlap() {
-    // The all-function exception suppresses ordinary TS2395 overload noise,
-    // not the default/non-default declaration-space invariant.
+fn all_function_group_never_reports_ts2652_for_default_non_default_overlap() {
+    // #16742: pinned oracle `typescript@7.0.2` reports only `TS2383`
+    // ("Overload signatures must all be exported or non-exported.") plus
+    // `TS2391` (missing implementation, outside this file's filtered code
+    // set) for this shape — never `TS2652`. A same-named run of function
+    // declarations is one overload group, not a merged declaration; tsc's
+    // flag-agreement check owns the default-vs-non-default mismatch here,
+    // the same way it already owns the plain exported-vs-local mismatch
+    // (`ordinary_function_overloads_keep_existing_ts2395_suppression` above).
+    // This test previously pinned tsz's own bug (spurious double `TS2652`)
+    // rather than oracle-verified behavior.
     let source = r#"
 export default function Execute(): void;
 function Execute(): void;
 "#;
 
-    assert_merge_diagnostics(source, "Execute", &[(TS2652, 0), (TS2652, 1)]);
+    assert_merge_diagnostics(source, "Execute", &[]);
 }
 
 #[test]


### PR DESCRIPTION
Second half of #16742 (the first half, missing TS2383, was fixed in #16750).

When a same-named function-overload run mixes `export default` and plain
visibility — `export default function fn(a: string): string; function
fn(a: string): string { return a; }` — that's one overload group (a signature
plus its implementation), not two colliding declarations. tsc's
`checkFlagAgreementBetweenOverloads` reports `TS2383` ("Overload signatures
must all be exported or non-exported.") for this mismatch. tsz's
merged-declaration scan instead treated the default-exported signature and the
plain implementation as conflicting declaration spaces and reported two
spurious `TS2652`s ("Merged declaration ... cannot include a default export
declaration...").

## Structural rule

When a symbol's local declarations are **all functions** (an overload run:
bodyless signatures plus at most one implementation), `tsc`'s flag-agreement
check owns *every* visibility mismatch within that group — both
exported-vs-local (already `TS2383`/suppressed-`TS2395` before this PR) and
default-vs-non-default (`TS2383`, not `TS2652`). tsz's merged-declaration scan
in `duplicate_identifiers.rs` already gated the `TS2395` branch
(`export_local_conflict_spaces`) by an `all_functions` check but never applied
the same gate to the `TS2652` branch (`default_conflict_spaces`), so a
default/non-default mismatch inside an all-function group fell through to the
generic merged-declaration path instead.

**Owner layer:** checker, `duplicate_identifiers.rs`'s merged-declaration scan
(the same function that already implements the `TS2395` exemption this PR
extends to `TS2652`).

## Adjacent-case matrix

New tests in `ts2391_default_export_overload_group_tests.rs::mixed_export_visibility`:
- Default-exported signature → plain implementation: `TS2383` only, no `TS2652`.
- Order flipped (plain signature → default-exported implementation): same.
- Renamed binder (`widget` instead of `fn`): unaffected by spelling.
- Plain `export` (non-default) signature → plain implementation: `TS2383` only (regression guard for the pre-existing `TS2395` exemption).
- **Positive control:** a genuine merged-declaration conflict (`export default class Model {}` + `interface Model {}`, not an all-function group) still reports `TS2652` — the exemption is scoped correctly.

Also corrected an existing pinned integration test,
`all_function_group_still_reports_default_non_default_overlap` in
`tests/default_export_merge_diagnostics_tests.rs`, which asserted `TS2652`
firing for `export default function Execute(): void; function Execute():
void;` — that assertion was itself pinning tsz's bug, not oracle-verified
behavior. Verified against pinned `typescript@7.0.2`: this shape reports only
`TS2383` (+ `TS2391` for the missing implementation, outside that test's
filtered code set), never `TS2652`.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib mixed_export_visibility` — 5/5 passed (new tests).
- `cargo test -p tsz-checker --lib -- ts2391_default_export_overload_group_tests duplicate_identifiers overload_modifier` — 99/99 passed.
- `cargo test -p tsz-checker --test default_export_merge_diagnostics_tests` — 10/10 passed (includes the corrected regression test).
- `cargo test -p tsz-checker --test overload_modifier_tests` — 57/57 passed.
- Oracle cross-check: pinned `typescript@7.0.2` on `export default function Execute(): void;\nfunction Execute(): void;` and the #16742 repro (`export default function fn(a: string): string;\nfunction fn(a: string): string { return a; }`) — both report only `TS2383` (+`TS2391` where applicable), matching the fixed behavior exactly.
- `cargo fmt --check -p tsz-checker` — clean.
- `cargo clippy -p tsz-checker --lib --profile dist-fast -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py --size-only` — clean (trimmed comments to stay within the `duplicate_identifiers.rs` line-count ratchet).
- Pre-commit hook (fmt + clippy + arch-size + affected-crate verification) passed.
- Owed, disclosed: the full `cargo test -p tsz-checker --lib` run (~10.5k tests) did not finish inside this session's time budget — it was still progressing cleanly through its known long tail (`ts2589_tests`, a documented slow-test family unrelated to this change) when the 900s budget ran out. This change is scoped to the merged-declaration/export-visibility diagnostic family; the targeted suites above are its full blast radius.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmW33PU3TYmBRiRdPBxgkW)_