### PR TITLE
fix(cli): wire the invalid-meta-property grammar family (TS17012/TS18061) into parse-diagnostic suppression

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -441,12 +441,18 @@ fn is_hard_keyword_interface_name_2427_parse_diagnostic(diagnostic: &ParseDiagno
 /// our parser emits instead.
 ///
 /// Membership is load-bearing in BOTH directions. A listed code is suppressed
-/// when a real parse error exists, and — because `has_non_grammar_parse_error`
-/// is computed as the complement of this list — an *unlisted* parser-emitted
-/// grammar code counts as a real parse error and suppresses every listed
-/// sibling. So omitting one member of a `grammarError`-family silently deletes
-/// the rest of its family: TS1049/TS1051 were missing here, and any file whose
-/// setter tripped one of them lost the getter's TS1054 entirely.
+/// when a real parse error exists. And every listed code is folded into
+/// `is_non_suppressing_parse_error` by construction (that predicate delegates
+/// to this one), so a parser-emitted grammar code that is *omitted* here is
+/// classified as a suppressing "real parse error" by
+/// `has_non_grammar_parse_error` and silently deletes every listed sibling in
+/// its file. (Before the filter-trigger unification `has_non_grammar_parse_error`
+/// was the literal complement of this list; it is now computed from
+/// `is_non_suppressing_parse_error`, but the containment above keeps the hazard
+/// — and the fix — identical.) So omitting one member of a `grammarError`-family
+/// silently deletes the rest of its family: TS1049/TS1051 were missing here,
+/// and any file whose setter tripped one of them lost the getter's TS1054
+/// entirely.
 ///
 /// The accessor family (tsc's single `checkGrammarAccessor`) is therefore all
 /// in or all out: TS1049, TS1051, TS1054, TS1095. TS1052/TS1053 belong to the
@@ -723,6 +729,28 @@ const fn is_parser_grammar_code(code: u32) -> bool {
         | 18037 // 'await' expression cannot be used inside a class static block
         | 18041 // A 'return' statement cannot be used inside a class static block
         | 18054 // 'await using' statements cannot be used inside a class static block
+        // The invalid-meta-property-name family, reported from tsc's single
+        // `checkMetaProperty` (checker-side `grammarErrorOnNode`) and emitted
+        // from tsz's parser instead (`state_expressions_literals.rs`, the
+        // `new.<name>` / `import.<name>` sites, which pick between the two codes
+        // on whether a `(` follows). It is all-in-or-all-out: TS17012 fires for
+        // the non-call form (`import.foo` / `new.foo`) and TS18061 for the call
+        // form (`import.foo()`), and a file can carry both at once
+        // (`importDefer/importMetaPropertyInvalidInCall.ts`), so listing only
+        // one lets the *other* — still counted as a suppressing "real parse
+        // error" — delete the listed one. The checker's own meta-property
+        // access path (`property_access_type/helpers.rs`) deliberately does NOT
+        // emit either ("A separate grammar check is expected to emit TS17012"),
+        // so there is no double-emission — the trap that blocked TS2499/TS18016.
+        // #16279 meta-property round: oracle-confirmed against `typescript@7.0.2`
+        // — Direction A, `const y = import.foo;` reports TS17012 and
+        // `import.foo();` reports TS18061; Direction B, either construct plus an
+        // unrelated real syntax error (`let zzz: = 1;`) drops the meta-property
+        // code entirely, which tsz's parser-emitted copies did not — and,
+        // unlisted, TS17012 deleted a co-occurring listed TS1054 (`get` accessor
+        // with parameters) from the same file.
+        | 17012 // '{0}' is not a valid meta-property for keyword '{1}'. Did you mean '{2}'?
+        | 18061 // '{0}' is not a valid meta-property for keyword 'import'. Did you mean 'meta' or 'defer'?
         | 1326 // This use of 'import' is invalid. 'import()' calls can be written,
                // but they must have parentheses and cannot have type arguments.
                // tsc's checkGrammarImportCallExpression reports this from the
@@ -1951,6 +1979,10 @@ mod class_static_block_grammar_tests;
 #[cfg(test)]
 #[path = "check_utils/import_call_type_arguments_grammar_tests.rs"]
 mod import_call_type_arguments_grammar_tests;
+
+#[cfg(test)]
+#[path = "check_utils/meta_property_grammar_tests.rs"]
+mod meta_property_grammar_tests;
 
 #[cfg(test)]
 #[path = "check_utils/private_identifier_parse_error_suppression_tests.rs"]

--- a/crates/tsz-cli/src/driver/check_utils/meta_property_grammar_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/meta_property_grammar_tests.rs
@@ -1,0 +1,238 @@
+//! Unit tests for the meta-property-name slice of `is_parser_grammar_code`
+//! (#16279's general shape, meta-property audit round).
+//!
+//! tsc's single `checkMetaProperty` reports the invalid-meta-property-name
+//! family from the checker via `grammarErrorOnNode`: TS17012 ("'{0}' is not a
+//! valid meta-property for keyword '{1}'. Did you mean '{2}'?") for the
+//! non-call form (`new.foo` / `import.foo`) and TS18061 (the import-defer
+//! variant, "Did you mean 'meta' or 'defer'?") for the call form
+//! (`import.foo()`). tsz emits both from the parser instead
+//! (`crates/tsz-parser/src/parser/state_expressions_literals.rs`, which picks
+//! between them on whether a `(` follows) and **not** from the checker — the
+//! meta-property access path (`types/property_access_type/helpers.rs`)
+//! explicitly defers it ("A separate grammar check is expected to emit
+//! TS17012"), so there is no double-emission to reconcile.
+//!
+//! The family is all-in-or-all-out: a single file can carry both
+//! (`importDefer/importMetaPropertyInvalidInCall.ts` has `import.foo();`
+//! then `import.foo;`). Listing only one lets the *other* — still counted as
+//! a suppressing "real parse error" — delete the listed one, which is the
+//! exact regression this round's conformance run caught.
+//!
+//! Before this fix both were absent from `is_parser_grammar_code`, so each
+//! counted as a "real" non-grammar parse error under
+//! `has_non_grammar_parse_error` and would silently delete an unrelated
+//! *listed* sibling from the same file, while itself never being suppressed
+//! alongside a real syntax error the way tsc suppresses it.
+//!
+//! Oracle-verified against `typescript@7.0.2`:
+//! - Direction A: `const y = import.foo;` (and `function f(){ new.foo }`)
+//!   alone reports TS17012; `import.foo();` alone reports TS18061.
+//! - Direction B: either construct plus an unrelated real syntax error
+//!   (`let zzz: = 1;`) elsewhere in the file reports only the real syntax
+//!   error (TS1110) — tsc drops the meta-property code entirely, confirming
+//!   both belong in the suppression list.
+//! - Self-suppression: `class C { get x(a: number){return a;} }` next to
+//!   `const y = import.foo;` reports **both** TS1054 and TS17012 on tsc; tsz
+//!   on `main` dropped the listed TS1054.
+
+use super::*;
+
+#[test]
+fn filtered_parse_diagnostics_suppresses_ts17012_when_real_parse_error_present() {
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 40,
+            length: 3,
+            message:
+                "'foo' is not a valid meta-property for keyword 'import'. Did you mean 'meta'?"
+                    .to_string(),
+            code: 17012,
+            related: None,
+        },
+        ParseDiagnostic {
+            start: 6,
+            length: 1,
+            message: "Type expected.".to_string(),
+            code: 1110,
+            related: None,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&17012),
+        "TS17012 should be suppressed when a real parse error (TS1110) is present, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1110),
+        "TS1110 (real parse error) should survive, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_keeps_ts17012_when_alone() {
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![ParseDiagnostic {
+        start: 40,
+        length: 3,
+        message: "'foo' is not a valid meta-property for keyword 'new'. Did you mean 'target'?"
+            .to_string(),
+        code: 17012,
+        related: None,
+    }];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&17012),
+        "TS17012 should be kept when it is the only diagnostic, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_ts17012_does_not_self_suppress_listed_sibling() {
+    use tsz::parser::ParseDiagnostic;
+
+    // Before the fix, TS17012 was unlisted in `is_parser_grammar_code`, so it
+    // counted as a "real" non-grammar parse error under
+    // `has_non_grammar_parse_error` and silently deleted every *listed*
+    // sibling in the same file — here, the already-listed TS1054 (a 'get'
+    // accessor with parameters). tsc reports both.
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 20,
+            length: 1,
+            message: "A 'get' accessor cannot have parameters.".to_string(),
+            code: 1054,
+            related: None,
+        },
+        ParseDiagnostic {
+            start: 80,
+            length: 3,
+            message:
+                "'foo' is not a valid meta-property for keyword 'import'. Did you mean 'meta'?"
+                    .to_string(),
+            code: 17012,
+            related: None,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&1054),
+        "TS1054 must not be self-suppressed by unlisted TS17012, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&17012),
+        "TS17012 should survive when no real parse error is present, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_suppresses_ts18061_when_real_parse_error_present() {
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 40,
+            length: 3,
+            message:
+                "'foo' is not a valid meta-property for keyword 'import'. Did you mean 'meta' or 'defer'?"
+                    .to_string(),
+            code: 18061,
+            related: None,
+        },
+        ParseDiagnostic {
+            start: 6,
+            length: 1,
+            message: "Type expected.".to_string(),
+            code: 1110,
+            related: None,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&18061),
+        "TS18061 should be suppressed when a real parse error (TS1110) is present, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1110),
+        "TS1110 (real parse error) should survive, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_meta_property_family_both_survive_together() {
+    use tsz::parser::ParseDiagnostic;
+
+    // The `importDefer/importMetaPropertyInvalidInCall.ts` shape: `import.foo();`
+    // (TS18061) and `import.foo;` (TS17012) in one file, no real parse error.
+    // tsc keeps both; listing only one member of the family let the unlisted
+    // one delete the listed one. Both must survive.
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 0,
+            length: 3,
+            message:
+                "'foo' is not a valid meta-property for keyword 'import'. Did you mean 'meta' or 'defer'?"
+                    .to_string(),
+            code: 18061,
+            related: None,
+        },
+        ParseDiagnostic {
+            start: 20,
+            length: 3,
+            message:
+                "'foo' is not a valid meta-property for keyword 'import'. Did you mean 'meta'?"
+                    .to_string(),
+            code: 17012,
+            related: None,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&17012) && codes.contains(&18061),
+        "both meta-property family codes must survive when no real parse error is present, got: {codes:?}"
+    );
+}
+
+#[test]
+fn is_parser_grammar_code_accepts_meta_property_family() {
+    assert!(is_parser_grammar_code(17012));
+    assert!(is_parser_grammar_code(18061));
+}
+
+#[test]
+fn is_non_suppressing_parse_error_folds_in_ts17012() {
+    // Containment invariant: every code `is_parser_grammar_code` accepts must
+    // be non-suppressing, or it would delete its own listed siblings. TS17012
+    // is now covered by construction (the predicate delegates to
+    // `is_parser_grammar_code`).
+    assert!(is_non_suppressing_parse_error(17012));
+}
+
+#[test]
+fn ts1437_and_ts6188_stay_unlisted_genuine_parser_diagnostics() {
+    // Rejected-with-evidence this round: both survive Direction B on
+    // `typescript@7.0.2` (kept alongside an unrelated real syntax error), so
+    // they are genuine parser diagnostics in tsc too and must NOT be treated
+    // as checker-suppressible grammar codes.
+    assert!(
+        !is_parser_grammar_code(1437),
+        "TS1437 (Namespace must be given a name) is a genuine parser diagnostic"
+    );
+    assert!(
+        !is_parser_grammar_code(6188),
+        "TS6188 (Numeric separators are not allowed here) is a genuine parser diagnostic"
+    );
+}


### PR DESCRIPTION
Wires the invalid-meta-property-name grammar family — **TS17012** (`'{0}' is not a valid meta-property for keyword '{1}'. Did you mean '{2}'?`) and its import-defer sibling **TS18061** (`… Did you mean 'meta' or 'defer'?`) — into `is_parser_grammar_code`, the parse-diagnostic suppression list in `crates/tsz-cli/src/driver/check_utils.rs`. Another audit round of #16279's "self-suppressing set" shape.

**Structural rule:** when a file contains an invalid meta-property (`new.foo`, `import.foo`, `import.foo()`), `tsc` reports the name error from its checker via `checkMetaProperty` → `grammarErrorOnNode`, so it is not in `sourceFile.parseDiagnostics` and does not suppress — nor is it suppressed by — other checker grammar checks; only a genuine parse failure suppresses it. tsz emits both codes from the parser (`state_expressions_literals.rs`, choosing between them on whether a `(` follows) and never from the checker (`property_access_type/helpers.rs:80` explicitly defers: *"A separate grammar check is expected to emit TS17012"*), so with them unlisted the CLI's `has_non_grammar_parse_error` gate treated each as a suppressing "real parse error." The fix routes them through the same `hasParseDiagnostics`-equivalent suppression as the rest of the family — owner layer: the CLI driver's parse-diagnostic filter; no checker/parser change, no double-emission.

Two bugs, both now matching `tsc`:
- **Sibling deletion:** `class C { get x(a: number){return a;} }` next to `const y = import.foo;` — `tsc` reports both TS1054 and TS17012; tsz on `main` dropped the listed TS1054.
- **Over-report under a real parse error:** `const y = import.foo;` plus `let zzz: = 1;` — `tsc` drops TS17012 and reports only TS1110; tsz on `main` kept TS17012.

The family is all-in-or-all-out: `importDefer/importMetaPropertyInvalidInCall.ts` carries both codes at once (`import.foo();` → TS18061, `import.foo;` → TS17012). Adding only TS17012 split the family and let TS18061 delete it — **the conformance run caught exactly this**, and adding TS18061 restores parity.

Also corrects the now-stale doc header on `is_parser_grammar_code`, which still claimed `has_non_grammar_parse_error` is "computed as the complement of this list" — it is now derived from `is_non_suppressing_parse_error` (which folds in this list by construction). The hazard and fix are unchanged; the stated mechanism was misleading for the next audit slice.

Rejected-with-evidence this round (survive Direction B on `typescript@7.0.2` — kept alongside an unrelated real syntax error, so genuine parser diagnostics in `tsc` too, must stay unlisted): **TS1437** (`Namespace must be given a name`), **TS6188** (`Numeric separators are not allowed here`). Pinned by a regression-guard test.

## Goal
Goal: hold

## Verification
- Oracle `typescript@7.0.2` (`--noEmit --strict --pretty false`):
  - Direction A — `const y = import.foo;` → TS17012; `import.foo();` → TS18061.
  - Direction B — either + `let zzz: = 1;` → only TS1110 (both meta-property codes dropped by `tsc`).
- End-to-end on the release `tsz` binary (before → after):
  - `importDefer/importMetaPropertyInvalidInCall.ts`: `[TS18061]` (split-family regression) → `[TS17012, TS18061]` (matches `tsc`).
  - sibling-deletion witness: `[TS17012]` → `[TS1054, TS17012]`.
  - Direction B witness: `[TS1110, TS17012]` → `[TS1110]`.
- Unit: 8 new tests in `crates/tsz-cli/src/driver/check_utils/meta_property_grammar_tests.rs`; full `check_utils` module green, 0 regressions.
- Conformance: all 3 corpus files touching TS17012/TS18061 (`misspelledNewMetaProperty.ts`, `es2019/importMeta/importMeta.ts`, `importDefer/importMetaPropertyInvalidInCall.ts`) pass; the previously-regressed row moves fail→pass; **0 net regressions** (blast radius is exactly those 3 files — the only corpus rows with these codes in the oracle cache).
- `cargo clippy -p tsz-cli --all-targets`: clean (pre-commit hook: Clippy + Architecture guard + Local verification passed).
- `arch-size`: `check_utils.rs` at 1989 lines (< 2000).
- Emit unaffected by construction: the emitter never consults `filtered_parse_diagnostics`; this change alters only which diagnostics surface, not emitted JS/DTS.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLo5CGQi4hjvbYrj2Cvosg)_