### PR TITLE
test(checker): update stale JSDoc-prototype constructor-this assertion to the oracle

### DIFF
--- a/crates/tsz-checker/tests/jsdoc_prototype_assignment_target_display.rs
+++ b/crates/tsz-checker/tests/jsdoc_prototype_assignment_target_display.rs
@@ -252,12 +252,23 @@ C.prototype = 12
     );
 }
 
-/// `/** @type {number} */ C.prototype.x;` declares the prototype property
-/// type and should check the constructor's `this.x = ...` initializer against
-/// that declared type. This mirrors
-/// `conformance/jsdoc/jsdocPrototypePropertyAccessWithType.ts`.
+/// `tsc` 7.0.2 no longer synthesizes a `this` type for a plain JS "constructor"
+/// function from its `this.prop = value` assignments (the `isJSConstructor`
+/// inference was dropped in TS7), so `this` in the body is untyped and
+/// `this.x = false` is never cross-checked against the `C.prototype.x` JSDoc
+/// declaration. For
+/// `function C() { this.x = false; } /** @type {number} */ C.prototype.x; new C().x;`
+/// the checked-in oracle
+/// (`conformance/jsdoc/jsdocPrototypePropertyAccessWithType.ts` in
+/// `scripts/conformance/tsc-cache-full.json`) reports `[TS2683, TS7009]` and
+/// **no TS2322** — the corpus `.errors.txt` (TS2322) is a stale pre-TS7
+/// baseline. #17040 removed the stale cross-check on the primary path and
+/// rewrote its sibling test
+/// (`jsdoc_typed_prototype_does_not_cross_check_constructor_this_assignment`);
+/// this mirror in the display suite was missed (#17048). tsz's in-process
+/// check surfaces the TS2683 companion (`this` implicitly `any`) here.
 #[test]
-fn ts2322_for_jsdoc_prototype_property_access_decl_checks_constructor_assignment() {
+fn jsdoc_prototype_property_access_decl_does_not_cross_check_constructor_assignment() {
     let diags = diagnostics_for_js(
         r#"
 function C() { this.x = false; }
@@ -266,15 +277,15 @@ C.prototype.x;
 new C().x;
 "#,
     );
-    let ts2322: Vec<_> = diags.iter().filter(|(c, _)| *c == 2322).collect();
-    assert_eq!(
-        ts2322.len(),
-        1,
-        "expected exactly one TS2322 for constructor assignment checked against JSDoc prototype property type; got: {diags:?}"
-    );
-    let msg = &ts2322[0].1;
     assert!(
-        msg.contains("'boolean'") && msg.contains("'number'"),
-        "TS2322 must compare the constructor RHS boolean with the prototype property's JSDoc number type; got: {msg:?}"
+        !diags.iter().any(|(c, _)| *c == 2322),
+        "tsc 7.0.2 does not cross-check a constructor's `this.x` assignment against the \
+         `C.prototype.x` JSDoc type when `this` is untyped (oracle: [2683, 7009], no 2322); \
+         got: {diags:?}"
+    );
+    assert!(
+        diags.iter().any(|(c, _)| *c == 2683),
+        "expected the companion TS2683 ('this' implicitly has type 'any') that evidences the \
+         untyped `this`; got: {diags:?}"
     );
 }


### PR DESCRIPTION
Fixes #17048 — `main` went red after #17040.

`ts2322_for_jsdoc_prototype_property_access_decl_checks_constructor_assignment` (in `crates/tsz-checker/tests/jsdoc_prototype_assignment_target_display.rs`) still asserted **one TS2322** for

```js
function C() { this.x = false; }
/** @type {number} */
C.prototype.x;
new C().x;
```

but #17040 correctly removed the pre-TS7 constructor-`this`-vs-prototype-JSDoc cross-check. It rewrote its sibling test (`jsdoc_typed_prototype_does_not_cross_check_constructor_this_assignment` in `src/tests/ts2565_jsdoc_prototype_type_decl_tests.rs`) but missed this second copy in the display suite, leaving the unit lane red (10936 passed / 1 failed).

## Oracle
The `main`-red write-up flagged the corpus `.errors.txt` (TS2322) against the harness oracle and asked to resolve it before touching the assertion. The authoritative answer is the checked-in tsc cache, not the stale baseline:

`scripts/conformance/tsc-cache-full.json` → `conformance/jsdoc/jsdocPrototypePropertyAccessWithType.ts` (`typescript_version: "7.0.2"`): `error_codes: [2683, 7009]` — **TS2683** at `a.js(1,16)`, **TS7009** at `a.js(4,1)`, **no TS2322**. TS7 dropped `isJSConstructor` `this`-synthesis, so `this` in the body is untyped and `this.x = false` is never cross-checked. The corpus `.errors.txt` (TS2322) is a pre-TS7 artifact. This is **option 2** from #17048: #17040 was correct and the conformance row passes with `[2683, 7009]`; the failing assertion was the stale test.

## Change
Rewrites the assertion to the oracle behavior — no TS2322, plus the **TS2683** companion tsz surfaces in this in-process harness (the TS7009 companion is emitted on the CLI/conformance path, which already matches the oracle). Test-only; no checker change. The sibling `ts2322_for_prototype_jsdoc_assignment_uses_rhs_type_for_source` (`/** @type {string} */ C.prototype = 12`, a distinct prototype-object-assignment mechanism) is untouched and still passes.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test jsdoc_prototype_assignment_target_display`: **5/5** pass (was 4/5; the renamed `jsdoc_prototype_property_access_decl_does_not_cross_check_constructor_assignment` now green, sibling `ts2322_for_prototype_jsdoc_assignment_uses_rhs_type_for_source` unchanged).
- Captured tsz's exact output for the fixture in this harness before writing the assertion: `[(2683, "'this' implicitly has type 'any' …")]` — no TS2322, no TS7009 here.
- No remaining references to the old test name (`grep -rn`).
- Pre-merge CI (clippy + arch-size) passes locally via the commit hook.
- Test-only change: no conformance/emit movement possible.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01NbKNAdiRGUEFffZgXqRZaR)_