### PR TITLE
feat(cli): wire TS1149 for root-file casing collisions

### DIFF
--- a/crates/tsz-cli/src/driver/core_diagnostics.rs
+++ b/crates/tsz-cli/src/driver/core_diagnostics.rs
@@ -630,6 +630,70 @@ fn compile_inner_impl(
     }
 
     let root_file_paths = file_paths.clone();
+
+    // TS1149: two root files whose real on-disk paths are identical except
+    // for casing (e.g. `foo.ts` and `Foo.ts` both specified as roots). tsc
+    // reports this unconditionally — independent of `useCaseSensitiveFileNames`
+    // — as a portability warning, with a two-line "file is in the program
+    // because: / Root file specified for compilation / Root file specified
+    // for compilation" chain and no source location, since neither
+    // colliding path is reached via an import specifier to anchor on.
+    // Import-discovered casing collisions (`tsc`'s `Imported via "..." from
+    // file '...'` chain link) are a separate, unclaimed slice: they need the
+    // module-resolution loop's specifier/importer attribution, not just the
+    // root file list.
+    {
+        let mut seen_by_lowercase: FxHashMap<String, PathBuf> = FxHashMap::default();
+        for path in &root_file_paths {
+            let canonical = canonicalize_or_owned(path);
+            let lowercase_key = canonical.to_string_lossy().to_ascii_lowercase();
+            match seen_by_lowercase.get(&lowercase_key) {
+                Some(existing) if existing != &canonical => {
+                    let new_display = canonical.to_string_lossy().into_owned();
+                    let existing_display = existing.to_string_lossy().into_owned();
+                    let mut diagnostic = Diagnostic::from_code(
+                        diagnostic_codes::FILE_NAME_DIFFERS_FROM_ALREADY_INCLUDED_FILE_NAME_ONLY_IN_CASING,
+                        String::new(),
+                        0,
+                        0,
+                        &[&new_display, &existing_display],
+                    );
+                    diagnostic
+                        .related_information
+                        .push(DiagnosticRelatedInformation {
+                            category: DiagnosticCategory::Message,
+                            code: diagnostic_codes::THE_FILE_IS_IN_THE_PROGRAM_BECAUSE,
+                            file: String::new(),
+                            start: 0,
+                            length: 0,
+                            message_text: "The file is in the program because:".to_string(),
+                            depth: 0,
+                            kind: RelatedInformationKind::ChainLink,
+                        });
+                    for _ in 0..2 {
+                        diagnostic
+                            .related_information
+                            .push(DiagnosticRelatedInformation {
+                                category: DiagnosticCategory::Message,
+                                code: diagnostic_codes::ROOT_FILE_SPECIFIED_FOR_COMPILATION,
+                                file: String::new(),
+                                start: 0,
+                                length: 0,
+                                message_text: "Root file specified for compilation".to_string(),
+                                depth: 1,
+                                kind: RelatedInformationKind::ChainLink,
+                            });
+                    }
+                    config_diagnostics.push(diagnostic);
+                }
+                Some(_) => {}
+                None => {
+                    seen_by_lowercase.insert(lowercase_key, canonical);
+                }
+            }
+        }
+    }
+
     // `@noTypesAndSymbols` is a TypeScript test-corpus pragma, not a real
     // compiler directive. Honor only the explicit value coming from
     // tsconfig/CLI; never let an ordinary source comment override the

--- a/crates/tsz-cli/src/lib.rs
+++ b/crates/tsz-cli/src/lib.rs
@@ -56,6 +56,9 @@ mod driver_tests_ts2307;
 #[path = "../tests/dual_package_exports_tests.rs"]
 mod dual_package_exports_tests;
 #[cfg(test)]
+#[path = "../tests/file_casing_collision_ts1149_tests.rs"]
+mod file_casing_collision_ts1149_tests;
+#[cfg(test)]
 #[path = "../tests/fs_tests.rs"]
 mod fs_tests;
 #[cfg(test)]

--- a/crates/tsz-cli/tests/file_casing_collision_ts1149_tests.rs
+++ b/crates/tsz-cli/tests/file_casing_collision_ts1149_tests.rs
@@ -1,0 +1,199 @@
+//! Regression tests for TS1149
+//! (`FILE_NAME_DIFFERS_FROM_ALREADY_INCLUDED_FILE_NAME_ONLY_IN_CASING`).
+//!
+//! Structural rule: when two root files specified for compilation resolve to
+//! distinct real on-disk paths that are identical except for casing (e.g.
+//! `foo.ts` and `Foo.ts` both existing and both listed as roots), `tsc`
+//! reports TS1149 unconditionally — this is a portability warning, not a
+//! `useCaseSensitiveFileNames` host check, so it fires the same way on a
+//! case-sensitive Linux filesystem as anywhere else. The diagnostic carries
+//! no source location (root files aren't reached via an import specifier to
+//! anchor on) and a two-line "file is in the program because" chain, one line
+//! per colliding file. Oracle-pinned against `typescript@7.0.2`.
+//!
+//! Owner: `crates/tsz-cli/src/driver/core_diagnostics.rs`, the root-file-list
+//! casing scan that runs before source reading begins.
+//!
+//! Scope: this only covers casing collisions among the explicit root file
+//! list. A collision introduced through an *import* specifier (tsc's
+//! `Imported via "..." from file '...'` chain link) is a distinct, unclaimed
+//! follow-up — it needs the module-resolution loop's specifier/importer
+//! attribution, not just the root file list, and is deliberately not
+//! addressed here.
+
+use super::args::CliArgs;
+use super::driver::compile;
+use clap::Parser;
+use std::path::Path;
+
+fn write_file(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("failed to create parent directory");
+    }
+    std::fs::write(path, contents).expect("failed to write file");
+}
+
+fn parse_args(args: &[&str]) -> CliArgs {
+    CliArgs::try_parse_from(args).expect("test args should parse")
+}
+
+/// Two real, distinct root files whose names differ only in casing must
+/// report TS1149, anchored nowhere (no `file`/`start`/`length`), with the
+/// "Root file specified for compilation" reason repeated once per file.
+#[test]
+fn two_root_files_differing_only_in_casing_report_ts1149() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let base = temp.path();
+
+    write_file(&base.join("foo.ts"), "export const a = 1;\n");
+    write_file(&base.join("Foo.ts"), "export const b = 2;\n");
+
+    let args = parse_args(&["tsz", "--noEmit", "foo.ts", "Foo.ts"]);
+    let result = compile(&args, base).expect("compile should run");
+
+    let casing: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 1149)
+        .collect();
+    assert_eq!(
+        casing.len(),
+        1,
+        "expected exactly one TS1149, got: {:#?}",
+        result.diagnostics
+    );
+    let diag = casing[0];
+    assert!(
+        diag.file.is_empty() && diag.start == 0 && diag.length == 0,
+        "TS1149 on root files has no anchor location, got file={:?} start={} length={}",
+        diag.file,
+        diag.start,
+        diag.length
+    );
+    assert!(
+        diag.message_text.contains("Foo.ts") && diag.message_text.contains("foo.ts"),
+        "message should name both colliding files: {}",
+        diag.message_text
+    );
+
+    let reason_lines: Vec<_> = diag
+        .related_information
+        .iter()
+        .map(|r| r.message_text.as_str())
+        .collect();
+    assert_eq!(
+        reason_lines,
+        vec![
+            "The file is in the program because:",
+            "Root file specified for compilation",
+            "Root file specified for compilation",
+        ],
+        "reason chain should have one header plus one line per colliding root file"
+    );
+}
+
+/// Argument order flips which file is "the new one" vs "already included",
+/// matching `tsc`'s message-parameter order (whichever file is processed
+/// second names itself first, points back at the first).
+#[test]
+fn casing_collision_message_order_follows_root_file_argument_order() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let base = temp.path();
+
+    write_file(&base.join("foo.ts"), "export const a = 1;\n");
+    write_file(&base.join("Foo.ts"), "export const b = 2;\n");
+
+    let args = parse_args(&["tsz", "--noEmit", "Foo.ts", "foo.ts"]);
+    let result = compile(&args, base).expect("compile should run");
+
+    let casing: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 1149)
+        .collect();
+    assert_eq!(casing.len(), 1, "got: {:#?}", result.diagnostics);
+    let message = &casing[0].message_text;
+    let foo_lower_pos = message.find("foo.ts").expect("names lowercase foo.ts");
+    let foo_upper_pos = message.find("Foo.ts").expect("names uppercase Foo.ts");
+    assert!(
+        foo_lower_pos < foo_upper_pos,
+        "the second-listed root file ('foo.ts') is the one newly processed and \
+         is named first ('File name X'); the first-listed ('Foo.ts') is 'already \
+         included' and is named second: {message}"
+    );
+}
+
+/// The exact same path listed twice (not a casing collision — it's the
+/// identical file) must not report TS1149; the existing root-file dedup
+/// already handles this and the casing scan must not double-count it.
+#[test]
+fn identical_root_path_listed_twice_does_not_report_ts1149() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let base = temp.path();
+
+    write_file(&base.join("foo.ts"), "export const a = 1;\n");
+
+    let args = parse_args(&["tsz", "--noEmit", "foo.ts", "foo.ts"]);
+    let result = compile(&args, base).expect("compile should run");
+
+    let casing: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 1149)
+        .collect();
+    assert!(
+        casing.is_empty(),
+        "an exact duplicate path is not a casing collision, got: {casing:#?}"
+    );
+}
+
+/// Root files with unrelated names never report TS1149 (no false positives
+/// on the common case).
+#[test]
+fn unrelated_root_file_names_do_not_report_ts1149() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let base = temp.path();
+
+    write_file(&base.join("a.ts"), "export const a = 1;\n");
+    write_file(&base.join("b.ts"), "export const b = 2;\n");
+
+    let args = parse_args(&["tsz", "--noEmit", "a.ts", "b.ts"]);
+    let result = compile(&args, base).expect("compile should run");
+
+    let casing: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 1149)
+        .collect();
+    assert!(casing.is_empty(), "got: {casing:#?}");
+}
+
+/// A casing collision reached only through an import specifier (neither
+/// colliding file is itself a root) is out of this slice's scope and must
+/// stay silent rather than partially/incorrectly report — this pins the
+/// documented scope boundary so a future session doesn't assume it's covered.
+#[test]
+fn import_discovered_casing_collision_is_out_of_scope_and_stays_silent() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let base = temp.path();
+
+    write_file(&base.join("foo.ts"), "export const a = 1;\n");
+    write_file(&base.join("Foo.ts"), "export const b = 2;\n");
+    write_file(
+        &base.join("main.ts"),
+        "import { a } from './foo';\nimport { b } from './Foo';\n",
+    );
+
+    let args = parse_args(&["tsz", "--noEmit", "main.ts"]);
+    let result = compile(&args, base).expect("compile should run");
+
+    let casing: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 1149)
+        .collect();
+    assert!(
+        casing.is_empty(),
+        "import-discovered casing collisions are an unclaimed follow-up, got: {casing:#?}"
+    );
+}


### PR DESCRIPTION
Wires a fully-unwired diagnostic code from #16291's enumeration (confirmed zero emit sites anywhere in `crates/` before this PR): **TS1149** (`FILE_NAME_DIFFERS_FROM_ALREADY_INCLUDED_FILE_NAME_ONLY_IN_CASING`).

**Structural rule:** when two root files specified for compilation resolve to distinct real on-disk paths that are identical except for casing (e.g. `foo.ts` and `Foo.ts` both existing and both listed as roots), `tsc` reports TS1149 **unconditionally** — this is a portability warning, not a `useCaseSensitiveFileNames` host check, confirmed firing the same way on a case-sensitive Linux filesystem as any other host. tsz now does the same through a root-file-list casing scan added in `compile_inner_impl` (`crates/tsz-cli/src/driver/core_diagnostics.rs`), right after the root file list is captured and before source reading begins.

Oracle-pinned against `typescript@7.0.2` (installed fresh, `--noEmit foo.ts Foo.ts`):

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `foo.ts`, `Foo.ts` both roots | TS1149, no location, "Root file specified for compilation" ×2 | silent | TS1149, no location, "Root file specified for compilation" ×2 |
| same, reversed arg order | TS1149 with file names swapped in the message | silent | matches (message-parameter order follows which file is processed second) |
| same root path listed twice | clean | clean | clean (unchanged — not a casing collision) |
| unrelated root file names | clean | clean | clean (unchanged) |

The diagnostic carries no source location (root files aren't reached via an import specifier to anchor on) and a two-line "The file is in the program because: / Root file specified for compilation" reason chain — reusing the exact `DiagnosticRelatedInformation` chain-link pattern the existing TS6504 (unsupported JS root) diagnostic already established, so no new rendering infrastructure was needed.

**Scope boundary (documented, not a gap):** this covers casing collisions among the explicit root file list only. A collision introduced through an *import* specifier (`tsc`'s `Imported via "..." from file '...'` chain link, confirmed via the oracle to anchor at the import specifier's location instead) is a distinct, unclaimed follow-up — it needs the module-resolution loop's specifier/importer attribution, which is a materially larger change, not just this root-list scan. A dedicated test (`import_discovered_casing_collision_is_out_of_scope_and_stays_silent`) pins that this stays silent rather than half-firing.

This is purely additive: the new scan only fires on a previously-unreachable diagnostic code, over a small (root-file-count) key set computed once via a cheap lowercase string comparison — no BFS/module-resolution hot path is touched.

## Goal
Goal: hold

## Verification
- New `crates/tsz-cli/tests/file_casing_collision_ts1149_tests.rs` (5 tests, drives the real CLI compile pipeline via `TempDir`): all pass — collision fires with the right message/location/reason-chain shape, argument-order message-parameter ordering, exact-duplicate-path is not a collision, unrelated names stay clean, and the import-discovered case stays silent (documented scope boundary).
- Manual oracle diff: fresh `npm i typescript@7.0.2`, `tsc --noEmit foo.ts Foo.ts` (and reversed order) on a real two-file fixture — byte-identical to tsz's output after this change.
- `cargo clippy -p tsz-cli --lib --tests --profile ci-lint -- -D warnings`: clean.
- `cargo fmt -p tsz-cli -- --check`: clean.
- `python3 scripts/arch/arch_guard.py`: clean.
- `cargo test -p tsz-cli --lib`: 1763 passed / 18 failed — verified by stashing this change and re-running the failing tests against unmodified `main` at the same head: all 18 reproduce identically on `main` (pre-existing, unrelated to this diff — e.g. `tsc_compat_tests::tsc_parity_no_input`, `driver_tests::cross_file_dependent_operand_aliases_accept_scalars_and_literal_arrays`). No new failures introduced.
- Conformance/emit/fourslash not run: this PR only adds a new emission path for a previously-silent diagnostic code with no existing test coverage anywhere in the corpus (grep confirmed zero prior emit sites), so it cannot change any existing conformance/emit/fourslash expectation; the pre-merge `clippy` + `arch-size` CI lane is the applicable gate.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_015vVGogfuoTKV86xktPyzTU)_