### PR TITLE
fix(checker): don't force TS2416 on an iterator next() override whose return value is any

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -1881,8 +1881,21 @@ impl<'a> CheckerState<'a> {
         let Some(shape) = object_shape_for_type(self.ctx.types, type_id) else {
             return false;
         };
-        let done_name = self.ctx.types.intern_string("done");
         let value_name = self.ctx.types.intern_string("value");
+        let value_prop = shape.properties.iter().find(|prop| prop.name == value_name);
+        // An `any`-typed `value` makes the object assignable to *either*
+        // `IteratorResult` arm (`IteratorYieldResult<TYield>` /
+        // `IteratorReturnResult<TReturn>`) regardless of its `done` discriminant —
+        // `any` satisfies both `TYield` and `TReturn`. So a broad `done` is not a
+        // genuine override mismatch here: `tsc` accepts a `next()` override whose
+        // inferred return is `{ done: boolean; value: any }`, which is exactly the
+        // shape produced by an unannotated iterator override under
+        // `strictNullChecks: false` (`value: undefined` widens to `any`, #17003).
+        // Defer to the general relation for these instead of forcing a TS2416.
+        if value_prop.is_some_and(|prop| self.type_evaluates_to(prop.type_id, TypeId::ANY)) {
+            return false;
+        }
+        let done_name = self.ctx.types.intern_string("done");
         let Some(done_prop) = shape.properties.iter().find(|prop| prop.name == done_name) else {
             return false;
         };
@@ -1894,11 +1907,7 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        !shape
-            .properties
-            .iter()
-            .find(|prop| prop.name == value_name)
-            .is_some_and(|prop| self.type_evaluates_to(prop.type_id, TypeId::UNDEFINED))
+        !value_prop.is_some_and(|prop| self.type_evaluates_to(prop.type_id, TypeId::UNDEFINED))
     }
 }
 

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -513,6 +513,8 @@ mod invocation_signature_detail_tests;
 mod issue_9762_literal_init_callback_inference;
 #[path = "tests/iterable_next_relation_routing_arch_tests.rs"]
 mod iterable_next_relation_routing_arch_tests;
+#[path = "tests/iterator_override_widened_value_tests.rs"]
+mod iterator_override_widened_value_tests;
 #[path = "tests/js_expando_order_sensitivity_tests.rs"]
 mod js_expando_order_sensitivity_tests;
 #[path = "tests/js_file_function_parameters_as_optional_tests.rs"]

--- a/crates/tsz-checker/src/tests/iterator_override_widened_value_tests.rs
+++ b/crates/tsz-checker/src/tests/iterator_override_widened_value_tests.rs
@@ -1,0 +1,145 @@
+//! Regression tests for #17003: a false-positive `TS2416` on an unannotated
+//! `next()` override whose inferred return widens to `{ done: boolean; value:
+//! any }`.
+//!
+//! Structural rule: the checker-only iterator-protocol diagnostic
+//! (`iterator_result_return_display_mismatch`) forces a member-override
+//! mismatch when a class' `next()` override returns an object with a "broad"
+//! `done` against a base whose `next()` returns `IteratorResult<_, unknown>`.
+//! But an `any`-typed `value` makes that object assignable to *either*
+//! `IteratorResult` arm regardless of `done` (`any` satisfies both `TYield` and
+//! `TReturn`), so it is NOT a genuine mismatch — `tsc` accepts it. This is
+//! exactly the shape an unannotated iterator override produces under
+//! `strictNullChecks: false`: `return { done: true, value: undefined }` widens
+//! `value: undefined` to `any`, and `done: true` to `boolean`.
+//!
+//! Oracle: `typescript@7.0.2`, `--strict false --target esnext --lib esnext`
+//! reports no diagnostic on the class; `--strict` reports `TS2416`
+//! (`done: boolean`/`true` is a genuine mismatch there). Both directions are
+//! pinned below, and the class/binder names are varied so the fix cannot be a
+//! name match.
+
+use std::sync::Arc;
+
+use tsz_binder::lib_loader::LibFile;
+
+use crate::CheckerOptions;
+use crate::test_utils::{
+    check_source_with_libs, diagnostic_codes, load_lib_files, non_strict_checker_options,
+    strict_checker_options,
+};
+
+/// The default lib bundle plus `es2025.iterator` (which declares the global
+/// `Iterator` abstract class used in the `extends Iterator<T>` clause). The
+/// standard default bundle does not include it.
+fn iterator_libs() -> Vec<Arc<LibFile>> {
+    let mut names: Vec<&str> = crate::test_utils::DEFAULT_LIB_NAMES.to_vec();
+    names.push("es2025.iterator.d.ts");
+    load_lib_files(&names)
+}
+
+fn codes_with_options(src: &str, options: CheckerOptions) -> Vec<u32> {
+    let libs = iterator_libs();
+    let diags = check_source_with_libs(src, "test.ts", options, &libs);
+    diagnostic_codes(&diags)
+}
+
+fn nonstrict_codes(src: &str) -> Vec<u32> {
+    codes_with_options(src, non_strict_checker_options())
+}
+
+fn strict_codes(src: &str) -> Vec<u32> {
+    codes_with_options(src, strict_checker_options())
+}
+
+#[test]
+fn nonstrict_unannotated_next_override_widened_value_is_clean() {
+    // `value: undefined` widens to `any` under non-strict; `tsc` accepts.
+    let codes = nonstrict_codes(
+        "
+class MyIterator extends Iterator<string> {
+    next() { return { done: true, value: undefined }; }
+}
+",
+    );
+    assert!(
+        !codes.contains(&2416),
+        "expected no TS2416 on the non-strict widened iterator override, got: {codes:?}"
+    );
+    // The lib must actually resolve, else the guard is vacuous.
+    assert!(
+        !codes.contains(&2304) && !codes.contains(&2583),
+        "iterator lib left unresolved — guard would be vacuous: {codes:?}"
+    );
+}
+
+#[test]
+fn nonstrict_widened_value_clean_under_renamed_binders() {
+    // Same shape, different class name and yield type — the fix is structural,
+    // not a name/text match.
+    let codes = nonstrict_codes(
+        "
+class WidgetCursor extends Iterator<number> {
+    next() { return { done: true, value: undefined }; }
+}
+",
+    );
+    assert!(
+        !codes.contains(&2416),
+        "expected no TS2416 under renamed binders, got: {codes:?}"
+    );
+}
+
+#[test]
+fn nonstrict_explicit_any_value_is_clean() {
+    // An explicit `value: any` is the same acceptable shape without relying on
+    // non-strict widening of `undefined`.
+    let codes = nonstrict_codes(
+        "
+declare const anyVal: any;
+class ExplicitAnyIter extends Iterator<string> {
+    next() { return { done: true as boolean, value: anyVal }; }
+}
+",
+    );
+    assert!(
+        !codes.contains(&2416),
+        "expected no TS2416 for an explicit any-valued iterator override, got: {codes:?}"
+    );
+}
+
+#[test]
+fn strict_unannotated_next_override_still_reports_ts2416() {
+    // Parity control: under `strictNullChecks`, `value: undefined` does NOT
+    // widen to `any`, so `{ done: true; value: undefined }` (with `done`
+    // widened to `boolean`) is a genuine mismatch against
+    // `IteratorResult<string, undefined>` — `tsc` reports TS2416. The
+    // any-value exemption must not suppress this.
+    let codes = strict_codes(
+        "
+class StrictIter extends Iterator<string> {
+    next() { return { done: true, value: undefined }; }
+}
+",
+    );
+    assert!(
+        codes.contains(&2416),
+        "expected TS2416 under strict mode (genuine mismatch), got: {codes:?}"
+    );
+}
+
+#[test]
+fn strict_genuine_named_method_return_mismatch_still_reported() {
+    // Unrelated genuine override mismatch must still fire (guards that the
+    // any-value exemption is narrowly scoped to the iterator `value` shape).
+    let codes = strict_codes(
+        "
+class NumBase { compute(): number { return 0; } }
+class StrSub extends NumBase { compute(): string { return ''; } }
+",
+    );
+    assert!(
+        codes.contains(&2416),
+        "expected TS2416 for a genuine number->string override mismatch, got: {codes:?}"
+    );
+}


### PR DESCRIPTION
Structural rule: when a class' unannotated `next()` override returns an object whose `value` property is `any` (e.g. `{ done: boolean; value: any }`) against a base whose `next()` returns `IteratorResult<_, unknown>`, `tsc` accepts it — `any` is assignable to either `IteratorResult` arm (`IteratorYieldResult<TYield>` / `IteratorReturnResult<TReturn>`) regardless of the `done` discriminant. tsz emitted a spurious **TS2416** through the checker-only iterator-protocol diagnostic `iterator_result_return_display_mismatch` (owner layer: `crates/tsz-checker/src/assignability/assignability_diagnostics.rs`).

Failure family: `usingDeclarationsWithIteratorObject` / `awaitUsingDeclarationsWithIteratorObject` (`// @strict: false`). An unannotated iterator override `next() { return { done: true, value: undefined }; }` infers `{ done: boolean; value: any }` under `strictNullChecks: false` (`value: undefined` widens to `any`, `done: true` widens to `boolean`). The general relation correctly accepts this; only the checker-only detector forced the mismatch.

Note: the issue's original diagnosis (missing heritage-sourced contextual typing) was not the cause — the return-type inference is correct, and the isolated relation accepts the shape. The root cause is the over-broad iterator-protocol detector, which short-circuits ahead of the general relation in `should_report_assignability_mismatch_bivariant`.

## Fix
`iterator_result_return_source_has_broad_done` now returns `false` when the source object's `value` property evaluates to `any`, so the detector defers to the general relation for that shape. This mirrors the existing `done: true` + `value: undefined` carve-out in the same function. Scoped narrowly (not a wholesale removal) because the detector also acts as a termination guard for an unrelated recursive-conditional path; the exempted shape is a concrete, non-recursive object, so it cannot reintroduce that hang.

Adjacent-case matrix (all covered by `iterator_override_widened_value_tests.rs`, binder names varied):
- non-strict unannotated `next()` override → clean (was TS2416)
- same shape, renamed class + different yield type → clean (fix is structural, not a name match)
- explicit `value: any` → clean
- **strict** unannotated override → still TS2416 (genuine mismatch; the exemption must not suppress it)
- unrelated `number` → `string` override mismatch → still TS2416

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib iterator_override_widened_value` — 5/5 pass (new regression module).
- `cargo test -p tsz-checker --lib builtin_iterator_implements` — 21/21 pass (no iterator-override regression).
- Full `cargo test -p tsz-checker --lib` — 10901/10901 pass, 0 failures (only the pre-existing, iterator-unrelated `ts2589` recursive-conditional hang from #15338/#15983).
- `cargo clippy --profile ci-lint --workspace --all-targets -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py` — passed.
- CLI vs `typescript@7.0.2` oracle on the `usingDeclarationsWithIteratorObject` class: non-strict now clean (matches tsc); strict still TS2416 (matches tsc).
- Conformance snapshot vs baseline: running; results to follow in a comment.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvpZybUzJBLJTAtWMyx1xz)_