### PR TITLE
fix(checker): report TS2842 for non-identifier property renames in signature binding patterns

### DIFF
--- a/crates/tsz-checker/src/checkers/parameter_checker.rs
+++ b/crates/tsz-checker/src/checkers/parameter_checker.rs
@@ -619,7 +619,11 @@ impl<'a> CheckerState<'a> {
                 // it used and `tsc` reports nothing.
                 if !has_body
                     && let Some(prop_node) = self.ctx.arena.get(elem.property_name)
-                    && prop_node.kind == tsz_scanner::SyntaxKind::Identifier as u16
+                    && (prop_node.kind == tsz_scanner::SyntaxKind::Identifier as u16
+                        || prop_node.kind == tsz_scanner::SyntaxKind::StringLiteral as u16
+                        || prop_node.kind == tsz_scanner::SyntaxKind::NumericLiteral as u16
+                        || prop_node.kind
+                            == tsz_parser::parser::syntax_kind_ext::COMPUTED_PROPERTY_NAME)
                     && let Some(name_node) = self.ctx.arena.get(elem.name)
                     && name_node.kind == tsz_scanner::SyntaxKind::Identifier as u16
                     && !self.ctx.arena.get_identifier_text(elem.name).is_some_and(|n| {

--- a/crates/tsz-checker/src/types/type_node_helpers.rs
+++ b/crates/tsz-checker/src/types/type_node_helpers.rs
@@ -147,6 +147,61 @@ pub(crate) fn check_duplicate_parameters_in_type(
     }
 }
 
+/// Property-name node kinds that can form the "renamed-from" side of a
+/// destructuring rename in a signature binding pattern (TS2842). `tsc` flags
+/// the rename regardless of how the property name is written, so identifier,
+/// string-literal, numeric-literal, and computed names all qualify.
+const fn is_renaming_source_property_kind(kind: u16) -> bool {
+    kind == SyntaxKind::Identifier as u16
+        || kind == SyntaxKind::StringLiteral as u16
+        || kind == SyntaxKind::NumericLiteral as u16
+        || kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME
+}
+
+/// Render the "renamed-from" property name for a TS2842 message. An identifier
+/// uses its escaped text; every other kind uses its verbatim source text so the
+/// message matches `tsc` with quotes and brackets preserved (`"a"`, `2`,
+/// `["a"]`, `[2]`).
+fn renaming_property_name_text(
+    ctx: &crate::CheckerContext,
+    prop_idx: NodeIndex,
+    prop_kind: u16,
+) -> String {
+    if prop_kind == SyntaxKind::Identifier as u16 {
+        return ctx
+            .arena
+            .get(prop_idx)
+            .and_then(|n| ctx.arena.get_identifier(n))
+            .map(|i| i.escaped_text.trim_end_matches(':').trim().to_string())
+            .unwrap_or_default();
+    }
+    node_source_text(ctx, prop_idx)
+        .map(|t| t.trim().to_string())
+        .unwrap_or_default()
+}
+
+/// Verbatim source text of `idx`, resolving the source file that owns the node
+/// so multi-file programs slice from the correct buffer (mirrors the checker's
+/// `owning_source_file` walk).
+fn node_source_text(ctx: &crate::CheckerContext, idx: NodeIndex) -> Option<String> {
+    let node = ctx.arena.get(idx)?;
+    let start = node.pos as usize;
+    let end = node.end as usize;
+    let mut current = idx;
+    let text = loop {
+        let n = ctx.arena.get(current)?;
+        if n.kind == syntax_kind_ext::SOURCE_FILE {
+            break ctx.arena.get_source_file(n)?.text.clone();
+        }
+        let info = ctx.arena.node_info(current)?;
+        if info.parent.is_none() {
+            return None;
+        }
+        current = info.parent;
+    };
+    text.get(start..end).map(str::to_string)
+}
+
 fn collect_names_in_type(
     ctx: &mut crate::CheckerContext,
     name_idx: tsz_parser::parser::NodeIndex,
@@ -184,35 +239,41 @@ fn collect_names_in_type(
                     continue;
                 }
                 if let Some(elem) = ctx.arena.get_binding_element(elem_node) {
+                    let prop_idx = elem.property_name;
+                    let name_idx = elem.name;
                     // TS2842 reports a renaming that is *unused*. The renamed
                     // local is in scope for the signature's own type
                     // positions, so a `typeof` query naming it makes the
-                    // renaming used and `tsc` stays silent.
-                    if elem.property_name.is_some()
-                        && let Some(prop_node) = ctx.arena.get(elem.property_name)
-                        && prop_node.kind == SyntaxKind::Identifier as u16
-                        && let Some(name_node) = ctx.arena.get(elem.name)
+                    // renaming used and `tsc` stays silent. The property side of
+                    // the rename may be spelled as an identifier (`a`), a string
+                    // literal (`"a"`), a numeric literal (`2`), or a computed
+                    // name (`["a"]`, `[2]`) — tsc flags all of them, so the gate
+                    // matches every property-name kind, not just identifiers.
+                    if prop_idx.is_some()
+                        && let Some(prop_node) = ctx.arena.get(prop_idx)
+                        && is_renaming_source_property_kind(prop_node.kind)
+                        && let Some(name_node) = ctx.arena.get(name_idx)
                         && name_node.kind == SyntaxKind::Identifier as u16
-                        && !ctx.arena.get_identifier_text(elem.name).is_some_and(|n| {
+                        && !ctx.arena.get_identifier_text(name_idx).is_some_and(|n| {
                             crate::types_domain::signature_binding_scope::binding_is_referenced_by_type_query(
                                 ctx, elem_idx, n,
                             )
                         })
                     {
-                        let prop_name = ctx
-                            .arena
-                            .get_identifier(prop_node)
-                            .map(|i| i.escaped_text.trim_end_matches(":").trim().to_string())
-                            .unwrap_or_default();
+                        let prop_kind = prop_node.kind;
+                        let name_pos = name_node.pos;
+                        let name_len = name_node.end - name_node.pos;
+                        let prop_name = renaming_property_name_text(ctx, prop_idx, prop_kind);
                         let name_str = ctx
                             .arena
-                            .get_identifier(name_node)
+                            .get(name_idx)
+                            .and_then(|n| ctx.arena.get_identifier(n))
                             .map(|i| i.escaped_text.clone())
                             .unwrap_or_default();
                         let msg = crate::diagnostics::format_message(crate::diagnostics::diagnostic_messages::IS_AN_UNUSED_RENAMING_OF_DID_YOU_INTEND_TO_USE_IT_AS_A_TYPE_ANNOTATION, &[&name_str, &prop_name]);
-                        ctx.error(name_node.pos, name_node.end - name_node.pos, msg, crate::diagnostics::diagnostic_codes::IS_AN_UNUSED_RENAMING_OF_DID_YOU_INTEND_TO_USE_IT_AS_A_TYPE_ANNOTATION);
+                        ctx.error(name_pos, name_len, msg, crate::diagnostics::diagnostic_codes::IS_AN_UNUSED_RENAMING_OF_DID_YOU_INTEND_TO_USE_IT_AS_A_TYPE_ANNOTATION);
                     }
-                    collect_names_in_type(ctx, elem.name, seen);
+                    collect_names_in_type(ctx, name_idx, seen);
                 }
             }
         }

--- a/crates/tsz-checker/tests/signature_binding_pattern_typeof_scope_tests.rs
+++ b/crates/tsz-checker/tests/signature_binding_pattern_typeof_scope_tests.rs
@@ -153,3 +153,89 @@ fn an_inner_signatures_binding_does_not_leak_outward() {
         "an inner signature's binding is not in the outer signature's scope; got {codes:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// The "renamed-from" property may be spelled with any property-name kind.
+//
+// `tsc` reports TS2842 for a destructuring rename regardless of how the
+// property is written — identifier (`a`), string literal (`"a"`), numeric
+// literal (`2`), or computed (`["a"]`, `[2]`) — rendering the property name
+// verbatim (quotes and brackets preserved). Oracled against
+// `renamingDestructuredPropertyInFunctionType` at tsc 7.0.2.
+// ---------------------------------------------------------------------------
+
+fn ts2842_messages(source: &str) -> Vec<String> {
+    tsz_checker::test_utils::check_source_non_strict(source)
+        .into_iter()
+        .filter(|d| d.code == TS2842_UNUSED_RENAMING)
+        .map(|d| d.message_text)
+        .collect()
+}
+
+#[test]
+fn rename_from_string_literal_property_reports_ts2842() {
+    let msgs = ts2842_messages("type F = ({ \"a\": renamed }) => void;");
+    assert_eq!(msgs.len(), 1, "a string-literal property rename is flagged");
+    assert!(
+        msgs[0].contains("unused renaming of '\"a\"'"),
+        "the property name renders with its quotes; got {msgs:?}"
+    );
+}
+
+#[test]
+fn rename_from_numeric_property_reports_ts2842() {
+    let msgs = ts2842_messages("type F = ({ 2: renamed }) => void;");
+    assert_eq!(msgs.len(), 1, "a numeric property rename is flagged");
+    assert!(
+        msgs[0].contains("unused renaming of '2'"),
+        "the numeric property renders verbatim; got {msgs:?}"
+    );
+}
+
+#[test]
+fn rename_from_computed_property_reports_ts2842() {
+    let msgs = ts2842_messages("type F = ({ [\"a\"]: renamed }) => void;");
+    assert_eq!(msgs.len(), 1, "a computed property rename is flagged");
+    assert!(
+        msgs[0].contains("unused renaming of '[\"a\"]'"),
+        "the computed name renders with its brackets; got {msgs:?}"
+    );
+}
+
+#[test]
+fn rename_from_string_literal_property_in_value_signature_reports_ts2842() {
+    // The value-position path (bodyless function declaration) flags the same
+    // non-identifier property-name kinds as the type-position path.
+    let codes = check_source_non_strict_codes(
+        "type O = { a?: string; b: number };\ndeclare function f({ \"a\": renamed }: O): void;",
+    );
+    assert!(
+        codes.contains(&TS2842_UNUSED_RENAMING),
+        "a string-literal rename in a bodyless declaration is flagged; got {codes:?}"
+    );
+}
+
+#[test]
+fn non_identifier_rename_referenced_by_type_query_reports_nothing() {
+    // The "unused" gate still applies: a `typeof` reference to the renamed
+    // binding silences TS2842 even when the property is a string literal.
+    let codes = check_source_non_strict_codes("type F = ({ \"a\": renamed }) => typeof renamed;");
+    assert!(
+        codes.is_empty(),
+        "`typeof renamed` uses the renaming, so no TS2842; got {codes:?}"
+    );
+}
+
+#[test]
+fn string_literal_rename_is_binder_name_invariant() {
+    // The diagnostic depends on the structural rename, not on the chosen local
+    // name — a different binder name produces the same single TS2842.
+    for local in ["renamed", "zzz", "alias"] {
+        let msgs = ts2842_messages(&format!("type F = ({{ \"a\": {local} }}) => void;"));
+        assert_eq!(
+            msgs.len(),
+            1,
+            "renaming `\"a\"` to `{local}` is flagged once; got {msgs:?}"
+        );
+    }
+}


### PR DESCRIPTION
When a destructuring parameter renames a property in a function-type or bodyless signature (`({ prop: local }: T) => …`), `tsc` reports TS2842 (`'local' is an unused renaming of 'prop'. Did you intend to use it as a type annotation?`) for **every** property-name kind — identifier, string literal, numeric literal, and computed — and silences it only when a `typeof local` query in the same signature uses the binding. tsz gated both of its TS2842 emission sites on `prop_node.kind == Identifier`, so `{ "a": x }`, `{ 2: x }`, `{ ["a"]: x }`, and `{ [2]: x }` renames went unreported (a false negative). The owning layer is the checker: `type_node_helpers::collect_names_in_type` for type positions and `parameter_checker` for value (bodyless-declaration) positions.

## Goal
Goal: hold

Structural rule: **when a signature binding pattern renames a property whose name is a string literal, numeric literal, or computed name, `tsc` reports TS2842; tsz now does the same through the checker's two binding-pattern emission sites.** The gate is relaxed to accept those kinds alongside identifiers, and the property name is rendered from its verbatim source text so the message keeps tsc's quotes and brackets (`"a"`, `2`, `["a"]`, `[2]`). The unused-binding `typeof` exemption is unchanged and still applies to every property-name kind.

Adjacent matrix (all oracled against tsc 7.0.2): identifier / string-literal / numeric / computed property names; type-position (`type F = (...) => T`) and value-position (`declare function f(...)`); the `typeof`-referenced case that must stay silent; and binder-name invariance.

## Verification
- `cargo test --release -p tsz-checker --test signature_binding_pattern_typeof_scope_tests` — 17 passed (11 pre-existing + 6 new: string/numeric/computed renames with source-text rendering, value-position, `typeof`-silencing, binder-name invariance).
- Conformance (full corpus, tsc 7.0.2 cache, pinned lib set), isolated same-machine diff of this branch vs its merge base: **0 PASS→FAIL regressions, +1 improvement** — `renamingDestructuredPropertyInFunctionType.ts` (8 previously-missing TS2842 now emitted at tsc's exact lines/columns and messages). Clean 11537 → branch 11538.
- Pre-commit gate (clippy `-D warnings` + architecture size guard) passed locally.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSAgsP2qbTNg4yS5ggXNCv)_