### PR TITLE
fix(checker/solver): nominal private-member elaboration on the TS2345 argument path and instantiated generics (#16769)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
@@ -1006,12 +1006,64 @@ impl<'a> CheckerState<'a> {
             })
     }
 
+    /// Resolve the *declaring class* name of `property_name` on `ty`.
+    ///
+    /// Evaluates through instantiated (`Application`) forms first, then reads
+    /// the member's owning class symbol, so an instantiated generic
+    /// (`G<number>`) reports its bare class name `G`. That is the spelling
+    /// `tsc` uses inside a nominal-member elaboration — the top-level
+    /// assignability line still shows the instantiated `G<number>`, but the
+    /// `refers to a different member` detail names the uninstantiated class.
+    pub(super) fn member_declaring_class_name(
+        &mut self,
+        ty: TypeId,
+        property_name: tsz_common::interner::Atom,
+    ) -> Option<String> {
+        let evaluated = self.evaluate_type_with_env(ty);
+        let info = self.property_info_for_display(evaluated, property_name)?;
+        let sym = self.ctx.binder.get_symbol(info.parent_id?)?;
+        Some(sym.escaped_name.clone())
+    }
+
+    /// Build the TS18015 elaboration for an ES private identifier (`#name`)
+    /// nominal mismatch, naming each side's declaring class (uninstantiated).
+    ///
+    /// `fallback_source` / `fallback_target` supply the top-level type display
+    /// for the rare case a side has no resolvable owning class symbol (e.g. an
+    /// anonymous structural source), preserving the historical spelling there.
+    pub(super) fn private_identifier_mismatch_detail(
+        &mut self,
+        source_type: TypeId,
+        target_type: TypeId,
+        property_name: tsz_common::interner::Atom,
+        fallback_source: &str,
+        fallback_target: &str,
+    ) -> String {
+        let prop_name = self.ctx.types.resolve_atom_ref(property_name).to_string();
+        let source_owner = self
+            .member_declaring_class_name(source_type, property_name)
+            .unwrap_or_else(|| fallback_source.to_string());
+        let target_owner = self
+            .member_declaring_class_name(target_type, property_name)
+            .unwrap_or_else(|| fallback_target.to_string());
+        format_message(
+            diagnostic_messages::PROPERTY_IN_TYPE_REFERS_TO_A_DIFFERENT_MEMBER_THAT_CANNOT_BE_ACCESSED_FROM_WITHI,
+            &[&prop_name, &source_owner, &target_owner],
+        )
+    }
+
     pub(super) fn nominal_mismatch_detail(
-        &self,
+        &mut self,
         source_type: TypeId,
         target_type: TypeId,
         property_name: tsz_common::interner::Atom,
     ) -> Option<String> {
+        // Evaluate through instantiated (`Application`) forms so a generic
+        // modifier-`private` pair (`class A<T> { private s } … : B<U> = new A()`)
+        // resolves the member and its visibility rather than dropping the
+        // elaboration.
+        let source_type = self.evaluate_type_with_env(source_type);
+        let target_type = self.evaluate_type_with_env(target_type);
         let source_prop = self.property_info_for_display(source_type, property_name)?;
         let target_prop = self.property_info_for_display(target_type, property_name)?;
         if source_prop.visibility != target_prop.visibility

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -602,6 +602,52 @@ impl<'a> CheckerState<'a> {
                     kind: RelatedInformationKind::ChainLink,
                 }]
             }
+            SubtypeFailureReason::PropertyNominalMismatch { property_name } => {
+                // Two unrelated classes each declare a same-spelled modifier
+                // `private`/`protected` member. tsc elaborates the argument
+                // mismatch (TS2345) with the same `Types have separate
+                // declarations of a … property 'x'.` line it attaches to the
+                // assignment (TS2322) surface; route it through the shared
+                // `nominal_mismatch_detail` builder so both surfaces agree.
+                // `nominal_mismatch_detail` evaluates through instantiated forms
+                // itself, so pass the raw types (matching the sibling arm below).
+                let detail = self.nominal_mismatch_detail(source, target, *property_name)?;
+                vec![DiagnosticRelatedInformation {
+                    category: DiagnosticCategory::Error,
+                    code: reason.diagnostic_code(),
+                    file: self.ctx.file_name.clone(),
+                    start,
+                    length,
+                    message_text: detail,
+                    depth: 0,
+                    kind: RelatedInformationKind::ChainLink,
+                }]
+            }
+            SubtypeFailureReason::PrivateIdentifierMemberMismatch { property_name } => {
+                // ES private identifier (`#name`) counterpart of the arm above:
+                // tsc's TS18015 `Property '#x' in type 'A' refers to a different
+                // member …` line, naming each side's declaring class. Shared with
+                // the assignment renderer (`render_private_identifier_member_mismatch`).
+                let (source_str, target_str) = self
+                    .format_top_level_assignability_message_types_at(source, target, anchor_idx);
+                let detail = self.private_identifier_mismatch_detail(
+                    source,
+                    target,
+                    *property_name,
+                    &source_str,
+                    &target_str,
+                );
+                vec![DiagnosticRelatedInformation {
+                    category: DiagnosticCategory::Error,
+                    code: reason.diagnostic_code(),
+                    file: self.ctx.file_name.clone(),
+                    start,
+                    length,
+                    message_text: detail,
+                    depth: 0,
+                    kind: RelatedInformationKind::ChainLink,
+                }]
+            }
             SubtypeFailureReason::ReturnTypeMismatch {
                 source_return,
                 target_return,

--- a/crates/tsz-checker/src/error_reporter/render_failure_property_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure_property_helpers.rs
@@ -525,10 +525,16 @@ impl<'a> CheckerState<'a> {
             base,
             diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
         );
-        let prop_name = self.ctx.types.resolve_atom_ref(property_name);
-        let detail = format_message(
-            diagnostic_messages::PROPERTY_IN_TYPE_REFERS_TO_A_DIFFERENT_MEMBER_THAT_CANNOT_BE_ACCESSED_FROM_WITHI,
-            &[&prop_name, &source_str, &target_str],
+        // The elaboration names each side's *declaring class* (uninstantiated),
+        // not the top-level `source_str`/`target_str` — so `G<number>` still
+        // elaborates as `G`, matching `tsc`. The top-level strings remain the
+        // fallback for a side with no resolvable owning class.
+        let detail = self.private_identifier_mismatch_detail(
+            ctx.source,
+            ctx.target,
+            property_name,
+            &source_str,
+            &target_str,
         );
         diag.push_elaboration(detail, reason.diagnostic_code(), 0);
         diag

--- a/crates/tsz-checker/tests/private_brands.rs
+++ b/crates/tsz-checker/tests/private_brands.rs
@@ -1261,3 +1261,166 @@ fn source_without_es_private_member_stays_missing_property() {
         "TS18015 wording must not fire when the source has no same-spelled ES private member, got: {diagnostics:?}"
     );
 }
+
+// =============================================================================
+// #16769 — nominal private-member elaboration on the TS2345 argument path and
+// on instantiated generic classes.
+//
+// The nominal-mismatch elaboration must attach wherever the relation failure is
+// rendered, not only on the assignment (TS2322) surface. Two unrelated classes
+// that each declare a same-spelled `private`/`#private` member are nominally
+// distinct; tsc attaches "Types have separate declarations of a private
+// property 'x'." (modifier-private) or TS18015 "Property '#x' in type 'A'
+// refers to a different member ..." (ES-private) to both TS2322 and TS2345, and
+// names the *uninstantiated* declaring class in the TS18015 detail even for an
+// instantiated generic.
+// =============================================================================
+
+fn related_or_message_contains(diagnostics: &[Diagnostic], code: u32, needle: &str) -> bool {
+    diagnostics.iter().filter(|d| d.code == code).any(|d| {
+        d.message_text.contains(needle)
+            || d.related_information
+                .iter()
+                .any(|info| info.message_text.contains(needle))
+    })
+}
+
+/// Leg 1, modifier-`private`: the TS2345 argument path carries the same
+/// "separate declarations" elaboration as the assignment path.
+#[test]
+fn ts2345_argument_modifier_private_carries_separate_declarations() {
+    let source = r"
+        class M2 { private s = 1; }
+        class N2 { private s = 1; }
+        declare function g(n: N2): void;
+        g(new M2());
+        ";
+    let diagnostics = collect_private_brand_diagnostics(source);
+    assert!(
+        related_or_message_contains(
+            &diagnostics,
+            2345,
+            "Types have separate declarations of a private property 's'."
+        ),
+        "TS2345 argument mismatch must carry the nominal elaboration, got: {diagnostics:?}"
+    );
+}
+
+/// Leg 1, ES-private (`#name`) via a `new`-expression argument: TS2345 carries
+/// the TS18015 detail naming each side's declaring class.
+#[test]
+fn ts2345_argument_es_private_carries_ts18015() {
+    let source = r"
+        class Alpha { #s = 1; }
+        class Beta { #s = 1; }
+        declare function takeBeta(b: Beta): void;
+        takeBeta(new Alpha());
+        ";
+    let diagnostics = collect_private_brand_diagnostics(source);
+    assert!(
+        related_or_message_contains(
+            &diagnostics,
+            2345,
+            "Property '#s' in type 'Alpha' refers to a different member that cannot be accessed from within type 'Beta'."
+        ),
+        "TS2345 argument mismatch must carry the TS18015 detail, got: {diagnostics:?}"
+    );
+}
+
+/// Renamed binders must not matter — the rule is structural, keyed on the
+/// nominal member, not on the class/parameter identifiers.
+#[test]
+fn ts2345_argument_modifier_private_renamed_binders() {
+    let source = r"
+        class Zeta { private q = 1; }
+        class Omega { private q = 1; }
+        declare function needOmega(o: Omega): void;
+        needOmega(new Zeta());
+        ";
+    let diagnostics = collect_private_brand_diagnostics(source);
+    assert!(
+        related_or_message_contains(
+            &diagnostics,
+            2345,
+            "Types have separate declarations of a private property 'q'."
+        ),
+        "renamed binders must still carry the nominal elaboration, got: {diagnostics:?}"
+    );
+}
+
+/// Leg 2, ES-private on instantiated generic classes: the TS2322 elaboration
+/// names the *uninstantiated* declaring classes (`G`/`H`) even though the
+/// top-level line shows `G<number>`/`H<string>`.
+#[test]
+fn ts2322_generic_es_private_names_uninstantiated_classes() {
+    let source = r"
+        class G<T> { #v: T; constructor(v: T) { this.#v = v; } }
+        class H<T> { #v: T; constructor(v: T) { this.#v = v; } }
+        const h: H<string> = new G<number>(1);
+        ";
+    let diagnostics = collect_private_brand_diagnostics(source);
+    let ts2322 = diagnostics
+        .iter()
+        .find(|d| d.code == 2322)
+        .expect("expected TS2322 for the generic nominal mismatch");
+    assert!(
+        ts2322.message_text.contains("G<number>") && ts2322.message_text.contains("H<string>"),
+        "top-level line keeps the instantiated spelling, got: {ts2322:?}"
+    );
+    assert!(
+        ts2322.related_information.iter().any(|info| info.message_text.contains(
+            "Property '#v' in type 'G' refers to a different member that cannot be accessed from within type 'H'."
+        )),
+        "elaboration must name the uninstantiated declaring classes, got: {ts2322:?}"
+    );
+}
+
+/// Leg 2, modifier-`private` on instantiated generic classes: the TS2322
+/// assignment path now also carries the "separate declarations" elaboration
+/// (previously dropped because the brand query could not see through the
+/// instantiated form).
+#[test]
+fn ts2322_generic_modifier_private_carries_separate_declarations() {
+    let source = r"
+        class G<T> { private v: T; constructor(v: T) { this.v = v; } }
+        class H<T> { private v: T; constructor(v: T) { this.v = v; } }
+        const h: H<string> = new G<number>(1);
+        ";
+    let diagnostics = collect_private_brand_diagnostics(source);
+    assert!(
+        related_or_message_contains(
+            &diagnostics,
+            2322,
+            "Types have separate declarations of a private property 'v'."
+        ),
+        "instantiated generic modifier-private assignment must carry the nominal elaboration, got: {diagnostics:?}"
+    );
+}
+
+/// Negative control: a structural argument failure with no shared nominal
+/// member keeps its ordinary missing-property elaboration (TS2741) and never
+/// grows a spurious nominal line.
+#[test]
+fn ts2345_argument_structural_failure_has_no_nominal_line() {
+    let source = r"
+        class P { a = 1; }
+        declare function needsB(x: { b: number }): void;
+        needsB(new P());
+        ";
+    let diagnostics = collect_private_brand_diagnostics(source);
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2345 || d.code == 2741),
+        "expected a structural argument failure, got: {diagnostics:?}"
+    );
+    assert!(
+        !diagnostics.iter().any(|d| {
+            d.message_text.contains("separate declarations")
+                || d.message_text.contains("refers to a different member")
+                || d.related_information.iter().any(|info| {
+                    info.message_text.contains("separate declarations")
+                        || info.message_text.contains("refers to a different member")
+                })
+        }),
+        "a purely structural failure must not carry a nominal elaboration, got: {diagnostics:?}"
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -1565,6 +1565,13 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             rustc_hash::FxHashSet::default();
         for t_prop in target_props {
             if !t_prop.optional {
+                // Skip the synthetic `__private_brand_*` marker (`tsc` never reports it
+                // missing) so a distinct-brand pair reaches the nominal second pass.
+                if crate::utils::is_synthetic_private_brand_name(
+                    self.interner.resolve_atom_ref(t_prop.name).as_ref(),
+                ) {
+                    continue;
+                }
                 let s_prop = self.lookup_property(source_props, source_shape_id, t_prop.name);
                 if s_prop.is_none() && seen_names.insert(t_prop.name) {
                     missing_with_order.push((


### PR DESCRIPTION
Fixes #16769.

The nominal private-member mismatch elaboration (`Types have separate declarations of a private property 'x'.` / TS18015 `Property '#x' in type 'A' refers to a different member that cannot be accessed from within type 'B'.`) was dropped on the TS2345 call-argument path and on instantiated generic classes, for both modifier-`private` and ES-private (`#name`) members.

**Structural rule:** when two unrelated classes each declare a same-spelled `private`/`#`-private member, the member is nominally distinct and `tsc` attaches the same nominal-mismatch elaboration wherever the relation failure is rendered — the assignment (TS2322) surface **and** the call-argument (TS2345) surface — and names the *uninstantiated* declaring class in the TS18015 detail even when the top-level line shows the instantiated form (`G<number>`). tsz owned the elaboration only on the assignment path (via the checker-side `private_brand_mismatch_error` interception), which additionally could not see through an instantiated `Application` form.

Owner layers:

- **Solver** (`relations/subtype/explain.rs`): the synthetic `__private_brand_*` marker is tsz-internal nominal bookkeeping that `tsc` never lists as a missing property. `explain_object_failure` now skips it in the missing-property collection, so a distinct-brand pair no longer collapses to `MissingProperty` on the brand atom and instead falls through to the nominal second pass — surfacing `PropertyNominalMismatch` / `PrivateIdentifierMemberMismatch`, the reasons whose elaboration matches `tsc` on every relation surface. The explain pass already evaluates `Application` operands, so this reaches instantiated generics too.
- **Checker** (`error_reporter/fingerprint_policy.rs`): `related_from_failure_reason` (the TS2345 argument render path) gains arms for those two reasons, routed through the shared detail builders so the argument surface carries the same elaboration as the assignment surface.
- **Checker** (`error_reporter/render_failure_property_helpers.rs`, `assignability_helpers.rs`): the ES-private elaboration now names each side's uninstantiated declaring class via `member_declaring_class_name`, so `G<number>` still elaborates as `G`; `nominal_mismatch_detail` evaluates through instantiated forms so a generic modifier-`private` pair elaborates too.

Derived once from the solver failure reason, attached wherever the relation failure is rendered — no per-path special case.

Adjacent-case matrix, all matching `typescript@7.0.2` `--noEmit --target es2022`: modifier-`private` and `#`-private TS2345 arguments, `new`-expression argument position, renamed binders, generic `#`-private assignment (elaboration names uninstantiated `G`/`H`), generic modifier-`private` assignment, subclass / type-alias source (`Sub`, `GAlias<number>`), and a structural-failure negative control (no spurious nominal line).

## Goal
Goal: hold

## Verification
- `cargo test --release -p tsz-checker --test private_brands` — 47 passed (41 existing + 6 new adjacent-case tests).
- CLI parity confirmed on all rows above against pinned `typescript@7.0.2`.
- Conformance snapshot (`conformance.sh snapshot --workers 12 --force`): net **+24** vs baseline (11499 → 11523 pass); the single PASS→FAIL (`arbitraryModuleNamespaceIdentifiers_syntax`, a parser TS1003 test) is unrelated run-to-run fingerprint nondeterminism (#16309) — verified my binary emits only TS1003 there, deterministically, with zero diagnostics in this change's domain.
- `cargo clippy --profile dist-fast -p tsz-checker -p tsz-solver` and the architecture guard (LOC + boundaries) pass via the pre-commit hook.
- Emit / fourslash: not a suite this change can affect — the change is diagnostic-elaboration-only and the emitter/LSP crates are untouched (the emit harness was additionally blocked on an environment npm-install hang).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_018P6w88ummYwCM2wEFR4Gw9)_