### PR TITLE
fix(parser): regex ']' expected must track class nesting depth under the v flag

### DIFF
--- a/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
@@ -2340,10 +2340,10 @@ impl ParserState {
             return None;
         }
 
-        let mut missing = None;
-        let mut paren_depth = 0i32;
+        // Under `v`, a nested `[` in a class opens ANOTHER class needing its own `]`.
+        let unicode_sets_mode = bytes[body_end + 1..].contains(&b'v');
+        let (mut paren_depth, mut class_depth) = (0i32, 0i32);
         in_escape = false;
-        in_character_class = false;
         for &ch in &bytes[1..body_end] {
             if in_escape {
                 in_escape = false;
@@ -2353,28 +2353,28 @@ impl ParserState {
                 in_escape = true;
                 continue;
             }
-            if in_character_class {
+            if class_depth > 0 {
                 if ch == b']' {
-                    in_character_class = false;
+                    class_depth -= 1;
+                } else if unicode_sets_mode && ch == b'[' {
+                    class_depth += 1;
                 }
                 continue;
             }
             match ch {
-                b'[' => in_character_class = true,
+                b'[' => class_depth = 1,
                 b'(' => paren_depth += 1,
                 b')' if paren_depth > 0 => paren_depth -= 1,
                 _ => {}
             }
         }
-
-        if in_character_class {
-            missing = Some(b']');
+        if class_depth > 0 {
+            Some(b']')
+        } else if paren_depth > 0 {
+            Some(b')')
+        } else {
+            None
         }
-        if missing.is_none() && paren_depth > 0 {
-            missing = Some(b')');
-        }
-
-        missing
     }
 }
 

--- a/crates/tsz-parser/tests/parser_improvement_regex_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_regex_recovery_tests.rs
@@ -1066,3 +1066,78 @@ fn test_non_modifier_group_forms_are_unaffected() {
         );
     }
 }
+
+// Regression for the `regExpWithOpenBracketInCharClass` / `regularExpressionScanning`
+// conformance family: under the `v` (unicodeSets) flag, an unescaped `[` inside a
+// character class opens a NESTED class that needs its own closing `]`, so
+// `missing_regex_closing_token`'s balance check must track class nesting DEPTH
+// under `v`, not a single in-class boolean. Without `v`, a nested `[` is an
+// ordinary class member and never needs its own close.
+#[test]
+fn test_unclosed_nested_class_under_unicode_sets_flag_reports_ts1005() {
+    // `[[]` under `v`: outer `[` opens, inner `[` opens a nested class, the
+    // lone `]` closes only the inner one — the outer class is never closed.
+    assert_eq!(
+        regex_codes("const r = /[[]/v;", tsz_common::ScriptTarget::ES2024),
+        vec![diagnostic_codes::EXPECTED],
+        "outer class left open by a nested class must report ']' expected"
+    );
+}
+
+#[test]
+fn test_same_bracket_shape_without_v_flag_is_not_a_nested_class() {
+    // Same `[[]` byte shape, but without `v` a nested `[` is just an ordinary
+    // class member: the single `]` closes the (only) class and the regex is
+    // well-formed. `u` alone (no `v`) must behave the same way.
+    for witness in ["const r = /[[]/;", "const r = /[[]/u;"] {
+        assert_eq!(
+            regex_codes(witness, tsz_common::ScriptTarget::ES2024),
+            Vec::<u32>::new(),
+            "{witness}: nested-looking `[` without `v` must not require a second `]`"
+        );
+    }
+}
+
+#[test]
+fn test_balanced_nested_class_under_unicode_sets_flag_is_clean() {
+    // `[[]]` under `v`: outer opens, inner opens and closes, outer closes.
+    // Fully balanced — no missing-token diagnostic.
+    assert_eq!(
+        regex_codes("const r = /[[]]/v;", tsz_common::ScriptTarget::ES2024),
+        Vec::<u32>::new(),
+        "fully balanced nested class under v must stay clean"
+    );
+}
+
+#[test]
+fn test_deeply_nested_unclosed_class_under_unicode_sets_flag_reports_ts1005() {
+    // `[[[]]` under `v`: three opens, two closes — one level (the outermost)
+    // is left open. Depth tracking, not a boolean, is required to see this.
+    assert_eq!(
+        regex_codes("const r = /[[[]]/v;", tsz_common::ScriptTarget::ES2024),
+        vec![diagnostic_codes::EXPECTED],
+        "one unclosed level in a deeper nest must still report ']' expected"
+    );
+    // `[[[]]]` under `v`: three opens, three closes — fully balanced.
+    assert_eq!(
+        regex_codes("const r = /[[[]]]/v;", tsz_common::ScriptTarget::ES2024),
+        Vec::<u32>::new(),
+        "a fully balanced deeper nest under v must stay clean"
+    );
+}
+
+#[test]
+fn test_realistic_class_set_expression_does_not_falsely_report_unclosed_class() {
+    // A real-world `unicodeSets` class-set expression (from the
+    // `regularExpressionScanning` conformance fixture) with heavy nesting and
+    // subtraction/intersection operators. It has its own set of dedicated
+    // class-set diagnostics (`--`/`&&` operand errors), but the OUTER class
+    // balance itself is correct and must not additionally trigger the
+    // generic `']' expected` fallback.
+    let source = r"const r = /[a--b[--][\d++[]]&&[[&0-9--]&&[\p{L}]--\P{L}-_-]]&&&\q{foo}[0---9][&&q&&&\q{bar}&&]/v;";
+    assert!(
+        !regex_codes(source, tsz_common::ScriptTarget::ES2024)
+            .contains(&diagnostic_codes::EXPECTED),
+        "balanced outer class in a heavily-nested class-set expression must not report ']' expected"
+    );
+}


### PR DESCRIPTION
Structural rule: when a regex literal carries the `v` (`unicodeSets`) flag, an unescaped `[` inside a character class opens a NESTED class that needs its own closing `]` — so `/[[]/v` is one unclosed outer class plus one balanced inner class, and `tsc` reports `TS1005 "']' expected."` at the pattern's end. Without `v`, a nested `[` is an ordinary class member and never needs a second `]`. `tsz`'s fallback balance check (`missing_regex_closing_token` in `crates/tsz-parser/src/parser/state_expressions_literals_regex.rs`) tracked class membership with a single boolean instead of a depth counter, so it saw `[[]` as closed by the first `]` and silently dropped the diagnostic.

Fix: track character-class nesting with a depth counter that only increments on a nested `[` when the `v` flag is present (matching `tsc`'s `unicodeSets`-only nested-class grammar); without `v`, a nested `[` still leaves depth untouched, exactly as before.

Adjacent-case matrix (new tests in `parser_improvement_regex_recovery_tests.rs`):
- Positive: `/[[]/v` → `TS1005` (outer class left open by the nested class).
- Negative: the identical `[[]` byte shape with no flag or with `u` only → clean (nested-looking `[` is an ordinary member without `v`).
- Negative: `/[[]]/v` → clean (nested class opened and closed, outer class closed).
- Depth vs. boolean: `/[[[]]/v` → `TS1005` (one of three levels left open); `/[[[]]]/v` → clean (fully balanced three-deep nest).
- Regression guard: the real `--`/`&&` class-set-operator expression from the `regularExpressionScanning` conformance fixture must not falsely trip the fallback despite heavy nesting.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-parser --lib parser_improvement_regex_recovery_tests` → 41/41 passed (5 new).
- `cargo test -p tsz-parser --lib regex` → 209/209 passed (no regression across every regex-family unit test).
- `cargo test -p tsz-parser --lib` → 2184/2184 passed (full crate suite, no regression).
- `cargo clippy --profile ci-lint -p tsz-parser --all-targets -- -D warnings` → clean.
- `cargo fmt --check -p tsz-parser` → clean.
- Oracle-pinned conformance runner (`tsz-conformance`, `typescript@7.0.2` cache) directly on the affected fixtures:
  - `TypeScript/tests/cases/compiler/regExpWithOpenBracketInCharClass.ts`: **FAIL → PASS**.
  - All 13 `reg*`-named conformance fixtures re-run: 11/13 pass, unchanged from before this fix — the 2 pre-existing failures (`regularExpressionScanning.ts`, `regularExpressionCharacterClassRangeOrder.ts`) have unrelated root causes (different diagnostic codes/positions, not the outer-class balance check this PR touches) and are untouched by this diff.
- Files touched are parser source + parser test only (`crates/tsz-parser/src/parser/state_expressions_literals_regex.rs`, `crates/tsz-parser/tests/parser_improvement_regex_recovery_tests.rs`) — no emit or checker path affected, so no emit/fourslash re-run is owed.
- `arch-size` guard: `state_expressions_literals_regex.rs` sits exactly at its ratcheted 2438-line cap (compacted the touched function to net zero extra lines rather than requesting a ceiling bump).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ntr6QyaYAkPRSnaTgkJhBM)_