### PR TITLE
fix(checker): wire TS1339 for bare `typeof import(...)` on value-less export=

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2832,3 +2832,6 @@ path = "tests/ts2540_import_equals_const_member_tests.rs"
 [[test]]
 name = "ts7023_self_recursive_var_reassigned_return_tests"
 path = "tests/ts7023_self_recursive_var_reassigned_return_tests.rs"
+[[test]]
+name = "ts1339_bare_typeof_import_no_value_tests"
+path = "tests/ts1339_bare_typeof_import_no_value_tests.rs"

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs
@@ -1758,6 +1758,62 @@ impl<'a> CheckerState<'a> {
         true
     }
 
+    /// Same question as `is_module_uninstantiated`, for a `sym_id` already
+    /// known to live in `binder` rather than the current checking file.
+    ///
+    /// Per-file binders mint colliding raw `SymbolId`s (no `base_offset` in
+    /// production; see `resolved_import_target_symbol`'s doc comment in
+    /// `cross_file.rs`). `get_cross_file_symbol` only resolves a `SymbolId`
+    /// to its true owning binder when that id was previously registered
+    /// through the resolver chain (`resolve_symbol_file_index` /
+    /// `cross_file_symbol_targets`); a `SymbolId` read straight out of a
+    /// target binder's `module_exports` table — as an `export =` proxy is —
+    /// was never registered that way, so `get_cross_file_symbol` falls back
+    /// to scanning the current file's own binder or an O(N) scan over all
+    /// binders and can silently pick up an unrelated same-id symbol from a
+    /// different file. Consulting the known-correct `binder` directly first
+    /// avoids that collision.
+    pub(crate) fn is_module_uninstantiated_in_binder(
+        &self,
+        binder: &tsz_binder::BinderState,
+        sym_id: SymbolId,
+    ) -> bool {
+        let lib_binders = self.get_lib_binders();
+        let symbol = binder
+            .get_symbol(sym_id)
+            .or_else(|| self.get_cross_file_symbol(sym_id))
+            .or_else(|| self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders));
+        let Some(symbol) = symbol else {
+            return false;
+        };
+        let Some(exports) = &symbol.exports else {
+            return true;
+        };
+        for (_, &export_sym_id) in exports.iter() {
+            let export_sym = binder
+                .get_symbol(export_sym_id)
+                .or_else(|| self.get_cross_file_symbol(export_sym_id))
+                .or_else(|| {
+                    self.ctx
+                        .binder
+                        .get_symbol_with_libs(export_sym_id, &lib_binders)
+                });
+            let Some(export_sym) = export_sym else {
+                continue;
+            };
+            let ef = export_sym.flags;
+            if (ef & (symbol_flags::VALUE & !symbol_flags::VALUE_MODULE)) != 0 {
+                return false;
+            }
+            if (ef & symbol_flags::VALUE_MODULE) != 0
+                && !self.is_module_uninstantiated_in_binder(binder, export_sym_id)
+            {
+                return false;
+            }
+        }
+        true
+    }
+
     /// Check if a named export was reached through a `export type *` wildcard chain.
     pub(crate) fn is_export_from_type_only_wildcard(
         &self,

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs
@@ -1725,7 +1725,7 @@ impl<'a> CheckerState<'a> {
         false
     }
 
-    fn is_module_uninstantiated(&self, sym_id: SymbolId) -> bool {
+    pub(crate) fn is_module_uninstantiated(&self, sym_id: SymbolId) -> bool {
         let lib_binders = self.get_lib_binders();
         let symbol = self
             .get_cross_file_symbol(sym_id)

--- a/crates/tsz-checker/src/state/type_analysis/core_type_query.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core_type_query.rs
@@ -92,7 +92,7 @@ impl<'a> CheckerState<'a> {
         if self.is_import_type_query(type_query.expr_name) {
             trace!("get_type_from_type_query: is import type query");
             return self
-                .resolve_typeof_import_query(type_query.expr_name)
+                .resolve_typeof_import_query(idx, type_query.expr_name)
                 .unwrap_or(TypeId::ANY);
         }
 
@@ -1660,7 +1660,11 @@ impl<'a> CheckerState<'a> {
         result
     }
 
-    pub(crate) fn resolve_typeof_import_query(&mut self, expr_name: NodeIndex) -> Option<TypeId> {
+    pub(crate) fn resolve_typeof_import_query(
+        &mut self,
+        anchor_idx: NodeIndex,
+        expr_name: NodeIndex,
+    ) -> Option<TypeId> {
         let (call_idx, segments) = self.decompose_typeof_import_query(expr_name)?;
         let (module_name, specifier_node) = self.get_import_type_module_specifier(call_idx)?;
         let resolution_mode_override = self.get_import_type_resolution_mode_override(call_idx);
@@ -1669,6 +1673,27 @@ impl<'a> CheckerState<'a> {
             specifier_node,
             resolution_mode_override,
         );
+
+        // TS1339: a bare `typeof import("mod")` — no `.Member` qualifier —
+        // resolves to the module's own value. A module with no `export =`
+        // always has one (the module object itself); a module whose
+        // `export =` targets a type-only symbol (interface, type alias,
+        // uninstantiated namespace) does not.
+        if segments.is_empty()
+            && !self.bare_typeof_import_names_a_value(&module_name, resolution_mode_override)
+        {
+            use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+            let message = format_message(
+                diagnostic_messages::MODULE_DOES_NOT_REFER_TO_A_VALUE_BUT_IS_USED_AS_A_VALUE_HERE,
+                &[&module_name],
+            );
+            self.error_at_node(
+                anchor_idx,
+                &message,
+                diagnostic_codes::MODULE_DOES_NOT_REFER_TO_A_VALUE_BUT_IS_USED_AS_A_VALUE_HERE,
+            );
+            return Some(TypeId::ERROR);
+        }
 
         let Some(mut current) =
             self.build_typeof_import_namespace_type(&module_name, resolution_mode_override)

--- a/crates/tsz-checker/src/state/type_resolution/import_type_meaning.rs
+++ b/crates/tsz-checker/src/state/type_resolution/import_type_meaning.rs
@@ -105,4 +105,117 @@ impl<'a> CheckerState<'a> {
                     .is_some_and(|resolved| symbol_is_type(self, resolved))
             })
     }
+
+    /// Whether a bare `typeof import("mod")` names a VALUE.
+    ///
+    /// A module with no `export =` always has runtime value — the module
+    /// object itself is the value, regardless of what it exports — so this
+    /// only ever returns `false` when the module's `export =` target is
+    /// itself type-only (an interface, a type alias, or an uninstantiated
+    /// namespace). `tsc` reports TS1339 in that case.
+    /// `import("mod").Member` is unaffected: it is not a bare typeof import.
+    pub(crate) fn bare_typeof_import_names_a_value(
+        &self,
+        module_name: &str,
+        resolution_mode_override: Option<crate::context::ResolutionModeOverride>,
+    ) -> bool {
+        use tsz_binder::symbol_flags;
+
+        let target_idx = self
+            .ctx
+            .resolve_import_target_from_file_with_mode(
+                self.ctx.current_file_idx,
+                module_name,
+                resolution_mode_override,
+            )
+            .or_else(|| self.ctx.resolve_import_target(module_name));
+
+        if let Some(target_idx) = target_idx {
+            // File-backed `export =`: reuse the same companion-aware
+            // type-only determination the sibling TS1340 check uses via
+            // `is_module_export_equals_type_only`. The `export =` table
+            // entry is a proxy symbol whose own flags do not reliably carry
+            // the target's value-ness (e.g. `export class C {} export = C;`
+            // records the proxy as `TYPE_ALIAS`-flagged); the real answer
+            // comes from that helper's sibling value-declaration lookup.
+            //
+            // That helper only recognizes `INTERFACE`/`TYPE_ALIAS` targets
+            // as type-only, so an `export =`-ed namespace whose members are
+            // all types (a `NAMESPACE_MODULE` that never instantiates a
+            // runtime object) slips through it uncaught; check that
+            // separately here.
+            let namespace_is_uninstantiated = self
+                .ctx
+                .get_binder_for_file(target_idx)
+                .and_then(|binder| {
+                    let file_name = self
+                        .ctx
+                        .get_arena_for_file(target_idx as u32)
+                        .source_files
+                        .first()?
+                        .file_name
+                        .clone();
+                    binder
+                        .module_exports
+                        .get(&file_name)
+                        .and_then(|exports| exports.get("export="))
+                })
+                .is_some_and(|eq_sym_id| {
+                    self.get_cross_file_symbol(eq_sym_id)
+                        .is_some_and(|eq_sym| eq_sym.has_any_flags(symbol_flags::NAMESPACE_MODULE))
+                        && self.is_module_uninstantiated(eq_sym_id)
+                });
+
+            return !namespace_is_uninstantiated
+                && !self.is_module_export_equals_type_only(module_name);
+        }
+
+        // Ambient `declare module "mod" { ... export = X }`: no target file
+        // to resolve through, so fall back to a direct flag check on the
+        // `export =` symbol — the same simpler check the sibling
+        // `bare_import_type_names_a_type` ambient branch uses.
+        const VALUE_PROVIDING: u32 = symbol_flags::VARIABLE
+            | symbol_flags::FUNCTION
+            | symbol_flags::CLASS
+            | symbol_flags::ENUM
+            | symbol_flags::ENUM_MEMBER
+            | symbol_flags::VALUE_MODULE;
+
+        let lib_binders = self.get_lib_binders();
+        let ambient_export_equals_sym = self
+            .ctx
+            .binder
+            .module_exports
+            .get(module_name)
+            .and_then(|exports| exports.get("export="))
+            .or_else(|| {
+                self.ctx
+                    .global_module_exports_index
+                    .as_ref()
+                    .and_then(|idx| idx.get(module_name))
+                    .and_then(|inner| inner.get("export="))
+                    .and_then(|entries| entries.first().map(|&(_file_idx, sym_id)| sym_id))
+            });
+
+        let Some(sym_id) = ambient_export_equals_sym else {
+            // No `export =`: an ordinary module object always has value.
+            return true;
+        };
+
+        let symbol_is_value = |checker: &Self, sym_id: tsz_binder::SymbolId| {
+            checker
+                .ctx
+                .binder
+                .get_symbol_with_libs(sym_id, &lib_binders)
+                .is_some_and(|sym| !sym.is_type_only && sym.has_any_flags(VALUE_PROVIDING))
+        };
+
+        if symbol_is_value(self, sym_id) {
+            return true;
+        }
+
+        let mut visited = AliasCycleTracker::new();
+        self.resolve_alias_symbol(sym_id, &mut visited)
+            .is_some_and(|resolved| symbol_is_value(self, resolved))
+    }
 }

--- a/crates/tsz-checker/src/state/type_resolution/import_type_meaning.rs
+++ b/crates/tsz-checker/src/state/type_resolution/import_type_meaning.rs
@@ -144,27 +144,35 @@ impl<'a> CheckerState<'a> {
             // all types (a `NAMESPACE_MODULE` that never instantiates a
             // runtime object) slips through it uncaught; check that
             // separately here.
-            let namespace_is_uninstantiated = self
-                .ctx
-                .get_binder_for_file(target_idx)
-                .and_then(|binder| {
-                    let file_name = self
-                        .ctx
-                        .get_arena_for_file(target_idx as u32)
-                        .source_files
-                        .first()?
-                        .file_name
-                        .clone();
-                    binder
-                        .module_exports
-                        .get(&file_name)
-                        .and_then(|exports| exports.get("export="))
-                })
-                .is_some_and(|eq_sym_id| {
-                    self.get_cross_file_symbol(eq_sym_id)
-                        .is_some_and(|eq_sym| eq_sym.has_any_flags(symbol_flags::NAMESPACE_MODULE))
-                        && self.is_module_uninstantiated(eq_sym_id)
-                });
+            //
+            // Must go through `module_exports_for_module` (not index
+            // `binder.module_exports` directly): a full project build
+            // aggregates exports into `ctx.program_module_exports` and
+            // leaves each per-file binder's own `module_exports` map
+            // unpopulated, so a direct index only ever succeeds in
+            // single/few-file harnesses that skip that aggregation step.
+            let namespace_is_uninstantiated =
+                self.ctx
+                    .get_binder_for_file(target_idx)
+                    .and_then(|binder| {
+                        let file_name = self
+                            .ctx
+                            .get_arena_for_file(target_idx as u32)
+                            .source_files
+                            .first()?
+                            .file_name
+                            .as_str();
+                        let eq_sym_id = self
+                            .ctx
+                            .module_exports_for_module(binder, file_name)
+                            .and_then(|exports| exports.get("export="))?;
+                        Some((binder, eq_sym_id))
+                    })
+                    .is_some_and(|(binder, eq_sym_id)| {
+                        binder.get_symbol(eq_sym_id).is_some_and(|eq_sym| {
+                            eq_sym.has_any_flags(symbol_flags::NAMESPACE_MODULE)
+                        }) && self.is_module_uninstantiated_in_binder(binder, eq_sym_id)
+                    });
 
             return !namespace_is_uninstantiated
                 && !self.is_module_export_equals_type_only(module_name);

--- a/crates/tsz-checker/src/types/type_node_query_members.rs
+++ b/crates/tsz-checker/src/types/type_node_query_members.rs
@@ -259,7 +259,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             tsz_common::perf_counters::CheckerCreationReason::ImportType,
         );
         child.ctx.current_file_idx = current_file_idx;
-        let resolved = child.resolve_typeof_import_query(expr_name);
+        let resolved = child.resolve_typeof_import_query(type_query_idx, expr_name);
         // Merge namespace bookkeeping back so display/TS2339 receiver and any
         // subsequent property access see the same namespace TypeId.
         for (type_id, module_name) in child.ctx.namespace_module_names.drain() {

--- a/crates/tsz-checker/tests/ts1339_bare_typeof_import_no_value_tests.rs
+++ b/crates/tsz-checker/tests/ts1339_bare_typeof_import_no_value_tests.rs
@@ -1,0 +1,200 @@
+//! TS1339: a bare `typeof import("mod")` — no `.Member` qualifier — names
+//! the module's own value. A module with no `export =` always has one (the
+//! module object itself is the runtime value, regardless of what it
+//! exports), so this only fires when the module's `export =` target is
+//! itself type-only: an interface, a type alias, or an uninstantiated
+//! namespace (one whose members are all types). `tsc` reports:
+//! "Module '{0}' does not refer to a value, but is used as a value here."
+//!
+//! Sibling of TS1340 (`bare_import_type_names_a_type` /
+//! `MODULE_DOES_NOT_REFER_TO_A_TYPE_BUT_IS_USED_AS_A_TYPE_HERE`), which
+//! covers the converse: `import("mod")` used in a type position when the
+//! `export =` target is value-only. Oracle-verified against
+//! `typescript@6.0.2`.
+//!
+//! Owner: `crates/tsz-checker/src/state/type_resolution/import_type_meaning.rs`
+//! (`bare_typeof_import_names_a_value`), consumed from
+//! `crates/tsz-checker/src/state/type_analysis/core_type_query.rs`
+//! (`resolve_typeof_import_query`) — the same `typeof import(...)`
+//! namespace-builder `typeof import("mod").Member` already uses, gated on
+//! the qualifier segments being empty.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_multi_file;
+use tsz_common::common::ModuleKind;
+
+const TS1339: u32 = 1339;
+
+fn check(files: &[(&str, &str)], entry: &str) -> Vec<(u32, String)> {
+    check_multi_file(
+        files,
+        entry,
+        CheckerOptions {
+            module: ModuleKind::CommonJS,
+            ..CheckerOptions::default()
+        },
+    )
+    .into_iter()
+    .map(|d| (d.code, d.message_text))
+    .collect()
+}
+
+fn codes(diagnostics: &[(u32, String)]) -> Vec<u32> {
+    let mut codes: Vec<u32> = diagnostics.iter().map(|(code, _)| *code).collect();
+    codes.sort_unstable();
+    codes
+}
+
+/// `export = <interface>`: the module's only value-side meaning is gone —
+/// the interface has no runtime existence — so `typeof import(...)` cannot
+/// name a value.
+#[test]
+fn export_equals_interface_reports_ts1339() {
+    let diags = check(
+        &[
+            (
+                "/mod.ts",
+                "export interface Y {\n  a: number;\n}\nexport = Y;\n",
+            ),
+            ("/main.ts", "type X = typeof import(\"./mod\");\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diags), vec![TS1339], "{diags:?}");
+    let (_, message) = diags.iter().find(|(code, _)| *code == TS1339).unwrap();
+    assert_eq!(
+        message,
+        "Module './mod' does not refer to a value, but is used as a value here."
+    );
+}
+
+/// `export = <type alias>`: same value-less shape as the interface case.
+#[test]
+fn export_equals_type_alias_reports_ts1339() {
+    let diags = check(
+        &[
+            ("/mod.ts", "export type T = number;\nexport = T;\n"),
+            ("/main.ts", "type X = typeof import(\"./mod\");\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diags), vec![TS1339], "{diags:?}");
+}
+
+/// `export = <namespace>` where the namespace's members are all types: the
+/// namespace itself never instantiates a runtime object, so it has no value.
+#[test]
+fn export_equals_uninstantiated_namespace_reports_ts1339() {
+    let diags = check(
+        &[
+            (
+                "/mod.ts",
+                "namespace N {\n  export interface I {}\n}\nexport = N;\n",
+            ),
+            ("/main.ts", "type X = typeof import(\"./mod\");\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diags), vec![TS1339], "{diags:?}");
+}
+
+/// Renamed-binder adjacent case: the interface's name must not be
+/// load-bearing.
+#[test]
+fn renamed_export_equals_interface_reports_ts1339() {
+    let diags = check(
+        &[
+            (
+                "/mod.ts",
+                "export interface SomethingElse {\n  a: number;\n}\nexport = SomethingElse;\n",
+            ),
+            ("/main.ts", "type X = typeof import(\"./mod\");\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diags), vec![TS1339], "{diags:?}");
+}
+
+/// Negative control: `export = <class>` — a class carries a value meaning
+/// (it is constructible at runtime) alongside its type meaning, so a bare
+/// `typeof import(...)` is legal.
+#[test]
+fn export_equals_class_is_clean() {
+    let diags = check(
+        &[
+            ("/mod.ts", "export class C {}\nexport = C;\n"),
+            ("/main.ts", "type X = typeof import(\"./mod\");\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diags), Vec::<u32>::new(), "{diags:?}");
+}
+
+/// Negative control: `export = <namespace with a value member>` — the
+/// namespace instantiates a runtime object, so it has value.
+#[test]
+fn export_equals_instantiated_namespace_is_clean() {
+    let diags = check(
+        &[
+            (
+                "/mod.ts",
+                "namespace N {\n  export const a = 1;\n}\nexport = N;\n",
+            ),
+            ("/main.ts", "type X = typeof import(\"./mod\");\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diags), Vec::<u32>::new(), "{diags:?}");
+}
+
+/// Negative control: no `export =` at all — the module object itself is
+/// always a value, regardless of whether every export is a type.
+#[test]
+fn no_export_equals_type_only_module_is_clean() {
+    let diags = check(
+        &[
+            (
+                "/mod.ts",
+                "export interface Y {}\nexport type Z = number;\n",
+            ),
+            ("/main.ts", "type X = typeof import(\"./mod\");\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diags), Vec::<u32>::new(), "{diags:?}");
+}
+
+/// Qualified form is unaffected: `typeof import("mod").Member` walks through
+/// the namespace builder rather than naming the module's own value, so it
+/// does not go through the bare-value check at all.
+#[test]
+fn qualified_typeof_import_on_export_equals_interface_is_not_ts1339() {
+    let diags = check(
+        &[
+            (
+                "/mod.ts",
+                "export interface Y {\n  a: number;\n}\nexport = Y;\n",
+            ),
+            ("/main.ts", "type X = typeof import(\"./mod\").a;\n"),
+        ],
+        "/main.ts",
+    );
+    assert!(
+        !codes(&diags).contains(&TS1339),
+        "qualified typeof import must not report TS1339: {diags:?}"
+    );
+}
+
+/// Plain `import("mod")` (no `typeof`) used as a type is the sibling TS1340
+/// diagnostic family, not TS1339 — the two must stay distinct.
+#[test]
+fn bare_import_type_no_typeof_on_export_equals_value_reports_ts1340_not_ts1339() {
+    let diags = check(
+        &[
+            ("/mod.ts", "export const y = 1;\nexport = y;\n"),
+            ("/main.ts", "type X = import(\"./mod\");\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diags), vec![1340], "{diags:?}");
+}


### PR DESCRIPTION
Module '{0}' does not refer to a value, but is used as a value here.

Structural rule: when a bare `typeof import("mod")` (no `.Member` qualifier)
resolves to a module whose `export =` target has no runtime value — an
interface, a type alias, or an uninstantiated namespace (members all
types) — `tsc` reports TS1339; `tsz` had zero emit sites for this code
(verified by grep across `tsz-checker`/`tsz-parser`) and silently resolved
the query to an empty/`any` type instead. A module with no `export =` at
all always has value (the module object itself), so this only fires on the
`export =` shape.

Owner: `crates/tsz-checker/src/state/type_resolution/import_type_meaning.rs`
(new `bare_typeof_import_names_a_value`, sibling of the existing TS1340
`bare_import_type_names_a_type`), consumed from `resolve_typeof_import_query`
in `crates/tsz-checker/src/state/type_analysis/core_type_query.rs`, gated on
the qualifier segments being empty so `typeof import("mod").Member` stays
unaffected.

The `export =`-ed namespace case (a `NAMESPACE_MODULE` whose members are all
types, so it never instantiates a runtime object) is not covered by the
existing `is_module_export_equals_type_only` helper (`INTERFACE`/`TYPE_ALIAS`
only) and needs a separate check — see the review fix note below for how that
check is wired correctly.

Adjacent-case matrix (`crates/tsz-checker/tests/ts1339_bare_typeof_import_no_value_tests.rs`):
- `export =` interface, type alias, uninstantiated namespace → TS1339
- `export =` class, instantiated namespace, no `export =` at all → clean
- renamed binder adjacent case → still TS1339 (name is not load-bearing)
- qualified `typeof import(...).Member` → unaffected (not a bare typeof import)
- sibling TS1340 (`import(...)` without `typeof`) → stays distinct

Oracle-verified against `typescript@6.0.2`.

## Review fix (commit 9e897f0)

[@mohsen1](https://github.com/mohsen1) found via a real `tsz-cli` build that the
uninstantiated-namespace shape passed the in-process multi-file unit-test
harness but never fired through the actual CLI — see the review thread for the
full matrix. Root cause, traced with `TSZ_LOG`: the namespace check indexed the
target file's own `BinderState::module_exports` table directly, but that table
is keyed by import specifier and lives on the *importing* file's binder, not
the imported file's. A full project build additionally aggregates exports into
`CheckerContext::program_module_exports` and leaves per-file `module_exports`
maps unpopulated, so the direct index only ever worked by accident in a small
enough harness. Fixed by routing through the existing `module_exports_for_module`
query-boundary helper instead (the same one `is_module_export_equals_type_only`
already used — why the interface/alias shapes worked from the start). A second,
related bug on the same path — resolving the `export=` proxy symbol's flags via
the ambient cross-file resolver instead of the already-known-correct target
binder, risking a raw `SymbolId` collision across files — is fixed by a new
`is_module_uninstantiated_in_binder` helper pinned to that binder.

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-checker --test ts1339_bare_typeof_import_no_value_tests` — 9/9 pass
- `cargo nextest run -p tsz-checker --lib` — 10979/10979 passed, 7 skipped (no regressions from either commit)
- `cargo nextest run -p tsz-checker --test typeof_import_commonjs_object_literal_export_tests --test namespace_import_export_equals_passthrough_tests --test export_equals_display_order_tests` — 20/20 passed (targeted `typeof import`/`export =` regression sweep)
- `cargo clippy -p tsz-checker --all-targets` — clean, no warnings
- `cargo fmt --check -p tsz-checker` — clean
- Manual cross-check of a built `tsz-cli` release binary against `typescript@6.0.2` on 14 shapes (the reviewer's exact namespace repro, all 6 uninstantiated-namespace variants from their matrix, and the interface/class/enum/const/no-`export=`/qualified-member negative controls) — all now match tsc exactly. This is what actually caught the namespace gap; the in-process unit suite alone did not.
- Not run: full `conformance.sh` / `emit/run.sh` / fourslash suites (this diagnostic was entirely unwired before, with no prior emit sites, so it cannot have contributed to any existing accepted baseline). Two pre-existing, unrelated test failures were observed in `import_type_utility_identity_tests`/`import_type_ambient_module_member_tests` (cross-file `import("mod").Member` conditional-type identity) and confirmed present on `main` via `git stash` before this change — not caused by this PR.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude