### PR TITLE
fix(checker): ambient const enum-reference initializers follow tsc's isSimpleLiteralEnumReference

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/statement_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_checks.rs
@@ -292,8 +292,9 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Check if a node is a valid const initializer in an ambient context.
-    /// Valid initializers are string literals, numeric literals, or negative numeric literals.
-    pub(crate) fn is_valid_const_initializer(&self, init_idx: NodeIndex) -> bool {
+    /// Delegates to [`Self::is_valid_ambient_const_initializer`] (literal forms
+    /// plus simple literal enum references).
+    pub(crate) fn is_valid_const_initializer(&mut self, init_idx: NodeIndex) -> bool {
         self.is_valid_ambient_const_initializer(init_idx)
     }
 

--- a/crates/tsz-checker/src/types/type_checking/declarations.rs
+++ b/crates/tsz-checker/src/types/type_checking/declarations.rs
@@ -1316,60 +1316,91 @@ impl<'a> CheckerState<'a> {
 
     /// Check if an initializer is a valid const initializer for ambient contexts.
     /// Valid initializers are string/numeric/bigint literals and enum references.
-    pub(crate) fn is_valid_ambient_const_initializer(&self, init_idx: NodeIndex) -> bool {
-        use tsz_binder::symbol_flags;
-
+    pub(crate) fn is_valid_ambient_const_initializer(&mut self, init_idx: NodeIndex) -> bool {
         let Some(node) = self.ctx.arena.get(init_idx) else {
             return false;
         };
-        match node.kind {
-            k if k == tsz_scanner::SyntaxKind::StringLiteral as u16
-                || k == tsz_scanner::SyntaxKind::NoSubstitutionTemplateLiteral as u16
-                || k == tsz_scanner::SyntaxKind::NumericLiteral as u16
-                || k == tsz_scanner::SyntaxKind::BigIntLiteral as u16
-                || k == tsz_scanner::SyntaxKind::TrueKeyword as u16
-                || k == tsz_scanner::SyntaxKind::FalseKeyword as u16 =>
-            {
-                true
-            }
-            k if k == syntax_kind_ext::PREFIX_UNARY_EXPRESSION => {
-                if let Some(unary) = self.ctx.arena.get_unary_expr(node)
-                    && unary.operator == tsz_scanner::SyntaxKind::MinusToken as u16
-                    && let Some(operand) = self.ctx.arena.get(unary.operand)
-                {
-                    return operand.kind == tsz_scanner::SyntaxKind::NumericLiteral as u16
-                        || operand.kind == tsz_scanner::SyntaxKind::BigIntLiteral as u16;
-                }
-                false
-            }
-            k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
-                || k == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION =>
-            {
-                let Some(access) = self.ctx.arena.get_access_expr(node) else {
-                    return false;
-                };
-                let Some(sym_id) = self.resolve_identifier_symbol(access.expression) else {
-                    return false;
-                };
-                let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
-                    return false;
-                };
-                if !symbol.has_any_flags(symbol_flags::ENUM) {
-                    return false;
-                }
-                if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
-                    return true;
-                }
-                let Some(arg_node) = self.ctx.arena.get(access.name_or_argument) else {
-                    return false;
-                };
-                arg_node.kind == tsz_scanner::SyntaxKind::StringLiteral as u16
-                    || arg_node.kind == tsz_scanner::SyntaxKind::NumericLiteral as u16
-                    || arg_node.kind
-                        == tsz_scanner::SyntaxKind::NoSubstitutionTemplateLiteral as u16
-            }
-            _ => false,
+        let kind = node.kind;
+
+        // Literal forms accepted verbatim: string / no-substitution template /
+        // numeric / bigint / `true` / `false`. Mirrors the union of tsc's
+        // `isStringOrNumericLiteralExpression`, `isBigIntLiteralExpression`, and
+        // the `TrueKeyword`/`FalseKeyword` arms of `checkAmbientInitializer`.
+        if kind == tsz_scanner::SyntaxKind::StringLiteral as u16
+            || kind == tsz_scanner::SyntaxKind::NoSubstitutionTemplateLiteral as u16
+            || kind == tsz_scanner::SyntaxKind::NumericLiteral as u16
+            || kind == tsz_scanner::SyntaxKind::BigIntLiteral as u16
+            || kind == tsz_scanner::SyntaxKind::TrueKeyword as u16
+            || kind == tsz_scanner::SyntaxKind::FalseKeyword as u16
+        {
+            return true;
         }
+
+        // A unary minus over a numeric or bigint literal (`-1`, `-1n`) — the
+        // `PrefixUnaryExpression && MinusToken` arm shared by tsc's
+        // `isStringOrNumericLiteralExpression` (numeric) and
+        // `isBigIntLiteralExpression` (bigint).
+        if kind == syntax_kind_ext::PREFIX_UNARY_EXPRESSION {
+            if let Some(unary) = self.ctx.arena.get_unary_expr(node)
+                && unary.operator == tsz_scanner::SyntaxKind::MinusToken as u16
+                && let Some(operand) = self.ctx.arena.get(unary.operand)
+            {
+                return operand.kind == tsz_scanner::SyntaxKind::NumericLiteral as u16
+                    || operand.kind == tsz_scanner::SyntaxKind::BigIntLiteral as u16;
+            }
+            return false;
+        }
+
+        // A "simple literal enum reference" — tsc's `isSimpleLiteralEnumReference`.
+        // A property access, or a string/numeric-literal element access, whose
+        // *object* is an entity-name expression and whose resulting type is an
+        // enum-member (enum-literal) type.
+        if kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+            || kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+        {
+            let Some(access) = self.ctx.arena.get_access_expr(node) else {
+                return false;
+            };
+            let object_expr = access.expression;
+            let arg_idx = access.name_or_argument;
+
+            // Element access must key off a string/numeric-literal argument
+            // (tsc's `isStringOrNumberLiteralExpression`); a computed/dynamic
+            // key is never a simple literal enum reference.
+            if kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION {
+                let Some(arg_node) = self.ctx.arena.get(arg_idx) else {
+                    return false;
+                };
+                if arg_node.kind != tsz_scanner::SyntaxKind::StringLiteral as u16
+                    && arg_node.kind != tsz_scanner::SyntaxKind::NumericLiteral as u16
+                    && arg_node.kind
+                        != tsz_scanner::SyntaxKind::NoSubstitutionTemplateLiteral as u16
+                {
+                    return false;
+                }
+            }
+
+            // The object must be an entity-name expression (identifier or a
+            // property-access chain over identifiers), so a qualified enum
+            // reference like `N.E.A` qualifies — not only a bare-identifier
+            // `E.A`.
+            if !self.is_entity_name_expression(object_expr) {
+                return false;
+            }
+
+            // Finally the whole reference must have an enum-member
+            // (enum-literal) type. This is tsc's
+            // `checkExpressionCached(expr).flags & TypeFlags.EnumLiteral`, and
+            // it is what tells a real member (`E.A`, `E["A"]`) apart from a
+            // numeric reverse-mapping index (`E[0]`, whose type is `string`)
+            // or a non-member tail (`E.A.toString`).
+            let ty = self.get_type_of_node(init_idx);
+            return crate::query_boundaries::enum_analysis::is_enum_member_for_widening(
+                &self.ctx, ty,
+            );
+        }
+
+        false
     }
 
     /// Check if a class declaration has the declare modifier (is ambient).

--- a/crates/tsz-checker/tests/ts1254_ambient_const_tests.rs
+++ b/crates/tsz-checker/tests/ts1254_ambient_const_tests.rs
@@ -45,3 +45,89 @@ fn ts1254_not_emitted_for_numeric_literal() {
         "TS1254 should NOT fire for numeric literal in ambient const, got: {codes:?}"
     );
 }
+
+// --- Simple-literal enum references (parity with tsc's `isSimpleLiteralEnumReference`) ---
+//
+// An ambient const initializer is a valid "literal enum reference" when it is a
+// property access, or a string/numeric-literal element access, whose *object*
+// is an entity-name expression AND whose resulting type is an enum-member
+// (enum-literal) type. Binder names are varied so no identifier is load-bearing.
+
+#[test]
+fn ts1254_not_emitted_for_direct_enum_member_reference() {
+    let codes = get_codes("enum Color { Red } export declare const x = Color.Red;");
+    assert!(
+        !codes.contains(&1254),
+        "a direct enum-member reference is a valid literal enum reference, got: {codes:?}"
+    );
+}
+
+#[test]
+fn ts1254_not_emitted_for_nested_namespace_enum_member_reference() {
+    // The object of the property access is a qualified name (`Palette.Shade`),
+    // not a bare identifier. tsc accepts it; tsz previously rejected it with a
+    // spurious TS1254 because it only resolved a plain-identifier object.
+    let codes = get_codes(
+        "declare namespace Palette { export enum Shade { Dark } } \
+         export declare const y = Palette.Shade.Dark;",
+    );
+    assert!(
+        !codes.contains(&1254),
+        "a nested-namespace enum-member reference is valid, got: {codes:?}"
+    );
+}
+
+#[test]
+fn ts1254_not_emitted_for_string_literal_index_enum_reference() {
+    let codes = get_codes(r#"enum Fruit { Apple } export declare const z = Fruit["Apple"];"#);
+    assert!(
+        !codes.contains(&1254),
+        "a string-literal element access resolving to an enum member is valid, got: {codes:?}"
+    );
+}
+
+#[test]
+fn ts1254_not_emitted_for_const_enum_member_reference() {
+    let codes =
+        get_codes("declare const enum Weekday { Mon } export declare const w = Weekday.Mon;");
+    assert!(
+        !codes.contains(&1254),
+        "a const-enum member reference is valid, got: {codes:?}"
+    );
+}
+
+#[test]
+fn ts1254_emitted_for_numeric_reverse_mapping_index() {
+    // `Suit[0]` is a reverse mapping whose type is `string`, not an enum
+    // literal, so tsc rejects it with TS1254 — tsz previously accepted it
+    // because the check was purely syntactic (any numeric-literal index passed).
+    let codes = get_codes("enum Suit { Hearts } export declare const q = Suit[0];");
+    assert!(
+        codes.contains(&1254),
+        "a numeric reverse-mapping index is NOT a literal enum reference, got: {codes:?}"
+    );
+}
+
+#[test]
+fn ts1254_emitted_for_non_member_tail_off_enum_member() {
+    // `Dir.North.toString` is a method reference, not an enum literal.
+    let codes = get_codes("enum Dir { North } export declare const r = Dir.North.toString;");
+    assert!(
+        codes.contains(&1254),
+        "a non-member tail off an enum member is not a literal enum reference, got: {codes:?}"
+    );
+}
+
+#[test]
+fn ts1254_emitted_for_non_enum_namespace_value_reference() {
+    // A property access whose type is a plain value (here `number`), not an
+    // enum literal, must still be rejected.
+    let codes = get_codes(
+        "declare namespace Cfg { export const flag: number; } \
+         export declare const s = Cfg.flag;",
+    );
+    assert!(
+        codes.contains(&1254),
+        "a non-enum namespace value reference is not a literal enum reference, got: {codes:?}"
+    );
+}


### PR DESCRIPTION
An ambient `const`/`readonly` initializer that references an enum is valid only
when tsc's `isSimpleLiteralEnumReference` accepts it. **When the initializer is a
property access, or a string/numeric-literal element access, whose object is an
entity-name expression *and* whose resulting type is an enum-member
(enum-literal) type, tsc treats it as a valid ambient const initializer; tsz now
does the same through the checker's `is_valid_ambient_const_initializer`** (the
shared helper behind TS1254/TS1039 for ambient variables, readonly class
properties, and namespace bodies).

Previously tsz approximated this syntactically — it resolved only a
plain-identifier object and checked the symbol's `ENUM` flag — which diverged
from tsc in two directions (both confirmed against the pinned `typescript@7.0.2`
oracle):

| source | tsc | tsz (before) | tsz (this PR) |
| --- | --- | --- | --- |
| `declare const x = N.E.A;` (nested namespace) | clean | **TS1254** (false positive) | ✅ clean |
| `declare const x = E[0];` (numeric reverse-map) | **TS1254** | clean (false negative) | ✅ TS1254 |
| `declare const x = E.A;` | clean | clean | ✅ clean |
| `declare const x = E["A"];` | clean | clean | ✅ clean |
| `declare const x = E.A.toString;` (non-member tail) | TS1254 | TS1254 | ✅ TS1254 |
| `declare const enum CE { A }` … `= CE.A;` | clean | clean | ✅ clean |
| literal / `-1` / `1n` / `true` / `1 + 1` / `null` controls | (unchanged) | (unchanged) | ✅ unchanged |

- **Nested-namespace member (`N.E.A`)** — the object `N.E` is a property access,
  not a bare identifier, so the old `resolve_identifier_symbol` check returned
  `None` and the reference was wrongly rejected. The new check gates on
  `is_entity_name_expression`, which accepts qualified names.
- **Numeric reverse-mapping index (`E[0]`)** — the old check accepted any
  numeric-literal index, but `E[0]` is a reverse mapping whose type is `string`,
  not an enum literal, so tsc rejects it. The new check requires the whole
  expression's type to be an enum-member type
  (`get_type_of_node` + `is_enum_member_for_widening`, tsz's `EnumLiteral`-flag
  equivalent), which also correctly rejects non-member tails (`E.A.toString`)
  and non-enum value references (a namespace `const`).

Owner layer: checker only. The expensive type computation is gated behind the
cheap literal/unary/entity-name syntactic checks (matching tsc's ordering) and,
at the variable-declaration site, its result is cached in `node_types` and
reused by the immediately-following inference — no double computation.

## Goal
Goal: hold

## Verification
- New/updated unit tests in
  `crates/tsz-checker/tests/ts1254_ambient_const_tests.rs` (11 tests: the 4
  existing literal cases plus 7 enum-reference cases pinning both directions,
  binder names varied so no identifier is load-bearing).
  `cargo test --release -p tsz-checker --test ts1254_ambient_const_tests`
  → 11 passed; `--test ambient_readonly_literal_initializer_tests` → 4 passed.
- `cargo clippy --release -p tsz-checker --lib` → clean.
- `cargo fmt -p tsz-checker` → clean.
- Full ambient-const matrix cross-checked against the pinned `typescript@7.0.2`
  oracle (`--noEmit --strict --pretty false --lib es2022 --target es2022
  --singleThreaded --stableTypeOrdering`): 14/14 rows match exactly, including
  the two previously-diverging rows and all literal/enum controls.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_015T9XoTGECxAJyeUb3FbWy7)_