### PR TITLE
fix(checker): setter's leading `this` param no longer leaks into paired getter typing

### DIFF
--- a/crates/tsz-checker/src/checkers/accessor_checker.rs
+++ b/crates/tsz-checker/src/checkers/accessor_checker.rs
@@ -74,6 +74,31 @@ impl<'a> CheckerState<'a> {
         self.contextual_setter_parameter_types_in_members(&members, setter_accessor)
     }
 
+    /// The setter's own *value* parameter — the parameter `tsc`'s
+    /// `getSetAccessorValueParameter` reads for property-type and
+    /// contextual-typing purposes — skipping a leading explicit `this`
+    /// parameter.
+    ///
+    /// A `this` parameter on an accessor is separately illegal (`TS2784`),
+    /// but it is still syntactically present at index 0 and must not be
+    /// mistaken for the value parameter: `set x(this: Foo, n: number)`'s
+    /// value parameter is `n`, not `this: Foo`. Mirrors the same skip
+    /// already applied in `check_setter_parameter_grammar`.
+    pub(crate) fn setter_value_parameter(
+        &self,
+        params: &tsz_parser::parser::NodeList,
+    ) -> Option<(usize, NodeIndex)> {
+        params.nodes.iter().enumerate().find_map(|(i, &param_idx)| {
+            let is_this = self
+                .ctx
+                .arena
+                .get(param_idx)
+                .and_then(|node| self.ctx.arena.get_parameter(node))
+                .is_some_and(|param| self.is_this_parameter_name(param.name));
+            (!is_this).then_some((i, param_idx))
+        })
+    }
+
     /// The contextual types of `setter_accessor`'s parameters, given the
     /// accessor's sibling `members`.
     ///
@@ -87,8 +112,9 @@ impl<'a> CheckerState<'a> {
         members: &[NodeIndex],
         setter_accessor: &tsz_parser::parser::node::AccessorData,
     ) -> Option<Vec<Option<tsz_solver::TypeId>>> {
-        let &first_param_idx = setter_accessor.parameters.nodes.first()?;
-        let param = self.ctx.arena.get_parameter_at(first_param_idx)?;
+        let (value_index, value_param_idx) =
+            self.setter_value_parameter(&setter_accessor.parameters)?;
+        let param = self.ctx.arena.get_parameter_at(value_param_idx)?;
         if param.type_annotation.is_some() && !self.ctx.is_js_file() {
             return None;
         }
@@ -106,7 +132,7 @@ impl<'a> CheckerState<'a> {
         };
 
         let mut contextual_types = vec![None; setter_accessor.parameters.nodes.len()];
-        contextual_types[0] = Some(getter_type);
+        contextual_types[value_index] = Some(getter_type);
         Some(contextual_types)
     }
 
@@ -352,8 +378,8 @@ impl<'a> CheckerState<'a> {
         let setter_member_idx = self.paired_setter_in_members(members, getter_accessor)?;
         let setter_node = self.ctx.arena.get(setter_member_idx)?;
         let setter = self.ctx.arena.get_accessor(setter_node)?;
-        let &first_param_idx = setter.parameters.nodes.first()?;
-        let param = self.ctx.arena.get_parameter_at(first_param_idx)?;
+        let (_, value_param_idx) = self.setter_value_parameter(&setter.parameters)?;
+        let param = self.ctx.arena.get_parameter_at(value_param_idx)?;
         if param.type_annotation.is_none() {
             return None;
         }
@@ -761,11 +787,11 @@ impl<'a> CheckerState<'a> {
                 pairs.entry(name).or_default().0 =
                     Some((accessor.name, accessor.body, accessor.type_annotation));
             } else if node.kind == syntax_kind_ext::SET_ACCESSOR
-                && let Some(&first_param) = accessor.parameters.nodes.first()
-                && let Some(param_node) = self.ctx.arena.get(first_param)
-                && let Some(param) = self.ctx.arena.get_parameter(param_node)
+                && let Some((_, value_param_idx)) =
+                    self.setter_value_parameter(&accessor.parameters)
+                && let Some(param) = self.ctx.arena.get_parameter_at(value_param_idx)
             {
-                pairs.entry(name).or_default().1 = Some((param.type_annotation, first_param));
+                pairs.entry(name).or_default().1 = Some((param.type_annotation, value_param_idx));
             }
         }
 
@@ -864,11 +890,11 @@ impl<'a> CheckerState<'a> {
                 pairs.entry(name).or_default().0 =
                     Some((accessor.name, accessor.body, accessor.type_annotation));
             } else if node.kind == syntax_kind_ext::SET_ACCESSOR
-                && let Some(&first_param) = accessor.parameters.nodes.first()
-                && let Some(param_node) = self.ctx.arena.get(first_param)
-                && let Some(param) = self.ctx.arena.get_parameter(param_node)
+                && let Some((_, value_param_idx)) =
+                    self.setter_value_parameter(&accessor.parameters)
+                && let Some(param) = self.ctx.arena.get_parameter_at(value_param_idx)
             {
-                pairs.entry(name).or_default().1 = Some((param.type_annotation, first_param));
+                pairs.entry(name).or_default().1 = Some((param.type_annotation, value_param_idx));
             }
         }
 

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -17,6 +17,8 @@
 //! here — several of them use `use super::*` and must stay children of the
 //! crate root for that to resolve.
 
+#[path = "tests/accessor_this_parameter_pairing_tests.rs"]
+mod accessor_this_parameter_pairing_tests;
 #[path = "tests/alias_application_display_retention_tests.rs"]
 mod alias_application_display_retention_tests;
 #[path = "tests/ambient_declare_async_modifier_tests.rs"]

--- a/crates/tsz-checker/src/tests/accessor_this_parameter_pairing_tests.rs
+++ b/crates/tsz-checker/src/tests/accessor_this_parameter_pairing_tests.rs
@@ -1,0 +1,146 @@
+//! Regression tests for get/set accessor pairing when the `set` accessor
+//! declares an explicit (illegal, `TS2784`) `this` parameter.
+//!
+//! `tsc`'s `getSetAccessorValueParameter` reads a setter's *value* parameter
+//! — skipping a leading `this` parameter — everywhere it contextually types
+//! the paired getter's return, the setter's own unannotated parameter, or
+//! compares get/set types for `TS2322`. tsz's equivalents
+//! (`contextual_getter_return_type_in_members`,
+//! `contextual_setter_parameter_types_in_members`, and the object-literal /
+//! class accessor type-compatibility checks) instead read
+//! `parameters.nodes.first()` unconditionally, so a setter with an explicit
+//! `this` parameter had that `this` parameter's type mistaken for the value
+//! parameter's type. On top of the correct `TS2784` (`this` parameters are
+//! blanket-illegal on accessors as of TypeScript 7), this produced spurious
+//! extra `TS2322`/`TS2339` diagnostics that `tsc` never reports.
+//!
+//! Every binder name is distinct per test so nothing can key on an
+//! identifier string.
+
+use crate::test_utils::check_source_strict_messages;
+
+fn codes(source: &str) -> Vec<u32> {
+    let mut found: Vec<u32> = check_source_strict_messages(source)
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect();
+    found.sort_unstable();
+    found
+}
+
+#[track_caller]
+fn assert_codes(source: &str, expected: &[u32]) {
+    let found = codes(source);
+    let mut want = expected.to_vec();
+    want.sort_unstable();
+    assert_eq!(found, want, "diagnostics for source:\n{source}");
+}
+
+/// An unannotated getter paired with a setter that has both an explicit
+/// (illegal) `this` parameter and its own annotated value parameter: the
+/// getter's contextual return type must come from the setter's *value*
+/// parameter (`number`), not its `this` parameter (`Wa1`) — so the getter's
+/// `return this.n` body must not draw a spurious `TS2322`.
+#[test]
+fn setter_this_param_does_not_leak_into_getter_contextual_return_type() {
+    assert_codes(
+        r"
+        interface Wa1 { n: number; x: number; }
+        const oa1 = {
+            n: 1,
+            get x() { return this.n; },
+            set x(this: Wa1, n: number) { this.n = n; }
+        };
+        ",
+        &[2784],
+    );
+}
+
+/// Both accessors declare an explicit (illegal) `this` parameter of
+/// *different* types (`Wa2` vs `Wb2`). Only the two `TS2784`s fire — tsc
+/// does not additionally compare the mismatched `this` types via `TS2322`
+/// once the parameter itself is illegal.
+#[test]
+fn mismatched_illegal_this_params_report_only_ts2784() {
+    assert_codes(
+        r"
+        interface Wa2 { n: number; }
+        interface Wb2 { wrong: string; }
+        const oa2 = {
+            n: 1,
+            get x(this: Wa2) { return this.n; },
+            set x(this: Wb2, n) { }
+        };
+        ",
+        &[2784, 2784],
+    );
+}
+
+/// The setter's own leading `this` parameter has no type annotation either
+/// (`set x(this, n)`); the paired getter's inferred return type must not be
+/// cached onto that `this` slot, or `this` inside the setter body is
+/// mistyped as the getter's return type, drawing a spurious `TS2339`.
+#[test]
+fn setter_this_param_without_annotation_does_not_receive_getter_return_type() {
+    assert_codes(
+        r"
+        interface Wa3 { n: number; x: number; }
+        const oa3 = {
+            n: 1,
+            get x(this: Wa3) { return this.n; },
+            set x(this, n) { this.n = n; }
+        };
+        ",
+        &[2784, 2784],
+    );
+}
+
+/// Control: with no `this` parameter on either accessor, a genuine
+/// getter/setter type mismatch must still report `TS2322` — the fix must
+/// not suppress the real diagnostic, only the `this`-parameter misread.
+#[test]
+fn genuine_getter_setter_type_mismatch_without_this_param_still_reports() {
+    assert_codes(
+        r"
+        interface Wa4 { wrong: string; }
+        const oa4 = {
+            get x() { return 1; },
+            set x(v: Wa4) { }
+        };
+        ",
+        &[2322],
+    );
+}
+
+/// Control: a setter whose own value parameter is annotated and a plain
+/// (no `this`) unannotated getter must still contextually type the getter's
+/// return from that annotation, unaffected by the `this`-skip change.
+#[test]
+fn unannotated_getter_still_takes_setter_value_param_type_without_this() {
+    assert_codes(
+        r"
+        const oa5 = {
+            get x() { return 1; },
+            set x(v: string) { }
+        };
+        ",
+        &[2322],
+    );
+}
+
+/// Class-accessor mirror of the object-literal case: an explicit `this`
+/// parameter on a class setter must not leak into the paired getter's
+/// contextual return type or the type-compatibility check.
+#[test]
+fn class_setter_this_param_does_not_leak_into_paired_getter() {
+    assert_codes(
+        r"
+        class Ca6 {
+            n: number = 1;
+            get x() { return this.n; }
+            set x(this: Ca6, n: number) { this.n = n; }
+        }
+        ",
+        &[2784],
+    );
+}

--- a/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
@@ -258,14 +258,13 @@ impl<'a> CheckerState<'a> {
                 }
                 self.get_type_of_function(elem_idx);
 
-                // Extract setter write type from first parameter.
+                // Extract setter write type from its value parameter (skipping
+                // a leading explicit `this` parameter, which is separately
+                // illegal via TS2784 and never the write type).
                 // When no type annotation, fall back to the paired getter's
                 // return type (mirroring tsc's inference behavior).
-                accessor
-                    .parameters
-                    .nodes
-                    .first()
-                    .and_then(|&param_idx| {
+                self.setter_value_parameter(&accessor.parameters)
+                    .and_then(|(_, param_idx)| {
                         let param = self.ctx.arena.get_parameter_at(param_idx)?;
                         if param.type_annotation.is_none() {
                             None


### PR DESCRIPTION
When a `set` accessor declares an explicit `this` parameter, `tsc`'s `getSetAccessorValueParameter` always skips it to find the setter's real value parameter for get/set pairing purposes (contextual getter-return-type, contextual setter-parameter-type, and get/set type-compatibility checks). tsz's equivalents instead read `parameters.nodes.first()` unconditionally, so an explicit (already-illegal, TS2784) `this` parameter on a setter had its type mistaken for the setter's value-parameter type — leaking into the paired getter's contextual return type, the setter's own `this`-parameter node (via cached contextual types), and the get/set type-compatibility check. On top of the correct TS2784, this produced spurious extra TS2322/TS2339 diagnostics `tsc` never reports.

**Structural rule:** when a `set` accessor's parameter list has a leading explicit `this` parameter, `tsc` skips it to find the value parameter for every pairing decision; tsz now does the same through a shared `setter_value_parameter` helper in `crates/tsz-checker/src/checkers/accessor_checker.rs`, which mirrors the identical skip already applied in `check_setter_parameter_grammar`.

**What changed** — routed four `.parameters.nodes.first()` call sites through `setter_value_parameter`:
- `contextual_setter_parameter_types_in_members` (`accessor_checker.rs`) — was caching the getter's return type onto the setter's `this`-parameter node instead of its value parameter.
- `contextual_getter_return_type_in_members` (`accessor_checker.rs`) — was contextually typing an unannotated getter's return from the setter's `this`-parameter type instead of its value-parameter annotation.
- `check_accessor_type_compatibility` / `check_object_literal_accessor_type_compatibility` (`accessor_checker.rs`, class and object-literal variants) — were comparing the getter's inferred return type against the setter's `this`-parameter type instead of its value-parameter type.
- The "extract setter write type" site in `accessor_element.rs` (object-literal property-type computation).

**Adjacent-case matrix** (`accessor_this_parameter_pairing_tests.rs`, 6 tests, distinct binder names per case):
| shape | expected |
| --- | --- |
| unannotated getter + setter with explicit `this` + annotated value param | `TS2784` only (no leaked `TS2322`) |
| both accessors have explicit, *mismatched* `this` params | `TS2784` ×2 only (no `TS2322` from comparing the illegal `this` types) |
| setter's `this` param itself unannotated, paired with explicit-`this` getter | `TS2784` ×2 only (no leaked `TS2339` on the setter's `this`) |
| control: no `this` param anywhere, genuine getter/setter mismatch | `TS2322` still reported |
| control: no `this` param, setter value param types the getter | unaffected |
| class-accessor mirror of the first case | `TS2784` only |

## Goal
Goal: hold

Closes two of #16866's `extra TS2322` one-away tests — `compiler/conformance/types/thisType/thisTypeInAccessors.ts` and `thisTypeInAccessorsNegative.ts` — both now byte-for-byte oracle matches. `thisTypeInObjectLiterals2.ts` (same #16866 bucket) is also confirmed clean post-fix, though it's unclear whether that was caused by this bug or a stale-snapshot artifact (no explicit `this` params in that fixture). `thisTypeInFunctions.ts` (same file-name family, different root cause — function-type `this`-parameter assignability, not accessor pairing) is unaffected and stays open for a future session.

## Verification
- Oracle: pinned `typescript@7.0.2` via `scripts/conformance/oracle.sh --strict --noImplicitAny true --noImplicitThis true --target es2015 --lib es2015`, byte-for-byte match on both `thisTypeInAccessors.ts` and `thisTypeInAccessorsNegative.ts`.
- `cargo test -p tsz-checker --lib -- accessor_this_parameter_pairing`: 6/6 new tests pass.
- `cargo test -p tsz-checker --lib -- accessor this_parameter setter getter`: 227/227 pass (no regressions in the existing accessor/this-parameter/getter/setter families, including `ts2322_tests`, `ts2411_tests`, `ts7032_zero_parameter_setter_tests`).
- Full `cargo test -p tsz-checker --lib` (~10,800 tests): running in the background at PR-open time (exceeded a 580s foreground wait twice); will post the count as a follow-up.
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`: clean.
- `cargo fmt --check -p tsz-checker`: clean.
- `python3 scripts/arch/arch_guard.py`: clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUa8mpV6iCpAaodM7rGGE5)_