### PR TITLE
fix(checker): variable-bound circular self-recursion infers `any`, not `void` (#16987)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2802,3 +2802,6 @@ path = "tests/ts2369_source_order_anchor_tests.rs"
 [[test]]
 name = "ts7032_zero_parameter_setter_tests"
 path = "tests/ts7032_zero_parameter_setter_tests.rs"
+[[test]]
+name = "ts7023_self_recursive_var_reassigned_return_tests"
+path = "tests/ts7023_self_recursive_var_reassigned_return_tests.rs"

--- a/crates/tsz-checker/src/types/function_type_circular.rs
+++ b/crates/tsz-checker/src/types/function_type_circular.rs
@@ -109,6 +109,42 @@ impl<'a> CheckerState<'a> {
         sites.iter().all(|site| lazy.contains(site))
     }
 
+    /// Whether `function_idx` has been recorded as a *non-lazy* circular return
+    /// site for any resolving variable — the same condition that drives the
+    /// TS7023 emission (a genuine implicit-`any` circularity, not a benign
+    /// deferred self-reference like #10675). Used to resolve such a function's
+    /// inferred return type to the circular `any` rather than the degenerate
+    /// `void`/`never` that return aggregation produces once the direct self-call
+    /// return is dropped.
+    ///
+    /// This is what distinguishes a *variable-bound* self-recursive function
+    /// expression / arrow (`var f = function(n){ return f(n); }` — the variable
+    /// resolution is circular, so tsc's return type is `any`) from a *clean*
+    /// no-base-case recursion in a named function declaration
+    /// (`function f(n){ return f(n); }` → `never`): only the former is a
+    /// resolving *variable*, so only it is ever recorded here.
+    pub(crate) fn function_is_nonlazy_circular_return_site(&self, function_idx: NodeIndex) -> bool {
+        // Fast path for the overwhelming common case: no circular return sites are
+        // recorded at all (only variable-bound self-recursion mid-resolution ever
+        // populates this map), so a void/never return-type inference pays nothing.
+        if self.ctx.pending_circular_return_sites.sites.is_empty() {
+            return false;
+        }
+        self.ctx
+            .pending_circular_return_sites
+            .sites
+            .iter()
+            .any(|(sym_id, sites)| {
+                sites.contains(&function_idx)
+                    && !self
+                        .ctx
+                        .pending_circular_return_sites
+                        .lazy
+                        .get(sym_id)
+                        .is_some_and(|lazy| lazy.contains(&function_idx))
+            })
+    }
+
     pub(super) fn return_body_has_resolving_var_in_call_like(&self, body_idx: NodeIndex) -> bool {
         let resolving_vars: FxHashSet<_> = self
             .ctx

--- a/crates/tsz-checker/src/types/utilities/return_type.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type.rs
@@ -767,6 +767,27 @@ impl<'a> CheckerState<'a> {
         self.ctx.preserve_literal_types = prev_preserve_literals;
         self.ctx.preserve_logical_operand_literals = prev_preserve_logical;
 
+        // A *variable-bound* self-recursive function expression / arrow whose own
+        // binding is genuinely circular — recorded as a non-lazy circular return
+        // site, i.e. the exact condition that fires TS7023 — resolves its return
+        // type to the circular implicit-`any`, mirroring tsc's
+        // `getReturnTypeOfSignature`, which returns `anyType` when re-entered while
+        // the signature is still being computed. When the sole return expression is
+        // a direct self-call (`return f(name)`), return aggregation drops it and the
+        // body degenerates to `void` (fall-through default) or `never`; that
+        // degenerate value must not thread through to the call site (`d = f(1)`),
+        // where tsc sees `any` (#16987). This is distinct from the clean
+        // no-base-case recursion in a *named function declaration*
+        // (`function f(n){ return f(n); }` → `never`) handled below: that is not a
+        // resolving variable, so it is never recorded as a circular return site.
+        if return_context.is_none()
+            && (result == TypeId::VOID || result == TypeId::NEVER)
+            && self.function_is_nonlazy_circular_return_site(function_idx)
+        {
+            snap.rollback(&mut self.ctx.speculation_state());
+            return TypeId::ANY;
+        }
+
         // Direct self-recursive functions with no base case return `never`.
         // Example: `function fn2(n: number) { return fn2(n); }` → return type `never`.
         // When the inferred return type is `any` (from the circular provisional type)

--- a/crates/tsz-checker/tests/ts7023_self_recursive_var_reassigned_return_tests.rs
+++ b/crates/tsz-checker/tests/ts7023_self_recursive_var_reassigned_return_tests.rs
@@ -1,0 +1,161 @@
+//! Regression tests for #16987: a self-recursive function whose own binding is a
+//! genuinely circular *variable* (e.g. reassigned inside its own body) must infer
+//! return type `any` — matching `tsc`'s circular implicit-`any` (TS7023)
+//! resolution — rather than the degenerate `void` / `never` that return
+//! aggregation produces once the direct self-call return is dropped.
+//!
+//! The clean, no-base-case recursion in a *named function declaration*
+//! (`function f(n){ return f(n); }`) must continue to infer `never` (tsc parity,
+//! existing behavior). Both shapes are exercised so the discriminator cannot
+//! regress one to fix the other.
+//!
+//! Binder names are varied across cases (anti-hardcoding): the logic keys off the
+//! structural shape (variable-bound circular self-recursion vs. named-declaration
+//! clean recursion), never a specific identifier.
+
+use tsz_checker::test_utils::{
+    check_js_source_code_messages_with_options, check_js_source_codes_with_options,
+    non_strict_checker_options, strict_checker_options,
+};
+
+fn js_codes_non_strict(src: &str) -> Vec<u32> {
+    let mut codes =
+        check_js_source_codes_with_options(src, "test.js", non_strict_checker_options());
+    codes.sort_unstable();
+    codes
+}
+
+fn js_codes_strict(src: &str) -> Vec<u32> {
+    let mut codes = check_js_source_codes_with_options(src, "test.js", strict_checker_options());
+    codes.sort_unstable();
+    codes
+}
+
+// The reported witness (#16987): `fn2` is reassigned inside its own body, so its
+// resolution is circular and tsc infers `any` for the recursive return. That
+// makes `fn2(1)` and therefore `d` `any`, so `d.redefined()` is clean. Before the
+// fix tsz threaded `void` through and emitted a spurious
+// `TS2339: Property 'redefined' does not exist on type 'void'`.
+const REASSIGNED_WITNESS: &str = r#"
+var fn2 = function(name) {
+  fn2 = compose(this, 0, 1)
+  return fn2(name)
+
+  function compose(child, level, find) {
+    if (child === find) {
+      return level
+    }
+    return compose(child, level + 1, find)
+  }
+}
+
+var d = fn2(1);
+d.redefined();
+"#;
+
+#[test]
+fn var_reassigned_self_recursion_no_spurious_ts2339_non_strict() {
+    // Under `@strict: false` the only diagnostic tsz used to emit was the
+    // spurious TS2339; with the fix the file is clean.
+    let codes = js_codes_non_strict(REASSIGNED_WITNESS);
+    assert!(
+        !codes.contains(&2339),
+        "spurious TS2339 on `d.redefined()` — fn2's circular return type must be `any`, not `void`; got {codes:?}"
+    );
+}
+
+#[test]
+fn var_reassigned_self_recursion_detects_circularity_and_no_ts2339_strict() {
+    // Under strict, the circularity detector fires TS7023 (matching tsc) and,
+    // once the return type is `any`, the spurious TS2339 is gone.
+    let codes = js_codes_strict(REASSIGNED_WITNESS);
+    assert!(
+        codes.contains(&7023),
+        "expected TS7023 (implicit circular return) on fn2; got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2339),
+        "spurious TS2339 on `d.redefined()` — fn2's circular return type must be `any`, not `void`; got {codes:?}"
+    );
+}
+
+// A minimal variable-bound arrow self-recursion (no trailing declaration, no
+// reassignment) is still a genuinely circular *variable*, so tsc infers `any`
+// too. tsz distinctively emits TS2339 on property access of BOTH `void` and
+// `never` but never on `any`, so the absence of TS2339 on `r.anything()` proves
+// the return type is specifically `any`. This guards the broader fix, not just
+// the exact reported fixture.
+#[test]
+fn var_bound_arrow_self_recursion_infers_any_strict() {
+    let src = r#"
+const loop = () => loop();
+const r = loop();
+r.anything();
+"#;
+    let codes = js_codes_strict(src);
+    assert!(
+        !codes.contains(&2339),
+        "variable-bound circular self-recursion must infer `any` (no TS2339 on property access); got {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Adjacent case: clean no-base-case recursion in a named function declaration
+// must stay `never` (no regression). A named declaration is not a resolving
+// variable, so it is never recorded as a circular return site and keeps the
+// `never` path — and, being non-circular, emits no TS7023. This is exactly the
+// behavior #16987 requires must not regress while the reassigned case moves to
+// `any`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn clean_no_base_case_named_recursion_stays_never_not_void() {
+    // `function rec(n) { return rec(n); }` never terminates: tsz infers `never`
+    // (unchanged by this fix — a named declaration is not a resolving variable,
+    // so the circular-`any` override never applies). Property access on the
+    // result reports TS2339 anchored on `never` — crucially NOT `void`, which is
+    // the exact regression the reassigned-case fix guards against, and NOT `any`.
+    let src = r#"
+function rec(n) { return rec(n); }
+var x = rec(1);
+x.whatever();
+"#;
+    let messages =
+        check_js_source_code_messages_with_options(src, "test.js", strict_checker_options());
+    let ts2339 = messages.iter().find(|(code, _)| *code == 2339);
+    let (_, msg) = ts2339.unwrap_or_else(|| {
+        panic!(
+            "expected TS2339 on `x.whatever()` for a `never`-returning recursion; got {messages:?}"
+        )
+    });
+    assert!(
+        msg.contains("'never'"),
+        "named-declaration recursion must stay `never`, not `void`/`any`; got message: {msg:?}"
+    );
+    let codes: Vec<u32> = messages.iter().map(|(c, _)| *c).collect();
+    assert!(
+        !codes.contains(&7023),
+        "clean (named-declaration) recursion is not a circular variable; TS7023 must not fire; got {codes:?}"
+    );
+}
+
+#[test]
+fn recursion_with_base_case_infers_base_type_not_void() {
+    // A genuine base case decides the inferred return type; the direct self-call
+    // return is dropped from aggregation (tsc parity). The base returns a number,
+    // so `y` is `number` and `y.toFixed()` is clean.
+    let src = r#"
+function rec2(n) { if (n > 0) return 1; return rec2(n); }
+var y = rec2(1);
+y.toFixed();
+"#;
+    let codes = js_codes_strict(src);
+    assert!(
+        !codes.contains(&2339),
+        "base-case recursion must infer the base type (`number`), not `void`; got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&7023),
+        "recursion with a real base case is not circular; TS7023 must not fire; got {codes:?}"
+    );
+}


### PR DESCRIPTION
Fixes #16987.

## Structural rule

When a function's own binding is a **genuinely circular variable** — a
function-expression / arrow bound to a variable that is referenced (in callee
position) inside its own body while that variable is still resolving, i.e. the
exact condition that fires `TS7023` — `tsc`'s `getReturnTypeOfSignature`
resolves the return type to the circular implicit-`any` (`anyType` on
re-entry). tsz was instead threading a degenerate `void`/`never` to the call
site, producing a spurious `TS2339 … does not exist on type 'void'`.

> When a variable-bound self-recursive function is genuinely circular (a
> non-lazy recorded circular-return site), tsc's inferred return type is `any`;
> tsz now returns `any` through the checker's return-type inference
> (`infer_return_type_from_body`).

This is distinct from a **clean no-base-case recursion in a named function
declaration** (`function f(n){ return f(n); }` → `never`): a named declaration
is not a resolving *variable*, so it is never recorded as a circular return
site and keeps the existing `never` path unchanged.

## Root cause

`infer_return_type_from_body` (`crates/tsz-checker/src/types/utilities/return_type.rs`)
drops the direct self-call return from aggregation (mirroring tsc's
`checkAndAggregateReturnExpressionTypes`). For a self-recursive body whose only
return is that dropped self-call, aggregation degenerates:

- with a trailing statement that is not a return/throw (e.g. a hoisted
  `function` declaration after the `return`, as in the reported fixture), the
  cheap `may_not_fall_through` pre-check short-circuits `falls_through` to
  `true`, yielding **`void`**;
- otherwise it yields **`never`**.

The existing `result == ANY → NEVER` upgrade never fired because the aggregate
was `void`/`never`, not `any`. So the call site (`var d = fn2(1)`) saw `void`
and emitted the spurious `TS2339`.

## Fix (owner layer: checker return-type inference)

In `infer_return_type_from_body`, after computing `result`, when there is no
contextual return type and `result` degenerated to `void`/`never`, and the
function is a **non-lazy recorded circular return site**, return `TypeId::ANY`
— mirroring tsc's circular-signature `any`. The discriminator reuses the exact
state that drives `TS7023` (`pending_circular_return_sites` minus the `#10675`
lazy-deferred sites), via a new
`function_is_nonlazy_circular_return_site(function_idx)` query in
`function_type_circular.rs`. No new heuristic, no name/fixture matching.

Because the discriminator keys on *variable* circularity, the fix also
generalizes beyond the reported fixture: a minimal `const f = () => f()` (no
reassignment, no trailing declaration) now infers `any` too, matching tsc,
while named-declaration recursion stays `never`.

### Adjacent-case matrix (covered by the new regression test)

| shape | tsc / tsz after fix |
| --- | --- |
| `var f = function(n){ f = g(); return f(n); … }` (reported #16987) | `any` — no spurious TS2339 |
| `const f = () => f()` (variable-bound, no base case) | `any` |
| `function f(n){ return f(n) }` (named, no base case) | `never` (unchanged) |
| `function f(n){ if (n>0) return 1; return f(n) }` (base case) | base type (unchanged) |

tsz distinctively emits `TS2339` on property access of **both** `void` and
`never` but never on `any`, so the absence of `TS2339` on the witness proves
the return type is specifically `any` (not `never`).

## Goal
Goal: hold

## Verification
- New regression test (5 cases, binder names varied):
  `crates/tsz-checker/tests/ts7023_self_recursive_var_reassigned_return_tests.rs`
  — passes (`cargo test -p tsz-checker --test ts7023_self_recursive_var_reassigned_return_tests`).
- Focused internal suites pass: `cargo test -p tsz-checker --lib circular`
  (98/98) and `--lib recursi` (322/322) — the code paths this change touches.
- `cargo clippy -p tsz-checker --lib` — clean; pre-commit architecture guard
  passed.
- Release CLI on the #16987 witness: `@strict: false` → 0 diagnostics (was 1
  spurious `TS2339`); `@strict: true` → `TS7023`/`TS7006`/`TS2683` preserved,
  `TS2339` gone.
- Full conformance / emit / fourslash run in CI (nightly + PR lane).

## Provenance
Machine: cloud
Assistant: claude-code
Model: opus
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYZ9jY2yRRaRmm4AjkAcDA)_