### PR TITLE
fix(solver): return-context inference matches evaluated object shapes

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -829,6 +829,8 @@ mod remapped_missing_property_relation_routing_arch_tests;
 mod rest_parameter_relation_routing_arch_tests;
 #[path = "tests/return_alias_unknown_eval_assignability_tests.rs"]
 mod return_alias_unknown_eval_assignability_tests;
+#[path = "tests/return_context_object_shape_alias_tests.rs"]
+mod return_context_object_shape_alias_tests;
 #[path = "tests/return_context_promise_identity_tests.rs"]
 mod return_context_promise_identity_tests;
 #[path = "tests/return_context_type_param_shadowing_tests.rs"]

--- a/crates/tsz-checker/src/tests/return_context_object_shape_alias_tests.rs
+++ b/crates/tsz-checker/src/tests/return_context_object_shape_alias_tests.rs
@@ -1,0 +1,101 @@
+//! Return-context inference must recover a nested generic call's type argument
+//! from a contextual target that has already been materialized to its structural
+//! object shape, not only from the `Application` form.
+//!
+//! Structural rule: when a generic call `make<T>(f): Box<T>` sits in argument
+//! position against a concrete contextual target (`take(b: Box<string>)`), `tsc`
+//! infers `T` from the return context (`Box<T>` vs `Box<string>` ⇒ `T = string`)
+//! so the callback parameter types as `string`. tsz's return-context matcher
+//! compared the *raw* source/target in its object-vs-object arm, so when the
+//! callee's parameter type had been eagerly reduced to its structural object
+//! shape while the callee return `Box<T>` was still an unevaluated `Application`,
+//! that arm was skipped and `T` fell back to its constraint, producing a spurious
+//! TS2345 at the callback. Matching the *evaluated* forms recovers the shared
+//! property structure so the binding is found regardless of which representation
+//! the contextual type happens to carry.
+//!
+//! (The sibling nominal-class shape — a `class` return rather than an object type
+//! alias — is not covered here: a class instance with a free type argument stays
+//! nominal under evaluation, so it never reaches this structural arm. That case is
+//! the eager-materialization structure loss tracked separately.)
+
+use crate::test_utils::check_source_codes as codes;
+
+#[test]
+fn nested_generic_call_binds_type_arg_from_object_alias_return_context() {
+    // `make(s => s.length)` in argument position: `T` must infer as `string`
+    // from `take`'s `Box<string>` parameter, so `s.length` is valid.
+    assert!(
+        codes(
+            "type Box<T> = { from: (x: T) => void }; \
+             declare function make<T>(f: (x: T) => void): Box<T>; \
+             declare function take(b: Box<string>): void; \
+             take(make(s => s.length));"
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn nested_generic_call_object_return_context_renamed_binders() {
+    // Same shape with every binder renamed, so the rule is not keyed on any
+    // identifier (`Wrap`/`U`/`build`/`consume`/`slot`).
+    assert!(
+        codes(
+            "type Wrap<U> = { slot: (v: U) => void }; \
+             declare function build<U>(g: (v: U) => void): Wrap<U>; \
+             declare function consume(w: Wrap<string>): void; \
+             consume(build(v => v.length));"
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn direct_annotated_object_alias_return_context_stays_clean() {
+    // Control: the same call as a direct variable initializer already worked
+    // (the contextual type keeps its `Application` form there). It must stay
+    // clean after the change.
+    assert!(
+        codes(
+            "type Box<T> = { from: (x: T) => void }; \
+             declare function make<T>(f: (x: T) => void): Box<T>; \
+             const b: Box<string> = make(s => s.length);"
+        )
+        .is_empty()
+    );
+}
+
+#[test]
+fn nested_generic_call_object_return_context_reports_genuine_body_error() {
+    // Negative control: with `T = number` inferred from `Box<number>`, the
+    // callback parameter is `number`, so `s.length` is a genuine property error.
+    // The return-context binding must not silence real errors under the concrete
+    // type argument.
+    assert_eq!(
+        codes(
+            "type Box<T> = { from: (x: T) => void }; \
+             declare function make<T>(f: (x: T) => void): Box<T>; \
+             declare function take(b: Box<number>): void; \
+             take(make(s => s.length));"
+        ),
+        vec![2339],
+    );
+}
+
+#[test]
+fn nested_generic_call_object_return_context_no_companion_binding_unchanged() {
+    // Negative control: when the outer target does not constrain the type
+    // argument (no return context to bind `T`), `T` defaults to its `unknown`
+    // constraint, so the callback parameter is `unknown` and `s.length` is
+    // TS18046 exactly as before — the change only adds a binding where the return
+    // context makes one recoverable, it does not invent one.
+    assert_eq!(
+        codes(
+            "type Box<T> = { from: (x: T) => void }; \
+             declare function make<T>(f: (x: T) => void): Box<T>; \
+             const b = make(s => s.length);"
+        ),
+        vec![18046],
+    );
+}

--- a/crates/tsz-solver/src/operations/generic_call/return_context.rs
+++ b/crates/tsz-solver/src/operations/generic_call/return_context.rs
@@ -898,9 +898,22 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         // Object-Object: match properties by name and recurse into their types.
         // This handles cases where applications are evaluated to structural object
         // types (e.g., Box<void, B> → { a: void, b: B }).
-        if let (Some(TypeData::Object(s_shape_id)), Some(TypeData::Object(t_shape_id))) =
-            (self.interner.lookup(source), self.interner.lookup(target))
-        {
+        //
+        // Match on the *evaluated* forms, not the raw source/target. A generic
+        // return that is a type-alias application (e.g. `type Box<T> = { from: (x:
+        // T) => void }`, returned as `Box<T>`) reaches here as an unevaluated
+        // `Application`, while the contextual target may already have been
+        // materialized to its structural object shape (a callee parameter type is
+        // reduced eagerly, whereas a variable annotation of the same type keeps
+        // its `Application` form). Evaluating both sides recovers the property
+        // structure so the tracked type parameter still binds through the shared
+        // members, regardless of which representation the contextual type happens
+        // to carry. `evaluate` is idempotent on an already-structural object, so
+        // this does not change the raw object-vs-object case.
+        if let (Some(TypeData::Object(s_shape_id)), Some(TypeData::Object(t_shape_id))) = (
+            self.interner.lookup(source_eval),
+            self.interner.lookup(target_eval),
+        ) {
             let s_shape = self.interner.object_shape(s_shape_id);
             let t_shape = self.interner.object_shape(t_shape_id);
             for s_prop in &s_shape.properties {


### PR DESCRIPTION
When a generic call whose return type is a type-alias object application (e.g. `Box<T>`) sits in **argument position** against a concrete contextual target, `tsc` infers the type parameter from the return context (`Box<T>` vs `Box<string>` ⇒ `T = string`) and contextually types the callback parameter accordingly. tsz emitted a spurious `TS2345` at the callback.

Structural rule: the solver's return-context matcher (`generic_call/return_context.rs`) has an Object-Object arm whose own comment says it "handles cases where applications are evaluated to structural object types", but it compared the **raw** `source`/`target`. A generic return like `Box<T>` reaches the arm as an unevaluated `Application`, while the contextual target has already been materialized to its structural object shape (a callee parameter type is reduced eagerly, whereas a variable annotation of the same type keeps its `Application` form and matched through the aligned-application path). So the arm was skipped, the tracked type parameter fell back to its constraint, the callee parameter instantiated at the constraint, and the correctly-typed callback failed contravariantly — a false `TS2345`. The arm now matches the **evaluated** forms of both sides; `evaluate` is idempotent on an already-structural object, so the raw object-vs-object case is unchanged.

Owner layer: solver `generic_call` return-context inference.

## Relationship to #17005
This resolves the **type-alias family** of #17005's nested-return-context false positives. #17005's named fixtures (`lambdaParameterWithTupleArgsHasCorrectAssignability.ts`, `parenthesizedContexualTyping3.ts`) are **not** fixed here and remain failing:

- `lambdaParameter…` uses a nominal `class GenericClass<T>` return. A class instance with a free type argument stays nominal under evaluation (it never reduces to a structural object), so it never reaches this arm. The contextual target arrives as the eagerly-materialized `ObjectWithIndex` instance shape with its type arguments dropped, and there is no primitive exposed to the solver matcher to expand the nominal source back to its member shape to compensate. That is the eager-materialize-and-re-mint structure loss tracked in #13806.
- `parenthesizedContexualTyping3.ts` is a distinct literal-widening bug in the tagged-template path (`T` inferred as the unwidened literal `10`), unrelated to this mechanism.

The full root-cause for both is written up on #17005.

## Goal
Goal: green

## Verification
- `cargo test -p tsz-checker --lib return_context_object_shape_alias`: **5/5** new (nested-bind, renamed binders, direct control, genuine-body-error control `TS2339`, no-context control `TS18046`).
- `cargo test -p tsz-checker --lib arrow_argument_to_overloaded_parameter_reports_ts2345`: #17000's guard still passes.
- Conformance snapshot, before/after on current `main` (dist-fast, --workers 12): **11568 → 11568**, computed by diffing the two `conformance-baseline.txt` PASS sets — **zero regressions, zero corpus fixes** (the alias case is not in the corpus). Pre-merge CI (clippy + arch-size) passes locally via the commit hook.
- Emit: could not be run locally — `scripts/emit/run.sh`'s `ensure-pinned-typescript.sh` setup hangs in this sandbox. The change touches only return-context type inference (conformance-neutral), so no emit output is expected to move; the nightly emit lane covers it.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01NbKNAdiRGUEFffZgXqRZaR)_