### PR TITLE
fix(parser,checker): declare+async class-member ambient conflict reports TS1040, not TS1042

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
@@ -1146,9 +1146,15 @@ impl<'a> CheckerState<'a> {
                 // order (`readonly async get`, `async readonly get` both report
                 // only TS1024). `readonly` on a *property* is legal and does not
                 // fire TS1024, so the property arm below keeps its lone TS1042.
+                // A `declare` accessor is excluded either way: tsc reports
+                // exactly one diagnostic per member, and a `declare`+`async`
+                // accessor already gets it from the parser — TS1031 (`declare`
+                // illegal on this member kind) when `declare` came first, or
+                // TS1040 (ambient conflict) when `async` came first.
                 syntax_kind_ext::GET_ACCESSOR | syntax_kind_ext::SET_ACCESSOR => {
                     if let Some(accessor) = self.ctx.arena.get_accessor(node)
                         && !self.has_readonly_modifier(&accessor.modifiers)
+                        && !self.has_declare_modifier(&accessor.modifiers)
                         && let Some(async_mod_idx) = self.find_async_modifier(&accessor.modifiers)
                     {
                         self.error_at_node(
@@ -1163,9 +1169,13 @@ impl<'a> CheckerState<'a> {
                 // only on method/function-like nodes. `readonly` on a property
                 // is legal, so `readonly async p` is a lone TS1042 with no
                 // ordering collision; anchored at the `async` keyword to match
-                // tsc's column even when the property carries a decorator.
+                // tsc's column even when the property carries a decorator. A
+                // `declare` property is excluded: the parser already reports
+                // tsc's single TS1040 (ambient conflict) for `declare async p`
+                // in either source order.
                 syntax_kind_ext::PROPERTY_DECLARATION => {
                     if let Some(prop) = self.ctx.arena.get_property_decl(node)
+                        && !self.has_declare_modifier(&prop.modifiers)
                         && let Some(async_mod_idx) = self.find_async_modifier(&prop.modifiers)
                     {
                         self.error_at_node(

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -19,6 +19,8 @@
 
 #[path = "tests/alias_application_display_retention_tests.rs"]
 mod alias_application_display_retention_tests;
+#[path = "tests/ambient_declare_async_modifier_tests.rs"]
+mod ambient_declare_async_modifier_tests;
 #[path = "tests/any_parameter_never_opposite_tests.rs"]
 mod any_parameter_never_opposite_tests;
 #[path = "tests/application_arg_concrete_index_access_display_tests.rs"]

--- a/crates/tsz-checker/src/tests/ambient_declare_async_modifier_tests.rs
+++ b/crates/tsz-checker/src/tests/ambient_declare_async_modifier_tests.rs
@@ -1,0 +1,171 @@
+//! `declare`/`async` interaction on a class member (issue #16291 follow-up,
+//! 2026-08-07T23:05Z comment): `declare async p` on a property previously
+//! reported tsz's semantic TS1042 (`'async' modifier cannot be used here.`)
+//! instead of tsc's TS1040 (`'async' modifier cannot be used in an ambient
+//! context.`).
+//!
+//! tsc's `checkGrammarModifiers` walks a member's modifiers in SOURCE ORDER
+//! and reports exactly one diagnostic, so which code wins depends on order
+//! and member kind:
+//! - `async`/`override` before `declare`: the ambient conflict (TS1040) is
+//!   known as soon as `declare` is reached, regardless of member kind (even
+//!   a method or accessor reports TS1040, not TS1031).
+//! - `declare` before `async`/`override`: `declare` is checked against the
+//!   member kind immediately. On a method/accessor/constructor — which never
+//!   allow `declare` at all — that is TS1031 and the walk stops there,
+//!   *before* async/override is even reached. Only on a property (the one
+//!   member kind `declare` is legal on) does the walk continue to report
+//!   TS1040 at `async`.
+//!
+//! Every expectation is pinned against `typescript@7.0.2`
+//! (`--noEmit --strict --target es2022 --lib es2022`). Binder names are varied
+//! so the diagnostic is keyed on the modifier shape, not any identifier.
+
+// TS1031/TS1040 are parser-emitted; TS1042 is checker-emitted. Only
+// `check_source_codes_with_parse_health` sees both sides (see its doc comment
+// in `test_utils.rs`) — the plain `check_source_diagnostics`/`check_source_codes`
+// helpers never wire parser diagnostics into the result at all, which is
+// exactly the family this suite needs to distinguish.
+use crate::test_utils::check_source_codes_with_parse_health;
+
+const TS1031: u32 = 1031; // 'declare' modifier cannot appear on class elements of this kind.
+const TS1040: u32 = 1040; // 'async' modifier cannot be used in an ambient context.
+const TS1042: u32 = 1042; // 'async' modifier cannot be used here.
+
+/// Grammar codes this suite is about, filtered so assertions stay immune to
+/// unrelated harness noise (e.g. a no-lib `Promise` return type also draws
+/// TS1064/TS2583 that the real CLI, with the lib present, never emits).
+const GRAMMAR_CODES: [u32; 3] = [TS1031, TS1040, TS1042];
+
+fn codes(source: &str) -> Vec<u32> {
+    let mut v: Vec<u32> = check_source_codes_with_parse_health(source)
+        .into_iter()
+        .filter(|c| GRAMMAR_CODES.contains(c))
+        .collect();
+    v.sort_unstable();
+    v
+}
+
+// --- `declare` before `async`, on a property: TS1040, not TS1042 -----------
+
+#[test]
+fn declare_async_property_reports_ts1040_not_ts1042() {
+    for name in ["p", "value", "data", "field"] {
+        let source = format!("class C {{ declare async {name}: number; }}");
+        assert_eq!(codes(&source), vec![TS1040], "source: {source}");
+    }
+}
+
+#[test]
+fn declare_async_property_reports_ts1040_independent_of_class_name() {
+    for name in ["C", "Widget", "Repository", "Zzz"] {
+        let source = format!("class {name} {{ declare async p: number; }}");
+        assert_eq!(codes(&source), vec![TS1040], "source: {source}");
+    }
+}
+
+// --- `async` before `declare`, any member kind: TS1040 -----------------------
+
+#[test]
+fn async_declare_property_reports_ts1040() {
+    assert_eq!(codes("class C { async declare p: number; }"), vec![TS1040]);
+}
+
+#[test]
+fn async_declare_method_reports_ts1040_not_ts1031() {
+    // `async` came first, so the ambient conflict wins before the
+    // declare-illegal-on-method check (TS1031) is even reached.
+    assert_eq!(codes("class C { async declare m(): void; }"), vec![TS1040]);
+}
+
+#[test]
+fn async_declare_accessor_reports_ts1040_not_ts1031() {
+    assert_eq!(
+        codes("class C { async declare get x(): number; }"),
+        vec![TS1040]
+    );
+}
+
+// --- `declare` before `async`, on a method/accessor: TS1031, not TS1040 ------
+// `declare` is illegal on these member kinds outright; the walk stops at
+// `declare` and never reaches `async`.
+
+#[test]
+fn declare_async_method_reports_ts1031_not_ts1040() {
+    assert_eq!(codes("class C { declare async m(): void; }"), vec![TS1031]);
+}
+
+#[test]
+fn declare_async_accessor_reports_ts1031_not_ts1040() {
+    assert_eq!(
+        codes("class C { declare async get x(): number; }"),
+        vec![TS1031]
+    );
+    assert_eq!(
+        codes("class C { declare async set x(v: number); }"),
+        vec![TS1031]
+    );
+}
+
+// --- an enclosing ambient context (no member-local `declare`) is unaffected --
+
+#[test]
+fn async_property_in_declare_class_reports_ts1040() {
+    assert_eq!(codes("declare class C { async p: number; }"), vec![TS1040]);
+}
+
+#[test]
+fn async_method_in_declare_namespace_class_reports_ts1040() {
+    assert_eq!(
+        codes("declare namespace N { class C { async m(): void; } }"),
+        vec![TS1040]
+    );
+}
+
+// --- member-local `declare` nested inside an enclosing ambient context still
+// --- reports exactly one TS1040, not a duplicate --------------------------
+
+#[test]
+fn declare_async_property_in_declare_namespace_reports_single_ts1040() {
+    assert_eq!(
+        codes("declare namespace N { class C { declare async p: number; } }"),
+        vec![TS1040]
+    );
+}
+
+// --- combined with other modifiers: order between `declare`/`async` still
+// --- decides the code, regardless of what else is present ------------------
+
+#[test]
+fn static_declare_async_property_reports_ts1040() {
+    assert_eq!(
+        codes("class C { static declare async p: number; }"),
+        vec![TS1040]
+    );
+}
+
+#[test]
+fn readonly_declare_async_property_reports_ts1040() {
+    assert_eq!(
+        codes("class C { readonly declare async p: number; }"),
+        vec![TS1040]
+    );
+}
+
+// --- adjacent controls: unaffected by this change ---------------------------
+
+#[test]
+fn plain_declare_property_stays_clean() {
+    assert!(codes("class C { declare p: number; }").is_empty());
+}
+
+#[test]
+fn plain_declare_method_reports_ts1031() {
+    assert_eq!(codes("class C { declare m(): void; }"), vec![TS1031]);
+}
+
+#[test]
+fn plain_async_property_without_declare_still_reports_ts1042() {
+    // No `declare` at all: the ordinary async-on-property check is untouched.
+    assert_eq!(codes("class C { async p: number = 1; }"), vec![TS1042]);
+}

--- a/crates/tsz-parser/src/parser/state_statements_class_members.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class_members.rs
@@ -33,6 +33,13 @@ pub(crate) struct ClassMemberModifierSet {
     pub(crate) has_declare: bool,
     pub(crate) has_accessor: bool,
     pub(crate) has_async: bool,
+    /// `declare` appears before `async` in source order (e.g. `declare async
+    /// p`). Distinct from the reverse order (`async declare p`), which is
+    /// already diagnosed eagerly while scanning modifiers regardless of member
+    /// kind — this flag exists because the `declare`-first ambient conflict is
+    /// legal to report only on a property, and the member kind isn't known
+    /// until after modifier scanning finishes. See `construct_class_member`.
+    pub(crate) declare_before_async: bool,
     /// Diagnostic-list length captured just before modifier parsing, used to
     /// selectively roll back modifier-ordering diagnostics when a static block
     /// is discovered after modifiers were already parsed.
@@ -325,7 +332,15 @@ impl ParserState {
                         .create_modifier(SyntaxKind::OverrideKeyword, start_pos)
                 }
                 SyntaxKind::AsyncKeyword => {
-                    // TS1040: 'async' modifier cannot be used in an ambient context
+                    // TS1040: 'async' modifier cannot be used in an ambient context.
+                    // Only the enclosing-ambient-context case (`declare
+                    // class`/`declare namespace`) is decidable here. A
+                    // member-local `declare` seen earlier in this same list
+                    // (`declare async p`) is legal only on a property — whose
+                    // kind isn't known until the member name/parameter list is
+                    // parsed — so that combination is handled later in
+                    // `scan_class_member_modifier_phase` /
+                    // `construct_class_member`, once the member kind is final.
                     if self.in_ambient_context() {
                         use tsz_common::diagnostics::diagnostic_codes;
                         self.parse_error_at_current_token(
@@ -344,6 +359,18 @@ impl ParserState {
                         use tsz_common::diagnostics::diagnostic_codes;
                         self.parse_error_at_current_token(
                             "'override' modifier cannot be used in an ambient context.",
+                            diagnostic_codes::MODIFIER_CANNOT_BE_USED_IN_AN_AMBIENT_CONTEXT,
+                        );
+                    }
+                    // TS1040: 'async' modifier cannot be used in an ambient context.
+                    // When `async` precedes `declare` (`async declare p`), the
+                    // ambient conflict is only known once `declare` is reached, so
+                    // — mirroring the `override` case above — report here rather
+                    // than at `async`'s own position.
+                    if seen_async {
+                        use tsz_common::diagnostics::diagnostic_codes;
+                        self.parse_error_at_current_token(
+                            "'async' modifier cannot be used in an ambient context.",
                             diagnostic_codes::MODIFIER_CANNOT_BE_USED_IN_AN_AMBIENT_CONTEXT,
                         );
                     }
@@ -1061,8 +1088,12 @@ impl ParserState {
         let mut has_declare = false;
         let mut has_accessor = false;
         let mut has_async = false;
+        // Source-order index of the first `declare`/`async` modifier, used
+        // below to detect `declare` appearing before `async`.
+        let mut declare_index: Option<usize> = None;
+        let mut async_index: Option<usize> = None;
         if let Some(ref mods) = combined {
-            for &idx in &mods.nodes {
+            for (i, &idx) in mods.nodes.iter().enumerate() {
                 if let Some(node) = self.arena.get(idx)
                     && let Some(kind) = SyntaxKind::try_from_u16(node.kind)
                 {
@@ -1070,14 +1101,22 @@ impl ParserState {
                         SyntaxKind::VarKeyword | SyntaxKind::LetKeyword => has_var_let = true,
                         SyntaxKind::StaticKeyword => has_static = true,
                         SyntaxKind::ExportKeyword => has_export = true,
-                        SyntaxKind::DeclareKeyword => has_declare = true,
+                        SyntaxKind::DeclareKeyword => {
+                            has_declare = true;
+                            declare_index.get_or_insert(i);
+                        }
                         SyntaxKind::AccessorKeyword => has_accessor = true,
-                        SyntaxKind::AsyncKeyword => has_async = true,
+                        SyntaxKind::AsyncKeyword => {
+                            has_async = true;
+                            async_index.get_or_insert(i);
+                        }
                         _ => {}
                     }
                 }
             }
         }
+        let declare_before_async =
+            matches!((declare_index, async_index), (Some(d), Some(a)) if d < a);
 
         ClassMemberModifierSet {
             modifiers: combined,
@@ -1088,6 +1127,7 @@ impl ParserState {
             has_declare,
             has_accessor,
             has_async,
+            declare_before_async,
             diag_len_before_modifiers,
         }
     }
@@ -2121,6 +2161,21 @@ impl ParserState {
             // Return NONE to indicate this is not a valid member
             NodeIndex::NONE
         } else {
+            // TS1040: 'async' modifier cannot be used in an ambient context.
+            // `declare async p` — the member kind is only known now (a plain
+            // property), which is the one member-local-`declare` host tsc
+            // allows, so this is where the ambient conflict is decidable. The
+            // reverse order (`async declare p`) is already reported eagerly
+            // while scanning modifiers, regardless of member kind, since tsc
+            // resolves that conflict before member kind is even relevant.
+            if mods.declare_before_async {
+                self.emit_modifier_error_on_constructor(
+                    &mods.modifiers,
+                    SyntaxKind::AsyncKeyword,
+                    "'async' modifier cannot be used in an ambient context.",
+                    diagnostic_codes::MODIFIER_CANNOT_BE_USED_IN_AN_AMBIENT_CONTEXT,
+                );
+            }
             self.construct_class_member_property(
                 start_pos,
                 mods,


### PR DESCRIPTION
`declare async p` on a class property reported tsz's semantic TS1042 (`'async' modifier cannot be used here.`) instead of tsc's TS1040 (`'async' modifier cannot be used in an ambient context.`). This is a follow-up named in #16291's 2026-08-07T23:05:04Z comment: "Ambient class member `declare async p` / `declare class { async get x() {} }` → tsc reports TS1040; tsz reports TS1042."

## Structural rule

tsc's `checkGrammarModifiers` walks a member's modifiers in SOURCE ORDER and reports exactly one diagnostic per member, so which code wins depends on order and member kind:
- `async`/`override` before `declare`: the ambient conflict (TS1040) is known as soon as `declare` is reached, regardless of member kind — even a method or accessor reports TS1040, not TS1031.
- `declare` before `async`/`override`: `declare` is checked against the member kind immediately. On a method/accessor/constructor (which never allow `declare`) that is TS1031 and the walk stops there, before `async` is even reached. Only on a property — the one member-local-`declare` host tsc allows — does the walk continue to report TS1040 at `async`.

tsz's parser splits modifier scanning from member-kind determination (a member's kind isn't known until the name/parameter list is parsed), so the `declare`-before-`async` case needed deferral: `ClassMemberModifierSet` gains a `declare_before_async` flag computed in `scan_class_member_modifier_phase` (`crates/tsz-parser/src/parser/state_statements_class_members.rs`), and `construct_class_member`'s property branch reports TS1040 there once the member is confirmed to be a property — mirroring how TS1031 is already reported per-kind in the method/accessor/constructor branches. The reverse order (`async` before `declare`) needed no such deferral; it already fires unconditionally in the `DeclareKeyword` arm, matching tsc for every member kind (verified, not touched).

The checker's TS1042 (`crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs`) now skips both the accessor and property arms when the member also carries `declare`, since the parser's TS1031/TS1040 always covers that combination alone — without this, `declare async p` produced both TS1040 (correct, new) and TS1042 (wrong, stale) together.

Owner: parser for TS1040 placement; checker for the TS1042 suppression.

**Out of scope, pre-existing and unrelated:** the equivalent `override`+`declare`-illegal-member-kind interaction (e.g. `declare override m()`) has an analogous TS1031-vs-TS1040 priority bug (tsz over-reports both), and `override declare m()` also over-reports an unrelated TS4112. Neither is touched here — narrowing to the `async` family named in the board comment. Filed as a note for whoever picks up the `override` sibling next.

## Goal
Goal: hold

## Verification
- 18-case oracle matrix against `typescript@7.0.2` (`--noEmit --strict --target es2022 --lib es2022`), all byte-identical: properties/methods/accessors/constructors × both modifier orders, enclosing `declare class`/`declare namespace`, member-local `declare`, combined with `static`/`readonly`, renamed binders (`C`/`Widget`/`Repository`/`Zzz`), and negative controls (plain `declare` property/method, plain `async` property without `declare`).
- New test file `crates/tsz-checker/src/tests/ambient_declare_async_modifier_tests.rs`: 15 tests, all passing.
- `cargo test -p tsz-parser --lib`: 2111/2111 passed, 0 failed (full suite, no regressions).
- `cargo test -p tsz-checker --lib -- member_modifier_placement_grammar async_export_modifier_order_ts1042_dedup modifier_ordering ambient_declare_async_modifier_tests`: 38/38 passed (23 existing sibling-family tests + 15 new), 0 regressions.
- `cargo clippy -p tsz-parser -p tsz-checker --all-targets -- -D warnings`: clean.
- `cargo fmt -p tsz-parser -p tsz-checker -- --check`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.
- A full `cargo test -p tsz-checker --lib` was started for extra coverage but did not finish before this session's container restarted — it was parked on one of the board's known-slow long-tail tests (`ts2589_tests::recursive_conditional_alias_omitted_default_transform_emits_definition_ts2589`), unrelated to this change. The targeted suites above are the evidence of record.
- No TypeScript submodule checked out this session; conformance set-difference not run standalone. This is a narrow parser+checker diagnostic-code fix for a rare class-member modifier-ordering shape (`declare`+`async`), the same reasoning several sibling PRs in the #16291 family used today (#16803, #16827, #16829).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1kfDroYwEZX5MR54azxmC)_