### PR TITLE
fix(binder): entity-name `import X = A.B` is not an external-module indicator

### DIFF
--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -771,21 +771,24 @@ impl BinderState {
                 | syntax_kind_ext::EXPORT_ASSIGNMENT => {
                     return true;
                 }
-                syntax_kind_ext::IMPORT_EQUALS_DECLARATION => {
-                    // Only `import X = require("...")` (an external module
-                    // reference) is a module indicator, matching tsc's
-                    // `isAnExternalModuleIndicatorNode`
-                    // (`isImportEqualsDeclaration(node) &&
-                    // isExternalModuleReference(node.moduleReference)`). An
-                    // internal `import X = A.B` (entity-name reference) is a
-                    // namespace alias, not external module syntax, so it must
-                    // not force its file to be a module — otherwise an
-                    // `await`/`yield`-as-identifier at the top level wrongly
-                    // becomes reserved (TS1262) in a file tsc treats as a
-                    // script.
-                    if Self::import_equals_is_external_module_reference(arena, stmt) {
-                        return true;
-                    }
+                // Only `import X = require("...")` (an external module
+                // reference) is a module indicator, matching tsc's
+                // `isAnExternalModuleIndicatorNode`
+                // (`isImportEqualsDeclaration(node) &&
+                // isExternalModuleReference(node.moduleReference)`). An
+                // internal `import X = A.B` (entity-name reference) is a
+                // namespace alias, not external module syntax, so it must not
+                // force its file to be a module — otherwise an
+                // `await`/`yield`-as-identifier at the top level wrongly
+                // becomes reserved (TS1262) in a file tsc treats as a script.
+                // Expressed as a match guard rather than a nested `if`: a
+                // non-external `import X = A.B` falls through to the `_` arm
+                // and is then still considered by the `is_node_exported` check
+                // below, exactly as before.
+                syntax_kind_ext::IMPORT_EQUALS_DECLARATION
+                    if Self::import_equals_is_external_module_reference(arena, stmt) =>
+                {
+                    return true;
                 }
                 _ => {}
             }

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -767,10 +767,25 @@ impl BinderState {
             };
             match stmt.kind {
                 syntax_kind_ext::IMPORT_DECLARATION
-                | syntax_kind_ext::IMPORT_EQUALS_DECLARATION
                 | syntax_kind_ext::EXPORT_DECLARATION
                 | syntax_kind_ext::EXPORT_ASSIGNMENT => {
                     return true;
+                }
+                syntax_kind_ext::IMPORT_EQUALS_DECLARATION => {
+                    // Only `import X = require("...")` (an external module
+                    // reference) is a module indicator, matching tsc's
+                    // `isAnExternalModuleIndicatorNode`
+                    // (`isImportEqualsDeclaration(node) &&
+                    // isExternalModuleReference(node.moduleReference)`). An
+                    // internal `import X = A.B` (entity-name reference) is a
+                    // namespace alias, not external module syntax, so it must
+                    // not force its file to be a module — otherwise an
+                    // `await`/`yield`-as-identifier at the top level wrongly
+                    // becomes reserved (TS1262) in a file tsc treats as a
+                    // script.
+                    if Self::import_equals_is_external_module_reference(arena, stmt) {
+                        return true;
+                    }
                 }
                 _ => {}
             }
@@ -780,6 +795,26 @@ impl BinderState {
         }
 
         Self::source_file_contains_import_meta(arena, root)
+    }
+
+    /// Whether an `import X = ...` statement references an external module
+    /// (`= require("...")`) rather than an entity name (`= A.B`). tsz's parser
+    /// currently flattens the `require` argument to a bare `StringLiteral`
+    /// stored as the `module_specifier`; an entity-name reference is an
+    /// `Identifier`/`QualifiedName` instead. `EXTERNAL_MODULE_REFERENCE` is
+    /// also accepted so this stays correct if the parser is later changed to
+    /// wrap `require(...)` in that node the way tsc's AST does.
+    fn import_equals_is_external_module_reference(
+        arena: &NodeArena,
+        stmt: &tsz_parser::parser::node::Node,
+    ) -> bool {
+        let Some(import) = arena.get_import_decl(stmt) else {
+            return false;
+        };
+        arena.get(import.module_specifier).is_some_and(|spec| {
+            spec.kind == SyntaxKind::StringLiteral as u16
+                || spec.kind == syntax_kind_ext::EXTERNAL_MODULE_REFERENCE
+        })
     }
 
     /// The `moduleDetection: auto` predicate — module syntax, plus the formats

--- a/crates/tsz-binder/src/state/tests/module_detection.rs
+++ b/crates/tsz-binder/src/state/tests/module_detection.rs
@@ -145,6 +145,70 @@ fn legacy_still_honours_an_exported_declaration() {
 }
 
 // ---------------------------------------------------------------------------
+// import-equals: only `= require("...")` is module syntax, not `= A.B`
+//
+// tsc's `isAnExternalModuleIndicatorNode` counts an `ImportEqualsDeclaration`
+// only when `isExternalModuleReference(node.moduleReference)` — i.e. the
+// `= require("...")` form. An internal `import X = A.B` (entity-name
+// reference) is a namespace alias, not module syntax, so its file stays a
+// script. Binder names vary so nothing keys on an identifier string.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn import_equals_require_is_module_syntax() {
+    assert!(
+        is_external_module(
+            "import wallaby = require(\"./w\");\nwallaby;\n",
+            "h.ts",
+            ModuleDetectionKind::Legacy
+        ),
+        "`import X = require(\"...\")` is an external module reference"
+    );
+}
+
+#[test]
+fn import_equals_entity_name_is_not_module_syntax() {
+    // The reported witness (issue-family): `import await = foo.await;` in a
+    // script must leave the file a script so `await` stays a legal top-level
+    // identifier (no spurious TS1262). Use a neutral name to prove the rule
+    // is structural, not a `await` special case.
+    assert!(
+        !is_external_module(
+            "namespace ns { export const wombat = 1; }\nimport alias = ns.wombat;\nalias;\n",
+            "i.ts",
+            ModuleDetectionKind::Legacy
+        ),
+        "`import X = A.B` (entity-name reference) is a namespace alias, not module syntax"
+    );
+}
+
+#[test]
+fn import_equals_entity_name_stays_a_script_under_auto() {
+    assert!(
+        !is_external_module(
+            "namespace ns { export const koala = 1; }\nimport alias = ns.koala;\nalias;\n",
+            "j.ts",
+            ModuleDetectionKind::Auto
+        ),
+        "auto detection must not promote an entity-name `import =` file to a module"
+    );
+}
+
+#[test]
+fn import_equals_entity_name_alongside_real_import_is_a_module() {
+    // The entity-name `import =` contributes nothing, but a sibling external
+    // import still makes the file a module — the gate is per-statement.
+    assert!(
+        is_external_module(
+            "import { yak } from \"./y\";\nnamespace ns { export const x = 1; }\nimport alias = ns.x;\nyak;\nalias;\n",
+            "k.ts",
+            ModuleDetectionKind::Legacy
+        ),
+        "a real import declaration is a module indicator even beside an entity-name `import =`"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // auto: syntax plus format, declaration files excluded from format forcing
 // ---------------------------------------------------------------------------
 

--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -882,6 +882,9 @@ path = "tests/class_reserved_word_diagnostics_tests.rs"
 name = "reserved_await_multiple_ts1262_tests"
 path = "tests/reserved_await_multiple_ts1262_tests.rs"
 [[test]]
+name = "import_equals_entity_name_not_module_ts1262_tests"
+path = "tests/import_equals_entity_name_not_module_ts1262_tests.rs"
+[[test]]
 name = "interface_heritage_display_tests"
 path = "tests/interface_heritage_display_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/import_equals_entity_name_not_module_ts1262_tests.rs
+++ b/crates/tsz-checker/tests/import_equals_entity_name_not_module_ts1262_tests.rs
@@ -1,0 +1,67 @@
+//! An internal `import X = A.B` (entity-name reference) is a namespace alias,
+//! not external module syntax, so it must not make its file a module. When it
+//! wrongly did, `await`/`yield`-as-identifier at the top level became reserved
+//! and tsz over-reported TS1262 on files tsc treats as scripts
+//! (`conformance/externalModules/topLevelAwait.2.ts`: oracle emits nothing).
+//!
+//! Structural rule: tsc's `isAnExternalModuleIndicatorNode` counts an
+//! `ImportEqualsDeclaration` only when `isExternalModuleReference` — the
+//! `= require("...")` form. `= A.B` is not an indicator. Fixed in the binder's
+//! `file_has_module_syntax_indicator`
+//! (`crates/tsz-binder/src/state/core.rs`).
+
+use tsz_checker::test_utils::check_source_codes;
+
+const TS1262: u32 = 1262;
+
+/// The reported witness: `import await = foo.await;` in a script keeps `await`
+/// a legal top-level identifier — no TS1262.
+#[test]
+fn import_equals_entity_name_keeps_await_a_script_identifier() {
+    let codes = check_source_codes(
+        r#"
+declare namespace foo { const await: any; }
+import await = foo.await;
+"#,
+    );
+    assert!(
+        !codes.contains(&TS1262),
+        "entity-name `import await = foo.await` must not make the file a module; got {codes:?}"
+    );
+}
+
+/// The same file, but with an explicit module marker, IS a module — so `await`
+/// bound at the top level is reserved and TS1262 fires. Proves the fix keys on
+/// module-ness, not on suppressing the check.
+#[test]
+fn export_marker_alongside_entity_name_import_equals_reserves_await() {
+    let codes = check_source_codes(
+        r#"
+export {};
+declare namespace foo { const await: any; }
+import await = foo.await;
+"#,
+    );
+    assert!(
+        codes.contains(&TS1262),
+        "with `export {{}}` the file is a module, so top-level `await` is reserved; got {codes:?}"
+    );
+}
+
+/// A neutral alias name proves the rule is structural: an entity-name
+/// `import =` contributes no module syntax, so a plain top-level `await`
+/// binding elsewhere stays a legal script identifier.
+#[test]
+fn entity_name_import_equals_does_not_reserve_a_sibling_await_binding() {
+    let codes = check_source_codes(
+        r#"
+namespace ns { export const value = 1; }
+import alias = ns.value;
+var await = alias;
+"#,
+    );
+    assert!(
+        !codes.contains(&TS1262),
+        "an entity-name `import =` leaves the file a script; `await` stays legal; got {codes:?}"
+    );
+}


### PR DESCRIPTION
Structural rule: **when a file's only module-shaped syntax is an internal `import X = A.B` (entity-name reference), tsc treats the file as a script, not an external module** — its `isAnExternalModuleIndicatorNode` counts an `ImportEqualsDeclaration` only when `isExternalModuleReference(node.moduleReference)`, i.e. the `= require("...")` form. tsz's binder counted *every* `import =` as a module indicator, so such a file was misclassified as an external module. Owner layer: `file_has_module_syntax_indicator` in `crates/tsz-binder/src/state/core.rs`.

Fixes the false positive on `conformance/externalModules/topLevelAwait.2.ts` (issue-family: TS1262 over-report; the pinned `typescript@7.0.2` oracle emits nothing there).

### What was wrong

`topLevelAwait.2.ts` is a script whose only import/export-shaped statement is `import await = foo.await;` (an entity-name alias). Because tsz classified it as an external module, the top-level `await` binding became reserved and tsz emitted an extra `TS1262` ("`'await'` is a reserved word at the top-level of a module"). tsc keeps `await` a legal identifier in a script.

The misclassification also contradicted the binder's *own* documented intent — the `file_has_module_syntax_indicator` doc comment already says the indicator is "an `import ... = require(...)`", but the implementation accepted all `import =` forms.

### The fix

Gate the `IMPORT_EQUALS_DECLARATION` arm on the reference being external. tsz's parser flattens `require("...")` to a bare `StringLiteral` stored as the `module_specifier`; an entity-name reference is an `Identifier`/`QualifiedName`. The new `import_equals_is_external_module_reference` helper accepts a `StringLiteral` (and `EXTERNAL_MODULE_REFERENCE`, for forward-compatibility if the parser is ever changed to wrap `require`).

- `import X = require("m")` → still a module indicator.
- `import X = A.B` → no longer a module indicator (namespace alias).

This is a global classification fix at the layer where tsc makes the same distinction, not a TS1262-scoped suppression — `is_external_module` is consumed broadly (checker + emitter), and leaving it wrong for these files would misclassify them everywhere (Anti-Hardcoding Gate: no single-check-scoped suppressions).

## Goal
Goal: hold

## Verification

**Conformance** — snapshot at the same base commit, with the fix isolated by stash + re-snapshot (both runs at SHA `c7ed8fe`, differing only by this change):

| | passing | failing |
| --- | --- | --- |
| pre-fix | 11529 | 514 |
| post-fix | 11530 | 513 |

Detail diff (post-fix vs clean pre-fix): **+1 row now passing** (`externalModules/topLevelAwait.2.ts`), **0 regressions**, 0 changed-code rows. The fix touches only files whose sole module indicator is an entity-name `import =`; across all 626 corpus files containing entity-name `import =`, this was the only behavioral change.

**Unit tests**
- `cargo test -p tsz-binder --lib module_detection` — 25 pass, incl. 4 new (require vs entity-name; auto/legacy; entity-name beside a real import still a module).
- `cargo test -p tsz-checker --test import_equals_entity_name_not_module_ts1262_tests` — 3 new (script stays a script → no TS1262; `export {}` marker restores module-ness → TS1262 still fires; neutral binder name proves the rule is structural).
- `cargo test -p tsz-checker --test reserved_await_multiple_ts1262_tests --test ts1262_multiple_await_declarations_tests --test top_level_await_grammar_diagnostics_tests` — 14 pass (no regression on the reserved-await family).
- `cargo clippy -p tsz-binder -p tsz-checker` + arch-size + local verification — green (pre-commit hook).

**Emit** — the emit runner (Node/npm) could not be built in this environment (the `npm install` step stalls under the sandbox proxy), so the JS/DTS suite was not run locally; the nightly emit CI is the authoritative check. The change cannot regress emit against tsc baselines: it moves entity-name-`import =`-only files toward tsc's *script* emit (dropping the `Object.defineProperty(exports, "__esModule")` module wrapper). Before the fix such a file emitted module-style (mismatching tsc's script baseline); after, script-style (matching or closer). Verified directly with the release binary on the affected shape.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjoTEGtkTvCQVLcQzm1xsY)_