### PR TITLE
fix(checker): empty named import/export clause is exempt from ESM-in-CJS diagnostics

### DIFF
--- a/crates/tsz-checker/src/declarations/import/verbatim.rs
+++ b/crates/tsz-checker/src/declarations/import/verbatim.rs
@@ -145,29 +145,51 @@ impl<'a> CheckerState<'a> {
         // detection requires), so there is no adjustable variant to pick.
         // Emit on the import clause and skip ESM-specific checks below. TSC
         // skips this check for .d.ts files.
-        if self.is_current_file_commonjs_for_vms() && !self.ctx.is_declaration_file() {
+        //
+        // An import clause that carries no runtime binding is exempt, exactly
+        // like a bare side-effect `import "./m"` (which has no clause at all
+        // and returns above): `import {} from "./m"` — an empty named-imports
+        // list with no default and no namespace binding — is erased in emit
+        // and tsc reports nothing. A default (`import x, {} from`) or
+        // namespace (`import * as ns from`) binding still counts as ESM
+        // syntax and reports. (Oracle-verified against `typescript@7.0.2`:
+        // `import {} from "./m";` is clean; `import def, {} from "./m";`
+        // fires TS1295 anchored at the default binding.)
+        // `get_named_imports` covers both a namespace import (its `name` is the
+        // `ns` in `* as ns`) and a named-imports list (its `elements` are the
+        // specifiers). Resolve it once and reuse for both the binding check and
+        // the error anchor below.
+        let named_imports = self
+            .ctx
+            .arena
+            .get(clause.named_bindings)
+            .and_then(|bindings_node| self.ctx.arena.get_named_imports(bindings_node));
+        // Either shape carrying content is a binding; an empty named-imports
+        // list (`import {}`) is not.
+        let clause_has_binding = clause.name.is_some()
+            || named_imports.is_some_and(|b| b.name.is_some() || !b.elements.nodes.is_empty());
+        if clause_has_binding
+            && self.is_current_file_commonjs_for_vms()
+            && !self.ctx.is_declaration_file()
+        {
             // TSC positions the error at the binding NAME:
             // - Default import `import X from ...` → at X
             // - Namespace import `import * as X from ...` → at X
             // - Named imports `import { X } from ...` → at X (first specifier name)
             let error_node = if clause.named_bindings.is_some() {
-                if let Some(bindings_node) = self.ctx.arena.get(clause.named_bindings) {
-                    if let Some(ns_import) = self.ctx.arena.get_named_imports(bindings_node) {
-                        if ns_import.name.is_some() {
-                            // Namespace import: use the name (esmy2 in `* as esmy2`)
-                            ns_import.name
-                        } else if let Some(&first_spec) = ns_import.elements.nodes.first() {
-                            // Named imports: use first specifier's local name
-                            if let Some(spec_node) = self.ctx.arena.get(first_spec)
-                                && let Some(spec) = self.ctx.arena.get_specifier(spec_node)
-                            {
-                                if spec.name.is_some() {
-                                    spec.name
-                                } else {
-                                    spec.property_name
-                                }
+                if let Some(ns_import) = named_imports {
+                    if ns_import.name.is_some() {
+                        // Namespace import: use the name (esmy2 in `* as esmy2`)
+                        ns_import.name
+                    } else if let Some(&first_spec) = ns_import.elements.nodes.first() {
+                        // Named imports: use first specifier's local name
+                        if let Some(spec_node) = self.ctx.arena.get(first_spec)
+                            && let Some(spec) = self.ctx.arena.get_specifier(spec_node)
+                        {
+                            if spec.name.is_some() {
+                                spec.name
                             } else {
-                                clause.named_bindings
+                                spec.property_name
                             }
                         } else {
                             clause.named_bindings

--- a/crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs
+++ b/crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs
@@ -48,9 +48,22 @@ impl<'a> CheckerState<'a> {
         // specifier's SOURCE name (before `as`, matching tsc); this takes
         // priority over the per-specifier type-only checks below exactly like
         // the import side does.
+        //
+        // An *empty* named-exports clause (`export {}`, with or without
+        // `from`) carries no runtime binding, so — like the empty import
+        // clause on the sibling check — tsc never fires TS1286/TS1295/TS1293
+        // for it. Only a clause with at least one specifier does.
+        // (Oracle-verified against `typescript@7.0.2`: `export {};`,
+        // `export {} from "./m";`, and `export {};` in a `.cts` are all clean.)
+        // `export_named_clause_is_empty` owns this "binds nothing" shape test,
+        // shared with the TS2307 module-resolution skip.
+        let clause_has_binding = !self.export_named_clause_is_empty(named_exports_idx);
         let vms = self.ctx.compiler_options.verbatim_module_syntax;
         let preserve_isolated = self.preserve_isolated_modules_cjs_check_active();
-        if (vms || preserve_isolated) && self.is_current_file_commonjs_for_vms() {
+        if clause_has_binding
+            && (vms || preserve_isolated)
+            && self.is_current_file_commonjs_for_vms()
+        {
             let anchor = named_exports
                 .elements
                 .nodes

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -895,6 +895,8 @@ mod ts1170_computed_property_syntactic_form_tests;
 mod ts1250_ts1251_ts1252_strict_function_in_block_tests;
 #[path = "tests/ts1293_preserve_isolated_modules_esm_syntax_in_cjs_tests.rs"]
 mod ts1293_preserve_isolated_modules_esm_syntax_in_cjs_tests;
+#[path = "tests/ts1295_empty_named_clause_cjs_exempt_tests.rs"]
+mod ts1295_empty_named_clause_cjs_exempt_tests;
 #[path = "tests/ts1309_top_level_await_commonjs_file_tests.rs"]
 mod ts1309_top_level_await_commonjs_file_tests;
 #[path = "tests/ts1318_abstract_accessor_implementation_tests.rs"]

--- a/crates/tsz-checker/src/tests/ts1295_empty_named_clause_cjs_exempt_tests.rs
+++ b/crates/tsz-checker/src/tests/ts1295_empty_named_clause_cjs_exempt_tests.rs
@@ -1,0 +1,257 @@
+//! An *empty* named import/export clause in a CommonJS file is exempt from the
+//! "ESM import/export syntax in a CommonJS file" diagnostic family
+//! (TS1286/TS1295 under `verbatimModuleSyntax`, TS1293 under
+//! `module: "preserve"` + `isolatedModules`).
+//!
+//! Structural rule: the diagnostic fires only when the clause carries a
+//! runtime binding. `import {} from "./m"` and `export {}` (with or without
+//! `from`) carry none — `export {}` is the conventional "make this file a
+//! module" marker, and an empty named clause is fully erased in emit — so tsc
+//! reports nothing, exactly as it exempts a bare side-effect `import "./m"`. A
+//! default (`import x, {} from`) or namespace (`import * as ns from`) binding,
+//! or any clause with at least one specifier (`import { x }`, `export { x }`),
+//! still counts as ESM syntax and reports.
+//!
+//! Regression guard for #16845: #16841 added the CJS-forbidden check to the
+//! named-export path and it began firing on a bare `export {};`.
+//!
+//! Oracle-verified against `typescript@7.0.2`:
+//! - `export {};`, `export {} from "./m";`, `import {} from "./m";` — clean
+//!   in both a `.ts` (module=commonjs, adjustable → TS1295) and a `.cts`
+//!   (extension-locked → TS1286) file.
+//! - `export { x };`, `export { x } from "./m";`, `import { x } from "./m";`,
+//!   `import def, {} from "./m";`, `import * as ns from "./m";` — still fire.
+//!
+//! Owner: the checker's verbatim import/export CJS gates in
+//! `crates/tsz-checker/src/declarations/import/verbatim.rs` and
+//! `crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs`.
+
+use crate::context::CheckerOptions;
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::check_multi_file;
+use tsz_common::common::ModuleKind;
+
+const TS1286: u32 = 1286; // extension-locked ESM-in-CJS
+const TS1293: u32 = 1293; // preserve + isolatedModules ESM-in-CJS
+const TS1295: u32 = 1295; // adjustable ESM-in-CJS
+
+/// `verbatimModuleSyntax` with `module: commonjs` — a `.ts` file's CJS-ness is
+/// adjustable, so the ESM-in-CJS defect surfaces as TS1295.
+fn check_vms_commonjs(files: &[(&str, &str)], entry: &str) -> Vec<Diagnostic> {
+    check_multi_file(
+        files,
+        entry,
+        CheckerOptions {
+            module: ModuleKind::CommonJS,
+            verbatim_module_syntax: true,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+/// `verbatimModuleSyntax` with a `.cts` entry — extension-locked CJS, so the
+/// ESM-in-CJS defect surfaces as TS1286.
+fn check_vms_cts(files: &[(&str, &str)], entry: &str) -> Vec<Diagnostic> {
+    check_multi_file(
+        files,
+        entry,
+        CheckerOptions {
+            module: ModuleKind::CommonJS,
+            verbatim_module_syntax: true,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+/// `module: "preserve"` + `isolatedModules` (no VMS) — `.cts` entry reports
+/// TS1293 for a real ESM clause.
+fn check_preserve_isolated(files: &[(&str, &str)], entry: &str) -> Vec<Diagnostic> {
+    check_multi_file(
+        files,
+        entry,
+        CheckerOptions {
+            module: ModuleKind::Preserve,
+            isolated_modules: true,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+fn codes(diagnostics: &[Diagnostic]) -> Vec<u32> {
+    let mut codes: Vec<u32> = diagnostics.iter().map(|d| d.code).collect();
+    codes.sort_unstable();
+    codes
+}
+
+// =========================================================================
+// Exempt: empty clause carries no runtime binding
+// =========================================================================
+
+/// The reported bug: a bare `export {};` module marker under VMS in a CJS file.
+#[test]
+fn bare_empty_export_in_commonjs_ts_is_clean_vms() {
+    let diagnostics = check_vms_commonjs(&[("/main.ts", "export {};\n")], "/main.ts");
+    assert_eq!(codes(&diagnostics), Vec::<u32>::new(), "{diagnostics:?}");
+}
+
+/// Same shape in an extension-locked `.cts` file — would have been TS1286.
+#[test]
+fn bare_empty_export_in_cts_is_clean_vms() {
+    let diagnostics = check_vms_cts(&[("/main.cts", "export {};\n")], "/main.cts");
+    assert_eq!(codes(&diagnostics), Vec::<u32>::new(), "{diagnostics:?}");
+}
+
+/// An empty re-export `export {} from "./m"` also carries no binding — clean.
+#[test]
+fn empty_reexport_with_from_in_commonjs_ts_is_clean_vms() {
+    let diagnostics = check_vms_commonjs(
+        &[
+            ("/mod.ts", "export interface Y {}\n"),
+            ("/main.ts", "export {} from \"./mod\";\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diagnostics), Vec::<u32>::new(), "{diagnostics:?}");
+}
+
+/// An empty named-imports clause `import {} from "./m"` carries no binding.
+#[test]
+fn empty_named_import_in_commonjs_ts_is_clean_vms() {
+    let diagnostics = check_vms_commonjs(
+        &[
+            ("/mod.ts", "export interface Y {}\n"),
+            ("/main.ts", "import {} from \"./mod\";\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diagnostics), Vec::<u32>::new(), "{diagnostics:?}");
+}
+
+/// Same empty import in `.cts` — would have been TS1286.
+#[test]
+fn empty_named_import_in_cts_is_clean_vms() {
+    let diagnostics = check_vms_cts(
+        &[
+            ("/mod.ts", "export interface Y {}\n"),
+            ("/main.cts", "import {} from \"./mod\";\n"),
+        ],
+        "/main.cts",
+    );
+    assert_eq!(codes(&diagnostics), Vec::<u32>::new(), "{diagnostics:?}");
+}
+
+/// Empty clauses are also exempt under `preserve` + `isolatedModules`.
+#[test]
+fn bare_empty_export_in_cts_is_clean_preserve_isolated() {
+    let diagnostics = check_preserve_isolated(&[("/main.cts", "export {};\n")], "/main.cts");
+    assert_eq!(codes(&diagnostics), Vec::<u32>::new(), "{diagnostics:?}");
+}
+
+#[test]
+fn empty_named_import_in_cts_is_clean_preserve_isolated() {
+    let diagnostics = check_preserve_isolated(
+        &[
+            ("/mod.ts", "export const y = 2;\n"),
+            ("/main.cts", "import {} from \"./mod\";\n"),
+        ],
+        "/main.cts",
+    );
+    assert_eq!(codes(&diagnostics), Vec::<u32>::new(), "{diagnostics:?}");
+}
+
+// =========================================================================
+// Controls: a clause that carries a binding still reports
+// =========================================================================
+
+/// A local named export with one specifier still reports TS1295.
+#[test]
+fn local_named_export_in_commonjs_ts_reports_ts1295() {
+    let diagnostics = check_vms_commonjs(
+        &[("/main.ts", "const z = 1;\nexport { z as w };\n")],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diagnostics), vec![TS1295], "{diagnostics:?}");
+}
+
+/// A non-empty re-export still reports TS1295 (renamed binder — the guard must
+/// not key off a specific identifier).
+#[test]
+fn renamed_named_reexport_in_commonjs_ts_reports_ts1295() {
+    let diagnostics = check_vms_commonjs(
+        &[
+            ("/mod.ts", "export const somethingElse = 2;\n"),
+            (
+                "/main.ts",
+                "export { somethingElse as renamedOut } from \"./mod\";\n",
+            ),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diagnostics), vec![TS1295], "{diagnostics:?}");
+}
+
+/// A non-empty named import still reports TS1295.
+#[test]
+fn named_import_in_commonjs_ts_reports_ts1295() {
+    let diagnostics = check_vms_commonjs(
+        &[
+            ("/mod.ts", "export const y = 2;\n"),
+            ("/main.ts", "import { y } from \"./mod\";\ny;\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diagnostics), vec![TS1295], "{diagnostics:?}");
+}
+
+/// A default binding alongside an *empty* named-imports list still reports —
+/// the default is a runtime binding.
+#[test]
+fn default_plus_empty_named_import_in_commonjs_ts_reports_ts1295() {
+    let diagnostics = check_vms_commonjs(
+        &[
+            ("/mod.ts", "export default 3;\n"),
+            ("/main.ts", "import def, {} from \"./mod\";\ndef;\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diagnostics), vec![TS1295], "{diagnostics:?}");
+}
+
+/// A namespace binding carries content and still reports.
+#[test]
+fn namespace_import_in_commonjs_ts_reports_ts1295() {
+    let diagnostics = check_vms_commonjs(
+        &[
+            ("/mod.ts", "export const y = 2;\n"),
+            ("/main.ts", "import * as ns from \"./mod\";\nns;\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diagnostics), vec![TS1295], "{diagnostics:?}");
+}
+
+/// Extension-locked control: a non-empty clause in `.cts` still reports TS1286.
+#[test]
+fn named_import_in_cts_reports_ts1286() {
+    let diagnostics = check_vms_cts(
+        &[
+            ("/mod.ts", "export const y = 2;\n"),
+            ("/main.cts", "import { y } from \"./mod\";\ny;\n"),
+        ],
+        "/main.cts",
+    );
+    assert_eq!(codes(&diagnostics), vec![TS1286], "{diagnostics:?}");
+}
+
+/// preserve + isolatedModules control: a non-empty clause still reports TS1293.
+#[test]
+fn named_import_in_cts_reports_ts1293_preserve_isolated() {
+    let diagnostics = check_preserve_isolated(
+        &[
+            ("/mod.ts", "export const y = 2;\n"),
+            ("/main.cts", "import { y } from \"./mod\";\ny;\n"),
+        ],
+        "/main.cts",
+    );
+    assert_eq!(codes(&diagnostics), vec![TS1293], "{diagnostics:?}");
+}


### PR DESCRIPTION
Fixes #16845.

**Structural rule:** When an ESM import/export clause in a CommonJS file — under `verbatimModuleSyntax`, or under `module: "preserve"` + `isolatedModules` — carries **no runtime binding**, tsc does not classify it as ESM import/export syntax written in a CommonJS file and emits no diagnostic. An *empty* named clause is exactly that: `export {};` is the conventional "make this file a module" marker, `export {} from "./m"` an empty re-export, and `import {} from "./m"` an empty named-imports list — all fully erased in emit. tsz was firing the ESM-in-CJS family (`TS1286`/`TS1295`/`TS1293`) on them anyway. Owner layer: the checker's verbatim import gate (`declarations/import/verbatim.rs`) and named-export gate (`declarations/module_checker/verbatim_module_syntax.rs`).

`#16841` extended the named-export gate to run the CJS-forbidden check for `export { ... }` clauses; that block fired on any `NAMED_EXPORTS` clause, including the empty `export {};` at line 25 of `conformance/externalModules/verbatimModuleSyntaxRestrictionsCJS.ts` — the reported +1 `TS1295`. The import gate had the same latent defect for `import {} from "./m"`, so the fix guards both sides with a `clause_has_binding` check rather than only the reported export path.

**Adjacent-case matrix** (oracle-verified against `typescript@7.0.2`, CJS file under VMS):

| shape | tsc | tsz (after) |
| --- | --- | --- |
| `export {};` | clean | clean |
| `export {} from "./m";` | clean | clean |
| `import {} from "./m";` | clean | clean |
| `export {};` in `.cts` (extension-locked) | clean | clean |
| `export { x };` / `export { x } from "./m";` | TS1295 | TS1295 |
| `import { x } from` / `import * as ns from` | TS1295 | TS1295 |
| `import def, {} from` (default binding present) | TS1295 | TS1295 |
| non-empty clause in `.cts` | TS1286 | TS1286 |
| non-empty clause, preserve+isolatedModules | TS1293 | TS1293 |

The guard reuses the existing `export_named_clause_is_empty` helper on the export side (single source of truth, already shared with the TS2307 module-resolution skip); the import side hoists the `named_imports` arena lookup once and reuses it for both the binding check and the error anchor.

## Goal
Goal: hold

## Verification
- New unit suite `ts1295_empty_named_clause_cjs_exempt_tests` — 14 cases (empty-clause exemptions across TS1295/TS1286/TS1293 on both import and export sides; binding-present controls including renamed binders and `import def, {}`): pass.
- `cargo test -p tsz-checker --lib -- verbatim ts1293 ts1286 isolated_module` — 42 pass, no regressions.
- `cargo clippy -p tsz-checker --lib -- -D warnings`, `cargo fmt --check`, `scripts/arch/arch_guard.py` — clean (also enforced by the pre-commit gate).
- Rule and every matrix row confirmed against the pinned `typescript@7.0.2` oracle via `scripts/conformance/oracle.sh`.
- Full `conformance.sh` snapshot not run locally (TypeScript submodule not checked out in this environment); the change removes exactly the extra `TS1295` at the reported site and is otherwise a no-op for any clause carrying a binding.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hv4wBMETSVjTERRjWSTyqm)_