### PR TITLE
fix(solver): union-source elaboration names first-written constituent when interning reverses order

### DIFF
--- a/crates/tsz-checker/tests/union_source_elaboration_constituent_tests.rs
+++ b/crates/tsz-checker/tests/union_source_elaboration_constituent_tests.rs
@@ -119,6 +119,35 @@ const ee: boolean = e;
 }
 
 #[test]
+fn object_union_names_first_source_order_constituent_when_interning_reverses_it() {
+    // `preB`/`preA` force `{ b: number }` to be content-interned before
+    // `{ a: string }`, reversing the union's canonical (allocation-identity)
+    // member order relative to how `v`'s union type was written. tsc mints a
+    // fresh anonymous type per `TypeLiteral`, so its relation walk (and its
+    // elaboration) still names the first *written* constituent, `{ a: string }`
+    // — not `{ b: number }` (issue #16965).
+    let diags = check_source_strict(
+        r#"
+declare const preB: { b: number };
+declare const preA: { a: string };
+declare const v: { a: string } | { b: number };
+const x: boolean = v;
+"#,
+    );
+    let texts = chain_texts(&diags);
+    assert!(
+        texts
+            .iter()
+            .any(|m| m.contains("Type '{ a: string; }' is not assignable to type 'boolean'")),
+        "expected the first written constituent `{{ a: string; }}`; got {texts:?}"
+    );
+    assert!(
+        !texts.iter().any(|m| m.contains("Type '{ b: number; }'")),
+        "elaboration must not name the second written constituent `{{ b: number; }}`; got {texts:?}"
+    );
+}
+
+#[test]
 fn mixed_object_then_enum_union_names_first_source_order_object() {
     // Ground truth (tsc): the object literal is written first, so it is the
     // named constituent even though the enum was declared earlier.

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -9,7 +9,9 @@ use crate::diagnostics::SubtypeFailureReason;
 use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
 use crate::relations::subtype::SubtypeChecker;
 use crate::relations::subtype::explain_guard::{ExplainFuelState, ExplainRecursionEntryState};
-use crate::relations::subtype::explain_union_order::reorder_union_members_nullish_first;
+use crate::relations::subtype::explain_union_order::{
+    reorder_union_members_nullish_first, union_elaboration_base_order,
+};
 use crate::type_queries::data::get_object_symbol;
 use crate::types::{
     IntrinsicKind, LiteralValue, ObjectShape, ObjectShapeId, PropertyInfo, TupleElement,
@@ -1202,11 +1204,20 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             };
         if let Some(member_list) = union_member_list {
             let members = self.interner.type_list(member_list);
+            // Prefer the union's as-written source order when the interner's
+            // canonical order reordered it (`union_elaboration_base_order`,
+            // issue #16965).
+            let base_order =
+                union_elaboration_base_order(self.interner, union_member_source, &members);
             // Pick the first failing member in tsc's *relation* order (nullish
             // first), not tsz's stored *printer* order (nullish last) — see
             // `reorder_union_members_nullish_first`. Example: `number | undefined`
-            // -> `string` drills the `undefined` member, matching tsc.
-            let mut ordered = reorder_union_members_nullish_first(&members);
+            // -> `string` drills the `undefined` member, matching tsc. This
+            // still applies on top of the origin order above: nullish members
+            // are pre-interned at the very start of both compilers, so tsc's
+            // relation walk always reaches them first regardless of where
+            // they were written.
+            let mut ordered = reorder_union_members_nullish_first(&base_order);
             // Same-rank enum members: `sort_union_members` orders the interned
             // list by allocation identity (needed so `E1 | E2` and `E2 | E1`
             // intern to one canonical `TypeId`), which does not track

--- a/crates/tsz-solver/src/relations/subtype/explain_union_order.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain_union_order.rs
@@ -8,9 +8,53 @@
 //! `TypeId`), not the source-declaration order — these two reorders bridge
 //! that gap without touching the interned identity itself.
 
+use crate::construction::TypeDatabase;
 use crate::def::resolver::TypeResolver;
 use crate::relations::subtype::SubtypeChecker;
 use crate::types::TypeId;
+
+/// Whether `origin` is a pure reordering of `members` — same length, same
+/// multiset of `TypeId`s — as opposed to a flatten/collapse (`origin` longer,
+/// e.g. a written duplicate anonymous object tsc keeps but tsz content-interns
+/// to one member) or an unrelated set.
+///
+/// Used to gate using a union's as-written `display_union_origin` order as the
+/// error-elaboration walk order: it is only safe to substitute when it
+/// describes the same members, just in a different order.
+pub(super) fn is_permutation_of(origin: &[TypeId], members: &[TypeId]) -> bool {
+    if origin.len() != members.len() {
+        return false;
+    }
+    let mut sorted_origin: Vec<u32> = origin.iter().map(|id| id.0).collect();
+    let mut sorted_members: Vec<u32> = members.iter().map(|id| id.0).collect();
+    sorted_origin.sort_unstable();
+    sorted_members.sort_unstable();
+    sorted_origin == sorted_members
+}
+
+/// Base order for a union-source elaboration walk: the union's as-written
+/// `display_union_origin` when one was stored and it is a pure reordering of
+/// `members` (same multiset — not a flatten/collapse, e.g. a duplicate
+/// anonymous object tsc keeps but tsz content-interns to one member),
+/// otherwise `members` unchanged.
+///
+/// tsc mints a fresh anonymous type per `TypeLiteral`, so its relation walk
+/// sees source order for object/literal/keyof/tuple members; tsz's canonical
+/// union order is allocation-identity order, which can reverse source order
+/// whenever a member's shape was interned by an earlier declaration (issue
+/// #16965). The union header already renders from this same origin, so this
+/// keeps the nested elaboration line naming the same constituent the header
+/// does.
+pub(super) fn union_elaboration_base_order(
+    interner: &dyn TypeDatabase,
+    union_member_source: TypeId,
+    members: &[TypeId],
+) -> Vec<TypeId> {
+    interner
+        .get_union_origin(union_member_source)
+        .filter(|origin| is_permutation_of(origin, members))
+        .map_or_else(|| members.to_vec(), |origin| origin.as_ref().clone())
+}
 
 /// Reorder a source union's members into tsc's relation-iteration order for
 /// error elaboration.


### PR DESCRIPTION
When an assignability failure has a union source, `tsc` elaborates the nested `Type 'X' is not assignable to type 'Y'.` line with the **first written failing member**. tsz's union-source elaboration (`SubtypeChecker::explain_failure_inner`, `crates/tsz-solver/src/relations/subtype/explain.rs`) instead walked the interner's **canonical (allocation-identity) member order**, patched only for nullish-first and same-rank enums. For anonymous object members the canonical order can reverse source order whenever a member's shape was content-interned *before* the union was written, so the elaboration names the wrong constituent — even though the union **header** line (rendered from `display_union_origin`) already prints the correct source order.

## Structural rule
When a union-source assignability failure elaborates its first failing member, `tsc` walks members in source-declaration order (its relation walk sees allocation order, and it mints a fresh anonymous type per `TypeLiteral`, so allocation order == source order for those). tsz's canonical union member order is content-interning identity order, which is *not* declaration order once an equivalent shape was interned by an earlier, unrelated declaration. The fix bases the union-source elaboration walk (`explain_failure_inner`'s union-source arm) on the union's as-written `display_union_origin` — the same provenance the union header already renders from — when it is a pure reordering of the interned member set (same multiset, not a flatten/collapse such as a written duplicate anonymous object tsc keeps but tsz content-interns to one member), falling back to the interned order otherwise. This is layered *underneath* the existing nullish-first and enum-declaration-order passes (`crates/tsz-solver/src/relations/subtype/explain_union_order.rs`) rather than replacing them, since nullish members are pre-interned ahead of any user type in both compilers regardless of where they're written.

Factored the new base-order lookup into `union_elaboration_base_order` in `explain_union_order.rs` (display-only, no relation/identity/perf change) to keep `explain.rs` under its arch-guard line ratchet.

## Repro (issue #16965, measured on `main`, `--strict --target es2022 --module esnext`)

```ts
declare const preB: { b: number };
declare const preA: { a: string };
declare const v: { a: string } | { b: number };
const x: boolean = v;
```

| | rendered |
| --- | --- |
| `tsc` 7.0.2 | `Type '{ a: string; } \| { b: number; }' …` → `Type '{ a: string; }' is not assignable to type 'boolean'.` |
| tsz `main` (before) | same header → `Type '{ b: number; }' is not assignable to type 'boolean'.` ❌ |
| tsz (this PR) | same header → `Type '{ a: string; }' is not assignable to type 'boolean'.` ✅ |

The leading `preB`/`preA` declarations force `{ b: number }` to be interned before `{ a: string }`; tsz shares one `TypeId` per shape, so the canonical union order becomes `{ b }, { a }`, reversed from source.

## Scope

Display/diagnostic-parity only — no assignability outcome changes (each union member still fails identically; only which failing member is named in the nested elaboration line changes). Distinct from #16509's headline (`{ m: number } | { m: number }` → scalar collapse), which needs per-`TypeLiteral` identity (#14344).

Closes #16965.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test union_source_elaboration_constituent_tests`: 7/7 pass, including a new regression test reproducing the issue's exact repro (`object_union_names_first_source_order_constituent_when_interning_reverses_it`) and the existing enum/named-alias/anon-object cases (unaffected — the enum-declaration-order and nullish-first passes still apply on top of the new base-order lookup).
- `cargo test -p tsz-checker --lib union_source`: 34/34 pass, no regressions across the broader union-source display/elaboration suite (narrowing, optional-property, literal-target, parameter-mismatch chains, etc.).
- `cargo clippy --profile dist-fast --target-dir .target -p tsz-checker -p tsz-solver --lib -- -D warnings`: clean.
- `cargo fmt` / architecture guard (`scripts/arch/check-checker-boundaries.sh`): clean (pre-commit hook).
- Targeted conformance (`./scripts/conformance/conformance.sh run --filter union --workers 12`): 59/60 passed (98.3%). The one fingerprint-only mismatch (`unionPropertyOfProtectedAndIntersectionProperty.ts`, a `(Foo | Bar)['foo']` indexed-access TS2339 message, an unrelated display path this PR doesn't touch) reproduces **identically on the parent commit** (`e56c158`, verified in an isolated worktree) — pre-existing, not a regression from this change.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium

AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nuh4fhhiauqjDyRmFkmad7)_