### PR TITLE
fix(sources): explicit-root node_modules JS is a full program input (fixes false TS2339 on Node16/NodeNext require)

### DIFF
--- a/crates/tsz-cli/src/driver/sources.rs
+++ b/crates/tsz-cli/src/driver/sources.rs
@@ -707,8 +707,26 @@ pub(super) fn read_source_files(
         canonical
     };
 
+    // Canonical paths of the explicit program roots (tsc's `rootNames` —
+    // `files`/CLI-argument entries). An explicit root is always a full program
+    // input in tsc's model, even when it is a `node_modules` JS file that the
+    // `maxNodeModuleJsDepth` gate would otherwise skip for a *transitively*
+    // reached dependency: `getSourceFilesToEmit`/`processRootFile` never apply
+    // the depth cap to a root, so its body is parsed, bound, and available for
+    // type analysis (its `module.exports`/`exports.x` surface is readable). The
+    // same distinction gates the external-CJS-require TS7016 suppression in
+    // `ModuleResolver::lookup` (#16926). Without this, a required, rooted
+    // `node_modules/<pkg>/index.js` is body-stripped here, so a later
+    // `require()`/`import x = require()` of it reads an empty export surface and
+    // reports a false TS2339 on every real member (worse under
+    // `node16`/`nodenext`, where the file is force-classified as an external
+    // module and typed as an empty `typeof import(...)` rather than falling back
+    // to `any`).
+    let mut root_paths_canonical: FxHashSet<PathBuf> = FxHashSet::default();
+
     for path in paths {
         let canonical = normalize(path, options);
+        root_paths_canonical.insert(canonical.clone());
         outfile_bundle_paths.insert(canonical.clone());
         if seen.insert(canonical.clone()) {
             discovery_order.insert(canonical.clone(), next_discovery_order);
@@ -761,7 +779,12 @@ pub(super) fn read_source_files(
                     });
                 if cached {
                     BatchAction::Cached
-                } else if should_skip_js_in_node_modules(path, options.max_node_module_js_depth) {
+                } else if should_skip_js_in_node_modules(path, options.max_node_module_js_depth)
+                    && !root_paths_canonical.contains(path)
+                {
+                    // A `node_modules` JS file that is itself an explicit program
+                    // root is never subject to the `maxNodeModuleJsDepth` skip —
+                    // roots are full program inputs (see `root_paths_canonical`).
                     BatchAction::SkipJs
                 } else {
                     BatchAction::Read

--- a/crates/tsz-cli/tests/driver_tests_parts/part_02.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_02.rs
@@ -169,11 +169,24 @@ fn compile_allow_js_passthrough_emits_skipped_node_modules_js() {
     let args = default_args();
     let result = compile(&args, base).expect("compile should succeed");
 
+    // `node_modules/untyped/index.js` is an explicit program root (a `files`
+    // entry), so its `require("untyped")` is clean — an explicit root is never
+    // `isExternalLibraryImport` in tsc's model, so no TS7016 fires (#16926,
+    // oracle-verified). The root's body is a full program input rather than
+    // `maxNodeModuleJsDepth`-stripped, so a `require()` of it reads the real
+    // `module.exports` surface instead of a false empty one. (Under `noCheck`
+    // the member accesses in `bug40140.js` are not type-checked, so no TS2339
+    // either — the non-`noCheck` shape is covered by the conformance witness
+    // `namespaceAssignmentToRequireAlias.ts` and by
+    // `explicit_root_node_modules_js_require_reads_surface_*`.)
     assert!(
-        result.diagnostics.iter().any(|diag| diag.code == 7016),
-        "Expected TS7016 for the untyped package, got: {:?}",
+        result.diagnostics.iter().all(|diag| diag.code != 7016),
+        "explicit-root node_modules JS require must not report TS7016, got: {:?}",
         result.diagnostics
     );
+    // The test's core invariant: a `maxNodeModuleJsDepth`-skipped node_modules
+    // JS is emitted verbatim (path-based emit passthrough, unaffected by the
+    // root's body now being parsed for type analysis).
     assert_eq!(
         std::fs::read_to_string(base.join("out/node_modules/untyped/index.js"))
             .expect("read emitted skipped JS"),

--- a/crates/tsz-cli/tests/driver_tests_parts/part_14.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_14.rs
@@ -590,3 +590,101 @@ module.exports = { ns };
         result.diagnostics
     );
 }
+
+/// An explicit-root `node_modules` JS file (tsc's `rootNames`) is a full
+/// program input: its `module.exports = { ... }` surface must be readable by a
+/// later `import x = require("pkg")`, so real members type-check and unknown
+/// members report TS2339 on the concrete shape — never a false TS2339 on an
+/// empty `typeof import("pkg")`.
+///
+/// Regression for the `maxNodeModuleJsDepth` body-strip leaking into explicit
+/// roots. Before the fix the rooted `node_modules/untyped/index.js` was
+/// body-stripped in the source-discovery BFS, so its export surface came back
+/// empty: `u.hello()` reported a false TS2339 under `node16`/`nodenext` (an
+/// empty `typeof import("untyped")`) while `commonjs` silently widened `u` to
+/// `any`. tsc reads the real surface in every module mode, so the two must
+/// agree and match it. The module setting is varied to pin that agreement.
+fn explicit_root_node_modules_js_require_reads_commonjs_surface(module: &str) {
+    let temp = TempDir::new().expect("temp dir");
+    let base = temp.path.as_path();
+
+    write_file(
+        &base.join("tsconfig.json"),
+        &format!(
+            r#"{{
+  "compilerOptions": {{
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "target": "es2015",
+    "module": "{module}",
+    "types": []
+  }},
+  "files": ["repro.ts", "node_modules/untyped/index.js"]
+}}"#
+        ),
+    );
+    write_file(
+        &base.join("node_modules/untyped/package.json"),
+        r#"{"name":"untyped","version":"1.0.0","main":"index.js"}"#,
+    );
+    write_file(
+        &base.join("node_modules/untyped/index.js"),
+        "module.exports = { hello: function () { return 1; } };\n",
+    );
+    write_file(
+        &base.join("repro.ts"),
+        "import u = require(\"untyped\");\nu.hello();\nu.nonexistent();\n",
+    );
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+
+    let ts2339: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE)
+        .collect();
+    // `u.hello()` is a real member of the read CJS surface — no TS2339 there
+    // (before the fix this was the reported false-positive on an empty
+    // `typeof import("untyped")`).
+    assert!(
+        ts2339
+            .iter()
+            .all(|d| !d.message_text.contains("'hello'")),
+        "[module={module}] real CJS member `u.hello()` must not report TS2339, got: {:#?}",
+        result.diagnostics
+    );
+    // `u.nonexistent()` is not on the surface — it must report TS2339 on the
+    // concrete `{ hello: () => number; }` shape. That the type is the real
+    // shape (not `any`, not an empty `typeof import(...)`) is the whole point:
+    // it proves the rooted JS body was parsed and its `module.exports` read.
+    let nonexistent: Vec<_> = ts2339
+        .iter()
+        .filter(|d| d.message_text.contains("'nonexistent'"))
+        .collect();
+    assert!(
+        nonexistent
+            .iter()
+            .any(|d| d.message_text.contains("{ hello: () => number; }")),
+        "[module={module}] unknown member `u.nonexistent()` must report TS2339 on the \
+         read `{{ hello: () => number; }}` surface (proves `u` is the real shape, not \
+         `any` nor an empty `typeof import(...)`), got: {:#?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn explicit_root_node_modules_js_require_reads_surface_commonjs() {
+    explicit_root_node_modules_js_require_reads_commonjs_surface("commonjs");
+}
+
+#[test]
+fn explicit_root_node_modules_js_require_reads_surface_node16() {
+    explicit_root_node_modules_js_require_reads_commonjs_surface("node16");
+}
+
+#[test]
+fn explicit_root_node_modules_js_require_reads_surface_nodenext() {
+    explicit_root_node_modules_js_require_reads_commonjs_surface("nodenext");
+}


### PR DESCRIPTION
Fixes #16928.

**Structural rule.** When a specifier resolves to a `node_modules` JS file that is *itself an explicit program root* (tsc's `rootNames` — a `files`/CLI-argument entry), tsc treats it as a full program input and reads its real CommonJS `module.exports`/`exports.x` surface — the `maxNodeModuleJsDepth` cap applies only to files reached *transitively* through module resolution, never to a root. tsz did this through the source-discovery BFS (`crates/tsz-cli/src/driver/sources.rs`), which body-stripped **every** `node_modules` JS at `maxNodeModuleJsDepth` (default 0), roots included.

A later `import x = require("pkg")` / `const x = require("pkg")` of such a root then read an empty export surface:
- under `commonjs` the alias silently widened to `any` (masking real member errors);
- under `node16`/`nodenext` the file is force-classified as an external module (`moduleDetection: force`), so the alias became an empty `typeof import("pkg")` and every real member access reported a false `TS2339` — the reported bug.

The fix excludes explicit roots (canonicalized `program.files`) from the BFS `SkipJs` classification, mirroring the same explicit-root distinction that already gates the external-CJS-require `TS7016` suppression in `ModuleResolver::lookup` (#16926). Emit passthrough for skipped `node_modules` JS is path-based (`js_input_skipped_by_node_modules_depth`) and is unaffected — verified by the (corrected) passthrough test.

Now byte-for-byte with `tsc` in `commonjs`, `node16`, and `nodenext` alike:
- `module.exports = {}` → `{}` (unknown members report `TS2339`, matching the conformance witness `conformance/salsa/namespaceAssignmentToRequireAlias.ts`, tsc: `TS2339` ×2 on `{}`);
- `module.exports = { hello }` → `{ hello: () => number }` (`u.hello()` resolves; unknown members report `TS2339`).

The pre-existing `compile_allow_js_passthrough_emits_skipped_node_modules_js` test asserted `TS7016` for a rooted `node_modules` JS require. Per #16926's own oracle-verified rule a rooted require is *clean*, so that assertion is corrected to assert **no** `TS7016` while keeping the emit-passthrough invariant the test exists to pin.

## Goal
Goal: hold

## Verification
- `cargo clippy -p tsz-cli` — clean (also via pre-commit hook: clippy + arch-size guard passed).
- `cargo test --release -p tsz-cli --lib driver_tests` — 508 passed. The 3 failures (`compile_incremental_reports_ts5033_when_tsbuildinfo_is_not_writable`, `cross_file_dependent_operand_aliases_accept_scalars_and_literal_arrays`, `declaration_emit_reports_ts7056_for_private_import_type_alias`) reproduce on the stashed base and are pre-existing/environmental (the first is a root-user artifact: `0o555` dirs stay writable; the second is listed in #15983; neither remaining test touches `node_modules`/`require`).
- New regression tests (`explicit_root_node_modules_js_require_reads_surface_{commonjs,node16,nodenext}`) — 3 passed; they vary the module setting to pin cross-mode agreement.
- #16926's `explicit_root_untyped_js` tests — 3 passed.
- Manual CLI repro on the release binary: `import u = require("untyped")` of a rooted `node_modules/untyped/index.js` (`module.exports = { hello }`) is clean under `node16`/`nodenext`/`commonjs` (was false `TS2339` under `node16`/`nodenext`).
- Full conformance/emit/fourslash were not run locally: this environment has only the vendored `TypeScript` subset, not the full corpus. Behavior is validated against the pinned tsc oracle (`scripts/conformance/tsc-cache-full.json`) for the exact affected shapes; the nightly conformance lane covers the corpus.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdHzBKddudvQMm61o3UGVY)_