### PR TITLE
fix(parser): independent statement after binary-operator-seeded recovery keeps its own missing-';' report

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -402,6 +402,10 @@ mod for_header_private_identifier_binding_tests;
 #[path = "../../tests/keyword_identifier_missing_semicolon_cascade_tests.rs"]
 mod keyword_identifier_missing_semicolon_cascade_tests;
 
+#[cfg(test)]
+#[path = "../../tests/binary_operator_seeded_statement_semicolon_cascade_tests.rs"]
+mod binary_operator_seeded_statement_semicolon_cascade_tests;
+
 // Re-export flags
 pub use flags::{modifier_flags, node_flags, transform_flags};
 

--- a/crates/tsz-parser/src/parser/state.rs
+++ b/crates/tsz-parser/src/parser/state.rs
@@ -187,6 +187,16 @@ pub struct ParserState {
     pub(crate) recursion_depth: u32,
     /// Position of last error (to prevent cascading errors at same position)
     pub(crate) last_error_pos: u32,
+    /// Set when an expression statement that began with a bare binary
+    /// operator (`in`, `instanceof`, ...; tsc's missing-left-operand
+    /// recovery) finishes without consuming a real `;`, to the position of
+    /// the unconsumed token it leaves behind. That token becomes the start of
+    /// the very next statement, so its own missing-`;` report can land within
+    /// `should_report_error`'s distance-suppression window of THIS
+    /// statement's — which are two distinct tsc diagnostics, not a cascade.
+    /// Consumed (taken) by `parse_error_for_missing_semicolon_after` so it
+    /// only ever applies to the one statement immediately following.
+    pub(crate) binary_seeded_statement_boundary: Option<u32>,
     /// Number of scanner diagnostics observed at the time the most recent
     /// parser-side diagnostic was pushed. `scanner_diagnostics[idx..]` for
     /// any `idx >= this` represents scanner emissions that happened *after*
@@ -427,6 +437,7 @@ impl ParserState {
             node_count: 0,
             recursion_depth: 0,
             last_error_pos: 0,
+            binary_seeded_statement_boundary: None,
             scanner_diagnostics_high_water_mark: 0,
             reported_offset_overflow: Cell::new(false),
             reported_node_flag_overflow: Cell::new(false),

--- a/crates/tsz-parser/src/parser/state/recovery.rs
+++ b/crates/tsz-parser/src/parser/state/recovery.rs
@@ -437,6 +437,13 @@ impl ParserState {
         use crate::parser::spelling;
         use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages};
 
+        // Take (and clear) the boundary left by an immediately preceding
+        // binary-operator-seeded expression statement (see
+        // `binary_seeded_statement_boundary`'s doc comment). Read unconditionally
+        // so it never leaks past the one statement it was recorded for,
+        // regardless of which branch below ends up using it.
+        let inherited_binary_seeded_boundary = self.binary_seeded_statement_boundary.take();
+
         let Some((pos, len, expression_text)) =
             self.missing_semicolon_after_expression_text(expression)
         else {
@@ -468,8 +475,33 @@ impl ParserState {
                 .rev()
                 .take(4)
                 .any(|diag| diag.start == token_pos);
+            // `should_report_error()`'s distance heuristic suppresses cascading
+            // diagnostics that share one root cause within a single statement's
+            // own recovery — correct for e.g. repeated stray `#!` tokens inside
+            // one malformed variable initializer. It wrongly suppresses THIS
+            // statement's own missing-`;` report, though, when the immediately
+            // *preceding* statement was itself a binary-operator-seeded
+            // recovery (`in`/`instanceof`/... at statement start) whose own
+            // missing-`;` report left its unconsumed token as the start of
+            // this new statement. E.g. `in get x(): number;`: `get`'s
+            // missing-`;` report anchors at `x` (the token `<missing> in get`
+            // left unconsumed), which is also where the next, independent
+            // statement's expression (`x()`) begins — so `x()`'s own
+            // missing-`;` report sits within `ERROR_SUPPRESSION_DISTANCE` of
+            // it even though it is a distinct tsc diagnostic (`parseErrorAtPosition`
+            // dedups only same-start, never same-neighborhood).
+            // `binary_seeded_statement_boundary` tags exactly that one shape
+            // (set only for a `started_with_binary_operator` statement, only
+            // when it did not consume a real `;`) so this bypass cannot also
+            // fire for unrelated cascades like the `#!` case above, which
+            // never sets that flag. Same class of fix already applied to the
+            // analogous `parse_expected(ColonToken)` gate in
+            // `state_expressions_literals/object_members.rs`.
+            let expr_start = self.arena.get(expression).map_or(token_pos, |n| n.pos);
+            let prior_statement_diagnostic = inherited_binary_seeded_boundary == Some(expr_start);
             if !already_reported_here
-                && (self.should_report_error()
+                && (prior_statement_diagnostic
+                    || self.should_report_error()
                     || self.last_error_was_leading_zero_at_other_pos()
                     || self.last_error_was_element_access_missing_argument_at_other_pos())
             {

--- a/crates/tsz-parser/src/parser/state_switch_recovery.rs
+++ b/crates/tsz-parser/src/parser/state_switch_recovery.rs
@@ -514,7 +514,8 @@ impl ParserState {
         // Use smart error reporting for missing semicolons (matches TypeScript's
         // parseExpressionOrLabeledStatement behavior). Instead of generic TS1005 "';' expected",
         // this checks if the expression is a misspelled keyword and emits TS1435/TS1434.
-        if self.is_token(SyntaxKind::SemicolonToken) {
+        let found_real_semicolon = self.is_token(SyntaxKind::SemicolonToken);
+        if found_real_semicolon {
             let semicolon_pos = self.token_pos();
             let needs_jsx_semicolon_missing_brace =
                 self.arena.get(expression).is_some_and(|node| {
@@ -681,6 +682,15 @@ impl ParserState {
             if self.is_token(SyntaxKind::ColonToken) {
                 self.next_token();
             }
+        }
+        // Tag the boundary this statement leaves behind when it began with a
+        // bare binary operator (`in`/`instanceof`/...) and did not consume a
+        // real `;`: the unconsumed token here becomes the very next
+        // statement's start, and that next statement's own missing-`;` report
+        // (if any) is a distinct tsc diagnostic, not a cascade of this one.
+        // See `binary_seeded_statement_boundary`'s doc comment.
+        if started_with_binary_operator && !found_real_semicolon {
+            self.binary_seeded_statement_boundary = Some(self.token_pos());
         }
         // token_full_start() (not token_end()) matches tsc's finishNode/getTokenFullStart() for ASI.
         let end_pos = self.token_full_start();

--- a/crates/tsz-parser/tests/binary_operator_seeded_statement_semicolon_cascade_tests.rs
+++ b/crates/tsz-parser/tests/binary_operator_seeded_statement_semicolon_cascade_tests.rs
@@ -1,0 +1,122 @@
+//! A statement-list-level regression in `parse_error_for_missing_semicolon_after`
+//! (`crates/tsz-parser/src/parser/state/recovery.rs`), oracle-verified against
+//! `typescript@7.0.2`.
+//!
+//! When a statement begins with a bare binary operator that cannot start an
+//! expression (`in`, `instanceof`, ...; tsc's missing-left-operand recovery,
+//! `started_with_binary_operator` in `parse_expression_statement`), the
+//! statement is built as `<missing> <op> <rhs>` and, if it does not find a
+//! real `;`, reports its own `';' expected.` at the token it leaves
+//! unconsumed. That unconsumed token becomes the START of the very next,
+//! independent statement. If that next statement is itself a postfix/call
+//! expression (not a plain identifier) and it *also* needs its own
+//! `';' expected.` report, tsc reports both — `parseErrorAtPosition` dedups
+//! only on an exact-same-start match, never on proximity.
+//!
+//! tsz's `should_report_error()` uses a *distance* heuristic
+//! (`ERROR_SUPPRESSION_DISTANCE` = 3) instead, to suppress cascades that
+//! genuinely share one root cause within a single statement's own recovery
+//! (e.g. repeated stray `#!` tokens inside one malformed variable
+//! initializer — see `state_statement_tests_parts/part_00.rs`'s
+//! `parse_malformed_variable_hashbang_tail_matches_tsc_shape`, which still
+//! must NOT regress). That heuristic wrongly also swallowed the *second*,
+//! independent statement's own report whenever it landed within 3 characters
+//! of the *first* statement's — exactly what happens here, since both
+//! reports anchor at the same short token.
+//!
+//! Fixed with `binary_seeded_statement_boundary`: a narrow, one-statement-only
+//! flag set *only* when `started_with_binary_operator` is true and no real
+//! `;` was found, recording the boundary position. The very next statement's
+//! own missing-`;` check bypasses the distance heuristic only when it lands
+//! exactly on that recorded boundary — never for the `#!` family or any other
+//! cascade shape, since only a bare-binary-operator-seeded statement sets the
+//! flag at all.
+
+use crate::parser::test_fixture::parse_source;
+use tsz_common::diagnostics::diagnostic_codes;
+use tsz_common::position::LineMap;
+
+/// `(code, line, column)` fingerprints, 1-based, in report order.
+fn fingerprints(source: &str) -> Vec<(u32, u32, u32)> {
+    let (parser, _root) = parse_source(source);
+    let line_map = LineMap::build(source);
+    parser
+        .get_diagnostics()
+        .iter()
+        .map(|diag| {
+            let pos = line_map.offset_to_position(diag.start, source);
+            (diag.code, pos.line + 1, pos.character + 1)
+        })
+        .collect()
+}
+
+const TS1005: u32 = diagnostic_codes::EXPECTED;
+const TS1109: u32 = diagnostic_codes::EXPRESSION_EXPECTED;
+
+// ---------------------------------------------------------------------------
+// The reported shape: `in` at statement start recovers as
+// `<missing> in get`, then the independent `x(): number;` statement follows
+// immediately and needs its own missing-`;` report.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn binary_seeded_statement_then_call_expression_with_type_annotation_tail() {
+    assert_eq!(
+        fingerprints("in get x(): number;"),
+        vec![(TS1109, 1, 1), (TS1005, 1, 8), (TS1005, 1, 11)]
+    );
+}
+
+/// Renamed binder: `instanceof` instead of `in`, and a differently-named
+/// call target, confirms the fix is not keyed to the literal text `in`/`get`/`x`.
+#[test]
+fn binary_seeded_statement_renamed_binder_instanceof_then_call_expression() {
+    assert_eq!(
+        fingerprints("instanceof set target(): string;"),
+        vec![(TS1109, 1, 1), (TS1005, 1, 16), (TS1005, 1, 24)]
+    );
+}
+
+/// Without the trailing `: number` tail, `x();` is a *complete* statement
+/// (a real `;` follows the call) — tsc's statement loop finds it and reports
+/// nothing further. Confirms the fix does not over-report once the second
+/// statement is itself well-formed.
+#[test]
+fn binary_seeded_statement_then_well_formed_call_expression_reports_only_two() {
+    assert_eq!(
+        fingerprints("in get x();"),
+        vec![(TS1109, 1, 1), (TS1005, 1, 8)]
+    );
+}
+
+/// Negative control: a real `;` right after the binary-operator-seeded
+/// statement's RHS means it never reaches the missing-semicolon path at all,
+/// so `binary_seeded_statement_boundary` is never set and the next statement
+/// gets no unwarranted treatment.
+#[test]
+fn binary_seeded_statement_with_real_semicolon_then_independent_statement() {
+    assert_eq!(
+        fingerprints("in get; x(): number;"),
+        vec![(TS1109, 1, 1), (TS1005, 1, 12)]
+    );
+}
+
+/// Regression guard for the adjacent, differently-shaped cascade this fix
+/// must not disturb: repeated stray `#!` tokens inside one malformed `const`
+/// initializer are a single statement's own recovery, not independent
+/// statements, and must keep reporting all four TS18026 sites (never gated on
+/// `binary_seeded_statement_boundary`, since `!` is not a binary operator).
+#[test]
+fn hashbang_tail_inside_one_malformed_initializer_still_reports_every_site() {
+    let source =
+        "const a =!@#!@$\nconst b = !@#!@#!@#!\nOK!\nHERE's A shouty thing\nGOTTA GO FAST\n";
+    let diags = fingerprints(source);
+    let ts18026_count = diags
+        .iter()
+        .filter(|(code, _, _)| *code == diagnostic_codes::CAN_ONLY_BE_USED_AT_THE_START_OF_A_FILE)
+        .count();
+    assert_eq!(
+        ts18026_count, 4,
+        "expected four TS18026 sites, got {diags:?}"
+    );
+}


### PR DESCRIPTION
Continues #16291's piece 1 (general statement-parser recovery, not
interface-specific): `in get x(): number;` — a statement beginning with a
bare binary operator that cannot start an expression — under-reported by one
diagnostic on current main.

## Structural rule

When a statement begins with a bare binary operator (`in`, `instanceof`, ...;
tsc's missing-left-operand recovery), tsc builds `<missing> <op> <rhs>` and,
absent a real `;`, reports `';' expected.` at the token it leaves unconsumed.
That token becomes the START of the very next, independent statement. If that
statement is itself a postfix/call expression needing its own missing-`;`
report, tsc reports **both** — `parseErrorAtPosition` dedups only on an exact
same-start match, never on proximity.

tsz's `should_report_error()` uses a *distance* heuristic
(`ERROR_SUPPRESSION_DISTANCE` = 3 chars) instead of exact-position dedup for
this call site. That heuristic is legitimate for cascades that share one root
cause within a *single* statement's own recovery (e.g. repeated stray `#!`
tokens inside one malformed variable initializer — see
`parse_malformed_variable_hashbang_tail_matches_tsc_shape`, preserved
unregressed and pinned as a new adjacent-case guard). But it also wrongly
swallowed the **second, independent statement's own** report whenever it
landed within 3 characters of the first — exactly the case here, since both
reports anchor on the same short token boundary.

Owner layer: parser recovery
(`crates/tsz-parser/src/parser/state/recovery.rs`'s
`parse_error_for_missing_semicolon_after`, and the caller in
`state_switch_recovery.rs`'s `parse_expression_statement`).

## Fix

Added a narrow, one-statement-lifetime flag,
`binary_seeded_statement_boundary`: set only when a
`started_with_binary_operator` statement finishes without consuming a real
`;`, to the position of the token it leaves behind. The very next statement's
own missing-`;` check takes (and clears) this flag, bypassing the distance
heuristic only when it lands exactly on that recorded boundary. This is
deliberately narrower than a blanket "always report" change — an earlier
version of this fix that removed the distance gate outright regressed the
`#!`-tail hashbang recovery test (2 of its 4 `TS18026` sites went missing,
replaced by 2 spurious `TS1005`s), because that heuristic is doing real work
suppressing genuine same-statement cascades elsewhere. Since `!` is not a
binary operator, the hashbang path never sets the new flag, so it is
unaffected.

## Adjacent-case matrix (oracle-verified, `typescript@7.0.2`)

New file `crates/tsz-parser/tests/binary_operator_seeded_statement_semicolon_cascade_tests.rs`:
- The reported repro (`in get x(): number;`) — 3 diagnostics, was 2.
- Renamed binder (`instanceof set target(): string;`) — same shape, different
  operator/identifiers, confirms not text-keyed.
- A well-formed second statement (`in get x();`) — still exactly 2
  diagnostics, confirming no over-reporting once the next statement is valid.
- Negative control: a real `;` right after the binary-operator-seeded
  statement (`in get; x(): number;`) — the flag is never set, next statement
  gets its own independent (unaffected) diagnostic.
- Regression guard: the `#!`-tail hashbang fixture still reports all 4
  `TS18026` sites.

## Verification

- `cargo test -p tsz-parser --lib` — **2232/2232 passed**, 0 regressions (was
  2227/2227 before the 5 new tests).
- `cargo clippy -p tsz-parser --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `python3 scripts/arch/arch_guard.py` — clean.
- `cargo test -p tsz-checker --lib statement` (117/117) and `--lib semicolon`
  (5/5) — 0 regressions in checker-side consumers of parser diagnostics.
- CLI end-to-end (debug build) vs. pinned `typescript@7.0.2` oracle, byte-for-byte
  match on 7 fixtures: the reported repro, both adjacent variants above, the
  isolated fragments (`x(): number;`, `get x(): number;`), and the hashbang
  regression-guard fixture.
- Not run: `compare-to-parent`/conformance snapshot (time budget). Expected
  zero/near-zero corpus movement — this is a diagnostic-count fix in a rare
  malformed-recovery shape (a bare binary operator at statement start
  immediately followed by a postfix expression with its own syntax error),
  not a new diagnostic class; flagged as owed.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwsFHUSmQayWgxrWmZAmvu)_