### PR TITLE
fix(checker/solver): TS18032 private-brand intersection elaboration

### DIFF
--- a/crates/tsz-checker/src/error_reporter/intersection_never_elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/intersection_never_elaboration.rs
@@ -95,15 +95,31 @@ impl<'a> CheckerState<'a> {
             .into_iter()
             .map(|member| self.resolve_type_for_property_access(member))
             .collect();
-        let conflict_atom =
-            crate::query_boundaries::intersection_display::find_disjoint_literal_property_across_intersection(
-                self.ctx.types,
-                &members,
-            )?;
         // tsc's elaboration names the discriminant that reduced the whole
         // intersection to `never`, not necessarily the property actually
         // accessed — once the receiver type itself is `never`, every access
         // on it carries the same reason.
+        let (code, conflict_atom) =
+            if let Some(atom) =
+                crate::query_boundaries::intersection_display::find_disjoint_literal_property_across_intersection(
+                    self.ctx.types,
+                    &members,
+                )
+            {
+                (
+                    diagnostic_codes::THE_INTERSECTION_WAS_REDUCED_TO_NEVER_BECAUSE_PROPERTY_HAS_CONFLICTING_TYPES_IN,
+                    atom,
+                )
+            } else {
+                let atom = crate::query_boundaries::intersection_display::find_private_brand_conflicting_property_across_intersection(
+                    self.ctx.types,
+                    &members,
+                )?;
+                (
+                    diagnostic_codes::THE_INTERSECTION_WAS_REDUCED_TO_NEVER_BECAUSE_PROPERTY_EXISTS_IN_MULTIPLE_CONSTI,
+                    atom,
+                )
+            };
         let conflict_prop_name = self.ctx.types.resolve_atom(conflict_atom);
         // Built directly from the recovered member types rather than
         // `declared_intersection_annotation_display_for_expression`: that
@@ -117,13 +133,20 @@ impl<'a> CheckerState<'a> {
             .collect::<Vec<_>>()
             .join(" & ");
         use crate::diagnostics::{Diagnostic, diagnostic_messages, format_message};
+        let message_template = if code
+            == diagnostic_codes::THE_INTERSECTION_WAS_REDUCED_TO_NEVER_BECAUSE_PROPERTY_HAS_CONFLICTING_TYPES_IN
+        {
+            diagnostic_messages::THE_INTERSECTION_WAS_REDUCED_TO_NEVER_BECAUSE_PROPERTY_HAS_CONFLICTING_TYPES_IN
+        } else {
+            diagnostic_messages::THE_INTERSECTION_WAS_REDUCED_TO_NEVER_BECAUSE_PROPERTY_EXISTS_IN_MULTIPLE_CONSTI
+        };
         Some(Diagnostic::related_message(
-            diagnostic_codes::THE_INTERSECTION_WAS_REDUCED_TO_NEVER_BECAUSE_PROPERTY_HAS_CONFLICTING_TYPES_IN,
+            code,
             self.ctx.file_name.clone(),
             0,
             0,
             format_message(
-                diagnostic_messages::THE_INTERSECTION_WAS_REDUCED_TO_NEVER_BECAUSE_PROPERTY_HAS_CONFLICTING_TYPES_IN,
+                message_template,
                 &[&intersection_display, &conflict_prop_name],
             ),
         ))

--- a/crates/tsz-checker/src/query_boundaries/intersection_display.rs
+++ b/crates/tsz-checker/src/query_boundaries/intersection_display.rs
@@ -20,6 +20,21 @@ pub(crate) fn find_disjoint_literal_property_across_intersection(
     tsz_solver::type_queries::find_disjoint_literal_property_across_intersection(db, members)
 }
 
+/// The property name whose required occurrences across a *written*
+/// intersection's members come from two or more distinct declaring classes
+/// with at least one `private` occurrence, forcing that intersection to
+/// reduce to `never` (`tsc`'s TS18032). See
+/// [`tsz_solver::type_queries::find_private_brand_conflicting_property_across_intersection`]
+/// for the declaring-class identity rule.
+pub(crate) fn find_private_brand_conflicting_property_across_intersection(
+    db: &dyn TypeDatabase,
+    members: &[TypeId],
+) -> Option<tsz_common::interner::Atom> {
+    tsz_solver::type_queries::find_private_brand_conflicting_property_across_intersection(
+        db, members,
+    )
+}
+
 pub(crate) fn collect_properties<R: TypeResolver>(
     type_id: TypeId,
     db: &dyn TypeDatabase,

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -899,6 +899,8 @@ mod ts18010_jsdoc_tag_anchor_tests;
 mod ts18017_ts18018_private_identifier_shadow_related_info_tests;
 #[path = "tests/ts18031_intersection_conflicting_property_tests.rs"]
 mod ts18031_intersection_conflicting_property_tests;
+#[path = "tests/ts18032_private_brand_intersection_tests.rs"]
+mod ts18032_private_brand_intersection_tests;
 #[path = "tests/ts18050_nullish_keyword_without_strict_null_checks_tests.rs"]
 mod ts18050_nullish_keyword_without_strict_null_checks_tests;
 #[path = "tests/ts2322_private_field_narrowing_write_tests.rs"]

--- a/crates/tsz-checker/src/tests/ts18031_intersection_conflicting_property_tests.rs
+++ b/crates/tsz-checker/src/tests/ts18031_intersection_conflicting_property_tests.rs
@@ -27,9 +27,10 @@
 //! Deliberately narrow scope, matching the helper's own doc comments: only
 //! the single-required-literal-per-member discriminant shape, only a
 //! directly-written intersection annotation (no alias/generic-application/
-//! heritage indirection, no private-brand conflicts — TS18032 is a separate,
-//! unimplemented follow-up). Every case outside that scope keeps today's
-//! behavior (`TS2339` with no elaboration), never a wrong one.
+//! heritage indirection). Private-brand conflicts are `TS18032`, a separate
+//! diagnostic covered by `ts18032_private_brand_intersection_tests.rs`.
+//! Every case outside that scope keeps today's behavior (`TS2339` with no
+//! elaboration), never a wrong one.
 
 use crate::diagnostics::Diagnostic;
 use crate::test_utils::check_source_strict;

--- a/crates/tsz-checker/src/tests/ts18032_private_brand_intersection_tests.rs
+++ b/crates/tsz-checker/src/tests/ts18032_private_brand_intersection_tests.rs
@@ -1,0 +1,220 @@
+//! Regression tests for the `TS18032` related-info line `tsc` attaches to a
+//! `TS2339` property access on an intersection reduced to `never` by a
+//! private-brand conflict — the sibling of `TS18031`
+//! (`ts18031_intersection_conflicting_property_tests.rs`) for the shape that
+//! file's own doc comment flags as a separate, then-unimplemented follow-up.
+//!
+//! Structural rule (pinned against `typescript@7.0.2`): when a *directly
+//! written* object intersection (`declare const c: A & B`) has two or more
+//! constituents that each declare a property of the same name, and that name
+//! is `private` in at least one of them, `tsc` collapses the intersection to
+//! `never` and any property access on it reports `TS2339` with a
+//! `relatedInformation` entry: "The intersection '{0}' was reduced to
+//! 'never' because property '{1}' exists in multiple constituents and is
+//! private in some." This fires regardless of whether the conflicting
+//! occurrences' types agree — unlike `TS18031`, this is a nominal-identity
+//! conflict, not a literal-value conflict.
+//!
+//! The conflict is keyed on *declaring symbol* identity, not proximity: a
+//! property inherited unchanged from a common base class through two
+//! subclasses is one occurrence (the base's), not two, so it does not
+//! trigger this rule — matching `PropertyInfo::parent_id`, which class-shape
+//! construction only rewrites for own/overriding members
+//! (`find_private_brand_conflicting_property_across_intersection`,
+//! `tsz-solver/src/type_queries/data/intersection_conflict.rs`). Owned by
+//! `error_reporter/intersection_never_elaboration.rs`'s
+//! `intersection_reduced_to_never_related_info`, as a fallback when the
+//! `TS18031` literal-conflict check finds nothing.
+
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::check_source_strict;
+use tsz_common::diagnostics::diagnostic_codes;
+
+const TS2339: u32 = diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE;
+const TS18032: u32 =
+    diagnostic_codes::THE_INTERSECTION_WAS_REDUCED_TO_NEVER_BECAUSE_PROPERTY_EXISTS_IN_MULTIPLE_CONSTI;
+
+fn only(diags: &[Diagnostic], code: u32) -> Diagnostic {
+    let matching: Vec<_> = diags.iter().filter(|d| d.code == code).collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected exactly one TS{code}; got {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+    matching[0].clone()
+}
+
+fn related(diagnostic: &Diagnostic, code: u32) -> Option<String> {
+    diagnostic
+        .related_information
+        .iter()
+        .find(|info| info.code == code)
+        .map(|info| info.message_text.clone())
+}
+
+// ---------------------------------------------------------------------------
+// Positive cases: a directly-written intersection with a private-brand
+// conflict carries the TS18032 elaboration.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn both_private_same_name_carries_ts18032_elaboration() {
+    let diags = check_source_strict(
+        r#"
+class Alpha { private x: number = 1; }
+class Beta { private x: string = "a"; }
+declare const value: Alpha & Beta;
+value.x;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18032).as_deref(),
+        Some(
+            "The intersection 'Alpha & Beta' was reduced to 'never' because property 'x' exists in multiple constituents and is private in some."
+        ),
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn private_and_public_same_name_carries_ts18032_elaboration() {
+    // The rule fires as soon as one occurrence is private, regardless of the
+    // other's visibility or whether the two types actually agree.
+    let diags = check_source_strict(
+        r#"
+class First { private slot: number = 1; }
+class Second { slot: number = 2; }
+declare const combined: First & Second;
+combined.slot;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18032).as_deref(),
+        Some(
+            "The intersection 'First & Second' was reduced to 'never' because property 'slot' exists in multiple constituents and is private in some."
+        ),
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn private_and_protected_same_name_carries_ts18032_elaboration() {
+    let diags = check_source_strict(
+        r#"
+class Holder1 { private count: number = 1; }
+class Holder2 { protected count: number = 2; }
+declare const both: Holder1 & Holder2;
+both.count;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18032).as_deref(),
+        Some(
+            "The intersection 'Holder1 & Holder2' was reduced to 'never' because property 'count' exists in multiple constituents and is private in some."
+        ),
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn three_way_intersection_carries_ts18032_elaboration() {
+    let diags = check_source_strict(
+        r#"
+class WithKeyA { private key: number = 1; }
+class WithKeyB { private key: number = 2; }
+class Plain { other: number = 3; }
+declare const anything: WithKeyA & WithKeyB & Plain;
+anything.other;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18032).as_deref(),
+        Some(
+            "The intersection 'WithKeyA & WithKeyB & Plain' was reduced to 'never' because property 'key' exists in multiple constituents and is private in some."
+        ),
+        "got {diags:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative / control cases: no TS18032 elaboration.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn both_protected_same_name_has_no_ts18032() {
+    // Protected-only conflicts do not collapse the intersection to `never`;
+    // `tsc` reports the ordinary protected-access diagnostic (TS2445) on the
+    // still-valid `A & B` type instead.
+    let diags = check_source_strict(
+        r#"
+class Alpha { protected x: number = 1; }
+class Beta { protected x: number = 2; }
+declare const value: Alpha & Beta;
+value.x;
+"#,
+    );
+    assert!(
+        diags.iter().all(|d| d.code != TS2339),
+        "protected-only conflicts must not reduce to never, got {diags:?}"
+    );
+}
+
+#[test]
+fn shared_base_private_member_has_no_ts18032() {
+    // Both subclasses inherit the exact same private declaration from
+    // `Base`, unchanged — one declaring symbol, not two, so this is not a
+    // conflict. `tsc` reports the ordinary private-access diagnostic
+    // (TS2341) naming the declaring class.
+    let diags = check_source_strict(
+        r#"
+class Base { private x: number = 1; }
+class Alpha extends Base {}
+class Beta extends Base {}
+declare const value: Alpha & Beta;
+value.x;
+"#,
+    );
+    assert!(
+        diags.iter().all(|d| d.code != TS2339),
+        "a private member inherited unchanged through a shared base must not reduce to never, got {diags:?}"
+    );
+}
+
+#[test]
+fn same_class_twice_has_no_ts18032() {
+    let diags = check_source_strict(
+        r#"
+class Alpha { private x: number = 1; }
+declare const value: Alpha & Alpha;
+value.x;
+"#,
+    );
+    assert!(
+        diags.iter().all(|d| d.code != TS2339),
+        "the same class repeated in an intersection must not reduce to never, got {diags:?}"
+    );
+}
+
+#[test]
+fn non_intersection_never_receiver_has_no_ts18032() {
+    let diags = check_source_strict(
+        r#"
+declare const value: string | number;
+if (typeof value === "string") {
+} else if (typeof value === "number") {
+} else {
+    value.toString();
+}
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert!(related(&diag, TS18032).is_none(), "got {diags:?}");
+}

--- a/crates/tsz-solver/src/type_queries/data/intersection_conflict.rs
+++ b/crates/tsz-solver/src/type_queries/data/intersection_conflict.rs
@@ -1,11 +1,15 @@
 //! Conflict detection over a *written* (pre-reduction) intersection member
 //! list, used only for diagnostic elaboration — see
-//! [`find_disjoint_literal_property_across_intersection`].
+//! [`find_disjoint_literal_property_across_intersection`] and
+//! [`find_private_brand_conflicting_property_across_intersection`].
 
 use crate::construction::TypeDatabase;
 use crate::types::TypeData;
 use crate::types::TypeId;
+use crate::types::Visibility;
+use crate::utils::is_synthetic_private_brand_name;
 use rustc_hash::{FxHashMap, FxHashSet};
+use tsz_binder::SymbolId;
 use tsz_common::interner::Atom;
 
 /// The property name whose required occurrences across `members` are literal
@@ -72,5 +76,74 @@ pub fn find_disjoint_literal_property_across_intersection(
     by_name
         .into_iter()
         .find(|(_, values)| values.len() >= 2)
+        .map(|(name, _)| name)
+}
+
+/// The property name whose required occurrences across `members` come from
+/// two or more distinct declaring classes with at least one `private`
+/// occurrence — the shape `tsc` reports as `TS18032` (`The intersection
+/// '{0}' was reduced to 'never' because property '{1}' exists in multiple
+/// constituents and is private in some.`), the private-brand sibling of
+/// [`find_disjoint_literal_property_across_intersection`]'s literal-conflict
+/// `TS18031`.
+///
+/// Declaring-class identity is `PropertyInfo::parent_id`: class-shape
+/// construction only rewrites a member's `parent_id` to the owning class
+/// when that member is *own* (newly declared or overriding), so a property
+/// inherited unchanged through a shared base class keeps the base's
+/// `parent_id` in every subclass and is correctly seen as one occurrence,
+/// not a conflict (`class A extends Base {}` / `class B extends Base {}` /
+/// `A & B` does not reduce to `never`, matching `tsc`).
+///
+/// Like its literal-conflict sibling, this is display-only and deliberately
+/// narrow: it does not re-derive whether `members` actually reduces to
+/// `never` (the caller already knows that from the receiver's `TypeId`), it
+/// only names the first conflicting property, by source declaration order,
+/// for the elaboration line. Returning `None` leaves today's plain `TS2339`
+/// exactly as it is, never a wrong message.
+pub fn find_private_brand_conflicting_property_across_intersection(
+    db: &dyn TypeDatabase,
+    members: &[TypeId],
+) -> Option<Atom> {
+    struct Entry {
+        parents: FxHashSet<Option<SymbolId>>,
+        saw_private: bool,
+        min_declaration_order: u32,
+    }
+
+    let mut by_name: FxHashMap<Atom, Entry> = FxHashMap::default();
+    let mut ingest = |properties: &[crate::types::PropertyInfo]| {
+        for prop in properties {
+            if is_synthetic_private_brand_name(&db.resolve_atom(prop.name)) {
+                continue;
+            }
+            let entry = by_name.entry(prop.name).or_insert_with(|| Entry {
+                parents: FxHashSet::default(),
+                saw_private: false,
+                min_declaration_order: prop.declaration_order,
+            });
+            entry.parents.insert(prop.parent_id);
+            entry.saw_private |= prop.visibility == Visibility::Private;
+            entry.min_declaration_order = entry.min_declaration_order.min(prop.declaration_order);
+        }
+    };
+    for &member in members {
+        if member.is_intrinsic() {
+            continue;
+        }
+        match db.lookup(member) {
+            Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => {
+                ingest(&db.object_shape(shape_id).properties);
+            }
+            Some(TypeData::Callable(callable_id)) => {
+                ingest(&db.callable_shape(callable_id).properties);
+            }
+            _ => {}
+        }
+    }
+    by_name
+        .into_iter()
+        .filter(|(_, entry)| entry.saw_private && entry.parents.len() >= 2)
+        .min_by_key(|(_, entry)| entry.min_declaration_order)
         .map(|(name, _)| name)
 }


### PR DESCRIPTION
When a directly-written intersection (`A & B`) has two or more constituents that declare the same property name and that name is `private` in at least one of them, `tsc` collapses the intersection to `never` and attaches a `TS18032` related-info line to the resulting `TS2339`. tsz already collapsed these intersections to `never` correctly (via `intersection_has_conflicting_private_brands` in the solver interner) but never attached the elaboration — unlike its `TS18031` (literal-conflict) sibling, which was recently implemented.

Structural rule: when a written intersection's constituents declare the same property name with at least one `private` occurrence from a *distinct declaring class*, `tsc` reports `TS18032`; tsz now does the same through a new solver query boundary (`find_private_brand_conflicting_property_across_intersection`) consumed by the checker's `error_reporter::intersection_never_elaboration`.

Declaring-class identity is `PropertyInfo::parent_id`: class-shape construction only rewrites `parent_id` to the owning class for own/overriding members, so a property inherited unchanged through a shared base class keeps the base's `parent_id` in every subclass and correctly does *not* trigger the rule.

## Goal
Goal: hold

## Verification
- Verified against real `typescript@7.0.2` (installed via `scripts/setup/ensure-pinned-typescript.sh`) across 13+ hand-written cases; tsz's `--strict` output now matches `tsc` exactly for every case, including:
  - both-private, private+public, private+protected, three-way-intersection (positive: `TS18032` elaboration attached)
  - both-protected-only, shared-base inheritance, same-class-twice (negative: unchanged `TS2445`/`TS2341`, no elaboration)
- `cargo fmt` — clean
- `cargo clippy -p tsz-checker -p tsz-solver --all-targets -- -D warnings` — clean
- `cargo nextest run -p tsz-checker --lib -E 'test(ts18032) or test(ts18031)'` — 16 passed, 0 failed (new `ts18032_private_brand_intersection_tests.rs`: 7 tests; existing `ts18031_intersection_conflicting_property_tests.rs`: 8 tests, unaffected)
- Not run locally (no TypeScript corpus checked out in this environment): broader `conformance.sh`, `emit/run.sh`, `fourslash/run-fourslash.sh`. This change is additive-only (a new fallback elaboration path gated on the literal-conflict check finding nothing) and narrowly scoped to a previously-unwired diagnostic code, so it should not affect existing conformance/emit/fourslash counts; happy to run these on request or before merge if a reviewer wants belt-and-suspenders confirmation.

**Separately noted, not fixed here (filed on the coordination board for follow-up):** tsz over-collapses `A & B` to `never` when two classes have *different*-named private members with no actual name collision (e.g. `class A { private x }`, `class B { private y }`), where real `tsc` does not collapse at all since there is no property-name collision. That's a solver-level bug in `intersection_has_conflicting_private_brands` (brand-set based, not keyed to whether a specific property name actually collides across constituents) — out of scope for this display-only PR.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_018T48tnkzoDiLndgEgdNSmt)_