### PR TITLE
docs(tests): correct stale static-block claim in await-grammar header (#16073)

### DIFF
--- a/crates/tsz-checker/src/tests/await_grammar_statement_position_tests.rs
+++ b/crates/tsz-checker/src/tests/await_grammar_statement_position_tests.rs
@@ -268,15 +268,18 @@ function h() { const holder = { emit() { throw await 1; } }; }
 /// now correct and pinned below (`class_member_body_await_reports_ts1308`):
 /// #16070 made a class member body a `ctx.function_depth` boundary.
 ///
-/// A class static block is deliberately *not* asserted, and the reason is
-/// narrower than it looks. `class K { static { await 1; } }` is correct
-/// through the CLI on any target — tsc and tsz both answer TS18037 — but
-/// through this suite's `check_source_codes` (which uses
-/// `CheckerOptions::default()`) tsz answers `[TS1375, TS1378]`, the
-/// top-level-await pair, i.e. it treats the static block as the top level of
-/// the file. That is a real defect, visible only under the unit harness's
-/// default options, and it is tracked on its own issue rather than pinned
-/// red here.
+/// A class static block was once wrong here in the same way: through this
+/// suite's parse-health-blind `check_source_codes` (which uses
+/// `CheckerOptions::default()`) `class K { static { await 1; } }` answered
+/// `[TS1375, TS1378]`, the top-level-await pair, as if the static block were
+/// the top level of the file. That is fixed. #16367 made
+/// `checkAwaitExpression`'s class-static-block branch exclusive at the source
+/// (`await_container_is_class_static_block` in `core_statement_checks.rs`), so
+/// this walk now declines and the parser's TS18037 stands alone. It is pinned
+/// in its own suite, `await_static_block_grammar_tests.rs` — in particular
+/// `static_block_await_is_silent_in_the_checker_walk_without_suppression`,
+/// which asserts that the same blind `check_source_codes` helper now reports
+/// none of TS1308/TS1375/TS1378 — rather than restated here.
 #[test]
 fn while_condition_await_in_function_expression_reports_ts1308() {
     let source = r"


### PR DESCRIPTION
Closes #16073.

The doc header on `while_condition_await_in_function_expression_reports_ts1308`
(`crates/tsz-checker/src/tests/await_grammar_statement_position_tests.rs`) still
described the class **static-block** `await` case as *"a real defect ... tracked
on its own issue rather than pinned red here"* — claiming that
`class K { static { await 1; } }` answers the top-level-await pair
`[TS1375, TS1378]` through the harness's parse-health-blind `check_source_codes`.

That is no longer true. The defect was fixed by #16367 (the `await using` sibling
by #16598): `checkAwaitExpression`'s class-static-block branch is now exclusive at
the source via `await_container_is_class_static_block`
(`core_statement_checks.rs`), so the checker walk declines and the parser's
`TS18037` stands alone. The behavior is comprehensively pinned in
`await_static_block_grammar_tests.rs` — notably
`static_block_await_is_silent_in_the_checker_walk_without_suppression`, which uses
the *same* blind `check_source_codes` helper the #16073 comment identified and
asserts none of `TS1308`/`TS1375`/`TS1378` fire.

This is the exact failure mode #16073 is about: a current-behavior claim written
once, believed, never re-checked — now pointing the next reader at a defect and a
tracking issue that no longer exist. The header is rewritten to state the case is
fixed and to cross-reference the suite that pins it, following the issue's own
meta-lesson (express behavior as tests, not prose — here the tests already exist,
so the prose just needed to stop contradicting them).

The sibling `class_member_body_await_reports_ts1308` claim in the same header was
already accurate (fixed by #16070, correctly pointed at its pin) and is left
untouched. A sweep of the other await-grammar test-file headers
(`await_grammar_computed_property_name_tests.rs`,
`await_grammar_expression_position_tests.rs`) found no other stale current-behavior
claims — their similar phrases describe intentionally-unasserted, still-accurate
cases.

Test-only; no production change.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib -- await_static_block_grammar await_grammar_statement_position` → **43 passed; 0 failed** on the branch. The static-block pins (which prove the rewritten prose) are green, confirming the documented behavior.
- `cargo clippy -p tsz-checker --lib` → clean (no `doc_markdown` regressions from the reworded comment).
- `python3 scripts/arch/arch_guard.py` → `Architecture guardrails passed.`
- These two (`clippy` + `arch-size`) are the per-merge CI lane; conformance/emit/fourslash are unaffected — the change touches only a doc comment in a test file.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRzBMRveCfuUkjY7TEVQVU)_