### PR TITLE
fix(checker): TS7032 fires for a zero-parameter set accessor

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2739,3 +2739,6 @@ path = "tests/ts2345_primitive_key_union_constraint_display_tests.rs"
 [[test]]
 name = "ts2369_source_order_anchor_tests"
 path = "tests/ts2369_source_order_anchor_tests.rs"
+[[test]]
+name = "ts7032_zero_parameter_setter_tests"
+path = "tests/ts7032_zero_parameter_setter_tests.rs"

--- a/crates/tsz-checker/src/checkers/accessor_checker.rs
+++ b/crates/tsz-checker/src/checkers/accessor_checker.rs
@@ -277,6 +277,26 @@ impl<'a> CheckerState<'a> {
             .is_some_and(|getter| getter.type_annotation.is_some() || getter.body.is_some());
         let accessor_name = accessor.name;
 
+        if accessor.parameters.nodes.is_empty() {
+            // A zero-parameter setter (`set a() {}` in an interface/type
+            // literal) is grammatically invalid (`TS1049` fires separately)
+            // but still "lacks a parameter type annotation" for `TS7032`
+            // purposes — the loop below never runs for this shape.
+            if !paired_getter_supplies_type
+                && let Some(prop_name) = self.property_name_for_error(accessor_name)
+            {
+                let message = format!(
+                    "Property '{prop_name}' implicitly has type 'any', because its set accessor lacks a parameter type annotation."
+                );
+                self.error_at_node(
+                    accessor_name,
+                    &message,
+                    diagnostic_codes::PROPERTY_IMPLICITLY_HAS_TYPE_ANY_BECAUSE_ITS_SET_ACCESSOR_LACKS_A_PARAMETER_TYPE,
+                );
+            }
+            return;
+        }
+
         for (param_index, &param_idx) in accessor.parameters.nodes.iter().enumerate() {
             let Some(param_node) = self.ctx.arena.get(param_idx) else {
                 continue;
@@ -619,6 +639,31 @@ impl<'a> CheckerState<'a> {
         accessor_jsdoc: Option<&str>,
         accessor_name: Option<NodeIndex>,
     ) {
+        if parameters.is_empty() {
+            // A zero-parameter setter (`set y() {}`) is grammatically invalid
+            // (`TS1049` fires separately, from `check_setter_parameter_grammar`)
+            // but `tsc` still reports `TS7032`: "lacks a parameter type
+            // annotation" is true of a setter with no parameter at all, not
+            // only of one whose sole parameter is unannotated. The loop below
+            // never runs for this shape, so the check needs its own arm.
+            let property_type_supplied = has_paired_getter && paired_getter_supplies_type;
+            if !property_type_supplied
+                && self.ctx.no_implicit_any()
+                && let Some(name_idx) = accessor_name
+            {
+                let prop_name = self.parameter_name_for_error(name_idx);
+                let message = format!(
+                    "Property '{prop_name}' implicitly has type 'any', because its set accessor lacks a parameter type annotation."
+                );
+                self.error_at_node(
+                    name_idx,
+                    &message,
+                    diagnostic_codes::PROPERTY_IMPLICITLY_HAS_TYPE_ANY_BECAUSE_ITS_SET_ACCESSOR_LACKS_A_PARAMETER_TYPE,
+                );
+            }
+            return;
+        }
+
         for &param_idx in parameters {
             let Some(param_node) = self.ctx.arena.get(param_idx) else {
                 continue;

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -663,6 +663,9 @@ mod symbol_index_signature_tests;
 #[path = "../tests/ts18048_unary_arithmetic_nullish_tests.rs"]
 mod ts18048_unary_arithmetic_nullish_tests;
 #[cfg(test)]
+#[path = "../tests/ts7032_zero_parameter_setter_tests.rs"]
+mod ts7032_zero_parameter_setter_tests;
+#[cfg(test)]
 #[path = "../tests/variadic_tuple_elaboration_tests.rs"]
 mod variadic_tuple_elaboration_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
@@ -110,7 +110,13 @@ impl<'a> CheckerState<'a> {
                 .is_some_and(|name| obj_getter_names.contains(name));
             // Check if accessor JSDoc has @param type annotations
             let accessor_jsdoc = self.get_jsdoc_for_function(elem_idx);
-            let mut first_param_lacks_annotation = false;
+            // A zero-parameter setter (`{ set z() {} }`) is grammatically
+            // invalid (`TS1049` fires separately) but still "lacks a
+            // parameter type annotation" for `TS7032` purposes — the loop
+            // below never runs for this shape, so start from `true` instead
+            // of `false` and let an actual annotated/JSDoc-typed parameter
+            // clear it.
+            let mut first_param_lacks_annotation = accessor.parameters.nodes.is_empty();
             for (pi, &param_idx) in accessor.parameters.nodes.iter().enumerate() {
                 if let Some(param_node) = self.ctx.arena.get(param_idx)
                     && let Some(param) = self.ctx.arena.get_parameter(param_node)

--- a/crates/tsz-checker/tests/ts7032_zero_parameter_setter_tests.rs
+++ b/crates/tsz-checker/tests/ts7032_zero_parameter_setter_tests.rs
@@ -1,0 +1,159 @@
+//! `TS7032` for a `set` accessor with **no parameter at all** — the
+//! zero-parameter half of the already-wired "setter lacks a parameter type
+//! annotation" family. Issue #16809.
+//!
+//! `tsc` reports `TS7032` here alongside the (unrelated) grammar error
+//! `TS1049` ("An accessor property setter must have exactly one parameter."):
+//! a zero-parameter setter still "lacks a parameter type annotation" under
+//! `noImplicitAny`, the same way a present-but-unannotated one does.
+//!
+//! `check_source_strict` (used below, matching the sibling test files in this
+//! family) only surfaces checker diagnostics, so `TS1049` — a parser grammar
+//! diagnostic — never appears in these expectations; it is unaffected by this
+//! change and out of scope here.
+//!
+//! Three checker-owned emission sites compute this decision inside a `for`
+//! loop over the setter's parameters, so a zero-parameter setter's loop body
+//! never ran and `TS7032` stayed silent:
+//! - `checkers/accessor_checker.rs::check_setter_parameter` (class member,
+//!   ambient class member).
+//! - `checkers/accessor_checker.rs::check_type_member_accessor_implicit_any`
+//!   (interface member, type-literal member).
+//! - `types/computation/object_literal/accessor_element.rs` (object literal
+//!   accessor element).
+//!
+//! Every expectation was recorded from `typescript@7.0.2` under `--noEmit
+//! --strict --lib es2022 --target es2022`.
+
+use tsz_checker::test_utils::check_source_strict;
+
+fn sites(source: &str) -> Vec<String> {
+    let mut out: Vec<String> = check_source_strict(source)
+        .iter()
+        .map(|d| format!("TS{}@{}", d.code, d.start))
+        .collect();
+    out.sort();
+    out
+}
+
+fn assert_sites(source: &str, expected: &[&str]) {
+    let actual = sites(source);
+    let expected: Vec<String> = expected.iter().map(|s| (*s).to_string()).collect();
+    assert_eq!(actual, expected, "source: {source}");
+}
+
+// ---------------------------------------------------------------------------
+// The six divergent rows from #16809: every container a `set` accessor can
+// be written in.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn class_zero_parameter_setter_reports_ts7032() {
+    assert_sites("class C { set y() {} }", &["TS7032@14"]);
+}
+
+#[test]
+fn object_literal_zero_parameter_setter_reports_ts7032() {
+    assert_sites("const o = { set z() {} };", &["TS7032@16"]);
+}
+
+#[test]
+fn ambient_class_zero_parameter_setter_reports_ts7032() {
+    assert_sites("declare class C { set w(); }", &["TS7032@22"]);
+}
+
+#[test]
+fn ambient_class_unpaired_get_and_zero_parameter_set_reports_ts7032() {
+    // Neither accessor supplies the property a type, so the pair still
+    // blames the setter — same rule as the present-but-unannotated pair,
+    // just with no parameter to blame TS7006 on.
+    assert_sites("declare class C { get p(); set p(); }", &["TS7032@31"]);
+}
+
+#[test]
+fn interface_zero_parameter_setter_reports_ts7032() {
+    assert_sites("interface I { set a(); }", &["TS7032@18"]);
+}
+
+#[test]
+fn type_literal_zero_parameter_setter_reports_ts7032() {
+    assert_sites("type T = { set c(); };", &["TS7032@15"]);
+}
+
+// ---------------------------------------------------------------------------
+// Controls from #16809: shapes that must stay exactly as they already were.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn class_paired_getter_with_annotation_suppresses_zero_parameter_setter() {
+    assert_sites("class C { get q(): number {return 1;} set q() {} }", &[]);
+}
+
+#[test]
+fn class_paired_getter_with_inferred_body_suppresses_zero_parameter_setter() {
+    assert_sites("class C { get r() {return 1;} set r() {} }", &[]);
+}
+
+#[test]
+fn interface_paired_annotated_getter_suppresses_zero_parameter_setter() {
+    assert_sites("interface I { get b(): number; set b(); }", &[]);
+}
+
+#[test]
+fn class_present_but_unannotated_setter_is_unaffected() {
+    // The already-wired half of the family: present-but-unannotated still
+    // reports both TS7006 (on the parameter) and TS7032 (on the setter name).
+    assert_sites("class C { set d(v) {} }", &["TS7006@16", "TS7032@14"]);
+}
+
+#[test]
+fn class_annotated_zero_arity_free_setter_is_clean() {
+    assert_sites("class C { set e(v: number) {} }", &[]);
+}
+
+// ---------------------------------------------------------------------------
+// Adjacent cases: renamed binders, and TS7006 must not fire when there is no
+// parameter to blame it on.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn renamed_binders_report_identically() {
+    assert_sites("class Zqx { set wobble() {} }", &["TS7032@16"]);
+    assert_sites("interface Zqx { set wobble(); }", &["TS7032@20"]);
+    assert_sites("type Zqx = { set wobble(); };", &["TS7032@17"]);
+}
+
+#[test]
+fn zero_parameter_setter_never_reports_ts7006() {
+    // There is no parameter node to blame TS7006 on — only TS7032 fires.
+    for source in [
+        "class C { set y() {} }",
+        "const o = { set z() {} };",
+        "declare class C { set w(); }",
+        "interface I { set a(); }",
+        "type T = { set c(); };",
+    ] {
+        let codes: Vec<u32> = check_source_strict(source).iter().map(|d| d.code).collect();
+        assert!(
+            !codes.contains(&7006),
+            "TS7006 must not fire on a zero-parameter setter: {source}"
+        );
+    }
+}
+
+#[test]
+fn the_family_is_governed_by_no_implicit_any() {
+    use tsz_checker::test_utils::check_source_non_strict_codes;
+    assert!(
+        check_source_non_strict_codes("class C { set y() {} }").is_empty(),
+        "TS7032 must be governed by noImplicitAny"
+    );
+    assert!(
+        check_source_non_strict_codes("interface I { set a(); }").is_empty(),
+        "TS7032 must be governed by noImplicitAny"
+    );
+    assert!(
+        check_source_non_strict_codes("const o = { set z() {} };").is_empty(),
+        "TS7032 must be governed by noImplicitAny"
+    );
+}


### PR DESCRIPTION
Closes #16809.

`set y() {}` (no parameter at all) is grammatically invalid (`TS1049` fires separately, unaffected by this change) but `tsc` still reports `TS7032` under `noImplicitAny`: "lacks a parameter type annotation" is true of a setter with no parameter at all, not only of one whose sole parameter is unannotated. tsz reported only `TS1049`.

**Structural rule**: When a `set` accessor has no parameter, `tsc` still reports `TS7032` on the setter name under `noImplicitAny` — unless a paired getter supplies the property type (an annotation, or a body it can infer from) — because "lacks a parameter type annotation" subsumes "has no parameter". tsz owns this in `crates/tsz-checker/src/checkers/accessor_checker.rs` and `crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs`.

Three checker-owned emission sites computed the TS7032 decision inside a `for` loop over the setter's parameters, so a zero-parameter setter's loop body never ran:

- `checkers/accessor_checker.rs::check_setter_parameter` (class member, ambient class member) — new early-return arm handles the empty-parameters case before the loop, mirroring the loop's own logic without touching per-parameter `TS7006` behavior for the `len >= 1` case.
- `checkers/accessor_checker.rs::check_type_member_accessor_implicit_any` (interface member, type-literal member) — same shape.
- `types/computation/object_literal/accessor_element.rs` (object literal accessor element) — the loop-guard flag (`first_param_lacks_annotation`) now starts `true` when there are no parameters, instead of `false`, so a real annotated/JSDoc-typed parameter is still what clears it.

`TS7006` (implicit-any on the *parameter*) is unaffected: there is no parameter node to blame it on, so it stays silent for a zero-parameter setter, matching tsc. The paired-getter suppression and the blame site (the setter *name*, not its parameter) are unchanged — the zero-parameter case reuses each.

## Adjacent-case matrix (oracle-verified, `typescript@7.0.2`)

| source | before | after |
| --- | --- | --- |
| `class C { set y() {} }` | `TS1049` only | `TS1049` + `TS7032` |
| `const o = { set z() {} };` | `TS1049` only | `TS1049` + `TS7032` |
| `declare class C { set w(); }` | `TS1049` only | `TS1049` + `TS7032` |
| `declare class C { get p(); set p(); }` | `TS1049` only | `TS1049` + `TS7032` |
| `interface I { set a(); }` | `TS1049` only | `TS1049` + `TS7032` |
| `type T = { set c(); };` | `TS1049` only | `TS1049` + `TS7032` |
| `class C { get q(): number {return 1;} set q() {} }` | `TS1049` only | unchanged (getter supplies type) |
| `class C { get r() {return 1;} set r() {} }` | `TS1049` only | unchanged (getter body supplies type) |
| `interface I { get b(): number; set b(); }` | `TS1049` only | unchanged |
| `class C { set d(v) {} }` (present-but-unannotated) | `TS7006`+`TS7032` | unchanged |
| `class C { set e(v: number) {} }` | clean | unchanged |
| renamed binders (`Zqx`/`wobble`) across class/interface/type-literal | — | verified to anchor identically |

New test file `crates/tsz-checker/tests/ts7032_zero_parameter_setter_tests.rs`, registered per the crate's `#[path]` + `[[test]]` convention (`autotests = false`).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib ts7032_zero_parameter_setter`: 14/14 new tests pass.
- `cargo test -p tsz-checker --lib -- accessor implicit_any setter ts7032 ts7006 ts7033 noimplicitany`: 270/270 pass, 0 regressions (before/after: same 270 passing, new zero-parameter cases added).
- `cargo clippy -p tsz-checker --lib --tests -- -D warnings`: clean.
- `cargo fmt --check -p tsz-checker`: clean.
- `python3 scripts/arch/arch_guard.py`: `Architecture guardrails passed.` (all touched files well under the 2000-line cap: `accessor_checker.rs` 941 lines, `accessor_element.rs` 638 lines).
- Corpus check: `grep -rlE "set \w+\(\s*\)\s*[{;]" TypeScript/tests/cases/{compiler,conformance}` finds only 4 fixtures, all under `// @strict: false` — this shape isn't exercised under `noImplicitAny` in the current corpus, so conformance set-difference is expected at 0/0 (not run standalone; the pre-commit hook's `-p tsz-checker` clippy+arch-guard gate is what CI's per-merge lane checks).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWZV2BmVDBTvoXUct3kQMs)_