### PR TITLE
fix(checker): TS2369 anchors at first parameter-property modifier in source order

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2736,3 +2736,6 @@ path = "tests/ts2433_cross_file_ambient_class_merge_tests.rs"
 [[test]]
 name = "ts2345_primitive_key_union_constraint_display_tests"
 path = "tests/ts2345_primitive_key_union_constraint_display_tests.rs"
+[[test]]
+name = "ts2369_source_order_anchor_tests"
+path = "tests/ts2369_source_order_anchor_tests.rs"

--- a/crates/tsz-checker/src/checkers/parameter_checker.rs
+++ b/crates/tsz-checker/src/checkers/parameter_checker.rs
@@ -1093,20 +1093,25 @@ impl<'a> CheckerState<'a> {
             })
     }
 
-    /// Find the first parameter property modifier in a modifier list.
-    /// Returns the `NodeIndex` of the first public/private/protected/readonly/override keyword.
+    /// First public/private/protected/readonly/override modifier **in source
+    /// order** (tsc's `checkGrammarModifiers` walks left to right and anchors
+    /// TS2369 there, not at a fixed kind priority).
     pub(crate) fn find_first_parameter_property_modifier(
         &self,
         modifiers: &Option<tsz_parser::parser::NodeList>,
     ) -> Option<NodeIndex> {
         use tsz_scanner::SyntaxKind;
         let arena = self.ctx.arena;
-        arena
-            .find_modifier(modifiers, SyntaxKind::PublicKeyword)
-            .or_else(|| arena.find_modifier(modifiers, SyntaxKind::PrivateKeyword))
-            .or_else(|| arena.find_modifier(modifiers, SyntaxKind::ProtectedKeyword))
-            .or_else(|| arena.find_modifier(modifiers, SyntaxKind::ReadonlyKeyword))
-            .or_else(|| arena.find_modifier(modifiers, SyntaxKind::OverrideKeyword))
+        let mods = modifiers.as_ref()?;
+        mods.nodes.iter().copied().find(|&mod_idx| {
+            arena.get(mod_idx).is_some_and(|node| {
+                node.kind == SyntaxKind::PublicKeyword as u16
+                    || node.kind == SyntaxKind::PrivateKeyword as u16
+                    || node.kind == SyntaxKind::ProtectedKeyword as u16
+                    || node.kind == SyntaxKind::ReadonlyKeyword as u16
+                    || node.kind == SyntaxKind::OverrideKeyword as u16
+            })
+        })
     }
 
     // =========================================================================

--- a/crates/tsz-checker/tests/ts2369_source_order_anchor_tests.rs
+++ b/crates/tsz-checker/tests/ts2369_source_order_anchor_tests.rs
@@ -1,0 +1,106 @@
+//! TS2369 ("A parameter property is only allowed in a constructor
+//! implementation") anchors at whichever parameter-property modifier
+//! (`public`/`private`/`protected`/`readonly`/`override`) appears **first in
+//! source order**, not at a fixed kind priority.
+//!
+//! Structural rule: tsc's `checkGrammarModifiers` walks a parameter's
+//! modifier list left to right and reports at the first modifier it visits.
+//! `find_first_parameter_property_modifier`
+//! (`crates/tsz-checker/src/checkers/parameter_checker.rs`) previously chose
+//! by a fixed `public > private > protected > readonly > override` priority
+//! via chained `.or_else()` lookups, so `readonly private x` anchored at
+//! `private` (matching the priority order) instead of `readonly` (the modifier
+//! that actually comes first in the source). Oracle-verified against
+//! `typescript@7.0.2`.
+
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn starts_for(source: &str, code: u32) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .iter()
+        .filter(|d| d.code == code)
+        .map(|d| d.start)
+        .collect()
+}
+
+fn offset_of(source: &str, needle: &str) -> u32 {
+    u32::try_from(source.find(needle).expect("needle present")).expect("fits u32")
+}
+
+/// The modifier that comes first in source order wins, even when a
+/// higher-priority-by-kind modifier (`private`) follows it.
+#[test]
+fn readonly_before_private_anchors_at_readonly() {
+    let source = "function f(readonly private x: number) {}\n";
+    assert_eq!(
+        starts_for(source, 2369),
+        vec![offset_of(source, "readonly")],
+        "TS2369 must anchor at `readonly`, the first modifier in source order"
+    );
+}
+
+/// The mirror ordering: when `private` genuinely comes first, it is still
+/// the anchor — this is not a "readonly always wins" special case.
+#[test]
+fn private_before_readonly_anchors_at_private() {
+    let source = "function f(private readonly x: number) {}\n";
+    assert_eq!(
+        starts_for(source, 2369),
+        vec![offset_of(source, "private")],
+        "TS2369 must anchor at `private`, the first modifier in source order"
+    );
+}
+
+/// `override` sorts last in the old fixed-priority chain; confirm it wins
+/// the anchor when it is written first.
+#[test]
+fn override_before_protected_anchors_at_override() {
+    let source = "function f(override protected x: number) {}\n";
+    assert_eq!(
+        starts_for(source, 2369),
+        vec![offset_of(source, "override")],
+        "TS2369 must anchor at `override`, the first modifier in source order"
+    );
+}
+
+#[test]
+fn protected_before_override_anchors_at_protected() {
+    let source = "function f(protected override x: number) {}\n";
+    assert_eq!(
+        starts_for(source, 2369),
+        vec![offset_of(source, "protected")],
+        "TS2369 must anchor at `protected`, the first modifier in source order"
+    );
+}
+
+/// Renamed binder and a non-function-declaration host (object-literal
+/// method) — the rule is structural, not keyed to `function f` or a
+/// particular container.
+#[test]
+fn object_method_readonly_before_public_anchors_at_readonly() {
+    let source = "const obj = {\n    m(readonly public someValue: number) {}\n};\n";
+    assert_eq!(
+        starts_for(source, 2369),
+        vec![offset_of(source, "readonly")],
+        "TS2369 on an object-literal method must anchor at `readonly`"
+    );
+}
+
+/// Single-modifier case is unaffected by the ordering fix — a regression
+/// guard for the common shape.
+#[test]
+fn single_modifier_still_anchors_at_itself() {
+    let source = "function f(public x: number) {}\n";
+    assert_eq!(starts_for(source, 2369), vec![offset_of(source, "public")],);
+}
+
+/// Inside an actual constructor implementation, parameter properties are
+/// legal and TS2369 must not fire at all, regardless of modifier order.
+#[test]
+fn constructor_implementation_with_reordered_modifiers_is_clean() {
+    let source = "class C {\n    constructor(readonly private x: number) {}\n}\n";
+    assert!(
+        starts_for(source, 2369).is_empty(),
+        "TS2369 must not fire inside a constructor implementation"
+    );
+}


### PR DESCRIPTION
tsc's `checkGrammarModifiers` walks a parameter's modifier list left to right and reports TS2369 ("A parameter property is only allowed in a constructor implementation.") at the first grammar-relevant modifier it meets, in source order. `find_first_parameter_property_modifier` (`crates/tsz-checker/src/checkers/parameter_checker.rs`) instead chose by a fixed kind priority (public, then private, then protected, then readonly, then override) via chained `.or_else()` lookups — so `readonly private x` anchored at `private` (the higher-priority kind) instead of `readonly` (the modifier that actually comes first in the source).

Named as an out-of-scope follow-up in #16782 (just-merged parameter-modifier grammar fix, closed #16778): "TS2369's anchor position (tsc anchors at the first modifier, tsz at the offending one) — a checker concern; grammar codes now match, positions of the semantic TS2369 are a separate follow-up." This PR is that follow-up.

## Structural rule

When a parameter carries more than one parameter-property modifier (public/private/protected/readonly/override), tsc's TS2369 diagnostic anchors at whichever modifier token appears first in the source, not at a fixed modifier-kind priority. Owner is the checker's `find_first_parameter_property_modifier`, which now does a single left-to-right scan of the modifier list and returns the first node whose kind is in the parameter-property-modifier set, instead of probing for each kind in a fixed priority order.

## Oracle matrix (typescript@7.0.2)

| source | tsc anchor column | tsz before | tsz after |
| --- | --- | --- | --- |
| `function f(readonly private x: number) {}` | col 13 (`readonly`) | `private` | `readonly` |
| `function f(private readonly x: number) {}` | col 13 (`private`) | `private` | `private` |
| `function f(override protected x: number) {}` | col 13 (`override`) | `protected` | `override` |
| `function f(protected override x: number) {}` | col 13 (`protected`) | `protected` | `protected` |
| `const obj = { m(readonly public x: number) {} }` | first modifier | `public` | `readonly` |
| `function f(public x: number) {}` (single modifier, regression guard) | `public` | `public` | `public` |
| `class C { constructor(readonly private x: number) {} }` (inside a real constructor implementation) | no TS2369 | no TS2369 | no TS2369 |

Confirmed manually against a real `typescript@7.0.2` install (`node .../tsc.js --noEmit --strict --target es2022 --module esnext`) before writing the fix; the new test file pins the same matrix.

## Goal
Goal: hold

## Verification
- New `crates/tsz-checker/tests/ts2369_source_order_anchor_tests.rs` (7 cases, oracle-verified) — 7/7 passed.
- `cargo test -p tsz-checker --lib -- parameter_prop` (existing parameter-property regression coverage) — 18/18 passed.
- `cargo fmt -p tsz-checker -- --check` — clean.
- `cargo clippy -p tsz-checker --all-targets` — clean.
- `python3 scripts/arch/arch_guard.py` — passed (`parameter_checker.rs` at 1996/2000 lines).
- Pre-commit hook (fmt + clippy + arch guard + affected-crate verification) passed locally.
- Conformance/emit/fourslash not run locally this session (owed to the nightly/`workflow_dispatch` CI lane per the per-merge policy) — this is a diagnostic-anchor-position-only change on an already-correctly-coded family (TS2369's code selection is untouched), so no code-set or count change is expected.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnYUrcoRGznL4ySeBq4NGC)_