### PR TITLE
fix(solver): preserve intersection source order for diagnostics (#16753)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -327,6 +327,9 @@ path = "tests/homomorphic_mapped_alias_readonly_index_source_tests.rs"
 name = "intersection_modifier_merge_tests"
 path = "tests/intersection_modifier_merge_tests.rs"
 [[test]]
+name = "intersection_source_order_constituent_16753_tests"
+path = "tests/intersection_source_order_constituent_16753_tests.rs"
+[[test]]
 name = "array_declaration_display_summary_tests"
 path = "tests/array_declaration_display_summary_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -1499,7 +1499,17 @@ impl<'a> CheckerState<'a> {
     /// rendered text — so fall back to that to recover the constituents.
     fn target_intersection_constituents(&mut self, target: TypeId) -> Option<Vec<TypeId>> {
         let resolved = self.resolve_lazy_type(target);
-        crate::query_boundaries::common::intersection_members(self.ctx.types, resolved)
+        // `normalize_intersection` reorders members into a canonical (object-last)
+        // form for structural identity, which drops tsc's source order. When a
+        // reorder was recorded, elaborate against the written order so the first
+        // failing constituent matches tsc (`typeRelatedToEachType`) — e.g.
+        // `{ z: 1 } & [string, number]` blames `{ z: 1; }`, not the tuple.
+        let ordered = self
+            .ctx
+            .types
+            .get_intersection_source_order(resolved)
+            .unwrap_or(resolved);
+        crate::query_boundaries::common::intersection_members(self.ctx.types, ordered)
             .map(|list| list.iter().copied().collect())
             .or_else(|| self.display_alias_intersection_constituents(resolved))
             .or_else(|| self.display_alias_intersection_constituents(target))

--- a/crates/tsz-checker/tests/intersection_source_order_constituent_16753_tests.rs
+++ b/crates/tsz-checker/tests/intersection_source_order_constituent_16753_tests.rs
@@ -1,0 +1,129 @@
+//! Regression tests for #16753: a target intersection that mixes an object with
+//! a non-mergeable member (a tuple/array) must elaborate the first **written**
+//! failing constituent, matching tsc's `typeRelatedToEachType`.
+//!
+//! Structural rule (verified against tsc 7.0.2): tsc relates a source to each
+//! constituent of `C1 & C2 & …` in source order and elaborates the first one it
+//! fails. tsz's interner reorders intersection members into a canonical
+//! (object-last) form so that structurally equal intersections built along
+//! different paths hash-cons to one `TypeId` — which dropped the source order,
+//! so `{ z: 1 } & [string, number]` named the tuple where tsc names `{ z: 1; }`.
+//! The interner now records the written order separately
+//! (`intersection_source_order`, diagnostics-only) and the assignability
+//! elaboration recovers it, without perturbing type identity, display, or
+//! relations.
+//!
+//! Note: because `A & B` and `B & A` intern to the same `TypeId` in tsz, only
+//! the first-written order can be recorded for a shared canonical type; the
+//! cases below are each self-contained so the order under test is the one
+//! recorded.
+
+use tsz_checker::diagnostics::Diagnostic;
+
+fn check(source: &str) -> Vec<Diagnostic> {
+    let libs = tsz_checker::test_utils::load_default_lib_files();
+    tsz_checker::test_utils::check_source_with_libs(
+        source,
+        "test.ts",
+        tsz_checker::context::CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+        &libs,
+    )
+}
+
+/// The full elaboration text of the single TS2322 (main message + every
+/// related-information line).
+fn ts2322_elaboration(source: &str) -> String {
+    let diags = check(source);
+    let matching: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected exactly one TS2322, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+    let mut lines = vec![matching[0].message_text.clone()];
+    lines.extend(
+        matching[0]
+            .related_information
+            .iter()
+            .map(|info| info.message_text.clone()),
+    );
+    lines.join("\n")
+}
+
+fn assert_names_object(source: &str, label: &str) {
+    let text = ts2322_elaboration(source);
+    assert!(
+        text.contains("to type '{ z: 1; }'"),
+        "[{label}] expected the elaboration to name the object constituent `{{ z: 1; }}`, got:\n{text}"
+    );
+}
+
+/// The headline witness: an object-first intersection with a spread tuple names
+/// the object, not the tuple.
+#[test]
+fn issue_16753_object_first_spread_tuple_names_object() {
+    assert_names_object(
+        "type B = { z: 1 } & [string, ...[number, boolean]];\nconst b: B = 1;",
+        "{ z: 1 } & [string, ...[number, boolean]]",
+    );
+}
+
+/// Not spread-specific: a plain tuple member behaves the same.
+#[test]
+fn issue_16753_object_first_plain_tuple_names_object() {
+    assert_names_object(
+        "type C = { z: 1 } & [string, number];\nconst c: C = 1;",
+        "{ z: 1 } & [string, number]",
+    );
+}
+
+/// Three-way: two objects then a tuple names the first written object.
+#[test]
+fn issue_16753_object_first_three_way_names_first_object() {
+    assert_names_object(
+        "type E = { z: 1 } & { w: 2 } & [string, number];\nconst e: E = 1;",
+        "{ z: 1 } & { w: 2 } & [string, number]",
+    );
+}
+
+/// Renamed binders: the alias/property names do not drive the selection.
+#[test]
+fn issue_16753_object_first_names_object_binder_independent() {
+    let text =
+        ts2322_elaboration("type Blend = { marker: 1 } & [string, number];\nconst v: Blend = 1;");
+    assert!(
+        text.contains("to type '{ marker: 1; }'"),
+        "expected the object constituent named, got:\n{text}"
+    );
+}
+
+/// Control (matches on `main` already): a **tuple-first** intersection still
+/// names the tuple — no source-order reorder is recorded, so the canonical
+/// order (tuple already first) is used. This pins that the fix does not flip the
+/// already-correct direction.
+#[test]
+fn issue_16753_tuple_first_still_names_tuple() {
+    let text = ts2322_elaboration("type D = [string, number] & { z: 1 };\nconst d: D = 1;");
+    assert!(
+        text.contains("to type '[string, number]'"),
+        "expected the tuple constituent named for a tuple-first intersection, got:\n{text}"
+    );
+}
+
+/// Control: a pure object∧object intersection is unaffected (it merges into a
+/// single object with a written-order display alias and already named the first
+/// constituent correctly).
+#[test]
+fn issue_16753_object_only_intersection_unaffected() {
+    assert_names_object(
+        "type O = { z: 1 } & { w: 2 };\nconst o: O = 1;",
+        "{ z: 1 } & { w: 2 }",
+    );
+}

--- a/crates/tsz-solver/src/caches/display_provenance.rs
+++ b/crates/tsz-solver/src/caches/display_provenance.rs
@@ -78,6 +78,16 @@ pub trait TypeDisplayProvenance {
         None
     }
 
+    /// Record the written source order of a canonically reordered intersection.
+    /// See [`crate::intern::TypeInterner::store_intersection_source_order`].
+    fn store_intersection_source_order(&self, _canonical: TypeId, _source_order: TypeId) {}
+
+    /// Look up the raw written-source-order `Intersection` for a canonically
+    /// reordered one. Returns `None` when no reorder was recorded.
+    fn get_intersection_source_order(&self, _type_id: TypeId) -> Option<TypeId> {
+        None
+    }
+
     /// Record semantic provenance from an evaluated structural result back
     /// to the nominal `Application` it was produced from (relation-layer
     /// accept-only variance recovery; never read by the printer).
@@ -254,6 +264,14 @@ impl TypeDisplayProvenance for TypeInterner {
 
     fn get_merged_intersection_origin(&self, type_id: TypeId) -> Option<TypeId> {
         Self::get_merged_intersection_origin(self, type_id)
+    }
+
+    fn store_intersection_source_order(&self, canonical: TypeId, source_order: TypeId) {
+        Self::store_intersection_source_order(self, canonical, source_order);
+    }
+
+    fn get_intersection_source_order(&self, type_id: TypeId) -> Option<TypeId> {
+        Self::get_intersection_source_order(self, type_id)
     }
 
     fn record_application_eval_origin(&self, evaluated: TypeId, application: TypeId) {

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -752,6 +752,15 @@ impl TypeDisplayProvenance for QueryCache<'_> {
         self.interner.get_merged_intersection_origin(type_id)
     }
 
+    fn store_intersection_source_order(&self, canonical: TypeId, source_order: TypeId) {
+        self.interner
+            .store_intersection_source_order(canonical, source_order);
+    }
+
+    fn get_intersection_source_order(&self, type_id: TypeId) -> Option<TypeId> {
+        self.interner.get_intersection_source_order(type_id)
+    }
+
     fn record_application_eval_origin(&self, evaluated: TypeId, application: TypeId) {
         self.interner
             .record_application_eval_origin(evaluated, application);

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -499,6 +499,8 @@ pub struct TypeInterner {
     /// recover the intersection members regardless of any alias the type later
     /// flows through. First write wins.
     pub(super) merged_intersection_origin: DashMap<TypeId, TypeId, FxBuildHasher>,
+    /// Diagnostic-only written-source-order map; see `store_intersection_source_order`.
+    pub(super) intersection_source_order: DashMap<TypeId, TypeId, FxBuildHasher>,
     /// Application bases whose type-alias body is a conditional type.
     ///
     /// Conditional aliases often evaluate to a branch with its own display
@@ -869,6 +871,7 @@ impl TypeInterner {
             display_properties: DashMap::with_hasher(FxBuildHasher),
             display_alias: DashMap::with_hasher(FxBuildHasher),
             merged_intersection_origin: DashMap::with_hasher(FxBuildHasher),
+            intersection_source_order: DashMap::with_hasher(FxBuildHasher),
             application_eval_origin: DashMap::with_hasher(FxBuildHasher),
             conditional_alias_bases: DashMap::with_hasher(FxBuildHasher),
             global_this_surface_display: DashMap::with_hasher(FxBuildHasher),

--- a/crates/tsz-solver/src/intern/core/interner/display.rs
+++ b/crates/tsz-solver/src/intern/core/interner/display.rs
@@ -357,6 +357,38 @@ impl TypeInterner {
         self.merged_intersection_origin.get(&type_id).map(|r| *r)
     }
 
+    /// Record that the canonically-ordered `canonical` intersection was written
+    /// with its members in the order of `source_order` (a raw, un-normalized
+    /// `Intersection`).
+    ///
+    /// `normalize_intersection` reorders members into a canonical (object-last)
+    /// form so that structurally equal intersections built along different paths
+    /// (e.g. a distributed `(string | null) & {}` vs. the directly written
+    /// `string & {}`) hash-cons to one `TypeId`. That reordering loses tsc's
+    /// source order, which `typeRelatedToEachType` needs to elaborate the first
+    /// *written* failing constituent of a target intersection. This map lets the
+    /// checker recover it. It is never read by the printer or the relation engine
+    /// — diagnostics only. Both ids must be distinct `Intersection` types; first
+    /// write wins.
+    pub fn store_intersection_source_order(&self, canonical: TypeId, source_order: TypeId) {
+        if canonical == source_order || canonical.is_intrinsic() {
+            return;
+        }
+        if !matches!(self.lookup(source_order), Some(TypeData::Intersection(_))) {
+            return;
+        }
+        if let Entry::Vacant(entry) = self.intersection_source_order.entry(canonical) {
+            entry.insert(source_order);
+            self.advance_display_provenance_generation();
+        }
+    }
+
+    /// Look up the raw written-source-order `Intersection` for a canonically
+    /// reordered one. Returns `None` when no reorder was recorded.
+    pub fn get_intersection_source_order(&self, type_id: TypeId) -> Option<TypeId> {
+        self.intersection_source_order.get(&type_id).map(|r| *r)
+    }
+
     /// Record that an application base belongs to a type alias whose body is a
     /// conditional type. This is diagnostic-only provenance.
     pub fn mark_conditional_alias_base(&self, base: TypeId) {

--- a/crates/tsz-solver/src/intern/intersection.rs
+++ b/crates/tsz-solver/src/intern/intersection.rs
@@ -552,6 +552,16 @@ impl TypeInterner {
             .copied()
             .collect();
 
+        // Snapshot the written member order before the partial merge below
+        // reorders it into canonical (object-last) form. Only a mixed
+        // object-plus-non-object intersection can reorder, so skip the
+        // allocation otherwise. Recorded on the canonical result at the final
+        // intern so diagnostics can elaborate the first *written* failing
+        // constituent (`typeRelatedToEachType`) without perturbing identity.
+        let source_order_snapshot: Option<SmallVec<[TypeId; 4]>> = (!original_objects.is_empty()
+            && original_objects.len() < flat.len())
+        .then(|| flat.iter().copied().collect());
+
         // Step 1: Extract and merge objects from mixed intersection
         let (merged_object, remaining_after_objects) = self.extract_and_merge_objects(&flat);
 
@@ -613,6 +623,14 @@ impl TypeInterner {
         // replace the first object/callable occurrence with its merged
         // representative; this keeps tsc's source-order display for mixed
         // intersections such as `(() => void) & { prop: any }`.
+        //
+        // The canonical (object-last) order this rebuild produces is load-bearing
+        // for structural identity: a distributed form such as `(string | null) &
+        // {}` (which builds its `{}`-anchored alternative in a different member
+        // order) must intern to the *same* `TypeId` as the directly written
+        // `string & {}`. The written source order is instead recorded separately
+        // below (`intersection_source_order`) so diagnostics can recover it
+        // without perturbing identity, display, or evaluation.
         let mut final_flat: TypeListBuffer = SmallVec::new();
         if merged_callable.is_some() {
             let mut emitted_object = false;
@@ -678,7 +696,23 @@ impl TypeInterner {
         }
 
         let list_id = self.intern_type_list_from_slice(&flat);
-        self.intern(TypeData::Intersection(list_id))
+        let canonical = self.intern(TypeData::Intersection(list_id));
+
+        // Record the written source order when the canonical rebuild reordered
+        // the members. The raw intersection is built directly (bypassing this
+        // normalizer, exactly as the object-merge display alias above does) so it
+        // keeps source order; `store_intersection_source_order` no-ops when it
+        // matches the canonical order or is not a distinct intersection.
+        // The snapshot is only captured for a mixed object-plus-non-object
+        // intersection, so it already has >= 2 members; the store self-guards
+        // against a no-op (canonical order unchanged) besides.
+        if let Some(snapshot) = source_order_snapshot {
+            let raw_list = self.intern_type_list_from_slice(&snapshot);
+            let raw_written = self.intern(TypeData::Intersection(raw_list));
+            self.store_intersection_source_order(canonical, raw_written);
+        }
+
+        canonical
     }
 
     fn try_merge_callables_in_intersection(&self, members: &[TypeId]) -> Option<TypeId> {


### PR DESCRIPTION
Fixes #16753.

## Goal
Goal: hold

## Structural rule

When a source fails against a target intersection `C1 & C2 & …`, `tsc`
(`typeRelatedToEachType`) relates it to each constituent in **written source
order** and elaborates the first one it fails. tsz's interner reorders
intersection members into a canonical (object-last) form so that structurally
equal intersections built along different paths hash-cons to one `TypeId` — and
that reordering dropped the source order, so an object-first intersection with a
non-mergeable member named the wrong constituent:

```ts
type B = { z: 1 } & [string, ...[number, boolean]];
const b: B = 1;
```

- `tsc` 7.0.2: `error TS2322: ... to type '{ z: 1; }'.`
- tsz before: `... to type '[string, number, boolean]'.` (named the tuple)
- tsz after: `... to type '{ z: 1; }'.`

Pure object∧object intersections were already correct — they merge into a single
object carrying a written-order display alias — so this only surfaced once a
non-object member (tuple/array) rode along and forced the intersection to stay a
real, reordered `Intersection` node.

## Owner layer

Solver interner (`crates/tsz-solver/src/intern/intersection.rs`) plus the
checker's assignability elaboration gateway
(`assignability_diagnostics.rs::target_intersection_constituents`).

The canonical (object-last) member order is **load-bearing for structural
identity**: a distributed form such as `(string | null) & {}` builds its
`{}`-anchored alternative in a different member order and must still intern to
the same `TypeId` as the directly written `string & {}`. So the fix does **not**
change the interned order. Instead the interner records the written source order
in a new **diagnostics-only** provenance channel `intersection_source_order`
(mirroring the existing `merged_intersection_origin`), and the elaboration
recovers it. The channel is never read by the printer or the relation engine, so
type identity, display, and relation results are unchanged — only which
constituent a TS2322/TS2345 against such an intersection names, moving it toward
`tsc`.

Because `A & B` and `B & A` intern to one `TypeId`, only the first-written order
is recorded for a shared canonical type — an inherent consequence of tsz's
order-independent intersection identity, not introduced here. Each adjacent-case
row below is self-contained so the order under test is the recorded one.

## Adjacent-case matrix (pinned in `intersection_source_order_constituent_16753_tests`)

| annotation | names | matches tsc |
| --- | --- | --- |
| `{ z: 1 } & [string, ...[number, boolean]]` | `{ z: 1; }` | ✓ |
| `{ z: 1 } & [string, number]` (no spread) | `{ z: 1; }` | ✓ |
| `{ z: 1 } & { w: 2 } & [string, number]` | `{ z: 1; }` (first) | ✓ |
| `{ marker: 1 } & [string, number]` (renamed binder) | `{ marker: 1; }` | ✓ |
| `[string, number] & { z: 1 }` (tuple-first control) | `[string, number]` | ✓ |
| `{ z: 1 } & { w: 2 }` (object-only control) | `{ z: 1; }` | ✓ |

## Verification

- `cargo test -p tsz-checker --test intersection_source_order_constituent_16753_tests` — 6/6 (new).
- `cargo test -p tsz-checker --lib -- intersection_target_elaboration` — 20/20 (existing elaboration pins hold).
- `cargo test -p tsz-solver --lib -- test_empty_object_rule_intersection` — passes (the distributed-vs-direct `(string|null)&{}` ≡ `string&{}` canonicalization the reorder protects).
- Broad sweep, all green: solver `intersection`/`diagnostics::format`/`reduce`/`normalize` (947), checker `intersection`/`assignability`/`union_target` (511), `anonymous_object_intersection_display_tests` (6), `union_tuple_source_display_tests` (8).
- `cargo clippy -p tsz-solver --lib` and `-p tsz-checker --lib` + the new test target — clean; pre-commit `clippy` + `arch-size` guards passed.
- Manual `tsz --noEmit --strict` on each matrix row — output matches `tsc` 7.0.2.
- Conformance / emit / fourslash floors: **not runnable in this environment** (TypeScript submodule not checked out). The change is diagnostics-only (the new channel is never read by the printer or relation engine), so emit is structurally unaffected; the full suite runs in CI on this PR.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high

Claude-Session: https://claude.ai/code/session_018WwM8BT6j6wbTjSgPWGkzQ

---
_Generated by [Claude Code](https://claude.ai/code/session_018WwM8BT6j6wbTjSgPWGkzQ)_