### PR TITLE
fix(parser): stop over-reporting TS1029 for the async/readonly/accessor pair

### DIFF
--- a/crates/tsz-parser/src/parser/state_statements_class_members.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class_members.rs
@@ -162,16 +162,18 @@ impl ParserState {
                         diagnostic_codes::MODIFIER_ALREADY_SEEN,
                     );
                 }
-                if seen_readonly || seen_override || seen_accessor || seen_async {
+                // `readonly` and `async` are excluded from this ordering
+                // check: `abstract` and `readonly` legally coexist in either
+                // order (a `readonly abstract` property is clean in tsc), and
+                // `abstract`/`async` never coexist at all (tsc rejects the
+                // combination outright with TS1243 regardless of order, not
+                // this ordering diagnostic).
+                if seen_override || seen_accessor {
                     use tsz_common::diagnostics::diagnostic_codes;
                     let other = if seen_override {
                         "override"
-                    } else if seen_readonly {
-                        "readonly"
-                    } else if seen_accessor {
-                        "accessor"
                     } else {
-                        "async"
+                        "accessor"
                     };
                     self.parse_error_at_current_token(
                         &format!("'abstract' modifier must precede '{other}' modifier."),
@@ -198,13 +200,11 @@ impl ParserState {
                         "'readonly' modifier cannot be used with 'accessor' modifier.",
                         diagnostic_codes::MODIFIER_CANNOT_BE_USED_WITH_MODIFIER,
                     );
-                } else if seen_async {
-                    use tsz_common::diagnostics::diagnostic_codes;
-                    self.parse_error_at_current_token(
-                        "'readonly' modifier must precede 'async' modifier.",
-                        diagnostic_codes::MODIFIER_MUST_PRECEDE_MODIFIER,
-                    );
                 }
+                // No `seen_async` ordering check here: `readonly` (data-member
+                // only) and `async` (method-only) never share a legal member
+                // kind, so tsc never reaches this ordering diagnostic for the
+                // pair — the member's own TS1024/TS1042 already covers it.
                 seen_readonly = true;
             } else if current_kind == SyntaxKind::OverrideKeyword {
                 // Check for duplicate override modifier
@@ -271,13 +271,10 @@ impl ParserState {
                         diagnostic_codes::MODIFIER_CANNOT_BE_USED_WITH_MODIFIER,
                     );
                 }
-                if seen_async {
-                    use tsz_common::diagnostics::diagnostic_codes;
-                    self.parse_error_at_current_token(
-                        "'accessor' modifier must precede 'async' modifier.",
-                        diagnostic_codes::MODIFIER_MUST_PRECEDE_MODIFIER,
-                    );
-                }
+                // No `seen_async` ordering check here: `accessor` (data-member
+                // only) and `async` (method-only) never share a legal member
+                // kind, so tsc never reaches this ordering diagnostic for the
+                // pair — the member's own TS1042 already covers it.
                 seen_accessor = true;
             } else if current_kind == SyntaxKind::AsyncKeyword {
                 // Check for duplicate async modifier

--- a/crates/tsz-parser/tests/modifier_ordering_tests.rs
+++ b/crates/tsz-parser/tests/modifier_ordering_tests.rs
@@ -147,6 +147,147 @@ fn accessor_readonly_emits_ts1243_without_ts1029() {
 }
 
 // =========================================================================
+// TS1029: `async` never legally coexists with `readonly`/`accessor`
+// (function-only vs data-member-only modifiers), and `readonly` legally
+// coexists with `abstract` in EITHER order — tsc never reaches the ordering
+// diagnostic in any of these shapes, matching only the member's own
+// TS1024/TS1042/TS1243. Oracle-verified against typescript@7.0.2 (#16553
+// coordination-board thread).
+// =========================================================================
+
+#[test]
+fn readonly_async_property_no_ts1029() {
+    // `readonly` before `async` on a property: tsc reports only TS1042
+    // ('async' cannot be used here); it never reaches the ordering check
+    // because `async` is illegal on a property regardless of order.
+    let source = "class C { readonly async p: number = 1; }";
+    let diagnostics = parse_diagnostics(source);
+    assert!(
+        !has_error(source, 1029),
+        "`readonly async` on a property should not produce TS1029: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn async_readonly_method_no_ts1029() {
+    // `async` before `readonly` on a method: tsc reports only TS1024
+    // ('readonly' cannot appear on a method); still no ordering diagnostic.
+    let source = "class C { async readonly m(): Promise<number> { return 1; } }";
+    let diagnostics = parse_diagnostics(source);
+    assert!(
+        !has_error(source, 1029),
+        "`async readonly` on a method should not produce TS1029: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn async_accessor_property_no_ts1029() {
+    // `async` before `accessor`: tsc reports only TS1042; `async` never
+    // legally applies to an auto-accessor property.
+    let source = "class C { async accessor p: number = 1; }";
+    let diagnostics = parse_diagnostics(source);
+    assert!(
+        !has_error(source, 1029),
+        "`async accessor` should not produce TS1029: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn readonly_abstract_property_no_ts1029() {
+    // `readonly` before `abstract`: legal in tsc in EITHER order on an
+    // abstract property (unlike `override`/`accessor`, which are genuinely
+    // order-constrained relative to `abstract`), so no TS1029 either way.
+    let source = "abstract class C { readonly abstract p: number; }";
+    let diagnostics = parse_diagnostics(source);
+    assert!(
+        !has_error(source, 1029),
+        "`readonly abstract` should not produce TS1029 — both orders are legal: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn abstract_readonly_property_no_ts1029() {
+    let source = "abstract class C { abstract readonly p: number; }";
+    let diagnostics = parse_diagnostics(source);
+    assert!(
+        !has_error(source, 1029),
+        "`abstract readonly` should not produce TS1029: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn abstract_async_method_no_ts1029() {
+    // `async` before `abstract`: tsc reports only TS1243 ('async' cannot be
+    // used with 'abstract') — never the ordering diagnostic, since an
+    // abstract member can never have a body an `async` modifier would apply
+    // to. TS1243 itself is a checker-level (not parser-level) diagnostic, so
+    // it is not asserted here — see `crates/tsz-checker`'s modifier-grammar
+    // suite for that half.
+    let source = "abstract class C { async abstract m(): Promise<number>; }";
+    let diagnostics = parse_diagnostics(source);
+    assert!(
+        !has_error(source, 1029),
+        "`async abstract` should not produce TS1029: {diagnostics:?}"
+    );
+}
+
+// Regression guard: unlike `abstract`/`readonly` above, `abstract`/`override`
+// and `abstract`/`accessor` ARE genuinely order-constrained (`abstract` must
+// come first) and must keep reporting TS1029 in the wrong order — only the
+// `readonly`/`async` triggers were removed from the `abstract` branch's
+// ordering check, not `override`/`accessor`.
+
+#[test]
+fn abstract_override_correct_order_no_ts1029() {
+    let source = r"
+class B { m(): void {} }
+abstract class D extends B {
+    abstract override m(): void;
+}
+";
+    assert!(
+        !has_error(source, 1029),
+        "`abstract override` is the correct order and must not produce TS1029: {:?}",
+        parse_diagnostics(source)
+    );
+}
+
+#[test]
+fn override_abstract_wrong_order_still_ts1029() {
+    let source = r"
+class B { m(): void {} }
+abstract class D extends B {
+    override abstract m(): void;
+}
+";
+    assert!(
+        has_error(source, 1029),
+        "`override abstract` (wrong order) must still produce TS1029: {:?}",
+        parse_diagnostics(source)
+    );
+}
+
+#[test]
+fn abstract_accessor_correct_order_no_ts1029() {
+    let source = "abstract class C { abstract accessor p: number; }\n";
+    assert!(
+        !has_error(source, 1029),
+        "`abstract accessor` is the correct order and must not produce TS1029: {:?}",
+        parse_diagnostics(source)
+    );
+}
+
+#[test]
+fn accessor_abstract_wrong_order_still_ts1029() {
+    let source = "abstract class C { accessor abstract p: number; }\n";
+    assert!(
+        has_error(source, 1029),
+        "`accessor abstract` (wrong order) must still produce TS1029: {:?}",
+        parse_diagnostics(source)
+    );
+}
+
+// =========================================================================
 // TS1040: override in ambient context (declare)
 // =========================================================================
 


### PR DESCRIPTION
`async`/`readonly`/`accessor` class-member modifier ordering: tsc's `checkGrammarModifiers` never reaches the "X must precede async" ordering diagnostic (TS1029) for `readonly`/`async` or `accessor`/`async` — `async` is legal only on methods/accessors-as-functions, while `readonly`/`accessor` are legal only on data-member declarations, so the two families never share a legal member kind and the ordering check is structurally unreachable in real tsc (confirmed against `typescript@7.0.2` across property + method witnesses, both directions: `readonly async p: number` → tsc reports only TS1042; `async readonly m()` → tsc reports only TS1024; same for `accessor`). tsz emitted a spurious extra TS1029 alongside the correct code anyway.

Same defect, different trigger, in the `abstract` branch: `abstract`/`async` never coexist either (tsc rejects the pair outright via TS1243, not an ordering check), and `abstract`/`readonly` legally coexist in *either* order (no ordering constraint at all — `readonly abstract p: number;` is clean in tsc) — but the combined trigger condition treated both as ordering violations. `abstract`/`override` and `abstract`/`accessor` remain genuinely order-constrained (verified both directions) and are untouched.

## Structural rule
When two class-member modifiers can never both be syntactically legal on the same member kind (e.g. a function-only modifier and a data-member-only modifier), tsc's modifier-ordering grammar check (TS1029) never fires for that pair — the member's own kind-specific rejection (TS1024/TS1042/TS1243) already covers it. tsz does this through the parser's per-modifier-keyword ordering walk in `crates/tsz-parser/src/parser/state_statements_class_members.rs`.

## Adjacent matrix (oracle-verified, `typescript@7.0.2`)

| source | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `readonly async p: number = 1;` | TS1042 only | TS1042 + TS1029 | TS1042 only |
| `async readonly m(): Promise<number> {}` | TS1024 only | TS1024 + TS1029 | TS1024 only |
| `async accessor p: number = 1;` | TS1042 only | TS1042 + TS1029 | TS1042 only |
| `readonly abstract p: number;` | clean (readonly) | TS1029 (false) | clean |
| `abstract readonly p: number;` | clean (readonly) | clean | clean (unchanged) |
| `async abstract m(): Promise<number>;` | TS1243 only | TS1243 + TS1029 | TS1243 only |
| `abstract override m(): void;` (correct order) | clean | clean | clean (unchanged, regression guard) |
| `override abstract m(): void;` (wrong order) | TS1029 | TS1029 | TS1029 (unchanged, regression guard) |
| `abstract accessor p: number;` (correct order) | clean | clean | clean (unchanged, regression guard) |
| `accessor abstract p: number;` (wrong order) | TS1029 | TS1029 | TS1029 (unchanged, regression guard) |

## Goal
Goal: hold

## Verification
- 10 new oracle-verified tests in `crates/tsz-parser/tests/modifier_ordering_tests.rs` covering both directions of readonly/async, accessor/async, abstract/readonly, plus regression guards that abstract/override and abstract/accessor still fire correctly.
- `cargo test -p tsz-parser --lib`: 2020 passed, 0 failed (was 2010).
- `cargo test -p tsz-checker --lib -- member_modifier_placement class_member_modifier_grammar`: 24 passed, 0 failed (no regressions in the sibling checker-level modifier suite).
- `cargo clippy -p tsz-parser --all-targets -- -D warnings`: clean.
- `cargo fmt -p tsz-parser -- --check`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.
- Parser-only diff (no `crates/**/src` outside `tsz-parser`), narrow grammar-only change on a rare misordered-modifier shape — conformance/emit/fourslash not run locally this session; no code-set or count movement expected (matches the 0/0 signature already measured for the sibling modifier-grammar PRs merged earlier today, e.g. #16789, #16795, #16803, #16804).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium

---
_Generated by [Claude Code](https://claude.ai/code/session_01XD2NL5LQHxEQYK5xViZcHD)_