### PR TITLE
fix(checker): reachability pre-gate skips trailing hoisted declarations

### DIFF
--- a/crates/tsz-checker/src/types/utilities/return_type.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type.rs
@@ -12,6 +12,22 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
+/// Whether a statement is control-flow-transparent as a function body's tail: a
+/// hoisted `function`, a type-erased `class`/`interface`/`type`/`enum`, or an
+/// empty statement. Such a trailing statement neither creates nor blocks a
+/// fall-through path, so `body_tail_may_terminate_control_flow` looks past it.
+const fn is_control_flow_transparent_tail_statement(kind: u16) -> bool {
+    matches!(
+        kind,
+        syntax_kind_ext::FUNCTION_DECLARATION
+            | syntax_kind_ext::CLASS_DECLARATION
+            | syntax_kind_ext::INTERFACE_DECLARATION
+            | syntax_kind_ext::TYPE_ALIAS_DECLARATION
+            | syntax_kind_ext::ENUM_DECLARATION
+            | syntax_kind_ext::EMPTY_STATEMENT
+    )
+}
+
 /// One block-body return contribution, collected *unwidened* so that a union of
 /// distinct fresh literals (`return "a"; return "b"` → `"a" | "b"`) is preserved
 /// rather than widened per branch. `widen_expr` is `Some(expr)` when this
@@ -266,13 +282,29 @@ impl<'a> CheckerState<'a> {
     ///
     /// This gates the (potentially evaluation-triggering)
     /// `function_body_falls_through` query. When the body's last statement is a
-    /// trivially-falling-through statement (a variable/function/class declaration,
-    /// a non-call expression statement, etc.), the body provably falls through, so
-    /// the return type is `void` and we must NOT run the reachability query —
-    /// doing so would evaluate flow-sensitive receivers (e.g. evolving
-    /// implicit-`any` arrays) prematurely and suppress their `TS7005`/`TS7034`
-    /// diagnostics. A never-returning tail call always appears as the terminal
-    /// expression statement, so it is preserved here (#14741).
+    /// trivially-falling-through statement (a variable declaration, a non-call
+    /// expression statement, etc.), the body provably falls through, so the
+    /// return type is `void` and we must NOT run the reachability query — doing so
+    /// would evaluate flow-sensitive receivers (e.g. evolving implicit-`any`
+    /// arrays) prematurely and suppress their `TS7005`/`TS7034` diagnostics. A
+    /// never-returning tail call always appears as the terminal expression
+    /// statement, so it is preserved here (#14741).
+    ///
+    /// When the syntactic last statement is a control-flow-transparent trailing
+    /// declaration (a hoisted `function`, a type-erased `class`/`interface`/
+    /// `type`/`enum`, or an empty statement), the real terminating tail is the
+    /// statement before it, and only an **unconditional terminator**
+    /// (`return`/`throw`) revealed there surfaces as "may terminate" — the shape
+    /// that made `function f(){ return f(); function g(){} }` misreport
+    /// fall-through and infer `void` instead of the reachable `return`'s `never`
+    /// (#16987, whose reassigned-variable case is handled downstream by
+    /// `function_is_nonlazy_circular_return_site`). A call-expression tail revealed
+    /// past a declaration is deliberately NOT surfaced: running
+    /// `function_body_falls_through` over an evolving implicit-`any` array
+    /// (`function f(){ x.push(1); function g(){} }`, `controlFlowArrayErrors.ts`)
+    /// would freeze it and drop `TS7005`/`TS7034`. When the last statement is not
+    /// such a declaration, the original classification (which surfaces a
+    /// never-returning tail call, #14741) is unchanged.
     fn body_tail_may_terminate_control_flow(&self, body_idx: NodeIndex) -> bool {
         let Some(body_node) = self.ctx.arena.get(body_idx) else {
             return false;
@@ -289,6 +321,21 @@ impl<'a> CheckerState<'a> {
         let Some(last) = self.ctx.arena.get(last_idx) else {
             return false;
         };
+        if is_control_flow_transparent_tail_statement(last.kind) {
+            return block
+                .statements
+                .nodes
+                .iter()
+                .rev()
+                .filter_map(|&idx| self.ctx.arena.get(idx))
+                .find(|node| !is_control_flow_transparent_tail_statement(node.kind))
+                .is_some_and(|node| {
+                    matches!(
+                        node.kind,
+                        syntax_kind_ext::RETURN_STATEMENT | syntax_kind_ext::THROW_STATEMENT
+                    )
+                });
+        }
         match last.kind {
             syntax_kind_ext::THROW_STATEMENT
             | syntax_kind_ext::RETURN_STATEMENT

--- a/crates/tsz-checker/tests/inferred_return_error_and_self_call_tests.rs
+++ b/crates/tsz-checker/tests/inferred_return_error_and_self_call_tests.rs
@@ -123,6 +123,64 @@ const size: number = walk();
     );
 }
 
+/// A *clean* (non-reassigned) self-recursion whose body ends in a hoisted
+/// `function` declaration must still infer `never` — not `void`. The trailing
+/// declaration is control-flow-transparent, so the reachability pre-gate must
+/// look past it to the real terminating tail (`return pure(n)`). Before the
+/// pre-gate skipped trailing declarations, the syntactically-last `function`
+/// statement made the body look like it fell through, defaulting to `void` (the
+/// root of #16987, shared with the reassigned fixture).
+///
+/// `never` is assignable to `string`; `void` is not — so the regression is
+/// detected as a TS2322 that must NOT appear. (Property access can't
+/// distinguish the two: both `never` and `void` reject it with TS2339.)
+#[test]
+fn clean_self_recursion_with_trailing_declaration_infers_never_not_void() {
+    let source = r#"
+function pure(n: number) {
+  return pure(n);
+  function helper() {}
+}
+const s: string = pure(1);
+"#;
+    let codes = check_strict(source);
+    assert!(
+        !codes.contains(&2322),
+        "a trailing hoisted declaration must not make a clean self-recursion infer \
+         `void`; `never` is assignable to `string`, so NO TS2322 fires; got: {codes:?}"
+    );
+}
+
+/// Skipping trailing hoisted declarations to find the terminating tail must NOT
+/// surface a call-expression tail: a body whose real tail is an evolving-array
+/// `x.push(...)` followed by a nested `function` declaration must keep its
+/// `TS7034`/`TS7005` implicit-`any[]` diagnostics. Surfacing the call would run
+/// the reachability query over the evolving array and freeze it, dropping those
+/// diagnostics (`controlFlowArrayErrors.ts`). Only `return`/`throw` tails
+/// revealed past a declaration are surfaced.
+#[test]
+fn evolving_array_before_trailing_declaration_keeps_implicit_any_diagnostics() {
+    let source = r#"
+function f3() {
+    let x = [];
+    x.push(5);
+    function g() {
+        x;
+    }
+}
+"#;
+    let codes = check_strict(source);
+    assert!(
+        codes.contains(&7034),
+        "the evolving-array `let x = []` must still report TS7034 even though the \
+         body ends in a hoisted `function` declaration; got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&7005),
+        "the evolving-array reference must still report TS7005; got: {codes:?}"
+    );
+}
+
 /// A *wrapped* self-call (`return [bounce][0]()`) is NOT a direct self-call, so
 /// — like tsc — its circular type is aggregated and the function degrades to the
 /// implicit-`any` circular return (TS7023), rather than adopting the base case.


### PR DESCRIPTION
**Structural rule.** `body_tail_may_terminate_control_flow` (the cheap pre-gate that decides whether to run the reachability query `function_body_falls_through`) classified the *syntactically last* statement of a function body. A trailing hoisted `function` — or type-erased `class`/`interface`/`type`/`enum` — declaration is control-flow-transparent, so it made the body look like it fell through and the return type default to `void`. When a clean no-base-case recursion's body ends in such a declaration, tsc infers `never`; tsz inferred `void`, threading the wrong type to call sites. Owner layer: checker return-type inference (`types::utilities::return_type`).

Witness (`--noImplicitAny`):

```ts
function f(n: number) { return f(n); function g() {} }   // tsc: never; tsz (before): void
```

The real terminating tail (`return f(n)`) was hidden behind the trailing `function g`.

**Fix.** The gate now looks past trailing control-flow-transparent declarations to the real tail. To stay safe, **only an unconditional terminator (`return`/`throw`)** revealed past a declaration is surfaced — surfacing a call-expression tail would run `function_body_falls_through` over an evolving implicit-`any` array (`function f(){ x.push(1); function g(){} }`) and freeze it, dropping `TS7005`/`TS7034` (`controlFlowArrayErrors.ts`). When the last statement is not such a declaration, the original classification (including the never-returning tail-call case, #14741) is unchanged.

**Relationship to #16987 / #16995.** This is the residual root cause behind #16987. That issue's reassigned-variable fixture (`simpleRecursionWithBaseCase4.ts`) was already fixed on main by #16995's downstream `function_is_nonlazy_circular_return_site` interceptor (which converts the degenerate `void`/`never` to the circular `any` for variable-bound self-recursion). This PR fixes the pre-gate at the source, covering the clean **function-declaration** sibling that the downstream interceptor does not reach (a named declaration is not a resolving variable, so it is never recorded as a circular return site). No name/fixture matching; the decision is purely on `SyntaxKind`.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test inferred_return_error_and_self_call_tests` — 7/7 pass, incl. 2 new guards: `clean_self_recursion_with_trailing_declaration_infers_never_not_void` (fn-decl recursion → `never`, not `void`) and `evolving_array_before_trailing_declaration_keeps_implicit_any_diagnostics` (TS7034/TS7005 preserved).
- `cargo clippy -p tsz-checker` clean; `python3 scripts/arch/arch_guard.py` passed (arch-size + anti-hardcoding). PR CI Summary (clippy + arch-size) green at head 6ce8ece.
- Pinned-tsc oracle: `function f(n){ return f(n); function g(){} }` and the `class`-tail variant → `never` (matches tsc; was `void`); `controlFlowArrayErrors.ts` retains all 12 diagnostics.
- Conformance snapshot (`conformance.sh snapshot --workers 12 --force`) on the final code: 11564 passed. The change fires **only** for function bodies ending in a trailing control-flow-transparent declaration, so it is a structural no-op for every other fixture (verified: `simpleRecursionWithBaseCase4.ts` passes; `controlFlowArrayErrors.ts` passes; no fixture that lacks a trailing-declaration tail is affected).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high