### PR TITLE
revert: keyof well-known-symbol reduction (#16628) — costs 3 conformance rows and the SymbolConstructor name

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -25,73 +25,6 @@ impl CheckerState<'_> {
         true
     }
 
-    /// Eagerly seed the well-known-symbol name registry from the global
-    /// `Symbol` (`SymbolConstructor`) declaration.
-    ///
-    /// The canonical `[Symbol.xxx]` object-shape key and the `UniqueSymbol(ref)`
-    /// that `typeof Symbol.xxx`/`keyof`/indexed-access produce round-trip through
-    /// this registry on the solver's `TypeResolver`. The per-member
-    /// computed-name resolution path also populates it, but lazily — as each
-    /// `[Symbol.xxx]`-keyed member is resolved. A `keyof`/indexed-access
-    /// evaluated *before* that member pass (e.g. a `type K = keyof I` alias
-    /// resolved while building the type environment, ahead of `I`'s member pass)
-    /// reads an empty registry, caches the wrong (string-literal) key, and never
-    /// reduces to the well-known symbol. Seeding the canonical lib-declared
-    /// members up front removes that ordering dependence.
-    ///
-    /// The registered `SymbolRef` is read from each member's own type
-    /// (`readonly iterator: unique symbol` is `typeof Symbol.iterator`), so it is
-    /// exactly the ref a use-site `typeof Symbol.iterator` resolves to — the two
-    /// `UniqueSymbol` type ids are then identical. The registry is a field of the
-    /// per-file `type_env`, so the seed runs per file.
-    fn seed_well_known_symbol_names(&mut self) {
-        let Some(symbol_ctor_sym) =
-            crate::types_domain::queries::lib_resolution::resolve_name_to_lib_symbol(
-                "SymbolConstructor",
-                self.ctx.binder,
-                self.ctx.global_file_locals_index.as_deref(),
-                self.ctx
-                    .all_binders
-                    .as_ref()
-                    .map(|binders| binders.as_ref().as_slice()),
-                &self.ctx.lib_contexts,
-            )
-        else {
-            return;
-        };
-        let symbol_ctor_type = self.type_reference_symbol_type(symbol_ctor_sym);
-        let symbol_ctor_type = self.resolve_lazy_type(symbol_ctor_type);
-        let tsz_solver::objects::PropertyCollectionResult::Properties { properties, .. } =
-            tsz_solver::objects::collect_properties(symbol_ctor_type, self.ctx.types, &self.ctx)
-        else {
-            return;
-        };
-        // A well-known member is typed `unique symbol`; its property type carries
-        // the same `UniqueSymbol(ref)` a use-site `typeof Symbol.<name>` resolves
-        // to. Its bare member name (`iterator`) is the `[Symbol.iterator]`
-        // object-shape key. Ordinary members and augmented plain-`symbol` members
-        // carry no unique-symbol ref and are skipped, matching tsc treating them
-        // as ordinary named members rather than well-known symbols.
-        let registrations: Vec<(String, tsz_solver::SymbolRef)> = properties
-            .iter()
-            .filter_map(|prop| {
-                let name = self.ctx.types.resolve_atom_ref(prop.name);
-                if name.starts_with("[Symbol.") || name.starts_with("__") {
-                    return None;
-                }
-                let sym_ref = crate::query_boundaries::common::unique_symbol_ref(
-                    self.ctx.types,
-                    prop.type_id,
-                )?;
-                Some((format!("[Symbol.{name}]"), sym_ref))
-            })
-            .collect();
-        for (name, sym_ref) in registrations {
-            self.ctx
-                .register_well_known_symbol_name_in_envs(name, sym_ref);
-        }
-    }
-
     fn prepare_source_file_for_checking(&mut self, root_idx: NodeIndex) -> Option<NodeIndex> {
         // Reset per-file flags
         self.ctx.is_in_ambient_declaration_file = false;
@@ -144,11 +77,6 @@ impl CheckerState<'_> {
         if !self.ctx.definition_store.is_fully_populated() {
             self.ctx.resolve_cross_batch_heritage();
         }
-
-        // Seed the well-known-symbol name registry from the lib `Symbol`
-        // members before the environment build eagerly evaluates (and caches)
-        // `keyof`/indexed-access type aliases over well-known-symbol keys.
-        self.seed_well_known_symbol_names();
 
         // Build TypeEnvironment with all type-defining symbols.
         // This populates both ctx.type_env and ctx.type_environment in-place

--- a/crates/tsz-checker/tests/well_known_symbol_syntactic_key_parity_tests.rs
+++ b/crates/tsz-checker/tests/well_known_symbol_syntactic_key_parity_tests.rs
@@ -181,19 +181,14 @@ export const t: { [k: symbol]: number } = i;
 // ---------------------------------------------------------------------------
 
 #[test]
+#[ignore = "known failure: keyof over a well-known-symbol-keyed interface does not reduce to the well-known symbol (false TS2322)"]
 fn keyof_a_well_known_symbol_keyed_interface_reduces_to_the_well_known_symbol() {
     // tsc 7.0.2: exit 0 — `keyof I` IS `typeof Symbol.iterator`.
+    // tsz today: TS2322 "Type 'keyof I' is not assignable to type 'unique symbol'."
     //
-    // A well-known-symbol-keyed member is a *named* member (`is_symbol_named`
-    // is false) stored under its canonical `[Symbol.iterator]` atom, so `keyof`
-    // took the literal-key branch and produced the string literal
-    // `"[Symbol.iterator]"` instead of `typeof Symbol.iterator`. `keyof` now
-    // recovers the unique-symbol key for such a named key through the
-    // well-known-symbol registry, which is seeded from the lib `SymbolConstructor`
-    // members up front so the registry is populated before the alias is
-    // evaluated. The equivalent shape keyed by a user-authored `unique symbol`
-    // binding (`declare const u: unique symbol; interface I { [u]: number }`)
-    // was already clean; this closes the well-known leg.
+    // The equivalent shape keyed by a user-authored `unique symbol` binding
+    // (`declare const u: unique symbol; interface I { [u]: number }`) is
+    // already clean, so the gap is specific to the well-known leg.
     let codes = diagnostic_codes(
         r#"
 interface I { [Symbol.iterator]: number }
@@ -210,7 +205,7 @@ export const a: typeof Symbol.iterator = k;
 }
 
 #[test]
-#[ignore = "known failure: blocked by a lib cross-file SymbolId collision — the well-known-symbol reverse lookup (UniqueSymbol(ref) -> [Symbol.xxx] atom) cannot be seeded eagerly because iterator/asyncIterator/hasInstance all resolve to the same SymbolRef across lib files; needs globally-unique lib SymbolIds"]
+#[ignore = "known failure: indexed access by a well-known symbol type leaks the __unique_N placeholder (TS2339/TS2538)"]
 fn indexed_access_by_a_well_known_symbol_type_resolves_the_member() {
     // tsc 7.0.2: exit 0 — `I[typeof Symbol.iterator]` is `number`.
     // tsz today, three diagnostics, the first of which leaks an internal key
@@ -218,15 +213,6 @@ fn indexed_access_by_a_well_known_symbol_type_resolves_the_member() {
     //   TS2339 "Property '__unique_5' does not exist on type 'I'."
     //   TS2538 "Type 'unique symbol' cannot be used as an index type."
     //   TS2322 "Type 'undefined' is not assignable to type 'number'."
-    //
-    // The forward direction (this member's `keyof` key) is fixed; the reverse
-    // direction here (`typeof Symbol.iterator` = `UniqueSymbol(ref)` back to the
-    // `[Symbol.iterator]` atom to find the member) reads the lazily-populated
-    // reverse index, which is still empty when this type alias is evaluated.
-    // It cannot be seeded eagerly like the forward index without regressing the
-    // reverse lookup, because several well-known members share one `SymbolRef`
-    // (lib cross-file `SymbolId` collision), so the reverse map would become
-    // ambiguous. Closing this needs globally-unique lib `SymbolId`s.
     let codes = diagnostic_codes(
         r#"
 interface I { [Symbol.iterator]: number }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs
@@ -257,36 +257,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         }
     }
 
-    /// The unique-symbol key type for a member stored under a well-known
-    /// `[Symbol.xxx]` text key (`Symbol.iterator`, `Symbol.asyncIterator`, …).
-    ///
-    /// A well-known-symbol-keyed member is a *named* member, not a symbol index
-    /// signature, so it carries `is_symbol_named = false` and is stored under its
-    /// canonical `[Symbol.xxx]` atom rather than a synthetic `__unique_N`
-    /// placeholder. `keyof` must nonetheless contribute the unique-symbol key
-    /// `typeof Symbol.xxx` for it — `keyof { [Symbol.iterator]: T }` is
-    /// `typeof Symbol.iterator` in `tsc`, not the string literal
-    /// `"[Symbol.iterator]"`. The registered `SymbolRef` is the same canonical
-    /// `SymbolConstructor` member ref that `typeof Symbol.xxx` resolves to, so
-    /// the two `UniqueSymbol` type ids are identical.
-    fn well_known_named_key_unique_symbol(&self, name: Atom) -> Option<TypeId> {
-        let name_text = self.interner().resolve_atom_ref(name);
-        if !name_text.starts_with("[Symbol.") {
-            return None;
-        }
-        let symbol_ref = self.resolver().resolve_well_known_symbol_name(&name_text)?;
-        Some(self.interner().unique_symbol(symbol_ref))
-    }
-
     fn property_name_to_key_type(&self, prop: &PropertyInfo) -> TypeId {
         if prop.is_symbol_named {
             if let Some(symbol_ref) = self.unique_symbol_ref_from_symbol_named_atom(prop.name) {
                 return self.interner().unique_symbol(symbol_ref);
             }
             return TypeId::SYMBOL;
-        }
-        if let Some(unique) = self.well_known_named_key_unique_symbol(prop.name) {
-            return unique;
         }
         // `keyof { 1: ... }` yields the *numeric* literal `1`, not `"1"`.
         // The bare-numeric-name vs string-quoted distinction is the same
@@ -307,9 +283,6 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 return self.interner().unique_symbol(symbol_ref);
             }
             return TypeId::SYMBOL;
-        }
-        if let Some(unique) = self.well_known_named_key_unique_symbol(key.name) {
-            return unique;
         }
         crate::utils::literal_key_for_property_name(self.interner(), key.name, key.is_string_named)
     }


### PR DESCRIPTION
Goal: hold

Reverts #16628 (`5a5c610baf`). It costs **3 conformance rows** and badly degrades `TS2339` message quality by losing the `SymbolConstructor` name. The underlying fix is real and worth relanding — details and acceptance criteria in the issue linked below.

## The regression

Conformance set-difference against `590e5d3ba0` (the commit immediately before it):

```
FIXED (0)
BROKEN (3):
  conformance/es6/Symbols/symbolProperty52.ts
  conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty4.ts
  conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty5.ts
```

All three have **identical code sets** (`{"e":["TS2339"],"a":["TS2339"]}`) — the divergence is the rendered type name:

```
tsc               Property 'nonsense' does not exist on type 'SymbolConstructor'.
590e5d3ba0 (pre)  Property 'nonsense' does not exist on type 'SymbolConstructor'.
5a5c610baf (post) Property 'nonsense' does not exist on type '{ readonly iterator: unique
                  symbol; } & { readonly hasInstance: unique symbol; readonly
                  isConcatSpreadable: unique symbol; readonly match: unique symbol; ... }
                  & { (description?: string | number | undefined): symbol; readonly
                  prototype: Symbol; for(key: string): symbol; ... }'.
```

A one-word type name became a 400-character structural expansion. Attributed by building `5a5c610baf^` in isolation.

## What the PR did fix

Genuinely one false negative — worth keeping when it relands:

```ts
interface I { [Symbol.iterator]: number; }
type K = keyof I;
const k: string = null as any as K;
// tsc: TS2322   pre-#16628: (silent)   #16628: TS2322
```

`Symbol.asyncIterator` already worked, so the defect was specific to `Symbol.iterator` — consistent with #16626's pin that the well-known symbols were collapsing onto one ref.

## After this revert

```
symbolProperty52.ts   type 'SymbolConstructor'   (matches tsc)
cargo nextest run -p tsz-checker --lib   10589 passed, 7 skipped
cargo nextest run -p tsz-solver  --lib    7654 passed
```

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high
