### PR TITLE
fix(checker): super.method() preserves the base method's polymorphic `this` return (#16960)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1512,6 +1512,9 @@ path = "tests/ts2344_accessor_constraint.rs"
 name = "ts2340_super_accessor_tests"
 path = "tests/ts2340_super_accessor_tests.rs"
 [[test]]
+name = "super_polymorphic_this_return_16960_tests"
+path = "tests/super_polymorphic_this_return_16960_tests.rs"
+[[test]]
 name = "ts2344_infer_conditional_constraint"
 path = "tests/ts2344_infer_conditional_constraint.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state.rs
+++ b/crates/tsz-checker/src/state/state.rs
@@ -712,7 +712,16 @@ impl<'a> CheckerState<'a> {
         };
 
         if let Some(access) = self.ctx.arena.get_access_expr(node) {
-            if self.is_this_expression(access.expression)
+            // A `this.method()` or `super.method()` call binds the callee's
+            // polymorphic `this` return to the enclosing class's `this`. For
+            // `super` this must NOT fall through to the receiver-type branch
+            // below, whose target is `super`'s *base* instance type — that would
+            // collapse a base `() => this` down to `() => Base` (#16960). The
+            // polymorphic `this` sentinel keeps the return polymorphic so it
+            // resolves to the real receiver at each use site and threads through
+            // multi-level `super` chains without collapsing at each hop.
+            if (self.is_this_expression(access.expression)
+                || self.is_super_expression(access.expression))
                 && self.ctx.enclosing_class.is_some()
                 && !self.is_this_in_nested_function_inside_class(call_expression)
                 && !self.is_this_in_static_class_member(call_expression)

--- a/crates/tsz-checker/src/types/property_access_type/identifier_resolution.rs
+++ b/crates/tsz-checker/src/types/property_access_type/identifier_resolution.rs
@@ -853,7 +853,20 @@ impl<'a> CheckerState<'a> {
                 // sees the base signature as `(other: Animal) => boolean`
                 // instead of `(other: Dog) => boolean`, which diverges from tsc.
                 let this_substitution_target = if self.is_super_expression(access.expression) {
-                    self.current_this_type().unwrap_or(original_object_type)
+                    // For a `super` receiver the raw-recovery branch below rebinds
+                    // the base member's polymorphic `this` to *this* target. It must
+                    // be the enclosing (derived) class's polymorphic `this`, not a
+                    // *materialized* instance type off `this_type_stack`
+                    // (`current_this_type()`): during phase-2 method checking the
+                    // stack top is a *partial prescan* instance type, and for a
+                    // derived class that declares no own instance properties (only
+                    // deferred methods) that partial type collapses toward the base —
+                    // turning a base `() => this` into `() => Base` and drawing a
+                    // spurious TS2339/TS2322 (#16960). The polymorphic `this` sentinel
+                    // keeps the member's `this` polymorphic so it resolves to the
+                    // correct derived receiver at each use site via flow, and threads
+                    // unchanged through multi-level `super` chains.
+                    self.ctx.types.this_type()
                 } else if direct_class_this_receiver
                     || crate::query_boundaries::common::contains_this_type(
                         self.ctx.types,
@@ -897,10 +910,12 @@ impl<'a> CheckerState<'a> {
                     && self.type_is_compound_this_relative(this_substitution_target)
                 {
                     // Leave `prop_type` as the solver produced it.
-                } else if crate::query_boundaries::common::contains_this_type(
-                    self.ctx.types,
-                    prop_type,
-                ) && prop_type != this_substitution_target
+                } else if !self.is_super_expression(access.expression)
+                    && crate::query_boundaries::common::contains_this_type(
+                        self.ctx.types,
+                        prop_type,
+                    )
+                    && prop_type != this_substitution_target
                 {
                     prop_type = crate::query_boundaries::common::substitute_this_type(
                         self.ctx.types,
@@ -908,6 +923,16 @@ impl<'a> CheckerState<'a> {
                         this_substitution_target,
                     );
                 } else if !used_class_chain_method_type {
+                    // For a `super` receiver the property was resolved against the
+                    // *base* instance type, which eagerly binds the member's
+                    // polymorphic `this` to the base (`() => Base`). The
+                    // `contains_this_type` guard above is spuriously true here
+                    // (the base instance's own members mention `this`), so it would
+                    // otherwise take the branch above and rewrite only those inner
+                    // `this` occurrences, leaving the *return* pinned to `Base`.
+                    // Skipping to this raw-recovery branch re-resolves with `this`
+                    // deferred so the base member's `this` return is recovered and
+                    // rebound to the enclosing (derived) class's `this` (#16960).
                     // When a method returns `this` on an intersection member,
                     // the solver's object visitor eagerly binds `this` to the
                     // structural (flattened) object — so `contains_this_type`

--- a/crates/tsz-checker/tests/super_polymorphic_this_return_16960_tests.rs
+++ b/crates/tsz-checker/tests/super_polymorphic_this_return_16960_tests.rs
@@ -1,0 +1,226 @@
+//! Regression coverage for #16960: `super.method()` must preserve the base
+//! method's polymorphic `this` return, binding it to the *enclosing (derived)*
+//! class — exactly as a direct `this.method()` call would.
+//!
+//! Structural rule (matches `tsc`): when the receiver of a property access is
+//! the `super` keyword, a base member whose type mentions the polymorphic
+//! `this` (e.g. an inferred `() => this` return, or an explicit `: this`
+//! annotation) binds that `this` to the *current* class's `this`, not to the
+//! base class's own materialized instance type. The previous implementation
+//! substituted with `current_this_type()` — the top of `this_type_stack` — which
+//! during phase-2 method checking is a *partial prescan* instance type. For a
+//! derived class that declares no own instance properties (only methods, which
+//! are deferred), that partial type collapses toward the base, turning
+//! `() => this` into `() => Base` and drawing a spurious `TS2339`/`TS2322`.
+//!
+//! All expectations below are oracle-verified against `typescript@7.0.2`.
+
+use tsz_checker::test_utils::{check_source_code_messages, check_source_diagnostics};
+
+/// The distilled #16960 repro: `returnThis()` forwards `super.returnThis()`,
+/// whose base returns the inferred polymorphic `this`. `instance.returnThis()`
+/// must be the *derived* class, so a derived-only member resolves cleanly.
+#[test]
+fn super_call_forwarding_inferred_this_binds_to_derived() {
+    let source = r#"
+class SomeBaseClass {
+    returnThis() {
+        return this;
+    }
+}
+
+class SomeDerivedClass extends SomeBaseClass {
+    returnThis() {
+        return super.returnThis();
+    }
+    fn() {}
+}
+
+let instance = new SomeDerivedClass();
+instance.returnThis().fn();
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        diagnostics.is_empty(),
+        "expected clean (derived `this` carries `fn`); got: {:?}",
+        check_source_code_messages(source)
+    );
+}
+
+/// Negative control: a member that exists on *neither* class must still report
+/// TS2339 — the fix must not widen `super`'s result to `any`.
+#[test]
+fn super_call_forwarding_this_absent_member_still_errors() {
+    let source = r#"
+class SomeBaseClass {
+    returnThis() {
+        return this;
+    }
+}
+
+class SomeDerivedClass extends SomeBaseClass {
+    returnThis() {
+        return super.returnThis();
+    }
+    fn() {}
+}
+
+let instance = new SomeDerivedClass();
+instance.returnThis().nope();
+"#;
+    let codes: Vec<u32> = check_source_diagnostics(source)
+        .iter()
+        .map(|d| d.code)
+        .collect();
+    assert!(
+        codes.contains(&2339),
+        "expected TS2339 for a genuinely-absent member; got: {:?}",
+        check_source_code_messages(source)
+    );
+}
+
+/// Base method returns `this` via an *explicit* `: this` annotation (not
+/// inference). The same super-substitution must apply.
+#[test]
+fn super_call_explicit_this_annotation_binds_to_derived() {
+    let source = r#"
+class Base {
+    self(): this {
+        return this;
+    }
+}
+
+class Derived extends Base {
+    self(): this {
+        return super.self();
+    }
+    fn() {}
+}
+
+let d = new Derived();
+d.self().fn();
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        diagnostics.is_empty(),
+        "explicit `: this` annotation must bind to derived; got: {:?}",
+        check_source_code_messages(source)
+    );
+}
+
+/// Multi-level inheritance: `C.m()` calls `super.m()` (B's), which itself calls
+/// `super.m()` (A's). `this` must thread through as the *original* receiver
+/// (`C`), not collapse at each hop.
+#[test]
+fn super_call_multi_level_threads_original_receiver() {
+    let source = r#"
+class A {
+    m() {
+        return this;
+    }
+}
+class B extends A {
+    m() {
+        return super.m();
+    }
+}
+class C extends B {
+    m() {
+        return super.m();
+    }
+    fn() {}
+}
+
+let c = new C();
+c.m().fn();
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        diagnostics.is_empty(),
+        "multi-level super chain must thread `this` to the original receiver; got: {:?}",
+        check_source_code_messages(source)
+    );
+}
+
+/// A base method whose return does NOT involve `this` must be unaffected: the
+/// `super` call keeps the base's declared (non-`this`) return type.
+#[test]
+fn super_call_non_this_return_is_unaffected() {
+    let source = r#"
+class Base {
+    make(): Base {
+        return this;
+    }
+}
+class Derived extends Base {
+    make(): Base {
+        return super.make();
+    }
+    fn() {}
+}
+
+let d = new Derived();
+d.make().fn();
+"#;
+    // `make()` is annotated `: Base`, so the result is `Base`, which has no
+    // `fn` — TS2339 in both tsc and tsz. The fix must not "helpfully" upgrade a
+    // non-`this` return to the derived class.
+    let codes: Vec<u32> = check_source_diagnostics(source)
+        .iter()
+        .map(|d| d.code)
+        .collect();
+    assert!(
+        codes.contains(&2339),
+        "a non-`this` annotated return must stay `Base`; got: {:?}",
+        check_source_code_messages(source)
+    );
+}
+
+/// Regression guard: a direct instance call (no `super`) of a `this`-returning
+/// method already resolved to the derived class and must keep doing so.
+#[test]
+fn direct_instance_call_this_return_still_binds_to_receiver() {
+    let source = r#"
+class Base {
+    returnThis() {
+        return this;
+    }
+}
+class Derived extends Base {
+    fn() {}
+}
+
+let d = new Derived();
+d.returnThis().fn();
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        diagnostics.is_empty(),
+        "direct instance `this`-return must bind to the receiver; got: {:?}",
+        check_source_code_messages(source)
+    );
+}
+
+/// The `super`-substitution must not break `this`-typed *parameters* in the
+/// override-forwarding shape (the case the original `super` special-case was
+/// written for): `super.accept(this)` where the parameter is `this`. Kept
+/// lib-free (no `Array`) so the check exercises only the `this`-binding path.
+#[test]
+fn super_call_this_param_override_forwarding_is_clean() {
+    let source = r#"
+class Base {
+    accept(other: this): void {}
+}
+class Derived extends Base {
+    accept(other: this): void {
+        super.accept(this);
+    }
+}
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        diagnostics.is_empty(),
+        "`super.accept(this)` with a `this` parameter must stay clean; got: {:?}",
+        check_source_code_messages(source)
+    );
+}


### PR DESCRIPTION
Fixes #16960.

**Structural rule:** When a base method's declared type mentions the polymorphic `this` (an inferred `() => this` or an explicit `: this` annotation) and it is called through `super`, `tsc` binds that `this` to the enclosing (derived) class's `this`, exactly as a direct `this.method()` call would — `super.returnThis()` inside a derived class returns the *derived* `this`. tsz collapsed it to the base, drawing a spurious `TS2339`/`TS2322`, through the **checker** property-access + call-return `this`-substitution layer.

## Root cause (two compounding checker frames)

Localized with tracing on the distilled repro (`() => Base` at both the property-access and call frames):

1. **Property resolution** (`resolve_identifier_property_access_inner`): a `super` receiver resolves the member against the *base* instance type, which eagerly binds the member's `this` to the base (`() => Base`). The existing `this`-substitution branch only fired when `contains_this_type(prop_type)` held — spuriously true here, because the base instance's *own* members mention `this` — so it rewrote only those inner occurrences and left the return pinned to `Base`. Super now skips that branch and takes the raw-recovery path (`resolve_property_access_raw_this`, `this`-binding deferred), rebinding the base member's `this` return to the enclosing class's polymorphic `this` sentinel.
2. **Call-return substitution** (`apply_this_substitution_to_call_return`): a `this` receiver was special-cased (target = polymorphic `this`) but a `super` receiver fell through to the receiver-type branch, whose target is `super`'s base instance — re-collapsing `() => this` to `() => Base`. The `this` and `super` branches now share the polymorphic-`this` target.

This is why the two prior investigations (which each tried a single site — call-time only, or property-access only) measured their fix as inert: the two frames compose, and both are required. No solver relation/identity/emit change.

## Adjacent matrix (oracle-verified vs `typescript@7.0.2`)

New suite `super_polymorphic_this_return_16960_tests` (7 tests):

| case | expected |
| --- | --- |
| `super.m()` forwarding an inferred `() => this` | derived `this` (clean) |
| explicit `: this` annotation on the base method | derived `this` (clean) |
| multi-level `A → B → C` super chain | threads to original receiver `C` |
| base method with a non-`this` return | unaffected (`Base`, TS2339) |
| direct instance call (no super) regression guard | still binds receiver |
| `super.accept(this)` with a `this` parameter | stays clean |
| genuinely-absent member | still TS2339 (no widening to `any`) |

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test super_polymorphic_this_return_16960_tests` → 7/7 (red on `main`: 3 core cases fail with `Base`-named TS2339/TS2322).
- No regressions across the super/`this`/mixin/polymorphic-`this` integration suites: `this_array_field_method_call_tests` (11), `this_array_field_method_param_14512_tests` (7), `ts2340_super_accessor_tests` (9), `this_type_tests` (32), `super_keyword_speculation_survival_tests` (23), `ts2513_abstract_super_access_tests` (10), `ts2855_static_super_field_tests` (3), `conditional_infer_polymorphic_this_tests` (7), `decorator_this_binding_tests` (16), `instance_type_this_member_class_tests` (7) — all green.
- `cargo clippy -p tsz-checker --all-targets` clean; pre-commit architecture guard passed (files under the 2000-line cap).
- Full `cargo test -p tsz-checker --lib` running as a broad safety net; result will be reported in a comment.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_019KcuvrdEvmoqSpfPwiTDz2)_