### PR TITLE
fix(checker): TS2383 export agreement includes the implementation; suppress spurious TS2652 on function overload runs

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -68,7 +68,7 @@ impl<'a> CheckerState<'a> {
     /// augmentation (`declare global { ... }`). Used to exempt overload-signature
     /// members of an ambient module/namespace body from the TS2383 export-
     /// consistency check, which tsc does not apply there.
-    fn is_within_ambient_module_container(&self, decl_idx: NodeIndex) -> bool {
+    pub(super) fn is_within_ambient_module_container(&self, decl_idx: NodeIndex) -> bool {
         let mut current = decl_idx;
         for _ in 0..100 {
             let Some(ext) = self.ctx.arena.get_extended(current) else {
@@ -316,56 +316,9 @@ impl<'a> CheckerState<'a> {
                 }
             }
 
-            // TS2383: all bodyless overload signatures must agree on export status.
-            // The rule applies when 2+ overload signatures exist; the implementation
-            // is not an overload signature and is not checked for export agreement.
-            //
-            // tsc does not apply this check to overloads declared directly inside an
-            // ambient module/namespace body (`declare namespace M { ... }` /
-            // `declare module "m" { ... }`, including namespaces nested inside one):
-            // `export` on a member of an ambient module body does not carry the same
-            // meaning as a module-level `export`, so mismatched `export` keywords
-            // there are not overload-consistency errors. `declare global { ... }` is
-            // a global augmentation, not an ambient module, and stays subject to the
-            // check, as does a bare top-level `declare function` with no enclosing
-            // namespace/module.
-            if func_decls_for_2384.len() >= 2
-                && !self.is_within_ambient_module_container(func_decls_for_2384[0])
-            {
-                // Restrict to bodyless overload signatures only by looking up export
-                // status for each entry in func_decls_for_2384. The implementation
-                // (absent from func_decls_for_2384) must not influence the check.
-                let func_export_info: Vec<(NodeIndex, bool)> = func_decls_for_2384
-                    .iter()
-                    .filter_map(|&decl_idx| {
-                        declarations
-                            .iter()
-                            .find(|&&(di, _, _, _, _)| di == decl_idx)
-                            .map(|&(di, _, _, is_exported, _)| (di, is_exported))
-                    })
-                    .collect();
-                let (has_exported, has_non_exported) = func_export_info
-                    .iter()
-                    .fold((false, false), |(exp, non_exp), &(_, e)| {
-                        (exp || e, non_exp || !e)
-                    });
-                // has_exported && has_non_exported already implies len >= 2
-                if has_exported && has_non_exported {
-                    // declarations is ordered, so [0] is always the first overload signature.
-                    let ref_exported = func_export_info[0].1;
-                    for &(decl_idx, is_exported) in &func_export_info {
-                        if is_exported != ref_exported {
-                            let error_node =
-                                self.get_declaration_name_node(decl_idx).unwrap_or(decl_idx);
-                            self.error_at_node(
-                                error_node,
-                                diagnostic_messages::OVERLOAD_SIGNATURES_MUST_ALL_BE_EXPORTED_OR_NON_EXPORTED,
-                                diagnostic_codes::OVERLOAD_SIGNATURES_MUST_ALL_BE_EXPORTED_OR_NON_EXPORTED,
-                            );
-                        }
-                    }
-                }
-            }
+            // TS2383: every declaration of a function overload run must agree on
+            // export status (see `check_overload_export_agreement`).
+            self.check_overload_export_agreement(&declarations);
 
             // TS2385: Overload signatures must all be public, private or protected
             // Applies to class method overloads with mixed access modifiers
@@ -634,7 +587,20 @@ impl<'a> CheckerState<'a> {
                         }
                     }
                     let non_default_spaces = exported_spaces | non_exported_spaces;
-                    let default_conflict_spaces = default_exported_spaces & non_default_spaces;
+                    // A same-named function overload run (all declarations are
+                    // functions) is one overload group, not a merged declaration.
+                    // tsc routes a default-export-vs-plain mismatch across such a run
+                    // through TS2383 (export agreement, above), never TS2652: a
+                    // signature/implementation pair like
+                    // `export default function f(sig); function f(impl) {}` is not a
+                    // "merged declaration that includes a default export". Only a
+                    // genuine merge (function+namespace, class+namespace, ...) yields
+                    // TS2652, and such a group is not all-functions.
+                    let default_conflict_spaces = if all_functions {
+                        0
+                    } else {
+                        default_exported_spaces & non_default_spaces
+                    };
                     let export_local_conflict_spaces =
                         if all_functions || suppress_ts2395_for_ambient {
                             0

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_helpers.rs
@@ -1017,6 +1017,95 @@ impl<'a> CheckerState<'a> {
             }
         }
     }
+
+    /// TS2383: every declaration of a function overload run must agree on export
+    /// status. tsc's `checkFlagAgreementBetweenOverloads` computes the export flag
+    /// over ALL of the symbol's function declarations — every bodyless overload
+    /// signature AND the implementation body — and reports at each declaration
+    /// whose export flag deviates from the canonical overload. The implementation
+    /// therefore participates: a lone exported signature over a non-exported
+    /// implementation (or the reverse) is a mismatch, and two exported signatures
+    /// over a non-exported implementation flag both signatures.
+    ///
+    /// The canonical overload (tsc's `getCanonicalOverload`) is the implementation
+    /// when present, otherwise the first overload in source order. Reading the
+    /// reference off the implementation is what anchors the diagnostic at the
+    /// deviating *signature* in `function f(sig); export function f(impl) {}`
+    /// rather than at the body. `export default function` carries the `export`
+    /// modifier, so it counts as exported here; a uniformly `export default` (or
+    /// mixed `export`/`export default`) run stays clean.
+    ///
+    /// The check runs only when at least one bodyless overload signature exists
+    /// (tsc's `hasOverloads`); a run of only implementations is a duplicate, not an
+    /// overload set. tsc does not apply it to overloads declared directly inside an
+    /// ambient module/namespace body (`declare namespace M { ... }` /
+    /// `declare module "m" { ... }`, including namespaces nested inside one):
+    /// `export` on a member of an ambient module body does not carry the same
+    /// meaning as a module-level `export`. `declare global { ... }` is a global
+    /// augmentation, not an ambient module, and stays subject to the check, as does
+    /// a bare top-level `declare function` with no enclosing namespace/module.
+    pub(super) fn check_overload_export_agreement(
+        &mut self,
+        declarations: &[(NodeIndex, u32, bool, bool, DuplicateDeclarationOrigin)],
+    ) {
+        use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+
+        // `symbol.declarations` (and hence `declarations`) is not guaranteed to be
+        // in source order — an exported declaration can be registered after a
+        // non-exported sibling. tsc's `getCanonicalOverload` reads `overloads[0]` in
+        // source order, and its `bodyDeclaration` is the first implementation in
+        // source order, so sort by declaration start position to recover it.
+        let mut all_func_decls: Vec<(NodeIndex, bool, bool)> = declarations
+            .iter()
+            .filter(|&&(_, flags, is_local, _, _)| {
+                is_local && (flags & (symbol_flags::FUNCTION | symbol_flags::METHOD)) != 0
+            })
+            .map(|&(decl_idx, _, _, is_exported, _)| {
+                (decl_idx, is_exported, self.function_has_body(decl_idx))
+            })
+            .collect();
+        all_func_decls.sort_by_key(|&(decl_idx, _, _)| {
+            self.ctx.arena.get(decl_idx).map(|n| n.pos).unwrap_or(0)
+        });
+
+        let has_overload_signature = all_func_decls.iter().any(|&(_, _, has_body)| !has_body);
+        if !(has_overload_signature
+            && all_func_decls.len() >= 2
+            && !self.is_within_ambient_module_container(all_func_decls[0].0))
+        {
+            return;
+        }
+
+        let first_exported = all_func_decls[0].1;
+        let mixed_export = all_func_decls.iter().any(|&(_, e, _)| e != first_exported);
+        if !mixed_export {
+            return;
+        }
+
+        // getCanonicalOverload: the reference flags come from the implementation
+        // when it shares a container with the first overload, otherwise from the
+        // first declaration. tsc's container guard exists to avoid taking the
+        // canonical flags from an implementation in a *different* file (a lib.d.ts
+        // overload paired with a local body). `all_func_decls` is already restricted
+        // to local declarations of this one symbol, which share their container, so
+        // the first local implementation is the canonical overload; with no
+        // implementation the first overload is canonical.
+        let canonical_exported = all_func_decls
+            .iter()
+            .find(|&&(_, _, has_body)| has_body)
+            .map(|&(_, e, _)| e)
+            .unwrap_or(first_exported);
+        for &(decl_idx, is_exported, _) in &all_func_decls {
+            if is_exported != canonical_exported {
+                let error_node = self.get_declaration_name_node(decl_idx).unwrap_or(decl_idx);
+                self.error_at_node(
+                    error_node,
+                    diagnostic_messages::OVERLOAD_SIGNATURES_MUST_ALL_BE_EXPORTED_OR_NON_EXPORTED,
+                    diagnostic_codes::OVERLOAD_SIGNATURES_MUST_ALL_BE_EXPORTED_OR_NON_EXPORTED,
+                );
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/tsz-checker/tests/default_export_merge_diagnostics_tests.rs
+++ b/crates/tsz-checker/tests/default_export_merge_diagnostics_tests.rs
@@ -171,15 +171,36 @@ function overload(value: string | number): void {}
 }
 
 #[test]
-fn all_function_group_still_reports_default_non_default_overlap() {
-    // The all-function exception suppresses ordinary TS2395 overload noise,
-    // not the default/non-default declaration-space invariant.
+fn all_function_group_default_non_default_is_ts2383_not_ts2652() {
+    // A same-name function overload run — even one mixing `export default` with a
+    // plain signature — is one overload group, not a merged declaration. tsc
+    // reports the export-agreement error (TS2383) and, here, a missing-impl error
+    // (TS2391); it never reports the merged-default TS2652. Pinned against
+    // tsc@7.0.2: `(2,10) TS2383` + `(2,10) TS2391`, no TS2652.
     let source = r#"
 export default function Execute(): void;
 function Execute(): void;
 "#;
 
-    assert_merge_diagnostics(source, "Execute", &[(TS2652, 0), (TS2652, 1)]);
+    // No merged-declaration conflicts survive for an all-function overload run.
+    assert_merge_diagnostics(source, "Execute", &[]);
+
+    let diagnostics = check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            module: ModuleKind::CommonJS,
+            ..CheckerOptions::default()
+        },
+    );
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2383),
+        "the export-status mismatch must surface as TS2383"
+    );
+    assert!(
+        !diagnostics.iter().any(|d| d.code == TS2652),
+        "an all-function overload run is not a merged default-export declaration"
+    );
 }
 
 #[test]

--- a/crates/tsz-checker/tests/overload_modifier_tests.rs
+++ b/crates/tsz-checker/tests/overload_modifier_tests.rs
@@ -186,30 +186,51 @@ class C {
     assert!(has_error(source, 2386));
 }
 
-// TS2383: only 2+ bodyless overload signatures must agree on export status.
-// The implementation is not an overload signature; tsc does not check it.
-// Single-overload + implementation export mismatches are silently accepted.
+// TS2383: every declaration of a function overload run — every bodyless
+// signature AND the implementation body — must agree on export status. This
+// mirrors tsc's `checkFlagAgreementBetweenOverloads`, which computes the export
+// flag over all of the symbol's function declarations and reports at each one
+// whose flag deviates from the canonical overload (the implementation when
+// present, else the first overload in source order). The rows below are pinned
+// against `tsc@7.0.2`. `export default function` carries the `export` modifier,
+// so it counts as exported.
 
-#[test]
-fn ts2383_single_overload_exported_implementation_not_exported_no_error() {
-    let source = r#"
-export function compute(x: number): number;
-function compute(x: any): number { return x; }
-"#;
-    assert!(!has_error(source, 2383));
+/// The 2383 error(s) must anchor at the deviating signature, never at the
+/// implementation body. `impl_body_marker` is a substring unique to the
+/// implementation line; every 2383 must start before it.
+fn assert_2383_before(source: &str, impl_body_marker: &str) {
+    let diags = check_source_diagnostics(source);
+    let errors: Vec<_> = diags.iter().filter(|d| d.code == 2383).collect();
+    assert!(!errors.is_empty(), "expected TS2383 for:\n{source}");
+    let impl_at = source
+        .find(impl_body_marker)
+        .expect("impl marker present in source");
+    for e in &errors {
+        assert!(
+            (e.start as usize) < impl_at,
+            "TS2383 at start={} should anchor at a signature (before byte {impl_at}), not the implementation:\n{source}",
+            e.start
+        );
+    }
 }
 
 #[test]
-fn ts2383_single_overload_not_exported_implementation_exported_no_error() {
-    let source = r#"
-function transform(x: number): number;
-export function transform(x: any): number { return x; }
-"#;
-    assert!(!has_error(source, 2383));
+fn ts2383_exported_signature_non_exported_impl_error() {
+    // tsc: (1,17) TS2383 — the exported signature deviates from the impl.
+    let source = "export function compute(x: number): number;\nfunction compute(x: any): number { return x; }\n";
+    assert_2383_before(source, "{ return x; }");
 }
 
 #[test]
-fn ts2383_single_overload_both_exported_no_error() {
+fn ts2383_non_exported_signature_exported_impl_error() {
+    // tsc: (1,10) TS2383 — anchored at the signature even though the impl is the
+    // one carrying `export`, because the impl is the canonical overload.
+    let source = "function transform(x: number): number;\nexport function transform(x: any): number { return x; }\n";
+    assert_2383_before(source, "{ return x; }");
+}
+
+#[test]
+fn ts2383_signature_impl_both_exported_no_error() {
     let source = r#"
 export function process(x: number): number;
 export function process(x: any): number { return x; }
@@ -218,7 +239,7 @@ export function process(x: any): number { return x; }
 }
 
 #[test]
-fn ts2383_single_overload_both_non_exported_no_error() {
+fn ts2383_signature_impl_both_non_exported_no_error() {
     let source = r#"
 function process(x: number): number;
 function process(x: any): number { return x; }
@@ -227,21 +248,16 @@ function process(x: any): number { return x; }
 }
 
 #[test]
-fn ts2383_single_overload_impl_export_mismatch_different_name_no_error() {
-    let source = r#"
-export function handle(x: string): string;
-function handle(x: any): string { return x; }
-"#;
-    assert!(!has_error(source, 2383));
+fn ts2383_exported_signature_non_exported_impl_same_name_error() {
+    // Same binder name on both declarations — still an overload run, still TS2383.
+    let source = "export function handle(x: string): string;\nfunction handle(x: any): string { return x; }\n";
+    assert_2383_before(source, "{ return x; }");
 }
 
 #[test]
-fn ts2383_single_overload_reversed_impl_export_mismatch_no_error() {
-    let source = r#"
-function serialize(x: number): string;
-export function serialize(x: any): string { return String(x); }
-"#;
-    assert!(!has_error(source, 2383));
+fn ts2383_reversed_non_exported_signature_exported_impl_error() {
+    let source = "function serialize(x: number): string;\nexport function serialize(x: any): string { return String(x); }\n";
+    assert_2383_before(source, "{ return String(x); }");
 }
 
 #[test]
@@ -265,24 +281,75 @@ export function route(x: any): void {}
 }
 
 #[test]
-fn ts2383_two_exported_overloads_non_exported_impl_no_error() {
-    // Implementation export status is not checked — only bodyless signatures matter.
-    let source = r#"
-export function compute(x: number): number;
-export function compute(x: string): number;
-function compute(x: any): number { return 0; }
-"#;
-    assert!(!has_error(source, 2383));
+fn ts2383_two_exported_signatures_non_exported_impl_error() {
+    // tsc: (1,17) AND (2,17) — both exported signatures deviate from the
+    // non-exported implementation (the canonical overload). Two TS2383 errors.
+    let source = "export function compute(x: number): number;\nexport function compute(x: string): number;\nfunction compute(x: any): number { return 0; }\n";
+    let count = get_diagnostics(source)
+        .iter()
+        .filter(|d| d.0 == 2383)
+        .count();
+    assert_eq!(count, 2, "expected TS2383 on both exported signatures");
+    assert_2383_before(source, "{ return 0; }");
 }
 
 #[test]
-fn ts2383_two_non_exported_overloads_exported_impl_no_error() {
-    let source = r#"
-function transform(x: number): string;
-function transform(x: string): string;
-export function transform(x: any): string { return ""; }
-"#;
+fn ts2383_two_non_exported_signatures_exported_impl_error() {
+    // tsc: (1,10) AND (2,10) — both non-exported signatures deviate from the
+    // exported implementation.
+    let source = "function transform(x: number): string;\nfunction transform(x: string): string;\nexport function transform(x: any): string { return \"\"; }\n";
+    let count = get_diagnostics(source)
+        .iter()
+        .filter(|d| d.0 == 2383)
+        .count();
+    assert_eq!(count, 2, "expected TS2383 on both non-exported signatures");
+    assert_2383_before(source, "{ return \"\"; }");
+}
+
+// TS2383 / TS2652: `export default` on a function overload run. tsc reports the
+// export-agreement error (TS2383) and NOT a merged-default conflict (TS2652):
+// a signature/implementation pair is one overload group, not a merge. This is
+// the regression from issue #16742.
+
+#[test]
+fn ts2383_default_export_signature_non_exported_impl_error_no_2652() {
+    // tsc: (1,25) TS2383 only. tsz previously emitted TS2652 x2 and no TS2383.
+    let source = "export default function fn(a: string): string;\nfunction fn(a: string): string { return a; }\nexport {};\n";
+    assert_2383_before(source, "{ return a; }");
+    assert!(
+        !has_error(source, 2652),
+        "a same-name signature/impl overload pair is not a merged default-export declaration"
+    );
+}
+
+#[test]
+fn ts2383_reversed_default_export_impl_error_no_2652() {
+    // tsc: (1,10) TS2383 only — the non-exported signature deviates from the
+    // `export default` implementation.
+    let source = "function fn(a: string): string;\nexport default function fn(a: string): string { return a; }\nexport {};\n";
+    assert_2383_before(source, "{ return a; }");
+    assert!(!has_error(source, 2652));
+}
+
+#[test]
+fn ts2383_default_export_signature_plain_exported_impl_no_error() {
+    // Both carry `export` (one via `export default`, one via `export`), so the
+    // run is uniformly exported: tsc reports nothing.
+    let source = "export default function fn(a: string): string;\nexport function fn(a: string): string { return a; }\nexport {};\n";
     assert!(!has_error(source, 2383));
+    assert!(!has_error(source, 2652));
+}
+
+#[test]
+fn ts2652_still_fires_for_function_namespace_default_merge() {
+    // A genuine merge (function + namespace) with a default export is not an
+    // all-function overload run, so the TS2652 suppression must not reach it.
+    let source =
+        "export default function fn(): void {}\nnamespace fn { export const x = 1; }\nexport {};\n";
+    assert!(
+        has_error(source, 2652),
+        "function+namespace default-export merge must still report TS2652"
+    );
 }
 
 // TS2394: overload signature must be compatible with implementation signature


### PR DESCRIPTION
Fixes #16742.

When a same-named function overload run mixes exported and non-exported declarations, tsc's `checkFlagAgreementBetweenOverloads` computes the export flag over **all** of the symbol's function declarations — every bodyless overload signature **and** the implementation body — and reports TS2383 at each declaration whose export flag deviates from the canonical overload (the implementation when present, else the first overload in source order).

tsz previously checked only bodyless signatures and required 2+ of them, so it missed cases the oracle (`tsc@7.0.2`) reports, and it mismodeled the default-export case as a merged declaration (TS2652).

## Structural rule
When a function overload run — every declaration is a function — mixes export status, tsc reports **TS2383** at each deviating declaration and never treats the run as a merged declaration, so it never reports **TS2652** there. A genuine merge (function+namespace, class+namespace) is not all-functions and still reports TS2652. Owner layer: checker `check_duplicate_identifiers` walk (`crates/tsz-checker/src/types/type_checking/duplicate_identifiers*.rs`).

### Before → after (pinned against `tsc@7.0.2`, `--noEmit --strict false --module commonjs --target es2015`)
| source | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `export function f(sig); function f(impl){}` | `(1,17) TS2383` | (nothing) | `(1,17) TS2383` |
| `function f(sig); export function f(impl){}` | `(1,10) TS2383` | (nothing) | `(1,10) TS2383` |
| `export default function f(sig); function f(impl){}` | `(1,25) TS2383` | `TS2652 ×2` | `(1,25) TS2383` |
| `export fn sig; export fn sig; non-exp impl{}` | `(1,17)+(2,17) TS2383` | (nothing) | `(1,17)+(2,17) TS2383` |
| `export default fn(){}` + `namespace fn{…}` (real merge) | `TS2652 ×2` | `TS2652 ×2` | `TS2652 ×2` (unchanged) |

## Changes
- New `check_overload_export_agreement` helper (in `duplicate_identifiers_helpers.rs`, keeping the main module under the 2000-LOC cap) computes export agreement over all local function declarations of the symbol, sorted into source order (the binder does not guarantee source order), using the implementation as the canonical overload so the diagnostic anchors at the deviating *signature*. `export default` counts as exported (it carries the `export` modifier). The ambient-module-body exemption is preserved.
- TS2652's default/non-default declaration-space conflict is suppressed for all-function groups, mirroring the existing TS2395 suppression.
- Existing tests that encoded the old "implementation is not checked" model are corrected to the oracle behavior; added the default-export repro and a guard that genuine function+namespace merges still report TS2652.

## Goal
Goal: hold

## Verification
- 25 structural rows verified byte-for-byte against `tsc@7.0.2` (every exported/non-exported/`export default` signature+impl combination, no-impl, namespaces, ambient modules, and genuine merges).
- `cargo test --release -p tsz-checker --test overload_modifier_tests` — 59 passed.
- `cargo test --release -p tsz-checker --test default_export_merge_diagnostics_tests` — 10 passed.
- `cargo test -p tsz-checker --lib ts2391_default_export_overload_group` — 24 passed (the #16741 guard suite stays green).
- Full `cargo test -p tsz-checker --lib` — 10479 passed, 0 failed (only pre-existing unrelated hangs from #15338 excluded: `ts2589`, class-static-init, contextual-return).
- Clippy + architecture guard (2000-LOC cap) pass via the pre-commit hook.
- Conformance snapshot (`conformance.sh snapshot --workers 12 --force`, `tsc@7.0.2` corpus): **544 → 520 failures (net −24)**, 25 improvements (incl. `mixedExports`, `functionOverloadErrors`, `defaultExportWithOverloads01`, `multipleDefaultExports02/04`, `functionLiteralForOverloads`), 0 diagnostic-code regressions. The one flipped row (`arbitraryModuleNamespaceIdentifiers_syntax.ts`) has `expected:[TS1003] actual:[TS1003]` — identical codes, a non-deterministic render-order fingerprint on a parser test unrelated to this checker change.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_014WeCDtviJ7rbcijtmWt3w2)_