### PR TITLE
fix(cli): TS2462 joins is_parser_grammar_code after #16989 moved it to the parser

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils/parser_grammar_code.rs
+++ b/crates/tsz-cli/src/driver/check_utils/parser_grammar_code.rs
@@ -178,6 +178,20 @@ pub(super) const fn is_parser_grammar_code(code: u32) -> bool {
              // that is a `CheckerDiagnostic`, never a `ParseDiagnostic`, so it
              // never reaches this filter and is unaffected by this entry.
         | 1014 // A rest parameter must be last in a parameter list
+        | 2462 // A rest element must be last in a destructuring pattern. tsc's
+               // checkGrammarBindingElement reports this from the checker;
+               // #16989 moved tsz's binding-pattern check into the parser
+               // (report_rest_element_not_last) to cover every binding-pattern
+               // position uniformly, which made it a ParseDiagnostic and so
+               // subject to this filter. Unlisted it behaved as a real parse
+               // error: it survived alongside a genuine syntax error (tsc drops
+               // it), and it deleted listed siblings — a file with both a
+               // misplaced binding-pattern rest and a misplaced rest parameter
+               // lost its TS1014 entirely. Sibling of TS1014 in both tsc's
+               // grammar family and this list. The distinct checker-emitted
+               // site for destructuring-*assignment* targets (#16966,
+               // assignment_ops.rs) is a CheckerDiagnostic, never a
+               // ParseDiagnostic, so it never reaches this filter.
         | 1017 // An index signature cannot have a rest parameter
         | 1018 // An index signature parameter cannot have an accessibility modifier
         | 1101 // 'with' statements are not allowed in strict mode. tsc's


### PR DESCRIPTION
#16989 moved the binding-pattern rest-element check into the parser
(`report_rest_element_not_last`) so it covers every binding-pattern position
uniformly — a real coverage win — but did not add TS2462 to
`is_parser_grammar_code`. An unlisted parser-emitted grammar code is treated as
a real parse error by the filter's `has_non_grammar_parse_error` complement,
which reintroduces both halves of the #16279 self-suppression defect that #16981
had just fixed for TS18007.

Both reproduce on main (`b703eb626c`) and both are correct at `4a50f1e7eb`,
i.e. this is a regression, not a pre-existing gap:

| fixture | tsc 7.0.2 | main | with this fix |
| --- | --- | --- | --- |
| `const [...a, b] = z;` + `let zzz: = 1;` | TS1110 | TS1110, **TS2462** | TS1110 |
| `const [...a, b] = z;` + `function f(...r: any[], q: number) {}` | TS1014, TS2462 | **TS2462 only** | TS1014, TS2462 |
| `const [...a, b] = z;` alone | TS2462 | TS2462 | TS2462 |
| `function g({ p: [...a, b] }: any) {}` (#16989's win) | TS2462 | TS2462 | TS2462 |
| `const [a, ...b] = z;` (control) | clean | clean | clean |

Row 2 is the one that matters: it is a *lost* diagnostic. After #16989, a file
containing both a misplaced binding-pattern rest and a misplaced rest parameter
silently drops its TS1014, so tsz accepts a rest-parameter-not-last that tsc
rejects. It is invisible to a code-set probe scoped to TS2462, because the row
that moves is TS1014.

TS2462 is the direct sibling of the already-listed TS1014 — same tsc grammar
family (`checkGrammarBindingElement` / `checkGrammarParameterList`), same
checker-in-tsc / parser-in-tsz split that defines this list's membership.

## Goal
Goal: hold

## Verification
- 5-row oracle matrix above against pinned `typescript@7.0.2` — 5/5 match after the fix (2/5 diverged on main)
- #16966's 14-row TS2462 matrix (5 assignment-target error rows + 9 value-context negative controls) — 14/14, exactly one TS2462 per error row, no double-report between the parser and checker owners

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high