### PR TITLE
fix(checker): route private-brand mismatch elaboration into TS2345 argument path

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -197,6 +197,60 @@ impl<'a> CheckerState<'a> {
         }
         let analysis = self.analyze_assignability_failure(arg_type, param_type);
 
+        // A private/`#`-private brand mismatch between argument and parameter
+        // is a nominal-identity failure, not a structural one: tsc's
+        // `checkTypeRelatedTo` attaches the "separate declarations of a
+        // private property" (modifier-`private`/`protected`) or "refers to a
+        // different member" (`#`-private) detail as an elaboration under the
+        // TS2345 head, ahead of the generic structural-property rendering
+        // below. This mirrors the assignment-statement path's
+        // `private_brand_mismatch_error` interception in
+        // `error_reporter/assignability.rs`.
+        if let Some(detail) = self.private_brand_mismatch_error(arg_type, param_type) {
+            let Some(anchor) = self.resolve_diagnostic_anchor(idx, DiagnosticAnchorKind::Exact)
+            else {
+                return;
+            };
+            let arg_str = self.format_type_for_diagnostic_role(
+                arg_type,
+                DiagnosticTypeDisplayRole::CallArgument {
+                    parameter: param_type,
+                    argument_idx: idx,
+                },
+            );
+            let param_str = self.format_type_for_diagnostic_role(
+                param_type,
+                DiagnosticTypeDisplayRole::CallParameter {
+                    argument: arg_type,
+                    argument_idx: idx,
+                },
+            );
+            let (code, msg_template) =
+                self.argument_not_assignable_code_and_template(arg_type, param_type);
+            let message = format_message(msg_template, &[&arg_str, &param_str]);
+            let related = vec![DiagnosticRelatedInformation {
+                category: DiagnosticCategory::Error,
+                code,
+                file: self.ctx.file_name.clone(),
+                start: anchor.start,
+                length: anchor.length,
+                message_text: detail,
+                depth: 0,
+                kind: RelatedInformationKind::ChainLink,
+            }];
+            self.emit_render_request_at_anchor(
+                anchor,
+                DiagnosticRenderRequest::with_related(
+                    DiagnosticAnchorKind::Exact,
+                    code,
+                    message,
+                    related,
+                    RelatedInformationPolicy::ELABORATION,
+                ),
+            );
+            return;
+        }
+
         // tsc promotes a sole missing-required-property failure to the PRIMARY
         // diagnostic at the argument node — TS2741 (one property), TS2739
         // (2-5), TS2740 (more) replace the generic TS2345 head

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -919,6 +919,8 @@ mod ts2323_variable_redeclaration_two_pass_tests;
 mod ts2339_js_this_function_name_display_tests;
 #[path = "tests/ts2341_private_access_via_type_param_constraint_tests.rs"]
 mod ts2341_private_access_via_type_param_constraint_tests;
+#[path = "tests/ts2345_private_brand_argument_elaboration_tests.rs"]
+mod ts2345_private_brand_argument_elaboration_tests;
 #[path = "tests/ts2353_generic_constraint_tests.rs"]
 mod ts2353_generic_constraint_tests;
 #[path = "tests/ts2383_overload_flag_agreement_tests.rs"]

--- a/crates/tsz-checker/src/tests/ts2345_private_brand_argument_elaboration_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2345_private_brand_argument_elaboration_tests.rs
@@ -1,0 +1,138 @@
+//! Regression tests for #16769 leg 1: the call-argument (`TS2345`) path
+//! dropping the nominal private-member elaboration that the
+//! assignment-statement path already attaches.
+//!
+//! Structural rule (pinned against `typescript@7.0.2`, `--noEmit --strict`):
+//! when a call argument fails to satisfy a parameter solely because the two
+//! types have distinct nominal private brands, tsc's `checkTypeRelatedTo`
+//! attaches the same "separate declarations of a private property" (`TS2442`
+//! wording, modifier-`private`) / "refers to a different member" (`TS18015`
+//! wording, `#`-private) elaboration under the `TS2345` head that the
+//! assignment-statement path already gets via
+//! `error_reporter/assignability.rs`'s `private_brand_mismatch_error`
+//! interception. tsz now routes the same detail into
+//! `error_reporter/call_errors/error_emission.rs`'s
+//! `error_argument_not_assignable_at_impl`.
+
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::check_source_diagnostics;
+use tsz_common::diagnostics::diagnostic_codes;
+
+const TS2345: u32 = diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE;
+
+fn only(diags: &[Diagnostic], code: u32) -> Diagnostic {
+    let matching: Vec<_> = diags.iter().filter(|d| d.code == code).collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected exactly one TS{code}; got {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+    matching[0].clone()
+}
+
+/// Modifier-`private` members with the same name on unrelated classes:
+/// `TS2345` elaborated with the `TS2442`-worded "separate declarations" line.
+#[test]
+fn modifier_private_argument_mismatch_carries_separate_declarations_elaboration() {
+    let source = r#"
+class M2 { private s = 1; }
+class N2 { private s = 1; }
+declare function g(n: N2): void;
+g(new M2());
+"#;
+    let diags = check_source_diagnostics(source);
+    let diag = only(&diags, TS2345);
+    assert_eq!(
+        diag.message_text,
+        "Argument of type 'M2' is not assignable to parameter of type 'N2'."
+    );
+    assert_eq!(diag.related_information.len(), 1);
+    assert_eq!(
+        diag.related_information[0].message_text,
+        "Types have separate declarations of a private property 's'."
+    );
+}
+
+/// ES `#`-private members with the same spelling on unrelated classes:
+/// `TS2345` elaborated with the `TS18015` wording instead.
+#[test]
+fn es_private_argument_mismatch_carries_refers_to_different_member_elaboration() {
+    let source = r#"
+class Alpha { #s = 1; }
+class Beta { #s = 1; }
+declare function takeBeta(n: Beta): void;
+takeBeta(new Alpha());
+"#;
+    let diags = check_source_diagnostics(source);
+    let diag = only(&diags, TS2345);
+    assert_eq!(
+        diag.message_text,
+        "Argument of type 'Alpha' is not assignable to parameter of type 'Beta'."
+    );
+    assert_eq!(diag.related_information.len(), 1);
+    assert_eq!(
+        diag.related_information[0].message_text,
+        "Property '#s' in type 'Alpha' refers to a different member that cannot be accessed from within type 'Beta'."
+    );
+}
+
+// NOTE: a `protected`-only witness (`class M3 { protected s = 1; }` vs.
+// `class N3 { protected s = 1; }`) is deliberately not covered here.
+// `private_brand_mismatch_error`'s protected branch renders "Types have
+// separate declarations of a protected property" for that shape on BOTH the
+// pre-existing assignment path (`error_reporter/assignability.rs`) and this
+// PR's new argument path, but the pinned `typescript@7.0.2` oracle instead
+// emits "Property 's' is protected but type 'M3' is not a class derived from
+// 'N3'." for both. That is a pre-existing divergence in
+// `private_brand_mismatch_error` itself (not introduced by routing it into
+// the argument path) and out of scope for #16769 leg 1, which is only about
+// the `TS2345` path missing elaboration the assignment path already had —
+// filed separately, see #16769 leg 1 PR discussion.
+
+/// A `new`-expression argument (not just a plain identifier construction
+/// pattern) still elaborates correctly.
+#[test]
+fn new_expression_argument_position_carries_elaboration() {
+    let source = r#"
+class M4 { private s = 1; }
+class N4 { private s = 1; }
+class Wrapper {
+    constructor(n: N4) {}
+}
+new Wrapper(new M4());
+"#;
+    let diags = check_source_diagnostics(source);
+    let diag = only(&diags, TS2345);
+    assert_eq!(diag.related_information.len(), 1);
+    assert_eq!(
+        diag.related_information[0].message_text,
+        "Types have separate declarations of a private property 's'."
+    );
+}
+
+/// Negative control: a structurally-failing argument with no private/`#`
+/// members keeps its existing property-incompatibility elaboration chain
+/// unchanged — the new nominal-brand interception must not fire here.
+#[test]
+fn structural_mismatch_without_nominal_members_has_no_elaboration() {
+    let source = r#"
+class Plain1 { s = 1; }
+class Plain2 { s = "x"; }
+declare function take(n: Plain2): void;
+take(new Plain1());
+"#;
+    let diags = check_source_diagnostics(source);
+    let diag = only(&diags, TS2345);
+    assert!(
+        diag.related_information
+            .iter()
+            .all(|info| !info.message_text.contains("separate declarations")
+                && !info.message_text.contains("refers to a different member")),
+        "expected no nominal-brand elaboration for a purely structural mismatch, got {:?}",
+        diag.related_information
+    );
+}


### PR DESCRIPTION
When a call argument fails to satisfy a parameter solely because the two types have distinct nominal private brands, tsc's `checkTypeRelatedTo` attaches the "separate declarations of a private property" (`TS2442` wording, modifier-`private`) or "refers to a different member" (`TS18015` wording, `#`-private) elaboration under the `TS2345` head.

Structural rule: when a call-argument relation fails solely due to a private/`#`-private brand mismatch, tsc's `checkTypeRelatedTo` elaborates the nominal-member detail under `TS2345`; tsz already did this for the assignment-statement path (`error_reporter/assignability.rs`'s `private_brand_mismatch_error` interception) but not for the call-argument path (`error_reporter/call_errors/error_emission.rs`'s `error_argument_not_assignable_at_impl`), which had no equivalent consultation and rendered a bare `TS2345` with no elaboration.

Fix: consult `private_brand_mismatch_error(arg_type, param_type)` right after computing the assignability analysis, ahead of the missing-property promotion and generic structural rendering, mirroring the assignment path's priority and `DiagnosticRelatedInformation` shape (`RelatedInformationKind::ChainLink` + `RelatedInformationPolicy::ELABORATION`).

Adjacent matrix (oracle-verified against pinned `typescript@7.0.2`, `--noEmit --strict`):
- modifier-`private` same-name members on unrelated classes → `TS2442` wording
- ES `#`-private same-spelling members → `TS18015` wording
- a `new`-expression argument position (not just a plain call) → elaborates correctly
- negative control: a plain structural mismatch (no nominal members) keeps its existing property-incompatibility elaboration chain unchanged — the new interception does not fire

A `protected`-only witness is deliberately **not** covered: `private_brand_mismatch_error`'s protected branch already diverges from tsc on both the pre-existing assignment path and this new argument path (real tsc says `Property 'x' is protected but type 'A' is not a class derived from 'B'.`, not "separate declarations"). That is a pre-existing bug in `private_brand_mismatch_error` itself, unrelated to this routing fix, and out of scope for this slice (documented in the test file and noted on the coordination board for a future session).

Closes #16769 (leg 1). Leg 2 (instantiated generic classes dropping the brand lookup through `Application`) is being handled separately.

## Goal
Goal: hold

## Verification
- New `ts2345_private_brand_argument_elaboration_tests` (4 rows, oracle-verified): modifier-private, ES-private, new-expression position, negative structural control — all green.
- `cargo test -p tsz-checker --lib -- ts2345 ts2322 ts2554 ts2769 private call_errors`: 1030/1030 green (no regressions in adjacent families).
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`: clean.
- `cargo fmt --check -p tsz-checker`: clean.
- `python3 scripts/arch/arch_guard.py`: passes.
- Pre-commit hook (clippy + affected-crate tests + arch guard): passed.
- This is a checker-only, additive elaboration change (no new diagnostic codes, no changed decision of whether `TS2345` fires) gated behind an already-existing, narrowly-scoped `private_brand_mismatch_error` query; conformance/emit impact expected to be at most a small positive shift toward parity on private-brand argument-mismatch fixtures. Full `conformance.sh snapshot` / `emit/run.sh` / fourslash not run in this session (TypeScript corpus not checked out); owed as a follow-up before merge if a future session has the corpus available.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_01D2p2bY24uVfzuCqKPf88hX)_