### PR TITLE
fix(solver): infer nested generic call type param from baked contextual return (#17005)

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -649,6 +649,8 @@ mod narrowed_union_source_display_tests;
 mod narrowing_union_source_display_tests;
 #[path = "tests/nested_function_async_context_scope_tests.rs"]
 mod nested_function_async_context_scope_tests;
+#[path = "tests/nested_generic_call_return_context_baked_tests.rs"]
+mod nested_generic_call_return_context_baked_tests;
 #[path = "tests/nested_tuple_literal_source_display_tests.rs"]
 mod nested_tuple_literal_source_display_tests;
 #[path = "tests/nested_type_parameter_target_elaboration_tests.rs"]

--- a/crates/tsz-checker/src/tests/nested_generic_call_return_context_baked_tests.rs
+++ b/crates/tsz-checker/src/tests/nested_generic_call_return_context_baked_tests.rs
@@ -1,0 +1,155 @@
+//! Regression tests for return-context inference through a nested generic call
+//! whose contextual return type has been baked into a structural object.
+//!
+//! Structural rule: when an inner generic call `f(cb)` sits in call-argument
+//! position and its result feeds an outer parameter of type `G<Concrete>`, the
+//! inner call's type parameter must be inferred from that contextual return
+//! type — `G<Param>` matched against `G<Concrete>` binds `Param := Concrete` —
+//! *before* the deferred callback `cb` is contextually typed. `tsc` does this in
+//! `inferTypeArguments` (return-type context, `InferencePriority.ReturnType`).
+//!
+//! tsz's solver-side return-context walk only decomposed a contextual type that
+//! was still interned as a `TypeData::Application`. A nominal `G<Concrete>`
+//! reaches the walk *baked* into a structural object (`{ ... }`) with no
+//! `Application` shape, so the walk bound nothing and the inner type parameter
+//! fell back to its declared constraint. The callback parameter was then typed
+//! from the constraint (`{}`), producing a spurious `TS2345` — issue #17005,
+//! the regression exposed by #17000. The fix recovers the baked object's
+//! originating `Application` through its display-alias back-reference, matching
+//! the checker-side `return_context_application_info` helper.
+//!
+//! Binder names vary across cases (`Params`/`received`, `V`/`x`, `A`/`B`) so no
+//! test pins the behavior to a specific identifier.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn ts2345<'a>(
+    diags: &'a [crate::diagnostics::Diagnostic],
+) -> Vec<&'a crate::diagnostics::Diagnostic> {
+    diags
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2345)
+        .collect()
+}
+
+#[test]
+fn variadic_tuple_callback_param_infers_from_baked_contextual_class_return() {
+    // The exact #17005 shape: a variadic-tuple constraint, a rest-parameter
+    // callback, and a nominal generic class result consumed by an outer call.
+    // `Params` must be inferred as `[string, boolean]` from `Wrapper<[string,
+    // boolean]>`, so `head` types as `string` and `head.length` is valid.
+    let diags = check_source_diagnostics(
+        r#"
+type Item = {};
+type Args = [Item, ...Item[]];
+type Handler<Params extends Args> = (...received: Params) => void;
+declare class Wrapper<Params extends Args> { data: Params; }
+declare function build<Params extends Args>(h: Handler<Params>): Wrapper<Params>;
+declare function apply(w: Wrapper<[string, boolean]>): void;
+
+apply(build(head => console.log(head.length)));
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "expected no diagnostics, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.as_str()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn single_type_param_interface_wrapper_infers_callback_param_from_return_context() {
+    // Interface heritage instead of a class, a single type parameter, and a
+    // one-arg callback. `V := string` from `Cell<string>`, so `s.length` holds.
+    let diags = check_source_diagnostics(
+        r#"
+interface Cell<V> { current: V; }
+declare function cellOf<V>(f: (x: V) => void): Cell<V>;
+declare function readCell(c: Cell<string>): void;
+
+readCell(cellOf(s => s.length));
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "expected no diagnostics, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.as_str()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn two_type_params_infer_first_from_return_context_second_from_callback_body() {
+    // `pair<A, B>(f: (a: A) => B): Pair<A, B>`; `A := string` from the
+    // contextual `Pair<string, number>` types `x`, and `B := number` follows
+    // from the body — both flow without a spurious mismatch.
+    let diags = check_source_diagnostics(
+        r#"
+interface Pair<A, B> { a: A; b: B; }
+declare function pair<A, B>(f: (a: A) => B): Pair<A, B>;
+declare function usePair(p: Pair<string, number>): void;
+
+usePair(pair(x => x.length));
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "expected no diagnostics, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.as_str()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn genuinely_incompatible_callback_body_still_reports_ts2345_family() {
+    // Negative guard: the return context now pins the callback parameter to a
+    // *concrete* type, so a body that misuses it must still be rejected. `n`
+    // types as `number` (from `Cell<number>`); `n.length` has no such property.
+    // Before the fix the constraint fallback masked this as a silent success.
+    let diags = check_source_diagnostics(
+        r#"
+interface Cell<V> { current: V; }
+declare function cellOf<V>(f: (x: V) => void): Cell<V>;
+declare function readNum(c: Cell<number>): void;
+
+readNum(cellOf(n => n.length));
+"#,
+    );
+    assert!(
+        !diags.is_empty(),
+        "expected a diagnostic for `n.length` on a number callback parameter"
+    );
+}
+
+#[test]
+fn baked_contextual_return_does_not_leak_when_outer_argument_is_concrete() {
+    // A concrete sibling still owns the parameter: when the outer call supplies
+    // the concrete wrapper directly (no callback deferral), the return context
+    // must neither spuriously error nor be needed. Keeps the fix confined to the
+    // deferred-callback path.
+    let diags = check_source_diagnostics(
+        r#"
+interface Cell<V> { current: V; }
+declare function identity<V>(c: Cell<V>): Cell<V>;
+declare function readCell(c: Cell<string>): void;
+declare const cell: Cell<string>;
+
+readCell(identity(cell));
+"#,
+    );
+    assert!(
+        ts2345(&diags).is_empty(),
+        "expected no TS2345, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.as_str()))
+            .collect::<Vec<_>>()
+    );
+}

--- a/crates/tsz-checker/src/tests/nested_generic_call_return_context_baked_tests.rs
+++ b/crates/tsz-checker/src/tests/nested_generic_call_return_context_baked_tests.rs
@@ -23,9 +23,7 @@
 
 use crate::test_utils::check_source_diagnostics;
 
-fn ts2345<'a>(
-    diags: &'a [crate::diagnostics::Diagnostic],
-) -> Vec<&'a crate::diagnostics::Diagnostic> {
+fn ts2345(diags: &[crate::diagnostics::Diagnostic]) -> Vec<&crate::diagnostics::Diagnostic> {
     diags
         .iter()
         .filter(|diagnostic| diagnostic.code == 2345)

--- a/crates/tsz-solver/src/operations/generic_call/return_context.rs
+++ b/crates/tsz-solver/src/operations/generic_call/return_context.rs
@@ -440,6 +440,54 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         resolver.defs_are_equivalent(source_def, target_def)
     }
 
+    /// Recover the canonical `Application(base, args)` for a type used during
+    /// return-context inference.
+    ///
+    /// A contextual return type such as `GenericClass<[string, boolean]>` can
+    /// exist in the interner in two shapes: the as-written
+    /// `Application(GenericClass, [[string, boolean]])` and the *baked*
+    /// (already-evaluated) structural object that merely displays as
+    /// `GenericClass<[string, boolean]>`. The baked form has no
+    /// `TypeData::Application`, so the application-aware matchers cannot
+    /// decompose it and any tracked type parameter on the source side is left
+    /// unbound — the inner generic call's own type parameter then falls back to
+    /// its declared constraint (e.g. `T := {}`), spuriously rejecting a
+    /// deferred callback argument.
+    ///
+    /// The evaluator records a display-alias back-reference from the baked form
+    /// to its originating application, so consult it (and, as a last resort, a
+    /// fresh evaluation) to restore the structural decomposition through the
+    /// validated `Application`↔`Application` path instead of relying on rendered
+    /// type text. This mirrors the checker-side
+    /// `return_context_application_info` so both return-context implementations
+    /// decompose the same baked contextual shapes.
+    fn return_context_application_info(
+        &mut self,
+        type_id: TypeId,
+    ) -> Option<(TypeId, Vec<TypeId>)> {
+        if let Some(info) = self.app_info_or_alias(type_id) {
+            return Some(info);
+        }
+        let evaluated = self.evaluate_return_context_match_type(type_id);
+        if evaluated == type_id {
+            return None;
+        }
+        self.app_info_or_alias(evaluated)
+    }
+
+    /// The non-evaluating half of `return_context_application_info`: take the
+    /// application form directly, else through a single display-alias hop. A
+    /// caller that already holds the evaluated form pairs a raw call with an
+    /// `app_info_or_alias(eval)` call to skip the redundant re-evaluation.
+    fn app_info_or_alias(&self, type_id: TypeId) -> Option<(TypeId, Vec<TypeId>)> {
+        let db = self.interner.as_type_database();
+        crate::type_queries::get_application_info(db, type_id).or_else(|| {
+            self.interner
+                .get_display_alias(type_id)
+                .and_then(|alias| crate::type_queries::get_application_info(db, alias))
+        })
+    }
+
     /// Match direct, same-base return applications before any structural
     /// expansion can expose foreign type parameters from nested members.
     ///
@@ -456,14 +504,10 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         substitution: &mut TypeSubstitution,
         visited: &mut FxHashSet<(TypeId, TypeId)>,
     ) -> bool {
-        let Some((source_base, source_args)) =
-            crate::type_queries::get_application_info(self.interner.as_type_database(), source)
-        else {
+        let Some((source_base, source_args)) = self.return_context_application_info(source) else {
             return false;
         };
-        let Some((target_base, target_args)) =
-            crate::type_queries::get_application_info(self.interner.as_type_database(), target)
-        else {
+        let Some((target_base, target_args)) = self.return_context_application_info(target) else {
             return false;
         };
         if source_args.len() != target_args.len()
@@ -982,7 +1026,19 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 ),
             ) {
                 (Some(source_app), Some(target_app)) => Some((source_app, target_app)),
-                _ => None,
+                // Last resort: recover a baked structural object's originating
+                // `Application` through its display-alias back-reference, so a
+                // contextual return type that has been evaluated away from its
+                // `Application` form still decomposes arg-by-arg. Reuse the
+                // already-computed `source_eval`/`target_eval` rather than
+                // re-evaluating; only the display-alias hop is genuinely new here.
+                _ => self
+                    .app_info_or_alias(source)
+                    .or_else(|| self.app_info_or_alias(source_eval))
+                    .zip(
+                        self.app_info_or_alias(target)
+                            .or_else(|| self.app_info_or_alias(target_eval)),
+                    ),
             },
         };
 
@@ -1179,10 +1235,13 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             return;
         }
 
-        // Application matching (same base, same arg count)
+        // Application matching (same base, same arg count). Recover a baked
+        // structural target through its display-alias back-reference so a
+        // nested generic-signature position whose contextual type has been
+        // evaluated away from its `Application` form still decomposes.
         if let (Some((source_base, source_args)), Some((target_base, target_args))) = (
-            crate::type_queries::get_application_info(self.interner.as_type_database(), source),
-            crate::type_queries::get_application_info(self.interner.as_type_database(), target),
+            self.app_info_or_alias(source),
+            self.app_info_or_alias(target),
         ) && source_base == target_base
             && source_args.len() == target_args.len()
         {


### PR DESCRIPTION
Fixes #17005. (GitHub strips angle-bracket generics from prose, so this body uses `G[Param]` for a generic application `G` of `Param`; the exact TypeScript repro is in the issue.)

**Structural rule.** When an untyped callback is passed to a generic call `f(cb)` that sits in **call-argument position**, and `f`'s result feeds an outer parameter of type `G[Concrete]`, `tsc` infers `f`'s type parameter from that contextual **return** type first — the return `G[Param]` matched against the contextual `G[Concrete]` binds `Param := Concrete` (`inferTypeArguments`, `InferencePriority.ReturnType`) — and only then contextually types the deferred callback `cb`.

Concretely (issue shape): `createClass` is `<T extends MyTuple>(f: GenericFunction[T]) => GenericClass[T]`, its result is passed to `consumeClass(c: GenericClass[[string, boolean]])`, and the argument is `str => console.log(str.length)`. `tsc` binds `T := [string, boolean]`, so `str: string` and the call is clean.

tsz's **solver-side** return-context walk (`operations/generic_call/return_context.rs`) only decomposed a contextual type that was still interned as a `TypeData::Application`. A nominal `GenericClass[[string, boolean]]` reaches the walk **baked** into a structural object (`ObjectWithIndex`/`Object`) with no `Application` shape, so the walk bound nothing and `T` fell back to its declared constraint `MyTuple` (making the parameter `{}`). The callback parameter was then typed from `{}`, producing a spurious `TS2345` — the regression #17000 exposed. (The checker-side walk already recovered this shape, which is why the arrow was partially typed but the solver-owned result inference was not.)

**Owner layer** — `crates/tsz-solver/src/operations/generic_call/return_context.rs`:

- Add `return_context_application_info` (and its non-evaluating half `app_info_or_alias`): recover a baked structural object's originating `Application` through the evaluator's **display-alias back-reference** (then a fresh evaluation as last resort), returning the decomposed `(base, args)`. This mirrors the checker-side `return_context_application_info` so both return-context implementations decompose the same baked contextual shapes — no rendered type-text matching.
- Wire it into **every** application-matching site in the walk: the aligned same-base path (`collect_aligned_return_application_substitution`), the app-info fallback in `collect_return_context_substitution` (reusing the already-computed `source_eval` / `target_eval`, so no redundant re-evaluation), and the nested generic-target matcher (`collect_return_context_for_generic_target`).

Single-`Application` contextual types are unaffected — the raw lookup still short-circuits first, so only baked-object contextuals change behavior. The fix also restores a **false negative**: a callback body that misuses the now concrete-typed parameter (`n => n.length` where `n: number`) is correctly rejected again, where the constraint fallback had silently accepted it.

No user-name/file-name literals and no formatted-message predicates: decisions use the structural `get_application_info` / `get_display_alias` primitives. The five new regression tests vary binder names (`Params` / `received`, `V` / `x`, `A` / `B`) and cover class and interface heritage, single and multiple type params, the negative body-misuse case, and the concrete-argument non-leak case.

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-solver --lib` — 7658 passed, 0 failed (after the change).
- `cargo nextest run -p tsz-checker --lib` — 10922 passed, 0 failed; includes the 5 new `nested_generic_call_return_context_baked_tests`.
- `cargo clippy --profile dist-fast -p tsz-solver --lib` — clean (the per-merge CI lint lane).
- `scripts/arch/arch_guard_file_limits.py` — pass (`return_context.rs` at 1966/2000 lines; the per-merge arch-size lane).
- CLI repro (issue shape): clean before/after — 2 → 0 spurious `TS2345`, and the genuine-mismatch negative now reports again.
- Emit parity: not applicable — this is a diagnostic-inference change and does not touch JS/DTS output.
- Conformance: the pinned corpus (`lambdaParameterWithTupleArgsHasCorrectAssignability.ts`, `parenthesizedContexualTyping3.ts`) is covered by CI's nightly conformance lane; the `TypeScript/` submodule is intentionally not materialized in this environment.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high