### PR TITLE
fix(checker): TS2345 target renders a longhand/keyof-any key-union constraint structurally, not as PropertyKey (#16751)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1539,6 +1539,9 @@ path = "tests/ts2344_keyof_constraint_display_tests.rs"
 name = "ts2344_primitive_key_union_alias_constraint_display_tests"
 path = "tests/ts2344_primitive_key_union_alias_constraint_display_tests.rs"
 [[test]]
+name = "ts2345_key_union_constraint_target_display_tests"
+path = "tests/ts2345_key_union_constraint_target_display_tests.rs"
+[[test]]
 name = "ts2344_conditional_constraint_display_tests"
 path = "tests/ts2344_conditional_constraint_display_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_parameters.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_parameters.rs
@@ -396,6 +396,17 @@ impl<'a> CheckerState<'a> {
     ) -> String {
         let direct_param_display = self.format_type_diagnostic(param_type);
 
+        // A generic call that clamps an un-inferable type parameter to its
+        // constraint reports the argument against the canonical primitive key
+        // union (`string | number | symbol`), which borrows `PropertyKey`'s
+        // alias. tsc strips that alias for a longhand / `keyof any` constraint
+        // but keeps it for `K extends PropertyKey`; recover the written form.
+        if let Some(display) =
+            self.call_argument_key_union_constraint_target_display(arg_idx, param_type)
+        {
+            return display;
+        }
+
         if let Some(display) = self.overloaded_recursive_typeof_parameter_display(param_type) {
             return display;
         }
@@ -836,24 +847,8 @@ impl<'a> CheckerState<'a> {
     }
 
     fn enclosing_call_arg_position(&mut self, arg_idx: NodeIndex) -> Option<(TypeId, usize)> {
-        let mut current = arg_idx;
-        loop {
-            let node = self.ctx.arena.get(current)?;
-            if node.kind == syntax_kind_ext::CALL_EXPRESSION
-                || node.kind == syntax_kind_ext::NEW_EXPRESSION
-            {
-                let call = self.ctx.arena.get_call_expr(node)?;
-                let args = call.arguments.as_ref()?;
-                let arg_pos = args.nodes.iter().position(|&a| a == arg_idx)?;
-                let callee_type = self.get_type_of_node(call.expression);
-                return Some((callee_type, arg_pos));
-            }
-            let ext = self.ctx.arena.get_extended(current)?;
-            if ext.parent.is_none() {
-                return None;
-            }
-            current = ext.parent;
-        }
+        let (callee_expr, arg_pos) = self.enclosing_call_expression_and_arg_pos(arg_idx)?;
+        Some((self.get_type_of_node(callee_expr), arg_pos))
     }
 
     fn expanded_rest_tuple_parameter_display_for_call(

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -10,6 +10,7 @@ mod computed_index_source_display;
 mod contextual_index_display;
 mod direct_source_expression;
 mod generic_source_display;
+mod keyof_constraint_target_display;
 mod keyof_source_display;
 mod literal_surface;
 mod literal_widening_helpers;

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/keyof_constraint_target_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/keyof_constraint_target_display.rs
@@ -1,0 +1,212 @@
+//! Target-side display for a call argument whose reported parameter type is a
+//! type-parameter constraint written as the canonical primitive key union.
+//!
+//! `keyof any` and the longhand `string | number | symbol` both intern to the
+//! one union `TypeId` that also carries `PropertyKey`'s registered `aliasSymbol`
+//! (tsz keeps a single interned union for every spelling, where tsc keys
+//! `getUnionType` on the member list *plus* the alias identity). So when a
+//! generic call clamps an un-inferable type parameter to its constraint and
+//! reports the argument against it (`TS2345`, "not assignable to parameter of
+//! type `…`"), the general target-display path repaints that union as
+//! `PropertyKey` regardless of what the constraint was written as.
+//!
+//! `tsc` strips the `aliasSymbol` here for a longhand / `keyof any` constraint
+//! (which carries none) but keeps it for a constraint written as `PropertyKey`
+//! (or a user alias). This is the target-side sibling of the source-side
+//! `keyof any` handling (`#16748`) and the `TS2344` constraint handling
+//! (`#16630`/`#16663`): the spelling written at the site decides. The written
+//! constraint is recovered structurally from the callee's type-parameter
+//! declaration, so a bare reference (`PropertyKey`, `Zed`) keeps its name and
+//! only a longhand union or a `keyof any`/`keyof never` operand is force-expanded.
+
+use crate::state::CheckerState;
+use tsz_common::interner::AstAtom;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    /// Display override for a `TS2345` target that is a type-parameter
+    /// constraint canonicalized to the primitive key union. Returns the
+    /// structurally-expanded `string | number | symbol` when the written
+    /// constraint at the call site was a longhand union or a `keyof any` /
+    /// `keyof never` operand — neither of which `tsc` stamps with an
+    /// `aliasSymbol` — and `None` (keep the ordinary alias display) otherwise,
+    /// including the `K extends PropertyKey` control and every non-call or
+    /// unresolvable site.
+    pub(in crate::error_reporter) fn call_argument_key_union_constraint_target_display(
+        &mut self,
+        anchor_idx: NodeIndex,
+        target: TypeId,
+    ) -> Option<String> {
+        // Only intervene when the reported parameter type is the canonical
+        // primitive key union — the one shape that borrows `PropertyKey`'s
+        // alias. Everything else renders through the ordinary path unchanged.
+        let evaluated = self.evaluate_type_for_assignability(target);
+        if !self.is_primitive_key_union_type(evaluated) {
+            return None;
+        }
+        let constraint_idx =
+            self.enclosing_call_argument_type_parameter_constraint_node(anchor_idx)?;
+        // A constraint written as a bare reference (`PropertyKey`, a user alias)
+        // keeps its written name through the ordinary alias display path. Only a
+        // longhand primitive-keyword union or a `keyof any`/`keyof never` operand
+        // — the spellings `tsc` renders structurally because neither carries an
+        // `aliasSymbol` — is force-expanded here. Both predicates are the shared
+        // "written structurally, aliasless" AST tests the source surface uses.
+        let written_structurally =
+            Self::annotation_is_longhand_primitive_keyword_union(self.ctx.arena, constraint_idx)
+                || Self::annotation_is_keyof_over_degenerate_operand(
+                    self.ctx.arena,
+                    constraint_idx,
+                );
+        if !written_structurally {
+            return None;
+        }
+        Some(self.format_type_diagnostic_constraint(evaluated))
+    }
+
+    /// Recover the *written* constraint clause of the type parameter standing in
+    /// for the parameter slot that `anchor_idx` (a call argument) fills. Walks
+    /// from the argument to its enclosing call, resolves the callee to a
+    /// function-like declaration, matches the parameter at the argument's
+    /// position to the declaration's type-parameter list by name, and returns
+    /// that type parameter's constraint node.
+    ///
+    /// Read-only: it never lowers or mints a type. It returns `None` for any
+    /// site it cannot resolve structurally (a method / overload callee, a
+    /// parameter whose type is not a bare reference to a type parameter, a
+    /// cross-file or non-function callee), so the ordinary display path stays in
+    /// control there — the override is strictly additive.
+    fn enclosing_call_argument_type_parameter_constraint_node(
+        &self,
+        anchor_idx: NodeIndex,
+    ) -> Option<NodeIndex> {
+        let (callee_expr, arg_pos) = self.enclosing_call_expression_and_arg_pos(anchor_idx)?;
+        let sym_raw = self.resolve_value_symbol_for_lowering(callee_expr)?;
+        // Only a callee declared in the current file is read here: its
+        // declaration nodes and identifier atoms live in `self.ctx.arena`, so
+        // the name-atom match below is valid. A cross-file callee's nodes belong
+        // to another arena and are left to the ordinary display path (`None`).
+        let symbol = self.ctx.binder.get_symbol(tsz_binder::SymbolId(sym_raw))?;
+
+        for &decl_idx in &symbol.declarations {
+            if let Some(constraint_idx) =
+                self.declaration_arg_type_parameter_constraint_node(decl_idx, arg_pos)
+            {
+                return Some(constraint_idx);
+            }
+        }
+        None
+    }
+
+    /// The callee expression node and the zero-based argument position of
+    /// `anchor_idx` within the nearest enclosing call / new expression. Shared
+    /// with `enclosing_call_arg_position`, which layers `get_type_of_node` on
+    /// the callee node to return the callee *type* instead.
+    pub(in crate::error_reporter) fn enclosing_call_expression_and_arg_pos(
+        &self,
+        anchor_idx: NodeIndex,
+    ) -> Option<(NodeIndex, usize)> {
+        let mut current = anchor_idx;
+        loop {
+            let node = self.ctx.arena.get(current)?;
+            if node.kind == syntax_kind_ext::CALL_EXPRESSION
+                || node.kind == syntax_kind_ext::NEW_EXPRESSION
+            {
+                let call = self.ctx.arena.get_call_expr(node)?;
+                let args = call.arguments.as_ref()?;
+                let arg_pos = args.nodes.iter().position(|&a| a == anchor_idx)?;
+                return Some((call.expression, arg_pos));
+            }
+            let ext = self.ctx.arena.get_extended(current)?;
+            if ext.parent.is_none() {
+                return None;
+            }
+            current = ext.parent;
+        }
+    }
+
+    /// For a function-like declaration `decl_idx`, the constraint node of the
+    /// type parameter named by the parameter at `arg_pos` — when that parameter
+    /// is annotated as a bare (no type-argument) reference to one of the
+    /// declaration's own type parameters. `None` for any other shape.
+    fn declaration_arg_type_parameter_constraint_node(
+        &self,
+        decl_idx: NodeIndex,
+        arg_pos: usize,
+    ) -> Option<NodeIndex> {
+        let func_idx = self.function_like_node_for_declaration(decl_idx)?;
+        let func_node = self.ctx.arena.get(func_idx)?;
+        let func = self.ctx.arena.get_function(func_node)?;
+        let type_params = func.type_parameters.as_ref()?;
+
+        let param_idx = *func.parameters.nodes.get(arg_pos)?;
+        let param_node = self.ctx.arena.get(param_idx)?;
+        let param = self.ctx.arena.get_parameter(param_node)?;
+        if param.type_annotation == NodeIndex::NONE {
+            return None;
+        }
+        let annotation_node = self.ctx.arena.get(param.type_annotation)?;
+        if annotation_node.kind != syntax_kind_ext::TYPE_REFERENCE {
+            return None;
+        }
+        let type_ref = self.ctx.arena.get_type_ref(annotation_node)?;
+        if type_ref
+            .type_arguments
+            .as_ref()
+            .is_some_and(|args| !args.nodes.is_empty())
+        {
+            return None;
+        }
+        let param_type_name = self.name_node_atom(type_ref.type_name)?;
+
+        for &tp_idx in &type_params.nodes {
+            let tp_node = self.ctx.arena.get(tp_idx)?;
+            let Some(type_param) = self.ctx.arena.get_type_parameter(tp_node) else {
+                continue;
+            };
+            if type_param.constraint == NodeIndex::NONE {
+                continue;
+            }
+            if self
+                .name_node_atom(type_param.name)
+                .is_some_and(|name| name == param_type_name)
+            {
+                return Some(type_param.constraint);
+            }
+        }
+        None
+    }
+
+    /// The function-like node backing a callee declaration: the declaration
+    /// itself when it is a function declaration / expression / arrow, or the
+    /// initializer of a `const f = <…>(…) => …` / `const f = function <…>(…)`
+    /// variable declaration. `None` for any other declaration shape.
+    fn function_like_node_for_declaration(&self, decl_idx: NodeIndex) -> Option<NodeIndex> {
+        let decl_node = self.ctx.arena.get(decl_idx)?;
+        if self.ctx.arena.get_function(decl_node).is_some() {
+            return Some(decl_idx);
+        }
+        if decl_node.kind == syntax_kind_ext::VARIABLE_DECLARATION {
+            let var_decl = self.ctx.arena.get_variable_declaration(decl_node)?;
+            if var_decl.initializer == NodeIndex::NONE {
+                return None;
+            }
+            let init_node = self.ctx.arena.get(var_decl.initializer)?;
+            if self.ctx.arena.get_function(init_node).is_some() {
+                return Some(var_decl.initializer);
+            }
+        }
+        None
+    }
+
+    /// The interned identifier atom of a plain identifier name node, or `None`
+    /// for any other node kind. Comparing atoms keeps the type-parameter/name
+    /// match O(1) and allocation-free.
+    fn name_node_atom(&self, name_idx: NodeIndex) -> Option<AstAtom> {
+        let name_node = self.ctx.arena.get(name_idx)?;
+        let ident = self.ctx.arena.get_identifier(name_node)?;
+        Some(ident.atom)
+    }
+}

--- a/crates/tsz-checker/tests/ts2345_key_union_constraint_target_display_tests.rs
+++ b/crates/tsz-checker/tests/ts2345_key_union_constraint_target_display_tests.rs
@@ -1,0 +1,123 @@
+//! Parity pins for #16751: a `TS2345` whose reported parameter type is a
+//! type-parameter constraint canonicalized to the primitive key union
+//! (`string | number | symbol`).
+//!
+//! When a generic call cannot infer a valid type argument, `tsc` clamps the
+//! parameter to the type parameter's constraint and reports the argument
+//! against it. A constraint written longhand (`string | number | symbol`) or as
+//! `keyof any` / `keyof never` carries no `aliasSymbol`, so `tsc` renders it
+//! structurally; a constraint written as `PropertyKey` keeps that alias.
+//!
+//! tsz interns one union `TypeId` for every spelling and it carries
+//! `PropertyKey`'s registered alias, so the general target-display path
+//! repainted all four spellings as `PropertyKey`. The fix recovers the *written*
+//! constraint clause from the callee's type-parameter declaration and expands
+//! the union structurally only for the longhand / `keyof`-degenerate spellings,
+//! leaving the `PropertyKey` control (and a user alias such as `Zed`) untouched.
+//! It is the target-side sibling of #16630/#16663 (TS2344 constraint display)
+//! and #16748 (TS2322 `keyof any` source display).
+//!
+//! Every expectation was verified against the pinned oracle
+//! (`typescript@7.0.2`, `--noEmit --strict`), matching the reduction #16748
+//! established for `keyof any` on the source side.
+
+use tsz_checker::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs_code_messages, load_default_lib_files};
+
+/// The rendered parameter type from the single TS2345 message a fixture
+/// produces — `... not assignable to parameter of type 'P'.` returns `P`.
+fn ts2345_parameter_display(source: &str) -> String {
+    let diagnostics = check_source_with_libs_code_messages(
+        source,
+        "case.ts",
+        CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+        &load_default_lib_files(),
+    );
+    let mut matches: Vec<&(u32, String)> = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 2345)
+        .collect();
+    assert_eq!(
+        matches.len(),
+        1,
+        "expected exactly one TS2345 for this fixture, got {diagnostics:?}"
+    );
+    let message = &matches.remove(0).1;
+    let marker = "not assignable to parameter of type '";
+    let start = message
+        .find(marker)
+        .map(|i| i + marker.len())
+        .unwrap_or_else(|| panic!("no parameter clause in {message:?}"));
+    let rest = &message[start..];
+    let end = rest.find('\'').unwrap_or(rest.len());
+    rest[..end].to_string()
+}
+
+#[test]
+fn keyof_any_constraint_renders_structurally() {
+    let source = "function f<K extends keyof any>(k: K): K { return k; }\nf(true);\n";
+    assert_eq!(ts2345_parameter_display(source), "string | number | symbol");
+}
+
+#[test]
+fn longhand_key_union_constraint_renders_structurally() {
+    let source =
+        "function f<K extends string | number | symbol>(k: K): K { return k; }\nf(true);\n";
+    assert_eq!(ts2345_parameter_display(source), "string | number | symbol");
+}
+
+#[test]
+fn keyof_never_constraint_renders_structurally() {
+    // `keyof never` reduces to the same universal key set as `keyof any`.
+    let source = "function f<K extends keyof never>(k: K): K { return k; }\nf(true);\n";
+    assert_eq!(ts2345_parameter_display(source), "string | number | symbol");
+}
+
+#[test]
+fn property_key_constraint_keeps_its_alias() {
+    // Control: a constraint written as the `PropertyKey` alias keeps that name.
+    let source = "function f<K extends PropertyKey>(k: K): K { return k; }\nf(true);\n";
+    assert_eq!(ts2345_parameter_display(source), "PropertyKey");
+}
+
+#[test]
+fn renamed_binder_with_reordered_union_renders_structurally() {
+    // Binder-name and member-order variation: the recovery is keyed on the
+    // written clause, not on the type-parameter spelling `K`.
+    let source = "function pick<Zz extends symbol | string | number>(z: Zz): Zz { return z; }\npick(true);\n";
+    assert_eq!(ts2345_parameter_display(source), "string | number | symbol");
+}
+
+#[test]
+fn second_type_parameter_constraint_renders_structurally() {
+    // The failing argument's parameter maps to the second type parameter; the
+    // recovery matches the parameter slot to its type parameter by name.
+    let source = "function f<A, K extends keyof any>(a: A, k: K): K { return k; }\nf(1, true);\n";
+    assert_eq!(ts2345_parameter_display(source), "string | number | symbol");
+}
+
+#[test]
+fn arrow_function_const_callee_renders_structurally() {
+    // A callee bound to a `const` arrow: the recovery follows the variable
+    // declaration's initializer to the arrow's type parameters.
+    let source = "const f = <K extends keyof any>(k: K): K => k;\nf(true);\n";
+    assert_eq!(ts2345_parameter_display(source), "string | number | symbol");
+}
+
+#[test]
+fn function_expression_const_callee_renders_structurally() {
+    let source = "const f = function <K extends string | number | symbol>(k: K): K { return k; };\nf(true);\n";
+    assert_eq!(ts2345_parameter_display(source), "string | number | symbol");
+}
+
+#[test]
+fn user_alias_key_union_constraint_keeps_its_alias_name() {
+    // A user alias whose body is the key union renders its own name, not
+    // `PropertyKey` and not the structural expansion — the spelling decides.
+    let source = "type Zed = string | number | symbol;\n\
+                  function f<K extends Zed>(k: K): K { return k; }\nf(true);\n";
+    assert_eq!(ts2345_parameter_display(source), "Zed");
+}


### PR DESCRIPTION
Fixes #16751.

**Structural rule.** When a generic call cannot infer a valid type argument, `tsc` clamps the parameter to the type parameter's constraint and reports the argument against it (`TS2345`, "not assignable to parameter of type `…`"). When that constraint is written longhand as `string | number | symbol` or as `keyof any` / `keyof never` — neither of which carries an `aliasSymbol` — `tsc` renders it structurally; a constraint written as `PropertyKey` keeps that alias name. tsz interns **one** union `TypeId` for every spelling and it borrows `PropertyKey`'s registered alias (tsc keys `getUnionType` on the member list *plus* the alias identity; tsz cannot), so the general target-display path in `format_call_parameter_type_for_diagnostic` repainted every spelling as `PropertyKey`.

**Owner layer.** Checker error-reporter display only — no solver / type-construction change. The fix recovers the *written* constraint clause from the callee's type-parameter declaration and expands the union structurally only for the longhand / keyof-degenerate spellings, leaving the `PropertyKey` control and a user alias (`Zed`) untouched. It reuses the shared aliasless-spelling AST predicates (`annotation_is_longhand_primitive_keyword_union`, `annotation_is_keyof_over_degenerate_operand`), the `is_primitive_key_union_type` gate, and the `with_expanded_primitive_key_union` formatter that the sibling surfaces — TS2344 constraint display (#16630 / #16663) and TS2322 `keyof any` source display (#16748) — already use. This PR is the TS2345 **target** sibling. The argument→call ancestor walk is shared with the existing `enclosing_call_arg_position`.

**Adjacent-case matrix** (`f<K extends …>(k: K); f(true)`, verified against the `typescript@7.0.2` reduction #16748 established for `keyof any`):

| constraint as written | before | after (== tsc) |
| --- | --- | --- |
| `keyof any` | `PropertyKey` | `string \| number \| symbol` |
| `string \| number \| symbol` | `PropertyKey` | `string \| number \| symbol` |
| `keyof never` | `PropertyKey` | `string \| number \| symbol` |
| `PropertyKey` (control) | `PropertyKey` | `PropertyKey` (unchanged) |
| renamed binder + reordered union | `PropertyKey` | `string \| number \| symbol` |
| second type parameter | `PropertyKey` | `string \| number \| symbol` |
| `const f = <K extends keyof any>(k: K) => k` | `PropertyKey` | `string \| number \| symbol` |
| `const f = function <K extends …>(k: K)` | `PropertyKey` | `string \| number \| symbol` |
| `type Zed = …; K extends Zed` | `Zed` | `Zed` (unchanged) |

**Fallback.** Any site the recovery cannot resolve structurally (method / overload callee, cross-file callee, a parameter whose annotation is not a bare reference to a type parameter) returns `None` and renders through the ordinary path — the override is strictly additive, so the `PropertyKey` control never regresses.

**Anti-hardcoding.** No user-name / file-name literals drive the logic; classification is structural (AST node kinds `UNION_TYPE` of primitive keywords / keyof-over-`any|unknown|never`, plus the interned key-union shape). No formatted diagnostic string is used as a predicate. Tests vary the binder name (`K`, `Zz`), union member order, parameter position, and callee shape.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts2345_key_union_constraint_target_display_tests` — 9/9 pass (new pins covering the matrix above).
- `cargo test -p tsz-checker --test ts2344_primitive_key_union_alias_constraint_display_tests` — 12/12 pass (sibling surface, no regression).
- Broad call/argument display batch (73 tests): `contextual_ts2345_conformance_tests`, `call_argument_boolean_literal_array_display_tests`, `generic_conflicting_argument_type_display_tests`, `generic_call_primitive_widening_display_tests`, `failed_generic_call_default_type_args_tests`, `index_signature_argument_assignability_tests`, `mapped_type_errors_conformance_tests`, `type_argument_inference_constraints_fingerprint_tests` — all pass (exercise the shared `enclosing_call_arg_position` core the `/simplify` dedup re-pointed).
- `cargo clippy -p tsz-checker --lib --tests` — clean; commit's local verification hook (clippy + arch-guard) passed.
- Conformance: display-only, strictly-additive change — the emitted diagnostic **code** and span are unchanged (still `TS2345` at the argument), and the message text only moves *closer* to the oracle (`PropertyKey` → `string | number | symbol`), so neither the code-set/count metric nor a message comparison can regress.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGyUsZGN33b38AqaruCxa4)_