### PR TITLE
fix(parser): keep a fresh statement's own missing-semicolon diagnostic near a missing-LHS binary-expression recovery

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -402,6 +402,10 @@ mod for_header_private_identifier_binding_tests;
 #[path = "../../tests/keyword_identifier_missing_semicolon_cascade_tests.rs"]
 mod keyword_identifier_missing_semicolon_cascade_tests;
 
+#[cfg(test)]
+#[path = "../../tests/missing_lhs_binary_expression_statement_boundary_tests.rs"]
+mod missing_lhs_binary_expression_statement_boundary_tests;
+
 // Re-export flags
 pub use flags::{modifier_flags, node_flags, transform_flags};
 

--- a/crates/tsz-parser/src/parser/state.rs
+++ b/crates/tsz-parser/src/parser/state.rs
@@ -361,6 +361,20 @@ pub struct ParserState {
     /// Set when the current function declaration parameter list yielded a hard
     /// reserved keyword back to the statement parser.
     pub(crate) reserved_parameter_yielded_to_statement: bool,
+    /// Set when an expression statement recovered a missing left operand of a
+    /// reserved-keyword binary operator (`in`/`instanceof`/...) at statement
+    /// start (tsc: `<missing> <op> <rhs>`, TS1109 at the operator). tsc's
+    /// statement-list loop then re-parses the *next* token as a fresh
+    /// statement independent of that recovery, so a missing-semicolon
+    /// diagnostic for that following statement must not be suppressed just
+    /// because it sits within `ERROR_SUPPRESSION_DISTANCE` of the missing-LHS
+    /// statement's own diagnostic — tsc's `parseErrorAtPosition` dedups by
+    /// exact start position only (#16291: `in get x(): number;` dropped tsc's
+    /// third diagnostic through this proximity heuristic). Consumed by the
+    /// very next `parse_semicolon()` / `parse_error_for_missing_semicolon_after()`
+    /// check, so it only ever bypasses suppression for that one, immediately
+    /// following statement.
+    pub(crate) force_next_missing_semicolon_error_once: bool,
 }
 
 impl ParserState {
@@ -473,6 +487,7 @@ impl ParserState {
             namespace_import_yielded_to_statement: false,
             recover_reserved_parameter_as_statement_tail_allowed: false,
             reserved_parameter_yielded_to_statement: false,
+            force_next_missing_semicolon_error_once: false,
         }
     }
 
@@ -530,6 +545,7 @@ impl ParserState {
         self.namespace_import_yielded_to_statement = false;
         self.recover_reserved_parameter_as_statement_tail_allowed = false;
         self.reserved_parameter_yielded_to_statement = false;
+        self.force_next_missing_semicolon_error_once = false;
         // The high-water mark tracks the count of scanner diagnostics that
         // have been considered by the parser-side dedup at `parse_error_at`.
         // When the parser is reused via `reset()` the caller passes a fresh

--- a/crates/tsz-parser/src/parser/state/recovery.rs
+++ b/crates/tsz-parser/src/parser/state/recovery.rs
@@ -415,8 +415,11 @@ impl ParserState {
             // emitted. This happens when a prior parse failure (e.g., missing identifier,
             // unsupported syntax) causes the parser to not consume tokens, then
             // parse_semicolon is called and fails too.
-            // Use centralized error suppression heuristic
-            if self.should_report_error() {
+            // Use centralized error suppression heuristic — except immediately after a
+            // missing-LHS binary-expression statement (#16291), where the following
+            // statement's own diagnostic must never be dropped just for proximity.
+            let force_emit = std::mem::take(&mut self.force_next_missing_semicolon_error_once);
+            if force_emit || self.should_report_error() {
                 self.error_token_expected(";");
             }
         }
@@ -468,8 +471,13 @@ impl ParserState {
                 .rev()
                 .take(4)
                 .any(|diag| diag.start == token_pos);
+            // Immediately after a missing-LHS binary-expression statement
+            // (#16291), this following statement's own diagnostic must never be
+            // dropped just for proximity to that recovery's diagnostic.
+            let force_emit = std::mem::take(&mut self.force_next_missing_semicolon_error_once);
             if !already_reported_here
-                && (self.should_report_error()
+                && (force_emit
+                    || self.should_report_error()
                     || self.last_error_was_leading_zero_at_other_pos()
                     || self.last_error_was_element_access_missing_argument_at_other_pos())
             {

--- a/crates/tsz-parser/src/parser/state_switch_recovery.rs
+++ b/crates/tsz-parser/src/parser/state_switch_recovery.rs
@@ -667,6 +667,28 @@ impl ParserState {
                 if self.expression_statement_block_function_recovers_conditional_tail(expression) {
                     self.recover_invalid_conditional_tail_after_expression_statement();
                 }
+                // The current token now starts a brand-new statement independent of
+                // this missing-LHS binary-expression recovery (tsc: `<missing> <op>
+                // <rhs>`, e.g. `in get`, `instanceof get`) — its own diagnostic must
+                // not be dropped just for sitting near this statement's TS1005
+                // (#16291). Detected by the statement's own "Expression expected"
+                // diagnostic anchored at its start position, rather than by
+                // `started_with_binary_operator` alone: a reserved word like
+                // `instanceof` is (incorrectly, but out of scope here) also listed
+                // in `is_expression_start()`'s identifier-like set, so it takes the
+                // generic `parse_expression()` path instead — which still recovers
+                // through the same "synthesize a missing left operand, keep parsing
+                // the operator as a binary continuation" shape and reports the same
+                // TS1109 at `start_pos`.
+                let statement_recovered_missing_lhs_at_start =
+                    self.parse_diagnostics.iter().any(|d| {
+                        d.start == start_pos && d.code == diagnostic_codes::EXPRESSION_EXPECTED
+                    });
+                if !started_with_binary_operator_skip_path
+                    && (started_with_binary_operator || statement_recovered_missing_lhs_at_start)
+                {
+                    self.force_next_missing_semicolon_error_once = true;
+                }
             }
             // For malformed JSX heads like `<X -attr={...} />`, tsc reports `';' expected`
             // at `=` and then continues from the `{...}` tail, which can surface

--- a/crates/tsz-parser/tests/missing_lhs_binary_expression_statement_boundary_tests.rs
+++ b/crates/tsz-parser/tests/missing_lhs_binary_expression_statement_boundary_tests.rs
@@ -1,0 +1,135 @@
+//! A statement that begins with a reserved-keyword binary operator (`in`,
+//! `instanceof`) with no left operand recovers as `tsc`'s
+//! `<missing> <op> <rhs>` (TS1109 at the operator, the operator and its RHS
+//! kept in the tree). tsc's statement-list loop then re-parses whatever
+//! follows as a completely independent fresh statement — e.g. `in get
+//! x(): number;` is `<missing> in get` (one statement) followed by
+//! `x(): number;` (a second, unrelated statement).
+//!
+//! tsz's `parse_error_for_missing_semicolon_after` / `parse_semicolon`
+//! suppress a "';' expected" diagnostic when a recent diagnostic was emitted
+//! within `ERROR_SUPPRESSION_DISTANCE` (3 characters) of the current
+//! position, to avoid cascading noise from a single failed parse. That
+//! heuristic doesn't know a *new*, independently-parsed statement sits in
+//! between: the first statement's own "';' expected" (reported at the second
+//! statement's first token, since that's where the missing semicolon was
+//! expected) sits well within 3 characters of the second statement's own
+//! "';' expected" a few tokens later, so tsz dropped it — even though `tsc`'s
+//! real dedup (`parseErrorAtPosition`) only ever compares against the
+//! immediately preceding diagnostic's exact start position, never a
+//! proximity window.
+//!
+//! Fixed in `crates/tsz-parser/src/parser/state_switch_recovery.rs`'s
+//! `parse_expression_statement`: a missing-LHS statement now sets a one-shot
+//! `force_next_missing_semicolon_error_once` flag (consumed by the very next
+//! `parse_semicolon` / `parse_error_for_missing_semicolon_after` check, in
+//! `crates/tsz-parser/src/parser/state/recovery.rs`), so the following
+//! statement's own diagnostic is never suppressed by proximity to this one.
+//!
+//! The trigger condition is not just `started_with_binary_operator`: `in` is
+//! recognized as a binary operator directly by `is_binary_operator()` at
+//! statement start, but `instanceof` — despite being an equally reserved
+//! word that can never itself start an expression — is also (incorrectly,
+//! out of scope here) listed in `is_expression_start()`'s identifier-like
+//! token set, so it takes the generic `parse_expression()` path instead of
+//! the dedicated `started_with_binary_operator` branch. Both still reach the
+//! same recovery shape and report the same TS1109 anchored at the
+//! statement's own start position, so the flag is set whenever that
+//! diagnostic is present, not only when `started_with_binary_operator` is
+//! set.
+
+use crate::parser::test_fixture::parse_source;
+use tsz_common::diagnostics::diagnostic_codes;
+use tsz_common::position::LineMap;
+
+/// `(code, line, column)` fingerprints, 1-based, in report order.
+fn fingerprints(source: &str) -> Vec<(u32, u32, u32)> {
+    let (parser, _root) = parse_source(source);
+    let line_map = LineMap::build(source);
+    parser
+        .get_diagnostics()
+        .iter()
+        .map(|diag| {
+            let pos = line_map.offset_to_position(diag.start, source);
+            (diag.code, pos.line + 1, pos.character + 1)
+        })
+        .collect()
+}
+
+const TS1109: u32 = diagnostic_codes::EXPRESSION_EXPECTED;
+const TS1005: u32 = diagnostic_codes::EXPECTED;
+
+// ---------------------------------------------------------------------------
+// `in`: the original #16291 witness. tsc: TS1109 at `in`, TS1005 at `x` (the
+// first statement's missing semicolon), TS1005 at `:` (the second,
+// independent `x(): number;` statement's own missing semicolon).
+#[test]
+fn in_missing_lhs_followed_by_call_statement_reports_both_semicolons() {
+    assert_eq!(
+        fingerprints("in get x(): number;"),
+        vec![(TS1109, 1, 1), (TS1005, 1, 8), (TS1005, 1, 11)],
+    );
+}
+
+// `instanceof` — same shape, but reaches the flag via the diagnostic-position
+// fallback rather than `started_with_binary_operator` (see module doc).
+#[test]
+fn instanceof_missing_lhs_followed_by_call_statement_reports_both_semicolons() {
+    assert_eq!(
+        fingerprints("instanceof get x(): number;"),
+        vec![(TS1109, 1, 1), (TS1005, 1, 16), (TS1005, 1, 19)],
+    );
+}
+
+// Nested inside a function body (the `parse_statements()` block-list loop,
+// not just the top-level `parse_source_file_statements()` loop) — and
+// followed by a third, ordinary statement to confirm recovery resumes
+// cleanly afterward.
+#[test]
+fn in_missing_lhs_inside_function_body_reports_both_semicolons() {
+    assert_eq!(
+        fingerprints("function f() {\n  in get x(): number;\n  const z = 1;\n}\n"),
+        vec![(TS1109, 2, 3), (TS1005, 2, 10), (TS1005, 2, 13)],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls: shapes that must NOT gain a spurious diagnostic.
+
+// An explicit semicolon closes the missing-LHS statement cleanly — no
+// missing-semicolon diagnostic to suppress or force in the first place.
+#[test]
+fn in_missing_lhs_with_explicit_semicolon_reports_only_ts1109() {
+    assert_eq!(fingerprints("in y;"), vec![(TS1109, 1, 1)]);
+}
+
+#[test]
+fn instanceof_missing_lhs_with_explicit_semicolon_reports_only_ts1109() {
+    assert_eq!(fingerprints("instanceof y;"), vec![(TS1109, 1, 1)]);
+}
+
+// The binary-expression continuation consumes through a full call chain with
+// no leftover tail — again nothing for a missing-semicolon diagnostic to
+// suppress.
+#[test]
+fn in_missing_lhs_consuming_full_member_call_chain_reports_only_ts1109() {
+    assert_eq!(fingerprints("in a.b.c();"), vec![(TS1109, 1, 1)]);
+}
+
+// A genuinely malformed, unrelated statement must keep its cascading
+// diagnostics suppressed: this is not a missing-LHS-binary-expression
+// statement at all, so the one-shot flag must never be set for it.
+#[test]
+fn octal_literal_missing_semicolon_cascade_is_unaffected() {
+    assert_eq!(
+        fingerprints("00.5;"),
+        vec![
+            (
+                diagnostic_codes::OCTAL_LITERALS_ARE_NOT_ALLOWED_USE_THE_SYNTAX,
+                1,
+                1
+            ),
+            (TS1005, 1, 3)
+        ]
+    );
+}


### PR DESCRIPTION
When a statement recovers a missing left operand of a reserved-keyword binary operator (`in`, `instanceof`) at statement start, `tsc` does `[missing] [op] [rhs]` (TS1109 at the operator) and its statement-list loop then re-parses whatever follows as a completely independent fresh statement. For `in get x(): number;` that's `[missing] in get` (one statement) followed by `x(): number;` (a second, unrelated statement) — tsc reports TS1109 at `in`, TS1005 at `x` (statement 1's missing `;`), and TS1005 at `:` (statement 2's own missing `;`).

tsz does this through the same shape, but its cascading-error suppression (`ERROR_SUPPRESSION_DISTANCE`, a 3-character proximity window used by `parse_semicolon`/`parse_error_for_missing_semicolon_after` to avoid re-reporting a single failed parse) doesn't know a brand-new, independently-parsed statement started in between: statement 1's own "';' expected" is reported at statement 2's first token (since that's where the missing semicolon was expected), which sits well within 3 characters of statement 2's own "';' expected" a few tokens later — so tsz dropped it. tsc's real dedup (`parseErrorAtPosition`) only ever compares a new diagnostic against the *immediately preceding* diagnostic's exact start position, never a proximity window, so it never drops this.

## Structural rule
When a fresh statement (parsed independently after a prior statement's own recovery) reaches its own missing-semicolon check, `tsc` reports it regardless of proximity to the prior statement's diagnostic; tsz now does the same through a one-shot `force_next_missing_semicolon_error_once` flag in the parser (`crates/tsz-parser/src/parser/state_switch_recovery.rs` sets it right after a missing-LHS binary-expression statement reports its own diagnostic; `crates/tsz-parser/src/parser/state/recovery.rs`'s `parse_semicolon`/`parse_error_for_missing_semicolon_after` consume it on the very next check).

`instanceof` needed a second detection path alongside `started_with_binary_operator`: it's (incorrectly, out of scope here) also listed in `is_expression_start()`'s identifier-like token set, so it takes the generic `parse_expression()` path instead of the dedicated missing-LHS branch — but it still reports the same TS1109 anchored at the statement's own start position, so the fix also fires whenever that diagnostic is present at that position.

## Adjacent-case matrix (all oracle-verified against pinned `typescript@7.0.2`)
- `in get x(): number;` (top-level) — fixed, 3/3 diagnostics now match.
- `instanceof get x(): number;` — fixed via the diagnostic-position fallback.
- Same shape nested inside a function body (`parse_statements()` block-list loop, not just the top-level loop) — fixed.
- `in y;` / `instanceof y;` (explicit semicolon, nothing to suppress) — unaffected, still 1 diagnostic.
- `in a.b.c();` (binary expression consumes a full chain, no leftover tail) — unaffected, still 1 diagnostic.
- `00.5;` (an unrelated genuine cascading-diagnostic case) — unaffected, still 2 diagnostics, confirming the fix is scoped and doesn't disable suppression generally.
- A class-member `in get x(): number;` position (TS1274 + a pre-existing, unrelated "'{' expected" divergence) — confirmed byte-identical before/after this change (verified against the pre-fix binary via `git stash`); not touched by this PR, left for a separate session per the class-member/type-member accessor-cascade family already tracked on #16291.
- `async in get x(): number;` (2 diagnostics expected, tsz reports 1) — confirmed pre-existing and unaffected by this change (different dispatch path, `AsyncKeyword` statement handling, not `parse_expression_statement`); out of scope.

A broader, unscoped version of this fix (forcing emission whenever a statement's *own* diagnostic count hadn't grown since `parse_statement()`'s dispatch began) regressed an existing oracle-pinned fixture (`parse_malformed_variable_hashbang_tail_matches_tsc_shape`) by changing downstream recovery through a spurious extra diagnostic. This PR's actual fix is the narrower one-shot flag scoped specifically to the missing-LHS-binary-expression statement boundary, which does not regress that fixture.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-parser --lib`: 2234/2234 passed (2227 pre-existing + 7 new, including the `parse_malformed_variable_hashbang_tail_matches_tsc_shape` regression-guard fixture, which stays green with the narrowed fix).
- `cargo clippy --workspace --lib -- -D warnings`: clean.
- `cargo fmt -p tsz-parser`: no changes needed.
- `python3 scripts/arch/arch_guard.py`: clean.
- CLI repro against pinned `typescript@7.0.2` oracle for the full adjacent-case matrix above (all match exactly).
- Not run: `scripts/conformance/compare-to-parent.sh` / a broader conformance snapshot (time budget this session). Expected impact is 0 — the touched recovery path only fires for a statement that begins with a bare `in`/`instanceof` keyword at raw statement position, which is not valid TypeScript in any real corpus fixture and does not appear in `conformance-detail.json`'s current failure set for this family. Worth a drain-step confirmation if a future session has spare budget.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE