### PR TITLE
fix(checker): empty export/import clause no longer over-reports ESM-in-CJS diagnostic

### DIFF
--- a/crates/tsz-checker/src/declarations/import/verbatim.rs
+++ b/crates/tsz-checker/src/declarations/import/verbatim.rs
@@ -110,6 +110,33 @@ impl<'a> CheckerState<'a> {
         false
     }
 
+    /// Whether an import clause binds at least one runtime name — a default
+    /// import (`import x from ...`), a `* as ns` namespace binding, or a
+    /// non-empty named-imports list (`import { a } from ...`). A specifier-less
+    /// `import {} from "./m";` binds nothing.
+    ///
+    /// tsc raises the ESM-in-CJS diagnostic per binding: `checkImportBinding`
+    /// for the default and `* as ns` forms, and
+    /// `forEach(namedBindings.elements, checkImportBinding)` for named imports.
+    /// The empty named-imports clause reaches none of those, so tsc stays
+    /// silent; this gate mirrors that.
+    fn import_clause_binds_runtime_name(
+        &self,
+        clause: &tsz_parser::parser::node::ImportClauseData,
+    ) -> bool {
+        if clause.name.is_some() {
+            return true;
+        }
+        let Some(bindings_node) = self.ctx.arena.get(clause.named_bindings) else {
+            return false;
+        };
+        let Some(named) = self.ctx.arena.get_named_imports(bindings_node) else {
+            return false;
+        };
+        // `* as ns` populates `name`; `{ a, b }` populates `elements`.
+        named.name.is_some() || !named.elements.nodes.is_empty()
+    }
+
     /// Check named import specifiers under `verbatimModuleSyntax`.
     pub(crate) fn check_verbatim_module_syntax_imports(
         &mut self,
@@ -145,7 +172,17 @@ impl<'a> CheckerState<'a> {
         // detection requires), so there is no adjustable variant to pick.
         // Emit on the import clause and skip ESM-specific checks below. TSC
         // skips this check for .d.ts files.
-        if self.is_current_file_commonjs_for_vms() && !self.ctx.is_declaration_file() {
+        //
+        // Mirror the export side: tsc raises this per import *binding*
+        // (`checkImportBinding` for a default or `* as ns` binding, or
+        // `forEach(namedBindings.elements, checkImportBinding)` for named
+        // imports). A specifier-less `import {} from "./m";` — the empty
+        // named-imports clause — reaches none of those, so tsc stays silent.
+        // Only fire when the clause actually binds something.
+        if self.is_current_file_commonjs_for_vms()
+            && !self.ctx.is_declaration_file()
+            && self.import_clause_binds_runtime_name(clause)
+        {
             // TSC positions the error at the binding NAME:
             // - Default import `import X from ...` → at X
             // - Namespace import `import * as X from ...` → at X

--- a/crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs
+++ b/crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs
@@ -48,9 +48,20 @@ impl<'a> CheckerState<'a> {
         // specifier's SOURCE name (before `as`, matching tsc); this takes
         // priority over the per-specifier type-only checks below exactly like
         // the import side does.
+        //
+        // tsc raises this diagnostic per export *specifier* (in
+        // `checkAliasSymbol`, reached only from `forEach(exportClause.elements,
+        // checkExportSpecifier)`). A bare `export {};` — or a specifier-less
+        // re-export `export {} from "./m";` — has no specifiers, so the walk
+        // never reaches the check and tsc stays silent: the empty export
+        // declaration is the conventional "make this file a module" marker and
+        // carries no ECMAScript binding to forbid. Requiring at least one
+        // specifier here keeps `export { something }` reporting while exempting
+        // the empty clause.
         let vms = self.ctx.compiler_options.verbatim_module_syntax;
         let preserve_isolated = self.preserve_isolated_modules_cjs_check_active();
-        if (vms || preserve_isolated) && self.is_current_file_commonjs_for_vms() {
+        let has_specifiers = !named_exports.elements.nodes.is_empty();
+        if (vms || preserve_isolated) && self.is_current_file_commonjs_for_vms() && has_specifiers {
             let anchor = named_exports
                 .elements
                 .nodes

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -1041,6 +1041,8 @@ mod variadic_tuple_constraint_literal_preservation_tests;
 mod variadic_tuple_spread_element_inference_tests;
 #[path = "tests/variance_property_function_bivariance_tests.rs"]
 mod variance_property_function_bivariance_tests;
+#[path = "tests/verbatim_module_syntax_empty_clause_cjs_tests.rs"]
+mod verbatim_module_syntax_empty_clause_cjs_tests;
 #[path = "tests/verbatim_module_syntax_export_default_alias_ts1284_tests.rs"]
 mod verbatim_module_syntax_export_default_alias_ts1284_tests;
 #[path = "tests/verbatim_module_syntax_export_default_type_only_import_ts1284_tests.rs"]

--- a/crates/tsz-checker/src/tests/verbatim_module_syntax_empty_clause_cjs_tests.rs
+++ b/crates/tsz-checker/src/tests/verbatim_module_syntax_empty_clause_cjs_tests.rs
@@ -1,0 +1,232 @@
+//! Empty named-import / named-export clauses are exempt from the
+//! ESM-syntax-in-a-CommonJS-file diagnostic (TS1295 / TS1286 under
+//! `verbatimModuleSyntax`, TS1293 under `module: "preserve"` +
+//! `isolatedModules`).
+//!
+//! Structural rule: tsc raises this diagnostic *per binding*. On the import
+//! side `checkImportBinding` runs for a default or `* as ns` binding and
+//! `forEach(namedBindings.elements, checkImportBinding)` runs per named
+//! specifier; on the export side `checkAliasSymbol` is reached only from
+//! `forEach(exportClause.elements, checkExportSpecifier)`. A bare
+//! `export {};` — the conventional "make this file a module" marker — and a
+//! specifier-less `import {} from "./m";` / `export {} from "./m";` carry no
+//! binding, so the walk never reaches the check and tsc stays silent. tsz was
+//! firing at the clause level regardless of specifier count, over-reporting
+//! one extra diagnostic on the empty clause (issue #16845). The fix requires
+//! at least one specifier before emitting, without exempting
+//! `export { something }` / `import { something }`.
+//!
+//! Owner: `crates/tsz-checker/src/declarations/import/verbatim.rs`
+//! (`import_clause_binds_runtime_name`) and
+//! `crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs`
+//! (the `!named_exports.elements.nodes.is_empty()` gate).
+//!
+//! Oracle: `typescript@7.0.2`, matching the
+//! `externalModules/verbatimModuleSyntaxRestrictionsCJS` conformance row,
+//! whose `export {};` on `main.ts` reports nothing.
+
+use crate::context::CheckerOptions;
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::check_multi_file;
+use tsz_common::common::ModuleKind;
+
+const TS1293: u32 = 1293;
+const TS1295: u32 = 1295;
+const TS1286: u32 = 1286;
+
+/// `verbatimModuleSyntax` + `module: commonjs`. A plain `.ts` file is CJS by
+/// config here (not extension-locked), so the adjustable TS1295 variant is
+/// the one that would fire.
+fn check_vms_cjs(files: &[(&str, &str)], entry: &str) -> Vec<Diagnostic> {
+    check_multi_file(
+        files,
+        entry,
+        CheckerOptions {
+            module: ModuleKind::CommonJS,
+            verbatim_module_syntax: true,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+/// `module: "preserve"` + `isolatedModules` (no VMS): the TS1293 variant.
+fn check_preserve_isolated(files: &[(&str, &str)], entry: &str) -> Vec<Diagnostic> {
+    check_multi_file(
+        files,
+        entry,
+        CheckerOptions {
+            module: ModuleKind::Preserve,
+            isolated_modules: true,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+fn codes(diagnostics: &[Diagnostic]) -> Vec<u32> {
+    let mut codes: Vec<u32> = diagnostics.iter().map(|d| d.code).collect();
+    codes.sort_unstable();
+    codes
+}
+
+// ---------------------------------------------------------------------
+// The reported bug: bare `export {};` under VMS + CJS is clean.
+// ---------------------------------------------------------------------
+
+#[test]
+fn empty_export_clause_in_cjs_ts_is_clean_under_vms() {
+    let diagnostics = check_vms_cjs(&[("/main.ts", "export {};\n")], "/main.ts");
+    assert_eq!(codes(&diagnostics), Vec::<u32>::new(), "{diagnostics:?}");
+}
+
+/// `.cts` is extension-locked (TS1286 would be the variant), still clean.
+#[test]
+fn empty_export_clause_in_cts_is_clean_under_vms() {
+    let diagnostics = check_vms_cjs(&[("/main.cts", "export {};\n")], "/main.cts");
+    assert_eq!(codes(&diagnostics), Vec::<u32>::new(), "{diagnostics:?}");
+}
+
+/// A specifier-less re-export `export {} from "./b"` is also empty — no
+/// specifier reaches `checkAliasSymbol`, so tsc stays silent.
+#[test]
+fn empty_reexport_clause_in_cjs_ts_is_clean_under_vms() {
+    let diagnostics = check_vms_cjs(
+        &[
+            ("/b.ts", "export const y = 2;\n"),
+            ("/main.ts", "export {} from \"./b\";\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diagnostics), Vec::<u32>::new(), "{diagnostics:?}");
+}
+
+/// Control: a non-empty `export { x }` still reports — the empty-clause gate
+/// must not silence a real specifier.
+#[test]
+fn nonempty_local_export_in_cjs_ts_still_reports_ts1295() {
+    let diagnostics = check_vms_cjs(&[("/main.ts", "const x = 1;\nexport { x };\n")], "/main.ts");
+    assert_eq!(codes(&diagnostics), vec![TS1295], "{diagnostics:?}");
+}
+
+/// Control: `.cts` picks the extension-locked TS1286 variant for a real
+/// specifier.
+#[test]
+fn nonempty_local_export_in_cts_still_reports_ts1286() {
+    let diagnostics = check_vms_cjs(
+        &[("/main.cts", "const x = 1;\nexport { x };\n")],
+        "/main.cts",
+    );
+    assert_eq!(codes(&diagnostics), vec![TS1286], "{diagnostics:?}");
+}
+
+/// Control, renamed binder: the gate keys on specifier presence, never on a
+/// fixed identifier name.
+#[test]
+fn nonempty_renamed_export_in_cjs_ts_still_reports_ts1295() {
+    let diagnostics = check_vms_cjs(
+        &[(
+            "/main.ts",
+            "const somethingElse = 1;\nexport { somethingElse as renamed };\n",
+        )],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diagnostics), vec![TS1295], "{diagnostics:?}");
+}
+
+// ---------------------------------------------------------------------
+// Import side: empty `import {} from "./b"` is the mirror case.
+// ---------------------------------------------------------------------
+
+#[test]
+fn empty_named_import_in_cjs_ts_is_clean_under_vms() {
+    let diagnostics = check_vms_cjs(
+        &[
+            ("/b.ts", "export const y = 2;\n"),
+            ("/main.ts", "import {} from \"./b\";\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diagnostics), Vec::<u32>::new(), "{diagnostics:?}");
+}
+
+#[test]
+fn empty_named_import_in_cts_is_clean_under_vms() {
+    let diagnostics = check_vms_cjs(
+        &[
+            ("/b.ts", "export const y = 2;\n"),
+            ("/main.cts", "import {} from \"./b\";\n"),
+        ],
+        "/main.cts",
+    );
+    assert_eq!(codes(&diagnostics), Vec::<u32>::new(), "{diagnostics:?}");
+}
+
+/// Control: a real named import still reports.
+#[test]
+fn nonempty_named_import_in_cjs_ts_still_reports_ts1295() {
+    let diagnostics = check_vms_cjs(
+        &[
+            ("/b.ts", "export const y = 2;\n"),
+            ("/main.ts", "import { y } from \"./b\";\ny;\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diagnostics), vec![TS1295], "{diagnostics:?}");
+}
+
+/// Control: a default import binds a name, so it still reports.
+#[test]
+fn default_import_in_cjs_ts_still_reports_ts1295() {
+    let diagnostics = check_vms_cjs(
+        &[
+            ("/b.ts", "export default 3;\n"),
+            ("/main.ts", "import def from \"./b\";\ndef;\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diagnostics), vec![TS1295], "{diagnostics:?}");
+}
+
+/// Control: a namespace import binds `ns`, so it still reports.
+#[test]
+fn namespace_import_in_cjs_ts_still_reports_ts1295() {
+    let diagnostics = check_vms_cjs(
+        &[
+            ("/b.ts", "export const y = 2;\n"),
+            ("/main.ts", "import * as ns from \"./b\";\nns;\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diagnostics), vec![TS1295], "{diagnostics:?}");
+}
+
+// ---------------------------------------------------------------------
+// preserve + isolatedModules (TS1293) path: same empty-clause exemption.
+// ---------------------------------------------------------------------
+
+#[test]
+fn empty_export_clause_in_cts_is_clean_under_preserve_isolated() {
+    let diagnostics = check_preserve_isolated(&[("/main.cts", "export {};\n")], "/main.cts");
+    assert_eq!(codes(&diagnostics), Vec::<u32>::new(), "{diagnostics:?}");
+}
+
+#[test]
+fn empty_named_import_in_cts_is_clean_under_preserve_isolated() {
+    let diagnostics = check_preserve_isolated(
+        &[
+            ("/b.ts", "export const y = 2;\n"),
+            ("/main.cts", "import {} from \"./b\";\n"),
+        ],
+        "/main.cts",
+    );
+    assert_eq!(codes(&diagnostics), Vec::<u32>::new(), "{diagnostics:?}");
+}
+
+/// Control on the preserve path: a real specifier still reports TS1293.
+#[test]
+fn nonempty_export_in_cts_still_reports_ts1293_under_preserve_isolated() {
+    let diagnostics = check_preserve_isolated(
+        &[("/main.cts", "const z = 1;\nexport { z as w };\n")],
+        "/main.cts",
+    );
+    assert_eq!(codes(&diagnostics), vec![TS1293], "{diagnostics:?}");
+}


### PR DESCRIPTION
Structural rule: **when an `import`/`export` named clause binds nothing** — a bare `export {};` (the "make this file a module" marker), or a specifier-less `import {} from "./m";` / `export {} from "./m";` — **tsc raises no ESM-syntax-in-a-CommonJS-file diagnostic**, because it emits that error *per binding* and an empty clause reaches none. tsz was emitting at the clause level regardless of specifier count, over-reporting one extra diagnostic. Owner layer: the `verbatimModuleSyntax` / `isolatedModules` CJS gate in `crates/tsz-checker/src/declarations/import/verbatim.rs` (imports) and `.../module_checker/verbatim_module_syntax.rs` (named/re-exports).

Fixes #16845.

### What was wrong

tsc's ESM-in-CJS diagnostic (TS1295 / TS1286 under `verbatimModuleSyntax`, TS1293 under `module:"preserve"` + `isolatedModules`) is emitted in `checkAliasSymbol`, reached only per specifier/binding:
- export side — `forEach(exportClause.elements, checkExportSpecifier)`;
- import side — `checkImportBinding` for a default or `* as ns` binding, and `forEach(namedBindings.elements, checkImportBinding)` for named imports.

An empty named clause has no specifiers, so tsc's walk never reaches the check. tsz fired unconditionally at the clause level, adding an extra `TS1295` on `export {};` in `externalModules/verbatimModuleSyntaxRestrictionsCJS` — a count/anchor divergence the code-set comparison hides (the row's code set already contains TS1295, so it scores as passing).

### The fix

Gate each clause-level emit on the clause actually binding something, mirroring tsc's per-binding walk:
- **export side** — require `!named_exports.elements.nodes.is_empty()`; `export { something }` still reports.
- **import side** — new `import_clause_binds_runtime_name` helper (true for a default import, a `* as ns` namespace binding, or a non-empty named-imports list); `import { x }`, `import def`, `import * as ns` still report.

Adjacent matrix (all oracle-checked against `typescript@7.0.2`):

| form | CJS + VMS | expected |
| --- | --- | --- |
| `export {};` | clean | clean ✓ |
| `export {} from "./b";` | clean | clean ✓ |
| `export { x };` | TS1295 (`.ts`) / TS1286 (`.cts`) | reports ✓ |
| `import {} from "./b";` | clean | clean ✓ |
| `import { y } from "./b";` | TS1295 | reports ✓ |
| `import def from "./b";` | TS1295 | reports ✓ |
| `import * as ns from "./b";` | TS1295 | reports ✓ |

Renamed-binder controls included so the gate keys on specifier presence, never a fixed identifier. The empty-clause exemption is also verified on the `preserve` + `isolatedModules` (TS1293) path.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib verbatim_module_syntax_empty_clause` — 14 new tests pass (reported case + import mirror + controls).
- `cargo test -p tsz-checker --lib ts1293_preserve_isolated` — 15 existing tests pass (no regression on the sibling path).
- `cargo test -p tsz-checker --lib -- verbatim vms cjs module_syntax isolated 1286 1287 1293 1295 1484 1485 export_default` — 75 tests pass across the affected area.
- `cargo clippy -p tsz-checker --all-targets` — clean.
- Change only *suppresses* emission on empty clauses; it cannot introduce a new diagnostic, so the `verbatimModuleSyntaxRestrictionsCJS` row moves from 11 to the expected 10 diagnostics (3×TS1287 + 7×TS1295).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjoTEGtkTvCQVLcQzm1xsY)_