### PR TITLE
fix(parser,checker): three statement-recovery divergences from #17062

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -999,6 +999,9 @@ path = "tests/object_literal_accessor_pair_parameter_type_tests.rs"
 name = "accessor_getter_contextual_return_from_setter_tests"
 path = "tests/accessor_getter_contextual_return_from_setter_tests.rs"
 [[test]]
+name = "accessor_missing_body_modifier_suppression_tests"
+path = "tests/accessor_missing_body_modifier_suppression_tests.rs"
+[[test]]
 name = "conditional_optional_infer_default_tests"
 path = "tests/conditional_optional_infer_default_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -1390,11 +1390,37 @@ impl<'a> CheckerState<'a> {
         // instead of tripping the program-wide `has_parse_errors` suppression.
         // The parser deliberately defers the body-less accessor here (see
         // `parse_accessor_body`); this is that deferred check.
+        //
+        // tsc's `checkGrammarModifiers(node) || checkGrammarAccessor(node)`
+        // OR-chain means a modifier already invalid on this accessor —
+        // `readonly` (TS1024), `in`/`out` (TS1274), or a duplicate `accessor`
+        // (TS1275) — reports its own error and short-circuits the missing-body
+        // check entirely, rather than piling a second diagnostic on the same
+        // malformed member (#17062). `declare` (TS1031) already gets this for
+        // free because a `declare`-modified node reads as ambient regardless
+        // of placement validity (`is_in_ambient_context`).
         let accessor_end = node.end;
         let accessor_body_missing = accessor.body.is_none();
         let accessor_is_abstract = self.has_abstract_modifier(&accessor.modifiers);
+        let accessor_has_modifier_invalid_on_accessor =
+            accessor.modifiers.as_ref().is_some_and(|mods| {
+                mods.nodes.iter().any(|&mod_idx| {
+                    self.ctx.arena.get(mod_idx).is_some_and(|mod_node| {
+                        matches!(
+                            tsz_scanner::SyntaxKind::try_from_u16(mod_node.kind),
+                            Some(
+                                tsz_scanner::SyntaxKind::ReadonlyKeyword
+                                    | tsz_scanner::SyntaxKind::InKeyword
+                                    | tsz_scanner::SyntaxKind::OutKeyword
+                                    | tsz_scanner::SyntaxKind::AccessorKeyword
+                            )
+                        )
+                    })
+                })
+            });
         if accessor_body_missing
             && !accessor_is_abstract
+            && !accessor_has_modifier_invalid_on_accessor
             && !self.ctx.is_declaration_file()
             && !self.ctx.arena.is_in_ambient_context(member_idx)
         {

--- a/crates/tsz-checker/tests/accessor_missing_body_modifier_suppression_tests.rs
+++ b/crates/tsz-checker/tests/accessor_missing_body_modifier_suppression_tests.rs
@@ -1,0 +1,98 @@
+//! A class get/set accessor's missing-`{`-body check
+//! (`check_accessor_declaration_with_request` in
+//! `crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs`)
+//! must not pile a `'{' expected` (TS1005) diagnostic on top of a member
+//! whose modifier list already carries its own grammar violation —
+//! `readonly` (TS1024), `in`/`out` (TS1274), or a duplicate `accessor`
+//! (TS1275). tsc's `checkGrammarModifiers(node) || checkGrammarAccessor(node)`
+//! OR-chain reports only the first problem and short-circuits the rest; tsz's
+//! checker previously ran the accessor-body check unconditionally, so these
+//! members got a spurious second diagnostic (#17062 item 3).
+//!
+//! `declare` (TS1031) already gets this "for free" via
+//! `NodeArena::is_in_ambient_context`, which treats any node carrying a
+//! `declare` modifier as ambient regardless of whether that placement is
+//! itself valid — no test needed for that shape here, it's covered by the
+//! plain bodyless-accessor baseline already matching tsc.
+
+use tsz_checker::test_utils::check_source_with_parse_health;
+
+const TS1005_EXPECTED: u32 = 1005;
+const TS1024_READONLY_MODIFIER: u32 = 1024;
+const TS1274_VARIANCE_MODIFIER: u32 = 1274;
+const TS1275_ACCESSOR_MODIFIER: u32 = 1275;
+
+/// Combined parser + checker diagnostic codes. TS1275 (duplicate `accessor`
+/// modifier) is parser-emitted; TS1005/TS1024/TS1274 here are all
+/// checker-emitted — `check_source_diagnostics` alone only sees the latter.
+fn codes(source: &str) -> Vec<u32> {
+    let (mut parser_codes, checker_codes) = check_source_with_parse_health(source);
+    parser_codes.extend(checker_codes);
+    parser_codes.sort_unstable();
+    parser_codes
+}
+
+// Baseline: a plain bodyless getter with no other modifier problem keeps its
+// TS1005 — this must NOT regress to being silently dropped.
+#[test]
+fn plain_bodyless_getter_reports_ts1005() {
+    let codes = codes("class C { get x(): number; }");
+    assert_eq!(codes, vec![TS1005_EXPECTED], "got {codes:?}");
+}
+
+#[test]
+fn plain_bodyless_setter_reports_ts1005() {
+    let codes = codes("class C { set x(v: number) {} get x(): number; }");
+    assert!(codes.contains(&TS1005_EXPECTED), "got {codes:?}");
+}
+
+// `readonly` on a getter: TS1024 only, no TS1005.
+#[test]
+fn readonly_bodyless_getter_reports_only_ts1024() {
+    let codes = codes("class C { readonly get x(): number; }");
+    assert_eq!(codes, vec![TS1024_READONLY_MODIFIER], "got {codes:?}");
+}
+
+#[test]
+fn static_readonly_bodyless_getter_reports_only_ts1024() {
+    let codes = codes("class C { static readonly get x(): number; }");
+    assert_eq!(codes, vec![TS1024_READONLY_MODIFIER], "got {codes:?}");
+}
+
+// `in`/`out` on a class member accessor: TS1274 only, no TS1005.
+#[test]
+fn in_modifier_bodyless_getter_reports_only_ts1274() {
+    let codes = codes("class C { in get x(): number; }");
+    assert_eq!(codes, vec![TS1274_VARIANCE_MODIFIER], "got {codes:?}");
+}
+
+#[test]
+fn out_modifier_bodyless_setter_reports_only_ts1274() {
+    let codes = codes("class C { out set x(v: number); }");
+    assert_eq!(codes, vec![TS1274_VARIANCE_MODIFIER], "got {codes:?}");
+}
+
+// Renamed accessor/property binder — the suppression is structural (reads
+// the modifier list), not keyed to a specific identifier.
+#[test]
+fn in_modifier_bodyless_getter_renamed_binder_reports_only_ts1274() {
+    let codes = codes("class Widget { in get value(): string; }");
+    assert_eq!(codes, vec![TS1274_VARIANCE_MODIFIER], "got {codes:?}");
+}
+
+// A duplicate `accessor` modifier on a get/set accessor: TS1275 only, no
+// TS1005.
+#[test]
+fn accessor_modifier_on_getter_reports_only_ts1275() {
+    let codes = codes("class C { accessor get x(): number; }");
+    assert_eq!(codes, vec![TS1275_ACCESSOR_MODIFIER], "got {codes:?}");
+}
+
+// Negative control: `abstract` legitimately allows a bodyless accessor with
+// no diagnostic at all — must stay clean, not accidentally suppressed-then-
+// re-triggered by the new modifier scan.
+#[test]
+fn abstract_bodyless_getter_in_abstract_class_stays_clean() {
+    let codes = codes("abstract class C { abstract get x(): number; }");
+    assert!(codes.is_empty(), "got {codes:?}");
+}

--- a/crates/tsz-parser/src/parser/state_diagnostics.rs
+++ b/crates/tsz-parser/src/parser/state_diagnostics.rs
@@ -642,6 +642,19 @@ impl ParserState {
         }) {
             return;
         }
+        // Immediately after a missing-LHS binary-expression statement
+        // (#16291), the following statement's own diagnostic must never be
+        // dropped just for sitting within `ERROR_SUPPRESSION_DISTANCE` of
+        // that recovery's own diagnostic — even when it surfaces here, inside
+        // argument-list parsing, rather than at a missing semicolon (#17062).
+        let force_emit = std::mem::take(&mut self.force_next_missing_semicolon_error_once);
+        if force_emit {
+            self.parse_error_at_current_token(
+                "',' expected.",
+                tsz_common::diagnostics::diagnostic_codes::EXPECTED,
+            );
+            return;
+        }
         self.error_token_expected(",");
     }
 

--- a/crates/tsz-parser/src/parser/state_expressions_binary.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_binary.rs
@@ -271,10 +271,27 @@ impl ParserState {
         // operator always emits TS1109 even if a prior error (for example,
         // TS1003 from JSX) is nearby.
         if !self.should_suppress_missing_binary_rhs_error() {
-            self.parse_error_at_current_token(
-                "Expression expected.",
-                diagnostic_codes::EXPRESSION_EXPECTED,
-            );
+            if self.is_token(SyntaxKind::EndOfFileToken) {
+                // At EOF, tsc's `createMissingNode` anchors the diagnostic at
+                // the position right after the last real token (before any
+                // trailing trivia, e.g. a final newline, is skipped) rather
+                // than at the EOF token's own post-trivia position — compare
+                // `a &&;`/`a && ;` (mid-line, anchored at the next real
+                // token) with `a &&\n` (anchored one column after `&&`, not
+                // at the start of the following line).
+                let pos = self.token_full_start();
+                self.parse_error_at(
+                    pos,
+                    0,
+                    "Expression expected.",
+                    diagnostic_codes::EXPRESSION_EXPECTED,
+                );
+            } else {
+                self.parse_error_at_current_token(
+                    "Expression expected.",
+                    diagnostic_codes::EXPRESSION_EXPECTED,
+                );
+            }
         }
     }
 

--- a/crates/tsz-parser/src/parser/state_expressions_tail.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_tail.rs
@@ -634,8 +634,23 @@ impl ParserState {
                     if (self.context_flags
                         & crate::parser::state::CONTEXT_FLAG_TEMPLATE_SPAN_EXPRESSION)
                         == 0
+                        && self.should_report_error()
                     {
-                        self.error_expression_expected();
+                        // tsc's `createMissingNode` anchors this at the
+                        // position right after the last real token — before
+                        // any trailing trivia (e.g. a final newline) is
+                        // skipped to reach EOF — not at the EOF token's own
+                        // post-trivia position. Compare `a &&;`/`a && ;`
+                        // (anchored at the next real token) with `a &&\n`
+                        // (anchored one column after `&&`, not at the start
+                        // of the following line).
+                        let pos = self.token_full_start();
+                        self.parse_error_at(
+                            pos,
+                            0,
+                            "Expression expected.",
+                            diagnostic_codes::EXPRESSION_EXPECTED,
+                        );
                     }
                     return NodeIndex::NONE;
                 }

--- a/crates/tsz-parser/tests/missing_lhs_binary_expression_statement_boundary_tests.rs
+++ b/crates/tsz-parser/tests/missing_lhs_binary_expression_statement_boundary_tests.rs
@@ -133,3 +133,93 @@ fn octal_literal_missing_semicolon_cascade_is_unaffected() {
         ]
     );
 }
+
+// ---------------------------------------------------------------------------
+// #17062 item 1: the same cascading-suppression bug also hits `error_comma_
+// expected` inside a call's argument list — not just `parse_semicolon` — when
+// the following statement's own first diagnostic is a missing `,` rather than
+// a missing `;`. `in set y(v: number);` is `<missing> in set` (first
+// statement, TS1109 + TS1005) followed by `y(v: number)` (second, independent
+// statement: `v` parses as the sole argument, then the argument list hits an
+// unexpected `:` where `,` or `)` was expected).
+#[test]
+fn in_missing_lhs_followed_by_call_with_colon_typed_argument_reports_comma_expected() {
+    assert_eq!(
+        fingerprints("in set y(v: number);"),
+        vec![(TS1109, 1, 1), (TS1005, 1, 8), (TS1005, 1, 11)],
+    );
+}
+
+#[test]
+fn instanceof_missing_lhs_followed_by_call_with_colon_typed_argument_reports_comma_expected() {
+    assert_eq!(
+        fingerprints("instanceof set y(v: number);"),
+        vec![(TS1109, 1, 1), (TS1005, 1, 16), (TS1005, 1, 19)],
+    );
+}
+
+// `get` accessor keeps working the same way (regression guard for the fix's
+// sibling shape, already covered by #17052 but re-asserted here alongside
+// the new `set`/comma-expected cases).
+#[test]
+fn in_missing_lhs_followed_by_get_call_statement_reports_both_semicolons() {
+    assert_eq!(
+        fingerprints("in get x(): number;"),
+        vec![(TS1109, 1, 1), (TS1005, 1, 8), (TS1005, 1, 11)],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #17062 item 2: `report_missing_binary_rhs` anchored a missing-RHS TS1109 at
+// the EOF token's own (post-trivia) position rather than right after the
+// last real token — before any trailing trivia (e.g. a final newline) is
+// skipped to reach EOF. This is a general binary-expression bug, not
+// specific to the `in`/`instanceof` statement-boundary recovery: it also
+// reproduces for an ordinary `+`/`&&` binary expression whose RHS is missing
+// at EOF.
+
+// Bare `in` at EOF: both diagnostics anchor on line 1 (tsc: col 1, col 3 —
+// right after `in`), not (2, 1).
+#[test]
+fn bare_in_at_eof_anchors_second_diagnostic_after_operator_not_next_line() {
+    assert_eq!(fingerprints("in\n"), vec![(TS1109, 1, 1), (TS1109, 1, 3)]);
+}
+
+#[test]
+fn bare_instanceof_at_eof_anchors_second_diagnostic_after_operator_not_next_line() {
+    assert_eq!(
+        fingerprints("instanceof\n"),
+        vec![(TS1109, 1, 1), (TS1109, 1, 11)],
+    );
+}
+
+// Ordinary (non-statement-boundary) binary expressions with a missing RHS at
+// EOF show the identical anchor bug.
+#[test]
+fn plus_missing_rhs_at_eof_with_trailing_newline_anchors_after_operator() {
+    assert_eq!(fingerprints("a +\n"), vec![(TS1109, 1, 4)]);
+}
+
+#[test]
+fn logical_and_missing_rhs_at_eof_with_trailing_newline_anchors_after_operator() {
+    assert_eq!(fingerprints("a &&\n"), vec![(TS1109, 1, 5)]);
+}
+
+// Negative controls: when a *real* token (not EOF) follows — even across a
+// line break, or separated by whitespace on the same line — tsc anchors at
+// that real token's own position, which already matched before this fix and
+// must stay unchanged.
+#[test]
+fn plus_missing_rhs_at_eof_without_trailing_trivia_is_unaffected() {
+    assert_eq!(fingerprints("a +"), vec![(TS1109, 1, 4)]);
+}
+
+#[test]
+fn logical_and_missing_rhs_before_real_token_same_line_anchors_at_token() {
+    assert_eq!(fingerprints("a && ;"), vec![(TS1109, 1, 6)]);
+}
+
+#[test]
+fn logical_and_missing_rhs_before_real_token_next_line_anchors_at_token() {
+    assert_eq!(fingerprints("a &&\n;"), vec![(TS1109, 2, 1)]);
+}


### PR DESCRIPTION
Fixes all three statement-recovery divergences reported in #17062, found while verifying #17052's `in get`/`instanceof get` fix. All confirmed byte-exact against pinned `typescript@7.0.2`.

## Structural rules

**1. `in set y(v: number);` dropped its third diagnostic (`',' expected` inside call-argument parsing).**
When a missing-LHS binary-expression statement (`in`/`instanceof` at statement start) is immediately followed by a second, independent statement whose own first diagnostic is a missing `,` inside a call's argument list (not a missing `;`), tsc still reports it (`parseErrorAtPosition` dedups only on exact-same-start); tsz's `error_comma_expected` suppressed it via `ERROR_SUPPRESSION_DISTANCE` proximity because #17052's `force_next_missing_semicolon_error_once` one-shot flag was only consumed by `parse_semicolon`/`parse_error_for_missing_semicolon_after`. Extended the same flag to `error_comma_expected` (`crates/tsz-parser/src/parser/state_diagnostics.rs`).

**2. Bare `in` at EOF anchored its second TS1109 on the wrong line.**
When a binary expression's RHS is missing right at EOF, tsc's `createMissingNode` anchors the diagnostic at the position right after the last real token (before trailing trivia — e.g. a final newline — is skipped), not at the EOF token's own post-trivia position. This is a *general* binary-expression bug, not specific to `in`/`instanceof` statement-boundary recovery: `a &&\n` and `a +\n` show the identical divergence, while `a &&;` / `a && ;` / `a &&\n;` (a real token follows, even across a line break) already matched and must stay unchanged. Fixed both `report_missing_binary_rhs` and `parse_primary_expression`'s own EOF fallback (`crates/tsz-parser/src/parser/state_expressions_binary.rs`, `state_expressions_tail.rs`) — both independently reported the same wrong position, and both needed the anchor fixed for the pre-existing exact-position diagnostic dedup to still collapse them into tsc's single diagnostic.

**3. `class C { in get x(): number; }` showed both TS1274 and a spurious extra `'{' expected.`**
tsc's `checkGrammarModifiers(node) || checkGrammarAccessor(node)` OR-chain reports only the first problem and short-circuits the rest: a `readonly`/`in`/`out`/duplicate-`accessor` modifier already invalid on a get/set accessor reports its own diagnostic and the missing-body check never runs. tsz's checker ran `check_accessor_declaration_with_request`'s missing-body check unconditionally. Fixed by skipping it when the accessor's own modifier list already carries one of those violations (`crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs`). `declare` (TS1031) already got this "for free" via `NodeArena::is_in_ambient_context`, which treats any `declare`-modified node as ambient regardless of placement validity — confirmed via oracle, no fix needed there.

## Adjacent-case matrix (oracle-pinned against `typescript@7.0.2`)

| Case | Before | After | tsc |
| --- | --- | --- | --- |
| `in set y(v: number);` | 2 diagnostics | 3 | 3 ✓ |
| `instanceof set y(v: number);` | 2 | 3 | 3 ✓ |
| `in get x(): number;` (regression guard, #17052) | 3 | 3 | 3 ✓ |
| `in\n` (bare, EOF) | `(1,1)(2,1)` | `(1,1)(1,3)` | `(1,1)(1,3)` ✓ |
| `instanceof\n` | `(1,1)(2,1)` | `(1,1)(1,11)` | `(1,1)(1,11)` ✓ |
| `a +\n` | `(1,4)(2,1)`→wrong | `(1,4)` | `(1,4)` ✓ |
| `a &&\n` | wrong line | `(1,5)` | `(1,5)` ✓ |
| `a +` (no trailing trivia, negative control) | `(1,4)` | `(1,4)` unchanged | `(1,4)` ✓ |
| `a && ;` (real token same line, negative control) | `(1,6)` | `(1,6)` unchanged | `(1,6)` ✓ |
| `a &&\n;` (real token next line, negative control) | `(2,1)` | `(2,1)` unchanged | `(2,1)` ✓ |
| `class C { in get x(): number; }` | TS1274 + spurious TS1005 | TS1274 only | TS1274 only ✓ |
| `class C { out set x(v: number); }` | TS1274 + spurious | TS1274 only | TS1274 only ✓ |
| `class C { readonly get x(): number; }` | TS1024 + spurious | TS1024 only | TS1024 only ✓ |
| `class C { static readonly get x(): number; }` | TS1024 + spurious | TS1024 only | TS1024 only ✓ |
| `class C { accessor get x(): number; }` | TS1275 + spurious | TS1275 only | TS1275 only ✓ |
| `class Widget { in get value(): string; }` (renamed binder) | TS1274 + spurious | TS1274 only | TS1274 only ✓ |
| `class C { get x(): number; }` (regression guard, no invalid modifier) | TS1005 | TS1005 unchanged | TS1005 ✓ |
| `abstract class C { abstract get x(): number; }` (negative control) | clean | clean unchanged | clean ✓ |

Two unrelated pre-existing divergences were found and left untouched (out of scope for #17062, not mentioned in the issue): `class C { get x<T>(): number; }` shows an extra TS1094 tsc doesn't emit, and `class C { get x(a): number; }` shows an extra TS1054 tsc doesn't emit. Both are orthogonal accessor-signature grammar checks, not the missing-body/modifier interaction this PR fixes.

## Goal
Goal: hold

## Verification
- 19 new tests: 10 in `crates/tsz-parser/tests/missing_lhs_binary_expression_statement_boundary_tests.rs` (items 1–2), 9 in new `crates/tsz-checker/tests/accessor_missing_body_modifier_suppression_tests.rs` (item 3), all passing.
- `cargo test -p tsz-parser --lib`: 2244/2244 passed (was 2234/2234; +10 new).
- `cargo test -p tsz-checker --test accessor_missing_body_modifier_suppression_tests`: 9/9 passed.
- `cargo test -p tsz-checker --lib -- accessor modifier readonly variance`: 589/589 passed.
- `cargo test -p tsz-checker --lib -- accessor_declaration check_accessor grammar_accessor bodyless ambient abstract_accessor`: 165/165 passed.
- `cargo clippy -p tsz-parser -p tsz-checker --lib -- -D warnings`: clean.
- `cargo fmt --check -p tsz-parser -p tsz-checker`: clean.
- `python3 scripts/arch/arch_guard.py`: clean.
- Every table row above verified by hand against a debug `tsz` build and the pinned oracle (`typescript@7.0.2`, via `npm i typescript@7.0.2` + `node .../bin/tsc --noEmit --strict --lib es2022 --target es2022`).
- Full `cargo test -p tsz-checker --lib` (all ~11,000 tests) was started but ran unusually long in this session; the targeted filters above (750+ tests covering every touched code path: accessor/modifier/readonly/variance/ambient/abstract grammar) all pass. Will report back if the full run surfaces anything.
- Not run: `conformance.sh snapshot` / `compare-to-parent.sh` (two-sided run is 55–90+ min per board history). All three fixes touch malformed/invalid-syntax recovery paths (a bare binary operator at statement start with no LHS, a binary expression with no RHS at literal EOF, and a modifier that's already grammatically invalid on a get/set accessor) that don't occur in valid TypeScript source, so real corpus movement is expected to be zero.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUKbiKfyfV1EXEDRtW8qEF)_