### PR TITLE
fix(parser): TS1182 destructuring-initializer check skips ambient .d.ts files, not just `declare`

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -79,6 +79,9 @@ pub(crate) mod test_fixture;
 // without grepping a single monolithic file. Each shard imports only the
 // `test_fixture` helpers it actually uses; tests share no per-shard helpers.
 #[cfg(test)]
+#[path = "../../tests/ambient_destructuring_initializer_tests.rs"]
+mod ambient_destructuring_initializer_tests;
+#[cfg(test)]
 #[path = "../../tests/definite_assignment_assertion_tests.rs"]
 mod definite_assignment_assertion_tests;
 #[cfg(test)]

--- a/crates/tsz-parser/src/parser/state_variable_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_variable_declarations.rs
@@ -311,10 +311,16 @@ impl ParserState {
         // TS1182 — `const {x}\n!foo;` still reports the missing initializer.
         let stray_same_line_definite_assignment =
             self.is_token(SyntaxKind::ExclamationToken) && !self.scanner.has_preceding_line_break();
+        // Skip in every ambient declaration, not just `declare`-flagged ones: a
+        // destructuring `var`/`let`/`const` at the top level of a `.d.ts` file is
+        // ambient by virtue of the file and never carries an initializer, so tsc
+        // reports no TS1182 there. `in_ambient_context()` only covers the
+        // `CONTEXT_FLAG_AMBIENT` set inside a `declare`, missing the whole-file case;
+        // `in_ambient_declaration()` covers both.
         if !is_catch_clause
             && initializer.is_none()
             && !stray_same_line_definite_assignment
-            && !self.in_ambient_context()
+            && !self.in_ambient_declaration()
             && let Some(name_node) = self.arena.get(name)
             && name_node.is_binding_pattern()
         {

--- a/crates/tsz-parser/tests/ambient_destructuring_initializer_tests.rs
+++ b/crates/tsz-parser/tests/ambient_destructuring_initializer_tests.rs
@@ -1,0 +1,89 @@
+//! TS1182 ("A destructuring declaration must have an initializer") is a grammar
+//! check tsc skips in **every** ambient declaration, not just `declare`-flagged
+//! ones. A destructuring `var`/`let`/`const` at the top level of a `.d.ts` file
+//! is ambient by virtue of the file and never carries an initializer, so tsc
+//! reports nothing there.
+//!
+//! tsz previously gated the suppression on `in_ambient_context()`, which only
+//! tracks the `CONTEXT_FLAG_AMBIENT` set inside a `declare` — so a top-level
+//! `.d.ts` destructuring declaration wrongly drew TS1182. The fix consults
+//! `in_ambient_declaration()`, which also covers whole `.d.ts` files.
+//!
+//! Binder names are varied so the behavior is structural, not identifier-keyed.
+
+use crate::parser::test_fixture::parse_source_named;
+use tsz_common::diagnostics::diagnostic_codes;
+
+fn codes(file_name: &str, source: &str) -> Vec<u32> {
+    let (parser, _) = parse_source_named(file_name, source);
+    parser.get_diagnostics().iter().map(|d| d.code).collect()
+}
+
+fn has_ts1182(file_name: &str, source: &str) -> bool {
+    codes(file_name, source)
+        .contains(&diagnostic_codes::A_DESTRUCTURING_DECLARATION_MUST_HAVE_AN_INITIALIZER)
+}
+
+// ---------------------------------------------------------------------------
+// Ambient by file (`.d.ts`): no initializer required, so no TS1182.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn declaration_file_object_destructuring_no_ts1182() {
+    for (name, source) in [
+        ("a.d.ts", "export var { a, b }: Foo;"),
+        ("lib.d.ts", "export let { first, second }: Pair;"),
+        ("types.d.ts", "export const { x, y }: Point;"),
+        ("m.d.mts", "export var { one }: Wrap;"),
+    ] {
+        assert!(
+            !has_ts1182(name, source),
+            "no TS1182 expected in ambient .d.ts for {source:?}, got {:?}",
+            codes(name, source)
+        );
+    }
+}
+
+#[test]
+fn declaration_file_object_rest_and_array_patterns_no_ts1182() {
+    assert!(!has_ts1182("a.d.ts", "export var { a, ...rest }: Foo;"));
+    assert!(!has_ts1182("a.d.ts", "export var [head, tail]: Tuple;"));
+}
+
+// ---------------------------------------------------------------------------
+// Ambient by `declare` keyword: already correct, kept as a coupled guard.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn declare_keyword_destructuring_no_ts1182() {
+    assert!(!has_ts1182("m.ts", "declare var { a, b }: Foo;"));
+    assert!(!has_ts1182(
+        "m.ts",
+        "declare namespace N { export var { value }: Foo; }"
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// Non-ambient: the grammar rule still applies — TS1182 must fire.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn non_ambient_destructuring_without_initializer_reports_ts1182() {
+    for (name, source) in [
+        ("m.ts", "var { a, b }: Foo;"),
+        ("m.ts", "let { first }: Pair;"),
+        ("app.ts", "const { x, y }: Point;"),
+    ] {
+        assert!(
+            has_ts1182(name, source),
+            "TS1182 expected for non-ambient {source:?}, got {:?}",
+            codes(name, source)
+        );
+    }
+}
+
+#[test]
+fn non_ambient_destructuring_with_initializer_no_ts1182() {
+    // Sanity: a plain declaration with an initializer never trips the rule.
+    assert!(!has_ts1182("m.ts", "var { a, b } = obj;"));
+}


### PR DESCRIPTION
A destructuring `var`/`let`/`const` at the top level of a `.d.ts` file — e.g. `export var { a, ...x }: Foo;` — is ambient by virtue of the file. Like every ambient declaration it never carries an initializer, so tsc reports no **TS1182** ("A destructuring declaration must have an initializer") there. tsz gated the suppression on `in_ambient_context()`, which only tracks the `CONTEXT_FLAG_AMBIENT` flag set inside a `declare`, so a destructuring declaration at the top level of a declaration file (no `declare` keyword) drew a false TS1182.

**Structural rule:** TS1182 is a grammar check tsc skips in *every* ambient declaration; the parser suppression must consult `in_ambient_declaration()` (`in_ambient_context() || is_declaration_file()`) — whose own doc comment states exactly this ("Grammar checks that tsc skips in ambient contexts … should consult this") — not `in_ambient_context()` alone.

The change can only *remove* a TS1182 in ambient contexts — it never adds a diagnostic and never touches non-ambient code — and tsc emits no TS1182 in ambient contexts, so no test can expect one there.

## Goal
Goal: hold

<!-- when a destructuring declaration sits in an ambient declaration (`.d.ts` file or `declare`), tsc emits no TS1182; tsz's parser suppression covered only the `declare` case and missed whole `.d.ts` files. -->

## Verification
- Conformance snapshot (`scripts/conformance/conformance.sh snapshot --workers 12 --force`) vs this session's baseline: **0 regressions** across 12042 tests; `compiler/importHelpersInAmbientContext.ts` flips FAIL → PASS (the other improvements in the diff come from unrelated PRs that merged into `main` during the run).
- Repro (`.target/dist-fast/tsz --noEmit --pretty false`):
  - `a.d.ts` containing `export var { a, ...x }: Foo;` → clean (was TS1182).
  - `declare var { a, ...x }: Foo;` in a `.ts` file → clean (already worked).
  - plain `.ts` `var { a, ...x }: Foo;` (no initializer) → still TS1182.
  - a `.ts` file literally named `d.ts` still reports — the check is file-kind-based (`.d.ts`), not name-substring-based.
- Parser unit tests: new `crates/tsz-parser/tests/ambient_destructuring_initializer_tests.rs` (5 cases, binder names varied) all pass; full `-p tsz-parser` clippy + architecture guard pass via the pre-commit hook.

## Provenance
Machine: cloud
Assistant: claude-code
Model: withheld (undercover session)
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjxZHeQ9e6LX4XwnYv444Z)_