### PR TITLE
Revert "fix(solver): defer a class application whose partial body dropped its nominal symbol"

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate/application.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/application.rs
@@ -207,35 +207,6 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 self.apparent_conditional_branch = saved_apparent;
                 self.decrement_def_depth(def_id);
 
-                // A class application that evaluated to a structural object which
-                // dropped the class's nominal symbol is a degraded, partially
-                // built instance body: the class's instance type carried only its
-                // annotated fields (no methods, no nominal identity) when this
-                // application forced its resolution — a circular import can make a
-                // sibling's build reach `Class<Args>` before the class publishes
-                // its final type. Surfacing that partial object (e.g. as a
-                // `[X, ...X[]][number]` union member beside the complete
-                // representation) yields spurious `TS2339`s for every missing
-                // method (issue #16055). Discard it: purge whatever the body
-                // evaluation cached under `(def, args)` so a later evaluation
-                // recomputes against the finished body, taint the run so nothing
-                // persists this partial, and keep the application opaque so a
-                // property access re-resolves it. Mirrors the Phase-4.5 in-flight
-                // sentinel's `mark_unresolved_def_seen()`/return-opaque shape.
-                if result != original_type_id
-                    && matches!(
-                        self.resolver.get_def_kind(def_id),
-                        Some(crate::def::DefKind::Class)
-                    )
-                    && self.application_result_dropped_nominal_symbol(result)
-                {
-                    if let Some(db) = self.query_db {
-                        db.invalidate_application_eval_cache_for_def(def_id);
-                    }
-                    self.mark_unresolved_def_seen();
-                    return original_type_id;
-                }
-
                 // Phase 7 — display-alias bookkeeping. Skip entirely when
                 // the result is the original `Application` itself (the
                 // historical `if result != original_type_id` gate).
@@ -267,21 +238,6 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 }
                 result
             }
-        }
-    }
-
-    /// True when `result` is a structural object (`Object`/`ObjectWithIndex`)
-    /// carrying no nominal `symbol`. For a class application this is the
-    /// signature of an instance body instantiated from a partial,
-    /// mid-construction source: the complete instance keeps its class
-    /// `SymbolId`, whereas the annotated-fields-only snapshot produced before
-    /// the class finishes building loses it (issue #16055).
-    fn application_result_dropped_nominal_symbol(&self, result: TypeId) -> bool {
-        match self.interner.lookup(result) {
-            Some(TypeData::Object(shape_id)) | Some(TypeData::ObjectWithIndex(shape_id)) => {
-                self.interner.object_shape(shape_id).symbol.is_none()
-            }
-            _ => false,
         }
     }
 


### PR DESCRIPTION
Reverts #16911 (`a0ecdff826`). **Main is red on the solver lane** and this restores it.

Goal: hold

```
FAIL evaluation::evaluate::orchestrator_tests::evaluate_application_class_uses_construct_signature_return_type

crates/tsz-solver/tests/evaluate_application_orchestrator_tests.rs:452
assertion `left == right` failed: class application must reduce to the instance
type produced by the construct signature
  left:  TypeId(130)   right: TypeId(105)
```

| commit | solver lane |
|---|---|
| merge-base `f1c8f87627` | **PASS** |
| `a0ecdff826` (#16911) | **FAIL** 7654/7655 |
| this revert | **PASS** 7655/7655 |

## Why it broke

#16911 added an early return for a class application whose result is a structural object that "dropped" the class's nominal symbol — a real degradation when a circular import forces resolution against a partially built body.

But the orchestrator fixture constructs a class body with `symbol: None` whose construct signature legitimately returns `{ value: string }`. There was never a nominal symbol to drop, so the guard cannot distinguish *structural because the body was partial* from *structural because that is the correct answer*, and the application is left opaque instead of reducing to the construct signature's instance type.

That fixture is the witness for the second case, and the assertion states the invariant the guard bypasses.

## Why revert rather than fix forward

The obvious narrowing is to require that the class's **own body carried a nominal symbol** which the result then lost — if the source never had one, nothing was dropped. I did not push that, because **#16911 added no tests**: there is no fixture for the partial-body state it targets, so I cannot confirm a narrowed guard still closes #16055. Landing an unverified narrowing on top of an unverified fix is worse than reverting.

Nothing verifiable is lost here. I also tried to reproduce #16055's witness reduced —

```ts
class ZodType<A, B, C> { _parse(): void {} }
type ZodTypeAny = ZodType<any, any, any>;
declare const x: ZodType<any, any, any> | ZodTypeAny;
x._parse();
```

— and it is **already clean on main**, along with four adjacent rows (genuine union missing the member still `TS2339`, absent member still `TS2339`, renamed binders, direct access). So the flat shape does not reach the partial-body condition; only the circular-import setup does.

## Reland criteria

1. A fixture that reproduces the partial-body/circular-import state, failing before the fix.
2. `evaluate_application_class_uses_construct_signature_return_type` still passing — the guard must not fire when the class body had no nominal symbol to begin with.
3. Evidence the zod row from #16055 actually flips, since that is the motivating case and the reduced witness does not reproduce it.

#16055 stays open; the diagnosis on #16911 is worth keeping — the circular-import-reaches-`Class<Args>`-before-publish mechanism is a real finding regardless of this guard.

## Verification

- `cargo nextest run -p tsz-solver --lib` — **7655/7655** (was 7654/7655 on main)
- `cargo nextest run -p tsz-checker --lib` — **10826/10826**
- `cargo build --release -p tsz-cli --bin tsz` — rc=0

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high
