### PR TITLE
fix(resolver): TS6263 for a .json companion without --allowArbitraryExtensions

### DIFF
--- a/crates/tsz-core/src/module_resolver/mod.rs
+++ b/crates/tsz-core/src/module_resolver/mod.rs
@@ -1300,8 +1300,16 @@ fn is_arbitrary_extension_declaration(specifier: &str, resolved_path: &std::path
         None => return false,
     };
 
-    // Standard TS/JS extensions are not arbitrary
-    let standard = ["ts", "tsx", "js", "jsx", "mts", "cts", "mjs", "cjs", "json"];
+    // Standard TS/JS extensions are not arbitrary. `json` is deliberately
+    // absent: tsc still gates a `.json` specifier's `.d.json.ts` declaration
+    // companion behind `--allowArbitraryExtensions` (`tryAddingExtensions`'s
+    // `Extension.Json` case tries the Declaration extension unconditionally,
+    // but `getIsDeclarationFileName`'s arbitrary-extension diagnostic does not
+    // special-case `.json`), so the suffix check below must still be allowed
+    // to fire for it (#17020). A specifier that resolves straight to the
+    // literal `.json` file never matches the `.d.json.ts` suffix check, so
+    // this is a no-op for the common case.
+    let standard = ["ts", "tsx", "js", "jsx", "mts", "cts", "mjs", "cjs"];
     if standard.contains(&spec_ext) {
         return false;
     }

--- a/crates/tsz-core/src/module_resolver/tests.rs
+++ b/crates/tsz-core/src/module_resolver/tests.rs
@@ -15,6 +15,7 @@ mod diagnostics_ts2792;
 mod diagnostics_ts2835;
 mod explicit_root_untyped_js;
 mod importing_module_kind;
+mod json_arbitrary_ext_ts6263;
 mod lookup_classify;
 mod lookup_integration;
 mod max_node_module_js_depth;

--- a/crates/tsz-core/src/module_resolver/tests/json_arbitrary_ext_ts6263.rs
+++ b/crates/tsz-core/src/module_resolver/tests/json_arbitrary_ext_ts6263.rs
@@ -1,0 +1,179 @@
+//! TS6263 for a `.json` specifier resolved through its `.d.json.ts`
+//! declaration companion without `--allowArbitraryExtensions` (#17020).
+//!
+//! Structural rule: `#17019` made a `.json` specifier's sibling
+//! `<base>.d.json.ts` declaration companion take resolution priority over the
+//! literal `.json` file, unconditionally — matching `tsc`'s
+//! `tryAddingExtensions` `Extension.Json` case. But `tsc` still gates that
+//! resolution behind `--allowArbitraryExtensions`: when the flag is unset,
+//! `getIsDeclarationFileName`'s arbitrary-extension diagnostic (TS6263) fires
+//! at the import specifier, identically for both `resolveJsonModule` settings
+//! (verified against the pinned `typescript@7.0.2` oracle). tsz's
+//! `is_arbitrary_extension_declaration` (`mod.rs`) previously excluded
+//! `.json` from the arbitrary-extension check outright, so the resolution
+//! happened silently instead.
+
+use super::super::*;
+use super::fixtures::TempFixture;
+
+fn json_companion_fixture() -> (TempFixture, std::path::PathBuf) {
+    let fixture = TempFixture::new();
+    let dir = fixture.path().to_path_buf();
+    fixture.write("app.ts", "import data from './data.json';");
+    fixture.write("data.json", "{}");
+    fixture.write(
+        "data.d.json.ts",
+        "declare var val: string; export default val;",
+    );
+    (fixture, dir)
+}
+
+fn json_lookup_request<'a>(containing_file: &'a std::path::Path) -> ModuleLookupRequest<'a> {
+    ModuleLookupRequest {
+        specifier: "./data.json",
+        containing_file,
+        specifier_span: Span::new(19, 32),
+        import_kind: ImportKind::EsmImport,
+        resolution_mode_override: None,
+        no_implicit_any: false,
+        implied_classic_resolution: false,
+    }
+}
+
+/// `resolveJsonModule: true`, no `allowArbitraryExtensions`: `tsc` still
+/// resolves through the `.d.json.ts` companion and reports TS6263.
+#[test]
+fn ts6263_fires_for_json_companion_without_allow_arbitrary_extensions_resolve_json_true() {
+    let (_fixture, dir) = json_companion_fixture();
+    let containing = dir.join("app.ts");
+    let mut resolver = ModuleResolver::new(&ResolvedCompilerOptions {
+        resolve_json_module: true,
+        allow_arbitrary_extensions: false,
+        ..Default::default()
+    });
+    let request = json_lookup_request(&containing);
+    let result = resolver.lookup(&request, |_, _| None, |_| false, None);
+
+    assert_eq!(
+        result.resolved_path,
+        Some(dir.join("data.d.json.ts")),
+        "resolved path should still be the declaration companion"
+    );
+    let error = result
+        .error
+        .expect("expected TS6263 when allowArbitraryExtensions is unset");
+    assert_eq!(
+        error.code, MODULE_WAS_RESOLVED_TO_BUT_ALLOW_ARBITRARY_EXTENSIONS_IS_NOT_SET,
+        "expected TS6263, got {error:?}"
+    );
+}
+
+/// Same fixture with `resolveJsonModule: false` — `tsc` reports TS6263
+/// identically regardless of `resolveJsonModule`, since the `.d.json.ts`
+/// companion resolution does not consult that flag at all.
+#[test]
+fn ts6263_fires_for_json_companion_without_allow_arbitrary_extensions_resolve_json_false() {
+    let (_fixture, dir) = json_companion_fixture();
+    let containing = dir.join("app.ts");
+    let mut resolver = ModuleResolver::new(&ResolvedCompilerOptions {
+        resolve_json_module: false,
+        allow_arbitrary_extensions: false,
+        ..Default::default()
+    });
+    let request = json_lookup_request(&containing);
+    let result = resolver.lookup(&request, |_, _| None, |_| false, None);
+
+    let error = result
+        .error
+        .expect("expected TS6263 when allowArbitraryExtensions is unset");
+    assert_eq!(
+        error.code,
+        MODULE_WAS_RESOLVED_TO_BUT_ALLOW_ARBITRARY_EXTENSIONS_IS_NOT_SET
+    );
+}
+
+/// Control from #17020: with `allowArbitraryExtensions: true`, resolution is
+/// clean — no TS6263.
+#[test]
+fn no_ts6263_for_json_companion_with_allow_arbitrary_extensions() {
+    let (_fixture, dir) = json_companion_fixture();
+    let containing = dir.join("app.ts");
+    let mut resolver = ModuleResolver::new(&ResolvedCompilerOptions {
+        resolve_json_module: true,
+        allow_arbitrary_extensions: true,
+        ..Default::default()
+    });
+    let request = json_lookup_request(&containing);
+    let result = resolver.lookup(&request, |_, _| None, |_| false, None);
+
+    assert_eq!(result.resolved_path, Some(dir.join("data.d.json.ts")));
+    assert!(
+        result.error.is_none(),
+        "expected clean resolution with allowArbitraryExtensions set, got {:?}",
+        result.error
+    );
+}
+
+/// Control from #17020: without a `.d.json.ts` companion at all, both
+/// compilers agree exactly regardless of `allowArbitraryExtensions` — the
+/// literal `.json` file resolves and TS6263 must not fire.
+#[test]
+fn no_ts6263_for_plain_json_without_companion() {
+    let fixture = TempFixture::new();
+    let dir = fixture.path().to_path_buf();
+    fixture.write("app.ts", "import data from './data.json';");
+    fixture.write("data.json", "{}");
+    let containing = dir.join("app.ts");
+
+    let mut resolver = ModuleResolver::new(&ResolvedCompilerOptions {
+        resolve_json_module: true,
+        allow_arbitrary_extensions: false,
+        ..Default::default()
+    });
+    let request = json_lookup_request(&containing);
+    let result = resolver.lookup(&request, |_, _| None, |_| false, None);
+
+    assert_eq!(result.resolved_path, Some(dir.join("data.json")));
+    assert!(
+        result.error.is_none(),
+        "plain .json resolution (no companion) must not report TS6263, got {:?}",
+        result.error
+    );
+}
+
+/// Renamed-binder variant: the gate is keyed on the `.d.json.ts` shape, not
+/// on `data`/`val` specifically.
+#[test]
+fn ts6263_fires_for_renamed_json_companion() {
+    let fixture = TempFixture::new();
+    let dir = fixture.path().to_path_buf();
+    fixture.write("app.ts", "import cfg from './settings.json';");
+    fixture.write("settings.json", "{}");
+    fixture.write(
+        "settings.d.json.ts",
+        "declare var payload: number; export default payload;",
+    );
+    let containing = dir.join("app.ts");
+
+    let mut resolver = ModuleResolver::new(&ResolvedCompilerOptions {
+        resolve_json_module: true,
+        allow_arbitrary_extensions: false,
+        ..Default::default()
+    });
+    let request = ModuleLookupRequest {
+        specifier: "./settings.json",
+        containing_file: &containing,
+        specifier_span: Span::new(18, 34),
+        import_kind: ImportKind::EsmImport,
+        resolution_mode_override: None,
+        no_implicit_any: false,
+        implied_classic_resolution: false,
+    };
+    let result = resolver.lookup(&request, |_, _| None, |_| false, None);
+
+    let error = result.error.expect("expected TS6263 for renamed companion");
+    assert_eq!(
+        error.code,
+        MODULE_WAS_RESOLVED_TO_BUT_ALLOW_ARBITRARY_EXTENSIONS_IS_NOT_SET
+    );
+}


### PR DESCRIPTION
Fixes #17020.

## Goal
Goal: hold

## Structural rule

When a `.json` specifier resolves through a sibling `.d.json.ts` arbitrary-extension declaration companion (the priority `#17019` added, matching tsc's `tryAddingExtensions` `Extension.Json` case), tsc still gates that resolution behind `--allowArbitraryExtensions` and reports **TS6263** at the import specifier when the flag is unset — identically for both `resolveJsonModule` settings. tsz does this through `crates/tsz-core/src/module_resolver/mod.rs`'s `is_arbitrary_extension_declaration`, which is consulted by `ModuleResolver::lookup`'s existing TS6263 gate.

`#17019` (merged as `cad6663`) made the companion resolution itself correct but left this gate unfixed: `is_arbitrary_extension_declaration`'s `standard` extension list explicitly excluded `.json`, so the function always returned `false` for a `.json` specifier before ever reaching the `.d.<ext>.ts` suffix check — the gate could structurally never fire for `.json`. The regression moved the row from *wrong diagnostic* (pre-#17019: TS2322, companion ignored) to *no diagnostic* (post-#17019: silent, companion used unconditionally), which is the worse direction — tsz now silently accepts a program tsc rejects.

## Fix

Remove `"json"` from the `standard` array in `is_arbitrary_extension_declaration`. The function's suffix check (`resolved_name.ends_with(".d.json.ts")`) already correctly distinguishes "resolved straight to the literal `.json` file" (no match, gate stays silent) from "resolved through the `.d.json.ts` companion" (match, TS6263 fires when the flag is unset) — the `standard` list was the only thing preventing that check from ever running for `.json`. No change needed to the resolution priority `#17019` added; only the diagnostic gate.

## Adjacent-case matrix (5 new unit tests, `crates/tsz-core/src/module_resolver/tests/json_arbitrary_ext_ts6263.rs`)

| case | expected |
| --- | --- |
| `.d.json.ts` companion present, `allowArbitraryExtensions` unset, `resolveJsonModule: true` | TS6263 |
| same, `resolveJsonModule: false` | TS6263 (flag-independent, matching tsc) |
| same, `allowArbitraryExtensions: true` | clean (control from #17020) |
| no `.d.json.ts` companion at all | clean, resolves the literal `.json` file (control from #17020) |
| renamed specifier/companion (`settings.json`/`settings.d.json.ts`) | TS6263 (structural, not name-keyed) |

Verified end-to-end against the exact repro from #17020 with a `dist-fast` CLI build:
```
$ tsz --project tsconfig.json   # resolveJsonModule: true, allowArbitraryExtensions unset
app.ts(1,18): error TS6263: Module './data.json' was resolved to 'data.d.json.ts', but '--allowArbitraryExtensions' is not set.

$ tsz --project tsconfig2.json  # same fixture, allowArbitraryExtensions: true
# exit 0, no diagnostics
```

No corpus fixture in the current TypeScript conformance suite exercises this exact combination (per #17020's own investigation), so no conformance count movement is expected; not re-run given the narrow, single-function change and full unit + end-to-end verification above.

## Verification
- `cargo test -p tsz-core --lib json_arbitrary_ext_ts6263`: 5/5 new tests pass.
- `cargo test -p tsz-core --lib module_resolver`: 297/297 pass, no regressions.
- `cargo test -p tsz-core --lib` (full crate): 3318/3319 pass; the 1 failure (`isolated_test_runner::tests::test_isolated_runner_timeout`) is a pre-existing, unrelated timing-sensitive test — reproduces green in isolation, confirmed not caused by this change.
- `cargo clippy -p tsz-core --all-targets -- -D warnings`: clean.
- `cargo fmt --check -p tsz-core`: clean.
- Manual end-to-end CLI check against a `dist-fast` build (both `allowArbitraryExtensions` settings) — see above.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude


---
_Generated by [Claude Code](https://claude.ai/code/session_01BpuY9QMheZ66jrWSuCUcVj)_