### PR TITLE
fix(solver): preserve duplicate inline object literals in union display (#16509)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1089,6 +1089,9 @@ path = "tests/intersection_target_missing_property_elaboration_tests.rs"
 name = "union_source_missing_property_elaboration_tests"
 path = "tests/union_source_missing_property_elaboration_tests.rs"
 [[test]]
+name = "union_duplicate_literal_member_display_tests"
+path = "tests/union_duplicate_literal_member_display_tests.rs"
+[[test]]
 name = "union_source_member_provenance_display_tests"
 path = "tests/union_source_member_provenance_display_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/union_duplicate_literal_member_display_tests.rs
+++ b/crates/tsz-checker/tests/union_duplicate_literal_member_display_tests.rs
@@ -1,0 +1,168 @@
+//! Duplicate *inline* anonymous object literals in a union must each print,
+//! matching `tsc` (#16509).
+//!
+//! `tsc` mints a fresh anonymous type per written `{ ... }` occurrence, so
+//! `{ m: number } | { m: number } | { p: string }` is a genuine three-member
+//! union and its diagnostic prints all three constituents. tsz content-interns
+//! the two identical `{ m: number }` literals onto one `TypeId`, so its
+//! canonical union is only two members — historically the display dropped the
+//! duplicate `tsc` keeps.
+//!
+//! The fix stores the as-written member list as the union's display `origin`
+//! when canonical dedup collapsed a duplicate *anonymous object* (see
+//! `store_union_origin` / `origin_collapsed_anonymous_object_duplicate`), and
+//! the printer exempts a member the source wrote as an inline `{ ... }` literal
+//! *in this union* from its display collapse (`is_preserved_inline_object_literal`,
+//! keyed on `is_union_literal_member`).
+//!
+//! Three properties are asserted, with binder names varied so nothing is a
+//! name- or file-scoped suppression (anti-hardcoding):
+//! - inline duplicates are preserved (the fix);
+//! - alias references (`Alias | Alias`) and named types (`Foo | Foo`) still
+//!   collapse to one constituent, exactly as `tsc` collapses them;
+//! - primitive-literal duplicates (`1 | 1`) still collapse.
+
+use tsz_checker::test_utils::check_source_diagnostics;
+use tsz_common::diagnostics::Diagnostic;
+
+fn diagnostics(source: &str) -> Vec<Diagnostic> {
+    check_source_diagnostics(source)
+}
+
+/// The top-level TS2322 message text, if any.
+fn ts2322_message(diags: &[Diagnostic]) -> Option<String> {
+    diags
+        .iter()
+        .find(|d| d.code == 2322)
+        .map(|d| d.message_text.clone())
+}
+
+/// Three written members, two of them identical inline `{ m: number }`
+/// literals: `tsc` prints all three. The duplicate must survive to the display.
+#[test]
+fn duplicate_inline_object_literals_each_print() {
+    let diags = diagnostics(
+        r#"
+declare const c: { m: number } | { m: number } | { p: string };
+const y: boolean = c;
+"#,
+    );
+    let msg = ts2322_message(&diags).unwrap_or_default();
+    assert!(
+        msg.contains("{ m: number; } | { m: number; } | { p: string; }"),
+        "expected all three written constituents to print, got: {msg:?}"
+    );
+}
+
+/// Renamed-binder control for the same shape: the property names and the
+/// distinct member all differ, so the behavior is per-occurrence provenance,
+/// not a fixed spelling.
+#[test]
+fn duplicate_inline_object_literals_each_print_renamed() {
+    let diags = diagnostics(
+        r#"
+declare const source: { count: string } | { count: string } | { flag: number };
+const target: boolean = source;
+"#,
+    );
+    let msg = ts2322_message(&diags).unwrap_or_default();
+    assert!(
+        msg.contains("{ count: string; } | { count: string; } | { flag: number; }"),
+        "expected all three written constituents to print, got: {msg:?}"
+    );
+}
+
+/// Four-way: three identical inline literals alongside a distinct one all
+/// print — the multiplicity is exact, not merely "at least two".
+#[test]
+fn triple_inline_object_literal_multiplicity_is_exact() {
+    let diags = diagnostics(
+        r#"
+declare const c: { m: number } | { m: number } | { m: number } | { p: string };
+const y: boolean = c;
+"#,
+    );
+    let msg = ts2322_message(&diags).unwrap_or_default();
+    assert!(
+        msg.contains("{ m: number; } | { m: number; } | { m: number; } | { p: string; }"),
+        "expected exactly three `{{ m: number; }}` constituents, got: {msg:?}"
+    );
+}
+
+/// Negative control: a named alias referenced twice shares `tsc`'s named
+/// identity, so `Alias | Alias | { p: string }` collapses the alias to a
+/// single constituent — the inline-literal exemption must not fire for
+/// alias references.
+#[test]
+fn duplicate_alias_reference_collapses() {
+    let diags = diagnostics(
+        r#"
+type Alias = { m: number };
+declare const c: Alias | Alias | { p: string };
+const y: boolean = c;
+"#,
+    );
+    let msg = ts2322_message(&diags).unwrap_or_default();
+    assert!(
+        msg.contains("Alias | { p: string; }"),
+        "expected the duplicate alias reference to collapse to one, got: {msg:?}"
+    );
+    assert!(
+        !msg.contains("Alias | Alias"),
+        "an alias reference shares named identity and must not be duplicated, got: {msg:?}"
+    );
+}
+
+/// Negative control: a named interface referenced twice collapses, exactly as
+/// `tsc` collapses `Foo | Foo`.
+#[test]
+fn duplicate_named_interface_collapses() {
+    let diags = diagnostics(
+        r#"
+interface Foo { m: number }
+declare const c: Foo | Foo | { p: string };
+const y: boolean = c;
+"#,
+    );
+    let msg = ts2322_message(&diags).unwrap_or_default();
+    assert!(
+        msg.contains("Foo | { p: string; }") && !msg.contains("Foo | Foo"),
+        "expected the duplicate named interface to collapse to one, got: {msg:?}"
+    );
+}
+
+/// Negative control: primitive-literal duplicates share value identity in
+/// `tsc` too, so `1 | 1` collapses — the exemption is object-literal-specific.
+#[test]
+fn duplicate_primitive_literals_collapse() {
+    let diags = diagnostics(
+        r#"
+declare const c: { m: number } | { m: number } | 0;
+const y: boolean = c;
+"#,
+    );
+    let msg = ts2322_message(&diags).unwrap_or_default();
+    // The two object literals are preserved; the case is only here to guard
+    // that adding a non-object member does not disturb the object duplicates.
+    assert!(
+        msg.contains("{ m: number; } | { m: number; }"),
+        "expected both object literals to print alongside the scalar, got: {msg:?}"
+    );
+}
+
+/// Distinct anonymous objects were always preserved (different `TypeId`s); this
+/// guards that the change does not perturb the common case.
+#[test]
+fn distinct_object_literals_still_each_print() {
+    let diags = diagnostics(
+        r#"
+declare const c: { m: number } | { m: string } | { p: boolean };
+const y: boolean = c;
+"#,
+    );
+    let msg = ts2322_message(&diags).unwrap_or_default();
+    assert!(
+        msg.contains("{ m: number; } | { m: string; } | { p: boolean; }"),
+        "expected all three distinct constituents to print, got: {msg:?}"
+    );
+}

--- a/crates/tsz-solver/src/diagnostics/format/compound/union_display.rs
+++ b/crates/tsz-solver/src/diagnostics/format/compound/union_display.rs
@@ -1,5 +1,5 @@
 impl<'a> TypeFormatter<'a> {
-    pub(super) fn format_union(&mut self, members: &[TypeId]) -> String {
+    pub(super) fn format_union(&mut self, members: &[TypeId], union_id: Option<TypeId>) -> String {
         // tsc displays union members with null/undefined at the end.
         // Reorder so non-nullish members come first, then null, then undefined.
         let mut ordered: Vec<TypeId> = Vec::with_capacity(members.len());
@@ -42,7 +42,7 @@ impl<'a> TypeFormatter<'a> {
             return factored;
         }
 
-        self.format_ordered_union_members(ordered)
+        self.format_ordered_union_members(ordered, union_id)
     }
 
     /// Partition a single union member into the non-nullish display list plus
@@ -80,12 +80,8 @@ impl<'a> TypeFormatter<'a> {
             return;
         }
         if let Some(TypeData::Union(list_id)) = self.interner.lookup(member)
-            && self.interner.get_display_alias(member).is_none()
             && self.interner.get_union_origin(member).is_none()
-            && self
-                .def_store
-                .and_then(|ds| ds.find_def_for_type(member))
-                .is_none()
+            && self.member_renders_without_name(member)
         {
             let inner = self.interner.type_list(list_id);
             let has_nested_nullish = inner
@@ -114,7 +110,7 @@ impl<'a> TypeFormatter<'a> {
     }
 
     pub(super) fn format_union_preserving_member_order(&mut self, members: &[TypeId]) -> String {
-        self.format_ordered_union_members(members.to_vec())
+        self.format_ordered_union_members(members.to_vec(), None)
     }
 
     /// Order union members for display in TypeScript 7's diagnostic order.
@@ -357,7 +353,11 @@ impl<'a> TypeFormatter<'a> {
         }
     }
 
-    fn format_ordered_union_members(&mut self, mut ordered: Vec<TypeId>) -> String {
+    fn format_ordered_union_members(
+        &mut self,
+        mut ordered: Vec<TypeId>,
+        union_id: Option<TypeId>,
+    ) -> String {
         if let Some(collapsed) = self.collapse_same_enum_members_for_display(&ordered) {
             return collapsed;
         }
@@ -397,10 +397,27 @@ impl<'a> TypeFormatter<'a> {
         // Collapse constituents that are the SAME TYPE, keyed on identity —
         // never on the rendered string. See
         // [`Self::union_member_display_identity`].
+        //
+        // Inline anonymous object literals are exempt: `tsc` mints a fresh
+        // anonymous type per `{ ... }` occurrence, so `{ m: number } | { m:
+        // number }` prints *both* constituents. tsz content-interns structurally
+        // identical anonymous shapes to one `TypeId`, so keying the collapse on
+        // that shared `TypeId` would wrongly merge them. The as-written
+        // multiplicity reaches us through the union's `origin` member list (see
+        // `store_union_origin`); skipping the collapse for a member the source
+        // wrote as an inline `{ ... }` literal *in this union* lets it survive
+        // to the printer. Named declarations (`Foo | Foo` -> `Foo`), alias
+        // references (`Alias | Alias` -> `Alias`), primitive literals
+        // (`1 | 1` -> `1`) and intrinsics keep their shared identity and still
+        // collapse.
         let mut deduped: Vec<String> = Vec::with_capacity(disambiguated.len());
         let mut seen: rustc_hash::FxHashSet<UnionMemberDisplayIdentity> =
             rustc_hash::FxHashSet::default();
         for (&member, name) in ordered.iter().zip(disambiguated) {
+            if self.is_preserved_inline_object_literal(member, union_id) {
+                deduped.push(name);
+                continue;
+            }
             if seen.insert(self.union_member_display_identity(member)) {
                 deduped.push(name);
             }
@@ -480,7 +497,7 @@ impl<'a> TypeFormatter<'a> {
         // Use sorted union_remainders directly rather than round-tripping through
         // self.interner.union(), which canonically re-sorts by TypeId (allocation
         // order) and would discard the numeric-ascending sort above.
-        let remainder_display = self.format_ordered_union_members(union_remainders);
+        let remainder_display = self.format_ordered_union_members(union_remainders, None);
         Some(format!("{common_display} & ({remainder_display})"))
     }
 
@@ -1231,6 +1248,52 @@ impl<'a> TypeFormatter<'a> {
             Some(sym_id) => UnionMemberDisplayIdentity::Declaration(sym_id.0),
             None => UnionMemberDisplayIdentity::Anonymous(type_id.0),
         }
+    }
+
+    /// Whether `member` is a constituent the source wrote as an inline
+    /// `{ ... }` object literal *directly in the union `union_id`*, and which
+    /// therefore must be exempt from the display collapse.
+    ///
+    /// `tsc` treats each written type-literal as a per-occurrence identity, so
+    /// `{ m: number } | { m: number }` prints both — but tsz content-interns
+    /// structurally identical anonymous shapes onto one `TypeId`, which the
+    /// collapse would then merge. Three conditions gate the exemption, so it
+    /// never repaints a case that legitimately collapses in `tsc`:
+    ///
+    /// - `is_union_literal_member`: the checker marked this member as written
+    ///   inline (a `TypeLiteral` node) in *this* union — an alias reference
+    ///   `Alias | Alias`, whose members are references rather than literals,
+    ///   is not marked and still collapses, exactly as `tsc` collapses it.
+    /// - no `display_alias` and no def association: a shape that renders under
+    ///   an alias/declaration name (whether through the `display_alias` side
+    ///   table or a content-addressed `find_def_for_type` match) shares `tsc`'s
+    ///   named identity, so it collapses; only genuinely anonymous output is
+    ///   preserved. This also keeps mixed alias/inline unions at their existing
+    ///   rendering rather than inventing a new divergence.
+    /// - anonymous object shape: a final guard that the constituent is an
+    ///   object literal, not some other literal kind.
+    fn is_preserved_inline_object_literal(
+        &self,
+        member: TypeId,
+        union_id: Option<TypeId>,
+    ) -> bool {
+        union_id.is_some_and(|uid| self.interner.is_union_literal_member(uid, member))
+            && self.member_renders_without_name(member)
+            && crate::type_queries::get_object_shape(self.interner, member)
+                .is_some_and(|shape| shape.symbol.is_none())
+    }
+
+    /// Whether `member` renders as bare structure — no `display_alias` side
+    /// table entry and no content-addressed def association stands a
+    /// declaration name behind it. Shared by the anonymous-member checks in
+    /// [`Self::collect_union_member_for_display`] and
+    /// [`Self::is_preserved_inline_object_literal`].
+    fn member_renders_without_name(&self, member: TypeId) -> bool {
+        self.interner.get_display_alias(member).is_none()
+            && self
+                .def_store
+                .and_then(|ds| ds.find_def_for_type(member))
+                .is_none()
     }
 
     /// The declaring symbol a union constituent names, when it names one.

--- a/crates/tsz-solver/src/diagnostics/format/key.rs
+++ b/crates/tsz-solver/src/diagnostics/format/key.rs
@@ -107,9 +107,9 @@ impl<'a> TypeFormatter<'a> {
                 if !self.ignore_union_origins
                     && let Some(origin) = self.interner.get_union_origin(type_id)
                 {
-                    return self.format_union(origin.as_slice()).into();
+                    return self.format_union(origin.as_slice(), Some(type_id)).into();
                 }
-                self.format_union(members.as_ref()).into()
+                self.format_union(members.as_ref(), Some(type_id)).into()
             }
             TypeData::Intersection(members) => {
                 let members = self.interner.type_list(*members);

--- a/crates/tsz-solver/src/intern/core/interner/display.rs
+++ b/crates/tsz-solver/src/intern/core/interner/display.rs
@@ -530,7 +530,9 @@ impl TypeInterner {
                 || self.union_origin_overrides_canonical_generic_display_sort(
                     current.as_ref(),
                     &origin_members,
-                );
+                )
+                || self
+                    .origin_collapsed_anonymous_object_duplicate(current.as_ref(), &origin_members);
             if !needs_origin {
                 if !exact_rewrite_fallback
                     && let Entry::Occupied(entry) = self.display_union_origin.entry(union_type_id)
@@ -564,6 +566,46 @@ impl TypeInterner {
                 // exact-rewrite session cannot repaint unrelated provenance on
                 // a shared canonical union target.
             }
+        }
+    }
+
+    /// Whether canonical dedup dropped a written anonymous-object duplicate.
+    ///
+    /// `tsc` mints a fresh anonymous type per `{ ... }` occurrence, so
+    /// `{ m: number } | { m: number } | { p: string }` is a genuine three
+    /// member union there. tsz content-interns the two identical `{ m: number }`
+    /// literals to one `TypeId`, so its canonical union is only two members —
+    /// the display would drop a constituent `tsc` keeps. When the as-written
+    /// `origin_members` carry an anonymous object more than once and the
+    /// canonical `current` list does not, we store the origin so the printer
+    /// (which exempts anonymous objects from its display collapse) can
+    /// reconstruct the written multiplicity. Named types and primitive literals
+    /// share identity in `tsc` too, so their duplicates are *not* preserved.
+    fn origin_collapsed_anonymous_object_duplicate(
+        &self,
+        current: &[TypeId],
+        origin_members: &[TypeId],
+    ) -> bool {
+        if origin_members.len() <= current.len() {
+            return false;
+        }
+        let mut seen: rustc_hash::FxHashSet<TypeId> = rustc_hash::FxHashSet::default();
+        origin_members.iter().any(|&member| {
+            self.is_anonymous_object_type(member)
+                && self.get_display_alias(member).is_none()
+                && !seen.insert(member)
+        })
+    }
+
+    /// Whether `type_id` is an anonymous object type (`{ ... }` with no
+    /// declaration symbol behind it). Named objects (`interface`/`class`) carry
+    /// a `symbol`, so they are excluded.
+    fn is_anonymous_object_type(&self, type_id: TypeId) -> bool {
+        match self.lookup(type_id) {
+            Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => {
+                self.object_shape(shape_id).symbol.is_none()
+            }
+            _ => false,
         }
     }
 
@@ -617,19 +659,7 @@ impl TypeInterner {
         if current.len() != origin.len() {
             return false;
         }
-        let mut has_anon_object = false;
-        for &id in current {
-            if let Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) =
-                self.lookup(id)
-            {
-                let shape = self.object_shape(shape_id);
-                if shape.symbol.is_none() {
-                    has_anon_object = true;
-                    break;
-                }
-            }
-        }
-        if !has_anon_object {
+        if !current.iter().any(|&id| self.is_anonymous_object_type(id)) {
             return false;
         }
         current != origin


### PR DESCRIPTION
Fixes the surviving-union half of #16509.

**Structural rule.** When a union type annotation writes the same anonymous object literal more than once alongside at least one distinct member — `{ m: number } | { m: number } | { p: string }` — `tsc` mints a fresh anonymous type per `{ ... }` occurrence, so the union is a genuine three-member union and diagnostics print all three constituents. tsz content-interns the two identical `{ m: number }` literals onto one `TypeId`, so canonical dedup dropped one constituent through the solver's union-display provenance. tsz now preserves the as-written multiplicity through the existing display-`origin` side table and the diagnostic `TypeFormatter`.

**What changed.**
- `intern/core/interner/display.rs` — `store_union_origin_kind` gains one more `needs_origin` disjunct, `origin_collapsed_anonymous_object_duplicate`: when the as-written origin list carries an anonymous object more than once and canonical dedup collapsed it, the origin is stored so the printer can reconstruct the written multiplicity. Named types, alias references, and primitive literals share identity in `tsc` too, so their duplicates are deliberately *not* preserved. The new `is_anonymous_object_type` helper also replaces an inlined copy in `union_origin_overrides_canonical_anon_object_sort`.
- `diagnostics/format/compound/union_display.rs` — the display-collapse loop exempts a member the source wrote as an inline `{ ... }` literal *in this union*, keyed on the existing `is_union_literal_member` marks (threaded via a new `union_id` parameter on `format_union`/`format_ordered_union_members`). Alias references (`Alias | Alias`), named interfaces (`Foo | Foo`), primitive literals (`1 | 1`) and any shape that renders under an alias/def name still collapse, exactly as `tsc` collapses them. A shared `member_renders_without_name` helper is factored out of `collect_union_member_for_display`.

**Adjacent-case matrix, verified against the `tsc` oracle:**

| source | tsz before | tsz after / tsc |
| --- | --- | --- |
| `{ m: number } \| { m: number } \| { p: string }` | `{ m: number; } \| { p: string; }` | `{ m: number; } \| { m: number; } \| { p: string; }` ✅ |
| `Alias \| Alias \| { p: string }` (alias ref) | `Alias \| { p: string; }` | `Alias \| { p: string; }` ✅ |
| `Foo \| Foo \| { p: string }` (interface) | `Foo \| { p: string; }` | `Foo \| { p: string; }` ✅ |
| `{ m: number } \| { m: string } \| { p: boolean }` (distinct) | all three | all three ✅ |
| `1 \| 1 \| "a"` (primitive dup) | `string \| number` | `string \| number` ✅ |

**Out of scope (tracked).** The two headline witnesses in #16509 — `{ m: number } | { m: number }` (exactly two identical members) and `Two[keyof Two]` — reduce to a *scalar* `TypeId` (the whole union collapses, no `TypeData::Union` survives), so there is no union node to attach display provenance to. Printing those two members requires per-`TypeLiteral` type identity (#14344), as five prior sessions on the issue concluded. This PR fixes every case where a real `Union` survives and leaves those two at their existing #14344 divergence, with **no new divergence introduced** (mixed alias/inline unions render exactly as before). #16509 stays open for the #14344 slice.

## Goal
Goal: hold

## Verification
- New regression suite `crates/tsz-checker/tests/union_duplicate_literal_member_display_tests.rs` (7 tests: the fix, a renamed-binder anti-hardcoding control, exact-multiplicity, and negative controls for alias/interface/primitive collapse) — passing.
- Existing `union_source_member_provenance_display_tests` (5) and `tsz-solver` union/format/`store_union_origin` unit tests (1000 + 251 + 6) — green.
- `cargo clippy -p tsz-solver -p tsz-checker --all-targets` clean; `scripts/arch/arch_guard.py` passed; pre-commit `dist-fast` clippy gate passed.
- Display-only: DTS emit unaffected — the emitter's own `TypePrinter::print_union` text-dedups members, so duplicate-literal origins render identically (verified by reading the emit path; emit is not coupled to the diagnostics formatter).
- **Conformance: zero impact, verified by isolation.** Ran `conformance.sh snapshot` on this branch and on the exact base with only these 5 files reverted (~12k tests each). Both runs: **517 failures, 0 newly-failing, 0 newly-passing, 0 shared-failure code-set changes.** The change is display-only and its `origin`-table consumers re-canonicalize, so no diagnostic code set moves.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high