### PR TITLE
fix(checker): nested function-arity elaboration depth, and the using/Disposable tail's redundant wrapper

### DIFF
--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -1155,6 +1155,11 @@ impl<'a> CheckerState<'a> {
                 source_count,
                 target_count,
             } => {
+                // Unlike the arity-only `TupleElementMismatch`/`TupleArityMismatch`
+                // siblings below, a function-signature arity mismatch keeps its
+                // "Type S is not assignable to type T." header at every nesting
+                // depth — that line names the two *function* types being compared,
+                // which a property/member header one level up does not restate.
                 let (source_str, target_str) =
                     self.format_top_level_assignability_message_types_at(source, target, idx);
                 let message = format_message(
@@ -1172,11 +1177,18 @@ impl<'a> CheckerState<'a> {
                     diagnostic_messages::TARGET_SIGNATURE_PROVIDES_TOO_FEW_ARGUMENTS_EXPECTED_OR_MORE_BUT_GOT,
                     &[&source_count.to_string(), &target_count.to_string()],
                 );
-                diag.push_elaboration(
-                    elaboration,
-                    diagnostic_codes::TARGET_SIGNATURE_PROVIDES_TOO_FEW_ARGUMENTS_EXPECTED_OR_MORE_BUT_GOT,
-                    0,
-                );
+                // `depth` is the absolute depth at which THIS diag's own
+                // `message` will be seated by the caller (0 when this render is
+                // the diagnostic's root, unembedded). The arity elaboration is
+                // one level deeper than that: depth 0 (the first elaboration
+                // level) at the root, `depth + 1` when this reason is itself a
+                // nested chain link — `push_nested_chain` appends a nested
+                // diag's `related_information` unshifted, on the invariant that
+                // it already carries depths absolute from its own render, so
+                // hardcoding 0 here (as before) collapsed this leaf to the same
+                // depth as its embedding parent instead of one deeper.
+                let elaboration_depth = if depth == 0 { 0 } else { depth + 1 };
+                diag.push_elaboration(elaboration, diagnostic_codes::TARGET_SIGNATURE_PROVIDES_TOO_FEW_ARGUMENTS_EXPECTED_OR_MORE_BUT_GOT, elaboration_depth);
                 diag
             }
             SubtypeFailureReason::TupleElementMismatch {

--- a/crates/tsz-checker/src/types/type_checking/core.rs
+++ b/crates/tsz-checker/src/types/type_checking/core.rs
@@ -1839,22 +1839,27 @@ impl<'a> CheckerState<'a> {
         let analysis = self.analyze_assignability_failure(init_type, disposable_type);
         let reason = analysis.failure_reason?;
         let rendered = self.render_failure_reason(&reason, init_type, disposable_type, anchor, 0);
-        // The rendered reason's top message is the first elaboration line; its own
-        // nested chain re-seats one level deeper beneath it.
-        let mut related = vec![crate::diagnostics::Diagnostic::related_message(
-            rendered.code,
-            rendered.file,
-            rendered.start,
-            rendered.length,
-            rendered.message_text,
-        )];
-        related.extend(
-            rendered
-                .related_information
-                .into_iter()
-                .map(|info| info.with_depth_shift(1)),
-        );
-        Some(related)
+        // A leaf reason (e.g. a missing property) has no nested chain of its own:
+        // `rendered.message_text` IS the specific line `tsc` shows, so it becomes
+        // the tail's only line. A reason that drills further (e.g. a property
+        // whose value type itself mismatches) renders `rendered.message_text` as
+        // a generic top-level "Type S is not assignable to type T." wrapper that
+        // `tsc` never repeats here — the top-line TS2850/TS2851 message already
+        // carries that relationship — so the tail starts directly at the real
+        // chain in `rendered.related_information`, whose entries already carry
+        // depths absolute from that first line (the same invariant
+        // `push_nested_chain` relies on elsewhere), unshifted.
+        if rendered.related_information.is_empty() {
+            Some(vec![crate::diagnostics::Diagnostic::related_message(
+                rendered.code,
+                rendered.file,
+                rendered.start,
+                rendered.length,
+                rendered.message_text,
+            )])
+        } else {
+            Some(rendered.related_information)
+        }
     }
 
     /// Check if a type has the appropriate dispose method.

--- a/crates/tsz-checker/tests/ts2322_tests/part_03.rs
+++ b/crates/tsz-checker/tests/ts2322_tests/part_03.rs
@@ -1654,6 +1654,75 @@ fn test_ts2322_too_many_parameters_emits_chained_target_signature_elaboration() 
     );
 }
 
+/// The same `TS2849` chain nested one level deeper, under a `Types of property
+/// 'm' are incompatible.` header (a member-function arity mismatch, not a
+/// top-level one). `tsc` keeps the same three-line shape at every nesting
+/// depth — property header, then the member's own function-vs-function "Type X
+/// is not assignable to Y." line, then the arity leaf one level deeper still —
+/// oracle-verified (`typescript@7.0.2`):
+///
+/// ```text
+/// error TS2322: Type '{ m: (extra: number) => void; }' is not assignable to type 'HasMethod'.
+///   Types of property 'm' are incompatible.
+///     Type '(extra: number) => void' is not assignable to type '() => void'.
+///       Target signature provides too few arguments. Expected 1 or more, but got 0.
+/// ```
+///
+/// Regression test for #16859: `render_failure_reason`'s `TooManyParameters`
+/// arm pushed its arity elaboration at a hardcoded absolute depth `0` — correct
+/// only when the reason itself is the diagnostic's un-embedded root (`depth ==
+/// 0`). Nested one level under a property header (`depth == 1`), the elaboration
+/// needs `depth + 1` to land one level under this reason's own "Type X is not
+/// assignable to Y." message, not flush with the property header itself.
+///
+/// Asserts depths and codes only, not the middle line's exact type text: this
+/// shape (an identifier `src` assigned to a named interface target) hits a
+/// separate, pre-existing display bug where that line's source type renders as
+/// the outer object instead of the property's own function type — unrelated to
+/// nesting depth (unaffected by this fix; not scoped here, flagged separately).
+#[test]
+fn test_ts2322_too_many_parameters_nested_under_property_keeps_correct_depth() {
+    let source = r#"
+        interface HasMethod { m(): void }
+        declare const src: { m: (extra: number) => void };
+        declare let tgt: HasMethod;
+        tgt = src;
+    "#;
+
+    let diags = diagnostics_for_source(source);
+    let mismatch = diagnostics_with_code(&diags, diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE)
+        .into_iter()
+        .next()
+        .unwrap_or_else(|| panic!("expected TS2322, got: {diags:#?}"));
+
+    let shape: Vec<(u8, u32)> = mismatch
+        .related_information
+        .iter()
+        .map(|r| (r.depth, r.code))
+        .collect();
+    assert_eq!(
+        shape,
+        vec![
+            (0, diagnostic_codes::TYPES_OF_PROPERTY_ARE_INCOMPATIBLE),
+            (1, diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+            (
+                2,
+                diagnostic_codes::TARGET_SIGNATURE_PROVIDES_TOO_FEW_ARGUMENTS_EXPECTED_OR_MORE_BUT_GOT
+            ),
+        ],
+        "expected the property-header -> signature-mismatch -> arity-leaf chain \
+         at depths 0/1/2 respectively; got: {:#?}",
+        mismatch.related_information
+    );
+    assert!(
+        mismatch.related_information[2]
+            .message_text
+            .contains("Expected 1 or more, but got 0"),
+        "got: {:#?}",
+        mismatch.related_information
+    );
+}
+
 #[test]
 fn test_reverse_mapped_contextual_target_display_uses_inferred_application_args() {
     let source = r#"

--- a/crates/tsz-checker/tests/using_disposable_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/using_disposable_elaboration_tests.rs
@@ -162,6 +162,41 @@ function f() { using r = x; }
     );
 }
 
+/// Sync `using` whose initializer HAS `[Symbol.dispose]`, but with an
+/// incompatible signature (an extra required parameter): the relation fails on
+/// a property TYPE mismatch rather than a missing property, and `tsc`'s tail
+/// drills straight into the property-then-signature chain with no leading
+/// `Type '{...}' is not assignable to type 'Disposable'.` wrapper (the top-line
+/// TS2850 message already carries that relationship) — unlike the
+/// missing-property tail above, whose sole line already *is* the specific
+/// reason and needs no such trimming. Regression test for #16859.
+///
+/// Ignored: `type_has_disposable_method` (the `check_using_declaration_disposable`
+/// gate this test's own `using` statement runs through) currently only checks
+/// `[Symbol.dispose]` for PRESENCE, not signature-assignability, so this
+/// initializer is accepted with zero diagnostics on current `main` and this
+/// path in `disposable_relation_tail` — fixed here regardless, since it is
+/// exercised by the (independently verified) plain-object nested case below —
+/// stays unreachable until #16858 lands the gate fix. Un-ignore once merged.
+#[test]
+#[ignore = "blocked on #16858 (disposable gate is presence-only, not signature-checked)"]
+fn using_dispose_signature_mismatch_tail_has_no_wrapper_and_correct_nesting() {
+    let text = elaboration(
+        r#"
+function f() { using x = { [Symbol.dispose](extra: number) {} }; }
+"#,
+        2850,
+    );
+    assert_eq!(
+        text,
+        "The initializer of a 'using' declaration must be either an object with a \
+         '[Symbol.dispose]()' method, or be 'null' or 'undefined'.\n\
+         Types of property '[Symbol.dispose]' are incompatible.\n\
+         Type '(extra: number) => void' is not assignable to type '() => void'.\n\
+         Target signature provides too few arguments. Expected 1 or more, but got 0.",
+    );
+}
+
 /// The broader explain fix: a plain assignment to `Disposable` whose source lacks
 /// only the symbol member now produces the symbol-keyed TS2741 (matching `tsc`),
 /// instead of collapsing to a flat `TypeMismatch` with no member listed. This is


### PR DESCRIPTION
When a `SubtypeFailureReason::TooManyParameters` (function-signature arity) reason renders as a nested chain link (`depth >= 1`, e.g. beneath a `Types of property 'x' are incompatible.` header), tsc keeps its own "Type S is not assignable to type T." + "Target signature provides too few arguments..." pair one level deeper than its embedding parent; tsz hardcoded the arity elaboration at absolute depth `0` regardless of nesting, collapsing it flush with the parent header instead of one level under its own "Type S not assignable T" line. Owner: `tsz-checker`'s shared `render_failure_reason` (the query-boundary diagnostic-rendering path every `TS2322`/`TS2345`-family nested reason goes through).

Fixed by seating the elaboration at `depth + 1` instead of a hardcoded `0` — the same invariant every sibling multi-level reason in the file already follows (`push_nested_chain` appends a nested diag's `related_information` unshifted, assuming it already carries depths absolute from its own render).

This also fixes the `using`/`await using` Disposable elaboration tail (`disposable_relation_tail`, #16859): its old "take `rendered.message_text` as the header, then shift everything else by +1" logic assumed every failure reason is a bare leaf (true for a missing-property tail — already covered by an existing pinned test), but a property *type* mismatch's `rendered.message_text` is itself a generic "Type S is not assignable to Disposable." wrapper tsc never repeats there (the top-line TS2850/TS2851 message already carries that relationship). Now: a leaf reason's `message_text` is still the tail's sole line; a reason with its own nested chain uses that chain directly (already correctly seated once the depth fix above lands), dropping both the redundant wrapper and the extra `+1` shift that was double-nesting the rest.

Adjacent cases covered: a top-level (`depth == 0`) function-arity `TS2322` (pre-existing, unaffected — still passes), a nested member-arity `TS2322` under a named interface target (new, oracle-verified against `typescript@7.0.2`), and the `using`-declaration Disposable signature-mismatch tail itself (new, `#[ignore]`d — its own gate, `type_has_disposable_method`, is presence-only today and blocks this path until #16858 lands the signature-assignability check; verified correct in this session via a temporary local-only gate override, not part of this diff — safe to un-ignore once #16858 merges).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts2322_tests`: 309/309
- `cargo test -p tsz-checker --test using_disposable_elaboration_tests`: 5 passed, 1 ignored (pending #16858)
- `cargo test -p tsz-checker --lib -- ts2345 ts2739 ts2740 ts2741 ts2849 ts2851 property_type_mismatch return_type_mismatch tuple_element`: 233/233
- `cargo clippy -p tsz-checker --lib -- -D warnings`: clean
- `cargo fmt -p tsz-checker -- --check`: clean
- Display-only change (relation verdict/diagnostic codes unaffected; only related-information nesting depth and the `using`-tail's line count change) — full `cargo test -p tsz-checker --lib` and `conformance`/`emit`/`fourslash` were not run to completion inside this session's window (the full `--lib` run hit the documented long tail); the targeted suites above span every `SubtypeFailureReason` family that recurses through this same nested-chain machinery.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_01TN1voztfMju3rSGbE5h9i4)_