### PR TITLE
fix(solver): union-source elaboration walks as-written member order (#16965)

### DIFF
--- a/crates/tsz-checker/tests/union_source_elaboration_constituent_tests.rs
+++ b/crates/tsz-checker/tests/union_source_elaboration_constituent_tests.rs
@@ -10,22 +10,38 @@
 use tsz_checker::test_utils::check_source_strict;
 use tsz_common::diagnostics::Diagnostic;
 
-/// The nested elaboration lines (depth, code, text) of the first TS2322.
-fn ts2322_chain(diags: &[Diagnostic]) -> Vec<(u8, u32, String)> {
+/// The nested elaboration lines' text of the first diagnostic with `code`.
+fn chain_texts_for(diags: &[Diagnostic], code: u32) -> Vec<String> {
     diags
         .iter()
-        .find(|d| d.code == 2322)
+        .find(|d| d.code == code)
         .map(|d| {
             d.related_information
                 .iter()
-                .map(|r| (r.depth, r.code, r.message_text.clone()))
+                .map(|r| r.message_text.clone())
                 .collect()
         })
         .unwrap_or_default()
 }
 
+/// The nested elaboration lines' text of the first TS2322 (assignment mismatch).
 fn chain_texts(diags: &[Diagnostic]) -> Vec<String> {
-    ts2322_chain(diags).into_iter().map(|(_, _, m)| m).collect()
+    chain_texts_for(diags, 2322)
+}
+
+/// Assert the elaboration names `present` as a failing constituent and (when
+/// given) does not name `absent`.
+fn assert_names_constituent(texts: &[String], present: &str, absent: Option<&str>) {
+    assert!(
+        texts.iter().any(|m| m.contains(present)),
+        "expected the source-order constituent `{present}`; got {texts:?}"
+    );
+    if let Some(absent) = absent {
+        assert!(
+            !texts.iter().any(|m| m.contains(absent)),
+            "must not name `{absent}`; got {texts:?}"
+        );
+    }
 }
 
 #[test]
@@ -40,16 +56,10 @@ const y1: boolean = c1;
 type U = { m: number } | { m: number };
 "#,
     );
-    let texts = chain_texts(&diags);
-    assert!(
-        texts
-            .iter()
-            .any(|m| m.contains("Type '{ m: number; }' is not assignable to type 'boolean'")),
-        "expected the anonymous constituent `{{ m: number; }}` in the elaboration; got {texts:?}"
-    );
-    assert!(
-        !texts.iter().any(|m| m.contains("Type 'U'")),
-        "elaboration must not name the unrelated alias `U`; got {texts:?}"
+    assert_names_constituent(
+        &chain_texts(&diags),
+        "Type '{ m: number; }' is not assignable to type 'boolean'",
+        Some("Type 'U'"),
     );
 }
 
@@ -109,12 +119,10 @@ declare const e: { m: number } | { n: string };
 const ee: boolean = e;
 "#,
     );
-    let texts = chain_texts(&diags);
-    assert!(
-        texts
-            .iter()
-            .any(|m| m.contains("Type '{ m: number; }' is not assignable to type 'boolean'")),
-        "expected the first constituent `{{ m: number; }}`; got {texts:?}"
+    assert_names_constituent(
+        &chain_texts(&diags),
+        "Type '{ m: number; }' is not assignable to type 'boolean'",
+        None,
     );
 }
 
@@ -129,12 +137,75 @@ declare const e: { m: number } | E1;
 const ee: boolean = e;
 "#,
     );
-    let texts = chain_texts(&diags);
-    assert!(
-        texts
-            .iter()
-            .any(|m| m.contains("Type '{ m: number; }' is not assignable to type 'boolean'")),
-        "expected the first source-order constituent `{{ m: number; }}`; got {texts:?}"
+    assert_names_constituent(
+        &chain_texts(&diags),
+        "Type '{ m: number; }' is not assignable to type 'boolean'",
+        None,
+    );
+}
+
+#[test]
+fn anonymous_object_union_names_first_source_order_member_when_interning_reverses_it() {
+    // #16965: the leading `preB`/`preA` declarations force `{ b: number }`'s
+    // shape to be content-interned *before* `{ a: string }`, so tsz's canonical
+    // (ShapeId-keyed) union member order is `{ b } , { a }` — reversed from the
+    // written `{ a: string } | { b: number }`. tsc mints a fresh anonymous type
+    // per `TypeLiteral`, so it always names the first *written* failing member.
+    // The union header already prints source order (from `union_origin`); the
+    // nested elaboration must agree.
+    let diags = check_source_strict(
+        r#"
+declare const preB: { b: number };
+declare const preA: { a: string };
+declare const v: { a: string } | { b: number };
+const x: boolean = v;
+"#,
+    );
+    assert_names_constituent(
+        &chain_texts(&diags),
+        "Type '{ a: string; }' is not assignable to type 'boolean'",
+        Some("Type '{ b: number; }' is not assignable to type 'boolean'"),
+    );
+}
+
+#[test]
+fn anonymous_object_union_ts2345_names_first_source_order_member_when_reversed() {
+    // Same reversed-interning shape as above, but the failing relation is a
+    // TS2345 argument mismatch rather than a TS2322 assignment. Both diagnostics
+    // consume the same union-source elaboration, so the fix covers both.
+    let diags = check_source_strict(
+        r#"
+declare const preB: { b: number };
+declare const preA: { a: string };
+declare const v: { a: string } | { b: number };
+declare function f(x: boolean): void;
+f(v);
+"#,
+    );
+    assert_names_constituent(
+        &chain_texts_for(&diags, 2345),
+        "Type '{ a: string; }' is not assignable to type 'boolean'",
+        Some("Type '{ b: number; }' is not assignable to type 'boolean'"),
+    );
+}
+
+#[test]
+fn anonymous_object_union_three_members_names_first_source_order_member_when_reversed() {
+    // Three anonymous members with pre-declarations that scramble the canonical
+    // order: source order `{ a } | { b } | { c }` must still name `{ a }`.
+    let diags = check_source_strict(
+        r#"
+declare const preC: { c: boolean };
+declare const preB: { b: number };
+declare const preA: { a: string };
+declare const v: { a: string } | { b: number } | { c: boolean };
+const x: number = v;
+"#,
+    );
+    assert_names_constituent(
+        &chain_texts(&diags),
+        "Type '{ a: string; }' is not assignable to type 'number'",
+        None,
     );
 }
 

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -1202,11 +1202,23 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             };
         if let Some(member_list) = union_member_list {
             let members = self.interner.type_list(member_list);
+            // Base the walk on the union's as-written source order when the
+            // interner recorded one (`get_union_origin`) and it is a pure
+            // reordering of the interned members. tsz's canonical member order
+            // is by `ShapeId`/allocation identity, which can reverse source
+            // order for anonymous object members (#16965); the header already
+            // renders source order from the same side table, so the nested
+            // elaboration must agree. A flatten/collapse origin (a different
+            // member set) is rejected and the interned order is kept — see
+            // `union_source_elaboration_origin_override`.
+            let origin_override =
+                self.union_source_elaboration_origin_override(union_member_source, &members);
+            let base = origin_override.as_deref().unwrap_or(&members);
             // Pick the first failing member in tsc's *relation* order (nullish
             // first), not tsz's stored *printer* order (nullish last) — see
             // `reorder_union_members_nullish_first`. Example: `number | undefined`
             // -> `string` drills the `undefined` member, matching tsc.
-            let mut ordered = reorder_union_members_nullish_first(&members);
+            let mut ordered = reorder_union_members_nullish_first(base);
             // Same-rank enum members: `sort_union_members` orders the interned
             // list by allocation identity (needed so `E1 | E2` and `E2 | E1`
             // intern to one canonical `TypeId`), which does not track

--- a/crates/tsz-solver/src/relations/subtype/explain_union_order.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain_union_order.rs
@@ -42,7 +42,62 @@ pub(super) fn reorder_union_members_nullish_first(members: &[TypeId]) -> Vec<Typ
     ordered
 }
 
+/// Whether `a` and `b` hold the same multiset of `TypeId`s (same length, and
+/// every value appears the same number of times). `TypeId` is only
+/// `Hash + Eq`, so the check counts occurrences rather than sorting.
+fn is_pure_permutation(a: &[TypeId], b: &[TypeId]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut counts: rustc_hash::FxHashMap<TypeId, isize> = rustc_hash::FxHashMap::default();
+    for &member in a {
+        *counts.entry(member).or_default() += 1;
+    }
+    for &member in b {
+        *counts.entry(member).or_default() -= 1;
+    }
+    counts.values().all(|&count| count == 0)
+}
+
 impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
+    /// As-written source order for a union-source failure elaboration, when the
+    /// interner recorded one that should override the canonical member order.
+    ///
+    /// `tsc` walks a union source's members in source (as-written) order when
+    /// it elaborates the failing member beneath the union-to-target line. tsz's
+    /// interner stores members in a canonicalization order (by `ShapeId` /
+    /// allocation identity) so that `A | B` and `B | A` share one `TypeId`; for
+    /// anonymous object members that canonical order can reverse source order
+    /// (e.g. `{ a: string } | { b: number }` interned as `{ b: number }`-first
+    /// when `{ b: number }`'s shape was content-interned first), so a raw
+    /// interned walk names the wrong constituent even though the union *header*
+    /// already prints source order (#16965).
+    ///
+    /// The interner records the as-written order in the `union_origin` side
+    /// table (`get_union_origin`) precisely when canonical and source order
+    /// disagree — the same table the printer's header uses. Returns `Some` of
+    /// that order only when it is a *pure reordering* of the interned member set
+    /// (same length and same multiset of `TypeId`s); the caller then walks it
+    /// instead of the interned order. Returns `None` — walk the interned order —
+    /// when no origin was recorded (canonical already matches source order) or
+    /// when the recorded origin is a flatten (`T | null` where `T` is a union
+    /// alias, which carries more members) or an anonymous-object duplicate
+    /// collapse (`{ m } | { m }` deduped to one interned member, #14344), whose
+    /// member set differs from the interned union. This is display-only: the
+    /// order is the same multiset either way, so the relation outcome and the
+    /// elaborated member's failure reason are unaffected — only which failing
+    /// constituent is named changes.
+    pub(in crate::relations::subtype) fn union_source_elaboration_origin_override(
+        &self,
+        union_type_id: TypeId,
+        interned_members: &[TypeId],
+    ) -> Option<Vec<TypeId>> {
+        self.interner
+            .get_union_origin(union_type_id)
+            .filter(|origin| is_pure_permutation(origin.as_ref(), interned_members))
+            .map(|origin| origin.as_ref().clone())
+    }
+
     /// Reorder same-rank enum members of a union-source elaboration list into
     /// declaration order, in place.
     ///


### PR DESCRIPTION
When an assignability failure has a **union source**, `tsc` elaborates the nested `Type 'X' is not assignable to type 'Y'.` line with the **first written failing member**. tsz's union-source elaboration (`SubtypeChecker::explain_failure_inner`) walked the interner's **canonical** (`ShapeId` / allocation-identity) member order, which content-interning can reverse relative to source order for **anonymous object members** — so the nested line named the wrong constituent even though the union *header* (rendered from the `union_origin` side table) already printed source order.

Structural rule: **when a union source has a recorded `union_origin` that is a pure reordering of the interned member set (same length + same multiset), tsz now bases the elaboration walk on that as-written order** — the same side table the header reads — then applies the existing nullish-first (relation order) and enum-by-declaration reorders on top. Owner layer: solver, `crates/tsz-solver/src/relations/subtype/explain_union_order.rs` (new `union_source_elaboration_origin_override`) + call site in `explain.rs`.

## Repro (`--strict --target es2022 --module esnext`)

```ts
declare const preB: { b: number };
declare const preA: { a: string };
declare const v: { a: string } | { b: number };
const x: boolean = v;
```

| | nested elaboration line |
| --- | --- |
| `tsc` 7.0.2 | `Type '{ a: string; }' is not assignable to type 'boolean'.` |
| tsz before | `Type '{ b: number; }' is not assignable to type 'boolean'.` ❌ |
| tsz after | `Type '{ a: string; }' is not assignable to type 'boolean'.` ✅ |

The `preB`/`preA` declarations force `{ b: number }`'s shape to be interned before `{ a: string }`, reversing tsz's canonical union order from source order.

## Scope / correctness

- **Display-only.** Each union arm still fails identically; only which failing constituent is *named* changes. No relation, identity, or perf change (the reorder runs only while building an error message, over tiny member lists). Covers **TS2322 and TS2345** — both consume the same `explain_failure_inner` reason.
- **Flatten / collapse rejected.** A `union_origin` that is a flatten (`T | null` over a union alias) or an anonymous-object duplicate collapse (`{ m } | { m }` deduped to one interned member, #14344) carries a *different* member set; the pure-permutation guard rejects it and keeps the interned order, so no constituent outside the relation can be named.
- **Enum reorder retained, not removed.** The issue speculated origin-order "subsumes" the enum-by-declaration special case, but no `union_origin` is recorded for pure-enum unions, so `reorder_enum_members_by_declaration` remains the only correction for the #16513 family. Confirmed by `union_source_enum_elaboration_order_tests` staying green.
- **Known gap (out of scope, #14344):** a union that both collapses an anonymous-object duplicate *and* reverses canonical order can still show a header/elaboration mismatch; the guard deliberately falls back to interned order there.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --release --test union_source_elaboration_constituent_tests` — 9 passed (3 new: reversed-interning TS2322, reversed-interning TS2345, three-member reversal; 6 existing incl. enum-order and named-alias).
- Adjacent suites green: `union_source_member_provenance_display_tests` (22), `union_source_missing_property_elaboration_tests`, `union_source_structural_elaboration_tests`, `union_target_missing_property_elaboration_tests` (13), `union_source_enum_elaboration_order_tests` (5), `union_duplicate_literal_member_display_tests` (7, the #14344 collapse case — unaffected), `union_origin_display_tests` (5), `union_display_alias_repaint_parity_tests`.
- CLI repro above confirmed against the release `tsz` binary.
- **Conformance** (`conformance.sh snapshot --workers 12 --force`) at PR head: **11556 passed / 487 failed / 96.0%** — no regressions vs the committed baseline (11499 / 544; the net gain also includes intervening `main` merges). This change is strictly parity-directed (names the tsc-correct source-order constituent), so it can only fix or leave fixtures unchanged.
- Merge lane: `cargo clippy -p tsz-solver --lib` and the new checker test target clean under `-D warnings`; `scripts/arch/arch_guard.py` + per-file line-limit guard pass (`explain.rs` 2017 ≤ 2026 ratchet). CI `clippy` + `arch-size` + `CI Summary` green on head.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high