### PR TITLE
fix(checker): TS2345 argument diagnostics keep the function-signature arity / type-predicate elaboration

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -285,6 +285,9 @@ path = "tests/tuple_call_argument_elaboration_tests.rs"
 name = "array_source_tuple_target_elaboration_tests"
 path = "tests/array_source_tuple_target_elaboration_tests.rs"
 [[test]]
+name = "ts2345_signature_arity_predicate_elaboration_tests"
+path = "tests/ts2345_signature_arity_predicate_elaboration_tests.rs"
+[[test]]
 name = "array_literal_rest_tuple_drill_cap_tests"
 path = "tests/array_literal_rest_tuple_drill_cap_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -850,6 +850,30 @@ impl<'a> CheckerState<'a> {
                 // (category + start/length), exactly like the union-target arm.
                 self.reanchored_container_related(reason, source, target, anchor_idx, start, length)
             }
+            SubtypeFailureReason::TooManyParameters { .. }
+            | SubtypeFailureReason::TypePredicateMismatch { .. } => {
+                // Function-signature relation failures whose cause is the
+                // signature *shape* rather than a named member: a source that
+                // declares more required parameters than the target provides
+                // arguments for (`Target signature provides too few arguments.
+                // Expected N or more, but got M.`, TS2849), or an incompatible
+                // type-predicate return (`Type predicate 'x is A' is not
+                // assignable to 'x is B'.` plus its nested leaf). tsc
+                // elaborates both beneath the call's TS2345 head exactly as it
+                // does beneath the direct-assignment TS2322 head; without this
+                // arm they fall through to `_ => return None` and the
+                // elaboration is dropped on the argument surface only (the
+                // assignment surface renders it via `render_failure_reason`).
+                // Reuse that same TS2322 elaboration as the single source of
+                // truth and re-anchor its child lines onto the call site.
+                let related = self.reanchored_container_related(
+                    reason, source, target, anchor_idx, start, length,
+                );
+                if related.is_empty() {
+                    return None;
+                }
+                related
+            }
             _ => return None,
         };
 

--- a/crates/tsz-checker/tests/ts2345_signature_arity_predicate_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/ts2345_signature_arity_predicate_elaboration_tests.rs
@@ -1,0 +1,178 @@
+//! Argument (`TS2345`) relation failures whose cause is a function-signature
+//! *shape* must carry the same chained elaboration `tsc` emits under the
+//! direct-assignment (`TS2322`) surface.
+//!
+//! Two function-signature `SubtypeFailureReason`s used to render their
+//! elaboration only on the assignment surface and dropped it on the argument
+//! surface, because `related_from_failure_reason` (the `TS2345` related-info
+//! builder) had no arm for them and fell through to its `_ => return None`
+//! catch-all:
+//!
+//! - [`TooManyParameters`] — the source callback declares more required
+//!   parameters than the target signature provides arguments for. `tsc`:
+//!   `Target signature provides too few arguments. Expected N or more, but got
+//!   M.` (`TS2849`).
+//! - [`TypePredicateMismatch`] — the source's `x is A` type predicate is not
+//!   assignable to the target's `x is B`. `tsc`: `Type predicate 'x is A' is
+//!   not assignable to 'x is B'.` followed by the nested `Type 'A' is not
+//!   assignable to type 'B'.` leaf.
+//!
+//! The header-only `TS2345` (no elaboration) is exactly the shape #14816 fixed
+//! for tuple-arity reasons; this is the same class on the function-signature
+//! axis. The structural rule is independent of the binder names and the call
+//! surface (free call, method call, `new`), so each case varies them.
+//!
+//! Oracle: `typescript@7.0.2`.
+//!
+//! [`TooManyParameters`]: tsz_solver::SubtypeFailureReason::TooManyParameters
+//! [`TypePredicateMismatch`]: tsz_solver::SubtypeFailureReason::TypePredicateMismatch
+
+use tsz_checker::diagnostics::{Diagnostic, diagnostic_codes};
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn single(source: &str, code: u32) -> Diagnostic {
+    let diagnostics: Vec<Diagnostic> = check_source_diagnostics(source)
+        .into_iter()
+        .filter(|diagnostic| diagnostic.code == code)
+        .collect();
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "expected exactly one TS{code} diagnostic, got {diagnostics:#?}"
+    );
+    diagnostics.into_iter().next().unwrap()
+}
+
+fn related_messages(diagnostic: &Diagnostic) -> Vec<String> {
+    diagnostic
+        .related_information
+        .iter()
+        .map(|related| related.message_text.clone())
+        .collect()
+}
+
+fn has_related(diagnostic: &Diagnostic, expected: &str) -> bool {
+    related_messages(diagnostic)
+        .iter()
+        .any(|message| message == expected)
+}
+
+// ---------------------------------------------------------------------------
+// TooManyParameters -> TS2849 "Target signature provides too few arguments."
+// on the argument (TS2345) surface. Vary the binder names and the call
+// surface: a free call, a method call, and a `new` expression all route
+// through `error_argument_not_assignable_at`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn too_many_params_free_call_argument_reports_too_few_arguments() {
+    let diagnostic = single(
+        "declare function run(cb: (x: number) => void): void;
+         run((first: number, second: number) => {});",
+        2345,
+    );
+    assert!(
+        has_related(
+            &diagnostic,
+            "Target signature provides too few arguments. Expected 2 or more, but got 1."
+        ),
+        "argument-surface TS2345 dropped the TS2849 arity line; related = {:#?}",
+        related_messages(&diagnostic)
+    );
+    assert!(
+        diagnostic.related_information.iter().any(|r| r.code
+            == diagnostic_codes::TARGET_SIGNATURE_PROVIDES_TOO_FEW_ARGUMENTS_EXPECTED_OR_MORE_BUT_GOT
+            && r.depth == 0),
+        "the arity leaf must sit at depth 0 under the TS2345 head; related = {:#?}",
+        diagnostic.related_information
+    );
+}
+
+#[test]
+fn too_many_params_method_call_argument_reports_too_few_arguments() {
+    // Renamed binders + a method-call surface: same structural reason.
+    let diagnostic = single(
+        "declare class Registry { subscribe(handler: (evt: number) => void): void; }
+         declare const registry: Registry;
+         registry.subscribe((evt: number, meta: number) => {});",
+        2345,
+    );
+    assert!(
+        has_related(
+            &diagnostic,
+            "Target signature provides too few arguments. Expected 2 or more, but got 1."
+        ),
+        "method-call TS2345 dropped the TS2849 arity line; related = {:#?}",
+        related_messages(&diagnostic)
+    );
+}
+
+#[test]
+fn too_many_params_new_expression_argument_reports_too_few_arguments() {
+    let diagnostic = single(
+        "declare class Widget { constructor(render: (frame: number) => void); }
+         const widget = new Widget((frame: number, layer: number) => {});",
+        2345,
+    );
+    assert!(
+        has_related(
+            &diagnostic,
+            "Target signature provides too few arguments. Expected 2 or more, but got 1."
+        ),
+        "new-expression TS2345 dropped the TS2849 arity line; related = {:#?}",
+        related_messages(&diagnostic)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TypePredicateMismatch -> "Type predicate 'x is A' is not assignable to
+// 'x is B'." plus the nested "Type 'A' is not assignable to type 'B'." leaf,
+// on the argument (TS2345) surface.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn type_predicate_mismatch_argument_reports_predicate_and_nested_leaf() {
+    let diagnostic = single(
+        "declare function accept(guard: (value: unknown) => value is string): void;
+         declare const isNumber: (value: unknown) => value is number;
+         accept(isNumber);",
+        2345,
+    );
+    assert!(
+        has_related(
+            &diagnostic,
+            "Type predicate 'value is number' is not assignable to 'value is string'."
+        ),
+        "argument-surface TS2345 dropped the type-predicate line; related = {:#?}",
+        related_messages(&diagnostic)
+    );
+    assert!(
+        has_related(
+            &diagnostic,
+            "Type 'number' is not assignable to type 'string'."
+        ),
+        "argument-surface TS2345 dropped the nested predicate leaf; related = {:#?}",
+        related_messages(&diagnostic)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Guard: a plain parameter-*type* mismatch (already handled) still elaborates,
+// so the new arms did not shadow the existing ParameterTypeMismatch path.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parameter_type_mismatch_argument_still_elaborates() {
+    let diagnostic = single(
+        "declare function run(cb: (x: string) => void): void;
+         run((x: number) => {});",
+        2345,
+    );
+    assert!(
+        related_messages(&diagnostic)
+            .iter()
+            .any(|message| message.contains("Types of parameters 'x' and 'x' are incompatible")),
+        "parameter-type-mismatch elaboration regressed; related = {:#?}",
+        related_messages(&diagnostic)
+    );
+}


### PR DESCRIPTION
Fixes #17006.

When a **call argument** fails assignability because the source function's *signature shape* is wrong, `tsc` chains the same elaboration under the `TS2345` head that it chains under the direct-assignment `TS2322` head. tsz emitted the bare `TS2345` head and dropped the elaboration.

**Structural rule:** when a function/callback argument fails through a signature-*shape* reason — the source declares more required parameters than the target provides arguments for (`TooManyParameters`), or its `x is A` type predicate is not assignable to the target's `x is B` (`TypePredicateMismatch`) — `tsc` elaborates the argument (`TS2345`) diagnostic exactly as it elaborates the assignment (`TS2322`) one. tsz already renders both correctly on the assignment surface via `render_failure_reason`; the argument surface dropped them because `related_from_failure_reason` (the `TS2345` related-info builder in `crates/tsz-checker/src/error_reporter/fingerprint_policy.rs`) had no arm for either reason and fell through to its `_ => return None` catch-all. This is the same class of bug #14816 fixed for tuple-arity reasons, on the function-signature axis.

**Owner layer:** checker — `error_reporter::fingerprint_policy::related_from_failure_reason`. The new arm reuses the existing `reanchored_container_related` path: the `TS2322` elaboration (`render_failure_reason`) is the single source of truth, and only its child lines are re-anchored (category → `Message`, span → the call site) onto the `TS2345` head. No second rendering, so the argument and assignment surfaces stay byte-identical and cannot drift.

### Adjacent-case matrix (verified vs pinned `typescript@7.0.2` oracle, `--strict --target es2022`)

| case | before | after / tsc |
| --- | --- | --- |
| `f((x, y) => {})` where `f(cb: (x: number) => void)` — free call | `TS2345` head only | `TS2345` + `Target signature provides too few arguments. Expected 2 or more, but got 1.` |
| `k.run((a, b) => {})` — method call | head only | + arity line |
| `new Widget((a, b) => {})` — `new` expression | head only | + arity line |
| `accept(isNumber)` — `(v) => v is number` vs `(v) => v is string` | head only | + `Type predicate 'v is number' is not assignable to 'v is string'.` + nested `Type 'number' is not assignable to type 'string'.` |
| direct assignment `const h: (x: number) => void = (a, b) => {}` (`TS2322`) | already correct | unchanged |
| parameter-*type* mismatch `run((x: number) => {})` vs `(x: string)` | already correct | unchanged (no-shadow guard) |

All three argument surfaces (free-call, method-call, `new`) route through `error_argument_not_assignable_at`, so one arm covers them.

## Goal
Goal: hold

## Verification
- **Conformance `scripts/conformance/compare-to-parent.sh HEAD~1`** (both sides built, full TypeScript corpus): base failing = 482, branch failing = 482 — **0 newly failing, 0 newly passing, 0 still-failing-with-changed-fingerprint**. No message-rendering drift anywhere in the corpus (the definitive gate for a related-info change).
- New registered unit test `crates/tsz-checker/tests/ts2345_signature_arity_predicate_elaboration_tests.rs` (5 cases: arity on free/method/`new` surfaces, type-predicate with nested leaf, parameter-type-mismatch no-shadow guard) — **5/5 pass**.
- End-to-end vs pinned `typescript@7.0.2` oracle on every matrix row above — byte-identical after the fix.
- Broad regression sweep of ~80 checker elaboration/argument/`TS2345`/`TS2322`/tuple/param/predicate test targets — all green (no drift on the container/tuple/parameter arms that share `reanchored_container_related`).
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets` — clean. `python3 scripts/arch/arch_guard.py` (arch-size merge gate) — passed. These two are the only PR-lane CI checks.
- Emit: unaffected by construction — the change lives entirely in the checker diagnostic related-info builder; the emitter crate is untouched and does not consume checker diagnostics, so JS/DTS counts (11562 / 1375) cannot move.
- Fourslash: running locally against the restored pinned corpus; will update.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high