### PR TITLE
fix(bench): hyperfine's own comparison text no longer fabricates an Nx ratio for a killed/errored row

### DIFF
--- a/scripts/bench/lib/bench-vs-tsgo-prereqs.sh
+++ b/scripts/bench/lib/bench-vs-tsgo-prereqs.sh
@@ -393,6 +393,42 @@ hyperfine_exit_status_for() {
     return 0
 }
 
+# Print hyperfine's own captured comparison output for a two-command run.
+#
+# hyperfine prints its "Summary\n  <faster> ran\n  N.NN times faster than
+# <slower>" comparison unconditionally whenever `--ignore-failure` let a
+# killed-by-timeout or non-zero-exit command finish "successfully" alongside
+# a clean one: that comparison is `ceiling_or_error_time / other_time`, not a
+# measurement of the losing side, the exact "42.99x faster" fabrication
+# #16196 found from a killed `large-ts-repo` row. #16196's own fix
+# (`row-utils.mjs`'s `didNotFinish`) only reaches the structured JSON/CSV
+# path — hyperfine's raw stdout is a distinct emitter of the same fabricated
+# number and streams straight to the console/CI log before this script ever
+# inspects an exit code, so the JSON-side gate can't intercept it. When `ok`
+# is not "true", strip the trailing Summary block (detected on a
+# color-code-stripped copy so the line count still matches the original,
+# still-colored text) and print an explicit note instead; the per-benchmark
+# timing lines above it stay, since those are real per-command
+# wall-clock measurements even when one side was killed or errored.
+print_hyperfine_comparison_output() {
+    local output="$1"
+    local ok="$2"
+    if [ "$ok" = true ]; then
+        printf '%s\n' "$output"
+        return
+    fi
+    local plain
+    plain="$(printf '%s\n' "$output" | sed 's/\x1b\[[0-9;]*m//g')"
+    local summary_line
+    summary_line="$(printf '%s\n' "$plain" | grep -n '^Summary$' | head -1 | cut -d: -f1)"
+    if [ -n "$summary_line" ] && [ "$summary_line" -gt 1 ]; then
+        printf '%s\n' "$output" | sed -n "1,$((summary_line - 1))p"
+        echo "  (comparison ratio suppressed: a killed/errored run makes it ceiling/other_time, not a measurement — see #16196)"
+    else
+        printf '%s\n' "$output"
+    fi
+}
+
 project_failure_class() {
     local status="$1"
     shift || true

--- a/scripts/bench/lib/bench-vs-tsgo-results.sh
+++ b/scripts/bench/lib/bench-vs-tsgo-results.sh
@@ -313,7 +313,9 @@ run_benchmark() {
     # Use --ignore-failure so hyperfine continues even if a rare iteration is killed.
     local run_timeout=15
     local json_file=$(mktemp)
-    if ! hyperfine \
+    local hyperfine_output=""
+    local hyperfine_status=0
+    hyperfine_output="$(hyperfine \
         --warmup "$WARMUP" \
         --min-runs "$MIN_RUNS" \
         --max-runs "$MAX_RUNS" \
@@ -321,7 +323,9 @@ run_benchmark() {
         --ignore-failure \
         --export-json "$json_file" \
         -n "tsz" "bash $BENCH_TIMEOUT_RUNNER $run_timeout -- ${TSZ_LIB_DIR:+env TSZ_LIB_DIR=$TSZ_LIB_DIR} $TSZ --noEmit $extra_args $file 2>/dev/null" \
-        -n "tsgo" "bash $BENCH_TIMEOUT_RUNNER $run_timeout -- $TSGO --noEmit $extra_args $file 2>/dev/null"; then
+        -n "tsgo" "bash $BENCH_TIMEOUT_RUNNER $run_timeout -- $TSGO --noEmit $extra_args $file 2>/dev/null" 2>&1)" || hyperfine_status=$?
+    if [ "$hyperfine_status" -ne 0 ]; then
+        printf '%s\n' "$hyperfine_output"
         local status="hyperfine error"
         RESULTS_CSV="${RESULTS_CSV}${name},${lines},${kb},ERR,ERR,N/A,N/A,error,0,${status}\n"
         rm -f "$json_file"
@@ -334,7 +338,11 @@ run_benchmark() {
         local tsgo_exit_status
         tsz_exit_status="$(hyperfine_exit_status_for "$json_file" "tsz" || true)"
         tsgo_exit_status="$(hyperfine_exit_status_for "$json_file" "tsgo" || true)"
-        if [ "$tsz_exit_status" != "ok" ] || [ "$tsgo_exit_status" != "ok" ]; then
+        local hyperfine_ok=true
+        [ "$tsz_exit_status" != "ok" ] && hyperfine_ok=false
+        [ "$tsgo_exit_status" != "ok" ] && hyperfine_ok=false
+        print_hyperfine_comparison_output "$hyperfine_output" "$hyperfine_ok"
+        if [ "$hyperfine_ok" != true ]; then
             local status=""
             [ "$tsz_exit_status" != "ok" ] && status="tsz ${tsz_exit_status}"
             [ "$tsgo_exit_status" != "ok" ] && status="${status:+${status}; }tsgo ${tsgo_exit_status}"
@@ -366,6 +374,8 @@ run_benchmark() {
 
             RESULTS_CSV="${RESULTS_CSV}${name},${lines},${kb},${tsz_ms},${tsgo_ms},${tsz_lps},${tsgo_lps},${winner},${ratio},\n"
         fi
+    else
+        printf '%s\n' "$hyperfine_output"
     fi
     rm -f "$json_file"
 }
@@ -664,8 +674,9 @@ run_project_benchmark() {
     fi
 
     local hyperfine_status=0
+    local hyperfine_output=""
     if [ "${#hyperfine_prepare_args[@]}" -gt 0 ]; then
-        hyperfine \
+        hyperfine_output="$(hyperfine \
             --warmup "$proj_warmup" \
             --min-runs "$proj_min" \
             --max-runs "$proj_max" \
@@ -674,9 +685,9 @@ run_project_benchmark() {
             --export-json "$json_file" \
             "${hyperfine_prepare_args[@]}" \
             -n "tsz" "bash $BENCH_TIMEOUT_RUNNER $run_timeout -- ${tsz_cmd_prefix}$TSZ --noEmit -p $tsconfig 2>/dev/null" \
-            -n "tsgo" "bash $BENCH_TIMEOUT_RUNNER $run_timeout -- ${tsgo_cmd_prefix}$TSGO --noEmit -p $tsconfig 2>/dev/null" || hyperfine_status=$?
+            -n "tsgo" "bash $BENCH_TIMEOUT_RUNNER $run_timeout -- ${tsgo_cmd_prefix}$TSGO --noEmit -p $tsconfig 2>/dev/null" 2>&1)" || hyperfine_status=$?
     else
-        hyperfine \
+        hyperfine_output="$(hyperfine \
             --warmup "$proj_warmup" \
             --min-runs "$proj_min" \
             --max-runs "$proj_max" \
@@ -684,9 +695,10 @@ run_project_benchmark() {
             --ignore-failure \
             --export-json "$json_file" \
             -n "tsz" "bash $BENCH_TIMEOUT_RUNNER $run_timeout -- ${tsz_cmd_prefix}$TSZ --noEmit -p $tsconfig 2>/dev/null" \
-            -n "tsgo" "bash $BENCH_TIMEOUT_RUNNER $run_timeout -- ${tsgo_cmd_prefix}$TSGO --noEmit -p $tsconfig 2>/dev/null" || hyperfine_status=$?
+            -n "tsgo" "bash $BENCH_TIMEOUT_RUNNER $run_timeout -- ${tsgo_cmd_prefix}$TSGO --noEmit -p $tsconfig 2>/dev/null" 2>&1)" || hyperfine_status=$?
     fi
     if [ "$hyperfine_status" -ne 0 ]; then
+        printf '%s\n' "$hyperfine_output"
         local status="hyperfine error"
         record_project_compatibility "$name" "runner error" "timing" "hyperfine failed" "hyperfine failed while timing project row" "$file_count" "$peak_memory_bytes" "$tsc_exit_codes" "" "" "$tsconfig" "$src_dir"
         RESULTS_CSV="${RESULTS_CSV}${name},${lines},${kb},ERR,ERR,N/A,N/A,error,0,${status}\n"
@@ -700,7 +712,11 @@ run_project_benchmark() {
         local tsgo_exit_status
         tsz_exit_status="$(hyperfine_exit_status_for "$json_file" "tsz" || true)"
         tsgo_exit_status="$(hyperfine_exit_status_for "$json_file" "tsgo" || true)"
-        if [ "$tsz_exit_status" != "ok" ] || [ "$tsgo_exit_status" != "ok" ]; then
+        local hyperfine_ok=true
+        [ "$tsz_exit_status" != "ok" ] && hyperfine_ok=false
+        [ "$tsgo_exit_status" != "ok" ] && hyperfine_ok=false
+        print_hyperfine_comparison_output "$hyperfine_output" "$hyperfine_ok"
+        if [ "$hyperfine_ok" != true ]; then
             local status=""
             [ "$tsz_exit_status" != "ok" ] && status="tsz ${tsz_exit_status}"
             [ "$tsgo_exit_status" != "ok" ] && status="${status:+${status}; }tsgo ${tsgo_exit_status}"
@@ -744,6 +760,8 @@ run_project_benchmark() {
             record_project_compatibility "$name" "$success_exit_class" "$success_phase" "$success_diagnostic_status" "$success_diagnostic_delta" "$file_count" "$peak_memory_bytes" "$tsc_exit_codes" "0" "0" "$tsconfig" "$src_dir"
             RESULTS_CSV="${RESULTS_CSV}${name},${lines},${kb},${tsz_ms},${tsgo_ms},${tsz_lps},${tsgo_lps},${winner},${ratio},\n"
         fi
+    else
+        printf '%s\n' "$hyperfine_output"
     fi
     rm -f "$json_file"
 }

--- a/scripts/bench/test-hyperfine-comparison-output.sh
+++ b/scripts/bench/test-hyperfine-comparison-output.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Unit test for print_hyperfine_comparison_output (scripts/bench/lib/bench-vs-tsgo-prereqs.sh).
+#
+# #16196 fixed the structured-data half of "a killed/errored benchmark row
+# still reports a fabricated Nx ratio" (row-utils.mjs's didNotFinish, wired
+# through the JS reporting layer in #16779). #16779's own PR body named one
+# residual it did not cover: hyperfine's own "Summary\n  X ran\n  N.NN times
+# faster than Y" comparison text streams straight to stdout/the CI log
+# whenever `--ignore-failure` lets a killed-by-timeout or non-zero-exit
+# command finish "successfully" next to a clean one — before this script
+# ever inspects an exit code, so the JSON-side gate can't intercept it. This
+# is not reachable from Node (the JS suite that covers #16196/#16779), hence
+# a standalone shell test.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/bench/lib/bench-vs-tsgo-prereqs.sh
+source "$SCRIPT_DIR/lib/bench-vs-tsgo-prereqs.sh"
+
+pass=0
+fail=0
+
+check() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    pass=$((pass + 1))
+    echo "  ok   $label"
+  else
+    fail=$((fail + 1))
+    echo "  FAIL $label:"
+    echo "    expected: $(printf '%q' "$expected")"
+    echo "    actual:   $(printf '%q' "$actual")"
+  fi
+}
+
+# A real capture of `hyperfine --style full --ignore-failure` comparing a
+# command killed by the repo's timeout runner (tsz) against a clean one
+# (tsgo) — reproduced against real hyperfine 1.18 output shape. Colored
+# (hyperfine emits ANSI codes under --style full even when not a tty).
+KILLED_TSZ_OUTPUT=$'\x1b[1mBenchmark \x1b[0m\x1b[1m1\x1b[0m: tsz\n  Time (\x1b[1;32mabs\x1b[0m \xe2\x89\xa1):        \x1b[1;32m 1.029 s\x1b[0m               [User: \x1b[34m0.011 s\x1b[0m, System: \x1b[34m0.012 s\x1b[0m]\n \n  \x1b[33mWarning\x1b[0m: Ignoring non-zero exit code.\n \n\x1b[1mBenchmark \x1b[0m\x1b[1m2\x1b[0m: tsgo\n  Time (\x1b[1;32mabs\x1b[0m \xe2\x89\xa1):        \x1b[1;32m 51.7 ms\x1b[0m               [User: \x1b[34m1.7 ms\x1b[0m, System: \x1b[34m0.0 ms\x1b[0m]\n \n\x1b[1mSummary\x1b[0m\n  \x1b[36mtsgo\x1b[0m ran\n\x1b[1;32m   19.89\x1b[0m times faster than \x1b[35mtsz\x1b[0m'
+
+CLEAN_OUTPUT=$'\x1b[1mBenchmark \x1b[0m\x1b[1m1\x1b[0m: tsz\n  Time (\x1b[1;32mabs\x1b[0m \xe2\x89\xa1):        \x1b[1;32m 45.0 ms\x1b[0m\n \n\x1b[1mBenchmark \x1b[0m\x1b[1m2\x1b[0m: tsgo\n  Time (\x1b[1;32mabs\x1b[0m \xe2\x89\xa1):        \x1b[1;32m 51.7 ms\x1b[0m\n \n\x1b[1mSummary\x1b[0m\n  \x1b[36mtsz\x1b[0m ran\n\x1b[1;32m   1.15\x1b[0m times faster than \x1b[35mtsgo\x1b[0m'
+
+# ok=true: hyperfine's output must pass through byte-identical, Summary and all.
+actual="$(print_hyperfine_comparison_output "$CLEAN_OUTPUT" true)"
+check "ok=true passes the Summary comparison through unchanged" "$CLEAN_OUTPUT" "$actual"
+
+# ok=false (the #16196/#16779-residual case): the fabricated Summary/ratio
+# line must never reach the output, but the truthful per-benchmark timing
+# lines above it must survive.
+actual="$(print_hyperfine_comparison_output "$KILLED_TSZ_OUTPUT" false)"
+if printf '%s' "$actual" | grep -q "times faster"; then
+  fail=$((fail + 1))
+  echo "  FAIL ok=false must never print a fabricated 'times faster' ratio"
+  echo "    actual: $actual"
+else
+  pass=$((pass + 1))
+  echo "  ok   ok=false suppresses the fabricated 'times faster' ratio"
+fi
+actual_plain="$(printf '%s' "$actual" | sed 's/\x1b\[[0-9;]*m//g')"
+case "$actual_plain" in
+  *"Benchmark 1: tsz"*) pass=$((pass + 1)); echo "  ok   ok=false keeps the truthful tsz timing line" ;;
+  *) fail=$((fail + 1)); echo "  FAIL ok=false dropped the truthful tsz timing line: $actual_plain" ;;
+esac
+case "$actual_plain" in
+  *"Benchmark 2: tsgo"*) pass=$((pass + 1)); echo "  ok   ok=false keeps the truthful tsgo timing line" ;;
+  *) fail=$((fail + 1)); echo "  FAIL ok=false dropped the truthful tsgo timing line: $actual_plain" ;;
+esac
+case "$actual" in
+  *"#16196"*) pass=$((pass + 1)); echo "  ok   ok=false explains the suppression" ;;
+  *) fail=$((fail + 1)); echo "  FAIL ok=false gave no explanation for the missing ratio: $actual" ;;
+esac
+
+# Defensive case: ok=false with no Summary block at all (should not happen on
+# the real 2-command comparison path, but must not crash or mangle output).
+NO_SUMMARY_OUTPUT=$'\x1b[1mBenchmark \x1b[0m\x1b[1m1\x1b[0m: tsz\n  Time (\x1b[1;32mabs\x1b[0m \xe2\x89\xa1):        \x1b[1;32m 45.0 ms\x1b[0m'
+actual="$(print_hyperfine_comparison_output "$NO_SUMMARY_OUTPUT" false)"
+check "ok=false with no Summary block passes output through unchanged" "$NO_SUMMARY_OUTPUT" "$actual"
+
+echo
+echo "print_hyperfine_comparison_output: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/scripts/ci/full-ci.sh
+++ b/scripts/ci/full-ci.sh
@@ -350,6 +350,7 @@ run_lint() {
   node scripts/bench/validate-project-metadata.mjs || return $?
   node scripts/bench/test-validate-project-metadata.mjs || return $?
   node scripts/bench/test-row-utils.mjs || return $?
+  bash scripts/bench/test-hyperfine-comparison-output.sh || return $?
   node scripts/bench/test-merge-results.mjs || return $?
   node scripts/bench/test-perf-hotspots.mjs || return $?
   node scripts/bench/test-tsgo-winner-report.mjs || return $?


### PR DESCRIPTION
When `--ignore-failure` lets a timeout-runner-killed or non-zero-exit
benchmark command finish "successfully" alongside a clean one, hyperfine
itself still prints its own `Summary\n  X ran\n  N.NN times faster than Y`
comparison — using the killed side's ceiling wall time as if it were a real
measurement — and that text streams straight to stdout/the CI log *before*
this script's own exit-status JSON check ever runs.

#16196 found this exact fabrication (a killed `large-ts-repo` row reporting
"42.99x faster", which was exactly `1500s ceiling / tsgo_time`) and #16779
fixed the structured-data half: `row-utils.mjs`'s `didNotFinish` now keeps a
DNF row from ever reaching `RESULTS_CSV`/the published JSON with a computed
ratio. But #16779's own PR body named an explicit residual it did not cover:

> The exact daily-report surface that printed the raw hyperfine "42.99 times
> faster" string is the shell/awk path in `scripts/bench/bench-vs-tsgo.sh`,
> which is not unit-testable from JS and is left as a separate residual.

Reproduced live with real hyperfine: a command killed by the repo's timeout
runner (1.03s ceiling) benchmarked against a clean one (0.05s) prints
"19.89 times faster" — `ceiling / other_time`, no measurement of the killed
side at all — regardless of what the script's own JSON-derived exit-status
check later decides.

**Structural rule:** when either benchmarked command's hyperfine exit code is
non-zero (timeout or error), hyperfine's own comparison summary contains no
real measurement of the losing side; the bench reporting layer must suppress
that summary rather than forward it verbatim. Owner layer: `scripts/bench`
(the shell reporting/tooling layer), not the structured-data path #16779
already fixed.

## What changed

- `scripts/bench/lib/bench-vs-tsgo-prereqs.sh` — new
  `print_hyperfine_comparison_output(output, ok)` helper, beside the existing
  `hyperfine_mean_for`/`hyperfine_exit_status_for` helpers. Captures
  hyperfine's own stdout+stderr instead of letting it stream directly to the
  terminal, then either passes it through byte-identical (`ok=true`) or
  strips the trailing `Summary`/ratio block while keeping the truthful
  per-benchmark timing lines above it (`ok=false`) — the strip point is
  found via a color-code-stripped line-number lookup so it still works
  against hyperfine's ANSI-colored `--style full` output.
- `scripts/bench/lib/bench-vs-tsgo-results.sh` — both hyperfine invocations
  in `run_benchmark` and `run_project_benchmark` now capture instead of
  stream, and call the new helper right where `tsz_exit_status`/
  `tsgo_exit_status` are already computed from the exported JSON (the exact
  same information the pre-existing gate already uses to decide `ERR` vs a
  real row — this reuses that decision rather than adding a second one). The
  single-command tsgo-only path (`tsz_failed_expected`) is untouched:
  hyperfine only prints a `Summary` comparison when timing 2+ commands, so
  there's no fabricated ratio possible there.
- `scripts/bench/test-hyperfine-comparison-output.sh` (new) — 6 assertions
  against real captured hyperfine 1.18 output: `ok=true` passthrough is
  byte-identical; `ok=false` never prints "times faster", keeps both
  per-benchmark timing lines, and explains the suppression; a defensive
  `ok=false` case with no `Summary` block at all passes through unchanged.
  Registered in `full-ci.sh`'s `run_lint` beside `test-row-utils.mjs`.

## Goal
Goal: fast

## Verification
- `bash scripts/bench/test-hyperfine-comparison-output.sh` — 6/6 pass.
- Manual reproduction with real hyperfine (installed locally via `apt-get`):
  before this fix, a timeout-runner-killed command vs. a clean one printed a
  fabricated `N times faster` line; after, it prints the two truthful timing
  lines plus an explicit suppression note citing #16196, no ratio.
- `shellcheck --shell=bash` on both touched lib files: clean — zero new
  findings (pre-existing `SC2155`/`SC2086` info/warnings are all on
  untouched lines).
- `bash -n` on all three touched/added shell files: clean.
- `python3 scripts/arch/arch_guard.py`: clean.
- No Rust changed (`crates/**` untouched), so conformance/emit/fourslash
  cannot move and were not run.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude


---
_Generated by [Claude Code](https://claude.ai/code/session_01FPvGMWvVodMaaE7eBNEu2G)_