### PR TITLE
fix(checker): TS2314 renders a generic type alias by its bare name

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1251,6 +1251,9 @@ path = "tests/ts2313_generic_constraint_tests.rs"
 name = "ts2314_in_type_literal_suppresses_ts2322_tests"
 path = "tests/ts2314_in_type_literal_suppresses_ts2322_tests.rs"
 [[test]]
+name = "ts2314_generic_type_alias_display_tests"
+path = "tests/ts2314_generic_type_alias_display_tests.rs"
+[[test]]
 name = "commonjs_module_export_alias_tests"
 path = "tests/commonjs_module_export_alias_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
+++ b/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
@@ -147,11 +147,29 @@ impl CheckerState<'_> {
                                     })
                                     .unwrap_or_else(|| name.to_string())
                             };
-                            let display_name = Self::format_generic_display_name_with_interner(
-                                &resolved_name,
-                                &type_params,
-                                self.ctx.types,
-                            );
+                            // tsc renders a generic type *alias* by its bare name
+                            // (`callback`), but a generic class/interface with its
+                            // type parameters (`Array<T>`, `I<T>`) —
+                            // `typeToString` writes the declared type parameters
+                            // for the latter only. A re-export carries `ALIAS`
+                            // (not `TYPE_ALIAS`), so `export type { A as B }` still
+                            // resolves to its target's parameterized `A<T>`.
+                            let is_bare_type_alias =
+                                self.ctx.binder.get_symbol(sym_id).is_some_and(|s| {
+                                    s.has_any_flags(symbol_flags::TYPE_ALIAS)
+                                        && !s.has_any_flags(
+                                            symbol_flags::CLASS | symbol_flags::INTERFACE,
+                                        )
+                                });
+                            let display_name = if is_bare_type_alias {
+                                resolved_name
+                            } else {
+                                Self::format_generic_display_name_with_interner(
+                                    &resolved_name,
+                                    &type_params,
+                                    self.ctx.types,
+                                )
+                            };
                             if required_count < type_params.len() {
                                 // TS2707: Generic type 'X<T, U, V>' requires between N and M type arguments.
                                 let min_str = required_count.to_string();

--- a/crates/tsz-checker/tests/ts2314_generic_type_alias_display_tests.rs
+++ b/crates/tsz-checker/tests/ts2314_generic_type_alias_display_tests.rs
@@ -1,0 +1,79 @@
+//! TS2314 ("Generic type '{0}' requires {1} type argument(s).") renders the
+//! generic type's name from `declarationNameToString`/`typeToString`: a generic
+//! type **alias** shows its bare name (`callback`), while a generic
+//! **interface**/**class** shows its declared type parameters (`Array<T>`,
+//! `I<T>`). Pinned against the tsc 7.0.2 oracle
+//! (`compiler/typeAliasDeclarationEmit.ts` reports `callback`, and the many
+//! interface cases such as `genericInterfacesWithoutTypeArguments.ts` report
+//! `I<T>`).
+
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn ts2314_messages(source: &str) -> Vec<String> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .filter(|d| d.code == 2314)
+        .map(|d| d.message_text)
+        .collect()
+}
+
+#[test]
+fn generic_type_alias_renders_bare_name_in_ts2314() {
+    // `callback` is a generic type alias used without type arguments in a
+    // constraint. tsc names it bare: `Generic type 'callback' requires 1 type
+    // argument(s).` — not `callback<T>`.
+    let source = r#"
+type callback<T> = () => T;
+type CallbackArray<T extends callback> = () => T;
+"#;
+    let messages = ts2314_messages(source);
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("Generic type 'callback' requires")),
+        "expected the bare alias name `callback`, got: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("callback<")),
+        "a generic type alias must not carry its type parameters in TS2314, got: {messages:?}"
+    );
+}
+
+#[test]
+fn generic_type_alias_bare_name_is_independent_of_binder_names() {
+    // Same shape, renamed binders — the rule is structural, so the bare name
+    // follows whatever the alias is called.
+    let source = r#"
+type Boxed<Elem> = { value: Elem };
+type UsesBoxed<X extends Boxed> = X;
+"#;
+    let messages = ts2314_messages(source);
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("Generic type 'Boxed' requires")),
+        "expected the bare alias name `Boxed`, got: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("Boxed<")),
+        "renaming the alias must not reintroduce its type parameters, got: {messages:?}"
+    );
+}
+
+#[test]
+fn generic_interface_keeps_type_parameters_in_ts2314() {
+    // Control: a generic *interface* used without arguments keeps its type
+    // parameters (`I<T>`), matching tsc — so the alias rule above must not
+    // strip parameters from interfaces.
+    let source = r#"
+interface I<T> { value: T; }
+type UsesI<X extends I> = X;
+"#;
+    let messages = ts2314_messages(source);
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("Generic type 'I<T>' requires")),
+        "a generic interface must keep its type parameters in TS2314, got: {messages:?}"
+    );
+}


### PR DESCRIPTION
`Generic type '{0}' requires {1} type argument(s).` (TS2314) fills `{0}` from `typeToString`, which writes a generic **alias** by its bare name (`callback`) but a generic **interface**/**class** with its declared type parameters (e.g. `Array` and `I` rendered with their `&lt;T&gt;` lists). tsz rendered every generic type reference in the parameterized form, so a type alias used without arguments printed as `callback&lt;T&gt;` where tsc prints the bare `callback`.

_(This branch originally carried a TS2411 inherited-computed-name fix; that exact change landed independently as #16877 while this was in flight, so the branch was repointed at a still-open over-reporting item from the same #16866 conformance-targeting sweep.)_

**Structural rule:** when a generic type is referenced without type arguments and TS2314 fires, tsc names an *alias* bare and a *class/interface* with its type parameters; tsz must match. The owner layer is the checker's type-reference resolution site that already distinguishes class/interface symbols.

**What changed**
- At the type-reference resolution site (`state/type_resolution/reference_helpers.rs`) that already branches on `is_class_or_interface`, render the bare name when the referenced symbol is a `TYPE_ALIAS` (and not a class/interface); otherwise keep the parameterized form.
- A re-export specifier carries the `ALIAS` flag, not `TYPE_ALIAS`, so `export type { A as B }` still resolves through to its target's parameterized `A&lt;T&gt;`. The built-in (`Array&lt;T&gt;`) and heritage TS2314 sites are untouched.

**Adjacent cases** (`ts2314_generic_type_alias_display_tests.rs`): generic alias → bare name; renamed binders (structural, not name-keyed); generic interface control → keeps its `&lt;T&gt;` list.

## Goal
Goal: hold

## Verification
- Full conformance (tsc 7.0.2 oracle, 12043 tests), baseline binary vs this change, fail-set diff: **+1 / −0** — `compiler/typeAliasDeclarationEmit.ts` flips to pass, **no regressions** (11536 → 11537).
- Interface/class TS2314 preserved: `arrayReferenceWithoutTypeArgs`, `genericInterfacesWithoutTypeArguments`, `genericGetter2`, `externalModuleExportingGenericClass` all still pass with their type-parameter lists.
- `cargo test -p tsz-checker --test ts2314_generic_type_alias_display_tests` → 3 passed.
- `cargo clippy -p tsz-checker --profile ci-lint --all-targets -- -D warnings` → clean; pre-commit arch-size guard passed.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high