### PR TITLE
fix(checker): widen round-1 literal inference before tagged-template round-2 contextual typing

### DIFF
--- a/crates/tsz-checker/src/types/computation/tagged_template.rs
+++ b/crates/tsz-checker/src/types/computation/tagged_template.rs
@@ -364,6 +364,19 @@ impl<'a> CheckerState<'a> {
                 };
 
                 // === Round 2: Type-check all substitutions with contextual types ===
+                // Widen literal types inferred from round 1 (e.g. a numeric
+                // literal argument binding `T := 10`) before using the
+                // substitution to seed a sensitive argument's contextual
+                // type — mirrors the regular call-argument two-pass path
+                // (`widen_round2_contextual_substitution`, used by
+                // `argument_collection.rs`). Without this, `T` stays pinned
+                // to the literal while the tag's final call resolution
+                // (a separate, later inference pass) widens it normally,
+                // producing a self-contradictory diagnostic where a
+                // callback's actual and expected types render identically
+                // but their nested literal-vs-widened members disagree.
+                let contextual_substitution =
+                    self.widen_round2_contextual_substitution(&evaluated_shape, &substitution);
                 let total_args = 1 + substitution_exprs.len();
                 let mut arg_types = Vec::with_capacity(total_args);
                 arg_types.push(TypeId::ANY);
@@ -371,7 +384,8 @@ impl<'a> CheckerState<'a> {
                     let ctx_type = ctx_helper
                         .get_parameter_type_for_call(i + 1, total_args)
                         .map(|pt| {
-                            let instantiated = instantiate_type(self.ctx.types, pt, &substitution);
+                            let instantiated =
+                                instantiate_type(self.ctx.types, pt, &contextual_substitution);
                             self.evaluate_type_with_env(instantiated)
                         });
                     let arg_request = if is_contextually_sensitive(self, expr_idx) {
@@ -596,5 +610,114 @@ impl<'a> CheckerState<'a> {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tagged_template_overload_literal_widening_tests {
+    use crate::test_utils::check_source_diagnostics;
+
+    // Oracle-pinned against `typescript@7.0.2` on
+    // `conformance/expressions/contextualTyping/parenthesizedContexualTyping3.ts`.
+    // Every case below is clean on tsc.
+
+    fn assert_no_ts2345(source: &str) {
+        let diags = check_source_diagnostics(source);
+        let ts2345: Vec<_> = diags.iter().filter(|d| d.code == 2345).collect();
+        assert!(
+            ts2345.is_empty(),
+            "expected no TS2345, got: {ts2345:?} (all diagnostics: {diags:?})"
+        );
+    }
+
+    const SINGLE_ARITY_TAG: &str = "
+function tempFun<T>(tempStrs: TemplateStringsArray, g: (x: T) => T, x: T): T {
+    return g(x);
+}
+";
+
+    #[test]
+    fn direct_pass_widens_round1_literal_before_seeding_sensitive_arg_context() {
+        assert_no_ts2345(&format!(
+            "{SINGLE_ARITY_TAG}\nvar a = tempFun`${{ x => x }}  ${{ 10 }}`;"
+        ));
+    }
+
+    #[test]
+    fn parenthesized_arrow_variants_are_unaffected() {
+        assert_no_ts2345(&format!(
+            "{SINGLE_ARITY_TAG}\nvar b = tempFun`${{ (x => x) }}  ${{ 10 }}`;"
+        ));
+        assert_no_ts2345(&format!(
+            "{SINGLE_ARITY_TAG}\nvar c = tempFun`${{ ((x => x)) }} ${{ 10 }}`;"
+        ));
+    }
+
+    #[test]
+    fn renamed_binder_and_type_param_are_unaffected() {
+        assert_no_ts2345(
+            "
+function stamp<Value>(strs: TemplateStringsArray, project: (received: Value) => Value, seed: Value): Value {
+    return project(seed);
+}
+var out = stamp`${ received => received }  ${ 10 }`;
+",
+        );
+    }
+
+    #[test]
+    fn overload_with_two_callback_params_widens_both() {
+        // Second overload: two `(x: T) => T` callbacks before the literal.
+        const TWO_CALLBACK_TAG: &str = "
+function tempFun<T>(tempStrs: TemplateStringsArray, g: (x: T) => T, x: T): T;
+function tempFun<T>(tempStrs: TemplateStringsArray, g: (x: T) => T, h: (y: T) => T, x: T): T;
+function tempFun<T>(tempStrs: TemplateStringsArray, g: (x: T) => T, x: T): T {
+    return g(x);
+}
+";
+        assert_no_ts2345(&format!(
+            "{TWO_CALLBACK_TAG}\nvar d = tempFun`${{ x => x }} ${{ x => x }} ${{ 10 }}`;"
+        ));
+        assert_no_ts2345(&format!(
+            "{TWO_CALLBACK_TAG}\nvar e = tempFun`${{ x => x }} ${{ (x => x) }} ${{ 10 }}`;"
+        ));
+        assert_no_ts2345(&format!(
+            "{TWO_CALLBACK_TAG}\nvar f = tempFun`${{ x => x }} ${{ ((x => x)) }} ${{ 10 }}`;"
+        ));
+        assert_no_ts2345(&format!(
+            "{TWO_CALLBACK_TAG}\nvar g = tempFun`${{ (x => x) }} ${{ (((x => x))) }} ${{ 10 }}`;"
+        ));
+    }
+
+    #[test]
+    fn nullish_literal_positional_argument_is_unaffected() {
+        const TWO_CALLBACK_TAG: &str = "
+function tempFun<T>(tempStrs: TemplateStringsArray, g: (x: T) => T, x: T): T;
+function tempFun<T>(tempStrs: TemplateStringsArray, g: (x: T) => T, h: (y: T) => T, x: T): T;
+function tempFun<T>(tempStrs: TemplateStringsArray, g: (x: T) => T, x: T): T {
+    return g(x);
+}
+";
+        assert_no_ts2345(&format!(
+            "{TWO_CALLBACK_TAG}\nvar h = tempFun`${{ (x => x) }} ${{ (((x => x))) }} ${{ undefined }}`;"
+        ));
+    }
+
+    #[test]
+    fn genuine_body_mismatch_still_reports_after_widening() {
+        // Negative control: the fix must widen the *contextual parameter type*
+        // fed to the callback, not silence real errors inside its body. Once
+        // `x` is correctly widened to `number`, `.length` on it is a genuine
+        // TS2339, proving the widened type actually reached the callback.
+        let diags = check_source_diagnostics(&format!(
+            "{SINGLE_ARITY_TAG}\nvar neg = tempFun`${{ x => x.length }} ${{ 10 }}`;"
+        ));
+        let ts2339: Vec<_> = diags.iter().filter(|d| d.code == 2339).collect();
+        assert_eq!(
+            ts2339.len(),
+            1,
+            "expected exactly one TS2339 from `.length` on the widened `number` \
+             parameter, got: {ts2339:?} (all diagnostics: {diags:?})"
+        );
     }
 }


### PR DESCRIPTION
When a generic tag function is applied to a tagged template with a context-sensitive substitution (an unannotated arrow) alongside a literal argument that feeds the same type parameter, `tsc` widens the literal candidate (`T := 10` becomes `T := number`) before using it as the contextual parameter type for the sensitive argument's second inference pass. The regular call-argument two-pass path already does this via `widen_round2_contextual_substitution` (`crates/tsz-checker/src/types/computation/call_inference.rs`), but the tagged-template two-pass path in `crates/tsz-checker/src/types/computation/tagged_template.rs` fed the raw, un-widened round-1 substitution straight into `instantiate_type` when building each sensitive argument's contextual type. `T` stayed pinned to the literal `10` while the tag's separate, later call-resolution pass widened it normally, producing a self-contradictory `TS2345` where the argument and parameter function types render identically as `(x: number) => number` but a nested member comparison disagrees (`number` vs `10`).

**Structural rule:** when a tagged-template tag function's round-1 inference binds a type parameter to a literal type, the round-2 contextual-typing pass must widen that literal (unless the type parameter's constraint preserves literals) before seeding a context-sensitive substitution expression's contextual type — through the same `widen_round2_contextual_substitution` owner already used by the regular call-argument path.

This fixes the row-2 residual of #17005 (`parenthesizedContexualTyping3.ts`, 7 spurious TS2345), which #17029 left open — that PR fixed a different mechanism (row 1) and its "Fixes #17005" wording auto-closed the issue before the row-2 comment (documenting the residual) landed. Reopened #17005 with evidence before picking this up; this PR closes it for real.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib` filtered to `tagged_template call_inference generic_call two_pass round2`: 251 passed, 0 failed. Includes 6 new tests (`tagged_template_overload_literal_widening_tests`) covering the full `parenthesizedContexualTyping3.ts` fixture family: direct/parenthesized arrow variants, renamed binders/type params, the two-callback overload arity, the nullish positional argument, and a negative control (`x => x.length`) proving the widened `number` type actually reaches the callback body rather than just silencing the diagnostic.
- Full `cargo test -p tsz-checker --lib` hit the suite's documented long-tail timeout on this container (a handful of named tests run long regardless of what changed; unrelated to this diff).
- `cargo clippy -p tsz-checker --lib -- -D warnings`: clean.
- `cargo fmt --check -p tsz-checker`: clean.
- CLI repro: `tsz --noEmit` on the full 8-line `parenthesizedContexualTyping3.ts` fixture (lines a–h) — exit 0 after the fix (was 7x TS2345 before), matching pinned `typescript@7.0.2` exactly.
- Not run: `compare-to-parent.sh` / broader conformance snapshot (time budget). Change is scoped to one new call site reusing an existing, already-unit-tested widening helper; the diagnostic-family risk is the same class the sibling regular-call path already carries and is covered by that path's own existing test suite (unaffected by this change — verified via the filtered run above).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpQfh4Qq15SDMko1J1UFK4)_