### PR TITLE
refactor(checker): consolidate set-accessor TS7032 emission into one helper and decision

### DIFF
--- a/crates/tsz-checker/src/checkers/accessor_checker.rs
+++ b/crates/tsz-checker/src/checkers/accessor_checker.rs
@@ -276,26 +276,10 @@ impl<'a> CheckerState<'a> {
             .and_then(|getter_node| self.ctx.arena.get_accessor(getter_node))
             .is_some_and(|getter| getter.type_annotation.is_some() || getter.body.is_some());
         let accessor_name = accessor.name;
-
-        if accessor.parameters.nodes.is_empty() {
-            // A zero-parameter setter (`set a() {}` in an interface/type
-            // literal) is grammatically invalid (`TS1049` fires separately)
-            // but still "lacks a parameter type annotation" for `TS7032`
-            // purposes — the loop below never runs for this shape.
-            if !paired_getter_supplies_type
-                && let Some(prop_name) = self.property_name_for_error(accessor_name)
-            {
-                let message = format!(
-                    "Property '{prop_name}' implicitly has type 'any', because its set accessor lacks a parameter type annotation."
-                );
-                self.error_at_node(
-                    accessor_name,
-                    &message,
-                    diagnostic_codes::PROPERTY_IMPLICITLY_HAS_TYPE_ANY_BECAUSE_ITS_SET_ACCESSOR_LACKS_A_PARAMETER_TYPE,
-                );
-            }
-            return;
-        }
+        // A set accessor gives its property no type when it has no parameter at
+        // all, or a parameter with no type annotation — "no parameter" subsumes
+        // "no annotation", so both halves feed one decision and one blame site.
+        let mut setter_lacks_property_type = accessor.parameters.nodes.is_empty();
 
         for (param_index, &param_idx) in accessor.parameters.nodes.iter().enumerate() {
             let Some(param_node) = self.ctx.arena.get(param_idx) else {
@@ -308,21 +292,37 @@ impl<'a> CheckerState<'a> {
             // TS7006 on the parameter: a paired getter contextually types it.
             self.maybe_report_implicit_any_parameter(param, paired_getter.is_some(), param_index);
 
-            // TS7032 on the setter name: nothing gave the property a type.
-            if param.type_annotation.is_none()
-                && !paired_getter_supplies_type
-                && let Some(prop_name) = self.property_name_for_error(accessor_name)
-            {
-                let message = format!(
-                    "Property '{prop_name}' implicitly has type 'any', because its set accessor lacks a parameter type annotation."
-                );
-                self.error_at_node(
-                    accessor_name,
-                    &message,
-                    diagnostic_codes::PROPERTY_IMPLICITLY_HAS_TYPE_ANY_BECAUSE_ITS_SET_ACCESSOR_LACKS_A_PARAMETER_TYPE,
-                );
+            if param.type_annotation.is_none() {
+                setter_lacks_property_type = true;
             }
         }
+
+        // TS7032 on the setter name: nothing gave the property a type. A paired
+        // getter that supplies the type (an annotation, or a body it can infer
+        // from) suppresses it.
+        if setter_lacks_property_type
+            && !paired_getter_supplies_type
+            && let Some(prop_name) = self.property_name_for_error(accessor_name)
+        {
+            self.report_set_accessor_lacks_parameter_type_annotation(accessor_name, &prop_name);
+        }
+    }
+
+    /// Emit `TS7032` on a `set` accessor's name — the single blame site for a
+    /// setter that leaves its property implicitly `any` (it has no parameter, or
+    /// an unannotated one). Centralizes the message and code shared by the
+    /// class, object-literal, interface, and type-literal accessor paths so the
+    /// diagnostic template is owned in one place.
+    pub(crate) fn report_set_accessor_lacks_parameter_type_annotation(
+        &mut self,
+        name_idx: NodeIndex,
+        prop_name: &str,
+    ) {
+        self.error_at_node_msg(
+            name_idx,
+            diagnostic_codes::PROPERTY_IMPLICITLY_HAS_TYPE_ANY_BECAUSE_ITS_SET_ACCESSOR_LACKS_A_PARAMETER_TYPE,
+            &[prop_name],
+        );
     }
 
     pub(crate) fn contextual_getter_return_type_for_class_accessor(
@@ -639,30 +639,11 @@ impl<'a> CheckerState<'a> {
         accessor_jsdoc: Option<&str>,
         accessor_name: Option<NodeIndex>,
     ) {
-        if parameters.is_empty() {
-            // A zero-parameter setter (`set y() {}`) is grammatically invalid
-            // (`TS1049` fires separately, from `check_setter_parameter_grammar`)
-            // but `tsc` still reports `TS7032`: "lacks a parameter type
-            // annotation" is true of a setter with no parameter at all, not
-            // only of one whose sole parameter is unannotated. The loop below
-            // never runs for this shape, so the check needs its own arm.
-            let property_type_supplied = has_paired_getter && paired_getter_supplies_type;
-            if !property_type_supplied
-                && self.ctx.no_implicit_any()
-                && let Some(name_idx) = accessor_name
-            {
-                let prop_name = self.parameter_name_for_error(name_idx);
-                let message = format!(
-                    "Property '{prop_name}' implicitly has type 'any', because its set accessor lacks a parameter type annotation."
-                );
-                self.error_at_node(
-                    name_idx,
-                    &message,
-                    diagnostic_codes::PROPERTY_IMPLICITLY_HAS_TYPE_ANY_BECAUSE_ITS_SET_ACCESSOR_LACKS_A_PARAMETER_TYPE,
-                );
-            }
-            return;
-        }
+        // A set accessor gives its property no type when it has no parameter at
+        // all, or a parameter with no type annotation (and no JSDoc supplying
+        // one) — "no parameter" subsumes "no annotation", so both halves feed
+        // one decision and one blame site below.
+        let mut setter_lacks_property_type = parameters.is_empty();
 
         for &param_idx in parameters {
             let Some(param_node) = self.ctx.arena.get(param_idx) else {
@@ -686,33 +667,26 @@ impl<'a> CheckerState<'a> {
             let has_jsdoc = has_paired_getter || jsdoc_declares_type;
             self.maybe_report_implicit_any_parameter(param, has_jsdoc, 0);
 
-            // Also report TS7032 on the setter name if the parameter implicitly has type any.
-            //
-            // A paired getter suppresses this only when it actually supplies the
-            // property's type. `declare class A { get g(); set g(v); }` has a
-            // paired getter and still reports TS7032 on the setter, because
-            // neither accessor names a type — the pair shares one property type
-            // and nothing provides it. The TS7006 flag above cannot be reused
-            // here: it folds in `has_paired_getter` unconditionally, which is
-            // right for contextually typing the parameter and wrong for deciding
-            // whether the property has a type at all.
-            let property_type_supplied =
-                jsdoc_declares_type || (has_paired_getter && paired_getter_supplies_type);
-            if param.type_annotation.is_none()
-                && !property_type_supplied
-                && self.ctx.no_implicit_any()
-                && let Some(name_idx) = accessor_name
-            {
-                let prop_name = self.parameter_name_for_error(name_idx);
-                let message = format!(
-                    "Property '{prop_name}' implicitly has type 'any', because its set accessor lacks a parameter type annotation."
-                );
-                self.error_at_node(
-                        name_idx,
-                        &message,
-                        diagnostic_codes::PROPERTY_IMPLICITLY_HAS_TYPE_ANY_BECAUSE_ITS_SET_ACCESSOR_LACKS_A_PARAMETER_TYPE,
-                    );
+            if param.type_annotation.is_none() && !jsdoc_declares_type {
+                setter_lacks_property_type = true;
             }
+        }
+
+        // TS7032 on the setter name: nothing gave the property a type. A paired
+        // getter suppresses this only when it actually supplies the property's
+        // type — `declare class A { get g(); set g(v); }` (or `set g()`) has a
+        // paired getter and still reports, because the pair shares one property
+        // type and neither accessor names it. The TS7006 flag above cannot be
+        // reused here: it folds in `has_paired_getter` unconditionally, which is
+        // right for contextually typing the parameter and wrong for deciding
+        // whether the property has a type at all.
+        if setter_lacks_property_type
+            && !(has_paired_getter && paired_getter_supplies_type)
+            && self.ctx.no_implicit_any()
+            && let Some(name_idx) = accessor_name
+        {
+            let prop_name = self.parameter_name_for_error(name_idx);
+            self.report_set_accessor_lacks_parameter_type_annotation(name_idx, &prop_name);
         }
     }
 

--- a/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
@@ -110,13 +110,12 @@ impl<'a> CheckerState<'a> {
                 .is_some_and(|name| obj_getter_names.contains(name));
             // Check if accessor JSDoc has @param type annotations
             let accessor_jsdoc = self.get_jsdoc_for_function(elem_idx);
-            // A zero-parameter setter (`{ set z() {} }`) is grammatically
-            // invalid (`TS1049` fires separately) but still "lacks a
-            // parameter type annotation" for `TS7032` purposes — the loop
-            // below never runs for this shape, so start from `true` instead
-            // of `false` and let an actual annotated/JSDoc-typed parameter
-            // clear it.
-            let mut first_param_lacks_annotation = accessor.parameters.nodes.is_empty();
+            // A setter gives its property no type when it has no parameter at
+            // all, or a parameter with no annotation (and no JSDoc supplying
+            // one) — "no parameter" subsumes "no annotation", so seed the flag
+            // from the empty case and let the loop set it for the unannotated
+            // case; the loop below never runs for a zero-parameter setter.
+            let mut setter_lacks_property_type = accessor.parameters.nodes.is_empty();
             for (pi, &param_idx) in accessor.parameters.nodes.iter().enumerate() {
                 if let Some(param_node) = self.ctx.arena.get(param_idx)
                     && let Some(param) = self.ctx.arena.get_parameter(param_node)
@@ -130,25 +129,20 @@ impl<'a> CheckerState<'a> {
                             false
                         };
                     if param.type_annotation.is_none() && !has_jsdoc {
-                        first_param_lacks_annotation = true;
+                        setter_lacks_property_type = true;
                     }
                     self.maybe_report_implicit_any_parameter(param, has_jsdoc, pi);
                 }
             }
-            // TS7032: emit on property name when the setter has no parameter type
-            // annotation and no paired getter (TSC checks this at accessor symbol
+            // TS7032: emit on property name when the setter supplies no property
+            // type and has no paired getter (TSC checks this at accessor symbol
             // resolution time; we emit it here during object literal checking).
-            if first_param_lacks_annotation
+            if setter_lacks_property_type
                 && !has_paired_getter
                 && self.ctx.no_implicit_any()
                 && let Some(prop_name) = name_opt.as_deref()
             {
-                use crate::diagnostics::diagnostic_codes;
-                self.error_at_node_msg(
-                            accessor.name,
-                            diagnostic_codes::PROPERTY_IMPLICITLY_HAS_TYPE_ANY_BECAUSE_ITS_SET_ACCESSOR_LACKS_A_PARAMETER_TYPE,
-                            &[prop_name],
-                        );
+                self.report_set_accessor_lacks_parameter_type_annotation(accessor.name, prop_name);
             }
         }
 


### PR DESCRIPTION
Behavior-preserving cleanup following up #16814 (bug #16809).

#16814 fixed the zero-parameter `set` accessor TS7032 gap by adding an early-return arm at each of the three emission sites. That left the diagnostic message string and its `error_at_node` call duplicated across the new arms **and** the pre-existing per-parameter arms — five hand-written copies of the same template text across two files, a hand-written string re-deriving the diagnostics-data template.

This consolidates them:

- New `report_set_accessor_lacks_parameter_type_annotation` — the single blame site for TS7032, emitting through the diagnostics-data template (`error_at_node_msg`) so the message text is owned in one place, not hand-written per call.
- Each site now computes one `setter_lacks_property_type` predicate (seeded from `parameters.is_empty()`, set inside the loop for the unannotated-parameter case) and emits once after the loop. "No parameter" subsumes "no annotation", so both halves feed one decision. The object-literal site already used this shape; the two `accessor_checker.rs` sites now match it, replacing #16814's early-return arms.

Structural rule (unchanged from #16814): when a `set` accessor supplies no property type — it has no parameter, or an unannotated one — and no paired getter supplies it, tsc reports TS7032 on the setter name under `noImplicitAny`, in every container (class, object literal, ambient class, interface, type literal). Owned by the checker (`checkers/accessor_checker.rs`, `types/computation/object_literal/accessor_element.rs`).

Per-parameter TS7006 reporting, the paired-getter suppression, the `noImplicitAny` gate, and the setter-name blame site are all unchanged. Net −32 lines.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts7032_zero_parameter_setter_tests` — #16814's suite (14 tests) green on the refactored code, confirming behavior is preserved.
- `cargo test -p tsz-checker --test noimplicitany_type_member_accessor_tests` (27), `--test setter_parameter_grammar_container_coverage_tests` (22), `--test object_literal_set_only_accessor_type_tests` (7), `--test object_literal_accessor_pair_parameter_type_tests` (11), `--test noimplicitany_ambient_member_surface_tests` (45) — all green.
- Pre-commit `clippy` + `arch-size` + local `-p tsz-checker` verification passed.
- Oracle spot-check (`typescript@7.0.2`) over the full container × pairing matrix (zero-param, one-unannotated, annotated, 2-param, paired-typed/body/untyped, static/abstract/private/computed/string-name) matches tsc.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_019Bfhyf5TYXgxJe2sgW6jZL)_