### PR TITLE
fix(checker/solver): ES private identifier nominal mismatch reports TS18015 wording, not TS2446

### DIFF
--- a/crates/tsz-checker/src/classes/private_checker.rs
+++ b/crates/tsz-checker/src/classes/private_checker.rs
@@ -94,6 +94,16 @@ impl<'a> CheckerState<'a> {
             && source_member == target_member
             && source_visibility == target_visibility
         {
+            // An ES private identifier (`#name`) is a per-class slot: tsc
+            // reports TS18015 ("refers to a different member") for it, and
+            // reserves the "separate declarations" wording for
+            // modifier-`private`/`protected` members.
+            if tsz_solver::utils::is_es_private_identifier_name(&source_member) {
+                return Some(format_message(
+                    diagnostic_messages::PROPERTY_IN_TYPE_REFERS_TO_A_DIFFERENT_MEMBER_THAT_CANNOT_BE_ACCESSED_FROM_WITHI,
+                    &[&source_member, &self.format_type(source), &self.format_type(target)],
+                ));
+            }
             return Some(match source_visibility {
                 tsz_solver::Visibility::Private => format_message(
                     diagnostic_messages::TYPES_HAVE_SEPARATE_DECLARATIONS_OF_A_PRIVATE_PROPERTY,
@@ -114,11 +124,13 @@ impl<'a> CheckerState<'a> {
             .or_else(|| self.get_private_field_name_from_brand(source))
             .unwrap_or_else(|| "[private field]".to_string());
 
-        Some(format!(
-            "Property '{}' in type '{}' refers to a different member that cannot be accessed from within type '{}'.",
-            field_name,
-            self.format_type(source),
-            self.format_type(target)
+        Some(format_message(
+            diagnostic_messages::PROPERTY_IN_TYPE_REFERS_TO_A_DIFFERENT_MEMBER_THAT_CANNOT_BE_ACCESSED_FROM_WITHI,
+            &[
+                &field_name,
+                &self.format_type(source),
+                &self.format_type(target),
+            ],
         ))
     }
 }

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -995,6 +995,9 @@ impl<'a> CheckerState<'a> {
             SubtypeFailureReason::PropertyNominalMismatch { property_name } => {
                 self.render_property_nominal_mismatch(reason, &rctx, *property_name)
             }
+            SubtypeFailureReason::PrivateIdentifierMemberMismatch { property_name } => {
+                self.render_private_identifier_member_mismatch(reason, &rctx, *property_name)
+            }
             SubtypeFailureReason::ExcessProperty {
                 property_name,
                 target_type: _,

--- a/crates/tsz-checker/src/error_reporter/render_failure_property_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure_property_helpers.rs
@@ -500,6 +500,40 @@ impl<'a> CheckerState<'a> {
         diag
     }
 
+    /// Render a nominal mismatch on an ES private identifier (`#name`).
+    ///
+    /// tsc: `Type 'A' is not assignable to type 'B'.` elaborated with TS18015
+    /// `Property '#x' in type 'A' refers to a different member that cannot be
+    /// accessed from within type 'B'.` — the source class first, the target
+    /// second, both spelled as in the top-level assignability message.
+    pub(super) fn render_private_identifier_member_mismatch(
+        &mut self,
+        reason: &tsz_solver::SubtypeFailureReason,
+        ctx: &RenderContext,
+        property_name: tsz_common::interner::Atom,
+    ) -> Diagnostic {
+        let (source_str, target_str) =
+            self.format_top_level_assignability_message_types_at(ctx.source, ctx.target, ctx.idx);
+        let base = format_message(
+            diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            &[&source_str, &target_str],
+        );
+        let mut diag = Diagnostic::error(
+            ctx.file_name.clone(),
+            ctx.start,
+            ctx.length,
+            base,
+            diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+        );
+        let prop_name = self.ctx.types.resolve_atom_ref(property_name);
+        let detail = format_message(
+            diagnostic_messages::PROPERTY_IN_TYPE_REFERS_TO_A_DIFFERENT_MEMBER_THAT_CANNOT_BE_ACCESSED_FROM_WITHI,
+            &[&prop_name, &source_str, &target_str],
+        );
+        diag.push_elaboration(detail, reason.diagnostic_code(), 0);
+        diag
+    }
+
     pub(super) fn render_return_type_mismatch(
         &mut self,
         reason: &tsz_solver::SubtypeFailureReason,

--- a/crates/tsz-checker/src/query_boundaries/relation_types.rs
+++ b/crates/tsz-checker/src/query_boundaries/relation_types.rs
@@ -362,6 +362,7 @@ impl RelationFailure {
             SubtypeFailureReason::OptionalPropertyRequired { property_name }
             | SubtypeFailureReason::ReadonlyPropertyMismatch { property_name }
             | SubtypeFailureReason::PropertyNominalMismatch { property_name }
+            | SubtypeFailureReason::PrivateIdentifierMemberMismatch { property_name }
             | SubtypeFailureReason::PropertyVisibilityMismatch { property_name, .. } => {
                 Self::PropertyModifierMismatch { property_name }
             }

--- a/crates/tsz-checker/tests/private_brands.rs
+++ b/crates/tsz-checker/tests/private_brands.rs
@@ -1123,3 +1123,141 @@ C.#x++;
         "Got unexpected diagnostics (only TS2339 and TS18013 were being checked for): {unexpected:?}"
     );
 }
+
+// =============================================================================
+// ES private identifier nominal mismatch wording (TS18015 vs TS2446)
+// =============================================================================
+//
+// tsc reserves "Types have separate declarations of a private property" for
+// modifier-`private` members; a same-spelled ES private identifier (`#name`)
+// in two unrelated classes gets the TS18015 wording instead:
+// "Property '#x' in type 'A' refers to a different member that cannot be
+// accessed from within type 'B'."
+
+/// Two unrelated classes with a same-spelled `#field`: the TS2322 elaboration
+/// uses the TS18015 "refers to a different member" wording, naming the source
+/// class first and the target class second.
+#[test]
+fn es_private_identifier_nominal_mismatch_uses_ts18015_wording() {
+    let source = r"
+        class A { #x = 1; }
+        class B { #x = 1; }
+        const b: B = new A();
+        ";
+
+    test_private_brands(source, 1);
+    let diagnostics = collect_private_brand_diagnostics(source);
+    let ts2322 = diagnostics
+        .iter()
+        .find(|diag| diag.code == 2322)
+        .expect("expected TS2322 for ES private identifier nominal mismatch");
+    assert!(
+        ts2322.related_information.iter().any(|info| info
+            .message_text
+            .contains("Property '#x' in type 'A' refers to a different member that cannot be accessed from within type 'B'.")),
+        "Expected TS18015 wording in TS2322 related info, got: {ts2322:?}"
+    );
+    assert!(
+        !ts2322
+            .related_information
+            .iter()
+            .any(|info| info.message_text.contains("separate declarations")),
+        "ES private identifiers must not use the modifier-private 'separate declarations' wording, got: {ts2322:?}"
+    );
+}
+
+/// Same rule with renamed binders and a `#method` instead of a field.
+#[test]
+fn es_private_identifier_ts18015_wording_renamed_binders_method_form() {
+    let source = r"
+        class Granite { #erode() {} }
+        class Basalt { #erode() {} }
+        declare const rock: Granite;
+        const other: Basalt = rock;
+        ";
+
+    test_private_brands(source, 1);
+    let diagnostics = collect_private_brand_diagnostics(source);
+    let ts2322 = diagnostics
+        .iter()
+        .find(|diag| diag.code == 2322)
+        .expect("expected TS2322 for ES private method nominal mismatch");
+    assert!(
+        ts2322.related_information.iter().any(|info| info
+            .message_text
+            .contains("Property '#erode' in type 'Granite' refers to a different member that cannot be accessed from within type 'Basalt'.")),
+        "Expected TS18015 wording in TS2322 related info, got: {ts2322:?}"
+    );
+}
+
+/// Negative control: modifier-`private` members keep the TS2446
+/// "separate declarations" wording and never the TS18015 one.
+#[test]
+fn modifier_private_nominal_mismatch_keeps_separate_declarations_wording() {
+    let source = r"
+        class A { private x = 1; }
+        class B { private x = 1; }
+        const b: B = new A();
+        ";
+
+    test_private_brands(source, 1);
+    let diagnostics = collect_private_brand_diagnostics(source);
+    let ts2322 = diagnostics
+        .iter()
+        .find(|diag| diag.code == 2322)
+        .expect("expected TS2322 for modifier-private nominal mismatch");
+    assert!(
+        ts2322.related_information.iter().any(|info| info
+            .message_text
+            .contains("Types have separate declarations of a private property 'x'.")),
+        "Expected TS2446 wording in TS2322 related info, got: {ts2322:?}"
+    );
+    assert!(
+        !ts2322
+            .related_information
+            .iter()
+            .any(|info| info.message_text.contains("refers to a different member")),
+        "Modifier-private members must not use the TS18015 wording, got: {ts2322:?}"
+    );
+}
+
+/// Negative control: a derived class (with or without a redeclared `#x`)
+/// stays assignable to its base — the per-class slot is inherited.
+#[test]
+fn derived_class_redeclaring_es_private_stays_assignable_to_base() {
+    let source = r"
+        class Base { #x = 1; }
+        class Derived extends Base { }
+        const q: Base = new Derived();
+        class Derived2 extends Base { #x = 2; }
+        const r: Base = new Derived2();
+        ";
+
+    test_private_brands(source, 0);
+}
+
+/// Negative control: a source with no ES private member at all keeps the
+/// plain missing-property diagnostic (TS2741), not the TS18015 wording.
+#[test]
+fn source_without_es_private_member_stays_missing_property() {
+    let source = r"
+        class A { #x = 1; }
+        class C { y = 2; }
+        const c2: A = new C();
+        ";
+
+    assert!(
+        has_error_code(source, 2741),
+        "expected TS2741 missing-property for a source without any ES private member"
+    );
+    let diagnostics = collect_private_brand_diagnostics(source);
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.message_text.contains("refers to a different member")
+                || d.related_information
+                    .iter()
+                    .any(|info| info.message_text.contains("refers to a different member"))),
+        "TS18015 wording must not fire when the source has no same-spelled ES private member, got: {diagnostics:?}"
+    );
+}

--- a/crates/tsz-solver/src/diagnostics/core.rs
+++ b/crates/tsz-solver/src/diagnostics/core.rs
@@ -129,6 +129,10 @@ pub enum SubtypeFailureReason {
     },
     /// Property nominal mismatch (separate declarations of private/protected property).
     PropertyNominalMismatch { property_name: Atom },
+    /// ES private identifier (`#name`) member originates from a different
+    /// declaring class, so the target's slot is unreachable from the source
+    /// (TS18015: "refers to a different member").
+    PrivateIdentifierMemberMismatch { property_name: Atom },
     /// Return types are incompatible.
     ReturnTypeMismatch {
         source_return: TypeId,
@@ -782,6 +786,7 @@ pub mod codes {
     pub use dc::CANNOT_ASSIGN_AN_ABSTRACT_CONSTRUCTOR_TYPE_TO_A_NON_ABSTRACT_CONSTRUCTOR_TYPE as ABSTRACT_CONSTRUCTOR_ASSIGNMENT;
     pub use dc::CANNOT_ASSIGN_TO_BECAUSE_IT_IS_A_READ_ONLY_PROPERTY as READONLY_PROPERTY;
     pub use dc::OBJECT_LITERAL_MAY_ONLY_SPECIFY_KNOWN_PROPERTIES_AND_DOES_NOT_EXIST_IN_TYPE as EXCESS_PROPERTY;
+    pub use dc::PROPERTY_IN_TYPE_REFERS_TO_A_DIFFERENT_MEMBER_THAT_CANNOT_BE_ACCESSED_FROM_WITHI as PRIVATE_IDENTIFIER_MEMBER_MISMATCH;
     pub use dc::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE as PROPERTY_MISSING;
     pub use dc::PROPERTY_IS_OPTIONAL_IN_TYPE_BUT_REQUIRED_IN_TYPE as PROPERTY_OPTIONAL_BUT_REQUIRED;
     pub use dc::PROPERTY_IS_PRIVATE_AND_ONLY_ACCESSIBLE_WITHIN_CLASS as PROPERTY_VISIBILITY_MISMATCH;
@@ -922,6 +927,9 @@ impl SubtypeFailureReason {
             Self::ReadonlyPropertyMismatch { .. } => codes::READONLY_PROPERTY,
             Self::PropertyVisibilityMismatch { .. } => codes::PROPERTY_VISIBILITY_MISMATCH,
             Self::PropertyNominalMismatch { .. } => codes::PROPERTY_NOMINAL_MISMATCH,
+            Self::PrivateIdentifierMemberMismatch { .. } => {
+                codes::PRIVATE_IDENTIFIER_MEMBER_MISMATCH
+            }
             Self::TypePredicateMismatch {
                 source_predicate: None,
                 ..
@@ -1093,6 +1101,19 @@ impl SubtypeFailureReason {
                 .with_related(PendingDiagnostic::error(
                     codes::PROPERTY_NOMINAL_MISMATCH,
                     vec![(*property_name).into()],
+                ))
+            }
+
+            Self::PrivateIdentifierMemberMismatch { property_name } => {
+                // TS18015: Property '#x' in type 'A' refers to a different
+                // member that cannot be accessed from within type 'B'
+                PendingDiagnostic::error(
+                    codes::TYPE_NOT_ASSIGNABLE,
+                    vec![source.into(), target.into()],
+                )
+                .with_related(PendingDiagnostic::error(
+                    codes::PRIVATE_IDENTIFIER_MEMBER_MISMATCH,
+                    vec![(*property_name).into(), source.into(), target.into()],
                 ))
             }
 

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -1694,15 +1694,19 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                         // slot: tsc reports "refers to a different member"
                         // (TS18015), while a modifier-`private` member gets
                         // "separate declarations" (TS2446).
-                        return Some(if self.is_es_private_identifier_name(t_prop.name) {
-                            SubtypeFailureReason::PrivateIdentifierMemberMismatch {
-                                property_name: t_prop.name,
-                            }
-                        } else {
-                            SubtypeFailureReason::PropertyNominalMismatch {
-                                property_name: t_prop.name,
-                            }
-                        });
+                        return Some(
+                            if crate::utils::is_es_private_identifier_name(
+                                self.interner.resolve_atom_ref(t_prop.name).as_ref(),
+                            ) {
+                                SubtypeFailureReason::PrivateIdentifierMemberMismatch {
+                                    property_name: t_prop.name,
+                                }
+                            } else {
+                                SubtypeFailureReason::PropertyNominalMismatch {
+                                    property_name: t_prop.name,
+                                }
+                            },
+                        );
                     }
                 }
                 // Cannot assign private/protected source to public target

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -1690,8 +1690,18 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                         t_prop.parent_id,
                         t_prop.visibility,
                     ) {
-                        return Some(SubtypeFailureReason::PropertyNominalMismatch {
-                            property_name: t_prop.name,
+                        // An ES private identifier (`#name`) is a per-class
+                        // slot: tsc reports "refers to a different member"
+                        // (TS18015), while a modifier-`private` member gets
+                        // "separate declarations" (TS2446).
+                        return Some(if self.is_es_private_identifier_name(t_prop.name) {
+                            SubtypeFailureReason::PrivateIdentifierMemberMismatch {
+                                property_name: t_prop.name,
+                            }
+                        } else {
+                            SubtypeFailureReason::PropertyNominalMismatch {
+                                property_name: t_prop.name,
+                            }
                         });
                     }
                 }

--- a/crates/tsz-solver/src/relations/subtype/rules/objects.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/objects.rs
@@ -507,20 +507,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         SubtypeResult::True
     }
 
-    /// Whether `member_name` spells an ES private identifier (`#name`).
-    ///
-    /// ES private identifiers are per-class slots with hierarchical origin
-    /// rules, distinct from modifier-`private` members, and `tsc` reports a
-    /// different relation-failure elaboration for them (TS18015 vs TS2446).
-    pub(crate) fn is_es_private_identifier_name(
-        &self,
-        member_name: tsz_common::interner::Atom,
-    ) -> bool {
-        crate::utils::is_es_private_identifier_name(
-            self.interner.resolve_atom_ref(member_name).as_ref(),
-        )
-    }
-
     /// Decide whether a source property satisfies a *nominal* (private or
     /// protected) target property, given the member name, the two
     /// declaring-class symbols (`parent_id`s), and the target member's
@@ -563,7 +549,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // `private` (modifier) requires strict declaration identity, which just
         // failed — unless the member is an ES private identifier (`#name`),
         // which is a per-class slot that a derived class always inherits.
-        let is_es_private_identifier = self.is_es_private_identifier_name(member_name);
+        let is_es_private_identifier = crate::utils::is_es_private_identifier_name(
+            self.interner.resolve_atom_ref(member_name).as_ref(),
+        );
         if target_visibility != Visibility::Protected && !is_es_private_identifier {
             return false;
         }

--- a/crates/tsz-solver/src/relations/subtype/rules/objects.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/objects.rs
@@ -507,6 +507,20 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         SubtypeResult::True
     }
 
+    /// Whether `member_name` spells an ES private identifier (`#name`).
+    ///
+    /// ES private identifiers are per-class slots with hierarchical origin
+    /// rules, distinct from modifier-`private` members, and `tsc` reports a
+    /// different relation-failure elaboration for them (TS18015 vs TS2446).
+    pub(crate) fn is_es_private_identifier_name(
+        &self,
+        member_name: tsz_common::interner::Atom,
+    ) -> bool {
+        crate::utils::is_es_private_identifier_name(
+            self.interner.resolve_atom_ref(member_name).as_ref(),
+        )
+    }
+
     /// Decide whether a source property satisfies a *nominal* (private or
     /// protected) target property, given the member name, the two
     /// declaring-class symbols (`parent_id`s), and the target member's
@@ -549,11 +563,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // `private` (modifier) requires strict declaration identity, which just
         // failed — unless the member is an ES private identifier (`#name`),
         // which is a per-class slot that a derived class always inherits.
-        let is_es_private_identifier = self
-            .interner
-            .resolve_atom_ref(member_name)
-            .as_ref()
-            .starts_with('#');
+        let is_es_private_identifier = self.is_es_private_identifier_name(member_name);
         if target_visibility != Visibility::Protected && !is_es_private_identifier {
             return false;
         }

--- a/crates/tsz-solver/src/utils/mod.rs
+++ b/crates/tsz-solver/src/utils/mod.rs
@@ -148,6 +148,18 @@ pub fn is_synthetic_private_brand_name(name: &str) -> bool {
     !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit())
 }
 
+/// Checks if a member name spells an ES private identifier (`#name`).
+///
+/// ES private identifiers are per-class slots with hierarchical origin rules,
+/// distinct from modifier-`private` members. `tsc` reports a different
+/// relation-failure elaboration for them: TS18015 ("refers to a different
+/// member") instead of TS2446 ("separate declarations of a private property").
+/// A `#` can never begin a user-spellable ordinary property name, so the
+/// prefix test is structural, not a user-name match.
+pub fn is_es_private_identifier_name(name: &str) -> bool {
+    name.starts_with('#')
+}
+
 /// Checks if a string represents a numeric literal name.
 ///
 /// Returns `true` for:


### PR DESCRIPTION
Takes the TS18015 row off #16291's 38-code unwired table — not by wiring a dead code, but by fixing the wrong-wording defect that hid it: the code's one reachable site was already firing, with the TS2446 message.

**Structural rule:** when an assignability failure's culprit nominal member is an ES private identifier (`#name`) declared by a different class on each side, tsc elaborates with TS18015 — `Property '#x' in type 'A' refers to a different member that cannot be accessed from within type 'B'.` (source class first, target second) — and reserves the TS2446 `Types have separate declarations of a private property 'x'.` wording for modifier-`private` members; tsz does this through the checker's private-brand interception (`classes/private_checker.rs`) and, for the paths that reach the solver's explain pass, a new `SubtypeFailureReason::PrivateIdentifierMemberMismatch` produced where `nominal_member_origin_ok` fails (`relations/subtype/explain.rs`), rendered at the `render_failure` boundary.

The `#`-prefix rule is a language-level structural marker (a `#` can never begin an ordinary user property name), owned by `tsz_solver::utils::is_es_private_identifier_name` and shared by the solver relation code and the checker; it is the same discriminator the relation layer already used internally (`objects.rs` `nominal_member_origin_ok`), now extracted instead of duplicated. Also replaced `private_brand_mismatch_error`'s hand-rolled `format!` copy of the TS18015 text with the message constant.

**Adjacent matrix** (oracle: pinned `typescript@7.0.2`, `--noEmit --target es2022`; every row byte-identical after the fix, and every control row already matched before it):

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| two classes, same `#x` field | TS2322 + TS18015 wording | TS2322 + TS2446 wording | ✅ matches |
| renamed binders, `#method` | TS2322 + TS18015 wording | TS2446 wording | ✅ matches |
| private `get #a()` accessor | TS2322 + TS18015 wording | TS2446 wording | ✅ matches |
| array element position (`V[] = [new U()]`) | TS2322 + TS18015 wording | TS2446 wording | ✅ matches |
| modifier-`private` pair (control) | TS2322 + TS2446 wording | ✅ already matched | unchanged |
| `protected` pair (control) | TS2322 + protected wording | already TS2445-family wording | unchanged |
| derived class (incl. redeclared `#x`) → base (control) | clean | ✅ clean | unchanged |
| source without any `#x` (control) | TS2741 missing | ✅ TS2741 | unchanged |
| object literal vs `#x` class (control) | TS2741 missing | ✅ TS2741 | unchanged |
| static-only `#s` pair (control) | clean | ✅ clean | unchanged |

Two pre-existing, orthogonal gaps found by the matrix are deliberately out of scope and filed as a follow-up (missing elaboration, not wrong wording; they affect modifier-private identically): the TS2345 argument path drops the nominal elaboration line entirely, and generic instantiations (`G<number>` → `H<number>`) drop it on the TS2322 path.

## Goal
Goal: hold

## Verification
- `cargo test --profile dist-fast -p tsz-checker --test private_brands`: 41 passed / 0 failed (36 pre-existing + 5 new: positive, renamed-binder/method form, modifier-private negative, derived-class control, missing-property control). `cargo-nextest` is not installed in this container and its prebuilt download is blocked by the egress proxy (403), hence `cargo test` for this targeted run.
- `cargo clippy --profile dist-fast -p tsz-solver -p tsz-checker --lib -- -D warnings`: clean. (`--all-targets` under `dist-fast` fails on pre-existing perf-counter test helpers that are cfg'd out of optimized profiles — unrelated to this change; the per-merge CI clippy lane covers the dev-profile workspace.)
- `cargo fmt --check`: clean.
- 11-row witness matrix vs pinned `typescript@7.0.2` oracle (table above), before/after on the same `dist-fast` binary.
- `scripts/conformance/compare-to-parent.sh` (two-sided, vs parent `6018d51`): running now in this container; result will be posted as a PR comment before merge.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-fable-5
Effort: medium
AgentName: Tephra

---
_Generated by [Claude Code](https://claude.ai/code/session_01JUuFSRW7SEuPDAkiEyAAFf)_