### PR TITLE
fix(checker): TS2411 renders inherited computed member names with brackets

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
@@ -1279,6 +1279,16 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
 
+            // tsc's `declarationNameToString` renders a computed member name
+            // (e.g. `["get1"]`) as verbatim source text; `prop_name` here is
+            // just the resolved atom (`get1`) with no such formatting. Walk the
+            // heritage chain to find the base declaration that actually
+            // introduced this inherited property, falling back to the resolved
+            // name when the base declaration can't be located (e.g. a lib type).
+            let diag_prop_name = self
+                .inherited_member_display_name(iface_node, &prop_name)
+                .unwrap_or_else(|| prop_name.clone());
+
             // Symbol-keyed inherited properties (e.g. [Symbol.iterator]) are
             // checked against the symbol index signature, NOT string/number.
             let is_symbol_property =
@@ -1294,7 +1304,7 @@ impl<'a> CheckerState<'a> {
                     self.error_at_node_msg(
                         error_node,
                         diagnostic_codes::PROPERTY_OF_TYPE_IS_NOT_ASSIGNABLE_TO_INDEX_TYPE,
-                        &[&prop_name, &prop_type_str, "symbol", &index_type_str],
+                        &[&diag_prop_name, &prop_type_str, "symbol", &index_type_str],
                     );
                 }
                 continue;
@@ -1316,7 +1326,7 @@ impl<'a> CheckerState<'a> {
                 self.error_at_node_msg(
                     error_node,
                     diagnostic_codes::PROPERTY_OF_TYPE_IS_NOT_ASSIGNABLE_TO_INDEX_TYPE,
-                    &[&prop_name, &prop_type_str, "number", &index_type_str],
+                    &[&diag_prop_name, &prop_type_str, "number", &index_type_str],
                 );
             }
 
@@ -1352,7 +1362,12 @@ impl<'a> CheckerState<'a> {
                 self.error_at_node_msg(
                     error_node,
                     diagnostic_codes::PROPERTY_OF_TYPE_IS_NOT_ASSIGNABLE_TO_INDEX_TYPE,
-                    &[&prop_name, &prop_type_str, &index_kind_str, &index_type_str],
+                    &[
+                        &diag_prop_name,
+                        &prop_type_str,
+                        &index_kind_str,
+                        &index_type_str,
+                    ],
                 );
             }
         }

--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_inherited_display.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_inherited_display.rs
@@ -1,0 +1,101 @@
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+
+impl<'a> CheckerState<'a> {
+    /// Find the base class/interface member that introduced an inherited
+    /// property, so TS2411 can render tsc's source-verbatim computed-name text
+    /// (`declarationNameToString`) instead of the bare resolved property name.
+    /// `shape.properties` only carries the resolved `Atom`, not the declaring
+    /// node, so the heritage chain is walked (recursively, for multi-level
+    /// `extends` chains) to recover it.
+    pub(crate) fn inherited_member_display_name(
+        &mut self,
+        iface_node: NodeIndex,
+        prop_name: &str,
+    ) -> Option<String> {
+        let mut visited = std::collections::HashSet::new();
+        let name_idx =
+            self.find_member_name_node_in_hierarchy(iface_node, prop_name, false, &mut visited)?;
+        self.get_member_name_text(name_idx)
+    }
+
+    /// Recursive helper for [`Self::inherited_member_display_name`]. When
+    /// `check_self_members` is `false`, `decl_node`'s own members are skipped
+    /// (used for the starting node, whose own members are never the source of
+    /// an *inherited* property) and only its heritage bases are searched.
+    fn find_member_name_node_in_hierarchy(
+        &mut self,
+        decl_node: NodeIndex,
+        prop_name: &str,
+        check_self_members: bool,
+        visited: &mut std::collections::HashSet<NodeIndex>,
+    ) -> Option<NodeIndex> {
+        if !visited.insert(decl_node) {
+            return None;
+        }
+        let node = self.ctx.arena.get(decl_node)?;
+        let (members, heritage) = if node.kind == syntax_kind_ext::CLASS_DECLARATION {
+            let class = self.ctx.arena.get_class(node)?;
+            (class.members.nodes.clone(), class.heritage_clauses.clone())
+        } else if node.kind == syntax_kind_ext::INTERFACE_DECLARATION {
+            let iface = self.ctx.arena.get_interface(node)?;
+            (iface.members.nodes.clone(), iface.heritage_clauses.clone())
+        } else {
+            return None;
+        };
+
+        if check_self_members {
+            for &member_idx in &members {
+                let Some(member_node) = self.ctx.arena.get(member_idx) else {
+                    continue;
+                };
+                if member_node.kind == syntax_kind_ext::INDEX_SIGNATURE {
+                    continue;
+                }
+                let Some(name_idx) = self.get_member_name_node(member_node) else {
+                    continue;
+                };
+                let resolved = self
+                    .get_property_name_resolved(name_idx)
+                    .or_else(|| self.get_member_name(member_idx));
+                if resolved.as_deref() == Some(prop_name) {
+                    return Some(name_idx);
+                }
+            }
+        }
+
+        let heritage = heritage?;
+        for &clause_idx in &heritage.nodes {
+            let Some(clause_node) = self.ctx.arena.get(clause_idx) else {
+                continue;
+            };
+            let Some(heritage_clause) = self.ctx.arena.get_heritage_clause(clause_node) else {
+                continue;
+            };
+            for &type_idx in &heritage_clause.types.nodes {
+                let expr_idx = self
+                    .ctx
+                    .arena
+                    .get(type_idx)
+                    .and_then(|n| self.ctx.arena.get_expr_type_args(n))
+                    .map(|eta| eta.expression)
+                    .unwrap_or(type_idx);
+                let Some(sym_id) = self.resolve_heritage_symbol(expr_idx) else {
+                    continue;
+                };
+                let Some(symbol) = self.ctx.binder.symbols.get(sym_id) else {
+                    continue;
+                };
+                for base_decl in symbol.declarations.clone() {
+                    if let Some(found) =
+                        self.find_member_name_node_in_hierarchy(base_decl, prop_name, true, visited)
+                    {
+                        return Some(found);
+                    }
+                }
+            }
+        }
+        None
+    }
+}

--- a/crates/tsz-checker/src/state/state_checking_members/mod.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/mod.rs
@@ -16,6 +16,7 @@ mod implicit_any_param_context;
 mod index_signature_checks;
 #[cfg(test)]
 mod index_signature_checks_tests;
+mod index_signature_inherited_display;
 mod index_signature_key_helpers;
 mod index_signature_type_helpers;
 mod index_signature_validity;

--- a/crates/tsz-checker/tests/ts2411_tests.rs
+++ b/crates/tsz-checker/tests/ts2411_tests.rs
@@ -251,9 +251,122 @@ function test(arg: string | number, whatever: any) {
     );
 }
 
-// Note: Inherited member vs index signature is tested via conformance tests
-// (e.g. inheritedMembersAndIndexSignaturesFromDifferentBases.ts) since it
-// requires full lib type resolution that unit tests don't provide.
+// =========================================================================
+// Inherited member vs index signature: computed-name display (#16866)
+//
+// tsc's `declarationNameToString` renders a computed member name
+// (`["get1"]`) as verbatim source text. tsz's own-member TS2411 path already
+// did this (`diag_prop_name`), but the INHERITED-member path
+// (`check_inherited_properties_against_index_signatures`) used the bare
+// resolved property name instead, dropping the brackets for a member
+// inherited from a base class/interface.
+// =========================================================================
+
+#[test]
+fn test_ts2411_inherited_computed_name_class_keeps_brackets() {
+    let source = r#"
+class Foo { x: number = 0; }
+class Foo2 { x: number = 0; y: number = 0; }
+class C {
+    get ["get1"]() { return new Foo(); }
+}
+class D extends C {
+    [s: string]: Foo2;
+}
+"#;
+    let diags = get_diagnostics(source);
+    let ts2411 = diags
+        .iter()
+        .find(|d| d.0 == 2411)
+        .expect("expected TS2411 for inherited computed-name getter vs string index");
+    assert!(
+        ts2411.1.contains("[\"get1\"]"),
+        "TS2411 must render the inherited computed name as `[\"get1\"]` (tsc's \
+         declarationNameToString), got: {}",
+        ts2411.1
+    );
+}
+
+#[test]
+fn test_ts2411_inherited_plain_identifier_has_no_brackets() {
+    // Adjacent case: a plain (non-computed) inherited member name must NOT
+    // gain brackets -- only computed names get the verbatim-source treatment.
+    let source = r#"
+class Foo { x: number = 0; }
+class Foo2 { x: number = 0; y: number = 0; }
+class C {
+    get plainGetter() { return new Foo(); }
+}
+class D extends C {
+    [s: string]: Foo2;
+}
+"#;
+    let diags = get_diagnostics(source);
+    let ts2411 = diags
+        .iter()
+        .find(|d| d.0 == 2411)
+        .expect("expected TS2411 for inherited plain getter vs string index");
+    assert!(
+        ts2411.1.contains("Property 'plainGetter'"),
+        "TS2411 for a plain inherited identifier must not gain brackets, got: {}",
+        ts2411.1
+    );
+}
+
+#[test]
+fn test_ts2411_inherited_computed_name_interface_keeps_brackets() {
+    // Adjacent case: the same fix applies to `interface extends`, not just
+    // `class extends` (the shared function handles both declaration kinds).
+    let source = r#"
+class Foo { x: number = 0; }
+class Foo2 { x: number = 0; y: number = 0; }
+interface IBase {
+    ["ifaceGet"]: Foo;
+}
+interface IDerived extends IBase {
+    [s: string]: Foo2;
+}
+"#;
+    let diags = get_diagnostics(source);
+    let ts2411 = diags
+        .iter()
+        .find(|d| d.0 == 2411)
+        .expect("expected TS2411 for inherited interface computed name vs string index");
+    assert!(
+        ts2411.1.contains("[\"ifaceGet\"]"),
+        "TS2411 must render the inherited interface computed name as \
+         `[\"ifaceGet\"]`, got: {}",
+        ts2411.1
+    );
+}
+
+#[test]
+fn test_ts2411_inherited_computed_name_multi_level_class_chain() {
+    // Adjacent case: the computed name lives two `extends` hops up
+    // (D -> C -> B), exercising the heritage-walk recursion.
+    let source = r#"
+class Foo { x: number = 0; }
+class Foo2 { x: number = 0; y: number = 0; }
+class B {
+    get ["deep"]() { return new Foo(); }
+}
+class C extends B {}
+class D extends C {
+    [s: string]: Foo2;
+}
+"#;
+    let diags = get_diagnostics(source);
+    let ts2411 = diags
+        .iter()
+        .find(|d| d.0 == 2411)
+        .expect("expected TS2411 for a two-level-inherited computed name vs string index");
+    assert!(
+        ts2411.1.contains("[\"deep\"]"),
+        "TS2411 must render the two-level-inherited computed name as \
+         `[\"deep\"]`, got: {}",
+        ts2411.1
+    );
+}
 
 #[test]
 fn test_ts2411_method_overload_displays_merged_signatures() {


### PR DESCRIPTION
Structural rule: when a property is checked against an index signature it *inherits* from a base class/interface, tsc's `declarationNameToString` renders the property's original declaration name verbatim (`["get1"]` for a computed name) in the TS2411 message; tsz does the same for **own** members already (`diag_prop_name` in `check_own_properties_against_index_signatures`), but the **inherited**-property path (`check_inherited_properties_against_index_signatures`) fell back to the bare resolved atom (`get1`, no brackets) because `shape.properties` only carries the resolved name, not the declaring node.

## Witness (oracle-verified, `typescript@7.0.2`)

```ts
class Foo { x: number = 0; }
class Foo2 { x: number = 0; y: number = 0; }
class C {
    get ["get1"]() { return new Foo(); }
}
class D extends C {
    [s: string]: Foo2;
}
```

| | tsc | tsz (before) | tsz (after) |
|---|---|---|---|
| message | `Property '["get1"]' of type 'Foo' is not assignable to 'string' index type 'Foo2'.` | `Property 'get1' of type 'Foo' is not assignable to 'string' index type 'Foo2'.` | byte-identical to tsc |

This is exactly why `computedPropertyNames45_ES5.ts`/`_ES6.ts` showed up in #16866 as "1 diagnostic away from passing" despite the TS2411 *code* set already matching tsc — the artifact only records codes, not message text, so the bracket-dropping bug was invisible to it.

## Fix

Walk the heritage chain (recursively, for multi-level `extends` chains; shared between class and interface declarations, since both use the same `members`/`heritage_clauses` shape) to find the base declaration that actually introduced the inherited property, then reuse the existing `get_member_name_text` formatter — the same one already used for own members — to render its name. New helper lives in its own module (`index_signature_inherited_display.rs`) rather than growing `index_signature_checks.rs` past the 2000-line arch-size limit.

## Adjacent-case matrix (oracle-verified against `typescript@7.0.2`, byte-for-byte)

| shape | tsc | tsz (after) |
|---|---|---|
| inherited computed name (`class C { get ["get1"]() {} } class D extends C { [s: string]: Foo2 }`) | `["get1"]` | `["get1"]` |
| inherited **plain identifier** (`get plainGetter()`) — must NOT gain brackets | `'plainGetter'` | `'plainGetter'` |
| inherited computed name via `interface extends` | `["ifaceGet"]` | `["ifaceGet"]` |
| computed name two `extends` hops up (`D extends C extends B`) | `["deep"]` | `["deep"]` |

## Scope note

#16866 grouped `unionSubtypeIfEveryConstituentTypeIsSubtype.ts` into the same "TS2411 cluster," but it's a **different** bug: a real extra-TS2411 false positive from enum-vs-`number` index-type assignability (solver relation, not display). Out of scope here — left for a separate PR/claim.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts2411_tests`: 51/51 passed (4 new: inherited computed-name class/interface, plain-identifier no-brackets control, multi-level chain).
- `cargo test -p tsz-checker --lib -- index_signature`: 266/266 passed.
- `cargo test -p tsz-checker --lib -- computed_property`: 83/83 passed. `-- inherit`: 137/137 passed.
- `cargo clippy -p tsz-checker --lib --tests -- -D warnings`: clean. `cargo fmt -p tsz-checker -- --check`: clean. `python3 scripts/arch/arch_guard.py`: passed.
- Manually verified against a rebuilt `dist-fast` `tsz` binary on the two real conformance fixtures (`computedPropertyNames45_ES5.ts`, `computedPropertyNames45_ES6.ts`) plus the 4-row adjacent-case matrix above, diffed against the pinned `typescript@7.0.2` oracle (`--singleThreaded --stableTypeOrdering true`, matching `scripts/conformance/oracle.sh`): byte-for-byte identical in every case.
- Anti-hardcoding: tests vary the binder name (`get1`/`plainGetter`/`ifaceGet`/`deep`) and declaration kind (class/interface); the fix keys on AST structure (computed vs. non-computed name node, heritage-clause shape), never on rendered text or a specific identifier.
- `scripts/conformance/compare-to-parent.sh` not run this session (time budget) — change is message-text-only within an existing TS2411 emission (no diagnostic code or count change elsewhere), and the two target fixtures are directly verified byte-for-byte against the oracle above. Full two-sided count is owed; will post on a later run if not drained sooner.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_01D7g6FvbPUKn5Q4wSE9HEZr)_