### PR TITLE
fix(resolver): enforce maxNodeModuleJsDepth for external require() TS7016

### DIFF
--- a/crates/tsz-core/src/module_resolver/mod.rs
+++ b/crates/tsz-core/src/module_resolver/mod.rs
@@ -151,6 +151,12 @@ pub struct ModuleResolver {
     module_kind: ModuleKind,
     /// Whether allowJs is enabled (affects extension candidates)
     allow_js: bool,
+    /// `maxNodeModuleJsDepth` (default 0): the deepest `node_modules` nesting a
+    /// resolved JavaScript dependency may sit at and still be admitted into the
+    /// program. Governs whether the external-`require()` TS7016 fires — a
+    /// `node_modules` JS file within the budget is type-checked as real JS, so
+    /// no "missing declaration file" diagnostic is produced.
+    max_node_module_js_depth: u32,
     /// Whether to rewrite relative imports with TypeScript extensions during emit.
     rewrite_relative_import_extensions: bool,
     /// Whether to print TypeScript-style module resolution traces.
@@ -207,6 +213,17 @@ pub struct ModuleResolver {
     out_dir: Option<PathBuf>,
 }
 
+/// Count the `node_modules` path segments in `path` — tsz's structural proxy
+/// for tsc's `currentNodeModulesDepth`. A first-party file is depth 0; a
+/// top-level dependency at `.../node_modules/foo/index.js` is depth 1; a nested
+/// `.../node_modules/foo/node_modules/bar/index.js` is depth 2. Used to gate
+/// the external-`require()` TS7016 on `maxNodeModuleJsDepth`.
+fn node_modules_nesting_depth(path: &Path) -> u32 {
+    path.components()
+        .filter(|component| component.as_os_str() == "node_modules")
+        .count() as u32
+}
+
 impl ModuleResolver {
     fn increment_counter(counter: &Cell<u64>) {
         counter.set(counter.get().saturating_add(1));
@@ -240,6 +257,7 @@ impl ModuleResolver {
             custom_conditions: options.custom_conditions.clone(),
             module_kind: options.printer.module,
             allow_js: options.allow_js,
+            max_node_module_js_depth: options.max_node_module_js_depth,
             rewrite_relative_import_extensions: options.rewrite_relative_import_extensions,
             trace_resolution: options.trace_resolution,
             resolution_cache_hits: Cell::new(0),
@@ -281,6 +299,7 @@ impl ModuleResolver {
             custom_conditions: Vec::new(),
             module_kind: ModuleKind::CommonJS,
             allow_js: false,
+            max_node_module_js_depth: 0,
             rewrite_relative_import_extensions: false,
             trace_resolution: false,
             resolution_cache_hits: Cell::new(0),
@@ -892,9 +911,22 @@ impl ModuleResolver {
                 // `needs_explicit_root_files` in `crates/conformance/src/tsz_wrapper.rs`).
                 let is_explicit_root =
                     known_files.is_some_and(|roots| roots.contains(&resolved_module.resolved_path));
+                // `maxNodeModuleJsDepth` (default 0) admits a resolved
+                // `node_modules` JS dependency into the program when its nesting
+                // depth is within the budget; once admitted the file is
+                // type-checked as real JS, so the external-`require()` TS7016 is
+                // not produced. The default of 0 admits nothing reached through
+                // `node_modules`, preserving the diagnostic. Oracle-verified
+                // against typescript@7.0.2 (#16921): `require("untyped")` of a
+                // `node_modules/untyped` JS file is TS7016 at the default depth
+                // but clean at `--maxNodeModuleJsDepth 1`.
+                let within_node_module_js_depth =
+                    node_modules_nesting_depth(&resolved_module.resolved_path)
+                        <= self.max_node_module_js_depth;
                 let is_external_cjs_require = resolved_module.is_external
                     && matches!(import_kind, ImportKind::CjsRequire)
-                    && !is_explicit_root;
+                    && !is_explicit_root
+                    && !within_node_module_js_depth;
                 // tsc's augmentation-target check (TS2665) keys on the
                 // *resolution extension*, not on whether the import site was
                 // diagnosed: a specifier resolving to a `.js`/`.jsx` file is an

--- a/crates/tsz-core/src/module_resolver/tests.rs
+++ b/crates/tsz-core/src/module_resolver/tests.rs
@@ -17,6 +17,7 @@ mod explicit_root_untyped_js;
 mod importing_module_kind;
 mod lookup_classify;
 mod lookup_integration;
+mod max_node_module_js_depth;
 mod mixed_esm_cjs_exports;
 mod module_extension;
 mod node16_modes;

--- a/crates/tsz-core/src/module_resolver/tests/max_node_module_js_depth.rs
+++ b/crates/tsz-core/src/module_resolver/tests/max_node_module_js_depth.rs
@@ -1,0 +1,104 @@
+//! `maxNodeModuleJsDepth` (default 0) admits a resolved `node_modules` JS
+//! dependency into the program when its nesting depth is within the budget;
+//! once admitted the file is type-checked as real JS, so the
+//! external-`require()` TS7016 ("could not find a declaration file") does not
+//! fire. Oracle-verified against `typescript@7.0.2` (#16921):
+//! `require("untyped")` of a `node_modules/untyped` JS file reports TS7016 at
+//! the default depth of 0 but is clean at `--maxNodeModuleJsDepth 1`. This is
+//! the residual of #16921 after #16926 handled the explicit-`files`-root shape.
+
+use super::super::*;
+use super::fixtures::TempFixture;
+
+/// A `node`-resolution resolver with `allowJs` on (so a `.js` resolution takes
+/// the primary `Ok(resolved_module)` branch) and the given
+/// `maxNodeModuleJsDepth`.
+fn resolver_with_depth(max_node_module_js_depth: u32) -> ModuleResolver {
+    let options = ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Node16),
+        module_suffixes: vec![String::new()],
+        allow_js: true,
+        max_node_module_js_depth,
+        printer: crate::emitter::PrinterOptions {
+            module: crate::emitter::ModuleKind::Node16,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    ModuleResolver::new(&options)
+}
+
+fn setup_untyped_package(fixture: &TempFixture) -> std::path::PathBuf {
+    fixture.write(
+        "node_modules/untyped/package.json",
+        r#"{"name":"untyped","version":"1.0.0","main":"index.js"}"#,
+    );
+    fixture.write("node_modules/untyped/index.js", "module.exports = 1;")
+}
+
+fn require_request<'a>(
+    specifier: &'a str,
+    containing_file: &'a std::path::Path,
+) -> ModuleLookupRequest<'a> {
+    ModuleLookupRequest {
+        specifier,
+        containing_file,
+        specifier_span: Span::new(0, 0),
+        import_kind: ImportKind::CjsRequire,
+        resolution_mode_override: None,
+        no_implicit_any: true,
+        implied_classic_resolution: false,
+    }
+}
+
+#[test]
+fn default_depth_zero_reports_ts7016() {
+    let fixture = TempFixture::new();
+    setup_untyped_package(&fixture);
+    let containing_file = fixture.write("a.ts", "import u = require(\"untyped\");");
+
+    let mut resolver = resolver_with_depth(0);
+    let request = require_request("untyped", &containing_file);
+    let result = resolver.lookup(&request, |_, _| None, |_| false, None);
+
+    let error = result
+        .error
+        .expect("maxNodeModuleJsDepth 0 must report TS7016 for an untyped node_modules require()");
+    assert_eq!(error.code, COULD_NOT_FIND_DECLARATION_FILE);
+}
+
+#[test]
+fn depth_one_admits_top_level_dependency_and_suppresses_ts7016() {
+    let fixture = TempFixture::new();
+    let resolved_js = setup_untyped_package(&fixture);
+    let containing_file = fixture.write("a.ts", "import u = require(\"untyped\");");
+
+    let mut resolver = resolver_with_depth(1);
+    let request = require_request("untyped", &containing_file);
+    let result = resolver.lookup(&request, |_, _| None, |_| false, None);
+
+    assert_eq!(
+        result.resolved_path.as_deref(),
+        Some(resolved_js.as_path()),
+        "the require() must still resolve to the real JS file"
+    );
+    assert!(
+        result.error.is_none(),
+        "maxNodeModuleJsDepth 1 admits the top-level dependency, so no TS7016: {:?}",
+        result.error
+    );
+}
+
+#[test]
+fn nesting_depth_counts_node_modules_segments() {
+    use std::path::Path;
+    assert_eq!(node_modules_nesting_depth(Path::new("/p/src/index.js")), 0);
+    assert_eq!(
+        node_modules_nesting_depth(Path::new("/p/node_modules/foo/index.js")),
+        1
+    );
+    assert_eq!(
+        node_modules_nesting_depth(Path::new("/p/node_modules/foo/node_modules/bar/index.js")),
+        2
+    );
+}


### PR DESCRIPTION
Closes the residual of #16921 after #16926.

`maxNodeModuleJsDepth` was parsed into `ResolvedCompilerOptions` but the external-`require()` TS7016 ("could not find a declaration file for module") branch never read it. So `import u = require("untyped")` of a `node_modules`-hosted JS module reported TS7016 even at `--maxNodeModuleJsDepth 1`, where tsc admits the file into the program and reports nothing. #16926 fixed the sibling explicit-`files`-root shape (the two conformance fixtures) but explicitly left the depth-budget case open.

## Structural rule
When a bare `require()` resolves to a `node_modules`-hosted JS file whose nesting depth is within `maxNodeModuleJsDepth` (default 0), tsc admits it into the program and type-checks it as real JS, so no TS7016 fires; beyond the budget it stays `isExternalLibraryImport` and the diagnostic stands. tsz now owns this in `ModuleResolver::lookup` (crates/tsz-core/src/module_resolver/mod.rs), right beside the explicit-root gate from #16926: `ModuleResolver` carries `max_node_module_js_depth`, and the external-CJS-require branch is additionally gated on `node_modules_nesting_depth(resolved_path) <= max_node_module_js_depth`. The gate is a pure structural property of the resolved path (a `node_modules`-segment count, tsz's proxy for tsc's `currentNodeModulesDepth`), so it composes with #16926's root gate without touching program membership.

Adjacent-case matrix (oracle `typescript@7.0.2`, `import u = require("untyped")`, `--strict --allowJs`):

| shape | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| default depth 0 | TS7016 | TS7016 | TS7016 |
| `--maxNodeModuleJsDepth 1` | clean | **TS7016** | clean |
| `--maxNodeModuleJsDepth 2` | clean | TS7016 | clean |
| `--noImplicitAny false` | clean | clean | clean |
| first-party `.js` require | clean | clean | clean |
| `node_modules` JS as `files` root | clean | clean (#16926) | clean |

The ESM-`import` path of untyped node_modules JS is a distinct tsc rule (issue #3050, gated on `allowJs` alone) and is intentionally out of scope, matching #16921/#16926.

## Goal
Goal: hold

## Verification
- New resolver unit tests: `module_resolver::tests::max_node_module_js_depth` (depth-0 reports TS7016, depth-1 admits the top-level dependency and suppresses it, segment-count helper) + existing `explicit_root_untyped_js` tests still green.
- `cargo clippy --release -p tsz-core -p tsz-cli` clean.
- Manual matrix above reproduced against the release `tsz` binary.
- Conformance snapshot + emit floor: results appended in a follow-up comment once the local runs finish.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_014f7Zt1kQBfYeCx5pEYq32b)_