### PR TITLE
fix(checker): the member-prefix suggestion is value-position only

### DIFF
--- a/crates/tsz-checker/src/symbols/scope_finder.rs
+++ b/crates/tsz-checker/src/symbols/scope_finder.rs
@@ -371,6 +371,55 @@ impl<'a> CheckerState<'a> {
         None
     }
 
+    /// Whether `idx` sits inside a `typeof T` **type** query, i.e. a type
+    /// position rather than a value position.
+    ///
+    /// `typeof T` in a type annotation is the one place a *value* name appears
+    /// inside a type: a bare identifier anywhere else in type syntax parses as
+    /// a `TYPE_REFERENCE` and resolves through the type path. So `TYPE_QUERY`
+    /// is the precise marker for "this value name is not in an expression".
+    ///
+    /// Used to keep the `TS2662`/`TS2663` member-prefix suggestion off type
+    /// positions, where `tsc` reports the bare `TS2304` because `this.x` is not
+    /// writable there.
+    ///
+    /// The walk stops at the enclosing class: a `typeof` *outside* the class
+    /// that contains it says nothing about a reference inside one of its
+    /// members. Being purely syntactic, this answers identically during the
+    /// statement walk and during on-demand class-type computation, which the
+    /// suggestion depends on to emit exactly one diagnostic per site.
+    pub(crate) fn is_in_type_query(&self, idx: NodeIndex) -> bool {
+        use tsz_parser::parser::syntax_kind_ext::{
+            CLASS_DECLARATION, CLASS_EXPRESSION, TYPE_QUERY,
+        };
+
+        let mut current = idx;
+        let mut iterations = 0;
+        while current.is_some() {
+            iterations += 1;
+            if iterations > MAX_TREE_WALK_ITERATIONS {
+                return false;
+            }
+            let Some(node) = self.ctx.arena.get(current) else {
+                return false;
+            };
+            if node.kind == TYPE_QUERY {
+                return true;
+            }
+            if node.kind == CLASS_DECLARATION || node.kind == CLASS_EXPRESSION {
+                return false;
+            }
+            let Some(ext) = self.ctx.arena.get_extended(current) else {
+                return false;
+            };
+            if ext.parent.is_none() {
+                return false;
+            }
+            current = ext.parent;
+        }
+        false
+    }
+
     /// Check if `this` is inside a static class member by walking the AST.
     /// Returns true if the nearest enclosing class member/static-block has a `static` modifier.
     /// Unlike `enclosing_class.in_static_member`, this works even outside the

--- a/crates/tsz-checker/src/types/computation/identifier/resolution.rs
+++ b/crates/tsz-checker/src/types/computation/identifier/resolution.rs
@@ -429,7 +429,16 @@ impl<'a> CheckerState<'a> {
         // function boundaries, so a class's statics are suggestable from a nested
         // function too; the `this`-rebind boundary is enforced on the instance
         // arm below.
-        if let Some(class_idx) = self.nearest_enclosing_class(idx)
+        // Only from a *value* position. In a type position — `b: typeof a`,
+        // `m(x: typeof a)`, `m(): typeof a` — tsc reports the bare `TS2304`
+        // even when the name matches a member, because `this.a` is not
+        // writable there. In tsc this falls out of call-site placement:
+        // `checkAndReportErrorForMissingPrefix` is reached from
+        // `checkIdentifier`, while a type-position name resolves through the
+        // type-reference path. Here both paths share this function, so the
+        // position has to be asked for explicitly.
+        if !self.is_in_type_query(idx)
+            && let Some(class_idx) = self.nearest_enclosing_class(idx)
             && let Some((member_nodes, class_name)) = self.class_members_and_name(class_idx)
         {
             // Static (TS2662): a declared static, or a member of `Function`

--- a/crates/tsz-checker/tests/missing_prefix_member_suggestion_tests.rs
+++ b/crates/tsz-checker/tests/missing_prefix_member_suggestion_tests.rs
@@ -183,3 +183,100 @@ fn suggestion_is_binder_name_invariant() {
         &["TS2663: Cannot find name 'frob'. Did you mean the instance member 'this.frob'?"],
     );
 }
+
+// ---------------------------------------------------------------------------
+// Type positions take the bare `TS2304` (#16840). `typeof a` in a type is the
+// one place a *value* name appears inside type syntax, and `this.a` is not
+// writable there, so tsc offers no suggestion — `checkAndReportErrorForMissing
+// Prefix` is reached from `checkIdentifier`, never from the type-reference path.
+//
+// Each row pairs a type position with the *same* class and member name in a
+// value position. Without the pairing these would only show that some sources
+// produce no suggestion; paired, they isolate the position as the variable.
+// Oracle-verified against `typescript@7.0.2` (`--singleThreaded
+// --stableTypeOrdering true`): the type rows report `TS2304`, the value rows
+// report `TS2663`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn property_type_annotation_produces_no_suggestion() {
+    let libs = load_default_lib_files();
+    // `compiler/typeofProperty.ts` — the conformance row this regressed.
+    assert_suggestions(
+        "class C { a: number = 1; b: typeof a = 1 as any; }",
+        &libs,
+        &[],
+    );
+    // Same class, same member, value position → suggestion.
+    assert_suggestions(
+        "class C { a: number = 1; p = a; }",
+        &libs,
+        &["TS2663: Cannot find name 'a'. Did you mean the instance member 'this.a'?"],
+    );
+}
+
+#[test]
+fn parameter_type_annotation_produces_no_suggestion() {
+    let libs = load_default_lib_files();
+    assert_suggestions("class C { a: number = 1; m(x: typeof a) {} }", &libs, &[]);
+    assert_suggestions(
+        "class C { a: number = 1; m() { return a; } }",
+        &libs,
+        &["TS2663: Cannot find name 'a'. Did you mean the instance member 'this.a'?"],
+    );
+}
+
+#[test]
+fn return_type_annotation_produces_no_suggestion() {
+    let libs = load_default_lib_files();
+    assert_suggestions(
+        "class C { a: number = 1; m(): typeof a { return 1 as any; } }",
+        &libs,
+        &[],
+    );
+    assert_suggestions(
+        "class C { a: number = 1; constructor() { a; } }",
+        &libs,
+        &["TS2663: Cannot find name 'a'. Did you mean the instance member 'this.a'?"],
+    );
+}
+
+#[test]
+#[ignore = "known divergence (#16840, pre-existing and older than #16834): a \
+            *declared static* named in a type position still reports TS2662 \
+            where tsc reports the bare TS2304. That name binds to a real \
+            symbol, so it never reaches resolve_truly_unknown_identifier — it \
+            is emitted from the resolved-symbol paths in \
+            types/computation/identifier/resolved.rs and \
+            types/computation/helpers.rs, which need the same value-position \
+            guard applied at their own sites"]
+fn a_static_member_in_a_type_position_produces_no_suggestion() {
+    let libs = load_default_lib_files();
+    assert_suggestions(
+        "class C { static s: number = 1; b: typeof s = 1 as any; }",
+        &libs,
+        &[],
+    );
+}
+
+#[test]
+fn a_static_member_in_a_value_position_still_suggests() {
+    let libs = load_default_lib_files();
+    // The control for the ignored row above: the same class and member in a
+    // value position must keep its suggestion, so whoever fixes the static
+    // arm's type-position leak has a live guard against over-correcting.
+    assert_suggestions(
+        "class C { static s: number = 1; m() { return s; } }",
+        &libs,
+        &["TS2662: Cannot find name 's'. Did you mean the static member 'C.s'?"],
+    );
+}
+
+#[test]
+fn arguments_in_a_type_position_produces_no_suggestion() {
+    let libs = load_default_lib_files();
+    // The `Function`-member path (#16815's original witness) is the widest arm —
+    // it matches any name on `Function`/`Object` — so it is the most likely to
+    // leak into a type position.
+    assert_suggestions("class C { b: typeof arguments = 1 as any; }", &libs, &[]);
+}


### PR DESCRIPTION
Fixes #16840. Restores the conformance row #16834 cost: **11,524 → 11,525**.

Goal: hold

## The divergence

#16834 correctly gave an unresolved name inside a class the `TS2662`/`TS2663` member-prefix suggestion. It also fires in **type** positions, where tsc reports the bare `TS2304` — `this.a` is not writable there.

| position | tsc 7.0.2 | main | this PR |
|---|---|---|---|
| `class C { a: number; b: typeof a; }` — property type annotation | `TS2304` | `TS2663` | ✓ |
| `class C { a: number; m(x: typeof a) {} }` — parameter type annotation | `TS2304` | `TS2663` | ✓ |
| `class C { a: number; m(): typeof a {} }` — return type annotation | `TS2304` | `TS2663` | ✓ |
| `class C { a = 1; m() { return a; } }` — method body | `TS2663` | `TS2663` | ✓ unchanged |
| `class C { a = 1; constructor() { a; } }` — ctor body | `TS2663` | `TS2663` | ✓ unchanged |
| `class C { a = 1; p = a; }` — property initializer | `TS2663` | `TS2663` | ✓ unchanged |
| `class C { static s = 1; m() { return s; } }` — static from method | `TS2662` | `TS2662` | ✓ unchanged |
| `interface I { a: number; b: typeof a; }` | `TS2304` | `TS2304` | ✓ unchanged |

`compiler/typeofProperty.ts` is now byte-identical to tsc.

## Structural rule

When an unresolved identifier appears in a **type** position, tsc reports the bare `TS2304` even if the name matches a member of the enclosing class; the member-prefix suggestion is reachable only from the value-identifier path. In tsc this falls out of call-site placement — `checkAndReportErrorForMissingPrefix` is called from `checkIdentifier`, while a type-position name resolves through the type-reference path and never reaches it. tsz routes both through `resolve_truly_unknown_identifier`, so the position has to be asked for explicitly.

Owner layer: unresolved-identifier resolution/display in the checker (`types/computation/identifier/resolution.rs`), with the syntactic query in `symbols/scope_finder.rs`.

## Why `TYPE_QUERY` is the right marker

`typeof T` is the one place a **value** name appears inside type syntax. A bare identifier anywhere else in a type parses as `TYPE_REFERENCE` and resolves through the type path, never reaching this function. So testing for an enclosing `TYPE_QUERY` is exactly the "not an expression" condition, not a proxy for it.

The new `is_in_type_query` is a parent walk that stops at the enclosing class — a `typeof` *outside* the class says nothing about a reference inside one of its members.

**It preserves #16834's two-pass agreement.** That PR deliberately moved off the ambient `enclosing_class` context because the context is unset during on-demand class-type computation, so a context-keyed suggestion fired in the statement-walk pass but not the type-computation pass; since diagnostics dedupe by `(start, code)`, a suggestion in one pass and a bare `TS2304` in the other both survived. `is_in_type_query` is purely syntactic, so it answers identically in both passes and that property still holds.

## Tests

Five rows added to `missing_prefix_member_suggestion_tests.rs`. Each type position is paired with **the same class and member name in a value position** — without the pairing the rows would only show that some sources produce no suggestion; paired, they isolate the position as the variable.

One row is `#[ignore]`d as a **pre-existing** divergence, not this PR's:

```ts
class C { static s: number = 1; b: typeof s = 1 as any; }   // tsc TS2304, tsz TS2662
```

A *declared static* named in a type position binds to a real symbol, so it never reaches `resolve_truly_unknown_identifier` — it is emitted from the resolved-symbol paths in `types/computation/identifier/resolved.rs:477` and `types/computation/helpers.rs:1237`, which need the same guard at their own sites. Measured on three binaries to confirm it is older than #16834:

| case | tsc | pre-#16834 | post-#16834 | this PR |
|---|---|---|---|---|
| instance in type position | `TS2304` | `TS2304` | `TS2663` | `TS2304` ✓ |
| **static** in type position | `TS2304` | `TS2662` | `TS2662` | `TS2662` — pre-existing |
| static in value position | `TS2662` | `TS2662` | `TS2662` | `TS2662` ✓ |

Its value-position control is a live (non-ignored) test, so whoever fixes the static arm has a guard against over-correcting. Tracked in #16840.

## Verification

- `cargo nextest run -p tsz-checker --test missing_prefix_member_suggestion_tests` — **15 passed, 1 skipped** (the known-divergence row)
- `cargo nextest run -p tsz-checker --lib` — **10696/10696**
- `cargo nextest run -p tsz-core -p tsz-solver -p tsz-parser -p tsz-emitter --lib` — **17079/17079**
- `cargo clippy -p tsz-checker --all-targets` — 0 diagnostics
- `python3 scripts/arch/arch_guard.py` — rc=0
- Conformance set-difference: **`compiler/typeofProperty.ts` FIXED**, 0 broken by this change.

One note on that conformance run: it also showed `conformance/externalModules/verbatimModuleSyntaxRestrictionsCJS.ts` breaking. That is **not** from this PR — it is an extra `TS1295` at `(25,8)` in the verbatim-module-syntax family, which landed on main between my baseline and this run. This diff touches only `TS2662`/`TS2663` gating and cannot emit `TS1295`. Reported separately.

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high
