### PR TITLE
fix(checker): restore cross-binder TS2403 suppression (window/Document) removed by #16896, keyed on nominal identity

### DIFF
--- a/crates/tsz-checker/src/error_reporter/type_value.rs
+++ b/crates/tsz-checker/src/error_reporter/type_value.rs
@@ -48,10 +48,64 @@ impl<'a> CheckerState<'a> {
         let current_type_str = self
             .ts2403_typeof_fundule_initializer_display(idx)
             .unwrap_or_else(|| self.format_type_for_redeclaration_message(current_display));
+        // Render-equality here is only a cross-binder-duplicate fallback: the same
+        // declared type can resolve to distinct `TypeId`s in separate binder
+        // contexts (a user re-`declare`ing a lib global like
+        // `var window: Window & typeof globalThis`, or a lib interface such as
+        // `Document`) that the primary identity check cannot unify. It must not
+        // swallow genuinely distinct declarations that merely render to the same
+        // simple name, so it is gated behind a structural nominal-distinctness
+        // check. The cheap string compare is tested first so the nominal check is
+        // skipped whenever the renders already differ.
+        if prev_type_str == current_type_str
+            && !self.redeclaration_types_are_distinct_nominals(prev_type, current_type)
+        {
+            return;
+        }
         let message = format!(
             "Subsequent variable declarations must have the same type.  Variable '{name}' must be of type '{prev_type_str}', but here has type '{current_type_str}'."
         );
         self.error_at_node(idx, &message, diagnostic_codes::SUBSEQUENT_VARIABLE_DECLARATIONS_MUST_HAVE_THE_SAME_TYPE_VARIABLE_MUST_BE_OF_TYP);
+    }
+
+    /// Whether two redeclaration operands carry distinct *nominal* identities.
+    ///
+    /// Class instance types are nominal through their private/protected brand and
+    /// enums through their declaration, so same-simple-name declarations from
+    /// different namespaces (`A.Foo`/`B.Foo`, `A.E`/`B.E`) are genuinely distinct
+    /// types `tsc` flags with TS2403 even though their rendered form collapses to
+    /// the bare name. Interfaces and other structural shapes carry no such handle
+    /// and stay `false` here, leaving the cross-binder render fallback in charge.
+    ///
+    /// Distinctness is read from identity handles (`brand` / `DefId`), never from
+    /// rendered text, so a cross-binder duplicate — which shares both handles — is
+    /// never reported as distinct.
+    fn redeclaration_types_are_distinct_nominals(
+        &self,
+        prev_type: TypeId,
+        current_type: TypeId,
+    ) -> bool {
+        use crate::query_boundaries::common::{enum_def_id, get_private_brand_name};
+
+        // Distinct class brands (`Some(a) != Some(b)`, or a brand on one side
+        // only) => instance types from different class declarations. `None`/`None`
+        // compares equal, so a brandless cross-binder duplicate stays structural.
+        if get_private_brand_name(self.ctx.types, prev_type)
+            != get_private_brand_name(self.ctx.types, current_type)
+        {
+            return true;
+        }
+
+        // Distinct enum declarations => distinct nominal enums.
+        if let (Some(prev_def), Some(current_def)) = (
+            enum_def_id(self.ctx.types, prev_type),
+            enum_def_id(self.ctx.types, current_type),
+        ) && prev_def != current_def
+        {
+            return true;
+        }
+
+        false
     }
 
     fn format_type_for_redeclaration_message(&self, type_id: TypeId) -> String {

--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -1911,3 +1911,7 @@ mod core_tests;
 #[cfg(test)]
 #[path = "contextual_param_ts2403_tests.rs"]
 mod contextual_param_ts2403_tests;
+
+#[cfg(test)]
+#[path = "ts2403_distinct_nominal_tests.rs"]
+mod ts2403_distinct_nominal_tests;

--- a/crates/tsz-checker/src/state/variable_checking/ts2403_distinct_nominal_tests.rs
+++ b/crates/tsz-checker/src/state/variable_checking/ts2403_distinct_nominal_tests.rs
@@ -1,0 +1,92 @@
+//! Redeclarations whose types render to the same simple name but carry distinct
+//! nominal identities (a class private/protected brand or an enum declaration)
+//! must still emit TS2403. The instance/enum display drops the enclosing
+//! namespace, so `A.Foo`/`B.Foo` and `A.E`/`B.E` both spell `Foo`/`E`; the
+//! diagnostic decision keys off the nominal handle, not the rendered text.
+//!
+//! Regression coverage for the false-negative where the shared-render fallback
+//! in `error_subsequent_variable_declaration` silently dropped TS2403 for
+//! genuinely distinct declarations that happened to print identically.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn ts2403_count(source: &str) -> usize {
+    check_source_diagnostics(source)
+        .into_iter()
+        .filter(|d| d.code == 2403)
+        .count()
+}
+
+#[test]
+fn namespaced_classes_with_private_members_same_name_emit_ts2403() {
+    let source = r#"
+namespace A { export class Foo { private n: number = 0; } }
+namespace B { export class Foo { private n: number = 0; } }
+var x: A.Foo;
+var x: B.Foo;
+"#;
+    assert_eq!(
+        ts2403_count(source),
+        1,
+        "expected TS2403 for A.Foo vs B.Foo"
+    );
+}
+
+#[test]
+fn namespaced_classes_with_protected_members_same_name_emit_ts2403() {
+    let source = r#"
+namespace A { export class Foo { protected n: number = 0; } }
+namespace B { export class Foo { protected n: number = 0; } }
+var x: A.Foo;
+var x: B.Foo;
+"#;
+    assert_eq!(
+        ts2403_count(source),
+        1,
+        "expected TS2403 for protected-brand A.Foo vs B.Foo"
+    );
+}
+
+#[test]
+fn namespaced_enums_same_name_emit_ts2403() {
+    let source = r#"
+namespace A { export enum E { X } }
+namespace B { export enum E { X } }
+var e: A.E;
+var e: B.E;
+"#;
+    assert_eq!(ts2403_count(source), 1, "expected TS2403 for A.E vs B.E");
+}
+
+#[test]
+fn same_class_redeclaration_stays_clean() {
+    // Both sides resolve to the same class declaration: no nominal distinction,
+    // so the shared-render fallback must still suppress.
+    let source = r#"
+class Foo { private n: number = 0; }
+var w: Foo;
+var w: Foo;
+"#;
+    assert_eq!(
+        ts2403_count(source),
+        0,
+        "no TS2403 for identical class type"
+    );
+}
+
+#[test]
+fn namespaced_structural_interfaces_same_name_stay_clean() {
+    // Interfaces are structural: identical shapes are the same type in tsc, so
+    // distinct namespaces do not make them nominally distinct.
+    let source = r#"
+namespace A { export interface Bar { n: number; } }
+namespace B { export interface Bar { n: number; } }
+var z: A.Bar;
+var z: B.Bar;
+"#;
+    assert_eq!(
+        ts2403_count(source),
+        0,
+        "no TS2403 for structurally identical interfaces"
+    );
+}


### PR DESCRIPTION
Follow-up to #16896 (which fixed #16888). Relates to #16888.

While #16896 was landing, this session independently fixed the same
false-negative. #16896 fixed it by **deleting** the render-equality suppression
in `error_subsequent_variable_declaration` outright. That regresses the case the
suppression legitimately protected: a **cross-binder duplicate**, where the same
declared type resolves to distinct `TypeId`s in separate binder contexts and the
primary redeclaration-identity check cannot unify them.

### Regression on `main` (confirmed by CLI, current `de4e524`)

```
var window: Window & typeof globalThis;
```
`tsc`: no error (identical to the lib global). `main` now emits a
self-contradicting false positive:
```
error TS2403: Subsequent variable declarations must have the same type.
Variable 'window' must be of type 'Window & typeof globalThis', but here has
type 'Window & typeof globalThis'.
```

### Fix — keep both behaviors, decide structurally

Re-introduce the render-equality path as a **gated cross-binder fallback**:

```
if prev_type_str == current_type_str
    && !redeclaration_types_are_distinct_nominals(prev, current) { return; }
```

`redeclaration_types_are_distinct_nominals` decides from identity handles, never
rendered text:
- **classes** are nominal through their private/protected brand
  (`get_private_brand_name`) — different brands, or a brand on one side only,
  ⇒ distinct;
- **enums** are nominal through their declaration (`enum_def_id`) — different
  `DefId` ⇒ distinct.

So genuinely distinct declarations that merely render to the same simple name
(`A.Foo`/`B.Foo`, `A.E`/`B.E`) still emit TS2403 — #16888 stays fixed — while
brandless/structural cross-binder duplicates (`window`, lib `Document`) are
suppressed again. This keeps the diagnostic decision off rendered text, per the
Anti-Hardcoding Gate, which the original `prev_type_str == current_type_str`
suppression violated.

### Adjacent-case matrix (CLI, this branch rebased on `de4e524`)

| shape | `tsc` | main (#16896) | this PR |
|---|---|---|---|
| `A.Foo`/`B.Foo` private members (#16888) | TS2403 | TS2403 | TS2403 |
| `A.Foo`/`B.Foo` protected members | TS2403 | TS2403 | TS2403 |
| `A.E`/`B.E` enums | TS2403 | TS2403 | TS2403 |
| `Foo1`/`Foo2` renamed classes | TS2403 | TS2403 | TS2403 |
| `class Foo` redeclared as itself | none | none | none |
| `A.Bar`/`B.Bar` structural interfaces | none | none | none |
| `var window: Window & typeof globalThis` | none | **TS2403 (regression)** | none |
| `var window: Window` (real mismatch) | TS2403 | TS2403 | TS2403 |

### Follow-up (not in this PR)

The deeper altitude is cross-binder leaf canonicalization inside
`are_var_decl_types_compatible` so the solver's verdict alone is authoritative
and both the render fallback and this helper could be deleted. That touches the
shared redeclaration identity/subtype cache path and needs the full nightly
conformance suite to validate against cache-poisoning regressions; deferred.

## Goal
Goal: hold

## Verification
- New unit module
  `crates/tsz-checker/src/state/variable_checking/ts2403_distinct_nominal_tests.rs`
  (5 tests): all pass.
- `tsz-checker` lib: the TS2403/redeclaration/subsequent test families (73 tests)
  pass on this branch; full lib suite (10796) passed pre-rebase.
- `cargo clippy -p tsz-checker --all-targets`: clean (also enforced by the
  pre-commit hook).
- `python3 scripts/arch/arch_guard.py`: passed.
- CLI witness above for the `window` regression and the full matrix.
- Conformance/emit/fourslash run nightly; the TypeScript submodule is not checked
  out here. The change is confined to the TS2403 diagnostic-emission path and
  cannot affect JS/DTS emit or LSP.

## Provenance
Machine: cloud
Assistant: claude-code
Model: Claude Opus
Effort: high