### PR TITLE
fix(checker): well-known symbol element-access reads follow const-alias chains

### DIFF
--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -1264,31 +1264,30 @@ impl<'a> CheckerState<'a> {
 
             // Fallback: well-known symbols (Symbol.hasInstance, Symbol.iterator, etc.)
             // are stored as "[Symbol.xxx]" in class/interface types, not "__unique_N".
-            // When the __unique_N lookup fails, try the [Symbol.xxx] format.
-            if result_type.is_none() {
-                let sym_id =
-                    crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id(sym_ref);
-                if let Some(symbol) = self.ctx.binder.get_symbol(sym_id) {
-                    let sym_name = &symbol.escaped_name;
-                    // Check if the parent is the Symbol global constructor
-                    if symbol.parent.is_some()
-                        && let Some(parent_sym) = self.ctx.binder.get_symbol(symbol.parent)
-                        && parent_sym.escaped_name == "Symbol"
-                    {
-                        let well_known_name = format!("[Symbol.{sym_name}]");
-                        let result =
-                            self.resolve_property_access_with_env(resolved_type, &well_known_name);
-                        if let PropertyAccessResult::Success {
-                            type_id,
-                            write_type,
-                            ..
-                        } = result
-                            && !union_member_missing_symbol
-                        {
-                            use_index_signature_check = false;
-                            result_type = Some(effective_write_result(type_id, write_type));
-                        }
-                    }
+            // When the __unique_N lookup fails, try the [Symbol.xxx] format, recovered
+            // from the solver's well-known-symbol registry (populated whenever a
+            // well-known-symbol-keyed member, e.g. `Array<T>`'s own
+            // `[Symbol.iterator]`, is constructed) rather than by reinterpreting
+            // `sym_ref` as a raw `SymbolId` — that ordinal is per-binder and a
+            // well-known symbol's identity is minted in whichever binder built the
+            // `SymbolConstructor` interface member (typically a lib file's, not the
+            // current file's), so reinterpreting it through the wrong binder can
+            // silently hit an unrelated symbol (#16961).
+            if result_type.is_none()
+                && let Some(well_known_name) =
+                    self.ctx.types.well_known_symbol_name_for_ref(sym_ref)
+            {
+                let well_known_name = well_known_name.to_string();
+                let result = self.resolve_property_access_with_env(resolved_type, &well_known_name);
+                if let PropertyAccessResult::Success {
+                    type_id,
+                    write_type,
+                    ..
+                } = result
+                    && !union_member_missing_symbol
+                {
+                    use_index_signature_check = false;
+                    result_type = Some(effective_write_result(type_id, write_type));
                 }
             }
 

--- a/crates/tsz-checker/src/types/computation/access_tests.rs
+++ b/crates/tsz-checker/src/types/computation/access_tests.rs
@@ -350,3 +350,156 @@ value["size"];
         "Expected TS2576 for inherited static field and accessor element access, got: {errors:?}"
     );
 }
+
+/// Element-access reads of a well-known symbol reached through a `const`
+/// alias must resolve identically to the literal `Symbol.<name>` spelling
+/// (#16961). These need the real `Array<T>`/`SymbolConstructor` lib shape
+/// (not a hand-stub), so they route through [`check_source_with_libs`] with
+/// [`load_default_lib_files`] and skip gracefully when the vendored
+/// TypeScript lib assets aren't present in this checkout, matching the
+/// established pattern for lib-dependent unit tests in this crate.
+mod well_known_symbol_element_access_through_alias_tests {
+    use crate::context::CheckerOptions;
+    use crate::test_utils::{check_source_with_libs, load_default_lib_files};
+
+    fn check_with_default_libs(source: &str) -> Option<Vec<crate::diagnostics::Diagnostic>> {
+        let libs = load_default_lib_files();
+        if libs.is_empty() {
+            return None;
+        }
+        Some(check_source_with_libs(
+            source,
+            "test.ts",
+            CheckerOptions::default(),
+            &libs,
+        ))
+    }
+
+    fn semantic_errors(diags: &[crate::diagnostics::Diagnostic]) -> Vec<u32> {
+        diags.iter().map(|d| d.code).collect()
+    }
+
+    /// A well-known symbol read directly off the literal `Symbol` identifier
+    /// is the baseline this whole family compares against.
+    #[test]
+    fn direct_symbol_iterator_access_is_clean() {
+        let Some(diags) = check_with_default_libs(
+            "export {};\ndeclare const a: unknown[];\na[Symbol.iterator];\n",
+        ) else {
+            return;
+        };
+        assert_eq!(
+            semantic_errors(&diags),
+            Vec::<u32>::new(),
+            "direct `Symbol.iterator` element access must stay clean: {diags:?}"
+        );
+    }
+
+    /// `const S = Symbol; a[S.iterator]` — one `const` alias indirection.
+    /// tsc resolves this identically to the direct form; tsz previously
+    /// false-positived TS7015 because the read fell through to a raw
+    /// `SymbolId` reinterpreted through the wrong binder (#16961).
+    #[test]
+    fn single_const_alias_iterator_access_is_clean() {
+        let Some(diags) = check_with_default_libs(
+            "export {};\ndeclare const a: unknown[];\nconst S = Symbol;\na[S.iterator];\n",
+        ) else {
+            return;
+        };
+        assert_eq!(
+            semantic_errors(&diags),
+            Vec::<u32>::new(),
+            "`const S = Symbol; a[S.iterator]` must stay clean like the direct form: {diags:?}"
+        );
+    }
+
+    /// Binder-name independence: the alias must work under an arbitrary
+    /// identifier, not just names that look related to `Symbol`.
+    #[test]
+    fn arbitrary_binder_name_alias_iterator_access_is_clean() {
+        let Some(diags) = check_with_default_libs(
+            "export {};\ndeclare const a: unknown[];\nconst zzTop = Symbol;\na[zzTop.iterator];\n",
+        ) else {
+            return;
+        };
+        assert_eq!(
+            semantic_errors(&diags),
+            Vec::<u32>::new(),
+            "an arbitrarily-named alias must resolve the well-known symbol just like `S`: {diags:?}"
+        );
+    }
+
+    /// `const S = globalThis.Symbol; a[S.iterator]` — alias through a
+    /// `globalThis.Symbol` property access initializer, not a bare identifier.
+    #[test]
+    fn globalthis_alias_iterator_access_is_clean() {
+        let Some(diags) = check_with_default_libs(
+            "export {};\ndeclare const a: unknown[];\nconst S = globalThis.Symbol;\na[S.iterator];\n",
+        ) else {
+            return;
+        };
+        assert_eq!(
+            semantic_errors(&diags),
+            Vec::<u32>::new(),
+            "`const S = globalThis.Symbol; a[S.iterator]` must stay clean: {diags:?}"
+        );
+    }
+
+    /// `const Symbol = globalThis.Symbol; a[Symbol.iterator]` — the local
+    /// binding shadows the global name `Symbol` but is itself an alias chain
+    /// back to the real global, so the read must still resolve.
+    #[test]
+    fn shadowed_symbol_name_aliased_to_global_iterator_access_is_clean() {
+        let Some(diags) = check_with_default_libs(
+            "export {};\ndeclare const a: unknown[];\nconst Symbol = globalThis.Symbol;\na[Symbol.iterator];\n",
+        ) else {
+            return;
+        };
+        assert_eq!(
+            semantic_errors(&diags),
+            Vec::<u32>::new(),
+            "a `Symbol`-shadowing alias of the real global must still resolve `.iterator`: {diags:?}"
+        );
+    }
+
+    /// `String.prototype` declares its own `[Symbol.iterator]` member (added
+    /// by `lib.es2015.iterable.d.ts`), so an aliased well-known-symbol read
+    /// against a `string` receiver resolves cleanly too — `tsc` reports no
+    /// diagnostic here (per the oracle in #16961); this same alias fix
+    /// recovers this receiver-independent case, which predates #16958 and
+    /// was out of that issue's scope but shares the exact mechanism.
+    #[test]
+    fn string_receiver_aliased_iterator_access_is_clean() {
+        let Some(diags) = check_with_default_libs(
+            "export {};\ndeclare const s: string;\nconst S = globalThis.Symbol;\ns[S.iterator];\n",
+        ) else {
+            return;
+        };
+        assert_eq!(
+            semantic_errors(&diags),
+            Vec::<u32>::new(),
+            "an aliased well-known symbol against `string` must resolve `String.prototype[Symbol.iterator]` \
+             cleanly, matching tsc: {diags:?}"
+        );
+    }
+
+    /// Declaration-time computed member NAMES must stay purely syntactic
+    /// (tsc's `isWellKnownSymbolSyntactically`, #16307): an alias-reached
+    /// `[S.iterator]` in a declaration position must NOT bind under the
+    /// canonical `[Symbol.iterator]` name, unlike the read-side fix above.
+    #[test]
+    fn aliased_computed_name_declaration_stays_syntactic_not_well_known() {
+        let Some(diags) = check_with_default_libs(
+            "export {};\nconst S = Symbol;\nclass C {\n  [S.iterator]() { return 1; }\n}\ndeclare const c: C;\nconst x: IterableIterator<number> = c[Symbol.iterator]();\n",
+        ) else {
+            return;
+        };
+        let errors = semantic_errors(&diags);
+        assert!(
+            errors.contains(&2322),
+            "an alias-reached computed member NAME must stay off the well-known `[Symbol.iterator]` \
+             slot (tsc's #16307 syntactic rule), so `c[Symbol.iterator]()` must not see the aliased \
+             declaration's `number` return type as an `IterableIterator<number>`: {errors:?}"
+        );
+    }
+}

--- a/crates/tsz-checker/src/types/computed_names.rs
+++ b/crates/tsz-checker/src/types/computed_names.rs
@@ -167,6 +167,123 @@ pub(crate) fn well_known_symbol_property_name(
     }
 }
 
+/// Does `expr_idx` denote the global `Symbol` constructor value, either
+/// directly (the unshadowed `Symbol` identifier) or through a `const` alias
+/// chain (`const S = Symbol;`, `const S = globalThis.Symbol;`)?
+///
+/// Unlike [`well_known_symbol_property_name`], which stays purely syntactic
+/// for computed-property-NAME declarations (tsc's own
+/// `isWellKnownSymbolSyntactically`, #16307), an element-access READ of
+/// `<expr>.wellKnownName` follows ordinary value identity in `tsc`: `S.iterator`
+/// types the same as `Symbol.iterator` regardless of how many `const` aliases
+/// separate `S` from the global. [`well_known_symbol_property_name_for_read`]
+/// is the read-side counterpart that uses this. #16961.
+fn expr_denotes_global_symbol_value(
+    ctx: &CheckerContext<'_>,
+    arena: &NodeArena,
+    binder: &BinderState,
+    expr_idx: NodeIndex,
+    depth: u32,
+) -> bool {
+    // Bound alias-chasing depth; a real program never nests this deep and the
+    // binder graph has no cycle-guard here.
+    if depth > 8 {
+        return false;
+    }
+    let mut idx = expr_idx;
+    while let Some(node) = arena.get(idx)
+        && node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION
+        && let Some(paren) = arena.get_parenthesized(node)
+    {
+        idx = paren.expression;
+    }
+    let Some(node) = arena.get(idx) else {
+        return false;
+    };
+
+    if arena.get_identifier(node).is_some() {
+        if identifier_resolves_to_unshadowed_global_in_context(ctx, arena, binder, idx, "Symbol") {
+            return true;
+        }
+        let Some(sym_id) = binder.resolve_identifier(arena, idx) else {
+            return false;
+        };
+        let Some(symbol) = binder.get_symbol(sym_id) else {
+            return false;
+        };
+        if symbol.value_declaration.is_none()
+            || !arena.is_const_variable_declaration(symbol.value_declaration)
+        {
+            return false;
+        }
+        let Some(decl_node) = arena.get(symbol.value_declaration) else {
+            return false;
+        };
+        let Some(var_decl) = arena.get_variable_declaration(decl_node) else {
+            return false;
+        };
+        if var_decl.initializer.is_none() {
+            return false;
+        }
+        return expr_denotes_global_symbol_value(
+            ctx,
+            arena,
+            binder,
+            var_decl.initializer,
+            depth + 1,
+        );
+    }
+
+    // `<base>.Symbol` / `<base>["Symbol"]`, e.g. `globalThis.Symbol`.
+    if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+        || node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+    {
+        let Some(access) = arena.get_access_expr(node) else {
+            return false;
+        };
+        let Some(name_node) = arena.get(access.name_or_argument) else {
+            return false;
+        };
+        let member_is_symbol = arena
+            .get_identifier(name_node)
+            .is_some_and(|ident| ident.escaped_text == "Symbol")
+            || (matches!(
+                name_node.kind,
+                k if k == SyntaxKind::StringLiteral as u16
+                    || k == SyntaxKind::NoSubstitutionTemplateLiteral as u16
+            ) && arena
+                .get_literal(name_node)
+                .is_some_and(|lit| lit.text == "Symbol"));
+        if member_is_symbol {
+            return identifier_resolves_to_unshadowed_global_in_context(
+                ctx,
+                arena,
+                binder,
+                access.expression,
+                "globalThis",
+            );
+        }
+    }
+
+    false
+}
+
+/// Read-side counterpart of [`well_known_symbol_property_name`]: recover the
+/// canonical `[Symbol.<member>]` key for an ELEMENT ACCESS whose base resolves
+/// to the global `Symbol` value through any number of `const` alias
+/// indirections, not only the literal `Symbol` spelling. #16961.
+pub(crate) fn well_known_symbol_property_name_for_read(
+    ctx: &CheckerContext<'_>,
+    arena: &NodeArena,
+    binder: &BinderState,
+    expr_idx: NodeIndex,
+) -> Option<String> {
+    let parts = member_access_parts(arena, expr_idx)?;
+    let member = parts.member?;
+    expr_denotes_global_symbol_value(ctx, arena, binder, parts.base, 0)
+        .then(|| format!("[Symbol.{member}]"))
+}
+
 /// Is `expr_idx` a resolved `Symbol.<member>` (or `Symbol["<member>"]`)
 /// syntactic access — the shape that always mints the canonical
 /// `[Symbol.<member>]` named key regardless of `<member>`'s declared kind?

--- a/crates/tsz-checker/src/types/type_checking/declarations_utils.rs
+++ b/crates/tsz-checker/src/types/type_checking/declarations_utils.rs
@@ -375,28 +375,50 @@ impl<'a> CheckerState<'a> {
     /// literal-type key declared by the shadowing const object member
     /// instead (a `CheckerState`-only recovery: it needs the expression's
     /// computed literal type, which the lowering layer cannot ask for).
+    ///
+    /// This is a READ-side query (element access, `delete`, readonly/exact-
+    /// optional checks — never computed-property-NAME declaration binding),
+    /// so when neither the direct nor the shadow recovery applies, it also
+    /// follows `const` alias chains to the global `Symbol` value
+    /// (`const S = Symbol; a[S.iterator]`, #16961) — a read has no syntactic
+    /// reason to stay alias-blind the way `tsc`'s late-bound NAME binding
+    /// intentionally does (#16307).
     pub(crate) fn get_symbol_property_name_from_expr(&self, expr_idx: NodeIndex) -> Option<String> {
         use crate::types_domain::computed_names::{
             WellKnownSymbolName, well_known_symbol_property_name,
+            well_known_symbol_property_name_for_read,
         };
 
-        match well_known_symbol_property_name(&self.ctx, self.ctx.arena, self.ctx.binder, expr_idx)?
+        if let Some(name) =
+            well_known_symbol_property_name(&self.ctx, self.ctx.arena, self.ctx.binder, expr_idx)
         {
-            WellKnownSymbolName::Global(name) => Some(name),
-            WellKnownSymbolName::Shadowed => {
-                // `Symbol` is shadowed by a local binding: recover the
-                // literal-type key from the shadowing const object member,
-                // e.g. `[Symbol.obs]` with `const Symbol = { obs: "x" }`
-                // names the property "x".
-                let literal_type = self.const_object_member_literal_type_query(expr_idx)?;
-                let name =
-                    crate::query_boundaries::type_computation::access::literal_property_name(
-                        self.ctx.types,
-                        literal_type,
-                    )?;
-                Some(self.ctx.types.resolve_atom_ref(name).to_string())
+            match name {
+                WellKnownSymbolName::Global(name) => return Some(name),
+                WellKnownSymbolName::Shadowed => {
+                    // `Symbol` is shadowed by a local binding: recover the
+                    // literal-type key from the shadowing const object member,
+                    // e.g. `[Symbol.obs]` with `const Symbol = { obs: "x" }`
+                    // names the property "x".
+                    if let Some(literal_type) =
+                        self.const_object_member_literal_type_query(expr_idx)
+                        && let Some(name) =
+                            crate::query_boundaries::type_computation::access::literal_property_name(
+                                self.ctx.types,
+                                literal_type,
+                            )
+                    {
+                        return Some(self.ctx.types.resolve_atom_ref(name).to_string());
+                    }
+                }
             }
         }
+
+        well_known_symbol_property_name_for_read(
+            &self.ctx,
+            self.ctx.arena,
+            self.ctx.binder,
+            expr_idx,
+        )
     }
 
     // 22. Node Containment


### PR DESCRIPTION
Closes #16961.

`a[Symbol.iterator]` resolved correctly, but `const S = Symbol; a[S.iterator]` false-positived TS7015. `well_known_symbol_access_shape`'s literal-text `base_text == "Symbol"` check (correctly syntactic for computed-property-NAME declarations — tsc's own `isWellKnownSymbolSyntactically`, #16307) also gated the READ-side property-name shortcut, so an aliased access fell through to generic unique-symbol resolution. That fallback then reinterpreted the unique-symbol's `SymbolRef` as a raw `SymbolId` through the CURRENT file's binder — but the ref was minted in whichever binder built the `SymbolConstructor` interface member (typically a lib file's), so the reinterpretation silently hit an unrelated symbol.

## Structural rule

When an element-access key's base identifier denotes the global `Symbol` value through any number of `const` alias indirections, `tsc` resolves it identically to the literal `Symbol.<member>` spelling — ordinary value identity, not syntax. Fixed at two owners:

- `crates/tsz-checker/src/types/computed_names.rs` gains `well_known_symbol_property_name_for_read`, a READ-only counterpart to `well_known_symbol_property_name` that follows `const` alias chains (including through `globalThis.Symbol`) via binder identity, never touching the existing syntax-only declaration-binding path (`well_known_symbol_access_shape` itself is untouched — #16307's rule for computed-property-NAME *declarations* stays exactly as before).
- `crates/tsz-checker/src/types/computation/access.rs`'s remaining raw-`SymbolId` fallback now recovers the canonical name from the solver's well-known-symbol registry (`well_known_symbol_name_for_ref`, already used by `keyof`/`index_access_keys` evaluators) instead of reinterpreting the ordinal.

## Adjacent-case matrix (`access_tests.rs`, oracle-verified against the issue's own `tsc` table)

- direct `Symbol.iterator` (baseline, unaffected by this change)
- single `const` alias (`const S = Symbol`)
- arbitrary binder name (`const zzTop = Symbol`) — binder-name independence
- `globalThis.Symbol` alias initializer
- a `Symbol`-shadowing alias of the real global (`const Symbol = globalThis.Symbol`)
- `string` receiver (predates #16958, same mechanism, matches `tsc`'s own "clean" oracle for this row)
- **negative control**: an alias-reached computed-property-NAME *declaration* (`class C { [S.iterator]() {} }`) stays off the well-known slot, confirming #16307's syntactic rule is untouched

## Goal
Goal: hold

## Verification
- `cargo fmt --check`: clean.
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`: clean.
- `cargo test -p tsz-checker --lib well_known_symbol_element_access_through_alias_tests`: 7/7 new tests pass (real-lib-backed, oracle-verified expectations).
- `cargo test -p tsz-checker --lib` scoped to `symbol`, `computed_names`, `well_known`, `element_access`, `access_tests`, `iterator`: 700+ existing tests pass, zero regressions.
- A full `conformance.sh snapshot` vs. parent is **owed**, not run this session — no local TypeScript corpus checkout in this container and this is a time-boxed hourly routine. The CLI was manually verified against all rows of the issue's oracle table via a dev build with the bundled default libs, matching `tsc` exactly in every case.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_015SULHZ8TC8bArThQS1zze3)_