### PR TITLE
fix(checker): route soft reserved interface-name TS2427 through the checker, not the parser

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/interface_checks.rs
@@ -189,9 +189,11 @@ impl<'a> CheckerState<'a> {
         // (public, private, static, etc.)
         self.check_never_valid_type_parameter_modifiers(iface.type_parameters.as_ref());
 
-        // Check for reserved interface names (TS2427)
-        // tsc's checkTypeNameIsReserved uses the same set for both interfaces and
-        // classes. It forbids predefined type names.
+        // Check for reserved interface names (TS2427). The checker owns the soft
+        // predefined-type names (`string`, `number`, ...); the hard-keyword
+        // `void`/`null` copy this also emits is deduplicated by the CLI keep-gate
+        // against the parser's own hard-keyword TS2427. See #16279 and
+        // `checker_diagnostics::keep_checker_diagnostic_when_program_has_real_syntax_errors`.
         if iface.name.is_some()
             && let Some(name_node) = self.ctx.arena.get(iface.name)
             && let Some(ident) = self.ctx.arena.get_identifier(name_node)

--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part5.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part5.rs
@@ -378,3 +378,124 @@ interface LibBase {
             "a memberless derived interface must not run heritage compatibility, got: {extension:?}"
         );
     }
+
+    // ------------------------------------------------------------------
+    // #16279: the reserved interface/type-alias-name family (TS2427/TS2457)
+    // is split by tsc's emission site. Hard keywords (`void`/`null`) and
+    // numeric names are parser diagnostics (they short-circuit the file's
+    // semantic phase); soft predefined-type names (`string`, `number`, ...)
+    // are checker `grammarErrorOnNode` diagnostics (suppressed by a sibling
+    // parse error, but otherwise coexisting with unrelated grammar errors).
+    // Before the fix tsz emitted the soft-name TS2427 from the parser, which
+    // both double-emitted and, being outside `is_parser_grammar_code`, counted
+    // as a suppressing "real parse error" that silently deleted sibling grammar
+    // diagnostics in the same file.
+
+    #[test]
+    fn soft_reserved_interface_name_does_not_delete_sibling_grammar_diagnostic() {
+        // The headline family-deletion witness. tsc reports BOTH the soft-name
+        // TS2427 and the sibling accessor grammar error (TS1054); tsz used to
+        // drop the TS1054 because the parser-emitted TS2427 was treated as a
+        // suppressing parse error.
+        for soft in ["string", "number", "object"] {
+            let src = format!(
+                "interface {soft} {{}}\nclass C {{ get x(a: number) {{ return a; }} }}\n"
+            );
+            let diagnostics = collect_test_diagnostics(&[("/a.ts", src.as_str())]);
+            assert!(
+                diagnostics.iter().any(|d| d.code == 2427),
+                "expected TS2427 for `interface {soft}`, got: {diagnostics:?}"
+            );
+            assert!(
+                diagnostics.iter().any(|d| d.code == 1054),
+                "sibling TS1054 (get accessor with parameters) must survive \
+                 alongside the soft-name TS2427 for `interface {soft}`, got: {diagnostics:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn soft_reserved_interface_name_is_single_emission() {
+        // No parser/checker double-emission for the soft-name form.
+        for soft in ["string", "number", "boolean"] {
+            let src = format!("interface {soft} {{}}\n");
+            let diagnostics = collect_test_diagnostics(&[("/a.ts", src.as_str())]);
+            assert_eq!(
+                diagnostics.iter().filter(|d| d.code == 2427).count(),
+                1,
+                "exactly one TS2427 expected for `interface {soft}`, got: {diagnostics:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn soft_reserved_interface_name_suppressed_by_sibling_parse_error() {
+        // Direction B: a genuine syntax error elsewhere in the file drops the
+        // soft-name (checker-emitted) TS2427, matching tsc's hasParseDiagnostics.
+        let diagnostics =
+            collect_test_diagnostics(&[("/a.ts", "interface string {}\nlet zzz: = 1;\n")]);
+        assert!(
+            diagnostics.iter().any(|d| d.code == 1110),
+            "the real syntax error (TS1110) must be reported, got: {diagnostics:?}"
+        );
+        assert!(
+            !diagnostics.iter().any(|d| d.code == 2427),
+            "soft-name TS2427 must be suppressed by a sibling parse error, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn hard_keyword_interface_name_short_circuits_semantic_phase() {
+        // `interface void {}` is a parser diagnostic (`void` cannot be an
+        // identifier), so tsc suppresses the file's unrelated type error just
+        // as it would for any parse error. The TS2427 itself survives.
+        let diagnostics = collect_test_diagnostics(&[(
+            "/a.ts",
+            "interface void {}\nconst x: number = \"s\";\n",
+        )]);
+        assert!(
+            diagnostics.iter().any(|d| d.code == 2427),
+            "hard-keyword TS2427 for `interface void` must be reported, got: {diagnostics:?}"
+        );
+        assert!(
+            !diagnostics.iter().any(|d| d.code == 2322),
+            "the unrelated type error must be short-circuited by the hard-keyword \
+             parse diagnostic, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn hard_keyword_interface_name_suppresses_soft_sibling_same_file() {
+        // `interface void {}` + `interface string {}` in one file: tsc reports
+        // only the `void` TS2427. This falls out of the general
+        // hasParseDiagnostics mechanism (the parser `void`-TS2427 makes
+        // `program_has_real_syntax_errors` true, suppressing the checker's
+        // soft-name TS2427), not a message-text special case.
+        let diagnostics =
+            collect_test_diagnostics(&[("/a.ts", "interface void {}\ninterface string {}\n")]);
+        let ts2427: Vec<_> = diagnostics.iter().filter(|d| d.code == 2427).collect();
+        assert_eq!(
+            ts2427.len(),
+            1,
+            "only the hard-keyword TS2427 should survive, got: {diagnostics:?}"
+        );
+        assert!(
+            ts2427[0].message_text.contains("void"),
+            "the surviving TS2427 must be the `void` one, got: {:?}",
+            ts2427[0]
+        );
+    }
+
+    #[test]
+    fn numeric_and_hard_keyword_interface_names_both_reported() {
+        // Numeric names are parser diagnostics too, and tsc keeps both a numeric
+        // and a hard-keyword TS2427 in the same file (neither suppresses the
+        // other) — the branch the removed bespoke filter would have collapsed.
+        let diagnostics =
+            collect_test_diagnostics(&[("/a.ts", "interface void {}\ninterface 123 {}\n")]);
+        assert_eq!(
+            diagnostics.iter().filter(|d| d.code == 2427).count(),
+            2,
+            "both the `void` and numeric TS2427 must survive, got: {diagnostics:?}"
+        );
+    }

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -348,9 +348,6 @@ pub(super) fn filtered_parse_diagnostics(
     // parse diagnostics (tsc does this in plain JS binder errors), but suppress
     // it for expression-recovery cases where TS1109 is the primary diagnostic.
     let has_expression_expected_parse_error = parse_diagnostics.iter().any(|d| d.code == 1109);
-    let has_hard_keyword_interface_ts2427 = parse_diagnostics
-        .iter()
-        .any(is_hard_keyword_interface_name_2427_parse_diagnostic);
     parse_diagnostics
         .iter()
         .filter(|diagnostic| {
@@ -374,12 +371,6 @@ pub(super) fn filtered_parse_diagnostics(
             if diagnostic.code == 1359
                 && diagnostic.message.contains("'await'")
                 && has_expression_expected_parse_error
-            {
-                return false;
-            }
-            if has_hard_keyword_interface_ts2427
-                && diagnostic.code == 2427
-                && !is_hard_keyword_interface_name_2427_parse_diagnostic(diagnostic)
             {
                 return false;
             }
@@ -427,12 +418,6 @@ pub(super) fn suppress_parameter_grammar_losers(
             .iter()
             .any(|&(start, end)| diagnostic.start >= start && diagnostic.start < end)
     });
-}
-
-fn is_hard_keyword_interface_name_2427_parse_diagnostic(diagnostic: &ParseDiagnostic) -> bool {
-    diagnostic.code == 2427
-        && (diagnostic.message == "Interface name cannot be 'void'."
-            || diagnostic.message == "Interface name cannot be 'null'.")
 }
 
 #[path = "check_utils/parser_grammar_code.rs"]
@@ -567,6 +552,11 @@ pub(super) const fn keep_diagnostic_when_js_only_syntactic_skips_semantic(code: 
     is_real_syntax_error(code)
         || is_ts1xxx_allowed_in_js(code)
         || (code >= 8000 && code < 9000)
+        // Reserved declaration-name diagnostics survive the JS-only semantic
+        // skip. This axis is orthogonal to #16279's parse-error suppression
+        // (which distinguishes 2427 from 2457): here both are kept because a JS
+        // file's reserved-name grammar error is not a suppressible semantic
+        // diagnostic, regardless of which side emits it.
         || matches!(code, 2427 | 2457)
 }
 

--- a/crates/tsz-cli/src/driver/check_utils/parser_grammar_code.rs
+++ b/crates/tsz-cli/src/driver/check_utils/parser_grammar_code.rs
@@ -101,17 +101,16 @@
 ///   reports TS2499 twice today regardless of this list. Adding it here
 ///   would fold a real emission-site bug into this suppression-only audit;
 ///   left for its own fix.
-/// - **TS2427/TS2457** (interface/type-alias reserved names) have an
-///   existing bespoke hard-keyword-vs-checker-emitted split
-///   (`is_hard_keyword_interface_name_2427_parse_diagnostic` here,
-///   `is_hard_keyword_interface_name_2427` in `checker_diagnostics.rs`) that
-///   this audit did not have the budget to verify safe to fold in here; a
-///   future slice should re-derive that interaction against the oracle
-///   before touching either code. TS2819 (namespace reserved names, the
-///   third member of this same family) was oracle-tested and rejected: tsc
-///   keeps it alongside an unrelated syntax error in the same file, unlike
-///   its TS2427/TS2457 siblings — so family membership must not be assumed
-///   from a sibling's membership.
+/// - **TS2427/TS2457** (interface/type-alias reserved names) are resolved by
+///   emission site rather than by this list (#16279): the parser owns the
+///   hard-keyword `void`/`null` (and numeric) interface-name TS2427, the checker
+///   owns the soft predefined-type names, and the CLI keep-gate
+///   (`checker_diagnostics.rs`) deduplicates and suppresses per tsc's
+///   `hasParseDiagnostics` — so neither code belongs in this parser-grammar
+///   list. TS2819 (namespace reserved names, the third member of this family)
+///   was oracle-tested and rejected: tsc keeps it alongside an unrelated syntax
+///   error in the same file, unlike its TS2427/TS2457 siblings — so family
+///   membership must not be assumed from a sibling's membership.
 ///
 /// #16279 audit round 5: TS1492 (`'{0}' declarations may not have binding
 /// patterns.`, `state_variable_declarations.rs` — `using {a} = x` / `await

--- a/crates/tsz-cli/src/driver/checker_diagnostics.rs
+++ b/crates/tsz-cli/src/driver/checker_diagnostics.rs
@@ -14,7 +14,14 @@ pub(super) fn program_has_real_syntax_errors(program: &MergedProgram) -> bool {
         .files
         .iter()
         .flat_map(|file| file.parse_diagnostics.iter())
-        .any(|diag| is_real_syntax_error(diag.code))
+        // TS2427/TS2457 as *parse* diagnostics are the hard-keyword/numeric
+        // reserved-name rejections the parser owns (`void`/`null`/`123` as an
+        // interface or type-alias name — soft predefined-type names are
+        // checker-emitted and never reach `parse_diagnostics`). tsc treats those
+        // as `hasParseDiagnostics`, short-circuiting the whole file's semantic
+        // phase — e.g. `interface void {}` next to a real type error suppresses
+        // the type error entirely (#16279). Counting them here reproduces that.
+        .any(|diag| is_real_syntax_error(diag.code) || matches!(diag.code, 2427 | 2457))
         || program
             .files
             .iter()
@@ -47,42 +54,36 @@ pub(super) fn program_has_unsupported_js_root(
             .any(|file| is_js_file(Path::new(&file.file_name)))
 }
 
-const fn is_reserved_type_name_declaration_diagnostic(code: u32) -> bool {
-    matches!(code, 2427 | 2457)
-}
-
-/// Returns true if a TS2427 diagnostic message refers to a hard reserved
-/// keyword that triggers a parser error in tsc (`void` or `null`). When such
-/// an interface declaration is present in a source file, tsc only surfaces
-/// the TS2427 for that hard-keyword interface and suppresses TS2427 for any
-/// other reserved-name interfaces in the same file. This mirrors tsc's
-/// behavior in `interfacesWithPredefinedTypesAsNames.ts` and similar tests.
-fn is_hard_keyword_interface_name_2427(diag: &Diagnostic) -> bool {
-    if diag.code != 2427 {
-        return false;
-    }
-    diag.message_text == "Interface name cannot be 'void'."
-        || diag.message_text == "Interface name cannot be 'null'."
+/// The reserved *type-alias*-name diagnostic (TS2457) that survives a sibling
+/// parse error, unlike the reserved *interface*-name diagnostic (TS2427).
+///
+/// tsc emits `type void = ...`'s TS2457 such that it survives alongside an
+/// unrelated parse error (oracle: `type void = number` survives Direction B),
+/// and tsz emits even that hard-keyword form from the checker
+/// (`statement_callback_bridge`), never from the parser — and never for a soft
+/// name. TS2427 is the opposite: its hard-keyword `void`/`null` form is now
+/// parser-owned (`state_declarations.rs`) so it never reaches a checker gate,
+/// and the soft form that does reach one is a checker `grammarErrorOnNode` that
+/// tsc suppresses under a sibling parse error. So the two codes are gated
+/// differently everywhere the checker-diagnostic pipeline consults them (#16279).
+const fn checker_reserved_type_alias_name_survives_parse_error(code: u32) -> bool {
+    code == 2457
 }
 
 pub(super) fn keep_checker_diagnostic_when_program_has_real_syntax_errors(code: u32) -> bool {
     // tsc suppresses type-level semantic diagnostics when any source file in the
-    // program has a real syntax error, but it still reports declaration-name
-    // diagnostics such as TS2427/TS2457 alongside parse errors because the parser
-    // accepts those names and defers validation to the checker.
-    //
-    // `code < 2000` is only a proxy for "the parser emitted this". It is wrong
-    // for every `TS1xxx` code that tsz emits from the checker's or binder's
-    // grammar phase: tsc routes those through `getSemanticDiagnostics`, so the
-    // syntactic phase short-circuits them program-wide. Both this gate and the
-    // JS-only (`TS8xxx`) gate model that same tsc short-circuit, so they share
-    // one list.
+    // program has a real syntax error. `code < 2000` is a proxy for "the parser
+    // emitted this"; `is_checker_routed_ts1xxx_grammar` corrects the TS1xxx codes
+    // tsz emits from the checker/binder that tsc routes through the semantic
+    // phase. TS2457 is kept per its own rule (see the predicate); TS2427 is not
+    // (it is now parser-owned for hard keywords, checker-emitted for soft names
+    // which tsc suppresses here).
     if check_utils::is_checker_routed_ts1xxx_grammar(code) {
         return false;
     }
     code < 2000
         || tsz::checker::diagnostics::is_js_grammar_diagnostic(code)
-        || is_reserved_type_name_declaration_diagnostic(code)
+        || checker_reserved_type_alias_name_survives_parse_error(code)
 }
 
 /// `TS1xxx` codes that tsc routes through `getSemanticDiagnostics`. They are in
@@ -193,29 +194,13 @@ pub(super) fn post_process_checker_diagnostics(
         checker_diagnostics.retain(|diag| diag.code < 2000);
     }
 
-    // When the file contains an `interface void {}` or `interface null {}`
-    // declaration, tsc only emits TS2427 for that hard-keyword interface and
-    // suppresses TS2427 for ANY other interfaces in the same file (including
-    // ones with predefined-type names like `any`, `number`, etc.). This is
-    // because tsc's parser produces a parse error for hard-keyword names,
-    // which prevents the lazy diagnostic queue from running for the other
-    // interface declarations. We don't currently emit a parse error in our
-    // parser for `void`/`null` as interface names, so we model the same
-    // suppression by filtering out non-hard-keyword TS2427 when a
-    // hard-keyword TS2427 is present.
-    let has_hard_keyword_ts2427 = checker_diagnostics
-        .iter()
-        .any(is_hard_keyword_interface_name_2427);
-    if has_hard_keyword_ts2427 {
-        checker_diagnostics.retain(|diag| {
-            // Keep all non-TS2427 diagnostics untouched.
-            if diag.code != 2427 {
-                return true;
-            }
-            // Among TS2427, keep only the hard-keyword (`void`/`null`) ones.
-            is_hard_keyword_interface_name_2427(diag)
-        });
-    }
+    // The `interface void {}` / `interface null {}` same-file suppression that
+    // used to live here is now handled structurally: the parser owns the
+    // hard-keyword TS2427 (a `ParseDiagnostic`), which makes
+    // `program_has_real_syntax_errors` true and suppresses every *checker*
+    // TS2427 (the soft predefined-type-name form) in the file via the keep-gate
+    // above — exactly tsc's `hasParseDiagnostics` short-circuit, with no
+    // message-text matching (#16279).
 
     // TS2499 ("An interface can only extend an identifier/qualified-name
     // with optional type arguments") is grammar-decidable at parse time for
@@ -293,12 +278,9 @@ pub(super) fn post_process_checker_diagnostics(
             if diag.code < 2000 || tsz::checker::diagnostics::is_js_grammar_diagnostic(diag.code) {
                 return true;
             }
-            // Some semantic errors are deliberately emitted alongside
-            // structural parse errors and must not be suppressed.
-            // TS2427 / TS2457 are checker-side validation for reserved type names
-            // in interface/type-alias declarations. TSC keeps them even when the
-            // surrounding file also has structural parse errors.
-            if is_reserved_type_name_declaration_diagnostic(diag.code) {
+            // TS2457 survives a sibling parse error (see the predicate); its
+            // TS2427 sibling does not, so it is not exempted here (#16279).
+            if checker_reserved_type_alias_name_survives_parse_error(diag.code) {
                 return true;
             }
             // Suppress if a structural parse error is within the cascade window
@@ -335,8 +317,16 @@ mod tests {
         assert!(keep_checker_diagnostic_when_program_has_real_syntax_errors(
             1005
         ));
+        // #16279: the reserved interface-name TS2427 is now parser-owned for the
+        // hard keywords `void`/`null` (a `ParseDiagnostic` that never reaches this
+        // checker-diagnostic gate); the only TS2427 that reaches here is the soft
+        // predefined-type-name form, which tsc suppresses under a sibling parse
+        // error — so it must NOT be kept. The reserved type-alias-name TS2457,
+        // whose hard-keyword `void` form tsz emits from the checker, IS kept
+        // (tsc keeps `type void = ...`'s TS2457 alongside a parse error).
+        assert!(!keep_checker_diagnostic_when_program_has_real_syntax_errors(2427));
         assert!(keep_checker_diagnostic_when_program_has_real_syntax_errors(
-            2427
+            2457
         ));
         assert!(!keep_checker_diagnostic_when_program_has_real_syntax_errors(2322));
     }

--- a/crates/tsz-parser/src/parser/state_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_declarations.rs
@@ -11,24 +11,6 @@ use crate::parser::{
 use tsz_common::interner::{AstAtom, IdentText};
 use tsz_scanner::SyntaxKind;
 
-fn is_reserved_interface_type_name(name: &str) -> bool {
-    matches!(
-        name,
-        "any"
-            | "unknown"
-            | "never"
-            | "string"
-            | "number"
-            | "boolean"
-            | "symbol"
-            | "bigint"
-            | "void"
-            | "undefined"
-            | "null"
-            | "object"
-    )
-}
-
 enum TypeMemberPropertyOrMethodName {
     Property(NodeIndex),
     IndexSignature(NodeIndex),
@@ -87,9 +69,16 @@ impl ParserState {
                     self.current_token,
                     SyntaxKind::VoidKeyword | SyntaxKind::NullKeyword
                 );
-                let name_text = self.scanner.get_token_value();
-                if is_reserved_interface_type_name(name_text.as_str()) {
+                // Emit TS2427 only for the hard keywords `void`/`null`, which
+                // cannot be identifiers — tsc rejects those at parse time. The
+                // soft predefined-type names (`string`, `number`, ...) are valid
+                // identifiers that tsc (and `interface_checks.rs`) reject from the
+                // checker instead; emitting them here too double-emitted and, being
+                // outside `is_parser_grammar_code`, deleted sibling grammar
+                // diagnostics in the same file (#16279).
+                if has_invalid_hard_keyword_name {
                     use tsz_common::diagnostics::diagnostic_codes;
+                    let name_text = self.scanner.get_token_value();
                     let name_start = self.token_pos();
                     let name_end = self.token_end();
                     self.parse_error_at(


### PR DESCRIPTION
Fixes the reserved interface/type-alias-name slice of #16279 (the round-4-deferred TS2427/TS2457 family).

**Structural rule:** when an interface name is a reserved type name, `tsc` splits the TS2427 rejection by emission site — hard keywords (`void`/`null`) and numeric names are **parser** diagnostics (they set `hasParseDiagnostics`, survive alongside a sibling syntax error, and short-circuit the file's semantic phase); soft predefined-type names (`string`, `number`, `object`, …) are **checker** `grammarErrorOnNode` diagnostics, suppressed by a sibling parse error. tsz emitted the *soft-name* TS2427 from the parser, which both double-emitted with the checker's copy and — being outside `is_parser_grammar_code` — counted as a suppressing "real parse error" that silently deleted sibling grammar diagnostics in the same file (#16279's family-deletion signature; `interface string {}` next to a bad `get` accessor dropped the TS1054). This can't be a classification-list add: `void`-2427 and `string`-2427 share code 2427 and `tsc` keeps the former but drops the latter, and distinguishing them by message text is the diagnostic-string predicate the anti-hardcoding gate forbids — so the correct owner is the emission site.

**Owner layer:**
- Parser (`state_declarations.rs`) emits the interface-name TS2427 only for hard keywords `void`/`null` (numeric names keep their branch); the checker (`interface_checks.rs`) owns the soft names it already handled.
- `program_has_real_syntax_errors` counts parser-emitted TS2427/TS2457 so the hard-keyword form short-circuits the file's semantic phase (matching `hasParseDiagnostics`) and suppresses the checker's soft-name copy in the same file via the keep-gate.
- The keep-gate drops TS2427 (soft-name form suppressed under a sibling parse error) but keeps TS2457 via a named predicate — tsz emits even the hard-keyword `type void` TS2457 from the checker, which `tsc` keeps alongside a parse error.
- Deletes both message-text hacks (`is_hard_keyword_interface_name_2427` + `..._parse_diagnostic`) and the same-file suppression block they drove; now handled structurally.

**Adjacent matrix (oracle `typescript@7.0.2`, both directions):**

| case | before | after = tsc |
| --- | --- | --- |
| `interface string {}` + `get x(a){}` | TS1054 **deleted** | both TS2427 + TS1054 |
| `interface string {}` | double TS2427 | single TS2427 |
| `interface string {}` + syntax error | TS2427 kept | TS2427 suppressed |
| `interface void {}` + type error | TS2322 leaked | TS2322 suppressed (2nd divergence fixed) |
| `interface void {}` + `interface string {}` | message-filter | only `void` TS2427 (structural) |
| `interface void {}` + `interface 123 {}` | collapsed | both TS2427 |
| `type void = number` + syntax error | TS2457 kept | TS2457 kept |

Soft names varied across `string`/`number`/`object`/`boolean` in tests. Moving type-alias TS2457 to the parser for symmetry would *diverge* from tsc (its `void`-2457 is checker-emitted upstream too) — correctly out of scope.

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-cli --lib` reserved-name tests: 6 new (`soft_reserved_*`, `hard_keyword_*`, `numeric_and_hard_keyword_*`) + `checker_diagnostics` keep-gate unit test + 2 existing `real_syntax_errors_preserve_*` — all pass.
- `cargo nextest run -p tsz-cli --test tsc_compat_tests -E 'test(ts2427)'` — all 3 `tsc_parity_ts2427_*` pass against the local `tsc`.
- `cargo nextest run -p tsz-checker --test conformance_issues_errors` — 301/303 pass (js_module reserved-name tests green; the 2 failures are pre-existing class private-member/implements conformance, no interface/reserved-name/parse-error overlap).
- `cargo clippy -p tsz-parser -p tsz-checker -p tsz-cli` clean; architecture guard (2000-line cap) passes.
- All 14 CLI witnesses match `typescript@7.0.2` exactly (Direction A/B for `interface {void,null,string,number,object,123}`, `type {void,string}`, and combos).

Note: the `tsc_compat` `tsc_parity_version`/`help`/flag failures observed locally are the tsc 6.0.2-vs-tsz 7.0.2 environmental version mismatch (the pinned repo TypeScript isn't installed in this sandbox), not this change.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYF5KufCEv5hUqWkoSdUg2)_