### PR TITLE
fix(checker): TS18032 elaboration for private-brand intersection conflicts

### DIFF
--- a/crates/tsz-checker/src/error_reporter/intersection_never_elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/intersection_never_elaboration.rs
@@ -1,7 +1,7 @@
-//! `TS18031` related-info elaboration for a `TS2339` property access whose
-//! receiver is `never` because a *directly written* intersection reduced to
-//! it. Split out of `properties.rs` to keep that file under its size
-//! ratchet; the two are otherwise one unit of work.
+//! `TS18031`/`TS18032` related-info elaboration for a `TS2339` property
+//! access whose receiver is `never` because a *directly written*
+//! intersection reduced to it. Split out of `properties.rs` to keep that
+//! file under its size ratchet; the two are otherwise one unit of work.
 
 use crate::diagnostics::diagnostic_codes;
 use crate::error_reporter::fingerprint_policy::DiagnosticAnchorKind;
@@ -61,22 +61,22 @@ impl<'a> CheckerState<'a> {
         None
     }
 
-    /// The `TS18031` related-info line for a property access on a `never`
-    /// receiver, when that `never` came from a *directly written*
-    /// intersection whose members conflict over a required literal property
-    /// (`declare const c: A & B` where `A`/`B` disagree on it). tsc: `The
-    /// intersection '{0}' was reduced to 'never' because property '{1}' has
-    /// conflicting types in some constituents.`
+    /// The `TS18031`/`TS18032` related-info line for a property access on a
+    /// `never` receiver, when that `never` came from a *directly written*
+    /// intersection whose members conflict either over a required literal
+    /// property (`declare const c: A & B` where `A`/`B` disagree on it,
+    /// TS18031) or over a private-brand-carrying property declared on two
+    /// or more members (TS18032).
     ///
     /// `TypeInterner::intern` collapses such an intersection to the single
     /// canonical `TypeId::NEVER` at construction time, so by the time this
     /// `TS2339` is reported the member list is gone from `type_id` itself —
     /// this recovers it from the receiver's own declared-type syntax instead.
     /// Deliberately narrow (only the single-literal-per-member discriminant
-    /// shape, only a directly-written intersection annotation, not an alias/
-    /// generic-application/heritage chain): every early return here just
-    /// leaves the diagnostic as it is today, with no elaboration line, so
-    /// under-covering is safe and never produces a wrong message.
+    /// shape for TS18031, only a directly-written intersection annotation,
+    /// not an alias/generic-application/heritage chain): every early return
+    /// here just leaves the diagnostic as it is today, with no elaboration
+    /// line, so under-covering is safe and never produces a wrong message.
     pub(super) fn intersection_reduced_to_never_related_info(
         &mut self,
         type_id: TypeId,
@@ -95,11 +95,32 @@ impl<'a> CheckerState<'a> {
             .into_iter()
             .map(|member| self.resolve_type_for_property_access(member))
             .collect();
-        let conflict_atom =
-            crate::query_boundaries::intersection_display::find_disjoint_literal_property_across_intersection(
+        // Two independent reasons an intersection reduces to `never`: a
+        // literal-discriminant conflict (TS18031) or a private-brand
+        // conflict (TS18032). Try the literal check first — it matches
+        // tsc's own message-selection precedent from the sibling TS18015
+        // (ES-private) vs TS2442 (modifier-private "separate declarations")
+        // split, where the more specific structural reason wins when both
+        // could apply.
+        let (code, conflict_atom) =
+            if let Some(atom) = crate::query_boundaries::intersection_display::find_disjoint_literal_property_across_intersection(
                 self.ctx.types,
                 &members,
-            )?;
+            ) {
+                (
+                    diagnostic_codes::THE_INTERSECTION_WAS_REDUCED_TO_NEVER_BECAUSE_PROPERTY_HAS_CONFLICTING_TYPES_IN,
+                    atom,
+                )
+            } else {
+                let atom = crate::query_boundaries::intersection_display::find_private_brand_conflict_property(
+                    self.ctx.types,
+                    &members,
+                )?;
+                (
+                    diagnostic_codes::THE_INTERSECTION_WAS_REDUCED_TO_NEVER_BECAUSE_PROPERTY_EXISTS_IN_MULTIPLE_CONSTI,
+                    atom,
+                )
+            };
         // tsc's elaboration names the discriminant that reduced the whole
         // intersection to `never`, not necessarily the property actually
         // accessed — once the receiver type itself is `never`, every access
@@ -117,13 +138,20 @@ impl<'a> CheckerState<'a> {
             .collect::<Vec<_>>()
             .join(" & ");
         use crate::diagnostics::{Diagnostic, diagnostic_messages, format_message};
+        let message_template = if code
+            == diagnostic_codes::THE_INTERSECTION_WAS_REDUCED_TO_NEVER_BECAUSE_PROPERTY_HAS_CONFLICTING_TYPES_IN
+        {
+            diagnostic_messages::THE_INTERSECTION_WAS_REDUCED_TO_NEVER_BECAUSE_PROPERTY_HAS_CONFLICTING_TYPES_IN
+        } else {
+            diagnostic_messages::THE_INTERSECTION_WAS_REDUCED_TO_NEVER_BECAUSE_PROPERTY_EXISTS_IN_MULTIPLE_CONSTI
+        };
         Some(Diagnostic::related_message(
-            diagnostic_codes::THE_INTERSECTION_WAS_REDUCED_TO_NEVER_BECAUSE_PROPERTY_HAS_CONFLICTING_TYPES_IN,
+            code,
             self.ctx.file_name.clone(),
             0,
             0,
             format_message(
-                diagnostic_messages::THE_INTERSECTION_WAS_REDUCED_TO_NEVER_BECAUSE_PROPERTY_HAS_CONFLICTING_TYPES_IN,
+                message_template,
                 &[&intersection_display, &conflict_prop_name],
             ),
         ))

--- a/crates/tsz-checker/src/query_boundaries/intersection_display.rs
+++ b/crates/tsz-checker/src/query_boundaries/intersection_display.rs
@@ -20,6 +20,17 @@ pub(crate) fn find_disjoint_literal_property_across_intersection(
     tsz_solver::type_queries::find_disjoint_literal_property_across_intersection(db, members)
 }
 
+/// The property name whose declarations across a *written* intersection's
+/// members force a private-brand conflict (`tsc`'s TS18032), forwarding to
+/// [`tsz_solver::type_queries::find_private_brand_conflict_property`]. See
+/// that function for the exact condition and `members`' provenance.
+pub(crate) fn find_private_brand_conflict_property(
+    db: &dyn TypeDatabase,
+    members: &[TypeId],
+) -> Option<tsz_common::interner::Atom> {
+    tsz_solver::type_queries::find_private_brand_conflict_property(db, members)
+}
+
 pub(crate) fn collect_properties<R: TypeResolver>(
     type_id: TypeId,
     db: &dyn TypeDatabase,

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -899,6 +899,8 @@ mod ts18010_jsdoc_tag_anchor_tests;
 mod ts18017_ts18018_private_identifier_shadow_related_info_tests;
 #[path = "tests/ts18031_intersection_conflicting_property_tests.rs"]
 mod ts18031_intersection_conflicting_property_tests;
+#[path = "tests/ts18032_intersection_private_brand_conflict_tests.rs"]
+mod ts18032_intersection_private_brand_conflict_tests;
 #[path = "tests/ts18050_nullish_keyword_without_strict_null_checks_tests.rs"]
 mod ts18050_nullish_keyword_without_strict_null_checks_tests;
 #[path = "tests/ts2322_private_field_narrowing_write_tests.rs"]

--- a/crates/tsz-checker/src/tests/ts18032_intersection_private_brand_conflict_tests.rs
+++ b/crates/tsz-checker/src/tests/ts18032_intersection_private_brand_conflict_tests.rs
@@ -1,0 +1,225 @@
+//! Regression tests for the `TS18032` related-info line `tsc` attaches to a
+//! `TS2339` property access on an intersection reduced to `never` because of
+//! a private-brand conflict — the sibling of `TS18031`
+//! (`ts18031_intersection_conflicting_property_tests.rs`), which handles the
+//! *literal-discriminant* reduction reason instead.
+//!
+//! Structural rule (pinned against `typescript@7.0.2`): when a *directly
+//! written* object intersection (`declare const c: A & B`) has two or more
+//! members that each declare a property of the same name, and at least one
+//! of those declarations is modifier-`private`, `tsc`'s `getReducedType`
+//! collapses the intersection to `never` (the private member's nominal brand
+//! makes the property un-satisfiable across constituents, regardless of
+//! whether the *types* agree) and any property access on it reports
+//! `TS2339` with a `relatedInformation` entry: "The intersection '{0}' was
+//! reduced to 'never' because property '{1}' exists in multiple constituents
+//! and is private in some."
+//!
+//! Both modifier-`private` on both sides AND modifier-`private` on only one
+//! side (paired with a structurally-identical `public` member) trigger this
+//! — oracle-verified with an identical-type control, so the conflict is
+//! genuinely about the private brand, not a type mismatch a different
+//! diagnostic would already catch.
+//!
+//! Owned by the same `error_reporter/intersection_never_elaboration.rs`
+//! helper as TS18031 (`intersection_reduced_to_never_related_info`), which
+//! tries the literal-discriminant query first and falls back to
+//! `find_private_brand_conflict_property`
+//! (`tsz-solver/src/type_queries/data/intersection_conflict.rs`).
+//!
+//! Deliberately narrow scope, matching TS18031's own precedent: only a
+//! directly-written intersection annotation (no alias/generic-application/
+//! heritage indirection). Cases that don't reduce to `never` at all
+//! (protected-only conflicts report `TS2445` instead; ES `#`-private
+//! members don't merge into a brand conflict at all; the same class
+//! intersected with itself is not a conflict) are documented as negative
+//! controls below — they never reach this helper's `type_id == NEVER` gate,
+//! so they're regression coverage for the surrounding machinery, not for the
+//! new query itself.
+
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::check_source_strict;
+use tsz_common::diagnostics::diagnostic_codes;
+
+const TS2339: u32 = diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE;
+const TS18032: u32 =
+    diagnostic_codes::THE_INTERSECTION_WAS_REDUCED_TO_NEVER_BECAUSE_PROPERTY_EXISTS_IN_MULTIPLE_CONSTI;
+
+fn only(diags: &[Diagnostic], code: u32) -> Diagnostic {
+    let matching: Vec<_> = diags.iter().filter(|d| d.code == code).collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected exactly one TS{code}; got {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+    matching[0].clone()
+}
+
+fn related(diagnostic: &Diagnostic, code: u32) -> Option<String> {
+    diagnostic
+        .related_information
+        .iter()
+        .find(|info| info.code == code)
+        .map(|info| info.message_text.clone())
+}
+
+// ---------------------------------------------------------------------------
+// Positive cases: a directly-written intersection with a private-brand
+// conflict carries the TS18032 elaboration.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn both_sides_private_carry_ts18032_elaboration() {
+    let diags = check_source_strict(
+        r#"
+class P1 { private x: string = ""; }
+class P2 { private x: string = ""; }
+declare const c: P1 & P2;
+c.x;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18032).as_deref(),
+        Some(
+            "The intersection 'P1 & P2' was reduced to 'never' because property 'x' exists in multiple constituents and is private in some."
+        ),
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn one_side_private_one_side_public_still_conflicts() {
+    // Identical property type on both sides — the conflict is the private
+    // brand, not a structural type mismatch a different check would catch.
+    let diags = check_source_strict(
+        r#"
+class P1 { private x: string = ""; }
+class P2 { x: string = ""; }
+declare const c: P1 & P2;
+c.x;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18032).as_deref(),
+        Some(
+            "The intersection 'P1 & P2' was reduced to 'never' because property 'x' exists in multiple constituents and is private in some."
+        ),
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn renamed_binders_carry_ts18032_elaboration() {
+    // Same rule, different identifiers — structural, not name-keyed.
+    let diags = check_source_strict(
+        r#"
+class Alpha { private val: number = 0; }
+class Beta { private val: number = 0; }
+declare const combined: Alpha & Beta;
+combined.val;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18032).as_deref(),
+        Some(
+            "The intersection 'Alpha & Beta' was reduced to 'never' because property 'val' exists in multiple constituents and is private in some."
+        ),
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn accessing_a_different_property_still_carries_ts18032() {
+    let diags = check_source_strict(
+        r#"
+class WithSecret { private secret: string = ""; }
+class AlsoSecret { private secret: string = ""; }
+declare const anything: WithSecret & AlsoSecret;
+anything.other;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18032).as_deref(),
+        Some(
+            "The intersection 'WithSecret & AlsoSecret' was reduced to 'never' because property 'secret' exists in multiple constituents and is private in some."
+        ),
+        "got {diags:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative / control cases: no TS18032 elaboration.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn protected_only_conflict_does_not_reduce_to_never() {
+    // tsc reports TS2445 (protected access) against the un-reduced
+    // intersection type here, not TS2339 against `never` — this shape never
+    // reaches the never-elaboration helper at all.
+    let diags = check_source_strict(
+        r#"
+class P1 { protected x: string = ""; }
+class P2 { protected x: string = ""; }
+declare const c: P1 & P2;
+c.x;
+"#,
+    );
+    assert!(
+        diags.iter().all(|d| d.code != TS2339),
+        "protected-only conflicts must not reduce to never, got {diags:?}"
+    );
+}
+
+#[test]
+fn same_class_intersected_with_itself_has_no_conflict() {
+    let diags = check_source_strict(
+        r#"
+class P1 { private x: string = ""; }
+declare const c: P1 & P1;
+c.x;
+"#,
+    );
+    assert!(
+        diags.iter().all(|d| d.code != TS2339),
+        "a class intersected with itself must not reduce to never, got {diags:?}"
+    );
+}
+
+#[test]
+fn compatible_public_members_report_nothing() {
+    let diags = check_source_strict(
+        r#"
+class Pub1 { x: string = ""; }
+class Pub2 { x: string = ""; }
+declare const c: Pub1 & Pub2;
+c.x;
+"#,
+    );
+    assert!(diags.is_empty(), "got {diags:?}");
+}
+
+#[test]
+fn indirect_alias_intersection_has_no_ts18032() {
+    // Same scope limit as TS18031: the narrow syntactic walk declines once
+    // the receiver's own declared type is an alias rather than a
+    // directly-written intersection.
+    let diags = check_source_strict(
+        r#"
+class P1 { private x: string = ""; }
+class P2 { private x: string = ""; }
+type Combined = P1 & P2;
+declare const value: Combined;
+value.x;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert!(related(&diag, TS18032).is_none(), "got {diags:?}");
+}

--- a/crates/tsz-solver/src/type_queries/data/intersection_conflict.rs
+++ b/crates/tsz-solver/src/type_queries/data/intersection_conflict.rs
@@ -74,3 +74,54 @@ pub fn find_disjoint_literal_property_across_intersection(
         .find(|(_, values)| values.len() >= 2)
         .map(|(name, _)| name)
 }
+
+/// The property name responsible for `tsc`'s `TS18032` elaboration (`The
+/// intersection '{0}' was reduced to 'never' because property '{1}' exists
+/// in multiple constituents and is private in some.`): a name declared by
+/// two or more `members`, where at least one declaration is modifier-`private`.
+///
+/// Oracle-verified (`typescript@7.0.2`) that this fires even when only ONE
+/// side is `private` and the other is `public` with an identical type — the
+/// conflict is about the private member's nominal brand, not about the
+/// property's structural type, so no type-compatibility check is needed
+/// here (unlike [`find_disjoint_literal_property_across_intersection`]'s
+/// literal-value comparison). Mirrors that function's scope discipline:
+/// under-covering (returning `None`) just leaves the diagnostic as it is
+/// today, so a name this helper doesn't recognize is safe, never wrong.
+pub fn find_private_brand_conflict_property(
+    db: &dyn TypeDatabase,
+    members: &[TypeId],
+) -> Option<Atom> {
+    let mut occurrences: FxHashMap<Atom, (u32, bool)> = FxHashMap::default();
+    let mut ingest = |properties: &[crate::types::PropertyInfo]| {
+        for prop in properties {
+            let name = db.resolve_atom(prop.name);
+            if name.starts_with("__private_brand_") {
+                continue;
+            }
+            let entry = occurrences.entry(prop.name).or_insert((0, false));
+            entry.0 += 1;
+            if prop.visibility == crate::types::Visibility::Private {
+                entry.1 = true;
+            }
+        }
+    };
+    for &member in members {
+        if member.is_intrinsic() {
+            continue;
+        }
+        match db.lookup(member) {
+            Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => {
+                ingest(&db.object_shape(shape_id).properties);
+            }
+            Some(TypeData::Callable(callable_id)) => {
+                ingest(&db.callable_shape(callable_id).properties);
+            }
+            _ => {}
+        }
+    }
+    occurrences
+        .into_iter()
+        .find(|(_, (count, saw_private))| *count >= 2 && *saw_private)
+        .map(|(name, _)| name)
+}


### PR DESCRIPTION
tsc's `TS2339` for a property access on an intersection reduced to `never` carries a `relatedInformation` entry naming the conflicting property. `TS18031` (literal-discriminant conflicts, e.g. `{ x: 1 } & { x: 2 }`) already landed in #16781; this is the private-brand sibling: `class P1 { private x: T }` intersected with another member that also declares `x` (private or not) reduces to `never`, and tsc names the property: `The intersection '{0}' was reduced to 'never' because property '{1}' exists in multiple constituents and is private in some.` (TS18032).

## Structural rule

`intersection_has_conflicting_private_brands` (`crates/tsz-solver/src/intern/normalize.rs`) already decides at intern time whether such an intersection collapses to `never`, using synthetic `__private_brand_*` markers. That decision discards *which* real property name caused it, so the elaboration recovers the pre-reduction member list the same way TS18031 does (`declared_intersection_member_types_for_expression`) and runs a new solver query, `find_private_brand_conflict_property` (`crates/tsz-solver/src/type_queries/data/intersection_conflict.rs`), which finds a property name declared on 2+ members where at least one declaration is modifier-`private`.

Oracle-verified (`typescript@7.0.2`) that a single private declaration paired with a structurally-identical public one on the same name still conflicts — the reduction is about the private brand's nominal identity, not a type mismatch a different check would already catch. Also verified the shapes that must NOT fire: protected-only conflicts report `TS2445` against the un-reduced intersection (never reaches `never` at all), ES `#`-private members don't merge into this brand mechanism, and a class intersected with itself is not a conflict (matching brand sets) — none of these reach the elaboration's `type_id == TypeId::NEVER` gate, so no extra guard was needed in the new query itself.

`intersection_reduced_to_never_related_info` now tries the TS18031 literal check first, then falls back to the TS18032 private-brand check, selecting the matching diagnostic code/message template dynamically. Same narrow scope as TS18031: only a directly-written intersection annotation (no alias/generic-application/heritage indirection) — every early return leaves the diagnostic exactly as it is today, never a wrong message.

## Adjacent matrix

All oracle-verified against `typescript@7.0.2`, all in the new test file:
- Both sides `private` (different declaring classes).
- One side `private`, one side `public`, identical type — still conflicts.
- Renamed binders.
- Conflicting property named independent of which property was accessed.
- Negative: protected-only conflict (`TS2445`, never reaches `never`).
- Negative: same class intersected with itself (no conflict).
- Negative: compatible public members (clean).
- Negative: alias indirection (`type Combined = P1 & P2`) — scope limit matching TS18031's own.

## Goal
Goal: hold

## Verification
- New `ts18032_intersection_private_brand_conflict_tests` (8 cases) — green.
- `cargo test -p tsz-checker --lib -- ts18031 ts2339 intersection`: 362/362.
- `cargo clippy -p tsz-solver -p tsz-checker --all-targets`: clean.
- `cargo fmt --check -p tsz-solver -p tsz-checker`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.
- End-to-end via debug CLI against the pinned `typescript@7.0.2` oracle: byte-identical output on the private/private and private/public cases.
- TypeScript corpus not checked out in this environment; conformance/emit/fourslash owed to CI — related-info-only addition, no diagnostic code or count change expected (same signature as TS18031's own #16781).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTLt42yTYjb6Wwy8bamEKG)_