### PR TITLE
fix(bench): stop silently omitting unmeasured corpus rows from compatibility reporting

### DIFF
--- a/crates/tsz-website/scripts/benchmark-data-smoke.mjs
+++ b/crates/tsz-website/scripts/benchmark-data-smoke.mjs
@@ -521,9 +521,12 @@ try {
   assert.match(compatibilityDashboard, /type-challenges solutions[\s\S]*compat-state green/);
   assert.match(compatibilityDashboard, /umami[\s\S]*compat-state green[\s\S]*204 files[\s\S]*200 MiB peak/);
   assert.doesNotMatch(compatibilityDashboard, /type-challenges assertions/);
-  // Unmeasured (gray) rows are excluded entirely; the dashboard never renders "Not measured".
-  assert.doesNotMatch(compatibilityDashboard, /Not measured/);
-  assert.doesNotMatch(compatibilityDashboard, /compat-state gray/);
+  // Unmeasured (gray) rows are rendered explicitly as "Not measured" (#16310) so
+  // shrinking coverage is visible instead of silently dropped, and the dashboard
+  // publishes a coverage summary of measured-vs-defined rows.
+  assert.match(compatibilityDashboard, /Not measured/);
+  assert.match(compatibilityDashboard, /compat-state gray/);
+  assert.match(compatibilityDashboard, /defined corpus rows measured/);
 
   process.env.TSZ_WEBSITE_BENCHMARK_ARTIFACT = failedOnlyArtifact;
   const failedOnlyCharts = getBenchmarkCharts();
@@ -544,10 +547,11 @@ try {
   assert.match(failedOnlyCompatibility, /data-compat-sort="files"/);
   assert.match(failedOnlyCompatibility, /data-compat-sort="peak"/);
   assert.match(failedOnlyCompatibility, /RxJS[\s\S]*compat-state yellow[\s\S]*diagnostic mismatch[\s\S]*12 files[\s\S]*100 MiB peak/);
-  // Gray "oracle unavailable" / unmeasured rows (e.g. large-ts-repo) are excluded.
-  assert.doesNotMatch(failedOnlyCompatibility, /large-ts-repo/);
-  assert.doesNotMatch(failedOnlyCompatibility, /Not measured/);
-  assert.doesNotMatch(failedOnlyCompatibility, /compat-state gray/);
+  // Gray "oracle unavailable" / unmeasured rows (e.g. large-ts-repo) are now
+  // rendered explicitly as "Not measured" rather than excluded (#16310).
+  assert.match(failedOnlyCompatibility, /large-ts-repo/);
+  assert.match(failedOnlyCompatibility, /Not measured/);
+  assert.match(failedOnlyCompatibility, /compat-state gray/);
   assert.match(failedOnlyCompatibility, /utility-types[\s\S]*compat-state red[\s\S]*exit success[\s\S]*10 files[\s\S]*—/);
 
   const slugs = new Map();

--- a/crates/tsz-website/src/_data/benchmark_data.js
+++ b/crates/tsz-website/src/_data/benchmark_data.js
@@ -1759,12 +1759,17 @@ export function getBenchmarkEnvironmentSummary() {
 export function getProjectCompatibilityDashboard() {
   const data = loadBenchmarks();
   const allResults = withExpectedProjectRows(data?.results);
-  // Only show rows we actually measured. A "gray" / "Not measured" row (no
-  // compatibility artifact, oracle unavailable, or fixture not recorded) carries
-  // no signal, so it is excluded rather than rendered as "Not measured".
+  // Render EVERY defined corpus row, including unmeasured ("gray") ones (#16310).
+  // A row that is never measured is otherwise indistinguishable, downstream,
+  // from a row that does not exist — so coverage can silently shrink and nothing
+  // reports it. An unmeasured row is shown as "Not measured" and still carries
+  // its reason in the Exit class column ("missing or incomplete artifact" /
+  // "fixture invalid"), which is honest and creates pressure to fix it.
   const rows = COMPATIBILITY_CORPUS_ROWS
-    .map((definition) => compatibilityRowFor(definition, allResults, data))
-    .filter((row) => row.className !== "gray");
+    .map((definition) => compatibilityRowFor(definition, allResults, data));
+
+  const measuredCount = rows.filter((row) => row.className !== "gray").length;
+  const notMeasuredCount = rows.length - measuredCount;
 
   if (!rows.length) {
     return `<section class="compat-dashboard">
@@ -1830,9 +1835,21 @@ export function getProjectCompatibilityDashboard() {
 })();
 </script>`;
 
+  const runStatusRaw = String(data?.run_status || "").trim();
+  let runStatusLabel = "";
+  if (runStatusRaw === "local") runStatusLabel = "local snapshot (not a CI run)";
+  else if (runStatusRaw) runStatusLabel = `run status: ${runStatusRaw}`;
+  const provenanceSummary = runnerEnvironmentSummary(data);
+  const provenanceParts = [provenanceSummary, escapeHtml(runStatusLabel)].filter(Boolean);
+  const provenanceLine = provenanceParts.length
+    ? `\n  <p class="compat-dashboard-meta">${provenanceParts.join(" · ")}</p>`
+    : "";
+  const coverageLine = `<p class="compat-dashboard-coverage">${measuredCount} of ${rows.length} defined corpus rows measured${notMeasuredCount ? ` · ${notMeasuredCount} not measured` : ""}.</p>`;
+
   return `<section class="compat-dashboard">
   <h2>Project compatibility</h2>
-  <p class="compat-dashboard-intro">These rows track real project fixtures that <code>tsc</code> accepts. A green row means <code>tsz</code> completed the same project check; red or yellow rows identify the current compatibility blocker.</p>
+  <p class="compat-dashboard-intro">These rows track real project fixtures that <code>tsc</code> accepts. A green row means <code>tsz</code> completed the same project check; red or yellow rows identify the current compatibility blocker. A "Not measured" row is a defined corpus project with no measurement in the latest artifact.</p>
+  ${coverageLine}${provenanceLine}
   <div class="compat-table-wrap">
     <table class="compat-table" data-compat-sortable>
       <thead>

--- a/scripts/bench/merge-results.mjs
+++ b/scripts/bench/merge-results.mjs
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import {
+  COMPATIBILITY_CORPUS_ROW_NAMES,
   COMPILE_CANARY_PROJECT_ROWS,
   PROJECT_ROW_DEFINITIONS,
   REQUIRED_COMPATIBILITY_FIELDS,
@@ -459,6 +460,26 @@ function validateMeasurementProfileConsistency(profiles) {
 //     primary content. The genuinely-unsafe TIMING conditions (fewer than the
 //     expected shards, a missing REQUIRED timing row) are enforced independently
 //     by the bench.yml shard-count gate and check-artifact-readiness.mjs.
+// Enumerate every DEFINED compatibility corpus row that carries no measured row,
+// so coverage can never silently shrink (#16310). This spans the FULL corpus —
+// the 20 `category:"application"` rows included — a strictly wider scope than
+// `collectProjectCompatibilityFailures` below, which validates only the
+// required ∪ compile-canary subset (`PROJECT_COMPATIBILITY_ROW_SET`). Previously
+// the missing-row advisory walked only `REQUIRED_PROJECT_ROWS`, so an unmeasured
+// application row was indistinguishable downstream from a row that does not
+// exist. Keyed on the full set of measured row names, and gated on the artifact
+// actually carrying at least one corpus row so unrelated timing-only/standalone
+// artifacts are not spuriously advised against the whole corpus.
+function collectMissingCorpusRows(rows) {
+  const measuredNames = new Set(rows.map((row) => row?.name).filter(Boolean));
+  if (!COMPATIBILITY_CORPUS_ROW_NAMES.some((name) => measuredNames.has(name))) {
+    return [];
+  }
+  return COMPATIBILITY_CORPUS_ROW_NAMES
+    .filter((name) => !measuredNames.has(name))
+    .map((name) => `${name}: missing project row`);
+}
+
 function collectProjectCompatibilityFailures(rows) {
   const blocking = [];
   const advisory = [];
@@ -479,14 +500,6 @@ function collectProjectCompatibilityFailures(rows) {
   // artifact double-counts a benchmark, which corrupts win/timing totals.
   for (const name of [...duplicateNames].sort()) {
     blocking.push(`${name}: duplicate project row`);
-  }
-
-  if (projectRows.some((row) => REQUIRED_PROJECT_ROW_SET.has(row.name))) {
-    for (const name of REQUIRED_PROJECT_ROWS) {
-      if (!seenNames.has(name)) {
-        advisory.push(`${name}: missing project row`);
-      }
-    }
   }
 
   for (const row of projectRows) {
@@ -642,6 +655,7 @@ function main() {
   );
 
   const { blocking: compatBlocking, advisory: compatAdvisory } = collectProjectCompatibilityFailures(results);
+  compatAdvisory.push(...collectMissingCorpusRows(results));
   if (compatAdvisory.length > 0) {
     // Advisory project-compatibility gaps must NOT block publishing benchmark
     // timing data (issue #13607). Surface them as GitHub annotations and keep

--- a/scripts/bench/project-rows.mjs
+++ b/scripts/bench/project-rows.mjs
@@ -1311,3 +1311,8 @@ export const COMPATIBILITY_CORPUS_ROWS = PROJECT_ROW_DEFINITIONS
     family: row.family,
     readme_candidates: row.readme_candidates,
   }));
+
+// The names of every defined compatibility corpus row, kept beside its sibling
+// derived name-lists so consumers (the merge advisory, the website dashboard)
+// share one canonical source instead of re-deriving `.map(row => row.name)`.
+export const COMPATIBILITY_CORPUS_ROW_NAMES = COMPATIBILITY_CORPUS_ROWS.map((row) => row.name);

--- a/scripts/bench/test-merge-results.mjs
+++ b/scripts/bench/test-merge-results.mjs
@@ -5,7 +5,11 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { COMPILE_CANARY_PROJECT_ROWS, REQUIRED_PROJECT_ROWS } from "./project-rows.mjs";
+import {
+  COMPILE_CANARY_PROJECT_ROWS,
+  PROJECT_ROW_DEFINITIONS,
+  REQUIRED_PROJECT_ROWS,
+} from "./project-rows.mjs";
 import { GREEN_COMPAT, YELLOW_COMPAT, RED_COMPAT } from "./row-utils.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -246,6 +250,31 @@ withTempDir((dir) => {
   assert.ok(
     merged.validation.project_compatibility_advisory.includes(`${missingRow}: missing project row`),
     "advisory gap must be recorded in merged.validation.project_compatibility_advisory",
+  );
+});
+
+// Issue #16310: the missing-project-row advisory must span the FULL defined
+// compatibility corpus, not just REQUIRED_PROJECT_ROWS. A `category:"application"`
+// row (guard_set:"canary", never in REQUIRED) that is absent from every shard
+// must be advised, otherwise unmeasured application coverage shrinks silently.
+withTempDir((dir) => {
+  const applicationRow = PROJECT_ROW_DEFINITIONS.find(
+    (row) => row.category === "application" && !REQUIRED_PROJECT_ROWS.includes(row.name),
+  );
+  assert.ok(applicationRow, "test fixture expects at least one application corpus row");
+  // A complete REQUIRED set (so no required row is itself missing) plus the
+  // application row absent from the artifact entirely.
+  const rows = REQUIRED_PROJECT_ROWS.map((name) => projectRow(name));
+  const result = runMerge(dir, rows);
+  assert.equal(result.status, 0, result.stderr);
+  const merged = JSON.parse(fs.readFileSync(result.output, "utf8"));
+  assert.ok(
+    merged.validation.project_compatibility_advisory.includes(`${applicationRow.name}: missing project row`),
+    `an unmeasured application corpus row must be advised (${applicationRow.name})`,
+  );
+  assert.match(
+    result.stderr,
+    new RegExp(`::warning::[\\s\\S]*${applicationRow.name}: missing project row`),
   );
 });
 


### PR DESCRIPTION
Refs #16310 — addresses the silent-omission core (Asks 1–3). Deliberately **not** auto-closing: Ask 4 (re-run the 20-app survey, an operational run) and Ask 5 (per-row total file-count column) remain, so the issue stays open for those.

A defined compatibility corpus row that is never measured was, downstream, indistinguishable from a row that does not exist — so coverage could silently shrink and nothing reported it. The published `/compatibility` dashboard rendered 39 of 69 defined rows (all 20 `application` rows and 9 gray rows dropped), and the merged artifact's own self-check advised on exactly one missing row. This kills that silent-omission property at both layers where it leaked.

## Goal
Goal: grow

## What changed

**Merge self-validation — `scripts/bench/merge-results.mjs`.** `validation.project_compatibility_advisory` enumerated only `REQUIRED_PROJECT_ROWS` for the "missing project row" check, so the 20 `category:"application"` corpus rows (which are `guard_set:"canary"`, never in the required set) were never advised when absent. New `collectMissingCorpusRows(rows)` enumerates **every** defined corpus row missing a measurement — keyed on the full measured-name set (so a measured application row is correctly seen as present) and gated on the artifact actually carrying at least one corpus row (so unrelated timing-only/standalone artifacts are not spuriously advised against the whole corpus). It is a separate, explicitly whole-corpus function so the wider scope is named rather than smuggled into the required∪canary validator beside it.

**Dashboard — `crates/tsz-website/src/_data/benchmark_data.js`.** `getProjectCompatibilityDashboard()` dropped `className === "gray"` rows, so unmeasured rows vanished from the page. It now renders every defined corpus row: an unmeasured one shows as "Not measured" with its reason carried in the Exit class column, and the page publishes a coverage summary (measured vs defined) plus the artifact's provenance/freshness line (`generated_at` / `source_commit` / `run_status`), so staleness and shrinking coverage are visible to readers.

**Shared source — `scripts/bench/project-rows.mjs`.** The derived corpus name-list gets its canonical home as `COMPATIBILITY_CORPUS_ROW_NAMES` beside its sibling name-lists, shared by both consumers instead of re-derived.

Scope is display/reporting only — no compiler, solver, or emit behavior changes.

## Verification
- `node scripts/bench/test-merge-results.mjs` — passes, incl. a new case asserting an unmeasured `category:"application"` corpus row is advised as `missing project row`.
- `node scripts/bench/test-project-rows.mjs`, `node scripts/bench/test-project-row-summary.mjs` — pass (corpus metadata unaffected).
- `cd crates/tsz-website && node scripts/benchmark-data-smoke.mjs` — passes; assertions updated to require unmeasured rows render as "Not measured" and the coverage summary is present.
- Rendered the dashboard against the committed `bench-snapshot.json`: 69 rows now render (was 39), coverage line reads `39 of 69 defined corpus rows measured · 30 not measured`.
- Per-merge CI (`clippy` + `arch-size`) is Rust-only and unaffected; no file crosses the 2000-line ceiling.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high