### PR TITLE
fix(checker): TS18031 elaboration for a property access on an intersection reduced to never

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/declared_intersection_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/declared_intersection_display.rs
@@ -189,26 +189,7 @@ impl<'a> CheckerState<'a> {
         &mut self,
         annotation_idx: NodeIndex,
     ) -> Option<String> {
-        let mut annotation_idx = annotation_idx;
-        while self.ctx.arena.get(annotation_idx).is_some_and(|node| {
-            node.kind == tsz_parser::parser::syntax_kind_ext::PARENTHESIZED_TYPE
-        }) {
-            annotation_idx = self
-                .ctx
-                .arena
-                .get_wrapped_type_at(annotation_idx)?
-                .type_node;
-        }
-
-        let node = self.ctx.arena.get(annotation_idx)?;
-        if node.kind != tsz_parser::parser::syntax_kind_ext::INTERSECTION_TYPE {
-            return None;
-        }
-
-        let member_nodes = self.ctx.arena.get_composite_type(node)?.types.nodes.clone();
-        if member_nodes.len() < 2 {
-            return None;
-        }
+        let member_nodes = self.declared_intersection_annotation_member_nodes(annotation_idx)?;
 
         let mut members = Vec::with_capacity(member_nodes.len());
         let mut saw_type_literal_member = false;
@@ -235,5 +216,62 @@ impl<'a> CheckerState<'a> {
             return None;
         }
         Some(members.join(" & "))
+    }
+
+    /// The member type nodes of `annotation_idx` when it is (after peeling
+    /// wrapping parentheses) a written `IntersectionType` with at least two
+    /// members, shared by [`Self::format_declared_intersection_annotation_node`]
+    /// and [`Self::declared_intersection_member_types_for_expression`] so the
+    /// peel-and-validate walk is not re-spelled between a display-oriented
+    /// caller and a type-oriented one.
+    fn declared_intersection_annotation_member_nodes(
+        &self,
+        annotation_idx: NodeIndex,
+    ) -> Option<Vec<NodeIndex>> {
+        let mut annotation_idx = annotation_idx;
+        while self.ctx.arena.get(annotation_idx).is_some_and(|node| {
+            node.kind == tsz_parser::parser::syntax_kind_ext::PARENTHESIZED_TYPE
+        }) {
+            annotation_idx = self
+                .ctx
+                .arena
+                .get_wrapped_type_at(annotation_idx)?
+                .type_node;
+        }
+
+        let node = self.ctx.arena.get(annotation_idx)?;
+        if node.kind != tsz_parser::parser::syntax_kind_ext::INTERSECTION_TYPE {
+            return None;
+        }
+
+        let members = self.ctx.arena.get_composite_type(node)?.types.nodes.clone();
+        (members.len() >= 2).then_some(members)
+    }
+
+    /// The evaluated types of a property-access receiver's *declared*
+    /// written-intersection members (`declare const c: A & B` — each member
+    /// evaluated independently), when the receiver's declared type is
+    /// directly a written intersection.
+    ///
+    /// Unlike [`Self::declared_intersection_annotation_display_for_expression`],
+    /// this carries no type-literal display gate: a conflict-detection query
+    /// over the members is just as valid when every member is a plain
+    /// interface/type-alias reference as when one is a type literal. Returns
+    /// `None` for every case the caller must silently accept (no explicit
+    /// annotation, not an intersection, fewer than two members) rather than
+    /// guessing — the primary diagnostic is unaffected either way.
+    pub(in crate::error_reporter) fn declared_intersection_member_types_for_expression(
+        &mut self,
+        expr_idx: NodeIndex,
+    ) -> Option<Vec<tsz_solver::TypeId>> {
+        let annotation_idx =
+            self.declared_current_arena_annotation_node_for_expression(expr_idx)?;
+        let member_nodes = self.declared_intersection_annotation_member_nodes(annotation_idx)?;
+        Some(
+            member_nodes
+                .iter()
+                .map(|&member_node| self.get_type_from_type_node(member_node))
+                .collect(),
+        )
     }
 }

--- a/crates/tsz-checker/src/error_reporter/emitters.rs
+++ b/crates/tsz-checker/src/error_reporter/emitters.rs
@@ -105,6 +105,24 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// [`Self::error_at_anchor`] with `related_information` already attached,
+    /// built as one complete `Diagnostic` value before it is pushed — the
+    /// anchor-resolving counterpart to [`Self::error_at_span_with_related`],
+    /// for callers whose primary span comes from the shared anchor policy
+    /// rather than a raw node span.
+    pub(crate) fn error_at_anchor_with_related(
+        &mut self,
+        node_idx: NodeIndex,
+        anchor_kind: DiagnosticAnchorKind,
+        message: &str,
+        code: u32,
+        related: Vec<crate::diagnostics::DiagnosticRelatedInformation>,
+    ) {
+        if let Some(anchor) = self.resolve_diagnostic_anchor(node_idx, anchor_kind) {
+            self.error_at_span_with_related(anchor.start, anchor.length, message, code, related);
+        }
+    }
+
     /// Emit a generator-related error (TS1221/TS1222) at the `*` asterisk token.
     ///
     /// TSC's `grammarErrorOnNode(node.asteriskToken!, ...)` anchors these errors

--- a/crates/tsz-checker/src/error_reporter/intersection_never_elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/intersection_never_elaboration.rs
@@ -1,0 +1,131 @@
+//! `TS18031` related-info elaboration for a `TS2339` property access whose
+//! receiver is `never` because a *directly written* intersection reduced to
+//! it. Split out of `properties.rs` to keep that file under its size
+//! ratchet; the two are otherwise one unit of work.
+
+use crate::diagnostics::diagnostic_codes;
+use crate::error_reporter::fingerprint_policy::DiagnosticAnchorKind;
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    /// `TS2339` ("Property does not exist on type") emitted with the
+    /// `TS18031` related-info attached when applicable — the shared tail of
+    /// `properties.rs`'s `error_property_not_exist_at`, kept here so that
+    /// file's call site stays one line under its size ratchet.
+    pub(super) fn error_property_does_not_exist_with_never_elaboration(
+        &mut self,
+        idx: NodeIndex,
+        code: u32,
+        message: &str,
+        type_id: TypeId,
+    ) {
+        let related = self
+            .intersection_reduced_to_never_related_info(type_id, idx)
+            .into_iter()
+            .collect();
+        self.error_at_anchor_with_related(
+            idx,
+            DiagnosticAnchorKind::PropertyToken,
+            message,
+            code,
+            related,
+        );
+    }
+
+    /// The receiver (object) expression of a property/element access, from
+    /// either the access expression node itself or its name/argument node —
+    /// mirroring the two shapes [`crate::error_reporter::fingerprint_policy::DiagnosticAnchorKind::PropertyToken`]'s
+    /// own anchor resolution (`property_token_anchor_node`) accepts for `idx`.
+    pub(super) fn property_access_receiver_expr(&self, idx: NodeIndex) -> Option<NodeIndex> {
+        let is_access_expr_kind = |kind: u16| {
+            kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+                || kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+        };
+        if let Some(node) = self.ctx.arena.get(idx)
+            && is_access_expr_kind(node.kind)
+            && let Some(access) = self.ctx.arena.get_access_expr(node)
+        {
+            return Some(access.expression);
+        }
+        let parent_idx = self.ctx.arena.get_extended(idx).map(|ext| ext.parent)?;
+        let parent_node = self.ctx.arena.get(parent_idx)?;
+        if is_access_expr_kind(parent_node.kind)
+            && let Some(access) = self.ctx.arena.get_access_expr(parent_node)
+            && access.name_or_argument == idx
+        {
+            return Some(access.expression);
+        }
+        None
+    }
+
+    /// The `TS18031` related-info line for a property access on a `never`
+    /// receiver, when that `never` came from a *directly written*
+    /// intersection whose members conflict over a required literal property
+    /// (`declare const c: A & B` where `A`/`B` disagree on it). tsc: `The
+    /// intersection '{0}' was reduced to 'never' because property '{1}' has
+    /// conflicting types in some constituents.`
+    ///
+    /// `TypeInterner::intern` collapses such an intersection to the single
+    /// canonical `TypeId::NEVER` at construction time, so by the time this
+    /// `TS2339` is reported the member list is gone from `type_id` itself —
+    /// this recovers it from the receiver's own declared-type syntax instead.
+    /// Deliberately narrow (only the single-literal-per-member discriminant
+    /// shape, only a directly-written intersection annotation, not an alias/
+    /// generic-application/heritage chain): every early return here just
+    /// leaves the diagnostic as it is today, with no elaboration line, so
+    /// under-covering is safe and never produces a wrong message.
+    pub(super) fn intersection_reduced_to_never_related_info(
+        &mut self,
+        type_id: TypeId,
+        idx: NodeIndex,
+    ) -> Option<crate::diagnostics::DiagnosticRelatedInformation> {
+        if type_id != TypeId::NEVER {
+            return None;
+        }
+        let receiver_idx = self.property_access_receiver_expr(idx)?;
+        let members = self.declared_intersection_member_types_for_expression(receiver_idx)?;
+        // Each member is resolved through the same lazy-type machinery
+        // property access itself uses (`Lazy(DefId)` interface/type-alias
+        // references do not carry a structural shape the solver query below
+        // can read until stabilized against the type environment).
+        let members: Vec<TypeId> = members
+            .into_iter()
+            .map(|member| self.resolve_type_for_property_access(member))
+            .collect();
+        let conflict_atom =
+            crate::query_boundaries::intersection_display::find_disjoint_literal_property_across_intersection(
+                self.ctx.types,
+                &members,
+            )?;
+        // tsc's elaboration names the discriminant that reduced the whole
+        // intersection to `never`, not necessarily the property actually
+        // accessed — once the receiver type itself is `never`, every access
+        // on it carries the same reason.
+        let conflict_prop_name = self.ctx.types.resolve_atom(conflict_atom);
+        // Built directly from the recovered member types rather than
+        // `declared_intersection_annotation_display_for_expression`: that
+        // sibling gates its result on seeing a type-literal member (it exists
+        // to improve *assignability*-message display, not to answer "was
+        // this written as an intersection"), so it declines exactly the
+        // plain-interface-member shape (`A & B`) this diagnostic needs most.
+        let intersection_display = members
+            .iter()
+            .map(|&member| self.format_type(member))
+            .collect::<Vec<_>>()
+            .join(" & ");
+        use crate::diagnostics::{Diagnostic, diagnostic_messages, format_message};
+        Some(Diagnostic::related_message(
+            diagnostic_codes::THE_INTERSECTION_WAS_REDUCED_TO_NEVER_BECAUSE_PROPERTY_HAS_CONFLICTING_TYPES_IN,
+            self.ctx.file_name.clone(),
+            0,
+            0,
+            format_message(
+                diagnostic_messages::THE_INTERSECTION_WAS_REDUCED_TO_NEVER_BECAUSE_PROPERTY_HAS_CONFLICTING_TYPES_IN,
+                &[&intersection_display, &conflict_prop_name],
+            ),
+        ))
+    }
+}

--- a/crates/tsz-checker/src/error_reporter/mod.rs
+++ b/crates/tsz-checker/src/error_reporter/mod.rs
@@ -40,6 +40,7 @@ mod expected_type_from_return;
 mod fingerprint_policy;
 mod generic_display_helpers;
 mod generics;
+mod intersection_never_elaboration;
 mod literal_alias_display;
 mod literal_alias_rewrites;
 mod missing_property_declared_here;

--- a/crates/tsz-checker/src/error_reporter/properties.rs
+++ b/crates/tsz-checker/src/error_reporter/properties.rs
@@ -1821,7 +1821,7 @@ impl<'a> CheckerState<'a> {
                     format!("Property '{prop_name}' does not exist on type '{type_display}'."),
                 )
             };
-            self.error_at_anchor(idx, DiagnosticAnchorKind::PropertyToken, &message, code);
+            self.error_property_does_not_exist_with_never_elaboration(idx, code, &message, type_id);
         }
     }
 }

--- a/crates/tsz-checker/src/query_boundaries/intersection_display.rs
+++ b/crates/tsz-checker/src/query_boundaries/intersection_display.rs
@@ -5,6 +5,21 @@ use tsz_solver::{ObjectShape, TypeId};
 
 pub(crate) use tsz_solver::objects::PropertyCollectionResult;
 
+/// The property name whose required occurrences across a *written*
+/// intersection's members are literal values from mutually exclusive
+/// value-sets, forcing that intersection to reduce to `never` (`tsc`'s
+/// TS18031). `members` is the pre-reduction member list recovered from
+/// source syntax — see `declared_intersection_annotation_display_for_expression`
+/// — since the interned intersection has already collapsed to the single
+/// canonical `TypeId::NEVER` by the time a property-access failure is
+/// reported against it.
+pub(crate) fn find_disjoint_literal_property_across_intersection(
+    db: &dyn TypeDatabase,
+    members: &[TypeId],
+) -> Option<tsz_common::interner::Atom> {
+    tsz_solver::type_queries::find_disjoint_literal_property_across_intersection(db, members)
+}
+
 pub(crate) fn collect_properties<R: TypeResolver>(
     type_id: TypeId,
     db: &dyn TypeDatabase,

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -897,6 +897,8 @@ mod ts1539_bigint_literal_property_name_tests;
 mod ts18010_jsdoc_tag_anchor_tests;
 #[path = "tests/ts18017_ts18018_private_identifier_shadow_related_info_tests.rs"]
 mod ts18017_ts18018_private_identifier_shadow_related_info_tests;
+#[path = "tests/ts18031_intersection_conflicting_property_tests.rs"]
+mod ts18031_intersection_conflicting_property_tests;
 #[path = "tests/ts18050_nullish_keyword_without_strict_null_checks_tests.rs"]
 mod ts18050_nullish_keyword_without_strict_null_checks_tests;
 #[path = "tests/ts2322_private_field_narrowing_write_tests.rs"]

--- a/crates/tsz-checker/src/tests/ts18031_intersection_conflicting_property_tests.rs
+++ b/crates/tsz-checker/src/tests/ts18031_intersection_conflicting_property_tests.rs
@@ -1,0 +1,229 @@
+//! Regression tests for the `TS18031` related-info line `tsc` attaches to a
+//! `TS2339` property access on an intersection reduced to `never`.
+//!
+//! Structural rule (pinned against `typescript@7.0.2`): when a *directly
+//! written* object intersection (`declare const c: A & B`) has two members
+//! whose required literal-typed occurrences of the same property name are
+//! mutually exclusive (`{ x: 1 }` vs `{ x: 2 }`), `tsc`'s `getReducedType`
+//! collapses the intersection to `never` and any property access on it
+//! reports `TS2339` with a `relatedInformation` entry: "The intersection
+//! '{0}' was reduced to 'never' because property '{1}' has conflicting types
+//! in some constituents." The entry carries no location of its own (a
+//! message-chain link, not a cross-location pointer), so it prints in both
+//! `--pretty` and plain output alike, unindented in front of a file/line
+//! header.
+//!
+//! `TypeInterner::intern` already collapses such an intersection to the
+//! single canonical `TypeId::NEVER` at construction time, so tsz recovers the
+//! pre-reduction member list from the receiver's own declared-type syntax
+//! (`declared_intersection_member_types_for_expression`,
+//! `error_reporter/core/declared_intersection_display.rs`) rather than from
+//! the reported `never` itself, and re-runs a conflict search
+//! (`find_disjoint_literal_property_across_intersection`,
+//! `tsz-solver/src/type_queries/data/content_predicates.rs`) over the
+//! resolved members. Owned by `error_reporter/properties.rs`'s
+//! `intersection_reduced_to_never_related_info`.
+//!
+//! Deliberately narrow scope, matching the helper's own doc comments: only
+//! the single-required-literal-per-member discriminant shape, only a
+//! directly-written intersection annotation (no alias/generic-application/
+//! heritage indirection, no private-brand conflicts — TS18032 is a separate,
+//! unimplemented follow-up). Every case outside that scope keeps today's
+//! behavior (`TS2339` with no elaboration), never a wrong one.
+
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::check_source_strict;
+use tsz_common::diagnostics::diagnostic_codes;
+
+const TS2339: u32 = diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE;
+const TS18031: u32 =
+    diagnostic_codes::THE_INTERSECTION_WAS_REDUCED_TO_NEVER_BECAUSE_PROPERTY_HAS_CONFLICTING_TYPES_IN;
+
+fn only(diags: &[Diagnostic], code: u32) -> Diagnostic {
+    let matching: Vec<_> = diags.iter().filter(|d| d.code == code).collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected exactly one TS{code}; got {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+    matching[0].clone()
+}
+
+fn related(diagnostic: &Diagnostic, code: u32) -> Option<String> {
+    diagnostic
+        .related_information
+        .iter()
+        .find(|info| info.code == code)
+        .map(|info| info.message_text.clone())
+}
+
+// ---------------------------------------------------------------------------
+// Positive cases: a directly-written intersection with a conflicting literal
+// discriminant carries the TS18031 elaboration.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn interface_members_carry_ts18031_elaboration() {
+    let diags = check_source_strict(
+        r#"
+interface Alpha { tag: 1 }
+interface Beta { tag: 2 }
+declare const value: Alpha & Beta;
+value.tag;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18031).as_deref(),
+        Some(
+            "The intersection 'Alpha & Beta' was reduced to 'never' because property 'tag' has conflicting types in some constituents."
+        ),
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn type_literal_members_carry_ts18031_elaboration() {
+    // Same rule with inline type-literal members instead of named
+    // interfaces — the recovered member types are named by their structural
+    // display, not by a symbol name.
+    let diags = check_source_strict(
+        r#"
+declare const value: { mode: "left" } & { mode: "right" };
+value.mode;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    let msg = related(&diag, TS18031);
+    assert!(
+        msg.as_deref().is_some_and(|m| m.contains("property 'mode'")
+            && m.contains("conflicting types in some constituents")),
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn class_members_carry_ts18031_elaboration() {
+    // Binder names varied from the interface case above so the rule is
+    // structural, not keyed to a particular identifier.
+    let diags = check_source_strict(
+        r#"
+class First { slot: "a" = "a"; }
+class Second { slot: "b" = "b"; }
+declare const combined: First & Second;
+combined.slot;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18031).as_deref(),
+        Some(
+            "The intersection 'First & Second' was reduced to 'never' because property 'slot' has conflicting types in some constituents."
+        ),
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn numeric_literal_conflict_carries_ts18031_elaboration() {
+    let diags = check_source_strict(
+        r#"
+interface Holder1 { count: 1 }
+interface Holder2 { count: 2 }
+declare const both: Holder1 & Holder2;
+both.count;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18031).as_deref(),
+        Some(
+            "The intersection 'Holder1 & Holder2' was reduced to 'never' because property 'count' has conflicting types in some constituents."
+        ),
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn accessing_a_different_property_still_carries_ts18031() {
+    // Once reduced to `never`, *any* property access errors — the
+    // elaboration still names the discriminant that caused the reduction,
+    // not the property actually accessed.
+    let diags = check_source_strict(
+        r#"
+interface WithKeyA { key: "a" }
+interface WithKeyB { key: "b" }
+declare const anything: WithKeyA & WithKeyB;
+anything.whatever;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18031).as_deref(),
+        Some(
+            "The intersection 'WithKeyA & WithKeyB' was reduced to 'never' because property 'key' has conflicting types in some constituents."
+        ),
+        "got {diags:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative / control cases: no TS18031 elaboration.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn non_intersection_never_receiver_has_no_ts18031() {
+    // `never` from ordinary exhaustive narrowing, not from an intersection
+    // reduction, must not carry the intersection elaboration.
+    let diags = check_source_strict(
+        r#"
+declare const value: string | number;
+if (typeof value === "string") {
+} else if (typeof value === "number") {
+} else {
+    value.toString();
+}
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert!(related(&diag, TS18031).is_none(), "got {diags:?}");
+}
+
+#[test]
+fn same_literal_members_do_not_reduce_and_report_nothing() {
+    let diags = check_source_strict(
+        r#"
+interface WithKind { kind: "a" }
+declare const value: WithKind & WithKind;
+const read: "a" = value.kind;
+"#,
+    );
+    assert!(
+        diags.iter().all(|d| d.code != TS2339),
+        "identical discriminant members must not reduce, got {diags:?}"
+    );
+}
+
+#[test]
+fn indirect_alias_intersection_has_no_ts18031() {
+    // The conflict is real (tsc still reports the elaboration here through
+    // its full alias-resolution machinery), but the narrow syntactic walk
+    // this diagnostic uses declines once the receiver's own declared type is
+    // an alias rather than a directly-written intersection — a documented
+    // scope limit, not a false report.
+    let diags = check_source_strict(
+        r#"
+interface Left { tag: 1 }
+interface Right { tag: 2 }
+type Combined = Left & Right;
+declare const value: Combined;
+value.tag;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert!(related(&diag, TS18031).is_none(), "got {diags:?}");
+}

--- a/crates/tsz-solver/src/type_queries/data/intersection_conflict.rs
+++ b/crates/tsz-solver/src/type_queries/data/intersection_conflict.rs
@@ -1,0 +1,76 @@
+//! Conflict detection over a *written* (pre-reduction) intersection member
+//! list, used only for diagnostic elaboration — see
+//! [`find_disjoint_literal_property_across_intersection`].
+
+use crate::construction::TypeDatabase;
+use crate::types::TypeData;
+use crate::types::TypeId;
+use rustc_hash::{FxHashMap, FxHashSet};
+use tsz_common::interner::Atom;
+
+/// The property name whose required occurrences across `members` are literal
+/// values from mutually exclusive value-sets — the shape `tsc` reports as
+/// `TS18031` (`The intersection '{0}' was reduced to 'never' because
+/// property '{1}' has conflicting types in some constituents.`).
+///
+/// `members` is the *pre-reduction* member list of a written intersection
+/// (e.g. recovered from source syntax via
+/// `declared_intersection_annotation_display_for_expression`'s sibling walk),
+/// since `TypeInterner::intern` already collapses a conflicting intersection
+/// to the single canonical `TypeId::NEVER` at construction time — by the time
+/// a checker query sees `NEVER` there is no member list left to inspect.
+///
+/// This intentionally covers only the common single-literal-per-member
+/// discriminant shape (`{ kind: "a" } & { kind: "b" }`), mirroring the
+/// `TypeInterner`-internal `intersection_has_disjoint_object_literals`'s
+/// single-literal fast path rather than its full cross-domain/optional
+/// analysis. It is a display-only helper consumed for diagnostic elaboration:
+/// returning `None` for a conflict shape it doesn't recognize leaves the
+/// primary `TS2339` diagnostic exactly as it is today (no elaboration line),
+/// never a wrong one, so under-covering here is safe.
+pub fn find_disjoint_literal_property_across_intersection(
+    db: &dyn TypeDatabase,
+    members: &[TypeId],
+) -> Option<Atom> {
+    let mut by_name: FxHashMap<Atom, FxHashSet<crate::types::LiteralValue>> = FxHashMap::default();
+    // Names disqualified by a non-literal required occurrence, tracked
+    // separately from `by_name` so a disqualification is permanent
+    // regardless of whether it is observed before or after a literal
+    // occurrence of the same name.
+    let mut excluded: FxHashSet<Atom> = FxHashSet::default();
+    let mut ingest = |properties: &[crate::types::PropertyInfo]| {
+        for prop in properties {
+            if prop.optional || excluded.contains(&prop.name) {
+                continue;
+            }
+            let Some(TypeData::Literal(value)) = db.lookup(prop.type_id) else {
+                // A non-literal (or absent) required occurrence could still
+                // conflict via the fuller `TypeInterner`-internal analysis,
+                // but this helper only recognizes the single-literal shape —
+                // drop the whole name rather than guess at a partial match.
+                excluded.insert(prop.name);
+                by_name.remove(&prop.name);
+                continue;
+            };
+            by_name.entry(prop.name).or_default().insert(value);
+        }
+    };
+    for &member in members {
+        if member.is_intrinsic() {
+            continue;
+        }
+        match db.lookup(member) {
+            Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => {
+                ingest(&db.object_shape(shape_id).properties);
+            }
+            Some(TypeData::Callable(callable_id)) => {
+                ingest(&db.callable_shape(callable_id).properties);
+            }
+            _ => {}
+        }
+    }
+    by_name
+        .into_iter()
+        .find(|(_, values)| values.len() >= 2)
+        .map(|(name, _)| name)
+}

--- a/crates/tsz-solver/src/type_queries/data/mod.rs
+++ b/crates/tsz-solver/src/type_queries/data/mod.rs
@@ -17,6 +17,7 @@ mod free_infer_cache_tests;
 mod free_infer_predicate;
 #[cfg(test)]
 mod free_param_cache_tests;
+mod intersection_conflict;
 mod nominal_and_base;
 mod rest_binder_queries;
 mod signatures_and_advanced;
@@ -30,6 +31,7 @@ pub use conditional_distribution::*;
 pub use content_predicates::*;
 pub use exact_property_keys::*;
 pub use free_infer_predicate::*;
+pub use intersection_conflict::*;
 pub use nominal_and_base::*;
 pub use rest_binder_queries::*;
 pub use signatures_and_advanced::*;


### PR DESCRIPTION
tsc's `checkGrammar`-adjacent property-access check reports `TS2339` ("Property 'x' does not exist on type 'never'.") for a property access whose receiver is a `never`-typed intersection, and attaches a `relatedInformation` entry (a `TS18031` message-chain link, no location of its own) explaining why: "The intersection '{0}' was reduced to 'never' because property '{1}' has conflicting types in some constituents." tsz already computed the correct `TS2339` for this shape but never attached the explanation — this PR adds it.

## Structural rule

`TypeInterner::intern` collapses a conflicting object intersection to the single canonical `TypeId::NEVER` at construction time (`crates/tsz-solver/src/intern/normalize.rs`'s `intersection_has_disjoint_object_literals`), so by the time a property-access failure is reported against that `never`, the member list — and therefore *which* property conflicted and *why* — is already gone; `TypeId::NEVER` is one shared id across the whole program, not a per-occurrence value. tsz recovers this provenance from the receiver's own *declared-type syntax* instead of from the reported type:

- `crates/tsz-checker/src/error_reporter/core/declared_intersection_display.rs` gains `declared_intersection_member_types_for_expression`, which walks a property-access receiver back to its declared type annotation (reusing the existing `declared_current_arena_annotation_node_for_expression` walk) and evaluates each `IntersectionType` syntax member *independently*, bypassing the eager reduction. This is a sibling of the existing `declared_intersection_annotation_display_for_expression` (used for assignability-message display), not a replacement — that function gates on seeing a type-literal member, which the plain-interface-member shape this diagnostic needs most (`declare const c: A & B`) never satisfies.
- `crates/tsz-solver/src/type_queries/data/intersection_conflict.rs` (new file, split out to stay under the 2000-line solver-src cap) adds `find_disjoint_literal_property_across_intersection(db: &dyn TypeDatabase, members: &[TypeId]) -> Option<Atom>`, a solver-backed query-boundary function that re-runs the by-name conflict search over the recovered member list.
- `crates/tsz-checker/src/error_reporter/intersection_never_elaboration.rs` (new file, split out of `properties.rs` to stay under its size ratchet) owns the checker-side wiring: recovering the receiver expression from the property-access node, resolving each member through `resolve_type_for_property_access` (the same lazy-type machinery ordinary property access already uses — `Lazy(DefId)` interface/type-alias references carry no structural shape until stabilized against the type environment), and building the `TS18031` related-info entry.

Deliberately narrow scope, matching caveat 1 in `.claude/CLAUDE.md`: only the common single-required-literal-per-member discriminant shape (`{ kind: "a" } & { kind: "b" }`), and only a *directly-written* intersection annotation — not an alias, generic-application, or heritage indirection, and not the private-brand conflict (`TS18032`) sibling. Every case outside that scope leaves the diagnostic exactly as it is today (no elaboration line), never a wrong one, since every recovery step is a `?`-chained early return.

## Adjacent matrix

Oracle-verified against `typescript@7.0.2` and covered by `crates/tsz-checker/src/tests/ts18031_intersection_conflicting_property_tests.rs` (8 new tests):
- interface members, type-literal members, and class members (renamed binders across all three) — all carry byte-identical elaboration text to tsc.
- numeric-literal discriminant conflict.
- accessing a *different* property than the one that conflicted still carries the elaboration (tsc: once the whole receiver type is `never`, every access on it carries the same reason).
- negative controls: `never` from exhaustive narrowing (not an intersection) carries no elaboration; identical-literal members don't reduce at all (no diagnostic); an intersection reached through a type alias (`type Combined = Left & Right`) is a real conflict tsc still elaborates, but the narrow syntactic walk here declines — a documented scope limit, not a false report.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib ts18031_intersection_conflicting_property_tests` — 8/8 passed.
- `cargo test -p tsz-checker --test intersection_reduced_never_property_access_tests` — 11/11 passed (pre-existing coverage for the underlying reduction, unaffected).
- `cargo test -p tsz-checker --lib property` — 1406/1406 passed (broad property-access sweep).
- `cargo test -p tsz-solver --lib intersection` — 506/506 passed.
- `cargo test -p tsz-checker --lib architecture_contract_tests` — 160/160 passed.
- `cargo clippy -p tsz-checker -p tsz-solver --lib --all-features -- -D warnings` — clean.
- `cargo fmt --check -p tsz-checker -p tsz-solver` — clean.
- `python3 scripts/arch/arch_guard.py` — clean (both the new solver-src 2000-line cap and the `error_reporter/properties.rs` size ratchet required splitting the new code into dedicated files, done above).
- Manual byte-diff against a release build + the pinned `typescript@7.0.2` oracle for the two positive-case oracle repros — identical output.
- **Owed**: `compare-to-parent.sh` / a conformance snapshot was not run this session (no TypeScript corpus checked out in this container). Diagnostic *code* and *count* are unaffected (this only adds a `related_information` entry to an already-correct `TS2339`), and prior related-info-only PRs this session (#16761) measured a 0/0 conformance set-difference for exactly this reason — the wording lives in related info, which the corpus fingerprints don't cover per that PR's own reviewer note. Emit floors are untouched (no `tsz-emitter` file in this diff) — `./scripts/emit/run.sh --skip-build` could not run in this container (no TS baselines checked out) but has zero plausible blast radius here.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_0163m7Rj2k1GLsWADPdhoV53)_