### PR TITLE
fix(checker): removed `assert` import-attribute keyword abandons the whole declaration (TS2880)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -32,6 +32,9 @@ dashmap = { workspace = true }
 web-time = { workspace = true }
 stacker = "0.1.23"
 [[test]]
+name = "import_assert_keyword_abandon_tests"
+path = "tests/import_assert_keyword_abandon_tests.rs"
+[[test]]
 name = "enum_member_binding_widening_tests"
 path = "tests/enum_member_binding_widening_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/declarations/import/declaration_attributes.rs
+++ b/crates/tsz-checker/src/declarations/import/declaration_attributes.rs
@@ -57,6 +57,49 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Whether an import/export declaration's attributes clause uses the removed
+    /// `assert` keyword rather than `with`.
+    ///
+    /// In TypeScript 7 the `assert` import-attribute keyword has been removed:
+    /// `tsc` reports TS2880 at the `assert` keyword and then *abandons the entire
+    /// declaration* — it never resolves the module specifier (no TS2307), never
+    /// checks the attribute values (no TS2858/TS2322), and never runs the
+    /// module-support / type-only / CommonJS attribute grammar. This holds at
+    /// every module mode (`esnext`, `node18`, `node20`, `nodenext`, `preserve`,
+    /// and even the attribute-unsupported `commonjs`), so it takes precedence
+    /// over all of them. Callers use this to short-circuit before any of those
+    /// checks run. Oracle-confirmed against `typescript@7.0.2`.
+    pub(crate) fn import_attributes_use_removed_assert(&self, attributes_idx: NodeIndex) -> bool {
+        if attributes_idx.is_none() {
+            return false;
+        }
+        let Some(attr_node) = self.ctx.arena.get(attributes_idx) else {
+            return false;
+        };
+        let Some(attrs_data) = self.ctx.arena.get_import_attributes_data(attr_node) else {
+            return false;
+        };
+        attrs_data.token == SyntaxKind::AssertKeyword as u16
+    }
+
+    /// TS2880: report the removed `assert` import-attribute keyword.
+    ///
+    /// Anchored at the `assert` keyword — the attributes clause start — with
+    /// length 6 (`assert`), matching `tsc`. The caller is responsible for
+    /// abandoning the rest of the declaration after this fires; see
+    /// [`Self::import_attributes_use_removed_assert`].
+    pub(crate) fn report_removed_import_assert(&mut self, attributes_idx: NodeIndex) {
+        let Some(attr_node) = self.ctx.arena.get(attributes_idx) else {
+            return;
+        };
+        self.error_at_position(
+            attr_node.pos,
+            6, // length of "assert"
+            diagnostic_messages::IMPORT_ASSERTIONS_HAVE_BEEN_REPLACED_BY_IMPORT_ATTRIBUTES_USE_WITH_INSTEAD_OF_AS,
+            diagnostic_codes::IMPORT_ASSERTIONS_HAVE_BEEN_REPLACED_BY_IMPORT_ATTRIBUTES_USE_WITH_INSTEAD_OF_AS,
+        );
+    }
+
     /// Grammar validation for an import/export declaration's attributes clause
     /// (`with { ... }` / `assert { ... }`).
     ///
@@ -64,6 +107,15 @@ impl<'a> CheckerState<'a> {
     /// matters because each step *returns* (suppressing later steps), and the
     /// diagnostic code depends on whether the deprecated `assert` keyword or the
     /// `with` keyword was used:
+    ///
+    /// In TypeScript 7 the removed `assert` keyword is a hard error that
+    /// abandons the whole declaration (TS2880) *before* this function is
+    /// reached — see [`Self::import_attributes_use_removed_assert`] and the
+    /// early return in `check_import_declaration` / `check_export_declaration`.
+    /// So on the normal (parse-error-free) path this function only ever sees a
+    /// `with` clause; the `assert` arms below remain solely as the fallback for
+    /// the parse-error edge (where the upstream abandon is suppressed) and
+    /// mirror `tsc`'s historical `checkImportAttributes` cascade:
     ///
     /// 1. A type-only declaration carrying an *effective* `resolution-mode`
     ///    override is allowed — nothing else is reported.

--- a/crates/tsz-checker/src/declarations/import/declaration_check_body.rs
+++ b/crates/tsz-checker/src/declarations/import/declaration_check_body.rs
@@ -206,6 +206,18 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
+        // TS2880: the removed `assert` import-attribute keyword is a hard error
+        // in TypeScript 7 at every module mode. `tsc` reports it at the `assert`
+        // keyword and abandons the whole declaration — no module resolution
+        // (TS2307), no attribute-value or assignability checks (TS2858/TS2322),
+        // no deferred/reserved-word/type-only checks. It takes precedence over
+        // the module-support gate (TS2823/TS2821), so it must run before any of
+        // those. `with` clauses fall through to the normal checks below.
+        if !has_parse_errors && self.import_attributes_use_removed_assert(import.attributes) {
+            self.report_removed_import_assert(import.attributes);
+            return;
+        }
+
         // TS18058/TS18059: Validate deferred import binding restrictions.
         // Deferred imports only allow namespace imports: `import defer * as ns from "..."`
         self.check_deferred_import_restrictions(import.import_clause);

--- a/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_callback_bridge.rs
@@ -256,6 +256,20 @@ impl<'a> StatementCheckCallbacks for CheckerState<'a> {
                 }
             }
 
+            // TS2880: the removed `assert` import-attribute keyword is a hard
+            // error in TypeScript 7 at every module mode. `tsc` reports it at the
+            // `assert` keyword and abandons the whole declaration — no module
+            // resolution (TS2307), no attribute-value or assignability checks
+            // (TS2858/TS2322), no re-exported-member validation, and not even the
+            // string-literal export-name check (TS18057). `with` clauses fall
+            // through to the normal checks below.
+            if !self.ctx.has_parse_errors
+                && self.import_attributes_use_removed_assert(export_decl.attributes)
+            {
+                self.report_removed_import_assert(export_decl.attributes);
+                return;
+            }
+
             // TS18057: string-literal export names need a module target newer
             // than `es2015`/`es2020`. Unlike the import side, tsc does not gate
             // this on the module specifier resolving.

--- a/crates/tsz-checker/tests/import_assert_keyword_abandon_tests.rs
+++ b/crates/tsz-checker/tests/import_assert_keyword_abandon_tests.rs
@@ -1,0 +1,174 @@
+//! The removed `assert` import-attribute keyword abandons the whole declaration.
+//!
+//! In TypeScript 7 the `assert` import-attribute keyword has been removed. `tsc`
+//! reports TS2880 at the `assert` keyword and then *abandons the entire
+//! declaration* — it never runs the module-support gate (TS2823/TS2821), the
+//! type-only attribute check (TS2857/TS2822), the value-literal / assignability
+//! checks (TS2858/TS2322), or module resolution (TS2307). This holds at every
+//! module mode, so TS2880 takes precedence over all of them. `with` clauses are
+//! unaffected and keep their full grammar checks.
+//!
+//! These are lib-free checks (no `ImportAttributes` interface, no module
+//! resolution), so they exercise the grammar-level codes that distinguish the
+//! abandon: a type-only or module-unsupported `assert` used to leak
+//! TS2857/TS2822/TS2821 alongside (or instead of) TS2880. Oracle-pinned against
+//! `typescript@7.0.2`. Binder names are irrelevant here (the rule keys on the
+//! `assert` keyword, not any identifier), so nothing can key on a fixed name.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::check_source;
+use tsz_common::common::ModuleKind;
+
+fn check_module(source: &str, module: ModuleKind) -> Vec<Diagnostic> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            module,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+fn codes(diags: &[Diagnostic]) -> Vec<u32> {
+    let mut c: Vec<u32> = diags.iter().map(|d| d.code).collect();
+    c.sort_unstable();
+    c
+}
+
+/// The attribute-grammar diagnostic codes that an `assert` clause must abandon.
+const IMPORT_ATTRIBUTE_GRAMMAR_CODES: [u32; 6] = [2821, 2822, 2823, 2836, 2857, 2858];
+
+#[test]
+fn import_assert_type_only_abandons_no_ts2822() {
+    // `import type X ... assert { ... }`: main leaked TS2822 (type-only assert)
+    // from the grammar check that ran after TS2880. The abandon suppresses it.
+    let c = codes(&check_module(
+        r#"import type X from "./x.json" assert { type: "json" };"#,
+        ModuleKind::ESNext,
+    ));
+    assert!(c.contains(&2880), "expected TS2880, got: {c:?}");
+    assert!(
+        !c.contains(&2822),
+        "TS2822 must be abandoned under the removed `assert` keyword, got: {c:?}"
+    );
+}
+
+#[test]
+fn import_assert_module_unsupported_reports_ts2880_not_ts2821() {
+    // Under `commonjs` (attributes unsupported) the module-support gate would
+    // fire TS2821 for `assert` first. TS2880 takes precedence and abandons, so
+    // TS2821 must not appear.
+    let c = codes(&check_module(
+        r#"import a from "./x.json" assert { type: "json" };"#,
+        ModuleKind::CommonJS,
+    ));
+    assert!(c.contains(&2880), "expected TS2880, got: {c:?}");
+    assert!(
+        !c.contains(&2821),
+        "TS2821 must be superseded by TS2880 under `assert`, got: {c:?}"
+    );
+}
+
+#[test]
+fn import_assert_esnext_leaves_only_ts2880_grammar() {
+    // The full abandon: no import-attribute grammar code other than TS2880
+    // survives on an `assert` clause.
+    let c = codes(&check_module(
+        r#"import a from "./x.json" assert { type: "json" };"#,
+        ModuleKind::ESNext,
+    ));
+    assert!(c.contains(&2880), "expected TS2880, got: {c:?}");
+    for code in IMPORT_ATTRIBUTE_GRAMMAR_CODES {
+        assert!(
+            !c.contains(&code),
+            "TS{code} must be abandoned under the removed `assert` keyword, got: {c:?}"
+        );
+    }
+}
+
+#[test]
+fn import_assert_hard_error_mode_leaves_only_ts2880() {
+    // `node20`/`nodenext` were tsz's only pre-fix "hard error" modes, yet they
+    // still over-reported because the assignability check ran before the grammar
+    // check. The abandon covers them too.
+    for module in [ModuleKind::Node20, ModuleKind::NodeNext] {
+        let c = codes(&check_module(
+            r#"import a from "./x.json" assert { type: "json" };"#,
+            module,
+        ));
+        assert!(
+            c.contains(&2880),
+            "expected TS2880 for {module:?}, got: {c:?}"
+        );
+        for code in IMPORT_ATTRIBUTE_GRAMMAR_CODES {
+            assert!(
+                !c.contains(&code),
+                "TS{code} must be abandoned for {module:?}, got: {c:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn export_star_assert_module_unsupported_reports_ts2880_not_ts2821() {
+    // The export path abandons identically to the import path.
+    let c = codes(&check_module(
+        r#"export * from "./x.json" assert { type: "json" };"#,
+        ModuleKind::CommonJS,
+    ));
+    assert!(c.contains(&2880), "expected TS2880, got: {c:?}");
+    assert!(
+        !c.contains(&2821),
+        "TS2821 must be superseded by TS2880 under `assert` on exports, got: {c:?}"
+    );
+}
+
+#[test]
+fn export_named_assert_type_only_abandons_no_ts2822() {
+    let c = codes(&check_module(
+        r#"export type { X } from "./x.json" assert { type: "json" };"#,
+        ModuleKind::ESNext,
+    ));
+    assert!(c.contains(&2880), "expected TS2880, got: {c:?}");
+    assert!(
+        !c.contains(&2822),
+        "TS2822 must be abandoned under `assert` on exports, got: {c:?}"
+    );
+}
+
+/// Negative control: `with` clauses are untouched — a type-only `with` still
+/// reports TS2857, and none of it turns into TS2880.
+#[test]
+fn import_with_type_only_still_reports_ts2857_not_ts2880() {
+    let c = codes(&check_module(
+        r#"import type X from "./x.json" with { type: "json" };"#,
+        ModuleKind::ESNext,
+    ));
+    assert!(
+        c.contains(&2857),
+        "`with` on a type-only import must still report TS2857, got: {c:?}"
+    );
+    assert!(
+        !c.contains(&2880),
+        "`with` must never report TS2880, got: {c:?}"
+    );
+}
+
+/// Negative control: `with` under an unsupported module still reports TS2823.
+#[test]
+fn import_with_module_unsupported_still_reports_ts2823_not_ts2880() {
+    let c = codes(&check_module(
+        r#"import a from "./x.json" with { type: "json" };"#,
+        ModuleKind::CommonJS,
+    ));
+    assert!(
+        c.contains(&2823),
+        "`with` under commonjs must still report TS2823, got: {c:?}"
+    );
+    assert!(
+        !c.contains(&2880),
+        "`with` must never report TS2880, got: {c:?}"
+    );
+}


### PR DESCRIPTION
Fixes a false-positive family around the removed `assert` import-attribute
keyword: `tsz` over-reported spurious diagnostics that `tsc` (TypeScript 7)
does not.

**Structural rule.** When an import/export declaration uses the removed `assert`
import-attribute keyword, `tsc` reports **TS2880 at the `assert` keyword and
abandons the entire declaration** — no module resolution (TS2307), no
attribute-value/assignability checks (TS2858/TS2322), no reserved-word /
type-only / module-support attribute grammar (TS1214/TS2822/TS2823/TS2821), not
even a resolution-mode override. This holds at **every** module mode (`esnext`,
`node18`, `node20`, `nodenext`, `preserve`, and even the attribute-unsupported
`commonjs`), so `assert` takes precedence over all of them. `with` clauses are
unaffected and keep their full checks in every mode.

`tsz` diverged two ways, both pre-7.0 artifacts: `import_assert_is_hard_error()`
gated the abandon on `node20`/`nodenext` only (the old model where `esnext` was
a continue-checking deprecation), and `check_import_attributes_assignability`
(TS2858/TS2322) ran *before* the grammar check and never gated on `with` vs
`assert`, while module resolution ran regardless — so tsz over-reported even in
the two "hard error" modes.

**Owner layer.** Checker, at the declaration boundary — a top-precedence abandon
in `check_import_declaration`
(`declarations/import/declaration_check_body.rs`) and `check_export_declaration`
(`state_checking_members/statement_callback_bridge.rs`), matching `tsc`'s
`checkImportDeclaration`/`checkExportDeclaration` early return. A new
`import_attributes_use_removed_assert` / `report_removed_import_assert` pair
(`declarations/import/declaration_attributes.rs`) owns the detection and the
TS2880 emission (anchored at the `assert` keyword, length 6). `with` clauses
never hit the abandon; the existing `check_import_attributes_grammar` assert arms
remain solely as the parse-error-edge fallback (documented) — no dead code, no
double-emission. Dynamic-import and `import(...)` type paths are separate and
already match `tsc`; left untouched.

**Adjacent matrix** (oracle-pinned, `typescript@7.0.2`, code + line + column):

| witness | `tsc` | tsz before | tsz after |
| --- | --- | --- | --- |
| `import a from "./x.json" assert { type: bad }` (esnext) | TS2880 | TS2304+TS2307+TS2858+TS2880 | TS2880 |
| `import a from "./x.json" assert { type: "json" }` (esnext) | TS2880 | TS2307+TS2880 | TS2880 |
| `import eval from "./x.json" assert { type: "json" }` (esnext) | TS2880 | TS2307+TS2880 | TS2880 |
| `import type a from "./x.json" assert { type: "json" }` (esnext) | TS2880 | TS2307+TS2822+TS2880 | TS2880 |
| `import a from "./x.json" assert { type: "json" }` (commonjs) | TS2880 | TS2304+TS2307+TS2821+TS2858 | TS2880 |
| `import a from "./x.json" assert { type: bad }` (node20) | TS2880 | TS2304+TS2732+TS2858+TS2880 | TS2880 |
| `import type { X } from "./x.js" assert { "resolution-mode": "import" }` (esnext) | TS2880 | — | TS2880 |
| `export { a } from "./x.json" assert { type: bad }` (esnext) | TS2880 | TS2304+TS2307+TS2858+TS2880 | TS2880 |
| `export * from "./x.json" assert { type: 99 }` (esnext) | TS2880 | TS2307+TS2322+TS2858+TS2880 | TS2880 |
| **control** `import a from "./x.json" with { type: bad }` (esnext) | TS2307+TS2304+TS2858 | *unchanged* | *unchanged* |
| **control** `import a from "./x.json" with { type: "json" }` (commonjs) | TS2307+TS2823 | *unchanged* | *unchanged* |
| **control** `import type X from "./x.json" with { type: "json" }` (esnext) | TS2307+TS2857 | *unchanged* | *unchanged* |

Part of #16291 (a distinct, non-modifier-grammar slice: a missing-abandon /
wrong-code defect in the already-wired TS2880 family).

## Goal
Goal: hold

## Verification
- New integration test `crates/tsz-checker/tests/import_assert_keyword_abandon_tests.rs`
  (8 cases): import/export × type-only × module-unsupported × `node20`/`nodenext`,
  plus `with` negative controls; binder-name-independent. `cargo test -p tsz-checker
  --test import_assert_keyword_abandon_tests` → 8 passed. (Placed as a registered
  integration test rather than a `src/tests` lib module so it compiles
  independently of the checker lib-test tier, which is red on `main` for an
  unrelated reason — #15983.)
- CLI differential vs `scripts/conformance/oracle.sh` (`typescript@7.0.2`,
  `--singleThreaded --stableTypeOrdering true`) — code + line + column parity for
  every witness above, across all six supported module modes.
- `cargo clippy --profile ci-lint --workspace --all-targets -- -D warnings` — clean
  (the per-merge CI gate).
- `scripts/arch/check-checker-boundaries.sh` — clean.
- Conformance snapshot — see comment below (no import-assertion regressions;
  false-positive reduction only).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9vRC81i59NZTUjjySY1Ju)_