### PR TITLE
fix(parser,checker): override+declare modifier priority reports one diagnostic, not several

### DIFF
--- a/crates/tsz-checker/src/classes/class_chain_lookup.rs
+++ b/crates/tsz-checker/src/classes/class_chain_lookup.rs
@@ -103,6 +103,7 @@ impl<'a> CheckerState<'a> {
                                 has_dynamic_name: false,
                                 has_computed_non_literal_name: false,
                                 from_interface: false,
+                                has_declare: self.has_declare_modifier(&param.modifiers),
                             };
                             return Some(info);
                         }

--- a/crates/tsz-checker/src/classes/class_checker.rs
+++ b/crates/tsz-checker/src/classes/class_checker.rs
@@ -94,6 +94,10 @@ pub(crate) struct ClassMemberInfo {
     /// True when `override` comes from a JSDoc `@override` tag (not the keyword).
     /// Used to emit TS4118-4123 (JSDoc variants) instead of TS4112-4117.
     pub(crate) is_jsdoc_override: bool,
+    /// True when the member's own modifier list carries `declare`; combined
+    /// with `has_override` to suppress TS4112/4113/4115/4127 (see the guard
+    /// in `check_property_inheritance_compatibility`).
+    pub(crate) has_declare: bool,
     pub(crate) has_dynamic_name: bool,
     /// True when the member name is a computed property whose expression is NOT
     /// a direct string/number literal. tsc uses this (`isComputedNonLiteralName`)
@@ -163,134 +167,6 @@ pub(crate) fn visibility_conflict_elaboration(
 // =============================================================================
 
 impl<'a> CheckerState<'a> {
-    /// Report explicit/implicit override errors for constructor parameter properties.
-    pub(crate) fn check_constructor_parameter_property_overrides(
-        &mut self,
-        class_data: &tsz_parser::parser::node::ClassData,
-        base_class_idx: Option<NodeIndex>,
-        base_chain_summary: Option<&ClassChainSummary>,
-        base_class_name: &str,
-        derived_class_name: &str,
-        base_instance_member_names: &rustc_hash::FxHashSet<String>,
-        no_implicit_override: bool,
-    ) {
-        for &member_idx in &class_data.members.nodes {
-            let Some(member_node) = self.ctx.arena.get(member_idx) else {
-                continue;
-            };
-            if member_node.kind != syntax_kind_ext::CONSTRUCTOR {
-                continue;
-            }
-
-            let Some(ctor) = self.ctx.arena.get_constructor(member_node) else {
-                continue;
-            };
-            for &param_idx in &ctor.parameters.nodes {
-                let Some(param_node) = self.ctx.arena.get(param_idx) else {
-                    continue;
-                };
-                let Some(param) = self.ctx.arena.get_parameter(param_node) else {
-                    continue;
-                };
-                if !self.has_parameter_property_modifier(&param.modifiers) {
-                    continue;
-                }
-                let Some(param_name) = self.get_property_name(param.name) else {
-                    continue;
-                };
-
-                let has_override = self.has_override_modifier(&param.modifiers)
-                    || self.has_jsdoc_override_tag(param_idx);
-                let base_member = match (base_class_idx, base_chain_summary) {
-                    (Some(base_idx), Some(summary)) => {
-                        let _ = base_idx;
-                        summary.lookup(&param_name, false, true).cloned()
-                    }
-                    (Some(base_idx), None) => {
-                        self.find_member_in_class_chain(base_idx, &param_name, false, 0, true)
-                    }
-                    (None, _) => None,
-                };
-
-                if has_override {
-                    if base_class_idx.is_none() {
-                        // tsc points at the parameter declaration (starting at the
-                        // first modifier like 'public'), not just the identifier name.
-                        // Use ctx.error() directly to bypass normalized_anchor_span
-                        // which would strip modifiers and point at just the name.
-                        self.ctx.error(
-                            param_node.pos,
-                            param_node.end - param_node.pos,
-                            crate::diagnostics::format_message(
-                                diagnostic_messages::THIS_MEMBER_CANNOT_HAVE_AN_OVERRIDE_MODIFIER_BECAUSE_ITS_CONTAINING_CLASS_DOES_N,
-                                &[base_class_name],
-                            ),
-                            diagnostic_codes::THIS_MEMBER_CANNOT_HAVE_AN_OVERRIDE_MODIFIER_BECAUSE_ITS_CONTAINING_CLASS_DOES_N,
-                        );
-                        continue;
-                    }
-
-                    if base_member.is_none() {
-                        // tsc points at the parameter declaration (starting at the
-                        // first modifier like 'public'), not just the identifier name.
-                        if let Some(suggestion) = self
-                            .find_override_name_suggestion(base_instance_member_names, &param_name)
-                        {
-                            self.ctx.error(
-                                param_node.pos,
-                                param_node.end - param_node.pos,
-                                crate::diagnostics::format_message(
-                                    diagnostic_messages::THIS_MEMBER_CANNOT_HAVE_AN_OVERRIDE_MODIFIER_BECAUSE_IT_IS_NOT_DECLARED_IN_THE_B_2,
-                                    &[base_class_name, &suggestion],
-                                ),
-                                diagnostic_codes::THIS_MEMBER_CANNOT_HAVE_AN_OVERRIDE_MODIFIER_BECAUSE_IT_IS_NOT_DECLARED_IN_THE_B_2,
-                            );
-                        } else {
-                            self.ctx.error(
-                                param_node.pos,
-                                param_node.end - param_node.pos,
-                                crate::diagnostics::format_message(
-                                    diagnostic_messages::THIS_MEMBER_CANNOT_HAVE_AN_OVERRIDE_MODIFIER_BECAUSE_IT_IS_NOT_DECLARED_IN_THE_B,
-                                    &[base_class_name],
-                                ),
-                                diagnostic_codes::THIS_MEMBER_CANNOT_HAVE_AN_OVERRIDE_MODIFIER_BECAUSE_IT_IS_NOT_DECLARED_IN_THE_B,
-                            );
-                        }
-                    }
-                } else if no_implicit_override && base_member.is_some() {
-                    // tsc points TS4115 at the parameter declaration (starting at the
-                    // first modifier like 'public'), not just the identifier name.
-                    self.ctx.error(
-                        param_node.pos,
-                        param_node.end - param_node.pos,
-                        crate::diagnostics::format_message(
-                            diagnostic_messages::THIS_PARAMETER_PROPERTY_MUST_HAVE_AN_OVERRIDE_MODIFIER_BECAUSE_IT_OVERRIDES_A_ME,
-                            &[base_class_name],
-                        ),
-                        diagnostic_codes::THIS_PARAMETER_PROPERTY_MUST_HAVE_AN_OVERRIDE_MODIFIER_BECAUSE_IT_OVERRIDES_A_ME,
-                    );
-                }
-
-                // TS2610: constructor parameter property overrides a base accessor
-                // A parameter property like `constructor(public p: string)` acts as an
-                // instance property. If the base class defines the same name as an
-                // accessor (get/set), this is an accessor/property kind mismatch.
-                if let Some(ref base_info) = base_member
-                    && base_info.is_accessor
-                    && !base_info.is_abstract
-                {
-                    self.error_at_node(
-                            param.name,
-                            &format!(
-                                "'{param_name}' is defined as an accessor in class '{base_class_name}', but is overridden here in '{derived_class_name}' as an instance property."
-                            ),
-                            diagnostic_codes::IS_DEFINED_AS_AN_ACCESSOR_IN_CLASS_BUT_IS_OVERRIDDEN_HERE_IN_AS_AN_INSTANCE_PROP,
-                        );
-                }
-            }
-        }
-    }
-
     // =========================================================================
     // Inheritance Checking
     // =========================================================================
@@ -810,6 +686,7 @@ impl<'a> CheckerState<'a> {
                 has_dynamic_name,
                 is_abstract,
                 has_computed_non_literal_name,
+                has_declare,
             ) = (
                 info.name,
                 info.type_id,
@@ -824,6 +701,7 @@ impl<'a> CheckerState<'a> {
                 info.has_dynamic_name,
                 info.is_abstract,
                 info.has_computed_non_literal_name,
+                info.has_declare,
             );
 
             // Private identifiers (#foo) are lexically scoped to their own
@@ -854,6 +732,13 @@ impl<'a> CheckerState<'a> {
                     .lookup(&member_name, is_static, true)
                     .cloned()
             };
+
+            // `override`+`declare` together already produced one grammar
+            // diagnostic (TS1031/TS1040/TS1243); tsc never reaches TS4112/4113
+            // below for that member.
+            if has_override && has_declare {
+                continue;
+            }
 
             if has_override {
                 // Cannot use `override` when name is computed dynamically.

--- a/crates/tsz-checker/src/classes/class_checker_constructor_overrides.rs
+++ b/crates/tsz-checker/src/classes/class_checker_constructor_overrides.rs
@@ -1,0 +1,138 @@
+//! Constructor parameter-property override checks, split out of
+//! `class_checker.rs` to keep it under the 2000-line architecture cap.
+
+use crate::classes_domain::class_summary::ClassChainSummary;
+use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+
+impl<'a> CheckerState<'a> {
+    /// Report explicit/implicit override errors for constructor parameter properties.
+    pub(crate) fn check_constructor_parameter_property_overrides(
+        &mut self,
+        class_data: &tsz_parser::parser::node::ClassData,
+        base_class_idx: Option<NodeIndex>,
+        base_chain_summary: Option<&ClassChainSummary>,
+        base_class_name: &str,
+        derived_class_name: &str,
+        base_instance_member_names: &rustc_hash::FxHashSet<String>,
+        no_implicit_override: bool,
+    ) {
+        for &member_idx in &class_data.members.nodes {
+            let Some(member_node) = self.ctx.arena.get(member_idx) else {
+                continue;
+            };
+            if member_node.kind != syntax_kind_ext::CONSTRUCTOR {
+                continue;
+            }
+
+            let Some(ctor) = self.ctx.arena.get_constructor(member_node) else {
+                continue;
+            };
+            for &param_idx in &ctor.parameters.nodes {
+                let Some(param_node) = self.ctx.arena.get(param_idx) else {
+                    continue;
+                };
+                let Some(param) = self.ctx.arena.get_parameter(param_node) else {
+                    continue;
+                };
+                if !self.has_parameter_property_modifier(&param.modifiers) {
+                    continue;
+                }
+                let Some(param_name) = self.get_property_name(param.name) else {
+                    continue;
+                };
+
+                let has_override = self.has_override_modifier(&param.modifiers)
+                    || self.has_jsdoc_override_tag(param_idx);
+                let base_member = match (base_class_idx, base_chain_summary) {
+                    (Some(base_idx), Some(summary)) => {
+                        let _ = base_idx;
+                        summary.lookup(&param_name, false, true).cloned()
+                    }
+                    (Some(base_idx), None) => {
+                        self.find_member_in_class_chain(base_idx, &param_name, false, 0, true)
+                    }
+                    (None, _) => None,
+                };
+
+                if has_override {
+                    if base_class_idx.is_none() {
+                        // tsc points at the parameter declaration (starting at the
+                        // first modifier like 'public'), not just the identifier name.
+                        // Use ctx.error() directly to bypass normalized_anchor_span
+                        // which would strip modifiers and point at just the name.
+                        self.ctx.error(
+                            param_node.pos,
+                            param_node.end - param_node.pos,
+                            crate::diagnostics::format_message(
+                                diagnostic_messages::THIS_MEMBER_CANNOT_HAVE_AN_OVERRIDE_MODIFIER_BECAUSE_ITS_CONTAINING_CLASS_DOES_N,
+                                &[base_class_name],
+                            ),
+                            diagnostic_codes::THIS_MEMBER_CANNOT_HAVE_AN_OVERRIDE_MODIFIER_BECAUSE_ITS_CONTAINING_CLASS_DOES_N,
+                        );
+                        continue;
+                    }
+
+                    if base_member.is_none() {
+                        // tsc points at the parameter declaration (starting at the
+                        // first modifier like 'public'), not just the identifier name.
+                        if let Some(suggestion) = self
+                            .find_override_name_suggestion(base_instance_member_names, &param_name)
+                        {
+                            self.ctx.error(
+                                param_node.pos,
+                                param_node.end - param_node.pos,
+                                crate::diagnostics::format_message(
+                                    diagnostic_messages::THIS_MEMBER_CANNOT_HAVE_AN_OVERRIDE_MODIFIER_BECAUSE_IT_IS_NOT_DECLARED_IN_THE_B_2,
+                                    &[base_class_name, &suggestion],
+                                ),
+                                diagnostic_codes::THIS_MEMBER_CANNOT_HAVE_AN_OVERRIDE_MODIFIER_BECAUSE_IT_IS_NOT_DECLARED_IN_THE_B_2,
+                            );
+                        } else {
+                            self.ctx.error(
+                                param_node.pos,
+                                param_node.end - param_node.pos,
+                                crate::diagnostics::format_message(
+                                    diagnostic_messages::THIS_MEMBER_CANNOT_HAVE_AN_OVERRIDE_MODIFIER_BECAUSE_IT_IS_NOT_DECLARED_IN_THE_B,
+                                    &[base_class_name],
+                                ),
+                                diagnostic_codes::THIS_MEMBER_CANNOT_HAVE_AN_OVERRIDE_MODIFIER_BECAUSE_IT_IS_NOT_DECLARED_IN_THE_B,
+                            );
+                        }
+                    }
+                } else if no_implicit_override && base_member.is_some() {
+                    // tsc points TS4115 at the parameter declaration (starting at the
+                    // first modifier like 'public'), not just the identifier name.
+                    self.ctx.error(
+                        param_node.pos,
+                        param_node.end - param_node.pos,
+                        crate::diagnostics::format_message(
+                            diagnostic_messages::THIS_PARAMETER_PROPERTY_MUST_HAVE_AN_OVERRIDE_MODIFIER_BECAUSE_IT_OVERRIDES_A_ME,
+                            &[base_class_name],
+                        ),
+                        diagnostic_codes::THIS_PARAMETER_PROPERTY_MUST_HAVE_AN_OVERRIDE_MODIFIER_BECAUSE_IT_OVERRIDES_A_ME,
+                    );
+                }
+
+                // TS2610: constructor parameter property overrides a base accessor
+                // A parameter property like `constructor(public p: string)` acts as an
+                // instance property. If the base class defines the same name as an
+                // accessor (get/set), this is an accessor/property kind mismatch.
+                if let Some(ref base_info) = base_member
+                    && base_info.is_accessor
+                    && !base_info.is_abstract
+                {
+                    self.error_at_node(
+                            param.name,
+                            &format!(
+                                "'{param_name}' is defined as an accessor in class '{base_class_name}', but is overridden here in '{derived_class_name}' as an instance property."
+                            ),
+                            diagnostic_codes::IS_DEFINED_AS_AN_ACCESSOR_IN_CLASS_BUT_IS_OVERRIDDEN_HERE_IN_AS_AN_INSTANCE_PROP,
+                        );
+                }
+            }
+        }
+    }
+}

--- a/crates/tsz-checker/src/classes/class_member_info.rs
+++ b/crates/tsz-checker/src/classes/class_member_info.rs
@@ -679,6 +679,12 @@ impl<'a> CheckerState<'a> {
             if !info.has_override {
                 continue;
             }
+            // See the identical guard in `check_property_inheritance_compatibility`:
+            // `override`+`declare` together already produced one grammar
+            // diagnostic (TS1031/TS1040/TS1243), which suppresses TS4112 too.
+            if info.has_declare {
+                continue;
+            }
             if info.has_dynamic_name {
                 self.error_at_node(
                     info.name_idx,
@@ -825,6 +831,7 @@ impl<'a> CheckerState<'a> {
                     has_dynamic_name: self.is_computed_name_dynamic(prop.name),
                     has_computed_non_literal_name: self.is_computed_non_literal_name(prop.name),
                     from_interface: false,
+                    has_declare: self.has_declare_modifier(&prop.modifiers),
                 })
             }
             k if k == syntax_kind_ext::METHOD_DECLARATION => {
@@ -861,6 +868,7 @@ impl<'a> CheckerState<'a> {
                                     has_dynamic_name: true,
                                     has_computed_non_literal_name: true,
                                     from_interface: false,
+                                    has_declare: self.has_declare_modifier(&method.modifiers),
                                 });
                             }
                             return None;
@@ -899,6 +907,7 @@ impl<'a> CheckerState<'a> {
                     has_dynamic_name: self.is_computed_name_dynamic(method.name),
                     has_computed_non_literal_name: self.is_computed_non_literal_name(method.name),
                     from_interface: false,
+                    has_declare: self.has_declare_modifier(&method.modifiers),
                 })
             }
             k if k == syntax_kind_ext::GET_ACCESSOR => {
@@ -944,6 +953,7 @@ impl<'a> CheckerState<'a> {
                     has_dynamic_name: self.is_computed_name_dynamic(accessor.name),
                     has_computed_non_literal_name: self.is_computed_non_literal_name(accessor.name),
                     from_interface: false,
+                    has_declare: self.has_declare_modifier(&accessor.modifiers),
                 })
             }
             k if k == syntax_kind_ext::SET_ACCESSOR => {
@@ -996,6 +1006,7 @@ impl<'a> CheckerState<'a> {
                     has_dynamic_name: self.is_computed_name_dynamic(accessor.name),
                     has_computed_non_literal_name: self.is_computed_non_literal_name(accessor.name),
                     from_interface: false,
+                    has_declare: self.has_declare_modifier(&accessor.modifiers),
                 })
             }
             _ => None,

--- a/crates/tsz-checker/src/classes/class_summary.rs
+++ b/crates/tsz-checker/src/classes/class_summary.rs
@@ -1387,6 +1387,7 @@ impl<'a> CheckerState<'a> {
             has_dynamic_name: false,
             has_computed_non_literal_name: false,
             from_interface: false,
+            has_declare: self.has_declare_modifier(&param.modifiers),
         })
     }
 
@@ -1503,6 +1504,7 @@ impl<'a> CheckerState<'a> {
             has_dynamic_name: false,
             has_computed_non_literal_name: false,
             from_interface: true,
+            has_declare: false,
         };
         let is_visible = visibility != crate::class_checker::MemberVisibility::Private;
         Self::record_unified_member(info, is_visible, summary, self);
@@ -1682,6 +1684,7 @@ impl<'a> CheckerState<'a> {
                 has_dynamic_name: false,
                 has_computed_non_literal_name: false,
                 from_interface: false,
+                has_declare: false,
             },
             display_name,
             kind,

--- a/crates/tsz-checker/src/classes/mod.rs
+++ b/crates/tsz-checker/src/classes/mod.rs
@@ -4,6 +4,7 @@ pub mod class_checker;
 pub(crate) mod class_checker_compat;
 pub(crate) mod class_checker_compat_overloads;
 pub(crate) mod class_checker_compat_this;
+pub(crate) mod class_checker_constructor_overrides;
 pub(crate) mod class_helpers;
 pub(crate) mod class_implements_checker;
 pub(crate) mod class_implements_helpers;

--- a/crates/tsz-checker/src/state/state_checking_members/ambient_constructor_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_constructor_checks.rs
@@ -39,7 +39,13 @@ impl<'a> CheckerState<'a> {
         }
 
         // Error 1089: 'override' modifier cannot appear on a constructor declaration.
-        if let Some(override_mod_idx) = self.find_override_modifier(&ctor.modifiers) {
+        // Suppressed when the constructor also carries `declare`: that combination
+        // already produces its own single grammar diagnostic (TS1031 or TS1040 —
+        // see `parse_class_member_modifiers`), and tsc's `checkGrammarModifiers`
+        // walk stops there rather than also reporting TS1089.
+        if let Some(override_mod_idx) = self.find_override_modifier(&ctor.modifiers)
+            && !self.has_declare_modifier(&ctor.modifiers)
+        {
             self.error_at_node_msg(
                 override_mod_idx,
                 diagnostic_codes::MODIFIER_CANNOT_APPEAR_ON_A_CONSTRUCTOR_DECLARATION,

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -19,6 +19,8 @@
 
 #[path = "tests/alias_application_display_retention_tests.rs"]
 mod alias_application_display_retention_tests;
+#[path = "tests/ambient_declare_override_modifier_tests.rs"]
+mod ambient_declare_override_modifier_tests;
 #[path = "tests/any_parameter_never_opposite_tests.rs"]
 mod any_parameter_never_opposite_tests;
 #[path = "tests/application_arg_concrete_index_access_display_tests.rs"]

--- a/crates/tsz-checker/src/tests/ambient_declare_override_modifier_tests.rs
+++ b/crates/tsz-checker/src/tests/ambient_declare_override_modifier_tests.rs
@@ -1,0 +1,214 @@
+//! `declare`/`override` interaction on a class member (issue #16291 follow-up
+//! named on #16838's 2026-08-08T00:19:45Z comment): tsz over-reported
+//! multiple diagnostics for `declare override`/`override declare` combos
+//! instead of tsc's single one.
+//!
+//! tsc's `checkGrammarModifiers` walks a member's modifiers in SOURCE ORDER
+//! and reports exactly one diagnostic for the pair, so which code wins
+//! depends on order and member kind:
+//! - `override` before `declare`: the ambient conflict (TS1040) is known as
+//!   soon as `declare` is reached, regardless of member kind — even a method,
+//!   accessor, or constructor reports TS1040 alone (not TS1031/TS1089).
+//! - `declare` before `override`: `declare` is checked against the member
+//!   kind immediately. On a method/accessor/constructor (which never allow
+//!   `declare`) that is TS1031 and the walk stops there, before `override` is
+//!   even reached. On a property (the one member kind `declare` is legal on),
+//!   the walk continues and reports TS1243 ("'override' modifier cannot be
+//!   used with 'declare' modifier") at `override` instead.
+//!
+//! Either way, once one of these grammar diagnostics fires for the pair, tsc
+//! never reaches the semantic override-compatibility checks (TS4112/TS4113)
+//! or the constructor-specific TS1089 for that member — this suite pins that
+//! suppression too, both with and without a base class in scope.
+//!
+//! Every expectation is pinned against `typescript@7.0.2`
+//! (`--noEmit --strict --target es2022 --lib es2022`). Binder names are varied
+//! so the diagnostic is keyed on the modifier shape, not any identifier.
+
+// TS1031/TS1040/TS1243 are parser-emitted; TS4112/TS4113/TS1089 are
+// checker-emitted. Only `check_source_codes_with_parse_health` sees both
+// sides — the plain `check_source_diagnostics`/`check_source_codes` helpers
+// never wire parser diagnostics into the result at all.
+use crate::test_utils::check_source_codes_with_parse_health;
+
+const TS1031: u32 = 1031; // 'declare' modifier cannot appear on class elements of this kind.
+const TS1040: u32 = 1040; // 'override' modifier cannot be used in an ambient context.
+const TS1089: u32 = 1089; // 'override' modifier cannot appear on a constructor declaration.
+const TS1243: u32 = 1243; // 'override' modifier cannot be used with 'declare' modifier.
+const TS4112: u32 = 4112; // cannot have override — containing class does not extend another class.
+const TS4113: u32 = 4113; // cannot have override — not declared in the base class.
+
+/// Grammar/override codes this suite is about, filtered so assertions stay
+/// immune to unrelated harness noise (the unit harness has no lib).
+const RELEVANT_CODES: [u32; 6] = [TS1031, TS1040, TS1089, TS1243, TS4112, TS4113];
+
+fn codes(source: &str) -> Vec<u32> {
+    let mut v: Vec<u32> = check_source_codes_with_parse_health(source)
+        .into_iter()
+        .filter(|c| RELEVANT_CODES.contains(c))
+        .collect();
+    v.sort_unstable();
+    v
+}
+
+// --- `override` before `declare`, any member kind: TS1040 alone ------------
+
+#[test]
+fn override_declare_property_reports_ts1040_alone() {
+    for name in ["p", "value", "data", "field"] {
+        let source = format!("class C {{ override declare {name}: number; }}");
+        assert_eq!(codes(&source), vec![TS1040], "source: {source}");
+    }
+}
+
+#[test]
+fn override_declare_method_reports_ts1040_alone_not_ts1031() {
+    assert_eq!(
+        codes("class C { override declare m(): void; }"),
+        vec![TS1040]
+    );
+}
+
+#[test]
+fn override_declare_accessor_reports_ts1040_alone_not_ts1031() {
+    assert_eq!(
+        codes("class C { override declare get x(): number; }"),
+        vec![TS1040]
+    );
+    assert_eq!(
+        codes("class C { override declare set x(v: number); }"),
+        vec![TS1040]
+    );
+}
+
+#[test]
+fn override_declare_constructor_reports_ts1040_alone_not_ts1089() {
+    assert_eq!(
+        codes("class C { override declare constructor(); }"),
+        vec![TS1040]
+    );
+}
+
+#[test]
+fn override_declare_reports_ts1040_independent_of_class_name() {
+    for name in ["C", "Widget", "Repository", "Zzz"] {
+        let source = format!("class {name} {{ override declare m(): void; }}");
+        assert_eq!(codes(&source), vec![TS1040], "source: {source}");
+    }
+}
+
+// --- `declare` before `override`, on a method/accessor/constructor: TS1031 alone
+
+#[test]
+fn declare_override_method_reports_ts1031_alone() {
+    assert_eq!(
+        codes("class C { declare override m(): void; }"),
+        vec![TS1031]
+    );
+}
+
+#[test]
+fn declare_override_accessor_reports_ts1031_alone() {
+    assert_eq!(
+        codes("class C { declare override get x(): number; }"),
+        vec![TS1031]
+    );
+    assert_eq!(
+        codes("class C { declare override set x(v: number); }"),
+        vec![TS1031]
+    );
+}
+
+#[test]
+fn declare_override_constructor_reports_ts1031_alone_not_ts1089() {
+    assert_eq!(
+        codes("class C { declare override constructor(); }"),
+        vec![TS1031]
+    );
+}
+
+#[test]
+fn declare_override_method_reports_ts1031_independent_of_class_name() {
+    for name in ["C", "Widget", "Repository", "Zzz"] {
+        let source = format!("class {name} {{ declare override m(): void; }}");
+        assert_eq!(codes(&source), vec![TS1031], "source: {source}");
+    }
+}
+
+// --- `declare` before `override`, on a property: TS1243 alone --------------
+
+#[test]
+fn declare_override_property_reports_ts1243_not_ts1040() {
+    for name in ["p", "value", "data", "field"] {
+        let source = format!("class C {{ declare override {name}: number; }}");
+        assert_eq!(codes(&source), vec![TS1243], "source: {source}");
+    }
+}
+
+// --- suppression holds with a real base class in scope, both orders --------
+
+#[test]
+fn override_declare_method_suppresses_ts4112_with_extends() {
+    let source =
+        "class Base { m(): void {} } declare class D extends Base { override declare m(): void; }";
+    assert_eq!(codes(source), vec![TS1040], "source: {source}");
+}
+
+#[test]
+fn override_declare_method_suppresses_ts4113_when_base_lacks_member() {
+    // `Base` has no `m` at all — would be TS4113 without the suppression.
+    let source = "class Base { other(): void {} } declare class D extends Base { override declare m(): void; }";
+    assert_eq!(codes(source), vec![TS1040], "source: {source}");
+}
+
+#[test]
+fn declare_override_method_suppresses_ts4112_no_extends() {
+    let source = "declare class C { declare override m(): void; }";
+    assert_eq!(codes(source), vec![TS1031], "source: {source}");
+}
+
+// --- negative controls: unrelated grammar errors do not suppress TS4112 ----
+
+#[test]
+fn duplicate_accessibility_does_not_suppress_ts4112() {
+    // A grammar error unrelated to declare/override (duplicate accessibility)
+    // must not suppress the override-compatibility check.
+    assert_eq!(
+        codes("class C { public public override m(): void {} }"),
+        vec![TS4112]
+    );
+}
+
+// --- negative controls: plain `override`/`declare` alone are unaffected ----
+
+#[test]
+fn plain_override_no_extends_still_reports_ts4112() {
+    assert_eq!(
+        codes("declare class C { override m(): void; }"),
+        vec![TS4112]
+    );
+}
+
+#[test]
+fn plain_declare_method_still_reports_ts1031() {
+    assert_eq!(
+        codes("declare class C { declare m(): void; }"),
+        vec![TS1031]
+    );
+}
+
+#[test]
+fn plain_override_constructor_still_reports_ts1089() {
+    assert_eq!(
+        codes("class Base {} class C extends Base { override constructor() {} }"),
+        vec![TS1089]
+    );
+}
+
+#[test]
+fn plain_override_with_matching_base_member_is_clean() {
+    assert_eq!(
+        codes("class Base { m(): void {} } class D extends Base { override m(): void {} }"),
+        Vec::<u32>::new()
+    );
+}

--- a/crates/tsz-parser/src/parser/state_statements_class_members.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class_members.rs
@@ -33,6 +33,13 @@ pub(crate) struct ClassMemberModifierSet {
     pub(crate) has_declare: bool,
     pub(crate) has_accessor: bool,
     pub(crate) has_async: bool,
+    /// `declare` appears before `override` in source order (e.g. `declare
+    /// override p`). Distinct from the reverse order (`override declare p`),
+    /// which is already diagnosed eagerly while scanning modifiers regardless
+    /// of member kind (TS1040) — this flag exists because the `declare`-first
+    /// conflict's diagnostic depends on the member kind, which isn't known
+    /// until after modifier scanning finishes. See `construct_class_member`.
+    pub(crate) declare_before_override: bool,
     /// Diagnostic-list length captured just before modifier parsing, used to
     /// selectively roll back modifier-ordering diagnostics when a static block
     /// is discovered after modifiers were already parsed.
@@ -215,15 +222,13 @@ impl ParserState {
                         diagnostic_codes::MODIFIER_ALREADY_SEEN,
                     );
                 }
-                // TS1040: 'override' modifier cannot be used in an ambient context
-                // Handles `declare override` ordering (override after declare on same member)
-                if seen_declare {
-                    use tsz_common::diagnostics::diagnostic_codes;
-                    self.parse_error_at_current_token(
-                        "'override' modifier cannot be used in an ambient context.",
-                        diagnostic_codes::MODIFIER_CANNOT_BE_USED_IN_AN_AMBIENT_CONTEXT,
-                    );
-                }
+                // `declare override` ordering (declare before override) is NOT
+                // reported here: unlike the reverse order, tsc's actual
+                // diagnostic depends on the member kind, which is not known
+                // until later (TS1031 on a method/accessor/constructor — the
+                // existing `has_declare` check in `construct_class_member`
+                // already covers that; TS1243 on a property, handled once the
+                // member kind is confirmed — see `declare_before_override`).
                 if seen_accessor || seen_async || seen_readonly {
                     use tsz_common::diagnostics::diagnostic_codes;
                     let other = if seen_accessor {
@@ -1061,8 +1066,12 @@ impl ParserState {
         let mut has_declare = false;
         let mut has_accessor = false;
         let mut has_async = false;
+        // Source-order index of the first `declare`/`override` modifier, used
+        // below to detect `declare` appearing before `override`.
+        let mut declare_index: Option<usize> = None;
+        let mut override_index: Option<usize> = None;
         if let Some(ref mods) = combined {
-            for &idx in &mods.nodes {
+            for (i, &idx) in mods.nodes.iter().enumerate() {
                 if let Some(node) = self.arena.get(idx)
                     && let Some(kind) = SyntaxKind::try_from_u16(node.kind)
                 {
@@ -1070,14 +1079,22 @@ impl ParserState {
                         SyntaxKind::VarKeyword | SyntaxKind::LetKeyword => has_var_let = true,
                         SyntaxKind::StaticKeyword => has_static = true,
                         SyntaxKind::ExportKeyword => has_export = true,
-                        SyntaxKind::DeclareKeyword => has_declare = true,
+                        SyntaxKind::DeclareKeyword => {
+                            has_declare = true;
+                            declare_index.get_or_insert(i);
+                        }
                         SyntaxKind::AccessorKeyword => has_accessor = true,
                         SyntaxKind::AsyncKeyword => has_async = true,
+                        SyntaxKind::OverrideKeyword => {
+                            override_index.get_or_insert(i);
+                        }
                         _ => {}
                     }
                 }
             }
         }
+        let declare_before_override =
+            matches!((declare_index, override_index), (Some(d), Some(o)) if d < o);
 
         ClassMemberModifierSet {
             modifiers: combined,
@@ -1088,6 +1105,7 @@ impl ParserState {
             has_declare,
             has_accessor,
             has_async,
+            declare_before_override,
             diag_len_before_modifiers,
         }
     }
@@ -2121,6 +2139,20 @@ impl ParserState {
             // Return NONE to indicate this is not a valid member
             NodeIndex::NONE
         } else {
+            // TS1243: 'override' modifier cannot be used with 'declare' modifier.
+            // `declare override p` — the member kind is only known now (a plain
+            // property), which is the one member-local-`declare` host tsc
+            // allows for `override` to coexist with at all. The reverse order
+            // (`override declare p`) is already reported eagerly while scanning
+            // modifiers (TS1040, ambient conflict), regardless of member kind.
+            if mods.declare_before_override {
+                self.emit_modifier_error_on_constructor(
+                    &mods.modifiers,
+                    SyntaxKind::OverrideKeyword,
+                    "'override' modifier cannot be used with 'declare' modifier.",
+                    diagnostic_codes::MODIFIER_CANNOT_BE_USED_WITH_MODIFIER,
+                );
+            }
             self.construct_class_member_property(
                 start_pos,
                 mods,

--- a/crates/tsz-parser/tests/modifier_ordering_tests.rs
+++ b/crates/tsz-parser/tests/modifier_ordering_tests.rs
@@ -307,8 +307,13 @@ class D extends B {
 }
 
 #[test]
-fn declare_override_produces_ts1040() {
-    // Reverse order `declare override` also → TS1040
+fn declare_override_produces_ts1243_not_ts1040() {
+    // Reverse order `declare override` on a property → TS1243 ("'override'
+    // modifier cannot be used with 'declare' modifier"), NOT TS1040. Oracle
+    // (typescript@7.0.2): tsc's `checkGrammarModifiers` resolves the
+    // `declare`-first conflict once the member kind is known — a property is
+    // the one member-local-`declare` host it allows, and there it reports the
+    // pairwise TS1243, distinct from the `override`-first order's TS1040.
     let source = r"
 class B { p: number = 1; }
 class D extends B {
@@ -316,8 +321,14 @@ class D extends B {
 }
 ";
     assert!(
-        has_error(source, 1040),
-        "`declare override` should produce TS1040 — override cannot be in ambient context"
+        has_error(source, 1243),
+        "`declare override` on a property should produce TS1243, not TS1040: {:?}",
+        parse_diagnostics(source)
+    );
+    assert!(
+        !has_error(source, 1040),
+        "`declare override` on a property must not also produce TS1040: {:?}",
+        parse_diagnostics(source)
     );
 }
 

--- a/scripts/arch/arch_guard_policy.toml
+++ b/scripts/arch/arch_guard_policy.toml
@@ -61,6 +61,7 @@ exclude_files = [
   # Pre-existing: class member lookup in class_checker
   "crates/tsz-checker/src/classes/class_checker.rs",
   "crates/tsz-checker/src/classes/class_checker_compat.rs",
+  "crates/tsz-checker/src/classes/class_checker_constructor_overrides.rs",
   # Pre-existing: property access lookup
   "crates/tsz-checker/src/checkers/property_checker.rs",
   "crates/tsz-checker/src/state/state_checking/property.rs",


### PR DESCRIPTION
## Goal
Goal: hold

`declare override m()` and `override declare m()` each over-reported multiple diagnostics instead of tsc's single one, on every class-member kind.

## Structural rule

tsc's `checkGrammarModifiers` walks a member's modifiers in SOURCE ORDER and reports exactly one diagnostic per member for this pair (oracled on `typescript@7.0.2`):

- `override` before `declare`: the ambient conflict (TS1040) is known as soon as `declare` is reached, regardless of member kind — even a method, accessor, or constructor reports TS1040 alone.
- `declare` before `override`: `declare` is checked against the member kind immediately. On a method/accessor/constructor (which never allow `declare`) that is TS1031 and the walk stops there, before `override` is even reached. Only on a property (the one member-local-`declare` host tsc allows) does the walk continue and report TS1243 ("'override' modifier cannot be used with 'declare' modifier") at `override` instead.
- Either way, once one of these grammar diagnostics fires, tsc never reaches the semantic override-compatibility checks (TS4112/TS4113) or the constructor-specific TS1089 for that member.

tsz previously fired an eager, member-kind-blind TS1040 whenever `override` was scanned after a `declare` (wrong for method/accessor/constructor, which should get TS1031 alone, and wrong for properties, which should get TS1243), and never suppressed TS4112/TS4113/TS1089 once the grammar conflict fired.

**Owner:** parser for which grammar diagnostic wins (TS1031/TS1040/TS1243); checker for suppressing the semantic override checks once one of those fires.

## What changed

- **Parser** (`state_statements_class_members.rs`): removed the incorrect eager `seen_declare` check in the `override` arm; added a `declare_before_override` flag (mirroring the existing `declare`-vs-`async` pattern used elsewhere in this file) resolved once the member kind is confirmed to be a property, where it reports TS1243. The `override`-before-`declare` case needed no change — it already fires TS1040 unconditionally, matching tsc for every member kind.
- **Checker**: added `has_declare` to `ClassMemberInfo`, populated at every construction site, and used to skip the override-compatibility checks (`class_checker.rs`'s `check_property_inheritance_compatibility`, `class_member_info.rs`'s `report_overrides_without_base`) and the constructor-specific TS1089 (`ambient_constructor_checks.rs`) whenever a member carries both `override` and `declare`.
- Split `check_constructor_parameter_property_overrides` out of `class_checker.rs` into `class_checker_constructor_overrides.rs` (unchanged body) to stay under the 2000-line architecture cap after the `has_declare` additions; carried its pre-existing `.lookup()` allowlist entry to the new file in `arch_guard_policy.toml`.
- Fixed one existing test (`declare_override_produces_ts1040` → `declare_override_produces_ts1243_not_ts1040`) that had pinned the old wrong behavior — real tsc reports TS1243 for `declare override` on a property, never TS1040.

## Adjacent-case matrix

Method / accessor (get+set) / constructor / property × both orders, with and without a base class in scope, renamed binders, and negative controls (unrelated grammar error, plain `override` alone, plain `declare` alone) — all oracle-verified and covered by the new test file.

## Verification

- New `crates/tsz-checker/src/tests/ambient_declare_override_modifier_tests.rs`: 18 tests, all passing.
- 17-case oracle matrix against `typescript@7.0.2` (`--noEmit --strict --target es2022 --lib es2022`): 16/17 byte-identical diagnostic (line,col,code) sets. The 17th (`override constructor` without `declare` — a pre-existing, unrelated TS2377 column mismatch) is untouched by this change and out of scope.
- `cargo test -p tsz-parser --lib`: 2129/2129 passed, 0 failed.
- `cargo test -p tsz-checker --lib -- ambient_declare_override_modifier_tests member_modifier_placement_grammar async_export_modifier_order_ts1042_dedup modifier_ordering class_extends_generic_override_variance interface_extends_generic_override_variance class_implements_generic_override_variance generic_method_override_variance no_implicit_override_ambient_context override_incompatibility_elaboration class_checker`: 134/134 passed, 0 regressions.
- `cargo clippy -p tsz-parser -p tsz-checker --all-targets -- -D warnings`: clean.
- `cargo fmt -p tsz-parser -p tsz-checker -- --check`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.
- Full `cargo test -p tsz-checker --lib` started for broader coverage in the background; the targeted suites above already cover every touched code path.
- No TypeScript submodule checked out this session; conformance set-difference not run standalone. `declare`+`override` together on the same class member is rare in real code, and the oracle-pinned matrix above is the primary evidence — same reasoning several sibling #16291-family PRs used today (#16803, #16827, #16829, #16832).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLU58ffmHkCFraW4p5WjG9)_