### PR TITLE
fix(checker): unknown resolves Object.prototype members under non-strict, not any/never

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/property_access.rs
+++ b/crates/tsz-checker/src/query_boundaries/property_access.rs
@@ -60,6 +60,17 @@ pub(crate) fn resolve_property_access_with_options(
     evaluator.resolve_property_access_atom(obj_type, prop_name)
 }
 
+/// Resolve a property against `unknown`'s non-strict apparent surface (the
+/// `Object.prototype` member table). See
+/// `PropertyAccessEvaluator::resolve_unknown_non_strict_member`.
+pub(crate) fn resolve_unknown_non_strict_property_access(
+    db: &dyn QueryDatabase,
+    prop_name: Atom,
+) -> PropertyAccessResult {
+    let evaluator = tsz_solver::operations::property::PropertyAccessEvaluator::new(db);
+    evaluator.resolve_unknown_non_strict_member(prop_name)
+}
+
 pub(crate) fn resolve_private_identifier_property_access(
     db: &dyn QueryDatabase,
     obj_type: TypeId,

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -1048,7 +1048,8 @@ impl<'a> CheckerState<'a> {
                     Some(property_type.unwrap_or(TypeId::ERROR))
                 }
                 PropertyAccessResult::IsUnknown => {
-                    let unknown_result = self.unknown_object_access_result(access.expression);
+                    let unknown_result =
+                        self.unknown_object_access_result(access.expression, Some(&property_name));
                     if unknown_result.is_some() {
                         use_index_signature_check = false;
                     }
@@ -1183,7 +1184,8 @@ impl<'a> CheckerState<'a> {
                     Some(property_type.unwrap_or(TypeId::ERROR))
                 }
                 PropertyAccessResult::IsUnknown => {
-                    let unknown_result = self.unknown_object_access_result(access.expression);
+                    let unknown_result =
+                        self.unknown_object_access_result(access.expression, Some(&property_name));
                     if unknown_result.is_some() && !keep_index_signature_check {
                         use_index_signature_check = false;
                     }
@@ -1645,7 +1647,7 @@ impl<'a> CheckerState<'a> {
         if use_index_signature_check
             && !is_fresh_object_literal
             && object_type_for_access == TypeId::UNKNOWN
-            && let Some(result) = self.unknown_object_access_result(access.expression)
+            && let Some(result) = self.unknown_object_access_result(access.expression, None)
         {
             return result;
         }

--- a/crates/tsz-checker/src/types/computation/access_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/access_helpers.rs
@@ -241,18 +241,40 @@ impl<'a> CheckerState<'a> {
     /// — so under `strictNullChecks` we emit the diagnostic and return `Some`:
     /// `TS18046` (`'x' is of type 'unknown'.`) when the base expression has a
     /// printable name, otherwise the object form `TS2571` (`Object is of type
-    /// 'unknown'.`), returning `ERROR` to stop cascading diagnostics. When
-    /// `strictNullChecks` is off, `unknown` behaves like `any`; we return `None` so
-    /// each caller can apply its own non-strict fallback (index-signature handling
-    /// for element access, `error_property_not_exist_at` for property access).
+    /// 'unknown'.`), returning `ERROR` to stop cascading diagnostics.
+    ///
+    /// When `strictNullChecks` is off, `unknown` is not simply `any`: for a
+    /// statically known property name (`prop_name`), tsc still resolves it
+    /// against `unknown`'s apparent type, which is the `Object.prototype`
+    /// surface (`toString`, `valueOf`, `hasOwnProperty`, ...). A genuine
+    /// member there returns `Some` with its real type; anything else —
+    /// including a general (non-literal) index with no fixed name to check —
+    /// returns `None` so each caller applies its own non-strict fallback for
+    /// a truly missing member (index-signature handling for element access,
+    /// `error_property_not_exist_at` for dot-access property access).
     ///
     /// This is the single decision gate for the unknown-object access result,
     /// shared by the element-access `literal_string`/`literal_index` arms and the
-    /// property-access path, so the `TS2571`/`TS18046` choice is not re-derived
-    /// independently in each place.
-    pub(crate) fn unknown_object_access_result(&mut self, base_expr: NodeIndex) -> Option<TypeId> {
+    /// property-access path, so the `TS2571`/`TS18046`/`Object.prototype` choice
+    /// is not re-derived independently in each place.
+    pub(crate) fn unknown_object_access_result(
+        &mut self,
+        base_expr: NodeIndex,
+        prop_name: Option<&str>,
+    ) -> Option<TypeId> {
         if !self.ctx.compiler_options.strict_null_checks {
-            return None;
+            let prop_name = prop_name?;
+            let prop_atom = self.ctx.types.intern_string(prop_name);
+            return match crate::query_boundaries::property_access::resolve_unknown_non_strict_property_access(
+                self.ctx.types,
+                prop_atom,
+            ) {
+                tsz_solver::operations::property::PropertyAccessResult::Success {
+                    type_id,
+                    ..
+                } => Some(type_id),
+                _ => None,
+            };
         }
         if self.error_is_of_type_unknown(base_expr) {
             Some(TypeId::ERROR)

--- a/crates/tsz-checker/src/types/computation/access_tests.rs
+++ b/crates/tsz-checker/src/types/computation/access_tests.rs
@@ -176,6 +176,156 @@ class A {
     );
 }
 
+/// Structural rule: when `strictNullChecks` is off, property access on
+/// `unknown` resolves against `unknown`'s apparent type — the
+/// `Object.prototype` surface (`toString`, `valueOf`, `hasOwnProperty`, ...)
+/// — instead of either always failing (dot access) or masking every key to
+/// `any` (element access). A genuinely missing member still reports TS2339
+/// for dot access; `strictNullChecks` on is unaffected (TS18046/TS2571 still
+/// fire unconditionally, matching tsc's `unknown` restriction).
+mod unknown_non_strict_apparent_member_access {
+    use super::*;
+    use crate::test_utils::{check_source_non_strict, check_source_non_strict_codes};
+
+    #[test]
+    fn dot_access_to_object_prototype_member_is_clean() {
+        let diags = check_source_non_strict(
+            r#"
+declare var call: { <T>(): T };
+call().toString();
+call().valueOf();
+call().hasOwnProperty("x");
+"#,
+        );
+        assert!(
+            semantic_errors(&diags).is_empty(),
+            "Expected no diagnostics for Object.prototype members on non-strict unknown, got: {:?}",
+            semantic_errors(&diags)
+        );
+    }
+
+    #[test]
+    fn dot_access_to_missing_member_still_reports_ts2339() {
+        let codes = check_source_non_strict_codes(
+            r#"
+declare var call: { <T>(): T };
+call().nonexistent();
+"#,
+        );
+        assert_eq!(
+            codes,
+            vec![2339],
+            "A member absent from Object.prototype must still be TS2339 under non-strict unknown"
+        );
+    }
+
+    #[test]
+    fn dot_access_renamed_binder_still_resolves() {
+        // Same shape with different identifiers, to rule out a name-string check.
+        let diags = check_source_non_strict(
+            r#"
+declare var produce: { <Widget>(): Widget };
+produce().toString();
+"#,
+        );
+        assert!(
+            semantic_errors(&diags).is_empty(),
+            "Renamed binder must not change resolution: {:?}",
+            semantic_errors(&diags)
+        );
+    }
+
+    #[test]
+    fn bracket_access_to_object_prototype_member_resolves_real_type() {
+        // If tsz masked the member to `any` (its pre-fix behavior), this
+        // assignment would be silently accepted instead of reporting TS2322.
+        let codes = check_source_non_strict_codes(
+            r#"
+declare var call: { <T>(): T };
+var mismatch: number = call()["toString"]();
+"#,
+        );
+        assert_eq!(
+            codes,
+            vec![2322],
+            "Bracket access must resolve the real Object.prototype member type, got: {codes:?}"
+        );
+    }
+
+    #[test]
+    fn bracket_access_to_missing_member_stays_implicit_any() {
+        // Unchanged pre-fix behavior: a non-Object member via bracket access
+        // on non-strict `unknown` still falls back to implicit `any`, not TS2339.
+        let diags = check_source_non_strict(
+            r#"
+declare var call: { <T>(): T };
+call()["nonexistent"]();
+"#,
+        );
+        assert!(
+            semantic_errors(&diags).is_empty(),
+            "Bracket access to a missing member should stay implicit any under non-strict unknown: {:?}",
+            semantic_errors(&diags)
+        );
+    }
+
+    #[test]
+    fn general_index_access_on_unknown_is_unaffected() {
+        // A non-literal (dynamic) index has no fixed name to check against
+        // Object.prototype, so this path is untouched by the fix.
+        let diags = check_source_non_strict(
+            r#"
+declare var call: { <T>(): T };
+declare var key: string;
+call()[key];
+"#,
+        );
+        assert!(
+            semantic_errors(&diags).is_empty(),
+            "General index access on non-strict unknown must stay unaffected: {:?}",
+            semantic_errors(&diags)
+        );
+    }
+
+    #[test]
+    fn strict_null_checks_still_rejects_object_prototype_member() {
+        // Regression guard: the strict-mode gate must still fire
+        // unconditionally, even for a genuine Object.prototype member. A
+        // plain identifier receiver gets the named TS18046 form; the call
+        // expression in the sibling test below gets the unnamed TS2571 form
+        // (no printable base name) — both are the strict-mode block, neither
+        // falls through to the non-strict apparent-member resolution.
+        let diags = check_source_with_default_libs(
+            r#"
+declare var u: unknown;
+u.toString();
+"#,
+        );
+        let errors = semantic_errors(&diags);
+        assert_eq!(
+            errors,
+            vec![18046],
+            "strictNullChecks must still block unknown member access unconditionally: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn strict_null_checks_still_rejects_object_prototype_member_no_printable_name() {
+        let diags = check_source_with_default_libs(
+            r#"
+declare var call: { <T>(): T };
+call().toString();
+"#,
+        );
+        let errors = semantic_errors(&diags);
+        assert_eq!(
+            errors,
+            vec![2571],
+            "strictNullChecks must still block unknown member access without a printable base name: {errors:?}"
+        );
+    }
+}
+
 #[test]
 fn inherited_static_member_element_access_emits_ts2576() {
     let diags = check_source_with_default_libs(

--- a/crates/tsz-checker/src/types/property_access_type/identifier_resolution.rs
+++ b/crates/tsz-checker/src/types/property_access_type/identifier_resolution.rs
@@ -1800,10 +1800,14 @@ impl<'a> CheckerState<'a> {
 
             PropertyAccessResult::IsUnknown => {
                 // Shared unknown-object decision gate (TS18046/TS2571 under
-                // strictNullChecks). `None` means non-strict, where property
-                // access reports the missing property instead of falling
-                // through to index signatures the way element access does.
-                if let Some(result) = self.unknown_object_access_result(access.expression) {
+                // strictNullChecks; the `Object.prototype` apparent-surface
+                // fallback otherwise). `None` means the property is genuinely
+                // missing even from that surface, so property access reports
+                // it instead of falling through to index signatures the way
+                // element access does.
+                if let Some(result) = self
+                    .unknown_object_access_result(access.expression, Some(property_name.as_str()))
+                {
                     return result;
                 }
                 self.error_property_not_exist_at(

--- a/crates/tsz-solver/src/operations/property.rs
+++ b/crates/tsz-solver/src/operations/property.rs
@@ -531,6 +531,18 @@ impl<'a> PropertyAccessEvaluator<'a> {
             })
     }
 
+    /// Resolve a property against `unknown`'s non-strict apparent surface.
+    ///
+    /// `unknown` itself has no members, but when `strictNullChecks` is off
+    /// tsc does not treat `unknown` as `any` for member access — it still
+    /// requires the property to exist on `unknown`'s apparent type, which is
+    /// the same `Object.prototype` surface `IntrinsicKind::Object` resolves
+    /// through. The checker calls this only after its own strict-mode gate
+    /// (`TS18046`/`TS2571`) has already declined to fire.
+    pub fn resolve_unknown_non_strict_member(&self, prop_atom: Atom) -> PropertyAccessResult {
+        self.resolve_object_member_or_not_found(TypeId::UNKNOWN, prop_atom)
+    }
+
     pub(crate) fn is_deferred_any_fallback_member(&self, type_id: TypeId) -> bool {
         if type_id.is_intrinsic() {
             return false;


### PR DESCRIPTION
Structural rule: when `strictNullChecks` is off, `tsc` does not treat `unknown` as `any` for member access — it still resolves the property against `unknown`'s apparent type, the same `Object.prototype` surface (`toString`/`valueOf`/`hasOwnProperty`/...) `IntrinsicKind::Object` already uses through `PropertyAccessEvaluator::resolve_object_member`. tsz did this through two independently wrong non-strict fallbacks:

- **Dot access** (`identifier_resolution.rs`'s `PropertyAccessResult::IsUnknown` arm) unconditionally reported the property missing, even when it existed on `Object.prototype` — a false-positive TS2339 on e.g. `a().toString()` where `a: { <T>(): T }` (no candidates/no constraint infers `T = unknown`).
- **Element access** (`access.rs`, both the `literal_string` and `literal_index` arms) unconditionally masked every key to `any`, even a genuine member — a false negative: `a()['toString']()` silently typed `any` instead of the real `() => string`, so `var x: number = a()['toString']()` accepted without error.

Both now share the existing `unknown_object_access_result` decision gate (`access_helpers.rs`), extended to try the solver's Object-prototype member table via a new `PropertyAccessEvaluator::resolve_unknown_non_strict_member` (exposed through the `query_boundaries::property_access` gateway) before falling through to each caller's existing "truly missing" behavior — dot access still reports TS2339, element access still falls back to implicit `any`. The general (non-literal-key) index-access path (`obj[dynamicKey]`) is unaffected, since there is no fixed name to check against the table. `strictNullChecks` on is unchanged: TS18046/TS2571 still fire unconditionally, before this new fallback is ever consulted.

Owner layer: solver (`crates/tsz-solver/src/operations/property.rs`, reusing the existing `resolve_object_member`/`apparent_object_member_kind` table — no new hardcoded identifier list), wired through the checker's existing shared gate.

Found via the `--false-positives` conformance queue: `modularizeLibrary_UsingES5LibES6ArrayLibES6WellknownSymbolLib.ts` and `propertyAccessOnTypeParameterWithoutConstraints.ts` both false-positive TS2322/TS2339; this PR fixes the latter (the former, a `unique symbol` array-index-key issue, is unrelated and out of scope here).

## Goal
Goal: hold

## Verification
- Oracle-pinned (`typescript@7.0.2`, per `scripts/conformance/typescript-versions.json`): confirmed both the false-positive (`a().toString()` clean) and the two adjacent negative/positive controls (`a().nonexistent()` → TS2339; `strictNullChecks: true` → TS18046/TS2571 unconditionally) match `tsc` exactly before/after.
- `cargo test -p tsz-checker --lib unknown_non_strict_apparent_member_access` — 8/8 new tests: dot/bracket access to an existing vs. missing member, a renamed-binder positive control, the general (dynamic-key) index path (unaffected), and two strictNullChecks-on regression guards (TS18046 named form, TS2571 unnamed form).
- `cargo fmt` + `cargo clippy -p tsz-checker -p tsz-solver --lib -- -D warnings` — clean.
- Pre-commit hook (`cargo fmt` + affected-crate clippy + architecture guard) — passed.
- Full corpus fixture `TypeScript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithoutConstraints.ts` run through the built CLI — clean (was 1 spurious TS2339 before).
- `cargo test -p tsz-checker --lib` (full suite, dev profile) — in progress at time of opening; will report the count once it lands, no regressions expected given the narrow surface (only triggers when the resolved receiver type is exactly the intrinsic `TypeId::UNKNOWN`, under non-strict, with a statically known property name).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUeT816ACSmbj9LfTQqcE9)_