### PR TITLE
fix(config): report TS18051 for an empty extends specifier instead of TS6053

### DIFF
--- a/crates/tsz-core/src/config/mod.rs
+++ b/crates/tsz-core/src/config/mod.rs
@@ -1518,6 +1518,27 @@ fn load_tsconfig_inner_with_diagnostics(
             // recoverable error: tsc emits TS6053 anchored at the specifier and
             // continues with the remaining (local) options. Emit the same and
             // skip this base instead of failing the whole config load.
+            //
+            // A bare `""` is a distinct diagnosis (`getExtendsConfigPathOrArray`
+            // in `commandLineParser.ts`): every resolution strategy (relative,
+            // absolute, package) is a no-op on an empty specifier, so `tsc`
+            // short-circuits to TS18051 (`Compiler option 'extends' cannot be
+            // given an empty string.`) instead of TS6053's `File '' not found.`.
+            if extends_path_str.is_empty() {
+                let (start, length) = find_extends_specifier_span(&stripped, extends_path_str);
+                let message = format_message(
+                    diagnostic_messages::COMPILER_OPTION_CANNOT_BE_GIVEN_AN_EMPTY_STRING,
+                    &["extends"],
+                );
+                parsed.diagnostics.push(Diagnostic::error(
+                    &file_display,
+                    start,
+                    length,
+                    message,
+                    diagnostic_codes::COMPILER_OPTION_CANNOT_BE_GIVEN_AN_EMPTY_STRING,
+                ));
+                continue;
+            }
             let Some(base_path) = resolve_extends_path(path, extends_path_str)? else {
                 let (start, length) = find_extends_specifier_span(&stripped, extends_path_str);
                 let message =

--- a/crates/tsz-core/src/config/tests/extends_empty_specifier.rs
+++ b/crates/tsz-core/src/config/tests/extends_empty_specifier.rs
@@ -1,0 +1,101 @@
+//! `extends: ""` diagnosis (TS18051).
+//!
+//! Split out of `module_resolution.rs` to keep it under the 2000-line limit
+//! (§19; ratchet tracked by #8280) rather than growing an already-large file.
+
+use super::super::*;
+use tempfile::tempdir;
+
+#[test]
+fn extends_empty_string_reports_ts18051_not_ts6053() {
+    // `tsc`'s `getExtendsConfigPathOrArray` (`commandLineParser.ts`) checks
+    // `extendedConfig === ""` only after every resolution strategy (relative,
+    // absolute, package/node_modules) has already failed on the empty
+    // specifier, and reports TS18051 there instead of the generic TS6053
+    // "File '' not found." every other unresolved specifier gets.
+    let temp = tempdir().expect("create temp dir");
+    let project = temp.path().join("project");
+    std::fs::create_dir_all(&project).expect("create project dir");
+    let child_path = project.join("tsconfig.json");
+    let child_source = r#"{ "extends": "", "compilerOptions": { "strict": true } }"#;
+    std::fs::write(&child_path, child_source).expect("write child");
+
+    let parsed = load_tsconfig_with_diagnostics(&child_path).expect("load must succeed");
+
+    assert!(
+        !parsed.diagnostics.iter().any(|d| d.code == 6053),
+        "an empty extends must not report the generic TS6053, got: {:?}",
+        parsed.diagnostics
+    );
+    let ts18051: Vec<&Diagnostic> = parsed
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 18051)
+        .collect();
+    assert_eq!(
+        ts18051.len(),
+        1,
+        "exactly one TS18051 for the empty extends: {:?}",
+        parsed.diagnostics
+    );
+    assert!(
+        ts18051[0].message_text.contains("'extends'"),
+        "TS18051 names the 'extends' option: {}",
+        ts18051[0].message_text
+    );
+    let expected_start = child_source.find("\"\"").expect("empty literal present") as u32;
+    assert_eq!(
+        ts18051[0].start, expected_start,
+        "TS18051 anchors at the empty extends literal"
+    );
+
+    let opts = parsed
+        .config
+        .compiler_options
+        .expect("local options retained");
+    assert_eq!(
+        opts.strict,
+        Some(true),
+        "local options survive an empty extends"
+    );
+}
+
+#[test]
+fn extends_array_with_one_empty_entry_reports_ts18051_for_that_entry_only() {
+    // An empty entry inside an array `extends` gets its own TS18051; sibling
+    // entries resolve/report independently (mirrors the unresolved-entry
+    // array coverage in `module_resolution.rs`).
+    let temp = tempdir().expect("create temp dir");
+    let project = temp.path().join("project");
+    std::fs::create_dir_all(&project).expect("create project dir");
+    std::fs::write(
+        project.join("present.json"),
+        r#"{ "compilerOptions": { "target": "ES2021" } }"#,
+    )
+    .expect("write present base");
+    let child_path = project.join("tsconfig.json");
+    std::fs::write(&child_path, r#"{ "extends": ["./present.json", ""] }"#).expect("write child");
+
+    let parsed = load_tsconfig_with_diagnostics(&child_path).expect("load must succeed");
+    assert!(
+        !parsed.diagnostics.iter().any(|d| d.code == 6053),
+        "the empty array entry must not report TS6053, got: {:?}",
+        parsed.diagnostics
+    );
+    assert_eq!(
+        parsed
+            .diagnostics
+            .iter()
+            .filter(|d| d.code == 18051)
+            .count(),
+        1,
+        "one TS18051 for the empty array entry: {:?}",
+        parsed.diagnostics
+    );
+    let opts = parsed.config.compiler_options.expect("present base merged");
+    assert_eq!(
+        opts.target.as_deref(),
+        Some("ES2021"),
+        "the resolvable array entry is still applied alongside the empty one"
+    );
+}

--- a/crates/tsz-core/src/config/tests/mod.rs
+++ b/crates/tsz-core/src/config/tests/mod.rs
@@ -5,6 +5,7 @@
 //! contains no test logic itself; it only wires up the shards.
 
 mod extends_cycle_and_jsx_factory_values;
+mod extends_empty_specifier;
 mod files_list_empty;
 mod module_resolution;
 mod options_parsing;


### PR DESCRIPTION
`tsc`'s `getExtendsConfigPathOrArray` (`commandLineParser.ts`) special-cases a literal empty-string `extends` specifier: every resolution strategy (relative, absolute, package/`node_modules`) is a no-op on `""`, so after they all fail it short-circuits to TS18051 (`Compiler option 'extends' cannot be given an empty string.`) instead of the generic TS6053 (`File '{0}' not found.`) every other unresolved specifier gets. tsz's `load_tsconfig_inner_with_diagnostics` (`crates/tsz-core/src/config/mod.rs`) treated `""` the same as any other unresolved specifier, reporting `File '' not found.` (TS6053) instead.

**Structural rule:** when a tsconfig's `extends` specifier is the literal empty string, `tsc` reports TS18051 (naming the `extends` option) rather than TS6053 (naming the unresolved file); tsz now does the same through the same config-loader diagnostic site that already emits TS6053 for every other unresolved `extends` entry, short-circuiting before the (pointless) resolution attempt.

TS18051 previously had a diagnostics-table entry (code + message) but zero emit sites — one of the 88 diagnostic codes tracked as unwired in #16291.

Owner layer: `tsz-core` config loader (`load_tsconfig_inner_with_diagnostics`), the same site/pattern as the existing TS6053 handling and the existing TS18002 (`files: []`) diagnosis in the same file.

Adjacent-case matrix (oracle-verified against pinned `typescript@7.0.2`):
- bare `{"extends": ""}` at the entry config → TS18051, not TS6053, local `compilerOptions` still applied.
- array `extends` with one empty entry alongside a resolvable sibling (`["./present.json", ""]`) → the resolvable entry still merges, the empty entry gets its own TS18051, no TS6053.
- (unchanged, already covered by existing tests) a non-empty unresolved specifier still reports TS6053; a resolvable specifier reports neither.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-core --lib` — `config::tests::extends_empty_specifier::extends_empty_string_reports_ts18051_not_ts6053` and `...extends_array_with_one_empty_entry_reports_ts18051_for_that_entry_only` both pass; full `config::` module 286/286 pass (was 284/284 on `main`, +2 new).
- `cargo clippy -p tsz-core --lib -- -D warnings` — clean.
- `cargo fmt --check -p tsz-core` — clean.
- `python3 scripts/arch/arch_guard.py` — passes. `module_resolution.rs` was already at its exact size-ratchet limit (2016/2016), so the two new tests live in a new `extends_empty_specifier.rs` shard instead of growing it.
- Change is confined to `crates/tsz-core/src/config` (no `crates/tsz-checker` or `crates/tsz-emitter` path touched), test-file-diff-dominant; conformance/emit/fourslash cannot move and were not run (TypeScript submodule/corpus not checked out this session).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_015ihKCGvhYpT8KppH4hwpBW)_