### PR TITLE
test(parser/checker/cli): pin property-name grammar-diagnostic spans and ordering (#17024 follow-up)

### DIFF
--- a/crates/tsz-checker/tests/js_grammar_span_tests.rs
+++ b/crates/tsz-checker/tests/js_grammar_span_tests.rs
@@ -310,3 +310,33 @@ fn js_module_declaration_ignores_namespace_word_in_comment_for_ts8006_text() {
         "expected TS8006 to identify a module declaration from parser flags. Actual diagnostics: {ts8006:#?}"
     );
 }
+
+/// A class property's definite-assignment diagnostics (TS1255/TS1263/TS1264)
+/// anchor on the `!` token, which immediately follows the property name — i.e.
+/// at `name_node.end`, length 1, exactly as `tsc` reports it and as the
+/// variable-declaration arm already does. This regressed once before: the
+/// property name is parsed via `parse_property_name`, whose node `end` used to
+/// overshoot the identifier, and the checker compensated with `end - 1`; when
+/// the parser overshoot was fixed the compensation had to go with it. Binder
+/// names vary per row so no assertion keys on an identifier string.
+#[test]
+fn class_property_definite_assignment_anchors_at_exclamation() {
+    let source = "class Cx { px! = 1; }";
+    let diagnostics = check_source(source, "a.ts", CheckerOptions::default());
+
+    let ts1263: Vec<_> = diagnostics
+        .iter()
+        .filter(|diag| diag.code == 1263)
+        .collect();
+    assert_eq!(ts1263.len(), 1, "unexpected diagnostics: {diagnostics:#?}");
+
+    let excl = source.find('!').expect("definite assignment marker") as u32;
+    assert_eq!(
+        ts1263[0].start, excl,
+        "TS1263 must anchor at the '!' token (name_node.end). Actual: {ts1263:#?}"
+    );
+    assert_eq!(
+        ts1263[0].length, 1,
+        "unexpected diagnostic length: {ts1263:#?}"
+    );
+}

--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part5.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part5.rs
@@ -378,3 +378,43 @@ interface LibBase {
             "a memberless derived interface must not run heritage compatibility, got: {extension:?}"
         );
     }
+
+    /// End-to-end guard for the property-name span fix in
+    /// `parse_property_name_impl`: a parser grammar diagnostic and a checker
+    /// diagnostic anchored on the *same* accessor name must interleave by code,
+    /// exactly as `tsc`'s `compareDiagnostics` orders them (start, then length,
+    /// then code). `TS1054` ("A 'get' accessor cannot have parameters.") and
+    /// `TS2378` ("A 'get' accessor must return a value.") both anchor on the `x`
+    /// name of `get x(v: number): string`; `tsc` emits `TS1054` first because
+    /// `1054 < 2378` at an equal span.
+    ///
+    /// The property-name node used to overshoot its `end` by the width of the
+    /// following `(`, so `TS1054` carried a longer span than `TS2378`; since
+    /// `compare` breaks ties on length before code, the longer diagnostic sorted
+    /// *after* the shorter one, inverting the pair relative to `tsc`. This asserts
+    /// the corrected, code-ordered interleaving through the full CLI sort path.
+    #[test]
+    fn accessor_grammar_and_checker_diagnostics_interleave_by_code_at_one_name() {
+        let mut diagnostics =
+            collect_es2015_default_lib_diagnostics("class C { get x(v: number): string {} }\n");
+        diagnostics.sort_by(|a, b| a.compare(b));
+
+        let ts1054 = diagnostics
+            .iter()
+            .position(|d| d.code == 1054)
+            .expect("TS1054 (get accessor cannot have parameters) must be reported");
+        let ts2378 = diagnostics
+            .iter()
+            .position(|d| d.code == 2378)
+            .expect("TS2378 (get accessor must return a value) must be reported");
+
+        assert_eq!(
+            diagnostics[ts1054].start, diagnostics[ts2378].start,
+            "both diagnostics must anchor on the same accessor name"
+        );
+        assert!(
+            ts1054 < ts2378,
+            "TS1054 must sort before TS2378 at an equal span (code order), matching tsc; \
+             got TS1054 at {ts1054} and TS2378 at {ts2378}: {diagnostics:?}"
+        );
+    }

--- a/crates/tsz-parser/tests/accessor_signature_parameter_list_tests.rs
+++ b/crates/tsz-parser/tests/accessor_signature_parameter_list_tests.rs
@@ -181,10 +181,14 @@ fn get_accessor_signature_reports_ts1054_at_the_accessor_name() {
 }
 
 /// The signature arm and the class arm must produce the *same shape* of span for
-/// TS1054, so the two cannot drift. Both read `name.end - name.pos`, and that
-/// length currently overshoots the identifier by one — a property-name node-end
-/// overshoot shared by both arms and out of scope here. Pinning the two against
-/// each other catches a change to either without baking in the wrong number.
+/// TS1054, so the two cannot drift. Both read `name.end - name.pos`; the length is
+/// now exactly the accessor name's width (`gy27`, 4 chars), matching tsc's
+/// `grammarErrorOnNode(accessor.name, …)`. This span used to overshoot the
+/// identifier by the width of the following token (`(`) because
+/// `parse_property_name_impl` read `token_end()` *after* advancing past the name —
+/// which not only mis-underlined but, since `compareDiagnostics` breaks ties on
+/// length before code, sorted TS1054 *after* a same-position checker diagnostic
+/// (e.g. TS2378) instead of before it. Pinning the exact width guards the fix.
 #[test]
 fn get_accessor_ts1054_span_agrees_between_the_signature_and_class_arms() {
     let (sig_start, sig_len) = span_of(
@@ -198,6 +202,11 @@ fn get_accessor_ts1054_span_agrees_between_the_signature_and_class_arms() {
     assert_eq!(
         sig_len, class_len,
         "TS1054 span length must match between the accessor-signature and class arms"
+    );
+    assert_eq!(
+        sig_len,
+        "gy27".len() as u32,
+        "TS1054 must span exactly the accessor name, matching tsc"
     );
     assert_eq!(
         sig_start - "interface Iy27 { get ".len() as u32,


### PR DESCRIPTION
Follow-up **test-only** coverage for the property-name node `end` fix (#17024). The fix itself is already on `main` — the parser half via #17037 and the checker anchor half via #17039 — so this PR adds no product code, only the guards those PRs went in without. (Supersedes the now-closed #17035, which carried the same fix + tests before both halves landed independently; salvaging the non-duplicated tests here as invited on that PR.)

## What this guards
The fix corrected `parse_property_name_impl` to end the property-name node at the name (it had read `token_end()` *after* `next_token()`, overshooting to the following token). Because tsc's `compareDiagnostics` breaks ties on `length` before `code`, that overshoot sorted an accessor grammar diagnostic *after* a same-position checker diagnostic and mis-underlined it; two checker anchors (`ambient_signature_checks.rs`, `js_grammar.rs`) had been compensating with `name_node.end - 1` and were un-compensated when the root was fixed.

- **parser** — `get_accessor_ts1054_span_agrees_between_the_signature_and_class_arms` now pins the exact `TS1054` span width to the accessor name (`"gy27".len()`), and its doc comment no longer describes the (now-removed) overshoot as "out of scope."
- **checker** — `class_property_definite_assignment_anchors_at_exclamation` pins `TS1263` at the `!` (`name_node.end`, length 1) for a class property — the anchor #17039 un-compensated. (The method/property `TS8009` `?` arms were already covered by `js_optional_class_elements_report_ts8009_at_question_token`.)
- **cli** — `accessor_grammar_and_checker_diagnostics_interleave_by_code_at_one_name` is the end-to-end guard through the full CLI sort path that `TS1054` sorts before a same-position `TS2378` by code — the user-visible symptom the span fix restored.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-parser get_accessor_ts1054_span_agrees_between_the_signature_and_class_arms` — pass
- `cargo test -p tsz-checker --test js_grammar_span_tests class_property_definite_assignment_anchors_at_exclamation` — pass
- `cargo test -p tsz-cli accessor_grammar_and_checker_diagnostics_interleave_by_code_at_one_name` — pass

All three run against current `main` (the fix is already landed); test-only, so conformance/emit/fourslash are unaffected.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eacty8zGugTSHucnL89TS5)_