### PR TITLE
fix(checker): lexical `this` at script top level types as `typeof globalThis`, not `any`

### DIFF
--- a/crates/tsz-checker/src/dispatch/this.rs
+++ b/crates/tsz-checker/src/dispatch/this.rs
@@ -231,33 +231,7 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                 idx,
                 crate::recovery::RecoveryReason::ThisUnresolvedClassOrObjectLiteralMember,
             )
-        } else if self.checker.ctx.no_implicit_this()
-            && !self.checker.is_js_file()
-            && !self.checker.ctx.binder.is_external_module()
-            && self.checker.is_this_in_global_capturing_arrow(idx)
-        {
-            // TS7041: `this` in an arrow chain with no enclosing
-            // function/class/object `this` binder captures globalThis.
-            // Prefer this over the generic TS2683 path.
-            //
-            // Only fires in *script* files. At the top level of an
-            // external module (has `import`/`export`), `this` is
-            // `undefined`, not `globalThis`, so a capturing arrow at
-            // module top-level produces TS2532 on property access,
-            // not a global-capture warning. Matches tsc.
-            use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-            self.checker.error_at_node(
-                idx,
-                diagnostic_messages::THE_CONTAINING_ARROW_FUNCTION_CAPTURES_THE_GLOBAL_VALUE_OF_THIS,
-                diagnostic_codes::THE_CONTAINING_ARROW_FUNCTION_CAPTURES_THE_GLOBAL_VALUE_OF_THIS,
-            );
-            TypeId::ANY
-        } else if self.checker.ctx.no_implicit_this()
-            && self
-                .checker
-                .find_enclosing_non_arrow_function(idx)
-                .is_some()
-        {
+        } else if let Some(_enclosing_fn) = self.checker.find_enclosing_non_arrow_function(idx) {
             // TS2683: 'this' implicitly has type 'any'
             // Reaching this branch means `this` has no resolved owner: all
             // owned receivers (class member, JSDoc `@this`, contextual, and
@@ -266,53 +240,67 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
             // synthesizes a `this` for plain JS constructor functions, so a
             // top-level JS function's `this` is implicitly `any` here just like
             // in TS files — not only nested ones.
-            // Suppress if the enclosing function has an explicit `this` parameter
-            // or a contextual `this` type from a parent type annotation
-            if self
-                .checker
-                .enclosing_function_has_explicit_this_parameter(idx)
-                || self
+            //
+            // The TYPE is `any` regardless of `noImplicitThis` (a plain
+            // function's `this` has no declared receiver either way); only
+            // the *warning* about that implicit `any` is gated by the flag.
+            // Suppress the warning if the enclosing function has an explicit
+            // `this` parameter or a contextual `this` type from a parent
+            // type annotation.
+            if self.checker.ctx.no_implicit_this()
+                && !self
+                    .checker
+                    .enclosing_function_has_explicit_this_parameter(idx)
+                && !self
                     .checker
                     .enclosing_function_has_contextual_this_type(idx)
             {
-                TypeId::ANY
-            } else {
                 use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
                 self.checker.error_at_node(
                     idx,
                     diagnostic_messages::THIS_IMPLICITLY_HAS_TYPE_ANY_BECAUSE_IT_DOES_NOT_HAVE_A_TYPE_ANNOTATION,
                     diagnostic_codes::THIS_IMPLICITLY_HAS_TYPE_ANY_BECAUSE_IT_DOES_NOT_HAVE_A_TYPE_ANNOTATION,
                 );
-                TypeId::ANY
             }
-        } else if self.checker.ctx.no_implicit_this()
-            && !self.checker.is_js_file()
-            && self
-                .checker
-                .find_enclosing_non_arrow_function(idx)
-                .is_none()
-        {
-            // `this` at the top level of a script or module with noImplicitThis.
+            TypeId::ANY
+        } else if self.checker.is_js_file() {
+            // JS-file top-level/arrow-inherited `this` behavior is
+            // unaffected by this change; keep it exactly as before.
+            TypeId::ANY
+        } else {
+            // `this` at the top level of a script or module (including
+            // inside an arrow chain, which has no `this` binding of its
+            // own and inherits lexically from here).
             //
             // In an external module (has `import`/`export`), top-level `this`
             // — including `this` inside a top-level arrow — is `undefined`.
             // Property access on `this` then produces TS2532 ("Object is
             // possibly 'undefined'.") under strictNullChecks, matching tsc.
             //
-            // In a script, tsc resolves `this` to `typeof globalThis` (an
-            // object type). We approximate with TypeId::OBJECT since we
-            // don't have a full globalThis type yet; this ensures that
-            // operations like `++this` correctly emit TS2356 (arithmetic
-            // type error) instead of TS2357 (invalid lvalue) — matching
-            // tsc behavior where the type check fires first and suppresses
-            // the lvalue check.
+            // In a script, tsc resolves `this` to `typeof globalThis`, the
+            // synthetic surface object built from in-scope globals
+            // (`CheckerContext::global_this_surface_type`).
+            //
+            // Both resolve to their real TYPE regardless of `noImplicitThis`
+            // — TypeScript computes the type of `this` unconditionally and
+            // only conditionally *warns* about an arrow capturing it
+            // implicitly (TS7041, script files only).
+            if !self.checker.ctx.binder.is_external_module()
+                && self.checker.ctx.no_implicit_this()
+                && self.checker.is_this_in_global_capturing_arrow(idx)
+            {
+                use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+                self.checker.error_at_node(
+                    idx,
+                    diagnostic_messages::THE_CONTAINING_ARROW_FUNCTION_CAPTURES_THE_GLOBAL_VALUE_OF_THIS,
+                    diagnostic_codes::THE_CONTAINING_ARROW_FUNCTION_CAPTURES_THE_GLOBAL_VALUE_OF_THIS,
+                );
+            }
             if self.checker.ctx.binder.is_external_module() {
                 TypeId::UNDEFINED
             } else {
-                TypeId::OBJECT
+                self.checker.ctx.global_this_surface_type()
             }
-        } else {
-            TypeId::ANY
         }
     }
 }

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -871,6 +871,8 @@ mod syntax_constraint_relation_routing_arch_tests;
 mod synthetic_unique_atom_union_display_tests;
 #[path = "tests/this_context_self_type_tests.rs"]
 mod this_context_self_type_tests;
+#[path = "tests/this_lexical_global_type_tests.rs"]
+mod this_lexical_global_type_tests;
 #[path = "tests/this_parameter_placement_tests.rs"]
 mod this_parameter_placement_tests;
 #[path = "tests/this_prop_nullish_operand_code_tests.rs"]

--- a/crates/tsz-checker/src/tests/this_lexical_global_type_tests.rs
+++ b/crates/tsz-checker/src/tests/this_lexical_global_type_tests.rs
@@ -1,0 +1,174 @@
+//! `this` at the top level of a script (and inside arrow chains, which have
+//! no `this` binding of their own and inherit lexically) resolves to its real
+//! TYPE — `typeof globalThis` in a script, `undefined` in a module —
+//! regardless of `noImplicitThis`. Previously `dispatch_this_keyword`
+//! (`dispatch/this.rs`) gated the whole type computation behind
+//! `no_implicit_this()`, not just the implicit-any *warning*: with
+//! `noImplicitThis` off (the common case — `strict: false` or unset), every
+//! such `this` silently fell through to `any`, and even with `noImplicitThis`
+//! on, an arrow-captured `this` still hard-coded `any` alongside its TS7041
+//! warning instead of resolving `typeof globalThis`.
+//!
+//! Structural rule: `tsc` computes the type of `this` from lexical position
+//! alone; `noImplicitThis` only controls whether it also emits a warning
+//! (TS2683 for a plain function's owner-less `this`, TS7041 for an arrow
+//! capturing the global `this`) — never what the type actually is. tsz's
+//! `dispatch/this.rs` must make the same two decisions independently instead
+//! of gating the type on the warning's flag.
+//!
+//! Oracle-verified against pinned `typescript@7.0.2`.
+//!
+//! Owner: `dispatch/this.rs::dispatch_this_keyword`; the concrete `typeof
+//! globalThis` object comes from `CheckerContext::global_this_surface_type`
+//! (see `global_this_typeof_surface_tests.rs`).
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_source_codes, check_with_options_code_messages};
+
+const TS2403: u32 = 2403; // Subsequent variable declarations must have the same type.
+const TS2532: u32 = 2532; // Object is possibly 'undefined'.
+const TS7041: u32 = 7041; // The containing arrow function captures the global value of 'this'.
+
+fn no_implicit_this_options() -> CheckerOptions {
+    CheckerOptions {
+        no_implicit_this: true,
+        ..CheckerOptions::default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Positive: script top level, `noImplicitThis` off (the fixture's own
+// `strict: false` shape) — `this` must type-identify with `typeof globalThis`,
+// not `any`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn top_level_this_is_typeof_global_this_under_default_options() {
+    let codes = check_source_codes(
+        r#"
+var t!: typeof globalThis;
+var t = this;
+"#,
+    );
+    assert!(
+        !codes.contains(&TS2403),
+        "top-level `this` must type-identify with `typeof globalThis`, not fall back to `any`: {codes:?}"
+    );
+}
+
+#[test]
+fn arrow_body_this_is_typeof_global_this_under_default_options() {
+    let codes = check_source_codes(
+        r#"
+var q = () => {
+    var t!: typeof globalThis;
+    var t = this;
+};
+"#,
+    );
+    assert!(
+        !codes.contains(&TS2403),
+        "an arrow function has no `this` of its own and inherits the lexical (script) `this`, `typeof globalThis`: {codes:?}"
+    );
+}
+
+#[test]
+fn nested_arrow_chain_this_is_typeof_global_this_under_default_options() {
+    let codes = check_source_codes(
+        r#"
+var q = () => () => {
+    var t!: typeof globalThis;
+    var t = this;
+};
+"#,
+    );
+    assert!(
+        !codes.contains(&TS2403),
+        "a chain of arrows still inherits the script-level `this`: {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Positive: `noImplicitThis` on — the warning fires, but the resolved TYPE is
+// unaffected (still `typeof globalThis`, never downgraded to `any`).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn arrow_capturing_this_still_types_as_global_this_alongside_ts7041() {
+    let pairs = check_with_options_code_messages(
+        r#"
+var q = () => {
+    var t!: typeof globalThis;
+    var t = this;
+};
+"#,
+        no_implicit_this_options(),
+    );
+    let codes: Vec<u32> = pairs.iter().map(|(c, _)| *c).collect();
+    assert!(
+        codes.contains(&TS7041),
+        "noImplicitThis must still warn that the arrow captures the global `this`: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&TS2403),
+        "the TS7041 warning must not change the resolved type away from `typeof globalThis`: {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls: cases this fix must not touch.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn plain_function_this_is_still_any_under_default_options() {
+    // A plain (non-arrow) function's owner-less `this` is `any` regardless of
+    // `noImplicitThis` — unaffected by this fix, which only concerns the
+    // lexically-inherited (arrow/top-level) case.
+    let codes = check_source_codes(
+        r#"
+function f() {
+    var t!: any;
+    var t = this;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&TS2403),
+        "a plain function's `this` is still `any`: {codes:?}"
+    );
+}
+
+#[test]
+fn plain_function_this_still_reports_ts2683_under_no_implicit_this() {
+    let pairs = check_with_options_code_messages(
+        "function f() { return this; }",
+        no_implicit_this_options(),
+    );
+    assert!(
+        pairs.iter().any(|(code, _)| *code == 2683),
+        "a plain function's implicit-any `this` warning is unaffected by this fix: {pairs:?}"
+    );
+}
+
+#[test]
+fn module_top_level_this_is_still_undefined() {
+    // An external module's top-level `this` is `undefined`, not
+    // `typeof globalThis` — unaffected by this fix (`is_external_module()`
+    // branch unchanged). Accessing a property on it under strict null checks
+    // still reports TS2532.
+    let codes = check_with_options_code_messages(
+        r#"
+export {};
+this.foo;
+"#,
+        CheckerOptions {
+            strict_null_checks: true,
+            ..CheckerOptions::default()
+        },
+    );
+    let codes: Vec<u32> = codes.iter().map(|(c, _)| *c).collect();
+    assert!(
+        codes.contains(&TS2532),
+        "module top-level `this` is `undefined`, so a property read is possibly-undefined: {codes:?}"
+    );
+}


### PR DESCRIPTION
Investigating #16866's `typeOfThisGeneral.ts` cluster (a genuine multi-bug family, not a one-away drain-slot per ClaudeDE's 09:27Z finding on that issue).

`dispatch_this_keyword` (`crates/tsz-checker/src/dispatch/this.rs`) gated the **type** of `this` at the top level of a script — and inside an arrow chain, which has no `this` binding of its own and inherits lexically — behind `no_implicit_this()`. With `noImplicitThis` off (the common case: `strict: false` or unset, as in the triggering fixture), every such `this` fell straight through to the final catch-all `TypeId::ANY` instead of the real `typeof globalThis`. Even with the flag on, the arrow-capturing-global-`this` branch still hard-coded `TypeId::ANY` alongside its TS7041 warning, and the top-level branch approximated the type with a bare `TypeId::OBJECT` (printing as `object`, not `typeof globalThis`) instead of the real surface type.

**Structural rule:** tsc computes the type of `this` from lexical position alone; `noImplicitThis` only controls whether it *also* emits a warning (TS2683 for a plain function's owner-less `this`, TS7041 for an arrow capturing the global `this`) — it never changes what the type actually is. `dispatch/this.rs` now makes the two decisions independently: the arrow-capturing-global and top-level-of-script/module branches always resolve to `CheckerContext::global_this_surface_type()` (script) or `TypeId::UNDEFINED` (external module), and separately, conditionally emit their diagnostic under `no_implicit_this()`.

### Adjacent-case matrix (oracle-verified against pinned `typescript@7.0.2`)

| case | tsc | tsz (before) | tsz (after) |
| --- | --- | --- | --- |
| top-level `this` in a script, default options | `typeof globalThis` | `any` | `typeof globalThis` |
| `this` in an arrow body at top level, default options | `typeof globalThis` | `any` | `typeof globalThis` |
| nested arrow chain `this` at top level | `typeof globalThis` | `any` | `typeof globalThis` |
| arrow captures global `this`, `noImplicitThis: true` | TS7041 warning + `typeof globalThis` | TS7041 warning + `any` | TS7041 warning + `typeof globalThis` |
| plain (non-arrow) function's owner-less `this` (unaffected) | `any` | `any` | `any` (unchanged) |
| same, `noImplicitThis: true` (unaffected) | TS2683 | TS2683 | TS2683 (unchanged) |
| external-module top-level `this` (unaffected) | `undefined` | `undefined` | `undefined` (unchanged) |

### Scope note

This does **not** close #16866's `typeOfThisGeneral.ts` — that fixture bundles at least three more distinct bugs I found while investigating, left for a follow-up (documented on #16866 and the coordination board):
1. `this` in a **parameter default value** (`memberFunc(t = this)`, static or arrow) resolves incorrectly — a different code path than the body case fixed here.
2. A **static accessor's** (`get`/`set`) body `this` wrongly resolves to the instance type instead of the constructor/static type (a regular static *method* body already resolves correctly).
3. `typeof globalThis`'s surface object is too permissive for unrecognized dot-property access (`s.unknownProp = 4` silently passes instead of the implicit-any treatment tsc gives it) — pre-existing and unrelated to `this` dispatch; reproduces with a plain `declare var s: typeof globalThis` and no `this` involved at all.

## Goal
Goal: hold

## Verification
- New `this_lexical_global_type_tests` (7 tests, oracle-verified): 7/7.
- Targeted regression sweep, `cargo test -p tsz-checker --lib -- this global_this thisType typeOfThis`: 371/371, no regressions (includes `ts7041_tests`, `ts2683_tests`, `ts2430_tests`, `window_self_globalthis_resolution_tests`, `global_this_typeof_surface_tests` — all directly adjacent to the changed branches).
- Full `cargo test -p tsz-checker --lib` (~10,800 tests): running in the background at PR-open time; will report back if it surfaces anything.
- `cargo clippy -p tsz-checker --lib --tests -- -D warnings` (via the pre-commit gate): clean.
- `cargo fmt -p tsz-checker -- --check` (via the pre-commit gate): clean.
- `python3 scripts/arch/arch_guard.py` (via the pre-commit gate): passed.
- Manual oracle diff (pinned `typescript@7.0.2`, via a `tsconfig.json` matching the harness's `directives_to_tsconfig` fanout) on the triggering fixture: confirms the two arrow/top-level-`this` false extras (lines 171, 177 of `typeOfThisGeneral.ts`) are gone; the remaining diagnostics there are the three separate bugs noted above.
- `compare-to-parent.sh` / full conformance snapshot: not run this session (55-90+ min on a cold cloud seat); owed as a follow-up. This is a semantic change to `this`-type resolution outside class bodies, so a broader corpus sweep is worth running before landing if another session picks up the drain.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude


---
_Generated by [Claude Code](https://claude.ai/code/session_01FfwJzrbJSxWJJJvUx6sKHK)_