### PR TITLE
fix(solver): merge overloaded generic contextual signatures with a shared type-parameter mapper (#16950)

### DIFF
--- a/crates/tsz-checker/src/tests/overloaded_callable_param_no_implicit_any_tests.rs
+++ b/crates/tsz-checker/src/tests/overloaded_callable_param_no_implicit_any_tests.rs
@@ -245,3 +245,193 @@ var f: (x: string) => void = (x) => { x.bogusProp; };
         "a single-signature target must still contextually type its parameter, got: {diags:#?}"
     );
 }
+
+// ── noImplicitAny ON: combinable generic overloads produce a *combined* generic
+//    signature, so the arrow adopts one shared `<T>` and stays a generic identity.
+//
+// tsc's `getIntersectedSignatures` combines two-or-more arity-applicable
+// signatures under `noImplicitAny` only when their type parameters are identical
+// (`compareTypeParametersIdentical`), mapping each later signature's own type
+// parameters onto the first's before unioning parameter positions
+// (`combineIntersectionParameters`). Two overloads that each declare their own
+// `<T>` collapse to a single `<T>` — not an undeduped `T | T` — and the function
+// expression adopts that `<T>`, becoming `<T>(x: T) => T`, which every overload
+// can instantiate. Oracle-verified against pinned `typescript@7.0.2` `--strict`
+// for each case below.
+
+#[test]
+fn shared_type_param_position_combines_and_stays_clean() {
+    // `functionLiteralForOverloads.ts` `f3`. The pre-fix bug: the arity-filtered
+    // extractor unioned the two overloads' distinct-but-same-named `T` into an
+    // undeduped `T | T` and left the arrow non-generic, producing a spurious
+    // TS2322 (`Type 'T | T' is not assignable to type 'string'`). #16950.
+    let diags = diagnostics_no_implicit_any(
+        r#"
+var f3: {
+    <T>(x: T): string;
+    <T>(x: T): number;
+} = (x) => x;
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "combinable shared-`T` overloads must contextually type the arrow as a generic identity, got: {diags:#?}"
+    );
+}
+
+#[test]
+fn generic_return_overloads_stay_clean() {
+    // `functionLiteralForOverloads.ts` `f4`: a generic return with concrete
+    // parameters. The arrow adopts `<T>` and stays assignable to both overloads.
+    let diags = diagnostics_no_implicit_any(
+        r#"
+var f4: {
+    <T>(x: string): T;
+    <T>(x: number): T;
+} = (x) => x;
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "generic-return overloads must stay clean under noImplicitAny, got: {diags:#?}"
+    );
+}
+
+#[test]
+fn renamed_binders_shared_position_stay_clean() {
+    // The combine maps type parameters *positionally*, so two overloads that name
+    // their shared-position parameter differently (`<U>`/`<V>`) still collapse to
+    // one type parameter. Guards against a name-string dependence in the merge.
+    let diags = diagnostics_no_implicit_any(
+        r#"
+var h: {
+    <U>(x: U): string;
+    <V>(x: V): number;
+} = (x) => x;
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "renamed shared-position binders must still combine, got: {diags:#?}"
+    );
+}
+
+#[test]
+fn matching_constraint_overloads_stay_clean() {
+    // Identical constraints are combinable (`compareTypeParametersIdentical`).
+    let diags = diagnostics_no_implicit_any(
+        r#"
+var h: {
+    <T extends object>(x: T): string;
+    <T extends object>(x: T): number;
+} = (x) => x;
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "matching-constraint overloads must combine, got: {diags:#?}"
+    );
+}
+
+#[test]
+fn three_shared_type_param_overloads_stay_clean() {
+    // The identity check is pairwise across the whole set, not just adjacent.
+    let diags = diagnostics_no_implicit_any(
+        r#"
+var h: {
+    <T>(x: T): string;
+    <T>(x: T): number;
+    <T>(x: T): boolean;
+} = (x) => x;
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "three combinable shared-`T` overloads must stay clean, got: {diags:#?}"
+    );
+}
+
+// ── noImplicitAny ON: non-combinable overloads combine to nothing, so the arrow
+//    parameter falls back to implicit `any` (TS7006) — never a synthesized union.
+
+#[test]
+fn mismatched_constraint_overloads_report_ts7006() {
+    // Differing constraints are NOT identical, so tsc yields no contextual
+    // signature at all and the parameter is implicitly `any`.
+    let diags = diagnostics_no_implicit_any(
+        r#"
+var h: {
+    <T extends string>(x: T): string;
+    <T extends number>(x: T): number;
+} = (x) => x;
+"#,
+    );
+    assert!(
+        diags.iter().any(|(code, _)| *code == 7006),
+        "mismatched-constraint overloads must not combine; expected TS7006, got: {diags:#?}"
+    );
+    assert!(
+        !diags.iter().any(|(code, _)| *code == 2322),
+        "mismatched-constraint overloads must not synthesize a unioned parameter (no TS2322), got: {diags:#?}"
+    );
+}
+
+#[test]
+fn mixed_generic_and_non_generic_overloads_report_ts7006() {
+    // A generic/non-generic mix differs in type-parameter arity, so it is not
+    // combinable and the parameter stays implicit `any`.
+    let diags = diagnostics_no_implicit_any(
+        r#"
+var h: {
+    (x: string): string;
+    <T>(x: T): number;
+} = (x) => x;
+"#,
+    );
+    assert!(
+        diags.iter().any(|(code, _)| *code == 7006),
+        "generic/non-generic mix must not combine; expected TS7006, got: {diags:#?}"
+    );
+}
+
+// ── noImplicitAny ON: combinable *non-generic* overloads with disagreeing
+//    concrete positions still combine and still report the return mismatch.
+
+#[test]
+fn disagreeing_concrete_params_report_ts2322() {
+    // `functionLiteralForOverloads.ts` `f`: non-generic overloads combine to
+    // `(x: string | number) => string | number`, which — because the return is
+    // concrete and cannot be re-instantiated — is not assignable to either
+    // overload's `string`/`number` return. tsc reports TS2322 here.
+    let diags = diagnostics_no_implicit_any(
+        r#"
+var f: {
+    (x: string): string;
+    (x: number): number;
+} = (x) => x;
+"#,
+    );
+    assert!(
+        diags.iter().any(|(code, _)| *code == 2322),
+        "disagreeing concrete-parameter overloads must still report TS2322, got: {diags:#?}"
+    );
+}
+
+#[test]
+fn unused_generic_disagreeing_concrete_params_report_ts2322() {
+    // `functionLiteralForOverloads.ts` `f2`: an unused `<T>` on each overload
+    // does not save the concrete `string`/`number` return positions from the
+    // same TS2322 as `f`.
+    let diags = diagnostics_no_implicit_any(
+        r#"
+var f2: {
+    <T>(x: string): string;
+    <T>(x: number): number;
+} = (x) => x;
+"#,
+    );
+    assert!(
+        diags.iter().any(|(code, _)| *code == 2322),
+        "unused-generic disagreeing overloads must still report TS2322, got: {diags:#?}"
+    );
+}

--- a/crates/tsz-solver/src/contextual/extractors.rs
+++ b/crates/tsz-solver/src/contextual/extractors.rs
@@ -6,13 +6,14 @@
 //! bidirectional type inference.
 
 use crate::construction::TypeDatabase;
+use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
 use crate::relations::relation_queries::{
     RelationContext, RelationKind, RelationPolicy, query_relation,
 };
 use crate::types::{
     CallableShapeId, FunctionShapeId, IndexSignature, IntrinsicKind, LiteralValue, ObjectShapeId,
     ParamInfo, SymbolRef, TupleElement, TupleListId, TypeApplicationId, TypeData, TypeId,
-    TypeListId,
+    TypeListId, TypeParamInfo,
 };
 use crate::visitor::TypeVisitor;
 use tsz_common::interner::Atom;
@@ -49,6 +50,61 @@ pub(crate) fn collect_single_or_union_no_reduce(
         1 => Some(types[0]),
         _ => Some(db.union_literal_reduce(types)),
     }
+}
+
+/// tsc `compareTypeParametersIdentical` (checker.ts), restricted to the
+/// overload-merge use in the contextual-parameter extractors.
+///
+/// When an overloaded callable contextual type has two or more arity-applicable
+/// signatures, tsc's `getIntersectedSignatures` produces a combined signature
+/// only when every signature's type parameters are *identical*: equal arity and,
+/// after mapping one signature's parameters onto the other's positionally,
+/// identical constraints. A differing arity — which includes any mix of generic
+/// and non-generic overloads — or a differing constraint yields no combined
+/// signature, so the callable contextually types nothing.
+///
+/// Two overloads that each declare their own `<T>` are identical under this rule;
+/// their `T`s are distinct decl-scoped ids for the same surface name, so the
+/// constraint comparison is done through [`canonical_type_param_substitution`].
+pub(crate) fn type_parameters_identical(
+    db: &dyn TypeDatabase,
+    left: &[TypeParamInfo],
+    right: &[TypeParamInfo],
+) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    if left.is_empty() {
+        return true;
+    }
+    let substitution = canonical_type_param_substitution(db, right, left);
+    left.iter().zip(right.iter()).all(|(l, r)| {
+        let left_constraint = l.constraint.unwrap_or(TypeId::UNKNOWN);
+        let right_constraint = r.constraint.unwrap_or(TypeId::UNKNOWN);
+        // Interned identity: after remapping `right`'s own type parameters onto
+        // `left`'s, structurally identical constraints share one `TypeId`.
+        instantiate_type(db, right_constraint, &substitution) == left_constraint
+    })
+}
+
+/// Build the tsc `createTypeMapper(from, to)` substitution that rewrites the
+/// `from` type parameters onto the positionally-corresponding `to` (canonical)
+/// type parameters.
+///
+/// Keyed by name so the instantiator rewrites every occurrence — including the
+/// distinct decl-scoped ids two overloads mint for the same surface name — onto
+/// the canonical parameter's interned `TypeParameter` id.
+fn canonical_type_param_substitution(
+    db: &dyn TypeDatabase,
+    from: &[TypeParamInfo],
+    to: &[TypeParamInfo],
+) -> TypeSubstitution {
+    let mut substitution = TypeSubstitution::new();
+    for (src, dst) in from.iter().zip(to.iter()) {
+        let target = db.type_param(*dst);
+        substitution.insert(src.name, target);
+    }
+    substitution
 }
 
 /// Like [`collect_single_or_union`] but preserves every member without any

--- a/crates/tsz-solver/src/contextual/extractors_for_call.rs
+++ b/crates/tsz-solver/src/contextual/extractors_for_call.rs
@@ -2,7 +2,9 @@
 //! extractors in [`super::extractors`], split into its own file so that file
 //! stays under the architecture size ratchet.
 
-use super::extractors::{collect_single_or_union_no_reduce, extract_param_type_at_for_call};
+use super::extractors::{
+    collect_single_or_union_no_reduce, extract_param_type_at_for_call, type_parameters_identical,
+};
 use crate::construction::TypeDatabase;
 use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
 use crate::types::{
@@ -142,45 +144,36 @@ impl TypeVisitor for ParameterForCallExtractor<'_> {
             return None;
         }
 
-        // tsc's getIntersectedSignatures returns undefined when multiple
-        // signatures are present and ANY is generic. This prevents contextual
-        // typing when assigning arrow functions to overloaded types that have
-        // both generic and non-generic call signatures.
-        // Only apply when there's a MIX of generic and non-generic signatures
-        // (genuine overloads). When ALL signatures are generic, they likely
-        // come from union member merging and should still provide contextual types.
-        if matching_call_signatures.len() > 1 {
-            let has_generic = matching_call_signatures
-                .iter()
-                .any(|sig| !sig.type_params.is_empty());
-            let has_non_generic = matching_call_signatures
-                .iter()
-                .any(|sig| sig.type_params.is_empty());
-            if has_generic && has_non_generic {
-                return None;
-            }
+        // tsc's `getIntersectedSignatures` (checker.ts) combines two or more
+        // arity-applicable signatures only when their type parameters are
+        // *identical* (`compareTypeParametersIdentical`): equal arity and, after
+        // positional remapping, identical constraints. A differing arity — which
+        // includes any mix of generic and non-generic overloads — or a differing
+        // constraint yields no combined signature, so the callable contextually
+        // types nothing here (the parameter falls back to implicit `any`).
+        let canonical_type_params = matching_call_signatures
+            .first()
+            .map(|sig| sig.type_params.clone())
+            .unwrap_or_default();
+        if matching_call_signatures.len() > 1
+            && !matching_call_signatures[1..].iter().all(|sig| {
+                type_parameters_identical(self.db, &canonical_type_params, &sig.type_params)
+            })
+        {
+            return None;
         }
 
-        // Same-arity generic overloads share one canonical type-parameter
-        // identity (the first matching signature's), so every later
-        // signature's params are read through that mapping before extraction
-        // — see `signature_params_mapped_to_canonical`.
-        let canonical_type_params = matching_call_signatures
-            .iter()
-            .find(|sig| !sig.type_params.is_empty())
-            .map(|sig| sig.type_params.clone());
-
+        // When the signatures ARE combined, tsc maps each later signature's own
+        // type parameters onto the first signature's before unioning parameter
+        // positions (`createTypeMapper` + `combineIntersectionParameters`). Two
+        // overloads that each declare their own `<T>` therefore collapse to a
+        // single `T` at the shared position instead of an undeduped `T | T`.
         for sig in matching_call_signatures {
             matched = true;
-            let mapped_params;
-            let params = if let Some(canonical) = canonical_type_params.as_deref() {
-                mapped_params = signature_params_mapped_to_canonical(self.db, canonical, sig);
-                &mapped_params
-            } else {
-                &sig.params
-            };
+            let mapped_params =
+                signature_params_mapped_to_canonical(self.db, &canonical_type_params, sig);
             if let Some(param_type) =
-                extract_param_type_at_for_call(self.db, params, self.index, self.arg_count)
+                extract_param_type_at_for_call(self.db, &mapped_params, self.index, self.arg_count)
             {
                 param_types.push(param_type);
             }

--- a/crates/tsz-solver/src/type_queries/flow.rs
+++ b/crates/tsz-solver/src/type_queries/flow.rs
@@ -1113,14 +1113,34 @@ fn extract_contextual_type_params_inner(
         }
         Some(TypeData::Callable(shape_id)) => {
             let shape = db.callable_shape(shape_id);
-            if shape.call_signatures.len() != 1 {
+            let first = shape.call_signatures.first()?;
+            // tsc `getContextualSignature`: an overloaded callable contributes the
+            // *combined* signature's type parameters only when every call
+            // signature is combinable — identical type-parameter arity and
+            // constraints (`getIntersectedSignatures` /
+            // `compareTypeParametersIdentical`). Two overloads that each declare
+            // their own `<T>` are combinable, so a function expression assigned to
+            // `{ <T>(x: T): string; <T>(x: T): number }` adopts a single `<T>` and
+            // stays a generic identity (`<T>(x: T) => T`) that each overload can
+            // instantiate, rather than a non-generic `(x: T) => T` that fails to
+            // satisfy either overload. A non-combinable set (differing arity, e.g.
+            // a generic/non-generic mix) contributes nothing, matching the sibling
+            // gate in the contextual-parameter extractor.
+            if shape.call_signatures.len() > 1
+                && !shape.call_signatures[1..].iter().all(|sig| {
+                    crate::contextual::extractors::type_parameters_identical(
+                        db,
+                        &first.type_params,
+                        &sig.type_params,
+                    )
+                })
+            {
                 return None;
             }
-            let sig = &shape.call_signatures[0];
-            if sig.type_params.is_empty() {
+            if first.type_params.is_empty() {
                 None
             } else {
-                Some(sig.type_params.clone())
+                Some(first.type_params.clone())
             }
         }
         Some(TypeData::Application(app_id)) => {


### PR DESCRIPTION
Fixes #16950 (the disagreeing-return residual that #16957 deferred to #16952).

Under `noImplicitAny`, a function expression assigned to an overloaded callable whose signatures each declare their own generics with a shared parameter position and **disagreeing concrete returns** was rejected with a spurious `TS2322`, where `tsc --strict` is clean:

```ts
var f3: {
    <T>(x: T): string;
    <T>(x: T): number;
} = (x) => x;   // tsc --strict: clean;  tsz (before): TS2322: Type 'T | T' is not assignable to type 'string'
```

#16957 fixed the `T | T` display (mapping each overload's own type parameter onto the first signature's canonical one), but explicitly left this disagreeing-return case failing, because the arrow was still typed as a **non-generic** `(x: T) => T` that cannot satisfy either overload's concrete return. That is the residual this PR closes.

## Structural rule
When two or more arity-applicable overload signatures are combinable — identical type-parameter arity and constraints (`compareTypeParametersIdentical`) — tsc combines them (`getIntersectedSignatures`) and the function expression **adopts the combined signature's type parameters** (`assignContextualParameterTypes`), so `(x) => x` becomes a generic identity `<T>(x: T) => T` that each overload instantiates. A non-combinable set (differing arity — including any generic/non-generic mix — or differing constraints) yields no combined signature; the parameter falls back to implicit `any` (`TS7006`). Owner layer: solver contextual queries.

## What this PR changes (on top of #16957)
1. **`extract_contextual_type_params` (`type_queries/flow.rs`)** — the key fix. It returned `None` for *any* multi-signature callable, so the arrow never adopted the combined generic's type parameters and stayed non-generic. It now surfaces the first signature's type parameters for a *combinable* overload set (gated by `compareTypeParametersIdentical`), so the arrow becomes generic and the existing generic-to-generic relation accepts it.
2. **`ParameterForCallExtractor::visit_callable` (`contextual/extractors_for_call.rs`)** — adds the `compareTypeParametersIdentical` combinability gate in front of #16957's `signature_params_mapped_to_canonical` mapping, so a non-combinable set (mismatched constraints, generic/non-generic mix) yields no contextual type (implicit `any` → `TS7006`) instead of a wrongly-merged parameter.

The shared combinability predicate `type_parameters_identical` (with `canonical_type_param_substitution`) lives in `contextual/extractors.rs` and is used by both call sites.

## Adjacent matrix (oracle-verified against pinned `typescript@7.0.2`, `--strict`; tsz matches tsc in every row)

| case | result |
| --- | --- |
| `<T>(x:T):string` / `<T>(x:T):number` (f3, disagreeing returns) | clean |
| `<T>(x:T):T` / `<T>(x:T):T` (agreeing) | clean |
| `<T>(x:string):T` / `<T>(x:number):T` (generic return) | clean |
| renamed shared binders `<U>` / `<V>` | clean |
| `<T extends object>` twice | clean |
| three `<T>(x:T)` overloads | clean |
| `<T>(x:T):T` twice with `x.toFixed()` body | TS2339 |
| `(x:string):string` / `(x:number):number` (non-generic) | TS2322 |
| `<T>(x:string):string` / `<T>(x:number):number` (unused generic) | TS2322 |
| `<T extends string>` / `<T extends number>` (mismatched constraint) | TS7006 |
| generic / non-generic mix | TS7006 |
| differing arity `<T,U>` / `<T>` | TS7006 |

## Goal
Goal: hold

## Verification
- New checker unit tests in `overloaded_callable_param_no_implicit_any_tests.rs` (combinable → clean; non-combinable → TS7006; disagreeing concrete params → TS2322). #16957's `generic_overload_shared_type_param_contextual_tests.rs` (agreeing/renamed/member-access/arity) continue to pass unchanged.
- CLI parity vs `typescript@7.0.2` for the full matrix above, under both `--strict` and `--noImplicitAny false`: exact match.
- Conformance: **delta 0** — measured by running the full snapshot on `main` and on this change in the same environment (the corpus exercises these overload shapes only under non-strict, where behavior is unchanged).
- `cargo clippy -p tsz-solver -p tsz-checker` clean on the rebased tree; `TypeData` construction routed through `db.type_param` (`typedata_contract_tests` green); architecture guard passed.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high