### PR TITLE
fix(solver): TS18031 multi-conflict elaboration names tsc's first-declared property

### DIFF
--- a/crates/tsz-checker/src/tests/ts18031_intersection_conflicting_property_tests.rs
+++ b/crates/tsz-checker/src/tests/ts18031_intersection_conflicting_property_tests.rs
@@ -208,6 +208,107 @@ const read: "a" = value.kind;
     );
 }
 
+// ---------------------------------------------------------------------------
+// Multi-conflict ordering: when more than one property name conflicts, tsc
+// always names the first one by a combined declaration order (walk members
+// left to right, and within each member walk its own properties in
+// declaration order — a name is positioned at its *first* occurrence).
+// Oracle-verified against `typescript@7.0.2` for every case below.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn multi_conflict_names_first_declared_property_in_first_member() {
+    // `x` is declared before `y` in the first member, so `x` wins even
+    // though the access is on `x` itself and both `x` and `y` conflict.
+    let diags = check_source_strict(
+        r#"
+interface A { x: 1; y: "a" }
+interface B { x: 2; y: "b" }
+declare const c: A & B;
+c.x;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18031).as_deref(),
+        Some(
+            "The intersection 'A & B' was reduced to 'never' because property 'x' has conflicting types in some constituents."
+        ),
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn multi_conflict_order_follows_first_members_declaration_order_not_alphabetical() {
+    // Source order is `zz` then `aa` (reverse of alphabetical); the winner
+    // is `zz`, proving the pick is declaration order, not name order.
+    let diags = check_source_strict(
+        r#"
+interface P { zz: 1; aa: "a" }
+interface Q { zz: 2; aa: "b" }
+declare const r: P & Q;
+r.zz;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18031).as_deref(),
+        Some(
+            "The intersection 'P & Q' was reduced to 'never' because property 'zz' has conflicting types in some constituents."
+        ),
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn multi_conflict_order_ignores_second_members_declaration_order() {
+    // `A` declares `y` before `x`; `B` declares `x` before `y`. tsc uses the
+    // FIRST member's order, so `y` wins even though `B` (and the access
+    // itself) would suggest `x`.
+    let diags = check_source_strict(
+        r#"
+interface A { y: "a"; x: 1 }
+interface B { x: 2; y: "b" }
+declare const c: A & B;
+c.x;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18031).as_deref(),
+        Some(
+            "The intersection 'A & B' was reduced to 'never' because property 'y' has conflicting types in some constituents."
+        ),
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn multi_conflict_order_appends_property_absent_from_first_member() {
+    // `A` declares only `p` (no conflict on its own). `B` declares `r` then
+    // `q`; `C` declares `q` then `r`. Since `p` never conflicts, the winner
+    // is the first NEW name introduced by a later member: `B`'s own order
+    // puts `r` before `q`, so `r` wins over `q` even though `C` declares
+    // `q` first.
+    let diags = check_source_strict(
+        r#"
+interface A { p: 1 }
+interface B { r: "b"; q: "x" }
+interface C { q: "y"; r: "c" }
+declare const c: A & B & C;
+c.p;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18031).as_deref(),
+        Some(
+            "The intersection 'A & B & C' was reduced to 'never' because property 'r' has conflicting types in some constituents."
+        ),
+        "got {diags:?}"
+    );
+}
+
 #[test]
 fn indirect_alias_intersection_has_no_ts18031() {
     // The conflict is real (tsc still reports the elaboration here through

--- a/crates/tsz-solver/src/type_queries/data/intersection_conflict.rs
+++ b/crates/tsz-solver/src/type_queries/data/intersection_conflict.rs
@@ -28,6 +28,20 @@ use tsz_common::interner::Atom;
 /// returning `None` for a conflict shape it doesn't recognize leaves the
 /// primary `TS2339` diagnostic exactly as it is today (no elaboration line),
 /// never a wrong one, so under-covering here is safe.
+///
+/// When more than one property name conflicts, tsc always names the first
+/// one by a combined declaration order: walk `members` left to right, and
+/// within each member walk its own properties in declaration order, adding
+/// each name to the combined order only the first time it is seen (a
+/// property introduced by a later member is ordered after every name the
+/// earlier members already declared, even ones that didn't conflict).
+/// Oracle-verified against `typescript@7.0.2`: the picked property tracks
+/// this combined order regardless of which property was actually accessed,
+/// and is independent of alphabetical order or which operand later members
+/// re-declare the name in. `ObjectShape::properties` itself is sorted by
+/// interned `Atom` id for canonical hashing identity, so this reads each
+/// property's own `declaration_order` field (excluded from hashing, backfilled
+/// by the interner from source insertion order) rather than `Vec` position.
 pub fn find_disjoint_literal_property_across_intersection(
     db: &dyn TypeDatabase,
     members: &[TypeId],
@@ -38,8 +52,16 @@ pub fn find_disjoint_literal_property_across_intersection(
     // regardless of whether it is observed before or after a literal
     // occurrence of the same name.
     let mut excluded: FxHashSet<Atom> = FxHashSet::default();
+    let mut order: Vec<Atom> = Vec::new();
+    let mut seen: FxHashSet<Atom> = FxHashSet::default();
     let mut ingest = |properties: &[crate::types::PropertyInfo]| {
-        for prop in properties {
+        let mut by_declaration_order: Vec<&crate::types::PropertyInfo> =
+            properties.iter().collect();
+        by_declaration_order.sort_by_key(|prop| prop.declaration_order);
+        for prop in by_declaration_order {
+            if seen.insert(prop.name) {
+                order.push(prop.name);
+            }
             if prop.optional || excluded.contains(&prop.name) {
                 continue;
             }
@@ -69,8 +91,7 @@ pub fn find_disjoint_literal_property_across_intersection(
             _ => {}
         }
     }
-    by_name
+    order
         .into_iter()
-        .find(|(_, values)| values.len() >= 2)
-        .map(|(name, _)| name)
+        .find(|name| by_name.get(name).is_some_and(|values| values.len() >= 2))
 }


### PR DESCRIPTION
When a `never`-typed property-access receiver's declared intersection has more than one conflicting property name, `find_disjoint_literal_property_across_intersection` (added in #16781) picked which one to name via `FxHashMap::into_iter().find(...)` — arbitrary hash-bucket order, not any order tsc's own output tracks.

**Structural rule** (oracle-verified against `typescript@7.0.2`, 10 probes): when multiple properties conflict, tsc always names the first one by a *combined declaration order* — walk the intersection's members left to right, and within each member walk its own properties in declaration order, positioning each name at its **first** occurrence across all members. This holds independent of which property is actually accessed, independent of alphabetical order, and uses the **first** member's property order even when a later member declares the same names in a different order (confirmed with reverse-alphabetical source order, swapped member orders, and a case where the conflicting name is introduced by a later member entirely).

`ObjectShape::properties` is sorted by interned `Atom` id for canonical hashing identity, so `Vec` position can't recover source order either. Each `PropertyInfo` already carries a `declaration_order` field for exactly this purpose (excluded from `PartialEq`/`Hash`, backfilled by the interner from source insertion order) — `crates/tsz-solver/src/type_queries/data/intersection_conflict.rs` now sorts each member's properties by it before folding into a first-seen combined order, and returns the first name in that order whose occurrences still conflict.

**Adjacent matrix** (new tests in `ts18031_intersection_conflicting_property_tests.rs`, all oracle-verified): first member's declaration order wins even when the access targets a different (also-conflicting) property; source order beats alphabetical order (reverse-alphabetical case); the first member's order wins even when a later member declares the same two names in the opposite order; a property absent from the first member is ordered by whichever later member introduces it first, using *that* member's own order for ties among newly-introduced names.

Related: my own #16788 opened moments after #16781 merged, duplicating its scope; closed as superseded once the overlap was clear (see comment there) — this PR is the one real gap #16788's review surfaced.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib ts18031_intersection_conflicting_property_tests` — 12/12 (4 new multi-conflict-ordering cases + the 8 existing).
- `cargo test -p tsz-solver --lib intersection` — 506/506 (unaffected: the fix only changes *which* Atom is returned on the already-narrow multi-conflict path, not the has-a-conflict predicate).
- `cargo test -p tsz-checker --lib property` — 1410/1410, 1 pre-existing ignore.
- `cargo clippy -p tsz-solver -p tsz-checker --lib --all-features -- -D warnings` — clean.
- `cargo fmt --check -p tsz-solver -p tsz-checker` — clean.
- `python3 scripts/arch/arch_guard.py` — passed.
- Manual: 10 oracle probes against the pinned `typescript@7.0.2` binary (`node .../tsc --noEmit --strict ...`) establishing the combined-declaration-order rule before writing the fix.
- **Owed**: `compare-to-parent.sh` / conformance snapshot not run (no TypeScript corpus checked out in this container). Diagnostic *code* and *count* are unaffected — this only changes the property name inside an already-emitted `related_information` string on an already-narrow, newly-added path (#16781, not yet in a conformance baseline), so a 0/0 set-difference is expected for the same reason #16781 itself recorded.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqhVf4tK8AZi2NqrxHAU2c)_