### PR TITLE
fix(checker): follow type aliases when elaborating an intersection reduced to never (TS18031/TS18032)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/declared_intersection_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/declared_intersection_display.rs
@@ -248,30 +248,124 @@ impl<'a> CheckerState<'a> {
         (members.len() >= 2).then_some(members)
     }
 
-    /// The evaluated types of a property-access receiver's *declared*
-    /// written-intersection members (`declare const c: A & B` — each member
-    /// evaluated independently), when the receiver's declared type is
-    /// directly a written intersection.
+    /// The written intersection that reduced a property-access receiver to
+    /// `never`, recovered from the receiver's *declared* annotation and
+    /// followed through any type-alias references.
+    ///
+    /// Returns the evaluated member types (for conflict detection) paired with
+    /// the display `tsc` uses in the `{0}` slot of the `TS18031`/`TS18032`
+    /// elaboration:
+    ///
+    /// - `None` display — the annotation is a *directly written* intersection
+    ///   (`declare const c: A & B`); the caller renders the members
+    ///   structurally (`A & B`), byte-for-byte as before this alias support.
+    /// - `Some(name)` — the intersection is reached through one or more type
+    ///   aliases (`type C = A & B; declare const c: C`); `tsc` names the alias
+    ///   whose body *is* the intersection (`C`, `Pair<"y">`), not the members
+    ///   and not an outer alias that merely forwards to it (`type D = C` still
+    ///   displays `C`), so the walk keeps the innermost naming alias.
     ///
     /// Unlike [`Self::declared_intersection_annotation_display_for_expression`],
     /// this carries no type-literal display gate: a conflict-detection query
     /// over the members is just as valid when every member is a plain
     /// interface/type-alias reference as when one is a type literal. Returns
     /// `None` for every case the caller must silently accept (no explicit
-    /// annotation, not an intersection, fewer than two members) rather than
-    /// guessing — the primary diagnostic is unaffected either way.
-    pub(in crate::error_reporter) fn declared_intersection_member_types_for_expression(
+    /// annotation, not an intersection, fewer than two members, a cross-arena
+    /// or multi-declaration alias) rather than guessing — the primary
+    /// diagnostic is unaffected either way, so under-covering never produces a
+    /// wrong message.
+    pub(in crate::error_reporter) fn declared_never_intersection_for_expression(
         &mut self,
         expr_idx: NodeIndex,
-    ) -> Option<Vec<tsz_solver::TypeId>> {
+    ) -> Option<(Vec<tsz_solver::TypeId>, Option<String>)> {
         let annotation_idx =
             self.declared_current_arena_annotation_node_for_expression(expr_idx)?;
-        let member_nodes = self.declared_intersection_annotation_member_nodes(annotation_idx)?;
-        Some(
-            member_nodes
-                .iter()
-                .map(|&member_node| self.get_type_from_type_node(member_node))
-                .collect(),
-        )
+        self.recover_never_intersection_from_annotation(annotation_idx)
+    }
+
+    /// Walk the receiver annotation to the written intersection, hopping through
+    /// single-declaration type-alias references (`C` -> `A & B`, `D` -> `C` ->
+    /// `A & B`, `Pair<"y">` -> `{ kind: T } & { kind: "x" }`). Bounded by the
+    /// per-alias `visited` cycle guard and a hard hop cap so a pathological
+    /// alias chain cannot spin.
+    fn recover_never_intersection_from_annotation(
+        &mut self,
+        annotation_idx: NodeIndex,
+    ) -> Option<(Vec<tsz_solver::TypeId>, Option<String>)> {
+        /// Alias hops to follow before giving up. Deep enough for any realistic
+        /// forwarding chain; the `visited` set already stops true cycles.
+        const MAX_ALIAS_HOPS: usize = 16;
+
+        let mut visited: Vec<tsz_binder::SymbolId> = Vec::new();
+        let mut current = annotation_idx;
+        // `None` until the first alias hop; each hop overwrites it, so the last
+        // hop before the intersection — the alias that directly wraps it — wins.
+        let mut alias_display: Option<String> = None;
+
+        for _ in 0..MAX_ALIAS_HOPS {
+            current = self.skip_parenthesized_type_node(current);
+            let node = self.ctx.arena.get(current)?;
+            let kind = node.kind;
+
+            if kind == tsz_parser::parser::syntax_kind_ext::INTERSECTION_TYPE {
+                let member_nodes = self.declared_intersection_annotation_member_nodes(current)?;
+                let members = member_nodes
+                    .iter()
+                    .map(|&member_node| self.get_type_from_type_node(member_node))
+                    .collect();
+                return Some((members, alias_display));
+            }
+
+            if kind == tsz_parser::parser::syntax_kind_ext::TYPE_REFERENCE {
+                let type_name = self.ctx.arena.get_type_ref(node)?.type_name;
+                let alias_body = self.type_reference_alias_body(type_name, &mut visited)?;
+                alias_display = self.format_alias_reference_display(current);
+                current = alias_body;
+                continue;
+            }
+
+            return None;
+        }
+        None
+    }
+
+    /// Peel wrapping `ParenthesizedType` nodes (`(A & B)`, `((C))`) so the walk
+    /// sees the intersection or type reference underneath.
+    fn skip_parenthesized_type_node(&self, mut idx: NodeIndex) -> NodeIndex {
+        while self.ctx.arena.get(idx).is_some_and(|node| {
+            node.kind == tsz_parser::parser::syntax_kind_ext::PARENTHESIZED_TYPE
+        }) {
+            match self.ctx.arena.get_wrapped_type_at(idx) {
+                Some(wrapped) => idx = wrapped.type_node,
+                None => break,
+            }
+        }
+        idx
+    }
+
+    /// `tsc`'s `{0}` display for an alias reference that names a never-reduced
+    /// intersection: the alias name, plus its written type arguments rendered
+    /// through the type printer so literals normalize the same way the rest of
+    /// the message does (`Pair<'y'>` -> `Pair<"y">`).
+    fn format_alias_reference_display(&mut self, reference_idx: NodeIndex) -> Option<String> {
+        let node = self.ctx.arena.get(reference_idx)?;
+        let type_ref = self.ctx.arena.get_type_ref(node)?;
+        let name = self.entity_name_text(type_ref.type_name)?;
+        let Some(type_arguments) = type_ref.type_arguments.clone() else {
+            return Some(name);
+        };
+        if type_arguments.nodes.is_empty() {
+            return Some(name);
+        }
+        let rendered = type_arguments
+            .nodes
+            .iter()
+            .map(|&arg_idx| {
+                let arg_type = self.get_type_from_type_node(arg_idx);
+                self.format_type(arg_type)
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        Some(format!("{name}<{rendered}>"))
     }
 }

--- a/crates/tsz-checker/src/error_reporter/intersection_never_elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/intersection_never_elaboration.rs
@@ -86,11 +86,19 @@ impl<'a> CheckerState<'a> {
             return None;
         }
         let receiver_idx = self.property_access_receiver_expr(idx)?;
-        let members = self.declared_intersection_member_types_for_expression(receiver_idx)?;
+        // Recover the written intersection behind the `never` receiver, following
+        // any type-alias references (`type C = A & B; declare const c: C`). The
+        // recovered display is `None` for a directly-written intersection (render
+        // the members structurally) or the naming alias otherwise (`C`,
+        // `Pair<"y">`) — matching `tsc`'s `typeToString` of the reduced type.
+        let (members, alias_display) =
+            self.declared_never_intersection_for_expression(receiver_idx)?;
         // Each member is resolved through the same lazy-type machinery
         // property access itself uses (`Lazy(DefId)` interface/type-alias
         // references do not carry a structural shape the solver query below
-        // can read until stabilized against the type environment).
+        // can read until stabilized against the type environment; a generic
+        // application member such as `WithKind<"a">` reached through an alias
+        // must materialize here before its literal property is comparable).
         let members: Vec<TypeId> = members
             .into_iter()
             .map(|member| self.resolve_type_for_property_access(member))
@@ -126,17 +134,22 @@ impl<'a> CheckerState<'a> {
         // accessed — once the receiver type itself is `never`, every access
         // on it carries the same reason.
         let conflict_prop_name = self.ctx.types.resolve_atom(conflict_atom);
-        // Built directly from the recovered member types rather than
-        // `declared_intersection_annotation_display_for_expression`: that
-        // sibling gates its result on seeing a type-literal member (it exists
-        // to improve *assignability*-message display, not to answer "was
-        // this written as an intersection"), so it declines exactly the
-        // plain-interface-member shape (`A & B`) this diagnostic needs most.
-        let intersection_display = members
-            .iter()
-            .map(|&member| self.format_type(member))
-            .collect::<Vec<_>>()
-            .join(" & ");
+        // A directly-written intersection is rendered structurally from the
+        // recovered member types (rather than
+        // `declared_intersection_annotation_display_for_expression`, which gates
+        // its result on seeing a type-literal member — it exists to improve
+        // *assignability*-message display, not to answer "was this written as an
+        // intersection" — and so declines exactly the plain-interface-member
+        // shape `A & B` this diagnostic needs most). When the intersection was
+        // reached through a type alias, `tsc` names that alias instead of its
+        // members, so the recovered alias display wins.
+        let intersection_display = alias_display.unwrap_or_else(|| {
+            members
+                .iter()
+                .map(|&member| self.format_type(member))
+                .collect::<Vec<_>>()
+                .join(" & ")
+        });
         use crate::diagnostics::{Diagnostic, diagnostic_messages, format_message};
         let message_template = if code
             == diagnostic_codes::THE_INTERSECTION_WAS_REDUCED_TO_NEVER_BECAUSE_PROPERTY_HAS_CONFLICTING_TYPES_IN

--- a/crates/tsz-checker/src/tests/ts18031_intersection_conflicting_property_tests.rs
+++ b/crates/tsz-checker/src/tests/ts18031_intersection_conflicting_property_tests.rs
@@ -16,7 +16,7 @@
 //! `TypeInterner::intern` already collapses such an intersection to the
 //! single canonical `TypeId::NEVER` at construction time, so tsz recovers the
 //! pre-reduction member list from the receiver's own declared-type syntax
-//! (`declared_intersection_member_types_for_expression`,
+//! (`declared_never_intersection_for_expression`,
 //! `error_reporter/core/declared_intersection_display.rs`) rather than from
 //! the reported `never` itself, and re-runs a conflict search
 //! (`find_disjoint_literal_property_across_intersection`,
@@ -24,12 +24,14 @@
 //! resolved members. Owned by `error_reporter/properties.rs`'s
 //! `intersection_reduced_to_never_related_info`.
 //!
-//! Deliberately narrow scope, matching the helper's own doc comments: only
-//! the single-required-literal-per-member discriminant shape, only a
-//! directly-written intersection annotation (no alias/generic-application/
-//! heritage indirection, no private-brand conflicts — TS18032 is a separate,
-//! unimplemented follow-up). Every case outside that scope keeps today's
-//! behavior (`TS2339` with no elaboration), never a wrong one.
+//! The recovery follows type-alias references (`type C = A & B; declare const
+//! c: C`, and multi-hop `type D = C`), naming the alias whose body is directly
+//! the intersection exactly as `tsc`'s `typeToString` does. Remaining scope
+//! limits (each an under-cover that keeps `TS2339` with no elaboration, never
+//! a wrong one): the single-required-literal-per-member discriminant shape
+//! only; a generic *alias* whose conflicting property is the unsubstituted
+//! type parameter (the reduction to `never` itself does not yet fire there);
+//! and a cross-arena alias whose declaration lives in another file.
 
 use crate::diagnostics::Diagnostic;
 use crate::test_utils::check_source_strict;
@@ -310,12 +312,12 @@ c.p;
 }
 
 #[test]
-fn indirect_alias_intersection_has_no_ts18031() {
-    // The conflict is real (tsc still reports the elaboration here through
-    // its full alias-resolution machinery), but the narrow syntactic walk
-    // this diagnostic uses declines once the receiver's own declared type is
-    // an alias rather than a directly-written intersection — a documented
-    // scope limit, not a false report.
+fn alias_to_intersection_carries_ts18031_naming_the_alias() {
+    // The receiver's declared type is a *type alias* to the conflicting
+    // intersection. The syntactic walk now follows the alias reference to the
+    // intersection behind it, and — matching `tsc`'s `typeToString` of the
+    // reduced type — names the alias (`Combined`) in the `{0}` slot rather
+    // than expanding its members.
     let diags = check_source_strict(
         r#"
 interface Left { tag: 1 }
@@ -326,5 +328,104 @@ value.tag;
 "#,
     );
     let diag = only(&diags, TS2339);
-    assert!(related(&diag, TS18031).is_none(), "got {diags:?}");
+    assert_eq!(
+        related(&diag, TS18031).as_deref(),
+        Some(
+            "The intersection 'Combined' was reduced to 'never' because property 'tag' has conflicting types in some constituents."
+        ),
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn multi_hop_alias_names_the_alias_that_wraps_the_intersection() {
+    // `Outer -> Inner -> A & B`: `tsc` names the *innermost* alias whose body
+    // is directly the intersection (`Inner`), not the outer alias that merely
+    // forwards to it, nor the members.
+    let diags = check_source_strict(
+        r#"
+interface A { tag: 1 }
+interface B { tag: 2 }
+type Inner = A & B;
+type Outer = Inner;
+declare const value: Outer;
+value.tag;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18031).as_deref(),
+        Some(
+            "The intersection 'Inner' was reduced to 'never' because property 'tag' has conflicting types in some constituents."
+        ),
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn alias_of_generic_application_members_materializes_then_conflicts() {
+    // The alias body intersects two *generic applications* (`WithKind<"a">`,
+    // `WithKind<"b">`). Each must materialize before its literal `kind`
+    // property is comparable; once it does, the conflict is found and the
+    // alias `Combined` is named. (Witness from issue #15396's `Combined` case.)
+    let diags = check_source_strict(
+        r#"
+type WithKind<K> = { kind: K };
+type Combined = WithKind<"a"> & WithKind<"b">;
+declare const value: Combined;
+value.kind;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18031).as_deref(),
+        Some(
+            "The intersection 'Combined' was reduced to 'never' because property 'kind' has conflicting types in some constituents."
+        ),
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn parenthesized_alias_body_still_carries_ts18031() {
+    let diags = check_source_strict(
+        r#"
+interface A { tag: 1 }
+interface B { tag: 2 }
+type Combined = (A & B);
+declare const value: Combined;
+value.tag;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18031).as_deref(),
+        Some(
+            "The intersection 'Combined' was reduced to 'never' because property 'tag' has conflicting types in some constituents."
+        ),
+        "got {diags:?}"
+    );
+}
+
+#[test]
+fn alias_intersection_elaboration_is_binder_name_agnostic() {
+    // Renaming every binder must not change whether the elaboration fires —
+    // only the rendered alias/property names, which track the source verbatim.
+    let diags = check_source_strict(
+        r#"
+interface Zebra { kind: 'x' }
+interface Yak { kind: 'y' }
+type Quokka = Zebra & Yak;
+declare const w: Quokka;
+w.kind;
+"#,
+    );
+    let diag = only(&diags, TS2339);
+    assert_eq!(
+        related(&diag, TS18031).as_deref(),
+        Some(
+            "The intersection 'Quokka' was reduced to 'never' because property 'kind' has conflicting types in some constituents."
+        ),
+        "got {diags:?}"
+    );
 }

--- a/crates/tsz-checker/src/tests/ts18032_intersection_private_brand_conflict_tests.rs
+++ b/crates/tsz-checker/src/tests/ts18032_intersection_private_brand_conflict_tests.rs
@@ -448,10 +448,10 @@ c.x;
 }
 
 #[test]
-fn indirect_alias_intersection_has_no_ts18032() {
-    // Same scope limit as TS18031: the narrow syntactic walk declines once
-    // the receiver's own declared type is an alias rather than a
-    // directly-written intersection.
+fn alias_to_private_brand_intersection_carries_ts18032_naming_the_alias() {
+    // Same alias support as TS18031: the walk follows the receiver's alias to
+    // the private-brand-conflicting intersection behind it and names the alias
+    // (`Combined`), matching `tsc`.
     let diags = check_source_strict(
         r#"
 class P1 { private x: string = ""; }
@@ -462,5 +462,11 @@ value.x;
 "#,
     );
     let diag = only(&diags, TS2339);
-    assert!(related(&diag, TS18032).is_none(), "got {diags:?}");
+    assert_eq!(
+        related(&diag, TS18032).as_deref(),
+        Some(
+            "The intersection 'Combined' was reduced to 'never' because property 'x' exists in multiple constituents and is private in some."
+        ),
+        "got {diags:?}"
+    );
 }

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
@@ -756,7 +756,13 @@ impl<'a> CheckerState<'a> {
         Some(values)
     }
 
-    fn type_reference_alias_body(
+    /// The single-declaration type-alias body node a `TypeReference`'s
+    /// `type_name` resolves to, cycle-guarded by `visited_aliases`.
+    ///
+    /// Shared with the `error_reporter` never-intersection elaboration, which
+    /// walks the same alias chain to recover the written intersection that
+    /// reduced a property-access receiver to `never`.
+    pub(crate) fn type_reference_alias_body(
         &self,
         type_name: NodeIndex,
         visited_aliases: &mut Vec<tsz_binder::SymbolId>,


### PR DESCRIPTION
When a property-access receiver's type is an intersection that reduced to `never`, `tsc` attaches a related-info line ("The intersection 'X' was reduced to 'never' because property 'p' ..."). tsz recovers the pre-reduction members from the receiver's declared-type syntax (the interned type is already the canonical `never`), but only recognized a **directly written** intersection annotation and dropped the elaboration whenever the receiver's declared type was a type alias — exactly the shape real code uses (`type C = A & B; declare const c: C`).

## Structural rule
When a property access lands on a `never` receiver produced by an intersection reduced to `never`, and the receiver's declared type reaches that intersection through one or more single-declaration type aliases, `tsc`'s `typeToString` names the alias whose body **is** the intersection (`C`, `Pair<"y">`) — not its members, and not an outer alias that merely forwards to it (`type D = C` still displays `C`). tsz now does the same: the `error_reporter` never-intersection recovery follows alias references (multi-hop, parenthesized, and generic-application members that materialize per-member before their literal property is comparable) to the written intersection, keeping the innermost naming alias for the `{0}` slot. A directly-written intersection still renders structurally (`A & B`), byte-for-byte as before.

Owner layer: checker `error_reporter/core/declared_intersection_display.rs` (recovery) + `error_reporter/intersection_never_elaboration.rs` (consumer), reusing the solver conflict-detection queries and promoting the shared `type_reference_alias_body` alias resolver to `pub(crate)` instead of duplicating it.

Adjacent matrix (each verified against `tsc` 6.0.2): direct interface / type-literal intersection; alias to intersection; multi-hop alias (`D = C = A & B` names `C`); parenthesized alias body; generic-application members via alias (issue #15396's `Combined` witness); private-brand conflict (TS18032) via alias; element access; renamed binders (name-agnostic). Negative / fallback: a genuinely-absent property still reports `TS2339` + the elaboration; a non-conflicting alias (no `never`) yields no elaboration; a generic alias whose conflicting property is the unsubstituted type parameter, and a cross-arena alias declared in another file, both **safely under-cover** (`TS2339` with no elaboration — never a wrong message), matching the existing same-arena scope of this elaboration.

Advances #15396 (a decision site — here the never-intersection elaboration — judging unmaterialized application operands reached through an alias). Does not close it.

## Goal
Goal: green

## Verification
- `CARGO_PROFILE_DEV_DEBUG=0 cargo test -p tsz-checker --lib ts1803` — 44 pass, including the new alias / multi-hop / generic-application / parenthesized / private-brand / name-agnostic cases; the two tests that previously pinned "no elaboration through an alias" are flipped to assert the now-correct `tsc`-matching output.
- `cargo clippy --profile dist-fast -p tsz-checker --lib -- -D warnings` (pre-commit gate) — clean.
- `scripts/arch/arch_guard.py` and the checker-boundary guard — pass; all touched files stay well under the 2000-line ceiling.
- `tsc` 6.0.2 oracle diff across the adjacent matrix above — tsz matches byte-for-byte where it fires.
- Conformance / emit / fourslash require the TypeScript submodule (not checked out this session) and run in nightly CI. The change is additive and gated to `never` receivers, so it can only add elaborations where `tsc` already emits them — no primary-diagnostic behavior changes.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYdNwbeRW2hhZ5MU3hXhF7)_