### PR TITLE
fix(fourslash): a test that completes past its wall-clock budget is slow, not failed

### DIFF
--- a/scripts/fourslash/runner.cjs
+++ b/scripts/fourslash/runner.cjs
@@ -247,6 +247,17 @@ function stringifyCompactSnapshot(snapshot) {
         lines.push(`    ${chunk}${comma}`);
     }
 
+    lines.push("  ],", '  "slow": [');
+
+    // Subset of `pass` that exceeded the wall-clock budget — assertions
+    // passed, but flagged for harness-performance attention.
+    const slowEntries = (snapshot.slow || []).map(file => JSON.stringify(file));
+    for (let i = 0; i < slowEntries.length; i += 8) {
+        const chunk = slowEntries.slice(i, i + 8).join(", ");
+        const comma = i + 8 < slowEntries.length ? "," : "";
+        lines.push(`    ${chunk}${comma}`);
+    }
+
     lines.push(
         "  ],",
         `  "fail": ${indentJson(snapshot.fail, 2).trimStart()},`,
@@ -392,6 +403,7 @@ async function runSequential(opts, testsToRun) {
 
     const testType = 1; // FourSlashTestType.Server — tsz-server talks over stdio
     let passed = 0;
+    let slow = 0;
     let failed = 0;
     let xfailed = 0;
     let timedOut = 0;
@@ -414,13 +426,13 @@ async function runSequential(opts, testsToRun) {
             if (content == null) throw new Error(`Could not read test file: ${testFile}`);
             FourSlash.runFourSlashTestContent(basePath, testType, content, testFile);
             const elapsed = Date.now() - startTime;
-            if (elapsed > opts.testTimeout) {
-                throw new Error(`Test completed but took ${elapsed}ms (timeout: ${opts.testTimeout}ms)`);
-            }
+            const isSlow = elapsed > opts.testTimeout;
             passed++;
-            testResults.push({ file: testFile, status: "pass", timedOut: false, error: null, elapsed });
+            if (isSlow) slow++;
+            testResults.push({ file: testFile, status: isSlow ? "slow" : "pass", timedOut: false, error: null, elapsed });
             if (opts.verbose) {
-                console.log(`\x1b[32mPASS\x1b[0m (${elapsed}ms)`);
+                const tag = isSlow ? `\x1b[33mSLOW\x1b[0m` : `\x1b[32mPASS\x1b[0m`;
+                console.log(`${tag} (${elapsed}ms)`);
             } else if ((passed + failed + xfailed) % 50 === 0) {
                 process.stdout.write(`\r  Progress: ${passed + failed + xfailed}/${testsToRun.length} (${passed} passed, ${failed} failed${xfailed > 0 ? `, ${xfailed} xfailed` : ""})`);
             }
@@ -453,7 +465,7 @@ async function runSequential(opts, testsToRun) {
     }
 
     bridge.shutdown();
-    return { passed, failed, xfailed, timedOut, errors, testResults };
+    return { passed, slow, failed, xfailed, timedOut, errors, testResults };
 }
 
 function setupGlobals(tsDir) {
@@ -614,6 +626,7 @@ async function runParallel(opts, testsToRun) {
     console.log(`  Spawning ${chunks.length} workers (timeout: ${opts.testTimeout}ms, mem limit: ${opts.memoryLimitMB}MB)...`);
 
     let passed = 0;
+    let slow = 0;
     let failed = 0;
     let xfailed = 0;
     let timedOut = 0;
@@ -648,7 +661,7 @@ async function runParallel(opts, testsToRun) {
             if (activeWorkers === 0) {
                 if (!opts.verbose) printProgress();
                 clearInterval(watchdog);
-                resolve({ passed, failed, xfailed, timedOut, errors, testResults, bridgeRestarts, memoryWarnings, workerStats });
+                resolve({ passed, slow, failed, xfailed, timedOut, errors, testResults, bridgeRestarts, memoryWarnings, workerStats });
             }
         }
 
@@ -697,7 +710,8 @@ async function runParallel(opts, testsToRun) {
                 } else if (msg.type === "result") {
                     if (msg.passed) {
                         passed++;
-                        testResults.push({ file: msg.testFile, status: "pass", timedOut: false, error: null, elapsed: msg.elapsed });
+                        if (msg.slow) slow++;
+                        testResults.push({ file: msg.testFile, status: msg.slow ? "slow" : "pass", timedOut: false, error: null, elapsed: msg.elapsed });
                     } else if (msg.xfailed) {
                         xfailed++;
                         testResults.push({ file: msg.testFile, status: "xfail", timedOut: false, error: msg.error || null, elapsed: msg.elapsed });
@@ -727,7 +741,7 @@ async function runParallel(opts, testsToRun) {
 
                     if (opts.verbose) {
                         const status = msg.passed
-                            ? `\x1b[32mPASS\x1b[0m`
+                            ? (msg.slow ? `\x1b[33mSLOW\x1b[0m` : `\x1b[32mPASS\x1b[0m`)
                             : msg.xfailed
                             ? `\x1b[36mXFAIL\x1b[0m`
                             : msg.timedOut
@@ -898,21 +912,28 @@ async function main() {
         results = await runParallel(opts, testsToRun);
     }
 
-    const { passed, failed, xfailed = 0, timedOut, errors } = results;
+    const { passed, slow = 0, failed, xfailed = 0, timedOut, errors } = results;
     const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+    const executedCount = passed + failed + xfailed;
 
     // Print summary
     console.log("");
     console.log("─".repeat(70));
     console.log("");
-    console.log(`Results: ${passed} passed, ${failed} failed${xfailed > 0 ? `, ${xfailed} xfailed` : ""} out of ${testsToRun.length} (${elapsed}s)`);
+    console.log(`Results: ${passed} passed${slow > 0 ? ` (${slow} slow)` : ""}, ${failed} failed${xfailed > 0 ? `, ${xfailed} xfailed` : ""} out of ${testsToRun.length} (${elapsed}s)`);
 
     if (totalAvailable > testsToRun.length) {
         console.log(`  (${totalAvailable - testsToRun.length} tests skipped, ${totalAvailable} total available)`);
     }
 
-    const passRate = testsToRun.length > 0
-        ? ((passed / testsToRun.length) * 100).toFixed(1)
+    if (executedCount < testsToRun.length) {
+        console.log(`  (run aborted early: only ${executedCount}/${testsToRun.length} executed)`);
+    }
+
+    // Rate over what actually ran, not the intended total — an early-aborted
+    // run must not report a rate diluted by tests that never executed.
+    const passRate = executedCount > 0
+        ? ((passed / executedCount) * 100).toFixed(1)
         : "0.0";
     console.log(`  Pass rate: ${passRate}%`);
 
@@ -1005,32 +1026,41 @@ async function main() {
         jsonResults.sort((a, b) => a.file.localeCompare(b.file));
 
         const total = testsToRun.length;
+        const executed = passed + failed + xfailed;
         const detail = {
             timestamp: new Date().toISOString(),
             summary: {
                 total,
                 passed,
+                slow,
                 failed,
                 xfailed,
                 timedOut,
                 shard: opts.shardTotal > 0 ? { index: opts.shardId, count: opts.shardTotal, strategy: opts.shardStrategy } : null,
                 slowest,
-                passRate: total > 0 ? Math.round(passed / total * 1000) / 10 : 0,
+                passRate: executed > 0 ? Math.round(passed / executed * 1000) / 10 : 0,
             },
             results: jsonResults,
         };
 
         const outPath = path.resolve(opts.jsonOut);
         const snapshotOutPath = path.resolve(snapshotWeightFile());
+        // A test whose assertions passed but which ran past the wall-clock
+        // budget is "slow", not a failure — it must land in `pass`/`slow`,
+        // never in `fail`. Only a genuine assertion failure or timeout
+        // (status "fail"/"timeout"/"xfail") belongs in `fail`.
         const output = outPath === snapshotOutPath
             ? {
                 timestamp: detail.timestamp,
                 summary: detail.summary,
                 pass: jsonResults
-                    .filter(r => r.status === "pass" && !r.timedOut)
+                    .filter(r => (r.status === "pass" || r.status === "slow") && !r.timedOut)
+                    .map(r => r.file),
+                slow: jsonResults
+                    .filter(r => r.status === "slow")
                     .map(r => r.file),
                 fail: jsonResults
-                    .filter(r => r.status !== "pass" || r.timedOut)
+                    .filter(r => r.status !== "pass" && r.status !== "slow")
                     .map(r => {
                         const record = {
                             file: r.file,
@@ -1043,13 +1073,13 @@ async function main() {
                         if (r.elapsed !== undefined) record.elapsed = r.elapsed;
                         return record;
                     }),
-                // Per-test timings (ms) for passing tests, consumed by
-                // loadHistoricalWeights() for LPT shard balancing. Kept as a
-                // compact {file: ms} map so the snapshot stays small while the
+                // Per-test timings (ms) for passing tests (including slow-but-passed),
+                // consumed by loadHistoricalWeights() for LPT shard balancing. Kept as
+                // a compact {file: ms} map so the snapshot stays small while the
                 // balancer still sees a real weight for ~every test.
                 weights: Object.fromEntries(
                     jsonResults
-                        .filter(r => r.status === "pass" && !r.timedOut && Number.isFinite(Number(r.elapsed)))
+                        .filter(r => (r.status === "pass" || r.status === "slow") && Number.isFinite(Number(r.elapsed)))
                         .map(r => [r.file, Number(r.elapsed)]),
                 ),
             }

--- a/scripts/fourslash/test-worker.cjs
+++ b/scripts/fourslash/test-worker.cjs
@@ -85,8 +85,7 @@ function isTemporarilyAllowedParityFailure(testName, errMsg) {
         message.includes("isNewIdentifierLocation") ||
         message.includes("Cannot read properties of undefined") ||
         message.includes("Found an error:") ||
-        message.includes("Timeout waiting for tsz-server response") ||
-        message.includes("Test completed but took")
+        message.includes("Timeout waiting for tsz-server response")
     );
 }
 
@@ -225,15 +224,16 @@ function runSingleTest(FourSlash, Harness, testFile, testType) {
  * Run a test with a timeout. Since fourslash tests are synchronous,
  * we can't use setTimeout. Instead we use the bridge's existing timeout
  * (30s per request) as a natural guard. For an additional layer, we
- * track wall-clock time and report timeouts.
+ * track wall-clock time and flag tests that ran past budget.
+ *
+ * A test that completes past `timeoutMs` still had its assertions pass —
+ * it is slow, not failed. Callers must not treat `slow: true` as an error.
  */
 function runTestWithTimeout(FourSlash, Harness, testFile, testType, timeoutMs) {
     const start = Date.now();
     runSingleTest(FourSlash, Harness, testFile, testType);
     const elapsed = Date.now() - start;
-    if (elapsed > timeoutMs) {
-        throw new Error(`Test completed but took ${elapsed}ms (timeout: ${timeoutMs}ms)`);
-    }
+    return { elapsed, slow: elapsed > timeoutMs };
 }
 
 async function main() {
@@ -314,9 +314,8 @@ async function main() {
             : "";
 
         try {
-            runTestWithTimeout(FourSlash, Harness, testFile, testType, perTestTimeout);
-            const elapsed = Date.now() - startTime;
-            process.send({ type: "result", workerId, testFile, testName, passed: true, elapsed });
+            const { elapsed, slow } = runTestWithTimeout(FourSlash, Harness, testFile, testType, perTestTimeout);
+            process.send({ type: "result", workerId, testFile, testName, passed: true, slow, elapsed });
         } catch (err) {
             const elapsed = Date.now() - startTime;
             const errMsg = err.message || String(err);

--- a/scripts/refresh-readme.py
+++ b/scripts/refresh-readme.py
@@ -174,6 +174,8 @@ def normalize_suite_summary(data, suite):
         }
 
     if suite == "fourslash" and isinstance(data.get("pass"), list):
+        # `pass` already includes slow-but-passing tests (see runner.cjs); `slow`
+        # is a redundant subset kept for visibility, so it must not be added again.
         failed = len(data.get("fail") or [])
         return {
             "passed": len(data["pass"]),


### PR DESCRIPTION
Fixes #17010.

**Structural rule:** when a fourslash test's assertions pass but its wall-clock exceeds `opts.testTimeout`, the harness must record it as passed-but-slow, not as a failure/timeout. It previously did the opposite: both `runner.cjs`'s sequential loop and `test-worker.cjs`'s `runTestWithTimeout` synthesized a throw (`Test completed but took Nms (timeout: Nms)`) purely because the wall clock exceeded budget, even though `FourSlash.runFourSlashTestContent` had already returned successfully. That throw was caught by the generic failure path, which sets `isTimeout = elapsed >= opts.testTimeout || ...` — true by construction — so the test counted toward `failed`/`timedOut`, not `passed`, and landed in the snapshot's `fail` array.

**Why this reached the published README number:** `fourslash-snapshot.json` always carries a `summary` object, so `refresh-readme.py`'s `normalize_suite_summary` takes the `summary.passed`/`summary.total` branch directly — not the `pass`/`fail`-array-length fallback. The corrupted count was baked in at the source (the JS counters), not just in the JSON's array shape, so the fix has to live in `runner.cjs`/`test-worker.cjs`'s counting, not just in serialization.

**Owner layer:** test tooling (`scripts/fourslash/runner.cjs`, `scripts/fourslash/test-worker.cjs`) — not the compiler; no anti-hardcoding gate concerns apply.

## Fix

- `test-worker.cjs`'s `runTestWithTimeout` now returns `{elapsed, slow}` instead of throwing when a completed test ran past budget.
- `runner.cjs`'s sequential loop no longer synthesizes a throw for the same case.
- Both paths count a slow-but-passed test toward `passed` and tag it with a new `"slow"` status (distinct from `"pass"`/`"fail"`/`"timeout"`/`"xfail"`).
- The compact snapshot gains a `"slow"` array (subset of `"pass"`) alongside `"pass"`/`"fail"`, matching the schema #17010 suggested. `"weights"` (consumed by `loadHistoricalWeights()` for LPT shard balancing) now includes slow-but-passed elapsed times, which it previously silently dropped.
- Removed the now-dead `"Test completed but took"` string match from `test-worker.cjs`'s `isTemporarilyAllowedParityFailure` allowlist — that message can no longer be thrown.
- Also fixes the console `Pass rate` denominator bug named in #17010: it previously divided by the *intended* test count even when a run aborted early (`executed < intended`), diluting the rate. Now divides by the executed count and prints an explicit "run aborted early" note when the two differ.

## Adjacent-case matrix (verified against the real harness + built `tsz-server`)

| case | before | after |
| --- | --- | --- |
| assertions pass, `elapsed > timeout` (`--timeout=1` forcing every test slow, 20-test `quickInfo*` filter) | 0 passed, 20 failed/timeout | **20 passed (11 slow), 0 failed** |
| assertions genuinely fail (`importNameCodeFix_importType`, real `No codefixes returned.`) | 1 failed | **1 failed** (unchanged — negative control) |
| compact snapshot (`--json-out` with no path, i.e. the real `fourslash-snapshot.json` target) | `slow` tests land in `fail` | **`pass`: 20, `slow`: 11 (⊆ pass), `fail`: 0, `weights`: 20 entries** |

## Goal
Goal: hold

## Verification
- `node -c scripts/fourslash/runner.cjs && node -c scripts/fourslash/test-worker.cjs && python3 -m py_compile scripts/refresh-readme.py` — clean.
- Built `tsz-server` release binary (`cargo build --release -p tsz-cli --bin tsz-server`), then ran real fourslash sub-runs against it:
  - `run-fourslash.sh --skip-cargo-build --filter=quickInfo --max=20 --timeout=1 --workers=2 --json-out=<scratch>` — `20 passed (11 slow), 0 failed`, matches the table above.
  - Same run with `--json-out` (default path, exercising the compact-snapshot branch) — `pass` 20 / `slow` 11 (subset of `pass`) / `fail` 0 / `weights` 20 entries; restored the original committed `fourslash-snapshot.json` afterward via backup/restore (no snapshot content changed by this PR).
  - `run-fourslash.sh --skip-cargo-build --filter=importNameCodeFix_importType --workers=1` (default 25s timeout) — `9 passed, 1 failed`, the one genuine failure (`No codefixes returned.`) still correctly reported as `FAIL`, not `SLOW` — negative control.
- No Rust changed; `clippy`/`arch-size` not applicable.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaxUyoB7BuJm6Mjbjnqc52)_