### PR TITLE
test(checker): nested function-arity TS2849 depth holds outside using/Disposable

### DIFF
--- a/crates/tsz-checker/tests/ts2322_tests/part_03.rs
+++ b/crates/tsz-checker/tests/ts2322_tests/part_03.rs
@@ -1654,6 +1654,68 @@ fn test_ts2322_too_many_parameters_emits_chained_target_signature_elaboration() 
     );
 }
 
+/// The same `TS2849` chain, but nested one level deeper under a `Types of
+/// property 'm' are incompatible.` header (a member-function arity mismatch,
+/// not a top-level one) — not `using`/`Disposable`-specific, proving the
+/// `render_failure_reason` `TooManyParameters` depth fix (#16859, landed in
+/// `4617da0`) generalizes to any nested function-arity mismatch. Oracle-verified
+/// (`typescript@7.0.2`):
+///
+/// ```text
+/// error TS2322: Type '{ m: (extra: number) => void; }' is not assignable to type 'HasMethod'.
+///   Types of property 'm' are incompatible.
+///     Type '(extra: number) => void' is not assignable to type '() => void'.
+///       Target signature provides too few arguments. Expected 1 or more, but got 0.
+/// ```
+///
+/// Asserts depths and codes only, not the middle line's exact type text: this
+/// shape (an identifier `src` assigned to a named interface target) hits a
+/// separate, pre-existing display bug where that line's source type renders as
+/// the outer object instead of the property's own function type — unrelated to
+/// nesting depth, unfiled, out of scope here.
+#[test]
+fn test_ts2322_too_many_parameters_nested_under_property_keeps_correct_depth() {
+    let source = r#"
+        interface HasMethod { m(): void }
+        declare const src: { m: (extra: number) => void };
+        declare let tgt: HasMethod;
+        tgt = src;
+    "#;
+
+    let diags = diagnostics_for_source(source);
+    let mismatch = diagnostics_with_code(&diags, diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE)
+        .into_iter()
+        .next()
+        .unwrap_or_else(|| panic!("expected TS2322, got: {diags:#?}"));
+
+    let shape: Vec<(u8, u32)> = mismatch
+        .related_information
+        .iter()
+        .map(|r| (r.depth, r.code))
+        .collect();
+    assert_eq!(
+        shape,
+        vec![
+            (0, diagnostic_codes::TYPES_OF_PROPERTY_ARE_INCOMPATIBLE),
+            (1, diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+            (
+                2,
+                diagnostic_codes::TARGET_SIGNATURE_PROVIDES_TOO_FEW_ARGUMENTS_EXPECTED_OR_MORE_BUT_GOT
+            ),
+        ],
+        "expected the property-header -> signature-mismatch -> arity-leaf chain \
+         at depths 0/1/2 respectively; got: {:#?}",
+        mismatch.related_information
+    );
+    assert!(
+        mismatch.related_information[2]
+            .message_text
+            .contains("Expected 1 or more, but got 0"),
+        "got: {:#?}",
+        mismatch.related_information
+    );
+}
+
 #[test]
 fn test_reverse_mapped_contextual_target_display_uses_inferred_application_args() {
     let source = r#"


### PR DESCRIPTION
#16859's fix (already landed as `4617da0`, merged via #16867) corrected `render_failure_reason`'s `TooManyParameters` arm to seat its "Target signature provides too few arguments..." elaboration at `depth + 1` instead of a hardcoded `0`, and was verified there through the `using`/`Disposable` path that originally surfaced it.

This adds the missing adjacent case named in CLAUDE.md's bug discipline ("Behavior fixes need adjacent cases... generic and concrete forms"): a plain, non-`using`, non-`Disposable` nested member-arity mismatch — a property whose function-typed value has an incompatible arity, assigned to a named interface target — proving the depth fix is general `render_failure_reason` infrastructure and not `using`-specific. Oracle-verified against `typescript@7.0.2`.

(Context: I opened #16874 for the same underlying fix before discovering an independent session had landed the identical mechanism as `4617da0`/#16867 while my PR was in review — closed #16874 as superseded once I found the conflict merging `main` in. This PR is just the one adjacent-case test from that branch that #16867 didn't already cover.)

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts2322_tests`: 309/309
- `cargo fmt -p tsz-checker -- --check`: clean
- Test-only diff — no `crates/**/src` path touched, so conformance/emit counts cannot move.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_01TN1voztfMju3rSGbE5h9i4)_