### PR TITLE
fix(checker): stop fabricating TS2374 on a single JSX IntrinsicElements index signature

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1744,6 +1744,9 @@ path = "tests/jsdoc_nested_generic_missing_name_tests.rs"
 name = "ts2374_lib_merged_index_signature_tests"
 path = "tests/ts2374_lib_merged_index_signature_tests.rs"
 [[test]]
+name = "ts2374_jsx_runtime_self_import_no_false_positive_tests"
+path = "tests/ts2374_jsx_runtime_self_import_no_false_positive_tests.rs"
+[[test]]
 name = "large_union_index_merge_regression_tests"
 path = "tests/large_union_index_merge_regression_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
@@ -387,14 +387,6 @@ impl<'a> CheckerState<'a> {
                         &["string"],
                     );
                 }
-            } else if nodes.len() == 1
-                && self.jsx_runtime_self_imports_intrinsic_elements(container_node)
-            {
-                self.error_at_node_msg(
-                    nodes[0],
-                    crate::diagnostics::diagnostic_codes::DUPLICATE_INDEX_SIGNATURE_FOR_TYPE,
-                    &["string"],
-                );
             }
         }
         for nodes in [&number_index_nodes, &static_number_index_nodes] {
@@ -406,14 +398,6 @@ impl<'a> CheckerState<'a> {
                         &["number"],
                     );
                 }
-            } else if nodes.len() == 1
-                && self.jsx_runtime_self_imports_intrinsic_elements(container_node)
-            {
-                self.error_at_node_msg(
-                    nodes[0],
-                    crate::diagnostics::diagnostic_codes::DUPLICATE_INDEX_SIGNATURE_FOR_TYPE,
-                    &["number"],
-                );
             }
         }
         for nodes in [&symbol_index_nodes, &static_symbol_index_nodes] {
@@ -425,14 +409,6 @@ impl<'a> CheckerState<'a> {
                         &["symbol"],
                     );
                 }
-            } else if nodes.len() == 1
-                && self.jsx_runtime_self_imports_intrinsic_elements(container_node)
-            {
-                self.error_at_node_msg(
-                    nodes[0],
-                    crate::diagnostics::diagnostic_codes::DUPLICATE_INDEX_SIGNATURE_FOR_TYPE,
-                    &["symbol"],
-                );
             }
         }
         self.report_duplicate_other_index_signatures(&other_index_nodes);
@@ -1593,223 +1569,6 @@ impl<'a> CheckerState<'a> {
             }
         }
         false
-    }
-
-    fn jsx_runtime_self_imports_intrinsic_elements(&self, container_node: NodeIndex) -> bool {
-        use tsz_common::checker_options::JsxMode;
-
-        if !matches!(
-            self.ctx.compiler_options.jsx_mode,
-            JsxMode::ReactJsx | JsxMode::ReactJsxDev
-        ) && self.ctx.compiler_options.jsx_import_source.is_empty()
-        {
-            return false;
-        }
-
-        let Some(container) = self.ctx.arena.get(container_node) else {
-            return false;
-        };
-        let Some(interface) = self.ctx.arena.get_interface(container) else {
-            return false;
-        };
-        let Some(name_node) = self.ctx.arena.get(interface.name) else {
-            return false;
-        };
-        let Some(name) = self.ctx.arena.get_identifier(name_node) else {
-            return false;
-        };
-        if name.escaped_text.as_str() != "IntrinsicElements" {
-            return false;
-        }
-
-        let namespace_node = self.get_enclosing_namespace(container_node);
-        let Some(namespace) = self.ctx.arena.get(namespace_node) else {
-            return false;
-        };
-        let Some(namespace_decl) = self.ctx.arena.get_module(namespace) else {
-            return false;
-        };
-        let Some(namespace_name_node) = self.ctx.arena.get(namespace_decl.name) else {
-            return false;
-        };
-        let Some(namespace_name) = self.ctx.arena.get_identifier(namespace_name_node) else {
-            return false;
-        };
-        if namespace_name.escaped_text.as_str() != "JSX" {
-            return false;
-        }
-
-        let current_file = self.ctx.file_name.replace('\\', "/");
-        let Some(package_dir) = current_file
-            .strip_suffix("/index.d.ts")
-            .or_else(|| current_file.strip_suffix("/index.d.mts"))
-            .or_else(|| current_file.strip_suffix("/index.d.cts"))
-        else {
-            return false;
-        };
-        if !package_dir.contains("/node_modules/@types/") {
-            return false;
-        }
-        if !self.jsx_runtime_types_package_dir_matches(package_dir) {
-            return false;
-        }
-
-        let Some(all_arenas) = self.ctx.all_arenas.as_ref() else {
-            return false;
-        };
-
-        let package_json_exports = all_arenas.iter().find_map(|arena| {
-            let source_file = arena.source_files.first()?;
-            let package_json = source_file.file_name.replace('\\', "/");
-            if package_json == format!("{package_dir}/package.json") {
-                Some(Self::package_json_redirects_package_subpaths_to_js(
-                    &source_file.text,
-                ))
-            } else {
-                None
-            }
-        });
-        if package_json_exports == Some(false) {
-            return false;
-        }
-
-        all_arenas.iter().any(|arena| {
-            let Some(source_file) = arena.source_files.first() else {
-                return false;
-            };
-            let runtime_file = source_file.file_name.replace('\\', "/");
-            let in_runtime_file = runtime_file == format!("{package_dir}/jsx-runtime.d.ts")
-                || runtime_file == format!("{package_dir}/jsx-runtime/index.d.ts")
-                || runtime_file == format!("{package_dir}/jsx-dev-runtime.d.ts")
-                || runtime_file == format!("{package_dir}/jsx-dev-runtime/index.d.ts");
-            in_runtime_file && Self::has_package_root_side_effect_import(&source_file.text)
-        })
-    }
-
-    fn has_package_root_side_effect_import(text: &str) -> bool {
-        let bytes = text.as_bytes();
-        let mut idx = 0usize;
-        while idx < bytes.len() {
-            idx = Self::skip_js_trivia(text, idx);
-            if idx >= bytes.len() {
-                break;
-            }
-
-            if !text[idx..].starts_with("import") || !Self::is_word_boundary(text, idx + 6) {
-                idx += text[idx..].chars().next().map(char::len_utf8).unwrap_or(1);
-                continue;
-            }
-
-            let mut cursor = Self::skip_js_trivia(text, idx + 6);
-            let Some(quote) = text[cursor..].chars().next() else {
-                break;
-            };
-            if quote != '"' && quote != '\'' {
-                idx += 6;
-                continue;
-            }
-            cursor += quote.len_utf8();
-            let Some(rest) = text.get(cursor..) else {
-                break;
-            };
-            if let Some(after_specifier) = rest
-                .strip_prefix("./")
-                .map(|_| cursor + 2)
-                .or_else(|| rest.strip_prefix('.').map(|_| cursor + 1))
-                && text[after_specifier..].starts_with(quote)
-            {
-                let after_quote = after_specifier + quote.len_utf8();
-                let after_import = Self::skip_js_trivia(text, after_quote);
-                if after_import >= text.len()
-                    || text[after_import..].starts_with(';')
-                    || text[after_import..].starts_with('\n')
-                    || text[after_import..].starts_with('\r')
-                {
-                    return true;
-                }
-            }
-
-            idx += 6;
-        }
-
-        false
-    }
-
-    fn skip_js_trivia(text: &str, mut idx: usize) -> usize {
-        loop {
-            while let Some(ch) = text[idx..].chars().next()
-                && ch.is_whitespace()
-            {
-                idx += ch.len_utf8();
-            }
-
-            if text[idx..].starts_with("//") {
-                idx += 2;
-                while let Some(ch) = text[idx..].chars().next() {
-                    idx += ch.len_utf8();
-                    if ch == '\n' || ch == '\r' {
-                        break;
-                    }
-                }
-                continue;
-            }
-
-            if text[idx..].starts_with("/*") {
-                idx += 2;
-                if let Some(end) = text[idx..].find("*/") {
-                    idx += end + 2;
-                } else {
-                    return text.len();
-                }
-                continue;
-            }
-
-            return idx;
-        }
-    }
-
-    fn is_word_boundary(text: &str, idx: usize) -> bool {
-        text[idx..]
-            .chars()
-            .next()
-            .is_none_or(|ch| !(ch == '_' || ch == '$' || ch.is_ascii_alphanumeric()))
-    }
-
-    fn jsx_runtime_types_package_dir_matches(&self, package_dir: &str) -> bool {
-        use tsz_common::checker_options::JsxMode;
-
-        let import_source = if self.ctx.compiler_options.jsx_import_source.is_empty()
-            && matches!(
-                self.ctx.compiler_options.jsx_mode,
-                JsxMode::ReactJsx | JsxMode::ReactJsxDev
-            ) {
-            "react"
-        } else {
-            self.ctx.compiler_options.jsx_import_source.as_str()
-        };
-        let Some(types_package) = Self::types_package_name_for_jsx_import_source(import_source)
-        else {
-            return false;
-        };
-        package_dir.ends_with(&format!("/node_modules/{types_package}"))
-    }
-
-    fn types_package_name_for_jsx_import_source(import_source: &str) -> Option<String> {
-        let mut parts = import_source.split('/').filter(|part| !part.is_empty());
-        let first = parts.next()?;
-        if let Some(scope) = first.strip_prefix('@') {
-            let second = parts.next()?;
-            Some(format!("@types/{scope}__{second}"))
-        } else {
-            Some(format!("@types/{first}"))
-        }
-    }
-
-    fn package_json_redirects_package_subpaths_to_js(text: &str) -> bool {
-        let compact: String = text.chars().filter(|ch| !ch.is_whitespace()).collect();
-        compact.contains("\"exports\"")
-            && compact.contains("\"./*.js\":\"./*.js\"")
-            && compact.contains("\"./*\":\"./*.js\"")
     }
 
     fn synthesized_computed_member_index_info(

--- a/crates/tsz-checker/tests/ts2374_jsx_runtime_self_import_no_false_positive_tests.rs
+++ b/crates/tsz-checker/tests/ts2374_jsx_runtime_self_import_no_false_positive_tests.rs
@@ -1,0 +1,125 @@
+//! TS2374 must not fabricate a "duplicate index signature" for a JSX
+//! `IntrinsicElements` interface that declares a single index signature, even
+//! when the `@types/*` package's `jsx-runtime` entrypoint re-imports the
+//! package root (`import './';`).
+//!
+//! Structural rule: `tsc` reports TS2374 only when an interface actually
+//! merges two or more same-kind index signatures across its declarations. A
+//! JSX runtime entrypoint importing the package root does not duplicate the
+//! `IntrinsicElements` interface — the corpus rows
+//! `compiler/reactJsxReactResolvedNodeNext.tsx` and its ESM sibling both
+//! produce zero diagnostics under `tsc@7.0.2` (no `.errors.txt` baseline), and
+//! no TypeScript baseline anywhere reports "Duplicate index signature" on an
+//! `IntrinsicElements` interface.
+//!
+//! These tests lock the parity floor: the single-signature JSX self-import
+//! shape stays clean, while a genuinely duplicated index signature (two of the
+//! same kind) still reports TS2374 — the detection must be driven by the real
+//! merged-signature count, never by the JSX-runtime file shape.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_multi_file, check_source, diagnostic_count};
+use tsz_common::checker_options::JsxMode;
+
+fn react_jsx_options() -> CheckerOptions {
+    CheckerOptions {
+        jsx_mode: JsxMode::ReactJsx,
+        ..CheckerOptions::default()
+    }
+}
+
+/// The bug witness: a `@types/react`-shaped package whose `jsx-runtime` and
+/// `jsx-dev-runtime` entrypoints re-import the package root. The single
+/// `IntrinsicElements` index signature must NOT be reported as a duplicate.
+#[test]
+fn react_jsx_intrinsic_elements_single_string_index_with_self_import_runtime_is_clean() {
+    let files = [
+        (
+            "/proj/node_modules/@types/react/index.d.ts",
+            "declare namespace JSX {\n    interface IntrinsicElements { [x: string]: any; }\n}\n",
+        ),
+        (
+            "/proj/node_modules/@types/react/jsx-runtime.d.ts",
+            "import './';\n",
+        ),
+        (
+            "/proj/node_modules/@types/react/jsx-dev-runtime.d.ts",
+            "import './';\n",
+        ),
+    ];
+    let diags = check_multi_file(
+        &files,
+        "/proj/node_modules/@types/react/index.d.ts",
+        react_jsx_options(),
+    );
+    assert_eq!(
+        diagnostic_count(&diags, 2374),
+        0,
+        "a single JSX.IntrinsicElements index signature must not be reported as a \
+         duplicate just because the JSX runtime entrypoint re-imports the package \
+         root; got: {diags:?}"
+    );
+}
+
+/// Same self-import runtime shape, but the `IntrinsicElements` body genuinely
+/// declares two same-kind index signatures. The real merged-count rule must
+/// still fire TS2374 — removing the JSX-runtime heuristic must not disable
+/// genuine duplicate detection inside a JSX namespace.
+#[test]
+fn react_jsx_intrinsic_elements_two_string_indexes_still_report_ts2374() {
+    let files = [
+        (
+            "/proj/node_modules/@types/react/index.d.ts",
+            "declare namespace JSX {\n    interface IntrinsicElements {\n        [x: string]: any;\n        [y: string]: any;\n    }\n}\n",
+        ),
+        (
+            "/proj/node_modules/@types/react/jsx-runtime.d.ts",
+            "import './';\n",
+        ),
+    ];
+    let diags = check_multi_file(
+        &files,
+        "/proj/node_modules/@types/react/index.d.ts",
+        react_jsx_options(),
+    );
+    assert!(
+        diagnostic_count(&diags, 2374) >= 2,
+        "two same-kind index signatures in IntrinsicElements must still report \
+         TS2374 on each; got: {diags:?}"
+    );
+}
+
+/// Structural, name-independent positive check: a plain interface with two
+/// `string` index signatures reports TS2374 regardless of the binder names.
+/// Guards that the fix left the ordinary duplicate-index path untouched.
+#[test]
+fn plain_interface_two_string_indexes_report_ts2374_name_independent() {
+    for (iface, a, b) in [("Widget", "a", "b"), ("Zephyr", "keyA", "keyB")] {
+        let source = format!(
+            "interface {iface} {{\n    [{a}: string]: number;\n    [{b}: string]: number;\n}}\n"
+        );
+        let diags = check_source(&source, "dup_index.ts", CheckerOptions::default());
+        assert!(
+            diagnostic_count(&diags, 2374) >= 2,
+            "interface {iface} with two string index signatures must report TS2374 \
+             on each; got: {diags:?}"
+        );
+    }
+}
+
+/// A single index signature in a plain (non-JSX) interface is never a
+/// duplicate — the ordinary baseline that the JSX heuristic wrongly departed
+/// from.
+#[test]
+fn plain_interface_single_string_index_is_clean() {
+    let diags = check_source(
+        "interface Widget { [x: string]: any; }\n",
+        "single_index.ts",
+        CheckerOptions::default(),
+    );
+    assert_eq!(
+        diagnostic_count(&diags, 2374),
+        0,
+        "a single string index signature must never report TS2374; got: {diags:?}"
+    );
+}


### PR DESCRIPTION
When a `@types/*` package's `jsx-runtime`/`jsx-dev-runtime` entrypoint re-imports the package root (`import './';`) and `JSX.IntrinsicElements` declares a single same-kind index signature, `tsc` reports nothing. tsz reported a false `TS2374` "Duplicate index signature" through a `jsx_runtime_self_imports_intrinsic_elements` heuristic in the checker's index-signature pass.

**Structural rule:** when an interface merges fewer than two same-kind index signatures, `tsc` reports no `TS2374`; tsz now does the same through the checker's `check_index_signature_compatibility` (owner layer: checker index-signature diagnostics). `TS2374` is driven solely by the real merged same-kind count (`nodes.len() > 1`).

The removed heuristic was a symptom patch — file-name suffix checks (`/index.d.ts`), `/node_modules/@types/` substring matching, and hand-rolled text scanning of file contents for `import './'` — the kind the anti-hardcoding gate forbids. It also ran a per-interface `all_arenas` scan with per-file string allocations on a hot path. Its six private helpers are removed with it (zero remaining references, no orphaned imports).

No TypeScript baseline anywhere reports a duplicate index signature on `IntrinsicElements`; `compiler/reactJsxReactResolvedNodeNext.tsx` and its ESM sibling both produce zero diagnostics under `tsc@7.0.2` (no `.errors.txt` baseline).

Adjacent cases covered by the new regression tests:
- single JSX `IntrinsicElements` sig + self-import runtime → clean (the witness);
- two same-kind sigs inside the same JSX shape → `TS2374` still fires (detection not disabled);
- two plain-interface sigs with varied binder names → `TS2374` (structural, name-independent);
- single plain sig → clean.

## Goal
Goal: hold

## Verification
- `./scripts/conformance/conformance.sh run --filter reactJsxReactResolvedNodeNext` → **2/2 passed** (was 0/2, both emitting an extra `TS2374`).
- Full conformance snapshot on this branch vs pre-fix: **490 → 488** failures; the two `reactJsxReactResolvedNodeNext` rows newly pass; **zero new regressions**.
- `cargo test -p tsz-checker --test ts2374_jsx_runtime_self_import_no_false_positive_tests` → 4/4, and `--test ts2374_lib_merged_index_signature_tests` → 4/4 (ordinary merged-duplicate path intact).
- `cargo clippy -p tsz-checker --all-targets` clean; architecture-size guard passes (edited file 1712 < 2000 lines).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-code
Effort: high

https://claude.ai/code/session_01WPvPaUyqu1zunCoxM6upDt

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPvPaUyqu1zunCoxM6upDt)_