### PR TITLE
fix(checker): instantiated generic classes drop TS18015/2446 private-brand elaboration

### DIFF
--- a/crates/tsz-checker/src/classes/private_checker.rs
+++ b/crates/tsz-checker/src/classes/private_checker.rs
@@ -66,12 +66,21 @@ impl<'a> CheckerState<'a> {
     ///
     /// Returns `Some(error_message)` if there's a private brand mismatch.
     pub(crate) fn private_brand_mismatch_error(
-        &self,
+        &mut self,
         source: TypeId,
         target: TypeId,
     ) -> Option<String> {
-        let source_brand = self.get_private_brand(source)?;
-        let target_brand = self.get_private_brand(target)?;
+        // `get_private_brand`/`object_shape_for_type` only recognize a
+        // materialized `Object`/`ObjectWithIndex`/`Callable` shape; an
+        // instantiated generic class (`Application`) is opaque to them until
+        // evaluated. Route through the canonical materialize-or-defer
+        // gateway (#15396) so a generic receiver's brand is visible the same
+        // way a plain class's already is.
+        let source_resolved = self.apparent_type_of_receiver_light(source).into_type();
+        let target_resolved = self.apparent_type_of_receiver_light(target).into_type();
+
+        let source_brand = self.get_private_brand(source_resolved)?;
+        let target_brand = self.get_private_brand(target_resolved)?;
 
         if source_brand == target_brand {
             return None;
@@ -89,9 +98,10 @@ impl<'a> CheckerState<'a> {
                 })
         };
 
-        if let (Some((source_member, source_visibility)), Some((target_member, target_visibility))) =
-            (shared_nominal_member(source), shared_nominal_member(target))
-            && source_member == target_member
+        if let (Some((source_member, source_visibility)), Some((target_member, target_visibility))) = (
+            shared_nominal_member(source_resolved),
+            shared_nominal_member(target_resolved),
+        ) && source_member == target_member
             && source_visibility == target_visibility
         {
             // An ES private identifier (`#name`) is a per-class slot: tsc
@@ -99,9 +109,22 @@ impl<'a> CheckerState<'a> {
             // reserves the "separate declarations" wording for
             // modifier-`private`/`protected` members.
             if tsz_solver::utils::is_es_private_identifier_name(&source_member) {
+                // tsc names the *uninstantiated* declaring class here, even
+                // when the receiver is a generic application (`G<number>`
+                // reports the detail as `... in type 'G' ...`, not
+                // `'G<number>'`), and walks to the base that actually
+                // declares the member for inherited private identifiers.
+                let source_class =
+                    self.get_declaring_class_name_for_private_member(source, &source_member);
+                let target_class =
+                    self.get_declaring_class_name_for_private_member(target, &target_member);
                 return Some(format_message(
                     diagnostic_messages::PROPERTY_IN_TYPE_REFERS_TO_A_DIFFERENT_MEMBER_THAT_CANNOT_BE_ACCESSED_FROM_WITHI,
-                    &[&source_member, &self.format_type(source), &self.format_type(target)],
+                    &[
+                        &source_member,
+                        &source_class.unwrap_or_else(|| self.format_type(source)),
+                        &target_class.unwrap_or_else(|| self.format_type(target)),
+                    ],
                 ));
             }
             return Some(match source_visibility {
@@ -119,17 +142,20 @@ impl<'a> CheckerState<'a> {
             });
         }
 
-        let field_name = shared_nominal_member(source)
+        let field_name = shared_nominal_member(source_resolved)
             .map(|(member_name, _)| member_name)
-            .or_else(|| self.get_private_field_name_from_brand(source))
+            .or_else(|| self.get_private_field_name_from_brand(source_resolved))
             .unwrap_or_else(|| "[private field]".to_string());
+
+        let source_class = self.get_declaring_class_name_for_private_member(source, &field_name);
+        let target_class = self.get_declaring_class_name_for_private_member(target, &field_name);
 
         Some(format_message(
             diagnostic_messages::PROPERTY_IN_TYPE_REFERS_TO_A_DIFFERENT_MEMBER_THAT_CANNOT_BE_ACCESSED_FROM_WITHI,
             &[
                 &field_name,
-                &self.format_type(source),
-                &self.format_type(target),
+                &source_class.unwrap_or_else(|| self.format_type(source)),
+                &target_class.unwrap_or_else(|| self.format_type(target)),
             ],
         ))
     }

--- a/crates/tsz-checker/tests/private_brands.rs
+++ b/crates/tsz-checker/tests/private_brands.rs
@@ -1221,6 +1221,76 @@ fn modifier_private_nominal_mismatch_keeps_separate_declarations_wording() {
     );
 }
 
+/// Instantiated generic classes: two *unrelated* generic classes with a
+/// same-spelled `#v` still get the TS18015 "refers to a different member"
+/// elaboration, and tsc names the *uninstantiated* class in that detail
+/// (`'G'`/`'H'`, not `'G<number>'`/`'H<number>'`) even though the enclosing
+/// TS2322 head names the instantiated form.
+#[test]
+fn es_private_identifier_nominal_mismatch_uses_ts18015_wording_for_generic_classes() {
+    let source = r"
+        class G<T> { #v: T; constructor(v: T) { this.#v = v; } }
+        class H<T> { #v: T; constructor(v: T) { this.#v = v; } }
+        const h: H<number> = new G(1);
+        ";
+
+    test_private_brands(source, 1);
+    let diagnostics = collect_private_brand_diagnostics(source);
+    let ts2322 = diagnostics
+        .iter()
+        .find(|diag| diag.code == 2322)
+        .expect("expected TS2322 for generic ES private identifier nominal mismatch");
+    assert_eq!(
+        ts2322.message_text, "Type 'G<number>' is not assignable to type 'H<number>'.",
+        "the head names the instantiated forms"
+    );
+    assert!(
+        ts2322.related_information.iter().any(|info| info
+            .message_text
+            .contains("Property '#v' in type 'G' refers to a different member that cannot be accessed from within type 'H'.")),
+        "Expected TS18015 wording naming the uninstantiated classes in TS2322 related info, got: {ts2322:?}"
+    );
+    assert!(
+        !ts2322
+            .related_information
+            .iter()
+            .any(|info| info.message_text.contains("separate declarations")),
+        "ES private identifiers must not use the modifier-private 'separate declarations' wording, got: {ts2322:?}"
+    );
+}
+
+/// Same rule for modifier-`private` generic classes: the "separate
+/// declarations" wording, not TS18015, and still the uninstantiated class
+/// names.
+#[test]
+fn modifier_private_nominal_mismatch_generic_classes_keeps_separate_declarations_wording() {
+    let source = r"
+        class G<T> { private v: T; constructor(v: T) { this.v = v; } }
+        class H<T> { private v: T; constructor(v: T) { this.v = v; } }
+        const h: H<number> = new G(1);
+        ";
+
+    test_private_brands(source, 1);
+    let diagnostics = collect_private_brand_diagnostics(source);
+    let ts2322 = diagnostics
+        .iter()
+        .find(|diag| diag.code == 2322)
+        .expect("expected TS2322 for generic modifier-private nominal mismatch");
+    assert!(
+        ts2322.related_information.iter().any(|info| info
+            .message_text
+            .contains("Types have separate declarations of a private property 'v'.")),
+        "Expected 'separate declarations' wording in TS2322 related info, got: {ts2322:?}"
+    );
+    assert!(
+        !ts2322
+            .related_information
+            .iter()
+            .any(|info| info.message_text.contains("refers to a different member")),
+        "Modifier-private members must not use the TS18015 wording, got: {ts2322:?}"
+    );
+}
+
 /// Negative control: a derived class (with or without a redeclared `#x`)
 /// stays assignable to its base — the per-class slot is inherited.
 #[test]


### PR DESCRIPTION
When two unrelated generic classes with a same-spelled private member are compared (`class G[T] { #v: T; ... } class H[T] { #v: T; ... } const h: H[number] = new G(1);`), `tsc` adds the nominal-brand elaboration line (`Property '#v' in type 'G' refers to a different member that cannot be accessed from within type 'H'.` for ES-private, or `Types have separate declarations of a private property 'v'.` for modifier-`private`) as related info under the `TS2322`. tsz's `TS2322` head line already matched (`Type 'G[number]' is not assignable to type 'H[number]'.`), but the elaboration was silently missing — leg 2 of #16769.

## Structural rule

When the assignability failure's source/target are an instantiated generic class (`TypeData::Application`), `private_brand_mismatch_error`'s brand/shape lookups (`get_private_brand`, `object_shape_for_type`) only recognize a materialized `Object`/`ObjectWithIndex`/`Callable` shape — an `Application` is opaque to them until evaluated, so the function returned `None` before ever comparing brands. Owner layer: checker (`crates/tsz-checker/src/classes/private_checker.rs`), reached from the shared assignability elaboration path (`error_reporter/assignability.rs`).

Fix: route `source`/`target` through the canonical materialize-or-defer `apparent_type` gateway (#15396's chokepoint, `apparent_type_of_receiver_light`) before the brand/shape lookups — the same mechanism property-access decision sites already use to resolve an `Application` receiver. Separately, `tsc` names the *uninstantiated* declaring class in this specific elaboration (`'G'`, not `'G[number]'`) even though the enclosing `TS2322` head still names the instantiated form, and walks to whichever base in the hierarchy actually declares the member for inherited cases. Reused the existing `get_declaring_class_name_for_private_member` helper (already used for TS18013) instead of hand-rolling `Application`-unwrapping display logic, since it already handles both the `Application`-base-walk and the inherited-declarer-name cases correctly.

## Adjacent cases (oracle-verified against pinned `typescript@7.0.2`)

- ES-private (`#v`) generic mismatch: `TS18015` wording, uninstantiated class names — new test.
- Modifier-`private` generic mismatch: `TS2446` "separate declarations" wording (no class-name display) — new test.
- Generic classes with **differing type-parameter arity** (`Basalt[T,U]` vs `Granite[T]`): manually oracle-verified, same wording.
- Non-generic classes (existing 41 tests in `private_brands.rs`): unaffected, still passing — the `Application`-unwrap path is a no-op for plain classes.
- Negative controls already in the suite (public members, subclass compatibility, same-class assignment) continue to pass.

## Verification

- `cargo test -p tsz-checker --test private_brands`: 43/43 passing (2 new).
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`: clean.
- Two new-test witnesses hand-verified against `typescript@7.0.2` via `node .../bin/tsc --noEmit --strict --target es2022 --pretty false`: exact message match (main line + elaboration).
- `compare-to-parent.sh`/emit not run: this is a related-info-only addition on an already-correct `TS2322` (does not change whether TS2322 fires), matching the 0/0 signature already measured for the same class of change on the sibling legs of #16769 (#16780, #16781). `git diff --name-only` for this PR touches only `crates/tsz-checker/src/classes/private_checker.rs` and its test file — no printer/display-string path shared with conformance fingerprints beyond the elaboration text itself.
- CI: `CI Summary`, `clippy`, `arch-size` all green at head `034c1ac`.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude