### PR TITLE
fix(checker): braceless @satisfies tag reports one TS1005, not two

### DIFF
--- a/crates/tsz-checker/src/jsdoc/diagnostics.rs
+++ b/crates/tsz-checker/src/jsdoc/diagnostics.rs
@@ -1032,19 +1032,13 @@ impl<'a> CheckerState<'a> {
                 diagnostic_codes::CANNOT_FIND_NAME,
             );
         }
-        for (open_pos, close_pos) in
+        for open_pos in
             Self::malformed_jsdoc_satisfies_positions(source_text, comment_pos, comment_end)
         {
             self.ctx.error(
                 open_pos,
                 0,
                 format_message(diagnostic_messages::EXPECTED, &["{"]),
-                diagnostic_codes::EXPECTED,
-            );
-            self.ctx.error(
-                close_pos,
-                0,
-                format_message(diagnostic_messages::EXPECTED, &["}"]),
                 diagnostic_codes::EXPECTED,
             );
         }
@@ -1256,11 +1250,15 @@ impl<'a> CheckerState<'a> {
         results
     }
 
+    /// Byte positions where a `@satisfies` tag is missing its required `{TypeExpression}`
+    /// braces entirely (no `{` follows the tag at all). `tsc`'s JSDoc tag parser never enters
+    /// brace-parsing mode in this shape, so it reports a single `'{' expected` per occurrence —
+    /// there is no opened brace to pair with a `'}' expected` companion.
     fn malformed_jsdoc_satisfies_positions(
         source_text: &str,
         comment_pos: u32,
         comment_end: u32,
-    ) -> Vec<(u32, u32)> {
+    ) -> Vec<u32> {
         let raw = &source_text[comment_pos as usize..comment_end as usize];
         let mut result = Vec::new();
         for tag_start in Self::jsdoc_tag_offsets(raw, "satisfies") {
@@ -1269,8 +1267,7 @@ impl<'a> CheckerState<'a> {
             let skipped = raw[after_tag..].len() - ws_trimmed.len();
             if !ws_trimmed.starts_with('{') {
                 let open_pos = comment_pos + (after_tag + skipped) as u32;
-                let close_pos = comment_end.saturating_sub(2);
-                result.push((open_pos, close_pos));
+                result.push(open_pos);
             }
         }
         result

--- a/crates/tsz-checker/tests/jsdoc_satisfies_tests.rs
+++ b/crates/tsz-checker/tests/jsdoc_satisfies_tests.rs
@@ -6,6 +6,70 @@
 
 use crate::test_utils::{check_js_source_diagnostics, diagnostic_codes};
 
+/// A `@satisfies` tag with no `{TypeExpression}` braces at all never enters
+/// brace-parsing mode, so `tsc` reports a single `'{' expected` (TS1005) per
+/// occurrence — there is no opened brace to pair with a `'}' expected`
+/// companion. Regression test for a prior double-report bug where tsz also
+/// emitted a spurious `'}' expected` anchored at the comment's closing `*/`.
+#[test]
+fn malformed_satisfies_missing_braces_reports_single_open_brace_expected() {
+    let source = r#"
+/**
+ * @satisfies T1
+ */
+const t1 = { a: 1 };
+"#;
+    let diagnostics = check_js_source_diagnostics(source);
+    let codes = diagnostic_codes(&diagnostics);
+    let ts1005_count = codes.iter().filter(|code| **code == 1005).count();
+    assert_eq!(
+        ts1005_count, 1,
+        "Expected exactly one TS1005 ('{{' expected) for a braceless @satisfies tag, got: {codes:?}",
+    );
+}
+
+/// Two malformed `@satisfies` tags in the same comment each get their own
+/// single `'{' expected`, not a paired `'}' expected` for either.
+#[test]
+fn malformed_satisfies_missing_braces_reports_one_per_occurrence() {
+    let source = r#"
+/**
+ * @satisfies Foo
+ * @satisfies Bar
+ */
+const t1 = { a: 1 };
+"#;
+    let diagnostics = check_js_source_diagnostics(source);
+    let codes = diagnostic_codes(&diagnostics);
+    let ts1005_count = codes.iter().filter(|code| **code == 1005).count();
+    assert_eq!(
+        ts1005_count, 2,
+        "Expected one TS1005 per malformed @satisfies occurrence, got: {codes:?}",
+    );
+}
+
+/// Control: a well-formed `@satisfies {T1}` tag stays clean (no TS1005),
+/// confirming the fix only touches the missing-brace path.
+#[test]
+fn well_formed_satisfies_braces_reports_no_ts1005() {
+    let source = r#"
+/**
+ * @typedef {Object} T1
+ * @property {number} a
+ */
+/**
+ * @satisfies {T1}
+ */
+const t1 = { a: 1 };
+"#;
+    let diagnostics = check_js_source_diagnostics(source);
+    let codes = diagnostic_codes(&diagnostics);
+    assert!(
+        !codes.contains(&1005),
+        "Expected well-formed @satisfies {{T1}} to report no TS1005, got: {codes:?}",
+    );
+}
+
 #[test]
 fn invalid_satisfies_prefix_is_not_a_jsdoc_satisfies_tag() {
     let source = r#"


### PR DESCRIPTION
When a `@satisfies` JSDoc tag has no `{TypeExpression}` braces at all, `tsc`'s JSDoc tag parser never enters brace-parsing mode, so it reports a single `'{' expected` (TS1005) per occurrence. tsz's `emit_malformed_jsdoc_satisfies_diagnostics` (`crates/tsz-checker/src/jsdoc/diagnostics.rs`) unconditionally paired that with a synthetic `'}' expected`, anchored at the comment's closing `*/`, even though there was never an opened brace to close — `malformed_jsdoc_satisfies_positions` only ever fires in the *no-brace-at-all* branch, so the "close" position it manufactured was always bogus.

**Structural rule:** when a `@satisfies` tag's type expression is missing its opening `{` entirely, `tsc` reports exactly one TS1005 (`'{' expected`) per occurrence; tsz now does the same through `emit_malformed_jsdoc_satisfies_diagnostics` in the checker's JSDoc diagnostics module, by dropping the synthetic close-brace error and having `malformed_jsdoc_satisfies_positions` return only the open positions it actually computes.

This closes one of #16866's four one-away TS1005 clusters (`compiler/jsdoc/checkJsdocSatisfiesTag14.ts`). The other three TS1005 one-away tests (`jsdocParameterParsingInfiniteLoop`, `jsdocParseDotDotDotInJSDocFunction`, `jsdocPrefixPostfixParsing`) are unrelated JSDoc type-syntax parsing gaps (rest-in-function-type, nullable prefix/postfix markers) — not touched here.

## Adjacent-case matrix (oracle-verified against pinned `typescript@7.0.2`)

| source | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `@satisfies T1` (no braces) | 1× TS1005 (`'{'`) | 2× TS1005 (`'{'` + spurious `'}'`) | 1× TS1005 (`'{'`) |
| `@satisfies Foo` + `@satisfies Bar` (two malformed tags, one comment) | 1 TS1005 per occurrence (2 total) | 2 per occurrence (4 total) | 1 per occurrence (2 total) |
| `@satisfies {T1}` (well-formed) | clean | clean | clean (unchanged) |

Full fixture (`checkJsdocSatisfiesTag14.ts`) diff vs. the pinned oracle: empty (byte-identical).

## Goal
Goal: hold

## Verification
- Oracle: pinned `typescript@7.0.2` via `--noEmit --target es2015 --allowJs --checkJs`, byte-for-byte match on the full fixture and the adjacent-case matrix above.
- `cargo test -p tsz-checker --lib -- jsdoc_satisfies`: 13/13 (3 new regression tests added: braceless-single-report, two-malformed-tags, well-formed control).
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`: clean.
- `cargo fmt --check -p tsz-checker`: clean.
- `python3 scripts/arch/arch_guard.py`: clean.
- Full `cargo test -p tsz-checker --lib` (~10,800 tests): still running in the background at PR-open time (this is a narrow, two-call-site diagnostic-count change confined to the JSDoc `@satisfies` malformed-tag path, and the pre-commit hook's scoped `-p tsz-checker` verification already passed); will post the count as a follow-up if it lands before this PR is picked up.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_018rFBVe91gBERiwx6SVLgRJ)_