### PR TITLE
fix(checker): enforce TS2462 rest-must-be-last for object and nested destructuring assignment targets

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -531,6 +531,9 @@ path = "tests/tuple_rest_destructuring_slice_tests.rs"
 name = "destructuring_binding_element_source_tests"
 path = "tests/destructuring_binding_element_source_tests.rs"
 [[test]]
+name = "destructuring_assignment_rest_position_tests"
+path = "tests/destructuring_assignment_rest_position_tests.rs"
+[[test]]
 name = "nan_equality_lib_symbol_ids_tests"
 path = "tests/nan_equality_lib_symbol_ids_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
@@ -907,7 +907,6 @@ impl<'a> CheckerState<'a> {
             let is_iterable =
                 self.check_destructuring_iterability(left_idx, right_type, NodeIndex::NONE);
             is_not_iterable = !is_iterable;
-            self.check_array_destructuring_rest_position(left_idx);
             if !is_not_iterable {
                 self.check_tuple_destructuring_bounds(left_idx, right_type);
             }
@@ -917,6 +916,7 @@ impl<'a> CheckerState<'a> {
         if is_destructuring {
             self.check_rest_element_initializer(left_idx);
             self.check_rest_element_trailing_comma(left_idx);
+            self.check_destructuring_rest_position(left_idx);
         }
 
         // tsc suppresses TS2322 alongside TS2540 (readonly named property writes)
@@ -1570,37 +1570,74 @@ impl<'a> CheckerState<'a> {
             .is_some_and(|bin| bin.operator_token == SyntaxKind::EqualsToken as u16)
     }
 
-    /// TS2462: A rest element in array destructuring must be the last element.
+    /// TS2462: A rest element must be last in a destructuring pattern.
     ///
-    /// Enforce syntax for array destructuring assignment targets.
-    fn check_array_destructuring_rest_position(&mut self, left_idx: NodeIndex) {
-        let Some(left_node) = self.ctx.arena.get(left_idx) else {
-            return;
-        };
-        if left_node.kind != syntax_kind_ext::ARRAY_LITERAL_EXPRESSION {
-            return;
-        }
-        let Some(array_lit) = self.ctx.arena.get_literal_expr(left_node) else {
+    /// Enforces the "rest must be last" rule for both array (`[...a, b] = x`)
+    /// and object (`({ ...a, b } = x)`) destructuring *assignment* targets, at
+    /// every nesting level. The parser owns the binding-pattern form
+    /// (`let { ...a, b } = x`, enforced in `type_checking::core`); assignment
+    /// targets parse as plain array/object literals — where a spread is legal
+    /// expression syntax anywhere — so the pattern-context rule is only
+    /// enforceable here. Array rest parses as `SpreadElement`, object rest as
+    /// `SpreadAssignment`; either one is illegal unless it is the final element.
+    ///
+    /// Mirrors `check_rest_element_trailing_comma`'s recursion so a mis-placed
+    /// rest is reported inside nested targets (`[x, { ...a, y }] = z`,
+    /// `({ p: [...a, b] } = z)`, `[a, [...b, x]] = z`), matching tsc. Anchored
+    /// at the offending spread element.
+    fn check_destructuring_rest_position(&mut self, node_idx: NodeIndex) {
+        let Some(node) = self.ctx.arena.get(node_idx) else {
             return;
         };
 
-        let elements_len = array_lit.elements.nodes.len();
-        if elements_len == 0 {
+        // A `pattern = default` assignment target: the destructuring pattern is
+        // on the left; the right side is a value expression, not a target.
+        if let Some(bin) = self.ctx.arena.get_binary_expr(node)
+            && bin.operator_token == SyntaxKind::EqualsToken as u16
+        {
+            self.check_destructuring_rest_position(bin.left);
             return;
         }
-        for (i, &element_idx) in array_lit.elements.nodes.iter().enumerate() {
-            if i + 1 >= elements_len {
-                break;
-            }
+
+        let is_array = node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION;
+        let is_object = node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION;
+        if !is_array && !is_object {
+            return;
+        }
+        let Some(lit) = self.ctx.arena.get_literal_expr(node) else {
+            return;
+        };
+
+        let elements: Vec<NodeIndex> = lit.elements.nodes.clone();
+        let last = elements.len().saturating_sub(1);
+        for (i, &element_idx) in elements.iter().enumerate() {
             let Some(element_node) = self.ctx.arena.get(element_idx) else {
                 continue;
             };
-            if element_node.kind == syntax_kind_ext::SPREAD_ELEMENT {
+            let is_rest = element_node.kind == syntax_kind_ext::SPREAD_ELEMENT
+                || element_node.kind == syntax_kind_ext::SPREAD_ASSIGNMENT;
+            if is_rest && i < last {
                 self.error_at_node_msg(
                     element_idx,
                     diagnostic_codes::A_REST_ELEMENT_MUST_BE_LAST_IN_A_DESTRUCTURING_PATTERN,
                     &[],
                 );
+            }
+
+            // Recurse into nested destructuring targets: object property values,
+            // rest operands, and nested array/object patterns (the latter reach
+            // the array/object branch above; a `= default` element unwraps via
+            // the binary-`=` handling at the top of this method).
+            if element_node.kind == syntax_kind_ext::PROPERTY_ASSIGNMENT {
+                if let Some(prop) = self.ctx.arena.get_property_assignment(element_node) {
+                    self.check_destructuring_rest_position(prop.initializer);
+                }
+            } else if is_rest {
+                if let Some(spread) = self.ctx.arena.get_spread(element_node) {
+                    self.check_destructuring_rest_position(spread.expression);
+                }
+            } else {
+                self.check_destructuring_rest_position(element_idx);
             }
         }
     }

--- a/crates/tsz-checker/tests/destructuring_assignment_rest_position_tests.rs
+++ b/crates/tsz-checker/tests/destructuring_assignment_rest_position_tests.rs
@@ -1,0 +1,131 @@
+//! TS2462 ("A rest element must be last in a destructuring pattern") for
+//! destructuring *assignment* targets.
+//!
+//! The parser enforces the rule for binding-pattern forms (`let { ...a, b } = x`);
+//! assignment targets parse as plain array/object literals, so the checker must
+//! enforce it. Previously only top-level *array* assignment targets were checked;
+//! object targets and every nested target were silently accepted. These tests
+//! pin parity with `tsc` (verified against `typescript@7.0.2`).
+
+use tsz_checker::test_utils::{check_source_diagnostics, diagnostic_codes, diagnostic_count};
+
+fn ts2462_count(source: &str) -> usize {
+    let diagnostics = check_source_diagnostics(source);
+    diagnostic_count(&diagnostics, 2462)
+}
+
+/// The reported conformance witness (`objectRestPropertyMustBeLast.ts`): an
+/// object rest that is not the last property in an assignment target errors.
+#[test]
+fn object_rest_not_last_in_assignment_errors() {
+    let source = r#"
+var a: any, x: any;
+({ ...a, x } = { x: 1 });
+"#;
+    assert_eq!(
+        ts2462_count(source),
+        1,
+        "object rest before another property in an assignment target must emit TS2462, got {:?}",
+        diagnostic_codes(&check_source_diagnostics(source))
+    );
+}
+
+/// Two out-of-place rests (`{ ...a, x, ...b }`): only the non-last `...a`
+/// errors, matching `tsc` (the trailing `...b` is a valid last rest).
+#[test]
+fn object_rest_only_non_last_errors_in_assignment() {
+    let source = r#"
+var a: any, b: any, x: any;
+({ ...a, x, ...b } = { x: 1 });
+"#;
+    assert_eq!(
+        ts2462_count(source),
+        1,
+        "only the non-last object rest must emit TS2462, got {:?}",
+        diagnostic_codes(&check_source_diagnostics(source))
+    );
+}
+
+/// A rest that IS last is legal in both object and array assignment targets.
+#[test]
+fn rest_last_in_assignment_is_ok() {
+    let source = r#"
+var a: any, b: any, p: any, x: any, z: any;
+({ p, ...a } = z);
+[x, ...b] = z;
+"#;
+    assert_eq!(
+        ts2462_count(source),
+        0,
+        "a trailing rest must not emit TS2462, got {:?}",
+        diagnostic_codes(&check_source_diagnostics(source))
+    );
+}
+
+/// The check recurses into nested targets: object rest inside an array target,
+/// object rest inside an object target, and an array rest inside an object
+/// target all error, matching `tsc`.
+#[test]
+fn nested_out_of_place_rest_in_assignment_errors() {
+    let source = r#"
+var a: any, b: any, c: any, x: any, y: any, p: any, z: any;
+[x, { ...a, y }] = z;
+({ p: { ...b, y } } = z);
+({ p: [...c, y] } = z);
+"#;
+    assert_eq!(
+        ts2462_count(source),
+        3,
+        "each nested out-of-place rest must emit TS2462, got {:?}",
+        diagnostic_codes(&check_source_diagnostics(source))
+    );
+}
+
+/// Regression: a top-level array rest that is not last still errors (behavior
+/// preserved from the previous array-only implementation), and a nested array
+/// rest now errors too.
+#[test]
+fn array_rest_not_last_in_assignment_errors_including_nested() {
+    let source = r#"
+var a: any, b: any, x: any, z: any;
+[...a, x] = z;
+[a, [...b, x]] = z;
+"#;
+    assert_eq!(
+        ts2462_count(source),
+        2,
+        "top-level and nested non-last array rests must each emit TS2462, got {:?}",
+        diagnostic_codes(&check_source_diagnostics(source))
+    );
+}
+
+/// Anti-hardcoding: the rule is structural (spread position), not keyed on any
+/// particular identifier. Renaming the binders keeps exactly one diagnostic.
+#[test]
+fn rest_position_rule_is_name_independent() {
+    let source = r#"
+var head: any, tail: any, mid: any;
+({ ...head, mid } = { mid: 1 });
+"#;
+    assert_eq!(
+        ts2462_count(source),
+        1,
+        "renaming binders must not change the structural TS2462 outcome, got {:?}",
+        diagnostic_codes(&check_source_diagnostics(source))
+    );
+}
+
+/// The declaration binding-pattern path is unchanged: `var { ...a, x } = ...`
+/// still emits exactly one TS2462 (enforced separately from assignment targets).
+#[test]
+fn declaration_binding_pattern_rest_still_errors_once() {
+    let source = r#"
+var { ...a, x } = { x: 1 };
+"#;
+    assert_eq!(
+        ts2462_count(source),
+        1,
+        "declaration binding-pattern rest-not-last must still emit exactly one TS2462, got {:?}",
+        diagnostic_codes(&check_source_diagnostics(source))
+    );
+}


### PR DESCRIPTION
Fixes #16963.

## Summary

TS2462 ("A rest element must be last in a destructuring pattern") was only
enforced for **top-level array** destructuring *assignment* targets. Object
assignment targets and **every nested** destructuring target silently accepted
an out-of-place rest, unlike `tsc`.

```ts
({ ...a, x } = { x: 1 });        // tsc: TS2462 @ ...a — tsz (before): no error
[x, { ...a, y }] = z;            // tsc: TS2462 @ ...a — tsz (before): no error
({ p: [...a, b] } = z);          // tsc: TS2462 @ ...a — tsz (before): no error
[a, [...b, x]] = z;              // tsc: TS2462 @ ...b — tsz (before): no error (nested array missed too)
```

The parser owns the binding-pattern form (`let { ...a, b } = x`, enforced in
`type_checking::core`). Assignment targets parse as plain array/object
literals — where a spread is legal expression syntax anywhere — so the
"rest must be last" pattern-context rule is only enforceable in the checker.

## Structural rule

When a destructuring **assignment target** contains a rest element that is not
the final element of its pattern, `tsc` reports TS2462. Array rest parses as
`SpreadElement`, object rest as `SpreadAssignment`; the rule applies to both and
at every nesting level (`checker.ts` `checkArrayLiteralAssignmentElements` /
`checkObjectLiteralAssignment`). tsz now enforces it through the checker's
assignment path (`assignability::assignment_checker`).

## Owner layer / breadth

Replaced the array-only, non-recursive `check_array_destructuring_rest_position`
with a recursive `check_destructuring_rest_position`
(`crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs`)
that:

- handles **both** array (`SpreadElement`) and object (`SpreadAssignment`)
  assignment targets;
- recurses into nested targets — nested array/object patterns, object property
  values, and `pattern = default` left sides — mirroring the existing
  `check_rest_element_trailing_comma` traversal, so the recursion set is proven
  and does not descend into default *value* expressions (a value spread inside a
  default like `[a = [1, ...rest]] = z` is correctly left alone);
- anchors the diagnostic at the offending spread element, matching `tsc`'s span.

It is now invoked for all destructuring assignments (object and array), not only
arrays.

## Anti-hardcoding

The rule is purely structural (spread node kind and position within its
pattern) — no identifier/file/printer-string checks. A name-independence test
varies the binders. Value spreads and trailing (last-position) rests are
untouched.

## Adjacent-case matrix (verified against `typescript@7.0.2` via `scripts/conformance/oracle.sh`)

| case | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `({ ...a, x } = z)` object rest not last | TS2462 | — | TS2462 |
| `({ ...a, x, ...b } = z)` two rests | TS2462 (on `...a`) | — | TS2462 (on `...a`) |
| `[x, { ...a, y }] = z` nested object in array | TS2462 | — | TS2462 |
| `({ p: { ...a, y } } = z)` nested object in object | TS2462 | — | TS2462 |
| `({ p: [...a, y] } = z)` nested array in object | TS2462 | — | TS2462 |
| `[...a, x] = z` top-level array | TS2462 | TS2462 | TS2462 |
| `[a, [...b, x]] = z` nested array in array | TS2462 | — | TS2462 |
| `({ p, ...a } = z)` / `[x, ...a] = z` rest last | clean | clean | clean |
| `[a = [1, ...rest]] = z` value spread in default | clean | clean | clean |
| `let { ...a, x } = z` declaration binding pattern | TS2462 | TS2462 | TS2462 (unchanged path) |

Closes the `objectRestPropertyMustBeLast.ts` conformance false-negative
(0-extra / +2 previously-missing TS2462).

## Goal
Goal: hold

## Verification

- New regression suite `crates/tsz-checker/tests/destructuring_assignment_rest_position_tests.rs`
  (7 tests): object rest not-last, two-rest single-error, trailing-rest-ok,
  nested (object-in-array / object-in-object / array-in-object), array
  top-level + nested, name-independence, and declaration-path-unchanged — all pass.
- Oracle parity for every row in the matrix above, plus a no-false-positive
  battery (value spreads in defaults, plain value spreads, valid trailing
  rests) — byte-matches `tsc`.
- `cargo clippy --release -p tsz-checker` — clean (production crate); the
  pre-commit hook's clippy + architecture guard also passed.
- `scripts/arch/arch_guard.py` — passed (touched file 1957/2000 lines).
- Full conformance snapshot (`conformance.sh snapshot --workers 12 --force`) at
  branch HEAD: 11554 passed. **Isolated effect of this change**, verified by
  diffing per-fixture TS2462 code-sets against the pre-change detail:
  `objectRestPropertyMustBeLast.ts` moves failing → passing; **zero** fixtures
  gain a spurious extra TS2462 and **zero** remain missing a TS2462. The change
  emits only TS2462 (in destructuring-assignment position), so it cannot affect
  any other diagnostic — confirmed: the only non-TS2462 rows that differ from the
  committed baseline are intervening-main-delta `this`/module rows
  (TS2683/TS2309) in files with no destructuring, unrelated to this diff.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_018UYtBD9XEkEmfENUjwSmUb)_