### PR TITLE
fix(checker): evolving-array assignment target doesn't source its any[] as RHS contextual type (#14141)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -35,6 +35,9 @@ stacker = "0.1.23"
 name = "import_assert_keyword_abandon_tests"
 path = "tests/import_assert_keyword_abandon_tests.rs"
 [[test]]
+name = "evolving_array_assignment_contextual_inference_tests"
+path = "tests/evolving_array_assignment_contextual_inference_tests.rs"
+[[test]]
 name = "enum_member_binding_widening_tests"
 path = "tests/enum_member_binding_widening_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
@@ -84,6 +84,40 @@ impl<'a> CheckerState<'a> {
             .is_some_and(|sym_id| self.assignment_target_is_control_flow_typed_any_symbol(sym_id))
     }
 
+    /// Whether the assignment target `idx` is an evolving/auto array reference
+    /// (`let x = []`, or the control-flow-any `let x; x = []`). Such a target's
+    /// finalized `any[]` is provisional, so the caller withholds it as the RHS
+    /// contextual type (a contextual `any` return would fix a generic call's
+    /// type parameter and swallow argument errors); tsc does the same.
+    ///
+    /// The underlying evolving-array query resolves the target identifier with
+    /// the read-tracking resolver, which would mark a write-only variable as
+    /// "read" and suppress its TS6133. This is a pure structural query on the
+    /// assignment *target* (not a read), so it must not perturb unused-variable
+    /// tracking: resolve the symbol without tracking and, if the query inserted
+    /// the target into the read-set, restore it. The query only ever resolves
+    /// this one target reference, so restoring that single symbol is sufficient.
+    fn assignment_target_is_evolving_array(&mut self, idx: NodeIndex) -> bool {
+        if self
+            .ctx
+            .arena
+            .get(idx)
+            .is_none_or(|node| node.kind != SyntaxKind::Identifier as u16)
+        {
+            return false;
+        }
+        let target_sym = self.resolve_identifier_symbol_without_tracking(idx);
+        let already_referenced =
+            target_sym.is_some_and(|sym| self.ctx.referenced_symbols.borrow().contains(&sym));
+        let is_evolving = self.reference_is_reachable_evolving_array_mutation_target(idx);
+        if let Some(sym) = target_sym
+            && !already_referenced
+        {
+            self.ctx.referenced_symbols.borrow_mut().remove(&sym);
+        }
+        is_evolving
+    }
+
     fn is_evolving_array_element_assignment_target(&mut self, idx: NodeIndex) -> bool {
         let Some(node) = self.ctx.arena.get(idx) else {
             return false;
@@ -785,6 +819,11 @@ impl<'a> CheckerState<'a> {
             && left_type != TypeId::NEVER
             && left_type != TypeId::UNKNOWN
             && !self.type_contains_error(left_type)
+            // An evolving/auto array target's provisional `any[]` must not be
+            // sourced as the RHS contextual type (see
+            // `assignment_target_is_evolving_array`). Checked last so the query
+            // only runs once the target carries a real non-`any` array type.
+            && !self.assignment_target_is_evolving_array(left_idx)
         {
             let contextual_target = if let Some(right_node) = self.ctx.arena.get(right_idx) {
                 if right_node.kind == syntax_kind_ext::ARROW_FUNCTION

--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -885,7 +885,6 @@ impl CheckerState<'_> {
 
         self.rewrite_conditional_types1_fingerprints(&sf.text);
         self.align_awaited_type_instantiation_diagnostics(&sf.text);
-        self.align_evolving_array_inference_diagnostics(&sf.text);
         self.align_complex_recursive_collections_diagnostics(&sf.text);
     }
 
@@ -1208,44 +1207,6 @@ impl CheckerState<'_> {
                 code,
             ));
         }
-    }
-
-    fn align_evolving_array_inference_diagnostics(&mut self, source_text: &str) {
-        use tsz_common::diagnostics::{Diagnostic, diagnostic_codes};
-
-        if !Self::fixture_has_markers(
-            source_text,
-            &[
-                "function logFirstLength<T extends string[], U extends string>",
-                "let zz = [];",
-                "zz = logFirstLength([42]);",
-            ],
-        ) {
-            return;
-        }
-
-        let Some(line_start) = source_text.find("zz = logFirstLength([42]);") else {
-            return;
-        };
-        let Some(anchor_offset) = source_text[line_start..].find("42") else {
-            return;
-        };
-        let start = (line_start + anchor_offset) as u32;
-        let message = "Type 'number' is not assignable to type 'string'.";
-        if self.ctx.diagnostics.iter().any(|diag| {
-            diag.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
-                && diag.start == start
-                && diag.message_text == message
-        }) {
-            return;
-        }
-        self.ctx.diagnostics.push(Diagnostic::error(
-            self.ctx.file_name.clone(),
-            start,
-            2,
-            message,
-            diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-        ));
     }
 
     fn align_complex_recursive_collections_diagnostics(&mut self, source_text: &str) {

--- a/crates/tsz-checker/tests/evolving_array_assignment_contextual_inference_tests.rs
+++ b/crates/tsz-checker/tests/evolving_array_assignment_contextual_inference_tests.rs
@@ -1,0 +1,191 @@
+//! Regression coverage for #14141's `inferenceShouldFailOnEvolvingArrays`
+//! sub-fixture: the native fix that replaced the source-text-gated
+//! `align_evolving_array_inference_diagnostics` rewrite.
+//!
+//! Structural rule:
+//!
+//! > An evolving/auto array assignment target (`let acc = []`, or `let acc;
+//! > acc = []`) has the provisional element type `any`; its finalized `any[]`
+//! > is not a stable declared type. It must NOT be sourced as the contextual
+//! > type for the assignment RHS. When the RHS is a generic call, using that
+//! > `any[]` as a contextual return type fixes the call's type parameter to
+//! > `any` and suppresses the argument-position error the same call reports
+//! > with no context. So `acc = f([42])` for
+//! > `f<T extends string[], U extends string>(arg: { [K in U]: T }[U]): T` must
+//! > still check the `[42]` element against `string` — exactly as the bare
+//! > `f([42])` statement does.
+//!
+//! `tsc` (pinned 7.0.2) reports `TS2322 Type 'number' is not assignable to type
+//! 'string'.` at both the bare call and the evolving-array assignment. Every
+//! case here uses distinct binder / type-parameter names so the behavior
+//! follows the structural shape, not any identifier spelling (CLAUDE.md
+//! anti-hardcoding gate) — the deleted rewrite matched the literal fixture text
+//! `zz`/`logFirstLength`, which these names deliberately avoid.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+
+const TS2322_NOT_ASSIGNABLE: u32 = 2322;
+const NUMBER_NOT_STRING: &str = "Type 'number' is not assignable to type 'string'.";
+
+fn diagnostics(source: &str) -> Vec<(u32, String)> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+    )
+    .into_iter()
+    .map(|d| (d.code, d.message_text))
+    .collect()
+}
+
+fn count_number_not_string(diags: &[(u32, String)]) -> usize {
+    diags
+        .iter()
+        .filter(|(code, msg)| *code == TS2322_NOT_ASSIGNABLE && msg == NUMBER_NOT_STRING)
+        .count()
+}
+
+/// The generic whose parameter type blocks argument inference but simplifies to
+/// `T`, so a non-`string[]` argument surfaces the element mismatch (the shape
+/// from TS issue #25675). Named `firstLen`/`A`/`B` to avoid the deleted
+/// rewrite's `logFirstLength`/`T`/`U` literals.
+const GENERIC: &str = "function firstLen<A extends string[], B extends string>(arg: { [K in B]: A }[B]): A {\n\
+     \x20   return arg;\n\
+     }\n";
+
+#[test]
+fn evolving_empty_array_target_still_reports_argument_error() {
+    // Both the bare call and the evolving-array-assigned call must error.
+    let src = format!(
+        "{GENERIC}\
+         firstLen([42]);\n\
+         let acc = [];\n\
+         acc = firstLen([42]);\n"
+    );
+    let diags = diagnostics(&src);
+    assert_eq!(
+        count_number_not_string(&diags),
+        2,
+        "evolving-array assignment must not suppress the generic-call argument \
+         error; expected TS2322 at both the bare and assigned call, got: {diags:?}"
+    );
+}
+
+#[test]
+fn control_flow_any_null_then_empty_array_target_reports_argument_error() {
+    // `let a; a = []` is the control-flow-typed-any evolving-array form; it must
+    // behave like the direct `let a = []` initializer.
+    let src = format!(
+        "{GENERIC}\
+         let bucket;\n\
+         bucket = [];\n\
+         bucket = firstLen([42]);\n"
+    );
+    let diags = diagnostics(&src);
+    assert_eq!(
+        count_number_not_string(&diags),
+        1,
+        "control-flow-any evolving array assignment must still report the \
+         generic-call argument error; got: {diags:?}"
+    );
+}
+
+#[test]
+fn explicit_array_annotation_target_still_reports_argument_error() {
+    // A real annotation is a stable declared type and still contextually types
+    // the RHS — the fix is scoped to evolving/auto arrays, not to every `[]`.
+    let src = format!(
+        "{GENERIC}\
+         let named: string[] = [];\n\
+         named = firstLen([42]);\n"
+    );
+    let diags = diagnostics(&src);
+    assert_eq!(
+        count_number_not_string(&diags),
+        1,
+        "annotated array target must still report the generic-call argument \
+         error; got: {diags:?}"
+    );
+}
+
+#[test]
+fn evolving_array_assigned_well_typed_generic_call_is_clean() {
+    // Negative control: a `string[]` argument satisfies the constraint, so the
+    // fix must not manufacture a spurious error on the evolving-array path.
+    let src = format!(
+        "{GENERIC}\
+         let store = [];\n\
+         store = firstLen([\"ok\"]);\n"
+    );
+    let diags = diagnostics(&src);
+    assert_eq!(
+        count_number_not_string(&diags),
+        0,
+        "a constraint-satisfying argument must not error on the evolving-array \
+         path; got: {diags:?}"
+    );
+}
+
+const TS6133_DECLARED_NEVER_READ: u32 = 6133;
+
+fn diagnostics_no_unused(source: &str) -> Vec<(u32, String)> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            no_unused_locals: true,
+            no_unused_parameters: true,
+            ..Default::default()
+        },
+    )
+    .into_iter()
+    .map(|d| (d.code, d.message_text))
+    .collect()
+}
+
+#[test]
+fn write_only_assignment_target_still_reports_unused() {
+    // The evolving-array gate resolves the assignment target, so it must NOT
+    // mark the target as "read" — otherwise a write-only variable is silently
+    // treated as used and its TS6133 disappears (the `unusedMultipleParameter*`
+    // / `noUnusedLocals_writeOnly` regression family). Mirrors
+    // `unusedMultipleParameter1InFunctionExpression`: `slot` is written only.
+    let src = "var run = function (slot: string) {\n    slot = \"dummy\";\n};\n";
+    let count = diagnostics_no_unused(src)
+        .iter()
+        .filter(|(code, msg)| *code == TS6133_DECLARED_NEVER_READ && msg.contains("'slot'"))
+        .count();
+    assert_eq!(
+        count, 1,
+        "a write-only assignment target must still report TS6133"
+    );
+}
+
+#[test]
+fn read_then_written_target_reports_no_unused() {
+    // Negative control: once the variable is genuinely read, no TS6133 — the
+    // gate must not manufacture a spurious unused diagnostic either.
+    let src =
+        "var run = function (slot: string) {\n    console.log(slot);\n    slot = \"dummy\";\n};\n";
+    let has = diagnostics_no_unused(src)
+        .iter()
+        .any(|(code, msg)| *code == TS6133_DECLARED_NEVER_READ && msg.contains("'slot'"));
+    assert!(!has, "a read variable must not report TS6133");
+}
+
+#[test]
+fn evolving_array_assigned_plain_array_literal_is_clean() {
+    // Withholding the contextual type must not break ordinary evolving-array
+    // growth: assigning a concrete array literal remains error-free.
+    let src = "let list = [];\nlist = [1, 2, 3];\nlist = [\"a\"];\n";
+    let diags = diagnostics(src);
+    assert!(
+        diags.is_empty(),
+        "plain evolving-array reassignment must stay clean; got: {diags:?}"
+    );
+}


### PR DESCRIPTION
Removes the source-text-gated `align_evolving_array_inference_diagnostics` rewrite (one of the four remaining fixture-gated diagnostic rewrites tracked by #14141) by fixing the underlying checker divergence so the `inferenceShouldFailOnEvolvingArrays` diagnostics fall out natively.

## Structural rule

When the assignment target is an evolving/auto array (`let zz = []`, or the control-flow-any `let zz; zz = []`), its finalized `any[]` is a *provisional* type, not a stable declared type. tsc does **not** source a contextual type from an auto array; tsz did. Passing that `any[]` as the RHS's contextual **return** type fixes a generic call's type parameter to `any`, so the argument is checked against `any` and the argument-position error the same call reports with no context disappears.

For `f<T extends string[], U extends string>(arg: { [K in U]: T }[U]): T`:

```ts
f([42]);        // TS2322 Type 'number' is not assignable to type 'string'  (reported)
let zz = [];
zz = f([42]);   // same call, same error — was dropped because zz's any[] became the context
```

tsz now withholds the contextual type when the target resolves through `reference_is_reachable_evolving_array_mutation_target`, so the RHS is checked as if unassigned and the element mismatch is reported at both call sites — owner layer: `check_assignment_expression` in `crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs`.

The source-text-gated rewrite that hardcoded the fixture's `zz`/`logFirstLength` identifiers to inject the missing `TS2322` is deleted (function + dispatch). Three fixture-gated rewrites remain (`conditionalTypes1`, `awaitedTypeStrictNull`, `complexRecursiveCollections`), each tracked separately in #14141.

## Read-tracking guard (regression found and fixed during verification)

The evolving-array query resolves the target identifier via the read-tracking resolver, which marked every assignment-target identifier as "read". An isolated before/after conformance run caught this as a real regression: `noUnusedLocals_writeOnly` and the `unusedMultipleParameter*` / `unusedLocals*` family lost their `TS6133` (write-only variables looked "used"). The query is now routed through a helper that resolves the target *without* tracking and restores the read-set, so evolving-array detection never perturbs unused-variable reporting. Covered by `write_only_assignment_target_still_reports_unused`.

## Adjacent-case matrix

New `evolving_array_assignment_contextual_inference_tests` (varied binder / type-parameter names, not the fixture's `zz`/`logFirstLength`):
- direct `let acc = []` evolving target → argument error at both bare and assigned call
- control-flow-any `let bucket; bucket = []` evolving target → argument error reported
- explicit `let named: string[] = []` (real annotation, out of scope) → still reports
- write-only assignment target under `noUnusedLocals`/`noUnusedParameters` → still reports `TS6133`
- negatives: constraint-satisfying argument → clean; read variable → no `TS6133`; plain array growth → clean

## Goal
Goal: hold

## Verification
- **Target fixture native pass:** `inferenceShouldFailOnEvolvingArrays` matches the pinned tsc 7.0.2 cache **fingerprint-for-fingerprint** with the rewrite removed — exactly the 5 expected diagnostics (`TS2345` @7:11/@9:15/@17:19, `TS2322` @15:17/@18:22; the @18:22 error is the one the rewrite used to inject). Confirmed PASS in a full corpus run.
- **Unit:** `cargo test -p tsz-checker --test evolving_array_assignment_contextual_inference_tests` — 7/7.
- **Isolated conformance (before vs after, same pinned lib set, full 18,876-file corpus):** the TS6133 regression above was found here and fixed; after the fix, the target fixture is PASS and the whole `unused*`/`noUnusedLocals` family is back to PASS. The residual before/after delta is confined to known run-to-run-nondeterministic fixtures (the #16308/#16309 `interface extends Array` heritage + non-canonical-instantiation family, e.g. `coAndContraVariantInferences*`, index-signature `TS2430`, DOM-lib); **every** such fixture contains zero evolving-array (`= []`) targets, and this change is a semantic no-op for non-evolving assignment targets (contextual path unchanged; read-set restored), so none of them are semantically affected — the flips are pre-existing flakiness incidentally reordered by the binary, not caused by this diff.
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`: clean (pre-commit).
- Architecture-size guard (pre-commit): passed; `assignment_ops.rs` 1996 lines.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high