### PR TITLE
fix(parser): TS1030 for a duplicate `readonly` on a type member

### DIFF
--- a/crates/tsz-parser/src/parser/state_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_declarations.rs
@@ -34,6 +34,17 @@ enum TypeMemberPropertyOrMethodName {
     IndexSignature(NodeIndex),
 }
 
+/// The offending token immediately following a type member's leading
+/// `readonly`, when it is not the property/index-signature name. `tsc`
+/// reports a different message and code depending on which of these it is:
+/// a second `readonly` is TS1030 (`'readonly' modifier already seen.`), any
+/// other modifier is TS1070 (`'{0}' modifier cannot appear on a type
+/// member.`).
+enum SecondTypeMemberModifier {
+    DuplicateReadonly,
+    Illegal(String),
+}
+
 impl ParserState {
     /// Parse interface declaration
     pub(crate) fn parse_interface_declaration(&mut self) -> NodeIndex {
@@ -501,38 +512,48 @@ impl ParserState {
         };
         let readonly = readonly_span.is_some();
 
-        // `readonly async x(): number` / `readonly static m(): number` / etc:
-        // any other type-member modifier written directly after `readonly` is a
-        // second leading modifier, not the member name. `tsc` checks `readonly`
-        // first in source order (legal only on a property/index signature — see
-        // the TS1024 check below) and, only when that doesn't already reject the
-        // member, checks the second modifier next (always illegal on a type
-        // member — TS1070). Detected here, before name parsing, so the second
-        // modifier is never misread as the property name (oracle-verified: it
-        // is not a valid property-name continuation in this position, e.g.
-        // `readonly static: number` — `static` used AS the name — stays clean,
-        // guarded by the same `look_ahead_is_property_name_after_keyword` check
-        // used for the leading-modifier case). It must still be consumed even
+        // `readonly async x(): number` / `readonly static m(): number` /
+        // `readonly readonly x: number` / etc: any second leading modifier
+        // written directly after `readonly` — including a repeated
+        // `readonly` itself — is not the member name. `tsc` checks each
+        // modifier in source order and reports (and immediately stops at)
+        // the first violation: `readonly` on a method/construct signature
+        // (TS1024, checked below once the member kind is known), a second
+        // `readonly` once the first was already legal (TS1030), or any other
+        // modifier, which is always illegal on a type member (TS1070).
+        // Detected here, before name parsing, so the offending token is
+        // never misread as the property name (oracle-verified: it is not a
+        // valid property-name continuation in this position, e.g. `readonly
+        // static: number` — `static` used AS the name — stays clean, guarded
+        // by the same `look_ahead_is_property_name_after_keyword` check used
+        // for the leading-modifier case). It must still be consumed even
         // when `modifier_diagnostic_reported` is already true (an earlier
         // illegal modifier fired) — only the diagnostic, not the consumption,
         // is suppressed in that case.
         let second_modifier_span = if readonly
             && (self.is_token(SyntaxKind::AsyncKeyword)
+                || self.is_token(SyntaxKind::ReadonlyKeyword)
                 || Self::is_illegal_type_member_modifier(self.token()))
             && !self.look_ahead_is_property_name_after_keyword()
         {
-            let text = self.scanner.get_token_text();
+            let kind = if self.is_token(SyntaxKind::ReadonlyKeyword) {
+                SecondTypeMemberModifier::DuplicateReadonly
+            } else {
+                SecondTypeMemberModifier::Illegal(self.scanner.get_token_text())
+            };
             let span = (self.token_pos(), self.token_end());
             self.next_token();
 
-            // A longer chain (`readonly async static x`, `readonly static
-            // public x`, ...) still reports a single diagnostic naming only
-            // the first offender — every modifier past it must still be
-            // consumed silently so the member parses cleanly, matching
-            // `parse_type_member_visibility_modifier_error`'s equivalent
-            // "consume the whole run" step for the illegal-modifier-first
-            // case.
+            // A longer chain (`readonly async static x`, `readonly readonly
+            // static x`, `readonly static readonly x`, ...) still reports a
+            // single diagnostic naming only the first offender — every
+            // modifier past it, including further repeated `readonly`s, must
+            // still be consumed silently so the member parses cleanly,
+            // matching `parse_type_member_visibility_modifier_error`'s
+            // equivalent "consume the whole run" step for the
+            // illegal-modifier-first case.
             while (self.is_token(SyntaxKind::AsyncKeyword)
+                || self.is_token(SyntaxKind::ReadonlyKeyword)
                 || Self::is_illegal_type_member_modifier(self.token()))
                 && !self.look_ahead_is_property_name_after_keyword()
             {
@@ -542,7 +563,7 @@ impl ParserState {
             if modifier_diagnostic_reported {
                 None
             } else {
-                Some((span, text))
+                Some((span, kind))
             }
         } else {
             None
@@ -554,6 +575,10 @@ impl ParserState {
 
         let name = match name {
             TypeMemberPropertyOrMethodName::IndexSignature(index_signature) => {
+                // An index signature can never be a method, so `readonly`'s
+                // own TS1024 (readonly-on-method) never applies here — the
+                // second-modifier violation (if any) always gets to report.
+                self.report_type_member_second_modifier(second_modifier_span);
                 return index_signature;
             }
             TypeMemberPropertyOrMethodName::Property(name) => name,
@@ -586,17 +611,7 @@ impl ParserState {
 
         // Property: `readonly` (if present) is legal here, so the second
         // modifier (if present) is the first — and only — offending one.
-        if !modifier_diagnostic_reported
-            && let Some(((mod_start, mod_end), modifier_text)) = second_modifier_span
-        {
-            use tsz_common::diagnostics::diagnostic_codes;
-            self.parse_error_at(
-                mod_start,
-                mod_end.saturating_sub(mod_start),
-                &format!("'{modifier_text}' modifier cannot appear on a type member."),
-                diagnostic_codes::MODIFIER_CANNOT_APPEAR_ON_A_TYPE_MEMBER,
-            );
-        }
+        self.report_type_member_second_modifier(second_modifier_span);
 
         self.parse_type_member_property_signature(
             start_pos,
@@ -605,6 +620,40 @@ impl ParserState {
             question_token,
             in_interface_declaration,
         )
+    }
+
+    /// Reports the diagnostic for a type member's second leading modifier
+    /// (the token right after `readonly`, if it wasn't the member name) —
+    /// TS1030 for a repeated `readonly`, TS1070 for anything else. A `None`
+    /// span means no such modifier was present, or `readonly`'s own TS1024
+    /// (readonly-on-method) already claimed the member's one diagnostic.
+    fn report_type_member_second_modifier(
+        &mut self,
+        second_modifier_span: Option<((u32, u32), SecondTypeMemberModifier)>,
+    ) {
+        let Some(((mod_start, mod_end), kind)) = second_modifier_span else {
+            return;
+        };
+        use tsz_common::diagnostics::diagnostic_codes;
+        let len = mod_end.saturating_sub(mod_start);
+        match kind {
+            SecondTypeMemberModifier::DuplicateReadonly => {
+                self.parse_error_at(
+                    mod_start,
+                    len,
+                    "'readonly' modifier already seen.",
+                    diagnostic_codes::MODIFIER_ALREADY_SEEN,
+                );
+            }
+            SecondTypeMemberModifier::Illegal(modifier_text) => {
+                self.parse_error_at(
+                    mod_start,
+                    len,
+                    &format!("'{modifier_text}' modifier cannot appear on a type member."),
+                    diagnostic_codes::MODIFIER_CANNOT_APPEAR_ON_A_TYPE_MEMBER,
+                );
+            }
+        }
     }
 
     fn parse_type_member_property_or_method_name(

--- a/crates/tsz-parser/tests/type_member_modifier_grammar_tests.rs
+++ b/crates/tsz-parser/tests/type_member_modifier_grammar_tests.rs
@@ -34,6 +34,19 @@
 //!     for `async`; the other nine modifiers previously mis-parsed instead of
 //!     reporting at all, since only `async` had this second-modifier
 //!     lookahead).
+//!   * A second (or later) `readonly` on a type member → TS1030 (`'readonly'
+//!     modifier already seen.`), anchored at the repeated `readonly` — a
+//!     duplicate-modifier check tsz's type-member parser previously did not
+//!     implement at all (the second `readonly` mis-parsed as a failed
+//!     property-name lookahead, `NodeIndex::NONE`). Follows the same
+//!     source-order-wins rule as the row above: an illegal modifier
+//!     encountered before the duplicate `readonly` still wins (`readonly
+//!     static readonly x` is TS1070 at `static`), a duplicate `readonly`
+//!     encountered first wins over a later illegal modifier (`readonly
+//!     readonly static x` is TS1030), and `readonly` on a method reports the
+//!     pre-existing TS1024 regardless of how many `readonly`s lead it, since
+//!     the method-kind check on the very first `readonly` fires before a
+//!     second one is ever inspected.
 //!
 //! `readonly` on a property / index signature stays legal, and `export` / `in`
 //! / `out` used as a member *name* (`export: T`, `export(): void`) stay clean —
@@ -84,6 +97,7 @@ const TS1071: u32 = diagnostic_codes::MODIFIER_CANNOT_APPEAR_ON_AN_INDEX_SIGNATU
 const TS1024: u32 =
     diagnostic_codes::READONLY_MODIFIER_CAN_ONLY_APPEAR_ON_A_PROPERTY_DECLARATION_OR_INDEX_SIGNATURE;
 const TS1131: u32 = diagnostic_codes::PROPERTY_OR_SIGNATURE_EXPECTED;
+const TS1030: u32 = diagnostic_codes::MODIFIER_ALREADY_SEEN;
 
 // ---------------------------------------------------------------------------
 // TS1070: export / in / out modifier on a type member
@@ -1107,5 +1121,148 @@ fn async_second_modifier_used_as_property_name_still_reports_ts1070_at_async() {
             15,
             "'async' modifier cannot appear on a type member.".to_string()
         )],
+    );
+}
+
+// A second (or later) `readonly` on a type member — TS1030 ("'readonly'
+// modifier already seen."), not tsc's checkGrammarModifiers duplicate check,
+// which tsz's parser previously did not implement at all for type members:
+// the second `readonly` mis-parsed as a failed property-name lookahead
+// (`NodeIndex::NONE`) instead of reporting. `checkGrammarModifiers` walks
+// modifiers in SOURCE ORDER and stops at the first violation, so a duplicate
+// `readonly` only wins when nothing else in the run fires first — an earlier
+// illegal modifier (`static`) still wins over a trailing duplicate `readonly`
+// (mirroring the existing `readonly`-then-illegal-modifier precedence), and
+// `readonly` on a method reports the pre-existing TS1024 regardless of how
+// many `readonly`s lead it, since the method-kind check on the very first
+// `readonly` fires before a second one is ever inspected.
+
+#[test]
+fn duplicate_readonly_on_interface_property_reports_ts1030() {
+    assert_eq!(
+        fingerprints("interface I { readonly readonly x: number; }"),
+        vec![(
+            TS1030,
+            1,
+            24,
+            "'readonly' modifier already seen.".to_string()
+        )],
+    );
+}
+
+#[test]
+fn duplicate_readonly_on_type_literal_property_reports_ts1030() {
+    assert_eq!(
+        fingerprints("type T = { readonly readonly x: number; };"),
+        vec![(
+            TS1030,
+            1,
+            21,
+            "'readonly' modifier already seen.".to_string()
+        )],
+    );
+}
+
+#[test]
+fn triple_readonly_on_property_reports_ts1030_once_at_the_second() {
+    // A third `readonly` is silently swallowed, not separately reported —
+    // `checkGrammarModifiers` stops at the first violation.
+    assert_eq!(
+        fingerprints("interface I { readonly readonly readonly x: number; }"),
+        vec![(
+            TS1030,
+            1,
+            24,
+            "'readonly' modifier already seen.".to_string()
+        )],
+    );
+}
+
+#[test]
+fn duplicate_readonly_on_index_signature_reports_ts1030() {
+    // An index signature can never be a method, so `readonly`'s own TS1024
+    // never competes here — the duplicate always gets to report. (Index
+    // signatures return early in the parser, a separate code path from the
+    // property/method branch that the other rows in this matrix exercise.)
+    assert_eq!(
+        fingerprints("interface I { readonly readonly [k: string]: number; }"),
+        vec![(
+            TS1030,
+            1,
+            24,
+            "'readonly' modifier already seen.".to_string()
+        )],
+    );
+}
+
+#[test]
+fn duplicate_readonly_on_method_reports_ts1024_not_ts1030() {
+    // The method-kind check on the FIRST `readonly` fires immediately, before
+    // the parser ever inspects the second one for a duplicate — anchored at
+    // the first `readonly`, matching the existing single-`readonly` TS1024
+    // row exactly.
+    assert_eq!(
+        fingerprints("interface I { readonly readonly m(): void; }"),
+        vec![(
+            TS1024,
+            1,
+            15,
+            "'readonly' modifier can only appear on a property declaration or index signature."
+                .to_string()
+        )],
+    );
+}
+
+#[test]
+fn duplicate_readonly_then_illegal_modifier_reports_ts1030_and_swallows_the_rest() {
+    // The duplicate `readonly` is encountered before `static` in source
+    // order, so it wins; `static` is consumed silently rather than mis-parsed
+    // as the property name.
+    assert_eq!(
+        fingerprints("interface I { readonly readonly static x: number; }"),
+        vec![(
+            TS1030,
+            1,
+            24,
+            "'readonly' modifier already seen.".to_string()
+        )],
+    );
+}
+
+#[test]
+fn illegal_modifier_then_duplicate_readonly_reports_ts1070_and_swallows_the_readonly() {
+    // `static` is encountered before the second `readonly` in source order,
+    // so it wins here — the reverse ordering from the row above. The trailing
+    // duplicate `readonly` must still be consumed so `x` parses as the name,
+    // not mis-parsed as a failed name lookahead.
+    assert_eq!(
+        fingerprints("interface I { readonly static readonly x: number; }"),
+        vec![(
+            TS1070,
+            1,
+            24,
+            "'static' modifier cannot appear on a type member.".to_string()
+        )],
+    );
+}
+
+#[test]
+fn duplicate_readonly_then_async_reports_ts1030_and_swallows_async() {
+    assert_eq!(
+        fingerprints("interface I { readonly readonly async x: number; }"),
+        vec![(
+            TS1030,
+            1,
+            24,
+            "'readonly' modifier already seen.".to_string()
+        )],
+    );
+}
+
+#[test]
+fn duplicate_readonly_does_not_swallow_the_following_member() {
+    assert_eq!(
+        codes("interface I { readonly readonly x: number; y: string; }"),
+        vec![TS1030],
     );
 }


### PR DESCRIPTION
`readonly readonly x: number;` on an interface/type-literal member silently mis-parsed the second `readonly` as a failed property-name lookahead (`NodeIndex::NONE`) instead of reporting — a duplicate-modifier check tsz's type-member parser never implemented, flagged repeatedly on the board (#16291 family) as "the separate duplicate-modifier-detection gap already noted" but never picked up.

## Structural rule

When a type member (interface/type-literal) carries more than one `readonly` modifier, `tsc`'s `checkGrammarModifiers` walks the leading modifiers in SOURCE ORDER and reports (and stops at) the FIRST violation; tsz does this through the parser's `parse_type_member_property_or_method` (`crates/tsz-parser/src/parser/state_declarations.rs`). Concretely, oracle-verified against `typescript@7.0.2`:

- A second (or later) `readonly`, once the first was already legal for the member's eventual kind → **TS1030** (`'readonly' modifier already seen.`), anchored at the repeated `readonly`.
- An illegal modifier (`static`, `async`, etc.) encountered *before* the duplicate `readonly` in source order still wins: `readonly static readonly x` → TS1070 at `static`, not TS1030.
- A duplicate `readonly` encountered *before* a later illegal modifier wins the reverse way: `readonly readonly static x` → TS1030, `static` silently swallowed.
- `readonly` on a method/construct signature still reports the pre-existing TS1024 regardless of how many `readonly`s lead it — the method-kind check on the very first `readonly` fires immediately, before the parser ever gets to inspect a second one for a duplicate.
- A third+ `readonly` is silently consumed, not separately reported (single-diagnostic-per-member).

## Fix

Generalizes the existing "second modifier after `readonly`" mechanism in `parse_type_member_property_or_method` (previously only recognized `async`/illegal-modifiers) to also recognize a repeated `readonly`, tagging which kind of violation it is (`SecondTypeMemberModifier::DuplicateReadonly` vs `Illegal`) so the right code/message (TS1030 vs TS1070) is reported. Extends the whole-run consumption loop to swallow further repeats of any of `readonly`/`async`/illegal-modifiers, so trailing tokens (e.g. the `static` in `readonly readonly static x`, or the trailing `readonly` in `readonly static readonly x`) don't leak into name-parsing.

Also fixes an adjacent, previously-untested gap surfaced by this: the second-modifier diagnostic (TS1070, and now TS1030) was **never reported at all when the member turned out to be an index signature** — that path returns early, before the existing reporting code ran. Added a `report_type_member_second_modifier` helper called from both the index-signature and property branches so this is covered uniformly.

Owner: parser (`crates/tsz-parser/src/parser/state_declarations.rs`), consistent with how the rest of this modifier-grammar family (#16803/#16827/#16829/#16838) is owned.

## Goal
Goal: hold

## Verification
- Oracle-verified against `typescript@7.0.2` (`--noEmit --target es2022`) across: interface property, type-literal property, index signature, method, triple-readonly, duplicate-then-illegal-modifier (both orders), and duplicate-then-`async` — all byte-identical on code + line + column.
- 9 new tests in `crates/tsz-parser/tests/type_member_modifier_grammar_tests.rs`: 89/89 (80 existing + 9 new), 0 regressions.
- `cargo test -p tsz-parser --lib`: 2138/2138 passed, 0 failed (full suite).
- `cargo clippy -p tsz-parser --all-targets -- -D warnings`: clean.
- `cargo fmt -p tsz-parser -- --check`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.
- Parser-only diagnostic-position/code fix on a narrow type-member modifier-ordering shape; no TypeScript submodule checked out this session, so conformance set-difference wasn't run standalone (same reasoning several sibling PRs in this family used — e.g. #16803, #16827, #16829).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_014QMVDrfgcPzp4nYRzhEA1n)_