### PR TITLE
fix(checker): untyped node_modules JS require() binds as `any`, not empty typeof import (#16934)

### DIFF
--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -972,9 +972,24 @@ impl<'a> CheckerContext<'a> {
     /// inspects a rendered TS7016 message — and returns `None` for drivers that
     /// do not populate the map (LSP, WASM, unit harness).
     pub fn untyped_module_path_for(&self, specifier: &str) -> Option<&str> {
+        self.untyped_module_path_for_file(self.current_file_idx, specifier)
+    }
+
+    /// Like `untyped_module_path_for`, but resolves the untyped-JS target as
+    /// seen from an arbitrary source file rather than the current one.
+    ///
+    /// Semantic-type queries (`commonjs_module_value_type`) thread the
+    /// importing file index through explicitly, so an untyped-module decision
+    /// made for a cross-file `require()` keys off the file that actually wrote
+    /// the specifier, not whichever file the checker happens to be centered on.
+    pub fn untyped_module_path_for_file(
+        &self,
+        source_file_idx: usize,
+        specifier: &str,
+    ) -> Option<&str> {
         self.untyped_module_paths
             .as_ref()?
-            .get(&(self.current_file_idx, specifier.to_string()))
+            .get(&(source_file_idx, specifier.to_string()))
             .map(String::as_str)
     }
 

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_resolution.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_resolution.rs
@@ -937,6 +937,44 @@ impl<'a> CheckerState<'a> {
             })
             .or_else(|| self.ctx.resolve_import_target(module_name));
 
+        // An untyped JavaScript module — a `node_modules` `.js` file above
+        // `maxNodeModuleJsDepth`, resolvable but deliberately left out of the
+        // type graph — has value type `any` in tsc, whatever CommonJS export
+        // shape its source happens to spell out. The driver marks such a
+        // specifier in `untyped_module_paths` (so `require()` binds and TS2307
+        // stays silent) but does not bind its `module.exports` assignments for
+        // types, so no export surface can be synthesized from it. Without this
+        // gate the checker falls through to an empty `typeof import("mod")` and
+        // reports a spurious TS2339 on every real member — a message strictly
+        // worse than the pre-suppression TS7016 it replaced.
+        //
+        // The surface check is load-bearing. The driver records an
+        // `untyped_module_paths` entry for *every* JS-extension resolution —
+        // including admitted first-party `.js` and `node_modules` JS within
+        // `maxNodeModuleJsDepth` — so the checker's TS2665 augmentation gate
+        // can key on the resolution extension. Those admitted files ARE bound
+        // for types and DO yield a real CommonJS export surface, which must
+        // still be synthesized below; only a JS module marked untyped that
+        // yields no surface (either unresolved to a program file, or resolved
+        // to a depth-excluded file the driver left unbound) is the `any` case.
+        // Keeping the untyped condition (rather than returning `any` for every
+        // shapeless module) preserves the TS2307/error path for genuinely
+        // missing modules.
+        if self
+            .ctx
+            .untyped_module_path_for_file(
+                source_file_idx.unwrap_or(self.ctx.current_file_idx),
+                module_name,
+            )
+            .is_some()
+            && !target_file_idx.is_some_and(|target_idx| {
+                self.resolve_js_export_surface(target_idx)
+                    .has_commonjs_exports
+            })
+        {
+            return Some(TypeId::ANY);
+        }
+
         let exports_table = self
             .resolve_effective_module_exports_from_file(module_name, source_file_idx)
             .or_else(|| {

--- a/crates/tsz-cli/tests/untyped_module_resolution_tests.rs
+++ b/crates/tsz-cli/tests/untyped_module_resolution_tests.rs
@@ -65,6 +65,37 @@ fn write_tsconfig(base: &Path, extra_options: &str, files: &[&str]) {
     );
 }
 
+/// A tsconfig using Node16 resolution with `allowJs` enabled. Unlike
+/// `write_tsconfig`, admitting JavaScript files makes the `maxNodeModuleJsDepth`
+/// boundary observable: at the default depth of 0 a `node_modules` JS file is
+/// resolved but left unbound for types (`any`), while a raised depth pulls it
+/// into the type graph so its `module.exports` shape is inferred.
+fn write_node16_untyped_tsconfig(base: &Path, extra_options: &str, files: &[&str]) {
+    let files_json = files
+        .iter()
+        .map(|f| format!("\"{f}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    write_file(
+        &base.join("tsconfig.json"),
+        &format!(
+            r#"{{
+              "compilerOptions": {{
+                "target": "es2020",
+                "module": "node16",
+                "moduleResolution": "node16",
+                "allowJs": true,
+                "strict": false,
+                "noImplicitAny": false,
+                "noEmit": true,
+                "types": []{extra_options}
+              }},
+              "files": [{files_json}]
+            }}"#
+        ),
+    );
+}
+
 /// An untyped package: a `node_modules` entry whose only file is JavaScript,
 /// with no `package.json` `types` entry and no sibling declaration file.
 fn write_untyped_package(base: &Path, package_name: &str) {
@@ -453,5 +484,141 @@ fn require_only_exports_still_reports_ts2307_for_esm_dynamic_import() {
     assert!(
         unresolved[0].message_text.contains("require-only-pkg"),
         "TS2307 names the require-only package, got: {unresolved:#?}"
+    );
+}
+
+const PROPERTY_DOES_NOT_EXIST: u32 = 2339;
+
+/// #16934: once TS7016 is correctly suppressed (`noImplicitAny: false`), a real
+/// member access on an untyped `node_modules` JS module must stay clean. The
+/// module is left out of the type graph, so `tsc` binds it as `any` and reports
+/// nothing — regardless of the CommonJS export shape the source spells out. The
+/// pre-fix behavior fell through to an empty `typeof import("mod")` and reported
+/// a spurious TS2339 on every real member, a message strictly worse than the
+/// TS7016 it replaced.
+///
+/// The matrix varies the package name, the local alias, the exported member
+/// name, AND the `module.exports` shape (object literal, property assignment,
+/// bare `exports`, callable, and require re-export) so no name-shaped or
+/// shape-shaped rule can pass it by accident.
+#[test]
+fn untyped_node_modules_member_access_binds_as_any_across_export_shapes() {
+    let cases: &[(&str, &str, &str, &str)] = &[
+        // (package, alias, exported source, access expression)
+        (
+            "obj-literal-pkg",
+            "objLit",
+            "module.exports = { readValue: function () { return 1; } };\n",
+            "objLit.readValue()",
+        ),
+        (
+            "prop-assign-pkg",
+            "propAssign",
+            "module.exports.compute = function () { return 2; };\n",
+            "propAssign.compute()",
+        ),
+        (
+            "bare-exports-pkg",
+            "bareExports",
+            "exports.emit = function () { return 3; };\n",
+            "bareExports.emit()",
+        ),
+        (
+            "callable-pkg",
+            "callable",
+            "module.exports = function () { return 4; };\n",
+            "callable()",
+        ),
+        (
+            "reexport-pkg",
+            "reexported",
+            "module.exports = require(\"./inner\");\n",
+            "reexported.anything",
+        ),
+    ];
+
+    for (package, alias, source, access) in cases {
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let base = temp.path();
+
+        write_file(
+            &base.join(format!("node_modules/{package}/index.js")),
+            source,
+        );
+        // Backing file for the require re-export shape; harmless for the rest.
+        write_file(
+            &base.join(format!("node_modules/{package}/inner.js")),
+            "module.exports = { deep: 1 };\n",
+        );
+
+        write_file(
+            &base.join("consumer.ts"),
+            &format!("import {alias} = require(\"{package}\");\n{access};\n"),
+        );
+
+        // `allowJs` + `node16` reproduces #16934 exactly: the JS file is
+        // admitted to the program for resolution (so `require()` binds and
+        // TS7016 is suppressed under `noImplicitAny: false`) yet stays above the
+        // default `maxNodeModuleJsDepth` of 0, so it is not bound for types.
+        write_node16_untyped_tsconfig(base, "", &["consumer.ts"]);
+
+        let args = parse_args(&["tsz", "--noEmit"]);
+        let result = compile(&args, base).expect("compile should succeed");
+
+        let missing_member = diagnostics_with_code(&result.diagnostics, PROPERTY_DOES_NOT_EXIST);
+        assert!(
+            missing_member.is_empty(),
+            "untyped `{package}` binds as `any`, so `{access}` is clean, got: {missing_member:#?}"
+        );
+        let unresolved = diagnostics_with_code(&result.diagnostics, CANNOT_FIND_MODULE);
+        assert!(
+            unresolved.is_empty(),
+            "untyped `{package}` still resolves (no TS2307), got: {unresolved:#?}"
+        );
+    }
+}
+
+/// Positive guard against over-correcting to a blanket `any`. Raising
+/// `maxNodeModuleJsDepth` pulls the same `node_modules` JS file into the type
+/// graph, where `tsc` DOES infer its `module.exports` shape. A member the file
+/// does not export must then report TS2339 — proving the untyped→`any` gate
+/// keys on "no synthesizable export surface", not on the `node_modules` path or
+/// the JS extension alone. The binder names differ from the negative matrix so
+/// the two tests cannot share an accidental fast path.
+#[test]
+fn node_modules_js_admitted_within_depth_infers_export_shape() {
+    let temp = tempfile::TempDir::new().expect("temp dir");
+    let base = temp.path();
+
+    write_file(
+        &base.join("node_modules/admitted-pkg/index.js"),
+        "module.exports = { present: function () { return 1; } };\n",
+    );
+
+    write_file(
+        &base.join("consumer.ts"),
+        "import admitted = require(\"admitted-pkg\");\nadmitted.present();\nadmitted.missing();\n",
+    );
+
+    // `maxNodeModuleJsDepth: 1` raises the `node_modules` JS file into the type
+    // graph; `allowJs` lets it in. Now its `module.exports` shape IS inferred.
+    write_node16_untyped_tsconfig(
+        base,
+        ",\n                \"maxNodeModuleJsDepth\": 1",
+        &["consumer.ts"],
+    );
+
+    let args = parse_args(&["tsz", "--noEmit"]);
+    let result = compile(&args, base).expect("compile should succeed");
+
+    let missing_member = diagnostics_with_code(&result.diagnostics, PROPERTY_DOES_NOT_EXIST);
+    assert_eq!(
+        missing_member.len(),
+        1,
+        "the admitted module infers `{{ present }}`, so only `missing` reports TS2339, got: {missing_member:#?}"
+    );
+    assert!(
+        missing_member[0].message_text.contains("missing"),
+        "TS2339 names the genuinely-absent member, got: {missing_member:#?}"
     );
 }


### PR DESCRIPTION
Fixes #16934.

When a `node_modules` `.js` module resolves above `maxNodeModuleJsDepth` (the
default `0` under `--module node16`), tsc admits it for resolution but leaves it
out of the type graph, so `require()`ing it yields value type `any`. Once TS7016
is correctly suppressed under `noImplicitAny: false` (the #16916/#16926/#16933
work), tsz fell through to an empty `typeof import("mod")` and reported a
spurious **TS2339 on every real member** — a message strictly worse than the
TS7016 it replaced.

**Structural rule:** when a module specifier resolves to an untyped JS module
that the driver deliberately left unbound for types, `tsc` gives it value type
`any`, whatever CommonJS export shape its source spells out; tsz now does the
same through the solver-backed `commonjs_module_value_type` query.

The gate returns `any` when the specifier is in `untyped_module_paths` **and** no
CommonJS export surface can be synthesized from a program file. The surface
check is load-bearing: the driver records an `untyped_module_paths` entry for
*every* JS-extension resolution (so the TS2665 augmentation gate can key on the
resolution extension), including admitted first-party `.js` and `node_modules`
JS within depth — those ARE bound and yield a real surface, which must still be
synthesized. Only a JS module marked untyped that yields no surface is the `any`
case, so the TS2307 path for genuinely-missing modules and the inferred shape
for admitted modules are both preserved.

Both the property-access path (`import_equals_alias_value_type`) and the general
alias path (`get_type_of_symbol` for `import x = require(...)`) route through
this one query, so a single gate fixes every usage.

## Goal
Goal: hold

## Verification
- New regression tests in `crates/tsz-cli/tests/untyped_module_resolution_tests.rs`
  (11 pass), varying package name, local alias, member name, and the
  `module.exports` shape (object literal, property assignment, bare `exports`,
  callable, require re-export) so no name/shape-shaped rule passes by accident:
  - `untyped_node_modules_member_access_binds_as_any_across_export_shapes` — the
    #16934 negative case (untyped → `any`, no TS2339).
  - `node_modules_js_admitted_within_depth_infers_export_shape` — positive guard:
    `maxNodeModuleJsDepth: 1` admits the file, its shape is inferred, and a
    genuinely-absent member reports TS2339 (proves no over-correction to blanket `any`).
- Manual CLI parity matrix on the issue repro (`--allowJs --module node16`):
  depth-0 member access clean (`any`); `noImplicitAny: true` still reports TS7016
  (no TS2339); depth-1 and first-party `.js` still infer `{ ... }` shapes.
- `cargo clippy -p tsz-checker --release` clean; changed files under the 2000-line cap.
- Adjacent checker suites (`commonjs_require_value_tests`, `js_export_surface_tests`,
  `typeof_import_commonjs_object_literal_export_tests`,
  `commonjs_module_export_alias_tests`, `cjs_direct_object_export_no_typeof_import_display_tests`,
  `js_exports_surface_fallback_for_named_imports_tests`,
  `commonjs_constructor_diagnostics_tests`) show no new failures; the 3
  pre-existing failures reproduce on the pristine base (the #15983 forward-read family).
- Conformance snapshot in progress; results to follow in a comment.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_011YWU519yvMVFHewtEKzMcF)_