### PR TITLE
fix(solver): object-first mixed intersections keep source-order member position

### DIFF
--- a/crates/tsz-checker/src/tests/intersection_target_elaboration_tests.rs
+++ b/crates/tsz-checker/src/tests/intersection_target_elaboration_tests.rs
@@ -518,3 +518,153 @@ const value: Both = new Animal();
         "Nominal class intersection must elaborate against the nominal member name 'Dog'. Got: {text:?}"
     );
 }
+
+// ===========================================================================
+// Object-first mixed intersections whose merged object is not the LAST
+// member in source order (`{ z: 1 } & [tuple]`, not `[tuple] & { z: 1 }`).
+//
+// `normalize_intersection`'s member-list rebuild (`crates/tsz-solver/src/
+// intern/intersection.rs`) used to special-case the "no merged callable"
+// path: it appended the merged object *after* every other remaining member
+// unconditionally, instead of substituting it at its original position like
+// the callable-merge path already did. A tuple (or any other non-object,
+// non-callable member — primitive, array, ...) that appeared *after* the
+// object in source order was silently promoted ahead of it in the interned
+// `Intersection`'s member list. The written-order elaboration
+// (`IntersectionTargetMismatch` in `crates/tsz-checker/src/assignability/
+// assignability_diagnostics.rs`) then walked that reordered list and named
+// the wrong "first failing constituent" — the tuple instead of tsc's object.
+// Reversing the operands (`[tuple] & { z: 1 }`) happened to keep the correct
+// order by coincidence (the object was already last), which is why the bug
+// was order-sensitive rather than a blanket display defect. (Verified
+// against `tsc` 7.0.2, `--noEmit --strict`.)
+// ===========================================================================
+
+/// The exact #16753 repro: an object-first intersection with a tuple member
+/// (via a nested spread) elaborates the object, matching tsc.
+#[test]
+fn object_first_tuple_intersection_names_object_constituent() {
+    let text = elaboration(
+        r#"
+type B = { z: 1 } & [string, ...[number, boolean]];
+const b: B = 1;
+"#,
+        2322,
+    );
+    assert!(
+        text.contains("is not assignable to type 'B'."),
+        "Expected the alias headline. Got: {text:?}"
+    );
+    assert!(
+        text.contains("Type 'number' is not assignable to type '{ z: 1; }'."),
+        "Expected the object constituent frame (tsc names the object, not the tuple). Got: {text:?}"
+    );
+    assert!(
+        !text.contains("[string, number, boolean]"),
+        "Must not name the tuple constituent when the object is written first. Got: {text:?}"
+    );
+}
+
+/// Control: with the tuple written first, tsc (and tsz, unaffected by this
+/// bug) names the tuple — both compilers already agreed here.
+#[test]
+fn tuple_first_object_intersection_names_tuple_constituent() {
+    let text = elaboration(
+        r#"
+type B = [string, ...[number, boolean]] & { z: 1 };
+const b: B = 1;
+"#,
+        2322,
+    );
+    assert!(
+        text.contains("Type 'number' is not assignable to type '[string, number, boolean]'."),
+        "Expected the tuple constituent frame. Got: {text:?}"
+    );
+}
+
+/// The bug is not specific to a spread-flattened tuple: a plain
+/// no-spread tuple reproduces the same object-first reordering.
+#[test]
+fn object_first_plain_tuple_intersection_names_object_constituent() {
+    let text = elaboration(
+        r#"
+type B = { z: 1 } & [string, number];
+const b: B = 1;
+"#,
+        2322,
+    );
+    assert!(
+        text.contains("Type 'number' is not assignable to type '{ z: 1; }'."),
+        "Expected the object constituent frame. Got: {text:?}"
+    );
+}
+
+/// Three-way intersection: the first-written object constituent still wins
+/// over a trailing tuple, not just a two-member intersection.
+#[test]
+fn three_way_object_first_intersection_names_first_object_constituent() {
+    let text = elaboration(
+        r#"
+type B = { z: 1 } & { w: 2 } & [string, number];
+const b: B = 1;
+"#,
+        2322,
+    );
+    assert!(
+        text.contains("Type 'number' is not assignable to type '{ z: 1; }'."),
+        "Expected the first-written object constituent frame. Got: {text:?}"
+    );
+}
+
+/// The same reordering bug applies to any non-callable, non-object member —
+/// not just tuples. An array member after the object in source order must
+/// not be promoted ahead of it either.
+#[test]
+fn object_first_array_intersection_names_object_constituent() {
+    let text = elaboration(
+        r#"
+type B = { z: 1 } & string[];
+const b: B = 1;
+"#,
+        2322,
+    );
+    assert!(
+        text.contains("Type 'number' is not assignable to type '{ z: 1; }'."),
+        "Expected the object constituent frame. Got: {text:?}"
+    );
+}
+
+/// Control: a bare primitive first (no object member at all — nothing for
+/// the merge step to reorder) already kept source order before this fix and
+/// must remain unaffected by it.
+#[test]
+fn primitive_first_tuple_intersection_names_primitive_constituent() {
+    let text = elaboration(
+        r#"
+type B = number & [string, number];
+const b: B = "x";
+"#,
+        2322,
+    );
+    assert!(
+        text.contains("Type 'string' is not assignable to type 'number'."),
+        "Expected the first-written primitive constituent frame. Got: {text:?}"
+    );
+}
+
+/// Renamed-binder control: the rule is structural, not keyed on the
+/// property/tuple-element spelling.
+#[test]
+fn renamed_object_first_tuple_intersection_names_object_constituent() {
+    let text = elaboration(
+        r#"
+type Widget = { kind: "circle" } & [boolean, ...[bigint]];
+const w: Widget = 1;
+"#,
+        2322,
+    );
+    assert!(
+        text.contains(r#"Type 'number' is not assignable to type '{ kind: "circle"; }'."#),
+        "Expected the renamed object constituent frame. Got: {text:?}"
+    );
+}

--- a/crates/tsz-solver/src/intern/intersection.rs
+++ b/crates/tsz-solver/src/intern/intersection.rs
@@ -589,7 +589,7 @@ impl TypeInterner {
             .collect();
 
         // Step 2: Extract and merge callables from remaining members
-        let (merged_callable, remaining_after_callables) =
+        let (merged_callable, _remaining_after_callables) =
             self.extract_and_merge_callables(&remaining_after_objects);
 
         // When 2+ callables are merged into one, store a display alias from the
@@ -607,47 +607,46 @@ impl TypeInterner {
             }
         }
 
-        // Step 3: Rebuild the member list. Keep the existing canonical rebuild
-        // for non-callable object intersections so `{}`/primitive normalization
-        // remains stable. When callables participate, walk the original list and
-        // replace the first object/callable occurrence with its merged
+        // Step 3: Rebuild the member list by walking the original list and
+        // replacing the first object/callable occurrence with its merged
         // representative; this keeps tsc's source-order display for mixed
-        // intersections such as `(() => void) & { prop: any }`.
+        // intersections such as `(() => void) & { prop: any }` and, just as
+        // importantly, for a merged-object member that is *not* last in
+        // source order (`{ z: 1 } & [string, number]` must keep the object
+        // first — appending it unconditionally after every other remaining
+        // member, as an earlier version of this rebuild did, silently
+        // reordered any object-first mixed intersection whose merged object
+        // had no callable co-member, which also skewed which constituent
+        // `tsc`-parity elaboration (`IntersectionTargetMismatch`) names as
+        // the first failing one).
         let mut final_flat: TypeListBuffer = SmallVec::new();
-        if merged_callable.is_some() {
-            let mut emitted_object = false;
-            let mut emitted_callable = false;
-            for &member in &flat {
-                if let Some(obj_id) = merged_object
-                    && matches!(
-                        self.lookup(member),
-                        Some(TypeData::Object(_) | TypeData::ObjectWithIndex(_))
-                    )
-                {
-                    if !emitted_object {
-                        final_flat.push(obj_id);
-                        emitted_object = true;
-                    }
-                    continue;
+        let mut emitted_object = false;
+        let mut emitted_callable = false;
+        for &member in &flat {
+            if let Some(obj_id) = merged_object
+                && matches!(
+                    self.lookup(member),
+                    Some(TypeData::Object(_) | TypeData::ObjectWithIndex(_))
+                )
+            {
+                if !emitted_object {
+                    final_flat.push(obj_id);
+                    emitted_object = true;
                 }
+                continue;
+            }
 
-                if let Some(call_id) = merged_callable
-                    && crate::type_queries::is_callable_type(self, member)
-                {
-                    if !emitted_callable {
-                        final_flat.push(call_id);
-                        emitted_callable = true;
-                    }
-                    continue;
+            if let Some(call_id) = merged_callable
+                && crate::type_queries::is_callable_type(self, member)
+            {
+                if !emitted_callable {
+                    final_flat.push(call_id);
+                    emitted_callable = true;
                 }
+                continue;
+            }
 
-                final_flat.push(member);
-            }
-        } else {
-            final_flat.extend(remaining_after_callables.iter().copied());
-            if let Some(obj_id) = merged_object {
-                final_flat.push(obj_id);
-            }
+            final_flat.push(member);
         }
 
         // Early exit if simplified to single type

--- a/crates/tsz-solver/src/intern/normalize.rs
+++ b/crates/tsz-solver/src/intern/normalize.rs
@@ -1722,24 +1722,17 @@ impl TypeInterner {
             return None;
         }
 
-        // Build the distributed union
-        // Start with the first non-union member as the base
-        let base_members: Vec<_> = flat
-            .iter()
-            .enumerate()
-            .filter(|(i, _)| !union_indices.contains(i))
-            .map(|(_, &id)| id)
-            .collect();
-
-        // If all members are unions, start with an empty intersection (unknown)
-        let initial_intersection = if base_members.is_empty() {
-            vec![]
-        } else {
-            base_members
-        };
-
-        // Recursively distribute: for each union, create intersections with all combinations
-        let mut combinations = vec![initial_intersection];
+        // Build the distributed union. Each combination is a same-length copy
+        // of `flat`, with every union slot progressively overwritten by one of
+        // its branches — non-union members keep their original index so the
+        // result preserves tsc's source order (`{} & (string | null)`
+        // distributes to `({} & string) | ({} & null)`, not `(string & {}) |
+        // (null & {})`). An earlier version built each combination by
+        // collecting the non-union members first and appending the union
+        // branch last regardless of the union's own position, which silently
+        // reordered any distribution where a union member was not already
+        // the last flat member.
+        let mut combinations: Vec<Vec<TypeId>> = vec![flat.to_vec()];
 
         for &union_idx in &union_indices {
             let union_type = flat[union_idx];
@@ -1754,7 +1747,7 @@ impl TypeInterner {
             for combination in &combinations {
                 for &union_member in union_members.iter() {
                     let mut new_combination = combination.clone();
-                    new_combination.push(union_member);
+                    new_combination[union_idx] = union_member;
                     new_combinations.push(new_combination);
                 }
             }


### PR DESCRIPTION
When a target intersection's `normalize_intersection` merge step rebuilt the final member list, the "no merged callable" path unconditionally appended the merged object member *after* every other remaining member instead of substituting it at its original position (the way the "merged callable" sibling path already did). A tuple, array, primitive, or any other non-object, non-callable member written *after* the object in source order was silently promoted ahead of it in the interned `Intersection`'s member list.

Structural rule: when an intersection target relates to a source and fails, tsc's `typeRelatedToEachType` elaborates the *first written* constituent the source fails against (`crates/tsz-checker/src/assignability/assignability_diagnostics.rs`'s `wrap_intersection_target_failure`/`IntersectionTargetMismatch` already implements this correctly) — but it reads the constituent list straight off the interned `Intersection`'s member order, so a scrambled intern-time order produces a scrambled elaboration regardless of how faithful the elaboration logic itself is. Owner: `crates/tsz-solver/src/intern/intersection.rs` (`normalize_intersection`, Step 3 rebuild).

`{ z: 1 } & [string, ...[number, boolean]]` assigned an incompatible value elaborated against the tuple (`[string, number, boolean]`) where tsc elaborates the object (`{ z: 1; }`); the reversed spelling (`tuple & object`) already matched by coincidence, since the object was already last. Fixed by unifying the two rebuild paths into one that always walks the original member list and substitutes the merged object/callable at its own first-occurrence position.

Fixing this exposed a second, related order bug in the same file's `distribute_intersection_over_unions` (`normalize.rs`): it built each distributed combination by collecting all non-union members first and appending the chosen union branch last, instead of substituting the branch at the union's own original index. `(string | null) & {}` distributed to `({} & string) | ({} & null)` instead of `(string & {}) | (null & {})` — this was previously masked because the (buggy) object-append-last behavior above happened to normalize both the direct and the distributed construction to the same final order (an existing unit test, `test_empty_object_rule_intersection`, caught this the moment the first fix landed). Fixed by building each combination as a same-length copy of the flat member list with only the union's own slot overwritten per branch.

Adjacent matrix, oracle-verified against pinned `typescript@7.0.2` (`--noEmit --strict`): object-first with a nested-spread tuple (#16753's repro), the reversed tuple-first control, a plain no-spread tuple, a three-way intersection, an array member instead of a tuple, a bare-primitive control (unaffected either way), and a renamed-binder control. New tests in `crates/tsz-checker/src/tests/intersection_target_elaboration_tests.rs`.

Closes #16753.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib -- intersection_target_elaboration_tests`: 27/27 (7 new).
- `cargo test -p tsz-solver --lib`: 7654/7654 (full crate suite — this is what caught the `distribute_intersection_over_unions` regression the fix also required).
- `cargo test -p tsz-checker --lib -- ts2322 ts2345 ts2353 ts2559 ts2560 ts2739 ts2741 union weak_type keyof mapped distribute intersection object_literal`: 2253/2253.
- `cargo clippy --profile ci-lint -p tsz-solver -p tsz-checker --all-targets -- -D warnings`: clean.
- `cargo fmt --check -p tsz-solver -p tsz-checker`: clean.
- `python3 scripts/arch/arch_guard.py`: passes.
- `scripts/conformance/compare-to-parent.sh`: running at post time (this is a core solver-identity change — intersection member order — with broader blast radius than a narrow display fix, so a two-sided corpus run is warranted); will post the result as a PR comment once it completes.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

Claude-Session: https://claude.ai/code/session_01EpbaDBfd6Szk6zTsBouda4

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpbaDBfd6Szk6zTsBouda4)_