### PR TITLE
fix(solver): erase identity-shared free type params in N x M overload signature comparison

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1759,6 +1759,9 @@ path = "tests/ts2374_jsx_runtime_self_import_no_false_positive_tests.rs"
 name = "generic_overload_shared_type_param_contextual_tests"
 path = "tests/generic_overload_shared_type_param_contextual_tests.rs"
 [[test]]
+name = "generic_overload_signature_erasure_tests"
+path = "tests/generic_overload_signature_erasure_tests.rs"
+[[test]]
 name = "large_union_index_merge_regression_tests"
 path = "tests/large_union_index_merge_regression_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/generic_overload_signature_erasure_tests.rs
+++ b/crates/tsz-checker/tests/generic_overload_signature_erasure_tests.rs
@@ -1,0 +1,181 @@
+//! When a source callable's signature and a target overload signature are
+//! both generic, `tsc`'s `compareSignaturesRelated` erases each side's own
+//! type parameters to `any` (`getErasedSignature`) before running the N×M
+//! `signaturesRelatedTo` comparison used for a target with two or more call
+//! signatures. A single, non-overloaded target signature never takes this
+//! path — it keeps its own type parameters opaque and infers/alpha-renames
+//! against the source instead.
+//!
+//! tsz's N×M erased-signature fallback
+//! (`crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs`,
+//! `erase_call_sig_to_any`/`erase_fn_shape_to_any`) erased only a signature's
+//! own declared `type_params` list. A contextually-typed function
+//! expression's parameter can be seeded directly from a target overload's own
+//! type-parameter `TypeId` (shared identity) without the expression carrying
+//! a `type_params` list of its own, so that shared `T` stayed opaque and
+//! never got erased — producing a spurious `TS2322` when the merged
+//! overloads' return types disagreed (`<T>(x:T):string` vs `<T>(x:T):number`,
+//! issue #16952, a residual of #16950/PR #16957).
+//!
+//! Fix: `erase_call_sig_to_any`/`erase_fn_shape_to_any` now erase every FREE
+//! type-parameter occurrence in a signature that is `is_same_binder` with
+//! either its own declared `type_params` or the *paired* signature's declared
+//! `type_params` (owner: `crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs::free_type_params_to_any`).
+//! A free type parameter belonging to neither side — an outer/captured
+//! parameter from an enclosing generic function that both signatures merely
+//! reference — stays opaque and un-erased.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source, diagnostic_count};
+
+fn options() -> CheckerOptions {
+    CheckerOptions::default()
+}
+
+/// The bug witness (#16952): two same-arity generic overloads whose RETURN
+/// types disagree. The contextual identity arrow's merged parameter type is a
+/// bare, opaque `T` under both overloads (#16950/#16957 already fixed the
+/// `T | T` dedup); `tsc` still accepts the assignment via generic-to-generic
+/// erasure.
+#[test]
+fn identity_arrow_against_disagreeing_return_overloads_is_clean() {
+    let source = r#"
+var f3: {
+    <T>(x: T): string;
+    <T>(x: T): number;
+} = (x) => x;
+"#;
+    let diags = check_source(source, "disagreeing_returns.ts", options());
+    assert_eq!(
+        diagnostic_count(&diags, 2322),
+        0,
+        "a contextual identity arrow against disagreeing-return same-arity \
+         generic overloads must not report TS2322 (tsc erases both sides' \
+         type params to `any` for this N x M comparison); got: {diags:?}"
+    );
+}
+
+/// Same shape with three disagreeing-return overloads, proving the erasure
+/// is not special-cased to exactly two signatures.
+#[test]
+fn identity_arrow_against_three_disagreeing_return_overloads_is_clean() {
+    let source = r#"
+var f5: {
+    <T>(x: T): string;
+    <T>(x: T): number;
+    <T>(x: T): boolean;
+} = (x) => x;
+"#;
+    let diags = check_source(source, "three_disagreeing_returns.ts", options());
+    assert_eq!(
+        diagnostic_count(&diags, 2322),
+        0,
+        "three disagreeing-return overloads must still erase cleanly; got: {diags:?}"
+    );
+}
+
+/// An independently-declared generic function (not a contextually-typed
+/// literal) assigned to the same disagreeing-return overload set must also
+/// erase cleanly — the fix must not be limited to the contextual-arrow shape.
+#[test]
+fn named_generic_function_against_disagreeing_return_overloads_is_clean() {
+    let source = r#"
+function idfn<T>(x: T): T { return x; }
+var f9: {
+    <T>(x: T): string;
+    <T>(x: T): number;
+} = idfn;
+"#;
+    let diags = check_source(source, "named_fn_disagreeing_returns.ts", options());
+    assert_eq!(
+        diagnostic_count(&diags, 2322),
+        0,
+        "a named generic identity function against disagreeing-return \
+         overloads must not report TS2322; got: {diags:?}"
+    );
+}
+
+/// Mixed overload set: one generic overload matching the source's own shape,
+/// and one fully concrete overload. Erasure must apply per target-signature
+/// pair, not require every overload to be generic.
+#[test]
+fn named_generic_function_against_mixed_generic_and_concrete_overload_is_clean() {
+    let source = r#"
+function idfn<T>(x: T): T { return x; }
+var f13: {
+    <T>(x: T): T;
+    (x: number): string;
+} = idfn;
+"#;
+    let diags = check_source(source, "mixed_overload.ts", options());
+    assert_eq!(
+        diagnostic_count(&diags, 2322),
+        0,
+        "a generic identity function against a mixed generic/concrete \
+         overload set must not report TS2322; got: {diags:?}"
+    );
+}
+
+/// Negative control: a single, non-overloaded generic target signature must
+/// keep its prior (correct) rejection. The N x M erasure path is specific to
+/// an overloaded (2+ call signature) target; a lone generic target signature
+/// alpha-renames/infers against the source instead, and a bare, opaque `T`
+/// genuinely is not assignable to a concrete `string`.
+#[test]
+fn single_non_overloaded_generic_target_still_rejects_return_mismatch() {
+    let source = r#"
+var f4: <T>(x: T) => string = (x) => x;
+"#;
+    let diags = check_source(source, "single_target.ts", options());
+    assert!(
+        diagnostic_count(&diags, 2322) > 0,
+        "a single (non-overloaded) generic target signature must still \
+         reject a bare-T-vs-string return mismatch; got: {diags:?}"
+    );
+}
+
+/// Negative control: the source body's return is genuinely concrete (a
+/// string literal, not the shared `T`), so it must still fail against
+/// whichever overload it does not structurally satisfy -- erasure must not
+/// blanket-accept every N x M comparison regardless of the source's real
+/// shape.
+#[test]
+fn concrete_return_still_rejected_by_mismatched_overload() {
+    let source = r#"
+var f6: {
+    <T>(x: T): string;
+    <T>(x: T): number;
+} = (x) => { return "hello"; };
+"#;
+    let diags = check_source(source, "concrete_return.ts", options());
+    assert!(
+        diagnostic_count(&diags, 2322) > 0,
+        "a source whose return is genuinely the concrete string 'hello' \
+         must still fail against the number overload; got: {diags:?}"
+    );
+}
+
+/// Negative control (regression guard): a type parameter captured from an
+/// *enclosing* generic function -- not declared by either compared signature
+/// -- must stay opaque even though it occurs free in both the source and
+/// target signatures of an overloaded comparison. Erasing it would silently
+/// accept a genuinely unsound assignment (`tsc` rejects this).
+#[test]
+fn outer_captured_type_param_shared_across_overloads_still_rejects() {
+    let source = r#"
+function f<Args extends unknown[]>(
+  source: {
+    (...args: Args): void;
+    (...renamed: Args): void;
+  },
+  target: (value: Args) => void
+) { target = source; }
+"#;
+    let diags = check_source(source, "outer_captured.ts", options());
+    assert!(
+        diagnostic_count(&diags, 2322) > 0,
+        "an outer/captured type parameter shared by identity across both \
+         overloads (not declared by either signature) must not be erased; \
+         got: {diags:?}"
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking/overloads.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking/overloads.rs
@@ -27,8 +27,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         source: &FunctionShape,
         target: &CallSignature,
     ) -> bool {
-        let source = erase_fn_shape_to_any(source, self.interner);
-        let target = erase_call_sig_to_any(target, self.interner);
+        let target_erased = erase_call_sig_to_any(target, &source.type_params, self.interner);
+        let source = erase_fn_shape_to_any(source, &target.type_params, self.interner);
+        let target = target_erased;
         let normalization = self.normalize_erased_target_return(target.return_type);
         if !normalization.contains_conditional {
             return false;
@@ -41,8 +42,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         source: &CallSignature,
         target: &CallSignature,
     ) -> bool {
-        let source = erase_call_sig_to_any(source, self.interner);
-        let target = erase_call_sig_to_any(target, self.interner);
+        let target_erased = erase_call_sig_to_any(target, &source.type_params, self.interner);
+        let source = erase_call_sig_to_any(source, &target.type_params, self.interner);
+        let target = target_erased;
         let normalization = self.normalize_erased_target_return(target.return_type);
         if !normalization.contains_conditional {
             return false;
@@ -75,8 +77,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         s_fn: &FunctionShape,
         t_sig: &CallSignature,
     ) -> SubtypeResult {
-        let s_erased = erase_fn_shape_to_any(s_fn, self.interner);
-        let t_erased = erase_call_sig_to_any(t_sig, self.interner);
+        let s_erased = erase_fn_shape_to_any(s_fn, &t_sig.type_params, self.interner);
+        let t_erased = erase_call_sig_to_any(t_sig, &s_fn.type_params, self.interner);
         if self.erased_return_variance_rejects(s_erased.return_type, t_erased.return_type) {
             return SubtypeResult::False;
         }
@@ -91,8 +93,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         if s_fn.type_params.is_empty() && t_sig.type_params.is_empty() {
             return SubtypeResult::False;
         }
-        let s_erased = erase_fn_shape_to_any(s_fn, self.interner);
-        let t_erased = erase_call_sig_to_any(t_sig, self.interner);
+        let s_erased = erase_fn_shape_to_any(s_fn, &t_sig.type_params, self.interner);
+        let t_erased = erase_call_sig_to_any(t_sig, &s_fn.type_params, self.interner);
         self.check_erased_function_shapes_params_with_matching_return_base(
             s_erased, t_erased, false,
         )
@@ -114,8 +116,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         if s_shape.type_params.is_empty() && t_shape.type_params.is_empty() {
             return SubtypeResult::False;
         }
-        let s_erased = erase_fn_shape_to_any(&s_shape, self.interner);
-        let t_erased = erase_fn_shape_to_any(&t_shape, self.interner);
+        let s_erased = erase_fn_shape_to_any(&s_shape, &t_shape.type_params, self.interner);
+        let t_erased = erase_fn_shape_to_any(&t_shape, &s_shape.type_params, self.interner);
         self.check_erased_function_shapes_params_with_matching_return_base(s_erased, t_erased, true)
     }
 
@@ -139,9 +141,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         ) else {
             return false;
         };
-        let source = erase_fn_shape_to_any(&self.interner.function_shape(s_fn_id), self.interner);
-        let target = self.interner.function_shape(t_fn_id);
-        let target = erase_fn_shape_to_any(&target, self.interner);
+        let s_shape = self.interner.function_shape(s_fn_id);
+        let t_shape = self.interner.function_shape(t_fn_id);
+        let source = erase_fn_shape_to_any(&s_shape, &t_shape.type_params, self.interner);
+        let target = erase_fn_shape_to_any(&t_shape, &s_shape.type_params, self.interner);
         let normalization = self.normalize_erased_target_return(target.return_type);
         if !normalization.contains_conditional {
             return false;
@@ -892,10 +895,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         s_sig: &CallSignature,
         t_fn: &FunctionShape,
     ) -> SubtypeResult {
-        let mut s_erased = erase_call_sig_to_any(s_sig, self.interner);
+        let mut s_erased = erase_call_sig_to_any(s_sig, &t_fn.type_params, self.interner);
         // Preserve constructor-vs-callable intent from the target function shape.
         s_erased.is_constructor = t_fn.is_constructor;
-        let t_erased = erase_fn_shape_to_any(t_fn, self.interner);
+        let t_erased = erase_fn_shape_to_any(t_fn, &s_sig.type_params, self.interner);
         if self.erased_return_variance_rejects(s_erased.return_type, t_erased.return_type) {
             return SubtypeResult::False;
         }
@@ -909,8 +912,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         source: &CallSignature,
         target: &CallSignature,
     ) -> SubtypeResult {
-        let s_erased = erase_call_sig_to_any(source, self.interner);
-        let t_erased = erase_call_sig_to_any(target, self.interner);
+        let s_erased = erase_call_sig_to_any(source, &target.type_params, self.interner);
+        let t_erased = erase_call_sig_to_any(target, &source.type_params, self.interner);
         if self.erased_return_variance_rejects(s_erased.return_type, t_erased.return_type) {
             return SubtypeResult::False;
         }
@@ -925,8 +928,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         if source.type_params.is_empty() && target.type_params.is_empty() {
             return SubtypeResult::False;
         }
-        let s_erased = erase_call_sig_to_any(source, self.interner);
-        let t_erased = erase_call_sig_to_any(target, self.interner);
+        let s_erased = erase_call_sig_to_any(source, &target.type_params, self.interner);
+        let t_erased = erase_call_sig_to_any(target, &source.type_params, self.interner);
         let normalization = self.normalize_erased_target_return(t_erased.return_type);
         // Preserve the hard plain-return variance veto without recursively
         // relating the full returned value here. Conditional returns and the
@@ -964,8 +967,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             }
         }
 
-        let mut s_erased = erase_call_sig_to_any(source, self.interner);
-        let mut t_erased = erase_call_sig_to_any(target, self.interner);
+        let mut s_erased = erase_call_sig_to_any(source, &target.type_params, self.interner);
+        let mut t_erased = erase_call_sig_to_any(target, &source.type_params, self.interner);
         s_erased.is_constructor = true;
         t_erased.is_constructor = true;
         self.check_function_subtype(&s_erased, &t_erased)
@@ -991,12 +994,16 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // rejection once per source signature so a params-only match cannot
         // bypass a determinate conditional return mismatch (and so V tuple
         // variants do not repeat the return walk).
-        let erased_target = erase_call_sig_to_any(target_sig, self.interner);
+        // This tuple/union-rest coverage helper compares per-element candidate
+        // shapes, not a single signature pair, so there is no single "paired"
+        // side to seed identity-shared erasure from; keep the erasure scoped
+        // to each signature's own declared type parameters, as before.
+        let erased_target = erase_call_sig_to_any(target_sig, &[], self.interner);
         let target_normalization = self.normalize_erased_target_return(erased_target.return_type);
         let return_rejections: Vec<bool> = source_sigs
             .iter()
             .map(|source_sig| {
-                let erased_source = erase_call_sig_to_any(source_sig, self.interner);
+                let erased_source = erase_call_sig_to_any(source_sig, &[], self.interner);
                 self.erased_normalized_return_rejects(
                     erased_source.return_type,
                     target_normalization,

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/erasure.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/erasure.rs
@@ -1,0 +1,182 @@
+//! Generic signature erasure helpers for the N×M overload comparison path.
+//!
+//! Split out of `functions/mod.rs` to stay under the file-size ratchet; these
+//! functions have no dependency on `SubtypeChecker` and are pure functions of
+//! an interner plus the signature data passed in.
+
+use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
+use crate::type_param_info;
+use crate::types::{CallSignature, FunctionShape, ParamInfo, TypeId, TypeParamInfo};
+
+/// Build a `TypeSubstitution` that maps each type parameter to its constraint
+/// (or `unknown` if unconstrained). This corresponds to tsc's `getCanonicalSignature`
+/// behavior — used when generic signatures need to be compared structurally after
+/// erasing their type parameter identities.
+pub(super) fn erase_type_params_to_constraints(type_params: &[TypeParamInfo]) -> TypeSubstitution {
+    let mut sub = TypeSubstitution::for_signature_domain(type_params);
+    for tp in type_params {
+        sub.insert(tp.name, tp.constraint.unwrap_or(TypeId::UNKNOWN));
+    }
+    sub
+}
+
+/// Build a `TypeSubstitution` erasing to `any` every `TypeParameter`/`Infer`
+/// that occurs *free* across `params`/`return_type` and is either this
+/// signature's own declared `type_params` or one it merely references by
+/// shared identity with the *paired* signature's declared `type_params` --
+/// e.g. a contextually-typed function expression's parameter is seeded from a
+/// target overload's own type parameter `TypeId` without the expression
+/// carrying a `type_params` list of its own (#16952). tsc erases whichever
+/// side of a `compareSignaturesRelated` pair is generic regardless of how
+/// that genericity was introduced, so this keys off free occurrences rather
+/// than the declared quantifier list alone.
+///
+/// A free occurrence that belongs to neither signature -- an outer/captured
+/// type parameter from an enclosing generic function that both signatures
+/// merely reference, e.g. `Args` in
+/// `f<Args extends unknown[]>(source: (...a: Args) => void, target: (v: Args) => void)`
+/// -- is not erasable: it names a single rigid type the caller controls, not
+/// a per-signature generic marker, so it must stay opaque for the structural
+/// comparison.
+fn free_type_params_to_any(
+    interner: &dyn crate::construction::TypeDatabase,
+    params: &[ParamInfo],
+    return_type: TypeId,
+    own_type_params: &[TypeParamInfo],
+    paired_type_params: &[TypeParamInfo],
+) -> Option<TypeSubstitution> {
+    // Fast path, and by far the common case: a signature that declares its
+    // own type parameters erases exactly those by name, with no need to walk
+    // the (potentially large) param/return type graph -- substituting by
+    // name already reaches every occurrence of that declared parameter,
+    // including any the paired signature happens to share by identity.
+    if !own_type_params.is_empty() {
+        let mut sub = TypeSubstitution::for_signature_domain(own_type_params);
+        for tp in own_type_params {
+            sub.insert(tp.name, TypeId::ANY);
+        }
+        return Some(sub);
+    }
+    if paired_type_params.is_empty() {
+        return None;
+    }
+    // Narrow, contextual-identity-sharing case (#16952): this signature
+    // declares no type parameters of its own, but its body may still
+    // reference the *paired* signature's own type parameter by identity
+    // (e.g. a contextually-typed function expression whose parameter was
+    // seeded directly from a target overload's `T`). Only pay for the free-
+    // occurrence walk here, where it is the sole way to detect that sharing.
+    let free = crate::visitors::visitor_predicates::free_type_parameter_ids_in(
+        interner,
+        params
+            .iter()
+            .map(|p| p.type_id)
+            .chain(std::iter::once(return_type)),
+    );
+    if free.is_empty() {
+        return None;
+    }
+    // Match by `is_same_binder`, not a re-interned `TypeId` from
+    // `paired_type_params`: a signature's own declared `TypeParamInfo` can
+    // carry slightly different structural metadata than the `TypeParameter`
+    // node actually occurring free in its body (the same #14345
+    // declaration-scoped-intern gap `own_type_param_identity_ids` above
+    // works around), so an exact `TypeId` comparison silently misses genuine
+    // same-binder occurrences.
+    let mut sub = TypeSubstitution::new();
+    for id in free {
+        let Some(info) = type_param_info(interner, id) else {
+            continue;
+        };
+        if paired_type_params.iter().any(|tp| tp.is_same_binder(info)) {
+            sub.insert(info.name, TypeId::ANY);
+        }
+    }
+    if sub.is_empty() { None } else { Some(sub) }
+}
+
+/// Erase a call signature's type parameters to `any`, producing a non-generic
+/// `FunctionShape`. Used by the N×M signature comparison path. `paired_type_params`
+/// is the other side of this signature pair's own declared type parameters, so a
+/// contextually shared identity (no `type_params` of its own but a free reference to
+/// the paired signature's `T`) still erases; see [`free_type_params_to_any`].
+pub(super) fn erase_call_sig_to_any(
+    sig: &CallSignature,
+    paired_type_params: &[TypeParamInfo],
+    interner: &dyn crate::construction::TypeDatabase,
+) -> FunctionShape {
+    let Some(sub) = free_type_params_to_any(
+        interner,
+        &sig.params,
+        sig.return_type,
+        &sig.type_params,
+        paired_type_params,
+    ) else {
+        return FunctionShape {
+            type_params: Vec::new(),
+            params: sig.params.clone(),
+            this_type: sig.this_type,
+            return_type: sig.return_type,
+            type_predicate: sig.type_predicate,
+            is_constructor: false,
+            is_method: sig.is_method,
+        };
+    };
+    let erased_params: Vec<_> = sig
+        .params
+        .iter()
+        .map(|p| ParamInfo {
+            name: p.name,
+            type_id: instantiate_type(interner, p.type_id, &sub),
+            optional: p.optional,
+            rest: p.rest,
+        })
+        .collect();
+    FunctionShape {
+        type_params: Vec::new(),
+        params: erased_params,
+        this_type: sig.this_type,
+        return_type: instantiate_type(interner, sig.return_type, &sub),
+        type_predicate: sig.type_predicate,
+        is_constructor: false,
+        is_method: sig.is_method,
+    }
+}
+
+/// Erase a function shape's type parameters to `any`, producing a non-generic
+/// `FunctionShape`. Used by the N×M signature comparison path. See
+/// [`erase_call_sig_to_any`] for `paired_type_params`.
+pub(super) fn erase_fn_shape_to_any(
+    f: &FunctionShape,
+    paired_type_params: &[TypeParamInfo],
+    interner: &dyn crate::construction::TypeDatabase,
+) -> FunctionShape {
+    let Some(sub) = free_type_params_to_any(
+        interner,
+        &f.params,
+        f.return_type,
+        &f.type_params,
+        paired_type_params,
+    ) else {
+        return f.clone();
+    };
+    let erased_params: Vec<_> = f
+        .params
+        .iter()
+        .map(|p| ParamInfo {
+            name: p.name,
+            type_id: instantiate_type(interner, p.type_id, &sub),
+            optional: p.optional,
+            rest: p.rest,
+        })
+        .collect();
+    FunctionShape {
+        type_params: Vec::new(),
+        params: erased_params,
+        this_type: f.this_type,
+        return_type: instantiate_type(interner, f.return_type, &sub),
+        type_predicate: f.type_predicate,
+        is_constructor: f.is_constructor,
+        is_method: f.is_method,
+    }
+}

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs
@@ -14,8 +14,7 @@ use crate::inference::infer::InferenceContext;
 use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
 use crate::type_param_info;
 use crate::types::{
-    CallSignature, FunctionShape, InferencePriority, ParamInfo, TypeData, TypeId, TypeParamInfo,
-    TypePredicate,
+    FunctionShape, InferencePriority, ParamInfo, TypeData, TypeId, TypeParamInfo, TypePredicate,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use tsz_common::Atom;
@@ -29,102 +28,8 @@ struct CallbackParameterPair {
     enters_callback_mode: bool,
 }
 
-/// Build a `TypeSubstitution` that maps each type parameter to its constraint
-/// (or `unknown` if unconstrained). This corresponds to tsc's `getCanonicalSignature`
-/// behavior — used when generic signatures need to be compared structurally after
-/// erasing their type parameter identities.
-pub(super) fn erase_type_params_to_constraints(type_params: &[TypeParamInfo]) -> TypeSubstitution {
-    let mut sub = TypeSubstitution::for_signature_domain(type_params);
-    for tp in type_params {
-        sub.insert(tp.name, tp.constraint.unwrap_or(TypeId::UNKNOWN));
-    }
-    sub
-}
-
-/// Build a `TypeSubstitution` that maps each type parameter to `any`.
-/// This matches tsc's `getErasedSignature` / `createTypeEraser` behavior, which
-/// maps type parameters to `any` (NOT to their constraints). Used in the N×M
-/// signature comparison path (`signaturesRelatedTo` with `erase = true`) where
-/// multiple overloaded signatures are compared against a target.
-pub(super) fn erase_type_params_to_any(type_params: &[TypeParamInfo]) -> TypeSubstitution {
-    let mut sub = TypeSubstitution::for_signature_domain(type_params);
-    for tp in type_params {
-        sub.insert(tp.name, TypeId::ANY);
-    }
-    sub
-}
-
-/// Erase a call signature's type parameters to `any`, producing a non-generic
-/// `FunctionShape`. Used by the N×M signature comparison path.
-pub(super) fn erase_call_sig_to_any(
-    sig: &CallSignature,
-    interner: &dyn crate::construction::TypeDatabase,
-) -> FunctionShape {
-    use crate::instantiation::instantiate::instantiate_type;
-    if sig.type_params.is_empty() {
-        return FunctionShape {
-            type_params: Vec::new(),
-            params: sig.params.clone(),
-            this_type: sig.this_type,
-            return_type: sig.return_type,
-            type_predicate: sig.type_predicate,
-            is_constructor: false,
-            is_method: sig.is_method,
-        };
-    }
-    let sub = erase_type_params_to_any(&sig.type_params);
-    let erased_params: Vec<_> = sig
-        .params
-        .iter()
-        .map(|p| ParamInfo {
-            name: p.name,
-            type_id: instantiate_type(interner, p.type_id, &sub),
-            optional: p.optional,
-            rest: p.rest,
-        })
-        .collect();
-    FunctionShape {
-        type_params: Vec::new(),
-        params: erased_params,
-        this_type: sig.this_type,
-        return_type: instantiate_type(interner, sig.return_type, &sub),
-        type_predicate: sig.type_predicate,
-        is_constructor: false,
-        is_method: sig.is_method,
-    }
-}
-
-/// Erase a function shape's type parameters to `any`, producing a non-generic
-/// `FunctionShape`. Used by the N×M signature comparison path.
-pub(super) fn erase_fn_shape_to_any(
-    f: &FunctionShape,
-    interner: &dyn crate::construction::TypeDatabase,
-) -> FunctionShape {
-    use crate::instantiation::instantiate::instantiate_type;
-    if f.type_params.is_empty() {
-        return f.clone();
-    }
-    let sub = erase_type_params_to_any(&f.type_params);
-    let erased_params: Vec<_> = f
-        .params
-        .iter()
-        .map(|p| ParamInfo {
-            name: p.name,
-            type_id: instantiate_type(interner, p.type_id, &sub),
-            optional: p.optional,
-            rest: p.rest,
-        })
-        .collect();
-    FunctionShape {
-        type_params: Vec::new(),
-        params: erased_params,
-        this_type: f.this_type,
-        return_type: instantiate_type(interner, f.return_type, &sub),
-        type_predicate: f.type_predicate,
-        is_constructor: f.is_constructor,
-        is_method: f.is_method,
-    }
-}
+mod erasure;
+use erasure::{erase_call_sig_to_any, erase_fn_shape_to_any, erase_type_params_to_constraints};
 
 pub(super) fn resolve_contextual_source_inference_candidate(
     lower_bounds: &[TypeId],


### PR DESCRIPTION
Fixes #16952.

## Structural rule

When a source callable's signature and a target overload signature are both generic, tsc's `compareSignaturesRelated` erases each side's own type parameters to `any` (`getErasedSignature`) before the N×M `signaturesRelatedTo` comparison used for a target with 2+ call signatures. A single, non-overloaded target signature never takes this path — it infers/alpha-renames against the source instead, keeping its own type parameters opaque.

tsz's `erase_call_sig_to_any`/`erase_fn_shape_to_any` (`crates/tsz-solver/src/relations/subtype/rules/functions/erasure.rs`, split out of `mod.rs` to stay under the 2000-line file cap) erased only a signature's own declared `type_params` list. A contextually-typed function expression's parameter can be seeded directly from a target overload's own type-parameter `TypeId` (shared identity, via the existing "source references target's bound type params" promotion) without the expression carrying a `type_params` list of its own. That shared `T` stayed opaque and never got erased, producing a spurious `TS2322` when the merged overloads' return types disagreed:

```ts
var f3: {
    <T>(x: T): string;
    <T>(x: T): number;
} = (x) => x;   // tsc: clean; tsz (before this PR): TS2322
```

(Residual of #16950 / PR #16957, which fixed the parameter-side `T | T` dedup but deliberately left this return-mismatch shape unasserted.)

**Fix** (owner layer: solver, `crates/tsz-solver/src/relations/subtype/rules/functions/erasure.rs::free_type_params_to_any`): when a signature declares its own type parameters, erase exactly those by name (fast path — identical cost to before). Only when a signature declares **no** type parameters of its own does it pay for a free-occurrence walk, checking whether its body references the *paired* signature's own declared type parameter by identity (matched via `is_same_binder`, not raw `TypeId` equality — the same #14345 declaration-scoped-intern gap `own_type_param_identity_ids` already works around elsewhere in `checking.rs`). A free type parameter belonging to **neither** side — an outer/captured parameter from an enclosing generic function that both signatures merely reference — stays opaque and un-erased.

An earlier version of this fix walked every free occurrence unconditionally and caused a severe full-suite slowdown (a `cargo test -p tsz-checker --lib` run that normally finishes in minutes never returned); restricting the walk to the narrow "own `type_params` empty" case above restored normal performance while keeping full correctness.

## Adjacent-case matrix (oracle-verified against pinned `typescript@7.0.2`)

| case | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| contextual identity arrow, 2 disagreeing-return overloads | clean | `TS2322` | clean |
| contextual identity arrow, 3 disagreeing-return overloads | clean | `TS2322` | clean |
| named (non-contextual) generic function, same shape | clean | `TS2322` | clean |
| mixed generic + concrete overload (`<T>(x:T):T` / `(x:number):string`) | clean | `TS2322` | clean |
| single, non-overloaded generic target (`<T>(x:T)=>string`) | `TS2322` | `TS2322` | `TS2322` (unaffected) |
| source return genuinely concrete (`"hello"`) vs disagreeing overloads | `TS2322` on the mismatched overload | `TS2322` | `TS2322` (unaffected) |
| outer/captured type param shared across overloads (`f<Args>(source: {...}, target: (v: Args) => void)`) | `TS2322` | `TS2322` | `TS2322` (unaffected — regression guard) |

The last row is a real regression I caught locally with the broader (pre-restriction) version of this fix against `generic_callable_outer_type_param_mismatch_tests::keeps_2322_overloaded_callable_bare_outer_rest_against_fixed_slot`; the `is_same_binder`-against-only-the-paired-signature restriction fixes it.

## Goal
Goal: hold

## Verification
- New regression suite `crates/tsz-checker/tests/generic_overload_signature_erasure_tests.rs` (registered in `Cargo.toml`, `autotests = false`): `cargo test -p tsz-checker --test generic_overload_signature_erasure_tests` → 7/7 passed.
- `cargo test -p tsz-checker --lib overload` → 408/408 passed (was 405/408 with the naive unrestricted-erasure version; the 3 failures there are now fixed and re-verified).
- `cargo test -p tsz-checker --lib contextual` → 311/311 passed.
- `cargo test -p tsz-checker --lib generic_callable_outer_type_param_mismatch` → 27/27 passed (regression guard for the outer/captured-type-param case).
- `cargo test -p tsz-checker --lib overload_two_pass_any_source` → 29/29 passed.
- `cargo test -p tsz-solver --lib` → 7657/7657 passed (full crate suite).
- `cargo test -p tsz-checker --lib` full run: 10,842+ tests passing with zero failures observed before the run was interrupted by the pre-existing, independently-documented long-tail test `ts2589_tests::recursive_conditional_alias_omitted_default_transform_emits_definition_ts2589` (confirmed 1.96s in isolation; another agent's session today on an unrelated PR — #16955 — independently hit the exact same tail behavior on the full suite, confirming it predates this change).
- `cargo clippy -p tsz-solver -p tsz-checker --all-targets -- -D warnings` → clean.
- `cargo fmt` → clean (pre-commit hook).
- `scripts/arch/check-checker-boundaries.sh` → passed (`erasure.rs` split keeps `mod.rs` at 1840 lines, under the 2000-line cap).
- Diff is confined to `crates/tsz-solver` (production) and `crates/tsz-checker/tests` + `Cargo.toml` (test-only) — no checker/emitter production path touched.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_0151tMCrHBez5ypP2qV14dUN)_