### PR TITLE
fix(solver): keep registration-window artifacts out of run-wide and reused eval caches

### DIFF
--- a/crates/tsz-cli/src/driver/check_file.rs
+++ b/crates/tsz-cli/src/driver/check_file.rs
@@ -713,6 +713,14 @@ where
             qc_stats,
             ds_stats,
         ));
+
+        // This file's registration window has ended. Evict any `eval_cache`
+        // entry that was only window-valid (published under an `UnresolvedDef`
+        // taint) so it cannot shadow the authoritative type the next file in
+        // this partition computes once the missing bodies register — the
+        // fresh-vs-pool divergence in #16553. Clean entries are retained, so
+        // the pool keeps amortizing evaluation cost across files.
+        query_cache.evict_registration_window_eval_entries();
     }
 
     results

--- a/crates/tsz-solver/src/caches/dependency_index.rs
+++ b/crates/tsz-solver/src/caches/dependency_index.rs
@@ -79,6 +79,13 @@ pub(super) fn invalidate_for_def<K: Eq + Hash>(
     }
 }
 
+/// Drop `key`'s dependency edges from the index without touching any cache.
+/// Callers that evict a single entry directly (rather than through
+/// [`invalidate_for_def`]) use this to keep the reverse index consistent.
+pub(super) fn forget_key<K: Eq + Hash>(index: &DependencyIndex<K>, key: &K) {
+    remove_dependencies(&mut index.borrow_mut(), key);
+}
+
 fn remove_dependencies<K: Eq + Hash>(index: &mut DependencyIndexState<K>, key: &K) {
     let Some(deps) = index.key_dependencies.remove(key) else {
         return;

--- a/crates/tsz-solver/src/caches/eval_dependency_index.rs
+++ b/crates/tsz-solver/src/caches/eval_dependency_index.rs
@@ -29,3 +29,9 @@ pub(super) fn invalidate_for_def(
 ) {
     dependency_index::invalidate_for_def(index, cache, def_id);
 }
+
+/// Drop `key`'s dependency edges after the caller has removed it from the cache
+/// directly (single-entry eviction, not `DefId`-scoped invalidation).
+pub(super) fn forget_key(index: &EvalDependencyIndex, key: &EvaluationCacheKey) {
+    dependency_index::forget_key(index, key);
+}

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -232,6 +232,15 @@ pub struct QueryCache<'a> {
     interner: &'a TypeInterner,
     eval_cache: RefCell<FxHashMap<EvaluationCacheKey, TypeId>>,
     eval_dependency_index: EvalDependencyIndex,
+    /// Top-level `eval_cache` keys whose result passed the depth-agnostic gate
+    /// but not the stricter `is_stable_for_run_wide_cache` gate — i.e. a
+    /// registration-window artifact (`UnresolvedDef`), valid only within the
+    /// window that produced it. The bounded checker pool reuses one
+    /// `QueryCache` across a partition's files, each a distinct window, so
+    /// these are evicted at every file boundary by
+    /// `evict_registration_window_eval_entries`; clean entries stay, preserving
+    /// the pool's cross-file amortization (#16553).
+    registration_window_eval_keys: RefCell<rustc_hash::FxHashSet<EvaluationCacheKey>>,
     /// Substitution-independent evaluation cache (see the `closed_eval` module
     /// in `evaluate`). Keyed by
     /// `(TypeId, no_unchecked_indexed_access, exact_optional_property_types)`.
@@ -350,6 +359,7 @@ impl<'a> QueryCache<'a> {
             interner,
             eval_cache: RefCell::new(FxHashMap::default()),
             eval_dependency_index: RefCell::new(EvalDependencyIndexState::default()),
+            registration_window_eval_keys: RefCell::new(rustc_hash::FxHashSet::default()),
             closed_eval_cache: RefCell::new(FxHashMap::default()),
             closed_eval_dependency_index: RefCell::new(EvalDependencyIndexState::default()),
             conditional_branch_verdict_cache: RefCell::new(FxHashMap::default()),
@@ -415,6 +425,7 @@ impl<'a> QueryCache<'a> {
     pub fn clear(&self) {
         self.eval_cache.borrow_mut().clear();
         self.eval_dependency_index.borrow_mut().clear();
+        self.registration_window_eval_keys.borrow_mut().clear();
         self.closed_eval_cache.borrow_mut().clear();
         self.closed_eval_dependency_index.borrow_mut().clear();
         self.conditional_branch_verdict_cache.borrow_mut().clear();
@@ -1454,8 +1465,27 @@ impl QueryDatabase for QueryCache<'_> {
         {
             if top_level_clean {
                 self.insert_eval_cache_entry(key, result);
-                // Also write to shared cache for cross-file benefit.
-                if let Some(shared) = self.shared {
+                if !intermediates_clean {
+                    // `top_level_clean` (depth-agnostic) admitted this entry, but
+                    // the stricter run-wide gate refused it: its value is a
+                    // function of the current registration window, not of its key
+                    // alone (an `UnresolvedDef` taint). It is reusable *within*
+                    // this window — a same-file circular type-parameter default's
+                    // recovery relies on exactly that (#16587) — but the bounded
+                    // checker pool reuses one `QueryCache` across the files of a
+                    // partition, each a distinct window, so it must be evicted at
+                    // the next file boundary rather than shadow the next file's
+                    // authoritative answer (#16553).
+                    self.registration_window_eval_keys.borrow_mut().insert(key);
+                }
+                // The shared cache is the run-wide, cross-window cache other
+                // files/threads read without ever entering this window; per
+                // `is_stable_for_run_wide_cache`'s own contract it must never
+                // receive a registration-window artifact. Gate its top-level
+                // write on run-wide stability, matching the intermediate drain
+                // below (previously it inherited only the looser
+                // `top_level_clean`, which tolerates `UnresolvedDef`).
+                if intermediates_clean && let Some(shared) = self.shared {
                     shared.insert_eval_cache(self.interner, self.definition_store(), key, result);
                 }
             }
@@ -1962,3 +1992,6 @@ mod property;
 
 #[path = "query_cache_spread.rs"]
 mod spread;
+
+#[path = "query_cache_registration_window.rs"]
+mod registration_window;

--- a/crates/tsz-solver/src/caches/query_cache_registration_window.rs
+++ b/crates/tsz-solver/src/caches/query_cache_registration_window.rs
@@ -1,0 +1,56 @@
+//! Registration-window eviction for the reused checker-pool [`QueryCache`].
+//!
+//! Split out of `query_cache.rs` to keep that shard under the 2000-line
+//! file-size cap. This is a child module of `query_cache`, so it keeps access
+//! to the cache's private fields (`eval_cache`, `eval_dependency_index`, and
+//! `registration_window_eval_keys`).
+//!
+//! The bounded checker pool reuses one `QueryCache` across the files of a
+//! partition, and each file is a distinct def-registration window. A top-level
+//! `eval_cache` entry that the depth-agnostic gate admitted but
+//! `is_stable_for_run_wide_cache` refused (an `UnresolvedDef` registration-window
+//! artifact) is reusable only *within* the window that produced it. The driver
+//! evicts those entries at every file boundary so the invariant
+//! `is_stable_for_run_wide_cache`'s documentation relies on — "the window ends
+//! before the next registration can occur" — actually holds for the reused
+//! cache (#16553).
+
+use super::*;
+
+impl QueryCache<'_> {
+    /// Evict `eval_cache` entries published under a registration-window taint
+    /// (see the `registration_window_eval_keys` field), retaining every clean
+    /// entry so the pool keeps amortizing evaluation cost across files.
+    pub fn evict_registration_window_eval_entries(&self) {
+        let mut keys = self.registration_window_eval_keys.borrow_mut();
+        if keys.is_empty() {
+            return;
+        }
+        let mut cache = self.eval_cache.borrow_mut();
+        for key in keys.drain() {
+            if cache.remove(&key).is_some() {
+                // Keep the reverse dependency index consistent so a later
+                // `invalidate_for_def` never chases an already-evicted key.
+                eval_dependency_index::forget_key(&self.eval_dependency_index, &key);
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn insert_eval_entry_for_test(
+        &self,
+        key: EvaluationCacheKey,
+        result: TypeId,
+        registration_window_tainted: bool,
+    ) {
+        self.insert_eval_cache_entry(key, result);
+        if registration_window_tainted {
+            self.registration_window_eval_keys.borrow_mut().insert(key);
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn eval_cache_contains_key_for_test(&self, key: &EvaluationCacheKey) -> bool {
+        self.eval_cache.borrow().contains_key(key)
+    }
+}

--- a/crates/tsz-solver/src/caches/query_cache_statistics_test.rs
+++ b/crates/tsz-solver/src/caches/query_cache_statistics_test.rs
@@ -1170,3 +1170,38 @@ fn query_cache_statistics_merge_includes_closed_eval_cache() {
     assert_eq!(left.closed_eval_cache_entries, 9);
     assert_eq!(left.permissive_false_branch_cache_entries, 14);
 }
+
+#[test]
+fn evict_registration_window_entries_drops_only_tainted_keys() {
+    use crate::evaluation::request::EvaluationCacheKey;
+
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    // A clean top-level entry (would pass `is_stable_for_run_wide_cache`) and a
+    // registration-window entry (passed only the depth-agnostic gate) share the
+    // reused pool cache. Only the latter is window-scoped.
+    let clean = EvaluationCacheKey::new(TypeId::STRING, false, false);
+    let tainted = EvaluationCacheKey::new(TypeId::NUMBER, false, false);
+    db.insert_eval_entry_for_test(clean, TypeId::BOOLEAN, false);
+    db.insert_eval_entry_for_test(tainted, TypeId::BOOLEAN, true);
+    assert!(db.eval_cache_contains_key_for_test(&clean));
+    assert!(db.eval_cache_contains_key_for_test(&tainted));
+
+    // A file boundary in the checker-pool reuse loop: the window ends, so the
+    // window-scoped entry must go while the clean cross-file entry stays.
+    db.evict_registration_window_eval_entries();
+    assert!(
+        db.eval_cache_contains_key_for_test(&clean),
+        "clean cross-file entry must be retained for pool amortization"
+    );
+    assert!(
+        !db.eval_cache_contains_key_for_test(&tainted),
+        "registration-window entry must not survive into the next file's window"
+    );
+
+    // Idempotent: the tracked-key set was drained, so a second eviction is a
+    // no-op and leaves the clean entry alone.
+    db.evict_registration_window_eval_entries();
+    assert!(db.eval_cache_contains_key_for_test(&clean));
+}


### PR DESCRIPTION
Structural rule: when an `evaluate_type_with_options` result passes only the
depth-agnostic gate (`is_stable_for_depth_agnostic_cache`, which tolerates an
`UnresolvedDef` registration-window taint) but fails the stricter run-wide gate
(`is_stable_for_run_wide_cache`), tsc-parity requires it to stay window-local —
it must not be read across registration windows. `is_stable_for_run_wide_cache`'s
own documentation already states this ("never publish a registration-window
artifact into [the run-wide cache]; the window ends before the next registration
can occur"), but two write paths did not honor it:

1. **Shared cross-file cache.** The shared `eval_cache` top-level write was gated
   only by the looser `top_level_clean`, so it accepted `UnresolvedDef` artifacts
   its own contract forbids. It is now gated on `is_stable_for_run_wide_cache`,
   matching the intermediate drain directly below it.

2. **Reused per-partition cache.** The bounded checker pool reuses one
   `QueryCache` across a partition's files — each a distinct registration window —
   so a window-local top-level entry in the per-partition `eval_cache` outlived
   its window. Such entries are now tracked (`registration_window_eval_keys`) and
   evicted at each file boundary (`evict_registration_window_eval_entries`) from
   the checker-pool reuse loop; clean entries stay, preserving the pool's
   cross-file amortization.

Owner layer: solver `QueryCache` (write gate + eviction) and the CLI checker-pool
reuse loop (per-file eviction call).

**Cache-discipline only** — a refused or evicted entry is recomputed to the same
result, so no diagnostic outcome changes. Same-file circular type-parameter
default recovery (#16587) is unaffected: within a file the entry is still cached
and reused; it is only dropped at the *file boundary*. Both write paths engage
only in multi-file runs (the shared cache needs `checker_item_count > 1`; the
pool eviction needs a multi-file partition), so single-file fixtures are wholly
unaffected.

Relation to #16553: this hardens the documented run-wide-cache invariant and is a
partial mitigation for the checker-pool-vs-fresh-checker divergence family. It
does **not** close #16553's mobx witness itself — that divergence is carried by
interner-level non-canonical identity (#14344/#14345), not the `eval_cache`;
[localization posted on the issue](https://github.com/tsz-org/tsz/issues/16553#issuecomment-5228127281).

## Goal
Goal: hold

## Verification
- `python3 scripts/arch/arch_guard.py` — passed (size caps / boundaries; `query_cache.rs` split into a `query_cache_registration_window.rs` shard to stay under the 2000-line cap).
- `cargo clippy --profile ci-lint --workspace --all-targets -- -D warnings` — passed (green `CI Summary` on this PR head).
- `cargo test -p tsz-solver evict_registration_window_entries_drops_only_tainted_keys` — new unit test, passed.
- Local conformance snapshot on branch head (`./scripts/conformance/conformance.sh snapshot --workers 12 --force`): **0 PASS→FAIL regressions** vs the committed baseline (11555 vs 11500 passing — the +55 is the older baseline SHA plus other merged fixes, not this change). Consistent with the single-file-neutral analysis above. The heavy conformance/emit/fourslash lanes run on the nightly/dispatch schedule, not on PR events.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus
Effort: high