### PR TITLE
fix(checker): TS2456 for indexed access into a self-referencing mapped type

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -762,6 +762,9 @@ path = "tests/type_alias_namespace_merge_tests.rs"
 name = "keyof_self_circular_alias_tests"
 path = "tests/keyof_self_circular_alias_tests.rs"
 [[test]]
+name = "indexed_mapped_type_self_circular_tests"
+path = "tests/indexed_mapped_type_self_circular_tests.rs"
+[[test]]
 name = "tuple_spread_circular_alias_tests"
 path = "tests/tuple_spread_circular_alias_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_circular.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_circular.rs
@@ -28,6 +28,35 @@ impl<'a> CheckerState<'a> {
         )
     }
 
+    /// True when `type_node` is an indexed access into a mapped type
+    /// (`{ [P in K]: X }[Key]`) at the alias's own top level.
+    ///
+    /// Indexing a mapped type at a literal key forces eager resolution of
+    /// that one property — the same "eager position" `keyof` already gets
+    /// elsewhere in this function — unlike an ordinary deferred object or
+    /// mapped-type property access. Oracle-verified: `type Rec = { [P in
+    /// "x"]: Rec }` is accepted (deferred recursion, a linked-list shape),
+    /// but `type Rec = { [P in "x"]: Rec }["x"]` is `TS2456`. This check is
+    /// purely syntactic (object side is a `MAPPED_TYPE` node); the caller
+    /// only reaches it after the type-level `Lazy` chain has already
+    /// confirmed the whole indexed access resolves back to the alias being
+    /// defined, so no separate key/template inspection is needed here.
+    fn type_node_is_indexed_mapped_type_self_access(&self, type_node: NodeIndex) -> bool {
+        let Some(node) = self.ctx.arena.get(type_node) else {
+            return false;
+        };
+        if node.kind != syntax_kind_ext::INDEXED_ACCESS_TYPE {
+            return false;
+        }
+        let Some(iat) = self.ctx.arena.get_indexed_access_type(node) else {
+            return false;
+        };
+        self.ctx
+            .arena
+            .get(iat.object_type)
+            .is_some_and(|obj_node| obj_node.kind == syntax_kind_ext::MAPPED_TYPE)
+    }
+
     /// Look through enclosing parentheses to the first non-parenthesized type
     /// node. Used by circular-alias detection so `(A<T>)` is treated like
     /// `A<T>`.
@@ -581,6 +610,7 @@ impl<'a> CheckerState<'a> {
                 }
             } else {
                 self.is_simple_type_reference(type_node)
+                    || self.type_node_is_indexed_mapped_type_self_access(type_node)
             };
 
             if is_direct {

--- a/crates/tsz-checker/tests/indexed_mapped_type_self_circular_tests.rs
+++ b/crates/tsz-checker/tests/indexed_mapped_type_self_circular_tests.rs
@@ -1,0 +1,73 @@
+//! Tests for TS2456 circular-type-alias detection through an indexed access
+//! into a self-referencing mapped type (`{ [P in K]: X }[Key]`).
+//!
+//! Indexing a mapped type at a literal key forces eager resolution of that
+//! one property, the same "eager position" `keyof` already gets — unlike an
+//! ordinary deferred object or mapped-type property access. Oracle-verified
+//! against `typescript@7.0.2`: `type Rec = { [P in "x"]: Rec }` (no indexing)
+//! is accepted as legitimate deferred recursion (a linked-list shape), but
+//! `type Rec = { [P in "x"]: Rec }["x"]` is `TS2456`. These tests lock that
+//! boundary, including renamed binders and adjacent non-circular shapes, so
+//! no name-literal drives the logic.
+
+use tsz_checker::test_utils::check_source_codes as get_error_codes;
+
+fn assert_ts2456(src: &str) {
+    let codes = get_error_codes(src);
+    assert!(
+        codes.contains(&2456),
+        "Expected TS2456 (circularly references itself) for:\n{src}\ngot: {codes:?}"
+    );
+}
+
+fn assert_no_ts2456(src: &str) {
+    let codes = get_error_codes(src);
+    assert!(
+        !codes.contains(&2456),
+        "Expected no TS2456 for:\n{src}\ngot: {codes:?}"
+    );
+}
+
+#[test]
+fn indexed_mapped_type_self_access_is_circular() {
+    assert_ts2456(r#"type Self = { [P in "x"]: Self }["x"]; declare const s: Self;"#);
+}
+
+#[test]
+fn renamed_binder_indexed_mapped_type_self_access_is_circular() {
+    // No dependence on a particular alias name.
+    assert_ts2456(r#"type Whatever = { [K in "a"]: Whatever }["a"];"#);
+    assert_ts2456(r#"type SomethingElse = { [Q in "z"]: SomethingElse }["z"];"#);
+}
+
+#[test]
+fn indexed_mapped_type_self_access_with_number_literal_key_is_circular() {
+    assert_ts2456("type Bar = { [K in 1]: Bar }[1];");
+}
+
+#[test]
+fn indexed_mapped_type_self_access_with_multi_key_constraint_is_circular() {
+    assert_ts2456(r#"type Rec = { [P in "x" | "y"]: Rec }["x"]; declare const r: Rec;"#);
+}
+
+#[test]
+fn indexed_mapped_type_self_access_via_keyof_full_domain_is_circular() {
+    assert_ts2456(r#"type All = { [K in "a"]: All }[keyof { [K in "a"]: All }];"#);
+}
+
+#[test]
+fn bare_mapped_type_self_reference_without_indexing_is_not_circular() {
+    // Legitimate deferred recursion (a linked-list shape) — no top-level
+    // indexed access to force eager resolution.
+    assert_no_ts2456(r#"type Rec = { [P in "x"]: Rec };"#);
+}
+
+#[test]
+fn plain_object_property_self_reference_is_not_circular() {
+    assert_no_ts2456("type Rec = { next: Rec };");
+}
+
+#[test]
+fn indexed_mapped_type_non_self_value_is_not_circular() {
+    assert_no_ts2456(r#"type Baz = { [K in "a"]: number }["a"]; declare const b: Baz;"#);
+}


### PR DESCRIPTION
Fixes half of #17028 (the missing-`TS2456` item; the spurious-`TS2589` item is a separate, deeper solver depth-guard calibration issue and is left open — see the NOTE this session posted on the board).

```ts
type Self = { [P in "x"]: Self }["x"];
declare const s: Self;
```

was silently accepted by tsz. `tsc 7.0.2` reports `TS2456: Type alias 'Self' circularly references itself.`

## Structural rule

When a type alias's body is a top-level **indexed access into a mapped type at a literal key** (`{ [P in K]: X }[Key]`), `tsc` treats that as an *eager* position — the same category `keyof` already gets — so a self-reference reached through it is a direct circularity (`TS2456`). This is unlike an ordinary deferred property/mapped-type reference: a *bare* `type Rec = { [P in "x"]: Rec };` (no top-level indexing) is accepted as legitimate deferred recursion (a linked-list shape), and tsz already got that case right.

Owner layer: checker (`crates/tsz-checker/src/state/type_analysis/computed_helpers_circular.rs`, `is_direct_circular_reference`). The existing eager-evaluation step at the type-alias computation site (`type_alias_variable_alias.rs`) collapses the indexed access down to the alias's own `Lazy` placeholder before circularity detection ever runs, so `is_direct_circular_reference`'s Lazy-chain branch was reached but its `is_simple_type_reference(type_node)` gate only recognized bare `type A = B;` references — not this indexed-access shape — and returned `false` early. Added `type_node_is_indexed_mapped_type_self_access`, a purely syntactic check (object side of the `INDEXED_ACCESS_TYPE` node is a `MAPPED_TYPE` node) that widens that gate. It's safe to key off syntax alone here because the caller only reaches this decision after the type-level `Lazy` chain has already confirmed the whole indexed access resolves back to the alias being defined — no separate key/template inspection is needed.

## Adjacent-case matrix (oracle-pinned, `typescript@7.0.2`)

- Renamed binders (`Whatever`, `SomethingElse`).
- Number-literal key (`{ [K in 1]: Bar }[1]`).
- Multi-key constraint, indexed at one member (`{ [P in "x" | "y"]: Rec }["x"]`).
- `keyof`-of-the-same-mapped-type as the index (full-domain indexed access).
- Negative controls (unaffected, confirmed against oracle):
  - Bare mapped-type self-reference with **no** top-level indexing — stays accepted (deferred recursion).
  - Plain object-property self-reference (`{ next: Rec }`) — stays accepted.
  - Indexed access into a mapped type whose value does **not** self-reference — stays accepted.

Known gap, deliberately out of scope (not the reported repro; angle brackets below written as `[ ]` since this board's API layer strips real `<`/`>` from PR body text): a self-referencing indexed-mapped-access nested inside a further generic wrapper (`Wrap[{ [K in "a"]: Qux }["a"]]`), and the fully generic form of this exact shape (`type Gen[T] = { [K in "a"]: Gen[T] }["a"]`, where `tsc` itself emits two diagnostics — `TS2456` *and* `TS2315`, an unusual double-diagnostic edge case). Both are structurally deeper variants beyond the alias's own top level; left for a follow-up if they turn out to matter for the corpus.

## Verification

- New test file `crates/tsz-checker/tests/indexed_mapped_type_self_circular_tests.rs`, registered in `Cargo.toml`: `cargo test -p tsz-checker --test indexed_mapped_type_self_circular_tests` — 8/8 passed.
- Existing circularity suites, 0 regressions: `cargo test -p tsz-checker --lib circular` (99/99), `--lib mapped_type` (96/96), `--lib type_alias` (243/243), plus the dedicated `keyof_self_circular_alias_tests`, `tuple_spread_circular_alias_tests`, `type_alias_typeof_circular_tests`, `generic_self_circular_alias_tests`, `typeof_self_referential_alias_termination_tests`, `ts2303_tests` integration suites — all pass.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings`: clean.
- `cargo fmt --check -p tsz-checker`: clean.
- `python3 scripts/arch/arch_guard.py`: passed (`computed_helpers_circular.rs` at 1943/2000 lines).
- CLI repro before/after: `TS2456` now fires on the reported shape and 5 adjacent-positive variants; stays clean on 3 adjacent-negative variants — all oracle-matched exactly (`typescript@7.0.2`).
- Not run: broader `conformance.sh` snapshot / `compare-to-parent.sh` (`TypeScript/` submodule not materialized this session, time budget) — flagging as owed rather than skipping silently. This is a same-file, non-generic circularity-detection change with no existing test asserting the old (wrong) behavior, and the dedicated regression suite above locks the new boundary precisely against the oracle.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT
