### PR TITLE
fix(checker): TS2662/TS2663 member-prefix suggestion for an inherited class member (#16815)

### DIFF
--- a/crates/tsz-checker/src/types/computation/identifier/resolution.rs
+++ b/crates/tsz-checker/src/types/computation/identifier/resolution.rs
@@ -402,6 +402,48 @@ impl<'a> CheckerState<'a> {
         )
     }
 
+    /// Whether a class in the `extends` chain *above* `class_idx` (its base
+    /// classes, not `class_idx` itself) declares a member named `name` that is
+    /// static when `want_static`, or instance otherwise. This extends the
+    /// member-prefix suggestion to inherited members — `class D extends C`
+    /// referencing `C`'s static `s` unqualified is `TS2662 'D.s'` in tsc, just
+    /// like an own static.
+    ///
+    /// Resolved purely from the AST heritage and binder symbol flags (via
+    /// [`Self::get_base_class_idx`] / [`Self::is_static_member`]) — never a
+    /// materialized constructor/instance type — so, like the own-member check,
+    /// it yields the identical answer in both the type-computation and
+    /// statement-walk passes and cannot desync into a double diagnostic. The
+    /// walk is cycle-guarded (an illegal `extends` cycle would otherwise loop).
+    fn base_chain_declares_member(
+        &self,
+        class_idx: NodeIndex,
+        name: &str,
+        want_static: bool,
+    ) -> bool {
+        let mut visited: rustc_hash::FxHashSet<NodeIndex> = rustc_hash::FxHashSet::default();
+        visited.insert(class_idx);
+        let mut current = class_idx;
+        while let Some(base) = self.get_base_class_idx(current) {
+            if !visited.insert(base) {
+                break;
+            }
+            if let Some(class) = self.ctx.arena.get_class_at(base) {
+                let members = &class.members.nodes;
+                let found = if want_static {
+                    self.is_static_member(members, name)
+                } else {
+                    self.is_instance_member(members, name)
+                };
+                if found {
+                    return true;
+                }
+            }
+            current = base;
+        }
+        false
+    }
+
     /// Handle a truly unresolved identifier — not a type parameter, not in the
     /// binder, not a known global. Emits the member-prefix suggestion
     /// (`TS2662`/`TS2663`), `TS2524`/`TS2523`, or falls through to the bare
@@ -432,23 +474,27 @@ impl<'a> CheckerState<'a> {
         if let Some(class_idx) = self.nearest_enclosing_class(idx)
             && let Some((member_nodes, class_name)) = self.class_members_and_name(class_idx)
         {
-            // Static (TS2662): a declared static, or a member of `Function`
-            // (`arguments`/`caller`/… — every constructor type is a subtype of
-            // `Function`). Checked before the instance arm, matching tsc.
+            // Static (TS2662): a declared static — own or inherited from a base
+            // class — or a member of `Function` (`arguments`/`caller`/… — every
+            // constructor type is a subtype of `Function`). Checked before the
+            // instance arm, matching tsc.
             if self.is_static_member(&member_nodes, name)
                 || self.global_function_type_has_member(name)
+                || self.base_chain_declares_member(class_idx, name, true)
             {
                 self.error_cannot_find_name_static_member_at(name, &class_name, idx);
                 return TypeId::ERROR;
             }
-            // Instance (TS2663): a declared instance member, in a non-static
-            // context (in a static member `this` is the constructor, so tsc
-            // reports the bare `TS2304`) with no regular-function boundary
-            // between the reference and the class (a function rebinds `this`, so
-            // `this.x` would not reach the class instance).
+            // Instance (TS2663): a declared instance member — own or inherited
+            // from a base class — in a non-static context (in a static member
+            // `this` is the constructor, so tsc reports the bare `TS2304`) with
+            // no regular-function boundary between the reference and the class (a
+            // function rebinds `this`, so `this.x` would not reach the class
+            // instance).
             if !self.is_in_static_class_member_context(idx)
                 && !self.has_regular_function_boundary_to_class(idx)
-                && self.is_instance_member(&member_nodes, name)
+                && (self.is_instance_member(&member_nodes, name)
+                    || self.base_chain_declares_member(class_idx, name, false))
             {
                 use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
                 let message = format_message(

--- a/crates/tsz-checker/tests/missing_prefix_member_suggestion_tests.rs
+++ b/crates/tsz-checker/tests/missing_prefix_member_suggestion_tests.rs
@@ -25,11 +25,13 @@
 //! `typescript@7.0.2` (`scripts/conformance/oracle.sh`) under `--strict --lib
 //! es2022 --target es2022`.
 //!
-//! Out of scope (a known limitation, not asserted here): a member inherited from
-//! a *base class* (`class Sub extends Base { p = baseStatic; }`) still gets a
-//! bare `TS2304` rather than the suggestion — resolving it needs the class's own
-//! (mid-computation) constructor/instance type, whose lookup is not stable across
-//! the two resolution passes and would reintroduce a duplicate diagnostic.
+//! A member inherited from a *base class* (`class Sub extends Base { p =
+//! baseStatic; }`) is suggested too. The `extends` chain is walked from the AST
+//! and the base classes' own members are read by binder symbol flags — never a
+//! materialized (mid-computation) constructor/instance type — so, like the
+//! own-member check, the answer is identical in both resolution passes and does
+//! not desync into a duplicate diagnostic. Lib/`node_modules` base classes,
+//! whose declarations are not walkable class AST nodes here, remain out of scope.
 
 use std::sync::Arc;
 use tsz_binder::lib_loader::LibFile;
@@ -132,6 +134,75 @@ fn own_instance_member_suggests_the_instance_member() {
         "class E { m() {} p = m; }",
         &libs,
         &["TS2663: Cannot find name 'm'. Did you mean the instance member 'this.m'?"],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Inherited members: a static/instance member declared on a base class is
+// suggested on the derived class, via the AST `extends` chain.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn inherited_static_member_suggests_the_derived_static_member() {
+    let libs = load_default_lib_files();
+    assert_suggestions(
+        "class Base { static bs = 1; } class Sub extends Base { p = bs; }",
+        &libs,
+        &["TS2662: Cannot find name 'bs'. Did you mean the static member 'Sub.bs'?"],
+    );
+}
+
+#[test]
+fn inherited_instance_member_suggests_the_derived_instance_member() {
+    let libs = load_default_lib_files();
+    assert_suggestions(
+        "class Base { bm() {} } class Sub extends Base { p = bm; }",
+        &libs,
+        &["TS2663: Cannot find name 'bm'. Did you mean the instance member 'this.bm'?"],
+    );
+}
+
+#[test]
+fn inherited_static_member_is_found_through_multiple_levels() {
+    let libs = load_default_lib_files();
+    // The walk follows the whole `extends` chain, not just the direct base.
+    assert_suggestions(
+        "class A { static as = 1; } class B extends A {} class Cc extends B { p = as; }",
+        &libs,
+        &["TS2662: Cannot find name 'as'. Did you mean the static member 'Cc.as'?"],
+    );
+}
+
+#[test]
+fn inherited_static_member_is_suggested_in_a_static_context() {
+    let libs = load_default_lib_files();
+    // A static member stays suggestable where `this` is the constructor.
+    assert_suggestions(
+        "class Base { static bs = 1; } class Sub extends Base { static p = bs; }",
+        &libs,
+        &["TS2662: Cannot find name 'bs'. Did you mean the static member 'Sub.bs'?"],
+    );
+}
+
+#[test]
+fn inherited_instance_member_from_a_static_context_produces_no_suggestion() {
+    let libs = load_default_lib_files();
+    // An inherited *instance* member is no more reachable from a static context
+    // than an own one — `this` is the constructor, so tsc reports a bare TS2304.
+    assert_suggestions(
+        "class Base { bm() {} } class Sub extends Base { static p = bm; }",
+        &libs,
+        &[],
+    );
+}
+
+#[test]
+fn inherited_suggestion_is_binder_name_invariant() {
+    let libs = load_default_lib_files();
+    assert_suggestions(
+        "class Vault { static token = 1; } class Client extends Vault { p = token; }",
+        &libs,
+        &["TS2662: Cannot find name 'token'. Did you mean the static member 'Client.token'?"],
     );
 }
 


### PR DESCRIPTION
Follow-up to #16834, which added tsc's `checkAndReportErrorForMissingPrefix`
suggestion (TS2662 `Class.name` / TS2663 `this.name`) for an unresolved
identifier inside a class, covering own members and the `Function`/`Object`
members every constructor type carries (`arguments`, `caller`, …). That fix left
one gap — its own test module documents it as out of scope: a member **inherited
from a base class** still fell back to a bare `TS2304`.

**Structural rule:** when an unresolved value identifier inside a class names a
member declared on the enclosing class *or any class in its `extends` chain*, tsc
suggests it — `TS2662` for a static member, `TS2663` for an instance member in a
non-static context. `class D extends C { static c() { s = 1; } }` referencing
`C`'s static `s` unqualified is `TS2662 'D.s'` in tsc; tsz reported `TS2304`.
tsz now covers it through symbol resolution in `resolve_truly_unknown_identifier`
(the site #16834 introduced).

**Owner layer:** `base_chain_declares_member` walks the AST `extends` chain (via
`get_base_class_idx`, the resolver `is_class_derived_from` already uses) and reads
each base class's own static/instance members by binder symbol flags
(`is_static_member` / `is_instance_member`). The TS2662 arm now also fires for an
inherited static; the TS2663 arm (under the existing non-static-context /
no-`this`-rebind gates) for an inherited instance member.

The walk never materializes a constructor/instance type. #16834 deliberately
avoided the enclosing class's own type because it is mid-computation during the
on-demand class-type pass and would desync from the statement-walk pass — a
suggestion in one pass and a bare `TS2304` in the other both survive (they dedupe
by `(start, code)`). The heritage walk is AST- and binder-derived, identical in
both passes, so it stays single-diagnostic without the type #16834 ruled out, and
is cycle-guarded against an illegal `extends` cycle. Lib / `node_modules` base
classes, whose declarations are not walkable class AST nodes, remain out of scope.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test missing_prefix_member_suggestion_tests` — 16/16
  (own-member, Function-member, and fallback rows from #16834 stay green; adds
  inherited static → TS2662, inherited instance → TS2663, multi-level `extends`,
  inherited static in a static context, inherited instance from a static context →
  bare TS2304, and binder-name invariance).
- CLI parity (`--strict --target es2022`): `class C { static s; } class D extends C
  { static c(){ s = 1; } }` → `TS2662 'D.s'`; inherited instance → `TS2663`;
  inherited instance from a static context → bare `TS2304`.
- Conformance snapshot, isolated before/after on the same base (main): 2 rows
  improve toward tsc — `scopeCheckExtendedClassInsidePublicMethod2`,
  `scopeCheckExtendedClassInsideStaticMethod1` — 0 regressions.

## Provenance
Machine: cloud
Assistant: claude-code
Model: Opus 4.8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_0128DCFBx7Aeox1H5tcXbAxQ)_