### PR TITLE
fix(checker): async generator `yield`/`yield*` awaits its yielded value like tsc

### DIFF
--- a/crates/tsz-checker/src/dispatch/yield_.rs
+++ b/crates/tsz-checker/src/dispatch/yield_.rs
@@ -552,16 +552,23 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                     // query rather than defaulting the aggregate to `any`.
                     match async_info {
                         Some(ref i) if i.yield_type != TypeId::ANY => {
+                            // Same `getAwaitedType` wrap tsc applies uniformly in
+                            // `getYieldedTypeOfYieldExpression`: the contribution that
+                            // builds this generator's own inferred `TYield` must match
+                            // the awaited value the consumer actually observes, not the
+                            // delegate's raw iterated-element type.
+                            let awaited = self.checker.compute_awaited_type(i.yield_type, 0);
                             self.checker.ctx.push_generator_yield_star_contribution(
-                                i.yield_type,
+                                awaited,
                                 yield_star_next_type,
                             );
                         }
                         resolved_via_solver => {
                             let resolved = self.checker.for_of_element_type(expression_type, true);
                             if resolved != TypeId::ANY {
+                                let awaited = self.checker.compute_awaited_type(resolved, 0);
                                 self.checker.ctx.push_generator_yield_star_contribution(
-                                    resolved,
+                                    awaited,
                                     yield_star_next_type,
                                 );
                             } else if resolved_via_solver.is_some() {
@@ -579,7 +586,17 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                             }
                         }
                     }
-                    element
+                    // tsc's `getYieldedTypeOfYieldExpression` unconditionally wraps an
+                    // async generator's `yield*` result in `getAwaitedType(...)`. The
+                    // delegated iterable's element type by itself is not yet the
+                    // yielded value: when the delegate is a plain (sync) iterable of
+                    // promises, `AsyncFromSyncIteratorObject` awaits each item before
+                    // handing it to the async generator's consumer, so
+                    // `yield* [Promise.resolve(1)]` yields `number`, not
+                    // `Promise<number>`. Wrapping the already-computed `element` here
+                    // (rather than changing how it is derived above) keeps the
+                    // solver-only resolution this block deliberately preserves.
+                    self.checker.compute_awaited_type(element, 0)
                 } else {
                     let info = tsz_solver::operations::get_iterator_info(
                         self.checker.ctx.types,
@@ -662,7 +679,16 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                         diagnostic_codes::TYPE_OF_YIELD_OPERAND_IN_AN_ASYNC_GENERATOR_MUST_EITHER_BE_A_VALID_PROMISE_OR_MU,
                     );
                 }
-                expression_type
+                // tsc's `getYieldedTypeOfYieldExpression` returns
+                // `getAwaitedType(expressionType)` for a plain `yield` in an async
+                // generator: the async-generator runtime awaits a yielded value
+                // before delivering it to the consumer, so `yield promise` yields
+                // the promise's resolved type, not the promise itself.
+                if is_async_generator {
+                    self.checker.compute_awaited_type(expression_type, 0)
+                } else {
+                    expression_type
+                }
             }
         };
 

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -114,6 +114,9 @@ mod assertion_overlap_object_primitive_tests;
 #[path = "../tests/assertion_overlap_template_literal_tests.rs"]
 mod assertion_overlap_template_literal_tests;
 #[cfg(test)]
+#[path = "../tests/async_generator_yield_awaited_type_tests.rs"]
+mod async_generator_yield_awaited_type_tests;
+#[cfg(test)]
 #[path = "../tests/async_imported_promise_tests.rs"]
 mod async_imported_promise_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/tests/async_generator_yield_awaited_type_tests.rs
+++ b/crates/tsz-checker/tests/async_generator_yield_awaited_type_tests.rs
@@ -1,0 +1,195 @@
+//! Tests for `Awaited<T>` unwrapping of an async generator's yielded value.
+//!
+//! Structural rule: `tsc`'s `getYieldedTypeOfYieldExpression` unconditionally
+//! wraps the computed yielded/delegated type in `getAwaitedType(...)` when the
+//! enclosing generator is async — for both a plain `yield expr` and a
+//! `yield* iterable`. The async generator runtime (`AsyncGeneratorYield`)
+//! awaits a yielded value before handing it to the consumer, and for a
+//! `yield*` over a plain (sync) iterable, `AsyncFromSyncIteratorObject` awaits
+//! each delegated item the same way. `tsz` computed the raw iterated/operand
+//! type without that final `Awaited` step, so `yield Promise.resolve(1)` and
+//! `yield* [Promise.resolve(1)]` in an async generator both left the inferred
+//! `TYield` as `Promise<number>` instead of `number`, producing spurious
+//! TS2322 against any `AsyncIterable<number>`/`AsyncIterableIterator<number>`/
+//! `AsyncIterator<number>` annotation.
+//!
+//! Owner: checker (`crates/tsz-checker/src/dispatch/yield_.rs`), reusing the
+//! existing solver-backed `Awaited<T>` computation
+//! (`CheckerState::compute_awaited_type`, already used for `await` operands).
+
+use std::sync::Arc;
+
+use crate::test_utils::{check_source_with_libs, load_default_lib_files, strict_checker_options};
+use tsz_binder::lib_loader::LibFile;
+
+fn codes_with(source: &str, libs: &[Arc<LibFile>]) -> Vec<u32> {
+    check_source_with_libs(source, "test.ts", strict_checker_options(), libs)
+        .iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+// =========================================================================
+// The regression: plain `yield` of a promise in an async generator.
+// =========================================================================
+
+#[test]
+fn async_generator_plain_yield_of_promise_unwraps_to_awaited_type() {
+    let libs = load_default_lib_files();
+    let src = r#"
+const f: () => AsyncIterable<number> = async function* () {
+    yield Promise.resolve(1);
+};
+"#;
+    assert!(
+        !codes_with(src, &libs).contains(&2322),
+        "an async generator's plain `yield` of a promise must be Awaited-unwrapped, not compared raw"
+    );
+}
+
+#[test]
+fn async_generator_plain_yield_of_promise_wrong_awaited_type_still_errors() {
+    let libs = load_default_lib_files();
+    let src = r#"
+const f: () => AsyncIterable<string> = async function* () {
+    yield Promise.resolve(1);
+};
+"#;
+    assert!(
+        codes_with(src, &libs).contains(&2322),
+        "Awaited<Promise<number>> = number is still not assignable to the declared `string` yield type"
+    );
+}
+
+// =========================================================================
+// The regression: `yield*` delegating to a sync iterable of promises.
+// =========================================================================
+
+#[test]
+fn async_generator_yield_star_sync_array_of_promises_unwraps_to_awaited_type() {
+    let libs = load_default_lib_files();
+    let src = r#"
+const f: () => AsyncIterable<number> = async function* () {
+    yield* [Promise.resolve(1)];
+};
+"#;
+    assert!(
+        !codes_with(src, &libs).contains(&2322),
+        "`yield*` over a sync array of promises in an async generator must await each element"
+    );
+}
+
+#[test]
+fn async_generator_yield_star_sync_array_of_promises_against_iterable_iterator() {
+    let libs = load_default_lib_files();
+    let src = r#"
+const f: () => AsyncIterableIterator<number> = async function* () {
+    yield* [Promise.resolve(1)];
+};
+"#;
+    assert!(!codes_with(src, &libs).contains(&2322));
+}
+
+#[test]
+fn async_generator_yield_star_sync_array_of_promises_against_iterator() {
+    let libs = load_default_lib_files();
+    let src = r#"
+const f: () => AsyncIterator<number, any, any> = async function* () {
+    yield* [Promise.resolve(1)];
+};
+"#;
+    assert!(!codes_with(src, &libs).contains(&2322));
+}
+
+#[test]
+fn async_generator_yield_star_sync_array_of_promises_wrong_awaited_type_still_errors() {
+    let libs = load_default_lib_files();
+    let src = r#"
+const f: () => AsyncIterable<string> = async function* () {
+    yield* [Promise.resolve(1)];
+};
+"#;
+    assert!(
+        codes_with(src, &libs).contains(&2322),
+        "Awaited<Promise<number>> = number is still not assignable to the declared `string` yield type"
+    );
+}
+
+#[test]
+fn async_generator_yield_star_sync_array_union_of_promise_and_plain_unwraps() {
+    // `Promise<number> | number` distributes: `Awaited<Promise<number> | number> = number`.
+    let libs = load_default_lib_files();
+    let src = r#"
+const f: () => AsyncIterable<number> = async function* () {
+    yield* [Promise.resolve(1), 2];
+};
+"#;
+    assert!(!codes_with(src, &libs).contains(&2322));
+}
+
+// =========================================================================
+// Fallback: delegating to an already-async iterable must stay unaffected.
+// =========================================================================
+
+#[test]
+fn async_generator_yield_star_another_async_generator_unaffected() {
+    let libs = load_default_lib_files();
+    let src = r#"
+async function* inner() {
+    yield 1;
+}
+const f: () => AsyncGenerator<number, void, unknown> = async function* () {
+    yield* inner();
+};
+"#;
+    assert!(
+        !codes_with(src, &libs).contains(&2322),
+        "delegating to an async iterable that already yields `number` (not `Promise<number>`) must not regress"
+    );
+}
+
+// =========================================================================
+// Negative control: a plain (non-async) generator must not Awaited-unwrap.
+// =========================================================================
+
+#[test]
+fn sync_generator_plain_yield_of_promise_is_not_unwrapped() {
+    let libs = load_default_lib_files();
+    let src = r#"
+function* f(): IterableIterator<Promise<number>> {
+    yield Promise.resolve(1);
+}
+"#;
+    assert!(
+        !codes_with(src, &libs).contains(&2322),
+        "a sync generator's yielded promise must stay `Promise<number>`, matching the declared type"
+    );
+}
+
+#[test]
+fn sync_generator_yield_star_of_promise_array_is_not_unwrapped() {
+    let libs = load_default_lib_files();
+    let src = r#"
+function* f(): IterableIterator<Promise<number>> {
+    yield* [Promise.resolve(1)];
+}
+"#;
+    assert!(
+        !codes_with(src, &libs).contains(&2322),
+        "a sync generator's `yield*` element type must stay `Promise<number>`, matching the declared type"
+    );
+}
+
+#[test]
+fn sync_generator_yield_of_promise_against_unwrapped_type_still_errors() {
+    // Negative control's negative: a sync generator declared to yield `number`
+    // (not `Promise<number>`) must still report the mismatch — proves the
+    // async-only guard isn't accidentally suppressing sync-generator checks.
+    let libs = load_default_lib_files();
+    let src = r#"
+function* f(): IterableIterator<number> {
+    yield Promise.resolve(1);
+}
+"#;
+    assert!(codes_with(src, &libs).contains(&2322));
+}


### PR DESCRIPTION
When a generator is async, tsc's `getYieldedTypeOfYieldExpression` unconditionally wraps the computed yielded value in `getAwaitedType(...)`, for both a plain `yield expr` and a `yield* iterable`. The async generator runtime awaits a yielded value before handing it to the consumer (`AsyncGeneratorYield`), and for `yield*` over a plain sync iterable, `AsyncFromSyncIteratorObject` awaits each delegated item the same way. tsz computed the raw operand/iterated-element type without that final Awaited step, so `yield Promise.resolve(1)` and `yield* [Promise.resolve(1)]` inside an async generator both left the inferred `TYield` as `Promise<number>` instead of `number`, producing spurious TS2322 against any `AsyncIterable<number>`/`AsyncIterableIterator<number>`/`AsyncIterator<number>` annotation.

**Structural rule:** when the enclosing generator is `async`, `tsc` awaits the yielded/delegated value before comparing it to the declared yield type or contributing it to inference; tsz now does the same through the checker's existing solver-backed `Awaited<T>` computation (`CheckerState::compute_awaited_type`, the same helper already used for `await` operands).

**Fix, owner layer = checker** (`crates/tsz-checker/src/dispatch/yield_.rs`): wrap the already-computed yielded value in `compute_awaited_type` at the two points that were missing it — the plain-yield branch, and the yield-star branch's returned `element` — and additionally wrap the value pushed into `push_generator_yield_star_contribution`, which builds an *unannotated* generator's own inferred `AsyncGenerator<TYield,...>` signature and was still surfacing the un-awaited type in diagnostic messages.

**Adjacent cases** (`crates/tsz-checker/tests/async_generator_yield_awaited_type_tests.rs`): plain `yield` and `yield*` of a promise against `AsyncIterable`/`AsyncIterableIterator`/`AsyncIterator` annotations; a union of promise and non-promise delegate elements; delegating to an already-async iterable (must stay unaffected — `i.yield_type` is already unwrapped); a genuinely-wrong `Awaited` type still reports TS2322 (not over-suppressed); and negative controls proving a *sync* (non-async) generator must not Awaited-unwrap at all, including a sync-generator control that still correctly errors.

Closes the `types.asyncGenerators.es2018.1.ts` conformance false-positive family (11 spurious TS2322 diagnostics across 6 assignability rows in that one fixture, all oracle-verified clean against pinned `typescript@7.0.2`).

## Goal
Goal: hold

## Verification
- New tests: `cargo test -p tsz-checker --lib async_generator_yield_awaited_type_tests` — 11/11 passed.
- Adjacent family: `cargo test -p tsz-checker --lib -- yield generator async_generator promise` — 407/407 passed, 0 failed, 6 pre-existing ignored.
- Full conformance corpus (current binary vs `TypeScript/tests/cases`, cache `scripts/conformance/tsc-cache-full.json`): `11562/12043` passed (96.0%), up from the `11560/12043` baseline committed in #16988 — **+2**, no new entries in the top error-code/fingerprint mismatch tables.
- Minimal repro and the full adjacent matrix additionally verified against the pinned `typescript@7.0.2` oracle directly (`node .../tsc --noEmit --strict ...`) — exact match, including the negative-control error message shape.
- `cargo build --release -p tsz-cli --bin tsz` — clean.
- Pre-commit hook (clippy + affected-crate tests for `tsz-checker`) passed.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01HRG2CFmdvabGEcb24z54wW)_