### PR TITLE
chore(readme): refresh conformance stats to 11,572 (96.1%)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ test suite against it.
 
 <!-- CONFORMANCE_START -->
 ```
-Progress: [███████████████████░] 96.0% (11,563/12,043 runnable tests)
+Progress: [███████████████████░] 96.1% (11,572/12,043 runnable tests)
 Candidates: 12,585 (12,043 runnable, 507 unsupported, 35 skipped)
 ```
 <!-- CONFORMANCE_END -->


### PR DESCRIPTION
Goal: hold

Refreshes the README conformance block from a snapshot measured at
`2de8c3481a`. Changes: `96.0% (11,563/12,043)` -> **`96.1% (11,572/12,043)`**.

Generated via `scripts/refresh-readme.py --write --skip-performance`; the
committed value was read back out of the commit (`git show HEAD:README.md`)
before the conformance snapshot tree was discarded.

## Fourslash left at 6,558 (still 1 test low), per #17010

The refresh again wrote `6,557` and I again reverted that line. The run has
**3 genuine failures** (`importFixesWithPackageJsonInSideAnotherPackage`,
`importNameCodeFix_importType`, `autoImportProvider_importsMap1`), so the true
figure is `6559 / 6562`. `fourslash-snapshot.json` records passed-but-slow tests
in its `fail` list, making the published number depend on machine load -- see
**#17010**. Publishing conservatively low until that is fixed.

## Note on the concurrently open #17015

#17015 is currently `DIRTY` and its README hunk publishes `11,560`, which is
behind both `main` (11,563) and this PR (11,572), so that hunk is stale and will
conflict. Its **benchmark PNG refresh is still wanted** and is not duplicated
here -- this PR is `--skip-performance` and touches README only. Suggest
rebasing #17015 and dropping its README hunk, keeping the two PNGs.

## Verification

Measured at `2de8c3481a`, on a quiet repo:

- conformance `11572 / 12043` (96.1%), 12585 candidates, 507 unsupported, 35 skipped
- emit JS `11562 / 11563`, emit DTS `1377 / 1390` -- both at their floors
- fourslash: 3 real failures, 0 watchdog kills, 0 slow-but-passed

### These numbers replace a contaminated run

An earlier run this cycle reported emit `11557 / 11563` (`Failed: 6 (5
timeouts)`), DTS `1372 / 1390`, and no fourslash output at all. That was
self-inflicted: I was concurrently deleting ~974 merged-PR branches, which held
the git index lock (fourslash died with `Another git process seems to be running
in this repository`) and saturated CPU/network (emit picked up spurious
timeouts). Re-running on a quiet repo returned emit to exactly `11562 / 1377`,
confirming no regression. Recording it here so the discarded figures are not
mistaken for a real dip if they surface elsewhere.

Repo maintenance also completed this cycle: remote branches went **1,377 ->
366**, deleting 973 branches whose PRs are merged. Closed-but-unmerged (109),
no-PR (~246) and open-PR (5) branches were deliberately left alone. Note
`git branch -r --merged` is the wrong signal in this repo -- squash merges mean a
landed branch's commits are never ancestors of `main`, so it reported only 226
of the ~1,084 actually-dead branches; PR state is the reliable mapping.

## Provenance

Machine: m1
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high

AgentName: M1FableArchitect