### PR TITLE
fix(checker): TS18029/TS18009 suppress a file's semantic diagnostics like tsc

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1610,12 +1610,23 @@ pub(super) const fn is_real_syntax_error(code: u32) -> bool {
         | 1438 // Interface must be given a name (recovery creates invalid expression statements)
         | 1442 // Identifier or expression expected (TS-only construct in JS)
         | 1477 // Member must have an initializer
-        // TS18030 is emitted by tsc's parser (`parseErrorAtRange` on a private
-        // identifier in an optional chain), so it belongs to the syntactic
-        // phase: tsc reports it and then skips the whole program's semantic
-        // diagnostics. Without this entry a chain continuation such as
-        // `o?.a.#b` would still surface the receiver's possibly-nullish
-        // TS2532/TS18048, which tsc suppresses.
+        // The private-identifier-in-a-value-position family. All three are tsc
+        // *parser* diagnostics (`parseErrorAtRange`) that land in
+        // `sourceFile.parseDiagnostics` and drive `hasParseDiagnostics()`, so tsc
+        // short-circuits the program's whole semantic phase: `o?.a.#b` stops
+        // surfacing the receiver's TS2532/TS18048, and a `const #x` / `function
+        // f(#x)` file stops surfacing trailing TS2322/TS2304. tsz emits all three
+        // from the parser too (`parse_error_at`), so they must be classified
+        // together here (TS18029/TS18009 were previously missing — issue #16817).
+        // Distinct from the checker-routed private-identifier grammar codes
+        // TS18016/TS18024, which tsc raises via `grammarErrorOnNode` and are
+        // suppressed *by* — not triggers of — a parse error, so they live in
+        // `is_parser_grammar_code`. Oracle evidence: #16817 and the #16279 audit
+        // round 6, which found all of these "survive Direction B" (tsc keeps them
+        // alongside an unrelated real syntax error — the signature of a genuine
+        // parser diagnostic rather than a checker grammar check).
+        | 18009 // Private identifiers cannot be used as parameters
+        | 18029 // Private identifiers are not allowed in variable declarations
         | 18030 // An optional chain cannot contain private identifiers
     )
 }
@@ -1890,3 +1901,7 @@ mod class_static_block_grammar_tests;
 #[cfg(test)]
 #[path = "check_utils/import_call_type_arguments_grammar_tests.rs"]
 mod import_call_type_arguments_grammar_tests;
+
+#[cfg(test)]
+#[path = "check_utils/private_identifier_parse_error_suppression_tests.rs"]
+mod private_identifier_parse_error_suppression_tests;

--- a/crates/tsz-cli/src/driver/check_utils/private_identifier_parse_error_suppression_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/private_identifier_parse_error_suppression_tests.rs
@@ -1,0 +1,173 @@
+//! Tests for the private-identifier parser-error family in
+//! `is_real_syntax_error` (issue #16817).
+//!
+//! TS18009 (`Private identifiers cannot be used as parameters.`), TS18029
+//! (`Private identifiers are not allowed in variable declarations.`) and TS18030
+//! (`An optional chain cannot contain private identifiers.`) are tsc *parser*
+//! diagnostics that drive `hasParseDiagnostics()`, short-circuiting the whole
+//! program's semantic phase — see the family comment on the `18009 | 18029 |
+//! 18030` arm of `is_real_syntax_error`. tsz emits all three from the parser but
+//! only classified TS18030, so TS18029/TS18009 files went on to full semantic
+//! checking and surfaced diagnostics tsc never reaches. These tests pin the
+//! classifier and the end-to-end suppression, plus the controls that must keep
+//! full semantic checking. Witnesses pinned against `typescript@7.0.2` (issue
+//! #16817; #16279 audit round 6 for the Direction-B evidence).
+
+use super::super::check::{CheckerLibSet, collect_diagnostics};
+use super::*;
+
+const TS18009: u32 = 18009;
+const TS18029: u32 = 18029;
+const TS18030: u32 = 18030;
+
+/// The whole private-identifier-in-a-value-position family is a real syntax
+/// error (drives tsc's whole-program semantic short-circuit) and must stay a
+/// genuine *parser* diagnostic — a suppression trigger, not a checker-routed
+/// grammar code that is itself suppressed.
+#[test]
+fn private_identifier_value_position_codes_are_real_syntax_errors() {
+    for code in [TS18009, TS18029, TS18030] {
+        assert!(
+            is_real_syntax_error(code),
+            "TS{code} is a tsc parser diagnostic (parseErrorAtRange) that drives \
+             hasParseDiagnostics(); it must count as a real syntax error so the \
+             program's semantic phase is short-circuited, matching tsc."
+        );
+        assert!(
+            !is_parser_grammar_code(code),
+            "TS{code} survives Direction B (tsc keeps it alongside an unrelated \
+             real syntax error), so it is a parser diagnostic, not a checker-side \
+             grammar code."
+        );
+        assert!(
+            !is_non_suppressing_parse_error(code),
+            "TS{code} triggers tsc's hasParseDiagnostics() suppression, so it must \
+             remain a suppressing parse error."
+        );
+    }
+}
+
+/// Control: the *checker-routed* private-identifier grammar codes (TS18016
+/// `outside class bodies`, TS18024 `enum member named with a private
+/// identifier`) are raised by tsc via `grammarErrorOnNode`, so they are
+/// suppressed *by* a parse error rather than being a trigger of one. They must
+/// not be promoted into the real-syntax-error family — that split is the whole
+/// point of the fix.
+#[test]
+fn checker_routed_private_identifier_grammar_codes_stay_non_suppressing() {
+    for code in [18016_u32, 18024] {
+        assert!(
+            !is_real_syntax_error(code),
+            "TS{code} is a checker-side grammar check in tsc; promoting it to a \
+             real syntax error would wrongly suppress the program's semantics."
+        );
+        assert!(
+            is_parser_grammar_code(code),
+            "TS{code} is a checker-routed grammar code and must stay in \
+             is_parser_grammar_code."
+        );
+    }
+}
+
+fn collect_diagnostic_codes(files: &[(&str, &str)]) -> Vec<u32> {
+    let bind_results: Vec<_> = files
+        .iter()
+        .map(|(file_name, source)| {
+            parallel::parse_and_bind_single((*file_name).to_string(), (*source).to_string())
+        })
+        .collect();
+    let program = parallel::merge_bind_results(bind_results);
+    let type_cache_output = std::sync::Mutex::new(FxHashMap::default());
+
+    let mut codes: Vec<u32> = collect_diagnostics(
+        &CollectDiagnosticsInput {
+            program: &program,
+            options: &ResolvedCompilerOptions::default(),
+            base_dir: std::path::Path::new("/"),
+            reference_path_current_directory: None,
+            checker_libs: &CheckerLibSet::default(),
+            typescript_dom_replacement_globals: (false, false, false),
+            has_deprecation_diagnostics: false,
+            collect_compile_stats: false,
+        },
+        None,
+        &type_cache_output,
+    )
+    .diagnostics
+    .iter()
+    .map(|diagnostic| diagnostic.code)
+    .collect();
+    codes.sort_unstable();
+    codes
+}
+
+/// Each private-identifier parse error suppresses the file's trailing semantics.
+/// The TS18029 witness is issue #16817's repro (a `for`-header private-identifier
+/// binding next to a mis-annotation and an unresolved name); TS18009 is the
+/// parameter sibling. tsc reports only the parse code — the trailing TS2322
+/// (mis-annotation) and TS2304 (unresolved name) must be suppressed program-wide.
+#[test]
+fn private_identifier_parse_error_suppresses_trailing_semantics() {
+    let witnesses = [
+        (
+            TS18029,
+            "const arr = [1];\nfor (const #x of arr) {}\nconst bad: number = \"str\";\nnope();\n",
+        ),
+        (
+            TS18009,
+            "function f(#x) {}\nconst bad: number = \"str\";\nnope();\n",
+        ),
+    ];
+    for (code, source) in witnesses {
+        let codes = collect_diagnostic_codes(&[("repro.ts", source)]);
+        assert!(
+            codes.contains(&code),
+            "expected TS{code} for the private-identifier witness, got {codes:?}"
+        );
+        assert!(
+            !codes.contains(&2322) && !codes.contains(&2304),
+            "TS{code} is a parse error; tsc short-circuits the semantic phase, so \
+             the trailing TS2322/TS2304 must not appear, got {codes:?}"
+        );
+    }
+}
+
+/// Program-wide fence: a private-identifier parse error in one file suppresses
+/// the semantic diagnostics of an *unrelated* clean file in the same program,
+/// mirroring tsc's `hasParseDiagnostics()` short-circuit over the whole program.
+#[test]
+fn private_identifier_parse_error_suppresses_semantics_program_wide() {
+    let codes = collect_diagnostic_codes(&[
+        ("bad.ts", "const #x = 1;\n"),
+        ("clean.ts", "const bad: number = \"str\";\n"),
+    ]);
+    assert!(
+        codes.contains(&TS18029),
+        "expected TS18029 from bad.ts, got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2322),
+        "a real syntax error anywhere in the program suppresses semantic \
+         diagnostics program-wide, so clean.ts's TS2322 must not appear, got {codes:?}"
+    );
+}
+
+/// Negative control: a *legal* private identifier inside a class body is not a
+/// parse error, so full semantic checking still runs and an unrelated
+/// mis-annotation still reports TS2322.
+#[test]
+fn legal_private_identifier_keeps_full_semantic_checking() {
+    let codes = collect_diagnostic_codes(&[(
+        "ok.ts",
+        "class C { #p = 1; m() { return this.#p; } }\nconst bad: number = \"str\";\n",
+    )]);
+    assert!(
+        !codes.contains(&TS18009) && !codes.contains(&TS18029) && !codes.contains(&TS18030),
+        "a legal private field must not raise any private-identifier parse error, got {codes:?}"
+    );
+    assert!(
+        codes.contains(&2322),
+        "with no parse error, semantic checking runs and the mis-annotation's \
+         TS2322 must be reported, got {codes:?}"
+    );
+}


### PR DESCRIPTION
Fixes #16817.

Structural rule: when a file records a private-identifier **parse-category** diagnostic — TS18029 (private identifier in a variable declaration), TS18009 (private identifier as a parameter), TS18030 (private identifier in an optional chain) — tsc emits it from its **parser** (`parseErrorAtRange`), so it lands in `sourceFile.parseDiagnostics`, `hasParseDiagnostics()` becomes true, and tsc short-circuits the program's whole semantic phase. tsz continued to full semantic checking and reported diagnostics (TS2322, TS2304, …) tsc never reaches. Owner layer: the `is_real_syntax_error` parse-category classifier in `crates/tsz-cli/src/driver/check_utils.rs`, which drives `program_has_real_syntax_errors` → program-wide semantic suppression.

tsz already listed TS18030 there; the fix adds its two parser-emitted siblings TS18009 and TS18029 to the same arm so the whole family drives the fence identically. This is deliberately *not* scoped to the bug's single witness (TS18029): "TS18029 is the witness, not the boundary" (#16817). It keeps the mirror-image split intact — the checker-routed private-identifier grammar codes TS18016/TS18024 are raised by tsc via `grammarErrorOnNode`, are suppressed *by* rather than triggers of a parse error, and stay in `is_parser_grammar_code`. The #16279 audit round 6 already recorded that TS18009/TS18029 "survive Direction B" (tsc keeps them alongside an unrelated real syntax error) — the signature of a genuine parser diagnostic, which is exactly what `is_real_syntax_error` classifies.

Adjacent-case matrix (new tests, `check_utils/private_identifier_parse_error_suppression_tests.rs`):
- Classifier: TS18009/18029/18030 are real syntax errors, are not `is_parser_grammar_code`, and stay suppressing.
- Control: TS18016/18024 stay checker-routed grammar codes and are **not** promoted (the split is preserved).
- End-to-end suppression: the #16817 repro (`for (const #x of arr)`) and the parameter sibling (`function f(#x)`) each suppress trailing TS2322/TS2304.
- Program-wide fence: a `const #x` parse error in one file suppresses an unrelated clean file's TS2322.
- Negative control: a legal `#p` class field keeps full semantic checking (TS2322 still reported, no private-identifier parse error).

Anti-hardcoding: this is code-number matching on parser-origin diagnostics within the existing curated, oracle-pinned enumeration — no identifier/file-name/rendered-string predicate is introduced.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-cli --lib private_identifier_parse_error` — 5 new tests pass.
- Full `cargo test -p tsz-cli --lib`: 1650 passed / 124 failed; the same 124 fail on the clean baseline (environmental, need a built binary), so this change adds 5 passing tests and **zero** new failures.
- `cargo clippy -p tsz-cli --all-targets -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py` — "Architecture guardrails passed" (LOC violations: 0; `check_utils.rs` at 1913 lines).
- Corpus impact is documented zero in #16817 (no conformance case exercises these shapes today); this is a correctness-of-model fix. Acceptance is by conformance set-difference, not totals, per the issue.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qtrn88f7CZf5nvujUphZac)_