### PR TITLE
fix(resolver): explicit-root JS file suppresses TS7016 on external require()

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -203,7 +203,7 @@ pub(super) fn collect_diagnostics(
     cache: Option<&mut CompilationCache>,
     type_cache_output: &std::sync::Mutex<FxHashMap<PathBuf, TypeCache>>,
 ) -> CollectDiagnosticsResult {
-    collect_diagnostics_with_source_resolutions(input, cache, type_cache_output, None, None)
+    collect_diagnostics_with_source_resolutions(input, cache, type_cache_output, None, None, None)
 }
 
 pub(super) fn collect_diagnostics_with_source_resolutions(
@@ -214,6 +214,7 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
         &FxHashMap<SourceModuleResolutionKey, SourceModuleResolution>,
     >,
     source_module_resolution_misses: Option<&FxHashSet<SourceModuleResolutionKey>>,
+    explicit_root_paths: Option<&FxHashSet<PathBuf>>,
 ) -> CollectDiagnosticsResult {
     let &CollectDiagnosticsInput {
         program,
@@ -329,6 +330,7 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
         source_module_resolution_misses,
         program_file_index: &program_file_index,
         program_paths: &program_paths,
+        root_file_paths: explicit_root_paths,
         package_redirects: &package_redirects,
         resolution_cache: &mut resolution_cache,
     });

--- a/crates/tsz-cli/src/driver/core_diagnostics.rs
+++ b/crates/tsz-cli/src/driver/core_diagnostics.rs
@@ -630,6 +630,10 @@ fn compile_inner_impl(
     }
 
     let root_file_paths = file_paths.clone();
+    let explicit_root_paths: FxHashSet<PathBuf> = root_file_paths
+        .iter()
+        .map(|path| canonicalize_or_owned(path))
+        .collect();
 
     // TS1149: two root files whose real on-disk paths are identical except
     // for casing (e.g. `foo.ts` and `Foo.ts` both specified as roots). tsc
@@ -1149,6 +1153,7 @@ fn compile_inner_impl(
         &parallel_type_caches,
         Some(&module_resolutions),
         Some(&module_resolution_misses),
+        Some(&explicit_root_paths),
     );
     let mut diagnostics: Vec<Diagnostic> = collected.diagnostics;
     let check_duration = collect_diagnostics_start.elapsed();

--- a/crates/tsz-cli/src/driver/source_resolution_setup.rs
+++ b/crates/tsz-cli/src/driver/source_resolution_setup.rs
@@ -39,6 +39,12 @@ pub(super) struct SourceResolutionSetupInput<'a> {
     pub(super) source_module_resolution_misses: Option<&'a FxHashSet<SourceModuleResolutionKey>>,
     pub(super) program_file_index: &'a ProgramFileIndex,
     pub(super) program_paths: &'a FxHashSet<PathBuf>,
+    /// Canonicalized paths of files that are explicit program roots (tsc's
+    /// `rootNames` - `files`/CLI-argument entries), as opposed to files only
+    /// reached transitively through import/require resolution. `None` when
+    /// the caller has no such distinction available (falls back to the old
+    /// behavior of never treating a resolution as root-explicit).
+    pub(super) root_file_paths: Option<&'a FxHashSet<PathBuf>>,
     pub(super) package_redirects: &'a FxHashMap<PathBuf, PathBuf>,
     pub(super) resolution_cache: &'a mut ModuleResolutionCache,
 }
@@ -95,6 +101,7 @@ pub(super) fn prepare_source_resolution_setup(
         source_module_resolution_misses,
         program_file_index,
         program_paths,
+        root_file_paths,
         package_redirects,
         resolution_cache,
     } = input;
@@ -407,7 +414,7 @@ pub(super) fn prepare_source_resolution_setup(
                         program.declared_modules.contains(spec)
                             || program.shorthand_ambient_modules.contains(spec)
                     },
-                    Some(program_paths),
+                    root_file_paths,
                 );
 
                 // Classify the lookup result into a driver-facing outcome.
@@ -584,7 +591,7 @@ pub(super) fn prepare_source_resolution_setup(
                         program.declared_modules.contains(spec)
                             || program.shorthand_ambient_modules.contains(spec)
                     },
-                    Some(program_paths),
+                    root_file_paths,
                 );
                 let outcome = result.classify();
                 if let Some(ref untyped_path) = outcome.untyped_module_path {

--- a/crates/tsz-core/src/module_resolver/mod.rs
+++ b/crates/tsz-core/src/module_resolver/mod.rs
@@ -696,7 +696,7 @@ impl ModuleResolver {
         request: &ModuleLookupRequest<'_>,
         fallback_resolve: impl FnOnce(&str, &Path) -> Option<PathBuf>,
         is_ambient_module: impl Fn(&str) -> bool,
-        _known_files: Option<&rustc_hash::FxHashSet<std::path::PathBuf>>,
+        known_files: Option<&rustc_hash::FxHashSet<std::path::PathBuf>>,
     ) -> ModuleLookupResult {
         let specifier = request.specifier;
         let containing_file = request.containing_file;
@@ -871,8 +871,30 @@ impl ModuleResolver {
                 //    not flagged as "missing declaration file".
                 let is_imported_js =
                     resolved_module.extension.is_javascript() && request.no_implicit_any;
-                let is_external_cjs_require =
-                    resolved_module.is_external && matches!(import_kind, ImportKind::CjsRequire);
+                // A `node_modules`-hosted JS file that is itself an explicit
+                // program root (tsc's `rootNames`, e.g. `files`/CLI-argument
+                // entries - the TypeScript test-harness convention of turning
+                // every `@Filename` including node_modules ones into a root)
+                // is never `isExternalLibraryImport` in tsc's model: the file
+                // already has a `SourceFile` from being processed as a root,
+                // so a later `require()` of it resolves to that existing file
+                // rather than being (re)classified as an external dependency.
+                // Confirmed against the pinned oracle (typescript@7.0.2):
+                // `require("foo")` of an unrooted `node_modules/foo` JS file
+                // reports TS7016, but the identical `require()` is clean once
+                // `foo`'s resolved JS file is *also* passed as a root -
+                // independent of `maxNodeModuleJsDepth`, which is unset in
+                // both cases. `compiler/importNonExportedMember12.ts` and
+                // `conformance/salsa/namespaceAssignmentToRequireAlias.ts`
+                // are exactly this shape (their `.js` fixtures are declared
+                // via `@Filename` under `node_modules/`, which the conformance
+                // harness turns into explicit `files` roots - see
+                // `needs_explicit_root_files` in `crates/conformance/src/tsz_wrapper.rs`).
+                let is_explicit_root =
+                    known_files.is_some_and(|roots| roots.contains(&resolved_module.resolved_path));
+                let is_external_cjs_require = resolved_module.is_external
+                    && matches!(import_kind, ImportKind::CjsRequire)
+                    && !is_explicit_root;
                 // tsc's augmentation-target check (TS2665) keys on the
                 // *resolution extension*, not on whether the import site was
                 // diagnosed: a specifier resolving to a `.js`/`.jsx` file is an

--- a/crates/tsz-core/src/module_resolver/tests.rs
+++ b/crates/tsz-core/src/module_resolver/tests.rs
@@ -13,6 +13,7 @@ mod conditional_types_flavor;
 mod diagnostics_ts2307;
 mod diagnostics_ts2792;
 mod diagnostics_ts2835;
+mod explicit_root_untyped_js;
 mod importing_module_kind;
 mod lookup_classify;
 mod lookup_integration;

--- a/crates/tsz-core/src/module_resolver/tests/explicit_root_untyped_js.rs
+++ b/crates/tsz-core/src/module_resolver/tests/explicit_root_untyped_js.rs
@@ -1,0 +1,165 @@
+//! `require()` of an untyped `node_modules` JS module, when that JS file is
+//! itself an explicit program root, is not `isExternalLibraryImport` in tsc's
+//! model — the file already has a `SourceFile` from being processed as a
+//! root, so no TS7016 fires. Oracle-verified (`typescript@7.0.2`) against the
+//! real conformance-corpus shapes `compiler/importNonExportedMember12.ts` and
+//! `conformance/salsa/namespaceAssignmentToRequireAlias.ts`: both are `.js`
+//! fixtures under `node_modules/` that the TypeScript test harness (and
+//! tsz's own conformance harness — see `needs_explicit_root_files` in
+//! `crates/conformance/src/tsz_wrapper.rs`) turns into explicit `files`
+//! roots, and both are clean of TS7016 only because of that, independent of
+//! `maxNodeModuleJsDepth` (unset in both).
+
+use super::super::*;
+use super::fixtures::TempFixture;
+use rustc_hash::FxHashSet;
+
+fn setup_untyped_package(fixture: &TempFixture) -> std::path::PathBuf {
+    fixture.write(
+        "node_modules/untyped/package.json",
+        r#"{"name":"untyped","version":"1.0.0","main":"index.js"}"#,
+    );
+    fixture.write("node_modules/untyped/index.js", "module.exports = 1;")
+}
+
+/// `ModuleResolver::node_resolver()` hardcodes `allow_js: false`, which
+/// routes every `.js`-only resolution through the `probe_js_file` fallback
+/// (a different code path from the one under test here). Real projects that
+/// hit this false positive set `allowJs: true` (both named conformance
+/// fixtures do), so tests need a resolver that actually takes the primary
+/// `Ok(resolved_module)` branch for a `.js` file.
+fn allow_js_node_resolver() -> ModuleResolver {
+    let options = ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Node16),
+        module_suffixes: vec![String::new()],
+        allow_js: true,
+        printer: crate::emitter::PrinterOptions {
+            module: crate::emitter::ModuleKind::Node16,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    ModuleResolver::new(&options)
+}
+
+fn require_request<'a>(
+    specifier: &'a str,
+    containing_file: &'a std::path::Path,
+) -> ModuleLookupRequest<'a> {
+    ModuleLookupRequest {
+        specifier,
+        containing_file,
+        specifier_span: Span::new(0, 0),
+        import_kind: ImportKind::CjsRequire,
+        resolution_mode_override: None,
+        no_implicit_any: true,
+        implied_classic_resolution: false,
+    }
+}
+
+#[test]
+fn explicit_root_untyped_js_suppresses_ts7016() {
+    let fixture = TempFixture::new();
+    let resolved_js = setup_untyped_package(&fixture);
+    let containing_file = fixture.write("a.ts", "import u = require(\"untyped\");");
+
+    let mut resolver = allow_js_node_resolver();
+    let request = require_request("untyped", &containing_file);
+
+    let mut known_files = FxHashSet::default();
+    known_files.insert(resolved_js.clone());
+
+    let result = resolver.lookup(&request, |_, _| None, |_| false, Some(&known_files));
+
+    assert_eq!(
+        result.resolved_path.as_deref(),
+        Some(resolved_js.as_path()),
+        "should still resolve to the real JS file"
+    );
+    assert!(
+        result.error.is_none(),
+        "an explicit-root untyped JS module must not report TS7016: {:?}",
+        result.error
+    );
+}
+
+#[test]
+fn non_root_untyped_js_still_reports_ts7016() {
+    let fixture = TempFixture::new();
+    let resolved_js = setup_untyped_package(&fixture);
+    let containing_file = fixture.write("a.ts", "import u = require(\"untyped\");");
+
+    let mut resolver = allow_js_node_resolver();
+    let request = require_request("untyped", &containing_file);
+
+    // No `known_files` at all: the genuine "no root, no depth allowance"
+    // default shape most real projects hit.
+    let result_no_known_files = resolver.lookup(&request, |_, _| None, |_| false, None);
+    let error = result_no_known_files
+        .error
+        .expect("a genuinely external, non-rooted require() of untyped JS must report TS7016");
+    assert_eq!(error.code, COULD_NOT_FIND_DECLARATION_FILE);
+
+    resolver.clear_cache();
+
+    // `known_files` present but not containing this resolution: must not
+    // accidentally treat every program file as root-explicit.
+    let mut unrelated_known_files = FxHashSet::default();
+    unrelated_known_files.insert(containing_file.clone());
+    let result_unrelated = resolver.lookup(
+        &request,
+        |_, _| None,
+        |_| false,
+        Some(&unrelated_known_files),
+    );
+    let error = result_unrelated
+        .error
+        .expect("an unrelated known_files set must not suppress TS7016 for this resolution");
+    assert_eq!(error.code, COULD_NOT_FIND_DECLARATION_FILE);
+    assert!(
+        error.message.contains(&resolved_js.display().to_string()),
+        "error should still reference the resolved JS path: {}",
+        error.message
+    );
+}
+
+#[test]
+fn explicit_root_esm_import_of_untyped_js_is_unaffected() {
+    // The explicit-root bypass is scoped to the external-CJS-require branch
+    // (`is_external_cjs_require`); a plain ESM `import` of the same untyped
+    // JS file is a different tsc rule (issue #3050, gated on `allowJs`
+    // alone) and must keep its existing behavior regardless of root status.
+    let fixture = TempFixture::new();
+    let resolved_js = setup_untyped_package(&fixture);
+    let containing_file = fixture.write("a.ts", "import u from \"untyped\";");
+
+    let options = ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Node16),
+        module_suffixes: vec![String::new()],
+        allow_js: false,
+        printer: crate::emitter::PrinterOptions {
+            module: crate::emitter::ModuleKind::Node16,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let mut resolver = ModuleResolver::new(&options);
+    let request = ModuleLookupRequest {
+        specifier: "untyped",
+        containing_file: &containing_file,
+        specifier_span: Span::new(0, 0),
+        import_kind: ImportKind::EsmImport,
+        resolution_mode_override: None,
+        no_implicit_any: true,
+        implied_classic_resolution: false,
+    };
+
+    let mut known_files = FxHashSet::default();
+    known_files.insert(resolved_js);
+
+    let result = resolver.lookup(&request, |_, _| None, |_| false, Some(&known_files));
+    assert!(
+        result.error.is_some(),
+        "ESM import of untyped JS without allowJs still reports TS7016 even when rooted"
+    );
+}


### PR DESCRIPTION
A `node_modules`-hosted JS file that is itself an explicit program root (tsc's `rootNames` — `files`/CLI-argument entries) is never `isExternalLibraryImport` in tsc's model: the file already has a `SourceFile` from being processed as a root, so a later `require()` of it resolves to that existing file rather than being (re)classified as an external dependency.

**Structural rule.** When a `require()`d `node_modules` JS module's resolved path is itself an explicit program root, tsc never emits TS7016 for it (independent of `maxNodeModuleJsDepth`); tsz now recognizes this through the owner layer (`ModuleResolver::lookup`'s `is_external_cjs_require` branch, `crates/tsz-core/src/module_resolver/mod.rs`).

**Why this, not `maxNodeModuleJsDepth`.** Issue #16921 (filed by my own prior-hour session, from the #16916 revert) diagnosed the two motivating conformance fixtures — `compiler/importNonExportedMember12.ts` and `conformance/salsa/namespaceAssignmentToRequireAlias.ts` — as a `maxNodeModuleJsDepth` admission gap. Re-investigating from scratch this session found that framing was wrong: `maxNodeModuleJsDepth` **is** already read back (`should_skip_js_in_node_modules` in `crates/tsz-cli/src/driver/sources.rs`, wired into the real BFS at `core_diagnostics.rs:738`), and neither fixture sets it. Oracle-verified (`typescript@7.0.2`) with a minimal isolated repro (`node_modules/untyped/index.js`, `require("untyped")` from a `.ts` file):
- Unrooted `require()`, no `maxNodeModuleJsDepth` → **TS7016** (matches tsz today).
- Same `require()`, `--maxNodeModuleJsDepth 1` → clean (a real, separate, unimplemented feature — still open, now correctly scoped in #16921).
- Same `require()`, **no** `maxNodeModuleJsDepth`, but the resolved JS file is *also* passed as an explicit root → clean.

Both named conformance fixtures are exactly the third shape: their `node_modules`-hosted `.js` files are declared via `@Filename`, which the real TypeScript test harness — and tsz's own conformance harness (`needs_explicit_root_files` in `crates/conformance/src/tsz_wrapper.rs`) — turns into explicit `files` roots. That's what makes them clean in `tsc-cache-full.json`, not depth gating.

**Fix.** `ModuleResolver::lookup` already had an unused `known_files` parameter plumbed through from the driver (received `program_paths`, but never read). Renamed it to `known_files` and used it to gate `is_external_cjs_require`. Threaded the driver's actual pre-BFS explicit-root list (`root_file_paths` in `core_diagnostics.rs`, canonicalized) through `CollectDiagnosticsInput` → `SourceResolutionSetupInput` → both `ModuleResolver::lookup` call sites in `source_resolution_setup.rs`, replacing the previous (unused) `program_paths` argument. The `#[cfg(test)]` `collect_diagnostics` wrapper forwards `None` for the new parameter automatically, so none of the ~30 existing test call sites needed touching.

**Adjacent-case matrix** (`crates/tsz-core/src/module_resolver/tests/explicit_root_untyped_js.rs`, new file — `lookup_integration.rs` is already at the 2000-line cap):
- Positive: external CJS `require()` of an untyped JS module whose resolved path is an explicit root → clean, resolves normally.
- Negative: same `require()` with no `known_files` at all → still TS7016 (the common real-world default).
- Negative: `known_files` present but not containing this resolution → still TS7016 (proves the gate is resolution-specific, not "any known file suppresses everything").
- Negative: the same untyped JS file reached via a plain ESM `import` (not `require()`), even when rooted → still TS7016 — the explicit-root bypass is scoped to `is_external_cjs_require` only; the separate `is_imported_js && !allow_js` branch (issue #3050) is untouched.

## Known residual (not fixed by this PR, tracked in #16928)

Review (mohsen1/m4, opus-5) found that under **`--moduleResolution node16`/`nodenext`** specifically, property access on the `require()`d module (`u.hello()`) now reports a false `TS2339` instead of the pre-fix `TS7016`. Verified this is not a regression: the pre-fix binary reported `TS7016` for the identical Node16 repro (implicit `any` on `u`, which happened to suppress the property-access check rather than catch it correctly) — so the underlying JS-export-inference gap for `require()` under Node16/NodeNext already existed; this PR just stops masking it with `any` for the explicit-root case. Confirmed the gap is resolution-kind-specific: classic/`commonjs` resolution (what both named conformance fixtures use, and what `namespaceAssignmentToRequireAlias.ts`'s own property-access assertions exercise) correctly infers the JS module's real shape and is unaffected. Filed #16928 with the narrowed repro and a likely-owner pointer (checker's CJS-require type construction under Node16/NodeNext) — out of scope for this PR, which is resolver-layer only.

## Goal
Goal: hold

## Verification
- New: `cargo test -p tsz-core --lib explicit_root_untyped_js` → 3/3 passed.
- No regression: `cargo test -p tsz-core --lib module_resolver` → 286/286 passed (283 pre-existing + 3 new).
- No regression: `cargo test -p tsz-cli --lib -- module_resolution` → 33/33 passed, including the pre-existing `untyped_node_modules_package_reports_ts7016_under_no_implicit_any`.
- `cargo clippy --profile ci-lint -p tsz-core -p tsz-cli --all-targets -- -D warnings` → clean.
- `cargo fmt -p tsz-core -p tsz-cli` → no diff.
- `python3 scripts/arch/arch_guard_file_limits.py` → clean (all touched files well under the 2000-line cap).
- Manual end-to-end CLI verification with a `dev` build, byte-for-byte matching the pinned `typescript@7.0.2` oracle on all three named/derived shapes:
  - `compiler/importNonExportedMember12.ts` replica, `foo/src/index.js` passed as an explicit root → clean (was TS7016 before this fix, matching tsc).
  - `conformance/salsa/namespaceAssignmentToRequireAlias.ts` replica, `untyped/index.js` passed as an explicit root → clean of TS7016, and its `TS2339` property-access assertions match tsc byte-for-byte under the fixture's actual (default/commonjs) resolution.
  - Both fixture replicas **unrooted** → still TS7016, matching tsc (no regression).
  - Minimal isolated `require("untyped")` repro, unrooted → still TS7016 (matches tsc; confirms the fix is resolution-specific, not a blanket relaxation).
  - Node16/NodeNext + property-access repro (post-review) → `TS2339` false positive, confirmed pre-existing (not introduced by this PR) and tracked in #16928.
- Files touched are `crates/tsz-cli/src/driver/{check,core_diagnostics,source_resolution_setup}.rs` and `crates/tsz-core/src/module_resolver/{mod.rs,tests.rs}` + one new test file — broader conformance/emit/fourslash suites were not run this session (time-boxed hourly session); `compare-to-parent.sh` is owed and left as a follow-up given the change is scoped to a single, previously-dead-code resolver branch with a full oracle-verified adjacent matrix above.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude