### PR TITLE
fix(arch): route property-traversal classification through query_boundaries

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/property_access.rs
+++ b/crates/tsz-checker/src/query_boundaries/property_access.rs
@@ -13,6 +13,21 @@ pub(crate) use super::common::{
     array_element_type, callable_shape_for_type as callable_shape, is_string_type, unwrap_readonly,
 };
 
+pub(crate) use tsz_solver::type_queries::PropertyTraversalKind;
+
+/// Classify `type_id` into a property-traversal shape — the object/callable
+/// shape carrying the properties, or the member list to descend into.
+///
+/// Sibling of `common::classify_for_traversal` for callers that need each
+/// property's `PropertyInfo` (name *and* `TypeId`) rather than a name-only
+/// view, such as matching a declared symbol-keyed property by type identity.
+pub(crate) fn classify_property_traversal(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> PropertyTraversalKind {
+    tsz_solver::type_queries::classify_property_traversal(db, type_id)
+}
+
 /// Resolve a named property on a type through the solver's property evaluator.
 ///
 /// This is the canonical boundary for property access resolution. Checker code

--- a/crates/tsz-checker/src/types/computation/access_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/access_helpers.rs
@@ -1692,18 +1692,21 @@ fn collect_object_properties_for_identity_match(
     if depth > max_depth {
         return;
     }
-    match tsz_solver::type_queries::classify_property_traversal(db, type_id) {
-        tsz_solver::type_queries::PropertyTraversalKind::Object(shape) => {
+    use crate::query_boundaries::property_access::{
+        PropertyTraversalKind, classify_property_traversal,
+    };
+    match classify_property_traversal(db, type_id) {
+        PropertyTraversalKind::Object(shape) => {
             out.extend(shape.properties.iter().cloned());
         }
-        tsz_solver::type_queries::PropertyTraversalKind::Callable(shape) => {
+        PropertyTraversalKind::Callable(shape) => {
             out.extend(shape.properties.iter().cloned());
         }
-        tsz_solver::type_queries::PropertyTraversalKind::Members(members) => {
+        PropertyTraversalKind::Members(members) => {
             for member in members {
                 collect_object_properties_for_identity_match(db, member, depth + 1, max_depth, out);
             }
         }
-        tsz_solver::type_queries::PropertyTraversalKind::Other => {}
+        PropertyTraversalKind::Other => {}
     }
 }


### PR DESCRIPTION
#16974 introduced a direct `tsz_solver::type_queries::classify_property_traversal`
call (plus four `PropertyTraversalKind` variant paths) in
`types/computation/access_helpers.rs`, outside `query_boundaries/`. That trips
the checker/solver boundary contract:

    ALL checker code must use query_boundaries wrappers — no direct
    tsz_solver::type_queries:: calls allowed outside query_boundaries/.

`architecture_contract_tests_src::part_02::test_no_inline_type_queries_in_cleaned_modules`
fails on main as a result. Behavior-preserving: the wrapper forwards the same
call, so no diagnostic changes.

The wrapper lives in `query_boundaries/property_access.rs` (which already
gateways several `type_queries` calls and is the thematic owner) rather than
`common.rs`, because `common.rs` is the #8225 quarantine — it is line-capped
(1764) and its direct-reference count is itself a guarded budget, so adding
there fails `scripts/arch/arch_guard.py` even though it satisfies the contract
test. Both layers pass here.

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-checker --lib -E 'test(architecture_contract)'` — 160 passed (was 159 passed / 1 failed on main)
- `cargo nextest run -p tsz-checker --lib` — 10883 passed, 0 failed
- `python3 scripts/arch/arch_guard.py` — rc=0, "Architecture guardrails passed."
- `cargo clippy -p tsz-checker --lib -- -D warnings` — clean

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high