### PR TITLE
fix(parser): treat // and /* */ comments as trivia in .json validation

### DIFF
--- a/crates/tsz-core/src/parallel/core/json_validation.rs
+++ b/crates/tsz-core/src/parallel/core/json_validation.rs
@@ -14,7 +14,6 @@ fn validate_json_syntax(source: &str) -> Vec<ParseDiagnostic> {
     let len = bytes.len();
     let mut i = 0;
 
-    let is_ws = |b: u8| matches!(b, b' ' | b'\t' | b'\n' | b'\r');
     let is_ident_start = |b: u8| b.is_ascii_alphabetic() || b == b'_' || b == b'$';
     let is_ident_part = |b: u8| b.is_ascii_alphanumeric() || b == b'_' || b == b'$';
 
@@ -25,10 +24,10 @@ fn validate_json_syntax(source: &str) -> Vec<ParseDiagnostic> {
     //   end of run        -> TS1005 "'}' expected."
     //
     // Valid JSON roots `true` / `false` / `null` are explicitly allowed.
-    let mut j = 0usize;
-    while j < len && is_ws(bytes[j]) {
-        j += 1;
-    }
+    // Leading trivia (whitespace and comments) is skipped first, so a bare
+    // identifier root preceded by a `// header` comment still triggers the
+    // recovery rather than being masked by the unrecognized `/`.
+    let j = skip_json_trivia(bytes, 0, len);
     if j < len && is_ident_start(bytes[j]) {
         let mut spans: Vec<(usize, usize)> = Vec::new();
         let mut k = j;
@@ -39,9 +38,10 @@ fn validate_json_syntax(source: &str) -> Vec<ParseDiagnostic> {
             }
             spans.push((start, k));
 
-            while k < len && is_ws(bytes[k]) {
-                k += 1;
-            }
+            // Trivia (whitespace and comments alike) separates identifiers in
+            // this recovery run, matching how tsc's scanner tokenizes the same
+            // bytes — so `foo /*c*/ bar` recovers identically to `foo bar`.
+            k = skip_json_trivia(bytes, k, len);
 
             if k < len && is_ident_start(bytes[k]) {
                 continue;
@@ -100,13 +100,20 @@ fn validate_json_syntax(source: &str) -> Vec<ParseDiagnostic> {
     let mut expecting_value = false;
 
     while i < len {
-        let b = bytes[i];
-
-        // Skip whitespace
-        if b == b' ' || b == b'\t' || b == b'\n' || b == b'\r' {
-            i += 1;
+        // Skip whitespace and JSON comment trivia (`//` line and `/* */`
+        // block). tsc's JSON scanner treats both as trivia. This runs before
+        // value/property classification below so a comment sitting between a
+        // property's `:` and its value is skipped rather than mis-reported as
+        // TS1328. Strings are consumed atomically by the string-skip block
+        // further down, so a `//` or `/* */` *inside* a string never reaches
+        // this point and stays part of the value.
+        let after_trivia = skip_json_trivia(bytes, i, len);
+        if after_trivia != i {
+            i = after_trivia;
             continue;
         }
+
+        let b = bytes[i];
 
         // When expecting a property value (just past a property's `:`) or an
         // array element (just past `[` or a `,` inside an array), check what
@@ -250,6 +257,45 @@ fn validate_json_syntax(source: &str) -> Vec<ParseDiagnostic> {
     }
 
     diagnostics
+}
+
+/// Advance `idx` past JSON trivia: ASCII whitespace and `//` line / `/* */`
+/// block comments, which tsc's JSON scanner skips as trivia. Stops at the
+/// first byte that begins neither. A `/` not followed by `/` or `*` is not a
+/// comment and is left in place for the caller to classify. An unterminated
+/// block comment consumes to end of input, matching the scanner treating the
+/// rest of the file as comment.
+///
+/// Callers must only invoke this outside of string literals: a `//` or `/* */`
+/// appearing inside a JSON string is ordinary string content, and the caller's
+/// string handling is responsible for consuming the string whole before this
+/// runs.
+fn skip_json_trivia(bytes: &[u8], mut idx: usize, len: usize) -> usize {
+    loop {
+        idx = tsz_common::text_scan::skip_ascii_whitespace(bytes, idx);
+
+        if idx + 1 < len && bytes[idx] == b'/' && bytes[idx + 1] == b'/' {
+            idx += 2;
+            while idx < len && bytes[idx] != b'\n' {
+                idx += 1;
+            }
+            continue;
+        }
+
+        if idx + 1 < len && bytes[idx] == b'/' && bytes[idx + 1] == b'*' {
+            idx += 2;
+            while idx + 1 < len && !(bytes[idx] == b'*' && bytes[idx + 1] == b'/') {
+                idx += 1;
+            }
+            // Consume the closing `*/`, or run to end of input if the block
+            // comment is unterminated.
+            idx = (idx + 2).min(len);
+            continue;
+        }
+
+        break;
+    }
+    idx
 }
 
 /// Returns whether `bytes[i..]` starts with the exact keyword `word` (`true`,

--- a/crates/tsz-core/tests/parallel_tests_parts/part_05.rs
+++ b/crates/tsz-core/tests/parallel_tests_parts/part_05.rs
@@ -1074,3 +1074,235 @@ fn test_parse_and_bind_single_json_reports_property_value_violation() {
         .collect();
     assert_eq!(codes, vec![1328], "got: {:?}", result.parse_diagnostics);
 }
+
+/// tsc's JSON scanner treats `//` line comments as trivia. A commented line
+/// inside an object — the shape of a `tsconfig.json` with an explanatory
+/// comment — must stay clean, not report TS1327 by mis-reading `//` as an
+/// unquoted property name.
+#[test]
+fn test_parse_file_single_json_line_comment_is_trivia() {
+    let result = parse_file_single(
+        "settings.json".to_string(),
+        "{\n  // comment\n  \"a\": 1\n}".to_string(),
+    );
+
+    assert!(
+        result.parse_diagnostics.is_empty(),
+        "expected no diagnostics, got: {:?}",
+        result.parse_diagnostics
+    );
+}
+
+/// A `/* */` block comment in property-name position is also trivia.
+#[test]
+fn test_parse_file_single_json_leading_block_comment_is_trivia() {
+    let result = parse_file_single(
+        "settings.json".to_string(),
+        r#"{ /* leading */ "a": 1 }"#.to_string(),
+    );
+
+    assert!(
+        result.parse_diagnostics.is_empty(),
+        "expected no diagnostics, got: {:?}",
+        result.parse_diagnostics
+    );
+}
+
+/// A trailing line comment after the closing `}` is trivia at object depth 0.
+#[test]
+fn test_parse_file_single_json_trailing_line_comment_is_trivia() {
+    let result = parse_file_single(
+        "settings.json".to_string(),
+        "{ \"a\": 1 } // trailing line comment".to_string(),
+    );
+
+    assert!(
+        result.parse_diagnostics.is_empty(),
+        "expected no diagnostics, got: {:?}",
+        result.parse_diagnostics
+    );
+}
+
+/// A comment between a property's `:` and its value must be skipped *before*
+/// value classification — otherwise the `/` starts the value and draws TS1328
+/// (a different wrong answer), which is exactly the #16819 interaction the
+/// issue calls out.
+#[test]
+fn test_parse_file_single_json_comment_between_key_and_value_is_trivia() {
+    let result = parse_file_single(
+        "settings.json".to_string(),
+        r#"{ "a": /* between key and value */ 1 }"#.to_string(),
+    );
+
+    assert!(
+        result.parse_diagnostics.is_empty(),
+        "expected no diagnostics, got: {:?}",
+        result.parse_diagnostics
+    );
+}
+
+/// The constraining controls: a `//` or `/* */` sequence *inside* a string
+/// value is ordinary content, not a comment. The string must stay clean and
+/// must not be eaten — proven by a following invalid value that still draws
+/// its own TS1328 (if the `//` had started a line comment, the rest of the
+/// object, `undefined` included, would have been swallowed and gone silent).
+#[test]
+fn test_parse_file_single_json_slashes_inside_string_are_not_a_comment() {
+    let line = parse_file_single(
+        "settings.json".to_string(),
+        r#"{ "a": "// x", "b": undefined }"#.to_string(),
+    );
+    let line_got: Vec<(u32, u32)> = line
+        .parse_diagnostics
+        .iter()
+        .map(|d| (d.code, d.start))
+        .collect();
+    assert_eq!(
+        line_got,
+        vec![(1328, 20)],
+        "`//` inside a string must stay content; the trailing invalid value must still report, got: {:?}",
+        line.parse_diagnostics
+    );
+
+    let block = parse_file_single(
+        "settings.json".to_string(),
+        r#"{ "a": "/* x */", "b": undefined }"#.to_string(),
+    );
+    let block_got: Vec<(u32, u32)> = block
+        .parse_diagnostics
+        .iter()
+        .map(|d| (d.code, d.start))
+        .collect();
+    assert_eq!(
+        block_got,
+        vec![(1328, 23)],
+        "`/* */` inside a string must stay content; the trailing invalid value must still report, got: {:?}",
+        block.parse_diagnostics
+    );
+}
+
+/// A commented-out property line — the practical case in a hand-maintained
+/// `tsconfig.json` — is trivia and leaves the real properties untouched.
+#[test]
+fn test_parse_file_single_json_commented_out_property_line_is_trivia() {
+    let result = parse_file_single(
+        "settings.json".to_string(),
+        "{\n  // \"old\": 1,\n  \"new\": 2\n}".to_string(),
+    );
+
+    assert!(
+        result.parse_diagnostics.is_empty(),
+        "expected no diagnostics, got: {:?}",
+        result.parse_diagnostics
+    );
+}
+
+/// Mixed and adjacent line and block comments all resolve as a single run of
+/// trivia — the trivia skip loops until no comment or whitespace remains.
+#[test]
+fn test_parse_file_single_json_mixed_comments_are_trivia() {
+    let result = parse_file_single(
+        "settings.json".to_string(),
+        "{ /* a */ // b\n \"x\": 1 }".to_string(),
+    );
+
+    assert!(
+        result.parse_diagnostics.is_empty(),
+        "expected no diagnostics, got: {:?}",
+        result.parse_diagnostics
+    );
+}
+
+/// A block comment whose body contains structural bytes (`}`, `]`, `"`, `:`)
+/// must be consumed whole, so those bytes never desync the object/array state
+/// machine.
+#[test]
+fn test_parse_file_single_json_block_comment_body_is_not_structural() {
+    let result = parse_file_single(
+        "settings.json".to_string(),
+        r#"{ /* } ] " : */ "a": 1 }"#.to_string(),
+    );
+
+    assert!(
+        result.parse_diagnostics.is_empty(),
+        "expected no diagnostics, got: {:?}",
+        result.parse_diagnostics
+    );
+}
+
+/// Comment skipping is trivia, not suppression: a genuinely unquoted property
+/// name that merely happens to be preceded by a comment must still report
+/// TS1327, anchored at the name.
+#[test]
+fn test_parse_file_single_json_comment_does_not_suppress_real_ts1327() {
+    let result = parse_file_single(
+        "settings.json".to_string(),
+        r#"{ /* c */ bad: 1 }"#.to_string(),
+    );
+
+    let got: Vec<(u32, u32)> = result
+        .parse_diagnostics
+        .iter()
+        .map(|d| (d.code, d.start))
+        .collect();
+    assert_eq!(
+        got,
+        vec![(1327, 10)],
+        "a comment must not swallow a real unquoted-name error, got: {:?}",
+        result.parse_diagnostics
+    );
+}
+
+/// Leading trivia includes comments in the bare-identifier-root recovery
+/// pre-scan too: a `// header` before a bare identifier run must not mask the
+/// recovery. The reported diagnostics match the un-commented form exactly in
+/// code sequence, only shifted past the comment.
+#[test]
+fn test_parse_file_single_json_leading_comment_before_bare_identifier_root_still_recovers() {
+    let with_comment =
+        parse_file_single("settings.json".to_string(), "// header\nfoo bar".to_string());
+    let without = parse_file_single("settings.json".to_string(), "foo bar".to_string());
+
+    let codes_with: Vec<u32> = with_comment.parse_diagnostics.iter().map(|d| d.code).collect();
+    let codes_without: Vec<u32> = without.parse_diagnostics.iter().map(|d| d.code).collect();
+
+    assert!(
+        !codes_with.is_empty(),
+        "bare identifier root must still recover after a leading comment, got: {:?}",
+        with_comment.parse_diagnostics
+    );
+    assert_eq!(
+        codes_with, codes_without,
+        "a leading comment is trivia; recovery codes must match the un-commented form"
+    );
+    // `// header\n` is 10 bytes, so the first recovery anchor sits at `foo`.
+    assert_eq!(
+        with_comment.parse_diagnostics[0].start, 10,
+        "recovery must anchor past the skipped comment, got: {:?}",
+        with_comment.parse_diagnostics
+    );
+}
+
+/// A comment *between* two bare identifiers in the recovery run is trivia too:
+/// tsc tokenizes `foo /*c*/ bar` and `foo bar` identically, so both must emit
+/// the same TS1005/TS1136 recovery sequence rather than the commented form
+/// falling silent.
+#[test]
+fn test_parse_file_single_json_comment_between_bare_identifiers_still_recovers() {
+    let with_comment =
+        parse_file_single("settings.json".to_string(), "foo /* c */ bar".to_string());
+    let without = parse_file_single("settings.json".to_string(), "foo bar".to_string());
+
+    let codes_with: Vec<u32> = with_comment.parse_diagnostics.iter().map(|d| d.code).collect();
+    let codes_without: Vec<u32> = without.parse_diagnostics.iter().map(|d| d.code).collect();
+
+    assert!(
+        !codes_with.is_empty(),
+        "a comment between bare identifiers must not mask the recovery, got: {:?}",
+        with_comment.parse_diagnostics
+    );
+    assert_eq!(
+        codes_with, codes_without,
+        "an inter-identifier comment is trivia; recovery codes must match the un-commented form"
+    );
+}


### PR DESCRIPTION
Structural rule: when a `.json` file contains a `//` line or `/* */` block comment, tsc's dedicated JSON scanner skips it as trivia before every token; tsz's `.json` byte-scanner validator (`validate_json_syntax` in `crates/tsz-core/src/parallel/core/json_validation.rs`) recognized only whitespace as inter-token trivia, so a comment in property-name position was mis-read as an unquoted name → `TS1327`, and (post the `#16819` `TS1328` value check) a comment between `:` and its value would become `TS1328`. Fixes #16826.

The fix adds a shared `skip_json_trivia` helper — whitespace via the existing `tsz_common::text_scan::skip_ascii_whitespace` primitive, plus both comment forms — and invokes it at every trivia site the scanner has: the main scan loop **before** value/property classification (so a comment between `:` and its value is skipped, not mis-reported as `TS1328`), the leading-trivia skip of the bare-identifier-root recovery pre-scan, and that pre-scan's inter-identifier gap (so `foo /*c*/ bar` recovers identically to `foo bar`, matching tsc's token stream). Strings are consumed atomically by the existing string-skip block, so a `//` or `/* */` **inside** a string stays content and never reaches the trivia skip.

Owner layer: this is the `.json` parse path in `tsz-core`, tsz's owner for JSON validation diagnostics — no checker/solver involvement, no `.json`-file-name or source-text predicate driving the decision (comment recognition is purely structural byte classification).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-core --lib -- json` → 62 passed / 0 failed (11 new comment-trivia tests + the existing JSON validation suite unchanged).
- `cargo test -p tsz-core --lib -- parallel::core::tests` → 241 passed / 0 failed.
- `cargo clippy -p tsz-core --lib` → clean; local pre-commit `clippy` + `arch-size` guards passed.
- Adjacent matrix covered by new tests: line comment, leading/trailing/`/* */`-between-key-and-value positions, commented-out property line, mixed line+block comments, structural bytes (`}`/`]`/`"`/`:`) inside a block comment; the two string-content controls (`"// not a comment"`, `"/* also text */"`) proven clean **and** un-eaten via a following invalid value that still reports; a comment never suppressing a real `TS1327`; and leading/inter-identifier comments still triggering the bare-identifier recovery with the same code sequence as the un-commented form.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZ8YfLHpnAkAVqDAGsttfQ)_