### PR TITLE
fix(checker): the this-parameter protected widening is instance-side only

### DIFF
--- a/crates/tsz-checker/src/checkers/property_checker.rs
+++ b/crates/tsz-checker/src/checkers/property_checker.rs
@@ -306,8 +306,9 @@ impl<'a> CheckerState<'a> {
         // widening at all — tsc denies even an exact-class `this: Foo` free
         // function (TS2341) — so `current_class_idx` itself stays unwidened
         // for that branch.
+        // ...instance-side only; see the helper for why statics are excluded.
         let protected_context_class_idx = self
-            .resolve_this_parameter_class_context(error_node)
+            .resolve_this_parameter_class_context(error_node, is_static)
             .or(current_class_idx);
         let protected_candidates =
             self.protected_access_candidate_classes(protected_context_class_idx, object_expr);

--- a/crates/tsz-checker/src/symbols/symbol_resolver_utils.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver_utils.rs
@@ -1538,10 +1538,23 @@ impl<'a> CheckerState<'a> {
     /// must see `B` as the current class the same way a method body would.
     /// Mirrors `resolve_class_for_access`'s constraint walk so a generic
     /// `this: T extends Foo` resolves through `T`'s constraint to `Foo`.
+    ///
+    /// `is_static` is the accessed member's staticness, and a `true` here means
+    /// no context at all: a `this` parameter constrains the receiver *instance*
+    /// and says nothing about the class object's static side. tsc keeps
+    /// `function f(this: MyClass) { MyClass.protectedStatic }` at `TS2445` for
+    /// exactly that reason. Widening statics too silently accepted three
+    /// `TS2445`s in `conformance/types/thisType/thisTypeAccessibility.ts`
+    /// (#16894) — the false-negative direction, and invisible to a code-set
+    /// comparison because that row's other `TS2445`s kept the code present.
     pub(crate) fn resolve_this_parameter_class_context(
         &mut self,
         idx: NodeIndex,
+        is_static: bool,
     ) -> Option<NodeIndex> {
+        if is_static {
+            return None;
+        }
         let enclosing_fn = self.find_enclosing_non_arrow_function(idx)?;
         let fn_node = self.ctx.arena.get(enclosing_fn)?;
         let params: &[NodeIndex] = if let Some(f) = self.ctx.arena.get_function(fn_node) {
@@ -1582,8 +1595,10 @@ impl<'a> CheckerState<'a> {
             }
             // No literal enclosing class: fall back to the nearest enclosing
             // free function's own `this` parameter type, which is what the
-            // receiver's runtime type is bound by in that case.
-            return self.resolve_this_parameter_class_context(expr_idx);
+            // receiver's runtime type is bound by in that case. `is_static:
+            // false` — this arm only runs for a `this`/`super` receiver, which
+            // is instance-side by construction.
+            return self.resolve_this_parameter_class_context(expr_idx, false);
         }
 
         if self

--- a/crates/tsz-checker/src/tests/ts2445_protected_access_via_subclass_this_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2445_protected_access_via_subclass_this_tests.rs
@@ -190,3 +190,76 @@ class Garage {
         "Renamed variant: narrower `this: Car` must allow other.wheels. Got: {codes:?}"
     );
 }
+
+/// #16894: the `this: T` widening is **instance-side only**. A `this` parameter
+/// says what the receiver instance is; it grants nothing on the class object's
+/// static side, so a `protected static` reached through the class name stays
+/// `TS2445` in tsc even inside a function whose `this` is that exact class.
+///
+/// This regressed when the widening first landed and silenced three `TS2445`s in
+/// `conformance/types/thisType/thisTypeAccessibility.ts`. It hid well: that row's
+/// code *set* was unchanged (other `TS2445`s remained), so only the count moved,
+/// and net conformance still went up because two other rows were fixed.
+#[test]
+fn ts2445_on_protected_static_via_class_object_despite_this_param() {
+    let source = "\
+class MyClass { protected static spp: number = 0; }
+const f = function (this: MyClass, p: number) { MyClass.spp = p; };
+";
+    let codes = diag_codes(source);
+    assert!(
+        codes.contains(&2445),
+        "MyClass.spp is a protected static reached through the class object; a `this: MyClass` \
+         parameter must not grant access. Got: {codes:?}"
+    );
+}
+
+/// The paired instance case, so the row above cannot be satisfied by simply
+/// disabling the widening: the same class and the same `this` parameter must
+/// still allow instance-side access to a protected member.
+#[test]
+fn no_ts2445_on_protected_instance_via_this_param() {
+    let source = "\
+class MyClass { protected pp: number = 0; }
+const f = function (this: MyClass, p: number) { this.pp = p; };
+";
+    let codes = diag_codes(source);
+    assert!(
+        !codes.contains(&2445),
+        "this.pp is instance-side access under an exact `this: MyClass`; must be allowed. \
+         Got: {codes:?}"
+    );
+}
+
+/// Control isolating the trigger: the identical static access *without* a `this`
+/// parameter was always denied, so a green result above must come from the
+/// static/instance split rather than from static access being denied generally.
+#[test]
+fn ts2445_on_protected_static_without_any_this_param() {
+    let source = "\
+class MyClass { protected static spp: number = 0; }
+const f = function (p: number) { MyClass.spp = p; };
+";
+    let codes = diag_codes(source);
+    assert!(
+        codes.contains(&2445),
+        "protected static via the class object is denied with no `this` parameter at all. \
+         Got: {codes:?}"
+    );
+}
+
+/// Control isolating the access level: a `private` static under the same `this`
+/// parameter reports `TS2341` and never took part in the widening, so the fix
+/// must not be keyed on staticness alone.
+#[test]
+fn ts2341_on_private_static_via_class_object_despite_this_param() {
+    let source = "\
+class MyClass { private static sp: number = 0; }
+const f = function (this: MyClass, p: number) { MyClass.sp = p; };
+";
+    let codes = diag_codes(source);
+    assert!(
+        codes.contains(&2341),
+        "private static keeps TS2341 regardless of the `this` parameter. Got: {codes:?}"
+    );
+}


### PR DESCRIPTION
Fixes #16894. Restores the three `TS2445`s #16892 silenced, without giving back any of the five behaviours it fixed.

Goal: hold

## The divergence

#16892 correctly made an explicit `this: T` parameter widen the accessibility context for `protected` access. That is right for instance-side access — but it also reached the class object's **static** side:

```ts
class MyClass { protected static spp: number = 0; }
const f = function (this: MyClass, p: number) { MyClass.spp = p; };
// tsc: TS2445 · main: silent
```

A `this` parameter constrains the receiver *instance*; it says nothing about the static side. tsc keeps this at `TS2445`.

| case | tsc 7.0.2 | main | this PR |
|---|---|---|---|
| `protected static` via class object, with `this: MyClass` | `TS2445` | *silent* | ✓ **fixed** |
| `protected` instance via `this`, same class | clean | clean | ✓ unchanged |
| `protected static`, **no** `this` parameter | `TS2445` | `TS2445` | ✓ unchanged |
| `private static` with `this: MyClass` | `TS2341` | `TS2341` | ✓ unchanged |

Rows 3 and 4 localize the defect rather than just demonstrating it: row 3 shows the `this` parameter was the trigger (the same static access without one was always denied), and row 4 shows it was specific to `protected` (private never took part in the widening). Together they mean the fix has to be the static/instance split and not something coarser.

**And all five of #16892's behaviours are preserved**, re-checked after the refactor:

| case | tsc | this PR |
|---|---|---|
| same-hierarchy `this: T extends B`, `arg: B` | allow | ✓ |
| cross-hierarchy `this: T extends C`, `arg: B` | `TS2445` | ✓ still denied |
| class member with `this: T` | allow | ✓ |
| renamed binders (`Vehicle`/`Car`) | allow | ✓ |
| plain outside access | `TS2445` | ✓ |

`conformance/types/thisType/thisTypeAccessibility.ts` is byte-identical to tsc again (`TS2341`x8 `TS2445`x4 `TS2564`x3).

## Why it hid

Worth recording, because the shape recurs. That row's **code set never changed** — other `TS2445`s in the file kept the code present — so `{"e":[TS2341,TS2445,TS2564],"a":[TS2341,TS2445,TS2564]}` and a code-set comparison scores it as passing. Only the count moved, 4 → 1. And net conformance still went **+1**, because #16892 fixed two other rows, so a totals-only check read it as a clean win. Both unit lanes were green too. Set-difference on the failing-row set was the only thing that saw it.

## Implementation note

The staticness is threaded into `resolve_this_parameter_class_context`, which returns `None` for a static member so the caller falls back to the literal enclosing class. Putting the rule in the helper rather than branching at the call site was partly deliberate for a second reason: `property_checker.rs` was sitting at 1996 lines, and an inline branch plus its comment took it to **2006** — over the 2000 ceiling. The helper form leaves it at 1997 with headroom, and arguably belongs there anyway since the helper owns "what class does this `this` parameter establish".

The one other call site (`resolve_receiver_class_for_access`) passes `is_static: false`, which is correct by construction — that arm only runs for a `this`/`super` receiver.

## Verification

- `cargo nextest run -p tsz-checker --lib` — **10802/10802**
- `cargo nextest run -p tsz-binder -p tsz-core -p tsz-solver -p tsz-parser -p tsz-emitter --lib` — **17557/17557**
- `cargo clippy -p tsz-checker --all-targets` — 0 diagnostics
- `python3 scripts/arch/arch_guard.py` — rc=0 (it caught the 2006-line version; the fix is not an allowlist entry)
- 4 tests added to #16892's own suite. **1 fails on main** — the regression row — while the other 3 are controls that correctly pass, which is the shape I want: the defect test flips, the guards don't.
- 9-row diagnostic matrix above, all matching the pinned 7.0.2 oracle

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high
