### PR TITLE
fix(fourslash): split completed-but-slow and never-ran tests from the failure buckets (#17010)

### DIFF
--- a/scripts/ci/full-ci-summary.py
+++ b/scripts/ci/full-ci-summary.py
@@ -191,12 +191,27 @@ def fourslash_summary(metrics_dir: Path, logs_dir: Path, lines: list[str]) -> No
     if not details:
         details = [load_json(Path("scripts/fourslash/fourslash-snapshot.json")) or {}]
 
-    failures = [
-        result
-        for detail in details
-        for result in (detail.get("results") or detail.get("fail") or [])
-        if result.get("status") != "pass" or result.get("timedOut")
-    ]
+    # A completed-but-slow test passed its assertions; only fail/timeout/unrun
+    # are genuine non-passes worth surfacing here (issue #17010). A shard detail
+    # carries a full `results` array; the compact snapshot splits the failure
+    # family across fail/timeout/unrun (older ones only have `fail`).
+    non_passing_statuses = {"fail", "timeout", "unrun"}
+
+    def failing_rows(detail):
+        results = detail.get("results")
+        if isinstance(results, list):
+            return [
+                r for r in results
+                if r.get("status") in non_passing_statuses or (
+                    r.get("timedOut") and r.get("status") not in ("pass", "slow", "xfail")
+                )
+            ]
+        rows = []
+        for bucket in ("fail", "timeout", "unrun"):
+            rows.extend(detail.get(bucket) or [])
+        return rows
+
+    failures = [result for detail in details for result in failing_rows(detail)]
     if failures:
         lines.append("#### Fourslash Failures")
         lines.append("")

--- a/scripts/ci/full-ci-summary.py
+++ b/scripts/ci/full-ci-summary.py
@@ -7,8 +7,15 @@ import argparse
 import json
 import os
 import re
+import sys
 from pathlib import Path
 from typing import Any
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from lib.query_snapshot import (  # noqa: E402
+    FOURSLASH_NON_PASSING_BUCKETS,
+    FOURSLASH_NON_PASSING_STATUSES,
+)
 
 MAX_SUMMARY_CHARS = 60000
 ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
@@ -192,22 +199,17 @@ def fourslash_summary(metrics_dir: Path, logs_dir: Path, lines: list[str]) -> No
         details = [load_json(Path("scripts/fourslash/fourslash-snapshot.json")) or {}]
 
     # A completed-but-slow test passed its assertions; only fail/timeout/unrun
-    # are genuine non-passes worth surfacing here (issue #17010). A shard detail
-    # carries a full `results` array; the compact snapshot splits the failure
-    # family across fail/timeout/unrun (older ones only have `fail`).
-    non_passing_statuses = {"fail", "timeout", "unrun"}
-
+    # are genuine non-passes worth surfacing here (issue #17010). `status` is
+    # authoritative — the producer guarantees any non-completion carries
+    # status "timeout" — so we trust it rather than re-deriving from `timedOut`.
+    # A shard detail carries a full `results` array; the compact snapshot splits
+    # the failure family across the buckets (older ones only have `fail`).
     def failing_rows(detail):
         results = detail.get("results")
         if isinstance(results, list):
-            return [
-                r for r in results
-                if r.get("status") in non_passing_statuses or (
-                    r.get("timedOut") and r.get("status") not in ("pass", "slow", "xfail")
-                )
-            ]
+            return [r for r in results if r.get("status") in FOURSLASH_NON_PASSING_STATUSES]
         rows = []
-        for bucket in ("fail", "timeout", "unrun"):
+        for bucket in FOURSLASH_NON_PASSING_BUCKETS:
             rows.extend(detail.get(bucket) or [])
         return rows
 

--- a/scripts/ci/test_refresh_readme.py
+++ b/scripts/ci/test_refresh_readme.py
@@ -50,6 +50,30 @@ class RefreshReadmeTests(unittest.TestCase):
         self.assertEqual(summary["passed"], 6558)
         self.assertEqual(summary["total"], 6562)
 
+    def test_fourslash_bucket_shape_counts_slow_as_passing(self):
+        # A summary-less snapshot (the fallback shape): completed-but-slow tests
+        # count as passing; only fail/timeout/unrun are non-passing (#17010).
+        summary = refresh_readme.normalize_suite_summary({
+            "pass": ["a", "b", "c"],
+            "slow": ["d", "e"],
+            "fail": [{"name": "f"}],
+            "timeout": [{"name": "g"}],
+            "unrun": [{"name": "h"}],
+        }, "fourslash")
+
+        self.assertEqual(summary["passed"], 5)   # 3 pass + 2 slow
+        self.assertEqual(summary["total"], 8)    # 5 passing + 3 non-passing
+
+    def test_fourslash_bucket_shape_tolerates_missing_new_buckets(self):
+        # Older snapshots have only pass/fail — the new buckets default to empty.
+        summary = refresh_readme.normalize_suite_summary({
+            "pass": ["a", "b"],
+            "fail": [{"name": "f"}],
+        }, "fourslash")
+
+        self.assertEqual(summary["passed"], 2)
+        self.assertEqual(summary["total"], 3)
+
     def test_ci_emit_metric_shape_normalizes_to_readme_summary(self):
         summary = refresh_readme.normalize_emit_summary({
             "suite": "emit",

--- a/scripts/fourslash/query-fourslash.py
+++ b/scripts/fourslash/query-fourslash.py
@@ -54,33 +54,44 @@ def normalized_results(data):
         return data["results"]
 
     results = []
-    for file_name in data.get("pass", []):
-        if isinstance(file_name, str):
-            results.append({
-                "file": file_name,
-                "name": test_name_from_file(file_name),
-                "status": "pass",
-                "timedOut": False,
-            })
-        elif isinstance(file_name, dict):
-            record = dict(file_name)
+    # `pass` and `slow` hold bare file paths (both are assertion-passes; slow
+    # just overran the wall-clock budget — issue #17010). `timedOut` stays
+    # False for slow because it completed.
+    for status, bucket in (("pass", "pass"), ("slow", "slow")):
+        for file_name in data.get(bucket, []):
+            if isinstance(file_name, str):
+                results.append({
+                    "file": file_name,
+                    "name": test_name_from_file(file_name),
+                    "status": status,
+                    "timedOut": False,
+                })
+            elif isinstance(file_name, dict):
+                record = dict(file_name)
+                record.setdefault("file", record.get("name", ""))
+                record.setdefault("name", test_name_from_file(record.get("file", "")))
+                record.setdefault("status", status)
+                record.setdefault("timedOut", False)
+                results.append(record)
+
+    # Failure family. `fail` predates the fail/timeout/unrun split, so a legacy
+    # snapshot's `fail` array may still carry timeout rows (status derived from
+    # `timedOut`); the newer per-bucket arrays each carry their own status.
+    for bucket, default_status in (("fail", None), ("timeout", "timeout"), ("unrun", "unrun")):
+        for failure in data.get(bucket, []):
+            if isinstance(failure, str):
+                failure = {"file": failure}
+            record = dict(failure)
             record.setdefault("file", record.get("name", ""))
             record.setdefault("name", test_name_from_file(record.get("file", "")))
-            record.setdefault("status", "pass")
             record.setdefault("timedOut", False)
+            if default_status is not None:
+                record.setdefault("status", default_status)
+            else:
+                record.setdefault("status", "timeout" if record["timedOut"] else "fail")
+            if "firstFailure" not in record and "output" in record:
+                record["firstFailure"] = record["output"]
             results.append(record)
-
-    for failure in data.get("fail", []):
-        if isinstance(failure, str):
-            failure = {"file": failure}
-        record = dict(failure)
-        record.setdefault("file", record.get("name", ""))
-        record.setdefault("name", test_name_from_file(record.get("file", "")))
-        record.setdefault("timedOut", False)
-        record.setdefault("status", "timeout" if record["timedOut"] else "fail")
-        if "firstFailure" not in record and "output" in record:
-            record["firstFailure"] = record["output"]
-        results.append(record)
 
     results.sort(key=lambda r: r.get("file", ""))
     return results
@@ -89,15 +100,22 @@ def normalized_results(data):
 def normalized_summary(data, results):
     summary = data.get("summary") or {}
     total = summary.get("total", len(results))
-    passed = summary.get("passed", sum(1 for r in results if r.get("status") == "pass"))
-    failed = summary.get("failed", sum(1 for r in results if r.get("status") not in ("pass", "timeout")))
-    timed_out = summary.get("timedOut", sum(1 for r in results if r.get("timedOut")))
-    pass_rate = summary.get("passRate", round((passed / total) * 100, 1) if total else 0)
+    # Passing = pass + slow (slow completed its assertions). Failed counts only
+    # genuine assertion failures; timeout/unrun are their own tallies (#17010).
+    passed = summary.get("passed", sum(1 for r in results if r.get("status") in ("pass", "slow")))
+    failed = summary.get("failed", sum(1 for r in results if r.get("status") == "fail"))
+    timed_out = summary.get("timedOut", sum(1 for r in results if r.get("status") == "timeout"))
+    slow = summary.get("slow", sum(1 for r in results if r.get("status") == "slow"))
+    unrun = summary.get("unrun", sum(1 for r in results if r.get("status") == "unrun"))
+    executed = total - unrun
+    pass_rate = summary.get("passRate", round((passed / executed) * 100, 1) if executed else 0)
     return {
         "total": total,
         "passed": passed,
         "failed": failed,
+        "slow": slow,
         "timedOut": timed_out,
+        "unrun": unrun,
         "passRate": pass_rate,
     }
 
@@ -108,9 +126,13 @@ def show_overview(data):
     print(f"Fourslash Test Results")
     print(f"  Total: {s['total']}")
     print(f"  Passed: {s['passed']} ({s['passRate']}%)")
+    if s.get("slow", 0) > 0:
+        print(f"    of which slow (completed over budget): {s['slow']}")
     print(f"  Failed: {s['failed']}")
     if s.get("timedOut", 0) > 0:
         print(f"  Timed out: {s['timedOut']}")
+    if s.get("unrun", 0) > 0:
+        print(f"  Did not run: {s['unrun']}")
     print()
 
     fails = [r for r in results if r["status"] == "fail"]

--- a/scripts/fourslash/query-fourslash.py
+++ b/scripts/fourslash/query-fourslash.py
@@ -36,7 +36,13 @@ from collections import Counter
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from lib.query_snapshot import load_snapshot, print_top_counter, print_truncated_more
+from lib.query_snapshot import (
+    FOURSLASH_NON_PASSING_BUCKETS,
+    FOURSLASH_PASSING_BUCKETS,
+    load_snapshot,
+    print_top_counter,
+    print_truncated_more,
+)
 
 SNAPSHOT_FILE = Path(__file__).parent / "fourslash-snapshot.json"
 
@@ -54,30 +60,32 @@ def normalized_results(data):
         return data["results"]
 
     results = []
-    # `pass` and `slow` hold bare file paths (both are assertion-passes; slow
-    # just overran the wall-clock budget — issue #17010). `timedOut` stays
-    # False for slow because it completed.
-    for status, bucket in (("pass", "pass"), ("slow", "slow")):
+    # Passing buckets (pass, slow) hold bare file paths — both are
+    # assertion-passes; slow just overran the wall-clock budget (issue #17010).
+    # `timedOut` stays False for slow because it completed. The bucket name is
+    # the status.
+    for bucket in FOURSLASH_PASSING_BUCKETS:
         for file_name in data.get(bucket, []):
             if isinstance(file_name, str):
                 results.append({
                     "file": file_name,
                     "name": test_name_from_file(file_name),
-                    "status": status,
+                    "status": bucket,
                     "timedOut": False,
                 })
             elif isinstance(file_name, dict):
                 record = dict(file_name)
                 record.setdefault("file", record.get("name", ""))
                 record.setdefault("name", test_name_from_file(record.get("file", "")))
-                record.setdefault("status", status)
+                record.setdefault("status", bucket)
                 record.setdefault("timedOut", False)
                 results.append(record)
 
     # Failure family. `fail` predates the fail/timeout/unrun split, so a legacy
     # snapshot's `fail` array may still carry timeout rows (status derived from
     # `timedOut`); the newer per-bucket arrays each carry their own status.
-    for bucket, default_status in (("fail", None), ("timeout", "timeout"), ("unrun", "unrun")):
+    for bucket in FOURSLASH_NON_PASSING_BUCKETS:
+        default_status = None if bucket == "fail" else bucket
         for failure in data.get(bucket, []):
             if isinstance(failure, str):
                 failure = {"file": failure}
@@ -102,7 +110,7 @@ def normalized_summary(data, results):
     total = summary.get("total", len(results))
     # Passing = pass + slow (slow completed its assertions). Failed counts only
     # genuine assertion failures; timeout/unrun are their own tallies (#17010).
-    passed = summary.get("passed", sum(1 for r in results if r.get("status") in ("pass", "slow")))
+    passed = summary.get("passed", sum(1 for r in results if r.get("status") in FOURSLASH_PASSING_BUCKETS))
     failed = summary.get("failed", sum(1 for r in results if r.get("status") == "fail"))
     timed_out = summary.get("timedOut", sum(1 for r in results if r.get("status") == "timeout"))
     slow = summary.get("slow", sum(1 for r in results if r.get("status") == "slow"))

--- a/scripts/fourslash/runner.cjs
+++ b/scripts/fourslash/runner.cjs
@@ -193,6 +193,12 @@ function snapshotWeightFile() {
     return path.join(__dirname, "fourslash-snapshot.json");
 }
 
+// Compact-snapshot bucket names, single-sourced (issue #17010). File buckets
+// hold bare paths (both are assertion-passes); row buckets hold failure-family
+// detail objects. Everything that splits results by outcome iterates these.
+const SNAPSHOT_FILE_BUCKETS = ["pass", "slow"];
+const SNAPSHOT_ROW_BUCKETS = ["fail", "timeout", "unrun"];
+
 function resultRowsForWeights(parsed) {
     // Legacy uncollapsed snapshot kept a full per-test result array.
     if (Array.isArray(parsed.results)) {
@@ -214,7 +220,7 @@ function resultRowsForWeights(parsed) {
     }
     // `fail` predates the split into fail/timeout/unrun; read all of them so
     // both old and new snapshots contribute their weighted rows.
-    for (const key of ["fail", "timeout", "unrun"]) {
+    for (const key of SNAPSHOT_ROW_BUCKETS) {
         if (Array.isArray(parsed[key])) {
             rows.push(...parsed[key]);
         }
@@ -236,11 +242,6 @@ function indentJson(value, spaces) {
         .map(line => `${prefix}${line}`)
         .join("\n");
 }
-
-// Buckets holding bare file-path strings, packed 8/line.
-const SNAPSHOT_FILE_BUCKETS = ["pass", "slow"];
-// Buckets holding failure-family objects ({file, name, status, ...}).
-const SNAPSHOT_ROW_BUCKETS = ["fail", "timeout", "unrun"];
 
 function stringifyCompactSnapshot(snapshot) {
     const lines = [
@@ -304,8 +305,6 @@ function stringifyCompactSnapshot(snapshot) {
 // `passed` for reporting = pass + slow, because a slow completion is still a
 // correctness pass. Only fail/timeout/unrun are non-passing; unrun additionally
 // means the run was incomplete.
-const OUTCOME_STATUSES = ["pass", "slow", "fail", "xfail", "timeout", "unrun"];
-
 function summarizeResults(testResults) {
     const counts = { passed: 0, slow: 0, failed: 0, xfailed: 0, timedOut: 0, unrun: 0 };
     for (const r of testResults || []) {
@@ -361,18 +360,20 @@ function classifySnapshotBuckets(jsonResults) {
             if (r.elapsed !== undefined) row.elapsed = r.elapsed;
             return row;
         });
-    return {
-        pass: filesFor("pass"),
-        slow: filesFor("slow"),
-        fail: rowsFor("fail"),
-        timeout: rowsFor("timeout"),
-        unrun: rowsFor("unrun"),
-        weights: Object.fromEntries(
-            jsonResults
-                .filter(r => (r.status === "pass" || r.status === "slow") && Number.isFinite(Number(r.elapsed)))
-                .map(r => [r.file, Number(r.elapsed)]),
-        ),
-    };
+    const buckets = {};
+    for (const status of SNAPSHOT_FILE_BUCKETS) buckets[status] = filesFor(status);
+    for (const status of SNAPSHOT_ROW_BUCKETS) buckets[status] = rowsFor(status);
+    // Weights cover every completed test (pass + slow) — the slow ones are
+    // exactly what the LPT balancer most needs, so they must not be dropped.
+    // This leans on the invariant that the file-form buckets are precisely the
+    // completed/passing outcomes; if a future passing outcome ever serialized
+    // as a detail row, this filter would need its own explicit status list.
+    buckets.weights = Object.fromEntries(
+        jsonResults
+            .filter(r => SNAPSHOT_FILE_BUCKETS.includes(r.status) && Number.isFinite(Number(r.elapsed)))
+            .map(r => [r.file, Number(r.elapsed)]),
+    );
+    return buckets;
 }
 
 // When a test timed out at its CI cap (TSZ_CI_FOURSLASH_TIMEOUT_MS,
@@ -499,7 +500,6 @@ async function runSequential(opts, testsToRun) {
     let failed = 0;
     let xfailed = 0;
     let timedOut = 0;
-    const unrun = 0; // sequential runs never abandon queued tests
     const errors = [];
     const testResults = [];
 
@@ -570,7 +570,9 @@ async function runSequential(opts, testsToRun) {
     }
 
     bridge.shutdown();
-    return { passed, slow, failed, xfailed, timedOut, unrun, errors, testResults };
+    // main derives the authoritative tally from testResults (summarizeResults);
+    // the counters above exist only for this function's live progress line.
+    return { errors, testResults };
 }
 
 function setupGlobals(tsDir) {
@@ -767,7 +769,9 @@ async function runParallel(opts, testsToRun) {
             if (activeWorkers === 0) {
                 if (!opts.verbose) printProgress();
                 clearInterval(watchdog);
-                resolve({ passed, slow, failed, xfailed, timedOut, unrun, errors, testResults, bridgeRestarts, memoryWarnings, workerStats });
+                // Counters above feed only the live progress line; main derives
+                // the authoritative tally from testResults (summarizeResults).
+                resolve({ errors, testResults, bridgeRestarts, memoryWarnings, workerStats });
             }
         }
 
@@ -1062,11 +1066,9 @@ async function main() {
     // Pass rate is over the tests that actually produced a verdict (executed),
     // not the full planned set — otherwise an early abort drags the rate down
     // purely because queued tests never ran (issue #17010). Slow completions
-    // count as passing.
-    const passRate = executed > 0
-        ? ((reportedPassed / executed) * 100).toFixed(1)
-        : "0.0";
-    console.log(`  Pass rate: ${passRate}% (${reportedPassed}/${executed} executed)`);
+    // count as passing. Computed once here; the snapshot summary reuses it.
+    const passRate = executed > 0 ? Math.round(reportedPassed / executed * 1000) / 10 : 0;
+    console.log(`  Pass rate: ${passRate.toFixed(1)}% (${reportedPassed}/${executed} executed)`);
     if (unrun > 0) {
         console.log(`  \x1b[33m${unrun} test(s) did not run — figure is over executed tests only\x1b[0m`);
     }
@@ -1164,11 +1166,11 @@ async function main() {
         // `passed` in the summary is the load-independent correctness figure —
         // assertion-passes = pass + slow — which is what the README and the CI
         // floor read via `.summary.passed`. `slow`/`unrun` are exposed as their
-        // own sub-counts so the distinction stays visible (issue #17010).
+        // own sub-counts so the distinction stays visible (issue #17010); the
+        // raw within-budget count is `passed - slow` if ever needed.
         const summary = {
             total,
             passed: reportedPassed,
-            strictPassed: passed,
             slow,
             failed,
             xfailed,
@@ -1176,7 +1178,7 @@ async function main() {
             unrun,
             shard: opts.shardTotal > 0 ? { index: opts.shardId, count: opts.shardTotal, strategy: opts.shardStrategy } : null,
             slowest,
-            passRate: executed > 0 ? Math.round(reportedPassed / executed * 1000) / 10 : 0,
+            passRate,
         };
         const detail = {
             timestamp: new Date().toISOString(),
@@ -1218,7 +1220,6 @@ module.exports = {
     reportedPassCount,
     executedCount,
     runFailedCount,
-    OUTCOME_STATUSES,
     TIMEOUT_WEIGHT_BIAS_MS,
 };
 

--- a/scripts/fourslash/runner.cjs
+++ b/scripts/fourslash/runner.cjs
@@ -199,20 +199,25 @@ function resultRowsForWeights(parsed) {
         return parsed.results;
     }
     // Compact snapshot: `weights` is a {file: elapsedMs} map covering every
-    // passing test, and `fail` carries the failing/timeout rows (with their
-    // own `elapsed` + `timedOut` so the timeout bias still applies). Combine
-    // both so the LPT balancer sees a weight for ~every test rather than the
-    // handful in `summary.slowest`. Before this, collapsing `pass` to bare
-    // strings (#13274) left only ~10 weighted tests and silently degraded
-    // weighted sharding to near-uniform assignment.
+    // completed test (pass + slow), and the failure-family arrays (`fail`,
+    // `timeout`, `unrun`) carry their rows with `elapsed` + `timedOut` so the
+    // timeout bias still applies. Combine them so the LPT balancer sees a
+    // weight for ~every test rather than the handful in `summary.slowest`.
+    // Before this, collapsing `pass` to bare strings (#13274) left only ~10
+    // weighted tests and silently degraded weighted sharding to near-uniform
+    // assignment.
     const rows = [];
     if (parsed.weights && typeof parsed.weights === "object" && !Array.isArray(parsed.weights)) {
         for (const [file, elapsed] of Object.entries(parsed.weights)) {
             rows.push({ file, elapsed });
         }
     }
-    if (Array.isArray(parsed.fail)) {
-        rows.push(...parsed.fail);
+    // `fail` predates the split into fail/timeout/unrun; read all of them so
+    // both old and new snapshots contribute their weighted rows.
+    for (const key of ["fail", "timeout", "unrun"]) {
+        if (Array.isArray(parsed[key])) {
+            rows.push(...parsed[key]);
+        }
     }
     if (rows.length > 0) {
         return rows;
@@ -232,30 +237,41 @@ function indentJson(value, spaces) {
         .join("\n");
 }
 
+// Buckets holding bare file-path strings, packed 8/line.
+const SNAPSHOT_FILE_BUCKETS = ["pass", "slow"];
+// Buckets holding failure-family objects ({file, name, status, ...}).
+const SNAPSHOT_ROW_BUCKETS = ["fail", "timeout", "unrun"];
+
 function stringifyCompactSnapshot(snapshot) {
     const lines = [
         "{",
         `  "timestamp": ${JSON.stringify(snapshot.timestamp)},`,
         `  "summary": ${indentJson(snapshot.summary, 2).trimStart()},`,
-        '  "pass": [',
     ];
 
-    const passEntries = snapshot.pass.map(file => JSON.stringify(file));
-    for (let i = 0; i < passEntries.length; i += 8) {
-        const chunk = passEntries.slice(i, i + 8).join(", ");
-        const comma = i + 8 < passEntries.length ? "," : "";
-        lines.push(`    ${chunk}${comma}`);
+    // File-string buckets (pass, slow): bare paths packed 8/line so the
+    // full-corpus set stays well under the 2000-line file cap (#13274).
+    for (const bucket of SNAPSHOT_FILE_BUCKETS) {
+        const entries = (snapshot[bucket] || []).map(file => JSON.stringify(file));
+        lines.push(`  "${bucket}": [`);
+        for (let i = 0; i < entries.length; i += 8) {
+            const chunk = entries.slice(i, i + 8).join(", ");
+            const comma = i + 8 < entries.length ? "," : "";
+            lines.push(`    ${chunk}${comma}`);
+        }
+        lines.push("  ],");
     }
 
-    lines.push(
-        "  ],",
-        `  "fail": ${indentJson(snapshot.fail, 2).trimStart()},`,
-        '  "weights": {',
-    );
+    // Failure-family object buckets (fail, timeout, unrun): small enough to
+    // pretty-print in full.
+    for (const bucket of SNAPSHOT_ROW_BUCKETS) {
+        lines.push(`  "${bucket}": ${indentJson(snapshot[bucket] || [], 2).trimStart()},`);
+    }
 
     // Per-test timings as a compact {file: ms} map. Packed many entries per
     // line so the full-corpus weight set stays well under the 2000-line file
     // cap (the reason #13274 collapsed the old per-test result array).
+    lines.push('  "weights": {');
     const weightEntries = Object.entries(snapshot.weights || {})
         .map(([file, ms]) => `${JSON.stringify(file)}: ${ms}`);
     for (let i = 0; i < weightEntries.length; i += 16) {
@@ -270,6 +286,93 @@ function stringifyCompactSnapshot(snapshot) {
         "",
     );
     return lines.join("\n");
+}
+
+// -----------------------------------------------------------------------------
+// Outcome taxonomy (issue #17010)
+//
+// Every executed test lands in exactly one bucket. "Completed but slow" and
+// "never ran" are split out from the pass/fail axis so the published figure
+// tracks compiler correctness, not machine load:
+//
+//   pass    — assertions passed, within the wall-clock budget
+//   slow    — assertions passed, but overran the budget (harness perf signal)
+//   fail    — assertions failed (a genuine correctness result)
+//   timeout — did not complete (bridge timeout, or in-flight when a worker died)
+//   unrun   — queued behind a dead worker; never started
+//
+// `passed` for reporting = pass + slow, because a slow completion is still a
+// correctness pass. Only fail/timeout/unrun are non-passing; unrun additionally
+// means the run was incomplete.
+const OUTCOME_STATUSES = ["pass", "slow", "fail", "xfail", "timeout", "unrun"];
+
+function summarizeResults(testResults) {
+    const counts = { passed: 0, slow: 0, failed: 0, xfailed: 0, timedOut: 0, unrun: 0 };
+    for (const r of testResults || []) {
+        switch (r.status) {
+            case "pass": counts.passed++; break;
+            case "slow": counts.slow++; break;
+            case "fail": counts.failed++; break;
+            case "xfail": counts.xfailed++; break;
+            case "timeout": counts.timedOut++; break;
+            case "unrun": counts.unrun++; break;
+            default: break;
+        }
+    }
+    return counts;
+}
+
+// Assertion-passes (load-independent). What the README/CI floor publish.
+function reportedPassCount(counts) {
+    return counts.passed + counts.slow;
+}
+
+// Tests that produced a verdict (everything except the ones that never ran).
+function executedCount(counts) {
+    return counts.passed + counts.slow + counts.failed + counts.xfailed + counts.timedOut;
+}
+
+// A run is "bad" (non-zero exit) on any genuine failure, non-completion, or
+// abandoned test. Slowness alone never fails the run — that was the load
+// dependence in #17010.
+function runFailedCount(counts) {
+    return counts.failed + counts.timedOut + counts.unrun;
+}
+
+// Split per-test results into the compact snapshot buckets. `pass`/`slow` are
+// bare file paths; the failure family keeps its detail rows. `weights` covers
+// every completed test (pass + slow) — the slow ones are exactly what the LPT
+// balancer most needs, so they must not be dropped.
+function classifySnapshotBuckets(jsonResults) {
+    const filesFor = status => jsonResults
+        .filter(r => r.status === status)
+        .map(r => r.file);
+    const rowsFor = status => jsonResults
+        .filter(r => r.status === status)
+        .map(r => {
+            const row = {
+                file: r.file,
+                name: r.name,
+                status: r.status,
+                timedOut: r.timedOut || false,
+                output: r.firstFailure || "",
+            };
+            if (r.bucket) row.bucket = r.bucket;
+            if (r.elapsed !== undefined) row.elapsed = r.elapsed;
+            return row;
+        });
+    return {
+        pass: filesFor("pass"),
+        slow: filesFor("slow"),
+        fail: rowsFor("fail"),
+        timeout: rowsFor("timeout"),
+        unrun: rowsFor("unrun"),
+        weights: Object.fromEntries(
+            jsonResults
+                .filter(r => (r.status === "pass" || r.status === "slow") && Number.isFinite(Number(r.elapsed)))
+                .map(r => [r.file, Number(r.elapsed)]),
+        ),
+    };
 }
 
 // When a test timed out at its CI cap (TSZ_CI_FOURSLASH_TIMEOUT_MS,
@@ -392,9 +495,11 @@ async function runSequential(opts, testsToRun) {
 
     const testType = 1; // FourSlashTestType.Server — tsz-server talks over stdio
     let passed = 0;
+    let slow = 0;
     let failed = 0;
     let xfailed = 0;
     let timedOut = 0;
+    const unrun = 0; // sequential runs never abandon queued tests
     const errors = [];
     const testResults = [];
 
@@ -414,15 +519,25 @@ async function runSequential(opts, testsToRun) {
             if (content == null) throw new Error(`Could not read test file: ${testFile}`);
             FourSlash.runFourSlashTestContent(basePath, testType, content, testFile);
             const elapsed = Date.now() - startTime;
+            // Assertions passed. Overrunning the wall-clock budget is a "slow"
+            // performance observation about the harness, not a correctness
+            // failure, so it gets its own bucket instead of being thrown as a
+            // failure (issue #17010).
             if (elapsed > opts.testTimeout) {
-                throw new Error(`Test completed but took ${elapsed}ms (timeout: ${opts.testTimeout}ms)`);
+                slow++;
+                testResults.push({ file: testFile, status: "slow", timedOut: false, error: null, elapsed });
+                if (opts.verbose) {
+                    console.log(`\x1b[33mSLOW\x1b[0m (${elapsed}ms)`);
+                }
+            } else {
+                passed++;
+                testResults.push({ file: testFile, status: "pass", timedOut: false, error: null, elapsed });
+                if (opts.verbose) {
+                    console.log(`\x1b[32mPASS\x1b[0m (${elapsed}ms)`);
+                }
             }
-            passed++;
-            testResults.push({ file: testFile, status: "pass", timedOut: false, error: null, elapsed });
-            if (opts.verbose) {
-                console.log(`\x1b[32mPASS\x1b[0m (${elapsed}ms)`);
-            } else if ((passed + failed + xfailed) % 50 === 0) {
-                process.stdout.write(`\r  Progress: ${passed + failed + xfailed}/${testsToRun.length} (${passed} passed, ${failed} failed${xfailed > 0 ? `, ${xfailed} xfailed` : ""})`);
+            if (!opts.verbose && (passed + slow + failed + xfailed) % 50 === 0) {
+                process.stdout.write(`\r  Progress: ${passed + slow + failed + xfailed}/${testsToRun.length} (${passed} passed, ${slow} slow, ${failed} failed${xfailed > 0 ? `, ${xfailed} xfailed` : ""})`);
             }
         } catch (err) {
             const elapsed = Date.now() - startTime;
@@ -432,15 +547,17 @@ async function runSequential(opts, testsToRun) {
                 testResults.push({ file: testFile, status: "pass", timedOut: false, error: null, elapsed });
                 if (opts.verbose) {
                     console.log(`\x1b[36mBASELINE\x1b[0m (${elapsed}ms)`);
-                } else if ((passed + failed + xfailed) % 50 === 0) {
-                    process.stdout.write(`\r  Progress: ${passed + failed + xfailed}/${testsToRun.length} (${passed} passed, ${failed} failed${xfailed > 0 ? `, ${xfailed} xfailed` : ""})`);
+                } else if ((passed + slow + failed + xfailed) % 50 === 0) {
+                    process.stdout.write(`\r  Progress: ${passed + slow + failed + xfailed}/${testsToRun.length} (${passed} passed, ${slow} slow, ${failed} failed${xfailed > 0 ? `, ${xfailed} xfailed` : ""})`);
                 }
                 continue;
             }
 
-            failed++;
-            const isTimeout = elapsed >= opts.testTimeout || errMsg.includes("Timeout");
-            if (isTimeout) timedOut++;
+            // A did-not-complete timeout (bridge "Timeout") is its own outcome;
+            // everything else is a genuine assertion failure. Disjoint so the
+            // counts sum cleanly.
+            const isTimeout = errMsg.includes("Timeout");
+            if (isTimeout) timedOut++; else failed++;
             errors.push({ file: testFile, error: errMsg, timedOut: isTimeout });
             testResults.push({ file: testFile, status: isTimeout ? "timeout" : "fail", timedOut: isTimeout, error: errMsg, elapsed });
 
@@ -453,7 +570,7 @@ async function runSequential(opts, testsToRun) {
     }
 
     bridge.shutdown();
-    return { passed, failed, xfailed, timedOut, errors, testResults };
+    return { passed, slow, failed, xfailed, timedOut, unrun, errors, testResults };
 }
 
 function setupGlobals(tsDir) {
@@ -614,9 +731,11 @@ async function runParallel(opts, testsToRun) {
     console.log(`  Spawning ${chunks.length} workers (timeout: ${opts.testTimeout}ms, mem limit: ${opts.memoryLimitMB}MB)...`);
 
     let passed = 0;
+    let slow = 0;
     let failed = 0;
     let xfailed = 0;
     let timedOut = 0;
+    let unrun = 0;
     let completed = 0;
     let bridgeRestarts = 0;
     let memoryWarnings = 0;
@@ -636,8 +755,8 @@ async function runParallel(opts, testsToRun) {
 
         function printProgress() {
             const total = testsToRun.length;
-            const done = passed + failed + xfailed;
-            const msg = `\r  Progress: ${done}/${total} (${passed} passed, ${failed} failed${xfailed > 0 ? `, ${xfailed} xfailed` : ""}${timedOut > 0 ? `, ${timedOut} timeout` : ""}) [${activeWorkers} workers]`;
+            const done = passed + slow + failed + xfailed + timedOut + unrun;
+            const msg = `\r  Progress: ${done}/${total} (${passed} passed${slow > 0 ? `, ${slow} slow` : ""}, ${failed} failed${xfailed > 0 ? `, ${xfailed} xfailed` : ""}${timedOut > 0 ? `, ${timedOut} timeout` : ""}${unrun > 0 ? `, ${unrun} unrun` : ""}) [${activeWorkers} workers]`;
             const padded = msg + " ".repeat(Math.max(0, lastProgressLen - msg.length));
             process.stdout.write(padded);
             lastProgressLen = msg.length;
@@ -648,7 +767,7 @@ async function runParallel(opts, testsToRun) {
             if (activeWorkers === 0) {
                 if (!opts.verbose) printProgress();
                 clearInterval(watchdog);
-                resolve({ passed, failed, xfailed, timedOut, errors, testResults, bridgeRestarts, memoryWarnings, workerStats });
+                resolve({ passed, slow, failed, xfailed, timedOut, unrun, errors, testResults, bridgeRestarts, memoryWarnings, workerStats });
             }
         }
 
@@ -696,8 +815,16 @@ async function runParallel(opts, testsToRun) {
                     }
                 } else if (msg.type === "result") {
                     if (msg.passed) {
-                        passed++;
-                        testResults.push({ file: msg.testFile, status: "pass", timedOut: false, error: null, elapsed: msg.elapsed });
+                        // Assertions passed. `slow` means it overran the
+                        // wall-clock budget — a harness perf signal, still a
+                        // pass for correctness (issue #17010).
+                        if (msg.slow) {
+                            slow++;
+                            testResults.push({ file: msg.testFile, status: "slow", timedOut: false, error: null, elapsed: msg.elapsed });
+                        } else {
+                            passed++;
+                            testResults.push({ file: msg.testFile, status: "pass", timedOut: false, error: null, elapsed: msg.elapsed });
+                        }
                     } else if (msg.xfailed) {
                         xfailed++;
                         testResults.push({ file: msg.testFile, status: "xfail", timedOut: false, error: msg.error || null, elapsed: msg.elapsed });
@@ -715,8 +842,9 @@ async function runParallel(opts, testsToRun) {
                             }
                             return;
                         }
-                        failed++;
-                        if (msg.timedOut) timedOut++;
+                        // Disjoint: a did-not-complete timeout is counted as
+                        // timedOut, an assertion failure as failed.
+                        if (msg.timedOut) timedOut++; else failed++;
                         errors.push({ file: msg.testFile, error: msg.error, timedOut: msg.timedOut });
                         testResults.push({ file: msg.testFile, status: msg.timedOut ? "timeout" : "fail", timedOut: msg.timedOut, error: msg.error, elapsed: msg.elapsed });
                     }
@@ -727,7 +855,7 @@ async function runParallel(opts, testsToRun) {
 
                     if (opts.verbose) {
                         const status = msg.passed
-                            ? `\x1b[32mPASS\x1b[0m`
+                            ? (msg.slow ? `\x1b[33mSLOW\x1b[0m` : `\x1b[32mPASS\x1b[0m`)
                             : msg.xfailed
                             ? `\x1b[36mXFAIL\x1b[0m`
                             : msg.timedOut
@@ -780,23 +908,31 @@ async function runParallel(opts, testsToRun) {
                         if (stderr) {
                             console.error(`  Worker ${i} stderr tail:\n${stderr}`);
                         }
-                        // Count remaining tests as failed
-                        failed += remaining;
-                        timedOut += remaining;
+                        // The test in flight when the worker died did not
+                        // complete → "timeout". The rest were still queued and
+                        // never started → "unrun". Conflating the two (the old
+                        // "all timeout") overstated genuine non-completions and
+                        // hid that the run was incomplete (issue #17010).
                         for (let j = wp.completed; j < wp.total; j++) {
-                            const error = stderr ? `Worker crashed (${reason})\n${stderr}` : `Worker crashed (${reason})`;
+                            const inFlight = j === wp.completed;
+                            const detail = stderr ? `Worker crashed (${reason})\n${stderr}` : `Worker crashed (${reason})`;
+                            const error = inFlight
+                                ? detail
+                                : `Not run — worker ${i} died before this test started (${reason})`;
                             errors.push({
                                 file: chunks[i][j],
                                 error,
-                                timedOut: true,
+                                timedOut: inFlight,
+                                unrun: !inFlight,
                             });
                             testResults.push({
                                 file: chunks[i][j],
-                                status: "timeout",
-                                timedOut: true,
+                                status: inFlight ? "timeout" : "unrun",
+                                timedOut: inFlight,
                                 error,
                                 elapsed: 0,
                             });
+                            if (inFlight) timedOut++; else unrun++;
                         }
                     }
                     workerStderr.delete(i);
@@ -898,28 +1034,48 @@ async function main() {
         results = await runParallel(opts, testsToRun);
     }
 
-    const { passed, failed, xfailed = 0, timedOut, errors } = results;
+    const { errors } = results;
+    // Derive the final tally from the per-test results — the single source of
+    // truth — so the summary can never disagree with the recorded buckets.
+    const counts = summarizeResults(results.testResults || []);
+    const { passed, slow, failed, xfailed, timedOut, unrun } = counts;
+    const reportedPassed = reportedPassCount(counts); // pass + slow
+    const executed = executedCount(counts);           // excludes unrun
     const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
 
     // Print summary
     console.log("");
     console.log("─".repeat(70));
     console.log("");
-    console.log(`Results: ${passed} passed, ${failed} failed${xfailed > 0 ? `, ${xfailed} xfailed` : ""} out of ${testsToRun.length} (${elapsed}s)`);
+    const parts = [`${passed} passed`];
+    if (slow > 0) parts.push(`${slow} slow`);
+    parts.push(`${failed} failed`);
+    if (xfailed > 0) parts.push(`${xfailed} xfailed`);
+    if (timedOut > 0) parts.push(`${timedOut} timed out`);
+    if (unrun > 0) parts.push(`${unrun} did not run`);
+    console.log(`Results: ${parts.join(", ")} out of ${testsToRun.length} (${elapsed}s)`);
 
     if (totalAvailable > testsToRun.length) {
         console.log(`  (${totalAvailable - testsToRun.length} tests skipped, ${totalAvailable} total available)`);
     }
 
-    const passRate = testsToRun.length > 0
-        ? ((passed / testsToRun.length) * 100).toFixed(1)
+    // Pass rate is over the tests that actually produced a verdict (executed),
+    // not the full planned set — otherwise an early abort drags the rate down
+    // purely because queued tests never ran (issue #17010). Slow completions
+    // count as passing.
+    const passRate = executed > 0
+        ? ((reportedPassed / executed) * 100).toFixed(1)
         : "0.0";
-    console.log(`  Pass rate: ${passRate}%`);
+    console.log(`  Pass rate: ${passRate}% (${reportedPassed}/${executed} executed)`);
+    if (unrun > 0) {
+        console.log(`  \x1b[33m${unrun} test(s) did not run — figure is over executed tests only\x1b[0m`);
+    }
 
     // Extra stats for parallel mode
     if (!opts.sequential && results.bridgeRestarts !== undefined) {
         const statsLine = [];
         if (timedOut > 0) statsLine.push(`${timedOut} timed out`);
+        if (unrun > 0) statsLine.push(`${unrun} did not run`);
         if (results.bridgeRestarts > 0) statsLine.push(`${results.bridgeRestarts} bridge restarts`);
         if (results.memoryWarnings > 0) statsLine.push(`${results.memoryWarnings} memory warnings`);
         if (statsLine.length > 0) {
@@ -937,13 +1093,13 @@ async function main() {
 
     if (errors.length > 0 && !opts.verbose) {
         console.log("");
-        console.log(`First ${errors.length} failures:`);
-        for (const { file, error, timedOut: to } of errors.slice(0, 20)) {
-            const icon = to ? "\x1b[33m⏱\x1b[0m" : "\x1b[31m✗\x1b[0m";
+        console.log(`First ${errors.length} non-passing:`);
+        for (const { file, error, timedOut: to, unrun: didNotRun } of errors.slice(0, 20)) {
+            const icon = didNotRun ? "\x1b[90m∅\x1b[0m" : to ? "\x1b[33m⏱\x1b[0m" : "\x1b[31m✗\x1b[0m";
             console.log(`  ${icon} ${path.basename(file, ".ts")}: ${error.split("\n")[0].substring(0, 100)}`);
         }
         if (errors.length > 20) {
-            console.log(`  ... and ${errors.length - 20} more failures`);
+            console.log(`  ... and ${errors.length - 20} more`);
         }
     }
 
@@ -1005,54 +1161,36 @@ async function main() {
         jsonResults.sort((a, b) => a.file.localeCompare(b.file));
 
         const total = testsToRun.length;
+        // `passed` in the summary is the load-independent correctness figure —
+        // assertion-passes = pass + slow — which is what the README and the CI
+        // floor read via `.summary.passed`. `slow`/`unrun` are exposed as their
+        // own sub-counts so the distinction stays visible (issue #17010).
+        const summary = {
+            total,
+            passed: reportedPassed,
+            strictPassed: passed,
+            slow,
+            failed,
+            xfailed,
+            timedOut,
+            unrun,
+            shard: opts.shardTotal > 0 ? { index: opts.shardId, count: opts.shardTotal, strategy: opts.shardStrategy } : null,
+            slowest,
+            passRate: executed > 0 ? Math.round(reportedPassed / executed * 1000) / 10 : 0,
+        };
         const detail = {
             timestamp: new Date().toISOString(),
-            summary: {
-                total,
-                passed,
-                failed,
-                xfailed,
-                timedOut,
-                shard: opts.shardTotal > 0 ? { index: opts.shardId, count: opts.shardTotal, strategy: opts.shardStrategy } : null,
-                slowest,
-                passRate: total > 0 ? Math.round(passed / total * 1000) / 10 : 0,
-            },
+            summary,
             results: jsonResults,
         };
 
         const outPath = path.resolve(opts.jsonOut);
         const snapshotOutPath = path.resolve(snapshotWeightFile());
+        // The compact snapshot splits results into pass/slow/fail/timeout/unrun
+        // buckets and a `weights` map (pass + slow, the timings the LPT balancer
+        // needs). classifySnapshotBuckets owns that split.
         const output = outPath === snapshotOutPath
-            ? {
-                timestamp: detail.timestamp,
-                summary: detail.summary,
-                pass: jsonResults
-                    .filter(r => r.status === "pass" && !r.timedOut)
-                    .map(r => r.file),
-                fail: jsonResults
-                    .filter(r => r.status !== "pass" || r.timedOut)
-                    .map(r => {
-                        const record = {
-                            file: r.file,
-                            name: r.name,
-                            status: r.status,
-                            timedOut: r.timedOut || false,
-                            output: r.firstFailure || "",
-                        };
-                        if (r.bucket) record.bucket = r.bucket;
-                        if (r.elapsed !== undefined) record.elapsed = r.elapsed;
-                        return record;
-                    }),
-                // Per-test timings (ms) for passing tests, consumed by
-                // loadHistoricalWeights() for LPT shard balancing. Kept as a
-                // compact {file: ms} map so the snapshot stays small while the
-                // balancer still sees a real weight for ~every test.
-                weights: Object.fromEntries(
-                    jsonResults
-                        .filter(r => r.status === "pass" && !r.timedOut && Number.isFinite(Number(r.elapsed)))
-                        .map(r => [r.file, Number(r.elapsed)]),
-                ),
-            }
+            ? { timestamp: detail.timestamp, summary, ...classifySnapshotBuckets(jsonResults) }
             : detail;
         fs.mkdirSync(path.dirname(outPath), { recursive: true });
         const jsonText = outPath === snapshotOutPath
@@ -1062,10 +1200,31 @@ async function main() {
         console.log(`\nJSON results written to ${outPath}`);
     }
 
-    process.exit(failed > 0 ? 1 : 0);
+    // Slowness alone never fails the run (that was the load dependence in
+    // #17010); genuine failures, non-completions, and abandoned tests do.
+    process.exit(runFailedCount(counts) > 0 ? 1 : 0);
 }
 
-main().catch(err => {
-    console.error("Fatal error:", err);
-    process.exit(2);
-});
+// Pure helpers are exported so unit tests exercise the real classification
+// code rather than a drifting mirror. Only run the suite when invoked directly.
+module.exports = {
+    resultRowsForWeights,
+    loadHistoricalWeights,
+    defaultUnknownWeight,
+    weightedShardTests,
+    stringifyCompactSnapshot,
+    classifySnapshotBuckets,
+    summarizeResults,
+    reportedPassCount,
+    executedCount,
+    runFailedCount,
+    OUTCOME_STATUSES,
+    TIMEOUT_WEIGHT_BIAS_MS,
+};
+
+if (require.main === module) {
+    main().catch(err => {
+        console.error("Fatal error:", err);
+        process.exit(2);
+    });
+}

--- a/scripts/fourslash/runner.cjs
+++ b/scripts/fourslash/runner.cjs
@@ -499,7 +499,6 @@ async function runSequential(opts, testsToRun) {
     let slow = 0;
     let failed = 0;
     let xfailed = 0;
-    let timedOut = 0;
     const errors = [];
     const testResults = [];
 
@@ -553,11 +552,12 @@ async function runSequential(opts, testsToRun) {
                 continue;
             }
 
-            // A did-not-complete timeout (bridge "Timeout") is its own outcome;
-            // everything else is a genuine assertion failure. Disjoint so the
-            // counts sum cleanly.
+            // A did-not-complete timeout (bridge "Timeout") is its own outcome
+            // ("timeout"); everything else is a genuine assertion failure
+            // ("fail"). main re-derives the tally from testResults, so only the
+            // failed counter (read by the progress line) is tracked here.
             const isTimeout = errMsg.includes("Timeout");
-            if (isTimeout) timedOut++; else failed++;
+            if (!isTimeout) failed++;
             errors.push({ file: testFile, error: errMsg, timedOut: isTimeout });
             testResults.push({ file: testFile, status: isTimeout ? "timeout" : "fail", timedOut: isTimeout, error: errMsg, elapsed });
 

--- a/scripts/fourslash/shard-balance.test.cjs
+++ b/scripts/fourslash/shard-balance.test.cjs
@@ -1,24 +1,25 @@
 #!/usr/bin/env node
 //
-// Unit tests for the LPT (longest-processing-time-first) shard balancer
-// in `runner.cjs`. Runs as a standalone Node script: `node shard-balance.test.cjs`.
+// Unit tests for the LPT (longest-processing-time-first) shard balancer and the
+// outcome taxonomy in `runner.cjs`. Runs as a standalone Node script:
+// `node shard-balance.test.cjs`.
 //
-// Re-implements the small helpers under test rather than refactoring runner.cjs
-// to export them — the bias formulas are short enough that two copies is
-// cheaper than the export surface area. Update both sides if you change the
-// formula.
+// runner.cjs guards its main() with `require.main === module`, so requiring it
+// exercises the real exported helpers directly. Only the timeout-bias formula
+// is mirrored below, because runner exports the disk-reading `loadHistoricalWeights`
+// rather than the pure results->weights core; the bias constant it uses is
+// still pulled from runner so the two can't drift on the magnitude.
 
 "use strict";
 
 const assert = require("node:assert/strict");
 
-// runner.cjs guards its main() with `require.main === module`, so requiring it
-// here pulls in the real pure helpers without kicking off a test run.
 const runner = require("./runner.cjs");
+const { defaultUnknownWeight, TIMEOUT_WEIGHT_BIAS_MS } = runner;
 
-// Mirror of runner.cjs constants and helpers under test. Keep in sync.
-const TIMEOUT_WEIGHT_BIAS_MS = 60_000 * 1.5;
-
+// Mirror of the pure core inside runner.loadHistoricalWeights (which reads the
+// snapshot from disk, so it can't be called directly on an in-memory array).
+// Reuses runner's TIMEOUT_WEIGHT_BIAS_MS so only the shape is duplicated here.
 function loadHistoricalWeightsFromResults(results) {
     const weights = new Map();
     for (const result of results || []) {
@@ -32,12 +33,6 @@ function loadHistoricalWeightsFromResults(results) {
         weights.set(result.file.replace(/\\/g, "/"), weight);
     }
     return weights;
-}
-
-function defaultUnknownWeight(weights) {
-    if (weights.size === 0) return 100;
-    const sorted = [...weights.values()].sort((a, b) => a - b);
-    return sorted[Math.floor(sorted.length / 2)];
 }
 
 let failed = 0;

--- a/scripts/fourslash/shard-balance.test.cjs
+++ b/scripts/fourslash/shard-balance.test.cjs
@@ -12,6 +12,10 @@
 
 const assert = require("node:assert/strict");
 
+// runner.cjs guards its main() with `require.main === module`, so requiring it
+// here pulls in the real pure helpers without kicking off a test run.
+const runner = require("./runner.cjs");
+
 // Mirror of runner.cjs constants and helpers under test. Keep in sync.
 const TIMEOUT_WEIGHT_BIAS_MS = 60_000 * 1.5;
 
@@ -113,6 +117,100 @@ test("timeout bias prevents two timeouts being indistinguishable at LPT input", 
     // The slow non-timeout test stays well below the biased timeouts, so the
     // LPT will schedule the timeouts onto separate shards before considering
     // the slow test.
+});
+
+// -----------------------------------------------------------------------------
+// Outcome taxonomy (issue #17010) — exercised against the REAL exported helpers
+// in runner.cjs, so these can't drift from production the way the mirrors above
+// can.
+// -----------------------------------------------------------------------------
+
+// A representative per-test result set covering every outcome.
+const SAMPLE_RESULTS = [
+    { file: "t/p1.ts", name: "p1", status: "pass", timedOut: false, elapsed: 120 },
+    { file: "t/p2.ts", name: "p2", status: "pass", timedOut: false, elapsed: 300 },
+    { file: "t/slow1.ts", name: "slow1", status: "slow", timedOut: false, elapsed: 38298 },
+    { file: "t/slow2.ts", name: "slow2", status: "slow", timedOut: false, elapsed: 29185 },
+    { file: "t/f1.ts", name: "f1", status: "fail", timedOut: false, elapsed: 90, firstFailure: "boom" },
+    { file: "t/to1.ts", name: "to1", status: "timeout", timedOut: true, elapsed: 60000, firstFailure: "Timeout" },
+    { file: "t/u1.ts", name: "u1", status: "unrun", timedOut: false, elapsed: 0, firstFailure: "Not run" },
+    { file: "t/x1.ts", name: "x1", status: "xfail", timedOut: false, elapsed: 50 },
+];
+
+test("summarizeResults tallies each outcome into its own disjoint bucket", () => {
+    const c = runner.summarizeResults(SAMPLE_RESULTS);
+    assert.deepEqual(c, { passed: 2, slow: 2, failed: 1, xfailed: 1, timedOut: 1, unrun: 1 });
+});
+
+test("reportedPassCount folds slow into passing (load-independent figure)", () => {
+    const c = runner.summarizeResults(SAMPLE_RESULTS);
+    assert.equal(runner.reportedPassCount(c), 4); // 2 pass + 2 slow
+});
+
+test("executedCount excludes tests that never ran (unrun)", () => {
+    const c = runner.summarizeResults(SAMPLE_RESULTS);
+    // 2 pass + 2 slow + 1 fail + 1 xfail + 1 timeout = 7; the 1 unrun is excluded.
+    assert.equal(runner.executedCount(c), 7);
+});
+
+test("runFailedCount trips on fail/timeout/unrun but never on slow", () => {
+    const c = runner.summarizeResults(SAMPLE_RESULTS);
+    assert.equal(runner.runFailedCount(c), 3); // 1 fail + 1 timeout + 1 unrun
+    // A run whose only blemish is slowness exits clean.
+    const slowOnly = runner.summarizeResults([
+        { status: "pass" }, { status: "slow" }, { status: "slow" },
+    ]);
+    assert.equal(runner.runFailedCount(slowOnly), 0);
+});
+
+test("classifySnapshotBuckets splits pass/slow/fail/timeout/unrun; weights = pass+slow", () => {
+    const b = runner.classifySnapshotBuckets(SAMPLE_RESULTS);
+    assert.deepEqual(b.pass, ["t/p1.ts", "t/p2.ts"]);
+    assert.deepEqual(b.slow, ["t/slow1.ts", "t/slow2.ts"]);
+    assert.deepEqual(b.fail.map(r => r.name), ["f1"]);
+    assert.deepEqual(b.timeout.map(r => r.name), ["to1"]);
+    assert.deepEqual(b.unrun.map(r => r.name), ["u1"]);
+    // Slow tests carry real timings and are exactly what the LPT balancer needs
+    // — they must land in the weight map alongside the fast passes.
+    assert.deepEqual(b.weights, {
+        "t/p1.ts": 120,
+        "t/p2.ts": 300,
+        "t/slow1.ts": 38298,
+        "t/slow2.ts": 29185,
+    });
+});
+
+test("snapshot round-trips: classify -> stringify -> parse -> weights cover pass+slow, bias timeouts", () => {
+    const buckets = runner.classifySnapshotBuckets(SAMPLE_RESULTS);
+    const snapshot = { timestamp: "2026-08-09T00:00:00.000Z", summary: { total: 8 }, ...buckets };
+    const parsed = JSON.parse(runner.stringifyCompactSnapshot(snapshot));
+    assert.deepEqual(parsed.pass, ["t/p1.ts", "t/p2.ts"]);
+    assert.deepEqual(parsed.slow, ["t/slow1.ts", "t/slow2.ts"]);
+    assert.equal(parsed.timeout.length, 1);
+    assert.equal(parsed.unrun.length, 1);
+
+    // The weight-loader reads weights (pass+slow) plus the failure-family rows.
+    const rows = runner.resultRowsForWeights(parsed);
+    const byFile = new Map(rows.map(r => [r.file, r]));
+    assert.equal(byFile.get("t/slow1.ts").elapsed, 38298); // slow test weighted
+    assert.equal(byFile.get("t/p1.ts").elapsed, 120);
+    // The timeout row is carried so its bias still applies downstream.
+    assert.ok(byFile.has("t/to1.ts"));
+});
+
+test("resultRowsForWeights still reads legacy `fail`-only + `results` snapshots", () => {
+    // Legacy compact snapshot: weights map + a single `fail` array.
+    const legacyCompact = {
+        weights: { "t/a.ts": 100 },
+        fail: [{ file: "t/b.ts", elapsed: 26000, status: "timeout", timedOut: true }],
+    };
+    const rows = runner.resultRowsForWeights(legacyCompact);
+    const files = rows.map(r => r.file).sort();
+    assert.deepEqual(files, ["t/a.ts", "t/b.ts"]);
+
+    // Even older uncollapsed snapshot: a full `results` array.
+    const legacyFull = { results: [{ file: "t/c.ts", elapsed: 5 }] };
+    assert.deepEqual(runner.resultRowsForWeights(legacyFull).map(r => r.file), ["t/c.ts"]);
 });
 
 if (failed > 0) {

--- a/scripts/fourslash/test-worker.cjs
+++ b/scripts/fourslash/test-worker.cjs
@@ -85,8 +85,7 @@ function isTemporarilyAllowedParityFailure(testName, errMsg) {
         message.includes("isNewIdentifierLocation") ||
         message.includes("Cannot read properties of undefined") ||
         message.includes("Found an error:") ||
-        message.includes("Timeout waiting for tsz-server response") ||
-        message.includes("Test completed but took")
+        message.includes("Timeout waiting for tsz-server response")
     );
 }
 
@@ -222,18 +221,21 @@ function runSingleTest(FourSlash, Harness, testFile, testType) {
 }
 
 /**
- * Run a test with a timeout. Since fourslash tests are synchronous,
- * we can't use setTimeout. Instead we use the bridge's existing timeout
- * (30s per request) as a natural guard. For an additional layer, we
- * track wall-clock time and report timeouts.
+ * Run a test and measure its wall-clock cost. Fourslash tests are
+ * synchronous, so we can't use setTimeout; the bridge's own per-request
+ * timeout (30s) is the hard guard against a genuinely stuck request.
+ *
+ * A test whose assertions pass but that overran `timeoutMs` is reported as
+ * `slow: true` rather than thrown as a failure. "Completed but slow" is a
+ * performance observation about the harness under load, not a correctness
+ * result about the compiler, so it must not be folded into the failure
+ * buckets (issue #17010). Returns { elapsed, slow }.
  */
 function runTestWithTimeout(FourSlash, Harness, testFile, testType, timeoutMs) {
     const start = Date.now();
     runSingleTest(FourSlash, Harness, testFile, testType);
     const elapsed = Date.now() - start;
-    if (elapsed > timeoutMs) {
-        throw new Error(`Test completed but took ${elapsed}ms (timeout: ${timeoutMs}ms)`);
-    }
+    return { elapsed, slow: elapsed > timeoutMs };
 }
 
 async function main() {
@@ -314,13 +316,17 @@ async function main() {
             : "";
 
         try {
-            runTestWithTimeout(FourSlash, Harness, testFile, testType, perTestTimeout);
+            const { slow } = runTestWithTimeout(FourSlash, Harness, testFile, testType, perTestTimeout);
             const elapsed = Date.now() - startTime;
-            process.send({ type: "result", workerId, testFile, testName, passed: true, elapsed });
+            process.send({ type: "result", workerId, testFile, testName, passed: true, slow, elapsed });
         } catch (err) {
             const elapsed = Date.now() - startTime;
             const errMsg = err.message || String(err);
-            const timedOut = elapsed >= perTestTimeout || errMsg.includes("Timeout");
+            // A genuine non-completion is signalled by the bridge's own
+            // "Timeout" error. Overrunning the wall-clock budget on the
+            // success path is "slow" (handled above), not a timeout — so a
+            // slow *assertion failure* stays a plain failure here.
+            const timedOut = errMsg.includes("Timeout");
             const bridgeLikelyUnhealthy =
                 timedOut ||
                 errMsg.includes("Stream closed before complete message was read") ||

--- a/scripts/lib/query_snapshot.py
+++ b/scripts/lib/query_snapshot.py
@@ -9,6 +9,29 @@ from collections import Counter
 from pathlib import Path
 
 
+# Fourslash outcome taxonomy (issue #17010). The runner classifies every test
+# into exactly one status; these group which statuses/buckets count as passing.
+# Offline consumers import them instead of each re-encoding the split, so adding
+# or reclassifying a bucket is a one-line change here rather than in three
+# scripts. A completed-but-slow test passed its assertions — the slowness is a
+# harness perf signal, not a correctness failure — so `slow` is a passing bucket.
+FOURSLASH_PASSING_BUCKETS = ("pass", "slow")
+FOURSLASH_NON_PASSING_BUCKETS = ("fail", "timeout", "unrun")
+FOURSLASH_NON_PASSING_STATUSES = frozenset(FOURSLASH_NON_PASSING_BUCKETS)
+
+
+def fourslash_bucket_counts(data: dict) -> tuple:
+    """``(passed, total)`` from a compact snapshot that lacks a ``summary`` block.
+
+    Slow tests count as passing; only fail/timeout/unrun are non-passing.
+    Tolerates older snapshots missing the slow/timeout/unrun buckets —
+    ``data.get(b) or []`` treats an absent bucket as empty.
+    """
+    passed = sum(len(data.get(b) or []) for b in FOURSLASH_PASSING_BUCKETS)
+    non_passing = sum(len(data.get(b) or []) for b in FOURSLASH_NON_PASSING_BUCKETS)
+    return passed, passed + non_passing
+
+
 def load_snapshot(path: Path, run_hint: str = "Run the test suite with --json-out to generate it.") -> dict:
     """Load a JSON snapshot file, printing a helpful error and exiting if missing."""
     if not path.exists():

--- a/scripts/lib/test_query_snapshot.py
+++ b/scripts/lib/test_query_snapshot.py
@@ -11,11 +11,35 @@ from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from lib.query_snapshot import (
+    FOURSLASH_NON_PASSING_BUCKETS,
+    FOURSLASH_PASSING_BUCKETS,
     filter_by_name,
+    fourslash_bucket_counts,
     load_snapshot,
     print_top_counter,
     print_truncated_more,
 )
+
+
+class TestFourslashBucketCounts(unittest.TestCase):
+    def test_slow_counts_as_passing(self):
+        data = {
+            "pass": ["a", "b", "c"],
+            "slow": ["d", "e"],
+            "fail": [{"name": "f"}],
+            "timeout": [{"name": "g"}],
+            "unrun": [{"name": "h"}],
+        }
+        self.assertEqual(fourslash_bucket_counts(data), (5, 8))
+
+    def test_tolerates_missing_new_buckets(self):
+        # Older snapshots have only pass/fail.
+        self.assertEqual(fourslash_bucket_counts({"pass": ["a", "b"], "fail": [{}]}), (2, 3))
+
+    def test_taxonomy_partitions_are_disjoint(self):
+        self.assertEqual(
+            set(FOURSLASH_PASSING_BUCKETS) & set(FOURSLASH_NON_PASSING_BUCKETS), set()
+        )
 
 
 class TestLoadSnapshot(unittest.TestCase):

--- a/scripts/refresh-readme.py
+++ b/scripts/refresh-readme.py
@@ -174,10 +174,21 @@ def normalize_suite_summary(data, suite):
         }
 
     if suite == "fourslash" and isinstance(data.get("pass"), list):
-        failed = len(data.get("fail") or [])
+        # A completed-but-slow test ("slow" bucket) passed its assertions; the
+        # slowness is a harness perf signal, not a correctness failure, so it
+        # counts as passing. Only fail/timeout/unrun are non-passing. Keeping
+        # slow out of the published figure made it move with machine load
+        # (issue #17010). Older snapshots have no slow/timeout/unrun buckets;
+        # ``.get(...) or []`` treats them as empty.
+        passed = len(data["pass"]) + len(data.get("slow") or [])
+        non_passing = (
+            len(data.get("fail") or [])
+            + len(data.get("timeout") or [])
+            + len(data.get("unrun") or [])
+        )
         return {
-            "passed": len(data["pass"]),
-            "total": len(data["pass"]) + failed,
+            "passed": passed,
+            "total": passed + non_passing,
         }
 
     if data.get("suite") != suite:

--- a/scripts/refresh-readme.py
+++ b/scripts/refresh-readme.py
@@ -30,6 +30,9 @@ import tempfile
 import urllib.request
 from pathlib import Path
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from lib.query_snapshot import fourslash_bucket_counts  # noqa: E402
+
 ROOT = Path(__file__).parent.parent
 README = ROOT / "README.md"
 PERFORMANCE_PNG_DIR = ROOT / "crates" / "tsz-website" / "static" / "benchmark-data"
@@ -174,22 +177,11 @@ def normalize_suite_summary(data, suite):
         }
 
     if suite == "fourslash" and isinstance(data.get("pass"), list):
-        # A completed-but-slow test ("slow" bucket) passed its assertions; the
-        # slowness is a harness perf signal, not a correctness failure, so it
-        # counts as passing. Only fail/timeout/unrun are non-passing. Keeping
-        # slow out of the published figure made it move with machine load
-        # (issue #17010). Older snapshots have no slow/timeout/unrun buckets;
-        # ``.get(...) or []`` treats them as empty.
-        passed = len(data["pass"]) + len(data.get("slow") or [])
-        non_passing = (
-            len(data.get("fail") or [])
-            + len(data.get("timeout") or [])
-            + len(data.get("unrun") or [])
-        )
-        return {
-            "passed": passed,
-            "total": passed + non_passing,
-        }
+        # Summary-less snapshot: count from the buckets. Slow counts as passing
+        # (keeping it out made the published figure move with machine load,
+        # issue #17010); the taxonomy lives in lib.query_snapshot.
+        passed, total = fourslash_bucket_counts(data)
+        return {"passed": passed, "total": total}
 
     if data.get("suite") != suite:
         return None


### PR DESCRIPTION
Fixes #17010.

`scripts/fourslash/run-fourslash.sh --json-out` classified tests that **passed**
their assertions but overran the wall-clock budget as failures — a passing test
over budget was `throw`n as `"Test completed but took ..."`, caught, and
bucketed as a timeout failure. The README figure and CI floor read that number,
so they moved with machine load rather than with code: the same commit produced
fourslash pass rates of 99.9%, 99.7%, 99.5% and 52.9% purely from contention,
and a genuine fix could look like a regression. Separately, every test a crashed
worker didn't finish was marked `timeout`, hiding that most never ran, and the
console pass rate divided by the full planned set even after an early abort.

Structural rule: when a fourslash test completes with passing assertions,
`tsc`-parity is not at stake — the compiler answered correctly; only the harness
was slow. That is a performance observation, not a correctness result, and must
not share a bucket with real failures. The runner (`scripts/fourslash/runner.cjs`)
owns the outcome taxonomy; every downstream consumer reads it.

The change introduces a five-way taxonomy, owned by the runner and threaded
through every consumer:

| status    | meaning                                                       | counts as  |
|-----------|---------------------------------------------------------------|------------|
| `pass`    | assertions passed, within budget                              | passing    |
| `slow`    | assertions passed, over budget (harness perf signal)          | passing    |
| `fail`    | assertions failed                                             | failing    |
| `timeout` | did not complete (bridge timeout / in-flight when worker died) | failing    |
| `unrun`   | queued behind a dead worker; never started                    | incomplete |

- `runner.cjs` / `test-worker.cjs`: a completed-but-slow test reports `slow`
  (still passing) instead of throwing; counters are disjoint; a worker crash
  splits the in-flight test (`timeout`) from the queued remainder (`unrun`);
  exit is non-zero on `fail`/`timeout`/`unrun`, never on `slow` alone.
- Snapshot: `pass`/`slow`/`fail`/`timeout`/`unrun` buckets plus a `weights` map
  that now includes the slow timings (exactly what the LPT shard-balancer most
  needs). `summary.passed` is the load-independent `pass + slow`.
- Console pass rate is over *executed* tests (excludes `unrun`); slow/unrun are
  surfaced distinctly.
- `refresh-readme.py`, `full-ci-summary.py`, `query-fourslash.py` count `slow`
  as passing via a shared taxonomy hoisted into `scripts/lib/query_snapshot.py`;
  all stay backward compatible with the existing (pre-split) snapshot on disk.
- Pure helpers are exported from `runner.cjs` (guarded by `require.main`) so the
  unit tests exercise the real classification code, not a mirror.

## Goal
Goal: hold

## Verification
- `node scripts/fourslash/shard-balance.test.cjs` — extended with cases over the
  real exported helpers (taxonomy tally, pass+slow folding, executed
  denominator, snapshot round-trip, legacy-snapshot reading). Green.
- `python3 -m unittest scripts.lib.test_query_snapshot scripts.ci.test_refresh_readme scripts.ci.test_full_ci_summary`
  — 41 tests, incl. new fourslash bucket cases. Green.
- `python3 scripts/arch/arch_guard.py` — passes (all touched files < 2000 LOC).
- Backward-compat smoke: `query-fourslash.py` renders both the committed
  (old-format) snapshot and a synthetic new-format one.
- The fourslash behavior suite itself is nightly/`workflow_dispatch` (needs a
  release `tsz-server` + TypeScript submodule); this change is pure harness
  classification logic, fully covered by the unit tests above. The committed
  snapshot is left untouched; all readers stay compatible with it.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbmJajzvjCWCzgF9z4FrGB)_