### PR TITLE
fix(checker): widen freshness before the using-declaration disposable check

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/core.rs
+++ b/crates/tsz-checker/src/types/type_checking/core.rs
@@ -1768,8 +1768,17 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        // Get the type of the initializer
-        let init_type = self.get_type_of_node(var_decl.initializer);
+        // Get the type of the initializer. `tsc` checks the disposal shape
+        // against the initializer's *regular* (non-fresh) type — an object
+        // literal's excess-property freshness is consumed once, at its own
+        // point of use, and does not re-trigger for this auxiliary structural
+        // query. Without widening, `is_assignable_to` below would apply
+        // excess-property checking against `Disposable`/`AsyncDisposable`
+        // and wrongly reject `{ [Symbol.dispose]() {}, extra: 1 }`.
+        let init_type = crate::query_boundaries::common::widen_freshness(
+            self.ctx.types,
+            self.get_type_of_node(var_decl.initializer),
+        );
 
         // Skip error type and any (suppressed by convention)
         if init_type == TypeId::ERROR || init_type == TypeId::ANY {


### PR DESCRIPTION
Regression fix for #16858 (merged as 08e6853), caught by `compare-to-parent.sh` after that PR landed — I'm the author of both.

When `<a using or await using initializer's disposal method exists but the object literal also carries an extra property>`, `tsc` does not apply excess-property checking against `Disposable`/`AsyncDisposable` (that check is only consumed once, at the literal's own point of use against an explicit annotation, if any); tsz's new #16858 gate did, through `is_assignable_to` seeing the initializer's still-*fresh* object literal type.

## The regression

```ts
using _ = { [Symbol.dispose]() {}, value: 1 };
```

- `tsc`: clean.
- tsz after #16858 (before this fix): `TS2850` — `Object literal may only specify known properties, and 'value' does not exist in type 'Disposable'.`

Caught by two real conformance fixtures going newly-failing in `compare-to-parent.sh` against #16858's merge base:

```
NEWLY FAILING (2):
   - usingDeclarationsWithObjectLiterals1.ts | expected:[TS2353] actual:[TS2353,TS2850,TS2851]
   - usingDeclarationsWithObjectLiterals2.ts | expected:[TS7018] actual:[TS2850,TS2851,TS7018]
```

## Fix

Widen the initializer's type (`query_boundaries::common::widen_freshness`, the same helper used at every other post-hoc structural query site in the checker — e.g. `for_loop.rs`, `mapped_object_literals.rs`, `variable_checking/core.rs`) before the `is_assignable_to` check in `check_using_declaration_disposable`, so the disposability query sees the object literal's *regular* (non-fresh) type, matching `tsc`'s `getRegularTypeOfObjectLiteral` semantics. The `disposable_relation_tail` elaboration-tail helper receives the same widened type, since it's built from the same `init_type` local.

## Verification

- Both flagged conformance fixtures now match `tsc` exactly (verified directly against the rebuilt release CLI):
  - `usingDeclarationsWithObjectLiterals1.ts`: only the two expected `TS2353`s (excess property against the explicit `MyDisposable`/`MyAsyncDisposable` annotations), no more `TS2850`/`TS2851`.
  - `usingDeclarationsWithObjectLiterals2.ts`: only the two expected `TS7018`s, no more `TS2850`/`TS2851`.
- `cargo test -p tsz-checker --lib -- using`: 33/33 passed.
- `cargo test -p tsz-checker --test using_disposable_elaboration_tests`: 5/5 passed.
- Re-ran #16858's full oracle matrix (`typescript@7.0.2`) against the rebuilt binary: the original false-negative fix still holds (`await using` with a `void`-returning `asyncDispose` still correctly reports `TS2851`; the signature-mismatch cases still correctly reject); no new divergences introduced.
- `cargo clippy -p tsz-checker --lib -- -D warnings`: clean.
- `cargo fmt -p tsz-checker -- --check`: clean.
- Full `compare-to-parent.sh` (this branch vs. its own parent) queued next; will report the numbers on this PR once the two-sided build finishes.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_01P3evSrwyhdhjTad6PPKnei)_