### PR TITLE
chore(readme): refresh conformance stats to 11,525

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ test suite against it.
 
 <!-- CONFORMANCE_START -->
 ```
-Progress: [███████████████████░] 95.7% (11,524/12,043 runnable tests)
+Progress: [███████████████████░] 95.7% (11,525/12,043 runnable tests)
 Candidates: 12,585 (12,043 runnable, 507 unsupported, 35 skipped)
 ```
 <!-- CONFORMANCE_END -->


### PR DESCRIPTION
Goal: hold

Refreshes the generated README conformance block from a snapshot measured at
`075f0d4928`. Changes: `11,524/12,043` -> `11,525/12,043` (both render 95.7%).

A one-test delta, published because it is free and correct: the snapshot was
already on disk from this cycle's suite run, so the refresh costs nothing beyond
the CI it triggers, and the published figure now matches the measured tree
exactly.

Generated via `scripts/refresh-readme.py --write --skip-performance`; no
hand-edited numbers. The committed value was read back out of the commit
(`git show HEAD:README.md`) before the conformance snapshot tree was discarded.

Emit metrics left untouched -- the script declined to rewrite them
(`preserving README emit metrics because scripts/emit/emit-detail.json is behind
the existing README emit block and does not record the current HEAD`).
Fourslash metrics already accurate. Performance chart skipped; the full sweep
for this cycle runs after this lands (see below).

## Verification

Measured at `075f0d4928`:

- conformance: `11525 / 12043` runnable (95.7%), 12585 candidates, 507
  unsupported, 35 skipped
- emit JS: `11562 / 11563`, emit DTS: `1375 / 1390` -- both at the parity floor,
  unmoved across roughly 470 commits
- fourslash: `6558 / 6562` baseline held. Complete run (`6562/6562` executed),
  0 watchdog kills, 2 slow-but-passed (those passed, over the 15s wall clock
  under concurrent load). The 4 failures are exactly the known baseline set:
  `completionListFunctionExpression`,
  `importFixesWithPackageJsonInSideAnotherPackage`,
  `importNameCodeFix_importType`, `autoImportProvider_importsMap1`.

## Benchmark ordering note

This PR is deliberately opened *before* the benchmark sweep starts. The sweep's
launch step discards `scripts/conformance/`, which is the artifact
`refresh-readme.py` reads -- and since a full sweep takes ~6 hours, during which
conformance cannot be re-run without corrupting the timings, discarding first
blocks the publish for the whole window. That happened last cycle. Correct order
is: suites -> publish and merge -> discard -> benchmark.

## comlink (#16554) status carried forward

Unrecovered at ~320.5 ms, +12.6 ms (+4.1%) over the 307.9 ms baseline. Post-
regression readings: `321.1`, `320.8`, `320.2`, `315.8`, `320.4` -- four cluster
tightly, the lone `315.8` is a 2-3σ outlier I previously and wrongly reported as
a partial recovery. This cycle's sweep will add a sixth reading; any apparent
improvement needs ~8-10 ms to clear the scatter and a second confirming SHA
before it gets reported as recovery.

## Provenance

Machine: m1
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high

AgentName: M1FableArchitect