### PR TITLE
fix(checker): protected-member brand mismatch reports TS2443, not fabricated wording

### DIFF
--- a/crates/tsz-checker/src/classes/private_checker.rs
+++ b/crates/tsz-checker/src/classes/private_checker.rs
@@ -1,6 +1,6 @@
 //! Private field access and brand checking for nominal class typing.
 
-use crate::diagnostics::{diagnostic_messages, format_message, internal_elaboration_messages};
+use crate::diagnostics::{diagnostic_messages, format_message};
 use crate::state::CheckerState;
 use tsz_solver::TypeId;
 
@@ -84,43 +84,48 @@ impl<'a> CheckerState<'a> {
                         let prop_name = self.ctx.types.resolve_atom_ref(prop.name);
                         (!tsz_solver::utils::is_synthetic_private_brand_name(&prop_name)
                             && prop.visibility != tsz_solver::Visibility::Public)
-                            .then(|| (prop_name.to_string(), prop.visibility))
+                            .then(|| (prop_name.to_string(), prop.visibility, prop.parent_id))
                     })
                 })
         };
 
-        if let (Some((source_member, source_visibility)), Some((target_member, target_visibility))) =
-            (shared_nominal_member(source), shared_nominal_member(target))
+        if let (
+            Some((source_member, source_visibility, source_parent)),
+            Some((target_member, target_visibility, target_parent)),
+        ) = (shared_nominal_member(source), shared_nominal_member(target))
             && source_member == target_member
             && source_visibility == target_visibility
         {
             // An ES private identifier (`#name`) is a per-class slot: tsc
             // reports TS18015 ("refers to a different member") for it, and
             // reserves the "separate declarations" wording for
-            // modifier-`private`/`protected` members.
+            // modifier-`private` members.
             if tsz_solver::utils::is_es_private_identifier_name(&source_member) {
                 return Some(format_message(
                     diagnostic_messages::PROPERTY_IN_TYPE_REFERS_TO_A_DIFFERENT_MEMBER_THAT_CANNOT_BE_ACCESSED_FROM_WITHI,
                     &[&source_member, &self.format_type(source), &self.format_type(target)],
                 ));
             }
-            return Some(match source_visibility {
-                tsz_solver::Visibility::Private => format_message(
+            return match source_visibility {
+                tsz_solver::Visibility::Private => Some(format_message(
                     diagnostic_messages::TYPES_HAVE_SEPARATE_DECLARATIONS_OF_A_PRIVATE_PROPERTY,
                     &[&source_member],
-                ),
-                tsz_solver::Visibility::Protected => format_message(
-                    internal_elaboration_messages::TYPES_HAVE_SEPARATE_DECLARATIONS_OF_A_PROTECTED_PROPERTY,
-                    &[&source_member],
+                )),
+                tsz_solver::Visibility::Protected => self.protected_brand_mismatch_error(
+                    &source_member,
+                    source,
+                    target,
+                    source_parent,
+                    target_parent,
                 ),
                 tsz_solver::Visibility::Public => {
                     unreachable!("public members do not create nominal brands")
                 }
-            });
+            };
         }
 
         let field_name = shared_nominal_member(source)
-            .map(|(member_name, _)| member_name)
+            .map(|(member_name, _, _)| member_name)
             .or_else(|| self.get_private_field_name_from_brand(source))
             .unwrap_or_else(|| "[private field]".to_string());
 
@@ -130,6 +135,55 @@ impl<'a> CheckerState<'a> {
                 &field_name,
                 &self.format_type(source),
                 &self.format_type(target),
+            ],
+        ))
+    }
+
+    // =========================================================================
+    // Protected Brand Mismatch Error
+    // =========================================================================
+
+    /// tsc's `propertyRelatedTo` never treats two differently-declared
+    /// `protected` members as a "separate declarations" mismatch the way it
+    /// does for `private`. It instead runs `isValidOverrideOf`: the mismatch
+    /// is only an error when the source's declaring class is *not* derived
+    /// from the target's declaring class (`hasBaseType`); a subclass legally
+    /// narrowing an inherited protected member is not an error at all. When
+    /// it does fail, tsc reports `TS2443` ("Property '{0}' is protected but
+    /// type '{1}' is not a class derived from '{2}'.") naming each side's
+    /// declaring class, not the receiver type itself.
+    ///
+    /// Returns `None` when the override is valid (no mismatch to report).
+    pub(crate) fn protected_brand_mismatch_error(
+        &self,
+        member_name: &str,
+        source: TypeId,
+        target: TypeId,
+        source_parent: Option<tsz_binder::SymbolId>,
+        target_parent: Option<tsz_binder::SymbolId>,
+    ) -> Option<String> {
+        if let (Some(source_sym), Some(target_sym)) = (source_parent, target_parent)
+            && (source_sym == target_sym
+                || self
+                    .ctx
+                    .inheritance_graph
+                    .is_derived_from(source_sym, target_sym))
+        {
+            return None;
+        }
+
+        let declaring_class_display_name = |sym: Option<tsz_binder::SymbolId>, fallback: TypeId| {
+            sym.and_then(|sym| self.get_class_declaration_from_symbol(sym))
+                .map(|class_idx| self.get_syntactic_class_name_or_anonymous(class_idx))
+                .unwrap_or_else(|| self.format_type(fallback))
+        };
+
+        Some(format_message(
+            diagnostic_messages::PROPERTY_IS_PROTECTED_BUT_TYPE_IS_NOT_A_CLASS_DERIVED_FROM,
+            &[
+                member_name,
+                &declaring_class_display_name(source_parent, source),
+                &declaring_class_display_name(target_parent, target),
             ],
         ))
     }

--- a/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
@@ -1,9 +1,7 @@
 //! Helper methods for assignability error reporting.
 //! Extracted from `assignability.rs` for maintainability.
 
-use crate::diagnostics::{
-    diagnostic_codes, diagnostic_messages, format_message, internal_elaboration_messages,
-};
+use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
 use crate::error_reporter::assignability::is_object_prototype_method;
 use crate::error_reporter::fingerprint_policy::{
     DiagnosticAnchorKind, DiagnosticRenderRequest, RelatedInformationPolicy,
@@ -1025,10 +1023,13 @@ impl<'a> CheckerState<'a> {
                 diagnostic_messages::TYPES_HAVE_SEPARATE_DECLARATIONS_OF_A_PRIVATE_PROPERTY,
                 &[&prop_name],
             )),
-            tsz_solver::Visibility::Protected => Some(format_message(
-                internal_elaboration_messages::TYPES_HAVE_SEPARATE_DECLARATIONS_OF_A_PROTECTED_PROPERTY,
-                &[&prop_name],
-            )),
+            tsz_solver::Visibility::Protected => self.protected_brand_mismatch_error(
+                &prop_name,
+                source_type,
+                target_type,
+                source_prop.parent_id,
+                target_prop.parent_id,
+            ),
             tsz_solver::Visibility::Public => None,
         }
     }

--- a/crates/tsz-checker/src/types/queries/core.rs
+++ b/crates/tsz-checker/src/types/queries/core.rs
@@ -1765,7 +1765,7 @@ impl<'a> CheckerState<'a> {
     /// name, else the enclosing `VariableDeclaration` binding name (tsc
     /// names `const C = class {…}` as 'C' via the class symbol), else the
     /// exact tsc placeholder `"(Anonymous class)"`.
-    fn get_syntactic_class_name_or_anonymous(&self, class_idx: NodeIndex) -> String {
+    pub(crate) fn get_syntactic_class_name_or_anonymous(&self, class_idx: NodeIndex) -> String {
         let syntactic = self
             .ctx
             .arena

--- a/crates/tsz-checker/tests/private_brands.rs
+++ b/crates/tsz-checker/tests/private_brands.rs
@@ -196,10 +196,15 @@ fn test_private_member_prevents_structural_assignment() {
 
 /// Test that protected members are also nominal.
 /// Protected members create a brand just like private members.
+///
+/// Oracle-verified against `typescript@7.0.2`: unlike modifier-`private`,
+/// tsc never reports a "separate declarations" wording for `protected` — it
+/// runs the declaring-class derivation check (`isValidOverrideOf`) and
+/// reports `TS2443` naming each side's declaring class.
 #[test]
 fn test_protected_members_are_nominal() {
     // TS2322: Type 'B' is not assignable to type 'A'.
-    //   Types have separate declarations of a protected property 'x'.
+    //   Property 'x' is protected but type 'B' is not a class derived from 'A'.
     let source = r"
         class A { protected x: number = 1; }
         class B { protected x: number = 1; }
@@ -215,8 +220,49 @@ fn test_protected_members_are_nominal() {
     assert!(
         ts2322.related_information.iter().any(|info| info
             .message_text
-            .contains("Types have separate declarations of a protected property 'x'.")),
-        "Expected nominal protected-property detail in TS2322 related info, got: {ts2322:?}"
+            .contains("Property 'x' is protected but type 'B' is not a class derived from 'A'.")),
+        "Expected TS2443 protected-derivation detail in TS2322 related info, got: {ts2322:?}"
+    );
+}
+
+/// A subclass narrowing an inherited protected member is a *valid* override
+/// (`isValidOverrideOf` succeeds since the source's declaring class — the
+/// subclass — is derived from the target's declaring class). tsc reports no
+/// protected-mismatch elaboration at all here; oracle-verified against
+/// `typescript@7.0.2`.
+#[test]
+fn test_protected_member_valid_override_has_no_mismatch_elaboration() {
+    let source = r"
+        class Base { protected s: number = 1; }
+        class Derived extends Base { protected s: number = 2; }
+        let b: Base = new Derived();
+        ";
+
+    test_private_brands(source, 0);
+}
+
+/// The same `TS2443` derivation check applies to the call-argument (`TS2345`)
+/// path, which routes through the same `private_brand_mismatch_error`.
+/// Oracle-verified against `typescript@7.0.2`.
+#[test]
+fn test_protected_member_mismatch_elaborates_ts2345() {
+    let source = r"
+        class M3 { protected s = 1; }
+        class N3 { protected s = 1; }
+        declare function g(n: N3): void;
+        g(new M3());
+        ";
+
+    let diagnostics = collect_private_brand_diagnostics(source);
+    let ts2345 = diagnostics
+        .iter()
+        .find(|diag| diag.code == 2345)
+        .expect("expected TS2345 for protected nominal mismatch on a call argument");
+    assert!(
+        ts2345.related_information.iter().any(|info| info
+            .message_text
+            .contains("Property 's' is protected but type 'M3' is not a class derived from 'N3'.")),
+        "Expected TS2443 protected-derivation detail in TS2345 related info, got: {ts2345:?}"
     );
 }
 


### PR DESCRIPTION
When two class types have a same-named, same-visibility `protected` member and one is assigned/passed to the other, `private_brand_mismatch_error` (`crates/tsz-checker/src/classes/private_checker.rs`) emitted `internal_elaboration_messages::TYPES_HAVE_SEPARATE_DECLARATIONS_OF_A_PROTECTED_PROPERTY` — `"Types have separate declarations of a protected property '{0}'."` — a message that **does not exist anywhere in tsc's diagnostic catalog** (confirmed by grepping the full compiled `typescript.js` message table).

## Structural rule

When a `protected` property on the assignment/argument source and target share a name, `tsc`'s `propertyRelatedTo` (checker.ts) never treats this as a "separate declarations" mismatch — that wording is reserved for modifier-`private`. For `protected`, `tsc` runs `isValidOverrideOf(sourceProp, targetProp)`: a declaring-class subtype check (`hasBaseType(sourceClass, targetClass)`). When it fails, `tsc` reports **TS2443** (`"Property '{0}' is protected but type '{1}' is not a class derived from '{2}'."`) naming each side's *declaring* class, not the receiver type. When it succeeds — e.g. a subclass narrowing an inherited protected member — `tsc` reports **no mismatch at all**. tsz previously always flagged an error in this shape, even for valid overrides.

tsz already had the TS2443 message auto-generated in its diagnostic catalog (`diagnostic_messages::PROPERTY_IS_PROTECTED_BUT_TYPE_IS_NOT_A_CLASS_DERIVED_FROM`, `crates/tsz-common/src/diagnostics/data/parts/part_000.rs:617`) but never emitted it from this path.

Fix, owned by the checker (`crates/tsz-checker/src/classes/private_checker.rs`): a new `protected_brand_mismatch_error` helper uses `PropertyInfo::parent_id` (the declaring class's `SymbolId`, already tracked on every class member property) and `CheckerContext::inheritance_graph.is_derived_from` to replicate `isValidOverrideOf`. Declaring-class display names reuse the existing `get_class_declaration_from_symbol` / `get_syntactic_class_name_or_anonymous` helpers (now `pub(crate)`), falling back to the receiver type's own display name when a property has no declaring-class symbol (mirrors tsc's `getDeclaringClass(prop) || receiverType` fallback).

`crates/tsz-checker/src/error_reporter/assignability_helpers.rs`'s `nominal_mismatch_detail` had the identical fabricated-message bug on a sibling property-display path (used by `render_failure_property_helpers.rs`) — same root cause, same fix, reused directly rather than duplicated.

Both `TS2322` (assignment) and `TS2345` (call-argument) elaboration route through `private_brand_mismatch_error`, so both are fixed together.

**Out of scope** (left untouched, no fabricated text introduced): `crates/tsz-checker/src/classes/class_checker.rs`'s `visibility_conflict_elaboration`, which uses the same fake string but for the structurally different `TS2415` ("class incorrectly extends base class") heritage-checking path — that needs its own oracle pass, not assumed identical to this one. Filed as a NOTE on the agent-coordination board (#15994) for a follow-up slice. Also out of scope: generic classes (declaring-class display would need `typeToString`-style instantiation rendering, not the bare syntactic name this PR uses) — matches this session's other narrow-slice precedent.

## Adjacent matrix (oracle-verified against pinned `typescript@7.0.2`)

- Two unrelated classes, same-named `protected` member (assignment, `TS2322`): now `"Property 'x' is protected but type 'B' is not a class derived from 'A'."` — byte-identical to tsc.
- Same shape via a call argument (`TS2345`): same TS2443 wording under the argument-path elaboration, byte-identical to tsc.
- Valid override — `class Derived extends Base` both declaring the same protected member: **no elaboration at all**, matching tsc (previously tsz always reported the fake "separate declarations" text here too).
- Modifier-`private` same-name mismatch: unchanged, still `TS2442` "separate declarations" wording (this PR only touches the `Protected` arm).
- ES `#`-private mismatch: unchanged, still `TS18015` "refers to a different member" wording.
- Mixed `protected`/`public` visibility and purely-structural mismatches: unchanged (these never reach the `shared_nominal_member`-matched branch this PR touches, since it requires equal visibility on both sides).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test private_brands`: **43/43 passed** (1 existing test updated to the corrected TS2443 wording, 2 new tests added: valid-override no-elaboration, and the TS2345 argument-path witness).
- `cargo test -p tsz-checker --lib -- property assignability nominal`: **1673 passed / 0 failed** (1 pre-existing ignored, unrelated).
- `cargo clippy` (workspace, `-D warnings`) and `python3 scripts/arch/arch_guard.py`: clean, via the pre-commit hook (`Clippy passed. Architecture guard passed. Local verification passed.`).
- `cargo build --profile dist-fast -p tsz-cli --bin tsz`: clean release build. Manually diffed the compiled binary's output against the pinned `typescript@7.0.2` oracle (`node .../bin/tsc --noEmit --strict --target es2022 --pretty false`) for all four adjacent-matrix witnesses above — every line byte-identical, including the previously-wrong valid-override negative control (now silent on both sides).
- `compare-to-parent.sh` / conformance snapshot: not run this session (no TypeScript corpus checked out in this container). This changes *diagnostic wording only* on an existing `TS2322`/`TS2345` path (does not change whether the diagnostic fires) plus a `None`-vs-`Some` change confined to the narrow valid-override shape — risk is limited to fixtures whose expected text includes the fabricated "separate declarations of a protected property" string, which — per the grep above — never appears in the real corpus since it's not a real tsc message.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqj33bs29kSaDtWTPrgY13)_