### PR TITLE
fix(parser): TS18029 for a private identifier used as a for-header binding

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -370,6 +370,10 @@ mod ts1180_property_destructuring_pattern_expected_tests;
 #[path = "../../tests/type_member_modifier_grammar_tests.rs"]
 mod type_member_modifier_grammar_tests;
 
+#[cfg(test)]
+#[path = "../../tests/for_header_private_identifier_binding_tests.rs"]
+mod for_header_private_identifier_binding_tests;
+
 // Re-export flags
 pub use flags::{modifier_flags, node_flags, transform_flags};
 

--- a/crates/tsz-parser/src/parser/state_declarations_exports.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_exports.rs
@@ -1464,6 +1464,24 @@ impl ParserState {
             );
         }
 
+        // TS18029: a private identifier is not allowed as a declaration name,
+        // including a `for`-header entry (`for (const #x of arr)`,
+        // `for (var #x = 0; ...)`). Sibling of the plain-statement check in
+        // `parse_variable_declaration_with_flags_pre_checks`
+        // (`state_variable_declarations.rs`) — `for`-header entries are
+        // parsed by this wholly separate function, so that check does not
+        // cover them.
+        if self.is_token(SyntaxKind::PrivateIdentifier) {
+            let start = self.token_pos();
+            let length = self.token_end() - start;
+            self.parse_error_at(
+                start,
+                length,
+                "Private identifiers are not allowed in variable declarations.",
+                diagnostic_codes::PRIVATE_IDENTIFIERS_ARE_NOT_ALLOWED_IN_VARIABLE_DECLARATIONS,
+            );
+        }
+
         let name = if self.is_token(SyntaxKind::OpenBraceToken) {
             self.parse_object_binding_pattern()
         } else if self.is_token(SyntaxKind::OpenBracketToken) {

--- a/crates/tsz-parser/src/parser/state_statements_keywords.rs
+++ b/crates/tsz-parser/src/parser/state_statements_keywords.rs
@@ -1486,11 +1486,19 @@ impl ParserState {
     /// In tsc, `let` is only treated as a declaration keyword when followed by
     /// an identifier, `{` (object destructuring), or `[` (array destructuring).
     /// Otherwise (e.g. `let;`), `let` is treated as an identifier expression.
+    ///
+    /// A `PrivateIdentifier` also counts (`let #x = 1;`, `for (let #x of arr)`):
+    /// tsc still treats `let` as the declaration keyword there and reports
+    /// TS18029 on the binding name, rather than falling back to parsing `let`
+    /// as an identifier expression. `is_identifier_or_keyword` (the free
+    /// function, not `ParserState::is_identifier_or_keyword`) does not cover
+    /// `PrivateIdentifier`, so this needs its own arm.
     pub(crate) fn look_ahead_is_let_declaration(&mut self) -> bool {
         look_ahead_is(&mut self.scanner, self.current_token, |token| {
             is_identifier_or_keyword(token)
                 || token == SyntaxKind::OpenBraceToken
                 || token == SyntaxKind::OpenBracketToken
+                || token == SyntaxKind::PrivateIdentifier
         })
     }
 

--- a/crates/tsz-parser/tests/for_header_private_identifier_binding_tests.rs
+++ b/crates/tsz-parser/tests/for_header_private_identifier_binding_tests.rs
@@ -1,0 +1,114 @@
+//! TS18029: a private identifier used as a `for`-header binding.
+//!
+//! `parse_variable_declaration_with_flags_pre_checks`
+//! (`state_variable_declarations.rs`) already reports TS18029 for a plain
+//! `let #x = 1;`-style statement, but a `for`-header declaration entry
+//! (`for (const #x of arr)`, `for (var #x in obj)`, `for (var #x = 0; ...)`)
+//! is parsed by a wholly separate function, `parse_for_variable_declaration_entry`
+//! (`state_declarations_exports.rs`) — which did not carry the same check.
+//! Before this fix `#x` there silently parsed as an ordinary binding name: no
+//! TS18029, no diagnostic at all, `is_identifier_or_keyword()` (true for a
+//! `PrivateIdentifier` token, since it sorts after `Identifier` in
+//! `SyntaxKind`) let it through as plain identifier text.
+//!
+//! A `catch (#x) {}` clause was never affected — its own binding-name parse
+//! path already goes through `parse_variable_declaration_name`, which has an
+//! explicit `PrivateIdentifier` arm alongside the pre-checks call.
+//!
+//! Every case here is oracle-verified against `typescript@7.0.2`
+//! (`scripts/conformance/typescript-versions.json`'s pinned `current`).
+
+use crate::parser::test_fixture::parse_source;
+
+fn codes_and_starts(source: &str) -> Vec<(u32, u32)> {
+    let (parser, _root) = parse_source(source);
+    let mut diags: Vec<(u32, u32)> = parser
+        .get_diagnostics()
+        .iter()
+        .map(|d| (d.code, d.start))
+        .collect();
+    diags.sort_unstable();
+    diags
+}
+
+const TS18029: u32 = 18029;
+
+#[test]
+fn for_of_const_private_binding_reports_ts18029() {
+    // tsc: exactly one TS18029 at the `#x` token.
+    let source = "class C {\n  m(arr: number[]) {\n    for (const #x of arr) {}\n  }\n}\n";
+    let diags = codes_and_starts(source);
+    assert!(
+        diags.contains(&(TS18029, 46)),
+        "expected TS18029 at the `#x` token, got {diags:?}"
+    );
+}
+
+#[test]
+fn for_in_const_private_binding_reports_ts18029() {
+    let source = "class C {\n  m(obj: any) {\n    for (const #x in obj) {}\n  }\n}\n";
+    let diags = codes_and_starts(source);
+    assert!(
+        diags.contains(&(TS18029, 41)),
+        "expected TS18029 at the `#x` token, got {diags:?}"
+    );
+}
+
+#[test]
+fn for_of_var_private_binding_reports_ts18029() {
+    let source = "class C {\n  m(arr: number[]) {\n    for (var #x of arr) {}\n  }\n}\n";
+    let diags = codes_and_starts(source);
+    assert!(
+        diags.contains(&(TS18029, 44)),
+        "expected TS18029 at the `#x` token, got {diags:?}"
+    );
+}
+
+#[test]
+fn for_of_let_private_binding_reports_ts18029() {
+    let source = "class C {\n  m(arr: number[]) {\n    for (let #x of arr) {}\n  }\n}\n";
+    let diags = codes_and_starts(source);
+    assert!(
+        diags.contains(&(TS18029, 44)),
+        "expected TS18029 at the `#x` token, got {diags:?}"
+    );
+}
+
+#[test]
+fn c_style_for_var_private_binding_reports_ts18029() {
+    // C-style `for (var #x = 0; ...)` — a different call path within
+    // `parse_for_variable_declaration_entry` from the for-in/for-of head
+    // (both share this function; the initializer-vs-condition split happens
+    // in the caller), so pinned separately.
+    let source = "class C {\n  m() {\n    for (var #x = 0; ; ) {}\n  }\n}\n";
+    let diags = codes_and_starts(source);
+    assert!(
+        diags.contains(&(TS18029, 31)),
+        "expected TS18029 at the `#x` token, got {diags:?}"
+    );
+}
+
+#[test]
+fn catch_clause_private_binding_already_reported_ts18029_control() {
+    // Control: the catch-clause path was never broken — confirms this test
+    // module's expectations are pinned against the right mechanism rather
+    // than a change in scanning/token classification.
+    let source = "class C {\n  m() {\n    try {} catch (#x) {}\n  }\n}\n";
+    let diags = codes_and_starts(source);
+    assert!(
+        diags.contains(&(TS18029, 36)),
+        "expected TS18029 at the `#x` token, got {diags:?}"
+    );
+}
+
+#[test]
+fn for_of_normal_binding_stays_clean_control() {
+    // Control: an ordinary identifier binding in the same for-header shape
+    // must not regress to spuriously reporting TS18029.
+    let source = "class C {\n  m(arr: number[]) {\n    for (const x of arr) {}\n  }\n}\n";
+    let diags = codes_and_starts(source);
+    assert!(
+        !diags.iter().any(|&(code, _)| code == TS18029),
+        "ordinary binding must not report TS18029, got {diags:?}"
+    );
+}


### PR DESCRIPTION
Continues the #16279 `is_parser_grammar_code` audit (extending past the modifier-grammar family, which #16320/#16807/#16808/#16809/#16813 already mined out this hour).

## What's wrong

tsc's TS18029 (`Private identifiers are not allowed in variable declarations.`) fires for a private-identifier binding name in **any** declaration position: plain statement, `for`-in/`for`-of head, C-style `for` initializer, or catch clause. tsz's parser only implemented the plain-statement check (`parse_variable_declaration_with_flags_pre_checks`, `state_variable_declarations.rs`). The `for`-header form is parsed by a wholly separate function, `parse_for_variable_declaration_entry` (`state_declarations_exports.rs`), which had no equivalent check — `for (const #x of arr) {}` silently accepted `#x` as an ordinary binding name with **zero diagnostics**, because `PrivateIdentifier` sorts after `Identifier` in `SyntaxKind` and so satisfies the generic `is_identifier_or_keyword()` name-parsing fallback.

A second, related gap surfaced while building the adjacent-case matrix: `for (let #x of arr)` additionally hit `look_ahead_is_let_declaration`'s free-standing `is_identifier_or_keyword` helper (`parse_rules/utils.rs`, distinct from the `ParserState` method of the same name), which excludes `PrivateIdentifier`. That made `let` misclassify as an identifier expression instead of the declaration keyword, cascading into a wrong `TS1005`/`TS1128` parse-recovery instead of tsc's single `TS18029`. `const`/`var` for-headers don't go through this look-ahead disambiguation and were unaffected.

## Structural rule

When a private identifier appears as a `for`-header (or C-style `for` initializer) binding name, tsc's `checkGrammarVariableDeclarationList`-family reports `TS18029` regardless of the `var`/`let`/`const` keyword; tsz now does the same, through a matching check at `parse_for_variable_declaration_entry`'s name-parsing site (owner: parser), plus a `PrivateIdentifier` arm added to `look_ahead_is_let_declaration`'s look-ahead predicate so `let` is still recognized as the declaration keyword in that position.

Both fixes are structurally minimal: no change to the shared `is_identifier_or_keyword` utility, since it has unrelated callers in unary-expression and statement-recovery code where widening it is out of scope.

## Goal
Goal: hold

## Verification
- New adjacent-case matrix, all oracle-verified against `typescript@7.0.2` (the version `scripts/conformance/typescript-versions.json` pins as `current`): `for`-of/`for`-in with `const`/`let`/`var`, C-style `for` with `var`, and a catch-clause control (already correct pre-fix — confirms the fix targets the right mechanism, not a scanning/token-classification change). An ordinary-identifier `for`-of binding stays clean (no false positive).
- `cargo test -p tsz-parser --lib`: 2073/2073 (2066 pre-existing + 7 new)
- `cargo test -p tsz-checker --lib -- for_in for_of using variable_declaration`: 242/242, 1 pre-existing ignore
- `cargo fmt -p tsz-parser -- --check` and `cargo clippy -p tsz-parser --lib --tests -- -D warnings`: clean
- End-to-end CLI binary re-verified against the oracle on all 7 repro cases post-fix, matching tsc's diagnostic code and position exactly
- Test-and-parser-only diff (`crates/tsz-parser/src/**` + one new test file) — no `crates/tsz-checker/**`/`crates/tsz-solver/**` path touched, so no conformance/emit gate is owed by this change's own scope

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_016cHVxKXSDcTkd2YeUTNnns)_