### PR TITLE
fix(checker): TS2345 target keeps the written key-union constraint spelling (#16751)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2727,3 +2727,6 @@ path = "tests/optional_chain_any_receiver_no_expando_read_tests.rs"
 [[test]]
 name = "ts2433_cross_file_ambient_class_merge_tests"
 path = "tests/ts2433_cross_file_ambient_class_merge_tests.rs"
+[[test]]
+name = "ts2345_primitive_key_union_constraint_display_tests"
+path = "tests/ts2345_primitive_key_union_constraint_display_tests.rs"

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_property_access.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_property_access.rs
@@ -232,6 +232,142 @@ impl<'a> CheckerState<'a> {
         ))
     }
 
+    /// The structural display for the type substituted into a naked
+    /// type-parameter call-parameter surface when that substituted type is the
+    /// canonical primitive key union `string | number | symbol` **and** the
+    /// type parameter's constraint was written structurally (`keyof any`,
+    /// `keyof unknown`, `keyof never`, or the longhand `string | number |
+    /// symbol`).
+    ///
+    /// tsz interns one `TypeId` for every spelling of the key union and, via
+    /// the reverse type-to-def lookup, repaints it with whatever coincidentally
+    /// shaped alias is in scope (the lib `PropertyKey`, a user alias). That
+    /// reverse lookup already yields the correct name for a constraint written
+    /// *as* an alias (`PropertyKey`, `type Zed = …`), so those are left
+    /// untouched — this only intercepts the two structural spellings, which
+    /// `tsc` prints by their members. The written spelling is read from the
+    /// callee's type-parameter constraint node in the AST because every
+    /// spelling collapses to the same interned `TypeId` (the type level cannot
+    /// tell them apart). This is the TS2345 call-argument counterpart of the
+    /// TS2344 explicit-type-argument recovery.
+    fn key_union_type_param_replacement_display(
+        &mut self,
+        callee_expr: NodeIndex,
+        tp_name: tsz_common::interner::Atom,
+        replacement_type: TypeId,
+    ) -> Option<String> {
+        let evaluated_replacement = self.evaluate_type_for_assignability(replacement_type);
+        if !self.is_primitive_key_union_type(evaluated_replacement) {
+            return None;
+        }
+        let constraint_idx = self.callee_type_parameter_constraint_node(callee_expr, tp_name)?;
+        let structural =
+            Self::annotation_is_keyof_over_degenerate_operand(self.ctx.arena, constraint_idx)
+                || Self::annotation_is_longhand_primitive_keyword_union(
+                    self.ctx.arena,
+                    constraint_idx,
+                );
+        structural.then(|| self.format_type_diagnostic_constraint(evaluated_replacement))
+    }
+
+    /// The AST constraint node (`extends …`) of the callee's type parameter
+    /// named `tp_name`, when the callee resolves to a function/method-like
+    /// declaration whose type-parameter list declares it. Covers a plain
+    /// function (`f`), a method (`obj.m`, resolved through the qualified-symbol
+    /// path), and a value whose declared type is a function/constructor type
+    /// (`declare const f: <K extends …>(…) => …`, whose variable declaration's
+    /// type annotation carries the parameters). Returns `None` for an
+    /// unconstrained parameter or a callee with no resolvable declaration — the
+    /// ordinary display path then stands.
+    fn callee_type_parameter_constraint_node(
+        &self,
+        callee_expr: NodeIndex,
+        tp_name: tsz_common::interner::Atom,
+    ) -> Option<NodeIndex> {
+        let sym_id = self
+            .resolve_qualified_symbol(callee_expr)
+            .or_else(|| self.resolve_identifier_symbol(callee_expr))?;
+        let symbol = self
+            .ctx
+            .binder
+            .get_symbol(sym_id)
+            .or_else(|| self.get_cross_file_symbol(sym_id))?;
+        let wanted = self.ctx.types.resolve_atom_ref(tp_name);
+        for &decl_idx in &symbol.declarations {
+            let Some(type_parameters) = self.node_type_parameters(decl_idx) else {
+                continue;
+            };
+            for &tp_idx in &type_parameters.nodes {
+                let Some(tp_node) = self.ctx.arena.get(tp_idx) else {
+                    continue;
+                };
+                let Some(tp_data) = self.ctx.arena.get_type_parameter(tp_node) else {
+                    continue;
+                };
+                if tp_data.constraint.is_none() {
+                    continue;
+                }
+                if self
+                    .ctx
+                    .arena
+                    .get(tp_data.name)
+                    .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
+                    .is_some_and(|ident| ident.escaped_text == *wanted)
+                {
+                    return Some(tp_data.constraint);
+                }
+            }
+        }
+        None
+    }
+
+    /// The type-parameter list declared directly on a function/method-like
+    /// declaration node, across the node kinds that can own one. Returns `None`
+    /// for any other node kind (the callee is then displayed the ordinary way).
+    fn node_type_parameters(&self, node_idx: NodeIndex) -> Option<tsz_parser::parser::NodeList> {
+        let node = self.ctx.arena.get(node_idx)?;
+        match node.kind {
+            k if k == syntax_kind_ext::FUNCTION_DECLARATION
+                || k == syntax_kind_ext::FUNCTION_EXPRESSION
+                || k == syntax_kind_ext::ARROW_FUNCTION =>
+            {
+                self.ctx.arena.get_function(node)?.type_parameters.clone()
+            }
+            k if k == syntax_kind_ext::METHOD_DECLARATION => self
+                .ctx
+                .arena
+                .get_method_decl(node)?
+                .type_parameters
+                .clone(),
+            k if k == syntax_kind_ext::METHOD_SIGNATURE
+                || k == syntax_kind_ext::CALL_SIGNATURE
+                || k == syntax_kind_ext::CONSTRUCT_SIGNATURE =>
+            {
+                self.ctx.arena.get_signature(node)?.type_parameters.clone()
+            }
+            k if k == syntax_kind_ext::FUNCTION_TYPE || k == syntax_kind_ext::CONSTRUCTOR_TYPE => {
+                self.ctx
+                    .arena
+                    .get_function_type(node)?
+                    .type_parameters
+                    .clone()
+            }
+            // `declare const f: <K extends …>(…) => …`: the type parameters live
+            // on the variable's function/constructor-type annotation.
+            k if k == syntax_kind_ext::VARIABLE_DECLARATION => {
+                // A null `type_annotation` resolves to `None` one frame down
+                // (`arena.get` returns `None` for a null `NodeIndex`).
+                let annotation = self
+                    .ctx
+                    .arena
+                    .get_variable_declaration(node)?
+                    .type_annotation;
+                self.node_type_parameters(annotation)
+            }
+            _ => None,
+        }
+    }
+
     pub(in crate::error_reporter::call_errors) fn generic_call_parameter_alias_display(
         &mut self,
         param_type: TypeId,
@@ -298,7 +434,15 @@ impl<'a> CheckerState<'a> {
                 } else {
                     replacement_type
                 };
-                let replacement = self.format_type_for_assignability_message(replacement_type);
+                let replacement = self
+                    .key_union_type_param_replacement_display(
+                        callee_expr,
+                        tp.name,
+                        replacement_type,
+                    )
+                    .unwrap_or_else(|| {
+                        self.format_type_for_assignability_message(replacement_type)
+                    });
                 let tp_name = self.ctx.types.resolve_atom_ref(tp.name);
                 display =
                     Self::replace_type_param_name_in_display(&display, &tp_name, &replacement);

--- a/crates/tsz-checker/tests/ts2345_primitive_key_union_constraint_display_tests.rs
+++ b/crates/tsz-checker/tests/ts2345_primitive_key_union_constraint_display_tests.rs
@@ -1,0 +1,165 @@
+//! Parity pins for #16751: the TS2345 target display for a call argument
+//! checked against a generic parameter whose constraint is the canonical
+//! primitive key union `string | number | symbol`.
+//!
+//! The structural rule is the one every other type-display surface obeys — the
+//! spelling written at the site decides — and it is the same rule the TS2344
+//! explicit-type-argument path already enforces
+//! (`ts2344_primitive_key_union_alias_constraint_display_tests`). A constraint
+//! written as `keyof any` or the longhand `string | number | symbol` renders
+//! structurally; a constraint written as an alias (`PropertyKey`, a user
+//! `type Zed = …`, or a chain to either) renders that alias name.
+//!
+//! tsz interns one `TypeId` for every spelling of the key union and, through
+//! the reverse type-to-def lookup, repaints it with whatever coincidentally
+//! shaped alias is in scope (the lib `PropertyKey`). That reverse lookup already
+//! recovers the correct name for a constraint written *as* an alias, so the fix
+//! only intercepts the two structural spellings — read from the callee's
+//! type-parameter constraint node in the AST, because at the type level every
+//! spelling has collapsed to the same interned union.
+//!
+//! Every expectation here was verified against pinned `typescript@7.0.2`
+//! (`--strict`). Each fixture calls a generic function with an argument that
+//! fails the constraint (`boolean`/`true` against a key-space bound), producing
+//! exactly one TS2345.
+
+use tsz_checker::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs_code_messages, load_default_lib_files};
+
+/// The single TS2345 message a fixture produces.
+fn ts2345_message(source: &str) -> String {
+    let diagnostics = check_source_with_libs_code_messages(
+        source,
+        "case.ts",
+        CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+        &load_default_lib_files(),
+    );
+    let mut matches: Vec<&(u32, String)> = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 2345)
+        .collect();
+    assert_eq!(
+        matches.len(),
+        1,
+        "expected exactly one TS2345 for this fixture, got {diagnostics:?}"
+    );
+    matches.remove(0).1.clone()
+}
+
+/// The rendered parameter type from a TS2345 message
+/// `Argument of type 'A' is not assignable to parameter of type 'P'.` — this
+/// returns `P`.
+fn rendered_parameter(source: &str) -> String {
+    let message = ts2345_message(source);
+    let marker = "is not assignable to parameter of type '";
+    let start = message
+        .find(marker)
+        .unwrap_or_else(|| panic!("unexpected TS2345 shape: {message}"))
+        + marker.len();
+    let rest = &message[start..];
+    let end = rest
+        .rfind('\'')
+        .unwrap_or_else(|| panic!("unexpected TS2345 shape: {message}"));
+    rest[..end].to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Structural spellings render by their members (the rows the fix repairs).
+// ---------------------------------------------------------------------------
+
+/// `keyof any` resolves to the key union and is displayed structurally, never
+/// as the coincidentally-shaped `PropertyKey` alias.
+#[test]
+fn keyof_any_constraint_renders_structurally() {
+    let source = "function f<K extends keyof any>(k: K): K { return k; }\nf(true);\n";
+    assert_eq!(rendered_parameter(source), "string | number | symbol");
+}
+
+/// The longhand union carries no alias to preserve, so it renders structurally.
+#[test]
+fn longhand_key_union_constraint_renders_structurally() {
+    let source =
+        "function f<K extends string | number | symbol>(k: K): K { return k; }\nf(true);\n";
+    assert_eq!(rendered_parameter(source), "string | number | symbol");
+}
+
+/// Renamed binders and a reordered longhand union, so the row cannot be
+/// satisfied by anything keyed on a specific name or the canonical member order.
+#[test]
+fn renamed_binders_reordered_longhand_renders_structurally() {
+    let source =
+        "function gg<Q extends symbol | string | number>(q: Q): Q { return q; }\ngg(false);\n";
+    assert_eq!(rendered_parameter(source), "string | number | symbol");
+}
+
+/// A `keyof any` constraint on a value whose declared type is a function type
+/// (`declare const f: <K extends keyof any>(…) => …`) is recovered from the
+/// variable declaration's type annotation.
+#[test]
+fn const_function_type_keyof_any_constraint_renders_structurally() {
+    let source = "declare const f: <K extends keyof any>(k: K) => K;\nf(true);\n";
+    assert_eq!(rendered_parameter(source), "string | number | symbol");
+}
+
+// ---------------------------------------------------------------------------
+// Alias spellings keep their name (negative controls the fix must not repaint).
+// ---------------------------------------------------------------------------
+
+/// The lib alias `PropertyKey` renders as its name — the control that must not
+/// regress to structural.
+#[test]
+fn lib_property_key_alias_constraint_renders_the_alias() {
+    let source = "function f<K extends PropertyKey>(k: K): K { return k; }\nf(true);\n";
+    assert_eq!(rendered_parameter(source), "PropertyKey");
+}
+
+/// A user alias for the same union renders its own name (`Zed`), not the lib
+/// `PropertyKey` and not the structural union.
+#[test]
+fn user_key_union_alias_constraint_renders_the_alias() {
+    let source = "type Zed = string | number | symbol;\n\
+                  function f<K extends Zed>(k: K): K { return k; }\n\
+                  f(true);\n";
+    assert_eq!(rendered_parameter(source), "Zed");
+}
+
+/// A pure alias-to-alias chain resolves to the underlying alias (`A`), the one
+/// whose body is directly the key union — not the head written at the site.
+#[test]
+fn alias_chain_to_key_union_constraint_renders_the_underlying_alias() {
+    let source = "type A = string | number | symbol;\n\
+                  type B = A;\n\
+                  function f<K extends B>(k: K): K { return k; }\n\
+                  f(true);\n";
+    assert_eq!(rendered_parameter(source), "A");
+}
+
+// ---------------------------------------------------------------------------
+// Non-key-union constraints are unaffected (shape/altitude controls).
+// ---------------------------------------------------------------------------
+
+/// A two-member primitive union constraint is not the canonical key union, so
+/// it never took the alias-repaint path and continues to render its members.
+#[test]
+fn two_member_primitive_union_constraint_renders_its_members() {
+    let source = "function f<K extends string | number>(k: K): K { return k; }\nf(true);\n";
+    assert_eq!(rendered_parameter(source), "string | number");
+}
+
+/// An object constraint renders structurally through the ordinary path,
+/// untouched by the key-union recovery.
+#[test]
+fn object_constraint_renders_structurally() {
+    let source = "function f<K extends { a: number }>(k: K): K { return k; }\nf(true);\n";
+    assert_eq!(rendered_parameter(source), "{ a: number; }");
+}
+
+/// A bare primitive constraint renders as the primitive, untouched.
+#[test]
+fn string_primitive_constraint_renders_the_primitive() {
+    let source = "function f<K extends string>(k: K): K { return k; }\nf(true);\n";
+    assert_eq!(rendered_parameter(source), "string");
+}


### PR DESCRIPTION
Fixes #16751.

A call argument checked against a generic parameter whose constraint is the canonical primitive key union `string | number | symbol` displayed the constraint as `PropertyKey` even when it was written as `keyof any` or the longhand union. `tsc` prints those structurally and reserves `PropertyKey` for a constraint written *as* that alias.

```ts
function f<K extends keyof any>(k: K): K { return k; }
f(true);
```

| constraint as written | tsc 7.0.2 | tsz before | tsz after |
| --- | --- | --- | --- |
| `K extends keyof any` | `… parameter of type 'string \| number \| symbol'.` | `… 'PropertyKey'.` | `… 'string \| number \| symbol'.` |
| `K extends string \| number \| symbol` | same | `… 'PropertyKey'.` | same as tsc |
| `K extends PropertyKey` (control) | `… 'PropertyKey'.` | `… 'PropertyKey'.` | unchanged ✓ |

**Structural rule:** when a naked type parameter's constraint is (or reduces to) `string | number | symbol` and the constraint clause was written structurally (`keyof any`/`keyof unknown`/`keyof never` or the longhand union), `tsc` renders it by its members; a constraint written as an alias (`PropertyKey`, a user alias, or a chain to either) renders the alias name. tsz interns one `TypeId` for every spelling and stamps `PropertyKey`'s `aliasSymbol` on it globally, so at the type level the spellings are indistinguishable (the constraint arrives as the bare union with `lazy=false, alias=None` for every spelling). The written form is therefore recovered from the callee's type-parameter constraint **node** in the AST.

**Owner layer:** `generic_call_parameter_alias_display` (the call-parameter constraint substitution in the diagnostic display path). This is the TS2345 call-argument counterpart of the TS2344 explicit-type-argument recovery (#16630) and reuses the same shared primitives — `annotation_is_keyof_over_degenerate_operand`, `annotation_is_longhand_primitive_keyword_union`, `is_primitive_key_union_type`, `format_type_diagnostic_constraint` — rather than duplicating the decision logic. The reverse type-to-def lookup already recovers alias names correctly, so the fix only intercepts the two structural spellings.

**Adjacent-case matrix (all pinned against `typescript@7.0.2 --strict`):** `keyof any`, longhand union, renamed binders + reordered union, `declare const f: <K extends keyof any>(…)` (function-type annotation on a variable) → structural; `PropertyKey`, a user alias `Zed`, an alias-to-alias chain `type B = A` → alias name preserved; two-member union `string | number`, object constraint `{ a: number }`, bare `string` → untouched. Method calls whose callee is a property access flow through a different display branch and are unchanged (pre-existing behavior, not a regression).

Display-only: no assignability outcome changes; only the rendered target text.

## Goal
Goal: hold

## Verification
- New pins: `cargo test -p tsz-checker --test ts2345_primitive_key_union_constraint_display_tests` (10 passing) — structural spellings, alias controls, and non-key-union controls.
- Sibling unchanged: `cargo test -p tsz-checker --test ts2344_primitive_key_union_alias_constraint_display_tests` (12 passing).
- Regression batch (unchanged): `call_resolution_regression_tests` (172), `index_signature_argument_assignability_tests` (14), `mapped_type_errors_conformance_tests` (19), `failed_generic_call_default_type_args_tests`, `constraint_unresolved_lazy_defer_tests`, `abstract_constructor_argument_tests`, `contextual_literal_keyof_lib_tests`, `call_argument_boolean_literal_array_display_tests`.
- `cargo clippy -p tsz-checker --all-targets` clean; commit-time clippy + arch-guard passed.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high


---
_Generated by [Claude Code](https://claude.ai/code/session_01MXwQtgaVMSZJ7JAqCLNJox)_