### PR TITLE
fix(checker): well-known symbol reached through an alias resolves member lookup by type identity

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -1059,6 +1059,8 @@ mod verbatim_module_syntax_export_default_alias_ts1284_tests;
 mod verbatim_module_syntax_export_default_type_only_import_ts1284_tests;
 #[path = "tests/void_undefined_discriminant_narrowing_tests.rs"]
 mod void_undefined_discriminant_narrowing_tests;
+#[path = "tests/well_known_symbol_alias_member_tests.rs"]
+mod well_known_symbol_alias_member_tests;
 #[path = "tests/window_self_globalthis_resolution_tests.rs"]
 mod window_self_globalthis_resolution_tests;
 #[path = "tests/yieldstar_async_iterable_invalid_thenable_element_tests.rs"]

--- a/crates/tsz-checker/src/tests/well_known_symbol_alias_member_tests.rs
+++ b/crates/tsz-checker/src/tests/well_known_symbol_alias_member_tests.rs
@@ -1,0 +1,181 @@
+//! Regression tests for a false-positive `TS7015`/`TS7053` when a well-known
+//! symbol (`Symbol.iterator`, etc.) is reached through an alias binding
+//! (`const S = Symbol;` or `const S = globalThis.Symbol;`) rather than
+//! spelled directly off the global `Symbol`.
+//!
+//! `tsc` resolves `S.iterator` to the same well-known symbol regardless of
+//! how `S` was obtained, because the identity lives in the TYPE
+//! (`SymbolConstructor.iterator`'s declared `unique symbol`), not in the
+//! access syntax. tsz's element-access path only recognized the well-known
+//! shape through a purely-syntactic check requiring the base identifier's
+//! literal text to be `"Symbol"` (`computed_names::well_known_symbol_access_shape`);
+//! an alias bypassed that shortcut and fell into a numeric fallback that
+//! decoded the key's `SymbolRef` as a binder `SymbolId` — but a well-known
+//! symbol's `SymbolRef` is minted by the lowering layer from the `unique
+//! symbol` type-operator's NODE INDEX
+//! (`tsz_lowering::lower::advanced::lower_type_operator`), not a `SymbolId`
+//! at all, so the raw-id lookup silently resolved to an unrelated symbol
+//! that happened to share the same per-binder-local number.
+//!
+//! Fix: identify the well-known-symbol member NAME by TYPE IDENTITY against
+//! the lib's own `SymbolConstructor` interface
+//! (`well_known_symbol_name_by_type_identity`) instead of decoding the
+//! `SymbolRef` as an id.
+//!
+//! Every read of `Symbol.<name>` — direct or aliased — resolves through
+//! ordinary property-type computation against the same merged
+//! `SymbolConstructor` type, so the fix works uniformly for both spellings.
+//!
+//! Oracle-verified against `typescript@7.0.2`, `--target es6`.
+//!
+//! Issue: <https://github.com/tsz-org/tsz/issues/16961>
+
+use std::sync::{Arc, OnceLock};
+use tsz_binder::lib_loader::LibFile;
+
+use crate::CheckerOptions;
+use crate::test_utils::{check_source_with_libs_code_messages, load_default_lib_files};
+
+fn default_libs() -> &'static [Arc<LibFile>] {
+    static DEFAULT_LIBS: OnceLock<Vec<Arc<LibFile>>> = OnceLock::new();
+    DEFAULT_LIBS.get_or_init(load_default_lib_files)
+}
+
+fn check_with_libs(src: &str) -> Vec<(u32, String)> {
+    check_source_with_libs_code_messages(src, "test.ts", CheckerOptions::default(), default_libs())
+}
+
+#[track_caller]
+fn assert_fully_clean(src: &str) {
+    let diags = check_with_libs(src);
+    assert!(diags.is_empty(), "expected no diagnostics, got: {diags:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Direct spelling stays clean (control — must not regress).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn direct_symbol_iterator_element_access_stays_clean() {
+    assert_fully_clean("[][Symbol.iterator];");
+}
+
+// ---------------------------------------------------------------------------
+// Alias forms — the false-positive family.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn simple_const_alias_of_symbol() {
+    assert_fully_clean(
+        "
+        const S = Symbol;
+        [][S.iterator];
+        ",
+    );
+}
+
+#[test]
+fn shadowed_symbol_via_global_this() {
+    assert_fully_clean(
+        "
+        export {};
+        const Symbol = globalThis.Symbol;
+        [][Symbol.iterator];
+        ",
+    );
+}
+
+#[test]
+fn aliased_global_this_symbol() {
+    assert_fully_clean(
+        "
+        const S = globalThis.Symbol;
+        [][S.iterator];
+        ",
+    );
+}
+
+#[test]
+fn shadowed_symbol_used_as_object_literal_computed_key_and_alias_element_access() {
+    assert_fully_clean(
+        "
+        export {};
+        const Symbol = globalThis.Symbol;
+        const o = { [Symbol.iterator]: 1 };
+        [][Symbol.iterator];
+        ",
+    );
+}
+
+/// Binder-name independence: the alias must work under an arbitrary
+/// identifier, not just `S`/`Symbol`.
+#[test]
+fn arbitrary_alias_identifier_name() {
+    assert_fully_clean(
+        "
+        const zzTop = Symbol;
+        [][zzTop.iterator];
+        ",
+    );
+}
+
+/// The pre-existing (non-array) receiver case: same missed lookup, reported
+/// as `TS7053` rather than `TS7015` since there is no element-type fallback
+/// to hide it. Receiver-independent — this predates the array-specific fix
+/// in #16958 and must be fixed by the same identity-based lookup.
+#[test]
+fn aliased_symbol_on_string_receiver() {
+    assert_fully_clean(
+        r#"
+        const S = globalThis.Symbol;
+        "abc"[S.iterator];
+        "#,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls — must still error; the fix must not over-suppress.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unrelated_unique_symbol_still_reports_ts7015() {
+    let diags = check_with_libs(
+        "
+        declare const s: unique symbol;
+        [][s];
+        ",
+    );
+    assert!(
+        diags.iter().any(|(code, _)| *code == 7015),
+        "expected TS7015 for an unrelated unique symbol key, got: {diags:?}"
+    );
+}
+
+#[test]
+fn plain_wide_symbol_still_reports_ts7015() {
+    let diags = check_with_libs(
+        "
+        declare const s: symbol;
+        [][s];
+        ",
+    );
+    assert!(
+        diags.iter().any(|(code, _)| *code == 7015),
+        "expected TS7015 for a plain `symbol`-typed key, got: {diags:?}"
+    );
+}
+
+#[test]
+fn well_known_symbol_hasinstance_still_resolves_through_alias() {
+    assert_fully_clean(
+        "
+        class C {
+            static [Symbol.hasInstance](x: unknown): boolean {
+                return true;
+            }
+        }
+        const S = Symbol;
+        (C as any)[S.hasInstance];
+        ",
+    );
+}

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -1264,31 +1264,26 @@ impl<'a> CheckerState<'a> {
 
             // Fallback: well-known symbols (Symbol.hasInstance, Symbol.iterator, etc.)
             // are stored as "[Symbol.xxx]" in class/interface types, not "__unique_N".
-            // When the __unique_N lookup fails, try the [Symbol.xxx] format.
-            if result_type.is_none() {
-                let sym_id =
-                    crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id(sym_ref);
-                if let Some(symbol) = self.ctx.binder.get_symbol(sym_id) {
-                    let sym_name = &symbol.escaped_name;
-                    // Check if the parent is the Symbol global constructor
-                    if symbol.parent.is_some()
-                        && let Some(parent_sym) = self.ctx.binder.get_symbol(symbol.parent)
-                        && parent_sym.escaped_name == "Symbol"
-                    {
-                        let well_known_name = format!("[Symbol.{sym_name}]");
-                        let result =
-                            self.resolve_property_access_with_env(resolved_type, &well_known_name);
-                        if let PropertyAccessResult::Success {
-                            type_id,
-                            write_type,
-                            ..
-                        } = result
-                            && !union_member_missing_symbol
-                        {
-                            use_index_signature_check = false;
-                            result_type = Some(effective_write_result(type_id, write_type));
-                        }
-                    }
+            // When the __unique_N lookup fails, identify the well-known name by
+            // TYPE IDENTITY against the lib's `SymbolConstructor` interface
+            // (`well_known_symbol_name_by_type_identity`) rather than decoding
+            // `sym_ref` as a binder `SymbolId` — it may have been minted from a
+            // `unique symbol` type-operator NODE INDEX instead, which collides
+            // with an unrelated symbol under a raw-id lookup (#16961).
+            if result_type.is_none()
+                && let Some(well_known_name) =
+                    self.well_known_symbol_name_by_type_identity(index_type)
+            {
+                let result = self.resolve_property_access_with_env(resolved_type, &well_known_name);
+                if let PropertyAccessResult::Success {
+                    type_id,
+                    write_type,
+                    ..
+                } = result
+                    && !union_member_missing_symbol
+                {
+                    use_index_signature_check = false;
+                    result_type = Some(effective_write_result(type_id, write_type));
                 }
             }
 

--- a/crates/tsz-checker/src/types/computation/access_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/access_helpers.rs
@@ -1494,7 +1494,7 @@ impl<'a> CheckerState<'a> {
     /// any symbol key — so they are always missing unless an explicit `symbol`
     /// index signature is present.
     pub(crate) fn symbol_keyed_access_is_missing(
-        &self,
+        &mut self,
         object_type: TypeId,
         index_type_for_access: TypeId,
     ) -> bool {
@@ -1516,7 +1516,7 @@ impl<'a> CheckerState<'a> {
     }
 
     fn symbol_keyed_property_exists(
-        &self,
+        &mut self,
         object_type: TypeId,
         index_type_for_access: TypeId,
     ) -> bool {
@@ -1538,23 +1538,70 @@ impl<'a> CheckerState<'a> {
             return true;
         }
 
-        let sym_id = crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id(sym_ref);
-        let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
+        let Some(well_known_name) =
+            self.well_known_symbol_name_by_type_identity(index_type_for_access)
+        else {
             return false;
         };
-        let Some(parent_sym) = self.ctx.binder.get_symbol(symbol.parent) else {
-            return false;
-        };
-        if parent_sym.escaped_name != "Symbol" {
-            return false;
-        }
-        let well_known_name = format!("[Symbol.{}]", symbol.escaped_name);
         crate::query_boundaries::common::find_property_by_str(
             self.ctx.types,
             object_type,
             &well_known_name,
         )
         .is_some()
+    }
+
+    /// Resolve the well-known-symbol member name (`hasInstance`, `iterator`,
+    /// etc.) that a `unique symbol`-typed element-access key denotes, by TYPE
+    /// IDENTITY against the lib's own `SymbolConstructor` interface — never by
+    /// decoding the key's `SymbolRef` as a binder `SymbolId`.
+    ///
+    /// A well-known symbol's `SymbolRef` is minted by the lowering layer from
+    /// the `unique symbol` type-operator's NODE INDEX
+    /// (`lower_type_operator`'s `SymbolRef(node_idx.0)`, used for a readonly
+    /// property signature like `SymbolConstructor.iterator`) — not a
+    /// `SymbolId` at all, and a per-binder-local raw id silently collides with
+    /// an unrelated symbol when looked up directly (#16961). Even the DIRECT
+    /// `Symbol.iterator` spelling only ever avoided this: it resolves through
+    /// a separate, purely-syntactic shortcut
+    /// (`computed_names::well_known_symbol_access_shape`) that requires the
+    /// base identifier's literal text to be `"Symbol"` — an alias
+    /// (`const S = Symbol`) bypasses that shortcut and falls through to here.
+    ///
+    /// Every read of `Symbol.<name>` — direct or aliased — resolves through
+    /// ordinary property-type computation against the SAME merged
+    /// `SymbolConstructor` type, so `<name>`'s member type is exactly
+    /// `index_type` whenever `index_type` denotes that well-known symbol;
+    /// comparing by `TypeId` sidesteps the identity-space mismatch entirely.
+    pub(crate) fn well_known_symbol_name_by_type_identity(
+        &mut self,
+        index_type: TypeId,
+    ) -> Option<String> {
+        let ctor_sym_id = crate::types_domain::queries::lib_resolution::resolve_name_to_lib_symbol(
+            "SymbolConstructor",
+            self.ctx.binder,
+            self.ctx.global_file_locals_index.as_deref(),
+            self.ctx
+                .all_binders
+                .as_ref()
+                .map(|binders| binders.as_ref().as_slice()),
+            &self.ctx.lib_contexts,
+        )?;
+        let ctor_type_raw = self.get_type_of_symbol(ctor_sym_id);
+        let ctor_type = self.resolve_type_for_property_access(ctor_type_raw);
+        // `SymbolConstructor` is declaration-merged across several lib files
+        // (base symbol type, iterable, well-known-symbol augmentations); its
+        // resolved type is a naked intersection of each augmentation's own
+        // object shape rather than one flattened shape, so a direct
+        // `get_object_shape`/`find_property_by_str` on `ctor_type` itself
+        // finds nothing — the properties only appear one level down, on the
+        // intersection's members.
+        let mut props = Vec::new();
+        collect_object_properties_for_identity_match(self.ctx.types, ctor_type, 0, 1, &mut props);
+        props
+            .iter()
+            .find(|prop| prop.type_id == index_type)
+            .map(|prop| format!("[Symbol.{}]", self.ctx.types.resolve_atom(prop.name)))
     }
 
     /// Whether an `ESSymbolLike` element-access key resolves *only* through a
@@ -1628,5 +1675,35 @@ impl<'a> CheckerState<'a> {
         // asking generic element access, which may intentionally return the
         // string-index value type for diagnostic parity.
         !self.symbol_keyed_property_exists(object_type, index_type_for_access)
+    }
+}
+
+/// Collect properties reachable from `type_id` for a by-`TypeId` identity
+/// match, descending into intersection/union members up to `max_depth` —
+/// mirrors `tsz_solver::type_queries::collect_property_name_atoms_for_diagnostics`'s
+/// traversal shape but keeps each property's `TypeId`, not just its name.
+fn collect_object_properties_for_identity_match(
+    db: &dyn tsz_solver::construction::TypeDatabase,
+    type_id: TypeId,
+    depth: usize,
+    max_depth: usize,
+    out: &mut Vec<tsz_solver::PropertyInfo>,
+) {
+    if depth > max_depth {
+        return;
+    }
+    match tsz_solver::type_queries::classify_property_traversal(db, type_id) {
+        tsz_solver::type_queries::PropertyTraversalKind::Object(shape) => {
+            out.extend(shape.properties.iter().cloned());
+        }
+        tsz_solver::type_queries::PropertyTraversalKind::Callable(shape) => {
+            out.extend(shape.properties.iter().cloned());
+        }
+        tsz_solver::type_queries::PropertyTraversalKind::Members(members) => {
+            for member in members {
+                collect_object_properties_for_identity_match(db, member, depth + 1, max_depth, out);
+            }
+        }
+        tsz_solver::type_queries::PropertyTraversalKind::Other => {}
     }
 }


### PR DESCRIPTION
Fixes #16961.

`Symbol.iterator` (and other well-known symbols) accessed through an alias binding (`const S = Symbol;` or `const S = globalThis.Symbol;`) reported a false `TS7015`/`TS7053` on element access (`[][S.iterator]`) — a defect #16958 exposed by removing the element-type fallback that had silently masked it.

## Structural rule

`tsc` resolves `S.iterator` to the same well-known symbol as `Symbol.iterator` regardless of alias, because the identity lives in the TYPE (`SymbolConstructor.iterator`'s declared `unique symbol`), not the access syntax. tsz's element-access path only recognized the well-known shape through a purely-syntactic check requiring the base identifier's literal text to be `"Symbol"` (`computed_names::well_known_symbol_access_shape`); an alias bypassed that shortcut and fell into a fallback that decoded the key's `SymbolRef` as a binder `SymbolId` via `self.ctx.binder.get_symbol`.

Root cause: a well-known symbol's `SymbolRef` is minted by the lowering layer from the `unique symbol` type-operator's **NODE INDEX** (`tsz_lowering::lower::advanced::lower_type_operator`'s `SymbolRef(node_idx.0)`, used for a readonly property signature like `SymbolConstructor.iterator`) — not a `SymbolId` at all, so the raw-id lookup (`self.ctx.binder.get_symbol(SymbolId(sym_ref.0))`) silently resolved to an unrelated symbol that happened to share the same per-binder-local number (traced with `rdbg`-style tracing to a collision landing on an unrelated DOM global, `confirm`, sharing the numeric id by coincidence).

## Fix (owner: checker, `crates/tsz-checker/src/types/computation/access.rs` + `access_helpers.rs`)

`well_known_symbol_name_by_type_identity` resolves the member name by comparing `TypeId`s against the lib's own `SymbolConstructor` interface, instead of decoding the `SymbolRef` as an id. Every read of `Symbol.<name>` — direct or aliased — resolves through ordinary property-type computation against the same merged `SymbolConstructor` type, so this works uniformly for every alias path. `SymbolConstructor` is declaration-merged across several lib files, so its resolved type is a naked intersection of each augmentation's own object shape; the helper walks intersection members (mirroring the solver's own `collect_property_name_atoms_for_diagnostics` traversal shape) rather than assuming one flattened shape.

Applied at both call sites that had the identical raw-id decoding bug: `access.rs`'s element-access fallback, and `access_helpers.rs`'s `symbol_keyed_property_exists` (used by the TS2538 string-index-fallthrough check).

## Adjacent-case matrix (oracle-verified against `typescript@7.0.2`, `--target es6`)

| shape | tsc | before | after |
| --- | --- | --- | --- |
| `[][Symbol.iterator]` (direct, control) | clean | clean | clean |
| `const S = Symbol; [][S.iterator]` | clean | **TS7015** | clean |
| `const Symbol = globalThis.Symbol; [][Symbol.iterator]` (shadowed) | clean | **TS7015** | clean |
| `const S = globalThis.Symbol; [][S.iterator]` | clean | **TS7015** | clean |
| `const zzTop = Symbol; [][zzTop.iterator]` (binder-name independence) | clean | **TS7015** | clean |
| `const S = globalThis.Symbol; "abc"[S.iterator]` (non-array receiver, pre-existing) | clean | **TS7053** | clean |
| `Symbol.hasInstance` via alias against a class static member | clean | **TS7015** | clean |
| `declare const s: unique symbol; [][s]` (unrelated unique symbol — negative control) | TS7015 | TS7015 | TS7015 (unchanged) |
| `declare const s: symbol; [][s]` (plain wide symbol — negative control) | TS7015 | TS7015 | TS7015 (unchanged) |

Fixes the `indirectGlobalSymbolPartOfObjectType.ts` conformance false positive.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib well_known_symbol_alias_member`: 10/10 new tests pass (oracle-verified).
- `cargo test -p tsz-checker --lib symbol`: 489/489 pass, no regressions.
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- Targeted fixture: `TypeScript/tests/cases/compiler/indirectGlobalSymbolPartOfObjectType.ts` — `tsz --noEmit --target es6`, exit 0, no diagnostics (was TS7015).
- A full `cargo test -p tsz-checker --lib` (all ~10,800 tests) was kicked off before push; this change only touches two unique-symbol element-access fallback functions and their only two call sites, both covered above.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mgx8dpugWwM8pmRtD11iuR)_