### PR TITLE
fix(checker): TS1293 for module=preserve + isolatedModules ESM syntax in a CJS file

### DIFF
--- a/crates/tsz-checker/src/declarations/import/verbatim.rs
+++ b/crates/tsz-checker/src/declarations/import/verbatim.rs
@@ -118,7 +118,9 @@ impl<'a> CheckerState<'a> {
     ) {
         use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
 
-        if !self.ctx.compiler_options.verbatim_module_syntax {
+        let vms = self.ctx.compiler_options.verbatim_module_syntax;
+        let preserve_isolated = self.preserve_isolated_modules_cjs_check_active();
+        if !vms && !preserve_isolated {
             return;
         }
 
@@ -132,9 +134,17 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        // TS1286/TS1295: In CJS+VMS mode, ESM import syntax is forbidden entirely.
-        // Emit TS1286 (extension-locked) or TS1295 (adjustable) on the import
-        // clause and skip ESM-specific checks. TSC skips this check for .d.ts files.
+        // TS1286/TS1295/TS1293: In a CJS file, ESM import syntax carrying a
+        // binding (default/namespace/named import clause) is forbidden
+        // entirely. `verbatimModuleSyntax` picks TS1286 (extension-locked) or
+        // TS1295 (adjustable via `package.json`); `module: "preserve"` +
+        // `isolatedModules` (without VMS) always reports TS1293 — under
+        // `preserve`, per-file CJS-ness only ever comes from the `.cts`/
+        // `.cjs` extension (never `package.json`, since `preserve` cannot
+        // pair with the `node16`/`nodenext` `moduleResolution` that package.json-based
+        // detection requires), so there is no adjustable variant to pick.
+        // Emit on the import clause and skip ESM-specific checks below. TSC
+        // skips this check for .d.ts files.
         if self.is_current_file_commonjs_for_vms() && !self.ctx.is_declaration_file() {
             // TSC positions the error at the binding NAME:
             // - Default import `import X from ...` → at X
@@ -173,7 +183,12 @@ impl<'a> CheckerState<'a> {
             } else {
                 import.import_clause
             };
-            let (message, code) = if self.current_file_commonjs_is_extension_locked() {
+            let (message, code) = if preserve_isolated {
+                (
+                    diagnostic_messages::ECMASCRIPT_MODULE_SYNTAX_IS_NOT_ALLOWED_IN_A_COMMONJS_MODULE_WHEN_MODULE_IS_SET,
+                    diagnostic_codes::ECMASCRIPT_MODULE_SYNTAX_IS_NOT_ALLOWED_IN_A_COMMONJS_MODULE_WHEN_MODULE_IS_SET,
+                )
+            } else if self.current_file_commonjs_is_extension_locked() {
                 (
                     diagnostic_messages::ECMASCRIPT_IMPORTS_AND_EXPORTS_CANNOT_BE_WRITTEN_IN_A_COMMONJS_FILE_UNDER_VERBAT,
                     diagnostic_codes::ECMASCRIPT_IMPORTS_AND_EXPORTS_CANNOT_BE_WRITTEN_IN_A_COMMONJS_FILE_UNDER_VERBAT,
@@ -185,6 +200,14 @@ impl<'a> CheckerState<'a> {
                 )
             };
             self.error_at_node(error_node, message, code);
+            return;
+        }
+
+        // `module: "preserve"` + `isolatedModules` (without VMS) has no
+        // ESM-file-mode checks of its own — TS1484/TS1485/TS2748 below are
+        // verbatimModuleSyntax-exclusive (isolatedModules alone only requires
+        // marking *re-exports* type-only, via TS1448, checked elsewhere).
+        if preserve_isolated {
             return;
         }
 
@@ -618,6 +641,16 @@ impl<'a> CheckerState<'a> {
                 diagnostic_codes::AN_EXPORT_DECLARATION_MUST_REFERENCE_A_VALUE_WHEN_VERBATIMMODULESYNTAX_IS_ENABLE,
             );
         }
+    }
+
+    /// TS1293's gate: `module: "preserve"` with `isolatedModules` enabled and
+    /// `verbatimModuleSyntax` OFF. When VMS is also on, TS1286/TS1295/TS1287
+    /// take priority (oracle-confirmed: `typescript@7.0.2` reports TS1286 for
+    /// a CJS+VMS+preserve file, never TS1293).
+    pub(crate) fn preserve_isolated_modules_cjs_check_active(&self) -> bool {
+        !self.ctx.compiler_options.verbatim_module_syntax
+            && self.ctx.compiler_options.isolated_modules
+            && self.ctx.compiler_options.module == tsz_common::common::ModuleKind::Preserve
     }
 
     /// Determine if the current file is treated as CommonJS for VMS checks.

--- a/crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs
+++ b/crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs
@@ -41,6 +41,50 @@ impl<'a> CheckerState<'a> {
             return;
         };
 
+        // TS1286/TS1295/TS1293: `export { ... }` (with or without `from`)
+        // carries a runtime export/re-export clause, forbidden in a CommonJS
+        // file the same way an import clause is — see the sibling check in
+        // `check_verbatim_module_syntax_imports`. Anchor at the first
+        // specifier's SOURCE name (before `as`, matching tsc); this takes
+        // priority over the per-specifier type-only checks below exactly like
+        // the import side does.
+        let vms = self.ctx.compiler_options.verbatim_module_syntax;
+        let preserve_isolated = self.preserve_isolated_modules_cjs_check_active();
+        if (vms || preserve_isolated) && self.is_current_file_commonjs_for_vms() {
+            let anchor = named_exports
+                .elements
+                .nodes
+                .first()
+                .and_then(|&first_idx| self.ctx.arena.get(first_idx))
+                .and_then(|n| self.ctx.arena.get_specifier(n))
+                .map(|spec| {
+                    if spec.property_name.is_some() {
+                        spec.property_name
+                    } else {
+                        spec.name
+                    }
+                })
+                .unwrap_or(named_exports_idx);
+            let (message, code) = if preserve_isolated {
+                (
+                    diagnostic_messages::ECMASCRIPT_MODULE_SYNTAX_IS_NOT_ALLOWED_IN_A_COMMONJS_MODULE_WHEN_MODULE_IS_SET,
+                    diagnostic_codes::ECMASCRIPT_MODULE_SYNTAX_IS_NOT_ALLOWED_IN_A_COMMONJS_MODULE_WHEN_MODULE_IS_SET,
+                )
+            } else if self.current_file_commonjs_is_extension_locked() {
+                (
+                    diagnostic_messages::ECMASCRIPT_IMPORTS_AND_EXPORTS_CANNOT_BE_WRITTEN_IN_A_COMMONJS_FILE_UNDER_VERBAT,
+                    diagnostic_codes::ECMASCRIPT_IMPORTS_AND_EXPORTS_CANNOT_BE_WRITTEN_IN_A_COMMONJS_FILE_UNDER_VERBAT,
+                )
+            } else {
+                (
+                    diagnostic_messages::ECMASCRIPT_IMPORTS_AND_EXPORTS_CANNOT_BE_WRITTEN_IN_A_COMMONJS_FILE_UNDER_VERBAT_2,
+                    diagnostic_codes::ECMASCRIPT_IMPORTS_AND_EXPORTS_CANNOT_BE_WRITTEN_IN_A_COMMONJS_FILE_UNDER_VERBAT_2,
+                )
+            };
+            self.error_at_node(anchor, message, code);
+            return;
+        }
+
         let module_specifier_text = if module_specifier_idx.is_some() {
             self.ctx
                 .arena

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -887,6 +887,8 @@ mod ts1168_method_overload_computed_name_tests;
 mod ts1170_computed_property_syntactic_form_tests;
 #[path = "tests/ts1250_ts1251_ts1252_strict_function_in_block_tests.rs"]
 mod ts1250_ts1251_ts1252_strict_function_in_block_tests;
+#[path = "tests/ts1293_preserve_isolated_modules_esm_syntax_in_cjs_tests.rs"]
+mod ts1293_preserve_isolated_modules_esm_syntax_in_cjs_tests;
 #[path = "tests/ts1309_top_level_await_commonjs_file_tests.rs"]
 mod ts1309_top_level_await_commonjs_file_tests;
 #[path = "tests/ts1318_abstract_accessor_implementation_tests.rs"]

--- a/crates/tsz-checker/src/tests/ts1293_preserve_isolated_modules_esm_syntax_in_cjs_tests.rs
+++ b/crates/tsz-checker/src/tests/ts1293_preserve_isolated_modules_esm_syntax_in_cjs_tests.rs
@@ -1,0 +1,266 @@
+//! TS1293: `module: "preserve"` + `isolatedModules` (without
+//! `verbatimModuleSyntax`) forbids ESM import/export syntax that carries a
+//! binding in a CommonJS file.
+//!
+//! Structural rule: under `preserve`, a file's CJS-ness is *always*
+//! extension-locked (`.cts`/`.cjs`) — `preserve` cannot pair with the
+//! `node16`/`nodenext` `moduleResolution` that `package.json`
+//! `"type"`-based detection requires, so there is no adjustable variant of
+//! this diagnostic the way `verbatimModuleSyntax` has TS1286 vs TS1295.
+//! `tsc` fires it only for clauses that need a runtime require()/exports
+//! rewrite — default/namespace/named imports, `export { ... }` (local or
+//! `from`), and `export * as ns from` — and exempts type-only forms
+//! (`import type`, `export type { ... }`), bare side-effect forms (`import
+//! "./m"`, `export * from "./m"`), and `export` on a value declaration
+//! (`export const x = 1`, which stays legal even in this mode). When
+//! `verbatimModuleSyntax` is also on, it takes over entirely (TS1286/TS1295)
+//! and TS1293 never fires. Oracle-verified against `typescript@7.0.2`.
+//!
+//! Owner: parser-adjacent checker gate in
+//! `crates/tsz-checker/src/declarations/import/verbatim.rs` (imports) and
+//! `crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs`
+//! (named/re-exports) — the same CJS-forbidden-ESM-syntax mechanism
+//! `verbatimModuleSyntax` already uses for TS1286/TS1295, gated on
+//! `preserve_isolated_modules_cjs_check_active` instead.
+
+use crate::context::CheckerOptions;
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::check_multi_file;
+use tsz_common::common::ModuleKind;
+
+const TS1293: u32 = 1293;
+
+fn check(files: &[(&str, &str)], entry: &str) -> Vec<Diagnostic> {
+    check_multi_file(
+        files,
+        entry,
+        CheckerOptions {
+            module: ModuleKind::Preserve,
+            isolated_modules: true,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+fn check_vms(files: &[(&str, &str)], entry: &str) -> Vec<Diagnostic> {
+    check_multi_file(
+        files,
+        entry,
+        CheckerOptions {
+            module: ModuleKind::Preserve,
+            isolated_modules: true,
+            verbatim_module_syntax: true,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+fn codes(diagnostics: &[Diagnostic]) -> Vec<u32> {
+    let mut codes: Vec<u32> = diagnostics.iter().map(|d| d.code).collect();
+    codes.sort_unstable();
+    codes
+}
+
+// ---------------------------------------------------------------------
+// Imports
+// ---------------------------------------------------------------------
+
+#[test]
+fn named_import_in_cts_reports_ts1293() {
+    let diagnostics = check(
+        &[
+            ("/b.ts", "export const y = 2;\n"),
+            ("/main.cts", "import { y } from \"./b\";\ny;\n"),
+        ],
+        "/main.cts",
+    );
+    assert_eq!(codes(&diagnostics), vec![TS1293], "{diagnostics:?}");
+}
+
+#[test]
+fn default_import_in_cts_reports_ts1293() {
+    let diagnostics = check(
+        &[
+            ("/b.ts", "export default 3;\n"),
+            ("/main.cts", "import def from \"./b\";\ndef;\n"),
+        ],
+        "/main.cts",
+    );
+    assert_eq!(codes(&diagnostics), vec![TS1293], "{diagnostics:?}");
+}
+
+#[test]
+fn namespace_import_in_cts_reports_ts1293() {
+    let diagnostics = check(
+        &[
+            ("/b.ts", "export const y = 2;\n"),
+            ("/main.cts", "import * as ns from \"./b\";\nns;\n"),
+        ],
+        "/main.cts",
+    );
+    assert_eq!(codes(&diagnostics), vec![TS1293], "{diagnostics:?}");
+}
+
+/// Renamed binder: the diagnostic must not key off a fixed identifier name.
+#[test]
+fn renamed_named_import_in_cts_reports_ts1293() {
+    let diagnostics = check(
+        &[
+            ("/b.ts", "export const somethingElse = 2;\n"),
+            (
+                "/main.cts",
+                "import { somethingElse as renamed } from \"./b\";\nrenamed;\n",
+            ),
+        ],
+        "/main.cts",
+    );
+    assert_eq!(codes(&diagnostics), vec![TS1293], "{diagnostics:?}");
+}
+
+/// `import type` is exempt — it is erased entirely, no runtime rewrite needed.
+#[test]
+fn type_only_import_in_cts_is_clean() {
+    let diagnostics = check(
+        &[
+            ("/b.ts", "export interface Y {}\n"),
+            ("/main.cts", "import type { Y } from \"./b\";\n"),
+        ],
+        "/main.cts",
+    );
+    assert_eq!(codes(&diagnostics), Vec::<u32>::new(), "{diagnostics:?}");
+}
+
+/// Bare side-effect import has no binding to rewrite — exempt.
+#[test]
+fn side_effect_import_in_cts_is_clean() {
+    let diagnostics = check(
+        &[
+            ("/b.ts", "export const y = 2;\n"),
+            ("/main.cts", "import \"./b\";\n"),
+        ],
+        "/main.cts",
+    );
+    assert_eq!(codes(&diagnostics), Vec::<u32>::new(), "{diagnostics:?}");
+}
+
+/// `.mts` is ESM-locked, never CJS — TS1293 cannot apply.
+#[test]
+fn named_import_in_mts_is_clean() {
+    let diagnostics = check(
+        &[
+            ("/b.ts", "export const y = 2;\n"),
+            ("/main.mts", "import { y } from \"./b\";\ny;\n"),
+        ],
+        "/main.mts",
+    );
+    assert_eq!(codes(&diagnostics), Vec::<u32>::new(), "{diagnostics:?}");
+}
+
+/// Without `isolatedModules`, `module: preserve` alone does not gate TS1293.
+#[test]
+fn named_import_in_cts_without_isolated_modules_is_clean() {
+    let diagnostics = check_multi_file(
+        &[
+            ("/b.ts", "export const y = 2;\n"),
+            ("/main.cts", "import { y } from \"./b\";\ny;\n"),
+        ],
+        "/main.cts",
+        CheckerOptions {
+            module: ModuleKind::Preserve,
+            isolated_modules: false,
+            ..CheckerOptions::default()
+        },
+    );
+    assert_eq!(codes(&diagnostics), Vec::<u32>::new(), "{diagnostics:?}");
+}
+
+/// `verbatimModuleSyntax` takes over entirely; TS1293 never fires alongside it.
+#[test]
+fn named_import_in_cts_under_vms_reports_ts1286_not_ts1293() {
+    const TS1286: u32 = 1286;
+    let diagnostics = check_vms(
+        &[
+            ("/b.ts", "export const y = 2;\n"),
+            ("/main.cts", "import { y } from \"./b\";\ny;\n"),
+        ],
+        "/main.cts",
+    );
+    assert_eq!(codes(&diagnostics), vec![TS1286], "{diagnostics:?}");
+}
+
+// ---------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------
+
+#[test]
+fn named_reexport_in_cts_reports_ts1293() {
+    let diagnostics = check(
+        &[
+            ("/b.ts", "export const y = 2;\n"),
+            ("/main.cts", "export { y } from \"./b\";\n"),
+        ],
+        "/main.cts",
+    );
+    assert_eq!(codes(&diagnostics), vec![TS1293], "{diagnostics:?}");
+}
+
+/// Local named export (no `from`) is the same clause shape.
+#[test]
+fn local_named_export_in_cts_reports_ts1293() {
+    let diagnostics = check(
+        &[("/main.cts", "const z = 1;\nexport { z as w };\n")],
+        "/main.cts",
+    );
+    assert_eq!(codes(&diagnostics), vec![TS1293], "{diagnostics:?}");
+}
+
+/// Renamed export alias — must not key off a fixed identifier name.
+#[test]
+fn renamed_named_reexport_in_cts_reports_ts1293() {
+    let diagnostics = check(
+        &[
+            ("/b.ts", "export const somethingElse = 2;\n"),
+            (
+                "/main.cts",
+                "export { somethingElse as renamedOut } from \"./b\";\n",
+            ),
+        ],
+        "/main.cts",
+    );
+    assert_eq!(codes(&diagnostics), vec![TS1293], "{diagnostics:?}");
+}
+
+/// `export type { ... } from` is erased entirely — exempt.
+#[test]
+fn type_only_named_reexport_in_cts_is_clean() {
+    let diagnostics = check(
+        &[
+            ("/b.ts", "export interface Y {}\n"),
+            ("/main.cts", "export type { Y } from \"./b\";\n"),
+        ],
+        "/main.cts",
+    );
+    assert_eq!(codes(&diagnostics), Vec::<u32>::new(), "{diagnostics:?}");
+}
+
+/// A value declaration carrying the `export` modifier keeps working —
+/// `preserve`'s CJS emit can still translate this without ESM clause syntax.
+#[test]
+fn exported_value_declaration_in_cts_is_clean() {
+    let diagnostics = check(&[("/main.cts", "export const z = 5;\n")], "/main.cts");
+    assert_eq!(codes(&diagnostics), Vec::<u32>::new(), "{diagnostics:?}");
+}
+
+/// Bare `export * from "./m"` has no clause (no local binding at all) —
+/// exempt, unlike `export * as ns from`.
+#[test]
+fn bare_star_reexport_in_cts_is_clean() {
+    let diagnostics = check(
+        &[
+            ("/b.ts", "export const y = 2;\n"),
+            ("/main.cts", "export * from \"./b\";\n"),
+        ],
+        "/main.cts",
+    );
+    assert_eq!(codes(&diagnostics), Vec::<u32>::new(), "{diagnostics:?}");
+}


### PR DESCRIPTION
When `module: "preserve"` and `isolatedModules` are enabled without `verbatimModuleSyntax`, `tsc` forbids ESM import/export syntax that carries a runtime binding — default/namespace/named imports, `export { ... }` (local or `from`) — inside a CommonJS file, via TS1293 (`ECMAScript module syntax is not allowed in a CommonJS module when 'module' is set to 'preserve'.`). tsz reported nothing for any of these shapes.

**Structural rule:** under `module: "preserve"`, a file's CJS-ness is *always* extension-locked (`.cts`/`.cjs`) — `preserve` cannot pair with the `node16`/`nodenext` `moduleResolution` that `package.json` `"type"`-based detection requires (confirmed: `moduleResolution: "nodenext"` + `module: "preserve"` is itself a hard config error, TS5110) — so unlike `verbatimModuleSyntax`'s TS1286 (extension-locked) vs TS1295 (adjustable) pair, there is no adjustable variant to pick. `tsc` does this through the same "ESM import/export clause forbidden in a CJS file" check `verbatimModuleSyntax` already uses for TS1286/TS1295; tsz now does it through the same owner, extended to also fire under this narrower gate.

Owner layer: checker, `crates/tsz-checker/src/declarations/import/verbatim.rs` (import clauses) and `crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs` (named/re-export clauses) — both already own the equivalent `verbatimModuleSyntax` check; this reuses the exact same CJS-detection helpers (`is_current_file_commonjs_for_vms`) and adds one new gate, `preserve_isolated_modules_cjs_check_active()`.

## What changed

- New `preserve_isolated_modules_cjs_check_active()` helper (`verbatim.rs`): `!verbatimModuleSyntax && isolatedModules && module == Preserve`.
- `check_verbatim_module_syntax_imports`: gate extended to also enter under the new condition; when the CJS-forbidden branch fires under preserve+isolatedModules, it reports TS1293 instead of picking between TS1286/TS1295, then returns before the VMS-exclusive per-specifier type-only checks (TS1484/1485/TS2748), which don't apply outside real `verbatimModuleSyntax`.
- `check_verbatim_module_syntax_named_exports`: same CJS-forbidden check added for the `export { ... }` clause (with or without `from`), anchored at the first specifier's source name — previously this function only handled the type-only-marking diagnostics (TS1205/TS1448) and never checked CJS-forbidden-ness for export clauses at all under either mode.
- 15 new oracle-pinned tests (`ts1293_preserve_isolated_modules_esm_syntax_in_cjs_tests.rs`): positive cases (named/default/namespace import, renamed binder, local named export, re-export, renamed export alias) and negative controls (type-only import/export exempt, bare side-effect import exempt, `.mts` exempt, `isolatedModules: false` exempt, `export const x = 1` value-declaration exempt, bare `export * from` exempt, and `verbatimModuleSyntax` takes priority over TS1293 when both are set).

**Adjacent case found and deliberately out of scope:** `export * as ns from "./m"` also reports TS1293 in real `tsc` (oracle-confirmed), but tsz's parser (`parse_export_star`) folds `* as ns` down to just the `ns` identifier node in `ExportDeclData.export_clause` with no `NAMESPACE_EXPORT` wrapper and no retained position for the `*` token — there is nothing to anchor the diagnostic at without a parser change. Grepped: zero references to `NAMESPACE_EXPORT` (kind 281) anywhere in the checker, so this same gap almost certainly already suppresses TS1286 for that shape under plain `verbatimModuleSyntax` too, independent of this PR. Flagged on the coordination board as a follow-up rather than scope-creeping this diff into a parser change.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib -- ts1293` — 15/15 new tests pass.
- `cargo test -p tsz-checker --lib -- verbatim isolated_module` — 28/28 pass (all existing `verbatimModuleSyntax`/`isolatedModules` tests unaffected).
- `cargo test -p tsz-checker --lib` (full suite) — ran to completion on the bulk (10,000+ tests, zero `FAILED` observed) before being interrupted by session time on a known-slow, unrelated pre-existing long-tail test (`ts2589_tests::recursive_conditional_alias_omitted_default_transform...`, already flagged on the coordination board as a long-tail case, not something this PR touches).
- `cargo clippy -p tsz-checker --lib -- -D warnings` — clean.
- `cargo fmt -p tsz-checker -- --check` — clean.
- `python3 scripts/arch/arch_guard.py` — clean.
- Pre-commit hook's own `-p tsz-checker` clippy + arch-guard + test gate — passed.
- Conformance: grepped the full `TypeScript/tests/cases` corpus for the combination this PR gates on (`@module: preserve` + `@isolatedModules: true`) — 37 fixtures use `@module: preserve`, **zero** also set `@isolatedModules: true`, so this change cannot move the conformance count; full `conformance.sh snapshot` not run given that static confirmation and session time.
- Emit: no `crates/tsz-emitter` path touched; not run.
- Manual oracle verification against `typescript@7.0.2` (~15 config/shape probes) established the structural rule itself before implementation — see the PR description above and the board CLAIM comment for the full probe matrix.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLK1aQmYfBTkarkNsTuqGJ)_