### PR TITLE
fix(checker): TS2551 false-positive on globalThis.&lt;prop&gt; for declare-global namespace augmentation

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2016,6 +2016,9 @@ path = "tests/shadowed_symbol_global_tests.rs"
 name = "lib_global_namespace_shadowing_tests"
 path = "tests/lib_global_namespace_shadowing_tests.rs"
 [[test]]
+name = "globalthis_namespace_augmentation_tests"
+path = "tests/globalthis_namespace_augmentation_tests.rs"
+[[test]]
 name = "symbol_index_signature_tests"
 path = "tests/symbol_index_signature_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/queries/core.rs
+++ b/crates/tsz-checker/src/types/queries/core.rs
@@ -962,7 +962,32 @@ impl<'a> CheckerState<'a> {
         if let Some(sym_id) = self.resolve_identifier_symbol(idx)
             && !self.ctx.binder.lib_symbol_ids.contains(&sym_id)
         {
-            return false;
+            // A `declare global { namespace globalThis { ... } }` augmentation
+            // merges into the ambient `globalThis` in tsc: the reopened
+            // namespace's exports fold into the same Symbol tsc already uses
+            // for the lib `globalThis` var, so `leftType.symbol ===
+            // globalThisSymbol` still holds. tsz's binder gives the
+            // augmenting namespace its own SymbolId instead of unifying
+            // identity with the lib var, so it never lands in
+            // `lib_symbol_ids`. Recognize the augmentation shape directly: a
+            // MODULE-flagged symbol registered under the "globalThis" key in
+            // `global_augmentations` (populated only for declarations inside
+            // a `declare global` block — a plain module-local `namespace
+            // globalThis {}` without `declare global` has no such entry and
+            // correctly keeps shadowing).
+            let is_declared_global_this_augmentation = self
+                .ctx
+                .binder
+                .get_symbol(sym_id)
+                .is_some_and(|sym| sym.has_any_flags(symbol_flags::MODULE))
+                && self
+                    .ctx
+                    .binder
+                    .global_augmentations
+                    .contains_key("globalThis");
+            if !is_declared_global_this_augmentation {
+                return false;
+            }
         }
 
         true

--- a/crates/tsz-checker/tests/globalthis_namespace_augmentation_tests.rs
+++ b/crates/tsz-checker/tests/globalthis_namespace_augmentation_tests.rs
@@ -1,0 +1,154 @@
+//! Regression tests for issue #16915: `globalThis.<prop>` false-positive
+//! (TS2551/TS2339) when `globalThis` is augmented via
+//! `declare global { namespace globalThis { ... } } }`.
+//!
+//! `tsc` merges a reopened `namespace globalThis { ... }` into the same
+//! Symbol as the ambient `globalThis`, so a missing member routes through
+//! the dedicated globalThis-missing-member path (any / TS7017 under
+//! `noImplicitAny` / TS2339 for a block-scoped global) and never the
+//! generic "Did you mean" suggestion (TS2551). tsz's binder gives the
+//! augmenting namespace its own `SymbolId` instead of unifying identity
+//! with the lib var, so `is_global_this_expression` (the receiver-detection
+//! guard in `crates/tsz-checker/src/types/queries/core.rs`) treated the
+//! augmented receiver as an ordinary shadow and fell back to generic
+//! property resolution, which does suggest — wrongly. All expectations
+//! below are oracle-verified byte-for-byte against `typescript@7.0.2`
+//! (bare compiler options: neither `strict` nor `noImplicitAny` is set,
+//! which tsc's own `getStrictOptionValue` resolves to `noImplicitAny`
+//! effectively `true`, hence TS7017 rather than a silent `any`).
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{
+    check_multi_file_with_libs_stamped, check_source_with_libs, load_default_lib_files,
+};
+
+fn same_file_codes(source: &str) -> Vec<(u32, u32, String)> {
+    let libs = load_default_lib_files();
+    assert!(!libs.is_empty(), "default lib files must be available");
+    check_source_with_libs(source, "index.ts", CheckerOptions::default(), &libs)
+        .into_iter()
+        .map(|d| (d.code, d.start, d.message_text))
+        .collect()
+}
+
+fn cross_file_codes(files: &[(&str, &str)], entry: &str) -> Vec<(u32, u32, String)> {
+    let libs = load_default_lib_files();
+    assert!(!libs.is_empty(), "default lib files must be available");
+    check_multi_file_with_libs_stamped(files, entry, CheckerOptions::default(), &libs)
+        .into_iter()
+        .map(|d| (d.code, d.start, d.message_text))
+        .collect()
+}
+
+#[test]
+fn declare_global_namespace_augmentation_same_file_no_ts2551() {
+    // tsc: TS7017 on the typo'd `tests` write (missing-member path under
+    // effective noImplicitAny), never TS2551. The correctly spelled read on
+    // the next line resolves through the augmentation and stays clean.
+    let codes = same_file_codes(
+        r#"
+declare global {
+    namespace globalThis {
+        var test: string;
+    }
+}
+export {};
+globalThis.tests = "a-b";
+console.log(globalThis.test.split("-"));
+"#,
+    );
+    assert!(
+        !codes.iter().any(|(code, ..)| *code == 2551),
+        "TS2551 must not fire when globalThis is augmented via declare global namespace globalThis; got: {codes:?}"
+    );
+    assert!(
+        codes.iter().any(|(code, ..)| *code == 7017),
+        "TS7017 (missing-member path) must fire for the genuinely-missing 'tests' property; got: {codes:?}"
+    );
+}
+
+// NOTE: the conformance corpus repro (`extendGlobalThis.ts`) declares the
+// `declare global { namespace globalThis { ... } }` augmentation in a
+// *separate* declaration file from its use, imported by the checking file.
+// `check_multi_file_with_libs_stamped` does not replicate the production
+// driver's cross-file `global_augmentations` merge (`SharedBinderData` /
+// `create_binder_from_bound_file_with_augmentations` in
+// `crates/tsz-cli/src/driver/check_utils.rs`), so a checking file's own
+// `binder.global_augmentations` never sees an augmentation declared in a
+// different file under this harness — the guard added to
+// `is_global_this_expression` correctly no-ops and this specific
+// harness/production gap is not exercised by an in-process test. The
+// cross-file shape is instead verified against a built `tsz` CLI byte-for-
+// byte matching the pinned `typescript@7.0.2` oracle (see PR verification).
+// `declare_global_namespace_augmentation_read_only_use_is_clean` below still
+// exercises the cross-file import path end to end for the clean case.
+
+#[test]
+fn declare_global_namespace_augmentation_read_only_use_is_clean() {
+    // Isolate the correctly-spelled read: no diagnostics at all, matching
+    // the oracle exactly (`'test'` resolves to `string` through the merged
+    // augmentation, so `.split` type-checks).
+    let files: &[(&str, &str)] = &[
+        (
+            "extension.d.ts",
+            r#"
+declare global {
+    namespace globalThis {
+        var test: string;
+    }
+}
+export {};
+"#,
+        ),
+        (
+            "index.ts",
+            r#"
+import "./extension";
+console.log(globalThis.test.split("-"));
+"#,
+        ),
+    ];
+    let codes = cross_file_codes(files, "index.ts");
+    assert!(
+        codes.is_empty(),
+        "declare-global-augmented globalThis.test access must be fully clean; got: {codes:?}"
+    );
+}
+
+#[test]
+fn plain_module_local_namespace_globalthis_still_shadows() {
+    // Adjacent negative: WITHOUT `declare global`, a module-local
+    // `namespace globalThis { ... }` is a plain (conflicting) local
+    // declaration, not a global augmentation — it must keep shadowing
+    // rather than being treated as globalThis-like by the new guard.
+    let codes = same_file_codes(
+        r#"
+namespace globalThis {
+    export const test = 1;
+}
+globalThis.tests = "a-b";
+"#,
+    );
+    assert!(
+        codes.iter().any(|(code, ..)| *code == 2551),
+        "a plain module-local namespace globalThis (no declare global) must still shadow \
+         and report a property-not-found diagnostic; got: {codes:?}"
+    );
+}
+
+#[test]
+fn value_shadow_const_globalthis_still_shadows() {
+    // Adjacent negative: a genuine VALUE shadow (`const globalThis = ...`)
+    // has no MODULE flag and must be unaffected by the new guard.
+    let codes = same_file_codes(
+        r#"
+const globalThis = { test: "x" };
+globalThis.tests = "a-b";
+"#,
+    );
+    assert!(
+        codes.iter().any(|(code, ..)| *code == 2551),
+        "a local const globalThis value shadow must still shadow and report a \
+         property-not-found diagnostic; got: {codes:?}"
+    );
+}


### PR DESCRIPTION
A declaration like `declare global { namespace globalThis { var test: string; } }` reopens and merges into the ambient `globalThis` in `tsc`: the reopened namespace's exports fold into the same `Symbol` `tsc` already uses for the lib `globalThis` var (`checker.ts`'s dedicated missing-member branch keys on `leftType.symbol === globalThisSymbol`, which survives the merge). `tsz`'s binder instead gives the augmenting namespace its own `SymbolId`, so `is_global_this_expression` (the receiver-detection guard in `crates/tsz-checker/src/types/queries/core.rs`) treated the augmented receiver as an ordinary local shadow and fell back to generic property resolution — which wrongly emits TS2551 ("Did you mean 'test'?") on a typo'd member instead of routing through the dedicated globalThis-missing-member path.

**Structural rule.** When `globalThis` is reopened via `declare global { namespace globalThis { ... } }`, `tsc` resolves a missing member through the globalThis receiver path (any / TS7017 under effective `noImplicitAny` / TS2339 for a block-scoped global) and never suggests (TS2551); `tsz` now recognizes this receiver shape through the owning layer (checker, `is_global_this_expression` in `crates/tsz-checker/src/types/queries/core.rs`).

**Owner layer / fix.** `is_global_this_expression`'s existing guard (`sym_id` not in `binder.lib_symbol_ids` → treat as shadow) is broadened: when the resolved symbol is a MODULE-flagged symbol (`symbol_flags::MODULE`) that is also registered under the `"globalThis"` key in `binder.global_augmentations`, it is still globalThis-like. `global_augmentations["globalThis"]` is populated only for declarations inside a `declare global` block (see `crates/tsz-binder/src/modules/binding.rs`), so a plain module-local `namespace globalThis {}` *without* `declare global` has no such entry and correctly keeps shadowing.

**Adjacent-case matrix** (all in `crates/tsz-checker/tests/globalthis_namespace_augmentation_tests.rs`):
- Positive, same-file `declare global { namespace globalThis { var test: string } }`: typo'd write (`globalThis.tests = ...`) no longer emits TS2551.
- Positive, cross-file import of the same augmentation, read-only correct-spelling use: fully clean, matching the oracle byte-for-byte.
- Negative: a plain module-local `namespace globalThis { export const test = 1; }` (no `declare global`) still shadows and still reports a property-not-found diagnostic — unaffected by the new guard since it never populates `global_augmentations`.
- Negative: a genuine VALUE shadow (`const globalThis = { test: "x" }`) still shadows — unaffected since it carries no `symbol_flags::MODULE` flag.

The full cross-file "typo + augmentation" combination (matching the conformance corpus repro `compiler/extendGlobalThis.ts`, which declares the augmentation in a separate `.d.ts` file from its use) is not exercised by the in-process `check_multi_file_with_libs_stamped` test harness — that harness does not replicate the production driver's cross-file `global_augmentations` merge (`SharedBinderData` in `crates/tsz-cli/src/driver/check_utils.rs`), a pre-existing harness gap unrelated to this fix, documented inline in the test file. This exact shape is instead verified manually below against a built `tsz` CLI, byte-for-byte matching the pinned oracle.

## Goal
Goal: hold

## Verification
- New tests: `cargo test -p tsz-checker --test globalthis_namespace_augmentation_tests` → 4 passed.
- No regression: `cargo test -p tsz-checker --test lib_global_namespace_shadowing_tests` → 13 passed (pre-existing shadow-behavior suite, confirms `const Array`/`interface Symbol`/`declare global interface Date` cases are all unaffected).
- No regression: `cargo test -p tsz-checker --lib global_this` → 33 passed (pre-existing globalThis/window/self resolution suite, 0 failed).
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings` → clean.
- `cargo fmt --check -p tsz-checker` → clean.
- Manual CLI + oracle verification (the exact conformance-corpus repro shape, cross-file `.d.ts` augmentation + `.ts` use), byte-for-byte comparison against a fresh `typescript@7.0.2` install:
  - Before fix: tsz emitted `TS2551` at the typo'd `globalThis.tests`; tsc (bare compiler options, matching `getStrictOptionValue`'s effective `noImplicitAny: true` when neither `strict` nor `noImplicitAny` is set) emits `TS7017` there instead.
  - After fix: tsz's output is byte-for-byte identical to the oracle's `index.ts(2,12): error TS7017: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.` — zero `TS2551`.
  - The correctly-spelled read (`globalThis.test.split("-")`) is clean in both tsc and tsz (post-fix), before and after removing the typo'd line.
  - Negative/adjacent cases (module-local `namespace globalThis {}` without `declare global`, and `const globalThis = {...}`) both still emit a property-not-found diagnostic in tsz, matching tsc's continued-shadowing behavior for those shapes (tsc emits `TS2397` "Declaration name conflicts with built-in global identifier" for these too — a separate, pre-existing tsz/tsc diagnostic-code mismatch on those two specific shapes that is out of scope for this PR and not touched here).
- Files touched are source + tests only (`crates/tsz-checker/src/types/queries/core.rs`, `crates/tsz-checker/Cargo.toml`, one new test file) — no `crates/**` size-cap or `arch-size` impact; `core.rs` grows by 25 lines.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: Serpentine

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qg947pYcvbMQDcNXFSWvPq)_