### PR TITLE
fix(checker): correct TS2850 using-disposable elaboration tail for signature mismatches

### DIFF
--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -1172,10 +1172,22 @@ impl<'a> CheckerState<'a> {
                     diagnostic_messages::TARGET_SIGNATURE_PROVIDES_TOO_FEW_ARGUMENTS_EXPECTED_OR_MORE_BUT_GOT,
                     &[&source_count.to_string(), &target_count.to_string()],
                 );
+                // The arity leaf sits one level under this reason's own
+                // `Type 'S' is not assignable to type 'T'.` line. At the top
+                // level that line is the diagnostic's primary message, so the
+                // leaf is the first elaboration (depth 0). When this reason is
+                // drilled beneath a property/member header (e.g. a method
+                // property whose signature takes too few target arguments), the
+                // `Type 'S' …` line is re-seated at `depth` by the parent chain,
+                // so the leaf must follow at `depth + 1` — mirroring the
+                // absolute-depth convention every other nested `render_*` arm
+                // honors. Authoring it at a fixed `0` collapsed it up to the
+                // property-header level (issue #16859).
+                let leaf_depth = if depth == 0 { 0 } else { depth + 1 };
                 diag.push_elaboration(
                     elaboration,
                     diagnostic_codes::TARGET_SIGNATURE_PROVIDES_TOO_FEW_ARGUMENTS_EXPECTED_OR_MORE_BUT_GOT,
-                    0,
+                    leaf_depth,
                 );
                 diag
             }

--- a/crates/tsz-checker/src/types/type_checking/core.rs
+++ b/crates/tsz-checker/src/types/type_checking/core.rs
@@ -1823,38 +1823,74 @@ impl<'a> CheckerState<'a> {
         init_type: TypeId,
         anchor: NodeIndex,
     ) -> Option<Vec<crate::diagnostics::DiagnosticRelatedInformation>> {
-        let lib_binders = self.get_lib_binders();
-        let disposable_sym = self
-            .ctx
-            .binder
-            .get_global_type_with_libs("Disposable", &lib_binders)?;
-        // Build the `Disposable` target exactly as a `: Disposable` annotation
-        // would: prime the `DefId` (registering the lib interface body in the type
-        // environment) and intern it as `Lazy(DefId)`. A bare `get_type_of_symbol`
-        // here yields an unresolved/member-less shell when nothing else in the file
-        // referenced `Disposable` (the `using` initializer is the only consumer),
-        // so the relation would see no `[Symbol.dispose]` member.
-        let def_id = self.ensure_def_ready_for_lowering(disposable_sym, "Disposable");
-        let disposable_type = self.ctx.types.lazy(def_id);
+        let disposable_type = self.resolve_disposable_interface_type(false)?;
         let analysis = self.analyze_assignability_failure(init_type, disposable_type);
         let reason = analysis.failure_reason?;
         let rendered = self.render_failure_reason(&reason, init_type, disposable_type, anchor, 0);
-        // The rendered reason's top message is the first elaboration line; its own
-        // nested chain re-seats one level deeper beneath it.
-        let mut related = vec![crate::diagnostics::Diagnostic::related_message(
-            rendered.code,
-            rendered.file,
-            rendered.start,
-            rendered.length,
-            rendered.message_text,
-        )];
-        related.extend(
-            rendered
-                .related_information
-                .into_iter()
-                .map(|info| info.with_depth_shift(1)),
-        );
+        // `tsc` reports this failure through `checkTypeAssignableTo(initType,
+        // Disposable, headMessage = TS2850)`. In its `reportRelationError`, a
+        // supplied head message *replaces* the generic outer
+        // `Type 'S' is not assignable to type 'T'.` frame rather than nesting
+        // beneath it — the TS2850 wording ("must be … an object with a
+        // '[Symbol.dispose]()' method …") already conveys that relationship, so
+        // the tail drills straight to the specific nested reason.
+        //
+        // `render_failure_reason` at depth 0 reproduces that generic frame as
+        // the rendered *top* message (code `TYPE_IS_NOT_ASSIGNABLE_TO_TYPE`)
+        // whenever the reason is an object-structural mismatch that carries a
+        // deeper chain (e.g. a `[Symbol.dispose]` whose signature is
+        // incompatible). Mirror `tsc`: drop that redundant frame and promote its
+        // already-correctly-nested children directly beneath the head message.
+        // A self-heading leaf reason instead renders as its own specific message
+        // (e.g. `Property '[Symbol.dispose]' is missing … required in type
+        // 'Disposable'.`, code TS2741) with no generic frame to replace, so keep
+        // it as the first tail line with its own chain one level deeper.
+        let top_is_generic_frame = rendered.code
+            == crate::diagnostics::diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
+            && !rendered.related_information.is_empty();
+        let related = if top_is_generic_frame {
+            rendered.related_information
+        } else {
+            let mut related = vec![crate::diagnostics::Diagnostic::related_message(
+                rendered.code,
+                rendered.file,
+                rendered.start,
+                rendered.length,
+                rendered.message_text,
+            )];
+            related.extend(
+                rendered
+                    .related_information
+                    .into_iter()
+                    .map(|info| info.with_depth_shift(1)),
+            );
+            related
+        };
         Some(related)
+    }
+
+    /// Resolve the `Disposable`/`AsyncDisposable` global interface as a
+    /// `Lazy(DefId)` type, primed for lowering exactly as a `: Disposable`
+    /// annotation would be. Returns `None` when the current lib does not
+    /// declare the interface (e.g. `--lib` without `esnext.disposable`).
+    ///
+    /// A bare `get_type_of_symbol` here would yield an unresolved/member-less
+    /// shell when nothing else in the file references the interface (a
+    /// `using` initializer is often its only consumer), so the relation
+    /// would see no `[Symbol.dispose]`/`[Symbol.asyncDispose]` member.
+    fn resolve_disposable_interface_type(&mut self, want_async: bool) -> Option<TypeId> {
+        let name = if want_async {
+            "AsyncDisposable"
+        } else {
+            "Disposable"
+        };
+        let lib_binders = self.get_lib_binders();
+        let sym = self
+            .ctx
+            .binder
+            .get_global_type_with_libs(name, &lib_binders)?;
+        let def_id = self.ensure_def_ready_for_lowering(sym, name);
+        Some(self.ctx.types.lazy(def_id))
     }
 
     /// Check if a type has the appropriate dispose method.
@@ -1915,19 +1951,26 @@ impl<'a> CheckerState<'a> {
             return true;
         }
 
-        // Check for the dispose method on the object type
-        let has_dispose = has_property(self, type_id, &["[Symbol.dispose]", "Symbol.dispose"]);
+        // Check the object type against the full `Disposable`/`AsyncDisposable`
+        // structural shape (`tsc`'s `checkTypeAssignableTo`), not mere property
+        // existence — a `[Symbol.dispose]`/`[Symbol.asyncDispose]` method with an
+        // incompatible signature (extra required params, wrong parameter types,
+        // or for the async case a non-`PromiseLike` return type) must still be
+        // rejected, while the ordinary void-return exception (a `(): number`
+        // dispose method) must still be accepted, exactly as the relation
+        // already implements for every other assignability check.
+        let is_disposable = self
+            .resolve_disposable_interface_type(false)
+            .is_some_and(|target| self.is_assignable_to(type_id, target));
 
         if is_await_using {
             // await using accepts either Symbol.asyncDispose or Symbol.dispose
-            return has_dispose
-                || has_property(
-                    self,
-                    type_id,
-                    &["[Symbol.asyncDispose]", "Symbol.asyncDispose"],
-                );
+            return is_disposable
+                || self
+                    .resolve_disposable_interface_type(true)
+                    .is_some_and(|target| self.is_assignable_to(type_id, target));
         }
 
-        has_dispose
+        is_disposable
     }
 }

--- a/crates/tsz-checker/tests/using_disposable_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/using_disposable_elaboration_tests.rs
@@ -182,3 +182,157 @@ const d: Disposable = x;
          in type 'Disposable'.",
     );
 }
+
+/// Full elaboration as `(depth, text)` pairs — the primary message at depth 0,
+/// then each related line at its rendered nesting depth + 1 (so the primary is
+/// the shallowest). Locks both the wording AND the `tsc`-style progressive
+/// indentation, which a flat text join cannot distinguish.
+fn elaboration_with_depths(body: &str, code: u32) -> Vec<(u8, String)> {
+    let diags = check(body);
+    let matching: Vec<_> = diags.iter().filter(|d| d.code == code).collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "Expected exactly one TS{code}. Got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+    let d = matching[0];
+    let mut out = vec![(0u8, d.message_text.clone())];
+    out.extend(
+        d.related_information
+            .iter()
+            .map(|info| (info.depth + 1, info.message_text.clone())),
+    );
+    out
+}
+
+/// Sync `using` whose `[Symbol.dispose]` method has an incompatible *signature*
+/// (an extra required parameter): the TS2850 top line keeps its wording and the
+/// relation-derived tail drills straight to the specific incompatibility, with
+/// no redundant `Type '{…}' is not assignable to type 'Disposable'.` wrapper
+/// frame (the TS2850 head message already conveys it) and with the arity leaf
+/// nested one level under the function-type line — matching `tsc`. Regression
+/// for #16859 (a type-mismatch, not missing-property, Disposable failure).
+#[test]
+fn using_type_mismatch_dispose_signature_attaches_incompatible_tail() {
+    let lines = elaboration_with_depths(
+        r#"
+function f() { using r = { [Symbol.dispose](extra: number) {} }; }
+"#,
+        2850,
+    );
+    assert_eq!(
+        lines,
+        vec![
+            (
+                0u8,
+                "The initializer of a 'using' declaration must be either an object with a \
+                 '[Symbol.dispose]()' method, or be 'null' or 'undefined'."
+                    .to_string(),
+            ),
+            (
+                1,
+                "Types of property '[Symbol.dispose]' are incompatible.".to_string(),
+            ),
+            (
+                2,
+                "Type '(extra: number) => void' is not assignable to type '() => void'."
+                    .to_string(),
+            ),
+            (
+                3,
+                "Target signature provides too few arguments. Expected 1 or more, but got 0."
+                    .to_string(),
+            ),
+        ],
+    );
+}
+
+/// Same rule, different parameter name — the tail must echo the renamed source
+/// signature, never a hard-coded `extra` (CLAUDE.md anti-hardcoding gate).
+#[test]
+fn using_type_mismatch_tail_is_param_name_independent() {
+    let lines = elaboration_with_depths(
+        r#"
+function open() { using h = { [Symbol.dispose](spare: string) {} }; }
+"#,
+        2850,
+    );
+    assert_eq!(
+        lines,
+        vec![
+            (
+                0u8,
+                "The initializer of a 'using' declaration must be either an object with a \
+                 '[Symbol.dispose]()' method, or be 'null' or 'undefined'."
+                    .to_string(),
+            ),
+            (
+                1,
+                "Types of property '[Symbol.dispose]' are incompatible.".to_string(),
+            ),
+            (
+                2,
+                "Type '(spare: string) => void' is not assignable to type '() => void'."
+                    .to_string(),
+            ),
+            (
+                3,
+                "Target signature provides too few arguments. Expected 1 or more, but got 0."
+                    .to_string(),
+            ),
+        ],
+    );
+}
+
+/// The void-return exception is unchanged by the structural gate: a
+/// `[Symbol.dispose]` method that *returns a value* is still a valid `Disposable`
+/// (anything is assignable to a `void`-returning target position), so no TS2850
+/// fires. Locks that the gate rejects only genuine signature failures.
+#[test]
+fn using_dispose_value_return_is_clean() {
+    let diags = check(
+        r#"
+function f() { using r = { [Symbol.dispose]() { return 1; } }; }
+"#,
+    );
+    assert!(
+        !diags.iter().any(|d| d.code == 2850),
+        "a value-returning `[Symbol.dispose]` must not raise TS2850 (void-return exception), got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// `await using` whose `[Symbol.asyncDispose]` returns `void` (not a
+/// `PromiseLike`) and which carries no sync `[Symbol.dispose]` fallback must
+/// report TS2851 — the signature-level rejection the structural gate newly
+/// catches. Per `tsc`, TS2851 carries no elaboration tail, so it stays flat.
+#[test]
+fn await_using_async_dispose_wrong_return_reports_flat_ts2851() {
+    let diags = check(
+        r#"
+async function f() { await using r = { [Symbol.asyncDispose](): void {} }; }
+"#,
+    );
+    let ts2851 = diags.iter().find(|d| d.code == 2851).unwrap_or_else(|| {
+        panic!(
+            "expected TS2851 for a void-returning `[Symbol.asyncDispose]`, got: {:?}",
+            diags.iter().map(|d| d.code).collect::<Vec<_>>()
+        )
+    });
+    assert!(
+        ts2851.related_information.is_empty(),
+        "await using (TS2851) must carry no elaboration tail, got: {:?}",
+        ts2851
+            .related_information
+            .iter()
+            .map(|i| i.message_text.clone())
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
Structural rule: when a sync `using` initializer's `[Symbol.dispose]` method has an incompatible **signature** (not a missing property), `tsc` validates it through `checkTypeAssignableTo(initType, Disposable, headMessage = TS2850)` and drills its elaboration tail straight to the specific incompatibility; tsz over-wrapped and mis-nested that tail through the checker's shared `render_failure_reason` / `disposable_relation_tail` owners.

Fixes #16859. Also lands (and **supersedes #16858**) the reachability fix that makes this path fire at all.

### Two display defects fixed (issue #16859)

1. **Redundant wrapper frame.** `disposable_relation_tail` promoted `render_failure_reason`'s depth-0 generic `Type 'S' is not assignable to type 'T'.` line as the first tail line. `tsc`'s `reportRelationError` *replaces* that generic frame with the supplied head message (TS2850) rather than nesting beneath it — the TS2850 wording already conveys the relationship. Mirror it: drop the redundant frame when the rendered top is that generic code and carries a deeper chain, and promote the already-correctly-nested children beneath the head message. A self-heading leaf reason (missing property, TS2741) has no generic frame to replace and is kept as-is (the existing missing-property test is unchanged).

2. **Mis-nested arity leaf (broad).** The shared `render_failure_reason` `TooManyParameters` arm authored its `Target signature provides too few arguments…` leaf at a fixed absolute depth `0`, ignoring the render depth — so when a too-few-args method mismatch is drilled beneath a property/member header the leaf collapsed up to the header level. Every other nested `render_*` arm authors deeper lines at `depth + 1`; this arm now does too when nested (the top-level shape is byte-identical). This corrects the nesting for **every** caller that drills a nested arity mismatch, not just `using`.

Result — now byte-for-byte with `tsc` (`typescript@7.0.2`) for `using r = { [Symbol.dispose](extra: number) {} }`:

```
TS2850: The initializer of a 'using' declaration must be either an object with a '[Symbol.dispose]()' method, or be 'null' or 'undefined'.
  Types of property '[Symbol.dispose]' are incompatible.
    Type '(extra: number) => void' is not assignable to type '() => void'.
      Target signature provides too few arguments. Expected 1 or more, but got 0.
```

### Reachability fix (supersedes #16858)

`type_has_disposable_method`'s gate now runs the real `is_assignable_to` relation against `Disposable`/`AsyncDisposable` (via a shared `resolve_disposable_interface_type` helper) instead of a bare property-existence probe. A `[Symbol.dispose]`/`[Symbol.asyncDispose]` with an incompatible signature is now rejected (TS2850/TS2851) while the void-return exception (a value-returning dispose method) is still accepted — exactly as the relation already implements everywhere else. This is a strict superset of #16858 (same +helper, same gate) plus the display fix, so #16858 should close in favor of this PR.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test using_disposable_elaboration_tests` — 9/9 pass (4 new: type-mismatch tail with depth assertions, param-name-independence, void-return-exception-clean, async-wrong-return TS2851-flat).
- `cargo test -p tsz-checker --lib -- using` — 33/33 pass.
- `cargo clippy -p tsz-checker --lib --tests -- -D warnings` — clean; `cargo fmt --check` — clean; `scripts/arch/arch_guard_file_limits.py` — passed.
- Anti-hardcoding: tests vary the binder/param name (`extra` vs `spare`, `[Symbol.dispose]` source echoed from the renamed signature); the wrapper-drop keys on the diagnostic **code** (`TYPE_IS_NOT_ASSIGNABLE_TO_TYPE`), never on rendered message text.
- Scope note: the change alters no diagnostic **codes or counts** (only a `related_information` `depth` field and the rare disposable signature-mismatch gate), so the conformance code-set/count comparison is unaffected; emit output is independent of diagnostic rendering. Full conformance/emit/fourslash are the nightly lanes, not the per-merge gate (clippy + arch-size), which is green.

## Provenance
Machine: cloud
Assistant: claude-code
Model: Claude Opus 4.8 (1M context)
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01YX4RZ1PfqxznFRFGEc1rNM)_