### PR TITLE
fix(parser): hard modifier before a type-member accessor cascades like tsc (#16291)

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -372,6 +372,9 @@ mod reserved_parameter_recovery_tests;
 mod ts1180_property_destructuring_pattern_expected_tests;
 
 #[cfg(test)]
+#[path = "../../tests/type_member_hard_modifier_accessor_cascade_tests.rs"]
+mod type_member_hard_modifier_accessor_cascade_tests;
+#[cfg(test)]
 #[path = "../../tests/type_member_modifier_grammar_tests.rs"]
 mod type_member_modifier_grammar_tests;
 #[cfg(test)]

--- a/crates/tsz-parser/src/parser/state.rs
+++ b/crates/tsz-parser/src/parser/state.rs
@@ -230,6 +230,14 @@ pub struct ParserState {
     /// actual `}` tokens for statement-level TS1128 recovery, skip this many
     /// enclosing close-brace expectations.
     pub(crate) deferred_type_member_close_braces: u32,
+    /// Set when a type-member body is abandoned mid-parse (a hard modifier
+    /// before an accessor — see `report_hard_modifier_run_before_accessor`) so
+    /// its leftover tokens re-parse as top-level statements. An enclosing
+    /// `type X = <literal>` alias consults and clears this to skip its trailing
+    /// `parse_semicolon`: the leftover tokens belong to the statement list, not
+    /// the alias, so requiring a separator here would emit a spurious TS1005.
+    /// The interface path clears it directly (it parses no trailing separator).
+    pub(crate) pending_type_member_body_reparse: bool,
     /// After malformed import-attribute recovery inside an intersection type,
     /// parse the next `import()` options object with generic expression
     /// grammar so its diagnostics degrade like TypeScript's fallback path.
@@ -431,6 +439,7 @@ impl ParserState {
             deferred_module_close_braces: 0,
             abort_intersection_continuation: false,
             deferred_type_member_close_braces: 0,
+            pending_type_member_body_reparse: false,
             fallback_import_type_options_once: false,
             pending_array_binding_tail_recovery: false,
             in_import_type_options_context: false,
@@ -489,6 +498,7 @@ impl ParserState {
         self.current_specifier_recovered_braced_unicode_escape_debris = false;
         self.deferred_module_close_braces = 0;
         self.deferred_type_member_close_braces = 0;
+        self.pending_type_member_body_reparse = false;
         self.abort_intersection_continuation = false;
         self.fallback_import_type_options_once = false;
         self.pending_array_binding_tail_recovery = false;

--- a/crates/tsz-parser/src/parser/state_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_declarations.rs
@@ -287,6 +287,11 @@ impl ParserState {
         let members = self.parse_type_members();
         let end_pos = self.finish_type_member_container_close_brace();
         self.type_member_container_depth = saved_type_member_depth;
+        // An interface parses no trailing separator, so clear any abandon-body
+        // flag here rather than leak it to a later `type X = ...` alias (which
+        // would then wrongly skip its own semicolon). See
+        // `pending_type_member_body_reparse`.
+        self.pending_type_member_body_reparse = false;
         self.arena.add_interface(
             syntax_kind_ext::INTERFACE_DECLARATION,
             start_pos,
@@ -334,6 +339,22 @@ impl ParserState {
             // so `get`/`set` is never mistaken for the property name and the
             // modifiers are never silently dropped (which previously produced a
             // misleading TS1005 or TS1070).
+            // A run containing a "hard" modifier (`async`/`declare`/`abstract`/
+            // `override`) before an accessor does not recover as a bare accessor
+            // in tsc: after one TS1131 per modifier, tsc abandons the
+            // type-member body and re-parses the accessor's own tail as
+            // top-level statements (TS1434/TS1005/TS1128). Reproduced by
+            // deferring the container close brace — the same mechanism
+            // `recover_invalid_type_member` uses — so the tail is left for the
+            // enclosing statement parser. Checked before the clean-only run
+            // below because that helper stops at (and never counts) a hard
+            // modifier, so the two are mutually exclusive.
+            let hard_run_len = self.look_ahead_hard_modifier_run_before_accessor();
+            if hard_run_len > 0 {
+                self.report_hard_modifier_run_before_accessor(hard_run_len);
+                break;
+            }
+
             let modifier_run_len = self.look_ahead_modifier_run_before_accessor();
             if modifier_run_len > 0 {
                 for _ in 0..modifier_run_len {
@@ -1488,7 +1509,14 @@ impl ParserState {
 
         let type_node = self.parse_type();
 
-        self.parse_semicolon();
+        // When the alias's type is a `{ ... }` literal that abandoned its body
+        // mid-parse (a hard modifier before an accessor), the leftover tokens
+        // belong to the enclosing statement list, not the alias — re-parsed as
+        // statements (TS1434/TS1005/TS1128). Requiring a separator here would
+        // emit a spurious TS1005 at those tokens, so take the flag and skip.
+        if !std::mem::take(&mut self.pending_type_member_body_reparse) {
+            self.parse_semicolon();
+        }
 
         let end_pos = self.token_full_start();
         self.arena.add_type_alias(

--- a/crates/tsz-parser/src/parser/state_declarations_type_member_modifiers.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_type_member_modifiers.rs
@@ -103,6 +103,39 @@ impl ParserState {
         (false, None)
     }
 
+    /// Report a run of `count` type-member modifiers directly before a
+    /// `get`/`set` accessor where at least one is "hard"
+    /// (`async`/`declare`/`abstract`/`override`): one TS1131 per modifier, each
+    /// anchored at its own token, then defer the container's close brace so the
+    /// accessor's own tail re-parses as top-level statements
+    /// (TS1434/TS1005/TS1128). This reproduces tsc's abandon-body recovery,
+    /// which differs from the clean-only run's bare-accessor recovery. Shared by
+    /// the interface (`parse_type_members`) and type-literal
+    /// (`parse_type_literal_rest`) member loops; the caller breaks its member
+    /// loop immediately after, leaving the deferred close brace for
+    /// `finish_type_member_container_close_brace`.
+    pub(crate) fn report_hard_modifier_run_before_accessor(&mut self, count: usize) {
+        use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages};
+        for _ in 0..count {
+            let mod_start = self.token_pos();
+            let mod_end = self.token_end();
+            self.next_token();
+            self.parse_error_at(
+                mod_start,
+                mod_end.saturating_sub(mod_start),
+                diagnostic_messages::PROPERTY_OR_SIGNATURE_EXPECTED,
+                diagnostic_codes::PROPERTY_OR_SIGNATURE_EXPECTED,
+            );
+        }
+        self.deferred_type_member_close_braces = self
+            .deferred_type_member_close_braces
+            .max(self.type_member_container_depth);
+        // The abandoned tail re-parses as top-level statements; an enclosing
+        // `type X = <literal>` alias must not then require a trailing semicolon
+        // for those tokens. See `pending_type_member_body_reparse`.
+        self.pending_type_member_body_reparse = true;
+    }
+
     /// If the current token is a leading `async` modifier, consumes it and,
     /// when `report` is set, emits the TS1070 diagnostic. `report` is `false`
     /// when an earlier modifier in the same member already reported — `tsc`'s
@@ -142,5 +175,128 @@ impl ParserState {
         } else {
             false
         }
+    }
+
+    /// A "clean" type-member modifier: one `tsc` parses as a modifier and then
+    /// rejects with a single TS1131 before an accessor, recovering the accessor
+    /// as a bare (modifier-less) member. `readonly` is included because it is a
+    /// legal member modifier that still cannot precede an accessor.
+    pub(crate) const fn is_clean_type_member_modifier(kind: SyntaxKind) -> bool {
+        matches!(
+            kind,
+            SyntaxKind::PrivateKeyword
+                | SyntaxKind::ProtectedKeyword
+                | SyntaxKind::PublicKeyword
+                | SyntaxKind::StaticKeyword
+                | SyntaxKind::AccessorKeyword
+                | SyntaxKind::ExportKeyword
+                | SyntaxKind::ReadonlyKeyword
+        )
+    }
+
+    /// A "hard" type-member modifier before an accessor: one `tsc` does NOT
+    /// recover into a bare accessor. Instead it abandons the type-member body
+    /// after one TS1131 per modifier and re-parses the accessor's own tail as
+    /// top-level statements (TS1434/TS1005/TS1128). `in`/`out` are deliberately
+    /// excluded — `in` is a reserved operator whose statement re-parse differs,
+    /// and both carry variance-position idiosyncrasies; they keep the
+    /// pre-existing semantic TS1070 path.
+    pub(crate) const fn is_hard_accessor_cascade_modifier(kind: SyntaxKind) -> bool {
+        matches!(
+            kind,
+            SyntaxKind::AsyncKeyword
+                | SyntaxKind::DeclareKeyword
+                | SyntaxKind::AbstractKeyword
+                | SyntaxKind::OverrideKeyword
+        )
+    }
+
+    /// Check whether the current token starts a run of one or more *clean*
+    /// type-member modifiers directly followed, each on the same line, by a
+    /// `get`/`set` accessor signature (`static get x()`, `public static get
+    /// x()`, ...), as opposed to a modifier or `get`/`set` used as an ordinary
+    /// property/method name (`static get(): void`, `static get: number`). tsc
+    /// reports one TS1131 per modifier in the run (each anchored at its own
+    /// token) then recovers by retrying at the accessor keyword, which parses
+    /// as a bare (modifier-less) accessor. Returns the run length, or `0`.
+    ///
+    /// A run containing a "hard" modifier is handled separately by
+    /// [`Self::look_ahead_hard_modifier_run_before_accessor`] (a different,
+    /// abandon-body recovery); `in`/`out` stay on the semantic TS1070 path.
+    pub(crate) fn look_ahead_modifier_run_before_accessor(&mut self) -> usize {
+        let snapshot = self.scanner.save_state();
+        let current = self.current_token;
+
+        let mut count = 0usize;
+        loop {
+            if !Self::is_clean_type_member_modifier(self.token())
+                || self.look_ahead_is_property_name_after_keyword()
+            {
+                break;
+            }
+            self.next_token();
+            count += 1;
+            if self.scanner.has_preceding_line_break() {
+                count = 0;
+                break;
+            }
+        }
+
+        let ends_in_accessor = count > 0
+            && (self.is_token(SyntaxKind::GetKeyword) || self.is_token(SyntaxKind::SetKeyword))
+            && !self.look_ahead_is_property_name_after_keyword();
+
+        self.scanner.restore_state(snapshot);
+        self.current_token = current;
+
+        if ends_in_accessor { count } else { 0 }
+    }
+
+    /// Look ahead for a run of type-member modifiers (clean and/or hard)
+    /// directly before a `get`/`set` accessor where AT LEAST ONE modifier is
+    /// "hard" (`async`/`declare`/`abstract`/`override`). Returns the run length,
+    /// or 0 when no such run ends in an accessor.
+    ///
+    /// Distinct from [`Self::look_ahead_modifier_run_before_accessor`], which
+    /// covers clean-only runs (one TS1131 per modifier, then a recovered bare
+    /// accessor). A run containing a hard modifier does not parse as any member
+    /// in `tsc`: after one TS1131 per modifier the type-member body is abandoned
+    /// and the accessor's own tail re-parses as top-level statements. The caller
+    /// reproduces that by deferring the container's close brace (the same
+    /// mechanism [`Self::recover_invalid_type_member`] uses).
+    pub(crate) fn look_ahead_hard_modifier_run_before_accessor(&mut self) -> usize {
+        let snapshot = self.scanner.save_state();
+        let current = self.current_token;
+
+        let mut count = 0usize;
+        let mut saw_hard = false;
+        loop {
+            let kind = self.token();
+            let is_hard = Self::is_hard_accessor_cascade_modifier(kind);
+            if (!Self::is_clean_type_member_modifier(kind) && !is_hard)
+                || self.look_ahead_is_property_name_after_keyword()
+            {
+                break;
+            }
+            if is_hard {
+                saw_hard = true;
+            }
+            self.next_token();
+            count += 1;
+            if self.scanner.has_preceding_line_break() {
+                count = 0;
+                break;
+            }
+        }
+
+        let ends_in_accessor = count > 0
+            && saw_hard
+            && (self.is_token(SyntaxKind::GetKeyword) || self.is_token(SyntaxKind::SetKeyword))
+            && !self.look_ahead_is_property_name_after_keyword();
+
+        self.scanner.restore_state(snapshot);
+        self.current_token = current;
+
+        if ends_in_accessor { count } else { 0 }
     }
 }

--- a/crates/tsz-parser/src/parser/state_types_advanced.rs
+++ b/crates/tsz-parser/src/parser/state_types_advanced.rs
@@ -1392,6 +1392,16 @@ impl ParserState {
             // qualifying modifier set). tsc's parser cannot build any member starting
             // at the first modifier, reports one TS1131 per modifier in the run, and
             // retries from the accessor keyword.
+            // A run containing a "hard" modifier before an accessor abandons the
+            // type-literal body and re-parses the accessor tail as statements —
+            // see `parse_type_members`'s identical check and
+            // `look_ahead_hard_modifier_run_before_accessor`.
+            let hard_run_len = self.look_ahead_hard_modifier_run_before_accessor();
+            if hard_run_len > 0 {
+                self.report_hard_modifier_run_before_accessor(hard_run_len);
+                break;
+            }
+
             let modifier_run_len = self.look_ahead_modifier_run_before_accessor();
             if modifier_run_len > 0 {
                 for _ in 0..modifier_run_len {
@@ -1914,68 +1924,6 @@ impl ParserState {
         self.scanner.restore_state(snapshot);
         self.current_token = current;
         is_property_name
-    }
-
-    /// Check whether the current token starts a run of one or more type-member
-    /// modifiers directly followed, each on the same line, by a `get`/`set`
-    /// accessor signature (`static get x()`, `public static get x()`,
-    /// `readonly export get x()`, ...), as opposed to a modifier or `get`/`set`
-    /// used as an ordinary property/method name (`static get(): void`,
-    /// `static get: number`). No modifier at all may precede an accessor
-    /// signature in an interface or type-literal body: tsc's parser cannot
-    /// build any member starting at the first modifier, and reports one
-    /// TS1131 per modifier in the run (each anchored at its own token) before
-    /// recovering by retrying at the accessor keyword, which then parses as a
-    /// bare (modifier-less) accessor.
-    ///
-    /// Only `private`/`protected`/`public`/`static`/`accessor`/`export`/
-    /// `readonly` qualify — oracle-verified (`typescript@7.0.2`) to recover
-    /// this way. `declare`/`abstract`/`override`/`in`/`out` are deliberately
-    /// excluded: preceding an accessor, tsc's recovery for those cascades
-    /// into a different diagnostic set (TS1434/TS1005/TS1128) rather than one
-    /// TS1131 per modifier, a distinct and out-of-scope shape. Returns the
-    /// number of modifiers in the qualifying run, or `0` if this token does
-    /// not start one.
-    pub(crate) fn look_ahead_modifier_run_before_accessor(&mut self) -> usize {
-        const fn is_clean_type_member_modifier(kind: SyntaxKind) -> bool {
-            matches!(
-                kind,
-                SyntaxKind::PrivateKeyword
-                    | SyntaxKind::ProtectedKeyword
-                    | SyntaxKind::PublicKeyword
-                    | SyntaxKind::StaticKeyword
-                    | SyntaxKind::AccessorKeyword
-                    | SyntaxKind::ExportKeyword
-                    | SyntaxKind::ReadonlyKeyword
-            )
-        }
-
-        let snapshot = self.scanner.save_state();
-        let current = self.current_token;
-
-        let mut count = 0usize;
-        loop {
-            if !is_clean_type_member_modifier(self.token())
-                || self.look_ahead_is_property_name_after_keyword()
-            {
-                break;
-            }
-            self.next_token();
-            count += 1;
-            if self.scanner.has_preceding_line_break() {
-                count = 0;
-                break;
-            }
-        }
-
-        let ends_in_accessor = count > 0
-            && (self.is_token(SyntaxKind::GetKeyword) || self.is_token(SyntaxKind::SetKeyword))
-            && !self.look_ahead_is_property_name_after_keyword();
-
-        self.scanner.restore_state(snapshot);
-        self.current_token = current;
-
-        if ends_in_accessor { count } else { 0 }
     }
 
     /// Check if there is a line break between the current keyword and the next token.

--- a/crates/tsz-parser/tests/type_member_hard_modifier_accessor_cascade_tests.rs
+++ b/crates/tsz-parser/tests/type_member_hard_modifier_accessor_cascade_tests.rs
@@ -1,0 +1,446 @@
+//! A "hard" type-member modifier (`async`/`declare`/`abstract`/`override`)
+//! directly before a `get`/`set` accessor in an interface or type literal.
+//!
+//! Unlike the "clean" modifiers (`private`/`protected`/`public`/`static`/
+//! `accessor`/`export`/`readonly`), which `tsc` rejects with a single TS1131
+//! per modifier and then recovers as a bare accessor, a run containing a hard
+//! modifier does not parse as any member at all in `typescript@7.0.2`. After
+//! one TS1131 per modifier in the run, `tsc` abandons the type-member body and
+//! re-parses the accessor's own tail as top-level statements — a cascade of
+//! TS1434 (`Unexpected keyword or identifier.`) at the accessor keyword,
+//! TS1005 (`';'`/`','` expected) at the tail's next unexpected `:`/`,`, and
+//! TS1128 (`Declaration or statement expected.`) at the container's closing
+//! `}`. tsz previously reported the uniform semantic TS1070 for these; this
+//! suite pins the cascade parity.
+//!
+//! `in`/`out` are intentionally NOT covered: `in` is a reserved operator whose
+//! statement re-parse differs, and both carry variance-position idiosyncrasies
+//! — they keep the pre-existing semantic TS1070 (asserted in
+//! `type_member_modifier_grammar_tests.rs`).
+
+use crate::parser::test_fixture::parse_source;
+use tsz_common::diagnostics::diagnostic_codes;
+use tsz_common::position::LineMap;
+
+fn fingerprints(source: &str) -> Vec<(u32, u32, u32, String)> {
+    let (parser, _root) = parse_source(source);
+    let line_map = LineMap::build(source);
+    parser
+        .get_diagnostics()
+        .iter()
+        .map(|diag| {
+            let pos = line_map.offset_to_position(diag.start, source);
+            (
+                diag.code,
+                pos.line + 1,
+                pos.character + 1,
+                diag.message.clone(),
+            )
+        })
+        .collect()
+}
+
+fn codes(source: &str) -> Vec<u32> {
+    let (parser, _root) = parse_source(source);
+    parser.get_diagnostics().iter().map(|d| d.code).collect()
+}
+
+const TS1131: u32 = diagnostic_codes::PROPERTY_OR_SIGNATURE_EXPECTED;
+const TS1434: u32 = diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER;
+const TS1005: u32 = diagnostic_codes::EXPECTED;
+const TS1128: u32 = diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED;
+
+// ---------------------------------------------------------------------------
+// Single hard modifier before a get accessor in an interface.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn async_before_get_accessor_cascades() {
+    // Oracle (typescript@7.0.2):
+    //   (1,15) TS1131 async | (1,21) TS1434 get | (1,28) TS1005 ';' | (1,38) TS1128 }
+    assert_eq!(
+        fingerprints("interface I { async get x(): number; }"),
+        vec![
+            (TS1131, 1, 15, "Property or signature expected.".to_string()),
+            (
+                TS1434,
+                1,
+                21,
+                "Unexpected keyword or identifier.".to_string()
+            ),
+            (TS1005, 1, 28, "';' expected.".to_string()),
+            (
+                TS1128,
+                1,
+                38,
+                "Declaration or statement expected.".to_string()
+            ),
+        ],
+    );
+}
+
+#[test]
+fn async_before_set_accessor_cascades_with_comma_expected() {
+    // A setter's `(v: number)` param list makes the tail's next unexpected
+    // token the `:` inside the parens → TS1005 `','` expected (not `';'`).
+    assert_eq!(
+        fingerprints("interface I { async set x(v: number); }"),
+        vec![
+            (TS1131, 1, 15, "Property or signature expected.".to_string()),
+            (
+                TS1434,
+                1,
+                21,
+                "Unexpected keyword or identifier.".to_string()
+            ),
+            (TS1005, 1, 28, "',' expected.".to_string()),
+            (
+                TS1128,
+                1,
+                39,
+                "Declaration or statement expected.".to_string()
+            ),
+        ],
+    );
+}
+
+#[test]
+fn declare_before_get_accessor_cascades() {
+    assert_eq!(
+        fingerprints("interface I { declare get x(): number; }"),
+        vec![
+            (TS1131, 1, 15, "Property or signature expected.".to_string()),
+            (
+                TS1434,
+                1,
+                23,
+                "Unexpected keyword or identifier.".to_string()
+            ),
+            (TS1005, 1, 30, "';' expected.".to_string()),
+            (
+                TS1128,
+                1,
+                40,
+                "Declaration or statement expected.".to_string()
+            ),
+        ],
+    );
+}
+
+#[test]
+fn abstract_before_get_accessor_cascades() {
+    assert_eq!(
+        fingerprints("interface I { abstract get x(): number; }"),
+        vec![
+            (TS1131, 1, 15, "Property or signature expected.".to_string()),
+            (
+                TS1434,
+                1,
+                24,
+                "Unexpected keyword or identifier.".to_string()
+            ),
+            (TS1005, 1, 31, "';' expected.".to_string()),
+            (
+                TS1128,
+                1,
+                41,
+                "Declaration or statement expected.".to_string()
+            ),
+        ],
+    );
+}
+
+#[test]
+fn override_before_get_accessor_cascades() {
+    assert_eq!(
+        fingerprints("interface I { override get x(): number; }"),
+        vec![
+            (TS1131, 1, 15, "Property or signature expected.".to_string()),
+            (
+                TS1434,
+                1,
+                24,
+                "Unexpected keyword or identifier.".to_string()
+            ),
+            (TS1005, 1, 31, "';' expected.".to_string()),
+            (
+                TS1128,
+                1,
+                41,
+                "Declaration or statement expected.".to_string()
+            ),
+        ],
+    );
+}
+
+#[test]
+fn async_before_get_accessor_no_return_type_cascades() {
+    // Oracle: (1,15) TS1131 | (1,21) TS1434 | (1,29) TS1128 } — no TS1005 when
+    // there is no `: number` tail before the brace.
+    assert_eq!(
+        fingerprints("interface I { async get x() }"),
+        vec![
+            (TS1131, 1, 15, "Property or signature expected.".to_string()),
+            (
+                TS1434,
+                1,
+                21,
+                "Unexpected keyword or identifier.".to_string()
+            ),
+            (
+                TS1128,
+                1,
+                29,
+                "Declaration or statement expected.".to_string()
+            ),
+        ],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Type literals: same cascade.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn async_before_get_accessor_on_type_literal_cascades() {
+    assert_eq!(
+        fingerprints("type T = { async get x(): number; };"),
+        vec![
+            (TS1131, 1, 12, "Property or signature expected.".to_string()),
+            (
+                TS1434,
+                1,
+                18,
+                "Unexpected keyword or identifier.".to_string()
+            ),
+            (TS1005, 1, 25, "';' expected.".to_string()),
+            (
+                TS1128,
+                1,
+                35,
+                "Declaration or statement expected.".to_string()
+            ),
+        ],
+    );
+}
+
+#[test]
+fn declare_before_set_accessor_on_type_literal_cascades() {
+    assert_eq!(
+        fingerprints("type T = { declare set x(v: number); };"),
+        vec![
+            (TS1131, 1, 12, "Property or signature expected.".to_string()),
+            (
+                TS1434,
+                1,
+                20,
+                "Unexpected keyword or identifier.".to_string()
+            ),
+            (TS1005, 1, 27, "',' expected.".to_string()),
+            (
+                TS1128,
+                1,
+                38,
+                "Declaration or statement expected.".to_string()
+            ),
+        ],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Stacked runs: a clean modifier leading a hard one still cascades, with one
+// TS1131 per modifier before the tail re-parse.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn clean_then_hard_modifier_before_accessor_reports_ts1131_per_modifier() {
+    // `static declare get x()` — TS1131 at both `static` and `declare`, then
+    // the cascade tail. Oracle: (1,15) (1,22) TS1131 | (1,30) TS1434 |
+    // (1,37) TS1005 | (1,47) TS1128.
+    assert_eq!(
+        fingerprints("interface I { static declare get x(): number; }"),
+        vec![
+            (TS1131, 1, 15, "Property or signature expected.".to_string()),
+            (TS1131, 1, 22, "Property or signature expected.".to_string()),
+            (
+                TS1434,
+                1,
+                30,
+                "Unexpected keyword or identifier.".to_string()
+            ),
+            (TS1005, 1, 37, "';' expected.".to_string()),
+            (
+                TS1128,
+                1,
+                47,
+                "Declaration or statement expected.".to_string()
+            ),
+        ],
+    );
+}
+
+#[test]
+fn public_then_abstract_before_accessor_cascades() {
+    assert_eq!(
+        fingerprints("interface I { public abstract get x(): number; }"),
+        vec![
+            (TS1131, 1, 15, "Property or signature expected.".to_string()),
+            (TS1131, 1, 22, "Property or signature expected.".to_string()),
+            (
+                TS1434,
+                1,
+                31,
+                "Unexpected keyword or identifier.".to_string()
+            ),
+            (TS1005, 1, 38, "';' expected.".to_string()),
+            (
+                TS1128,
+                1,
+                48,
+                "Declaration or statement expected.".to_string()
+            ),
+        ],
+    );
+}
+
+#[test]
+fn readonly_then_async_before_accessor_cascades() {
+    assert_eq!(
+        fingerprints("interface I { readonly async get x(): number; }"),
+        vec![
+            (TS1131, 1, 15, "Property or signature expected.".to_string()),
+            (TS1131, 1, 24, "Property or signature expected.".to_string()),
+            (
+                TS1434,
+                1,
+                30,
+                "Unexpected keyword or identifier.".to_string()
+            ),
+            (TS1005, 1, 37, "';' expected.".to_string()),
+            (
+                TS1128,
+                1,
+                47,
+                "Declaration or statement expected.".to_string()
+            ),
+        ],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Multi-line / ASI: once the body is abandoned, every following member is also
+// re-parsed as statements.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn async_accessor_multiline_reparses_the_whole_tail() {
+    // Oracle: (2,3) TS1131 | (2,9) TS1434 | (2,20) TS1005 ';' | (3,3) TS1434 |
+    // (3,9) TS1434 | (3,20) TS1005 ',' | (4,1) TS1128.
+    let source = "interface Widget {\n  async get value(): string\n  async set value(v: string)\n}";
+    assert_eq!(
+        fingerprints(source),
+        vec![
+            (TS1131, 2, 3, "Property or signature expected.".to_string()),
+            (
+                TS1434,
+                2,
+                9,
+                "Unexpected keyword or identifier.".to_string()
+            ),
+            (TS1005, 2, 20, "';' expected.".to_string()),
+            (
+                TS1434,
+                3,
+                3,
+                "Unexpected keyword or identifier.".to_string()
+            ),
+            (
+                TS1434,
+                3,
+                9,
+                "Unexpected keyword or identifier.".to_string()
+            ),
+            (TS1005, 3, 20, "',' expected.".to_string()),
+            (
+                TS1128,
+                4,
+                1,
+                "Declaration or statement expected.".to_string()
+            ),
+        ],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Structural, not keyed to any binder spelling.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn hard_modifier_accessor_cascade_is_not_keyed_to_a_binder_name() {
+    // Renamed container and accessor; the cascade's leading TS1131 is fixed.
+    assert_eq!(
+        codes("interface Alpha { abstract get beta(): number; }"),
+        vec![TS1131, TS1434, TS1005, TS1128],
+    );
+    assert_eq!(
+        codes("type Gamma = { declare get delta(): number; };"),
+        vec![TS1131, TS1434, TS1005, TS1128],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls: the fix must not fire where a hard modifier is NOT
+// immediately before an accessor keyword.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn hard_modifier_on_method_or_property_stays_ts1070() {
+    // A hard modifier before a plain method/property is the pre-existing
+    // semantic TS1070, untouched by the accessor cascade.
+    const TS1070: u32 = diagnostic_codes::MODIFIER_CANNOT_APPEAR_ON_A_TYPE_MEMBER;
+    for modifier in ["async", "declare", "abstract", "override"] {
+        assert_eq!(
+            codes(&format!("interface I {{ {modifier} m(): void; }}")),
+            vec![TS1070],
+            "method: {modifier}",
+        );
+        assert_eq!(
+            codes(&format!("interface I {{ {modifier} p: number; }}")),
+            vec![TS1070],
+            "property: {modifier}",
+        );
+    }
+}
+
+#[test]
+fn hard_modifier_named_get_method_stays_ts1070() {
+    // `async get(): number` — `get` immediately followed by `(` is a method
+    // *named* `get`, not an accessor. The cascade lookahead must not fire; the
+    // pre-existing semantic TS1070 stands.
+    const TS1070: u32 = diagnostic_codes::MODIFIER_CANNOT_APPEAR_ON_A_TYPE_MEMBER;
+    assert_eq!(codes("interface I { async get(): number; }"), vec![TS1070]);
+    assert_eq!(codes("interface I { declare get: number; }"), vec![TS1070]);
+}
+
+#[test]
+fn hard_modifier_as_a_property_name_stays_clean() {
+    // `async`/`declare` used as the member's own name (`async: number`) are
+    // ordinary properties — no cascade, no diagnostic.
+    assert!(codes("interface I { async: number; }").is_empty());
+    assert!(codes("interface I { declare: number; }").is_empty());
+}
+
+#[test]
+fn line_break_between_hard_modifier_and_accessor_does_not_cascade() {
+    // A line break between the modifier and `get`/`set` takes tsc down a
+    // different (out-of-scope) ASI path; the same-line-only lookahead must not
+    // fire, so the two sources differ.
+    let with_break = "interface I {\n  async\n  get x(): number\n}";
+    let without_break = "interface I {\n  async get x(): number\n}";
+    assert_ne!(codes(with_break), codes(without_break));
+}
+
+#[test]
+fn plain_accessor_without_modifier_stays_clean() {
+    assert!(codes("interface I { get x(): number; set x(v: number); }").is_empty());
+}

--- a/crates/tsz-parser/tests/type_member_modifier_grammar_tests.rs
+++ b/crates/tsz-parser/tests/type_member_modifier_grammar_tests.rs
@@ -53,15 +53,15 @@
 //! matching tsc. `import` / `const` / `default` are not type-member modifiers in
 //! tsc (they take a parser-recovery path) and are intentionally not covered.
 //!
-//! Left as follow-up (a separate, larger defect, not fixed here): `declare`/
-//! `abstract`/`override`/`in`/`out` before an interface/type-literal accessor
-//! also fail to parse in tsc, but the recovery is a different shape entirely —
-//! it cascades into TS1434/TS1005/TS1128 (the retry re-parses the accessor's
-//! own name as a fresh top-level statement) rather than a single TS1131 per
-//! modifier. tsz still reports the uniform semantic TS1070 for those; they are
-//! deliberately excluded from the qualifying modifier set (see
-//! `look_ahead_modifier_run_before_accessor`), a pre-existing, unrelated code
-//! path this change does not touch.
+//! The "hard" cascade modifiers `async`/`declare`/`abstract`/`override` before
+//! an interface/type-literal accessor also fail to parse in tsc, but with a
+//! different recovery shape — one TS1131 per modifier, then the accessor's own
+//! tail re-parses as top-level statements (TS1434/TS1005/TS1128) rather than a
+//! bare-accessor recovery. That family is now handled and lives, with full
+//! fingerprint parity, in `type_member_hard_modifier_accessor_cascade_tests`
+//! (see `look_ahead_hard_modifier_run_before_accessor`). `in`/`out` remain on
+//! the pre-existing semantic TS1070 path: `in` is a reserved operator whose
+//! statement re-parse differs, and both carry variance-position idiosyncrasies.
 
 use crate::parser::test_fixture::parse_source;
 use tsz_common::diagnostics::diagnostic_codes;
@@ -605,21 +605,38 @@ fn clean_modifier_run_is_not_keyed_to_a_binder_name() {
 }
 
 // ---------------------------------------------------------------------------
-// Cascade-shaped modifiers stay OUT of scope: `declare`/`abstract`/`override`/
-// `in`/`out` before an accessor keep reporting the pre-existing semantic
-// TS1070, not the new TS1131 path (see the module doc comment).
+// Hard-cascade modifiers (`async`/`declare`/`abstract`/`override`) before an
+// accessor now derail into tsc's abandon-body statement re-parse cascade,
+// covered in full by `type_member_hard_modifier_accessor_cascade_tests`. Only
+// `in`/`out` remain on the pre-existing semantic TS1070 path (see the module
+// doc comment); guarded here so they are not accidentally swept into the hard
+// set.
 // ---------------------------------------------------------------------------
 
 #[test]
-fn cascade_modifiers_before_accessor_still_report_ts1070_not_ts1131() {
+fn hard_cascade_modifiers_before_accessor_now_cascade_not_ts1070() {
+    // `declare`/`abstract`/`override` are hard modifiers: one TS1131, then the
+    // accessor tail re-parses as statements — TS1434 (unexpected keyword),
+    // TS1005 (`;` expected), TS1128 (declaration or statement expected). Full
+    // fingerprint parity lives in the sibling cascade suite.
+    const TS1434: u32 = diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER;
+    const TS1005: u32 = diagnostic_codes::EXPECTED;
+    const TS1128: u32 = diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED;
     for modifier in ["declare", "abstract", "override"] {
         let source = format!("interface I {{ {modifier} get x(): number; }}");
-        assert_eq!(codes(&source), vec![TS1070], "modifier `{modifier}`");
+        assert_eq!(
+            codes(&source),
+            vec![TS1131, TS1434, TS1005, TS1128],
+            "modifier `{modifier}`",
+        );
     }
 }
 
 #[test]
 fn in_out_before_accessor_on_generic_interface_still_report_ts1070() {
+    // `in` is a reserved operator (different statement re-parse) and both
+    // `in`/`out` carry variance-position idiosyncrasies, so they are excluded
+    // from the hard set and keep the pre-existing semantic TS1070.
     for modifier in ["in", "out"] {
         let source = format!("interface I<T> {{ {modifier} get x(): number; }}");
         assert_eq!(codes(&source), vec![TS1070], "modifier `{modifier}`");
@@ -627,17 +644,17 @@ fn in_out_before_accessor_on_generic_interface_still_report_ts1070() {
 }
 
 #[test]
-fn cascade_modifier_poisons_a_run_with_a_leading_clean_modifier() {
-    // `declare` anywhere in the run keeps the WHOLE run out of the TS1131
-    // path, even when a clean modifier (`static`) leads it — matches tsc,
-    // where the clean modifier still fails to recover once `declare` follows
-    // (tsc itself reports a 5-diagnostic TS1131/TS1128/TS1434/TS1005/TS1128
-    // cascade for this exact shape). tsz's existing (unrelated, pre-existing)
-    // multi-modifier TS1070 handling consumes the whole illegal-modifier run
-    // and reports once, which this change does not touch or improve.
+fn hard_modifier_poisons_a_run_with_a_leading_clean_modifier() {
+    // A hard modifier anywhere in the run keeps the WHOLE run off the
+    // clean-only bare-accessor recovery, even when a clean modifier (`static`)
+    // leads it — matching tsc, which reports one TS1131 per modifier
+    // (`static` and `declare`) then re-parses the accessor tail as statements.
+    const TS1434: u32 = diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER;
+    const TS1005: u32 = diagnostic_codes::EXPECTED;
+    const TS1128: u32 = diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED;
     assert_eq!(
         codes("interface I { static declare get x(): number; }"),
-        vec![TS1070],
+        vec![TS1131, TS1131, TS1434, TS1005, TS1128],
     );
 }
 


### PR DESCRIPTION
Closes the accessor-cascade follow-up documented in `type_member_modifier_grammar_tests.rs` (module doc) and tracked under #16291.

When a run of interface/type-literal member modifiers before a `get`/`set` accessor contains a **hard** modifier (`async`/`declare`/`abstract`/`override`), `tsc` does not recover a bare accessor the way it does for the **clean** set (`private`/`protected`/`public`/`static`/`accessor`/`export`/`readonly`, one TS1131 per modifier then a recovered accessor). Instead it reports one TS1131 per modifier, then abandons the type-member body and re-parses the accessor's own tail as top-level statements. tsz previously reported a single semantic **TS1070** for these.

**Structural rule:** when a modifier run before a type-member accessor contains a hard modifier, `tsc` reports one **TS1131** per modifier (each at its own token), then re-parses the accessor tail as statements — **TS1434** at the accessor keyword, **TS1005** at the tail's next unexpected `:`/`,`, **TS1128** at the container's closing `}`. tsz now reproduces this through the parser's existing `deferred_type_member_close_braces` mechanism (the same "abort body, defer close brace, re-parse tail as statements" path `recover_invalid_type_member` uses); tsz's statement recovery already emits `tsc`'s TS1434/TS1005/TS1128 at identical columns. A `type X = <literal>` alias additionally skips its trailing semicolon when its literal abandoned its body, matching `tsc` (no spurious TS1005).

`in`/`out` deliberately stay on the pre-existing TS1070 path — `in` is a reserved operator whose statement re-parse differs, and both carry variance-position idiosyncrasies (a separate, narrower follow-up).

Owner layer: parser only. No checker/solver/emitter changes.

Adjacent matrix (oracle-verified against `typescript@7.0.2`): `get`/`set`, interface/type-literal, single (`async get`), stacked with a clean prefix (`static declare get`, `public abstract get`, `readonly async get`), no-return-type (`async get x()`), multi-line/ASI (a whole abandoned body re-parses), renamed binders, and negative controls (hard modifier on a plain method/property stays TS1070; `async get()` method-named-`get` stays TS1070; `async: number` property name stays clean; a line break between modifier and accessor does not fire).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-parser` — **2156 passed / 0 failed** (incl. new `type_member_hard_modifier_accessor_cascade_tests`, 18 cases, and the two flipped assertions in `type_member_modifier_grammar_tests`).
- `cargo clippy -p tsz-parser --all-targets -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py` — passed (helpers moved to `state_declarations_type_member_modifiers.rs` to keep `state_types_advanced.rs` under the 2000-LOC cap).
- **Conformance parity** — `scripts/conformance/compare-to-parent.sh` vs `main`: base failing=507, branch failing=507, **NEWLY FAILING (0)**, NEWLY PASSING (0), fingerprint changed (0). 95.8% both. Zero Hold-floor impact (this construct has no corpus coverage, mirroring #16803's sibling readonly-accessor fix).
- CI Summary (clippy + arch-size) — green on exact head.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high