### PR TITLE
refactor(lint): self-policing dead_code suppressions, drop stale allowances (#16794)

### DIFF
--- a/crates/conformance/src/tsz_wrapper.rs
+++ b/crates/conformance/src/tsz_wrapper.rs
@@ -39,6 +39,8 @@ pub struct PreparedTest {
 ///
 /// `original_extension` is the file extension of the original test file (e.g. "tsx"),
 /// used when there are no `@Filename` directives so the single-file test preserves its extension.
+// Dead in the lib/bin build; the thin wrapper over `prepare_test_dir_with_lib_dir`
+// is exercised only by `tests/tsz_wrapper.rs`, so `allow` (not `expect`) is correct.
 #[allow(dead_code)]
 pub fn prepare_test_dir(
     content: &str,

--- a/crates/tsz-binder/src/lib_loader.rs
+++ b/crates/tsz-binder/src/lib_loader.rs
@@ -154,7 +154,7 @@ impl LibFile {
 /// and merges them into a single `LibFile` where all symbols are in one binder
 /// with remapped `SymbolIds` to avoid collisions.
 #[must_use]
-#[allow(dead_code)] // Reserved for future multi-lib merging support
+#[expect(dead_code)] // Reserved for future multi-lib merging support
 pub(crate) fn merge_lib_files(lib_files: Vec<Arc<LibFile>>) -> Vec<Arc<LibFile>> {
     use crate::state::LibContext as BinderLibContext;
 

--- a/crates/tsz-binder/src/nodes/names.rs
+++ b/crates/tsz-binder/src/nodes/names.rs
@@ -602,7 +602,7 @@ impl BinderState {
     }
 
     /// Check if modifiers list contains the 'static' keyword.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn has_static_modifier(arena: &NodeArena, modifiers: Option<&NodeList>) -> bool {
         arena.has_modifier_ref(modifiers, SyntaxKind::StaticKeyword)
     }

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -551,7 +551,7 @@ impl BinderState {
 
     /// Enter a new persistent scope (in addition to legacy scope chain).
     /// This method is called when binding begins for a scope-creating node.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn enter_persistent_scope(&mut self, kind: ContainerKind, node: NodeIndex) {
         self.enter_persistent_scope_with_capacity(kind, node, 0);
     }

--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -169,7 +169,7 @@ impl<'a> CheckerState<'a> {
 
     /// Alias for `should_skip_weak_union_error_with_outcome` — kept for
     /// architecture contract test compatibility.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn should_skip_weak_union_error_with_hint(
         &mut self,
         source: TypeId,

--- a/crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs
+++ b/crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs
@@ -49,7 +49,7 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Get the type of a JSX opening element (Rule #36: case-sensitive tag lookup).
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn get_type_of_jsx_opening_element(&mut self, idx: NodeIndex) -> TypeId {
         self.get_type_of_jsx_opening_element_with_children(idx, &TypingRequest::NONE, None)
     }

--- a/crates/tsz-checker/src/classes/class_chain_lookup.rs
+++ b/crates/tsz-checker/src/classes/class_chain_lookup.rs
@@ -23,7 +23,6 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Internal implementation of `find_member_in_class_chain` with recursion guard.
-    #[allow(dead_code)]
     fn find_member_in_class_chain_impl(
         &mut self,
         class_idx: NodeIndex,

--- a/crates/tsz-checker/src/classes/class_member_info.rs
+++ b/crates/tsz-checker/src/classes/class_member_info.rs
@@ -153,7 +153,6 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Collect base member names for override suggestions.
-    #[allow(dead_code)]
     fn collect_base_member_names_for_override(
         &mut self,
         class_idx: NodeIndex,

--- a/crates/tsz-checker/src/context/speculation.rs
+++ b/crates/tsz-checker/src/context/speculation.rs
@@ -506,7 +506,6 @@ impl<'a> CheckerContext<'a> {
     /// Used when a speculative path succeeds and its diagnostics should be
     /// kept. Only the dedup set needs reconciliation — diagnostics are already
     /// in the vector.
-    #[allow(dead_code)]
     pub(crate) fn commit_diagnostics(&mut self, snap: &DiagnosticSnapshot) {
         // Diagnostics already in the vector; just rebuild dedup for new entries.
         let start = snap.diagnostics_len.min(self.diagnostics.len());
@@ -722,13 +721,12 @@ impl SpeculationState<'_, '_> {
 /// // OR
 /// drop(snap);         // implicit commit — speculative diagnostics survive
 /// ```
-#[allow(dead_code)]
 pub(crate) struct DiagnosticSpeculationSnapshot {
     snapshot: DiagnosticSnapshot,
     committed: bool,
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 impl DiagnosticSpeculationSnapshot {
     pub(crate) fn new(ctx: &CheckerContext) -> Self {
         Self {
@@ -808,13 +806,11 @@ impl DiagnosticSpeculationSnapshot {
 /// Like `DiagnosticSpeculationSnapshot`, dropping is an implicit commit.
 /// Call `rollback()` explicitly when discarding diagnostics, implicit-any
 /// bookkeeping, and request cache state produced during a speculative probe.
-#[allow(dead_code)]
 pub(crate) struct FullSpeculationSnapshot {
     snapshot: FullSnapshot,
     committed: bool,
 }
 
-#[allow(dead_code)]
 impl FullSpeculationSnapshot {
     pub(crate) fn new(ctx: &CheckerContext) -> Self {
         Self {

--- a/crates/tsz-checker/src/jsdoc/lookup.rs
+++ b/crates/tsz-checker/src/jsdoc/lookup.rs
@@ -1554,7 +1554,7 @@ impl<'a> CheckerState<'a> {
     /// Check if two source positions are in different function scopes.
     /// Used for JSDoc typedef scoping — a typedef defined inside a function
     /// should not be visible outside that function.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn is_in_different_function_scope(&self, comment_pos: u32, anchor_pos: u32) -> bool {
         let Some(sf) = self.ctx.arena.source_files.first() else {
             return false;

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -13,15 +13,17 @@
 //! Note: The thin checker is the unified checker pipeline; `CheckerState`
 //! is an alias to the thin checker.
 
-// XL: crate-wide `dead_code` is suppressed because lifting it surfaces ~149
-// item-level warnings across ~70 files in this crate (counted via a lib build
-// pass for #13440). Each needs case-by-case judgment (delete vs. local allow
-// vs. intended API) and several candidates are only reachable through tests or
-// macros that a `--lib` pass cannot see, so a safe audit is its own campaign.
+// XL: crate-wide `dead_code` is suppressed because lifting it surfaces ~360
+// item-level warnings across the crate (counted via an `--all-targets` pass for
+// #13440/#16794). Each needs case-by-case judgment (delete vs. local expect vs.
+// intended API) and several candidates are only reachable through tests or
+// macros an item-level pass cannot see, so a safe audit is its own campaign.
 // Scoping per-module would reproduce the blanket across most of the tree. The
 // solver half of #13440 (false `InferenceError` "reserved" label + dead
 // `ConstraintSet` methods) is already resolved by #13534; this crate-wide allow
-// is the remaining XL item tracked by #13440.
+// is the remaining XL item tracked by #13440. The per-symbol `#[expect(dead_code)]`
+// annotations inside this crate still self-police: an item-level `expect` overrides
+// this blanket, so a stale one (its symbol became used) fails the build even here.
 #![allow(dead_code)]
 
 extern crate self as tsz_checker;

--- a/crates/tsz-checker/src/state/state.rs
+++ b/crates/tsz-checker/src/state/state.rs
@@ -1909,7 +1909,7 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Compute the type of a node (internal, not cached).
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     fn compute_type_of_node_complex(&mut self, idx: NodeIndex) -> TypeId {
         self.compute_type_of_node_complex_with_request(idx, &crate::context::TypingRequest::NONE)
     }

--- a/crates/tsz-checker/src/state/state_checking/class.rs
+++ b/crates/tsz-checker/src/state/state_checking/class.rs
@@ -1029,7 +1029,7 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn check_class_expression(
         &mut self,
         class_idx: NodeIndex,

--- a/crates/tsz-checker/src/state/state_checking/core.rs
+++ b/crates/tsz-checker/src/state/state_checking/core.rs
@@ -135,7 +135,6 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    #[allow(dead_code)]
     pub(crate) fn report_isolated_decl_computed_property_names(
         &mut self,
         decl_idx: NodeIndex,
@@ -264,7 +263,6 @@ impl<'a> CheckerState<'a> {
         reported
     }
 
-    #[allow(dead_code)]
     fn is_isolated_decl_simple_computed_name(&self, name_idx: NodeIndex) -> bool {
         use tsz_parser::parser::syntax_kind_ext;
         use tsz_scanner::SyntaxKind;
@@ -303,7 +301,6 @@ impl<'a> CheckerState<'a> {
         false
     }
 
-    #[allow(dead_code)]
     fn is_isolated_decl_const_computed_name_requiring_diagnostic(
         &self,
         name_idx: NodeIndex,
@@ -339,7 +336,6 @@ impl<'a> CheckerState<'a> {
         true
     }
 
-    #[allow(dead_code)]
     fn report_isolated_decl_computed_name_dependency(&mut self, name_idx: NodeIndex) {
         use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
         use tsz_binder::symbol_flags;

--- a/crates/tsz-checker/src/state/state_checking_members/ambient_constructor_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_constructor_checks.rs
@@ -9,7 +9,7 @@ use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
     /// Check a constructor declaration.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn check_constructor_declaration(&mut self, member_idx: NodeIndex) {
         self.check_constructor_declaration_with_request(member_idx, &TypingRequest::NONE);
     }

--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -11,7 +11,7 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn check_property_declaration(&mut self, member_idx: NodeIndex) {
         self.check_property_declaration_with_request(member_idx, &TypingRequest::NONE);
     }
@@ -624,7 +624,7 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Check a method declaration.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn check_method_declaration(&mut self, member_idx: NodeIndex) {
         self.check_method_declaration_with_request(member_idx, &TypingRequest::NONE);
     }
@@ -1342,7 +1342,7 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Check an accessor declaration (getter/setter).
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn check_accessor_declaration(&mut self, member_idx: NodeIndex) {
         self.check_accessor_declaration_with_request(member_idx, &TypingRequest::NONE);
     }

--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -270,7 +270,6 @@ impl CheckerState<'_> {
     /// type Nested = (string | number) | boolean;
     /// // Normalized to Union(STRING, NUMBER, BOOLEAN)
     /// ```
-    #[allow(dead_code)]
     /// Decide whether a `typeof <name>` query is positioned in the signature
     /// (type-annotation) region of a function and the name resolves only
     /// because of body-local hoisting. tsc treats such references as
@@ -387,7 +386,6 @@ impl CheckerState<'_> {
     /// Resolve a qualified name chain as a value property access chain
     /// for `typeof` context. Recurses through nested `QualifiedName` nodes
     /// so that `typeof a.b.c` resolves `a` as a value, then `.b`, then `.c`.
-    #[allow(dead_code)]
     pub(crate) fn resolve_typeof_qualified_value_chain(
         &mut self,
         idx: NodeIndex,
@@ -528,7 +526,6 @@ impl CheckerState<'_> {
         Some(self.resolve_type_query_type(property_type))
     }
 
-    #[allow(dead_code)]
     pub(super) fn resolve_type_query_import_type_symbol(&self, idx: NodeIndex) -> Option<u32> {
         let node = self.ctx.arena.get(idx)?;
         if node.kind != tsz_scanner::SyntaxKind::Identifier as u16 {

--- a/crates/tsz-checker/src/state/variable_checking/destructuring/tail.rs
+++ b/crates/tsz-checker/src/state/variable_checking/destructuring/tail.rs
@@ -174,7 +174,7 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(super) fn get_binding_element_computed_key_type(
         &mut self,
         pattern_idx: NodeIndex,
@@ -335,7 +335,7 @@ impl<'a> CheckerState<'a> {
         self.resolve_identifier_symbol(target_idx) == Some(sym_id)
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(super) fn get_binding_identifier_initializer_key_type(
         &mut self,
         sym_id: SymbolId,
@@ -469,7 +469,7 @@ impl<'a> CheckerState<'a> {
     /// Array patterns → tuple with `any`; object patterns → typed properties.
     /// Default initializers (e.g., `{ f = (x: string) => x.length }`) seed
     /// property types instead of `any` to enable contextual typing.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn build_contextual_type_from_pattern(
         &mut self,
         pattern_idx: NodeIndex,

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -27,7 +27,7 @@ impl<'a> CheckerState<'a> {
     ///
     /// Handles element access with optional chaining, index signatures,
     /// and nullish coalescing.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn get_type_of_element_access(&mut self, idx: NodeIndex) -> TypeId {
         self.get_type_of_element_access_with_request(idx, &TypingRequest::NONE)
     }

--- a/crates/tsz-checker/src/types/computation/access_await.rs
+++ b/crates/tsz-checker/src/types/computation/access_await.rs
@@ -26,7 +26,7 @@ impl<'a> CheckerState<'a> {
     ///     return obj;
     /// }
     /// ```
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn get_type_of_await_expression(&mut self, idx: NodeIndex) -> TypeId {
         self.get_type_of_await_expression_with_request(idx, &TypingRequest::NONE)
     }

--- a/crates/tsz-checker/src/types/computation/array_literal.rs
+++ b/crates/tsz-checker/src/types/computation/array_literal.rs
@@ -445,7 +445,7 @@ impl<'a> CheckerState<'a> {
     /// - Tuple contexts (e.g., `[string, number]`)
     /// - Spread elements (`[...arr]`)
     /// - Common type inference for mixed elements
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn get_type_of_array_literal(&mut self, idx: NodeIndex) -> TypeId {
         self.get_type_of_array_literal_with_request(idx, &crate::context::TypingRequest::NONE)
     }

--- a/crates/tsz-checker/src/types/computation/binary.rs
+++ b/crates/tsz-checker/src/types/computation/binary.rs
@@ -14,7 +14,7 @@ impl<'a> CheckerState<'a> {
     ///
     /// Handles all binary operators including arithmetic, comparison, logical,
     /// assignment, nullish coalescing, and comma operators.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn get_type_of_binary_expression(&mut self, idx: NodeIndex) -> TypeId {
         self.get_type_of_binary_expression_with_request(idx, &TypingRequest::NONE)
     }

--- a/crates/tsz-checker/src/types/computation/call/mod.rs
+++ b/crates/tsz-checker/src/types/computation/call/mod.rs
@@ -1394,7 +1394,7 @@ impl<'a> CheckerState<'a> {
     /// - Overload resolution
     /// - Argument type checking
     /// - Type argument validation (TS2344)
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn get_type_of_call_expression(&mut self, idx: NodeIndex) -> TypeId {
         self.get_type_of_call_expression_with_request(idx, &TypingRequest::NONE)
     }

--- a/crates/tsz-checker/src/types/computation/helpers.rs
+++ b/crates/tsz-checker/src/types/computation/helpers.rs
@@ -134,7 +134,7 @@ impl<'a> CheckerState<'a> {
     ///
     /// Uses `solver::compute_conditional_expression_type` for type computation
     /// as part of the Solver-First architecture migration.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn get_type_of_conditional_expression(&mut self, idx: NodeIndex) -> TypeId {
         self.get_type_of_conditional_expression_with_request(idx, &TypingRequest::NONE)
     }
@@ -297,7 +297,7 @@ impl<'a> CheckerState<'a> {
     ///
     /// Computes the type of unary expressions like `!x`, `+x`, `-x`, `~x`, `++x`, `--x`, `typeof x`.
     /// Returns boolean for `!`, number for arithmetic operators, string for `typeof`.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn get_type_of_prefix_unary(&mut self, idx: NodeIndex) -> TypeId {
         self.get_type_of_prefix_unary_with_request(idx, &TypingRequest::NONE)
     }
@@ -803,7 +803,7 @@ impl<'a> CheckerState<'a> {
     ///
     /// Uses `solver::compute_template_expression_type` for type computation
     /// as part of the Solver-First architecture migration.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn get_type_of_template_expression(&mut self, idx: NodeIndex) -> TypeId {
         self.get_type_of_template_expression_with_request(idx, &TypingRequest::NONE)
     }

--- a/crates/tsz-checker/src/types/computation/object_literal/mod.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/mod.rs
@@ -200,7 +200,7 @@ impl<'a> CheckerState<'a> {
     /// - Duplicate property detection
     /// - Contextual type inference
     /// - Implicit any reporting (TS7008)
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn get_type_of_object_literal(&mut self, idx: NodeIndex) -> TypeId {
         self.get_type_of_object_literal_with_request(idx, &TypingRequest::NONE)
     }

--- a/crates/tsz-checker/src/types/computation/object_literal_context.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_context.rs
@@ -367,7 +367,6 @@ impl<'a> CheckerState<'a> {
     /// provide a contextual type for callback parameters (-> TS7006). This is distinct from
     /// properties that only exist on the object member (e.g. `validate` on `string | FullRule`
     /// where `String` has no `validate`), which should still be contextually typed.
-    #[allow(dead_code)] // Reserved for contextual typing improvements
     pub(crate) fn primitive_union_member_has_property(
         &mut self,
         type_id: TypeId,

--- a/crates/tsz-checker/src/types/computation/tagged_template.rs
+++ b/crates/tsz-checker/src/types/computation/tagged_template.rs
@@ -42,7 +42,7 @@ impl<'a> CheckerState<'a> {
     ///
     /// This computes the return type of the tag function and ensures
     /// the template substitution expressions are type-checked.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn get_type_of_tagged_template_expression(&mut self, idx: NodeIndex) -> TypeId {
         self.get_type_of_tagged_template_expression_with_request(idx, &TypingRequest::NONE)
     }

--- a/crates/tsz-checker/src/types/property_access_type/helpers.rs
+++ b/crates/tsz-checker/src/types/property_access_type/helpers.rs
@@ -1485,7 +1485,7 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Get type of property access expression.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn get_type_of_property_access(&mut self, idx: NodeIndex) -> TypeId {
         self.get_type_of_property_access_with_request(idx, &TypingRequest::NONE)
     }

--- a/crates/tsz-checker/src/types/queries/callable_truthiness.rs
+++ b/crates/tsz-checker/src/types/queries/callable_truthiness.rs
@@ -74,7 +74,7 @@ impl<'a> CheckerState<'a> {
     ///
     /// Gated on `strictNullChecks`: without it, all types implicitly include
     /// `null | undefined`, so nothing is semantically "always truthy."
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn check_always_truthy(&mut self, node_idx: NodeIndex) {
         if !self.ctx.compiler_options.strict_null_checks {
             return;

--- a/crates/tsz-checker/src/types/type_checking/core.rs
+++ b/crates/tsz-checker/src/types/type_checking/core.rs
@@ -1206,7 +1206,7 @@ impl<'a> CheckerState<'a> {
     /// - Checks array destructuring target types (TS2461)
     /// - Validates default value assignability for binding elements
     /// - Recursively checks nested binding patterns
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn check_binding_pattern(
         &mut self,
         pattern_idx: NodeIndex,
@@ -1366,7 +1366,7 @@ impl<'a> CheckerState<'a> {
     /// - Checks computed property names for unresolved identifiers
     /// - Validates default value type assignability
     /// - Recursively checks nested binding patterns
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn check_binding_element(
         &mut self,
         element_idx: NodeIndex,

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_jsdoc.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_jsdoc.rs
@@ -1331,7 +1331,6 @@ impl Server {
     }
 
     /// Find class names defined in the content.
-    #[allow(dead_code)]
     pub(super) fn collect_class_names(content: &str) -> Vec<String> {
         let mut names = Vec::new();
         let bytes = content.as_bytes();

--- a/crates/tsz-cli/src/bin/tsz_server/main.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/main.rs
@@ -1357,7 +1357,7 @@ impl Server {
     /// Recognized command that has no implementation yet.
     // No production call site yet — kept as part of the taxonomy so future
     // stub handlers can mark themselves honest without re-deriving the shape.
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Dead in the lib build; exercised only by tests.
     pub(crate) fn unimplemented_response(
         &self,
         seq: u64,

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1007,7 +1007,7 @@ impl MergedAugmentations {
     }
 }
 
-#[allow(dead_code)]
+#[allow(dead_code)] // Dead in the lib build; exercised only by tests.
 pub(super) fn create_binder_from_bound_file(
     file: &BoundFile,
     program: &MergedProgram,

--- a/crates/tsz-cli/src/driver/core.rs
+++ b/crates/tsz-cli/src/driver/core.rs
@@ -1279,7 +1279,7 @@ struct BuildProgramResult {
     /// Number of times `merge_bind_results_ref` was called for this result.
     /// 0 means the fast path fired (merge skipped); 1 means a full merge ran.
     /// Only consumed by tests; production call sites only use `program`/`dirty_paths`.
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Dead in the lib build; exercised only by tests.
     merge_calls: u32,
 }
 

--- a/crates/tsz-cli/src/driver/resolution/discovery.rs
+++ b/crates/tsz-cli/src/driver/resolution/discovery.rs
@@ -12,7 +12,7 @@ use tsz::scanner::scanner_impl::ScannerState;
 #[allow(unused_imports)]
 use super::*;
 
-#[allow(dead_code)]
+#[allow(dead_code)] // Dead in the lib build; exercised only by tests.
 pub(crate) fn collect_module_specifiers_from_text(path: &Path, text: &str) -> Vec<String> {
     collect_module_requests_from_text(path, text)
         .into_iter()

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/mod.rs
@@ -151,7 +151,6 @@ pub(crate) struct JsdocOverloadSignature {
 }
 
 /// Lightweight `TypeResolver` backed by `TypeCacheView` data for DTS emit.
-#[allow(dead_code)]
 pub(crate) struct DtsCacheResolver<'a> {
     pub(crate) cache: &'a crate::type_cache_view::TypeCacheView,
 }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/portability_resolve.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/portability_resolve.rs
@@ -385,7 +385,6 @@ impl<'a> DeclarationEmitter<'a> {
         None
     }
 
-    #[allow(dead_code)]
     pub(in crate::declaration_emitter) fn declaration_name_idx_from_source_arena(
         &self,
         source_arena: &NodeArena,
@@ -418,7 +417,7 @@ impl<'a> DeclarationEmitter<'a> {
             .filter(|name_idx| name_idx.is_some())
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(in crate::declaration_emitter) fn declaration_is_publicly_emittable(
         &self,
         decl_node: &tsz_parser::parser::node::Node,
@@ -1457,7 +1456,7 @@ impl<'a> DeclarationEmitter<'a> {
     /// When the printed type text has NO such non-portable import references,
     /// the type is already nameable from the consumer's perspective and the
     /// deeper type-graph portability walk can be skipped.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(in crate::declaration_emitter) fn printed_type_contains_non_portable_import(
         &self,
         printed: &str,

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing_paths.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing_paths.rs
@@ -422,7 +422,6 @@ impl<'a> DeclarationEmitter<'a> {
         None
     }
 
-    #[allow(dead_code)]
     pub(crate) fn resolve_symbol_module_path_cached(&mut self, sym_id: SymbolId) -> Option<String> {
         if let Some(cached) = self.symbol_module_specifier_cache.get(&sym_id) {
             return cached.clone();
@@ -1274,7 +1273,7 @@ impl<'a> DeclarationEmitter<'a> {
     /// Group foreign symbols by their module paths.
     ///
     /// Returns a map of module path -> Vec<SymbolId> for all foreign symbols.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn group_foreign_symbols_by_module(&mut self) -> FxHashMap<String, Vec<SymbolId>> {
         let mut module_map: FxHashMap<String, Vec<SymbolId>> = FxHashMap::default();
 

--- a/crates/tsz-emitter/src/emitter/core_setup.rs
+++ b/crates/tsz-emitter/src/emitter/core_setup.rs
@@ -827,7 +827,7 @@ impl<'a> Printer<'a> {
         self.emit_node(node, idx);
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn emit_expression_with_scoped_static_initializer(
         &mut self,
         idx: NodeIndex,

--- a/crates/tsz-emitter/src/emitter/es5/mod.rs
+++ b/crates/tsz-emitter/src/emitter/es5/mod.rs
@@ -22,7 +22,6 @@ mod helpers_class_expression_comments;
 mod helpers_class_expression_names;
 mod helpers_class_expression_static;
 mod helpers_object_literal;
-#[allow(dead_code)]
 pub(in crate::emitter) mod loop_capture;
 pub(in crate::emitter) mod loop_this_capture;
 mod templates;

--- a/crates/tsz-emitter/src/lowering/helpers.rs
+++ b/crates/tsz-emitter/src/lowering/helpers.rs
@@ -1787,7 +1787,7 @@ impl<'a> LoweringPass<'a> {
         node.kind == SyntaxKind::StringLiteral as u16
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(super) fn export_decl_has_runtime_value(
         &self,
         export_decl: &tsz_parser::parser::node::ExportDeclData,

--- a/crates/tsz-emitter/tests/test_support.rs
+++ b/crates/tsz-emitter/tests/test_support.rs
@@ -16,6 +16,11 @@
 //! Rationale: workstream 8 item 4 in `docs/plan/ROADMAP.md`
 //! ("Add `emit_test_support` with parser/print helpers and table-case support").
 
+// Shared helper module `#[path]`-mounted into several test binaries; each binary
+// exercises a different subset of these helpers, so a symbol unused in one binary
+// is used in another. `allow` (not `expect`) is the correct tool here: `expect`
+// would fire `unfulfilled_lint_expectations` in whichever binary happens to use
+// every helper.
 #![allow(dead_code)]
 
 use tsz_emitter::output::printer::{PrintOptions, Printer, lower_and_print};

--- a/crates/tsz-parser/src/parser/state.rs
+++ b/crates/tsz-parser/src/parser/state.rs
@@ -896,7 +896,7 @@ impl ParserState {
     /// These are: implements, interface, let, package, private, protected, public, static, yield.
     /// In strict mode contexts these cannot be used as identifiers.
     #[inline]
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) const fn is_future_reserved_word(&self) -> bool {
         self.current_token as u16 >= SyntaxKind::FIRST_FUTURE_RESERVED_WORD as u16
             && self.current_token as u16 <= SyntaxKind::LAST_FUTURE_RESERVED_WORD as u16
@@ -905,7 +905,6 @@ impl ParserState {
     /// Check if we're in a strict mode context (class body or module).
     /// TypeScript class bodies and modules are always in strict mode.
     #[inline]
-    #[allow(dead_code)]
     pub(crate) const fn in_strict_mode_context(&self) -> bool {
         self.in_class_body() || self.seen_module_indicator
     }

--- a/crates/tsz-parser/src/parser/state_diagnostics.rs
+++ b/crates/tsz-parser/src/parser/state_diagnostics.rs
@@ -390,7 +390,6 @@ impl ParserState {
     }
 
     /// Parse regex escape diagnostics for regex literals.
-    #[allow(dead_code)]
     pub(crate) fn report_invalid_regular_expression_escape_errors(&mut self) {
         let token_text = self.scanner.get_token_text_ref().to_string();
         if !token_text.starts_with('/') || token_text.len() < 2 {

--- a/crates/tsz-parser/src/parser/state_statements_keywords.rs
+++ b/crates/tsz-parser/src/parser/state_statements_keywords.rs
@@ -1568,7 +1568,7 @@ impl ParserState {
         result
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn look_ahead_is_await_using(&mut self) -> bool {
         look_ahead_is(&mut self.scanner, self.current_token, |token| {
             token == SyntaxKind::UsingKeyword
@@ -1626,7 +1626,7 @@ impl ParserState {
     }
 
     /// Look ahead to see if we have `export =`.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn look_ahead_is_export_assignment(&mut self) -> bool {
         let snapshot = self.scanner.save_state();
         let current = self.current_token;

--- a/crates/tsz-solver/src/caches/instantiation_cache.rs
+++ b/crates/tsz-solver/src/caches/instantiation_cache.rs
@@ -200,13 +200,11 @@ impl InstantiationCache {
     }
 
     /// Look up an entry by key. Returns `None` if no entry exists.
-    #[allow(dead_code)]
     pub fn lookup(&self, key: &InstantiationCacheKey) -> Option<TypeId> {
         self.inner.borrow().get(key).copied()
     }
 
     /// Insert (or overwrite) an entry.
-    #[allow(dead_code)]
     pub fn insert(&self, key: InstantiationCacheKey, result: TypeId) {
         self.inner.borrow_mut().insert(key, result);
     }
@@ -224,7 +222,7 @@ impl InstantiationCache {
 
     /// Returns `true` if the cache is empty.
     #[must_use]
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Dead in the lib build; exercised only by tests.
     pub fn is_empty(&self) -> bool {
         self.inner.borrow().is_empty()
     }

--- a/crates/tsz-solver/src/caches/subtype_reduction_cache.rs
+++ b/crates/tsz-solver/src/caches/subtype_reduction_cache.rs
@@ -234,7 +234,7 @@ impl SubtypeReductionCache {
 
     /// Returns `true` if the cache is empty.
     #[must_use]
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Dead in the lib build; exercised only by tests.
     pub fn is_empty(&self) -> bool {
         self.inner.borrow().is_empty()
     }

--- a/crates/tsz-solver/src/diagnostics/format/test_tracing.rs
+++ b/crates/tsz-solver/src/diagnostics/format/test_tracing.rs
@@ -24,7 +24,7 @@ use tracing_subscriber::layer::SubscriberExt;
 
 /// A captured tracing span.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub struct CapturedSpan {
     /// The span name (e.g., "`check_subtype`", "`evaluate_type`").
     pub name: String,
@@ -36,7 +36,7 @@ pub struct CapturedSpan {
 
 /// A captured tracing event.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub struct CapturedEvent {
     /// The event message (from the `message` field).
     pub message: String,
@@ -63,13 +63,13 @@ impl TracingCapture {
     }
 
     /// Get all captured spans.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub fn spans(&self) -> Vec<CapturedSpan> {
         self.spans.lock().unwrap().clone()
     }
 
     /// Get all captured events.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub fn events(&self) -> Vec<CapturedEvent> {
         self.events.lock().unwrap().clone()
     }

--- a/crates/tsz-solver/src/evaluation/evaluate/application.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/application.rs
@@ -1793,7 +1793,7 @@ enum SameAliasExpansion {
     /// would otherwise terminate silently — report the depth verdict now.
     // Designed verdict not yet wired: `classify_same_alias_expansion` does not
     // return this yet; the `resolve_application` match already handles the arm.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     DivergentConditional,
     /// Convergent or still-generic: keep the meta-rereduce identity wrapper.
     None,

--- a/crates/tsz-solver/src/inference/infer.rs
+++ b/crates/tsz-solver/src/inference/infer.rs
@@ -149,7 +149,7 @@ impl UnifyValue for InferenceInfo {
 // Constructed throughout inference as a control-flow signal; the variant
 // payload is retained for `Debug`/future error reporting, and only the variant
 // kind and `BoundsViolation.lower` are read today.
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) enum InferenceError {
     /// Two incompatible types were unified
     Conflict(TypeId, TypeId),
@@ -225,7 +225,6 @@ pub(crate) const MAX_TYPE_RECURSION_DEPTH: usize = 100;
 /// Owner: one inference request. The subtype memo is scoped to that request
 /// and is dropped with the context.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-#[allow(dead_code)] // Inference cache accounting; consumed by inference unit tests
 pub(crate) struct InferenceContextCacheStatistics {
     /// Entries in the inference subtype memo keyed by source and target `TypeId`.
     pub(crate) subtype_entries: usize,
@@ -688,7 +687,6 @@ impl<'a> InferenceContext<'a> {
     }
 
     /// Get the declared `extends` constraint for an inference variable.
-    #[allow(dead_code)] // Reserved for full constraint-based inference
     pub fn get_declared_constraint(&mut self, var: InferenceVar) -> Option<TypeId> {
         let root = self.table.find(var);
         self.declared_constraints.get(&root).copied()
@@ -1258,7 +1256,7 @@ impl<'a> InferenceContext<'a> {
     }
 
     /// Resolve all type parameters to concrete types
-    #[allow(dead_code)] // Reserved for full constraint-based inference
+    #[expect(dead_code)] // Reserved for full constraint-based inference
     pub fn resolve_all(&mut self) -> Result<Vec<(Atom, TypeId)>, InferenceError> {
         // Clone type_params to avoid borrow conflict
         let type_params: Vec<_> = self.type_params.clone();
@@ -1273,7 +1271,7 @@ impl<'a> InferenceContext<'a> {
     }
 
     /// Get the interner reference
-    #[allow(dead_code)] // Reserved for full constraint-based inference
+    #[expect(dead_code)] // Reserved for full constraint-based inference
     pub fn interner(&self) -> &dyn TypeDatabase {
         self.interner
     }
@@ -1644,7 +1642,7 @@ impl<'a> InferenceContext<'a> {
     /// concrete (non-TypeParameter) type. `TypeParameter` types in `contra_candidates`
     /// are typically unresolved source inference placeholders from generic function
     /// arguments and should not drive the resolution gate.
-    #[allow(dead_code)] // Reserved contra-candidate resolution-gate query
+    #[expect(dead_code)] // Reserved contra-candidate resolution-gate query
     pub fn has_concrete_contra_candidates(
         &mut self,
         var: InferenceVar,

--- a/crates/tsz-solver/src/inference/infer_resolve.rs
+++ b/crates/tsz-solver/src/inference/infer_resolve.rs
@@ -1266,7 +1266,10 @@ impl<'a> InferenceContext<'a> {
     /// Infer type parameters from a conditional type.
     /// When a type parameter appears in a conditional type, we can sometimes
     /// infer its value from the check and extends clauses.
-    #[allow(dead_code)] // Reserved for conditional type inference
+    // Dead in the lib build; entered only from `tests/infer_tests/context_overloads_solv16.rs`.
+    // `allow` (not `expect`) is correct: the test build makes it live, which would leave an
+    // `expect` unfulfilled.
+    #[allow(dead_code)]
     pub fn infer_from_conditional(
         &mut self,
         var: InferenceVar,
@@ -1291,7 +1294,9 @@ impl<'a> InferenceContext<'a> {
     }
 
     /// Infer type parameters from a type by traversing its structure.
-    #[allow(dead_code)] // Reserved for conditional type inference (paired with `infer_from_conditional`)
+    // Reachable only through `infer_from_conditional`, which is itself test-only; dead in the
+    // lib build, so it carries its own `allow`.
+    #[allow(dead_code)]
     fn infer_from_type(&mut self, var: InferenceVar, ty: TypeId) {
         let root = self.table.find(var);
 

--- a/crates/tsz-solver/src/inference/infer_variance.rs
+++ b/crates/tsz-solver/src/inference/infer_variance.rs
@@ -9,7 +9,6 @@ use crate::inference::infer::InferenceContext;
 use crate::types::{TypeData, TypeId};
 use tsz_common::interner::Atom;
 
-#[allow(dead_code)] // Reserved for variance analysis in inference resolution
 struct VarianceState<'a> {
     target_param: Atom,
     covariant: &'a mut u32,
@@ -19,7 +18,6 @@ struct VarianceState<'a> {
 impl InferenceContext<'_> {
     /// Compute the variance of a type parameter within a type.
     /// Returns (`covariant_count`, `contravariant_count`, `invariant_count`, `bivariant_count`)
-    #[allow(dead_code)] // Reserved for variance analysis in inference
     pub fn compute_variance(&self, ty: TypeId, target_param: Atom) -> (u32, u32, u32, u32) {
         let mut covariant = 0u32;
         let mut contravariant = 0u32;

--- a/crates/tsz-solver/src/instantiation/instantiate/display_properties.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/display_properties.rs
@@ -4,7 +4,6 @@ use rustc_hash::FxHashMap;
 
 impl<'a> TypeInstantiator<'a> {
     /// Propagate display properties from intersection members to the result.
-    #[allow(dead_code)]
     pub(super) fn propagate_display_properties_for_intersection(
         &self,
         original_members: &[TypeId],

--- a/crates/tsz-solver/src/intern/core/interner/cache.rs
+++ b/crates/tsz-solver/src/intern/core/interner/cache.rs
@@ -25,7 +25,6 @@ use tsz_common::interner::Atom;
 
 const LOOKUP_CACHE_BITS: u32 = 10;
 const LOOKUP_CACHE_SIZE: usize = 1 << LOOKUP_CACHE_BITS; // 1024
-#[allow(dead_code)]
 const LOOKUP_CACHE_MASK: u32 = (LOOKUP_CACHE_SIZE as u32) - 1;
 
 /// A single cache entry: (tag = TypeId raw value, cached TypeData, owning
@@ -54,7 +53,6 @@ struct LookupCacheEntry {
 
 const INTERN_CACHE_BITS: u32 = 9;
 const INTERN_CACHE_SIZE: usize = 1 << INTERN_CACHE_BITS; // 512
-#[allow(dead_code)]
 const INTERN_CACHE_MASK: u64 = (INTERN_CACHE_SIZE as u64) - 1;
 
 #[derive(Clone, Copy)]
@@ -179,7 +177,6 @@ const EMPTY_UNION_COMPLEXITY_STATE: UnionComplexityThreadState = UnionComplexity
     pending_count: 0,
 };
 
-#[allow(dead_code)]
 impl TypeInternerCache {
     #[allow(clippy::large_stack_arrays)]
     const fn new() -> Self {

--- a/crates/tsz-solver/src/narrowing/discriminants.rs
+++ b/crates/tsz-solver/src/narrowing/discriminants.rs
@@ -687,7 +687,7 @@ impl<'a> NarrowingContext<'a> {
 
     /// O(1) discriminant narrowing for the false/excluding branch.
     /// Builds the index if needed, then returns all members NOT matching the literal.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     fn fast_narrow_excluding_via_discriminant_index(
         &self,
         original_union_type: TypeId,

--- a/crates/tsz-solver/src/operations/generics.rs
+++ b/crates/tsz-solver/src/operations/generics.rs
@@ -12,7 +12,6 @@ use tsz_common::interner::Atom;
 
 /// Result of validating type arguments against their type parameter constraints.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[allow(dead_code)] // Used in operations_tests.rs
 pub(crate) enum GenericInstantiationResult {
     /// All type arguments satisfy their constraints
     Success,

--- a/crates/tsz-solver/src/relations/subtype/rules/intrinsic_object.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/intrinsic_object.rs
@@ -58,7 +58,7 @@ pub(crate) enum IntrinsicObjectKind {
     /// This variant is provided for completeness so `intrinsic_vs_object_super`
     /// encodes the full three-column matrix. The structural path in `core.rs`
     /// handles `{}` targets without calling this helper at runtime.
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Dead in the lib build; exercised only by tests.
     EmptyObject,
     /// The global `Object` interface from `lib.d.ts` — all non-null/undefined.
     GlobalObject,

--- a/crates/tsz-solver/tests/common/mod.rs
+++ b/crates/tsz-solver/tests/common/mod.rs
@@ -2,13 +2,15 @@
 //
 // This module is loaded into multiple test binaries, so consumers vary in which
 // items they actually use. All items carry `#[allow(dead_code)]` to keep
-// cross-binary unused-warning noise quiet.
+// cross-binary unused-warning noise quiet -- `expect` cannot be used here because
+// it would fire `unfulfilled_lint_expectations` in whichever binary does use the
+// item.
 
 use crate::construction::TypeInterner;
 use crate::relations::judge::{DefaultJudge, JudgeConfig};
 use crate::relations::subtype::TypeEnvironment;
 
-#[allow(dead_code)]
+#[allow(dead_code)] // Dead in the lib build; exercised only by tests.
 pub fn create_test_interner() -> TypeInterner {
     TypeInterner::new()
 }
@@ -20,13 +22,13 @@ pub fn create_test_interner() -> TypeInterner {
 /// must be built per-call site. This fixture exposes a `judge()` accessor for
 /// the default config and a `judge_with_config()` accessor for the rare
 /// non-default `JudgeConfig` cases.
-#[allow(dead_code)]
+#[allow(dead_code)] // Dead in the lib build; exercised only by tests.
 pub struct JudgeSetup {
     pub interner: TypeInterner,
     pub env: TypeEnvironment,
 }
 
-#[allow(dead_code)]
+#[allow(dead_code)] // Dead in the lib build; exercised only by tests.
 impl JudgeSetup {
     /// Create a fresh `JudgeSetup` with an empty interner and environment.
     pub fn new() -> Self {


### PR DESCRIPTION
Fixes #16794.

`#[allow(dead_code)]` appeared 107 times across `crates/`. `allow` is a permanent
suppression with no expiry and no proof obligation: once applied it stays
correct-looking whether or not the symbol is still dead, so the population only
grows and its signal decays to zero. Sampling in #16794 found roughly half sat on
symbols that were actually used.

This PR fixes the mechanism and clears the stale population, using the compiler as
the oracle (unfulfilled-expectation is denied under `-D warnings`).

### What changed

- **Convert per-symbol `#[allow(dead_code)]` → `#[expect(dead_code)]`.** An
  item-level `expect` self-polices: it fails the build the moment its symbol
  becomes used (unfulfilled expectation), converting a recurring cleanup into a
  one-time one. This is #16794's suggestion #4 and is what makes the fix durable.
- **Delete 32 stale allowances** whose symbol is used in the lib build (rustc
  reported the expectation unfulfilled in a lib-only build). Removing an
  annotation from a used symbol cannot break the build; several carried outdated
  "Reserved for future" comments while being called throughout (e.g.
  `GenericInstantiationResult`, `infer_from_conditional`'s neighbours,
  `get_declared_constraint`).
- **Revert to `allow` (with rationale)** the items that are dead in the lib build
  but live only under `cfg(test)`/integration tests. `expect` is the *wrong* tool
  there: `--all-targets` compiles the test target, where the item is live,
  leaving the expectation unfulfilled. `allow` is silent in every config, so it
  is correct for test-only-used symbols and for cross-binary `#[path]`-mounted
  test-support modules (`tsz-emitter/tests/test_support.rs`,
  `tsz-solver/tests/common/mod.rs`).
- **Keep the two crate-wide blankets, with clearer rationale.** `tsz-checker`'s
  `#[allow(dead_code)]` remains the separately-tracked **#13440** XL campaign —
  lifting it surfaces ~360 item-level warnings requiring per-symbol
  delete-vs-wire judgment (including the orphaned `check_*` entry points), which
  is a semantic effort that risks conformance changes and belongs in that
  campaign, not this hygiene PR. Its per-symbol `expect`s still self-police: an
  item-level `expect` overrides the blanket, so a stale one fails the build even
  there.

### Method note

The lib-only-vs-`--all-targets` unfulfilled split is the discriminator between
"used in production" (delete the annotation) and "used only in tests" (must stay
`allow`). Two items initially misclassified as production-used were caught by the
authoritative `--all-targets` re-check — `expect` acts as a live root in
dead-code reachability, so a mutually-recursive test-only cluster looked "used"
in the lib-only probe. They were corrected to documented `allow`.

No semantic change: `allow`/`expect(dead_code)` are lint-only attributes with no
codegen effect, and only unused attributes were deleted — no code was removed.

## Goal
Goal: hold

## Verification
- `cargo clippy --workspace --exclude tsz-conformance --all-targets -- -D warnings` — clean (matches the per-merge CI lint lane; `unfulfilled_lint_expectations` is denied under `-D warnings`).
- `cargo check --workspace --all-targets` — zero `dead_code`/unfulfilled warnings.
- `python3 scripts/arch/arch_guard.py` — Architecture guardrails passed.
- Conformance/emit/fourslash not run: change is behavior-neutral (lint-only attributes; no code deleted).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01He2Bc5DzoSf17QSvyCm63V)_