### PR TITLE
fix(resolver): .json specifier prefers its .d.json.ts declaration companion

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2347,6 +2347,9 @@ path = "tests/recovery_any_sites_tests.rs"
 name = "arbitrary_ext_decl_module_resolution_tests"
 path = "tests/arbitrary_ext_decl_module_resolution_tests.rs"
 [[test]]
+name = "json_declaration_companion_module_resolution_tests"
+path = "tests/json_declaration_companion_module_resolution_tests.rs"
+[[test]]
 name = "mixin_any_base_index_sig_tests"
 path = "tests/mixin_any_base_index_sig_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/module_resolution.rs
+++ b/crates/tsz-checker/src/module_resolution.rs
@@ -99,13 +99,20 @@ fn target_resolution_priority(target: &IndexedTarget<'_>) -> usize {
 }
 
 /// Tails that mark a file as an *arbitrary-extension declaration file*: a file
-/// named `<base>.d.<ext>.ts` where `<ext>` is itself a known TS/JS/JSON
-/// extension. These files are addressable through their paired implementation
-/// specifier (`./file.ts` → `./file.d.ts.ts`) but NOT through the stripped form
+/// named `<base>.d.<ext>.ts` where `<ext>` is itself a known TS/JS extension.
+/// These files are addressable through their paired implementation specifier
+/// (`./file.ts` → `./file.d.ts.ts`) but NOT through the stripped form
 /// (`./file.d.ts`), because that form would collide with genuine declaration
 /// imports the user wrote.
+///
+/// `.d.json` is deliberately absent: unlike the TS/JS tails above, tsc's own
+/// `tryAddingExtensions` gives a `.json` specifier's `.d.json.ts` companion
+/// declaration priority over the JSON file's own literal shape (tried before
+/// the `.json` extension itself, unconditionally). So `<base>.d.json.ts` is
+/// registered as a normal target and additionally reachable through the
+/// *stripped* `<base>.json` form — see `relative_file_specifier`'s `user_alt`.
 const ARBITRARY_EXT_TAILS: &[&str] = &[
-    ".d.ts", ".d.tsx", ".d.mts", ".d.cts", ".d.js", ".d.jsx", ".d.mjs", ".d.cjs", ".d.json",
+    ".d.ts", ".d.tsx", ".d.mts", ".d.cts", ".d.js", ".d.jsx", ".d.mjs", ".d.cjs",
 ];
 
 /// Detect `<base>.d.<ext>.ts` files. These are treated specially (see the
@@ -365,8 +372,10 @@ struct RelativeFileSpecifier {
     stem: String,
     /// Present only when the file has a recognized extension: `./foo.js`.
     with_extension: Option<String>,
-    /// Present only for `<base>.d.<ext>.ts` with `<ext>` outside TS/JS/JSON:
-    /// the user-written `<base>.<ext>` form (e.g. `./component.html`).
+    /// Present for `<base>.d.<ext>.ts` with `<ext>` outside TS/JS (the
+    /// user-written `<base>.<ext>` form, e.g. `./component.html`), and for
+    /// `<base>.d.json.ts` (the user-written `<base>.json` form — tsc's
+    /// declaration-before-json priority, not a generic arbitrary-extension).
     user_alt: Option<String>,
 }
 
@@ -387,8 +396,20 @@ fn relative_file_specifier(from_dir: &Path, to_file: &Path) -> Option<RelativeFi
     // `./component.d.html.ts`). The legacy `<base>.d.<ext>` stem stays
     // registered for behavior compatibility with existing fixtures; the
     // user-form is added so tsc-style imports also resolve.
-    let user_alt =
-        arbitrary_ext_decl_user_parts(&rel_str).map(|(base, ext)| format!("{prefix}{base}.{ext}"));
+    //
+    // `<base>.d.json.ts` is a separate, tsc-specific rule (not the generic
+    // arbitrary-extension mechanism above, since `.json` is a recognized
+    // extension): a `.json` specifier's declaration companion is tried before
+    // its own JSON extension, unconditionally. Registered under the same
+    // `user_alt` slot so it participates in the same priority-ordered
+    // overwrite as any sibling `<base>.json` target.
+    let user_alt = arbitrary_ext_decl_user_parts(&rel_str)
+        .map(|(base, ext)| format!("{prefix}{base}.{ext}"))
+        .or_else(|| {
+            rel_str
+                .strip_suffix(".d.json.ts")
+                .map(|base| format!("{prefix}{base}.json"))
+        });
 
     Some(RelativeFileSpecifier {
         stem,
@@ -1037,6 +1058,21 @@ fn resolve_specifier_via_file_index_uncached(
         s
     };
     let base = lexical_normalize_slash(&joined);
+
+    // A `.json` specifier's sibling `.d.json.ts` declaration file takes
+    // priority over the JSON file's own literal shape, unconditionally —
+    // mirrors tsc's `tryAddingExtensions` `Extension.Json` case (Declaration
+    // tried before Json) and `register_canonical_forms`'s `user_alt` slot.
+    // Checked before the direct hit below so the declaration wins even when
+    // both a `.json` and a `.d.json.ts` are project files.
+    if let Some(json_stem) = base.strip_suffix(".json") {
+        let mut decl = String::with_capacity(json_stem.len() + 10);
+        decl.push_str(json_stem);
+        decl.push_str(".d.json.ts");
+        if let Some(&idx) = filename_idx.get(&decl) {
+            return Some(idx);
+        }
+    }
 
     // Direct hit: the specifier already spells out the full path (e.g.
     // `./foo.ts` when `foo.ts` is a project file).

--- a/crates/tsz-checker/tests/json_declaration_companion_module_resolution_tests.rs
+++ b/crates/tsz-checker/tests/json_declaration_companion_module_resolution_tests.rs
@@ -1,0 +1,164 @@
+//! Coverage for the `.json` declaration-companion resolution rule:
+//! a `.json` specifier's sibling `<base>.d.json.ts` declaration file takes
+//! priority over the JSON file's own literal shape.
+//!
+//! Owner layer: module resolution (`tsz_core::module_resolver::file_probing`
+//! for on-disk project discovery; `tsz_checker::module_resolution`'s
+//! `resolve_specifier_via_file_index_uncached` and `register_canonical_forms`
+//! for the checker's specifier → file-index maps).
+//!
+//! Structural rule (pinned `typescript@7.0.2` oracle,
+//! `declarationFileForJsonImport.ts`): `tsc`'s `tryAddingExtensions`
+//! `Extension.Json` case tries the `Declaration` extension
+//! (`<base>.d.json.ts`) *before* the `Json` extension (`<base>.json`),
+//! unconditionally — independent of `resolveJsonModule`. So when both files
+//! exist, `import x from "./data.json"` always types `x` from the
+//! declaration file, and never reports TS2732 ("consider using
+//! `--resolveJsonModule`"), in either `resolveJsonModule` setting.
+//!
+//! Adjacent cases (§26 generalization gate):
+//! 1. Declaration wins with `resolveJsonModule: true` (would otherwise type
+//!    from the JSON literal's own inferred shape).
+//! 2. Declaration wins with `resolveJsonModule: false` (would otherwise be
+//!    TS2732, "cannot find module").
+//! 3. Renamed binder/specifier (§25 structural-over-identifier gate).
+//! 4. Negative control: without the declaration file, `resolveJsonModule:
+//!    false` still errors (the fix must not blanket-suppress it).
+//! 5. Negative control: without the declaration file, `resolveJsonModule:
+//!    true` still types from the JSON literal's own shape (a real mismatch
+//!    still surfaces TS2322).
+
+use tsz_checker::context::CheckerOptions;
+use tsz_common::common::ModuleKind;
+
+fn diagnostic_codes(files: &[(&str, &str)], entry: &str, resolve_json_module: bool) -> Vec<u32> {
+    tsz_checker::test_utils::check_multi_file(
+        files,
+        entry,
+        CheckerOptions {
+            module: ModuleKind::CommonJS,
+            resolve_json_module,
+            ..CheckerOptions::default()
+        },
+    )
+    .into_iter()
+    .map(|d| d.code)
+    .collect()
+}
+
+#[test]
+fn json_decl_companion_wins_with_resolve_json_module_true() {
+    let decl = "declare var val: string; export default val;";
+    let json = "{}";
+    let consumer = r#"
+import data from "./data.json";
+let x: string = data;
+"#;
+    let codes = diagnostic_codes(
+        &[
+            ("/proj/data.d.json.ts", decl),
+            ("/proj/data.json", json),
+            ("/proj/main.ts", consumer),
+        ],
+        "/proj/main.ts",
+        true,
+    );
+    assert!(
+        codes.is_empty(),
+        "declaration companion should type `data` as string, no diagnostics: {codes:?}",
+    );
+}
+
+#[test]
+fn json_decl_companion_wins_with_resolve_json_module_false() {
+    let decl = "declare var val: string; export default val;";
+    let json = "{}";
+    let consumer = r#"
+import data from "./data.json";
+let x: string = data;
+"#;
+    let codes = diagnostic_codes(
+        &[
+            ("/proj/data.d.json.ts", decl),
+            ("/proj/data.json", json),
+            ("/proj/main.ts", consumer),
+        ],
+        "/proj/main.ts",
+        false,
+    );
+    assert!(
+        codes.is_empty(),
+        "declaration companion resolves even with resolveJsonModule off, no TS2732: {codes:?}",
+    );
+}
+
+#[test]
+fn json_decl_companion_renamed_binder_and_specifier() {
+    // §25: structural over the specific identifiers `data`/`val`/`data.json`.
+    let decl = "declare var payload: number; export default payload;";
+    let json = "{}";
+    let consumer = r#"
+import cfg from "./settings.json";
+let n: number = cfg;
+"#;
+    let codes = diagnostic_codes(
+        &[
+            ("/proj/settings.d.json.ts", decl),
+            ("/proj/settings.json", json),
+            ("/proj/main.ts", consumer),
+        ],
+        "/proj/main.ts",
+        true,
+    );
+    assert!(
+        codes.is_empty(),
+        "renamed binder/specifier should behave identically: {codes:?}",
+    );
+}
+
+#[test]
+fn json_without_decl_companion_still_errors_when_resolve_json_module_off() {
+    // Negative control: no `.d.json.ts` sibling exists, so the fix must not
+    // blanket-suppress the "not resolvable as a value import" diagnostic.
+    // This lightweight index-based harness reports TS2306 ("File is not a
+    // module") here rather than the real disk-backed resolver's TS2732
+    // upgrade (`tsz_core::module_resolver::mod.rs`'s
+    // `JsonModuleWithoutResolveJsonModule`, exercised by the CLI/conformance
+    // path) — confirmed identical on `main` before this change, so the
+    // assertion pins the harness's pre-existing behavior, not a claim about
+    // which code tsc itself reports.
+    let json = "{}";
+    let consumer = r#"
+import data from "./data.json";
+"#;
+    let codes = diagnostic_codes(
+        &[("/proj/data.json", json), ("/proj/main.ts", consumer)],
+        "/proj/main.ts",
+        false,
+    );
+    assert!(
+        !codes.is_empty(),
+        "missing declaration companion + resolveJsonModule off should still error: {codes:?}",
+    );
+}
+
+#[test]
+fn json_without_decl_companion_still_types_from_json_literal_when_resolve_json_module_on() {
+    // Negative control: no `.d.json.ts` sibling, resolveJsonModule on — the
+    // JSON file's own inferred shape (`{}`) still governs, so a real
+    // mismatch against `string` still reports TS2322.
+    let json = "{}";
+    let consumer = r#"
+import data from "./data.json";
+let x: string = data;
+"#;
+    let codes = diagnostic_codes(
+        &[("/proj/data.json", json), ("/proj/main.ts", consumer)],
+        "/proj/main.ts",
+        true,
+    );
+    assert!(
+        codes.contains(&2322),
+        "missing declaration companion should still type from the JSON literal shape: {codes:?}",
+    );
+}

--- a/crates/tsz-checker/tests/module_resolution.rs
+++ b/crates/tsz-checker/tests/module_resolution.rs
@@ -1152,34 +1152,60 @@ fn test_arbitrary_ext_decl_renamed_extensions() {
 }
 
 #[test]
-fn test_arbitrary_ext_decl_does_not_disturb_ts_js_json_wrapped_files() {
+fn test_arbitrary_ext_decl_does_not_disturb_ts_js_wrapped_files() {
     // Regression guard for the existing `test_arbitrary_extension_declaration_file_is_not_mapped`
-    // invariant: TS/JS/JSON-wrapped declaration files remain unmapped.
+    // invariant: TS/JS-wrapped declaration files remain unmapped. `.d.json.ts`
+    // is deliberately excluded here — see
+    // `test_json_decl_wrapped_file_registers_under_stripped_json_form` below,
+    // which covers the opposite, tsc-mandated rule for that one extension.
     let files = vec![
         "/proj/app.ts".to_string(),
         "/proj/foo.d.ts.ts".to_string(),
-        "/proj/bar.d.json.ts".to_string(),
         "/proj/baz.d.js.ts".to_string(),
     ];
     let (paths, modules) = build_module_resolution_maps(&files);
-    for spec in [
-        "./foo.d.ts",
-        "./foo.json",
-        "./bar.json",
-        "./baz.js",
-        "./foo",
-        "./bar",
-        "./baz",
-    ] {
+    for spec in ["./foo.d.ts", "./foo.json", "./baz.js", "./foo", "./baz"] {
         assert!(
             !paths.contains_key(&(0, spec.to_string())),
-            "TS/JS/JSON-wrapped decl file must not register {spec}",
+            "TS/JS-wrapped decl file must not register {spec}",
         );
         assert!(
             !modules.contains(spec),
-            "TS/JS/JSON-wrapped decl file must not register {spec} in module set",
+            "TS/JS-wrapped decl file must not register {spec} in module set",
         );
     }
+}
+
+#[test]
+fn test_json_decl_wrapped_file_registers_under_stripped_json_form() {
+    // Unlike `.d.ts.ts`/`.d.js.ts` above, `.d.json.ts` is tsc's real
+    // declaration-companion shape for a `.json` specifier (pinned
+    // `typescript@7.0.2` oracle, `declarationFileForJsonImport.ts`):
+    // `tryAddingExtensions`'s `Extension.Json` case tries the Declaration
+    // extension before the Json extension, unconditionally. So `./bar.json`
+    // must resolve to `bar.d.json.ts`, and — when a sibling `bar.json` also
+    // exists — the declaration wins (last-registered-wins overwrite, since a
+    // `.d.json.ts` target's `.ts` suffix ranks it as the highest-priority
+    // resolution-extension group).
+    let files = vec![
+        "/proj/app.ts".to_string(),
+        "/proj/bar.d.json.ts".to_string(),
+    ];
+    let (paths, modules) = build_module_resolution_maps(&files);
+    assert_eq!(paths.get(&(0, "./bar.json".to_string())), Some(&1));
+    assert!(modules.contains("./bar.json"));
+
+    let files_with_sibling_json = vec![
+        "/proj/app.ts".to_string(),
+        "/proj/bar.d.json.ts".to_string(),
+        "/proj/bar.json".to_string(),
+    ];
+    let (paths, _) = build_module_resolution_maps(&files_with_sibling_json);
+    assert_eq!(
+        paths.get(&(0, "./bar.json".to_string())),
+        Some(&1),
+        "declaration companion must win over a sibling literal .json file",
+    );
 }
 
 #[test]

--- a/crates/tsz-core/src/module_resolver/file_probing.rs
+++ b/crates/tsz-core/src/module_resolver/file_probing.rs
@@ -71,6 +71,20 @@ impl ModuleResolver {
             return None;
         }
         if let Some((base, extension)) = split_path_extension(path) {
+            // A `.json` specifier prefers a sibling `.d.json.ts` declaration
+            // file over the JSON file's own literal shape, matching tsc's
+            // `tryAddingExtensions` `Extension.Json` case: the declaration
+            // extension is tried before the JSON extension, unconditionally
+            // (independent of `resolveJsonModule`). Without this, a resolved
+            // `.json` file with `resolveJsonModule` off is later upgraded to
+            // TS2732 by the caller, and with it on the JSON literal's own
+            // inferred shape shadows the declared type.
+            if extension == "json"
+                && let Some(resolved) = try_arbitrary_extension_declaration(path, extension)
+            {
+                return Some(resolved);
+            }
+
             // Try extension substitution (.js -> .ts/.tsx/.d.ts) for all resolution modes.
             // TypeScript resolves `.js` imports to `.ts` sources in all modes.
             if let Some(rewritten) = node16_extension_substitution(path, extension) {

--- a/crates/tsz-core/src/module_resolver/tests/resolver_integration.rs
+++ b/crates/tsz-core/src/module_resolver/tests/resolver_integration.rs
@@ -250,6 +250,82 @@ fn test_json_import_without_resolve_json_module() {
     assert_eq!(diagnostic.code, 2732); // TS2732
 }
 
+/// A `.json` specifier's sibling `<base>.d.json.ts` declaration file takes
+/// priority over the JSON file's own literal shape, unconditionally — tsc's
+/// `tryAddingExtensions` `Extension.Json` case tries the Declaration
+/// extension before the Json extension. Verified against the pinned
+/// `typescript@7.0.2` oracle (`declarationFileForJsonImport.ts`): both
+/// `resolveJsonModule` settings resolve to the declaration file, never TS2732.
+#[test]
+fn test_json_import_prefers_decl_companion_with_resolve_json_module_true() {
+    let fixture = TempFixture::new();
+    let dir = fixture.path();
+    fixture.write("app.ts", "import data from './data.json';");
+    fixture.write("data.json", "{}");
+    fixture.write(
+        "data.d.json.ts",
+        "declare var val: string; export default val;",
+    );
+
+    let mut resolver = ModuleResolver::new(&ResolvedCompilerOptions {
+        resolve_json_module: true,
+        ..Default::default()
+    });
+
+    let resolved = resolver
+        .resolve("./data.json", &dir.join("app.ts"), Span::new(0, 10))
+        .expect("declaration companion should resolve");
+    assert_eq!(resolved.resolved_path, dir.join("data.d.json.ts"));
+    assert!(resolved.extension.is_declaration());
+}
+
+#[test]
+fn test_json_import_prefers_decl_companion_with_resolve_json_module_false() {
+    let fixture = TempFixture::new();
+    let dir = fixture.path();
+    fixture.write("app.ts", "import data from './data.json';");
+    fixture.write("data.json", "{}");
+    fixture.write(
+        "data.d.json.ts",
+        "declare var val: string; export default val;",
+    );
+
+    let mut resolver = ModuleResolver::new(&ResolvedCompilerOptions {
+        resolve_json_module: false,
+        ..Default::default()
+    });
+
+    let resolved = resolver
+        .resolve("./data.json", &dir.join("app.ts"), Span::new(0, 10))
+        .expect("declaration companion resolves regardless of resolveJsonModule");
+    assert_eq!(resolved.resolved_path, dir.join("data.d.json.ts"));
+    assert!(resolved.extension.is_declaration());
+}
+
+/// Renamed-binder variant (§25 structural-over-identifier gate): the rule is
+/// keyed on the `.d.json.ts` shape, not on `data`/`val` specifically.
+#[test]
+fn test_json_import_prefers_decl_companion_renamed_specifier() {
+    let fixture = TempFixture::new();
+    let dir = fixture.path();
+    fixture.write("app.ts", "import cfg from './settings.json';");
+    fixture.write("settings.json", "{}");
+    fixture.write(
+        "settings.d.json.ts",
+        "declare var payload: number; export default payload;",
+    );
+
+    let mut resolver = ModuleResolver::new(&ResolvedCompilerOptions {
+        resolve_json_module: true,
+        ..Default::default()
+    });
+
+    let resolved = resolver
+        .resolve("./settings.json", &dir.join("app.ts"), Span::new(0, 10))
+        .expect("renamed declaration companion should resolve");
+    assert_eq!(resolved.resolved_path, dir.join("settings.d.json.ts"));
+}
+
 #[test]
 fn test_extensionless_json_import_does_not_resolve_with_resolve_json_module() {
     let fixture = TempFixture::new();


### PR DESCRIPTION
Fixes the `declarationFileForJsonImport.ts` conformance false positive (extra TS2322/TS2732 on both `resolveJsonModule` variants).

## Structural rule

When a `.json` specifier has a sibling `.d.json.ts` declaration file, `tsc`'s `tryAddingExtensions` `Extension.Json` case tries the Declaration extension before the Json extension, unconditionally — independent of `resolveJsonModule`. So `import x from "./data.json"` always types `x` from the declaration file when both exist, and never reports TS2732, in either `resolveJsonModule` setting. Verified against the pinned `typescript@7.0.2` oracle (`declarationFileForJsonImport.ts`'s own baseline: both `resolveJsonModule: true` and `false` variants type `data` as `string` from `data.d.json.ts`, never from the literal `data.json` shape `{}`).

Before this change tsz had no `.d.json.ts` handling at all, so `./data.json` always resolved to the literal JSON file: with `resolveJsonModule` off that upgrades to TS2732 ("cannot find module... consider `--resolveJsonModule`"); with it on, `data` types from the JSON literal's own inferred shape (`{}`), producing a spurious TS2322 against `let x: string = data`.

## Owner layers (two, both needed)

- `tsz_core::module_resolver::file_probing` (on-disk project discovery, `crates/tsz-core/src/module_resolver/file_probing.rs`): a `.json` specifier now probes `.d.json.ts` before falling back to the literal `.json` file, reusing the existing `try_arbitrary_extension_declaration` helper (the same one already used for genuinely arbitrary extensions like `.html`/`.svelte`).
- `tsz_checker::module_resolution` (checker specifier → file-index maps, `crates/tsz-checker/src/module_resolution.rs`): `.d.json.ts` was previously grouped with the pathological `.d.ts.ts`/`.d.js.ts` self-referential shapes and dropped from the target index entirely (`ARBITRARY_EXT_TAILS`). Unlike those, `.d.json.ts` is `tsc`'s real declaration-companion shape for `.json`, so it's removed from that list; it now registers under the stripped `.json` form via `relative_file_specifier`'s `user_alt` slot (same mechanism as the `.html`/`.svelte` "user form" registration), and `resolve_specifier_via_file_index_uncached` (the primary checker resolution path per that module's own doc comment) tries the same declaration form before its direct-hit check on the literal specifier.

Both were necessary: the disk resolver controls *program membership* (which files get loaded from an entry point), while the checker's index-based map controls *specifier → file-index resolution* once the program is already loaded — they're two independent implementations that both needed to know about the `.json` → `.d.json.ts` priority rule.

## Adjacent-case matrix (pinned `typescript@7.0.2` oracle where noted)

| case | tsc / tsz (after) |
| --- | --- |
| `.d.json.ts` sibling exists, `resolveJsonModule: true` | types from declaration, no diagnostics |
| `.d.json.ts` sibling exists, `resolveJsonModule: false` | types from declaration, no TS2732 |
| renamed specifier/binder (`settings.json`/`settings.d.json.ts`/`payload`) | same as above — structural, not identifier-keyed |
| declaration + literal `.json` both present as program files | declaration wins (last-registered-wins overwrite: a `.d.json.ts` target's trailing `.ts` ranks it as the highest-priority resolution-extension group) |
| no `.d.json.ts` sibling, `resolveJsonModule: false` (negative control) | still errors — fix does not blanket-suppress the "enable resolveJsonModule" diagnostic |
| no `.d.json.ts` sibling, `resolveJsonModule: true` (negative control) | still types from the JSON literal's own shape — a real TS2322 mismatch still surfaces |

An existing unit test (`crates/tsz-checker/tests/module_resolution.rs`) asserted the old, incorrect "never register `.d.json.ts`" behavior for this extension specifically (grouped with the genuinely-pathological `.d.ts.ts`/`.d.js.ts` cases); split it into two tests with the corrected expectation for `.json`.

## Goal
Goal: hold

## Verification

- `cargo test -p tsz-core --lib module_resolver`: 292/292 (was 289; +3 new adjacent-case tests)
- `cargo test -p tsz-checker --lib module_resolution`: 113/113
- `cargo test -p tsz-checker --test arbitrary_ext_decl_module_resolution_tests`: 12/12 (no regression to the existing generic arbitrary-extension mechanism)
- `cargo test -p tsz-checker --test json_declaration_companion_module_resolution_tests`: 5/5 (new dedicated file)
- `cargo clippy -p tsz-core -p tsz-checker --all-targets`: clean
- `cargo fmt --check -p tsz-core -p tsz-checker`: clean
- `python3 scripts/arch/arch_guard.py`: passed
- Direct binary check against the actual conformance fixture (both compiler-option variants), `dist-fast` build: `declarationFileForJsonImport.ts` now exits 0 with `--resolveJsonModule` both on and off — previously extra `TS2322`/`TS2732`.
- `./scripts/conformance/conformance.sh snapshot --workers 12 --force` at this PR's head (`8fb6348`): **12585 candidates, 12043 runnable, 11567 passed, 476 failed** (96.0%). `declarationFileForJsonImport.ts` no longer appears in the failures list (confirmed fixed). The only failure anywhere in `moduleResolution`/`nonjsExtensions`/`json`-named test paths is a pre-existing, unrelated `packageJsonExportsOptionsCompat.ts` (`TS5098`/`TS5108` options-compat mismatch) — no adjacent regression. This is not a clean two-sided parent diff (several other PRs from concurrent sessions landed on `main` during this run), so the pass count includes their contributions too; the fixture-level before/after and the oracle-pinned adjacent-case matrix above are the primary evidence for this specific fix, per this repo's own convention for zero/small-corpus-movement families.
- CI green at exact head `8fb6348` (clippy, arch-size, CI Summary all success).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6vPxkbSJ5Ze6P3Y2QqLSZ)_