### PR TITLE
fix(checker): assignment-RHS `this` no longer inherits enclosing class type

### DIFF
--- a/crates/tsz-checker/src/dispatch/this.rs
+++ b/crates/tsz-checker/src/dispatch/this.rs
@@ -203,8 +203,10 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                 TypeId::ANY
             } else {
                 // Fall through to TS2683 / TS7041 checks below
-                // Suppress if the nested function has an explicit `this` parameter
-                // or a contextual `this` type from a parent type annotation
+                // Suppress if the nested function has an explicit `this` parameter,
+                // a contextual `this` type from a parent type annotation, or is
+                // itself the direct RHS of an assignment (`x.y = function () {}`
+                // does not warn, even though `this` still resolves to `any` below).
                 if self.checker.ctx.no_implicit_this()
                     && !self
                         .checker
@@ -212,6 +214,7 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                     && !self
                         .checker
                         .enclosing_function_has_contextual_this_type(idx)
+                    && !self.checker.enclosing_function_is_assignment_rhs(idx)
                 {
                     use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
                     self.checker.error_at_node(
@@ -245,8 +248,8 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
             // function's `this` has no declared receiver either way); only
             // the *warning* about that implicit `any` is gated by the flag.
             // Suppress the warning if the enclosing function has an explicit
-            // `this` parameter or a contextual `this` type from a parent
-            // type annotation.
+            // `this` parameter, a contextual `this` type from a parent type
+            // annotation, or is itself the direct RHS of an assignment.
             if self.checker.ctx.no_implicit_this()
                 && !self
                     .checker
@@ -254,6 +257,7 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                 && !self
                     .checker
                     .enclosing_function_has_contextual_this_type(idx)
+                && !self.checker.enclosing_function_is_assignment_rhs(idx)
             {
                 use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
                 self.checker.error_at_node(

--- a/crates/tsz-checker/src/symbols/scope_finder.rs
+++ b/crates/tsz-checker/src/symbols/scope_finder.rs
@@ -299,30 +299,6 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        if fn_node.kind == FUNCTION_EXPRESSION {
-            let mut current = enclosing_fn;
-            for _ in 0..3 {
-                let Some(parent) = self.ctx.arena.parent_of(current) else {
-                    break;
-                };
-                let Some(parent_node) = self.ctx.arena.get(parent) else {
-                    break;
-                };
-                if parent_node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION {
-                    current = parent;
-                    continue;
-                }
-                if parent_node.kind == syntax_kind_ext::BINARY_EXPRESSION
-                    && let Some(binary) = self.ctx.arena.get_binary_expr(parent_node)
-                    && binary.right == current
-                    && self.is_assignment_operator(binary.operator_token)
-                {
-                    return false;
-                }
-                break;
-            }
-        }
-
         if self.is_js_file()
             && self
                 .ctx
@@ -344,6 +320,59 @@ impl<'a> CheckerState<'a> {
         // function still creates its own `this` binding unless one of the
         // explicit/contextual receiver checks above already claimed ownership.
         true
+    }
+
+    /// Whether the nearest enclosing non-arrow function *expression* is the
+    /// direct right-hand side of an assignment (`x.y = function () {}`,
+    /// optionally parenthesized), regardless of what `x.y`'s type is.
+    ///
+    /// This is a purely syntactic assignment-target check: tsc does not warn
+    /// about the resulting implicit-`any` `this` in that position (see
+    /// `property_assignment_any_receiver_no_ts2683`), but assignment position
+    /// alone does not establish a contextual `this` TYPE — a real contextual
+    /// receiver still requires `enclosing_function_has_contextual_this_type`
+    /// (e.g. the target actually carries a `this`-parameterized signature).
+    /// Callers must use this only to gate the TS2683 diagnostic, never to
+    /// decide whether the function has its own `this` binding — conflating
+    /// the two previously caused a nested `this.` (e.g.
+    /// `obj.onload = function () { this. }` inside a class method) to
+    /// silently resolve to the *enclosing class's* instance type instead of
+    /// `any`.
+    pub(crate) fn enclosing_function_is_assignment_rhs(&self, idx: NodeIndex) -> bool {
+        use tsz_parser::parser::syntax_kind_ext::FUNCTION_EXPRESSION;
+
+        let Some(enclosing_fn) = self.find_enclosing_non_arrow_function(idx) else {
+            return false;
+        };
+        let Some(fn_node) = self.ctx.arena.get(enclosing_fn) else {
+            return false;
+        };
+        if fn_node.kind != FUNCTION_EXPRESSION {
+            return false;
+        }
+
+        let mut current = enclosing_fn;
+        for _ in 0..3 {
+            let Some(parent) = self.ctx.arena.parent_of(current) else {
+                break;
+            };
+            let Some(parent_node) = self.ctx.arena.get(parent) else {
+                break;
+            };
+            if parent_node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION {
+                current = parent;
+                continue;
+            }
+            if parent_node.kind == syntax_kind_ext::BINARY_EXPRESSION
+                && let Some(binary) = self.ctx.arena.get_binary_expr(parent_node)
+                && binary.right == current
+                && self.is_assignment_operator(binary.operator_token)
+            {
+                return true;
+            }
+            break;
+        }
+        false
     }
 
     /// Find the nearest enclosing class declaration/expression by walking parents.

--- a/crates/tsz-lsp/tests/fourslash_tests_parts/part_02.rs
+++ b/crates/tsz-lsp/tests/fourslash_tests_parts/part_02.rs
@@ -1669,3 +1669,49 @@ fn edit_file_fixes_diagnostic() {
     // Should be clean now
     t.verify_no_errors("test.ts");
 }
+
+#[test]
+fn this_completions_none_inside_property_assigned_function_expression() {
+    // `this` inside a plain (non-arrow) function expression assigned to a
+    // property of an `any`-typed receiver creates its own implicit-`any`
+    // `this` binding — it must NOT inherit the enclosing class's members,
+    // even though the assignment target itself never warns about it (see
+    // `property_assignment_any_receiver_no_ts2683` in ts2683_tests.rs).
+    // Mirrors TypeScript/tests/cases/fourslash/completionListFunctionExpression.ts.
+    let mut t = FourslashTest::new(
+        "
+        class DataHandler {
+            dataArray: Uint8Array;
+            loadData(filename) {
+                var xmlReq = new XMLHttpRequest();
+                xmlReq.open(\"GET\", \"/\" + filename, true);
+                xmlReq.onload = function(xmlEvent) {
+                    this./*this*/;
+                }
+            }
+        }
+    ",
+    );
+    t.completions("this").expect_none();
+}
+
+#[test]
+fn this_completions_present_inside_property_assigned_arrow_function() {
+    // An arrow function does not create its own `this` binding, so the same
+    // assignment shape as above must still show the enclosing class's
+    // members when the callback is an arrow instead of a plain function.
+    let mut t = FourslashTest::new(
+        "
+        class DataHandler {
+            dataArray: Uint8Array;
+            loadData(filename) {
+                var xmlReq = new XMLHttpRequest();
+                xmlReq.onload = (xmlEvent) => {
+                    this./*this*/;
+                }
+            }
+        }
+    ",
+    );
+    t.completions("this").expect_contains("dataArray");
+}


### PR DESCRIPTION
Fixes one of the ROADMAP-tracked "remaining 4" fourslash Hold gaps (`completionListFunctionExpression.ts`).

**Structural rule.** When `this` is read inside a plain (non-arrow) function expression, tsc always gives it its own implicit-`any` binding unless a real contextual receiver is established (explicit `this` parameter, a `this`-parameterized target signature, JSDoc `@this`, etc.) — assignment position alone (`x.y = function () {}`) only suppresses the noisy TS2683 warning, it does not by itself supply a `this` TYPE. tsz did this through `is_this_in_nested_function_without_own_this_binding` (`crates/tsz-checker/src/symbols/scope_finder.rs`), which conflated the two: its assignment-RHS carve-out returned `false` ("does not create its own binding") for *any* `x.y = function () {}`, so `dispatch_this_keyword`'s enclosing-class branch (`crates/tsz-checker/src/dispatch/this.rs`) treated the callback's `this` as still owned by the surrounding class and returned the class instance type instead of `any`.

Reproducible whenever such an assignment sits inside a class method body. `crates/tsz-lsp` completions surfaced it first: `this.` inside `xmlReq.onload = function (e) { this. }` nested in a class method offered the class's own members instead of nothing, diverging from `TypeScript/tests/cases/fourslash/completionListFunctionExpression.ts`.

**Fix.** Extract the assignment-RHS syntactic check into its own predicate, `enclosing_function_is_assignment_rhs`, and use it *only* to gate the TS2683 diagnostic (both call sites in `dispatch/this.rs`) — never to decide whether the function has its own `this` binding. `is_this_in_nested_function_without_own_this_binding` now always reports the true structural fact, so the type-dispatch fallback (`TypeId::ANY`) fires as it should. Downstream consumers that read the same predicate for other purposes (`this_receiver_class_type.rs`, `call_inference.rs`, `error_reporter/properties.rs`) get the correct answer too — this was a shared, single-boolean conflation, not a completions-only bug.

**Adjacent cases.** The new completions regression tests cover the same assignment shape with an arrow function instead (must still see the enclosing class, since arrows don't create their own `this`), confirming the fix is scoped to non-arrow functions only. The existing `ts2683_tests.rs` suite (29 tests) already covers the renamed-binder, explicit-`this`-param, contextual-`this`-type, and JS-constructor-pattern matrix for the diagnostic side and all continue to pass unchanged — including `property_assignment_any_receiver_no_ts2683`, the exact case the fix had to avoid regressing.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts2683_tests` — 29/29 pass (before and after; diagnostic-suppression behavior unchanged).
- `cargo test -p tsz-lsp --lib` — 4080/4080 pass, including 2 new regression tests (`this_completions_none_inside_property_assigned_function_expression`, `this_completions_present_inside_property_assigned_arrow_function`).
- `cargo test -p tsz-checker --lib this_` — 370/370 pass (broad sweep of every `this`-related unit test in the checker, catching the three other call sites of the shared predicate).
- `cargo clippy` + arch-size guard — clean (via pre-commit hook).
- Full conformance/emit/fourslash were not run locally (cold-container budget went to the targeted sweeps above, which directly exercise every call site of the changed predicate); this is a checker-only semantic change with no production diagnostic-shape change confirmed by the unchanged `ts2683_tests.rs` suite, so conformance/emit counts are not expected to move. The nightly lane covers the corpus; happy to re-run `compare-to-parent.sh` if requested before merge.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_012ErDJMfLxjDC7yUtUvMkqW)_