### PR TITLE
fix(solver): TS2403 respects private/protected brand identity, not just structural shape

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1938,6 +1938,9 @@ path = "tests/optional_undefined_property_index_signature_tests.rs"
 name = "ts2403_enum_object_redeclaration_tests"
 path = "tests/ts2403_enum_object_redeclaration_tests.rs"
 [[test]]
+name = "ts2403_private_brand_redeclaration_tests"
+path = "tests/ts2403_private_brand_redeclaration_tests.rs"
+[[test]]
 name = "ts1262_multiple_await_declarations_tests"
 path = "tests/ts1262_multiple_await_declarations_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/ts2403_private_brand_redeclaration_tests.rs
+++ b/crates/tsz-checker/tests/ts2403_private_brand_redeclaration_tests.rs
@@ -1,0 +1,128 @@
+//! Regression coverage: TS2403 ("Subsequent variable declarations must have
+//! the same type") must respect TypeScript's nominal private/protected brand
+//! rule, not just plain structural identity.
+//!
+//! `are_types_identical_for_redeclaration` (`crates/tsz-solver/src/relations/
+//! compat_overrides.rs`) previously delegated straight to the raw structural
+//! (Judge) bidirectional-subtype relation, which knows nothing about private
+//! member branding — that rule lives in `private_brand_assignability_override`,
+//! otherwise reached only through the ordinary assignability ("Lawyer") path.
+//! Two classes each declaring their own `private` member of the same name are
+//! bidirectional structural subtypes of one another (private members are
+//! erased from the raw structural comparison) yet tsc's `isTypeIdenticalTo`
+//! still treats them as distinct declaration surfaces, exactly like ordinary
+//! assignability does. Without the fix, `var x: A.Foo; var x: B.Foo;` for two
+//! unrelated `Foo` declarations that each carry a private member silently
+//! dropped TS2403.
+//!
+//! All expected diagnostics oracle-verified against pinned `typescript@7.0.2`.
+//!
+//! Note: the conformance fixture `compiler/propertyIdentityWithPrivacyMismatch.ts`
+//! has a second, SAME-simple-name redeclaration (`var x: m1.Foo; var x: m2.Foo;`)
+//! that this fix does not resolve — `are_types_identical_for_redeclaration` itself
+//! correctly returns "not identical" for that pair (verified directly), but no
+//! diagnostic is emitted. That is a distinct bug downstream in the checker's
+//! emission path, not the private-brand identity gap fixed here. See #16888.
+
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn ts2403_count(source: &str) -> usize {
+    check_source_diagnostics(source)
+        .iter()
+        .filter(|d| d.code == 2403)
+        .count()
+}
+
+#[test]
+fn cross_namespace_private_brand_mismatch_renamed_binders_emits_ts2403() {
+    // Renamed-binder variant of the above: differently-named classes that are
+    // otherwise structurally identical still conflict, because the private
+    // member brand — not the class name — drives identity here.
+    let source = r#"
+namespace A { export class Foo { private m: number = 0; } }
+namespace B { export class Bar { private m: number = 0; } }
+var x: A.Foo;
+var x: B.Bar;
+"#;
+    assert_eq!(
+        ts2403_count(source),
+        1,
+        "Expected TS2403: private brand mismatch must fire regardless of the \
+         declaring classes' names"
+    );
+}
+
+#[test]
+fn same_class_via_type_alias_is_not_a_brand_mismatch() {
+    // Negative: an alias to the SAME declaration must not trip the new
+    // private-brand check — only genuinely distinct declarations conflict.
+    let source = r#"
+namespace A { export class Foo { private n: number = 0; } }
+type FooAlias = A.Foo;
+var x: A.Foo;
+var x: FooAlias;
+"#;
+    assert_eq!(
+        ts2403_count(source),
+        0,
+        "Expected no TS2403: FooAlias resolves to the identical A.Foo declaration"
+    );
+}
+
+#[test]
+fn protected_member_hierarchy_widening_is_not_a_brand_mismatch() {
+    // Negative: `protected` is hierarchical, not exact-declaration nominal —
+    // a subclass that inherits (does not redeclare) the protected member
+    // stays redeclaration-identical to its base, matching
+    // `private_brand_assignability_override`'s existing protected handling.
+    let source = r#"
+class Base { protected m: number = 0; }
+class Derived extends Base {}
+var x: Base;
+var x: Derived;
+"#;
+    assert_eq!(
+        ts2403_count(source),
+        0,
+        "Expected no TS2403: Derived inherits (does not redeclare) Base's \
+         protected member, so the hierarchical protected rule allows it"
+    );
+}
+
+#[test]
+fn same_declaration_reused_with_private_member_is_not_a_brand_mismatch() {
+    // Negative: redeclaring against the SAME class declaration twice must
+    // stay clean even when it carries a private member — the fast
+    // physical-identity path (`a == b`) already covers this, this test
+    // guards against the new check regressing it.
+    let source = r#"
+class A { private n: number = 0; }
+var x: A;
+var x: A;
+"#;
+    assert_eq!(
+        ts2403_count(source),
+        0,
+        "Expected no TS2403: both declarations reference the same class A"
+    );
+}
+
+#[test]
+fn structurally_identical_public_classes_without_private_members_unaffected() {
+    // Negative control: without any private/protected members, two
+    // differently-named but structurally identical classes remain
+    // redeclaration-identical (purely structural comparison, unaffected by
+    // the new private-brand check).
+    let source = r#"
+namespace A { export class Foo { m: number = 0; } }
+namespace B { export class Bar { m: number = 0; } }
+var x: A.Foo;
+var x: B.Bar;
+"#;
+    assert_eq!(
+        ts2403_count(source),
+        0,
+        "Expected no TS2403: neither class has a private/protected member, so \
+         plain structural identity applies"
+    );
+}

--- a/crates/tsz-solver/src/relations/compat_overrides.rs
+++ b/crates/tsz-solver/src/relations/compat_overrides.rs
@@ -762,6 +762,25 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
             return res;
         }
 
+        // 4b. Private/protected brand identity check.
+        //
+        // `are_types_identical_for_redeclaration` delegates to `self.subtype.is_subtype_of`
+        // below, which is the raw structural (Judge) relation and knows nothing about
+        // TypeScript's nominal private/protected member rule — that rule lives in
+        // `private_brand_assignability_override` (the Lawyer/`CompatChecker` layer) and is
+        // otherwise only reached via `is_assignable_with_overrides`. Two classes with a
+        // private member of the same name are structurally identical (bidirectional
+        // subtypes) yet tsc's `isTypeIdenticalTo` still rejects them as different
+        // declaration surfaces, exactly like `isTypeAssignableTo` does. Without this check,
+        // `declare module 'a' { class Foo { private n; } }` and an unrelated `declare
+        // module 'b' { class Foo { private n; } }` are wrongly treated as the same type,
+        // silently dropping TS2403 for `var x: a.Foo; var x: b.Foo;`.
+        if self.private_brand_assignability_override(a, b) == Some(false)
+            || self.private_brand_assignability_override(b, a) == Some(false)
+        {
+            return false;
+        }
+
         if let Some(result) = self.array_redeclaration_identity(a, b) {
             return result;
         }


### PR DESCRIPTION
When tsc reports TS2403 ("Subsequent variable declarations must have the same type"), it uses `isTypeIdenticalTo`, which applies TypeScript's nominal private/protected member rule — the same rule ordinary assignability uses. `are_types_identical_for_redeclaration` (`crates/tsz-solver/src/relations/compat_overrides.rs`) instead delegated straight to the raw structural (Judge) bidirectional-subtype relation, which knows nothing about private branding — that rule lives in `private_brand_assignability_override` (the Lawyer/`CompatChecker` layer) and was otherwise only reached through the ordinary assignability path (`is_assignable_with_overrides`).

Two classes each declaring their own `private` member of the same name are bidirectional structural subtypes of one another (private members are erased from the raw structural comparison), yet tsc's `isTypeIdenticalTo` still rejects them as distinct declaration surfaces. Without this fix, `var x: A.Foo; var x: B.Foo;` for two unrelated `Foo`-shaped classes that each carry a private member silently dropped TS2403.

**Structural rule:** when two `var` redeclarations' types each carry a private or protected member, tsc's TS2403 identity check applies the same nominal brand rule as assignability; tsz's redeclaration identity now does the same by calling `private_brand_assignability_override` in both directions before falling through to bidirectional structural comparison.

### Adjacent-case matrix (all oracle-verified against pinned `typescript@7.0.2`)

| case | tsc | tsz (after) |
| --- | --- | --- |
| renamed classes, both with an unrelated private member (`A.Foo`/`B.Bar`) | TS2403 | TS2403 |
| same declaration reused via a type alias | no error | no error |
| protected member hierarchy widening (`Derived extends Base {}`) | no error | no error |
| same declaration referenced twice, carries a private member | no error | no error |
| structurally identical public classes, no private/protected members | no error | no error (unaffected — purely structural path) |

### Found while draining, scope note

Found while draining #16866's TS2403 cluster — specifically the conformance fixture `compiler/propertyIdentityWithPrivacyMismatch.ts`, which has two redeclaration pairs: `y: Foo1 | Foo2` (renamed classes, private-brand mismatch — the shape this PR fixes) and `x: m1.Foo | m2.Foo` (both sides render as the plain simple name `'Foo'`). The `x` shape is a **separate, deeper bug**: verified directly that the solver's `are_types_identical_for_redeclaration` already returns the correct "not identical" for that pair (traced with temporary instrumentation, removed before landing) — the defect is downstream, in the checker's TS2403 diagnostic-emission path, not in this relation. Filed as #16888 with the full investigation and a hypothesis (a display-name-keyed suppression somewhere in the emission path, which if confirmed would itself be an Anti-Hardcoding Gate violation worth its own fix).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts2403_private_brand_redeclaration_tests`: 5/5 (new file, adjacent-case matrix above)
- `cargo test -p tsz-checker --test ts2403_enum_object_redeclaration_tests`: 7/7 (no regression)
- `cargo test -p tsz-checker --test ts2403_js_cross_file_tests`: 2/2 (no regression)
- `cargo test -p tsz-checker --lib -- ts2403 redeclaration enum private_brand`: 462/462
- `cargo test -p tsz-solver --lib -- redeclaration private_brand`: 22/22 (existing private-brand/redeclaration coverage, no regression)
- `cargo clippy -p tsz-solver -p tsz-checker --lib --tests -- -D warnings`: clean
- `cargo fmt`: clean
- Full `compare-to-parent.sh`/`conformance.sh snapshot` not run this session (time budget) — this is a message-related-information-free, purely additive nominal check gated on the pre-existing `private_brand_assignability_override` (already used elsewhere for assignability with no known false positives), and the risk surface is covered by the targeted matrix above plus the 22 pre-existing solver private-brand/redeclaration tests, all still green. Owed as a follow-up if anyone wants the corpus-wide confirmation.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoQgDQfZJGKj5ghmVJMfKr)_