### PR TITLE
fix(checker): class static-block `this.prop=` declares an implicit static member in JS files

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1056,6 +1056,9 @@ path = "tests/js_constructor_property_tests.rs"
 name = "js_constructor_property_more_tests"
 path = "tests/js_constructor_property_more_tests.rs"
 [[test]]
+name = "js_static_block_this_property_tests"
+path = "tests/js_static_block_this_property_tests.rs"
+[[test]]
 name = "jsdoc_type_tag_tests"
 path = "tests/jsdoc_type_tag_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/class_type/constructor.rs
+++ b/crates/tsz-checker/src/types/class_type/constructor.rs
@@ -1123,6 +1123,13 @@ impl<'a> CheckerState<'a> {
                         }
                     }
                 }
+                k if k == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION => self
+                    .collect_js_static_block_this_properties(
+                        member_idx,
+                        class_idx,
+                        &mut properties,
+                        current_sym,
+                    ),
                 _ => {}
             }
         }

--- a/crates/tsz-checker/src/types/class_type/js_class_properties.rs
+++ b/crates/tsz-checker/src/types/class_type/js_class_properties.rs
@@ -567,6 +567,32 @@ impl CheckerState<'_> {
         None
     }
 
+    /// Scan a class `static { }` block for `this.prop = value` assignments and
+    /// add them as static properties, mirroring the constructor-body handling
+    /// in [`Self::collect_js_constructor_this_properties`] for instance members.
+    /// Checks the class's own file rather than the currently-processed file so
+    /// a TS file referencing a JS class still sees the implicit static members.
+    pub(crate) fn collect_js_static_block_this_properties(
+        &mut self,
+        static_block_idx: NodeIndex,
+        class_idx: NodeIndex,
+        properties: &mut FxHashMap<Atom, PropertyInfo>,
+        parent_sym: Option<SymbolId>,
+    ) {
+        let class_is_in_js_file = self
+            .source_file_data_for_node(class_idx)
+            .map(|sf| crate::context::is_js_file_name(&sf.file_name))
+            .unwrap_or(false);
+        if class_is_in_js_file {
+            self.collect_js_constructor_this_properties(
+                static_block_idx,
+                properties,
+                parent_sym,
+                true,
+            );
+        }
+    }
+
     /// Scan a body (constructor or method) for `this.prop = value` assignments
     /// and add them as instance properties. This implements the JS/checkJs
     /// pattern where assignments serve as implicit property declarations.

--- a/crates/tsz-checker/tests/js_static_block_this_property_tests.rs
+++ b/crates/tsz-checker/tests/js_static_block_this_property_tests.rs
@@ -1,0 +1,231 @@
+//! Tests for JS static-block `this.prop = value` property inference.
+//!
+//! In JS/checkJs mode, `this.prop = value` inside a class `static { }` block
+//! serves as an implicit *static* property declaration, mirroring the
+//! existing constructor-body `this.prop = value` handling for *instance*
+//! members. See `js_constructor_property_tests.rs` for the instance-side
+//! coverage this mirrors.
+
+use tsz_checker::context::CheckerOptions;
+
+fn check_js(source: &str) -> Vec<(u32, String)> {
+    check_with_options_and_file(
+        source,
+        "test.js",
+        CheckerOptions {
+            check_js: true,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+fn check_ts(source: &str) -> Vec<(u32, String)> {
+    check_with_options_and_file(source, "test.ts", CheckerOptions::default())
+}
+
+fn check_with_options_and_file(
+    source: &str,
+    file_name: &str,
+    options: CheckerOptions,
+) -> Vec<(u32, String)> {
+    let mut parser =
+        tsz_parser::parser::ParserState::new(file_name.to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let mut binder = tsz_binder::BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let types = tsz_solver::construction::TypeInterner::new();
+    let mut checker = tsz_checker::state::CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        file_name.to_string(),
+        options,
+    );
+
+    checker.ctx.set_lib_contexts(Vec::new());
+    checker.check_source_file(root);
+
+    checker
+        .ctx
+        .diagnostics
+        .iter()
+        .map(|d| (d.code, d.message_text.clone()))
+        .collect()
+}
+
+fn count_code(diags: &[(u32, String)], code: u32) -> usize {
+    diags.iter().filter(|(c, _)| *c == code).count()
+}
+
+/// Basic case from the conformance fixture: `this.prop = value` inside a
+/// static block creates a static member, so a later `Class.prop` access
+/// does not false-positive TS2339.
+#[test]
+fn static_block_this_prop_no_false_ts2339() {
+    let source = r#"
+class Thing {
+    static {
+        this.doSomething = () => {};
+    }
+}
+Thing.doSomething();
+"#;
+    let diagnostics = check_js(source);
+    assert_eq!(
+        count_code(&diagnostics, 2339),
+        0,
+        "expected static-block `this.prop=` to declare a static member, got: {diagnostics:?}"
+    );
+}
+
+/// Renamed binder: the class name and property name must not matter.
+#[test]
+fn static_block_this_prop_renamed_binders_no_false_ts2339() {
+    let source = r#"
+class zzTop {
+    static {
+        this.frobnicate = 42;
+    }
+}
+zzTop.frobnicate;
+"#;
+    let diagnostics = check_js(source);
+    assert_eq!(
+        count_code(&diagnostics, 2339),
+        0,
+        "expected renamed static-block this-assignment to declare a static member, got: {diagnostics:?}"
+    );
+}
+
+/// Multiple `this.prop = value` statements in one static block all become
+/// static members.
+#[test]
+fn static_block_multiple_this_props_no_false_ts2339() {
+    let source = r#"
+class K {
+    static {
+        this.a = 1;
+        this.b = "x";
+    }
+}
+K.a;
+K.b;
+"#;
+    let diagnostics = check_js(source);
+    assert_eq!(
+        count_code(&diagnostics, 2339),
+        0,
+        "expected all static-block this-assignments to declare static members, got: {diagnostics:?}"
+    );
+}
+
+/// Multiple static blocks in the same class each contribute members.
+#[test]
+fn static_block_two_blocks_no_false_ts2339() {
+    let source = r#"
+class K {
+    static {
+        this.a = 1;
+    }
+    static {
+        this.b = 2;
+    }
+}
+K.a;
+K.b;
+"#;
+    let diagnostics = check_js(source);
+    assert_eq!(
+        count_code(&diagnostics, 2339),
+        0,
+        "expected members from every static block to be visible, got: {diagnostics:?}"
+    );
+}
+
+/// A subclass extending a lib/user base still gets its own static-block
+/// implicit members (checks the fix does not depend on a bare base class).
+#[test]
+fn static_block_this_prop_extends_no_false_ts2339() {
+    let source = r#"
+class Base {}
+class ElementsArray extends Base {
+    static {
+        this.isArray = (arg) => false;
+    }
+}
+ElementsArray.isArray(1);
+"#;
+    let diagnostics = check_js(source);
+    assert_eq!(
+        count_code(&diagnostics, 2339),
+        0,
+        "expected static-block this-assignment on a derived class to declare a static member, got: {diagnostics:?}"
+    );
+}
+
+/// An already-declared static property is not overridden by a static-block
+/// assignment of the same name — the explicit declaration still wins and no
+/// spurious diagnostic is introduced either way.
+#[test]
+fn static_block_this_prop_does_not_override_explicit_declaration() {
+    let source = r#"
+class K {
+    static p = "declared";
+    static {
+        this.p = "assigned";
+    }
+}
+K.p;
+"#;
+    let diagnostics = check_js(source);
+    assert_eq!(
+        count_code(&diagnostics, 2339),
+        0,
+        "expected explicit static declaration + static-block assignment of the same name to coexist without TS2339, got: {diagnostics:?}"
+    );
+}
+
+/// Negative control: a member that is genuinely never assigned anywhere
+/// must still report TS2339 — the fix must not become a blanket suppression.
+#[test]
+fn static_block_this_prop_genuinely_missing_member_still_reports_ts2339() {
+    let source = r#"
+class K {
+    static {
+        this.a = 1;
+    }
+}
+K.doesNotExist;
+"#;
+    let diagnostics = check_js(source);
+    assert_eq!(
+        count_code(&diagnostics, 2339),
+        1,
+        "expected a genuinely absent static member to still report TS2339, got: {diagnostics:?}"
+    );
+}
+
+/// Negative control: the implicit-member-from-assignment JS special case
+/// must not leak into TS files. A `.ts` class doing `this.prop = value` in
+/// a static block with no declared member for `prop` still errors on both
+/// the assignment and the later read.
+#[test]
+fn static_block_this_prop_ts_file_still_reports_ts2339() {
+    let source = r#"
+class K {
+    static {
+        this.a = 1;
+    }
+}
+K.a;
+"#;
+    let diagnostics = check_ts(source);
+    assert!(
+        count_code(&diagnostics, 2339) >= 1,
+        "expected TS files to keep reporting TS2339 for an undeclared static member \
+         written via `this.prop=` in a static block (JS-only special case), got: {diagnostics:?}"
+    );
+}

--- a/scripts/arch/arch_guard_file_limits.py
+++ b/scripts/arch/arch_guard_file_limits.py
@@ -643,6 +643,10 @@ FILE_LINE_LIMIT_CHECKS = [
         2896,
     ),
     (
+        # Ratcheted 1981->1982: +1 line for the CLASS_STATIC_BLOCK_DECLARATION
+        # match arm that scans a static block for implicit `this.prop=` static
+        # members in JS/checkJs mode (conformance false positive fixed by
+        # javascriptThisAssignmentInStaticBlock.ts).
         "Checker boundary: types/class_type/constructor.rs size ratchet",
         ROOT
         / "crates"
@@ -651,7 +655,7 @@ FILE_LINE_LIMIT_CHECKS = [
         / "types"
         / "class_type"
         / "constructor.rs",
-        1981,
+        1982,
     ),
     (
         "Solver boundary: diagnostics/format/compound.rs size ratchet",


### PR DESCRIPTION
## Goal
Goal: hold

## Structural rule

When `this.prop = value` is written inside a class `static { }` block in a JS/checkJs file, `tsc` treats the assignment as an implicit **static** property declaration — the same JS-binder special case that already applies to `this.prop = value` inside a **constructor** body for instance members. tsz implemented the constructor-body case (`crates/tsz-checker/src/types/class_type/instance.rs`'s `CONSTRUCTOR` arm calling `collect_js_constructor_this_properties`) but never implemented the static-block case: the static-side type builder's member loop (`crates/tsz-checker/src/types/class_type/constructor.rs`) had no `CLASS_STATIC_BLOCK_DECLARATION` match arm at all, so a static block's body was silently skipped by the catch-all `_ => {}`. A later read of the assigned member (e.g. `Thing.doSomething()`) then spuriously reported TS2339.

This is the conformance false positive in `javascriptThisAssignmentInStaticBlock.ts`, found via `query-conformance.py --extra-code TS2339` (expected 0 diagnostics, tsz emitted 1x TS2339).

## Fix (owner: checker, `crates/tsz-checker/src/types/class_type/{constructor,js_class_properties}.rs`)

Added `collect_js_static_block_this_properties` in `js_class_properties.rs`, which checks the class's *own* file (not the currently-processed file, so a TS file referencing a JS class still sees the implicit members — mirroring the existing constructor-side check) and reuses the existing `collect_js_constructor_this_properties` scanner against the static block's body (static blocks are already a valid `get_block` target: `[BLOCK, CLASS_STATIC_BLOCK_DECLARATION, CASE_BLOCK]`). Wired into `constructor.rs`'s static-member loop as a new `CLASS_STATIC_BLOCK_DECLARATION` arm.

Kept the new logic in `js_class_properties.rs` rather than inline in `constructor.rs` because `constructor.rs` is already at its `arch_guard` size-ratchet ceiling (1981 lines); the one-line match arm this adds required a 1-line ratchet bump (1981→1982), documented in `scripts/arch/arch_guard_file_limits.py`.

## Adjacent-case matrix (8 new tests, `crates/tsz-checker/tests/js_static_block_this_property_tests.rs`)

| case | before | after |
| --- | --- | --- |
| basic static-block `this.prop=` then `Class.prop` read | TS2339 | clean |
| renamed class/property binders | TS2339 | clean |
| multiple `this.prop=` statements in one static block | TS2339 | clean |
| two separate static blocks, each contributing members | TS2339 | clean |
| derived class (`extends Base`) static block | TS2339 | clean |
| static block assignment to an already-declared static property | n/a | clean (explicit declaration still wins, no regression) |
| genuinely absent member (negative control) | TS2339 | TS2339 (unchanged — not a blanket suppression) |
| same shape in a `.ts` file (negative control — JS-only special case) | TS2339 | TS2339 (unchanged — no leak into TS files) |

## Verification

- `cargo test -p tsz-checker --test js_static_block_this_property_tests`: 8/8 new tests pass.
- `cargo test -p tsz-checker --lib class` / `static` / `constructor`: 994 / 161 / 252 passed, 0 failed (no regressions).
- `cargo test -p tsz-checker --test js_constructor_property_tests` / `js_constructor_property_more_tests`: 41/41, 45/45 pass (instance-side reference behavior unchanged).
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- `python3 scripts/arch/arch_guard.py`: passes (after the 1-line ratchet bump).
- Targeted fixture: built `tsz --noEmit --target es2015 --strict false --allowJs true --checkJs true` against the real `javascriptThisAssignmentInStaticBlock.ts` repro — exit 0 (was exit 1, TS2339).
- Conformance/emit/fourslash: not run locally this session (test-and-checker-only diff scoped to the JS static-block path); relying on CI's nightly/dispatch lanes per the per-merge lane being clippy + arch-size only.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6ds5SspV2rnDDmdgMLRQi)_