### PR TITLE
fix(checker): top-level ambient declare const/let/var drops TS1039

### DIFF
--- a/crates/tsz-checker/src/state/variable_checking/initializer_policy.rs
+++ b/crates/tsz-checker/src/state/variable_checking/initializer_policy.rs
@@ -301,6 +301,16 @@ impl<'a> CheckerState<'a> {
                     self.ctx.diagnostics.retain(|diag| {
                         diag.code
                             == crate::diagnostics::diagnostic_codes::STATIC_MEMBERS_CANNOT_REFERENCE_CLASS_TYPE_PARAMETERS
+                            // TS1039: an ambient declaration's "initializers are
+                            // not allowed" grammar check is anchored at the
+                            // initializer node (same span this retain otherwise
+                            // clears), but it is a structural check that ran
+                            // once before the contextual re-evaluation below —
+                            // not a stale artifact of the pre-contextual type
+                            // computation. It must survive the reset the same
+                            // way the other structural checks below do.
+                            || diag.code
+                                == crate::diagnostics::diagnostic_codes::INITIALIZERS_ARE_NOT_ALLOWED_IN_AMBIENT_CONTEXTS
                             // TS2693/TS2585/TS1361/TS1362: type-only keywords and
                             // type-only import/export used as values are structural
                             // errors, not contextual-typing artifacts.

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -29,6 +29,8 @@ mod ambient_declare_async_modifier_tests;
 mod ambient_declare_async_static_modifier_tests;
 #[path = "tests/ambient_declare_override_modifier_tests.rs"]
 mod ambient_declare_override_modifier_tests;
+#[path = "tests/ambient_top_level_initializer_ts1039_tests.rs"]
+mod ambient_top_level_initializer_ts1039_tests;
 #[path = "tests/any_parameter_never_opposite_tests.rs"]
 mod any_parameter_never_opposite_tests;
 #[path = "tests/application_arg_concrete_index_access_display_tests.rs"]

--- a/crates/tsz-checker/src/tests/ambient_top_level_initializer_ts1039_tests.rs
+++ b/crates/tsz-checker/src/tests/ambient_top_level_initializer_ts1039_tests.rs
@@ -1,0 +1,206 @@
+//! A top-level ambient variable declaration (`declare const/let/var x: T = v`,
+//! or a non-`const` `let`/`var` with any initializer) drops TS1039
+//! (`Initializers are not allowed in ambient contexts.`) — see #17073.
+//!
+//! Structural rule: `tsc`'s ambient-initializer grammar check fires whenever
+//! an ambient variable declaration carries both a type annotation and an
+//! initializer (or is a non-`const` `let`/`var` with any initializer). tsz's
+//! checker computes and emits this diagnostic correctly (confirmed via a
+//! direct probe reaching `error_at_node` at `state/variable_checking/core.rs`)
+//! but it never reached output at the top level: the initializer's
+//! contextual-typing "pre-contextual diagnostic reset" in
+//! `state/variable_checking/initializer_policy.rs` unconditionally clears
+//! every diagnostic anchored inside the initializer's own span before
+//! re-evaluating the initializer with its contextual type, and TS1039 is
+//! anchored at that same initializer node. That reset path only runs when a
+//! type annotation is present (`has_type_annotation` gates the whole block),
+//! which is exactly why the *no-annotation* sibling case (TS1254) was never
+//! affected, and why the namespace-nested / class-property paths (which
+//! route through a different check, `check_initializers_in_ambient_body`,
+//! never through this contextual-typing reset) were already correct.
+//!
+//! Fixed by adding TS1039 to the reset's structural-diagnostic allow-list,
+//! alongside the other position-anchored-in-initializer checks (TS2693,
+//! TS2454, TS2348, TS2538, TS2339, TS2304, ...) that already survive it for
+//! the same reason: they are not artifacts of the pre-contextual type
+//! computation.
+
+use crate::context::CheckerOptions;
+use crate::diagnostics::Diagnostic;
+use crate::query_boundaries::common::TypeInterner;
+use crate::state::CheckerState;
+use tsz_binder::BinderState;
+use tsz_parser::parser::ParserState;
+
+const INITIALIZERS_NOT_ALLOWED_IN_AMBIENT: u32 = 1039;
+const CONST_INITIALIZER_MUST_BE_LITERAL: u32 = 1254;
+const TYPE_NOT_ASSIGNABLE: u32 = 2322;
+
+fn check_source_diagnostics(file_name: &str, source: &str) -> Vec<Diagnostic> {
+    let mut parser = ParserState::new(file_name.to_string(), source.to_string());
+    let source_file = parser.parse_source_file();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), source_file);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        file_name.to_string(),
+        CheckerOptions::default(),
+    );
+    checker.enable_source_file_test_pragmas();
+    checker.ctx.set_lib_contexts(Vec::new());
+    checker.ctx.report_unresolved_imports = true;
+    checker.check_source_file(source_file);
+    checker.ctx.diagnostics.clone()
+}
+
+fn codes(source: &str) -> Vec<u32> {
+    let mut c: Vec<u32> = check_source_diagnostics("test.ts", source)
+        .into_iter()
+        .map(|d| d.code)
+        .collect();
+    c.sort_unstable();
+    c
+}
+
+fn codes_in_file(file_name: &str, source: &str) -> Vec<u32> {
+    let mut c: Vec<u32> = check_source_diagnostics(file_name, source)
+        .into_iter()
+        .map(|d| d.code)
+        .collect();
+    c.sort_unstable();
+    c
+}
+
+#[test]
+fn top_level_declare_const_annotated_literal_reports_ts1039() {
+    let got = codes("declare const x: number = 1;");
+    assert!(
+        got.contains(&INITIALIZERS_NOT_ALLOWED_IN_AMBIENT),
+        "expected TS1039, got {got:?}"
+    );
+}
+
+#[test]
+fn top_level_declare_let_annotated_literal_reports_ts1039() {
+    let got = codes("declare let x: number = 1;");
+    assert!(
+        got.contains(&INITIALIZERS_NOT_ALLOWED_IN_AMBIENT),
+        "expected TS1039, got {got:?}"
+    );
+}
+
+#[test]
+fn top_level_declare_var_annotated_literal_reports_ts1039() {
+    let got = codes("declare var x: number = 1;");
+    assert!(
+        got.contains(&INITIALIZERS_NOT_ALLOWED_IN_AMBIENT),
+        "expected TS1039, got {got:?}"
+    );
+}
+
+#[test]
+fn top_level_declare_const_annotated_computed_initializer_reports_ts1039() {
+    let got = codes("declare const x: number = 1 + 1;");
+    assert!(
+        got.contains(&INITIALIZERS_NOT_ALLOWED_IN_AMBIENT),
+        "expected TS1039, got {got:?}"
+    );
+}
+
+#[test]
+fn top_level_declare_const_renamed_binder_reports_ts1039() {
+    let got = codes("declare const totallyDifferentName: number = 1;");
+    assert!(
+        got.contains(&INITIALIZERS_NOT_ALLOWED_IN_AMBIENT),
+        "expected TS1039, got {got:?}"
+    );
+}
+
+#[test]
+fn top_level_declare_const_mismatched_annotation_reports_ts1039_and_ts2322() {
+    let got = codes("declare const x: string = 1;");
+    assert!(
+        got.contains(&INITIALIZERS_NOT_ALLOWED_IN_AMBIENT),
+        "expected TS1039, got {got:?}"
+    );
+    assert!(
+        got.contains(&TYPE_NOT_ASSIGNABLE),
+        "expected TS2322 to still fire alongside TS1039, got {got:?}"
+    );
+}
+
+/// Negative control: no annotation, non-literal initializer keeps its
+/// existing TS1254 behavior and must NOT gain a spurious TS1039 (`1 + 1` is
+/// not a `const`-with-annotation case, so it never enters the fixed path).
+#[test]
+fn top_level_declare_const_no_annotation_computed_initializer_keeps_ts1254() {
+    let got = codes("declare const x = 1 + 1;");
+    assert!(
+        got.contains(&CONST_INITIALIZER_MUST_BE_LITERAL),
+        "expected TS1254, got {got:?}"
+    );
+    assert!(
+        !got.contains(&INITIALIZERS_NOT_ALLOWED_IN_AMBIENT),
+        "did not expect TS1039 for the no-annotation case, got {got:?}"
+    );
+}
+
+/// Negative control: a plain literal ambient const without annotation is
+/// clean on both codes.
+#[test]
+fn top_level_declare_const_no_annotation_literal_is_clean() {
+    let got = codes("declare const x = 1;");
+    assert!(
+        !got.contains(&CONST_INITIALIZER_MUST_BE_LITERAL)
+            && !got.contains(&INITIALIZERS_NOT_ALLOWED_IN_AMBIENT),
+        "expected no ambient-initializer diagnostics, got {got:?}"
+    );
+}
+
+/// Regression guard: the namespace-nested path already worked (a different
+/// check, `check_initializers_in_ambient_body`) and must keep working.
+#[test]
+fn namespace_nested_ambient_const_still_reports_ts1039() {
+    let got = codes("declare namespace M { const x: number = 1; }");
+    assert!(
+        got.contains(&INITIALIZERS_NOT_ALLOWED_IN_AMBIENT),
+        "expected TS1039 for namespace-nested ambient const, got {got:?}"
+    );
+}
+
+/// Regression guard: the ambient class `readonly` property-initializer path
+/// already worked and must keep working.
+#[test]
+fn ambient_class_readonly_property_still_reports_ts1039() {
+    let got = codes("declare class C { readonly x: number = 1; }");
+    assert!(
+        got.contains(&INITIALIZERS_NOT_ALLOWED_IN_AMBIENT),
+        "expected TS1039 for ambient class readonly property, got {got:?}"
+    );
+}
+
+/// Regression pin, not a correctness claim: `core.rs` gates this whole check
+/// on `is_in_ambient_context` (explicit `declare` ancestor), which is `false`
+/// for a bare `.d.ts` top-level declaration with no `declare` keyword, so
+/// tsz emits nothing here today. Oracle-verified against pinned
+/// `typescript@7.0.2` while writing this fix: real `tsc` DOES emit TS1039 in
+/// this exact `.d.ts` shape (`case.d.ts(1,19): error TS1039 ...`) — the
+/// pre-existing comment above the `is_in_ambient_context` check ("TSC does
+/// not emit TS1039 for variable initializers in .d.ts files") does not hold
+/// for this shape. That is a separate, pre-existing false-negative in the
+/// `is_in_ambient_context` gate itself, not the pre-contextual-reset drop
+/// this PR fixes, and out of scope here — this test only pins that the
+/// reset fix does not change `.d.ts` behavior one way or the other.
+#[test]
+fn dts_file_bare_annotated_initializer_unaffected_by_this_fix() {
+    let got = codes_in_file("test.d.ts", "const x: number = 1;");
+    assert!(
+        !got.contains(&INITIALIZERS_NOT_ALLOWED_IN_AMBIENT),
+        "this fix must not change bare-.d.ts TS1039 behavior; got {got:?}"
+    );
+}


### PR DESCRIPTION
A top-level `declare const/let/var x: T = v` (or a non-`const` `let`/`var`
with any initializer) drops `tsc`'s TS1039 (`Initializers are not allowed in
ambient contexts.`) — the namespace-nested and `readonly` class-property
paths were already correct. #17073 localized the emission site
(`state/variable_checking/core.rs` ~L477) and confirmed with a probe that it
*is* reached with the right guard values, but the diagnostic never surfaced.

## Structural rule

`check_variable_declaration_with_request` (`core.rs`) computes and pushes
TS1039 correctly, anchored at the initializer node. But when the declaration
has a type annotation, `compute_variable_decl_type`
(`state/variable_checking/initializer_policy.rs`) runs a "pre-contextual
diagnostic reset" before re-evaluating the initializer against its declared
contextual type — a `retain()` that drops every diagnostic anchored inside
the initializer's own span *except* an explicit allow-list (TS2693, TS2454,
TS2348, TS2538, TS2339, TS2304, ...) of checks already known to be
structural rather than artifacts of the first, context-free type pass.
TS1039 is anchored at that same initializer span and wasn't on the
allow-list, so the reset silently deleted it. This only runs when
`has_type_annotation` is true, which is exactly why the no-annotation
sibling (TS1254) and the namespace-nested/class-property paths (a
completely different check, `check_initializers_in_ambient_body`, which
never goes through this reset) were already correct.

Confirmed by direct instrumentation before writing the fix: `error()` was
called exactly once for TS1039 with `discarded=false` and the diagnostic was
pushed into `ctx.diagnostics`, yet the final diagnostics list was empty —
narrowing it to a downstream `retain()`, not a "never emitted"/discarded-pass
bug as originally hypothesized in #17073.

Fix: add TS1039 to the reset's allow-list, next to the other
position-anchored-in-initializer structural checks it already preserves.

## Scope note (found, not fixed)

Oracle-verified while writing the adjacent-case matrix: the pre-existing
comment above the `is_in_ambient_context` gate in `core.rs` ("TSC does not
emit TS1039 for variable initializers in .d.ts files") does not hold — real
`tsc` 7.0.2 *does* emit TS1039 for a bare `.d.ts` top-level annotated
initializer (`case.d.ts(1,19): error TS1039 ...`). That's a separate,
pre-existing false-negative in the `is_in_ambient_context` gate itself (it
requires an explicit `declare` keyword ancestor, which a bare `.d.ts`
declaration doesn't have), not the diagnostic-reset drop this PR fixes. Left
untouched and pinned as a regression guard (not a correctness claim) in the
new test file; worth its own follow-up issue.

## Goal
Goal: hold

## Verification
- New `crates/tsz-checker/src/tests/ambient_top_level_initializer_ts1039_tests.rs`:
  11 tests — the full adjacent matrix from #17073 (`const`/`let`/`var`,
  literal/computed initializer, renamed binder, mismatched-annotation
  TS1039+TS2322 co-occurrence, no-annotation TS1254 negative control,
  no-annotation-literal clean negative control, namespace-nested and
  ambient-class-`readonly` regression guards, bare-`.d.ts` regression guard)
  — all pass.
- `cargo test -p tsz-checker --lib -- variable ambient initializer
  const_initializer`: 553 passed, 0 failed.
- `cargo clippy -p tsz-checker --lib`: clean.
- `cargo fmt --check -p tsz-checker`: clean.
- `python3 scripts/arch/arch_guard.py`: passed.
- Full unfiltered `cargo test -p tsz-checker --lib` was still running in the
  background at push time (buffered, this board's own documented
  zero-bytes-until-done gotcha) — land-and-continue, will report the count
  in a follow-up comment. `compare-to-parent.sh` not run this session (time
  budget); this is a single-file, purely-additive diagnostic-preservation
  fix on a rare grammar shape (an ambient declaration with both a type
  annotation and an initializer is invalid source), so no conformance
  movement is expected.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_01Dv7WbD91bRAmtUKZ9yzSEk)_