### PR TITLE
fix(parser/checker): anchor property-name-derived grammar diagnostics at the correct span

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/js_grammar.rs
+++ b/crates/tsz-checker/src/state/state_checking/js_grammar.rs
@@ -397,13 +397,13 @@ impl<'a> CheckerState<'a> {
                         .arena
                         .get_method_decl(node)
                         .and_then(|method| self.ctx.arena.get(method.name))
-                        .map(|name| name.end.saturating_sub(1)),
+                        .map(|name| name.end),
                     syntax_kind_ext::PROPERTY_DECLARATION => self
                         .ctx
                         .arena
                         .get_property_decl(node)
                         .and_then(|prop| self.ctx.arena.get(prop.name))
-                        .map(|name| name.end.saturating_sub(1)),
+                        .map(|name| name.end),
                     _ => None,
                 };
                 if let Some(start) = optional_start {

--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -250,15 +250,10 @@ impl<'a> CheckerState<'a> {
             let is_abstract = self.has_abstract_modifier(&prop.modifiers);
             let has_declare = self.has_declare_modifier(&prop.modifiers);
 
-            // tsc points TS1255/TS1263/TS1264 at the `!` token itself.
-            // For class property names parsed via parse_property_name(), the name
-            // node's `end` is one past the `!` (due to end_pos being captured after
-            // next_token()). So the `!` is at name_node.end - 1.
-            let excl_pos = self
-                .ctx
-                .arena
-                .get(prop.name)
-                .map(|n| n.end.saturating_sub(1));
+            // tsc points TS1255/TS1263/TS1264 at the `!` token itself, which
+            // immediately follows the property name, i.e. at `name_node.end`
+            // (length 1) — the same anchor the variable-declaration arm uses.
+            let excl_pos = self.ctx.arena.get(prop.name).map(|n| n.end);
 
             // TS1255: ! is not permitted on static, abstract, ambient, or declared properties
             if in_ambient || is_static || is_abstract || has_declare {

--- a/crates/tsz-checker/tests/js_grammar_span_tests.rs
+++ b/crates/tsz-checker/tests/js_grammar_span_tests.rs
@@ -310,3 +310,33 @@ fn js_module_declaration_ignores_namespace_word_in_comment_for_ts8006_text() {
         "expected TS8006 to identify a module declaration from parser flags. Actual diagnostics: {ts8006:#?}"
     );
 }
+
+/// A class property's definite-assignment diagnostics (TS1255/TS1263/TS1264)
+/// anchor on the `!` token, which immediately follows the property name — i.e.
+/// at `name_node.end`, length 1, exactly as `tsc` reports it and as the
+/// variable-declaration arm already does. This regressed once before: the
+/// property name is parsed via `parse_property_name`, whose node `end` used to
+/// overshoot the identifier, and the checker compensated with `end - 1`; when
+/// the parser overshoot was fixed the compensation had to go with it. Binder
+/// names vary per row so no assertion keys on an identifier string.
+#[test]
+fn class_property_definite_assignment_anchors_at_exclamation() {
+    let source = "class Cx { px! = 1; }";
+    let diagnostics = check_source(source, "a.ts", CheckerOptions::default());
+
+    let ts1263: Vec<_> = diagnostics
+        .iter()
+        .filter(|diag| diag.code == 1263)
+        .collect();
+    assert_eq!(ts1263.len(), 1, "unexpected diagnostics: {diagnostics:#?}");
+
+    let excl = source.find('!').expect("definite assignment marker") as u32;
+    assert_eq!(
+        ts1263[0].start, excl,
+        "TS1263 must anchor at the '!' token (name_node.end). Actual: {ts1263:#?}"
+    );
+    assert_eq!(
+        ts1263[0].length, 1,
+        "unexpected diagnostic length: {ts1263:#?}"
+    );
+}

--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part5.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part5.rs
@@ -378,3 +378,43 @@ interface LibBase {
             "a memberless derived interface must not run heritage compatibility, got: {extension:?}"
         );
     }
+
+    /// End-to-end guard for the property-name span fix in
+    /// `parse_property_name_impl`: a parser grammar diagnostic and a checker
+    /// diagnostic anchored on the *same* accessor name must interleave by code,
+    /// exactly as `tsc`'s `compareDiagnostics` orders them (start, then length,
+    /// then code). `TS1054` ("A 'get' accessor cannot have parameters.") and
+    /// `TS2378` ("A 'get' accessor must return a value.") both anchor on the `x`
+    /// name of `get x(v: number): string`; `tsc` emits `TS1054` first because
+    /// `1054 < 2378` at an equal span.
+    ///
+    /// The property-name node used to overshoot its `end` by the width of the
+    /// following `(`, so `TS1054` carried a longer span than `TS2378`; since
+    /// `compare` breaks ties on length before code, the longer diagnostic sorted
+    /// *after* the shorter one, inverting the pair relative to `tsc`. This asserts
+    /// the corrected, code-ordered interleaving through the full CLI sort path.
+    #[test]
+    fn accessor_grammar_and_checker_diagnostics_interleave_by_code_at_one_name() {
+        let mut diagnostics =
+            collect_es2015_default_lib_diagnostics("class C { get x(v: number): string {} }\n");
+        diagnostics.sort_by(|a, b| a.compare(b));
+
+        let ts1054 = diagnostics
+            .iter()
+            .position(|d| d.code == 1054)
+            .expect("TS1054 (get accessor cannot have parameters) must be reported");
+        let ts2378 = diagnostics
+            .iter()
+            .position(|d| d.code == 2378)
+            .expect("TS2378 (get accessor must return a value) must be reported");
+
+        assert_eq!(
+            diagnostics[ts1054].start, diagnostics[ts2378].start,
+            "both diagnostics must anchor on the same accessor name"
+        );
+        assert!(
+            ts1054 < ts2378,
+            "TS1054 must sort before TS2378 at an equal span (code order), matching tsc; \
+             got TS1054 at {ts1054} and TS2378 at {ts2378}: {diagnostics:?}"
+        );
+    }

--- a/crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs
@@ -1235,8 +1235,17 @@ impl ParserState {
                     } else {
                         None
                     };
-                self.next_token(); // Accept any token as property name (error recovery)
+                // Capture the identifier/keyword's own end *before* advancing:
+                // `token_end()` after `next_token()` reports the end of the
+                // *following* token, overshooting the property-name node's span
+                // (the same hazard the computed-name branch above guards against).
+                // That overshoot corrupts `name.end - name.pos` for every
+                // diagnostic anchored on a property name (TS1054/TS1049/TS1095…),
+                // which then mis-sorts against a same-position checker diagnostic
+                // (`compareDiagnostics` breaks ties on length before code) and
+                // mis-renders the underline.
                 let end_pos = self.token_end();
+                self.next_token(); // Accept any token as property name (error recovery)
 
                 self.arena.add_identifier(
                     SyntaxKind::Identifier as u16,

--- a/crates/tsz-parser/tests/accessor_signature_parameter_list_tests.rs
+++ b/crates/tsz-parser/tests/accessor_signature_parameter_list_tests.rs
@@ -181,10 +181,14 @@ fn get_accessor_signature_reports_ts1054_at_the_accessor_name() {
 }
 
 /// The signature arm and the class arm must produce the *same shape* of span for
-/// TS1054, so the two cannot drift. Both read `name.end - name.pos`, and that
-/// length currently overshoots the identifier by one — a property-name node-end
-/// overshoot shared by both arms and out of scope here. Pinning the two against
-/// each other catches a change to either without baking in the wrong number.
+/// TS1054, so the two cannot drift. Both read `name.end - name.pos`; the length is
+/// now exactly the accessor name's width (`gy27`, 4 chars), matching tsc's
+/// `grammarErrorOnNode(accessor.name, …)`. This span used to overshoot the
+/// identifier by the width of the following token (`(`) because
+/// `parse_property_name_impl` read `token_end()` *after* advancing past the name —
+/// which not only mis-underlined but, since `compareDiagnostics` breaks ties on
+/// length before code, sorted TS1054 *after* a same-position checker diagnostic
+/// (e.g. TS2378) instead of before it. Pinning the exact width guards the fix.
 #[test]
 fn get_accessor_ts1054_span_agrees_between_the_signature_and_class_arms() {
     let (sig_start, sig_len) = span_of(
@@ -198,6 +202,11 @@ fn get_accessor_ts1054_span_agrees_between_the_signature_and_class_arms() {
     assert_eq!(
         sig_len, class_len,
         "TS1054 span length must match between the accessor-signature and class arms"
+    );
+    assert_eq!(
+        sig_len,
+        "gy27".len() as u32,
+        "TS1054 must span exactly the accessor name, matching tsc"
     );
     assert_eq!(
         sig_start - "interface Iy27 { get ".len() as u32,


### PR DESCRIPTION
Fixes #17024.

When a property/member name is parsed via `parse_property_name_impl`, tsc anchors grammar diagnostics on the name's own span; tsz was building the name node with an `end` that overshot to the *following* token, so every property-name-anchored diagnostic carried a too-wide span. Because tsc's `compareDiagnostics` breaks ties on `length` **before** `code`, the inflated span sorted grammar diagnostics *after* a same-position checker diagnostic instead of interleaving by code, and it mis-rendered the underline. This corrects the root span and the two downstream anchors that had been compensating for the overshoot.

## Structural rule
When a property name is written as an identifier/keyword, `parse_property_name_impl` must set the name node's `end` to the name token's own end (not the following token's). tsz read `token_end()` *after* `next_token()` advanced past the name — the exact hazard the computed-name branch documents and guards against. With the root corrected:
- accessor grammar diagnostics (`TS1054`/`TS1049`/`TS1095`) now span just the accessor name and interleave with same-position checker diagnostics by code, matching tsc (`get x(v){}` → `TS1054` then `TS2378`, both at the name);
- the class-property definite-assignment anchors (`TS1255`/`TS1263`/`TS1264`) and the JS optional-modifier anchor (`TS8009` on a method/property) read `name_node.end` directly instead of `name_node.end - 1`, dropping the compensation that only existed because of the overshoot. The variable-declaration and parameter arms already used the un-compensated `name_node.end`.

Owner layers: parser (`state_expressions_literals/object_members.rs`) for the span; checker (`state_checking_members/ambient_signature_checks.rs`, `state_checking/js_grammar.rs`) for the two anchors.

## Adjacent matrix (oracle: `typescript@7.0.2`, `--noEmit --strict --target es2022 --lib es2022`)
| case | tsc | before | after |
| --- | --- | --- | --- |
| `class C { get x(v): string {} }` | `TS1054`@15 then `TS2378`@15 | `TS2378` then `TS1054`; `~~` on `x(` | `TS1054` then `TS2378`; `~` on `x` |
| `class C { get x(v){} set y(){} }` | 1054,2378,7006,1049,7032 | 2378,1054,7006,7032,1049 | matches tsc |
| `class C { a! = 1 }` | `TS1263`@`!` | `TS1263`@`!` | `TS1263`@`!` (net unchanged) |
| `let v! = 1` | `TS1263`@`!` | `TS1263`@`!` | unchanged (variable path) |
| `class C { m?() {} p?: number }` (JS) | `TS8009`@`?` ×2 | `TS8009`@`?` ×2 | net unchanged |

The class-property / JS rows are unchanged *net* — the parser fix and the checker anchor fix cancel — which is the point: the diagnostics that were only correct by compensation stay correct, while the accessor-ordering family that had no compensation is now fixed.

## Goal
Goal: hold

## Verification (all run locally on this head; per-merge CI Summary green: clippy + arch-size)
- `cargo test -p tsz-parser` — **2213 passed**; updated `get_accessor_ts1054_span_agrees_between_the_signature_and_class_arms` to pin the exact name width.
- `cargo test -p tsz-checker` — passed; added `class_property_definite_assignment_anchors_at_exclamation`; existing `js_optional_class_elements_report_ts8009_at_question_token` covers the method/property `?` arms.
- `cargo test -p tsz-cli accessor_grammar_and_checker_diagnostics_interleave_by_code_at_one_name` — new end-to-end guard that `TS1054` sorts before `TS2378` at one accessor name.
- **Conformance** (`conformance.sh run`, `typescript@7.0.2` corpus): **11569/12043 (96.1%), +11 improvements, 0 regressions from this PR**. A parser-only intermediate shifted 6 class-property/JS rows by one column; the checker anchor fix restores all 6 to byte-identical output. The only 2 rows conformance still flags vs the saved baseline (`lambdaParameterWithTupleArgsHasCorrectAssignability`, `parenthesizedContexualTyping3`) are pre-existing drift on `main` — proven `NEW==base` on both. Display/position only; the code-set score is unchanged.
- **Fourslash**: **6557/6562 passed**; the 3 non-passing tests (`importFixesWithPackageJsonInSideAnotherPackage`, `importNameCodeFix_importType`, `autoImportProvider_importsMap1`) fail identically on a base `tsz-server` — pre-existing, unrelated to name spans.
- **Emit** (`emit/run.sh`): **0 delta** — the 14 known failures and the held counts (JS 11562, DTS 1377) are byte-identical between this head and a base `tsz` binary.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high