### PR TITLE
fix(parser): TS1003 for a string-literal export-specifier property name is a checker grammar diagnostic, not a parser one (#16702)

### DIFF
--- a/crates/tsz-parser/src/parser/state_declarations_exports.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_exports.rs
@@ -579,14 +579,6 @@ impl ParserState {
             NodeIndex::NONE
         };
 
-        // TS1003: without a `from` clause, the *local* name of an export specifier
-        // (the part before `as`) must be an identifier, not a string literal. This is
-        // the export mirror of the import-specifier string-binding check; see
-        // `report_export_specifier_string_local_names` for the full rule.
-        if module_specifier.is_none() {
-            self.report_export_specifier_string_local_names(export_clause);
-        }
-
         // Parse optional import attributes: with { ... } or assert { ... }
         let attributes = if module_specifier.is_none() {
             NodeIndex::NONE

--- a/crates/tsz-parser/src/parser/state_declarations_modules.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_modules.rs
@@ -1358,51 +1358,5 @@ impl ParserState {
         self.parse_import_or_export_specifier(syntax_kind_ext::IMPORT_SPECIFIER)
     }
 
-    /// TS1003 for export specifiers whose local name is a string literal, the
-    /// export mirror of the string-binding check in
-    /// `parse_import_or_export_specifier`.
-    ///
-    /// In an export declaration with NO module specifier (`from`), the *local*
-    /// name of an export specifier — the part before `as`, stored as
-    /// `property_name` — must be an identifier, not a string literal. Unlike the
-    /// import check (imports always have a `from`, so their binding can never be a
-    /// string), this one is gated on the absence of `from`: with a module
-    /// specifier the string re-exports a string-named module binding
-    /// (`export { "q" as y } from "m"`), which tsc accepts. The exported alias may
-    /// itself be a string (`export { x as "s" }`), and a bare `{ "q" }` with no
-    /// `as` is also allowed — matching tsc's `checkExportSpecifier` /
-    /// `checkModuleExportName`. Callers must invoke this only when there is no
-    /// module specifier; `export_clause` is the `NAMED_EXPORTS` node.
-    pub(crate) fn report_export_specifier_string_local_names(&mut self, export_clause: NodeIndex) {
-        use tsz_common::diagnostics::diagnostic_codes;
-        let specifiers: Vec<NodeIndex> = self
-            .arena
-            .get_named_imports_at(export_clause)
-            .map(|named| named.elements.nodes.clone())
-            .unwrap_or_default();
-        for spec in specifiers {
-            let Some(property_name) = self
-                .arena
-                .get_specifier_at(spec)
-                .map(|data| data.property_name)
-            else {
-                continue;
-            };
-            let Some(name_node) = self.arena.get(property_name) else {
-                continue;
-            };
-            if name_node.is_string_literal() {
-                let name_start = name_node.pos;
-                let name_len = name_node.end.saturating_sub(name_node.pos);
-                self.parse_error_at(
-                    name_start,
-                    name_len,
-                    "Identifier expected.",
-                    diagnostic_codes::IDENTIFIER_EXPECTED,
-                );
-            }
-        }
-    }
-
     // Export declarations and control flow statements → state_declarations_exports.rs
 }

--- a/crates/tsz-parser/tests/state_declaration_tests.rs
+++ b/crates/tsz-parser/tests/state_declaration_tests.rs
@@ -643,90 +643,10 @@ import { from as fromObservable } from "./from";
     );
 }
 
-/// Mirror of `import_specifier_string_literal_binding_names_emit_ts1003` for the
-/// *export* side. Without a `from` clause, the local name of an export specifier
-/// (the part before `as`, i.e. the `property_name`) must be an identifier; a
-/// string literal there is TS1003 "Identifier expected." in `tsc`. The exported
-/// alias (after `as`) and a bare `{ "q" }` name may be string literals, so only
-/// the `property_name` position is flagged.
-#[test]
-fn export_specifier_string_literal_local_names_without_from_emit_ts1003() {
-    // Names are varied so nothing keys on a specific identifier.
-    let source = r#"
-export { "aa" as bb };
-export type { "cc" as dd };
-export { ee, "ff" as gg };
-export { "hh" as "ii" };
-"#;
-    let (parser, _root) = parse_source(source);
-    let diagnostics = parser.get_diagnostics();
-    let ts1003_count = diagnostics
-        .iter()
-        .filter(|d| d.code == diagnostic_codes::IDENTIFIER_EXPECTED)
-        .count();
-    assert_eq!(
-        ts1003_count, 4,
-        "expected TS1003 for every string-literal export local name, got {diagnostics:?}"
-    );
-}
-
-/// The TS1003 anchor must sit on the offending string literal itself, exactly
-/// where `tsc` points it.
-#[test]
-fn export_specifier_string_local_name_ts1003_anchors_on_the_string() {
-    // `export { "q" as y };` — the `"q"` literal begins at byte offset 9.
-    let (parser, _root) = parse_source(r#"export { "q" as y };"#);
-    let diagnostics = parser.get_diagnostics();
-    assert!(
-        diagnostics
-            .iter()
-            .any(|d| d.code == diagnostic_codes::IDENTIFIER_EXPECTED && d.start == 9),
-        "expected TS1003 anchored at the string literal (offset 9), got {diagnostics:?}"
-    );
-}
-
-/// With a `from` clause the string local name re-exports a string-named module
-/// binding, which `tsc` accepts — so no TS1003.
-#[test]
-fn export_specifier_string_local_name_is_valid_with_from() {
-    let source = r#"
-export { "aa" as bb } from "./m";
-export type { "cc" as dd } from "./m";
-export { "hh" as "ii" } from "./m";
-"#;
-    let (parser, _root) = parse_source(source);
-    let ts1003_count = parser
-        .get_diagnostics()
-        .iter()
-        .filter(|d| d.code == diagnostic_codes::IDENTIFIER_EXPECTED)
-        .count();
-    assert_eq!(
-        ts1003_count, 0,
-        "a string local name re-exporting through `from` must not emit TS1003"
-    );
-}
-
-/// Negative controls without a `from` clause: a string *alias* (after `as`), a
-/// bare string name with no `as`, and all-identifier specifiers are each valid.
-#[test]
-fn export_specifier_string_alias_and_bare_string_without_from_are_valid() {
-    let source = r#"
-const jj = 1;
-export { jj as "kk" };
-export { "ll" };
-export { jj as nn };
-"#;
-    let (parser, _root) = parse_source(source);
-    let ts1003_count = parser
-        .get_diagnostics()
-        .iter()
-        .filter(|d| d.code == diagnostic_codes::IDENTIFIER_EXPECTED)
-        .count();
-    assert_eq!(
-        ts1003_count, 0,
-        "string aliases and bare string export names must not emit TS1003"
-    );
-}
+// TS1003 for a string-literal export-specifier property name without a `from`
+// clause is a *checker* grammar diagnostic, owned by
+// `crates/tsz-checker/src/declarations/module_export_names.rs`; its coverage
+// lives in the checker suite `string_literal_module_export_name_grammar_tests`.
 
 #[test]
 fn conditional_tuple_element_inside_conditional_extends_type_parses() {


### PR DESCRIPTION
Fixes #16702.

**Structural rule.** When an export-specifier property name is a string literal and the export declaration has no `from` clause (`export { "x" as y }`), `tsc`/`tsgo` report `TS1003` ("Identifier expected.") through `checkModuleExportName` → `grammarErrorOnNode` — a **checker** grammar diagnostic that is suppressed program-wide whenever the program has any *syntactic* error. tsz owns this in the checker (`crates/tsz-checker/src/declarations/module_export_names.rs`, from #16356), gated by `should_check_module_export_names()` = `!has_parse_errors`, where `has_parse_errors` = `program_has_real_syntax_errors`.

#16700 additionally emitted the same `TS1003` from the **parser** (`report_export_specifier_string_local_names`, via `parse_error_at`). As a *syntactic* diagnostic it escaped the program-wide suppression, so it over-reported on `arbitraryModuleNamespaceIdentifiers_syntax` (12 `TS1003` where the pinned oracle emits 9 — the 3 extras being the export-specifier property-name sites, each of which the fixture's import-specifier parse errors should suppress). Being a parser diagnostic, it also wrongly counted as a syntactic error that could suppress *other* files' semantic diagnostics.

**Fix.** Revert #16700: drop the parser function, its call site, and its 4 parser tests. The diagnostic stays owned by the checker (#16356), whose suite already pins both the fire and the suppression at the correct layer, so nothing is lost — a standalone `export { "x" as y }` still reports `TS1003` (now emitted by the checker, since no parser parse-error is set to suppress the checker walk).

I confirmed the layering against the pinned oracle (`typescript@7.0.2`, `--singleThreaded --stableTypeOrdering`): the export-side `TS1003` fires alone but disappears the moment the program contains any syntactic error (an import-specifier string binding, or a generic `TS1109`), while a semantic error elsewhere does not suppress it — exactly `tsc`'s "report semantic diagnostics only when there are zero syntactic diagnostics" behavior.

## Goal
Goal: hold

## Verification
Release `dist-fast` binary on the reconstructed 15-file fixture (`--module ES2022 --target ES2022`):
- **before (main): 12 × `TS1003`; after: 9 × `TS1003`** — byte-identical to the pinned `typescript@7.0.2` oracle-cache fingerprints in `scripts/conformance/tsc-cache-full.json`. The 3 removed sites are exactly `values-bad-export.ts(1,10)`, `type-decls-bad-export.ts(1,15)`, `type-clause-bad-export.ts(1,15)`; no other diagnostics newly surfaced.
- `cargo test -p tsz-checker --test string_literal_module_export_name_grammar_tests` — **39 passed / 0 failed** (includes `a_parse_error_suppresses_ts1003_too` + its control, and `a_local_export_property_name_draws_ts1003_on_every_module_target`).
- `cargo test -p tsz-parser --lib` — **2134 passed / 0 failed**.
- `python3 scripts/arch/arch_guard.py` — passed.
- `cargo clippy -p tsz-parser -p tsz-checker --all-targets -- -D warnings` — clean.

Full conformance/emit/fourslash run nightly; the conformance code-set gate is unaffected (the affected rows keep the code set `{TS1003}`), and the per-site count now matches the oracle.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01UqK39DUZjQNrBxpiZwSoRJ)_