### PR TITLE
fix(cli): TS8020 joins the #16279 parser-grammar self-suppression list

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1657,5 +1657,9 @@ mod meta_property_grammar_tests;
 mod jsx_comma_operator_grammar_tests;
 
 #[cfg(test)]
+#[path = "check_utils/jsdoc_star_type_grammar_tests.rs"]
+mod jsdoc_star_type_grammar_tests;
+
+#[cfg(test)]
 #[path = "check_utils/private_identifier_parse_error_suppression_tests.rs"]
 mod private_identifier_parse_error_suppression_tests;

--- a/crates/tsz-cli/src/driver/check_utils/jsdoc_star_type_grammar_tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/jsdoc_star_type_grammar_tests.rs
@@ -1,0 +1,148 @@
+//! Unit tests for the `TS8020` slice of `is_parser_grammar_code`
+//! (#16279's general shape, audit round 11).
+//!
+//! tsc's checker reports `TS8020` ("JSDoc types can only be used inside
+//! documentation comments.") via `grammarErrorOnNode` for a bare `*` (JSDoc
+//! "any type" syntax) used in an ordinary type position. tsz emits it
+//! directly from the parser (`crates/tsz-parser/src/parser/state_types.rs`,
+//! `state_types_jsx.rs`) and has no checker-side counterpart, so there is no
+//! double-emission to reconcile.
+//!
+//! Oracle-verified against `typescript@7.0.2`:
+//! - Direction A: `let x: *;` alone reports TS8020.
+//! - Direction B: the same line plus an unrelated real syntax error
+//!   (`let y: = 1;`) elsewhere in the file reports only the real syntax
+//!   error (TS1110) — tsc drops TS8020 entirely, confirming it belongs in
+//!   the suppression list.
+//! - Self-suppression: `class C { get x(a: number) { return a; } }` next to
+//!   `let y: *;` reports **both** TS1054 and TS8020 on tsc; before this fix
+//!   tsz would have dropped the listed TS1054 because the unlisted TS8020
+//!   counted as a "real" parse error.
+//!
+//! `TS6189` (`Multiple consecutive numeric separators are not permitted.`)
+//! was also probed this round as a same-scan adjacent candidate and
+//! correctly rejected: it survives Direction B on the real compiler (kept
+//! alongside an unrelated syntax error), so it stays unlisted — a genuine
+//! parser diagnostic in tsc, matching its already-rejected sibling TS6188.
+
+use super::*;
+
+#[test]
+fn filtered_parse_diagnostics_suppresses_ts8020_when_real_parse_error_present() {
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 7,
+            length: 1,
+            message: "JSDoc types can only be used inside documentation comments.".to_string(),
+            code: 8020,
+            related: None,
+        },
+        ParseDiagnostic {
+            start: 20,
+            length: 1,
+            message: "Type expected.".to_string(),
+            code: 1110,
+            related: None,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&8020),
+        "TS8020 should be suppressed when a real parse error (TS1110) is present, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1110),
+        "TS1110 (real parse error) should survive, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_keeps_ts8020_when_alone() {
+    use tsz::parser::ParseDiagnostic;
+
+    let diagnostics = vec![ParseDiagnostic {
+        start: 7,
+        length: 1,
+        message: "JSDoc types can only be used inside documentation comments.".to_string(),
+        code: 8020,
+        related: None,
+    }];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&8020),
+        "TS8020 should be kept when it is the only diagnostic, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_ts8020_does_not_self_suppress_listed_sibling() {
+    use tsz::parser::ParseDiagnostic;
+
+    // Before the fix, TS8020 was unlisted in `is_parser_grammar_code`, so it
+    // counted as a "real" non-grammar parse error under
+    // `has_non_grammar_parse_error` and silently deleted every *listed*
+    // sibling in the same file — here, the already-listed TS1054 (a 'get'
+    // accessor with parameters). tsc reports both.
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 20,
+            length: 1,
+            message: "A 'get' accessor cannot have parameters.".to_string(),
+            code: 1054,
+            related: None,
+        },
+        ParseDiagnostic {
+            start: 80,
+            length: 1,
+            message: "JSDoc types can only be used inside documentation comments.".to_string(),
+            code: 8020,
+            related: None,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&1054),
+        "TS1054 must not be self-suppressed by unlisted TS8020, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&8020),
+        "TS8020 should survive when no real parse error is present, got: {codes:?}"
+    );
+}
+
+#[test]
+fn is_parser_grammar_code_accepts_ts8020() {
+    assert!(is_parser_grammar_code(8020));
+}
+
+#[test]
+fn is_non_suppressing_parse_error_folds_in_ts8020() {
+    // Containment invariant: every code `is_parser_grammar_code` accepts must
+    // be non-suppressing, or it would delete its own listed siblings. TS8020
+    // is now covered by construction (the predicate delegates to
+    // `is_parser_grammar_code`).
+    assert!(is_non_suppressing_parse_error(8020));
+}
+
+#[test]
+fn ts6189_stays_unlisted_genuine_parser_diagnostic() {
+    // Rejected-with-evidence this round: survives Direction B on
+    // `typescript@7.0.2` (kept alongside an unrelated real syntax error), so
+    // it is a genuine parser diagnostic in tsc too and must NOT be treated as
+    // checker-suppressible — matching its already-rejected sibling TS6188.
+    // Tested independently rather than assumed from TS6188's membership, per
+    // round 4's own caution that family membership must not be inferred from
+    // a sibling.
+    assert!(
+        !is_parser_grammar_code(6189),
+        "TS6189 (Multiple consecutive numeric separators are not permitted) is a genuine parser diagnostic"
+    );
+}

--- a/crates/tsz-cli/src/driver/check_utils/parser_grammar_code.rs
+++ b/crates/tsz-cli/src/driver/check_utils/parser_grammar_code.rs
@@ -170,6 +170,34 @@
 /// TS2304 (TS1313 does not itself suppress cascading semantic diagnostics,
 /// unlike a genuine structural failure). Fix removed 1313 from the two
 /// structural-error lists and added it here instead.
+///
+/// #16279 audit round 11: re-derived the grep-and-diff recipe (every
+/// `diagnostic_codes::*` name emitted from `crates/tsz-parser/src`, resolved
+/// to numeric codes, diffed against this list AND
+/// `is_non_suppressing_parse_error`'s extra codes plus the 1499-1538 regex
+/// band — round 6's diff undercounted coverage by treating those as
+/// unlisted) surfaced 80 remaining candidates. Message-text triage found the
+/// overwhelming majority are genuine "X expected"/"unterminated X" structural
+/// syntax errors that must stay unlisted. One real addition: **TS8020**
+/// (`JSDoc types can only be used inside documentation comments.`, a bare `*`
+/// in type position outside a doc comment — `state_types.rs`,
+/// `state_types_jsx.rs`). `check_utils.rs`'s own `is_js_only_syntactic_diagnostic`
+/// doc comment already states "JSDoc-related `TS8xxx` codes (TS8020-TS8039 save
+/// for TS8038) come from the checker" in tsc, corroborating the classification
+/// independently of the oracle run. Oracle-confirmed against
+/// `typescript@7.0.2`: Direction A, `let x: *;` alone reports TS8020;
+/// Direction B, the same line plus an unrelated real syntax error
+/// (`let y: = 1;`) drops TS8020 entirely, leaving only TS1110; self-suppression
+/// witness, `class C { get x(a: number) { return a; } }` next to `let y: *;`
+/// reports BOTH TS1054 and TS8020 on tsc, confirming the already-listed
+/// TS1054 would have been silently deleted by the unlisted TS8020. No
+/// checker-side emission site in tsz (parser-only), so no double-emission
+/// risk. Sole rejected candidate this round: **TS6189** (`Multiple
+/// consecutive numeric separators are not permitted.`) survives Direction B
+/// (kept alongside an unrelated real syntax error on the real compiler), so —
+/// like its already-rejected sibling TS6188 — it is a genuine parser
+/// diagnostic in tsc too and must NOT be added; tested independently rather
+/// than assumed from TS6188's membership, per round 4's own caution.
 pub(super) const fn is_parser_grammar_code(code: u32) -> bool {
     matches!(
         code,
@@ -365,6 +393,12 @@ pub(super) const fn is_parser_grammar_code(code: u32) -> bool {
                // error (`let x: = 1;`) elsewhere in the file drops TS1326
                // entirely on the real compiler. Sole emission site, no
                // checker-side counterpart, so no double-emission risk.
+        | 8020 // JSDoc types can only be used inside documentation comments.
+               // tsc's checker reports this `TS8xxx` code via
+               // `grammarErrorOnNode` for a bare `*` (JSDoc "any type") in
+               // ordinary type position; tsz's parser emits it directly
+               // (`state_types.rs`, `state_types_jsx.rs`), sole emission
+               // site, no checker-side counterpart. #16279 audit round 11.
         | 2499 // An interface can only extend an identifier/qualified-name
                // with optional type arguments. tsc's checker rejects a
                // parenthesized or bracketed `extends` operand


### PR DESCRIPTION
Continues #16279's audit of `is_parser_grammar_code` (`crates/tsz-cli/src/driver/check_utils/parser_grammar_code.rs`) — the list of parser-emitted codes that tsc's checker would instead report via `grammarErrorOnNode`. Membership is load-bearing in both directions: an *unlisted* parser-emitted grammar code counts as a "real" parse error and silently deletes every *listed* sibling diagnostic in the same file, and itself survives alongside a genuine syntax error where tsc would suppress it.

## Structural rule

When `tsc`'s checker reports a diagnostic via `grammarErrorOnNode` but tsz's parser emits the same diagnostic directly, that code must be classified as checker-suppressible (`is_parser_grammar_code`) — not doing so is a self-suppression bug, not merely a missed diagnostic.

**TS8020** (`JSDoc types can only be used inside documentation comments.`, a bare `*` in ordinary type position, e.g. `let x: *;`) fits this exactly: tsz's parser emits it directly (`crates/tsz-parser/src/parser/state_types.rs`, `state_types_jsx.rs`), with no checker-side counterpart, so no double-emission risk. `check_utils.rs`'s own `is_js_only_syntactic_diagnostic` doc comment already independently states "JSDoc-related `TS8xxx` codes (TS8020-TS8039 save for TS8038) come from the checker" in tsc, corroborating the classification.

Re-derived the audit's grep-and-diff recipe (every `diagnostic_codes::*` name emitted from `crates/tsz-parser/src`, resolved to numeric codes, diffed against `is_parser_grammar_code` **and** `is_non_suppressing_parse_error`'s separate extra-codes list plus the 1499-1538 regex band — round 6's diff undercounted coverage by treating those as unlisted). 80 candidates remained; message-text triage found the overwhelming majority are genuine "X expected"/"unterminated X" structural syntax errors that must stay unlisted. TS8020 was the one real addition. TS6189 (`Multiple consecutive numeric separators are not permitted.`, sibling of the already-rejected TS6188) was also probed and correctly rejected — tested independently rather than assumed from its sibling's rejection, per round 4's own caution about family membership.

## Adjacent cases (owner layer: CLI diagnostic-filtering boundary, `crates/tsz-cli`)

- **Direction A** (alone): `let x: *;` — tsc reports TS8020.
- **Direction B** (suppression): `let x: *;` + an unrelated real syntax error (`let y: = 1;`) — tsc drops TS8020 entirely, keeps only TS1110.
- **Self-suppression witness**: `class C { get x(a: number) { return a; } }` next to `let y: *;` — tsc reports **both** TS1054 and TS8020; before this fix tsz would drop the already-listed TS1054 because the unlisted TS8020 counted as a "real" parse error.
- **Rejected sibling**: TS6189 survives Direction B on the real compiler (kept alongside an unrelated syntax error), so it stays unlisted, matching TS6188.

All four cases oracle-verified against the pinned `typescript@7.0.2` and pinned as unit tests in the new `jsdoc_star_type_grammar_tests.rs`.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-cli --lib jsdoc_star_type_grammar_tests`: 6/6 pass.
- `cargo test -p tsz-cli --lib check_utils`: 200/200 pass (no regression in the surrounding suppression-list suites).
- `cargo clippy -p tsz-cli --all-targets --lib --tests`: clean.
- `cargo fmt --check -p tsz-cli`: clean.
- `python3 scripts/arch/arch_guard.py`: passed (both touched files stay well under the 2000-line cap: 421 and 148 lines).
- `./scripts/conformance/conformance.sh snapshot --workers 12 --force` at this branch's head: 11568/12043 (96.1%) — consistent with the 11567-11570 range other same-hour sessions reported off the same `main` base, i.e. zero movement. Expected: zero fixtures in the entire `vendor/TypeScript` corpus reference TS8020 at all (`grep -rl "TS8020" vendor/TypeScript/tests/baselines/reference/*.errors.txt` → empty), so this change cannot move conformance counts either way.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_012hhv25yAEkt8mWMdWsrXDH)_