### PR TITLE
fix(checker): relate arrow-body return against the union of overloaded target returns (#16986)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics/argument_reports.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics/argument_reports.rs
@@ -143,8 +143,18 @@ impl<'a> CheckerState<'a> {
                 .checker_only_assignability_failure_reason(source, target)
                 .is_some();
         }
+        // Gate on `callback_type_params_are_unresolved`: only suppress when
+        // contextual typing genuinely failed to bind the callback's parameters
+        // (they remained `any`/`unknown`). When the parameters DID resolve to
+        // concrete types and the whole-callback relation still fails (e.g. an
+        // untyped arrow `(x) => x` whose body unions the overload parameters to
+        // `string | number` cannot satisfy `{ (x: string): string; (x: number):
+        // number }`), the mismatch is real and `tsc` reports `TS2345` at the
+        // argument — mirroring the identical triple-gate in
+        // `error_argument_not_assignable_at_impl`.
         if !checker_only_mismatch
             && self.arg_is_callback_with_unannotated_params(arg_idx)
+            && self.callback_type_params_are_unresolved(source)
             && self.target_can_contextually_type_callback_params(arg_idx, target)
         {
             return true;

--- a/crates/tsz-checker/src/assignability/assignment_checker_template_display_tests.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker_template_display_tests.rs
@@ -340,3 +340,168 @@ function convert<Result extends Output[]>(ors: Input[]): Result {
         "TS2322 should use the structural source display in the arbitrary-type elaboration, got: {diag:?}"
     );
 }
+
+// An untyped function literal assigned to a MULTI-call-signature (overload)
+// target: `tsc`'s `elaborateArrowFunction` relates the literal's return against
+// the UNION of every target signature's return type. When that union relates
+// (the literal's body unions the overload parameters, e.g. `(p) => p` gives
+// `string | number`), elaboration declines and the outer whole-function
+// relation reports a single TS2322 at the binding — NOT an inner TS2322 drilled
+// into the arrow body against one overload's return. Regression for #16986.
+#[test]
+fn arrow_assigned_to_overloaded_target_reports_outer_ts2322_at_binding() {
+    let source = r#"
+var handler: {
+    (p: string): string;
+    (p: number): number;
+} = (p) => p;
+"#;
+    let diagnostics = diagnostics_for(source);
+    let ts2322s: Vec<_> = diagnostics.iter().filter(|d| d.code == 2322).collect();
+    assert_eq!(
+        ts2322s.len(),
+        1,
+        "expected exactly one TS2322 for the overloaded-target arrow; got: {diagnostics:?}"
+    );
+    let diag = ts2322s[0];
+    // The whole-function message must appear (outer relation), not the
+    // inner-only `string | number -> string` body drill.
+    assert!(
+        diag.message_text
+            .contains("(p: string | number) => string | number")
+            && diag.message_text.contains("(p: string): string"),
+        "TS2322 should carry the whole-function-type outer message, got: {:?}",
+        diag.message_text
+    );
+    // Anchor at the binding name `handler`, not inside the arrow body.
+    let binding_start = source.find("handler").expect("expected binding name") as u32;
+    assert_eq!(
+        diag.start, binding_start,
+        "TS2322 should anchor at the binding name, not the arrow body; got: {diag:?}"
+    );
+}
+
+// A single-call-signature target with a matching contextual return must remain
+// clean — the union collapses to the sole return type, so this stays identical
+// to the pre-change first-signature behavior (no spurious diagnostic).
+#[test]
+fn arrow_assigned_to_single_signature_target_is_accepted() {
+    let source = r#"
+var identity: {
+    (p: string): string;
+} = (p) => p;
+"#;
+    let diagnostics = diagnostics_for(source);
+    assert!(
+        diagnostics.iter().all(|d| d.code != 2322),
+        "single-signature contextual return must not emit TS2322; got: {diagnostics:?}"
+    );
+}
+
+// An untyped function literal PASSED AS AN ARGUMENT to a multi-signature
+// overload parameter: when the contextually-typed literal's whole type still
+// fails to satisfy the overload set, `tsc` reports TS2345 at the argument (the
+// return union relates, so no inner body drill fires). Regression for #16986:
+// the argument-level report must not be suppressed just because the callback
+// has unannotated parameters — its parameters DID resolve to concrete types.
+#[test]
+fn arrow_argument_to_overloaded_parameter_reports_ts2345() {
+    let source = r#"
+declare function accept(cb: { (p: string): string; (p: number): number; }): void;
+accept((p) => p);
+"#;
+    let diagnostics = diagnostics_for(source);
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2345),
+        "expected TS2345 at the overloaded-callback argument; got: {diagnostics:?}"
+    );
+    assert!(
+        diagnostics.iter().all(|d| d.code != 2322),
+        "the argument mismatch must surface as TS2345, not an inner-body TS2322; got: {diagnostics:?}"
+    );
+    let diag = diagnostics.iter().find(|d| d.code == 2345).unwrap();
+    assert!(
+        diag.message_text
+            .contains("(p: string | number) => string | number"),
+        "TS2345 should display the contextually-typed whole-function source, got: {:?}",
+        diag.message_text
+    );
+}
+
+// A return value genuinely OUTSIDE the union of overload returns still drills
+// into the arrow body (matching `tsc`'s `elaborateArrowFunction` when the
+// return does not relate to the target-return union). Guards that the union
+// change did not disable the legitimate body drill.
+#[test]
+fn arrow_argument_return_outside_overload_union_drills_to_body() {
+    let source = r#"
+declare function accept(cb: { (p: string): string; (p: number): number; }): void;
+accept((p) => true);
+"#;
+    let diagnostics = diagnostics_for(source);
+    let diag = diagnostics
+        .iter()
+        .find(|d| d.code == 2322)
+        .expect("expected TS2322 drilled into the arrow body for an out-of-union return");
+    assert!(
+        diag.message_text.contains("'boolean'") && diag.message_text.contains("'string | number'"),
+        "TS2322 should describe the body return-type mismatch (boolean vs string | number), got: {:?}",
+        diag.message_text
+    );
+    // Anchor at the body `true`, not the argument.
+    let body_start = source.find("true").expect("expected body expression") as u32;
+    assert_eq!(
+        diag.start, body_start,
+        "TS2322 should anchor at the arrow body expression; got: {diag:?}"
+    );
+}
+
+// An untyped arrow written as an object-literal PROPERTY value whose declared
+// member type is an overload set: the same `elaborateArrowFunction` rule
+// applies. The member drill must relate the arrow return against the union of
+// the member's signature returns, so `(p) => p` (body `string | number`) does
+// not spuriously inner-drill against the first signature's `string`. Regression
+// for #16986 — the object-literal-property arrow drill shares the union
+// resolver with the argument/assignment sites.
+#[test]
+fn arrow_object_literal_property_to_overloaded_member_does_not_inner_drill() {
+    let source = r#"
+const container: { run: { (p: string): string; (p: number): number } } = {
+    run: (p) => p,
+};
+"#;
+    let diagnostics = diagnostics_for(source);
+    let ts2322s: Vec<_> = diagnostics.iter().filter(|d| d.code == 2322).collect();
+    assert_eq!(
+        ts2322s.len(),
+        1,
+        "expected exactly one TS2322 for the overloaded-member property arrow; got: {diagnostics:?}"
+    );
+    // The single diagnostic must NOT be the inner-body drill against `string`.
+    assert!(
+        !ts2322s[0]
+            .message_text
+            .contains("Type 'string | number' is not assignable to type 'string'.")
+            || ts2322s[0].message_text.contains("(p: string): string"),
+        "TS2322 must carry the property/function-type frame, not the inner-only \
+         `string | number -> string` body drill; got: {:?}",
+        ts2322s[0].message_text
+    );
+}
+
+// A single-signature object-literal member with a matching contextual return
+// stays clean — the union collapses to the sole return, so the alias/inline
+// drill behavior is unchanged.
+#[test]
+fn arrow_object_literal_property_to_single_signature_member_is_accepted() {
+    let source = r#"
+const container: { run: { (p: string): string } } = {
+    run: (p) => p,
+};
+"#;
+    let diagnostics = diagnostics_for(source);
+    assert!(
+        diagnostics.iter().all(|d| d.code != 2322),
+        "single-signature member contextual return must not emit TS2322; got: {diagnostics:?}"
+    );
+}

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -870,7 +870,7 @@ impl<'a> CheckerState<'a> {
             return false;
         };
 
-        let Some(expected_return_type) = self.first_callable_return_type(param_type) else {
+        let Some(expected_return_type) = self.union_callable_return_type(param_type) else {
             return false;
         };
 
@@ -1357,40 +1357,97 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    fn first_callable_return_type(&mut self, ty: TypeId) -> Option<TypeId> {
+    /// Collect the return types of every call signature reachable from `ty`,
+    /// resolving through nullish unwrapping, a bare function shape, a callable
+    /// shape's call signatures, and a type application's base — the shared
+    /// traversal behind both [`Self::first_callable_return_type`] and
+    /// [`Self::union_callable_return_type`]. `None` when `ty` exposes no callable
+    /// shape at all; `Some(vec)` (possibly empty) once a callable arm matched.
+    fn callable_return_types(&mut self, ty: TypeId) -> Option<Vec<TypeId>> {
         use crate::query_boundaries::diagnostics::{
             callable_shape_for_type, function_shape, type_application,
         };
 
         if let (Some(non_nullish), Some(_nullish_cause)) = self.split_nullish_type(ty) {
-            return self.first_callable_return_type(non_nullish);
+            return self.callable_return_types(non_nullish);
         }
 
         if let Some(shape) = function_shape(self.ctx.types, ty) {
-            return Some(shape.return_type);
+            return Some(vec![shape.return_type]);
         }
 
         if let Some(signatures) =
             crate::query_boundaries::common::call_signatures_for_type(self.ctx.types, ty)
         {
-            return signatures.first().map(|sig| sig.return_type);
+            return Some(signatures.iter().map(|sig| sig.return_type).collect());
         }
 
         if let Some(shape) = callable_shape_for_type(self.ctx.types, ty) {
-            return shape.call_signatures.first().map(|sig| sig.return_type);
+            return Some(
+                shape
+                    .call_signatures
+                    .iter()
+                    .map(|sig| sig.return_type)
+                    .collect(),
+            );
         }
 
         if let Some(app) = type_application(self.ctx.types, ty) {
-            return self.first_callable_return_type(app.base);
+            return self.callable_return_types(app.base);
         }
 
         None
     }
 
+    fn first_callable_return_type(&mut self, ty: TypeId) -> Option<TypeId> {
+        self.callable_return_types(ty)?.first().copied()
+    }
+
+    /// The expected return type governing the arrow-body drill, matching `tsc`'s
+    /// `elaborateArrowFunction`: `getUnionType(map(getSignaturesOfType(target,
+    /// Call), getReturnTypeOfSignature))`.
+    ///
+    /// When the target is an overload set (multiple call signatures), the arrow's
+    /// inferred return type is related against the UNION of every signature's
+    /// return type — not just the first. A contextually-typed arrow whose body
+    /// unions across the overload parameters — e.g. `(x) => x` assigned to
+    /// `{ (x: string): string; (x: number): number }`, whose body `x` is
+    /// contextually typed `string | number` — has return type `string | number`.
+    /// Relating that against only the *first* signature's return type (`string`,
+    /// as [`Self::first_callable_return_type`] yields) makes the drill spuriously
+    /// fail, so the drill reports an inner `TS2322` anchored inside the body and
+    /// suppresses `tsc`'s outer whole-function relation error. Relating against
+    /// the union (`string | number`) lets the drill relation succeed exactly as
+    /// `tsc`'s does, so this elaborator declines and the caller reports the
+    /// outer `TS2322`/`TS2345` at the assignment/argument site with the full
+    /// function-type message and its nested elaboration.
+    ///
+    /// For a single-signature target the union collapses to that one return type,
+    /// so this is identical to [`Self::first_callable_return_type`] there and only
+    /// changes behavior for genuine overload sets.
+    fn union_callable_return_type(&mut self, ty: TypeId) -> Option<TypeId> {
+        // Reduce the collected returns to `tsc`'s `getUnionType`: none → decline,
+        // one → the sole member (no needless intern), many → the interned union
+        // (which dedupes/reduces).
+        let return_types = self.callable_return_types(ty)?;
+        match return_types.len() {
+            0 => None,
+            1 => Some(return_types[0]),
+            _ => Some(self.ctx.types.union(return_types)),
+        }
+    }
+
     /// The expected return type governing the arrow-body drill for an object
     /// literal member whose declared type is `ty`.
     ///
-    /// [`Self::first_callable_return_type`] answers for a type whose callable
+    /// Uses [`Self::union_callable_return_type`] so an overloaded member type
+    /// (`{ (x: string): string; (x: number): number }`) drives the drill with
+    /// the UNION of its signature returns, matching `tsc`'s `elaborateArrowFunction`
+    /// exactly as the argument/assignment sites do; a single-signature member
+    /// collapses to that one return type, leaving the alias-resolution behavior
+    /// below unchanged.
+    ///
+    /// [`Self::union_callable_return_type`] answers for a type whose callable
     /// structure is already materialized. A member written through a type alias
     /// (`cb: Fn` for `type Fn = () => string`) arrives as an unresolved
     /// `TypeData::Lazy(DefId)` that it does not see through, so the drill read
@@ -1422,19 +1479,19 @@ impl<'a> CheckerState<'a> {
     /// own type parameter `T`. This hop is gated on `ty` actually being an
     /// application so it cannot fire on an unrelated declined shape.
     fn callable_return_type_for_drill(&mut self, ty: TypeId) -> Option<TypeId> {
-        if let Some(found) = self.first_callable_return_type(ty) {
+        if let Some(found) = self.union_callable_return_type(ty) {
             return Some(found);
         }
         let resolved = self.resolve_lazy_type(ty);
         if resolved != ty
-            && let Some(found) = self.first_callable_return_type(resolved)
+            && let Some(found) = self.union_callable_return_type(resolved)
         {
             return Some(found);
         }
         if crate::query_boundaries::diagnostics::type_application(self.ctx.types, ty).is_some() {
             let evaluated = self.judge_evaluate(ty);
             if evaluated != ty {
-                return self.first_callable_return_type(evaluated);
+                return self.union_callable_return_type(evaluated);
             }
         }
         None


### PR DESCRIPTION
Fixes #16986.

**Structural rule.** When an untyped function literal (arrow or function
expression) is assigned to, passed as a call argument to, or written as an
object-literal property value of a target type with **multiple call
signatures**, `tsc`'s `elaborateArrowFunction` relates the literal's inferred
return type against the **union of every target signature's return type**
(`getUnionType(map(getSignaturesOfType(target, Call), getReturnTypeOfSignature))`).
When that union relates, elaboration declines and the outer whole-function
relation owns the diagnostic — `TS2322` at the binding / property, `TS2345` at a
call argument — with the full function-type message and nested elaboration.
`tsc` only drills into the arrow body (inner `TS2322` at the returned expression)
when the return does **not** relate to that union.

tsz drilled using only the **first** target signature's return type. For
`(x) => x` against `{ (x: string): string; (x: number): number }` the
contextually-typed body is `string | number`; related against just `string` it
spuriously failed, so tsz anchored an inner `TS2322` inside the arrow body and
suppressed the outer relation (wrong code/position/message for assignments and
object-literal properties, wrong code for arguments). The argument path also
*dropped* the diagnostic once the inner drill was removed, because
`check_argument_assignable_or_report` suppressed `TS2345` for **any**
unannotated-parameter callback the target could contextually type — even when
the parameters had resolved to concrete types and the whole-callback relation
still failed.

**Owner layer** — `crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs`
and `.../assignability/assignability_diagnostics/argument_reports.rs`:

- Extract the shared `callable_return_types` collector (nullish → function shape
  → call signatures → callable shape → application base). `first_callable_return_type`
  (`.first()`) and the new `union_callable_return_type` (`getUnionType`) both
  delegate to it — no duplicated traversal, no net-new `query_boundaries::common`
  reference.
- Use the union at all three arrow-body drill sites: the argument/assignment
  drill and `callable_return_type_for_drill` (object-literal member). Single-
  signature targets collapse to the sole return type, so only overload sets
  change behavior; the drill's lazy-alias / generic-application resolution is
  preserved.
- Gate the unannotated-callback `TS2345` suppression on
  `callback_type_params_are_unresolved(source)`, mirroring the identical
  triple-gate already in `error_argument_not_assignable_at_impl`: suppress only
  when contextual typing failed to bind the callback params.

**Adjacent-case matrix** (verified against the release binary):

| Case | Before | After / `tsc` |
| --- | --- | --- |
| assign `var f: {overloads} = (p) => p` | inner TS2322 in body | **TS2322 at binding**, full fn-type message |
| assign, block body | TS2322 at binding | unchanged |
| assign single-sig | none | none (union collapses) |
| arg `accept((p) => p)` | inner TS2322 in body | **TS2345 at argument** |
| arg, block body | TS2345 | unchanged |
| arg single-sig return mismatch | TS2322 at body | unchanged |
| obj-literal prop `{ run: (p) => p }` vs overload member | inner TS2322 in body | **TS2322 at property**, full fn-type message |
| obj-literal prop single-sig member | none | none |
| any site, return outside the union `(p) => true` | TS2322 at body | unchanged (drill to body) |

No user-name/file-name literals and no formatted-message predicates: decisions
use structural helpers (`callable_return_types`, `callback_type_params_are_unresolved`).
The six new regression tests vary binder names (`handler`, `identity`, `accept`,
`container`, `run`) and parameter names.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib arrow_` — 234 passed, 0 failed (incl. the 6
  new regression tests). Run in debug so `tsz-common`'s
  `#[cfg(any(test, debug_assertions))]` `ScopedPerfCounters` overlay compiles
  cross-crate (a `--release` test build cannot).
- `cargo clippy --profile dist-fast -p tsz-checker --lib -- -D warnings` — clean
  (the per-merge CI lint lane).
- `scripts/arch/check-checker-boundaries.sh` — architecture guard + field
  inventory pass; the shared collector keeps the `query_boundaries::common`
  reference count at baseline (the per-merge arch-size lane).
- Emit parity: not applicable — this is a diagnostic-elaboration change and does
  not touch JS/DTS output.
- Conformance: the pinned corpus would not materialize in this environment
  (`conformance.sh` reports the `TypeScript/` submodule tree as dirty and
  refuses); CI's nightly conformance lane covers it.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXhvCWCp1vzFAiZxvkTogt)_