### PR TITLE
fix(checker): TS2411 materializes a property's type before the index-constraint check

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -870,6 +870,9 @@ path = "tests/cjs_direct_object_export_no_typeof_import_display_tests.rs"
 name = "ts2303_tests"
 path = "tests/ts2303_tests.rs"
 [[test]]
+name = "ts2411_union_subtype_reduction_index_tests"
+path = "tests/ts2411_union_subtype_reduction_index_tests.rs"
+[[test]]
 name = "namespace_qualified_diagnostic_tests"
 path = "tests/namespace_qualified_diagnostic_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_key_helpers.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_key_helpers.rs
@@ -11,6 +11,21 @@ impl<'a> CheckerState<'a> {
         prop_type: TypeId,
         index_value_type: TypeId,
     ) -> bool {
+        // Materialize the property type before the constraint decision. tsc
+        // checks `getTypeOfSymbol(prop)`, which is the *reduced* type, against
+        // the index type; the raw annotation union may still carry constituents
+        // that a sibling constituent subsumes. In particular a numeric enum is a
+        // subtype of `number`, so `E | number` reduces to `number` — but the
+        // union arrives here as `Lazy(E) | number`, and union subtype reduction
+        // skips lazy members at intern time, so the collapse only happens on
+        // evaluation. Judging the unmaterialized union member-by-member makes the
+        // absorbed `E` constituent spuriously fail `E → indexType` and emit a
+        // false TS2411 (the diagnostic then even renders the *reduced* type,
+        // because `format_ts2411_type` evaluates while this check did not). This
+        // is the apparent-type materialize-before-decide gateway (#15396):
+        // evaluate first so the decision and the rendered type agree, and match
+        // tsc's reduced operand.
+        let prop_type = self.evaluate_type_with_env(prop_type);
         if let Some(list_id) = crate::query_boundaries::common::union_list_id(
             self.ctx.types,
             self.resolve_lazy_type(prop_type),

--- a/crates/tsz-checker/tests/ts2411_union_subtype_reduction_index_tests.rs
+++ b/crates/tsz-checker/tests/ts2411_union_subtype_reduction_index_tests.rs
@@ -1,0 +1,89 @@
+//! TS2411 checks a property's *materialized* type against an index signature,
+//! matching tsc's `getTypeOfSymbol` (a reduced type). A union whose constituent
+//! is subsumed by a sibling — a numeric enum inside `E | number`, since every
+//! enum value is a `number` — collapses to that sibling before the constraint
+//! is judged. Judging the raw, unmaterialized union member-by-member made the
+//! absorbed enum constituent spuriously fail `E -> indexType` and emit a false
+//! TS2411 (even while the rendered type already showed the reduced form).
+//!
+//! Regression for `unionSubtypeIfEveryConstituentTypeIsSubtype.ts` (the extra
+//! `foo2` TS2411) tracked in #16866; the underlying decision-vs-display
+//! asymmetry is the apparent-type materialize-before-decide gateway (#15396).
+//! Oracled against pinned `typescript@7.0.2`.
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn ts2411_props(source: &str) -> Vec<String> {
+    check_source_diagnostics(source)
+        .iter()
+        .filter(|d| d.code == 2411)
+        // Pull the offending property name out of the message so assertions read
+        // structurally rather than pinning the whole rendered string.
+        .map(|d| d.message_text.clone())
+        .collect()
+}
+
+#[test]
+fn numeric_enum_union_with_number_is_absorbed_before_the_index_check() {
+    // `E | number` reduces to `number`, which is assignable to a numeric-enum
+    // index — so `foo2` must NOT report. `foo` (`string | number`) still reports
+    // because `string` is not assignable.
+    let props = ts2411_props(
+        r#"
+enum e { e1, e2 }
+enum E2 { A }
+interface I14 {
+    [x: string]: E2;
+    foo: string | number;
+    foo2: e | number;
+}
+"#,
+    );
+    assert!(
+        props.iter().any(|m| m.contains("'foo'")),
+        "`foo: string | number` must still report against the enum index; got: {props:?}"
+    );
+    assert!(
+        !props.iter().any(|m| m.contains("'foo2'")),
+        "`foo2: e | number` reduces to `number` and must not report; got: {props:?}"
+    );
+}
+
+#[test]
+fn numeric_enum_member_union_with_number_is_absorbed() {
+    // The enum *member* form reduces the same way a numeric literal does
+    // (`1 | number` -> `number`): a single enum member is a number subtype.
+    let props = ts2411_props(
+        r#"
+enum e { e1, e2 }
+enum E2 { A }
+interface A2 {
+    [x: string]: E2;
+    p: e.e1 | number;
+}
+"#,
+    );
+    assert!(
+        props.is_empty(),
+        "`e.e1 | number` reduces to `number`; no TS2411 expected, got: {props:?}"
+    );
+}
+
+#[test]
+fn genuinely_unassignable_union_member_still_reports() {
+    // Negative control: `string | boolean` shares no constituent absorbed by the
+    // numeric-enum index, so the check must still fire. Guards against the
+    // materialize step masking real errors.
+    let props = ts2411_props(
+        r#"
+enum E2 { A }
+interface Bad {
+    [x: string]: E2;
+    q: string | boolean;
+}
+"#,
+    );
+    assert!(
+        props.iter().any(|m| m.contains("'q'")),
+        "a union with no index-assignable-only reduction must still report; got: {props:?}"
+    );
+}


### PR DESCRIPTION
The index-signature constraint check judged a property's *unmaterialized*
annotation type. `property_type_assignable_to_index_type` resolved only the
top-level lazy wrapper, then tested each raw union member against the index
type. A union whose constituent is subsumed by a sibling therefore failed
spuriously: for `foo2: e | number` against a numeric-enum index, the numeric
enum `e` is a subtype of `number`, so tsc reduces the type to `number` (which
is assignable to the enum index) and reports nothing — but tsz checked
`[e, number]` member-by-member, `e → E2` failed, and it emitted a false TS2411.
The diagnostic even rendered the *reduced* type (`'number'`), because
`format_ts2411_type` evaluates while the check did not — a decision/display
asymmetry.

## Structural rule

When checking whether a property satisfies an index signature, tsc compares
`getTypeOfSymbol(prop)` — the *reduced* type — against the index type. tsz's
union arrives as `Lazy(E) | number`, and union subtype reduction skips lazy
members at intern time, so the `E | number → number` collapse only happens on
evaluation. Materialize the property type before the constraint decision so the
decision and the rendered type agree and match tsc's reduced operand. This is
the apparent-type materialize-before-decide gateway (#15396): a decision site
must not judge an unmaterialized `Lazy`/union operand.

Owner layer: checker — `state_checking_members/index_signature_key_helpers.rs`.

## Adjacent matrix

- `E | number` (whole numeric enum) against an enum index → reduces to
  `number`, no TS2411 (the reported bug).
- `E.member | number` (enum member) against an enum index → same reduction.
- `string | boolean` against a numeric-enum index → still reports (negative
  control; the materialize step must not mask real errors).
- `foo: string | number` in the same interface → still reports (`string` is
  not assignable), unchanged.

## Goal
Goal: hold

## Verification

Oracle: pinned `typescript@7.0.2` cache via `tsz-conformance` against the
release binary.

- `unionSubtypeIfEveryConstituentTypeIsSubtype.ts` → PASS (was FAIL: extra
  TS2411 on `foo2`).
- Full `--error-code 2411` conformance run: **11,534 PASS / 6 FAIL**, and all 6
  failures (numeric-literal property-name display `2.0` vs `2`, plus unrelated
  TS2322/TS2353) are **pre-existing on the parent commit** — verified by
  rebuilding the binary without this change and re-running those 6. Net: +1
  pass, 0 regressions.
- New unit tests:
  `crates/tsz-checker/tests/ts2411_union_subtype_reduction_index_tests.rs`
  (enum∪number absorption, enum-member∪number absorption, unassignable-union
  negative control) — 3/3 pass.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqcCVeuF9axbWTFM7gm1bA)_