### PR TITLE
fix(bench): required-set coverage signal so an unmeasured required row can't pass as a green run

### DIFF
--- a/scripts/bench/check-artifact-readiness.mjs
+++ b/scripts/bench/check-artifact-readiness.mjs
@@ -11,6 +11,8 @@
  *       application rows (canary application gaps are advisory, never blocking),
  *       --require-green-project-timing-pairs found green perf-timed rows
  *       missing tsz/tsgo timing pairs,
+ *       --require-required-coverage found declared benchmark_set:"required" rows
+ *       absent from the artifact,
  *       or the --require-source-current gate found a stale artifact source commit
  *   2 — artifact file absent or unparseable
  *
@@ -22,7 +24,7 @@
  * is absent (exit 2) so callers reliably get machine-readable status in all cases.
  *
  * Usage:
- *   node scripts/bench/check-artifact-readiness.mjs [--json] [--require-green] [--require-clean-metadata] [--require-application-compat] [--require-green-project-timing-pairs] [--require-project-timing-pairs[=<n>]] [--expect-source-commit=<sha>] [--require-source-current] <artifact.json>
+ *   node scripts/bench/check-artifact-readiness.mjs [--json] [--require-green] [--require-clean-metadata] [--require-application-compat] [--require-green-project-timing-pairs] [--require-required-coverage] [--require-project-timing-pairs[=<n>]] [--expect-source-commit=<sha>] [--require-source-current] <artifact.json>
  */
 
 import fs from "node:fs";
@@ -38,6 +40,7 @@ import { BENCH_RUNNER_EXCLUDED_ROWS } from "./project-row-summary.mjs";
 import {
   hasCompletePhaseMetadata,
   isGreen,
+  missingDeclaredRows,
 } from "./row-utils.mjs";
 import { measurementProfileStatus } from "./measurement-profile.mjs";
 
@@ -102,6 +105,7 @@ function parseArgs(rawArgs) {
     requireCleanMetadata: false,
     requireApplicationCompat: false,
     requireGreenProjectTimingPairs: false,
+    requireRequiredCoverage: false,
     requireSourceCurrent: false,
     requiredProjectTimingPairs: 0,
     expectedSourceCommit: process.env.TSZ_BENCH_EXPECT_SOURCE_COMMIT ?? null,
@@ -120,6 +124,8 @@ function parseArgs(rawArgs) {
       options.requireApplicationCompat = true;
     } else if (arg === "--require-green-project-timing-pairs") {
       options.requireGreenProjectTimingPairs = true;
+    } else if (arg === "--require-required-coverage") {
+      options.requireRequiredCoverage = true;
     } else if (arg === "--require-source-current") {
       options.requireSourceCurrent = true;
     } else if (arg === "--require-project-timing-pairs") {
@@ -151,6 +157,7 @@ const {
   requireCleanMetadata,
   requireApplicationCompat,
   requireGreenProjectTimingPairs,
+  requireRequiredCoverage,
   requireSourceCurrent,
   requiredProjectTimingPairs: rawRequiredProjectTimingPairs,
   expectedSourceCommit: rawExpectedSourceCommit,
@@ -418,7 +425,31 @@ function analyzeArtifact(artifact, expectedCommit) {
   const blockingApplicationGaps = applicationGaps.filter((r) => isBlockingApplicationRow(r.name));
   const advisoryApplicationGaps = applicationGaps.filter((r) => !isBlockingApplicationRow(r.name));
 
+  // Required-set coverage (#17025): every declared benchmark_set:"required" row
+  // that carries no result row at all. This is a PRESENCE check over the full
+  // required set, strictly wider than REQUIRED_MEASURED_ROWS (which drops the
+  // never-timed excluded/application rows): a required row can stop being
+  // measured indefinitely — no timing shard, no compile-guard compat — and pass
+  // the shard-count gate as a `completed` run with a smaller results array. The
+  // artifact's own run_status is surfaced alongside so a merge-stamped `partial`
+  // is visible in the readiness report.
+  // Recomputed from the persisted results rather than trusting the merge-written
+  // validation.missing_required_rows: the readiness gate independently re-judges
+  // an arbitrary artifact (as it does for every other row signal) so a stale or
+  // wrong-version merge cannot self-certify. No all-absent guard here — unlike
+  // the per-shard merge, readiness always sees the final merged artifact, so an
+  // empty/degenerate one legitimately reports the whole required set absent.
+  const missingRequiredCoverageRows = missingDeclaredRows(REQUIRED_PROJECT_ROWS, artifact?.results);
+  const requiredCoverage = {
+    declared: REQUIRED_PROJECT_ROWS.length,
+    present: REQUIRED_PROJECT_ROWS.length - missingRequiredCoverageRows.length,
+    missing: missingRequiredCoverageRows.length,
+    missing_rows: missingRequiredCoverageRows,
+    run_status: artifact?.run_status ?? null,
+  };
+
   return {
+    requiredCoverage,
     measurementProfile: measurementProfileStatus(artifact),
     validationWarnings: analyzeValidationWarnings(artifact),
     sourceFreshness: analyzeSourceFreshness(artifact, expectedCommit),
@@ -459,6 +490,7 @@ function buildJson({
   artifactAbsent,
   parseError,
   artifact,
+  requiredCoverage,
   measurementProfile,
   validationWarnings,
   sourceFreshness,
@@ -511,6 +543,11 @@ function buildJson({
     },
     metadata_clean: metadataWarningsList.length === 0,
     metadata_warnings_total: metadataWarningsList.length,
+    // Full declared benchmark_set:"required" presence coverage (#17025), wider
+    // than the required-timing row set below. `run_status` echoes the artifact's
+    // own merge-stamped status (`partial` when the merge saw the same gap). Null
+    // only on the artifact-absent path, alongside `measurement_profile` below.
+    required_coverage: requiredCoverage ?? null,
     required_row_count: rows?.length ?? REQUIRED_MEASURED_ROWS.length,
     successful_project_timing_pairs: successfulProjectTimingPairs?.length ?? 0,
     required_project_timing_pairs: requiredProjectTimingPairs,
@@ -668,6 +705,7 @@ function artifactAge(generatedAt) {
 
 function buildReport({
   artifact,
+  requiredCoverage,
   measurementProfile,
   validationWarnings,
   sourceFreshness,
@@ -717,6 +755,7 @@ function buildReport({
     `| PGO training | ${profile.training_fingerprint ? `\`${profile.training_fingerprint.slice(0, 12)}\`` : "—"} |`,
     `| Binary target CPU | ${profile.rust_target_cpu ? `\`${profile.rust_target_cpu}\`` : "—"} |`,
     `| Required rows | ${rows.length} |`,
+    `| Required-set coverage | ${requiredCoverage.present}/${requiredCoverage.declared} declared present${requiredCoverage.missing ? ` (${requiredCoverage.missing} absent)` : ""}${requiredCoverage.run_status ? ` · run status: ${requiredCoverage.run_status}` : ""} |`,
     `| Successful project timing pairs | ${successfulProjectTimingPairs.length} |`,
     `| Green perf-timed rows missing timing | ${greenTimedRowsMissingTimingPairs.length} |`,
     `| Application compatibility rows | ${applicationRows.length - applicationMissing.length}/${applicationRows.length} present, ${applicationIncomplete.length} incomplete |`,
@@ -734,6 +773,17 @@ function buildReport({
   if (missing.length > 0) {
     lines.push(`### 🚫 Missing required rows (${missing.length})`, "");
     for (const r of missing) lines.push(`- \`${r.name}\``);
+    lines.push("");
+  }
+
+  if (requiredCoverage.missing > 0) {
+    lines.push(
+      `### 📉 Required-set coverage gap (${requiredCoverage.missing})`,
+      "",
+      `Declared \`benchmark_set:"required"\` rows with no result row in the artifact — never measured by any shard, so "the benchmark is green" excludes them (#17025):`,
+      "",
+    );
+    for (const name of requiredCoverage.missing_rows) lines.push(`- \`${name}\``);
     lines.push("");
   }
 
@@ -851,6 +901,7 @@ if (artifactAbsent || parseError) {
         artifactAbsent: true,
         parseError,
         artifact: null,
+        requiredCoverage: null,
         measurementProfile: null,
         sourceFreshness: null,
         rows: null,
@@ -878,6 +929,7 @@ if (artifactAbsent || parseError) {
 
 const analysis = analyzeArtifact(artifact, expectedSourceCommit);
 const {
+  requiredCoverage,
   measurementProfile,
   validationWarnings,
   sourceFreshness,
@@ -908,6 +960,7 @@ if (jsonOutput) {
       artifactAbsent: false,
       parseError: null,
       artifact,
+      requiredCoverage,
       measurementProfile,
       validationWarnings,
       sourceFreshness,
@@ -1023,6 +1076,20 @@ if (requireGreenProjectTimingPairs && blockingTimedRowsMissingTimingPairs.length
   process.stderr.write(
     `bench-artifact-readiness: ${blockingTimedRowsMissingTimingPairs.length} required perf-timed project row(s) ` +
       `missing tsz/tsgo timing pairs: ${blockingTimedRowsMissingTimingPairs.map((r) => r.name).join(", ")}\n`,
+  );
+  process.exit(1);
+}
+
+// Required-set coverage is always surfaced (report + JSON) and the merge step
+// already downgrades run_status to `partial`, but blocking on it is opt-in:
+// today `nextjs` and `type-challenges-solutions-project` have no measurement
+// path, so a default-on gate would freeze every publish (the #14398/#15004
+// anti-freeze contract). A caller that has given the full required set a
+// measurement path can pass --require-required-coverage to enforce it.
+if (requireRequiredCoverage && requiredCoverage.missing > 0) {
+  process.stderr.write(
+    `bench-artifact-readiness: ${requiredCoverage.missing} declared benchmark_set:"required" row(s) ` +
+      `absent from artifact: ${requiredCoverage.missing_rows.join(", ")}\n`,
   );
   process.exit(1);
 }

--- a/scripts/bench/merge-results.mjs
+++ b/scripts/bench/merge-results.mjs
@@ -9,7 +9,7 @@ import {
   REQUIRED_PROJECT_ROWS,
 } from "./project-rows.mjs";
 import { BENCH_RUNNER_EXCLUDED_ROWS } from "./project-row-summary.mjs";
-import { isGreen } from "./row-utils.mjs";
+import { isGreen, missingDeclaredRows } from "./row-utils.mjs";
 
 const REQUIRED_PROJECT_ROW_SET = new Set(REQUIRED_PROJECT_ROWS);
 // Application rows (real apps cloned + installed) are NEVER timed by the
@@ -471,13 +471,28 @@ function validateMeasurementProfileConsistency(profiles) {
 // actually carrying at least one corpus row so unrelated timing-only/standalone
 // artifacts are not spuriously advised against the whole corpus.
 function collectMissingCorpusRows(rows) {
-  const measuredNames = new Set(rows.map((row) => row?.name).filter(Boolean));
-  if (!COMPATIBILITY_CORPUS_ROW_NAMES.some((name) => measuredNames.has(name))) {
+  const missing = missingDeclaredRows(COMPATIBILITY_CORPUS_ROW_NAMES, rows);
+  // Skip an artifact carrying none of the corpus rows (a timing-only/standalone
+  // shard) so it is not spuriously advised against the whole corpus.
+  if (missing.length === COMPATIBILITY_CORPUS_ROW_NAMES.length) {
     return [];
   }
-  return COMPATIBILITY_CORPUS_ROW_NAMES
-    .filter((name) => !measuredNames.has(name))
-    .map((name) => `${name}: missing project row`);
+  return missing.map((name) => `${name}: missing project row`);
+}
+
+// Enumerate the declared `benchmark_set:"required"` rows absent from the
+// measured results — the required-set coverage check the shard-count gate
+// cannot see (#17025). A required row that produces NO result row at all (never
+// measured by any shard, its compile-guard compat JSONL absent) passes the
+// shard gate as a `completed` run with a silently smaller `results` array, so
+// "the benchmark is green" degrades to "the rows that reported are green". This
+// is isolated from `collectMissingCorpusRows` above (which spans the FULL corpus
+// as an advisory) because the required subset is the one whose absence must
+// change the artifact's own `run_status`. Shares the same all-absent guard so a
+// standalone/timing-only shard is never flagged against the whole required set.
+function collectMissingRequiredRows(rows) {
+  const missing = missingDeclaredRows(REQUIRED_PROJECT_ROWS, rows);
+  return missing.length === REQUIRED_PROJECT_ROWS.length ? [] : missing;
 }
 
 function collectProjectCompatibilityFailures(rows) {
@@ -560,9 +575,21 @@ function githubRunUrl(runId) {
   return `${serverUrl}/${repository}/actions/runs/${runId}`;
 }
 
-function mergedArtifactMetadata(payloads, generatedAt) {
+function mergedArtifactMetadata(payloads, generatedAt, missingRequiredRows = []) {
   const payloadMetadata = payloads.find(({ payload }) => payload?.source_commit)?.payload;
   const runId = firstNonLocal(payloadMetadata?.workflow_run_id, process.env.GITHUB_RUN_ID, "local");
+  let runStatus = firstNonLocal(
+    payloadMetadata?.run_status,
+    process.env.GITHUB_ACTIONS === "true" ? "completed" : "local",
+  );
+  // A required-set coverage gap must not masquerade as a clean `completed` run:
+  // downgrade to `partial` so the published artifact self-signals that part of
+  // the declared benchmark_set:"required" set was never measured (#17025). Only
+  // `completed` is downgraded — a `local` snapshot is already non-authoritative,
+  // and an upstream `partial`/error status is preserved as the stronger signal.
+  if (missingRequiredRows.length > 0 && runStatus === "completed") {
+    runStatus = "partial";
+  }
   return {
     generated_at: generatedAt,
     source_commit: firstNonLocal(
@@ -575,10 +602,7 @@ function mergedArtifactMetadata(payloads, generatedAt) {
     workflow_run_id: runId,
     workflow_run_url: firstNonLocal(payloadMetadata?.workflow_run_url, githubRunUrl(runId)),
     workflow_run_attempt: firstNonEmpty(payloadMetadata?.workflow_run_attempt, process.env.GITHUB_RUN_ATTEMPT),
-    run_status: firstNonLocal(
-      payloadMetadata?.run_status,
-      process.env.GITHUB_ACTIONS === "true" ? "completed" : "local",
-    ),
+    run_status: runStatus,
   };
 }
 
@@ -654,6 +678,21 @@ function main() {
     compatibilityJsonlFiles,
   );
 
+  // Required-set coverage: which declared benchmark_set:"required" rows never
+  // produced a result row. Non-blocking (never freezes the publish, per the
+  // #14398/#15004 anti-freeze contract) but it downgrades run_status to
+  // `partial` and is recorded in the artifact so the gap can never again pass as
+  // a silent `completed` run (#17025).
+  const missingRequiredRows = collectMissingRequiredRows(results);
+  if (missingRequiredRows.length > 0) {
+    console.warn(
+      `::warning::${missingRequiredRows.length} declared benchmark_set:"required" row(s) absent from the merged artifact; run_status downgraded to "partial":`,
+    );
+    for (const name of missingRequiredRows) {
+      console.warn(`  - ${name}: missing required row`);
+    }
+  }
+
   const { blocking: compatBlocking, advisory: compatAdvisory } = collectProjectCompatibilityFailures(results);
   compatAdvisory.push(...collectMissingCorpusRows(results));
   if (compatAdvisory.length > 0) {
@@ -709,7 +748,7 @@ function main() {
   }
 
   const merged = {
-    ...mergedArtifactMetadata(payloads, new Date().toISOString()),
+    ...mergedArtifactMetadata(payloads, new Date().toISOString(), missingRequiredRows),
     benchmark_runner: BENCHMARK_RUNNER,
     merged_from: payloads.map(({ file }) => path.basename(file)).sort(),
     validation: {
@@ -719,6 +758,7 @@ function main() {
       runner_environment_warnings: runnerEnvironmentWarnings,
       measurement_profile_warnings: measurementProfileWarnings,
       project_compatibility_advisory: compatAdvisory,
+      missing_required_rows: missingRequiredRows,
       runner_signature_advisory: runnerSignatureAdvisory,
       dropped_empty_shards: droppedEmptyShards.map(({ file, payload }) => ({
         file: path.basename(file),

--- a/scripts/bench/row-utils.mjs
+++ b/scripts/bench/row-utils.mjs
@@ -13,6 +13,17 @@ export function hasCompletePhaseMetadata(compatibility) {
   return REQUIRED_PHASE_EXIT_FIELDS.every((field) => Object.hasOwn(compatibility, field));
 }
 
+// The declared row names (from any benchmark_set/guard_set/corpus name list)
+// that have no result row in `rows`, preserving `declaredNames` order. This is
+// the raw "declared minus measured" primitive shared by the corpus advisory, the
+// required-coverage signal, and the readiness gate. It applies NO all-absent
+// guard: a caller that must not flag a shard carrying none of the declared rows
+// (a standalone/timing-only shard) applies that guard itself.
+export function missingDeclaredRows(declaredNames, rows) {
+  const measuredNames = new Set((rows ?? []).map((row) => row?.name).filter(Boolean));
+  return declaredNames.filter((name) => !measuredNames.has(name));
+}
+
 // A row is green when it succeeded (no status error, not artifact_missing) and
 // either has no compatibility object at all (single-file rows are always
 // eligible) or has a complete green compatibility object.

--- a/scripts/bench/test-check-artifact-readiness.mjs
+++ b/scripts/bench/test-check-artifact-readiness.mjs
@@ -1066,4 +1066,62 @@ withTempDir((dir) => {
 });
 console.log("✅ multiple missing rows all named in report");
 
+// ---------------------------------------------------------------------------
+// Test (#17025): required-set coverage. A declared benchmark_set:"required" row
+// that the bench runner never measures (BENCH_RUNNER_EXCLUDED_ROWS, e.g.
+// type-challenges-solutions-project) is absent from REQUIRED_MEASURED_ROWS, so
+// its absence does NOT trip the default missing-required-row gate — but it IS
+// reported in required_coverage, and the artifact's merge-stamped run_status is
+// echoed through.
+const COVERAGE_EXCLUDED_ROW = "type-challenges-solutions-project";
+assert.ok(
+  ALL_REQUIRED_PROJECT_ROWS.includes(COVERAGE_EXCLUDED_ROW) &&
+    !REQUIRED_PROJECT_ROWS.includes(COVERAGE_EXCLUDED_ROW),
+  "test fixture expects a declared-required row that the readiness timing gate excludes",
+);
+withTempDir((dir) => {
+  const file = path.join(dir, "bench.json");
+  const rows = ALL_REQUIRED_PROJECT_ROWS.filter((n) => n !== COVERAGE_EXCLUDED_ROW).map((n) =>
+    makeRow(n, "green"),
+  );
+  writeJson(file, makeArtifact(rows, { run_status: "partial" }));
+  const jsonRes = run(file, ["--json"]);
+  assert.equal(jsonRes.status, 0, `excluded-row absence must not block by default: ${jsonRes.stderr}`);
+  const json = JSON.parse(jsonRes.stdout);
+  assert.equal(json.required_coverage.declared, ALL_REQUIRED_PROJECT_ROWS.length);
+  assert.equal(json.required_coverage.missing, 1);
+  assert.deepEqual(json.required_coverage.missing_rows, [COVERAGE_EXCLUDED_ROW]);
+  assert.equal(json.required_coverage.run_status, "partial");
+  assert.match(jsonRes.stderr, /Required-set coverage gap/);
+});
+console.log("✅ required-set coverage reports an unmeasured declared-required row (non-blocking)");
+
+// The opt-in --require-required-coverage flag turns an absent declared-required
+// row into a blocking failure for callers that have given the full set a
+// measurement path.
+withTempDir((dir) => {
+  const file = path.join(dir, "bench.json");
+  const rows = ALL_REQUIRED_PROJECT_ROWS.filter((n) => n !== COVERAGE_EXCLUDED_ROW).map((n) =>
+    makeRow(n, "green"),
+  );
+  writeJson(file, makeArtifact(rows));
+  const res = run(file, ["--require-required-coverage"]);
+  assert.equal(res.status, 1, "opt-in coverage gate must block on an absent declared-required row");
+  assert.match(res.stderr, new RegExp(COVERAGE_EXCLUDED_ROW));
+});
+console.log("✅ --require-required-coverage blocks on an absent declared-required row");
+
+// A complete declared-required set clears the coverage gate under the opt-in flag.
+withTempDir((dir) => {
+  const file = path.join(dir, "bench.json");
+  const rows = ALL_REQUIRED_PROJECT_ROWS.map((n) => makeRow(n, "green"));
+  writeJson(file, makeArtifact(rows));
+  const jsonRes = run(file, ["--json", "--require-required-coverage"]);
+  assert.equal(jsonRes.status, 0, `a complete required set must pass the coverage gate: ${jsonRes.stderr}`);
+  const json = JSON.parse(jsonRes.stdout);
+  assert.equal(json.required_coverage.missing, 0);
+  assert.deepEqual(json.required_coverage.missing_rows, []);
+});
+console.log("✅ complete required set passes --require-required-coverage");
+
 console.log("\nAll tests passed.");

--- a/scripts/bench/test-merge-results.mjs
+++ b/scripts/bench/test-merge-results.mjs
@@ -253,6 +253,73 @@ withTempDir((dir) => {
   );
 });
 
+// Issue #17025: required-set coverage. A CI run with the full declared
+// benchmark_set:"required" set present stays `completed` and records an empty
+// missing_required_rows list.
+const CI_ENV_OVERRIDES = {
+  BENCH_TARGET_SHA: "feedface1234567890",
+  GITHUB_ACTIONS: "true",
+  GITHUB_REPOSITORY: "tsz-org/tsz",
+  GITHUB_RUN_ATTEMPT: "1",
+  GITHUB_RUN_ID: "67890",
+  GITHUB_SERVER_URL: "https://github.com",
+  GITHUB_SHA: "badcafe1234567890",
+  GITHUB_WORKFLOW: "Bench",
+};
+
+withTempDir((dir) => {
+  const input = writeInput(
+    dir,
+    "input.json",
+    REQUIRED_PROJECT_ROWS.map((name) => projectRow(name)),
+    { run_status: "completed" },
+  );
+  const result = runMergeInputs(dir, [input], [], CI_ENV_OVERRIDES);
+  assert.equal(result.status, 0, result.stderr);
+  const merged = JSON.parse(fs.readFileSync(result.output, "utf8"));
+  assert.equal(merged.run_status, "completed");
+  assert.deepEqual(merged.validation.missing_required_rows, []);
+});
+
+// A CI run missing a declared required row downgrades run_status to `partial`,
+// records the absent row in validation.missing_required_rows, still publishes
+// (exit 0, artifact written), and surfaces a ::warning::. This closes the
+// reported gap: a `completed` run with a silently smaller results array.
+withTempDir((dir) => {
+  const missingRow = REQUIRED_PROJECT_ROWS[0];
+  const rows = REQUIRED_PROJECT_ROWS.filter((name) => name !== missingRow).map((name) =>
+    projectRow(name),
+  );
+  const input = writeInput(dir, "input.json", rows, { run_status: "completed" });
+  const result = runMergeInputs(dir, [input], [], CI_ENV_OVERRIDES);
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(fs.existsSync(result.output), "a partial required set must still publish");
+  assert.match(
+    result.stderr,
+    new RegExp(`::warning::[\\s\\S]*${missingRow}: missing required row`),
+  );
+  const merged = JSON.parse(fs.readFileSync(result.output, "utf8"));
+  assert.equal(merged.run_status, "partial");
+  assert.ok(
+    merged.validation.missing_required_rows.includes(missingRow),
+    "the absent required row must be recorded in validation.missing_required_rows",
+  );
+});
+
+// A standalone/timing-only shard carrying NO required rows must not be flagged
+// against the whole required set (the coverage check is gated on the artifact
+// actually carrying at least one required row), so its run_status is untouched.
+withTempDir((dir) => {
+  const input = writeInput(dir, "input.json", [projectRow("standalone")], {
+    run_status: "completed",
+  });
+  const result = runMergeInputs(dir, [input], [], CI_ENV_OVERRIDES);
+  assert.equal(result.status, 0, result.stderr);
+  const merged = JSON.parse(fs.readFileSync(result.output, "utf8"));
+  assert.equal(merged.run_status, "completed");
+  assert.deepEqual(merged.validation.missing_required_rows, []);
+});
+
 // Issue #16310: the missing-project-row advisory must span the FULL defined
 // compatibility corpus, not just REQUIRED_PROJECT_ROWS. A `category:"application"`
 // row (guard_set:"canary", never in REQUIRED) that is absent from every shard


### PR DESCRIPTION
Closes #17025.

A row declared `benchmark_set:"required"` that produces no result at all — never measured by any shard, its compile-guard compat JSONL absent — passes the shard-count gate as a `run_status:"completed"` run with a silently smaller `results` array. So "the benchmark is green" degrades to "the rows that reported are green", and a required row can stop being measured indefinitely with no signal (the same detection-gap family as the artifact-vs-published-URL one behind the 2026-06 outage).

Structural rule: when the merged benchmark artifact omits a declared `benchmark_set:"required"` row, the run is *not* complete; it must self-signal that partial coverage through the merge owner (`merge-results.mjs`), and the readiness gate (`check-artifact-readiness.mjs`) must independently re-derive and surface it. Delivered as a broad, always-on signal rather than a two-row patch:

- **`merge-results.mjs`** — the merged artifact self-describes required-set coverage. When any declared required row is absent from the measured results, `run_status` downgrades `completed → partial` and a machine-readable `validation.missing_required_rows` list is recorded (empty when complete). Non-blocking, so a chronically-unmeasured required row can never freeze the publish (the anti-freeze contract from #14398/#15004). Only `completed` is downgraded; `local` and an upstream `partial`/error status are preserved.
- **`check-artifact-readiness.mjs`** — adds a `required_coverage` block to the report and JSON (declared vs present, echoing the artifact's `run_status`), and an opt-in `--require-required-coverage` flag that makes absence blocking for callers that have given the full required set a measurement path. Consistent with the gate's defense-in-depth role, it re-derives the missing set from the persisted results rather than trusting the merge-written field.
- **`row-utils.mjs`** — extracts a shared `missingDeclaredRows(declaredNames, rows)` "declared minus measured" primitive; the corpus advisory, the required-coverage signal, and the readiness gate now share one definition.

Scope note: the two currently-absent rows (`nextjs` — `guard_set:null`, in `COMPILE_GUARD_EXCLUDED_ROWS`, not in the bench-runner set; `type-challenges-solutions-project` — in `BENCH_RUNNER_EXCLUDED_ROWS`) have no measurement path today, so they are genuinely unmeasured, not a rename. Wiring the full `vercel/next.js` clone into the timing runner is a separate, environment-heavy change; this PR makes the gap visible and machine-readable instead of silent, which is exactly the fix the issue requests.

## Goal
Goal: hold

## Verification
Local node tests (the affected suites; per-merge CI runs clippy + arch-size only, and these `.mjs` scripts are outside both):
- `node scripts/bench/test-merge-results.mjs` — pass (adds: full required set → `completed` + empty `missing_required_rows`; missing one → `partial` + recorded + warning + still publishes; standalone shard → untouched).
- `node scripts/bench/test-check-artifact-readiness.mjs` — pass (adds: unmeasured declared-required row reported but non-blocking by default; `--require-required-coverage` blocks; complete set passes).
- `node scripts/bench/test-row-utils.mjs`, `node scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs`, `node scripts/bench/test-check-latest-freshness.mjs` — pass (downstream consumers unaffected by the additive JSON fields).
- `git diff --stat`: 5 files, +256/-13; all files well under the 2000-line arch-size ceiling.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKm5H2Th2dwChGFyCn5qwm)_