### PR TITLE
fix(checker): treat `namespace globalThis` augmentation as the global object, not a shadow

### DIFF
--- a/crates/tsz-checker/src/types/queries/core.rs
+++ b/crates/tsz-checker/src/types/queries/core.rs
@@ -961,11 +961,35 @@ impl<'a> CheckerState<'a> {
 
         if let Some(sym_id) = self.resolve_identifier_symbol(idx)
             && !self.ctx.binder.lib_symbol_ids.contains(&sym_id)
+            && !self.symbol_is_global_this_namespace_merge(sym_id)
         {
             return false;
         }
 
         true
+    }
+
+    /// Whether `sym_id` is a `declare global { namespace globalThis { ... } }`
+    /// augmentation of the built-in global object rather than a same-file
+    /// shadow of it.
+    ///
+    /// tsc merges a reopened `namespace globalThis` into the single
+    /// `globalThisSymbol`, so property access on it keeps the global-object
+    /// semantics (`checker.ts`'s `leftType.symbol === globalThisSymbol` branch:
+    /// a missing member is `any`/`TS7017`, never a `TS2551` "did you mean"
+    /// suggestion). tsz binds the reopening as its own user namespace symbol
+    /// instead, so [`Self::is_global_this_expression`] would otherwise treat the
+    /// augmented receiver as a shadow and route it through generic property
+    /// resolution, over-reporting `TS2551`/`TS2339`. A genuine value shadow
+    /// (`const globalThis = ...`, `function globalThis() {}`) or an alias
+    /// import carries no module meaning and is correctly still treated as a
+    /// shadow.
+    fn symbol_is_global_this_namespace_merge(&self, sym_id: tsz_binder::SymbolId) -> bool {
+        let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
+            return false;
+        };
+        symbol.has_any_flags(symbol_flags::VALUE_MODULE | symbol_flags::NAMESPACE_MODULE)
+            && !symbol.has_any_flags(symbol_flags::ALIAS)
     }
 
     /// Check if a node is an ambient global object alias that should resolve through

--- a/scripts/conformance/conformance-baseline.txt
+++ b/scripts/conformance/conformance-baseline.txt
@@ -73,7 +73,7 @@ FAIL TypeScript/tests/cases/compiler/exportAssignmentMembersVisibleInAugmentatio
 FAIL TypeScript/tests/cases/compiler/exportSpecifierAndLocalMemberDeclaration.ts | expected:[TS2503] actual:[]
 FAIL TypeScript/tests/cases/compiler/expressionWithJSDocTypeArguments.ts | expected:[TS1110] actual:[TS8020,TS17019,TS17020]
 FAIL TypeScript/tests/cases/compiler/expressionsForbiddenInParameterInitializers.ts | expected:[TS2523,TS2524] actual:[]
-FAIL TypeScript/tests/cases/compiler/extendGlobalThis.ts | expected:[TS2882] actual:[TS2551,TS2882]
+PASS TypeScript/tests/cases/compiler/extendGlobalThis.ts
 FAIL TypeScript/tests/cases/compiler/externSemantics.ts | expected:[TS1039] actual:[TS1039]
 FAIL TypeScript/tests/cases/compiler/externalModuleImmutableBindings.ts | expected:[TS2339,TS2540] actual:[TS2339,TS2405,TS2540]
 FAIL TypeScript/tests/cases/compiler/extractInferenceImprovement.ts | expected:[TS2322,TS2345] actual:[TS2345]


### PR DESCRIPTION
Fixes the TS2551/TS2339 false positive on property access over a `globalThis` that has been augmented via `declare global { namespace globalThis { ... } }`.

**Structural rule:** When the receiver of a property access is `globalThis`, tsc's checker (`checker.ts` ~34957) keys on the receiver *type*'s symbol (`leftType.symbol === globalThisSymbol`) and, for a missing member, emits **TS2339** only when the name is a *block-scoped* global, **TS7017** under `noImplicitAny`, otherwise **nothing** — and never the TS2551 "Did you mean" suggestion, returning `anyType`. Because tsc merges a reopened `namespace globalThis` into the single `globalThisSymbol`, this branch survives augmentation.

tsz keyed its globalThis handling on the *identifier* (`is_global_this_expression`), which bailed as soon as the `globalThis` identifier resolved to a non-lib symbol. The `namespace globalThis` augmentation binds exactly such a user namespace symbol, so tsz treated the augmented receiver as a shadow and routed it through generic property resolution, over-reporting TS2551 (`tests` → `test`) / TS2339 (`alpha`). The fix recognizes that symbol (a `VALUE_MODULE`/`NAMESPACE_MODULE`, non-alias merge) as the global object so the augmented receiver keeps globalThis property-resolution semantics, while a genuine value shadow (`const globalThis = ...`, `function globalThis() {}`) or alias import stays a shadow.

Owner layer: checker globalThis receiver detection (`crates/tsz-checker/src/types/queries/core.rs`).

Adjacent cases verified against tsc:
- `globalThis.tests = "a-b"` (augmented, undeclared) → clean (was TS2551).
- `globalThis.alpha = 4` (augmented, no similar name) → clean (was TS2339).
- `globalThis.test.split(...)` (augmented, declared) → clean.
- `const globalThis = {...}; globalThis.tests` (value shadow) → TS2397 + TS2551 preserved (correctly still a shadow).
- `let zzz; globalThis.zzz` (block-scoped global via augmented receiver) → TS2339 preserved.

Closes #16915.

## Goal
Goal: hold

## Verification
- `compiler/extendGlobalThis.ts`: `[TS2551,TS2882]` → `[TS2882]`, matching `tsc@7.0.2`. Conformance baseline row flipped FAIL→PASS.
- Conformance footprint is provably a single row: only two corpus tests contain `namespace globalThis` — this one, and `extendGlobalThis2.ts`, which has no `globalThis` property access (verified still `[TS2397]`, matching tsc).
- Unit tests (rebased tree): `global` 154, `augment` 67, `property_access` 135, `did_you_mean` 23, `namespace_access` 1 — all pass, 0 failures.
- `clippy` + `arch-size` (the per-merge CI lane) pass via the pre-commit hook.
- Emit/fourslash are unaffected: the change reroutes a *diagnostic* for a not-found globalThis member; it does not alter JS/DTS output.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fibxn3P4KwdzEXqsiURgkx)_