### PR TITLE
fix(cli): TS1313 (empty if-body) was a stale mislabel, not a structural parse error

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1328,7 +1328,19 @@ pub(super) const fn is_real_syntax_error(code: u32) -> bool {
         // excluded. It is a grammar constraint error, not a structural parse failure.
         // The AST is fully valid — the import is parsed correctly. tsc still emits
         // semantic errors like TS2323 alongside TS1191.
-        | 1313 // 'else' is not allowed after rest element
+        //
+        // Note: TS1313 (The body of an 'if' statement cannot be the empty
+        // statement) is intentionally excluded (#16279 follow-up). It was
+        // previously listed here under an unrelated, non-existent message
+        // ("'else' is not allowed after rest element" is not a tsc diagnostic
+        // at all) — a stale mislabel, not a real classification decision. The
+        // `then_statement` AST node tsz emits it on
+        // (`state_declarations_exports.rs`) is a well-formed EMPTY_STATEMENT,
+        // not an error-recovery placeholder, and oracle-verified against
+        // `typescript@7.0.2`: `if (true); undeclaredName;` reports both
+        // TS1313 and TS2304 — TS1313 does not suppress cascading semantic
+        // diagnostics the way a genuine structural parse failure does. It now
+        // lives in `is_parser_grammar_code` instead.
         | 1351 // An identifier or keyword cannot immediately follow a numeric literal
         | 1357 // A default clause cannot appear more than once
         | 1378 // Top-level 'for await' loops are only allowed...
@@ -1402,7 +1414,8 @@ pub(super) const fn is_structural_parse_error(code: u32) -> bool {
         | 1161 // Unterminated regular expression literal
         | 1180 // Property destructuring pattern expected
         | 1185 // Merge conflict marker encountered
-        | 1313 // 'else' is not allowed after rest element
+        // TS1313 is intentionally excluded — see the matching note in
+        // `is_real_syntax_error` above. It moved to `is_parser_grammar_code`.
         | 1351 // An identifier or keyword cannot immediately follow a numeric literal
         | 1382 // Unexpected token in JSX
         | 1441 // Cannot start a function call in a type annotation

--- a/crates/tsz-cli/src/driver/check_utils/audit_round_3_grammar_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/audit_round_3_grammar_tests.rs
@@ -1,9 +1,13 @@
 //! Unit tests for #16279 audit round 3: two unrelated single-code families
 //! (TS1156, TS1358, TS18024 — see the doc comment on
 //! `is_parser_grammar_code` for the oracle-derived structural rule for each,
-//! including why the adjacent TS1313/TS2499/TS2427/TS2457/TS2819 candidates
-//! from the same scan were investigated and rejected). Split into its own
-//! file rather than growing `tests.rs` past the 2000-line limit (§19).
+//! including why the adjacent TS2499/TS2427/TS2457/TS2819 candidates from
+//! the same scan were investigated and rejected). Split into its own file
+//! rather than growing `tests.rs` past the 2000-line limit (§19).
+//!
+//! TS1313 was round 3's deferred candidate (self-suppression via a stale
+//! mislabel in `is_real_syntax_error`/`is_structural_parse_error`); its
+//! tests live below, fixed up for round 10's resolution of that trap.
 
 use super::*;
 
@@ -74,37 +78,49 @@ fn ts1156_survives_alone() {
     );
 }
 
-/// TS1313 must NOT be in `is_parser_grammar_code`, unlike its siblings above.
-/// It is already a member of `is_real_syntax_error`/`is_structural_parse_error`
-/// (see that doc comment), so the driver's `program_has_real_syntax_errors`
-/// becomes true from TS1313 alone; adding it here would make it suppress
-/// itself. This reproduces that interaction directly (passing
-/// `program_has_real_syntax_errors: true`, mirroring what the driver
-/// actually computes for a file whose only diagnostic is TS1313) so a future
-/// attempt to add 1313 to `is_parser_grammar_code` fails this test instead
-/// of silently regressing `if (true) ;` to report nothing.
+/// #16279 audit round 10: TS1313 is now IN `is_parser_grammar_code` — it was
+/// a stale mislabel (see the doc comment on `is_parser_grammar_code`) that
+/// wrongly classified it as a structural parse failure, not a deliberate
+/// exclusion. `program_has_real_syntax_errors` is `false` here because
+/// TS1313 is no longer a member of `is_real_syntax_error`, so this does not
+/// hit the self-suppression trap the old (inverted) version of this test
+/// guarded against — see `ts1313_alone_does_not_flag_program_has_real_syntax_errors`
+/// below for that half directly.
 #[test]
-fn ts1313_is_not_suppressed_and_must_stay_out_of_the_list() {
-    use tsz::parser::ParseDiagnostic;
+fn ts1313_suppressed_when_real_parse_error_present() {
+    assert_suppressed_by_real_parse_error(
+        1313,
+        "The body of an 'if' statement cannot be the empty statement.",
+    );
+}
 
-    let diagnostics = vec![ParseDiagnostic {
-        start: 20,
-        length: 6,
-        message: "The body of an 'if' statement cannot be the empty statement.".to_string(),
-        code: 1313,
-        related: None,
-    }];
+#[test]
+fn ts1313_survives_alone() {
+    assert_survives_alone(
+        1313,
+        "The body of an 'if' statement cannot be the empty statement.",
+    );
+}
 
-    // `true` mirrors `program_has_real_syntax_errors(program)` being true
-    // because TS1313 itself is (pre-existing) classified by
-    // `is_real_syntax_error`, independent of `is_parser_grammar_code`.
-    let filtered = filtered_parse_diagnostics(&diagnostics, true);
-    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+/// The other half of round 10's fix: TS1313 must not set
+/// `program_has_real_syntax_errors`, so a lone `if (true);` does not
+/// suppress unrelated cascading semantic diagnostics (tsc keeps both TS1313
+/// and TS2304 for `if (true); undeclaredName;` — oracle-verified against
+/// `typescript@7.0.2`). Before round 10, TS1313 was a member of
+/// `is_real_syntax_error`, which made this `false`.
+#[test]
+fn ts1313_alone_does_not_flag_program_has_real_syntax_errors() {
     assert!(
-        codes.contains(&1313),
-        "TS1313 must survive here — if this fails, TS1313 was added to \
-         is_parser_grammar_code and now self-suppresses via program_has_real_syntax_errors, \
-         got: {codes:?}"
+        !is_real_syntax_error(1313),
+        "TS1313 must not be a member of is_real_syntax_error — it is a \
+         checker-side grammar check on a well-formed AST, not a structural \
+         parse failure; tsc keeps cascading semantic diagnostics (e.g. \
+         TS2304) alongside it"
+    );
+    assert!(
+        !is_structural_parse_error(1313),
+        "TS1313 must not be a member of is_structural_parse_error, same \
+         reasoning as is_real_syntax_error above"
     );
 }
 

--- a/crates/tsz-cli/src/driver/check_utils/parser_grammar_code.rs
+++ b/crates/tsz-cli/src/driver/check_utils/parser_grammar_code.rs
@@ -88,22 +88,10 @@
 /// counted as a "real" non-grammar parse error and could silently delete an
 /// unrelated *listed* sibling (e.g. TS1091 itself) from the same file.
 ///
-/// Three adjacent candidates from the same scan were investigated and
+/// Two adjacent candidates from the same scan were investigated and
 /// deliberately left OUT of this round, each for a different reason —
-/// worth reading before extending this list, since none of the three
-/// failure modes is obvious from a synthetic-diagnostic unit test alone:
-/// - **TS1313** (`the body of an 'if' statement cannot be the empty
-///   statement`) is Direction-B-confirmed suppressible in isolation, but
-///   this exact code number is ALSO a pre-existing (mislabeled-comment)
-///   member of `is_real_syntax_error`/`is_structural_parse_error` below —
-///   so a file whose *only* diagnostic is TS1313 already counts as
-///   "the program has a real syntax error" through that other list, and
-///   adding TS1313 here made it suppress *itself*, confirmed as a real
-///   regression by rebuilding `tsz` and rerunning `if (true) ;` before and
-///   after (present on `main`, silently dropped with the naive fix). Fixing
-///   this needs auditing whether 1313 genuinely belongs in
-///   `is_real_syntax_error`/`is_structural_parse_error` first — left as a
-///   NOTE on the coordination board, not folded into this PR.
+/// worth reading before extending this list, since neither failure mode is
+/// obvious from a synthetic-diagnostic unit test alone:
 /// - **TS2499** (`an interface can only extend an identifier/qualified-name
 ///   with optional type arguments`) is Direction-B-confirmed suppressible,
 ///   but has a pre-existing, unrelated double-emission bug: both the parser
@@ -164,6 +152,24 @@
 /// alongside its five parser sites — the same double-emission shape that
 /// blocked TS2499 in round 3. Adding it here only patches the parser-emitted
 /// occurrences and needs the checker-side sites audited first, same caveat.
+///
+/// #16279 audit round 10: TS1313 (`the body of an 'if' statement cannot be
+/// the empty statement`, `state_declarations_exports.rs`) was round 3's
+/// deferred "adjacent candidate" — Direction-B-confirmed suppressible, but
+/// adding it here previously made it suppress *itself*, because it was
+/// simultaneously a member of `is_real_syntax_error`/`is_structural_parse_error`
+/// (`check_utils.rs`) under an unrelated, non-existent message ("'else' is
+/// not allowed after rest element" matches no tsc diagnostic anywhere in
+/// `crates/tsz-common/src/diagnostics`) — a stale mislabel, not a deliberate
+/// classification. The `then_statement` node TS1313 is reported on is a
+/// well-formed `EMPTY_STATEMENT`, not an error-recovery placeholder, so it
+/// was never a structural parse failure. Oracle-confirmed against
+/// `typescript@7.0.2`: `if (true);` alone reports TS1313 (Direction A);
+/// `if (true); let x: = 1;` drops TS1313 and keeps only the real error
+/// (Direction B); `if (true); undeclaredName;` reports BOTH TS1313 and
+/// TS2304 (TS1313 does not itself suppress cascading semantic diagnostics,
+/// unlike a genuine structural failure). Fix removed 1313 from the two
+/// structural-error lists and added it here instead.
 pub(super) const fn is_parser_grammar_code(code: u32) -> bool {
     matches!(
         code,
@@ -290,6 +296,7 @@ pub(super) const fn is_parser_grammar_code(code: u32) -> bool {
         | 1275 // 'accessor' modifier can only appear on a property declaration
         | 1276 // An 'accessor' property cannot be declared optional
         | 1156 // '{0}' declarations can only be declared inside a block
+        | 1313 // The body of an 'if' statement cannot be the empty statement
         | 1358 // Tagged template expressions are not permitted in an optional chain
         | 18024 // An enum member cannot be named with a private identifier
         | 18016 // Private identifiers are not allowed outside class bodies.


### PR DESCRIPTION
Part of #16279's general shape (`is_parser_grammar_code` self-suppression audit).

**Structural rule:** `tsc`'s `checkIfStatement` reports TS1313 ("The body of an 'if' statement cannot be the empty statement.") from the checker via `grammarErrorOnNode`, on an otherwise well-formed AST — tsc still reports cascading semantic diagnostics (e.g. TS2304) alongside it, and suppresses it when a real syntax error exists elsewhere in the file. tsz emits TS1313 from the parser instead (`state_declarations_exports.rs:846-855`), on a fully-formed `EMPTY_STATEMENT` `then_statement` node — not an error-recovery placeholder.

`is_real_syntax_error`/`is_structural_parse_error` (`check_utils.rs`) both listed 1313 under the comment `'else' is not allowed after rest element` — a message that does not exist anywhere in tsz's diagnostics table (grepped `crates/tsz-common/src/diagnostics`: no match). The canonical message for code 1313 is confirmed by `crates/tsz-common/src/diagnostics/data/parts/part_000.rs` to be the if-empty-body one. This was a stale mislabel, not a deliberate classification, and it caused exactly the self-suppression trap #16279's audit round 3 flagged: adding TS1313 to `is_parser_grammar_code` used to make it suppress *itself* (a lone TS1313 already counted as `program_has_real_syntax_errors`), so round 3 left it out and filed the follow-up as a TODO in that predicate's own doc comment.

**Fix (owner layer = CLI diagnostic-filter, `crates/tsz-cli/src/driver/check_utils.rs`):** move 1313 out of `is_real_syntax_error`/`is_structural_parse_error` and into `is_parser_grammar_code`, where it belongs alongside the rest of the #16279 audit's checker-grammar family. Replaced the now-inverted `ts1313_is_not_suppressed_and_must_stay_out_of_the_list` test with the correct-direction pair (`ts1313_suppressed_when_real_parse_error_present`, `ts1313_survives_alone`) plus a direct regression test on the two predicates (`ts1313_alone_does_not_flag_program_has_real_syntax_errors`).

**Adjacent cases:** oracle-verified against `typescript@7.0.2` in all three directions this predicate cares about:
- Direction A (isolated): `if (true);` reports TS1313 only.
- Direction B (suppressed by a real error): `if (true); let x: = 1;` drops TS1313 entirely, keeping only the real error.
- Direction C (does not itself suppress): `if (true); undeclaredName;` reports BOTH TS1313 and TS2304 — a genuine structural parse failure would have suppressed the TS2304.

End-to-end verified against a freshly built `dist-fast` `tsz` binary on all three fixtures — output now matches the pinned oracle exactly in every case (byte-for-byte diagnostic set).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-cli --lib check_utils`: 194/194 pass (includes 3 new/updated TS1313 tests).
- `cargo clippy --profile ci-lint -p tsz-cli --all-targets -- -D warnings`: clean.
- `cargo fmt --check -p tsz-cli`: clean.
- Pre-commit hook (clippy + architecture guard): passed.
- End-to-end: `.target/dist-fast/tsz` on the three oracle-pinned fixtures above, output identical to `typescript@7.0.2`.
- Diff confined to `crates/tsz-cli/src/driver/check_utils*` (no `crates/tsz-checker`/`crates/tsz-solver` production path). Grepped for `check_utils`/`filtered_parse_diagnostics`/`is_parser_grammar_code` usage outside `tsz-cli`: none — the conformance runner (`crates/conformance`) and `tsz-lsp`/`tsz-server` (fourslash) call `tsz-checker` directly and do not route through this CLI-only post-filter, so conformance/emit/fourslash counts are not expected to move.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9f147nsMqRPvLP7bpGWuE)_