### PR TITLE
fix(resolver): enforce maxNodeModuleJsDepth for the untyped-JS TS7016 gate

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -203,7 +203,7 @@ pub(super) fn collect_diagnostics(
     cache: Option<&mut CompilationCache>,
     type_cache_output: &std::sync::Mutex<FxHashMap<PathBuf, TypeCache>>,
 ) -> CollectDiagnosticsResult {
-    collect_diagnostics_with_source_resolutions(input, cache, type_cache_output, None, None)
+    collect_diagnostics_with_source_resolutions(input, cache, type_cache_output, None, None, None)
 }
 
 pub(super) fn collect_diagnostics_with_source_resolutions(
@@ -214,6 +214,7 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
         &FxHashMap<SourceModuleResolutionKey, SourceModuleResolution>,
     >,
     source_module_resolution_misses: Option<&FxHashSet<SourceModuleResolutionKey>>,
+    depth_skipped_js: Option<&FxHashSet<PathBuf>>,
 ) -> CollectDiagnosticsResult {
     let &CollectDiagnosticsInput {
         program,
@@ -327,6 +328,7 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
         base_dir,
         source_module_resolutions,
         source_module_resolution_misses,
+        depth_skipped_js,
         program_file_index: &program_file_index,
         program_paths: &program_paths,
         package_redirects: &package_redirects,

--- a/crates/tsz-cli/src/driver/core_diagnostics.rs
+++ b/crates/tsz-cli/src/driver/core_diagnostics.rs
@@ -734,6 +734,7 @@ fn compile_inner_impl(
         module_resolution_misses,
         type_reference_errors,
         resolution_mode_errors,
+        depth_skipped_js,
     } = {
         read_source_files(
             &file_paths,
@@ -1149,6 +1150,7 @@ fn compile_inner_impl(
         &parallel_type_caches,
         Some(&module_resolutions),
         Some(&module_resolution_misses),
+        Some(&depth_skipped_js),
     );
     let mut diagnostics: Vec<Diagnostic> = collected.diagnostics;
     let check_duration = collect_diagnostics_start.elapsed();

--- a/crates/tsz-cli/src/driver/source_resolution_setup.rs
+++ b/crates/tsz-cli/src/driver/source_resolution_setup.rs
@@ -442,37 +442,32 @@ pub(super) fn prepare_source_resolution_setup(
                     );
                 }
 
-                // tsc reports TS7016 ("Could not find a declaration file for
-                // module ...") for a JavaScript module only when the resolved
-                // `.js` file is *not* part of the program: its checker probes
-                // `host.getSourceFile(resolvedFileName)` and falls through to the
-                // diagnostic only when that returns nothing. Once the file is
-                // admitted, the import binds to the file's inferred JS type and
-                // no diagnostic is produced.
-                //
-                // A `node_modules`-hosted JS file is admitted when it is an
-                // explicit program root, or when it is reached through resolution
-                // within `maxNodeModuleJsDepth` (default 0). The source-discovery
-                // BFS is the authority on that decision — it records every JS file
-                // it depth-gated out in `depth_skipped_js`. The resolver, running
-                // before the program is finalized, cannot see admission and
-                // conservatively flags every external untyped-JS `require()` with
-                // TS7016. Reconcile it here against the BFS decision: if the
-                // resolved JS file was *not* depth-skipped, it is a real program
-                // member, so clear the error and let the binding below wire it —
-                // exactly as tsc does. Files the BFS excluded (beyond depth), and
-                // untyped-JS results that carry no resolved path (`allowJs` off),
-                // keep the diagnostic.
+                // Reconcile the resolver's untyped-JS TS7016 against real program
+                // admission (default 0), mirroring tsc's checker-side
+                // `host.getSourceFile(resolvedFileName)` gate — see the
+                // `depth_skipped_js` field docs. The resolver runs before the
+                // program is finalized and conservatively flags every external
+                // untyped-JS `require()` with TS7016; a resolved `.js` file the
+                // source-discovery BFS did *not* depth-skip is a genuine program
+                // member, so drop the diagnostic and let the binding below wire it
+                // to the file's inferred JS type. Files excluded beyond depth, and
+                // untyped-JS results with no resolved path (`allowJs` off), keep
+                // the diagnostic. `resolved_canonical` is memoized so the
+                // realpath/symlink walk in `normalize_resolved_path` runs at most
+                // once per specifier (the membership check below reuses it).
+                let mut resolved_canonical: Option<PathBuf> = None;
                 if outcome
                     .error
                     .as_ref()
                     .is_some_and(|error| error.code == 7016)
                     && let Some(ref resolved_path) = outcome.resolved_path
-                    && depth_skipped_js.is_some_and(|skipped| {
-                        !skipped.contains(&normalize_resolved_path(resolved_path, options))
-                    })
+                    && let Some(skipped) = depth_skipped_js
                 {
-                    outcome.error = None;
+                    let canonical = normalize_resolved_path(resolved_path, options);
+                    if !skipped.contains(&canonical) {
+                        outcome.error = None;
+                    }
+                    resolved_canonical = Some(canonical);
                 }
 
                 // Map resolved path to file index.
@@ -483,7 +478,8 @@ pub(super) fn prepare_source_resolution_setup(
                 if outcome.error.is_none() {
                     if let Some(ref resolved_path) = outcome.resolved_path {
                         resolved_module_specifiers.insert((file_idx, specifier.clone()));
-                        let canonical = normalize_resolved_path(resolved_path, options);
+                        let canonical = resolved_canonical
+                            .unwrap_or_else(|| normalize_resolved_path(resolved_path, options));
                         // Apply duplicate package redirect
                         let canonical = if should_apply_duplicate_package_redirect(file_path) {
                             package_redirects

--- a/crates/tsz-cli/src/driver/source_resolution_setup.rs
+++ b/crates/tsz-cli/src/driver/source_resolution_setup.rs
@@ -37,6 +37,13 @@ pub(super) struct SourceResolutionSetupInput<'a> {
     pub(super) source_module_resolutions:
         Option<&'a FxHashMap<SourceModuleResolutionKey, SourceModuleResolution>>,
     pub(super) source_module_resolution_misses: Option<&'a FxHashSet<SourceModuleResolutionKey>>,
+    /// Canonical paths of JS files the source-discovery BFS depth-gated out of
+    /// the program under `maxNodeModuleJsDepth` (see
+    /// `sources::should_skip_js_in_node_modules`). Used to reconcile the
+    /// resolver's conservative untyped-JS TS7016 against real program
+    /// admission. `None` when the caller has no BFS authority (test-only
+    /// entry point), in which case the resolver's decision stands unchanged.
+    pub(super) depth_skipped_js: Option<&'a FxHashSet<PathBuf>>,
     pub(super) program_file_index: &'a ProgramFileIndex,
     pub(super) program_paths: &'a FxHashSet<PathBuf>,
     pub(super) package_redirects: &'a FxHashMap<PathBuf, PathBuf>,
@@ -93,6 +100,7 @@ pub(super) fn prepare_source_resolution_setup(
         base_dir,
         source_module_resolutions,
         source_module_resolution_misses,
+        depth_skipped_js,
         program_file_index,
         program_paths,
         package_redirects,
@@ -432,6 +440,39 @@ pub(super) fn prepare_source_resolution_setup(
                         outcome.is_resolved,
                         outcome.error,
                     );
+                }
+
+                // tsc reports TS7016 ("Could not find a declaration file for
+                // module ...") for a JavaScript module only when the resolved
+                // `.js` file is *not* part of the program: its checker probes
+                // `host.getSourceFile(resolvedFileName)` and falls through to the
+                // diagnostic only when that returns nothing. Once the file is
+                // admitted, the import binds to the file's inferred JS type and
+                // no diagnostic is produced.
+                //
+                // A `node_modules`-hosted JS file is admitted when it is an
+                // explicit program root, or when it is reached through resolution
+                // within `maxNodeModuleJsDepth` (default 0). The source-discovery
+                // BFS is the authority on that decision — it records every JS file
+                // it depth-gated out in `depth_skipped_js`. The resolver, running
+                // before the program is finalized, cannot see admission and
+                // conservatively flags every external untyped-JS `require()` with
+                // TS7016. Reconcile it here against the BFS decision: if the
+                // resolved JS file was *not* depth-skipped, it is a real program
+                // member, so clear the error and let the binding below wire it —
+                // exactly as tsc does. Files the BFS excluded (beyond depth), and
+                // untyped-JS results that carry no resolved path (`allowJs` off),
+                // keep the diagnostic.
+                if outcome
+                    .error
+                    .as_ref()
+                    .is_some_and(|error| error.code == 7016)
+                    && let Some(ref resolved_path) = outcome.resolved_path
+                    && depth_skipped_js.is_some_and(|skipped| {
+                        !skipped.contains(&normalize_resolved_path(resolved_path, options))
+                    })
+                {
+                    outcome.error = None;
                 }
 
                 // Map resolved path to file index.

--- a/crates/tsz-cli/src/driver/sources.rs
+++ b/crates/tsz-cli/src/driver/sources.rs
@@ -274,11 +274,10 @@ pub(super) struct SourceReadResult {
     /// Tuples of (`file_path`, `byte_offset`, `span_length`).
     pub(super) resolution_mode_errors: Vec<(PathBuf, usize, usize)>,
     /// Canonical paths of `node_modules`-hosted JS files the BFS depth-gated out
-    /// of the program under `maxNodeModuleJsDepth` (i.e. `should_skip_js_in_node_modules`
-    /// returned true and the file was not an explicit program root). Consumers
-    /// reconcile the resolver's conservative untyped-JS TS7016 against this set:
-    /// a resolved JS file absent from it is a genuine program member, so the
-    /// diagnostic is dropped and the import binds to the file's JS type.
+    /// of the program under `maxNodeModuleJsDepth` — `should_skip_js_in_node_modules`
+    /// returned true and the file was not an explicit program root. The
+    /// resolution-setup pass consults this to reconcile untyped-JS TS7016 against
+    /// program admission (see `SourceResolutionSetupInput::depth_skipped_js`).
     pub(super) depth_skipped_js: FxHashSet<PathBuf>,
 }
 
@@ -831,8 +830,15 @@ pub(super) fn read_source_files(
                     continue;
                 }
                 BatchAction::SkipJs => {
-                    // Record the depth-gated JS file so the diagnostic pass can
-                    // tell it apart from a genuinely admitted program member.
+                    // Record the depth-gated JS file in a side set so the
+                    // diagnostic pass can tell it apart from a genuinely admitted
+                    // member. tsc would leave the file out of the program
+                    // entirely; tsz still inserts an empty stub below because
+                    // dropping it would change the discovery-order-based
+                    // `SymbolId` assignment (see `SourceReadResult::dependencies`)
+                    // and risk conformance/reproducibility drift. The stub makes
+                    // program membership alone ambiguous, which is why membership
+                    // consumers consult this set rather than `program_file_index`.
                     depth_skipped_js.insert(path.clone());
                     sources.insert(path.clone(), (None, false, false));
                     continue;

--- a/crates/tsz-cli/src/driver/sources.rs
+++ b/crates/tsz-cli/src/driver/sources.rs
@@ -273,6 +273,13 @@ pub(super) struct SourceReadResult {
     /// TS1453: Invalid `resolution-mode` values in `/// <reference types="..." />` directives.
     /// Tuples of (`file_path`, `byte_offset`, `span_length`).
     pub(super) resolution_mode_errors: Vec<(PathBuf, usize, usize)>,
+    /// Canonical paths of `node_modules`-hosted JS files the BFS depth-gated out
+    /// of the program under `maxNodeModuleJsDepth` (i.e. `should_skip_js_in_node_modules`
+    /// returned true and the file was not an explicit program root). Consumers
+    /// reconcile the resolver's conservative untyped-JS TS7016 against this set:
+    /// a resolved JS file absent from it is a genuine program member, so the
+    /// diagnostic is dropped and the import binds to the file's JS type.
+    pub(super) depth_skipped_js: FxHashSet<PathBuf>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -680,6 +687,7 @@ pub(super) fn read_source_files(
         FxHashMap::default();
     let mut module_resolution_misses: FxHashSet<SourceModuleResolutionKey> = FxHashSet::default();
     let mut seen = FxHashSet::default();
+    let mut depth_skipped_js: FxHashSet<PathBuf> = FxHashSet::default();
     let mut discovery_order: FxHashMap<PathBuf, usize> = FxHashMap::default();
     let mut next_discovery_order = 0usize;
     let mut pending = VecDeque::new();
@@ -707,9 +715,17 @@ pub(super) fn read_source_files(
         canonical
     };
 
+    // Explicit program roots (the `files`/`include` set tsc seeds the program
+    // with) are always admitted, even a `node_modules`-hosted `.js` file that
+    // `maxNodeModuleJsDepth` would exclude when reached through resolution.
+    // tsc's depth gate applies only to JS files *discovered* by following
+    // imports, never to files the user listed directly. Track the canonical
+    // roots so the depth skip below can exempt them.
+    let mut root_paths: FxHashSet<PathBuf> = FxHashSet::default();
     for path in paths {
         let canonical = normalize(path, options);
         outfile_bundle_paths.insert(canonical.clone());
+        root_paths.insert(canonical.clone());
         if seen.insert(canonical.clone()) {
             discovery_order.insert(canonical.clone(), next_discovery_order);
             next_discovery_order += 1;
@@ -761,7 +777,9 @@ pub(super) fn read_source_files(
                     });
                 if cached {
                     BatchAction::Cached
-                } else if should_skip_js_in_node_modules(path, options.max_node_module_js_depth) {
+                } else if !root_paths.contains(path)
+                    && should_skip_js_in_node_modules(path, options.max_node_module_js_depth)
+                {
                     BatchAction::SkipJs
                 } else {
                     BatchAction::Read
@@ -813,6 +831,9 @@ pub(super) fn read_source_files(
                     continue;
                 }
                 BatchAction::SkipJs => {
+                    // Record the depth-gated JS file so the diagnostic pass can
+                    // tell it apart from a genuinely admitted program member.
+                    depth_skipped_js.insert(path.clone());
                     sources.insert(path.clone(), (None, false, false));
                     continue;
                 }
@@ -1136,6 +1157,7 @@ pub(super) fn read_source_files(
         module_resolution_misses,
         type_reference_errors,
         resolution_mode_errors,
+        depth_skipped_js,
     })
 }
 

--- a/crates/tsz-cli/tests/untyped_module_resolution_tests.rs
+++ b/crates/tsz-cli/tests/untyped_module_resolution_tests.rs
@@ -455,3 +455,121 @@ fn require_only_exports_still_reports_ts2307_for_esm_dynamic_import() {
         "TS2307 names the require-only package, got: {unresolved:#?}"
     );
 }
+
+/// `maxNodeModuleJsDepth` gate — positive direction. A `node_modules`-hosted
+/// `.js` dependency reached through `require()` is admitted into the program
+/// once its resolution depth is within `maxNodeModuleJsDepth`, so `tsc` binds
+/// the import to the file's inferred JS type and reports no TS7016 — even under
+/// `noImplicitAny`. Before this fix `maxNodeModuleJsDepth` was parsed but never
+/// consulted by the untyped-JS diagnostic, so the depth-1 dependency kept a
+/// spurious TS7016.
+#[test]
+fn node_modules_js_within_max_depth_is_admitted_without_ts7016() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let base = temp.path();
+
+    write_untyped_package(base, "depth-pkg");
+
+    write_file(
+        &base.join("main.ts"),
+        "import viaRequire = require(\"depth-pkg\");\nexport const a = viaRequire;\n",
+    );
+
+    write_tsconfig(
+        base,
+        ",\n                \"allowJs\": true,\n                \"noImplicitAny\": true,\n                \"maxNodeModuleJsDepth\": 1",
+        &["main.ts"],
+    );
+
+    let args = parse_args(&["tsz", "--noEmit"]);
+    let result = compile(&args, base).expect("compile should succeed");
+
+    let missing_declaration =
+        diagnostics_with_code(&result.diagnostics, COULD_NOT_FIND_DECLARATION_FILE);
+    assert!(
+        missing_declaration.is_empty(),
+        "a node_modules JS dependency within maxNodeModuleJsDepth is admitted, so no TS7016, got: {missing_declaration:#?}"
+    );
+    let unresolved = diagnostics_with_code(&result.diagnostics, CANNOT_FIND_MODULE);
+    assert!(
+        unresolved.is_empty(),
+        "an admitted dependency is not a resolution failure, got: {unresolved:#?}"
+    );
+}
+
+/// `maxNodeModuleJsDepth` gate — negative direction (matrix row 1). With
+/// `allowJs` on but `maxNodeModuleJsDepth` left at its default of 0, a
+/// `node_modules` JS dependency reached only through `require()` is *not*
+/// admitted, so `tsc` still reports TS7016 under `noImplicitAny`. `allowJs`
+/// alone must never be mistaken for admission — the reconciliation only drops
+/// the diagnostic for files the BFS actually kept.
+#[test]
+fn node_modules_js_at_default_depth_still_reports_ts7016_with_allow_js() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let base = temp.path();
+
+    write_untyped_package(base, "shallow-pkg");
+
+    write_file(
+        &base.join("app.ts"),
+        "import loaded = require(\"shallow-pkg\");\nexport const v = loaded;\n",
+    );
+
+    write_tsconfig(
+        base,
+        ",\n                \"allowJs\": true,\n                \"noImplicitAny\": true",
+        &["app.ts"],
+    );
+
+    let args = parse_args(&["tsz", "--noEmit"]);
+    let result = compile(&args, base).expect("compile should succeed");
+
+    let missing_declaration =
+        diagnostics_with_code(&result.diagnostics, COULD_NOT_FIND_DECLARATION_FILE);
+    assert_eq!(
+        missing_declaration.len(),
+        1,
+        "a node_modules JS dependency at the default maxNodeModuleJsDepth (0) is not admitted, so TS7016 stands, got: {missing_declaration:#?}"
+    );
+}
+
+/// Explicit-root gate (matrix row 5). A `node_modules`-hosted `.js` file listed
+/// directly in the program's `files` is an explicit root, so it is admitted
+/// regardless of `maxNodeModuleJsDepth` and a `require()` of it reports no
+/// TS7016 — matching `tsc`'s program-membership gate (its checker probes
+/// `host.getSourceFile(resolvedFileName)`). This is the fixture-shape behind the
+/// TS test-harness cases `importNonExportedMember12.ts` /
+/// `namespaceAssignmentToRequireAlias.ts`.
+#[test]
+fn node_modules_js_listed_as_explicit_root_is_admitted_without_ts7016() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let base = temp.path();
+
+    write_untyped_package(base, "root-pkg");
+
+    write_file(
+        &base.join("main.ts"),
+        "import rooted = require(\"root-pkg\");\nexport const r = rooted;\n",
+    );
+
+    write_tsconfig(
+        base,
+        ",\n                \"allowJs\": true,\n                \"noImplicitAny\": true",
+        &["main.ts", "node_modules/root-pkg/index.js"],
+    );
+
+    let args = parse_args(&["tsz", "--noEmit"]);
+    let result = compile(&args, base).expect("compile should succeed");
+
+    let missing_declaration =
+        diagnostics_with_code(&result.diagnostics, COULD_NOT_FIND_DECLARATION_FILE);
+    assert!(
+        missing_declaration.is_empty(),
+        "a node_modules JS file listed as an explicit root is admitted, so no TS7016, got: {missing_declaration:#?}"
+    );
+    let unresolved = diagnostics_with_code(&result.diagnostics, CANNOT_FIND_MODULE);
+    assert!(
+        unresolved.is_empty(),
+        "an explicit-root dependency is not a resolution failure, got: {unresolved:#?}"
+    );
+}


### PR DESCRIPTION
Fixes #16921.

**Structural rule.** When a module specifier resolves to a `node_modules`-hosted JavaScript file, `tsc` reports TS7016 ("Could not find a declaration file for module ...") *only when that `.js` file is not part of the program* — its checker probes `host.getSourceFile(resolvedFileName)` and emits the diagnostic only when that returns nothing. Program membership for such a file is decided by two gates the resolver cannot see: an **explicit program root** is always admitted, and a file **reached through resolution** is admitted only when its `node_modules` depth is within `maxNodeModuleJsDepth` (default `0`). tsz parsed `maxNodeModuleJsDepth` but never let it influence the diagnostic, and applied the source-discovery depth skip uniformly — including to explicit roots — so `require()` of an untyped `node_modules` JS package produced a spurious TS7016 both when the depth setting admitted the file and when the file was listed directly in `files`.

**Owner layer.** The fix lives entirely in the driver, mirroring tsc's *checker*-side reconciliation, so the resolver stays the single owner of resolution and the driver owns the membership-vs-diagnostic decision:

- `driver/sources.rs` — the source-discovery BFS now exempts explicit program roots from the `maxNodeModuleJsDepth` skip (a `node_modules` JS file in `files` is admitted and parsed like any other root), and records every JS file it depth-gated out in `SourceReadResult::depth_skipped_js`.
- `driver/source_resolution_setup.rs` — reconciles the resolver's conservative untyped-JS TS7016 against that authoritative admission decision: a resolved JS file that was **not** depth-skipped is a real program member, so the error is cleared and the import binds to the file's inferred JS type. Files excluded beyond depth, and untyped-JS results with no resolved path (`allowJs` off), keep the diagnostic.
- `driver/check.rs`, `driver/core_diagnostics.rs` — thread `depth_skipped_js` from the BFS to the resolution-setup pass.

A depth-skipped file still receives an empty program stub rather than being dropped, because removing it would shift the discovery-order-based `SymbolId` assignment and risk reproducibility drift; that stub is why membership consumers consult `depth_skipped_js` instead of `program_file_index`. This is documented at the SkipJs site.

**Adjacent-case matrix** (oracle-verified against the issue; all now match `tsc`, confirmed via CLI and the new unit tests):

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `require("untyped")`, `--strict --allowJs` | TS7016 | TS7016 | TS7016 |
| same, `--maxNodeModuleJsDepth 1` | clean | TS7016 | clean |
| same, `--allowJs --noImplicitAny false` | clean | clean | clean |
| first-party `.js` `require` (not node_modules) | clean | clean | clean |
| `node_modules` JS in explicit `files` | clean | TS7016 | clean |

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-cli --release --lib untyped_module_resolution` — **12 passed** (3 new: positive depth gate, default-depth negative guard, explicit-root admission).
- `./scripts/conformance/conformance.sh snapshot --workers 12` (HEAD `ad4aec3`) — **0 regressions** vs the checked-in baseline; failures 544 → 490, passed 11499 → 11552. The two fixtures the issue names both flip to passing: `compiler/importNonExportedMember12.ts` and `conformance/salsa/namespaceAssignmentToRequireAlias.ts`. The most directly-affected areas are fully green: `projects/NodeModulesSearch` 14/14, `projects/jsFileCompilation` 20/20. (The other improvements in the diff come from main commits merged after the checked-in baseline snapshot; the change itself is confined to the untyped-`node_modules`-JS TS7016 path.)
- `cargo clippy --release -p tsz-cli` — clean; architecture guard passed (largest touched file `sources.rs` at 1976 < 2000).
- `./scripts/emit/run.sh` — not run locally: the emit test-runner build hangs on a `node` install step in this environment, unrelated to the change. The change touches only `tsz-cli/src/driver` resolution diagnostics — no emitter code — and the conformance run above exercises the same program-construction path with no regressions.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high