### PR TITLE
fix(checker): TS2842 unused-renaming never fires inside a .d.ts file

### DIFF
--- a/crates/tsz-checker/src/checkers/parameter_checker.rs
+++ b/crates/tsz-checker/src/checkers/parameter_checker.rs
@@ -613,11 +613,11 @@ impl<'a> CheckerState<'a> {
                 self.check_computed_property_name(elem.property_name);
 
                 // TS2842: 'b' is an unused renaming of 'a'. Did you intend to use it as a type annotation?
-                // This is emitted when both property_name and name are identifiers, and there's no body.
-                // The renaming is only *unused* when no `typeof` query in the
-                // owning signature names the renamed binding; `typeof b` keeps
-                // it used and `tsc` reports nothing.
+                // Emitted when property_name/name are both identifiers, no body, and no
+                // `typeof` query in the signature names the rename (which would use it);
+                // also never inside `.d.ts`, which has no bodies at all.
                 if !has_body
+                    && !self.ctx.is_declaration_file()
                     && let Some(prop_node) = self.ctx.arena.get(elem.property_name)
                     && (prop_node.kind == tsz_scanner::SyntaxKind::Identifier as u16
                         || prop_node.kind == tsz_scanner::SyntaxKind::StringLiteral as u16

--- a/crates/tsz-checker/src/types/type_node_helpers.rs
+++ b/crates/tsz-checker/src/types/type_node_helpers.rs
@@ -250,6 +250,7 @@ fn collect_names_in_type(
                     // name (`["a"]`, `[2]`) — tsc flags all of them, so the gate
                     // matches every property-name kind, not just identifiers.
                     if prop_idx.is_some()
+                        && !ctx.is_declaration_file()
                         && let Some(prop_node) = ctx.arena.get(prop_idx)
                         && is_renaming_source_property_kind(prop_node.kind)
                         && let Some(name_node) = ctx.arena.get(name_idx)

--- a/crates/tsz-checker/tests/signature_binding_pattern_typeof_scope_tests.rs
+++ b/crates/tsz-checker/tests/signature_binding_pattern_typeof_scope_tests.rs
@@ -11,7 +11,7 @@
 //!
 //! Oracled against `tsc` 7.0.2 with `--strict false --target es2015`.
 
-use tsz_checker::test_utils::check_source_non_strict_codes;
+use tsz_checker::test_utils::{check_source_codes_named, check_source_non_strict_codes};
 
 const TS2304_CANNOT_FIND_NAME: u32 = 2304;
 const TS2842_UNUSED_RENAMING: u32 = 2842;
@@ -238,4 +238,91 @@ fn string_literal_rename_is_binder_name_invariant() {
             "renaming `\"a\"` to `{local}` is flagged once; got {msgs:?}"
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// TS2842 never fires inside a `.d.ts` file.
+//
+// A declaration file has no bodies at all, so tsc treats a renamed
+// destructured parameter as ordinary declaration syntax rather than a
+// possible authoring mistake. Oracled against `tsc` 7.0.2:
+// identical `{ a: renamed }: O` source reports TS2842 in a `.ts` file and is
+// silent in a `.d.ts` file. Covers both diagnostic-emission sites: the bare
+// function-type path (`type F = (...) => void`, `type_node_helpers.rs`'s
+// `check_duplicate_parameters_in_type`) and the member/signature path
+// (interface methods, `declare function`, a type literal's function-typed
+// property; `parameter_checker.rs`'s `check_duplicate_parameters`).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bare_function_type_rename_in_declaration_file_reports_nothing() {
+    let codes = check_source_codes_named(
+        "type O = { a: string; b: number };\ntype F = ({ a: renamed }: O) => void;",
+        "lib.d.ts",
+    );
+    assert!(
+        !codes.contains(&TS2842_UNUSED_RENAMING),
+        "a `.d.ts` file has no bodies, so tsc never flags a renamed destructured \
+         parameter there; got {codes:?}"
+    );
+}
+
+#[test]
+fn interface_method_signature_rename_in_declaration_file_reports_nothing() {
+    let codes = check_source_codes_named(
+        "type O = { a: string; b: number };\ninterface I { method({ a: renamed }: O): void; }",
+        "lib.d.ts",
+    );
+    assert!(
+        !codes.contains(&TS2842_UNUSED_RENAMING),
+        "an interface method signature is exempt in a `.d.ts` file too; got {codes:?}"
+    );
+}
+
+#[test]
+fn declare_function_rename_in_declaration_file_reports_nothing() {
+    let codes = check_source_codes_named(
+        "type O = { a: string; b: number };\ndeclare function f({ a: renamed }: O): void;",
+        "lib.d.ts",
+    );
+    assert!(
+        !codes.contains(&TS2842_UNUSED_RENAMING),
+        "a `declare function` in a `.d.ts` file is exempt; got {codes:?}"
+    );
+}
+
+#[test]
+fn type_literal_property_function_type_rename_in_declaration_file_reports_nothing() {
+    let codes = check_source_codes_named(
+        "type O = { a: string; b: number };\ntype T = { f: ({ a: renamed }: O) => void };",
+        "lib.d.ts",
+    );
+    assert!(
+        !codes.contains(&TS2842_UNUSED_RENAMING),
+        "a function-typed type-literal property is exempt in a `.d.ts` file; got {codes:?}"
+    );
+}
+
+#[test]
+fn non_identifier_property_rename_in_declaration_file_reports_nothing() {
+    let codes = check_source_codes_named("type F = ({ \"a\": renamed }) => void;", "lib.d.ts");
+    assert!(
+        !codes.contains(&TS2842_UNUSED_RENAMING),
+        "the declaration-file exemption applies regardless of property-name kind; got {codes:?}"
+    );
+}
+
+#[test]
+fn bare_function_type_rename_in_ordinary_ts_file_still_reports_ts2842() {
+    // Adjacent negative case: the exact same source in a `.ts` file (not
+    // `.d.ts`) must still report — the exemption is declaration-file-scoped,
+    // not a blanket change to the diagnostic.
+    let codes = check_source_codes_named(
+        "type O = { a: string; b: number };\ntype F = ({ a: renamed }: O) => void;",
+        "plain.ts",
+    );
+    assert!(
+        codes.contains(&TS2842_UNUSED_RENAMING),
+        "a plain `.ts` file keeps reporting TS2842; got {codes:?}"
+    );
 }


### PR DESCRIPTION
A declaration file has no bodies at all, so `tsc` never treats a renamed
destructured parameter there as a possible authoring mistake. Oracle-verified
against `typescript@7.0.2`: identical `{ a: renamed }: O` source reports
TS2842 (`'X' is an unused renaming of 'Y'. Did you intend to use it as a type
annotation?`) in a `.ts` file and is silent in a `.d.ts` file, across every
shape tried (bare function type, `declare function`, interface method
signature, type-literal property with a function-type value, and every
property-name kind — identifier/string/numeric/computed).

**Structural rule.** When the current file is a declaration file
(`.d.ts`/`.d.mts`/`.d.cts`), `tsc` never reports TS2842 on a renamed
destructured binding; `tsz` now checks this through the owning layer
(checker, `CheckerContext::is_declaration_file()`).

**Owner layer / two duplicated emission sites, both fixed.** tsz has two
independent implementations of this diagnostic (a pre-existing DRY gap, not
introduced here):
- `crates/tsz-checker/src/checkers/parameter_checker.rs`'s
  `collect_and_check_binding_element` — the member/signature path: interface
  method signatures, `declare function`, a type-literal property's
  function-typed value.
- `crates/tsz-checker/src/types/type_node_helpers.rs`'s
  `collect_names_in_type` — the bare-type-alias path (`type F = (...) =>
  void`), reached from `get_type_from_function_type` in `type_node.rs`.

Both now gate the check on `!ctx.is_declaration_file()`, alongside the
existing `!has_body` and `typeof`-reference exemptions from a prior session's
fix (#16866 family; `crates/tsz-checker/tests/signature_binding_pattern_typeof_scope_tests.rs`).

Fixes the false positive on
`renamingDestructuredPropertyInFunctionType2.ts` (conformance corpus): tsz
reported TS2842 4× where `tsc` is clean (that fixture's own `// @filename:
a.d.ts` directive is what makes it a declaration file under the conformance
harness).

## Goal
Goal: hold

## Verification
- New tests in `crates/tsz-checker/tests/signature_binding_pattern_typeof_scope_tests.rs`
  (6 cases: bare function-type alias, interface method signature, `declare
  function`, type-literal property, non-identifier property name, and an
  adjacent negative — the same source in a plain `.ts` file must still
  report). `cargo test -p tsz-checker --test signature_binding_pattern_typeof_scope_tests`
  → 23 passed (17 pre-existing + 6 new).
- `cargo test -p tsz-checker --lib ts2693_signature_binding_shadowed_primitive`
  → 9 passed, unaffected (different filename, not `.d.ts`).
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings` — clean.
- `cargo fmt --check -p tsz-checker` — clean.
- Manual oracle diff vs `typescript@7.0.2` across the covered matrix
  (`.ts` fires, `.d.ts` silent) for every shape above — all byte-identical.
- Real fixture: copied `renamingDestructuredPropertyInFunctionType2.ts` to
  `a.d.ts` (matching its own `// @filename` directive) and ran the built CLI
  directly — clean (previously 4× TS2842).
- `scripts/conformance/compare-to-parent.sh` was started but its own
  `--help` path rebuilds a `dist-fast` binary first (~tens of minutes on this
  seat, a known cost per the board's standing gotcha) and did not finish
  within this session's budget. This is a two-site, single-diagnostic-code
  false-positive removal gated purely on file-kind (`.d.ts` vs `.ts`), with
  no other diagnostic-count interaction — landing on the unit-test +
  oracle + real-fixture evidence above, per this environment's
  land-and-continue convention (see e.g. #16902's emit/fourslash note). Will
  add the compare-to-parent numbers as a follow-up comment if the run
  finishes before merge.
- Files touched are source only (no `crates/**/src` size regression):
  `parameter_checker.rs` stays at exactly 2000 physical lines (the
  hard-cap ceiling), `type_node_helpers.rs` grows by 1 line to 1576.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: Malachite


---
_Generated by [Claude Code](https://claude.ai/code/session_01CtadEtuemqWHdJUdPRvyHL)_