### PR TITLE
fix(solver): object→union TS2322 elaboration selects tsc's best-matching member

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1101,6 +1101,9 @@ path = "tests/union_source_member_provenance_display_tests.rs"
 name = "union_target_missing_property_elaboration_tests"
 path = "tests/union_target_missing_property_elaboration_tests.rs"
 [[test]]
+name = "union_target_discriminant_member_selection_tests"
+path = "tests/union_target_discriminant_member_selection_tests.rs"
+[[test]]
 name = "union_generic_class_shared_member_tests"
 path = "tests/union_generic_class_shared_member_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/union_target_discriminant_member_selection_tests.rs
+++ b/crates/tsz-checker/tests/union_target_discriminant_member_selection_tests.rs
@@ -1,0 +1,184 @@
+//! Object-literal → union-target elaboration selects the member `tsc`'s
+//! `getBestMatchingType` selects.
+//!
+//! Structural rule: when an object literal is assigned to a union and fails,
+//! `tsc` picks the member to elaborate against with `getBestMatchingType`,
+//! which tries `findMatchingDiscriminantType` *before* `findMostOverlappyType`.
+//! So a written unit discriminant (`kind: "a"`) selects the member whose
+//! discriminant it matches — even when every member shares that same key and a
+//! pure key-overlap heuristic would tie and fall to the *last* member. And when
+//! the source shares no property key with any member, `tsc` selects no member
+//! at all (its `findMostOverlappyType` needs a unit-typed key intersection), so
+//! the failure is the bare union line with no nested missing-property drill.
+//!
+//! Owner: `SubtypeChecker::select_union_target_best_member`
+//! (`crates/tsz-solver/src/relations/subtype/explain_union_discriminant.rs`).
+//!
+//! These tests vary the discriminant key name, the member/property names, and
+//! the written discriminant value so a fix keyed to a particular spelling would
+//! not satisfy them; they assert *which* property is named missing (i.e. which
+//! member was selected), not the exact rendered source type.
+
+use tsz_checker::test_utils::check_source_diagnostics;
+use tsz_common::diagnostics::Diagnostic;
+
+/// Every `Property '<name>' is missing ... but required in type ...` message on
+/// a TS2322 diagnostic in `source`.
+fn missing_property_elaborations(source: &str) -> Vec<String> {
+    check_source_diagnostics(source)
+        .iter()
+        .filter(|diagnostic: &&Diagnostic| diagnostic.code == 2322)
+        .flat_map(|diagnostic| diagnostic.related_information.iter())
+        .map(|info| info.message_text.clone())
+        .filter(|text| text.contains("is missing") && text.contains("but required in type"))
+        .collect()
+}
+
+fn names_missing_property(source: &str, property: &str) -> bool {
+    let needle = format!("Property '{property}' is missing");
+    missing_property_elaborations(source)
+        .iter()
+        .any(|text| text.contains(&needle))
+}
+
+// ---------------------------------------------------------------------------
+// Discriminant selects the matching member, not the last-overlapping one.
+// Both members share only the discriminant key, so pure key-overlap ties and
+// (breaking to the last member) would name the wrong missing property.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn first_member_discriminant_selects_first_member() {
+    let source = r#"
+        type Shape = { kind: "a"; alpha: number } | { kind: "b"; beta: string };
+        const value: Shape = { kind: "a" };
+        export {};
+    "#;
+    // Discriminant `kind: "a"` -> first member -> `alpha` is the missing prop.
+    assert!(
+        names_missing_property(source, "alpha"),
+        "expected the `kind: \"a\"` member's `alpha` to be reported missing, got {:#?}",
+        missing_property_elaborations(source)
+    );
+    assert!(
+        !names_missing_property(source, "beta"),
+        "must not elaborate the non-matching `kind: \"b\"` member; got {:#?}",
+        missing_property_elaborations(source)
+    );
+}
+
+#[test]
+fn last_member_discriminant_selects_last_member() {
+    let source = r#"
+        type Shape = { tag: "one"; first: number } | { tag: "two"; second: string };
+        const value: Shape = { tag: "two" };
+        export {};
+    "#;
+    assert!(
+        names_missing_property(source, "second"),
+        "expected the `tag: \"two\"` member's `second` to be reported missing, got {:#?}",
+        missing_property_elaborations(source)
+    );
+    assert!(!names_missing_property(source, "first"));
+}
+
+#[test]
+fn middle_member_discriminant_over_three_members() {
+    // Three same-keyed members: overlap ties three ways and would pick the
+    // *last* (`third`); the discriminant must pick the middle one.
+    let source = r#"
+        type Shape =
+            | { variant: "x"; ex: number }
+            | { variant: "y"; why: string }
+            | { variant: "z"; zed: boolean };
+        const value: Shape = { variant: "y" };
+        export {};
+    "#;
+    assert!(
+        names_missing_property(source, "why"),
+        "expected the `variant: \"y\"` member's `why` to be reported missing, got {:#?}",
+        missing_property_elaborations(source)
+    );
+    assert!(!names_missing_property(source, "ex"));
+    assert!(!names_missing_property(source, "zed"));
+}
+
+#[test]
+fn discriminant_name_is_not_hardcoded() {
+    // A discriminant key with an unusual name, to rule out a `kind`/`tag`
+    // spelling fast-path.
+    let source = r#"
+        type Node = { __disc: "leaf"; payload: number } | { __disc: "branch"; children: string };
+        const node: Node = { __disc: "branch" };
+        export {};
+    "#;
+    assert!(
+        names_missing_property(source, "children"),
+        "expected the `__disc: \"branch\"` member's `children` missing, got {:#?}",
+        missing_property_elaborations(source)
+    );
+    assert!(!names_missing_property(source, "payload"));
+}
+
+// ---------------------------------------------------------------------------
+// No discriminant: the key-overlap heuristic still applies (ties to the last
+// member), matching `findMostOverlappyType`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn no_discriminant_falls_back_to_key_overlap() {
+    // `common` is typed `string` (not a unit), so it is not a discriminant;
+    // both members share `common`, overlap ties, and tsc breaks to the last
+    // member -> `beta` is reported missing.
+    let source = r#"
+        type Shape = { alpha: number; common: string } | { beta: number; common: string };
+        const value: Shape = { common: "present" };
+        export {};
+    "#;
+    assert!(
+        names_missing_property(source, "beta"),
+        "expected the last overlapping member's `beta` missing, got {:#?}",
+        missing_property_elaborations(source)
+    );
+    assert!(!names_missing_property(source, "alpha"));
+}
+
+// ---------------------------------------------------------------------------
+// Zero key overlap: tsc selects no member and emits only the bare union line.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn zero_overlap_source_has_no_nested_elaboration() {
+    let source = r#"
+        type Shape = { alpha: number } | { beta: string };
+        const value: Shape = {};
+        export {};
+    "#;
+    let elaborations = missing_property_elaborations(source);
+    assert!(
+        elaborations.is_empty(),
+        "a source sharing no key with any member must not drill into a member; got {elaborations:#?}"
+    );
+    // The bare TS2322 union line must still fire.
+    assert!(
+        check_source_diagnostics(source)
+            .iter()
+            .any(|diagnostic| diagnostic.code == 2322),
+        "expected the bare TS2322 union-mismatch line"
+    );
+}
+
+#[test]
+fn disjoint_keyed_source_has_no_nested_elaboration() {
+    // Source carries a key, but it overlaps no member -> still no drill.
+    let source = r#"
+        type Shape = { alpha: number } | { beta: string };
+        const value: Shape = { gamma: 1 };
+        export {};
+    "#;
+    assert!(
+        missing_property_elaborations(source).is_empty(),
+        "a source whose only key overlaps no member must not drill; got {:#?}",
+        missing_property_elaborations(source)
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -176,7 +176,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
 
     /// Resolve `type_id` to its apparent structural form, resolving lazy
     /// aliases and expanding a generic application one level.
-    fn apparent_type_for_keys(&mut self, type_id: TypeId) -> TypeId {
+    pub(super) fn apparent_type_for_keys(&mut self, type_id: TypeId) -> TypeId {
         let mut resolved = self.resolve_lazy_type(type_id);
         if let Some(app_id) = application_id(self.interner, resolved)
             && let Some(expanded) = self.try_expand_application_type(resolved, app_id)
@@ -190,7 +190,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// aliases / expanding generic applications and folding intersection
     /// members. Used to score union-member overlap the way tsc's
     /// `findMostOverlappyType` intersects `keyof source` with `keyof member`.
-    fn object_like_property_names(&mut self, type_id: TypeId) -> Vec<tsz_common::interner::Atom> {
+    pub(super) fn object_like_property_names(
+        &mut self,
+        type_id: TypeId,
+    ) -> Vec<tsz_common::interner::Atom> {
         use crate::type_queries::data::get_intersection_members;
 
         let resolved = self.apparent_type_for_keys(type_id);
@@ -1088,34 +1091,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             }
 
             // Structural union target: select the best-matching member the way
-            // tsc's `getBestMatchingType` -> `findMostOverlappyType` does — the
-            // member sharing the most property-name keys with the source, ties
-            // broken by the *last* such member (tsc compares overlap with `>=`).
-            // Any case where a discriminant would prefer a different member than
-            // overlap necessarily carries an excess property, which surfaces as
-            // the separate TS2353 elaboration, so overlap selection is faithful
-            // for the missing-property path handled here.
-            let source_names = self.object_like_property_names(resolved_source);
-            let mut best_member: Option<TypeId> = None;
-            let mut best_overlap = 0usize;
-            for &member in members.iter() {
-                if self.check_subtype(resolved_source, member).is_true() {
-                    continue;
-                }
-                let overlap = if source_names.is_empty() {
-                    0
-                } else {
-                    let member_names = self.object_like_property_names(member);
-                    source_names
-                        .iter()
-                        .filter(|name| member_names.contains(name))
-                        .count()
-                };
-                if best_member.is_none() || overlap >= best_overlap {
-                    best_overlap = overlap;
-                    best_member = Some(member);
-                }
-            }
+            // tsc's `getBestMatchingType` does — discriminant first, then
+            // key-overlap, and no member at all when nothing overlaps. See
+            // [`SubtypeChecker::select_union_target_best_member`].
+            let best_member: Option<TypeId> =
+                self.select_union_target_best_member(resolved_source, &members);
 
             // Elaborate against the best member, but only when its failure is a
             // missing required property. Property-type mismatches and excess

--- a/crates/tsz-solver/src/relations/subtype/explain_union_discriminant.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain_union_discriminant.rs
@@ -1,0 +1,176 @@
+//! Best-matching-member selection for object-to-union failure elaboration.
+//!
+//! When an object value fails to assign to a union target, `tsc`'s
+//! `getBestMatchingType` picks the single union member to elaborate the failure
+//! against. It tries, in order:
+//!
+//! 1. `findMatchingDiscriminantType` — a written unit discriminant on the
+//!    source (`kind: "a"`) selects the member whose discriminant it matches,
+//!    regardless of raw key overlap;
+//! 2. `findMostOverlappyType` — otherwise the member sharing the most
+//!    property-name keys with the source, ties broken by the *last* such member
+//!    (`tsc` compares overlap with `>=`);
+//! 3. no member at all when nothing overlaps (`findMostOverlappyType` needs a
+//!    unit-typed key intersection), leaving the bare union line.
+//!
+//! `SubtypeChecker::explain_failure`'s structural-union arm (`explain.rs`)
+//! previously implemented only step 2, so a discriminated union
+//! (`{ kind: "a"; x } | { kind: "b"; y }` given `{ kind: "a" }`) tied on the
+//! shared `kind` key and elaborated the *last* member — naming the wrong
+//! missing property — and a source with no overlap picked an arbitrary member
+//! `tsc` never elaborates. These helpers restore the full ordering.
+
+use crate::def::resolver::TypeResolver;
+use crate::relations::subtype::SubtypeChecker;
+use crate::type_queries::flow::is_unit_type;
+use crate::types::{ObjectShapeId, TypeId};
+use crate::visitor::{object_shape_id, object_with_index_shape_id};
+use tsz_common::interner::Atom;
+
+impl<R: TypeResolver> SubtypeChecker<'_, R> {
+    /// Select the union member `tsc`'s `getBestMatchingType` would elaborate a
+    /// failed object-to-union assignment against: a discriminant match first,
+    /// then the highest-key-overlap member (ties to the last), and `None` when
+    /// no member shares a key with the source.
+    pub(super) fn select_union_target_best_member(
+        &mut self,
+        resolved_source: TypeId,
+        members: &[TypeId],
+    ) -> Option<TypeId> {
+        if let Some(member) = self.union_discriminant_matched_member(resolved_source, members) {
+            return Some(member);
+        }
+
+        let source_names = self.object_like_property_names(resolved_source);
+        if source_names.is_empty() {
+            return None;
+        }
+        let mut best_member: Option<TypeId> = None;
+        let mut best_overlap = 0usize;
+        for &member in members.iter() {
+            if self.check_subtype(resolved_source, member).is_true() {
+                continue;
+            }
+            let member_names = self.object_like_property_names(member);
+            let overlap = source_names
+                .iter()
+                .filter(|name| member_names.contains(name))
+                .count();
+            if overlap > 0 && (best_member.is_none() || overlap >= best_overlap) {
+                best_overlap = overlap;
+                best_member = Some(member);
+            }
+        }
+        best_member
+    }
+
+    /// `tsc`'s `getBestMatchingType` -> `findMatchingDiscriminantType`: when the
+    /// source object carries a discriminant property whose written unit value
+    /// (`kind: "a"`) selects exactly one union member, elaborate against that
+    /// member — regardless of raw key-overlap ties. Returns the matched member,
+    /// or `None` when no source property narrows the union to a single member.
+    ///
+    /// A property is treated as a union discriminant only when every member that
+    /// declares it types it as a unit (a literal / enum member / `true` /
+    /// `false` / `null` / `undefined`) — matching `tsc`'s
+    /// `isDiscriminantProperty` — and the source's own value for it is likewise
+    /// a unit. Members are narrowed by relating the source value to each
+    /// member's value; a single survivor is the match.
+    fn union_discriminant_matched_member(
+        &mut self,
+        source: TypeId,
+        members: &[TypeId],
+    ) -> Option<TypeId> {
+        let source_names = self.object_like_property_names(source);
+        if source_names.is_empty() {
+            return None;
+        }
+        let mut candidates: Vec<TypeId> = members.to_vec();
+        let mut narrowed = false;
+        for name in source_names {
+            let Some(source_value) = self.discriminant_property_type(source, name) else {
+                continue;
+            };
+            if !is_unit_type(self.interner, source_value) {
+                continue;
+            }
+            // Qualify `name` as a union discriminant: at least one member
+            // declares it and every member that declares it types it as a unit.
+            let mut any_present = false;
+            let mut all_unit = true;
+            for &member in members.iter() {
+                if let Some(member_value) = self.discriminant_property_type(member, name) {
+                    any_present = true;
+                    if !is_unit_type(self.interner, member_value) {
+                        all_unit = false;
+                        break;
+                    }
+                }
+            }
+            if !any_present || !all_unit {
+                continue;
+            }
+            let filtered: Vec<TypeId> = candidates
+                .iter()
+                .copied()
+                .filter(|&member| {
+                    self.discriminant_property_type(member, name)
+                        .is_some_and(|member_value| {
+                            self.check_subtype(source_value, member_value).is_true()
+                        })
+                })
+                .collect();
+            if !filtered.is_empty() {
+                candidates = filtered;
+                narrowed = true;
+                if candidates.len() == 1 {
+                    break;
+                }
+            }
+        }
+        if narrowed && candidates.len() == 1 {
+            Some(candidates[0])
+        } else {
+            None
+        }
+    }
+
+    /// The read type of property `name` on the apparent (lazy-resolved,
+    /// application-expanded) form of `type_id`, folding intersection members.
+    /// Returns `None` when the property is absent. Used to compare a source
+    /// object's written discriminant value against each union member's own
+    /// value for that key.
+    fn discriminant_property_type(&mut self, type_id: TypeId, name: Atom) -> Option<TypeId> {
+        use crate::type_queries::data::get_intersection_members;
+
+        let resolved = self.apparent_type_for_keys(type_id);
+        if let Some(shape_id) = object_shape_id(self.interner, resolved)
+            .or_else(|| object_with_index_shape_id(self.interner, resolved))
+            && let Some(property_type) = self.object_shape_property_type(shape_id, name)
+        {
+            return Some(property_type);
+        }
+        if let Some(members) = get_intersection_members(self.interner, resolved) {
+            for member in members {
+                let resolved_member = self.apparent_type_for_keys(member);
+                if let Some(shape_id) = object_shape_id(self.interner, resolved_member)
+                    .or_else(|| object_with_index_shape_id(self.interner, resolved_member))
+                    && let Some(property_type) = self.object_shape_property_type(shape_id, name)
+                {
+                    return Some(property_type);
+                }
+            }
+        }
+        None
+    }
+
+    /// The read type of property `name` declared directly on `shape_id`.
+    fn object_shape_property_type(&self, shape_id: ObjectShapeId, name: Atom) -> Option<TypeId> {
+        self.interner
+            .object_shape(shape_id)
+            .properties
+            .iter()
+            .find(|prop| prop.name == name)
+            .map(|prop| prop.type_id)
+    }
+}

--- a/crates/tsz-solver/src/relations/subtype/mod.rs
+++ b/crates/tsz-solver/src/relations/subtype/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod explain_function;
 pub(crate) mod explain_guard;
 pub(crate) mod explain_indexes;
 pub(crate) mod explain_tuple;
+pub(crate) mod explain_union_discriminant;
 pub(crate) mod explain_union_order;
 pub(crate) mod helpers;
 pub(crate) mod overlap;


### PR DESCRIPTION
When an object literal fails to assign to a union target, tsz's structural-union failure elaboration picked the member to drill into with only `findMostOverlappyType` (most shared property-name keys, ties broken by the *last* member). tsc's `getBestMatchingType` tries `findMatchingDiscriminantType` **first**, so a written unit discriminant (`kind: "a"`) selects the member whose discriminant it matches — even though every member of a discriminated union shares that key and pure overlap ties to the last member. tsz therefore named the **wrong missing property**. tsc also selects *no* member when the source shares no key with any member (its overlap needs a unit-typed key intersection), leaving the bare union line; tsz picked an arbitrary member and drilled a spurious missing-property line.

Fixes #16861.

### Before / after (vs `typescript@7.0.2` oracle, `--strict --target es2022 --module esnext`)

```ts
type A = { kind: "a"; x: number } | { kind: "b"; y: string };
const a: A = { kind: "a" };
```
| | nested elaboration |
| --- | --- |
| tsc | `Property 'x' is missing ... required in type '{ kind: "a"; x: number; }'` |
| tsz before | `Property 'y' is missing ...`  ← wrong member |
| tsz after | `Property 'x' is missing ...`  ← matches tsc |

```ts
type A = { x: number } | { y: string };
const a: A = { };   // tsc: bare TS2322, no drill.  tsz before: spurious "Property 'y' missing".  after: bare, matches tsc
```

### Structural rule

When an object source fails against a union target, tsc elaborates against the member `getBestMatchingType` selects — discriminant match, then highest key overlap (ties to the last), then no member at all. tsz now does the same through the solver's relation-explain boundary (`SubtypeChecker::select_union_target_best_member`, new `explain_union_discriminant.rs`). The selection logic moves out of `explain.rs`, ratcheting that file from 2025 back to 2005 lines (under its arch-guard limit).

**Out of scope (noted in #16861):** the nested line still renders the regularized source (`{ kind: string }`) where tsc keeps the written literal (`{ kind: "a" }`) — a separate checker-side display-provenance gap. The member/property named is what this PR fixes.

## Goal
Goal: hold

## Verification
- `cargo build --release -p tsz-cli` clean; pre-commit **clippy + arch guard passed**; CI **clippy + arch-size + CI Summary green**.
- New `crates/tsz-checker/tests/union_target_discriminant_member_selection_tests.rs` (7 cases, names/keys/values varied so a spelling-keyed fix would fail them) + existing 35 union-elaboration tests pass.
- Target cases verified against the pinned `typescript@7.0.2` oracle.
- **Conformance-neutral by construction:** the change only alters which union member a TS2322 nested elaboration names and removes a spurious nested line at zero overlap; it never adds/removes a top-level diagnostic **code**, and the relation *decision* is unchanged, so the `expected/actual` code sets conformance compares are unaffected. A full `conformance.sh snapshot --workers 12 --force` run (11529 passed) shows only pre-existing run-to-run non-determinism in unrelated areas (#16309; the #16702 flaky `arbitraryModuleNamespaceIdentifiers_syntax` TS1003-count row flips in the same diff), none attributable to this change.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high