### PR TITLE
fourslash: raise per-test timeout default 15s -> 25s to absorb contention

### DIFF
--- a/scripts/ci/full-ci.sh
+++ b/scripts/ci/full-ci.sh
@@ -920,7 +920,7 @@ run_fourslash_shard() {
     --shard="${shard_index}/${shard_count}" \
     --shard-strategy="${TSZ_CI_FOURSLASH_SHARD_STRATEGY:-weighted}" \
     --workers="$FOURSLASH_WORKERS" \
-    --timeout="${TSZ_CI_FOURSLASH_TIMEOUT_MS:-15000}" \
+    --timeout="${TSZ_CI_FOURSLASH_TIMEOUT_MS:-25000}" \
     --memory-limit=512 \
     --json-out="$detail_json"
   local rc="$?"

--- a/scripts/fourslash/run-fourslash.sh
+++ b/scripts/fourslash/run-fourslash.sh
@@ -88,7 +88,7 @@ OPTIONS:
     Parallelism:
     --workers=N         Number of parallel workers (default: CPU count)
     --sequential        Run tests sequentially (single process, no workers)
-    --timeout=MS        Per-test timeout in ms (default: 15000)
+    --timeout=MS        Per-test timeout in ms (default: 25000)
     --memory-limit=MB   Per-worker memory limit in MB (default: 512)
 
     Build:

--- a/scripts/fourslash/runner.cjs
+++ b/scripts/fourslash/runner.cjs
@@ -7,7 +7,7 @@
  *
  * Features:
  * - Parallel execution with N workers (default: CPU count)
- * - Per-test timeout protection (default: 15s)
+ * - Per-test timeout protection (default: 25s)
  * - Per-worker OOM protection with memory monitoring + bridge restart
  * - Worker crash recovery (remaining tests redistributed)
  * - Detailed timing and memory stats in summary
@@ -36,7 +36,7 @@
  *   --server-tests        Run server-specific tests
  *   --workers=N           Number of parallel workers (default: CPU count)
  *   --sequential          Run tests sequentially (single process, no workers)
- *   --timeout=MS          Per-test timeout in ms (default: 15000)
+ *   --timeout=MS          Per-test timeout in ms (default: 25000)
  *   --memory-limit=MB     Per-worker memory limit in MB (default: 512)
  */
 
@@ -74,7 +74,7 @@ function parseArgs() {
         serverTests: false,
         workers: os.cpus().length,
         sequential: false,
-        testTimeout: 15000,
+        testTimeout: 25000,
         memoryLimitMB: 512,
         jsonOut: null,
     };
@@ -609,7 +609,7 @@ async function runParallel(opts, testsToRun) {
     // Wall-clock timeout per test: if a worker sends no result for this long, kill it.
     // This catches infinite loops in the Rust server that the per-request Atomics.wait
     // timeout (30s) cannot fully guard against (a test may make dozens of requests).
-    const WORKER_WATCHDOG_MS = opts.testTimeout * 4; // 60s default (4x the 15s per-test timeout)
+    const WORKER_WATCHDOG_MS = opts.testTimeout * 4; // 100s default (4x the 25s per-test timeout)
 
     console.log(`  Spawning ${chunks.length} workers (timeout: ${opts.testTimeout}ms, mem limit: ${opts.memoryLimitMB}MB)...`);
 

--- a/scripts/fourslash/test-worker.cjs
+++ b/scripts/fourslash/test-worker.cjs
@@ -35,8 +35,9 @@ function preloadLibFiles(builtLocal) {
     } catch { /* best-effort */ }
 }
 
-// Per-test timeout (ms) - tests taking longer are killed
-const TEST_TIMEOUT_MS = 15000;
+// Per-test timeout (ms) - tests taking longer are killed. Fallback only:
+// runner.cjs always passes testTimeout explicitly (see its own default).
+const TEST_TIMEOUT_MS = 25000;
 // Memory threshold per worker (bytes) - restart bridge if exceeded
 const MEMORY_THRESHOLD_BYTES = 512 * 1024 * 1024; // 512MB
 // Check memory every N tests


### PR DESCRIPTION
Fixes #16837.

The fourslash suite's per-test timeout default (15000ms, in `runner.cjs`)
is too tight for contention-bound tests under full-suite parallelism.
#16837 measured `renameImport` taking ~5.4s in isolation but ~17s under
the full 6562-test suite at 16 workers on an m4 — 13% over the 15s
default — and confirmed with a same-commit rebuild that this is pure
machine-state variance, not a code regression: the identical commit
flips between 6558/4 and 6557/5 depending on contention alone. That is
exactly the kind of false-parity-regression signal that costs review
time, since the failing-test *name* looks like a real change and a
count-based audit reports "1 new failure" for a commit that changed
nothing.

This raises the shared default from 15000ms to 25000ms everywhere it's
defined, giving the observed ~17s real margin (the issue's own
recommended option 1 — the "immediate unblock"; option 3, fixing the
underlying per-test cost, is out of scope for this change):

- `runner.cjs`'s own `testTimeout` default + help text
- `run-fourslash.sh`'s help text
- `test-worker.cjs`'s fallback constant (`runner.cjs` always passes
  `testTimeout` explicitly today, so this is a consistency-only change)
- `full-ci.sh`'s `${TSZ_CI_FOURSLASH_TIMEOUT_MS:-15000}` fallback

The GitHub Actions workflow already overrides this explicitly via
`TSZ_CI_FOURSLASH_TIMEOUT_MS: 60000` and is unaffected either way. What
this actually fixes is the CLAUDE.md-documented local verification
command (`./scripts/fourslash/run-fourslash.sh --skip-build`), which
has no override and was hitting the too-tight 15s default.

No Rust changed — this doesn't touch the clippy+arch-size per-merge
lane.

## Goal
Goal: hold

## Verification
- `node --check` on both touched `.cjs` files, `bash -n` on both touched
  `.sh` files — clean.
- `./scripts/fourslash/run-fourslash.sh --max=40` (fresh release build,
  4-core cloud box): confirmed the runner logs `timeout: 25000ms` (the
  new default took effect) and all 40 sampled tests pass.
- Full suite, `./scripts/fourslash/run-fourslash.sh --skip-build`
  (4-core cloud box, so real contention despite fewer workers than the
  issue's 16-core measurement): **6558 passed, 4 failed out of 6562**
  (99.9%) — exactly the ROADMAP.md floor (`6,558 / 6,562`), and the 4
  failures are byte-identical to the issue's own named stable set
  (`completionListFunctionExpression`, `importNameCodeFix_importType`,
  `importFixesWithPackageJsonInSideAnotherPackage`,
  `autoImportProvider_importsMap1`). Critically, `renameImport` — the
  test named in the issue — passed at **19592ms**, which would have
  timed out and flipped the gate to 6557/5 under the old 15000ms
  default; this run reproduces the exact contention-bound slowness the
  issue describes and confirms the new timeout absorbs it.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1DKjhvJXJJSf9FbUUn6Y4)_