### PR TITLE
chore(readme): refresh conformance stats to 11,524

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ test suite against it.
 
 <!-- CONFORMANCE_START -->
 ```
-Progress: [███████████████████░] 95.6% (11,513/12,043 runnable tests)
+Progress: [███████████████████░] 95.7% (11,524/12,043 runnable tests)
 Candidates: 12,585 (12,043 runnable, 507 unsupported, 35 skipped)
 ```
 <!-- CONFORMANCE_END -->


### PR DESCRIPTION
Goal: hold

Refreshes the generated README conformance block from a snapshot measured at
`107e931742`. Changes: `95.6% (11,513/12,043)` -> `95.7% (11,524/12,043)`.

Generated via `scripts/refresh-readme.py --write --skip-performance`; no
hand-edited numbers. The committed value was read back out of the commit
(`git show HEAD:README.md`) before the conformance snapshot tree was discarded.

Emit metrics left untouched -- the script declined to rewrite them
(`preserving README emit metrics because scripts/emit/emit-detail.json is behind
the existing README emit block and does not record the current HEAD`).
Fourslash metrics already accurate. Performance chart skipped.

## Verification

Measured at `107e931742`:

- conformance: `11524 / 12043` runnable (95.7%), 12585 candidates, 507
  unsupported, 35 skipped

Full suite run this cycle at `6018d51161`:

- conformance `11522 / 12043` (95.7%)
- emit JS `11562 / 11563`, emit DTS `1375 / 1390` -- both at the parity floor,
  unmoved across roughly 450 commits
- fourslash `6558 / 6562` baseline held. Complete run (`6562/6562`), 0 watchdog
  kills, 2 slow-but-passed. The 4 failures are the known baseline set.
- benchmark: **full 99-row sweep**, load-gated, bracketed `start 3.85 -> end 1.95`.
  Score `tsz 94 vs tsgo 4`. Gaps: comlink `2.81 ± 0.02`, ts-toolbelt
  `2.51 ± 0.04`, vite-vanilla-ts-app `1.79 ± 0.03`, recursive utility aliases
  `1.13 ± 0.01` -- the tightest error bars recorded this week.

## comlink (#16554): unrecovered, and a correction

I previously reported a partial recovery. That was wrong and I have corrected
it on the issue. Post-regression readings of tsz's absolute time:

`321.1 ± 2.1`, `320.8 ± 1.4`, `320.2 ± 2.6`, `315.8 ± 2.1`, `320.4 ± 1.1`

Four cluster at 320.2-321.1; the lone `315.8` sits 2-3σ below all of them and is
an outlier, not a step. **The regression is unrecovered and stable at ~320.5 ms,
+12.6 ms (+4.1%) over the 307.9 ms baseline.**

The process error was mine: I required two independent confirmations before
filing the original regression, then accepted a single ~2σ reading as evidence
of recovery. Same instrument, same known σ, weaker bar -- applied to the result
I was hoping for. Anyone bisecting should treat ~320.5 ms as the plateau and
307.9 ms as the target, and confirm any apparent win on a second SHA.

Rows that do not complete, reported separately from the `fast` gaps:
`large-ts-repo` (tsz exit 124 at the 1500s ceiling), `zod-project` and
`kysely-project` (`tsz error; tsc ok`).

## Provenance

Machine: m1
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high

AgentName: M1FableArchitect