### PR TITLE
fix(emit): CJS bare re-export of an import binding follows its own require()

### DIFF
--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -777,6 +777,20 @@ pub struct Printer<'a> {
     /// is what distinguishes the two at the re-export site.
     pub(crate) commonjs_default_import_local_names: FxHashSet<String>,
 
+    /// Bare `export { x }` (no `from`) re-export names of an import-bound local,
+    /// keyed by the local name, populated once per file before statements are
+    /// printed. tsc emits these bindings immediately after the import's own
+    /// `require(...)` line rather than at the `export { }` statement's source
+    /// position; `emit_import_declaration_commonjs` drains this map as it emits
+    /// each import's `require(...)`, and `emit_export_declaration_commonjs` skips
+    /// any name already recorded in `commonjs_import_reexports_emitted`.
+    pub(crate) pending_bare_import_reexports: FxHashMap<String, Vec<String>>,
+
+    /// Export names already emitted at their import's `require(...)` site via
+    /// `pending_bare_import_reexports`, so the `export { }` statement's own
+    /// handler does not emit them a second time.
+    pub(crate) commonjs_import_reexports_emitted: FxHashSet<String>,
+
     /// Module expressions for wrapped AMD re-export declarations, keyed by node start.
     /// AMD binds dependencies as factory parameters instead of body-local `require()` calls.
     pub(crate) wrapped_export_module_substitutions: FxHashMap<u32, String>,

--- a/crates/tsz-emitter/src/emitter/core_setup.rs
+++ b/crates/tsz-emitter/src/emitter/core_setup.rs
@@ -369,6 +369,8 @@ impl<'a> Printer<'a> {
             hoisted_for_of_temps: Vec::new(),
             commonjs_named_import_substitutions: FxHashMap::default(),
             commonjs_default_import_local_names: FxHashSet::default(),
+            pending_bare_import_reexports: FxHashMap::default(),
+            commonjs_import_reexports_emitted: FxHashSet::default(),
             wrapped_export_module_substitutions: FxHashMap::default(),
             reserved_iterator_return_temps: FxHashMap::default(),
             iterator_for_of_depth: 0,

--- a/crates/tsz-emitter/src/emitter/module_emission/core/module_analysis.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/module_analysis.rs
@@ -722,4 +722,63 @@ impl<'a> Printer<'a> {
     pub(in crate::emitter) fn source_has_dynamic_import_call(&self, statements: &NodeList) -> bool {
         crate::core::module_facts::source_has_dynamic_import_call(self.arena, statements)
     }
+
+    /// Collect every bare `export { local [as exportName] }` (no `from`) whose
+    /// exported name binds an import-bound local, keyed by local name in
+    /// specifier source order. tsc's CommonJS transform emits these bindings
+    /// right after the import's own `require(...)` line, not at the `export { }`
+    /// statement's position, so `emit_import_declaration_commonjs` drains this
+    /// map at each import site instead of leaving it for the export statement.
+    /// Whether a given local actually turns out to be import-bound (vs. a plain
+    /// local declaration) is decided later, when the import populates
+    /// `commonjs_named_import_substitutions` — this pass only records candidates.
+    pub(in crate::emitter) fn collect_bare_reexported_import_locals(
+        &self,
+        statements: &NodeList,
+    ) -> rustc_hash::FxHashMap<String, Vec<String>> {
+        let mut result: rustc_hash::FxHashMap<String, Vec<String>> =
+            rustc_hash::FxHashMap::default();
+        for &stmt_idx in &statements.nodes {
+            let Some(stmt_node) = self.arena.get(stmt_idx) else {
+                continue;
+            };
+            if stmt_node.kind != syntax_kind_ext::EXPORT_DECLARATION {
+                continue;
+            }
+            let Some(export) = self.arena.get_export_decl(stmt_node) else {
+                continue;
+            };
+            if export.is_type_only || export.module_specifier.is_some() {
+                continue;
+            }
+            let Some(clause_node) = self.arena.get(export.export_clause) else {
+                continue;
+            };
+            if clause_node.kind != syntax_kind_ext::NAMED_EXPORTS {
+                continue;
+            }
+            let Some(named_exports) = self.arena.get_named_imports(clause_node) else {
+                continue;
+            };
+            for spec_idx in self.collect_local_export_value_specifiers(&named_exports.elements) {
+                let Some(spec_node) = self.arena.get(spec_idx) else {
+                    continue;
+                };
+                let Some(spec) = self.arena.get_specifier(spec_node) else {
+                    continue;
+                };
+                let Some(export_name) = self.get_specifier_name_text(spec.name) else {
+                    continue;
+                };
+                let local_name = if spec.property_name.is_some() {
+                    self.get_specifier_name_text(spec.property_name)
+                        .unwrap_or_else(|| export_name.clone())
+                } else {
+                    export_name.clone()
+                };
+                result.entry(local_name).or_default().push(export_name);
+            }
+        }
+        result
+    }
 }

--- a/crates/tsz-emitter/src/emitter/module_emission/core/tests/cjs_named_import_reexport_tests.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/tests/cjs_named_import_reexport_tests.rs
@@ -292,6 +292,112 @@ export { payload as renamed };
     );
 }
 
+// ── Position: the re-export binding follows its own import's require() ─────
+//
+// tsc's CommonJS transform emits a bare `export { x }` re-export of an import
+// binding immediately after that import's own `require(...)` line, not at the
+// `export { }` statement's source position. #16924.
+
+/// A statement (`export const a = 1;`) sitting between the import and the
+/// bare re-export must not push the getter to the tail — it stays right after
+/// the `require(...)` it belongs to.
+#[test]
+fn import_reexport_getter_follows_its_own_require_not_trailing_export_clause() {
+    let source = r#"import { readFile } from "fs";
+export const a = 1;
+export function f() { return a; }
+export { readFile };
+"#;
+    let output = emit_commonjs(source);
+    let require_pos = output
+        .find("require(\"fs\")")
+        .expect("require(\"fs\") should be emitted");
+    let getter_pos = output
+        .find(r#"Object.defineProperty(exports, "readFile""#)
+        .expect("readFile getter should be emitted");
+    let a_pos = output
+        .find("exports.a = 1;")
+        .expect("exports.a assignment should be emitted");
+    assert!(
+        getter_pos < a_pos,
+        "readFile getter must come right after its own require(), before the \
+         unrelated `exports.a = 1;` that sits between the import and the \
+         export clause in source order.\nOutput:\n{output}"
+    );
+    assert!(
+        require_pos < getter_pos,
+        "readFile getter must come after its own require() line.\nOutput:\n{output}"
+    );
+}
+
+/// Two imports, each re-exported: each binding follows its OWN `require()`,
+/// not one trailing block after both requires.
+#[test]
+fn two_import_reexports_each_follow_their_own_require() {
+    let source = r#"import { x1 as x } from "./a";
+import { y1 as y } from "./b";
+export { x, y };
+"#;
+    let output = emit_commonjs(source);
+    let require_a = output.find("require(\"./a\")").unwrap();
+    let require_b = output.find("require(\"./b\")").unwrap();
+    let getter_x = output
+        .find(r#"Object.defineProperty(exports, "x""#)
+        .unwrap();
+    let getter_y = output
+        .find(r#"Object.defineProperty(exports, "y""#)
+        .unwrap();
+    assert!(
+        require_a < getter_x && getter_x < require_b,
+        "x's getter must land between a's require() and b's require(), not \
+         after both.\nOutput:\n{output}"
+    );
+    assert!(
+        require_b < getter_y,
+        "y's getter must come after b's require().\nOutput:\n{output}"
+    );
+}
+
+/// A default-import re-export (plain assignment, not a getter) also follows
+/// its own `require()`, matching the getter-form rule above.
+#[test]
+fn default_import_reexport_assignment_follows_its_own_require() {
+    let source = r#"import data from "./mod";
+export const a = 1;
+export { data };
+"#;
+    let output = emit_commonjs(source);
+    let require_pos = output.find("require(\"./mod\")").unwrap();
+    let assign_pos = output.find("exports.data = mod_1.default;").unwrap();
+    let a_pos = output.find("exports.a = 1;").unwrap();
+    assert!(
+        require_pos < assign_pos && assign_pos < a_pos,
+        "data's re-export assignment must come right after its own require(), \
+         before the unrelated `exports.a = 1;`.\nOutput:\n{output}"
+    );
+}
+
+/// A local (non-import) re-export in the same clause as an import re-export
+/// is unaffected: it still emits at the `export { }` statement's own position.
+#[test]
+fn local_reexport_still_emits_at_export_clause_position_alongside_import_reexport() {
+    let source = r#"import { v1 as v } from "./mod";
+var local = 2;
+export { v, local };
+"#;
+    let output = emit_commonjs(source);
+    let require_pos = output.find("require(\"./mod\")").unwrap();
+    let getter_pos = output
+        .find(r#"Object.defineProperty(exports, "v""#)
+        .unwrap();
+    let local_pos = output.find("exports.local = local;").unwrap();
+    assert!(
+        require_pos < getter_pos && getter_pos < local_pos,
+        "v's getter follows its own require(); local's static assignment \
+         stays at the export clause's own position, after it.\nOutput:\n{output}"
+    );
+}
+
 /// A combined `import def, { a, b as bb }` re-exported as `export { def, a, bb as cc }`
 /// mixes both forms: the default binding `def` assigns, while the named
 /// specifiers `a`/`cc` keep their live-binding getters.

--- a/crates/tsz-emitter/src/emitter/module_emission/exports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/exports.rs
@@ -1306,6 +1306,15 @@ impl<'a> Printer<'a> {
                                     .get(&local_name)
                                     .cloned()
                                 {
+                                    // Already emitted right after this import's own
+                                    // `require(...)` line (tsc parity) — do not
+                                    // duplicate it here at the `export { }` position.
+                                    if self
+                                        .commonjs_import_reexports_emitted
+                                        .contains(&export_name)
+                                    {
+                                        continue;
+                                    }
                                     if self
                                         .commonjs_default_import_local_names
                                         .contains(&local_name)

--- a/crates/tsz-emitter/src/emitter/module_emission/imports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/imports.rs
@@ -955,7 +955,8 @@ impl<'a> Printer<'a> {
         // This must come after the namespace-only check to avoid wasting
         // counter values on imports that use their own namespace name.
         let module_var = self.next_commonjs_module_var(&module_spec);
-        self.register_commonjs_named_import_substitutions(node, &module_var);
+        let import_local_names =
+            self.register_commonjs_named_import_substitutions(node, &module_var);
         let has_runtime_named_bindings =
             self.import_clause_has_runtime_named_bindings(node, clause);
         let is_default_only_ast = clause.name.is_some() && !has_runtime_named_bindings;
@@ -1007,6 +1008,7 @@ impl<'a> Printer<'a> {
                 self.write("\");");
             }
             self.write_line();
+            self.emit_pending_import_reexports(&import_local_names);
             return;
         }
 
@@ -1034,17 +1036,62 @@ impl<'a> Printer<'a> {
             self.write("\");");
         }
         self.write_line();
+        self.emit_pending_import_reexports(&import_local_names);
     }
 
-    fn register_commonjs_named_import_substitutions(&mut self, node: &Node, module_var: &str) {
+    /// Emit any bare `export { local }` re-export bindings queued for this
+    /// import's local names (see `pending_bare_import_reexports`), immediately
+    /// after the import's own `require(...)` line — matching tsc's CommonJS
+    /// transform. Each emitted export name is recorded so the `export { }`
+    /// statement's own handler skips re-emitting it.
+    fn emit_pending_import_reexports(&mut self, local_names: &[String]) {
+        for local_name in local_names {
+            let Some(export_names) = self.pending_bare_import_reexports.remove(local_name) else {
+                continue;
+            };
+            let Some(substitution) = self
+                .commonjs_named_import_substitutions
+                .get(local_name)
+                .cloned()
+            else {
+                continue;
+            };
+            let is_default_binding = self
+                .commonjs_default_import_local_names
+                .contains(local_name);
+            for export_name in export_names {
+                if is_default_binding {
+                    self.write_export_property_access(&export_name);
+                    self.write(" = ");
+                    self.write(&substitution);
+                    self.write(";");
+                } else {
+                    self.write("Object.defineProperty(exports, \"");
+                    self.write(&export_name);
+                    self.write("\", { enumerable: true, get: function () { return ");
+                    self.write(&substitution);
+                    self.write("; } });");
+                }
+                self.write_line();
+                self.commonjs_import_reexports_emitted.insert(export_name);
+            }
+        }
+    }
+
+    fn register_commonjs_named_import_substitutions(
+        &mut self,
+        node: &Node,
+        module_var: &str,
+    ) -> Vec<String> {
+        let mut local_names = Vec::new();
         let Some(import) = self.arena.get_import_decl(node) else {
-            return;
+            return local_names;
         };
         let Some(clause_node) = self.arena.get(import.import_clause) else {
-            return;
+            return local_names;
         };
         let Some(clause) = self.arena.get_import_clause(clause_node) else {
-            return;
+            return local_names;
         };
         if clause.name.is_some()
             && let Some(default_name_node) = self.arena.get(clause.name)
@@ -1059,20 +1106,21 @@ impl<'a> Printer<'a> {
             // rather than a named-specifier live-binding getter.
             self.commonjs_default_import_local_names
                 .insert(default_ident.escaped_text.to_string());
+            local_names.push(default_ident.escaped_text.to_string());
         }
         if !clause.named_bindings.is_some() {
-            return;
+            return local_names;
         }
         let Some(bindings_node) = self.arena.get(clause.named_bindings) else {
-            return;
+            return local_names;
         };
         let Some(named_imports) = self.arena.get_named_imports(bindings_node) else {
-            return;
+            return local_names;
         };
 
         // Skip namespace imports (`import * as ns from "x"`).
         if named_imports.name.is_some() && named_imports.elements.nodes.is_empty() {
-            return;
+            return local_names;
         }
 
         let mut value_specs = self.collect_value_specifiers(&named_imports.elements);
@@ -1127,7 +1175,9 @@ impl<'a> Printer<'a> {
                 };
             self.commonjs_named_import_substitutions
                 .insert(local_ident.escaped_text.to_string(), substitution);
+            local_names.push(local_ident.escaped_text.to_string());
         }
+        local_names
     }
 
     fn import_clause_has_runtime_named_bindings(

--- a/crates/tsz-emitter/src/emitter/source_file/emit.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/emit.rs
@@ -783,6 +783,13 @@ impl<'a> Printer<'a> {
             self.cjs_destr_hoist_line = self.writer.current_line();
             self.cjs_destructuring_export_temps.clear();
 
+            // Bare `export { x }` re-exports of import-bound locals emit at their
+            // import's `require(...)` site, not the `export { }` statement's own
+            // position (tsc parity). Drained by `emit_import_declaration_commonjs`.
+            self.pending_bare_import_reexports =
+                self.collect_bare_reexported_import_locals(&source.statements);
+            self.commonjs_import_reexports_emitted.clear();
+
             // Emit __esModule if this is an ES module.
             // Also emit it when JSX auto-import synthesizes a require() — tsc
             // considers the synthesized import as ESM syntax that triggers __esModule.


### PR DESCRIPTION
Structural rule: when a bare `export { x }` (no `from`) re-exports a name `x` that is bound by an import, tsc's CommonJS transform emits the re-export binding immediately after that import's own `require(...)` line — not at the `export { }` statement's own source position. tsz emitted it at the `export { }` position instead, so any statement sitting between the import and the export pushed the re-export to the wrong place in the output.

Owner layer: emitter (`crates/tsz-emitter`, CommonJS module emission). Display/emit-only parity gap; no semantic/diagnostic change.

**Fix.** A new pre-pass (`Printer::collect_bare_reexported_import_locals`, `crates/tsz-emitter/src/emitter/module_emission/core/module_analysis.rs`) scans the file's top-level bare `export { }` clauses once per CommonJS file and records `local_name -> [export_name, ...]` candidates into `pending_bare_import_reexports`. `emit_import_declaration_commonjs` (`imports.rs`) drains this map for each import's own local names right after writing its `require(...)` line — emitting an `Object.defineProperty` getter for a named-import-specifier local, or a plain `exports.x = mod.default;` assignment for a default-import-clause local, matching the existing getter/assignment distinction. Each emitted export name is recorded in `commonjs_import_reexports_emitted`, and the `export { }` statement's own handler (`exports.rs`) now skips any name already emitted at its import site instead of emitting it a second time at the wrong position.

Namespace imports (`import * as ns`) are untouched — they were never in `commonjs_named_import_substitutions` and already re-export correctly at the export-clause position (per the issue's own matrix).

**Adjacent-case matrix** (new tests in `crates/tsz-emitter/src/emitter/module_emission/core/tests/cjs_named_import_reexport_tests.rs`):
- A statement between the import and the bare re-export no longer pushes the getter to the tail (`import_reexport_getter_follows_its_own_require_not_trailing_export_clause`).
- Two separate imports, each re-exported: each binding follows its own `require()`, not one trailing block after both (`two_import_reexports_each_follow_their_own_require`).
- Default-import re-export (plain assignment form) also follows its own `require()` (`default_import_reexport_assignment_follows_its_own_require`).
- A local (non-import) re-export sharing a clause with an import re-export still emits at the `export { }` statement's own position, unaffected (`local_reexport_still_emits_at_export_clause_position_alongside_import_reexport`).
- All 11 pre-existing tests in the same file (getter vs. assignment content, type-only elision, string-literal names, `default`-named specifier boundary) still pass unmodified — this PR changes *position*, not *content*.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-emitter --lib cjs_named_import_reexport` → 15/15 passed (4 new, 11 pre-existing unchanged).
- `cargo test -p tsz-emitter --lib` → 3995/3995 passed, no regression.
- `cargo clippy --profile ci-lint -p tsz-emitter --all-targets -- -D warnings` → clean.
- `cargo fmt --check -p tsz-emitter` → clean.
- `python3 scripts/arch/arch_guard.py` → `Architecture guardrails passed.`
- Manual oracle-shape check: built `dist-fast` `tsz` CLI and compiled the issue's exact repro (`import { readFile } from "fs"; export const a = 1; export function f() { return a; } export { readFile };`) — output now reads:
  ```js
  const fs_1 = require("fs");
  Object.defineProperty(exports, "readFile", { enumerable: true, get: function () { return fs_1.readFile; } });
  exports.a = 1;
  function f() { return exports.a; }
  ```
  matching the issue's pinned `typescript@7.0.2` oracle output byte-for-byte (getter right after `require("fs")`, before `exports.a`).
- `./scripts/emit/run.sh` baseline suite: started, but this container has no prebuilt emit-runner JS and the first-time release build did not finish within this session's window — count owed, not skipped. Files touched are emitter source + one emitter unit-test file only (no checker/solver/parser path), so conformance and fourslash are unaffected by this change; only the emit baseline count is open.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_019dQTE7YeFeZDy9n5cwJzd9)_