### PR TITLE
fix(parser): TS8038 reports once with a TS1486 related-info pointer for decorators split across export

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -219,13 +219,23 @@ pub(super) fn parse_diagnostic_to_checker(
     file_name: &str,
     diagnostic: &ParseDiagnostic,
 ) -> Diagnostic {
-    Diagnostic::error(
+    let mut result = Diagnostic::error(
         file_name.to_string(),
         diagnostic.start,
         diagnostic.length,
         diagnostic.message.clone(),
         diagnostic.code,
-    )
+    );
+    if let Some(related) = &diagnostic.related {
+        result.related_information.push(Diagnostic::related_pointer(
+            related.code,
+            file_name.to_string(),
+            related.start,
+            related.length,
+            related.message.clone(),
+        ));
+    }
+    result
 }
 
 pub(super) fn collect_no_check_parse_diagnostics_for_file(

--- a/crates/tsz-cli/src/driver/check_utils/audit_round_3_grammar_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/audit_round_3_grammar_tests.rs
@@ -16,12 +16,14 @@ fn assert_suppressed_by_real_parse_error(code: u32, message: &str) {
             length: 6,
             message: message.to_string(),
             code,
+            related: None,
         },
         ParseDiagnostic {
             start: 60,
             length: 1,
             message: "Type expected.".to_string(),
             code: 1110,
+            related: None,
         },
     ];
 
@@ -45,6 +47,7 @@ fn assert_survives_alone(code: u32, message: &str) {
         length: 6,
         message: message.to_string(),
         code,
+        related: None,
     }];
 
     let filtered = filtered_parse_diagnostics(&diagnostics, false);
@@ -89,6 +92,7 @@ fn ts1313_is_not_suppressed_and_must_stay_out_of_the_list() {
         length: 6,
         message: "The body of an 'if' statement cannot be the empty statement.".to_string(),
         code: 1313,
+        related: None,
     }];
 
     // `true` mirrors `program_has_real_syntax_errors(program)` being true
@@ -149,12 +153,14 @@ fn ts2819_not_suppressed_when_real_parse_error_present() {
             length: 6,
             message: "Namespace name cannot be 'true'.".to_string(),
             code: 2819,
+            related: None,
         },
         ParseDiagnostic {
             start: 60,
             length: 1,
             message: "Type expected.".to_string(),
             code: 1110,
+            related: None,
         },
     ];
 

--- a/crates/tsz-cli/src/driver/check_utils/class_static_block_grammar_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/class_static_block_grammar_tests.rs
@@ -36,12 +36,14 @@ fn filtered_parse_diagnostics_suppresses_ts18054_when_real_parse_error_present()
             message: "'await using' statements cannot be used inside a class static block."
                 .to_string(),
             code: 18054,
+            related: None,
         },
         ParseDiagnostic {
             start: 60,
             length: 1,
             message: "Type expected.".to_string(),
             code: 1110,
+            related: None,
         },
     ];
 
@@ -66,6 +68,7 @@ fn filtered_parse_diagnostics_keeps_ts18054_when_alone() {
         length: 6,
         message: "'await using' statements cannot be used inside a class static block.".to_string(),
         code: 18054,
+        related: None,
     }];
 
     let filtered = filtered_parse_diagnostics(&diagnostics, false);
@@ -91,6 +94,7 @@ fn filtered_parse_diagnostics_ts18054_does_not_self_suppress_listed_sibling() {
             length: 6,
             message: "'await' expression cannot be used inside a class static block.".to_string(),
             code: 18037,
+            related: None,
         },
         ParseDiagnostic {
             start: 80,
@@ -98,6 +102,7 @@ fn filtered_parse_diagnostics_ts18054_does_not_self_suppress_listed_sibling() {
             message: "'await using' statements cannot be used inside a class static block."
                 .to_string(),
             code: 18054,
+            related: None,
         },
     ];
 
@@ -125,6 +130,7 @@ fn filtered_parse_diagnostics_ts18054_does_not_self_suppress_ts18041_sibling() {
             length: 6,
             message: "A 'return' statement cannot be used inside a class static block.".to_string(),
             code: 18041,
+            related: None,
         },
         ParseDiagnostic {
             start: 80,
@@ -132,6 +138,7 @@ fn filtered_parse_diagnostics_ts18054_does_not_self_suppress_ts18041_sibling() {
             message: "'await using' statements cannot be used inside a class static block."
                 .to_string(),
             code: 18054,
+            related: None,
         },
     ];
 

--- a/crates/tsz-cli/src/driver/check_utils/filter_trigger_unification_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/filter_trigger_unification_tests.rs
@@ -35,12 +35,14 @@ fn grammar_plus_sibling(code: u32, message: &str) -> Vec<ParseDiagnostic> {
             length: 2,
             message: "A 'get' accessor cannot have parameters.".to_string(),
             code: 1054,
+            related: None,
         },
         ParseDiagnostic {
             start: 52,
             length: 2,
             message: message.to_string(),
             code,
+            related: None,
         },
     ]
 }
@@ -136,6 +138,7 @@ fn lone_grammar_code_is_kept() {
         length: 2,
         message: "A 'get' accessor cannot have parameters.".to_string(),
         code: 1054,
+        related: None,
     }];
     let filtered = filtered_parse_diagnostics(&diagnostics, false);
     assert_eq!(filtered.len(), 1, "a lone grammar code must survive");

--- a/crates/tsz-cli/src/driver/check_utils/for_in_of_single_declaration_grammar_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/for_in_of_single_declaration_grammar_tests.rs
@@ -27,12 +27,14 @@ fn filtered_parse_diagnostics_suppresses_ts1091_when_real_parse_error_present() 
             message: "Only a single variable declaration is allowed in a 'for...in' statement."
                 .to_string(),
             code: 1091,
+            related: None,
         },
         ParseDiagnostic {
             start: 60,
             length: 1,
             message: "Type expected.".to_string(),
             code: 1110,
+            related: None,
         },
     ];
 
@@ -59,12 +61,14 @@ fn filtered_parse_diagnostics_suppresses_ts1188_when_real_parse_error_present() 
             message: "Only a single variable declaration is allowed in a 'for...of' statement."
                 .to_string(),
             code: 1188,
+            related: None,
         },
         ParseDiagnostic {
             start: 60,
             length: 1,
             message: "Type expected.".to_string(),
             code: 1110,
+            related: None,
         },
     ];
 
@@ -99,6 +103,7 @@ fn filtered_parse_diagnostics_keeps_ts1091_ts1188_when_alone() {
             length: 1,
             message: message.to_string(),
             code,
+            related: None,
         }];
 
         let filtered = filtered_parse_diagnostics(&diagnostics, false);
@@ -125,6 +130,7 @@ fn filtered_parse_diagnostics_ts1091_does_not_self_suppress_listed_sibling() {
             length: 6,
             message: "An import declaration cannot have modifiers.".to_string(),
             code: 1191,
+            related: None,
         },
         ParseDiagnostic {
             start: 60,
@@ -132,6 +138,7 @@ fn filtered_parse_diagnostics_ts1091_does_not_self_suppress_listed_sibling() {
             message: "Only a single variable declaration is allowed in a 'for...in' statement."
                 .to_string(),
             code: 1091,
+            related: None,
         },
     ];
 
@@ -157,6 +164,7 @@ fn filtered_parse_diagnostics_ts1188_does_not_self_suppress_listed_sibling() {
             length: 6,
             message: "An import declaration cannot have modifiers.".to_string(),
             code: 1191,
+            related: None,
         },
         ParseDiagnostic {
             start: 60,
@@ -164,6 +172,7 @@ fn filtered_parse_diagnostics_ts1188_does_not_self_suppress_listed_sibling() {
             message: "Only a single variable declaration is allowed in a 'for...of' statement."
                 .to_string(),
             code: 1188,
+            related: None,
         },
     ];
 

--- a/crates/tsz-cli/src/driver/check_utils/for_in_using_declaration_grammar_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/for_in_using_declaration_grammar_tests.rs
@@ -27,12 +27,14 @@ fn filtered_parse_diagnostics_suppresses_ts1493_when_real_parse_error_present() 
                 "The left-hand side of a 'for...in' statement cannot be a 'using' declaration."
                     .to_string(),
             code: 1493,
+            related: None,
         },
         ParseDiagnostic {
             start: 60,
             length: 1,
             message: "Type expected.".to_string(),
             code: 1110,
+            related: None,
         },
     ];
 
@@ -60,12 +62,14 @@ fn filtered_parse_diagnostics_suppresses_ts1494_when_real_parse_error_present() 
                 "The left-hand side of a 'for...in' statement cannot be an 'await using' declaration."
                     .to_string(),
             code: 1494,
+            related: None,
         },
         ParseDiagnostic {
             start: 60,
             length: 1,
             message: "Type expected.".to_string(),
             code: 1110,
+            related: None,
         },
     ];
 
@@ -100,6 +104,7 @@ fn filtered_parse_diagnostics_keeps_ts1493_ts1494_when_alone() {
             length: 5,
             message: message.to_string(),
             code,
+            related: None,
         }];
 
         let filtered = filtered_parse_diagnostics(&diagnostics, false);
@@ -130,6 +135,7 @@ fn filtered_parse_diagnostics_ts1493_does_not_self_suppress_listed_sibling() {
                 "The left-hand side of a 'for...in' statement cannot be a 'using' declaration."
                     .to_string(),
             code: 1493,
+            related: None,
         },
         ParseDiagnostic {
             start: 60,
@@ -137,6 +143,7 @@ fn filtered_parse_diagnostics_ts1493_does_not_self_suppress_listed_sibling() {
             message: "Only a single variable declaration is allowed in a 'for...in' statement."
                 .to_string(),
             code: 1091,
+            related: None,
         },
     ];
 
@@ -164,6 +171,7 @@ fn filtered_parse_diagnostics_ts1494_does_not_self_suppress_listed_sibling() {
                 "The left-hand side of a 'for...in' statement cannot be an 'await using' declaration."
                     .to_string(),
             code: 1494,
+            related: None,
         },
         ParseDiagnostic {
             start: 60,
@@ -171,6 +179,7 @@ fn filtered_parse_diagnostics_ts1494_does_not_self_suppress_listed_sibling() {
             message: "Only a single variable declaration is allowed in a 'for...in' statement."
                 .to_string(),
             code: 1091,
+            related: None,
         },
     ];
 

--- a/crates/tsz-cli/src/driver/check_utils/heritage_clause_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/heritage_clause_tests.rs
@@ -27,12 +27,14 @@ fn filtered_parse_diagnostics_suppresses_ts1173_when_real_parse_error_present() 
             length: 6,
             message: "'extends' clause must precede 'implements' clause.".to_string(),
             code: 1173,
+            related: None,
         },
         ParseDiagnostic {
             start: 60,
             length: 1,
             message: "Type expected.".to_string(),
             code: 1110,
+            related: None,
         },
     ];
 
@@ -58,12 +60,14 @@ fn filtered_parse_diagnostics_suppresses_ts1175_when_real_parse_error_present() 
             length: 6,
             message: "'implements' clause already seen.".to_string(),
             code: 1175,
+            related: None,
         },
         ParseDiagnostic {
             start: 60,
             length: 1,
             message: "Type expected.".to_string(),
             code: 1110,
+            related: None,
         },
     ];
 
@@ -89,12 +93,14 @@ fn filtered_parse_diagnostics_suppresses_ts1176_when_real_parse_error_present() 
             length: 6,
             message: "Interface declaration cannot have an 'implements' clause.".to_string(),
             code: 1176,
+            related: None,
         },
         ParseDiagnostic {
             start: 60,
             length: 1,
             message: "Type expected.".to_string(),
             code: 1110,
+            related: None,
         },
     ];
 
@@ -127,6 +133,7 @@ fn filtered_parse_diagnostics_keeps_ts1173_ts1175_ts1176_when_alone() {
             length: 1,
             message: message.to_string(),
             code,
+            related: None,
         }];
 
         let filtered = filtered_parse_diagnostics(&diagnostics, false);
@@ -153,12 +160,14 @@ fn filtered_parse_diagnostics_ts1173_does_not_self_suppress_listed_sibling() {
             length: 8,
             message: "'extends' clause already seen.".to_string(),
             code: 1172,
+            related: None,
         },
         ParseDiagnostic {
             start: 80,
             length: 6,
             message: "'extends' clause must precede 'implements' clause.".to_string(),
             code: 1173,
+            related: None,
         },
     ];
 
@@ -184,12 +193,14 @@ fn filtered_parse_diagnostics_ts1175_does_not_self_suppress_listed_sibling() {
             length: 8,
             message: "'extends' clause already seen.".to_string(),
             code: 1172,
+            related: None,
         },
         ParseDiagnostic {
             start: 80,
             length: 6,
             message: "'implements' clause already seen.".to_string(),
             code: 1175,
+            related: None,
         },
     ];
 
@@ -215,12 +226,14 @@ fn filtered_parse_diagnostics_ts1176_does_not_self_suppress_listed_sibling() {
             length: 8,
             message: "'extends' clause already seen.".to_string(),
             code: 1172,
+            related: None,
         },
         ParseDiagnostic {
             start: 80,
             length: 6,
             message: "Interface declaration cannot have an 'implements' clause.".to_string(),
             code: 1176,
+            related: None,
         },
     ];
 

--- a/crates/tsz-cli/src/driver/check_utils/import_call_type_arguments_grammar_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/import_call_type_arguments_grammar_tests.rs
@@ -32,12 +32,14 @@ fn filtered_parse_diagnostics_suppresses_ts1326_when_real_parse_error_present() 
             length: 6,
             message: "This use of 'import' is invalid. 'import()' calls can be written, but they must have parentheses and cannot have type arguments.".to_string(),
             code: 1326,
+            related: None,
         },
         ParseDiagnostic {
             start: 6,
             length: 1,
             message: "Type expected.".to_string(),
             code: 1110,
+            related: None,
         },
     ];
 
@@ -62,6 +64,7 @@ fn filtered_parse_diagnostics_keeps_ts1326_when_alone() {
         length: 6,
         message: "This use of 'import' is invalid. 'import()' calls can be written, but they must have parentheses and cannot have type arguments.".to_string(),
         code: 1326,
+        related: None,
     }];
 
     let filtered = filtered_parse_diagnostics(&diagnostics, false);
@@ -88,12 +91,14 @@ fn filtered_parse_diagnostics_ts1326_does_not_self_suppress_listed_sibling() {
             message: "A 'declare' modifier cannot be used with an import declaration."
                 .to_string(),
             code: 1079,
+            related: None,
         },
         ParseDiagnostic {
             start: 80,
             length: 6,
             message: "This use of 'import' is invalid. 'import()' calls can be written, but they must have parentheses and cannot have type arguments.".to_string(),
             code: 1326,
+            related: None,
         },
     ];
 

--- a/crates/tsz-cli/src/driver/check_utils/rest_parameter_grammar_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/rest_parameter_grammar_tests.rs
@@ -41,12 +41,14 @@ fn filtered_parse_diagnostics_suppresses_ts1013_when_real_parse_error_present() 
             message: "A rest parameter or binding pattern may not have a trailing comma."
                 .to_string(),
             code: 1013,
+            related: None,
         },
         ParseDiagnostic {
             start: 60,
             length: 1,
             message: "Type expected.".to_string(),
             code: 1110,
+            related: None,
         },
     ];
 
@@ -71,6 +73,7 @@ fn filtered_parse_diagnostics_keeps_ts1013_when_alone() {
         length: 1,
         message: "A rest parameter or binding pattern may not have a trailing comma.".to_string(),
         code: 1013,
+        related: None,
     }];
 
     let filtered = filtered_parse_diagnostics(&diagnostics, false);
@@ -96,6 +99,7 @@ fn filtered_parse_diagnostics_ts1013_does_not_self_suppress_listed_sibling() {
             length: 6,
             message: "A rest parameter must be last in a parameter list.".to_string(),
             code: 1014,
+            related: None,
         },
         ParseDiagnostic {
             start: 80,
@@ -103,6 +107,7 @@ fn filtered_parse_diagnostics_ts1013_does_not_self_suppress_listed_sibling() {
             message: "A rest parameter or binding pattern may not have a trailing comma."
                 .to_string(),
             code: 1013,
+            related: None,
         },
     ];
 
@@ -128,12 +133,14 @@ fn filtered_parse_diagnostics_suppresses_ts1047_when_real_parse_error_present() 
             length: 6,
             message: "A rest parameter cannot be optional.".to_string(),
             code: 1047,
+            related: None,
         },
         ParseDiagnostic {
             start: 60,
             length: 1,
             message: "Type expected.".to_string(),
             code: 1110,
+            related: None,
         },
     ];
 
@@ -159,12 +166,14 @@ fn filtered_parse_diagnostics_suppresses_ts1048_when_real_parse_error_present() 
             length: 6,
             message: "A rest parameter cannot have an initializer.".to_string(),
             code: 1048,
+            related: None,
         },
         ParseDiagnostic {
             start: 60,
             length: 1,
             message: "Type expected.".to_string(),
             code: 1110,
+            related: None,
         },
     ];
 
@@ -193,6 +202,7 @@ fn filtered_parse_diagnostics_keeps_ts1047_ts1048_when_alone() {
             length: 1,
             message: message.to_string(),
             code,
+            related: None,
         }];
 
         let filtered = filtered_parse_diagnostics(&diagnostics, false);
@@ -219,12 +229,14 @@ fn filtered_parse_diagnostics_ts1047_does_not_self_suppress_listed_sibling() {
             length: 6,
             message: "A rest parameter must be last in a parameter list.".to_string(),
             code: 1014,
+            related: None,
         },
         ParseDiagnostic {
             start: 80,
             length: 6,
             message: "A rest parameter cannot be optional.".to_string(),
             code: 1047,
+            related: None,
         },
     ];
 
@@ -250,12 +262,14 @@ fn filtered_parse_diagnostics_ts1048_does_not_self_suppress_listed_sibling() {
             length: 6,
             message: "A rest parameter must be last in a parameter list.".to_string(),
             code: 1014,
+            related: None,
         },
         ParseDiagnostic {
             start: 80,
             length: 6,
             message: "A rest parameter cannot have an initializer.".to_string(),
             code: 1048,
+            related: None,
         },
     ];
 

--- a/crates/tsz-cli/src/driver/check_utils/tests_part2.rs
+++ b/crates/tsz-cli/src/driver/check_utils/tests_part2.rs
@@ -14,12 +14,14 @@ fn filtered_parse_diagnostics_suppresses_await_ts1359_when_ts1109_present() {
             message: "Identifier expected. 'await' is a reserved word that cannot be used here."
                 .to_string(),
             code: 1359,
+            related: None,
         },
         ParseDiagnostic {
             start: 200,
             length: 1,
             message: "Expression expected.".to_string(),
             code: 1109,
+            related: None,
         },
     ];
 
@@ -46,12 +48,14 @@ fn filtered_parse_diagnostics_keeps_await_ts1359_with_unrelated_parse_errors() {
             message: "Identifier expected. 'await' is a reserved word that cannot be used here."
                 .to_string(),
             code: 1359,
+            related: None,
         },
         ParseDiagnostic {
             start: 10,
             length: 6,
             message: "A module cannot have multiple default exports.".to_string(),
             code: 2528,
+            related: None,
         },
     ];
 
@@ -73,6 +77,7 @@ fn filtered_parse_diagnostics_keeps_await_ts1359_when_alone() {
         message: "Identifier expected. 'await' is a reserved word that cannot be used here."
             .to_string(),
         code: 1359,
+        related: None,
     }];
 
     let filtered = filtered_parse_diagnostics(&diagnostics, false);
@@ -98,12 +103,14 @@ fn filtered_parse_diagnostics_suppresses_ts1028_when_real_parse_error_present() 
             length: 6,
             message: "Accessibility modifier already seen.".to_string(),
             code: 1028,
+            related: None,
         },
         ParseDiagnostic {
             start: 50,
             length: 6,
             message: "Unexpected keyword or identifier.".to_string(),
             code: 1434,
+            related: None,
         },
     ];
 
@@ -131,6 +138,7 @@ fn filtered_parse_diagnostics_keeps_ts1028_when_alone() {
         length: 6,
         message: "Accessibility modifier already seen.".to_string(),
         code: 1028,
+        related: None,
     }];
 
     let filtered = filtered_parse_diagnostics(&diagnostics, false);
@@ -158,12 +166,14 @@ fn filtered_parse_diagnostics_suppresses_ts1101_when_real_parse_error_present() 
             length: 4,
             message: "'with' statements are not allowed in strict mode.".to_string(),
             code: 1101,
+            related: None,
         },
         ParseDiagnostic {
             start: 80,
             length: 1,
             message: "')' expected.".to_string(),
             code: 1005,
+            related: None,
         },
     ];
 
@@ -188,6 +198,7 @@ fn filtered_parse_diagnostics_keeps_ts1101_when_alone() {
         length: 4,
         message: "'with' statements are not allowed in strict mode.".to_string(),
         code: 1101,
+        related: None,
     }];
 
     let filtered = filtered_parse_diagnostics(&diagnostics, false);
@@ -212,12 +223,14 @@ fn filtered_parse_diagnostics_keeps_ts1101_with_non_real_parse_error() {
             length: 4,
             message: "'with' statements are not allowed in strict mode.".to_string(),
             code: 1101,
+            related: None,
         },
         ParseDiagnostic {
             start: 90,
             length: 1,
             message: "A rest parameter must be last in a parameter list.".to_string(),
             code: 1014,
+            related: None,
         },
     ];
 
@@ -245,12 +258,14 @@ fn accessor_grammar_pair(
             length: 2,
             message: "A 'get' accessor cannot have parameters.".to_string(),
             code: 1054,
+            related: None,
         },
         ParseDiagnostic {
             start: 52,
             length: 2,
             message: setter_message.to_string(),
             code: setter_code,
+            related: None,
         },
     ]
 }
@@ -330,12 +345,14 @@ fn filtered_parse_diagnostics_keeps_repeated_setter_ts1049_without_a_getter() {
             length: 2,
             message: "A 'set' accessor must have exactly one parameter.".to_string(),
             code: 1049,
+            related: None,
         },
         ParseDiagnostic {
             start: 52,
             length: 2,
             message: "A 'set' accessor must have exactly one parameter.".to_string(),
             code: 1049,
+            related: None,
         },
     ];
 
@@ -364,24 +381,28 @@ fn filtered_parse_diagnostics_suppresses_accessor_grammar_family_when_real_parse
             length: 2,
             message: "A 'get' accessor cannot have parameters.".to_string(),
             code: 1054,
+            related: None,
         },
         ParseDiagnostic {
             start: 52,
             length: 2,
             message: "A 'set' accessor must have exactly one parameter.".to_string(),
             code: 1049,
+            related: None,
         },
         ParseDiagnostic {
             start: 70,
             length: 2,
             message: "A 'set' accessor cannot have an optional parameter.".to_string(),
             code: 1051,
+            related: None,
         },
         ParseDiagnostic {
             start: 90,
             length: 1,
             message: "Expression expected.".to_string(),
             code: 1109,
+            related: None,
         },
     ];
 
@@ -418,12 +439,14 @@ fn filtered_parse_diagnostics_suppresses_ts1018_when_real_parse_error_present() 
             message: "An index signature parameter cannot have an accessibility modifier."
                 .to_string(),
             code: 1018,
+            related: None,
         },
         ParseDiagnostic {
             start: 60,
             length: 1,
             message: "Type expected.".to_string(),
             code: 1110,
+            related: None,
         },
     ];
 
@@ -449,12 +472,14 @@ fn filtered_parse_diagnostics_suppresses_ts1020_when_real_parse_error_present() 
             length: 1,
             message: "An index signature parameter cannot have an initializer.".to_string(),
             code: 1020,
+            related: None,
         },
         ParseDiagnostic {
             start: 60,
             length: 1,
             message: "Type expected.".to_string(),
             code: 1110,
+            related: None,
         },
     ];
 
@@ -480,12 +505,14 @@ fn filtered_parse_diagnostics_suppresses_ts1025_when_real_parse_error_present() 
             length: 1,
             message: "An index signature cannot have a trailing comma.".to_string(),
             code: 1025,
+            related: None,
         },
         ParseDiagnostic {
             start: 60,
             length: 1,
             message: "Type expected.".to_string(),
             code: 1110,
+            related: None,
         },
     ];
 
@@ -521,6 +548,7 @@ fn filtered_parse_diagnostics_keeps_ts1018_ts1020_ts1025_when_alone() {
             length: 1,
             message: message.to_string(),
             code,
+            related: None,
         }];
 
         let filtered = filtered_parse_diagnostics(&diagnostics, false);
@@ -547,12 +575,14 @@ fn filtered_parse_diagnostics_ts1018_does_not_self_suppress_listed_sibling() {
             message: "An index signature parameter cannot have an accessibility modifier."
                 .to_string(),
             code: 1018,
+            related: None,
         },
         ParseDiagnostic {
             start: 80,
             length: 3,
             message: "Duplicate label 'foo'.".to_string(),
             code: 1114,
+            related: None,
         },
     ];
 
@@ -587,12 +617,14 @@ fn filtered_parse_diagnostics_suppresses_16279_audit_codes_when_real_parse_error
                 length: 1,
                 message: "candidate".to_string(),
                 code,
+                related: None,
             },
             ParseDiagnostic {
                 start: 10,
                 length: 1,
                 message: "Expression expected.".to_string(),
                 code: 1109,
+                related: None,
             },
         ];
         let filtered = filtered_parse_diagnostics(&diagnostics, false);
@@ -620,6 +652,7 @@ fn filtered_parse_diagnostics_keeps_16279_audit_codes_when_alone() {
             length: 1,
             message: "candidate".to_string(),
             code,
+            related: None,
         }];
         let filtered = filtered_parse_diagnostics(&diagnostics, false);
         let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
@@ -649,12 +682,14 @@ fn filtered_parse_diagnostics_suppresses_ts18016_when_real_parse_error_present()
             length: 1,
             message: "Private identifiers are not allowed outside class bodies.".to_string(),
             code: 18016,
+            related: None,
         },
         ParseDiagnostic {
             start: 10,
             length: 1,
             message: "Expression expected.".to_string(),
             code: 1109,
+            related: None,
         },
     ];
     let filtered = filtered_parse_diagnostics(&diagnostics, false);
@@ -678,6 +713,7 @@ fn filtered_parse_diagnostics_keeps_ts18016_when_alone() {
         length: 1,
         message: "Private identifiers are not allowed outside class bodies.".to_string(),
         code: 18016,
+        related: None,
     }];
     let filtered = filtered_parse_diagnostics(&diagnostics, false);
     let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
@@ -703,12 +739,14 @@ fn filtered_parse_diagnostics_ts18016_does_not_self_suppress_listed_sibling() {
             length: 1,
             message: "Private identifiers are not allowed outside class bodies.".to_string(),
             code: 18016,
+            related: None,
         },
         ParseDiagnostic {
             start: 10,
             length: 1,
             message: "A 'set' accessor must have exactly one parameter.".to_string(),
             code: 1049,
+            related: None,
         },
     ];
     let filtered = filtered_parse_diagnostics(&diagnostics, false);
@@ -741,12 +779,14 @@ fn filtered_parse_diagnostics_keeps_ts1433_and_ts1436_alongside_real_parse_error
                 length: 1,
                 message: "candidate".to_string(),
                 code,
+                related: None,
             },
             ParseDiagnostic {
                 start: 10,
                 length: 1,
                 message: "Expression expected.".to_string(),
                 code: 1109,
+                related: None,
             },
         ];
         let filtered = filtered_parse_diagnostics(&diagnostics, false);

--- a/crates/tsz-cli/src/driver/check_utils/using_declaration_binding_pattern_grammar_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/using_declaration_binding_pattern_grammar_tests.rs
@@ -25,12 +25,14 @@ fn filtered_parse_diagnostics_suppresses_ts1492_when_real_parse_error_present() 
             length: 5,
             message: "'using' declarations may not have binding patterns.".to_string(),
             code: 1492,
+            related: None,
         },
         ParseDiagnostic {
             start: 60,
             length: 1,
             message: "Type expected.".to_string(),
             code: 1110,
+            related: None,
         },
     ];
 
@@ -55,6 +57,7 @@ fn filtered_parse_diagnostics_keeps_ts1492_when_alone() {
         length: 5,
         message: "'using' declarations may not have binding patterns.".to_string(),
         code: 1492,
+        related: None,
     }];
 
     let filtered = filtered_parse_diagnostics(&diagnostics, false);
@@ -82,12 +85,14 @@ fn filtered_parse_diagnostics_ts1492_does_not_self_suppress_listed_sibling() {
             length: 5,
             message: "'using' declarations may not have binding patterns.".to_string(),
             code: 1492,
+            related: None,
         },
         ParseDiagnostic {
             start: 60,
             length: 7,
             message: "A 'declare' modifier cannot be used with an import declaration.".to_string(),
             code: 1079,
+            related: None,
         },
     ];
 

--- a/crates/tsz-core/src/parallel/core/json_validation.rs
+++ b/crates/tsz-core/src/parallel/core/json_validation.rs
@@ -67,12 +67,14 @@ fn validate_json_syntax(source: &str) -> Vec<ParseDiagnostic> {
                         length: 1,
                         message: expected_msg.to_string(),
                         code: tsz_common::diagnostics::diagnostic_codes::EXPECTED,
+                        related: None,
                     });
                     diagnostics.push(ParseDiagnostic {
                         start: *start as u32,
                         length: 1,
                         message: tsz_common::diagnostics::diagnostic_messages::PROPERTY_ASSIGNMENT_EXPECTED.to_string(),
                         code: tsz_common::diagnostics::diagnostic_codes::PROPERTY_ASSIGNMENT_EXPECTED,
+                        related: None,
                     });
                 }
                 if let Some((_, end)) = spans.last() {
@@ -81,6 +83,7 @@ fn validate_json_syntax(source: &str) -> Vec<ParseDiagnostic> {
                         length: 1,
                         message: "'}' expected.".to_string(),
                         code: tsz_common::diagnostics::diagnostic_codes::EXPECTED,
+                        related: None,
                     });
                 }
             }
@@ -131,6 +134,7 @@ fn validate_json_syntax(source: &str) -> Vec<ParseDiagnostic> {
                         length: 1,
                         message: tsz_common::diagnostics::diagnostic_messages::STRING_LITERAL_WITH_DOUBLE_QUOTES_EXPECTED.to_string(),
                         code: tsz_common::diagnostics::diagnostic_codes::STRING_LITERAL_WITH_DOUBLE_QUOTES_EXPECTED,
+                        related: None,
                     });
                     true
                 }
@@ -142,6 +146,7 @@ fn validate_json_syntax(source: &str) -> Vec<ParseDiagnostic> {
                     length: 1,
                     message: tsz_common::diagnostics::diagnostic_messages::PROPERTY_VALUE_CAN_ONLY_BE_STRING_LITERAL_NUMERIC_LITERAL_TRUE_FALSE_NULL_OBJECT.to_string(),
                     code: tsz_common::diagnostics::diagnostic_codes::PROPERTY_VALUE_CAN_ONLY_BE_STRING_LITERAL_NUMERIC_LITERAL_TRUE_FALSE_NULL_OBJECT,
+                    related: None,
                 });
             }
             expecting_value = false;
@@ -219,6 +224,7 @@ fn validate_json_syntax(source: &str) -> Vec<ParseDiagnostic> {
                 length: 1,
                 message: tsz_common::diagnostics::diagnostic_messages::STRING_LITERAL_WITH_DOUBLE_QUOTES_EXPECTED.to_string(),
                 code: tsz_common::diagnostics::diagnostic_codes::STRING_LITERAL_WITH_DOUBLE_QUOTES_EXPECTED,
+                related: None,
             });
             expecting_property_name = false;
         }

--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -36,6 +36,7 @@ pub mod state;
 mod state_declarations;
 mod state_declarations_enums;
 mod state_declarations_exports;
+mod state_declarations_exports_decorator_position;
 mod state_declarations_modules;
 mod state_declarations_type_member_modifiers;
 mod state_diagnostics;
@@ -281,6 +282,10 @@ mod close_brace_node_end_position_remaining_tests;
 #[cfg(test)]
 #[path = "../../tests/decorator_tests.rs"]
 mod decorator_tests;
+
+#[cfg(test)]
+#[path = "../../tests/decorator_export_position_grammar_tests.rs"]
+mod decorator_export_position_grammar_tests;
 
 #[cfg(test)]
 #[path = "../../tests/regex_octal_decimal_class_escape_tests.rs"]

--- a/crates/tsz-parser/src/parser/state.rs
+++ b/crates/tsz-parser/src/parser/state.rs
@@ -108,6 +108,20 @@ pub struct ParseDiagnostic {
     pub length: u32,
     pub message: String,
     pub code: u32,
+    /// `tsc`'s `relatedInformation`: a single secondary pointer into the same
+    /// file (e.g. TS1486 `Decorator used before 'export' here.` alongside
+    /// TS8038). Boxed so the overwhelming majority of diagnostics that carry
+    /// no related info do not pay for the extra fields inline.
+    pub related: Option<Box<ParseDiagnosticRelated>>,
+}
+
+/// A single `relatedInformation` entry attached to a [`ParseDiagnostic`].
+#[derive(Clone, Debug)]
+pub struct ParseDiagnosticRelated {
+    pub start: u32,
+    pub length: u32,
+    pub message: String,
+    pub code: u32,
 }
 
 impl ParseDiagnostic {

--- a/crates/tsz-parser/src/parser/state/recovery.rs
+++ b/crates/tsz-parser/src/parser/state/recovery.rs
@@ -40,9 +40,35 @@ impl ParserState {
             length,
             message: message.to_string(),
             code,
+            related: None,
         });
         // After pushing a parser diagnostic, the effective "lastError" is
         // ours; subsequent scanner emissions reset the comparison frame.
+        self.scanner_diagnostics_high_water_mark = self.scanner.get_scanner_diagnostics().len();
+    }
+
+    /// Like [`Self::parse_error_at`], but attaches a single `relatedInformation`
+    /// pointer (`tsc`: `DiagnosticRelatedInformation`) into the same file —
+    /// e.g. TS1486 `Decorator used before 'export' here.` alongside TS8038.
+    /// Bypasses `parse_error_at`'s same-position/scanner dedup: a diagnostic
+    /// that carries related info is always a deliberate single emission from
+    /// its call site, not a cascade the dedup heuristics need to guard.
+    pub(crate) fn parse_error_at_with_related(
+        &mut self,
+        start: u32,
+        length: u32,
+        message: &str,
+        code: u32,
+        related: ParseDiagnosticRelated,
+    ) {
+        self.last_error_pos = start;
+        self.parse_diagnostics.push(ParseDiagnostic {
+            start,
+            length,
+            message: message.to_string(),
+            code,
+            related: Some(Box::new(related)),
+        });
         self.scanner_diagnostics_high_water_mark = self.scanner.get_scanner_diagnostics().len();
     }
 

--- a/crates/tsz-parser/src/parser/state_declarations_exports.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_exports.rs
@@ -134,52 +134,43 @@ impl ParserState {
             return self.parse_export_default_with_decorators(start_pos, decorators);
         }
 
-        let declaration = match self.token() {
-            SyntaxKind::ClassKeyword => {
-                self.parse_class_declaration_with_decorators(decorators, self.token_pos())
-            }
-            SyntaxKind::AbstractKeyword => {
-                self.parse_abstract_class_declaration_with_decorators(decorators, self.token_pos())
-            }
-            SyntaxKind::AtToken => {
-                // Decorators after `export` when decorators also appeared before `export`:
-                // @dec export @dec class Foo {}
-                let post_decorators = self.parse_decorators();
-                if decorators.is_some()
-                    && let Some(ref post_decs) = post_decorators
-                {
-                    for &dec_node in &post_decs.nodes {
-                        if let Some(node) = self.arena.get(dec_node) {
-                            self.parse_error_at(
-                                node.pos,
-                                node.end - node.pos,
-                                "Decorators may not appear after 'export' or 'export default' if they also appear before 'export'.",
-                                diagnostic_codes::DECORATORS_MAY_NOT_APPEAR_AFTER_EXPORT_OR_EXPORT_DEFAULT_IF_THEY_ALSO_APPEAR_BEF,
-                            );
+        let declaration =
+            match self.token() {
+                SyntaxKind::ClassKeyword => {
+                    self.parse_class_declaration_with_decorators(decorators, self.token_pos())
+                }
+                SyntaxKind::AbstractKeyword => self
+                    .parse_abstract_class_declaration_with_decorators(decorators, self.token_pos()),
+                SyntaxKind::AtToken => {
+                    // Decorators after `export` when decorators also appeared before `export`:
+                    // @dec export @dec class Foo {}. tsc reports exactly one TS8038,
+                    // anchored at the *first* trailing decorator regardless of how
+                    // many trailing decorators follow, with a TS1486 related-info
+                    // pointer at the *first* leading decorator (oracle-verified,
+                    // `typescript@7.0.2`: extra leading/trailing decorators do not
+                    // multiply the report).
+                    let post_decorators = self.parse_decorators();
+                    self.report_decorator_used_before_export(&decorators, &post_decorators);
+                    // Use pre-export decorators for the class
+                    match self.token() {
+                        SyntaxKind::ClassKeyword => self
+                            .parse_class_declaration_with_decorators(decorators, self.token_pos()),
+                        SyntaxKind::AbstractKeyword => self
+                            .parse_abstract_class_declaration_with_decorators(
+                                decorators,
+                                self.token_pos(),
+                            ),
+                        _ => {
+                            self.error_statement_expected();
+                            self.parse_expression_statement()
                         }
                     }
                 }
-                // Use pre-export decorators for the class
-                match self.token() {
-                    SyntaxKind::ClassKeyword => {
-                        self.parse_class_declaration_with_decorators(decorators, self.token_pos())
-                    }
-                    SyntaxKind::AbstractKeyword => self
-                        .parse_abstract_class_declaration_with_decorators(
-                            decorators,
-                            self.token_pos(),
-                        ),
-                    _ => {
-                        self.error_statement_expected();
-                        self.parse_expression_statement()
-                    }
+                _ => {
+                    self.error_statement_expected();
+                    self.parse_expression_statement()
                 }
-            }
-            _ => {
-                self.error_statement_expected();
-                self.parse_expression_statement()
-            }
-        };
+            };
 
         let end_pos = self.token_end();
         self.arena.add_export_decl(
@@ -206,93 +197,80 @@ impl ParserState {
         let default_pos = self.token_pos();
         self.parse_expected(SyntaxKind::DefaultKeyword);
 
-        let expression = match self.token() {
-            SyntaxKind::ClassKeyword => {
-                self.parse_class_declaration_with_decorators(decorators, self.token_pos())
-            }
-            SyntaxKind::AbstractKeyword => {
-                self.parse_abstract_class_declaration_with_decorators(decorators, self.token_pos())
-            }
-            SyntaxKind::AtToken => {
-                // Decorators after `export default` when decorators also appeared before `export`:
-                // @dec export default @dec class Foo {}
-                let post_decorators = self.parse_decorators();
-                if decorators.is_some()
-                    && let Some(ref post_decs) = post_decorators
-                {
-                    for &dec_node in &post_decs.nodes {
-                        if let Some(node) = self.arena.get(dec_node) {
+        let expression =
+            match self.token() {
+                SyntaxKind::ClassKeyword => {
+                    self.parse_class_declaration_with_decorators(decorators, self.token_pos())
+                }
+                SyntaxKind::AbstractKeyword => self
+                    .parse_abstract_class_declaration_with_decorators(decorators, self.token_pos()),
+                SyntaxKind::AtToken => {
+                    // Decorators after `export default` when decorators also appeared before `export`:
+                    // @dec export default @dec class Foo {}. Same single-report,
+                    // related-info-pointer semantics as the non-default form above.
+                    let post_decorators = self.parse_decorators();
+                    self.report_decorator_used_before_export(&decorators, &post_decorators);
+                    match self.token() {
+                        SyntaxKind::ClassKeyword => self
+                            .parse_class_declaration_with_decorators(decorators, self.token_pos()),
+                        SyntaxKind::AbstractKeyword => self
+                            .parse_abstract_class_declaration_with_decorators(
+                                decorators,
+                                self.token_pos(),
+                            ),
+                        _ => {
                             self.parse_error_at(
-                                node.pos,
-                                node.end - node.pos,
-                                "Decorators may not appear after 'export' or 'export default' if they also appear before 'export'.",
-                                diagnostic_codes::DECORATORS_MAY_NOT_APPEAR_AFTER_EXPORT_OR_EXPORT_DEFAULT_IF_THEY_ALSO_APPEAR_BEF,
+                                start_pos,
+                                0,
+                                "Decorators are not valid here.",
+                                diagnostic_codes::DECORATORS_ARE_NOT_VALID_HERE,
                             );
+                            let expr = self.parse_assignment_expression();
+                            self.parse_semicolon();
+                            expr
                         }
                     }
                 }
-                match self.token() {
-                    SyntaxKind::ClassKeyword => {
-                        self.parse_class_declaration_with_decorators(decorators, self.token_pos())
-                    }
-                    SyntaxKind::AbstractKeyword => self
-                        .parse_abstract_class_declaration_with_decorators(
-                            decorators,
-                            self.token_pos(),
-                        ),
-                    _ => {
-                        self.parse_error_at(
-                            start_pos,
-                            0,
-                            "Decorators are not valid here.",
-                            diagnostic_codes::DECORATORS_ARE_NOT_VALID_HERE,
-                        );
-                        let expr = self.parse_assignment_expression();
-                        self.parse_semicolon();
-                        expr
-                    }
+                SyntaxKind::FunctionKeyword => {
+                    self.parse_error_at(
+                        start_pos,
+                        0,
+                        "Decorators are not valid here.",
+                        diagnostic_codes::DECORATORS_ARE_NOT_VALID_HERE,
+                    );
+                    self.parse_function_declaration_with_async_optional_name(false, None)
                 }
-            }
-            SyntaxKind::FunctionKeyword => {
-                self.parse_error_at(
-                    start_pos,
-                    0,
-                    "Decorators are not valid here.",
-                    diagnostic_codes::DECORATORS_ARE_NOT_VALID_HERE,
-                );
-                self.parse_function_declaration_with_async_optional_name(false, None)
-            }
-            SyntaxKind::AsyncKeyword if self.look_ahead_is_async_function() => {
-                self.parse_error_at(
-                    start_pos,
-                    0,
-                    "Decorators are not valid here.",
-                    diagnostic_codes::DECORATORS_ARE_NOT_VALID_HERE,
-                );
-                self.next_token(); // consume 'async'
-                self.parse_function_declaration_with_async_optional_name(true, None)
-            }
-            SyntaxKind::InterfaceKeyword => {
-                self.parse_error_at(
-                    start_pos,
-                    0,
-                    "Decorators are not valid here.",
-                    diagnostic_codes::DECORATORS_ARE_NOT_VALID_HERE,
-                );
-                self.parse_interface_declaration()
-            }
-            _ => {
-                self.parse_error_at(
-                    start_pos,
-                    0,
-                    "Decorators are not valid here.",
-                    diagnostic_codes::DECORATORS_ARE_NOT_VALID_HERE,
-                );
-                let expr = self.parse_assignment_expression();
-                self.parse_semicolon();
-                expr
-            }
-        };
+                SyntaxKind::AsyncKeyword if self.look_ahead_is_async_function() => {
+                    self.parse_error_at(
+                        start_pos,
+                        0,
+                        "Decorators are not valid here.",
+                        diagnostic_codes::DECORATORS_ARE_NOT_VALID_HERE,
+                    );
+                    self.next_token(); // consume 'async'
+                    self.parse_function_declaration_with_async_optional_name(true, None)
+                }
+                SyntaxKind::InterfaceKeyword => {
+                    self.parse_error_at(
+                        start_pos,
+                        0,
+                        "Decorators are not valid here.",
+                        diagnostic_codes::DECORATORS_ARE_NOT_VALID_HERE,
+                    );
+                    self.parse_interface_declaration()
+                }
+                _ => {
+                    self.parse_error_at(
+                        start_pos,
+                        0,
+                        "Decorators are not valid here.",
+                        diagnostic_codes::DECORATORS_ARE_NOT_VALID_HERE,
+                    );
+                    let expr = self.parse_assignment_expression();
+                    self.parse_semicolon();
+                    expr
+                }
+            };
 
         let end_pos = self.token_end();
         // Use export assignment for default exports

--- a/crates/tsz-parser/src/parser/state_declarations_exports_decorator_position.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_exports_decorator_position.rs
@@ -1,0 +1,71 @@
+//! TS8038/TS1486: decorators split across `export`/`export default`.
+//!
+//! Split out of `state_declarations_exports.rs` to stay under the parser's
+//! per-file line cap; this is a single self-contained diagnostic concern
+//! (`@dec export @dec class` / `@dec export default @dec class`), not a
+//! shared dependency of the rest of that file.
+
+use super::state::ParserState;
+use crate::parser::NodeIndex;
+use tsz_common::diagnostics::diagnostic_codes;
+
+impl ParserState {
+    /// TS8038 (`Decorators may not appear after 'export' or 'export default' if
+    /// they also appear before 'export'.`) with its TS1486 (`Decorator used
+    /// before 'export' here.`) related-info pointer, for `@dec export @dec
+    /// class` / `@dec export default @dec class`. `tsc` reports this exactly
+    /// once per declaration regardless of how many leading or trailing
+    /// decorators are present: anchored at the *first* trailing decorator,
+    /// pointing back at the *first* leading decorator (oracle-verified,
+    /// `typescript@7.0.2`).
+    pub(super) fn report_decorator_used_before_export(
+        &mut self,
+        leading: &Option<crate::parser::NodeList>,
+        trailing: &Option<crate::parser::NodeList>,
+    ) {
+        let (Some(leading), Some(trailing)) = (leading, trailing) else {
+            return;
+        };
+        let (Some(&first_leading), Some(&first_trailing)) =
+            (leading.nodes.first(), trailing.nodes.first())
+        else {
+            return;
+        };
+        // A decorator node's own `end` is the end of the token *following* it
+        // (used elsewhere as a trailing-trivia boundary), not the end of its
+        // own expression — anchoring the diagnostic there would swallow
+        // whatever comes after the decorator (e.g. `export`/`class`). Read
+        // the wrapped expression's own end instead, which is unaffected by
+        // that convention.
+        let (Some(lead_span), Some(trail_span)) = (
+            self.decorator_span(first_leading),
+            self.decorator_span(first_trailing),
+        ) else {
+            return;
+        };
+        let (lead_pos, lead_end) = lead_span;
+        let (trail_pos, trail_end) = trail_span;
+        self.parse_error_at_with_related(
+            trail_pos,
+            trail_end - trail_pos,
+            "Decorators may not appear after 'export' or 'export default' if they also appear before 'export'.",
+            diagnostic_codes::DECORATORS_MAY_NOT_APPEAR_AFTER_EXPORT_OR_EXPORT_DEFAULT_IF_THEY_ALSO_APPEAR_BEF,
+            crate::parser::state::ParseDiagnosticRelated {
+                start: lead_pos,
+                length: lead_end - lead_pos,
+                message: "Decorator used before 'export' here.".to_string(),
+                code: diagnostic_codes::DECORATOR_USED_BEFORE_EXPORT_HERE,
+            },
+        );
+    }
+
+    /// A decorator node's true `(start, end)` span — the `@` token through
+    /// the end of its wrapped expression — rather than the decorator node's
+    /// own `end` field, which points past the token that follows it.
+    fn decorator_span(&self, decorator: NodeIndex) -> Option<(u32, u32)> {
+        let decorator_node = self.arena.get(decorator)?;
+        let data = self.arena.get_decorator_at(decorator)?;
+        let expr_end = self.arena.get(data.expression)?.end;
+        Some((decorator_node.pos, expr_end))
+    }
+}

--- a/crates/tsz-parser/src/parser/state_diagnostics.rs
+++ b/crates/tsz-parser/src/parser/state_diagnostics.rs
@@ -66,6 +66,7 @@ impl ParserState {
             length,
             message: message.to_string(),
             code,
+            related: None,
         });
     }
     pub(crate) fn report_invalid_string_or_template_escape_errors(&mut self) {

--- a/crates/tsz-parser/src/parser/state_statements.rs
+++ b/crates/tsz-parser/src/parser/state_statements.rs
@@ -154,6 +154,7 @@ impl ParserState {
                 length: self.u32_from_usize(diag.length),
                 message,
                 code: diag.code,
+                related: None,
             });
         }
         // Sort diagnostics into tsc's canonical `compareDiagnostics` order after

--- a/crates/tsz-parser/tests/decorator_export_position_grammar_tests.rs
+++ b/crates/tsz-parser/tests/decorator_export_position_grammar_tests.rs
@@ -1,0 +1,130 @@
+//! `@dec export @dec class` / `@dec export default @dec class`: TS8038
+//! (`Decorators may not appear after 'export' or 'export default' if they
+//! also appear before 'export'.`) with its TS1486 (`Decorator used before
+//! 'export' here.`) related-info pointer.
+//!
+//! `tsc` reports TS8038 exactly once per declaration, anchored at the
+//! *first* trailing decorator, regardless of how many leading or trailing
+//! decorators are present — extra decorators on either side do not multiply
+//! the report. The related-info pointer always names the *first* leading
+//! decorator. Oracle-verified against `typescript@7.0.2`.
+
+use crate::parser::test_fixture::parse_source;
+
+fn parse_code(code: &str) -> Vec<crate::parser::ParseDiagnostic> {
+    let (parser, _root) = parse_source(code);
+    parser.get_diagnostics().to_vec()
+}
+
+fn ts8038_diagnostics(code: &str) -> Vec<crate::parser::ParseDiagnostic> {
+    parse_code(code)
+        .into_iter()
+        .filter(|d| d.code == 8038)
+        .collect()
+}
+
+/// A single leading + trailing decorator: one TS8038 at the trailing
+/// decorator, with a TS1486 related pointer at the leading decorator.
+#[test]
+fn single_leading_and_trailing_decorator_reports_once_with_related_info() {
+    let src = "@dec export @dec class M {}\n";
+    let diags = ts8038_diagnostics(src);
+    assert_eq!(diags.len(), 1, "expected exactly one TS8038, got {diags:?}");
+    let diag = &diags[0];
+    // Anchored at the trailing decorator's `@dec` (after `export `).
+    let trailing_pos = src.find("export @dec").unwrap() as u32 + "export ".len() as u32;
+    assert_eq!(diag.start, trailing_pos);
+    assert_eq!(diag.length, 4); // "@dec"
+    let related = diag
+        .related
+        .as_ref()
+        .expect("TS8038 must carry a TS1486 related-info pointer");
+    assert_eq!(related.code, 1486);
+    assert_eq!(related.message, "Decorator used before 'export' here.");
+    // Anchored at the leading decorator, position 0.
+    assert_eq!(related.start, 0);
+    assert_eq!(related.length, 4); // "@dec"
+}
+
+/// `export default` form: same single-report, related-pointer semantics.
+#[test]
+fn export_default_single_leading_and_trailing_decorator_reports_once() {
+    let src = "@dec export default @dec class M {}\n";
+    let diags = ts8038_diagnostics(src);
+    assert_eq!(diags.len(), 1, "expected exactly one TS8038, got {diags:?}");
+    let related = diags[0]
+        .related
+        .as_ref()
+        .expect("TS8038 must carry a TS1486 related-info pointer");
+    assert_eq!(related.code, 1486);
+    assert_eq!(related.start, 0);
+}
+
+/// Multiple *trailing* decorators must not multiply the report: `tsc` still
+/// emits exactly one TS8038, at the first trailing decorator.
+#[test]
+fn multiple_trailing_decorators_report_once() {
+    let src = "@dec export @dec @dec class M {}\n";
+    let diags = ts8038_diagnostics(src);
+    assert_eq!(
+        diags.len(),
+        1,
+        "multiple trailing decorators must not multiply TS8038, got {diags:?}"
+    );
+    let trailing_pos = src.find("export @dec").unwrap() as u32 + "export ".len() as u32;
+    assert_eq!(diags[0].start, trailing_pos);
+}
+
+/// Multiple *leading* decorators: still one TS8038, related info at the
+/// first leading decorator (position 0), not the second.
+#[test]
+fn multiple_leading_decorators_point_related_info_at_first() {
+    let src = "@dec @dec export @dec class M {}\n";
+    let diags = ts8038_diagnostics(src);
+    assert_eq!(diags.len(), 1, "expected exactly one TS8038, got {diags:?}");
+    let related = diags[0]
+        .related
+        .as_ref()
+        .expect("TS8038 must carry a TS1486 related-info pointer");
+    assert_eq!(related.start, 0);
+}
+
+/// `export default`, multiple trailing decorators: still one TS8038.
+#[test]
+fn export_default_multiple_trailing_decorators_report_once() {
+    let src = "@dec export default @dec @dec class M {}\n";
+    let diags = ts8038_diagnostics(src);
+    assert_eq!(
+        diags.len(),
+        1,
+        "multiple trailing decorators must not multiply TS8038, got {diags:?}"
+    );
+}
+
+/// Negative control: a lone leading decorator with no trailing decorator
+/// after `export` is legal and must not report TS8038 or TS1486.
+#[test]
+fn leading_decorator_only_is_clean() {
+    let src = "@dec export class M {}\n";
+    let diags = ts8038_diagnostics(src);
+    assert!(diags.is_empty(), "expected no TS8038, got {diags:?}");
+}
+
+/// Negative control: a lone trailing decorator (`export @dec class`, no
+/// leading decorator) is the ordinary native-decorator form and must not
+/// report TS8038 or TS1486.
+#[test]
+fn trailing_decorator_only_is_clean() {
+    let src = "export @dec class M {}\n";
+    let diags = ts8038_diagnostics(src);
+    assert!(diags.is_empty(), "expected no TS8038, got {diags:?}");
+}
+
+/// Renamed-binder adjacent case: the decorator's identifier text must not be
+/// load-bearing.
+#[test]
+fn renamed_decorator_identifier_still_reports() {
+    let src = "@myCustomDecorator export @myCustomDecorator class Widget {}\n";
+    let diags = ts8038_diagnostics(src);
+    assert_eq!(diags.len(), 1, "expected exactly one TS8038, got {diags:?}");
+}

--- a/crates/tsz-parser/tests/parse_diagnostic_order_tests.rs
+++ b/crates/tsz-parser/tests/parse_diagnostic_order_tests.rs
@@ -14,6 +14,7 @@ fn diag(start: u32, length: u32, code: u32, message: &str) -> ParseDiagnostic {
         length,
         message: message.to_string(),
         code,
+        related: None,
     }
 }
 


### PR DESCRIPTION
`@dec export @dec class Foo {}` / `@dec export default @dec class Foo {}`: `tsc`'s decorator-position check reports **TS8038** (`Decorators may not appear after 'export' or 'export default' if they also appear before 'export'.`) exactly once per declaration — anchored at the *first* trailing decorator — with a **TS1486** (`Decorator used before 'export' here.`) related-info pointer at the *first* leading decorator, regardless of how many leading or trailing decorators are present.

tsz already emitted TS8038 at this site (`state_declarations_exports.rs`), but it reported one TS8038 **per trailing decorator** (over-reporting when more than one is present) and never attached the TS1486 pointer, because `ParseDiagnostic` had no related-information support at all — that plumbing only existed at the checker level.

## Structural rule
When decorators appear on both sides of `export`/`export default`, `tsc` reports the split exactly once, anchored at the first trailing decorator with a related pointer at the first leading decorator; tsz now does the same through the parser's own TS8038 site (`state_declarations_exports_decorator_position.rs`, split out of `state_declarations_exports.rs` to stay under the 2000-line cap), via a new `ParseDiagnostic::related` field threaded through to the checker-facing `Diagnostic` as a `LocationPointer` (`crates/tsz-cli/src/driver/check_utils.rs::parse_diagnostic_to_checker`) — matching `tsc`'s own behavior of suppressing this class of pointer under `--pretty false`.

While fixing the anchor position, found and fixed an adjacent bug: a `Decorator` AST node's own `.end` field is the end of the token *following* the decorator (a trailing-trivia convention used elsewhere), not the end of the decorator's own expression — using it directly made the diagnostic's reported length include everything up to the next token (e.g. `@dec` at length 10 instead of 4, swallowing ` export`). Fixed via a `decorator_span` helper that reads through to the decorator's wrapped expression's own end.

## Adjacent matrix (oracle-verified, `typescript@7.0.2`)
| source | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `@dec export @dec class M {}` | TS8038@col13(len4) + TS1486@col1(len4) related | TS8038@col13(len**10**, wrong span) no related | TS8038@col13(len4) + TS1486@col1(len4) related |
| `@dec export @dec @dec class M {}` (multiple trailing) | **one** TS8038 | **two** TS8038 (over-report) | one TS8038 |
| `@dec @dec export @dec class N {}` (multiple leading) | TS1486 points at the *first* leading decorator (col1) | n/a (position untested previously) | TS1486 points at col1, not the second |
| `@dec export default @dec @dec class O {}` | one TS8038 | over-report | one TS8038 |
| `@dec export class M {}` (leading only) | clean | clean | clean (unaffected) |
| `export @dec class M {}` (trailing only — ordinary native decorator) | clean | clean | clean (unaffected) |
| renamed decorator identifier (`@myCustomDecorator`) | reports | reports | reports (unaffected — binder-name-independent) |

Verified byte-for-byte against a real `typescript@7.0.2` CLI (`--pretty` and `--pretty false`) for all of the above, not just the isolated-witness case.

## Goal
Goal: hold

## Verification
- 8 new oracle-verified tests: `crates/tsz-parser/tests/decorator_export_position_grammar_tests.rs`.
- `cargo test -p tsz-parser --lib`: 2081/2081 pass (2073 baseline + 8 new, 0 regressions).
- `cargo test -p tsz-core --lib -- json`: 51/51 pass (unaffected by the `related: None` plumbing added to the JSON validator's existing diagnostic sites).
- `cargo clippy -p tsz-parser --all-targets -- -D warnings`: clean.
- `cargo clippy -p tsz-core --lib --tests -- -D warnings`: clean.
- `cargo clippy -p tsz-cli --lib --tests -- -D warnings`: clean.
- `cargo fmt --check` (tsz-parser/tsz-core/tsz-cli): clean.
- `python3 scripts/arch/arch_guard.py`: passed (file split keeps `state_declarations_exports.rs` at 1975 lines, under the 2000-line cap).
- Manual diff against `node .../typescript@7.0.2/bin/tsc` CLI output for the full adjacent matrix above (both pretty modes): exact match, including column positions.
- Not run: broader conformance/emit/fourslash. TS1486 is a `LocationPointer`-kind related-info entry, suppressed under `--pretty false` (the conformance harness's mode) exactly like `tsc`'s own, so it cannot move conformance counts; the TS8038 duplicate-report fix only changes behavior for the multiple-trailing-decorator shape, an unlikely existing fixture pattern. The `TypeScript` submodule was not checked out in this container this session; a snapshot is owed if a future run shows drift.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude


---
_Generated by [Claude Code](https://claude.ai/code/session_011gNfMvyJF4SfRPZvwri9i5)_