### PR TITLE
fix(solver): TS18032 multi-conflict elaboration names tsc's first-declared property

### DIFF
--- a/crates/tsz-checker/src/tests/ts18032_intersection_private_brand_conflict_tests.rs
+++ b/crates/tsz-checker/src/tests/ts18032_intersection_private_brand_conflict_tests.rs
@@ -168,6 +168,106 @@ anything.other;
 }
 
 // ---------------------------------------------------------------------------
+// Multi-conflict ordering: when more than one property qualifies (declared in
+// two or more members, private in at least one), tsc names the first one by a
+// combined declaration order — the same walk `elaborateNeverIntersection`
+// uses for TS18031: members left to right, and within each member its own
+// properties in declaration order, positioning each name at its *first*
+// occurrence. The pick is independent of alphabetical order, of which property
+// was accessed, and of a later member's own declaration order.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn multi_conflict_names_first_declared_private_property() {
+    // Both `x` and `y` are private in both members; `x` is declared first, so
+    // `x` wins even though the access is on `x` itself.
+    let diags = check_source_strict(
+        r#"
+class A { private x: string = ""; private y: string = ""; }
+class B { private x: string = ""; private y: string = ""; }
+declare const c: A & B;
+c.x;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18032).as_deref(),
+        Some(
+            "The intersection 'A & B' was reduced to 'never' because property 'x' exists in multiple constituents and is private in some."
+        ),
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn multi_conflict_order_follows_declaration_order_not_alphabetical() {
+    // Source order is `zz` then `aa` (reverse of alphabetical); the winner is
+    // `zz`, proving the pick is declaration order, not name order — the same
+    // guarantee the sibling TS18031 rule makes.
+    let diags = check_source_strict(
+        r#"
+class P { private zz: string = ""; private aa: string = ""; }
+class Q { private zz: string = ""; private aa: string = ""; }
+declare const r: P & Q;
+r.zz;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18032).as_deref(),
+        Some(
+            "The intersection 'P & Q' was reduced to 'never' because property 'zz' exists in multiple constituents and is private in some."
+        ),
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn multi_conflict_order_ignores_second_members_declaration_order() {
+    // `A` declares `y` before `x`; `B` declares `x` before `y`. tsc uses the
+    // FIRST member's order, so `y` wins even though the access is on `x`.
+    let diags = check_source_strict(
+        r#"
+class A { private y: string = ""; private x: string = ""; }
+class B { private x: string = ""; private y: string = ""; }
+declare const c: A & B;
+c.x;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18032).as_deref(),
+        Some(
+            "The intersection 'A & B' was reduced to 'never' because property 'y' exists in multiple constituents and is private in some."
+        ),
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn multi_conflict_skips_non_conflicting_private_and_names_first_shared_private() {
+    // `A`'s `solo` is private but declared in only one member — it never
+    // conflicts, so it is skipped. `shared` (private in both) is the first
+    // name that qualifies, even though `solo` is declared before it.
+    let diags = check_source_strict(
+        r#"
+class A { private solo: string = ""; private shared: string = ""; }
+class B { private shared: string = ""; }
+declare const c: A & B;
+c.shared;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18032).as_deref(),
+        Some(
+            "The intersection 'A & B' was reduced to 'never' because property 'shared' exists in multiple constituents and is private in some."
+        ),
+        "got {diags:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Negative / control cases: no TS18032 elaboration.
 // ---------------------------------------------------------------------------
 

--- a/crates/tsz-solver/src/type_queries/data/intersection_conflict.rs
+++ b/crates/tsz-solver/src/type_queries/data/intersection_conflict.rs
@@ -8,6 +8,46 @@ use crate::types::TypeId;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tsz_common::interner::Atom;
 
+/// Invoke `visit` once per property of the intersection's object/callable
+/// members, in *combined declaration order*: members left to right, and within
+/// each member its own properties sorted by `declaration_order` (since
+/// `ObjectShape::properties` is `Atom`-id-sorted for canonical hashing and so
+/// does not preserve source order). Intrinsic and non-object members carry no
+/// properties and are skipped.
+///
+/// This owns the ordered member-walk that both the `TS18031` and `TS18032`
+/// elaboration queries fold into their own first-seen accumulators — the
+/// combined declaration order is the property `tsc`'s `elaborateNeverIntersection`
+/// depends on for both diagnostics, so it lives in one place rather than being
+/// re-established identically in each query.
+fn for_each_member_property_in_declaration_order(
+    db: &dyn TypeDatabase,
+    members: &[TypeId],
+    mut visit: impl FnMut(&crate::types::PropertyInfo),
+) {
+    let mut visit_member = |properties: &[crate::types::PropertyInfo]| {
+        let mut ordered: Vec<&crate::types::PropertyInfo> = properties.iter().collect();
+        ordered.sort_by_key(|prop| prop.declaration_order);
+        for prop in ordered {
+            visit(prop);
+        }
+    };
+    for &member in members {
+        if member.is_intrinsic() {
+            continue;
+        }
+        match db.lookup(member) {
+            Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => {
+                visit_member(&db.object_shape(shape_id).properties);
+            }
+            Some(TypeData::Callable(callable_id)) => {
+                visit_member(&db.callable_shape(callable_id).properties);
+            }
+            _ => {}
+        }
+    }
+}
+
 /// The property name whose required occurrences across `members` are literal
 /// values from mutually exclusive value-sets — the shape `tsc` reports as
 /// `TS18031` (`The intersection '{0}' was reduced to 'never' because
@@ -54,43 +94,25 @@ pub fn find_disjoint_literal_property_across_intersection(
     let mut excluded: FxHashSet<Atom> = FxHashSet::default();
     let mut order: Vec<Atom> = Vec::new();
     let mut seen: FxHashSet<Atom> = FxHashSet::default();
-    let mut ingest = |properties: &[crate::types::PropertyInfo]| {
-        let mut by_declaration_order: Vec<&crate::types::PropertyInfo> =
-            properties.iter().collect();
-        by_declaration_order.sort_by_key(|prop| prop.declaration_order);
-        for prop in by_declaration_order {
-            if seen.insert(prop.name) {
-                order.push(prop.name);
-            }
-            if prop.optional || excluded.contains(&prop.name) {
-                continue;
-            }
-            let Some(TypeData::Literal(value)) = db.lookup(prop.type_id) else {
-                // A non-literal (or absent) required occurrence could still
-                // conflict via the fuller `TypeInterner`-internal analysis,
-                // but this helper only recognizes the single-literal shape —
-                // drop the whole name rather than guess at a partial match.
-                excluded.insert(prop.name);
-                by_name.remove(&prop.name);
-                continue;
-            };
-            by_name.entry(prop.name).or_default().insert(value);
+    let ingest = |prop: &crate::types::PropertyInfo| {
+        if seen.insert(prop.name) {
+            order.push(prop.name);
         }
+        if prop.optional || excluded.contains(&prop.name) {
+            return;
+        }
+        let Some(TypeData::Literal(value)) = db.lookup(prop.type_id) else {
+            // A non-literal (or absent) required occurrence could still
+            // conflict via the fuller `TypeInterner`-internal analysis,
+            // but this helper only recognizes the single-literal shape —
+            // drop the whole name rather than guess at a partial match.
+            excluded.insert(prop.name);
+            by_name.remove(&prop.name);
+            return;
+        };
+        by_name.entry(prop.name).or_default().insert(value);
     };
-    for &member in members {
-        if member.is_intrinsic() {
-            continue;
-        }
-        match db.lookup(member) {
-            Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => {
-                ingest(&db.object_shape(shape_id).properties);
-            }
-            Some(TypeData::Callable(callable_id)) => {
-                ingest(&db.callable_shape(callable_id).properties);
-            }
-            _ => {}
-        }
-    }
+    for_each_member_property_in_declaration_order(db, members, ingest);
     order
         .into_iter()
         .find(|name| by_name.get(name).is_some_and(|values| values.len() >= 2))
@@ -120,42 +142,46 @@ pub fn find_disjoint_literal_property_across_intersection(
 /// text alone (as the modifier-`private` case does) would wrongly treat
 /// same-spelled `#`-private fields from different classes as one
 /// conflicting name.
+///
+/// When more than one property name qualifies (each declared in two or more
+/// members with at least one modifier-`private` occurrence), tsc names the
+/// first one by the same combined declaration order as
+/// [`find_disjoint_literal_property_across_intersection`]: both diagnostics
+/// are produced by `elaborateNeverIntersection`, which walks
+/// `getPropertiesOfUnionOrIntersectionType` — members left to right, each
+/// member's own properties in declaration order, positioning each name at its
+/// *first* occurrence across all members — and returns the first match. So
+/// this reads each property's `declaration_order` field (excluded from
+/// hashing, backfilled by the interner from source insertion order) rather
+/// than `ObjectShape::properties`'s `Atom`-id-sorted `Vec` position, which
+/// does not recover written order.
 pub fn find_private_brand_conflict_property(
     db: &dyn TypeDatabase,
     members: &[TypeId],
 ) -> Option<Atom> {
     let mut occurrences: FxHashMap<Atom, (u32, bool)> = FxHashMap::default();
-    let mut ingest = |properties: &[crate::types::PropertyInfo]| {
-        for prop in properties {
-            let name = db.resolve_atom(prop.name);
-            if name.starts_with("__private_brand_")
-                || crate::utils::is_es_private_identifier_name(&name)
-            {
-                continue;
-            }
-            let entry = occurrences.entry(prop.name).or_insert((0, false));
-            entry.0 += 1;
-            if prop.visibility == crate::types::Visibility::Private {
-                entry.1 = true;
-            }
+    let mut order: Vec<Atom> = Vec::new();
+    let mut seen: FxHashSet<Atom> = FxHashSet::default();
+    let ingest = |prop: &crate::types::PropertyInfo| {
+        let name = db.resolve_atom(prop.name);
+        if name.starts_with("__private_brand_")
+            || crate::utils::is_es_private_identifier_name(&name)
+        {
+            return;
+        }
+        if seen.insert(prop.name) {
+            order.push(prop.name);
+        }
+        let entry = occurrences.entry(prop.name).or_insert((0, false));
+        entry.0 += 1;
+        if prop.visibility == crate::types::Visibility::Private {
+            entry.1 = true;
         }
     };
-    for &member in members {
-        if member.is_intrinsic() {
-            continue;
-        }
-        match db.lookup(member) {
-            Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => {
-                ingest(&db.object_shape(shape_id).properties);
-            }
-            Some(TypeData::Callable(callable_id)) => {
-                ingest(&db.callable_shape(callable_id).properties);
-            }
-            _ => {}
-        }
-    }
-    occurrences
-        .into_iter()
-        .find(|(_, (count, saw_private))| *count >= 2 && *saw_private)
-        .map(|(name, _)| name)
+    for_each_member_property_in_declaration_order(db, members, ingest);
+    order.into_iter().find(|name| {
+        occurrences
+            .get(name)
+            .is_some_and(|(count, saw_private)| *count >= 2 && *saw_private)
+    })
 }


### PR DESCRIPTION
When a directly-written object intersection reduces to `never` because of a private-brand conflict, tsc's `elaborateNeverIntersection` names the **first-declared** conflicting property in *combined declaration order* — members left to right, each member's own properties in declaration order, positioning each name at its first occurrence — and tsz named an arbitrary one. This is the TS18032 sibling of the TS18031 bug already fixed in #16793; it was the remaining, explicitly-unclaimed half of #16790.

## Structural rule
When an intersection reduces to `never` from a private-brand conflict and more than one property qualifies (declared in ≥2 members, private in at least one), tsc names the first such property by combined declaration order — independent of which property was accessed and of alphabetical order. Both TS18031 and TS18032 are produced by the same `elaborateNeverIntersection` walk over `getPropertiesOfUnionOrIntersectionType`, so they share the ordering rule. tsz did this through the solver query `find_private_brand_conflict_property` (`crates/tsz-solver/src/type_queries/data/intersection_conflict.rs`), which returned `FxHashMap::into_iter().find(...)` — arbitrary hash-bucket order that matched tsc only by coincidence.

Owner layer: solver (diagnostic-elaboration query). No checker/emitter behavior changes; the primary `TS2339`/`never` result is unchanged, only the related-info property name.

## Fix
- `find_private_brand_conflict_property` now folds properties in combined declaration order (via each `PropertyInfo`'s `declaration_order`, since `ObjectShape::properties` is `Atom`-id-sorted for canonical hashing and cannot recover written order) and returns the first name that qualifies — mirroring #16793's TS18031 fix.
- Extracted the combined-declaration-order member-walk that #16793 established for TS18031 and this fix needs for TS18032 into a shared `for_each_member_property_in_declaration_order` helper, so the ordering guarantee lives in one documented place instead of being re-established identically in each query.

## Adjacent-case matrix (new tests)
- `x` before `y`, both private in both members → names `x` (first-declared, not the accessed one).
- Reverse-alphabetical source order (`zz` before `aa`) → names `zz` (declaration order, not alphabetical).
- First member declares `y` before `x`, second the reverse → names `y` (first member's order wins).
- A non-conflicting private (`solo`, in one member only) is skipped; first *shared* private (`shared`) wins even though declared later.
- Renamed binders keep the same behavior (structural, not name-keyed).
- Existing negative controls (protected-only, ES `#`-private, self-intersection, alias indirection) preserved.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib ts18032` → 13 passed (9 existing + 4 new multi-conflict ordering)
- `cargo test -p tsz-checker --lib ts18031` → 12 passed (sibling unaffected)
- `cargo test -p tsz-checker --lib intersection` → 281 passed
- `cargo test -p tsz-solver --lib intersection_conflict` → passed
- `cargo clippy -p tsz-solver -p tsz-checker` → clean; pre-commit arch-size guard passed (both files < 2000 lines)

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

Closes #16790

---
_Generated by [Claude Code](https://claude.ai/code/session_01494ZKBC29ofh1AMLAdvrST)_