### PR TITLE
fix(checker): TS1345 void-truthiness fires regardless of strictNullChecks

### DIFF
--- a/crates/tsz-checker/src/types/computation/binary_tests.rs
+++ b/crates/tsz-checker/src/types/computation/binary_tests.rs
@@ -553,7 +553,15 @@ fn no_ts2365_for_same_orderable_kind() {
 }
 
 // =========================================================================
-// TS1345: Void truthiness gated on strictNullChecks
+// TS1345: Void truthiness fires regardless of strictNullChecks
+//
+// Oracle-verified (`typescript@7.0.2`): `declare var v: void; v && x;`
+// reports TS1345 with no `--strict` flag at all, and even with an explicit
+// `--strict false` — matching the real conformance fixtures
+// `logicalAndOperatorWithEveryType.ts`/`logicalOrOperatorWithEveryType.ts`,
+// both of which set `@strict: false` and still expect TS1345. Previously
+// this file asserted the opposite (TS1345 should NOT fire without strict),
+// which was never true in tsc.
 // =========================================================================
 
 fn check_source_diagnostics_no_strict(source: &str) -> Vec<crate::diagnostics::Diagnostic> {
@@ -585,26 +593,85 @@ fn ts1345_void_truthiness_with_strict() {
 }
 
 #[test]
-fn no_ts1345_void_truthiness_without_strict() {
-    // Without strictNullChecks, TS1345 should NOT fire for void truthiness.
-    // TSC does not emit this diagnostic when strictNullChecks is off.
+fn ts1345_void_truthiness_without_strict() {
+    // TS1345 fires for void truthiness even without strictNullChecks.
     let diags = check_source_diagnostics_no_strict("declare var a: void; if (a) {}");
     assert!(
-        !diags.iter().any(|d| d.code == 1345),
-        "Should NOT emit TS1345 for void truthiness without strict, got: {:?}",
+        diags.iter().any(|d| d.code == 1345),
+        "Expected TS1345 for void truthiness without strict, got: {:?}",
         diags.iter().map(|d| d.code).collect::<Vec<_>>()
     );
 }
 
 #[test]
-fn no_ts1345_void_in_logical_and_without_strict() {
-    // void && any — should NOT emit TS1345 without strictNullChecks.
+fn ts1345_void_in_logical_and_without_strict() {
+    // void && any — TS1345 fires on the left operand even without strictNullChecks.
     let diags = check_source_diagnostics_no_strict(
         "declare var a: void; declare var b: any; var r = a && b;",
     );
     assert!(
+        diags.iter().any(|d| d.code == 1345),
+        "Expected TS1345 for void && any without strict, got: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn ts1345_void_in_logical_or_without_strict() {
+    // void || any — TS1345 fires on the left operand even without strictNullChecks.
+    let diags = check_source_diagnostics_no_strict(
+        "declare var a: void; declare var b: any; var r = a || b;",
+    );
+    assert!(
+        diags.iter().any(|d| d.code == 1345),
+        "Expected TS1345 for void || any without strict, got: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn no_ts1345_void_in_logical_and_right_operand() {
+    // any && void — tsc only recurses into the LEFT operand of `&&`/`||`;
+    // the right operand's value is the expression's result, not something
+    // being "tested" at that AST node, so no TS1345 fires here (oracle-verified).
+    let diags =
+        check_source_diagnostics("declare var a: any; declare var b: void; var r = a && b;");
+    assert!(
         !diags.iter().any(|d| d.code == 1345),
-        "Should NOT emit TS1345 for void && any without strict, got: {:?}",
+        "Should NOT emit TS1345 for the right operand of &&, got: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn ts1345_void_not_operand_without_strict() {
+    // !void — TS1345 fires on the `!` operand even without strictNullChecks.
+    let diags = check_source_diagnostics_no_strict("declare var a: void; var r = !a;");
+    assert!(
+        diags.iter().any(|d| d.code == 1345),
+        "Expected TS1345 for !void without strict, got: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn ts1345_void_ternary_condition_without_strict() {
+    // void ? a : b — TS1345 fires on the ternary condition even without strictNullChecks.
+    let diags = check_source_diagnostics_no_strict("declare var a: void; var r = a ? 1 : 2;");
+    assert!(
+        diags.iter().any(|d| d.code == 1345),
+        "Expected TS1345 for void ternary condition without strict, got: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn ts1345_void_while_condition_without_strict() {
+    // while (void) — TS1345 fires even without strictNullChecks.
+    let diags = check_source_diagnostics_no_strict("declare function f(): void; while (f()) {}");
+    assert!(
+        diags.iter().any(|d| d.code == 1345),
+        "Expected TS1345 for void while-condition without strict, got: {:?}",
         diags.iter().map(|d| d.code).collect::<Vec<_>>()
     );
 }

--- a/crates/tsz-checker/src/types/queries/callable_truthiness.rs
+++ b/crates/tsz-checker/src/types/queries/callable_truthiness.rs
@@ -98,10 +98,13 @@ impl<'a> CheckerState<'a> {
 
     /// Same as `check_truthy_or_falsy`, but reuses a caller-provided type.
     ///
-    /// Both the `void` TS1345 check and the TS2872/TS2873 syntactic checks are
-    /// gated on `strictNullChecks`. Without strict null checks, `void` is
-    /// effectively `undefined` (which is a valid falsy value), and all types
-    /// implicitly include `null | undefined`, so truthiness checks are not meaningful.
+    /// The TS1345 (`void` truthiness) check fires regardless of
+    /// `strictNullChecks` — tsc's `checkTruthinessOfType` rejects a `void`
+    /// operand unconditionally (oracle-verified, `typescript@7.0.2`:
+    /// `declare var v: void; v && x;` reports TS1345 with no `--strict` flag
+    /// at all, and even with `--strict false` explicit). The TS2872/TS2873
+    /// syntactic always-truthy/always-falsy checks below are independent and
+    /// unaffected by this.
     ///
     /// `check_enum_members` controls TS2845 enum member truthiness diagnostics.
     /// tsc only emits TS2845 for enum members in condition contexts (if/while/for/
@@ -128,8 +131,8 @@ impl<'a> CheckerState<'a> {
     ) {
         use crate::diagnostics::diagnostic_codes;
 
-        // TS1345 (void truthiness) requires strictNullChecks
-        if self.ctx.compiler_options.strict_null_checks && ty == TypeId::VOID {
+        // TS1345 (void truthiness) fires regardless of strictNullChecks.
+        if ty == TypeId::VOID {
             self.error_at_node(
                 node_idx,
                 "An expression of type 'void' cannot be tested for truthiness.",


### PR DESCRIPTION
When a `void`-typed expression is used as a truthiness test (`if`, `while`, `!`, `? :`, or the left operand of `&&`/`||`), tsc's `checkTruthinessOfType` reports TS1345 unconditionally; tsz gated the check behind `strict_null_checks` — a wrong assumption baked into the code's own doc comment and into two existing unit tests that asserted the opposite.

## Witness (oracle-verified, `typescript@7.0.2`)

```ts
declare var v: void;
declare var x: any;
var r = v && x;
```

| flags | tsc |
| --- | --- |
| (no `--strict` at all) | TS1345 |
| `--strict false` (explicit) | TS1345 |
| `--strict` (default true) | TS1345 |

Same for `if (v)`, `while (v)`, `!v`, and `v ? 1 : 2` — all fire TS1345 regardless of strict mode. The two real conformance fixtures `logicalAndOperatorWithEveryType.ts` / `logicalOrOperatorWithEveryType.ts` both set `@strict: false` and still expect TS1345 — that's the oracle evidence this was wrong all along, surfaced via the committed `conformance-detail.json` work queue (both were pure single-missing-code rows).

Adjacent-case matrix confirmed clean both before and after: the right operand of `&&`/`||` is never tested (tsc's `checkTruthinessOfExpression` only recurses into the *left* operand of `&&`/`||`, matching tsz's existing `check_truthy_or_falsy_with_type_no_enum` wiring at `binary.rs:503,527`), and non-`void` falsy types (`null`, `undefined` literals) are unaffected since the gate is keyed on `TypeId::VOID` specifically.

## Structural rule

When a `void`-typed expression is tested for truthiness (directly, or as the left operand of `&&`/`||`, or as a `!`/`?:` operand), `tsc` reports TS1345 unconditionally through `checkTruthinessOfType`; tsz now does the same through the shared `check_truthy_or_falsy_with_type_inner` (`crates/tsz-checker/src/types/queries/callable_truthiness.rs`) — the recursion into `&&`/`||` left operands, `!` operands, and ternary conditions already existed (`binary.rs`, `helpers.rs`), so this is a single incorrect gate condition, not missing plumbing.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib -- ts1345`: 8/8 passed (2 corrected + 6 new adjacent-case tests: `&&`, `||`, `!`, ternary, `while`, right-operand exemption).
- `cargo test -p tsz-checker --lib -- truthy`: 9/9 passed (no regression in flow-narrowing truthiness tests).
- `cargo test -p tsz-checker --lib -- void`: 86/86 passed.
- `cargo clippy -p tsz-checker --lib -- -D warnings`: clean.
- `cargo fmt -p tsz-checker -- --check`: clean.
- Full `cargo test -p tsz-checker --lib` (~10,800 tests): in progress at time of PR open, 6600+/~10800 done, 0 failures so far — will report final count on this PR.
- Manually verified against a rebuilt `release` `tsz` binary on the exact real conformance fixture shape (`declare var a: void; if (a) {}`, `a && b`, `a || b`, `!a`, `a ? 1 : 2`, `while (f())`) with and without `--strict`: matches tsc exactly in every case, including the right-operand-of-`&&` negative case.
- Pre-commit hook local verification (clippy + arch-guard + affected-crate tests): passed.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChqbWZY4ye67urfMY2ccja)_