### PR TITLE
fix(checker): TS2815 for `arguments` only inside an enclosing function

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1029,6 +1029,9 @@ path = "tests/curry_recursive_conditional_infer_tests.rs"
 name = "ts1210_class_arguments_tests"
 path = "tests/ts1210_class_arguments_tests.rs"
 [[test]]
+name = "ts2815_arguments_class_scope_tests"
+path = "tests/ts2815_arguments_class_scope_tests.rs"
+[[test]]
 name = "jsdoc_implements_tests"
 path = "tests/jsdoc_implements_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/computation/identifier/core.rs
+++ b/crates/tsz-checker/src/types/computation/identifier/core.rs
@@ -469,7 +469,20 @@ impl<'a> CheckerState<'a> {
         // TS2815: 'arguments' cannot be referenced in property initializers
         // or class static initialization blocks. Must check BEFORE regular
         // function body check because arrow functions are transparent.
-        if self.is_arguments_in_class_initializer_or_static_block(idx) {
+        //
+        // tsc only reports TS2815 when the reference would otherwise capture
+        // an *enclosing* function's `arguments` object — i.e. the class whose
+        // field initializer or static block holds the reference is itself
+        // nested inside a (non-arrow) function. When the class sits at module
+        // or global scope there is no such function, so `arguments` is just an
+        // undefined name and tsc reports the ordinary "cannot find name"
+        // diagnostic (TS2662 with a static-member suggestion, or TS2304 for a
+        // computed property name whose expression is evaluated in the class's
+        // enclosing scope). Gating on `has_enclosing_regular_function` lets
+        // those out-of-function references fall through to normal resolution.
+        if self.is_arguments_in_class_initializer_or_static_block(idx)
+            && self.has_enclosing_regular_function(idx)
+        {
             use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
             self.error_at_node(
                     idx,

--- a/crates/tsz-checker/tests/ts2815_arguments_class_scope_tests.rs
+++ b/crates/tsz-checker/tests/ts2815_arguments_class_scope_tests.rs
@@ -1,0 +1,193 @@
+//! `arguments` referenced in a class field initializer, static block, or
+//! computed property name.
+//!
+//! tsc reports TS2815 (`'arguments' cannot be referenced in property
+//! initializers or class static initialization blocks`) **only** when the
+//! reference would otherwise capture an *enclosing* function's `arguments`
+//! object — i.e. the class holding the initializer/static-block is itself
+//! nested inside a (non-arrow) function. When the class sits at module or
+//! global scope there is no such function, so `arguments` is simply an
+//! undefined name: tsc reports the ordinary "cannot find name" diagnostic
+//! (TS2662 with an inherited-`Function`-member suggestion, or TS2304 for a
+//! computed property name evaluated in the class's enclosing scope), never
+//! TS2815.
+//!
+//! Regression witness: tsz previously emitted TS2815 unconditionally for any
+//! `arguments` in these positions, ignoring the enclosing-function scope.
+//!
+//! The suite has two tiers:
+//!   * the TS2815 *gating* decision does not depend on lib resolution, so it is
+//!     asserted with the fast no-lib helper;
+//!   * the exact fall-through code (TS2304 / TS2662) is a lib-dependent
+//!     name-resolution result, so it is asserted with `es5.d.ts` wired in
+//!     (that lib carries the `Function` interface whose inherited members drive
+//!     the TS2662 suggestion).
+//!
+//! Names are varied across cases (`C`/`Widget`, `f`/`run`) so the rule is
+//! anchored on scope structure, not on any particular identifier.
+
+use std::sync::Arc;
+use tsz_binder::lib_loader::LibFile;
+use tsz_checker::test_utils::{
+    check_source_strict_codes, check_source_with_libs_code_messages, load_lib_files,
+    strict_checker_options,
+};
+
+const TS2815: u32 = 2815;
+const TS2304: u32 = 2304;
+const TS2662: u32 = 2662;
+
+fn es5_libs() -> Vec<Arc<LibFile>> {
+    load_lib_files(&["es5.d.ts"])
+}
+
+/// Diagnostic codes for `source`, strict, with `es5.d.ts` wired in.
+fn lib_codes(source: &str) -> Vec<u32> {
+    check_source_with_libs_code_messages(source, "test.ts", strict_checker_options(), &es5_libs())
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect()
+}
+
+// ===========================================================================
+// Tier 1 — the TS2815 gating decision (lib-independent).
+// ===========================================================================
+
+/// The core regression guard: TS2815 must not fire for `arguments` at module
+/// scope, where there is no enclosing function to capture from.
+fn assert_no_ts2815(source: &str) {
+    let codes = check_source_strict_codes(source);
+    assert!(
+        !codes.contains(&TS2815),
+        "TS2815 must not fire for `arguments` at module scope (no enclosing \
+         function to capture): {codes:?}\nsource:\n{source}"
+    );
+}
+
+fn assert_ts2815(source: &str) {
+    let codes = check_source_strict_codes(source);
+    assert!(
+        codes.contains(&TS2815),
+        "expected TS2815 for `arguments` inside an enclosing function, got: \
+         {codes:?}\nsource:\n{source}"
+    );
+}
+
+#[test]
+fn module_scope_static_block_is_not_ts2815() {
+    assert_no_ts2815("class C { static { arguments; } }");
+}
+
+#[test]
+fn module_scope_instance_field_initializer_is_not_ts2815() {
+    assert_no_ts2815("class Widget { p = arguments; }");
+}
+
+#[test]
+fn module_scope_static_field_initializer_is_not_ts2815() {
+    assert_no_ts2815("class C { static p = arguments; }");
+}
+
+#[test]
+fn module_scope_computed_property_name_is_not_ts2815() {
+    assert_no_ts2815("class Widget { [arguments] = 1; }");
+}
+
+#[test]
+fn module_scope_transparent_arrow_is_not_ts2815() {
+    // Arrow functions are transparent for `arguments`; the arrow does not
+    // introduce an enclosing-function boundary, so the module-scope rule holds.
+    assert_no_ts2815("class C { p = (() => arguments)(); }");
+}
+
+#[test]
+fn module_scope_own_static_arguments_member_is_not_ts2815() {
+    assert_no_ts2815("class C { static arguments = 1; static { arguments; } }");
+}
+
+#[test]
+fn function_scope_static_block_is_ts2815() {
+    assert_ts2815("function f() { class C { static { arguments; } } }");
+}
+
+#[test]
+fn function_scope_field_initializer_is_ts2815() {
+    assert_ts2815("function run() { class Widget { p = arguments; } }");
+}
+
+#[test]
+fn function_scope_computed_property_name_is_ts2815() {
+    assert_ts2815("function f() { class C { [arguments] = 1; } }");
+}
+
+#[test]
+fn function_scope_transparent_arrow_is_ts2815() {
+    assert_ts2815("function run() { class C { p = (() => arguments)(); } }");
+}
+
+#[test]
+fn class_nested_in_method_static_block_is_ts2815() {
+    // The method is a (non-arrow) function boundary, so the inner class's
+    // static block sits inside a function: TS2815.
+    assert_ts2815("class Outer { m() { class Inner { static { arguments; } } } }");
+}
+
+// Regression controls: `arguments` that resolves normally must be untouched.
+
+#[test]
+fn method_body_arguments_has_no_grammar_error() {
+    let codes = check_source_strict_codes("class C { m() { return arguments; } }");
+    assert!(
+        !codes.contains(&TS2815) && !codes.contains(&TS2304) && !codes.contains(&TS2662),
+        "`arguments` in a method body must resolve cleanly: {codes:?}"
+    );
+}
+
+#[test]
+fn function_body_arguments_has_no_grammar_error() {
+    let codes = check_source_strict_codes("function f() { return arguments; }");
+    assert!(
+        !codes.contains(&TS2815) && !codes.contains(&TS2304) && !codes.contains(&TS2662),
+        "`arguments` in a function body must resolve cleanly: {codes:?}"
+    );
+}
+
+// ===========================================================================
+// Tier 2 — exact fall-through code parity (lib-backed).
+// ===========================================================================
+
+// NOTE on the module-scope *fall-through* code (TS2304 / TS2662): the real
+// `tsz` CLI, run with the full default lib set, reports
+//   `class C { static { arguments; } }`  -> TS2662 (suggests `C.arguments`)
+//   `class Widget { [arguments] = 1; }`  -> TS2304
+// matching `typescript@7.0.2`. The unit-test harness cannot reproduce that
+// fall-through — with only `es5.d.ts` wired in it emits no cannot-find-name
+// diagnostic for an unresolved module-scope `arguments` (a known
+// harness/CLI divergence, cf. #16125) — so those exact codes are pinned at
+// the CLI/oracle level in the PR rather than asserted here. What this suite
+// pins is the part the harness *does* see faithfully and the part the fix
+// actually changes: that TS2815 no longer fires at module scope.
+
+#[test]
+fn module_scope_own_static_member_suggests_ts2662() {
+    // With an own static `arguments`, the suggestion resolves and tsc/tsz agree
+    // on TS2662.
+    let codes = lib_codes("class C { static arguments = 1; static { arguments; } }");
+    assert!(
+        !codes.contains(&TS2815),
+        "TS2815 must not fire with an own static `arguments` member: {codes:?}"
+    );
+    assert!(
+        codes.contains(&TS2662),
+        "expected TS2662 static-member suggestion: {codes:?}"
+    );
+}
+
+#[test]
+fn function_scope_static_block_reports_ts2815_lib_backed() {
+    let codes = lib_codes("function f() { class C { static { arguments; } } }");
+    assert!(
+        codes.contains(&TS2815),
+        "expected TS2815 inside an enclosing function (lib-backed): {codes:?}"
+    );
+}


### PR DESCRIPTION
When an `arguments` reference sits in a class field initializer, static block, or computed property name, `tsc` reports **TS2815** (`'arguments' cannot be referenced in property initializers or class static initialization blocks`) **iff** the class element is nested inside a (non-arrow) function whose `arguments` object the reference would otherwise capture. At module/global scope there is no such function, so `arguments` is an ordinary unresolved name and tsc reports the cannot-find-name diagnostic instead — TS2662 (with a static-member suggestion) for a field-init/static-block, or TS2304 for a computed property name evaluated in the class's enclosing scope. tsz owns this decision in the checker's `arguments_identifier_type`.

tsz gated the TS2815 emission only on `is_arguments_in_class_initializer_or_static_block`, never on the presence of an enclosing function, so it emitted the **wrong code (TS2815)** for every module-scope occurrence. This gates it additionally on `has_enclosing_regular_function`, letting out-of-function references fall through to normal name resolution. Arrow functions remain transparent on both sides. Filed as #16811.

### Oracle matrix (`typescript@7.0.2`, `--noEmit --strict --target es2022 --module esnext`, CLI = built `tsz`)

| source | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `class C { static { arguments; } }` | TS2662 | TS2815 ✗ | TS2304¹ |
| `class C { p = arguments; }` | TS2662 | TS2815 ✗ | TS2304¹ |
| `class C { [arguments] = 1; }` | TS2304 | TS2815 ✗ | **TS2304 ✅** |
| `class C { static arguments = 1; static { arguments; } }` | TS2662 | TS2815 ✗ | **TS2662 ✅** |
| `function f(){ class C { static { arguments; } } }` | TS2815 | TS2815 ✅ | TS2815 ✅ |
| `function f(){ class C { p = arguments; } }` | TS2815 | TS2815 ✅ | TS2815 ✅ |
| `function f(){ class C { [arguments] = 1; } }` | TS2815 | TS2815 ✅ | TS2815 ✅ |
| `class Outer { m(){ class Inner { static { arguments; } } } }` | TS2815 | TS2815 ✅ | TS2815 ✅ |
| `class C { m() { return arguments; } }` | clean | clean ✅ | clean ✅ |

¹ **Residual, tracked in #16811:** in the no-enclosing-function case with no *own* `arguments` static member, tsc's TS2662 suggestion draws on the inherited `Function` static members (`C.arguments`/`C.caller`/`C.bind` are all suggested); tsz's suggestion machinery only considers own declared static members, so it lands on TS2304 — the same cannot-find-name category, minus the inherited-member suggestion, and strictly closer to tsc than the previous wrong TS2815. That suggestion-quality gap is reachable well beyond `arguments` and is left for a follow-up in the name-resolution path.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts2815_arguments_class_scope_tests` — 15/15 pass (new file; scope-structured rule with varied binder names, arrow transparency, nested-class, and regression controls).
- `cargo test -p tsz-checker` — full checker suite green (exit 0) after the change.
- `cargo clippy -p tsz-checker --lib --test ts2815_arguments_class_scope_tests -- -D warnings` — clean; pre-commit arch-guard passed.
- CLI + `typescript@7.0.2` oracle matrix above (built `tsz` at branch head).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01382xV3EwKsNqf3H4gB6miP)_