### PR TITLE
test(cli): skip the TS1149 casing fixtures on case-insensitive filesystems

### DIFF
--- a/crates/tsz-cli/tests/file_casing_collision_ts1149_tests.rs
+++ b/crates/tsz-cli/tests/file_casing_collision_ts1149_tests.rs
@@ -37,6 +37,32 @@ fn parse_args(args: &[&str]) -> CliArgs {
     CliArgs::try_parse_from(args).expect("test args should parse")
 }
 
+/// Whether `dir`'s filesystem distinguishes file names by case.
+///
+/// The two collision fixtures below need `foo.ts` and `Foo.ts` to exist as two
+/// distinct files. On a case-insensitive filesystem — APFS's default on macOS,
+/// and Windows — the second `write_file` overwrites the first, leaving a single
+/// root, so there is no casing collision and `TS1149` correctly does not fire.
+/// The compiler is right and the scenario is simply unrepresentable there, so
+/// those cases skip rather than assert.
+///
+/// Deliberately a runtime probe and not a `known-failures.txt` entry: on a
+/// case-sensitive filesystem (Linux CI) these must run and pass, and a blanket
+/// known-failure would mask a genuine regression there.
+fn fs_is_case_sensitive(dir: &Path) -> bool {
+    let lower = dir.join("tsz_case_probe.tmp");
+    let upper = dir.join("TSZ_CASE_PROBE.tmp");
+    if std::fs::write(&lower, "probe").is_err() {
+        // Cannot tell; assume sensitive so the assertions still run rather than
+        // silently skipping on an unrelated I/O problem.
+        return true;
+    }
+    let sensitive = !upper.exists();
+    let _ = std::fs::remove_file(&lower);
+    let _ = std::fs::remove_file(&upper);
+    sensitive
+}
+
 /// Two real, distinct root files whose names differ only in casing must
 /// report TS1149, anchored nowhere (no `file`/`start`/`length`), with the
 /// "Root file specified for compilation" reason repeated once per file.
@@ -44,6 +70,12 @@ fn parse_args(args: &[&str]) -> CliArgs {
 fn two_root_files_differing_only_in_casing_report_ts1149() {
     let temp = tempfile::TempDir::new().expect("temp dir");
     let base = temp.path();
+
+    if !fs_is_case_sensitive(base) {
+        // See `fs_is_case_sensitive`: the two-distinct-files fixture cannot
+        // exist here, so there is no collision to detect.
+        return;
+    }
 
     write_file(&base.join("foo.ts"), "export const a = 1;\n");
     write_file(&base.join("Foo.ts"), "export const b = 2;\n");
@@ -99,6 +131,12 @@ fn two_root_files_differing_only_in_casing_report_ts1149() {
 fn casing_collision_message_order_follows_root_file_argument_order() {
     let temp = tempfile::TempDir::new().expect("temp dir");
     let base = temp.path();
+
+    if !fs_is_case_sensitive(base) {
+        // See `fs_is_case_sensitive`: the two-distinct-files fixture cannot
+        // exist here, so there is no collision to detect.
+        return;
+    }
 
     write_file(&base.join("foo.ts"), "export const a = 1;\n");
     write_file(&base.join("Foo.ts"), "export const b = 2;\n");


### PR DESCRIPTION
Fixes #16938.

Goal: hold

Two cases in `file_casing_collision_ts1149_tests` cannot pass on a case-insensitive filesystem, which is APFS's default on macOS. They have failed on every macOS local run since #16913 and are **not** in `known-failures.txt`.

## Why they fail

The fixture needs `foo.ts` and `Foo.ts` as two distinct files:

```
$ printf 'a' > Foo.ts ; printf 'b' > foo.ts ; ls
Foo.ts
```

One file. Both roots resolve to it, so there is no casing collision and `TS1149` correctly does not fire:

```
assertion `left == right` failed: expected exactly one TS1149, got: []
  left: 0   right: 1
```

**The tests are right and the compiler is right** — the scenario is unrepresentable on that filesystem.

## The fix

A runtime case-sensitivity probe, with the two affected cases early-returning when it reports false. The other three in the file are unaffected and keep running everywhere.

Deliberately **not** a `known-failures.txt` entry. On a case-sensitive filesystem these must run and pass; a blanket known-failure would mask a genuine Linux regression. A conditional skip keeps full coverage where the fixture is possible and stays quiet where it is not.

The probe fails **open** — if the write errors for an unrelated reason it returns `true`, so the assertions still run rather than silently skipping on an I/O problem.

## Verified the guard is a skip, not a removal

The obvious failure mode is a guard that quietly disables the assertions everywhere. Forcing the probe to return `true` on this machine:

```
5 tests run: 3 passed, 2 failed     <- both cases execute and fail again
```

So the bodies still run and still assert wherever the filesystem can host the fixture; only the unrepresentable case is skipped.

## Verification

- `cargo nextest run -p tsz-cli -E 'test(file_casing_collision_ts1149_tests)'` — **5/5 passed** (was 3/5)
- `cargo nextest run -p tsz-cli` — 2723/2727, and the 4 remaining failures are exactly the set tracked in `scripts/ci/known-failures.txt`, attributed by name. The lane is now clean of untracked failures.
- `cargo clippy -p tsz-cli --all-targets` — 0 diagnostics
- `python3 scripts/arch/arch_guard.py` — rc=0
- Test-only change; no compiler behaviour touched.

## Provenance
Machine: m4 (macOS, APFS case-insensitive)
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high
