### PR TITLE
fix(arch): ratchet allowlisted files so the 2000-LOC ceiling is enforced (#16488)

### DIFF
--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -198,6 +198,11 @@ def main() -> int:
             if hits:
                 size_failures.append((name, hits))
 
+        allowlist_gap = scan_allowlist_ratchet_coverage()
+        size_total += len(allowlist_gap)
+        if allowlist_gap:
+            size_failures.append((ALLOWLIST_RATCHET_COVERAGE_NAME, allowlist_gap))
+
         payload = build_json_payload(size_failures, size_total)
         if args.json_report:
             write_json_report(Path(args.json_report), payload)
@@ -279,6 +284,11 @@ def main() -> int:
         total_hits += len(hits)
         if hits:
             failures.append((name, hits))
+
+    allowlist_gap = scan_allowlist_ratchet_coverage()
+    total_hits += len(allowlist_gap)
+    if allowlist_gap:
+        failures.append((ALLOWLIST_RATCHET_COVERAGE_NAME, allowlist_gap))
 
     for name, path, struct_name, max_fields in STRUCT_FIELD_COUNT_CHECKS:
         hits = scan_struct_field_count(path, struct_name, max_fields)

--- a/scripts/arch/arch_guard_file_limits.py
+++ b/scripts/arch/arch_guard_file_limits.py
@@ -9,7 +9,13 @@ exactly as before, so `self.arch_guard.FILE_LINE_LIMIT_CHECKS` and friends in
 `test_arch_guard.py` keep working unmodified.
 """
 
-from arch_guard_shared import ROOT
+from pathlib import Path
+
+from arch_guard_shared import (
+    _CRATE_SRC_LINE_LIMIT_ALLOWLISTS,
+    _CRATE_TESTS_LINE_LIMIT_ALLOWLISTS,
+    ROOT,
+)
 
 # Ratcheted 1901 -> 1740 by the #15643 arch-health paydown: FunctionShape
 # instantiation, parameter-list transformation, and redeclaration-widening
@@ -1012,4 +1018,143 @@ FILE_LINE_LIMIT_CHECKS = [
     # parser/state_declarations.rs dropped below the 2000-line cap once enum
     # declaration parsing moved to state_declarations_enums.rs; its ratchet
     # entry was removed (the allowlist only shrinks).
+    #
+    # #16488: the eleven entries below close the last hole in the 2000-LOC
+    # ceiling. #16733/#16745 registered every `crates/*/src` and `crates/*/tests`
+    # root under the per-crate cap, but a file listed in one of those crates'
+    # allowlists is *exempt* from the directory cap — and these eleven had no
+    # `FILE_LINE_LIMIT_CHECKS` ratchet of their own, so they could grow without
+    # bound above 2000 while the `arch-size` gate stayed green (exactly the
+    # `core_dispatch.rs`-at-2075 gap the issue reports, in its residual form).
+    # Pinning each at its observed size makes the allowlist shrink-only, as the
+    # contract requires. `scan_allowlist_ratchet_coverage` (below) keeps this
+    # closed: any future allowlist addition without a matching ratchet fails.
+    (
+        "Checker tests boundary: symbol_index_signature_tests.rs size ratchet (#16488)",
+        ROOT / "crates" / "tsz-checker" / "tests" / "symbol_index_signature_tests.rs",
+        2158,
+    ),
+    (
+        "Checker tests boundary: ts2353_tests.rs size ratchet (#16488)",
+        ROOT / "crates" / "tsz-checker" / "tests" / "ts2353_tests.rs",
+        2113,
+    ),
+    (
+        "CLI tests boundary: driver_tests_parts/part_12.rs size ratchet (#16488)",
+        ROOT / "crates" / "tsz-cli" / "tests" / "driver_tests_parts" / "part_12.rs",
+        2078,
+    ),
+    (
+        "CLI tests boundary: tsc_compat_tests_parts/part_00.rs size ratchet (#16488)",
+        ROOT / "crates" / "tsz-cli" / "tests" / "tsc_compat_tests_parts" / "part_00.rs",
+        2069,
+    ),
+    (
+        "Core boundary: config/tests/module_resolution.rs size ratchet (#16488)",
+        ROOT / "crates" / "tsz-core" / "src" / "config" / "tests" / "module_resolution.rs",
+        2016,
+    ),
+    (
+        "Core tests boundary: parser_state_tests_parts/part_00.rs size ratchet (#16488)",
+        ROOT / "crates" / "tsz-core" / "tests" / "parser_state_tests_parts" / "part_00.rs",
+        2045,
+    ),
+    (
+        "Emitter boundary: declaration_emitter/tests/type_info.rs size ratchet (#16488)",
+        ROOT
+        / "crates"
+        / "tsz-emitter"
+        / "src"
+        / "declaration_emitter"
+        / "tests"
+        / "type_info.rs",
+        2153,
+    ),
+    (
+        "Emitter boundary: emitter/source_file/es5_emit_tests.rs size ratchet (#16488)",
+        ROOT
+        / "crates"
+        / "tsz-emitter"
+        / "src"
+        / "emitter"
+        / "source_file"
+        / "es5_emit_tests.rs",
+        2048,
+    ),
+    (
+        "LSP tests boundary: hover_tests.rs size ratchet (#16488)",
+        ROOT / "crates" / "tsz-lsp" / "tests" / "hover_tests.rs",
+        2151,
+    ),
+    (
+        "Solver tests boundary: canonicalize_tests.rs size ratchet (#16488)",
+        ROOT / "crates" / "tsz-solver" / "tests" / "canonicalize_tests.rs",
+        2287,
+    ),
+    (
+        "Solver tests boundary: intern_tests.rs size ratchet (#16488)",
+        ROOT / "crates" / "tsz-solver" / "tests" / "intern_tests.rs",
+        2045,
+    ),
 ]
+
+
+ALLOWLIST_RATCHET_COVERAGE_NAME = (
+    "Architecture boundary: every file allowlisted from the per-crate 2000-LOC "
+    "cap must also carry a FILE_LINE_LIMIT_CHECKS size ratchet — an allowlisted "
+    "file is otherwise fully exempt from the ceiling and can grow unbounded "
+    "(#16488)"
+)
+
+
+def file_line_limit_ratcheted_paths(checks=None) -> set:
+    """Repo-relative POSIX paths that carry a per-file size ratchet."""
+    checks = checks if checks is not None else FILE_LINE_LIMIT_CHECKS
+    paths = set()
+    for _name, path, _limit in checks:
+        path = Path(path)
+        try:
+            paths.add(path.resolve().relative_to(ROOT).as_posix())
+        except ValueError:
+            paths.add(path.as_posix())
+    return paths
+
+
+def line_limit_allowlisted_files(
+    src_allowlists=None, tests_allowlists=None
+) -> set:
+    """Every file exempted from a per-crate 2000-LOC directory cap."""
+    src = (
+        src_allowlists
+        if src_allowlists is not None
+        else _CRATE_SRC_LINE_LIMIT_ALLOWLISTS
+    )
+    tests = (
+        tests_allowlists
+        if tests_allowlists is not None
+        else _CRATE_TESTS_LINE_LIMIT_ALLOWLISTS
+    )
+    files = set()
+    for _crate, _label, allow in src:
+        files |= set(allow)
+    for _crate, _label, allow in tests:
+        files |= set(allow)
+    return files
+
+
+def scan_allowlist_ratchet_coverage(
+    src_allowlists=None, tests_allowlists=None, file_line_checks=None
+) -> list:
+    """Report allowlisted files that lack a per-file size ratchet.
+
+    A file listed in a `crates/*/src` or `crates/*/tests` allowlist is exempt
+    from that directory's 2000-LOC cap. Without a matching
+    `FILE_LINE_LIMIT_CHECKS` ratchet it is then bounded by *nothing* and can
+    grow arbitrarily while the `arch-size` gate stays green — the residual hole
+    #16488 tracks. Making "allowlisted implies ratcheted" a checked invariant
+    (the same pattern `scan_line_limit_coverage` uses for crate registration)
+    means the ceiling cannot silently reopen for a newly allowlisted file.
+    """
+    allowlisted = line_limit_allowlisted_files(src_allowlists, tests_allowlists)
+    ratcheted = file_line_limit_ratcheted_paths(file_line_checks)
+    return sorted(f for f in allowlisted if f not in ratcheted)

--- a/scripts/arch/test_arch_guard.py
+++ b/scripts/arch/test_arch_guard.py
@@ -1473,5 +1473,62 @@ class ArchGuardAllFileLimitChecksPassTests(unittest.TestCase):
             )
 
 
+class ArchGuardAllowlistRatchetCoverageTests(unittest.TestCase):
+    """Cover the "allowlisted implies ratcheted" invariant (#16488).
+
+    #16733/#16745 registered every `crates/*/src` and `crates/*/tests` root
+    under the per-crate 2000-LOC cap, but a file named in one of those crates'
+    allowlists is *exempt* from the directory cap. Without a matching
+    `FILE_LINE_LIMIT_CHECKS` ratchet such a file is bounded by nothing and can
+    grow arbitrarily while `arch-size` stays green — the residual hole #16488
+    reports. `scan_allowlist_ratchet_coverage` makes the pairing a checked
+    invariant so the ceiling cannot silently reopen for a newly allowlisted
+    file.
+    """
+
+    def setUp(self):
+        self.arch_guard = load_arch_guard_module()
+
+    def test_every_allowlisted_file_is_ratcheted(self):
+        """No allowlisted file may lack a per-file size ratchet on main."""
+        gap = self.arch_guard.scan_allowlist_ratchet_coverage()
+        self.assertEqual(
+            gap,
+            [],
+            "Allowlisted files exempt from the 2000-LOC cap but with no "
+            "FILE_LINE_LIMIT_CHECKS ratchet (can grow unbounded): "
+            + ", ".join(gap),
+        )
+
+    def test_flags_allowlisted_file_without_ratchet(self):
+        """An allowlisted file with no ratchet entry is reported."""
+        gap = self.arch_guard.scan_allowlist_ratchet_coverage(
+            src_allowlists=[("tsz-demo", "Demo", {"crates/tsz-demo/src/huge.rs"})],
+            tests_allowlists=[],
+            file_line_checks=[],
+        )
+        self.assertEqual(gap, ["crates/tsz-demo/src/huge.rs"])
+
+    def test_ratcheted_allowlisted_file_is_not_flagged(self):
+        """An allowlisted file that carries a ratchet is not reported."""
+        rel = "crates/tsz-demo/src/huge.rs"
+        gap = self.arch_guard.scan_allowlist_ratchet_coverage(
+            src_allowlists=[("tsz-demo", "Demo", {rel})],
+            tests_allowlists=[],
+            file_line_checks=[("Demo ratchet", ROOT / rel, 2500)],
+        )
+        self.assertEqual(gap, [])
+
+    def test_tests_allowlist_entries_are_covered_too(self):
+        """The tests-tree allowlist is scanned alongside the src allowlist."""
+        rel = "crates/tsz-demo/tests/huge_tests.rs"
+        gap = self.arch_guard.scan_allowlist_ratchet_coverage(
+            src_allowlists=[],
+            tests_allowlists=[("tsz-demo", "Demo", {rel})],
+            file_line_checks=[],
+        )
+        self.assertEqual(gap, [rel])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #16488.

The repo contract sets a hard 2000-physical-line ceiling on every hand-authored
shard. #16733/#16745 registered every `crates/*/src` and `crates/*/tests` root
under a per-crate 2000-LOC directory cap — but a file named in a crate's
**allowlist** is *exempt* from that cap. 11 allowlisted files carried no
`FILE_LINE_LIMIT_CHECKS` ratchet of their own, so they were bounded by nothing
and could grow without limit above 2000 while `arch-size` stayed green. That is
the residual form of the `core_dispatch.rs`-at-2075 hole the issue reports:
`arch_guard.py` returns rc=0 today with these files already over the ceiling and
free to keep growing.

Structural rule: **allowlisted implies ratcheted.** A file exempted from the
directory cap must carry an explicit per-file size ratchet, so the ceiling is
enforced in one direction or the other for every file — never neither.

## Changes
- Pin the 11 allowlisted-but-unratcheted files at their observed size in
  `FILE_LINE_LIMIT_CHECKS` (all are test / test-module files), matching the
  shrink-only convention the other 23 allowlisted files already follow.
- Add `scan_allowlist_ratchet_coverage`, wired into both the full guard run and
  the `--size-only` CI gate. It fails if any allowlist entry lacks a ratchet —
  the same coverage-invariant pattern `scan_line_limit_coverage` uses for crate
  registration — so the ceiling cannot silently reopen for a newly allowlisted
  file.
- 4 new unit tests in `test_arch_guard.py` (real-repo coverage is clean; a
  synthetic allowlisted-without-ratchet file is flagged; a ratcheted one is not;
  the tests-tree allowlist is scanned alongside `src`).

No Rust / compiler behavior changes — guard-only.

## Goal
Goal: hold

## Verification
- `python3 scripts/arch/arch_guard.py` → rc=0 (full guard passes)
- `python3 scripts/arch/arch_guard.py --size-only` → rc=0 (CI size gate passes)
- `python3 -m unittest discover -p "test_arch_guard*.py"` → 493 pass (+4 new)
- Enforcement proven both ways: growing any of the 11 pinned files by one line
  now fails `scan_file_line_limit`; a new allowlisted file with no ratchet is
  flagged by `scan_allowlist_ratchet_coverage`.

## Provenance
Machine: cloud
Assistant: claude-code
Model: Opus 4.8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3L1r8vUEMdcWbsyWEiN8P)_