### PR TITLE
fix(checker): unannotated generator no longer drops nested class diagnostics

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -347,6 +347,8 @@ mod generator_declaration_yield_star_inference_tests;
 mod generator_default_type_argument_relation_tests;
 #[path = "tests/generator_inferred_yield_star_array_generic_call_tests.rs"]
 mod generator_inferred_yield_star_array_generic_call_tests;
+#[path = "tests/generator_nested_class_diagnostics_tests.rs"]
+mod generator_nested_class_diagnostics_tests;
 #[path = "tests/generator_yield_identity_tests.rs"]
 mod generator_yield_identity_tests;
 #[path = "tests/generator_yield_invalid_thenable_tests.rs"]

--- a/crates/tsz-checker/src/tests/generator_nested_class_diagnostics_tests.rs
+++ b/crates/tsz-checker/src/tests/generator_nested_class_diagnostics_tests.rs
@@ -1,0 +1,166 @@
+//! Regression coverage: an **unannotated** generator declaration must not
+//! swallow the diagnostics owed by a class nested in its body.
+//!
+//! `infer_generator_declaration_yield_type`
+//! (`types/function_type/generator_declaration_yield.rs`) runs a *suppressed*
+//! speculative pass over the generator body to recover its inferred yield
+//! type — real body diagnostics are meant to come from the later, real
+//! declaration check. That pass walks the whole body, so any class it reaches
+//! is checked (with diagnostics rolled back) and, before the fix, left marked
+//! in `checked_classes`. The real pass then treated the class as
+//! "already checked" and skipped it, silently dropping every diagnostic its
+//! members owe: TS2322 on a member/property body, TS1308/TS1166 on a computed
+//! name, TS2507 on the heritage clause. Annotating the generator's return
+//! type disabled the speculative pass and hid the bug; only the inferred-yield
+//! path tripped it.
+//!
+//! The fix snapshots `checked_classes`/`checking_classes` across the
+//! speculative walk and restores them past the rollback, so a class checked
+//! speculatively is re-checked for real. Every expectation below is pinned
+//! against `tsc@5.9 --noEmit --strict --target es2022 --module esnext` and
+//! cross-checked against the compiled `tsz` CLI.
+//!
+//! Binder names are varied across cases (`Holder`/`Bag`/`Inner`/`Widget`/`Cell`,
+//! `gen`/`g`/`stream`/`pump`/`feed`) so the coverage rides on the structural
+//! generator/class nesting, not on any particular identifier.
+
+use crate::test_utils::check_source_codes_with_parse_health;
+
+/// The unit harness has no lib, so an unannotated generator's inferred
+/// `Generator<...>` return type reports missing-global-type noise
+/// (TS2318/TS2468/TS2304 on `Generator`/`Iterator*`) that the compiled CLI,
+/// which has a lib, never produces. Strip those so assertions read only the
+/// class-body diagnostics under test — which is exactly the family the bug
+/// dropped.
+fn class_body_codes(mut codes: Vec<u32>) -> Vec<u32> {
+    codes.retain(|&c| !matches!(c, 2318 | 2468 | 2304 | 2705 | 7025 | 7057));
+    codes.sort_unstable();
+    codes
+}
+
+#[test]
+fn unannotated_generator_nested_class_member_body_reports_ts2322() {
+    let codes = class_body_codes(check_source_codes_with_parse_health(
+        r#"
+function* gen() { class Holder { m(): string { return 42; } } }
+"#,
+    ));
+    assert_eq!(codes, vec![2322], "got {codes:?}");
+}
+
+#[test]
+fn unannotated_generator_nested_class_property_reports_ts2322() {
+    let codes = class_body_codes(check_source_codes_with_parse_health(
+        r#"
+function* g() { class Bag { p: string = 42; } }
+"#,
+    ));
+    assert_eq!(codes, vec![2322], "got {codes:?}");
+}
+
+#[test]
+fn unannotated_generator_nested_class_heritage_reports_ts2507() {
+    let codes = class_body_codes(check_source_codes_with_parse_health(
+        r#"
+function* stream() { class Inner extends 5 {} }
+"#,
+    ));
+    assert_eq!(codes, vec![2507], "got {codes:?}");
+}
+
+#[test]
+fn unannotated_generator_nested_class_computed_name_await_reports_ts1308() {
+    // `await` in a class computed name is evaluated in the enclosing scope,
+    // which here is a *generator* (non-async) — so TS1308 is correct, and the
+    // dropped-class bug had been hiding it.
+    let codes = class_body_codes(check_source_codes_with_parse_health(
+        r#"
+declare const key: string;
+function* gen() { class Holder { [await key]() {} } }
+"#,
+    ));
+    assert_eq!(codes, vec![1308], "got {codes:?}");
+}
+
+#[test]
+fn unannotated_generator_nested_class_computed_property_yield_reports_ts1166() {
+    // `[yield 1]` in a class *property* declaration: the generator context
+    // makes `yield 1` a legal yield expression (no TS1163), but a class
+    // property computed name still requires a literal/unique-symbol type
+    // (TS1166). The bug dropped both this and the type check.
+    let codes = class_body_codes(check_source_codes_with_parse_health(
+        r#"
+function* gen() { class Holder { [yield 1] = 2; } }
+"#,
+    ));
+    assert_eq!(codes, vec![1166], "got {codes:?}");
+}
+
+#[test]
+fn async_generator_nested_class_member_body_reports_ts2322() {
+    // Async generators take the identical inferred-yield speculative path.
+    let codes = class_body_codes(check_source_codes_with_parse_health(
+        r#"
+async function* pump() { class Widget { m(): string { return 42; } } }
+"#,
+    ));
+    assert_eq!(codes, vec![2322], "got {codes:?}");
+}
+
+#[test]
+fn unannotated_generator_class_under_nested_function_reports_ts2322() {
+    // The speculative walk reaches every depth, so the leak dropped classes
+    // arbitrarily deep — here inside a plain function inside the generator.
+    let codes = class_body_codes(check_source_codes_with_parse_health(
+        r#"
+function* gen() { function h() { class Holder { m(): string { return 42; } } } }
+"#,
+    ));
+    assert_eq!(codes, vec![2322], "got {codes:?}");
+}
+
+#[test]
+fn unannotated_generator_class_under_block_reports_ts2322() {
+    let codes = class_body_codes(check_source_codes_with_parse_health(
+        r#"
+function* gen() { { class Holder { m(): string { return 42; } } } }
+"#,
+    ));
+    assert_eq!(codes, vec![2322], "got {codes:?}");
+}
+
+#[test]
+fn unannotated_generator_with_yield_still_reports_nested_class_ts2322() {
+    // A real yield in the body exercises the yield-collection side of the
+    // speculative pass while a nested class error is still owed.
+    let codes = class_body_codes(check_source_codes_with_parse_health(
+        r#"
+function* feed() { yield 1; class Cell { m(): string { return 42; } } }
+"#,
+    ));
+    assert_eq!(codes, vec![2322], "got {codes:?}");
+}
+
+#[test]
+fn annotated_generator_nested_class_still_reports_ts2322() {
+    // The annotated path never ran the speculative pass, so it was already
+    // correct; pin it so a future refactor can't regress the twin.
+    let codes = class_body_codes(check_source_codes_with_parse_health(
+        r#"
+function* gen(): Generator<number> { class Holder { m(): string { return 42; } } }
+"#,
+    ));
+    assert_eq!(codes, vec![2322], "got {codes:?}");
+}
+
+#[test]
+fn unannotated_generator_yield_grammar_in_nested_class_stays_clean() {
+    // Control: a class-computed-name `yield` that *is* legal (generator
+    // context) must stay clean — the fix must not manufacture a diagnostic.
+    let codes = class_body_codes(check_source_codes_with_parse_health(
+        r#"
+function* gen() { class Holder { [yield 1]() {} } }
+"#,
+    ));
+    assert!(codes.is_empty(), "got {codes:?}");
+}

--- a/crates/tsz-checker/src/types/function_type/generator_declaration_yield.rs
+++ b/crates/tsz-checker/src/types/function_type/generator_declaration_yield.rs
@@ -62,6 +62,21 @@ impl CheckerState<'_> {
         let saved_cf_context = self.ctx.enter_function_like_control_flow();
         let saved_yield_collection = std::mem::take(&mut self.ctx.generator_yield_operand_types);
         let saved_had_ts7057 = std::mem::replace(&mut self.ctx.generator_had_ts7057, false);
+        // `checked_classes` is not part of `snapshot_return_type`. This
+        // suppressed pass walks the whole body, so any nested class it reaches
+        // gets marked there as fully checked — but with its diagnostics rolled
+        // back below. Left in place, that mark makes the later real declaration
+        // check treat the class as "already checked" and skip it, silently
+        // dropping every diagnostic its members owe (TS2322 on a member body,
+        // TS1308/TS1166 on a computed name, TS2507 on the heritage, ...).
+        // Snapshot it and restore past the rollback so classes checked
+        // speculatively are re-checked for real. A generator never draws its
+        // yield type from a nested class body (classes own their own yields),
+        // so un-memoizing them costs the signature pass nothing. `checking_classes`
+        // needs no snapshot: it is a recursion guard that `check_class_declaration`
+        // balances (every insert has a matching remove on completion), so a pass
+        // that runs to completion leaves it exactly as it found it.
+        let saved_checked_classes = self.ctx.checked_classes.clone();
 
         let body_request = self.function_body_statement_request(false, contextual_type);
         self.check_function_body_statement_with_own_literal_context(body, &body_request);
@@ -88,6 +103,7 @@ impl CheckerState<'_> {
         self.ctx.generator_had_ts7057 = saved_had_ts7057;
         self.ctx.exit_function_like_control_flow(saved_cf_context);
         yield_snapshot.rollback(&mut self.ctx.speculation_state());
+        self.ctx.checked_classes = saved_checked_classes;
         InferredGeneratorYield {
             yield_type: final_yield,
             delegated_next_type,


### PR DESCRIPTION
When a class declaration is nested anywhere in an **unannotated** generator's
body, `tsc` checks its members and reports their diagnostics; `tsz` was
silently dropping all of them.

`infer_generator_declaration_yield_type`
(`crates/tsz-checker/src/types/function_type/generator_declaration_yield.rs`)
runs a *suppressed* speculative pass over the generator body to recover its
inferred yield type — real body diagnostics are meant to come from the later
real declaration check. That pass walks the whole body, so any nested class it
reaches gets checked (with diagnostics rolled back) and left marked in
`ctx.checked_classes`. `checked_classes` is **not** part of the
`snapshot_return_type` speculation snapshot, so the rollback never cleared it;
the real pass then treated the class as "already checked"
(`check_class_declaration`'s early return) and skipped it — dropping every
diagnostic its members owe. Annotating the generator's return type disabled
the speculative pass and hid the bug.

The fix snapshots `checked_classes` across the speculative walk and restores it
past the rollback, so a class checked speculatively is re-checked for real. A
generator never draws its yield type from a nested class body (classes own
their own yields), so un-memoizing them costs the signature pass nothing.
`checking_classes` needs no snapshot: `check_class_declaration` balances it
(every insert has a matching remove), so a completed pass leaves it untouched.

Fixes #16839.

## Goal
Goal: hold

## Verification
Oracle: `tsc@5.9 --noEmit --strict --target es2022 --module esnext`, module file.

| case | source | tsc | tsz before | tsz after |
| --- | --- | --- | --- | --- |
| member body | `function* g(){ class C { m(): string { return 42; } } }` | TS2322 | (clean) | TS2322 |
| property | `function* g(){ class C { p: string = 42; } }` | TS2322 | (clean) | TS2322 |
| heritage | `function* g(){ class C extends 5 {} }` | TS2507 | (clean) | TS2507 |
| computed-name await | `function* g(){ class C { [await x](){} } }` | TS1308 | (clean) | TS1308 |
| computed-property yield | `function* g(){ class C { [yield 1] = 2; } }` | TS1166 | (clean) | TS1166 |
| async generator | `async function* g(){ class C { m(): string { return 42; } } }` | TS2322 | (clean) | TS2322 |
| nested fn/block | `function* g(){ function h(){ class C { m(): string { return 42; } } } }` | TS2322 | (clean) | TS2322 |
| annotated (control) | `function* g(): Generator<number> { class C { m(): string { return 42; } } }` | TS2322 | TS2322 | TS2322 |
| clean control | `function* g(){ class C { [yield 1](){} } }` | (clean) | (clean) | (clean) |

- Yield-type inference for unannotated generators is unchanged (verified a
  wrong-yield assignment still reports TS2322 and a class-in-body generator
  still infers its yield type).
- New regression suite `generator_nested_class_diagnostics_tests.rs` (11 cases,
  binder names varied) — passes.
- `cargo test -p tsz-checker --lib` targeted suites (`generator`, `yield`,
  `await`, `class_`, `function`, `computed`, `decorator`, `static_block`,
  `enum_`) — 2942 tests green, plus the 11 new.
- `cargo clippy -p tsz-checker --lib` — clean.
- Full CI (clippy + arch-size) via this PR.

## Provenance
Machine: cloud
Assistant: claude-code
Model: opus
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpRoAH1FPb747jJ7hWHjut)_