### PR TITLE
fix(checker): TS2403 no longer suppressed when both types render the same display name (#16888)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1941,6 +1941,9 @@ path = "tests/ts2403_enum_object_redeclaration_tests.rs"
 name = "ts2403_private_brand_redeclaration_tests"
 path = "tests/ts2403_private_brand_redeclaration_tests.rs"
 [[test]]
+name = "ts2403_same_display_name_redeclaration_tests"
+path = "tests/ts2403_same_display_name_redeclaration_tests.rs"
+[[test]]
 name = "ts1262_multiple_await_declarations_tests"
 path = "tests/ts1262_multiple_await_declarations_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/error_reporter/type_value.rs
+++ b/crates/tsz-checker/src/error_reporter/type_value.rs
@@ -30,8 +30,7 @@ impl<'a> CheckerState<'a> {
         // (`{ x: number; y: number; }` not `{ x: 0; y: 0; }`), matching tsc.
         // But preserve top-level literal/union-of-literal types so explicit
         // annotations like `var x: 5; var x: 6;` keep their literal form
-        // (`'5'` / `'6'`) instead of collapsing to `number`/`number` (which
-        // would also self-suppress via the equal-display short-circuit below).
+        // (`'5'` / `'6'`) instead of collapsing to `number`/`number`.
         //
         // Use the widened formatter (no display-property side-table fallback)
         // so the widened shape is actually rendered — `format_type_diagnostic`
@@ -49,16 +48,8 @@ impl<'a> CheckerState<'a> {
         let current_type_str = self
             .ts2403_typeof_fundule_initializer_display(idx)
             .unwrap_or_else(|| self.format_type_for_redeclaration_message(current_display));
-        // Suppress when both types format to the same name. This handles cross-binder
-        // scenarios where a lib_checker resolves a type annotation (e.g., `Document`)
-        // to a separate DefId from the main checker's version. Interface declaration
-        // merging means both annotations semantically refer to the same type, but
-        // different internal TypeIds prevent the structural check from recognizing this.
-        if prev_type_str == current_type_str {
-            return;
-        }
         let message = format!(
-            "Subsequent variable declarations must have the same type. Variable '{name}' must be of type '{prev_type_str}', but here has type '{current_type_str}'."
+            "Subsequent variable declarations must have the same type.  Variable '{name}' must be of type '{prev_type_str}', but here has type '{current_type_str}'."
         );
         self.error_at_node(idx, &message, diagnostic_codes::SUBSEQUENT_VARIABLE_DECLARATIONS_MUST_HAVE_THE_SAME_TYPE_VARIABLE_MUST_BE_OF_TYP);
     }

--- a/crates/tsz-checker/tests/ts2403_same_display_name_redeclaration_tests.rs
+++ b/crates/tsz-checker/tests/ts2403_same_display_name_redeclaration_tests.rs
@@ -1,0 +1,102 @@
+//! Regression coverage for #16888: TS2403 ("Subsequent variable declarations
+//! must have the same type") was silently dropped whenever both redeclared
+//! types happened to render to the same simple display name, even though the
+//! solver's `are_types_identical_for_redeclaration` (fixed for private/
+//! protected brands in #16891) already correctly determined the two types
+//! were NOT identical.
+//!
+//! The drop was not in the identity check itself but in the checker's
+//! diagnostic-emission path: `error_subsequent_variable_declaration`
+//! (`crates/tsz-checker/src/error_reporter/type_value.rs`) suppressed the
+//! diagnostic whenever `prev_type_str == current_type_str` — a formatted
+//! diagnostic string used as a semantic predicate, which the Anti-Hardcoding
+//! Gate (`.claude/CLAUDE.md`) forbids. Two structurally-distinct classes that
+//! both happen to be named `Foo` (in different namespaces/modules) rendered
+//! identically and were wrongly suppressed, even though tsc reports TS2403
+//! for exactly this shape (`isTypeIdenticalTo` does not care that both sides
+//! print the same short name).
+//!
+//! This also fixes a byte-level message mismatch uncovered while unblocking
+//! these cases: tsc's TS2403 template has two spaces after the first
+//! sentence ("...must have the same type.  Variable ..."), oracle-verified
+//! against pinned `typescript@7.0.2`; tsz's ad hoc `format!` call only had
+//! one.
+//!
+//! All expected diagnostics oracle-verified against pinned `typescript@7.0.2`.
+
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn ts2403_count(source: &str) -> usize {
+    check_source_diagnostics(source)
+        .iter()
+        .filter(|d| d.code == 2403)
+        .count()
+}
+
+fn ts2403_messages(source: &str) -> Vec<String> {
+    check_source_diagnostics(source)
+        .iter()
+        .filter(|d| d.code == 2403)
+        .map(|d| d.message_text.clone())
+        .collect()
+}
+
+#[test]
+fn same_simple_name_different_private_brand_emits_ts2403() {
+    // The core #16888 repro: `A.Foo` and `B.Foo` are unrelated classes (each
+    // carrying its own private member) that happen to share a display name.
+    let source = r#"
+namespace A { export class Foo { private n: number = 0; } }
+namespace B { export class Foo { private n: number = 0; } }
+var x: A.Foo;
+var x: B.Foo;
+"#;
+    let messages = ts2403_messages(source);
+    assert_eq!(
+        messages.len(),
+        1,
+        "Expected exactly one TS2403 for distinct same-named private-branded classes: {messages:?}"
+    );
+    assert_eq!(
+        messages[0],
+        "Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'Foo', but here has type 'Foo'.",
+        "Message must byte-match tsc's two-space template"
+    );
+}
+
+#[test]
+fn same_simple_name_same_private_brand_stays_clean() {
+    // Negative control: the SAME declaration referenced twice (via the same
+    // namespace-qualified path) must not trigger TS2403 just because it has
+    // a private member — it is genuinely identical, not merely same-named.
+    let source = r#"
+namespace A { export class Foo { private n: number = 0; } }
+var x: A.Foo;
+var x: A.Foo;
+"#;
+    assert_eq!(
+        ts2403_count(source),
+        0,
+        "Expected no TS2403: both declarations refer to the identical class"
+    );
+}
+
+#[test]
+fn same_simple_name_no_private_member_stays_clean() {
+    // Negative control: two same-named, structurally identical PUBLIC-only
+    // classes remain redeclaration-identical under plain structural
+    // comparison (no private/protected brand involved), so this must not
+    // regress now that the display-name suppression is gone.
+    let source = r#"
+namespace A { export class Foo { m: number = 0; } }
+namespace B { export class Foo { m: number = 0; } }
+var x: A.Foo;
+var x: B.Foo;
+"#;
+    assert_eq!(
+        ts2403_count(source),
+        0,
+        "Expected no TS2403: neither class has a private/protected member, so \
+         plain structural identity applies even though both are named `Foo`"
+    );
+}


### PR DESCRIPTION
Fixes #16888.

`error_subsequent_variable_declaration` (`crates/tsz-checker/src/error_reporter/type_value.rs`) suppressed the TS2403 diagnostic whenever `prev_type_str == current_type_str` — a formatted diagnostic string used as a semantic predicate, which the Anti-Hardcoding Gate (`.claude/CLAUDE.md`) forbids. Two structurally-distinct classes that happen to be named `Foo` in different namespaces (each with its own private member) rendered identically and were wrongly suppressed, even though the solver's `are_types_identical_for_redeclaration` (private-brand-aware since #16891) already correctly determined the two types were **not** identical. tsc's `isTypeIdenticalTo` does not care that both sides print the same short name.

**Structural rule:** when the redeclaration identity check (solver, via `is_redeclaration_identical_with_resolver`) has already determined two var-redeclaration types are not identical, tsc reports TS2403 regardless of whether the two types render to the same display text; tsz's emission path (checker `error_reporter::type_value`) no longer re-derives a second, string-based verdict that can override that answer.

Also fixes a byte-level message mismatch surfaced while unblocking these cases: tsc's TS2403 template has **two spaces** after the first sentence (`"...must have the same type.  Variable ..."`), oracle-verified against pinned `typescript@7.0.2`; tsz's `format!` call only had one.

### Adjacent-case matrix (oracle-verified against pinned `typescript@7.0.2`)

| case | tsc | tsz (after) |
| --- | --- | --- |
| same-name/different-brand (this fix): `namespace A { class Foo { private n } } namespace B { class Foo { private n } } var x: A.Foo; var x: B.Foo;` | TS2403 | TS2403 |
| same declaration referenced twice via the same path | no error | no error |
| same-name, no private/protected member (pure structural identity) | no error | no error |
| renamed-binder/different-brand (#16891) | TS2403 | TS2403 (unaffected) |

### Scope note

#16888 also mentions the original conformance fixture's ambient-module (`declare module 'mod1'` + `import = require`) shape. I could not build a faithful single-file reproduction of that exact shape (it requires real cross-file module resolution — a synthetic single-file version hits `TS2664`/`TS2307` instead, since `declare module '<string>'` is treated as an *augmentation* once the file contains `import = require`), so I scoped the regression tests to the namespace-qualified shape that is directly oracle-verified, plus the two negative controls. The underlying fix is the same emission-path change either way.

## Goal
Goal: hold

## Verification
- New `ts2403_same_display_name_redeclaration_tests`: 3/3 (registered via `[[test]]` in `Cargo.toml` — this crate sets `autotests = false`).
- `cargo test -p tsz-checker --test ts2403_private_brand_redeclaration_tests --test ts2403_enum_object_redeclaration_tests --test ts2403_js_cross_file_tests`: 14/14, no regression.
- `cargo test -p tsz-checker --lib -- ts2403 redeclaration enum private_brand`: 469/469, no regression.
- Manual oracle diff (pinned `typescript@7.0.2`) for the namespace repro (`var x: A.Foo; var x: B.Foo;`, each with a private member): tsz output now byte-identical to tsc, including the two-space message template.
- `cargo clippy -p tsz-checker --lib --tests -- -D warnings`: clean.
- `cargo fmt -p tsz-checker -- --check`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.
- Local pre-commit gate (clippy + arch-size, scoped to `tsz-checker`): passed.
- Full `cargo test -p tsz-checker --lib` (~10,800 tests) and `compare-to-parent.sh` were started but did not finish within this session's time budget; owed as a follow-up. Risk is scoped: this function has exactly one caller family (the local and cross-file TS2403 var-redeclaration paths in `state/variable_checking/core.rs`), all covered by the 483 targeted tests above.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_012qKU8wrpFbtfyWnXzR7mua)_