### PR TITLE
fix(checker): TS2309 counts a type-only `export import` alias correctly

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1056,6 +1056,9 @@ path = "tests/ts1203_node_esm_tests.rs"
 name = "ts2309_export_default_conflict_tests"
 path = "tests/ts2309_export_default_conflict_tests.rs"
 [[test]]
+name = "ts2309_import_equals_alias_conflict_tests"
+path = "tests/ts2309_import_equals_alias_conflict_tests.rs"
+[[test]]
 name = "noimplicitany_ambient_member_surface_tests"
 path = "tests/noimplicitany_ambient_member_surface_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/declarations/import/core/module_exports.rs
+++ b/crates/tsz-checker/src/declarations/import/core/module_exports.rs
@@ -120,6 +120,17 @@ impl<'a> CheckerState<'a> {
         {
             return false;
         }
+        // `export import a = x.c;` parses as an EXPORT_DECLARATION whose
+        // clause is the inner IMPORT_EQUALS_DECLARATION (parser's
+        // `parse_export_import_equals`). It counts as an "other exported
+        // element" only when the aliased entity has value meaning — an alias
+        // that resolves purely to a type (e.g. `x.c` naming an interface)
+        // carries no runtime export. Verified against tsc 7.0.2: aliasing an
+        // interface is clean alongside `export =`; aliasing a class (or any
+        // other value) still reports TS2309.
+        if clause_node.kind == syntax_kind_ext::IMPORT_EQUALS_DECLARATION {
+            return self.import_equals_declaration_has_value_meaning(export_data.export_clause);
+        }
         if clause_node.kind != syntax_kind_ext::NAMED_EXPORTS {
             return true;
         }

--- a/crates/tsz-checker/src/declarations/import/equals.rs
+++ b/crates/tsz-checker/src/declarations/import/equals.rs
@@ -79,6 +79,101 @@ impl<'a> CheckerState<'a> {
         false
     }
 
+    /// The bitwise-OR of flags on the alias-resolved target symbol of an
+    /// `import X = <entity-name>` / `import X = require(...)` declaration,
+    /// plus that symbol's declaration list. Shared by the TS2309/TS2440
+    /// value-meaning check and TS1288's pure-type-vs-value classification.
+    fn import_equals_resolved_target_flags(&self, stmt_idx: NodeIndex) -> (u32, Vec<NodeIndex>) {
+        let mut resolved_flags = 0u32;
+        let mut resolved_decls = Vec::new();
+
+        let Some(target_node) = self
+            .ctx
+            .arena
+            .get(stmt_idx)
+            .and_then(|node| self.ctx.arena.get_import_decl(node))
+            .map(|import_decl| import_decl.module_specifier)
+        else {
+            return (resolved_flags, resolved_decls);
+        };
+
+        let target_sym_id_opt = if let Some(node) = self.ctx.arena.get(target_node) {
+            if node.kind == tsz_scanner::SyntaxKind::Identifier as u16 {
+                self.resolve_identifier_symbol(target_node)
+            } else if node.kind == tsz_parser::parser::syntax_kind_ext::QUALIFIED_NAME {
+                // For qualified names like A.B.C, we need to resolve the whole chain
+                self.resolve_qualified_symbol(target_node)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        if let Some(target_sym_id) = target_sym_id_opt {
+            let mut visited = AliasCycleTracker::new();
+            if let Some(resolved_id) = self.resolve_alias_symbol(target_sym_id, &mut visited)
+                && let Some(resolved_sym) = self
+                    .ctx
+                    .binder
+                    .get_symbol_with_libs(resolved_id, &self.get_lib_binders())
+            {
+                resolved_flags = resolved_sym.flags;
+                resolved_decls = resolved_sym.declarations.clone();
+            }
+        }
+
+        (resolved_flags, resolved_decls)
+    }
+
+    /// Whether an `import X = <entity-name>` / `import X = require(...)`
+    /// declaration's resolved target has runtime value semantics, as opposed
+    /// to being purely a type (an interface, type alias, or an
+    /// uninstantiated/type-only namespace).
+    ///
+    /// Shared by TS2440 (import conflicts with a local value declaration) and
+    /// the TS2309 "other exported element" gate for `export import` aliases
+    /// (`check_export_assignment` in `core/module_exports.rs`): both need the
+    /// same answer to "does this alias carry a runtime export."
+    pub(crate) fn import_equals_declaration_has_value_meaning(&self, stmt_idx: NodeIndex) -> bool {
+        let (resolved_flags, resolved_decls) = self.import_equals_resolved_target_flags(stmt_idx);
+
+        let mut has_value = (resolved_flags & tsz_binder::symbol_flags::VALUE) != 0;
+        if has_value
+            && (resolved_flags & tsz_binder::symbol_flags::VALUE_MODULE) != 0
+            && (resolved_flags
+                & (tsz_binder::symbol_flags::VALUE & !tsz_binder::symbol_flags::VALUE_MODULE))
+                == 0
+        {
+            let mut any_instantiated = false;
+            for decl_idx in &resolved_decls {
+                if let Some(decl_node) = self.ctx.arena.get(*decl_idx) {
+                    if decl_node.kind == tsz_parser::parser::syntax_kind_ext::MODULE_DECLARATION {
+                        if self.is_namespace_declaration_instantiated(*decl_idx) {
+                            any_instantiated = true;
+                            break;
+                        }
+                    } else {
+                        any_instantiated = true;
+                        break;
+                    }
+                }
+            }
+            has_value = any_instantiated;
+        }
+        if !has_value
+            && let Some(target_node) = self
+                .ctx
+                .arena
+                .get(stmt_idx)
+                .and_then(|node| self.ctx.arena.get_import_decl(node))
+                .map(|import_decl| import_decl.module_specifier)
+        {
+            has_value = self.import_equals_target_has_exported_value(target_node);
+        }
+        has_value
+    }
+
     pub(crate) fn check_import_equals_declaration(&mut self, stmt_idx: NodeIndex) {
         use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
         use crate::state_checking::is_strict_mode_reserved_name;
@@ -364,77 +459,7 @@ impl<'a> CheckerState<'a> {
 
         // Resolve the import alias target to determine if it has Value semantics.
         // This is needed for both TS2440 and TS2437 checks.
-        let mut resolved_flags = 0u32;
-        let mut resolved_decls = Vec::new();
-
-        if let Some(import_decl) = self.ctx.arena.get_import_decl(
-            self.ctx
-                .arena
-                .get(stmt_idx)
-                .expect("stmt_idx is a valid node index from caller"),
-        ) {
-            let target_node = import_decl.module_specifier;
-            let target_sym_id_opt = if let Some(node) = self.ctx.arena.get(target_node) {
-                if node.kind == tsz_scanner::SyntaxKind::Identifier as u16 {
-                    self.resolve_identifier_symbol(target_node)
-                } else if node.kind == tsz_parser::parser::syntax_kind_ext::QUALIFIED_NAME {
-                    // For qualified names like A.B.C, we need to resolve the whole chain
-                    self.resolve_qualified_symbol(target_node)
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
-
-            if let Some(target_sym_id) = target_sym_id_opt {
-                let mut visited = AliasCycleTracker::new();
-                if let Some(resolved_id) = self.resolve_alias_symbol(target_sym_id, &mut visited)
-                    && let Some(resolved_sym) = self
-                        .ctx
-                        .binder
-                        .get_symbol_with_libs(resolved_id, &self.get_lib_binders())
-                {
-                    resolved_flags = resolved_sym.flags;
-                    resolved_decls = resolved_sym.declarations.clone();
-                }
-            }
-        }
-
-        let mut has_value = (resolved_flags & tsz_binder::symbol_flags::VALUE) != 0;
-        if has_value
-            && (resolved_flags & tsz_binder::symbol_flags::VALUE_MODULE) != 0
-            && (resolved_flags
-                & (tsz_binder::symbol_flags::VALUE & !tsz_binder::symbol_flags::VALUE_MODULE))
-                == 0
-        {
-            let mut any_instantiated = false;
-            for decl_idx in &resolved_decls {
-                if let Some(decl_node) = self.ctx.arena.get(*decl_idx) {
-                    if decl_node.kind == tsz_parser::parser::syntax_kind_ext::MODULE_DECLARATION {
-                        if self.is_namespace_declaration_instantiated(*decl_idx) {
-                            any_instantiated = true;
-                            break;
-                        }
-                    } else {
-                        any_instantiated = true;
-                        break;
-                    }
-                }
-            }
-            has_value = any_instantiated;
-        }
-        if !has_value
-            && let Some(import_decl) = self.ctx.arena.get_import_decl(
-                self.ctx
-                    .arena
-                    .get(stmt_idx)
-                    .expect("stmt_idx is a valid node index from caller"),
-            )
-        {
-            has_value = self.import_equals_target_has_exported_value(import_decl.module_specifier);
-        }
-        let import_has_value = has_value;
+        let import_has_value = self.import_equals_declaration_has_value_meaning(stmt_idx);
 
         // Check for TS2440: Import declaration conflicts with local declaration
         // This error is specific to ImportEqualsDeclaration (not ES6 imports).
@@ -736,6 +761,7 @@ impl<'a> CheckerState<'a> {
                     | tsz_binder::symbol_flags::CLASS
                     | tsz_binder::symbol_flags::ENUM
                     | tsz_binder::symbol_flags::NAMESPACE;
+                let (resolved_flags, _) = self.import_equals_resolved_target_flags(stmt_idx);
                 if (resolved_flags & pure_type_flags) != 0 && (resolved_flags & value_flags) == 0 {
                     self.error_at_node(
                         stmt_idx,

--- a/crates/tsz-checker/tests/ts2309_import_equals_alias_conflict_tests.rs
+++ b/crates/tsz-checker/tests/ts2309_import_equals_alias_conflict_tests.rs
@@ -1,0 +1,145 @@
+//! TS2309 ("An export assignment cannot be used in a module with other
+//! exported elements") for `export import a = <entity-name>;` mixed with
+//! `export = x;`.
+//!
+//! Structural rule (verified against `typescript@7.0.2`): an `export import`
+//! alias counts as an "other exported element" for the TS2309 conflict only
+//! when the aliased entity has value meaning. An alias that resolves purely
+//! to a type (an interface, or a namespace with no value members) carries no
+//! runtime export and does not conflict with `export =` — exactly like a
+//! directly-exported `interface`/`type` alias is excluded from this same
+//! check, while still counting when routed through a named `export { X }`
+//! clause elsewhere in the checker. `check_export_assignment`
+//! (`crates/tsz-checker/src/declarations/import/core/module_exports.rs`) is
+//! the owning check for both the ambient `declare module` body and the
+//! ordinary top-level module path (it is called from both
+//! `check_module_body` and the source-file checker).
+//!
+//! Binder names are varied across rows so the check keys off structure, not a
+//! fixed identifier.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source(source, "test.ts", CheckerOptions::default())
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Negative: a type-only `export import` alias does not count.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn export_import_alias_of_interface_in_ambient_module_does_not_emit_ts2309() {
+    let src = concat!(
+        "declare module \"m\" {\n",
+        "    namespace x {\n",
+        "        interface c {}\n",
+        "    }\n",
+        "    export import a = x.c;\n",
+        "    export = x;\n",
+        "}\n",
+    );
+    let got = codes(src);
+    assert!(
+        !got.contains(&2309),
+        "a type-only `export import` alias of an interface must NOT emit TS2309, got: {got:?}"
+    );
+}
+
+#[test]
+fn export_import_alias_of_interface_at_top_level_does_not_emit_ts2309() {
+    let src = concat!(
+        "namespace outerNs {\n",
+        "    export interface Member {}\n",
+        "}\n",
+        "export import aliasName = outerNs.Member;\n",
+        "export = outerNs;\n",
+    );
+    let got = codes(src);
+    assert!(
+        !got.contains(&2309),
+        "a type-only `export import` alias at top level must NOT emit TS2309, got: {got:?}"
+    );
+}
+
+#[test]
+fn export_import_alias_of_interface_with_renamed_binders_does_not_emit_ts2309() {
+    // Same structure as the ambient case, with every binder renamed, to prove
+    // the check is structural and not keyed on a specific identifier.
+    let src = concat!(
+        "declare module \"pkg\" {\n",
+        "    namespace zeta {\n",
+        "        interface Shape {}\n",
+        "    }\n",
+        "    export import shapeAlias = zeta.Shape;\n",
+        "    export = zeta;\n",
+        "}\n",
+    );
+    let got = codes(src);
+    assert!(
+        !got.contains(&2309),
+        "a renamed type-only `export import` alias must NOT emit TS2309, got: {got:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Positive controls: a value-meaning `export import` alias still conflicts.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn export_import_alias_of_class_in_ambient_module_emits_ts2309() {
+    let src = concat!(
+        "declare module \"m\" {\n",
+        "    namespace x {\n",
+        "        class c {}\n",
+        "    }\n",
+        "    export import a = x.c;\n",
+        "    export = x;\n",
+        "}\n",
+    );
+    let got = codes(src);
+    assert!(
+        got.contains(&2309),
+        "an `export import` alias of a class (a value) must still emit TS2309, got: {got:?}"
+    );
+}
+
+#[test]
+fn export_import_alias_of_class_at_top_level_emits_ts2309() {
+    let src = concat!(
+        "namespace outerNs {\n",
+        "    export class Member {}\n",
+        "}\n",
+        "export import aliasName = outerNs.Member;\n",
+        "export = outerNs;\n",
+    );
+    let got = codes(src);
+    assert!(
+        got.contains(&2309),
+        "an `export import` alias of a class at top level must still emit TS2309, got: {got:?}"
+    );
+}
+
+#[test]
+fn export_import_alias_of_namespace_with_value_member_emits_ts2309() {
+    // A namespace that itself has a value member (not just types) is not
+    // type-only, so aliasing it still conflicts with `export =`.
+    let src = concat!(
+        "namespace outerNs {\n",
+        "    export namespace inner {\n",
+        "        export const v = 1;\n",
+        "    }\n",
+        "}\n",
+        "export import aliasName = outerNs.inner;\n",
+        "export = outerNs;\n",
+    );
+    let got = codes(src);
+    assert!(
+        got.contains(&2309),
+        "an `export import` alias of a value-bearing namespace must still emit TS2309, got: {got:?}"
+    );
+}


### PR DESCRIPTION
`export import a = x.c;` parses as an `EXPORT_DECLARATION` whose clause is the inner `IMPORT_EQUALS_DECLARATION` (parser's `parse_export_import_equals`). `check_export_assignment`'s `export_declaration_has_exported_elements` (`crates/tsz-checker/src/declarations/import/core/module_exports.rs`) already excluded direct `export interface`/`export type` clauses from the TS2309 "other exported elements" conflict, but had no case for an `IMPORT_EQUALS_DECLARATION` clause — it fell through to `return true` unconditionally, so *any* `export import` alias counted, even one aliasing a pure type with no runtime export:

```ts
declare module "m" {
    namespace x {
        interface c {}
    }
    export import a = x.c;   // pure-type alias
    export = x;
}
```
tsc: clean. tsz (before this PR): spurious `TS2309`.

**Structural rule** (verified against `typescript@7.0.2` with 9 hand-built oracle probes): when an `export import` alias's resolved target has no value meaning (e.g. an interface, or an uninstantiated/type-only namespace), tsc does **not** count it as an "other exported element" for the `export =` conflict; tsz now does the same through the checker's `check_export_assignment` (owner layer: checker, `declarations/import/core/module_exports.rs`). When the target *does* have value meaning (a class, a value-bearing namespace, etc.), TS2309 still fires — detection is not disabled, just correctly scoped.

Reuses TS2440's already-correct "does this import-equals target have value meaning" computation rather than re-deriving it: extracted into `import_equals_declaration_has_value_meaning` (`declarations/import/equals.rs`), now shared by TS2440 (conflicts with local declaration), TS1288 (verbatimModuleSyntax pure-type alias), and this TS2309 check.

**Adjacent-case matrix** (6 new unit tests, `crates/tsz-checker/tests/ts2309_import_equals_alias_conflict_tests.rs`):
- type-only alias inside an ambient `declare module` body → clean (the witness)
- type-only alias at ordinary top-level (non-ambient) → clean
- type-only alias with renamed binders → clean (structural, not identifier-keyed)
- value alias (class) inside ambient module → still `TS2309`
- value alias (class) at top level → still `TS2309`
- alias of a namespace with a value member → still `TS2309`

**Found but out of scope**: oracle-verifying this also surfaced that a *directly*-exported `export interface I {}` / `export type T = ...;` (not via `export { X }`) combined with `export =` **does** fire `TS2309` on real tsc, but tsz's existing code unconditionally excludes `INTERFACE_DECLARATION`/`TYPE_ALIAS_DECLARATION` clause kinds and emits nothing. That's a distinct, pre-existing gap in the same function (not the `export import`-alias bug this PR fixes) — left unfixed and posted as a NOTE on the coordination board (#15994) for the next agent.

## Goal
Goal: hold

## Verification
- New: `cargo test -p tsz-checker --test ts2309_import_equals_alias_conflict_tests` → 6/6 pass.
- Targeted: `./scripts/conformance/conformance.sh run --filter importDeclWithExportModifierAndExportAssignmentInAmbientContext` → 1/1 pass (was 0/1).
- Full `./scripts/conformance/conformance.sh snapshot --workers 12 --force` → 11555/12043 (95.9%); `python3 scripts/conformance/query-conformance.py --code TS2309` shows **0 extra** anywhere in the corpus (no regressions from this change). Snapshot/baseline/detail artifacts reverted before commit — this PR doesn't touch them.
- No regressions in existing suites that touch the same code paths: `ts2309_export_default_conflict_tests` (13/13), `ts2300_tests` (71/71), `ts1203_node_esm_tests` (14/14), `imported_companion_value_type_tests` (6/6), `isolated_modules_export_default_tests` (5/5), and `--lib ts2440` (23/23, covers TS2440/TS1288's shared new helper). `commonjs_module_export_alias_tests::test_module_exports_forward_read_reports_ts2565` fails both with and without this diff (confirmed via `git stash`) — pre-existing on `main`, unrelated.
- `cargo fmt --check -p tsz-checker` clean. `cargo clippy -p tsz-checker --all-targets` clean. `python3 scripts/arch/arch_guard.py` passed.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNmy9iNvG1nEpRiy6x1san)_