### PR TITLE
fix(checker): wide-keyed method/accessor members display their source-spelled key (#16662)

### DIFF
--- a/crates/tsz-checker/src/context/analysis_state_types.rs
+++ b/crates/tsz-checker/src/context/analysis_state_types.rs
@@ -107,4 +107,12 @@ pub struct ObjectLiteralTracking {
     pub contextual_targets: FxHashMap<NodeIndex, TypeId>,
     /// Stack of in-progress object literal variable initializers.
     pub partial_initializers: Vec<PartialObjectLiteralInitializer>,
+    /// Property-level type of a computed-name method/accessor that routed
+    /// into an index-signature bucket (wide `string`/`number`/`symbol` key),
+    /// keyed by the member element node. Captured at object-literal
+    /// computation time — when the member's type is already safely inferred —
+    /// so `object_literal_source_type_display` can re-spell the member
+    /// (`[ws]: () => number`) without re-running function inference at
+    /// display time. #16662.
+    pub computed_index_member_display_types: FxHashMap<NodeIndex, TypeId>,
 }

--- a/crates/tsz-checker/src/context/file_session_reset.rs
+++ b/crates/tsz-checker/src/context/file_session_reset.rs
@@ -181,6 +181,9 @@ impl<'a> CheckerContext<'a> {
         self.object_literal_tracking.property_diag_targets.clear();
         self.object_literal_tracking.contextual_targets.clear();
         self.object_literal_tracking.partial_initializers.clear();
+        self.object_literal_tracking
+            .computed_index_member_display_types
+            .clear();
         // Spelling candidates and scan results are keyed by binder-local
         // `ScopeId`; clear both so a new file's identically-numbered scopes never
         // inherit the previous file's symbol universe or suggestions.

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/contextual_index_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/contextual_index_display.rs
@@ -5,7 +5,81 @@ use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::TypeId;
 
+/// One rendered computed-name method/accessor member that folded into an
+/// index-signature bucket, plus the facts the caller's wide-key merge
+/// bookkeeping needs (see `object_literal_source_type_display`).
+pub(in crate::error_reporter) struct ComputedIndexMemberDisplay {
+    /// Property-style rendering, e.g. `[ws]: () => number`.
+    pub rendered: String,
+    /// Index kind (`"string"`/`"number"`) when the key folds into the
+    /// target's matching index signature; `None` for `symbol` keys and
+    /// targets without one.
+    pub computed_index_kind: Option<&'static str>,
+    /// Display-widened member value type, for the merged-clause value union.
+    pub widened_value: TypeId,
+    /// Whether the key expression is a re-spellable entity name.
+    pub key_is_entity_name: bool,
+}
+
 impl<'a> CheckerState<'a> {
+    /// Render a computed-name object-literal method/accessor whose type was
+    /// captured into `computed_index_member_display_types` at computation
+    /// time — a getter by its return type, a setter by its parameter type, a
+    /// method by its function type — in the same `[{expr}]: V` bracket-
+    /// property form a computed-key property assignment gets (`tsc` prints
+    /// `{ [ws]: () => number; }`, #16662). Returns `None` when the member was
+    /// not captured (a named or late-bound member) or its key resolves to a
+    /// static name; the caller then falls back to the structural formatter
+    /// for the whole literal.
+    pub(in crate::error_reporter) fn computed_index_member_source_display(
+        &mut self,
+        elem_idx: NodeIndex,
+        target_shape: Option<&tsz_solver::ObjectShape>,
+    ) -> Option<ComputedIndexMemberDisplay> {
+        let member_type = *self
+            .ctx
+            .object_literal_tracking
+            .computed_index_member_display_types
+            .get(&elem_idx)?;
+        let elem_node = self.ctx.arena.get(elem_idx)?;
+        let name_idx = if let Some(method) = self.ctx.arena.get_method_decl(elem_node) {
+            method.name
+        } else {
+            self.ctx.arena.get_accessor(elem_node)?.name
+        };
+        // Only a wide, non-resolvable key takes the re-spelled property form;
+        // a resolvable name keeps its named-member display semantics.
+        if self.get_property_name(name_idx).is_some() {
+            return None;
+        }
+        let name_node = self.ctx.arena.get(name_idx)?;
+        if name_node.kind != syntax_kind_ext::COMPUTED_PROPERTY_NAME {
+            return None;
+        }
+        // Same two-step spelling as the property-assignment arm in
+        // `object_literal_source_type_display`: the whole `[...]` node's own
+        // source text when renderable, else brackets reassembled around the
+        // key expression's text.
+        let display_name = if let Some(name) = self.get_member_name_display_text(name_idx) {
+            name
+        } else {
+            let computed = self.ctx.arena.get_computed_property(name_node)?;
+            let expr = self.node_text(computed.expression)?;
+            format!("[{expr}]", expr = expr.trim())
+        };
+        let computed_index_kind = self.contextual_computed_index_key_kind(name_idx, target_shape);
+        let key_is_entity_name = self.computed_key_is_entity_name_reference(name_idx);
+        let widened = self.widen_type_for_display(member_type);
+        let widened_value = self.widen_function_like_display_type(widened);
+        let value_display = self.format_type_for_assignability_message(widened_value);
+        Some(ComputedIndexMemberDisplay {
+            rendered: format!("{display_name}: {value_display}"),
+            computed_index_kind,
+            widened_value,
+            key_is_entity_name,
+        })
+    }
+
     pub(crate) fn contextual_computed_index_key_kind(
         &mut self,
         name_idx: NodeIndex,

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/object_literal_source_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/object_literal_source_display.rs
@@ -93,6 +93,37 @@ impl<'a> CheckerState<'a> {
         let mut any_non_entity_wide_key = false;
         for child_idx in literal.elements.nodes.iter().copied() {
             let child = self.ctx.arena.get(child_idx)?;
+            if matches!(
+                child.kind,
+                k if k == syntax_kind_ext::METHOD_DECLARATION
+                    || k == syntax_kind_ext::GET_ACCESSOR
+                    || k == syntax_kind_ext::SET_ACCESSOR
+            ) {
+                // A computed-name method/accessor that folded into an
+                // index-signature bucket displays property-style from the type
+                // captured at computation time (`[ws]: () => number`, a getter
+                // by its return type, a setter by its parameter type), like a
+                // computed-key property assignment. Any other method/accessor
+                // keeps the structural fallback for the whole literal.
+                let member =
+                    self.computed_index_member_source_display(child_idx, target_shape.as_deref())?;
+                match (contextual_index_key_kind, member.computed_index_kind) {
+                    (None, Some(kind)) => contextual_index_key_kind = Some(kind),
+                    (Some(existing), Some(kind)) if existing == kind => {}
+                    _ => all_contextual_index_properties = false,
+                }
+                if member.computed_index_kind.is_some() && !member.key_is_entity_name {
+                    any_non_entity_wide_key = true;
+                }
+                if member.computed_index_kind.is_some() {
+                    contextual_index_value_types.push(member.widened_value);
+                }
+                // A wide computed key never resolves to a static property
+                // name, so it cannot collide in the property table — always
+                // appended.
+                parts.push(member.rendered);
+                continue;
+            }
             let (name_idx, value_idx) = if child.kind == syntax_kind_ext::PROPERTY_ASSIGNMENT {
                 let prop = self.ctx.arena.get_property_assignment(child)?;
                 (prop.name, prop.initializer)

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -175,6 +175,8 @@ mod commonjs_reentrant_surface_tests;
 mod commonjs_require_binding_type_meaning_tests;
 #[path = "tests/computed_alias_source_display_tests.rs"]
 mod computed_alias_source_display_tests;
+#[path = "tests/computed_index_member_source_display_tests.rs"]
+mod computed_index_member_source_display_tests;
 #[path = "tests/computed_key_missing_property_primary_code_tests.rs"]
 mod computed_key_missing_property_primary_code_tests;
 #[path = "tests/computed_key_nested_excess_property_tests.rs"]

--- a/crates/tsz-checker/src/tests/computed_index_member_source_display_tests.rs
+++ b/crates/tsz-checker/src/tests/computed_index_member_source_display_tests.rs
@@ -1,0 +1,241 @@
+//! Source-spelled display for a computed-name method/accessor whose wide
+//! (non-literal) key folds into an index-signature bucket.
+//!
+//! Structural rule, oracled against `typescript@7.0.2` (`--strict`): a fresh
+//! object literal whose member is a method, getter, or setter under a wide
+//! `string`/`number`/`symbol` computed key displays that member
+//! property-style from its own source spelling — `{ [ws]: () => number; }`
+//! for a method, the return type for a getter, the parameter type for a
+//! setter — exactly as the property-assignment form of the same key already
+//! does. The generic `[x: kind]: V` clause appears only under the #16721
+//! fold rule: at least one wide key in the homogeneous group is not an
+//! entity-name reference.
+//!
+//! tsz rendered every method/accessor-bearing literal through the structural
+//! formatter, whose synthesized index signature carries no source name, so
+//! the message showed `{ [x: string]: () => number; }` (#16662). The member
+//! type is captured at object-literal computation time
+//! (`computed_index_member_display_types`) and re-spelled by
+//! `computed_index_member_source_display`; function inference never re-runs
+//! at display time.
+//!
+//! Binder names vary across cases so no identifier string is load-bearing.
+
+use crate::test_utils::check_source_strict_messages;
+
+fn message_for(source: &str, code: u32) -> Option<String> {
+    check_source_strict_messages(source)
+        .into_iter()
+        .find(|(c, _)| *c == code)
+        .map(|(_, message)| message)
+}
+
+// ---------------------------------------------------------------------------
+// Entity-name wide keys re-spell the member, property-style.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_wide_string_keyed_method_displays_its_source_key_and_function_type() {
+    let source = r#"
+declare const routeName: string;
+interface StrTable { [slot: string]: string }
+const table: StrTable = { [routeName]() { return 1; } };
+"#;
+    let message = message_for(source, 2322).expect("TS2322 for the index mismatch");
+    assert!(
+        message.contains("{ [routeName]: () => number; }"),
+        "method should display property-style from its source key: {message}"
+    );
+}
+
+#[test]
+fn a_wide_string_keyed_getter_displays_its_return_type() {
+    let source = r#"
+declare const fieldKey: string;
+interface StrTable { [slot: string]: string }
+const table: StrTable = { get [fieldKey]() { return 5; } };
+"#;
+    let message = message_for(source, 2322).expect("TS2322 for the index mismatch");
+    assert!(
+        message.contains("{ [fieldKey]: number; }"),
+        "getter should display by its return type: {message}"
+    );
+}
+
+#[test]
+fn a_wide_string_keyed_setter_displays_its_parameter_type() {
+    let source = r#"
+declare const sinkKey: string;
+interface StrTable { [slot: string]: string }
+const table: StrTable = { set [sinkKey](next: number) {} };
+"#;
+    let message = message_for(source, 2322).expect("TS2322 for the index mismatch");
+    assert!(
+        message.contains("{ [sinkKey]: number; }"),
+        "setter should display by its parameter type: {message}"
+    );
+}
+
+#[test]
+fn a_wide_number_keyed_method_displays_its_source_key() {
+    let source = r#"
+declare const rowIndex: number;
+interface NumTable { [slot: number]: string }
+const table: NumTable = { [rowIndex]() { return 2; } };
+"#;
+    let message = message_for(source, 2322).expect("TS2322 for the index mismatch");
+    assert!(
+        message.contains("{ [rowIndex]: () => number; }"),
+        "number-keyed method should display its source key: {message}"
+    );
+}
+
+#[test]
+fn a_wide_symbol_keyed_method_displays_its_source_key() {
+    let source = r#"
+declare const tagSym: symbol;
+interface SymTable { [slot: symbol]: string }
+const table: SymTable = { [tagSym]() { return 3; } };
+"#;
+    let message = message_for(source, 2322).expect("TS2322 for the index mismatch");
+    assert!(
+        message.contains("{ [tagSym]: () => number; }"),
+        "symbol-keyed method should display its source key: {message}"
+    );
+}
+
+#[test]
+fn a_dotted_entity_name_keyed_method_keeps_the_dotted_spelling() {
+    let source = r#"
+declare const box: { label: string };
+interface StrTable { [slot: string]: string }
+const table: StrTable = { [box.label]() { return 4; } };
+"#;
+    let message = message_for(source, 2322).expect("TS2322 for the index mismatch");
+    assert!(
+        message.contains("{ [box.label]: () => number; }"),
+        "dotted entity key should keep its spelling: {message}"
+    );
+}
+
+#[test]
+fn a_method_with_parameters_displays_its_full_function_type() {
+    let source = r#"
+declare const opKey: string;
+interface StrTable { [slot: string]: string }
+const table: StrTable = { [opKey](count: number, label: string) { return 6; } };
+"#;
+    let message = message_for(source, 2322).expect("TS2322 for the index mismatch");
+    assert!(
+        message.contains("{ [opKey]: (count: number, label: string) => number; }"),
+        "method parameters should survive in the display: {message}"
+    );
+}
+
+#[test]
+fn a_getter_setter_pair_displays_both_members_like_tsc() {
+    // tsc renders the pair as two property-style members with the same
+    // spelling (getter by return type, setter by parameter type).
+    let source = r#"
+declare const pairKey: string;
+interface StrTable { [slot: string]: string }
+const table: StrTable = { get [pairKey]() { return 7; }, set [pairKey](v: number) {} };
+"#;
+    let message = message_for(source, 2322).expect("TS2322 for the index mismatch");
+    assert!(
+        message.contains("{ [pairKey]: number; [pairKey]: number; }"),
+        "accessor pair should render both members: {message}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The #16721 fold rule applies to methods exactly as to property assignments.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_lone_non_entity_wide_keyed_method_folds_to_the_generic_clause() {
+    let source = r#"
+declare const stem: string;
+interface StrTable { [slot: string]: string }
+const table: StrTable = { [stem + "s"]() { return 8; } };
+"#;
+    let message = message_for(source, 2322).expect("TS2322 for the index mismatch");
+    assert!(
+        message.contains("{ [x: string]: () => number; }"),
+        "non-entity key cannot be re-spelled and must fold: {message}"
+    );
+}
+
+#[test]
+fn one_non_entity_sibling_folds_the_entity_named_method_too() {
+    let source = r#"
+declare const goodKey: string;
+interface StrTable { [slot: string]: string }
+const table: StrTable = { [goodKey]() { return 9; }, [goodKey + "x"]() { return 10; } };
+"#;
+    let message = message_for(source, 2322).expect("TS2322 for the index mismatch");
+    assert!(
+        message.contains("{ [x: string]: () => number; }"),
+        "one non-entity sibling folds the whole group: {message}"
+    );
+    assert!(
+        !message.contains("[goodKey]:"),
+        "no member may keep its own spelling once the group folds: {message}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fallback and negative controls.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_plainly_named_method_keeps_the_structural_display() {
+    // Not captured into an index bucket, so the literal falls back to the
+    // structural formatter — named methods keep their method-signature form.
+    let source = r#"
+interface StrTable { [slot: string]: string }
+const table: StrTable = { plainAction() { return 11; } };
+"#;
+    let message = message_for(source, 2322).expect("TS2322 for the mismatch");
+    assert!(
+        message.contains("plainAction"),
+        "named method display should be unchanged: {message}"
+    );
+    assert!(
+        !message.contains("[x: string]"),
+        "a named method is not an index-signature contributor: {message}"
+    );
+}
+
+#[test]
+fn an_assignable_wide_keyed_method_reports_nothing() {
+    let source = r#"
+declare const quietKey: string;
+const table: { [slot: string]: () => number } = { [quietKey]() { return 12; } };
+"#;
+    assert_eq!(
+        check_source_strict_messages(source),
+        vec![],
+        "assignable literal must stay silent"
+    );
+}
+
+#[test]
+fn a_well_known_symbol_method_stays_a_named_member() {
+    // `[Symbol.iterator]` late-binds to the well-known member; a value
+    // mismatch against a target declaring it reports per-member, never the
+    // synthesized index clause or a re-spelled wide-key form.
+    let source = r#"
+interface WithIter { [Symbol.iterator]: string }
+const holder: WithIter = { [Symbol.iterator]() { return 13; } };
+"#;
+    let messages = check_source_strict_messages(source);
+    assert!(
+        !messages.is_empty(),
+        "the mismatch must still be reported somewhere"
+    );
+    assert!(
+        messages.iter().all(|(_, m)| !m.contains("[x: ")),
+        "well-known symbol member must not fold into an index clause: {messages:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
@@ -579,6 +579,10 @@ impl<'a> CheckerState<'a> {
                     contextual_type,
                 );
             }
+            self.ctx
+                .object_literal_tracking
+                .computed_index_member_display_types
+                .insert(elem_idx, accessor_type);
             self.route_computed_member_value_to_index_signature(
                 prop_name_type,
                 accessor_type,

--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -1783,6 +1783,10 @@ impl<'a> CheckerState<'a> {
                             contextual_type,
                         );
                     }
+                    self.ctx
+                        .object_literal_tracking
+                        .computed_index_member_display_types
+                        .insert(elem_idx, method_type);
                     self.route_computed_member_value_to_index_signature(
                         prop_name_type,
                         method_type,


### PR DESCRIPTION
Takes Jadeite's 10:55Z board DROP handoff on #16662 (display slice). Fixes the wrong-diagnostic-display family where a computed-name **method/getter/setter** under a wide key rendered the structural formatter's synthesized index clause instead of tsc's source-spelled member.

**Structural rule:** when a fresh object literal member is a method, getter, or setter under a wide (non-literal) `string`/`number`/`symbol` computed key, tsc displays that member property-style from its own source spelling — `{ [ws]: () => number; }` for a method, the return type for a getter, the parameter type for a setter — exactly as the property-assignment form of the same key already does; tsz does this through the checker's diagnostic-source display layer (`object_literal_source_type_display`), reading the member's type from a map captured at object-literal **computation** time (`ObjectLiteralTracking::computed_index_member_display_types`, populated at the two sites that route a computed member into an index-signature bucket) so display never re-runs function inference — the exact hazard Jadeite's handoff flagged with `get_type_of_function`. The structural `IndexSignature.param_name` is untouched, per the handoff's finding that it is the wrong field (it renders declared-signature form `[name: string]`).

Map membership is the gate: named methods, late-bound members, and well-known-symbol members are never captured, so they keep the structural fallback bit-for-bit — no behavior change outside the broken family. The #16721 fold rule (one non-entity key folds the whole homogeneous wide-key group into `[x: kind]: V`) applies to these members exactly as to property assignments, via the same merge bookkeeping.

**Adjacent-case matrix** (all oracled against pinned `typescript@7.0.2` via `scripts/conformance/oracle.sh --strict`, byte-identical after the fix; binder names varied in the unit tests):
- method / getter / setter × wide `string` / `number` / `symbol` keys → source-spelled (`{ [ws]: () => number; }`, `{ [wn]: … }`, `{ [wsym]: … }`)
- dotted entity key `[obj.key]` method → keeps dotted spelling
- method with parameters → full function type `(count: number, label: string) => number`
- getter+setter pair on one key → both members rendered (`{ [k]: number; [k]: number; }`, matching tsc's duplication)
- lone non-entity key (`[stem + "s"]`) and mixed entity+non-entity group → fold to `{ [x: string]: () => number; }` (negative for re-spelling)
- named method, well-known `[Symbol.iterator]` method → unchanged structural/named display (fallback controls)
- assignable wide-keyed method → still silent (negative control)
- alias-wrapped target, nested literal, mixed with named property → match tsc

**Known sibling gaps left open (pre-existing, verified NOT touched by this PR):** (1) TS2345 argument-position source display shows the generic clause for this whole family *including plain property assignments* (`f({ [wk]: 1 })` → `{ [x: string]: number; }` on main today) and uses a different index elaboration wording — different display entry path; (2) a *named* method mismatching an index signature reports whole-object where tsc elaborates per-member. Both noted on #16662.

## Goal
Goal: hold

## Verification
- `scripts/conformance/oracle.sh` on two repro matrices (17 diagnostics total): tsz output byte-identical to pinned `typescript@7.0.2` after fix; before fix 6/9 rows on the primary matrix showed `[x: …]` placeholders.
- `cargo nextest run -p tsz-checker computed_index_member_source_display`: 13/13 new pinning tests pass.
- `scripts/conformance/compare-to-parent.sh` (two-sided vs parent): running at PR-open time; result will be posted as a PR comment before queueing the merge.
- `cargo clippy --workspace --all-targets -- -D warnings`: queued behind the conformance run (same tree); result posted with the above.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-fable-5
Effort: medium
AgentName: Scoria

https://claude.ai/code/session_012xEgNjYy3SXJhnAfgcK3as

---
_Generated by [Claude Code](https://claude.ai/code/session_012xEgNjYy3SXJhnAfgcK3as)_