### PR TITLE
fix(checker): print every constituent of a fully-collapsed anonymous object union (#16509)

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/type_construction.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_construction.rs
@@ -171,9 +171,52 @@ pub(crate) fn type_node_annotation_union_with_origin(
     db: &dyn TypeDatabase,
     members: Vec<TypeId>,
 ) -> TypeId {
-    let result = tsz_solver::utils::union_or_single_literal_reduce(db, members.clone());
+    let result = union_annotation_preserving_anonymous_multiplicity(db, &members);
     db.store_union_origin(result, members);
     result
+}
+
+/// Reduce a written type-annotation union while preserving the *display*
+/// multiplicity of duplicate anonymous object members that content-interning
+/// would otherwise collapse (#16509).
+///
+/// `tsc` mints a fresh anonymous type per written `{ ... }` occurrence, so
+/// `{ m: number } | { m: number }` is a genuine two-member union whose
+/// diagnostic prints both constituents. tsz content-interns the identical
+/// literals onto one `TypeId`, so the ordinary literal reduction collapses the
+/// whole union to that single member and the printer has no union left to
+/// render, dropping the duplicate `tsc` keeps.
+///
+/// When the reduction fully collapses to a lone *anonymous* object that the
+/// written members listed two or more times, this re-interns those members
+/// verbatim through [`TypeDatabase::union_from_sorted_vec`], which interns the
+/// list as given rather than re-deduplicating it, so the duplicate occurrences
+/// survive as a real `Union` carrier; the printer's per-occurrence
+/// literal-member exemption then renders each one. Named types (`Foo | Foo`,
+/// whose members reduce to a `Lazy`/symbol-bearing type, not a bare anonymous
+/// object) and primitive literals (`1 | 1`) are unaffected and collapse exactly
+/// as `tsc` collapses them. A union of structurally identical members is
+/// semantically equivalent to the member, so no assignability or narrowing
+/// outcome changes.
+fn union_annotation_preserving_anonymous_multiplicity(
+    db: &dyn TypeDatabase,
+    members: &[TypeId],
+) -> TypeId {
+    let reduced = db.union_literal_reduce(members.to_vec());
+    // Anonymous object = a direct object shape carrying no declaration symbol.
+    // `get_object_shape_id` resolves only object/substitution forms, never a
+    // type parameter's constraint, so a constrained `T | T` (whose reduced form
+    // is the bare type parameter) is not treated as an anonymous object and
+    // still collapses.
+    let reduced_is_anonymous_object = tsz_solver::type_queries::get_object_shape_id(db, reduced)
+        .is_some_and(|shape_id| db.object_shape(shape_id).symbol.is_none());
+    if reduced_is_anonymous_object {
+        let occurrences = members.iter().filter(|&&member| member == reduced).count();
+        if occurrences >= 2 {
+            return db.union_from_sorted_vec(vec![reduced; occurrences]);
+        }
+    }
+    reduced
 }
 
 pub(crate) fn type_node_intersection(db: &dyn TypeDatabase, members: Vec<TypeId>) -> TypeId {

--- a/crates/tsz-checker/src/types/computation/type_operators.rs
+++ b/crates/tsz-checker/src/types/computation/type_operators.rs
@@ -78,19 +78,19 @@ impl<'a> CheckerState<'a> {
             }
             let construction_members = construction_members.unwrap_or_else(|| member_types.clone());
 
-            let result = tsz_solver::utils::union_or_single_literal_reduce(
-                self.ctx.types,
-                construction_members.clone(),
-            );
-            // Mirror tsc's `UnionType.origin`: record the as-written input
-            // member list so the diagnostic printer can preserve top-level
-            // alias names that union flattening would otherwise dissolve
-            // (e.g., `T | null` should display as `T | null`, not as T's
-            // expanded body). The interner stores at most one origin per
-            // flattened TypeId; first writer wins.
-            self.ctx
-                .types
-                .store_union_origin(result, construction_members);
+            // Reduce the written union and record its as-written `origin`.
+            // `type_node_annotation_union_with_origin` mirrors tsc's
+            // `UnionType.origin` (so `T | null` displays as `T | null`, not T's
+            // expanded body) and keeps a union of identical inline anonymous
+            // object literals (`{ m: number } | { m: number }`) as a real
+            // multi-member `Union` so every constituent prints, as `tsc` does
+            // (#16509). Shared with the `type_node` union path so both reduce
+            // identically.
+            let result =
+                crate::query_boundaries::type_construction::type_node_annotation_union_with_origin(
+                    self.ctx.types,
+                    construction_members,
+                );
             // Record, per member, whether it was written as an anonymous
             // `{ ... }` literal directly in *this* union — as opposed to a
             // named alias/interface reference whose body happens to reduce

--- a/crates/tsz-checker/tests/union_duplicate_literal_member_display_tests.rs
+++ b/crates/tsz-checker/tests/union_duplicate_literal_member_display_tests.rs
@@ -37,6 +37,104 @@ fn ts2322_message(diags: &[Diagnostic]) -> Option<String> {
         .map(|d| d.message_text.clone())
 }
 
+/// The issue's exact repro (#16509): a two-member union whose members are
+/// *both* the identical inline `{ m: number }` literal. Content-interning
+/// collapses the whole union to that one shape, so before the multiplicity-
+/// preserving construction the display dropped to a single `{ m: number; }`.
+/// `tsc` prints both.
+#[test]
+fn fully_collapsing_two_member_object_literal_union_prints_both() {
+    let diags = diagnostics(
+        r#"
+declare const a: { m: number } | { m: number };
+const x: boolean = a;
+"#,
+    );
+    let msg = ts2322_message(&diags).unwrap_or_default();
+    assert!(
+        msg.contains("{ m: number; } | { m: number; }"),
+        "expected both written constituents to print, got: {msg:?}"
+    );
+}
+
+/// Renamed-binder control for the fully-collapsing two-member case: distinct
+/// property spelling, same per-occurrence provenance behavior.
+#[test]
+fn fully_collapsing_two_member_object_literal_union_prints_both_renamed() {
+    let diags = diagnostics(
+        r#"
+declare const source: { count: string } | { count: string };
+const target: boolean = source;
+"#,
+    );
+    let msg = ts2322_message(&diags).unwrap_or_default();
+    assert!(
+        msg.contains("{ count: string; } | { count: string; }"),
+        "expected both written constituents to print, got: {msg:?}"
+    );
+}
+
+/// Fully-collapsing three-identical case: multiplicity is exact even when
+/// nothing else distinguishes the union, so it renders three constituents.
+#[test]
+fn fully_collapsing_three_member_object_literal_union_prints_all_three() {
+    let diags = diagnostics(
+        r#"
+declare const a: { m: number } | { m: number } | { m: number };
+const x: boolean = a;
+"#,
+    );
+    let msg = ts2322_message(&diags).unwrap_or_default();
+    assert!(
+        msg.contains("{ m: number; } | { m: number; } | { m: number; }"),
+        "expected exactly three constituents to print, got: {msg:?}"
+    );
+}
+
+/// Negative control for the fully-collapsing path: a two-member union of the
+/// *same named interface* still collapses to one constituent — the multiplicity
+/// preservation is anonymous-object-specific, matching `tsc`'s `Foo | Foo` → `Foo`.
+#[test]
+fn fully_collapsing_two_member_named_interface_union_collapses() {
+    let diags = diagnostics(
+        r#"
+interface Foo { m: number }
+declare const a: Foo | Foo;
+const x: boolean = a;
+"#,
+    );
+    let msg = ts2322_message(&diags).unwrap_or_default();
+    assert!(
+        msg.contains("'Foo' is not assignable") && !msg.contains("Foo | Foo"),
+        "expected the duplicate named interface to collapse to one, got: {msg:?}"
+    );
+}
+
+/// Negative control: a two-member union of the same type parameter (`T | T`)
+/// collapses to `T`. The multiplicity preservation keys on the reduced type
+/// being a *bare anonymous object*, not on an object reachable only through a
+/// type parameter's constraint, so a constrained `T` never renders as `T | T`.
+#[test]
+fn fully_collapsing_type_parameter_union_collapses() {
+    let diags = diagnostics(
+        r#"
+declare function f<T extends { m: number }>(x: T | T): void;
+declare const v: boolean;
+f(v);
+"#,
+    );
+    // The TS2345 argument message names the parameter type `T`, never `T | T`.
+    let msg = diags
+        .iter()
+        .find(|d| d.code == 2345)
+        .map(|d| d.message_text.clone())
+        .unwrap_or_default();
+    assert!(
+        !msg.contains("T | T"),
+        "a `T | T` type-parameter union must collapse to `T`, got: {msg:?}"
+    );
+}
+
 /// Three written members, two of them identical inline `{ m: number }`
 /// literals: `tsc` prints all three. The duplicate must survive to the display.
 #[test]


### PR DESCRIPTION
Fixes #16509.

A written type-annotation union whose members all content-intern to one anonymous object — `{ m: number } | { m: number }` — collapsed to that single shape, so the diagnostic printed **one** constituent where `tsc` prints every written occurrence. The existing origin machinery (added for `{ m: number } | { m: number } | { p: string }`) only reconstructs multiplicity for a union that *survives* as a multi-member `Union`; a full collapse leaves a bare object with no union to carry the origin, so exactly-`N`-identical unions still dropped their duplicates.

**Structural rule:** when a source union of two or more inline `{ ... }` literals content-interns to one anonymous object, `tsc` prints each written occurrence; tsz now does too, through the checker's union-annotation construction boundary.

### Owner layer & mechanism
`type_node_annotation_union_with_origin` (the single reduction boundary shared by both syntactic union paths) now calls `union_annotation_preserving_anonymous_multiplicity`. It detects the full collapse — the literal reduction yields a lone anonymous object that the written members listed two-or-more times — and re-interns those members verbatim through the existing `union_from_sorted_vec`, which interns the list as given rather than re-deduplicating it. The result is a real multi-member `Union` carrier, and the printer's existing per-occurrence literal-member exemption renders every constituent. No solver type-identity, semantics, or trait surface changes; a union of structurally identical members is equivalent to the member and every relation/narrowing site iterates members.

### Adjacent-case matrix (all tested, binder names varied)
- **Fix:** `{ m: number } | { m: number }` and the `N`-identical / renamed variants print all constituents.
- **Negative — named interface:** `Foo | Foo` collapses to `Foo` (member reduces to a `Lazy`/symbol-bearing type, not a bare anonymous object).
- **Negative — alias reference:** `Alias | Alias` collapses.
- **Negative — primitive literal:** `1 | 1` collapses.
- **Negative — type parameter:** `T | T` (reduced form is the bare type parameter, never a direct object shape via `get_object_shape_id`) collapses.
- **Unchanged:** distinct anonymous objects (`{ m: number } | { m: string }`) still each print.

### Scope / follow-up
Both syntactic union-construction paths route through the one reduction helper. The indexed-access/evaluator class (`T[keyof T]` over an interface whose properties share a value type — issue repro 2) is a separate owner layer (the union is synthesized in the evaluator and fully collapses at the type level) and is left as follow-up; it needs a distinct, semantically riskier change to the evaluation path.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test union_duplicate_literal_member_display_tests` — 12/12 (incl. new full-collapse fix cases + named/alias/primitive/type-parameter negative controls).
- `cargo test -p tsz-checker` union display siblings: `union_source_member_provenance_display_tests` (5/5), `union_source_elaboration_constituent_tests` (9/9), `union_target_missing_property_elaboration_tests` (13/13) — no regression.
- `cargo clippy -p tsz-checker --lib --tests` — clean.
- `python3 scripts/arch/arch_guard.py` (full) and `--size` — pass.
- Conformance snapshot (`conformance.sh snapshot --workers 12 --force`): 11,573 passed. This change is **message-text only** and conformance compares error **codes**, so it is code-invariant (the issue itself notes "a code-set comparison cannot see it"); the pre/post baseline diff is the known non-deterministic diagnostic set (#16309/#16308), none of which involve duplicate-anonymous-object unions.
- DTS emit verified directly on the repro (`tsz --declaration --emitDeclarationOnly`): `export declare const a: { m: number; } | { m: number; };` — matches `tsc`. (The full emit baseline runner could not be built in this environment — its Node setup step hangs on a network-gated install; nightly CI exercises the 13,530 JS / 1,669 DTS suite.)

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_016n91hcYbeqM9zSm9X3NPWb)_