### PR TITLE
fix(solver): numeric/string enum member absorbs into a co-present number/string in a union

### DIFF
--- a/crates/tsz-checker/tests/ts2411_tests.rs
+++ b/crates/tsz-checker/tests/ts2411_tests.rs
@@ -897,3 +897,153 @@ declare const m: M;
         get_diagnostics(source)
     );
 }
+
+// =========================================================================
+// Regression: a numeric/string enum unioned with its own primitive absorbs
+// into that primitive before the index-signature check runs, matching tsc's
+// `removeRedundantLiteralTypes` (which sweeps an enum member's LiteralType
+// the same as any other literal). #16866 / unionSubtypeIfEveryConstituentTypeIsSubtype.ts.
+// =========================================================================
+
+#[test]
+fn ts2411_numeric_enum_unioned_with_number_absorbs_against_unrelated_enum_index() {
+    // `e | number` collapses to `number` before this check runs, so it is
+    // never compared against `E2` as a nominal enum member — matches tsc
+    // 7.0.2 exactly (byte-for-byte on the real conformance fixture).
+    let source = r#"
+enum e { e1, e2 }
+enum E2 { A }
+interface I14 {
+    [x: string]: E2;
+    foo2: e | number;
+}
+"#;
+    assert!(
+        !has_error_with_code(source, 2411),
+        "e | number must absorb into number and not be checked against the unrelated enum E2: {:?}",
+        get_diagnostics(source)
+    );
+}
+
+#[test]
+fn ts2411_string_enum_unioned_with_string_still_errors_against_unrelated_enum_index() {
+    // Negative control, oracle-verified against tsc 7.0.2: `s | string` DOES
+    // absorb into plain `string` (same union-construction rule as the
+    // numeric case), but unlike numeric enums, tsc has no "open string enum"
+    // exception — a bare `string` is never assignable to ANY string enum, so
+    // the diagnostic still fires. The message text itself proves absorption
+    // happened: it names the collapsed type `'string'`, not the enum `'s'`.
+    let source = r#"
+enum s { a = "a", b = "b" }
+enum S2 { X = "x" }
+interface I {
+    [x: string]: S2;
+    foo2: s | string;
+}
+"#;
+    let diagnostics = get_diagnostics(source);
+    assert!(
+        diagnostics.iter().any(|(code, message)| {
+            *code == 2411 && message.contains("type 'string'") && message.contains("'S2'")
+        }),
+        "s | string must absorb into string (proven by the message naming 'string', not 's') \
+         and still fail against the unrelated string enum S2: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn ts2411_specific_numeric_enum_member_unioned_with_number_absorbs() {
+    // Adjacent case: a specific member (`e.e1`), not the whole enum type,
+    // must absorb the same way.
+    let source = r#"
+enum e { e1, e2 }
+enum E2 { A }
+interface I {
+    [x: string]: E2;
+    foo2: e.e1 | number;
+}
+"#;
+    assert!(
+        !has_error_with_code(source, 2411),
+        "e.e1 | number must absorb into number: {:?}",
+        get_diagnostics(source)
+    );
+}
+
+#[test]
+fn ts2411_renamed_numeric_enum_unioned_with_number_absorbs() {
+    // Adjacent case: renamed binders prove the rule is structural, not tied
+    // to a specific identifier.
+    let source = r#"
+enum Direction { Up, Down }
+enum Suit { Clubs }
+interface Board {
+    [x: string]: Suit;
+    cell: Direction | number;
+}
+"#;
+    assert!(
+        !has_error_with_code(source, 2411),
+        "Direction | number must absorb into number regardless of binder names: {:?}",
+        get_diagnostics(source)
+    );
+}
+
+#[test]
+fn ts2411_numeric_enum_alias_wrapper_unioned_with_number_absorbs() {
+    // Adjacent case: alias/wrapper — the union is written through a type
+    // alias rather than inline in the property; the alias resolves to the
+    // same underlying union before this check runs.
+    let source = r#"
+enum e { e1, e2 }
+enum E2 { A }
+type EOrNumber = e | number;
+interface I {
+    [x: string]: E2;
+    foo2: EOrNumber;
+}
+"#;
+    assert!(
+        !has_error_with_code(source, 2411),
+        "an aliased e | number must still absorb into number: {:?}",
+        get_diagnostics(source)
+    );
+}
+
+#[test]
+fn ts2411_string_literal_still_errors_against_unrelated_numeric_enum_index() {
+    // Negative control: `foo: string | number` in the same interface must
+    // still error — `string` is not absorbed, and `number` alone is not
+    // structurally assignable to the unrelated enum `E2` (matches tsc).
+    let source = r#"
+enum E2 { A }
+interface I14 {
+    [x: string]: E2;
+    foo: string | number;
+}
+"#;
+    assert!(
+        has_error_with_code(source, 2411),
+        "string | number must still be rejected against the unrelated enum E2: {:?}",
+        get_diagnostics(source)
+    );
+}
+
+#[test]
+fn ts2411_distinct_numeric_enums_without_a_bare_number_stay_nominal() {
+    // Negative control: without a co-present bare `number`, two distinct
+    // numeric enums do NOT absorb into each other — nominal typing holds.
+    let source = r#"
+enum e { e1, e2 }
+enum E2 { A }
+interface I {
+    [x: string]: E2;
+    foo2: e;
+}
+"#;
+    assert!(
+        has_error_with_code(source, 2411),
+        "e alone (no bare number present) must stay nominal and fail against E2: {:?}",
+        get_diagnostics(source)
+    );
+}

--- a/crates/tsz-solver/src/intern/normalize.rs
+++ b/crates/tsz-solver/src/intern/normalize.rs
@@ -1140,19 +1140,64 @@ impl TypeInterner {
                 return !has_boolean;
             }
 
-            // Keep if it's not a literal type
-            let Some(TypeData::Literal(literal)) = self.lookup(*type_id) else {
-                return true;
-            };
-
-            // Remove literal if the corresponding primitive is present
-            match literal {
-                LiteralValue::String(_) => !has_string,
-                LiteralValue::Number(_) => !has_number,
-                LiteralValue::Boolean(_) => !has_boolean,
-                LiteralValue::BigInt(_) => !has_bigint,
+            match self.lookup(*type_id) {
+                // Remove literal if the corresponding primitive is present
+                Some(TypeData::Literal(literal)) => match literal {
+                    LiteralValue::String(_) => !has_string,
+                    LiteralValue::Number(_) => !has_number,
+                    LiteralValue::Boolean(_) => !has_boolean,
+                    LiteralValue::BigInt(_) => !has_bigint,
+                },
+                // tsc represents an enum member's type as a LiteralType
+                // carrying an extra `Enum` flag, not a distinct type kind, so
+                // `removeRedundantLiteralTypes` sweeps a numeric/string enum
+                // member into a co-present `number`/`string` the same way it
+                // sweeps a plain literal (`e | number` => `number`). tsz keeps
+                // enums as a nominal `Enum(DefId, member_type)` wrapper, so
+                // mirror that absorption here based on the wrapped member
+                // type's primitive domain instead.
+                Some(TypeData::Enum(_, member_type)) => {
+                    match self.enum_underlying_primitive_class(member_type) {
+                        Some(PrimitiveClass::String) => !has_string,
+                        Some(PrimitiveClass::Number) => !has_number,
+                        _ => true,
+                    }
+                }
+                // Keep if it's not a literal or enum type
+                _ => true,
             }
         });
+    }
+
+    /// Classifies an enum's structural member type (the second field of
+    /// `TypeData::Enum(DefId, member_type)`) as `String`/`Number` when every
+    /// member is drawn from that single primitive domain — the wrapped type
+    /// is either the primitive itself (`e.g. TypeId::NUMBER`, used for the
+    /// whole-enum reference), a single literal (a specific member), or a
+    /// union of literals (the whole enum's member set). A mixed or non-
+    /// literal member type returns `None` so absorption is skipped.
+    fn enum_underlying_primitive_class(&self, member_type: TypeId) -> Option<PrimitiveClass> {
+        if let Some(class) = self.primitive_class_for(member_type) {
+            return matches!(class, PrimitiveClass::String | PrimitiveClass::Number)
+                .then_some(class);
+        }
+        let TypeData::Union(list_id) = self.lookup(member_type)? else {
+            return None;
+        };
+        let members = self.type_list(list_id);
+        let mut result = None;
+        for &member in members.iter() {
+            let class = self.primitive_class_for(member)?;
+            if !matches!(class, PrimitiveClass::String | PrimitiveClass::Number) {
+                return None;
+            }
+            match result {
+                None => result = Some(class),
+                Some(existing) if existing == class => {}
+                Some(_) => return None,
+            }
+        }
+        result
     }
 
     /// TS2590 pairwise-iteration budget matching tsc `removeSubtypes`.

--- a/crates/tsz-solver/src/intern/normalize_tests.rs
+++ b/crates/tsz-solver/src/intern/normalize_tests.rs
@@ -311,6 +311,83 @@ fn enum_absorbed_into_base_primitive_in_union_reduction() {
     );
 }
 
+#[test]
+fn enum_absorbed_into_base_primitive_via_literal_only_union() {
+    // Regression for #16866's TS2411 false positive on
+    // `unionSubtypeIfEveryConstituentTypeIsSubtype.ts`: an interface property
+    // annotation like `foo2: e | number` is constructed through
+    // `normalize_union_literal_only` (the type-annotation path,
+    // `get_type_from_union_type` -> `union_or_single_literal_reduce`), which
+    // — unlike the general `union()` path already covered by
+    // `enum_absorbed_into_base_primitive_in_union_reduction` above — skips
+    // subtype-based reduction entirely and relies solely on the literal
+    // ladder's `absorb_literals_into_primitives` step. tsc's own
+    // `removeRedundantLiteralTypes` sweeps enum member literals the same way
+    // it sweeps plain literals, so this path must absorb too.
+    use crate::def::DefId;
+    let interner = TypeInterner::new();
+    let mk_enum =
+        |def: u32, members: Vec<TypeId>| interner.enum_type(DefId(def), interner.union(members));
+
+    // Renamed binder (different DefId/name than the union() test above) to
+    // prove the rule is structural, not tied to a specific def or literal set.
+    let num_enum = mk_enum(
+        8101,
+        vec![interner.literal_number(0.0), interner.literal_number(1.0)],
+    );
+    let str_enum = mk_enum(
+        8102,
+        vec![interner.literal_string("p"), interner.literal_string("q")],
+    );
+    // A specific enum member (not the whole-enum union) — the checker
+    // represents `E.a` as `Enum(member_def_id, <that member's own literal>)`.
+    let num_member = interner.enum_type(DefId(8103), interner.literal_number(5.0));
+
+    for enriched in [false, true] {
+        assert_eq!(
+            interner.union_literal_ladder_for_test(vec![TypeId::NUMBER, num_enum], enriched),
+            TypeId::NUMBER,
+            "number | (numeric enum) must reduce to number on the literal-only path (enriched={enriched})"
+        );
+        assert_eq!(
+            interner.union_literal_ladder_for_test(vec![TypeId::STRING, str_enum], enriched),
+            TypeId::STRING,
+            "string | (string enum) must reduce to string on the literal-only path (enriched={enriched})"
+        );
+        assert_eq!(
+            interner.union_literal_ladder_for_test(vec![TypeId::NUMBER, num_member], enriched),
+            TypeId::NUMBER,
+            "number | (specific numeric enum member) must reduce to number (enriched={enriched})"
+        );
+
+        // Negative control: a string enum is disjoint from `number` and must
+        // NOT be absorbed.
+        let mixed =
+            interner.union_literal_ladder_for_test(vec![TypeId::NUMBER, str_enum], enriched);
+        let Some(TypeData::Union(list_id)) = interner.lookup(mixed) else {
+            panic!(
+                "number | (string enum) must stay a union on the literal-only path (enriched={enriched})"
+            );
+        };
+        assert_eq!(interner.type_list(list_id).len(), 2);
+
+        // Negative control: without the co-present primitive, two distinct
+        // numeric enums stay nominal (mirrors the real I14 case: `e | E2`
+        // itself, absent any bare `number`, is not touched by this rule).
+        let other_num_enum = mk_enum(
+            8104,
+            vec![interner.literal_number(0.0), interner.literal_number(1.0)],
+        );
+        let two = interner.union_literal_ladder_for_test(vec![num_enum, other_num_enum], enriched);
+        let Some(TypeData::Union(list_id)) = interner.lookup(two) else {
+            panic!(
+                "two distinct enums without a bare primitive must stay a union (enriched={enriched})"
+            );
+        };
+        assert_eq!(interner.type_list(list_id).len(), 2);
+    }
+}
+
 fn distinct_keyof(interner: &TypeInterner, n: u32) -> TypeId {
     // `keyof <unique literal>` — a distinct, unevaluated `TypeData::KeyOf`
     // per `n`. This is the shape produced by distributing `keyof` over a


### PR DESCRIPTION
Structural rule: tsc represents an enum member's type as a `LiteralType` carrying an extra `Enum` flag, not a distinct type kind — so `removeRedundantLiteralTypes` sweeps a numeric/string enum member into a co-present `number`/`string` in a union exactly the same way it sweeps a plain literal (`1 | number => number`, `e | number => number`). tsz keeps enums as a nominal `Enum(DefId, member_type)` wrapper instead, and `absorb_literals_into_primitives` only matched `TypeData::Literal`, so an `Enum` member survived into a union tsc would already have collapsed.

Owner layer: solver, `crates/tsz-solver/src/intern/normalize.rs` (`absorb_literals_into_primitives`, called from the shared `apply_union_literal_ladder`). This ladder backs *both* the general `union()` path (which already got numeric/string-enum-into-primitive right, but only via the separate, heavier subtype-based union reduction step) and the literal-only path used for written type annotations (`get_type_from_union_type` -> `union_or_single_literal_reduce` -> `normalize_union_literal_only`), which intentionally skips subtype reduction and relies solely on the literal ladder — this is the path that actually builds an interface property's `foo2: e | number` annotation, and the one that was missing the enum case.

**Update**: while this PR was open, an independent session landed #16879, a complementary checker-side fix for the same underlying symptom — `property_type_assignable_to_index_type` (the TS2411 call site) now widens `prop_type` through `evaluate_type_with_env` before decomposing the union, so the checked type matches the displayed type at that one call site. Merged `origin/main` in; the two fixes don't conflict (different files — solver vs. checker) and are complementary in scope: #16879 patches the one diagnostic call site, this PR fixes the underlying *type construction* so every other consumer of a written `enum | primitive` union (not just TS2411) gets tsc's actual collapsed type, per CLAUDE.md's "type semantics live in solver" layering rule. Both sets of oracle-verified adjacent-case tests are kept (resolved as a textual merge conflict in `ts2411_tests.rs`, no functional overlap removed).

### Bug

`unionSubtypeIfEveryConstituentTypeIsSubtype.ts`'s `I14` interface:

```ts
enum e { e1, e2 }
enum E2 { A }
interface I14 {
    [x: string]: E2;
    foo: string | number;   // tsc: TS2411 (string not assignable to E2)
    foo2: e | number;       // tsc: no error — `e | number` collapses to `number`,
                             //      and a bare `number` is allowed against ANY
                             //      numeric enum type (tsc's "open numeric enum" rule)
}
```

tsz never collapsed `e | number` (never running the literal-only path's enum case), so the leftover nominal `e` member was checked directly against the unrelated enum `E2` and correctly-per-tsz-but-wrong-per-tsc rejected — an extra/false-positive TS2411.

### Fix

`absorb_literals_into_primitives` gains an `Enum(_, member_type)` arm alongside its existing `Literal` arm. A new `enum_underlying_primitive_class` helper classifies the wrapped `member_type` as `Number`/`String` when every member is drawn from that single primitive domain (handles all three shapes the checker constructs: the primitive itself for a whole-enum reference, a single literal for a specific member, or a union of literals for the whole enum's member set) — mixed/non-literal member types return `None` and are left untouched.

### Adjacent-case matrix (oracle-verified against pinned `typescript@7.0.2`)

| case | tsc | tsz (after) |
| --- | --- | --- |
| whole numeric enum + number, unrelated numeric enum index (`e \| number` vs `E2`) | no error | no error |
| specific numeric enum member + number (`e.e1 \| number` vs `E2`) | no error | no error |
| renamed binders (`Direction \| number` vs `Suit`) | no error | no error |
| alias/wrapper (`type EOrNumber = e \| number`) | no error | no error |
| string enum + string, unrelated string enum index (`s \| string` vs `S2`) | **still errors** — no "open string enum" rule exists for tsc, only numeric | **still errors**, message now correctly names `'string'` (proves absorption), not `'s'` |
| `string \| number` (no enum) vs unrelated numeric enum index | still errors (string not absorbed) | still errors |
| bare `e` alone (no co-present `number`) vs unrelated numeric enum index | still errors (nominal, no absorption trigger) | still errors |

The string-enum negative control matters: it proves the fix is a pure *type-construction* change (union collapses the same way tsc's type identity does) and does not smuggle in any enum-vs-primitive *assignability* leniency — that asymmetry (numeric enums accept bare `number`, string enums do not) already lives correctly in `compat_overrides.rs::enum_assignability_override` and is untouched here.

## Goal
Goal: hold

## Verification
- New unit test `crates/tsz-solver/src/intern/normalize_tests.rs::enum_absorbed_into_base_primitive_via_literal_only_union` (the literal-only path — the one the pre-existing `enum_absorbed_into_base_primitive_in_union_reduction` test does *not* cover, since that one exercises the general `union()` path where subtype-based reduction already masked the bug).
- `cargo test -p tsz-solver --lib`: 7655/7655 passed. `cargo test -p tsz-solver --test '*'`: all integration suites passed.
- `cargo test -p tsz-checker --test ts2411_tests`: 62/62 passed after merging main's #16879 (8 new from this PR + 4 new from #16879, no overlap removed).
- `cargo test -p tsz-checker --lib -- ts2411`: 57/57. `-- enum`: 321/321. `-- index_signature`: 266/266. No regressions.
- Real fixture, rebuilt `dist-fast` binary vs. the actual `unionSubtypeIfEveryConstituentTypeIsSubtype.ts` conformance file (fetched at the pinned corpus SHA `4d4f005c8541e0255a9d8791205fdce326e462bc`): 30/30 diagnostics, position-and-code-identical to the pinned tsc baseline (previously 31, with the extra false-positive TS2411 at line 102/`foo2` under `I14`).
- `cargo clippy -p tsz-solver -p tsz-checker --lib --tests -- -D warnings`: clean. Pre-commit hook (fmt + targeted clippy + arch-size) passed at commit time, including the merge commit.
- `scripts/conformance/compare-to-parent.sh origin/main` running post-merge; will post the newly-passing/newly-failing counts as a follow-up comment once it completes (this is a solver-level union-construction change, so the two-sided count matters more than usual before merge).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE