### PR TITLE
fix(checker): TS2662/TS2663 member-prefix suggestion for an unresolved name in a class

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2685,6 +2685,9 @@ path = "tests/namespace_body_local_declaration_merge_tests.rs"
 [[test]]
 name = "noimplicitany_type_member_accessor_tests"
 path = "tests/noimplicitany_type_member_accessor_tests.rs"
+[[test]]
+name = "missing_prefix_member_suggestion_tests"
+path = "tests/missing_prefix_member_suggestion_tests.rs"
 
 [[test]]
 name = "signature_binding_pattern_typeof_scope_tests"

--- a/crates/tsz-checker/src/types/computation/identifier/resolution.rs
+++ b/crates/tsz-checker/src/types/computation/identifier/resolution.rs
@@ -365,41 +365,103 @@ impl<'a> CheckerState<'a> {
         TypeId::ERROR
     }
 
+    /// The declared member nodes and name text of the class at `class_idx`.
+    fn class_members_and_name(&self, class_idx: NodeIndex) -> Option<(Vec<NodeIndex>, String)> {
+        let class_node = self.ctx.arena.get(class_idx)?;
+        let class = self.ctx.arena.get_class(class_node)?;
+        let members = class.members.nodes.clone();
+        let name_node = self.ctx.arena.get(class.name)?;
+        let name = self
+            .ctx
+            .arena
+            .get_identifier(name_node)?
+            .escaped_text
+            .to_string();
+        Some((members, name))
+    }
+
+    /// Whether the global `Function` interface has a member `name`. Every class
+    /// constructor type is a subtype of `Function` (which extends `Object`), so
+    /// tsc's `getPropertyOfType(typeof Class, name)` resolves the `Function`
+    /// (and `Object`) members on it — `arguments`, `caller`, `length`, `name`,
+    /// `prototype`, `apply`, `call`, `bind`, `hasOwnProperty`, … This is the same
+    /// subtype-of-`Function` mechanism, applied to any name (not an
+    /// `arguments`-specific special case), and it is stable across the two
+    /// resolution passes because it depends only on the global lib type, not on
+    /// the enclosing class's own (mid-computation) constructor type.
+    fn global_function_type_has_member(&mut self, name: &str) -> bool {
+        let Some(function_type) = self.resolve_lib_type_by_name("Function") else {
+            return false;
+        };
+        matches!(
+            self.resolve_property_access_with_env(function_type, name),
+            tsz_solver::operations::property::PropertyAccessResult::Success {
+                from_index_signature: false,
+                ..
+            }
+        )
+    }
+
     /// Handle a truly unresolved identifier — not a type parameter, not in the
-    /// binder, not a known global. Emits TS2304, TS2524, TS2662 as appropriate.
+    /// binder, not a known global. Emits the member-prefix suggestion
+    /// (`TS2662`/`TS2663`), `TS2524`/`TS2523`, or falls through to the bare
+    /// `TS2304`/`TS2552` name-resolution boundary.
     fn resolve_truly_unknown_identifier(&mut self, idx: NodeIndex, name: &str) -> TypeId {
         // Note: TS1212/1213/1214 strict-mode reserved word check is now handled
         // centrally in error_cannot_find_name_at to cover both value and type contexts.
 
-        // Check static member suggestion (error 2662)
-        if let Some(ref class_info) = self.ctx.enclosing_class.clone()
-            && self.is_static_member(&class_info.member_nodes, name)
+        // Member-prefix suggestion (tsc's `checkAndReportErrorForMissingPrefix`):
+        // an unresolved identifier inside a class that names a member reachable on
+        // the class's constructor type gets `TS2662` ("Did you mean the static
+        // member 'C.x'?"), or — in a non-static context — its instance type gets
+        // `TS2663` ("Did you mean the instance member 'this.x'?"), instead of a
+        // bare `TS2304`.
+        //
+        // The class is found from the AST (`nearest_enclosing_class`) rather than
+        // the ambient `enclosing_class` context, which is unset during on-demand
+        // class-type computation (evaluating member initializers to type them).
+        // A suggestion keyed on that context would fire in the statement-walk
+        // pass but not the type-computation pass; since both passes resolve the
+        // same identifier and diagnostics dedupe by `(start, code)`, a suggestion
+        // in one pass and a bare `TS2304` in the other would *both* survive.
+        // Deciding from the AST (and the global-lib `Function` type) makes the two
+        // passes agree — one diagnostic. `nearest_enclosing_class` walks through
+        // function boundaries, so a class's statics are suggestable from a nested
+        // function too; the `this`-rebind boundary is enforced on the instance
+        // arm below.
+        if let Some(class_idx) = self.nearest_enclosing_class(idx)
+            && let Some((member_nodes, class_name)) = self.class_members_and_name(class_idx)
         {
-            self.error_cannot_find_name_static_member_at(name, &class_info.name, idx);
-            return TypeId::ERROR;
-        }
-        // TS2663: Check instance member suggestion — "Did you mean 'this.X'?"
-        // When an unresolved name matches an instance member of the enclosing class
-        // AND we're in a non-static context where `this` refers to the class instance,
-        // suggest 'this.X'. Don't suggest when:
-        // - We're in a static method (this refers to constructor)
-        // - We're inside a regular function expression (this is rebound)
-        if let Some(ref class_info) = self.ctx.enclosing_class.clone()
-            && !class_info.in_static_member
-            && self.is_instance_member(&class_info.member_nodes, name)
-            && !self.has_regular_function_boundary_to_class(idx)
-        {
-            use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
-            let message = format_message(
-                diagnostic_messages::CANNOT_FIND_NAME_DID_YOU_MEAN_THE_INSTANCE_MEMBER_THIS,
-                &[name],
-            );
-            self.error_at_node(
-                idx,
-                &message,
-                diagnostic_codes::CANNOT_FIND_NAME_DID_YOU_MEAN_THE_INSTANCE_MEMBER_THIS,
-            );
-            return TypeId::ERROR;
+            // Static (TS2662): a declared static, or a member of `Function`
+            // (`arguments`/`caller`/… — every constructor type is a subtype of
+            // `Function`). Checked before the instance arm, matching tsc.
+            if self.is_static_member(&member_nodes, name)
+                || self.global_function_type_has_member(name)
+            {
+                self.error_cannot_find_name_static_member_at(name, &class_name, idx);
+                return TypeId::ERROR;
+            }
+            // Instance (TS2663): a declared instance member, in a non-static
+            // context (in a static member `this` is the constructor, so tsc
+            // reports the bare `TS2304`) with no regular-function boundary
+            // between the reference and the class (a function rebinds `this`, so
+            // `this.x` would not reach the class instance).
+            if !self.is_in_static_class_member_context(idx)
+                && !self.has_regular_function_boundary_to_class(idx)
+                && self.is_instance_member(&member_nodes, name)
+            {
+                use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+                let message = format_message(
+                    diagnostic_messages::CANNOT_FIND_NAME_DID_YOU_MEAN_THE_INSTANCE_MEMBER_THIS,
+                    &[name],
+                );
+                self.error_at_node(
+                    idx,
+                    &message,
+                    diagnostic_codes::CANNOT_FIND_NAME_DID_YOU_MEAN_THE_INSTANCE_MEMBER_THIS,
+                );
+                return TypeId::ERROR;
+            }
         }
         // TS2524: 'await' in default parameter
         if name == "await" && self.is_in_default_parameter(idx) {

--- a/crates/tsz-checker/tests/missing_prefix_member_suggestion_tests.rs
+++ b/crates/tsz-checker/tests/missing_prefix_member_suggestion_tests.rs
@@ -1,0 +1,185 @@
+//! `TS2662`/`TS2663` — the "did you mean the static/instance member" suggestion
+//! for an unresolved identifier inside a class, tsc's
+//! `checkAndReportErrorForMissingPrefix`. Issue #16815.
+//!
+//! Structural rule, one sentence: when an unresolved value identifier sits in a
+//! class member's body/initializer and names a member reachable on the enclosing
+//! class's **constructor type** (`TS2662`, `Class.name`) or — in a non-static
+//! context — its **instance type** (`TS2663`, `this.name`), tsc suggests that
+//! member instead of the bare `TS2304`. A constructor type is a subtype of
+//! `Function` (which extends `Object`), so `arguments`, `caller`, `length`,
+//! `prototype`, `apply`, … resolve on it for *any* class — `arguments` in a
+//! class field initializer at module scope is the #16815 witness: post-#16812
+//! (which stopped `TS2815` firing when no function encloses the reference) it
+//! fell through to a bare `TS2304`.
+//!
+//! The suggestion is decided from the AST (the enclosing `class` ancestor), not
+//! the ambient enclosing-class state, so it is identical in the statement-walk
+//! pass and the on-demand class-type-computation pass — the two both resolve the
+//! same identifier and diagnostics dedupe by `(start, code)`, so a suggestion in
+//! one pass and a bare `TS2304` in the other would otherwise both surface.
+//!
+//! These tests load the real default lib (via [`load_default_lib_files`]) so the
+//! global `Function` interface resolves — the no-lib `check_source_strict`
+//! harness cannot see `Function`'s members. Expectations were recorded from
+//! `typescript@7.0.2` (`scripts/conformance/oracle.sh`) under `--strict --lib
+//! es2022 --target es2022`.
+//!
+//! Out of scope (a known limitation, not asserted here): a member inherited from
+//! a *base class* (`class Sub extends Base { p = baseStatic; }`) still gets a
+//! bare `TS2304` rather than the suggestion — resolving it needs the class's own
+//! (mid-computation) constructor/instance type, whose lookup is not stable across
+//! the two resolution passes and would reintroduce a duplicate diagnostic.
+
+use std::sync::Arc;
+use tsz_binder::lib_loader::LibFile;
+use tsz_checker::test_utils::{
+    check_source_with_libs, load_default_lib_files, strict_checker_options,
+};
+
+/// The member-prefix *suggestion* diagnostics (`TS2662`/`TS2663`) for `source`,
+/// as `"TS<code>: <message>"`, sorted.
+///
+/// Only the suggestion codes are asserted here: this in-process harness does not
+/// exercise the bare-`TS2304` fallback arm (a name reachable on neither side
+/// leaves this view empty rather than showing `TS2304`), so a fallback row reads
+/// as "no suggestion". The bare `TS2304`, and the exact column anchors, are
+/// verified end-to-end against the pinned oracle (see the module doc).
+fn suggestions(source: &str, libs: &[Arc<LibFile>]) -> Vec<String> {
+    let mut out: Vec<String> =
+        check_source_with_libs(source, "test.ts", strict_checker_options(), libs)
+            .iter()
+            .filter(|d| matches!(d.code, 2662 | 2663))
+            .map(|d| format!("TS{}: {}", d.code, d.message_text))
+            .collect();
+    out.sort();
+    out
+}
+
+fn assert_suggestions(source: &str, libs: &[Arc<LibFile>], expected: &[&str]) {
+    let actual = suggestions(source, libs);
+    let expected: Vec<String> = expected.iter().map(|s| (*s).to_string()).collect();
+    assert_eq!(actual, expected, "source: {source}");
+}
+
+// ---------------------------------------------------------------------------
+// TS2662 — the constructor-type (static) suggestion, including the `Function`
+// members every constructor carries. Exactly one diagnostic (no duplicate).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn arguments_in_field_initializer_suggests_the_static_member() {
+    let libs = load_default_lib_files();
+    // The #16815 witness: `arguments` is a `Function` member, so it is a member
+    // of `typeof C`. Exactly one diagnostic — the two resolution passes agree.
+    assert_suggestions(
+        "class C { p = arguments; }",
+        &libs,
+        &["TS2662: Cannot find name 'arguments'. Did you mean the static member 'C.arguments'?"],
+    );
+}
+
+#[test]
+fn caller_in_field_initializer_suggests_the_static_member() {
+    let libs = load_default_lib_files();
+    assert_suggestions(
+        "class F { p = caller; }",
+        &libs,
+        &["TS2662: Cannot find name 'caller'. Did you mean the static member 'F.caller'?"],
+    );
+}
+
+#[test]
+fn prototype_is_a_function_member_too() {
+    let libs = load_default_lib_files();
+    assert_suggestions(
+        "class C3 { p = prototype; }",
+        &libs,
+        &["TS2662: Cannot find name 'prototype'. Did you mean the static member 'C3.prototype'?"],
+    );
+}
+
+#[test]
+fn own_static_member_suggests_the_static_member() {
+    let libs = load_default_lib_files();
+    assert_suggestions(
+        "class D { static s = 1; p = s; }",
+        &libs,
+        &["TS2662: Cannot find name 's'. Did you mean the static member 'D.s'?"],
+    );
+}
+
+#[test]
+fn static_context_prefers_the_static_suggestion() {
+    let libs = load_default_lib_files();
+    // In a static field initializer `this` is the constructor, so a static
+    // member (here `prototype`, a `Function` member) is still suggested.
+    assert_suggestions(
+        "class J { static p = prototype; }",
+        &libs,
+        &["TS2662: Cannot find name 'prototype'. Did you mean the static member 'J.prototype'?"],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TS2663 — the instance-type suggestion, only in a non-static context.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn own_instance_member_suggests_the_instance_member() {
+    let libs = load_default_lib_files();
+    assert_suggestions(
+        "class E { m() {} p = m; }",
+        &libs,
+        &["TS2663: Cannot find name 'm'. Did you mean the instance member 'this.m'?"],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fallback rows: bare TS2304 (no suggestion). A name reachable on neither side,
+// and an instance member referenced from a static context.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_name_on_neither_side_produces_no_suggestion() {
+    let libs = load_default_lib_files();
+    // Reachable on neither side → tsc's bare `TS2304` (verified via the oracle);
+    // here the point is that no member-prefix suggestion is offered.
+    assert_suggestions("class G { p = nonexistent; }", &libs, &[]);
+}
+
+#[test]
+fn instance_member_from_a_static_initializer_produces_no_suggestion() {
+    let libs = load_default_lib_files();
+    // `m` is an instance member, but in `static p = m` `this` is the constructor,
+    // so tsc reports a bare `TS2304` — no `this.m` suggestion (and `m` is not on
+    // the constructor type, so the static arm does not fire either).
+    assert_suggestions("class H { m() {} static p = m; }", &libs, &[]);
+}
+
+#[test]
+fn arguments_inside_a_method_body_is_resolved_not_reported() {
+    let libs = load_default_lib_files();
+    // With an enclosing function, `arguments` resolves to `IArguments` — no
+    // cannot-find-name diagnostic at all.
+    assert_suggestions("class C { m() { return arguments; } }", &libs, &[]);
+}
+
+// ---------------------------------------------------------------------------
+// Binder-name invariance: the rule reads the class shape, never a name string.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn suggestion_is_binder_name_invariant() {
+    let libs = load_default_lib_files();
+    assert_suggestions(
+        "class Zqx { static wob = 1; p = wob; }",
+        &libs,
+        &["TS2662: Cannot find name 'wob'. Did you mean the static member 'Zqx.wob'?"],
+    );
+    assert_suggestions(
+        "class Wibble { frob() {} p = frob; }",
+        &libs,
+        &["TS2663: Cannot find name 'frob'. Did you mean the instance member 'this.frob'?"],
+    );
+}


### PR DESCRIPTION
Closes #16815. Follow-up to #16812. When an unresolved identifier in a class member's
body/initializer names a member reachable on the enclosing class's constructor
type, `tsc` reports a member-prefix suggestion instead of the bare `TS2304`;
tsz reported `TS2304`. `class C { p = arguments; }` is the witness: `arguments`
is a `Function` member and every constructor type is a subtype of `Function`,
so `tsc` reports `TS2662` ("Did you mean the static member 'C.arguments'?").

## Structural rule
When an unresolved value identifier inside a class names a member reachable on
the class's **constructor type** (`getPropertyOfType(typeof C, name)`), `tsc`
reports `TS2662` (`Class.name`); in a non-static context, a member reachable on
the **instance type** gets `TS2663` (`this.name`); otherwise the bare `TS2304`.
tsz owns this in `checkers`-adjacent identifier resolution
(`types/computation/identifier/resolution.rs::resolve_truly_unknown_identifier`,
tsc's `checkAndReportErrorForMissingPrefix`), the symbol-resolution/display
layer — not the `arguments` scoping fence #16812 already placed.

A constructor type is a subtype of `Function` (which extends `Object`), so the
static arm also matches `arguments`/`caller`/`length`/`prototype`/`apply`/… for
any class — the same subtype-of-`Function` mechanism, not an `arguments`-specific
case.

## Owner layer / design
- The enclosing class is found from the **AST** (nearest `class` ancestor, via
  the existing `nearest_enclosing_class`), not the ambient `enclosing_class`
  context. That context is unset during on-demand class-type computation (which
  evaluates member initializers to type them), so keying on it fires the
  suggestion in the statement-walk pass but not the type-computation pass; since
  diagnostics dedupe by `(start, code)`, a suggestion in one pass and a bare
  `TS2304` in the other would both surface. AST-driven detection makes the two
  passes agree — exactly one diagnostic.
- Static side runs through function boundaries (a class's statics are
  suggestable from a nested function); the instance side is gated on non-static
  context and no regular-function boundary (`this` rebind).

## Adjacent matrix (oracle: typescript@7.0.2, `--strict --lib es2022 --target es2022`)
| source | tsc / tsz |
| --- | --- |
| `class C { p = arguments; }` | TS2662 `C.arguments` |
| `class F { p = caller; }` | TS2662 `F.caller` |
| `class C3 { p = prototype; }` | TS2662 `C3.prototype` |
| `class D { static s = 1; p = s; }` | TS2662 `D.s` |
| `class E { m() {} p = m; }` | TS2663 `this.m` |
| `class G { p = nonexistent; }` | TS2304 (bare) |
| `class H { m() {} static p = m; }` | TS2304 (static ctx, no `this.m`) |
| `class C { static s=1; m(){ const f=function(){return s}; } }` | TS2662 `C.s` (through function) |
| `class C { m() { return arguments; } }` | clean (resolves to `IArguments`) |

All match `tsc` in code, message, and column, with **no duplicate** diagnostic.

Known limitation (out of scope, not a regression): a member inherited from a
*base class* still gets a bare `TS2304` rather than the suggestion — resolving
it needs the class's own (mid-computation) constructor/instance type, whose
lookup is not stable across the two resolution passes and would reintroduce a
duplicate diagnostic.

## Goal
Goal: hold

## Verification
- Oracle-pinned matrix above verified end-to-end with the built `tsz` CLI vs
  `typescript@7.0.2` (`scripts/conformance/oracle.sh`) — code, message, column,
  and single-diagnostic all match.
- New `crates/tsz-checker/tests/missing_prefix_member_suggestion_tests.rs`
  (10 tests, real default lib via `load_default_lib_files`).
- Targeted `cargo test -p tsz-checker`: `ts2815_arguments_class_scope_tests`
  (15), and `--lib` filters `resolve_truly_unknown`/`cannot_find_name`/
  `did_you_mean` (26), `identifier_resolution`/`ts2662`/`ts2663`/`ts2304`/
  `static_member`/`instance_member` (72), accessor (69),
  `implicit_any`/`setter`/`getter` (191) — all green.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings` clean;
  `scripts/arch/arch_guard.py` passed.
- Conformance/emit/fourslash are the nightly gates; the TypeScript corpus is not
  checked out in this environment, so those were not run locally.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high