### PR TITLE
fix(parser): property-name node `end` no longer overshoots into the next token

### DIFF
--- a/crates/tsz-cli/tests/driver_tests_parts/part_14.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_14.rs
@@ -685,3 +685,177 @@ fn explicit_root_node_modules_js_require_reads_surface_node16() {
 fn explicit_root_node_modules_js_require_reads_surface_nodenext() {
     explicit_root_node_modules_js_require_reads_commonjs_surface("nodenext");
 }
+
+// ---------------------------------------------------------------------------
+// #17024: `parse_property_name_impl`'s identifier/keyword branch read
+// `token_end()` *after* `next_token()` had already advanced past the name, so
+// the shared property-name node's `end` overshot into whatever token follows
+// (e.g. the `(` after an accessor name). Since diagnostic ordering sorts by
+// `(start, length, code)`, the inflated length flipped the order between a
+// parser grammar diagnostic anchored on the name (TS1054/TS1049) and a
+// checker diagnostic anchored at the same `start` (TS2378/TS7032). Every
+// expectation below is oracle-verified against `typescript@7.0.2`.
+// ---------------------------------------------------------------------------
+
+/// Returns `(start, length)` for the first diagnostic with `code`.
+fn first_diagnostic_span(
+    diagnostics: &[tsz_common::diagnostics::Diagnostic],
+    code: u32,
+) -> (u32, u32) {
+    let diag = diagnostics
+        .iter()
+        .find(|d| d.code == code)
+        .unwrap_or_else(|| panic!("expected code {code}, got: {diagnostics:#?}"));
+    (diag.start, diag.length)
+}
+
+#[test]
+fn get_accessor_ts1054_span_does_not_overshoot_into_the_parameter_list() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = temp.path.as_path();
+    write_file(
+        &base.join("index.ts"),
+        "class Cq30 { get xq30(vq30: number): string { return \"\"; } }\n",
+    );
+
+    let args = parse_args(&["tsz", "--noEmit", "--strict", "index.ts"]);
+    let result = compile(&args, base).expect("compile should succeed");
+    let (_, length) = first_diagnostic_span(&result.diagnostics, 1054);
+    assert_eq!(
+        length, 4,
+        "TS1054 must span exactly the accessor name `xq30` (length 4), not overshoot into `(`; got: {:#?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn get_accessor_with_value_parameter_orders_ts1054_before_ts2378_matching_tsc() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = temp.path.as_path();
+    write_file(
+        &base.join("index.ts"),
+        "class Cr31 { get xr31(vr31: number): string {} }\n",
+    );
+
+    let args = parse_args(&["tsz", "--noEmit", "--strict", "index.ts"]);
+    let result = compile(&args, base).expect("compile should succeed");
+
+    let (ts1054_start, ts1054_len) = first_diagnostic_span(&result.diagnostics, 1054);
+    let (ts2378_start, ts2378_len) = first_diagnostic_span(&result.diagnostics, 2378);
+    assert_eq!(
+        ts1054_start, ts2378_start,
+        "TS1054 and TS2378 must anchor at the same start (the accessor name)"
+    );
+    assert_eq!(
+        ts1054_len, ts2378_len,
+        "TS1054 and TS2378 must share the same span length (both anchor on `name`)"
+    );
+
+    let ts1054_index = result
+        .diagnostics
+        .iter()
+        .position(|d| d.code == 1054)
+        .unwrap();
+    let ts2378_index = result
+        .diagnostics
+        .iter()
+        .position(|d| d.code == 2378)
+        .unwrap();
+    assert!(
+        ts1054_index < ts2378_index,
+        "tsc's (start, length, code) ordering puts TS1054 before TS2378 at an equal span; got order: {:#?}",
+        result.diagnostics
+    );
+}
+
+/// Same shape with every binder renamed, to rule out a name-string match.
+#[test]
+fn get_accessor_with_value_parameter_orders_ts1054_before_ts2378_renamed_binders() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = temp.path.as_path();
+    write_file(
+        &base.join("index.ts"),
+        "class ContainerS32 { get widthS32(inputS32: number): string {} }\n",
+    );
+
+    let args = parse_args(&["tsz", "--noEmit", "--strict", "index.ts"]);
+    let result = compile(&args, base).expect("compile should succeed");
+
+    let ts1054_index = result
+        .diagnostics
+        .iter()
+        .position(|d| d.code == 1054)
+        .unwrap_or_else(|| panic!("expected TS1054, got: {:#?}", result.diagnostics));
+    let ts2378_index = result
+        .diagnostics
+        .iter()
+        .position(|d| d.code == 2378)
+        .unwrap_or_else(|| panic!("expected TS2378, got: {:#?}", result.diagnostics));
+    assert!(
+        ts1054_index < ts2378_index,
+        "renamed binders must not change the (start, length, code) ordering; got: {:#?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn set_accessor_with_no_parameters_orders_ts1049_before_ts7032_matching_tsc() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = temp.path.as_path();
+    write_file(
+        &base.join("index.ts"),
+        "class Ct33 { set yt33() {} }\n",
+    );
+
+    let args = parse_args(&["tsz", "--noEmit", "--strict", "index.ts"]);
+    let result = compile(&args, base).expect("compile should succeed");
+
+    let (ts1049_start, ts1049_len) = first_diagnostic_span(&result.diagnostics, 1049);
+    let (ts7032_start, ts7032_len) = first_diagnostic_span(&result.diagnostics, 7032);
+    assert_eq!(
+        ts1049_start, ts7032_start,
+        "TS1049 and TS7032 must anchor at the same start (the accessor name)"
+    );
+    assert_eq!(
+        ts1049_len, ts7032_len,
+        "TS1049 and TS7032 must share the same span length (both anchor on `name`)"
+    );
+
+    let ts1049_index = result
+        .diagnostics
+        .iter()
+        .position(|d| d.code == 1049)
+        .unwrap();
+    let ts7032_index = result
+        .diagnostics
+        .iter()
+        .position(|d| d.code == 7032)
+        .unwrap();
+    assert!(
+        ts1049_index < ts7032_index,
+        "tsc's (start, length, code) ordering puts TS1049 before TS7032 at an equal span; got order: {:#?}",
+        result.diagnostics
+    );
+}
+
+/// A `set` accessor's own `name.end` (not the accessor family's shared
+/// helper) is exercised the same way in a type-literal member, confirming
+/// the fix is not scoped to class members alone.
+#[test]
+fn type_literal_set_accessor_ts1049_span_does_not_overshoot() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = temp.path.as_path();
+    write_file(
+        &base.join("index.ts"),
+        "type Tv35 = { set yv35(av35: number, bv35: number): void };\n",
+    );
+
+    let args = parse_args(&["tsz", "--noEmit", "--strict", "index.ts"]);
+    let result = compile(&args, base).expect("compile should succeed");
+    let (_, length) = first_diagnostic_span(&result.diagnostics, 1049);
+    assert_eq!(
+        length, 4,
+        "TS1049 must span exactly the accessor name `yv35` (length 4), not overshoot into `(`; got: {:#?}",
+        result.diagnostics
+    );
+}

--- a/crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs
@@ -1235,8 +1235,11 @@ impl ParserState {
                     } else {
                         None
                     };
-                self.next_token(); // Accept any token as property name (error recovery)
+                // Capture the name token's own end before `next_token()` advances past it —
+                // `token_end()` after the call would report the end of the *next* token
+                // instead (mirrors the computed-name branch's `]`-end capture above).
                 let end_pos = self.token_end();
+                self.next_token(); // Accept any token as property name (error recovery)
 
                 self.arena.add_identifier(
                     SyntaxKind::Identifier as u16,


### PR DESCRIPTION
Fixes #17024.

## Structural rule

`parse_property_name_impl`'s identifier/keyword branch (`crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs`) read `token_end()` *after* `next_token()` had already advanced past the property name, so the shared property-name node's `end` overshot to the end of whatever token follows (e.g. the `(` after an accessor name). The computed-name branch a few lines above already captures its end before advancing; the identifier branch did not.

When a diagnostic anchors on a property/member name node via `name.end - name.pos`, tsc's `grammarErrorOnNode(accessor.name, ...)` reports the name's own width; tsz must capture that width before advancing past the name, through the shared `parse_property_name_impl` — not doing so is a span bug, not merely cosmetic.

## Why it is observable

`compareDiagnostics` orders by `(start, length, code)` — length is a tie-breaker before code. When a parser grammar diagnostic (TS1054/TS1049) and a checker diagnostic (TS2378/TS7032) share the accessor name's `start`, the overshoot gave the grammar diagnostic a longer `length`, so it sorted *after* the checker diagnostic instead of interleaving by code. It also rendered a too-wide underline.

Fix: capture the name's `token_end()` before `next_token()` (mirrors the computed-name branch's `]`-end capture a few lines above).

## Adjacent cases (owner layer: parser, `crates/tsz-parser`)

Oracle-verified against pinned `typescript@7.0.2` and pinned as 5 new regression tests in `crates/tsz-cli/tests/driver_tests_parts/part_14.rs`:

- Exact span length: `class C { get x(v: number): string { return ""; } }` — TS1054 spans exactly the 1-char name, not `x(`.
- Ordering: `class C { get x(v: number): string {} }` — TS1054 before TS2378 at equal `(start, length)`.
- Same ordering with every binder renamed, to rule out a name-string match.
- Ordering: `class C { set y() {} }` — TS1049 before TS7032 at equal `(start, length)`.
- Type-literal (non-class) `set` accessor signature — confirms the fix is not scoped to class members alone.

All 5 tests fail on the pre-fix parser and pass after the fix (verified by reverting the parser hunk locally and re-running).

Display/ordering only — no diagnostic code is added or removed, so a code-set conformance comparison cannot see this (same invisibility class as #16509).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-parser --lib`: 2213/2213 (no regressions; includes the full `accessor_signature_parameter_list_tests` module, which is `#[path]`-included into the lib).
- `cargo test -p tsz-cli --lib`: 1794 passed / 19 failed, all 19 pre-existing and unrelated — confirmed by reverting just the parser hunk and re-running the identical filter sets:
  - 2 are known-failures.txt entries (`cross_file_class_namespace_merge_value_keeps_call_signature_in_import_cycle`, `default_lib_validation_normalizes_cross_arena_method_members_after_global_merge`).
  - 14 are `tsc_compat_tests::*` — this container has a real `tsc` on `PATH`, and those tests diff tsz's CLI output against it; they fail identically with the parser change reverted.
  - 1 is `compile_incremental_reports_ts5033_when_tsbuildinfo_is_not_writable`, a root/sandbox write-permission artifact unrelated to parsing.
  - 2 are `driver_tests` entries already tracked in `scripts/ci/known-failures.txt:140-141`.
  - The 5 new regression tests for this fix pass.
- `cargo clippy -p tsz-parser -p tsz-cli --lib --tests --profile ci-lint`: clean.
- `cargo fmt --check -p tsz-parser -p tsz-cli`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.
- Conformance: not run — this is a display/ordering-only change with no fixture in the corpus reaching this exact shape (per #17024), so it cannot move the code-set count either way.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqgykDjqveehZsTwafXQen)_