### PR TITLE
fix(checker): gate TS2430 on the TS2320 simultaneous-extend conflict like tsc

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -35,6 +35,9 @@ stacker = "0.1.23"
 name = "import_assert_keyword_abandon_tests"
 path = "tests/import_assert_keyword_abandon_tests.rs"
 [[test]]
+name = "interface_simultaneous_extend_suppresses_incorrectly_extends_tests"
+path = "tests/interface_simultaneous_extend_suppresses_incorrectly_extends_tests.rs"
+[[test]]
 name = "evolving_array_assignment_contextual_inference_tests"
 path = "tests/evolving_array_assignment_contextual_inference_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -885,7 +885,7 @@ impl CheckerState<'_> {
 
         self.rewrite_conditional_types1_fingerprints(&sf.text);
         self.align_awaited_type_instantiation_diagnostics(&sf.text);
-        self.align_complex_recursive_collections_diagnostics(&sf.text);
+        self.suppress_incorrectly_extends_on_simultaneous_extend_conflict();
     }
 
     /// Grammar pass for misplaced `unique symbol` type operators — the
@@ -1209,32 +1209,55 @@ impl CheckerState<'_> {
         }
     }
 
-    fn align_complex_recursive_collections_diagnostics(&mut self, source_text: &str) {
-        use tsz_common::diagnostics::diagnostic_codes;
+    /// Reconcile TS2430 with TS2320 the way tsc's `checkInterfaceDeclaration` does.
+    ///
+    /// This is a structural diagnostic reconciliation, **not** a conformance-fixture
+    /// rewrite like its `rewrite_*`/`align_*` neighbours: it takes no source text and
+    /// keys only on diagnostic codes and structural anchor offsets. Do not fold it in
+    /// when those fixture rewrites are eventually deleted (#14141).
+    ///
+    /// tsc runs the per-base "incorrectly extends" (TS2430) assignability loop only
+    /// when `checkInheritedPropertiesAreIdentical` succeeds. When two bases of an
+    /// interface contribute a shared member with non-identical types, tsc reports
+    /// TS2320 ("cannot simultaneously extend types '{0}' and '{1}'") and skips the
+    /// TS2430 loop for that interface entirely. tsz's heritage-compatibility pass
+    /// (`check_interface_extension_compatibility`) emits TS2430 eagerly while
+    /// iterating the bases, so when a *later* base introduces the conflict the
+    /// TS2430 already reported against an *earlier* base is not withheld and the
+    /// interface ends up carrying both a TS2320 and one or more spurious TS2430.
+    ///
+    /// The reconciliation leans on an invariant of the heritage checkers: every
+    /// TS2320 and TS2430 is emitted via `error_at_node(iface_data.name, ...)`, so
+    /// both anchor at the interface name node (see `class_checker_compat.rs` and
+    /// `class_checker_compat_overloads.rs`). A TS2430 sharing a start offset with a
+    /// TS2320 is therefore, unambiguously, the same interface — exactly the
+    /// "incorrectly extends" tsc's gated loop would never have produced; drop it. If
+    /// a future refactor moves either anchor off the name node, this key must move
+    /// with it.
+    fn suppress_incorrectly_extends_on_simultaneous_extend_conflict(&mut self) {
+        use crate::diagnostics::diagnostic_codes;
 
-        if !Self::fixture_has_markers(
-            source_text,
-            &[
-                "declare namespace Immutable",
-                "export interface Keyed<K, V> extends Seq<K, V>",
-                "export interface Indexed<T> extends Seq<number, T>",
-                "export interface Set<T> extends Seq<never, T>",
-            ],
-        ) {
+        let conflict_anchors: FxHashSet<u32> = self
+            .ctx
+            .diagnostics
+            .iter()
+            .filter(|diag| {
+                diag.code == diagnostic_codes::INTERFACE_CANNOT_SIMULTANEOUSLY_EXTEND_TYPES_AND
+            })
+            .map(|diag| diag.start)
+            .collect();
+        if conflict_anchors.is_empty() {
             return;
         }
 
-        let extra_messages = [
-            "Interface 'Keyed<K, V>' incorrectly extends interface 'Seq<K, V>'.",
-            "Interface 'Indexed<T>' incorrectly extends interface 'Seq<number, T>'.",
-            "Interface 'Set<T>' incorrectly extends interface 'Seq<never, T>'.",
-        ];
+        let before = self.ctx.diagnostics.len();
         self.ctx.diagnostics.retain(|diag| {
-            diag.code != diagnostic_codes::INTERFACE_INCORRECTLY_EXTENDS_INTERFACE
-                || !extra_messages
-                    .iter()
-                    .any(|message| diag.message_text == *message)
+            !(diag.code == diagnostic_codes::INTERFACE_INCORRECTLY_EXTENDS_INTERFACE
+                && conflict_anchors.contains(&diag.start))
         });
+        if self.ctx.diagnostics.len() != before {
+            self.ctx.rebuild_emitted_diagnostics_from_current();
+        }
     }
 
     fn has_ts_nocheck_pragma(&self, source: &str) -> bool {

--- a/crates/tsz-checker/tests/interface_simultaneous_extend_suppresses_incorrectly_extends_tests.rs
+++ b/crates/tsz-checker/tests/interface_simultaneous_extend_suppresses_incorrectly_extends_tests.rs
@@ -1,0 +1,178 @@
+//! Parity for tsc's `checkInterfaceDeclaration` gate between TS2320 and TS2430.
+//!
+//! tsc runs the per-base "incorrectly extends" (TS2430) assignability loop only
+//! when `checkInheritedPropertiesAreIdentical` succeeds. When two bases of an
+//! interface contribute a shared member with non-identical types, tsc reports
+//! TS2320 ("cannot simultaneously extend types '{0}' and '{1}'") and skips the
+//! TS2430 loop for that interface entirely — so a conflicting interface never
+//! carries both codes.
+//!
+//! tsz's heritage-compatibility pass emits TS2430 eagerly while iterating bases,
+//! so when a *later* base introduces the conflict, a TS2430 already reported
+//! against an *earlier* base was not withheld. The checker now reconciles this to
+//! tsc by dropping any TS2430 anchored at the same position as a TS2320. These
+//! rows pin both directions: the conflict must suppress TS2430, and a genuine
+//! incorrect-extends with no cross-base conflict must still report it.
+//!
+//! This is the structural root-cause fix that replaces the `complexRecursiveCollections`
+//! fixture-text rewrite removed from `source_file.rs` (#14141).
+
+use tsz_checker::test_utils::check_source_code_messages;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_code_messages(source)
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect()
+}
+
+fn count(source: &str, code: u32) -> usize {
+    codes(source).iter().filter(|&&c| c == code).count()
+}
+
+// ---------------------------------------------------------------------------
+// Positive: a cross-base conflict (TS2320) suppresses TS2430 for that interface,
+// even though the derived interface's own member is incompatible with an
+// earlier base (which is what makes tsz emit the eager TS2430).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn conflicting_bases_suppress_incorrectly_extends() {
+    // `p` is shared by A and B with different types -> TS2320 on C.
+    // `m` on C is incompatible with A.m -> tsz eagerly emits TS2430 (vs A) while
+    // iterating base A, before the A/B conflict on `p` is discovered on base B.
+    // tsc reports only TS2320 and skips the TS2430 loop; tsz now matches.
+    let source = r#"
+interface A { p: string; m: string; }
+interface B { p: number; }
+interface C extends A, B { m: boolean; }
+"#;
+    let cs = codes(source);
+    assert!(
+        cs.contains(&2320),
+        "two conflicting bases must report TS2320, got: {cs:?}"
+    );
+    assert!(
+        !cs.contains(&2430),
+        "an interface with a TS2320 cross-base conflict must not also report \
+         TS2430; got: {cs:?}"
+    );
+}
+
+#[test]
+fn conflicting_bases_suppress_incorrectly_extends_renamed_binders() {
+    // Same shape, every binder renamed: the reconciliation is by diagnostic code
+    // and anchor position, never by identifier text.
+    let source = r#"
+interface Alpha { field: string; method: string; }
+interface Beta { field: number; }
+interface Gamma extends Alpha, Beta { method: boolean; }
+"#;
+    let cs = codes(source);
+    assert!(
+        cs.contains(&2320),
+        "renamed conflicting bases must still report TS2320, got: {cs:?}"
+    );
+    assert!(
+        !cs.contains(&2430),
+        "renamed conflicting-base interface must not report TS2430, got: {cs:?}"
+    );
+}
+
+#[test]
+fn conflicting_bases_without_own_incompatible_member_report_only_ts2320() {
+    // No derived-vs-base incompatibility at all; only the cross-base `p` conflict.
+    let source = r#"
+interface A { p: string; }
+interface B { p: number; }
+interface C extends A, B { }
+"#;
+    let cs = codes(source);
+    assert!(cs.contains(&2320), "expected TS2320, got: {cs:?}");
+    assert!(!cs.contains(&2430), "expected no TS2430, got: {cs:?}");
+}
+
+#[test]
+fn three_bases_two_conflicting_still_suppress_incorrectly_extends() {
+    // A third, compatible base does not change the outcome: the A/B conflict on
+    // `p` fires TS2320, and the eager TS2430 from C.m-vs-A.m is suppressed.
+    let source = r#"
+interface A { p: string; m: string; }
+interface B { p: number; }
+interface D { q: number; }
+interface C extends A, D, B { m: boolean; }
+"#;
+    let cs = codes(source);
+    assert!(cs.contains(&2320), "expected TS2320, got: {cs:?}");
+    assert!(!cs.contains(&2430), "expected no TS2430, got: {cs:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls: with no cross-base conflict, a genuine incorrect-extends
+// must still report TS2430 (the reconciliation must not over-suppress).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn single_base_incompatible_still_reports_ts2430() {
+    let source = r#"
+interface Base { m: string; }
+interface Derived extends Base { m: boolean; }
+"#;
+    let cs = codes(source);
+    assert!(
+        cs.contains(&2430),
+        "a single-base incompatible override must still report TS2430, got: {cs:?}"
+    );
+    assert!(
+        !cs.contains(&2320),
+        "a single base cannot produce a simultaneous-extend conflict, got: {cs:?}"
+    );
+}
+
+#[test]
+fn disjoint_bases_incompatible_override_still_reports_ts2430() {
+    // X and Y share no member -> no TS2320. Z.a is incompatible with X.a, so the
+    // TS2430 loop runs and must still fire.
+    let source = r#"
+interface X { a: string; }
+interface Y { b: number; }
+interface Z extends X, Y { a: boolean; }
+"#;
+    let cs = codes(source);
+    assert!(
+        cs.contains(&2430),
+        "disjoint bases with an incompatible override must still report TS2430, \
+         got: {cs:?}"
+    );
+    assert!(
+        !cs.contains(&2320),
+        "disjoint bases must not report a simultaneous-extend conflict, got: {cs:?}"
+    );
+}
+
+#[test]
+fn unrelated_conflicting_interface_does_not_suppress_another_interfaces_ts2430() {
+    // One interface has a TS2320 conflict; a *different* interface genuinely
+    // incorrectly extends its single base. The second must keep its TS2430 —
+    // suppression is scoped to the conflicting interface's own anchor.
+    let source = r#"
+interface A { p: string; }
+interface B { p: number; }
+interface C extends A, B { }
+
+interface Base { m: string; }
+interface Derived extends Base { m: boolean; }
+"#;
+    assert_eq!(
+        count(source, 2320),
+        1,
+        "exactly one TS2320 expected: {:?}",
+        codes(source)
+    );
+    assert_eq!(
+        count(source, 2430),
+        1,
+        "the unrelated Derived must keep its TS2430: {:?}",
+        codes(source)
+    );
+}


### PR DESCRIPTION
Removes one of the fixture-scoped diagnostic rewrites tracked by #14141 (`align_complex_recursive_collections_diagnostics`, the `complexRecursiveCollections` fixture) by fixing the underlying semantics.

**Structural rule.** When two bases of an interface contribute a shared member with non-identical types, `tsc`'s `checkInterfaceDeclaration` reports **TS2320** ("Interface 'X' cannot simultaneously extend types 'A' and 'B'") and — because `checkInheritedPropertiesAreIdentical` returned false — **skips the per-base "incorrectly extends" (TS2430) assignability loop for that interface entirely**. So a conflicting interface never carries both codes. tsz's `check_interface_extension_compatibility` emits TS2430 eagerly while iterating bases, so when a *later* base introduces the cross-base conflict, a TS2430 already reported against an *earlier* base was not withheld — the interface ended up with both a TS2320 and one or more spurious TS2430. Owner layer: checker (interface heritage compatibility / source-file finalization).

**Fix.** Reconcile to tsc in the checker's source-file finalization: drop any TS2430 whose anchor coincides with a TS2320. Both diagnostics anchor at the interface name node, so identical start offsets identify exactly the "incorrectly extends" entries tsc's gated loop would never have produced. Keyed only on diagnostic **codes** and structural **anchor offsets** — no message text, identifier, source text, or fixture matching, so it passes the anti-hardcoding gate. This is a general invariant, not a `complexRecursiveCollections`-specific patch.

**What this removes.** `align_complex_recursive_collections_diagnostics` gated on `source_text.contains("declare namespace Immutable")` etc. and dropped three hardcoded message sentences (`Interface 'Keyed<K, V>' incorrectly extends interface 'Seq<K, V>'.` …). Deleted, along with its dispatch.

**`complexRecursiveCollections` oracle (pinned `typescript@7.0.2`).** The 3 removed spurious TS2430 were `Keyed/Indexed/Set incorrectly extends Seq`, exactly the interfaces `tsc` reports TS2320 for (`Seq.Keyed extends Seq<K,V>, Collection.Keyed<K,V>`, etc.). tsc keeps the four `… incorrectly extends Collection<…>` TS2430 (single-base `Collection.*` interfaces, no conflict) — those are unaffected because the fix only suppresses TS2430 co-anchored with a TS2320.

**Adjacent-case matrix** (new unit test `interface_simultaneous_extend_suppresses_incorrectly_extends_tests.rs`, 7 rows, lib-free `check_source`):

| shape | tsc / tsz-after |
| --- | --- |
| `C extends A, B` (A,B conflict on `p`), `C.m` incompatible with `A.m` | TS2320 only, no TS2430 |
| same, renamed binders | TS2320 only |
| `C extends A, B` conflict, no own incompatible member | TS2320 only |
| `C extends A, D, B` (A/B conflict, D compatible), `C.m` incompatible with A | TS2320 only |
| `Derived extends Base` single base, incompatible override | **TS2430 still fires** (negative control) |
| `Z extends X, Y` disjoint bases, `Z.a` incompatible with `X.a` | **TS2430 still fires** (no over-suppression) |
| conflicting interface + unrelated genuinely-incorrect interface | 1× TS2320 **and** 1× TS2430 (scoping) |

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test interface_simultaneous_extend_suppresses_incorrectly_extends_tests` — **7/7 pass**.
- `python3 scripts/arch/arch_guard.py` — passed (arch-size + anti-hardcoding).
- `cargo clippy -p tsz-checker --all-targets` — clean (exit 0, no warnings).
- Pre-commit hook (formatting + affected `tsz-checker` tests) — passed.
- **Conformance `scripts/conformance/compare-to-parent.sh HEAD~1`** (drift-free, both sides built + snapshotted):
  - branch **11564 passed** · base (main) **11564 passed**
  - **NEWLY FAILING: 0** · newly passing: 0 · fingerprint-changed: 0
  - This is the expected hack→real-fix result: `complexRecursiveCollections` was already green on main *via the removed hack* and stays green *via real semantics*, with zero collateral and zero fingerprint changes anywhere in the corpus.
- Emit/fourslash unaffected (change touches only TS2320/TS2430 diagnostic reconciliation, not JS/DTS output); they run in the nightly lane.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high