### PR TITLE
fix(solver): rank union-source elaboration through the display comparator

### DIFF
--- a/crates/tsz-checker/tests/union_source_elaboration_constituent_tests.rs
+++ b/crates/tsz-checker/tests/union_source_elaboration_constituent_tests.rs
@@ -209,6 +209,17 @@ const x: number = v;
     );
 }
 
+// Named-type-vs-inline-anonymous ranking (`{ z: string } | I` / `… | K` with a
+// class declared later, where tsc ranks the named `I`/`K` first — regression
+// #16980) is a re-ranking of `Lazy` interface/class members by their declaration
+// span, which `order_union_members_for_display` performs from the full compiler's
+// definition store. The in-process `check_source_strict` harness does not
+// populate that span for `Lazy` interface/class members (only enums and inline
+// anonymous objects resolve here), so those cases cannot be reproduced through
+// this entry point; they are covered by the CLI oracle matrix in PR #16977 and by
+// the conformance corpus. The anonymous-object and enum cases below exercise the
+// same display-comparator ordering path that the fix routes through.
+
 #[test]
 fn named_type_alias_union_members_keep_their_names() {
     // Named references carry an `aliasSymbol`, so they must keep their names —

--- a/crates/tsz-checker/tests/union_source_enum_elaboration_order_tests.rs
+++ b/crates/tsz-checker/tests/union_source_enum_elaboration_order_tests.rs
@@ -13,11 +13,13 @@
 //! position. Elaboration selection that walks the interned list directly can
 //! therefore name the wrong enum entirely, not just the wrong order.
 //!
-//! Structural rule: `SubtypeChecker::reorder_enum_members_by_declaration`
-//! (`crates/tsz-solver/src/relations/subtype/explain.rs`) reorders only the
-//! enum-typed slots of a union-source elaboration list into declaration order
-//! before the first-failing-member scan, leaving every other member's slot —
-//! and the existing nullish-first order — untouched.
+//! Structural rule: the union-source elaboration arm
+//! (`crates/tsz-solver/src/relations/subtype/explain.rs`) ranks its member list
+//! through the shared display comparator (`order_union_members_for_display`)
+//! before the first-failing-member scan. Same-rank enum members break the tie on
+//! their declaration span, so the scan sees them in declaration order — the same
+//! order the union header renders — leaving every other member's slot and the
+//! nullish-first hoist untouched.
 //!
 //! Regression guard for #16513.
 

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -6,6 +6,7 @@
 
 use crate::def::resolver::TypeResolver;
 use crate::diagnostics::SubtypeFailureReason;
+use crate::diagnostics::format::TypeFormatter;
 use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
 use crate::relations::subtype::SubtypeChecker;
 use crate::relations::subtype::explain_guard::{ExplainFuelState, ExplainRecursionEntryState};
@@ -1202,37 +1203,39 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             };
         if let Some(member_list) = union_member_list {
             let members = self.interner.type_list(member_list);
-            // Base the walk on the union's as-written source order when the
-            // interner recorded one (`get_union_origin`) and it is a pure
-            // reordering of the interned members. tsz's canonical member order
-            // is by `ShapeId`/allocation identity, which can reverse source
-            // order for anonymous object members (#16965); the header already
-            // renders source order from the same side table, so the nested
-            // elaboration must agree. A flatten/collapse origin (a different
-            // member set) is rejected and the interned order is kept — see
-            // `union_source_elaboration_origin_override`.
+            // Name the same first failing member tsc drills beneath the union
+            // line by walking the members in the union *header*'s order. tsc's
+            // relation walk and its `typeToString` iterate one type-id-sorted
+            // array, so header and nested always agree; tsz keeps two orders —
+            // the interner's canonicalization order (`sort_union_members`,
+            // allocation identity) and the header's display order
+            // (`order_union_members_by_source`) — so the walk must be ranked
+            // through the display comparator to match. Feed the comparator the
+            // union's as-written source order when the interner recorded one
+            // (`union_source_elaboration_origin_override`, a pure reordering of
+            // the interned members that fixes anonymous-object source order,
+            // #16965); the comparator then floats named/higher-rank members
+            // ahead of inline anonymous objects exactly as the header does
+            // (`{ z: string } | K` elaborates `K`, not the object — #16980).
             let origin_override =
                 self.union_source_elaboration_origin_override(union_member_source, &members);
-            let base = origin_override.as_deref().unwrap_or(&members);
-            // Pick the first failing member in tsc's *relation* order (nullish
-            // first), not tsz's stored *printer* order (nullish last) — see
-            // `reorder_union_members_nullish_first`. Example: `number | undefined`
-            // -> `string` drills the `undefined` member, matching tsc.
-            let mut ordered = reorder_union_members_nullish_first(base);
-            // Same-rank enum members: `sort_union_members` orders the interned
-            // list by allocation identity (needed so `E1 | E2` and `E2 | E1`
-            // intern to one canonical `TypeId`), which does not track
-            // declaration order — an enum's `DefId`/`TypeId` can be allocated
-            // lazily, in whatever order the checker first requests its type,
-            // independent of source position (issue #16513). tsc always
-            // elaborates the union's first-declared failing member, and the
-            // printer's own tie-break already keeps enum members in
-            // declaration order (`order_union_members_by_source`). Reorder
-            // just the enum members among themselves — by declaration
-            // position, in place, leaving every other member's slot and the
-            // rest of the nullish-first order untouched — so elaboration
-            // selection agrees with what the union header already displays.
-            self.reorder_enum_members_by_declaration(&mut ordered);
+            let base = origin_override.unwrap_or_else(|| members.to_vec());
+            let display_ordered = match self
+                .query_db
+                .and_then(|db| db.definition_store_for_inference())
+            {
+                Some(def_store) => TypeFormatter::new(self.interner)
+                    .with_def_store(def_store)
+                    .order_union_members_for_display(base),
+                None => base,
+            };
+            // tsc's *relation* walk visits the nullish intrinsics first (smallest
+            // type ids) even though the header shows them last, so hoist them
+            // ahead of the display order — see `reorder_union_members_nullish_first`.
+            // Same-rank enum members are already in declaration order: the
+            // display comparator breaks their tie on the declaration span
+            // (#16513) and the nullish hoist preserves their relative order.
+            let ordered = reorder_union_members_nullish_first(&display_ordered);
             for &member in ordered.iter() {
                 if member == source || member == union_member_source {
                     // Defensive: avoid self-recursion on a degenerate union.

--- a/crates/tsz-solver/src/relations/subtype/explain_union_order.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain_union_order.rs
@@ -5,25 +5,28 @@
 //! pick the same "first failing member" `tsc` elaborates beneath the
 //! union-to-target line. The interner's own stored member order is a
 //! *canonicalization* order (needed so `A | B` and `B | A` intern to one
-//! `TypeId`), not the source-declaration order — these two reorders bridge
-//! that gap without touching the interned identity itself.
+//! `TypeId`), not the display/source-declaration order. The arm reconciles the
+//! two by ranking the members through the display comparator
+//! (`order_union_members_for_display`), seeded with the as-written source order
+//! from [`SubtypeChecker::union_source_elaboration_origin_override`] when the
+//! interner recorded one, and then applying [`reorder_union_members_nullish_first`]
+//! on top — `tsc`'s relation walk visits the nullish intrinsics first even
+//! though the display shows them last.
 
 use crate::def::resolver::TypeResolver;
 use crate::relations::subtype::SubtypeChecker;
 use crate::types::TypeId;
 
-/// Reorder a source union's members into tsc's relation-iteration order for
-/// error elaboration.
+/// Hoist the nullish intrinsics to the front of an elaboration member list.
 ///
 /// `eachTypeRelatedToType` walks `source.types` in ascending type-id order, and
 /// the intrinsic `undefined` and `null` types are allocated before any user
 /// type — so tsc examines them first and elaborates a failing nullish member
-/// ahead of the others. tsz stores union members with `undefined`/`null` last
-/// (that is tsc's *printer* order, keyed by `builtin_sort_key`), so this
-/// restores the relation order used to pick the first failing member:
-/// `undefined`, then `null`, then the remaining members unchanged. Non-nullish
-/// unions keep their stored order, which matches tsc's relation order except
-/// for same-rank enum members — see [`SubtypeChecker::reorder_enum_members_by_declaration`].
+/// ahead of the others. The display order the arm ranks members into
+/// (`order_union_members_for_display`) instead places `undefined`/`null` last
+/// (tsc's *printer* order), so this restores the relation order used to pick the
+/// first failing member: `undefined`, then `null`, then the remaining members in
+/// the order they were given.
 pub(super) fn reorder_union_members_nullish_first(members: &[TypeId]) -> Vec<TypeId> {
     let mut ordered = Vec::with_capacity(members.len());
     // `undefined` before `null` (their intrinsic allocation order), then the
@@ -96,58 +99,5 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             .get_union_origin(union_type_id)
             .filter(|origin| is_pure_permutation(origin.as_ref(), interned_members))
             .map(|origin| origin.as_ref().clone())
-    }
-
-    /// Reorder same-rank enum members of a union-source elaboration list into
-    /// declaration order, in place.
-    ///
-    /// `sort_union_members` (the interner's canonicalization pass) orders a
-    /// union's stored member list by allocation identity so that `E1 | E2`
-    /// and `E2 | E1` intern to one canonical `TypeId` — a `DefId`/`TypeId` is
-    /// allocated lazily, in whatever order the checker first requests an
-    /// enum's type, which does not track source position. `tsc` always
-    /// elaborates the union's first-*declared* failing member, and the
-    /// printer's own tie-break for same-rank union members keeps enum
-    /// members in declaration order (`order_union_members_by_source`'s
-    /// `compare_union_member_names` exception for enums). Without this, the
-    /// elaboration line can name the wrong enum entirely — not just the wrong
-    /// order, but a sibling enum with an unrelated declaration (#16513).
-    ///
-    /// Only the slots already holding an enum member are touched: their
-    /// values are reassigned by ascending `(file_id, span_start)`, leaving
-    /// every other member's position — and the nullish-first order already
-    /// applied — untouched. A union with 0 or 1 enum members is a no-op.
-    pub(in crate::relations::subtype) fn reorder_enum_members_by_declaration(
-        &self,
-        members: &mut [TypeId],
-    ) {
-        let Some(def_store) = self
-            .query_db
-            .and_then(|db| db.definition_store_for_inference())
-        else {
-            return;
-        };
-        let mut enum_slots: Vec<usize> = Vec::new();
-        let mut keyed: Vec<((u32, u32), TypeId)> = Vec::new();
-        for (idx, &member) in members.iter().enumerate() {
-            let Some(def_id) = crate::type_queries::get_enum_def_id(self.interner, member) else {
-                continue;
-            };
-            let Some(def) = def_store.get(def_id) else {
-                continue;
-            };
-            let (Some(file_id), Some((span_start, _))) = (def.file_id, def.span) else {
-                continue;
-            };
-            enum_slots.push(idx);
-            keyed.push(((file_id, span_start), member));
-        }
-        if keyed.len() < 2 {
-            return;
-        }
-        keyed.sort_by_key(|&(pos, _)| pos);
-        for (&idx, &(_, member)) in enum_slots.iter().zip(keyed.iter()) {
-            members[idx] = member;
-        }
     }
 }


### PR DESCRIPTION
Fixes #16980. Refs #16965, #16972.

#16972 (which fixed the original #16965) based the union-source failure elaboration on the **raw as-written `union_origin` order**. tsc instead elaborates the member its **display** lists first (`typeToString` order), which ranks named / higher-rank members ahead of inline anonymous objects — not raw source order. So #16972 fixed the two-anonymous-object reorder case but **regressed** named-vs-anonymous unions that were correct before it, and still missed one it aimed at.

| case | source (relevant line) | tsc | pre-#16972 | main (#16972) | this PR |
| --- | --- | --- | --- | --- | --- |
| `{ a: string } \| { b: number }` after `preB: {b}` | anon reorder | `{ a: string; }` | ❌ | ✅ | ✅ |
| `{ z: string } \| I` (`interface I`) | named vs anon | `I` | ✅ | ❌ regressed | ✅ |
| `{ z: string } \| K` (`declare class K` later) | named interned late | `K` | ❌ | ❌ | ✅ |
| `pre: I; { z: string } \| I` | named vs anon | `I` | ✅ | ❌ regressed | ✅ |
| `E1 \| E2` | enum decl order | `E1` | ✅ | ✅ | ✅ |

The conformance code-set comparison is blind to message text, so #16972's regression shipped without a snapshot delta. In every regressed row the union **header** already renders tsc's order (`I | { z: string; }`); only the nested `Type 'X' is not assignable…` line disagreed.

**Structural rule:** when a union source fails a relation, tsc elaborates the member its display lists first — `order_union_members_by_source` order (named/higher-rank before anonymous, anonymous in source order, nullish hoisted ahead for the relation walk). The union-source arm in `crates/tsz-solver/src/relations/subtype/explain.rs` now ranks its member list through that shared display comparator (`order_union_members_for_display`), seeded with the as-written source order from #16972's `union_source_elaboration_origin_override` (kept, so anonymous members still get source order), then hoists the nullish intrinsics. This subsumes the separate `reorder_enum_members_by_declaration` special case, which is removed.

Display/diagnostic-only: no diagnostic **code** changes.

## Goal
Goal: hold

## Verification
- CLI oracle matrix — 13 cases (anonymous reorder, class, interface, enum, named-interned-after-anon, nullish) all match `tsc@7.0.2 --strict --target es2022 --module esnext`, including every regressed row above.
- Unit suites green: `union_source_elaboration_constituent_tests` (9), `union_source_enum_elaboration_order_tests` (5), `union_source_structural_elaboration_tests` (22), `union_source_missing_property_elaboration_tests` (5), `union_origin_display_tests` (5). The named-type re-ranking is verified via the CLI/conformance path — `check_source_strict` does not populate declaration spans for `Lazy` interface/class members, so those specific rows are not unit-testable through that harness; the enum and anonymous-object cases (which are) exercise the same comparator path.
- Conformance snapshot (`conformance.sh snapshot --workers 12 --force`) on the reconciled branch: 11557 pass / 486 fail at base `3aa24aa` — display/message-text change only, no diagnostic-code deltas.
- `cargo clippy -p tsz-solver -p tsz-checker --all-targets` clean; `arch_guard.py` + `arch_guard_file_limits.py` pass (`explain.rs` 2020 ≤ 2026 cap).
- Emit unaffected by construction (no emit-path code touched; diagnostic message text only).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high