### PR TITLE
refactor(checker): drop redundant identifier-kind guard in assignment_rhs_base_this_type

### DIFF
--- a/crates/tsz-checker/src/symbols/scope_finder.rs
+++ b/crates/tsz-checker/src/symbols/scope_finder.rs
@@ -408,13 +408,10 @@ impl<'a> CheckerState<'a> {
     ///   receiver / an `any` `this`, matching `tsc`.
     pub(crate) fn assignment_rhs_base_this_type(&mut self, base_expr: NodeIndex) -> Option<TypeId> {
         if self.is_js_file() && !self.current_source_file_has_esm_syntax() {
-            if self
-                .ctx
-                .arena
-                .get(base_expr)
-                .is_some_and(|n| n.kind == SyntaxKind::Identifier as u16)
-                && self.is_unshadowed_commonjs_exports_identifier(base_expr)
-            {
+            // `is_unshadowed_commonjs_exports_identifier` already resolves to
+            // `false` for any non-identifier node, so no explicit kind guard is
+            // needed here.
+            if self.is_unshadowed_commonjs_exports_identifier(base_expr) {
                 return None;
             }
             // The bare `exports` identifier is handled above, so the only


### PR DESCRIPTION
Follow-up cleanup to #16998 (#16964 Mechanism 2), surfaced by a `/simplify` pass whose fix landed after that PR's auto-merge had already fired.

In `assignment_rhs_base_this_type` (`crates/tsz-checker/src/symbols/scope_finder.rs`), the bare-`exports` branch guarded on `get(base_expr).kind == Identifier` **and** `is_unshadowed_commonjs_exports_identifier(base_expr)`. The kind pre-check is dead: `is_unshadowed_commonjs_exports_identifier` goes through `get_identifier_at` → `get_identifier`, which returns `None` for any non-identifier node, and only a plain `Identifier` can carry `escaped_text == "exports"` (a `PrivateIdentifier`'s text is `#…`). The clause was carried over verbatim from the old `this_type_from_assignment_left` block the helper replaced. Removing it is behavior-identical.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts2683_tests` — 44/44 (unchanged)
- CommonJS `this` matrix exact-match vs the pinned `typescript@7.0.2` oracle unchanged: `exports.f = function(){ this.q }` → TS2683, `module.exports.a = function(){ this.q }` → TS2339, `o.m` → TS2339, plain-id → TS2683
- `cargo clippy --profile ci-lint --workspace --all-targets -- -D warnings` — clean; `python3 scripts/arch/arch_guard.py` — clean

## Provenance
Machine: cloud
Assistant: claude-code
Model: Claude
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_013TnNwHytxJQLG2sv4t271X)_