### PR TITLE
fix(solver): TS18032 elaboration excludes ES #-private names

### DIFF
--- a/crates/tsz-checker/src/tests/ts18032_intersection_private_brand_conflict_tests.rs
+++ b/crates/tsz-checker/src/tests/ts18032_intersection_private_brand_conflict_tests.rs
@@ -30,12 +30,22 @@
 //! Deliberately narrow scope, matching TS18031's own precedent: only a
 //! directly-written intersection annotation (no alias/generic-application/
 //! heritage indirection). Cases that don't reduce to `never` at all
-//! (protected-only conflicts report `TS2445` instead; ES `#`-private
-//! members don't merge into a brand conflict at all; the same class
+//! (protected-only conflicts report `TS2445` instead; the same class
 //! intersected with itself is not a conflict) are documented as negative
 //! controls below — they never reach this helper's `type_id == NEVER` gate,
 //! so they're regression coverage for the surrounding machinery, not for the
 //! new query itself.
+//!
+//! ES `#`-private members are a separate case: `#x` on two different classes
+//! is never the same name to `tsc` (each is lexically scoped to its own
+//! class body), so real `tsc` neither reduces the intersection to `never`
+//! nor elaborates. tsz's `intersection_has_conflicting_private_brands`
+//! (`crates/tsz-solver/src/intern/normalize.rs`) currently *does* still
+//! reduce that shape to `never` — a separate, pre-existing bug in the
+//! reduction itself, not owned by this elaboration. `find_private_brand_conflict_property`
+//! is deliberately scoped to never attach the TS18032 line to whatever
+//! `TS2339` that reduction bug produces, so fixing the reduction later needs
+//! no matching change here.
 
 use crate::diagnostics::Diagnostic;
 use crate::test_utils::check_source_strict;
@@ -176,6 +186,32 @@ c.x;
         diags.iter().all(|d| d.code != TS2339),
         "protected-only conflicts must not reduce to never, got {diags:?}"
     );
+}
+
+#[test]
+fn es_private_same_spelled_fields_do_not_carry_ts18032() {
+    // ES `#`-private fields are lexically scoped to their declaring class —
+    // `#x` on `A` and `#x` on `B` are never the same name to tsc even though
+    // they share identical source text, so this is not a naming collision
+    // tsc elaborates (tsc: `Property 'foo' does not exist on type 'A & B'.`,
+    // no relatedInformation, no `never` reduction at all).
+    //
+    // tsz still (incorrectly, as of this test) reduces `A & B` to `never`
+    // here — a pre-existing, separate bug in the reduction itself, not this
+    // elaboration. This test pins only the elaboration's own scope: whatever
+    // TS2339 that reduction bug produces must never carry the TS18032
+    // related-info line, which would misattribute the wrong reason to it.
+    let diags = check_source_strict(
+        r#"
+class A { #x = 1; }
+class B { #x = 1; }
+declare const v: A & B;
+v.foo;
+"#,
+    );
+    for diag in diags.iter().filter(|d| d.code == TS2339) {
+        assert!(related(diag, TS18032).is_none(), "got {diags:?}");
+    }
 }
 
 #[test]

--- a/crates/tsz-solver/src/type_queries/data/intersection_conflict.rs
+++ b/crates/tsz-solver/src/type_queries/data/intersection_conflict.rs
@@ -109,6 +109,17 @@ pub fn find_disjoint_literal_property_across_intersection(
 /// literal-value comparison). Mirrors that function's scope discipline:
 /// under-covering (returning `None`) just leaves the diagnostic as it is
 /// today, so a name this helper doesn't recognize is safe, never wrong.
+///
+/// Deliberately excludes ES `#`-private names
+/// ([`crate::utils::is_es_private_identifier_name`]): unlike modifier-
+/// `private`, two classes' `#x` fields are lexically scoped to their own
+/// class body and are never the same name to `tsc` even when they share
+/// identical source text, so `#x` on `A` and `#x` on `B` is not a naming
+/// collision at all — tsc reports no elaboration (and, correctly, no
+/// `never` reduction) for that shape. Matching on the interned `Atom`'s
+/// text alone (as the modifier-`private` case does) would wrongly treat
+/// same-spelled `#`-private fields from different classes as one
+/// conflicting name.
 pub fn find_private_brand_conflict_property(
     db: &dyn TypeDatabase,
     members: &[TypeId],
@@ -117,7 +128,9 @@ pub fn find_private_brand_conflict_property(
     let mut ingest = |properties: &[crate::types::PropertyInfo]| {
         for prop in properties {
             let name = db.resolve_atom(prop.name);
-            if name.starts_with("__private_brand_") {
+            if name.starts_with("__private_brand_")
+                || crate::utils::is_es_private_identifier_name(&name)
+            {
                 continue;
             }
             let entry = occurrences.entry(prop.name).or_insert((0, false));


### PR DESCRIPTION
Follow-up to #16796 (merged before its own review comment landed), addressing that comment directly: `find_private_brand_conflict_property` matched on the interned `Atom`'s text alone, which wrongly treats two classes' same-spelled ES `#`-private fields as one conflicting name.

## Structural rule

ES `#x` fields are lexically scoped to their declaring class — `#x` on class `A` and `#x` on class `B` are never the same name to `tsc`, even though they share identical source text. Real `tsc` (`typescript@7.0.2`) neither reduces `A & B` to `never` nor elaborates for that shape; it stays a plain `Property does not exist on type 'A & B'.`. Modifier-`private` members genuinely share one name, so they do collide (tsc's own TS18032 wording, "exists in multiple constituents and is private in some", only applies there).

tsz's `intersection_has_conflicting_private_brands` (`crates/tsz-solver/src/intern/normalize.rs`) already reduces the ES `#`-private shape to `never` on `main` today — a separate, pre-existing false-positive in the reduction itself, not owned by this elaboration (filed independently by the reviewer as #16797). This fix only stops attaching an authoritative-sounding TS18032 line to whatever `TS2339` that reduction bug produces; it does not touch the reduction. `is_es_private_identifier_name` (`tsz-solver/src/utils/mod.rs`, already used by `private_checker.rs` for the same ES-private-vs-modifier-private split) is reused here rather than re-deriving the `#`-prefix check.

**This PR does not fix the `#private` intersection reduction bug — see #16797 for that.** It only stops a wrong explanation from being attached to whatever diagnostic #16797 currently produces.

## Adjacent matrix

Oracle-verified against `typescript@7.0.2`, all in the existing test file:
- ES `#`-private same-spelled fields: no TS18032 elaboration (new negative test, the review comment's exact repro).
- Renamed ES-private binder (`#q`): no elaboration.
- Modifier-`private` (both existing positive cases): unchanged, still correct.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib -- ts18032 ts18031 ts2339 intersection`: 367/367.
- `cargo clippy -p tsz-solver -p tsz-checker --all-targets`: clean.
- `cargo fmt --check -p tsz-solver -p tsz-checker`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.
- End-to-end via debug CLI against the pinned `typescript@7.0.2` oracle: the review comment's exact repro (`class A { #x = 1 }` / `B`, `(A & B).foo`) and a renamed-binder variant (`#q`) both now report the bare `TS2339` with no elaboration, matching tsc. Modifier-private control (`class C { private p = 1 }` / `D`) still carries the TS18032 line, byte-identical to tsc.
- Independently re-verified by reviewer: `-p tsz-checker --lib` 10650/10650, `-p tsz-solver --lib` 7654/7654, conformance set-difference 0 fixed / 0 broken.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTLt42yTYjb6Wwy8bamEKG)_