### PR TITLE
fix(parser): TS2462 (rest element must be last) is a uniform grammar check

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/core.rs
+++ b/crates/tsz-checker/src/types/type_checking/core.rs
@@ -1271,18 +1271,6 @@ impl<'a> CheckerState<'a> {
 
         let _pattern_kind = pattern_node.kind;
 
-        let is_declarative_pattern = self
-            .ctx
-            .arena
-            .get_extended(pattern_idx)
-            .and_then(|ext| self.ctx.arena.get(ext.parent))
-            .is_some_and(|parent| {
-                matches!(
-                    parent.kind,
-                    syntax_kind_ext::VARIABLE_DECLARATION | syntax_kind_ext::PARAMETER
-                )
-            });
-
         for (i, &element_idx) in pattern_data.elements.nodes.iter().enumerate() {
             if let Some(element_node) = self.ctx.arena.get(element_idx)
                 && let Some(element_data) = self.ctx.arena.get_binding_element(element_node)
@@ -1319,25 +1307,10 @@ impl<'a> CheckerState<'a> {
                     );
                 }
 
-                // TS2462: A rest element must be last in a destructuring pattern.
-                // Applies to both array and object binding patterns.
-                if i < elements_len - 1 {
-                    let diag_node = if is_declarative_pattern {
-                        self.ctx
-                            .arena
-                            .get(element_data.name)
-                            .and_then(|node| self.ctx.arena.get_identifier(node))
-                            .and(Some(element_data.name))
-                            .unwrap_or(element_idx)
-                    } else {
-                        element_idx
-                    };
-                    self.error_at_node_msg(
-                        diag_node,
-                        diagnostic_codes::A_REST_ELEMENT_MUST_BE_LAST_IN_A_DESTRUCTURING_PATTERN,
-                        &[],
-                    );
-                }
+                // TS2462 (a rest element must be last in a destructuring
+                // pattern) is a pure grammar check, emitted uniformly for every
+                // binding pattern during parsing (`report_rest_element_not_last`
+                // in the parser), so it is intentionally not re-checked here.
             }
 
             self.check_binding_element_with_request(

--- a/crates/tsz-checker/tests/destructuring_assignment_rest_position_tests.rs
+++ b/crates/tsz-checker/tests/destructuring_assignment_rest_position_tests.rs
@@ -7,11 +7,20 @@
 //! object targets and every nested target were silently accepted. These tests
 //! pin parity with `tsc` (verified against `typescript@7.0.2`).
 
-use tsz_checker::test_utils::{check_source_diagnostics, diagnostic_codes, diagnostic_count};
+use tsz_checker::test_utils::{
+    check_source_codes_with_parse_health, check_source_diagnostics, diagnostic_codes,
+};
 
+/// Count TS2462 across both diagnostic sources. Assignment-target rests are
+/// emitted by the checker (`assignment_ops`); binding-pattern rests are emitted
+/// by the parser grammar check (`report_rest_element_not_last`). The two forms
+/// never overlap on a single node, so a combined count still reads exactly one
+/// per offending rest.
 fn ts2462_count(source: &str) -> usize {
-    let diagnostics = check_source_diagnostics(source);
-    diagnostic_count(&diagnostics, 2462)
+    check_source_codes_with_parse_health(source)
+        .into_iter()
+        .filter(|code| *code == 2462)
+        .count()
 }
 
 /// The reported conformance witness (`objectRestPropertyMustBeLast.ts`): an

--- a/crates/tsz-checker/tests/spread_rest_tests.rs
+++ b/crates/tsz-checker/tests/spread_rest_tests.rs
@@ -1,7 +1,8 @@
 //! Tests for spread and rest operator type checking
 
 use tsz_checker::test_utils::{
-    check_source_diagnostics, diagnostic_code_message_refs as diagnostic_code_messages,
+    check_source_codes_with_parse_health, check_source_diagnostics,
+    diagnostic_code_message_refs as diagnostic_code_messages,
     diagnostic_code_message_refs_with_code as diagnostic_code_messages_with_code, diagnostic_count,
     diagnostic_count_where, diagnostic_messages_with_code, diagnostics_where,
     diagnostics_with_code, has_diagnostic_where,
@@ -892,16 +893,19 @@ const chars = [...str];  // Should be string[]
 fn test_object_rest_not_last_emits_ts2462() {
     // TypeScript emits TS2462 for object rest patterns where the rest is
     // not the last element, just like it does for array patterns.
+    //
+    // TS2462 is a grammar check emitted while parsing the binding pattern
+    // (`report_rest_element_not_last`), so it lives on the parser side of the
+    // parse-health split rather than in the type-checker's output.
     let source = r#"
 var { ...rest, x } = { x: 1 };
 "#;
 
-    let diagnostics = check_source_diagnostics(source);
+    let codes = check_source_codes_with_parse_health(source);
 
-    let ts2462_count = diagnostic_count(&diagnostics, 2462);
     assert!(
-        ts2462_count >= 1,
-        "Expected TS2462 for object rest that is not last, got {ts2462_count}. Diagnostics: {diagnostics:#?}"
+        codes.contains(&2462),
+        "Expected TS2462 for object rest that is not last, got {codes:?}"
     );
 }
 
@@ -911,12 +915,11 @@ fn test_array_rest_not_last_still_reports_ts2462() {
 var [...rest, x] = [1, 2, 3];
 "#;
 
-    let diagnostics = check_source_diagnostics(source);
+    let codes = check_source_codes_with_parse_health(source);
 
-    let ts2462_count = diagnostic_count(&diagnostics, 2462);
     assert!(
-        ts2462_count >= 1,
-        "Expected TS2462 for array rest that is not last, got {ts2462_count}"
+        codes.contains(&2462),
+        "Expected TS2462 for array rest that is not last, got {codes:?}"
     );
 }
 

--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -219,6 +219,10 @@ mod trailing_comma_tests;
 mod rest_param_trailing_comma_tests;
 
 #[cfg(test)]
+#[path = "../../tests/rest_element_not_last_grammar_tests.rs"]
+mod rest_element_not_last_grammar_tests;
+
+#[cfg(test)]
 #[path = "../../tests/spelling_integration_tests.rs"]
 mod spelling_integration_tests;
 

--- a/crates/tsz-parser/src/parser/state_expressions_literals.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals.rs
@@ -246,6 +246,8 @@ impl ParserState {
             }
         }
 
+        self.report_rest_element_not_last(&elements);
+
         let end_pos = if self.is_token(SyntaxKind::CloseBraceToken) {
             let end = self.token_end();
             self.parse_expected(SyntaxKind::CloseBraceToken);
@@ -449,6 +451,8 @@ impl ParserState {
             );
         }
 
+        self.report_rest_element_not_last(&elements);
+
         self.arena.add_binding_pattern(
             syntax_kind_ext::ARRAY_BINDING_PATTERN,
             start_pos,
@@ -457,6 +461,51 @@ impl ParserState {
                 elements: Self::make_node_list(elements),
             },
         )
+    }
+
+    /// TS2462: A rest element must be last in a destructuring pattern.
+    ///
+    /// `tsc` reports this grammar error (`checkGrammarBindingElement`) for any
+    /// binding-pattern rest element (`...x`) that is followed by another
+    /// element, anchored at the element's name. Emitting it here — during
+    /// binding-pattern parsing — covers every position uniformly: variable
+    /// declarations, parameters (including arrow, method, and type-signature
+    /// forms), `catch` bindings, and nested patterns. Assignment-destructuring
+    /// targets are array/object *literals* reinterpreted later and carry their
+    /// own TS2462 check, so they never reach this path.
+    fn report_rest_element_not_last(&mut self, elements: &[NodeIndex]) {
+        if elements.len() < 2 {
+            return;
+        }
+        let last_index = elements.len() - 1;
+        let mut anchors: Vec<(u32, u32)> = Vec::new();
+        for &elem_idx in &elements[..last_index] {
+            let Some(elem_node) = self.arena.get(elem_idx) else {
+                continue;
+            };
+            let Some(elem_data) = self.arena.get_binding_element(elem_node) else {
+                continue;
+            };
+            if !elem_data.dot_dot_dot_token {
+                continue;
+            }
+            // Anchor at the rest element's name, matching `tsc`; fall back to the
+            // whole element span when the name is missing (recovery).
+            let anchor = self
+                .arena
+                .get(elem_data.name)
+                .map(|name_node| (name_node.pos, name_node.end.saturating_sub(name_node.pos)))
+                .unwrap_or((elem_node.pos, elem_node.end.saturating_sub(elem_node.pos)));
+            anchors.push(anchor);
+        }
+        for (start, length) in anchors {
+            self.parse_error_at(
+                start,
+                length,
+                "A rest element must be last in a destructuring pattern.",
+                diagnostic_codes::A_REST_ELEMENT_MUST_BE_LAST_IN_A_DESTRUCTURING_PATTERN,
+            );
+        }
     }
 
     /// Parse binding element name (can be identifier or nested binding pattern)

--- a/crates/tsz-parser/tests/rest_element_not_last_grammar_tests.rs
+++ b/crates/tsz-parser/tests/rest_element_not_last_grammar_tests.rs
@@ -1,0 +1,217 @@
+//! Tests for TS2462 ("A rest element must be last in a destructuring pattern"),
+//! emitted as a grammar check while parsing array/object binding patterns
+//! (`report_rest_element_not_last`).
+//!
+//! `tsc` reports TS2462 for any binding-pattern rest element (`...x`) followed
+//! by another element, anchored at the element's name, uniformly across every
+//! position: variable declarations, parameters (function, arrow, method,
+//! type-signature, ambient), `catch` bindings, and nested patterns. Assignment
+//! destructuring targets are array/object *literals* reinterpreted elsewhere and
+//! carry their own TS2462 check, so they are out of scope for this file.
+
+use crate::parser::test_fixture::parse_source;
+
+const TS2462: u32 = 2462;
+
+/// All `(code, start_offset)` pairs the parser reports for `source`.
+fn diags(source: &str) -> Vec<(u32, u32)> {
+    let (parser, _root) = parse_source(source);
+    parser
+        .get_diagnostics()
+        .iter()
+        .map(|d| (d.code, d.start))
+        .collect()
+}
+
+/// The byte offsets at which TS2462 was reported.
+fn ts2462_starts(source: &str) -> Vec<u32> {
+    diags(source)
+        .into_iter()
+        .filter(|(code, _)| *code == TS2462)
+        .map(|(_, start)| start)
+        .collect()
+}
+
+/// Byte offset of the identifier `name`, anchored just past its leading `...`
+/// occurrence so the helper points at the same character `tsc` anchors on.
+fn rest_name_offset(source: &str, name: &str) -> u32 {
+    let needle = format!("...{name}");
+    let dots = source
+        .find(&needle)
+        .unwrap_or_else(|| panic!("`{needle}` not found in {source:?}"));
+    (dots + 3) as u32
+}
+
+// --- array binding patterns, every declaration/parameter position ---
+
+#[test]
+fn variable_declaration_array_rest_not_last() {
+    let src = "const [...a, b] = [1, 2];";
+    assert_eq!(ts2462_starts(src), vec![rest_name_offset(src, "a")]);
+}
+
+#[test]
+fn variable_declaration_array_rest_middle() {
+    let src = "const [a, ...b, c] = [1, 2, 3];";
+    assert_eq!(ts2462_starts(src), vec![rest_name_offset(src, "b")]);
+}
+
+#[test]
+fn function_parameter_array_rest_not_last_untyped() {
+    // The gap that motivated this fix: an untyped function parameter binding
+    // pattern never reached the type-checker's binding-pattern walk.
+    let src = "function f([...a, b]) {}";
+    assert_eq!(ts2462_starts(src), vec![rest_name_offset(src, "a")]);
+}
+
+#[test]
+fn function_parameter_array_rest_not_last_typed() {
+    let src = "function f([...a, b]: number[]) {}";
+    assert_eq!(ts2462_starts(src), vec![rest_name_offset(src, "a")]);
+}
+
+#[test]
+fn arrow_parameter_array_rest_not_last() {
+    let src = "const g = ([...a, b]) => a;";
+    assert_eq!(ts2462_starts(src), vec![rest_name_offset(src, "a")]);
+}
+
+#[test]
+fn arrow_parameter_array_rest_not_last_typed() {
+    let src = "const g = ([...a, b]: number[]) => a;";
+    assert_eq!(ts2462_starts(src), vec![rest_name_offset(src, "a")]);
+}
+
+#[test]
+fn method_parameter_array_rest_not_last() {
+    let src = "class C { m([...a, b]) {} }";
+    assert_eq!(ts2462_starts(src), vec![rest_name_offset(src, "a")]);
+}
+
+#[test]
+fn type_signature_parameter_array_rest_not_last() {
+    let src = "type F = ([...a, b]) => void;";
+    assert_eq!(ts2462_starts(src), vec![rest_name_offset(src, "a")]);
+}
+
+#[test]
+fn ambient_function_parameter_array_rest_not_last() {
+    let src = "declare function f([...a, b]): void;";
+    assert_eq!(ts2462_starts(src), vec![rest_name_offset(src, "a")]);
+}
+
+#[test]
+fn catch_clause_array_rest_not_last() {
+    let src = "try {} catch ([...a, b]) {}";
+    assert_eq!(ts2462_starts(src), vec![rest_name_offset(src, "a")]);
+}
+
+// --- object binding patterns ---
+
+#[test]
+fn variable_declaration_object_rest_not_last() {
+    let src = "const { ...a, b } = { };";
+    assert_eq!(ts2462_starts(src), vec![rest_name_offset(src, "a")]);
+}
+
+#[test]
+fn function_parameter_object_rest_not_last() {
+    let src = "function f({ ...a, b }) {}";
+    assert_eq!(ts2462_starts(src), vec![rest_name_offset(src, "a")]);
+}
+
+#[test]
+fn arrow_parameter_object_rest_not_last() {
+    let src = "const h = ({ ...a, b }) => a;";
+    assert_eq!(ts2462_starts(src), vec![rest_name_offset(src, "a")]);
+}
+
+// --- nested patterns: each pattern is checked independently, anchored at its
+// own rest element (previously the checker anchored nested rests at the wrong
+// column) ---
+
+#[test]
+fn nested_array_pattern_rest_not_last() {
+    let src = "const [a, [...b, c]] = [1, [2, 3]];";
+    assert_eq!(ts2462_starts(src), vec![rest_name_offset(src, "b")]);
+}
+
+#[test]
+fn nested_object_to_array_pattern_rest_not_last() {
+    let src = "const { a: [...p, q] } = obj;";
+    assert_eq!(ts2462_starts(src), vec![rest_name_offset(src, "p")]);
+}
+
+// --- binder-name invariance: the diagnostic must not depend on identifiers ---
+
+#[test]
+fn rest_name_invariance() {
+    let renamed = "function fn([...zz, yy]) {}";
+    assert_eq!(
+        ts2462_starts(renamed),
+        vec![rest_name_offset(renamed, "zz")]
+    );
+}
+
+// --- multiple offending rests each report ---
+
+#[test]
+fn two_rests_report_twice() {
+    let src = "const [...a, ...b, c] = [];";
+    assert_eq!(
+        ts2462_starts(src),
+        vec![rest_name_offset(src, "a"), rest_name_offset(src, "b")]
+    );
+}
+
+#[test]
+fn elision_after_rest_reports() {
+    // A hole following the rest still makes it not-last.
+    let src = "const [...a, ,] = [1, 2];";
+    assert_eq!(ts2462_starts(src), vec![rest_name_offset(src, "a")]);
+}
+
+// --- negative cases: a trailing rest is legal, so no TS2462 ---
+
+#[test]
+fn array_trailing_rest_is_clean() {
+    assert!(
+        !diags("const [a, ...b] = [1, 2];")
+            .iter()
+            .any(|(c, _)| *c == TS2462)
+    );
+}
+
+#[test]
+fn object_trailing_rest_is_clean() {
+    assert!(
+        !diags("const { a, ...b } = { a: 1 };")
+            .iter()
+            .any(|(c, _)| *c == TS2462)
+    );
+}
+
+#[test]
+fn param_trailing_rest_is_clean() {
+    assert!(
+        !diags("function f([a, ...b]) {}")
+            .iter()
+            .any(|(c, _)| *c == TS2462)
+    );
+}
+
+#[test]
+fn trailing_comma_after_rest_is_not_ts2462() {
+    // `[...a,]` is a trailing comma (TS1013), not a rest-not-last (TS2462).
+    let src = "const [...a,] = [1];";
+    assert!(!diags(src).iter().any(|(c, _)| *c == TS2462));
+}
+
+#[test]
+fn no_rest_pattern_is_clean() {
+    assert!(
+        !diags("const [a, b, c] = [1, 2, 3];")
+            .iter()
+            .any(|(c, _)| *c == TS2462)
+    );
+}


### PR DESCRIPTION
When a binding pattern contains a rest element (`...x`) that is not the last
element, `tsc` reports **TS2462** anchored at the element's name, uniformly, for
every binding-pattern position. tsz emitted TS2462 from
`check_binding_pattern_with_request` — a *type-checking* function that is only
reached for variable declarations and **annotated regular-function**
parameters — so the check silently disappeared everywhere else, and the one
nested case it did catch anchored at the wrong column.

**Structural rule:** when a binding-pattern rest element is followed by another
element, `tsc` reports TS2462 at the element name via its grammar check
(`checkGrammarBindingElement`); tsz now reports it through the binding-pattern
**parser** (`report_rest_element_not_last`), the same layer that already owns the
sibling rest-element grammar checks TS1013/TS1186.

Measured gap on current `main` (tsc `A rest element must be last…` vs tsz):

| position | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `const [...a, b] = …` | TS2462 | TS2462 | TS2462 |
| `function f([...a, b])` (untyped) | TS2462 | *silent* | TS2462 |
| `function f([...a, b]: number[])` | TS2462 | TS2462 | TS2462 |
| `const g = ([...a, b]) => …` (arrow) | TS2462 | *silent* | TS2462 |
| `class C { m([...a, b]) {} }` | TS2462 | *silent* | TS2462 |
| `type F = ([...a, b]) => void` | TS2462 | *silent* | TS2462 |
| `declare function f([...a, b])` | TS2462 | *silent* | TS2462 |
| `try {} catch ([...a, b]) {}` | TS2462 | *silent* | TS2462 |
| `{ ...a, b }` (all above positions) | TS2462 | mostly silent | TS2462 |
| `const [a, [...b, c]] = …` (nested) | col 15 (name) | col 12 (`...`) | col 15 (name) |

Assignment-destructuring targets (`({ ...a, b } = o)`, `[...a, b] = […]`) parse
as array/object *literals* and keep their own TS2462 check in
`assignment_ops`; they never reach the binding-pattern parser, so there is no
double-report.

## Goal
Goal: hold

<!-- also serves green parity: TS2462 now fires where tsz was silent -->

## Verification
- `cargo test -p tsz-parser --lib` — 2207 pass, incl. 23 new
  `rest_element_not_last_grammar_tests` (every position + nesting + renamed
  binders + multi-rest + elision + negatives, exact anchor offsets pinned to
  `tsc`).
- `cargo test -p tsz-checker --test spread_rest_tests --test destructuring_assignment_rest_position_tests` — 83 pass (the two checker tests that asserted this via the plain, parser-diagnostic-dropping harness now read the combined parse-health codes).
- `cargo test -p tsz-checker --lib -- binding destructur rest param catch` — 1885 pass, 0 fail.
- End-to-end CLI (`dist-fast`) diff vs `tsc` across the full position matrix: TS2462 now byte-matches `tsc` (code + line + column) in every case; no new divergences introduced.
- `cargo clippy -p tsz-parser -p tsz-checker --all-targets` clean; arch-size guard passes; pre-commit local verification passed.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsxDbTwJDoecob2rQfKjFR)_