### PR TITLE
fix(config): missing relative/absolute extends target ending in .json reports TS5083, not TS6053

### DIFF
--- a/crates/tsz-core/src/config/extends.rs
+++ b/crates/tsz-core/src/config/extends.rs
@@ -13,6 +13,7 @@
 use anyhow::{Result, anyhow};
 use std::path::{Path, PathBuf};
 
+use crate::module_resolver_helpers::normalize_path_segments;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::module_resolver_helpers::{
     PackageExports, PackageJson, find_best_export_pattern, match_export_pattern,
@@ -44,12 +45,8 @@ pub(super) fn resolve_extends_path(current_path: &Path, extends: &str) -> Result
         .ok_or_else(|| anyhow!("tsconfig has no parent directory"))?;
 
     // Relative or absolute path: resolve against the declaring config's dir.
-    if extends.starts_with('.') || extends.starts_with('/') {
-        let candidate = if Path::new(extends).is_absolute() {
-            PathBuf::from(extends)
-        } else {
-            base_dir.join(extends)
-        };
+    if is_relative_or_absolute_extends_specifier(extends) {
+        let candidate = anchor_extends_specifier(current_path, extends)?;
         return Ok(probe_extends_candidate(&candidate, false));
     }
 
@@ -72,6 +69,36 @@ pub(super) fn resolve_extends_path(current_path: &Path, extends: &str) -> Result
     }
 
     Ok(None)
+}
+
+/// Whether an `extends` specifier resolves as a relative/absolute filesystem
+/// path (`./base`, `../base.json`, `/abs`) rather than through Node module
+/// resolution (`@scope/pkg`, `pkg/base.json`).
+pub(super) fn is_relative_or_absolute_extends_specifier(extends: &str) -> bool {
+    extends.starts_with('.') || extends.starts_with('/')
+}
+
+/// Anchor a relative/absolute `extends` specifier at its declaring config's
+/// directory, lexically normalized (no `.`/embedded `..`) like tsc's
+/// `getNormalizedAbsolutePath` — never touches the filesystem.
+///
+/// Besides feeding [`resolve_extends_path`]'s candidate probe, the caller in
+/// `mod.rs` reuses this to anchor tsc's TS5083 diagnostic: `tsc`'s
+/// `getExtendsConfigPath` only probes existence for a specifier lacking a
+/// `.json` extension (appending one and checking again); a specifier that
+/// already ends in `.json` is assumed to resolve, so its read failure
+/// surfaces later as "cannot read file" against the resolved path rather
+/// than the TS6053 "not found" raw-specifier diagnosis.
+pub(super) fn anchor_extends_specifier(current_path: &Path, extends: &str) -> Result<PathBuf> {
+    let base_dir = current_path
+        .parent()
+        .ok_or_else(|| anyhow!("tsconfig has no parent directory"))?;
+    let candidate = if Path::new(extends).is_absolute() {
+        PathBuf::from(extends)
+    } else {
+        base_dir.join(extends)
+    };
+    Ok(normalize_path_segments(&candidate).into_owned())
 }
 
 /// Probe a single candidate path for an `extends` target, returning the

--- a/crates/tsz-core/src/config/mod.rs
+++ b/crates/tsz-core/src/config/mod.rs
@@ -17,8 +17,9 @@ mod lib_offsets;
 mod lib_resolution;
 
 use extends::{
-    anchor_inherited_path_options, anchor_inherited_root_selectors, merge_configs,
-    resolve_extends_path, substitute_config_dir_templates,
+    anchor_extends_specifier, anchor_inherited_path_options, anchor_inherited_root_selectors,
+    is_relative_or_absolute_extends_specifier, merge_configs, resolve_extends_path,
+    substitute_config_dir_templates,
 };
 use jsonc::remove_trailing_commas;
 use lib_offsets::find_lib_entry_offset;
@@ -1541,15 +1542,42 @@ fn load_tsconfig_inner_with_diagnostics(
             }
             let Some(base_path) = resolve_extends_path(path, extends_path_str)? else {
                 let (start, length) = find_extends_specifier_span(&stripped, extends_path_str);
-                let message =
-                    format_message(diagnostic_messages::FILE_NOT_FOUND, &[extends_path_str]);
-                parsed.diagnostics.push(Diagnostic::error(
-                    &file_display,
-                    start,
-                    length,
-                    message,
-                    diagnostic_codes::FILE_NOT_FOUND,
-                ));
+                // A relative/absolute specifier that already names a `.json`
+                // path skips tsc's existence probe entirely (see
+                // `anchor_extends_specifier`'s doc comment): the failure only
+                // surfaces when tsc tries to read the resolved file, which
+                // reports TS5083 against that resolved path. Every other
+                // shape (extensionless or differently-extensioned
+                // relative/absolute specifiers, and any non-relative package
+                // specifier regardless of extension) fails at resolution
+                // time and keeps TS6053 with the raw specifier text.
+                if is_relative_or_absolute_extends_specifier(extends_path_str)
+                    && extends_path_str.ends_with(".json")
+                {
+                    let resolved = anchor_extends_specifier(path, extends_path_str)?;
+                    let resolved_display = resolved.to_string_lossy();
+                    let message = format_message(
+                        diagnostic_messages::CANNOT_READ_FILE_2,
+                        &[&resolved_display],
+                    );
+                    parsed.diagnostics.push(Diagnostic::error(
+                        &file_display,
+                        start,
+                        length,
+                        message,
+                        diagnostic_codes::CANNOT_READ_FILE_2,
+                    ));
+                } else {
+                    let message =
+                        format_message(diagnostic_messages::FILE_NOT_FOUND, &[extends_path_str]);
+                    parsed.diagnostics.push(Diagnostic::error(
+                        &file_display,
+                        start,
+                        length,
+                        message,
+                        diagnostic_codes::FILE_NOT_FOUND,
+                    ));
+                }
                 continue;
             };
             // Route base configs through the diagnostic path so TS5023 / TS5024 / TS5025

--- a/crates/tsz-core/src/config/mod.rs
+++ b/crates/tsz-core/src/config/mod.rs
@@ -1541,7 +1541,6 @@ fn load_tsconfig_inner_with_diagnostics(
                 continue;
             }
             let Some(base_path) = resolve_extends_path(path, extends_path_str)? else {
-                let (start, length) = find_extends_specifier_span(&stripped, extends_path_str);
                 // A relative/absolute specifier that already names a `.json`
                 // path skips tsc's existence probe entirely (see
                 // `anchor_extends_specifier`'s doc comment): the failure only
@@ -1560,14 +1559,18 @@ fn load_tsconfig_inner_with_diagnostics(
                         diagnostic_messages::CANNOT_READ_FILE_2,
                         &[&resolved_display],
                     );
+                    // Unlike TS6053, tsc reports TS5083 as a bare filesystem
+                    // read failure with no `file(line,col):` prefix — it is
+                    // not a complaint about a token in the config source.
                     parsed.diagnostics.push(Diagnostic::error(
-                        &file_display,
-                        start,
-                        length,
+                        String::new(),
+                        0,
+                        0,
                         message,
                         diagnostic_codes::CANNOT_READ_FILE_2,
                     ));
                 } else {
+                    let (start, length) = find_extends_specifier_span(&stripped, extends_path_str);
                     let message =
                         format_message(diagnostic_messages::FILE_NOT_FOUND, &[extends_path_str]);
                     parsed.diagnostics.push(Diagnostic::error(

--- a/crates/tsz-core/src/config/tests/extends_missing_json_target.rs
+++ b/crates/tsz-core/src/config/tests/extends_missing_json_target.rs
@@ -58,6 +58,13 @@ fn extends_array_reports_each_unresolved_entry() {
         "TS5083 names the second entry's own resolved path: {}",
         ts5083[1].message_text
     );
+    for diagnostic in &ts5083 {
+        assert!(
+            diagnostic.file.is_empty() && diagnostic.start == 0 && diagnostic.length == 0,
+            "tsc reports TS5083 as a bare filesystem read failure with no \
+             file(line,col) prefix, not anchored at the config source: {diagnostic:?}"
+        );
+    }
     let opts = parsed.config.compiler_options.expect("present base merged");
     assert_eq!(
         opts.target.as_deref(),
@@ -99,6 +106,11 @@ fn extends_missing_relative_json_emits_ts5083_at_resolved_path() {
             .contains(&expected_path.to_string_lossy().into_owned()),
         "TS5083 names the resolved absolute path, not the raw specifier: {}",
         ts5083[0].message_text
+    );
+    assert!(
+        ts5083[0].file.is_empty() && ts5083[0].start == 0 && ts5083[0].length == 0,
+        "tsc reports TS5083 unanchored (no file(line,col) prefix), unlike TS6053: {:?}",
+        ts5083[0]
     );
     assert!(
         !parsed.diagnostics.iter().any(|d| d.code == 6053),
@@ -147,9 +159,55 @@ fn extends_missing_relative_extensionless_keeps_ts6053() {
         ts6053[0].message_text
     );
     assert!(
+        !ts6053[0].file.is_empty(),
+        "TS6053, unlike TS5083, anchors at the extends specifier literal: {:?}",
+        ts6053[0]
+    );
+    assert!(
         !parsed.diagnostics.iter().any(|d| d.code == 5083),
         "an extensionless relative extends must not emit TS5083: {:?}",
         parsed.diagnostics
+    );
+}
+
+#[test]
+fn extends_missing_parent_relative_json_normalizes_dotdot() {
+    // `../` must lexically collapse against the declaring config's directory
+    // before it reaches the TS5083 message — tsc's `getNormalizedAbsolutePath`
+    // never renders an embedded `/../` segment. Oracle-verified against
+    // pinned typescript@7.0.2.
+    let temp = tempdir().expect("create temp dir");
+    let project = temp.path().join("project");
+    let nested = project.join("nested");
+    std::fs::create_dir_all(&nested).expect("create nested dir");
+    let child_path = nested.join("tsconfig.json");
+    let child_source = r#"{ "extends": "../nope.json", "compilerOptions": { "strict": true } }"#;
+    std::fs::write(&child_path, child_source).expect("write child");
+
+    let parsed = load_tsconfig_with_diagnostics(&child_path).expect("load must succeed");
+    let ts5083: Vec<&Diagnostic> = parsed
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 5083)
+        .collect();
+    assert_eq!(
+        ts5083.len(),
+        1,
+        "exactly one TS5083 for the unreadable parent-relative extends target: {:?}",
+        parsed.diagnostics
+    );
+    let expected_path = project.join("nope.json");
+    assert!(
+        ts5083[0]
+            .message_text
+            .contains(&expected_path.to_string_lossy().into_owned()),
+        "TS5083 names the lexically-collapsed path, not one with an embedded '/../': {}",
+        ts5083[0].message_text
+    );
+    assert!(
+        !ts5083[0].message_text.contains("/../"),
+        "the resolved path must not carry an embedded '/../' segment: {}",
+        ts5083[0].message_text
     );
 }
 
@@ -184,5 +242,10 @@ fn extends_missing_absolute_json_emits_ts5083_at_specifier_path() {
             .contains("/definitely/not/a/real/path/nope.json"),
         "TS5083 names the absolute specifier path verbatim: {}",
         ts5083[0].message_text
+    );
+    assert!(
+        ts5083[0].file.is_empty() && ts5083[0].start == 0 && ts5083[0].length == 0,
+        "tsc reports TS5083 unanchored (no file(line,col) prefix): {:?}",
+        ts5083[0]
     );
 }

--- a/crates/tsz-core/src/config/tests/extends_missing_json_target.rs
+++ b/crates/tsz-core/src/config/tests/extends_missing_json_target.rs
@@ -1,0 +1,188 @@
+//! A relative/absolute `extends` target ending in `.json`: TS5083 ("Cannot
+//! read file") vs. the generic TS6053 ("File not found").
+//!
+//! Split out of `module_resolution.rs` to keep it under the 2000-line limit
+//! (§19; ratchet tracked by #8280) rather than growing an already-large file.
+
+use super::super::*;
+use tempfile::tempdir;
+
+#[test]
+fn extends_array_reports_each_unresolved_entry() {
+    // Array `extends` (TS 5.0): every entry that cannot be resolved gets its
+    // own diagnostic, and resolvable entries still merge. Each missing entry
+    // here already carries a `.json` extension, so per tsc's
+    // `getExtendsConfigPath` (oracle-verified against pinned typescript@7.0.2)
+    // each independently reports TS5083 ("Cannot read file") against its own
+    // resolved absolute path, not TS6053 — see #17079.
+    let temp = tempdir().expect("create temp dir");
+    let project = temp.path().join("project");
+    std::fs::create_dir_all(&project).expect("create project dir");
+    std::fs::write(
+        project.join("present.json"),
+        r#"{ "compilerOptions": { "target": "ES2021" } }"#,
+    )
+    .expect("write present base");
+    let child_path = project.join("tsconfig.json");
+    std::fs::write(
+        &child_path,
+        r#"{ "extends": ["./present.json", "./missing-a.json", "./missing-b.json"] }"#,
+    )
+    .expect("write child");
+
+    let parsed = load_tsconfig_with_diagnostics(&child_path).expect("load must succeed");
+    let ts5083: Vec<&Diagnostic> = parsed
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 5083)
+        .collect();
+    assert_eq!(
+        ts5083.len(),
+        2,
+        "one TS5083 per unresolved .json array entry: {:?}",
+        parsed.diagnostics
+    );
+    let missing_a = project.join("missing-a.json");
+    let missing_b = project.join("missing-b.json");
+    assert!(
+        ts5083[0]
+            .message_text
+            .contains(&missing_a.to_string_lossy().into_owned()),
+        "TS5083 names the first entry's own resolved path: {}",
+        ts5083[0].message_text
+    );
+    assert!(
+        ts5083[1]
+            .message_text
+            .contains(&missing_b.to_string_lossy().into_owned()),
+        "TS5083 names the second entry's own resolved path: {}",
+        ts5083[1].message_text
+    );
+    let opts = parsed.config.compiler_options.expect("present base merged");
+    assert_eq!(
+        opts.target.as_deref(),
+        Some("ES2021"),
+        "the resolvable array entry is still applied"
+    );
+}
+
+#[test]
+fn extends_missing_relative_json_emits_ts5083_at_resolved_path() {
+    // A relative `extends` specifier that already carries a `.json`
+    // extension skips tsc's existence probe entirely; the failure surfaces
+    // as TS5083 ("Cannot read file") against the resolved absolute path,
+    // not TS6053's raw-specifier "File not found." Oracle-verified against
+    // pinned typescript@7.0.2. See #17079.
+    let temp = tempdir().expect("create temp dir");
+    let project = temp.path().join("project");
+    std::fs::create_dir_all(&project).expect("create project dir");
+    let child_path = project.join("tsconfig.json");
+    let child_source = r#"{ "extends": "./nope.json", "compilerOptions": { "strict": true } }"#;
+    std::fs::write(&child_path, child_source).expect("write child");
+
+    let parsed = load_tsconfig_with_diagnostics(&child_path).expect("load must succeed");
+    let ts5083: Vec<&Diagnostic> = parsed
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 5083)
+        .collect();
+    assert_eq!(
+        ts5083.len(),
+        1,
+        "exactly one TS5083 for the unreadable extends target: {:?}",
+        parsed.diagnostics
+    );
+    let expected_path = project.join("nope.json");
+    assert!(
+        ts5083[0]
+            .message_text
+            .contains(&expected_path.to_string_lossy().into_owned()),
+        "TS5083 names the resolved absolute path, not the raw specifier: {}",
+        ts5083[0].message_text
+    );
+    assert!(
+        !parsed.diagnostics.iter().any(|d| d.code == 6053),
+        "a .json-suffixed relative extends must not also emit TS6053: {:?}",
+        parsed.diagnostics
+    );
+    let opts = parsed
+        .config
+        .compiler_options
+        .expect("local options retained");
+    assert_eq!(
+        opts.strict,
+        Some(true),
+        "local options survive an unreadable extends"
+    );
+}
+
+#[test]
+fn extends_missing_relative_extensionless_keeps_ts6053() {
+    // The negative control: an extensionless relative specifier (no `.json`)
+    // still fails resolution up front (tsc probes the raw specifier, then
+    // the specifier with `.json` appended) and keeps the raw-specifier
+    // TS6053, not TS5083. Oracle-verified against pinned typescript@7.0.2.
+    let temp = tempdir().expect("create temp dir");
+    let project = temp.path().join("project");
+    std::fs::create_dir_all(&project).expect("create project dir");
+    let child_path = project.join("tsconfig.json");
+    let child_source = r#"{ "extends": "./nope", "compilerOptions": { "strict": true } }"#;
+    std::fs::write(&child_path, child_source).expect("write child");
+
+    let parsed = load_tsconfig_with_diagnostics(&child_path).expect("load must succeed");
+    let ts6053: Vec<&Diagnostic> = parsed
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 6053)
+        .collect();
+    assert_eq!(
+        ts6053.len(),
+        1,
+        "extensionless relative extends keeps TS6053: {:?}",
+        parsed.diagnostics
+    );
+    assert!(
+        ts6053[0].message_text.contains("./nope"),
+        "TS6053 names the raw specifier, not a resolved path: {}",
+        ts6053[0].message_text
+    );
+    assert!(
+        !parsed.diagnostics.iter().any(|d| d.code == 5083),
+        "an extensionless relative extends must not emit TS5083: {:?}",
+        parsed.diagnostics
+    );
+}
+
+#[test]
+fn extends_missing_absolute_json_emits_ts5083_at_specifier_path() {
+    // Absolute specifiers follow the same `.json`-suffix split as relative
+    // ones: an absolute path is used as-is (no anchoring join needed), so
+    // the TS5083 message names the specifier verbatim. Oracle-verified
+    // against pinned typescript@7.0.2.
+    let temp = tempdir().expect("create temp dir");
+    let project = temp.path().join("project");
+    std::fs::create_dir_all(&project).expect("create project dir");
+    let child_path = project.join("tsconfig.json");
+    let child_source = r#"{ "extends": "/definitely/not/a/real/path/nope.json", "compilerOptions": { "strict": true } }"#;
+    std::fs::write(&child_path, child_source).expect("write child");
+
+    let parsed = load_tsconfig_with_diagnostics(&child_path).expect("load must succeed");
+    let ts5083: Vec<&Diagnostic> = parsed
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 5083)
+        .collect();
+    assert_eq!(
+        ts5083.len(),
+        1,
+        "exactly one TS5083 for the unreadable absolute extends target: {:?}",
+        parsed.diagnostics
+    );
+    assert!(
+        ts5083[0]
+            .message_text
+            .contains("/definitely/not/a/real/path/nope.json"),
+        "TS5083 names the absolute specifier path verbatim: {}",
+        ts5083[0].message_text
+    );
+}

--- a/crates/tsz-core/src/config/tests/mod.rs
+++ b/crates/tsz-core/src/config/tests/mod.rs
@@ -6,6 +6,7 @@
 
 mod extends_cycle_and_jsx_factory_values;
 mod extends_empty_specifier;
+mod extends_missing_json_target;
 mod files_list_empty;
 mod module_resolution;
 mod options_parsing;

--- a/crates/tsz-core/src/config/tests/module_resolution.rs
+++ b/crates/tsz-core/src/config/tests/module_resolution.rs
@@ -1882,45 +1882,6 @@ fn extends_unresolved_package_emits_ts6053_and_keeps_local_options() {
 }
 
 #[test]
-fn extends_array_reports_each_unresolved_entry() {
-    // Array `extends` (TS 5.0): every entry that cannot be resolved gets its
-    // own TS6053, and resolvable entries still merge.
-    let temp = tempdir().expect("create temp dir");
-    let project = temp.path().join("project");
-    std::fs::create_dir_all(&project).expect("create project dir");
-    std::fs::write(
-        project.join("present.json"),
-        r#"{ "compilerOptions": { "target": "ES2021" } }"#,
-    )
-    .expect("write present base");
-    let child_path = project.join("tsconfig.json");
-    std::fs::write(
-        &child_path,
-        r#"{ "extends": ["./present.json", "./missing-a.json", "./missing-b.json"] }"#,
-    )
-    .expect("write child");
-
-    let parsed = load_tsconfig_with_diagnostics(&child_path).expect("load must succeed");
-    let ts6053: Vec<&Diagnostic> = parsed
-        .diagnostics
-        .iter()
-        .filter(|d| d.code == 6053)
-        .collect();
-    assert_eq!(
-        ts6053.len(),
-        2,
-        "one TS6053 per unresolved array entry: {:?}",
-        parsed.diagnostics
-    );
-    let opts = parsed.config.compiler_options.expect("present base merged");
-    assert_eq!(
-        opts.target.as_deref(),
-        Some("ES2021"),
-        "the resolvable array entry is still applied"
-    );
-}
-
-#[test]
 fn config_dir_template_expands_against_leaf_config_dir() {
     // TS 5.5 `${configDir}`: a root config's template resolves to its own
     // directory and produces absolute selectors/paths.


### PR DESCRIPTION
When a tsconfig's `extends` specifier resolves to a **relative or absolute path that already ends in `.json`** (e.g. `"extends": "./nope.json"`), `tsc` reports TS5083 (`Cannot read file '{0}'.`) against the resolved absolute path; tsz's `load_tsconfig_inner_with_diagnostics` (`crates/tsz-core/src/config/mod.rs`) reported the generic TS6053 (`File '{0}' not found.`) against the raw specifier instead — the same code it (correctly) uses for an extensionless/differently-extensioned relative specifier or an unresolvable non-relative package specifier. Closes #17079.

## Structural rule

`tsc`'s `getExtendsConfigPath` (`commandLineParser.ts`) only probes filesystem existence for an extends specifier that does **not** already end in `.json` (trying the raw path, then the path with `.json` appended). Once a specifier already carries a `.json` extension, resolution is assumed to succeed with no existence check; the failure only surfaces later when `tsc` actually tries to *read* that resolved file, which reports TS5083 against the resolved path rather than TS6053 against the raw specifier. A non-relative package specifier (`no-such-pkg/tsconfig.json`) keeps TS6053 unconditionally even when it ends in `.json`, since `node_modules` resolution failure is a distinct "never resolved to anything" case, not "resolved but unreadable".

Owner layer: `tsz-core` config loader — `crates/tsz-core/src/config/mod.rs` (diagnostic emission site) and `crates/tsz-core/src/config/extends.rs` (new `is_relative_or_absolute_extends_specifier`/`anchor_extends_specifier` helpers, reused by both the diagnostic site and `resolve_extends_path`'s own candidate computation to avoid duplicating the anchoring logic).

## Adjacent-case matrix (oracle-verified against pinned `typescript@7.0.2`)

| `extends` value | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `"./nope.json"` (relative, missing) | TS5083 (resolved path) | TS6053 (raw specifier) | TS5083 (resolved path) ✓ |
| `"./nope"` (relative, extensionless, negative control) | TS6053 (raw specifier) | TS6053 | TS6053 (unchanged) ✓ |
| `"/abs/nope.json"` (absolute, missing) | TS5083 (specifier path) | TS6053 | TS5083 ✓ |
| `"./nope.foo"` (relative, non-json extension) | TS6053 (raw specifier) | TS6053 | TS6053 (unchanged) ✓ |
| array `["./missing-a.json", "./missing-b.json"]` | independent TS5083 per entry | one TS6053 per entry | independent TS5083 per entry ✓ |
| `"no-such-pkg/tsconfig.json"` (package, negative control) | TS6053 (raw specifier) | TS6053 | TS6053 (unchanged) ✓ |
| existing directory named `nope.json` | TS5083 | TS6053 | TS5083 ✓ |

Also found and fixed a pre-existing wrong test expectation while adding this matrix: `extends_array_reports_each_unresolved_entry` asserted `TS6053.len() == 2` for two missing `.json` array entries — oracle-verified this was wrong on `main` before this PR too (both entries are TS5083), not a regression introduced here.

New tests live in a new shard `crates/tsz-core/src/config/tests/extends_missing_json_target.rs` (following the `extends_empty_specifier.rs` precedent from #17078) since `module_resolution.rs` is already at its `2016`-line arch-guard ratchet (#16488) and had no headroom for the new cases.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-core --lib config::` — 287/287 (was 283/283 on `main`; net +4 new tests, 1 pre-existing test's assertion corrected in place).
- `cargo test -p tsz-core --lib` — 3338/3339 (the one failure, `isolated_test_runner::tests::test_isolated_runner_timeout`, is a pre-existing timing-sensitive test unrelated to this change — passes in isolation, reproduces on `main`).
- `cargo clippy -p tsz-core --lib --all-targets -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard_file_limits.py` — clean.
- `cargo fmt -p tsz-core` — clean.
- Oracle-verified against pinned `typescript@7.0.2` (`scripts/conformance/typescript-versions.json`) across the full adjacent matrix above.
- Not run: `compare-to-parent.sh` / broader conformance snapshot — this changes tsconfig `extends`-resolution diagnostics only (not source-level checker diagnostics), a shape the TypeScript conformance corpus does not exercise; the same scope as the sibling #17078 (which also skipped it).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01GaYQBUGDKByQcGtkGxBfiJ)_