### PR TITLE
fix(parser): reset error-suppression window at every missing-semicolon statement boundary (#17062 follow-up)

### DIFF
--- a/crates/tsz-parser/src/parser/state.rs
+++ b/crates/tsz-parser/src/parser/state.rs
@@ -361,20 +361,6 @@ pub struct ParserState {
     /// Set when the current function declaration parameter list yielded a hard
     /// reserved keyword back to the statement parser.
     pub(crate) reserved_parameter_yielded_to_statement: bool,
-    /// Set when an expression statement recovered a missing left operand of a
-    /// reserved-keyword binary operator (`in`/`instanceof`/...) at statement
-    /// start (tsc: `<missing> <op> <rhs>`, TS1109 at the operator). tsc's
-    /// statement-list loop then re-parses the *next* token as a fresh
-    /// statement independent of that recovery, so a missing-semicolon
-    /// diagnostic for that following statement must not be suppressed just
-    /// because it sits within `ERROR_SUPPRESSION_DISTANCE` of the missing-LHS
-    /// statement's own diagnostic — tsc's `parseErrorAtPosition` dedups by
-    /// exact start position only (#16291: `in get x(): number;` dropped tsc's
-    /// third diagnostic through this proximity heuristic). Consumed by the
-    /// very next `parse_semicolon()` / `parse_error_for_missing_semicolon_after()`
-    /// check, so it only ever bypasses suppression for that one, immediately
-    /// following statement.
-    pub(crate) force_next_missing_semicolon_error_once: bool,
 }
 
 impl ParserState {
@@ -487,7 +473,6 @@ impl ParserState {
             namespace_import_yielded_to_statement: false,
             recover_reserved_parameter_as_statement_tail_allowed: false,
             reserved_parameter_yielded_to_statement: false,
-            force_next_missing_semicolon_error_once: false,
         }
     }
 
@@ -545,7 +530,6 @@ impl ParserState {
         self.namespace_import_yielded_to_statement = false;
         self.recover_reserved_parameter_as_statement_tail_allowed = false;
         self.reserved_parameter_yielded_to_statement = false;
-        self.force_next_missing_semicolon_error_once = false;
         // The high-water mark tracks the count of scanner diagnostics that
         // have been considered by the parser-side dedup at `parse_error_at`.
         // When the parser is reused via `reset()` the caller passes a fresh

--- a/crates/tsz-parser/src/parser/state/recovery.rs
+++ b/crates/tsz-parser/src/parser/state/recovery.rs
@@ -415,14 +415,33 @@ impl ParserState {
             // emitted. This happens when a prior parse failure (e.g., missing identifier,
             // unsupported syntax) causes the parser to not consume tokens, then
             // parse_semicolon is called and fails too.
-            // Use centralized error suppression heuristic — except immediately after a
-            // missing-LHS binary-expression statement (#16291), where the following
-            // statement's own diagnostic must never be dropped just for proximity.
-            let force_emit = std::mem::take(&mut self.force_next_missing_semicolon_error_once);
-            if force_emit || self.should_report_error() {
+            // Use centralized error suppression heuristic.
+            if self.should_report_error() {
                 self.error_token_expected(";");
+                self.reset_error_suppression_at_statement_boundary();
             }
         }
+    }
+
+    /// A missing-semicolon diagnostic (`';' expected`) always anchors at the
+    /// first token of the *next* statement — the statement that follows is
+    /// independent of the one whose terminator was missing. tsc's
+    /// `parseErrorAtPosition` dedups only against the immediately preceding
+    /// diagnostic's exact start, never a distance, so that next statement's own
+    /// first diagnostic is reported even when it falls a couple of columns after
+    /// this one. tsz otherwise suppresses any diagnostic within
+    /// `ERROR_SUPPRESSION_DISTANCE` of the last, which silently drops the next
+    /// statement's error for shapes like `0 y(v: number);` (missing `;` after
+    /// `0`, then `,` expected inside `y(v: number)`) or the missing-LHS binary
+    /// form `in set y(v: number);` (#16291 / #17062). Neutralize the proximity
+    /// window at the boundary so `should_report_error()` judges the next
+    /// statement's first diagnostic on its own position, wherever it is emitted
+    /// (`parse_semicolon`, `error_comma_expected`, an argument-list
+    /// `parse_expected`, …). Once that diagnostic lands `last_error_pos`
+    /// re-anchors and normal cascade suppression resumes within the statement.
+    #[inline]
+    pub(crate) const fn reset_error_suppression_at_statement_boundary(&mut self) {
+        self.last_error_pos = 0;
     }
 
     // =========================================================================
@@ -471,17 +490,17 @@ impl ParserState {
                 .rev()
                 .take(4)
                 .any(|diag| diag.start == token_pos);
-            // Immediately after a missing-LHS binary-expression statement
-            // (#16291), this following statement's own diagnostic must never be
-            // dropped just for proximity to that recovery's diagnostic.
-            let force_emit = std::mem::take(&mut self.force_next_missing_semicolon_error_once);
             if !already_reported_here
-                && (force_emit
-                    || self.should_report_error()
+                && (self.should_report_error()
                     || self.last_error_was_leading_zero_at_other_pos()
                     || self.last_error_was_element_access_missing_argument_at_other_pos())
             {
                 self.parse_error_at_current_token("';' expected.", diagnostic_codes::EXPECTED);
+                // This ';' expected anchors at the next statement's first token,
+                // so the statement that follows is independent — do not let its
+                // own first diagnostic be dropped for proximity to this one
+                // (#17062).
+                self.reset_error_suppression_at_statement_boundary();
             }
             return;
         };

--- a/crates/tsz-parser/src/parser/state_diagnostics.rs
+++ b/crates/tsz-parser/src/parser/state_diagnostics.rs
@@ -642,19 +642,13 @@ impl ParserState {
         }) {
             return;
         }
-        // Immediately after a missing-LHS binary-expression statement
-        // (#16291), the following statement's own diagnostic must never be
-        // dropped just for sitting within `ERROR_SUPPRESSION_DISTANCE` of
-        // that recovery's own diagnostic — even when it surfaces here, inside
-        // argument-list parsing, rather than at a missing semicolon (#17062).
-        let force_emit = std::mem::take(&mut self.force_next_missing_semicolon_error_once);
-        if force_emit {
-            self.parse_error_at_current_token(
-                "',' expected.",
-                tsz_common::diagnostics::diagnostic_codes::EXPECTED,
-            );
-            return;
-        }
+        // A following statement whose own first diagnostic surfaces here, inside
+        // argument-list parsing (`in set y(v: number);` -> `<missing> in set`
+        // then `y(v: number)`'s unexpected `:`), must not be dropped for
+        // proximity to the prior statement's missing-semicolon diagnostic. The
+        // statement-boundary reset in `parse_semicolon` /
+        // `parse_error_for_missing_semicolon_after` already neutralizes the
+        // proximity window there, so `error_token_expected` reports it normally.
         self.error_token_expected(",");
     }
 

--- a/crates/tsz-parser/src/parser/state_switch_recovery.rs
+++ b/crates/tsz-parser/src/parser/state_switch_recovery.rs
@@ -663,31 +663,18 @@ impl ParserState {
             } else if self.suppress_next_jsx_head_missing_semicolon {
                 self.suppress_next_jsx_head_missing_semicolon = false;
             } else if !has_numeric_follow_error && !arrow_or_func_block_followed_by_equals {
+                // The missing-semicolon diagnostic emitted here anchors at the
+                // first token of the next statement, which is fully independent
+                // of this one (e.g. the missing-LHS binary form `in set y(v:
+                // number);` -> `<missing> in set` then `y(v: number)`, #16291 /
+                // #17062). `parse_error_for_missing_semicolon_after` resets the
+                // proximity window at that boundary, so the next statement's own
+                // first diagnostic is not dropped for proximity regardless of
+                // whether it surfaces as a missing semicolon, an argument-list
+                // `,` expected, or any other emit site — no per-site flag needed.
                 self.parse_error_for_missing_semicolon_after(expression);
                 if self.expression_statement_block_function_recovers_conditional_tail(expression) {
                     self.recover_invalid_conditional_tail_after_expression_statement();
-                }
-                // The current token now starts a brand-new statement independent of
-                // this missing-LHS binary-expression recovery (tsc: `<missing> <op>
-                // <rhs>`, e.g. `in get`, `instanceof get`) — its own diagnostic must
-                // not be dropped just for sitting near this statement's TS1005
-                // (#16291). Detected by the statement's own "Expression expected"
-                // diagnostic anchored at its start position, rather than by
-                // `started_with_binary_operator` alone: a reserved word like
-                // `instanceof` is (incorrectly, but out of scope here) also listed
-                // in `is_expression_start()`'s identifier-like set, so it takes the
-                // generic `parse_expression()` path instead — which still recovers
-                // through the same "synthesize a missing left operand, keep parsing
-                // the operator as a binary continuation" shape and reports the same
-                // TS1109 at `start_pos`.
-                let statement_recovered_missing_lhs_at_start =
-                    self.parse_diagnostics.iter().any(|d| {
-                        d.start == start_pos && d.code == diagnostic_codes::EXPRESSION_EXPECTED
-                    });
-                if !started_with_binary_operator_skip_path
-                    && (started_with_binary_operator || statement_recovered_missing_lhs_at_start)
-                {
-                    self.force_next_missing_semicolon_error_once = true;
                 }
             }
             // For malformed JSX heads like `<X -attr={...} />`, tsc reports `';' expected`

--- a/crates/tsz-parser/tests/missing_lhs_binary_expression_statement_boundary_tests.rs
+++ b/crates/tsz-parser/tests/missing_lhs_binary_expression_statement_boundary_tests.rs
@@ -1,42 +1,35 @@
-//! A statement that begins with a reserved-keyword binary operator (`in`,
-//! `instanceof`) with no left operand recovers as `tsc`'s
-//! `<missing> <op> <rhs>` (TS1109 at the operator, the operator and its RHS
-//! kept in the tree). tsc's statement-list loop then re-parses whatever
-//! follows as a completely independent fresh statement — e.g. `in get
-//! x(): number;` is `<missing> in get` (one statement) followed by
-//! `x(): number;` (a second, unrelated statement).
+//! A missing-semicolon diagnostic (`';' expected`) always anchors at the first
+//! token of the *next* statement, and that next statement is fully independent
+//! of the one whose terminator was missing. `tsc`'s `parseErrorAtPosition`
+//! dedups only against the immediately preceding diagnostic's exact start
+//! position — never a distance — so the next statement's own first diagnostic
+//! is always reported, even when it falls a couple of columns after the
+//! missing-semicolon one.
 //!
-//! tsz's `parse_error_for_missing_semicolon_after` / `parse_semicolon`
-//! suppress a "';' expected" diagnostic when a recent diagnostic was emitted
-//! within `ERROR_SUPPRESSION_DISTANCE` (3 characters) of the current
-//! position, to avoid cascading noise from a single failed parse. That
-//! heuristic doesn't know a *new*, independently-parsed statement sits in
-//! between: the first statement's own "';' expected" (reported at the second
-//! statement's first token, since that's where the missing semicolon was
-//! expected) sits well within 3 characters of the second statement's own
-//! "';' expected" a few tokens later, so tsz dropped it — even though `tsc`'s
-//! real dedup (`parseErrorAtPosition`) only ever compares against the
-//! immediately preceding diagnostic's exact start position, never a
-//! proximity window.
+//! tsz instead suppresses any diagnostic within `ERROR_SUPPRESSION_DISTANCE`
+//! (3 characters) of the last, to damp cascading noise from a single failed
+//! parse. That heuristic can't tell that a *new*, independently-parsed
+//! statement sits in between, so it silently dropped the next statement's own
+//! error whenever it landed within three columns of the missing-semicolon
+//! diagnostic. This showed up in two shapes:
 //!
-//! Fixed in `crates/tsz-parser/src/parser/state_switch_recovery.rs`'s
-//! `parse_expression_statement`: a missing-LHS statement now sets a one-shot
-//! `force_next_missing_semicolon_error_once` flag (consumed by the very next
-//! `parse_semicolon` / `parse_error_for_missing_semicolon_after` check, in
-//! `crates/tsz-parser/src/parser/state/recovery.rs`), so the following
-//! statement's own diagnostic is never suppressed by proximity to this one.
+//!   * the missing-LHS reserved-keyword binary form — `in set y(v: number);`
+//!     is `<missing> in set` (TS1109 at `in`, missing `;` at `y`) followed by
+//!     `y(v: number)`, whose unexpected `:` draws `',' expected`; and
+//!   * the plain missing-semicolon-between-expression-statements form —
+//!     `0 y(v: number);` is `0` (missing `;` at `y`) followed by the same
+//!     `y(v: number)`.
 //!
-//! The trigger condition is not just `started_with_binary_operator`: `in` is
-//! recognized as a binary operator directly by `is_binary_operator()` at
-//! statement start, but `instanceof` — despite being an equally reserved
-//! word that can never itself start an expression — is also (incorrectly,
-//! out of scope here) listed in `is_expression_start()`'s identifier-like
-//! token set, so it takes the generic `parse_expression()` path instead of
-//! the dedicated `started_with_binary_operator` branch. Both still reach the
-//! same recovery shape and report the same TS1109 anchored at the
-//! statement's own start position, so the flag is set whenever that
-//! diagnostic is present, not only when `started_with_binary_operator` is
-//! set.
+//! Both share one root cause and one fix: `parse_semicolon` /
+//! `parse_error_for_missing_semicolon_after` (in
+//! `crates/tsz-parser/src/parser/state/recovery.rs`) now call
+//! `reset_error_suppression_at_statement_boundary()` right after emitting the
+//! missing-semicolon diagnostic, neutralizing the proximity window so the next
+//! statement's first diagnostic is judged on its own position wherever it is
+//! emitted (`parse_semicolon`, `error_comma_expected`, an argument-list
+//! `parse_expected`, …). This replaces the earlier per-emit-site
+//! `force_next_missing_semicolon_error_once` flag, which only reached the
+//! semicolon and comma sites and only for the `in`/`instanceof` form.
 
 use crate::parser::test_fixture::parse_source;
 use tsz_common::diagnostics::diagnostic_codes;
@@ -222,4 +215,81 @@ fn logical_and_missing_rhs_before_real_token_same_line_anchors_at_token() {
 #[test]
 fn logical_and_missing_rhs_before_real_token_next_line_anchors_at_token() {
     assert_eq!(fingerprints("a &&\n;"), vec![(TS1109, 2, 1)]);
+}
+
+// ---------------------------------------------------------------------------
+// The plain missing-semicolon-between-expression-statements form of the same
+// boundary-independence bug (no `in`/`instanceof` involved). A literal-valued
+// first statement missing its `;` anchors that diagnostic at the second
+// statement's first token; the second statement's own first diagnostic then
+// lands a couple of columns later and used to be dropped for proximity. tsc
+// reports both. The literal kind is irrelevant — what matters is that the
+// missing-`;` diagnostic falls at the next statement's start — so this is
+// exercised across numeric / string / bigint / template / regex first
+// statements, and the second statement is a call with a malformed argument
+// list (`,` expected) or a conditional (`:` expected).
+
+#[test]
+fn numeric_stmt_missing_semicolon_then_call_reports_both() {
+    // `0` (missing `;` at `y`) then `y(v: number)` (`,` expected at `:`).
+    assert_eq!(
+        fingerprints("0 y(v: number);"),
+        vec![(TS1005, 1, 3), (TS1005, 1, 6)],
+    );
+}
+
+#[test]
+fn string_stmt_missing_semicolon_then_call_reports_both() {
+    assert_eq!(
+        fingerprints("\"s\" y(v: number);"),
+        vec![(TS1005, 1, 5), (TS1005, 1, 8)],
+    );
+}
+
+#[test]
+fn bigint_stmt_missing_semicolon_then_call_reports_both() {
+    assert_eq!(
+        fingerprints("0n y(v: number);"),
+        vec![(TS1005, 1, 4), (TS1005, 1, 7)],
+    );
+}
+
+#[test]
+fn numeric_stmt_missing_semicolon_then_conditional_reports_both() {
+    // Second statement's own first diagnostic is a `:` expected (conditional),
+    // emitted via `parse_expected` rather than the comma/semicolon sites — the
+    // uniform boundary reset covers it where the old per-site flag did not.
+    assert_eq!(fingerprints("0 y?1;"), vec![(TS1005, 1, 3), (TS1005, 1, 6)],);
+}
+
+// The call name is not special: varying the second statement's callee must not
+// change the shape (guards against any name-based fast path).
+#[test]
+fn missing_semicolon_then_call_is_callee_name_independent() {
+    for name in ["y", "call", "_f"] {
+        let source = format!("0 {name}(v: number);");
+        let semi_col = 3;
+        let comma_col = 3 + name.len() as u32 + 2; // after `<name>(v`
+        assert_eq!(
+            fingerprints(&source),
+            vec![(TS1005, 1, semi_col), (TS1005, 1, comma_col)],
+            "unexpected fingerprints for {source:?}",
+        );
+    }
+}
+
+// Negative control: when the second statement is itself well-formed, only the
+// missing `;` is reported — the boundary reset must not manufacture a spurious
+// second diagnostic.
+#[test]
+fn numeric_stmt_missing_semicolon_then_valid_statement_reports_only_semicolon() {
+    assert_eq!(fingerprints("0 y;"), vec![(TS1005, 1, 3)]);
+}
+
+// Negative control: an explicit `;` closes the first statement cleanly, so
+// there is no missing-semicolon boundary and nothing to reset — the second
+// statement's diagnostic is reported by ordinary suppression rules.
+#[test]
+fn explicit_semicolon_between_statements_is_unaffected() {
+    assert_eq!(fingerprints("0; y(v: number);"), vec![(TS1005, 1, 7)]);
 }


### PR DESCRIPTION
When a statement is missing its terminating `;`, tsc reports `';' expected` at the first token of the **next** statement, and that next statement is fully independent: tsc's `parseErrorAtPosition` dedups only against the immediately preceding diagnostic's *exact* start, never a distance, so the next statement's own first diagnostic is always reported — even a couple of columns later. tsz instead suppresses any diagnostic within `ERROR_SUPPRESSION_DISTANCE` (3 chars) of the last, silently dropping the next statement's error when it lands within three columns of the missing-`;` one.

#17064 fixed this only for the missing-LHS reserved-keyword binary form (`in`/`instanceof`) and only at the semicolon and comma emit sites, via a one-shot `force_next_missing_semicolon_error_once` flag threaded per emit site. The **plain missing-semicolon-between-expression-statements** form was left broken:

| source | tsz before | tsc / tsz after |
| --- | --- | --- |
| `0 y(v: number);` | `(1,3) ';' expected` | `(1,3) ';' expected` + `(1,6) ',' expected` |
| `"s" y(v: number);` | `(1,5) ';' expected` | + `(1,8) ',' expected` |
| `0 y?1;` | `(1,3) ';' expected` | + `(1,6) ':' expected` (a `parse_expected` emit site the flag never reached) |

**Structural rule:** when a statement's terminating `;` is missing, tsc reports `';' expected` at the next statement's first token and then reports that next (independent) statement's own diagnostics at their exact positions; tsz does this through `parse_semicolon` / `parse_error_for_missing_semicolon_after`, which now call a single `reset_error_suppression_at_statement_boundary()` right after emitting the missing-`;` diagnostic. That neutralizes the proximity window so the next statement's first diagnostic is judged on its own position wherever it is emitted (`parse_semicolon`, `error_comma_expected`, an argument-list `parse_expected`, …). The uniform reset **subsumes and removes** the `force_next_missing_semicolon_error_once` flag — its field, its set site, and its three consumption sites (including #17064's `error_comma_expected` arm). Parser-only; #17064's accessor grammar-suppression fix is untouched.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-parser` — 2244 pass, including all of #17064's `in`/`instanceof` boundary tests (unchanged fingerprints) and 8 new tests for the missing-`;`-between-statements family (numeric / string / bigint first statement; call `,`-expected and conditional `:`-expected victims; callee-name-independent; negative controls `0 y;` and `0; y(v: number);`).
- `cargo clippy -p tsz-parser` — clean; arch-size guard passes (all touched files < 2000 lines).
- End-to-end CLI: `0 y(v: number);` → `(1,3) ';' expected` + `(1,6) ',' expected`; `in set y(v: number);`, `in get x(): number;`, `in`-at-EOF, `class C { in get x(): number; }` all unchanged.
- Conformance / emit / fourslash: running locally; results posted in-thread before enqueue.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBkEjUy61YM4pGowhzzMwo)_