### PR TITLE
test(resolver): guard TS6263 across the arbitrary-extension declaration family and the declaration-importer exemption

### DIFF
--- a/crates/tsz-core/src/module_resolver/tests.rs
+++ b/crates/tsz-core/src/module_resolver/tests.rs
@@ -7,6 +7,7 @@
 
 mod fixtures;
 
+mod arbitrary_extension_ts6263_family;
 mod cache_statistics;
 mod canonical_entry_path;
 mod conditional_types_flavor;

--- a/crates/tsz-core/src/module_resolver/tests/arbitrary_extension_ts6263_family.rs
+++ b/crates/tsz-core/src/module_resolver/tests/arbitrary_extension_ts6263_family.rs
@@ -1,0 +1,250 @@
+//! TS6263 for the *general* arbitrary-extension declaration family at
+//! `ModuleResolver::lookup()`.
+//!
+//! Complements `json_decl_companion` (#17021), which exhaustively covers the
+//! `.json` companion matrix. This module guards the branches that the json
+//! fix shares but that no `lookup()`-level test exercised:
+//!
+//! 1. The non-`json` family (`.css`/`.html`/`.svelte`/`.node`, ...): a
+//!    genuinely-unknown extension resolves to its `<base>.d.<ext>.ts` companion
+//!    and reports TS6263 when `--allowArbitraryExtensions` is off, clean when
+//!    on. The existing `arbitrary_ext_decl_module_resolution_tests` cover this
+//!    family only through the checker's in-memory path, which emits no
+//!    resolution diagnostics — so the driver-owned gate
+//!    (`is_arbitrary_extension_declaration` + the `lookup` emit site) had no
+//!    guard. `.json` and this family share that predicate, so a broad
+//!    short-circuit re-silencing one would silence the other; these catch it.
+//!
+//! 2. The declaration-file-importer exemption: tsc does not report TS6263 when
+//!    the importer is itself a declaration file (`.d.ts`/`.d.mts`/`.d.cts`) —
+//!    those already live in the type-declaration layer. Unguarded before now,
+//!    for both the family and `.json`.
+//!
+//! 3. A multi-dot base (`data.config.json` -> `data.config.d.json.ts`): the
+//!    `with_extension` companion shape and the `ends_with(".d.<ext>.ts")`
+//!    predicate must agree on a specifier whose base already contains a dot.
+//!
+//! Structural rule (shared with #17021): resolution lands on the declaration
+//! companion regardless of the flag; the flag only toggles the diagnostic. The
+//! resolved path is always preserved so the imported type still binds.
+
+use super::super::*;
+use super::fixtures::TempFixture;
+
+const TS6263: u32 = MODULE_WAS_RESOLVED_TO_BUT_ALLOW_ARBITRARY_EXTENSIONS_IS_NOT_SET;
+
+/// One arbitrary-extension family member: the user-written specifier and the
+/// `<base>.d.<ext>.ts` companion file it resolves through.
+struct FamilyCase {
+    specifier: &'static str,
+    companion: &'static str,
+}
+
+const FAMILY: &[FamilyCase] = &[
+    FamilyCase {
+        specifier: "./style.css",
+        companion: "style.d.css.ts",
+    },
+    FamilyCase {
+        specifier: "./component.html",
+        companion: "component.d.html.ts",
+    },
+    FamilyCase {
+        specifier: "./Widget.svelte",
+        companion: "Widget.d.svelte.ts",
+    },
+    FamilyCase {
+        specifier: "./addon.node",
+        companion: "addon.d.node.ts",
+    },
+];
+
+fn lookup_outcome(
+    fixture: &TempFixture,
+    importer: &str,
+    specifier: &str,
+    allow_arbitrary_extensions: bool,
+) -> ModuleLookupOutcome {
+    let options = ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Node),
+        allow_arbitrary_extensions,
+        module_suffixes: vec![String::new()],
+        ..Default::default()
+    };
+    let mut resolver = ModuleResolver::new(&options);
+    let importer_path = fixture.join(importer);
+    let request = ModuleLookupRequest {
+        specifier,
+        containing_file: &importer_path,
+        specifier_span: Span::new(0, specifier.len() as u32),
+        import_kind: ImportKind::EsmImport,
+        resolution_mode_override: None,
+        no_implicit_any: false,
+        implied_classic_resolution: false,
+    };
+    resolver
+        .lookup(&request, |_, _| None, |_| false, None)
+        .classify()
+}
+
+/// Flag off: every family member resolves to its declaration companion and
+/// reports TS6263, with the resolved path preserved (the diagnostic is
+/// additive). The message names the companion and the flag.
+#[test]
+fn family_reports_ts6263_when_flag_off_across_extensions() {
+    for case in FAMILY {
+        let fixture = TempFixture::new();
+        fixture.write("main.ts", &format!("import x from '{}';", case.specifier));
+        fixture.write(
+            case.companion,
+            "declare const x: number;\nexport default x;\n",
+        );
+
+        let outcome = lookup_outcome(&fixture, "main.ts", case.specifier, false);
+
+        let resolved = outcome
+            .resolved_path
+            .as_ref()
+            .unwrap_or_else(|| panic!("{}: resolved path preserved on TS6263", case.specifier));
+        assert!(
+            resolved.ends_with(case.companion),
+            "{}: expected resolution to {}, got {}",
+            case.specifier,
+            case.companion,
+            resolved.display()
+        );
+        let error = outcome
+            .error
+            .as_ref()
+            .unwrap_or_else(|| panic!("{}: expected TS6263 when flag off", case.specifier));
+        assert_eq!(
+            error.code, TS6263,
+            "{}: expected TS6263, got {error:?}",
+            case.specifier
+        );
+        assert!(
+            error.message.contains(case.companion)
+                && error.message.contains("allowArbitraryExtensions"),
+            "{}: message names companion and flag: {}",
+            case.specifier,
+            error.message
+        );
+    }
+}
+
+/// Flag on: the same resolutions are silent.
+#[test]
+fn family_is_clean_when_flag_on_across_extensions() {
+    for case in FAMILY {
+        let fixture = TempFixture::new();
+        fixture.write("main.ts", &format!("import x from '{}';", case.specifier));
+        fixture.write(
+            case.companion,
+            "declare const x: number;\nexport default x;\n",
+        );
+
+        let outcome = lookup_outcome(&fixture, "main.ts", case.specifier, true);
+
+        assert!(
+            outcome.error.is_none(),
+            "{}: flag on must be clean, got {:?}",
+            case.specifier,
+            outcome.error
+        );
+        let resolved = outcome
+            .resolved_path
+            .as_ref()
+            .unwrap_or_else(|| panic!("{}: resolved path", case.specifier));
+        assert!(
+            resolved.ends_with(case.companion),
+            "{}: expected resolution to {}",
+            case.specifier,
+            case.companion
+        );
+    }
+}
+
+/// Declaration-file importers are exempt from TS6263 (they already live in the
+/// type layer), for both the family and `.json`. Covers `.d.ts`, `.d.mts`, and
+/// `.d.cts` importers, and asserts resolution still lands on the companion.
+#[test]
+fn declaration_file_importer_is_exempt_from_ts6263() {
+    let importers = ["host.d.ts", "host.d.mts", "host.d.cts"];
+    for importer in importers {
+        // Family member (.css).
+        let fixture = TempFixture::new();
+        fixture.write(importer, "import s from './style.css';");
+        fixture.write(
+            "style.d.css.ts",
+            "declare const s: number;\nexport default s;\n",
+        );
+        let outcome = lookup_outcome(&fixture, importer, "./style.css", false);
+        assert!(
+            outcome.error.is_none(),
+            "importer {importer}: .css companion is exempt from TS6263, got {:?}",
+            outcome.error
+        );
+        assert!(
+            outcome
+                .resolved_path
+                .as_ref()
+                .is_some_and(|p| p.ends_with("style.d.css.ts")),
+            "importer {importer}: resolution still lands on the .css companion"
+        );
+
+        // `.json` companion, same exemption.
+        let fixture = TempFixture::new();
+        fixture.write(importer, "import d from './data.json';");
+        fixture.write("data.json", "{}");
+        fixture.write(
+            "data.d.json.ts",
+            "declare const d: number;\nexport default d;\n",
+        );
+        let outcome = lookup_outcome(&fixture, importer, "./data.json", false);
+        assert!(
+            outcome.error.is_none(),
+            "importer {importer}: .json companion is exempt from TS6263, got {:?}",
+            outcome.error
+        );
+        assert!(
+            outcome
+                .resolved_path
+                .as_ref()
+                .is_some_and(|p| p.ends_with("data.d.json.ts")),
+            "importer {importer}: resolution still lands on the .json companion"
+        );
+    }
+}
+
+/// A specifier whose base already contains a dot (`data.config.json`) must
+/// still match its `data.config.d.json.ts` companion — the `with_extension`
+/// companion shape and the `ends_with(".d.json.ts")` predicate have to agree
+/// on a multi-dot base.
+#[test]
+fn multi_dot_json_base_reports_ts6263_when_flag_off() {
+    let fixture = TempFixture::new();
+    fixture.write("main.ts", "import d from './data.config.json';");
+    fixture.write("data.config.json", "{}");
+    fixture.write(
+        "data.config.d.json.ts",
+        "declare const d: number;\nexport default d;\n",
+    );
+
+    let outcome = lookup_outcome(&fixture, "main.ts", "./data.config.json", false);
+
+    let resolved = outcome
+        .resolved_path
+        .as_ref()
+        .expect("resolved path preserved on TS6263");
+    assert!(
+        resolved.ends_with("data.config.d.json.ts"),
+        "expected the multi-dot companion, got {}",
+        resolved.display()
+    );
+    assert_eq!(
+        outcome.error.as_ref().map(|e| e.code),
+        Some(TS6263),
+        "multi-dot json base must report TS6263 when flag off: {:?}",
+        outcome.error
+    );
+}


### PR DESCRIPTION
## Context

`#17020` (missing TS6263 when a `.json` specifier resolves through its
`.d.json.ts` companion without `--allowArbitraryExtensions`) was fixed and
merged concurrently by **#17021**, which dropped `json` from
`is_arbitrary_extension_declaration`'s short-circuit and added an exhaustive
`.json` matrix (`json_decl_companion`). This PR does **not** re-do that fix — it
adds the complementary `lookup()`-level regression guards for the branches that
fix shares but that no lookup-level test exercised. #17021's own body notes that
the two prior PRs (#17018, #17019) "missed the same adjacent case" on this path;
these guards pin the adjacencies so the next churn can't silently re-open them.

Structural rule (shared with #17021, verified against the pinned
`typescript@7.0.2` oracle): a specifier resolves to its `{base}.d.{ext}.ts`
declaration companion regardless of `--allowArbitraryExtensions`; the flag only
toggles the diagnostic — TS6263 when off, silent when on — and the resolved
path is always preserved so the imported type still binds. A declaration-file
importer is exempt.

## What this adds (test-only; no behavior change)

New `module_resolver::tests::arbitrary_extension_ts6263_family` (4 tests),
complementary to #17021's json-only `json_decl_companion`:

- **Non-json family** (`.css` / `.html` / `.svelte` / `.node`, parametrized):
  TS6263 when the flag is off (path preserved, message names the companion and
  the flag); clean when on. The existing `arbitrary_ext_decl_module_resolution_tests`
  cover this family only through the checker's in-memory path, which emits no
  resolution diagnostics — so the driver-owned gate
  (`is_arbitrary_extension_declaration` + the `lookup` emit site) had **no**
  guard. json and this family share that predicate, so a broad short-circuit
  re-silencing one would silence the other.
- **Declaration-file-importer exemption**: `.d.ts` / `.d.mts` / `.d.cts`
  importers are exempt from TS6263, for both the family and `.json` — previously
  unguarded; asserts resolution still lands on the companion.
- **Multi-dot base** (`data.config.json` → `data.config.d.json.ts`): the
  `with_extension` companion shape and the `ends_with(".d.{ext}.ts")` predicate
  must agree on a base that already contains a dot.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-core --lib arbitrary_extension_ts6263_family` — **4/4 pass**
  (asserts current main behavior, which matches the typescript@7.0.2 oracle rule
  #17021 established).
- Pre-commit gate (clippy + `arch-size`) — the per-merge CI lane — run on the
  committed change.
- Test-only: cannot change any diagnostic outcome; conformance/emit/fourslash
  unaffected by construction.

## Provenance
Machine: cloud
Assistant: claude-code
Model: Opus 4.8
Effort: high