### PR TITLE
ci(readme-refresh): heal today's refresh branch instead of abandoning it

### DIFF
--- a/.github/workflows/readme-benchmark-refresh.yml
+++ b/.github/workflows/readme-benchmark-refresh.yml
@@ -74,15 +74,42 @@ jobs:
 
           stamp="$(date -u +%Y%m%d)"
           branch="automation/readme-benchmark-refresh-${stamp}"
-          if git ls-remote --exit-code --heads origin "${branch}" >/dev/null 2>&1; then
-            echo "Branch ${branch} already exists on origin; today's refresh is already open."
-            exit 0
-          fi
 
+          # Build the refreshed commit first, on top of the checkout (which is
+          # at origin/main), so it exists whether we are creating today's branch
+          # or healing it.
           git checkout -b "${branch}"
           git add README.md crates/tsz-website/static/benchmark-data
           git commit -m "chore(readme): refresh benchmark image and stats"
-          git push -u origin "${branch}"
+
+          if ! git ls-remote --exit-code --heads origin "${branch}" >/dev/null 2>&1; then
+            git push -u origin "${branch}"
+          else
+            # Today's branch already exists. It was cut from whatever main was
+            # earlier today, so once README moves underneath it -- a conformance
+            # stats refresh, a manual edit -- the PR goes CONFLICTING and can
+            # never merge. Exiting here (the previous behaviour) meant a re-run
+            # regenerated the assets, detected changes, and then threw them away:
+            # the stale PR stayed stuck until the next calendar day orphaned it
+            # behind a fresh `-<tomorrow>` branch.
+            #
+            # Only heal a branch that still has an OPEN PR. If the PR merged or
+            # was closed, the branch is finished and must not be resurrected.
+            open_prs="$(gh pr list --head "${branch}" --state open --json number --jq 'length')"
+            if [ "${open_prs}" = "0" ]; then
+              echo "Branch ${branch} exists with no open PR (merged or closed); not resurrecting it."
+              exit 0
+            fi
+
+            # --force-with-lease against the tip we just observed, so a
+            # concurrent run or a human push is refused rather than clobbered.
+            git fetch origin "${branch}:refs/remotes/origin/${branch}"
+            remote_tip="$(git rev-parse "refs/remotes/origin/${branch}")"
+            echo "Healing existing branch ${branch} (was ${remote_tip}) onto current main."
+            git push --force-with-lease="${branch}:${remote_tip}" origin "${branch}"
+            echo "Updated the open refresh PR in place; not opening a second one."
+            exit 0
+          fi
 
           body=$(cat <<'EOF'
           Automated refresh of the README benchmark image and progress stats from


### PR DESCRIPTION
Goal: hold

## Structural rule

When today's dated refresh branch already exists on origin **and still has an
open PR**, the refresh must update that branch rather than discard the result.
Exiting early is correct only when the branch is finished (merged or closed).

## The failure, observed today

#17015 was cut from main at 07:50 UTC. README then moved underneath it (#17045,
#17071 both rewrite generated README blocks), so the PR went `CONFLICTING` and
can never merge.

I dispatched `readme-benchmark-refresh.yml` to regenerate it on a current base.
The run reported **success** and every step passed:

```
success  Install website deps (sharp renders the PNGs)
success  Refresh README from latest published benchmark data
success  Detect changes
success  Open refresh PR
```

It had genuinely done the work —

```
crates/tsz-website/static/benchmark-data/readme-perf-light.png updated.
crates/tsz-website/static/benchmark-data/readme-perf-dark.png updated.
README.md updated.
```

— and then threw it away:

```
Branch automation/readme-benchmark-refresh-20260809 already exists on origin;
today's refresh is already open.
```

#17015's head never moved (`cf663c0379`, last updated 12:44 UTC). A green run
that regenerates the assets, detects the change, and drops it reads as "already
current" — the same shape as #16126, where a lane reported success for work it
did not do.

Waiting does not fix it either: tomorrow's run creates `-20260810` and opens a
second PR, orphaning #17015 with its conflict intact. One stuck PR per day that
README changes.

## Owner layer

`.github/workflows/readme-benchmark-refresh.yml`, `Open refresh PR` step only.
The refreshed commit is now built first — on top of the checkout, which is at
`origin/main` — so it exists in every path. Then:

| state | action |
| --- | --- |
| branch absent | push, open PR (unchanged) |
| branch present, **PR open** | `--force-with-lease` onto current main, update the PR in place |
| branch present, no open PR (merged/closed) | do nothing — a finished branch is not resurrected |

The lease is taken against the tip observed in the same step, so a concurrent
run or a human push is refused rather than clobbered.

## Verification

`shellcheck -S warning` on the extracted step: clean. YAML parses; the step's
`if:` and `GH_TOKEN` env are unchanged.

The three control-flow paths, exercised against stub `git`/`gh` binaries (a
workflow step has no unit harness in this repo, so the branch logic is tested
directly rather than asserted):

```
=== CASE A: branch does NOT exist -> create + open PR ===
    [git push -u origin automation/readme-benchmark-refresh-20260809]
    [gh pr create --base main --head automation/readme-benchmark-refresh-20260809 ...]

=== CASE B: branch exists WITH an open PR -> heal, no second PR ===
Healing existing branch automation/readme-benchmark-refresh-20260809 (was deadbeefcafe) onto current main.
    [git push --force-with-lease=automation/readme-benchmark-refresh-20260809:deadbeefcafe origin ...]
Updated the open refresh PR in place; not opening a second one.

=== CASE C: branch exists, NO open PR (merged/closed) -> do not resurrect ===
Branch automation/readme-benchmark-refresh-20260809 exists with no open PR (merged or closed); not resurrecting it.
```

Case C is the one worth keeping: without the open-PR check, healing would
push a new commit onto a branch whose PR had already merged, creating a
zombie.

## Note for whoever lands this

#17015 stays conflicting until this merges — after which a dispatch of
`readme-benchmark-refresh.yml` will heal it in place. I did not hand-regenerate
it: the PNGs require `sharp`, which lives in `crates/tsz-website/node_modules`
and is not installed here, and `readme-perf-svg.mjs` silently emits a degraded
1457-byte chart instead of the real 7869-byte one when it is missing. The
generator's own `TSZ_README_PERF_REQUIRE_SHARP=1` guard caught that — worth
noting it did its job.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high
