### PR TITLE
fix(release): fail the npm publish preflight on a rejected token (#16126)

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -6,6 +6,16 @@ name: Install test
 # Triggers:
 #   - on every release publish (full validation against real assets)
 #   - on push changes to the installer or this workflow (syntax/logic check)
+#   - on pull requests touching those same files, so `static-checks` gates the
+#     change that breaks them rather than reporting after the merge. The heavy
+#     `installer-from-release` matrix stays off: its own `if:` restricts it to
+#     `release` and `workflow_dispatch`, so a PR here costs one ubuntu job.
+#
+# The path list must name every file `static-checks` actually checks. It did
+# not: the npm publish helpers and their unit suite were added by #16127 and
+# never listed, so the only run they ever got was the one that happened to
+# touch `install.sh` in the same PR. A suite that cannot fire when its subject
+# changes is not coverage.
 
 on:
   release:
@@ -17,11 +27,22 @@ on:
         required: false
         default: "latest"
         type: string
+  # Kept in sync by hand: GitHub Actions does not support YAML anchors, so the
+  # two path lists below must be edited together.
   push:
     branches: [main]
     paths:
       - "scripts/install.sh"
       - "scripts/install.ps1"
+      - "scripts/build/npm-publish-lib.sh"
+      - "scripts/build/test-npm-publish-lib.sh"
+      - ".github/workflows/install-test.yml"
+  pull_request:
+    paths:
+      - "scripts/install.sh"
+      - "scripts/install.ps1"
+      - "scripts/build/npm-publish-lib.sh"
+      - "scripts/build/test-npm-publish-lib.sh"
       - ".github/workflows/install-test.yml"
 permissions:
   contents: read

--- a/scripts/build/npm-publish-lib.sh
+++ b/scripts/build/npm-publish-lib.sh
@@ -58,12 +58,61 @@ npm_clear_placeholder_auth() {
   mv "$tmp" "$npmrc"
 }
 
+# A token can be present, well-formed, and still rejected by the registry --
+# expired, revoked, or issued to an account that no longer has write access to
+# the scope. npm answers the resulting PUT with
+#
+#   npm error 404  The requested resource '<pkg>@<version>' could not be found
+#                  or you do not have permission to access it.
+#
+# which reads as a missing package rather than a dead credential. That is the
+# shape #16126 wore for its second phase: `npm_auth_preflight` passed (the
+# secret was set), provenance signed, and only the PUT failed -- 20 minutes and
+# seven build jobs in.
+#
+# `npm whoami` is the cheapest authenticated call the registry offers, so it
+# converts that into a first-second failure that names the acting account.
+# Only meaningful on the token path: under OIDC trusted publishing there is no
+# ambient credential for `whoami` to report, and a failure there would be
+# expected rather than diagnostic.
+npm_assert_token_accepted() {
+  local out status
+  set +e
+  out="$(npm whoami --registry "$NPM_REGISTRY" 2>&1)"
+  status=$?
+  set -e
+
+  if [ "$status" -eq 0 ]; then
+    echo "npm auth: registry accepted the token as '$(printf '%s' "$out" | tr -d '[:space:]')'"
+    return 0
+  fi
+
+  {
+    echo "npm auth: NODE_AUTH_TOKEN is set but the registry rejected it."
+    echo
+    echo "  npm whoami --registry ${NPM_REGISTRY} failed (exit ${status}):"
+    printf '%s\n' "$out" | sed 's/^/    /'
+    echo
+    echo "  A present-but-rejected token is what #16126 looked like after"
+    echo "  #16127: the publish PUT is answered 404, which reads as a missing"
+    echo "  package rather than an expired credential."
+    echo
+    echo "Fix one of:"
+    echo "  * rotate NPM_TOKEN (granular token with write access to try-tsz and"
+    echo "    the @mohsen-azimi/* platform packages) and update the repo secret, or"
+    echo "  * move to OIDC trusted publishing and stop setting NODE_AUTH_TOKEN"
+    echo "    (scripts/build/setup-npm-trusted-publishers.sh)."
+  } >&2
+  return 1
+}
+
 # Fail loudly, before any package is touched, when the job has no way to
 # authenticate. Without this the first symptom is an E404 on a PUT, which reads
 # like a missing package rather than a missing credential.
 npm_auth_preflight() {
   if [ -n "${NODE_AUTH_TOKEN:-}" ]; then
     echo "npm auth: using NODE_AUTH_TOKEN"
+    npm_assert_token_accepted || return 1
     return 0
   fi
   if [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then

--- a/scripts/build/test-npm-publish-lib.sh
+++ b/scripts/build/test-npm-publish-lib.sh
@@ -52,6 +52,17 @@ case "$1" in
     echo "$PWD" >>"$NPM_STUB_PUBLISH_LOG"
     exit "${NPM_STUB_PUBLISH_STATUS:-0}"
     ;;
+  whoami)
+    # Every invocation is recorded so a test can assert the OIDC path does NOT
+    # reach for an ambient credential that trusted publishing does not have.
+    [ -n "${NPM_STUB_WHOAMI_LOG:-}" ] && echo called >>"$NPM_STUB_WHOAMI_LOG"
+    if [ "${NPM_STUB_WHOAMI_STATUS:-0}" -eq 0 ]; then
+      echo "${NPM_STUB_WHOAMI_USER:-stub-user}"
+      exit 0
+    fi
+    echo "npm error code E401 Unauthorized" >&2
+    exit 1
+    ;;
 esac
 exit 0
 STUB
@@ -116,6 +127,47 @@ check "token present -> ok" "0" "$?"
 check "oidc available -> ok" "0" "$?"
 ( unset NODE_AUTH_TOKEN; unset ACTIONS_ID_TOKEN_REQUEST_URL; npm_auth_preflight >/dev/null 2>&1 )
 check "neither -> fails" "1" "$?"
+
+# A token that is SET but REJECTED is the second phase of #16126: the preflight
+# passed on presence alone, provenance signed, and only the PUT failed -- with a
+# 404 that reads as a missing package rather than an expired credential.
+( NODE_AUTH_TOKEN=tok; export NPM_STUB_WHOAMI_STATUS=1
+  unset ACTIONS_ID_TOKEN_REQUEST_URL
+  npm_auth_preflight >/dev/null 2>&1 )
+check "token set but registry rejects it -> fails" "1" "$?"
+
+# The failure must name the real cause, not just exit non-zero: a job log that
+# says 404 sends the next reader hunting for a missing package.
+rejected_msg="$( ( NODE_AUTH_TOKEN=tok; export NPM_STUB_WHOAMI_STATUS=1
+                   unset ACTIONS_ID_TOKEN_REQUEST_URL
+                   npm_auth_preflight 2>&1 >/dev/null ) )"
+case "$rejected_msg" in
+  *"registry rejected it"*) check "rejection message names the credential" "0" "0" ;;
+  *) check "rejection message names the credential" "0" "1 (got: ${rejected_msg:0:60})" ;;
+esac
+
+# The accepted path should report WHICH account the registry sees, so a token
+# scoped to the wrong account is visible in the log without a second run.
+accepted_msg="$( ( NODE_AUTH_TOKEN=tok; export NPM_STUB_WHOAMI_USER=release-bot
+                   unset ACTIONS_ID_TOKEN_REQUEST_URL
+                   npm_auth_preflight 2>/dev/null ) )"
+case "$accepted_msg" in
+  *release-bot*) check "accepted path reports the account" "0" "0" ;;
+  *) check "accepted path reports the account" "0" "1 (got: ${accepted_msg:0:60})" ;;
+esac
+
+# Under OIDC there is no ambient credential, so probing for one would fail for a
+# reason that is not a problem. The token probe must stay on the token path.
+export NPM_STUB_WHOAMI_LOG="$tmp_root/whoami-calls"
+: >"$NPM_STUB_WHOAMI_LOG"
+( unset NODE_AUTH_TOKEN; ACTIONS_ID_TOKEN_REQUEST_URL=https://example.invalid
+  npm_auth_preflight >/dev/null 2>&1 )
+check "oidc path does not probe whoami" "0" "$(wc -l <"$NPM_STUB_WHOAMI_LOG" | tr -d ' ')"
+
+: >"$NPM_STUB_WHOAMI_LOG"
+( NODE_AUTH_TOKEN=tok; unset ACTIONS_ID_TOKEN_REQUEST_URL; npm_auth_preflight >/dev/null 2>&1 )
+check "token path does probe whoami" "1" "$(wc -l <"$NPM_STUB_WHOAMI_LOG" | tr -d ' ')"
+unset NPM_STUB_WHOAMI_LOG
 
 echo
 echo "npm_clear_placeholder_auth"


### PR DESCRIPTION
Goal: hold

## Structural rule

When `NODE_AUTH_TOKEN` is set, tsz's release lane asserts the credential is
*present* but never that the registry *accepts* it. `tsc` has no analogue here —
this is release infrastructure — so the rule is stated against npm's behaviour:
**an authenticated-but-unauthorized PUT to an existing package is answered 404,
not 403**, so a dead credential is indistinguishable from a missing package at
the point it finally fails.

## Why now

#16126 is still live. Measured today:

```
$ npm view try-tsz version
0.1.16                     # published 2026-06-04
$ grep -m1 '^version' Cargo.toml
version = "0.1.65"
```

49 version bumps have merged since the last successful publish. #16127 fixed
the *visibility* half — every run since has failed loudly rather than reporting
green — but nothing has acted on the red. Run `31253577152`, step
`Publish packages`:

```
npm auth: using NODE_AUTH_TOKEN
Publishing @mohsen-azimi/try-tsz-darwin-arm64@0.1.65
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm notice publish Provenance statement published to transparency log: .../logIndex=2383689838
npm error 404  The requested resource '@mohsen-azimi/try-tsz-darwin-arm64@0.1.65'
               could not be found or you do not have permission to access it.
```

All 7 `Build ${suffix}` jobs succeed. The secret is set, provenance signs, and
only the PUT is rejected — on a package that demonstrably exists:

```
$ npm view @mohsen-azimi/try-tsz-darwin-arm64 version
0.1.16
```

`npm-publish-lib.sh` already documents this exact signature in its own header.
The preflight simply could not see it.

## Owner layer

`scripts/build/npm-publish-lib.sh` — the same helper #16127 introduced. New
`npm_assert_token_accepted` runs `npm whoami --registry "$NPM_REGISTRY"`, the
cheapest authenticated call the registry offers, and is called only from the
`NODE_AUTH_TOKEN` branch of `npm_auth_preflight`.

**The OIDC path deliberately does not probe.** Under trusted publishing there
is no ambient credential for `whoami` to report, so a failure there would be
expected rather than diagnostic — probing both paths would turn a working
configuration red. There is a test pinning that asymmetry in both directions.

## Adjacent-case matrix

`scripts/build/test-npm-publish-lib.sh`, against the existing stub `npm`
(extended with a `whoami` verb driven by `NPM_STUB_WHOAMI_STATUS` /
`NPM_STUB_WHOAMI_USER`, and logging each call):

| case | expected |
| --- | --- |
| token set, registry accepts | preflight ok |
| **token set, registry rejects** | **preflight fails** |
| token set, rejected → message names the credential (not "404") | asserted on stderr |
| token set, accepted → message names the acting account | asserted on stdout |
| OIDC path | `whoami` **not** called |
| token path | `whoami` called exactly once |
| no token, no OIDC | preflight fails (pre-existing) |

## Verification

```
$ bash scripts/build/test-npm-publish-lib.sh
passed: 24, failed: 0                       # was 19 before this PR

$ shellcheck -S warning -x scripts/build/npm-publish-lib.sh \
                          scripts/build/test-npm-publish-lib.sh
$ echo $?
0
```

Both commands are exactly what `install-test.yml`'s `static-checks` job runs.

**Correction to an earlier version of this body**, which claimed those tests
"execute in CI on every push". They did not, and that is now the second commit
here. `install-test.yml`'s path filter listed only `scripts/install.sh`,
`scripts/install.ps1`, and the workflow itself — **neither npm publish helper
was ever in it**, so the suite #16127 added could not fire when its own subject
changed:

```
$ gh run list --workflow=install-test.yml --limit 6
2026-08-01  push  success  main     <- the run that landed #16127
2026-07-23  push  success  main
2026-07-02  push  success  main
...
```

It has run exactly once since #16127, on the push that landed it — and only
because that PR touched `install.sh` in the same commit. Every run since is
absent, not failing.

So `ci: run the npm publish helper checks when those helpers change` adds both
helper paths plus a `pull_request` trigger, so the checks gate the change
instead of reporting after the merge. The heavy matrices stay off for PRs on
their own existing conditions — `installer-from-release` is
release/`workflow_dispatch` only, `installer-syntax-only` is `push` only — so a
pull request here costs one ubuntu job. Verified by parsing the workflow:

| job | `if:` | runs on a PR? |
| --- | --- | --- |
| `static-checks` | (none) | yes |
| `installer-from-release` | `release` or `workflow_dispatch` | no |
| `installer-syntax-only` | `push` | no |

GitHub Actions does not support YAML anchors — no workflow in this repo uses
them — so the two path lists are duplicated with a comment saying they must be
edited together.

**Positive control** — reverted `npm-publish-lib.sh` to `origin/main` while
keeping the new tests, to confirm they are not vacuous:

```
  FAIL token set but registry rejects it -> fails: expected '1', got '0'
  FAIL rejection message names the credential
  FAIL accepted path reports the account
  FAIL token path does probe whoami
```

4 of the 5 new assertions go red without the fix. The 5th
(`oidc path does not probe whoami`) passes both ways by design — it guards
against a regression this PR could introduce, rather than testing new
behaviour.

## What this does NOT do

It does not fix the outage. That needs one of:

1. rotating `NPM_TOKEN` to a granular token with write access to `try-tsz` and
   `@mohsen-azimi/*`, then re-dispatching `npm-publish.yml` at the existing
   `v0.1.65` tag — no new tag needed, since `npm_publish_if_needed` skips
   versions already present; or
2. registering the trusted publisher and dropping `NODE_AUTH_TOKEN`
   (`id-token: write` is already granted and provenance already signs), which
   removes the token-expiry failure mode permanently.

Both require npm account access. This PR only ensures the next expiry is
diagnosed in seconds instead of after a full matrix build, and that the log
says "the registry rejected the token" rather than "404 not found".

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high

