### PR TITLE
fix(emit): computed-index-signature string union interleaves concrete/dynamic buckets out of source order

### DIFF
--- a/crates/tsz-cli/Cargo.toml
+++ b/crates/tsz-cli/Cargo.toml
@@ -156,6 +156,10 @@ name = "const_assertion_wide_index_signature_dts_emit_tests"
 path = "tests/const_assertion_wide_index_signature_dts_emit_tests.rs"
 
 [[test]]
+name = "computed_object_index_signature_source_order_dts_emit_tests"
+path = "tests/computed_object_index_signature_source_order_dts_emit_tests.rs"
+
+[[test]]
 name = "object_rest_binding_dts_emit_tests"
 path = "tests/object_rest_binding_dts_emit_tests.rs"
 

--- a/crates/tsz-cli/tests/computed_object_index_signature_source_order_dts_emit_tests.rs
+++ b/crates/tsz-cli/tests/computed_object_index_signature_source_order_dts_emit_tests.rs
@@ -1,0 +1,179 @@
+//! DTS emit: the synthesized `[x: string]` index-signature union of an object
+//! literal whose computed members mix string- and number-keyed entries.
+//!
+//! Structural rule, oracled against `typescript@7.0.2`
+//! (conformance/types/members/indexSignatures1.ts's `obj13`): a JS numeric
+//! property key is also reachable through the string index (engines coerce
+//! numeric keys to strings), so `tsc` folds every string- AND number-keyed
+//! computed member's value type into one `[x: string]` union, in true source
+//! declaration order across both kinds — not "every string-kind member, then
+//! every number-kind member".
+//!
+//! Before the fix, `rewrite_object_literal_computed_index_signatures`
+//! (`crates/tsz-emitter/src/declaration_emitter/helpers/
+//! type_inference_object_rewrites.rs`) built the `[x: string]` union from two
+//! separate buckets — "concrete-kind" members (regardless of string vs
+//! number) and "dynamic-kind" members (regardless of string vs number) —
+//! concatenated concrete-bucket-then-dynamic-bucket. That reorders
+//! `'x': 0, 'a'+'b': 1, [1]: 2, [1+2]: 3` (declared in that order) into
+//! `0 | 2 | 1 | 3` instead of `0 | 1 | 2 | 3`.
+//!
+//! These run the full checker pipeline (the emitter's unit-level harness uses
+//! an empty type cache and cannot reach this rewrite path at all).
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(name: &str) -> std::io::Result<Self> {
+        let mut path = std::env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!("tsz_computed_index_order_dts_{name}_{nanos}"));
+        std::fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn find_tsz_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_tsz") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    let current_exe = std::env::current_exe().ok()?;
+    let debug_dir = current_exe.parent()?.parent()?;
+    let candidate = debug_dir.join("tsz");
+    candidate.exists().then_some(candidate)
+}
+
+fn emit_dts(name: &str, source: &str) -> Option<String> {
+    let tsz_bin = find_tsz_binary()?;
+    let temp = TempDir::new(name).expect("temp dir");
+    let src_path = temp.path.join("repro.ts");
+    std::fs::write(&src_path, source).expect("write repro file");
+
+    let output = Command::new(tsz_bin)
+        .args([
+            "repro.ts",
+            "--declaration",
+            "--emitDeclarationOnly",
+            "--strict",
+            "--target",
+            "esnext",
+            "--lib",
+            "esnext",
+            "--pretty",
+            "false",
+        ])
+        .current_dir(&temp.path)
+        .output()
+        .expect("run tsz declaration emit");
+
+    let dts = std::fs::read_to_string(temp.path.join("repro.d.ts")).unwrap_or_else(|_| {
+        panic!(
+            "expected repro.d.ts to be emitted.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    Some(dts)
+}
+
+macro_rules! dts_or_skip {
+    ($name:expr, $src:expr) => {
+        match emit_dts($name, $src) {
+            Some(dts) => dts,
+            None => {
+                println!("skipping: tsz binary not found");
+                return;
+            }
+        }
+    };
+}
+
+#[test]
+fn string_and_number_keyed_members_stay_in_source_order() {
+    // The exact shape from indexSignatures1.ts's obj13 (string, dynamic
+    // string, concrete number, dynamic number, in that source order).
+    let dts = dts_or_skip!(
+        "obj13_shape",
+        "export const sym = Symbol();\n\
+         export const o = {\n\
+         \x20   ['x']: 0 as const,\n\
+         \x20   ['a' + 'b']: 1 as const,\n\
+         \x20   [1]: 2 as const,\n\
+         \x20   [1 + 2]: 3 as const,\n\
+         \x20   [sym]: 4 as const,\n\
+         \x20   [Symbol()]: 5 as const,\n\
+         };\n"
+    );
+    assert!(
+        dts.contains("[x: string]: 0 | 1 | 2 | 3;"),
+        "string index must list every string/number member in source order: {dts}"
+    );
+    assert!(
+        dts.contains("[x: number]: 2 | 3;"),
+        "number index unaffected: {dts}"
+    );
+    assert!(
+        dts.contains("[x: symbol]: 4 | 5;"),
+        "symbol index unaffected: {dts}"
+    );
+}
+
+#[test]
+fn number_keyed_member_written_before_string_keyed_member() {
+    // Adjacent case: reversing which kind is declared first still preserves
+    // true source order — this cannot be "string bucket always first".
+    let dts = dts_or_skip!(
+        "number_before_string",
+        "export const o = {\n\
+         \x20   [1]: 0 as const,\n\
+         \x20   ['x']: 1 as const,\n\
+         \x20   [1 + 2]: 2 as const,\n\
+         \x20   ['a' + 'b']: 3 as const,\n\
+         };\n"
+    );
+    assert!(
+        dts.contains("[x: string]: 0 | 1 | 2 | 3;"),
+        "source order must survive even when a number-keyed member leads: {dts}"
+    );
+    assert!(
+        dts.contains("[x: number]: 0 | 2;"),
+        "number index keeps its own source order: {dts}"
+    );
+}
+
+#[test]
+fn only_dynamic_string_members_still_render_in_source_order() {
+    // Negative/fallback case: no number-keyed member at all, so the
+    // concrete/dynamic split degenerates to a single bucket — must still
+    // work (this path already passed before the fix, guards no regression).
+    let dts = dts_or_skip!(
+        "string_only",
+        "export const o = {\n\
+         \x20   ['x']: 0 as const,\n\
+         \x20   ['a' + 'b']: 1 as const,\n\
+         \x20   ['c' + 'd']: 2 as const,\n\
+         };\n"
+    );
+    assert!(
+        dts.contains("[x: string]: 0 | 1 | 2;"),
+        "string-only union must stay in source order: {dts}"
+    );
+}

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_rewrites.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_rewrites.rs
@@ -486,8 +486,17 @@ impl<'a> DeclarationEmitter<'a> {
             return false;
         }
 
-        let mut concrete_string_or_number = Vec::new();
-        let mut dynamic_string_or_number = Vec::new();
+        // A JS numeric property key is also reachable through the string
+        // index (engines coerce numeric keys to strings), so `tsc` folds
+        // every string- and number-keyed member's value type into one
+        // `[x: string]` union, in source declaration order across both
+        // kinds. A single ordered pass (rather than a concrete/dynamic
+        // split concatenated back together) is required to preserve that
+        // order: splitting into "concrete-kind" and "dynamic-kind" buckets
+        // and appending the dynamic bucket after the concrete one silently
+        // reorders a mixed `'x': 0, 'a'+'b': 1, [1]: 2, [1+2]: 3` into
+        // `0 | 2 | 1 | 3` instead of `0 | 1 | 2 | 3`.
+        let mut string_or_number_values = Vec::new();
         let mut number_values = Vec::new();
         let mut symbol_values = Vec::new();
         let mut dynamic_names = Vec::new();
@@ -495,23 +504,23 @@ impl<'a> DeclarationEmitter<'a> {
         for member in &members {
             match member.kind {
                 ComputedObjectIndexKeyKind::ConcreteString => {
-                    Self::push_unique_type_text(&mut concrete_string_or_number, &member.value_type);
+                    Self::push_unique_type_text(&mut string_or_number_values, &member.value_type);
                 }
                 ComputedObjectIndexKeyKind::ConcreteNumber => {
-                    Self::push_unique_type_text(&mut concrete_string_or_number, &member.value_type);
+                    Self::push_unique_type_text(&mut string_or_number_values, &member.value_type);
                     Self::push_unique_type_text(&mut number_values, &member.value_type);
                 }
                 ComputedObjectIndexKeyKind::ConcreteSymbol => {
                     Self::push_unique_type_text(&mut symbol_values, &member.value_type);
                 }
                 ComputedObjectIndexKeyKind::DynamicString => {
-                    Self::push_unique_type_text(&mut dynamic_string_or_number, &member.value_type);
+                    Self::push_unique_type_text(&mut string_or_number_values, &member.value_type);
                     if let Some(name_text) = member.name_text.as_deref() {
                         dynamic_names.push(name_text.to_string());
                     }
                 }
                 ComputedObjectIndexKeyKind::DynamicNumber => {
-                    Self::push_unique_type_text(&mut dynamic_string_or_number, &member.value_type);
+                    Self::push_unique_type_text(&mut string_or_number_values, &member.value_type);
                     Self::push_unique_type_text(&mut number_values, &member.value_type);
                     if let Some(name_text) = member.name_text.as_deref() {
                         dynamic_names.push(name_text.to_string());
@@ -539,14 +548,11 @@ impl<'a> DeclarationEmitter<'a> {
 
         let mut new_index_lines = Vec::new();
         let indent = "    ".repeat((self.indent_level + 1) as usize);
-        if has_dynamic_string {
-            let mut values = concrete_string_or_number.clone();
-            for value in &dynamic_string_or_number {
-                Self::push_unique_type_text(&mut values, value);
-            }
-            if !values.is_empty() {
-                new_index_lines.push(format!("{indent}[x: string]: {};", values.join(" | ")));
-            }
+        if has_dynamic_string && !string_or_number_values.is_empty() {
+            new_index_lines.push(format!(
+                "{indent}[x: string]: {};",
+                string_or_number_values.join(" | ")
+            ));
         }
         if has_dynamic_number && !number_values.is_empty() {
             new_index_lines.push(format!(


### PR DESCRIPTION
## Summary

When an object literal has both string- and number-keyed computed members, `tsc` folds every non-symbol member's value type into one `[x: string]` union (JS engines coerce numeric keys to strings), in true source declaration order across both kinds. `rewrite_object_literal_computed_index_signatures` (`crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_rewrites.rs`) instead built two separate buckets during its single member-iteration pass — `concrete_string_or_number` (both `ConcreteString` and `ConcreteNumber` members) and `dynamic_string_or_number` (both `DynamicString` and `DynamicNumber` members) — then concatenated concrete-bucket-then-dynamic-bucket to render the `[x: string]` union. That silently reorders a source sequence like `'x': 0, 'a'+'b': 1, [1]: 2, [1+2]: 3` into `0 | 2 | 1 | 3` instead of `0 | 1 | 2 | 3`, since the concrete members (0, 2) get grouped ahead of the dynamic members (1, 3) regardless of true declaration order.

**Structural rule.** When an object literal has computed members of mixed string/number key kind, `tsc` folds every non-symbol member into the synthesized `[x: string]` index in true source order (owner: declaration emitter's computed-index-signature recovery); `tsz` now does the same by collecting a single `string_or_number_values` vec in one ordered pass, matching how `number_values` and `symbol_values` were already built correctly.

Fixes the `indexSignatures1.ts` emit-gate fixture (`obj13`): tsz's `.d.ts` is now byte-identical to `typescript@7.0.2`'s. This bug was flagged as a separate, unrelated issue while landing #16909 (a different reordering bug in the same file, for const-asserted wide computed members).

## Goal
Goal: hold

## Verification
- New `crates/tsz-cli/tests/computed_object_index_signature_source_order_dts_emit_tests.rs`: 3 full-pipeline CLI tests (the `obj13` shape, a reversed-declaration-order adjacent case, and a string-only negative/fallback case) — all pass, all oracle-verified against `typescript@7.0.2`.
- `cargo test -p tsz-emitter --lib`: 3991/3991 passed, no regressions.
- Oracle diff: tsz's `.d.ts` for `TypeScript/tests/cases/conformance/types/members/indexSignatures1.ts` is now byte-identical to `typescript@7.0.2`'s (previously differed by one line: `0 | 2 | 1 | 3` vs `0 | 1 | 2 | 3`).
- `cargo fmt --check -p tsz-emitter -p tsz-cli` and `cargo clippy --profile ci-lint -p tsz-emitter --all-targets -- -D warnings`: clean.
- Confirmed via `git stash` bisection against unmodified `main` that two other discrepancies visible on adjacent hand-built cases (an index-signature kind mislabel, and computed-bracket-vs-plain member-name syntax) are pre-existing and unrelated to this change — not touched here, left for a future session.
- Pre-commit hook (clippy + affected-crate tests + arch guard): passed at commit time.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_016bwwxK7ieByDMeueFu2eqm)_