### PR TITLE
fix(solver): unique-symbol array index key no longer falls back to element type

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2031,6 +2031,9 @@ path = "tests/globalthis_namespace_augmentation_tests.rs"
 name = "symbol_index_signature_tests"
 path = "tests/symbol_index_signature_tests.rs"
 [[test]]
+name = "array_unique_symbol_index_key_ts7015_tests"
+path = "tests/array_unique_symbol_index_key_ts7015_tests.rs"
+[[test]]
 name = "non_unique_symbol_late_bound_member_tests"
 path = "tests/non_unique_symbol_late_bound_member_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/array_unique_symbol_index_key_ts7015_tests.rs
+++ b/crates/tsz-checker/tests/array_unique_symbol_index_key_ts7015_tests.rs
@@ -1,0 +1,194 @@
+//! Issue #16948-adjacent: array/tuple index-key evaluation for `unique
+//! symbol` keys.
+//!
+//! Structural rule: `Array<T>[K]` where `K` is a `unique symbol` (a
+//! well-known symbol like `Symbol.isConcatSpreadable`, or a user `declare
+//! const s: unique symbol`) is not a numeric/string index contributor. tsc
+//! reports TS7015 ("index expression is not of type 'number'") under
+//! `noImplicitAny`/strict, matching the existing bare-`symbol` case; it
+//! never treats the key as if it matched the array's own numeric index
+//! signature. tsz's `ArrayKeyVisitor`
+//! (crates/tsz-solver/src/evaluation/evaluate_rules/index_access_keys.rs)
+//! had no `visit_unique_symbol` override, so unhandled key shapes fell
+//! through `default_output()` -> `None` -> the element-type fallback in
+//! `evaluate()`, wrongly checking the assigned value against the array's
+//! element type instead of raising TS7015 — producing a spurious TS2322
+//! whenever the RHS didn't happen to match the element type. Oracled
+//! against `tsc` 7.0.2.
+
+use tsz_checker::CheckerOptions;
+use tsz_checker::diagnostics::diagnostic_codes;
+use tsz_checker::test_utils::{
+    check_source_diagnostics, check_source_with_libs_code_messages, load_default_lib_files,
+};
+
+fn diagnostic_codes_for_ts(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|diagnostic| diagnostic.code)
+        .collect()
+}
+
+#[test]
+fn well_known_symbol_array_index_write_reports_ts7015_not_ts2322() {
+    let libs = load_default_lib_files();
+    if libs.is_empty() {
+        return;
+    }
+    let diagnostics = check_source_with_libs_code_messages(
+        r#"
+let a = ['c', 'd'];
+a[Symbol.isConcatSpreadable] = false;
+"#,
+        "test.ts",
+        CheckerOptions::default(),
+        &libs,
+    );
+    let codes: Vec<u32> = diagnostics.iter().map(|(code, _)| *code).collect();
+    assert!(
+        codes.contains(&diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_INDEX_EXPRESSION_IS_NOT_OF_TYPE_NUMBE),
+        "expected TS7015 for a well-known-symbol array index write, got {diagnostics:?}",
+    );
+    assert!(
+        !codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "well-known-symbol array index write must not fall back to the element type (spurious TS2322), got {diagnostics:?}",
+    );
+}
+
+#[test]
+fn unique_symbol_const_array_index_write_reports_ts7015_not_ts2322() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const s: unique symbol;
+let a = ['c', 'd'];
+a[s] = false;
+"#,
+    );
+    assert!(
+        codes.contains(&diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_INDEX_EXPRESSION_IS_NOT_OF_TYPE_NUMBE),
+        "expected TS7015 for a `unique symbol` const array index write, got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "`unique symbol` array index write must not fall back to the element type (spurious TS2322), got {codes:?}",
+    );
+}
+
+// Renamed binder — proves the fix is structural, not keyed on `s`'s spelling.
+#[test]
+fn unique_symbol_const_array_index_write_reports_ts7015_renamed_binder() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const uniqueKey: unique symbol;
+let letters = ['c', 'd'];
+letters[uniqueKey] = false;
+"#,
+    );
+    assert!(
+        codes.contains(&diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_INDEX_EXPRESSION_IS_NOT_OF_TYPE_NUMBE),
+        "expected TS7015 regardless of the unique-symbol binder's name, got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "renamed unique-symbol array index write must not report TS2322, got {codes:?}",
+    );
+}
+
+// Negative control: plain (non-unique) `symbol` on an array already worked
+// before this fix (`visit_intrinsic`'s `Symbol` arm) — regression guard.
+#[test]
+fn plain_symbol_array_index_write_still_reports_ts7015() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+let s: symbol = Symbol();
+let a = ['c', 'd'];
+a[s] = false;
+"#,
+    );
+    assert!(
+        codes.contains(&diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_INDEX_EXPRESSION_IS_NOT_OF_TYPE_NUMBE),
+        "expected TS7015 for a plain-symbol array index write (regression guard), got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "plain-symbol array index write must not report TS2322, got {codes:?}",
+    );
+}
+
+// Negative control: numeric and string keys must still resolve to the
+// element type via the array's real numeric index signature — the fix must
+// not touch this path.
+#[test]
+fn numeric_and_string_array_index_write_unaffected() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+let a = ['c', 'd'];
+a[0] = 'x';
+a['1'] = 'y';
+"#,
+    );
+    assert!(
+        !codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "numeric/string array index writes with matching element type must stay clean, got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_INDEX_EXPRESSION_IS_NOT_OF_TYPE_NUMBE),
+        "numeric/string array index writes must not report TS7015, got {codes:?}",
+    );
+}
+
+#[test]
+fn numeric_array_index_write_mismatch_still_reports_ts2322() {
+    // Negative control: a genuine element-type mismatch through the real
+    // numeric index signature must still report TS2322 — the fix narrows the
+    // unique-symbol fallback only, not the legitimate numeric-key path.
+    let codes = diagnostic_codes_for_ts(
+        r#"
+let a = ['c', 'd'];
+a[0] = 42;
+"#,
+    );
+    assert!(
+        codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "expected TS2322 for a genuine numeric-index element-type mismatch, got {codes:?}",
+    );
+}
+
+// Read access (not just write) must also route through TS7015, not silently
+// resolve to the element type.
+#[test]
+fn unique_symbol_const_array_index_read_reports_ts7015() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const s: unique symbol;
+let a = ['c', 'd'];
+const v = a[s];
+"#,
+    );
+    assert!(
+        codes.contains(&diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_INDEX_EXPRESSION_IS_NOT_OF_TYPE_NUMBE),
+        "expected TS7015 for a `unique symbol` array index read, got {codes:?}",
+    );
+}
+
+// Unique-symbol index on a tuple was already correct (`TupleKeyVisitor`
+// defaults to `UNDEFINED`, not the fallback bug) — regression guard so the
+// two visitors don't drift.
+#[test]
+fn unique_symbol_const_tuple_index_write_reports_ts7015() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const s: unique symbol;
+let t: [string, string] = ['c', 'd'];
+t[s] = false;
+"#,
+    );
+    assert!(
+        codes.contains(&diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_INDEX_EXPRESSION_IS_NOT_OF_TYPE_NUMBE),
+        "expected TS7015 for a `unique symbol` tuple index write, got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "unique-symbol tuple index write must not report TS2322, got {codes:?}",
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_keys.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_keys.rs
@@ -178,6 +178,15 @@ impl TypeVisitor for ArrayKeyVisitor<'_> {
         }
     }
 
+    /// A `unique symbol` key (e.g. `Symbol.isConcatSpreadable`, `declare const
+    /// s: unique symbol`) is not a numeric/string index contributor, so it
+    /// must resolve like any other unmatched key — `undefined` — not fall
+    /// through to `default_output` -> `None` -> the element-type fallback in
+    /// `evaluate`. Matches the plain-`symbol` arm in `visit_intrinsic` above.
+    fn visit_unique_symbol(&mut self, _symbol_ref: u32) -> Self::Output {
+        Some(TypeId::UNDEFINED)
+    }
+
     /// Signal "use the default fallback" for unhandled type variants.
     fn default_output() -> Self::Output {
         None


### PR DESCRIPTION
Fixes the array-side half of the false-positive family under #16948's slug (`array-unique-symbol-index-key-false-positive-ts2322`).

`ArrayKeyVisitor::evaluate` (`crates/tsz-solver/src/evaluation/evaluate_rules/index_access_keys.rs:121-124`) does `result.unwrap_or(self.element_type)` — any `TypeVisitor` key-shape with no override (`default_output()` -> `None`) silently falls back to the array's element type. `visit_unique_symbol` had no override in `ArrayKeyVisitor`, so a `unique symbol` index key (`Symbol.isConcatSpreadable`, or a user `declare const s: unique symbol`) hit that fallback and got type-checked against the *element* type instead of `undefined` — producing a spurious `TS2322` whenever the assigned/read value's type didn't happen to match the element type.

**Structural rule:** when a `unique symbol` is used as an `Array<T>` index key, `tsc` (7.0.2, oracled) reports `TS7015` ("index expression is not of type 'number'") under `noImplicitAny`/strict — identically to the existing plain-`symbol` case (already correctly handled by `visit_intrinsic`'s `Symbol` arm). It is never treated as a numeric/string index contributor. tsz now matches this: added a `visit_unique_symbol` override to `ArrayKeyVisitor` returning `Some(TypeId::UNDEFINED)`. The sibling `TupleKeyVisitor::evaluate` two structs down already defaults correctly to `TypeId::UNDEFINED`, so tuples were unaffected by the bug — a regression-guard test pins that they stay that way.

**Anti-hardcoding:** the fix is a structural `TypeVisitor` override keyed on the `UniqueSymbol` type-data variant, not any identifier/file/printer-string check. Tests vary the unique-symbol binder name (`s`, `uniqueKey`) to prove the rule isn't spelling-keyed, per repo convention.

New test file `crates/tsz-checker/tests/array_unique_symbol_index_key_ts7015_tests.rs` (kept separate from `symbol_index_signature_tests.rs`, which already sits at its exact 2158-line arch-guard ratchet with zero headroom — see #16488). Adjacent-case matrix: well-known symbol write, `unique symbol` const write (+ renamed binder), read access, `unique symbol` on a tuple (negative control — already correct), plus regression guards: plain `symbol` (already worked), numeric/string keys unaffected, and a genuine numeric-index element-type mismatch still reports `TS2322`.

## Goal
Goal: hold

## Verification
- **Oracle parity (tsc 7.0.2, pinned):** confirmed pre-fix spurious `TS2322` for `declare const s: unique symbol; let a = ['c','d']; a[s] = false;` (reverted the fix locally and re-ran the exact same test to verify); post-fix matches `tsc` exactly (`TS7015`) for well-known-symbol write, `unique symbol` const write, and read access.
- `cargo test -p tsz-checker --test array_unique_symbol_index_key_ts7015_tests` — 8/8 passed (new file).
- `cargo test -p tsz-checker --test symbol_index_signature_tests` — 102/102 passed (unchanged file, confirms no regression in the adjacent symbol-index-signature suite).
- `cargo test -p tsz-solver --lib` — 7657/7657 passed (full solver suite, exercises the shared `TypeVisitor` trait broadly).
- `cargo clippy -p tsz-solver -p tsz-checker --all-targets` — clean.
- `cargo fmt --check` — clean.
- Architecture guard (`scripts/arch/arch_guard_file_limits.py`, run via the pre-commit hook) — clean; new test file kept the existing `symbol_index_signature_tests.rs` ratchet untouched by living in its own file.
- A full `cargo test -p tsz-checker --lib` run (~8500+ tests) was still in progress at push time; will report back if it surfaces anything. The change is a single new match arm in one `TypeVisitor` impl, isolated to `unique symbol` array/tuple indexing — a narrow, previously-mishandled key shape — so no broader interaction is expected.
- Driver/solver+checker-only diff (no emitter path touched); JS/DTS emit floors not expected to move.
- Broad `conformance.sh snapshot` two-sided run not taken this session (narrow fix touching a key shape with no known corpus occurrence per the originating diagnosis); flagged here for anyone landing this to re-run if wanted.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_01Seq7tG4BKUTKf2C78G9UL3)_