### PR TITLE
fix(solver): a mixed object/non-object intersection names members in written order (#16753)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -1489,20 +1489,39 @@ impl<'a> CheckerState<'a> {
         reason
     }
 
-    /// The written constituents of an intersection `target`, or `None` if it is
-    /// not an intersection.
+    /// The written constituents of an intersection `target` in source order, or
+    /// `None` if it is not an intersection.
     ///
-    /// Resolves lazy aliases (`type T = A & B`) without evaluating/merging so the
-    /// constituents survive. Anonymous object intersections (`{ x } & { y }`) are
-    /// eagerly merged into a single object at construction but retain the written
-    /// intersection as a display alias — a structural `TypeId` back-reference, not
-    /// rendered text — so fall back to that to recover the constituents.
+    /// Order is load-bearing: `tsc` (`typeRelatedToEachType`) elaborates the
+    /// first constituent the source fails in *written* order. `normalize_
+    /// intersection` moves the object member of a mixed object / non-object
+    /// intersection last for a stable identity (`{ z: 1 } & [T]` interns as
+    /// `[T] & { z: 1 }`) but records the written order as a display alias, so
+    /// prefer that alias (also the anonymous-object-intersection recovery path)
+    /// over the reordered interned members.
+    ///
+    /// Adjacent object members are likewise merged into one object at
+    /// construction (`{ a } & { b }` interns as one object, aliased back to its
+    /// written form), so expand each merged-object member through its own alias:
+    /// `tsc` never merges, so `{ a } & { b } & [T]` elaborates the first written
+    /// object `{ a }`, not the merged `{ a; b }`.
     fn target_intersection_constituents(&mut self, target: TypeId) -> Option<Vec<TypeId>> {
         let resolved = self.resolve_lazy_type(target);
-        crate::query_boundaries::common::intersection_members(self.ctx.types, resolved)
-            .map(|list| list.iter().copied().collect())
-            .or_else(|| self.display_alias_intersection_constituents(resolved))
+        let members: Vec<TypeId> = self
+            .display_alias_intersection_constituents(resolved)
             .or_else(|| self.display_alias_intersection_constituents(target))
+            .or_else(|| {
+                crate::query_boundaries::common::intersection_members(self.ctx.types, resolved)
+                    .map(|list| list.iter().copied().collect())
+            })?;
+        let mut expanded = Vec::with_capacity(members.len());
+        for member in members {
+            match self.display_alias_intersection_constituents(member) {
+                Some(inner) => expanded.extend(inner),
+                None => expanded.push(member),
+            }
+        }
+        Some(expanded)
     }
 
     /// The intersection constituents of `ty`'s display alias, if it has one whose

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -489,6 +489,8 @@ mod intersection_callable_constraint_ts2344_tests;
 mod intersection_source_literal_member_display_tests;
 #[path = "tests/intersection_target_elaboration_tests.rs"]
 mod intersection_target_elaboration_tests;
+#[path = "tests/intersection_target_member_order_tests.rs"]
+mod intersection_target_member_order_tests;
 #[path = "tests/invalid_thenable_no_fulfillment_payload_tests.rs"]
 mod invalid_thenable_no_fulfillment_payload_tests;
 #[path = "tests/invocation_signature_detail_tests.rs"]

--- a/crates/tsz-checker/src/tests/intersection_target_member_order_tests.rs
+++ b/crates/tsz-checker/src/tests/intersection_target_member_order_tests.rs
@@ -1,0 +1,107 @@
+//! Regression tests for target-intersection elaboration member **order**
+//! (#16753).
+//!
+//! Structural rule (`tsc`'s `typeRelatedToEachType`, quoted in the issue): a
+//! source related to a target intersection `C1 & C2 & …` is related to each
+//! constituent in **written** order, and the **first** failing constituent is
+//! elaborated one level deeper — the same order the top-level headline prints.
+//!
+//! `normalize_intersection` rebuilds a mixed object / non-object intersection
+//! with the object member moved to the end (`{ z: 1 } & [string, number]`
+//! interns as `[string, number] & { z: 1 }`), so the interned member list no
+//! longer matches the written order. The elaboration must recover the written
+//! order (from the display alias) rather than iterate the reordered members,
+//! otherwise it names the non-object member even when the object comes first.
+//!
+//! Binder-independent: the rule is structural, so the property/element spellings
+//! vary across rows and none drives the decision.
+
+use crate::test_utils::check_source_diagnostics;
+
+/// The nested elaboration line (the second-level `Type '…' is not assignable to
+/// type '…'.`) of the single `TS2322` produced by `source`.
+fn nested_line(source: &str) -> String {
+    let diags = check_source_diagnostics(source);
+    let matching: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "Expected exactly one TS2322. Got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+    matching[0]
+        .related_information
+        .first()
+        .map(|info| info.message_text.clone())
+        .unwrap_or_default()
+}
+
+/// Issue witness: an object-first intersection with a tuple names the **object**
+/// member, matching tsc (`... to type '{ z: 1; }'.`), not the tuple.
+#[test]
+fn object_first_then_tuple_names_the_object() {
+    assert_eq!(
+        nested_line("const b: { z: 1 } & [string, ...[number, boolean]] = 1;\n"),
+        "Type 'number' is not assignable to type '{ z: 1; }'.",
+    );
+}
+
+/// A plain (non-spread) tuple behaves the same — the divergence was never
+/// spread-specific.
+#[test]
+fn object_first_then_plain_tuple_names_the_object() {
+    assert_eq!(
+        nested_line("const c: { z: 1 } & [string, number] = 1;\n"),
+        "Type 'number' is not assignable to type '{ z: 1; }'.",
+    );
+}
+
+/// An object-first intersection with a primitive names the object.
+#[test]
+fn object_first_then_primitive_names_the_object() {
+    assert_eq!(
+        nested_line("const d: { a: 0 } & string = 1;\n"),
+        "Type 'number' is not assignable to type '{ a: 0; }'.",
+    );
+}
+
+/// An object-first intersection with an array names the object.
+#[test]
+fn object_first_then_array_names_the_object() {
+    assert_eq!(
+        nested_line("const e: { k: 2 } & string[] = 1;\n"),
+        "Type 'number' is not assignable to type '{ k: 2; }'.",
+    );
+}
+
+/// Control — a tuple-first intersection still names the tuple (both compilers
+/// already agreed here). The fix must not flip this row.
+#[test]
+fn tuple_first_then_object_still_names_the_tuple() {
+    assert_eq!(
+        nested_line("const f: [string, number] & { z: 1 } = 1;\n"),
+        "Type 'number' is not assignable to type '[string, number]'.",
+    );
+}
+
+/// A three-way intersection names the first written constituent the source
+/// fails — the leading object.
+#[test]
+fn three_way_object_first_names_the_first_object() {
+    assert_eq!(
+        nested_line("const g: { z: 1 } & { w: 2 } & [string, number] = 1;\n"),
+        "Type 'number' is not assignable to type '{ z: 1; }'.",
+    );
+}
+
+/// Control — a two-object intersection is unaffected: still the first object.
+#[test]
+fn two_object_intersection_names_the_first_object() {
+    assert_eq!(
+        nested_line("const h: { z: 1 } & { w: 2 } = 1;\n"),
+        "Type 'number' is not assignable to type '{ z: 1; }'.",
+    );
+}

--- a/crates/tsz-solver/src/intern/intersection.rs
+++ b/crates/tsz-solver/src/intern/intersection.rs
@@ -614,6 +614,14 @@ impl TypeInterner {
         // representative; this keeps tsc's source-order display for mixed
         // intersections such as `(() => void) & { prop: any }`.
         let mut final_flat: TypeListBuffer = SmallVec::new();
+        // The written source order, with the merged object substituted in place
+        // of its first constituent. The canonical rebuild below moves the object
+        // member to the end for a stable identity (`A & {}` and `{} & A` intern
+        // to one type), but `tsc` preserves written order in both display and the
+        // target-intersection diagnostic elaboration. Recorded as a display alias
+        // after interning so those consumers can recover it without disturbing
+        // canonical identity. Empty when the rebuild already matches source order.
+        let mut source_ordered: TypeListBuffer = SmallVec::new();
         if merged_callable.is_some() {
             let mut emitted_object = false;
             let mut emitted_callable = false;
@@ -647,6 +655,25 @@ impl TypeInterner {
             final_flat.extend(remaining_after_callables.iter().copied());
             if let Some(obj_id) = merged_object {
                 final_flat.push(obj_id);
+                // Written order: place the merged object where its first
+                // constituent was written, keeping every other member in place.
+                let mut emitted_object = false;
+                for &member in &flat {
+                    if matches!(
+                        self.lookup(member),
+                        Some(TypeData::Object(_) | TypeData::ObjectWithIndex(_))
+                    ) {
+                        if !emitted_object {
+                            source_ordered.push(obj_id);
+                            emitted_object = true;
+                        }
+                        continue;
+                    }
+                    source_ordered.push(member);
+                }
+                if source_ordered[..] == final_flat[..] {
+                    source_ordered.clear();
+                }
             }
         }
 
@@ -678,7 +705,25 @@ impl TypeInterner {
         }
 
         let list_id = self.intern_type_list_from_slice(&flat);
-        self.intern(TypeData::Intersection(list_id))
+        let canonical = self.intern(TypeData::Intersection(list_id));
+
+        // Record the written source order (captured before the objects-last
+        // rebuild) as a display alias, so the formatter and the target-
+        // intersection diagnostic elaboration name members in written order. Only
+        // when subtype reduction did not change the member set — otherwise the
+        // captured order is stale and the canonical order is used as-is.
+        if !source_ordered.is_empty() && source_ordered.len() == flat.len() {
+            let canonical_set: FxHashSet<TypeId> = flat.iter().copied().collect();
+            if source_ordered.iter().all(|id| canonical_set.contains(id)) {
+                let source_list = self.intern_type_list_from_slice(&source_ordered);
+                let source_intersection = self.intern(TypeData::Intersection(source_list));
+                if source_intersection != canonical {
+                    self.store_display_alias(canonical, source_intersection);
+                }
+            }
+        }
+
+        canonical
     }
 
     fn try_merge_callables_in_intersection(&self, members: &[TypeId]) -> Option<TypeId> {


### PR DESCRIPTION
When a mixed object/non-object intersection target rejects a source, tsc's `typeRelatedToEachType` elaborates the **first constituent the source fails, in written order**, and `typeToString` prints members in written order. tsz's `normalize_intersection` moves the object member to the end to canonicalize identity (`{ z: 1 } & [string, number]` and `[string, number] & { z: 1 }` must intern to one type), so both the display and the elaboration named the non-object member even when the object was written first.

Structural rule: when a source fails a target intersection whose object member is written before a tuple/array/primitive member, tsc names the object member; tsz named the reordered non-object member through the diagnostics display seam (`crates/tsz-solver/src/intern/intersection.rs` reorder + `crates/tsz-checker/.../assignability_diagnostics.rs` constituent walk).

Fix: `normalize_intersection` now records the written source order as a **display alias** on the canonical (objects-last) intersection whenever the rebuild reorders members — and only when subtype reduction preserves the member set, so a stale order is never stored. The formatter already resolves display aliases, so the outer intersection renders in written order; the checker's target-intersection constituent walk prefers that alias and expands each merged-object member through its own alias (so a three-way `{ a } & { b } & [T]` elaborates the first written object `{ a }`, not the merged `{ a; b }`). Canonical/identity interning is unchanged.

Adjacent matrix (all verified): object-first `& [tuple]` / `& [spread tuple]` / `& string` / `& string[]` → names the object; tuple-first `[T] & { z }` → still names the tuple; three-way `{ a } & { b } & [T]` → names `{ a }`; two-object control unchanged. Binder names vary across rows.

Closes #16753

## Goal
Goal: hold

## Verification
- New `intersection_target_member_order_tests` (7 rows: issue witness, plain-tuple, primitive, array, tuple-first control, three-way, two-object control) — green.
- `cargo test -p tsz-checker --lib intersection_target` — 36/36 green (existing `intersection_target_elaboration`, `ts2322`, `ts2353` families included).
- `cargo test -p tsz-solver --lib` — 7654/7654 green, including `test_empty_object_rule_intersection` which pins that `(string | null) & {}` and `string & {}` still intern identically (canonical identity preserved).
- `cargo test -p tsz-checker --lib` for `ts2322` (670), `ts2741` (46), `ts2559` (18), `ts2353` (125), `ts2769` (35), `intersection` (256), `display` (576) — all green.
- Full `cargo test -p tsz-checker --lib` — 10582 tests, 0 failures (run halted on the pre-existing slow `ts2589` recursive test tracked in #15338; unrelated to this change).
- End-to-end via release CLI: the issue witness now emits `... to type '{ z: 1; }'.`; conformance/emit lanes to be validated by CI (TypeScript corpus not checked out in this environment).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_019vwSXf8DjiQ3Ur8vYtzVJV)_