### PR TITLE
fix(solver): defer conditional when `keyof O[K]` extends reduces to an unmaterializable member interface (#15983)

### DIFF
--- a/crates/tsz-checker/tests/mapped_conditional_keyof_indexed_access_tests.rs
+++ b/crates/tsz-checker/tests/mapped_conditional_keyof_indexed_access_tests.rs
@@ -116,7 +116,7 @@ const ok: Pick2<'row'> = 'alpha'
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// The failing shape (ignored red signal).
+// The formerly-failing shape (now fixed; #15983 / #15396).
 // ──────────────────────────────────────────────────────────────────────────
 
 /// A generic mapped type whose conditional *check* is
@@ -127,12 +127,14 @@ const ok: Pick2<'row'> = 'alpha'
 /// Oracle (`tsc` 7.0.2, `--strict`): `FieldLookup<Store, 'row', 'kind'>` is
 /// `'alpha' | 'beta'`, so `const ok = 'alpha'` is accepted.
 ///
-/// tsz today collapses the member to `never` (the extends type
-/// `keyof Store['row']` is judged without materialising it), rejecting every
-/// value. Un-ignore when the unmaterialised-`keyof(IndexAccess(Lazy))` branch
-/// relation is fixed (#15396 family; driver row in #15983).
+/// Fixed by the materialize-or-defer gateway in the solver's conditional
+/// evaluator (`keyof_inner_is_unresolvable_lazy` now evaluates an `IndexAccess`
+/// inner): `Store['row']` reduces to the nested-only interface `StoreRow`, which
+/// that pure-solver evaluation context cannot materialise, so `keyof Store['row']`
+/// stays a deferred `KeyOf`. The conditional now defers instead of judging the
+/// branch against the un-materialised operand, so a later pass takes the true
+/// branch (#15983 / #15396).
 #[test]
-#[ignore = "keyof(IndexAccess(Lazy)) conditional check collapses to never inside a mapped body — #15983 / #15396"]
 fn mapped_conditional_keyof_mapped_key_check_resolves() {
     assert_resolves(
         r#"
@@ -152,7 +154,6 @@ const ok: Looked = 'alpha'
 /// concrete-literal `Tb` form. Oracle (`tsc` 7.0.2, `--strict`):
 /// `FieldLookup<Store, keyof Store, 'kind'>` is `'alpha' | 'beta'`.
 #[test]
-#[ignore = "keyof(IndexAccess(Lazy)) conditional check collapses to never inside a mapped body — #15983 / #15396"]
 fn mapped_conditional_keyof_mapped_key_check_keyof_arg_resolves() {
     assert_resolves(
         r#"
@@ -164,5 +165,51 @@ type Looked = FieldLookup<Store, keyof Store, 'kind'>
 const ok: Looked = 'alpha'
 "#,
         "FieldLookup<Store, keyof Store, 'kind'> must resolve to 'alpha' | 'beta', not never",
+    );
+}
+
+/// Binder-name independence (`.claude/CLAUDE.md` §25): the fix must key on the
+/// structural shape, not on the `Store`/`StoreRow`/`FieldLookup` identifiers.
+/// Renaming every binder — and reordering the type parameters — still resolves.
+#[test]
+fn mapped_conditional_keyof_renamed_binders_resolves() {
+    assert_resolves(
+        r#"
+interface Cell { label: string; tag: 'x' | 'y' }
+interface Grid { cell: Cell }
+type Pluck<Key, Tbl extends keyof Db2, Db2> =
+  { [Q in Tbl]: Key extends keyof Db2[Q] ? Db2[Q][Key] : never }[Tbl]
+type Got = Pluck<'tag', 'cell', Grid>
+const ok: Got = 'x'
+const ok2: Got = 'y'
+"#,
+        "renamed FieldLookup with reordered params must still resolve to 'x' | 'y'",
+    );
+}
+
+/// Negative control: a genuinely-absent member must still take the *false*
+/// branch and yield `never`, so the deferral fix does not over-accept. Oracle
+/// (`tsc` 7.0.2, `--strict`): `FieldLookup<Store, 'row', 'nope'>` is `never`, so
+/// `const bad: Looked = 'alpha'` is a `TS2322`.
+#[test]
+fn mapped_conditional_keyof_absent_member_stays_never() {
+    let codes: Vec<u32> = check_source_strict(
+        r#"
+interface StoreRow { title: string; kind: 'alpha' | 'beta' }
+interface Store { row: StoreRow }
+type FieldLookup<Db, Tb extends keyof Db, Name> =
+  { [P in Tb]: Name extends keyof Db[P] ? Db[P][Name] : never }[Tb]
+type Looked = FieldLookup<Store, 'row', 'nope'>
+const bad: Looked = 'alpha'
+"#,
+    )
+    .iter()
+    .map(|d| d.code)
+    .filter(|&c| c == 2322)
+    .collect();
+    assert_eq!(
+        codes,
+        vec![2322],
+        "an absent member must collapse to never and reject the assignment (TS2322)"
     );
 }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
@@ -253,7 +253,21 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     }
 
     /// True when `ty` is — or a union/intersection member of `ty` is — a
-    /// `Lazy(DefId)` the resolver returns `None` for (cannot expand).
+    /// `Lazy(DefId)` the resolver returns `None` for (cannot expand), or a
+    /// meta-operation (`IndexAccess`/`Application`) that *reduces* to such a
+    /// `Lazy`.
+    ///
+    /// The `IndexAccess`/`Application` arm covers `keyof Obj["k"]`: the operand
+    /// `Obj["k"]` is not itself a `Lazy`, but reducing it can yield a member
+    /// interface (`Obj`'s `"k"` property type) that the current resolver cannot
+    /// materialize — a nested-only interface no use site independently requested,
+    /// so it lives only as an unregistered `Lazy(DefId)` in this evaluation
+    /// context. Without evaluating the operand the `keyof` reads as reducible and
+    /// the branch relation commits a schedule-dependent `false`, collapsing a
+    /// mapped member to `never` (#15983 / #15396). Evaluation is memoized (the
+    /// enclosing `resolve_operands` already reduced this operand), and the
+    /// `evaluated != ty` productivity guard plus the depth bound keep a
+    /// non-reducing self-map from recursing.
     fn keyof_inner_is_unresolvable_lazy(&mut self, ty: TypeId, depth: u32) -> bool {
         match unresolvable_keyof_lazy_depth_state(depth) {
             UnresolvableKeyofLazyDepthState::Continue => {}
@@ -269,6 +283,10 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 members
                     .iter()
                     .any(|&m| self.keyof_inner_is_unresolvable_lazy(m, depth + 1))
+            }
+            Some(TypeData::IndexAccess(_, _) | TypeData::Application(_)) => {
+                let evaluated = self.evaluate(ty);
+                evaluated != ty && self.keyof_inner_is_unresolvable_lazy(evaluated, depth + 1)
             }
             _ => false,
         }


### PR DESCRIPTION
## Summary

Fixes the root cause behind the `tsz-cli` driver row
`cross_file_dependent_operand_aliases_accept_scalars_and_literal_arrays`
and the two ignored pinned rows in
`mapped_conditional_keyof_indexed_access_tests` (#15983).

A generic mapped/conditional alias body

```ts
type FieldLookup<Db, Tb extends keyof Db, Name> =
  { [P in Tb]: Name extends keyof Db[P] ? Db[P][Name] : never }[Tb]
```

collapsed to `never`. When evaluated in a pure-solver context (alias-body
lowering, not a checker-driven use site), `keyof Store["row"]`'s operand
`Store["row"]` reduces to the **nested-only interface `StoreRow`** — a type no
use site independently requested, so its body was never materialised into
`symbol_types`/the type environments and is an unregistered `Lazy(DefId)` the
solver resolver returns `None` for. The `keyof` therefore stayed a deferred
`KeyOf`, and the conditional's branch relation judged
`Name extends <deferred keyof>` as **false**, collapsing the member to `never`
and rejecting every valid value with a spurious `TS2322`/`TS2345`.

## Structural rule

When a conditional's `extends` type is `keyof X` and `X` reduces to a
`Lazy(DefId)` the current resolver cannot expand, `tsc` keeps the conditional
pending until the reference resolves. tsz must **defer** rather than commit a
schedule-dependent false branch. Owner: the solver's conditional branch
relation (the #15396 materialize-or-defer family).

## Fix (owner layer: solver)

`evaluate_conditional` already defers when either operand hides part of its key
space behind an unresolvable `keyof Lazy(D)`, via
`relation_has_unresolvable_keyof_lazy` → `keyof_inner_is_unresolvable_lazy`
(#14337). That helper handled `keyof Lazy` and `keyof (A | Lazy)` but **not**
`keyof O[K]`, whose inner is an `IndexAccess`, not a bare `Lazy`.

The one-arm change teaches `keyof_inner_is_unresolvable_lazy` to *evaluate* an
`IndexAccess`/`Application` inner and re-test the reduced result. The existing
deferral then fires — no new decision site, and the check-side and
union-member cases are covered by the same reused walk. An `evaluated != ty`
productivity guard plus the existing depth bound prevent non-reducing
self-maps from recursing.

This was chosen over a standalone extends-side guard (the first draft) after a
reuse/altitude review flagged that the existing helper already models exactly
this class one decision layer up.

## Adjacent-case matrix

Un-ignored the two pinned failing rows and added:
- **renamed binders + reordered type params** (`Cell`/`Grid`/`Pluck`) — the fix
  keys on structure, not identifiers (`.claude/CLAUDE.md` §25).
- **negative control**: a genuinely-absent member (`FieldLookup<Store,'row','nope'>`)
  must still take the false branch and yield `never` (asserts the `TS2322`), so
  the deferral does not over-accept.

The existing passing controls (plain-type-param check, mapped value, conditional
check without the mapped-key `keyof`) remain green as regression fences.

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-checker --test mapped_conditional_keyof_indexed_access_tests --run-ignored all`
  → **8 passed** (was 4 passed + 2 ignored-red before).
- Minimal single-file repro + a two-alias repro (Probe control + FieldLookup):
  both `--noEmit --strict` clean (were `TS2322 Type '"alpha"' is not assignable to type 'never'`).
- `tsz-cli::driver_tests::cross_file_dependent_operand_aliases_accept_scalars_and_literal_arrays`:
  the code/position assertion now passes — the three deliberately-invalid
  operands are the only diagnostics (2345 @ 507/547/630) and the valid scalar
  and literal-array operands are accepted. A residual **display-only** parity
  gap remains on the `title` error path (its target renders the expanded
  `InputValueOrList` union instead of the `DependentOperand<…>` alias), so the
  row stays in `known-failures.txt`; that alias-preservation nuance is separate
  from the never-collapse root cause fixed here.
- `clippy` + `arch-size` — the per-merge CI gate — pass **on CI** (CI Summary: success)
  and locally via the commit hook.
- Conformance: `./scripts/conformance/conformance.sh run --workers 12` (auto-diff vs
  baseline) running locally against this branch; the change is narrow (a `keyof O[K]`
  extends type reducing to an unregistered member-interface `Lazy`), so no
  single-file conformance rows are expected to move. Result appended in a comment
  once the run completes.

## Provenance
Machine: cloud
Assistant: claude-code
Model: Opus 4.8
Effort: high