### PR TITLE
fix(checker): property-assignment function-expression `this` is contextual, not implicit `any` (#16964)

### DIFF
--- a/crates/tsz-checker/src/dispatch/this.rs
+++ b/crates/tsz-checker/src/dispatch/this.rs
@@ -201,12 +201,19 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                     return self.checker.apply_flow_narrowing(idx, this_type);
                 }
                 TypeId::ANY
+            } else if let Some(base_this_type) = self
+                .checker
+                .enclosing_function_assignment_rhs_this_type(idx)
+            {
+                // The function expression is the direct RHS of a property/
+                // element-access assignment (`x.y = function () {...}`):
+                // `this` is contextually the type of the assignment's base
+                // object expression `x`, not implicit `any` (#16964).
+                self.checker.apply_flow_narrowing(idx, base_this_type)
             } else {
                 // Fall through to TS2683 / TS7041 checks below
-                // Suppress if the nested function has an explicit `this` parameter,
-                // a contextual `this` type from a parent type annotation, or is
-                // itself the direct RHS of an assignment (`x.y = function () {}`
-                // does not warn, even though `this` still resolves to `any` below).
+                // Suppress if the nested function has an explicit `this` parameter
+                // or a contextual `this` type from a parent type annotation.
                 if self.checker.ctx.no_implicit_this()
                     && !self
                         .checker
@@ -214,7 +221,6 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                     && !self
                         .checker
                         .enclosing_function_has_contextual_this_type(idx)
-                    && !self.checker.enclosing_function_is_assignment_rhs(idx)
                 {
                     use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
                     self.checker.error_at_node(
@@ -243,30 +249,39 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
             // synthesizes a `this` for plain JS constructor functions, so a
             // top-level JS function's `this` is implicitly `any` here just like
             // in TS files — not only nested ones.
-            //
-            // The TYPE is `any` regardless of `noImplicitThis` (a plain
-            // function's `this` has no declared receiver either way); only
-            // the *warning* about that implicit `any` is gated by the flag.
-            // Suppress the warning if the enclosing function has an explicit
-            // `this` parameter, a contextual `this` type from a parent type
-            // annotation, or is itself the direct RHS of an assignment.
-            if self.checker.ctx.no_implicit_this()
-                && !self
-                    .checker
-                    .enclosing_function_has_explicit_this_parameter(idx)
-                && !self
-                    .checker
-                    .enclosing_function_has_contextual_this_type(idx)
-                && !self.checker.enclosing_function_is_assignment_rhs(idx)
+            if let Some(base_this_type) = self
+                .checker
+                .enclosing_function_assignment_rhs_this_type(idx)
             {
-                use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-                self.checker.error_at_node(
-                    idx,
-                    diagnostic_messages::THIS_IMPLICITLY_HAS_TYPE_ANY_BECAUSE_IT_DOES_NOT_HAVE_A_TYPE_ANNOTATION,
-                    diagnostic_codes::THIS_IMPLICITLY_HAS_TYPE_ANY_BECAUSE_IT_DOES_NOT_HAVE_A_TYPE_ANNOTATION,
-                );
+                // The function expression is the direct RHS of a property/
+                // element-access assignment (`x.y = function () {...}`):
+                // `this` is contextually the type of the assignment's base
+                // object expression `x`, not implicit `any` (#16964).
+                self.checker.apply_flow_narrowing(idx, base_this_type)
+            } else {
+                // The TYPE is `any` regardless of `noImplicitThis` (a plain
+                // function's `this` has no declared receiver either way); only
+                // the *warning* about that implicit `any` is gated by the flag.
+                // Suppress the warning if the enclosing function has an explicit
+                // `this` parameter or a contextual `this` type from a parent
+                // type annotation.
+                if self.checker.ctx.no_implicit_this()
+                    && !self
+                        .checker
+                        .enclosing_function_has_explicit_this_parameter(idx)
+                    && !self
+                        .checker
+                        .enclosing_function_has_contextual_this_type(idx)
+                {
+                    use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+                    self.checker.error_at_node(
+                        idx,
+                        diagnostic_messages::THIS_IMPLICITLY_HAS_TYPE_ANY_BECAUSE_IT_DOES_NOT_HAVE_A_TYPE_ANNOTATION,
+                        diagnostic_codes::THIS_IMPLICITLY_HAS_TYPE_ANY_BECAUSE_IT_DOES_NOT_HAVE_A_TYPE_ANNOTATION,
+                    );
+                }
+                TypeId::ANY
             }
-            TypeId::ANY
         } else if self.checker.is_js_file() {
             // JS-file top-level/arrow-inherited `this` behavior is
             // unaffected by this change; keep it exactly as before.

--- a/crates/tsz-checker/src/symbols/scope_finder.rs
+++ b/crates/tsz-checker/src/symbols/scope_finder.rs
@@ -322,43 +322,52 @@ impl<'a> CheckerState<'a> {
         true
     }
 
-    /// Whether the nearest enclosing non-arrow function *expression* is the
-    /// direct right-hand side of an assignment (`x.y = function () {}`,
-    /// optionally parenthesized), regardless of what `x.y`'s type is.
+    /// If the nearest enclosing non-arrow function *expression* is the direct
+    /// right-hand side of a property/element-access assignment
+    /// (`x.y = function () {}`, `x[y] = function () {}`, optionally
+    /// parenthesized), returns the contextual `this` type tsc gives the
+    /// function body: the type of the assignment's base object expression
+    /// (`x`), evaluated at the assignment site.
     ///
-    /// This is a purely syntactic assignment-target check: tsc does not warn
-    /// about the resulting implicit-`any` `this` in that position (see
-    /// `property_assignment_any_receiver_no_ts2683`), but assignment position
-    /// alone does not establish a contextual `this` TYPE — a real contextual
-    /// receiver still requires `enclosing_function_has_contextual_this_type`
-    /// (e.g. the target actually carries a `this`-parameterized signature).
-    /// Callers must use this only to gate the TS2683 diagnostic, never to
-    /// decide whether the function has its own `this` binding — conflating
-    /// the two previously caused a nested `this.` (e.g.
+    /// A bare-identifier reassignment (`f = function () {}`, no base object)
+    /// is not a property-assignment RHS and returns `None` — tsc still
+    /// reports plain implicit-any TS2683 for that shape, matching an
+    /// unassigned function expression (#16964).
+    ///
+    /// tsc's rule is `this` = the type of the LHS's *base object* expression,
+    /// not the assigned property's own declared type: an `any`-typed base
+    /// still yields `this: any` (`property_assignment_any_receiver_no_ts2683`
+    /// — an `any` base makes this function return `Some(TypeId::ANY)`, which
+    /// is why that test sees no TS2683 either — the type is `any` because the
+    /// contextual receiver genuinely is, not because the diagnostic was
+    /// blanket-suppressed), and a nominally-typed base missing the accessed
+    /// member reports TS2339 against that base type rather than staying
+    /// silent.
+    ///
+    /// Callers must use the returned type as the function's actual `this`
+    /// type, never merely to decide whether the function has its own `this`
+    /// binding — conflating the two previously caused a nested `this.` (e.g.
     /// `obj.onload = function () { this. }` inside a class method) to
     /// silently resolve to the *enclosing class's* instance type instead of
-    /// `any`.
-    pub(crate) fn enclosing_function_is_assignment_rhs(&self, idx: NodeIndex) -> bool {
-        use tsz_parser::parser::syntax_kind_ext::FUNCTION_EXPRESSION;
+    /// the assignment's contextual type.
+    pub(crate) fn enclosing_function_assignment_rhs_this_type(
+        &mut self,
+        idx: NodeIndex,
+    ) -> Option<TypeId> {
+        use tsz_parser::parser::syntax_kind_ext::{
+            ELEMENT_ACCESS_EXPRESSION, FUNCTION_EXPRESSION, PROPERTY_ACCESS_EXPRESSION,
+        };
 
-        let Some(enclosing_fn) = self.find_enclosing_non_arrow_function(idx) else {
-            return false;
-        };
-        let Some(fn_node) = self.ctx.arena.get(enclosing_fn) else {
-            return false;
-        };
+        let enclosing_fn = self.find_enclosing_non_arrow_function(idx)?;
+        let fn_node = self.ctx.arena.get(enclosing_fn)?;
         if fn_node.kind != FUNCTION_EXPRESSION {
-            return false;
+            return None;
         }
 
         let mut current = enclosing_fn;
         for _ in 0..3 {
-            let Some(parent) = self.ctx.arena.parent_of(current) else {
-                break;
-            };
-            let Some(parent_node) = self.ctx.arena.get(parent) else {
-                break;
-            };
+            let parent = self.ctx.arena.parent_of(current)?;
+            let parent_node = self.ctx.arena.get(parent)?;
             if parent_node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION {
                 current = parent;
                 continue;
@@ -368,11 +377,18 @@ impl<'a> CheckerState<'a> {
                 && binary.right == current
                 && self.is_assignment_operator(binary.operator_token)
             {
-                return true;
+                let lhs_node = self.ctx.arena.get(binary.left)?;
+                if lhs_node.kind != PROPERTY_ACCESS_EXPRESSION
+                    && lhs_node.kind != ELEMENT_ACCESS_EXPRESSION
+                {
+                    return None;
+                }
+                let base_expr_idx = self.ctx.arena.get_access_expr(lhs_node)?.expression;
+                return Some(self.get_type_of_node(base_expr_idx));
             }
             break;
         }
-        false
+        None
     }
 
     /// Find the nearest enclosing class declaration/expression by walking parents.

--- a/crates/tsz-checker/tests/ts2683_tests.rs
+++ b/crates/tsz-checker/tests/ts2683_tests.rs
@@ -525,3 +525,114 @@ function outer() {
         "Expected nested function inside class inside function to emit TS2683, got: {diags:?}"
     );
 }
+
+// #16964: a function expression assigned as the RHS of a property/element
+// write gets a contextual `this` from the assignment's base object
+// expression — matching tsc — instead of being silently `any`.
+
+#[test]
+fn property_assignment_this_is_base_object_type_ts2339() {
+    // `this` inside the assigned function is the *base object's* type
+    // (`{}`, the type of `o`), not `any` — so an absent member access
+    // reports TS2339 against that base type instead of staying silent.
+    let src = r#"
+const o = {};
+o.m = function () {
+    this.q = 1;
+};
+"#;
+    let diags = get_diagnostics(src);
+    assert!(
+        diags.iter().any(|d| d.0 == 2339),
+        "Expected TS2339 for a missing member on the base object's type, got: {diags:?}"
+    );
+    assert!(
+        !diags.iter().any(|d| d.0 == 2683),
+        "This is a resolved contextual `this`, not implicit `any` — TS2683 must not fire, got: {diags:?}"
+    );
+}
+
+#[test]
+fn property_assignment_this_is_nominal_base_type_ts2339() {
+    // Same rule against a nominally-typed base: `this` = `Foo`, and `Foo`
+    // does not declare `q`, so TS2339 fires against `Foo` — not `bar`'s own
+    // (irrelevant) declared type.
+    let src = r#"
+interface Foo {
+    bar: any;
+}
+declare const foo: Foo;
+foo.bar = function () {
+    this.q = 1;
+};
+"#;
+    let diags = get_diagnostics(src);
+    assert!(
+        diags.iter().any(|d| d.0 == 2339),
+        "Expected TS2339 against the base object's declared type, got: {diags:?}"
+    );
+    assert!(
+        !diags.iter().any(|d| d.0 == 2683),
+        "Contextual `this` resolved from the base object — TS2683 must not fire, got: {diags:?}"
+    );
+}
+
+#[test]
+fn property_assignment_this_member_present_on_base_type_no_error() {
+    // Adjacent positive case: the base object's type already declares the
+    // member `this` accesses, so neither TS2339 nor TS2683 fires.
+    let src = r#"
+interface Foo {
+    bar: any;
+    q: number;
+}
+declare const foo: Foo;
+foo.bar = function () {
+    this.q = 1;
+};
+"#;
+    let diags = get_diagnostics(src);
+    assert!(
+        diags.is_empty(),
+        "Expected a clean check when the base type already declares the accessed member, got: {diags:?}"
+    );
+}
+
+#[test]
+fn property_assignment_this_element_access_base_no_error() {
+    // Same rule via an element-access assignment target (`x[y] = function`),
+    // not just dotted property access.
+    let src = r#"
+interface Foo {
+    q: number;
+}
+declare const foo: Foo;
+declare const key: string;
+(foo as any)[key] = function () {
+    this.q = 1;
+};
+"#;
+    let diags = get_diagnostics(src);
+    assert!(
+        diags.is_empty(),
+        "Expected a clean check for an `any`-typed element-access base, got: {diags:?}"
+    );
+}
+
+#[test]
+fn bare_identifier_reassignment_still_emits_ts2683() {
+    // A bare-identifier reassignment (`f = function () {...}`, no base
+    // object) is NOT a property-assignment RHS: tsc still reports plain
+    // implicit-any TS2683, matching an unassigned function expression.
+    let src = r#"
+let f: () => void;
+f = function () {
+    this.q = 1;
+};
+"#;
+    let diags = get_diagnostics(src);
+    assert!(
+        diags.iter().any(|d| d.0 == 2683),
+        "Expected TS2683 for a bare-identifier reassignment (no base object), got: {diags:?}"
+    );
+}


### PR DESCRIPTION
Fixes mechanism 1 of #16964.

`this` inside a function expression assigned as the RHS of a property or element write (`o.m = function () {...}`, `foo.bar = function () {...}`) was silently `any` in tsz: `enclosing_function_is_assignment_rhs` unconditionally suppressed TS2683 for any assignment RHS and the dispatcher always returned `TypeId::ANY` for that position, so every diagnostic tsc reports on such a `this` was dropped — a false negative.

**Structural rule:** when a function expression is the direct RHS of a property/element-access assignment, tsc gives its `this` the type of the assignment's *base object* expression (`o`, `foo`), not the assigned property's own declared type. An `any`-typed base still yields `this: any` (consistent with the existing `property_assignment_any_receiver_no_ts2683` test — the type genuinely is `any`, not a blanket-suppressed diagnostic), and a nominally-typed base missing the accessed member reports TS2339 against that base type. A bare-identifier reassignment (`f = function () {...}`, no base object) is not a property-assignment RHS and keeps plain implicit-any TS2683, matching an unassigned function expression.

**Owner layer:** checker contextual-`this` resolution. `enclosing_function_is_assignment_rhs` (`crates/tsz-checker/src/symbols/scope_finder.rs`) is replaced by `enclosing_function_assignment_rhs_this_type`, which walks the same assignment-RHS shape but additionally requires the LHS to be a property/element access and returns the computed type of its base expression. `dispatch/this.rs`'s two `this`-with-no-owner branches (nested function inside a class, and top-level) use that type via `apply_flow_narrowing` instead of hard-coding `TypeId::ANY`, and only fall back to the old TS2683-suppression checks (explicit `this` parameter, contextual `this` type) when there is no property-assignment base.

Mechanism 2 from #16964 (CommonJS `exports.X = ...`/`module.exports.X = ...` as a named-export binder classification) is separate, larger scope and not attempted here — see ClaudeDE's NOTE on #16964 for why it needs distinct binder machinery.

**Adjacent matrix** (new tests in `ts2683_tests.rs`, values cross-checked against ClaudeDE's oracle-verified matrix on #16964):

| case | tsc / tsz after |
| --- | --- |
| `const o = {}; o.m = function(){ this.q=1 }` | TS2339 against `{}` |
| `foo.bar = function(){ this.q=1 }`, `Foo` missing `q` | TS2339 against `Foo` |
| same, but `Foo` declares `q` | clean (no TS2339, no TS2683) |
| element-access assignment through an `any`-typed base | clean |
| `f = function(){ this.q=1 }` bare-identifier reassignment | TS2683 |
| `property_assignment_any_receiver_no_ts2683` (existing) | still clean |

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts2683_tests` — 34/34 passed (5 new).
- `cargo test -p tsz-checker --lib this` (full `this`-related sweep across the lib test suite) — 385/385 passed, 0 regressions.
- `cargo test -p tsz-checker --lib expando` and `--lib property_assignment` (adjacent JS-expando/constructor-property families) — 43/43 and 33/33 passed, 0 regressions.
- `cargo clippy -p tsz-checker --lib -- -D warnings` clean.
- `cargo fmt -p tsz-checker -- --check` clean.
- Pre-commit hook (clippy + architecture guard + local verification) passed.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_013tfJ8aM6epECsm368GV8k2)_