### PR TITLE
fix(parser): bare `?`/`!` JSDoc wildcard in a type position is TS1110, not TS8020

### DIFF
--- a/crates/tsz-parser/src/parser/state_types.rs
+++ b/crates/tsz-parser/src/parser/state_types.rs
@@ -488,15 +488,14 @@ impl ParserState {
             let q_end = self.token_end();
             self.next_token(); // consume '?'
 
-            // Bare `?` is legacy JSDoc wildcard syntax. In TS source it should
-            // surface TS8020 and stop there rather than cascading into TS17020/TS1110.
+            // A bare `?` (the JSDoc "unknown" wildcard with no operand) is not a
+            // valid TypeScript type. tsc consumes the `?` and then reports TS1110
+            // (`Type expected.`) at the following token — e.g. `var x: ?;` reports
+            // at the `;`, and `Foo<?>` at the `>`. It does NOT report TS8020, which
+            // tsc reserves for the `*` all-type and the dotted `Foo.<T>` legacy
+            // generic (both handled by their own branches below/above).
             if !self.can_token_start_type() {
-                self.parse_error_at(
-                    q_start,
-                    q_end.saturating_sub(q_start).max(1),
-                    tsz_common::diagnostics::diagnostic_messages::JSDOC_TYPES_CAN_ONLY_BE_USED_INSIDE_DOCUMENTATION_COMMENTS,
-                    tsz_common::diagnostics::diagnostic_codes::JSDOC_TYPES_CAN_ONLY_BE_USED_INSIDE_DOCUMENTATION_COMMENTS,
-                );
+                self.error_type_expected();
                 return self.arena.add_identifier(
                     SyntaxKind::Identifier as u16,
                     q_start,
@@ -541,12 +540,10 @@ impl ParserState {
 
             if !self.can_token_start_type() {
                 let bang_end = self.token_pos();
-                self.parse_error_at(
-                    bang_start,
-                    bang_end - bang_start,
-                    "JSDoc types can only be used inside documentation comments.",
-                    tsz_common::diagnostics::diagnostic_codes::JSDOC_TYPES_CAN_ONLY_BE_USED_INSIDE_DOCUMENTATION_COMMENTS,
-                );
+                // A bare `!` (JSDoc non-null wildcard with no operand) is not valid
+                // TypeScript. Like the bare `?` above, tsc reports TS1110 at the
+                // following token, not TS8020.
+                self.error_type_expected();
                 return self.arena.add_identifier(
                     SyntaxKind::Identifier as u16,
                     bang_start,

--- a/crates/tsz-parser/src/parser/state_types_advanced.rs
+++ b/crates/tsz-parser/src/parser/state_types_advanced.rs
@@ -1546,34 +1546,17 @@ impl ParserState {
         let question_end = self.token_end();
         self.next_token(); // consume '?'
 
-        if self.is_greater_than_or_compound() || self.is_token(SyntaxKind::CommaToken) {
-            // `foo<?>` should not emit TS1110; consume the `>` path via caller's expected parser.
-            self.parse_error_at(
-                question_start,
-                question_end - question_start,
-                "JSDoc types can only be used inside documentation comments.",
-                diagnostic_codes::JSDOC_TYPES_CAN_ONLY_BE_USED_INSIDE_DOCUMENTATION_COMMENTS,
-            );
-            return self.arena.add_identifier(
-                SyntaxKind::Identifier as u16,
-                question_start,
-                question_end,
-                crate::parser::node::IdentifierData {
-                    atom: tsz_common::interner::AstAtom::NONE,
-                    escaped_text: IdentText::empty(),
-                    original_text: None,
-                },
-            );
-        }
-
-        if !self.can_token_start_type() {
-            // `foo<?` with no valid following type should emit TS8020.
-            self.parse_error_at(
-                question_start,
-                question_end - question_start,
-                "JSDoc types can only be used inside documentation comments.",
-                diagnostic_codes::JSDOC_TYPES_CAN_ONLY_BE_USED_INSIDE_DOCUMENTATION_COMMENTS,
-            );
+        // A bare `?` wildcard type argument: `foo<?>` / `foo<?, T>` (the `?` is
+        // immediately followed by `>` or `,`), or `foo<?` followed by any token
+        // that cannot start a type. tsc consumes the `?` and reports TS1110
+        // (`Type expected.`) at that following token, not TS8020. The `>` is left
+        // unconsumed, so the caller's `parse_expected_greater_than` still closes
+        // the list cleanly (no cascade).
+        if self.is_greater_than_or_compound()
+            || self.is_token(SyntaxKind::CommaToken)
+            || !self.can_token_start_type()
+        {
+            self.error_type_expected();
             return self.arena.add_identifier(
                 SyntaxKind::Identifier as u16,
                 question_start,

--- a/crates/tsz-parser/tests/parser_improvement_jsdoc_type_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_jsdoc_type_recovery_tests.rs
@@ -4,31 +4,11 @@ use crate::parser::test_fixture::parse_source;
 use tsz_common::diagnostics::diagnostic_codes;
 
 #[test]
-fn test_type_argument_with_empty_jsdoc_wildcard_has_no_ts1110() {
-    // `Foo<?>` should emit TS8020 but avoid TS17020/TS1110 cascading.
-    let source = r#"
-type T = Foo<?>;
-"#;
-    let (parser, _root) = parse_source(source);
-
-    let diagnostics: Vec<u32> = parser.get_diagnostics().iter().map(|d| d.code).collect();
-    assert!(
-        diagnostics.contains(
-            &diagnostic_codes::JSDOC_TYPES_CAN_ONLY_BE_USED_INSIDE_DOCUMENTATION_COMMENTS
-        ),
-        "Expected TS8020 for `Foo<?>`, got {:?}",
-        parser.get_diagnostics(),
-    );
-    assert!(
-        !diagnostics.contains(&diagnostic_codes::TYPE_EXPECTED),
-        "Expected no TS1110 for `Foo<?>`, got {:?}",
-        parser.get_diagnostics(),
-    );
-    assert!(
-        !diagnostics.contains(&diagnostic_codes::AT_THE_START_OF_A_TYPE_IS_NOT_VALID_TYPESCRIPT_SYNTAX_DID_YOU_MEAN_TO_WRITE),
-        "Expected no TS17020 for `Foo<?>`, got {:?}",
-        parser.get_diagnostics(),
-    );
+fn test_type_argument_with_empty_jsdoc_wildcard_emits_ts1110() {
+    // A bare `?` wildcard type argument (`Foo<?>`) is `Type expected.` (TS1110)
+    // in tsc, not TS8020 — tsc reserves TS8020 for `*` and dotted `Foo.<T>`.
+    // Oracle (`typescript@7.0.2`): `type T = Foo<?>;` -> TS1110 at the `>`.
+    assert_bare_wildcard_is_ts1110("type T = Foo<?>;\n", "`Foo<?>`");
 }
 
 #[test]
@@ -79,30 +59,11 @@ type T = Foo<?undefined>;
 }
 
 #[test]
-fn test_expression_type_argument_with_empty_jsdoc_wildcard_emits_ts8020_only() {
-    let source = r#"
-const WhatFoo = foo<?>;
-"#;
-    let (parser, _root) = parse_source(source);
-
-    let diagnostics: Vec<u32> = parser.get_diagnostics().iter().map(|d| d.code).collect();
-    assert!(
-        diagnostics.contains(
-            &diagnostic_codes::JSDOC_TYPES_CAN_ONLY_BE_USED_INSIDE_DOCUMENTATION_COMMENTS
-        ),
-        "Expected TS8020 for `foo<?>`, got {:?}",
-        parser.get_diagnostics(),
-    );
-    assert!(
-        !diagnostics.contains(&diagnostic_codes::TYPE_EXPECTED),
-        "Expected no TS1110 for `foo<?>`, got {:?}",
-        parser.get_diagnostics(),
-    );
-    assert!(
-        !diagnostics.contains(&diagnostic_codes::AT_THE_START_OF_A_TYPE_IS_NOT_VALID_TYPESCRIPT_SYNTAX_DID_YOU_MEAN_TO_WRITE),
-        "Expected no TS17020 for `foo<?>`, got {:?}",
-        parser.get_diagnostics(),
-    );
+fn test_expression_type_argument_with_empty_jsdoc_wildcard_emits_ts1110() {
+    // A bare `?` wildcard in an expression's type-argument list (`foo<?>`) is
+    // TS1110 in tsc, not TS8020. Oracle (`typescript@7.0.2`):
+    // `const WhatFoo = foo<?>;` -> TS1110 at the `>`.
+    assert_bare_wildcard_is_ts1110("const WhatFoo = foo<?>;\n", "`foo<?>`");
 }
 
 #[test]
@@ -204,4 +165,77 @@ let whatevs: * = 1001;
         "Expected only TS8020 for wildcard type, got {:?}",
         parser.get_diagnostics()
     );
+}
+
+// ---------------------------------------------------------------------------
+// #17001: a *bare* `?`/`!` JSDoc wildcard (no operand) in a type position is
+// TS1110 (`Type expected.`) in tsc, not TS8020. Every case below is
+// oracle-verified against `typescript@7.0.2`
+// (`tsc --noEmit --strict --lib es2022 --target es2022`). The `*` all-type and
+// the dotted `Foo.<T>` legacy generic genuinely stay TS8020 (pinned above);
+// a wildcard *followed by a real type* (`?string`) stays TS17020 (pinned
+// above). Only the bare, operand-less wildcard is TS1110.
+// ---------------------------------------------------------------------------
+
+/// Assert a bare-wildcard source reports TS1110 and neither TS8020 nor TS17020.
+fn assert_bare_wildcard_is_ts1110(source: &str, label: &str) {
+    let (parser, _root) = parse_source(source);
+    let diagnostics: Vec<u32> = parser.get_diagnostics().iter().map(|d| d.code).collect();
+    assert!(
+        diagnostics.contains(&diagnostic_codes::TYPE_EXPECTED),
+        "Expected TS1110 for {label}, got {:?}",
+        parser.get_diagnostics(),
+    );
+    assert!(
+        !diagnostics.contains(
+            &diagnostic_codes::JSDOC_TYPES_CAN_ONLY_BE_USED_INSIDE_DOCUMENTATION_COMMENTS
+        ),
+        "Expected no TS8020 for {label}, got {:?}",
+        parser.get_diagnostics(),
+    );
+    assert!(
+        !diagnostics.contains(
+            &diagnostic_codes::AT_THE_START_OF_A_TYPE_IS_NOT_VALID_TYPESCRIPT_SYNTAX_DID_YOU_MEAN_TO_WRITE
+        ),
+        "Expected no TS17020 for {label}, got {:?}",
+        parser.get_diagnostics(),
+    );
+}
+
+#[test]
+fn test_bare_question_wildcard_in_annotation_is_ts1110() {
+    // Oracle: `var x: ?;` -> TS1110 at the `;`.
+    assert_bare_wildcard_is_ts1110("var x: ?;\n", "`var x: ?;`");
+}
+
+#[test]
+fn test_bare_question_wildcard_in_required_position_is_ts1110() {
+    // Oracle: `type T = string | ?;` -> TS1110 (a `|`-separated constituent is a
+    // *required* type position, so tsc reports even at a terminator).
+    assert_bare_wildcard_is_ts1110("type T = string | ?;\n", "`string | ?`");
+}
+
+#[test]
+fn test_bare_question_wildcard_in_tuple_is_ts1110() {
+    // Oracle: `type T = [?];` -> TS1110.
+    assert_bare_wildcard_is_ts1110("type T = [?];\n", "`[?]`");
+}
+
+#[test]
+fn test_bare_question_wildcard_with_following_comma_is_ts1110() {
+    // Oracle: `type T = Map<?, string>;` -> TS1110 at the `,`.
+    assert_bare_wildcard_is_ts1110("type T = Map<?, string>;\n", "`Map<?, string>`");
+}
+
+#[test]
+fn test_bare_bang_wildcard_in_annotation_is_ts1110() {
+    // Oracle: `var x: !;` -> TS1110.
+    assert_bare_wildcard_is_ts1110("var x: !;\n", "`var x: !;`");
+}
+
+#[test]
+fn test_bare_bang_wildcard_in_type_argument_is_ts1110() {
+    // Oracle: `type T = Foo<!>;` -> TS1110 (the `!` flows through the ordinary
+    // primary-type parse for each type argument).
+    assert_bare_wildcard_is_ts1110("type T = Foo<!>;\n", "`Foo<!>`");
 }


### PR DESCRIPTION
Closes #17001. Found while auditing parser-emitted grammar diagnostics for #16279.

**Structural rule:** when a **bare** JSDoc wildcard `?` or `!` (no operand) appears in a TypeScript type position, `tsc` consumes the wildcard and reports **TS1110** (`Type expected.`) at the following token; tsz reported **TS8020** (`JSDoc types can only be used inside documentation comments.`) instead. Fixed in the parser (owner layer) by routing all four bare-wildcard branches through the canonical `error_type_expected()` helper — the same one the general "token can't start a type" fallback uses.

The four branches:
- the `?` and `!` branches of `parse_primary_type_required` (`state_types.rs`)
- the `foo<?>` / `foo<?` branches of `parse_type_argument_in_type_arguments` (`state_types_advanced.rs`), now collapsed into one since their bodies became identical.

Recovery is unchanged (consume the wildcard, return a synthetic identifier); only the diagnostic code/message/position moves to match `tsc`. Because TS1110 is a *structural* parse error (unlike TS8020), the fix also makes tsz suppress the semantic error `tsc` suppresses — e.g. `type T = Foo<?>;` now reports only TS1110, not TS1110 + a spurious TS2304 for `Foo`.

**Not changed (verified still correct):** the `*` all-type (`let x: * = 1`) and dotted `Foo.<T>` legacy generic genuinely stay **TS8020**; a wildcard *followed by a real type* (`?string`) stays **TS17020**.

## Goal
Goal: hold

## Verification
Pinned oracle: `typescript@7.0.2` (`tsc --noEmit --strict --pretty false --lib es2022 --target es2022`).

- **Oracle parity, code + message + position** — every bare `?`/`!` shape now matches `tsc` exactly (built `tsz` vs oracle):

  | source | tsz & tsc |
  | --- | --- |
  | `var x: ?;` / `var y: !;` | `(1,9) TS1110` |
  | `type T = Foo<?>;` / `Foo<!>` | `(1,15) TS1110` |
  | `type T = Map<?, string>;` | `(1,15) TS1110` (at the `,`) |
  | `const W = foo<?>;` | TS1110 |
  | `type T = string \| ?;` / `[?]` | TS1110 |
  | `let w: * = 1;` / `Array.<string>` | TS8020 (unchanged) |
  | `Foo<?string>` / `var x: !number;` | TS17020 (unchanged) |

- **Unit** — `cargo test -p tsz-parser --lib jsdoc_type_recovery`: 14 passed (2 corrected + 6-case matrix added: annotation, required union constituent, tuple, type-argument, comma, `!`). Full `tsz-parser` lib suite: 2213 passed, 0 failed.
- **Clippy** — `cargo clippy --workspace --all-targets`: clean.
- **Arch-size** — all touched files under the 2000-line cap; pre-commit arch guard passed.
- **Conformance impact** — the only two corpus fixtures exercising this pattern (`compiler/expressionWithJSDocTypeArguments.ts`, `conformance/jsdoc/jsdocDisallowedInTypescript.ts`) are already-failing and move **strictly toward** parity (the bare-`?`/`!` lines flip TS8020 → TS1110, matching `tsc`; their remaining deltas are unrelated pre-existing TS17019/17020 over-reporting). No *passing* fixture can be affected: `tsc` emits TS1110 for a bare wildcard, so a passing test could never have relied on tsz's old TS8020. (Full conformance/emit suites need the TypeScript submodule, not present here; this change only affects invalid-syntax recovery, which never appears in valid emit fixtures.)

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_014RFndvQ3fvmbJCGeXZqiKr)_