### PR TITLE
fix(resolver): node_modules JS require falls back to any, not empty {}

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -203,7 +203,15 @@ pub(super) fn collect_diagnostics(
     cache: Option<&mut CompilationCache>,
     type_cache_output: &std::sync::Mutex<FxHashMap<PathBuf, TypeCache>>,
 ) -> CollectDiagnosticsResult {
-    collect_diagnostics_with_source_resolutions(input, cache, type_cache_output, None, None, None)
+    collect_diagnostics_with_source_resolutions(
+        input,
+        cache,
+        type_cache_output,
+        None,
+        None,
+        None,
+        None,
+    )
 }
 
 pub(super) fn collect_diagnostics_with_source_resolutions(
@@ -215,6 +223,7 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
     >,
     source_module_resolution_misses: Option<&FxHashSet<SourceModuleResolutionKey>>,
     explicit_root_paths: Option<&FxHashSet<PathBuf>>,
+    depth_skipped_js_paths: Option<&FxHashSet<PathBuf>>,
 ) -> CollectDiagnosticsResult {
     let &CollectDiagnosticsInput {
         program,
@@ -331,6 +340,7 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
         program_file_index: &program_file_index,
         program_paths: &program_paths,
         root_file_paths: explicit_root_paths,
+        depth_skipped_js_paths,
         package_redirects: &package_redirects,
         resolution_cache: &mut resolution_cache,
     });

--- a/crates/tsz-cli/src/driver/core_diagnostics.rs
+++ b/crates/tsz-cli/src/driver/core_diagnostics.rs
@@ -738,6 +738,7 @@ fn compile_inner_impl(
         module_resolution_misses,
         type_reference_errors,
         resolution_mode_errors,
+        depth_skipped_js_paths,
     } = {
         read_source_files(
             &file_paths,
@@ -1154,6 +1155,7 @@ fn compile_inner_impl(
         Some(&module_resolutions),
         Some(&module_resolution_misses),
         Some(&explicit_root_paths),
+        Some(&depth_skipped_js_paths),
     );
     let mut diagnostics: Vec<Diagnostic> = collected.diagnostics;
     let check_duration = collect_diagnostics_start.elapsed();

--- a/crates/tsz-cli/src/driver/source_resolution_setup.rs
+++ b/crates/tsz-cli/src/driver/source_resolution_setup.rs
@@ -45,6 +45,15 @@ pub(super) struct SourceResolutionSetupInput<'a> {
     /// the caller has no such distinction available (falls back to the old
     /// behavior of never treating a resolution as root-explicit).
     pub(super) root_file_paths: Option<&'a FxHashSet<PathBuf>>,
+    /// Canonical paths of `node_modules` JS files the `maxNodeModuleJsDepth`
+    /// BFS gate skipped reading (see `sources::SourceReadResult`). A
+    /// specifier that resolves to one of these paths must not be mapped into
+    /// `resolved_module_paths`: the target file is a real program entry but
+    /// has a permanently empty statement list, so treating it as a normal
+    /// resolved target makes the checker synthesize an empty CJS export
+    /// surface instead of falling back to `any` the way tsc does for a JS
+    /// module it never inspected (#16934).
+    pub(super) depth_skipped_js_paths: Option<&'a FxHashSet<PathBuf>>,
     pub(super) package_redirects: &'a FxHashMap<PathBuf, PathBuf>,
     pub(super) resolution_cache: &'a mut ModuleResolutionCache,
 }
@@ -102,6 +111,7 @@ pub(super) fn prepare_source_resolution_setup(
         program_file_index,
         program_paths,
         root_file_paths,
+        depth_skipped_js_paths,
         package_redirects,
         resolution_cache,
     } = input;
@@ -352,19 +362,33 @@ pub(super) fn prepare_source_resolution_setup(
 
                 if let Some((target_idx, resolved_using_ts_extension)) = discovered_target {
                     resolved_module_specifiers.insert((file_idx, specifier.clone()));
-                    resolved_module_paths.insert((file_idx, specifier.clone()), target_idx);
-                    resolved_module_request_paths.insert(
-                        (
-                            file_idx,
-                            specifier.clone(),
-                            request_mode_key,
-                            request_kind_key,
-                        ),
-                        target_idx,
-                    );
-                    if resolved_using_ts_extension {
-                        resolved_module_ts_extension_flags
-                            .insert((file_idx, specifier.clone()), true);
+                    // A depth-skipped `node_modules` JS stub (see the
+                    // `untyped_module_paths` block above) is a real program
+                    // file but was never read, so it must not be trusted as a
+                    // normal resolved target: mapping it into
+                    // `resolved_module_paths` would let the checker
+                    // synthesize an empty CJS export surface for it instead
+                    // of falling back to `any` (#16934). Leave the specifier
+                    // resolved (no TS2307) but no target index.
+                    let is_depth_skipped_stub = discovered.is_some_and(|d| {
+                        depth_skipped_js_paths
+                            .is_some_and(|skipped| skipped.contains(&d.canonical_path))
+                    });
+                    if !is_depth_skipped_stub {
+                        resolved_module_paths.insert((file_idx, specifier.clone()), target_idx);
+                        resolved_module_request_paths.insert(
+                            (
+                                file_idx,
+                                specifier.clone(),
+                                request_mode_key,
+                                request_kind_key,
+                            ),
+                            target_idx,
+                        );
+                        if resolved_using_ts_extension {
+                            resolved_module_ts_extension_flags
+                                .insert((file_idx, specifier.clone()), true);
+                        }
                     }
                     continue;
                 }
@@ -459,11 +483,19 @@ pub(super) fn prepare_source_resolution_setup(
                         } else {
                             canonical
                         };
-                        if let Some(target_idx) = program_file_index.get_with_symlink_fallback(
-                            &canonical,
-                            resolved_path,
-                            options,
-                        ) {
+                        // See the `discovered_target` arm above: a depth-skipped
+                        // `node_modules` JS stub resolves to a real `target_idx`
+                        // but was never read, so it must not be mapped as a
+                        // normal target (#16934).
+                        let is_depth_skipped_stub = depth_skipped_js_paths
+                            .is_some_and(|skipped| skipped.contains(&canonical));
+                        if !is_depth_skipped_stub
+                            && let Some(target_idx) = program_file_index.get_with_symlink_fallback(
+                                &canonical,
+                                resolved_path,
+                                options,
+                            )
+                        {
                             resolved_module_paths.insert((file_idx, specifier.clone()), target_idx);
                             resolved_module_request_paths.insert(
                                 (

--- a/crates/tsz-cli/src/driver/sources.rs
+++ b/crates/tsz-cli/src/driver/sources.rs
@@ -273,6 +273,16 @@ pub(super) struct SourceReadResult {
     /// TS1453: Invalid `resolution-mode` values in `/// <reference types="..." />` directives.
     /// Tuples of (`file_path`, `byte_offset`, `span_length`).
     pub(super) resolution_mode_errors: Vec<(PathBuf, usize, usize)>,
+    /// Canonical paths of non-root `node_modules` JS files that the
+    /// `maxNodeModuleJsDepth` BFS gate skipped (`BatchAction::SkipJs`): the
+    /// path is registered as a real program file (a real `target_idx` exists)
+    /// but its body was never read, so it permanently has an empty statement
+    /// list. A resolution that lands on one of these paths must not be
+    /// treated as a normal same-program target downstream — see #16934,
+    /// where mapping a `require()` specifier to a depth-skipped stub let the
+    /// checker synthesize an empty CJS export surface (`{}`) instead of
+    /// falling back to `any`, unlike the `noImplicitAny`/TS7016 sibling case.
+    pub(super) depth_skipped_js_paths: FxHashSet<PathBuf>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -687,6 +697,7 @@ pub(super) fn read_source_files(
     let mut module_resolver = ModuleResolver::new(options);
     let mut type_reference_errors = Vec::new();
     let mut resolution_mode_errors = Vec::new();
+    let mut depth_skipped_js_paths: FxHashSet<PathBuf> = FxHashSet::default();
     let use_cache = cache.is_some() && changed_paths.is_some();
 
     // PERF: cache `normalize_resolved_path` results for the BFS lifetime.
@@ -815,6 +826,15 @@ pub(super) fn read_source_files(
                         .expect("cached arm only fires when dependencies entry exists");
                     dependencies.insert(path.clone(), cached_deps.clone());
                     sources.insert(path.clone(), (None, false, false));
+                    // A depth-skipped stub can itself be reused from a prior
+                    // incremental build's bind cache (it was still a real,
+                    // if permanently empty, program file) — reclassify it here
+                    // too so a cached rebuild does not lose this signal.
+                    if !root_paths.contains(&path)
+                        && should_skip_js_in_node_modules(&path, options.max_node_module_js_depth)
+                    {
+                        depth_skipped_js_paths.insert(path.clone());
+                    }
                     if let Some(cached_bundle_deps) = cache.outfile_bundle_dependencies.get(&path) {
                         outfile_bundle_paths.extend(cached_bundle_deps.iter().cloned());
                     }
@@ -829,6 +849,7 @@ pub(super) fn read_source_files(
                 }
                 BatchAction::SkipJs => {
                     sources.insert(path.clone(), (None, false, false));
+                    depth_skipped_js_paths.insert(path.clone());
                     continue;
                 }
                 BatchAction::Read => {}
@@ -1151,6 +1172,7 @@ pub(super) fn read_source_files(
         module_resolution_misses,
         type_reference_errors,
         resolution_mode_errors,
+        depth_skipped_js_paths,
     })
 }
 

--- a/crates/tsz-cli/src/driver/sources/tests.rs
+++ b/crates/tsz-cli/src/driver/sources/tests.rs
@@ -378,6 +378,47 @@ fn read_source_files_skips_body_of_non_root_js_under_node_modules() {
         entry.text.is_none(),
         "non-root JS file beyond maxNodeModuleJsDepth must stay skipped"
     );
+    assert!(
+        result.depth_skipped_js_paths.contains(&entry.path),
+        "depth-skipped stub must be recorded so downstream CJS export \
+         inference does not treat it as a normal resolved target (#16934)"
+    );
+}
+
+#[test]
+fn read_source_files_root_js_under_node_modules_is_not_depth_skipped() {
+    // The explicit-root counterpart: a root JS file under `node_modules`
+    // (see `read_source_files_reads_body_of_explicit_root_js_under_node_modules`
+    // above) has its body read and must never land in
+    // `depth_skipped_js_paths`, even though its path shape would otherwise
+    // match `should_skip_js_in_node_modules`.
+    let dir = tempdir().unwrap();
+    let root_js = dir.path().join("node_modules/untyped/index.js");
+    std::fs::create_dir_all(root_js.parent().unwrap()).unwrap();
+    std::fs::write(&root_js, "module.exports = { hello: function() {} };\n").unwrap();
+
+    let options = ResolvedCompilerOptions {
+        allow_js: true,
+        checker: tsz::checker::context::CheckerOptions {
+            allow_js: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let result = read_source_files(
+        std::slice::from_ref(&root_js),
+        dir.path(),
+        &options,
+        None,
+        None,
+    )
+    .expect("read source files");
+
+    assert!(
+        !result.depth_skipped_js_paths.contains(&root_js),
+        "an explicit program root must never be treated as depth-skipped"
+    );
 }
 
 #[test]

--- a/crates/tsz-cli/tests/driver_tests_parts/part_02.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_02.rs
@@ -194,6 +194,147 @@ fn compile_allow_js_passthrough_emits_root_node_modules_js() {
 }
 
 #[test]
+fn compile_untyped_node_modules_js_require_property_access_falls_back_to_any() {
+    // A non-root `node_modules` JS module reached only via `require()` stays
+    // beyond the default `maxNodeModuleJsDepth` (0), so tsc never inspects its
+    // body and types the import as `any` — a bare `require()` and a property
+    // access on it are both clean. Before this fix, tsz still registered the
+    // depth-skipped file as a real resolved target (with a permanently empty
+    // statement list) and synthesized an empty `{}` CJS export surface for
+    // it, producing a spurious TS2339 on `u.hello()` where tsc is clean. See
+    // #16934.
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "compilerOptions": {
+            "allowJs": true,
+            "noImplicitAny": false,
+            "module": "node16",
+            "target": "es2020",
+            "noEmit": true
+          },
+          "files": ["main.ts"]
+        }"#,
+    );
+    write_file(
+        &base.join("node_modules/untyped/index.js"),
+        "module.exports = { hello: function () { return 1; } };\n",
+    );
+    write_file(
+        &base.join("main.ts"),
+        "import u = require(\"untyped\");\nu.hello();\n",
+    );
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+
+    assert!(
+        result.diagnostics.is_empty(),
+        "depth-skipped node_modules JS require must fall back to `any`, got: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn compile_untyped_node_modules_js_require_no_implicit_any_still_reports_ts7016() {
+    // Negative control for the fix above: under `noImplicitAny: true`, tsc
+    // (and tsz, both before and after this fix) reports TS7016 for the same
+    // depth-skipped require — the `any` fallback must not silently swallow
+    // the real diagnostic.
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "compilerOptions": {
+            "allowJs": true,
+            "noImplicitAny": true,
+            "module": "node16",
+            "target": "es2020",
+            "noEmit": true
+          },
+          "files": ["main.ts"]
+        }"#,
+    );
+    write_file(
+        &base.join("node_modules/untyped/index.js"),
+        "module.exports = { hello: function () { return 1; } };\n",
+    );
+    write_file(
+        &base.join("main.ts"),
+        "import u = require(\"untyped\");\nu.hello();\n",
+    );
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+
+    assert!(
+        result.diagnostics.iter().any(|diag| diag.code
+            == diagnostic_codes::COULD_NOT_FIND_A_DECLARATION_FILE_FOR_MODULE_IMPLICITLY_HAS_AN_ANY_TYPE),
+        "noImplicitAny must still surface TS7016 for the depth-skipped require, got: {:?}",
+        result.diagnostics
+    );
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .all(|diag| diag.code != diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE),
+        "TS7016 must not be joined by a spurious TS2339, got: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn compile_node_modules_js_require_within_max_depth_infers_real_export_shape() {
+    // Positive control: raising `maxNodeModuleJsDepth` to admit the file for
+    // real makes tsz read its body and infer the actual CJS export shape
+    // (not `any`), matching tsc. `hello()` genuinely returns `number`, so
+    // assigning it to a `string` must still report TS2322 — proving the fix
+    // above did not widen this case to `any` as well.
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "compilerOptions": {
+            "allowJs": true,
+            "noImplicitAny": false,
+            "module": "node16",
+            "target": "es2020",
+            "maxNodeModuleJsDepth": 1,
+            "noEmit": true
+          },
+          "files": ["main.ts"]
+        }"#,
+    );
+    write_file(
+        &base.join("node_modules/untyped/index.js"),
+        "module.exports = { hello: function () { return 1; } };\n",
+    );
+    write_file(
+        &base.join("main.ts"),
+        "import u = require(\"untyped\");\nconst x: string = u.hello();\n",
+    );
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .any(|diag| diag.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "raising maxNodeModuleJsDepth must infer the real export shape, got: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
 fn compile_checked_js_prototype_optional_chain_method_call_suppresses_ts2531() {
     let temp = TempDir::new().expect("temp dir");
     let base = &temp.path;


### PR DESCRIPTION
When `maxNodeModuleJsDepth` skips a non-root `node_modules` JS file's body, the file still gets a real program `target_idx` — the driver only ever left its statement list permanently empty. Resolving a `require()`/import specifier to that stub let the checker synthesize an empty CJS export surface (`{}`) instead of falling back to `any` the way tsc does for a JS module it never inspects, so `u.hello()` reported a spurious `TS2339` where tsc is clean (property access on `typeof import("untyped")`).

**Structural rule**: when a specifier resolves to a `node_modules` JS file that `maxNodeModuleJsDepth` skipped reading, the driver must not map it into `resolved_module_paths` — mirroring what already happens for the `noImplicitAny`-driven `TS7016` case, where an unmapped target lets the checker's own `target_idx.is_some()` fallback in `build_typeof_import_namespace_type` return `any`. Owner layer is the CLI driver's module-resolution wiring (`crates/tsz-cli/src/driver/sources.rs`, `source_resolution_setup.rs`), not the checker — the checker's `ANY` fallback was already correct and simply unreachable.

`sources::read_source_files` now records which canonical paths its BFS skipped (`depth_skipped_js_paths`), threaded through `SourceResolutionSetupInput` into both resolution sites in `source_resolution_setup.rs` (the source-discovery `discovered_target` arm and the direct `module_resolver.lookup` arm) so neither maps a depth-skipped stub into `resolved_module_paths`, while still marking the specifier resolved (no spurious `TS2307`).

Closes #16934.

## Goal
Goal: hold

## Adjacent cases covered
- Bare `require()` with no property access stays clean (both before and after this fix).
- An explicit program root under `node_modules` (#16926/#16936) is never treated as depth-skipped — new unit test `read_source_files_root_js_under_node_modules_is_not_depth_skipped`.
- `noImplicitAny: true` still reports `TS7016` without a joined `TS2339` (negative control) — new test `compile_untyped_node_modules_js_require_no_implicit_any_still_reports_ts7016`.
- Raising `maxNodeModuleJsDepth` past the file's depth reads the real body and infers the genuine export shape (`hello()` really returns `number`, proven via a `TS2322` positive control) — new test `compile_node_modules_js_require_within_max_depth_infers_real_export_shape` — so the fix does not widen the admitted case to `any` as well.
- Primary repro fixed — new test `compile_untyped_node_modules_js_require_property_access_falls_back_to_any`.

## Verification
- `cargo test -p tsz-cli --lib` (touched areas): `node_modules` (51/51), `js_export` (5/5), `commonjs` (21/21), `depth_skipped`/new tests (all passing).
- Full `cargo test -p tsz-cli --lib`: 1777 passed / 18 failed. All 18 failures reproduce identically on `main` before this change (verified via `git stash` + targeted re-run) — 4 are the known pre-existing `#15983`/`#15338` unit-test family (unrelated: cross-file namespace merge, incremental TS5033, cross-file operand aliases, TS7056 declaration emit), 14 are `tsc_compat_tests` comparing CLI text output against a pinned oracle binary whose installed version (6.0.2) doesn't match this container's npm-installed oracle (7.0.2) — an environment mismatch, not a regression from this diff.
- `cargo clippy -p tsz-cli --lib --tests` (workspace lints, warnings denied): clean.
- `cargo fmt -p tsz-cli -- --check`: clean.
- Diff touches only `crates/tsz-cli` driver-layer production code (module resolution wiring) plus tests — no `crates/tsz-checker`/`tsz-solver`/`tsz-emitter` production paths, so conformance/emit/fourslash counts are not expected to move; broader `conformance.sh`/`compare-to-parent.sh` two-sided run not executed this session (disk-constrained container, ~38GB total allowance) — owed if a reviewer wants the belt-and-suspenders confirmation, but the change is scoped to a driver-only resolution-mapping decision with direct repro + adjacent-case coverage above.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_01MYaxPb1TjjpndfYptEUY55)_