### PR TITLE
fix(checker): TS2411 renders inherited computed/string-literal property names as written

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
@@ -850,26 +850,9 @@ impl<'a> CheckerState<'a> {
 
             // TSC preserves the original text for computed names and the original
             // quote style for string-literal property names in TS2411 diagnostics.
-            let diag_prop_name = if let Some(name_node) = self.ctx.arena.get(name_idx) {
-                if name_node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME {
-                    // The node range runs one token past the `]` (a trailing
-                    // `(`, `:`, `=` leaks in); truncate at the closing bracket
-                    // so the printed name is exactly the bracketed text.
-                    self.node_text(name_idx)
-                        .map(|text| match text.rfind(']') {
-                            Some(end) => text[..=end].to_string(),
-                            None => text.trim_end_matches(':').to_string(),
-                        })
-                        .unwrap_or_else(|| prop_name.clone())
-                } else if name_node.kind == tsz_scanner::SyntaxKind::StringLiteral as u16 {
-                    self.node_text(name_idx)
-                        .unwrap_or_else(|| prop_name.clone())
-                } else {
-                    prop_name.clone()
-                }
-            } else {
-                prop_name.clone()
-            };
+            let diag_prop_name = self
+                .ts2411_written_member_name(name_idx)
+                .unwrap_or_else(|| prop_name.clone());
 
             // Select the applicable index signatures: static members check
             // against static index signatures, instance members check against
@@ -1290,11 +1273,13 @@ impl<'a> CheckerState<'a> {
                     let prop_type_str = self.format_ts2411_type(prop_type);
                     let index_type_str = self.format_ts2411_type(sym_value_type);
                     let error_node = symbol_index_sig_node.unwrap_or(name_fallback_node);
+                    let diag_prop_name =
+                        self.ts2411_inherited_prop_name(prop.parent_id, &prop_name);
 
                     self.error_at_node_msg(
                         error_node,
                         diagnostic_codes::PROPERTY_OF_TYPE_IS_NOT_ASSIGNABLE_TO_INDEX_TYPE,
-                        &[&prop_name, &prop_type_str, "symbol", &index_type_str],
+                        &[&diag_prop_name, &prop_type_str, "symbol", &index_type_str],
                     );
                 }
                 continue;
@@ -1312,11 +1297,12 @@ impl<'a> CheckerState<'a> {
                 let prop_type_str = self.format_ts2411_type(prop_type);
                 let index_type_str = self.format_ts2411_type(number_idx.value_type);
                 let error_node = number_index_sig_node.unwrap_or(name_fallback_node);
+                let diag_prop_name = self.ts2411_inherited_prop_name(prop.parent_id, &prop_name);
 
                 self.error_at_node_msg(
                     error_node,
                     diagnostic_codes::PROPERTY_OF_TYPE_IS_NOT_ASSIGNABLE_TO_INDEX_TYPE,
-                    &[&prop_name, &prop_type_str, "number", &index_type_str],
+                    &[&diag_prop_name, &prop_type_str, "number", &index_type_str],
                 );
             }
 
@@ -1348,11 +1334,17 @@ impl<'a> CheckerState<'a> {
                 let index_type_str = self.format_ts2411_type(string_value_type);
                 let index_kind_str = self.index_signature_key_display(string_key_type);
                 let error_node = string_index_sig_node.unwrap_or(name_fallback_node);
+                let diag_prop_name = self.ts2411_inherited_prop_name(prop.parent_id, &prop_name);
 
                 self.error_at_node_msg(
                     error_node,
                     diagnostic_codes::PROPERTY_OF_TYPE_IS_NOT_ASSIGNABLE_TO_INDEX_TYPE,
-                    &[&prop_name, &prop_type_str, &index_kind_str, &index_type_str],
+                    &[
+                        &diag_prop_name,
+                        &prop_type_str,
+                        &index_kind_str,
+                        &index_type_str,
+                    ],
                 );
             }
         }

--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_property_names.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_property_names.rs
@@ -1,0 +1,112 @@
+//! TS2411 property-name rendering.
+//!
+//! `tsc` names the offending property in a TS2411
+//! ("Property '{0}' ... is not assignable to '{1}' index type ...") from the
+//! property's *declaration* name node (`getNameOfSymbolAsWritten` ->
+//! `declarationNameToString`), not from its resolved symbol name: a computed
+//! key keeps its brackets (`["get1"]`, `[42]`) and a string-literal key keeps
+//! its quotes. This holds even when the diagnostic anchors at a *derived*
+//! type's index signature and the offending property is inherited from a base.
+//!
+//! The own-member index-constraint path renders directly from the member's own
+//! name node; the inherited path only has the resolved atom on the derived-side
+//! object shape, so it recovers the base declaration's name node through the
+//! property's declaring class/interface symbol. Both share
+//! [`CheckerState::ts2411_written_member_name`].
+
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+
+impl CheckerState<'_> {
+    /// The property name as `tsc` writes it in a TS2411 diagnostic.
+    ///
+    /// A computed property name keeps its bracketed source text (`["get1"]`,
+    /// `[42]`) and a string-literal name keeps its original quotes. Returns
+    /// `None` for a plain identifier name, so callers fall back to the resolved
+    /// property name — which for an identifier is the identical text.
+    pub(crate) fn ts2411_written_member_name(&self, name_idx: NodeIndex) -> Option<String> {
+        let name_node = self.ctx.arena.get(name_idx)?;
+        if name_node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME {
+            // The node range runs one token past the `]` (a trailing `(`, `:`,
+            // `=` leaks in); truncate at the closing bracket so the printed
+            // name is exactly the bracketed text.
+            let text = self.node_text(name_idx)?;
+            Some(match text.rfind(']') {
+                Some(end) => text[..=end].to_string(),
+                None => text.trim_end_matches(':').to_string(),
+            })
+        } else if name_node.kind == tsz_scanner::SyntaxKind::StringLiteral as u16 {
+            self.node_text(name_idx)
+        } else {
+            None
+        }
+    }
+
+    /// The declaration name node of an inherited property `prop_name`, found on
+    /// its declaring class/interface (`parent_id`).
+    ///
+    /// A TS2411 reported against a *derived* index signature names an inherited
+    /// property, and `tsc` renders that name from the property symbol's own
+    /// declaration — so a computed name written on the base
+    /// (`get ["get1"]() {}`) must still print as `["get1"]`, not the resolved
+    /// `get1`. The derived-side shape only carries the resolved atom, so recover
+    /// the base declaration's name node here. Returns `None` when no declaration
+    /// carries a member with a matching resolved name (e.g. a plain identifier
+    /// key, for which the resolved name is already the written form).
+    fn inherited_member_name_node(
+        &self,
+        parent_id: tsz_binder::SymbolId,
+        prop_name: &str,
+    ) -> Option<NodeIndex> {
+        let decls = self.ctx.binder.symbols.get(parent_id)?.declarations.clone();
+        for decl_idx in decls {
+            let Some(decl_node) = self.ctx.arena.get(decl_idx) else {
+                continue;
+            };
+            let members = if decl_node.kind == syntax_kind_ext::CLASS_DECLARATION {
+                self.ctx
+                    .arena
+                    .get_class(decl_node)
+                    .map(|c| c.members.nodes.clone())
+            } else if decl_node.kind == syntax_kind_ext::INTERFACE_DECLARATION {
+                self.ctx
+                    .arena
+                    .get_interface(decl_node)
+                    .map(|i| i.members.nodes.clone())
+            } else {
+                None
+            };
+            let Some(members) = members else {
+                continue;
+            };
+            for member_idx in members {
+                let Some(member_node) = self.ctx.arena.get(member_idx) else {
+                    continue;
+                };
+                let Some(name_node_idx) = self.get_member_name_node(member_node) else {
+                    continue;
+                };
+                if self.get_member_name(member_idx).as_deref() == Some(prop_name) {
+                    return Some(name_node_idx);
+                }
+            }
+        }
+        None
+    }
+
+    /// The TS2411 written name for an inherited property: the base declaration's
+    /// computed/string-literal name text when there is one, else the resolved
+    /// `prop_name`. Mirrors the own-member path so both report an inherited and
+    /// an own computed key identically.
+    pub(crate) fn ts2411_inherited_prop_name(
+        &self,
+        parent_id: Option<tsz_binder::SymbolId>,
+        prop_name: &str,
+    ) -> String {
+        parent_id
+            .and_then(|pid| self.inherited_member_name_node(pid, prop_name))
+            .and_then(|name_idx| self.ts2411_written_member_name(name_idx))
+            .unwrap_or_else(|| prop_name.to_string())
+    }
+}

--- a/crates/tsz-checker/src/state/state_checking_members/mod.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/mod.rs
@@ -17,6 +17,7 @@ mod index_signature_checks;
 #[cfg(test)]
 mod index_signature_checks_tests;
 mod index_signature_key_helpers;
+mod index_signature_property_names;
 mod index_signature_type_helpers;
 mod index_signature_validity;
 mod interface_checks;

--- a/crates/tsz-checker/tests/ts2411_inherited_computed_name_display_tests.rs
+++ b/crates/tsz-checker/tests/ts2411_inherited_computed_name_display_tests.rs
@@ -1,0 +1,108 @@
+//! TS2411 renders an *inherited* property's name the way `tsc` does: from the
+//! property's own declaration, not from the resolved symbol name. A computed
+//! key written on the base (`get ["get1"]() {}`) keeps its bracketed source
+//! text (`["get1"]`) even when the diagnostic is reported at a derived class's
+//! index signature, matching `tsc`'s `getNameOfSymbolAsWritten`
+//! (`declarationNameToString`).
+//!
+//! Regression for the `computedPropertyNames45_ES5/ES6` conformance cluster
+//! tracked in #16866: tsz emitted `Property 'get1' ...` where `tsc` emits
+//! `Property '["get1"]' ...` (same code TS2411, same position — message only).
+//! The own-member path already spelled computed keys correctly; only the
+//! inherited-property path in `check_inherited_properties_against_index_signatures`
+//! fell back to the bare resolved name. Oracled against pinned
+//! `typescript@7.0.2`.
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn ts2411_messages(source: &str) -> Vec<String> {
+    check_source_diagnostics(source)
+        .iter()
+        .filter(|d| d.code == 2411)
+        .map(|d| d.message_text.clone())
+        .collect()
+}
+
+#[test]
+fn inherited_computed_string_key_renders_bracketed_name() {
+    // `computedPropertyNames45_ES6`: the getter `["get1"]` is declared on the
+    // base class `C`; the index signature that rejects it lives on the derived
+    // class `D`, so this exercises the inherited-property path.
+    let messages = ts2411_messages(
+        r#"
+class Foo { x }
+class Foo2 { x; y }
+
+class C {
+    get ["get1"]() { return new Foo }
+}
+
+class D extends C {
+    [s: string]: Foo2;
+    set ["set1"](p: Foo) { }
+}
+"#,
+    );
+    assert!(
+        messages.contains(
+            &"Property '[\"get1\"]' of type 'Foo' is not assignable to 'string' index type 'Foo2'."
+                .to_string()
+        ),
+        "inherited computed key must keep its bracketed source text; got: {messages:?}"
+    );
+    assert!(
+        !messages
+            .iter()
+            .any(|m| m.contains("Property 'get1'") && !m.contains("[\"get1\"]")),
+        "must not spell the inherited computed key as the bare resolved name; got: {messages:?}"
+    );
+}
+
+#[test]
+fn inherited_computed_key_display_is_independent_of_binder_names() {
+    // The rule is structural: renaming the classes and the key must not change
+    // that the bracketed source text is preserved.
+    let messages = ts2411_messages(
+        r#"
+class Alpha { a }
+class Beta { a; b }
+
+class Base {
+    get ["wibble"]() { return new Alpha }
+}
+
+class Derived extends Base {
+    [s: string]: Beta;
+}
+"#,
+    );
+    assert!(
+        messages.iter().any(|m| m.contains("Property '[\"wibble\"]'")),
+        "renamed binders must still preserve the bracketed computed key; got: {messages:?}"
+    );
+}
+
+#[test]
+fn inherited_plain_identifier_key_is_unchanged() {
+    // Negative control: a plain identifier property inherited from the base
+    // still renders as the bare name — the fix must not add brackets where the
+    // source had none.
+    let messages = ts2411_messages(
+        r#"
+class Foo { x }
+class Foo2 { x; y }
+
+class C {
+    get get1() { return new Foo }
+}
+
+class D extends C {
+    [s: string]: Foo2;
+}
+"#,
+    );
+    assert!(
+        messages.iter().any(|m| m
+            == "Property 'get1' of type 'Foo' is not assignable to 'string' index type 'Foo2'."),
+        "a plain identifier key must render bare, without brackets; got: {messages:?}"
+    );
+}


### PR DESCRIPTION
TS2411 ("Property '{0}' of type ... is not assignable to '{1}' index type ...")
named an **inherited** offending property by its *resolved* symbol name instead
of the name as written on its declaration.

When a property that violates an index signature is reported, `tsc` renders its
name from the property symbol's own declaration name node
(`getNameOfSymbolAsWritten` → `declarationNameToString`): a computed key keeps
its brackets (`["get1"]`, `[42]`) and a string-literal key keeps its quotes.
This holds even when the diagnostic anchors at a *derived* type's index
signature and the property is inherited from a base — e.g. a base-class
`get ["get1"]() {}` must still print as `["get1"]`, not `get1`.

tsz's own-member index-constraint path already did this; only the
inherited-property path (`check_inherited_properties_against_index_signatures`)
fell back to the bare resolved atom, because the derived-side object shape only
carries the resolved name. The fix extracts the shared rendering into a new
`index_signature_property_names` module (`ts2411_written_member_name`) and
recovers the inherited property's declaration name node through its declaring
class/interface symbol (`PropertyInfo::parent_id`), so both paths render
identically. Plain identifier keys are unchanged (the helper returns `None` and
callers fall back to the resolved name). No user-name/file-name literal drives
the decision — only the declaration name node's kind.

Failure family: `computedPropertyNames45_ES5/ES6` (message-only over-report:
same TS2411 code, same position, name spelling differed), tracked in #16866.

## Goal
Goal: hold

## Verification
- Oracle: pinned `typescript@7.0.2` cache via `tsz-conformance` against the
  release binary.
  - `computedPropertyNames45_ES5.ts` → PASS (was FAIL: `get1` vs `["get1"]`)
  - `computedPropertyNames45_ES6.ts` → PASS (was FAIL: `get1` vs `["get1"]`)
  - `--error-code 2411` conformance sweep: 4859 PASS / 0 FAIL (no regressions).
- New unit tests: `crates/tsz-checker/tests/ts2411_inherited_computed_name_display_tests.rs`
  (inherited computed key bracketed; renamed-binder invariance; plain-identifier
  negative control).
- `arch-size` guard held by splitting the helpers into a sibling module
  (`index_signature_checks.rs` back under 2000 lines); pre-commit `clippy -D warnings`
  on `tsz-checker` clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqcCVeuF9axbWTFM7gm1bA)_