### PR TITLE
fix(solver): pair number/string-literal source members with fixed union targets (isTypeOrBaseIdenticalTo) in both union-inference paths

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -303,6 +303,9 @@ path = "tests/generic_generator_member_substitution_tests.rs"
 name = "array_element_naked_inference_tests"
 path = "tests/array_element_naked_inference_tests.rs"
 [[test]]
+name = "naked_type_param_union_literal_base_infer_tests"
+path = "tests/naked_type_param_union_literal_base_infer_tests.rs"
+[[test]]
 name = "return_only_defaulted_intersection_contextual_inference_tests"
 path = "tests/return_only_defaulted_intersection_contextual_inference_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/naked_type_param_union_literal_base_infer_tests.rs
+++ b/crates/tsz-checker/tests/naked_type_param_union_literal_base_infer_tests.rs
@@ -1,0 +1,181 @@
+//! Regression tests for issue #16948.
+//!
+//! When `tsc` infers a naked type parameter `T` from an array-literal argument
+//! against a declared element type `T | number | string` (a union of a naked
+//! variable plus fixed primitive members), it pairs each fixed union member
+//! against the matching array element and infers `T` from the single leftover
+//! element. The pairing follows `isTypeOrBaseIdenticalTo`: a *number literal*
+//! source element matches a fixed `number` target and a *string literal* source
+//! element matches a fixed `string` target.
+//!
+//! tsz previously matched fixed union members by type identity only, so the
+//! unwidened literal element types `13` and `"12"` failed to pair with the
+//! fixed `number`/`string` targets and leaked into `T`'s candidate set. Because
+//! `"12"` (a string) violates `T extends Numeric`, inference discarded the whole
+//! candidate set and fell back to `T`'s constraint (`Numeric`) instead of the
+//! correct `NumCoercible`, producing a spurious `TS2741`/`TS2322`.
+//!
+//! These tests pin the corrected behaviour across structurally equivalent
+//! shapes (renamed binders, differing union arity, the tuple-return form), not
+//! just the reported spelling.
+
+use std::sync::Arc;
+use tsz_binder::lib_loader::LibFile;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs_code_messages, load_compiled_lib_files};
+
+const NUMERIC_PRELUDE: &str = r#"
+interface Numeric { valueOf(): number; }
+class NumCoercible {
+    public a: number;
+    constructor(a: number) { this.a = a; }
+    public valueOf() { return this.a; }
+}
+"#;
+
+fn es5_lib_files() -> Vec<Arc<LibFile>> {
+    // `Array<T>` and the array-literal element inference this test exercises
+    // come from `lib.es5.d.ts`; the default lib-less helper cannot type them.
+    load_compiled_lib_files(&["lib.es5.d.ts"])
+}
+
+fn assignment_error_codes(source: &str) -> Vec<u32> {
+    check_source_with_libs_code_messages(
+        source,
+        "test.ts",
+        CheckerOptions::default(),
+        &es5_lib_files(),
+    )
+    .into_iter()
+    // TS2741 (property missing) and TS2322 (not assignable) are the two
+    // shapes the constraint-fallback bug surfaced through.
+    .filter(|(code, _)| *code == 2741 || *code == 2322)
+    .map(|(code, _)| code)
+    .collect()
+}
+
+#[test]
+fn three_member_union_three_distinct_elements_infers_leftover_not_constraint() {
+    // The reported repro: `T | number | string` with `[NumCoercible, 13, "12"]`.
+    // `13` pairs with `number`, `"12"` pairs with `string`, and `T` is inferred
+    // from the leftover `NumCoercible` — not the `Numeric` constraint.
+    let source = format!(
+        "{NUMERIC_PRELUDE}
+function extent<T extends Numeric>(array: Array<T | number | string>): T {{ return array[0] as T; }}
+let extentMixed = extent([new NumCoercible(10), 13, \"12\"]);
+let check: NumCoercible = extentMixed;
+"
+    );
+    assert!(
+        assignment_error_codes(&source).is_empty(),
+        "T must infer to NumCoercible, not its Numeric constraint; got {:?}",
+        assignment_error_codes(&source)
+    );
+}
+
+#[test]
+fn renamed_binders_reproduce_the_fix_identically() {
+    // The rule is structural, not tied to the identifier names
+    // `T`/`Numeric`/`NumCoercible`/`extent`.
+    let source = r#"
+interface HasVal { valueOf(): number; }
+class Widget {
+    public w: number;
+    constructor(w: number) { this.w = w; }
+    public valueOf() { return this.w; }
+}
+function pick<Elem extends HasVal>(xs: Array<Elem | number | string>): Elem { return xs[0] as Elem; }
+let got = pick([new Widget(1), 7, "z"]);
+let chk: Widget = got;
+"#;
+    assert!(
+        assignment_error_codes(source).is_empty(),
+        "renamed binders must reproduce the fix identically; got {:?}",
+        assignment_error_codes(source)
+    );
+}
+
+#[test]
+fn two_member_union_control_still_clean() {
+    // Control: the 2-member union (1 fixed + T) already worked and must stay
+    // clean after the fix.
+    let source = format!(
+        "{NUMERIC_PRELUDE}
+function extent<T extends Numeric>(array: Array<T | number>): T {{ return array[0] as T; }}
+let m = extent([new NumCoercible(10), 13]);
+let check: NumCoercible = m;
+"
+    );
+    assert!(
+        assignment_error_codes(&source).is_empty(),
+        "2-member union control must stay clean; got {:?}",
+        assignment_error_codes(&source)
+    );
+}
+
+#[test]
+fn three_member_union_with_string_element_absent_still_clean() {
+    // Boundary: 3-member union but only 2 distinct element types
+    // (`string` member unmatched by the array). Already clean; must stay clean.
+    let source = format!(
+        "{NUMERIC_PRELUDE}
+function extent<T extends Numeric>(array: Array<T | number | string>): T {{ return array[0] as T; }}
+let m = extent([new NumCoercible(10), 13]);
+let check: NumCoercible = m;
+"
+    );
+    assert!(
+        assignment_error_codes(&source).is_empty(),
+        "3-member union with an unmatched string member must stay clean; got {:?}",
+        assignment_error_codes(&source)
+    );
+}
+
+#[test]
+fn tuple_return_form_with_boolean_member_infers_leftover() {
+    // The tuple-return shape from the issue's original discovery context. The
+    // return-type structure (`[T | ... , T | ...] | [undefined, undefined]`)
+    // does not change the array/param inference: `T` still resolves so the
+    // contextual assignment is clean.
+    let source = r#"
+interface Numeric { valueOf(): number; }
+class NumCoercible {
+    public a: number;
+    constructor(a: number) { this.a = a; }
+    public valueOf() { return this.a; }
+}
+function extent<T extends Numeric>(
+    array: Array<T | number | string | boolean>
+): [T | number | string | boolean, T | number | string | boolean] | [undefined, undefined] {
+    return [undefined, undefined];
+}
+let extentMixed: [number | string | boolean | NumCoercible, number | string | boolean | NumCoercible] | [undefined, undefined];
+extentMixed = extent([new NumCoercible(10), 13, "12", true]);
+"#;
+    assert!(
+        assignment_error_codes(source).is_empty(),
+        "tuple-return form must infer T without falling back to the constraint; got {:?}",
+        assignment_error_codes(source)
+    );
+}
+
+#[test]
+fn string_literal_element_still_reaches_naked_var_without_fixed_string_target() {
+    // Negative guard against over-matching: when the union has NO fixed `string`
+    // member, a string-literal element must NOT be consumed as if it matched a
+    // fixed target — it flows into `T`. With array-literal widening `T` becomes
+    // `string`, so assigning to a `"hi"` literal target is a genuine error
+    // (matches tsc). This proves the literal->base pairing is gated on the fixed
+    // primitive actually being present in the target union.
+    let source = r#"
+function pick<T>(xs: Array<T | number>): T { return xs[0] as T; }
+let got = pick(["hi", 13]);
+let chk: "hi" = got;
+"#;
+    let codes = assignment_error_codes(source);
+    assert_eq!(
+        codes,
+        vec![2322],
+        "string literal must reach T (widening to `string`) and error against the `\"hi\"` target; got {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/inference/infer_matching.rs
+++ b/crates/tsz-solver/src/inference/infer_matching.rs
@@ -1514,8 +1514,15 @@ impl<'a> InferenceContext<'a> {
 
         let mut structurally_matched_sources = std::collections::HashSet::new();
         for &source_ty in resolved_sources.iter() {
-            // Skip source members that match fixed targets
-            if fixed.contains(&source_ty) {
+            // Skip source members that match a fixed target, by identity or tsc's
+            // number/string literal->base leg (`isTypeOrBaseIdenticalTo`); without
+            // the literal leg a literal source (`13`, `"12"`) would leak past the
+            // fixed `number`/`string` targets into a naked variable (#16948).
+            if crate::type_queries::source_is_or_base_identical_to_fixed(
+                self.interner,
+                source_ty,
+                |candidate| fixed.contains(&candidate),
+            ) {
                 continue;
             }
 
@@ -1530,8 +1537,12 @@ impl<'a> InferenceContext<'a> {
         let unmatched: Vec<TypeId> = resolved_sources
             .iter()
             .copied()
-            .filter(|source_ty| {
-                !fixed.contains(source_ty) && !structurally_matched_sources.contains(source_ty)
+            .filter(|&source_ty| {
+                !crate::type_queries::source_is_or_base_identical_to_fixed(
+                    self.interner,
+                    source_ty,
+                    |candidate| fixed.contains(&candidate),
+                ) && !structurally_matched_sources.contains(&source_ty)
             })
             .collect();
 

--- a/crates/tsz-solver/src/operations/constraints/walker.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker.rs
@@ -629,7 +629,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     };
                     let mut unmatched: Vec<TypeId> = Vec::new();
                     for &member in s_members.iter() {
-                        if fixed_targets.contains(&member) {
+                        if self.source_member_matches_fixed_target(member, &fixed_targets) {
                             continue;
                         }
                         let structural_matches: Vec<TypeId> = structured_targets
@@ -673,35 +673,48 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     // target union. This matches tsc's `inferFromMatchingTypes`:
                     // without it, `T | null` against `HTMLElement | null` would
                     // infer `T = HTMLElement | null` instead of `T = HTMLElement`.
-                    let matched_fixed: FxHashSet<TypeId> = s_members
+                    // Drop every fixed *target* member that some source member
+                    // consumed, leaving the reduced target the unmatched sources
+                    // infer against. Filtered by target id (not source id) because a
+                    // number/string literal source matches a `number`/`string`
+                    // target whose id differs, so the reduction must remove the
+                    // target, not the source (tsc's `isTypeOrBaseIdenticalTo`,
+                    // #16948). The `fixed_targets` guard keeps the identity leg from
+                    // treating a naked/structured target as consumed.
+                    let remaining_targets: Vec<TypeId> = t_members_list
                         .iter()
                         .copied()
-                        .filter(|member| fixed_targets.contains(member))
+                        .filter(|&candidate| {
+                            !(fixed_targets.contains(&candidate)
+                                && s_members.iter().any(|&member| {
+                                    crate::type_queries::is_type_or_base_identical(
+                                        self.interner.as_type_database(),
+                                        member,
+                                        candidate,
+                                    )
+                                }))
+                        })
                         .collect();
-                    let has_unmatched_source = s_members
+                    let some_fixed_target_matched = remaining_targets.len() < t_members_list.len();
+                    // Source members that matched no fixed target: computed once and
+                    // reused as both the reduction gate and the inference work-list.
+                    let unmatched_sources: Vec<TypeId> = s_members
                         .iter()
-                        .any(|member| !fixed_targets.contains(member));
-                    let reduced_target = if !matched_fixed.is_empty() && has_unmatched_source {
-                        let remaining_targets: Vec<TypeId> = t_members_list
-                            .iter()
-                            .copied()
-                            .filter(|member| !matched_fixed.contains(member))
-                            .collect();
-                        if remaining_targets.is_empty()
-                            || remaining_targets.len() == t_members_list.len()
-                        {
-                            target // No reduction possible or nothing removed
-                        } else {
-                            crate::utils::union_or_single(self.interner, remaining_targets)
-                        }
+                        .copied()
+                        .filter(|&member| {
+                            !self.source_member_matches_fixed_target(member, &fixed_targets)
+                        })
+                        .collect();
+                    let reduced_target = if some_fixed_target_matched
+                        && !remaining_targets.is_empty()
+                        && !unmatched_sources.is_empty()
+                    {
+                        crate::utils::union_or_single(self.interner, remaining_targets)
                     } else {
                         target
                     };
-                    for &member in s_members.iter() {
-                        // Skip source members that directly match a fixed target member
-                        if !fixed_targets.contains(&member) {
-                            self.constrain_types(ctx, var_map, member, reduced_target, priority);
-                        }
+                    for &member in &unmatched_sources {
+                        self.constrain_types(ctx, var_map, member, reduced_target, priority);
                     }
                 }
             }

--- a/crates/tsz-solver/src/operations/constraints/walker_support.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker_support.rs
@@ -73,6 +73,26 @@ impl<C: AssignabilityChecker> CallEvaluator<'_, C> {
         out.into()
     }
 
+    /// Whether a source union member should be treated as "matched" by the set of
+    /// fixed (placeholder-free) target union members during inference
+    /// partitioning, per tsc's `isTypeOrBaseIdenticalTo` (identity or a
+    /// number/string literal against its base primitive). Thin `&self` wrapper
+    /// over the shared [`crate::type_queries::source_is_or_base_identical_to_fixed`]
+    /// predicate that binds the `FxHashSet` membership closure once for the two
+    /// loop call sites; the per-target case calls
+    /// [`crate::type_queries::is_type_or_base_identical`] directly.
+    pub(super) fn source_member_matches_fixed_target(
+        &self,
+        member: TypeId,
+        fixed_targets: &rustc_hash::FxHashSet<TypeId>,
+    ) -> bool {
+        crate::type_queries::source_is_or_base_identical_to_fixed(
+            self.interner.as_type_database(),
+            member,
+            |candidate| fixed_targets.contains(&candidate),
+        )
+    }
+
     fn lazy_alias_application_def_id(&self, member: TypeId) -> Option<DefId> {
         let TypeData::Application(app_id) = self.interner.lookup(member)? else {
             return None;

--- a/crates/tsz-solver/src/type_queries/extended.rs
+++ b/crates/tsz-solver/src/type_queries/extended.rs
@@ -163,6 +163,39 @@ pub fn is_number_literal(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     )
 }
 
+/// tsc's `isTypeOrBaseIdenticalTo`, restricted to the number/string leg it uses
+/// during union-inference partitioning: `source` matches `target` either by
+/// identity, or when `source` is a number/string *literal* whose base primitive
+/// (`number`/`string`) is `target`. Boolean and bigint literals are
+/// intentionally not widened here, matching tsc.
+///
+/// Union-inference must pair each fixed (placeholder-free) target member against
+/// a matching source member before the leftovers flow to a naked inference
+/// variable. Array-literal element types are literals (`13`, `"12"`), so without
+/// the literal->base leg they never pair with the fixed `number`/`string`
+/// targets and leak into the naked variable — where a constraint-violating
+/// literal (`"12"` against `T extends Numeric`) forces a fallback to the
+/// constraint and a spurious diagnostic (#16948).
+pub fn is_type_or_base_identical(db: &dyn TypeDatabase, source: TypeId, target: TypeId) -> bool {
+    source == target
+        || (target == TypeId::NUMBER && is_number_literal(db, source))
+        || (target == TypeId::STRING && is_string_literal(db, source))
+}
+
+/// [`is_type_or_base_identical`] against a collection of fixed target members,
+/// expressed as a membership predicate so both `FxHashSet`- and slice-backed
+/// callers keep their native lookup cost. True when `source` is identical to a
+/// fixed member, or its number/string literal base primitive is a fixed member.
+pub fn source_is_or_base_identical_to_fixed(
+    db: &dyn TypeDatabase,
+    source: TypeId,
+    fixed_contains: impl Fn(TypeId) -> bool,
+) -> bool {
+    fixed_contains(source)
+        || (is_number_literal(db, source) && fixed_contains(TypeId::NUMBER))
+        || (is_string_literal(db, source) && fixed_contains(TypeId::STRING))
+}
+
 /// Check if two types are literals of the same base kind.
 ///
 /// Returns true when both are string literals, both are number literals,

--- a/crates/tsz-solver/src/type_queries/mod.rs
+++ b/crates/tsz-solver/src/type_queries/mod.rs
@@ -87,8 +87,9 @@ pub use extended::{
     get_invalid_index_type_member, get_invalid_index_type_member_strict, get_literal_property_name,
     get_number_literal_value, get_string_literal_value, get_tuple_list_id, is_literal_enum_member,
     is_number_literal, is_object_with_index_type, is_string_like_type, is_string_literal,
-    key_matches_number_index, key_matches_string_index, string_like_type_for_type,
-    type_contains_string_literal, widen_literal_to_primitive,
+    is_type_or_base_identical, key_matches_number_index, key_matches_string_index,
+    source_is_or_base_identical_to_fixed, string_like_type_for_type, type_contains_string_literal,
+    widen_literal_to_primitive,
 };
 pub use extended_constructors::{
     AbstractClassCheckKind, AbstractConstructorAnchor, BaseInstanceMergeKind, ClassDeclTypeKind,


### PR DESCRIPTION
Fixes #16948.

When inferring a naked type parameter `T` from an array-literal argument against a declared element type `T | number | string`, tsz partitioned the source element union against the target's *fixed* (placeholder-free) members by `TypeId` identity only. Array-literal element types are **literals** (`13`, `"12"`), so they never matched the fixed `number`/`string` *intrinsics* and leaked into `T`'s candidate set. When one leaked literal (`"12"`, a string) violated `T`'s constraint (`T extends Numeric`), inference discarded the entire candidate set and fell back to the constraint (`Numeric`) instead of the correct leftover element (`NumCoercible`), producing a spurious `TS2741`/`TS2322`.

**Structural rule:** When a source union is matched against a target union `T | number | string` during inference, `tsc` pairs each fixed union member against a matching source member via `isTypeOrBaseIdenticalTo` — identity **or** a number-literal source against a `number` target and a string-literal source against a `string` target — and infers `T` from the genuinely-unmatched leftover.

**Owner layer / breadth:** the rule is centralized as `tsz_solver::type_queries::is_type_or_base_identical` / `source_is_or_base_identical_to_fixed` (reusing the existing `is_number_literal`/`is_string_literal`) and applied to **both** independent union-decomposition implementations that partition source members against fixed target members:
- the checker/generic-call constraint walker `(Union, Union)` arm (`operations/constraints/walker.rs`), which the reported repro exercises; and
- the relation/inference `InferenceContext::infer_unions` (`inference/infer_matching.rs`), which carried the identical identity-only gap latently on the subtype / template-literal / contextual-signature inference paths.

Previously the fix would have lived in one of two copies with the rule duplicated inline; centralizing removes the duplication and closes the latent second-path false positive. The walker fallback branch is also simplified to compute the reduced target and the unmatched-source work-list in a single pass each.

**Anti-hardcoding:** purely structural (literal-kind vs. the `number`/`string` intrinsic in the fixed target set) — no identifier/file/printer-string checks. The regression test varies binder names (`Elem`/`Widget`/`HasVal`). The rule is gated on the fixed target set containing the intrinsic `number`/`string`, so a fixed *literal* target (e.g. `T | 1`) is unaffected — a source `2` still flows to `T`, matching tsc. Boolean and bigint literals are intentionally not widened, matching tsc's `isTypeOrBaseIdenticalTo`.

## Goal
Goal: hold

## Verification
- **Oracle parity (tsc 6.0.2):** the reported repro, both issue repros, and all 4 boundary-table rows match `tsc` exactly (issue repro + `typeInferenceLiteralUnion.ts` go from spurious `TS2322` to clean).
- **Isolation:** rebuilt the base (no change) and confirmed `importDeclWithExportModifierAndExportAssignment.ts` is byte-identical with/without this change (its `TS2309` delta comes from already-merged #16944, not this PR), while `typeInferenceLiteralUnion.ts` flips base-fail → fixed-clean.
- **Conformance snapshot** (`conformance.sh snapshot --workers 12 --force`): 11499 → 11556 passing vs. the pre-change baseline; the broad (`infer_unions`) change produced **zero** additional deltas over the walker-only change (both 486 failures), confirming the second-path fix is latent and non-regressing. No regression attributable to this change.
- **Unit:** `cargo nextest run -p tsz-solver` → 7687 passed; focused checker inference targets → 257 passed; new regression suite `naked_type_param_union_literal_base_infer_tests` → 6 passed.
- **Gates:** `cargo clippy -p tsz-solver -p tsz-checker --all-targets` clean; `scripts/arch/arch_guard.py` + `arch_guard_file_limits.py` pass.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01P2LLye8d4T8vtvZLfpGDog