### PR TITLE
fix(checker): using/await using disposable check validates full structural assignability

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/core.rs
+++ b/crates/tsz-checker/src/types/type_checking/core.rs
@@ -1823,19 +1823,7 @@ impl<'a> CheckerState<'a> {
         init_type: TypeId,
         anchor: NodeIndex,
     ) -> Option<Vec<crate::diagnostics::DiagnosticRelatedInformation>> {
-        let lib_binders = self.get_lib_binders();
-        let disposable_sym = self
-            .ctx
-            .binder
-            .get_global_type_with_libs("Disposable", &lib_binders)?;
-        // Build the `Disposable` target exactly as a `: Disposable` annotation
-        // would: prime the `DefId` (registering the lib interface body in the type
-        // environment) and intern it as `Lazy(DefId)`. A bare `get_type_of_symbol`
-        // here yields an unresolved/member-less shell when nothing else in the file
-        // referenced `Disposable` (the `using` initializer is the only consumer),
-        // so the relation would see no `[Symbol.dispose]` member.
-        let def_id = self.ensure_def_ready_for_lowering(disposable_sym, "Disposable");
-        let disposable_type = self.ctx.types.lazy(def_id);
+        let disposable_type = self.resolve_disposable_interface_type(false)?;
         let analysis = self.analyze_assignability_failure(init_type, disposable_type);
         let reason = analysis.failure_reason?;
         let rendered = self.render_failure_reason(&reason, init_type, disposable_type, anchor, 0);
@@ -1855,6 +1843,30 @@ impl<'a> CheckerState<'a> {
                 .map(|info| info.with_depth_shift(1)),
         );
         Some(related)
+    }
+
+    /// Resolve the `Disposable`/`AsyncDisposable` global interface as a
+    /// `Lazy(DefId)` type, primed for lowering exactly as a `: Disposable`
+    /// annotation would be. Returns `None` when the current lib does not
+    /// declare the interface (e.g. `--lib` without `esnext.disposable`).
+    ///
+    /// A bare `get_type_of_symbol` here would yield an unresolved/member-less
+    /// shell when nothing else in the file references the interface (a
+    /// `using` initializer is often its only consumer), so the relation
+    /// would see no `[Symbol.dispose]`/`[Symbol.asyncDispose]` member.
+    fn resolve_disposable_interface_type(&mut self, want_async: bool) -> Option<TypeId> {
+        let name = if want_async {
+            "AsyncDisposable"
+        } else {
+            "Disposable"
+        };
+        let lib_binders = self.get_lib_binders();
+        let sym = self
+            .ctx
+            .binder
+            .get_global_type_with_libs(name, &lib_binders)?;
+        let def_id = self.ensure_def_ready_for_lowering(sym, name);
+        Some(self.ctx.types.lazy(def_id))
     }
 
     /// Check if a type has the appropriate dispose method.
@@ -1915,19 +1927,26 @@ impl<'a> CheckerState<'a> {
             return true;
         }
 
-        // Check for the dispose method on the object type
-        let has_dispose = has_property(self, type_id, &["[Symbol.dispose]", "Symbol.dispose"]);
+        // Check the object type against the full `Disposable`/`AsyncDisposable`
+        // structural shape (`tsc`'s `checkTypeAssignableTo`), not mere property
+        // existence — a `[Symbol.dispose]`/`[Symbol.asyncDispose]` method with an
+        // incompatible signature (extra required params, wrong parameter types,
+        // or for the async case a non-`PromiseLike` return type) must still be
+        // rejected, while the ordinary void-return exception (a `(): number`
+        // dispose method) must still be accepted, exactly as the relation
+        // already implements for every other assignability check.
+        let is_disposable = self
+            .resolve_disposable_interface_type(false)
+            .is_some_and(|target| self.is_assignable_to(type_id, target));
 
         if is_await_using {
             // await using accepts either Symbol.asyncDispose or Symbol.dispose
-            return has_dispose
-                || has_property(
-                    self,
-                    type_id,
-                    &["[Symbol.asyncDispose]", "Symbol.asyncDispose"],
-                );
+            return is_disposable
+                || self
+                    .resolve_disposable_interface_type(true)
+                    .is_some_and(|target| self.is_assignable_to(type_id, target));
         }
 
-        has_dispose
+        is_disposable
     }
 }


### PR DESCRIPTION
When `<structural condition>` a `using`/`await using` declaration's initializer has a `[Symbol.dispose]`/`[Symbol.asyncDispose]` method whose *signature* is not assignable to `Disposable`/`AsyncDisposable` (wrong return type, extra required params), `tsc` does report TS2850/TS2851 through `checkTypeAssignableTo(initType, Disposable/AsyncDisposable)`; tsz did not, through `check_using_declaration_disposable`'s gate (`type_has_disposable_method`) — a bespoke property-*existence* probe that only asked "does a property with this name resolve?" and never checked the method's signature.

The full structural-assignability machinery already existed one call away: `disposable_relation_tail` (added for the TS2850 elaboration tail) already calls `analyze_assignability_failure(init_type, disposable_type)` against a properly-primed `Disposable` lazy type — but only *after* the property-existence gate had already (wrongly) let a bad initializer through, so it was unreachable for this family of bug. This PR:

- Extracts the existing `Disposable`-priming logic (`get_global_type_with_libs` + `ensure_def_ready_for_lowering` + `db.lazy`) into a shared `resolve_disposable_interface_type(want_async)` helper, reused by both `disposable_relation_tail` and the gate itself.
- Replaces `type_has_disposable_method`'s final property-existence check with a real `is_assignable_to(type_id, target)` call against `Disposable` (sync `using`) or `AsyncDisposable`/`Disposable` (`await using`, either satisfies it — oracle-verified).

This reuses the shared relation (`is_assignable_to`), which already implements `tsc`'s "void-return exception" (a `(): number` dispose method is still accepted, since anything is assignable to a `void`-returning target position) — no new special-casing needed.

## Witness (oracle-verified, `typescript@7.0.2`, `--target esnext --lib esnext`)

| source | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `await using x = { [Symbol.asyncDispose](): void {} }` | TS2851 (`void` not assignable to `PromiseLike<void>`) | clean (false negative) | TS2851 |
| `using x = { [Symbol.dispose](extra: number) {} }` | TS2850 (too few args on target) | clean (false negative) | TS2850 |
| `using x = { [Symbol.dispose](): number { return 1 } }` | clean (void-return exception) | clean | clean |
| `await using x = { [Symbol.dispose]() {} }` (sync-only) | clean (accepts either interface) | clean | clean |
| `using x = { [Symbol.dispose]() {} }` | clean | clean | clean |
| `declare const x: { foo: number }; using r = x;` | TS2850 | TS2850 | TS2850 |

Adjacent/negative cases confirmed clean both before and after: a genuinely conforming `Disposable`/`AsyncDisposable` object, `null`/`undefined` initializers, `any`/`error`-typed initializers, and libs without `esnext.disposable` (gate no-ops as before, preserved by `resolve_disposable_interface_type` returning `None`).

Note: this also exposes a secondary, pre-existing formatting quirk in the shared `render_failure_reason` elaboration tail — for a *type-mismatch* (not "missing property") `Disposable` relation failure, tsz's tail carries an extra top-level "Type X is not assignable to type Disposable" line and one level of mis-nesting that `tsc`'s real output omits. That code path (`disposable_relation_tail` → `render_failure_reason`) existed before this PR but was previously unreachable from `using`/`await using` since the property-existence gate always short-circuited before reaching it. It's a distinct, separately-owned formatting concern (shared rendering infrastructure, not specific to `using`), so I'm not folding a fix for it into this PR — the diagnostic *code*, *position*, and *primary message* are all byte-correct; only the elaboration tail carries the extra noise. Filing as a follow-up issue.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test using_disposable_elaboration_tests`: 5/5 passed (pre-existing pinned tests, unaffected).
- `cargo test -p tsz-checker --lib -- using`: 33/33 passed (all using/await-using-related tests, including binding-pattern suppression and implicit-any interactions).
- `cargo clippy -p tsz-checker --lib -- -D warnings`: clean.
- `cargo fmt -p tsz-checker -- --check`: clean.
- Oracle matrix above (`typescript@7.0.2`) run against a rebuilt `release` `tsz` binary: false negative fixed, all adjacent/negative cases unchanged.
- `scripts/conformance/compare-to-parent.sh` started; this change is narrow (only reachable from `using`/`await using` initializers, a rare ES2022+ feature) so 0/0 is expected — will report the actual numbers on this PR once the two-sided build finishes (~55-90 min on a cold container per prior sessions' measurements).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_01P3evSrwyhdhjTad6PPKnei)_