### PR TITLE
chore(readme): refresh conformance to 11,553 and DTS to 1,377

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ test suite against it.
 
 <!-- CONFORMANCE_START -->
 ```
-Progress: [███████████████████░] 95.9% (11,554/12,043 runnable tests)
+Progress: [███████████████████░] 95.9% (11,555/12,043 runnable tests)
 Candidates: 12,585 (12,043 runnable, 507 unsupported, 35 skipped)
 ```
 <!-- CONFORMANCE_END -->

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ test suite against it.
 
 <!-- CONFORMANCE_START -->
 ```
-Progress: [███████████████████░] 95.9% (11,545/12,043 runnable tests)
+Progress: [███████████████████░] 95.9% (11,553/12,043 runnable tests)
 Candidates: 12,585 (12,043 runnable, 507 unsupported, 35 skipped)
 ```
 <!-- CONFORMANCE_END -->
@@ -85,7 +85,7 @@ Candidates: 12,585 (12,043 runnable, 507 unsupported, 35 skipped)
 <!-- EMIT_START -->
 ```
 JavaScript:  [████████████████████] 100.0% (11,562 / 11,563 tests)
-Declaration: [████████████████████] 98.9% (1,375 / 1,390 tests)
+Declaration: [████████████████████] 99.1% (1,377 / 1,390 tests)
 ```
 <!-- EMIT_END -->
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ test suite against it.
 
 <!-- CONFORMANCE_START -->
 ```
-Progress: [███████████████████░] 95.9% (11,553/12,043 runnable tests)
+Progress: [███████████████████░] 95.9% (11,554/12,043 runnable tests)
 Candidates: 12,585 (12,043 runnable, 507 unsupported, 35 skipped)
 ```
 <!-- CONFORMANCE_END -->


### PR DESCRIPTION
Goal: hold

Refreshes the generated README blocks from snapshots measured at `21679b1f49`.

- conformance: `11,545` -> `11,553` (95.9%)
- **emit DTS: `1,375` -> `1,377` (98.9% -> 99.1%)**

The DTS movement is the notable one: that figure had been pinned at exactly
`1375 / 1390` for roughly 500 commits, and this is the first time the refresh
script has been willing to rewrite the emit block at all -- previous runs
declined with `preserving README emit metrics because
scripts/emit/emit-detail.json is behind the existing README emit block and does
not record the current HEAD`. This run's emit artifact records the current HEAD,
so the SHA-aware guard from #16686 allowed the write.

Generated via `scripts/refresh-readme.py --write --skip-performance`; no
hand-edited numbers. The committed values were read back out of the commit
(`git show HEAD:README.md`) before the conformance snapshot tree was discarded.

## Fourslash also improved, but is NOT updated here

This cycle's fourslash run shows **3 failures, not 4** -- 
`completionListFunctionExpression` now passes, so the real figure is
`6559 / 6562` rather than the `6558 / 6562` this PR still publishes.

The remaining failures are:

```
importFixesWithPackageJsonInSideAnotherPackage
importNameCodeFix_importType
autoImportProvider_importsMap1
```

`completionListFunctionExpression` failed at marker `'this'` with "Expected no
completions", which lines up with #16899 (`lexical this at script top level
types as typeof globalThis, not any`) landing in this window.

I have deliberately not updated the fourslash block. `refresh-readme.py` reads
`scripts/fourslash/fourslash-snapshot.json`, which is dated Jul 25 and stale;
regenerating it needs `run-fourslash.sh --json-out`, and re-running the refresh
afterwards would read the conformance snapshot I had already discarded, risking
a revert of the `11,553` in this commit. Publishing a stale-but-conservative
fourslash number is the safer error here. It will be picked up next cycle, when
conformance is being measured anyway.

## Verification

Measured at `21679b1f49`:

- conformance `11553 / 12043` (95.9%), 12585 candidates, 507 unsupported, 35 skipped
- emit JS `11562 / 11563`, emit DTS `1377 / 1390`
- fourslash: complete run (`6562/6562` executed), 0 watchdog kills, 1
  slow-but-passed, **3 real failures** (see above)

## Benchmark

Runs after this lands, per the ordering that avoids the snapshot discard
blocking the publish for the ~6h sweep duration.

Carrying forward from last cycle: comlink (#16554) sits at ~318.4 ms across two
confirming SHAs, +10.5 ms over the 307.9 ms baseline -- still unrecovered. A
`ts-toolbelt` reading of 538.1 ms in the last sweep proved to be an environmental
artifact (confirmed back at 468.2 ms), with tsgo inflated in the same run;
nothing was filed.

## Provenance

Machine: m1
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high

AgentName: M1FableArchitect