### PR TITLE
fix(checker): super.method() preserves the base method's polymorphic `this` return

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1855,6 +1855,9 @@ path = "tests/destructuring_rest_computed_key_omit_tests.rs"
 name = "super_keyword_speculation_survival_tests"
 path = "tests/super_keyword_speculation_survival_tests.rs"
 [[test]]
+name = "super_polymorphic_this_return_tests"
+path = "tests/super_polymorphic_this_return_tests.rs"
+[[test]]
 name = "ambient_default_namespace_export_dup_tests"
 path = "tests/ambient_default_namespace_export_dup_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state.rs
+++ b/crates/tsz-checker/src/state/state.rs
@@ -712,7 +712,19 @@ impl<'a> CheckerState<'a> {
         };
 
         if let Some(access) = self.ctx.arena.get_access_expr(node) {
-            if self.is_this_expression(access.expression)
+            // A `this`-receiver keeps the return's `this` polymorphic (bound to
+            // the enclosing class's own `this`-type marker). An instance `super`
+            // receiver is the same case: the runtime receiver of `super.foo()` is
+            // still the current instance, so the base method's `this` return must
+            // bind to the *enclosing* class's `this`-type, not the base instance
+            // type that `super` evaluates to. Binding it to the base instance
+            // (via the receiver branch below) is what collapses `super.m()`'s
+            // `this` return to the base class — and a multi-level `super` chain to
+            // the root base. Static `super` falls through to the receiver branch,
+            // which uses the constructor receiver.
+            if (self.is_this_expression(access.expression)
+                || (self.is_super_expression(access.expression)
+                    && !self.is_this_in_static_class_member(call_expression)))
                 && self.ctx.enclosing_class.is_some()
                 && !self.is_this_in_nested_function_inside_class(call_expression)
                 && !self.is_this_in_static_class_member(call_expression)

--- a/crates/tsz-checker/src/types/property_access_type/identifier_resolution.rs
+++ b/crates/tsz-checker/src/types/property_access_type/identifier_resolution.rs
@@ -848,12 +848,35 @@ impl<'a> CheckerState<'a> {
                 //
                 // `super.method` is special: the property lookup happens on the
                 // base instance type, but polymorphic `this` in the base member
-                // should still bind to the current derived receiver. Without
-                // this, `super.compare(other)` inside `Dog.compare(other: this)`
-                // sees the base signature as `(other: Animal) => boolean`
-                // instead of `(other: Dog) => boolean`, which diverges from tsc.
+                // must bind to the *enclosing* class's `this`-type — matching
+                // tsc's `getTypeWithThisArgument(baseType, enclosingClassThisType)`
+                // — not the base instance type. JS's `super.foo()` never receives
+                // a fresh base-class instance: the runtime receiver stays the
+                // current instance, so `super.compare(other)` inside
+                // `Dog.compare(other: this)` must see `(other: this) => boolean`,
+                // and `super.returnThis()` where the base infers a `this` return
+                // must yield the enclosing class's `this`, not the base class.
+                //
+                // The enclosing class's `this`-type is the polymorphic `ThisType`
+                // marker itself (contextually the enclosing class): binding
+                // `this` to it is the identity, so the base member's `this` stays
+                // polymorphic and is rebound to the actual receiver at the
+                // eventual direct-access site. This is what threads the receiver
+                // through a multi-level `super` chain (`A -> B -> C`): each hop's
+                // inferred `this` return stays polymorphic, so `new C().m()`
+                // resolves to `C`. Baking it to the base instance type here
+                // instead — the previous behavior when `current_this_type()` was
+                // unavailable during lazy return-type inference — collapsed the
+                // whole chain to the root base class.
+                //
+                // Static `super` keeps the constructor-`this` binding computed by
+                // `current_this_type()`; only the instance case is the marker.
                 let this_substitution_target = if self.is_super_expression(access.expression) {
-                    self.current_this_type().unwrap_or(original_object_type)
+                    if self.is_this_in_static_class_member(access.expression) {
+                        self.current_this_type().unwrap_or(original_object_type)
+                    } else {
+                        self.ctx.types.this_type()
+                    }
                 } else if direct_class_this_receiver
                     || crate::query_boundaries::common::contains_this_type(
                         self.ctx.types,
@@ -893,14 +916,28 @@ impl<'a> CheckerState<'a> {
                 // `this[][]`, drawing a false TS2345). The empty branch also
                 // short-circuits the raw-recovery `else if` below, which would
                 // otherwise re-introduce the same nesting.
+                // An instance `super` receiver must force the raw-recovery path
+                // below. The solver eagerly binds a returned `this` to the lookup
+                // receiver — here the *base* instance — so `super.m()`'s stored
+                // type comes back as `() => Base` (whose `Base` still transitively
+                // mentions `this` through its own members). That makes the plain
+                // `contains_this_type(prop_type)` branch a no-op identity against
+                // the enclosing-`this` marker, leaving the return baked to the
+                // base class. Re-resolving with `this` binding deferred recovers
+                // the raw `() => this`, which the marker then keeps polymorphic so
+                // it rebinds to the real receiver at the direct-access site.
+                let super_receiver = self.is_super_expression(access.expression)
+                    && !self.is_this_in_static_class_member(access.expression);
                 if self.receiver_expr_is_this_relative(access.expression)
                     && self.type_is_compound_this_relative(this_substitution_target)
                 {
                     // Leave `prop_type` as the solver produced it.
-                } else if crate::query_boundaries::common::contains_this_type(
-                    self.ctx.types,
-                    prop_type,
-                ) && prop_type != this_substitution_target
+                } else if !super_receiver
+                    && crate::query_boundaries::common::contains_this_type(
+                        self.ctx.types,
+                        prop_type,
+                    )
+                    && prop_type != this_substitution_target
                 {
                     prop_type = crate::query_boundaries::common::substitute_this_type(
                         self.ctx.types,

--- a/crates/tsz-checker/tests/super_polymorphic_this_return_tests.rs
+++ b/crates/tsz-checker/tests/super_polymorphic_this_return_tests.rs
@@ -1,0 +1,212 @@
+//! Tests for `super.method()` preserving the base method's polymorphic `this`
+//! return type (issue #16960).
+//!
+//! Structural rule:
+//!   When a base method's return type is the polymorphic `this` type (whether
+//!   inferred from a bare `return this;` or written `): this`), accessing that
+//!   method through `super.` must bind `this` to the *enclosing* class's
+//!   `this`-type, exactly like tsc's
+//!   `getTypeWithThisArgument(baseType, enclosingClassThisType)`. JS's
+//!   `super.foo()` never receives a fresh base-class instance — the runtime
+//!   receiver stays the current instance — so the result must carry the derived
+//!   receiver, not the base class.
+//!
+//! tsz previously baked `super.method()`'s `this` return to the *base* instance
+//! type (the receiver of the `super` lookup), producing a spurious `TS2339`
+//! (`Property 'x' does not exist on type 'Base'`) and, for a multi-level
+//! `super` chain, collapsing every hop to the root base class.
+//!
+//! The fix keeps the base member's `this` polymorphic at the `super.` access
+//! site, so it threads through inference and is rebound to the actual receiver
+//! at the eventual direct-access site. Binder names are varied so no fix can
+//! key on a specific identifier.
+
+use tsz_checker::test_utils::{check_source_strict_codes, check_source_strict_messages};
+
+/// Diagnostics other than TS2318 (missing global types in the no-stdlib unit
+/// harness), which is noise here.
+fn codes(source: &str) -> Vec<u32> {
+    check_source_strict_codes(source)
+        .into_iter()
+        .filter(|&code| code != 2318)
+        .collect()
+}
+
+/// TS2322 messages (used to witness *which* class name the inferred type
+/// resolved to).
+fn ts2322_messages(source: &str) -> Vec<String> {
+    check_source_strict_messages(source)
+        .into_iter()
+        .filter(|(code, _)| *code == 2322)
+        .map(|(_, message)| message)
+        .collect()
+}
+
+// ── Primary repro: inferred `return this` threaded through `super` ──────────
+
+#[test]
+fn super_inferred_this_return_threads_derived_member_access() {
+    // `pull()` returns `this` (inferred). The override forwards it through
+    // `super.pull()`; the forwarded result must be the derived receiver, whose
+    // `tag()` member exists — so the whole program is clean, like tsc.
+    let source = r#"
+class Vessel {
+    pull() { return this; }
+}
+class Skiff extends Vessel {
+    tag() { return 0; }
+    pull() { return super.pull(); }
+}
+new Skiff().pull().tag();
+"#;
+    assert_eq!(
+        codes(source),
+        Vec::<u32>::new(),
+        "super.pull() must yield the derived receiver (Skiff), whose tag() exists"
+    );
+}
+
+#[test]
+fn super_inferred_this_return_never_witness_is_not_base() {
+    // Assigning the `super` result to `never` witnesses the inferred type. The
+    // base's `draw()` infers a polymorphic `this` return, so inside the derived
+    // method `super.draw()` is `this` (the derived receiver) — never the base
+    // class. The witnessing TS2322 must therefore fire and must NOT name the
+    // base class `Cistern` (the pre-fix behavior baked it to the base).
+    let source = r#"
+class Cistern {
+    draw() { return this; }
+}
+class Wellspring extends Cistern {
+    draw() {
+        let sink: never = super.draw();
+        return super.draw();
+    }
+}
+"#;
+    let messages = ts2322_messages(source);
+    assert!(
+        !messages.is_empty(),
+        "super.draw() assigned to `never` must raise TS2322"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("Cistern")),
+        "super.draw() must NOT resolve to the base class Cistern, got: {messages:?}"
+    );
+}
+
+// ── Multi-level `super` chain threads the original receiver ────────────────
+
+#[test]
+fn super_this_return_threads_through_multi_level_chain() {
+    // `A -> B -> C`, each overriding `hop()` as `return super.hop()`. The
+    // `this` must thread through as the *original* call's receiver (C), not
+    // collapse to B at each hop. `new C().hop().onlyOnC()` is therefore clean.
+    let source = r#"
+class Rung {
+    hop() { return this; }
+}
+class Middle extends Rung {
+    hop() { return super.hop(); }
+}
+class Summit extends Middle {
+    onlyOnSummit() { return 0; }
+    hop() { return super.hop(); }
+}
+new Summit().hop().onlyOnSummit();
+"#;
+    assert_eq!(
+        codes(source),
+        Vec::<u32>::new(),
+        "multi-level super chain must thread `this` to the outermost receiver (Summit)"
+    );
+}
+
+// ── Explicit `: this` annotation triggers the same path ────────────────────
+
+#[test]
+fn super_explicit_this_return_annotation_threads_derived() {
+    let source = r#"
+class Beacon {
+    signal(): this { return this; }
+}
+class Lighthouse extends Beacon {
+    glow() { return 0; }
+    signal(): this { return super.signal(); }
+}
+new Lighthouse().signal().glow();
+"#;
+    assert_eq!(
+        codes(source),
+        Vec::<u32>::new(),
+        "an explicit `: this` base return must thread through super just like an inferred one"
+    );
+}
+
+// ── Regression guard: `this`-typed parameter through `super` still accepted ─
+
+#[test]
+fn super_this_typed_param_call_still_accepted() {
+    // The `this`-parameter path must stay callable: passing the enclosing
+    // `this` into `super.addChild(c: this)` is valid.
+    let source = r#"
+class Branch {
+    children: this[] = [];
+    addChild(c: this): void { this.children.push(c); }
+}
+class Twig extends Branch {
+    addChild(c: this): void {
+        this.children.push(c);
+        super.addChild(c);
+    }
+}
+"#;
+    assert!(
+        !codes(source).contains(&2345),
+        "passing `this` into super.addChild(c: this) must not raise TS2345"
+    );
+}
+
+// ── Regression guard: a non-`this` base return is unaffected ────────────────
+
+#[test]
+fn super_non_this_return_is_unchanged() {
+    // `label()` returns a plain string, not `this`. Threading logic must not
+    // touch it: accessing a string-only member is fine, a bogus one still errors.
+    let clean = r#"
+class Marker {
+    label(): string { return ""; }
+}
+class Signpost extends Marker {
+    label(): string { return super.label(); }
+    read() { const s: string = this.label(); return s; }
+}
+"#;
+    assert_eq!(
+        codes(clean),
+        Vec::<u32>::new(),
+        "a non-this base return must flow through super unchanged"
+    );
+}
+
+// ── Anti-hardcoding: direct inherited call (no override) still resolves ─────
+
+#[test]
+fn direct_inherited_this_return_still_resolves_to_derived() {
+    // Regression guard for the path that already worked: a subclass that does
+    // NOT override still resolves the inherited `this` return to itself.
+    let source = r#"
+class Anchor {
+    moor() { return this; }
+}
+class Dock extends Anchor {
+    berth() { return 0; }
+}
+new Dock().moor().berth();
+"#;
+    assert_eq!(
+        codes(source),
+        Vec::<u32>::new(),
+        "inherited (non-super) `this` return must still resolve to the derived class"
+    );
+}


### PR DESCRIPTION
Fixes #16960.

`super.method()` where the base method's return type is the polymorphic `this` type — inferred from `return this;` or written `): this` — collapsed the result to the **base** class instead of the enclosing (derived) receiver, producing a spurious `TS2339`/`TS2322`. A multi-level `super` chain (`A -> B -> C`) collapsed every hop to the root base class.

**Structural rule:** when a base method's return type is the polymorphic `this`, `tsc` types `super.method()` via `getTypeWithThisArgument(baseType, enclosingClassThisType)` — JS's `super.foo()` never binds a fresh base-class instance, so the runtime receiver stays the current instance and `this` binds to the *enclosing* class's `this`-type, not the base instance type that `super` evaluates to. tsz must do the same through the checker's property-access + call-return `this`-substitution boundary.

**Root cause:** the solver eagerly binds a returned `this` to the lookup receiver, so `super.m()` came back as `() => Base`. Because `Base` still transitively mentions `this` through its own members, the property-access substitution was a no-op identity against the enclosing-`this` marker, and the call-return substitution then re-bound `this` to the base instance receiver — baking the polymorphic `this` down to the base class.

**Fix (checker; instance `super` only, static `super` unchanged):**
- `types/property_access_type/identifier_resolution.rs`: bind an instance-`super` member's `this` to the enclosing class's `this`-type marker (identity — keeps it polymorphic), and force the raw-`this` recovery path so the eager base binding is undone before rebinding.
- `state/state.rs` (`apply_this_substitution_to_call_return`): treat an instance-`super` receiver like a `this` receiver, keeping the call's `this` return polymorphic instead of baking it to the base instance type. Keeping it polymorphic is what lets a multi-level chain thread the receiver through to the outermost call.

Owner layer: checker property-access / call-return `this`-substitution boundary (solver-owned `substitute_this_type` is reused, not reimplemented).

## Goal
Goal: hold

## Verification
Adjacent-case matrix (all now match `tsc` 7.0.2; witnessed with a `never` assignment / member access that only exists on the derived class):

| case | before | after (== tsc) |
| --- | --- | --- |
| `super.m()` inferred `this` return | `Base` | derived receiver |
| multi-level `A -> B -> C`, each forwards `super.m()` | `A` | `C` |
| explicit `): this` base return through `super` | `Base` | derived receiver |
| `this`-typed param through `super` (`super.addChild(c: this)`) | clean | clean (unchanged) |
| non-`this` base return through `super` | unchanged | unchanged |
| direct inherited call (no `super`) | derived | derived (unchanged) |

Commands run locally (this environment lacks the TypeScript submodule, so the conformance/emit/fourslash gates run in CI):
- `cargo test --release -p tsz-checker --test super_polymorphic_this_return_tests` — 7 new tests pass (new file, binder names varied).
- Related suites pass: `this_array_field_method_param_14512_tests`, `this_array_field_method_call_tests`, `conditional_infer_polymorphic_this_tests`, `super_keyword_speculation_survival_tests`, `ts2340_super_accessor_tests`, `ts2513_abstract_super_access_tests`.
- Broad regression sweep: 495 checker integration test targets matching `this|super|class|assign|call|method|inherit|property|polymorphic|ts2322|ts2345|ts2416|ts2339` — 0 failures.
- Pre-commit gate: clippy + arch-size guard pass.
- Conformance snapshot / emit parity / fourslash: not runnable locally here (no TS submodule); rely on CI's nightly/dispatch lanes.

## Provenance
Machine: cloud
Assistant: claude-code
Model: Opus 4.8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_017mjnhVvtYjjj8CVTjKUBH3)_