### PR TITLE
fix(parser): non-readonly modifiers before an interface/type-literal accessor report TS1131, not TS1070

### DIFF
--- a/crates/tsz-parser/src/parser/state_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_declarations.rs
@@ -310,27 +310,32 @@ impl ParserState {
                 continue;
             }
 
-            // `readonly` directly followed by a `get`/`set` accessor is grammar-invalid
-            // in tsc: no modifier may precede an accessor signature in an interface or
-            // type literal (unlike a plain property/method, which accepts `readonly` and
-            // is validated semantically as TS1024). tsc's parser cannot build any member
-            // starting at `readonly` here, reports TS1131 anchored at the modifier, and
-            // retries from the accessor keyword — which then parses as a bare
-            // (modifier-less) accessor. Handled before the normal property/method path so
-            // `get`/`set` is never mistaken for the property name and `readonly` is never
-            // silently dropped (which previously produced a misleading TS1005).
-            if self.is_token(SyntaxKind::ReadonlyKeyword)
-                && self.look_ahead_is_accessor_after_readonly()
-            {
-                let ro_start = self.token_pos();
-                let ro_end = self.token_end();
-                self.next_token(); // consume `readonly`
-                self.parse_error_at(
-                    ro_start,
-                    ro_end.saturating_sub(ro_start),
-                    tsz_common::diagnostics::diagnostic_messages::PROPERTY_OR_SIGNATURE_EXPECTED,
-                    tsz_common::diagnostics::diagnostic_codes::PROPERTY_OR_SIGNATURE_EXPECTED,
-                );
+            // A run of one or more type-member modifiers directly followed by a
+            // `get`/`set` accessor is grammar-invalid in tsc: no modifier may precede
+            // an accessor signature in an interface or type literal (unlike a plain
+            // property/method, which accepts these modifiers and is validated
+            // semantically as TS1024/TS1070/TS1071). tsc's parser cannot build any
+            // member starting at the first modifier, reports one TS1131 per modifier
+            // in the run (each anchored at its own token), and recovers by retrying
+            // at the accessor keyword — which then parses as a bare (modifier-less)
+            // accessor. See `look_ahead_modifier_run_before_accessor` for the exact
+            // qualifying modifier set. Handled before the normal property/method path
+            // so `get`/`set` is never mistaken for the property name and the
+            // modifiers are never silently dropped (which previously produced a
+            // misleading TS1005 or TS1070).
+            let modifier_run_len = self.look_ahead_modifier_run_before_accessor();
+            if modifier_run_len > 0 {
+                for _ in 0..modifier_run_len {
+                    let mod_start = self.token_pos();
+                    let mod_end = self.token_end();
+                    self.next_token();
+                    self.parse_error_at(
+                        mod_start,
+                        mod_end.saturating_sub(mod_start),
+                        tsz_common::diagnostics::diagnostic_messages::PROPERTY_OR_SIGNATURE_EXPECTED,
+                        tsz_common::diagnostics::diagnostic_codes::PROPERTY_OR_SIGNATURE_EXPECTED,
+                    );
+                }
                 continue;
             }
 

--- a/crates/tsz-parser/src/parser/state_types_advanced.rs
+++ b/crates/tsz-parser/src/parser/state_types_advanced.rs
@@ -1372,24 +1372,26 @@ impl ParserState {
                 return mapped_type;
             }
 
-            // `readonly` directly followed by a `get`/`set` accessor is grammar-invalid
-            // in tsc: no modifier may precede an accessor signature in a type literal,
-            // matching the same restriction in an interface body (see
-            // `parse_type_members`'s identical check). tsc's parser cannot build any
-            // member starting at `readonly` here, reports TS1131 anchored at the
-            // modifier, and retries from the accessor keyword.
-            if self.is_token(SyntaxKind::ReadonlyKeyword)
-                && self.look_ahead_is_accessor_after_readonly()
-            {
-                let ro_start = self.token_pos();
-                let ro_end = self.token_end();
-                self.next_token(); // consume `readonly`
-                self.parse_error_at(
-                    ro_start,
-                    ro_end.saturating_sub(ro_start),
-                    tsz_common::diagnostics::diagnostic_messages::PROPERTY_OR_SIGNATURE_EXPECTED,
-                    tsz_common::diagnostics::diagnostic_codes::PROPERTY_OR_SIGNATURE_EXPECTED,
-                );
+            // A run of one or more type-member modifiers directly followed by a
+            // `get`/`set` accessor is grammar-invalid in tsc, matching the same
+            // restriction in an interface body (see `parse_type_members`'s identical
+            // check and `look_ahead_modifier_run_before_accessor` for the exact
+            // qualifying modifier set). tsc's parser cannot build any member starting
+            // at the first modifier, reports one TS1131 per modifier in the run, and
+            // retries from the accessor keyword.
+            let modifier_run_len = self.look_ahead_modifier_run_before_accessor();
+            if modifier_run_len > 0 {
+                for _ in 0..modifier_run_len {
+                    let mod_start = self.token_pos();
+                    let mod_end = self.token_end();
+                    self.next_token();
+                    self.parse_error_at(
+                        mod_start,
+                        mod_end.saturating_sub(mod_start),
+                        tsz_common::diagnostics::diagnostic_messages::PROPERTY_OR_SIGNATURE_EXPECTED,
+                        tsz_common::diagnostics::diagnostic_codes::PROPERTY_OR_SIGNATURE_EXPECTED,
+                    );
+                }
                 continue;
             }
 
@@ -1901,25 +1903,66 @@ impl ParserState {
         is_property_name
     }
 
-    /// Check if `readonly` (the current token) is directly followed, on the same
-    /// line, by a `get`/`set` accessor signature (`readonly get x()`), as opposed
-    /// to `get`/`set` used as an ordinary property/method name
-    /// (`readonly get(): void`, `readonly get: number`). Used by
-    /// `parse_type_members` to detect tsc's "no modifier before an interface/type
-    /// literal accessor" grammar restriction before the normal readonly-property
-    /// parse path misreads `get`/`set` as the property name.
-    pub(crate) fn look_ahead_is_accessor_after_readonly(&mut self) -> bool {
+    /// Check whether the current token starts a run of one or more type-member
+    /// modifiers directly followed, each on the same line, by a `get`/`set`
+    /// accessor signature (`static get x()`, `public static get x()`,
+    /// `readonly export get x()`, ...), as opposed to a modifier or `get`/`set`
+    /// used as an ordinary property/method name (`static get(): void`,
+    /// `static get: number`). No modifier at all may precede an accessor
+    /// signature in an interface or type-literal body: tsc's parser cannot
+    /// build any member starting at the first modifier, and reports one
+    /// TS1131 per modifier in the run (each anchored at its own token) before
+    /// recovering by retrying at the accessor keyword, which then parses as a
+    /// bare (modifier-less) accessor.
+    ///
+    /// Only `private`/`protected`/`public`/`static`/`accessor`/`export`/
+    /// `readonly` qualify — oracle-verified (`typescript@7.0.2`) to recover
+    /// this way. `declare`/`abstract`/`override`/`in`/`out` are deliberately
+    /// excluded: preceding an accessor, tsc's recovery for those cascades
+    /// into a different diagnostic set (TS1434/TS1005/TS1128) rather than one
+    /// TS1131 per modifier, a distinct and out-of-scope shape. Returns the
+    /// number of modifiers in the qualifying run, or `0` if this token does
+    /// not start one.
+    pub(crate) fn look_ahead_modifier_run_before_accessor(&mut self) -> usize {
+        const fn is_clean_type_member_modifier(kind: SyntaxKind) -> bool {
+            matches!(
+                kind,
+                SyntaxKind::PrivateKeyword
+                    | SyntaxKind::ProtectedKeyword
+                    | SyntaxKind::PublicKeyword
+                    | SyntaxKind::StaticKeyword
+                    | SyntaxKind::AccessorKeyword
+                    | SyntaxKind::ExportKeyword
+                    | SyntaxKind::ReadonlyKeyword
+            )
+        }
+
         let snapshot = self.scanner.save_state();
         let current = self.current_token;
 
-        self.next_token(); // skip `readonly`
-        let is_accessor = !self.scanner.has_preceding_line_break()
+        let mut count = 0usize;
+        loop {
+            if !is_clean_type_member_modifier(self.token())
+                || self.look_ahead_is_property_name_after_keyword()
+            {
+                break;
+            }
+            self.next_token();
+            count += 1;
+            if self.scanner.has_preceding_line_break() {
+                count = 0;
+                break;
+            }
+        }
+
+        let ends_in_accessor = count > 0
             && (self.is_token(SyntaxKind::GetKeyword) || self.is_token(SyntaxKind::SetKeyword))
             && !self.look_ahead_is_property_name_after_keyword();
 
         self.scanner.restore_state(snapshot);
         self.current_token = current;
-        is_accessor
+
+        if ends_in_accessor { count } else { 0 }
     }
 
     /// Check if there is a line break between the current keyword and the next token.

--- a/crates/tsz-parser/tests/type_member_modifier_grammar_tests.rs
+++ b/crates/tsz-parser/tests/type_member_modifier_grammar_tests.rs
@@ -10,28 +10,31 @@
 //!   * `readonly` on a method or construct signature → TS1024
 //!     (`'readonly' modifier can only appear on a property declaration or index
 //!     signature.`), anchored at `readonly`. tsz previously stayed silent.
-//!   * `readonly` directly followed by a `get`/`set` accessor → TS1131
-//!     (`Property or signature expected.`), anchored at `readonly`. No
-//!     modifier may precede an accessor signature in an interface or type
-//!     literal — unlike a plain method, this fails to parse as any member at
-//!     all in tsc, not a semantic TS1024. tsz previously mis-parsed `get`/`set`
-//!     as the property name and reported a spurious TS1005 at the accessor's
-//!     own property name.
+//!   * A run of one or more `private`/`protected`/`public`/`static`/
+//!     `accessor`/`export`/`readonly` modifiers directly followed by a
+//!     `get`/`set` accessor → one TS1131 per modifier in the run (each
+//!     anchored at its own token), then a clean (modifier-less) accessor. No
+//!     modifier at all may precede an accessor signature in an interface or
+//!     type literal — unlike a plain method, this fails to parse as any
+//!     member at all in tsc, not a semantic TS1024/TS1070. tsz previously
+//!     mis-parsed `get`/`set` as the property name (single `readonly`, TS1005)
+//!     or reported the uniform semantic TS1070 (every other modifier in the
+//!     set, single or stacked).
 //!
 //! `readonly` on a property / index signature stays legal, and `export` / `in`
 //! / `out` used as a member *name* (`export: T`, `export(): void`) stay clean —
 //! matching tsc. `import` / `const` / `default` are not type-member modifiers in
 //! tsc (they take a parser-recovery path) and are intentionally not covered.
 //!
-//! Left as follow-up (a separate, larger defect, not fixed here): tsc rejects
-//! *any* modifier before an interface/type-literal accessor with the same
-//! TS1131-plus-retry parse failure — `static`/`public`/`declare`/`abstract` all
-//! reproduce it (with `declare`/`abstract` additionally cascading into
-//! TS1434/TS1005/TS1128 on tsc, since the retry re-parses the accessor's own
-//! name as a fresh statement). tsz currently reports the uniform semantic
-//! TS1070 for those instead. A stacked-modifier chain before an accessor
-//! (`export readonly get x()`) is also unfixed. Both are pre-existing,
-//! unrelated code paths that this change does not touch.
+//! Left as follow-up (a separate, larger defect, not fixed here): `declare`/
+//! `abstract`/`override`/`in`/`out` before an interface/type-literal accessor
+//! also fail to parse in tsc, but the recovery is a different shape entirely —
+//! it cascades into TS1434/TS1005/TS1128 (the retry re-parses the accessor's
+//! own name as a fresh top-level statement) rather than a single TS1131 per
+//! modifier. tsz still reports the uniform semantic TS1070 for those; they are
+//! deliberately excluded from the qualifying modifier set (see
+//! `look_ahead_modifier_run_before_accessor`), a pre-existing, unrelated code
+//! path this change does not touch.
 
 use crate::parser::test_fixture::parse_source;
 use tsz_common::diagnostics::diagnostic_codes;
@@ -482,4 +485,148 @@ fn multi_modifier_run_is_not_keyed_to_a_binder_name() {
     ] {
         assert_eq!(codes(src), vec![TS1070], "structural rule: {src}");
     }
+}
+
+// ---------------------------------------------------------------------------
+// Any "clean" modifier (not just `readonly`) directly before an accessor:
+// one TS1131, anchored at the modifier, then a clean accessor retry.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn clean_modifiers_before_accessor_report_ts1131_not_ts1070() {
+    for modifier in [
+        "private",
+        "protected",
+        "public",
+        "static",
+        "accessor",
+        "export",
+    ] {
+        let source = format!("interface I {{ {modifier} get x(): number; }}");
+        assert_eq!(codes(&source), vec![TS1131], "modifier `{modifier}`");
+
+        let source = format!("interface I {{ {modifier} set x(v: number); }}");
+        assert_eq!(codes(&source), vec![TS1131], "modifier `{modifier}` (set)");
+    }
+}
+
+#[test]
+fn clean_modifier_before_accessor_on_type_literal_reports_ts1131() {
+    assert_eq!(codes("type T = { static get x(): number; };"), vec![TS1131],);
+}
+
+#[test]
+fn clean_modifier_before_accessor_recovers_a_working_accessor() {
+    // Exactly one diagnostic; the accessor itself is not lost to a cascade,
+    // and a following member still parses.
+    assert_eq!(
+        codes("interface I { static get x(): number; y: string; }"),
+        vec![TS1131],
+    );
+}
+
+#[test]
+fn stacked_clean_modifiers_before_accessor_report_one_ts1131_each() {
+    // tsc reports a SEPARATE TS1131 per modifier in the run — unlike the
+    // TS1070 family, this one does not collapse to a single diagnostic naming
+    // only the first modifier.
+    assert_eq!(
+        fingerprints("interface I { public static get x(): number; }"),
+        vec![
+            (TS1131, 1, 15, "Property or signature expected.".to_string(),),
+            (TS1131, 1, 22, "Property or signature expected.".to_string(),),
+        ],
+    );
+}
+
+#[test]
+fn three_stacked_clean_modifiers_before_accessor_report_three_ts1131() {
+    assert_eq!(
+        codes("interface I { export static readonly get x(): number; }"),
+        vec![TS1131, TS1131, TS1131],
+    );
+}
+
+#[test]
+fn readonly_mixed_into_a_clean_modifier_run_before_accessor_still_reports_each() {
+    // `readonly` participates in the run like any other clean modifier when
+    // it is not the sole/first modifier — distinct from the dedicated
+    // single-`readonly` case, but going through the same generalized path.
+    assert_eq!(
+        codes("interface I { static readonly get x(): number; }"),
+        vec![TS1131, TS1131],
+    );
+    assert_eq!(
+        codes("interface I { readonly static get x(): number; }"),
+        vec![TS1131, TS1131],
+    );
+}
+
+#[test]
+fn clean_modifier_run_is_not_keyed_to_a_binder_name() {
+    // Structural, not tied to any identifier spelling (renamed binders + a
+    // stacked run, in one pass).
+    assert_eq!(
+        codes("interface Alpha { static get beta(): number; }"),
+        vec![TS1131],
+    );
+    assert_eq!(
+        codes("type Gamma = { public static get delta(): number; };"),
+        vec![TS1131, TS1131],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cascade-shaped modifiers stay OUT of scope: `declare`/`abstract`/`override`/
+// `in`/`out` before an accessor keep reporting the pre-existing semantic
+// TS1070, not the new TS1131 path (see the module doc comment).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cascade_modifiers_before_accessor_still_report_ts1070_not_ts1131() {
+    for modifier in ["declare", "abstract", "override"] {
+        let source = format!("interface I {{ {modifier} get x(): number; }}");
+        assert_eq!(codes(&source), vec![TS1070], "modifier `{modifier}`");
+    }
+}
+
+#[test]
+fn in_out_before_accessor_on_generic_interface_still_report_ts1070() {
+    for modifier in ["in", "out"] {
+        let source = format!("interface I<T> {{ {modifier} get x(): number; }}");
+        assert_eq!(codes(&source), vec![TS1070], "modifier `{modifier}`");
+    }
+}
+
+#[test]
+fn cascade_modifier_poisons_a_run_with_a_leading_clean_modifier() {
+    // `declare` anywhere in the run keeps the WHOLE run out of the TS1131
+    // path, even when a clean modifier (`static`) leads it — matches tsc,
+    // where the clean modifier still fails to recover once `declare` follows
+    // (tsc itself reports a 5-diagnostic TS1131/TS1128/TS1434/TS1005/TS1128
+    // cascade for this exact shape). tsz's existing (unrelated, pre-existing)
+    // multi-modifier TS1070 handling consumes the whole illegal-modifier run
+    // and reports once, which this change does not touch or improve.
+    assert_eq!(
+        codes("interface I { static declare get x(): number; }"),
+        vec![TS1070],
+    );
+}
+
+#[test]
+fn line_break_before_accessor_is_unaffected_for_any_clean_modifier() {
+    // A line break between the last modifier and `get`/`set` takes tsc down a
+    // different (out-of-scope) ASI path; the lookahead must not fire.
+    let with_break = "interface I {\n  static\n  get x(): number\n}";
+    let without_break = "interface I {\n  static get x(): number\n}";
+    assert_ne!(codes(with_break), codes(without_break));
+}
+
+#[test]
+fn clean_modifier_used_as_accessor_own_name_stays_ts1070() {
+    // `static get(): number` — a method literally *named* `get`, not an
+    // accessor — is unaffected by the new lookahead and keeps the pre-existing
+    // semantic TS1070.
+    assert_eq!(codes("interface I { static get(): number; }"), vec![TS1070]);
+    assert_eq!(codes("interface I { static get: number; }"), vec![TS1070]);
 }


### PR DESCRIPTION
When a run of one or more `private`/`protected`/`public`/`static`/`accessor`/`export`/`readonly` type-member modifiers is directly followed, on the same line, by a `get`/`set` accessor signature in an interface or type-literal body, no modifier at all may precede the accessor in tsc's grammar. tsc's parser cannot build any member starting at the first modifier: it reports one TS1131 (`Property or signature expected.`) per modifier in the run, each anchored at its own token, then recovers by retrying at the accessor keyword, which parses as a clean, modifier-less accessor.

tsz previously reported the uniform semantic TS1070 (`'{0}' modifier cannot appear on a type member.`) for every modifier in this position except `readonly` (fixed for the single-modifier case by #16803), and would have collapsed a stacked modifier run to a single diagnostic instead of one TS1131 per modifier.

Closes the first of three follow-ups named on #16803's own scope-out, itself part of #16291.

## Structural rule

When an interface/type-literal member begins with a run of clean type-member modifiers immediately followed by an accessor keyword on the same line, tsc fails the whole member at the first modifier (TS1131 × N) through its member-dispatch grammar; tsz now does the same through a generalized lookahead (`look_ahead_modifier_run_before_accessor`, `state_types_advanced.rs`) that subsumes and replaces the `readonly`-only lookahead #16803 introduced, shared by both owner loops (`parse_type_members` for interfaces, `parse_type_literal_rest` for type literals, both in the parser).

`declare`/`abstract`/`override`/`in`/`out` are deliberately excluded from the qualifying modifier set: oracle-verified against `typescript@7.0.2`, those cascade into a different diagnostic shape (TS1434/TS1005/TS1128, as if the retry re-parses the accessor's own name as a fresh top-level statement) rather than one TS1131 per modifier. They keep reporting the pre-existing TS1070 unchanged — a distinct, harder problem, out of scope here and named as a follow-up in the module doc comment.

| source | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `interface I { static get x(): number }` | TS1131 | TS1070 | TS1131 |
| `interface I { public static get x(): number }` | TS1131, TS1131 (one per modifier) | TS1070 (one, on `public`) | TS1131, TS1131 |
| `type T = { static get x(): number };` | TS1131 | TS1070 | TS1131 |
| `interface I { declare get x(): number }` | TS1131 + TS1434/TS1005/TS1128 cascade | TS1070 | TS1070 (unchanged, out of scope) |
| `interface I<T> { in get x(): number }` | TS1131 + cascade | TS1070 | TS1070 (unchanged, out of scope) |
| `interface I { static get(): number }` (method named `get`) | TS1070 | TS1070 | TS1070 (unchanged) |
| `interface I { static get: number }` (property named `get`) | TS1070 | TS1070 | TS1070 (unchanged) |

Rebased onto main after #16804 (a sibling type-member-modifier PR) landed and moved the shared `parse_type_member_visibility_modifier_error` into its own module. That function is a different call site from the one this change touches (both loops' pre-member-dispatch accessor check, checked earlier in each loop), so the two changes are independent and merged without semantic conflict — confirmed by re-running the full local verification post-rebase. One existing adjacent-case test's expected diagnostic set (`static declare get x(): number`) was updated to match #16804's now-collapsed single-TS1070-per-run behavior for the pre-existing, still out-of-scope cascade family.

## Goal

Goal: hold

## Verification

- New adjacent-case tests in `crates/tsz-parser/tests/type_member_modifier_grammar_tests.rs` (12 cases), all oracle-verified against `typescript@7.0.2`: each clean modifier alone before `get`/`set`, the type-literal variant, stacked 2- and 3-modifier runs (each modifier gets its own TS1131), `readonly` mixed into a multi-modifier run, cascade modifiers (`declare`/`abstract`/`override`/`in`/`out`) confirmed unchanged at TS1070, a cascade modifier poisoning a run that starts with a clean modifier, line-break non-interference, and the get/set-as-property-name negative control.
- `cargo test -p tsz-parser --lib`: 2041 passed, 0 failed (47 in the extended `type_member_modifier_grammar_tests` module, 12 new).
- `cargo test -p tsz-checker --lib -- interface_member type_member modifier_grammar`: 72 passed, 0 failed.
- `cargo clippy -p tsz-parser --all-targets`: clean.
- `cargo fmt -p tsz-parser --check`: clean (no diff).
- `python3 scripts/arch/arch_guard.py`: passed.
- Parser-only grammar change on a rare syntax shape (a modifier directly before an interface/type-literal accessor); no emit/DTS surface touched, conformance/fourslash movement not expected.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: Mica