### PR TITLE
fix(checker): inherited TS2411 carries tsc's TS2728 declared-here pointer

### DIFF
--- a/crates/tsz-checker/src/error_reporter/emitters.rs
+++ b/crates/tsz-checker/src/error_reporter/emitters.rs
@@ -170,6 +170,21 @@ impl<'a> CheckerState<'a> {
         self.error_at_node(node_idx, &message, code);
     }
 
+    /// [`Self::error_at_node_msg`], with `related_information` already
+    /// attached via [`Self::error_at_node_with_related`].
+    pub(crate) fn error_at_node_msg_with_related(
+        &mut self,
+        node_idx: NodeIndex,
+        code: u32,
+        args: &[&str],
+        related: Vec<crate::diagnostics::DiagnosticRelatedInformation>,
+    ) {
+        use tsz_common::diagnostics::get_message_template;
+        let template = get_message_template(code).unwrap_or("Unexpected checker diagnostic code.");
+        let message = format_message(template, args);
+        self.error_at_node_with_related(node_idx, &message, code, related);
+    }
+
     /// Get the source text for a node by extracting from the source file text.
     pub(crate) fn get_source_text_for_node(&self, node_idx: NodeIndex) -> String {
         if let Some((start, end)) = self.get_node_span(node_idx)

--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
@@ -1285,9 +1285,18 @@ impl<'a> CheckerState<'a> {
             // heritage chain to find the base declaration that actually
             // introduced this inherited property, falling back to the resolved
             // name when the base declaration can't be located (e.g. a lib type).
-            let diag_prop_name = self
-                .inherited_member_display_name(iface_node, &prop_name)
+            let inherited_decl_node =
+                self.inherited_member_declaration_node(iface_node, &prop_name);
+            let diag_prop_name = inherited_decl_node
+                .and_then(|n| self.get_member_name_text(n))
                 .unwrap_or_else(|| prop_name.clone());
+            // tsc reports this TS2411 at the index signature the DERIVED type
+            // owns, not at the property (owned by the base), so it attaches a
+            // `'{0}' is declared here.` (TS2728) pointer back to the base
+            // declaration — unlike the own-member TS2411 case, where the
+            // report site already is the declaration.
+            let declared_here =
+                self.inherited_member_declared_here_related(inherited_decl_node, &diag_prop_name);
 
             // Symbol-keyed inherited properties (e.g. [Symbol.iterator]) are
             // checked against the symbol index signature, NOT string/number.
@@ -1301,10 +1310,11 @@ impl<'a> CheckerState<'a> {
                     let index_type_str = self.format_ts2411_type(sym_value_type);
                     let error_node = symbol_index_sig_node.unwrap_or(name_fallback_node);
 
-                    self.error_at_node_msg(
+                    self.error_at_node_msg_with_related(
                         error_node,
                         diagnostic_codes::PROPERTY_OF_TYPE_IS_NOT_ASSIGNABLE_TO_INDEX_TYPE,
                         &[&diag_prop_name, &prop_type_str, "symbol", &index_type_str],
+                        declared_here.clone(),
                     );
                 }
                 continue;
@@ -1323,10 +1333,11 @@ impl<'a> CheckerState<'a> {
                 let index_type_str = self.format_ts2411_type(number_idx.value_type);
                 let error_node = number_index_sig_node.unwrap_or(name_fallback_node);
 
-                self.error_at_node_msg(
+                self.error_at_node_msg_with_related(
                     error_node,
                     diagnostic_codes::PROPERTY_OF_TYPE_IS_NOT_ASSIGNABLE_TO_INDEX_TYPE,
                     &[&diag_prop_name, &prop_type_str, "number", &index_type_str],
+                    declared_here.clone(),
                 );
             }
 
@@ -1359,7 +1370,7 @@ impl<'a> CheckerState<'a> {
                 let index_kind_str = self.index_signature_key_display(string_key_type);
                 let error_node = string_index_sig_node.unwrap_or(name_fallback_node);
 
-                self.error_at_node_msg(
+                self.error_at_node_msg_with_related(
                     error_node,
                     diagnostic_codes::PROPERTY_OF_TYPE_IS_NOT_ASSIGNABLE_TO_INDEX_TYPE,
                     &[
@@ -1368,6 +1379,7 @@ impl<'a> CheckerState<'a> {
                         &index_kind_str,
                         &index_type_str,
                     ],
+                    declared_here,
                 );
             }
         }

--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_inherited_display.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_inherited_display.rs
@@ -1,3 +1,6 @@
+use crate::diagnostics::{
+    Diagnostic, DiagnosticRelatedInformation, diagnostic_codes, diagnostic_messages, format_message,
+};
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -14,10 +17,60 @@ impl<'a> CheckerState<'a> {
         iface_node: NodeIndex,
         prop_name: &str,
     ) -> Option<String> {
-        let mut visited = std::collections::HashSet::new();
-        let name_idx =
-            self.find_member_name_node_in_hierarchy(iface_node, prop_name, false, &mut visited)?;
+        let name_idx = self.inherited_member_declaration_node(iface_node, prop_name)?;
         self.get_member_name_text(name_idx)
+    }
+
+    /// The name node of the base class/interface member that introduced an
+    /// inherited property, or `None` when no base declaration could be
+    /// located (e.g. the property comes from a lib type outside this arena).
+    /// Shared by [`Self::inherited_member_display_name`] (text) and
+    /// [`Self::inherited_member_declared_here_related`] (the `TS2728`
+    /// cross-location pointer) so both walk the heritage chain once per
+    /// property, not twice.
+    pub(crate) fn inherited_member_declaration_node(
+        &mut self,
+        iface_node: NodeIndex,
+        prop_name: &str,
+    ) -> Option<NodeIndex> {
+        let mut visited = std::collections::HashSet::new();
+        self.find_member_name_node_in_hierarchy(iface_node, prop_name, false, &mut visited)
+    }
+
+    /// tsc's `declarationNameToString`-anchored `'{0}' is declared here.`
+    /// (`TS2728`) pointer for an inherited property's `TS2411` diagnostic.
+    ///
+    /// tsc reports TS2411 at the index signature (which the derived type
+    /// owns), not at the property (which a base type owns) — so unlike the
+    /// own-member TS2411 case, the message alone does not locate the
+    /// property's declaration, and tsc attaches this related-information
+    /// entry to point at it. Declines (empty vec, not a guess) when the
+    /// declaration node can't be resolved or has no span, leaving output
+    /// exactly as it was rather than fabricating a pointer.
+    pub(crate) fn inherited_member_declared_here_related(
+        &mut self,
+        decl_node: Option<NodeIndex>,
+        display_name: &str,
+    ) -> Vec<DiagnosticRelatedInformation> {
+        let Some(decl_node) = decl_node else {
+            return Vec::new();
+        };
+        let Some((start, end)) = self.get_node_span(decl_node) else {
+            return Vec::new();
+        };
+        let (start, length) =
+            self.normalized_anchor_span(decl_node, start, end.saturating_sub(start));
+        let file = self
+            .source_file_data_for_node(decl_node)
+            .map(|sf| sf.file_name.clone())
+            .unwrap_or_else(|| self.ctx.file_name.clone());
+        vec![Diagnostic::related_pointer(
+            diagnostic_codes::IS_DECLARED_HERE,
+            file,
+            start,
+            length,
+            format_message(diagnostic_messages::IS_DECLARED_HERE, &[display_name]),
+        )]
     }
 
     /// Recursive helper for [`Self::inherited_member_display_name`]. When

--- a/crates/tsz-checker/tests/ts2411_tests.rs
+++ b/crates/tsz-checker/tests/ts2411_tests.rs
@@ -4,7 +4,8 @@
 
 use tsz_checker::context::CheckerOptions;
 use tsz_checker::test_utils::{
-    check_source, check_source_code_messages as get_diagnostics, diagnostic_code_messages,
+    check_source, check_source_code_messages as get_diagnostics, check_source_diagnostics,
+    diagnostic_code_messages,
 };
 
 fn has_error_with_code(source: &str, code: u32) -> bool {
@@ -365,6 +366,104 @@ class D extends C {
         "TS2411 must render the two-level-inherited computed name as \
          `[\"deep\"]`, got: {}",
         ts2411.1
+    );
+}
+
+// =========================================================================
+// Inherited member vs index signature: `TS2728` "declared here" pointer
+//
+// tsc reports this TS2411 at the index signature the DERIVED type owns, not
+// at the property (owned by a base) -- so it attaches a `'{0}' is declared
+// here.` (TS2728) related-information entry pointing back at the base
+// declaration. The own-member TS2411 path needs no such pointer: the report
+// site already IS the declaration.
+// =========================================================================
+
+#[test]
+fn test_ts2411_inherited_computed_name_has_declared_here_pointer() {
+    let source = r#"
+class Foo { x: number = 0; }
+class Foo2 { x: number = 0; y: number = 0; }
+class C {
+    get ["get1"]() { return new Foo(); }
+}
+class D extends C {
+    [s: string]: Foo2;
+}
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    let ts2411 = diagnostics
+        .iter()
+        .find(|d| d.code == 2411)
+        .expect("expected TS2411 for inherited computed-name getter vs string index");
+    let declared_here = ts2411
+        .related_information
+        .iter()
+        .find(|r| r.code == 2728)
+        .expect("expected a TS2728 'declared here' pointer on the inherited TS2411");
+    assert!(
+        declared_here.is_location_pointer(),
+        "the TS2728 entry must be a cross-location pointer, not an elaboration chain link"
+    );
+    assert!(
+        declared_here.message_text.contains("[\"get1\"]"),
+        "TS2728 must name the property with tsc's verbatim computed-name text, got: {}",
+        declared_here.message_text
+    );
+}
+
+#[test]
+fn test_ts2411_inherited_plain_identifier_has_declared_here_pointer() {
+    // Adjacent case: the pointer is a property of being INHERITED, not of
+    // having a computed name -- a plain identifier gets it too.
+    let source = r#"
+class Foo { x: number = 0; }
+class Foo2 { x: number = 0; y: number = 0; }
+class C {
+    get plainGetter() { return new Foo(); }
+}
+class D extends C {
+    [s: string]: Foo2;
+}
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    let ts2411 = diagnostics
+        .iter()
+        .find(|d| d.code == 2411)
+        .expect("expected TS2411 for inherited plain getter vs string index");
+    let declared_here = ts2411
+        .related_information
+        .iter()
+        .find(|r| r.code == 2728)
+        .expect("expected a TS2728 'declared here' pointer on the inherited TS2411");
+    assert!(
+        declared_here.message_text.contains("'plainGetter'"),
+        "TS2728 must name the plain inherited identifier without brackets, got: {}",
+        declared_here.message_text
+    );
+}
+
+#[test]
+fn test_ts2411_own_member_has_no_declared_here_pointer() {
+    // Negative control: an OWN-member TS2411 (no inheritance involved) must
+    // NOT gain a TS2728 pointer -- the report site already is the
+    // declaration, so tsc attaches no related information there.
+    let source = r#"
+class Foo { x: number = 0; }
+interface I {
+    [s: string]: Foo;
+    ["own1"]: number;
+}
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    let ts2411 = diagnostics
+        .iter()
+        .find(|d| d.code == 2411)
+        .expect("expected TS2411 for own computed-name member vs string index");
+    assert!(
+        !ts2411.related_information.iter().any(|r| r.code == 2728),
+        "an own-member TS2411 must carry no TS2728 pointer, got: {:?}",
+        ts2411.related_information
     );
 }
 


### PR DESCRIPTION
When tsc reports TS2411 for a property inherited from a base class or interface, it attaches a `'{0}' is declared here.` (TS2728) related-information entry pointing at the base declaration — the primary diagnostic is anchored at the index signature the *derived* type owns, not at the property itself, so without the pointer a reader has no way back to where the offending member was actually declared. tsz's `check_inherited_properties_against_index_signatures` (`crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs`) had no related-information plumbing at all for this path, unlike the analogous TS2741 "missing property" pointer the checker already builds elsewhere (`missing_property_declared_here.rs`).

**Structural rule:** when TS2411 fires for a property inherited from a base declaration, tsc attaches a TS2728 pointer to that base declaration (since the report site is the derived type's index signature, not the property); tsz now does the same through `check_inherited_properties_against_index_signatures`'s existing heritage-walk lookup.

Found while draining #16879 (my own prior-session PR, already merged): that PR's own DONE record flagged `computedPropertyNames45_ES5/ES6` as carrying a residual display-only bug on top of #16877's bracket fix. Direct verification against a fresh binary showed #16877 already fixed the bracket text — the actual gap was the missing TS2728 pointer.

### Fix

- `inherited_member_declaration_node` (renamed from the body of `inherited_member_display_name`, which now calls it) exposes the heritage-walk result as a `NodeIndex`, not just formatted text, so the same lookup can anchor a related-information pointer.
- New `inherited_member_declared_here_related` builds the `TS2728` pointer from that node, reusing `Diagnostic::related_pointer` the same way `missing_property_declared_here.rs` does for TS2741.
- New general-purpose `error_at_node_msg_with_related` emitter (`error_reporter/emitters.rs`), the `related`-carrying counterpart to the existing `error_at_node_msg`.
- All three TS2411 report sites in `check_inherited_properties_against_index_signatures` (symbol-, number-, and string-index) now attach the pointer.

### Adjacent-case matrix (all oracle-verified against pinned `typescript@7.0.2`)

- Inherited computed name (`get ["get1"]()` in a base class checked against a derived class's own string index) — the fixture case, byte-for-byte identical to tsc including the pointer's exact span and indentation.
- Inherited plain identifier — the pointer is inheritance-driven, not bracket-driven, so a non-computed name gets it too.
- Own-member TS2411 (interface's own computed property against its own index signature) — negative control: **no** TS2728 pointer, matching tsc exactly, since the report site already is the declaration.

Verified `computedPropertyNames45_ES6.ts` end-to-end with a rebuilt release binary against the pinned oracle: diagnostics, codes, positions, and the TS2728 pointer's file/line/col/indentation are byte-for-byte identical (only a path-prefix difference from running from different working directories). The fixture's second TS2411 (`["set1"]`, an own member) correctly carries no pointer in both tsc and tsz, confirming the fix doesn't overreach into the own-member path.

## Goal
Goal: hold

## Verification
- Fixture `computedPropertyNames45_ES6.ts` (pinned TypeScript corpus SHA) vs pinned `typescript@7.0.2` oracle: byte-for-byte identical pretty-printed output (diagnostics, positions, and the new TS2728 pointer), confirmed via direct diff.
- `cargo test -p tsz-checker --test ts2411_tests`: 61/61 (3 new: inherited-computed-name pointer, inherited-plain-identifier pointer, own-member negative control).
- `cargo test -p tsz-checker --lib -- index_signature`: 266/266.
- `cargo test -p tsz-checker --lib -- ts2411 ts2413 enum`: 397/397.
- `cargo test -p tsz-checker --lib -- routing_arch`: 178/178.
- `cargo test -p tsz-checker --lib -- computed_property inherit`: 222/222.
- `cargo clippy -p tsz-checker --lib --tests -- -D warnings`: clean.
- `cargo fmt --check -p tsz-checker`: clean.
- `scripts/arch/arch_guard_file_limits.py`: passed (`index_signature_checks.rs` at 1953/2000 lines).
- `compare-to-parent.sh` / full `conformance.sh snapshot` not run this session (time budget) — this is a message-related-information-only addition inside an existing TS2411 emission (no diagnostic gained or lost, no code/count change), and is covered by the oracle byte-for-byte diff plus the full targeted matrix above. Owed as a follow-up if anyone wants the corpus-wide confirmation.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_018mUUmPWs7yPuag9fXYZUFv)_