### PR TITLE
fix(parser): parameter-modifier grammar matches tsc's per-modifier code selection and single-report

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -345,6 +345,10 @@ mod node_modifiers_tests;
 mod this_param_modifier_tests;
 
 #[cfg(test)]
+#[path = "../../tests/parameter_modifier_grammar_tests.rs"]
+mod parameter_modifier_grammar_tests;
+
+#[cfg(test)]
 #[path = "../../tests/legacy_octal_bigint_continuation_tests.rs"]
 mod legacy_octal_bigint_continuation_tests;
 

--- a/crates/tsz-parser/src/parser/state_statements_class.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class.rs
@@ -13,6 +13,42 @@ use tsz_common::diagnostics::diagnostic_codes;
 use tsz_common::interner::{AstAtom, IdentText};
 use tsz_scanner::SyntaxKind;
 
+/// Modifiers already seen while walking a parameter's modifier run, used by
+/// `parse_parameter_modifiers` to mirror tsc's `checkGrammarModifiers` flag
+/// accumulator for a `Parameter` node.
+#[derive(Clone, Copy, Default)]
+struct SeenParamModifiers {
+    accessibility: bool,
+    readonly: bool,
+    override_: bool,
+    static_: bool,
+    async_: bool,
+    abstract_: bool,
+    accessor: bool,
+    declare: bool,
+    export: bool,
+}
+
+impl SeenParamModifiers {
+    /// Record a modifier token into the accumulator. Unknown tokens are ignored.
+    const fn record(&mut self, kind: SyntaxKind) {
+        match kind {
+            SyntaxKind::PublicKeyword
+            | SyntaxKind::PrivateKeyword
+            | SyntaxKind::ProtectedKeyword => self.accessibility = true,
+            SyntaxKind::ReadonlyKeyword => self.readonly = true,
+            SyntaxKind::OverrideKeyword => self.override_ = true,
+            SyntaxKind::StaticKeyword => self.static_ = true,
+            SyntaxKind::AsyncKeyword => self.async_ = true,
+            SyntaxKind::AbstractKeyword => self.abstract_ = true,
+            SyntaxKind::AccessorKeyword => self.accessor = true,
+            SyntaxKind::DeclareKeyword => self.declare = true,
+            SyntaxKind::ExportKeyword => self.export = true,
+            _ => {}
+        }
+    }
+}
+
 impl ParserState {
     fn report_missing_close_paren_after_body_recovery(&mut self) {
         let snapshot = self.scanner.save_state();
@@ -788,86 +824,34 @@ impl ParserState {
         suppress_invalid_modifier_diagnostics: bool,
     ) -> Option<NodeList> {
         let mut modifiers = Vec::new();
-        let mut seen_readonly = false;
-        let mut seen_accessibility = false;
-        let mut seen_override = false;
-        let mut reported_accessibility_duplicate = false;
+        // Flag accumulator mirroring tsc's `checkGrammarModifiers` for a
+        // `Parameter` node: we walk the modifier run left-to-right, report the
+        // FIRST grammar violation, and then suppress further grammar diagnostics
+        // for this parameter (tsc `return`s after the first). Tokens are still
+        // consumed and pushed into the AST regardless.
+        let mut seen = SeenParamModifiers::default();
+        let mut reported = false;
 
         while self.is_parameter_modifier() {
             let mod_start = self.token_pos();
             let mod_kind = self.current_token;
 
-            // Emit TS1090 for modifiers that cannot appear on parameters.
-            // tsc does this in the checker via checkGrammarModifiers, but we
-            // emit it here during parsing so we don't need checker support yet.
-            if !self.is_valid_parameter_modifier() && !suppress_invalid_modifier_diagnostics {
-                use tsz_common::diagnostics::diagnostic_codes;
-                let modifier_name = match mod_kind {
-                    SyntaxKind::StaticKeyword => "static",
-                    SyntaxKind::ExportKeyword => "export",
-                    SyntaxKind::DeclareKeyword => "declare",
-                    SyntaxKind::AsyncKeyword => "async",
-                    SyntaxKind::AbstractKeyword => "abstract",
-                    SyntaxKind::AccessorKeyword => "accessor",
-                    SyntaxKind::ConstKeyword => "const",
-                    SyntaxKind::DefaultKeyword => "default",
-                    SyntaxKind::InKeyword => "in",
-                    SyntaxKind::OutKeyword => "out",
-                    _ => "modifier",
-                };
-                self.parse_error_at_current_token(
-                    &format!("'{modifier_name}' modifier cannot appear on a parameter."),
-                    diagnostic_codes::MODIFIER_CANNOT_APPEAR_ON_A_PARAMETER,
-                );
+            // tsc reports at most one modifier-grammar error per parameter, and
+            // for `this` parameters it collapses the whole run into a single
+            // TS1433 (`suppress_invalid_modifier_diagnostics`).
+            if !suppress_invalid_modifier_diagnostics
+                && !reported
+                && let Some((message, code)) =
+                    Self::parameter_modifier_grammar_error(mod_kind, seen)
+            {
+                self.parse_error_at_current_token(&message, code);
+                reported = true;
             }
 
-            // Check for modifier ordering violations
-            // Parameter modifiers must be in order: accessibility, override, readonly
-            if matches!(
-                mod_kind,
-                SyntaxKind::PublicKeyword
-                    | SyntaxKind::PrivateKeyword
-                    | SyntaxKind::ProtectedKeyword
-            ) {
-                if seen_accessibility && !reported_accessibility_duplicate {
-                    use tsz_common::diagnostics::diagnostic_codes;
-                    self.parse_error_at_current_token(
-                        "Accessibility modifier already seen.",
-                        diagnostic_codes::ACCESSIBILITY_MODIFIER_ALREADY_SEEN,
-                    );
-                    reported_accessibility_duplicate = true;
-                }
-                // TS1029: Accessibility modifier must precede override and readonly
-                if seen_override || seen_readonly {
-                    use tsz_common::diagnostics::diagnostic_codes;
-                    let modifier_name = match mod_kind {
-                        SyntaxKind::PrivateKeyword => "private",
-                        SyntaxKind::ProtectedKeyword => "protected",
-                        _ => "public",
-                    };
-                    let other = if seen_override {
-                        "override"
-                    } else {
-                        "readonly"
-                    };
-                    self.parse_error_at_current_token(
-                        &format!("'{modifier_name}' modifier must precede '{other}' modifier."),
-                        diagnostic_codes::MODIFIER_MUST_PRECEDE_MODIFIER,
-                    );
-                }
-                seen_accessibility = true;
-            } else if mod_kind == SyntaxKind::OverrideKeyword {
-                seen_override = true;
-            } else if mod_kind == SyntaxKind::ReadonlyKeyword {
-                if seen_readonly {
-                    use tsz_common::diagnostics::diagnostic_codes;
-                    self.parse_error_at_current_token(
-                        "'readonly' modifier already seen.",
-                        diagnostic_codes::MODIFIER_ALREADY_SEEN,
-                    );
-                }
-                seen_readonly = true;
-            }
+            // Accumulate the modifier flag whether or not it produced an error,
+            // so a later modifier in the same run is judged against everything
+            // written before it (matching tsc's flag accumulator).
+            seen.record(mod_kind);
 
             self.next_token();
             let mod_end = self.token_end();
@@ -878,6 +862,186 @@ impl ParserState {
             None
         } else {
             Some(Self::make_node_list(modifiers))
+        }
+    }
+
+    /// Human-readable spelling of a modifier keyword, used to fill the `{0}`/`{1}`
+    /// slots of the modifier grammar diagnostics.
+    const fn parameter_modifier_text(kind: SyntaxKind) -> &'static str {
+        match kind {
+            SyntaxKind::PublicKeyword => "public",
+            SyntaxKind::PrivateKeyword => "private",
+            SyntaxKind::ProtectedKeyword => "protected",
+            SyntaxKind::ReadonlyKeyword => "readonly",
+            SyntaxKind::OverrideKeyword => "override",
+            SyntaxKind::StaticKeyword => "static",
+            SyntaxKind::AsyncKeyword => "async",
+            SyntaxKind::AbstractKeyword => "abstract",
+            SyntaxKind::AccessorKeyword => "accessor",
+            SyntaxKind::DeclareKeyword => "declare",
+            SyntaxKind::ExportKeyword => "export",
+            SyntaxKind::ConstKeyword => "const",
+            SyntaxKind::DefaultKeyword => "default",
+            SyntaxKind::InKeyword => "in",
+            SyntaxKind::OutKeyword => "out",
+            _ => "modifier",
+        }
+    }
+
+    /// Decide which grammar diagnostic (if any) a modifier on a `Parameter` node
+    /// produces, given the modifiers already seen earlier in the same run. This
+    /// is a faithful port of the `Parameter`-relevant arms of tsc's
+    /// `checkGrammarModifiers`: duplicates -> TS1030/TS1028, out-of-order ->
+    /// TS1029, `abstract` -> TS1242, `accessor` -> TS1243 (with `readonly`/
+    /// `declare`) or TS1275, `in`/`out` -> TS1274, and the
+    /// static/export/declare/async fallthrough -> TS1090. The valid
+    /// parameter-property modifiers (`public`/`private`/`protected`/`readonly`/
+    /// `override`) return `None` here; their misuse outside a constructor is the
+    /// semantic TS2369, emitted by the checker.
+    ///
+    /// `const`/`default` keep the historical TS1090 fallback: tsc treats them as
+    /// reserved words on a parameter (a separate parser-recovery path), which is
+    /// out of scope for this modifier-code selection.
+    fn parameter_modifier_grammar_error(
+        kind: SyntaxKind,
+        seen: SeenParamModifiers,
+    ) -> Option<(String, u32)> {
+        let text = Self::parameter_modifier_text(kind);
+        let precede = |current: &str, earlier: &str| {
+            Some((
+                format!("'{current}' modifier must precede '{earlier}' modifier."),
+                diagnostic_codes::MODIFIER_MUST_PRECEDE_MODIFIER,
+            ))
+        };
+        let already_seen = |name: &str| {
+            Some((
+                format!("'{name}' modifier already seen."),
+                diagnostic_codes::MODIFIER_ALREADY_SEEN,
+            ))
+        };
+        let cannot_on_parameter = |name: &str| {
+            Some((
+                format!("'{name}' modifier cannot appear on a parameter."),
+                diagnostic_codes::MODIFIER_CANNOT_APPEAR_ON_A_PARAMETER,
+            ))
+        };
+        let cannot_with = |current: &str, earlier: &str| {
+            Some((
+                format!("'{current}' modifier cannot be used with '{earlier}' modifier."),
+                diagnostic_codes::MODIFIER_CANNOT_BE_USED_WITH_MODIFIER,
+            ))
+        };
+
+        match kind {
+            SyntaxKind::PublicKeyword
+            | SyntaxKind::PrivateKeyword
+            | SyntaxKind::ProtectedKeyword => {
+                if seen.accessibility {
+                    Some((
+                        "Accessibility modifier already seen.".to_string(),
+                        diagnostic_codes::ACCESSIBILITY_MODIFIER_ALREADY_SEEN,
+                    ))
+                } else if seen.static_ {
+                    precede(text, "static")
+                } else if seen.override_ {
+                    precede(text, "override")
+                } else if seen.readonly {
+                    precede(text, "readonly")
+                } else if seen.async_ {
+                    precede(text, "async")
+                } else if seen.abstract_ {
+                    precede(text, "abstract")
+                } else {
+                    None
+                }
+            }
+            SyntaxKind::OverrideKeyword => {
+                if seen.override_ {
+                    already_seen("override")
+                } else if seen.declare {
+                    cannot_with("override", "declare")
+                } else if seen.readonly {
+                    precede("override", "readonly")
+                } else if seen.accessor {
+                    precede("override", "accessor")
+                } else {
+                    None
+                }
+            }
+            SyntaxKind::ReadonlyKeyword => {
+                if seen.readonly {
+                    already_seen("readonly")
+                } else {
+                    // `readonly` is a valid parameter-property modifier.
+                    None
+                }
+            }
+            SyntaxKind::StaticKeyword => {
+                if seen.static_ {
+                    already_seen("static")
+                } else if seen.readonly {
+                    precede("static", "readonly")
+                } else if seen.async_ {
+                    precede("static", "async")
+                } else {
+                    cannot_on_parameter("static")
+                }
+            }
+            SyntaxKind::AsyncKeyword => {
+                if seen.async_ {
+                    already_seen("async")
+                } else {
+                    cannot_on_parameter("async")
+                }
+            }
+            SyntaxKind::AbstractKeyword => {
+                if seen.abstract_ {
+                    already_seen("abstract")
+                } else {
+                    Some((
+                        "'abstract' modifier can only appear on a class, method, or property declaration."
+                            .to_string(),
+                        diagnostic_codes::ABSTRACT_MODIFIER_CAN_ONLY_APPEAR_ON_A_CLASS_METHOD_OR_PROPERTY_DECLARATION,
+                    ))
+                }
+            }
+            SyntaxKind::AccessorKeyword => {
+                if seen.accessor {
+                    already_seen("accessor")
+                } else if seen.readonly {
+                    cannot_with("accessor", "readonly")
+                } else if seen.declare {
+                    cannot_with("accessor", "declare")
+                } else {
+                    Some((
+                        "'accessor' modifier can only appear on a property declaration.".to_string(),
+                        diagnostic_codes::ACCESSOR_MODIFIER_CAN_ONLY_APPEAR_ON_A_PROPERTY_DECLARATION,
+                    ))
+                }
+            }
+            SyntaxKind::InKeyword | SyntaxKind::OutKeyword => Some((
+                format!(
+                    "'{text}' modifier can only appear on a type parameter of a class, interface or type alias"
+                ),
+                diagnostic_codes::MODIFIER_CAN_ONLY_APPEAR_ON_A_TYPE_PARAMETER_OF_A_CLASS_INTERFACE_OR_TYPE_ALIAS,
+            )),
+            SyntaxKind::DeclareKeyword => {
+                if seen.declare {
+                    already_seen("declare")
+                } else {
+                    cannot_on_parameter("declare")
+                }
+            }
+            SyntaxKind::ExportKeyword => {
+                if seen.export {
+                    already_seen("export")
+                } else {
+                    cannot_on_parameter("export")
+                }
+            }
+            // `const`/`default` (and any other modifier token that reaches here)
+            // keep the generic TS1090 fallback.
+            _ => cannot_on_parameter(text),
         }
     }
 

--- a/crates/tsz-parser/tests/parameter_modifier_grammar_tests.rs
+++ b/crates/tsz-parser/tests/parameter_modifier_grammar_tests.rs
@@ -1,0 +1,214 @@
+//! Parity tests for `parse_parameter_modifiers` against tsc's
+//! `checkGrammarModifiers` for a `Parameter` node.
+//!
+//! tsc selects a dedicated code for some misplaced parameter modifiers
+//! (`abstract` -> TS1242, `accessor` -> TS1275/TS1243, `in`/`out` -> TS1274)
+//! rather than the generic TS1090, and it reports at most one grammar error per
+//! parameter (first grammar-invalid modifier wins, then it returns). Earlier,
+//! tsz emitted TS1090 for every invalid modifier. See issue #16778.
+//!
+//! These assert the *parser* diagnostic list, which contains only the grammar
+//! codes — the semantic TS2369 ("parameter property only allowed in a
+//! constructor") is emitted by the checker and is out of scope here. Binder and
+//! parameter names are varied across rows per the anti-hardcoding contract.
+
+use crate::parser::test_fixture::parse_source;
+
+fn grammar_diags(src: &str) -> Vec<(u32, String)> {
+    let (parser, _root) = parse_source(src);
+    parser
+        .get_diagnostics()
+        .iter()
+        .map(|d| (d.code, d.message.clone()))
+        .collect()
+}
+
+fn codes(src: &str) -> Vec<u32> {
+    grammar_diags(src).into_iter().map(|(c, _)| c).collect()
+}
+
+// --- dedicated code selection ------------------------------------------------
+
+#[test]
+fn abstract_on_function_parameter_is_ts1242() {
+    assert_eq!(
+        grammar_diags("function f(abstract x: number) {}"),
+        vec![(
+            1242,
+            "'abstract' modifier can only appear on a class, method, or property declaration."
+                .to_string()
+        )]
+    );
+}
+
+#[test]
+fn accessor_on_function_parameter_is_ts1275() {
+    assert_eq!(
+        grammar_diags("function draw(accessor pt: number) {}"),
+        vec![(
+            1275,
+            "'accessor' modifier can only appear on a property declaration.".to_string()
+        )]
+    );
+}
+
+#[test]
+fn in_and_out_on_parameter_are_ts1274() {
+    assert_eq!(
+        grammar_diags("function reduce(in seed: number) {}"),
+        vec![(
+            1274,
+            "'in' modifier can only appear on a type parameter of a class, interface or type alias"
+                .to_string()
+        )]
+    );
+    assert_eq!(
+        grammar_diags("function emit(out sink: number) {}"),
+        vec![(
+            1274,
+            "'out' modifier can only appear on a type parameter of a class, interface or type alias"
+                .to_string()
+        )]
+    );
+}
+
+#[test]
+fn abstract_on_constructor_parameter_is_ts1242() {
+    assert_eq!(
+        codes("class Shape { constructor(abstract radius: number) {} }"),
+        vec![1242]
+    );
+}
+
+#[test]
+fn accessor_on_constructor_parameter_is_ts1275() {
+    assert_eq!(
+        codes("class Box { constructor(accessor width: number) {} }"),
+        vec![1275]
+    );
+}
+
+#[test]
+fn abstract_on_method_setter_and_arrow_parameters_are_ts1242() {
+    assert_eq!(
+        codes("class C { render(abstract node: number) {} }"),
+        vec![1242]
+    );
+    assert_eq!(
+        codes("class C { set p(abstract value: number) {} }"),
+        vec![1242]
+    );
+    assert_eq!(
+        codes("const g = (abstract item: number) => item;"),
+        vec![1242]
+    );
+    assert_eq!(
+        codes("const o = { run(abstract task: number) {} };"),
+        vec![1242]
+    );
+}
+
+// --- combinations: accessor/readonly and ordering ----------------------------
+
+#[test]
+fn readonly_then_accessor_is_ts1243() {
+    assert_eq!(
+        grammar_diags("function f(readonly accessor entry: number) {}"),
+        vec![(
+            1243,
+            "'accessor' modifier cannot be used with 'readonly' modifier.".to_string()
+        )]
+    );
+    // constructor position too
+    assert_eq!(
+        codes("class Reg { constructor(readonly accessor slot: number) {} }"),
+        vec![1243]
+    );
+}
+
+#[test]
+fn accessor_then_readonly_reports_only_accessor() {
+    // accessor comes first: TS1275, then the run stops (readonly is valid anyway).
+    assert_eq!(
+        codes("function f(accessor readonly node: number) {}"),
+        vec![1275]
+    );
+}
+
+#[test]
+fn static_after_readonly_is_ordering_ts1029() {
+    assert_eq!(
+        grammar_diags("function f(readonly static field: number) {}"),
+        vec![(
+            1029,
+            "'static' modifier must precede 'readonly' modifier.".to_string()
+        )]
+    );
+}
+
+#[test]
+fn accessibility_after_readonly_is_ordering_ts1029() {
+    assert_eq!(
+        grammar_diags("function f(readonly public value: number) {}"),
+        vec![(
+            1029,
+            "'public' modifier must precede 'readonly' modifier.".to_string()
+        )]
+    );
+}
+
+// --- single-report: only the first grammar-invalid modifier fires ------------
+
+#[test]
+fn abstract_then_static_reports_only_abstract() {
+    assert_eq!(
+        codes("function f(abstract static x: number) {}"),
+        vec![1242]
+    );
+}
+
+#[test]
+fn static_then_abstract_reports_only_static() {
+    assert_eq!(
+        codes("function f(static abstract x: number) {}"),
+        vec![1090]
+    );
+}
+
+#[test]
+fn duplicate_abstract_reports_once() {
+    assert_eq!(
+        codes("function f(abstract abstract x: number) {}"),
+        vec![1242]
+    );
+}
+
+// --- regression: modifiers already correct stay correct ----------------------
+
+#[test]
+fn static_export_declare_async_on_parameter_stay_ts1090() {
+    assert_eq!(codes("function f(static x: number) {}"), vec![1090]);
+    assert_eq!(codes("function f(export x: number) {}"), vec![1090]);
+    assert_eq!(codes("function f(declare x: number) {}"), vec![1090]);
+    assert_eq!(codes("function f(async x: number) {}"), vec![1090]);
+}
+
+#[test]
+fn duplicate_accessibility_and_readonly_unchanged() {
+    assert_eq!(codes("function f(public public x: number) {}"), vec![1028]);
+    assert_eq!(
+        codes("function f(readonly readonly x: number) {}"),
+        vec![1030]
+    );
+}
+
+#[test]
+fn valid_parameter_properties_have_no_parser_grammar_error() {
+    // Grammar-valid parameter properties: any TS2369 is the checker's job.
+    assert_eq!(
+        codes(
+            "class C { constructor(public a: number, private b: string, protected c: boolean, readonly d: number) {} }"
+        ),
+        Vec::<u32>::new()
+    );
+}


### PR DESCRIPTION
`parse_parameter_modifiers` (`crates/tsz-parser/src/parser/state_statements_class.rs`) emitted the generic **TS1090** (`'{0}' modifier cannot appear on a parameter.`) for *every* invalid parameter modifier. tsc's `checkGrammarModifiers` instead selects a dedicated code for several modifiers and reports **only the first** grammar-invalid modifier per parameter, then returns.

## Structural rule

When a modifier appears on a `Parameter` node, tsc walks the modifier run left-to-right with a flag accumulator, reports the first grammar violation, and stops. Per modifier: `abstract` → **TS1242**; `accessor` → **TS1243** when `readonly`/`declare` precede else **TS1275**; `in`/`out` → **TS1274**; duplicate → **TS1030**/**TS1028**; out-of-order (e.g. `readonly static`) → **TS1029**; `static`/`export`/`declare`/`async` on a parameter → **TS1090**. The valid parameter-property modifiers (`public`/`private`/`protected`/`readonly`/`override`) produce no grammar error here — their misuse outside a constructor is the checker's semantic **TS2369**.

tsz did all of this through a single generic TS1090 and emitted one per invalid modifier. The fix ports the `Parameter`-relevant arms of tsc's `checkGrammarModifiers` into `parse_parameter_modifiers` (owner: parser, where tsz already emits TS1090/TS1028/TS1029/TS1030 for parameters), keyed on a `SeenParamModifiers` flag accumulator and a single-report `reported` gate. Closes #16778.

### Oracle matrix (`typescript@7.0.2`, grammar codes; TS2369 is the separate semantic check)

| source | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `function f(abstract x) {}` | TS1242 | TS1090 | TS1242 |
| `function f(accessor x) {}` | TS1275 | TS1090 | TS1275 |
| `function f(in x) {}` / `out` | TS1274 | TS1090 | TS1274 |
| method / setter / arrow / object-method / constructor `abstract`/`accessor` param | TS1242 / TS1275 | TS1090 | matches |
| `function f(readonly accessor x) {}` | TS1243 | TS1090 | TS1243 |
| `function f(readonly static x) {}` | TS1029 | TS1090 | TS1029 |
| `function f(abstract static x) {}` | TS1242 (once) | TS1090 ×2 | TS1242 |
| `function f(static abstract x) {}` | TS1090 (once) | TS1090 ×2 | TS1090 |
| `function f(abstract abstract x) {}` | TS1242 (once) | TS1090 ×2 | TS1242 |

Unchanged (regression-guarded): `static`/`export`/`declare`/`async` param → TS1090; duplicate accessibility → TS1028; `readonly readonly` → TS1030; valid ctor parameter properties → no parser grammar error.

### Out of scope (documented in #16778, unchanged here)
- `const`/`default` as a parameter "modifier" (tsc treats them as reserved words → TS1359+TS1005, a parser-recovery path) and the `static static` → TS1005 tokenization quirk.
- TS2369's anchor position (tsc anchors at the first modifier, tsz at the offending one) — a checker concern; grammar codes now match, positions of the semantic TS2369 are a separate follow-up.

## Goal
Goal: hold

## Verification
- New `crates/tsz-parser/tests/parameter_modifier_grammar_tests.rs` (16 rows: dedicated-code selection across function/method/arrow/setter/object/constructor positions, `readonly accessor`→TS1243, ordering `readonly static`/`readonly public`→TS1029, single-report `abstract static`/`static abstract`/`abstract abstract`, and regression rows for static/export/declare/async→TS1090, duplicates→TS1028/TS1030, valid parameter properties) — green.
- `cargo test -p tsz-parser --lib` — 1994 passed / 0 failed (incl. `this_param_modifier_tests`: TS1433-only suppression preserved).
- `cargo test -p tsz-checker --lib modifier` (153) and `… parameter` (563) — green.
- Suppression-safety: a param with an invalid modifier + an unrelated TS2322 + TS2304 emits all three (TS1242/TS1275/TS1274 do not join the suppressing set), matching tsc.
- End-to-end vs `typescript@7.0.2`: all in-scope parameter-modifier grammar codes match across three probe matrices (103 cases); residual diffs are exactly the out-of-scope items above.
- Conformance snapshot (`conformance.sh snapshot --workers 12 --force`) running; result to be posted.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdixMc88E6WxyiMmQkiDDf)_