### PR TITLE
test(checker): string-literal adjacent case for tagged-template round-2 widening

### DIFF
--- a/crates/tsz-checker/src/types/computation/tagged_template.rs
+++ b/crates/tsz-checker/src/types/computation/tagged_template.rs
@@ -644,6 +644,17 @@ function tempFun<T>(tempStrs: TemplateStringsArray, g: (x: T) => T, x: T): T {
     }
 
     #[test]
+    fn literal_widening_is_not_numeric_specific() {
+        // The fix reuses the general-purpose `widen_round2_contextual_substitution`
+        // helper, so a string-literal candidate must widen exactly like a
+        // numeric one — this is not a numeric-literal special case.
+        assert_no_ts2345(&format!(
+            r#"{SINGLE_ARITY_TAG}
+var s = tempFun`${{ x => x }} ${{ "s" }}`;"#
+        ));
+    }
+
+    #[test]
     fn parenthesized_arrow_variants_are_unaffected() {
         assert_no_ts2345(&format!(
             "{SINGLE_ARITY_TAG}\nvar b = tempFun`${{ (x => x) }}  ${{ 10 }}`;"


### PR DESCRIPTION
Small follow-up to #17041 (merged as `8aa33ba`), requested by the PR reviewer.

#17041 fixed a false-positive TS2345 in tagged-template generic inference by widening round-1 literal-typed inference candidates before seeding round-2 contextual types — reusing the existing `widen_round2_contextual_substitution` helper that the regular call-argument path already used. The reviewer asked for a string-literal adjacent case (not just the numeric `10` from the original fixture) to prove the fix is general-purpose literal widening, not a numeric special case.

Adds `literal_widening_is_not_numeric_specific`: `` t`${ x => x } ${ "s" }` `` — 1x spurious TS2345 on `main` before #17041, clean after, oracle-matched against `typescript@7.0.2`. No production code changes; test-only.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib tagged_template_overload_literal_widening_tests`: 7/7 passed (was 6/6 before this addition), rebuilt against current `main` (post-#17041).
- `cargo clippy -p tsz-checker --lib -- -D warnings`: clean (pre-commit hook).
- `cargo fmt --check -p tsz-checker`: clean (pre-commit hook).
- Test-only diff (`git diff --name-only` touches no non-test path outside the existing `#[cfg(test)]` module), so conformance/emit counts cannot move.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpQfh4Qq15SDMko1J1UFK4)_