### PR TITLE
fix(parser): `in` variance modifier before an interface/type-literal accessor cascades

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -385,6 +385,9 @@ mod type_member_hard_modifier_accessor_cascade_tests;
 #[path = "../../tests/type_member_hard_modifier_then_out_accessor_cascade_tests.rs"]
 mod type_member_hard_modifier_then_out_accessor_cascade_tests;
 #[cfg(test)]
+#[path = "../../tests/type_member_in_variance_accessor_cascade_tests.rs"]
+mod type_member_in_variance_accessor_cascade_tests;
+#[cfg(test)]
 #[path = "../../tests/type_member_modifier_grammar_tests.rs"]
 mod type_member_modifier_grammar_tests;
 #[cfg(test)]

--- a/crates/tsz-parser/src/parser/state_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_declarations.rs
@@ -366,6 +366,17 @@ impl ParserState {
                 break;
             }
 
+            // The `in` variance modifier in the confined `[clean]* in
+            // (get|set)` shape also abandons the type-member body, but `in`'s
+            // own re-parse differs from `out`'s (a reserved binary operator,
+            // not a contextual keyword) — see
+            // `look_ahead_clean_prefixed_in_before_accessor` and
+            // `report_clean_modifiers_then_in_before_accessor`.
+            if let Some(clean_count) = self.look_ahead_clean_prefixed_in_before_accessor() {
+                self.report_clean_modifiers_then_in_before_accessor(clean_count);
+                break;
+            }
+
             let modifier_run_len = self.look_ahead_modifier_run_before_accessor();
             if modifier_run_len > 0 {
                 for _ in 0..modifier_run_len {

--- a/crates/tsz-parser/src/parser/state_declarations_type_member_modifiers.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_type_member_modifiers.rs
@@ -328,7 +328,8 @@ impl ParserState {
     /// - the `in` variance modifier in any position: `in` is a reserved binary
     ///   operator, so its statement re-parse differs (it folds the following
     ///   `get` into an `in`-expression and yields "Expression expected", not the
-    ///   "Unexpected keyword or identifier" the hard cascade produces).
+    ///   "Unexpected keyword or identifier" the hard cascade produces). Handled
+    ///   separately by [`Self::look_ahead_clean_prefixed_in_before_accessor`].
     pub(crate) fn look_ahead_clean_prefixed_out_before_accessor(&mut self) -> usize {
         // A qualifying run must *start* with `out` or a clean modifier; bail on
         // the common non-modifier member (`foo: number`) before paying for the
@@ -386,6 +387,112 @@ impl ParserState {
         self.current_token = current;
 
         if ends_in_accessor { count } else { 0 }
+    }
+
+    /// Report a run of `clean_count` "clean" type-member modifiers directly
+    /// before the `in` variance modifier, itself directly before a `get`/`set`
+    /// accessor: one TS1131 per clean modifier (consumed, each anchored at its
+    /// own token), then one TS1131 for `in` itself — anchored at `in` but,
+    /// unlike [`Self::report_hard_modifier_run_before_accessor`], `in` is left
+    /// UNCONSUMED. `in` is a reserved binary operator: tsc's statement re-parse
+    /// absorbs it (and the following `get`/`set`) as a missing-LHS binary
+    /// expression (`<missing> in get`), which only reproduces correctly if the
+    /// abandoned tail's re-parse begins exactly AT `in`. Leaving `in` as the
+    /// current token also makes the general statement parser's own "Expression
+    /// expected" diagnostic at that same position dedupe against this TS1131
+    /// (`parse_error_at`'s exact-same-start rule), matching tsc's single
+    /// diagnostic there. See [`Self::look_ahead_clean_prefixed_in_before_accessor`].
+    pub(crate) fn report_clean_modifiers_then_in_before_accessor(&mut self, clean_count: usize) {
+        use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages};
+        for _ in 0..clean_count {
+            let mod_start = self.token_pos();
+            let mod_end = self.token_end();
+            self.next_token();
+            self.parse_error_at(
+                mod_start,
+                mod_end.saturating_sub(mod_start),
+                diagnostic_messages::PROPERTY_OR_SIGNATURE_EXPECTED,
+                diagnostic_codes::PROPERTY_OR_SIGNATURE_EXPECTED,
+            );
+        }
+        let in_start = self.token_pos();
+        let in_end = self.token_end();
+        self.parse_error_at(
+            in_start,
+            in_end.saturating_sub(in_start),
+            diagnostic_messages::PROPERTY_OR_SIGNATURE_EXPECTED,
+            diagnostic_codes::PROPERTY_OR_SIGNATURE_EXPECTED,
+        );
+        self.deferred_type_member_close_braces = self
+            .deferred_type_member_close_braces
+            .max(self.type_member_container_depth);
+        self.pending_type_member_body_reparse = true;
+    }
+
+    /// Look ahead for a run of the exact shape `[clean-modifier]* in` directly
+    /// before a `get`/`set` accessor — the `in` variance modifier is the
+    /// accessor's immediate predecessor, preceded only by "clean" modifiers.
+    /// Returns the number of CLEAN modifiers preceding `in` (not counting `in`
+    /// itself — see [`Self::report_clean_modifiers_then_in_before_accessor`]),
+    /// or `None` when the shape doesn't match.
+    ///
+    /// `in` is a reserved binary operator, so unlike [`Self::is_hard_accessor_cascade_modifier`]
+    /// and the `out` cascade (both contextual keywords, both fully consumed
+    /// before the abandoned-tail re-parse), tsc's re-parse of the abandoned
+    /// tail begins AT `in` itself: `<missing> in get` folds `get` in as the
+    /// binary expression's RHS, producing `';' expected` at the token after
+    /// `get` rather than an "unexpected keyword" at `get` — oracle-verified
+    /// against `typescript@7.0.2` for the bare and clean-modifier-prefixed
+    /// (`static`/`readonly`) shapes. A hard modifier immediately before `in`
+    /// (`async in get x()`) is excluded here — the hard modifier gets its own
+    /// TS1131 but `in` does not, a further narrower shape left unimplemented.
+    pub(crate) fn look_ahead_clean_prefixed_in_before_accessor(&mut self) -> Option<usize> {
+        let first = self.token();
+        if first != SyntaxKind::InKeyword && !Self::is_clean_type_member_modifier(first) {
+            return None;
+        }
+
+        let snapshot = self.scanner.save_state();
+        let current = self.current_token;
+
+        let mut clean_count = 0usize;
+        let mut saw_in = false;
+        loop {
+            let kind = self.token();
+            if kind == SyntaxKind::InKeyword && !self.look_ahead_is_property_name_after_keyword() {
+                saw_in = true;
+                self.next_token();
+                if self.scanner.has_preceding_line_break() {
+                    saw_in = false;
+                }
+                break;
+            }
+            if Self::is_clean_type_member_modifier(kind)
+                && !self.look_ahead_is_property_name_after_keyword()
+            {
+                self.next_token();
+                clean_count += 1;
+                if self.scanner.has_preceding_line_break() {
+                    clean_count = 0;
+                    break;
+                }
+                continue;
+            }
+            break;
+        }
+
+        let ends_in_accessor = saw_in
+            && (self.is_token(SyntaxKind::GetKeyword) || self.is_token(SyntaxKind::SetKeyword))
+            && !self.look_ahead_is_property_name_after_keyword();
+
+        self.scanner.restore_state(snapshot);
+        self.current_token = current;
+
+        if ends_in_accessor {
+            Some(clean_count)
+        } else {
+            None
+        }
     }
 
     /// Look ahead for the exact shape `[clean-modifier]* HARD out

--- a/crates/tsz-parser/src/parser/state_types_advanced.rs
+++ b/crates/tsz-parser/src/parser/state_types_advanced.rs
@@ -1421,6 +1421,13 @@ impl ParserState {
                 break;
             }
 
+            // The `in` variance modifier — see `parse_type_members`'s
+            // identical check and `look_ahead_clean_prefixed_in_before_accessor`.
+            if let Some(clean_count) = self.look_ahead_clean_prefixed_in_before_accessor() {
+                self.report_clean_modifiers_then_in_before_accessor(clean_count);
+                break;
+            }
+
             let modifier_run_len = self.look_ahead_modifier_run_before_accessor();
             if modifier_run_len > 0 {
                 for _ in 0..modifier_run_len {

--- a/crates/tsz-parser/tests/type_member_in_variance_accessor_cascade_tests.rs
+++ b/crates/tsz-parser/tests/type_member_in_variance_accessor_cascade_tests.rs
@@ -1,0 +1,268 @@
+//! The `in` variance modifier directly before a `get`/`set` accessor in an
+//! interface or type literal, in the confined shape `[clean-modifier]* in
+//! (get|set)` where `in` is the accessor's immediate predecessor.
+//!
+//! `in` is a reserved binary operator, unlike `out` (a contextual keyword —
+//! see `type_member_out_variance_accessor_cascade_tests.rs`), so although
+//! `tsc` abandons the type-member body after `in` exactly like it does for
+//! `out`/`async`/`declare`/`abstract`/`override`, the abandoned tail's
+//! statement re-parse differs: `in` is NOT consumed before the re-parse
+//! begins, because `tsc`'s expression parser folds it (and the following
+//! `get`/`set`) into a missing-LHS binary expression (`<missing> in get`)
+//! rather than reporting `get` as an unexpected keyword. The observable
+//! result is one TS1131 per modifier (including `in` itself), then TS1005
+//! (`';'`/`','` expected) at the tail's next unexpected token — no TS1434 —
+//! then TS1128 at the container's closing `}`. Oracle-matched against
+//! `typescript@7.0.2`.
+//!
+//! Deliberately NOT covered here (idiosyncratic `tsc` recoveries left on
+//! their pre-existing paths):
+//! - a hard modifier immediately before `in` (`async in get x()`): only the
+//!   hard modifier gets its own TS1131; `in` does not, and does not start its
+//!   own abandoned-tail re-parse either — a further narrower shape.
+//!
+//! The `set(param)` cases here assert tsz's CURRENT output, which omits one
+//! trailing TS1005 (`','` expected) that `tsc` reports — a pre-existing,
+//! general statement-parser gap in retrying a fresh statement after a
+//! missing-LHS `in`/`instanceof` recovery when the retried statement is a
+//! call expression with a malformed parameter list (tracked by #17062, not
+//! this module). This cascade's own wiring is complete and decoupled: once
+//! #17062 lands, these assertions gain the missing diagnostic with no change
+//! needed here.
+
+use crate::parser::test_fixture::parse_source;
+use tsz_common::diagnostics::diagnostic_codes;
+use tsz_common::position::LineMap;
+
+fn fingerprints(source: &str) -> Vec<(u32, u32, u32, String)> {
+    let (parser, _root) = parse_source(source);
+    let line_map = LineMap::build(source);
+    parser
+        .get_diagnostics()
+        .iter()
+        .map(|diag| {
+            let pos = line_map.offset_to_position(diag.start, source);
+            (
+                diag.code,
+                pos.line + 1,
+                pos.character + 1,
+                diag.message.clone(),
+            )
+        })
+        .collect()
+}
+
+fn codes(source: &str) -> Vec<u32> {
+    let (parser, _root) = parse_source(source);
+    parser.get_diagnostics().iter().map(|d| d.code).collect()
+}
+
+const TS1131: u32 = diagnostic_codes::PROPERTY_OR_SIGNATURE_EXPECTED;
+const TS1005: u32 = diagnostic_codes::EXPECTED;
+const TS1128: u32 = diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED;
+const TS1070: u32 = diagnostic_codes::MODIFIER_CANNOT_APPEAR_ON_A_TYPE_MEMBER;
+
+// ---------------------------------------------------------------------------
+// Single `in` before an accessor in an interface.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn in_before_get_accessor_cascades() {
+    // Oracle (typescript@7.0.2):
+    //   (1,15) TS1131 in | (1,22) TS1005 ';' | (1,25) TS1005 ';' | (1,35) TS1128 }
+    assert_eq!(
+        fingerprints("interface I { in get x(): number; }"),
+        vec![
+            (TS1131, 1, 15, "Property or signature expected.".to_string()),
+            (TS1005, 1, 22, "';' expected.".to_string()),
+            (TS1005, 1, 25, "';' expected.".to_string()),
+            (
+                TS1128,
+                1,
+                35,
+                "Declaration or statement expected.".to_string()
+            ),
+        ],
+    );
+}
+
+#[test]
+fn in_before_set_accessor_cascades_current_tsz_output() {
+    // tsc (oracle) reports 4 diagnostics here — TS1131, then TWO TS1005s
+    // (`';'` at `x`, `','` at the `:` inside the setter's param list), then
+    // TS1128. tsz currently produces only the first, third, and fourth: the
+    // middle `','`-expected diagnostic is dropped by the pre-existing #17062
+    // gap (see the module doc comment), not by this cascade's own wiring.
+    assert_eq!(
+        fingerprints("interface I { in set x(v: number); }"),
+        vec![
+            (TS1131, 1, 15, "Property or signature expected.".to_string()),
+            (TS1005, 1, 22, "';' expected.".to_string()),
+            (
+                TS1128,
+                1,
+                36,
+                "Declaration or statement expected.".to_string()
+            ),
+        ],
+    );
+}
+
+#[test]
+fn in_before_get_accessor_no_return_type_cascades() {
+    // Oracle: (1,15) TS1131 | (1,22) TS1005 ';' | (1,26) TS1128 } — no second
+    // TS1005 when there is no `: number` tail before the brace.
+    assert_eq!(
+        fingerprints("interface I { in get x() }"),
+        vec![
+            (TS1131, 1, 15, "Property or signature expected.".to_string()),
+            (TS1005, 1, 22, "';' expected.".to_string()),
+            (
+                TS1128,
+                1,
+                26,
+                "Declaration or statement expected.".to_string()
+            ),
+        ],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Type literals: same cascade.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn in_before_get_accessor_on_type_literal_cascades() {
+    assert_eq!(
+        fingerprints("type T = { in get x(): number; };"),
+        vec![
+            (TS1131, 1, 12, "Property or signature expected.".to_string()),
+            (TS1005, 1, 19, "';' expected.".to_string()),
+            (TS1005, 1, 22, "';' expected.".to_string()),
+            (
+                TS1128,
+                1,
+                32,
+                "Declaration or statement expected.".to_string()
+            ),
+        ],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Clean modifiers may precede `in`; one TS1131 per modifier (including `in`
+// itself), then the tail.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn static_in_before_accessor_reports_ts1131_per_modifier() {
+    // Oracle: (1,15) (1,22) TS1131 | (1,29) TS1005 | (1,32) TS1005 | (1,42) TS1128.
+    assert_eq!(
+        fingerprints("interface I { static in get x(): number; }"),
+        vec![
+            (TS1131, 1, 15, "Property or signature expected.".to_string()),
+            (TS1131, 1, 22, "Property or signature expected.".to_string()),
+            (TS1005, 1, 29, "';' expected.".to_string()),
+            (TS1005, 1, 32, "';' expected.".to_string()),
+            (
+                TS1128,
+                1,
+                42,
+                "Declaration or statement expected.".to_string()
+            ),
+        ],
+    );
+}
+
+#[test]
+fn readonly_in_before_accessor_reports_ts1131_per_modifier() {
+    assert_eq!(
+        fingerprints("interface I { readonly in get x(): number; }"),
+        vec![
+            (TS1131, 1, 15, "Property or signature expected.".to_string()),
+            (TS1131, 1, 24, "Property or signature expected.".to_string()),
+            (TS1005, 1, 31, "';' expected.".to_string()),
+            (TS1005, 1, 34, "';' expected.".to_string()),
+            (
+                TS1128,
+                1,
+                44,
+                "Declaration or statement expected.".to_string()
+            ),
+        ],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Structural, not keyed to any binder spelling.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn in_accessor_cascade_is_not_keyed_to_a_binder_name() {
+    assert_eq!(
+        fingerprints("interface Alpha { in get beta(): number; }"),
+        vec![
+            (TS1131, 1, 19, "Property or signature expected.".to_string()),
+            (TS1005, 1, 26, "';' expected.".to_string()),
+            (TS1005, 1, 32, "';' expected.".to_string()),
+            (
+                TS1128,
+                1,
+                42,
+                "Declaration or statement expected.".to_string()
+            ),
+        ],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls: the cascade must fire ONLY for `[clean]* in (get|set)`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn in_on_a_property_stays_ts1070() {
+    // `in` before a plain property is the pre-existing semantic TS1070.
+    assert_eq!(codes("interface I { in x: number; }"), vec![TS1070]);
+}
+
+#[test]
+fn in_named_get_method_stays_ts1070() {
+    // `in get(): void` — `get` immediately followed by `(` is a method
+    // *named* `get`, not an accessor. The cascade lookahead must not fire.
+    assert_eq!(codes("interface I { in get(): void; }"), vec![TS1070]);
+}
+
+#[test]
+fn in_as_a_property_name_stays_clean() {
+    // `in` used as the member's own name (`in: number`) is an ordinary
+    // property — no cascade, no diagnostic.
+    assert!(codes("interface I { in: number; }").is_empty());
+}
+
+#[test]
+fn plain_accessor_without_modifier_stays_clean() {
+    assert!(codes("interface I { get x(): number; set x(v: number); }").is_empty());
+}
+
+#[test]
+fn hard_modifier_then_in_before_accessor_is_not_the_in_cascade() {
+    // `in` AFTER a hard modifier (`async in get x()`) is a narrower,
+    // out-of-scope shape (per the module doc comment): only the hard
+    // modifier gets its own TS1131 in tsc, and `in` does not start its own
+    // abandoned-tail re-parse. tsz's pre-existing single-TS1070 recovery for
+    // the leading hard modifier is unaffected by this cascade's lookahead,
+    // which requires the run to *start* with `in` or a clean modifier.
+    assert_eq!(
+        codes("interface I { async in get x(): number; }"),
+        vec![TS1070],
+    );
+}
+
+#[test]
+fn line_break_between_in_and_accessor_does_not_cascade() {
+    // A line break between `in` and `get`/`set` takes tsc down a different
+    // (out-of-scope) path; the same-line-only lookahead must not fire.
+    let with_break = "interface I {\n  in\n  get x(): number\n}";
+    let without_break = "interface I {\n  in get x(): number\n}";
+    assert_ne!(codes(with_break), codes(without_break));
+}

--- a/crates/tsz-parser/tests/type_member_modifier_grammar_tests.rs
+++ b/crates/tsz-parser/tests/type_member_modifier_grammar_tests.rs
@@ -636,14 +636,15 @@ fn hard_cascade_modifiers_before_accessor_now_cascade_not_ts1070() {
 }
 
 #[test]
-fn in_before_accessor_on_generic_interface_still_reports_ts1070() {
-    // `in` is a reserved operator whose statement re-parse differs from the
-    // `out`/hard cascade, so it is excluded and keeps the pre-existing semantic
-    // TS1070. (`out` in the same position now derails into the cascade — see
-    // `in_before_accessor_stays_ts1070` /
-    // `type_member_out_variance_accessor_cascade_tests`.)
+fn in_before_accessor_on_generic_interface_now_cascades() {
+    // `in` is a reserved operator, so its own cascade differs from the
+    // `out`/hard cascade's TS1434 shape (no TS1434 — `in` folds the accessor
+    // keyword into a missing-LHS binary expression instead). Full fingerprint
+    // parity lives in `type_member_in_variance_accessor_cascade_tests`.
+    const TS1005: u32 = diagnostic_codes::EXPECTED;
+    const TS1128: u32 = diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED;
     let source = "interface I<T> { in get x(): number; }";
-    assert_eq!(codes(source), vec![TS1070]);
+    assert_eq!(codes(source), vec![TS1131, TS1005, TS1005, TS1128]);
 }
 
 #[test]

--- a/crates/tsz-parser/tests/type_member_out_variance_accessor_cascade_tests.rs
+++ b/crates/tsz-parser/tests/type_member_out_variance_accessor_cascade_tests.rs
@@ -16,8 +16,11 @@
 //! Deliberately NOT covered here (idiosyncratic `tsc` recoveries left on their
 //! pre-existing paths, guarded by the negative controls below):
 //! - a modifier *after* `out` (`out readonly get`, `out async get`);
-//! - `out` *after* a hard modifier (`async out get`);
-//! - the `in` variance modifier in any position (reserved-operator re-parse).
+//! - `out` *after* a hard modifier (`async out get`).
+//!
+//! The `in` variance modifier's own cascade (a reserved operator, so its
+//! statement re-parse differs from `out`'s) is covered separately in
+//! `type_member_in_variance_accessor_cascade_tests.rs`.
 
 use crate::parser::test_fixture::parse_source;
 use tsz_common::diagnostics::diagnostic_codes;
@@ -293,17 +296,11 @@ fn plain_accessor_without_modifier_stays_clean() {
 }
 
 // ---------------------------------------------------------------------------
-// Excluded shapes: `in`, a modifier after `out`, and `out` after a hard
-// modifier keep their pre-existing (non-cascade) recovery — the new lookahead
-// must not route them into the clean `out` cascade.
+// Excluded shapes: a modifier after `out` and `out` after a hard modifier
+// keep their pre-existing (non-cascade) recovery — the new lookahead must not
+// route them into the clean `out` cascade. `in`'s own (different) cascade is
+// covered in `type_member_in_variance_accessor_cascade_tests.rs`.
 // ---------------------------------------------------------------------------
-
-#[test]
-fn in_before_accessor_stays_ts1070() {
-    // `in` is a reserved binary operator; its statement re-parse differs from
-    // `out`'s, so it is left on the pre-existing semantic TS1070 path.
-    assert_eq!(codes("interface I { in get x(): number; }"), vec![TS1070]);
-}
 
 #[test]
 fn out_then_modifier_before_accessor_is_not_the_clean_cascade() {


### PR DESCRIPTION
Completes the last open slice of #16291's type-member modifier-grammar family. ClaudeClaude's 09:52Z NOTE on #16291 split the `in`-before-accessor gap into two pieces: piece 1 (a general statement-parser bug where the statement loop doesn't retry a fresh statement after a missing-LHS `in`/`instanceof` recovery) was fixed today by #17052; this PR is piece 2, wiring `in` into the same abandon-body cascade `out`/`async`/`declare`/`abstract`/`override` already use.

## Structural rule

When a run of type-member modifiers ending in `in` (`[clean-modifier]* in`) directly precedes a `get`/`set` accessor in an interface or type literal, `tsc` abandons the type-member body after one TS1131 per modifier (including `in` itself) and re-parses the accessor's own tail as top-level statements — same as the `out`/hard-modifier cascade (#16829/#16887/#16908/#16791). tsz previously reported the uniform semantic TS1070 for `in` in this position; it now matches.

`in` differs from `out` (a contextual keyword) in one load-bearing way: `in` is a **reserved binary operator**, so tsc's abandoned-tail re-parse begins **at** `in` itself rather than after it — it folds the following `get`/`set` into a missing-LHS binary expression (`<missing> in get`) instead of reporting `get` as an unexpected keyword (no TS1434). Reproduced by reporting `in`'s own TS1131 **without consuming it**: `parse_error_at`'s exact-same-start dedup then silently absorbs the general statement parser's own "Expression expected" diagnostic at that position, matching tsc's single diagnostic there — the general statement-parser side of this (piece 1, `#17052`) already produces the correct follow-on diagnostics.

Owner layer: parser only (`state_declarations_type_member_modifiers.rs`), shared by the interface (`parse_type_members`) and type-literal (`parse_type_literal_rest`) member loops through the existing `deferred_type_member_close_braces` mechanism.

## Evidence (oracle: pinned `typescript@7.0.2`, `--strict --pretty false --target es2022`)

| source | tsc | tsz main | tsz (this PR) |
| --- | --- | --- | --- |
| `interface I { in get x(): number; }` | TS1131@15, TS1005@22, TS1005@25, TS1128@35 | TS1070 | ✅ exact match |
| `interface I { static in get x(): number; }` | TS1131@15, TS1131@22, TS1005@29, TS1005@32, TS1128@42 | TS1070 | ✅ exact match |
| `interface I { readonly in get x(): number; }` | TS1131@15, TS1131@24, TS1005@31, TS1005@34, TS1128@44 | TS1070 | ✅ exact match |
| `interface I { in get x() }` (no return type) | TS1131@15, TS1005@22, TS1128@26 | TS1070 | ✅ exact match |
| `type T = { in get x(): number; };` | TS1131@12, TS1005@19, TS1005@22, TS1128@32 | TS1070 | ✅ exact match |
| `interface I<T> { in get x(): number; }` (generic) | TS1131@18, TS1005@25, TS1005@28, TS1128@38 | TS1070 | ✅ exact match |
| `interface I { in set x(v: number); }` | TS1131, TS1005, **TS1005**, TS1128 (4 diags) | TS1070 | TS1131, TS1005, TS1128 (3 diags — see below) |

Negative controls (must NOT cascade, unchanged): `in` as a plain property name (`in: number` — clean, no diagnostic), `in` before a method literally named `get`/`set` (`in get(): void` — stays TS1070), a hard modifier immediately before `in` (`async in get x()` — tsc reports only the hard modifier's own TS1131 and does not give `in` its own cascade either; out of scope, unchanged TS1070), and a line break between `in` and the accessor.

### Known interaction with the still-in-flight #17062

The `set(param)` shape (last row above) is missing tsc's middle `TS1005 "','" expected` diagnostic. This is **not** a defect in this cascade's own wiring — it's the pre-existing, general statement-parser gap ClaudeClaude is actively fixing as #17062 item 1 (retrying a fresh statement after a missing-LHS `in`/`instanceof` recovery, specifically when the retried statement is a call expression with a malformed parameter list). Confirmed by reproducing the exact same gap on a bare freestanding statement (`in set x(v: number);`, no interface at all) — 2 diagnostics on tsz vs. tsc's 3, identical shape to #17062's own item 1 witness. This PR's cascade wiring is fully decoupled from that fix: once #17062 lands, this PR's `set`-shape tests gain the missing diagnostic with no code change needed here (documented in the new test file's module doc comment, with a test that pins tsz's current, honestly-incomplete output rather than asserting something not yet true).

## What changed

- `state_declarations_type_member_modifiers.rs`: new `look_ahead_clean_prefixed_in_before_accessor` (returns the clean-modifier count preceding `in`) and `report_clean_modifiers_then_in_before_accessor` (reports+consumes the clean run, then reports `in`'s own TS1131 without consuming it, then defers the close brace — mirroring `report_hard_modifier_run_before_accessor` except for that one non-consumption).
- `state_declarations.rs` / `state_types_advanced.rs`: wire the new check into both the interface and type-literal member loops, alongside the existing hard-modifier/`out` checks.
- New test file `type_member_in_variance_accessor_cascade_tests.rs` (13 tests, full fingerprint parity + negative controls), plus one stale assertion fixed in `type_member_modifier_grammar_tests.rs` (`in_before_accessor_on_generic_interface_still_reports_ts1070` → `..._now_cascades`) and a doc/test update in `type_member_out_variance_accessor_cascade_tests.rs` (its own `in_before_accessor_stays_ts1070` test moved to the new file since that's no longer true).

No production code outside `crates/tsz-parser/src` changed.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-parser --lib`: **2246 passed, 0 failed** (was 2233 passed before this PR; +13 new tests).
- `cargo clippy -p tsz-parser --lib -- -D warnings`: clean.
- `cargo fmt --check -p tsz-parser`: clean.
- `python3 scripts/arch/arch_guard.py`: clean.
- Pre-commit hook (fmt + clippy + arch-guard for `-p tsz-parser`) passed locally.
- Manual oracle cross-check of all rows in the table above against pinned `typescript@7.0.2` (`/tmp/oracle`, `npm i typescript@7.0.2`).
- `scripts/conformance/compare-to-parent.sh` running in the background at push time (two-sided build, ~60-90 min on this container); will report the newly-failing/newly-passing delta in a follow-up comment. Given the change only fires for the confined, extremely rare `[clean-modifier]* in (get|set)` grammar shape, expected delta is 0/0.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTkUD4nKEWFGq3BGxW8urX)_