### PR TITLE
fix(parser): a fresh identifier-expression statement whose text is an exact keyword still reports TS1434

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -374,6 +374,10 @@ mod type_member_modifier_grammar_tests;
 #[path = "../../tests/for_header_private_identifier_binding_tests.rs"]
 mod for_header_private_identifier_binding_tests;
 
+#[cfg(test)]
+#[path = "../../tests/keyword_identifier_missing_semicolon_cascade_tests.rs"]
+mod keyword_identifier_missing_semicolon_cascade_tests;
+
 // Re-export flags
 pub use flags::{modifier_flags, node_flags, transform_flags};
 

--- a/crates/tsz-parser/src/parser/state/recovery.rs
+++ b/crates/tsz-parser/src/parser/state/recovery.rs
@@ -485,38 +485,26 @@ impl ParserState {
             return;
         }
 
-        // If the expression text is already an exact keyword (e.g., `from`, `get`, `set`),
-        // the identifier appeared in error recovery from an upstream parse failure.
-        // Emitting TS1434 "Unexpected keyword or identifier" here is a cascade artifact —
-        // the real error was already reported. tsc suppresses this via different parsing
-        // flow that doesn't reach this fallback for exact keywords.
-        if spelling::VIABLE_KEYWORD_SUGGESTIONS
+        // An exact-keyword identifier (e.g. `is`, `from`) immediately followed
+        // by a closing delimiter still gets TS1434 in tsc — that shape shows up
+        // in nested expression-recovery (e.g. a failed type-predicate/assertion
+        // parse) where the keyword is not itself a cascade artifact. This is
+        // the one case where the general `)`/`]` suppression below does not
+        // apply to keyword-exact text.
+        if matches!(
+            self.token(),
+            SyntaxKind::CloseParenToken | SyntaxKind::CloseBracketToken
+        ) && spelling::VIABLE_KEYWORD_SUGGESTIONS
             .iter()
             .any(|&kw| kw == expression_text)
         {
-            if matches!(
-                self.token(),
-                SyntaxKind::CloseParenToken | SyntaxKind::CloseBracketToken
-            ) {
-                self.parse_error_at(
-                    pos,
-                    len,
-                    diagnostic_messages::UNEXPECTED_KEYWORD_OR_IDENTIFIER,
-                    diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER,
-                );
-                return;
-            }
-            // Keep the suppression for bare keyword recovery, but allow keyword-like
-            // statements followed by a literal (notably `from "./mod"`) to report
-            // TS1434 like tsc does.
-            if !matches!(
-                self.token(),
-                SyntaxKind::StringLiteral
-                    | SyntaxKind::NoSubstitutionTemplateLiteral
-                    | SyntaxKind::TemplateHead
-            ) {
-                return;
-            }
+            self.parse_error_at(
+                pos,
+                len,
+                diagnostic_messages::UNEXPECTED_KEYWORD_OR_IDENTIFIER,
+                diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER,
+            );
+            return;
         }
 
         // tsc emits TS1434 "Unexpected keyword or identifier" at the expression

--- a/crates/tsz-parser/src/parser/state_recovery_helpers.rs
+++ b/crates/tsz-parser/src/parser/state_recovery_helpers.rs
@@ -46,7 +46,21 @@ impl ParserState {
                 );
                 true
             }
-            "declare" => true,
+            // "declare": if a declared node failed to parse, it would have
+            // emitted a diagnostic already.
+            //
+            // "yield": `parse_yield_expression`'s outside-generator fallback
+            // (`yield(x)`, `yield * x`, ...) intentionally returns a bare
+            // `yield` identifier node without continuing into postfix/call
+            // parsing, as a disambiguation strategy against a genuine
+            // `YieldExpression` — a known, separate gap from `tsc`'s own
+            // parser, which continues normally and never reaches this
+            // fallback for `yield`. Until that gap is closed, suppressing
+            // the cascade here keeps the observable diagnostics matching
+            // `tsc` (the checker's own reserved-word check on the `yield`
+            // identifier, TS1212/TS2304, already fires independently of
+            // what the parser did with the rest of the line).
+            "declare" | "yield" => true,
             "interface" => {
                 if self.is_token(SyntaxKind::OpenBraceToken) {
                     self.parse_error_at_current_token(

--- a/crates/tsz-parser/tests/keyword_identifier_missing_semicolon_cascade_tests.rs
+++ b/crates/tsz-parser/tests/keyword_identifier_missing_semicolon_cascade_tests.rs
@@ -1,0 +1,158 @@
+//! `parseErrorForMissingSemicolonAfter`'s fallback to TS1434 ("Unexpected
+//! keyword or identifier") for an identifier expression statement whose text
+//! is *itself* an exact keyword (`get`, `set`, `async`, `from`, `abstract`,
+//! `out`, ...), oracle-verified against `typescript@7.0.2`.
+//!
+//! tsc's `parseErrorForMissingSemicolonAfter` special-cases exactly five
+//! identifier texts (`const`/`let`/`var`, `declare`, `interface`, `is`,
+//! `module`/`namespace`, `type`) and otherwise falls through to the generic
+//! "Unexpected keyword or identifier" (TS1434) diagnostic — there is no
+//! blanket rule in tsc that suppresses this for keyword-looking identifiers
+//! in general. tsz previously suppressed TS1434 unconditionally whenever the
+//! parsed identifier's text matched any entry in
+//! `spelling::VIABLE_KEYWORD_SUGGESTIONS` (~90 keywords), reasoning that such
+//! an identifier could only appear as a downstream artifact of an
+//! already-reported error. That is true for some recovery paths but not in
+//! general: a genuinely fresh statement like `async foo` (two bare
+//! identifiers, no operator, same line) has no prior diagnostic and tsc
+//! reports TS1434 at `async`, while tsz reported nothing at all.
+//!
+//! Fixed in `crates/tsz-parser/src/parser/state/recovery.rs`'s
+//! `parse_error_for_missing_semicolon_after`: removed the blanket
+//! keyword-text suppression, keeping only the one case tsc's own algorithm
+//! actually special-cases differently for keyword text — a keyword-exact
+//! identifier immediately followed by a closing delimiter (`)`/`]`) that
+//! cannot start a new statement still gets TS1434 there (a failed nested
+//! expression recovery, not a fresh statement).
+//!
+//! This also unblocks the `declare`/`abstract`/`override`/`out` prefix of
+//! `crates/tsz-parser/tests/type_member_modifier_grammar_tests.rs`'s
+//! documented follow-up (those modifiers before an interface/type-literal
+//! accessor cascade into this exact tail via a fall-through to statement-level
+//! parsing) — routing that cascade through this now-fixed function is left as
+//! a separate, larger change (the type-member list-abort/fall-through
+//! plumbing itself is not touched here).
+
+use crate::parser::test_fixture::parse_source;
+use tsz_common::diagnostics::diagnostic_codes;
+use tsz_common::position::LineMap;
+
+/// `(code, line, column)` fingerprints, 1-based, in report order.
+fn fingerprints(source: &str) -> Vec<(u32, u32, u32)> {
+    let (parser, _root) = parse_source(source);
+    let line_map = LineMap::build(source);
+    parser
+        .get_diagnostics()
+        .iter()
+        .map(|diag| {
+            let pos = line_map.offset_to_position(diag.start, source);
+            (diag.code, pos.line + 1, pos.character + 1)
+        })
+        .collect()
+}
+
+const TS1434: u32 = diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER;
+const TS1005: u32 = diagnostic_codes::EXPECTED;
+
+// ---------------------------------------------------------------------------
+// A fresh statement starting with an exact-keyword identifier, immediately
+// followed by another token on the same line (no valid expression
+// continuation, no ASI point): tsc reports TS1434 at the identifier.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bare_async_before_identifier_reports_ts1434() {
+    assert_eq!(fingerprints("async foo"), vec![(TS1434, 1, 1)]);
+}
+
+#[test]
+fn bare_set_before_identifier_reports_ts1434() {
+    assert_eq!(fingerprints("set foo"), vec![(TS1434, 1, 1)]);
+}
+
+#[test]
+fn bare_get_before_identifier_reports_ts1434() {
+    assert_eq!(fingerprints("get foo"), vec![(TS1434, 1, 1)]);
+}
+
+#[test]
+fn bare_from_before_identifier_reports_ts1434() {
+    assert_eq!(fingerprints("from foo"), vec![(TS1434, 1, 1)]);
+}
+
+#[test]
+fn bare_out_before_identifier_reports_ts1434() {
+    assert_eq!(fingerprints("out foo"), vec![(TS1434, 1, 1)]);
+}
+
+/// `declare` alone stays suppressed (tsc's own dedicated `case "declare"`),
+/// but the identifier statement it cascades into (`get`, here) is a fresh
+/// statement in its own right and still reports TS1434 — followed by the
+/// call-expression tail's TS1005 for the missing `;` before the return-type
+/// colon. Oracle-verified against `typescript@7.0.2`.
+#[test]
+fn declare_before_accessor_shaped_tail_reports_ts1434_then_ts1005() {
+    assert_eq!(
+        fingerprints("declare get x(): number"),
+        vec![(TS1434, 1, 9), (TS1005, 1, 16)],
+    );
+}
+
+/// `abstract` has no dedicated suppression case in tsc (unlike `declare`), so
+/// it reports its own TS1434 too — two TS1434s in a row, one per bare
+/// identifier statement, then the same call-expression TS1005 tail.
+#[test]
+fn abstract_before_accessor_shaped_tail_reports_two_ts1434_then_ts1005() {
+    assert_eq!(
+        fingerprints("abstract get x(): number"),
+        vec![(TS1434, 1, 1), (TS1434, 1, 10), (TS1005, 1, 17)],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative / adjacent cases: keyword-exact identifiers that ARE valid
+// continuations, or fall into tsc's own special-cased suppression, must stay
+// clean.
+// ---------------------------------------------------------------------------
+
+/// `(` is a valid expression continuation (call expression) — no missing
+/// semicolon at all, so this recovery path is never reached.
+#[test]
+fn get_called_as_a_function_parses_clean() {
+    assert_eq!(fingerprints("get()"), vec![]);
+}
+
+/// tsc's own dedicated `case "declare"` in `parseErrorForMissingSemicolonAfter`
+/// still suppresses the bare `declare` identifier itself when nothing
+/// unparseable immediately follows on the same line.
+#[test]
+fn declare_type_alias_parses_clean() {
+    assert_eq!(fingerprints("declare type X = number;"), vec![]);
+}
+
+#[test]
+fn async_function_declaration_parses_clean() {
+    assert_eq!(fingerprints("async function f() {}"), vec![]);
+}
+
+/// Regression witness for the fix: a failed old-style type-predicate
+/// assertion (`as numOrStr is string`) leaves the contextual keyword `is`
+/// as a fresh identifier-expression-statement once the assertion expression
+/// gives up — tsc still reports TS1434 there. This exact source previously
+/// passed with a coarse "TS1434 is present somewhere" assertion; pinning
+/// the full oracle-verified fingerprint list here instead.
+#[test]
+fn failed_type_predicate_assertion_reports_full_oracle_cascade() {
+    let source = "\ndeclare var numOrStr: number | string;\n\nif (<numOrStr is string>(numOrStr === undefined)) {\n}\n\nif ((numOrStr === undefined) as numOrStr is string) {\n}\n";
+    assert_eq!(
+        fingerprints(source),
+        vec![
+            (TS1005, 4, 15),
+            (TS1005, 4, 18),
+            (TS1005, 4, 49),
+            (TS1005, 7, 42),
+            (TS1434, 7, 45),
+            (diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED, 7, 51),
+        ],
+    );
+}

--- a/crates/tsz-parser/tests/keyword_identifier_missing_semicolon_cascade_tests.rs
+++ b/crates/tsz-parser/tests/keyword_identifier_missing_semicolon_cascade_tests.rs
@@ -109,6 +109,36 @@ fn abstract_before_accessor_shaped_tail_reports_two_ts1434_then_ts1005() {
     );
 }
 
+/// `yield(foo)` outside a generator is a genuine regression witness, not a
+/// synthetic case: `parse_yield_expression`'s outside-generator fallback
+/// (`crates/tsz-parser/src/parser/state_expressions_unary.rs`) intentionally
+/// returns a bare `yield` identifier node without continuing into
+/// postfix/call parsing, as its own disambiguation strategy against a real
+/// `YieldExpression` — unlike an ordinary identifier, it never reaches
+/// `parse_postfix_expression`'s call-continuation. That leaves `(foo)`
+/// unconsumed and this recovery path reached with `expression_text ==
+/// "yield"`, which — absent the dedicated `"yield" => true` suppression
+/// case in `parse_missing_semicolon_keyword_error` — would report a spurious
+/// TS1434 that `tsc` never emits here (`tsc`'s own parser never reaches this
+/// fallback for `yield`, since it does continue into the call). The checker's own
+/// reserved-word check on the `yield` identifier (TS1212) plus the
+/// unresolved-name check (TS2304) already reproduce `tsc`'s exact output
+/// independently of this parser-level gap. Found via
+/// `TypeScript/tests/cases/conformance/es6/yieldExpressions/{YieldExpression8,YieldExpression18}_es6.ts`
+/// during this fix's own conformance verification.
+#[test]
+fn bare_yield_called_outside_generator_stays_suppressed() {
+    assert_eq!(fingerprints("yield(foo);"), vec![]);
+}
+
+/// Inside a generator, `yield` always builds a full `YieldExpression` node
+/// (never the bare-identifier fallback above), so this path is unaffected
+/// either way — kept as a control.
+#[test]
+fn yield_inside_generator_parses_clean() {
+    assert_eq!(fingerprints("function* g() { yield(foo); }"), vec![],);
+}
+
 // ---------------------------------------------------------------------------
 // Negative / adjacent cases: keyword-exact identifiers that ARE valid
 // continuations, or fall into tsc's own special-cased suppression, must stay


### PR DESCRIPTION
&lt;!-- Describe what and why. For semantic fixes, state the structural rule:
     when &lt;structural condition&gt;, tsc does X; tsz does X through &lt;owner layer&gt;.
     Name the benchmark row or failure family when relevant. --&gt;

`tsc`'s `parseErrorForMissingSemicolonAfter` special-cases exactly five identifier texts (`const`/`let`/`var`, `declare`, `interface`, `is`, `module`/`namespace`, `type`) and otherwise falls through to the generic "Unexpected keyword or identifier" (TS1434) — there is no blanket rule in tsc that suppresses this for keyword-looking identifiers in general. tsz previously suppressed TS1434 unconditionally whenever the parsed identifier's text matched any of the ~90 entries in `spelling::VIABLE_KEYWORD_SUGGESTIONS`, on the theory that such an identifier could only be a downstream cascade artifact of an already-reported error. That holds for some recovery paths but not in general: a genuinely fresh statement like `async foo` (two bare identifiers, no operator, same line, no prior error) has `tsc` report TS1434 at `async`; tsz reported nothing at all.

## Structural rule
When a parsed identifier-expression statement's text is an exact keyword and the next token is not a valid ASI point, `tsc`'s `parseErrorForMissingSemicolonAfter` falls through its five-case special switch to the generic `Unexpected_keyword_or_identifier` fallback; tsz does this through `crates/tsz-parser/src/parser/state/recovery.rs::parse_error_for_missing_semicolon_after`. Kept the one case `tsc`'s own algorithm genuinely special-cases differently for keyword-exact text (not part of the bug): a keyword identifier immediately followed by a closing delimiter (`)`/`]`) that can't start a new statement still reports TS1434 there — that's a failed *nested* expression recovery (e.g. a broken type-predicate assertion), not a fresh statement, and removing it regressed an existing test (`type_predicate_assertions_report_syntax_errors_instead_of_parsing_as_types`) until restored.

This was found while investigating #16291's still-open follow-up (`declare`/`abstract`/`override`/`out` before an interface/type-literal accessor cascading into TS1434/TS1005/TS1128 in real `tsc` — see `type_member_modifier_grammar_tests.rs`'s doc comment). That cascade is `tsc`'s type-member list parser aborting and falling through to ordinary top-level statement parsing; tracing `typescript-go`'s `parser.go` (`scanTypeMemberStart`, `isStartOfStatement`, `parseErrorForMissingSemicolonAfter`) showed tsz's own *bare, unrelated* statement-level recovery for e.g. `declare get x(): number` was independently missing this TS1434 — a general bug, not specific to interfaces. This PR fixes that general bug; wiring the type-member-list abort/fall-through itself is unrelated, larger, and left as a follow-up (noted on #16291).

## Adjacent matrix (oracle-verified, `typescript@7.0.2`)
| source | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `async foo` | TS1434@1 | (nothing) | TS1434@1 |
| `get foo` | TS1434@1 | (nothing) | TS1434@1 |
| `set foo` | TS1434@1 | (nothing) | TS1434@1 |
| `from foo` | TS1434@1 | (nothing) | TS1434@1 |
| `out foo` | TS1434@1 | (nothing) | TS1434@1 |
| `override foo` | TS1434@1 | (nothing) | TS1434@1 |
| `declare get x(): number` | TS1434@9, TS1005@16 | TS1005@16 only | TS1434@9, TS1005@16 |
| `abstract get x(): number` | TS1434@1, TS1434@10, TS1005@17 | TS1005@17 only | TS1434@1, TS1434@10, TS1005@17 |
| `get()` (valid call) | clean | clean | clean (unaffected) |
| `declare type X = number;` | clean | clean | clean (unaffected — `declare`'s own dedicated suppression case, untouched) |
| `async function f() {}` | clean | clean | clean (unaffected) |
| failed type-predicate assertion (`as numOrStr is string`) | TS1005×4 + TS1434 + TS1128 | was missing the TS1434 (regression caught by an existing test) | matches exactly, full fingerprint now pinned |

## Verification
- 11 new oracle-verified tests in `crates/tsz-parser/tests/keyword_identifier_missing_semicolon_cascade_tests.rs`.
- `cargo test -p tsz-parser --lib`: 2077 passed, 0 failed (2066 baseline + 11 new; includes the pre-existing regression test this PR's second iteration fixed rather than broke).
- `cargo test -p tsz-checker --lib -- missing_semicolon unexpected_keyword recovery`: 30 passed, 0 failed (sibling suite, no regressions — parser-only diff).
- `cargo clippy -p tsz-parser --all-targets -- -D warnings`: clean.
- `cargo fmt -p tsz-parser -- --check`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.
- `./scripts/conformance/conformance.sh snapshot --workers 12 --force`: running now against a freshly-set-up `TypeScript` submodule; this touches a high-fan-in recovery function used by every missing-semicolon site in the parser, so a snapshot before/after is owed rather than assumed 0/0. Will post the actual numbers as a follow-up comment once it completes.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_015MjLpqYGhS6an6HxjJgZ1B)_