### PR TITLE
Stop treating a maxNodeModuleJsDepth-skipped require() target as empty

### DIFF
--- a/crates/tsz-checker/src/context/checker_context_lifetimes.toml
+++ b/crates/tsz-checker/src/context/checker_context_lifetimes.toml
@@ -228,6 +228,7 @@ is_external_module_by_file = { lifetime = "ProgramStable", capability = "Program
 resolved_module_errors = { lifetime = "ProgramStable", capability = "ProgramLookupContext", reason = "shared immutable program data; valid until the compilation or project version changes" }
 resolved_module_request_errors = { lifetime = "ProgramStable", capability = "ProgramLookupContext", reason = "shared immutable program data; valid until the compilation or project version changes" }
 untyped_module_paths = { lifetime = "ProgramStable", capability = "ProgramLookupContext", reason = "shared immutable program data; valid until the compilation or project version changes" }
+depth_skipped_target_file_indices = { lifetime = "ProgramStable", capability = "ProgramLookupContext", reason = "shared immutable program data; valid until the compilation or project version changes" }
 import_resolution_stack = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 type_only_nodes = { lifetime = "FileLocalReset", capability = "EmitSummaryState", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 symbol_resolution_depth = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }

--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -473,6 +473,7 @@ impl<'a> CheckerContext<'a> {
             is_external_module_by_file: None,
             resolved_module_errors: None,
             untyped_module_paths: None,
+            depth_skipped_target_file_indices: None,
             resolved_module_request_errors: None,
             import_resolution_stack: Vec::new(),
             type_only_nodes: FxHashSet::default(),

--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -965,6 +965,21 @@ impl<'a> CheckerContext<'a> {
         self.untyped_module_paths = Some(paths);
     }
 
+    /// Install the driver's set of file indices skipped by the
+    /// `maxNodeModuleJsDepth` BFS gate (never actually parsed).
+    pub fn set_depth_skipped_target_file_indices(&mut self, indices: Arc<FxHashSet<usize>>) {
+        self.depth_skipped_target_file_indices = Some(indices);
+    }
+
+    /// True when `file_idx` is a `maxNodeModuleJsDepth`-skipped program entry
+    /// that was never actually parsed (see
+    /// `depth_skipped_target_file_indices`'s doc comment).
+    pub fn is_depth_skipped_target_file(&self, file_idx: usize) -> bool {
+        self.depth_skipped_target_file_indices
+            .as_ref()
+            .is_some_and(|indices| indices.contains(&file_idx))
+    }
+
     /// Absolute path of the untyped JavaScript file `specifier` resolves to
     /// from the current file, if the resolution carried no declaration file.
     ///

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -1756,6 +1756,15 @@ pub struct CheckerContext<'a> {
     /// Untyped-JavaScript resolution targets: (`source_file_idx`, specifier) ->
     /// resolved `.js` path. Consulted by the module-augmentation TS2665 gate.
     pub untyped_module_paths: Option<Arc<UntypedModulePathMap>>,
+    /// File indices the `maxNodeModuleJsDepth` BFS gate skipped rather than
+    /// read (driver's `depth_skipped_js_paths`, converted to file indices).
+    /// Such a file has a program entry — specifiers pointing at it still
+    /// resolve — but was never actually parsed: its `SourceFile` node exists
+    /// with permanently empty text, not the file's real content. A JS/CJS
+    /// export-shape computation for a `require()`/import target in this set
+    /// must not treat "found no exports" as "genuinely has no exports";
+    /// tsc types such a target as `any`. See #16934.
+    pub depth_skipped_target_file_indices: Option<Arc<FxHashSet<usize>>>,
 
     /// Import resolution stack for circular import detection.
     /// Tracks the chain of modules being resolved to detect circular dependencies.

--- a/crates/tsz-checker/src/context/program_context.rs
+++ b/crates/tsz-checker/src/context/program_context.rs
@@ -145,6 +145,11 @@ pub struct ProgramContext {
     pub resolved_module_request_errors: Arc<ResolvedModuleRequestErrorMap>,
     /// Untyped-JS resolution targets: (`source_file_idx`, specifier) -> `.js` path.
     pub untyped_module_paths: Arc<UntypedModulePathMap>,
+    /// File indices the `maxNodeModuleJsDepth` BFS gate skipped rather than
+    /// read. Such a file keeps a program entry (so specifiers pointing at it
+    /// still resolve) but was never actually parsed — see
+    /// `CheckerContext::depth_skipped_target_file_indices`.
+    pub depth_skipped_target_file_indices: Arc<FxHashSet<usize>>,
     /// Per-file external module status.
     pub is_external_module_by_file: Arc<FxHashMap<String, bool>>,
     /// Per-file ESM/CJS determination.
@@ -210,6 +215,7 @@ impl Default for ProgramContext {
             resolved_module_ts_extension_flags: Arc::new(FxHashMap::default()),
             resolved_module_errors: Arc::new(FxHashMap::default()),
             untyped_module_paths: Arc::new(FxHashMap::default()),
+            depth_skipped_target_file_indices: Arc::new(FxHashSet::default()),
             resolved_module_request_errors: Arc::new(FxHashMap::default()),
             is_external_module_by_file: Arc::new(FxHashMap::default()),
             file_is_esm_map: Arc::new(FxHashMap::default()),
@@ -361,6 +367,9 @@ impl ProgramContext {
         ctx.set_resolved_module_errors(Arc::clone(&self.resolved_module_errors));
         ctx.set_resolved_module_request_errors(Arc::clone(&self.resolved_module_request_errors));
         ctx.set_untyped_module_paths(Arc::clone(&self.untyped_module_paths));
+        ctx.set_depth_skipped_target_file_indices(Arc::clone(
+            &self.depth_skipped_target_file_indices,
+        ));
         ctx.is_external_module_by_file = Some(Arc::clone(&self.is_external_module_by_file));
         ctx.file_is_esm_map = Some(Arc::clone(&self.file_is_esm_map));
         // Warm local caches from the already-installed shared DefinitionStore.

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -818,6 +818,25 @@ impl<'a> CheckerState<'a> {
                         return (module_type, Vec::new());
                     }
 
+                    // `commonjs_module_value_type` returned `None` for a target the
+                    // `maxNodeModuleJsDepth` BFS gate skipped rather than read (see
+                    // `is_depth_skipped_target_file`'s doc comment). Match that
+                    // decision here instead of falling through to the exports-table
+                    // reconstruction below, which would otherwise re-derive the same
+                    // confidently-empty namespace type this function's own call above
+                    // just declined to synthesize — tsc types such a target as `any`
+                    // (#16934).
+                    if self
+                        .ctx
+                        .resolve_import_target_from_file(
+                            self.ctx.current_file_idx,
+                            &module_specifier,
+                        )
+                        .is_some_and(|target_idx| self.ctx.is_depth_skipped_target_file(target_idx))
+                    {
+                        return (TypeId::ANY, Vec::new());
+                    }
+
                     let exports_table = self.resolve_effective_module_exports(&module_specifier);
 
                     if let Some(exports_table) = exports_table {

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_resolution.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_resolution.rs
@@ -937,6 +937,21 @@ impl<'a> CheckerState<'a> {
             })
             .or_else(|| self.ctx.resolve_import_target(module_name));
 
+        // A require()/import target the driver's `maxNodeModuleJsDepth` BFS
+        // gate skipped rather than read keeps a program entry (so the
+        // specifier resolves) but was never actually parsed: its `SourceFile`
+        // node holds permanently empty text, not the file's real content. tsc
+        // types such a target as `any` — there is no real content to build a
+        // shape from — so return `None` here and let the caller fall back the
+        // same way it already does for an unresolved specifier, instead of
+        // synthesizing a confidently-empty namespace type from the target's
+        // (equally empty) exports table below (#16934).
+        if let Some(idx) = target_file_idx
+            && self.ctx.is_depth_skipped_target_file(idx)
+        {
+            return None;
+        }
+
         let exports_table = self
             .resolve_effective_module_exports_from_file(module_name, source_file_idx)
             .or_else(|| {

--- a/crates/tsz-checker/tests/program_context_tests.rs
+++ b/crates/tsz-checker/tests/program_context_tests.rs
@@ -42,6 +42,7 @@ fn empty_program_context() -> ProgramContext {
         program_cross_file_node_symbols: None,
         program_alias_partners: None,
         untyped_module_paths: Arc::new(FxHashMap::default()),
+        depth_skipped_target_file_indices: Arc::new(FxHashSet::default()),
         resolved_module_paths: Arc::new(FxHashMap::default()),
         resolved_module_request_paths: Arc::new(FxHashMap::default()),
         resolved_module_ts_extension_flags: Arc::new(FxHashMap::default()),

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -203,7 +203,15 @@ pub(super) fn collect_diagnostics(
     cache: Option<&mut CompilationCache>,
     type_cache_output: &std::sync::Mutex<FxHashMap<PathBuf, TypeCache>>,
 ) -> CollectDiagnosticsResult {
-    collect_diagnostics_with_source_resolutions(input, cache, type_cache_output, None, None, None)
+    collect_diagnostics_with_source_resolutions(
+        input,
+        cache,
+        type_cache_output,
+        None,
+        None,
+        None,
+        None,
+    )
 }
 
 pub(super) fn collect_diagnostics_with_source_resolutions(
@@ -215,6 +223,7 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
     >,
     source_module_resolution_misses: Option<&FxHashSet<SourceModuleResolutionKey>>,
     explicit_root_paths: Option<&FxHashSet<PathBuf>>,
+    depth_skipped_js_paths: Option<&FxHashSet<PathBuf>>,
 ) -> CollectDiagnosticsResult {
     let &CollectDiagnosticsInput {
         program,
@@ -305,6 +314,23 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
             canonical_to_file_name.insert(canonical, file.file_name.clone());
         }
     }
+
+    // File indices the `maxNodeModuleJsDepth` BFS gate skipped rather than
+    // read (see `depth_skipped_js_paths` on `SourceReadResult`). A resolved
+    // require()/import target in this set has a program entry but was never
+    // actually parsed — its `SourceFile` node exists with empty text, not the
+    // file's real content — so a JS/CJS export-shape computation for it must
+    // not treat "found no exports" as "genuinely has no exports" (#16934).
+    let depth_skipped_target_file_indices: Arc<FxHashSet<usize>> = Arc::new(
+        depth_skipped_js_paths
+            .map(|paths| {
+                paths
+                    .iter()
+                    .filter_map(|path| program_file_index.get(path))
+                    .collect()
+            })
+            .unwrap_or_default(),
+    );
 
     // Duplicate package redirect map
     let package_redirects: FxHashMap<PathBuf, PathBuf> = {
@@ -669,6 +695,7 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
         resolved_module_errors: Arc::clone(&resolved_module_errors),
         resolved_module_request_errors: Arc::clone(&resolved_module_request_errors),
         untyped_module_paths: Arc::clone(&untyped_module_paths),
+        depth_skipped_target_file_indices: Arc::clone(&depth_skipped_target_file_indices),
         is_external_module_by_file: Arc::clone(&is_external_module_by_file),
         file_is_esm_map: Arc::clone(&file_is_esm_map),
         typescript_dom_replacement_globals,

--- a/crates/tsz-cli/src/driver/core_diagnostics.rs
+++ b/crates/tsz-cli/src/driver/core_diagnostics.rs
@@ -738,6 +738,7 @@ fn compile_inner_impl(
         module_resolution_misses,
         type_reference_errors,
         resolution_mode_errors,
+        depth_skipped_js_paths,
     } = {
         read_source_files(
             &file_paths,
@@ -1154,6 +1155,7 @@ fn compile_inner_impl(
         Some(&module_resolutions),
         Some(&module_resolution_misses),
         Some(&explicit_root_paths),
+        Some(&depth_skipped_js_paths),
     );
     let mut diagnostics: Vec<Diagnostic> = collected.diagnostics;
     let check_duration = collect_diagnostics_start.elapsed();

--- a/crates/tsz-cli/src/driver/sources.rs
+++ b/crates/tsz-cli/src/driver/sources.rs
@@ -273,6 +273,14 @@ pub(super) struct SourceReadResult {
     /// TS1453: Invalid `resolution-mode` values in `/// <reference types="..." />` directives.
     /// Tuples of (`file_path`, `byte_offset`, `span_length`).
     pub(super) resolution_mode_errors: Vec<(PathBuf, usize, usize)>,
+    /// Paths the `maxNodeModuleJsDepth` BFS gate skipped rather than read
+    /// (`BatchAction::SkipJs`). Each such path keeps a `SourceFile` registered
+    /// in the program (so `require()`/import specifiers pointing at it still
+    /// resolve) but with permanently empty source text, never a real parse of
+    /// the file's actual content. Checker consumers that build a CJS/JS export
+    /// shape for a `require()` target need this set to tell "never read" apart
+    /// from "read and genuinely has no exports" — see #16934.
+    pub(super) depth_skipped_js_paths: FxHashSet<PathBuf>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -687,6 +695,7 @@ pub(super) fn read_source_files(
     let mut module_resolver = ModuleResolver::new(options);
     let mut type_reference_errors = Vec::new();
     let mut resolution_mode_errors = Vec::new();
+    let mut depth_skipped_js_paths: FxHashSet<PathBuf> = FxHashSet::default();
     let use_cache = cache.is_some() && changed_paths.is_some();
 
     // PERF: cache `normalize_resolved_path` results for the BFS lifetime.
@@ -829,6 +838,7 @@ pub(super) fn read_source_files(
                 }
                 BatchAction::SkipJs => {
                     sources.insert(path.clone(), (None, false, false));
+                    depth_skipped_js_paths.insert(path.clone());
                     continue;
                 }
                 BatchAction::Read => {}
@@ -1151,6 +1161,7 @@ pub(super) fn read_source_files(
         module_resolution_misses,
         type_reference_errors,
         resolution_mode_errors,
+        depth_skipped_js_paths,
     })
 }
 

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -538,7 +538,11 @@ STRUCT_FIELD_COUNT_CHECKS = [
         # parameters whose parser-emitted grammar diagnostics tsc's single
         # early-return `checkGrammarParameterList` never reached, so the driver
         # can drop them (#16644).
-        256,
+        # 256 -> 257: `depth_skipped_target_file_indices` lets a CJS/JS
+        # export-shape computation for a require()/import target tell "the
+        # driver's `maxNodeModuleJsDepth` BFS gate skipped this file" apart
+        # from "this file was read and genuinely has no exports" (#16934).
+        257,
     ),
 ]
 


### PR DESCRIPTION
Closes #16934.

When the driver's `maxNodeModuleJsDepth` BFS gate skips a `node_modules` JS
file rather than reading it (`BatchAction::SkipJs` in
`crates/tsz-cli/src/driver/sources.rs`), the file keeps a program entry — a
`require()`/import specifier pointing at it still resolves — but its
`SourceFile` node is a real parse of *empty text*, not the file's actual
content. The checker's CJS export-shape computation could not tell that
apart from "the file was read and genuinely has no exports", so it
synthesized a confidently-empty namespace type instead of falling back to
`any` the way tsc does for content it never saw. The user-visible effect was
worse than before #16926/#16933/#16936 fixed the over-eager TS7016
suppression: a false TS2339 ("Property does not exist") in place of the
previous, more honest TS7016.

## Structural rule

When a `require()`/import target file is a `maxNodeModuleJsDepth`-skipped
placeholder, tsc types it `any`; tsz's CJS export-shape computation now does
the same, through two owner sites that both build the export-shape type from
scratch: `commonjs_module_value_type` (solver-backed query,
`crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_resolution.rs`)
and its independent duplicate implementation for the declared-symbol-type
path in `crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs`.
Both previously fell through to reconstructing an empty namespace type from
the target's (equally empty) exports table instead of stopping at "unread".

## Plumbing

The driver already tracks which paths the BFS gate skips; this threads that
set through `SourceReadResult` -> `collect_diagnostics_with_source_resolutions`
-> `ProgramContext`/`CheckerContext` (mirroring the existing
`untyped_module_paths` field) as file indices, so
`CheckerContext::is_depth_skipped_target_file` gives both CJS-export call
sites a real "was this ever read" signal instead of a statement-count
heuristic — which would misfire on a genuinely empty *admitted* JS file,
verified below.

`CheckerContext` field count bumps 256 -> 257 for the new field; the cap in
`scripts/arch/arch_guard_shared.py` is bumped in this PR per its own stated
convention.

## Goal
Goal: hold

## Verification
- Hand-built `node_modules/untyped` fixture (`module.exports = { hello: () => 1 }`),
  `import u = require("untyped"); u.hello();`:
  - `--module node16 --moduleResolution node16`: was `TS2339`, now clean (matches tsc).
  - `--module nodenext --moduleResolution nodenext`: was `TS2339`, now clean.
  - `--module commonjs` (already-correct baseline): stays clean.
  - Bare `import u = require("untyped");` with no property access: stays clean under node16.
  - Negative/adjacent case — a genuinely empty *admitted* JS module
    (`./empty.js`, real parse, real zero statements, not BFS-skipped):
    `u.hello()` still reports `TS2339` — confirms the fix keys off "was this
    file's BFS entry a skip stub", not the file's statement count.
- `cargo fmt --check`: clean.
- `cargo clippy -p tsz-checker -p tsz-cli --all-targets -- -D warnings`: clean.
- `python3 scripts/arch/checker_field_inventory.py` and
  `scripts/arch/check-checker-boundaries.sh`: pass (257 fields, all classified).
- `cargo test -p tsz-checker --lib` / `cargo test -p tsz-cli --lib`: run locally
  (pre-commit hook's affected-crate verification also passed); full-suite
  results to follow in a PR comment once the long tail finishes.
- Conformance/emit: no `crates/**/src` path outside `tsz-checker`/`tsz-cli`
  touched; `compare-to-parent.sh` owed and will be posted once it completes —
  this is a checker/driver semantic change (CJS export-shape for an unread
  `node_modules` JS module), so a conformance delta is possible even though
  the repro isolates outside the pinned corpus today.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECsW3DKJeRTTGGnRGq3kd9)_