### PR TITLE
fix(checker): Awaited over a mutually-recursive thenable reports TS2589 natively (removes align_awaited rewrite, #14141)

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -884,7 +884,6 @@ impl CheckerState<'_> {
         });
 
         self.rewrite_conditional_types1_fingerprints(&sf.text);
-        self.align_awaited_type_instantiation_diagnostics(&sf.text);
         self.suppress_incorrectly_extends_on_simultaneous_extend_conflict();
     }
 
@@ -1032,10 +1031,6 @@ impl CheckerState<'_> {
         }
     }
 
-    fn fixture_has_markers(source: &str, markers: &[&str]) -> bool {
-        markers.iter().all(|marker| source.contains(marker))
-    }
-
     fn rewrite_conditional_types1_fingerprints(&mut self, source_text: &str) {
         use tsz_common::diagnostics::{Diagnostic, diagnostic_codes};
 
@@ -1157,55 +1152,6 @@ impl CheckerState<'_> {
                 replacement.message_text,
                 replacement.code,
             );
-        }
-    }
-
-    fn align_awaited_type_instantiation_diagnostics(&mut self, source_text: &str) {
-        use tsz_common::diagnostics::{Diagnostic, diagnostic_codes};
-
-        if !Self::fixture_has_markers(
-            source_text,
-            &[
-                "interface BadPromise { then(cb: (value: BadPromise) => void): void; }",
-                "interface BadPromise1 { then(cb: (value: BadPromise2) => void): void; }",
-                "type T17 = Awaited<BadPromise1>",
-            ],
-        ) {
-            return;
-        }
-
-        self.ctx.diagnostics.retain(|diag| {
-            !(diag.code
-                == diagnostic_codes::TYPE_INSTANTIATION_IS_EXCESSIVELY_DEEP_AND_POSSIBLY_INFINITE
-                && diag.message_text
-                    == "Type instantiation is excessively deep and possibly infinite.")
-        });
-
-        let code = diagnostic_codes::TYPE_INSTANTIATION_IS_EXCESSIVELY_DEEP_AND_POSSIBLY_INFINITE;
-        let message = "Type instantiation is excessively deep and possibly infinite.";
-        let anchors = [
-            ("type T16 = Awaited<BadPromise>", "type T16 = "),
-            ("type T17 = Awaited<BadPromise1>", "type T17 = "),
-        ];
-        for (line_marker, prefix) in anchors {
-            let Some(start) = source_text
-                .find(line_marker)
-                .map(|pos| (pos + prefix.len()) as u32)
-            else {
-                continue;
-            };
-            if self.ctx.diagnostics.iter().any(|diag| {
-                diag.code == code && diag.start == start && diag.message_text == message
-            }) {
-                continue;
-            }
-            self.ctx.diagnostics.push(Diagnostic::error(
-                self.ctx.file_name.clone(),
-                start,
-                "Awaited".len() as u32,
-                message,
-                code,
-            ));
         }
     }
 

--- a/crates/tsz-checker/src/types/computation/access_await.rs
+++ b/crates/tsz-checker/src/types/computation/access_await.rs
@@ -155,12 +155,16 @@ impl<'a> CheckerState<'a> {
     /// before the conditional runs.
     pub(crate) fn try_evaluate_awaited_application(&mut self, type_id: TypeId) -> Option<TypeId> {
         let arg = self.awaited_application_arg_from_type(type_id)?;
-        let (awaited, changed) = self.compute_explicit_awaited_application_type(arg, 0);
+        let mut chain: Vec<TypeId> = Vec::new();
+        let (awaited, changed) =
+            self.compute_explicit_awaited_application_type(arg, 0, &mut chain)?;
         if changed {
             return Some(awaited);
         }
         let alias_body = self.promise_branch_alias_body_from_application(arg)?;
-        let (awaited, changed) = self.compute_explicit_awaited_application_type(alias_body, 0);
+        chain.clear();
+        let (awaited, changed) =
+            self.compute_explicit_awaited_application_type(alias_body, 0, &mut chain)?;
         changed.then_some(awaited)
     }
 
@@ -190,29 +194,38 @@ impl<'a> CheckerState<'a> {
         (folded != type_id).then_some(folded)
     }
 
+    /// Fold one `Awaited<...>` layer, tracking the chain of thenable types
+    /// unwrapped so far so that a cyclic thenable defers to the conditional
+    /// evaluator instead of being folded to a finite value.
+    ///
+    /// Returns `Some((awaited, changed))` when the fold completed, and `None`
+    /// when a thenable cycle was detected in this subtree — the caller then
+    /// leaves the value as the deferred `Awaited<...>` application so the
+    /// conditional evaluator's cycle detection reports `TS2589`, matching tsc's
+    /// `getAwaitedType`/`awaitedTypeStack`. `chain` holds the thenable types on
+    /// the current unwrap path (excluding `type_id` itself until it recurses).
     fn compute_explicit_awaited_application_type(
         &mut self,
         type_id: TypeId,
         depth: u8,
-    ) -> (TypeId, bool) {
+        chain: &mut Vec<TypeId>,
+    ) -> Option<(TypeId, bool)> {
         if depth > 8 {
-            return (type_id, false);
+            return Some((type_id, false));
         }
         if let Some(members) = query::union_members(self.ctx.types, type_id) {
             let mut changed = false;
-            let unwrapped = members
-                .into_iter()
-                .map(|member| {
-                    let (awaited, member_changed) =
-                        self.compute_explicit_awaited_application_type(member, depth + 1);
-                    changed |= member_changed;
-                    awaited
-                })
-                .collect();
-            return (
+            let mut unwrapped = Vec::with_capacity(members.len());
+            for member in members {
+                let (awaited, member_changed) =
+                    self.compute_explicit_awaited_application_type(member, depth + 1, chain)?;
+                changed |= member_changed;
+                unwrapped.push(awaited);
+            }
+            return Some((
                 query::awaited_union_type(self.ctx.types, unwrapped),
                 changed,
-            );
+            ));
         }
         // Unwrap a single thenable layer. The fast path matches the
         // Application form (`Promise<T>` / `PromiseLike<T>`) without
@@ -243,16 +256,26 @@ impl<'a> CheckerState<'a> {
             }
         }
         if let Some(inner) = inner {
-            // A self-referential thenable (`onfulfilled` yields the thenable
-            // itself) must not spin; stop and let the conditional evaluator and
-            // its cycle detection own that case.
-            if inner == type_id {
-                return (type_id, false);
+            // A self-referential thenable must not spin. Two shapes qualify:
+            //   * direct  — `onfulfilled` yields the thenable itself
+            //     (`inner == type_id`);
+            //   * mutual  — `inner` was already unwrapped higher on this path
+            //     (`BadPromise1 -> BadPromise2 -> BadPromise1`), so it appears in
+            //     `chain`.
+            // Both are genuinely infinite: stop folding and defer (return `None`)
+            // so the value stays the deferred `Awaited<...>` application and the
+            // conditional evaluator's cycle detection reports TS2589, mirroring
+            // tsc's `getAwaitedType` guarding on its `awaitedTypeStack`.
+            if inner == type_id || chain.contains(&inner) {
+                return None;
             }
-            let (awaited, _) = self.compute_explicit_awaited_application_type(inner, depth + 1);
-            return (awaited, true);
+            chain.push(type_id);
+            let unwrapped = self.compute_explicit_awaited_application_type(inner, depth + 1, chain);
+            chain.pop();
+            let (awaited, _) = unwrapped?;
+            return Some((awaited, true));
         }
-        (type_id, false)
+        Some((type_id, false))
     }
 
     /// Compute the `Awaited<T>` of a type, mirroring tsc's `getAwaitedType`.

--- a/crates/tsz-checker/tests/awaited_generic_application_fold_tests.rs
+++ b/crates/tsz-checker/tests/awaited_generic_application_fold_tests.rs
@@ -1,7 +1,22 @@
 //! `Awaited<X>` must fold the same way whether it appears directly or behind
 //! an intermediate alias. Regression coverage for issue #5824.
 
-use tsz_checker::test_utils::check_source_codes;
+use std::sync::{Arc, OnceLock};
+use tsz_binder::lib_loader::LibFile;
+use tsz_checker::CheckerOptions;
+use tsz_checker::test_utils::{check_source_codes, check_source_with_libs, load_default_lib_files};
+
+/// Codes from a check run against the full default lib bundle, so global types
+/// like `Awaited`, `Promise`, and `PromiseLike` resolve (the bare
+/// `check_source_codes` harness binds no libs).
+fn lib_codes(source: &str) -> Vec<u32> {
+    static LIBS: OnceLock<Vec<Arc<LibFile>>> = OnceLock::new();
+    let libs = LIBS.get_or_init(load_default_lib_files);
+    check_source_with_libs(source, "test.ts", CheckerOptions::default(), libs)
+        .iter()
+        .map(|d| d.code)
+        .collect()
+}
 
 #[test]
 fn awaited_union_with_promise_folds_to_value() {
@@ -108,6 +123,113 @@ function checkNested<T>(x: _Nested<T>): T {
     assert!(
         !codes.contains(&2322),
         "Awaited<Promise<T | Promise<T>>> must recursively unwrap to T; got: {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cyclic thenables must report TS2589, not fold to a finite value.
+//
+// `Awaited<X>` over a thenable whose `then` callback value transitively yields
+// the thenable again is infinitely deep — tsc reports TS2589. The fold's cycle
+// detection must span the *mutual* case (`A -> B -> A`), not only the direct
+// self-cycle (`A -> A`), and it must be structural: the interface names are
+// irrelevant. Regression coverage for issue #14141 (removal of the
+// `align_awaited_type_instantiation_diagnostics` conformance-fixture rewrite;
+// the `awaitedTypeStrictNull` fixture now matches tsc natively).
+
+#[test]
+fn direct_self_referential_thenable_reports_ts2589() {
+    let source = r#"
+interface SelfThenable { then(cb: (value: SelfThenable) => void): void; }
+type Unwrapped = Awaited<SelfThenable>;
+declare const _u: Unwrapped;
+"#;
+    let codes = lib_codes(source);
+    assert!(
+        codes.contains(&2589),
+        "a directly self-referential thenable must report TS2589; got: {codes:?}"
+    );
+}
+
+#[test]
+fn mutually_recursive_thenable_two_cycle_reports_ts2589() {
+    // Ping -> Pong -> Ping. Deliberately not named `BadPromise1`/`BadPromise2`
+    // (the old rewrite keyed on those literals) to prove the fix is structural.
+    let source = r#"
+interface Ping { then(cb: (value: Pong) => void): void; }
+interface Pong { then(cb: (value: Ping) => void): void; }
+type Unwrapped = Awaited<Ping>;
+declare const _u: Unwrapped;
+"#;
+    let codes = lib_codes(source);
+    assert!(
+        codes.contains(&2589),
+        "a mutually recursive thenable (2-cycle) must report TS2589; got: {codes:?}"
+    );
+}
+
+#[test]
+fn mutually_recursive_thenable_three_cycle_reports_ts2589() {
+    let source = r#"
+interface Alpha { then(cb: (value: Beta) => void): void; }
+interface Beta { then(cb: (value: Gamma) => void): void; }
+interface Gamma { then(cb: (value: Alpha) => void): void; }
+type Unwrapped = Awaited<Alpha>;
+declare const _u: Unwrapped;
+"#;
+    let codes = lib_codes(source);
+    assert!(
+        codes.contains(&2589),
+        "a mutually recursive thenable (3-cycle) must report TS2589; got: {codes:?}"
+    );
+}
+
+#[test]
+fn renamed_binders_mutual_cycle_reports_ts2589() {
+    // Same shape, arbitrary names — the fold must not depend on any identifier.
+    let source = r#"
+interface Zeta { then(cb: (value: Omega) => void): void; }
+interface Omega { then(cb: (value: Zeta) => void): void; }
+type Resolved = Awaited<Zeta>;
+declare const _r: Resolved;
+"#;
+    let codes = lib_codes(source);
+    assert!(
+        codes.contains(&2589),
+        "a mutually recursive thenable must report TS2589 regardless of binder names; got: {codes:?}"
+    );
+}
+
+#[test]
+fn finite_nested_promise_does_not_report_ts2589() {
+    // A genuinely finite unwrap chain must never be mistaken for a cycle.
+    let source = r#"
+type A = Awaited<Promise<Promise<number>>>;
+declare const a: A;
+const n: number = a;
+"#;
+    let codes = lib_codes(source);
+    assert!(
+        !codes.contains(&2589),
+        "a finite nested promise must not report TS2589; got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2322),
+        "Awaited<Promise<Promise<number>>> must fold to number; got: {codes:?}"
+    );
+}
+
+#[test]
+fn finite_structural_thenable_does_not_report_ts2589() {
+    let source = r#"
+type B = Awaited<{ then(cb: (value: number, other: {}) => void): void }>;
+declare const b: B;
+const n: number = b;
+"#;
+    let codes = lib_codes(source);
+    assert!(
+        !codes.contains(&2589),
+        "a finite (non-cyclic) structural thenable must not report TS2589; got: {codes:?}"
     );
 }
 


### PR DESCRIPTION
Removes the `align_awaited_type_instantiation_diagnostics` conformance-fixture
rewrite (issue #14141) by fixing the underlying semantics.

**Structural rule:** when `Awaited<X>` is applied to a thenable whose `then`
callback value transitively yields the thenable again — directly
(`BadPromise.then` → `BadPromise`) or mutually (`BadPromise1` → `BadPromise2`
→ `BadPromise1`) — the type is infinitely deep and `tsc` reports **TS2589**.
tsz reports it through the checker's `Awaited` fold
(`compute_explicit_awaited_application_type`) deferring the cyclic case to the
conditional evaluator, whose cycle detection emits TS2589.

tsz already handled the **direct** self-cycle (`inner == type_id`) that way, so
`Awaited<BadPromise>` was correct. The **mutual** cycle was not detected: the
fold unwrapped `BadPromise1 → BadPromise2 → BadPromise1 → …` up to its depth-8
cap and returned a wrong finite value (`BadPromise2`), so no cycle ever reached
the conditional evaluator and no diagnostic fired. The fixture-gated rewrite
papered over this by dropping every native TS2589 in the file and re-injecting
two at source-text-matched offsets (`type T16 = `, `type T17 = `) — one of the
`source_text.contains` hacks #14141 tracks.

**Fix:** thread the chain of thenable types unwrapped on the current path and
defer (return `None`, leaving the deferred `Awaited<…>` application for the
conditional evaluator) when `inner` reappears in that chain — the mutual
generalization of the existing direct-cycle guard, mirroring tsc's
`getAwaitedType`/`awaitedTypeStack`. Only a genuine cycle reappears; a finite
unwrap chain visits distinct types each step and is unaffected.

With TS2589 now emitted natively at both `Awaited<BadPromise>` and
`Awaited<BadPromise1>`, the `awaitedTypeStrictNull` fixture matches `tsc`
fingerprint-for-fingerprint, and `align_awaited_type_instantiation_diagnostics`
+ its dispatch (and the now-orphaned `fixture_has_markers` helper) are deleted.

The fix is structural (no identifier/file-name/source-text gate); coverage
varies the binder names to prove it.

## Goal
Goal: hold

## Verification
- New `awaited_generic_application_fold_tests` rows (direct, mutual 2-cycle,
  mutual 3-cycle, renamed-binder cyclic thenables → TS2589; finite nested
  promise + finite structural thenable → clean): 14/14 pass.
- `awaitedTypeStrictNull.ts` now matches the pinned `tsc@7.0.2` cache natively
  (TS2589@25:12, TS2589@29:12, TS7010@32:22) with the rewrite removed.
- `awaitedType.ts`: 2×TS2589 + TS7010, no new/spurious diagnostics from this
  change (the pre-existing missing TS2493 is unrelated).
- Await/promise unit suites (`awaited_generic_application_fold_tests`,
  `async_return_promise_identity_tests`, `await_structural_thenable_object_literal_tests`,
  `await_thenable_this_context_tests`, `await_generic_non_promise_no_false_ts2339_tests`):
  all pass.
- `clippy -p tsz-checker` + arch-size guard: pass (pre-commit hook).
- Conformance `compare-to-parent.sh` (my change vs its parent `6c17e12`, both
  `dist-fast`, 12043 runnable): **NEWLY PASSING 0, NEWLY FAILING 0,
  fingerprint-changed 0** — exactly neutral. Both sides 11566 passed / 476
  failing. Removing the rewrite keeps `awaitedTypeStrictNull` passing (native
  TS2589 now, not the injected pair), with no other row moving. (Rebased onto
  current `main` afterward; the change is unchanged.)
- Change is diagnostic-only (no emit surface); the emit lane is unaffected.

## Provenance
Machine: cloud
Assistant: claude-code
Model: Claude Code (Opus-class)
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCbjuNFDxTSD1HkG4ewbF8)_