### PR TITLE
docs(rust-debugger): document the tsz-checker --lib breakpoint-binding wall (#15653)

### DIFF
--- a/.agents/skills/rust-debugger/REFERENCE.md
+++ b/.agents/skills/rust-debugger/REFERENCE.md
@@ -119,6 +119,29 @@ rdbg def | hover | refs <file> <line> <col>
   `--test <name> … -- <test_name>` for `tests/<name>.rs`; break at the
   assertion or inside the code under test.
 
+## When breakpoints don't bind
+
+A `launch` that reports `no stop/exit event` and runs to completion without ever
+pausing — even on a function you know is on the path — is a **binding failure**,
+not a wrong line or symbol. `rdbg breaks` shows the breakpoint `NOT BOUND` (or
+bound with `0 hits`) and there was no `>>> STOP`. The `tsz-checker --lib`
+unit-test binary is the known offender (#15653): it carries hundreds of MB of
+debug info and rdbg/lldb can fail to attach to or resolve symbols on it
+(reported on macOS with rdbg 0.4.0). Route around it:
+
+- **Break in a small `--test <stem>` integration target, not `--lib`.** The
+  `SKILL.md` tsz recipe already uses `--test crates/tsz-checker/tests/<stem>.rs`
+  for this reason — the giant `--lib` binary is the one that fails to bind, and
+  most checker behavior reproduces from an integration test.
+- **Last-resort fallback when nothing binds.** Build once with `cargo test -p
+  tsz-checker --lib --no-run`, then run the compiled binary directly
+  (`.target/debug/deps/tsz_checker-<hash> <test_name> --nocapture
+  --test-threads=1`), adding a temporary sentinel `return` at the top of the
+  suspect function to surface its inputs. Revert the sentinel afterward — it is
+  throwaway scaffolding, and `dbg!`/`println!` remain forbidden.
+- **If `cargo nextest` hangs at 0% CPU on a lock** (disk pressure), run the
+  compiled test binary directly as above instead of through the runner.
+
 ## Notes
 
 - `eval`, `set`, and conditions take variable paths and simple comparisons, not

--- a/.claude/skills/rust-debugger/REFERENCE.md
+++ b/.claude/skills/rust-debugger/REFERENCE.md
@@ -119,6 +119,29 @@ rdbg def | hover | refs <file> <line> <col>
   `--test <name> … -- <test_name>` for `tests/<name>.rs`; break at the
   assertion or inside the code under test.
 
+## When breakpoints don't bind
+
+A `launch` that reports `no stop/exit event` and runs to completion without ever
+pausing — even on a function you know is on the path — is a **binding failure**,
+not a wrong line or symbol. `rdbg breaks` shows the breakpoint `NOT BOUND` (or
+bound with `0 hits`) and there was no `>>> STOP`. The `tsz-checker --lib`
+unit-test binary is the known offender (#15653): it carries hundreds of MB of
+debug info and rdbg/lldb can fail to attach to or resolve symbols on it
+(reported on macOS with rdbg 0.4.0). Route around it:
+
+- **Break in a small `--test <stem>` integration target, not `--lib`.** The
+  `SKILL.md` tsz recipe already uses `--test crates/tsz-checker/tests/<stem>.rs`
+  for this reason — the giant `--lib` binary is the one that fails to bind, and
+  most checker behavior reproduces from an integration test.
+- **Last-resort fallback when nothing binds.** Build once with `cargo test -p
+  tsz-checker --lib --no-run`, then run the compiled binary directly
+  (`.target/debug/deps/tsz_checker-<hash> <test_name> --nocapture
+  --test-threads=1`), adding a temporary sentinel `return` at the top of the
+  suspect function to surface its inputs. Revert the sentinel afterward — it is
+  throwaway scaffolding, and `dbg!`/`println!` remain forbidden.
+- **If `cargo nextest` hangs at 0% CPU on a lock** (disk pressure), run the
+  compiled test binary directly as above instead of through the runner.
+
 ## Notes
 
 - `eval`, `set`, and conditions take variable paths and simple comparisons, not


### PR DESCRIPTION
Closes #15653.

## Goal
Goal: hold

## What

`rdbg launch --cargo crates/tsz-checker --lib …` builds and runs the test binary
but never stops at any breakpoint (`no stop/exit event`), even for functions that
are unquestionably on the path — a **binding failure** on the hundreds-of-MB
`tsz-checker` unit-test binary (reported on macOS with rdbg 0.4.0), not a wrong
line or symbol. Per #15653 this "has now bitten two independent agents on the
same crate", costing launch budget each time. The issue's ask is explicitly *"fix
the binding **or** add a documented workaround to the skill."* Binding can't be
fixed from this Linux/no-rdbg environment, so this lands the documented
workaround.

Adds a **"When breakpoints don't bind"** section to the `rust-debugger` skill's
`REFERENCE.md` (both the `.agents/` and `.claude/` copies) covering:

- the failure signature (`no stop/exit event` + `NOT BOUND`/`0 hits` + no
  `>>> STOP` = binding failure, distinct from a wrong breakpoint);
- **prefer a small `--test <stem>` integration target over `--lib`** — the giant
  `--lib` binary is the one that fails to bind; the `SKILL.md` tsz recipe already
  uses `--test` for this reason, now explained;
- the sentinel-return + run-the-compiled-binary-directly fallback the issue
  reporter used to unblock (revert the sentinel after; `dbg!`/`println!` stay
  forbidden);
- the `cargo nextest` 0%-CPU lock workaround (run the compiled binary directly).

Placed in `REFERENCE.md` (the on-demand companion), not `SKILL.md`, to stay
within the skill's context budget.

## Verification

- Docs-only change; touches only the two `rust-debugger` `REFERENCE.md` copies
  (identical). No source/test/build files changed — `clippy` and `arch-size` are
  unaffected.
- `python3 scripts/agents/llm-context-audit.py`: the one remaining finding
  (`.claude/skills/rust-debugger/SKILL.md` 130 lines > 120 budget) is
  **pre-existing on `main`** — verified via `git show HEAD:.claude/skills/rust-debugger/SKILL.md | wc -l` → 130 — and is not touched by this change; the `REFERENCE.md` additions introduce **no** new findings.
- The two `REFERENCE.md` copies remain byte-identical after the edit.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high

Claude-Session: https://claude.ai/code/session_018WwM8BT6j6wbTjSgPWGkzQ

---
_Generated by [Claude Code](https://claude.ai/code/session_018WwM8BT6j6wbTjSgPWGkzQ)_