### PR TITLE
fix(parser): type-member modifier grammar reports TS1070 for export/in/out and TS1024 for readonly on method/construct signatures (#16291)

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -34,6 +34,7 @@ mod speculation;
 pub mod spelling;
 pub mod state;
 mod state_declarations;
+mod state_declarations_enums;
 mod state_declarations_exports;
 mod state_declarations_modules;
 mod state_diagnostics;
@@ -363,6 +364,10 @@ mod reserved_parameter_recovery_tests;
 #[cfg(test)]
 #[path = "../../tests/ts1180_property_destructuring_pattern_expected_tests.rs"]
 mod ts1180_property_destructuring_pattern_expected_tests;
+
+#[cfg(test)]
+#[path = "../../tests/type_member_modifier_grammar_tests.rs"]
+mod type_member_modifier_grammar_tests;
 
 // Re-export flags
 pub use flags::{modifier_flags, node_flags, transform_flags};

--- a/crates/tsz-parser/src/parser/state_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_declarations.rs
@@ -1,9 +1,11 @@
-//! Parser state - interface, type alias, enum, module, import/export, and control flow parsing methods
+//! Parser state - interface, type alias, module, import/export, and control flow parsing methods
+//!
+//! Enum declaration parsing lives in `state_declarations_enums.rs`.
 
 use super::state::ParserState;
 use crate::parser::{
     NodeIndex, NodeList,
-    node::{EnumData, EnumMemberData, IdentifierData, ParameterData},
+    node::{IdentifierData, ParameterData},
     syntax_kind_ext,
 };
 use tsz_common::interner::{AstAtom, IdentText};
@@ -423,6 +425,9 @@ impl ParserState {
                 | SyntaxKind::OverrideKeyword
                 | SyntaxKind::AbstractKeyword
                 | SyntaxKind::DeclareKeyword
+                | SyntaxKind::ExportKeyword
+                | SyntaxKind::InKeyword
+                | SyntaxKind::OutKeyword
         ) && !self.look_ahead_is_property_name_after_keyword()
             && !self.look_ahead_has_line_break_after_keyword()
         {
@@ -485,14 +490,19 @@ impl ParserState {
         start_pos: u32,
         in_interface_declaration: bool,
     ) -> NodeIndex {
-        let readonly = if self.is_token(SyntaxKind::ReadonlyKeyword)
+        // Capture the `readonly` keyword span so a TS1024 (readonly on a
+        // method/construct signature) can be anchored at the modifier itself,
+        // matching tsc's `checkGrammarModifiers`.
+        let readonly_span = if self.is_token(SyntaxKind::ReadonlyKeyword)
             && !self.look_ahead_is_property_name_after_keyword()
         {
+            let span = (self.token_pos(), self.token_end());
             self.next_token();
-            true
+            Some(span)
         } else {
-            false
+            None
         };
+        let readonly = readonly_span.is_some();
 
         let Some(name) = self.parse_type_member_property_or_method_name(start_pos, readonly) else {
             return NodeIndex::NONE;
@@ -509,6 +519,18 @@ impl ParserState {
         let modifiers = self.readonly_modifier_node_list(start_pos, readonly);
 
         if self.is_token(SyntaxKind::OpenParenToken) || self.is_token(SyntaxKind::LessThanToken) {
+            // `readonly` is legal only on a property declaration or index
+            // signature; on a method or construct signature tsc reports TS1024,
+            // anchored at the `readonly` keyword.
+            if let Some((ro_start, ro_end)) = readonly_span {
+                use tsz_common::diagnostics::diagnostic_codes;
+                self.parse_error_at(
+                    ro_start,
+                    ro_end.saturating_sub(ro_start),
+                    "'readonly' modifier can only appear on a property declaration or index signature.",
+                    diagnostic_codes::READONLY_MODIFIER_CAN_ONLY_APPEAR_ON_A_PROPERTY_DECLARATION_OR_INDEX_SIGNATURE,
+                );
+            }
             return self.parse_type_member_method_signature(
                 start_pos,
                 name,
@@ -1372,214 +1394,6 @@ impl ParserState {
                 type_node,
             },
         )
-    }
-
-    /// Parse enum declaration
-    pub(crate) fn parse_enum_declaration(&mut self) -> NodeIndex {
-        let start_pos = self.token_pos();
-        self.parse_enum_declaration_with_modifiers(start_pos, None)
-    }
-
-    /// Parse enum declaration with explicit modifiers
-    pub(crate) fn parse_enum_declaration_with_modifiers(
-        &mut self,
-        start_pos: u32,
-        modifiers: Option<NodeList>,
-    ) -> NodeIndex {
-        let enum_keyword_end = self.token_end();
-        self.parse_expected(SyntaxKind::EnumKeyword);
-
-        let name = self.parse_enum_declaration_name();
-
-        let has_open_brace = self.parse_expected(SyntaxKind::OpenBraceToken);
-
-        let members = if has_open_brace {
-            self.parse_enum_members()
-        } else {
-            Self::make_node_list(Vec::new())
-        };
-
-        if has_open_brace {
-            self.parse_expected(SyntaxKind::CloseBraceToken);
-        }
-
-        let end_pos = if has_open_brace {
-            self.token_end()
-        } else {
-            enum_keyword_end
-        };
-        self.arena.add_enum(
-            syntax_kind_ext::ENUM_DECLARATION,
-            start_pos,
-            end_pos,
-            EnumData {
-                modifiers,
-                name,
-                members,
-            },
-        )
-    }
-
-    fn parse_enum_declaration_name(&mut self) -> NodeIndex {
-        let start_pos = self.token_pos();
-        let end_pos = self.token_end();
-
-        if self.is_reserved_word() {
-            // `tsc` reports the missing enum name but leaves the reserved word
-            // for the outer statement parser. This preserves recovered forms like
-            // `enum void {}` as an anonymous enum plus a following `void {}`.
-            self.error_identifier_expected();
-            return self.arena.add_identifier(
-                SyntaxKind::Identifier as u16,
-                start_pos,
-                end_pos,
-                IdentifierData {
-                    atom: AstAtom::NONE,
-                    escaped_text: IdentText::empty(),
-                    original_text: None,
-                },
-            );
-        }
-
-        self.parse_identifier()
-    }
-
-    /// Parse enum members
-    pub(crate) fn parse_enum_members(&mut self) -> NodeList {
-        use tsz_common::diagnostics::diagnostic_codes;
-        let mut members = Vec::new();
-
-        while !self.is_token(SyntaxKind::CloseBraceToken)
-            && !self.is_token(SyntaxKind::EndOfFileToken)
-        {
-            let start_pos = self.token_pos();
-
-            // Handle leading comma - emit TS1132 "Enum member expected" and skip
-            if self.is_token(SyntaxKind::CommaToken) {
-                self.parse_error_at_current_token(
-                    "Enum member expected.",
-                    diagnostic_codes::ENUM_MEMBER_EXPECTED,
-                );
-                self.next_token(); // Skip the comma
-                continue;
-            }
-
-            // Handle @ inside enum body - not a valid enum member start.
-            // Emit TS1132 and break out so the outer statement parser handles the
-            // decorator-like syntax (producing TS1146 + TS1128 matching tsc).
-            if self.is_token(SyntaxKind::AtToken) {
-                self.parse_error_at_current_token(
-                    "Enum member expected.",
-                    diagnostic_codes::ENUM_MEMBER_EXPECTED,
-                );
-                break;
-            }
-
-            // Enum member names can be identifiers, string literals, or computed property names.
-            // Numeric literals are parsed as names for error recovery (TS2452 reported by checker).
-            // Computed property names ([x]) are not valid in enums but we recover gracefully.
-            let name = if self.is_token(SyntaxKind::OpenBracketToken) {
-                // Parse computed property name for recovery. TS1164 is emitted by the
-                // checker (grammar check), not the parser, matching tsc's behavior.
-                // This avoids position-based dedup conflicts with TS1357.
-                self.parse_property_name()
-            } else if self.is_token(SyntaxKind::StringLiteral) {
-                self.parse_string_literal()
-            } else if self.is_token(SyntaxKind::NumericLiteral) {
-                // Parse numeric literal as name for recovery (checker emits TS2452)
-                self.parse_numeric_literal()
-            } else if self.is_token(SyntaxKind::BigIntLiteral) {
-                // Parse bigint literal as name for recovery (checker emits TS2452)
-                self.parse_bigint_literal()
-            } else if self.is_token(SyntaxKind::PrivateIdentifier) {
-                self.parse_error_at_current_token(
-                    "An enum member cannot be named with a private identifier.",
-                    diagnostic_codes::AN_ENUM_MEMBER_CANNOT_BE_NAMED_WITH_A_PRIVATE_IDENTIFIER,
-                );
-                self.parse_private_identifier()
-            } else {
-                self.parse_identifier_name()
-            };
-
-            // Check for unexpected token after enum member name - emit TS1357.
-            // `tsc` still records the malformed member before recovering, so emit
-            // continues to allocate enum values for invalid names such as
-            // `name: 1` and `name;`.
-            if !self.is_token(SyntaxKind::EqualsToken)
-                && !self.is_token(SyntaxKind::CommaToken)
-                && !self.is_token(SyntaxKind::CloseBraceToken)
-                && !self.is_token(SyntaxKind::EndOfFileToken)
-            {
-                self.parse_error_at_current_token(
-                    "An enum member name must be followed by a ',', '=', or '}'.",
-                    diagnostic_codes::AN_ENUM_MEMBER_NAME_MUST_BE_FOLLOWED_BY_A_OR,
-                );
-
-                let member_end = self.arena.get(name).map_or(start_pos, |node| node.end);
-                let member = self.arena.add_enum_member(
-                    syntax_kind_ext::ENUM_MEMBER,
-                    start_pos,
-                    member_end,
-                    EnumMemberData {
-                        name,
-                        initializer: NodeIndex::NONE,
-                    },
-                );
-                members.push(member);
-
-                // Recover by moving past one offending token unless that token
-                // can itself start the next enum member. This keeps namelike
-                // recovery tokens (`any`, `"hello"`, `1`) available to the next
-                // iteration, matching `tsc`'s invalid-member AST.
-                let starts_member = self.is_token(SyntaxKind::OpenBracketToken)
-                    || self.is_token(SyntaxKind::StringLiteral)
-                    || self.is_token(SyntaxKind::NumericLiteral)
-                    || self.is_token(SyntaxKind::BigIntLiteral)
-                    || self.is_token(SyntaxKind::PrivateIdentifier)
-                    || self.is_identifier_or_keyword();
-                if !starts_member {
-                    self.next_token();
-                }
-                continue;
-            }
-
-            let initializer = if self.parse_optional(SyntaxKind::EqualsToken) {
-                self.parse_assignment_expression()
-            } else {
-                NodeIndex::NONE
-            };
-
-            let end_pos = self.token_end();
-            let member = self.arena.add_enum_member(
-                syntax_kind_ext::ENUM_MEMBER,
-                start_pos,
-                end_pos,
-                EnumMemberData { name, initializer },
-            );
-            members.push(member);
-
-            // Parse comma or recover with missing comma
-            if !self.parse_optional(SyntaxKind::CommaToken) {
-                // Recovery: If the next token looks like the start of a valid enum member,
-                // emit TS1357 and continue parsing instead of breaking.
-                // tsc uses TS1357 (enum-specific) rather than generic TS1005 here.
-                if self.is_token(SyntaxKind::Identifier)
-                    || self.is_token(SyntaxKind::StringLiteral)
-                    || self.is_token(SyntaxKind::PrivateIdentifier)
-                    || self.is_token(SyntaxKind::OpenBracketToken)
-                {
-                    self.parse_error_at_current_token(
-                        "An enum member name must be followed by a ',', '=', or '}'.",
-                        diagnostic_codes::AN_ENUM_MEMBER_NAME_MUST_BE_FOLLOWED_BY_A_OR,
-                    );
-                    // Continue to next iteration to parse the next member
-                    continue;
-                }
-                break;
-            }
-        }
-
-        Self::make_node_list(members)
     }
 
     // =========================================================================

--- a/crates/tsz-parser/src/parser/state_declarations_enums.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_enums.rs
@@ -1,0 +1,224 @@
+//! Parser state - enum declaration parsing methods.
+//!
+//! Split out of `state_declarations.rs` to keep each parser source file under
+//! the 2000-line architecture ceiling. Behaviour is unchanged; these methods
+//! remain `impl ParserState` and are called from the same sites as before.
+
+use super::state::ParserState;
+use crate::parser::{
+    NodeIndex, NodeList,
+    node::{EnumData, EnumMemberData, IdentifierData},
+    syntax_kind_ext,
+};
+use tsz_common::interner::{AstAtom, IdentText};
+use tsz_scanner::SyntaxKind;
+
+impl ParserState {
+    /// Parse enum declaration
+    pub(crate) fn parse_enum_declaration(&mut self) -> NodeIndex {
+        let start_pos = self.token_pos();
+        self.parse_enum_declaration_with_modifiers(start_pos, None)
+    }
+
+    /// Parse enum declaration with explicit modifiers
+    pub(crate) fn parse_enum_declaration_with_modifiers(
+        &mut self,
+        start_pos: u32,
+        modifiers: Option<NodeList>,
+    ) -> NodeIndex {
+        let enum_keyword_end = self.token_end();
+        self.parse_expected(SyntaxKind::EnumKeyword);
+
+        let name = self.parse_enum_declaration_name();
+
+        let has_open_brace = self.parse_expected(SyntaxKind::OpenBraceToken);
+
+        let members = if has_open_brace {
+            self.parse_enum_members()
+        } else {
+            Self::make_node_list(Vec::new())
+        };
+
+        if has_open_brace {
+            self.parse_expected(SyntaxKind::CloseBraceToken);
+        }
+
+        let end_pos = if has_open_brace {
+            self.token_end()
+        } else {
+            enum_keyword_end
+        };
+        self.arena.add_enum(
+            syntax_kind_ext::ENUM_DECLARATION,
+            start_pos,
+            end_pos,
+            EnumData {
+                modifiers,
+                name,
+                members,
+            },
+        )
+    }
+
+    fn parse_enum_declaration_name(&mut self) -> NodeIndex {
+        let start_pos = self.token_pos();
+        let end_pos = self.token_end();
+
+        if self.is_reserved_word() {
+            // `tsc` reports the missing enum name but leaves the reserved word
+            // for the outer statement parser. This preserves recovered forms like
+            // `enum void {}` as an anonymous enum plus a following `void {}`.
+            self.error_identifier_expected();
+            return self.arena.add_identifier(
+                SyntaxKind::Identifier as u16,
+                start_pos,
+                end_pos,
+                IdentifierData {
+                    atom: AstAtom::NONE,
+                    escaped_text: IdentText::empty(),
+                    original_text: None,
+                },
+            );
+        }
+
+        self.parse_identifier()
+    }
+
+    /// Parse enum members
+    pub(crate) fn parse_enum_members(&mut self) -> NodeList {
+        use tsz_common::diagnostics::diagnostic_codes;
+        let mut members = Vec::new();
+
+        while !self.is_token(SyntaxKind::CloseBraceToken)
+            && !self.is_token(SyntaxKind::EndOfFileToken)
+        {
+            let start_pos = self.token_pos();
+
+            // Handle leading comma - emit TS1132 "Enum member expected" and skip
+            if self.is_token(SyntaxKind::CommaToken) {
+                self.parse_error_at_current_token(
+                    "Enum member expected.",
+                    diagnostic_codes::ENUM_MEMBER_EXPECTED,
+                );
+                self.next_token(); // Skip the comma
+                continue;
+            }
+
+            // Handle @ inside enum body - not a valid enum member start.
+            // Emit TS1132 and break out so the outer statement parser handles the
+            // decorator-like syntax (producing TS1146 + TS1128 matching tsc).
+            if self.is_token(SyntaxKind::AtToken) {
+                self.parse_error_at_current_token(
+                    "Enum member expected.",
+                    diagnostic_codes::ENUM_MEMBER_EXPECTED,
+                );
+                break;
+            }
+
+            // Enum member names can be identifiers, string literals, or computed property names.
+            // Numeric literals are parsed as names for error recovery (TS2452 reported by checker).
+            // Computed property names ([x]) are not valid in enums but we recover gracefully.
+            let name = if self.is_token(SyntaxKind::OpenBracketToken) {
+                // Parse computed property name for recovery. TS1164 is emitted by the
+                // checker (grammar check), not the parser, matching tsc's behavior.
+                // This avoids position-based dedup conflicts with TS1357.
+                self.parse_property_name()
+            } else if self.is_token(SyntaxKind::StringLiteral) {
+                self.parse_string_literal()
+            } else if self.is_token(SyntaxKind::NumericLiteral) {
+                // Parse numeric literal as name for recovery (checker emits TS2452)
+                self.parse_numeric_literal()
+            } else if self.is_token(SyntaxKind::BigIntLiteral) {
+                // Parse bigint literal as name for recovery (checker emits TS2452)
+                self.parse_bigint_literal()
+            } else if self.is_token(SyntaxKind::PrivateIdentifier) {
+                self.parse_error_at_current_token(
+                    "An enum member cannot be named with a private identifier.",
+                    diagnostic_codes::AN_ENUM_MEMBER_CANNOT_BE_NAMED_WITH_A_PRIVATE_IDENTIFIER,
+                );
+                self.parse_private_identifier()
+            } else {
+                self.parse_identifier_name()
+            };
+
+            // Check for unexpected token after enum member name - emit TS1357.
+            // `tsc` still records the malformed member before recovering, so emit
+            // continues to allocate enum values for invalid names such as
+            // `name: 1` and `name;`.
+            if !self.is_token(SyntaxKind::EqualsToken)
+                && !self.is_token(SyntaxKind::CommaToken)
+                && !self.is_token(SyntaxKind::CloseBraceToken)
+                && !self.is_token(SyntaxKind::EndOfFileToken)
+            {
+                self.parse_error_at_current_token(
+                    "An enum member name must be followed by a ',', '=', or '}'.",
+                    diagnostic_codes::AN_ENUM_MEMBER_NAME_MUST_BE_FOLLOWED_BY_A_OR,
+                );
+
+                let member_end = self.arena.get(name).map_or(start_pos, |node| node.end);
+                let member = self.arena.add_enum_member(
+                    syntax_kind_ext::ENUM_MEMBER,
+                    start_pos,
+                    member_end,
+                    EnumMemberData {
+                        name,
+                        initializer: NodeIndex::NONE,
+                    },
+                );
+                members.push(member);
+
+                // Recover by moving past one offending token unless that token
+                // can itself start the next enum member. This keeps namelike
+                // recovery tokens (`any`, `"hello"`, `1`) available to the next
+                // iteration, matching `tsc`'s invalid-member AST.
+                let starts_member = self.is_token(SyntaxKind::OpenBracketToken)
+                    || self.is_token(SyntaxKind::StringLiteral)
+                    || self.is_token(SyntaxKind::NumericLiteral)
+                    || self.is_token(SyntaxKind::BigIntLiteral)
+                    || self.is_token(SyntaxKind::PrivateIdentifier)
+                    || self.is_identifier_or_keyword();
+                if !starts_member {
+                    self.next_token();
+                }
+                continue;
+            }
+
+            let initializer = if self.parse_optional(SyntaxKind::EqualsToken) {
+                self.parse_assignment_expression()
+            } else {
+                NodeIndex::NONE
+            };
+
+            let end_pos = self.token_end();
+            let member = self.arena.add_enum_member(
+                syntax_kind_ext::ENUM_MEMBER,
+                start_pos,
+                end_pos,
+                EnumMemberData { name, initializer },
+            );
+            members.push(member);
+
+            // Parse comma or recover with missing comma
+            if !self.parse_optional(SyntaxKind::CommaToken) {
+                // Recovery: If the next token looks like the start of a valid enum member,
+                // emit TS1357 and continue parsing instead of breaking.
+                // tsc uses TS1357 (enum-specific) rather than generic TS1005 here.
+                if self.is_token(SyntaxKind::Identifier)
+                    || self.is_token(SyntaxKind::StringLiteral)
+                    || self.is_token(SyntaxKind::PrivateIdentifier)
+                    || self.is_token(SyntaxKind::OpenBracketToken)
+                {
+                    self.parse_error_at_current_token(
+                        "An enum member name must be followed by a ',', '=', or '}'.",
+                        diagnostic_codes::AN_ENUM_MEMBER_NAME_MUST_BE_FOLLOWED_BY_A_OR,
+                    );
+                    // Continue to next iteration to parse the next member
+                    continue;
+                }
+                break;
+            }
+        }
+
+        Self::make_node_list(members)
+    }
+}

--- a/crates/tsz-parser/tests/type_member_modifier_grammar_tests.rs
+++ b/crates/tsz-parser/tests/type_member_modifier_grammar_tests.rs
@@ -1,0 +1,253 @@
+//! Type-member (interface / type-literal) modifier grammar parity with tsc.
+//!
+//! Two positions that `checkGrammarModifiers` rejects but tsz previously did
+//! not, verified against `typescript@7.0.2`:
+//!   * `export` / `in` / `out` as a modifier on a type member → TS1070
+//!     (`'{0}' modifier cannot appear on a type member.`), anchored at the
+//!     modifier. tsz previously mis-parsed `export` to TS1005 and dropped
+//!     `in` / `out` silently.
+//!   * `readonly` on a method or construct signature → TS1024
+//!     (`'readonly' modifier can only appear on a property declaration or index
+//!     signature.`), anchored at `readonly`. tsz previously stayed silent.
+//!
+//! `readonly` on a property / index signature stays legal, and `export` / `in`
+//! / `out` used as a member *name* (`export: T`, `export(): void`) stay clean —
+//! matching tsc. `import` / `const` / `default` are not type-member modifiers in
+//! tsc (they take a parser-recovery path) and are intentionally not covered.
+
+use crate::parser::test_fixture::parse_source;
+use tsz_common::diagnostics::diagnostic_codes;
+use tsz_common::position::LineMap;
+
+/// `(code, line, column, message)` fingerprints, 1-based line/column, in the
+/// order the parser reported them.
+fn fingerprints(source: &str) -> Vec<(u32, u32, u32, String)> {
+    let (parser, _root) = parse_source(source);
+    let line_map = LineMap::build(source);
+    parser
+        .get_diagnostics()
+        .iter()
+        .map(|diag| {
+            let pos = line_map.offset_to_position(diag.start, source);
+            (
+                diag.code,
+                pos.line + 1,
+                pos.character + 1,
+                diag.message.clone(),
+            )
+        })
+        .collect()
+}
+
+fn codes(source: &str) -> Vec<u32> {
+    let (parser, _root) = parse_source(source);
+    parser.get_diagnostics().iter().map(|d| d.code).collect()
+}
+
+const TS1070: u32 = diagnostic_codes::MODIFIER_CANNOT_APPEAR_ON_A_TYPE_MEMBER;
+const TS1024: u32 =
+    diagnostic_codes::READONLY_MODIFIER_CAN_ONLY_APPEAR_ON_A_PROPERTY_DECLARATION_OR_INDEX_SIGNATURE;
+
+// ---------------------------------------------------------------------------
+// TS1070: export / in / out modifier on a type member
+// ---------------------------------------------------------------------------
+
+#[test]
+fn export_modifier_on_interface_property_reports_ts1070() {
+    // `export` starts at column 15 (`interface I { `).
+    assert_eq!(
+        fingerprints("interface I { export x: number; }"),
+        vec![(
+            TS1070,
+            1,
+            15,
+            "'export' modifier cannot appear on a type member.".to_string()
+        )],
+    );
+}
+
+#[test]
+fn export_modifier_on_interface_method_reports_ts1070() {
+    assert_eq!(
+        fingerprints("interface I { export m(): void; }"),
+        vec![(
+            TS1070,
+            1,
+            15,
+            "'export' modifier cannot appear on a type member.".to_string()
+        )],
+    );
+}
+
+#[test]
+fn export_modifier_on_type_literal_property_reports_ts1070() {
+    // `type T = { ` → `export` at column 12.
+    assert_eq!(
+        fingerprints("type T = { export x: number; };"),
+        vec![(
+            TS1070,
+            1,
+            12,
+            "'export' modifier cannot appear on a type member.".to_string()
+        )],
+    );
+}
+
+#[test]
+fn in_modifier_on_interface_property_reports_ts1070() {
+    assert_eq!(
+        fingerprints("interface Foo { in bar: number; }"),
+        vec![(
+            TS1070,
+            1,
+            17,
+            "'in' modifier cannot appear on a type member.".to_string()
+        )],
+    );
+}
+
+#[test]
+fn out_modifier_on_interface_property_reports_ts1070() {
+    assert_eq!(
+        fingerprints("interface Foo { out bar: number; }"),
+        vec![(
+            TS1070,
+            1,
+            17,
+            "'out' modifier cannot appear on a type member.".to_string()
+        )],
+    );
+}
+
+#[test]
+fn export_modifier_anchors_at_the_keyword_with_leading_whitespace() {
+    let source = "interface I {\n    export foo(): void;\n}";
+    assert_eq!(
+        fingerprints(source),
+        vec![(
+            TS1070,
+            2,
+            5,
+            "'export' modifier cannot appear on a type member.".to_string()
+        )],
+    );
+}
+
+#[test]
+fn export_before_legal_readonly_reports_only_ts1070() {
+    // `readonly` after `export` is legal on the property, so only the `export`
+    // is rejected — a single diagnostic, no TS1024.
+    assert_eq!(
+        codes("interface I { export readonly x: number; }"),
+        vec![TS1070],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TS1024: readonly on a method / construct signature
+// ---------------------------------------------------------------------------
+
+#[test]
+fn readonly_on_interface_method_reports_ts1024() {
+    assert_eq!(
+        fingerprints("interface I { readonly m(): void; }"),
+        vec![(
+            TS1024,
+            1,
+            15,
+            "'readonly' modifier can only appear on a property declaration or index signature."
+                .to_string()
+        )],
+    );
+}
+
+#[test]
+fn readonly_on_interface_generic_method_reports_ts1024() {
+    assert_eq!(
+        fingerprints("interface I { readonly m<T>(): void; }"),
+        vec![(
+            TS1024,
+            1,
+            15,
+            "'readonly' modifier can only appear on a property declaration or index signature."
+                .to_string()
+        )],
+    );
+}
+
+#[test]
+fn readonly_on_construct_signature_reports_ts1024() {
+    assert_eq!(
+        fingerprints("interface I { readonly new (): void; }"),
+        vec![(
+            TS1024,
+            1,
+            15,
+            "'readonly' modifier can only appear on a property declaration or index signature."
+                .to_string()
+        )],
+    );
+}
+
+#[test]
+fn readonly_on_type_literal_method_reports_ts1024() {
+    assert_eq!(
+        fingerprints("type Shape = { readonly compute(): number; };"),
+        vec![(
+            TS1024,
+            1,
+            16,
+            "'readonly' modifier can only appear on a property declaration or index signature."
+                .to_string()
+        )],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls: legal shapes stay clean, member-name uses stay clean
+// ---------------------------------------------------------------------------
+
+#[test]
+fn readonly_property_and_index_signature_stay_clean() {
+    assert!(codes("interface I { readonly x: number; }").is_empty());
+    assert!(codes("interface I { readonly [k: string]: number; }").is_empty());
+    assert!(codes("type T = { readonly y: string; };").is_empty());
+}
+
+#[test]
+fn export_in_out_as_member_names_stay_clean() {
+    // Followed by `:` → property name; followed by `(` → method name.
+    assert!(codes("interface I { export: number; }").is_empty());
+    assert!(codes("interface I { export(): void; }").is_empty());
+    assert!(codes("interface I { in: number; }").is_empty());
+    assert!(codes("interface I { out: number; }").is_empty());
+    assert!(codes("interface I { in(): void; }").is_empty());
+}
+
+#[test]
+fn method_named_readonly_stays_clean() {
+    // `readonly` immediately followed by `(` is a method *named* `readonly`,
+    // not a modifier — no TS1024.
+    assert!(codes("interface I { readonly(): void; }").is_empty());
+}
+
+#[test]
+fn plain_members_stay_clean() {
+    assert!(codes("interface I { m(): void; x: number; }").is_empty());
+}
+
+#[test]
+fn previously_covered_modifiers_still_report_ts1070() {
+    // Guard against a regression in the shared modifier-error branch.
+    for modifier in [
+        "public",
+        "private",
+        "protected",
+        "static",
+        "abstract",
+        "declare",
+    ] {
+        let source = format!("interface I {{ {modifier} x: number; }}");
+        assert_eq!(codes(&source), vec![TS1070], "modifier `{modifier}`");
+    }
+}

--- a/scripts/arch/arch_guard_file_limits.py
+++ b/scripts/arch/arch_guard_file_limits.py
@@ -1020,9 +1020,7 @@ FILE_LINE_LIMIT_CHECKS = [
         ROOT / "crates" / "tsz-solver" / "src" / "contextual" / "extractors.rs",
         2004,
     ),
-    (
-        "Parser boundary: parser/state_declarations.rs size ratchet",
-        ROOT / "crates" / "tsz-parser" / "src" / "parser" / "state_declarations.rs",
-        2001,
-    ),
+    # parser/state_declarations.rs dropped below the 2000-line cap once enum
+    # declaration parsing moved to state_declarations_enums.rs; its ratchet
+    # entry was removed (the allowlist only shrinks).
 ]

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -289,7 +289,6 @@ _CRATE_SRC_LINE_LIMIT_ALLOWLISTS = [
     ("tsz-parser", "Parser", {
         "crates/tsz-parser/src/parser/state_expressions_literals_regex.rs",
         "crates/tsz-parser/src/parser/state_statements_class_members.rs",
-        "crates/tsz-parser/src/parser/state_declarations.rs",
     }),
     ("tsz-scanner", "Scanner", set()),
     ("tsz-solver", "Solver", {


### PR DESCRIPTION
Interface / type-literal member modifier grammar was missing two positions that
tsc's `checkGrammarModifiers` reports. Found via #16291's cross-position method
against the pinned `typescript@7.0.2` oracle, in the type-member parse path
(`state_declarations.rs`, the existing TS1070 owner) — a distinct file from the
in-flight class-member modifier work.

- `export` / `in` / `out` as a modifier on a type member → **TS1070**
  (`'{0}' modifier cannot appear on a type member.`). tsz previously mis-parsed
  `export` to TS1005 and dropped `in` / `out` silently.
- `readonly` on a method or construct signature → **TS1024**
  (`'readonly' modifier can only appear on a property declaration or index
  signature.`). tsz previously stayed silent.

**Structural rule.** When a modifier keyword leads an interface / type-literal
member: `export` / `in` / `out` (like the already-covered
`public/private/protected/static/abstract/declare/override/accessor/async`) are
not permitted on a type element → tsc reports TS1070; and `readonly` is legal
only on a property declaration or index signature, so on a method / construct
signature → TS1024. Both are emitted by the parser (`state_declarations.rs`):
`parse_type_member_visibility_modifier_error` gains `export`/`in`/`out` in its
guarded modifier set (reusing the existing property-name / line-break lookahead,
so `export: T`, `export(){}`-as-name, and `readonly(){}`-as-name stay clean), and
`parse_type_member_property_or_method` emits TS1024 anchored at the `readonly`
keyword when a consumed `readonly` resolves to a method / construct signature.
Both fire for interface *and* type-literal members via the shared parse path.
`import` / `const` / `default` are not type-member modifiers in tsc (parser
recovery, TS1005 / TS1131) and already match — left untouched.

### Adjacent matrix (oracle-pinned vs `typescript@7.0.2`, code + line + column)

| source | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `interface I { export x: number }` | TS1070 @1:15 | TS1005 | TS1070 @1:15 |
| `interface I { export m(): void }` | TS1070 | TS1005 | TS1070 |
| `type T = { export x: number }` | TS1070 @1:12 | TS1128+TS1131+TS1434 | TS1070 @1:12 |
| `interface I { in x: number }` | TS1070 | silent | TS1070 |
| `interface I { out x: number }` | TS1070 | silent | TS1070 |
| `interface I { readonly m(): void }` | TS1024 @1:15 | silent | TS1024 @1:15 |
| `interface I { readonly new (): void }` | TS1024 | silent | TS1024 |
| `interface I { readonly m<T>(): void }` | TS1024 | silent | TS1024 |
| `type T = { readonly m(): void }` | TS1024 | silent | TS1024 |
| `interface I { export readonly x }` | TS1070 (single) | — | TS1070 (single) |
| `interface I { readonly x }` / `readonly [k]: v` | clean | clean | clean |
| `interface I { export: number }` / `export(): void` (name) | clean | clean | clean |
| `interface I { public/static/abstract/declare … }` | TS1070 | TS1070 | TS1070 |

### File split (arch ceiling)

The addition pushed `state_declarations.rs` over the 2000-line ceiling, so the
self-contained enum-declaration parsing (`parse_enum_declaration[_with_modifiers]`,
`parse_enum_declaration_name`, `parse_enum_members`) moved verbatim to a new
`state_declarations_enums.rs` (leaving 1815 lines). Its now-compliant entries
were removed from the two arch-guard allowlists (which only shrink). Enum
parsing behaviour is unchanged.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-parser` — **2010 passed, 0 failed** (16 new tests in
  `type_member_modifier_grammar_tests.rs`: anchored fingerprints, renamed
  binders, each container, readonly/export/in/out combos, negative
  property-name / method-name controls).
- `cargo clippy -p tsz-parser --all-targets` — clean, no warnings.
- `python3 scripts/arch/arch_guard.py` — passed; `test_arch_guard` self-tests
  (258) green after the allowlist removals.
- Oracle diff across the full modifier × type-member-position matrix: exact
  parity (code + line + column) on every previously-divergent row; negative
  controls unchanged.

## Provenance
Machine: cloud
Assistant: claude-code
Model: Opus 4.8
Effort: high

Addresses part of #16291.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvSPrnfeBHCYa4eXXrbhu6)_