### PR TITLE
fix(checker): readonly on a constructor is TS1024, async on a property is TS1042 (#16291)

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/ambient_constructor_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_constructor_checks.rs
@@ -61,6 +61,20 @@ impl<'a> CheckerState<'a> {
             );
         }
 
+        // Error 1024: 'readonly' modifier can only appear on a property
+        // declaration or index signature. A constructor is neither, so tsc's
+        // `checkGrammarModifiers` reports TS1024 anchored at the `readonly`
+        // keyword — the same code it already reports for `readonly` on a
+        // method/accessor (see `state_checking/class.rs`), which excludes the
+        // constructor node kind, leaving this the only site that can cover it.
+        if let Some(readonly_mod) = self.find_readonly_modifier(&ctor.modifiers) {
+            self.error_at_node(
+                readonly_mod,
+                diagnostic_messages::READONLY_MODIFIER_CAN_ONLY_APPEAR_ON_A_PROPERTY_DECLARATION_OR_INDEX_SIGNATURE,
+                diagnostic_codes::READONLY_MODIFIER_CAN_ONLY_APPEAR_ON_A_PROPERTY_DECLARATION_OR_INDEX_SIGNATURE,
+            );
+        }
+
         // Error 1183: An implementation cannot be declared in ambient contexts
         // Check if we're in a declared class and the constructor has a body.
         // TSC anchors the error at the body node (the `{`).

--- a/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
@@ -1147,6 +1147,23 @@ impl<'a> CheckerState<'a> {
                         );
                     }
                 }
+                // TS1042: 'async' modifier cannot be used on a property
+                // declaration either — `checkGrammarAsyncModifier` allows it
+                // only on method/function-like nodes. `readonly` on a property
+                // is legal, so `readonly async p` is a lone TS1042 with no
+                // ordering collision; anchored at the `async` keyword to match
+                // tsc's column even when the property carries a decorator.
+                syntax_kind_ext::PROPERTY_DECLARATION => {
+                    if let Some(prop) = self.ctx.arena.get_property_decl(node)
+                        && let Some(async_mod_idx) = self.find_async_modifier(&prop.modifiers)
+                    {
+                        self.error_at_node(
+                            async_mod_idx,
+                            "'async' modifier cannot be used here.",
+                            diagnostic_codes::MODIFIER_CANNOT_BE_USED_HERE,
+                        );
+                    }
+                }
                 syntax_kind_ext::CONSTRUCTOR => {
                     // Skip constructor overload checks when the file has parse errors.
                     // Malformed constructors (e.g., `constructor` without parentheses)

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -607,6 +607,8 @@ mod mapped_optional_target_excess_property_tests;
 mod mapped_true_base_constraint_relation_routing_arch_tests;
 #[path = "tests/member_assignment_narrowing_join_tests.rs"]
 mod member_assignment_narrowing_join_tests;
+#[path = "tests/member_modifier_placement_grammar_tests.rs"]
+mod member_modifier_placement_grammar_tests;
 #[path = "tests/member_name_source_quote_fidelity_tests.rs"]
 mod member_name_source_quote_fidelity_tests;
 #[path = "tests/merged_interface_constraint_relation_routing_arch_tests.rs"]

--- a/crates/tsz-checker/src/tests/member_modifier_placement_grammar_tests.rs
+++ b/crates/tsz-checker/src/tests/member_modifier_placement_grammar_tests.rs
@@ -1,0 +1,103 @@
+//! Class-member modifier *placement* grammar for `readonly` and `async`
+//! (issue #16291, the two positions surfaced 2026-08-07): `readonly` on a
+//! **constructor** is TS1024, and `async` on a **property declaration** is
+//! TS1042. tsz already covered the rest of each family (readonly on
+//! method/accessor, async on accessors), so these are missing-position gaps,
+//! not missing codes.
+//!
+//! Every expectation is pinned against `typescript@7.0.2`
+//! (`--noEmit --strict --target es2022 --lib es2022`). Binder names are varied
+//! so the diagnostic is keyed on the modifier position, not any identifier.
+
+use crate::test_utils::check_source_codes_with_parse_health;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_codes_with_parse_health(source)
+}
+
+const TS1024: u32 = 1024; // 'readonly' modifier can only appear on a property declaration or index signature.
+const TS1042: u32 = 1042; // 'async' modifier cannot be used here.
+const TS1089: u32 = 1089; // '{0}' modifier cannot appear on a constructor declaration.
+
+// --- readonly on a constructor => TS1024 (the newly-covered position) -------
+
+#[test]
+fn readonly_constructor_reports_ts1024_independent_of_class_name() {
+    for name in ["C", "Widget", "Repository", "Zzz"] {
+        let source = format!("class {name} {{ readonly constructor() {{}} }}");
+        assert_eq!(codes(&source), vec![TS1024], "source: {source}");
+    }
+}
+
+// --- async on a property declaration => TS1042 (the newly-covered position) --
+
+#[test]
+fn async_property_without_initializer_reports_ts1042_alongside_ts2564() {
+    // tsc reports both: the grammar TS1042 and the strict-init TS2564.
+    let mut c = codes("class C { async p: number; }");
+    c.sort_unstable();
+    assert_eq!(c, vec![TS1042, 2564]);
+}
+
+#[test]
+fn async_property_is_independent_of_property_name() {
+    for name in ["p", "value", "data", "field"] {
+        let source = format!("class C {{ async {name}: number = 1; }}");
+        assert_eq!(codes(&source), vec![TS1042], "source: {source}");
+    }
+}
+
+// --- combinations: still exactly one code, matching tsc's first-error walk ---
+
+#[test]
+fn readonly_async_property_reports_only_ts1042() {
+    // `readonly` on a property is legal, so only the `async` placement fires.
+    assert_eq!(codes("class C { readonly async p = 1; }"), vec![TS1042]);
+}
+
+// --- adjacent positions that must keep their existing (correct) behavior ----
+
+#[test]
+fn readonly_method_and_accessors_still_report_ts1024() {
+    assert_eq!(codes("class C { readonly m() {} }"), vec![TS1024]);
+    assert_eq!(
+        codes("class C { readonly get x() { return 1; } }"),
+        vec![TS1024]
+    );
+    assert_eq!(
+        codes("class C { readonly set x(v: number) {} }"),
+        vec![TS1024]
+    );
+}
+
+#[test]
+fn async_accessors_still_report_ts1042() {
+    assert_eq!(
+        codes("class C { async get x() { return 1; } }"),
+        vec![TS1042]
+    );
+    assert_eq!(codes("class C { async set x(v: number) {} }"), vec![TS1042]);
+}
+
+#[test]
+fn async_constructor_still_reports_ts1089_not_ts1042() {
+    // `async` on a constructor is TS1089, a distinct code, and must not be
+    // reclassified by the property/accessor async placement check.
+    assert_eq!(codes("class C { async constructor() {} }"), vec![TS1089]);
+}
+
+#[test]
+fn valid_members_stay_clean() {
+    for source in [
+        "class C { async m() {} }",
+        "class C { readonly p: number = 1; }",
+        "class C { p = 1; m() {} constructor() {} get g() { return 1; } }",
+        "class C { readonly p = 1; constructor() {} }",
+    ] {
+        assert!(
+            codes(source).is_empty(),
+            "expected no diagnostics for `{source}`, got {:?}",
+            codes(source)
+        );
+    }
+}

--- a/crates/tsz-checker/src/types/queries/core.rs
+++ b/crates/tsz-checker/src/types/queries/core.rs
@@ -239,6 +239,15 @@ impl<'a> CheckerState<'a> {
             .find_modifier(modifiers, SyntaxKind::OverrideKeyword)
     }
 
+    pub(crate) fn find_readonly_modifier(
+        &self,
+        modifiers: &Option<tsz_parser::parser::NodeList>,
+    ) -> Option<NodeIndex> {
+        self.ctx
+            .arena
+            .find_modifier(modifiers, SyntaxKind::ReadonlyKeyword)
+    }
+
     /// Check if a node has the `abstract` modifier.
     pub(crate) fn has_abstract_modifier(
         &self,


### PR DESCRIPTION
Closes two class-member modifier-placement gaps in the #16291 "unwired / missing-position diagnostics" vein.

## Structural rule

`tsc`'s `checkGrammarModifiers` validates a class member's modifiers by node kind:
- **`readonly`** is legal only on a property declaration or index signature, so on a **constructor** it is **TS1024** — the same code tsz already emits for `readonly` on a method/accessor.
- **`async`** is legal only on method/function-like nodes (`checkGrammarAsyncModifier`), so on a **property declaration** it is **TS1042** — the same code tsz already emits for `async` on an accessor.

tsz already covered the rest of each family; only these two positions were silently accepted. Owner layer: the checker's per-node-kind member-modifier checks.

| member | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `readonly constructor(){}` | TS1024 | *(silent)* | TS1024 |
| `async p: number = 1` (property) | TS1042 | *(silent)* | TS1042 |
| `async p: number;` (property) | TS1042 + TS2564 | TS2564 | TS1042 + TS2564 |
| `readonly m()` / `get` / `set` | TS1024 | TS1024 | TS1024 (unchanged) |
| `async get`/`set` | TS1042 | TS1042 | TS1042 (unchanged) |
| `async constructor(){}` | TS1089 | TS1089 | TS1089 (unchanged) |
| `readonly async p` | TS1042 | *(silent)* | TS1042 |
| `async m()`, `readonly p` | clean | clean | clean |

Both new cells are collision-free with tsc's one-diagnostic-per-member rule: `readonly` on a property is legal (so `readonly async p` is a lone TS1042), and the constructor `readonly` is a distinct node kind from the method/accessor readonly check, so no double-fire. Anchored at the offending modifier, matching tsc's column (robust to a leading decorator).

### Implementation
- `state_checking_members/ambient_constructor_checks.rs`: constructor `readonly` → TS1024, alongside the existing constructor async/override → TS1089 and abstract → TS1242 checks, via a new `find_readonly_modifier` helper mirroring `find_async_modifier`/`find_override_modifier`.
- `state_checking_members/member_declaration_checks.rs`: a new `PROPERTY_DECLARATION` arm in `check_class_member_implementations`, adjacent to the existing `async`-on-accessor arm.

The deeper unification (one source-ordered `checkGrammarModifiers` walk) is deliberately out of scope — tsz's split-owner architecture is documented and test-pinned; these two additions slot into it without worsening the co-emission seams that suite guards.

## Goal
Goal: hold

## Verification
- Oracle-pinned against `typescript@7.0.2` (`--noEmit --strict --target es2022 --lib es2022`) across the matrix above, verified end-to-end through the CLI binary.
- New `crates/tsz-checker/src/tests/member_modifier_placement_grammar_tests.rs` (8 tests: both new positions with binder-name variation, `readonly async p` combo, adjacent must-not-regress positions, and clean controls) — green.
- `cargo test -p tsz-checker --lib modifier` (154) / `constructor` (241) / `class_member_modifier_grammar_first_error_wins` (16) — green.
- `cargo clippy -p tsz-checker` and the pre-commit arch-size guard — pass.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbE3EGWDwVMUzJnLxTJh9j)_