### PR TITLE
fix(checker): keep TS1039/TS1254 across the initializer pre-contextual reset

### DIFF
--- a/crates/tsz-checker/src/state/variable_checking/initializer_policy.rs
+++ b/crates/tsz-checker/src/state/variable_checking/initializer_policy.rs
@@ -301,6 +301,15 @@ impl<'a> CheckerState<'a> {
                     self.ctx.diagnostics.retain(|diag| {
                         diag.code
                             == crate::diagnostics::diagnostic_codes::STATIC_MEMBERS_CANNOT_REFERENCE_CLASS_TYPE_PARAMETERS
+                            // TS1039/TS1254: ambient-initializer grammar errors are a
+                            // pure syntactic property of the declaration, independent of
+                            // contextual typing, so they survive the reset. Only
+                            // annotated ambient declarations take this contextual path,
+                            // which is why the reset used to drop their TS1039.
+                            || diag.code
+                                == crate::diagnostics::diagnostic_codes::INITIALIZERS_ARE_NOT_ALLOWED_IN_AMBIENT_CONTEXTS
+                            || diag.code
+                                == crate::diagnostics::diagnostic_codes::A_CONST_INITIALIZER_IN_AN_AMBIENT_CONTEXT_MUST_BE_A_STRING_OR_NUMERIC_LITERAL_OR
                             // TS2693/TS2585/TS1361/TS1362: type-only keywords and
                             // type-only import/export used as values are structural
                             // errors, not contextual-typing artifacts.

--- a/crates/tsz-checker/tests/using_declaration_placement_grammar_tests.rs
+++ b/crates/tsz-checker/tests/using_declaration_placement_grammar_tests.rs
@@ -382,3 +382,94 @@ fn ambient_annotated_const_still_emits_ts1039() {
         "an annotated ambient const still takes the TS1039 arm, got {codes:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// TS1039 must survive the initializer's pre-contextual diagnostic reset
+//
+// A type-annotated ambient variable declaration with an initializer
+// (`declare const a: number = 1`) computes its declared type from the
+// annotation and re-checks the initializer under contextual typing. That path
+// first clears stale contextual diagnostics inside the initializer span; the
+// ambient-initializer grammar error (TS1039) is structural, not a contextual
+// artifact, so it must be preserved across that reset. Untyped ambient
+// declarations never take the contextual path, which is why they were
+// unaffected. Every expectation is pinned against `typescript@7.0.2`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn top_level_declare_const_annotated_initializer_emits_ts1039() {
+    let codes = check_codes("declare const a: number = 1;");
+    assert!(codes.contains(&1039), "expected TS1039, got {codes:?}");
+}
+
+#[test]
+fn top_level_declare_let_annotated_initializer_emits_ts1039() {
+    let codes = check_codes("declare let a: number = 1;");
+    assert!(codes.contains(&1039), "expected TS1039, got {codes:?}");
+}
+
+#[test]
+fn top_level_declare_var_annotated_initializer_emits_ts1039() {
+    let codes = check_codes("declare var a: number = 1;");
+    assert!(codes.contains(&1039), "expected TS1039, got {codes:?}");
+}
+
+#[test]
+fn renamed_binder_declare_const_annotated_initializer_emits_ts1039() {
+    // The binder name must not matter (anti-hardcoding).
+    let codes = check_codes("declare const resourceHandle: string = \"x\";");
+    assert!(codes.contains(&1039), "expected TS1039, got {codes:?}");
+}
+
+#[test]
+fn annotated_ambient_initializer_survives_object_contextual_type() {
+    // A non-`any` object annotation supplies a contextual type, so the
+    // initializer is re-checked and its span reset — the exact path that
+    // dropped TS1039.
+    let codes = check_codes("declare const o: { x: number } = { x: 1 };");
+    assert!(codes.contains(&1039), "expected TS1039, got {codes:?}");
+}
+
+#[test]
+fn nested_ambient_namespace_annotated_initializer_emits_ts1039() {
+    let codes = check_codes("declare namespace N { namespace M { const b: number = 2; } }");
+    assert!(codes.contains(&1039), "expected TS1039, got {codes:?}");
+}
+
+#[test]
+fn declare_module_nested_namespace_annotated_initializer_emits_ts1039() {
+    let codes = check_codes("declare module Z { namespace M { const b: number = 2; } }");
+    assert!(codes.contains(&1039), "expected TS1039, got {codes:?}");
+}
+
+#[test]
+fn mixed_annotated_and_bare_ambient_initializers_report_both_codes() {
+    // The annotated declaration takes the TS1039 arm; the bare `const` with a
+    // non-literal initializer takes the TS1254 arm. Both must survive.
+    let codes = check_codes("declare const a: number = 1, b = {};");
+    assert!(
+        codes.contains(&1039) && codes.contains(&1254),
+        "expected both TS1039 and TS1254, got {codes:?}"
+    );
+}
+
+#[test]
+fn annotated_ambient_initializer_keeps_both_grammar_and_type_error() {
+    // The reset re-emits real contextual diagnostics: an initializer that also
+    // mismatches the annotation yields TS1039 (grammar) and TS2322 (type).
+    let codes = check_codes("declare const a: number = \"x\";");
+    assert!(
+        codes.contains(&1039) && codes.contains(&2322),
+        "expected both TS1039 and TS2322, got {codes:?}"
+    );
+}
+
+#[test]
+fn non_ambient_annotated_initializer_has_no_ts1039() {
+    // Control: TS1039 is gated on the ambient context, not the annotation.
+    let codes = check_codes("const a: number = 1;");
+    assert!(
+        !codes.contains(&1039),
+        "TS1039 must not fire outside ambient, got {codes:?}"
+    );
+}


### PR DESCRIPTION
Fixes #17083.

When a variable declaration sits in an ambient context (an explicit `declare`
ancestor) and carries an initializer, `tsc` reports **TS1039** ("Initializers
are not allowed in ambient contexts") — a `checkGrammarVariableDeclaration`
grammar error that is a pure syntactic property of the declaration. tsz emitted
it correctly for *untyped* forms but silently dropped it for *type-annotated*
ambient declarations (`declare const a: number = 1`).

**Structural rule:** when an ambient variable declaration has an initializer,
`tsc` reports TS1039 regardless of any type annotation; tsz owns this in
`variable_checking/core.rs` (the ambient-initializer grammar check) but was
losing it in the checker's initializer type-computation path.

**Root cause:** for a type-annotated declaration with an initializer,
`compute_variable_decl_type` (`variable_checking/initializer_policy.rs`) runs a
"pre-contextual diagnostic reset" — `self.ctx.diagnostics.retain(|diag| …)` —
that clears diagnostics inside the initializer span before re-checking the
initializer under contextual typing, keeping only a list of *structural* codes.
TS1039 (and its const-literal sibling TS1254) were missing from that keep-list,
so they were dropped as collateral. Untyped ambient declarations never take the
contextual path, which is why only the annotated forms regressed; a separate
emission path already covered single-level `declare namespace` bodies, masking
the gap for that one shape.

**Fix:** add TS1039/TS1254 to the keep-list. They are grammar errors independent
of contextual typing, exactly like the sibling structural codes already
preserved there (TS2693/TS2454/TS2339/TS2304). No change to *when* the grammar
check fires, so no new false positives are possible.

Out of scope (tracked separately): tsz also misses TS1039 for
`.d.ts`-implicit-ambient initializers (`export const a: number = 1;` in a
`.d.ts`); that lives in the `is_in_ambient_context` gate, not this reset.

## Goal
Goal: hold

## Verification
- Oracle differential vs `typescript@7.0.2` (`--noEmit --strict --target es2022 --lib es2022`), 20 cases: all previously-missing forms (`declare const/let/var a: T = …`, nested namespaces, `declare module`, mixed declarators, object annotations) now match `tsc`; controls (untyped forms, non-ambient typed, contextual TS2322 elaboration) unchanged.
- New regression tests in `crates/tsz-checker/tests/using_declaration_placement_grammar_tests.rs` (10 cases, incl. renamed binders / anti-hardcoding).
- `cargo clippy -p tsz-checker` clean; arch-size guard passes (files < 2000 lines).
- ~2,300 checker unit tests across initializer / variable / declaration / contextual / excess-property / assignability / const / narrowing / ambient: 0 failures.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_014barfCVvnh3ULji3bNEYXS)_