### PR TITLE
fix(checker): remove 3 inert fixture-gated diagnostic rewrites (#14141)

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -883,13 +883,10 @@ impl CheckerState<'_> {
                 || !is_same_display_assignability_message(&diag.message_text)
         });
 
-        self.rewrite_infer_generic_return_fingerprints(&sf.text);
         self.rewrite_conditional_types1_fingerprints(&sf.text);
         self.align_awaited_type_instantiation_diagnostics(&sf.text);
         self.align_evolving_array_inference_diagnostics(&sf.text);
-        self.align_type_inference_literal_union_diagnostics(&sf.text);
         self.align_complex_recursive_collections_diagnostics(&sf.text);
-        self.align_jsx_element_type_diagnostics(&sf.text);
     }
 
     /// Grammar pass for misplaced `unique symbol` type operators — the
@@ -1038,33 +1035,6 @@ impl CheckerState<'_> {
 
     fn fixture_has_markers(source: &str, markers: &[&str]) -> bool {
         markers.iter().all(|marker| source.contains(marker))
-    }
-
-    fn rewrite_infer_generic_return_fingerprints(&mut self, source_text: &str) {
-        use tsz_common::diagnostics::diagnostic_codes;
-
-        if !(source_text.contains("inferFromGenericFunctionReturnTypes3")
-            || source_text.contains("Repros from #5487")
-                && source_text.contains("Breaking change repros from #29478")
-                && source_text.contains("Promise.all(["))
-        {
-            return;
-        }
-
-        // Residual divergence-A only (tracked on #14141): the contextual return
-        // type of `f1: F = () => Promise.all([...])` is not propagated into the
-        // `Promise.all` reverse-mapped-tuple argument, so `tsz` widens the tuple
-        // element and emits a spurious `() => Promise<[...]>` vs `F` TS2322. Drop
-        // it until reverse-mapped contextual argument inference lands.
-        //
-        // The former `bar(() => cond ? [A] : [B])` TS2345→TS2322 rewrite is gone:
-        // the arrow-conditional-body return mismatch now drills to the inner
-        // conditional as `tsc` does, natively (`elaborate_expression_body_return_mismatch`).
-        self.ctx.diagnostics.retain(|diag| {
-            !(diag.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
-                && diag.message_text.contains("Type '() => Promise<[")
-                && diag.message_text.contains("not assignable to type 'F'"))
-        });
     }
 
     fn rewrite_conditional_types1_fingerprints(&mut self, source_text: &str) {
@@ -1278,39 +1248,6 @@ impl CheckerState<'_> {
         ));
     }
 
-    fn align_type_inference_literal_union_diagnostics(&mut self, source_text: &str) {
-        use tsz_common::diagnostics::diagnostic_codes;
-
-        if !Self::fixture_has_markers(
-            source_text,
-            &[
-                "export function extent<T extends Numeric>",
-                "class NumCoercible",
-                "extentMixed = extent([new NumCoercible(10), 13, '12', true]);",
-            ],
-        ) {
-            return;
-        }
-
-        let Some(line_start) =
-            source_text.find("extentMixed = extent([new NumCoercible(10), 13, '12', true]);")
-        else {
-            return;
-        };
-        let line_end = source_text[line_start..]
-            .find('\n')
-            .map(|offset| line_start + offset)
-            .unwrap_or(source_text.len());
-        self.ctx.diagnostics.retain(|diag| {
-            diag.code != diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
-                || !((diag.start as usize) >= line_start
-                    && (diag.start as usize) < line_end
-                    && diag
-                        .message_text
-                        .contains("[Primitive | Numeric, Primitive | Numeric]"))
-        });
-    }
-
     fn align_complex_recursive_collections_diagnostics(&mut self, source_text: &str) {
         use tsz_common::diagnostics::diagnostic_codes;
 
@@ -1337,57 +1274,6 @@ impl CheckerState<'_> {
                     .iter()
                     .any(|message| diag.message_text == *message)
         });
-    }
-
-    fn align_jsx_element_type_diagnostics(&mut self, source_text: &str) {
-        use tsz_common::diagnostics::{Diagnostic, diagnostic_codes};
-
-        if !Self::fixture_has_markers(
-            source_text,
-            &[
-                "type NewReactJSXElementConstructor<P>",
-                "class RenderStringClass extends React.Component",
-                "<RenderStringClass excessProp />;",
-            ],
-        ) {
-            return;
-        }
-
-        self.ctx.diagnostics.retain(|diag| {
-            !(diag.code == diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE
-                && diag.message_text
-                    == "Property 'props' does not exist on type 'RenderStringClass'.")
-        });
-
-        let overload_code = diagnostic_codes::NO_OVERLOAD_MATCHES_THIS_CALL;
-        let overload_message = "No overload matches this call.";
-        let anchors = [
-            ("<RenderStringClass />;", "RenderStringClass"),
-            ("<RenderStringClass excessProp />;", "excessProp"),
-        ];
-        for (line_marker, anchor) in anchors {
-            let Some(line_start) = source_text.find(line_marker) else {
-                continue;
-            };
-            let Some(anchor_offset) = source_text[line_start..].find(anchor) else {
-                continue;
-            };
-            let start = (line_start + anchor_offset) as u32;
-            if self.ctx.diagnostics.iter().any(|existing| {
-                existing.code == overload_code
-                    && existing.start == start
-                    && existing.message_text == overload_message
-            }) {
-                continue;
-            }
-            self.ctx.diagnostics.push(Diagnostic::error(
-                self.ctx.file_name.clone(),
-                start,
-                1,
-                overload_message,
-                overload_code,
-            ));
-        }
     }
 
     fn has_ts_nocheck_pragma(&self, source: &str) -> bool {


### PR DESCRIPTION
Removes three of the seven source-text-gated `rewrite_*`/`align_*` diagnostic rewrites in `crates/tsz-checker/src/state/state_checking/source_file.rs`. These are the "most explicit form of what the Anti-Hardcoding Gate forbids" (per #14141) — they gate on fixture source text, match hardcoded message sentences carrying user identifiers, and inject/drop diagnostics at text-searched offsets. Five weeks of solver progress since the last audit (2026-07-02) has rendered these three inert, so they can be deleted with zero conformance impact — the same fate as `recursiveTypeReferences1` (#14436) and `typeGuardOfFormIsTypeOnInterfaces` (#15473).

## Structural rule
When a diagnostic rewrite is gated on a conformance fixture's source text, it is a hardcoded suppression that must be deleted once the solver produces the correct diagnostics natively **or** once the rewrite's own string predicates have rotted and match nothing. An audit that disables each rewrite and compares its fixture against the tsc 7.0.2 cache classifies each one:

| removed rewrite | fixture | rewrite ON | rewrite OFF | verdict |
| --- | --- | --- | --- | --- |
| `align_jsx_element_type_diagnostics` | `jsxElementType.tsx` | PASS | PASS | **dead no-op** — passes natively (`jsx_element_type_constraint_tests`) |
| `rewrite_infer_generic_return_fingerprints` | `inferFromGenericFunctionReturnTypes3.ts` | FAIL | FAIL | **ineffective** — `"() => Promise<["` predicate no longer matches the current `"() => Promise<{...}[]>"` render (byte-identical ON/OFF) |
| `align_type_inference_literal_union_diagnostics` | `typeInferenceLiteralUnion.ts` | FAIL | FAIL | **ineffective** — retain predicate matches no current diagnostic (byte-identical ON/OFF) |

Each removed marker set matches **only** its one intended fixture across the entire corpus (`grep`-verified), so removal is conformance-neutral corpus-wide.

The four still-load-bearing rewrites are **retained** pending native root-cause fixes (each PASS→FAIL when disabled): `rewrite_conditional_types1_fingerprints`, `align_awaited_type_instantiation_diagnostics` (`awaitedTypeStrictNull`), `align_evolving_array_inference_diagnostics`, `align_complex_recursive_collections_diagnostics`.

## Goal
Goal: hold

## Verification
- **Audit method (same binary, env toggle):** built `dist-fast`, ran each fixture with all rewrites enabled vs. disabled against `scripts/conformance/tsc-cache-full.json` (tsc 7.0.2, `TSZ_LIB_DIR` = pinned corpus libs). Transition table above.
- **Neutrality of the two `FAIL→FAIL` removals:** full `--verbose` output is byte-identical ON vs OFF (`diff` empty) — the rewrites match nothing.
- **Isolation:** `grep -rl <marker>` over `TypeScript/tests/cases` returns exactly one file per removed rewrite (its intended fixture); no other corpus file can be affected.
- **Post-removal fixture pass-set** identical to pre-removal baseline: `jsxElementType*` PASS, `conditionalTypes1`/`inferenceShouldFailOnEvolvingArrays`/`complexRecursiveCollections`/`awaitedTypeStrictNull` PASS (load-bearing kept), `inferFromGenericFunctionReturnTypes3`/`typeInferenceLiteralUnion`/`awaitedType.ts` FAIL (unchanged).
- **Full conformance run:** the three affected fixtures do not appear in the diff vs the committed baseline (unchanged); the only PASS→FAIL entries are unrelated commonjs/salsa/jsdoc export tests attributable to pre-existing main drift vs a stale committed baseline, not to this diff.
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`: clean.
- Architecture guard (pre-commit): passed; `source_file.rs` now 1629 lines (pure −114 deletion).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5xvUwWcwadqkMkPpZiDu7)_