### PR TITLE
fix(checker): drop the now-stale property-name overshoot compensation

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/js_grammar.rs
+++ b/crates/tsz-checker/src/state/state_checking/js_grammar.rs
@@ -397,13 +397,13 @@ impl<'a> CheckerState<'a> {
                         .arena
                         .get_method_decl(node)
                         .and_then(|method| self.ctx.arena.get(method.name))
-                        .map(|name| name.end.saturating_sub(1)),
+                        .map(|name| name.end),
                     syntax_kind_ext::PROPERTY_DECLARATION => self
                         .ctx
                         .arena
                         .get_property_decl(node)
                         .and_then(|prop| self.ctx.arena.get(prop.name))
-                        .map(|name| name.end.saturating_sub(1)),
+                        .map(|name| name.end),
                     _ => None,
                 };
                 if let Some(start) = optional_start {

--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -250,15 +250,10 @@ impl<'a> CheckerState<'a> {
             let is_abstract = self.has_abstract_modifier(&prop.modifiers);
             let has_declare = self.has_declare_modifier(&prop.modifiers);
 
-            // tsc points TS1255/TS1263/TS1264 at the `!` token itself.
-            // For class property names parsed via parse_property_name(), the name
-            // node's `end` is one past the `!` (due to end_pos being captured after
-            // next_token()). So the `!` is at name_node.end - 1.
-            let excl_pos = self
-                .ctx
-                .arena
-                .get(prop.name)
-                .map(|n| n.end.saturating_sub(1));
+            // tsc points TS1255/TS1263/TS1264 at the `!` token itself, which
+            // immediately follows the property name, i.e. at `name_node.end`
+            // (length 1) — the same anchor the variable-declaration arm uses.
+            let excl_pos = self.ctx.arena.get(prop.name).map(|n| n.end);
 
             // TS1255: ! is not permitted on static, abstract, ambient, or declared properties
             if in_ambient || is_static || is_abstract || has_declare {

--- a/crates/tsz-checker/tests/definite_assignment_tests/part_01.rs
+++ b/crates/tsz-checker/tests/definite_assignment_tests/part_01.rs
@@ -537,3 +537,39 @@ fn test_ts2454_assignment_in_nullish_coalescing_right_operand_still_reported() {
         "`??` right-operand assignment is not guaranteed evaluated, so TS2454 must still fire, got: {diags:?}"
     );
 }
+
+/// Regression: TS1255/TS1263/TS1264 must anchor on the `!` token itself
+/// (`grammarErrorOnNode`-equivalent, length 1), not on the property name.
+/// The `!` immediately follows the property name, so its position is
+/// `name_node.end`. This previously depended on the property-name parser
+/// overshooting its own node `end` by one (into the `!`) with the checker
+/// compensating via `end - 1` — when the parser overshoot was fixed
+/// (#17024), the compensation became a new off-by-one bug pointing at the
+/// last character of the name instead of the `!`. Binder names vary per row
+/// so no assertion keys on an identifier string.
+#[test]
+fn test_ts1263_anchors_at_exclamation_not_the_property_name() {
+    let source = "class Cq36 { pq36! = 1; }";
+    let diags = full_diagnostics_with_options(source, CheckerOptions::default());
+
+    let ts1263: Vec<_> = diags
+        .iter()
+        .filter(|d| {
+            d.code
+                == diagnostic_codes::DECLARATIONS_WITH_INITIALIZERS_CANNOT_ALSO_HAVE_DEFINITE_ASSIGNMENT_ASSERTIONS
+        })
+        .collect();
+    assert_eq!(ts1263.len(), 1, "unexpected diagnostics: {diags:#?}");
+
+    let excl = source.find('!').expect("definite assignment marker") as u32;
+    assert_eq!(
+        ts1263[0].start, excl,
+        "TS1263 must anchor at the '!' token, not the property name; got: {:#?}",
+        ts1263[0]
+    );
+    assert_eq!(
+        ts1263[0].length, 1,
+        "TS1263 must span exactly the '!' token; got: {:#?}",
+        ts1263[0]
+    );
+}


### PR DESCRIPTION
Fast-follow to #17037 (merged as `452c409`), which fixed `parse_property_name_impl` to stop overshooting a property-name node's `end` into the following token.

## What broke

Three checker sites were compensating for that overshoot by subtracting 1 from the name's `end` to land on the token immediately after the name (the `!` of a definite-assignment assertion, or the `?` of an optional class member in a JS file). With the parser fix landed, `name.end` is already the position immediately after the name, so the `- 1` compensation now lands one character short — inside the name itself instead of on the following token.

This is currently **failing on `main` right now**: `js_optional_class_elements_report_ts8009_at_question_token` (`crates/tsz-checker/tests/js_grammar_span_tests.rs`), a pre-existing pinned-position test, fails against `origin/main` at `452c409` — confirmed by running it directly against that commit before this fix.

## Oracle verification (`typescript@6.0.2`, on `PATH` in this container)

```
class C { a! = 1; }
  tsc:  TS1263 at the `!` (column 12)
  main (post-#17037, pre-this-fix): TS1263 at `a` (column 11) — WRONG

class C { m?() {} p?: number }   (as .js, allowJs+checkJs)
  tsc:  TS8009 at each `?` (columns 12, 20)
  main (post-#17037, pre-this-fix): TS8009 one column early (11, 19) — WRONG
```

## Fix

Drop the `saturating_sub(1)` / `- 1` compensation at the three sites that read a property/method name's `end` for a diagnostic anchored on the token immediately following the name:
- `crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs` (TS1255/TS1263/TS1264, the `!` token)
- `crates/tsz-checker/src/state/state_checking/js_grammar.rs` (TS8009, the `?` token — `METHOD_DECLARATION` and `PROPERTY_DECLARATION` arms; the `PARAMETER` arm was already using the un-compensated `name.end` and is unchanged)

## Adjacent case added

Added `test_ts1263_anchors_at_exclamation_not_the_property_name` (`crates/tsz-checker/tests/definite_assignment_tests/part_01.rs`) since the existing TS1263/TS1264 tests only asserted diagnostic *codes*, not positions — which is exactly why this regression weren't caught before #17037 merged. The existing `js_optional_class_elements_report_ts8009_at_question_token` already pins TS8009's position and is the regression test for that half.

Display/position only — no diagnostic code is added or removed.

## Related open PRs

Two other in-flight drafts target the same root cause (#17024) with a combined parser+checker diff: #17032 (parser-only, superseded now that the parser half is on `main` via #17037) and #17035 (parser + this exact checker compensation fix, independently derived). This PR carries only the checker-side delta needed on top of current `main`. Commenting on both to flag the overlap now that #17037 is merged.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test js_grammar_span_tests`: 10/10 passed (was 9/10 against `origin/main` `452c409` before this fix — `js_optional_class_elements_report_ts8009_at_question_token` failing).
- `cargo test -p tsz-checker --lib -- test_ts1263_anchors_at_exclamation_not_the_property_name`: passes (new test).
- `cargo clippy -p tsz-checker --lib --tests --profile ci-lint`: clean.
- `cargo fmt --check -p tsz-checker`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.
- Full `cargo test -p tsz-checker --lib` (10,900+ tests) was still running at PR-open time (long-tail suite); will report the full result as a follow-up comment rather than block this fix from going up given the live regression on `main`.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqgykDjqveehZsTwafXQen)_