### PR TITLE
fix(checker): using initializer is not excess-property checked

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/core.rs
+++ b/crates/tsz-checker/src/types/type_checking/core.rs
@@ -1935,16 +1935,29 @@ impl<'a> CheckerState<'a> {
         // rejected, while the ordinary void-return exception (a `(): number`
         // dispose method) must still be accepted, exactly as the relation
         // already implements for every other assignability check.
+        // Widen freshness first. A disposable only has to *carry* a
+        // `[Symbol.dispose]` method; properties beyond it are fine, and tsc
+        // does not excess-property-check a `using` initializer. Passing the
+        // fresh literal type straight into the relation turns
+        // `using x = { [Symbol.dispose]() {}, extra: 1 }` into a `TS2850`
+        // whose tail reads "Object literal may only specify known properties",
+        // which is the freshness check leaking into a position tsc never runs
+        // it (#16862). The same object bound to a variable first was always
+        // accepted, which is the tell. Widening here mirrors tsc reaching this
+        // relation with `getRegularTypeOfObjectLiteral`, and leaves every
+        // signature-shape rejection above intact.
+        let source = crate::query_boundaries::common::widen_freshness(self.ctx.types, type_id);
+
         let is_disposable = self
             .resolve_disposable_interface_type(false)
-            .is_some_and(|target| self.is_assignable_to(type_id, target));
+            .is_some_and(|target| self.is_assignable_to(source, target));
 
         if is_await_using {
             // await using accepts either Symbol.asyncDispose or Symbol.dispose
             return is_disposable
                 || self
                     .resolve_disposable_interface_type(true)
-                    .is_some_and(|target| self.is_assignable_to(type_id, target));
+                    .is_some_and(|target| self.is_assignable_to(source, target));
         }
 
         is_disposable

--- a/crates/tsz-checker/tests/using_disposable_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/using_disposable_elaboration_tests.rs
@@ -182,3 +182,90 @@ const d: Disposable = x;
          in type 'Disposable'.",
     );
 }
+
+/// #16862: a `using` initializer is not excess-property checked. A fresh object
+/// literal carrying `[Symbol.dispose]` plus extra properties is a perfectly good
+/// disposable, and `tsc` accepts it — #16858 passed the fresh literal type
+/// straight into the relation, so freshness leaked in and produced a `TS2850`
+/// whose tail read "Object literal may only specify known properties".
+#[test]
+fn using_object_literal_with_extra_properties_is_clean() {
+    let diags = check(
+        r#"
+function f() { using r = { [Symbol.dispose]() {}, extra: 1 }; }
+"#,
+    );
+    assert!(
+        !diags.iter().any(|d| d.code == 2850),
+        "extra properties beyond `[Symbol.dispose]` must not raise TS2850, got: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}
+
+/// The same object bound to a variable first was always accepted, because a
+/// non-fresh source never reaches the excess-property check. Pairing the two
+/// is what identifies the mechanism as freshness rather than a structural
+/// mismatch — without this row, the fixture above only says "no error here".
+#[test]
+fn using_the_same_object_via_a_variable_is_also_clean() {
+    let diags = check(
+        r#"
+const o = { [Symbol.dispose]() {}, extra: 1 };
+function f() { using r = o; }
+"#,
+    );
+    assert!(
+        !diags.iter().any(|d| d.code == 2850),
+        "a non-fresh disposable with extra properties must not raise TS2850, got: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}
+
+/// `await using` rides the same relation against `AsyncDisposable`, so it needs
+/// its own row — the sync arm is checked first and can mask the async one.
+#[test]
+fn await_using_object_literal_with_extra_properties_is_clean() {
+    let diags = check(
+        r#"
+async function f() { await using r = { async [Symbol.asyncDispose]() {}, extra: 1 }; }
+"#,
+    );
+    assert!(
+        !diags.iter().any(|d| d.code == 2851),
+        "extra properties beyond `[Symbol.asyncDispose]` must not raise TS2851, got: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}
+
+/// Guard against over-correcting back to presence-only checking: widening
+/// freshness must not weaken the signature-shape rejections #16858 added. A
+/// non-callable `[Symbol.dispose]` is still an error.
+#[test]
+fn using_with_a_non_callable_dispose_still_errors() {
+    let diags = check(
+        r#"
+function f() { using r = { [Symbol.dispose]: 42 }; }
+"#,
+    );
+    assert!(
+        diags.iter().any(|d| d.code == 2850),
+        "a non-callable `[Symbol.dispose]` must still raise TS2850, got: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}
+
+/// The other half of that guard: a `[Symbol.dispose]` with a required parameter
+/// is structurally incompatible with `Disposable` and must stay rejected.
+#[test]
+fn using_with_a_required_parameter_on_dispose_still_errors() {
+    let diags = check(
+        r#"
+function f() { using r = { [Symbol.dispose](x: number) {} }; }
+"#,
+    );
+    assert!(
+        diags.iter().any(|d| d.code == 2850),
+        "a `[Symbol.dispose]` with a required parameter must still raise TS2850, got: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
Fixes #16862. Restores the two conformance rows #16858 cost: **11,526 → 11,528**.

Goal: hold

## The divergence

#16858 was right to replace presence-only checking of `[Symbol.dispose]` with a full assignability query — main was accepting `[Symbol.dispose]: 42`. But it passed the object literal's **fresh** type into the relation, so excess-property checking applied:

| case | tsc 7.0.2 | main | this PR |
|---|---|---|---|
| `using x = { [Symbol.dispose]() {}, extra: 1 }` | clean | `TS2850` | ✓ |
| `await using y = { async [Symbol.asyncDispose]() {}, extra: 1 }` | clean | `TS2851` | ✓ |
| `const o = { [Symbol.dispose]() {}, extra: 1 }; using z = o;` | clean | clean | ✓ unchanged |
| `using a = { [Symbol.dispose]() {} }` | clean | clean | ✓ unchanged |
| `using b = { [Symbol.dispose]: 42 }` | `TS2850` | `TS2850` | ✓ **still rejected** |
| `using c = { [Symbol.dispose](x: number) {} }` | `TS2850` | `TS2850` | ✓ **still rejected** |
| `await using d = { [Symbol.dispose]() {} }` (sync ok) | clean | clean | ✓ unchanged |
| `using e = null` / `using f = undefined` | clean | clean | ✓ unchanged |
| `declare const d2: Disposable; using g = d2` | clean | clean | ✓ unchanged |

Row 3 is the discriminator that identifies the mechanism: the **same object** routed through a variable was always accepted, because a non-fresh source never reaches the excess-property check. The emitted diagnostic said so too — the `TS2850` carried the tail `Object literal may only specify known properties, and 'extra' does not exist in type 'Disposable'`.

Rows 5–6 are the guard in the other direction: this must not become a revert of #16858 back to presence-only checking.

## Structural rule

A `using` / `await using` initializer only has to **carry** a `[Symbol.dispose]` (or `[Symbol.asyncDispose]`) method; properties beyond it are fine, and tsc does not excess-property-check that position. Widening freshness before the relation mirrors tsc reaching `checkTypeAssignableTo` with `getRegularTypeOfObjectLiteral`.

Owner layer: the checker's `using` disposable check, going through `query_boundaries::common::widen_freshness` rather than the solver function directly — there is an architecture contract test enforcing that wrapper, and this follows the same route the other checker freshness sites use.

## Tests

Five rows added to `using_disposable_elaboration_tests.rs`. **Two of them fail on main** (the literal-with-extras rows for `using` and `await using`); the other three are guards that correctly pass on main — the variable-routed control, and the two signature-shape rejections that must survive.

The `await using` row is not redundant with the sync one: the sync arm is evaluated first and can mask the async arm, so a fix applied to only one would still pass a sync-only fixture.

## Verification

- `cargo nextest run -p tsz-checker --test using_disposable_elaboration_tests` — **10/10** (5 pre-existing + 5 new); **8/10 with the source change reverted**, confirming non-vacuity
- `cargo nextest run -p tsz-checker --lib` — **10765/10765**
- `cargo nextest run -p tsz-core -p tsz-solver -p tsz-parser -p tsz-emitter --lib` — **17088/17088**
- `cargo clippy -p tsz-checker --all-targets` — 0 diagnostics
- `python3 scripts/arch/arch_guard.py` — rc=0
- Both regressed conformance files now match tsc exactly: `usingDeclarationsWithObjectLiterals1.ts` → `[TS2353]` vs `[TS2353]`, `usingDeclarationsWithObjectLiterals2.ts` → clean vs clean

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high
