### PR TITLE
fix(checker): JSDoc @callback @this tag is dropped from the synthesized signature

### DIFF
--- a/crates/tsz-checker/src/jsdoc/parsing.rs
+++ b/crates/tsz-checker/src/jsdoc/parsing.rs
@@ -5,7 +5,8 @@
 //! definition parsing. No type resolution or checker state access.
 
 use super::types::{
-    JsdocCallbackInfo, JsdocPropertyTagInfo, JsdocTemplateParamInfo, JsdocTypedefInfo,
+    JsdocCallbackInfo, JsdocParamTagInfo, JsdocPropertyTagInfo, JsdocTemplateParamInfo,
+    JsdocTypedefInfo,
 };
 use crate::state::CheckerState;
 
@@ -881,6 +882,20 @@ impl<'a> CheckerState<'a> {
                         && let Some(ref mut cb) = current_info.callback
                     {
                         cb.params.push(param_info);
+                    }
+                    continue;
+                }
+                if let Some(rest) = Self::strip_jsdoc_tag_prefix(line, "this") {
+                    let rest = rest.trim();
+                    if let Some(type_expr) = Self::jsdoc_balanced_braced_type_expr(rest)
+                        && let Some(ref mut cb) = current_info.callback
+                    {
+                        cb.params.push(JsdocParamTagInfo {
+                            name: "this".to_string(),
+                            type_expr: Some(type_expr.to_string()),
+                            optional: false,
+                            rest: false,
+                        });
                     }
                     continue;
                 }

--- a/crates/tsz-checker/tests/ts2683_tests.rs
+++ b/crates/tsz-checker/tests/ts2683_tests.rs
@@ -636,3 +636,108 @@ f = function () {
         "Expected TS2683 for a bare-identifier reassignment (no base object), got: {diags:?}"
     );
 }
+
+// =========================================================================
+// JSDoc `@callback` + `@this` tag tests (callbackTag4.ts conformance fixture)
+// =========================================================================
+
+#[test]
+fn jsdoc_callback_this_tag_suppresses_ts2683() {
+    // A `@callback` typedef carrying a standalone `@this {T}` tag must give
+    // the assigned function a contextual `this` type, same as a direct
+    // `@this` tag on the function itself. Matches
+    // `TypeScript/tests/cases/conformance/jsdoc/callbackTag4.ts`.
+    let src = r#"
+/**
+ * @callback C
+ * @this {{ a: string, b: number }}
+ * @param {string} a
+ * @param {number} b
+ * @returns {boolean}
+ */
+
+/** @type {C} */
+const cb = function (a, b) {
+    this
+    return true
+}
+"#;
+    let diags = get_js_diagnostics(src);
+    assert!(
+        !diags.iter().any(|d| d.0 == 2683),
+        "Expected a `@callback`'s `@this` tag to suppress TS2683, got: {diags:?}"
+    );
+}
+
+#[test]
+fn jsdoc_callback_this_tag_types_this_member_access() {
+    // The `@this` type on the callback should also be checked structurally:
+    // an absent member on the declared `this` shape should still TS2339.
+    let src = r#"
+/**
+ * @callback C
+ * @this {{ a: string }}
+ * @param {string} a
+ * @returns {boolean}
+ */
+
+/** @type {C} */
+const cb = function (a) {
+    this.missing
+    return true
+}
+"#;
+    let diags = get_js_diagnostics(src);
+    assert!(
+        diags.iter().any(|d| d.0 == 2339),
+        "Expected TS2339 for a member absent from the `@this` shape, got: {diags:?}"
+    );
+    assert!(
+        !diags.iter().any(|d| d.0 == 2683),
+        "A resolved `@this` type must not also emit TS2683, got: {diags:?}"
+    );
+}
+
+#[test]
+fn jsdoc_callback_without_this_tag_still_emits_ts2683() {
+    // Negative case: a `@callback` with no `@this` tag keeps the existing
+    // implicit-any behavior — this must not become a blanket suppression.
+    let src = r#"
+/**
+ * @callback C
+ * @param {string} a
+ * @returns {boolean}
+ */
+
+/** @type {C} */
+const cb = function (a) {
+    this
+    return true
+}
+"#;
+    let diags = get_js_diagnostics(src);
+    assert!(
+        diags.iter().any(|d| d.0 == 2683),
+        "Expected TS2683 when the callback has no `@this` tag, got: {diags:?}"
+    );
+}
+
+#[test]
+fn jsdoc_typedef_this_tag_outside_callback_is_ignored() {
+    // A plain (non-`@callback`) `@typedef` has no call signature, so an
+    // `@this` tag there is meaningless and must not be picked up as a
+    // param named "this" on some other shape.
+    let src = r#"
+/**
+ * @typedef {{ this: string }} T
+ */
+
+/** @type {T} */
+const t = { this: "x" };
+"#;
+    let diags = get_js_diagnostics(src);
+    assert!(
+        !diags.iter().any(|d| d.0 == 2683),
+        "A non-callback typedef must not be affected by callback `@this` parsing, got: {diags:?}"
+    );
+}


### PR DESCRIPTION
Fixes a spurious TS2683 on `TypeScript/tests/cases/conformance/jsdoc/callbackTag4.ts`, picked from the conformance `--one-extra` (TS2683) queue.

**Structural rule:** when a `@callback` JSDoc typedef carries a standalone `@this {T}` tag, tsc includes that type as the synthesized signature's `this` parameter, so any function assigned that callback type gets a contextual `this` (no TS2683, and `this`'s members are checked structurally against `T`). tsz's `@callback`-block line parser only recognized `@param` and `@return`/`@returns` tags inside a callback block; a standalone `@this` tag was silently dropped, so the synthesized signature never carried a `this` parameter and the assigned function fell back to implicit-any `this` -> TS2683.

**Owner layer:** checker JSDoc parsing (`crates/tsz-checker/src/jsdoc/parsing.rs`, `parse_jsdoc_typedefs`'s callback-block handling). The signature-construction side (`type_from_jsdoc_callback` in `jsdoc/resolution/type_construction.rs`) already fully supported a `this`-named param (the older `@param {T} this` style) — it was simply unreachable via the dedicated `@this` tag. The fix parses `@this {T}` into the same `this`-named `JsdocParamTagInfo` that machinery already consumes, reusing the existing `jsdoc_balanced_braced_type_expr` brace-nesting parser for object-literal `this` shapes like `{{ a: string, b: number }}`.

**Adjacent matrix** (new tests in `ts2683_tests.rs`):

| case | tsz after |
| --- | --- |
| `@callback` with `@this {T}`, no `this`-body access | clean (was TS2683) |
| `@callback` with `@this {T}`, access to a member absent from `T` | TS2339 (structural check on the `@this` shape still fires — not a blanket suppression) |
| `@callback` with no `@this` tag | TS2683 still fires (negative case) |
| non-callback `@typedef` with a property literally named `this` | unaffected — the new branch is scoped to `current_info.callback.is_some()` |

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts2683_tests` — 38/38 passed (4 new, including the exact `callbackTag4.ts` shape).
- `cargo clippy -p tsz-checker --lib -- -D warnings` — clean (via pre-commit hook).
- `scripts/arch/check-checker-boundaries.sh` — clean (via pre-commit hook).
- `cargo fmt` — clean (via pre-commit hook).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5uuc5YvWH5n3bko9KDfHA)_