### PR TITLE
fix(solver): keyof over a well-known-symbol-keyed interface reduces to the well-known symbol (#16605), without losing SymbolConstructor's name

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -25,6 +25,96 @@ impl CheckerState<'_> {
         true
     }
 
+    /// Eagerly seed the well-known-symbol name registry from the global
+    /// `Symbol` (`SymbolConstructor`) declaration.
+    ///
+    /// The canonical `[Symbol.xxx]` object-shape key and the `UniqueSymbol(ref)`
+    /// that `typeof Symbol.xxx`/`keyof`/indexed-access produce round-trip through
+    /// this registry on the solver's `TypeResolver`. The per-member
+    /// computed-name resolution path also populates it, but lazily — as each
+    /// `[Symbol.xxx]`-keyed member is resolved. A `keyof`/indexed-access
+    /// evaluated *before* that member pass (e.g. a `type K = keyof I` alias
+    /// resolved while building the type environment, ahead of `I`'s member pass)
+    /// reads an empty registry, caches the wrong (string-literal) key, and never
+    /// reduces to the well-known symbol. Seeding the canonical lib-declared
+    /// members up front removes that ordering dependence.
+    ///
+    /// The registered `SymbolRef` is read from each member's own type
+    /// (`readonly iterator: unique symbol` is `typeof Symbol.iterator`), so it is
+    /// exactly the ref a use-site `typeof Symbol.iterator` resolves to — the two
+    /// `UniqueSymbol` type ids are then identical. The registry is a field of the
+    /// per-file `type_env`, so the seed runs per file.
+    fn seed_well_known_symbol_names(&mut self) {
+        let Some(symbol_ctor_sym) =
+            crate::types_domain::queries::lib_resolution::resolve_name_to_lib_symbol(
+                "SymbolConstructor",
+                self.ctx.binder,
+                self.ctx.global_file_locals_index.as_deref(),
+                self.ctx
+                    .all_binders
+                    .as_ref()
+                    .map(|binders| binders.as_ref().as_slice()),
+                &self.ctx.lib_contexts,
+            )
+        else {
+            return;
+        };
+        let symbol_ctor_type = self.type_reference_symbol_type(symbol_ctor_sym);
+        let symbol_ctor_resolved = self.resolve_lazy_type(symbol_ctor_type);
+        // Eagerly evaluating `SymbolConstructor` here — ahead of the normal
+        // `declare var Symbol: SymbolConstructor` annotation check that would
+        // otherwise perform this same resolution first — must not cost the
+        // diagnostic printer its "SymbolConstructor" display name. A
+        // property-access failure on `Symbol` (e.g. `Symbol.nonsense`) shows
+        // the source-text annotation instead of the expanded structural type
+        // only when `TypeDatabase::get_display_alias` has an entry for the
+        // resolved type (`property_receiver_display_for_node` in
+        // `error_reporter/properties.rs`). Record that provenance explicitly so
+        // this pre-pass wins the race safely instead of leaving it to whichever
+        // caller happens to resolve the reference first — otherwise the
+        // structural intersection prints in full instead of `SymbolConstructor`
+        // (regressed `conformance/es6/Symbols/symbolProperty52.ts` and two
+        // sibling ES5-parser rows in #16628, reverted in #16764).
+        if symbol_ctor_resolved != symbol_ctor_type {
+            self.ctx
+                .types
+                .store_display_alias(symbol_ctor_resolved, symbol_ctor_type);
+        }
+        let tsz_solver::objects::PropertyCollectionResult::Properties { properties, .. } =
+            tsz_solver::objects::collect_properties(
+                symbol_ctor_resolved,
+                self.ctx.types,
+                &self.ctx,
+            )
+        else {
+            return;
+        };
+        // A well-known member is typed `unique symbol`; its property type carries
+        // the same `UniqueSymbol(ref)` a use-site `typeof Symbol.<name>` resolves
+        // to. Its bare member name (`iterator`) is the `[Symbol.iterator]`
+        // object-shape key. Ordinary members and augmented plain-`symbol` members
+        // carry no unique-symbol ref and are skipped, matching tsc treating them
+        // as ordinary named members rather than well-known symbols.
+        let registrations: Vec<(String, tsz_solver::SymbolRef)> = properties
+            .iter()
+            .filter_map(|prop| {
+                let name = self.ctx.types.resolve_atom_ref(prop.name);
+                if name.starts_with("[Symbol.") || name.starts_with("__") {
+                    return None;
+                }
+                let sym_ref = crate::query_boundaries::common::unique_symbol_ref(
+                    self.ctx.types,
+                    prop.type_id,
+                )?;
+                Some((format!("[Symbol.{name}]"), sym_ref))
+            })
+            .collect();
+        for (name, sym_ref) in registrations {
+            self.ctx
+                .register_well_known_symbol_name_in_envs(name, sym_ref);
+        }
+    }
+
     fn prepare_source_file_for_checking(&mut self, root_idx: NodeIndex) -> Option<NodeIndex> {
         // Reset per-file flags
         self.ctx.is_in_ambient_declaration_file = false;
@@ -77,6 +167,11 @@ impl CheckerState<'_> {
         if !self.ctx.definition_store.is_fully_populated() {
             self.ctx.resolve_cross_batch_heritage();
         }
+
+        // Seed the well-known-symbol name registry from the lib `Symbol`
+        // members before the environment build eagerly evaluates (and caches)
+        // `keyof`/indexed-access type aliases over well-known-symbol keys.
+        self.seed_well_known_symbol_names();
 
         // Build TypeEnvironment with all type-defining symbols.
         // This populates both ctx.type_env and ctx.type_environment in-place

--- a/crates/tsz-checker/tests/well_known_symbol_syntactic_key_parity_tests.rs
+++ b/crates/tsz-checker/tests/well_known_symbol_syntactic_key_parity_tests.rs
@@ -181,14 +181,26 @@ export const t: { [k: symbol]: number } = i;
 // ---------------------------------------------------------------------------
 
 #[test]
-#[ignore = "known failure: keyof over a well-known-symbol-keyed interface does not reduce to the well-known symbol (false TS2322)"]
 fn keyof_a_well_known_symbol_keyed_interface_reduces_to_the_well_known_symbol() {
     // tsc 7.0.2: exit 0 — `keyof I` IS `typeof Symbol.iterator`.
-    // tsz today: TS2322 "Type 'keyof I' is not assignable to type 'unique symbol'."
     //
-    // The equivalent shape keyed by a user-authored `unique symbol` binding
-    // (`declare const u: unique symbol; interface I { [u]: number }`) is
-    // already clean, so the gap is specific to the well-known leg.
+    // A well-known-symbol-keyed member is a *named* member (`is_symbol_named`
+    // is false) stored under its canonical `[Symbol.iterator]` atom, so `keyof`
+    // took the literal-key branch and produced the string literal
+    // `"[Symbol.iterator]"` instead of `typeof Symbol.iterator`. `keyof` now
+    // recovers the unique-symbol key for such a named key through the
+    // well-known-symbol registry, which is seeded from the lib `SymbolConstructor`
+    // members up front so the registry is populated before the alias is
+    // evaluated. The equivalent shape keyed by a user-authored `unique symbol`
+    // binding (`declare const u: unique symbol; interface I { [u]: number }`)
+    // was already clean; this closes the well-known leg.
+    //
+    // First landed as #16628, reverted as #16764 because seeding the registry
+    // eagerly (via `collect_properties` over `SymbolConstructor`'s resolved
+    // type) cost the `SymbolConstructor` display name on unrelated `TS2339`
+    // property-lookup failures — see
+    // `well_known_symbol_property_lookup_failure_keeps_symbol_constructor_name`
+    // below, the regression this reland must not reintroduce (#16765).
     let codes = diagnostic_codes(
         r#"
 interface I { [Symbol.iterator]: number }
@@ -204,6 +216,46 @@ export const a: typeof Symbol.iterator = k;
     );
 }
 
+// Pins #16765's acceptance criterion 4: a `TS2339` property-lookup failure on
+// `Symbol` (typed `SymbolConstructor`) must keep showing the alias name, not
+// the structural intersection `SymbolConstructor`'s per-file lib declarations
+// merge into. `seed_well_known_symbol_names` (called from
+// `prepare_source_file_for_checking`, ahead of the normal environment build)
+// resolves and collects `SymbolConstructor`'s properties eagerly; without
+// explicitly re-recording that resolution's display-alias provenance, whichever
+// caller reaches `SymbolConstructor` first "wins" the alias registration, and
+// losing that race prints ~400 characters of merged interface shape instead of
+// one word. This is a rendered-message assertion, deliberately narrower than
+// `diagnostic_codes` — the corpus regression in #16628/#16764 had an identical
+// diagnostic *code* set on both sides of the bug, so a code-only assertion here
+// would not have caught it.
+#[test]
+fn well_known_symbol_property_lookup_failure_keeps_symbol_constructor_name() {
+    use tsz_checker::test_utils::check_source_with_libs_code_messages;
+    let libs = load_default_lib_files();
+    let diags = check_source_with_libs_code_messages(
+        r#"
+Symbol.nonsense;
+"#,
+        "test.ts",
+        CheckerOptions::default(),
+        &libs,
+    );
+    let messages: Vec<&str> = diags.iter().map(|(_, m)| m.as_str()).collect();
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("does not exist on type 'SymbolConstructor'")),
+        "TS2339 on `Symbol.<unknown>` must name 'SymbolConstructor', not its \
+         expanded structural shape; got: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("readonly iterator")),
+        "must not leak SymbolConstructor's merged structural shape into the \
+         message; got: {messages:?}"
+    );
+}
+
 #[test]
 #[ignore = "known failure: indexed access by a well-known symbol type leaks the __unique_N placeholder (TS2339/TS2538)"]
 fn indexed_access_by_a_well_known_symbol_type_resolves_the_member() {
@@ -213,6 +265,15 @@ fn indexed_access_by_a_well_known_symbol_type_resolves_the_member() {
     //   TS2339 "Property '__unique_5' does not exist on type 'I'."
     //   TS2538 "Type 'unique symbol' cannot be used as an index type."
     //   TS2322 "Type 'undefined' is not assignable to type 'number'."
+    //
+    // The forward direction (this member's `keyof` key) is fixed; the reverse
+    // direction here (`typeof Symbol.iterator` = `UniqueSymbol(ref)` back to the
+    // `[Symbol.iterator]` atom to find the member) reads the lazily-populated
+    // reverse index, which is still empty when this type alias is evaluated.
+    // It cannot be seeded eagerly like the forward index without regressing the
+    // reverse lookup, because several well-known members share one `SymbolRef`
+    // (lib cross-file `SymbolId` collision), so the reverse map would become
+    // ambiguous. Closing this needs globally-unique lib `SymbolId`s.
     let codes = diagnostic_codes(
         r#"
 interface I { [Symbol.iterator]: number }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs
@@ -257,12 +257,36 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         }
     }
 
+    /// The unique-symbol key type for a member stored under a well-known
+    /// `[Symbol.xxx]` text key (`Symbol.iterator`, `Symbol.asyncIterator`, …).
+    ///
+    /// A well-known-symbol-keyed member is a *named* member, not a symbol index
+    /// signature, so it carries `is_symbol_named = false` and is stored under its
+    /// canonical `[Symbol.xxx]` atom rather than a synthetic `__unique_N`
+    /// placeholder. `keyof` must nonetheless contribute the unique-symbol key
+    /// `typeof Symbol.xxx` for it — `keyof { [Symbol.iterator]: T }` is
+    /// `typeof Symbol.iterator` in `tsc`, not the string literal
+    /// `"[Symbol.iterator]"`. The registered `SymbolRef` is the same canonical
+    /// `SymbolConstructor` member ref that `typeof Symbol.xxx` resolves to, so
+    /// the two `UniqueSymbol` type ids are identical.
+    fn well_known_named_key_unique_symbol(&self, name: Atom) -> Option<TypeId> {
+        let name_text = self.interner().resolve_atom_ref(name);
+        if !name_text.starts_with("[Symbol.") {
+            return None;
+        }
+        let symbol_ref = self.resolver().resolve_well_known_symbol_name(&name_text)?;
+        Some(self.interner().unique_symbol(symbol_ref))
+    }
+
     fn property_name_to_key_type(&self, prop: &PropertyInfo) -> TypeId {
         if prop.is_symbol_named {
             if let Some(symbol_ref) = self.unique_symbol_ref_from_symbol_named_atom(prop.name) {
                 return self.interner().unique_symbol(symbol_ref);
             }
             return TypeId::SYMBOL;
+        }
+        if let Some(unique) = self.well_known_named_key_unique_symbol(prop.name) {
+            return unique;
         }
         // `keyof { 1: ... }` yields the *numeric* literal `1`, not `"1"`.
         // The bare-numeric-name vs string-quoted distinction is the same
@@ -283,6 +307,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 return self.interner().unique_symbol(symbol_ref);
             }
             return TypeId::SYMBOL;
+        }
+        if let Some(unique) = self.well_known_named_key_unique_symbol(key.name) {
+            return unique;
         }
         crate::utils::literal_key_for_property_name(self.interner(), key.name, key.is_string_named)
     }


### PR DESCRIPTION
Relands #16628, which was reverted in #16764 for costing 3 conformance rows. Fixes #16605 and closes #16765 (the reland-tracking issue, with its acceptance criteria all covered below).

## Structural rule

When a member is keyed by a well-known symbol, `tsc` contributes the `UniqueSymbol` key `typeof Symbol.xxx` to `keyof`; tsz produced the string literal `"[Symbol.xxx]"` instead, through the solver's `keyof` evaluation (unchanged from #16628):

A well-known-symbol-keyed member is a **named** member, not a symbol index signature (the #16307/#16604 rule), so it carries `is_symbol_named = false` and is stored under its canonical `[Symbol.iterator]` atom rather than a synthetic `__unique_N` placeholder. `property_name_to_key_type`/`synthetic_property_key_to_key_type` now recover the unique-symbol key for a well-known named key from the well-known-symbol registry (`resolve_well_known_symbol_name`), seeded from the lib `SymbolConstructor` members before the environment build so a `keyof` alias evaluated ahead of the per-member computed-name pass still sees it.

## What #16628 got wrong, and the fix

Seeding the registry means resolving and collecting `SymbolConstructor`'s properties (`collect_properties`) during `prepare_source_file_for_checking`, **ahead of** the normal `declare var Symbol: SymbolConstructor` annotation check that would otherwise resolve it first. `property_receiver_display_for_node` (`error_reporter/properties.rs`) only prefers the source-text annotation ("SymbolConstructor") over the expanded structural type when `TypeDatabase::get_display_alias` has an entry for the resolved type — and #16628 lost that entry by winning the resolution race without recording the provenance the normal path would have, so `Symbol.nonsense`-style `TS2339` failures printed ~400 characters of merged lib-interface shape instead of one word.

`seed_well_known_symbol_names` now explicitly calls `store_display_alias(resolved, symbol_ctor_type)` itself, recording that provenance regardless of which caller resolves the reference first — the same pattern `evaluate_application_type` and a dozen other call sites in this codebase use to preserve a name over its expansion.

## #16765 acceptance criteria

1. `interface I { [Symbol.iterator]: number }`, `const k: string = null as any as K` reports `TS2322` — `keyof_a_well_known_symbol_keyed_interface_reduces_to_the_well_known_symbol` (un-ignored).
2. `Symbol.asyncIterator` in the same shape keeps reporting — unaffected by this change (different code path, `well_known_unique_symbols_are_conflated` pins the pre-existing conflation this doesn't touch).
3. A `unique symbol`-keyed interface and a string-keyed interface both keep their current behaviour — `well_known_keyed_interface_is_not_assignable_to_a_symbol_index_signature`, `wide_symbol_read_against_a_plain_named_interface_reports_ts7053` (unchanged, still green).
4. `Symbol.nonsense` on `SymbolConstructor` renders `'SymbolConstructor'`, not the expansion — new test `well_known_symbol_property_lookup_failure_keeps_symbol_constructor_name`, a rendered-message assertion (deliberately narrower than the `diagnostic_codes` helper the rest of this file uses, since the #16628 regression had an **identical code set** on both sides of the bug — only the message text differed, so a code-only assertion would not have caught it).
5. Verified by conformance set-difference against a freshly generated baseline, not code set/count — see Verification below.

## Scope / what stays open

The **indexed-access** row of #16605 (`I[typeof Symbol.iterator]` leaking `__unique_N`) stays `#[ignore]`d: a lib cross-file `SymbolId` collision (`iterator`/`asyncIterator`/`hasInstance` all resolve to the same `SymbolRef`) makes the *reverse* direction (`UniqueSymbol(ref)` → `[Symbol.xxx]` atom) ambiguous to seed eagerly. Closing it needs globally-unique lib `SymbolId`s (the #15983 class), left to that infra work.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test well_known_symbol_syntactic_key_parity_tests` — **9 passed, 1 ignored** (up from 8/1 pre-reland: the keyof row is un-ignored and the new `SymbolConstructor`-name pin is added).
- `cargo clippy -p tsz-solver -p tsz-checker --all-targets --all-features` — clean; pre-commit clippy + arch-size guard passed on the actual commit.
- Direct binary repro on the regression's own fixture, built at this branch's head: `Symbol.nonsense` (`TypeScript/tests/cases/conformance/es6/Symbols/symbolProperty52.ts`) → `error TS2339: Property 'nonsense' does not exist on type 'SymbolConstructor'.` — matches tsc exactly.
- `scripts/conformance/conformance.sh snapshot --workers 12 --force` at this branch's head (`49b97c6106` base): **12043 runnable, 11523 passed (95.7%)**. Set-difference against a freshly saved pre-#16628 baseline: **0 regressions** (the 3 `SymbolConstructor`-display rows #16764 flagged — `symbolProperty52.ts`, `parserES5SymbolProperty4.ts`, `parserES5SymbolProperty5.ts` — all pass again) plus 26 unrelated rows newly passing from other main progress since that baseline was cut. One pre-existing, unrelated failure (`arbitraryModuleNamespaceIdentifiers_syntax.ts`, a `TS1003` parser message-text mismatch on arbitrary-module-namespace-identifier syntax — nothing to do with `Symbol`/`SymbolConstructor`) was present in both the buggy and fixed builds; not touched by this PR.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqXyTzbWuWVUbrN1YiGDCe)_