### PR TITLE
test(checker): fresh-literal using initializer with no dispose member still errors

### DIFF
--- a/crates/tsz-checker/tests/using_disposable_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/using_disposable_elaboration_tests.rs
@@ -269,3 +269,21 @@ function f() { using r = { [Symbol.dispose](x: number) {} }; }
         diags.iter().map(|d| d.code).collect::<Vec<_>>()
     );
 }
+
+/// A third guard case alongside the two above: the freshness fix only stops
+/// excess PROPERTIES from failing the relation -- it must not weaken presence
+/// checking. A fresh object literal with no dispose member at all is still
+/// rejected, same as the non-fresh `declare const` shape already covered above.
+#[test]
+fn using_fresh_literal_missing_dispose_still_errors() {
+    let diags = check(
+        r#"
+function f() { using r = { notDispose() {} }; }
+"#,
+    );
+    assert!(
+        diags.iter().any(|d| d.code == 2850),
+        "a fresh literal with no dispose member must still raise TS2850, got: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
Tests-only follow-up to #16868 (the `using`/`await using` excess-property freshness fix for #16862).

I independently landed the same fix as #16868 in #16869 within the same ~40-minute window (three of us wrote it — see #16869's closing comment for the collision writeup), and closed #16869 as superseded once I confirmed #16868 on `main` matches `tsc` exactly across the full adjacent-case matrix, including a probe for a latent bug I suspected (a combined arity-mismatch + extra-property case, to check whether the elaboration tail — which #16868 doesn't widen freshness on — could leak a spurious excess-property reason instead of the real structural one). It doesn't; `analyze_assignability_failure` already prefers the genuine structural failure over freshness when both exist, verified against an unpatched `cdb1aaf` worktree.

Diffing my test file against #16868's landed one, 5 of my 6 new rows were exact duplicates of what #16868 already added. This is the one genuinely new row.

## What changed

`using_fresh_literal_missing_dispose_still_errors` in `crates/tsz-checker/tests/using_disposable_elaboration_tests.rs`: a fresh object literal with **no dispose member at all** (`using r = { notDispose() {} }`) still raises TS2850. #16868's own two guard rows (non-callable dispose, required-parameter dispose) cover a *mistyped* dispose method; this covers a fresh literal *missing* one entirely — pinning that the freshness fix only suppresses excess-**property** checking, not the underlying presence/shape requirement, on the fresh-literal path specifically (the existing `using_missing_dispose_attaches_symbol_missing_tail` test already covered this shape, but only for a non-fresh `declare const` source).

No production code changes — the fix itself is already on `main` via #16868.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test using_disposable_elaboration_tests`: 11/11 passed (10 existing + 1 new).
- Pre-commit hook's own affected-crate gate (`-p tsz-checker`: clippy + arch guard + local test verification) passed at commit time.
- Test-only diff (`git diff --name-only` touches no `crates/**/src` path) — no conformance/emit count can move, no corpus gate owed.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_01LtWJo6kL9uY7zF6NACnYDa)_