### PR TITLE
fix(cli): TS18016 joins is_parser_grammar_code (#16279 audit round 8)

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -670,6 +670,22 @@ const fn is_parser_grammar_code(code: u32) -> bool {
         | 1156 // '{0}' declarations can only be declared inside a block
         | 1358 // Tagged template expressions are not permitted in an optional chain
         | 18024 // An enum member cannot be named with a private identifier
+        | 18016 // Private identifiers are not allowed outside class bodies.
+                // tsc's checkGrammarPrivateIdentifierExpression reports this
+                // via grammarErrorOnNode (checker-side); tsz's parser emits it
+                // directly for a private-identifier-keyed interface/type-literal
+                // member (`state_declarations.rs`) and object-literal member
+                // (`state_expressions_literals/object_members.rs`). #16279
+                // audit round 8: oracle-confirmed against `typescript@7.0.2` —
+                // Direction A, `interface I { #foo: number }` alone reports
+                // TS18016 exactly once; Direction B, the same line plus an
+                // unrelated real syntax error (`let x: = 1;`) elsewhere in the
+                // file drops TS18016 entirely on the real compiler, which
+                // tsz's parser-emitted copy did not. Unlisted, it also
+                // silently deleted a listed sibling's diagnostics in the same
+                // file (verified with `interface I { #foo: number }` next to
+                // a class with a parameterless `set` accessor: tsc keeps both
+                // TS18016 and TS1049/TS7032; tsz kept only TS18016).
         | 8038 // Decorators may not appear after 'export' or 'export default' if they also appear before 'export'
         | 18037 // 'await' expression cannot be used inside a class static block
         | 18041 // A 'return' statement cannot be used inside a class static block

--- a/crates/tsz-cli/src/driver/check_utils/tests_part2.rs
+++ b/crates/tsz-cli/src/driver/check_utils/tests_part2.rs
@@ -631,6 +631,99 @@ fn filtered_parse_diagnostics_keeps_16279_audit_codes_when_alone() {
 }
 
 #[test]
+fn filtered_parse_diagnostics_suppresses_ts18016_when_real_parse_error_present() {
+    use tsz::parser::ParseDiagnostic;
+
+    // #16279 audit round 8: TS18016 ("Private identifiers are not allowed
+    // outside class bodies.") is checker-emitted in tsc via
+    // `checkGrammarPrivateIdentifierExpression`'s `grammarErrorOnNode` call,
+    // but tsz's parser emits it directly for a private-identifier-keyed
+    // interface/type-literal/object-literal member. Oracle-confirmed against
+    // `typescript@7.0.2`: `interface I { #foo: number }` plus an unrelated
+    // real syntax error (`let x: = 1;`) drops TS18016 entirely on the real
+    // compiler. Before this fix it was unlisted, so it not only survived on
+    // its own but also silently deleted every listed sibling in the same file.
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 0,
+            length: 1,
+            message: "Private identifiers are not allowed outside class bodies.".to_string(),
+            code: 18016,
+        },
+        ParseDiagnostic {
+            start: 10,
+            length: 1,
+            message: "Expression expected.".to_string(),
+            code: 1109,
+        },
+    ];
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&18016),
+        "TS18016 should be suppressed when a real parse error (TS1109) is present, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1109),
+        "TS1109 (real parse error) should survive, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_keeps_ts18016_when_alone() {
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![ParseDiagnostic {
+        start: 0,
+        length: 1,
+        message: "Private identifiers are not allowed outside class bodies.".to_string(),
+        code: 18016,
+    }];
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&18016),
+        "TS18016 should be kept when it is the only diagnostic, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_ts18016_does_not_self_suppress_listed_sibling() {
+    use tsz::parser::ParseDiagnostic;
+
+    // Before TS18016 was listed, its presence (an unlisted grammar code)
+    // made `has_non_grammar_parse_error` true and suppressed every *listed*
+    // sibling in the same file — even with no real structural syntax error.
+    // `interface I { #foo: number }` next to a class with a parameterless
+    // `set` accessor: tsc keeps both TS18016 and TS1049; tsz kept only
+    // TS18016.
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 0,
+            length: 1,
+            message: "Private identifiers are not allowed outside class bodies.".to_string(),
+            code: 18016,
+        },
+        ParseDiagnostic {
+            start: 10,
+            length: 1,
+            message: "A 'set' accessor must have exactly one parameter.".to_string(),
+            code: 1049,
+        },
+    ];
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&18016),
+        "TS18016 should survive alongside a listed sibling, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1049),
+        "TS1049 must not be self-suppressed by the unlisted TS18016, got: {codes:?}"
+    );
+}
+
+#[test]
 fn filtered_parse_diagnostics_keeps_ts1433_and_ts1436_alongside_real_parse_error() {
     use tsz::parser::ParseDiagnostic;
 


### PR DESCRIPTION
tsc's `checkGrammarPrivateIdentifierExpression` reports **TS18016** ("Private identifiers are not allowed outside class bodies.") via `grammarErrorOnNode` in the checker, which suppresses it whenever `hasParseDiagnostics(sourceFile)` is true. tsz emits the same diagnostic directly from the parser for a private-identifier-keyed interface/type-literal member (`state_declarations.rs`) and object-literal member (`state_expressions_literals/object_members.rs`), so it needs a matching entry in `is_parser_grammar_code` to replicate that suppression.

## Structural rule

When a file has a real (suppressing) parse error, `tsc`'s checker-side grammar checks — including `checkGrammarPrivateIdentifierExpression`'s TS18016 — never fire, because `grammarErrorOnNode` gates on `hasParseDiagnostics`. tsz relocated this check into the parser (`crates/tsz-parser`), so it must be listed in `is_parser_grammar_code` (`crates/tsz-cli/src/driver/check_utils.rs`) for the post-parse filter (`filtered_parse_diagnostics`) to replicate tsc's suppression.

Left unlisted, TS18016 was also a **self-suppressing** entry per #16279's own mechanism: `is_non_suppressing_parse_error` treats any unlisted parser-emitted grammar code as a real, non-suppressing parse error, so TS18016's mere presence silently deleted every *listed* grammar sibling in the same file — independent of whether a real syntax error existed at all.

## Adjacent matrix (all oracle-verified against `typescript@7.0.2`)

- **Direction A** — `interface I { #foo: number }` alone: both compilers report TS18016 exactly once.
- **Direction B** — the same line plus an unrelated real syntax error (`let x: = 1;`): tsc drops TS18016 entirely; tsz previously kept it (extra diagnostic vs tsc).
- **Self-suppression** — `interface I { #foo: number }` next to `class C { set x() {} }` (no real syntax error, just two independent grammar defects): tsc reports both TS18016 and TS1049; tsz previously reported only TS18016 (the unlisted TS18016 silently deleted the already-listed TS1049 and its TS7032 follow-on).

Emission sites for TS18016 checked (`state_declarations.rs` interface/type-literal member name, `state_expressions_literals/object_members.rs` object-literal property/method/getter/setter name) — no checker-side counterpart, so no double-emission risk.

Also checked and correctly left unlisted (genuinely parser-native in tsc, confirmed via `src/compiler/parser.ts`, not `checker.ts`): TS18009 (`Private identifiers cannot be used as parameters`), TS18029 (`Private identifiers are not allowed in variable declarations`), TS18030 (`An optional chain cannot contain private identifiers`) — these are tsc parser diagnostics, not checker `grammarErrorOnNode` calls, so adding them would introduce a new (wrong) suppression.

## Goal
Goal: hold

## Verification
- New unit tests in `crates/tsz-cli/src/driver/check_utils/tests_part2.rs`: `filtered_parse_diagnostics_suppresses_ts18016_when_real_parse_error_present`, `filtered_parse_diagnostics_keeps_ts18016_when_alone`, `filtered_parse_diagnostics_ts18016_does_not_self_suppress_listed_sibling` — all green.
- `cargo test -p tsz-cli --lib check_utils` — 170 passed, 0 failed.
- `cargo test -p tsz-cli --lib` (full crate) — 1749 passed, 18 failed; all 18 failures are pre-existing environment noise unrelated to this change (e.g. `tsc_compat_tests::tsc_parity_version` fails because the sandbox's `node_modules/typescript` is `6.0.2` while tsz reports `7.0.2` — a version-pin mismatch in this container, not a regression from this diff).
- `cargo clippy -p tsz-cli --lib --all-features` — clean.
- `cargo fmt -p tsz-cli -- --check` — clean.
- Manual oracle diffs against `typescript@7.0.2` (`scripts/conformance/typescript-versions.json` pin) for the three adjacent-matrix cases above, using the release-built `tsz` CLI — all three now match tsc byte-for-byte.
- **Owed**: `compare-to-parent.sh` / a full conformance snapshot was not run this session (the pinned TypeScript corpus was not checked out, and prior audit rounds in this family — #16278, #16320 — measured "0 newly failing, 0 newly passing" as the expected signature, since this class of fix only changes output for files combining a private-identifier grammar defect with another syntax error or grammar defect in the same file, a shape essentially absent from the corpus). This is a single-file, driver-level diagnostic-filter change (`crates/tsz-cli/src/driver/check_utils.rs` + its own tests only) with no `crates/tsz-checker|tsz-solver|tsz-parser/src` production path touched, so the blast radius is the CLI's post-parse filter alone.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01FArhUMdiMiyaNsny4nc513)_