### PR TITLE
fix(checker): anchor readonly/async class-member modifier diagnostics at the modifier keyword and dedup the accessor readonly+async report

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/class.rs
+++ b/crates/tsz-checker/src/state/state_checking/class.rs
@@ -522,28 +522,34 @@ impl<'a> CheckerState<'a> {
                     }
                 }
 
-                // TS1024: 'readonly' modifier can only appear on a property declaration or index signature.
+                // TS1024: 'readonly' modifier can only appear on a property
+                // declaration or index signature. tsc's `checkGrammarModifiers`
+                // anchors this at the `readonly` keyword itself, not the member
+                // name or the declaration start, so a `readonly` that is not the
+                // first modifier — `static readonly m()`, `public readonly get x()`,
+                // `abstract readonly get x()` — still points at `readonly`. Anchor
+                // at the modifier node the same way the constructor arm in
+                // `ambient_constructor_checks.rs` already does, rather than at the
+                // whole member node.
                 {
-                    let has_readonly_on_non_property = match member_node.kind {
-                        syntax_kind_ext::METHOD_DECLARATION => {
-                            if let Some(method) = self.ctx.arena.get_method_decl(member_node) {
-                                self.has_readonly_modifier(&method.modifiers)
-                            } else {
-                                false
-                            }
-                        }
-                        syntax_kind_ext::GET_ACCESSOR | syntax_kind_ext::SET_ACCESSOR => {
-                            if let Some(accessor) = self.ctx.arena.get_accessor(member_node) {
-                                self.has_readonly_modifier(&accessor.modifiers)
-                            } else {
-                                false
-                            }
-                        }
-                        _ => false,
+                    let readonly_mod = match member_node.kind {
+                        syntax_kind_ext::METHOD_DECLARATION => self
+                            .ctx
+                            .arena
+                            .get_method_decl(member_node)
+                            .map(|method| method.modifiers.clone())
+                            .and_then(|modifiers| self.find_readonly_modifier(&modifiers)),
+                        syntax_kind_ext::GET_ACCESSOR | syntax_kind_ext::SET_ACCESSOR => self
+                            .ctx
+                            .arena
+                            .get_accessor(member_node)
+                            .map(|accessor| accessor.modifiers.clone())
+                            .and_then(|modifiers| self.find_readonly_modifier(&modifiers)),
+                        _ => None,
                     };
-                    if has_readonly_on_non_property {
+                    if let Some(readonly_mod) = readonly_mod {
                         self.error_at_node(
-                            member_idx,
+                            readonly_mod,
                             diagnostic_messages::READONLY_MODIFIER_CAN_ONLY_APPEAR_ON_A_PROPERTY_DECLARATION_OR_INDEX_SIGNATURE,
                             diagnostic_codes::READONLY_MODIFIER_CAN_ONLY_APPEAR_ON_A_PROPERTY_DECLARATION_OR_INDEX_SIGNATURE,
                         );

--- a/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
@@ -1135,13 +1135,24 @@ impl<'a> CheckerState<'a> {
             };
 
             match node.kind {
-                // TS1042: 'async' modifier cannot be used on getters/setters
+                // TS1042: 'async' modifier cannot be used on getters/setters.
+                // Anchor at the `async` keyword (tsc's `checkGrammarModifiers`
+                // points at the offending modifier, not the accessor name, so
+                // `public async get x()` still points at `async`). When the
+                // accessor also carries `readonly`, defer to that member's
+                // TS1024 (`readonly`-on-accessor, reported from `class.rs`):
+                // tsc emits a single modifier-grammar diagnostic per member and
+                // `readonly` wins over `async` on an accessor in either source
+                // order (`readonly async get`, `async readonly get` both report
+                // only TS1024). `readonly` on a *property* is legal and does not
+                // fire TS1024, so the property arm below keeps its lone TS1042.
                 syntax_kind_ext::GET_ACCESSOR | syntax_kind_ext::SET_ACCESSOR => {
                     if let Some(accessor) = self.ctx.arena.get_accessor(node)
-                        && self.has_async_modifier(&accessor.modifiers)
+                        && !self.has_readonly_modifier(&accessor.modifiers)
+                        && let Some(async_mod_idx) = self.find_async_modifier(&accessor.modifiers)
                     {
                         self.error_at_node(
-                            member_idx,
+                            async_mod_idx,
                             "'async' modifier cannot be used here.",
                             diagnostic_codes::MODIFIER_CANNOT_BE_USED_HERE,
                         );

--- a/crates/tsz-checker/src/tests/member_modifier_placement_grammar_tests.rs
+++ b/crates/tsz-checker/src/tests/member_modifier_placement_grammar_tests.rs
@@ -9,7 +9,7 @@
 //! (`--noEmit --strict --target es2022 --lib es2022`). Binder names are varied
 //! so the diagnostic is keyed on the modifier position, not any identifier.
 
-use crate::test_utils::check_source_codes_with_parse_health;
+use crate::test_utils::{check_source_codes_with_parse_health, check_source_diagnostics};
 
 fn codes(source: &str) -> Vec<u32> {
     check_source_codes_with_parse_health(source)
@@ -18,6 +18,35 @@ fn codes(source: &str) -> Vec<u32> {
 const TS1024: u32 = 1024; // 'readonly' modifier can only appear on a property declaration or index signature.
 const TS1042: u32 = 1042; // 'async' modifier cannot be used here.
 const TS1089: u32 = 1089; // '{0}' modifier cannot appear on a constructor declaration.
+
+/// The modifier-placement grammar codes this suite is about. Anchoring/dedup
+/// assertions filter to these so they stay immune to unrelated harness noise —
+/// e.g. `check_source_diagnostics` loads no lib, so an `async` member with a
+/// `Promise` return type also draws TS1064/TS2583 (`Promise` unresolved) that
+/// the real CLI, with the lib present, never emits.
+const PLACEMENT_CODES: [u32; 3] = [TS1024, TS1042, TS1089];
+
+/// `(code, anchored source text)` for each modifier-placement diagnostic,
+/// sorted, so a test pins both the code and *where* the diagnostic points
+/// without hard-coding byte offsets. tsc's `checkGrammarModifiers` anchors a
+/// modifier-placement error at the offending modifier keyword itself (not the
+/// member name or the declaration start), so the anchored text is exactly
+/// `"readonly"` / `"async"`.
+fn coded_anchors(source: &str) -> Vec<(u32, String)> {
+    let mut v: Vec<(u32, String)> = check_source_diagnostics(source)
+        .iter()
+        .filter(|d| PLACEMENT_CODES.contains(&d.code))
+        .map(|d| {
+            let anchor = source
+                .get(d.start as usize..(d.start + d.length) as usize)
+                .unwrap_or_default()
+                .to_string();
+            (d.code, anchor)
+        })
+        .collect();
+    v.sort_unstable();
+    v
+}
 
 // --- readonly on a constructor => TS1024 (the newly-covered position) -------
 
@@ -84,6 +113,116 @@ fn async_constructor_still_reports_ts1089_not_ts1042() {
     // `async` on a constructor is TS1089, a distinct code, and must not be
     // reclassified by the property/accessor async placement check.
     assert_eq!(codes("class C { async constructor() {} }"), vec![TS1089]);
+}
+
+// --- anchor position: TS1024/TS1042 point at the offending modifier keyword,
+// --- not the member name or declaration start, for every modifier ordering ---
+
+#[test]
+fn readonly_on_method_anchors_at_readonly_even_when_not_first() {
+    // `readonly` is not the first modifier here; tsc still anchors TS1024 at
+    // the `readonly` keyword, not at `static`/`public` or the method name.
+    for source in [
+        "class C { static readonly m(): void {} }",
+        "class C { public readonly m(): void {} }",
+        "class C { async readonly m(): Promise<void> {} }",
+    ] {
+        assert_eq!(
+            coded_anchors(source),
+            vec![(TS1024, "readonly".to_string())],
+            "source: {source}"
+        );
+    }
+}
+
+#[test]
+fn readonly_on_accessor_anchors_at_readonly_even_when_not_first() {
+    for source in [
+        "class C { static readonly get x() { return 1; } }",
+        "class C { public readonly get x(): number { return 1; } }",
+        "class C { static readonly set x(v: number) {} }",
+    ] {
+        assert_eq!(
+            coded_anchors(source),
+            vec![(TS1024, "readonly".to_string())],
+            "source: {source}"
+        );
+    }
+}
+
+#[test]
+fn abstract_readonly_accessor_in_abstract_class_anchors_at_readonly() {
+    // `abstract` is legal on an abstract class's accessor, so the lone error is
+    // `readonly` (TS1024), anchored at the `readonly` keyword.
+    let source = "abstract class C { abstract readonly get x(): number; }";
+    assert_eq!(
+        coded_anchors(source),
+        vec![(TS1024, "readonly".to_string())]
+    );
+}
+
+#[test]
+fn async_on_accessor_anchors_at_async_even_when_not_first() {
+    for source in [
+        "class C { static async get x() { return 1; } }",
+        "class C { public async get x(): number { return 1; } }",
+        "class C { static async set x(v: number) {} }",
+    ] {
+        assert_eq!(
+            coded_anchors(source),
+            vec![(TS1042, "async".to_string())],
+            "source: {source}"
+        );
+    }
+}
+
+#[test]
+fn async_on_property_anchors_at_async_even_when_not_first() {
+    for source in [
+        "class C { static async p = 1; }",
+        "class C { readonly async p = 1; }",
+        "class C { async readonly p = 1; }",
+    ] {
+        assert_eq!(
+            coded_anchors(source),
+            vec![(TS1042, "async".to_string())],
+            "source: {source}"
+        );
+    }
+}
+
+// --- first-error-wins: an accessor carrying both `readonly` and `async` is a
+// --- single diagnostic (TS1024 at `readonly`), in either source order, since
+// --- tsc reports one modifier-grammar diagnostic per member and `readonly`
+// --- wins over `async` on an accessor. `readonly` on a *property* is legal, so
+// --- that shape keeps its lone TS1042 (asserted above). ----------------------
+
+#[test]
+fn readonly_and_async_on_accessor_reports_only_ts1024_at_readonly() {
+    for source in [
+        "class C { readonly async get x() { return 1; } }",
+        "class C { async readonly get x() { return 1; } }",
+        "class C { readonly async set x(v: number) {} }",
+        "class C { async readonly set x(v: number) {} }",
+    ] {
+        assert_eq!(
+            coded_anchors(source),
+            vec![(TS1024, "readonly".to_string())],
+            "source: {source}"
+        );
+    }
+}
+
+#[test]
+fn readonly_and_async_accessor_dedup_is_independent_of_member_name() {
+    for name in ["x", "value", "prop", "data"] {
+        let source = format!("class C {{ readonly async get {name}() {{ return 1; }} }}");
+        assert_eq!(
+            coded_anchors(&source),
+            vec![(TS1024, "readonly".to_string())],
+            "source: {source}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Follow-up to #16291's class-member modifier slice (`12b3403`, which added
`readonly`-on-constructor → TS1024 and `async`-on-property → TS1042). Two sibling
arms were left behind and diverge from tsc's `checkGrammarModifiers`.

**Structural rule:** when a class method or accessor carries a `readonly`
modifier, tsc reports TS1024 anchored **at the `readonly` keyword**; when an
accessor carries `async` (and no `readonly`), it reports TS1042 **at the `async`
keyword** — one diagnostic per member, at the offending modifier, regardless of
modifier order. tsz owns this in the checker (`state_checking/class.rs` for
`readonly`, `state_checking_members/member_declaration_checks.rs` for accessor
`async`), and both arms were anchoring at the whole member node and firing
independently.

Two observable divergences, both confirmed against `typescript@7.0.2`
(`--noEmit --strict --target es2022`) and a rebuilt release CLI:

- **Wrong anchor column** whenever the offending modifier is not first:

  | source | tsc | before | after |
  | --- | --- | --- | --- |
  | `static readonly m() {}` | TS1024 @ `readonly` | @ `static` | @ `readonly` |
  | `public async get x() {}` | TS1042 @ `async` | @ `public` | @ `async` |
  | `abstract readonly get x()` | TS1024 @ `readonly` | @ `abstract` | @ `readonly` |

- **Double report** on an accessor carrying both `readonly` and `async` (tsc
  emits one; `readonly` wins over `async` in either source order):

  | source | tsc | before | after |
  | --- | --- | --- | --- |
  | `readonly async get x() {}` | TS1024 only | TS1024 + TS1042 | TS1024 only |
  | `async readonly get x() {}` | TS1024 only | TS1024 + TS1042 | TS1024 only |

The fix anchors both at the modifier node (mirroring the already-correct
constructor arm in `ambient_constructor_checks.rs`) and suppresses the accessor
`async` TS1042 when `readonly` is also present. `readonly` on a **property** is
legal, so the property `async` arm is untouched (`readonly async p = 1` stays a
lone TS1042). The ambient `declare`-member async → TS1040 path is a separate
code-selection concern and is not touched.

## Goal
Goal: hold

## Verification
- New `typescript@7.0.2`-pinned adjacent-case matrix in
  `member_modifier_placement_grammar_tests.rs` asserting both the code and the
  anchored keyword across every modifier ordering, with binder/member names
  varied so the diagnostic is keyed on modifier position, not any identifier.
- `cargo test -p tsz-checker` green (full crate, via the pre-commit verification
  hook — modifier-grammar, first-error-wins, and private-name suites included).
- `clippy` and `arch-size` (the per-merge CI lane) pass locally (pre-commit hook:
  "Clippy passed / Architecture guard passed").
- Rebuilt release CLI vs the pinned oracle: 27/27 exact code+line+column parity
  on a class-member modifier matrix.
- Emit / conformance / fourslash baselines require the `TypeScript/tests/cases`
  submodule, which is not checked out in this container; the change is
  diagnostic-position/count-only (it does not affect emit) and moves these
  diagnostics to tsc's exact positions, so it is code-set-neutral or a parity
  improvement, never a net regression.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01WfX1N82FM9reeCvEsb43tm

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfX1N82FM9reeCvEsb43tm)_