### PR TITLE
fix(config): report TS5083 for an unreadable relative/absolute `extends` .json target

### DIFF
--- a/crates/tsz-core/src/config/extends.rs
+++ b/crates/tsz-core/src/config/extends.rs
@@ -20,42 +20,99 @@ use crate::module_resolver_helpers::{
 };
 
 use super::{CompilerOptions, TsConfig};
+use tsz_common::file_extensions::{JSON_EXTENSION, is_json_file};
+use tsz_common::module_resolution::path_identity::normalize_segments;
+
+/// The outcome of resolving a tsconfig `extends` specifier, carrying the
+/// distinction `tsc` draws between an unresolvable specifier (TS6053) and a
+/// resolved-but-unreadable file (TS5083).
+///
+/// `tsc`'s `getExtendsConfigPath` splits three ways, which this mirrors:
+/// - a specifier that names an existing config file → [`Self::Found`];
+/// - a **rooted/relative** specifier that already carries a `.json` extension
+///   but whose file does not exist → [`Self::Unreadable`]. `tsc` returns that
+///   path from `getExtendsConfigPath` *unchecked* (the `.json`-append fallback
+///   only fires for extensionless specifiers), so the subsequent file read
+///   fails and surfaces a file-less **TS5083** anchored at the resolved path;
+/// - any other miss — an extensionless/non-`.json` relative specifier whose
+///   `.json`-appended candidate is also absent, or a bare/package specifier
+///   that fails Node resolution → [`Self::NotFound`], the specifier-anchored
+///   **TS6053**.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum ExtendsResolution {
+    /// An existing config file to load and merge.
+    Found(PathBuf),
+    /// A rooted/relative `.json` specifier that resolved to a concrete path
+    /// which does not exist; the payload is the lexically normalized absolute
+    /// path `tsc` embeds in TS5083's `Cannot read file '{0}'.`
+    Unreadable(PathBuf),
+    /// The specifier never resolved to any candidate file; the caller reports
+    /// TS6053 anchored at the specifier literal.
+    NotFound,
+}
 
 /// Resolve a tsconfig `extends` specifier to the config file it names on disk.
 ///
-/// Returns `Ok(Some(path))` for a successfully located, existing config file,
-/// `Ok(None)` when the specifier cannot be resolved to an existing file (the
-/// caller then reports TS6053 and continues, matching `tsc`'s
-/// `getExtendsConfigPath`), and `Err` only for a malformed `current_path`.
+/// Returns an [`ExtendsResolution`] describing whether the specifier located an
+/// existing file, resolved to an unreadable `.json` path (TS5083), or failed to
+/// resolve at all (TS6053) — and `Err` only for a malformed `current_path`.
 ///
-/// Resolution mirrors `tsc`:
+/// Resolution mirrors `tsc`'s `getExtendsConfigPath`:
 /// - **Relative / absolute** specifiers (`./base`, `../base.json`, `/abs`)
-///   resolve against the declaring config's directory, appending `.json` when
-///   the specifier carries no extension. No directory lookup is attempted (a
+///   resolve against the declaring config's directory. The path is lexically
+///   normalized, probed as written, and — only when it carries no `.json`
+///   extension — re-probed with `.json` appended. A missing `.json` specifier
+///   is [`ExtendsResolution::Unreadable`]; a missing extensionless one is
+///   [`ExtendsResolution::NotFound`]. No directory lookup is attempted (a
 ///   relative `extends` must name a file, like `tsc`).
 /// - **Non-relative** specifiers go through Node module resolution: first the
 ///   package's `package.json` `"exports"` map, then a `node_modules` walk that
 ///   honors an explicit file subpath (`pkg/base.json`), an extensionless
 ///   subpath (`pkg/recommended` -> `recommended.json`), and a bare package
-///   whose root holds a `tsconfig.json`.
-pub(super) fn resolve_extends_path(current_path: &Path, extends: &str) -> Result<Option<PathBuf>> {
+///   whose root holds a `tsconfig.json`. Every module-resolution miss is
+///   [`ExtendsResolution::NotFound`] (TS6053) — `tsc` never reports TS5083 for
+///   a package specifier.
+pub(super) fn resolve_extends_path(
+    current_path: &Path,
+    extends: &str,
+) -> Result<ExtendsResolution> {
     let base_dir = current_path
         .parent()
         .ok_or_else(|| anyhow!("tsconfig has no parent directory"))?;
 
     // Relative or absolute path: resolve against the declaring config's dir.
     if extends.starts_with('.') || extends.starts_with('/') {
-        let candidate = if Path::new(extends).is_absolute() {
+        let joined = if Path::new(extends).is_absolute() {
             PathBuf::from(extends)
         } else {
             base_dir.join(extends)
         };
-        return Ok(probe_extends_candidate(&candidate, false));
+        // `tsc` normalizes the specifier against the config directory before
+        // probing, so the path it feeds to the file read (and thus TS5083's
+        // message) is lexically normalized — `../base.json` becomes an absolute
+        // sibling path, not a `<dir>/../base.json` spelling.
+        let candidate = normalize_segments(&joined);
+        if candidate.is_file() {
+            return Ok(ExtendsResolution::Found(candidate));
+        }
+        // A specifier that already ends in `.json` is returned by `tsc`
+        // unchecked; the ensuing file read fails with TS5083 at the resolved
+        // path rather than the generic specifier-anchored TS6053.
+        if is_json_file(&candidate) {
+            return Ok(ExtendsResolution::Unreadable(candidate));
+        }
+        // Otherwise `tsc` appends `.json` and re-probes; a miss there is the
+        // specifier-anchored TS6053.
+        let with_json = append_json_extension(candidate);
+        if with_json.is_file() {
+            return Ok(ExtendsResolution::Found(with_json));
+        }
+        return Ok(ExtendsResolution::NotFound);
     }
 
     // Non-relative: Node module resolution. `package.json` exports first.
     if let Some(resolved) = resolve_package_extends_path(current_path, extends) {
-        return Ok(Some(resolved));
+        return Ok(ExtendsResolution::Found(resolved));
     }
 
     // Package-name extends (e.g. "@tsconfig/node20/tsconfig.json").
@@ -64,14 +121,24 @@ pub(super) fn resolve_extends_path(current_path: &Path, extends: &str) -> Result
     loop {
         let candidate = search_dir.join("node_modules").join(extends);
         if let Some(resolved) = probe_extends_candidate(&candidate, true) {
-            return Ok(Some(resolved));
+            return Ok(ExtendsResolution::Found(resolved));
         }
         if !search_dir.pop() {
             break;
         }
     }
 
-    Ok(None)
+    Ok(ExtendsResolution::NotFound)
+}
+
+/// Append a literal `.json` to a path, matching `tsc`'s `path + Extension.Json`
+/// (a suffix append, never an extension *replacement*): `foo.bar` becomes
+/// `foo.bar.json`, not `foo.json` (which is what `Path::with_extension` would
+/// produce). Consumes `path` so the caller's dead `PathBuf` is reused.
+fn append_json_extension(path: PathBuf) -> PathBuf {
+    let mut os = path.into_os_string();
+    os.push(JSON_EXTENSION);
+    PathBuf::from(os)
 }
 
 /// Probe a single candidate path for an `extends` target, returning the
@@ -979,20 +1046,72 @@ mod tests {
 
         // Extensionless relative specifier resolves by appending `.json`.
         let resolved = resolve_extends_path(&child, "./base").unwrap();
-        assert_eq!(resolved, Some(project.join("base.json")));
+        assert_eq!(
+            resolved,
+            ExtendsResolution::Found(project.join("base.json"))
+        );
     }
 
     #[test]
-    fn resolve_extends_path_relative_missing_is_none() {
+    fn resolve_extends_path_relative_missing_extensionless_is_not_found() {
         let temp = tempdir().unwrap();
         let project = temp.path().join("p");
         std::fs::create_dir_all(&project).unwrap();
         let child = project.join("tsconfig.json");
 
-        // A relative specifier that names no existing file is reported as a
-        // miss (the caller then emits TS6053) rather than a bogus path.
+        // An extensionless relative specifier whose `.json`-appended candidate
+        // is also absent is a plain miss: the caller emits the specifier-
+        // anchored TS6053, never TS5083.
         let resolved = resolve_extends_path(&child, "./missing").unwrap();
-        assert_eq!(resolved, None);
+        assert_eq!(resolved, ExtendsResolution::NotFound);
+    }
+
+    #[test]
+    fn resolve_extends_path_relative_missing_json_is_unreadable() {
+        let temp = tempdir().unwrap();
+        let project = temp.path().join("p");
+        std::fs::create_dir_all(&project).unwrap();
+        let child = project.join("tsconfig.json");
+
+        // A relative specifier that already ends in `.json` and does not exist
+        // resolves to a concrete-but-unreadable path: `tsc` returns it unchecked
+        // and the file read fails with TS5083 anchored at the normalized path.
+        let resolved = resolve_extends_path(&child, "./nope.json").unwrap();
+        assert_eq!(
+            resolved,
+            ExtendsResolution::Unreadable(project.join("nope.json"))
+        );
+    }
+
+    #[test]
+    fn resolve_extends_path_relative_missing_json_normalizes_parent_segments() {
+        let temp = tempdir().unwrap();
+        let project = temp.path().join("p");
+        let nested = project.join("nested");
+        std::fs::create_dir_all(&nested).unwrap();
+        let child = nested.join("tsconfig.json");
+
+        // The TS5083 path is lexically normalized: `../nope.json` collapses to
+        // the sibling directory, never a `<dir>/../nope.json` spelling.
+        let resolved = resolve_extends_path(&child, "../nope.json").unwrap();
+        assert_eq!(
+            resolved,
+            ExtendsResolution::Unreadable(project.join("nope.json"))
+        );
+    }
+
+    #[test]
+    fn resolve_extends_path_relative_missing_non_json_extension_is_not_found() {
+        let temp = tempdir().unwrap();
+        let project = temp.path().join("p");
+        std::fs::create_dir_all(&project).unwrap();
+        let child = project.join("tsconfig.json");
+
+        // A non-`.json` extension is treated like an extensionless specifier
+        // (`tsc` appends `.json` and re-probes), so a miss is TS6053 — TS5083 is
+        // reserved for `.json` specifiers only.
+        let resolved = resolve_extends_path(&child, "./nope.txt").unwrap();
+        assert_eq!(resolved, ExtendsResolution::NotFound);
     }
 
     #[test]
@@ -1005,7 +1124,22 @@ mod tests {
         let child = project.join("tsconfig.json");
 
         let resolved = resolve_extends_path(&child, abs.to_string_lossy().as_ref()).unwrap();
-        assert_eq!(resolved, Some(abs));
+        assert_eq!(resolved, ExtendsResolution::Found(abs));
+    }
+
+    #[test]
+    fn resolve_extends_path_absolute_missing_json_is_unreadable() {
+        let temp = tempdir().unwrap();
+        let project = temp.path().join("p");
+        std::fs::create_dir_all(&project).unwrap();
+        let child = project.join("tsconfig.json");
+        let abs_missing = temp.path().join("does").join("not").join("exist.json");
+
+        // A rooted (absolute) `.json` specifier shares the relative branch's
+        // TS5083 rule per `isRootedDiskPath` in `commandLineParser.ts`.
+        let resolved =
+            resolve_extends_path(&child, abs_missing.to_string_lossy().as_ref()).unwrap();
+        assert_eq!(resolved, ExtendsResolution::Unreadable(abs_missing));
     }
 
     #[test]
@@ -1019,7 +1153,7 @@ mod tests {
         let child = project.join("tsconfig.json");
 
         let resolved = resolve_extends_path(&child, "@scope/pkg/recommended").unwrap();
-        assert_eq!(resolved, Some(base));
+        assert_eq!(resolved, ExtendsResolution::Found(base));
     }
 
     #[test]
@@ -1033,7 +1167,7 @@ mod tests {
         let child = project.join("tsconfig.json");
 
         let resolved = resolve_extends_path(&child, "@scope/pkg/tsconfig.base.json").unwrap();
-        assert_eq!(resolved, Some(base));
+        assert_eq!(resolved, ExtendsResolution::Found(base));
     }
 
     #[test]
@@ -1052,7 +1186,7 @@ mod tests {
         let child = nested.join("tsconfig.json");
 
         let resolved = resolve_extends_path(&child, "@scope/tsconfig/node22.json").unwrap();
-        assert_eq!(resolved, Some(base));
+        assert_eq!(resolved, ExtendsResolution::Found(base));
     }
 
     #[test]
@@ -1067,7 +1201,7 @@ mod tests {
         let child = project.join("tsconfig.json");
 
         let resolved = resolve_extends_path(&child, "shared-config").unwrap();
-        assert_eq!(resolved, Some(base));
+        assert_eq!(resolved, ExtendsResolution::Found(base));
     }
 
     #[test]
@@ -1080,6 +1214,6 @@ mod tests {
         let child = project.join("tsconfig.json");
 
         let resolved = resolve_extends_path(&child, "@scope/pkg/file.json").unwrap();
-        assert_eq!(resolved, None);
+        assert_eq!(resolved, ExtendsResolution::NotFound);
     }
 }

--- a/crates/tsz-core/src/config/mod.rs
+++ b/crates/tsz-core/src/config/mod.rs
@@ -17,8 +17,8 @@ mod lib_offsets;
 mod lib_resolution;
 
 use extends::{
-    anchor_inherited_path_options, anchor_inherited_root_selectors, merge_configs,
-    resolve_extends_path, substitute_config_dir_templates,
+    ExtendsResolution, anchor_inherited_path_options, anchor_inherited_root_selectors,
+    merge_configs, resolve_extends_path, substitute_config_dir_templates,
 };
 use jsonc::remove_trailing_commas;
 use lib_offsets::find_lib_entry_offset;
@@ -1429,11 +1429,12 @@ fn load_tsconfig_inner(
         // Each base is merged into the accumulated config.
         let mut accumulated: Option<TsConfig> = None;
         for extends_path_str in &extends_paths {
-            // An unresolved `extends` is a recoverable condition (tsc reports
-            // TS6053 and continues with the local config). This diagnostic-free
-            // loader simply degrades: skip the missing base rather than aborting
-            // the whole config load.
-            let Some(base_path) = resolve_extends_path(path, extends_path_str)? else {
+            // An unresolved or unreadable `extends` is a recoverable condition
+            // (tsc reports TS6053/TS5083 and continues with the local config).
+            // This diagnostic-free loader simply degrades: skip the base rather
+            // than aborting the whole config load.
+            let ExtendsResolution::Found(base_path) = resolve_extends_path(path, extends_path_str)?
+            else {
                 continue;
             };
             let base_config = load_tsconfig_inner(&base_path, visited, true, config_dir)?;
@@ -1514,16 +1515,12 @@ fn load_tsconfig_inner_with_diagnostics(
         let mut inherited_literal_keys: FxHashSet<String> = FxHashSet::default();
         let stripped = strip_jsonc(&source);
         for extends_path_str in &extends_paths {
-            // An `extends` specifier that names no existing config file is a
-            // recoverable error: tsc emits TS6053 anchored at the specifier and
-            // continues with the remaining (local) options. Emit the same and
-            // skip this base instead of failing the whole config load.
-            //
             // A bare `""` is a distinct diagnosis (`getExtendsConfigPathOrArray`
             // in `commandLineParser.ts`): every resolution strategy (relative,
             // absolute, package) is a no-op on an empty specifier, so `tsc`
             // short-circuits to TS18051 (`Compiler option 'extends' cannot be
-            // given an empty string.`) instead of TS6053's `File '' not found.`.
+            // given an empty string.`) instead of the unresolved-file codes. The
+            // resolved outcomes (TS6053/TS5083) are handled per-arm below.
             if extends_path_str.is_empty() {
                 let (start, length) = find_extends_specifier_span(&stripped, extends_path_str);
                 let message = format_message(
@@ -1539,18 +1536,45 @@ fn load_tsconfig_inner_with_diagnostics(
                 ));
                 continue;
             }
-            let Some(base_path) = resolve_extends_path(path, extends_path_str)? else {
-                let (start, length) = find_extends_specifier_span(&stripped, extends_path_str);
-                let message =
-                    format_message(diagnostic_messages::FILE_NOT_FOUND, &[extends_path_str]);
-                parsed.diagnostics.push(Diagnostic::error(
-                    &file_display,
-                    start,
-                    length,
-                    message,
-                    diagnostic_codes::FILE_NOT_FOUND,
-                ));
-                continue;
+            let base_path = match resolve_extends_path(path, extends_path_str)? {
+                ExtendsResolution::Found(base_path) => base_path,
+                ExtendsResolution::Unreadable(resolved) => {
+                    // A rooted/relative `.json` specifier resolved to a concrete
+                    // path that does not exist. tsc returns it unchecked from
+                    // `getExtendsConfigPath`, then the file read fails with a
+                    // file-less TS5083 anchored at the resolved path (not the
+                    // specifier), and continues with the remaining options.
+                    let message = format_message(
+                        diagnostic_messages::CANNOT_READ_FILE_2,
+                        &[resolved.to_string_lossy().as_ref()],
+                    );
+                    parsed.diagnostics.push(Diagnostic::error(
+                        "",
+                        0,
+                        0,
+                        message,
+                        diagnostic_codes::CANNOT_READ_FILE_2,
+                    ));
+                    continue;
+                }
+                ExtendsResolution::NotFound => {
+                    // An `extends` specifier that names no existing config file
+                    // is a recoverable error: tsc emits TS6053 anchored at the
+                    // specifier and continues with the remaining (local)
+                    // options. Emit the same and skip this base instead of
+                    // failing the whole config load.
+                    let (start, length) = find_extends_specifier_span(&stripped, extends_path_str);
+                    let message =
+                        format_message(diagnostic_messages::FILE_NOT_FOUND, &[extends_path_str]);
+                    parsed.diagnostics.push(Diagnostic::error(
+                        &file_display,
+                        start,
+                        length,
+                        message,
+                        diagnostic_codes::FILE_NOT_FOUND,
+                    ));
+                    continue;
+                }
             };
             // Route base configs through the diagnostic path so TS5023 / TS5024 / TS5025
             // fire on the *base* file (matching tsc's `base.json(L,C):` anchor)

--- a/crates/tsz-core/src/config/tests/extends_missing_target.rs
+++ b/crates/tsz-core/src/config/tests/extends_missing_target.rs
@@ -1,0 +1,285 @@
+//! Missing-`extends`-target diagnosis: TS5083 vs TS6053 (#17079).
+//!
+//! `tsc`'s `getExtendsConfigPath` (`commandLineParser.ts`) splits a failed
+//! `extends` resolution two ways, and the code it reports is *not* uniform:
+//!
+//! - A **rooted/relative** specifier that already carries a `.json` extension is
+//!   returned from `getExtendsConfigPath` unchecked (the `.json`-append fallback
+//!   only fires for extensionless specifiers). The ensuing file read fails and
+//!   surfaces a file-less **TS5083** `Cannot read file '{0}'.` whose `{0}` is the
+//!   lexically normalized absolute path.
+//! - Every other miss — an extensionless / non-`.json` relative specifier whose
+//!   `.json`-appended candidate is absent, or a bare/package specifier that
+//!   fails Node module resolution — is the specifier-anchored **TS6053**
+//!   `File '{0}' not found.`
+//!
+//! Oracle-verified against pinned `typescript@7.0.2` with
+//! `--noEmit --strict --pretty false --lib es2022 --target es2022
+//! --singleThreaded --stableTypeOrdering`.
+
+use super::super::*;
+use tempfile::tempdir;
+
+/// Build a project whose root `tsconfig.json` extends `spec`, load it with
+/// diagnostics, and return the parsed result. A single local option (`strict`)
+/// is set so callers can assert it survives the recoverable `extends` failure.
+fn load_extending(spec: &str) -> (tempfile::TempDir, ParsedTsConfig) {
+    let temp = tempdir().expect("create temp dir");
+    let project = temp.path().join("project");
+    std::fs::create_dir_all(&project).expect("create project dir");
+    let child_path = project.join("tsconfig.json");
+    let source = format!(r#"{{ "extends": "{spec}", "compilerOptions": {{ "strict": true }} }}"#);
+    std::fs::write(&child_path, source).expect("write child");
+    let parsed = load_tsconfig_with_diagnostics(&child_path).expect("load must succeed");
+    (temp, parsed)
+}
+
+#[test]
+fn missing_relative_json_reports_ts5083_not_ts6053() {
+    let (temp, parsed) = load_extending("./nope.json");
+
+    assert!(
+        !parsed.diagnostics.iter().any(|d| d.code == 6053),
+        "a missing relative .json extends must not report the generic TS6053, got: {:?}",
+        parsed.diagnostics
+    );
+    let ts5083: Vec<&Diagnostic> = parsed
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 5083)
+        .collect();
+    assert_eq!(
+        ts5083.len(),
+        1,
+        "exactly one TS5083 for the unreadable relative .json: {:?}",
+        parsed.diagnostics
+    );
+
+    // {0} is the lexically normalized absolute path of the resolved target.
+    let expected_path = temp
+        .path()
+        .join("project")
+        .join("nope.json")
+        .to_string_lossy()
+        .into_owned();
+    assert!(
+        ts5083[0].message_text.contains(&expected_path),
+        "TS5083 names the resolved target path {expected_path}: {}",
+        ts5083[0].message_text
+    );
+
+    // TS5083 comes from the file-read layer, so it is a file-less compiler
+    // diagnostic anchored at the whole compilation, not at the specifier span.
+    assert_eq!(
+        ts5083[0].file, "",
+        "TS5083 is a file-less diagnostic (no specifier anchor)"
+    );
+    assert_eq!(ts5083[0].start, 0, "TS5083 carries no source position");
+
+    let opts = parsed
+        .config
+        .compiler_options
+        .expect("local options retained");
+    assert_eq!(
+        opts.strict,
+        Some(true),
+        "local options survive an unreadable extends"
+    );
+}
+
+#[test]
+fn missing_relative_json_normalizes_parent_segments_in_message() {
+    let temp = tempdir().expect("create temp dir");
+    let nested = temp.path().join("project").join("nested");
+    std::fs::create_dir_all(&nested).expect("create nested dir");
+    let child_path = nested.join("tsconfig.json");
+    std::fs::write(&child_path, r#"{ "extends": "../nope.json" }"#).expect("write child");
+
+    let parsed = load_tsconfig_with_diagnostics(&child_path).expect("load must succeed");
+    let ts5083: Vec<&Diagnostic> = parsed
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 5083)
+        .collect();
+    assert_eq!(ts5083.len(), 1, "one TS5083: {:?}", parsed.diagnostics);
+
+    // `../nope.json` collapses to the sibling directory; the message must not
+    // carry a `/../` spelling.
+    let expected_path = temp
+        .path()
+        .join("project")
+        .join("nope.json")
+        .to_string_lossy()
+        .into_owned();
+    assert!(
+        ts5083[0].message_text.contains(&expected_path) && !ts5083[0].message_text.contains("/../"),
+        "TS5083 path is lexically normalized ({expected_path}): {}",
+        ts5083[0].message_text
+    );
+}
+
+#[test]
+fn missing_relative_extensionless_reports_ts6053_not_ts5083() {
+    let (_temp, parsed) = load_extending("./nope");
+
+    assert!(
+        !parsed.diagnostics.iter().any(|d| d.code == 5083),
+        "an extensionless relative miss must not report TS5083, got: {:?}",
+        parsed.diagnostics
+    );
+    let ts6053: Vec<&Diagnostic> = parsed
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 6053)
+        .collect();
+    assert_eq!(
+        ts6053.len(),
+        1,
+        "exactly one TS6053 for the extensionless miss: {:?}",
+        parsed.diagnostics
+    );
+    assert!(
+        ts6053[0].message_text.contains("./nope"),
+        "TS6053 names the specifier as written: {}",
+        ts6053[0].message_text
+    );
+    assert!(
+        !ts6053[0].file.is_empty(),
+        "TS6053 is anchored in the config file: {:?}",
+        ts6053[0]
+    );
+}
+
+#[test]
+fn missing_relative_non_json_extension_reports_ts6053() {
+    // A non-`.json` extension is treated like an extensionless specifier
+    // (`tsc` appends `.json` and re-probes), so a miss stays TS6053.
+    let (_temp, parsed) = load_extending("./nope.txt");
+
+    assert!(
+        !parsed.diagnostics.iter().any(|d| d.code == 5083),
+        "a non-.json relative miss must not report TS5083, got: {:?}",
+        parsed.diagnostics
+    );
+    let ts6053: Vec<&Diagnostic> = parsed
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 6053)
+        .collect();
+    assert_eq!(
+        ts6053.len(),
+        1,
+        "exactly one TS6053 for the non-.json miss: {:?}",
+        parsed.diagnostics
+    );
+    assert!(
+        ts6053[0].message_text.contains("./nope.txt"),
+        "TS6053 names the specifier as written: {}",
+        ts6053[0].message_text
+    );
+}
+
+#[test]
+fn missing_absolute_json_reports_ts5083() {
+    let temp = tempdir().expect("create temp dir");
+    let project = temp.path().join("project");
+    std::fs::create_dir_all(&project).expect("create project dir");
+    let child_path = project.join("tsconfig.json");
+    let abs_missing = temp.path().join("does").join("not").join("exist.json");
+    let source = format!(
+        r#"{{ "extends": "{}" }}"#,
+        abs_missing.to_string_lossy().replace('\\', "\\\\")
+    );
+    std::fs::write(&child_path, source).expect("write child");
+
+    let parsed = load_tsconfig_with_diagnostics(&child_path).expect("load must succeed");
+    let ts5083: Vec<&Diagnostic> = parsed
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 5083)
+        .collect();
+    assert_eq!(
+        ts5083.len(),
+        1,
+        "a rooted (absolute) .json miss shares the TS5083 rule: {:?}",
+        parsed.diagnostics
+    );
+    assert!(
+        ts5083[0]
+            .message_text
+            .contains(&abs_missing.to_string_lossy().into_owned()),
+        "TS5083 names the absolute target path: {}",
+        ts5083[0].message_text
+    );
+}
+
+#[test]
+fn unresolvable_package_keeps_ts6053() {
+    // A bare/package specifier that fails Node module resolution must keep
+    // TS6053 — TS5083 must not be widened to cover it.
+    let (_temp, parsed) = load_extending("no-such-pkg/tsconfig.json");
+
+    assert!(
+        !parsed.diagnostics.iter().any(|d| d.code == 5083),
+        "an unresolvable package must not report TS5083, got: {:?}",
+        parsed.diagnostics
+    );
+    let ts6053: Vec<&Diagnostic> = parsed
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 6053)
+        .collect();
+    assert_eq!(
+        ts6053.len(),
+        1,
+        "exactly one TS6053 for the unresolvable package: {:?}",
+        parsed.diagnostics
+    );
+    assert!(
+        ts6053[0].message_text.contains("no-such-pkg/tsconfig.json"),
+        "TS6053 names the package specifier: {}",
+        ts6053[0].message_text
+    );
+}
+
+#[test]
+fn array_extends_diagnoses_each_entry_independently() {
+    // An array `extends` mixing a resolvable base, an unreadable relative
+    // `.json` (TS5083), and an unresolvable package (TS6053) must diagnose each
+    // entry independently and still merge the resolvable base's options.
+    let temp = tempdir().expect("create temp dir");
+    let project = temp.path().join("project");
+    std::fs::create_dir_all(&project).expect("create project dir");
+    std::fs::write(
+        project.join("present.json"),
+        r#"{ "compilerOptions": { "target": "ES2021" } }"#,
+    )
+    .expect("write present base");
+    let child_path = project.join("tsconfig.json");
+    std::fs::write(
+        &child_path,
+        r#"{ "extends": ["./present.json", "./gone.json", "no-such-pkg"] }"#,
+    )
+    .expect("write child");
+
+    let parsed = load_tsconfig_with_diagnostics(&child_path).expect("load must succeed");
+
+    assert_eq!(
+        parsed.diagnostics.iter().filter(|d| d.code == 5083).count(),
+        1,
+        "the unreadable .json entry gets exactly one TS5083: {:?}",
+        parsed.diagnostics
+    );
+    assert_eq!(
+        parsed.diagnostics.iter().filter(|d| d.code == 6053).count(),
+        1,
+        "the unresolvable package entry gets exactly one TS6053: {:?}",
+        parsed.diagnostics
+    );
+    let opts = parsed.config.compiler_options.expect("present base merged");
+    assert_eq!(
+        opts.target.as_deref(),
+        Some("ES2021"),
+        "the resolvable entry is still applied alongside the failing ones"
+    );
+}

--- a/crates/tsz-core/src/config/tests/mod.rs
+++ b/crates/tsz-core/src/config/tests/mod.rs
@@ -6,6 +6,7 @@
 
 mod extends_cycle_and_jsx_factory_values;
 mod extends_empty_specifier;
+mod extends_missing_target;
 mod files_list_empty;
 mod module_resolution;
 mod options_parsing;

--- a/crates/tsz-core/src/config/tests/module_resolution.rs
+++ b/crates/tsz-core/src/config/tests/module_resolution.rs
@@ -1783,7 +1783,7 @@ fn test_resolve_extends_path_uses_package_exports_mapping() {
     let resolved =
         resolve_extends_path(&project_dir.join("tsconfig.json"), "pkg/tsconfig.json").unwrap();
 
-    assert_eq!(resolved, Some(expected));
+    assert_eq!(resolved, ExtendsResolution::Found(expected));
 }
 
 #[test]
@@ -1883,8 +1883,8 @@ fn extends_unresolved_package_emits_ts6053_and_keeps_local_options() {
 
 #[test]
 fn extends_array_reports_each_unresolved_entry() {
-    // Array `extends` (TS 5.0): every entry that cannot be resolved gets its
-    // own TS6053, and resolvable entries still merge.
+    // Array `extends` (TS 5.0): every unresolvable entry gets its own TS6053
+    // (entries are extensionless; missing `.json` is TS5083, covered elsewhere).
     let temp = tempdir().expect("create temp dir");
     let project = temp.path().join("project");
     std::fs::create_dir_all(&project).expect("create project dir");
@@ -1896,7 +1896,7 @@ fn extends_array_reports_each_unresolved_entry() {
     let child_path = project.join("tsconfig.json");
     std::fs::write(
         &child_path,
-        r#"{ "extends": ["./present.json", "./missing-a.json", "./missing-b.json"] }"#,
+        r#"{ "extends": ["./present.json", "./missing-a", "./missing-b"] }"#,
     )
     .expect("write child");
 


### PR DESCRIPTION
Closes #17079.

**Structural rule:** when a tsconfig `extends` specifier is a **rooted/relative path that already carries a `.json` extension** and the file does not exist, `tsc`'s `getExtendsConfigPath` returns that path *unchecked* (the `.json`-append fallback fires only for extensionless specifiers), so the subsequent file read fails and surfaces a **file-less TS5083** `Cannot read file '{0}'.` anchored at the lexically normalized resolved path. tsz collapsed this into the generic, specifier-anchored **TS6053** `File '{0}' not found.` Owner layer: `tsz-core` config loader (`resolve_extends_path` in `config/extends.rs`; emission in `config/mod.rs`).

The split is not "relative vs package" — it turns on whether the rooted/relative specifier already ends in `.json`. `{abs}` denotes the lexically normalized absolute path of the resolved target:

| `extends` value | tsc / tsz (after) | anchor |
| --- | --- | --- |
| `./nope.json` (relative, `.json`, missing) | TS5083 `Cannot read file '{abs}'.` | file-less |
| `../nope.json` | TS5083, `{abs}` normalized to sibling dir | file-less |
| `/abs/nope.json` | TS5083 | file-less |
| `./nope` (extensionless, missing) | TS6053 `File './nope' not found.` | at specifier |
| `./nope.txt` (non-`.json` ext, missing) | TS6053 (specifier as written) | at specifier |
| `no-such-pkg/tsconfig.json` (package) | TS6053 | at specifier |

**Fix (fundamental, not a bandaid):** model tsc's decision tree in the resolver rather than the caller. `resolve_extends_path` now returns `ExtendsResolution { Found, Unreadable, NotFound }`; the rooted/relative branch normalizes the candidate, probes it, and — only when it lacks a `.json` extension — re-probes with `.json` appended. A missing `.json` specifier is `Unreadable` (TS5083); a missing extensionless/non-`.json` one is `NotFound` (TS6053). Package/module-resolution misses stay `NotFound` and are **never** widened to TS5083. The diagnostic-free loader treats both failures as a recoverable skip; the diagnostic loader emits the matching code per arm, keeping diagnostic ownership with the caller.

Reuses shared infra: `tsz_common::file_extensions::is_json_file` / `JSON_EXTENSION` and `path_identity::normalize_segments` (no new `.json` literal, no hand-rolled `..` collapsing). No user-name/file-name literals and no formatted-message predicates.

**Adjacent cases covered by tests:** renamed binders (temp dirs), `.json` vs extensionless vs non-`.json`, relative vs absolute vs `../` parent, array `extends` with mixed unreadable-`.json` + unresolvable-package entries diagnosed independently, and the negative case (package miss stays TS6053).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-core --lib config::tests` — 249 passed (7 new resolver unit tests + 7 new end-to-end shard `extends_missing_target`; existing array test kept on TS6053 via extensionless entries).
- `cargo clippy -p tsz-core` — clean; local pre-commit `arch-size` guard passed; CI `clippy` + `arch-size` + `CI Summary` green on head `0a60f99`.
- End-to-end CLI vs pinned `typescript@7.0.2` oracle (`--noEmit --strict --pretty false --lib es2022 --target es2022`): output matches **exactly** on all six rows above, including the file-less TS5083 (no location prefix), the TS6053 specifier anchor, and the normalized `../` path.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high