### PR TITLE
fix(checker): TS18031 elaboration for disjoint-object-literal intersections

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2733,3 +2733,6 @@ path = "tests/ts2433_cross_file_ambient_class_merge_tests.rs"
 [[test]]
 name = "ts2345_primitive_key_union_constraint_display_tests"
 path = "tests/ts2345_primitive_key_union_constraint_display_tests.rs"
+[[test]]
+name = "ts18031_intersection_never_conflict_elaboration_tests"
+path = "tests/ts18031_intersection_never_conflict_elaboration_tests.rs"

--- a/crates/tsz-checker/src/error_reporter/core/declared_intersection_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/declared_intersection_display.rs
@@ -2,6 +2,7 @@
 
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
+use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
     pub(in crate::error_reporter) fn declared_intersection_annotation_display_for_expression(
@@ -11,6 +12,67 @@ impl<'a> CheckerState<'a> {
         let annotation_idx =
             self.declared_current_arena_annotation_node_for_expression(expr_idx)?;
         self.format_declared_intersection_annotation_node(annotation_idx)
+    }
+
+    /// Like [`Self::declared_intersection_annotation_display_for_expression`],
+    /// but also returns each member's independently-evaluated `TypeId` and has
+    /// no type-literal-member requirement — the sibling function is scoped to
+    /// its own (type-literal-only) callers, while the TS18031 "was reduced to
+    /// never" elaboration needs a plain `interface A & interface B` intersection
+    /// too (oracle-verified against `typescript@7.0.2`).
+    pub(in crate::error_reporter) fn declared_intersection_display_and_members_for_expression(
+        &mut self,
+        expr_idx: NodeIndex,
+    ) -> Option<(String, Vec<TypeId>)> {
+        let annotation_idx =
+            self.declared_current_arena_annotation_node_for_expression(expr_idx)?;
+        self.intersection_display_and_members_from_annotation_node(annotation_idx)
+    }
+
+    fn intersection_display_and_members_from_annotation_node(
+        &mut self,
+        annotation_idx: NodeIndex,
+    ) -> Option<(String, Vec<TypeId>)> {
+        let mut annotation_idx = annotation_idx;
+        while self.ctx.arena.get(annotation_idx).is_some_and(|node| {
+            node.kind == tsz_parser::parser::syntax_kind_ext::PARENTHESIZED_TYPE
+        }) {
+            annotation_idx = self
+                .ctx
+                .arena
+                .get_wrapped_type_at(annotation_idx)?
+                .type_node;
+        }
+
+        let node = self.ctx.arena.get(annotation_idx)?;
+        if node.kind != tsz_parser::parser::syntax_kind_ext::INTERSECTION_TYPE {
+            return None;
+        }
+
+        let member_nodes = self.ctx.arena.get_composite_type(node)?.types.nodes.clone();
+        if member_nodes.len() < 2 {
+            return None;
+        }
+
+        let mut displays = Vec::with_capacity(member_nodes.len());
+        let mut member_types = Vec::with_capacity(member_nodes.len());
+        for member_node in member_nodes {
+            let was_parenthesized = self.ctx.arena.get(member_node).map(|node| node.kind)
+                == Some(tsz_parser::parser::syntax_kind_ext::PARENTHESIZED_TYPE);
+            let member_type = self.get_type_from_type_node(member_node);
+            let display = self.format_type_for_assignability_message(member_type);
+            displays.push(if was_parenthesized {
+                format!("({display})")
+            } else {
+                display
+            });
+            // Resolve `Lazy(DefId)` (a bare interface/class reference) to its
+            // structural shape — the display above intentionally uses the
+            // unresolved type so nominal types still print their name, but the
+            // conflict-property query needs the actual `Object`/`Callable` shape.
+            member_types.push(self.resolve_lazy_type(member_type));
+        }
+        Some((displays.join(" & "), member_types))
     }
 
     fn declared_current_arena_annotation_node_for_expression(

--- a/crates/tsz-checker/src/error_reporter/core/mod.rs
+++ b/crates/tsz-checker/src/error_reporter/core/mod.rs
@@ -12,4 +12,5 @@ mod diagnostic_source;
 mod excess_display;
 mod identifier_source_display;
 mod intersection_optional_display;
+mod never_reduced_intersection_elaboration;
 mod type_display;

--- a/crates/tsz-checker/src/error_reporter/core/never_reduced_intersection_elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/core/never_reduced_intersection_elaboration.rs
@@ -1,0 +1,114 @@
+//! TS18031 elaboration: naming the conflicting property when a
+//! disjoint-object-literal intersection collapses to `never`.
+
+use crate::diagnostics::{
+    DiagnosticCategory, DiagnosticRelatedInformation, RelatedInformationKind, diagnostic_codes,
+    diagnostic_messages, format_message,
+};
+use crate::error_reporter::fingerprint_policy::DiagnosticAnchorKind;
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    /// `error_property_not_exist_at`'s final-fallback `error_at_anchor` call,
+    /// with the TS18031 elaboration attached when it applies: when a
+    /// `never`-typed property-access receiver came from a
+    /// disjoint-object-literal intersection collapsing to `never` at intern
+    /// time (e.g. `interface A { x: 1 } interface B { x: 2 };
+    /// declare const c: A & B;`), tsc attaches `The intersection '...' was
+    /// reduced to 'never' because property '...' has conflicting types in
+    /// some constituents.` as a chain-linked related message. Every other
+    /// `never` cause (primitive-disjoint intersections, explicit `never`,
+    /// exhausted narrowing, ...) falls through to the plain diagnostic —
+    /// oracle-verified against `typescript@7.0.2` that those have no such
+    /// elaboration.
+    pub(in crate::error_reporter) fn error_property_not_exist_with_never_elaboration(
+        &mut self,
+        idx: NodeIndex,
+        type_id: TypeId,
+        message: &str,
+        code: u32,
+    ) {
+        let Some(anchor) = self.resolve_diagnostic_anchor(idx, DiagnosticAnchorKind::PropertyToken)
+        else {
+            return;
+        };
+        let related = self.never_reduced_intersection_conflict_related_info(type_id, idx, &anchor);
+        if related.is_empty() {
+            self.error(anchor.start, anchor.length, message.to_string(), code);
+        } else {
+            self.error_at_span_with_related(anchor.start, anchor.length, message, code, related);
+        }
+    }
+
+    fn never_reduced_intersection_conflict_related_info(
+        &mut self,
+        type_id: TypeId,
+        idx: NodeIndex,
+        anchor: &crate::error_reporter::fingerprint_policy::ResolvedDiagnosticAnchor,
+    ) -> Vec<DiagnosticRelatedInformation> {
+        if type_id != TypeId::NEVER {
+            return Vec::new();
+        }
+        let Some(receiver_idx) = self.property_access_receiver_expression(idx) else {
+            return Vec::new();
+        };
+        let Some((intersection_display, member_types)) =
+            self.declared_intersection_display_and_members_for_expression(receiver_idx)
+        else {
+            return Vec::new();
+        };
+        let Some(atom) = tsz_solver::type_queries::find_disjoint_object_literal_conflict_property(
+            self.ctx.types,
+            &member_types,
+        ) else {
+            return Vec::new();
+        };
+        let prop_name = self.ctx.types.resolve_atom(atom);
+        let message = format_message(
+            diagnostic_messages::THE_INTERSECTION_WAS_REDUCED_TO_NEVER_BECAUSE_PROPERTY_HAS_CONFLICTING_TYPES_IN,
+            &[&intersection_display, &prop_name],
+        );
+        vec![DiagnosticRelatedInformation {
+            category: DiagnosticCategory::Error,
+            code: diagnostic_codes::THE_INTERSECTION_WAS_REDUCED_TO_NEVER_BECAUSE_PROPERTY_HAS_CONFLICTING_TYPES_IN,
+            file: self.ctx.file_name.clone(),
+            start: anchor.start,
+            length: anchor.length,
+            message_text: message,
+            depth: 0,
+            kind: RelatedInformationKind::ChainLink,
+        }]
+    }
+
+    /// The receiver expression of a property/element access, given either the
+    /// access expression node itself or its name/argument node — mirrors
+    /// `property_token_anchor_node`'s node-or-parent dispatch, since
+    /// `error_property_not_exist_at` callers pass either one depending on call
+    /// site.
+    fn property_access_receiver_expression(&self, idx: NodeIndex) -> Option<NodeIndex> {
+        let is_access_expr_kind = |kind: u16| {
+            kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+                || kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+        };
+
+        if let Some(node) = self.ctx.arena.get(idx)
+            && is_access_expr_kind(node.kind)
+            && let Some(access) = self.ctx.arena.get_access_expr(node)
+        {
+            return Some(access.expression);
+        }
+
+        let parent_idx = self.ctx.arena.get_extended(idx)?.parent;
+        let parent_node = self.ctx.arena.get(parent_idx)?;
+        if is_access_expr_kind(parent_node.kind)
+            && let Some(access) = self.ctx.arena.get_access_expr(parent_node)
+            && access.name_or_argument == idx
+        {
+            return Some(access.expression);
+        }
+        None
+    }
+}

--- a/crates/tsz-checker/src/error_reporter/properties.rs
+++ b/crates/tsz-checker/src/error_reporter/properties.rs
@@ -1821,7 +1821,7 @@ impl<'a> CheckerState<'a> {
                     format!("Property '{prop_name}' does not exist on type '{type_display}'."),
                 )
             };
-            self.error_at_anchor(idx, DiagnosticAnchorKind::PropertyToken, &message, code);
+            self.error_property_not_exist_with_never_elaboration(idx, type_id, &message, code);
         }
     }
 }

--- a/crates/tsz-checker/tests/ts18031_intersection_never_conflict_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/ts18031_intersection_never_conflict_elaboration_tests.rs
@@ -1,0 +1,155 @@
+//! TS18031: when a disjoint-object-literal intersection collapses to `never`
+//! at intern time (`crates/tsz-solver/src/intern/normalize.rs`'s
+//! `intersection_has_disjoint_object_literals`), tsc attaches a related-info
+//! line naming the conflicting property:
+//! `The intersection '...' was reduced to 'never' because property '...' has
+//! conflicting types in some constituents.`
+//!
+//! tsz already reports the top-level `TS2339`/`never` correctly; this family
+//! covers the elaboration line, which was previously dropped entirely.
+//! Oracle-verified against `typescript@7.0.2`.
+//!
+//! Scope: this only fires when *exactly one* property name conflicts.
+//! `ObjectShape::properties` is sorted by interned `Atom` id (for canonical
+//! hashing identity), not source declaration order, so when more than one
+//! property conflicts there is no order-independent way to recover tsc's
+//! "first written" choice from the interned shape alone — seeing that is a
+//! silent (not wrong) no-elaboration case, tracked separately.
+
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn ts2339(source: &str) -> Diagnostic {
+    let diagnostics: Vec<Diagnostic> = check_source_diagnostics(source)
+        .into_iter()
+        .filter(|diagnostic| diagnostic.code == 2339)
+        .collect();
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "expected exactly one TS2339 diagnostic, got {diagnostics:#?}"
+    );
+    diagnostics.into_iter().next().unwrap()
+}
+
+fn related_messages(diagnostic: &Diagnostic) -> Vec<String> {
+    diagnostic
+        .related_information
+        .iter()
+        .map(|related| related.message_text.clone())
+        .collect()
+}
+
+#[test]
+fn interface_intersection_single_conflict_names_property() {
+    let diag = ts2339(
+        r"
+interface A { x: 1 }
+interface B { x: 2 }
+declare const c: A & B;
+c.x;
+",
+    );
+    assert_eq!(
+        related_messages(&diag),
+        vec![
+            "The intersection 'A & B' was reduced to 'never' because property 'x' has conflicting types in some constituents."
+        ]
+    );
+}
+
+#[test]
+fn renamed_binders_single_conflict_names_property() {
+    let diag = ts2339(
+        r"
+interface Left { shape: 1 }
+interface Right { shape: 2 }
+declare const value: Left & Right;
+value.shape;
+",
+    );
+    assert_eq!(
+        related_messages(&diag),
+        vec![
+            "The intersection 'Left & Right' was reduced to 'never' because property 'shape' has conflicting types in some constituents."
+        ]
+    );
+}
+
+#[test]
+fn conflict_named_independent_of_accessed_property() {
+    // Only `y` conflicts (`x` is compatible across both members); tsc names
+    // the conflicting property, not the accessed one.
+    let diag = ts2339(
+        r"
+interface A { x: number; y: 'a' }
+interface B { x: number; y: 'b' }
+declare const c: A & B;
+c.x;
+",
+    );
+    assert_eq!(
+        related_messages(&diag),
+        vec![
+            "The intersection 'A & B' was reduced to 'never' because property 'y' has conflicting types in some constituents."
+        ]
+    );
+}
+
+#[test]
+fn multiple_conflicting_properties_omits_ambiguous_elaboration() {
+    // Both `x` and `y` conflict; tsz cannot recover tsc's "first written"
+    // pick from the interned (Atom-sorted) shape, so it stays silent rather
+    // than risk naming the wrong one.
+    let diag = ts2339(
+        r"
+interface A { x: 1; y: 'a' }
+interface B { x: 2; y: 'b' }
+declare const c: A & B;
+c.x;
+",
+    );
+    assert!(related_messages(&diag).is_empty());
+}
+
+#[test]
+fn primitive_disjoint_intersection_has_no_elaboration() {
+    // `string & number` also reduces to `never`, but tsc attaches no
+    // "was reduced to never" elaboration for primitive-disjoint intersections
+    // — only the object-literal-conflict family gets one.
+    let diag = ts2339(
+        r"
+declare const c: string & number;
+c.toString();
+",
+    );
+    assert!(related_messages(&diag).is_empty());
+}
+
+#[test]
+fn explicit_never_receiver_has_no_elaboration() {
+    let diag = ts2339(
+        r"
+declare const c: never;
+c.x;
+",
+    );
+    assert!(related_messages(&diag).is_empty());
+}
+
+#[test]
+fn compatible_intersection_members_report_no_ts2339() {
+    let diagnostics: Vec<Diagnostic> = check_source_diagnostics(
+        r"
+interface A { x: number }
+interface B { y: string }
+declare const c: A & B;
+c.x;
+c.y;
+",
+    )
+    .into_iter()
+    .filter(|diagnostic| diagnostic.code == 2339)
+    .collect();
+    assert!(diagnostics.is_empty(), "unexpected: {diagnostics:#?}");
+}

--- a/crates/tsz-solver/src/intern/mod.rs
+++ b/crates/tsz-solver/src/intern/mod.rs
@@ -35,6 +35,7 @@ pub use self::core::SharedDefVariance;
 pub use self::core::TypeInterner;
 pub use self::core::clear_thread_local_cache;
 pub(crate) use self::core::{PredicateCacheKind, TEMPLATE_LITERAL_EXPANSION_LIMIT, TypeListBuffer};
+pub(crate) use self::normalize::find_disjoint_object_literal_conflict_property;
 pub(crate) use self::tuple_normalization::tuple_normalized;
 pub(crate) use self::union_mode::union_literal_default_enabled;
 // Used by intern_tests.rs (included via #[path] below).

--- a/crates/tsz-solver/src/intern/normalize.rs
+++ b/crates/tsz-solver/src/intern/normalize.rs
@@ -10,6 +10,7 @@
 
 use super::shallow_subtype::ShallowReduceKind;
 use super::{TypeInterner, TypeListBuffer};
+use crate::construction::TypeDatabase;
 use crate::types::{
     IntrinsicKind, LiteralValue, PropertyInfo, TemplateLiteralId, TypeData, TypeId, Visibility,
 };
@@ -763,100 +764,7 @@ impl TypeInterner {
     /// occurrences of the name (O(k) for the common single-literal case) rather
     /// than an O(k²) pairwise comparison.
     fn name_occurrences_disjoint(&self, occurrences: &[PropOccurrence]) -> bool {
-        if occurrences.len() < 2 {
-            return false;
-        }
-
-        // Visibility: a `private` member's declaring-class identity cannot be
-        // satisfied by a public or protected member of the same name, so a private
-        // occurrence alongside any differently-visible occurrence reduces to `never`.
-        // Protected/public mixes stay on the merge path — they can still expose a
-        // public property.
-        let mut has_private = false;
-        let mut has_non_private = false;
-        for occ in occurrences {
-            if occ.visibility == Visibility::Private {
-                has_private = true;
-            } else {
-                has_non_private = true;
-            }
-        }
-        if has_private && has_non_private {
-            return true;
-        }
-
-        // Cross-domain: a literal occurrence whose primitive class differs from
-        // another occurrence's class is disjoint (e.g. `a: ""` (string) & `a: number`).
-        // As with the literal value-set check below, two *optional* occurrences only
-        // make the property itself `never`, so a conflicting pair needs at least one
-        // required side. A pair (literal `L` of class `C_L`, occurrence `X` of class
-        // `C_X != C_L`) is a not-both-optional conflict when either `L` is required
-        // (and any differing class exists) or some required occurrence has a class
-        // distinct from a literal's class.
-        let mut classes: SmallVec<[PrimitiveClass; 8]> = SmallVec::new();
-        let mut literal_classes: SmallVec<[PrimitiveClass; 8]> = SmallVec::new();
-        let mut required_classes: SmallVec<[PrimitiveClass; 8]> = SmallVec::new();
-        let mut has_required_literal = false;
-        for occ in occurrences {
-            let Some(class) = self.primitive_class_for(occ.type_id) else {
-                continue;
-            };
-            if !classes.contains(&class) {
-                classes.push(class);
-            }
-            if !occ.optional && !required_classes.contains(&class) {
-                required_classes.push(class);
-            }
-            if self.is_literal(occ.type_id) {
-                if !literal_classes.contains(&class) {
-                    literal_classes.push(class);
-                }
-                has_required_literal |= !occ.optional;
-            }
-        }
-        let required_literal_cross = has_required_literal && classes.len() >= 2;
-        let literal_vs_required_cross = literal_classes
-            .iter()
-            .any(|lit| required_classes.iter().any(|req| req != lit));
-        if required_literal_cross || literal_vs_required_cross {
-            return true;
-        }
-
-        // Literal value-sets: group literal-typed occurrences by domain. A required
-        // occurrence whose value-set is disjoint from any other occurrence's forces
-        // `never`; two *optional* occurrences only make the property itself `never`,
-        // so a conflicting pair needs at least one required side.
-        let mut by_domain: LiteralOccurrencesByDomain = SmallVec::new();
-        let mut has_required_literal = false;
-        for occ in occurrences {
-            let Some(kind) = self.literal_kind_from_type(occ.type_id) else {
-                continue;
-            };
-            has_required_literal |= !occ.optional;
-            let domain = kind.domain();
-            let lit = LiteralOccurrence {
-                kind,
-                optional: occ.optional,
-            };
-            match by_domain.iter_mut().find(|(d, _)| *d == domain) {
-                Some((_, group)) => group.push(lit),
-                None => {
-                    let mut group = SmallVec::new();
-                    group.push(lit);
-                    by_domain.push((domain, group));
-                }
-            }
-        }
-
-        // Literals drawn from two different domains are mutually disjoint; if any of
-        // them is required the intersection is `never`.
-        if has_required_literal && by_domain.len() >= 2 {
-            return true;
-        }
-
-        by_domain
-            .iter()
-            .any(|(_, group)| Self::literal_group_has_disjoint_pair(group))
+        name_occurrences_disjoint_db(self, occurrences)
     }
 
     /// Within a single literal domain, returns true when some *required* occurrence's
@@ -954,31 +862,7 @@ impl TypeInterner {
     }
 
     fn literal_kind_from_type(&self, type_id: TypeId) -> Option<LiteralKind> {
-        let key = self.lookup(type_id)?;
-        match key {
-            TypeData::Literal(literal) => Some(LiteralKind::Single(literal)),
-            TypeData::Union(members) => {
-                let members = self.type_list(members);
-                let mut domain: Option<LiteralDomain> = None;
-                let mut values = FxHashSet::default();
-                for &member in members.iter() {
-                    let Some(TypeData::Literal(literal)) = self.lookup(member) else {
-                        return None;
-                    };
-                    let literal_domain = literal_domain(&literal);
-                    if let Some(existing) = domain {
-                        if existing != literal_domain {
-                            return None;
-                        }
-                    } else {
-                        domain = Some(literal_domain);
-                    }
-                    values.insert(literal);
-                }
-                domain.map(|domain| LiteralKind::Union(domain, values))
-            }
-            _ => None,
-        }
+        literal_kind_from_type_db(self, type_id)
     }
 
     pub(super) fn literal_domain_from_type(&self, type_id: TypeId) -> Option<LiteralDomain> {
@@ -986,39 +870,7 @@ impl TypeInterner {
     }
 
     pub(crate) fn primitive_class_for(&self, type_id: TypeId) -> Option<PrimitiveClass> {
-        match type_id {
-            TypeId::STRING => return Some(PrimitiveClass::String),
-            TypeId::NUMBER => return Some(PrimitiveClass::Number),
-            TypeId::BOOLEAN => return Some(PrimitiveClass::Boolean),
-            TypeId::BIGINT => return Some(PrimitiveClass::Bigint),
-            TypeId::SYMBOL => return Some(PrimitiveClass::Symbol),
-            TypeId::NULL => return Some(PrimitiveClass::Null),
-            TypeId::UNDEFINED | TypeId::VOID => return Some(PrimitiveClass::Undefined),
-            _ => {}
-        }
-
-        let key = self.lookup(type_id)?;
-
-        match key {
-            TypeData::Intrinsic(kind) => match kind {
-                IntrinsicKind::String => Some(PrimitiveClass::String),
-                IntrinsicKind::Number => Some(PrimitiveClass::Number),
-                IntrinsicKind::Boolean => Some(PrimitiveClass::Boolean),
-                IntrinsicKind::Bigint => Some(PrimitiveClass::Bigint),
-                IntrinsicKind::Symbol => Some(PrimitiveClass::Symbol),
-                IntrinsicKind::Null => Some(PrimitiveClass::Null),
-                IntrinsicKind::Undefined | IntrinsicKind::Void => Some(PrimitiveClass::Undefined),
-                _ => None,
-            },
-            TypeData::Literal(literal) => match literal {
-                LiteralValue::String(_) => Some(PrimitiveClass::String),
-                LiteralValue::Number(_) => Some(PrimitiveClass::Number),
-                LiteralValue::Boolean(_) => Some(PrimitiveClass::Boolean),
-                LiteralValue::BigInt(_) => Some(PrimitiveClass::Bigint),
-            },
-            TypeData::UniqueSymbol(_) => Some(PrimitiveClass::Symbol),
-            _ => None,
-        }
+        primitive_class_for_db(self, type_id)
     }
 
     /// Merge `Enum(D, X) | Enum(D, Y)` into `Enum(D, X | Y)` for same-`DefId` enum
@@ -1763,6 +1615,234 @@ impl TypeInterner {
         // Return the union of all intersections
         Some(self.union(intersection_results))
     }
+}
+
+/// `db`-based counterpart of [`TypeInterner::primitive_class_for`].
+///
+/// Lives as a free function (rather than a `TypeInterner` inherent method) so
+/// it can run against any `&dyn TypeDatabase`, not just the concrete intern
+/// table — the checker only ever holds a trait object.
+fn primitive_class_for_db(db: &dyn TypeDatabase, type_id: TypeId) -> Option<PrimitiveClass> {
+    match type_id {
+        TypeId::STRING => return Some(PrimitiveClass::String),
+        TypeId::NUMBER => return Some(PrimitiveClass::Number),
+        TypeId::BOOLEAN => return Some(PrimitiveClass::Boolean),
+        TypeId::BIGINT => return Some(PrimitiveClass::Bigint),
+        TypeId::SYMBOL => return Some(PrimitiveClass::Symbol),
+        TypeId::NULL => return Some(PrimitiveClass::Null),
+        TypeId::UNDEFINED | TypeId::VOID => return Some(PrimitiveClass::Undefined),
+        _ => {}
+    }
+
+    let key = db.lookup(type_id)?;
+
+    match key {
+        TypeData::Intrinsic(kind) => match kind {
+            IntrinsicKind::String => Some(PrimitiveClass::String),
+            IntrinsicKind::Number => Some(PrimitiveClass::Number),
+            IntrinsicKind::Boolean => Some(PrimitiveClass::Boolean),
+            IntrinsicKind::Bigint => Some(PrimitiveClass::Bigint),
+            IntrinsicKind::Symbol => Some(PrimitiveClass::Symbol),
+            IntrinsicKind::Null => Some(PrimitiveClass::Null),
+            IntrinsicKind::Undefined | IntrinsicKind::Void => Some(PrimitiveClass::Undefined),
+            _ => None,
+        },
+        TypeData::Literal(literal) => match literal {
+            LiteralValue::String(_) => Some(PrimitiveClass::String),
+            LiteralValue::Number(_) => Some(PrimitiveClass::Number),
+            LiteralValue::Boolean(_) => Some(PrimitiveClass::Boolean),
+            LiteralValue::BigInt(_) => Some(PrimitiveClass::Bigint),
+        },
+        TypeData::UniqueSymbol(_) => Some(PrimitiveClass::Symbol),
+        _ => None,
+    }
+}
+
+/// `db`-based counterpart of [`TypeInterner::literal_kind_from_type`].
+fn literal_kind_from_type_db(db: &dyn TypeDatabase, type_id: TypeId) -> Option<LiteralKind> {
+    let key = db.lookup(type_id)?;
+    match key {
+        TypeData::Literal(literal) => Some(LiteralKind::Single(literal)),
+        TypeData::Union(members) => {
+            let members = db.type_list(members);
+            let mut domain: Option<LiteralDomain> = None;
+            let mut values = FxHashSet::default();
+            for &member in members.iter() {
+                let Some(TypeData::Literal(literal)) = db.lookup(member) else {
+                    return None;
+                };
+                let literal_domain = literal_domain(&literal);
+                if let Some(existing) = domain {
+                    if existing != literal_domain {
+                        return None;
+                    }
+                } else {
+                    domain = Some(literal_domain);
+                }
+                values.insert(literal);
+            }
+            domain.map(|domain| LiteralKind::Union(domain, values))
+        }
+        _ => None,
+    }
+}
+
+/// `db`-based counterpart of [`TypeInterner::name_occurrences_disjoint`].
+///
+/// Returns true when the occurrences of a single property name across the
+/// members of an intersection are mutually unsatisfiable, forcing the whole
+/// intersection to `never`. See the `TypeInterner` method this delegates from
+/// for the per-check rationale (visibility, cross-domain literal, and
+/// literal-value-set conflicts).
+fn name_occurrences_disjoint_db(db: &dyn TypeDatabase, occurrences: &[PropOccurrence]) -> bool {
+    if occurrences.len() < 2 {
+        return false;
+    }
+
+    let mut has_private = false;
+    let mut has_non_private = false;
+    for occ in occurrences {
+        if occ.visibility == Visibility::Private {
+            has_private = true;
+        } else {
+            has_non_private = true;
+        }
+    }
+    if has_private && has_non_private {
+        return true;
+    }
+
+    let mut classes: SmallVec<[PrimitiveClass; 8]> = SmallVec::new();
+    let mut literal_classes: SmallVec<[PrimitiveClass; 8]> = SmallVec::new();
+    let mut required_classes: SmallVec<[PrimitiveClass; 8]> = SmallVec::new();
+    let mut has_required_literal = false;
+    for occ in occurrences {
+        let Some(class) = primitive_class_for_db(db, occ.type_id) else {
+            continue;
+        };
+        if !classes.contains(&class) {
+            classes.push(class);
+        }
+        if !occ.optional && !required_classes.contains(&class) {
+            required_classes.push(class);
+        }
+        if is_literal_type(db, occ.type_id) {
+            if !literal_classes.contains(&class) {
+                literal_classes.push(class);
+            }
+            has_required_literal |= !occ.optional;
+        }
+    }
+    let required_literal_cross = has_required_literal && classes.len() >= 2;
+    let literal_vs_required_cross = literal_classes
+        .iter()
+        .any(|lit| required_classes.iter().any(|req| req != lit));
+    if required_literal_cross || literal_vs_required_cross {
+        return true;
+    }
+
+    let mut by_domain: LiteralOccurrencesByDomain = SmallVec::new();
+    let mut has_required_literal = false;
+    for occ in occurrences {
+        let Some(kind) = literal_kind_from_type_db(db, occ.type_id) else {
+            continue;
+        };
+        has_required_literal |= !occ.optional;
+        let domain = kind.domain();
+        let lit = LiteralOccurrence {
+            kind,
+            optional: occ.optional,
+        };
+        match by_domain.iter_mut().find(|(d, _)| *d == domain) {
+            Some((_, group)) => group.push(lit),
+            None => {
+                let mut group = SmallVec::new();
+                group.push(lit);
+                by_domain.push((domain, group));
+            }
+        }
+    }
+
+    if has_required_literal && by_domain.len() >= 2 {
+        return true;
+    }
+
+    by_domain
+        .iter()
+        .any(|(_, group)| TypeInterner::literal_group_has_disjoint_pair(group))
+}
+
+/// Returns the conflicting property name when exactly one of `members`'
+/// property names has mutually-unsatisfiable occurrences (the same test
+/// [`name_occurrences_disjoint_db`] runs) — the property tsc's TS18031
+/// elaboration (`The intersection '...' was reduced to 'never' because
+/// property '...' has conflicting types in some constituents.`) names.
+/// Oracle-verified against `typescript@7.0.2` that tsc names the conflicting
+/// property independent of which property was actually accessed.
+///
+/// When *more than one* property name conflicts, this returns `None` rather
+/// than guessing: `ObjectShape::properties` is sorted by interned `Atom` id
+/// (for canonical hashing identity), not source declaration order, so there
+/// is no order-independent way to recover tsc's "first written" choice from
+/// the interned shape alone. Silently skipping the elaboration here is never
+/// a parity regression — the caller already falls back to no elaboration —
+/// it just doesn't (yet) cover the multi-conflict case.
+///
+/// `members` must be independently re-evaluated from the source annotation —
+/// once an intersection's disjoint-object-literal conflict collapses it to
+/// `TypeId::NEVER` at intern time, the member list is gone from the
+/// interned type itself.
+pub(crate) fn find_disjoint_object_literal_conflict_property(
+    db: &dyn TypeDatabase,
+    members: &[TypeId],
+) -> Option<Atom> {
+    fn record_occurrence(
+        by_name: &mut FxHashMap<Atom, SmallVec<[PropOccurrence; 4]>>,
+        prop: &PropertyInfo,
+    ) {
+        by_name.entry(prop.name).or_default().push(PropOccurrence {
+            type_id: prop.type_id,
+            optional: prop.optional,
+            visibility: prop.visibility,
+        });
+    }
+
+    let mut by_name: FxHashMap<Atom, SmallVec<[PropOccurrence; 4]>> = FxHashMap::default();
+
+    for &member in members {
+        if member.is_intrinsic() {
+            continue;
+        }
+        let Some(key) = db.lookup(member) else {
+            continue;
+        };
+        match key {
+            TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id) => {
+                let shape = db.object_shape(shape_id);
+                for prop in &shape.properties {
+                    record_occurrence(&mut by_name, prop);
+                }
+            }
+            TypeData::Callable(callable_id) => {
+                let shape = db.callable_shape(callable_id);
+                for prop in &shape.properties {
+                    record_occurrence(&mut by_name, prop);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut conflict: Option<Atom> = None;
+    for (&name, occurrences) in &by_name {
+        if name_occurrences_disjoint_db(db, occurrences) {
+            if conflict.is_some() {
+                return None;
+            }
+            conflict = Some(name);
+        }
+    }
+    conflict
 }
 
 #[cfg(test)]

--- a/crates/tsz-solver/src/type_queries/data/intersection_conflict.rs
+++ b/crates/tsz-solver/src/type_queries/data/intersection_conflict.rs
@@ -1,0 +1,24 @@
+//! Query boundary for the "which property conflicts" question behind tsc's
+//! TS18031 elaboration on a disjoint-object-literal intersection reduced to
+//! `never`.
+
+use crate::construction::TypeDatabase;
+use crate::types::TypeId;
+use tsz_common::interner::Atom;
+
+/// Returns the first property name (in first-declared order across
+/// `members`) whose occurrences across an intersection's members are
+/// mutually unsatisfiable, forcing the whole intersection to `never`.
+///
+/// `members` must be independently re-evaluated from the source annotation
+/// text — once `crate::intern::normalize`'s disjoint-object-literal check
+/// collapses an intersection to `TypeId::NEVER` at intern time, the member
+/// list is gone from the interned type itself, so callers need to walk the
+/// declared annotation node and re-evaluate each member's type on their own
+/// (see `declared_intersection_display.rs` in `tsz-checker` for that walk).
+pub fn find_disjoint_object_literal_conflict_property(
+    db: &dyn TypeDatabase,
+    members: &[TypeId],
+) -> Option<Atom> {
+    crate::intern::find_disjoint_object_literal_conflict_property(db, members)
+}

--- a/crates/tsz-solver/src/type_queries/data/mod.rs
+++ b/crates/tsz-solver/src/type_queries/data/mod.rs
@@ -17,6 +17,7 @@ mod free_infer_cache_tests;
 mod free_infer_predicate;
 #[cfg(test)]
 mod free_param_cache_tests;
+mod intersection_conflict;
 mod nominal_and_base;
 mod rest_binder_queries;
 mod signatures_and_advanced;
@@ -30,6 +31,7 @@ pub use conditional_distribution::*;
 pub use content_predicates::*;
 pub use exact_property_keys::*;
 pub use free_infer_predicate::*;
+pub use intersection_conflict::*;
 pub use nominal_and_base::*;
 pub use rest_binder_queries::*;
 pub use signatures_and_advanced::*;


### PR DESCRIPTION
When an object-literal intersection's members share a property name with mutually-unsatisfiable types (`interface A { x: 1 } interface B { x: 2 }; declare const c: A & B;`), tsc's `checker.ts` reduces it to `never` and attaches a related-info line naming the offending property: `The intersection 'A & B' was reduced to 'never' because property 'x' has conflicting types in some constituents.` (TS18031). tsz already emitted the correct top-level `TS2339`/`never` diagnostic but dropped this elaboration entirely, since `intersection_has_disjoint_object_literals` (`crates/tsz-solver/src/intern/normalize.rs`) collapses the intersection to the single canonical `TypeId::NEVER` at intern time, discarding the member list the elaboration needs.

**Structural rule:** when a `never`-typed property-access receiver's declared annotation is a disjoint-object-literal intersection, tsc names the conflicting property via a solver-owned structural query over the intersection's independently-re-evaluated members; tsz now does the same through a new `find_disjoint_object_literal_conflict_property` query (`crates/tsz-solver/src/type_queries/data/intersection_conflict.rs`) plumbed into the TS2339 fallback in `error_reporter/properties.rs`.

**Scope:** fires only when exactly one property name conflicts. `ObjectShape::properties` is sorted by interned `Atom` id (for canonical hashing identity), not source declaration order, so when more than one property conflicts there is no order-independent way to recover tsc's "first written" choice from the interned shape alone — oracle-verified that tsc's choice does NOT depend on which property was accessed, only on declaration order. Falling silent on the ambiguous multi-conflict case is a strict improvement over the prior silent behavior, never a wrong-property regression. TS18032 (the private-brand sibling diagnostic) is a separate, larger follow-up (see #16291 / #16769 threads).

Refactored `primitive_class_for`/`literal_kind_from_type`/`name_occurrences_disjoint` from `TypeInterner`-only inherent methods into `&dyn TypeDatabase`-based free functions (with the `TypeInterner` methods now thin delegates) so the new query is callable from the checker, which only ever holds a trait object — no behavior change, pure delegation. `error_reporter/core/declared_intersection_display.rs` gained a sibling display+member-recovery walk (the existing one is scoped to type-literal-only members for its own assignability-message call site) that also resolves `Lazy(DefId)` interface references to their structural shape for the conflict query, while keeping the unresolved type for nominal display.

**Adjacent matrix** (all oracle-verified against `typescript@7.0.2`, all in the new test file): single conflict names the property; renamed binders; the conflicting property is named independent of which property was accessed; multiple simultaneous conflicts fall back to no elaboration; primitive-disjoint intersections (`string & number`) and explicit `never` get no elaboration (tsc has none for those); compatible intersection members report no TS2339 at all.

## Goal
Goal: hold

## Verification
- New `ts18031_intersection_never_conflict_elaboration_tests` (7 cases) — green.
- `cargo test -p tsz-checker --test ts18031_intersection_never_conflict_elaboration_tests` — 7/7.
- `cargo test -p tsz-solver --lib intersection` — 506/506 (normalize.rs refactor is delegation-only, no behavior change).
- `cargo test -p tsz-checker --lib ts2339` — 256/256.
- `cargo test -p tsz-checker --lib intersection` — 256/256.
- `cargo clippy -p tsz-solver -p tsz-checker --all-targets` — clean.
- `cargo fmt --check -p tsz-solver -p tsz-checker` — clean.
- `python3 scripts/arch/arch_guard.py` — passed (`properties.rs` and `query_boundaries/common.rs` stayed within their size ratchets by moving new logic into a new file, `error_reporter/core/never_reduced_intersection_elaboration.rs`, and calling `tsz_solver::type_queries` directly instead of adding to the frozen `common.rs` quarantine per #8225).
- End-to-end via debug CLI against the pinned `typescript@7.0.2` oracle: byte-identical elaboration text on the single-conflict cases. TypeScript corpus not checked out in this environment, so conformance/emit/fourslash are owed to CI — no diagnostic code or count changes expected, this is a related-info-only addition.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_012ioQ6QhtC1QMhPCGtGYvBY)_