### PR TITLE
fix(solver): TS18031 names the first-written conflicting property, not a hashmap pick (#16790)

### DIFF
--- a/crates/tsz-checker/src/tests/ts18031_intersection_conflicting_property_tests.rs
+++ b/crates/tsz-checker/src/tests/ts18031_intersection_conflicting_property_tests.rs
@@ -171,6 +171,81 @@ anything.whatever;
     );
 }
 
+#[test]
+fn multi_conflict_names_the_first_written_property() {
+    // Both `zz` and `aa` are disjoint across the members, so more than one
+    // property drives the reduction. `tsc` names the *first-written* one
+    // (`zz`, declared before `aa` in both members) — never whichever name a
+    // hashmap over the conflicting set happens to yield first.
+    let diags = check_source_strict(
+        r#"
+interface P { zz: 1; aa: "a" }
+interface Q { zz: 2; aa: "b" }
+declare const r: P & Q;
+r.zz;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18031).as_deref(),
+        Some(
+            "The intersection 'P & Q' was reduced to 'never' because property 'zz' has conflicting types in some constituents."
+        ),
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn multi_conflict_first_written_is_independent_of_accessed_property() {
+    // Same two-conflict shape, but the access is the *second*-written
+    // conflicting property. The elaboration still names the first-written
+    // discriminant (`zz`), combining the first-written rule with the
+    // accessed-property-independence rule.
+    let diags = check_source_strict(
+        r#"
+interface P { zz: 1; aa: "a" }
+interface Q { zz: 2; aa: "b" }
+declare const r: P & Q;
+r.aa;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18031).as_deref(),
+        Some(
+            "The intersection 'P & Q' was reduced to 'never' because property 'zz' has conflicting types in some constituents."
+        ),
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn multi_conflict_pick_is_declaration_order_not_atom_order() {
+    // The pick must follow source declaration order, not interned-atom order.
+    // `bb` is interned first (as a value binding) so it carries a lower atom id
+    // than `yy`, yet `yy` is written first in both members. A pick keyed on atom
+    // id would answer `bb`; tsc's first-written rule answers `yy`. (Even if the
+    // atom ids do not diverge in a given build, the asserted answer stays the
+    // tsc-correct one.)
+    let diags = check_source_strict(
+        r#"
+declare const bb: number;
+interface First { yy: 1; bb: "a" }
+interface Second { yy: 2; bb: "b" }
+declare const value: First & Second;
+value.yy;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18031).as_deref(),
+        Some(
+            "The intersection 'First & Second' was reduced to 'never' because property 'yy' has conflicting types in some constituents."
+        ),
+        "got {diags:?}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Negative / control cases: no TS18031 elaboration.
 // ---------------------------------------------------------------------------

--- a/crates/tsz-solver/src/type_queries/data/intersection_conflict.rs
+++ b/crates/tsz-solver/src/type_queries/data/intersection_conflict.rs
@@ -38,11 +38,24 @@ pub fn find_disjoint_literal_property_across_intersection(
     // regardless of whether it is observed before or after a literal
     // occurrence of the same name.
     let mut excluded: FxHashSet<Atom> = FxHashSet::default();
-    let mut ingest = |properties: &[crate::types::PropertyInfo]| {
+    // Where each name was *first written*, so a multi-conflict shape names the
+    // property `tsc` names. `tsc` always reports the first-written conflicting
+    // property (intersection-member order, then source declaration order within
+    // a member), independent of which property was accessed — never whichever
+    // name a hashmap happens to iterate first. `PropertyInfo::declaration_order`
+    // still carries source order here even though the interned shape's
+    // `properties` are sorted by atom id for canonical hashing, so the ordering
+    // key survives the shape sort. Members are walked in written order, and a
+    // name's position is recorded at its first occurrence only.
+    let mut first_written: FxHashMap<Atom, (usize, u32)> = FxHashMap::default();
+    let mut ingest = |member_idx: usize, properties: &[crate::types::PropertyInfo]| {
         for prop in properties {
             if prop.optional || excluded.contains(&prop.name) {
                 continue;
             }
+            first_written
+                .entry(prop.name)
+                .or_insert((member_idx, prop.declaration_order));
             let Some(TypeData::Literal(value)) = db.lookup(prop.type_id) else {
                 // A non-literal (or absent) required occurrence could still
                 // conflict via the fuller `TypeInterner`-internal analysis,
@@ -55,22 +68,28 @@ pub fn find_disjoint_literal_property_across_intersection(
             by_name.entry(prop.name).or_default().insert(value);
         }
     };
-    for &member in members {
+    for (member_idx, &member) in members.iter().enumerate() {
         if member.is_intrinsic() {
             continue;
         }
         match db.lookup(member) {
             Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => {
-                ingest(&db.object_shape(shape_id).properties);
+                ingest(member_idx, &db.object_shape(shape_id).properties);
             }
             Some(TypeData::Callable(callable_id)) => {
-                ingest(&db.callable_shape(callable_id).properties);
+                ingest(member_idx, &db.callable_shape(callable_id).properties);
             }
             _ => {}
         }
     }
     by_name
         .into_iter()
-        .find(|(_, values)| values.len() >= 2)
+        .filter(|(_, values)| values.len() >= 2)
         .map(|(name, _)| name)
+        .min_by_key(|name| {
+            first_written
+                .get(name)
+                .copied()
+                .unwrap_or((usize::MAX, u32::MAX))
+        })
 }


### PR DESCRIPTION
When an object intersection reduces to `never` because **more than one** property has disjoint literal types across its members, tsc names the *first-written* conflicting property in the TS18031 elaboration, independent of which property was accessed. tsz collected the conflicting names into an `FxHashMap` and returned `.into_iter().find()`'s first hit — hashmap-iteration order — so it matched tsc only by coincidence.

Structural rule: when a directly-written object intersection reduces to `never` via ≥2 disjoint-literal properties, `tsc` names the first-written one (intersection-member order, then source declaration order within a member); tsz must do the same through the solver's `find_disjoint_literal_property_across_intersection`.

```ts
interface P { zz: 1; aa: 'a' }
interface Q { zz: 2; aa: 'b' }
declare const r: P & Q;
r.zz;
```
- tsc: `… property 'zz' has conflicting types …`
- tsz before: `… property 'aa' …`  → after: `… property 'zz' …`

Owner layer: `crates/tsz-solver/src/type_queries/data/intersection_conflict.rs`. It now records each name's first-written position — member index, then `PropertyInfo::declaration_order`, which still carries **source** order even though the interned shape's `properties` are atom-sorted for canonical hashing — and returns the conflicting name with the smallest position. This is a lighter, correct alternative to threading reduction-time metadata: source order is already recoverable from the shape's per-property `declaration_order`.

Adjacent matrix (all verified on the release CLI):
- `r.zz` and `r.aa` both name `zz` — first-written, independent of the accessed property.
- Declaration order, not atom order: with `bb` interned before the interfaces (as a value binding) but `yy` written first, the elaboration names `yy` — an atom-ordered pick would answer `bb`.
- Single-conflict shapes (`{ tag: 1 } & { tag: 2 }`) are unchanged: one candidate, same result.
- The elaboration fires on exactly the same shapes; only the chosen name changes, so **no diagnostic code set moves**.

Out of scope: the TS18032 private-brand sibling names `{1}` too, but its elaboration is unimplemented in the checker (only the boolean reduction exists), so there is no name-pick to correct there yet.

## Goal
Goal: hold

## Verification
- Release CLI on the issue repro and the declaration-order/`r.aa`/single-conflict variants — all name the tsc-correct property (shown above).
- Added `crates/tsz-checker/src/tests/ts18031_intersection_conflicting_property_tests.rs` cases: `multi_conflict_names_the_first_written_property`, `multi_conflict_first_written_is_independent_of_accessed_property`, `multi_conflict_pick_is_declaration_order_not_atom_order`. Existing single-conflict cases keep their assertions. (Ran via the CLI code path; the in-crate lib test target does not compile under `--release` on `main` due to a pre-existing `ScopedPerfCounters` `debug_assertions` gate, unrelated to this change — CI runs the checker unit tier in the correct profile.)
- Conformance snapshot on this branch: 11525 passed / 518 failed, no mass regression. The change only rewrites the TS18031 related-information text, so the code-set failure set is identical to `main` by construction (a code-set probe cannot observe this row).
- `cargo clippy --release -p tsz-solver -p tsz-checker` — clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01HEdC8JooXwCWd7JMks6rEp)_