### PR TITLE
fix(resolver): .json resolves .d.json.ts companion unconditionally, TS6263 when flag is off

### DIFF
--- a/crates/tsz-core/src/module_resolver/file_probing.rs
+++ b/crates/tsz-core/src/module_resolver/file_probing.rs
@@ -71,6 +71,23 @@ impl ModuleResolver {
             return None;
         }
         if let Some((base, extension)) = split_path_extension(path) {
+            // A `.json` specifier's sibling `.d.json.ts` declaration file
+            // takes priority over the JSON file's own literal shape,
+            // unconditionally — mirrors tsc's `tryAddingExtensions`
+            // `Extension.Json` case (Declaration tried before Json) and is
+            // independent of both `resolveJsonModule` and
+            // `allowArbitraryExtensions`. Probed regardless of the flag, like
+            // the unknown-extension declaration probe above: when the flag
+            // is off, `is_arbitrary_extension_declaration` in `mod.rs` still
+            // emits TS6263 for the resolved declaration (verified against
+            // pinned `typescript@7.0.2`: both flag states resolve to the
+            // declaration, and only the diagnostic differs).
+            if extension == "json"
+                && let Some(resolved) = try_arbitrary_extension_declaration(path, extension)
+            {
+                return Some(resolved);
+            }
+
             // Try extension substitution (.js -> .ts/.tsx/.d.ts) for all resolution modes.
             // TypeScript resolves `.js` imports to `.ts` sources in all modes.
             if let Some(rewritten) = node16_extension_substitution(path, extension) {

--- a/crates/tsz-core/src/module_resolver/mod.rs
+++ b/crates/tsz-core/src/module_resolver/mod.rs
@@ -1300,8 +1300,17 @@ fn is_arbitrary_extension_declaration(specifier: &str, resolved_path: &std::path
         None => return false,
     };
 
-    // Standard TS/JS extensions are not arbitrary
-    let standard = ["ts", "tsx", "js", "jsx", "mts", "cts", "mjs", "cjs", "json"];
+    // Standard TS/JS extensions are not arbitrary. `.json` is deliberately
+    // excluded from this list: unlike the TS/JS tails, tsc's own
+    // `tryAddingExtensions` gives a `.json` specifier's `.d.json.ts`
+    // companion declaration priority over the JSON file's own literal shape
+    // *unconditionally* — resolution still lands on the declaration even
+    // when `allowArbitraryExtensions` is off, and tsc reports TS6263 for
+    // that case (verified against pinned `typescript@7.0.2`). The suffix
+    // check below already scopes this correctly: a `.json` specifier that
+    // resolves to the literal `.json` file never matches the `.d.json.ts`
+    // suffix, so this carve-out only fires for the genuine companion case.
+    let standard = ["ts", "tsx", "js", "jsx", "mts", "cts", "mjs", "cjs"];
     if standard.contains(&spec_ext) {
         return false;
     }

--- a/crates/tsz-core/src/module_resolver/tests.rs
+++ b/crates/tsz-core/src/module_resolver/tests.rs
@@ -15,6 +15,7 @@ mod diagnostics_ts2792;
 mod diagnostics_ts2835;
 mod explicit_root_untyped_js;
 mod importing_module_kind;
+mod json_decl_companion;
 mod lookup_classify;
 mod lookup_integration;
 mod max_node_module_js_depth;

--- a/crates/tsz-core/src/module_resolver/tests/json_decl_companion.rs
+++ b/crates/tsz-core/src/module_resolver/tests/json_decl_companion.rs
@@ -1,0 +1,178 @@
+//! Coverage for `.json` specifiers resolving through their `.d.json.ts`
+//! declaration companion.
+//!
+//! Structural rule, verified directly against the pinned `typescript@7.0.2`
+//! oracle (not just the `declarationFileForJsonImport.ts` conformance
+//! fixture, which only exercises the `allowArbitraryExtensions: true` case):
+//! tsc's `tryAddingExtensions` `Extension.Json` case tries the Declaration
+//! extension (`<base>.d.json.ts`) before the Json extension (`<base>.json`)
+//! **unconditionally** — independent of both `resolveJsonModule` and
+//! `allowArbitraryExtensions`. The two flags change only the DIAGNOSTIC, not
+//! whether resolution lands on the declaration:
+//!
+//! | `allowArbitraryExtensions` | `resolveJsonModule` | resolves to | diagnostic |
+//! | --- | --- | --- | --- |
+//! | true | true or false | `.d.json.ts` | none |
+//! | false | true or false | `.d.json.ts` | TS6263 (path preserved) |
+//!
+//! Confirmed with the oracle directly: `resolveJsonModule` has zero effect on
+//! either outcome once a `.d.json.ts` sibling exists — it only matters for a
+//! literal `.json` file with no companion (covered elsewhere by
+//! `test_json_import_without_resolve_json_module`).
+
+use super::super::*;
+use super::fixtures::TempFixture;
+
+fn lookup_json(
+    dir: &std::path::Path,
+    specifier: &str,
+    resolve_json_module: bool,
+    allow_arbitrary_extensions: bool,
+) -> ModuleLookupResult {
+    let options = ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Node),
+        resolve_json_module,
+        allow_arbitrary_extensions,
+        module_suffixes: vec![String::new()],
+        ..Default::default()
+    };
+    let mut resolver = ModuleResolver::new(&options);
+    let request = ModuleLookupRequest {
+        specifier,
+        containing_file: &dir.join("index.ts"),
+        specifier_span: Span::new(0, specifier.len() as u32),
+        import_kind: ImportKind::EsmImport,
+        resolution_mode_override: None,
+        no_implicit_any: false,
+        implied_classic_resolution: false,
+    };
+    resolver.lookup(&request, |_, _| None, |_| false, None)
+}
+
+#[test]
+fn decl_companion_wins_silently_when_flag_is_on_resolve_json_module_true() {
+    let fixture = TempFixture::new();
+    let dir = fixture.path();
+    fixture.write("index.ts", "import data from './data.json';");
+    fixture.write("data.json", "{}");
+    fixture.write(
+        "data.d.json.ts",
+        "declare var val: string;\nexport default val;\n",
+    );
+
+    let outcome = lookup_json(dir, "./data.json", true, true).classify();
+    assert!(outcome.is_resolved);
+    assert!(
+        outcome.error.is_none(),
+        "expected no diagnostic: {:?}",
+        outcome.error
+    );
+    let resolved = outcome.resolved_path.expect("resolved path");
+    assert!(resolved.ends_with("data.d.json.ts"));
+}
+
+#[test]
+fn decl_companion_wins_silently_when_flag_is_on_resolve_json_module_false() {
+    let fixture = TempFixture::new();
+    let dir = fixture.path();
+    fixture.write("index.ts", "import data from './data.json';");
+    fixture.write("data.json", "{}");
+    fixture.write(
+        "data.d.json.ts",
+        "declare var val: string;\nexport default val;\n",
+    );
+
+    let outcome = lookup_json(dir, "./data.json", false, true).classify();
+    assert!(outcome.is_resolved);
+    assert!(
+        outcome.error.is_none(),
+        "declaration companion resolves silently regardless of resolveJsonModule: {:?}",
+        outcome.error
+    );
+    let resolved = outcome.resolved_path.expect("resolved path");
+    assert!(resolved.ends_with("data.d.json.ts"));
+}
+
+#[test]
+fn decl_companion_still_wins_when_flag_is_off_but_reports_ts6263() {
+    // The adjacent case both #17018 and #17019 missed: without
+    // `allowArbitraryExtensions`, tsc does NOT fall back to the literal
+    // `.json` file — it still resolves to `.d.json.ts` and reports TS6263
+    // ("was resolved to '...', but '--allowArbitraryExtensions' is not
+    // set"), with the resolved path preserved (verified against pinned
+    // typescript@7.0.2: identical for both resolveJsonModule settings).
+    let fixture = TempFixture::new();
+    let dir = fixture.path();
+    fixture.write("index.ts", "import data from './data.json';");
+    fixture.write("data.json", "{}");
+    fixture.write(
+        "data.d.json.ts",
+        "declare var val: string;\nexport default val;\n",
+    );
+
+    for resolve_json_module in [true, false] {
+        let outcome = lookup_json(dir, "./data.json", resolve_json_module, false).classify();
+        let resolved = outcome.resolved_path.as_ref().unwrap_or_else(|| {
+            panic!("resolved path preserved on TS6263 (resolveJsonModule={resolve_json_module})")
+        });
+        assert!(
+            resolved.ends_with("data.d.json.ts"),
+            "resolveJsonModule={resolve_json_module}: expected resolution to the declaration \
+             companion even with the flag off, got {}",
+            resolved.display()
+        );
+        let error = outcome
+            .error
+            .as_ref()
+            .unwrap_or_else(|| panic!("expected TS6263 (resolveJsonModule={resolve_json_module})"));
+        assert_eq!(
+            error.code, 6263,
+            "resolveJsonModule={resolve_json_module}: expected TS6263, got {error:?}"
+        );
+    }
+}
+
+#[test]
+fn decl_companion_renamed_specifier_and_binder() {
+    // §25 structural-over-identifier gate: same shape, different names.
+    let fixture = TempFixture::new();
+    let dir = fixture.path();
+    fixture.write("index.ts", "import cfg from './settings.json';");
+    fixture.write("settings.json", "{}");
+    fixture.write(
+        "settings.d.json.ts",
+        "declare var payload: number;\nexport default payload;\n",
+    );
+
+    let outcome = lookup_json(dir, "./settings.json", true, true).classify();
+    assert!(outcome.is_resolved);
+    assert!(outcome.error.is_none());
+    let resolved = outcome.resolved_path.expect("resolved path");
+    assert!(resolved.ends_with("settings.d.json.ts"));
+}
+
+#[test]
+fn json_literal_wins_when_no_decl_companion_exists() {
+    // Negative control: no `.d.json.ts` sibling — the literal `.json` file
+    // resolves as before, regardless of `allowArbitraryExtensions`.
+    let fixture = TempFixture::new();
+    let dir = fixture.path();
+    fixture.write("index.ts", "import data from './plain.json';");
+    fixture.write("plain.json", "{}");
+
+    for allow_arbitrary_extensions in [true, false] {
+        let outcome = lookup_json(dir, "./plain.json", true, allow_arbitrary_extensions).classify();
+        assert!(outcome.is_resolved);
+        assert!(
+            outcome.error.is_none(),
+            "unexpected error: {:?}",
+            outcome.error
+        );
+        let resolved = outcome.resolved_path.expect("resolved path");
+        assert!(
+            resolved.ends_with("plain.json") && !resolved.to_string_lossy().contains("d.json.ts"),
+            "expected the literal JSON file, got {}",
+            resolved.display()
+        );
+    }
+}


### PR DESCRIPTION
Fixes the `declarationFileForJsonImport.ts` conformance false positive and consolidates two duplicate PRs (#17018, #17019) opened for the same bug this hour — both of which missed the same adjacent case.

## Structural rule

Verified directly against the pinned `typescript@7.0.2` oracle (not just the named conformance fixture): tsc's `tryAddingExtensions` `Extension.Json` case tries the Declaration extension (`<base>.d.json.ts`) before the Json extension (`<base>.json`) **unconditionally** — independent of both `resolveJsonModule` and `allowArbitraryExtensions`. The two flags change only the *diagnostic*, never whether resolution lands on the declaration:

| `allowArbitraryExtensions` | `resolveJsonModule` | resolves to | diagnostic |
| --- | --- | --- | --- |
| true | true or false | `.d.json.ts` | none |
| false | true or false | `.d.json.ts` | TS6263 |

Owner layer: `tsz-core` module resolver (`crates/tsz-core/src/module_resolver/`).

- `file_probing.rs`: probes the `.d.json.ts` companion unconditionally for a `.json` specifier — mirrors the existing unconditional probe used a few lines above for genuinely unknown extensions.
- `mod.rs`: `is_arbitrary_extension_declaration` excluded `"json"` from its arbitrary-extension check via a "standard extensions" short-circuit, so the existing TS6263 gate never fired for the new `.json` companion resolution. Dropping `"json"` from that list is safe — the suffix check that follows only matches when the resolved file actually ends in `.d.json.ts`, so a specifier resolving to the literal `.json` file is unaffected.

## Why this supersedes #17018 and #17019

Both open PRs fix the same bug in the same file but neither is fully correct, confirmed by building the oracle directly rather than trusting either PR's own negative control:

- **#17018** (Basanite) gates the new resolution on `allowArbitraryExtensions`. That's sufficient for the *named* conformance fixture (which sets `@allowArbitraryExtensions: true`, confirmed by fetching the real corpus source), but its own `test_json_arbitrary_ext_decl_ignored_without_allow_arbitrary_extensions` asserts the literal `.json` file wins when the flag is off — not what tsc does.
- **#17019** (mine, an earlier ClaudeT session this hour) resolves unconditionally (closer to correct) but never touches `is_arbitrary_extension_declaration`, so with the flag off it would silently resolve to the declaration with **no diagnostic at all** — also wrong.

Real tsc, confirmed with a direct oracle build (`data.json` + `data.d.json.ts` sibling, `--resolveJsonModule` both values, no `--allowArbitraryExtensions`): still resolves to the declaration, but reports **TS6263** ("was resolved to '...', but '--allowArbitraryExtensions' is not set"), identically for both `resolveJsonModule` values. This PR is the first to get all three flag combinations right, oracle-verified.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-core --lib module_resolver::tests::json_decl_companion`: 5/5 new, oracle-verified (including the TS6263 case both other PRs got wrong)
- `cargo test -p tsz-core --lib module_resolver`: 294/294 (was 289; +5 new)
- `cargo test -p tsz-core --lib` (full crate): 3316/3316
- `cargo clippy -p tsz-core --all-targets --lib --tests`: clean
- `cargo fmt --check -p tsz-core`: clean
- `python3 scripts/arch/arch_guard.py`: passed
- Direct `dist-fast` binary check against the real fixture shape (not just unit tests): exit 0 for both `resolveJsonModule` settings under `allowArbitraryExtensions`; `TS6263` with the exact tsc message when the flag is off — oracle-verified against `typescript@7.0.2`
- Full `conformance.sh` snapshot not re-run in this session (this exact fixture was already confirmed `PASS` on #17018's snapshot at a near-identical diff); the direct binary check above covers the specific behavior change

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_011yPfXFCgeLVd5XWEpWUxWJ)_