### PR TITLE
fix(checker): widen a union constituent absorbed into a sibling before TS2411's per-member check

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_key_helpers.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_key_helpers.rs
@@ -11,6 +11,16 @@ impl<'a> CheckerState<'a> {
         prop_type: TypeId,
         index_value_type: TypeId,
     ) -> bool {
+        // A union constituent that is itself a subtype of a sibling constituent
+        // (a numeric enum member type alongside a plain `number`, for example)
+        // is absorbed into that sibling when tsc constructs the union -- `e |
+        // number` is the type `number`, not a two-member union, so per-member
+        // decomposition below must see it that way too. `evaluate_type_with_env`
+        // is the same widen/reduce step `format_ts2411_type` already applies
+        // before formatting this property's type for the diagnostic message;
+        // reusing it here keeps the checked type and the displayed type in
+        // agreement instead of the message alone looking reduced.
+        let prop_type = self.evaluate_type_with_env(prop_type);
         if let Some(list_id) = crate::query_boundaries::common::union_list_id(
             self.ctx.types,
             self.resolve_lazy_type(prop_type),

--- a/crates/tsz-checker/tests/ts2411_tests.rs
+++ b/crates/tsz-checker/tests/ts2411_tests.rs
@@ -897,3 +897,91 @@ declare const m: M;
         get_diagnostics(source)
     );
 }
+
+// =========================================================================
+// Union widening: a constituent absorbed into a sibling constituent
+// =========================================================================
+
+#[test]
+fn enum_member_absorbed_into_number_in_union_matches_numeric_enum_index() {
+    // A union constituent that is a subtype of a sibling constituent is
+    // absorbed into it when tsc constructs the union type -- `Suit | number`
+    // is the type `number`, not a two-member union (confirmed against tsc
+    // 7.0.2: `let s: string = suitOrNumber` reports "Type 'number' is not
+    // assignable to type 'string'", not "Type 'Suit | number'"). A property
+    // of that union is therefore checked against a numeric-enum index the
+    // same way a bare `number` property is -- no TS2411.
+    let source = r#"
+enum Suit { Hearts, Spades }
+enum Rank { Ace }
+interface Hand {
+    [x: string]: Rank;
+    card: Suit | number;
+}
+"#;
+    assert!(
+        !has_error_with_code(source, 2411),
+        "`Suit | number` collapses to `number`, which a numeric enum index accepts: {:?}",
+        get_diagnostics(source)
+    );
+}
+
+#[test]
+fn distinct_enum_union_without_number_sibling_still_reports_ts2411() {
+    // Negative control: without a `number` (or matching-enum) sibling to
+    // absorb into, a different enum's member type is still not assignable to
+    // this index's enum -- the widen step must not silently accept every
+    // enum union.
+    let source = r#"
+enum Suit { Hearts, Spades }
+enum Rank { Ace }
+enum Season { Summer }
+interface Hand {
+    [x: string]: Rank;
+    card: Suit | Season;
+}
+"#;
+    assert!(
+        has_error_with_code(source, 2411),
+        "`Suit | Season` has no `number` sibling to collapse into, and neither is `Rank`: {:?}",
+        get_diagnostics(source)
+    );
+}
+
+#[test]
+fn numeric_literal_absorbed_into_number_in_union_matches_numeric_enum_index_renamed() {
+    // Same shape as the enum case above but with a numeric literal type and
+    // renamed binders, confirming the widen step is not keyed to a specific
+    // enum/interface/property name.
+    let source = r#"
+enum Level { Low, Mid, High }
+interface Config {
+    [k: string]: Level;
+    threshold: 1 | number;
+}
+"#;
+    assert!(
+        !has_error_with_code(source, 2411),
+        "`1 | number` collapses to `number`, matching the numeric enum index: {:?}",
+        get_diagnostics(source)
+    );
+}
+
+#[test]
+fn union_still_reports_ts2411_when_a_constituent_genuinely_mismatches() {
+    // Positive control: the widen step must not blanket-suppress TS2411 -- a
+    // union that still contains a genuinely incompatible constituent after
+    // widening (`string`, which has no relation to a `number` index) keeps
+    // reporting.
+    let source = r#"
+interface Bag {
+    [k: string]: number;
+    label: string | number;
+}
+"#;
+    assert!(
+        has_error_with_code(source, 2411),
+        "`string | number` still has `string`, incompatible with the `number` index: {:?}",
+        get_diagnostics(source)
+    );
+}


### PR DESCRIPTION
When tsc constructs a union type, a constituent that is itself a subtype of a sibling constituent is absorbed into it — `Suit | number` (a numeric enum alongside `number`) is the type `number`, not a two-member union. Confirmed against `typescript@7.0.2`: `let s: string = suitOrNumber` reports `Type 'number' is not assignable to type 'string'`, never `Type 'Suit | number'`.

`property_type_assignable_to_index_type` (TS2411, property vs. index signature; `crates/tsz-checker/src/state/state_checking_members/index_signature_key_helpers.rs`) decomposed the property's *raw*, unreduced union list and checked each member independently against the index's value type. For `card: Suit | number` against a `[x: string]: Rank` index, that meant checking `Suit -> Rank` on its own — which fails, since two unrelated enums are never mutually assignable — even though the widened, real type of `card` is plain `number`, and `number` IS assignable to any numeric enum's index (tsc's long-standing weak-enum rule). tsz reported a false-positive TS2411 that only the union form triggered.

**Structural rule:** when a union type annotation has a constituent that is a subtype of a sibling constituent, tsc absorbs it into that sibling at type-construction time; tsz's TS2411 property/index check must see the same widened type, through the solver-backed `evaluate_type_with_env` query it already uses to *format* the same property's type for the diagnostic message.

Fixed by widening `prop_type` through `evaluate_type_with_env` before the union decomposition, so the type that is checked matches the type that is already displayed.

Found while investigating #16866's TS2411 cluster: the conformance fixture `unionSubtypeIfEveryConstituentTypeIsSubtype.ts` now matches tsc byte-for-byte (30/30 diagnostics, verified position-by-position against the pinned `typescript@7.0.2` baseline) instead of one spurious extra TS2411 at the `foo2: e | number` vs. `E2` case.

### Adjacent-case matrix (all oracle-verified against `typescript@7.0.2`)

- enum absorbed into `number` in a union matches a numeric-enum index (the fix)
- two *unrelated* enums in a union, no `number`/matching-enum sibling to absorb into, still reports TS2411 (negative control — the widen step must not blanket-suppress)
- numeric literal (`1 | number`) absorbed the same way, renamed binders (anti-hardcoding)
- `string | number` against a `number` index still reports (positive control — a genuinely incompatible constituent still fires)

## Goal
Goal: hold

## Verification
- Fixture `unionSubtypeIfEveryConstituentTypeIsSubtype.ts` (fetched at the pinned TypeScript corpus SHA): before, 1 spurious extra `TS2411`; after, 30/30 diagnostics byte-for-byte identical to the `typescript@7.0.2` oracle baseline, position-by-position.
- `cargo test -p tsz-checker --test ts2411_tests`: 51/51 (4 new adjacent cases).
- `cargo test -p tsz-checker --test ts2411_pattern_index_signature_tests`: 10/10.
- `cargo test -p tsz-checker --lib -- index_signature`: 266/266.
- `cargo test -p tsz-checker --lib -- ts2411 ts2413 enum`: 386/386.
- `cargo test -p tsz-checker --lib -- routing_arch`: 178/178 (confirms the fix keeps routing through the shared `index_signature_relation_outcome` boundary, not a generic/raw guard).
- `cargo clippy -p tsz-checker --lib --tests -- -D warnings`: clean.
- `cargo fmt --check -p tsz-checker`: clean.
- `scripts/arch/arch_guard_file_limits.py`: passed.
- `cargo test -p tsz-checker --lib` (full ~10,800-test suite): ran clean through the entire suite except the single known-slow long-tail case (`ts2589_tests::recursive_conditional_alias_omitted_default_transform_emits_definition_ts2589`, a conditional-type/`infer` test unrelated to index signatures — this is the same 5-test long tail flagged repeatedly on the coordination board), which was still finishing at push time; no failures observed anywhere else in the run.
- `compare-to-parent.sh` / full `conformance.sh snapshot` not run this session (time budget) — the change is scoped to one function's union-widening step, is a net-positive fix (removes a false positive), and is covered by the oracle-verified fixture diff above plus the full targeted matrix. Owed as a follow-up if anyone wants the corpus-wide delta.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude


---
_Generated by [Claude Code](https://claude.ai/code/session_01C5KWbG4CCBsaEmdj4Z6vTN)_