### PR TITLE
test(checker): pin the 3-module ambient-cycle and tail-consumer TS2303 shapes

### DIFF
--- a/crates/tsz-checker/tests/ts2303_tests.rs
+++ b/crates/tsz-checker/tests/ts2303_tests.rs
@@ -558,6 +558,94 @@ declare module "moduleD" {
 }
 
 #[test]
+fn ambient_module_three_module_alias_cycle_reports_ts2303_at_every_site() {
+    // `recursiveExportAssignmentAndFindAliasedType3`: a three-module cycle
+    // (moduleC -> moduleD -> moduleE -> moduleC) whose members each
+    // contribute an import site and an `export =` site (6 total). Pinned
+    // against the real corpus fixture via the pinned `typescript@7.0.2`
+    // oracle: `def.d.ts` reports TS2303 at lines 2,3,6,7,10,11 and nowhere
+    // else.
+    const SOURCE: &str = r#"declare module "moduleC" {
+    import self = require("moduleD");
+    export = self;
+}
+declare module "moduleD" {
+    import self = require("moduleE");
+    export = self;
+}
+declare module "moduleE" {
+    import self = require("moduleC");
+    export = self;
+}
+"#;
+
+    assert_eq!(
+        ts2303_offsets(SOURCE, "def.d.ts"),
+        vec![
+            nth_offset(SOURCE, "import self", 0),
+            nth_offset(SOURCE, "export = self", 0),
+            nth_offset(SOURCE, "import self", 1),
+            nth_offset(SOURCE, "export = self", 1),
+            nth_offset(SOURCE, "import self", 2),
+            nth_offset(SOURCE, "export = self", 2),
+        ],
+        "Expected TS2303 at all six alias sites of the three-module ambient cycle"
+    );
+}
+
+#[test]
+fn ambient_module_cycle_consumer_file_that_only_imports_the_head_stays_clean() {
+    // The exact shape of `recursiveExportAssignmentAndFindAliasedType1/2/3`:
+    // a separate consumer file (`moduleA`) imports the cyclic ambient module
+    // by name but never resolves through it for a real type (`b`'s type
+    // comes from the unrelated `moduleB`/`ClassB`). `moduleA`'s own
+    // `import moduleC = require("moduleC")` alias is a *tail* pointing into
+    // the cycle, not a member of it — tsc reports TS2303 only inside the
+    // ambient declaration itself (`moduleDef`), never on `moduleA`'s import.
+    const FILES: &[(&str, &str)] = &[
+        (
+            "moduleDef.d.ts",
+            r#"declare module "moduleC" {
+    import self = require("moduleC");
+    export = self;
+}
+"#,
+        ),
+        (
+            "moduleB.ts",
+            r#"class ClassB { }
+export = ClassB;
+"#,
+        ),
+        (
+            "moduleA.ts",
+            r#"import moduleC = require("moduleC");
+import ClassB = require("./moduleB");
+export var b: ClassB;
+"#,
+        ),
+    ];
+
+    let sites = ts2303_sites(FILES);
+    assert_eq!(
+        sites,
+        vec![
+            (
+                "moduleDef.d.ts".to_string(),
+                nth_offset(FILES[0].1, "import self", 0),
+                circular_alias_message("self"),
+            ),
+            (
+                "moduleDef.d.ts".to_string(),
+                nth_offset(FILES[0].1, "export = self", 0),
+                circular_alias_message("self"),
+            ),
+        ],
+        "moduleA's import of the cyclic ambient module must stay clean — only the cycle's own members report"
+    );
+}
+
+#[test]
 fn ambient_module_alias_cycle_export_site_does_not_depend_on_the_binder_name() {
     // Same cycle as above with the alias renamed: the `export =` companion is
     // found through the enclosing module's export table, never by name.


### PR DESCRIPTION
#16866 flagged TS2303 as a false positive on `recursiveExportAssignmentAndFindAliasedType1/2/3`, `exportAsNamespaceConflict`, and `circular3` based on the committed `conformance-detail.json` snapshot's `e`/`a` code lists both reading `["TS2303"]` for these tests.

That snapshot is stale, not tsz. I fetched the real fixtures at the pinned corpus SHA (`4d4f005c8541e0255a9d8791205fdce326e462bc`), ran them through the pinned `typescript@7.0.2` oracle, and through a freshly built release `tsz` binary from current `main`: all 5 already match `tsc` **fingerprint-for-fingerprint** (file, line, column, message) — no code change needed. `crates/tsz-checker/tests/ts2303_tests.rs` already carries 24 tests pinning this exact structural rule and all pass on `main`. Full evidence: https://github.com/tsz-org/tsz/issues/16866#issuecomment-5224738482

While verifying I found one real coverage gap: the existing suite pinned 1- and 2-module ambient require-cycles (`declare module "m" { import self = require(...); export = self; }`, chained across ambient modules) but not the 3-module case, and none of the tests captured the actual multi-file shape the real corpus fixtures use — a separate consumer file (`moduleA.ts`) that imports the cyclic ambient module by name without itself being a cycle member. That second shape is exactly the case a regression in the walk's "does the repeated key equal my own starting symbol" check (`crates/tsz-checker/src/declarations/module_checker/circular_alias.rs`) could silently break without any existing test catching it.

## Structural rule

When an alias declaration inside a `declare module` block resolves back to itself through a chain of `import X = require(...)`/`export =` hops confined entirely to ambient modules, `tsc` reports `TS2303` once at every alias site *on* the cycle (2 per member: the import and the `export =`) and nowhere else — in particular, never at a separate file's `import` of the ambient module by name, even though that import's own resolution passes through the broken cycle. tsz already implements this correctly through `check_circular_import_aliases`'s walk (the `key == (starting file, starting symbol)` guard at `circular_alias.rs:307` is what keeps a "tail into a cycle" from being misreported); this PR just adds the two previously-unpinned adjacent cases.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts2303_tests`: 26/26 passed (24 pre-existing + 2 new).
- `cargo clippy -p tsz-checker --test ts2303_tests -- -D warnings`: clean.
- `cargo fmt -p tsz-checker -- --check`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.
- Pre-commit hook's own affected-crate gate (clippy + arch guard + local tests, `-p tsz-checker`): passed at commit time.
- Test-only diff (`git diff --name-only` touches only `crates/tsz-checker/tests/ts2303_tests.rs`, no `crates/**/src` path) — conformance/emit counts cannot move, so no corpus gate is owed.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Andfc22pLHb3Zp9Ar8uFtd)_