### PR TITLE
fix(checker): JS expando `this` write suppression predates #16978's assignment-receiver `this`

### DIFF
--- a/crates/tsz-checker/src/types/property_access_type/identifier_resolution.rs
+++ b/crates/tsz-checker/src/types/property_access_type/identifier_resolution.rs
@@ -1536,9 +1536,23 @@ impl<'a> CheckerState<'a> {
                             access.expression,
                             property_name,
                         );
+                    // A function expression assigned as the RHS of a property/
+                    // element write (`o.m = function () { this.q = 1; }`) gets a
+                    // real contextual `this` from the assignment's base object
+                    // (#16964/#16978) — tsc checks writes against that base type
+                    // (TS2339 for an absent member) instead of treating them as
+                    // loose JS expando writes. This predates that mechanism and
+                    // otherwise blanket-suppresses every JS `this`-write; carve
+                    // out the assignment-receiver shape specifically so the
+                    // narrower JSDoc-`@this`/`this:`-parameter void-zero carve-out
+                    // below is untouched.
+                    let this_is_property_assignment_receiver = self
+                        .enclosing_function_assignment_rhs_this_type(access.expression)
+                        .is_some();
                     if !(has_jsdoc_this_context
                         || (object_literal_owned_this && !prototype_object_literal_expando_write)
-                        || (has_explicit_this_context && this_direct_write_rhs_is_void_zero))
+                        || (has_explicit_this_context && this_direct_write_rhs_is_void_zero)
+                        || this_is_property_assignment_receiver)
                     {
                         return TypeId::ANY;
                     }

--- a/crates/tsz-checker/tests/ts2683_tests.rs
+++ b/crates/tsz-checker/tests/ts2683_tests.rs
@@ -619,6 +619,84 @@ declare const key: string;
     );
 }
 
+// #16964 residual: the JS/checkJs expando-receiver path for property-
+// assignment `this` (`const o = {}; o.m = function () { this.q = 1; };`)
+// stayed silent after #16978 fixed the `.ts` shape, because a JS-only
+// blanket "dynamic property write on `this`" suppression in
+// `identifier_resolution.rs` predates #16978's assignment-receiver `this`
+// mechanism and doesn't know about it — it unconditionally returned `any`
+// for any direct `this.prop =` write in a JS file unless the write's RHS
+// was `void 0`, even when `this` already had a real, structurally-checked
+// receiver type from the property-assignment rule.
+
+#[test]
+fn js_expando_property_assignment_this_is_base_object_type_ts2339() {
+    let src = r#"
+const o = {};
+o.m = function () {
+    this.q = 1;
+};
+"#;
+    let diags = get_js_diagnostics(src);
+    assert!(
+        diags.iter().any(|d| d.0 == 2339),
+        "Expected TS2339 for a missing member on the base object's type, got: {diags:?}"
+    );
+    assert!(
+        !diags.iter().any(|d| d.0 == 2683),
+        "This is a resolved contextual `this`, not implicit `any` — TS2683 must not fire, got: {diags:?}"
+    );
+}
+
+#[test]
+fn js_expando_property_assignment_this_is_nominal_base_type_ts2339() {
+    let src = r#"
+/** @type {{bar: any}} */
+var foo;
+foo.bar = function () {
+    this.q = 1;
+};
+"#;
+    let diags = get_js_diagnostics(src);
+    assert!(
+        diags.iter().any(|d| d.0 == 2339),
+        "Expected TS2339 against the base object's declared type, got: {diags:?}"
+    );
+}
+
+#[test]
+fn js_expando_property_assignment_this_member_present_no_error() {
+    let src = r#"
+const o = { q: 0 };
+o.m = function () {
+    this.q = 1;
+};
+"#;
+    let diags = get_js_diagnostics(src);
+    assert!(
+        diags.is_empty(),
+        "Expected a clean check when the base type already declares the accessed member, got: {diags:?}"
+    );
+}
+
+#[test]
+fn js_bare_function_this_property_assignment_still_ts2683() {
+    // Adjacent negative case: a plain (not property-assigned) JS function
+    // still gets implicit-any `this` — TypeScript 7 no longer synthesizes a
+    // constructor-style `this` from `this.prop =` assignments in its own
+    // body, so this is unaffected by the property-assignment-receiver fix.
+    let src = r#"
+function plain() {
+    this.q = 1;
+}
+"#;
+    let diags = get_js_diagnostics(src);
+    assert!(
+        diags.iter().any(|d| d.0 == 2683),
+        "Expected TS2683 for a plain JS function's own `this.prop=` body, got: {diags:?}"
+    );
+}
+
 #[test]
 fn bare_identifier_reassignment_still_emits_ts2683() {
     // A bare-identifier reassignment (`f = function () {...}`, no base


### PR DESCRIPTION
Fixes the residual scope of #16964 left open by #16978: the JS/checkJs expando-receiver path for property-assignment `this` writes.

`o.m = function () { this.q = 1; };` in a JS/checkJs file stayed silent (no TS2339) even after #16978 gave the function expression a real contextual `this` from the assignment's base object (`o`) — `.ts` files already got TS2339 correctly for this shape, but the JS path diverged.

**Root cause:** a JS-only blanket suppression in `identifier_resolution.rs` (predating #16978) unconditionally returns `any` for any direct `this.prop =` write in a JS file unless the RHS is `void 0` — a rule written for the old (TypeScript-7-removed) JS constructor-function `this` model, where `this` genuinely had no checkable receiver. It doesn't know about #16978's newer assignment-receiver `this`, which *does* have a real, structurally checked receiver type, so it silenced writes tsc actually flags.

**Structural rule:** when a function expression is the direct RHS of a property/element-access assignment in a JS file, `this` has a real contextual receiver type (the base object's type, per #16978), so tsc checks writes against it (TS2339 for an absent member) — it is not the loose "dynamic JS expando" case this suppression was written for.

**Owner layer:** checker property-access write-target resolution (`crates/tsz-checker/src/types/property_access_type/identifier_resolution.rs`). Fix carves out the property-assignment-receiver shape specifically, reusing `enclosing_function_assignment_rhs_this_type`'s existing structural check (from #16978) purely as a boolean predicate — so the narrower JSDoc-`@this`/`this:`-parameter void-zero carve-out beside it is untouched.

**Adjacent matrix** (new tests in `ts2683_tests.rs`):

| case | tsz after |
| --- | --- |
| `o.m = function(){ this.q=1 }` on `const o = {}` (JS) | TS2339 against `{}` (was silent) |
| `foo.bar = function(){ this.q=1 }` against a JSDoc-annotated nominal base missing `q` (JS) | TS2339 |
| same, base already declares `q` | clean |
| a plain (not property-assigned) JS function's own `this.prop=` body | still TS2683 (unaffected, negative control) |

**Remaining scope from #16964:** `exports.X =` / `module.exports.X =` (CommonJS `ExportsProperty` binder classification) is separate, larger scope and not attempted here — confirmed via `tsc_parity_jsdoc_ctor_fn_value_as_type_matrix`'s failure diff, which is byte-identical before/after this change.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts2683_tests` — 38/38 passed (4 new).
- `cargo test -p tsz-checker --lib this` — 391/391 passed, 0 regressions.
- `cargo test -p tsz-checker --lib expando` — 46/46 passed, 0 regressions.
- `cargo test -p tsz-checker --lib property_access` — 135/135 passed.
- `cargo test -p tsz-checker --lib ts2339` — 101/101 passed.
- `cargo clippy -p tsz-checker --lib -- -D warnings` — clean.
- `cargo fmt -p tsz-checker -- --check` — clean.
- `cargo test -p tsz-cli --test tsc_compat_tests tsc_parity_jsdoc_ctor_fn_value_as_type_matrix` — still fails (mechanism-2 `exports.X=` scope, unrelated TS2749 gaps), diff byte-identical before/after this change: confirmed no regression.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_01UqYvC4ZBwZoVcLB5GzFZFi)_