### PR TITLE
fix(solver): array index by unique-symbol key must not fall back to element type

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_keys.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_keys.rs
@@ -178,6 +178,16 @@ impl TypeVisitor for ArrayKeyVisitor<'_> {
         }
     }
 
+    // A `unique symbol` key (a well-known symbol like `Symbol.isConcatSpreadable`,
+    // or a `declare const s: unique symbol` binding) never matches an array's
+    // numeric index signature, so it must not fall through to `element_type` via
+    // `evaluate`'s default fallback the way an unresolved generic key does.
+    // Mirrors the `IntrinsicKind::Symbol` arm of `visit_intrinsic` above, which
+    // already returns `UNDEFINED` for the widened `symbol` type.
+    fn visit_unique_symbol(&mut self, _symbol_ref: u32) -> Self::Output {
+        Some(TypeId::UNDEFINED)
+    }
+
     /// Signal "use the default fallback" for unhandled type variants.
     fn default_output() -> Self::Output {
         None

--- a/crates/tsz-solver/tests/index_access_comprehensive_tests.rs
+++ b/crates/tsz-solver/tests/index_access_comprehensive_tests.rs
@@ -81,6 +81,51 @@ fn test_index_access_array_with_number_type() {
     assert_eq!(result, TypeId::NUMBER, "array[number] should be number");
 }
 
+#[test]
+fn test_index_access_array_with_unique_symbol_key_is_undefined() {
+    let interner = TypeInterner::new();
+
+    // `arr[Symbol.isConcatSpreadable]`-shaped access: a well-known symbol (or any
+    // `unique symbol`-typed key) never matches an array's numeric index
+    // signature. Regression guard for the `ArrayKeyVisitor::evaluate` fallback,
+    // which used to return the array's element type for any unhandled key shape
+    // (including `UniqueSymbol`) instead of `UNDEFINED`.
+    let array = interner.array(TypeId::STRING);
+    let unique_key = interner.unique_symbol(crate::types::SymbolRef(7));
+    let index_access = interner.index_access(array, unique_key);
+
+    let result = evaluate_type(&interner, index_access);
+    assert_eq!(
+        result,
+        TypeId::UNDEFINED,
+        "array[uniqueSymbol] must not fall back to the element type"
+    );
+}
+
+#[test]
+fn test_index_access_tuple_with_unique_symbol_key_is_undefined() {
+    let interner = TypeInterner::new();
+
+    // Sibling of the array case above: tuples already reject a unique-symbol
+    // key correctly. Pinned here so the two visitors cannot silently diverge
+    // again.
+    let tuple = interner.tuple(vec![TupleElement {
+        type_id: TypeId::STRING,
+        name: None,
+        optional: false,
+        rest: false,
+    }]);
+    let unique_key = interner.unique_symbol(crate::types::SymbolRef(7));
+    let index_access = interner.index_access(tuple, unique_key);
+
+    let result = evaluate_type(&interner, index_access);
+    assert_eq!(
+        result,
+        TypeId::UNDEFINED,
+        "tuple[uniqueSymbol] must not fall back to an element type"
+    );
+}
+
 // =============================================================================
 // Index Access on Tuples
 // =============================================================================


### PR DESCRIPTION
When an array is indexed by a `unique symbol`-typed key — a well-known symbol like `Symbol.isConcatSpreadable`, or a `declare const s: unique symbol` binding — tsc's `findApplicableIndexInfo` finds no applicable index signature (arrays only have a numeric one) and the access is implicit `any`. tsz was instead resolving `arr[Symbol.isConcatSpreadable]` to the array's *element type*, producing a spurious `TS2322` on assignment (e.g. `let a = ['c','d']; a[Symbol.isConcatSpreadable] = false;` → `Type 'boolean' is not assignable to type 'string'`).

## Structural rule

`ArrayKeyVisitor::evaluate` (`crates/tsz-solver/src/evaluation/evaluate_rules/index_access_keys.rs`) signals "no explicit handler for this key shape" via `TypeVisitor::default_output() -> None`, and its driver maps that to `unwrap_or(self.element_type)`. `TypeData::UniqueSymbol` had no override, so it fell into that default and got treated as if it were a matching index. The sibling `TupleKeyVisitor::evaluate` two structs below already defaults the same unhandled case to `TypeId::UNDEFINED` — this was a divergence between the two visitors, not an intentional design choice for arrays.

Fix: add `visit_unique_symbol` to `ArrayKeyVisitor` returning `Some(TypeId::UNDEFINED)`, mirroring the existing `visit_intrinsic` arm that already returns `UNDEFINED` for the widened `symbol` type. Owner layer: solver (`evaluate_rules`), the index-access evaluation boundary — no checker/emitter changes needed.

## Adjacent-case matrix (verified against the pinned oracle, `typescript@7.0.2`)

| case | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `a[Symbol.isConcatSpreadable] = false` (well-known symbol, non-strict) | clean | `TS2322` | clean |
| same, `--strict` | `TS7015` | clean (false negative) | `TS7015` |
| `declare const s: unique symbol; a[s] = false` | clean | `TS2322` | clean |
| `declare const s: symbol; a[s] = false` (widened `symbol`, not unique) | clean | clean | clean (unaffected) |
| `a[Symbol.unscopables]` (genuinely declared well-known-symbol array member) | resolves via property lookup | resolves | resolves (unaffected) |
| `readonly [string, number]` tuple indexed by a unique symbol | clean | clean | clean (already correct; pinned as a regression test) |
| `a[0]`, `a["1"]` (ordinary numeric/string keys) | element type | element type | element type (unaffected) |

The strict-mode row is a bonus fix: the same one-line change also restores the missing `TS7015` false negative, since `ElementAccessEvaluator::should_report_no_index_signature` now actually sees `UNDEFINED` from the array evaluator instead of a spurious element-type match.

Closes the `modularizeLibrary_UsingES5LibES6ArrayLibES6WellknownSymbolLib.ts` conformance false positive (1-extra-0-missing `TS2322`).

## Goal
Goal: hold

## Verification
- Manual oracle spot-checks (`scripts/conformance/oracle.sh`, pinned `typescript@7.0.2`) against a release `tsz` build for all 7 rows in the adjacent-case matrix above, plus the original fixture (`TypeScript/tests/cases/compiler/modularizeLibrary_UsingES5LibES6ArrayLibES6WellknownSymbolLib.ts`) — all now byte-match the oracle.
- `cargo test -p tsz-solver --lib` — 7655/7655 passed (full crate suite; this is the crate the fix lives in).
- `cargo test -p tsz-solver --lib index_access_comprehensive_tests` — 57/57 passed, including 2 new regression tests (`test_index_access_array_with_unique_symbol_key_is_undefined`, `test_index_access_tuple_with_unique_symbol_key_is_undefined`).
- `cargo test -p tsz-checker --lib` targeted filters (`array_index`, `symbol_index`, `element_access`) — 198/198 passed.
- `cargo test -p tsz-checker --lib` full run — completed with no failures through the entire suite except one pre-existing known-slow long-tail test (`ts2589_tests::recursive_conditional_alias_omitted_default_transform_emits_definition_ts2589`, unrelated to indexed access, already flagged this session by another agent as a known-slow test worth skipping rather than a regression).
- `cargo clippy -p tsz-solver -p tsz-checker --all-targets` — clean.
- `cargo fmt --check` — clean.
- Architecture guard (`scripts/arch/arch_guard_file_limits.py`, run again via the pre-commit hook) — clean; both touched files stay well under the 2000-line cap.
- Diff is confined to `crates/tsz-solver` (one production file, one test file) — no checker/emitter production path touched, so conformance/emit counts are not expected to move outside this one fixture family.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyzL8AuZuigy54bPpAXbzU)_