### PR TITLE
fix(checker): TS2662 static member-prefix suggestion is value-position only in the resolved-symbol path too (completes #16840)

### DIFF
--- a/crates/tsz-checker/src/types/computation/identifier/resolved.rs
+++ b/crates/tsz-checker/src/types/computation/identifier/resolved.rs
@@ -461,6 +461,20 @@ impl CheckerState<'_> {
                 // emitting TS2662.
                 return Some(self.get_type_of_symbol(outer_sym_id));
             }
+            // The `TS2662` suggestion is value-position only (#16840, the
+            // residual #16844 deferred). A static member is placed in class
+            // scope by tsz's binder but is not in tsc's value scope chain, so a
+            // type-position `typeof StaticName` never reaches
+            // `checkAndReportErrorForMissingPrefix` — tsc reports the bare
+            // `TS2304`. Route it back to the shared not-found boundary instead
+            // of offering the `Class.member` suggestion. `is_in_type_query` is
+            // the same purely-syntactic marker #16844 applied on the
+            // unresolved-name path, so the two resolution passes agree.
+            if self.is_in_type_query(idx) {
+                use crate::query_boundaries::name_resolution::NameLookupKind;
+                self.report_not_found_at_boundary(name, idx, NameLookupKind::Value);
+                return Some(TypeId::ERROR);
+            }
             // Get the class name from the symbol's parent for the error message
             let class_name = if let Some(parent_sym) = self.ctx.binder.get_symbol(
                 self.ctx

--- a/crates/tsz-checker/tests/missing_prefix_member_suggestion_tests.rs
+++ b/crates/tsz-checker/tests/missing_prefix_member_suggestion_tests.rs
@@ -242,16 +242,17 @@ fn return_type_annotation_produces_no_suggestion() {
 }
 
 #[test]
-#[ignore = "known divergence (#16840, pre-existing and older than #16834): a \
-            *declared static* named in a type position still reports TS2662 \
-            where tsc reports the bare TS2304. That name binds to a real \
-            symbol, so it never reaches resolve_truly_unknown_identifier — it \
-            is emitted from the resolved-symbol paths in \
-            types/computation/identifier/resolved.rs and \
-            types/computation/helpers.rs, which need the same value-position \
-            guard applied at their own sites"]
 fn a_static_member_in_a_type_position_produces_no_suggestion() {
     let libs = load_default_lib_files();
+    // The residual #16844 deferred (#16840): a *declared static* named in a
+    // type position binds to a real symbol, so it never reaches
+    // `resolve_truly_unknown_identifier` — the `TS2662` came from the
+    // resolved-symbol arm in `types/computation/identifier/resolved.rs`. That
+    // arm now applies the same `is_in_type_query` value-position guard, so a
+    // `typeof s` in a type annotation reports the bare `TS2304`. (The sibling
+    // static arm in `types/computation/helpers.rs` fires only for an
+    // assignment *target* — the LHS of `=` — which a `typeof` operand can
+    // never be, so it needs no guard.)
     assert_suggestions(
         "class C { static s: number = 1; b: typeof s = 1 as any; }",
         &libs,


### PR DESCRIPTION
Fixes #16840. Follow-up to #16844.

#16844 fixed the member-prefix suggestion (`TS2662`/`TS2663`) leaking into type positions on the **unresolved-name** path (`resolve_truly_unknown_identifier`) but **explicitly deferred** the resolved-symbol case, landing an `#[ignore]`d test that named the exact remaining site:

> a *declared static* named in a type position still reports `TS2662` where tsc reports the bare `TS2304`. That name binds to a real symbol, so it never reaches `resolve_truly_unknown_identifier` — it is emitted from the resolved-symbol paths in `types/computation/identifier/resolved.rs` and `types/computation/helpers.rs`, which need the same value-position guard applied at their own sites.

This PR completes that.

### Structural rule
When an unresolved value name appears in a **type** position — the operand of a `typeof` type query — tsc reports the bare `TS2304` even when the name matches an enclosing-class member; the member-prefix suggestion is reachable only from `checkIdentifier` (the value path). A **declared static** binds to a real symbol, so it never reaches the unresolved-name path #16844 guarded — its `TS2662` is emitted from the resolved-symbol arm in `resolved.rs`. tsz's binder places the static in class scope, but tsc's value scope chain does not, so a type-position `typeof StaticName` must route back to the shared not-found boundary (bare `TS2304`) instead of offering the `Class.member` suggestion.

### Owner layer / fix
- `crates/tsz-checker/src/types/computation/identifier/resolved.rs` — gate the static-member `TS2662` arm with the same purely-syntactic `is_in_type_query` marker #16844 introduced, then route through the shared `report_not_found_at_boundary` (bare `TS2304`). Being syntactic, it answers identically during the statement walk and on-demand class-type computation, preserving the one-diagnostic-per-site property.
- The sibling static arm in `types/computation/helpers.rs` needs **no** guard: it fires only from `get_type_of_assignment_target` (the LHS of `=`), which a `typeof` operand can never be. Documented in the test.

No new predicate added — reuses #16844's `is_in_type_query` and the existing `report_not_found_at_boundary`.

### Verification
- `cargo test -p tsz-checker --test missing_prefix_member_suggestion_tests` — 16/16 pass, **0 ignored** (un-ignores `a_static_member_in_a_type_position_produces_no_suggestion`; the value-position control `a_static_member_in_a_value_position_still_suggests` guards against over-correcting).
- End-to-end vs pinned tsc 7.0.2 oracle (`--strict --lib es2022 --target es2022`):
  - `class C { static s: number = 1; b: typeof s = 1 as any; }` → `TS2304` ✓ (was `TS2662`)
  - `class D { static s = 1; m() { return s; } }` → `TS2662` ✓ (value position preserved)
- Pre-commit gate: clippy + architecture-size guard + local verification (`-p tsz-checker`) passed.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high