### PR TITLE
fix(checker): TS2345 generic-constraint target display renders keyof any/longhand union structurally (#16751)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1768,6 +1768,9 @@ path = "tests/ts2339_union_narrow_display_tests.rs"
 name = "ts2339_user_defined_predicate_primitive_or_object_tests"
 path = "tests/ts2339_user_defined_predicate_primitive_or_object_tests.rs"
 [[test]]
+name = "ts2345_generic_constraint_keyof_any_target_display_tests"
+path = "tests/ts2345_generic_constraint_keyof_any_target_display_tests.rs"
+[[test]]
 name = "ts2345_instanceof_narrowed_union_display_tests"
 path = "tests/ts2345_instanceof_narrowed_union_display_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_property_access.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_property_access.rs
@@ -298,7 +298,37 @@ impl<'a> CheckerState<'a> {
                 } else {
                     replacement_type
                 };
-                let replacement = self.format_type_for_assignability_message(replacement_type);
+                // When the displayed substitution for `tp` is exactly its own
+                // constraint (the inference-candidate-violates-constraint
+                // fallback tsc's `getInferredType` performs), and that
+                // constraint was written as `keyof any` / `keyof unknown` /
+                // `keyof never` or the longhand `string | number | symbol`,
+                // tsc's `getIndexType` already resolved it to its fixed
+                // key-space union at type-construction time with no
+                // `aliasSymbol` attached. `format_type_for_assignability_message`
+                // would otherwise repaint that union with a coincidentally-
+                // shaped alias reached elsewhere (the lib `PropertyKey`) via
+                // its reverse type-to-def lookup — the same family as
+                // #16610/#16748's assignment-source fix, here on the TS2345
+                // call-argument TARGET side (#16751).
+                let degenerate_constraint_replacement = tp
+                    .constraint
+                    .map(|constraint| self.evaluate_type_for_assignability(constraint))
+                    .filter(|&evaluated_constraint| evaluated_constraint == replacement_type)
+                    .filter(|_| {
+                        self.written_type_param_constraint_is_degenerate_key_union(
+                            callee_expr,
+                            tp.name,
+                        )
+                    });
+                let replacement =
+                    if let Some(evaluated_constraint) = degenerate_constraint_replacement {
+                        self.format_type_for_assignability_message_anonymous_composite_structural(
+                            evaluated_constraint,
+                        )
+                    } else {
+                        self.format_type_for_assignability_message(replacement_type)
+                    };
                 let tp_name = self.ctx.types.resolve_atom_ref(tp.name);
                 display =
                     Self::replace_type_param_name_in_display(&display, &tp_name, &replacement);

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -145,6 +145,7 @@ impl<'a> CheckerState<'a> {
                             &sig,
                             arg_pos,
                             evaluated_param,
+                            call.expression,
                             &mut display,
                             &mut ambiguous,
                         );
@@ -163,6 +164,7 @@ impl<'a> CheckerState<'a> {
                             &sig,
                             arg_pos,
                             evaluated_param,
+                            call.expression,
                             &mut display,
                             &mut ambiguous,
                         );
@@ -331,6 +333,7 @@ impl<'a> CheckerState<'a> {
         sig: &tsz_solver::CallSignature,
         arg_pos: usize,
         evaluated_param: TypeId,
+        callee_expr: NodeIndex,
         display: &mut Option<String>,
         ambiguous: &mut bool,
     ) {
@@ -354,6 +357,34 @@ impl<'a> CheckerState<'a> {
         let matches_evaluated = evaluated_constraint == evaluated_param
             || self.types_are_mutually_assignable(evaluated_constraint, evaluated_param);
         if !matches_evaluated {
+            return;
+        }
+
+        // A type parameter's constraint written as `keyof any` / `keyof
+        // unknown` / `keyof never`, or longhand as `string | number | symbol`,
+        // resolves eagerly to its fixed key-space union at type-construction
+        // time (tsc's `getIndexType`) and so carries no `aliasSymbol` — the
+        // written operator/union never reaches `typeToString`. tsz's generic
+        // type-formatter reverse-lookup can still repaint that union with a
+        // coincidentally-shaped alias reached elsewhere (the lib
+        // `PropertyKey`), the same family as #16610/#16748's source-display
+        // fix, here on the TS2345 call-argument TARGET side. Render
+        // structurally instead when the constraint's own written clause
+        // matches one of those degenerate shapes.
+        if self.written_type_param_constraint_is_degenerate_key_union(callee_expr, type_param.name)
+        {
+            let candidate = self
+                .format_type_for_assignability_message_anonymous_composite_structural(
+                    evaluated_constraint,
+                );
+            if display
+                .as_ref()
+                .is_some_and(|existing| existing != &candidate)
+            {
+                *ambiguous = true;
+                return;
+            }
+            *display = Some(candidate);
             return;
         }
 
@@ -391,6 +422,57 @@ impl<'a> CheckerState<'a> {
             return;
         }
         *display = Some(candidate);
+    }
+
+    /// Whether the type parameter named `type_param_name`, declared on the
+    /// callee reached by `callee_expr`, was written with a constraint clause
+    /// matching one of the degenerate key-union shapes tsc resolves eagerly
+    /// and displays structurally: `keyof any` / `keyof unknown` / `keyof
+    /// never`, or the longhand `string | number | symbol`. A named alias
+    /// constraint (`K extends PropertyKey`) is a `TYPE_REFERENCE`, not either
+    /// shape, and keeps its existing alias-name display.
+    pub(in crate::error_reporter::call_errors) fn written_type_param_constraint_is_degenerate_key_union(
+        &self,
+        callee_expr: NodeIndex,
+        type_param_name: tsz_common::interner::Atom,
+    ) -> bool {
+        let Some(callee_sym) = self
+            .resolve_identifier_symbol(callee_expr)
+            .or_else(|| self.resolve_qualified_symbol(callee_expr))
+        else {
+            return false;
+        };
+        let Some(callee) = self.ctx.binder.get_symbol(callee_sym) else {
+            return false;
+        };
+        let type_param_name = self.ctx.types.resolve_atom_ref(type_param_name);
+        let Some(constraint_idx) = callee.declarations.iter().copied().find_map(|decl_idx| {
+            let node = self.ctx.arena.get(decl_idx)?;
+            // `const f = <K extends ...>(...) => ...` records the callee
+            // symbol's declaration as the `VariableDeclaration`, not the
+            // arrow-function initializer; unwrap it so arrow/function-
+            // expression callees reach their own type-parameter list too.
+            let func = self.ctx.arena.get_function(node).or_else(|| {
+                let var_decl = self.ctx.arena.get_variable_declaration(node)?;
+                let init_node = self.ctx.arena.get(var_decl.initializer)?;
+                self.ctx.arena.get_function(init_node)
+            })?;
+            let type_params = func.type_parameters.as_ref()?;
+            type_params.nodes.iter().copied().find_map(|tp_idx| {
+                let tp_node = self.ctx.arena.get(tp_idx)?;
+                let tp = self.ctx.arena.get_type_parameter(tp_node)?;
+                let name_node = self.ctx.arena.get(tp.name)?;
+                let ident = self.ctx.arena.get_identifier(name_node)?;
+                (ident.escaped_text.as_ref() == type_param_name.as_ref()).then_some(tp.constraint)
+            })
+        }) else {
+            return false;
+        };
+        if !constraint_idx.is_some() {
+            return false;
+        }
+        Self::annotation_is_keyof_over_degenerate_operand(self.ctx.arena, constraint_idx)
+            || Self::annotation_is_longhand_primitive_keyword_union(self.ctx.arena, constraint_idx)
     }
 
     /// Try to elaborate a generic assignability mismatch when the source expression is

--- a/crates/tsz-checker/tests/ts2345_generic_constraint_keyof_any_target_display_tests.rs
+++ b/crates/tsz-checker/tests/ts2345_generic_constraint_keyof_any_target_display_tests.rs
@@ -1,0 +1,127 @@
+//! Parity pins for #16751: a TS2345 argument-to-parameter TARGET display for a
+//! generic parameter constrained to `keyof any` / `keyof unknown` /
+//! `keyof never`, or the longhand `string | number | symbol`, must render
+//! structurally, not repainted as the coincidentally-shaped lib alias
+//! `PropertyKey`.
+//!
+//! Sibling of #16610/#16748 (assignment-SOURCE display) and #16630 (TS2344
+//! constraint display): the same `keyof any` / longhand-union degenerate-key
+//! shape resolves eagerly to its fixed key-space union at type-construction
+//! time (tsc's `getIndexType`), carries no `aliasSymbol`, and so must never be
+//! repainted by tsz's reverse type-to-def lookup finding the lib `PropertyKey`
+//! alias for the same structural union. This file covers the TARGET side of a
+//! call-argument mismatch (TS2345) specifically — the one row #16748 did not
+//! reach, since that fix only covered assignment-source display.
+//!
+//! Every expectation verified against pinned `typescript@7.0.2`
+//! (`--noEmit --strict`).
+
+use tsz_checker::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs_code_messages, load_default_lib_files};
+
+/// The single TS2345 message a fixture produces.
+fn ts2345_message(source: &str) -> String {
+    let diagnostics = check_source_with_libs_code_messages(
+        source,
+        "case.ts",
+        CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+        &load_default_lib_files(),
+    );
+    let mut matches: Vec<&(u32, String)> = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 2345)
+        .collect();
+    assert_eq!(
+        matches.len(),
+        1,
+        "expected exactly one TS2345 for this fixture, got {diagnostics:?}"
+    );
+    matches.remove(0).1.clone()
+}
+
+/// The rendered parameter type from a TS2345 message
+/// `Argument of type 'X' is not assignable to parameter of type 'Y'.` — this
+/// returns `Y`.
+fn rendered_parameter(source: &str) -> String {
+    let message = ts2345_message(source);
+    let marker = "is not assignable to parameter of type '";
+    let start = message
+        .find(marker)
+        .unwrap_or_else(|| panic!("unexpected TS2345 shape: {message}"))
+        + marker.len();
+    let rest = &message[start..];
+    let end = rest
+        .rfind('\'')
+        .unwrap_or_else(|| panic!("unexpected TS2345 shape: {message}"));
+    rest[..end].to_string()
+}
+
+#[test]
+fn keyof_any_constraint_renders_structurally() {
+    let source = "function f<K extends keyof any>(k: K): K { return k; }\n\
+                  f(true);\n";
+    assert_eq!(rendered_parameter(source), "string | number | symbol");
+}
+
+#[test]
+fn keyof_unknown_constraint_renders_structurally() {
+    let source = "function f<K extends keyof unknown>(k: K): K { return k; }\n\
+                  f(true);\n";
+    assert_eq!(rendered_parameter(source), "never");
+}
+
+#[test]
+fn keyof_never_constraint_renders_structurally() {
+    let source = "function f<K extends keyof never>(k: K): K { return k; }\n\
+                  f(true);\n";
+    assert_eq!(rendered_parameter(source), "string | number | symbol");
+}
+
+#[test]
+fn longhand_primitive_key_union_constraint_renders_structurally() {
+    let source = "function f<K extends string | number | symbol>(k: K): K { return k; }\n\
+                  f(true);\n";
+    assert_eq!(rendered_parameter(source), "string | number | symbol");
+}
+
+/// Renamed binders and a differently-named function, so the row cannot be
+/// satisfied by anything keyed on the specific `f`/`K` spelling.
+#[test]
+fn renamed_binders_keyof_any_constraint_renders_structurally() {
+    let source = "function wrap<Q extends keyof any>(q: Q): Q { return q; }\n\
+                  wrap(true);\n";
+    assert_eq!(rendered_parameter(source), "string | number | symbol");
+}
+
+/// Negative control: a constraint written as the lib alias `PropertyKey` must
+/// keep rendering the alias name, not the structural union — this row was
+/// already correct on `main` and must not regress.
+#[test]
+fn property_key_alias_constraint_keeps_the_alias_name() {
+    let source = "function f<K extends PropertyKey>(k: K): K { return k; }\n\
+                  f(true);\n";
+    assert_eq!(rendered_parameter(source), "PropertyKey");
+}
+
+/// Negative control: a constraint written as a user alias to the same union
+/// keeps its own name. Exercises the same code path with a non-lib alias to
+/// confirm the fix does not key on `PropertyKey`'s specific `DefId`.
+#[test]
+fn user_key_union_alias_constraint_keeps_the_alias_name() {
+    let source = "type Zed = string | number | symbol;\n\
+                  function f<K extends Zed>(k: K): K { return k; }\n\
+                  f(true);\n";
+    assert_eq!(rendered_parameter(source), "Zed");
+}
+
+/// Arrow-function form of the callee: the constraint lookup walks the
+/// declaration's `type_parameters`, not a `FunctionDeclaration`-only path.
+#[test]
+fn arrow_function_keyof_any_constraint_renders_structurally() {
+    let source = "const f = <K extends keyof any>(k: K): K => k;\n\
+                  f(true);\n";
+    assert_eq!(rendered_parameter(source), "string | number | symbol");
+}


### PR DESCRIPTION
Fixes #16751.

## Structural rule

When a generic parameter's inferred call-argument candidate fails its own constraint, tsc falls back to displaying the constraint itself as the parameter type (`getInferredType`'s constraint-fallback). When that constraint was written as `keyof any` / `keyof unknown` / `keyof never`, or the longhand `string | number | symbol`, tsc's `getIndexType` already resolved it to its fixed key-space union at type-construction time with no `aliasSymbol` attached — the operator/union never reaches `typeToString`. tsz's `format_type_for_assignability_message` reverse type-to-def lookup was repainting that same union with the coincidentally-shaped lib alias `PropertyKey`, through the checker's call-argument display helpers.

This is the TS2345 call-argument **target**-side sibling of #16610/#16748 (assignment-source display, already fixed) and #16630 (TS2344 type-alias-application constraint display, already fixed) — the one row #16748 explicitly left open.

```ts
function f<K extends keyof any>(k: K): K { return k; }
f(true);
// tsc: Argument of type 'boolean' is not assignable to parameter of type 'string | number | symbol'.
// tsz (before): ... parameter of type 'PropertyKey'.
```

## Owner / fix

Two call-argument display sites can substitute a type parameter with its own constraint when the inferred candidate violates it:

1. `generic_call_parameter_alias_display` (`crates/tsz-checker/src/error_reporter/call_errors/display_formatting_property_access.rs`) — the site actually reached for a plain, non-overloaded generic call (confirmed via targeted tracing: this is the one that produced `PropertyKey` for the issue's own repro).
2. `collect_constraint_parameter_display_candidate` (`crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs`) — the overloaded-signature sibling path, reached from `contextual_constraint_parameter_display`.

Both now call a new shared predicate, `written_type_param_constraint_is_degenerate_key_union`, which walks the callee's declaration (function declaration, function expression, arrow function — including one bound through a `const` `VariableDeclaration` initializer) to find the type parameter's own written constraint clause, then reuses the existing `annotation_is_keyof_over_degenerate_operand` / `annotation_is_longhand_primitive_keyword_union` structural predicates (already used by #16748's source-side fix) against that clause. When it matches, the constraint renders through the same anonymous-composite-structural formatter #16748 uses, bypassing the alias reverse-lookup.

A named alias constraint (`K extends PropertyKey`, or a user `type Zed = string | number | symbol; K extends Zed`) is a `TYPE_REFERENCE`, not either degenerate shape, so it's untouched and keeps rendering the alias name — verified as a regression control.

## Adjacent-case matrix

Oracle-verified against pinned `typescript@7.0.2`, all in `crates/tsz-checker/tests/ts2345_generic_constraint_keyof_any_target_display_tests.rs`:

| case | tsc / after |
| --- | --- |
| `K extends keyof any` | `string \| number \| symbol` |
| `K extends keyof unknown` | `never` |
| `K extends keyof never` | `string \| number \| symbol` |
| `K extends string \| number \| symbol` (longhand) | `string \| number \| symbol` |
| renamed binders (`wrap<Q extends keyof any>`) | `string \| number \| symbol` |
| arrow function bound via `const` | `string \| number \| symbol` |
| `K extends PropertyKey` (negative control) | `PropertyKey` (unchanged) |
| `K extends Zed` where `Zed = string \| number \| symbol` (negative control) | `Zed` (unchanged) |

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts2345_generic_constraint_keyof_any_target_display_tests` — 8 passed, 0 failed (new file).
- `cargo test -p tsz-checker --test ts2344_primitive_key_union_alias_constraint_display_tests --test ts2344_keyof_constraint_display_tests --test union_display_alias_repaint_parity_tests` — 12 + 16 passed (4 pre-existing `#[ignore]`d), 0 failed, 0 regressed — confirms the sibling TS2344/source-display families are untouched.
- `cargo test -p tsz-checker --lib generic_call_parameter` — 2 passed, 0 failed.
- `cargo clippy -p tsz-checker --lib --all-features -- -D warnings` — clean.
- `cargo fmt -p tsz-checker -- --check` — clean.
- `python3 scripts/arch/arch_guard.py` — clean.
- Pre-commit hook (clippy + affected-crate tests + arch guard) — passed.
- `cargo test -p tsz-checker --lib` (full ~10.6k-test suite) — running in background at PR-open time; will report the count in a follow-up comment.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_01VVCa9SRtBD1SsgyTWCz8DC)_