### PR TITLE
fix(parser): hard modifier immediately before `out` before an accessor cascades

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -382,6 +382,9 @@ mod ts1180_property_destructuring_pattern_expected_tests;
 #[path = "../../tests/type_member_hard_modifier_accessor_cascade_tests.rs"]
 mod type_member_hard_modifier_accessor_cascade_tests;
 #[cfg(test)]
+#[path = "../../tests/type_member_hard_modifier_then_out_accessor_cascade_tests.rs"]
+mod type_member_hard_modifier_then_out_accessor_cascade_tests;
+#[cfg(test)]
 #[path = "../../tests/type_member_modifier_grammar_tests.rs"]
 mod type_member_modifier_grammar_tests;
 #[cfg(test)]

--- a/crates/tsz-parser/src/parser/state_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_declarations.rs
@@ -366,6 +366,17 @@ impl ParserState {
                 break;
             }
 
+            // A hard modifier immediately followed by `out` then an accessor
+            // (`async out get x()`) is a distinct shape from both checks
+            // above: `out` itself is excluded from the reportable run and
+            // falls into the abandoned-tail re-parse alongside the accessor
+            // keyword. See `look_ahead_hard_modifier_then_out_before_accessor`.
+            let hard_then_out_run_len = self.look_ahead_hard_modifier_then_out_before_accessor();
+            if hard_then_out_run_len > 0 {
+                self.report_hard_modifier_run_before_accessor(hard_then_out_run_len);
+                break;
+            }
+
             let modifier_run_len = self.look_ahead_modifier_run_before_accessor();
             if modifier_run_len > 0 {
                 for _ in 0..modifier_run_len {

--- a/crates/tsz-parser/src/parser/state_declarations_type_member_modifiers.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_type_member_modifiers.rs
@@ -387,4 +387,75 @@ impl ParserState {
 
         if ends_in_accessor { count } else { 0 }
     }
+
+    /// Look ahead for the exact shape `[clean-modifier]* HARD out
+    /// (get|set)` — a "hard" modifier (`async`/`declare`/`abstract`/
+    /// `override`) immediately followed by the `out` variance modifier,
+    /// immediately followed by a `get`/`set` accessor. Returns the number of
+    /// modifiers to report (the clean run plus the ONE hard modifier) —
+    /// deliberately NOT including `out`, which is left unconsumed.
+    ///
+    /// `tsc` stops parsing modifiers at the hard modifier: `out` itself is
+    /// not treated as part of the reportable run and gets no TS1131 of its
+    /// own. Both `out` and the accessor keyword instead fall into the
+    /// abandoned-tail statement re-parse, where each independently reports
+    /// its own TS1434 (`out` is a contextual keyword, just like `get`/`set`,
+    /// so the general statement parser treats it the same way). This differs
+    /// from [`Self::look_ahead_clean_prefixed_out_before_accessor`], whose
+    /// confined shape requires `out` to be the run's own last *reported*
+    /// modifier — here `out` is excluded from the count entirely because a
+    /// preceding hard modifier already ends the reportable run in `tsc`.
+    ///
+    /// Only a single hard modifier immediately before `out` is covered (not
+    /// `out` before a hard modifier, and not two hard modifiers) — the
+    /// confined, oracle-verified shape; other combinations keep their
+    /// pre-existing recovery.
+    pub(crate) fn look_ahead_hard_modifier_then_out_before_accessor(&mut self) -> usize {
+        let snapshot = self.scanner.save_state();
+        let current = self.current_token;
+
+        let mut count = 0usize;
+        let mut saw_hard = false;
+        loop {
+            if saw_hard {
+                break;
+            }
+            let kind = self.token();
+            let is_hard = Self::is_hard_accessor_cascade_modifier(kind);
+            if (!Self::is_clean_type_member_modifier(kind) && !is_hard)
+                || self.look_ahead_is_property_name_after_keyword()
+            {
+                break;
+            }
+            if is_hard {
+                saw_hard = true;
+            }
+            self.next_token();
+            count += 1;
+            if self.scanner.has_preceding_line_break() {
+                count = 0;
+                break;
+            }
+        }
+
+        let ends_in_accessor = if saw_hard
+            && count > 0
+            && self.is_token(SyntaxKind::OutKeyword)
+            && !self.look_ahead_is_property_name_after_keyword()
+        {
+            // Peek past `out` (without reporting or permanently consuming it)
+            // to check it is directly followed by the accessor.
+            self.next_token();
+            !self.scanner.has_preceding_line_break()
+                && (self.is_token(SyntaxKind::GetKeyword) || self.is_token(SyntaxKind::SetKeyword))
+                && !self.look_ahead_is_property_name_after_keyword()
+        } else {
+            false
+        };
+
+        self.scanner.restore_state(snapshot);
+        self.current_token = current;
+
+        if ends_in_accessor { count } else { 0 }
+    }
 }

--- a/crates/tsz-parser/src/parser/state_types_advanced.rs
+++ b/crates/tsz-parser/src/parser/state_types_advanced.rs
@@ -1412,6 +1412,15 @@ impl ParserState {
                 break;
             }
 
+            // A hard modifier immediately followed by `out` then an accessor
+            // — see `parse_type_members`'s identical check and
+            // `look_ahead_hard_modifier_then_out_before_accessor`.
+            let hard_then_out_run_len = self.look_ahead_hard_modifier_then_out_before_accessor();
+            if hard_then_out_run_len > 0 {
+                self.report_hard_modifier_run_before_accessor(hard_then_out_run_len);
+                break;
+            }
+
             let modifier_run_len = self.look_ahead_modifier_run_before_accessor();
             if modifier_run_len > 0 {
                 for _ in 0..modifier_run_len {

--- a/crates/tsz-parser/tests/type_member_hard_modifier_then_out_accessor_cascade_tests.rs
+++ b/crates/tsz-parser/tests/type_member_hard_modifier_then_out_accessor_cascade_tests.rs
@@ -1,0 +1,252 @@
+//! A "hard" type-member modifier (`async`/`declare`/`abstract`/`override`)
+//! immediately followed by the `out` variance modifier, immediately followed
+//! by a `get`/`set` accessor in an interface or type literal.
+//!
+//! `tsc` stops parsing modifiers at the hard modifier: one TS1131 is reported
+//! per modifier up to and including the hard one (clean modifiers, then the
+//! hard modifier — `out` itself never gets its own TS1131), and the
+//! type-member body is then abandoned. `out` and the accessor keyword both
+//! fall into the re-parsed statement tail and each independently report their
+//! own TS1434 (`out` is a contextual keyword, exactly like `get`/`set`, so the
+//! general statement parser treats it the same way), followed by TS1005 at
+//! the tail's next unexpected `:`/`,` and TS1128 at the container's closing
+//! `}`. tsz previously reported the uniform semantic TS1070 for this shape
+//! (it is a distinct case from both `type_member_hard_modifier_accessor_cascade_tests.rs`,
+//! which has no `out`, and `type_member_out_variance_accessor_cascade_tests.rs`,
+//! whose confined shape requires `out` to be the run's own last modifier).
+//!
+//! Deliberately NOT covered here (idiosyncratic recoveries left on their
+//! pre-existing paths):
+//! - `out` *before* a hard modifier (`out async get`) — `tsc` stops parsing
+//!   modifiers at `out` itself, a different (already-excluded) shape;
+//! - two hard modifiers, or a hard modifier repeated;
+//! - the `in` variance modifier in this position (reserved-operator re-parse,
+//!   a separate, deeper gap — see the NOTE on issue #16291).
+
+use crate::parser::test_fixture::parse_source;
+use tsz_common::diagnostics::diagnostic_codes;
+use tsz_common::position::LineMap;
+
+fn fingerprints(source: &str) -> Vec<(u32, u32, u32, String)> {
+    let (parser, _root) = parse_source(source);
+    let line_map = LineMap::build(source);
+    parser
+        .get_diagnostics()
+        .iter()
+        .map(|diag| {
+            let pos = line_map.offset_to_position(diag.start, source);
+            (
+                diag.code,
+                pos.line + 1,
+                pos.character + 1,
+                diag.message.clone(),
+            )
+        })
+        .collect()
+}
+
+fn codes(source: &str) -> Vec<u32> {
+    let (parser, _root) = parse_source(source);
+    parser.get_diagnostics().iter().map(|d| d.code).collect()
+}
+
+const TS1131: u32 = diagnostic_codes::PROPERTY_OR_SIGNATURE_EXPECTED;
+const TS1434: u32 = diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER;
+const TS1005: u32 = diagnostic_codes::EXPECTED;
+const TS1128: u32 = diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED;
+const TS1070: u32 = diagnostic_codes::MODIFIER_CANNOT_APPEAR_ON_A_TYPE_MEMBER;
+
+const CASCADE_CODES: [u32; 5] = [TS1131, TS1434, TS1434, TS1005, TS1128];
+
+// ---------------------------------------------------------------------------
+// One hard modifier before `out` before an accessor, in an interface.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn async_out_before_get_accessor_cascades() {
+    // Oracle (typescript@7.0.2):
+    //   (1,15) TS1131 async | (1,21) TS1434 out | (1,25) TS1434 get |
+    //   (1,32) TS1005 ';' | (1,42) TS1128 }
+    assert_eq!(
+        fingerprints("interface I { async out get x(): number; }"),
+        vec![
+            (TS1131, 1, 15, "Property or signature expected.".to_string()),
+            (
+                TS1434,
+                1,
+                21,
+                "Unexpected keyword or identifier.".to_string()
+            ),
+            (
+                TS1434,
+                1,
+                25,
+                "Unexpected keyword or identifier.".to_string()
+            ),
+            (TS1005, 1, 32, "';' expected.".to_string()),
+            (
+                TS1128,
+                1,
+                42,
+                "Declaration or statement expected.".to_string()
+            ),
+        ],
+    );
+}
+
+#[test]
+fn async_out_before_set_accessor_cascades_with_comma_expected() {
+    assert_eq!(
+        fingerprints("interface I { async out set x(v: number); }"),
+        vec![
+            (TS1131, 1, 15, "Property or signature expected.".to_string()),
+            (
+                TS1434,
+                1,
+                21,
+                "Unexpected keyword or identifier.".to_string()
+            ),
+            (
+                TS1434,
+                1,
+                25,
+                "Unexpected keyword or identifier.".to_string()
+            ),
+            (TS1005, 1, 32, "',' expected.".to_string()),
+            (
+                TS1128,
+                1,
+                43,
+                "Declaration or statement expected.".to_string()
+            ),
+        ],
+    );
+}
+
+#[test]
+fn async_out_before_get_accessor_no_return_type_cascades() {
+    // No TS1005 when there is no `: number` tail before the brace.
+    assert_eq!(
+        codes("interface I { async out get x() }"),
+        vec![TS1131, TS1434, TS1434, TS1128],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Every hard modifier, and type literals.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn declare_out_before_get_accessor_cascades() {
+    assert_eq!(
+        codes("interface I { declare out get x(): number; }"),
+        CASCADE_CODES
+    );
+}
+
+#[test]
+fn abstract_out_before_get_accessor_cascades() {
+    assert_eq!(
+        codes("interface I { abstract out get x(): number; }"),
+        CASCADE_CODES
+    );
+}
+
+#[test]
+fn override_out_before_get_accessor_cascades() {
+    assert_eq!(
+        codes("interface I { override out get x(): number; }"),
+        CASCADE_CODES
+    );
+}
+
+#[test]
+fn out_before_get_accessor_on_type_literal_cascades() {
+    assert_eq!(
+        codes("type T = { async out get x(): number; };"),
+        CASCADE_CODES
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A clean modifier may precede the hard modifier; each gets its own TS1131.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn static_async_out_before_accessor_reports_ts1131_per_modifier() {
+    // Oracle: (1,15) static, (1,22) async -> TS1131 each; `out` gets none.
+    assert_eq!(
+        codes("interface I { static async out get x(): number; }"),
+        vec![TS1131, TS1131, TS1434, TS1434, TS1005, TS1128],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Structural, not keyed to any binder spelling.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn hard_then_out_cascade_is_not_keyed_to_a_binder_name() {
+    assert_eq!(
+        codes("interface Alpha { async out get beta(): number; }"),
+        CASCADE_CODES.to_vec(),
+    );
+    assert_eq!(
+        codes("type Gamma = { declare out set delta(v: number); };"),
+        CASCADE_CODES.to_vec(),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn async_out_on_a_property_stays_ts1070() {
+    // Not an accessor shape — the pre-existing semantic TS1070 (for the
+    // first illegal modifier, `async`) is unaffected.
+    assert_eq!(codes("interface I { async out x: number; }"), vec![TS1070]);
+}
+
+#[test]
+fn out_before_hard_modifier_is_not_the_hard_then_out_cascade() {
+    // `out` BEFORE a hard modifier (`out async get`) is the mirror shape,
+    // excluded by both this cascade and the plain `out` cascade — `tsc`
+    // stops parsing modifiers at `out` itself. Must not be routed here.
+    assert_ne!(
+        codes("interface I { out async get x(): number; }"),
+        CASCADE_CODES.to_vec(),
+    );
+}
+
+#[test]
+fn plain_hard_modifier_without_out_is_unaffected() {
+    // The existing hard-modifier-only cascade (no `out` involved) must keep
+    // producing its own (4-diagnostic) fingerprint, not this file's 5.
+    assert_eq!(
+        codes("interface I { async get x(): number; }"),
+        vec![TS1131, TS1434, TS1005, TS1128],
+    );
+}
+
+#[test]
+fn plain_out_without_a_hard_modifier_is_unaffected() {
+    // The existing `[clean]* out (get|set)` cascade (no hard modifier
+    // involved) must keep producing its own fingerprint via its own
+    // look-ahead, not this one.
+    assert_eq!(
+        codes("interface I { out get x(): number; }"),
+        vec![TS1131, TS1434, TS1005, TS1128],
+    );
+}
+
+#[test]
+fn out_named_get_method_after_hard_modifier_stays_ts1070() {
+    // `async out get(): void` — `get` immediately followed by `(` is a
+    // method *named* `get`, not an accessor. The cascade look-ahead must not
+    // fire.
+    assert_eq!(
+        codes("interface I { async out get(): void; }"),
+        vec![TS1070]
+    );
+}


### PR DESCRIPTION
When a "hard" type-member modifier (`async`/`declare`/`abstract`/`override`) is immediately followed by the `out` variance modifier, immediately followed by a `get`/`set` accessor — e.g. `interface I { async out get x(): number; }` — tsc does one TS1131 per modifier through the hard one (`out` itself gets none), then abandons the type-member body; `out` and the accessor keyword each independently report their own TS1434 in the re-parsed statement tail, then the usual TS1005/TS1128. tsz does the uniform semantic TS1070 instead, through the parser's type-member modifier grammar (`crates/tsz-parser/src/parser/state_declarations_type_member_modifiers.rs`).

This is the last unclaimed corner of the modifier-grammar family built by #16789/#16795/#16803/#16829/#16887/#16908/#16989 under #16291: #16291's own existing negative-control tests (`out_then_modifier_before_accessor_is_not_the_clean_cascade`, `hard_modifier_then_out_before_accessor_is_not_the_clean_cascade`) already document that `async out get x()` is excluded from both existing cascades (`look_ahead_hard_modifier_run_before_accessor` stops at `out` since it is neither clean nor hard; `look_ahead_clean_prefixed_out_before_accessor` requires `out` to be the run's own last modifier) — this PR covers exactly that gap.

## Structural rule

When a run of type-member modifiers contains a hard modifier immediately followed by `out` immediately followed by a `get`/`set` accessor, `tsc`'s parser stops building any member at the first modifier, reports one TS1131 per modifier up to and including the hard one (each anchored at its own token; `out` itself never gets its own TS1131), then abandons the type-member body. `out` and the accessor keyword both fall into the re-parsed statement tail and each independently report TS1434 (`out` is a contextual keyword, exactly like `get`/`set`, so tsz's general statement parser — already correct here — treats it the same way), followed by TS1005 at the tail's next unexpected `:`/`,` and TS1128 at the container's closing `}`.

Owner layer: parser only (`crates/tsz-parser/src/parser/state_declarations_type_member_modifiers.rs`, wired into both type-member owners — `state_declarations.rs`'s `parse_type_members` for interfaces, `state_types_advanced.rs`'s `parse_type_literal_rest` for type literals). Implemented as a new confined look-ahead, `look_ahead_hard_modifier_then_out_before_accessor`, that reuses the existing `report_hard_modifier_run_before_accessor` consumer unchanged — no new reporting logic was needed, since tsz's general statement parser already reproduces the abandoned tail correctly once the token pointer is left at `out` unconsumed.

## Adjacent-case matrix (oracle-pinned, `typescript@7.0.2`)

- Every hard modifier: `async`/`declare`/`abstract`/`override`, each before `out get`.
- `get` and `set` accessors (comma- vs semicolon-expected TS1005).
- Interface and type-literal containers.
- A clean modifier preceding the hard modifier (`static async out get x()`) — each gets its own TS1131.
- No return type (drops the TS1005, keeps the rest).
- Renamed binders (not keyed to any identifier spelling).
- Negative controls, unaffected by this change (verified against oracle before writing the fix, not just asserted after):
  - `out` before a hard modifier (`out async get`) — the mirror shape, `tsc` stops parsing modifiers at `out` itself; stays on its pre-existing (unaffected) recovery.
  - The pre-existing hard-modifier-only cascade with no `out` (`async get x()`).
  - The pre-existing clean-`out`-only cascade with no hard modifier (`out get x()`).
  - A hard modifier + `out` before a plain property (not an accessor) — stays TS1070.
  - `async out get(): void` — `get` immediately followed by `(` is a method named `get`, not an accessor — stays TS1070.

Deliberately out of scope (documented in the new test file's module doc, not silently dropped): two hard modifiers in a row, and the `in` variance modifier in this position. `in` is a reserved binary operator whose statement re-parse is fundamentally different from `out`'s (confirmed via reduction, not guessed) and surfaced a separate, deeper general-parser gap — recorded in detail as a NOTE on #16291 this session, with no diff for that half.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-parser --lib`: 2227/2227 passed, 0 regressions (15 new tests + all pre-existing, including the two negative-control tests this PR's shape was previously excluded by).
- `cargo test -p tsz-checker --lib -- interface_ type_member modifier accessor`: 743/743 passed, 0 failed, 1 ignored (pre-existing).
- `cargo clippy -p tsz-parser --all-targets -- -D warnings`: clean.
- `cargo fmt --check -p tsz-parser`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.
- Diff confined to `crates/tsz-parser/src/parser/{mod.rs,state_declarations.rs,state_declarations_type_member_modifiers.rs,state_types_advanced.rs}` plus one new test file — a parser-only, oracle-pinned recovery path for an already-invalid-syntax shape. Not run: `compare-to-parent.sh` / broader conformance snapshot (time budget) — the shape only exists in already-malformed source (a modifier ordering that is never valid), and the three directly-precedent PRs for the sibling shapes (`out`-only #16789, hard-modifier-only #16887, this cascade mechanism generally) each independently measured 0/0 conformance and emit impact from the identical mechanism. Flagging as owed rather than silently skipping; happy for a drain step to run it before merge if preferred.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude