### PR TITLE
fix(solver): defer a class application whose partial body dropped its nominal symbol (#16055)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate/application.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/application.rs
@@ -207,6 +207,35 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 self.apparent_conditional_branch = saved_apparent;
                 self.decrement_def_depth(def_id);
 
+                // A class application that evaluated to a structural object which
+                // dropped the class's nominal symbol is a degraded, partially
+                // built instance body: the class's instance type carried only its
+                // annotated fields (no methods, no nominal identity) when this
+                // application forced its resolution — a circular import can make a
+                // sibling's build reach `Class<Args>` before the class publishes
+                // its final type. Surfacing that partial object (e.g. as a
+                // `[X, ...X[]][number]` union member beside the complete
+                // representation) yields spurious `TS2339`s for every missing
+                // method (issue #16055). Discard it: purge whatever the body
+                // evaluation cached under `(def, args)` so a later evaluation
+                // recomputes against the finished body, taint the run so nothing
+                // persists this partial, and keep the application opaque so a
+                // property access re-resolves it. Mirrors the Phase-4.5 in-flight
+                // sentinel's `mark_unresolved_def_seen()`/return-opaque shape.
+                if result != original_type_id
+                    && matches!(
+                        self.resolver.get_def_kind(def_id),
+                        Some(crate::def::DefKind::Class)
+                    )
+                    && self.application_result_dropped_nominal_symbol(result)
+                {
+                    if let Some(db) = self.query_db {
+                        db.invalidate_application_eval_cache_for_def(def_id);
+                    }
+                    self.mark_unresolved_def_seen();
+                    return original_type_id;
+                }
+
                 // Phase 7 — display-alias bookkeeping. Skip entirely when
                 // the result is the original `Application` itself (the
                 // historical `if result != original_type_id` gate).
@@ -238,6 +267,21 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 }
                 result
             }
+        }
+    }
+
+    /// True when `result` is a structural object (`Object`/`ObjectWithIndex`)
+    /// carrying no nominal `symbol`. For a class application this is the
+    /// signature of an instance body instantiated from a partial,
+    /// mid-construction source: the complete instance keeps its class
+    /// `SymbolId`, whereas the annotated-fields-only snapshot produced before
+    /// the class finishes building loses it (issue #16055).
+    fn application_result_dropped_nominal_symbol(&self, result: TypeId) -> bool {
+        match self.interner.lookup(result) {
+            Some(TypeData::Object(shape_id)) | Some(TypeData::ObjectWithIndex(shape_id)) => {
+                self.interner.object_shape(shape_id).symbol.is_none()
+            }
+            _ => false,
         }
     }
 


### PR DESCRIPTION
Goal: green

Fixes #16055.

## Structural rule

When a generic class application `C<Args>` is evaluated while `C`'s instance
body is still under construction, tsc keeps the application deferred and
resolves it against the finished body. tsz instead instantiated `C`'s
*partial* body — the annotated-fields-only snapshot published before methods
and nominal identity are added — into a permanent structural object that
**dropped `C`'s class `SymbolId`**, cached it under `(def, args)`, and later
surfaced it as one member of the `[X, ...X[]][number]` union
(`ZodType<any,any,any> | ZodTypeAny`) beside the fully-built representation.
Property lookup then failed on the degraded member, producing a false
`TS2339` for every method it was missing.

The trigger is a circular module import (zod's `./helpers` ↔ `types.ts`): a
sibling class's heritage (`ZodUnion extends ZodType<T[number]["_output"], …>`)
forces `ZodType`'s resolution before `ZodType` has published its final type,
so the application observes the mid-construction body. This is the
`#14345`/`#14346`/`#16553` identity-blind-cache family, surfacing as a member
drop.

`When a class application evaluates to a structural object that has lost the
class's nominal symbol, tsc keeps it deferred; tsz now does the same through
the solver's evaluate_application.`

## Owner layer

Solver — `crates/tsz-solver/src/evaluation/evaluate/application.rs`,
`TypeEvaluator::evaluate_application` (the `Computed` outcome).

A complete class instance keeps its class `SymbolId`; only the partial,
mid-construction snapshot loses it. So a class-def application whose evaluated
result is an `Object`/`ObjectWithIndex` with `symbol == None` is recognised as
degraded. The fix:

- purges any `application_eval_cache` entry the body evaluation wrote under
  `(def, args)` (`invalidate_application_eval_cache_for_def`) so a later
  evaluation recomputes against the finished body;
- taints the run (`mark_unresolved_def_seen`) so nothing persists the partial;
- returns the opaque `Application` instead of the partial object, so a later
  property access re-resolves it against the completed body.

This mirrors the existing Phase-4.5 in-flight sentinel's
`mark_unresolved_def_seen()`/return-opaque shape. It is gated on
`DefKind::Class` and `symbol == None`, so interfaces, type aliases, and
complete class instantiations (which keep their symbol) are unaffected.

## Why prior attempts here were no-ops

Earlier sessions deferred on `class_instance_resolution_set` (same-file) and
on `register_class_instance_in_envs` rewrite-invalidation; both measured
no-ops. Tracing showed why: the partial body is produced when
`evaluate_application` itself *triggers* the class build (via
`force_def_on_miss`) at a point **before** the in-flight set is populated and
in a child checker context the parent cannot see — so neither the same-file
set nor the cross-arena stack is active at the deciding entry. Keying off the
*result* (a class instantiation that lost its nominal symbol) catches the
degraded body regardless of which window produced it.

## Verification

- `colinhacks/zod@93b0b689`, `include: ["src/types.ts"]`, `strict`, `es2020`,
  `esnext`, `bundler` (issue's exact probe):
  - before: `types.ts(1995,18) TS2339 _parse` + `types.ts(2009,37) TS2339
    _parseSync` (the two `#16055` witnesses) + one unrelated
    `types.ts(2434,7) TS2322` (ZodRecord intersection, not tracked here).
  - after: **both `TS2339`s gone.** The unrelated `TS2322` at 2434 is
    pre-existing and out of scope for this issue.
- Conformance (`conformance.sh run --workers 12`, auto-diff vs committed
  baseline): **Net 11499 → 11542 (+43)** — 44 tests move PASS. The single
  reported `PASS -> FAIL` (`thisTypeAccessibility.ts`) is not a real
  regression: the patched and unpatched binaries emit byte-identical
  diagnostics for that file standalone (`TS2341`x8 / `TS2445`x1 / `TS2564`x3
  either way), so my change does not touch it. The flip is the known
  parallel-pool check-order non-determinism (#16553/#16309) perturbed by the
  +43 genuine changes elsewhere, on a file already off-parity on `main`
  (that divergence is #16894, owned separately). Conformance is a nightly
  lane, not part of the per-merge gate.
- Emit (`emit/run.sh`): **JS 11562 pass / DTS 1375 pass** — both hold the
  floor exactly (the pre-existing known failures are unchanged), so no emit
  regression.
- Fourslash: not re-run this session (needs a release `tsz-server` rebuild);
  the change is a solver type-resolution fix with no LSP-surface edits.

A minimal standalone fixture could not be reduced (matching six prior
sessions): the trigger needs the full `ZodType`/`ZodUnion` surface plus the
real `./helpers` ↔ `types.ts` import cycle. The real-project witness above is
the regression guard.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZr9cT9fV6zQ9Nbdj1cZeR)_