### PR TITLE
fix(checker): an unannotated bodyless get accessor has implicit type `any`, not `void`

### DIFF
--- a/crates/tsz-checker/src/types/queries/class.rs
+++ b/crates/tsz-checker/src/types/queries/class.rs
@@ -1167,6 +1167,17 @@ impl<'a> CheckerState<'a> {
         accessor_idx: NodeIndex,
         body_idx: NodeIndex,
     ) -> TypeId {
+        // A get accessor with no body (abstract, ambient, or `declare`) has no
+        // source to infer a return type from. Its implicit type is `any` — tsc's
+        // implicit-any fallback, the same one that drives TS7033 — not the `void`
+        // that empty-body return inference produces. Returning `void` here makes an
+        // overriding member in a derived class fail the TS2416 base-type
+        // assignability check even though every type is assignable to an `any` base
+        // (and would likewise mis-widen any other consumer of a bodyless getter's
+        // type). Concrete getters with an (empty) body keep inferring normally.
+        if body_idx.is_none() {
+            return TypeId::ANY;
+        }
         let prev = self.ctx.preserve_literal_types;
         self.ctx.preserve_literal_types = false;
         let r = self.infer_return_type_from_body(accessor_idx, body_idx, None);

--- a/crates/tsz-checker/tests/accessor_pair_override_ts2416_tests.rs
+++ b/crates/tsz-checker/tests/accessor_pair_override_ts2416_tests.rs
@@ -194,3 +194,74 @@ class B extends A { get x(): number { return 1; } set x(v: number) {} }
         diags(source)
     );
 }
+
+// ---------------------------------------------------------------------------
+// 4. Unannotated bodyless (abstract / ambient) getter has implicit type `any`,
+//    not `void` — a derived override must not spuriously fail TS2416.
+//    Conformance: compiler/noImplicitAnyMissingSetAccessor.ts. Every type is
+//    assignable to an `any` base member, so the override is always compatible.
+//    Binder names vary across cases so the fix cannot be pinned to a spelling.
+// ---------------------------------------------------------------------------
+
+/// Reported repro: abstract getter with no return annotation, derived getter
+/// returns `string`. Base member type is implicit `any`, so no TS2416.
+#[test]
+fn abstract_unannotated_getter_is_any_derived_getter_no_ts2416() {
+    let source = r#"
+abstract class Parent { public abstract get message(); }
+class Child extends Parent { public get message() { return ""; } }
+"#;
+    assert_eq!(
+        ts2416_count(source),
+        0,
+        "an unannotated abstract getter is implicit `any`, not `void`; got: {:#?}",
+        diags(source)
+    );
+}
+
+/// Same rule when the derived member is a plain property rather than a getter.
+#[test]
+fn abstract_unannotated_getter_is_any_derived_property_no_ts2416() {
+    let source = r#"
+abstract class Shape { abstract get area(); }
+class Square extends Shape { area = 4; }
+"#;
+    assert_eq!(
+        ts2416_count(source),
+        0,
+        "derived property over an `any` base getter must not report TS2416; got: {:#?}",
+        diags(source)
+    );
+}
+
+/// The base member really is `any`: a derived getter returning an object type
+/// is just as compatible as one returning a primitive.
+#[test]
+fn abstract_unannotated_getter_is_any_derived_object_no_ts2416() {
+    let source = r#"
+abstract class Repo { abstract get handle(); }
+class FileRepo extends Repo { get handle() { return { fd: 1 }; } }
+"#;
+    assert_eq!(
+        ts2416_count(source),
+        0,
+        "every type is assignable to an `any` base member; got: {:#?}",
+        diags(source)
+    );
+}
+
+/// An explicitly annotated abstract getter still drives a real TS2416 when the
+/// override genuinely disagrees — the fix must not blanket-suppress the check.
+#[test]
+fn abstract_annotated_getter_mismatch_still_reports_ts2416() {
+    let source = r#"
+abstract class Provider { abstract get token(): string; }
+class NumProvider extends Provider { get token() { return 1; } }
+"#;
+    assert_eq!(
+        ts2416_count(source),
+        1,
+        "a real getter-type mismatch against an annotated base must still report TS2416; got: {:#?}",
+        diags(source)
+    );
+}


### PR DESCRIPTION
An abstract/ambient/`declare` get accessor with no return-type annotation has no body to infer a return type from. Its implicit type is `any` — tsc's implicit-any fallback, the same one that drives TS7033 ("... get accessor lacks a return type annotation") — but `infer_getter_return_type_for_node` ran empty-body return inference over the absent body and produced `void`.

## Structural rule
When a get accessor has no return-type annotation **and** no body, tsc gives its member the implicit `any` type; tsz was giving it `void` through the getter return-type inference query. Owner layer: checker `infer_getter_return_type_for_node` (`crates/tsz-checker/src/types/queries/class.rs`).

The `void` member type made a derived class member spuriously fail the TS2416 base-type-assignability check even though every type is assignable to an `any` base. The fix short-circuits `infer_getter_return_type_for_node` to `any` when the body is absent, so **every** caller (instance and static member types, the constructor-type path, member checks) is corrected uniformly. Concrete getters with an (empty) body keep inferring normally.

### Before → after (pinned against `tsc@7.0.2`)
| source | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `abstract class P { abstract get m(); }` + `class C extends P { get m() { return ""; } }` | `TS7033` | `TS2416 + TS7033` | `TS7033` |
| …derived `m = "";` (property override) | `TS7033` | `TS2416 + TS7033` | `TS7033` |
| `declare class P { get m(); }` (ambient) | `TS7033` | `TS2416 + TS7033` | `TS7033` |
| `abstract get m(): any` + derived getter | (clean) | (clean) | (clean) |
| `abstract get m(): string` + derived `get m(){return 1}` (real mismatch) | `TS2416` | `TS2416` | `TS2416` |

## Goal
Goal: hold

## Verification
- Root-caused with the `tsc@7.0.2` oracle: the unannotated bodyless getter resolved to `void`, so `string`/property/object overrides all failed TS2416; every listed row now matches tsc.
- Fixes conformance `compiler/noImplicitAnyMissingSetAccessor.ts` (was `expected:[TS7033] actual:[TS2416,TS7033]`).
- Conformance snapshot (`conformance.sh snapshot --workers 12 --force`, `tsc@7.0.2` corpus): **0 diagnostic-code regressions**. The four rows that flipped in the run all have `expected == actual` (identical codes) and contain no accessors — pre-existing non-deterministic harness-fingerprint flakiness (#16309), not caused by this change.
- `cargo test --release -p tsz-checker --test accessor_pair_override_ts2416_tests` — 16 passed (4 new, binder names varied so the fix is not pinned to a spelling; includes a guard that a real annotated-base mismatch still reports TS2416).
- Full `cargo test -p tsz-checker --lib` — 10519 passed, 0 failed.
- Clippy + architecture guard (2000-LOC cap) pass via the pre-commit hook.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_014WeCDtviJ7rbcijtmWt3w2)_