### PR TITLE
fix(checker): TS2540 on const members through import-equals module bindings

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2811,3 +2811,6 @@ path = "tests/ts7032_zero_parameter_setter_tests.rs"
 [[test]]
 name = "ts7023_self_recursive_var_reassigned_return_tests"
 path = "tests/ts7023_self_recursive_var_reassigned_return_tests.rs"
+[[test]]
+name = "ts2540_import_equals_const_member_tests"
+path = "tests/ts2540_import_equals_const_member_tests.rs"

--- a/crates/tsz-checker/src/state/state_checking/readonly.rs
+++ b/crates/tsz-checker/src/state/state_checking/readonly.rs
@@ -920,28 +920,170 @@ impl<'a> CheckerState<'a> {
         let sym_id = self.resolve_identifier_symbol(object_expr)?;
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
 
-        // Must be a namespace/module symbol
-        if !symbol.has_any_flags(symbol_flags::MODULE) {
-            return Some(false);
+        // Same-file namespace/module value: `namespace M { export const x = 0 }`
+        // accessed as `M.x`. Look the member up directly in the symbol's exports.
+        if symbol.has_any_flags(symbol_flags::MODULE) {
+            let member_sym_id = symbol.exports.as_ref()?.get(prop_name)?;
+            let member_symbol = self.ctx.binder.get_symbol(member_sym_id)?;
+
+            // Check if the member is a block-scoped variable (const/let)
+            if !member_symbol.has_any_flags(symbol_flags::BLOCK_SCOPED_VARIABLE) {
+                return Some(false);
+            }
+
+            // Check if its value declaration has the CONST flag
+            let value_decl = member_symbol.value_declaration;
+            if value_decl.is_none() {
+                return Some(false);
+            }
+
+            self.ctx.arena.get(value_decl)?;
+            return Some(self.ctx.arena.is_const_variable_declaration(value_decl));
         }
 
-        // Look up the property in the namespace's exports
-        let member_sym_id = symbol.exports.as_ref()?.get(prop_name)?;
-        let member_symbol = self.ctx.binder.get_symbol(member_sym_id)?;
+        // Whole-module import binding: `import m = require('./mod')`,
+        // `import m = OtherNamespace`, or `import * as m from './mod'`. tsc binds
+        // `m` to the target module namespace, whose `export const` members are
+        // readonly — the same rule as the same-file `namespace M` case above, so
+        // `m.x` must behave like `M.x`. The alias itself is not a MODULE symbol
+        // and, for a plain named-export target, `resolve_alias_symbol` does not
+        // reach the member, so the export is resolved through cross-file
+        // resolution instead.
+        //
+        // A *named* or *default* value import (`import { x }`, `import x from`)
+        // is excluded (`import_name` is `Some`): it binds a single value, so
+        // `x.member` is ordinary property access, not a module export.
+        if symbol.has_any_flags(symbol_flags::ALIAS) && symbol.import_name().is_none() {
+            return Some(self.import_equals_const_member(sym_id, prop_name));
+        }
+
+        Some(false)
+    }
+
+    /// Resolve whether `prop_name` is a `const` export of the module a
+    /// whole-module import binding refers to. `alias_sym_id` is the alias symbol
+    /// for the binding (`import m = require('...')`, `import m = Ns`, or
+    /// `import * as m`).
+    ///
+    /// Const exports of a module are readonly (TS2540) when written through the
+    /// binding, exactly as they are through a same-file `namespace`. `let`/`var`
+    /// exports, functions, and classes are not const, so they are not reported
+    /// here. (For an `import * as` namespace import, the surrounding
+    /// `is_namespace_import_binding` check additionally rejects writes to those
+    /// non-const members; an import-equals binding intentionally does not.)
+    fn import_equals_const_member(
+        &self,
+        alias_sym_id: tsz_binder::SymbolId,
+        prop_name: &str,
+    ) -> bool {
+        use tsz_binder::symbol_flags;
+
+        let Some(symbol) = self.ctx.binder.get_symbol(alias_sym_id) else {
+            return false;
+        };
+
+        // `import m = require('./mod')` / `import * as m from './mod'`: the alias
+        // carries the module specifier. Resolve the named export cross-file —
+        // this also follows re-export chains, `export =`, and ambient modules.
+        if let Some(module_name) = symbol.import_module() {
+            let source_file_idx = self
+                .ctx
+                .resolve_symbol_file_index_stable(alias_sym_id)
+                .unwrap_or(self.ctx.current_file_idx);
+            let resolution_mode_override: Option<crate::context::ResolutionModeOverride> =
+                symbol.import_resolution_mode().map(Into::into);
+            let Some(member_sym_id) = self.resolve_cross_file_export_from_file_with_mode(
+                module_name,
+                prop_name,
+                Some(source_file_idx),
+                resolution_mode_override,
+            ) else {
+                return false;
+            };
+            let member_file_idx = self
+                .ctx
+                .resolve_symbol_file_index_stable(member_sym_id)
+                .unwrap_or(source_file_idx);
+            return self.namespace_export_member_is_const(member_sym_id, member_file_idx);
+        }
+
+        // `import m = SomeNamespace`: no module specifier — resolve the alias to
+        // the namespace/module symbol and look the member up in its exports.
+        let Some(resolved_sym_id) =
+            self.resolve_alias_symbol(alias_sym_id, &mut AliasCycleTracker::new())
+        else {
+            return false;
+        };
+        let resolved_file_idx = self
+            .ctx
+            .resolve_symbol_file_index_stable(resolved_sym_id)
+            .unwrap_or(self.ctx.current_file_idx);
+        let Some(resolved_symbol) = self
+            .ctx
+            .get_binder_for_file(resolved_file_idx)
+            .and_then(|binder| binder.get_symbol(resolved_sym_id))
+            .or_else(|| self.ctx.binder.get_symbol(resolved_sym_id))
+        else {
+            return false;
+        };
+        if !resolved_symbol.has_any_flags(symbol_flags::MODULE) {
+            return false;
+        }
+        let Some(member_sym_id) = resolved_symbol
+            .exports
+            .as_ref()
+            .and_then(|exports| exports.get(prop_name))
+        else {
+            return false;
+        };
+        let member_file_idx = self
+            .ctx
+            .resolve_symbol_file_index_stable(member_sym_id)
+            .unwrap_or(resolved_file_idx);
+        self.namespace_export_member_is_const(member_sym_id, member_file_idx)
+    }
+
+    /// Whether `member_sym_id` (owned by `member_file_idx`) is a `const`
+    /// block-scoped variable, reading its declaration through the owning file's
+    /// binder and arena so the check stays correct across arenas (the member's
+    /// `value_declaration` `NodeIndex` is relative to its own file's arena).
+    fn namespace_export_member_is_const(
+        &self,
+        member_sym_id: tsz_binder::SymbolId,
+        member_file_idx: usize,
+    ) -> bool {
+        use tsz_binder::symbol_flags;
+
+        // Prefer the owning file's binder/arena; fall back to the current file's
+        // when the multi-file registry is not populated (single-file runs).
+        let (member_symbol, arena) = match self
+            .ctx
+            .get_binder_for_file(member_file_idx)
+            .and_then(|binder| binder.get_symbol(member_sym_id))
+        {
+            Some(member_symbol) => (
+                member_symbol,
+                self.ctx.get_arena_for_file(member_file_idx as u32),
+            ),
+            None => match self.ctx.binder.get_symbol(member_sym_id) {
+                Some(member_symbol) => (member_symbol, self.ctx.arena),
+                None => return false,
+            },
+        };
 
         // Check if the member is a block-scoped variable (const/let)
         if !member_symbol.has_any_flags(symbol_flags::BLOCK_SCOPED_VARIABLE) {
-            return Some(false);
+            return false;
         }
-
         // Check if its value declaration has the CONST flag
         let value_decl = member_symbol.value_declaration;
         if value_decl.is_none() {
-            return Some(false);
+            return false;
         }
-
-        self.ctx.arena.get(value_decl)?;
-        Some(self.ctx.arena.is_const_variable_declaration(value_decl))
+        if arena.get(value_decl).is_none() {
+            return false;
+        }
+        arena.is_const_variable_declaration(value_decl)
     }
 
     /// Check if a property access refers to an enum member.

--- a/crates/tsz-checker/tests/ts2540_import_equals_const_member_tests.rs
+++ b/crates/tsz-checker/tests/ts2540_import_equals_const_member_tests.rs
@@ -1,0 +1,178 @@
+//! TS2540 on `export const` members accessed through a whole-module import
+//! binding (`import m = require('...')`).
+//!
+//! Structural rule: `import m = require('./mod')` binds `m` to the target
+//! module namespace, whose `export const` members are readonly — the same rule
+//! as a same-file `namespace M { export const x = 0 }`, where `M.x = 1` is
+//! TS2540. Writing a const member through the import binding (`m.x = 1`,
+//! `m.x += 1`, `m.x++`, `++m.x`, `m["x"] = 1`) must therefore report TS2540 and
+//! suppress the TS2322 type-mismatch that otherwise fires against the const's
+//! narrowed literal type. `export let`/`var` members stay writable.
+//!
+//! Owner: `is_namespace_const_property_inner` in the checker's readonly path,
+//! extended to follow the alias to its target module and resolve the export
+//! cross-file (the alias itself is not a MODULE symbol and, for a plain
+//! named-export target, does not resolve to the member through
+//! `resolve_alias_symbol`).
+//!
+//! Adjacent cases covered:
+//! - property write, compound assignment, increment, and element access
+//! - `let` member stays writable (negative)
+//! - renamed alias binder (structural, not name-keyed)
+//! - named value import `obj.p` is NOT a module export even when the module
+//!   also exports a top-level `p` (negative — no false positive)
+//! - same-file `namespace M` const still readonly (regression guard)
+//! - `import * as ns` namespace import keeps every member readonly, const or
+//!   not (regression guard)
+
+use tsz_checker::context::CheckerOptions;
+use tsz_common::common::ModuleKind;
+
+fn readonly_diags(files: &[(&str, &str)]) -> Vec<(String, u32, String)> {
+    tsz_checker::test_utils::check_all_multi_file_with_global_index(
+        files,
+        CheckerOptions {
+            module: ModuleKind::CommonJS,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+    )
+    .into_iter()
+    // TS2540 (readonly named property), TS2542 (readonly index signature),
+    // TS2322 (type mismatch — should be suppressed alongside TS2540).
+    .filter(|diag| matches!(diag.code, 2540 | 2542 | 2322))
+    .map(|diag| (diag.file, diag.code, diag.message_text))
+    .collect()
+}
+
+const MOD_A: &str = "export const x = 0;\nexport let y = 0;\n";
+
+#[test]
+fn import_equals_const_member_write_is_readonly() {
+    let diags = readonly_diags(&[
+        ("a.ts", MOD_A),
+        ("b.ts", "import m = require('./a');\nm.x = 1;\n"),
+    ]);
+    // Exactly one TS2540 on `m.x`, and no TS2322 (suppressed by the readonly
+    // diagnostic).
+    let ts2540: Vec<_> = diags.iter().filter(|(_, c, _)| *c == 2540).collect();
+    assert_eq!(
+        diags.iter().filter(|(_, c, _)| *c == 2322).count(),
+        0,
+        "TS2322 must be suppressed alongside TS2540: {diags:?}"
+    );
+    assert_eq!(ts2540.len(), 1, "expected one TS2540: {diags:?}");
+    assert!(
+        ts2540[0].2.contains('x'),
+        "message should name 'x': {diags:?}"
+    );
+}
+
+#[test]
+fn import_equals_const_member_all_write_forms_are_readonly() {
+    // Property write, compound assignment, prefix/postfix increment, element
+    // access — every write form of the const member is TS2540, matching tsc.
+    let diags = readonly_diags(&[
+        ("a.ts", MOD_A),
+        (
+            "b.ts",
+            "import m = require('./a');\n\
+             m.x = 1;\n\
+             m.x += 2;\n\
+             m.x++;\n\
+             ++m.x;\n\
+             m[\"x\"] = 0;\n",
+        ),
+    ]);
+    assert_eq!(
+        diags.iter().filter(|(_, c, _)| *c == 2540).count(),
+        5,
+        "all five const write forms should report TS2540: {diags:?}"
+    );
+    assert_eq!(
+        diags.iter().filter(|(_, c, _)| *c == 2322).count(),
+        0,
+        "no TS2322 should survive alongside the readonly diagnostics: {diags:?}"
+    );
+}
+
+#[test]
+fn import_equals_let_member_stays_writable() {
+    // `export let y` is not const, so writing it through the binding is allowed
+    // (no TS2540). The assignment is type-compatible, so no TS2322 either.
+    let diags = readonly_diags(&[
+        ("a.ts", MOD_A),
+        ("b.ts", "import m = require('./a');\nm.y = 5;\nm.y++;\n"),
+    ]);
+    assert!(diags.is_empty(), "let member must stay writable: {diags:?}");
+}
+
+#[test]
+fn import_equals_readonly_is_structural_not_name_keyed() {
+    // A different alias binder name still reports TS2540 — the rule is
+    // structural (const export through a module binding), not tied to the name.
+    let diags = readonly_diags(&[
+        ("a.ts", MOD_A),
+        (
+            "consumer.ts",
+            "import renamedBinding = require('./a');\nrenamedBinding.x = 1;\n",
+        ),
+    ]);
+    assert_eq!(
+        diags.iter().filter(|(_, c, _)| *c == 2540).count(),
+        1,
+        "renamed alias must still report TS2540: {diags:?}"
+    );
+}
+
+#[test]
+fn named_value_import_property_is_not_a_module_const() {
+    // `import { obj }` binds a single value. `obj.p` accesses the object's own
+    // (mutable) property `p`, NOT the module-level `export const p` — so no
+    // TS2540 false positive, even though the module also exports `p`.
+    let diags = readonly_diags(&[
+        (
+            "mod.ts",
+            "export const obj = { p: 0 };\nexport const p = 99;\n",
+        ),
+        ("use.ts", "import { obj } from './mod';\nobj.p = 1;\n"),
+    ]);
+    assert_eq!(
+        diags.iter().filter(|(_, c, _)| *c == 2540).count(),
+        0,
+        "object property write must not be treated as a module const: {diags:?}"
+    );
+}
+
+#[test]
+fn same_file_namespace_const_still_readonly() {
+    // Regression guard: the pre-existing same-file namespace path is unchanged.
+    let diags = readonly_diags(&[(
+        "n.ts",
+        "namespace M { export const x = 0; export let y = 0; }\nM.x = 1;\nM.y = 2;\n",
+    )]);
+    assert_eq!(
+        diags.iter().filter(|(_, c, _)| *c == 2540).count(),
+        1,
+        "same-file namespace const write should still report exactly one TS2540: {diags:?}"
+    );
+}
+
+#[test]
+fn namespace_import_keeps_all_members_readonly() {
+    // Regression guard: `import * as ns` treats every member as readonly (an ES
+    // namespace object is immutable), const or not — both `ns.x` and `ns.y` are
+    // TS2540, matching tsc. The const path must not narrow this to const-only.
+    let diags = readonly_diags(&[
+        ("a.ts", MOD_A),
+        (
+            "star.ts",
+            "import * as ns from './a';\nns.x = 1;\nns.y = 2;\n",
+        ),
+    ]);
+    assert_eq!(
+        diags.iter().filter(|(_, c, _)| *c == 2540).count(),
+        2,
+        "namespace import should keep both members readonly: {diags:?}"
+    );
+}


### PR DESCRIPTION
Fixes #16993.

**Structural rule.** When an expression is a whole-module import binding (`import m = require('./a')`, `import m = Ns`, or `import * as m`) and the accessed member is an `export const` of the target module, `tsc` treats the member as readonly and reports **TS2540** ("Cannot assign to 'x' because it is a read-only property"), suppressing the accompanying TS2322 — the same rule as a same-file `namespace M { export const x = 0 }`, where `M.x = 1` is TS2540. tsz now does the same through the checker's readonly path.

Previously the alias symbol for `import m = require('./a')` is not a `MODULE` symbol, and for a plain named-export target `resolve_alias_symbol` does not reach the member, so `is_namespace_const_property_inner` returned `false` and TS2540 never fired: a TS2322 against the const's narrowed literal type fired instead (`m.x = 1` → "Type '1' is not assignable to type '0'"), or nothing at all (`m.x++`, `m["x"] = 0`).

**Owner layer:** checker — `crates/tsz-checker/src/state/state_checking/readonly.rs`. `is_namespace_const_property_inner` now, in addition to the existing same-file `MODULE`-symbol path, follows a whole-module import alias to its target and resolves the accessed export cross-file:
- require/star bindings resolve the named export via `resolve_cross_file_export_from_file_with_mode` (covers relative, ambient, `export =`, and re-export targets);
- `import m = Ns` resolves the alias to its namespace/module symbol;
- const-ness is read through the member's **owning file** binder + arena (its `value_declaration` `NodeIndex` is arena-relative — the per-file `SymbolId`/arena class, same family as #15983).

Named/default value imports (`import { x }`, `import x from`) are excluded (`import_name` is `Some`), so `obj.p` stays ordinary property access, not a module-export lookup — no false positive even when the module also exports a top-level `p`. `let`/`var` exports, functions, and classes stay writable through an import-equals binding, matching `tsc`. The same-file `namespace` and `import * as` (all-members-readonly) paths are unchanged.

### Adjacent-case matrix (verified vs pinned `typescript@7.0.2` oracle)

| case | tsc | tsz (this PR) |
| --- | --- | --- |
| `import m = require('./a'); m.x = 1` (const) | TS2540 | TS2540 |
| `m.x += 2`, `m.x++`, `++m.x`, `m["x"] = 0` (const) | TS2540 ×4 | TS2540 ×4 |
| `m.y = 5` (let) | ok | ok |
| renamed alias `import zzz = require('./a'); zzz.x = 1` | TS2540 | TS2540 |
| `import { obj } from './mod'; obj.p = 1` (module also exports `p`) | ok | ok |
| same-file `namespace M { export const x }; M.x = 1` | TS2540 | TS2540 |
| `import * as ns; ns.x = 1` / `ns.y = 2` | TS2540 ×2 | TS2540 ×2 |
| re-export chain `export { x } from './ra'` then `m.x = 1` | TS2322 | TS2322 |

### Note on provenance

This fix was first authored on PR #16997 (opened by a different, unidentified session). This PR carries forward only the genuine `readonly.rs` + test-file diff from that PR — I found and confirmed a serious, unrelated defect in #16997's own commit (see #16997 for the full writeup) and could not push a corrective commit there (this session's push credentials are scoped to its own branch only), so I rebuilt the clean fix here instead. #16997 is being closed as superseded.

## Goal
Goal: hold

## Verification
- New unit test `crates/tsz-checker/tests/ts2540_import_equals_const_member_tests.rs` (7 cases: write/compound/increment/element-access, let-writable negative, renamed-binder structural, named-import negative, same-file-namespace and namespace-import regression guards) — **7/7 pass**.
- Adjacent regression suites confirmed unaffected: `ts7023_self_recursive_var_reassigned_return_tests` (5/5) and `ts2433_cross_file_ambient_class_merge_tests` (7/7) — both relevant because #16997's defective commit had touched these areas.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings` — clean.
- `cargo test -p tsz-checker --test ts2540_import_equals_const_member_tests --test ts7023_self_recursive_var_reassigned_return_tests --test ts2433_cross_file_ambient_class_merge_tests` — 19/19 pass.
- Pre-commit hook (clippy + architecture guard) — passed.
- Full `conformance.sh`/`compare-to-parent.sh`/emit/fourslash not run this session (budget); this is a narrow, additive checker-readonly-path change confined to `crates/tsz-checker/src/state/state_checking/readonly.rs`, with no changes to unrelated files. Owed to the nightly lane / next drain per land-and-continue.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4SmXUCs8o6mWFThxHeaoV)_