### PR TITLE
fix(checker): TS2403 no longer self-suppresses when two distinct types render the same name (#16888)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/type_value.rs
+++ b/crates/tsz-checker/src/error_reporter/type_value.rs
@@ -30,8 +30,8 @@ impl<'a> CheckerState<'a> {
         // (`{ x: number; y: number; }` not `{ x: 0; y: 0; }`), matching tsc.
         // But preserve top-level literal/union-of-literal types so explicit
         // annotations like `var x: 5; var x: 6;` keep their literal form
-        // (`'5'` / `'6'`) instead of collapsing to `number`/`number` (which
-        // would also self-suppress via the equal-display short-circuit below).
+        // (`'5'` / `'6'`) instead of collapsing to `number`/`number`, matching
+        // the exact type names tsc renders for this pair.
         //
         // Use the widened formatter (no display-property side-table fallback)
         // so the widened shape is actually rendered — `format_type_diagnostic`
@@ -49,14 +49,17 @@ impl<'a> CheckerState<'a> {
         let current_type_str = self
             .ts2403_typeof_fundule_initializer_display(idx)
             .unwrap_or_else(|| self.format_type_for_redeclaration_message(current_display));
-        // Suppress when both types format to the same name. This handles cross-binder
-        // scenarios where a lib_checker resolves a type annotation (e.g., `Document`)
-        // to a separate DefId from the main checker's version. Interface declaration
-        // merging means both annotations semantically refer to the same type, but
-        // different internal TypeIds prevent the structural check from recognizing this.
-        if prev_type_str == current_type_str {
-            return;
-        }
+        // Whether these two declarations share a type is owned entirely by
+        // `are_var_decl_types_compatible` — the caller only reaches this reporter after
+        // it returned `false`. This reporter renders; it must not re-judge identity, and
+        // must not key on the rendered names. Two genuinely distinct nominal types
+        // routinely share a simple display name (`A.Foo` vs `B.Foo`, distinct only by
+        // their private brands), and tsc reports TS2403 for them regardless of the shared
+        // name. Suppressing on `prev_type_str == current_type_str` dropped exactly that
+        // diagnostic — the "formatted diagnostic string used as a semantic predicate" the
+        // Anti-Hardcoding Gate forbids. A cross-binder pair that truly refers to one merged
+        // type (e.g. two `Document` annotations resolved by separate checkers) is unified
+        // structurally in `are_types_identical_for_redeclaration`, so it never reaches here.
         let message = format!(
             "Subsequent variable declarations must have the same type. Variable '{name}' must be of type '{prev_type_str}', but here has type '{current_type_str}'."
         );

--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -1911,3 +1911,7 @@ mod core_tests;
 #[cfg(test)]
 #[path = "contextual_param_ts2403_tests.rs"]
 mod contextual_param_ts2403_tests;
+
+#[cfg(test)]
+#[path = "ts2403_same_name_distinct_brand_tests.rs"]
+mod ts2403_same_name_distinct_brand_tests;

--- a/crates/tsz-checker/src/state/variable_checking/ts2403_same_name_distinct_brand_tests.rs
+++ b/crates/tsz-checker/src/state/variable_checking/ts2403_same_name_distinct_brand_tests.rs
@@ -1,0 +1,118 @@
+//! TS2403 must fire whenever the two redeclaration types are genuinely
+//! distinct, even when they render to the same simple display name.
+//!
+//! The diagnostic reporter previously self-suppressed on
+//! `prev_type_str == current_type_str`, silently dropping TS2403 for
+//! same-named-but-nominally-distinct classes (`A.Foo` vs `B.Foo`, distinct
+//! only by their private brands). The identity decision belongs to
+//! `are_var_decl_types_compatible`; the reporter only renders. Binder names
+//! are varied deliberately so no test depends on a specific identifier.
+//!
+//! Oracle: `compiler/propertyIdentityWithPrivacyMismatch.ts` (tsc 7.0.2 reports
+//! TS2403 for both the same-name-across-modules and the renamed-class pairs).
+
+use crate::test_utils::check_source_diagnostics;
+
+/// TS2403 diagnostics for `source` as `(start, message)` pairs.
+fn ts2403(source: &str) -> Vec<(u32, String)> {
+    check_source_diagnostics(source)
+        .iter()
+        .filter(|d| d.code == 2403)
+        .map(|d| (d.start, d.message_text.clone()))
+        .collect()
+}
+
+#[test]
+fn namespace_same_class_name_distinct_private_brand_emits_ts2403() {
+    // Two classes with the same simple name in different namespaces are distinct
+    // nominal types (distinct private brands). Both render as `Widget`, but tsc
+    // still reports TS2403.
+    let source = r#"
+namespace Left { export class Widget { private n: number = 0; } }
+namespace Right { export class Widget { private n: number = 0; } }
+var w: Left.Widget;
+var w: Right.Widget;
+"#;
+    let diags = ts2403(source);
+    assert_eq!(diags.len(), 1, "Expected 1 TS2403: {diags:?}");
+    assert!(
+        diags[0].1.contains("'Widget'"),
+        "Message should name the shared display name: {diags:?}"
+    );
+}
+
+#[test]
+fn namespace_same_class_name_distinct_protected_brand_emits_ts2403() {
+    // Protected members carry the same nominal brand as private for identity.
+    let source = r#"
+namespace Alpha { export class Node { protected tag: string = ""; } }
+namespace Beta { export class Node { protected tag: string = ""; } }
+var t: Alpha.Node;
+var t: Beta.Node;
+"#;
+    let diags = ts2403(source);
+    assert_eq!(diags.len(), 1, "Expected 1 TS2403: {diags:?}");
+}
+
+#[test]
+fn ambient_module_same_class_name_distinct_private_brand_emits_ts2403() {
+    // The original witness shape: same class name across two ambient modules.
+    let source = r#"
+declare module "one" { export class Cell { private v: number; } }
+declare module "two" { export class Cell { private v: number; } }
+import a = require("one");
+import b = require("two");
+var c: a.Cell;
+var c: b.Cell;
+"#;
+    let diags = ts2403(source);
+    assert_eq!(diags.len(), 1, "Expected 1 TS2403: {diags:?}");
+}
+
+#[test]
+fn renamed_class_distinct_private_brand_emits_ts2403() {
+    // Guards the sibling private-brand fix: differently-named classes still
+    // report. This path never hit the same-name suppression, but the two must
+    // stay coupled so a future regression in either is caught here.
+    let source = r#"
+class Panel { private n: number = 0; }
+class Board { private n: number = 0; }
+var p: Panel;
+var p: Board;
+"#;
+    let diags = ts2403(source);
+    assert_eq!(diags.len(), 1, "Expected 1 TS2403: {diags:?}");
+}
+
+#[test]
+fn namespace_same_class_same_brand_no_ts2403() {
+    // Redeclaring against the SAME class is identical — must stay clean.
+    let source = r#"
+namespace Only { export class Gizmo { private n: number = 0; } }
+var g: Only.Gizmo;
+var g: Only.Gizmo;
+"#;
+    let diags = ts2403(source);
+    assert_eq!(
+        diags.len(),
+        0,
+        "No TS2403 for identical redeclaration: {diags:?}"
+    );
+}
+
+#[test]
+fn structurally_identical_interface_no_ts2403() {
+    // Interfaces have no private brand; an interface and a structurally identical
+    // object type are redeclaration-identical and must stay clean.
+    let source = r#"
+interface Shape { x: number; }
+var s: Shape;
+var s: { x: number };
+"#;
+    let diags = ts2403(source);
+    assert_eq!(
+        diags.len(),
+        0,
+        "No TS2403 for structural identity: {diags:?}"
+    );
+}


### PR DESCRIPTION
Fixes #16888.

The TS2403 reporter (`error_subsequent_variable_declaration`) dropped the diagnostic whenever the two redeclaration types formatted to the same display string:

```rust
if prev_type_str == current_type_str {
    return;
}
```

That is a "formatted diagnostic string used as a semantic predicate" — the Anti-Hardcoding Gate forbids it — and it over-suppressed. Two genuinely distinct nominal types that share a simple name (`A.Foo` vs `B.Foo`, distinguished only by their private brands) both render as `Foo`, so tsz silently dropped a TS2403 that tsc reports.

**Structural rule:** when two `var` redeclarations' resolved types are non-identical per `are_types_identical_for_redeclaration` (owner: solver `CompatChecker`, via `are_var_decl_types_compatible`), tsc reports TS2403 regardless of whether the two types render to the same display name; tsz was re-judging identity in the display reporter and dropping it.

The identity decision is already owned by `are_var_decl_types_compatible` — the reporter is only reached after it returned "not identical". The cross-binder merged-interface case the suppression was meant to protect (e.g. two `Document` annotations resolved by separate checkers) is unified structurally in `are_types_identical_for_redeclaration` (structurally-identical interfaces are bidirectional subtypes → compatible → the reporter is never reached). Confirmed empirically: removing the suppression produced **zero** false positives across the whole corpus. The reporter now renders unconditionally.

This fixes the `x` (same-name / distinct-brand) half of `compiler/propertyIdentityWithPrivacyMismatch.ts`; the `y` (renamed-binder) half was fixed by the sibling private-brand change (#16891).

## Goal
Goal: hold

<!-- when two var redeclarations resolve to non-identical types, tsc reports TS2403; tsz was suppressing it in the display reporter whenever the two rendered names matched. -->

## Verification
- Conformance snapshot (`scripts/conformance/conformance.sh snapshot --workers 12 --force`), before vs after on this machine: **11537 → 11538 PASS**, exactly `compiler/propertyIdentityWithPrivacyMismatch.ts` flips FAIL → PASS, **0 regressions** across 12042 tests.
- Repro matrix matches tsc (`--noEmit --pretty false`):
  - `namespace A { export class Foo { private n=0 } } namespace B { export class Foo { private n=0 } } var x: A.Foo; var x: B.Foo;` → TS2403 (`must be of type 'Foo', but here has type 'Foo'`) — was silently dropped.
  - `A.Foo` vs `A.Foo` → clean; renamed `Foo1`/`Foo2` → TS2403; `number`/`string` → TS2403.
- Unit tests: new `ts2403_same_name_distinct_brand_tests.rs` (6 cases, binder names varied) + existing `ts2403` / `variable_checking::core` / `error_reporter` / `redeclaration` suites all pass.
- `cargo clippy -p tsz-checker --lib --tests -- -D warnings` clean; pre-commit architecture guard passed (new tests extracted to their own file to keep `core_tests.rs` under 2000 lines).

## Provenance
Machine: cloud
Assistant: claude-code
Model: withheld (undercover session)
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjxZHeQ9e6LX4XwnYv444Z)_