### PR TITLE
fix(checker): suppress TS4112/TS4113/TS4127 when an override member also has declare

### DIFF
--- a/crates/tsz-checker/src/classes/class_chain_lookup.rs
+++ b/crates/tsz-checker/src/classes/class_chain_lookup.rs
@@ -103,6 +103,7 @@ impl<'a> CheckerState<'a> {
                                 has_dynamic_name: false,
                                 has_computed_non_literal_name: false,
                                 from_interface: false,
+                                has_declare: false,
                             };
                             return Some(info);
                         }

--- a/crates/tsz-checker/src/classes/class_checker.rs
+++ b/crates/tsz-checker/src/classes/class_checker.rs
@@ -73,44 +73,10 @@ pub(crate) const fn base_class_name_for_diagnostic(name: &str) -> Cow<'_, str> {
     Cow::Borrowed(name)
 }
 
-/// Extracted info about a single class member (property, method, or accessor).
-#[derive(Clone)]
-pub(crate) struct ClassMemberInfo {
-    pub(crate) name: String,
-    pub(crate) type_id: TypeId,
-    pub(crate) name_idx: NodeIndex,
-    pub(crate) visibility: MemberVisibility,
-    pub(crate) is_method: bool,
-    pub(crate) is_static: bool,
-    pub(crate) is_accessor: bool,
-    /// True when this entry comes from a `SET_ACCESSOR` declaration (always
-    /// implies `is_accessor`). Used to recognize the setter half of an accessor
-    /// pair: tsc treats an accessor pair as one property whose type is the
-    /// getter return type, so override-compat (TS2416/TS2417) must run once
-    /// per pair instead of independently on the setter parameter type.
-    pub(crate) is_setter: bool,
-    pub(crate) is_abstract: bool,
-    pub(crate) has_override: bool,
-    /// True when `override` comes from a JSDoc `@override` tag (not the keyword).
-    /// Used to emit TS4118-4123 (JSDoc variants) instead of TS4112-4117.
-    pub(crate) is_jsdoc_override: bool,
-    pub(crate) has_dynamic_name: bool,
-    /// True when the member name is a computed property whose expression is NOT
-    /// a direct string/number literal. tsc uses this (`isComputedNonLiteralName`)
-    /// to skip `noImplicitOverride` checks for computed names like `[someVar]`.
-    pub(crate) has_computed_non_literal_name: bool,
-    /// True when the member comes from a merged interface declaration (not a class
-    /// property declaration). Used to skip TS2610/TS2611 accessor/property mismatch
-    /// checks, since interface-sourced members can be freely overridden by accessors.
-    pub(crate) from_interface: bool,
-}
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub(crate) enum MemberVisibility {
-    Public,
-    Protected,
-    Private,
-}
+// `ClassMemberInfo` and `MemberVisibility` live in `class_member_info.rs`
+// (re-exported here so existing `crate::class_checker::` paths keep working)
+// to keep this file under the 2000-line split threshold.
+pub(crate) use crate::classes_domain::class_member_info::{ClassMemberInfo, MemberVisibility};
 
 /// Build the elaboration line tsc appends to TS2415 (class incorrectly extends
 /// base class) when the conflict is purely a visibility/branding mismatch on a
@@ -854,6 +820,11 @@ impl<'a> CheckerState<'a> {
                     .lookup(&member_name, is_static, true)
                     .cloned()
             };
+
+            // `override`+`declare` is TS1040 alone in `tsc`; skip the checks below.
+            if has_override && info.has_declare {
+                continue;
+            }
 
             if has_override {
                 // Cannot use `override` when name is computed dynamically.

--- a/crates/tsz-checker/src/classes/class_member_info.rs
+++ b/crates/tsz-checker/src/classes/class_member_info.rs
@@ -2,10 +2,7 @@
 
 use std::borrow::Cow;
 
-use crate::class_checker::{
-    ClassMemberInfo, MemberVisibility, base_class_name_for_diagnostic,
-    format_property_name_for_diagnostic,
-};
+use crate::class_checker::{base_class_name_for_diagnostic, format_property_name_for_diagnostic};
 use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
 use crate::query_boundaries::class::{
     should_report_member_type_mismatch_bivariant, should_report_own_member_type_mismatch,
@@ -16,6 +13,48 @@ use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
+
+/// Extracted info about a single class member (property, method, or accessor).
+#[derive(Clone)]
+pub(crate) struct ClassMemberInfo {
+    pub(crate) name: String,
+    pub(crate) type_id: TypeId,
+    pub(crate) name_idx: NodeIndex,
+    pub(crate) visibility: MemberVisibility,
+    pub(crate) is_method: bool,
+    pub(crate) is_static: bool,
+    pub(crate) is_accessor: bool,
+    /// True when this entry comes from a `SET_ACCESSOR` declaration (always
+    /// implies `is_accessor`). Used to recognize the setter half of an accessor
+    /// pair: tsc treats an accessor pair as one property whose type is the
+    /// getter return type, so override-compat (TS2416/TS2417) must run once
+    /// per pair instead of independently on the setter parameter type.
+    pub(crate) is_setter: bool,
+    pub(crate) is_abstract: bool,
+    pub(crate) has_override: bool,
+    /// True when `override` comes from a JSDoc `@override` tag (not the keyword).
+    /// Used to emit TS4118-4123 (JSDoc variants) instead of TS4112-4117.
+    pub(crate) is_jsdoc_override: bool,
+    /// `override`+`declare` together get `tsc`'s TS1040 alone; other override
+    /// checks must not also fire.
+    pub(crate) has_declare: bool,
+    pub(crate) has_dynamic_name: bool,
+    /// True when the member name is a computed property whose expression is NOT
+    /// a direct string/number literal. tsc uses this (`isComputedNonLiteralName`)
+    /// to skip `noImplicitOverride` checks for computed names like `[someVar]`.
+    pub(crate) has_computed_non_literal_name: bool,
+    /// True when the member comes from a merged interface declaration (not a class
+    /// property declaration). Used to skip TS2610/TS2611 accessor/property mismatch
+    /// checks, since interface-sourced members can be freely overridden by accessors.
+    pub(crate) from_interface: bool,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MemberVisibility {
+    Public,
+    Protected,
+    Private,
+}
 
 impl<'a> CheckerState<'a> {
     /// Determine if a class member name is dynamic (e.g. `[foo]` or computed expressions),
@@ -303,6 +342,13 @@ impl<'a> CheckerState<'a> {
                 } else {
                     base_instance_member_names.contains(&info.name)
                 }) || member_exists_via_type);
+
+            // See the matching guard in `check_property_inheritance_compatibility`:
+            // `override`+`declare` on one member is always TS1040 alone in `tsc`,
+            // which never also runs the override-legality checks for it.
+            if info.has_override && info.has_declare {
+                continue;
+            }
 
             if info.has_dynamic_name {
                 if info.has_override {
@@ -679,6 +725,14 @@ impl<'a> CheckerState<'a> {
             if !info.has_override {
                 continue;
             }
+            // See the matching guard in `check_property_inheritance_compatibility`:
+            // `override`+`declare` on one member is always TS1040 alone in `tsc`,
+            // which never also runs the override-legality checks for it — not even
+            // TS4112 ("does not extend another class"), the one this function exists
+            // to report.
+            if info.has_declare {
+                continue;
+            }
             if info.has_dynamic_name {
                 self.error_at_node(
                     info.name_idx,
@@ -825,6 +879,7 @@ impl<'a> CheckerState<'a> {
                     has_dynamic_name: self.is_computed_name_dynamic(prop.name),
                     has_computed_non_literal_name: self.is_computed_non_literal_name(prop.name),
                     from_interface: false,
+                    has_declare: self.has_declare_modifier(&prop.modifiers),
                 })
             }
             k if k == syntax_kind_ext::METHOD_DECLARATION => {
@@ -861,6 +916,7 @@ impl<'a> CheckerState<'a> {
                                     has_dynamic_name: true,
                                     has_computed_non_literal_name: true,
                                     from_interface: false,
+                                    has_declare: self.has_declare_modifier(&method.modifiers),
                                 });
                             }
                             return None;
@@ -899,6 +955,7 @@ impl<'a> CheckerState<'a> {
                     has_dynamic_name: self.is_computed_name_dynamic(method.name),
                     has_computed_non_literal_name: self.is_computed_non_literal_name(method.name),
                     from_interface: false,
+                    has_declare: self.has_declare_modifier(&method.modifiers),
                 })
             }
             k if k == syntax_kind_ext::GET_ACCESSOR => {
@@ -944,6 +1001,7 @@ impl<'a> CheckerState<'a> {
                     has_dynamic_name: self.is_computed_name_dynamic(accessor.name),
                     has_computed_non_literal_name: self.is_computed_non_literal_name(accessor.name),
                     from_interface: false,
+                    has_declare: self.has_declare_modifier(&accessor.modifiers),
                 })
             }
             k if k == syntax_kind_ext::SET_ACCESSOR => {
@@ -996,6 +1054,7 @@ impl<'a> CheckerState<'a> {
                     has_dynamic_name: self.is_computed_name_dynamic(accessor.name),
                     has_computed_non_literal_name: self.is_computed_non_literal_name(accessor.name),
                     from_interface: false,
+                    has_declare: self.has_declare_modifier(&accessor.modifiers),
                 })
             }
             _ => None,

--- a/crates/tsz-checker/src/classes/class_summary.rs
+++ b/crates/tsz-checker/src/classes/class_summary.rs
@@ -1387,6 +1387,7 @@ impl<'a> CheckerState<'a> {
             has_dynamic_name: false,
             has_computed_non_literal_name: false,
             from_interface: false,
+            has_declare: false,
         })
     }
 
@@ -1503,6 +1504,7 @@ impl<'a> CheckerState<'a> {
             has_dynamic_name: false,
             has_computed_non_literal_name: false,
             from_interface: true,
+            has_declare: false,
         };
         let is_visible = visibility != crate::class_checker::MemberVisibility::Private;
         Self::record_unified_member(info, is_visible, summary, self);
@@ -1682,6 +1684,7 @@ impl<'a> CheckerState<'a> {
                 has_dynamic_name: false,
                 has_computed_non_literal_name: false,
                 from_interface: false,
+                has_declare: false,
             },
             display_name,
             kind,

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -743,6 +743,8 @@ mod overload_union_context_callback_tests;
 mod overloaded_callable_param_no_implicit_any_tests;
 #[path = "tests/overloaded_contextual_rest_tuple_tests.rs"]
 mod overloaded_contextual_rest_tuple_tests;
+#[path = "tests/override_declare_member_ambient_grammar_tests.rs"]
+mod override_declare_member_ambient_grammar_tests;
 #[path = "tests/override_incompatibility_elaboration_tests.rs"]
 mod override_incompatibility_elaboration_tests;
 #[path = "tests/parameter_checker_tests.rs"]

--- a/crates/tsz-checker/src/tests/override_declare_member_ambient_grammar_tests.rs
+++ b/crates/tsz-checker/src/tests/override_declare_member_ambient_grammar_tests.rs
@@ -1,0 +1,248 @@
+//! Regression tests: a class member that combines `override` with `declare`
+//! (member-level ambient, independent of whether the *class* is ambient) must
+//! report `tsc`'s TS1040 ("'override' modifier cannot be used in an ambient
+//! context.") alone — never also one of the semantic override-legality
+//! diagnostics (TS4112 "does not extend another class", TS4113 "not declared
+//! in the base class", TS4117 "did you mean", TS4127 "name is dynamic").
+//!
+//! Verified against `typescript@7.0.2`: `checkGrammarModifiers` reports TS1040
+//! for the `override`+`declare` combination on a single member — in *either*
+//! source order — and once that grammar error has fired for the member, `tsc`
+//! never runs its separate semantic override-validity checks on it. This is
+//! true regardless of whether the class extends a base, whether the base
+//! declares the member by that name, whether the member's name is dynamic, or
+//! whether the *enclosing class* is itself ambient (`declare class`) — the
+//! class-level ambient gate in `no_implicit_override_ambient_context_tests.rs`
+//! is a different, narrower mechanism (it only suppresses the *implicit*
+//! TS4114 requirement) and does not by itself explain this suppression: a
+//! `declare class` whose member has `override` but NOT `declare` still
+//! reports TS4113 normally (see that file's negative controls).
+//!
+//! tsz previously computed TS1040 in the parser and TS4112/TS4113 in the
+//! checker as two independent diagnostic sources with no shared "already
+//! flagged" state, so both fired for the same member.
+
+use crate::test_utils::check_source_with_parse_health;
+
+const TS1031_DECLARE_MODIFIER_WRONG_KIND: u32 = 1031;
+const TS1040_MODIFIER_CANNOT_BE_USED_IN_AMBIENT_CONTEXT: u32 = 1040;
+const TS4112_CANNOT_HAVE_OVERRIDE_NO_BASE: u32 = 4112;
+const TS4113_CANNOT_HAVE_OVERRIDE_NOT_IN_BASE: u32 = 4113;
+
+// ---------------------------------------------------------------------------
+// Positive: `override declare` on a member suppresses every override-legality
+// checker diagnostic, leaving only the parser's TS1040.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn override_declare_member_no_base_reports_only_ts1040() {
+    let (parse_codes, checker_codes) = check_source_with_parse_health(
+        r"
+class Solo {
+  override declare m(): void;
+}
+",
+    );
+    assert_eq!(
+        parse_codes,
+        vec![TS1040_MODIFIER_CANNOT_BE_USED_IN_AMBIENT_CONTEXT],
+        "parser side: got {parse_codes:?}"
+    );
+    assert!(
+        checker_codes.is_empty(),
+        "TS4112 must not also fire once the member's own `declare` has already \
+         been flagged with TS1040, got: {checker_codes:?}"
+    );
+}
+
+#[test]
+fn override_declare_member_matching_base_reports_only_ts1040() {
+    let (parse_codes, checker_codes) = check_source_with_parse_health(
+        r"
+class Base {
+  m(): void {}
+}
+class Derived extends Base {
+  override declare m(): void;
+}
+",
+    );
+    assert_eq!(
+        parse_codes,
+        vec![TS1040_MODIFIER_CANNOT_BE_USED_IN_AMBIENT_CONTEXT],
+        "parser side: got {parse_codes:?}"
+    );
+    assert!(
+        checker_codes.is_empty(),
+        "a `declare`d member is exempt from the override-legality checks even \
+         when it happens to match a base member, got: {checker_codes:?}"
+    );
+}
+
+#[test]
+fn override_declare_member_not_in_base_reports_only_ts1040() {
+    let (parse_codes, checker_codes) = check_source_with_parse_health(
+        r"
+class Base {
+  m(): void {}
+}
+class Derived extends Base {
+  override declare notInBase(): void;
+}
+",
+    );
+    assert_eq!(
+        parse_codes,
+        vec![TS1040_MODIFIER_CANNOT_BE_USED_IN_AMBIENT_CONTEXT],
+        "parser side: got {parse_codes:?}"
+    );
+    assert!(
+        !checker_codes.contains(&TS4113_CANNOT_HAVE_OVERRIDE_NOT_IN_BASE),
+        "TS4113 must not also fire once the member's own `declare` has already \
+         been flagged with TS1040, got: {checker_codes:?}"
+    );
+}
+
+#[test]
+fn override_declare_member_dynamic_name_reports_only_ts1040() {
+    let (parse_codes, checker_codes) = check_source_with_parse_health(
+        r"
+declare const key: unique symbol;
+class Solo {
+  override declare [key](): void;
+}
+",
+    );
+    assert_eq!(
+        parse_codes,
+        vec![TS1040_MODIFIER_CANNOT_BE_USED_IN_AMBIENT_CONTEXT],
+        "parser side: got {parse_codes:?}"
+    );
+    assert!(
+        checker_codes.is_empty(),
+        "TS4127 (dynamic name) must not also fire once the member's own \
+         `declare` has already been flagged with TS1040, got: {checker_codes:?}"
+    );
+}
+
+/// Reversed modifier order: `tsc`'s grammar walk hits `declare` first (an
+/// illegal modifier on a bodyless, non-abstract, non-ambient-class method) and
+/// reports TS1031 alone (oracle-verified against `typescript@7.0.2`) — a
+/// different code than the `override`-first order, but the same suppression
+/// of the semantic override checks applies. tsz's parser currently reports
+/// TS1031 *and* TS1040 together for this ordering (a separate, pre-existing
+/// parser-grammar gap unrelated to this fix — real `tsc` stops at the first
+/// grammar error per member, tsz's `state_statements_class_members.rs` walk
+/// does not for this specific pair); only the checker side is asserted here
+/// since that is this fix's contract.
+#[test]
+fn declare_override_member_reversed_order_no_base_checker_side_is_clean() {
+    let (parse_codes, checker_codes) = check_source_with_parse_health(
+        r"
+class Solo {
+  declare override m(): void;
+}
+",
+    );
+    assert!(
+        parse_codes.contains(&TS1031_DECLARE_MODIFIER_WRONG_KIND),
+        "parser side: got {parse_codes:?}"
+    );
+    assert!(
+        checker_codes.is_empty(),
+        "TS4112 must not also fire regardless of which grammar diagnostic the \
+         member's `declare` produced, got: {checker_codes:?}"
+    );
+}
+
+/// Ambient class control: the suppression is driven by the *member's own*
+/// `declare`, not derived from the class already being ambient — a `declare
+/// class` reports the same lone TS1040 for an `override declare` member.
+#[test]
+fn override_declare_member_in_declare_class_reports_only_ts1040() {
+    let (parse_codes, checker_codes) = check_source_with_parse_health(
+        r"
+declare class Base {
+  m(): void;
+}
+declare class Derived extends Base {
+  override declare notInBase(): void;
+}
+",
+    );
+    assert_eq!(
+        parse_codes,
+        vec![TS1040_MODIFIER_CANNOT_BE_USED_IN_AMBIENT_CONTEXT],
+        "parser side: got {parse_codes:?}"
+    );
+    assert!(
+        !checker_codes.contains(&TS4113_CANNOT_HAVE_OVERRIDE_NOT_IN_BASE),
+        "got: {checker_codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls: `override` WITHOUT `declare` must keep reporting the
+// semantic checks normally — this is the boundary the fix must not cross.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn override_without_declare_no_base_still_reports_ts4112() {
+    let (parse_codes, checker_codes) = check_source_with_parse_health(
+        r"
+class Solo {
+  override m(): void {}
+}
+",
+    );
+    assert!(parse_codes.is_empty(), "got: {parse_codes:?}");
+    assert_eq!(
+        checker_codes,
+        vec![TS4112_CANNOT_HAVE_OVERRIDE_NO_BASE],
+        "a plain `override` (no `declare`) with no base class must still \
+         report TS4112, got: {checker_codes:?}"
+    );
+}
+
+#[test]
+fn override_without_declare_not_in_base_still_reports_ts4113() {
+    let (parse_codes, checker_codes) = check_source_with_parse_health(
+        r"
+class Base {
+  m(): void {}
+}
+class Derived extends Base {
+  override notInBase(): void {}
+}
+",
+    );
+    assert!(parse_codes.is_empty(), "got: {parse_codes:?}");
+    assert_eq!(
+        checker_codes,
+        vec![TS4113_CANNOT_HAVE_OVERRIDE_NOT_IN_BASE],
+        "a plain `override` (no `declare`) not declared in the base must \
+         still report TS4113, got: {checker_codes:?}"
+    );
+}
+
+/// A renamed-binder control: the rule is structural (member modifier
+/// combination), not name-driven.
+#[test]
+fn override_declare_member_renamed_binders_reports_only_ts1040() {
+    let (parse_codes, checker_codes) = check_source_with_parse_health(
+        r"
+class Wombat {
+  flurble(): void {}
+}
+class Grommet extends Wombat {
+  override declare flurble(): void;
+}
+",
+    );
+    assert_eq!(
+        parse_codes,
+        vec![TS1040_MODIFIER_CANNOT_BE_USED_IN_AMBIENT_CONTEXT],
+        "parser side: got {parse_codes:?}"
+    );
+    assert!(checker_codes.is_empty(), "got: {checker_codes:?}");
+}


### PR DESCRIPTION
## Goal
Goal: hold

**Structural rule:** When a class member's modifier list combines `override` with `declare` (member-level ambient, independent of whether the *class* is ambient), `tsc` reports TS1040 ("'override' modifier cannot be used in an ambient context") alone and never also runs its semantic override-legality checks on that member — not TS4112 ("does not extend another class"), not TS4113 ("not declared in the base class")/TS4117 ("did you mean"), and not TS4127 (dynamic name). This holds in either modifier order (`override declare` → TS1040; `declare override` → TS1031, a different grammar diagnostic, but the same suppression), regardless of whether the class extends a base, whether the base actually declares the member, or whether the enclosing class is itself ambient (`declare class`).

tsz's parser already emits TS1040 correctly (`state_statements_class_members.rs`). But the checker's three override-legality call sites — `report_overrides_without_base`, `check_override_members_against_type`, and the inline heritage path in `check_property_inheritance_compatibility` (all in `crates/tsz-checker/src/classes/`) — are an independent diagnostic source from the parser with no shared "already flagged" state, so they also fired TS4112/TS4113/TS4127 for the same member tsc had already flagged with TS1040. Owner layer: checker (`crates/tsz-checker/src/classes/class_checker.rs`, `class_member_info.rs`).

Oracle-verified against `typescript@7.0.2`, 8 cases (see the new test file's doc comment for the full matrix): no-base, matching-base, not-in-base, dynamic-name, reversed modifier order, ambient-class control, and the two negative controls (`override` without `declare` still reports TS4112/TS4113 normally).

**Fix:** Added `ClassMemberInfo::has_declare` (computed via the existing `has_declare_modifier` helper at all 5 real extraction sites in `extract_class_member_info`; `false` at the other construction sites, which are parameter properties/merged-interface/JS-implicit members that can never carry `declare`). Gated all three override-checking call sites on `has_override && has_declare` → skip.

**Housekeeping:** Moved `ClassMemberInfo`/`MemberVisibility` from `class_checker.rs` into `class_member_info.rs` (re-exported so all existing `crate::class_checker::` paths are unchanged) — `class_checker.rs` was exactly 2000 lines before this change and the new field would have pushed it to 2024, over CLAUDE.md's 2000-line cap.

**Adjacent case found, deliberately left out of scope:** tsz's parser currently emits *both* TS1031 and TS1040 for the reversed order (`declare override m()`), where `tsc` emits TS1031 alone — a separate, pre-existing parser-grammar gap (tsc's `checkGrammarModifiers` stops at the first modifier error per member; this specific pair doesn't in tsz's parser walk). The new test (`declare_override_member_reversed_order_no_base_checker_side_is_clean`) only asserts the checker side is clean, per this PR's actual contract. Left as a NOTE on the coordination board for a future session.

## Verification
- New test file `crates/tsz-checker/src/tests/override_declare_member_ambient_grammar_tests.rs`: 9 tests, all pass — `cargo test -p tsz-checker --lib override_declare_member_ambient_grammar_tests`: 9/9.
- No regression in the existing override-modifier family: `cargo test -p tsz-checker --lib override`: 187/187 (includes `no_implicit_override_ambient_context_tests`, `override_incompatibility_elaboration_tests`, etc.).
- `cargo clippy -p tsz-checker --lib -- -D warnings`: clean.
- `cargo fmt -- --check`: clean.
- Pre-commit hook (clippy + arch-size + local verification for `-p tsz-checker`): passed.
- `git diff --name-only` touches only `crates/tsz-checker/src/**` (checker-internal diagnostic gating + a new unit test file) — no parser/emitter changes, so emit floors cannot move. This is a narrow modifier-combination pattern (`override`+`declare` on one class member) not expected to appear in the conformance corpus at meaningful scale; the oracle-pinned targeted matrix is the primary evidence for this fix, per the established pattern for this class of change (see coordination board's "Standing gotchas": zero corpus movement is the expected signature here, not a null result).
- Full `cargo test -p tsz-checker --lib` (10700+ tests) was still running at push time (known long tail per the coordination board); no failures observed in the targeted subset above. Will confirm the full run's result and report back if anything surfaces.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_012WDHxHpwJh4UArtchQWCQi)_