### PR TITLE
fix(cli): suppress TS1274 alongside a real syntax error (#16279 audit round 9)

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -670,6 +670,29 @@ const fn is_parser_grammar_code(code: u32) -> bool {
         | 1213 // Identifier expected. '{0}' is a reserved word in strict mode. Class definitions are automatically in strict mode.
         | 1024 // 'readonly' modifier can only appear on a property declaration or index signature
         | 1242 // 'abstract' modifier can only appear on a class, method, or property declaration
+        | 1274 // '{0}' modifier can only appear on a type parameter of a class,
+                // interface or type alias. tsc's checkGrammarModifiers reports
+                // this for `in`/`out` used as a PARAMETER modifier (e.g.
+                // `function f(in x: number) {}`); tsz emits that shape from
+                // the parser's `parameter_modifier_grammar_error`
+                // (`state_statements_class.rs`). #16279 audit round 9:
+                // oracle-confirmed against `typescript@7.0.2` — Direction A,
+                // `function f(in x: number) {}` (and the `out` sibling)
+                // alone reports TS1274 exactly once; Direction B, the same
+                // line plus an unrelated real syntax error (`let x: = 1;`)
+                // elsewhere in the file drops TS1274 entirely on the real
+                // compiler, which tsz's parser-emitted copy did not.
+                //
+                // TS1274 has a SECOND, independent emission shape this list
+                // does not cover: `in`/`out` used as a class member's own
+                // modifier (`class C { in x }`) is checker-emitted, from
+                // `check_variance_modifier_not_on_class_member_node`
+                // (`class_type_param_checks.rs`) — a `CheckerDiagnostic`,
+                // never a `ParseDiagnostic`, so it never reaches this list or
+                // `filtered_parse_diagnostics`. That shape's suppression gap
+                // is fixed separately via `is_checker_routed_ts1xxx_grammar`
+                // below. No double-emission between the two: a parameter and
+                // a class member are disjoint node kinds.
         | 1243 // '{0}' modifier cannot be used with '{1}' modifier
         | 1246 // An interface property cannot have an initializer
         | 1247 // A type literal property cannot have an initializer
@@ -914,6 +937,19 @@ pub(super) const fn is_checker_routed_ts1xxx_grammar(code: u32) -> bool {
         | 1314 // Global module exports may only appear in module files.
         | 1315 // Global module exports may only appear in declaration files.
         | 1316 // Global module exports may only appear at top level.
+        // `in`/`out` used as a class member's own modifier (`class C { in x }`,
+        // as opposed to a parameter modifier — see the parser-emitted 1274 arm
+        // in `is_parser_grammar_code` above for that shape). tsc's
+        // `checkGrammarModifiers` reports this from the checker; tsz's
+        // `check_variance_modifier_not_on_class_member_node`
+        // (`class_type_param_checks.rs`) does too, but unconditionally, with
+        // no `hasParseDiagnostics`-equivalent gate. #16279 audit round 9:
+        // oracle-confirmed against `typescript@7.0.2` — Direction A,
+        // `class C { in x = 1; }` (and `out`) alone reports TS1274 exactly
+        // once; Direction B, the same line plus an unrelated real syntax
+        // error (`let x: = 1;`) elsewhere in the file drops TS1274 entirely,
+        // which tsz's checker-emitted copy did not.
+        | 1274 // '{0}' modifier can only appear on a type parameter of a class, interface or type alias
     )
 }
 
@@ -1887,6 +1923,10 @@ mod for_in_of_single_declaration_grammar_tests;
 #[cfg(test)]
 #[path = "check_utils/audit_round_3_grammar_tests.rs"]
 mod audit_round_3_grammar_tests;
+
+#[cfg(test)]
+#[path = "check_utils/audit_round_9_grammar_tests.rs"]
+mod audit_round_9_grammar_tests;
 
 #[cfg(test)]
 #[path = "check_utils/parser_grammar_non_suppressing_tests.rs"]

--- a/crates/tsz-cli/src/driver/check_utils/audit_round_9_grammar_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/audit_round_9_grammar_tests.rs
@@ -1,0 +1,90 @@
+//! Unit tests for #16279 audit round 9: TS1274 (`'{0}' modifier can only
+//! appear on a type parameter of a class, interface or type alias`) — see
+//! the doc comment on `is_parser_grammar_code` for the oracle-derived
+//! structural rule. Split into its own file rather than growing `tests.rs`
+//! past the 2000-line limit (§19).
+
+use super::*;
+
+fn assert_suppressed_by_real_parse_error(code: u32, message: &str) {
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 20,
+            length: 2,
+            message: message.to_string(),
+            code,
+            related: None,
+        },
+        ParseDiagnostic {
+            start: 60,
+            length: 1,
+            message: "Type expected.".to_string(),
+            code: 1110,
+            related: None,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&code),
+        "TS{code} should be suppressed when a real parse error (TS1110) is present, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1110),
+        "TS1110 (real parse error) should survive, got: {codes:?}"
+    );
+}
+
+fn assert_survives_alone(code: u32, message: &str) {
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![ParseDiagnostic {
+        start: 20,
+        length: 2,
+        message: message.to_string(),
+        code,
+        related: None,
+    }];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&code),
+        "TS{code} should survive when it is the only diagnostic in the file, got: {codes:?}"
+    );
+}
+
+#[test]
+fn ts1274_in_suppressed_when_real_parse_error_present() {
+    assert_suppressed_by_real_parse_error(
+        1274,
+        "'in' modifier can only appear on a type parameter of a class, interface or type alias.",
+    );
+}
+
+#[test]
+fn ts1274_in_survives_alone() {
+    assert_survives_alone(
+        1274,
+        "'in' modifier can only appear on a type parameter of a class, interface or type alias.",
+    );
+}
+
+#[test]
+fn ts1274_out_suppressed_when_real_parse_error_present() {
+    assert_suppressed_by_real_parse_error(
+        1274,
+        "'out' modifier can only appear on a type parameter of a class, interface or type alias.",
+    );
+}
+
+#[test]
+fn ts1274_out_survives_alone() {
+    assert_survives_alone(
+        1274,
+        "'out' modifier can only appear on a type parameter of a class, interface or type alias.",
+    );
+}

--- a/crates/tsz-cli/src/driver/checker_diagnostics.rs
+++ b/crates/tsz-cli/src/driver/checker_diagnostics.rs
@@ -327,6 +327,11 @@ mod tests {
         assert!(!keep_checker_diagnostic_when_program_has_real_syntax_errors(1314));
         assert!(!keep_checker_diagnostic_when_program_has_real_syntax_errors(1315));
         assert!(!keep_checker_diagnostic_when_program_has_real_syntax_errors(1316));
+        // #16279 audit round 9: `in`/`out` as a class member's own modifier
+        // (`class C { in x }`) is checker-emitted
+        // (`check_variance_modifier_not_on_class_member_node`); tsc's oracle
+        // suppresses it alongside an unrelated real syntax error.
+        assert!(!keep_checker_diagnostic_when_program_has_real_syntax_errors(1274));
         assert!(keep_checker_diagnostic_when_program_has_real_syntax_errors(
             1005
         ));


### PR DESCRIPTION
Structural rule: when a program also carries a real syntax error, tsc suppresses TS1274 ("'{0}' modifier can only appear on a type parameter of a class, interface or type alias") the same way it suppresses every other `checkGrammarModifiers`-family diagnostic — tsc emits these from the checker via `grammarErrorOnNode`, gated on `hasParseDiagnostics(sourceFile)`. tsz has two independent emission sites for TS1274 and neither was gated:

1. **Parameter modifier position** (`function f(in x: number) {}`) — parser-emitted, from `parameter_modifier_grammar_error` in `crates/tsz-parser/src/parser/state_statements_class.rs`. Owner: the `is_parser_grammar_code`/`filtered_parse_diagnostics` suppression pipeline in `crates/tsz-cli/src/driver/check_utils.rs`.
2. **Class member's own modifier position** (`class C { in x }`, and the method/accessor siblings) — checker-emitted, from `check_variance_modifier_not_on_class_member_node` in `crates/tsz-checker/src/state/state_checking_members/class_type_param_checks.rs`, called unconditionally with no syntax-error gate. Owner: the separate `is_checker_routed_ts1xxx_grammar` list (`crates/tsz-cli/src/driver/checker_diagnostics.rs`), which drives `keep_checker_diagnostic_when_program_has_real_syntax_errors`.

This is part of #16279's ongoing audit (the `is_parser_grammar_code` self-suppressing-set problem): a code emitted from two different tsz layers needs its suppression wired at both layers independently, and this is a case neither prior slice caught.

Fixed by adding `1274` to both allowlists, each with its own oracle-derived comment explaining which shape it covers so the two don't get conflated again.

## Adjacent-case matrix (oracle: `typescript@7.0.2`)

| shape | source | tsc alone | tsc + unrelated syntax error |
| --- | --- | --- | --- |
| parameter, `in` | `function f(in x: number) {}` | TS1274 | suppressed |
| parameter, `out` | (sibling) | TS1274 | suppressed |
| class property, `in` | `class C { in x = 1; }` | TS1274 | suppressed |
| class property, `out` | `class C { out y = 1; }` | TS1274 | suppressed |
| class method, `in` | `class C { in m(): void {} }` | TS1274 | suppressed |
| class accessor, `out` | `class C { out get x(): number {...} }` | TS1274 | suppressed |
| interface member (control) | `interface I { in x: number; }` | TS1070 (different code, already correct) | n/a |

tsz matches tsc exactly on all seven after the fix (all seven were verified byte-for-byte against a rebuilt `dev` binary, both before showing the bug and after showing the fix).

## Goal
Goal: hold

## Verification
- Oracle matrix above: 7/7 exact match against `typescript@7.0.2`, both pre-fix (reproducing the over-report) and post-fix.
- `cargo test -p tsz-cli --lib` (new `audit_round_9_grammar_tests` + existing `real_syntax_errors_suppress_semantic_ts1xxx_but_keep_parse_diagnostics`, extended with a TS1274 assertion): 1758 passed / 0 failed (the 18 pre-existing failures — 13 environment-dependent `tsc_compat_tests`/`tsc_parity_*` tests needing a locally-installed `tsc@7.0.2` on `PATH`, plus 5 unrelated pre-existing failures — reproduce identically on unmodified `main`, confirmed by re-running them with the diff stashed).
- `cargo clippy -p tsz-cli --lib --all-targets -- -D warnings`: clean.
- `cargo fmt -p tsz-cli -- --check`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.
- `scripts/conformance/compare-to-parent.sh`: running in the background at push time (two `dist-fast` builds, ~55-90 min on this container per the board's standing note); will report newly-passing/newly-failing counts once it completes. This is a diagnostic-suppression-only change (adds one code to two existing allowlists, no new code paths), so no regression is expected, but the number is owed and will be posted.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_011M9yQq9s893FypoGKLDv5s)_